### PR TITLE
[front] chore(FS tools): hide MCP server from Agent Builder

### DIFF
--- a/front/lib/actions/mcp_internal_actions/constants.ts
+++ b/front/lib/actions/mcp_internal_actions/constants.ts
@@ -268,9 +268,9 @@ export const INTERNAL_MCP_SERVERS: Record<
   data_sources_file_system: {
     id: 1010,
     availability: "auto",
-    isRestricted: ({ featureFlags }) => {
-      return !featureFlags.includes("dev_mcp_actions");
-    },
+    // This server is hidden for everyone, it is only available through the search tool
+    // when the advanced_search mode is enabled.
+    isRestricted: () => true,
   },
 };
 


### PR DESCRIPTION
## Description

- This PR hides the `data_sources_file_system` MCP server from the Agent Builder, making it available only through a toggle on the `search` tool.
- ~no more agent relying on it.

## Tests

## Risk

- N/A

## Deploy Plan

- Deploy front.
