### PR TITLE
Copy SlackConfiguration from slack to slack_bot on create

### DIFF
--- a/connectors/src/connectors/slack_bot/index.ts
+++ b/connectors/src/connectors/slack_bot/index.ts
@@ -143,10 +143,7 @@ export class SlackBotConnectorManager extends BaseConnectorManager<SlackConfigur
         await SlackChannel.bulkCreate(creationRecords);
       }
     }
-    // fetch configurationId from the configuration resource because it is not set in the connector creation
-    const configurationResource =
-      await SlackConfigurationResource.fetchByConnectorId(connector.id, ["id"]);
-    if (legacyConfiguration && configurationResource) {
+    if (legacyConfiguration && connector.configurationId) {
       const slackBotWhitelistModelCount = await SlackBotWhitelistModel.count({
         where: {
           connectorId: legacyConfiguration.connectorId,
@@ -168,7 +165,7 @@ export class SlackBotConnectorManager extends BaseConnectorManager<SlackConfigur
               groupIds: whitelistModel.groupIds,
               whitelistType: whitelistModel.whitelistType,
               connectorId: connector.id,
-              slackConfigurationId: configurationResource.id,
+              slackConfigurationId: connector.configurationId as number,
             };
           }
         );

--- a/connectors/src/connectors/slack_bot/index.ts
+++ b/connectors/src/connectors/slack_bot/index.ts
@@ -94,15 +94,17 @@ export class SlackBotConnectorManager extends BaseConnectorManager<SlackConfigur
               autoReadChannelPatterns:
                 legacyConfiguration.autoReadChannelPatterns,
               whitelistedDomains: legacyConfiguration.whitelistedDomains,
+              restrictedSpaceAgentsEnabled:
+                legacyConfiguration.restrictedSpaceAgentsEnabled,
             }
           : {
               autoReadChannelPatterns: configuration.autoReadChannelPatterns,
               whitelistedDomains: configuration.whitelistedDomains,
+              restrictedSpaceAgentsEnabled:
+                configuration.restrictedSpaceAgentsEnabled ?? true,
             }),
         botEnabled: configuration.botEnabled,
         slackTeamId: teamInfo.team.id,
-        restrictedSpaceAgentsEnabled:
-          configuration.restrictedSpaceAgentsEnabled ?? true,
       }
     );
 

--- a/connectors/src/connectors/slack_bot/index.ts
+++ b/connectors/src/connectors/slack_bot/index.ts
@@ -162,6 +162,7 @@ export class SlackBotConnectorManager extends BaseConnectorManager<SlackConfigur
                   connectorId: legacyConfiguration.connectorId,
                 },
               });
+            const slackConfigurationId = connector.configuration.id;
             const whitelistRecords = slackBotWhitelistModels.map(
               (whitelistModel) => {
                 return {
@@ -171,7 +172,7 @@ export class SlackBotConnectorManager extends BaseConnectorManager<SlackConfigur
                   groupIds: whitelistModel.groupIds,
                   whitelistType: whitelistModel.whitelistType,
                   connectorId: connector.id,
-                  slackConfigurationId: connector.configuration!.id,
+                  slackConfigurationId,
                 };
               }
             );

--- a/connectors/src/connectors/slack_bot/index.ts
+++ b/connectors/src/connectors/slack_bot/index.ts
@@ -90,12 +90,11 @@ export class SlackBotConnectorManager extends BaseConnectorManager<SlackConfigur
       }
     );
 
-    const legacyConnector = await ConnectorResource.model.findOne({
-      where: {
-        workspaceId: connector.workspaceId,
-        type: "slack",
-      },
-    });
+    const legacyConnector = await ConnectorResource.findBy(
+      connector.workspaceId,
+      { type: "slack" },
+      ["id"]
+    );
     if (legacyConnector) {
       const slackBotChannelsCount = await SlackChannel.count({
         where: {

--- a/connectors/src/resources/connector/slack.ts
+++ b/connectors/src/resources/connector/slack.ts
@@ -25,6 +25,7 @@ export class SlackConnectorStrategy
       whitelistedDomains: blob.whitelistedDomains
         ? [...blob.whitelistedDomains] // Ensure it's a readonly string[]
         : undefined,
+      restrictedSpaceAgentsEnabled: blob.restrictedSpaceAgentsEnabled,
       connectorId,
       transaction,
     });

--- a/connectors/src/resources/connector/slack.ts
+++ b/connectors/src/resources/connector/slack.ts
@@ -19,7 +19,7 @@ export class SlackConnectorStrategy
     blob: WithCreationAttributes<SlackConfigurationModel>,
     transaction: Transaction
   ): Promise<ConnectorProviderModelResourceMapping["slack"] | null> {
-    const model = await SlackConfigurationResource.makeNew({
+    return SlackConfigurationResource.makeNew({
       slackTeamId: blob.slackTeamId,
       autoReadChannelPatterns: blob.autoReadChannelPatterns,
       whitelistedDomains: blob.whitelistedDomains
@@ -29,10 +29,6 @@ export class SlackConnectorStrategy
       connectorId,
       transaction,
     });
-    return new SlackConfigurationResource(
-      SlackConfigurationResource.model,
-      model.get()
-    );
   }
 
   async delete(

--- a/connectors/src/resources/connector/slack.ts
+++ b/connectors/src/resources/connector/slack.ts
@@ -19,7 +19,7 @@ export class SlackConnectorStrategy
     blob: WithCreationAttributes<SlackConfigurationModel>,
     transaction: Transaction
   ): Promise<ConnectorProviderModelResourceMapping["slack"] | null> {
-    await SlackConfigurationResource.makeNew({
+    const model = await SlackConfigurationResource.makeNew({
       slackTeamId: blob.slackTeamId,
       autoReadChannelPatterns: blob.autoReadChannelPatterns,
       whitelistedDomains: blob.whitelistedDomains
@@ -29,7 +29,10 @@ export class SlackConnectorStrategy
       connectorId,
       transaction,
     });
-    return null;
+    return new SlackConfigurationResource(
+      SlackConfigurationResource.model,
+      model.get()
+    );
   }
 
   async delete(

--- a/connectors/src/resources/connector/slack.ts
+++ b/connectors/src/resources/connector/slack.ts
@@ -21,6 +21,10 @@ export class SlackConnectorStrategy
   ): Promise<ConnectorProviderModelResourceMapping["slack"] | null> {
     await SlackConfigurationResource.makeNew({
       slackTeamId: blob.slackTeamId,
+      autoReadChannelPatterns: blob.autoReadChannelPatterns,
+      whitelistedDomains: blob.whitelistedDomains
+        ? [...blob.whitelistedDomains] // Ensure it's a readonly string[]
+        : undefined,
       connectorId,
       transaction,
     });

--- a/connectors/src/resources/connector_resource.ts
+++ b/connectors/src/resources/connector_resource.ts
@@ -3,6 +3,7 @@ import { Err, Ok } from "@dust-tt/client";
 import type {
   Attributes,
   CreationAttributes,
+  FindAttributeOptions,
   ModelStatic,
   Transaction,
   WhereOptions,
@@ -146,6 +147,26 @@ export class ConnectorResource extends BaseResource<ConnectorModel> {
 
     const c = new this(this.model, blob.get());
     await c.postFetchHook();
+    return c;
+  }
+
+  static async findBy(
+    workspaceId: string,
+    where: WhereOptions<ConnectorModel>,
+    attributes?: FindAttributeOptions
+  ) {
+    const blob = await ConnectorResource.model.findOne({
+      where: {
+        ...where,
+        workspaceId,
+      },
+      attributes: attributes ?? undefined,
+    });
+    if (!blob) {
+      return null;
+    }
+
+    const c = new this(this.model, blob.get());
     return c;
   }
 

--- a/connectors/src/resources/connector_resource.ts
+++ b/connectors/src/resources/connector_resource.ts
@@ -282,6 +282,10 @@ export class ConnectorResource extends BaseResource<ConnectorModel> {
     return this.errorType === "third_party_internal_error";
   }
 
+  get configurationId() {
+    return this.configuration?.id ?? null;
+  }
+
   toJSON(): ConnectorType {
     return {
       id: this.id.toString(),

--- a/connectors/src/resources/connector_resource.ts
+++ b/connectors/src/resources/connector_resource.ts
@@ -37,7 +37,7 @@ export interface ConnectorResource
 export class ConnectorResource extends BaseResource<ConnectorModel> {
   static model: ModelStatic<ConnectorModel> = ConnectorModel;
 
-  public configuration: ConnectorProviderConfigurationResource | null = null;
+  private _configuration: ConnectorProviderConfigurationResource | null = null;
 
   // TODO(2024-02-20 flav): Delete Model from the constructor, once `update` has been migrated.
   constructor(
@@ -50,7 +50,7 @@ export class ConnectorResource extends BaseResource<ConnectorModel> {
   async postFetchHook() {
     const configurations =
       await this.strategy.fetchConfigurationsbyConnectorIds([this.id]);
-    this.configuration = configurations[this.id] ?? null;
+    this._configuration = configurations[this.id] ?? null;
   }
 
   get strategy(): ConnectorProviderStrategy<
@@ -83,7 +83,7 @@ export class ConnectorResource extends BaseResource<ConnectorModel> {
         t
       );
 
-      connectorRes.configuration = configuration;
+      connectorRes._configuration = configuration;
 
       return connectorRes;
     };
@@ -121,7 +121,7 @@ export class ConnectorResource extends BaseResource<ConnectorModel> {
 
     const connectors = blobs.map((b: ConnectorModel) => {
       const c = new this(this.model, b.get());
-      c.configuration = configurations[b.id] ?? null;
+      c._configuration = configurations[b.id] ?? null;
       return c;
     });
 
@@ -206,7 +206,7 @@ export class ConnectorResource extends BaseResource<ConnectorModel> {
 
     return blobs.map((b: ConnectorModel) => {
       const c = new this(this.model, b.get());
-      c.configuration = configurations[b.id] ?? null;
+      c._configuration = configurations[b.id] ?? null;
       return c;
     });
   }
@@ -280,6 +280,10 @@ export class ConnectorResource extends BaseResource<ConnectorModel> {
     return this.errorType === "third_party_internal_error";
   }
 
+  get configuration(): ConnectorProviderConfigurationResource | null {
+    return this._configuration;
+  }
+
   toJSON(): ConnectorType {
     return {
       id: this.id.toString(),
@@ -295,8 +299,8 @@ export class ConnectorResource extends BaseResource<ConnectorModel> {
       firstSuccessfulSyncTime: this.firstSuccessfulSyncTime?.getTime(),
       firstSyncProgress: this.firstSyncProgress,
       errorType: this.errorType ?? undefined,
-      configuration: this.configuration
-        ? this.strategy.configurationJSON(this.configuration)
+      configuration: this._configuration
+        ? this.strategy.configurationJSON(this._configuration)
         : null,
       pausedAt: this.pausedAt?.getTime(),
       updatedAt: this.updatedAt.getTime(),

--- a/connectors/src/resources/slack_configuration_resource.ts
+++ b/connectors/src/resources/slack_configuration_resource.ts
@@ -44,10 +44,14 @@ export class SlackConfigurationResource extends BaseResource<SlackConfigurationM
   static async makeNew({
     slackTeamId,
     connectorId,
+    autoReadChannelPatterns,
+    whitelistedDomains,
     transaction,
   }: {
     slackTeamId: string;
     connectorId: ModelId;
+    autoReadChannelPatterns?: SlackAutoReadPattern[];
+    whitelistedDomains?: string[];
     transaction: Transaction;
   }) {
     const otherSlackConfigurationWithBotEnabled =
@@ -61,11 +65,12 @@ export class SlackConfigurationResource extends BaseResource<SlackConfigurationM
 
     await SlackConfigurationModel.create(
       {
-        autoReadChannelPatterns: [],
+        autoReadChannelPatterns: autoReadChannelPatterns ?? [],
         botEnabled: otherSlackConfigurationWithBotEnabled ? false : true,
         connectorId,
         slackTeamId,
         restrictedSpaceAgentsEnabled: true,
+        whitelistedDomains,
       },
       { transaction }
     );

--- a/connectors/src/resources/slack_configuration_resource.ts
+++ b/connectors/src/resources/slack_configuration_resource.ts
@@ -65,7 +65,7 @@ export class SlackConfigurationResource extends BaseResource<SlackConfigurationM
         transaction,
       });
 
-    await SlackConfigurationModel.create(
+    return SlackConfigurationModel.create(
       {
         autoReadChannelPatterns: autoReadChannelPatterns ?? [],
         botEnabled: otherSlackConfigurationWithBotEnabled ? false : true,
@@ -78,12 +78,11 @@ export class SlackConfigurationResource extends BaseResource<SlackConfigurationM
     );
   }
 
-  static async fetchByConnectorId(connectorId: ModelId, attributes?: string[]) {
+  static async fetchByConnectorId(connectorId: ModelId) {
     const blob = await this.model.findOne({
       where: {
         connectorId: connectorId,
       },
-      attributes,
     });
     if (!blob) {
       return null;

--- a/connectors/src/resources/slack_configuration_resource.ts
+++ b/connectors/src/resources/slack_configuration_resource.ts
@@ -65,7 +65,7 @@ export class SlackConfigurationResource extends BaseResource<SlackConfigurationM
         transaction,
       });
 
-    return SlackConfigurationModel.create(
+    const model = await SlackConfigurationModel.create(
       {
         autoReadChannelPatterns: autoReadChannelPatterns ?? [],
         botEnabled: otherSlackConfigurationWithBotEnabled ? false : true,
@@ -75,6 +75,11 @@ export class SlackConfigurationResource extends BaseResource<SlackConfigurationM
         whitelistedDomains,
       },
       { transaction }
+    );
+
+    return new SlackConfigurationResource(
+      SlackConfigurationResource.model,
+      model.get()
     );
   }
 

--- a/connectors/src/resources/slack_configuration_resource.ts
+++ b/connectors/src/resources/slack_configuration_resource.ts
@@ -12,8 +12,8 @@ import {
 import logger from "@connectors/logger/logger";
 import { BaseResource } from "@connectors/resources/base_resource";
 import type { ReadonlyAttributesType } from "@connectors/resources/storage/types";
-import type { ModelId } from "@connectors/types";
 import type {
+  ModelId,
   SlackAutoReadPattern,
   SlackbotWhitelistType,
   SlackConfigurationType,
@@ -78,11 +78,12 @@ export class SlackConfigurationResource extends BaseResource<SlackConfigurationM
     );
   }
 
-  static async fetchByConnectorId(connectorId: ModelId) {
+  static async fetchByConnectorId(connectorId: ModelId, attributes?: string[]) {
     const blob = await this.model.findOne({
       where: {
         connectorId: connectorId,
       },
+      attributes,
     });
     if (!blob) {
       return null;

--- a/connectors/src/resources/slack_configuration_resource.ts
+++ b/connectors/src/resources/slack_configuration_resource.ts
@@ -46,12 +46,14 @@ export class SlackConfigurationResource extends BaseResource<SlackConfigurationM
     connectorId,
     autoReadChannelPatterns,
     whitelistedDomains,
+    restrictedSpaceAgentsEnabled,
     transaction,
   }: {
     slackTeamId: string;
     connectorId: ModelId;
     autoReadChannelPatterns?: SlackAutoReadPattern[];
     whitelistedDomains?: string[];
+    restrictedSpaceAgentsEnabled?: boolean;
     transaction: Transaction;
   }) {
     const otherSlackConfigurationWithBotEnabled =
@@ -69,7 +71,7 @@ export class SlackConfigurationResource extends BaseResource<SlackConfigurationM
         botEnabled: otherSlackConfigurationWithBotEnabled ? false : true,
         connectorId,
         slackTeamId,
-        restrictedSpaceAgentsEnabled: true,
+        restrictedSpaceAgentsEnabled: restrictedSpaceAgentsEnabled ?? true,
         whitelistedDomains,
       },
       { transaction }


### PR DESCRIPTION
## Description

Follow up of https://github.com/dust-tt/dust/pull/13756

Better read commit by commit

This PR contains two refactoring changes to the Slack connector:

1. **Model encapsulation**: Moved database model access logic from the connector implementation into the resource layer (`connector_resource.ts`), improving separation of concerns and preventing direct model usage outside of resources.

2. **Legacy configuration migration**: Added support for copying `autoReadChannelPatterns` and `whitelistedDomains` configuration from legacy Slack connectors to the new SlackBot connector, ensuring configuration continuity during migration.

Fix https://github.com/dust-tt/tasks/issues/3228

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

**Low Risk** - These are refactoring changes that improve code organization without altering core functionality:

- Model encapsulation change follows established patterns and maintains existing behavior
- Configuration migration adds backward compatibility without breaking existing setups
- Changes are isolated to Slack connector components with no impact on other connectors

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
