### PR TITLE
Salesforce: cleanup up feature flags

### DIFF
--- a/front/lib/connector_providers.ts
+++ b/front/lib/connector_providers.ts
@@ -27,7 +27,6 @@ import { SalesforceOauthExtraConfig } from "@app/components/data_source/salesfor
 import { SlackBotEnableView } from "@app/components/data_source/SlackBotEnableView";
 import { ZendeskConfigView } from "@app/components/data_source/ZendeskConfigView";
 import { ZendeskOAuthExtraConfig } from "@app/components/data_source/ZendeskOAuthExtraConfig";
-import { isProPlan } from "@app/lib/plans/plan_codes";
 import type {
   ConnectorPermission,
   ConnectorProvider,
@@ -499,14 +498,7 @@ export const isConnectorProviderAllowedForPlan = (
     case "webcrawler":
       return plan.limits.connections.isWebCrawlerAllowed;
     case "salesforce":
-      // Either salesforce is allowed for the plan, or the workspace
-      // is pro plan but has the pro_plan_salesforce_connector feature flag enabled
-      return (
-        plan.limits.connections.isSalesforceAllowed ||
-        (isProPlan(plan.code) &&
-          !!featureFlags?.includes("pro_plan_salesforce_connector"))
-      );
-
+      return !!featureFlags?.includes("salesforce_synced_queries");
     case "microsoft":
     case "slack_bot":
     case "snowflake":

--- a/front/lib/data_sources.ts
+++ b/front/lib/data_sources.ts
@@ -77,12 +77,10 @@ export function isManaged(ds: DataSource): ds is DataSource & WithConnector {
 
 export function isRemoteDatabase(ds: DataSource): ds is DataSource &
   WithConnector & {
-    connectorProvider: "snowflake" | "bigquery" | "salesforce";
+    connectorProvider: "snowflake" | "bigquery";
   } {
   return (
-    ds.connectorProvider === "snowflake" ||
-    ds.connectorProvider === "bigquery" ||
-    ds.connectorProvider === "salesforce"
+    ds.connectorProvider === "snowflake" || ds.connectorProvider === "bigquery"
   );
 }
 
@@ -97,11 +95,10 @@ export function supportsDocumentsData(
   ds: DataSource,
   featureFlags: WhitelistableFeature[]
 ): boolean {
-  return (
-    !isRemoteDatabase(ds) ||
-    (ds.connectorProvider === "salesforce" &&
-      featureFlags.includes("salesforce_synced_queries"))
-  );
+  if (ds.connectorProvider === "salesforce") {
+    return featureFlags.includes("salesforce_synced_queries");
+  }
+  return !isRemoteDatabase(ds);
 }
 
 export function supportsStructuredData(ds: DataSource): boolean {

--- a/front/types/shared/feature_flags.ts
+++ b/front/types/shared/feature_flags.ts
@@ -28,7 +28,6 @@ export const WHITELISTABLE_FEATURES = [
   "openai_o1_high_reasoning_custom_assistants_feature",
   "openai_o1_high_reasoning_feature",
   "openai_o1_mini_feature",
-  "pro_plan_salesforce_connector",
   "salesforce_synced_queries",
   "salesforce_tool",
   "search_knowledge_builder",


### PR DESCRIPTION
## Description

Remove the last feature flag that we don't want, which is `pro_plan_salesforce_connector`.
We now have 2 left: 
- `salesforce_tool` for the MCP tool. 
- `salesforce_synced_queries` for the alpha synced query connector. 

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

Deploy front. 