### PR TITLE
[front] fix invitation display

### DIFF
--- a/front/pages/w/[wId]/members/index.tsx
+++ b/front/pages/w/[wId]/members/index.tsx
@@ -194,13 +194,9 @@ function WorkspaceMembersGroupsList({
   searchTerm,
   isProvisioningEnabled,
 }: WorkspaceMembersListProps) {
-  const { hasFeature, isFeatureFlagsLoading } = useFeatureFlags({
-    workspaceId: owner.sId,
-  });
-
   const { isLoading } = useWorkOSSSOStatus({ owner });
 
-  if (isFeatureFlagsLoading || isLoading) {
+  if (isLoading) {
     return (
       <div className="flex items-center justify-center py-8">
         <Spinner size="lg" />

--- a/front/pages/w/[wId]/members/index.tsx
+++ b/front/pages/w/[wId]/members/index.tsx
@@ -210,35 +210,23 @@ function WorkspaceMembersGroupsList({
 
   return (
     <div className="flex flex-col gap-1 pt-2">
-      {hasFeature("workos_user_provisioning") ? (
-        <Tabs defaultValue="members">
-          <TabsList className="mb-4">
-            <TabsTrigger value="members" label="Members" />
-            <TabsTrigger value="invitations" label="Invitations" />
-          </TabsList>
-          <TabsContent value="members">
-            <WorkspaceMembersList
-              currentUser={currentUser}
-              owner={owner}
-              searchTerm={searchTerm}
-              isProvisioningEnabled={isProvisioningEnabled}
-            />
-          </TabsContent>
-          <TabsContent value="invitations">
-            <InvitationsList owner={owner} searchText={searchTerm} />
-          </TabsContent>
-        </Tabs>
-      ) : (
-        <>
-          <Page.H variant="h6">Members</Page.H>
+      <Tabs defaultValue="members">
+        <TabsList className="mb-4">
+          <TabsTrigger value="members" label="Members" />
+          <TabsTrigger value="invitations" label="Invitations" />
+        </TabsList>
+        <TabsContent value="members">
           <WorkspaceMembersList
             currentUser={currentUser}
             owner={owner}
             searchTerm={searchTerm}
             isProvisioningEnabled={isProvisioningEnabled}
           />
-        </>
-      )}
+        </TabsContent>
+        <TabsContent value="invitations">
+          <InvitationsList owner={owner} searchText={searchTerm} />
+        </TabsContent>
+      </Tabs>
     </div>
   );
 }


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

https://github.com/dust-tt/dust/commit/19ab4e394739ddbc0032721056aaef688c81cd13#diff-c0ecc7525570ee303a52367e6de622f873c0ce236b92da02d5ae42542d65c7e6
that PR introduced a regression on invitation displays,

current PR brings back the invitation list to the members page for all users, and not being a FF

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

tested by hand

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

low

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->

deploy front