### PR TITLE
[Durable Agents] Legacy action: migrate AgentProcessAction to AgentMCPAction

### DIFF
--- a/front/migrations/20250626_move_process_actions_to_mcp.ts
+++ b/front/migrations/20250626_move_process_actions_to_mcp.ts
@@ -82,7 +82,7 @@ function agentProcessActionToAgentMCPAction(
   } else {
     // For custom agent configurations, use the extract configuration.
     mcpServerConfigurationId =
-      extractMcpServerConfiguration?.sId ??
+      extractMcpServerConfiguration?.id.toString() ??
       NOT_FOUND_MCP_SERVER_CONFIGURATION_ID;
   }
 
@@ -136,12 +136,14 @@ function createQueryOutputItem(
   mcpActionId: ModelId
 ): CreationAttributes<AgentMCPActionOutputItem> {
   const timeFrame = getTimeFrameUnit(processAction);
+  const timeFrameAsString = timeFrame
+    ? "the last " +
+      (timeFrame.duration > 1
+        ? `${timeFrame.duration} ${timeFrame.unit}s`
+        : `${timeFrame.unit}`)
+    : "all time";
 
-  const queryText = `Extract structured information from documents.
-Schema: ${JSON.stringify(processAction.jsonSchema || {})}
-Time frame: ${timeFrame ? `${timeFrame.duration}${timeFrame.unit}` : "all"}
-Tags included: ${(processAction.tagsIn || []).join(", ") || "none"}
-Tags excluded: ${(processAction.tagsNot || []).join(", ") || "none"}`;
+  const queryText = `Extracted from ${processAction.outputs?.total_documents} documents over ${timeFrameAsString}.\nObjective: Extract structured information from documents`;
 
   const queryResource: ExtractQueryResourceType = {
     mimeType: INTERNAL_MIME_TYPES.TOOL_OUTPUT.EXTRACT_QUERY,
@@ -250,9 +252,7 @@ async function migrateSingleProcessAction(
       outputItems.push(resultItem);
     }
 
-    if (outputItems.length > 0) {
-      await AgentMCPActionOutputItem.bulkCreate(outputItems);
-    }
+    await AgentMCPActionOutputItem.bulkCreate(outputItems);
   }
 }
 

--- a/front/migrations/20250626_move_process_actions_to_mcp.ts
+++ b/front/migrations/20250626_move_process_actions_to_mcp.ts
@@ -63,10 +63,6 @@ function agentProcessActionToAgentMCPAction(
     "Found MCP server view ID for extract_data"
   );
 
-  // The `mcpServerConfigurationId` was not properly backfilled when AgentProcessConfiguration
-  // was migrated to MCP, preventing any possibility to convert the legacy process actions
-  // to MCP "working/replayable" actions. This is best effort, we take the first mcp server
-  // configuration for extract_data if available.
   const extractMcpServerConfiguration =
     agentConfiguration?.mcpServerConfigurations.find(
       (config) => config.mcpServerViewId === mcpServerViewForExtractId
@@ -128,7 +124,6 @@ function agentProcessActionToAgentMCPAction(
       },
       step: processAction.step,
       workspaceId: processAction.workspaceId,
-      // We did not save the error in the legacy process action.
       isError: false,
       executionState: "allowed_implicitly",
     },

--- a/front/migrations/20250626_move_process_actions_to_mcp.ts
+++ b/front/migrations/20250626_move_process_actions_to_mcp.ts
@@ -27,6 +27,7 @@ import { makeScript } from "@app/scripts/helpers";
 import { runOnAllWorkspaces } from "@app/scripts/workspace_helpers";
 import type { LightWorkspaceType, ModelId, TimeFrame } from "@app/types";
 import { isGlobalAgentId } from "@app/types";
+import config from "@app/lib/api/config";
 
 const WORKSPACE_CONCURRENCY = 50;
 const BATCH_SIZE = 200;
@@ -180,14 +181,11 @@ function createResultOutputItem(
   const resultResource: ExtractResultResourceType = {
     mimeType: INTERNAL_MIME_TYPES.TOOL_OUTPUT.EXTRACT_RESULT,
     text: extractResult,
-    uri: `https://dust.tt/api/v1/w/${auth.getNonNullableWorkspace().sId}/files/${processAction.jsonFileId}`,
+    uri: `${config.getClientFacingUrl()}/api/w/${auth.getNonNullableWorkspace().sId}/files/${processAction.jsonFileId}`,
     fileId: processAction.jsonFileId.toString(),
     title: "Extracted Data",
     contentType: "application/json",
-    snippet:
-      outputs.data && outputs.data.length > 0
-        ? JSON.stringify(outputs.data[0], null, 2).substring(0, 200) + "..."
-        : null,
+    snippet: processAction.jsonFileSnippet,
   };
 
   return {

--- a/front/migrations/20250626_move_process_actions_to_mcp.ts
+++ b/front/migrations/20250626_move_process_actions_to_mcp.ts
@@ -1,0 +1,386 @@
+import { INTERNAL_MIME_TYPES } from "@dust-tt/client";
+import * as assert from "assert";
+import type { Logger } from "pino";
+import type { CreationAttributes } from "sequelize";
+import { Op } from "sequelize";
+
+import { DEFAULT_CONVERSATION_EXTRACT_ACTION_NAME } from "@app/lib/actions/constants";
+import type { ActionBaseParams } from "@app/lib/actions/mcp";
+import type {
+  ExtractQueryResourceType,
+  ExtractResultResourceType,
+} from "@app/lib/actions/mcp_internal_actions/output_schemas";
+import type { ProcessActionOutputsType } from "@app/lib/actions/process";
+import { getWorkspaceInfos } from "@app/lib/api/workspace";
+import { Authenticator } from "@app/lib/auth";
+import {
+  AgentMCPAction,
+  AgentMCPActionOutputItem,
+  AgentMCPServerConfiguration,
+} from "@app/lib/models/assistant/actions/mcp";
+import { AgentProcessAction } from "@app/lib/models/assistant/actions/process";
+import { AgentConfiguration } from "@app/lib/models/assistant/agent";
+import { AgentMessage } from "@app/lib/models/assistant/conversation";
+import { MCPServerViewResource } from "@app/lib/resources/mcp_server_view_resource";
+import { concurrentExecutor } from "@app/lib/utils/async_utils";
+import { makeScript } from "@app/scripts/helpers";
+import { runOnAllWorkspaces } from "@app/scripts/workspace_helpers";
+import type { LightWorkspaceType, ModelId, TimeFrame } from "@app/types";
+import { isGlobalAgentId } from "@app/types";
+
+const WORKSPACE_CONCURRENCY = 50;
+const BATCH_SIZE = 200;
+const CREATION_CONCURRENCY = 50;
+
+const NOT_FOUND_MCP_SERVER_CONFIGURATION_ID = "unknown";
+
+function getTimeFrameUnit(processAction: AgentProcessAction): TimeFrame | null {
+  if (
+    processAction.relativeTimeFrameUnit &&
+    processAction.relativeTimeFrameDuration
+  ) {
+    return {
+      duration: processAction.relativeTimeFrameDuration,
+      unit: processAction.relativeTimeFrameUnit,
+    };
+  }
+
+  return null;
+}
+
+function agentProcessActionToAgentMCPAction(
+  processAction: AgentProcessAction,
+  agentConfiguration: AgentConfiguration | null,
+  mcpServerViewForExtractId: ModelId,
+  logger: Logger
+): {
+  action: ActionBaseParams & CreationAttributes<AgentMCPAction>;
+} {
+  logger.info(
+    {
+      mcpServerViewForExtractId,
+    },
+    "Found MCP server view ID for extract_data"
+  );
+
+  const extractMcpServerConfiguration =
+    agentConfiguration?.mcpServerConfigurations.find(
+      (config) => config.mcpServerViewId === mcpServerViewForExtractId
+    );
+
+  const isJITServerAction =
+    processAction.functionCallName === DEFAULT_CONVERSATION_EXTRACT_ACTION_NAME;
+
+  let mcpServerConfigurationId: string;
+
+  if (isJITServerAction) {
+    mcpServerConfigurationId = "-1";
+  } else {
+    mcpServerConfigurationId =
+      extractMcpServerConfiguration?.sId ??
+      NOT_FOUND_MCP_SERVER_CONFIGURATION_ID;
+  }
+
+  logger.info(
+    {
+      processActionId: processAction.id,
+      mcpServerConfigurationId,
+    },
+    "Converted process action to MCP action"
+  );
+
+  const timeFrame = getTimeFrameUnit(processAction);
+
+  return {
+    action: {
+      agentMessageId: processAction.agentMessageId,
+      functionCallId: processAction.functionCallId,
+      functionCallName: processAction.functionCallName,
+      createdAt: processAction.createdAt,
+      updatedAt: processAction.updatedAt,
+      generatedFiles: processAction.jsonFileId
+        ? [{ id: processAction.jsonFileId }]
+        : [],
+      mcpServerConfigurationId,
+      params: {
+        jsonSchema: processAction.jsonSchema,
+        objective: "Extract structured information from documents",
+        relativeTimeFrame: timeFrame
+          ? `${timeFrame.duration}${timeFrame.unit}`
+          : "all",
+        tagsIn: processAction.tagsIn,
+        tagsNot: processAction.tagsNot,
+      },
+      step: processAction.step,
+      workspaceId: processAction.workspaceId,
+      isError: false,
+      executionState: "allowed_implicitly",
+    },
+  };
+}
+
+function createQueryOutputItem(
+  processAction: AgentProcessAction,
+  mcpActionId: ModelId
+): CreationAttributes<AgentMCPActionOutputItem> {
+  const timeFrame = getTimeFrameUnit(processAction);
+
+  const queryText = `Extract structured information from documents.
+Schema: ${JSON.stringify(processAction.jsonSchema || {})}
+Time frame: ${timeFrame ? `${timeFrame.duration}${timeFrame.unit}` : "all"}
+Tags included: ${(processAction.tagsIn || []).join(", ") || "none"}
+Tags excluded: ${(processAction.tagsNot || []).join(", ") || "none"}`;
+
+  const queryResource: ExtractQueryResourceType = {
+    mimeType: INTERNAL_MIME_TYPES.TOOL_OUTPUT.EXTRACT_QUERY,
+    text: queryText,
+    uri: "",
+  };
+
+  return {
+    agentMCPActionId: mcpActionId,
+    content: {
+      type: "resource",
+      resource: queryResource,
+    },
+    createdAt: processAction.createdAt,
+    updatedAt: processAction.updatedAt,
+    workspaceId: processAction.workspaceId,
+  };
+}
+
+function createResultOutputItem(
+  processAction: AgentProcessAction,
+  mcpActionId: ModelId,
+  auth: Authenticator
+): CreationAttributes<AgentMCPActionOutputItem> | null {
+  if (!processAction.outputs || !processAction.jsonFileId) {
+    return null;
+  }
+
+  const outputs = processAction.outputs as ProcessActionOutputsType;
+
+  const extractResult =
+    "PROCESSED OUTPUTS:\n" +
+    (outputs.data && outputs.data.length > 0
+      ? outputs.data.map((d) => JSON.stringify(d)).join("\n")
+      : "(none)");
+
+  const resultResource: ExtractResultResourceType = {
+    mimeType: INTERNAL_MIME_TYPES.TOOL_OUTPUT.EXTRACT_RESULT,
+    text: extractResult,
+    uri: `https://dust.tt/api/v1/w/${auth.getNonNullableWorkspace().sId}/files/${processAction.jsonFileId}`,
+    fileId: processAction.jsonFileId,
+    title: "Extracted Data",
+    contentType: "application/json",
+    snippet:
+      outputs.data && outputs.data.length > 0
+        ? JSON.stringify(outputs.data[0], null, 2).substring(0, 200) + "..."
+        : null,
+  };
+
+  return {
+    agentMCPActionId: mcpActionId,
+    content: {
+      type: "resource",
+      resource: resultResource,
+    },
+    createdAt: processAction.createdAt,
+    updatedAt: processAction.updatedAt,
+    workspaceId: processAction.workspaceId,
+  };
+}
+
+async function migrateSingleProcessAction(
+  auth: Authenticator,
+  processAction: AgentProcessAction,
+  agentConfiguration: AgentConfiguration | null,
+  logger: Logger,
+  {
+    execute,
+    mcpServerViewForExtractId,
+  }: {
+    execute: boolean;
+    mcpServerViewForExtractId: ModelId;
+  }
+) {
+  const mcpAction = agentProcessActionToAgentMCPAction(
+    processAction,
+    agentConfiguration ?? null,
+    mcpServerViewForExtractId,
+    logger
+  );
+
+  if (execute) {
+    const mcpActionCreated = await AgentMCPAction.create(mcpAction.action);
+
+    const outputItems: CreationAttributes<AgentMCPActionOutputItem>[] = [];
+
+    outputItems.push(createQueryOutputItem(processAction, mcpActionCreated.id));
+
+    const resultItem = createResultOutputItem(
+      processAction,
+      mcpActionCreated.id,
+      auth
+    );
+    if (resultItem) {
+      outputItems.push(resultItem);
+    }
+
+    await AgentMCPActionOutputItem.bulkCreate(outputItems);
+  }
+}
+
+async function migrateWorkspaceProcessActions(
+  workspace: LightWorkspaceType,
+  logger: Logger,
+  { execute }: { execute: boolean }
+) {
+  const auth = await Authenticator.internalAdminForWorkspace(workspace.sId);
+
+  await MCPServerViewResource.ensureAllAutoToolsAreCreated(auth);
+
+  const mcpServerViewForExtract =
+    await MCPServerViewResource.getMCPServerViewForAutoInternalTool(
+      auth,
+      "extract_data"
+    );
+
+  assert(mcpServerViewForExtract, "Extract data MCP server view must exist");
+
+  let hasMore = false;
+  do {
+    const processActions = await AgentProcessAction.findAll({
+      where: {
+        workspaceId: workspace.id,
+      },
+      limit: BATCH_SIZE,
+    });
+
+    if (processActions.length === 0) {
+      return;
+    }
+
+    logger.info(`Found ${processActions.length} process actions`);
+
+    const agentMessages = await AgentMessage.findAll({
+      where: {
+        id: {
+          [Op.in]: processActions.map((action) => action.agentMessageId),
+        },
+        workspaceId: workspace.id,
+      },
+    });
+
+    const agentConfigurationSIds = [
+      ...new Set(agentMessages.map((message) => message.agentConfigurationId)),
+    ];
+
+    const agentConfigurations = await AgentConfiguration.findAll({
+      where: {
+        sId: {
+          [Op.in]: agentConfigurationSIds,
+        },
+        workspaceId: workspace.id,
+      },
+      include: [
+        {
+          model: AgentMCPServerConfiguration,
+          as: "mcpServerConfigurations",
+        },
+      ],
+    });
+
+    const agentConfigurationsMap = new Map(
+      agentConfigurations.map((config) => [
+        `${config.sId}-${config.version}`,
+        config,
+      ])
+    );
+
+    const agentMessagesMap = new Map(
+      agentMessages.map((message) => [message.id, message])
+    );
+
+    await concurrentExecutor(
+      processActions,
+      async (processAction) => {
+        const agentMessage = agentMessagesMap.get(processAction.agentMessageId);
+        assert(agentMessage, "Agent message must exist");
+
+        const agentConfiguration = agentConfigurationsMap.get(
+          `${agentMessage.agentConfigurationId}-${agentMessage.agentConfigurationVersion}`
+        );
+        assert(
+          agentConfiguration ||
+            isGlobalAgentId(agentMessage.agentConfigurationId),
+          "Agent configuration must exist"
+        );
+
+        await migrateSingleProcessAction(
+          auth,
+          processAction,
+          agentConfiguration ?? null,
+          logger,
+          {
+            execute,
+            mcpServerViewForExtractId: mcpServerViewForExtract.id,
+          }
+        );
+      },
+      {
+        concurrency: CREATION_CONCURRENCY,
+      }
+    );
+
+    if (execute) {
+      await AgentProcessAction.destroy({
+        where: {
+          id: {
+            [Op.in]: processActions.map((action) => action.id),
+          },
+          workspaceId: workspace.id,
+        },
+      });
+    }
+
+    hasMore = processActions.length === BATCH_SIZE;
+  } while (hasMore);
+}
+
+makeScript(
+  {
+    workspaceId: {
+      type: "string",
+      description: "Workspace ID to migrate",
+      required: false,
+    },
+  },
+  async ({ execute, workspaceId }, parentLogger) => {
+    const logger = parentLogger.child({ workspaceId });
+
+    if (workspaceId) {
+      const workspace = await getWorkspaceInfos(workspaceId);
+
+      if (!workspace) {
+        throw new Error(`Workspace ${workspaceId} not found`);
+      }
+
+      await migrateWorkspaceProcessActions(workspace, logger, { execute });
+    } else {
+      await runOnAllWorkspaces(
+        async (workspace) =>
+          migrateWorkspaceProcessActions(
+            workspace,
+            logger.child({ workspaceId: workspace.sId }),
+            {
+              execute,
+            }
+          ),
+        {
+          concurrency: WORKSPACE_CONCURRENCY,
+        }
+      );
+    }
+  }
+);

--- a/front/migrations/20250626_move_process_actions_to_mcp.ts
+++ b/front/migrations/20250626_move_process_actions_to_mcp.ts
@@ -108,7 +108,7 @@ function agentProcessActionToAgentMCPAction(
               fileId: processAction.jsonFileId.toString(),
               title: "Extracted Data",
               contentType: "application/json",
-              snippet: null,
+              snippet: processAction.jsonFileSnippet,
             },
           ]
         : [],


### PR DESCRIPTION
## Description

Following the pattern established in #13832 for retrieval actions, this PR migrates legacy `AgentProcessAction` records to `AgentMCPAction` records.

The process/extract action functionality was already migrated to MCP as the `extract_data` server, but the historical action records remained in the old format. This migration converts those records to the new MCP action format.

## Risks

Blast radius: Historical process/extract action records and their outputs
Risk: low (read-only migration that preserves all data)

## Tests

Tested locally by running the migration script in dry-run mode.

## Deploy Plan

- Take a database snapshot
- Run migration script: `npm run migrate -- 20250626_move_process_actions_to_mcp.ts`