### PR TITLE
[front] - feat(AB): add capabilities block

### DIFF
--- a/front/components/agent_builder/AgentBuilder.tsx
+++ b/front/components/agent_builder/AgentBuilder.tsx
@@ -3,21 +3,24 @@ import React from "react";
 import { AgentBuilderLayout } from "@app/components/agent_builder/AgentBuilderLayout";
 import { AgentBuilderLeftPanel } from "@app/components/agent_builder/AgentBuilderLeftPanel";
 import { AgentBuilderRightPanel } from "@app/components/agent_builder/AgentBuilderRightPanel";
+import { AgentBuilderCapabilitiesProvider } from "@app/components/agent_builder/capabilities/AgentBuilderCapabilitiesContext";
 import { AgentBuilderInstructionsProvider } from "@app/components/agent_builder/instructions/AgentBuilderInstructionsContext";
 
 export default function AgentBuilder() {
   return (
     <AgentBuilderInstructionsProvider>
-      <AgentBuilderLayout
-        leftPanel={
-          <AgentBuilderLeftPanel
-            title="Create new agent"
-            onCancel={() => console.log("Cancel")}
-            onSave={() => console.log("Save")}
-          />
-        }
-        rightPanel={<AgentBuilderRightPanel />}
-      />
+      <AgentBuilderCapabilitiesProvider>
+        <AgentBuilderLayout
+          leftPanel={
+            <AgentBuilderLeftPanel
+              title="Create new agent"
+              onCancel={() => console.log("Cancel")}
+              onSave={() => console.log("Save")}
+            />
+          }
+          rightPanel={<AgentBuilderRightPanel />}
+        />
+      </AgentBuilderCapabilitiesProvider>
     </AgentBuilderInstructionsProvider>
   );
 }

--- a/front/components/agent_builder/AgentBuilderLeftPanel.tsx
+++ b/front/components/agent_builder/AgentBuilderLeftPanel.tsx
@@ -19,21 +19,25 @@ export function AgentBuilderLeftPanel({
 }: AgentBuilderLeftPanelProps) {
   return (
     <div className="flex h-full flex-col">
-      <BarHeader
-        variant="default"
-        title={title}
-        rightActions={
-          <BarHeader.ButtonBar
-            variant="validate"
-            onCancel={onCancel}
-            onSave={onSave}
-            isSaving={isSaving}
-          />
-        }
-      />
-      <div className="flex-1 space-y-6 p-4">
-        <AgentBuilderInstructionsBlock />
-        <AgentBuilderCapabilitiesBlock />
+      <div className="sticky top-0 z-10">
+        <BarHeader
+          variant="default"
+          title={title}
+          rightActions={
+            <BarHeader.ButtonBar
+              variant="validate"
+              onCancel={onCancel}
+              onSave={onSave}
+              isSaving={isSaving}
+            />
+          }
+        />
+      </div>
+      <div className="flex-1 overflow-y-auto">
+        <div className="space-y-6 p-4">
+          <AgentBuilderInstructionsBlock />
+          <AgentBuilderCapabilitiesBlock />
+        </div>
       </div>
     </div>
   );

--- a/front/components/agent_builder/AgentBuilderLeftPanel.tsx
+++ b/front/components/agent_builder/AgentBuilderLeftPanel.tsx
@@ -1,6 +1,7 @@
 import { BarHeader } from "@dust-tt/sparkle";
 import React from "react";
 
+import { AgentBuilderCapabilitiesBlock } from "@app/components/agent_builder/capabilities/AgentBuilderCapabilitiesBlock";
 import { AgentBuilderInstructionsBlock } from "@app/components/agent_builder/instructions/AgentBuilderInstructionsBlock";
 
 interface AgentBuilderLeftPanelProps {
@@ -30,8 +31,9 @@ export function AgentBuilderLeftPanel({
           />
         }
       />
-      <div className="flex-1 p-4">
+      <div className="flex-1 space-y-6 p-4">
         <AgentBuilderInstructionsBlock />
+        <AgentBuilderCapabilitiesBlock />
       </div>
     </div>
   );

--- a/front/components/agent_builder/capabilities/AddKnowledgeDropdown.tsx
+++ b/front/components/agent_builder/capabilities/AddKnowledgeDropdown.tsx
@@ -1,0 +1,60 @@
+import {
+  Avatar,
+  BookOpenIcon,
+  Button,
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "@dust-tt/sparkle";
+
+import { getAvatar } from "@app/lib/actions/mcp_icons";
+import { ACTION_SPECIFICATIONS } from "@app/lib/actions/utils";
+import type { MCPServerViewType } from "@app/lib/api/mcp";
+
+const DATA_SOURCES_ACTION_CATEGORIES = [
+  "RETRIEVAL_SEARCH",
+  "RETRIEVAL_EXHAUSTIVE",
+  "PROCESS",
+  "TABLES_QUERY",
+] as const;
+
+interface AddKnowledgeDropdownProps {
+  mcpServerViewsWithKnowledge?: (MCPServerViewType & { label: string })[];
+}
+
+export function AddKnowledgeDropdown({
+  mcpServerViewsWithKnowledge = [],
+}: AddKnowledgeDropdownProps) {
+  return (
+    <DropdownMenu modal={false}>
+      <DropdownMenuTrigger asChild>
+        <Button label="Add knowledge" size="sm" icon={BookOpenIcon} isSelect />
+      </DropdownMenuTrigger>
+      <DropdownMenuContent>
+        {DATA_SOURCES_ACTION_CATEGORIES.map((key) => {
+          const spec = ACTION_SPECIFICATIONS[key];
+
+          return (
+            <DropdownMenuItem
+              truncateText
+              key={key}
+              icon={<Avatar icon={spec.dropDownIcon} size="sm" />}
+              label={spec.label}
+              description={spec.description}
+            />
+          );
+        })}
+        {mcpServerViewsWithKnowledge.map((view) => (
+          <DropdownMenuItem
+            truncateText
+            key={view.id}
+            icon={getAvatar(view.server)}
+            label={view.label}
+            description={view.server.description}
+          />
+        ))}
+      </DropdownMenuContent>
+    </DropdownMenu>
+  );
+}

--- a/front/components/agent_builder/capabilities/AddToolsDropdown.tsx
+++ b/front/components/agent_builder/capabilities/AddToolsDropdown.tsx
@@ -1,0 +1,80 @@
+import {
+  Avatar,
+  BoltIcon,
+  Button,
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuLabel,
+  DropdownMenuTrigger,
+} from "@dust-tt/sparkle";
+import { uniqueId } from "lodash";
+
+import type {
+  AssistantBuilderActionState,
+  AssistantBuilderDataVisualizationConfigurationWithId,
+} from "@app/components/assistant_builder/types";
+import { getDataVisualizationActionConfiguration } from "@app/components/assistant_builder/types";
+import { useAgentBuilderCapabilitiesContext } from "@app/components/agent_builder/capabilities/AgentBuilderCapabilitiesContext";
+import { DATA_VISUALIZATION_SPECIFICATION } from "@app/lib/actions/utils";
+
+export function AddToolsDropdown() {
+  const { actions, setActions } = useAgentBuilderCapabilitiesContext();
+
+  function onClickDataVisualization() {
+    const dataVisualizationConfig = getDataVisualizationActionConfiguration();
+    if (!dataVisualizationConfig) {
+      return;
+    }
+
+    const newAction: AssistantBuilderDataVisualizationConfigurationWithId = {
+      ...dataVisualizationConfig,
+      id: uniqueId(),
+    };
+
+    setActions([...actions, newAction]);
+  }
+
+  const hasDataVisualization = actions.some(
+    (action) => action.type === "DATA_VISUALIZATION"
+  );
+
+  return (
+    <DropdownMenu modal={false}>
+      <DropdownMenuTrigger asChild>
+        <Button
+          variant="outline"
+          label="Add tools"
+          icon={BoltIcon}
+          size="sm"
+          isSelect
+        />
+      </DropdownMenuTrigger>
+      <DropdownMenuContent
+        className="w-[20rem]"
+        align="start"
+        collisionPadding={10}
+      >
+        {hasDataVisualization ? (
+          <DropdownMenuLabel label="All tools have been added" />
+        ) : (
+          <>
+            <DropdownMenuLabel label="Available tools" />
+            <DropdownMenuItem
+              truncateText
+              icon={
+                <Avatar
+                  icon={DATA_VISUALIZATION_SPECIFICATION.dropDownIcon}
+                  size="sm"
+                />
+              }
+              label={DATA_VISUALIZATION_SPECIFICATION.label}
+              description={DATA_VISUALIZATION_SPECIFICATION.description}
+              onClick={onClickDataVisualization}
+            />
+          </>
+        )}
+      </DropdownMenuContent>
+    </DropdownMenu>
+  );
+}

--- a/front/components/agent_builder/capabilities/AddToolsDropdown.tsx
+++ b/front/components/agent_builder/capabilities/AddToolsDropdown.tsx
@@ -10,10 +10,7 @@ import {
 } from "@dust-tt/sparkle";
 import { uniqueId } from "lodash";
 
-import type {
-  AssistantBuilderActionState,
-  AssistantBuilderDataVisualizationConfigurationWithId,
-} from "@app/components/assistant_builder/types";
+import type { AssistantBuilderDataVisualizationConfigurationWithId } from "@app/components/assistant_builder/types";
 import { getDataVisualizationActionConfiguration } from "@app/components/assistant_builder/types";
 import { useAgentBuilderCapabilitiesContext } from "@app/components/agent_builder/capabilities/AgentBuilderCapabilitiesContext";
 import { DATA_VISUALIZATION_SPECIFICATION } from "@app/lib/actions/utils";
@@ -50,11 +47,7 @@ export function AddToolsDropdown() {
           isSelect
         />
       </DropdownMenuTrigger>
-      <DropdownMenuContent
-        className="w-[20rem]"
-        align="start"
-        collisionPadding={10}
-      >
+      <DropdownMenuContent>
         {hasDataVisualization ? (
           <DropdownMenuLabel label="All tools have been added" />
         ) : (

--- a/front/components/agent_builder/capabilities/AddToolsDropdown.tsx
+++ b/front/components/agent_builder/capabilities/AddToolsDropdown.tsx
@@ -10,9 +10,9 @@ import {
 } from "@dust-tt/sparkle";
 import { uniqueId } from "lodash";
 
+import { useAgentBuilderCapabilitiesContext } from "@app/components/agent_builder/capabilities/AgentBuilderCapabilitiesContext";
 import type { AssistantBuilderDataVisualizationConfigurationWithId } from "@app/components/assistant_builder/types";
 import { getDataVisualizationActionConfiguration } from "@app/components/assistant_builder/types";
-import { useAgentBuilderCapabilitiesContext } from "@app/components/agent_builder/capabilities/AgentBuilderCapabilitiesContext";
 import { DATA_VISUALIZATION_SPECIFICATION } from "@app/lib/actions/utils";
 
 export function AddToolsDropdown() {

--- a/front/components/agent_builder/capabilities/AddToolsDropdown.tsx
+++ b/front/components/agent_builder/capabilities/AddToolsDropdown.tsx
@@ -11,7 +11,6 @@ import {
 import { uniqueId } from "lodash";
 
 import { useAgentBuilderCapabilitiesContext } from "@app/components/agent_builder/capabilities/AgentBuilderCapabilitiesContext";
-import type { AssistantBuilderDataVisualizationConfigurationWithId } from "@app/components/assistant_builder/types";
 import { getDataVisualizationActionConfiguration } from "@app/components/assistant_builder/types";
 import { DATA_VISUALIZATION_SPECIFICATION } from "@app/lib/actions/utils";
 
@@ -24,12 +23,12 @@ export function AddToolsDropdown() {
       return;
     }
 
-    const newAction: AssistantBuilderDataVisualizationConfigurationWithId = {
+    const newAction = {
       ...dataVisualizationConfig,
       id: uniqueId(),
     };
 
-    setActions([...actions, newAction]);
+    setActions((prevActions) => [...prevActions, newAction]);
   }
 
   const hasDataVisualization = actions.some(

--- a/front/components/agent_builder/capabilities/AgentBuilderCapabilitiesBlock.tsx
+++ b/front/components/agent_builder/capabilities/AgentBuilderCapabilitiesBlock.tsx
@@ -1,0 +1,105 @@
+import {
+  Avatar,
+  Card,
+  CardActionButton,
+  CardGrid,
+  EmptyCTA,
+  Page,
+  XMarkIcon,
+} from "@dust-tt/sparkle";
+import React from "react";
+
+import type { AssistantBuilderActionState } from "@app/components/assistant_builder/types";
+import { AddToolsDropdown } from "@app/components/agent_builder/capabilities/AddToolsDropdown";
+import { useAgentBuilderCapabilitiesContext } from "@app/components/agent_builder/capabilities/AgentBuilderCapabilitiesContext";
+import { DATA_VISUALIZATION_SPECIFICATION } from "@app/lib/actions/utils";
+
+function ActionCard({
+  action,
+  onRemove,
+}: {
+  action: AssistantBuilderActionState;
+  onRemove: () => void;
+}) {
+  const spec =
+    action.type === "DATA_VISUALIZATION"
+      ? DATA_VISUALIZATION_SPECIFICATION
+      : null;
+
+  if (!spec) {
+    return null;
+  }
+
+  return (
+    <Card
+      variant="primary"
+      className="max-h-40"
+      action={
+        <CardActionButton
+          size="mini"
+          icon={XMarkIcon}
+          onClick={(e: any) => {
+            onRemove();
+            e.stopPropagation();
+          }}
+        />
+      }
+    >
+      <div className="flex w-full flex-col gap-2 text-sm">
+        <div className="flex w-full items-center gap-2 font-medium text-foreground dark:text-foreground-night">
+          <Avatar icon={spec.cardIcon} size="xs" />
+          <div className="w-full truncate">{action.name}</div>
+        </div>
+        <div className="line-clamp-4 text-muted-foreground dark:text-muted-foreground-night">
+          <p>{action.description}</p>
+        </div>
+      </div>
+    </Card>
+  );
+}
+
+export function AgentBuilderCapabilitiesBlock() {
+  const { actions, setActions } = useAgentBuilderCapabilitiesContext();
+
+  function removeAction(actionToRemove: AssistantBuilderActionState) {
+    setActions(actions.filter((action) => action.id !== actionToRemove.id));
+  }
+
+  return (
+    <div className="flex h-full flex-col gap-4">
+      <Page.H>Tools & Capabilities</Page.H>
+      <div className="flex flex-col items-center justify-between sm:flex-row">
+        <Page.P>
+          <span className="text-sm text-muted-foreground dark:text-muted-foreground-night">
+            Add tools and capabilities to enhance your agent's abilities.
+          </span>
+        </Page.P>
+        {actions.length > 0 && (
+          <div className="flex w-full flex-col gap-2 sm:w-auto">
+            <div className="flex items-center gap-2">
+              <AddToolsDropdown />
+            </div>
+          </div>
+        )}
+      </div>
+      <div className="flex-1">
+        {actions.length === 0 ? (
+          <EmptyCTA
+            message="No tools added yet. Add tools to enhance your agent's capabilities."
+            action={<AddToolsDropdown />}
+          />
+        ) : (
+          <CardGrid>
+            {actions.map((action) => (
+              <ActionCard
+                key={action.id}
+                action={action}
+                onRemove={() => removeAction(action)}
+              />
+            ))}
+          </CardGrid>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/front/components/agent_builder/capabilities/AgentBuilderCapabilitiesBlock.tsx
+++ b/front/components/agent_builder/capabilities/AgentBuilderCapabilitiesBlock.tsx
@@ -9,9 +9,9 @@ import {
 } from "@dust-tt/sparkle";
 import React from "react";
 
-import type { AssistantBuilderActionState } from "@app/components/assistant_builder/types";
 import { AddToolsDropdown } from "@app/components/agent_builder/capabilities/AddToolsDropdown";
 import { useAgentBuilderCapabilitiesContext } from "@app/components/agent_builder/capabilities/AgentBuilderCapabilitiesContext";
+import type { AssistantBuilderActionState } from "@app/components/assistant_builder/types";
 import { DATA_VISUALIZATION_SPECIFICATION } from "@app/lib/actions/utils";
 
 function ActionCard({

--- a/front/components/agent_builder/capabilities/AgentBuilderCapabilitiesBlock.tsx
+++ b/front/components/agent_builder/capabilities/AgentBuilderCapabilitiesBlock.tsx
@@ -39,7 +39,7 @@ function ActionCard({
         <CardActionButton
           size="mini"
           icon={XMarkIcon}
-          onClick={(e: any) => {
+          onClick={(e: Event) => {
             onRemove();
             e.stopPropagation();
           }}
@@ -63,7 +63,9 @@ export function AgentBuilderCapabilitiesBlock() {
   const { actions, setActions } = useAgentBuilderCapabilitiesContext();
 
   function removeAction(actionToRemove: AssistantBuilderActionState) {
-    setActions(actions.filter((action) => action.id !== actionToRemove.id));
+    setActions((prevActions) =>
+      prevActions.filter((action) => action.id !== actionToRemove.id)
+    );
   }
 
   return (

--- a/front/components/agent_builder/capabilities/AgentBuilderCapabilitiesBlock.tsx
+++ b/front/components/agent_builder/capabilities/AgentBuilderCapabilitiesBlock.tsx
@@ -9,6 +9,7 @@ import {
 } from "@dust-tt/sparkle";
 import React from "react";
 
+import { AddKnowledgeDropdown } from "@app/components/agent_builder/capabilities/AddKnowledgeDropdown";
 import { AddToolsDropdown } from "@app/components/agent_builder/capabilities/AddToolsDropdown";
 import { useAgentBuilderCapabilitiesContext } from "@app/components/agent_builder/capabilities/AgentBuilderCapabilitiesContext";
 import type { AssistantBuilderActionState } from "@app/components/assistant_builder/types";
@@ -77,6 +78,7 @@ export function AgentBuilderCapabilitiesBlock() {
         {actions.length > 0 && (
           <div className="flex w-full flex-col gap-2 sm:w-auto">
             <div className="flex items-center gap-2">
+              <AddKnowledgeDropdown />
               <AddToolsDropdown />
             </div>
           </div>
@@ -85,8 +87,13 @@ export function AgentBuilderCapabilitiesBlock() {
       <div className="flex-1">
         {actions.length === 0 ? (
           <EmptyCTA
-            message="No tools added yet. Add tools to enhance your agent's capabilities."
-            action={<AddToolsDropdown />}
+            message="No tools added yet. Add knowledge and tools to enhance your agent's capabilities."
+            action={
+              <div className="flex items-center gap-2">
+                <AddKnowledgeDropdown />
+                <AddToolsDropdown />
+              </div>
+            }
           />
         ) : (
           <CardGrid>

--- a/front/components/agent_builder/capabilities/AgentBuilderCapabilitiesContext.tsx
+++ b/front/components/agent_builder/capabilities/AgentBuilderCapabilitiesContext.tsx
@@ -4,7 +4,9 @@ import type { AssistantBuilderActionState } from "@app/components/assistant_buil
 
 interface AgentBuilderCapabilitiesContextType {
   actions: AssistantBuilderActionState[];
-  setActions: (actions: AssistantBuilderActionState[]) => void;
+  setActions: React.Dispatch<
+    React.SetStateAction<AssistantBuilderActionState[]>
+  >;
 }
 
 const AgentBuilderCapabilitiesContext = createContext<

--- a/front/components/agent_builder/capabilities/AgentBuilderCapabilitiesContext.tsx
+++ b/front/components/agent_builder/capabilities/AgentBuilderCapabilitiesContext.tsx
@@ -1,0 +1,46 @@
+import React, { createContext, useContext, useMemo, useState } from "react";
+
+import type { AssistantBuilderActionState } from "@app/components/assistant_builder/types";
+
+interface AgentBuilderCapabilitiesContextType {
+  actions: AssistantBuilderActionState[];
+  setActions: (actions: AssistantBuilderActionState[]) => void;
+}
+
+const AgentBuilderCapabilitiesContext = createContext<
+  AgentBuilderCapabilitiesContextType | undefined
+>(undefined);
+
+interface AgentBuilderCapabilitiesProviderProps {
+  children: React.ReactNode;
+}
+
+export function AgentBuilderCapabilitiesProvider({
+  children,
+}: AgentBuilderCapabilitiesProviderProps) {
+  const [actions, setActions] = useState<AssistantBuilderActionState[]>([]);
+
+  const contextValue = useMemo(
+    () => ({
+      actions,
+      setActions,
+    }),
+    [actions]
+  );
+
+  return (
+    <AgentBuilderCapabilitiesContext.Provider value={contextValue}>
+      {children}
+    </AgentBuilderCapabilitiesContext.Provider>
+  );
+}
+
+export function useAgentBuilderCapabilitiesContext() {
+  const context = useContext(AgentBuilderCapabilitiesContext);
+  if (context === undefined) {
+    throw new Error(
+      "useAgentBuilderCapabilitiesContext must be used within an AgentBuilderCapabilitiesProvider"
+    );
+  }
+  return context;
+}

--- a/front/components/agent_builder/instructions/AgentBuilderInstructionsContext.tsx
+++ b/front/components/agent_builder/instructions/AgentBuilderInstructionsContext.tsx
@@ -9,10 +9,12 @@ import { GPT_4O_MODEL_ID, isSupportingResponseFormat } from "@app/types";
 
 interface AgentBuilderInstructionsContextType {
   generationSettings: GenerationSettingsType;
-  setGenerationSettings: (settings: GenerationSettingsType) => void;
+  setGenerationSettings: React.Dispatch<
+    React.SetStateAction<GenerationSettingsType>
+  >;
   models: ModelConfigurationType[];
   instructions: string;
-  setInstructions: (instructions: string) => void;
+  setInstructions: React.Dispatch<React.SetStateAction<string>>;
 }
 
 const AgentBuilderInstructionsContext = createContext<
@@ -41,16 +43,19 @@ export function AgentBuilderInstructionsProvider({
   const [instructions, setInstructions] = useState<string>("");
 
   const handleSetGenerationSettings = useCallback(
-    (settings: GenerationSettingsType) => {
-      const processedSettings = {
-        ...settings,
-        responseFormat: isSupportingResponseFormat(
-          settings.modelSettings.modelId
-        )
-          ? settings.responseFormat
-          : undefined,
-      };
-      setGenerationSettings(processedSettings);
+    (settings: React.SetStateAction<GenerationSettingsType>) => {
+      setGenerationSettings((prevSettings) => {
+        const newSettings =
+          typeof settings === "function" ? settings(prevSettings) : settings;
+        return {
+          ...newSettings,
+          responseFormat: isSupportingResponseFormat(
+            newSettings.modelSettings.modelId
+          )
+            ? newSettings.responseFormat
+            : undefined,
+        };
+      });
     },
     []
   );


### PR DESCRIPTION
## Description


Adds a capabilities block to the Agent Builder UI that allows managing tools and capabilities like data visualization. The block includes a dropdown menu for adding tools and displays them in a card grid layout with the ability to remove tools. The implementation uses a context provider to manage the state of actions/capabilities.

![Screenshot 2025-06-25 at 11 24 56](https://github.com/user-attachments/assets/aac9a53f-316e-4117-8c4b-5571dd12fbb3)


Note: for now only the viz tool was added and knowledge tools do not trigger any action. So that we have all the foundational blocks to iterate.

## Risk

Low

## Deploy Plan

- Deploy front