### PR TITLE
Fix scrubdatasource stuck if tracker config for this ressource

### DIFF
--- a/front/lib/api/data_sources.ts
+++ b/front/lib/api/data_sources.ts
@@ -20,6 +20,7 @@ import { DustError } from "@app/lib/error";
 import { getDustDataSourcesBucket } from "@app/lib/file_storage";
 import { isGCSNotFoundError } from "@app/lib/file_storage/types";
 import { Lock } from "@app/lib/lock";
+import { TrackerDataSourceConfigurationModel } from "@app/lib/models/doc_tracker";
 import { DataSourceResource } from "@app/lib/resources/data_source_resource";
 import { DataSourceViewResource } from "@app/lib/resources/data_source_view_resource";
 import { FileResource } from "@app/lib/resources/file_resource";
@@ -195,6 +196,14 @@ export async function hardDeleteDataSource(
       );
     }
   } while (files.length === FILE_BATCH_SIZE);
+
+  // Delete all trackers datasource configurations associated with the data source.
+  await TrackerDataSourceConfigurationModel.destroy({
+    where: {
+      dataSourceId: dataSource.id,
+    },
+    hardDelete: true,
+  });
 
   // Ensure all content fragments from dsviews are expired.
   // Only used temporarily to unstuck queues -- TODO(fontanierh)


### PR DESCRIPTION
## Description

Fixes
```
ForeignKeyConstraintError: update or delete on table "data_source_views" violates foreign key constraint "tracker_data_source_configurations_dataSourceViewId_fkey" on table "tracker_data_source_configurations"
```

 https://app.datadoghq.eu/logs?query=status%3Aerror%20%40dd.env%3Aprod&agg_m=count&agg_m_source=base&agg_t=count&clustering_pattern_field_path=message&cols=host%2Cservice&event=AwAAAZehDc_iGGeDfwAAABhBWmVoRGRJZkFBQUp6NkJKS2lUT1JBQUwAAAAkMDE5N2ExMGQtZGNjMC00MjUwLWJmOTUtNWE1M2IxNjUzNmQyAAAo1g&fromUser=true&messageDisplay=inline&refresh_mode=sliding&storage=hot&stream_sort=desc&viz=stream&from_ts=1750752880516&to_ts=1750753780516&live=true

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

Deploy front. 