### PR TITLE
Slack OAuth provider: introduce use-cases routing

### DIFF
--- a/core/src/oauth/providers/slack.rs
+++ b/core/src/oauth/providers/slack.rs
@@ -19,6 +19,21 @@ use std::env;
 lazy_static! {
     static ref OAUTH_SLACK_CLIENT_ID: String = env::var("OAUTH_SLACK_CLIENT_ID").unwrap();
     static ref OAUTH_SLACK_CLIENT_SECRET: String = env::var("OAUTH_SLACK_CLIENT_SECRET").unwrap();
+    static ref OAUTH_SLACK_BOT_CLIENT_ID: String =
+        env::var("OAUTH_SLACK_BOT_CLIENT_ID").expect("OAUTH_SLACK_BOT_CLIENT_ID must be set");
+    static ref OAUTH_SLACK_BOT_CLIENT_SECRET: String = env::var("OAUTH_SLACK_BOT_CLIENT_SECRET")
+        .expect("OAUTH_SLACK_BOT_CLIENT_SECRET must be set");
+}
+
+/// We support three Slack apps. Our default `connection` app (for data source connections) a
+/// `personal_actions` app (for personal MCP server interactions) and a `bot` app (for interactions
+/// with Dust from Slack).
+#[derive(Debug, PartialEq, Clone)]
+pub enum SlackUseCase {
+    Connection,
+    Bot,
+    PersonalActions, // (personal tools setup)
+    PlatformActions, // (admin setup)
 }
 
 pub struct SlackConnectionProvider {}
@@ -28,11 +43,25 @@ impl SlackConnectionProvider {
         SlackConnectionProvider {}
     }
 
-    fn basic_auth(&self) -> String {
-        general_purpose::STANDARD.encode(&format!(
-            "{}:{}",
-            *OAUTH_SLACK_CLIENT_ID, *OAUTH_SLACK_CLIENT_SECRET
-        ))
+    fn basic_auth(&self, app_type: SlackUseCase) -> String {
+        match app_type {
+            SlackUseCase::Connection => general_purpose::STANDARD.encode(&format!(
+                "{}:{}",
+                *OAUTH_SLACK_CLIENT_ID, *OAUTH_SLACK_CLIENT_SECRET
+            )),
+            SlackUseCase::Bot => general_purpose::STANDARD.encode(&format!(
+                "{}:{}",
+                *OAUTH_SLACK_BOT_CLIENT_ID, *OAUTH_SLACK_BOT_CLIENT_SECRET
+            )),
+            // TODO(spolu): the tools related use-cases are currently supported by the main app as
+            // connections but this will be migrated soon to a new app.
+            SlackUseCase::PlatformActions | SlackUseCase::PersonalActions => {
+                general_purpose::STANDARD.encode(&format!(
+                    "{}:{}",
+                    *OAUTH_SLACK_CLIENT_ID, *OAUTH_SLACK_CLIENT_SECRET
+                ))
+            }
+        }
     }
 }
 
@@ -44,16 +73,30 @@ impl Provider for SlackConnectionProvider {
 
     async fn finalize(
         &self,
-        _connection: &Connection,
+        connection: &Connection,
         _related_credentials: Option<Credential>,
         code: &str,
         redirect_uri: &str,
     ) -> Result<FinalizeResult, ProviderError> {
+        let app_type = match connection.metadata()["use_case"].as_str() {
+            Some(use_case) => match use_case {
+                "connection" => SlackUseCase::Connection,
+                "bot" => SlackUseCase::Bot,
+                "platform_actions" => SlackUseCase::PlatformActions,
+                "personal_actions" => SlackUseCase::PersonalActions,
+                _ => Err(anyhow!("Slack use_case format invalid"))?,
+            },
+            None => Err(anyhow!("Slack use_case missing"))?,
+        };
+
         let req = self
             .reqwest_client()
             .post("https://slack.com/api/oauth.v2.access")
             .header("Content-Type", "application/x-www-form-urlencoded")
-            .header("Authorization", format!("Basic {}", self.basic_auth()))
+            .header(
+                "Authorization",
+                format!("Basic {}", self.basic_auth(app_type)),
+            )
             // Very important, this will *not* work with JSON body.
             .form(&[("code", code), ("redirect_uri", redirect_uri)]);
 


### PR DESCRIPTION
## Description

We already have `use_case: connection` set in metadata for all legacy connections.
The newly introduced `use_case: bot` is not used for now.
The `personal_actions` and `platform_actions` 

Note we will add `bot` as a new OAuthUseCase in front that will be reusable by other providers in the future (eg notion bot that responds to mentions in comments...). In the product we've floated the word "integrations" for these but this felt a bit too generic here so I'm sticking with a simple "bot".

## Tests

Relying on type checker

## Risk

None. 

`use_case:connection` already passed through and exists on all `slack` connections.
We have 2 MCP slack server in production that are OK to break but they will continue functioning here as we do pass correctly the use cases already.

## Deploy Plan

- deploy `core`