### PR TITLE
Agent data retention: lib logic in conversation resource to match convos

### DIFF
--- a/front/tests/utils/ConversationFactory.ts
+++ b/front/tests/utils/ConversationFactory.ts
@@ -4,6 +4,7 @@ import { createConversation } from "@app/lib/api/assistant/conversation";
 import type { Authenticator } from "@app/lib/auth";
 import {
   AgentMessage,
+  ConversationModel,
   Message,
   UserMessage,
 } from "@app/lib/models/assistant/conversation";
@@ -16,11 +17,13 @@ export class ConversationFactory {
     auth,
     agentConfigurationId,
     messagesCreatedAt,
+    conversationCreatedAt,
     t,
   }: {
     auth: Authenticator;
     agentConfigurationId: string;
     messagesCreatedAt: Date[];
+    conversationCreatedAt?: Date;
     t?: Transaction;
   }): Promise<ConversationType> {
     const user = auth.getNonNullableUser();
@@ -30,6 +33,13 @@ export class ConversationFactory {
       title: "Test Conversation",
       visibility: "unlisted",
     });
+
+    if (conversationCreatedAt) {
+      await ConversationModel.update(
+        { createdAt: conversationCreatedAt },
+        { where: { id: conversation.id } }
+      );
+    }
 
     for (let i = 0; i < messagesCreatedAt.length; i++) {
       const createdAt = messagesCreatedAt[i];


### PR DESCRIPTION
## Description

We're building a new agent data retention workflow. 
3 parts: 
- new model to store it (Yuka is on it)
- update in lib to match the convo. 
- workflow (either new activity in data-retention workflow or 

This is the lib part: 
- Add a new function listConversationWithAgentCreatedBeforeDate
- Add some tests for this function. 

## Tests

Not called yet from the app. 

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

Deploy front. 