### PR TITLE
[front] spaces: fix ui state for member of space

### DIFF
--- a/front/pages/api/w/[wId]/spaces/[spaceId]/index.ts
+++ b/front/pages/api/w/[wId]/spaces/[spaceId]/index.ts
@@ -115,7 +115,7 @@ async function handler(
               if (space.managementMode === "group") {
                 return g.kind === "provisioned";
               }
-              return g.kind === "regular";
+              return g.kind === "regular" || g.kind === "global";
             }),
             (group) => group.getActiveMembers(auth),
             { concurrency: 10 }


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

Following https://github.com/dust-tt/dust/commit/bb5184b1731c74c8162d36301c8bcb2293926f16, users have a banner saying they are not member of the global spaces. 

This PR fixes the filtering for public spaces.

<img width="1512" alt="Capture d’écran 2025-06-26 à 18 25 24" src="https://github.com/user-attachments/assets/b6f82f66-ca5b-4d60-9c1c-5921e77f3831" />

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

Tested by hand

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

Low

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->

Deploy front