### PR TITLE
[front] poke: allow force send invitation

### DIFF
--- a/front/lib/api/invitation.ts
+++ b/front/lib/api/invitation.ts
@@ -348,7 +348,7 @@ export async function handleMembershipInvitations(
     subscription: SubscriptionType;
     user: UserType;
     invitationRequests: MembershipInvitationBlob[];
-    force: boolean;
+    force?: boolean;
   }
 ): Promise<Result<HandleMembershipInvitationResult[], APIErrorWithStatusCode>> {
   const { maxUsers } = subscription.plan.limits.users;

--- a/front/lib/api/poke/plugins/workspaces/invite_user.ts
+++ b/front/lib/api/poke/plugins/workspaces/invite_user.ts
@@ -25,6 +25,13 @@ export const inviteUser = createPlugin({
           value: role,
         })),
       },
+      force: {
+        type: "boolean",
+        label: "Force",
+        description:
+          "If true, sends an email even if the user was already invited.",
+        defaultValue: false,
+      },
     },
   },
   execute: async (auth, _, args) => {
@@ -51,6 +58,7 @@ export const inviteUser = createPlugin({
       owner: auth.getNonNullableWorkspace(),
       user: auth.getNonNullableUser().toJSON(),
       subscription,
+      force: args.force,
       invitationRequests: [
         {
           ...args,


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
See https://dust4ai.slack.com/archives/C05B529FHV1/p1750745681192729
Solves https://github.com/dust-tt/tasks/issues/3253

When a user is invited, if he already was invited and his invitation was revoked less than 24 hours ago, the plugin/invite system sends an error (but silently successes un-revoking the invite).

With this, the system does not crashes anymore, and assess the success.
Added a force flag to the poke plugin, to allow re-sending the email even if the invitation was recently un-revoked.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->
Without the fix => hit the error
With the fix => hit a sendgrid error (bc my local setup) => means that we effectively try to send the email

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->
Break invites but it should be fine

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
Deploy front