### PR TITLE
[front] - feat(ab): `/create` route

### DIFF
--- a/front/components/agent_builder/AgentTemplateGrid.tsx
+++ b/front/components/agent_builder/AgentTemplateGrid.tsx
@@ -1,0 +1,62 @@
+import { ContextItem, LargeAssistantCard } from "@dust-tt/sparkle";
+
+import type { AssistantTemplateListType } from "@app/pages/api/templates";
+import type { TemplateTagCodeType, TemplateTagsType } from "@app/types";
+import { getUniqueTemplateTags } from "./utils";
+
+interface AgentTemplateGridProps {
+  templates: AssistantTemplateListType[];
+  openTemplateModal: (templateId: string) => void;
+  templateTagsMapping: TemplateTagsType;
+  selectedTags: TemplateTagCodeType[];
+}
+
+export function AgentTemplateGrid({
+  templates,
+  openTemplateModal,
+  templateTagsMapping,
+  selectedTags,
+}: AgentTemplateGridProps) {
+  if (!templates.length) {
+    return null;
+  }
+
+  const tags =
+    selectedTags.length > 0 ? selectedTags : getUniqueTemplateTags(templates);
+
+  return (
+    <div className="flex flex-col gap-6">
+      {tags
+        .map((tagName) => {
+          const templatesForTag = templates.filter((template) =>
+            template.tags.includes(tagName)
+          );
+
+          if (!templatesForTag.length) {
+            return null;
+          }
+
+          return (
+            <div key={tagName}>
+              <ContextItem.SectionHeader
+                title={templateTagsMapping[tagName].label}
+                hasBorder={false}
+              />
+              <div className="grid grid-cols-2 gap-2">
+                {templatesForTag.map((template) => (
+                  <LargeAssistantCard
+                    key={template.sId}
+                    title={template.handle}
+                    pictureUrl={template.pictureUrl}
+                    description={template.description ?? ""}
+                    onClick={() => openTemplateModal(template.sId)}
+                  />
+                ))}
+              </div>
+            </div>
+          );
+        })
+        .filter(Boolean)}
+    </div>
+  );
+}

--- a/front/components/agent_builder/AgentTemplateGrid.tsx
+++ b/front/components/agent_builder/AgentTemplateGrid.tsx
@@ -1,8 +1,8 @@
 import { ContextItem, LargeAssistantCard } from "@dust-tt/sparkle";
 
+import { getUniqueTemplateTags } from "@app/components/agent_builder/utils";
 import type { AssistantTemplateListType } from "@app/pages/api/templates";
 import type { TemplateTagCodeType, TemplateTagsType } from "@app/types";
-import { getUniqueTemplateTags } from "./utils";
 
 interface AgentTemplateGridProps {
   templates: AssistantTemplateListType[];

--- a/front/components/agent_builder/AgentTemplateModal.tsx
+++ b/front/components/agent_builder/AgentTemplateModal.tsx
@@ -1,0 +1,92 @@
+import {
+  Avatar,
+  Button,
+  Markdown,
+  Page,
+  Sheet,
+  SheetContainer,
+  SheetContent,
+  SheetHeader,
+  SheetTitle,
+  Spinner,
+} from "@dust-tt/sparkle";
+import Link from "next/link";
+
+import { ReadOnlyTextArea } from "@app/components/assistant/ReadOnlyTextArea";
+import type { BuilderFlow } from "@app/components/assistant_builder/types";
+import { useAssistantTemplate } from "@app/lib/swr/assistants";
+import type { WorkspaceType } from "@app/types";
+
+interface AgentTemplateModalProps {
+  flow: BuilderFlow;
+  onClose: () => void;
+  owner: WorkspaceType;
+  templateId: string | null;
+}
+
+export function AgentTemplateModal({
+  flow,
+  onClose,
+  owner,
+  templateId,
+}: AgentTemplateModalProps) {
+  const { assistantTemplate, isAssistantTemplateLoading } =
+    useAssistantTemplate({ templateId });
+
+  return (
+    <Sheet
+      open={!!templateId}
+      onOpenChange={(open) => {
+        if (!open) {
+          onClose();
+        }
+      }}
+    >
+      <SheetContent size="lg">
+        <SheetHeader>
+          <SheetTitle>Template {assistantTemplate?.handle ?? ""}</SheetTitle>
+        </SheetHeader>
+        {isAssistantTemplateLoading ? (
+          <div className="flex h-full items-center justify-center">
+            <Spinner variant="color" />
+          </div>
+        ) : assistantTemplate ? (
+          <SheetContainer>
+            <div className="flex flex-col gap-5">
+              <div className="flex max-h-32 max-w-lg flex-row gap-3">
+                <Avatar size="lg" visual={assistantTemplate.pictureUrl} />
+                <div className="flex flex-col gap-1">
+                  <span className="heading-lg text-foreground dark:text-foreground-night">
+                    @{assistantTemplate.handle}
+                  </span>
+                  <Link
+                    href={`/w/${owner.sId}/builder/assistants/new?flow=${flow}&templateId=${assistantTemplate.sId}`}
+                  >
+                    <Button
+                      label="Use this template"
+                      variant="primary"
+                      data-gtm-label="useTemplateButton"
+                      data-gtm-location="templateModal"
+                      size="sm"
+                    />
+                  </Link>
+                </div>
+              </div>
+              <div>
+                <Markdown content={assistantTemplate.description ?? ""} />
+              </div>
+              <Page.SectionHeader title="Instructions" />
+              <ReadOnlyTextArea
+                content={assistantTemplate.presetInstructions}
+              />
+            </div>
+          </SheetContainer>
+        ) : (
+          <div className="flex h-full items-center justify-center">
+            <span className="text-muted-foreground">Template not found</span>
+          </div>
+        )}
+      </SheetContent>
+    </Sheet>
+  );
+}

--- a/front/components/agent_builder/types.ts
+++ b/front/components/agent_builder/types.ts
@@ -33,3 +33,9 @@ export type GenerationSettingsType = {
   temperature: number;
   responseFormat?: string;
 };
+
+export const BUILDER_FLOWS = [
+  "workspace_assistants",
+  "personal_assistants",
+] as const;
+export type BuilderFlow = (typeof BUILDER_FLOWS)[number];

--- a/front/components/agent_builder/utils.ts
+++ b/front/components/agent_builder/utils.ts
@@ -1,3 +1,6 @@
+import type { AssistantTemplateListType } from "@app/pages/api/templates";
+import type { TemplateTagCodeType } from "@app/types";
+
 export const isInvalidJson = (value: string | null | undefined): boolean => {
   if (!value) {
     return false;
@@ -9,3 +12,11 @@ export const isInvalidJson = (value: string | null | undefined): boolean => {
     return true;
   }
 };
+
+export function getUniqueTemplateTags(
+  templates: AssistantTemplateListType[]
+): TemplateTagCodeType[] {
+  return Array.from(
+    new Set(templates.flatMap((template) => template.tags))
+  ).sort((a, b) => a.toLowerCase().localeCompare(b.toLowerCase()));
+}

--- a/front/pages/w/[wId]/builder/agents/create.tsx
+++ b/front/pages/w/[wId]/builder/agents/create.tsx
@@ -1,0 +1,250 @@
+import {
+  Button,
+  DocumentIcon,
+  Icon,
+  MagicIcon,
+  Page,
+  PencilSquareIcon,
+  SearchInput,
+} from "@dust-tt/sparkle";
+import type { InferGetServerSidePropsType } from "next";
+import { useRouter } from "next/router";
+import { useCallback, useMemo, useState } from "react";
+
+import { AgentTemplateGrid } from "@app/components/agent_builder/AgentTemplateGrid";
+import { AgentTemplateModal } from "@app/components/agent_builder/AgentTemplateModal";
+import type { BuilderFlow } from "@app/components/agent_builder/types";
+import { BUILDER_FLOWS } from "@app/components/agent_builder/types";
+import { getUniqueTemplateTags } from "@app/components/agent_builder/utils";
+import AppContentLayout, {
+  appLayoutBack,
+} from "@app/components/sparkle/AppContentLayout";
+import { AppLayoutSimpleCloseTitle } from "@app/components/sparkle/AppLayoutTitle";
+import AppRootLayout from "@app/components/sparkle/AppRootLayout";
+import { getFeatureFlags } from "@app/lib/auth";
+import { isRestrictedFromAgentCreation } from "@app/lib/auth";
+import { withDefaultUserAuthRequirements } from "@app/lib/iam/session";
+import { useAssistantTemplates } from "@app/lib/swr/assistants";
+import type {
+  SubscriptionType,
+  TemplateTagCodeType,
+  TemplateTagsType,
+  WorkspaceType,
+} from "@app/types";
+import { isTemplateTagCodeArray, TEMPLATES_TAGS_CONFIG } from "@app/types";
+
+export const getServerSideProps = withDefaultUserAuthRequirements<{
+  flow: BuilderFlow;
+  owner: WorkspaceType;
+  subscription: SubscriptionType;
+  templateTagsMapping: TemplateTagsType;
+}>(async (context, auth) => {
+  const owner = auth.workspace();
+  const plan = auth.plan();
+  const subscription = auth.subscription();
+  if (!owner || !plan || !auth.isUser() || !subscription) {
+    return {
+      notFound: true,
+    };
+  }
+
+  const featureFlags = await getFeatureFlags(owner);
+  if (
+    !featureFlags.includes("agent_builder_v2") ||
+    (await isRestrictedFromAgentCreation(owner))
+  ) {
+    return {
+      notFound: true,
+    };
+  }
+
+  const flow: BuilderFlow = BUILDER_FLOWS.includes(
+    context.query.flow as BuilderFlow
+  )
+    ? (context.query.flow as BuilderFlow)
+    : "personal_assistants";
+
+  return {
+    props: {
+      owner,
+      subscription,
+      flow,
+      templateTagsMapping: TEMPLATES_TAGS_CONFIG,
+    },
+  };
+});
+
+export default function CreateAgent({
+  flow,
+  owner,
+  subscription,
+  templateTagsMapping,
+}: InferGetServerSidePropsType<typeof getServerSideProps>) {
+  const router = useRouter();
+
+  const [searchTerm, setSearchTerm] = useState("");
+  const [selectedTags, setSelectedTags] = useState<TemplateTagCodeType[]>([]);
+  const [selectedTemplateId, setSelectedTemplateId] = useState<string | null>(
+    (router.query.templateId as string) ?? null
+  );
+
+  const { assistantTemplates } = useAssistantTemplates();
+
+  const { filteredTemplates, availableTags } = useMemo(() => {
+    const validTemplates = assistantTemplates.filter((template) =>
+      isTemplateTagCodeArray(template.tags)
+    );
+
+    const filtered = validTemplates.filter((template) => {
+      if (
+        selectedTags.length > 0 &&
+        !selectedTags.some((tag) => template.tags.includes(tag))
+      ) {
+        return false;
+      }
+
+      if (searchTerm) {
+        const searchLower = searchTerm.toLowerCase();
+        return (
+          template.handle.toLowerCase().includes(searchLower) ||
+          template.description?.toLowerCase().includes(searchLower)
+        );
+      }
+
+      return true;
+    });
+
+    const tags = getUniqueTemplateTags(validTemplates);
+
+    return { filteredTemplates: filtered, availableTags: tags };
+  }, [assistantTemplates, selectedTags, searchTerm]);
+
+  const openTemplateModal = useCallback(
+    async (templateId: string) => {
+      setSelectedTemplateId(templateId);
+      await router.replace(
+        { pathname: router.pathname, query: { wId: owner.sId, templateId } },
+        undefined,
+        { shallow: true }
+      );
+    },
+    [owner.sId, router]
+  );
+
+  const closeTemplateModal = useCallback(async () => {
+    setSelectedTemplateId(null);
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    const { templateId, ...queryWithoutTemplate } = router.query;
+    await router.replace(
+      { pathname: router.pathname, query: queryWithoutTemplate },
+      undefined,
+      { shallow: true }
+    );
+  }, [router]);
+
+  const handleTagClick = (tagName: TemplateTagCodeType) => {
+    setSelectedTags((prevTags) =>
+      prevTags.includes(tagName)
+        ? prevTags.filter((tag) => tag !== tagName)
+        : [...prevTags, tagName]
+    );
+  };
+
+  return (
+    <AppContentLayout
+      subscription={subscription}
+      hideSidebar
+      owner={owner}
+      titleChildren={
+        <AppLayoutSimpleCloseTitle
+          title="Create an Agent"
+          onClose={async () => {
+            await appLayoutBack(owner, router);
+          }}
+        />
+      }
+    >
+      <div id="pageContent">
+        <Page variant="modal">
+          <div className="flex flex-col gap-6">
+            <div className="flex min-h-[20vh] flex-col justify-end gap-6">
+              <div className="flex flex-row items-center gap-2">
+                <Icon
+                  visual={PencilSquareIcon}
+                  size="lg"
+                  className="text-primary-400 dark:text-primary-500"
+                />
+                <Page.Header title="Start new" />
+              </div>
+              <Button
+                icon={DocumentIcon}
+                label="New Agent"
+                data-gtm-label="assistantCreationButton"
+                data-gtm-location="assistantCreationPage"
+                size="md"
+                variant="highlight"
+                href={`/w/${owner.sId}/builder/agents/new`}
+              />
+            </div>
+
+            <Page.Separator />
+
+            <div className="flex flex-row items-center gap-2">
+              <Icon
+                visual={MagicIcon}
+                size="lg"
+                className="text-primary-400 dark:text-primary-500"
+              />
+              <Page.Header title="Start from a template" />
+            </div>
+
+            <div className="flex flex-col gap-6">
+              <SearchInput
+                placeholder="Search templates"
+                name="input"
+                value={searchTerm}
+                onChange={setSearchTerm}
+              />
+              <div className="flex flex-row flex-wrap gap-2">
+                {availableTags.map((tagName) => (
+                  <Button
+                    label={templateTagsMapping[tagName].label}
+                    variant={
+                      selectedTags.includes(tagName) ? "primary" : "outline"
+                    }
+                    key={tagName}
+                    size="xs"
+                    onClick={() => handleTagClick(tagName)}
+                  />
+                ))}
+              </div>
+            </div>
+            {filteredTemplates.length > 0 && (
+              <>
+                <Page.Separator />
+                <div className="flex flex-col pb-56">
+                  <AgentTemplateGrid
+                    templates={filteredTemplates}
+                    openTemplateModal={openTemplateModal}
+                    templateTagsMapping={templateTagsMapping}
+                    selectedTags={selectedTags}
+                  />
+                </div>
+              </>
+            )}
+          </div>
+        </Page>
+        <AgentTemplateModal
+          flow={flow}
+          owner={owner}
+          templateId={selectedTemplateId}
+          onClose={closeTemplateModal}
+        />
+      </div>
+    </AppContentLayout>
+  );
+}
+
+CreateAgent.getLayout = (page: React.ReactElement) => {
+  return <AppRootLayout>{page}</AppRootLayout>;
+};

--- a/front/pages/w/[wId]/builder/agents/create.tsx
+++ b/front/pages/w/[wId]/builder/agents/create.tsx
@@ -9,7 +9,7 @@ import {
 } from "@dust-tt/sparkle";
 import type { InferGetServerSidePropsType } from "next";
 import { useRouter } from "next/router";
-import { useCallback, useMemo, useState } from "react";
+import { useMemo, useState } from "react";
 
 import { AgentTemplateGrid } from "@app/components/agent_builder/AgentTemplateGrid";
 import { AgentTemplateModal } from "@app/components/agent_builder/AgentTemplateModal";
@@ -119,19 +119,16 @@ export default function CreateAgent({
     return { filteredTemplates: filtered, availableTags: tags };
   }, [assistantTemplates, selectedTags, searchTerm]);
 
-  const openTemplateModal = useCallback(
-    async (templateId: string) => {
-      setSelectedTemplateId(templateId);
-      await router.replace(
-        { pathname: router.pathname, query: { wId: owner.sId, templateId } },
-        undefined,
-        { shallow: true }
-      );
-    },
-    [owner.sId, router]
-  );
+  const openTemplateModal = async (templateId: string) => {
+    setSelectedTemplateId(templateId);
+    await router.replace(
+      { pathname: router.pathname, query: { wId: owner.sId, templateId } },
+      undefined,
+      { shallow: true }
+    );
+  };
 
-  const closeTemplateModal = useCallback(async () => {
+  const closeTemplateModal = async () => {
     setSelectedTemplateId(null);
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
     const { templateId, ...queryWithoutTemplate } = router.query;
@@ -140,7 +137,7 @@ export default function CreateAgent({
       undefined,
       { shallow: true }
     );
-  }, [router]);
+  };
 
   const handleTagClick = (tagName: TemplateTagCodeType) => {
     setSelectedTags((prevTags) =>


### PR DESCRIPTION
## Description

This PR adds a new /create route in the Agent Builder frontend to display available assistant templates in a grid layout. The templates are organized by tags and include a modal component for detailed template information and selection. The implementation provides filtering functionality by tags and search terms, and includes a fallback message when no templates are found.

Note: most of it is duplication from the current `assistants/create` route, but streamlined and refactored.

**References:**
- https://github.com/dust-tt/tasks/issues/2987

## Risk

Low, behind FF

## Deploy Plan

N/A