### PR TITLE
[front] fix(paste-url): normalize Zendesk ticket URLs

### DIFF
--- a/extension/shared/lib/connectors.ts
+++ b/extension/shared/lib/connectors.ts
@@ -171,7 +171,11 @@ const providers: Partial<Record<ConnectorProvider, Provider>> = {
       const path = url.pathname.endsWith("/")
         ? url.pathname.slice(0, -1)
         : url.pathname;
-      return { url: `${url.origin}${path}`, provider: "zendesk" };
+      // Zendesk ticket URL can contain /agent/ in the path if viewed from the agent page.
+      return {
+        url: `${url.origin}${path.replace("/agent", "")}`,
+        provider: "zendesk",
+      };
     },
   },
   intercom: {

--- a/front/lib/connectors.ts
+++ b/front/lib/connectors.ts
@@ -256,7 +256,11 @@ const providers: Partial<Record<ConnectorProvider, Provider>> = {
       const path = url.pathname.endsWith("/")
         ? url.pathname.slice(0, -1)
         : url.pathname;
-      return { url: `${url.origin}${path}`, provider: "zendesk" };
+      // Zendesk ticket URL can contain /agent/ in the path if viewed from the agent page.
+      return {
+        url: `${url.origin}${path.replace("/agent", "")}`,
+        provider: "zendesk",
+      };
     },
   },
   intercom: {


### PR DESCRIPTION
## Description

- Zendesk ticket URL can contain `/agent` in their path depending on where they are viewed from.
- The data we sync does not contain the `/agent` part.
- This PR normalizes the URL pasted into the input bar to remove it and allow matches on URL that contain this part.

## Tests

## Risk

- Low.

## Deploy Plan

- Deploy front.
