### PR TITLE
fix(anthropic.rs): don't reconnect on errors

### DIFF
--- a/core/src/providers/anthropic/anthropic.rs
+++ b/core/src/providers/anthropic/anthropic.rs
@@ -297,17 +297,7 @@ impl AnthropicLLM {
             }
         }
 
-        let client = builder
-            .body(body.to_string())
-            .reconnect(
-                es::ReconnectOptions::reconnect(true)
-                    .retry_initial(false)
-                    .delay(Duration::from_secs(1))
-                    .backoff_factor(2)
-                    .delay_max(Duration::from_secs(8))
-                    .build(),
-            )
-            .build();
+        let client = builder.body(body.to_string()).build();
 
         handle_streaming_response(client, event_sender).await
     }


### PR DESCRIPTION
## Description

It's the most likely reason for these duplicated tokens.

The anthropic client does not do any kind of reconection as far as I can tell: https://github.com/AbdelStark/anthropic-rs/blob/main/anthropic/src/client.rs

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
