### PR TITLE
Fix: handle table query errors correctly

### DIFF
--- a/front/lib/actions/mcp_internal_actions/servers/tables_query/server.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/tables_query/server.ts
@@ -9,6 +9,7 @@ import {
 import { DEFAULT_TABLES_QUERY_ACTION_NAME } from "@app/lib/actions/constants";
 import { ConfigurableToolInputSchemas } from "@app/lib/actions/mcp_internal_actions/input_schemas";
 import type {
+  ExecuteTablesQueryErrorResourceType,
   SqlQueryOutputType,
   ThinkingOutputType,
   ToolGeneratedFileType,
@@ -35,6 +36,7 @@ import { assertNever } from "@app/types";
 type TablesQueryOutputResources =
   | ThinkingOutputType
   | SqlQueryOutputType
+  | ExecuteTablesQueryErrorResourceType
   | ToolGeneratedFileType;
 
 export // We need a model with at least 54k tokens to run tables_query.
@@ -293,85 +295,98 @@ function createServer(
           )
         : [];
 
-      const queryTitle = getTablesQueryResultsFileTitle({
-        output: sanitizedOutput,
-      });
-
-      // Generate the CSV file.
-      const { csvFile, csvSnippet } = await generateCSVFileAndSnippet(auth, {
-        title: queryTitle,
-        conversationId: agentLoopRunContext.conversation.sId,
-        results,
-      });
-
-      // Upload the CSV file to the conversation data source.
-      await uploadFileToConversationDataSource({
-        auth,
-        file: csvFile,
-      });
-
-      // Append the CSV file to the output of the tool as an agent-generated file.
-      content.push({
-        type: "resource",
-        resource: {
-          text: `Your query results were generated successfully.`,
-          uri: csvFile.getPublicUrl(auth),
-          mimeType: INTERNAL_MIME_TYPES.TOOL_OUTPUT.FILE,
-          fileId: csvFile.sId,
-          title: queryTitle,
-          contentType: csvFile.contentType,
-          snippet: csvSnippet,
-        },
-      });
-
-      // Check if we should generate a section JSON file.
-      const shouldGenerateSectionFile = results.some((result) =>
-        Object.values(result).some(
-          (value) =>
-            typeof value === "string" &&
-            value.length > TABLES_QUERY_SECTION_FILE_MIN_COLUMN_LENGTH
-        )
-      );
-
-      if (shouldGenerateSectionFile) {
-        // First, we fetch the connector provider for the data source, cause the chunking
-        // strategy of the section file depends on it: Since all tables are from the same
-        // data source, we can just take the first table's data source view id.
-        const dataSourceView = await DataSourceViewResource.fetchById(
-          auth,
-          tableConfigurations[0].dataSourceViewId
-        );
-        const connectorProvider =
-          dataSourceView?.dataSource?.connectorProvider ?? null;
-        const sectionColumnsPrefix = getSectionColumnsPrefix(connectorProvider);
-
-        // Generate the section file.
-        const sectionFile = await generateSectionFile(auth, {
-          title: queryTitle,
-          conversationId: agentLoopRunContext.conversation.sId,
-          results,
-          sectionColumnsPrefix,
-        });
-
-        // Upload the section file to the conversation data source.
-        await uploadFileToConversationDataSource({
-          auth,
-          file: sectionFile,
-        });
-
-        // Append the section file to the output of the tool as an agent-generated file.
+      if (sanitizedOutput.error && typeof sanitizedOutput.error === "string") {
         content.push({
           type: "resource",
           resource: {
-            text: "Your query results were generated successfully.",
-            uri: sectionFile.getPublicUrl(auth),
-            mimeType: INTERNAL_MIME_TYPES.TOOL_OUTPUT.FILE,
-            fileId: sectionFile.sId,
-            title: `${queryTitle} (Rich Text)`,
-            contentType: sectionFile.contentType,
-            snippet: null,
+            text: sanitizedOutput.error as string,
+            mimeType:
+              INTERNAL_MIME_TYPES.TOOL_OUTPUT.EXECUTE_TABLES_QUERY_ERROR,
+            uri: "",
           },
         });
+      } else {
+        const queryTitle = getTablesQueryResultsFileTitle({
+          output: sanitizedOutput,
+        });
+
+        // Generate the CSV file.
+        const { csvFile, csvSnippet } = await generateCSVFileAndSnippet(auth, {
+          title: queryTitle,
+          conversationId: agentLoopRunContext.conversation.sId,
+          results,
+        });
+
+        // Upload the CSV file to the conversation data source.
+        await uploadFileToConversationDataSource({
+          auth,
+          file: csvFile,
+        });
+
+        // Append the CSV file to the output of the tool as an agent-generated file.
+        content.push({
+          type: "resource",
+          resource: {
+            text: `Your query results were generated successfully.`,
+            uri: csvFile.getPublicUrl(auth),
+            mimeType: INTERNAL_MIME_TYPES.TOOL_OUTPUT.FILE,
+            fileId: csvFile.sId,
+            title: queryTitle,
+            contentType: csvFile.contentType,
+            snippet: csvSnippet,
+          },
+        });
+
+        // Check if we should generate a section JSON file.
+        const shouldGenerateSectionFile = results.some((result) =>
+          Object.values(result).some(
+            (value) =>
+              typeof value === "string" &&
+              value.length > TABLES_QUERY_SECTION_FILE_MIN_COLUMN_LENGTH
+          )
+        );
+
+        if (shouldGenerateSectionFile) {
+          // First, we fetch the connector provider for the data source, cause the chunking
+          // strategy of the section file depends on it: Since all tables are from the same
+          // data source, we can just take the first table's data source view id.
+          const dataSourceView = await DataSourceViewResource.fetchById(
+            auth,
+            tableConfigurations[0].dataSourceViewId
+          );
+          const connectorProvider =
+            dataSourceView?.dataSource?.connectorProvider ?? null;
+          const sectionColumnsPrefix =
+            getSectionColumnsPrefix(connectorProvider);
+
+          // Generate the section file.
+          const sectionFile = await generateSectionFile(auth, {
+            title: queryTitle,
+            conversationId: agentLoopRunContext.conversation.sId,
+            results,
+            sectionColumnsPrefix,
+          });
+
+          // Upload the section file to the conversation data source.
+          await uploadFileToConversationDataSource({
+            auth,
+            file: sectionFile,
+          });
+
+          // Append the section file to the output of the tool as an agent-generated file.
+          content.push({
+            type: "resource",
+            resource: {
+              text: "Your query results were generated successfully.",
+              uri: sectionFile.getPublicUrl(auth),
+              mimeType: INTERNAL_MIME_TYPES.TOOL_OUTPUT.FILE,
+              fileId: sectionFile.sId,
+              title: `${queryTitle} (Rich Text)`,
+              contentType: sectionFile.contentType,
+              snippet: null,
+            },
+          });
+        }
       }
 
       return {


### PR DESCRIPTION
## Description

Fix so an empty result set because of an error is not considered 100% successful :)
It is still shown to the model and we don't stop the loop.

<img width="1334" alt="image" src="https://github.com/user-attachments/assets/e04f1442-1e70-44aa-8f25-02dcf07e3f14" />

## Tests

Locally, before / after

## Risk

Low.

## Deploy Plan

Deploy front