### PR TITLE
[Durable Agents] Legacy actions: move templates to mcp

### DIFF
--- a/front/components/assistant_builder/AssistantBuilder.tsx
+++ b/front/components/assistant_builder/AssistantBuilder.tsx
@@ -574,6 +574,7 @@ export default function AssistantBuilder({
             <AssistantBuilderRightPanel
               screen={screen}
               template={template}
+              mcpServerViews={mcpServerViews}
               removeTemplate={removeTemplate}
               resetToTemplateInstructions={async () => {
                 resetToTemplateInstructions(setBuilderState);


### PR DESCRIPTION
Description
---
Fixes https://github.com/dust-tt/tasks/issues/3284

Some legacy action configurations were still created by templates

Risks
---
low (blast radius templates)

Deploy
---
front
