### PR TITLE
[front] fix(FS tools): Add back MCP server

### DIFF
--- a/front/lib/actions/mcp_internal_actions/constants.ts
+++ b/front/lib/actions/mcp_internal_actions/constants.ts
@@ -274,7 +274,9 @@ export const INTERNAL_MCP_SERVERS: Record<
   data_sources_file_system: {
     id: 1010,
     availability: "auto",
-    isRestricted: () => true,
+    isRestricted: ({ featureFlags }) => {
+      return !featureFlags.includes("dev_mcp_actions");
+    },
   },
 };
 


### PR DESCRIPTION
## Description

- This PR adds back the MCP server temporarily to ease the migration.

## Tests

## Risk


## Deploy Plan

- Deploy front.
