### PR TITLE
[CLI] Add --conversationId flag for continuing conversations

### DIFF
--- a/cli/src/index.tsx
+++ b/cli/src/index.tsx
@@ -53,6 +53,11 @@ const cli = meow({
       shortFlag: "m",
       description: "Send a message to the agent non-interactively",
     },
+    conversationId: {
+      type: "string",
+      shortFlag: "c",
+      description: "Send message to an existing conversation (requires --agent and --message)",
+    },
   },
 });
 

--- a/cli/src/ui/App.tsx
+++ b/cli/src/ui/App.tsx
@@ -42,6 +42,10 @@ interface AppProps {
       type: "string";
       shortFlag: "m";
     };
+    conversationId: {
+      type: "string";
+      shortFlag: "c";
+    };
   }>;
 }
 
@@ -68,7 +72,7 @@ const App: FC<AppProps> = ({ cli }) => {
     case "agents-mcp":
       return <AgentsMCP port={flags.port} sId={flags.sId} />;
     case "chat":
-      return <Chat sId={flags.sId?.[0]} agentSearch={flags.agent} message={flags.message} />;
+      return <Chat sId={flags.sId?.[0]} agentSearch={flags.agent} message={flags.message} conversationId={flags.conversationId} />;
     case "cache:clear":
       return <Cache />;
     case "help":

--- a/cli/src/ui/Help.tsx
+++ b/cli/src/ui/Help.tsx
@@ -81,6 +81,11 @@ const Help: FC = () => {
           <Text bold>-m, --message</Text> Send a message non-interactively (requires --agent)
         </Text>
       </Box>
+      <Box marginLeft={2}>
+        <Text>
+          <Text bold>-c, --conversationId</Text> Send to existing conversation (requires --agent and --message)
+        </Text>
+      </Box>
     </Box>
   );
 };

--- a/cli/src/ui/commands/Chat.tsx
+++ b/cli/src/ui/commands/Chat.tsx
@@ -1,7 +1,6 @@
 import type {
   CreateConversationResponseType,
   GetAgentConfigurationsResponseType,
-  MeResponseType,
 } from "@dust-tt/client";
 import { Box, Text, useInput, useStdout } from "ink";
 import open from "open";
@@ -26,6 +25,7 @@ import Conversation from "../components/Conversation.js";
 import { FileSelector } from "../components/FileSelector.js";
 import type { UploadedFile } from "../components/FileUpload.js";
 import { FileUpload } from "../components/FileUpload.js";
+import { sendNonInteractiveMessage, validateNonInteractiveFlags } from "./chat/nonInteractive.js";
 import { createCommands } from "./types.js";
 
 type AgentConfiguration =
@@ -51,175 +51,13 @@ function getLastConversationItem<T extends ConversationItem>(
   return null;
 }
 
-async function sendNonInteractiveMessage(
-  message: string,
-  selectedAgent: AgentConfiguration,
-  me: MeResponseType["user"],
-  existingConversationId?: string
-): Promise<void> {
-  const dustClient = await getDustClient();
-  if (!dustClient) {
-    console.error(JSON.stringify({ 
-      error: "Authentication required",
-      details: "Run `dust login` first"
-    }));
-    process.exit(1);
-  }
-
-  try {
-    let conversation: CreateConversationResponseType["conversation"];
-    let userMessageId: string;
-    
-    if (existingConversationId) {
-      // Add message to existing conversation
-      const messageRes = await dustClient.postUserMessage({
-        conversationId: existingConversationId,
-        message: {
-          content: message,
-          mentions: [{ configurationId: selectedAgent.sId }],
-          context: {
-            timezone: Intl.DateTimeFormat().resolvedOptions().timeZone,
-            username: me.username,
-            fullName: me.fullName,
-            email: me.email,
-            origin: "api",
-          },
-        },
-      });
-
-      if (messageRes.isErr()) {
-        console.error(JSON.stringify({ 
-          error: "Error adding message to conversation",
-          details: messageRes.error.message
-        }));
-        process.exit(1);
-      }
-
-      userMessageId = messageRes.value.sId;
-
-      // Get the conversation for streaming
-      const convRes = await dustClient.getConversation({ 
-        conversationId: existingConversationId 
-      });
-      if (convRes.isErr()) {
-        console.error(JSON.stringify({ 
-          error: "Error retrieving conversation",
-          details: convRes.error.message
-        }));
-        process.exit(1);
-      }
-      conversation = convRes.value;
-    } else {
-      // Create a new conversation with the agent
-      const convRes = await dustClient.createConversation({
-        title: message.substring(0, 50) + (message.length > 50 ? "..." : ""),
-        visibility: "unlisted",
-        message: {
-          content: message,
-          mentions: [{ configurationId: selectedAgent.sId }],
-          context: {
-            timezone: Intl.DateTimeFormat().resolvedOptions().timeZone,
-            username: me.username,
-            fullName: me.fullName,
-            email: me.email,
-            origin: "api",
-          },
-        },
-        contentFragment: undefined,
-      });
-
-      if (convRes.isErr()) {
-        console.error(JSON.stringify({ 
-          error: "Failed to create conversation",
-          details: convRes.error.message
-        }));
-        process.exit(1);
-      }
-
-      conversation = convRes.value.conversation;
-      const messageId = convRes.value.message?.sId;
-      
-      if (!messageId) {
-        console.error(JSON.stringify({ 
-          error: "No message created"
-        }));
-        process.exit(1);
-      }
-      
-      userMessageId = messageId;
-    }
-
-    // Stream the agent's response
-    const streamRes = await dustClient.streamAgentAnswerEvents({
-      conversation: conversation,
-      userMessageId: userMessageId,
-    });
-
-    if (streamRes.isErr()) {
-      console.error(JSON.stringify({ 
-        error: "Failed to stream agent answer",
-        details: streamRes.error.message
-      }));
-      process.exit(1);
-    }
-
-    let fullResponse = "";
-    
-    for await (const event of streamRes.value.eventStream) {
-      if (event.type === "generation_tokens") {
-        if (event.classification === "tokens") {
-          fullResponse += event.text;
-        }
-      } else if (event.type === "agent_error") {
-        console.error(JSON.stringify({ 
-          error: "Agent error",
-          details: event.error.message
-        }));
-        process.exit(1);
-      } else if (event.type === "user_message_error") {
-        console.error(JSON.stringify({ 
-          error: "User message error",
-          details: event.error.message
-        }));
-        process.exit(1);
-      } else if (event.type === "agent_message_success") {
-        // Success - output the result
-        console.log(JSON.stringify({
-          agentId: selectedAgent.sId,
-          agentAnswer: fullResponse.trim(),
-          conversationId: conversation.sId
-        }));
-        process.exit(0);
-      }
-    }
-  } catch (error) {
-    console.error(JSON.stringify({ 
-      error: "Unexpected error",
-      details: normalizeError(error).message
-    }));
-    process.exit(1);
-  }
-}
 
 const CliChat: FC<CliChatProps> = ({ sId: requestedSId, agentSearch, message, conversationId }) => {
   const [error, setError] = useState<string | null>(null);
   
   // Validate flags usage
   useEffect(() => {
-    if (message && !agentSearch) {
-      console.error(JSON.stringify({ 
-        error: "Invalid usage",
-        details: "--message requires --agent to be specified"
-      }));
-      process.exit(1);
-    }
-    if (conversationId && (!agentSearch || !message)) {
-      console.error(JSON.stringify({ 
-        error: "Invalid usage",
-        details: "--conversationId requires both --agent and --message to be specified"
-      }));
-      process.exit(1);
-    }
+    validateNonInteractiveFlags(message, agentSearch, conversationId);
   }, [message, agentSearch, conversationId]);
   const [selectedAgent, setSelectedAgent] = useState<AgentConfiguration | null>(
     null

--- a/cli/src/ui/commands/chat/nonInteractive.ts
+++ b/cli/src/ui/commands/chat/nonInteractive.ts
@@ -1,0 +1,182 @@
+import type {
+  CreateConversationResponseType,
+  GetAgentConfigurationsResponseType,
+  MeResponseType,
+} from "@dust-tt/client";
+
+import { getDustClient } from "../../../utils/dustClient.js";
+import { normalizeError } from "../../../utils/errors.js";
+
+type AgentConfiguration =
+  GetAgentConfigurationsResponseType["agentConfigurations"][number];
+
+export async function sendNonInteractiveMessage(
+  message: string,
+  selectedAgent: AgentConfiguration,
+  me: MeResponseType["user"],
+  existingConversationId?: string
+): Promise<void> {
+  const dustClient = await getDustClient();
+  if (!dustClient) {
+    console.error(JSON.stringify({ 
+      error: "Authentication required",
+      details: "Run `dust login` first"
+    }));
+    process.exit(1);
+  }
+
+  try {
+    let conversation: CreateConversationResponseType["conversation"];
+    let userMessageId: string;
+    
+    if (existingConversationId) {
+      // Add message to existing conversation
+      const messageRes = await dustClient.postUserMessage({
+        conversationId: existingConversationId,
+        message: {
+          content: message,
+          mentions: [{ configurationId: selectedAgent.sId }],
+          context: {
+            timezone: Intl.DateTimeFormat().resolvedOptions().timeZone,
+            username: me.username,
+            fullName: me.fullName,
+            email: me.email,
+            origin: "api",
+          },
+        },
+      });
+
+      if (messageRes.isErr()) {
+        console.error(JSON.stringify({ 
+          error: "Error adding message to conversation",
+          details: messageRes.error.message
+        }));
+        process.exit(1);
+      }
+
+      userMessageId = messageRes.value.sId;
+
+      // Get the conversation for streaming
+      const convRes = await dustClient.getConversation({ 
+        conversationId: existingConversationId 
+      });
+      if (convRes.isErr()) {
+        console.error(JSON.stringify({ 
+          error: "Error retrieving conversation",
+          details: convRes.error.message
+        }));
+        process.exit(1);
+      }
+      conversation = convRes.value;
+    } else {
+      // Create a new conversation with the agent
+      const convRes = await dustClient.createConversation({
+        title: message.substring(0, 50) + (message.length > 50 ? "..." : ""),
+        visibility: "unlisted",
+        message: {
+          content: message,
+          mentions: [{ configurationId: selectedAgent.sId }],
+          context: {
+            timezone: Intl.DateTimeFormat().resolvedOptions().timeZone,
+            username: me.username,
+            fullName: me.fullName,
+            email: me.email,
+            origin: "api",
+          },
+        },
+        contentFragment: undefined,
+      });
+
+      if (convRes.isErr()) {
+        console.error(JSON.stringify({ 
+          error: "Failed to create conversation",
+          details: convRes.error.message
+        }));
+        process.exit(1);
+      }
+
+      conversation = convRes.value.conversation;
+      const messageId = convRes.value.message?.sId;
+      
+      if (!messageId) {
+        console.error(JSON.stringify({ 
+          error: "No message created"
+        }));
+        process.exit(1);
+      }
+      
+      userMessageId = messageId;
+    }
+
+    // Stream the agent's response
+    const streamRes = await dustClient.streamAgentAnswerEvents({
+      conversation: conversation,
+      userMessageId: userMessageId,
+    });
+
+    if (streamRes.isErr()) {
+      console.error(JSON.stringify({ 
+        error: "Failed to stream agent answer",
+        details: streamRes.error.message
+      }));
+      process.exit(1);
+    }
+
+    let fullResponse = "";
+    
+    for await (const event of streamRes.value.eventStream) {
+      if (event.type === "generation_tokens") {
+        if (event.classification === "tokens") {
+          fullResponse += event.text;
+        }
+      } else if (event.type === "agent_error") {
+        console.error(JSON.stringify({ 
+          error: "Agent error",
+          details: event.error.message
+        }));
+        process.exit(1);
+      } else if (event.type === "user_message_error") {
+        console.error(JSON.stringify({ 
+          error: "User message error",
+          details: event.error.message
+        }));
+        process.exit(1);
+      } else if (event.type === "agent_message_success") {
+        // Success - output the result
+        console.log(JSON.stringify({
+          agentId: selectedAgent.sId,
+          agentAnswer: fullResponse.trim(),
+          conversationId: conversation.sId
+        }));
+        process.exit(0);
+      }
+    }
+  } catch (error) {
+    console.error(JSON.stringify({ 
+      error: "Unexpected error",
+      details: normalizeError(error).message
+    }));
+    process.exit(1);
+  }
+}
+
+export function validateNonInteractiveFlags(
+  message?: string,
+  agentSearch?: string,
+  conversationId?: string
+): void {
+  if (message && !agentSearch) {
+    console.error(JSON.stringify({ 
+      error: "Invalid usage",
+      details: "--message requires --agent to be specified"
+    }));
+    process.exit(1);
+  }
+  if (conversationId && (!agentSearch || !message)) {
+    console.error(JSON.stringify({ 
+      error: "Invalid usage",
+      details: "--conversationId requires both --agent and --message to be specified"
+    }));
+    process.exit(1);
+  }
+}


### PR DESCRIPTION
## Description

This PR is the third and final part of the 3-step PR series to allow non-interactive use of the `dust` CLI chat.

The 3 PRs are:
1. ✅ Allow `dust chat --agent SEARCH_STRING` - searches for an agent matching SEARCH_STRING  
2. ✅ Allow `dust chat --agent [agent-string] --message MESSAGE` - sends MESSAGE to a new conversation
3. **This PR**: Allow `dust chat --agent [agent-string] --message MESSAGE --conversationId CID` - sends MESSAGE to existing conversation CID

This PR implements step 3: the `--conversationId` flag for continuing existing conversations.

### Implementation Details
- Added `--conversationId` flag (shorthand `-c`) to CLI argument parsing
- Validates that `--conversationId` requires both `--agent` and `--message` to be specified
- Modified `sendNonInteractiveMessage` function to accept optional conversation ID
- Uses `postUserMessage` API for existing conversations instead of `createConversation`
- Retrieves the conversation after posting for consistent streaming behavior
- Returns the same JSON format with the existing conversation ID
- Fixed naming conflict by renaming internal state from `conversationId` to `currentConversationId`

### Usage
```bash
# First message (creates conversation)
dust chat --agent "my agent" --message "Hello, what's the weather?"
# Returns: {"agentId":"agent_123","agentAnswer":"...","conversationId":"conv_abc123"}

# Continue the conversation
dust chat --agent "my agent" --message "What about tomorrow?" --conversationId "conv_abc123"
# Returns: {"agentId":"agent_123","agentAnswer":"...","conversationId":"conv_abc123"}
```

### Error Handling
- Returns JSON error if conversation is not found
- Returns JSON error if agent is not found or doesn't match
- Validates all required flags are present

## Risks

Blast radius: CLI chat functionality only
Risk: low

## Tests

- [ ] Build succeeds (`npm run build`) ✅
- [ ] Linting passes (`npm run lint`) ✅
- [ ] TypeScript check passes (`npx tsc --noEmit`) ✅
- [ ] Test creating new conversation with --agent and --message
- [ ] Test continuing conversation with --conversationId
- [ ] Test error when conversationId doesn't exist
- [ ] Test validation errors for missing required flags
- [ ] Verify interactive chat still works without flags

## Deploy Plan

No deployment steps required - CLI changes only.