### PR TITLE
[front] user: don't cache active user count apart from conv

### DIFF
--- a/front/lib/tracking/customerio/server.ts
+++ b/front/lib/tracking/customerio/server.ts
@@ -2,7 +2,7 @@ import * as _ from "lodash";
 
 import config from "@app/lib/api/config";
 import { Workspace } from "@app/lib/models/workspace";
-import { countActiveSeatsInWorkspaceCached } from "@app/lib/plans/usage/seats";
+import { countActiveSeatsInWorkspace } from "@app/lib/plans/usage/seats";
 import { MembershipResource } from "@app/lib/resources/membership_resource";
 import { SubscriptionResource } from "@app/lib/resources/subscription_resource";
 import { UserResource } from "@app/lib/resources/user_resource";
@@ -227,8 +227,7 @@ export class CustomerioServerSideTracking {
 
     const planCode = workspace.planCode ?? subscription.getPlan().code;
     const seats =
-      workspace.seats ??
-      (await countActiveSeatsInWorkspaceCached(workspace.sId));
+      workspace.seats ?? (await countActiveSeatsInWorkspace(workspace.sId));
 
     // Unless the info changes, we only identify a given workspace once per day.
     const rateLimiterKey = `customerio_workspace:${workspace.sId}:${workspace.name}:${planCode}:${seats}`;

--- a/front/lib/tracking/server.ts
+++ b/front/lib/tracking/server.ts
@@ -1,7 +1,7 @@
 import * as _ from "lodash";
 
 import { FREE_TEST_PLAN_CODE } from "@app/lib/plans/plan_codes";
-import { countActiveSeatsInWorkspaceCached } from "@app/lib/plans/usage/seats";
+import { countActiveSeatsInWorkspace } from "@app/lib/plans/usage/seats";
 import { SubscriptionResource } from "@app/lib/resources/subscription_resource";
 import { CustomerioServerSideTracking } from "@app/lib/tracking/customerio/server";
 import logger from "@app/logger/logger";
@@ -34,9 +34,7 @@ export class ServerSideTracking {
       const seatsByWorkspaceId = _.keyBy(
         await Promise.all(
           user.workspaces.map(async (workspace) => {
-            const seats = await countActiveSeatsInWorkspaceCached(
-              workspace.sId
-            );
+            const seats = await countActiveSeatsInWorkspace(workspace.sId);
             return { sId: workspace.sId, seats };
           })
         ),


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

Context : https://dust4ai.slack.com/archives/C05B529FHV1/p1750674349426249
We believe that caching the count of active users in the workspace does not make sense apart from counting the rate limit at the conversation level.

We remove the cache from the other usages of the function, in order to only set/get cache when sending messages. This way, when sending the first message of the workspace, the real count will be computed, and not a count equal to 0.

We believe the affected functions are not called often for a same workspace and this will not impact anything.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

Not tested.

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

Low risks.

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->

Deploy front.