### PR TITLE
Cache cookie refresh in redis to avoid race conditions

### DIFF
--- a/front/lib/api/redis.ts
+++ b/front/lib/api/redis.ts
@@ -23,8 +23,7 @@ export type RedisUsageTagsType =
   | "reasoning_generation"
   | "retry_agent_message"
   | "update_authors"
-  | "user_message_events"
-  | "workos_session_refresh";
+  | "user_message_events";
 
 export async function getRedisClient({
   origin,

--- a/front/lib/api/redis.ts
+++ b/front/lib/api/redis.ts
@@ -23,7 +23,8 @@ export type RedisUsageTagsType =
   | "reasoning_generation"
   | "retry_agent_message"
   | "update_authors"
-  | "user_message_events";
+  | "user_message_events"
+  | "workos_session_refresh";
 
 export async function getRedisClient({
   origin,

--- a/front/lib/api/workos/user.ts
+++ b/front/lib/api/workos/user.ts
@@ -5,6 +5,7 @@ import type {
   DirectoryUser as WorkOSDirectoryUser,
   RefreshSessionResponse,
   User as WorkOSUser,
+  WorkOS,
 } from "@workos-inc/node";
 import { sealData, unsealData } from "iron-session";
 import type {
@@ -64,7 +65,7 @@ export async function getWorkOSSession(
 
 export async function _getRefreshedCookie(
   workOSSessionCookie: string,
-  session: any,
+  session: ReturnType<WorkOS["userManagement"]["loadSealedSession"]>,
   organizationId: string | undefined,
   authenticationMethod: string | undefined,
   workspaceId: string | undefined,

--- a/front/lib/api/workos/user.ts
+++ b/front/lib/api/workos/user.ts
@@ -22,7 +22,7 @@ import { concurrentExecutor } from "@app/lib/utils/async_utils";
 import { cacheWithRedis } from "@app/lib/utils/cache";
 import logger from "@app/logger/logger";
 import type { LightWorkspaceType, Result } from "@app/types";
-import { Err, Ok } from "@app/types";
+import { Err, Ok, sha256 } from "@app/types";
 
 export type SessionCookie = {
   sessionData: string;
@@ -104,7 +104,7 @@ export async function _getRefreshedCookie(
 const getRefreshedCookie = cacheWithRedis(
   _getRefreshedCookie,
   (workOSSessionCookie) => {
-    return `workos_session_refresh:${workOSSessionCookie}`;
+    return `workos_session_refresh:${sha256(workOSSessionCookie)}`;
   },
   60 * 10 * 1000
 );

--- a/front/types/shared/utils/hashing.ts
+++ b/front/types/shared/utils/hashing.ts
@@ -4,6 +4,10 @@ export function md5(str: string): string {
   return crypto.createHash("md5").update(str).digest("hex");
 }
 
+export function sha256(str: string): string {
+  return crypto.createHash("sha256").update(str).digest("base64");
+}
+
 function saltedKey(key: string, size = 32): string {
   const { DUST_DEVELOPERS_SECRETS_SECRET } = process.env;
   return crypto


### PR DESCRIPTION
## Description

This stores the cookie in redis after a refresh to avoid re-refreshing multiple times. New cookie is always set to the client if it changed.

Note that race condition can still happen on a small window time, but is allowed by workos - refresh token can be called multiple time in a very short time range. Issue here : https://github.com/workos/authkit-nextjs/issues/28

Also removed the unneeded Max-Age. Session time is handled by workos.

## Tests

Tested locally 

## Risk

Can break session lifetime, can be rolledback.


## Deploy Plan

deploy front