### PR TITLE
[front] - feat(InputBarAttachmentsPicker): allow multi selection

### DIFF
--- a/extension/package-lock.json
+++ b/extension/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "@auth0/auth0-spa-js": "^2.1.3",
         "@dust-tt/client": "^1.0.54",
-        "@dust-tt/sparkle": "^0.2.529",
+        "@dust-tt/sparkle": "^0.2.530",
         "@frontapp/plugin-sdk": "^1.8.1",
         "@modelcontextprotocol/sdk": "^1.9.0",
         "@tailwindcss/forms": "^0.5.9",
@@ -335,10 +335,9 @@
       }
     },
     "node_modules/@dust-tt/sparkle": {
-      "version": "0.2.529",
-      "resolved": "https://registry.npmjs.org/@dust-tt/sparkle/-/sparkle-0.2.529.tgz",
-      "integrity": "sha512-Tk0gxemDGr93qE0PPArO8Am8f62dlnFBoOgxzpiwXR0Ju4fI6F1SSgwChbIkrEPLaPnc1h7X5MbSjReyRZ8wTw==",
-      "license": "ISC",
+      "version": "0.2.530",
+      "resolved": "https://registry.npmjs.org/@dust-tt/sparkle/-/sparkle-0.2.530.tgz",
+      "integrity": "sha512-Jtzo86rRU1rr9E0wowzBbP64s1vauAXl+g0G1emp3UlLQ47kfu1x352I4ETJGRV3FR26lH+GyOLbnOiRezHORA==",
       "dependencies": {
         "@emoji-mart/data": "^1.1.2",
         "@emoji-mart/react": "^1.1.1",

--- a/extension/package.json
+++ b/extension/package.json
@@ -58,7 +58,7 @@
   "dependencies": {
     "@auth0/auth0-spa-js": "^2.1.3",
     "@dust-tt/client": "^1.0.54",
-    "@dust-tt/sparkle": "^0.2.529",
+    "@dust-tt/sparkle": "^0.2.530",
     "@frontapp/plugin-sdk": "^1.8.1",
     "@modelcontextprotocol/sdk": "^1.9.0",
     "@tailwindcss/forms": "^0.5.9",

--- a/extension/ui/components/input_bar/InputBar.tsx
+++ b/extension/ui/components/input_bar/InputBar.tsx
@@ -369,6 +369,7 @@ export function AssistantInputBar({
                 fileUploaderService={fileUploaderService}
                 isSubmitting={isSubmitting ?? false}
                 onNodeSelect={handleNodesAttachmentSelect}
+                onNodeUnselect={handleNodesAttachmentRemove}
                 attachedNodes={attachedNodes}
               />
             </div>

--- a/extension/ui/components/input_bar/InputBarAttachmentPicker.tsx
+++ b/extension/ui/components/input_bar/InputBarAttachmentPicker.tsx
@@ -119,7 +119,6 @@ export const InputBarAttachmentsPicker = ({
       open={isOpen}
       onOpenChange={(open) => {
         if (open) {
-          setIsOpen(true);
           setSearch("");
         }
       }}

--- a/extension/ui/components/input_bar/InputBarAttachmentPicker.tsx
+++ b/extension/ui/components/input_bar/InputBarAttachmentPicker.tsx
@@ -18,6 +18,7 @@ import {
   CloudArrowUpIcon,
   DoubleIcon,
   DropdownMenu,
+  DropdownMenuCheckboxItem,
   DropdownMenuContent,
   DropdownMenuItem,
   DropdownMenuSearchbar,
@@ -36,6 +37,7 @@ interface InputBarAttachmentsPickerProps {
   owner: LightWorkspaceType;
   fileUploaderService: FileUploaderService;
   onNodeSelect: (node: DataSourceViewContentNodeType) => void;
+  onNodeUnselect: (node: DataSourceViewContentNodeType) => void;
   isLoading?: boolean;
   attachedNodes: DataSourceViewContentNodeType[];
 }
@@ -43,6 +45,7 @@ interface InputBarAttachmentsPickerProps {
 export const InputBarAttachmentsPicker = ({
   fileUploaderService,
   onNodeSelect,
+  onNodeUnselect,
   attachedNodes,
   isLoading = false,
 }: InputBarAttachmentsPickerProps) => {
@@ -115,7 +118,8 @@ export const InputBarAttachmentsPicker = ({
     <DropdownMenu
       open={isOpen}
       onOpenChange={(open) => {
-        if (!open) {
+        if (open) {
+          setIsOpen(true);
           setSearch("");
         }
       }}
@@ -134,6 +138,7 @@ export const InputBarAttachmentsPicker = ({
         side="bottom"
         align="end"
         onInteractOutside={() => setIsOpen(false)}
+        onEscapeKeyDown={() => setIsOpen(false)}
       >
         <Input
           type="file"
@@ -177,7 +182,7 @@ export const InputBarAttachmentsPicker = ({
             <ScrollArea className="flex max-h-96 flex-col" hideScrollBar>
               <div ref={itemsContainerRef}>
                 {pickedSpaceNodes.map((item, index) => (
-                  <DropdownMenuItem
+                  <DropdownMenuCheckboxItem
                     key={index}
                     label={item.title}
                     icon={
@@ -190,13 +195,16 @@ export const InputBarAttachmentsPicker = ({
                         size="md"
                       />
                     }
-                    disabled={attachedNodeIds.includes(item.internalId)}
                     description={`${getLocationForDataSourceViewContentNode(item)}`}
-                    onClick={() => {
-                      setSearch("");
-                      onNodeSelect(item);
-                      setIsOpen(false);
+                    checked={attachedNodeIds.includes(item.internalId)}
+                    onCheckedChange={(checked) => {
+                      if (checked) {
+                        onNodeSelect(item);
+                      } else {
+                        onNodeUnselect(item);
+                      }
                     }}
+                    truncateText
                   />
                 ))}
                 {pickedSpaceNodes.length === 0 && !showLoader && (

--- a/extension/ui/components/input_bar/InputBarContainer.tsx
+++ b/extension/ui/components/input_bar/InputBarContainer.tsx
@@ -40,7 +40,8 @@ export interface InputBarContainerProps {
   isTabIncluded: boolean;
   setIncludeTab: (includeTab: boolean) => void;
   fileUploaderService: FileUploaderService;
-  onNodeSelect?: (node: DataSourceViewContentNodeType) => void;
+  onNodeSelect: (node: DataSourceViewContentNodeType) => void;
+  onNodeUnselect: (node: DataSourceViewContentNodeType) => void;
   attachedNodes: DataSourceViewContentNodeType[];
   isSubmitting: boolean;
 }
@@ -57,6 +58,7 @@ export const InputBarContainer = ({
   setIncludeTab,
   fileUploaderService,
   onNodeSelect,
+  onNodeUnselect,
   attachedNodes,
   isSubmitting,
 }: InputBarContainerProps) => {
@@ -245,9 +247,8 @@ export const InputBarContainer = ({
             fileUploaderService={fileUploaderService}
             owner={owner}
             isLoading={false}
-            onNodeSelect={
-              onNodeSelect || ((node) => console.log(`Selected ${node.title}`))
-            }
+            onNodeSelect={onNodeSelect}
+            onNodeUnselect={onNodeUnselect}
             attachedNodes={attachedNodes}
           />
           <AssistantPicker

--- a/front/components/assistant/conversation/input_bar/InputBar.tsx
+++ b/front/components/assistant/conversation/input_bar/InputBar.tsx
@@ -371,6 +371,7 @@ export function AssistantInputBar({
                   disableSendButton || fileUploaderService.isProcessingFiles
                 }
                 onNodeSelect={handleNodesAttachmentSelect}
+                onNodeUnselect={handleNodesAttachmentRemove}
                 attachedNodes={attachedNodes}
               />
             </div>

--- a/front/components/assistant/conversation/input_bar/InputBarAttachmentsPicker.tsx
+++ b/front/components/assistant/conversation/input_bar/InputBarAttachmentsPicker.tsx
@@ -118,7 +118,6 @@ export const InputBarAttachmentsPicker = ({
       open={isOpen}
       onOpenChange={(open) => {
         if (open) {
-          setIsOpen(true);
           setSearch("");
         }
       }}

--- a/front/components/assistant/conversation/input_bar/InputBarAttachmentsPicker.tsx
+++ b/front/components/assistant/conversation/input_bar/InputBarAttachmentsPicker.tsx
@@ -26,7 +26,10 @@ import {
 } from "@app/lib/content_nodes";
 import { isFolder, isWebsite } from "@app/lib/data_sources";
 import { getSpaceAccessPriority } from "@app/lib/spaces";
-import { useSpaces, useSpacesSearchWithInfiniteScroll } from "@app/lib/swr/spaces";
+import {
+  useSpaces,
+  useSpacesSearchWithInfiniteScroll,
+} from "@app/lib/swr/spaces";
 import type { DataSourceViewContentNode, LightWorkspaceType } from "@app/types";
 import { MIN_SEARCH_QUERY_SIZE } from "@app/types";
 
@@ -184,22 +187,9 @@ export const InputBarAttachmentsPicker = ({
             {pickedSpaceNodes.map((item, index) => (
               <DropdownMenuCheckboxItem
                 key={index}
-                checked={attachedNodes.some(
-                  (attachedNode) =>
-                    attachedNode.internalId === item.internalId &&
-                    attachedNode.dataSourceView.dataSource.sId ===
-                      item.dataSourceView.dataSource.sId
-                )}
-                onCheckedChange={(checked) => {
-                  if (checked) {
-                    onNodeSelect(item);
-                  } else {
-                    onNodeUnselect(item);
-                  }
-                }}
-              >
-                <div className="flex items-center gap-2">
-                  {isWebsite(item.dataSourceView.dataSource) ||
+                label={item.title}
+                icon={
+                  isWebsite(item.dataSourceView.dataSource) ||
                   isFolder(item.dataSourceView.dataSource) ? (
                     <Icon
                       visual={getVisualForDataSourceViewContentNode(item)}
@@ -214,15 +204,24 @@ export const InputBarAttachmentsPicker = ({
                           item.dataSourceView.dataSource.connectorProvider,
                       })}
                     />
-                  )}
-                  <div className="flex flex-col">
-                    <span className="truncate">{item.title}</span>
-                    <span className="truncate text-xs text-muted-foreground">
-                      {getLocationForDataSourceViewContentNode(item)}
-                    </span>
-                  </div>
-                </div>
-              </DropdownMenuCheckboxItem>
+                  )
+                }
+                description={getLocationForDataSourceViewContentNode(item)}
+                checked={attachedNodes.some(
+                  (attachedNode) =>
+                    attachedNode.internalId === item.internalId &&
+                    attachedNode.dataSourceView.dataSource.sId ===
+                      item.dataSourceView.dataSource.sId
+                )}
+                onCheckedChange={(checked) => {
+                  if (checked) {
+                    onNodeSelect(item);
+                  } else {
+                    onNodeUnselect(item);
+                  }
+                }}
+                truncateText
+              />
             ))}
             {pickedSpaceNodes.length === 0 && !showLoader && (
               <div className="flex items-center justify-center py-4 text-sm text-muted-foreground dark:text-muted-foreground-night">

--- a/front/components/assistant/conversation/input_bar/InputBarContainer.tsx
+++ b/front/components/assistant/conversation/input_bar/InputBarContainer.tsx
@@ -60,7 +60,8 @@ export interface InputBarContainerProps {
   disableAutoFocus: boolean;
   disableSendButton: boolean;
   fileUploaderService: FileUploaderService;
-  onNodeSelect?: (node: DataSourceViewContentNode) => void;
+  onNodeSelect: (node: DataSourceViewContentNode) => void;
+  onNodeUnselect: (node: DataSourceViewContentNode) => void;
   attachedNodes: DataSourceViewContentNode[];
 }
 
@@ -76,6 +77,7 @@ const InputBarContainer = ({
   disableSendButton,
   fileUploaderService,
   onNodeSelect,
+  onNodeUnselect,
   attachedNodes,
 }: InputBarContainerProps) => {
   const suggestions = useAssistantSuggestions(agentConfigurations, owner);
@@ -281,10 +283,8 @@ const InputBarContainer = ({
                 fileUploaderService={fileUploaderService}
                 owner={owner}
                 isLoading={false}
-                onNodeSelect={
-                  onNodeSelect ||
-                  ((node) => console.log(`Selected ${node.title}`))
-                }
+                onNodeSelect={onNodeSelect}
+                onNodeUnselect={onNodeUnselect}
                 attachedNodes={attachedNodes}
               />
             </>

--- a/front/package-lock.json
+++ b/front/package-lock.json
@@ -7,7 +7,7 @@
       "dependencies": {
         "@auth0/nextjs-auth0": "^3.5.0",
         "@dust-tt/client": "file:../sdks/js",
-        "@dust-tt/sparkle": "^0.2.529",
+        "@dust-tt/sparkle": "^0.2.530",
         "@google-cloud/bigquery": "^7.9.1",
         "@google-cloud/storage-transfer": "^3.6.0",
         "@heroicons/react": "^2.0.11",
@@ -1105,10 +1105,9 @@
       "link": true
     },
     "node_modules/@dust-tt/sparkle": {
-      "version": "0.2.529",
-      "resolved": "https://registry.npmjs.org/@dust-tt/sparkle/-/sparkle-0.2.529.tgz",
-      "integrity": "sha512-Tk0gxemDGr93qE0PPArO8Am8f62dlnFBoOgxzpiwXR0Ju4fI6F1SSgwChbIkrEPLaPnc1h7X5MbSjReyRZ8wTw==",
-      "license": "ISC",
+      "version": "0.2.530",
+      "resolved": "https://registry.npmjs.org/@dust-tt/sparkle/-/sparkle-0.2.530.tgz",
+      "integrity": "sha512-Jtzo86rRU1rr9E0wowzBbP64s1vauAXl+g0G1emp3UlLQ47kfu1x352I4ETJGRV3FR26lH+GyOLbnOiRezHORA==",
       "dependencies": {
         "@emoji-mart/data": "^1.1.2",
         "@emoji-mart/react": "^1.1.1",

--- a/front/package.json
+++ b/front/package.json
@@ -24,7 +24,7 @@
   "dependencies": {
     "@auth0/nextjs-auth0": "^3.5.0",
     "@dust-tt/client": "file:../sdks/js",
-    "@dust-tt/sparkle": "^0.2.529",
+    "@dust-tt/sparkle": "^0.2.530",
     "@google-cloud/bigquery": "^7.9.1",
     "@google-cloud/storage-transfer": "^3.6.0",
     "@heroicons/react": "^2.0.11",


### PR DESCRIPTION
## Description

This change enhances the `InputBarAttachmentsPicker` component by replacing the selection with checkboxes, allowing users to select and unselect multiple nodes in the attachment picker.

![Screenshot 2025-06-23 at 11 22 11](https://github.com/user-attachments/assets/6a67e890-6c9c-4ffa-9977-3a2a65ea818a)

## Risk

Low

## Deploy Plan

- Deploy front