### PR TITLE
Salesforce: remove feature flag for connection, replace with the one for synced_queries

### DIFF
--- a/front/lib/connector_providers.ts
+++ b/front/lib/connector_providers.ts
@@ -406,7 +406,7 @@ export const CONNECTOR_CONFIGURATIONS: Record<
     name: "Salesforce",
     connectorProvider: "salesforce",
     status: "rolling_out",
-    rollingOutFlag: "salesforce_feature",
+    rollingOutFlag: "salesforce_synced_queries",
     hide: true,
     description:
       "Authorize access to your Salesforce organization, in order to query your Salesforce data from Dust.",

--- a/front/types/shared/feature_flags.ts
+++ b/front/types/shared/feature_flags.ts
@@ -30,7 +30,6 @@ export const WHITELISTABLE_FEATURES = [
   "openai_o1_high_reasoning_feature",
   "openai_o1_mini_feature",
   "pro_plan_salesforce_connector",
-  "salesforce_feature",
   "salesforce_synced_queries",
   "salesforce_tool",
   "search_knowledge_builder",

--- a/sdks/js/src/types.ts
+++ b/sdks/js/src/types.ts
@@ -836,7 +836,6 @@ const WhitelistableFeaturesSchema = FlexibleEnumSchema<
   | "openai_o1_high_reasoning_feature"
   | "openai_o1_mini_feature"
   | "pro_plan_salesforce_connector"
-  | "salesforce_feature"
   | "salesforce_synced_queries"
   | "salesforce_tool"
   | "search_knowledge_builder"


### PR DESCRIPTION
## Description

The Salesforce Connection has been removed for most workspaces. 
I am starting the cleanup. 
First step is to set that this Connection is now based on the "salesforce_synced_queries" feature flag activated only for the workspace using synced query. 

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

Deploy front. 
