### PR TITLE
Implement slack_bot connector retrievePermissions

### DIFF
--- a/connectors/src/connectors/slack/index.ts
+++ b/connectors/src/connectors/slack/index.ts
@@ -18,20 +18,15 @@ import {
   joinChannel,
 } from "@connectors/connectors/slack/lib/channels";
 import { slackConfig } from "@connectors/connectors/slack/lib/config";
+import { retrievePermissions } from "@connectors/connectors/slack/lib/retrieve_permissions";
 import {
   getSlackAccessToken,
   getSlackClient,
   reportSlackUsage,
 } from "@connectors/connectors/slack/lib/slack_client";
-import {
-  slackChannelIdFromInternalId,
-  slackChannelInternalIdFromSlackChannelId,
-} from "@connectors/connectors/slack/lib/utils";
+import { slackChannelIdFromInternalId } from "@connectors/connectors/slack/lib/utils";
 import { launchSlackSyncWorkflow } from "@connectors/connectors/slack/temporal/client.js";
-import {
-  ExternalOAuthTokenError,
-  ProviderWorkflowError,
-} from "@connectors/lib/error";
+import { ExternalOAuthTokenError } from "@connectors/lib/error";
 import { SlackChannel } from "@connectors/lib/models/slack";
 import { terminateAllWorkflowsForConnectorId } from "@connectors/lib/temporal";
 import logger from "@connectors/logger/logger";
@@ -40,13 +35,11 @@ import { SlackConfigurationResource } from "@connectors/resources/slack_configur
 import type {
   ConnectorPermission,
   ContentNode,
-  ContentNodesViewType,
+  DataSourceConfig,
+  ModelId,
   SlackConfigurationType,
 } from "@connectors/types";
-import type { ModelId } from "@connectors/types";
-import type { DataSourceConfig } from "@connectors/types";
 import {
-  INTERNAL_MIME_TYPES,
   isSlackAutoReadPatterns,
   normalizeError,
   safeParseJSON,
@@ -306,173 +299,15 @@ export class SlackConnectorManager extends BaseConnectorManager<SlackConfigurati
   }: {
     parentInternalId: string | null;
     filterPermission: ConnectorPermission | null;
-    viewType: ContentNodesViewType;
   }): Promise<
     Result<ContentNode[], ConnectorManagerError<RetrievePermissionsErrorCode>>
   > {
-    if (parentInternalId) {
-      return new Err(
-        new ConnectorManagerError(
-          "INVALID_PARENT_INTERNAL_ID",
-          "Slack connector does not support permission retrieval with non null `parentInternalId`"
-        )
-      );
-    }
-
-    const c = await ConnectorResource.fetchById(this.connectorId);
-    if (!c) {
-      logger.error({ connectorId: this.connectorId }, "Connector not found");
-      return new Err(
-        new ConnectorManagerError("CONNECTOR_NOT_FOUND", "Connector not found")
-      );
-    }
-    const slackConfig = await SlackConfigurationResource.fetchByConnectorId(
-      this.connectorId
-    );
-    if (!slackConfig) {
-      logger.error(
-        { connectorId: this.connectorId },
-        "Slack configuration not found"
-      );
-      // This is unexpected let's throw to return a 500.
-      throw new Error("Slack configuration not found");
-    }
-
-    let permissionToFilter: ConnectorPermission[] = [];
-
-    switch (filterPermission) {
-      case "read":
-        permissionToFilter = ["read", "read_write"];
-        break;
-      case "write":
-        permissionToFilter = ["write", "read_write"];
-        break;
-      case "read_write":
-        permissionToFilter = ["read_write"];
-        break;
-    }
-
-    const slackChannels: {
-      slackChannelId: string;
-      slackChannelName: string;
-      permission: ConnectorPermission;
-      private: boolean;
-    }[] = [];
-
-    try {
-      if (filterPermission === "read") {
-        const localChannels = await SlackChannel.findAll({
-          where: {
-            connectorId: this.connectorId,
-            permission: permissionToFilter,
-            skipReason: null, // We hide skipped channels from the UI.
-          },
-        });
-        slackChannels.push(
-          ...localChannels.map((channel) => ({
-            slackChannelId: channel.slackChannelId,
-            slackChannelName: channel.slackChannelName,
-            permission: channel.permission,
-            private: channel.private,
-          }))
-        );
-      } else {
-        const slackClient = await getSlackClient(c.id, {
-          // Do not reject rate limited calls in update connector. Called from the API.
-          rejectRateLimitedCalls: false,
-        });
-
-        const [remoteChannels, localChannels] = await Promise.all([
-          getChannels(slackClient, c.id, false),
-          SlackChannel.findAll({
-            where: {
-              connectorId: this.connectorId,
-              // Here we do not filter out channels with skipReason because we need to know the ones that are skipped.
-            },
-          }),
-        ]);
-
-        const localChannelsById = localChannels.reduce(
-          (acc, ch) => {
-            acc[ch.slackChannelId] = ch;
-            return acc;
-          },
-          {} as Record<string, SlackChannel>
-        );
-
-        for (const remoteChannel of remoteChannels) {
-          if (!remoteChannel.id || !remoteChannel.name) {
-            continue;
-          }
-
-          const localChannel = localChannelsById[remoteChannel.id];
-
-          // Skip channels with skipReason
-          if (localChannel?.skipReason) {
-            continue;
-          }
-
-          const permissions =
-            localChannel?.permission ||
-            (remoteChannel.is_member ? "write" : "none");
-
-          if (
-            permissionToFilter.length === 0 ||
-            permissionToFilter.includes(permissions)
-          ) {
-            slackChannels.push({
-              slackChannelId: remoteChannel.id,
-              slackChannelName: remoteChannel.name,
-              permission: permissions,
-              private: !!remoteChannel.is_private,
-            });
-          }
-        }
-      }
-
-      const resources: ContentNode[] = slackChannels.map((ch) => ({
-        internalId: slackChannelInternalIdFromSlackChannelId(ch.slackChannelId),
-        parentInternalId: null,
-        type: "folder",
-        title: `#${ch.slackChannelName}`,
-        sourceUrl: `https://app.slack.com/client/${slackConfig.slackTeamId}/${ch.slackChannelId}`,
-        expandable: false,
-        permission: ch.permission,
-        lastUpdatedAt: null,
-        providerVisibility: ch.private ? "private" : "public",
-        mimeType: INTERNAL_MIME_TYPES.SLACK.CHANNEL,
-      }));
-
-      resources.sort((a, b) => {
-        return a.title.localeCompare(b.title);
-      });
-
-      return new Ok(resources);
-    } catch (e) {
-      if (e instanceof ExternalOAuthTokenError) {
-        logger.error({ connectorId: this.connectorId }, "Slack token invalid");
-        return new Err(
-          new ConnectorManagerError(
-            "EXTERNAL_OAUTH_TOKEN_ERROR",
-            "Slack authorization error, please re-authorize."
-          )
-        );
-      }
-      if (e instanceof ProviderWorkflowError && e.type === "rate_limit_error") {
-        logger.error(
-          { connectorId: this.connectorId, error: e },
-          "Slack rate limit when retrieving permissions."
-        );
-        return new Err(
-          new ConnectorManagerError(
-            "RATE_LIMIT_ERROR",
-            `Slack rate limit error when retrieving content nodes.`
-          )
-        );
-      }
-      // Unhandled error, throwing to get a 500.
-      throw e;
-    }
+    return retrievePermissions({
+      connectorId: this.connectorId,
+      parentInternalId,
+      filterPermission,
+      getFilteredChannels,
+    });
   }
 
   async retrieveContentNodeParents({
@@ -846,4 +681,101 @@ export async function getRestrictedSpaceAgentsEnabled(
   }
 
   return new Ok(slackConfiguration.restrictedSpaceAgentsEnabled.toString());
+}
+
+async function getFilteredChannels(
+  connectorId: number,
+  filterPermission: ConnectorPermission | null
+) {
+  let permissionToFilter: ConnectorPermission[] = [];
+
+  switch (filterPermission) {
+    case "read":
+      permissionToFilter = ["read", "read_write"];
+      break;
+    case "write":
+      permissionToFilter = ["write", "read_write"];
+      break;
+    case "read_write":
+      permissionToFilter = ["read_write"];
+      break;
+  }
+
+  const slackChannels: {
+    slackChannelId: string;
+    slackChannelName: string;
+    permission: ConnectorPermission;
+    private: boolean;
+  }[] = [];
+
+  if (filterPermission === "read") {
+    const localChannels = await SlackChannel.findAll({
+      where: {
+        connectorId,
+        permission: permissionToFilter,
+        skipReason: null, // We hide skipped channels from the UI.
+      },
+    });
+    slackChannels.push(
+      ...localChannels.map((channel) => ({
+        slackChannelId: channel.slackChannelId,
+        slackChannelName: channel.slackChannelName,
+        permission: channel.permission,
+        private: channel.private,
+      }))
+    );
+  } else {
+    const slackClient = await getSlackClient(connectorId, {
+      // Do not reject rate limited calls in update connector. Called from the API.
+      rejectRateLimitedCalls: false,
+    });
+
+    const [remoteChannels, localChannels] = await Promise.all([
+      getChannels(slackClient, connectorId, false),
+      SlackChannel.findAll({
+        where: {
+          connectorId,
+          // Here we do not filter out channels with skipReason because we need to know the ones that are skipped.
+        },
+      }),
+    ]);
+
+    const localChannelsById = localChannels.reduce(
+      (acc: Record<string, SlackChannel>, ch: SlackChannel) => {
+        acc[ch.slackChannelId] = ch;
+        return acc;
+      },
+      {} as Record<string, SlackChannel>
+    );
+
+    for (const remoteChannel of remoteChannels) {
+      if (!remoteChannel.id || !remoteChannel.name) {
+        continue;
+      }
+
+      const localChannel = localChannelsById[remoteChannel.id];
+
+      // Skip channels with skipReason
+      if (localChannel?.skipReason) {
+        continue;
+      }
+
+      const permissions =
+        localChannel?.permission ||
+        (remoteChannel.is_member ? "write" : "none");
+
+      if (
+        permissionToFilter.length === 0 ||
+        permissionToFilter.includes(permissions)
+      ) {
+        slackChannels.push({
+          slackChannelId: remoteChannel.id,
+          slackChannelName: remoteChannel.name,
+          permission: permissions,
+          private: !!remoteChannel.is_private,
+        });
+      }
+    }
+  }
+  return slackChannels;
 }

--- a/connectors/src/connectors/slack/lib/retrieve_permissions.ts
+++ b/connectors/src/connectors/slack/lib/retrieve_permissions.ts
@@ -1,0 +1,110 @@
+import type { Result } from "@dust-tt/client";
+import { Err, Ok } from "@dust-tt/client";
+
+import type { RetrievePermissionsErrorCode } from "@connectors/connectors/interface";
+import { ConnectorManagerError } from "@connectors/connectors/interface";
+import { slackChannelInternalIdFromSlackChannelId } from "@connectors/connectors/slack/lib/utils";
+import {
+  ExternalOAuthTokenError,
+  ProviderWorkflowError,
+} from "@connectors/lib/error";
+import logger from "@connectors/logger/logger";
+import { ConnectorResource } from "@connectors/resources/connector_resource";
+import { SlackConfigurationResource } from "@connectors/resources/slack_configuration_resource";
+import type { ConnectorPermission, ContentNode } from "@connectors/types";
+import { INTERNAL_MIME_TYPES } from "@connectors/types";
+
+export async function retrievePermissions({
+  connectorId,
+  parentInternalId,
+  filterPermission,
+  getFilteredChannels,
+}: {
+  connectorId: number;
+  parentInternalId: string | null;
+  filterPermission: ConnectorPermission | null;
+  getFilteredChannels: (
+    connectorId: number,
+    filterPermission: ConnectorPermission | null
+  ) => Promise<
+    {
+      slackChannelId: string;
+      slackChannelName: string;
+      permission: ConnectorPermission;
+      private: boolean;
+    }[]
+  >;
+}): Promise<
+  Result<ContentNode[], ConnectorManagerError<RetrievePermissionsErrorCode>>
+> {
+  if (parentInternalId) {
+    return new Err(
+      new ConnectorManagerError(
+        "INVALID_PARENT_INTERNAL_ID",
+        "Slack connector does not support permission retrieval with non null `parentInternalId`"
+      )
+    );
+  }
+
+  const c = await ConnectorResource.fetchById(connectorId);
+  if (!c) {
+    logger.error({ connectorId }, "Connector not found");
+    return new Err(
+      new ConnectorManagerError("CONNECTOR_NOT_FOUND", "Connector not found")
+    );
+  }
+  const slackConfig =
+    await SlackConfigurationResource.fetchByConnectorId(connectorId);
+  if (!slackConfig) {
+    logger.error({ connectorId }, "Slack configuration not found");
+    // This is unexpected let's throw to return a 500.
+    throw new Error("Slack configuration not found");
+  }
+
+  try {
+    const slackChannels = await getFilteredChannels(c.id, filterPermission);
+
+    const resources: ContentNode[] = slackChannels.map((ch) => ({
+      internalId: slackChannelInternalIdFromSlackChannelId(ch.slackChannelId),
+      parentInternalId: null,
+      type: "folder",
+      title: `#${ch.slackChannelName}`,
+      sourceUrl: `https://app.slack.com/client/${slackConfig.slackTeamId}/${ch.slackChannelId}`,
+      expandable: false,
+      permission: ch.permission,
+      lastUpdatedAt: null,
+      providerVisibility: ch.private ? "private" : "public",
+      mimeType: INTERNAL_MIME_TYPES.SLACK.CHANNEL,
+    }));
+
+    resources.sort((a, b) => {
+      return a.title.localeCompare(b.title);
+    });
+
+    return new Ok(resources);
+  } catch (e) {
+    if (e instanceof ExternalOAuthTokenError) {
+      logger.error({ connectorId }, "Slack token invalid");
+      return new Err(
+        new ConnectorManagerError(
+          "EXTERNAL_OAUTH_TOKEN_ERROR",
+          "Slack authorization error, please re-authorize."
+        )
+      );
+    }
+    if (e instanceof ProviderWorkflowError && e.type === "rate_limit_error") {
+      logger.error(
+        { connectorId, error: e },
+        "Slack rate limit when retrieving permissions."
+      );
+      return new Err(
+        new ConnectorManagerError(
+          "RATE_LIMIT_ERROR",
+          `Slack rate limit error when retrieving content nodes.`
+        )
+      );
+    }
+    // Unhandled error, throwing to get a 500.
+    throw e;
+  }
+}

--- a/connectors/src/connectors/slack_bot/index.ts
+++ b/connectors/src/connectors/slack_bot/index.ts
@@ -462,7 +462,7 @@ async function getFilteredChannels(
   });
 
   const [remoteChannels, localChannels] = await Promise.all([
-    getChannels(slackClient, connectorId, false),
+    getChannels(slackClient, connectorId, true),
     SlackChannel.findAll({
       where: {
         connectorId,

--- a/connectors/src/connectors/slack_bot/index.ts
+++ b/connectors/src/connectors/slack_bot/index.ts
@@ -484,6 +484,11 @@ async function getFilteredChannels(
       continue;
     }
 
+    if (remoteChannel.is_private) {
+      // Skip private channels backend-side (displayed frontend-side if FF index_private_slack_channel is toggled)
+      continue;
+    }
+
     const localChannel = localChannelsById[remoteChannel.id];
 
     // Skip channels with skipReason


### PR DESCRIPTION
## Description

- Moved `retrievePermissions` functionality from `slack/index.ts` to a shared `slack/lib/retrieve_permissions.ts` module
- Added permission retrieval capabilities to the `slack_bot` connector (previously returned empty array)

## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

## Tests

Tested on casquedelumiere

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

**Low Risk**
- Refactoring extracts existing logic without changing behavior
- No API changes or breaking modifications
- Shared function maintains identical error handling and return types

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
