### PR TITLE
[Durable Agents] Fix: templates creating valid MCP Actions

### DIFF
--- a/front/components/assistant_builder/AssistantBuilderPreviewDrawer.tsx
+++ b/front/components/assistant_builder/AssistantBuilderPreviewDrawer.tsx
@@ -17,6 +17,7 @@ import {
   XMarkIcon,
 } from "@dust-tt/sparkle";
 import { Separator } from "@radix-ui/react-select";
+import assert from "assert";
 import { uniqueId } from "lodash";
 import { useContext, useEffect, useRef, useState } from "react";
 
@@ -51,7 +52,6 @@ import type {
 } from "@app/types";
 import type { LightAgentConfigurationType } from "@app/types";
 import { assertNever, isAssistantBuilderRightPanelTab } from "@app/types";
-import assert from "assert";
 
 interface AssistantBuilderRightPanelProps {
   screen: BuilderScreen;


### PR DESCRIPTION
Description
---
Fixes a regression introduced by #13777  in which when adding an action from template, the equivalent MCP server was wrongly matched, breaking action addition

Risk
---
low

Deploy
---
front
