### PR TITLE
refactor: add agentConfigurationIds to DataSourceWithAgentsUsageType

### DIFF
--- a/front/components/data_source/DeleteStaticDataSourceDialog.tsx
+++ b/front/components/data_source/DeleteStaticDataSourceDialog.tsx
@@ -53,7 +53,7 @@ export function DeleteStaticDataSourceDialog({
       return "No usage data available.";
     }
     if (usage.count > 0) {
-      return `${usage.count} agents currently use "${name}": ${usage.agentNames.join(", ")}.`;
+      return `${usage.count} agents currently use "${name}": ${usage.agents.map((a) => a.name).join(", ")}.`;
     }
     return `No agents are using "${name}".`;
   }, [isUsageLoading, isUsageError, usage, name]);

--- a/front/components/poke/data_source_views/columns.tsx
+++ b/front/components/poke/data_source_views/columns.tsx
@@ -92,8 +92,12 @@ export function makeColumnsForDataSourceViews(): ColumnDef<DataSourceView>[] {
             <span className="font-medium">{usage.count}</span>
             {usage.count > 0 && (
               <span className="ml-1 text-xs text-gray-500 dark:text-gray-500-night">
-                ({usage.agentNames.slice(0, 2).join(", ")}
-                {usage.agentNames.length > 2 && ", ..."})
+                (
+                {usage.agents
+                  .map((a) => a.name)
+                  .slice(0, 2)
+                  .join(", ")}
+                {usage.agents.length > 2 && ", ..."})
               </span>
             )}
           </div>

--- a/front/components/spaces/SpaceCategoriesList.tsx
+++ b/front/components/spaces/SpaceCategoriesList.tsx
@@ -72,7 +72,7 @@ const getTableColumns = () => {
               title={
                 info.row.original.usage.count === 0
                   ? "Un-used"
-                  : `Used by ${info.row.original.usage.agentNames.join(", ")}`
+                  : `Used by ${info.row.original.usage.agents.map((a) => a.name).join(", ")}`
               }
             >
               <span className="flex items-center gap-2 text-sm text-muted-foreground">

--- a/front/components/spaces/SpaceResourcesList.tsx
+++ b/front/components/spaces/SpaceResourcesList.tsx
@@ -41,7 +41,6 @@ import {
   isConnectorPermissionsEditable,
 } from "@app/lib/connector_providers";
 import { getDataSourceNameFromView } from "@app/lib/data_sources";
-import { useAgentConfigurationSIdLookup } from "@app/lib/swr/assistants";
 import {
   useDeleteFolderOrWebsite,
   useSpaceDataSourceViewsWithDetails,
@@ -76,7 +75,7 @@ type NumberColumnDef = ColumnDef<RowData, number>;
 type TableColumnDef = StringColumnDef | NumberColumnDef;
 
 function getTableColumns(
-  setAssistantName: (a: string | null) => void,
+  setAssistantSId: (a: string | null) => void,
   isManaged: boolean,
   isWebsite: boolean,
   space: SpaceType
@@ -126,7 +125,7 @@ function getTableColumns(
       const usage = ctx.row.original.dataSourceView.usage;
       return (
         <DataTable.CellContent>
-          <UsedByButton usage={usage} onItemClick={setAssistantName} />
+          <UsedByButton usage={usage} onItemClick={setAssistantSId} />
         </DataTable.CellContent>
       );
     },
@@ -257,11 +256,7 @@ export const SpaceResourcesList = ({
   user,
 }: SpaceResourcesListProps) => {
   const { isDark } = useTheme();
-  const [assistantName, setAssistantName] = useState<string | null>(null);
-  const { sId: assistantSId } = useAgentConfigurationSIdLookup({
-    workspaceId: owner.sId,
-    agentConfigurationName: assistantName,
-  });
+  const [assistantSId, setAssistantSId] = useState<string | null>(null);
   const [showConnectorPermissionsModal, setShowConnectorPermissionsModal] =
     useState(false);
   const [selectedDataSourceView, setSelectedDataSourceView] =
@@ -516,7 +511,7 @@ export const SpaceResourcesList = ({
         owner={owner}
         user={user}
         assistantId={assistantSId}
-        onClose={() => setAssistantName(null)}
+        onClose={() => setAssistantSId(null)}
       />
 
       {isEmpty && (
@@ -537,7 +532,7 @@ export const SpaceResourcesList = ({
         <DataTable<RowData>
           data={rows}
           columns={getTableColumns(
-            setAssistantName,
+            setAssistantSId,
             isManagedCategory,
             isWebsite,
             space

--- a/front/components/spaces/UsedByButton.tsx
+++ b/front/components/spaces/UsedByButton.tsx
@@ -37,16 +37,18 @@ export const UsedByButton = ({
         />
       </DropdownMenuTrigger>
       <DropdownMenuContent className="max-w-48">
-        {usage.agentNames.map((name) => (
-          <DropdownMenuItem
-            key={`assistant-picker-${name}`}
-            label={name}
-            onClick={(e) => {
-              e.stopPropagation();
-              onItemClick(name);
-            }}
-          />
-        ))}
+        {usage.agents
+          .map((a) => a.name)
+          .map((name) => (
+            <DropdownMenuItem
+              key={`assistant-picker-${name}`}
+              label={name}
+              onClick={(e) => {
+                e.stopPropagation();
+                onItemClick(name);
+              }}
+            />
+          ))}
       </DropdownMenuContent>
     </DropdownMenu>
   );

--- a/front/components/spaces/UsedByButton.tsx
+++ b/front/components/spaces/UsedByButton.tsx
@@ -37,18 +37,16 @@ export const UsedByButton = ({
         />
       </DropdownMenuTrigger>
       <DropdownMenuContent className="max-w-48">
-        {usage.agents
-          .map((a) => a.name)
-          .map((name) => (
-            <DropdownMenuItem
-              key={`assistant-picker-${name}`}
-              label={name}
-              onClick={(e) => {
-                e.stopPropagation();
-                onItemClick(name);
-              }}
-            />
-          ))}
+        {usage.agents.map((agent) => (
+          <DropdownMenuItem
+            key={`assistant-picker-${agent.sId}`}
+            label={agent.name}
+            onClick={(e) => {
+              e.stopPropagation();
+              onItemClick(agent.sId);
+            }}
+          />
+        ))}
       </DropdownMenuContent>
     </DropdownMenu>
   );

--- a/front/lib/api/agent_data_sources.ts
+++ b/front/lib/api/agent_data_sources.ts
@@ -373,7 +373,8 @@ export async function getDataSourceViewsUsageByCategory({
     usage.agentNames = uniq(sortBy(usage.agentNames));
     usage.agentConfigurationIds = [
       ...new Set(
-        usage.agentConfigurationIds.filter((sId) => sId && sId.length > 0)
+        ...usage.agentConfigurationIds,
+        ...dsViewConfig.sIds.filter((sId) => sId && sId.length > 0)
       ),
     ];
 
@@ -668,7 +669,8 @@ export async function getDataSourcesUsageByCategory({
     usage.agentNames = uniq(sortBy(usage.agentNames));
     usage.agentConfigurationIds = [
       ...new Set(
-        usage.agentConfigurationIds.filter((sId) => sId && sId.length > 0)
+        ...usage.agentConfigurationIds,
+        ...dsConfig.sIds.filter((sId) => sId && sId.length > 0)
       ),
     ];
 

--- a/front/lib/api/agent_data_sources.ts
+++ b/front/lib/api/agent_data_sources.ts
@@ -140,6 +140,15 @@ export async function getDataSourceViewsUsageByCategory({
           ),
           "names",
         ],
+        [
+          Sequelize.fn(
+            "array_agg",
+            Sequelize.col(
+              "agent_retrieval_configuration->agent_configuration.id"
+            )
+          ),
+          "ids",
+        ],
       ],
       include: [
         {
@@ -184,6 +193,13 @@ export async function getDataSourceViewsUsageByCategory({
             )
           ),
           "names",
+        ],
+        [
+          Sequelize.fn(
+            "array_agg",
+            Sequelize.col("agent_process_configuration->agent_configuration.id")
+          ),
+          "ids",
         ],
       ],
       include: [
@@ -230,6 +246,15 @@ export async function getDataSourceViewsUsageByCategory({
           ),
           "names",
         ],
+        [
+          Sequelize.fn(
+            "array_agg",
+            Sequelize.col(
+              "agent_mcp_server_configuration->agent_configuration.id"
+            )
+          ),
+          "ids",
+        ],
       ],
       include: [
         {
@@ -275,6 +300,15 @@ export async function getDataSourceViewsUsageByCategory({
           ),
           "names",
         ],
+        [
+          Sequelize.fn(
+            "array_agg",
+            Sequelize.col(
+              "agent_tables_query_configuration->agent_configuration.id"
+            )
+          ),
+          "ids",
+        ],
       ],
       include: [
         {
@@ -317,6 +351,7 @@ export async function getDataSourceViewsUsageByCategory({
   ])) as unknown as {
     dataSourceViewId: ModelId;
     names: string[];
+    ids: number[];
   }[][];
 
   return res.flat().reduce<DataSourcesUsageByAgent>((acc, dsViewConfig) => {
@@ -326,6 +361,7 @@ export async function getDataSourceViewsUsageByCategory({
       usage = {
         count: 0,
         agentNames: [],
+        agentConfigurationIds: [],
       };
     }
 
@@ -333,6 +369,14 @@ export async function getDataSourceViewsUsageByCategory({
       .concat(dsViewConfig.names)
       .filter((t) => t && t.length > 0);
     usage.agentNames = uniq(sortBy(usage.agentNames));
+    usage.agentConfigurationIds = uniq(
+      sortBy(
+        usage.agentConfigurationIds
+          .concat(dsViewConfig.ids || [])
+          .filter((t) => t && t > 0)
+      )
+    );
+
     usage.count = usage.agentNames.length;
 
     acc[dsViewConfig.dataSourceViewId] = usage;
@@ -391,6 +435,15 @@ export async function getDataSourcesUsageByCategory({
           ),
           "names",
         ],
+        [
+          Sequelize.fn(
+            "array_agg",
+            Sequelize.col(
+              "agent_retrieval_configuration->agent_configuration.id"
+            )
+          ),
+          "ids",
+        ],
       ],
       include: [
         {
@@ -439,6 +492,13 @@ export async function getDataSourcesUsageByCategory({
           ),
           "names",
         ],
+        [
+          Sequelize.fn(
+            "array_agg",
+            Sequelize.col("agent_process_configuration->agent_configuration.id")
+          ),
+          "ids",
+        ],
       ],
       include: [
         {
@@ -486,6 +546,15 @@ export async function getDataSourcesUsageByCategory({
             )
           ),
           "names",
+        ],
+        [
+          Sequelize.fn(
+            "array_agg",
+            Sequelize.col(
+              "agent_mcp_server_configuration->agent_configuration.id"
+            )
+          ),
+          "ids",
         ],
       ],
       include: [
@@ -535,6 +604,15 @@ export async function getDataSourcesUsageByCategory({
           ),
           "names",
         ],
+        [
+          Sequelize.fn(
+            "array_agg",
+            Sequelize.col(
+              "agent_tables_query_configuration->agent_configuration.id"
+            )
+          ),
+          "ids",
+        ],
       ],
       include: [
         {
@@ -569,6 +647,7 @@ export async function getDataSourcesUsageByCategory({
   ])) as unknown as {
     dataSourceId: ModelId;
     names: string[];
+    ids: number[];
   }[][];
 
   return res.flat().reduce<DataSourcesUsageByAgent>((acc, dsConfig) => {
@@ -577,6 +656,7 @@ export async function getDataSourcesUsageByCategory({
       usage = {
         count: 0,
         agentNames: [],
+        agentConfigurationIds: [],
       };
     }
 
@@ -584,6 +664,14 @@ export async function getDataSourcesUsageByCategory({
       .concat(dsConfig.names)
       .filter((t) => t && t.length > 0);
     usage.agentNames = uniq(sortBy(usage.agentNames));
+    usage.agentConfigurationIds = uniq(
+      sortBy(
+        usage.agentConfigurationIds
+          .concat(dsConfig.ids || [])
+          .filter((t) => t && t > 0)
+      )
+    );
+
     usage.count = usage.agentNames.length;
 
     acc[dsConfig.dataSourceId] = usage;
@@ -608,7 +696,7 @@ export async function getDataSourceUsage({
   }
 
   if (DISABLE_QUERIES) {
-    new Ok({ count: 0, agentNames: [] });
+    new Ok({ count: 0, agentNames: [], agentConfigurationIds: [] });
   }
 
   const res = (await Promise.all([
@@ -623,6 +711,15 @@ export async function getDataSourceUsage({
             )
           ),
           "names",
+        ],
+        [
+          Sequelize.fn(
+            "array_agg",
+            Sequelize.col(
+              "agent_retrieval_configuration->agent_configuration.id"
+            )
+          ),
+          "ids",
         ],
       ],
       where: {
@@ -662,6 +759,13 @@ export async function getDataSourceUsage({
           ),
           "names",
         ],
+        [
+          Sequelize.fn(
+            "array_agg",
+            Sequelize.col("agent_process_configuration->agent_configuration.id")
+          ),
+          "ids",
+        ],
       ],
       where: {
         workspaceId: owner.id,
@@ -699,6 +803,15 @@ export async function getDataSourceUsage({
             )
           ),
           "names",
+        ],
+        [
+          Sequelize.fn(
+            "array_agg",
+            Sequelize.col(
+              "agent_mcp_server_configuration->agent_configuration.id"
+            )
+          ),
+          "ids",
         ],
       ],
       where: {
@@ -738,6 +851,15 @@ export async function getDataSourceUsage({
           ),
           "names",
         ],
+        [
+          Sequelize.fn(
+            "array_agg",
+            Sequelize.col(
+              "agent_tables_query_configuration->agent_configuration.id"
+            )
+          ),
+          "names",
+        ],
       ],
       where: {
         workspaceId: owner.id,
@@ -764,10 +886,10 @@ export async function getDataSourceUsage({
         },
       ],
     }),
-  ])) as unknown as { names: string[] }[] | null;
+  ])) as unknown as { names: string[]; ids: number[] }[] | null;
 
   if (!res) {
-    return new Ok({ count: 0, agentNames: [] });
+    return new Ok({ count: 0, agentNames: [], agentConfigurationIds: [] });
   } else {
     const agentNames = uniq(
       sortBy(
@@ -776,8 +898,18 @@ export async function getDataSourceUsage({
           .filter((t) => t && t.length > 0)
       )
     );
-
-    return new Ok({ count: agentNames.length, agentNames });
+    const agentConfigurationIds = uniq(
+      sortBy(
+        res
+          .reduce<number[]>((acc, r) => acc.concat(r.ids), [])
+          .filter((t) => t && t > 0)
+      )
+    );
+    return new Ok({
+      count: agentNames.length,
+      agentNames,
+      agentConfigurationIds,
+    });
   }
 }
 
@@ -798,7 +930,7 @@ export async function getDataSourceViewUsage({
   }
 
   if (DISABLE_QUERIES) {
-    new Ok({ count: 0, agentNames: [] });
+    new Ok({ count: 0, agentNames: [], agentConfigurationIds: [] });
   }
 
   const res = (await Promise.all([
@@ -813,6 +945,15 @@ export async function getDataSourceViewUsage({
             )
           ),
           "names",
+        ],
+        [
+          Sequelize.fn(
+            "array_agg",
+            Sequelize.col(
+              "agent_retrieval_configuration->agent_configuration.id"
+            )
+          ),
+          "ids",
         ],
       ],
       where: {
@@ -852,6 +993,13 @@ export async function getDataSourceViewUsage({
           ),
           "names",
         ],
+        [
+          Sequelize.fn(
+            "array_agg",
+            Sequelize.col("agent_process_configuration->agent_configuration.id")
+          ),
+          "ids",
+        ],
       ],
       where: {
         workspaceId: owner.id,
@@ -889,6 +1037,15 @@ export async function getDataSourceViewUsage({
             )
           ),
           "names",
+        ],
+        [
+          Sequelize.fn(
+            "array_agg",
+            Sequelize.col(
+              "agent_mcp_server_configuration->agent_configuration.id"
+            )
+          ),
+          "ids",
         ],
       ],
       where: {
@@ -928,6 +1085,15 @@ export async function getDataSourceViewUsage({
           ),
           "names",
         ],
+        [
+          Sequelize.fn(
+            "array_agg",
+            Sequelize.col(
+              "agent_tables_query_configuration->agent_configuration.id"
+            )
+          ),
+          "ids",
+        ],
       ],
       where: {
         workspaceId: owner.id,
@@ -954,10 +1120,10 @@ export async function getDataSourceViewUsage({
         },
       ],
     }),
-  ])) as unknown as { names: string[] }[] | null;
+  ])) as unknown as { names: string[]; ids: number[] }[] | null;
 
   if (!res) {
-    return new Ok({ count: 0, agentNames: [] });
+    return new Ok({ count: 0, agentNames: [], agentConfigurationIds: [] });
   } else {
     const agentNames = uniq(
       sortBy(
@@ -966,6 +1132,17 @@ export async function getDataSourceViewUsage({
           .filter((t) => t && t.length > 0)
       )
     );
-    return new Ok({ count: agentNames.length, agentNames });
+    const agentConfigurationIds = uniq(
+      sortBy(
+        res
+          .reduce<number[]>((acc, r) => acc.concat(r.ids), [])
+          .filter((t) => t && t > 0)
+      )
+    );
+    return new Ok({
+      count: agentNames.length,
+      agentNames,
+      agentConfigurationIds,
+    });
   }
 }

--- a/front/lib/api/agent_data_sources.ts
+++ b/front/lib/api/agent_data_sources.ts
@@ -369,13 +369,9 @@ export async function getDataSourceViewsUsageByCategory({
       .concat(dsViewConfig.names)
       .filter((t) => t && t.length > 0);
     usage.agentNames = uniq(sortBy(usage.agentNames));
-    usage.agentConfigurationIds = uniq(
-      sortBy(
-        usage.agentConfigurationIds
-          .concat(dsViewConfig.ids || [])
-          .filter((t) => t && t > 0)
-      )
-    );
+    usage.agentConfigurationIds = [
+      ...new Set(usage.agentConfigurationIds.filter((id) => id > 0)),
+    ];
 
     usage.count = usage.agentNames.length;
 
@@ -664,13 +660,9 @@ export async function getDataSourcesUsageByCategory({
       .concat(dsConfig.names)
       .filter((t) => t && t.length > 0);
     usage.agentNames = uniq(sortBy(usage.agentNames));
-    usage.agentConfigurationIds = uniq(
-      sortBy(
-        usage.agentConfigurationIds
-          .concat(dsConfig.ids || [])
-          .filter((t) => t && t > 0)
-      )
-    );
+    usage.agentConfigurationIds = [
+      ...new Set(usage.agentConfigurationIds.filter((id) => id > 0)),
+    ];
 
     usage.count = usage.agentNames.length;
 

--- a/front/lib/api/agent_data_sources.ts
+++ b/front/lib/api/agent_data_sources.ts
@@ -386,13 +386,13 @@ export async function getDataSourceViewsUsageByCategory({
     if (!usage) {
       usage = {
         count: 0,
-        agentConfigurationIdsToAgentNames: [],
+        agents: [],
       };
     }
 
-    usage.agentConfigurationIdsToAgentNames = sortBy(
+    usage.agents = sortBy(
       uniqBy(
-        usage.agentConfigurationIdsToAgentNames.concat(
+        usage.agents.concat(
           dsViewConfig.sIds
             .map((sId, index) => ({
               sId,
@@ -411,7 +411,7 @@ export async function getDataSourceViewsUsageByCategory({
       "name"
     );
 
-    usage.count = usage.agentConfigurationIdsToAgentNames.length;
+    usage.count = usage.agents.length;
 
     acc[dsViewConfig.dataSourceViewId] = usage;
     return acc;
@@ -715,13 +715,13 @@ export async function getDataSourcesUsageByCategory({
     if (!usage) {
       usage = {
         count: 0,
-        agentConfigurationIdsToAgentNames: [],
+        agents: [],
       };
     }
 
-    usage.agentConfigurationIdsToAgentNames = sortBy(
+    usage.agents = sortBy(
       uniqBy(
-        usage.agentConfigurationIdsToAgentNames.concat(
+        usage.agents.concat(
           dsConfig.sIds
             .map((sId, index) => ({
               sId,
@@ -740,7 +740,7 @@ export async function getDataSourcesUsageByCategory({
       "name"
     );
 
-    usage.count = usage.agentConfigurationIdsToAgentNames.length;
+    usage.count = usage.agents.length;
 
     acc[dsConfig.dataSourceId] = usage;
     return acc;
@@ -764,7 +764,7 @@ export async function getDataSourceUsage({
   }
 
   if (DISABLE_QUERIES) {
-    return new Ok({ count: 0, agentConfigurationIdsToAgentNames: [] });
+    return new Ok({ count: 0, agents: [] });
   }
 
   const res = (await Promise.all([
@@ -983,7 +983,7 @@ export async function getDataSourceUsage({
   ])) as unknown as { names: string[]; sIds: string[] }[] | null;
 
   if (!res) {
-    return new Ok({ count: 0, agentConfigurationIdsToAgentNames: [] });
+    return new Ok({ count: 0, agents: [] });
   } else {
     const agents = res
       .flatMap((r) =>
@@ -1004,7 +1004,7 @@ export async function getDataSourceUsage({
 
     return new Ok({
       count: sortedAgents.length,
-      agentConfigurationIdsToAgentNames: sortedAgents,
+      agents: sortedAgents,
     });
   }
 }
@@ -1026,7 +1026,7 @@ export async function getDataSourceViewUsage({
   }
 
   if (DISABLE_QUERIES) {
-    return new Ok({ count: 0, agentConfigurationIdsToAgentNames: [] });
+    return new Ok({ count: 0, agents: [] });
   }
 
   const res = (await Promise.all([
@@ -1245,7 +1245,7 @@ export async function getDataSourceViewUsage({
   ])) as unknown as { names: string[]; sIds: string[] }[] | null;
 
   if (!res) {
-    return new Ok({ count: 0, agentConfigurationIdsToAgentNames: [] });
+    return new Ok({ count: 0, agents: [] });
   } else {
     const agents = res
       .flatMap((r) =>
@@ -1266,7 +1266,7 @@ export async function getDataSourceViewUsage({
 
     return new Ok({
       count: sortedAgents.length,
-      agentConfigurationIdsToAgentNames: sortedAgents,
+      agents: sortedAgents,
     });
   }
 }

--- a/front/lib/api/agent_data_sources.ts
+++ b/front/lib/api/agent_data_sources.ts
@@ -134,11 +134,8 @@ export async function getDataSourceViewsUsageByCategory({
         [
           Sequelize.fn(
             "array_agg",
-            Sequelize.col(
-              "agent_retrieval_configuration->agent_configuration.name"
-            ),
             Sequelize.literal(
-              "ORDER BY agent_retrieval_configuration->agent_configuration.name"
+              '"agent_retrieval_configuration->agent_configuration"."name" ORDER BY "agent_retrieval_configuration->agent_configuration"."name"'
             )
           ),
           "names",
@@ -146,11 +143,8 @@ export async function getDataSourceViewsUsageByCategory({
         [
           Sequelize.fn(
             "array_agg",
-            Sequelize.col(
-              "agent_retrieval_configuration->agent_configuration.sId"
-            ),
             Sequelize.literal(
-              "ORDER BY agent_retrieval_configuration->agent_configuration.name"
+              '"agent_retrieval_configuration->agent_configuration"."sId" ORDER BY "agent_retrieval_configuration->agent_configuration"."name"'
             )
           ),
           "sIds",
@@ -194,11 +188,8 @@ export async function getDataSourceViewsUsageByCategory({
         [
           Sequelize.fn(
             "array_agg",
-            Sequelize.col(
-              "agent_process_configuration->agent_configuration.name"
-            ),
             Sequelize.literal(
-              "ORDER BY agent_process_configuration->agent_configuration.name"
+              '"agent_process_configuration->agent_configuration"."name" ORDER BY "agent_process_configuration->agent_configuration"."name"'
             )
           ),
           "names",
@@ -206,11 +197,8 @@ export async function getDataSourceViewsUsageByCategory({
         [
           Sequelize.fn(
             "array_agg",
-            Sequelize.col(
-              "agent_process_configuration->agent_configuration.sId"
-            ),
             Sequelize.literal(
-              "ORDER BY agent_process_configuration->agent_configuration.name"
+              '"agent_process_configuration->agent_configuration"."sId" ORDER BY "agent_process_configuration->agent_configuration"."name"'
             )
           ),
           "sIds",
@@ -254,11 +242,8 @@ export async function getDataSourceViewsUsageByCategory({
         [
           Sequelize.fn(
             "array_agg",
-            Sequelize.col(
-              "agent_mcp_server_configuration->agent_configuration.name"
-            ),
             Sequelize.literal(
-              "ORDER BY agent_mcp_server_configuration->agent_configuration.name"
+              '"agent_mcp_server_configuration->agent_configuration"."name" ORDER BY "agent_mcp_server_configuration->agent_configuration"."name"'
             )
           ),
           "names",
@@ -266,11 +251,8 @@ export async function getDataSourceViewsUsageByCategory({
         [
           Sequelize.fn(
             "array_agg",
-            Sequelize.col(
-              "agent_mcp_server_configuration->agent_configuration.sId"
-            ),
             Sequelize.literal(
-              "ORDER BY agent_mcp_server_configuration->agent_configuration.name"
+              '"agent_mcp_server_configuration->agent_configuration"."sId" ORDER BY "agent_mcp_server_configuration->agent_configuration"."name"'
             )
           ),
           "sIds",
@@ -314,11 +296,8 @@ export async function getDataSourceViewsUsageByCategory({
         [
           Sequelize.fn(
             "array_agg",
-            Sequelize.col(
-              "agent_tables_query_configuration->agent_configuration.name"
-            ),
             Sequelize.literal(
-              "ORDER BY agent_tables_query_configuration->agent_configuration.name"
+              '"agent_tables_query_configuration->agent_configuration"."name" ORDER BY "agent_tables_query_configuration->agent_configuration"."name"'
             )
           ),
           "names",
@@ -326,11 +305,8 @@ export async function getDataSourceViewsUsageByCategory({
         [
           Sequelize.fn(
             "array_agg",
-            Sequelize.col(
-              "agent_tables_query_configuration->agent_configuration.sId"
-            ),
             Sequelize.literal(
-              "ORDER BY agent_tables_query_configuration->agent_configuration.name"
+              '"agent_tables_query_configuration->agent_configuration"."sId" ORDER BY "agent_tables_query_configuration->agent_configuration"."name"'
             )
           ),
           "sIds",
@@ -462,11 +438,8 @@ export async function getDataSourcesUsageByCategory({
         [
           Sequelize.fn(
             "array_agg",
-            Sequelize.col(
-              "agent_retrieval_configuration->agent_configuration.name"
-            ),
             Sequelize.literal(
-              "ORDER BY agent_retrieval_configuration->agent_configuration.name"
+              '"agent_retrieval_configuration->agent_configuration"."name" ORDER BY "agent_retrieval_configuration->agent_configuration"."name"'
             )
           ),
           "names",
@@ -474,11 +447,8 @@ export async function getDataSourcesUsageByCategory({
         [
           Sequelize.fn(
             "array_agg",
-            Sequelize.col(
-              "agent_retrieval_configuration->agent_configuration.sId"
-            ),
             Sequelize.literal(
-              "ORDER BY agent_retrieval_configuration->agent_configuration.name"
+              '"agent_retrieval_configuration->agent_configuration"."sId" ORDER BY "agent_retrieval_configuration->agent_configuration"."name"'
             )
           ),
           "sIds",
@@ -525,11 +495,8 @@ export async function getDataSourcesUsageByCategory({
         [
           Sequelize.fn(
             "array_agg",
-            Sequelize.col(
-              "agent_process_configuration->agent_configuration.name"
-            ),
             Sequelize.literal(
-              "ORDER BY agent_process_configuration->agent_configuration.name"
+              '"agent_process_configuration->agent_configuration"."name" ORDER BY "agent_process_configuration->agent_configuration"."name"'
             )
           ),
           "names",
@@ -537,11 +504,8 @@ export async function getDataSourcesUsageByCategory({
         [
           Sequelize.fn(
             "array_agg",
-            Sequelize.col(
-              "agent_process_configuration->agent_configuration.sId"
-            ),
             Sequelize.literal(
-              "ORDER BY agent_process_configuration->agent_configuration.name"
+              '"agent_process_configuration->agent_configuration"."sId" ORDER BY "agent_process_configuration->agent_configuration"."name"'
             )
           ),
           "sIds",
@@ -588,11 +552,8 @@ export async function getDataSourcesUsageByCategory({
         [
           Sequelize.fn(
             "array_agg",
-            Sequelize.col(
-              "agent_mcp_server_configuration->agent_configuration.name"
-            ),
             Sequelize.literal(
-              "ORDER BY agent_mcp_server_configuration->agent_configuration.name"
+              '"agent_mcp_server_configuration->agent_configuration"."name" ORDER BY "agent_mcp_server_configuration->agent_configuration"."name"'
             )
           ),
           "names",
@@ -600,11 +561,8 @@ export async function getDataSourcesUsageByCategory({
         [
           Sequelize.fn(
             "array_agg",
-            Sequelize.col(
-              "agent_mcp_server_configuration->agent_configuration.sId"
-            ),
             Sequelize.literal(
-              "ORDER BY agent_mcp_server_configuration->agent_configuration.name"
+              '"agent_mcp_server_configuration->agent_configuration"."sId" ORDER BY "agent_mcp_server_configuration->agent_configuration"."name"'
             )
           ),
           "sIds",
@@ -651,11 +609,8 @@ export async function getDataSourcesUsageByCategory({
         [
           Sequelize.fn(
             "array_agg",
-            Sequelize.col(
-              "agent_tables_query_configuration->agent_configuration.name"
-            ),
             Sequelize.literal(
-              "ORDER BY agent_tables_query_configuration->agent_configuration.name"
+              '"agent_tables_query_configuration->agent_configuration"."name" ORDER BY "agent_tables_query_configuration->agent_configuration"."name"'
             )
           ),
           "names",
@@ -663,11 +618,8 @@ export async function getDataSourcesUsageByCategory({
         [
           Sequelize.fn(
             "array_agg",
-            Sequelize.col(
-              "agent_tables_query_configuration->agent_configuration.sId"
-            ),
             Sequelize.literal(
-              "ORDER BY agent_tables_query_configuration->agent_configuration.name"
+              '"agent_tables_query_configuration->agent_configuration"."sId" ORDER BY "agent_tables_query_configuration->agent_configuration"."name"'
             )
           ),
           "sIds",
@@ -774,11 +726,8 @@ export async function getDataSourceUsage({
         [
           Sequelize.fn(
             "array_agg",
-            Sequelize.col(
-              "agent_retrieval_configuration->agent_configuration.name"
-            ),
             Sequelize.literal(
-              "ORDER BY agent_retrieval_configuration->agent_configuration.name"
+              '"agent_retrieval_configuration->agent_configuration"."name" ORDER BY "agent_retrieval_configuration->agent_configuration"."name"'
             )
           ),
           "names",
@@ -786,11 +735,8 @@ export async function getDataSourceUsage({
         [
           Sequelize.fn(
             "array_agg",
-            Sequelize.col(
-              "agent_retrieval_configuration->agent_configuration.sId"
-            ),
             Sequelize.literal(
-              "ORDER BY agent_retrieval_configuration->agent_configuration.name"
+              '"agent_retrieval_configuration->agent_configuration"."sId" ORDER BY "agent_retrieval_configuration->agent_configuration"."name"'
             )
           ),
           "sIds",
@@ -827,11 +773,8 @@ export async function getDataSourceUsage({
         [
           Sequelize.fn(
             "array_agg",
-            Sequelize.col(
-              "agent_process_configuration->agent_configuration.name"
-            ),
             Sequelize.literal(
-              "ORDER BY agent_process_configuration->agent_configuration.name"
+              '"agent_process_configuration->agent_configuration"."name" ORDER BY "agent_process_configuration->agent_configuration"."name"'
             )
           ),
           "names",
@@ -839,11 +782,8 @@ export async function getDataSourceUsage({
         [
           Sequelize.fn(
             "array_agg",
-            Sequelize.col(
-              "agent_process_configuration->agent_configuration.sId"
-            ),
             Sequelize.literal(
-              "ORDER BY agent_process_configuration->agent_configuration.name"
+              '"agent_process_configuration->agent_configuration"."sId" ORDER BY "agent_process_configuration->agent_configuration"."name"'
             )
           ),
           "sIds",
@@ -880,11 +820,8 @@ export async function getDataSourceUsage({
         [
           Sequelize.fn(
             "array_agg",
-            Sequelize.col(
-              "agent_mcp_server_configuration->agent_configuration.name"
-            ),
             Sequelize.literal(
-              "ORDER BY agent_mcp_server_configuration->agent_configuration.name"
+              '"agent_mcp_server_configuration->agent_configuration"."name" ORDER BY "agent_mcp_server_configuration->agent_configuration"."name"'
             )
           ),
           "names",
@@ -892,11 +829,8 @@ export async function getDataSourceUsage({
         [
           Sequelize.fn(
             "array_agg",
-            Sequelize.col(
-              "agent_mcp_server_configuration->agent_configuration.sId"
-            ),
             Sequelize.literal(
-              "ORDER BY agent_mcp_server_configuration->agent_configuration.name"
+              '"agent_mcp_server_configuration->agent_configuration"."sId" ORDER BY "agent_mcp_server_configuration->agent_configuration"."name"'
             )
           ),
           "sIds",
@@ -933,11 +867,8 @@ export async function getDataSourceUsage({
         [
           Sequelize.fn(
             "array_agg",
-            Sequelize.col(
-              "agent_tables_query_configuration->agent_configuration.name"
-            ),
             Sequelize.literal(
-              "ORDER BY agent_tables_query_configuration->agent_configuration.name"
+              '"agent_tables_query_configuration->agent_configuration"."name" ORDER BY "agent_tables_query_configuration->agent_configuration"."name"'
             )
           ),
           "names",
@@ -945,11 +876,8 @@ export async function getDataSourceUsage({
         [
           Sequelize.fn(
             "array_agg",
-            Sequelize.col(
-              "agent_tables_query_configuration->agent_configuration.sId"
-            ),
             Sequelize.literal(
-              "ORDER BY agent_tables_query_configuration->agent_configuration.name"
+              '"agent_tables_query_configuration->agent_configuration"."sId" ORDER BY "agent_tables_query_configuration->agent_configuration"."name"'
             )
           ),
           "sIds",
@@ -1036,11 +964,8 @@ export async function getDataSourceViewUsage({
         [
           Sequelize.fn(
             "array_agg",
-            Sequelize.col(
-              "agent_retrieval_configuration->agent_configuration.name"
-            ),
             Sequelize.literal(
-              "ORDER BY agent_retrieval_configuration->agent_configuration.name"
+              '"agent_retrieval_configuration->agent_configuration"."name" ORDER BY "agent_retrieval_configuration->agent_configuration"."name"'
             )
           ),
           "names",
@@ -1048,11 +973,8 @@ export async function getDataSourceViewUsage({
         [
           Sequelize.fn(
             "array_agg",
-            Sequelize.col(
-              "agent_retrieval_configuration->agent_configuration.sId"
-            ),
             Sequelize.literal(
-              "ORDER BY agent_retrieval_configuration->agent_configuration.name"
+              '"agent_retrieval_configuration->agent_configuration"."sId" ORDER BY "agent_retrieval_configuration->agent_configuration"."name"'
             )
           ),
           "sIds",
@@ -1089,11 +1011,8 @@ export async function getDataSourceViewUsage({
         [
           Sequelize.fn(
             "array_agg",
-            Sequelize.col(
-              "agent_process_configuration->agent_configuration.name"
-            ),
             Sequelize.literal(
-              "ORDER BY agent_process_configuration->agent_configuration.name"
+              '"agent_process_configuration->agent_configuration"."name" ORDER BY "agent_process_configuration->agent_configuration"."name"'
             )
           ),
           "names",
@@ -1101,11 +1020,8 @@ export async function getDataSourceViewUsage({
         [
           Sequelize.fn(
             "array_agg",
-            Sequelize.col(
-              "agent_process_configuration->agent_configuration.sId"
-            ),
             Sequelize.literal(
-              "ORDER BY agent_process_configuration->agent_configuration.name"
+              '"agent_process_configuration->agent_configuration"."sId" ORDER BY "agent_process_configuration->agent_configuration"."name"'
             )
           ),
           "sIds",
@@ -1142,11 +1058,8 @@ export async function getDataSourceViewUsage({
         [
           Sequelize.fn(
             "array_agg",
-            Sequelize.col(
-              "agent_mcp_server_configuration->agent_configuration.name"
-            ),
             Sequelize.literal(
-              "ORDER BY agent_mcp_server_configuration->agent_configuration.name"
+              '"agent_mcp_server_configuration->agent_configuration"."name" ORDER BY "agent_mcp_server_configuration->agent_configuration"."name"'
             )
           ),
           "names",
@@ -1154,11 +1067,8 @@ export async function getDataSourceViewUsage({
         [
           Sequelize.fn(
             "array_agg",
-            Sequelize.col(
-              "agent_mcp_server_configuration->agent_configuration.sId"
-            ),
             Sequelize.literal(
-              "ORDER BY agent_mcp_server_configuration->agent_configuration.name"
+              '"agent_mcp_server_configuration->agent_configuration"."sId" ORDER BY "agent_mcp_server_configuration->agent_configuration"."name"'
             )
           ),
           "sIds",
@@ -1195,11 +1105,8 @@ export async function getDataSourceViewUsage({
         [
           Sequelize.fn(
             "array_agg",
-            Sequelize.col(
-              "agent_tables_query_configuration->agent_configuration.name"
-            ),
             Sequelize.literal(
-              "ORDER BY agent_tables_query_configuration->agent_configuration.name"
+              '"agent_tables_query_configuration->agent_configuration"."name" ORDER BY "agent_tables_query_configuration->agent_configuration"."name"'
             )
           ),
           "names",
@@ -1207,11 +1114,8 @@ export async function getDataSourceViewUsage({
         [
           Sequelize.fn(
             "array_agg",
-            Sequelize.col(
-              "agent_tables_query_configuration->agent_configuration.sId"
-            ),
             Sequelize.literal(
-              "ORDER BY agent_tables_query_configuration->agent_configuration.name"
+              '"agent_tables_query_configuration->agent_configuration"."sId" ORDER BY "agent_tables_query_configuration->agent_configuration"."name"'
             )
           ),
           "sIds",

--- a/front/lib/api/agent_data_sources.ts
+++ b/front/lib/api/agent_data_sources.ts
@@ -696,7 +696,7 @@ export async function getDataSourceUsage({
   }
 
   if (DISABLE_QUERIES) {
-    new Ok({ count: 0, agentNames: [], agentConfigurationIds: [] });
+    return new Ok({ count: 0, agentNames: [], agentConfigurationIds: [] });
   }
 
   const res = (await Promise.all([
@@ -930,7 +930,7 @@ export async function getDataSourceViewUsage({
   }
 
   if (DISABLE_QUERIES) {
-    new Ok({ count: 0, agentNames: [], agentConfigurationIds: [] });
+    return new Ok({ count: 0, agentNames: [], agentConfigurationIds: [] });
   }
 
   const res = (await Promise.all([

--- a/front/lib/api/agent_data_sources.ts
+++ b/front/lib/api/agent_data_sources.ts
@@ -1,4 +1,4 @@
-import { sortBy, uniq } from "lodash";
+import { sortBy, uniq, uniqBy } from "lodash";
 import type { WhereAttributeHashValue } from "sequelize";
 import { Op, Sequelize } from "sequelize";
 
@@ -136,6 +136,9 @@ export async function getDataSourceViewsUsageByCategory({
             "array_agg",
             Sequelize.col(
               "agent_retrieval_configuration->agent_configuration.name"
+            ),
+            Sequelize.literal(
+              "ORDER BY agent_retrieval_configuration->agent_configuration.name"
             )
           ),
           "names",
@@ -145,6 +148,9 @@ export async function getDataSourceViewsUsageByCategory({
             "array_agg",
             Sequelize.col(
               "agent_retrieval_configuration->agent_configuration.sId"
+            ),
+            Sequelize.literal(
+              "ORDER BY agent_retrieval_configuration->agent_configuration.name"
             )
           ),
           "sIds",
@@ -190,6 +196,9 @@ export async function getDataSourceViewsUsageByCategory({
             "array_agg",
             Sequelize.col(
               "agent_process_configuration->agent_configuration.name"
+            ),
+            Sequelize.literal(
+              "ORDER BY agent_process_configuration->agent_configuration.name"
             )
           ),
           "names",
@@ -199,6 +208,9 @@ export async function getDataSourceViewsUsageByCategory({
             "array_agg",
             Sequelize.col(
               "agent_process_configuration->agent_configuration.sId"
+            ),
+            Sequelize.literal(
+              "ORDER BY agent_process_configuration->agent_configuration.name"
             )
           ),
           "sIds",
@@ -244,6 +256,9 @@ export async function getDataSourceViewsUsageByCategory({
             "array_agg",
             Sequelize.col(
               "agent_mcp_server_configuration->agent_configuration.name"
+            ),
+            Sequelize.literal(
+              "ORDER BY agent_mcp_server_configuration->agent_configuration.name"
             )
           ),
           "names",
@@ -253,6 +268,9 @@ export async function getDataSourceViewsUsageByCategory({
             "array_agg",
             Sequelize.col(
               "agent_mcp_server_configuration->agent_configuration.sId"
+            ),
+            Sequelize.literal(
+              "ORDER BY agent_mcp_server_configuration->agent_configuration.name"
             )
           ),
           "sIds",
@@ -298,6 +316,9 @@ export async function getDataSourceViewsUsageByCategory({
             "array_agg",
             Sequelize.col(
               "agent_tables_query_configuration->agent_configuration.name"
+            ),
+            Sequelize.literal(
+              "ORDER BY agent_tables_query_configuration->agent_configuration.name"
             )
           ),
           "names",
@@ -307,6 +328,9 @@ export async function getDataSourceViewsUsageByCategory({
             "array_agg",
             Sequelize.col(
               "agent_tables_query_configuration->agent_configuration.sId"
+            ),
+            Sequelize.literal(
+              "ORDER BY agent_tables_query_configuration->agent_configuration.name"
             )
           ),
           "sIds",
@@ -362,26 +386,34 @@ export async function getDataSourceViewsUsageByCategory({
     if (!usage) {
       usage = {
         count: 0,
-        agentNames: [],
-        agentConfigurationIds: [],
+        agentConfigurationIdsToAgentNames: [],
       };
     }
 
-    usage.agentNames = usage.agentNames
-      .concat(dsViewConfig.names)
-      .filter((t) => t && t.length > 0);
-    usage.agentNames = uniq(sortBy(usage.agentNames));
-    usage.agentConfigurationIds = [
-      ...new Set(
-        ...usage.agentConfigurationIds,
-        ...dsViewConfig.sIds.filter((sId) => sId && sId.length > 0)
+    usage.agentConfigurationIdsToAgentNames = sortBy(
+      uniqBy(
+        usage.agentConfigurationIdsToAgentNames.concat(
+          dsViewConfig.sIds
+            .map((sId, index) => ({
+              sId,
+              name: dsViewConfig.names[index],
+            }))
+            .filter(
+              (agent) =>
+                agent.sId &&
+                agent.sId.length > 0 &&
+                agent.name &&
+                agent.name.length > 0
+            )
+        ),
+        "sId"
       ),
-    ];
+      "name"
+    );
 
-    usage.count = usage.agentNames.length;
+    usage.count = usage.agentConfigurationIdsToAgentNames.length;
 
     acc[dsViewConfig.dataSourceViewId] = usage;
-
     return acc;
   }, {});
 }
@@ -432,6 +464,9 @@ export async function getDataSourcesUsageByCategory({
             "array_agg",
             Sequelize.col(
               "agent_retrieval_configuration->agent_configuration.name"
+            ),
+            Sequelize.literal(
+              "ORDER BY agent_retrieval_configuration->agent_configuration.name"
             )
           ),
           "names",
@@ -441,6 +476,9 @@ export async function getDataSourcesUsageByCategory({
             "array_agg",
             Sequelize.col(
               "agent_retrieval_configuration->agent_configuration.sId"
+            ),
+            Sequelize.literal(
+              "ORDER BY agent_retrieval_configuration->agent_configuration.name"
             )
           ),
           "sIds",
@@ -489,6 +527,9 @@ export async function getDataSourcesUsageByCategory({
             "array_agg",
             Sequelize.col(
               "agent_process_configuration->agent_configuration.name"
+            ),
+            Sequelize.literal(
+              "ORDER BY agent_process_configuration->agent_configuration.name"
             )
           ),
           "names",
@@ -498,6 +539,9 @@ export async function getDataSourcesUsageByCategory({
             "array_agg",
             Sequelize.col(
               "agent_process_configuration->agent_configuration.sId"
+            ),
+            Sequelize.literal(
+              "ORDER BY agent_process_configuration->agent_configuration.name"
             )
           ),
           "sIds",
@@ -546,6 +590,9 @@ export async function getDataSourcesUsageByCategory({
             "array_agg",
             Sequelize.col(
               "agent_mcp_server_configuration->agent_configuration.name"
+            ),
+            Sequelize.literal(
+              "ORDER BY agent_mcp_server_configuration->agent_configuration.name"
             )
           ),
           "names",
@@ -555,6 +602,9 @@ export async function getDataSourcesUsageByCategory({
             "array_agg",
             Sequelize.col(
               "agent_mcp_server_configuration->agent_configuration.sId"
+            ),
+            Sequelize.literal(
+              "ORDER BY agent_mcp_server_configuration->agent_configuration.name"
             )
           ),
           "sIds",
@@ -603,6 +653,9 @@ export async function getDataSourcesUsageByCategory({
             "array_agg",
             Sequelize.col(
               "agent_tables_query_configuration->agent_configuration.name"
+            ),
+            Sequelize.literal(
+              "ORDER BY agent_tables_query_configuration->agent_configuration.name"
             )
           ),
           "names",
@@ -612,6 +665,9 @@ export async function getDataSourcesUsageByCategory({
             "array_agg",
             Sequelize.col(
               "agent_tables_query_configuration->agent_configuration.sId"
+            ),
+            Sequelize.literal(
+              "ORDER BY agent_tables_query_configuration->agent_configuration.name"
             )
           ),
           "sIds",
@@ -655,26 +711,36 @@ export async function getDataSourcesUsageByCategory({
 
   return res.flat().reduce<DataSourcesUsageByAgent>((acc, dsConfig) => {
     let usage = acc[dsConfig.dataSourceId];
+
     if (!usage) {
       usage = {
         count: 0,
-        agentNames: [],
-        agentConfigurationIds: [],
+        agentConfigurationIdsToAgentNames: [],
       };
     }
 
-    usage.agentNames = usage.agentNames
-      .concat(dsConfig.names)
-      .filter((t) => t && t.length > 0);
-    usage.agentNames = uniq(sortBy(usage.agentNames));
-    usage.agentConfigurationIds = [
-      ...new Set(
-        ...usage.agentConfigurationIds,
-        ...dsConfig.sIds.filter((sId) => sId && sId.length > 0)
+    usage.agentConfigurationIdsToAgentNames = sortBy(
+      uniqBy(
+        usage.agentConfigurationIdsToAgentNames.concat(
+          dsConfig.sIds
+            .map((sId, index) => ({
+              sId,
+              name: dsConfig.names[index],
+            }))
+            .filter(
+              (agent) =>
+                agent.sId &&
+                agent.sId.length > 0 &&
+                agent.name &&
+                agent.name.length > 0
+            )
+        ),
+        "sId"
       ),
-    ];
+      "name"
+    );
 
-    usage.count = usage.agentNames.length;
+    usage.count = usage.agentConfigurationIdsToAgentNames.length;
 
     acc[dsConfig.dataSourceId] = usage;
     return acc;
@@ -698,7 +764,7 @@ export async function getDataSourceUsage({
   }
 
   if (DISABLE_QUERIES) {
-    return new Ok({ count: 0, agentNames: [], agentConfigurationIds: [] });
+    return new Ok({ count: 0, agentConfigurationIdsToAgentNames: [] });
   }
 
   const res = (await Promise.all([
@@ -710,6 +776,9 @@ export async function getDataSourceUsage({
             "array_agg",
             Sequelize.col(
               "agent_retrieval_configuration->agent_configuration.name"
+            ),
+            Sequelize.literal(
+              "ORDER BY agent_retrieval_configuration->agent_configuration.name"
             )
           ),
           "names",
@@ -719,6 +788,9 @@ export async function getDataSourceUsage({
             "array_agg",
             Sequelize.col(
               "agent_retrieval_configuration->agent_configuration.sId"
+            ),
+            Sequelize.literal(
+              "ORDER BY agent_retrieval_configuration->agent_configuration.name"
             )
           ),
           "sIds",
@@ -757,6 +829,9 @@ export async function getDataSourceUsage({
             "array_agg",
             Sequelize.col(
               "agent_process_configuration->agent_configuration.name"
+            ),
+            Sequelize.literal(
+              "ORDER BY agent_process_configuration->agent_configuration.name"
             )
           ),
           "names",
@@ -766,6 +841,9 @@ export async function getDataSourceUsage({
             "array_agg",
             Sequelize.col(
               "agent_process_configuration->agent_configuration.sId"
+            ),
+            Sequelize.literal(
+              "ORDER BY agent_process_configuration->agent_configuration.name"
             )
           ),
           "sIds",
@@ -804,6 +882,9 @@ export async function getDataSourceUsage({
             "array_agg",
             Sequelize.col(
               "agent_mcp_server_configuration->agent_configuration.name"
+            ),
+            Sequelize.literal(
+              "ORDER BY agent_mcp_server_configuration->agent_configuration.name"
             )
           ),
           "names",
@@ -813,6 +894,9 @@ export async function getDataSourceUsage({
             "array_agg",
             Sequelize.col(
               "agent_mcp_server_configuration->agent_configuration.sId"
+            ),
+            Sequelize.literal(
+              "ORDER BY agent_mcp_server_configuration->agent_configuration.name"
             )
           ),
           "sIds",
@@ -851,6 +935,9 @@ export async function getDataSourceUsage({
             "array_agg",
             Sequelize.col(
               "agent_tables_query_configuration->agent_configuration.name"
+            ),
+            Sequelize.literal(
+              "ORDER BY agent_tables_query_configuration->agent_configuration.name"
             )
           ),
           "names",
@@ -860,6 +947,9 @@ export async function getDataSourceUsage({
             "array_agg",
             Sequelize.col(
               "agent_tables_query_configuration->agent_configuration.sId"
+            ),
+            Sequelize.literal(
+              "ORDER BY agent_tables_query_configuration->agent_configuration.name"
             )
           ),
           "sIds",
@@ -893,24 +983,28 @@ export async function getDataSourceUsage({
   ])) as unknown as { names: string[]; sIds: string[] }[] | null;
 
   if (!res) {
-    return new Ok({ count: 0, agentNames: [], agentConfigurationIds: [] });
+    return new Ok({ count: 0, agentConfigurationIdsToAgentNames: [] });
   } else {
-    const agentNames = uniq(
-      sortBy(
-        res
-          .reduce<string[]>((acc, r) => acc.concat(r.names), [])
-          .filter((t) => t && t.length > 0)
+    const agents = res
+      .flatMap((r) =>
+        r.sIds.map((sId, index) => ({
+          sId,
+          name: r.names[index],
+        }))
       )
-    );
-    const agentConfigurationIds = [
-      ...new Set(
-        res.flatMap((r) => r.sIds).filter((sId) => sId && sId.length > 0)
-      ),
-    ];
+      .filter(
+        (agent) =>
+          agent.sId &&
+          agent.sId.length > 0 &&
+          agent.name &&
+          agent.name.length > 0
+      );
+
+    const sortedAgents = sortBy(uniqBy(agents, "sId"), "name");
+
     return new Ok({
-      count: agentNames.length,
-      agentNames,
-      agentConfigurationIds,
+      count: sortedAgents.length,
+      agentConfigurationIdsToAgentNames: sortedAgents,
     });
   }
 }
@@ -932,7 +1026,7 @@ export async function getDataSourceViewUsage({
   }
 
   if (DISABLE_QUERIES) {
-    return new Ok({ count: 0, agentNames: [], agentConfigurationIds: [] });
+    return new Ok({ count: 0, agentConfigurationIdsToAgentNames: [] });
   }
 
   const res = (await Promise.all([
@@ -944,6 +1038,9 @@ export async function getDataSourceViewUsage({
             "array_agg",
             Sequelize.col(
               "agent_retrieval_configuration->agent_configuration.name"
+            ),
+            Sequelize.literal(
+              "ORDER BY agent_retrieval_configuration->agent_configuration.name"
             )
           ),
           "names",
@@ -953,6 +1050,9 @@ export async function getDataSourceViewUsage({
             "array_agg",
             Sequelize.col(
               "agent_retrieval_configuration->agent_configuration.sId"
+            ),
+            Sequelize.literal(
+              "ORDER BY agent_retrieval_configuration->agent_configuration.name"
             )
           ),
           "sIds",
@@ -991,6 +1091,9 @@ export async function getDataSourceViewUsage({
             "array_agg",
             Sequelize.col(
               "agent_process_configuration->agent_configuration.name"
+            ),
+            Sequelize.literal(
+              "ORDER BY agent_process_configuration->agent_configuration.name"
             )
           ),
           "names",
@@ -1000,6 +1103,9 @@ export async function getDataSourceViewUsage({
             "array_agg",
             Sequelize.col(
               "agent_process_configuration->agent_configuration.sId"
+            ),
+            Sequelize.literal(
+              "ORDER BY agent_process_configuration->agent_configuration.name"
             )
           ),
           "sIds",
@@ -1038,6 +1144,9 @@ export async function getDataSourceViewUsage({
             "array_agg",
             Sequelize.col(
               "agent_mcp_server_configuration->agent_configuration.name"
+            ),
+            Sequelize.literal(
+              "ORDER BY agent_mcp_server_configuration->agent_configuration.name"
             )
           ),
           "names",
@@ -1047,6 +1156,9 @@ export async function getDataSourceViewUsage({
             "array_agg",
             Sequelize.col(
               "agent_mcp_server_configuration->agent_configuration.sId"
+            ),
+            Sequelize.literal(
+              "ORDER BY agent_mcp_server_configuration->agent_configuration.name"
             )
           ),
           "sIds",
@@ -1085,6 +1197,9 @@ export async function getDataSourceViewUsage({
             "array_agg",
             Sequelize.col(
               "agent_tables_query_configuration->agent_configuration.name"
+            ),
+            Sequelize.literal(
+              "ORDER BY agent_tables_query_configuration->agent_configuration.name"
             )
           ),
           "names",
@@ -1094,6 +1209,9 @@ export async function getDataSourceViewUsage({
             "array_agg",
             Sequelize.col(
               "agent_tables_query_configuration->agent_configuration.sId"
+            ),
+            Sequelize.literal(
+              "ORDER BY agent_tables_query_configuration->agent_configuration.name"
             )
           ),
           "sIds",
@@ -1127,24 +1245,28 @@ export async function getDataSourceViewUsage({
   ])) as unknown as { names: string[]; sIds: string[] }[] | null;
 
   if (!res) {
-    return new Ok({ count: 0, agentNames: [], agentConfigurationIds: [] });
+    return new Ok({ count: 0, agentConfigurationIdsToAgentNames: [] });
   } else {
-    const agentNames = uniq(
-      sortBy(
-        res
-          .reduce<string[]>((acc, r) => acc.concat(r.names), [])
-          .filter((t) => t && t.length > 0)
+    const agents = res
+      .flatMap((r) =>
+        r.sIds.map((sId, index) => ({
+          sId,
+          name: r.names[index],
+        }))
       )
-    );
-    const agentConfigurationIds = [
-      ...new Set(
-        res.flatMap((r) => r.sIds).filter((sId) => sId && sId.length > 0)
-      ),
-    ];
+      .filter(
+        (agent) =>
+          agent.sId &&
+          agent.sId.length > 0 &&
+          agent.name &&
+          agent.name.length > 0
+      );
+
+    const sortedAgents = sortBy(uniqBy(agents, "sId"), "name");
+
     return new Ok({
-      count: agentNames.length,
-      agentNames,
-      agentConfigurationIds,
+      count: sortedAgents.length,
+      agentConfigurationIdsToAgentNames: sortedAgents,
     });
   }
 }

--- a/front/lib/api/agent_data_sources.ts
+++ b/front/lib/api/agent_data_sources.ts
@@ -858,7 +858,7 @@ export async function getDataSourceUsage({
               "agent_tables_query_configuration->agent_configuration.id"
             )
           ),
-          "names",
+          "ids",
         ],
       ],
       where: {

--- a/front/lib/api/agent_data_sources.ts
+++ b/front/lib/api/agent_data_sources.ts
@@ -144,10 +144,10 @@ export async function getDataSourceViewsUsageByCategory({
           Sequelize.fn(
             "array_agg",
             Sequelize.col(
-              "agent_retrieval_configuration->agent_configuration.id"
+              "agent_retrieval_configuration->agent_configuration.sId"
             )
           ),
-          "ids",
+          "sIds",
         ],
       ],
       include: [
@@ -197,9 +197,11 @@ export async function getDataSourceViewsUsageByCategory({
         [
           Sequelize.fn(
             "array_agg",
-            Sequelize.col("agent_process_configuration->agent_configuration.id")
+            Sequelize.col(
+              "agent_process_configuration->agent_configuration.sId"
+            )
           ),
-          "ids",
+          "sIds",
         ],
       ],
       include: [
@@ -250,10 +252,10 @@ export async function getDataSourceViewsUsageByCategory({
           Sequelize.fn(
             "array_agg",
             Sequelize.col(
-              "agent_mcp_server_configuration->agent_configuration.id"
+              "agent_mcp_server_configuration->agent_configuration.sId"
             )
           ),
-          "ids",
+          "sIds",
         ],
       ],
       include: [
@@ -304,10 +306,10 @@ export async function getDataSourceViewsUsageByCategory({
           Sequelize.fn(
             "array_agg",
             Sequelize.col(
-              "agent_tables_query_configuration->agent_configuration.id"
+              "agent_tables_query_configuration->agent_configuration.sId"
             )
           ),
-          "ids",
+          "sIds",
         ],
       ],
       include: [
@@ -351,7 +353,7 @@ export async function getDataSourceViewsUsageByCategory({
   ])) as unknown as {
     dataSourceViewId: ModelId;
     names: string[];
-    ids: number[];
+    sIds: string[];
   }[][];
 
   return res.flat().reduce<DataSourcesUsageByAgent>((acc, dsViewConfig) => {
@@ -370,7 +372,9 @@ export async function getDataSourceViewsUsageByCategory({
       .filter((t) => t && t.length > 0);
     usage.agentNames = uniq(sortBy(usage.agentNames));
     usage.agentConfigurationIds = [
-      ...new Set(usage.agentConfigurationIds.filter((id) => id > 0)),
+      ...new Set(
+        usage.agentConfigurationIds.filter((sId) => sId && sId.length > 0)
+      ),
     ];
 
     usage.count = usage.agentNames.length;
@@ -435,10 +439,10 @@ export async function getDataSourcesUsageByCategory({
           Sequelize.fn(
             "array_agg",
             Sequelize.col(
-              "agent_retrieval_configuration->agent_configuration.id"
+              "agent_retrieval_configuration->agent_configuration.sId"
             )
           ),
-          "ids",
+          "sIds",
         ],
       ],
       include: [
@@ -491,9 +495,11 @@ export async function getDataSourcesUsageByCategory({
         [
           Sequelize.fn(
             "array_agg",
-            Sequelize.col("agent_process_configuration->agent_configuration.id")
+            Sequelize.col(
+              "agent_process_configuration->agent_configuration.sId"
+            )
           ),
-          "ids",
+          "sIds",
         ],
       ],
       include: [
@@ -547,10 +553,10 @@ export async function getDataSourcesUsageByCategory({
           Sequelize.fn(
             "array_agg",
             Sequelize.col(
-              "agent_mcp_server_configuration->agent_configuration.id"
+              "agent_mcp_server_configuration->agent_configuration.sId"
             )
           ),
-          "ids",
+          "sIds",
         ],
       ],
       include: [
@@ -604,10 +610,10 @@ export async function getDataSourcesUsageByCategory({
           Sequelize.fn(
             "array_agg",
             Sequelize.col(
-              "agent_tables_query_configuration->agent_configuration.id"
+              "agent_tables_query_configuration->agent_configuration.sId"
             )
           ),
-          "ids",
+          "sIds",
         ],
       ],
       include: [
@@ -643,7 +649,7 @@ export async function getDataSourcesUsageByCategory({
   ])) as unknown as {
     dataSourceId: ModelId;
     names: string[];
-    ids: number[];
+    sIds: string[];
   }[][];
 
   return res.flat().reduce<DataSourcesUsageByAgent>((acc, dsConfig) => {
@@ -661,7 +667,9 @@ export async function getDataSourcesUsageByCategory({
       .filter((t) => t && t.length > 0);
     usage.agentNames = uniq(sortBy(usage.agentNames));
     usage.agentConfigurationIds = [
-      ...new Set(usage.agentConfigurationIds.filter((id) => id > 0)),
+      ...new Set(
+        usage.agentConfigurationIds.filter((sId) => sId && sId.length > 0)
+      ),
     ];
 
     usage.count = usage.agentNames.length;
@@ -708,10 +716,10 @@ export async function getDataSourceUsage({
           Sequelize.fn(
             "array_agg",
             Sequelize.col(
-              "agent_retrieval_configuration->agent_configuration.id"
+              "agent_retrieval_configuration->agent_configuration.sId"
             )
           ),
-          "ids",
+          "sIds",
         ],
       ],
       where: {
@@ -754,9 +762,11 @@ export async function getDataSourceUsage({
         [
           Sequelize.fn(
             "array_agg",
-            Sequelize.col("agent_process_configuration->agent_configuration.id")
+            Sequelize.col(
+              "agent_process_configuration->agent_configuration.sId"
+            )
           ),
-          "ids",
+          "sIds",
         ],
       ],
       where: {
@@ -800,10 +810,10 @@ export async function getDataSourceUsage({
           Sequelize.fn(
             "array_agg",
             Sequelize.col(
-              "agent_mcp_server_configuration->agent_configuration.id"
+              "agent_mcp_server_configuration->agent_configuration.sId"
             )
           ),
-          "ids",
+          "sIds",
         ],
       ],
       where: {
@@ -847,10 +857,10 @@ export async function getDataSourceUsage({
           Sequelize.fn(
             "array_agg",
             Sequelize.col(
-              "agent_tables_query_configuration->agent_configuration.id"
+              "agent_tables_query_configuration->agent_configuration.sId"
             )
           ),
-          "ids",
+          "sIds",
         ],
       ],
       where: {
@@ -878,7 +888,7 @@ export async function getDataSourceUsage({
         },
       ],
     }),
-  ])) as unknown as { names: string[]; ids: number[] }[] | null;
+  ])) as unknown as { names: string[]; sIds: string[] }[] | null;
 
   if (!res) {
     return new Ok({ count: 0, agentNames: [], agentConfigurationIds: [] });
@@ -891,7 +901,9 @@ export async function getDataSourceUsage({
       )
     );
     const agentConfigurationIds = [
-      ...new Set(res.flatMap((r) => r.ids).filter((id) => id > 0)),
+      ...new Set(
+        res.flatMap((r) => r.sIds).filter((sId) => sId && sId.length > 0)
+      ),
     ];
     return new Ok({
       count: agentNames.length,
@@ -938,10 +950,10 @@ export async function getDataSourceViewUsage({
           Sequelize.fn(
             "array_agg",
             Sequelize.col(
-              "agent_retrieval_configuration->agent_configuration.id"
+              "agent_retrieval_configuration->agent_configuration.sId"
             )
           ),
-          "ids",
+          "sIds",
         ],
       ],
       where: {
@@ -984,9 +996,11 @@ export async function getDataSourceViewUsage({
         [
           Sequelize.fn(
             "array_agg",
-            Sequelize.col("agent_process_configuration->agent_configuration.id")
+            Sequelize.col(
+              "agent_process_configuration->agent_configuration.sId"
+            )
           ),
-          "ids",
+          "sIds",
         ],
       ],
       where: {
@@ -1030,10 +1044,10 @@ export async function getDataSourceViewUsage({
           Sequelize.fn(
             "array_agg",
             Sequelize.col(
-              "agent_mcp_server_configuration->agent_configuration.id"
+              "agent_mcp_server_configuration->agent_configuration.sId"
             )
           ),
-          "ids",
+          "sIds",
         ],
       ],
       where: {
@@ -1077,10 +1091,10 @@ export async function getDataSourceViewUsage({
           Sequelize.fn(
             "array_agg",
             Sequelize.col(
-              "agent_tables_query_configuration->agent_configuration.id"
+              "agent_tables_query_configuration->agent_configuration.sId"
             )
           ),
-          "ids",
+          "sIds",
         ],
       ],
       where: {
@@ -1108,7 +1122,7 @@ export async function getDataSourceViewUsage({
         },
       ],
     }),
-  ])) as unknown as { names: string[]; ids: number[] }[] | null;
+  ])) as unknown as { names: string[]; sIds: string[] }[] | null;
 
   if (!res) {
     return new Ok({ count: 0, agentNames: [], agentConfigurationIds: [] });
@@ -1121,7 +1135,9 @@ export async function getDataSourceViewUsage({
       )
     );
     const agentConfigurationIds = [
-      ...new Set(res.flatMap((r) => r.ids).filter((id) => id > 0)),
+      ...new Set(
+        res.flatMap((r) => r.sIds).filter((sId) => sId && sId.length > 0)
+      ),
     ];
     return new Ok({
       count: agentNames.length,

--- a/front/lib/api/agent_data_sources.ts
+++ b/front/lib/api/agent_data_sources.ts
@@ -898,13 +898,9 @@ export async function getDataSourceUsage({
           .filter((t) => t && t.length > 0)
       )
     );
-    const agentConfigurationIds = uniq(
-      sortBy(
-        res
-          .reduce<number[]>((acc, r) => acc.concat(r.ids), [])
-          .filter((t) => t && t > 0)
-      )
-    );
+    const agentConfigurationIds = [
+      ...new Set(res.flatMap((r) => r.ids).filter((id) => id > 0)),
+    ];
     return new Ok({
       count: agentNames.length,
       agentNames,
@@ -1132,13 +1128,9 @@ export async function getDataSourceViewUsage({
           .filter((t) => t && t.length > 0)
       )
     );
-    const agentConfigurationIds = uniq(
-      sortBy(
-        res
-          .reduce<number[]>((acc, r) => acc.concat(r.ids), [])
-          .filter((t) => t && t > 0)
-      )
-    );
+    const agentConfigurationIds = [
+      ...new Set(res.flatMap((r) => r.ids).filter((id) => id > 0)),
+    ];
     return new Ok({
       count: agentNames.length,
       agentNames,

--- a/front/lib/api/agent_data_sources.ts
+++ b/front/lib/api/agent_data_sources.ts
@@ -914,6 +914,7 @@ export async function getDataSourceUsage({
     return new Ok({ count: 0, agents: [] });
   } else {
     const agents = res
+      .filter((r) => r && Array.isArray(r.sIds) && Array.isArray(r.names))
       .flatMap((r) =>
         r.sIds.map((sId, index) => ({
           sId,
@@ -1152,6 +1153,7 @@ export async function getDataSourceViewUsage({
     return new Ok({ count: 0, agents: [] });
   } else {
     const agents = res
+      .filter((r) => r && Array.isArray(r.sIds) && Array.isArray(r.names))
       .flatMap((r) =>
         r.sIds.map((sId, index) => ({
           sId,

--- a/front/lib/api/agent_data_sources.ts
+++ b/front/lib/api/agent_data_sources.ts
@@ -1,4 +1,4 @@
-import { sortBy, uniq, uniqBy } from "lodash";
+import { sortBy, uniqBy } from "lodash";
 import type { WhereAttributeHashValue } from "sequelize";
 import { Op, Sequelize } from "sequelize";
 

--- a/front/lib/api/apps.ts
+++ b/front/lib/api/apps.ts
@@ -14,7 +14,8 @@ export async function softDeleteApp(
   if (usage.isErr()) {
     return usage;
   } else if (usage.value.count > 0) {
-    const { agentNames } = usage.value;
+    const { agents } = usage.value;
+    const agentNames = agents.map((a) => a.name);
     return new Err(
       new Error(
         "Cannot delete app in use by " +

--- a/front/lib/api/spaces.ts
+++ b/front/lib/api/spaces.ts
@@ -61,7 +61,11 @@ export async function softDeleteSpaceAndLaunchScrubWorkflow(
   }
 
   if (usages.length > 0) {
-    const agentNames = uniq(usages.map((u) => u.agentNames).flat());
+    const agentNames = uniq(
+      usages
+        .flatMap((u) => u.agentConfigurationIdsToAgentNames)
+        .map((agent) => agent.name)
+    );
     return new Err(
       new Error(
         `Cannot delete space with data source or app in use by agent(s): ${agentNames.join(", ")}.`

--- a/front/lib/api/spaces.ts
+++ b/front/lib/api/spaces.ts
@@ -62,9 +62,7 @@ export async function softDeleteSpaceAndLaunchScrubWorkflow(
 
   if (usages.length > 0) {
     const agentNames = uniq(
-      usages
-        .flatMap((u) => u.agentConfigurationIdsToAgentNames)
-        .map((agent) => agent.name)
+      usages.flatMap((u) => u.agents).map((agent) => agent.name)
     );
     return new Err(
       new Error(

--- a/front/lib/resources/app_resource.ts
+++ b/front/lib/resources/app_resource.ts
@@ -129,7 +129,7 @@ export class AppResource extends ResourceWithSpace<AppModel> {
       },
     });
 
-    const agentConfigurationIdsToAgentNames = sortBy(
+    const agents = sortBy(
       [
         ...new Set(
           agentConfigurations.map((a) => ({
@@ -142,8 +142,8 @@ export class AppResource extends ResourceWithSpace<AppModel> {
     );
 
     return new Ok({
-      count: agentConfigurationIdsToAgentNames.length,
-      agentConfigurationIdsToAgentNames,
+      count: agents.length,
+      agents,
     });
   }
 

--- a/front/lib/resources/app_resource.ts
+++ b/front/lib/resources/app_resource.ts
@@ -132,7 +132,15 @@ export class AppResource extends ResourceWithSpace<AppModel> {
       ...new Set(agentConfigurations.map((a) => a.name)),
     ].sort();
 
-    return new Ok({ count: agentNames.length, agentNames });
+    const agentConfigurationIds = [
+      ...new Set(agentConfigurations.map((a) => a.id)),
+    ];
+
+    return new Ok({
+      count: agentNames.length,
+      agentNames,
+      agentConfigurationIds,
+    });
   }
 
   // Clone.

--- a/front/lib/resources/app_resource.ts
+++ b/front/lib/resources/app_resource.ts
@@ -1,4 +1,5 @@
 import assert from "assert";
+import { sortBy } from "lodash";
 import type { Attributes, CreationAttributes, ModelStatic } from "sequelize";
 import { Op } from "sequelize";
 
@@ -17,7 +18,6 @@ import type { ResourceFindOptions } from "@app/lib/resources/types";
 import type { AppType, LightWorkspaceType, Result } from "@app/types";
 import type { SpecificationType } from "@app/types";
 import { Err, Ok } from "@app/types";
-import { sortBy } from "lodash";
 
 // Attributes are marked as read-only to reflect the stateless nature of our Resource.
 // This design will be moved up to BaseResource once we transition away from Sequelize.

--- a/front/lib/resources/app_resource.ts
+++ b/front/lib/resources/app_resource.ts
@@ -17,6 +17,7 @@ import type { ResourceFindOptions } from "@app/lib/resources/types";
 import type { AppType, LightWorkspaceType, Result } from "@app/types";
 import type { SpecificationType } from "@app/types";
 import { Err, Ok } from "@app/types";
+import { sortBy } from "lodash";
 
 // Attributes are marked as read-only to reflect the stateless nature of our Resource.
 // This design will be moved up to BaseResource once we transition away from Sequelize.
@@ -128,18 +129,21 @@ export class AppResource extends ResourceWithSpace<AppModel> {
       },
     });
 
-    const agentNames = [
-      ...new Set(agentConfigurations.map((a) => a.name)),
-    ].sort();
-
-    const agentConfigurationIds = [
-      ...new Set(agentConfigurations.map((a) => a.sId)),
-    ];
+    const agentConfigurationIdsToAgentNames = sortBy(
+      [
+        ...new Set(
+          agentConfigurations.map((a) => ({
+            sId: a.sId,
+            name: a.name,
+          }))
+        ),
+      ],
+      "name"
+    );
 
     return new Ok({
-      count: agentNames.length,
-      agentNames,
-      agentConfigurationIds,
+      count: agentConfigurationIdsToAgentNames.length,
+      agentConfigurationIdsToAgentNames,
     });
   }
 

--- a/front/lib/resources/app_resource.ts
+++ b/front/lib/resources/app_resource.ts
@@ -133,7 +133,7 @@ export class AppResource extends ResourceWithSpace<AppModel> {
     ].sort();
 
     const agentConfigurationIds = [
-      ...new Set(agentConfigurations.map((a) => a.id)),
+      ...new Set(agentConfigurations.map((a) => a.sId)),
     ];
 
     return new Ok({

--- a/front/lib/swr/assistants.ts
+++ b/front/lib/swr/assistants.ts
@@ -213,31 +213,6 @@ export function useUnifiedAgentConfigurations({
   };
 }
 
-export function useAgentConfigurationSIdLookup({
-  workspaceId,
-  agentConfigurationName,
-}: {
-  workspaceId: string;
-  agentConfigurationName: string | null;
-}) {
-  const sIdFetcher: Fetcher<{
-    sId: string;
-  }> = fetcher;
-
-  const { data, error } = useSWRWithDefaults(
-    agentConfigurationName
-      ? `/api/w/${workspaceId}/assistant/agent_configurations/lookup?handle=${agentConfigurationName}`
-      : null,
-    sIdFetcher
-  );
-
-  return {
-    sId: data ? data.sId : null,
-    isLoading: !error && !data,
-    isError: error,
-  };
-}
-
 export function useAgentConfiguration({
   workspaceId,
   agentConfigurationId,

--- a/front/pages/api/poke/workspaces/[wId]/data_sources/[dsId]/index.ts
+++ b/front/pages/api/poke/workspaces/[wId]/data_sources/[dsId]/index.ts
@@ -80,7 +80,9 @@ async function handler(
       const viewsUsedByAgentsName = viewsUsageByAgentsRes.reduce(
         (acc, usageRes) => {
           if (usageRes.isOk() && usageRes.value.count > 0) {
-            usageRes.value.agentNames.forEach((name) => acc.add(name));
+            usageRes.value.agents
+              .map((a) => a.name)
+              .forEach((name) => acc.add(name));
           }
 
           return acc;

--- a/front/pages/api/w/[wId]/spaces/[spaceId]/data_source_views/[dsvId]/index.ts
+++ b/front/pages/api/w/[wId]/spaces/[spaceId]/data_source_views/[dsvId]/index.ts
@@ -127,7 +127,7 @@ async function handler(
             api_error: {
               type: "data_source_error",
               message: usageRes.isOk()
-                ? `The data source view is in use by ${usageRes.value.agentNames.join(", ")} and cannot be deleted.`
+                ? `The data source view is in use by ${usageRes.value.agents.map((a) => a.name).join(", ")} and cannot be deleted.`
                 : "The data source view is in use and cannot be deleted.",
             },
           });

--- a/front/pages/api/w/[wId]/spaces/[spaceId]/data_source_views/index.ts
+++ b/front/pages/api/w/[wId]/spaces/[spaceId]/data_source_views/index.ts
@@ -119,8 +119,7 @@ async function handler(
                   },
                   usage: usages[dataSourceView.id] || {
                     count: 0,
-                    agentNames: [],
-                    agentConfigurationIds: [],
+                    agents: [],
                   },
                 };
               }
@@ -132,8 +131,7 @@ async function handler(
                 dataSource: augmentedDataSource,
                 usage: usages[dataSourceView.id] || {
                   count: 0,
-                  agentNames: [],
-                  agentConfigurationIds: [],
+                  agents: [],
                 },
               };
             })

--- a/front/pages/api/w/[wId]/spaces/[spaceId]/data_source_views/index.ts
+++ b/front/pages/api/w/[wId]/spaces/[spaceId]/data_source_views/index.ts
@@ -120,6 +120,7 @@ async function handler(
                   usage: usages[dataSourceView.id] || {
                     count: 0,
                     agentNames: [],
+                    agentConfigurationIds: [],
                   },
                 };
               }
@@ -132,6 +133,7 @@ async function handler(
                 usage: usages[dataSourceView.id] || {
                   count: 0,
                   agentNames: [],
+                  agentConfigurationIds: [],
                 },
               };
             })

--- a/front/pages/api/w/[wId]/spaces/[spaceId]/index.ts
+++ b/front/pages/api/w/[wId]/spaces/[spaceId]/index.ts
@@ -1,6 +1,6 @@
 import { isLeft } from "fp-ts/lib/Either";
 import * as reporter from "io-ts-reporters";
-import { uniq, uniqBy } from "lodash";
+import { uniqBy } from "lodash";
 import type { NextApiRequest, NextApiResponse } from "next";
 
 import { getDataSourceViewsUsageByCategory } from "@app/lib/api/agent_data_sources";

--- a/front/pages/api/w/[wId]/spaces/[spaceId]/index.ts
+++ b/front/pages/api/w/[wId]/spaces/[spaceId]/index.ts
@@ -68,8 +68,7 @@ async function handler(
           count: 0,
           usage: {
             count: 0,
-            agentNames: [],
-            agentConfigurationIds: [],
+            agents: [],
           },
         };
 
@@ -86,19 +85,20 @@ async function handler(
 
           for (const dsView of dataSourceViewsInCategory) {
             categories[category].count += 1;
-
             const usage = usages[dsView.id];
 
             if (usage) {
-              categories[category].usage.agentNames = categories[
+              categories[category].usage.agents = categories[
                 category
-              ].usage.agentNames.concat(usage.agentNames);
-              categories[category].usage.agentNames = uniq(
-                categories[category].usage.agentNames
+              ].usage.agents.concat(usage.agents);
+              categories[category].usage.agents = uniqBy(
+                categories[category].usage.agents,
+                "sId"
               );
-              categories[category].usage.count += usage.count;
             }
           }
+          categories[category].usage.count =
+            categories[category].usage.agents.length;
         }
       }
 

--- a/front/pages/api/w/[wId]/spaces/[spaceId]/index.ts
+++ b/front/pages/api/w/[wId]/spaces/[spaceId]/index.ts
@@ -69,6 +69,7 @@ async function handler(
           usage: {
             count: 0,
             agentNames: [],
+            agentConfigurationIds: [],
           },
         };
 

--- a/front/types/data_source.ts
+++ b/front/types/data_source.ts
@@ -65,7 +65,7 @@ export type DataSourceWithConnectorDetailsType = DataSourceType &
 export type DataSourceWithAgentsUsageType = {
   count: number;
 
-  agentConfigurationIds: ModelId[];
+  agentConfigurationIds: string[];
   agentNames: string[];
 };
 

--- a/front/types/data_source.ts
+++ b/front/types/data_source.ts
@@ -65,7 +65,7 @@ export type DataSourceWithConnectorDetailsType = DataSourceType &
 export type DataSourceWithAgentsUsageType = {
   count: number;
 
-  agentConfigurationIdsToAgentNames: Array<{ sId: string; name: string }>;
+  agents: Array<{ sId: string; name: string }>;
 };
 
 export function isDataSourceNameValid(name: string): Result<void, string> {

--- a/front/types/data_source.ts
+++ b/front/types/data_source.ts
@@ -65,8 +65,7 @@ export type DataSourceWithConnectorDetailsType = DataSourceType &
 export type DataSourceWithAgentsUsageType = {
   count: number;
 
-  agentConfigurationIds: string[];
-  agentNames: string[];
+  agentConfigurationIdsToAgentNames: Array<{ sId: string; name: string }>;
 };
 
 export function isDataSourceNameValid(name: string): Result<void, string> {

--- a/front/types/data_source.ts
+++ b/front/types/data_source.ts
@@ -64,6 +64,8 @@ export type DataSourceWithConnectorDetailsType = DataSourceType &
 
 export type DataSourceWithAgentsUsageType = {
   count: number;
+
+  agentConfigurationIds: ModelId[];
   agentNames: string[];
 };
 

--- a/front/types/data_source.ts
+++ b/front/types/data_source.ts
@@ -64,7 +64,6 @@ export type DataSourceWithConnectorDetailsType = DataSourceType &
 
 export type DataSourceWithAgentsUsageType = {
   count: number;
-
   agents: Array<{ sId: string; name: string }>;
 };
 


### PR DESCRIPTION
## Description

Add agent configuration ids to data source with agents usage type.

## Tests

manually tested.
- created agent pointing to a datasource
- published said agent
- killed agent

## Risk

lots. I could break anything in the typing system.

## Deploy Plan

Deploy front.