### PR TITLE
[CLI] Add --message flag for non-interactive chat

### DIFF
--- a/cli/src/index.tsx
+++ b/cli/src/index.tsx
@@ -48,6 +48,11 @@ const cli = meow({
       shortFlag: "a",
       description: "Search for and use an agent by name",
     },
+    message: {
+      type: "string",
+      shortFlag: "m",
+      description: "Send a message to the agent non-interactively",
+    },
   },
 });
 

--- a/cli/src/ui/App.tsx
+++ b/cli/src/ui/App.tsx
@@ -38,6 +38,10 @@ interface AppProps {
       type: "string";
       shortFlag: "a";
     };
+    message: {
+      type: "string";
+      shortFlag: "m";
+    };
   }>;
 }
 
@@ -64,7 +68,7 @@ const App: FC<AppProps> = ({ cli }) => {
     case "agents-mcp":
       return <AgentsMCP port={flags.port} sId={flags.sId} />;
     case "chat":
-      return <Chat sId={flags.sId?.[0]} agentSearch={flags.agent} />;
+      return <Chat sId={flags.sId?.[0]} agentSearch={flags.agent} message={flags.message} />;
     case "cache:clear":
       return <Cache />;
     case "help":

--- a/cli/src/ui/Help.tsx
+++ b/cli/src/ui/Help.tsx
@@ -76,6 +76,11 @@ const Help: FC = () => {
           <Text bold>-a, --agent</Text> Search for and use an agent by name
         </Text>
       </Box>
+      <Box marginLeft={2}>
+        <Text>
+          <Text bold>-m, --message</Text> Send a message non-interactively (requires --agent)
+        </Text>
+      </Box>
     </Box>
   );
 };

--- a/cli/src/ui/commands/Chat.tsx
+++ b/cli/src/ui/commands/Chat.tsx
@@ -244,6 +244,11 @@ const CliChat: FC<CliChatProps> = ({ sId: requestedSId, agentSearch, message }) 
 
     // Automatically send the message in non-interactive mode
     async function sendNonInteractiveMessage() {
+      if (!message) {
+        // This should never happen due to the outer check, but TypeScript needs this
+        return;
+      }
+      
       if (!me || meError || isMeLoading) {
         console.error(JSON.stringify({ 
           error: "Authentication error",
@@ -270,7 +275,7 @@ const CliChat: FC<CliChatProps> = ({ sId: requestedSId, agentSearch, message }) 
           visibility: "unlisted",
           message: {
             content: message,
-            mentions: [{ configurationId: selectedAgent.sId }],
+            mentions: [{ configurationId: selectedAgent!.sId }],
             context: {
               timezone: Intl.DateTimeFormat().resolvedOptions().timeZone,
               username: me.username,
@@ -336,7 +341,7 @@ const CliChat: FC<CliChatProps> = ({ sId: requestedSId, agentSearch, message }) 
           } else if (event.type === "agent_message_success") {
             // Success - output the result
             console.log(JSON.stringify({
-              agentId: selectedAgent.sId,
+              agentId: selectedAgent!.sId,
               agentAnswer: fullResponse.trim(),
               conversationId: conversation.sId
             }));

--- a/cli/src/ui/commands/Chat.tsx
+++ b/cli/src/ui/commands/Chat.tsx
@@ -241,20 +241,26 @@ const CliChat: FC<CliChatProps> = ({ sId: requestedSId, agentSearch, message }) 
     if (!message || !selectedAgent || nonInteractiveComplete) {
       return;
     }
+    
+    // Wait for authentication to load
+    if (isMeLoading) {
+      return;
+    }
+    
+    // Check for authentication errors
+    if (!me || meError) {
+      console.error(JSON.stringify({ 
+        error: "Authentication error",
+        details: meError || "Not authenticated"
+      }));
+      process.exit(1);
+    }
 
     // Automatically send the message in non-interactive mode
     async function sendNonInteractiveMessage() {
       if (!message) {
         // This should never happen due to the outer check, but TypeScript needs this
         return;
-      }
-      
-      if (!me || meError || isMeLoading) {
-        console.error(JSON.stringify({ 
-          error: "Authentication error",
-          details: meError || "Not authenticated"
-        }));
-        process.exit(1);
       }
 
       setIsProcessingQuestion(true);

--- a/cli/src/ui/commands/Chat.tsx
+++ b/cli/src/ui/commands/Chat.tsx
@@ -1115,20 +1115,8 @@ const CliChat: FC<CliChatProps> = ({ sId: requestedSId, agentSearch, message }) 
 
   // In non-interactive mode, show minimal UI
   if (message) {
-    if (agentSearch && agentsIsLoading) {
-      return <Text>Searching for agent...</Text>;
-    }
-    if (error || agentsError) {
-      // Error already logged in useEffect
-      return null;
-    }
-    if (!selectedAgent) {
-      return <Text>Waiting for agent selection...</Text>;
-    }
-    if (isProcessingQuestion) {
-      return <Text>Processing message...</Text>;
-    }
-    // Non-interactive mode complete or processing
+    // Don't show any UI in non-interactive mode
+    // All output is handled via console.log/console.error in the useEffect
     return null;
   }
 


### PR DESCRIPTION
## Description

This PR is the second of a 3-step PR series to allow non-interactive use of the `dust` CLI chat.

The 3 PRs are:
1. ✅ Allow `dust chat --agent SEARCH_STRING` - searches for an agent matching SEARCH_STRING
2. **This PR**: Allow `dust chat --agent [agent-string] --message MESSAGE` - sends MESSAGE to the matched agent in a new conversation and returns JSON with agentId, agentAnswer, and conversationId non-interactively
3. Allow `dust chat --agent [agent-string] --message MESSAGE --conversationId CID` - sends MESSAGE to existing conversation CID

This PR implements step 2: the `--message` flag for non-interactive messaging.

### Implementation Details
- Added `--message` flag (shorthand `-m`) to CLI argument parsing
- Modified Chat component to detect non-interactive mode when message is provided
- Validates that `--message` requires `--agent` to be specified
- Automatically creates a conversation and sends the message without user interaction
- Streams the agent's response internally (not shown to user)
- Returns structured JSON response and exits
- Shows minimal UI during processing (no interactive elements)
- Proper error handling with JSON error responses and exit codes

### Usage
```bash
# Send a message and get JSON response
dust chat --agent "my agent" --message "What is the weather today?"

# Using shorthands
dust chat -a "agent" -m "Hello"
```

### Response Format
Success:
```json
{
  "agentId": "agent_sId",
  "agentAnswer": "The agent's response text",
  "conversationId": "conversation_sId"
}
```

Error:
```json
{
  "error": "Error type",
  "details": "Detailed error message"
}
```

## Risks

Blast radius: CLI chat functionality only
Risk: low

## Tests

- [ ] Build succeeds (`npm run build`) ✅
- [ ] Linting passes (`npm run lint`) ✅
- [ ] Test with valid agent and message - should return JSON response
- [ ] Test with invalid agent name - should return JSON error
- [ ] Test with --message but no --agent - should return validation error
- [ ] Test that normal interactive chat still works without --message flag
- [ ] Verify JSON output can be parsed by other tools

## Deploy Plan

No deployment steps required - CLI changes only.