### PR TITLE
[front] fix(groups): Filter proper group to show active user in the given space

### DIFF
--- a/front/pages/api/w/[wId]/spaces/[spaceId]/index.ts
+++ b/front/pages/api/w/[wId]/spaces/[spaceId]/index.ts
@@ -107,7 +107,16 @@ async function handler(
       const currentMembers = uniqBy(
         (
           await concurrentExecutor(
-            space.groups,
+            // Filter the correct group, if we switch back and forth, the space will have 2 group
+            // one provisioned and one regular.
+            // If a user manully remove users from the regular group, they might still appear as they
+            // would still be in the provisioned group
+            space.groups.filter((g) => {
+              if (space.managementMode === "group") {
+                return g.kind === "provisioned";
+              }
+              return g.kind === "regular";
+            }),
             (group) => group.getActiveMembers(auth),
             { concurrency: 10 }
           )


### PR DESCRIPTION
## Description
- https://github.com/dust-tt/tasks/issues/3225
Issue was we were building the list of active user in a space with all groups related to the space. If the space has a provisioned and regular group, and a user is part of the provisioned group, we can remove the user all we want from the regular group, they'll still be included as they're part of the provisioned group.
So solution: filtering the group based on the `managementMode` of the space.

## Tests
- Locally

## Risk
- Low, easy to revert

## Deploy Plan
- Deploy front
