### PR TITLE
[front] fix(builder): extract description less than 800 chars

### DIFF
--- a/front/components/assistant_builder/actions/DataDescription.tsx
+++ b/front/components/assistant_builder/actions/DataDescription.tsx
@@ -43,6 +43,10 @@ export const DataDescription = ({
               getNewActionConfig: (old) => old,
             });
             setShowInvalidActionDescError(null);
+          } else {
+            setShowInvalidActionDescError(
+              "The description must be less than 800 characters."
+            );
           }
         }}
         error={showInvalidActionDescError}


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

fixes https://github.com/dust-tt/tasks/issues/3259
we don't error when the description is more than 800 chars in the extract tool => if a user tries to edit a too long description, we should give him feedback with an error instead of doing nothing 

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

Tested by hand.

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

Low risks

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->

Deploy front
