### PR TITLE
Default Sign in to WorkOS

### DIFF
--- a/front/components/home/LandingLayout.tsx
+++ b/front/components/home/LandingLayout.tsx
@@ -87,11 +87,11 @@ export default function LandingLayout({
               icon={LoginIcon}
               onClick={(e: React.MouseEvent<HTMLButtonElement>) => {
                 if (e.metaKey) {
-                  window.location.href = `/api/workos/login?returnTo=${postLoginReturnToUrl}`;
+                  window.location.href = `/api/auth/login?returnTo=${postLoginReturnToUrl}`;
                 } else if (e.shiftKey) {
                   window.location.href = `/api/auth/login?prompt=login&returnTo=${postLoginReturnToUrl}`;
                 } else {
-                  window.location.href = `/api/auth/login?returnTo=${postLoginReturnToUrl}`;
+                  window.location.href = `/api/workos/login?returnTo=${postLoginReturnToUrl}`;
                 }
               }}
             />

--- a/front/lib/api/workos/user.ts
+++ b/front/lib/api/workos/user.ts
@@ -91,6 +91,14 @@ export async function getWorkOSSession(
       }
 
       console.log("[WORKOS SESSION]", JSON.stringify(r, null, 2));
+      console.log(
+        "[WORKOS COOKIE]",
+        sessionData,
+        organizationId,
+        workspaceId,
+        region,
+        authenticationMethod
+      );
 
       return {
         type: "workos" as const,

--- a/front/lib/api/workos/user.ts
+++ b/front/lib/api/workos/user.ts
@@ -90,6 +90,8 @@ export async function getWorkOSSession(
         }
       }
 
+      console.log("[WORKOS SESSION]", JSON.stringify(r, null, 2));
+
       return {
         type: "workos" as const,
         sessionId: r.sessionId,

--- a/front/lib/api/workos/user.ts
+++ b/front/lib/api/workos/user.ts
@@ -90,16 +90,6 @@ export async function getWorkOSSession(
         }
       }
 
-      console.log("[WORKOS SESSION]", JSON.stringify(r, null, 2));
-      console.log(
-        "[WORKOS COOKIE]",
-        sessionData,
-        organizationId,
-        workspaceId,
-        region,
-        authenticationMethod
-      );
-
       return {
         type: "workos" as const,
         sessionId: r.sessionId,

--- a/front/lib/api/workos/user.ts
+++ b/front/lib/api/workos/user.ts
@@ -104,7 +104,7 @@ export async function getWorkOSSession(
         // TODO(workos): Should we resolve the workspaceId and remove organizationId from here?
         organizationId,
         workspaceId,
-        isSSO: authenticationMethod === "SSO",
+        isSSO: authenticationMethod?.toLowerCase() === "sso",
         authenticationMethod,
       };
     } catch (error) {

--- a/front/lib/auth.ts
+++ b/front/lib/auth.ts
@@ -978,11 +978,21 @@ export async function getSession(
   res: NextApiResponse | GetServerSidePropsContext["res"]
 ): Promise<SessionWithUser | null> {
   // Get Auth0 session first - in case of legacy SSO connection, we'll have 2 sessions and Auth0 will contains the SSO session
-  return (
-    (await getAuth0Session(req, res)) ||
-    (await getWorkOSSession(req, res)) ||
-    null
-  );
+  const workOsSession = await getWorkOSSession(req, res);
+  const auth0Session = await getAuth0Session(req, res);
+
+  // If any of the sessions is SSO, we return the SSO session. Priority goes to WorkOS.
+  if (workOsSession?.isSSO) {
+    return workOsSession;
+  }
+
+  // If the Auth0 session is SSO, we return it.
+  if (auth0Session?.isSSO) {
+    return auth0Session;
+  }
+
+  // If none of the sessions is SSO, we return the first one that exists. Priority goes to WorkOS.
+  return workOsSession || auth0Session || null;
 }
 
 /**

--- a/front/lib/auth.ts
+++ b/front/lib/auth.ts
@@ -977,7 +977,6 @@ export async function getSession(
   req: NextApiRequest | GetServerSidePropsContext["req"],
   res: NextApiResponse | GetServerSidePropsContext["res"]
 ): Promise<SessionWithUser | null> {
-  // Get Auth0 session first - in case of legacy SSO connection, we'll have 2 sessions and Auth0 will contains the SSO session
   const workOsSession = await getWorkOSSession(req, res);
   const auth0Session = await getAuth0Session(req, res);
 

--- a/front/pages/api/w/[wId]/domains.ts
+++ b/front/pages/api/w/[wId]/domains.ts
@@ -8,7 +8,6 @@ import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrapper
 import {
   generateWorkOSAdminPortalUrl,
   getOrCreateWorkOSOrganization,
-  getWorkOSOrganization,
   removeWorkOSOrganizationDomain,
 } from "@app/lib/api/workos/organization";
 import type { Authenticator } from "@app/lib/auth";

--- a/front/pages/api/w/[wId]/domains.ts
+++ b/front/pages/api/w/[wId]/domains.ts
@@ -7,6 +7,7 @@ import type { NextApiRequest, NextApiResponse } from "next";
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
 import {
   generateWorkOSAdminPortalUrl,
+  getOrCreateWorkOSOrganization,
   getWorkOSOrganization,
   removeWorkOSOrganizationDomain,
 } from "@app/lib/api/workos/organization";
@@ -43,7 +44,10 @@ async function handler(
 
   switch (req.method) {
     case "GET":
-      const organizationRes = await getWorkOSOrganization(
+      // If the workspace doesn't have a WorkOS organization (which can happen for workspaces
+      // created via admin tools), we create one before fetching domains. This ensures the
+      // endpoint works for all workspaces, regardless of how they were created.
+      const organizationRes = await getOrCreateWorkOSOrganization(
         auth.getNonNullableWorkspace()
       );
 

--- a/front/pages/api/workos/[action].ts
+++ b/front/pages/api/workos/[action].ts
@@ -250,6 +250,7 @@ async function handleCallback(req: NextApiRequest, res: NextApiResponse) {
       );
       if (isString(stateObj.returnTo)) {
         res.redirect(stateObj.returnTo);
+        return;
       }
     }
 


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
This PR introduces a new authentication flow leveraging a session cookie (introduced in https://github.com/dust-tt/dust/pull/13582) that stores the last accessed workspace. Here's how the new flow works:

_For workspaces with SSO enabled_:
- If the workspace has been migrated to WorkOS (WorkOS feature flag enabled):
  - Users will be redirected to WorkOS authentication

- If the workspace hasn't been migrated (WorkOS feature flag disabled):
  - Users will continue using Auth0 authentication

_For workspaces without SSO_:
- All users (both existing and new) will be redirected to WorkOS

**Known limitation:**

There's a temporary edge case where users without the session cookie who belong to non-migrated SSO workspaces will first be redirected to WorkOS before falling back to Auth0. This impact should be minimal since most users have already reconnected this Monday, which set their session cookie.
All users created since we did backfill password hashes will also be impacted, we will send an email to those impacted users.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
