### PR TITLE
[front] Move invite links to workos

### DIFF
--- a/front/lib/signup.ts
+++ b/front/lib/signup.ts
@@ -1,24 +1,13 @@
 export function getSignUpUrl({
   signupCallbackUrl,
   invitationEmail,
-  workOSEnabled,
 }: {
   signupCallbackUrl: string;
   invitationEmail?: string;
-  workOSEnabled?: boolean;
 }) {
-  if (workOSEnabled) {
-    let signUpUrl = `/api/workos/login?returnTo=${signupCallbackUrl}&screenHint=sign-up`;
-    if (invitationEmail) {
-      signUpUrl += `&loginHint=${encodeURIComponent(invitationEmail)}`;
-    }
-    return signUpUrl;
-  }
-
-  let signUpUrl = `/api/auth/login?returnTo=${signupCallbackUrl}&prompt=login&screen_hint=signup`;
+  let signUpUrl = `/api/workos/login?returnTo=${signupCallbackUrl}&screenHint=sign-up`;
   if (invitationEmail) {
-    signUpUrl += `&login_hint=${encodeURIComponent(invitationEmail)}`;
+    signUpUrl += `&loginHint=${encodeURIComponent(invitationEmail)}`;
   }
-
   return signUpUrl;
 }

--- a/front/pages/w/[wId]/join.tsx
+++ b/front/pages/w/[wId]/join.tsx
@@ -48,7 +48,6 @@ export const getServerSideProps = makeGetServerSidePropsRequirementsWrapper({
   onboardingType: OnboardingType;
   signUpCallbackUrl: string;
   workspace: LightWorkspaceType;
-  workOSEnabled: boolean;
 }>(async (context) => {
   const wId = context.query.wId as string;
   if (!wId) {

--- a/front/pages/w/[wId]/join.tsx
+++ b/front/pages/w/[wId]/join.tsx
@@ -11,12 +11,10 @@ import OnboardingLayout from "@app/components/sparkle/OnboardingLayout";
 import config from "@app/lib/api/config";
 import { getWorkspaceInfos } from "@app/lib/api/workspace";
 import { getWorkspaceVerifiedDomains } from "@app/lib/api/workspace_domains";
-import { getFeatureFlags } from "@app/lib/auth";
 import { makeGetServerSidePropsRequirementsWrapper } from "@app/lib/iam/session";
 import { MembershipInvitationResource } from "@app/lib/resources/membership_invitation_resource";
 import { getSignUpUrl } from "@app/lib/signup";
 import type { LightWorkspaceType } from "@app/types";
-import { isString } from "@app/types";
 
 /**
  * 3 ways to end up here:
@@ -65,10 +63,6 @@ export const getServerSideProps = makeGetServerSidePropsRequirementsWrapper({
       notFound: true,
     };
   }
-
-  const flags = await getFeatureFlags(workspace);
-  const workOSEnabled =
-    flags.includes("workos") && isString(workspace.workOSOrganizationId);
 
   const workspaceDomains = await getWorkspaceVerifiedDomains(workspace);
 
@@ -138,7 +132,6 @@ export const getServerSideProps = makeGetServerSidePropsRequirementsWrapper({
       onboardingType,
       signUpCallbackUrl,
       workspace,
-      workOSEnabled,
     },
   };
 });
@@ -148,12 +141,10 @@ export default function Join({
   onboardingType,
   signUpCallbackUrl,
   workspace,
-  workOSEnabled,
 }: InferGetServerSidePropsType<typeof getServerSideProps>) {
   const signUpUrl = getSignUpUrl({
     signupCallbackUrl: signUpCallbackUrl,
     invitationEmail: invitationEmail ?? undefined,
-    workOSEnabled,
   });
 
   return (


### PR DESCRIPTION
## Description

Sign up is disabled on auth0, all invites should go to default login link.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

deploy front