### PR TITLE
Data retention workflow: update to add agent data retention feature

### DIFF
--- a/front/lib/models/assistant/agent_data_retention.ts
+++ b/front/lib/models/assistant/agent_data_retention.ts
@@ -37,7 +37,7 @@ AgentDataRetentionModel.init(
     },
   },
   {
-    modelName: "agent_data_retention",
+    modelName: "agent_data_retentions",
     sequelize: frontSequelize,
     indexes: [
       {

--- a/front/migrations/db/migration_286.sql
+++ b/front/migrations/db/migration_286.sql
@@ -1,0 +1,1 @@
+DROP TABLE IF EXISTS "agent_data_retention";

--- a/front/migrations/db/migration_287.sql
+++ b/front/migrations/db/migration_287.sql
@@ -1,0 +1,13 @@
+-- Migration created on Jun 25, 2025
+CREATE TABLE IF NOT EXISTS "agent_data_retentions" (
+    "id" BIGSERIAL,
+    "createdAt" TIMESTAMP WITH TIME ZONE NOT NULL,
+    "updatedAt" TIMESTAMP WITH TIME ZONE NOT NULL,
+    "agentConfigurationId" TEXT NOT NULL,
+    "workspaceId" BIGINT NOT NULL REFERENCES "workspaces" ("id") ON DELETE RESTRICT ON UPDATE CASCADE,
+    "retentionDays" BIGINT NOT NULL CHECK ("retentionDays" > 0),
+    PRIMARY KEY ("id")
+);
+
+CREATE INDEX CONCURRENTLY "agent_data_retentions_agent_configuration_id" ON "agent_data_retentions" ("agentConfigurationId");
+CREATE UNIQUE INDEX "agent_data_retentions_unique_agent_workspace" ON "agent_data_retentions" ("workspaceId", "agentConfigurationId");

--- a/front/temporal/data_retention/activities.ts
+++ b/front/temporal/data_retention/activities.ts
@@ -2,10 +2,12 @@ import { Op } from "sequelize";
 
 import { destroyConversation } from "@app/lib/api/assistant/conversation/destroy";
 import { Authenticator } from "@app/lib/auth";
+import { AgentDataRetentionModel } from "@app/lib/models/assistant/agent_data_retention";
 import { ConversationResource } from "@app/lib/resources/conversation_resource";
 import { WorkspaceModel } from "@app/lib/resources/storage/models/workspace";
 import { concurrentExecutor } from "@app/lib/utils/async_utils";
 import logger from "@app/logger/logger";
+import type { ModelId } from "@app/types";
 
 /**
  * Get workspace ids with conversations retention policy.
@@ -94,4 +96,74 @@ export async function purgeConversationsBatchActivity({
   }
 
   return res;
+}
+
+/**
+ * Get agent configurations with conversations retention policy.
+ */
+export async function getAgentsWithConversationsRetentionActivity(): Promise<
+  {
+    agentConfigurationId: string;
+    workspaceId: ModelId;
+    retentionDays: number;
+  }[]
+> {
+  const agentRetentions = await AgentDataRetentionModel.findAll();
+  return agentRetentions.map((a) => ({
+    agentConfigurationId: a.agentConfigurationId,
+    workspaceId: a.workspaceId,
+    retentionDays: a.retentionDays,
+  }));
+}
+
+/**
+ * Purge conversations for an agent.
+ * We chunk the conversations to avoid hitting the database with too many queries at once.
+ */
+export async function purgeAgentConversationsBatchActivity({
+  agentConfigurationId,
+  workspaceId,
+  retentionDays,
+}: {
+  agentConfigurationId: string;
+  workspaceId: ModelId;
+  retentionDays: number;
+}): Promise<{
+  agentConfigurationId: string;
+  workspaceModelId: ModelId;
+  workspaceId: string;
+  retentionDays: number;
+  nbConversationsDeleted: number;
+}> {
+  const workspace = await WorkspaceModel.findByPk(workspaceId);
+  if (!workspace) {
+    throw new Error("Workspace not found");
+  }
+  const auth = await Authenticator.internalAdminForWorkspace(workspace.sId);
+
+  const cutoffDate = new Date();
+  cutoffDate.setDate(cutoffDate.getDate() - retentionDays);
+
+  const conversationIds =
+    await ConversationResource.listConversationWithAgentCreatedBeforeDate({
+      auth,
+      agentConfigurationId,
+      cutoffDate,
+    });
+
+  await concurrentExecutor(
+    conversationIds,
+    async (cId) => destroyConversation(auth, { conversationId: cId }),
+    {
+      concurrency: 4,
+    }
+  );
+
+  return {
+    agentConfigurationId,
+    workspaceModelId: workspace.id,
+    workspaceId: workspace.sId,
+    retentionDays,
+    nbConversationsDeleted: conversationIds.length,
+  };
 }

--- a/front/temporal/data_retention/config.ts
+++ b/front/temporal/data_retention/config.ts
@@ -1,3 +1,3 @@
-const QUEUE_VERSION = 1;
+const QUEUE_VERSION = 2;
 
 export const QUEUE_NAME = `data-retention-queue-v${QUEUE_VERSION}`;

--- a/front/temporal/data_retention/workflows.ts
+++ b/front/temporal/data_retention/workflows.ts
@@ -5,9 +5,11 @@ import type * as activities from "@app/temporal/data_retention/activities";
 
 import { runSignal } from "./signals";
 
-const { getWorkspacesWithConversationsRetentionActivity } = proxyActivities<
-  typeof activities
->({
+const {
+  getWorkspacesWithConversationsRetentionActivity,
+  getAgentsWithConversationsRetentionActivity,
+  purgeAgentConversationsBatchActivity,
+} = proxyActivities<typeof activities>({
   startToCloseTimeout: "5 minutes",
 });
 
@@ -20,12 +22,25 @@ export async function dataRetentionWorkflow(): Promise<void> {
     // Empty handler - just receiving the signal will trigger a workflow execution.
   });
 
+  // First the Workspace level data retention.
   const workspaceIds = await getWorkspacesWithConversationsRetentionActivity();
   const workspaceChunks = _.chunk(workspaceIds, 4);
 
   for (const workspaceChunk of workspaceChunks) {
     await purgeConversationsBatchActivity({
       workspaceIds: workspaceChunk,
+    });
+  }
+
+  // Then the Agent level data retention.
+  const agentsWithDataRetention =
+    await getAgentsWithConversationsRetentionActivity();
+
+  for (const agentWithDataRetention of agentsWithDataRetention) {
+    await purgeAgentConversationsBatchActivity({
+      agentConfigurationId: agentWithDataRetention.agentConfigurationId,
+      workspaceId: agentWithDataRetention.workspaceId,
+      retentionDays: agentWithDataRetention.retentionDays,
     });
   }
 }


### PR DESCRIPTION
## Description

Update the data retention workflow: 
After handling the workspace level data retention, we add one activity to fetch the agents that have a specific data retention set, and then we purge the conversation with this agent, if they were createdAt before the cutOffDate. 

## Tests

Locally. 

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

Merge. 
Run migrations.
Deploy front.
Stop data retention workflow
Restart it to be on v2.
