### PR TITLE
[front] refactor(MCP): invert meaning of `isRestricted`

### DIFF
--- a/front/lib/actions/mcp_internal_actions/constants.ts
+++ b/front/lib/actions/mcp_internal_actions/constants.ts
@@ -98,7 +98,7 @@ export const INTERNAL_MCP_SERVERS: Record<
     id: 6,
     availability: "auto",
     isRestricted: ({ featureFlags }) => {
-      return featureFlags.includes("dev_mcp_actions");
+      return !featureFlags.includes("dev_mcp_actions");
     },
   },
   hubspot: {
@@ -188,8 +188,8 @@ export const INTERNAL_MCP_SERVERS: Record<
     availability: "manual",
     isRestricted: ({ featureFlags }) => {
       // When we are ready to release the feature, the condition will be:
-      // return featureFlags.includes("salesforce_tool") || plan.limits.connections.isSalesforceAllowed;
-      return featureFlags.includes("salesforce_tool");
+      // return !featureFlags.includes("salesforce_tool") && !plan.limits.connections.isSalesforceAllowed;
+      return !featureFlags.includes("salesforce_tool");
     },
     tools_stakes: {
       execute_read_query: "low",
@@ -201,7 +201,7 @@ export const INTERNAL_MCP_SERVERS: Record<
     id: 15,
     availability: "manual",
     isRestricted: ({ featureFlags }) => {
-      return featureFlags.includes("gmail_tool");
+      return !featureFlags.includes("gmail_tool");
     },
     tools_stakes: {
       get_drafts: "never_ask",
@@ -212,7 +212,7 @@ export const INTERNAL_MCP_SERVERS: Record<
     id: 16,
     availability: "manual",
     isRestricted: ({ featureFlags }) => {
-      return featureFlags.includes("google_calendar_tool");
+      return !featureFlags.includes("google_calendar_tool");
     },
     tools_stakes: {
       list_calendars: "never_ask",
@@ -232,7 +232,7 @@ export const INTERNAL_MCP_SERVERS: Record<
     id: 18,
     availability: "manual",
     isRestricted: ({ featureFlags }) => {
-      return featureFlags.includes("slack_tool");
+      return !featureFlags.includes("slack_tool");
     },
     tools_stakes: {
       search_messages: "never_ask",
@@ -255,7 +255,7 @@ export const INTERNAL_MCP_SERVERS: Record<
     id: 1004,
     availability: "manual",
     isRestricted: ({ featureFlags }) => {
-      return featureFlags.includes("dev_mcp_actions");
+      return !featureFlags.includes("dev_mcp_actions");
     },
   },
   reasoning: {
@@ -267,7 +267,7 @@ export const INTERNAL_MCP_SERVERS: Record<
     availability: "auto",
     // We'll eventually switch everyone to this new tables query toolset.
     isRestricted: ({ featureFlags }) => {
-      return featureFlags.includes("exploded_tables_query");
+      return !featureFlags.includes("exploded_tables_query");
     },
   },
   data_sources_file_system: {

--- a/front/lib/actions/mcp_internal_actions/constants.ts
+++ b/front/lib/actions/mcp_internal_actions/constants.ts
@@ -12,7 +12,7 @@ export const ADVANCED_SEARCH_SWITCH = "advanced_search";
 
 export const AVAILABLE_INTERNAL_MCP_SERVER_NAMES = [
   // Note:
-  // Names should reflect the purpose of the server, but not directly the tools it contains.
+  // Names should reflect the purpose of the server but not directly the tools it contains.
   // We'll prefix all tools with the server name to avoid conflicts.
   // It's okay to change the name of the server as we don't refer to it directly.
   "agent_router",
@@ -55,10 +55,10 @@ export const INTERNAL_MCP_SERVERS: Record<
   {
     id: number;
     availability: MCPServerAvailability;
-    isRestricted?: (
-      plan: PlanType,
-      featureFlags: WhitelistableFeature[]
-    ) => boolean;
+    isRestricted?: (params: {
+      plan: PlanType;
+      featureFlags: WhitelistableFeature[];
+    }) => boolean;
     tools_stakes?: Record<string, MCPToolStakeLevelType>;
     timeoutMs?: number;
   }
@@ -97,7 +97,7 @@ export const INTERNAL_MCP_SERVERS: Record<
   think: {
     id: 6,
     availability: "auto",
-    isRestricted: (plan, featureFlags) => {
+    isRestricted: ({ featureFlags }) => {
       return featureFlags.includes("dev_mcp_actions");
     },
   },
@@ -186,7 +186,7 @@ export const INTERNAL_MCP_SERVERS: Record<
   salesforce: {
     id: 14,
     availability: "manual",
-    isRestricted: (plan, featureFlags) => {
+    isRestricted: ({ featureFlags }) => {
       // When we are ready to release the feature, the condition will be:
       // return featureFlags.includes("salesforce_tool") || plan.limits.connections.isSalesforceAllowed;
       return featureFlags.includes("salesforce_tool");
@@ -200,7 +200,7 @@ export const INTERNAL_MCP_SERVERS: Record<
   gmail: {
     id: 15,
     availability: "manual",
-    isRestricted: (plan, featureFlags) => {
+    isRestricted: ({ featureFlags }) => {
       return featureFlags.includes("gmail_tool");
     },
     tools_stakes: {
@@ -211,7 +211,7 @@ export const INTERNAL_MCP_SERVERS: Record<
   google_calendar: {
     id: 16,
     availability: "manual",
-    isRestricted: (plan, featureFlags) => {
+    isRestricted: ({ featureFlags }) => {
       return featureFlags.includes("google_calendar_tool");
     },
     tools_stakes: {
@@ -231,7 +231,7 @@ export const INTERNAL_MCP_SERVERS: Record<
   slack: {
     id: 18,
     availability: "manual",
-    isRestricted: (plan, featureFlags) => {
+    isRestricted: ({ featureFlags }) => {
       return featureFlags.includes("slack_tool");
     },
     tools_stakes: {
@@ -254,7 +254,7 @@ export const INTERNAL_MCP_SERVERS: Record<
   primitive_types_debugger: {
     id: 1004,
     availability: "manual",
-    isRestricted: (plan, featureFlags) => {
+    isRestricted: ({ featureFlags }) => {
       return featureFlags.includes("dev_mcp_actions");
     },
   },
@@ -266,14 +266,14 @@ export const INTERNAL_MCP_SERVERS: Record<
     id: 1009,
     availability: "auto",
     // We'll eventually switch everyone to this new tables query toolset.
-    isRestricted: (plan, featureFlags) => {
+    isRestricted: ({ featureFlags }) => {
       return featureFlags.includes("exploded_tables_query");
     },
   },
   data_sources_file_system: {
     id: 1010,
     availability: "auto",
-    isRestricted: () => false,
+    isRestricted: () => true,
   },
 };
 

--- a/front/lib/actions/mcp_internal_actions/index.ts
+++ b/front/lib/actions/mcp_internal_actions/index.ts
@@ -22,7 +22,7 @@ export const isEnabledForWorkspace = async (
   if (mcpServer.isRestricted) {
     const featureFlags = await getFeatureFlags(auth.getNonNullableWorkspace());
     const plan = auth.getNonNullablePlan();
-    return mcpServer.isRestricted({ plan, featureFlags });
+    return !mcpServer.isRestricted({ plan, featureFlags });
   }
 
   // If the server has no restriction, it is available by default.

--- a/front/lib/actions/mcp_internal_actions/index.ts
+++ b/front/lib/actions/mcp_internal_actions/index.ts
@@ -22,7 +22,7 @@ export const isEnabledForWorkspace = async (
   if (mcpServer.isRestricted) {
     const featureFlags = await getFeatureFlags(auth.getNonNullableWorkspace());
     const plan = auth.getNonNullablePlan();
-    return mcpServer.isRestricted(plan, featureFlags);
+    return mcpServer.isRestricted({ plan, featureFlags });
   }
 
   // If the server has no restriction, it is available by default.

--- a/front/lib/resources/mcp_server_view_resource.test.ts
+++ b/front/lib/resources/mcp_server_view_resource.test.ts
@@ -42,11 +42,13 @@ describe("MCPServerViewResource", () => {
           value: {
             ...originalThinkConfig,
             availability: "auto",
-            isRestricted: (
-              plan: PlanType,
-              featureFlags: WhitelistableFeature[]
-            ) => {
-              return featureFlags.includes("dev_mcp_actions");
+            isRestricted: ({
+              featureFlags,
+            }: {
+              plan: PlanType;
+              featureFlags: WhitelistableFeature[];
+            }) => {
+              return !featureFlags.includes("dev_mcp_actions");
             },
           },
           writable: true,

--- a/front/pages/api/w/[wId]/spaces/[spaceId]/mcp/available.test.ts
+++ b/front/pages/api/w/[wId]/spaces/[spaceId]/mcp/available.test.ts
@@ -40,11 +40,13 @@ describe("GET /api/w/[wId]/spaces/[spaceId]/mcp/available", () => {
       value: {
         ...originalPrimitiveTypesDebuggerConfig,
         availability: "auto",
-        isRestricted: (
-          plan: PlanType,
-          featureFlags: WhitelistableFeature[]
-        ) => {
-          return featureFlags.includes("dev_mcp_actions");
+        isRestricted: ({
+          featureFlags,
+        }: {
+          plan: PlanType;
+          featureFlags: WhitelistableFeature[];
+        }) => {
+          return !featureFlags.includes("dev_mcp_actions");
         },
       },
       writable: true,


### PR DESCRIPTION
## Description

- Currently, we have a parameter `isRestricted` for internal MCP servers that indicates whether a server should be allowed based on plan and feature flag restrictions.
- This callback `isRestricted` actually returns true if the MCP server is allowed.
- This PR inverts the return value and slightly refactors the parameters of the callback for ease of use (and partly to make it easier to review as it highlights every definition of `isRestricted`).

## Tests

- Checked locally that I do see the same servers.

## Risk

- N/A.

## Deploy Plan

- Deploy front.
