### PR TITLE
[front] enh(search): add tags clash detection

### DIFF
--- a/front/lib/actions/mcp_internal_actions/servers/data_sources_file_system.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/data_sources_file_system.ts
@@ -1,5 +1,6 @@
 import { INTERNAL_MIME_TYPES } from "@dust-tt/client";
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
 import assert from "assert";
 import { z } from "zod";
 
@@ -144,7 +145,7 @@ async function searchCallback(
     relativeTimeFrame,
   }: z.infer<typeof SearchToolInputSchema>,
   { tagsIn, tagsNot }: { tagsIn?: string[]; tagsNot?: string[] } = {}
-) {
+): Promise<CallToolResult> {
   const coreAPI = new CoreAPI(config.getCoreAPIConfig(), logger);
   const credentials = dustManagedCredentials();
   const timeFrame = parseTimeFrame(relativeTimeFrame);
@@ -496,7 +497,7 @@ const createServer = (
 
   server.tool(
     "find",
-    "Find content based on their title starting from a specific node. Can be used to to find specific " +
+    "Find content based on their title starting from a specific node. Can be used to find specific " +
       "nodes by searching for their titles. The query title can be omitted to list all nodes " +
       "starting from a specific node. This is like using 'find' in Unix.",
     {

--- a/front/lib/actions/mcp_internal_actions/servers/data_sources_file_system.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/data_sources_file_system.ts
@@ -17,6 +17,7 @@ import {
   makeFindTagsTool,
 } from "@app/lib/actions/mcp_internal_actions/servers/common/find_tags_tool";
 import {
+  checkClashingTags,
   fetchAgentDataSourceConfiguration,
   getCoreSearchArgs,
   parseDataSourceConfigurationURI,
@@ -229,6 +230,17 @@ async function searchCallback(
     return makeMCPToolTextError(
       "Search action must have at least one data source configured."
     );
+  }
+
+  const clashingTagsError = checkClashingTags(coreSearchArgs, {
+    tagsIn,
+    tagsNot,
+  });
+  if (clashingTagsError) {
+    return {
+      isError: false,
+      content: { type: "text", text: clashingTagsError },
+    };
   }
 
   const searchResults = await coreAPI.searchDataSources(

--- a/front/lib/actions/mcp_internal_actions/servers/data_sources_file_system.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/data_sources_file_system.ts
@@ -239,7 +239,7 @@ async function searchCallback(
   if (clashingTagsError) {
     return {
       isError: false,
-      content: { type: "text", text: clashingTagsError },
+      content: [{ type: "text", text: clashingTagsError }],
     };
   }
 

--- a/front/lib/actions/mcp_internal_actions/servers/data_sources_file_system.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/data_sources_file_system.ts
@@ -18,7 +18,7 @@ import {
   makeFindTagsTool,
 } from "@app/lib/actions/mcp_internal_actions/servers/common/find_tags_tool";
 import {
-  checkClashingTags,
+  checkConflictingTags,
   fetchAgentDataSourceConfiguration,
   getCoreSearchArgs,
   parseDataSourceConfigurationURI,
@@ -233,14 +233,14 @@ async function searchCallback(
     );
   }
 
-  const clashingTagsError = checkClashingTags(coreSearchArgs, {
+  const conflictingTags = checkConflictingTags(coreSearchArgs, {
     tagsIn,
     tagsNot,
   });
-  if (clashingTagsError) {
+  if (conflictingTags) {
     return {
       isError: false,
-      content: [{ type: "text", text: clashingTagsError }],
+      content: [{ type: "text", text: conflictingTags }],
     };
   }
 

--- a/front/lib/actions/mcp_internal_actions/servers/include.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/include.ts
@@ -17,6 +17,7 @@ import {
   makeFindTagsTool,
 } from "@app/lib/actions/mcp_internal_actions/servers/common/find_tags_tool";
 import {
+  checkClashingTags,
   getCoreSearchArgs,
   renderRelativeTimeFrameForToolOutput,
   shouldAutoGenerateTags,
@@ -157,6 +158,17 @@ function createServer(
     const coreSearchArgs = removeNulls(
       coreSearchArgsResults.map((res) => (res.isOk() ? res.value : null))
     );
+
+    const clashingTagsError = checkClashingTags(coreSearchArgs, {
+      tagsIn,
+      tagsNot,
+    });
+    if (clashingTagsError) {
+      return {
+        isError: false,
+        content: { type: "text", text: clashingTagsError },
+      };
+    }
 
     const searchResults = await coreAPI.searchDataSources(
       "",

--- a/front/lib/actions/mcp_internal_actions/servers/include.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/include.ts
@@ -166,7 +166,7 @@ function createServer(
     if (clashingTagsError) {
       return {
         isError: false,
-        content: { type: "text", text: clashingTagsError },
+        content: [{ type: "text", text: clashingTagsError }],
       };
     }
 

--- a/front/lib/actions/mcp_internal_actions/servers/include.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/include.ts
@@ -17,7 +17,7 @@ import {
   makeFindTagsTool,
 } from "@app/lib/actions/mcp_internal_actions/servers/common/find_tags_tool";
 import {
-  checkClashingTags,
+  checkConflictingTags,
   getCoreSearchArgs,
   renderRelativeTimeFrameForToolOutput,
   shouldAutoGenerateTags,
@@ -159,14 +159,14 @@ function createServer(
       coreSearchArgsResults.map((res) => (res.isOk() ? res.value : null))
     );
 
-    const clashingTagsError = checkClashingTags(coreSearchArgs, {
+    const conflictingTagsError = checkConflictingTags(coreSearchArgs, {
       tagsIn,
       tagsNot,
     });
-    if (clashingTagsError) {
+    if (conflictingTagsError) {
       return {
         isError: false,
-        content: [{ type: "text", text: clashingTagsError }],
+        content: [{ type: "text", text: conflictingTagsError }],
       };
     }
 

--- a/front/lib/actions/mcp_internal_actions/servers/search/utils.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/search/utils.ts
@@ -8,7 +8,7 @@ import type {
   SearchResultResourceType,
 } from "@app/lib/actions/mcp_internal_actions/output_schemas";
 import {
-  checkClashingTags,
+  checkConflictingTags,
   getCoreSearchArgs,
   renderRelativeTimeFrameForToolOutput,
   renderTagsForToolOutput,
@@ -107,14 +107,14 @@ export async function searchFunction({
     };
   }
 
-  const clashingTagsError = checkClashingTags(coreSearchArgs, {
+  const conflictingTagsError = checkConflictingTags(coreSearchArgs, {
     tagsIn,
     tagsNot,
   });
-  if (clashingTagsError) {
+  if (conflictingTagsError) {
     return {
       isError: false,
-      content: [{ type: "text", text: clashingTagsError }],
+      content: [{ type: "text", text: conflictingTagsError }],
     };
   }
 

--- a/front/lib/actions/mcp_internal_actions/servers/search/utils.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/search/utils.ts
@@ -114,7 +114,7 @@ export async function searchFunction({
   if (clashingTagsError) {
     return {
       isError: false,
-      content: { type: "text", text: clashingTagsError },
+      content: [{ type: "text", text: clashingTagsError }],
     };
   }
 

--- a/front/lib/actions/mcp_internal_actions/servers/search/utils.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/search/utils.ts
@@ -8,6 +8,7 @@ import type {
   SearchResultResourceType,
 } from "@app/lib/actions/mcp_internal_actions/output_schemas";
 import {
+  checkClashingTags,
   getCoreSearchArgs,
   renderRelativeTimeFrameForToolOutput,
   renderTagsForToolOutput,
@@ -103,6 +104,17 @@ export async function searchFunction({
           text: "Search action must have at least one data source configured.",
         },
       ],
+    };
+  }
+
+  const clashingTagsError = checkClashingTags(coreSearchArgs, {
+    tagsIn,
+    tagsNot,
+  });
+  if (clashingTagsError) {
+    return {
+      isError: false,
+      content: { type: "text", text: clashingTagsError },
     };
   }
 

--- a/front/lib/actions/mcp_internal_actions/servers/utils.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/utils.ts
@@ -436,7 +436,7 @@ export function checkConflictingTags(
       finalTagsNot.includes(tag)
     );
     if (conflictingTags.length > 0) {
-      const clashingTagsList = conflictingTags.join(", ");
+      const conflictingTagsList = conflictingTags.join(", ");
       const tagsInList =
         configTagsIn.length > 0 ? configTagsIn.join(", ") : "none";
       const tagsNotList =
@@ -450,7 +450,7 @@ export function checkConflictingTags(
       // probably not what the agent intended and its filtering had no use.
       return (
         "No results were found due to conflicting tags. The following tags appear in both " +
-        `include and exclude lists: ${clashingTagsList}.\n\nTags that are already included: ` +
+        `include and exclude lists: ${conflictingTagsList}.\n\nTags that are already included: ` +
         `${tagsInList}\n Tags that are already excluded ${tagsNotList}\n\nPlease adjust your ` +
         "tag filters to avoid conflicts."
       );

--- a/front/lib/actions/mcp_internal_actions/servers/utils.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/utils.ts
@@ -422,7 +422,7 @@ export function renderTagsForToolOutput(
  * If a tag is both included and excluded, we will not get any result.
  */
 export function checkClashingTags(
-  coreSearchArgs: CoreAPISearchFilter[],
+  coreSearchArgs: CoreSearchArgs[],
   { tagsIn, tagsNot }: { tagsIn?: string[]; tagsNot?: string[] }
 ): string | null {
   for (const args of coreSearchArgs) {

--- a/front/lib/actions/mcp_internal_actions/servers/utils.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/utils.ts
@@ -418,10 +418,10 @@ export function renderTagsForToolOutput(
 }
 
 /**
- * Checks for clashing tags across core search arguments and returns an error message if any.
+ * Checks for conflicting tags across core search arguments and returns an error message if any.
  * If a tag is both included and excluded, we will not get any result.
  */
-export function checkClashingTags(
+export function checkConflictingTags(
   coreSearchArgs: CoreSearchArgs[],
   { tagsIn, tagsNot }: { tagsIn?: string[]; tagsNot?: string[] }
 ): string | null {
@@ -432,11 +432,11 @@ export function checkClashingTags(
     const finalTagsIn = [...configTagsIn, ...(tagsIn ?? [])];
     const finalTagsNot = [...configTagsNot, ...(tagsNot ?? [])];
 
-    const clashingTags = finalTagsIn.filter((tag) =>
+    const conflictingTags = finalTagsIn.filter((tag) =>
       finalTagsNot.includes(tag)
     );
-    if (clashingTags.length > 0) {
-      const clashingTagsList = clashingTags.join(", ");
+    if (conflictingTags.length > 0) {
+      const clashingTagsList = conflictingTags.join(", ");
       const tagsInList =
         configTagsIn.length > 0 ? configTagsIn.join(", ") : "none";
       const tagsNotList =
@@ -449,10 +449,10 @@ export function checkClashingTags(
       // sources. Therefore, even if we did have some content in another data source, it is
       // probably not what the agent intended and its filtering had no use.
       return (
-        "No results found due to conflicting tags. The following tags appear in both include and " +
-        `exclude lists: ${clashingTagsList}.\n\nTags that are already included: ${tagsInList}\n` +
-        `Tags that are already excluded ${tagsNotList}\n\nPlease adjust your tag filters to ` +
-        "avoid conflicts."
+        "No results were found due to conflicting tags. The following tags appear in both " +
+        `include and exclude lists: ${clashingTagsList}.\n\nTags that are already included: ` +
+        `${tagsInList}\n Tags that are already excluded ${tagsNotList}\n\nPlease adjust your ` +
+        "tag filters to avoid conflicts."
       );
     }
   }

--- a/front/lib/actions/mcp_internal_actions/servers/utils.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/utils.ts
@@ -449,7 +449,7 @@ export function checkClashingTags(
       // sources. Therefore, even if we did have some content in another data source, it is
       // probably not what the agent intended and its filtering had no use.
       return (
-        "No results found due to clashing tags. The following tags appear in both include and " +
+        "No results found due to conflicting tags. The following tags appear in both include and " +
         `exclude lists: ${clashingTagsList}.\n\nTags that are already included: ${tagsInList}\n` +
         `Tags that are already excluded ${tagsNotList}\n\nPlease adjust your tag filters to ` +
         "avoid conflicts."

--- a/front/lib/actions/mcp_internal_actions/servers/utils.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/utils.ts
@@ -416,3 +416,46 @@ export function renderTagsForToolOutput(
       : "";
   return `${tagsInAsString}${tagsNotAsString}`;
 }
+
+/**
+ * Checks for clashing tags across core search arguments and returns an error message if any.
+ * If a tag is both included and excluded, we will not get any result.
+ */
+export function checkClashingTags(
+  coreSearchArgs: CoreAPISearchFilter[],
+  { tagsIn, tagsNot }: { tagsIn?: string[]; tagsNot?: string[] }
+): string | null {
+  for (const args of coreSearchArgs) {
+    const configTagsIn = args.filter.tags?.in ?? [];
+    const configTagsNot = args.filter.tags?.not ?? [];
+
+    const finalTagsIn = [...configTagsIn, ...(tagsIn ?? [])];
+    const finalTagsNot = [...configTagsNot, ...(tagsNot ?? [])];
+
+    const clashingTags = finalTagsIn.filter((tag) =>
+      finalTagsNot.includes(tag)
+    );
+    if (clashingTags.length > 0) {
+      const clashingTagsList = clashingTags.join(", ");
+      const tagsInList =
+        configTagsIn.length > 0 ? configTagsIn.join(", ") : "none";
+      const tagsNotList =
+        configTagsNot.length > 0 ? configTagsNot.join(", ") : "none";
+
+      // We actually return even if we get one conflict.
+      // We can have a conflict only if the agent created one by passing some tags without being
+      // aware that it would create a conflict with a configured tag.
+      // The rationale behind it is that there is a low overlap between the tags across data
+      // sources. Therefore, even if we did have some content in another data source, it is
+      // probably not what the agent intended and its filtering had no use.
+      return (
+        "No results found due to clashing tags. The following tags appear in both include and " +
+        `exclude lists: ${clashingTagsList}.\n\nTags that are already included: ${tagsInList}\n` +
+        `Tags that are already excluded ${tagsNotList}\n\nPlease adjust your tag filters to ` +
+        "avoid conflicts."
+      );
+    }
+  }
+
+  return null;
+}


### PR DESCRIPTION
## Description

- This PR handles an edge case when filtering a search using tags with the same tag both included and excluded.
- Having the same tag in both will cause the search to return no result.
- This situation may occur when using the 'auto' mode + passing some tags manually. The agent is not aware of the tags added manually so it may choose to do the opposite filter. The goal of this PR is to detect this situation and show a clear message to the agent so that it can action it and update its filters.

## Tests

- Tested.

## Risk

- Low

## Deploy Plan

- Deploy front.
