### PR TITLE
[connector] Skip child_page block

### DIFF
--- a/connectors/src/connectors/notion/lib/notion_api.ts
+++ b/connectors/src/connectors/notion/lib/notion_api.ts
@@ -807,6 +807,15 @@ export async function retrieveBlockChildrenResultPage({
       return null;
     }
 
+    // The block exists - Check if it is a child_page block.
+    // If it is, we return null, as it can't have children.
+    const block = await notionClient.blocks.retrieve({
+      block_id: blockOrPageId,
+    });
+    if (isFullBlock(block) && block.type === "child_page") {
+      return null;
+    }
+
     localLogger.error(
       {
         blockOrPageId,


### PR DESCRIPTION
## Description

When a block is a child_page type, calling children list return 500 as it's not allowed and child_page can't have children. Ignore the 500 in that case.


## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

low

## Deploy Plan


deploy connector