### PR TITLE
Fix: skip when there are no forbidden tables in a dataseet

### DIFF
--- a/core/src/databases/remote_databases/bigquery.rs
+++ b/core/src/databases/remote_databases/bigquery.rs
@@ -378,6 +378,11 @@ impl BigQueryRemoteDatabase {
         let mut remaining_forbidden_tables = Vec::<String>::new();
 
         for (dataset_key, dataset) in dataset_details.iter() {
+            // Skip if there are no forbidden tables in the dataset.
+            if dataset.forbidden_tables.is_empty() {
+                continue;
+            }
+
             // This query will return the view definitions for all specified tables in the dataset, if they are views.
             let query = format!(
                 r#"SELECT table_name as view_name, view_definition


### PR DESCRIPTION
## Description

Skip check if there are no forbidden tables in a specific dataset.
See https://dust4ai.slack.com/archives/C08F378EJCD/p1750950346167629?thread_ts=1750842666.572499&cid=C08F378EJCD

## Tests

Local

## Risk

None

## Deploy Plan

Deploy core