### PR TITLE
[front] - chore(ProviderManagementModal): polish

### DIFF
--- a/front/components/workspace/ProviderManagementModal.tsx
+++ b/front/components/workspace/ProviderManagementModal.tsx
@@ -6,6 +6,7 @@ import {
   DropdownMenuContent,
   DropdownMenuItem,
   DropdownMenuTrigger,
+  Icon,
   Sheet,
   SheetContainer,
   SheetContent,
@@ -163,7 +164,7 @@ export function ProviderManagementModal({
                 Make all providers available
               </span>
               <SliderToggle
-                size="sm"
+                size="xs"
                 selected={allToggleEnabled}
                 disabled={masterToggleDisabled}
                 onClick={() => {
@@ -188,10 +189,10 @@ export function ProviderManagementModal({
                   <ContextItem
                     key={provider}
                     title={prettyfiedProviderNames[provider]}
-                    visual={<LogoComponent />}
+                    visual={<Icon visual={LogoComponent} size="lg" />}
                     action={
                       <SliderToggle
-                        size="sm"
+                        size="xs"
                         selected={providerStates[provider]}
                         onClick={() => handleToggleChange(provider)}
                       />


### PR DESCRIPTION
## Description

This PR polishes the `ProviderManagementModal`:
- Changed the SliderToggle component size from 'sm' to 'xs' for a more consistent design
- Wrapped the LogoComponent in an Icon component with a 'lg' size for better visual integration

**References:**
- https://github.com/dust-tt/tasks/issues/3217

## Risk

Low

## Deploy Plan

Deploy front