### PR TITLE
[front] enh(poke): search by WorkOS org ID in command palette

### DIFF
--- a/front/lib/poke/search.ts
+++ b/front/lib/poke/search.ts
@@ -1,5 +1,6 @@
 import config from "@app/lib/api/config";
 import {
+  findWorkspaceByWorkOSOrganizationId,
   getWorkspaceInfos,
   unsafeGetWorkspacesByModelId,
 } from "@app/lib/api/workspace";
@@ -39,6 +40,19 @@ async function searchPokeWorkspaces(
         name: `Workspace (${w.name})`,
         link: `${config.getClientFacingUrl()}/poke/${w.sId}`,
       }));
+    }
+  }
+
+  if (searchTerm.startsWith("org_")) {
+    const workspaceByOrgId = await findWorkspaceByWorkOSOrganizationId(searchTerm);
+    if (workspaceByOrgId) {
+      return [
+        {
+          id: workspaceByOrgId.id,
+          name: `Workspace (${workspaceByOrgId.name})`,
+          link: `${config.getClientFacingUrl()}/poke/${workspaceByOrgId.sId}`,
+        },
+      ];
     }
   }
 

--- a/front/lib/poke/search.ts
+++ b/front/lib/poke/search.ts
@@ -44,7 +44,8 @@ async function searchPokeWorkspaces(
   }
 
   if (searchTerm.startsWith("org_")) {
-    const workspaceByOrgId = await findWorkspaceByWorkOSOrganizationId(searchTerm);
+    const workspaceByOrgId =
+      await findWorkspaceByWorkOSOrganizationId(searchTerm);
     if (workspaceByOrgId) {
       return [
         {


### PR DESCRIPTION
## Description

- This PR adds the possibility to paste a WorkOS organization ID into a command palette and get the corresponding workspace ID if any.

## Tests

- Tested locally.

## Risk

- Very low, only an admin action.

## Deploy Plan

- Deploy front.
