### PR TITLE
[front] enh(FS tools): add search labels tool

### DIFF
--- a/front/lib/actions/mcp_internal_actions/servers/data_sources_file_system.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/data_sources_file_system.ts
@@ -768,9 +768,19 @@ const createServer = (
     ? shouldAutoGenerateTags(agentLoopContext)
     : false;
 
-  // If tags are dynamic, then we add a tool for the agent to discover tags and let it pass tags in
-  // the search tool.
-  if (areTagsDynamic) {
+  if (!areTagsDynamic) {
+    server.tool(
+      "search",
+      "Perform a semantic search within the folders and files designated by `nodeIds`. All " +
+        "children of the designated nodes will be searched.",
+      SearchToolInputSchema.shape,
+      withToolLogging(auth, SEARCH_TOOL_NAME, async (params) =>
+        searchCallback(auth, agentLoopContext, params)
+      )
+    );
+  } else {
+    // If tags are dynamic, then we add a tool for the agent to discover tags and let it pass tags
+    // in the search tool.
     server.tool(
       "find_tags",
       makeFindTagsDescription(SEARCH_TOOL_NAME),
@@ -808,16 +818,6 @@ const createServer = (
           tagsIn: params.tagsIn,
           tagsNot: params.tagsNot,
         })
-      )
-    );
-  } else {
-    server.tool(
-      "search",
-      "Perform a semantic search within the folders and files designated by `nodeIds`. All " +
-        "children of the designated nodes will be searched.",
-      SearchToolInputSchema.shape,
-      withToolLogging(auth, SEARCH_TOOL_NAME, async (params) =>
-        searchCallback(auth, agentLoopContext, params)
       )
     );
   }

--- a/front/lib/actions/mcp_internal_actions/servers/data_sources_file_system.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/data_sources_file_system.ts
@@ -520,11 +520,11 @@ const createServer = (
   );
 
   // Check if tags are dynamic before creating the search tool.
-  const areTagsDynamic = agentLoopContext
+  const tagsAreDynamic = agentLoopContext
     ? shouldAutoGenerateTags(agentLoopContext)
     : false;
 
-  const tagsInputSchema = areTagsDynamic
+  const tagsInputSchema = tagsAreDynamic
     ? {
         tagsIn: z
           .array(z.string())
@@ -969,7 +969,7 @@ const createServer = (
   );
 
   // Add the find_tags tool if tags are dynamic.
-  if (areTagsDynamic) {
+  if (tagsAreDynamic) {
     server.tool(
       "find_tags",
       makeFindTagsDescription(SEARCH_TOOL_NAME),

--- a/front/lib/actions/mcp_internal_actions/servers/data_sources_file_system.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/data_sources_file_system.ts
@@ -768,6 +768,8 @@ const createServer = (
     ? shouldAutoGenerateTags(agentLoopContext)
     : false;
 
+  // If tags are dynamic, then we add a tool for the agent to discover tags and let it pass tags in
+  // the search tool.
   if (areTagsDynamic) {
     server.tool(
       "find_tags",

--- a/front/lib/actions/mcp_internal_actions/servers/data_sources_file_system.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/data_sources_file_system.ts
@@ -770,15 +770,12 @@ const createServer = (
 
   if (tagsAreDynamic) {
     server.tool(
-      "search",
-      "Perform a semantic search within the folders and files designated by `nodeIds`. All children " +
-        "of the designated nodes will be searched.",
-      SearchToolInputSchema.shape,
-      withToolLogging(auth, SEARCH_TOOL_NAME, async (params) =>
-        searchCallback(auth, agentLoopContext, params)
-      )
+      "find_tags",
+      makeFindTagsDescription(SEARCH_TOOL_NAME),
+      findTagsSchema,
+      makeFindTagsTool(auth)
     );
-  } else {
+
     server.tool(
       "search",
       "Perform a semantic search within the folders and files designated by `nodeIds`. All children " +
@@ -807,6 +804,16 @@ const createServer = (
           tagsIn: params.tagsIn,
           tagsNot: params.tagsNot,
         })
+      )
+    );
+  } else {
+    server.tool(
+      "search",
+      "Perform a semantic search within the folders and files designated by `nodeIds`. All children " +
+        "of the designated nodes will be searched.",
+      SearchToolInputSchema.shape,
+      withToolLogging(auth, SEARCH_TOOL_NAME, async (params) =>
+        searchCallback(auth, agentLoopContext, params)
       )
     );
   }
@@ -985,16 +992,6 @@ const createServer = (
       }
     )
   );
-
-  // Add the find_tags tool if tags are dynamic.
-  if (tagsAreDynamic) {
-    server.tool(
-      "find_tags",
-      makeFindTagsDescription(SEARCH_TOOL_NAME),
-      findTagsSchema,
-      makeFindTagsTool(auth)
-    );
-  }
 
   return server;
 };

--- a/front/lib/actions/mcp_internal_actions/servers/data_sources_file_system.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/data_sources_file_system.ts
@@ -764,11 +764,11 @@ const createServer = (
   );
 
   // Check if tags are dynamic before creating the search tool.
-  const tagsAreDynamic = agentLoopContext
+  const areTagsDynamic = agentLoopContext
     ? shouldAutoGenerateTags(agentLoopContext)
     : false;
 
-  if (tagsAreDynamic) {
+  if (areTagsDynamic) {
     server.tool(
       "find_tags",
       makeFindTagsDescription(SEARCH_TOOL_NAME),

--- a/front/lib/actions/mcp_internal_actions/servers/data_sources_file_system.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/data_sources_file_system.ts
@@ -780,25 +780,27 @@ const createServer = (
 
     server.tool(
       "search",
-      "Perform a semantic search within the folders and files designated by `nodeIds`. All children " +
-        "of the designated nodes will be searched.",
+      "Perform a semantic search within the folders and files designated by `nodeIds`. All " +
+        "children of the designated nodes will be searched.",
       {
         ...SearchToolInputSchema.shape,
         tagsIn: z
           .array(z.string())
           .optional()
           .describe(
-            "A list of labels (also called tags) to restrict the search based on the user request and past conversation context." +
-              "If multiple labels are provided, the search will return documents that have at least one of the labels." +
-              "You can't check that all labels are present, only that at least one is present." +
-              "If no labels are provided, the search will return all documents regardless of their labels."
+            "A list of labels (also called tags) to restrict the search based on the user " +
+              "request and past conversation context. If multiple labels are provided, the " +
+              "search will return documents that have at least one of the labels. You can't " +
+              "check that all labels are present, only that at least one is present. If no labels " +
+              "are provided, the search will  return all documents regardless of their labels."
           ),
         tagsNot: z
           .array(z.string())
           .optional()
           .describe(
-            "A list of labels (also called tags) to exclude from the search based on the user request and past conversation context." +
-              "Any document having one of these labels will be excluded from the search."
+            "A list of labels (also called tags) to exclude from the search based on the user " +
+              "request and past conversation context. Any document having one of these labels " +
+              "will be excluded from the search."
           ),
       },
       withToolLogging(auth, SEARCH_TOOL_NAME, async (params) =>
@@ -811,8 +813,8 @@ const createServer = (
   } else {
     server.tool(
       "search",
-      "Perform a semantic search within the folders and files designated by `nodeIds`. All children " +
-        "of the designated nodes will be searched.",
+      "Perform a semantic search within the folders and files designated by `nodeIds`. All " +
+        "children of the designated nodes will be searched.",
       SearchToolInputSchema.shape,
       withToolLogging(auth, SEARCH_TOOL_NAME, async (params) =>
         searchCallback(auth, agentLoopContext, params)

--- a/front/lib/actions/mcp_internal_actions/servers/utils.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/utils.ts
@@ -371,26 +371,23 @@ function hasTagAutoMode(dataSourceConfigurations: DataSourceConfiguration[]) {
 export function shouldAutoGenerateTags(
   agentLoopContext: AgentLoopContextType
 ): boolean {
+  const { listToolsContext, runContext } = agentLoopContext;
   if (
-    !!agentLoopContext.listToolsContext?.agentActionConfiguration &&
+    !!listToolsContext?.agentActionConfiguration &&
     isServerSideMCPServerConfiguration(
-      agentLoopContext.listToolsContext.agentActionConfiguration
+      listToolsContext.agentActionConfiguration
     ) &&
-    !!agentLoopContext.listToolsContext.agentActionConfiguration.dataSources
+    !!listToolsContext.agentActionConfiguration.dataSources
   ) {
     return hasTagAutoMode(
-      agentLoopContext.listToolsContext.agentActionConfiguration.dataSources
+      listToolsContext.agentActionConfiguration.dataSources
     );
   } else if (
-    !!agentLoopContext.runContext?.actionConfiguration &&
-    isServerSideMCPToolConfiguration(
-      agentLoopContext.runContext.actionConfiguration
-    ) &&
-    !!agentLoopContext.runContext.actionConfiguration.dataSources
+    !!runContext?.actionConfiguration &&
+    isServerSideMCPToolConfiguration(runContext.actionConfiguration) &&
+    !!runContext.actionConfiguration.dataSources
   ) {
-    return hasTagAutoMode(
-      agentLoopContext.runContext.actionConfiguration.dataSources
-    );
+    return hasTagAutoMode(runContext.actionConfiguration.dataSources);
   }
 
   return false;

--- a/front/lib/actions/mcp_internal_actions/servers/utils.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/utils.ts
@@ -361,17 +361,16 @@ export async function getCoreSearchArgs(
   }
 }
 
+function hasTagAutoMode(dataSourceConfigurations: DataSourceConfiguration[]) {
+  return dataSourceConfigurations.some(
+    (dataSourceConfiguration) =>
+      dataSourceConfiguration.filter.tags?.mode === "auto"
+  );
+}
+
 export function shouldAutoGenerateTags(
   agentLoopContext: AgentLoopContextType
 ): boolean {
-  const hasTagAutoMode = (
-    dataSourceConfigurations: DataSourceConfiguration[]
-  ) =>
-    dataSourceConfigurations.some(
-      (dataSourceConfiguration) =>
-        dataSourceConfiguration.filter.tags?.mode === "auto"
-    );
-
   if (
     !!agentLoopContext.listToolsContext?.agentActionConfiguration &&
     isServerSideMCPServerConfiguration(


### PR DESCRIPTION
## Description

- This PR extends the feature-set of the `data_sources_file_system` by adding a tool to search labels.
- The goal here is to make sure there is no feature in the `search` MCP server that are not part of the FS tools.
- The `cat` tool currently still bypasses the tag filtering, I will address this in a follow up PR.
- The other tools do bypass the tag filtering as well, no particular plan to prevent this currently as it would considerably reduce the discoverability capabilities of the toolset and may not be the expected behavior. Can be challenged but for now, sticking to not being able to see the content of the documents that are filtered out based on their tags seems reasonable.

## Tests

- Tested locally.

## Risk

- N/A.

## Deploy Plan

- Deploy front.
