### PR TITLE
[front] fix(conversation): Fix scroll when clicking new

### DIFF
--- a/front/components/assistant/conversation/ConversationLayout.tsx
+++ b/front/components/assistant/conversation/ConversationLayout.tsx
@@ -11,6 +11,7 @@ import { ActionValidationProvider } from "@app/components/assistant/conversation
 import { CoEditionContainer } from "@app/components/assistant/conversation/co_edition/CoEditionContainer";
 import { CoEditionProvider } from "@app/components/assistant/conversation/co_edition/CoEditionProvider";
 import { useCoEditionContext } from "@app/components/assistant/conversation/co_edition/context";
+import { CONVERSATION_VIEW_SCROLL_LAYOUT } from "@app/components/assistant/conversation/constant";
 import { ConversationErrorDisplay } from "@app/components/assistant/conversation/ConversationError";
 import {
   ConversationsNavigationProvider,
@@ -214,7 +215,10 @@ function ConversationInnerLayout({
         <ResizablePanel defaultSize={100}>
           <FileDropProvider>
             <GenerationContextProvider>
-              <div className="h-full overflow-y-auto px-4 sm:px-8">
+              <div
+                id={CONVERSATION_VIEW_SCROLL_LAYOUT}
+                className="h-full overflow-y-auto scroll-smooth px-4 sm:px-8"
+              >
                 {children}
               </div>
             </GenerationContextProvider>

--- a/front/components/assistant/conversation/SidebarMenu.tsx
+++ b/front/components/assistant/conversation/SidebarMenu.tsx
@@ -25,6 +25,7 @@ import type { NextRouter } from "next/router";
 import { useRouter } from "next/router";
 import React, { useCallback, useContext, useState } from "react";
 
+import { CONVERSATION_VIEW_SCROLL_LAYOUT } from "@app/components/assistant/conversation/constant";
 import { useConversationsNavigation } from "@app/components/assistant/conversation/ConversationsNavigationProvider";
 import { DeleteConversationsDialog } from "@app/components/assistant/conversation/DeleteConversationsDialog";
 import { InputBarContext } from "@app/components/assistant/conversation/input_bar/InputBarContext";
@@ -186,9 +187,26 @@ export function AssistantSidebarMenu({ owner }: AssistantSidebarMenuProps) {
 
   const { setAnimate } = useContext(InputBarContext);
 
-  const triggerInputAnimation = () => {
+  const triggerInputAnimation = useCallback(() => {
     setAnimate(true);
-  };
+  }, [setAnimate]);
+
+  const handleNewClick = useCallback(async () => {
+    setSidebarOpen(false);
+    const { cId } = router.query;
+    const isNewConversation =
+      router.pathname === "/w/[wId]/assistant/[cId]" &&
+      typeof cId === "string" &&
+      cId === "new";
+
+    if (isNewConversation && triggerInputAnimation) {
+      triggerInputAnimation();
+    } else {
+      await router.push(`/w/${owner.sId}/assistant/new`);
+    }
+
+    document.getElementById(CONVERSATION_VIEW_SCROLL_LAYOUT)?.scrollTo(0, 0);
+  }, [owner.sId, router, setSidebarOpen, triggerInputAnimation]);
 
   return (
     <>
@@ -228,24 +246,11 @@ export function AssistantSidebarMenu({ owner }: AssistantSidebarMenuProps) {
                   onChange={setTitleFilter}
                 />
                 <Button
-                  href={`/w/${owner.sId}/assistant/new`}
-                  shallow
                   label="New"
                   icon={ChatBubbleBottomCenterTextIcon}
                   className="shrink"
                   tooltip="Create a new conversation"
-                  onClick={() => {
-                    setSidebarOpen(false);
-                    const { cId } = router.query;
-                    const isNewConversation =
-                      router.pathname === "/w/[wId]/assistant/[cId]" &&
-                      typeof cId === "string" &&
-                      cId === "new";
-
-                    if (isNewConversation && triggerInputAnimation) {
-                      triggerInputAnimation();
-                    }
-                  }}
+                  onClick={handleNewClick}
                 />
                 <DropdownMenu>
                   <DropdownMenuTrigger asChild>

--- a/front/components/assistant/conversation/constant.ts
+++ b/front/components/assistant/conversation/constant.ts
@@ -1,0 +1,1 @@
+export const CONVERSATION_VIEW_SCROLL_LAYOUT = "conversation-scroll-layout";


### PR DESCRIPTION
## Description
- Fix https://github.com/dust-tt/tasks/issues/2300
- As scroll is managed by a specific div and not the window, set a specific `id` for the div managing the scroll.
- Make that div scroll to the top
- Use router.push instead of href to use the onClick, only use the router.push with await when we're not on the /assistant/new page to make sure we navigate before scrolling up. This avoid starting to scroll in the conversation and then navigating mid scroll.

## Tests
- Locally

## Risk
- Low

## Deploy Plan
- Deploy plan
