### PR TITLE
[front] - feat(AB): settings block

### DIFF
--- a/front/components/agent_builder/AgentBuilder.tsx
+++ b/front/components/agent_builder/AgentBuilder.tsx
@@ -5,21 +5,24 @@ import { AgentBuilderLeftPanel } from "@app/components/agent_builder/AgentBuilde
 import { AgentBuilderRightPanel } from "@app/components/agent_builder/AgentBuilderRightPanel";
 import { AgentBuilderCapabilitiesProvider } from "@app/components/agent_builder/capabilities/AgentBuilderCapabilitiesContext";
 import { AgentBuilderInstructionsProvider } from "@app/components/agent_builder/instructions/AgentBuilderInstructionsContext";
+import { AgentBuilderSettingsProvider } from "@app/components/agent_builder/settings/AgentSettingsContext";
 
 export default function AgentBuilder() {
   return (
     <AgentBuilderInstructionsProvider>
       <AgentBuilderCapabilitiesProvider>
-        <AgentBuilderLayout
-          leftPanel={
-            <AgentBuilderLeftPanel
-              title="Create new agent"
-              onCancel={() => console.log("Cancel")}
-              onSave={() => console.log("Save")}
-            />
-          }
-          rightPanel={<AgentBuilderRightPanel />}
-        />
+        <AgentBuilderSettingsProvider>
+          <AgentBuilderLayout
+            leftPanel={
+              <AgentBuilderLeftPanel
+                title="Create new agent"
+                onCancel={() => console.log("Cancel")}
+                onSave={() => console.log("Save")}
+              />
+            }
+            rightPanel={<AgentBuilderRightPanel />}
+          />
+        </AgentBuilderSettingsProvider>
       </AgentBuilderCapabilitiesProvider>
     </AgentBuilderInstructionsProvider>
   );

--- a/front/components/agent_builder/AgentBuilderLeftPanel.tsx
+++ b/front/components/agent_builder/AgentBuilderLeftPanel.tsx
@@ -3,6 +3,7 @@ import React from "react";
 
 import { AgentBuilderCapabilitiesBlock } from "@app/components/agent_builder/capabilities/AgentBuilderCapabilitiesBlock";
 import { AgentBuilderInstructionsBlock } from "@app/components/agent_builder/instructions/AgentBuilderInstructionsBlock";
+import { AgentBuilderSettingsBlock } from "@app/components/agent_builder/settings/AgentBuilderSettingsBlock";
 
 interface AgentBuilderLeftPanelProps {
   title: string;
@@ -37,6 +38,7 @@ export function AgentBuilderLeftPanel({
         <div className="space-y-6 p-4">
           <AgentBuilderInstructionsBlock />
           <AgentBuilderCapabilitiesBlock />
+          <AgentBuilderSettingsBlock />
         </div>
       </div>
     </div>

--- a/front/components/agent_builder/settings/AgentBuilderSettingsBlock.tsx
+++ b/front/components/agent_builder/settings/AgentBuilderSettingsBlock.tsx
@@ -1,0 +1,64 @@
+import {
+  Collapsible,
+  CollapsibleContent,
+  CollapsibleTrigger,
+  Input,
+  Page,
+  TextArea,
+} from "@dust-tt/sparkle";
+import React, { useState } from "react";
+
+import { useAgentBuilderSettingsContext } from "@app/components/agent_builder/settings/AgentSettingsContext";
+
+export function AgentBuilderSettingsBlock() {
+  const { name, setName, description, setDescription } =
+    useAgentBuilderSettingsContext();
+  const [isOpen, setIsOpen] = useState(false);
+
+  return (
+    <div className="flex h-full flex-col gap-4">
+      <Collapsible open={isOpen} onOpenChange={setIsOpen}>
+        <CollapsibleTrigger
+          isOpen={isOpen}
+          className="flex cursor-pointer items-center gap-2 border-0 bg-transparent p-0 hover:bg-transparent focus:outline-none"
+        >
+          <Page.H>Settings</Page.H>
+        </CollapsibleTrigger>
+        <CollapsibleContent>
+          <div className="flex flex-col gap-4 pt-4">
+            <Page.P>
+              <span className="text-sm text-muted-foreground dark:text-muted-foreground-night">
+                Configure the basic settings for your agent.
+              </span>
+            </Page.P>
+            <div className="space-y-4">
+              <div className="space-y-2">
+                <label className="text-sm font-medium text-foreground dark:text-foreground-night">
+                  Name
+                </label>
+                <Input
+                  placeholder="Enter agent name"
+                  value={name}
+                  onChange={(e) => setName(e.target.value)}
+                />
+              </div>
+              <div className="space-y-2">
+                <label className="text-sm font-medium text-foreground dark:text-foreground-night">
+                  Description
+                </label>
+                <TextArea
+                  placeholder="Enter agent description"
+                  value={description}
+                  onChange={(e: React.ChangeEvent<HTMLTextAreaElement>) =>
+                    setDescription(e.target.value)
+                  }
+                  rows={3}
+                />
+              </div>
+            </div>
+          </div>
+        </CollapsibleContent>
+      </Collapsible>
+    </div>
+  );
+}

--- a/front/components/agent_builder/settings/AgentSettingsContext.tsx
+++ b/front/components/agent_builder/settings/AgentSettingsContext.tsx
@@ -1,0 +1,49 @@
+import React, { createContext, useContext, useMemo, useState } from "react";
+
+interface AgentBuilderSettingsContextType {
+  name: string;
+  setName: (name: string) => void;
+  description: string;
+  setDescription: (description: string) => void;
+}
+
+const AgentBuilderSettingsContext = createContext<
+  AgentBuilderSettingsContextType | undefined
+>(undefined);
+
+interface AgentBuilderSettingsProviderProps {
+  children: React.ReactNode;
+}
+
+export function AgentBuilderSettingsProvider({
+  children,
+}: AgentBuilderSettingsProviderProps) {
+  const [name, setName] = useState<string>("");
+  const [description, setDescription] = useState<string>("");
+
+  const contextValue = useMemo(
+    () => ({
+      name,
+      setName,
+      description,
+      setDescription,
+    }),
+    [name, description]
+  );
+
+  return (
+    <AgentBuilderSettingsContext.Provider value={contextValue}>
+      {children}
+    </AgentBuilderSettingsContext.Provider>
+  );
+}
+
+export function useAgentBuilderSettingsContext() {
+  const context = useContext(AgentBuilderSettingsContext);
+  if (context === undefined) {
+    throw new Error(
+      "useAgentBuilderSettingsContext must be used within an AgentBuilderSettingsProvider"
+    );
+  }
+  return context;
+}

--- a/front/components/agent_builder/settings/AgentSettingsContext.tsx
+++ b/front/components/agent_builder/settings/AgentSettingsContext.tsx
@@ -2,9 +2,9 @@ import React, { createContext, useContext, useMemo, useState } from "react";
 
 interface AgentBuilderSettingsContextType {
   name: string;
-  setName: (name: string) => void;
+  setName: React.Dispatch<React.SetStateAction<string>>;
   description: string;
-  setDescription: (description: string) => void;
+  setDescription: React.Dispatch<React.SetStateAction<string>>;
 }
 
 const AgentBuilderSettingsContext = createContext<


### PR DESCRIPTION
## Description

Implements a settings block in the Agent Builder UI that allows configuring basic agent properties like name and description. The implementation uses a new context provider to manage settings state across components and integrates with the existing agent builder layout.

![Screenshot 2025-06-25 at 14 56 48](https://github.com/user-attachments/assets/52eb860f-d813-4f0e-ba1d-b3b07dcef19c)

**References:**
- https://github.com/dust-tt/tasks/issues/2984

## Risk

Low, behind FF

## Deploy Plan

Deploy front