### PR TITLE
feat: stop relying on raw contents for conversation rendering

### DIFF
--- a/front/lib/api/assistant/preprocessing.ts
+++ b/front/lib/api/assistant/preprocessing.ts
@@ -27,7 +27,10 @@ import {
   Ok,
   removeNulls,
 } from "@app/types";
-import type { AgentContentItemType } from "@app/types/assistant/agent_message_content";
+import type {
+  AgentContentItemType,
+  TextContentType,
+} from "@app/types/assistant/agent_message_content";
 
 /**
  * Model conversation rendering
@@ -68,9 +71,6 @@ export async function renderConversationForModel(
   for (const versions of conversation.content) {
     const m = versions[versions.length - 1];
 
-    // Whether the agent message is in the last 5 minutes.
-    const isRecent = m.created > Date.now() - 5 * 60 * 1000;
-
     if (isAgentMessageType(m)) {
       const actions = removeNulls(m.actions);
 
@@ -81,7 +81,6 @@ export async function renderConversationForModel(
       const stepByStepIndex = {} as Record<
         string,
         {
-          legacyTextContents: string[];
           contents: Array<{ step: number; content: AgentContentItemType }>;
           actions: Array<{
             call: FunctionCallType;
@@ -92,7 +91,6 @@ export async function renderConversationForModel(
 
       const emptyStep = () =>
         ({
-          legacyTextContents: [],
           contents: [],
           actions: [],
         }) satisfies (typeof stepByStepIndex)[number];
@@ -111,80 +109,6 @@ export async function renderConversationForModel(
         });
       }
 
-      // Use the contents array if available, otherwise use the rawContents array.
-      const nonEmptyRawContents = m.rawContents.filter(
-        (c) => !!c.content.trim()
-      );
-      const shadowReadRawContents: { step: number; content: string }[] = [];
-      if (
-        m.status === "succeeded" &&
-        isRecent &&
-        (nonEmptyRawContents.length || m.contents.length)
-      ) {
-        if (m.contents.length) {
-          for (const content of m.contents) {
-            if (
-              content.content.type === "text_content" &&
-              !!content.content.value.trim()
-            ) {
-              shadowReadRawContents.push({
-                step: content.step,
-                content: content.content.value,
-              });
-            }
-          }
-
-          // Check if the shadowReadRawContents is the same as the rawContents.
-          if (
-            shadowReadRawContents.length === nonEmptyRawContents.length &&
-            shadowReadRawContents.every(
-              (sc, i) =>
-                sc.content.trim() === nonEmptyRawContents[i].content.trim()
-            )
-          ) {
-            logger.info(
-              {
-                workspaceId: conversation.owner.sId,
-                conversationId: conversation.sId,
-                agentMessageId: m.sId,
-              },
-              "[CONVERSATION RENDERING] Shadow read raw contents is the same as the raw contents"
-            );
-          } else {
-            logger.info(
-              {
-                workspaceId: conversation.owner.sId,
-                conversationId: conversation.sId,
-                agentMessageId: m.sId,
-                shadowReadRawContents,
-                nonEmptyRawContents,
-                messageCreatedAt: new Date(m.created).toISOString(),
-              },
-              "[CONVERSATION RENDERING] Shadow read raw contents is different from the raw contents"
-            );
-          }
-        } else {
-          logger.info(
-            {
-              workspaceId: conversation.owner.sId,
-              conversationId: conversation.sId,
-              agentMessageId: m.sId,
-            },
-            "[CONVERSATION RENDERING] No contents available."
-          );
-        }
-      }
-
-      for (const content of nonEmptyRawContents) {
-        stepByStepIndex[content.step] =
-          stepByStepIndex[content.step] || emptyStep();
-        if (content.content.trim()) {
-          stepByStepIndex[content.step].legacyTextContents.push(
-            content.content
-          );
-        }
-      }
-
       for (const content of m.contents) {
         stepByStepIndex[content.step] =
           stepByStepIndex[content.step] || emptyStep();
@@ -200,16 +124,22 @@ export async function renderConversationForModel(
 
       if (excludeActions) {
         // In Exclude Actions mode, we only render the last step that has text content.
-        const stepsWithContent = steps.filter(
-          (s) => s?.legacyTextContents.length
+        const stepsWithContent = steps.filter((s) =>
+          s?.contents.some((c) => c.content.type === "text_content")
         );
         if (stepsWithContent.length) {
           const lastStepWithContent =
             stepsWithContent[stepsWithContent.length - 1];
+          const textContents: TextContentType[] = [];
+          for (const content of lastStepWithContent.contents) {
+            if (content.content.type === "text_content") {
+              textContents.push(content.content);
+            }
+          }
           messages.push({
             role: "assistant",
             name: m.configuration.name,
-            content: lastStepWithContent.legacyTextContents.join("\n"),
+            content: textContents.map((c) => c.value).join("\n"),
             contents: lastStepWithContent.contents,
           } satisfies AssistantContentMessageTypeModel);
         }
@@ -228,7 +158,13 @@ export async function renderConversationForModel(
             );
             continue;
           }
-          if (!step.actions.length && !step.legacyTextContents.length) {
+          const textContents: TextContentType[] = [];
+          for (const content of step.contents) {
+            if (content.content.type === "text_content") {
+              textContents.push(content.content);
+            }
+          }
+          if (!step.actions.length && !textContents.length) {
             logger.error(
               {
                 workspaceId: conversation.owner.sId,
@@ -244,13 +180,13 @@ export async function renderConversationForModel(
             messages.push({
               role: "assistant",
               function_calls: step.actions.map((s) => s.call),
-              content: step.legacyTextContents.join("\n"),
+              content: textContents.map((c) => c.value).join("\n"),
               contents: step.contents,
             } satisfies AssistantFunctionCallMessageTypeModel);
           } else {
             messages.push({
               role: "assistant",
-              content: step.legacyTextContents.join("\n"),
+              content: textContents.map((c) => c.value).join("\n"),
               name: m.configuration.name,
               contents: step.contents,
             } satisfies AssistantContentMessageTypeModel);


### PR DESCRIPTION
## Description

We're now happy with the new data model, as the text contents are ISO with the legacy raw contents.

This PR stops the shadow reading to start reading directly from the new table. Next step will be to stop fetching from the new table entirely.

## Tests

Tested locally

## Risk

Low

## Deploy Plan

Deploy front