### PR TITLE
[connectors] perf(Zendesk): speed up incremental sync

### DIFF
--- a/connectors/src/connectors/zendesk/lib/zendesk_api.ts
+++ b/connectors/src/connectors/zendesk/lib/zendesk_api.ts
@@ -520,7 +520,7 @@ export function isUserAdmin(user: ZendeskFetchedUser): boolean {
 }
 
 /**
- * Fetches a multiple users at once from the Zendesk API.
+ * Fetches multiple users at once from the Zendesk API.
  * May run multiple queries, more precisely we need userCount // 100 + 1 API calls.
  */
 export async function listZendeskUsers({

--- a/connectors/src/connectors/zendesk/temporal/incremental_activities.ts
+++ b/connectors/src/connectors/zendesk/temporal/incremental_activities.ts
@@ -4,6 +4,7 @@ import {
   shouldSyncTicket,
   syncTicket,
 } from "@connectors/connectors/zendesk/lib/sync_ticket";
+import type { ZendeskFetchedTicketComment } from "@connectors/connectors/zendesk/lib/types";
 import { getZendeskSubdomainAndAccessToken } from "@connectors/connectors/zendesk/lib/zendesk_access_token";
 import {
   fetchZendeskCategory,
@@ -28,7 +29,6 @@ import {
 } from "@connectors/resources/zendesk_resources";
 import type { ModelId } from "@connectors/types";
 import { INTERNAL_MIME_TYPES } from "@connectors/types";
-import { ZendeskFetchedTicketComment } from "@connectors/connectors/zendesk/lib/types";
 
 /**
  * Retrieves the timestamp cursor, which is the start date of the last successful incremental sync.


### PR DESCRIPTION
## Description

- This PR speeds up the incremental sync by preventing the same users from being fetches once for every ticket comment they authored.

## Tests

- Tested locally.

## Risk

- Low.

## Deploy Plan

- Deploy connectors.
