### PR TITLE
[front] - fix(AssistantDetails): sheet structure

### DIFF
--- a/front/components/assistant/AssistantDetails.tsx
+++ b/front/components/assistant/AssistantDetails.tsx
@@ -328,6 +328,9 @@ export function AssistantDetails({
   return (
     <Sheet open={!!assistantId} onOpenChange={onClose}>
       <SheetContent size="lg">
+        <VisuallyHidden>
+          <SheetTitle />
+        </VisuallyHidden>
         {isAgentConfigurationLoading ? (
           <div className="flex h-full w-full items-center justify-center">
             <Spinner size="lg" />
@@ -335,9 +338,6 @@ export function AssistantDetails({
         ) : (
           <>
             <SheetHeader className="flex flex-col gap-5 pb-0 text-sm text-foreground dark:text-foreground-night">
-              <VisuallyHidden>
-                <SheetTitle />
-              </VisuallyHidden>
               <DescriptionSection />
               {showEditorsTabs || showPerformanceTabs ? (
                 <Tabs value={selectedTab}>


### PR DESCRIPTION
## Description

This PR fixes a DOM structure error when opening the `AssistantDetails` sheet. It was caused by the `SheetTitle` component being conditionally rendered by the loading of the agent configuration. This led to console errors looking like:
```
console hook.js:608 `DialogContent` requires a `DialogTitle` for the component to be accessible for screen reader users.

  If you want to hide the `DialogTitle`, you can wrap it with our VisuallyHidden component.
  ....
```

## Risk

Low

## Deploy Plan

Deploy front