### PR TITLE
[front] Add option to ignore auth0 merge

### DIFF
--- a/front/lib/api/poke/plugins/workspaces/user_identity_merge.ts
+++ b/front/lib/api/poke/plugins/workspaces/user_identity_merge.ts
@@ -37,6 +37,12 @@ export const userIdentityMergePlugin = createPlugin({
           "If true, the secondary user will be revoked from the workspace after the merge.",
         default: false,
       },
+      skipAuth0: {
+        type: "boolean",
+        label: "Skip Auth0",
+        description: "If true, the Auth0 merge will be skipped.",
+        default: false,
+      },
     },
   },
   execute: async (auth, _, args) => {
@@ -53,6 +59,7 @@ export const userIdentityMergePlugin = createPlugin({
       secondaryUserId,
       enforceEmailMatch: !args.ignoreEmailMatch,
       revokeSecondaryUser: args.revokeSecondaryUser,
+      skipAuth0: args.skipAuth0,
     });
 
     if (mergeResult.isErr()) {

--- a/front/lib/iam/users.ts
+++ b/front/lib/iam/users.ts
@@ -233,12 +233,14 @@ export async function mergeUserIdentities({
   secondaryUserId,
   enforceEmailMatch = true,
   revokeSecondaryUser = false,
+  skipAuth0 = false,
 }: {
   auth: Authenticator;
   primaryUserId: string;
   secondaryUserId: string;
   enforceEmailMatch?: boolean;
   revokeSecondaryUser?: boolean;
+  skipAuth0?: boolean;
 }): Promise<
   Result<{ primaryUser: UserResource; secondaryUser: UserResource }, Error>
 > {
@@ -280,64 +282,63 @@ export async function mergeUserIdentities({
     );
   }
 
-  const auth0ManagemementClient = getAuth0ManagemementClient();
+  if (!skipAuth0) {
+    const auth0ManagemementClient = getAuth0ManagemementClient();
 
-  const primaryUserAuth0 =
-    await auth0ManagemementClient.usersByEmail.getByEmail({
-      email: primaryUser.email,
-    });
-
-  const secondaryUserAuth0 =
-    await auth0ManagemementClient.usersByEmail.getByEmail({
-      email: secondaryUser.email,
-    });
-
-  const primaryUserAuth0Sub = primaryUserAuth0.data.find(
-    (u) => u.user_id === primaryUser.auth0Sub
-  );
-  const secondaryUserAuth0Sub = secondaryUserAuth0.data.find(
-    (u) => u.user_id === secondaryUser.auth0Sub
-  );
-
-  if (!primaryUserAuth0Sub) {
-    return new Err(new Error("Primary user not found in Auth0."));
-  }
-
-  // No auth0 sub for the secondary user, nothing to merge on that side.
-  if (secondaryUserAuth0Sub) {
-    const [identityToMerge] = secondaryUserAuth0Sub.identities;
-
-    // Retrieve the connection id for the identity to merge.
-    const connectionsResponse =
-      await getAuth0ManagemementClient().connections.getAll({
-        name: identityToMerge.connection,
+    const primaryUserAuth0 =
+      await auth0ManagemementClient.usersByEmail.getByEmail({
+        email: primaryUser.email,
       });
 
-    const [connection] = connectionsResponse.data;
-    if (!connection) {
-      return new Err(
-        new Error(`Auth0 connection ${identityToMerge.connection} not found.`)
+    const secondaryUserAuth0 =
+      await auth0ManagemementClient.usersByEmail.getByEmail({
+        email: secondaryUser.email,
+      });
+
+    const primaryUserAuth0Sub = primaryUserAuth0.data.find(
+      (u) => u.user_id === primaryUser.auth0Sub
+    );
+    const secondaryUserAuth0Sub = secondaryUserAuth0.data.find(
+      (u) => u.user_id === secondaryUser.auth0Sub
+    );
+
+    // No auth0 sub for the primary or secondary user, nothing to merge on that side.
+    if (primaryUserAuth0Sub && secondaryUserAuth0Sub) {
+      const [identityToMerge] = secondaryUserAuth0Sub.identities;
+
+      // Retrieve the connection id for the identity to merge.
+      const connectionsResponse =
+        await getAuth0ManagemementClient().connections.getAll({
+          name: identityToMerge.connection,
+        });
+
+      const [connection] = connectionsResponse.data;
+      if (!connection) {
+        return new Err(
+          new Error(`Auth0 connection ${identityToMerge.connection} not found.`)
+        );
+      }
+
+      await auth0ManagemementClient.users.link(
+        { id: primaryUserAuth0Sub.user_id },
+        {
+          provider:
+            identityToMerge.provider as PostIdentitiesRequestProviderEnum,
+          connection_id: connection.id,
+          user_id: identityToMerge.user_id,
+        }
+      );
+
+      // Mark the primary user as having been linked.
+      await auth0ManagemementClient.users.update(
+        { id: primaryUserAuth0Sub.user_id },
+        {
+          app_metadata: {
+            account_linking_state: Date.now(),
+          },
+        }
       );
     }
-
-    await auth0ManagemementClient.users.link(
-      { id: primaryUserAuth0Sub.user_id },
-      {
-        provider: identityToMerge.provider as PostIdentitiesRequestProviderEnum,
-        connection_id: connection.id,
-        user_id: identityToMerge.user_id,
-      }
-    );
-
-    // Mark the primary user as having been linked.
-    await auth0ManagemementClient.users.update(
-      { id: primaryUserAuth0Sub.user_id },
-      {
-        app_metadata: {
-          account_linking_state: Date.now(),
-        },
-      }
-    );
   }
 
   // Migrate authorship of agent configurations from the secondary user to the primary user.
@@ -435,7 +436,7 @@ export async function mergeUserIdentities({
     const workOSUserId = secondaryUser.workOSUserId;
     await UserModel.update(
       {
-        workOSUserId: undefined,
+        workOSUserId: null,
       },
       {
         where: {

--- a/front/lib/iam/users.ts
+++ b/front/lib/iam/users.ts
@@ -302,8 +302,12 @@ export async function mergeUserIdentities({
       (u) => u.user_id === secondaryUser.auth0Sub
     );
 
-    // No auth0 sub for the primary or secondary user, nothing to merge on that side.
-    if (primaryUserAuth0Sub && secondaryUserAuth0Sub) {
+    if (!primaryUserAuth0Sub) {
+      return new Err(new Error("Primary user not found in Auth0."));
+    }
+
+    // No auth0 sub for the secondary user, nothing to merge on that side.
+    if (secondaryUserAuth0Sub) {
       const [identityToMerge] = secondaryUserAuth0Sub.identities;
 
       // Retrieve the connection id for the identity to merge.


### PR DESCRIPTION
## Description

- Add a skipAuth0 option to skip the checks and operations on auth0. This it to be able to merge users on a primary account, even if the primary account does not have existing auth0Sub.
- Fix the workOSUser update but setting it to null.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

deploy front