### PR TITLE
Polish the components and flow of mcp servers

### DIFF
--- a/front/components/actions/MCPActionHeader.tsx
+++ b/front/components/actions/MCPActionHeader.tsx
@@ -1,26 +1,14 @@
-import { Chip } from "@dust-tt/sparkle";
-
 import type { AssistantBuilderMCPConfiguration } from "@app/components/assistant_builder/types";
 import { getMcpServerDisplayName } from "@app/lib/actions/mcp_helper";
 import { getAvatar } from "@app/lib/actions/mcp_icons";
 import type { MCPServerType } from "@app/lib/api/mcp";
-import type { MCPOAuthUseCase } from "@app/types";
 
 interface MCPActionHeaderProps {
   mcpServer: MCPServerType;
-  oAuthUseCase: MCPOAuthUseCase | null;
-  isConnected: boolean;
-  isConnectionsLoading: boolean;
   action?: AssistantBuilderMCPConfiguration;
 }
 
-export function MCPActionHeader({
-  mcpServer,
-  oAuthUseCase,
-  isConnected,
-  isConnectionsLoading,
-  action,
-}: MCPActionHeaderProps) {
+export function MCPActionHeader({ mcpServer, action }: MCPActionHeaderProps) {
   return (
     <div className="items-top flex flex-col gap-3 sm:flex-row">
       {getAvatar(mcpServer, "md")}
@@ -31,23 +19,6 @@ export function MCPActionHeader({
         <div className="line-clamp-1 overflow-hidden text-sm text-muted-foreground dark:text-muted-foreground-night">
           {mcpServer.description}
         </div>
-        {oAuthUseCase &&
-          !isConnectionsLoading &&
-          (isConnected ? (
-            <div className="pt-2">
-              <Chip color="success" size="xs">
-                Uses{" "}
-                {oAuthUseCase === "personal_actions" ? "personal" : "workspace"}{" "}
-                credentials
-              </Chip>
-            </div>
-          ) : (
-            <div className="pt-2">
-              <Chip color="warning" size="xs">
-                Requires authentication
-              </Chip>
-            </div>
-          ))}
       </div>
     </div>
   );

--- a/front/components/actions/mcp/ConnectMCPServerDialog.tsx
+++ b/front/components/actions/mcp/ConnectMCPServerDialog.tsx
@@ -204,11 +204,6 @@ export function ConnectMCPServerDialog({
         <DialogContainer>
           {authorization && (
             <MCPServerOAuthConnexion
-              remoteMCPServerUrl={
-                mcpServer && isRemoteMCPServerType(mcpServer)
-                  ? mcpServer.url
-                  : undefined
-              }
               useCase={useCase}
               setUseCase={setUseCase}
               authorization={authorization}
@@ -227,8 +222,8 @@ export function ConnectMCPServerDialog({
           }}
           rightButtonProps={{
             isLoading: isLoading,
-            label: authorization ? "Save & Connect" : "",
-            variant: "primary",
+            label: authorization ? "Setup connection" : "",
+            variant: "highlight",
             onClick: (e: React.MouseEvent<HTMLButtonElement>) => {
               e.preventDefault();
               e.stopPropagation();

--- a/front/components/actions/mcp/CreateMCPServerDialog.tsx
+++ b/front/components/actions/mcp/CreateMCPServerDialog.tsx
@@ -308,7 +308,6 @@ export function CreateMCPServerDialog({
           )}
           {authorization && (
             <MCPServerOAuthConnexion
-              remoteMCPServerUrl={remoteServerUrl}
               authorization={authorization}
               authCredentials={authCredentials}
               useCase={useCase}
@@ -324,12 +323,12 @@ export function CreateMCPServerDialog({
         <DialogFooter
           leftButtonProps={{
             label: "Cancel",
-            variant: "ghost",
+            variant: "outline",
           }}
           rightButtonProps={{
             isLoading,
-            label: authorization ? "Save & Connect" : "Save",
-            variant: "primary",
+            label: authorization ? "Setup connection" : "Save",
+            variant: "highlight",
             onClick: (e: React.MouseEvent<HTMLButtonElement>) => {
               e.preventDefault();
               e.stopPropagation();

--- a/front/components/actions/mcp/DeleteMCPServerDialog.tsx
+++ b/front/components/actions/mcp/DeleteMCPServerDialog.tsx
@@ -46,10 +46,13 @@ export function DeleteMCPServerDialog({
         <DialogContainer>
           <div>
             Are you sure you want to remove{" "}
-            <b>{getMcpServerDisplayName(mcpServer)}</b> ?
+            <span className="font-semibold">
+              {getMcpServerDisplayName(mcpServer)}
+            </span>{" "}
+            ?
           </div>
           <div className="mt-2">
-            <b>This action cannot be undone.</b>
+            <span className="font-semibold">This action cannot be undone.</span>
           </div>
         </DialogContainer>
         <DialogFooter

--- a/front/components/actions/mcp/DeleteMCPServerDialog.tsx
+++ b/front/components/actions/mcp/DeleteMCPServerDialog.tsx
@@ -1,0 +1,78 @@
+import {
+  Dialog,
+  DialogContainer,
+  DialogContent,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@dust-tt/sparkle";
+import { useState } from "react";
+
+import { getMcpServerDisplayName } from "@app/lib/actions/mcp_helper";
+import type { MCPServerType } from "@app/lib/api/mcp";
+import { useDeleteMCPServer } from "@app/lib/swr/mcp_servers";
+import type { WorkspaceType } from "@app/types";
+
+type DeleteMCPServerDialogProps = {
+  owner: WorkspaceType;
+  onClose: (deleted: boolean) => void;
+  mcpServer: MCPServerType;
+  isOpen: boolean;
+};
+
+export function DeleteMCPServerDialog({
+  owner,
+  mcpServer,
+  isOpen,
+  onClose,
+}: DeleteMCPServerDialogProps) {
+  const { deleteServer } = useDeleteMCPServer(owner);
+
+  const [isLoading, setIsLoading] = useState(false);
+
+  return (
+    <Dialog
+      open={isOpen}
+      onOpenChange={(open) => {
+        if (!open) {
+          onClose(false);
+        }
+      }}
+    >
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>Confirm Removal</DialogTitle>
+        </DialogHeader>
+        <DialogContainer>
+          <div>
+            Are you sure you want to remove{" "}
+            <b>{getMcpServerDisplayName(mcpServer)}</b> ?
+          </div>
+          <div className="mt-2">
+            <b>This action cannot be undone.</b>
+          </div>
+        </DialogContainer>
+        <DialogFooter
+          leftButtonProps={{
+            label: "Cancel",
+            disabled: isLoading,
+            variant: "outline",
+            onClick: onClose,
+          }}
+          rightButtonProps={{
+            isLoading,
+            label: "Remove",
+            variant: "warning",
+            disabled: isLoading,
+            onClick: async () => {
+              setIsLoading(true);
+              await deleteServer(mcpServer);
+              setIsLoading(false);
+              onClose(true);
+            },
+          }}
+        />
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/front/components/actions/mcp/MCPServerDetails.tsx
+++ b/front/components/actions/mcp/MCPServerDetails.tsx
@@ -1,13 +1,12 @@
 import {
   Button,
-  Dialog,
-  DialogContainer,
-  DialogContent,
-  DialogFooter,
-  DialogHeader,
-  DialogTitle,
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
   InformationCircleIcon,
   LockIcon,
+  MoreIcon,
   Sheet,
   SheetContainer,
   SheetContent,
@@ -19,20 +18,13 @@ import {
   TrashIcon,
 } from "@dust-tt/sparkle";
 import { VisuallyHidden } from "@radix-ui/react-visually-hidden";
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { useEffect, useState } from "react";
 
-import { ConnectMCPServerDialog } from "@app/components/actions/mcp/ConnectMCPServerDialog";
+import { DeleteMCPServerDialog } from "@app/components/actions/mcp/DeleteMCPServerDialog";
 import { MCPServerDetailsInfo } from "@app/components/actions/mcp/MCPServerDetailsInfo";
 import { MCPServerDetailsSharing } from "@app/components/actions/mcp/MCPServerDetailsSharing";
 import { MCPActionHeader } from "@app/components/actions/MCPActionHeader";
-import { getMcpServerDisplayName } from "@app/lib/actions/mcp_helper";
 import type { MCPServerType, MCPServerViewType } from "@app/lib/api/mcp";
-import {
-  useDeleteMCPServer,
-  useDeleteMCPServerConnection,
-  useMCPServer,
-  useMCPServerConnections,
-} from "@app/lib/swr/mcp_servers";
 import type { WorkspaceType } from "@app/types";
 
 type MCPServerDetailsProps = {
@@ -50,122 +42,31 @@ export function MCPServerDetails({
 }: MCPServerDetailsProps) {
   const [selectedTab, setSelectedTab] = useState<string>("info");
 
-  const serverType = mcpServerView?.serverType;
-
-  const { server: updatedMCPServer } = useMCPServer({
-    owner,
-    serverId: mcpServerView?.server.sId || "",
-    disabled: serverType !== "remote",
-  });
-
   useEffect(() => {
     if (isOpen) {
       setSelectedTab("info");
     }
   }, [isOpen]);
 
-  const effectiveMCPServer = useMemo(
-    () => updatedMCPServer || mcpServerView?.server,
-    [updatedMCPServer, mcpServerView?.server]
-  );
-
-  const authorization = useMemo(
-    () => effectiveMCPServer?.authorization,
-    [effectiveMCPServer?.authorization]
-  );
-  const { deleteServer } = useDeleteMCPServer(owner);
   const [mcpServerToDelete, setMCPServerToDelete] = useState<
     MCPServerType | undefined
   >();
 
-  const { connections, isConnectionsLoading } = useMCPServerConnections({
-    owner,
-    connectionType: "workspace",
-    disabled: !authorization,
-  });
-
-  const connection = useMemo(
-    () =>
-      connections.find(
-        (c) =>
-          c.internalMCPServerId === effectiveMCPServer?.sId ||
-          c.remoteMCPServerId === effectiveMCPServer?.sId
-      ),
-    [connections, effectiveMCPServer?.sId]
-  );
-
-  const [isLoading, setIsLoading] = useState(false);
-  const { deleteMCPServerConnection } = useDeleteMCPServerConnection({
-    owner,
-  });
-
-  const handleDeleteConnection = useCallback(() => {
-    if (!connection || !effectiveMCPServer) {
-      return;
-    }
-    void deleteMCPServerConnection({
-      connection,
-      mcpServer: effectiveMCPServer,
-    });
-  }, [deleteMCPServerConnection, connection, effectiveMCPServer]);
-
-  const [isConnectDialogOpen, setIsConnectDialogOpen] = useState(false);
-
   return (
     <>
-      <ConnectMCPServerDialog
-        owner={owner}
-        mcpServer={effectiveMCPServer ?? null}
-        setIsLoading={setIsLoading}
-        isOpen={isConnectDialogOpen}
-        setIsOpen={setIsConnectDialogOpen}
-      />
-      <Dialog
-        open={mcpServerToDelete !== undefined}
-        onOpenChange={(open) => {
-          if (!open) {
+      {mcpServerToDelete && (
+        <DeleteMCPServerDialog
+          owner={owner}
+          mcpServer={mcpServerToDelete}
+          isOpen={mcpServerToDelete !== undefined}
+          onClose={(deleted) => {
             setMCPServerToDelete(undefined);
-          }
-        }}
-      >
-        <DialogContent>
-          <DialogHeader>
-            <DialogTitle>Remove action</DialogTitle>
-          </DialogHeader>
-          <DialogContainer>
-            Are you sure you want to remove the action "
-            {mcpServerToDelete
-              ? getMcpServerDisplayName(mcpServerToDelete)
-              : ""}
-            "?
-            <div className="mt-2">
-              <b>This action cannot be undone.</b>
-            </div>
-          </DialogContainer>
-          <DialogFooter
-            leftButtonProps={{
-              label: "Cancel",
-              disabled: isLoading,
-              variant: "outline",
-              onClick: () => setMCPServerToDelete(undefined),
-            }}
-            rightButtonProps={{
-              label: "Remove",
-              variant: "warning",
-              disabled: isLoading,
-              onClick: async () => {
-                if (mcpServerToDelete) {
-                  setMCPServerToDelete(undefined);
-                  setIsLoading(true);
-                  await deleteServer(mcpServerToDelete.sId);
-                  setIsLoading(false);
-                  onClose();
-                }
-              },
-            }}
-          />
-        </DialogContent>
-      </Dialog>
+            if (deleted) {
+              onClose();
+            }
+          }}
+        />
+      )}
 
       <Sheet open={isOpen} onOpenChange={onClose}>
         <SheetContent size="lg">
@@ -173,41 +74,9 @@ export function MCPServerDetails({
             <VisuallyHidden>
               <SheetTitle />
             </VisuallyHidden>
-            {effectiveMCPServer && (
-              <MCPActionHeader
-                mcpServer={effectiveMCPServer}
-                oAuthUseCase={mcpServerView?.oAuthUseCase ?? null}
-                isConnected={Boolean(connection)}
-                isConnectionsLoading={isConnectionsLoading}
-              />
+            {mcpServerView && (
+              <MCPActionHeader mcpServer={mcpServerView.server} />
             )}
-
-            <div className="flex w-full flex-row justify-end gap-2 pt-2">
-              {authorization && !connection && (
-                <div>
-                  <Button
-                    variant="highlight"
-                    disabled={isConnectionsLoading}
-                    label={"Connect"}
-                    size="sm"
-                    onClick={() => {
-                      setIsConnectDialogOpen(true);
-                    }}
-                  />
-                </div>
-              )}
-              {authorization && connection && (
-                <div>
-                  <Button
-                    variant="outline"
-                    disabled={isConnectionsLoading}
-                    label={"Disconnect"}
-                    size="sm"
-                    onClick={handleDeleteConnection}
-                  />
-                </div>
-              )}
-            </div>
 
             <Tabs value={selectedTab}>
               <TabsList border={false}>
@@ -217,7 +86,7 @@ export function MCPServerDetails({
                   icon={InformationCircleIcon}
                   onClick={() => setSelectedTab("info")}
                 />
-                {effectiveMCPServer?.availability === "manual" && (
+                {mcpServerView?.server.availability === "manual" && (
                   <TabsTrigger
                     value="sharing"
                     label="Sharing"
@@ -226,37 +95,43 @@ export function MCPServerDetails({
                   />
                 )}
 
-                {effectiveMCPServer &&
-                  effectiveMCPServer.availability === "manual" && (
-                    <>
-                      <div className="grow" />
-                      <Button
-                        variant="warning"
-                        icon={TrashIcon}
-                        label={"Remove"}
-                        size="sm"
-                        onClick={() => {
-                          setMCPServerToDelete(effectiveMCPServer);
-                        }}
-                      />
-                    </>
-                  )}
+                {mcpServerView?.server.availability === "manual" && (
+                  <>
+                    <div className="grow" />
+                    <DropdownMenu>
+                      <DropdownMenuTrigger asChild>
+                        <Button icon={MoreIcon} variant="outline" />
+                      </DropdownMenuTrigger>
+                      <DropdownMenuContent>
+                        <DropdownMenuItem
+                          key={`remove-mcp-server`}
+                          icon={TrashIcon}
+                          label={"Remove"}
+                          variant="warning"
+                          onClick={() => {
+                            setMCPServerToDelete(mcpServerView.server);
+                          }}
+                        />
+                      </DropdownMenuContent>
+                    </DropdownMenu>
+                  </>
+                )}
               </TabsList>
             </Tabs>
           </SheetHeader>
 
           <SheetContainer className="flex flex-col gap-5 pt-6 text-sm text-foreground dark:text-foreground-night">
-            {effectiveMCPServer && (
+            {mcpServerView && (
               <>
                 {selectedTab === "info" && (
                   <MCPServerDetailsInfo
-                    mcpServer={effectiveMCPServer}
+                    mcpServerView={mcpServerView}
                     owner={owner}
                   />
                 )}
                 {selectedTab === "sharing" && (
                   <MCPServerDetailsSharing
-                    mcpServer={effectiveMCPServer}
+                    mcpServer={mcpServerView.server}
                     owner={owner}
                   />
                 )}

--- a/front/components/actions/mcp/MCPServerDetails.tsx
+++ b/front/components/actions/mcp/MCPServerDetails.tsx
@@ -104,9 +104,9 @@ export function MCPServerDetails({
                       </DropdownMenuTrigger>
                       <DropdownMenuContent>
                         <DropdownMenuItem
-                          key={`remove-mcp-server`}
+                          key="remove-mcp-server"
                           icon={TrashIcon}
-                          label={"Remove"}
+                          label="Remove"
                           variant="warning"
                           onClick={() => {
                             setMCPServerToDelete(mcpServerView.server);

--- a/front/components/actions/mcp/MCPServerDetailsSharing.tsx
+++ b/front/components/actions/mcp/MCPServerDetailsSharing.tsx
@@ -129,10 +129,10 @@ export function MCPServerDetailsSharing({
     <div className="flex flex-col gap-2">
       <div className="mb-2 flex w-full flex-col gap-y-2 pt-2">
         <div className="flex w-full items-center justify-between overflow-visible">
-          <Page.SectionHeader title="Restricted Access" />
+          <Page.SectionHeader title="Available to all Spaces" />
           <SliderToggle
             disabled={loading}
-            selected={isRestricted}
+            selected={!isRestricted}
             onClick={async () => {
               if (globalSpace) {
                 setLoading(true);
@@ -150,14 +150,11 @@ export function MCPServerDetailsSharing({
         <div className="text-foreground dark:text-foreground-night">
           {isRestricted ? (
             <>
-              This action is only available to the users of the selected spaces:
+              These tools are only available to the users of the selected
+              spaces:
             </>
           ) : (
-            <>
-              Restricted access is disabled.
-              <br />
-              This action is accessible to everyone in the workspace.
-            </>
+            <>These tools are accessible to everyone in the workspace.</>
           )}
         </div>
       </div>

--- a/front/components/actions/mcp/MCPServerOAuthConnexion.tsx
+++ b/front/components/actions/mcp/MCPServerOAuthConnexion.tsx
@@ -1,14 +1,10 @@
 import {
   Button,
-  Chip,
-  ContentMessage,
   DropdownMenu,
   DropdownMenuCheckboxItem,
   DropdownMenuContent,
   DropdownMenuTrigger,
-  InformationCircleIcon,
   Input,
-  Label,
 } from "@dust-tt/sparkle";
 import { useEffect, useState } from "react";
 
@@ -24,13 +20,12 @@ import {
   OAUTH_PROVIDER_NAMES,
 } from "@app/types";
 
-const OAUTH_USE_CASE_TO_LABEL: Record<MCPOAuthUseCase, string> = {
+export const OAUTH_USE_CASE_TO_LABEL: Record<MCPOAuthUseCase, string> = {
   platform_actions: "Workspace",
   personal_actions: "Personal",
 };
 
 type MCPServerOauthConnexionProps = {
-  remoteMCPServerUrl?: string;
   authorization: AuthorizationInfo;
   authCredentials: OAuthCredentials | null;
   useCase: MCPOAuthUseCase | null;
@@ -41,7 +36,6 @@ type MCPServerOauthConnexionProps = {
 };
 
 export function MCPServerOAuthConnexion({
-  remoteMCPServerUrl,
   authorization,
   authCredentials,
   useCase,
@@ -119,32 +113,9 @@ export function MCPServerOAuthConnexion({
     >
       {authorization && (
         <>
-          <Chip color="warning">
-            <span>
-              {remoteMCPServerUrl
-                ? `${remoteMCPServerUrl} requires authentication with `
-                : "These tools require authentication with "}
-              {OAUTH_PROVIDER_NAMES[authorization.provider]}
-              {documentationUrl && (
-                <>
-                  . Follow{" "}
-                  <a
-                    href={documentationUrl}
-                    className="text-highlight-600"
-                    target="_blank"
-                  >
-                    this guide
-                  </a>{" "}
-                  to set it up
-                </>
-              )}
-              .
-            </span>
-          </Chip>
-
           {authorization.supported_use_cases.length > 1 && containerRef && (
             <div className="w-full">
-              <Label>Credentials Type</Label>
+              <div className="heading-base">Authentication type</div>
               <div>
                 <DropdownMenu>
                   <DropdownMenuTrigger asChild>
@@ -177,28 +148,18 @@ export function MCPServerOAuthConnexion({
               </div>
             </div>
           )}
-          <div className="w-full">
+          <div className="w-full text-xs text-muted-foreground dark:text-muted-foreground-night">
             {useCase === "platform_actions" && (
-              <ContentMessage
-                size="lg"
-                variant="golden"
-                title="Workspace level credentials."
-                icon={InformationCircleIcon}
-              >
-                The authentication credentials you provide during setup will be
-                shared by all users in this workspace when using these tools.
-              </ContentMessage>
+              <>
+                The credentials you provide will be shared by all users of these
+                tools.
+              </>
             )}
             {useCase === "personal_actions" && (
-              <ContentMessage
-                size="lg"
-                variant="highlight"
-                title="Personal level credentials."
-                icon={InformationCircleIcon}
-              >
-                Once setup for the workspace, each user will have to connect
-                their own credentials to interact with these tools.
-              </ContentMessage>
+              <>
+                Users will connect their own accounts the first time they
+                interact with these tools.
+              </>
             )}
           </div>
           {inputs &&
@@ -214,7 +175,7 @@ export function MCPServerOAuthConnexion({
               const value = authCredentials?.[key] ?? "";
               return (
                 <div key={key} className="w-full">
-                  <Label htmlFor={key}>{inputData.label}</Label>
+                  <div className="heading-base">{inputData.label}</div>
                   <Input
                     id={key}
                     value={value}
@@ -236,6 +197,19 @@ export function MCPServerOAuthConnexion({
                 </div>
               );
             })}
+          {documentationUrl && (
+            <div className="w-full text-muted-foreground dark:text-muted-foreground-night">
+              Questions ? Read{" "}
+              <a
+                href={documentationUrl}
+                className="font-bold text-highlight-600 dark:text-highlight-600-night"
+                target="_blank"
+              >
+                our guide
+              </a>{" "}
+              on {OAUTH_PROVIDER_NAMES[authorization.provider]}
+            </div>
+          )}
         </>
       )}
     </div>

--- a/front/components/actions/mcp/MCPServerOAuthConnexion.tsx
+++ b/front/components/actions/mcp/MCPServerOAuthConnexion.tsx
@@ -6,6 +6,7 @@ import {
   DropdownMenuTrigger,
   Input,
 } from "@dust-tt/sparkle";
+import Link from "next/link";
 import { useEffect, useState } from "react";
 
 import type { AuthorizationInfo } from "@app/lib/actions/mcp_metadata";
@@ -148,7 +149,7 @@ export function MCPServerOAuthConnexion({
               </div>
             </div>
           )}
-          <div className="w-full text-xs text-muted-foreground dark:text-muted-foreground-night">
+          <div className="w-full text-muted-foreground dark:text-muted-foreground-night">
             {useCase === "platform_actions" && (
               <>
                 The credentials you provide will be shared by all users of these
@@ -200,13 +201,13 @@ export function MCPServerOAuthConnexion({
           {documentationUrl && (
             <div className="w-full text-muted-foreground dark:text-muted-foreground-night">
               Questions ? Read{" "}
-              <a
+              <Link
                 href={documentationUrl}
-                className="font-bold text-highlight-600 dark:text-highlight-600-night"
                 target="_blank"
+                className="font-semibold text-highlight-600 dark:text-highlight-600-night"
               >
                 our guide
-              </a>{" "}
+              </Link>{" "}
               on {OAUTH_PROVIDER_NAMES[authorization.provider]}
             </div>
           )}

--- a/front/components/actions/mcp/MCPServerSettings.tsx
+++ b/front/components/actions/mcp/MCPServerSettings.tsx
@@ -1,0 +1,184 @@
+import {
+  Button,
+  Chip,
+  DropdownMenu,
+  DropdownMenuCheckboxItem,
+  DropdownMenuContent,
+  DropdownMenuTrigger,
+  LoginIcon,
+  XMarkIcon,
+} from "@dust-tt/sparkle";
+import { useCallback, useMemo, useState } from "react";
+
+import { ConnectMCPServerDialog } from "@app/components/actions/mcp/ConnectMCPServerDialog";
+import { OAUTH_USE_CASE_TO_LABEL } from "@app/components/actions/mcp/MCPServerOAuthConnexion";
+import type { MCPServerViewType } from "@app/lib/api/mcp";
+import {
+  useDeleteMCPServerConnection,
+  useMCPServerConnections,
+} from "@app/lib/swr/mcp_servers";
+import type { LightWorkspaceType, MCPOAuthUseCase } from "@app/types";
+
+interface MCPServerSettingsProps {
+  mcpServerView: MCPServerViewType;
+  owner: LightWorkspaceType;
+}
+
+export function MCPServerSettings({
+  mcpServerView,
+  owner,
+}: MCPServerSettingsProps) {
+  const authorization = useMemo(
+    () => mcpServerView.server.authorization,
+    [mcpServerView.server.authorization]
+  );
+
+  const { connections, isConnectionsLoading } = useMCPServerConnections({
+    owner,
+    connectionType: "workspace",
+    disabled: !authorization,
+  });
+
+  const connection = useMemo(
+    () =>
+      connections.find(
+        (c) =>
+          c.internalMCPServerId === mcpServerView.server.sId ||
+          c.remoteMCPServerId === mcpServerView.server.sId
+      ),
+    [connections, mcpServerView.server.sId]
+  );
+
+  const { deleteMCPServerConnection } = useDeleteMCPServerConnection({
+    owner,
+  });
+
+  const handleDeleteConnection = useCallback(() => {
+    if (!connection || !mcpServerView) {
+      return;
+    }
+
+    setSelectedUseCase(null);
+    void deleteMCPServerConnection({
+      connection,
+      mcpServer: mcpServerView.server,
+    });
+  }, [deleteMCPServerConnection, connection, mcpServerView]);
+
+  const [isConnectDialogOpen, setIsConnectDialogOpen] = useState(false);
+  const [isLoading, setIsLoading] = useState(false);
+  const [selectedUseCase, setSelectedUseCase] =
+    useState<MCPOAuthUseCase | null>();
+
+  const useCase = useMemo(
+    () => (selectedUseCase || mcpServerView.oAuthUseCase) as MCPOAuthUseCase,
+    [selectedUseCase, mcpServerView.oAuthUseCase]
+  );
+
+  return (
+    <>
+      <ConnectMCPServerDialog
+        owner={owner}
+        mcpServer={mcpServerView.server}
+        setIsLoading={setIsLoading}
+        isOpen={isConnectDialogOpen}
+        setIsOpen={setIsConnectDialogOpen}
+      />
+      <div className="heading-lg">Server Settings</div>
+      <div className="space-y-2">
+        <div className="heading-base">Authentication</div>
+        <div className="flex space-x-2">
+          <div className="flex-grow">
+            {mcpServerView.oAuthUseCase &&
+              !isConnectionsLoading &&
+              (connection ? (
+                <Chip color="success" size="sm">
+                  Active
+                </Chip>
+              ) : (
+                <Chip color="warning" size="sm">
+                  Requires authentication
+                </Chip>
+              ))}
+          </div>
+          {connection ? (
+            <Button
+              label={"Deactivate"}
+              icon={XMarkIcon}
+              variant="outline"
+              onClick={handleDeleteConnection}
+            />
+          ) : (
+            <Button
+              label={"Activate"}
+              icon={LoginIcon}
+              variant="primary"
+              onClick={() => setIsConnectDialogOpen(true)}
+              disabled={isLoading}
+              isLoading={isLoading}
+            />
+          )}
+        </div>
+      </div>
+
+      {connection && (
+        <div className="space-y-2">
+          <div className="heading-base">Credentials</div>
+
+          {mcpServerView.server.authorization &&
+            // Disabled for now, because switching to workspace credentials could be dangerous without knowing which account it was.
+            mcpServerView.server.authorization.supported_use_cases &&
+            mcpServerView.server.authorization.supported_use_cases.length <
+              0 && (
+              <>
+                <DropdownMenu>
+                  <DropdownMenuTrigger asChild>
+                    <Button
+                      isSelect
+                      variant="outline"
+                      label={
+                        useCase
+                          ? OAUTH_USE_CASE_TO_LABEL[useCase]
+                          : "Select credentials type"
+                      }
+                      size="sm"
+                    />
+                  </DropdownMenuTrigger>
+
+                  <DropdownMenuContent>
+                    {mcpServerView.server.authorization.supported_use_cases.map(
+                      (selectableUseCase) => (
+                        <DropdownMenuCheckboxItem
+                          key={selectableUseCase}
+                          checked={selectableUseCase === useCase}
+                          onCheckedChange={() =>
+                            setSelectedUseCase(selectableUseCase)
+                          }
+                        >
+                          {OAUTH_USE_CASE_TO_LABEL[selectableUseCase]}
+                        </DropdownMenuCheckboxItem>
+                      )
+                    )}
+                  </DropdownMenuContent>
+                </DropdownMenu>
+              </>
+            )}
+          <div className="w-full text-muted-foreground dark:text-muted-foreground-night">
+            {useCase === "platform_actions" && (
+              <>
+                <b>Workspace credentials</b>: These tools will use the account's
+                credentials provided during activation for all users.
+              </>
+            )}
+            {useCase === "personal_actions" && (
+              <>
+                <b>Personal credentials</b>: Users will connect their own
+                accounts the first time they interact with these tools.
+              </>
+            )}
+          </div>
+        </div>
+      )}
+    </>
+  );
+}

--- a/front/components/actions/mcp/MCPServerSettings.tsx
+++ b/front/components/actions/mcp/MCPServerSettings.tsx
@@ -103,14 +103,14 @@ export function MCPServerSettings({
           </div>
           {connection ? (
             <Button
-              label={"Deactivate"}
+              label="Deactivate"
               icon={XMarkIcon}
               variant="outline"
               onClick={handleDeleteConnection}
             />
           ) : (
             <Button
-              label={"Activate"}
+              label="Activate"
               icon={LoginIcon}
               variant="primary"
               onClick={() => setIsConnectDialogOpen(true)}
@@ -130,50 +130,50 @@ export function MCPServerSettings({
             mcpServerView.server.authorization.supported_use_cases &&
             mcpServerView.server.authorization.supported_use_cases.length <
               0 && (
-              <>
-                <DropdownMenu>
-                  <DropdownMenuTrigger asChild>
-                    <Button
-                      isSelect
-                      variant="outline"
-                      label={
-                        useCase
-                          ? OAUTH_USE_CASE_TO_LABEL[useCase]
-                          : "Select credentials type"
-                      }
-                      size="sm"
-                    />
-                  </DropdownMenuTrigger>
+              <DropdownMenu>
+                <DropdownMenuTrigger asChild>
+                  <Button
+                    isSelect
+                    variant="outline"
+                    label={
+                      useCase
+                        ? OAUTH_USE_CASE_TO_LABEL[useCase]
+                        : "Select credentials type"
+                    }
+                    size="sm"
+                  />
+                </DropdownMenuTrigger>
 
-                  <DropdownMenuContent>
-                    {mcpServerView.server.authorization.supported_use_cases.map(
-                      (selectableUseCase) => (
-                        <DropdownMenuCheckboxItem
-                          key={selectableUseCase}
-                          checked={selectableUseCase === useCase}
-                          onCheckedChange={() =>
-                            setSelectedUseCase(selectableUseCase)
-                          }
-                        >
-                          {OAUTH_USE_CASE_TO_LABEL[selectableUseCase]}
-                        </DropdownMenuCheckboxItem>
-                      )
-                    )}
-                  </DropdownMenuContent>
-                </DropdownMenu>
-              </>
+                <DropdownMenuContent>
+                  {mcpServerView.server.authorization.supported_use_cases.map(
+                    (selectableUseCase) => (
+                      <DropdownMenuCheckboxItem
+                        key={selectableUseCase}
+                        checked={selectableUseCase === useCase}
+                        onCheckedChange={() =>
+                          setSelectedUseCase(selectableUseCase)
+                        }
+                      >
+                        {OAUTH_USE_CASE_TO_LABEL[selectableUseCase]}
+                      </DropdownMenuCheckboxItem>
+                    )
+                  )}
+                </DropdownMenuContent>
+              </DropdownMenu>
             )}
           <div className="w-full text-muted-foreground dark:text-muted-foreground-night">
             {useCase === "platform_actions" && (
               <>
-                <b>Workspace credentials</b>: These tools will use the account's
-                credentials provided during activation for all users.
+                <span className="font-semibold">Workspace credentials</span>:
+                These tools will use the account's credentials provided during
+                activation for all users.
               </>
             )}
             {useCase === "personal_actions" && (
               <>
-                <b>Personal credentials</b>: Users will connect their own
-                accounts the first time they interact with these tools.
+                <span className="font-semibold">Personal credentials</span>:
+                Users will connect their own accounts the first time they
+                interact with these tools.
               </>
             )}
           </div>

--- a/front/components/assistant_builder/ActionsScreen.tsx
+++ b/front/components/assistant_builder/ActionsScreen.tsx
@@ -69,7 +69,6 @@ import {
   MCP_SPECIFICATION,
 } from "@app/lib/actions/utils";
 import type { MCPServerViewType } from "@app/lib/api/mcp";
-import { useMCPServerConnections } from "@app/lib/swr/mcp_servers";
 import { useFeatureFlags } from "@app/lib/swr/workspaces";
 import type {
   ModelConfigurationType,
@@ -835,18 +834,6 @@ function ActionEditor({
         )
       : undefined;
 
-  const { connections, isConnectionsLoading } = useMCPServerConnections({
-    owner,
-    connectionType: "workspace",
-    disabled: !selectedMCPServerView?.server.authorization,
-  });
-
-  const connection = connections.find(
-    (c) =>
-      c.internalMCPServerId === selectedMCPServerView?.server.sId ||
-      c.remoteMCPServerId === selectedMCPServerView?.server.sId
-  );
-
   const shouldDisplayAdvancedSettings = !["DUST_APP_RUN"].includes(action.type);
 
   return (
@@ -856,9 +843,6 @@ function ActionEditor({
           {action.type === "MCP" && selectedMCPServerView ? (
             <MCPActionHeader
               mcpServer={selectedMCPServerView.server}
-              oAuthUseCase={selectedMCPServerView.oAuthUseCase}
-              isConnected={Boolean(connection)}
-              isConnectionsLoading={isConnectionsLoading}
               action={action}
             />
           ) : (

--- a/front/components/assistant_builder/actions/MCPAction.tsx
+++ b/front/components/assistant_builder/actions/MCPAction.tsx
@@ -19,7 +19,6 @@ import type {
   AssistantBuilderMCPOrVizState,
   AssistantBuilderMCPServerConfiguration,
 } from "@app/components/assistant_builder/types";
-import { getServerTypeAndIdFromSId } from "@app/lib/actions/mcp_helper";
 import type { MCPServerAvailability } from "@app/lib/actions/mcp_internal_actions/constants";
 import { ADVANCED_SEARCH_SWITCH } from "@app/lib/actions/mcp_internal_actions/constants";
 import { getMCPServerRequirements } from "@app/lib/actions/mcp_internal_actions/input_configuration";
@@ -344,13 +343,8 @@ export function MCPAction({
         <ConfigurationSectionContainer title="Available Tools">
           <ToolsList
             owner={owner}
-            tools={selectedMCPServerView.server.tools}
-            serverType={
-              getServerTypeAndIdFromSId(selectedMCPServerView.server.sId)
-                .serverType
-            }
-            serverId={selectedMCPServerView.server.sId}
-            canUpdate={false}
+            mcpServerView={selectedMCPServerView}
+            forcedCanUpdate={false}
           />
         </ConfigurationSectionContainer>
       )}

--- a/front/lib/actions/mcp_internal_actions/servers/salesforce.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/salesforce.ts
@@ -17,7 +17,7 @@ const serverInfo: InternalMCPServerDefinitionType = {
     supported_use_cases: ["personal_actions", "platform_actions"] as const,
   },
   icon: "SalesforceLogo",
-  documentationUrl: null,
+  documentationUrl: "https://docs.dust.tt/docs/salesforce",
 };
 
 const SF_API_VERSION = "57.0";

--- a/front/lib/resources/mcp_server_view_resource.ts
+++ b/front/lib/resources/mcp_server_view_resource.ts
@@ -417,7 +417,11 @@ export class MCPServerViewResource extends ResourceWithSpace<MCPServerViewModel>
       );
     }
 
-    const [affectedCount] = await this.update({ oAuthUseCase });
+    const [affectedCount] = await this.update({
+      oAuthUseCase,
+      editedAt: new Date(),
+      editedByUserId: auth.getNonNullableUser().id,
+    });
     return new Ok(affectedCount);
   }
 

--- a/front/package-lock.json
+++ b/front/package-lock.json
@@ -195,7 +195,7 @@
     },
     "../sdks/js": {
       "name": "@dust-tt/client",
-      "version": "1.0.54",
+      "version": "1.0.56",
       "license": "ISC",
       "dependencies": {
         "@modelcontextprotocol/sdk": "git://github.com:dust-tt/typescript-sdk.git#bca26e405d6db2cf71fd7211234a72ecc46d0215",

--- a/front/pages/api/w/[wId]/mcp/[serverId]/index.ts
+++ b/front/pages/api/w/[wId]/mcp/[serverId]/index.ts
@@ -17,7 +17,7 @@ export type GetMCPServerResponseBody = {
 };
 
 export type PatchMCPServerResponseBody = {
-  success: boolean;
+  success: true;
   server: MCPServerType;
 };
 


### PR DESCRIPTION
## Description

Update the components related to MCP server details and connexion flow.
I refactored / simplified a bit by extracting into separate components files when possible.
I also moved dependant mutations & notifications of a hook directly in the hook instead of the user of the hook (DRY, usual pattern).
I fixed a few typing issue with the return values of the endpoint.

## Tests

Local

<img width="585" alt="image" src="https://github.com/user-attachments/assets/fc37137f-4aa3-45a1-baa9-44702bb480bb" />
<img width="572" alt="image" src="https://github.com/user-attachments/assets/503bf334-a97c-47dd-97df-6fe49555c95a" />
<img width="628" alt="image" src="https://github.com/user-attachments/assets/e1c61405-63f4-4d50-887b-f5a4a0ebf2b0" />
<img width="597" alt="image" src="https://github.com/user-attachments/assets/9812c38b-fe6b-4888-99e8-9e2a0d5e2231" />
<img width="574" alt="image" src="https://github.com/user-attachments/assets/51d2e938-0db7-4d5d-bda6-3b8321370133" />


## Risk

Medium, mostly visual changes.

## Deploy Plan

Deploy front