### PR TITLE
Fix: bigquery modal closing too fast

### DIFF
--- a/front/components/data_source/CreateOrUpdateConnectionBigQueryModal.tsx
+++ b/front/components/data_source/CreateOrUpdateConnectionBigQueryModal.tsx
@@ -344,19 +344,22 @@ export function CreateOrUpdateConnectionBigQueryModal({
                       customItem={
                         <Tooltip
                           label={
-                            <Label htmlFor={location}>
+                            <>
                               This location contains {tables.length} tables that
                               can be connected :{" "}
                               <span className="text-xs text-gray-500">
                                 {tables.join(", ")}
                               </span>
-                            </Label>
+                            </>
                           }
                           trigger={
-                            <div className="flex items-center gap-1">
-                              <b>{location}</b> - {tables.length} tables{" "}
-                              <InformationCircleIcon />
-                            </div>
+                            <Label
+                              htmlFor={location}
+                              className="flex cursor-pointer items-center gap-1"
+                            >
+                              <span className="font-semibold">{location}</span>{" "}
+                              - {tables.length} tables <InformationCircleIcon />
+                            </Label>
                           }
                         />
                       }
@@ -374,12 +377,18 @@ export function CreateOrUpdateConnectionBigQueryModal({
           }}
           rightButtonProps={{
             label: isLoading ? "Saving..." : "Save",
-            onClick: () => {
+            onClick: async (e: React.MouseEvent<HTMLButtonElement>) => {
+              e.preventDefault();
+              e.stopPropagation();
               setIsLoading(true);
               dataSourceToUpdate
-                ? void updateBigQueryConnection()
-                : void createBigQueryConnection();
+                ? await updateBigQueryConnection()
+                : await createBigQueryConnection();
+
+              setIsLoading(false);
+              onClose();
             },
+            isLoading: isLoading || isLocationsLoading,
             disabled:
               isLoading ||
               isLocationsLoading ||

--- a/front/components/data_source/CreateOrUpdateConnectionSnowflakeModal.tsx
+++ b/front/components/data_source/CreateOrUpdateConnectionSnowflakeModal.tsx
@@ -438,12 +438,15 @@ export function CreateOrUpdateConnectionSnowflakeModal({
           }}
           rightButtonProps={{
             label: isLoading ? "Saving..." : "Save",
-            onClick: (e: React.MouseEvent<HTMLButtonElement>) => {
+            onClick: async (e: React.MouseEvent<HTMLButtonElement>) => {
               e.preventDefault();
+              e.stopPropagation();
+              setIsLoading(true);
               dataSourceToUpdate
-                ? void updateSnowflakeConnection()
-                : void createSnowflakeConnection();
+                ? await updateSnowflakeConnection()
+                : await createSnowflakeConnection();
             },
+            isLoading: isLoading,
             disabled: isLoading || !areCredentialsValid(),
           }}
         />


### PR DESCRIPTION
## Description

Fix issues with bigquery modal:
- it was closing too fast (needed e.preventDefault())
- the label was not set at the right place

## Tests

Local

## Risk

None

## Deploy Plan

Deploy front