### PR TITLE
[connectors] fix(crawler): Handle 404 coming from Firecrawl when a job expires

### DIFF
--- a/connectors/src/connectors/webcrawler/temporal/activities.ts
+++ b/connectors/src/connectors/webcrawler/temporal/activities.ts
@@ -617,13 +617,13 @@ export async function firecrawlCrawlCompleted(
       };
     }
 
-    if (crawlStatus.completed >= webConfig.maxPageToCrawl) {
+    if (crawlStatus.completed < webConfig.maxPageToCrawl) {
+      await syncSucceeded(connectorId);
+    } else {
       await syncFailed(
         connectorId,
         "webcrawling_synchronization_limit_reached"
       );
-    } else {
-      await syncSucceeded(connector.id);
     }
   } catch (error) {
     if (error instanceof FirecrawlError) {

--- a/connectors/src/connectors/webcrawler/temporal/activities.ts
+++ b/connectors/src/connectors/webcrawler/temporal/activities.ts
@@ -584,17 +584,17 @@ export async function firecrawlCrawlCompleted(
   // Clean the crawlId
   await webConfig.updateCrawlId(null);
 
-  const crawlStatus = await getFirecrawl().checkCrawlStatus(crawlId);
-  if (!crawlStatus.success) {
-    localLogger.error(
-      { connectorId, crawlId },
-      `Couldn't fetch crawl status: ${crawlStatus.error}`
-    );
-    return;
-  }
+  try {
+    const crawlStatus = await getFirecrawl().checkCrawlStatus(crawlId);
+    if (!crawlStatus.success) {
+      localLogger.error(
+        { connectorId, crawlId },
+        `Couldn't fetch crawl status: ${crawlStatus.error}`
+      );
+      return;
+    }
 
-  if (crawlStatus.completed <= 0) {
-    try {
+    if (crawlStatus.completed <= 0) {
       // No content found, checking if it's blocked for robots.
       const crawlErrors = await getFirecrawl().checkCrawlErrors(crawlId);
       // Typing issue from Firecrawl, 'success = true' is not in the CrawlErrorsResponse
@@ -615,22 +615,58 @@ export async function firecrawlCrawlCompleted(
       return {
         lastSyncStartTs: connector.lastSyncStartTime?.getTime() ?? null,
       };
-    } catch (err) {
-      localLogger.warn(
-        { connectorId, crawlId },
-        `Couldn't check crawl errors: ${normalizeError(err)}`
+    }
+
+    if (crawlStatus.completed >= webConfig.maxPageToCrawl) {
+      await syncFailed(
+        connectorId,
+        "webcrawling_synchronization_limit_reached"
       );
-      await syncFailed(connectorId, "webcrawling_error_empty_content");
+    } else {
+      await syncSucceeded(connector.id);
+    }
+  } catch (error) {
+    if (error instanceof FirecrawlError) {
+      /*
+       * Putting the connector in succeed as we did get a `completed` event from Firecrawl.
+       * But we couldn't check the correct status or errors of it.
+       * Those expire after 24h, so we might just be late to the party.
+       */
+      await syncSucceeded(connectorId);
+
+      if (error.statusCode === 404 && error.message === "Job expired") {
+        localLogger.warn(
+          {
+            connectorId,
+            crawlId,
+            firecrawlError: {
+              statusCode: error.statusCode,
+              name: error.name,
+            },
+          },
+          "Firecrawl job expired. They expired 24h after the crawl finish. Moving the connector to succeed."
+        );
+      } else {
+        localLogger.error(
+          {
+            connectorId,
+            crawlId,
+            firecrawlError: {
+              statusCode: error.statusCode,
+              name: error.name,
+            },
+          },
+          `Error feching crawl status or error: ${error.message}`
+        );
+      }
+
       return {
         lastSyncStartTs: connector.lastSyncStartTime?.getTime() ?? null,
       };
     }
-  }
 
-  if (crawlStatus.completed >= webConfig.maxPageToCrawl) {
-    await syncFailed(connectorId, "webcrawling_synchronization_limit_reached");
-  } else {
-    await syncSucceeded(connector.id);
+    // If we didn't get a handled FirecrawlError, we can bubble up the error.
+    throw error;
   }
 
   return {


### PR DESCRIPTION
## Description
- crawl status & errors expired after 24h when a crawl finishes.
- Firecrawl fixed their endpoint, now we get a 404 if we try to fetch an expired crawl job.
- Updating the code to try/catch when checking the status in case we get late to check it.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk
- Low, easy to rollback

## Deploy Plan
- Deploy connectors
