### PR TITLE
Have AssistantBuilder use SlackBot and fallback to Slack

### DIFF
--- a/connectors/src/api/webhooks/slack/created_channel.ts
+++ b/connectors/src/api/webhooks/slack/created_channel.ts
@@ -1,4 +1,4 @@
-import type { Result } from "@dust-tt/client";
+import type { ConnectorProvider, Result } from "@dust-tt/client";
 import { Err, Ok } from "@dust-tt/client";
 
 import type { SlackWebhookEvent } from "@connectors/api/webhooks/slack/utils";
@@ -35,7 +35,7 @@ export function isChannelCreatedEvent(
 export interface OnChannelCreationInterface {
   event: ChannelCreatedEvent;
   logger: Logger;
-  provider?: "slack_bot" | "slack";
+  provider?: Extract<ConnectorProvider, "slack_bot" | "slack">;
 }
 
 export async function onChannelCreation({

--- a/connectors/src/connectors/slack/auto_read_channel.ts
+++ b/connectors/src/connectors/slack/auto_read_channel.ts
@@ -1,4 +1,4 @@
-import type { Result } from "@dust-tt/client";
+import type { ConnectorProvider, Result } from "@dust-tt/client";
 import { DustAPI, Err, Ok } from "@dust-tt/client";
 
 import { joinChannel } from "@connectors/connectors/slack/lib/channels";
@@ -35,7 +35,7 @@ export async function autoReadChannel(
   teamId: string,
   logger: Logger,
   slackChannelId: string,
-  provider: "slack_bot" | "slack" = "slack"
+  provider: Extract<ConnectorProvider, "slack_bot" | "slack"> = "slack"
 ): Promise<Result<undefined, Error>> {
   const slackConfiguration =
     await SlackConfigurationResource.fetchByTeamId(teamId);

--- a/front/components/assistant_builder/TryAssistant.tsx
+++ b/front/components/assistant_builder/TryAssistant.tsx
@@ -65,6 +65,7 @@ export function usePreviewAssistant({
         },
         agentConfigurationId: null,
         slackData: {
+          provider: "slack_bot",
           selectedSlackChannels: [],
           slackChannelsLinkedWithAgent: [],
         },

--- a/front/components/assistant_builder/submitAssistantBuilderForm.ts
+++ b/front/components/assistant_builder/submitAssistantBuilderForm.ts
@@ -1,3 +1,5 @@
+import type { ConnectorProvider } from "@dust-tt/client";
+
 import { isLegacyAssistantBuilderConfiguration } from "@app/components/assistant_builder/legacy_agent";
 import { removeLeadingAt } from "@app/components/assistant_builder/SettingsScreen";
 import { getTableIdForContentNode } from "@app/components/assistant_builder/shared";
@@ -86,6 +88,7 @@ export async function submitAssistantBuilderForm({
   builderState: AssistantBuilderState;
   agentConfigurationId: string | null;
   slackData: {
+    provider: Extract<ConnectorProvider, "slack_bot" | "slack">;
     selectedSlackChannels: SlackChannel[];
     slackChannelsLinkedWithAgent: SlackChannelLinkedWithAgent[];
   };
@@ -94,7 +97,8 @@ export async function submitAssistantBuilderForm({
 }): Promise<
   Result<LightAgentConfigurationType | AgentConfigurationType, Error>
 > {
-  const { selectedSlackChannels, slackChannelsLinkedWithAgent } = slackData;
+  const { provider, selectedSlackChannels, slackChannelsLinkedWithAgent } =
+    slackData;
   let { handle, description, instructions, avatarUrl, editors } = builderState;
   if (!handle || !description || !instructions || !avatarUrl || !editors) {
     if (!isDraft) {
@@ -388,7 +392,7 @@ export async function submitAssistantBuilderForm({
     ).length
   ) {
     const slackLinkRes = await fetch(
-      `/api/w/${owner.sId}/assistant/agent_configurations/${agentConfigurationSid}/linked_slack_channels`,
+      `/api/w/${owner.sId}/assistant/agent_configurations/${agentConfigurationSid}/linked_slack_channels?provider=${provider}`,
       {
         method: "PATCH",
         headers: {

--- a/front/components/assistant_builder/useSlackChannels.tsx
+++ b/front/components/assistant_builder/useSlackChannels.tsx
@@ -1,3 +1,4 @@
+import type { ConnectorProvider } from "@dust-tt/client";
 import { useEffect, useState } from "react";
 
 import type { SlackChannel } from "@app/components/assistant_builder/SlackIntegration";
@@ -10,6 +11,7 @@ interface useSlackChannelProps {
   isEdited: boolean;
   isPrivateAssistant: boolean;
   workspaceId: string;
+  connectorProvider?: Extract<ConnectorProvider, "slack" | "slack_bot">;
 }
 
 export function useSlackChannel({
@@ -19,6 +21,7 @@ export function useSlackChannel({
   isEdited,
   isPrivateAssistant,
   workspaceId,
+  connectorProvider = "slack",
 }: useSlackChannelProps) {
   // This state stores the slack channels that should have the current agent as default.
   const [selectedSlackChannels, setSelectedSlackChannels] =
@@ -33,6 +36,7 @@ export function useSlackChannel({
     mutateSlackChannels,
   } = useSlackChannelsLinkedWithAgent({
     workspaceId,
+    connectorProvider,
     disabled: !isBuilder,
   });
 

--- a/front/lib/swr/assistants.ts
+++ b/front/lib/swr/assistants.ts
@@ -24,6 +24,7 @@ import type { PostAgentUserFavoriteRequestBody } from "@app/pages/api/w/[wId]/me
 import type {
   AgentConfigurationType,
   AgentsGetViewType,
+  ConnectorProvider,
   LightAgentConfigurationType,
   LightWorkspaceType,
   UserType,
@@ -449,16 +450,18 @@ export function useAgentAnalytics({
 
 export function useSlackChannelsLinkedWithAgent({
   workspaceId,
+  connectorProvider = "slack",
   disabled,
 }: {
   workspaceId: string;
+  connectorProvider: Extract<ConnectorProvider, "slack" | "slack_bot">;
   disabled?: boolean;
 }) {
   const slackChannelsLinkedWithAgentFetcher: Fetcher<GetSlackChannelsLinkedWithAgentResponseBody> =
     fetcher;
 
   const { data, error, mutate } = useSWRWithDefaults(
-    `/api/w/${workspaceId}/assistant/builder/slack/channels_linked_with_agent`,
+    `/api/w/${workspaceId}/assistant/builder/${connectorProvider}/channels_linked_with_agent`,
     slackChannelsLinkedWithAgentFetcher,
     {
       disabled: !!disabled,

--- a/front/pages/api/w/[wId]/assistant/agent_configurations/[aId]/linked_slack_channels.ts
+++ b/front/pages/api/w/[wId]/assistant/agent_configurations/[aId]/linked_slack_channels.ts
@@ -39,9 +39,21 @@ async function handler(
     });
   }
 
+  const provider = (req.query.provider as string) || "slack";
+
+  if (provider !== "slack" && provider !== "slack_bot") {
+    return apiError(req, res, {
+      status_code: 400,
+      api_error: {
+        type: "invalid_request_error",
+        message: "Provider parameter must be either 'slack' or 'slack_bot'",
+      },
+    });
+  }
+
   const slackDataSources = await DataSourceResource.listByConnectorProvider(
     auth,
-    "slack",
+    provider,
     { limit: 1 }
   );
   const slackDataSource = slackDataSources[0];

--- a/front/pages/api/w/[wId]/assistant/builder/slack_bot/channels_linked_with_agent.ts
+++ b/front/pages/api/w/[wId]/assistant/builder/slack_bot/channels_linked_with_agent.ts
@@ -1,0 +1,20 @@
+import type { NextApiRequest, NextApiResponse } from "next";
+
+import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
+import type { Authenticator } from "@app/lib/auth";
+import type { WithAPIErrorResponse } from "@app/types";
+
+import type { GetSlackChannelsLinkedWithAgentResponseBody } from "../slack/channels_linked_with_agent";
+import { handleSlackChannelsLinkedWithAgent } from "../slack/channels_linked_with_agent";
+
+async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse<
+    WithAPIErrorResponse<GetSlackChannelsLinkedWithAgentResponseBody>
+  >,
+  auth: Authenticator
+): Promise<void> {
+  return handleSlackChannelsLinkedWithAgent(req, res, auth, "slack_bot");
+}
+
+export default withSessionAuthenticationForWorkspace(handler);


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

Updates the AssistantBuilder component to use the SlackBot connector first, and falls back to the legacy Slack connector if SlackBot is unavailable.

This change adds dual connector hooks, conditional rendering logic, and updates the form submission to pass the appropriate provider type to the API endpoint.

## Tests

Tested on dev local and casquedelumiere

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

`slack_bot` preempts `slack` connector, so once SlackBot has been enabled the UI component use `slack_bot` always. This is not an issue since we don't expect users reverting from `slack_bot` to `slack`, and even if they do it will only impact the ability to configure default assistant per Slack channel.

## Deploy Plan

