### PR TITLE
Improve workOS domain verification handling

### DIFF
--- a/front/lib/api/workos/organization.ts
+++ b/front/lib/api/workos/organization.ts
@@ -161,6 +161,18 @@ export async function removeWorkOSOrganizationDomain(
   return new Ok(undefined);
 }
 
+export async function listWorkOSOrganizationsWithDomain(
+  domain: string
+): Promise<Organization[]> {
+  const workOS = getWorkOS();
+  const organizations = await workOS.organizations.listOrganizations({
+    domains: [domain],
+    limit: 100,
+  });
+
+  return organizations.data;
+}
+
 // Mapping WorkOSPortalIntent to GeneratePortalLinkIntent,
 // as we can't use the WorkOSPortalIntent enum on any Client-Side code.
 const INTENT_MAP: Record<WorkOSPortalIntent, GeneratePortalLinkIntent> = {

--- a/front/lib/api/workspace_domains.ts
+++ b/front/lib/api/workspace_domains.ts
@@ -1,6 +1,10 @@
-import { listWorkOSOrganizationsWithDomain } from "@app/lib/api/workos/organization";
+import {
+  listWorkOSOrganizationsWithDomain,
+  removeWorkOSOrganizationDomain,
+} from "@app/lib/api/workos/organization";
 import { WorkspaceModel } from "@app/lib/resources/storage/models/workspace";
 import { WorkspaceHasDomainModel } from "@app/lib/resources/storage/models/workspace_has_domain";
+import { renderLightWorkspaceType } from "@app/lib/workspace";
 import logger from "@app/logger/logger";
 import type { LightWorkspaceType, Result, WorkspaceDomain } from "@app/types";
 import { Err, Ok } from "@app/types";
@@ -40,7 +44,18 @@ export async function upsertWorkspaceDomain(
         "Dropping existing domain"
       );
 
+      const { workspace } = existingDomainInRegion;
+
+      // Delete the domain from the DB.
       await existingDomainInRegion.destroy();
+
+      // Delete the domain from WorkOS.
+      await removeWorkOSOrganizationDomain(
+        renderLightWorkspaceType({ workspace }),
+        {
+          domain,
+        }
+      );
     } else {
       return new Err(
         new Error(


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
This PR fixes https://github.com/dust-tt/tasks/issues/3286.

We have some stuck workflows in WorkOS were we fail to add the verified domain in our DB because we have a unique constraint that WorkOS does not have. On WorkOS side, domain can be associated with multiple organizations, but can only be administrated by one. There is no way to tell from the API which organization owns it.

This PR changes the logic of the WorkOS webhooks for the following:
- on `domain_verified` (trigger when proper DNS record verification has been completed)
  - if the domain is not associated with any other organization, then we upsert it
  - if the domain is associated with another organization in the **same region**, we delete it from the DB and WorkOS
  - if the domain is associated with another organisation in **another region**, we throw an error that requires engineering action 
- on `organization_updated`
  - if the domain does not exist in our DB and is not associated with another organization, we proceed and save it in our DB
  - otherwise we silently swallow the errors and log

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
