### PR TITLE
Fix GitHub stateless activities Temporal serialization

### DIFF
--- a/connectors/src/connectors/github/temporal/activities/sync_code.ts
+++ b/connectors/src/connectors/github/temporal/activities/sync_code.ts
@@ -211,7 +211,7 @@ export async function githubProcessDirectoryChunkActivity({
   repoId,
   repoLogin,
   repoName,
-  updatedDirectoryIds,
+  updatedDirectoryIdsArray,
 }: {
   codeSyncStartedAtMs: number;
   connectorId: number;
@@ -226,7 +226,7 @@ export async function githubProcessDirectoryChunkActivity({
   repoId: number;
   repoLogin: string;
   repoName: string;
-  updatedDirectoryIds?: Set<string>;
+  updatedDirectoryIdsArray?: string[];
 }) {
   const codeSyncStartedAt = new Date(codeSyncStartedAtMs);
 
@@ -242,7 +242,7 @@ export async function githubProcessDirectoryChunkActivity({
         repoId,
         repoLogin,
         repoName,
-        updatedDirectoryIds,
+        updatedDirectoryIds: new Set(updatedDirectoryIdsArray),
       });
     },
     { concurrency: PARALLEL_DIRECTORY_UPLOADS }

--- a/connectors/src/connectors/github/temporal/workflows.ts
+++ b/connectors/src/connectors/github/temporal/workflows.ts
@@ -80,7 +80,7 @@ const MAX_CONCURRENT_ISSUE_SYNC_ACTIVITIES_PER_WORKFLOW = 8;
 
 const FILE_CHUNK_SIZE = 50;
 
-const CONNECTOR_IDS_USING_GCS_CODE_SYNC: number[] = [15];
+const CONNECTOR_IDS_USING_GCS_CODE_SYNC: number[] = [15, 8714];
 
 /**
  * This workflow is used to fetch and sync all the repositories of a GitHub connector.
@@ -615,7 +615,8 @@ export async function githubCodeSyncStatelessWorkflow({
         repoId,
         repoLogin,
         repoName,
-        updatedDirectoryIds: allUpdatedDirectoryIds,
+        // Temporal does not support Sets in workflow arguments, so we convert to an array.
+        updatedDirectoryIdsArray: Array.from(allUpdatedDirectoryIds),
       });
     }
   }


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
Follow up of https://github.com/dust-tt/dust/pull/13559. We oversaw one issue about Temporal serialization that automatically convert `Set` to `Array`. This PR ensures that `Set` are not used anymore at the activity level.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
