### PR TITLE
[front] fix(auth): Avoid 500s if there is no user

### DIFF
--- a/front/lib/api/auth_wrappers.ts
+++ b/front/lib/api/auth_wrappers.ts
@@ -145,7 +145,6 @@ export function withSessionAuthenticationForWorkspace<T>(
       );
 
       const auth = await Authenticator.fromSession(session, wId);
-      req.addResourceToLog?.(auth.getNonNullableUser());
 
       const owner = auth.workspace();
       const plan = auth.plan();
@@ -193,6 +192,7 @@ export function withSessionAuthenticationForWorkspace<T>(
           },
         });
       }
+      req.addResourceToLog?.(user);
 
       // If `allowUserOutsideCurrentWorkspace` is not set or false then we check that the user is a
       // member of the workspace.


### PR DESCRIPTION
## Description
In the case of no user found in the session, avoid breaking when `getNonNullableUser` and instead use the optional user down below and use api error if not found

## Tests
- Locally

## Risk
- None

## Deploy Plan
- Deploy front
