### PR TITLE
Feature flag: Add a description per feature flag and display it on Poké

### DIFF
--- a/front/components/poke/features/columns.tsx
+++ b/front/components/poke/features/columns.tsx
@@ -7,6 +7,7 @@ import { dateToHumanReadable } from "@app/types";
 
 type FeatureFlagsDisplayType = {
   name: WhitelistableFeature;
+  description: string;
   enabled: boolean;
   enabledAt: string | null;
 };
@@ -27,6 +28,17 @@ export function makeColumnsForFeatureFlags(): ColumnDef<FeatureFlagsDisplayType>
               }
             />
           </div>
+        );
+      },
+    },
+    {
+      accessorKey: "description",
+      header: "Description",
+      cell: ({ row }) => {
+        return (
+          <span className="text-sm text-gray-600 dark:text-gray-600-night">
+            {row.original.description}
+          </span>
         );
       },
     },

--- a/front/components/poke/features/table.tsx
+++ b/front/components/poke/features/table.tsx
@@ -3,6 +3,7 @@ import { PokeDataTableConditionalFetch } from "@app/components/poke/PokeConditio
 import { PokeDataTable } from "@app/components/poke/shadcn/ui/data_table";
 import { usePokeFeatureFlags } from "@app/lib/swr/poke";
 import type { WhitelistableFeature, WorkspaceType } from "@app/types";
+import { WHITELISTABLE_FEATURES_CONFIG } from "@app/types";
 
 interface FeatureFlagsDataTableProps {
   owner: WorkspaceType;
@@ -15,9 +16,10 @@ function prepareFeatureFlagsForDisplay(
 ) {
   return whitelistableFeatures.map((ff) => {
     const enabledFlag = workspaceFlags.find((f) => f.name === ff);
-
     return {
       name: ff,
+      description:
+        WHITELISTABLE_FEATURES_CONFIG[ff]?.description ?? "[Unknown feature]",
       enabled: !!enabledFlag,
       enabledAt: enabledFlag?.createdAt || null,
     };

--- a/front/lib/api/poke/plugins/workspaces/toggle_feature_flag.ts
+++ b/front/lib/api/poke/plugins/workspaces/toggle_feature_flag.ts
@@ -1,7 +1,7 @@
 import { createPlugin } from "@app/lib/api/poke/types";
 import { FeatureFlag } from "@app/lib/models/feature_flag";
 import type { EnumValue, WhitelistableFeature } from "@app/types";
-import { mapToEnumValues, Ok } from "@app/types";
+import { Ok } from "@app/types";
 import { WHITELISTABLE_FEATURES } from "@app/types/shared/feature_flags";
 
 function convertFeatureFlagToEnumValue(
@@ -28,10 +28,7 @@ export const toggleFeatureFlagPlugin = createPlugin({
         label: "Feature Flag",
         description: "Select which feature flag you want to enable/disable",
         async: true,
-        values: mapToEnumValues(
-          WHITELISTABLE_FEATURES,
-          convertFeatureFlagToEnumValue
-        ),
+        values: WHITELISTABLE_FEATURES.map(convertFeatureFlagToEnumValue),
       },
     },
   },

--- a/front/lib/api/poke/plugins/workspaces/toggle_feature_flag.ts
+++ b/front/lib/api/poke/plugins/workspaces/toggle_feature_flag.ts
@@ -1,18 +1,8 @@
 import { createPlugin } from "@app/lib/api/poke/types";
 import { FeatureFlag } from "@app/lib/models/feature_flag";
-import type { EnumValue, WhitelistableFeature } from "@app/types";
+import type { WhitelistableFeature } from "@app/types";
 import { Ok } from "@app/types";
 import { WHITELISTABLE_FEATURES } from "@app/types/shared/feature_flags";
-
-function convertFeatureFlagToEnumValue(
-  featureFlag: WhitelistableFeature
-): EnumValue {
-  return {
-    label: featureFlag,
-    value: featureFlag,
-    checked: false,
-  };
-}
 
 export const toggleFeatureFlagPlugin = createPlugin({
   manifest: {
@@ -28,7 +18,7 @@ export const toggleFeatureFlagPlugin = createPlugin({
         label: "Feature Flag",
         description: "Select which feature flag you want to enable/disable",
         async: true,
-        values: WHITELISTABLE_FEATURES.map(convertFeatureFlagToEnumValue),
+        values: [],
       },
     },
   },

--- a/front/pages/poke/[wId]/index.tsx
+++ b/front/pages/poke/[wId]/index.tsx
@@ -100,8 +100,7 @@ export const getServerSideProps = withSuperUserAuthRequirements<{
       owner,
       activeSubscription,
       subscriptions,
-      whitelistableFeatures:
-        WHITELISTABLE_FEATURES as unknown as WhitelistableFeature[],
+      whitelistableFeatures: WHITELISTABLE_FEATURES,
       registry: getDustProdActionRegistry(),
       workspaceVerifiedDomains,
       worspaceCreationDay: format(worspaceCreationDate, "yyyy-MM-dd"),

--- a/front/types/shared/feature_flags.ts
+++ b/front/types/shared/feature_flags.ts
@@ -1,43 +1,117 @@
-export const WHITELISTABLE_FEATURES = [
-  "advanced_notion_management",
-  "advanced_search",
-  "agent_builder_v2",
-  "agent_discovery",
-  "claude_3_7_reasoning",
-  "claude_4_opus_feature",
-  "co_edition",
-  "custom_webcrawler",
-  "deepseek_feature",
-  "deepseek_r1_global_agent_feature",
-  "dev_mcp_actions",
-  "disable_run_logs",
-  "disallow_agent_creation_to_users",
-  "document_tracker",
-  "exploded_tables_query",
-  "extended_max_steps_per_run",
-  "google_ai_studio_experimental_models_feature",
-  "index_private_slack_channel",
-  "labs_mcp_actions_dashboard",
-  "labs_trackers",
-  "labs_transcripts",
-  "okta_enterprise_connection",
-  "openai_o1_custom_assistants_feature",
-  "openai_o1_feature",
-  "openai_o1_high_reasoning_custom_assistants_feature",
-  "openai_o1_high_reasoning_feature",
-  "openai_o1_mini_feature",
-  "salesforce_synced_queries",
-  "salesforce_tool",
-  "search_knowledge_builder",
-  "show_debug_tools",
-  "slack_tool",
-  "snowflake_connector_feature",
-  "usage_data_api",
-  "workos",
-  "workos_user_provisioning",
-  "xai_feature",
-] as const;
-export type WhitelistableFeature = (typeof WHITELISTABLE_FEATURES)[number];
+export const WHITELISTABLE_FEATURES_CONFIG = {
+  advanced_notion_management: {
+    description: "Advanced features for Notion workspace management",
+  },
+  advanced_search: {
+    description: "Enhanced search capabilities across workspaces",
+  },
+  agent_builder_v2: {
+    description: "Version 2 of the agent builder interface",
+  },
+  claude_3_7_reasoning: {
+    description: "Claude 3.7 reasoning capabilities",
+  },
+  claude_4_opus_feature: {
+    description: "Access to Claude 4 Opus model",
+  },
+  co_edition: {
+    description: "Collaborative editing features",
+  },
+  custom_webcrawler: {
+    description: "Custom web crawling configuration",
+  },
+  deepseek_feature: {
+    description: "Access to DeepSeek models",
+  },
+  deepseek_r1_global_agent_feature: {
+    description: "Access to DeepSeek R1 model as global agent",
+  },
+  dev_mcp_actions: {
+    description: "MCP tools currently in development",
+  },
+  disable_run_logs: {
+    description: "Disable logging of agent runs",
+  },
+  disallow_agent_creation_to_users: {
+    description: "Restrict agent creation to admins only",
+  },
+  exploded_tables_query: {
+    description: "Enhanced table querying with exploded views",
+  },
+  extended_max_steps_per_run: {
+    description: "Increase maximum steps allowed per agent run",
+  },
+  google_ai_studio_experimental_models_feature: {
+    description: "Access to experimental Google AI Studio models",
+  },
+  index_private_slack_channel: {
+    description: "Allow indexing of private Slack channels",
+  },
+  labs_mcp_actions_dashboard: {
+    description: "MCP actions dashboard in Labs section",
+  },
+  labs_trackers: {
+    description: "Tracker feature (Labs)",
+  },
+  labs_transcripts: {
+    description: "Transcript feature (Labs)",
+  },
+  okta_enterprise_connection: {
+    description: "Okta SSO enterprise connection",
+  },
+  openai_o1_custom_assistants_feature: {
+    description: "OpenAI o1 model for custom assistants",
+  },
+  openai_o1_feature: {
+    description: "Access to OpenAI o1 model",
+  },
+  openai_o1_high_reasoning_custom_assistants_feature: {
+    description: "OpenAI o1 high reasoning model for custom assistants",
+  },
+  openai_o1_high_reasoning_feature: {
+    description: "Access to OpenAI o1 high reasoning model",
+  },
+  openai_o1_mini_feature: {
+    description: "Access to OpenAI o1-mini model",
+  },
+  salesforce_synced_queries: {
+    description: "Salesforce Connection: retrieval on Synchronized queries",
+  },
+  salesforce_tool: {
+    description: "Salesforce MCP tool",
+  },
+  search_knowledge_builder: {
+    description: "Build custom knowledge bases for search",
+  },
+  show_debug_tools: {
+    description: "Display debug tools in the interface",
+  },
+  slack_tool: {
+    description: "Slack integration tool",
+  },
+  snowflake_connector_feature: {
+    description: "Snowflake database connector",
+  },
+  usage_data_api: {
+    description: "API for accessing usage data",
+  },
+  workos: {
+    description: "WorkOS authentication integration",
+  },
+  workos_user_provisioning: {
+    description: "WorkOS user provisioning features",
+  },
+  xai_feature: {
+    description: "Access to xAI models",
+  },
+} as const;
+
+export const WHITELISTABLE_FEATURES = Object.keys(
+  WHITELISTABLE_FEATURES_CONFIG
+) as WhitelistableFeature[];
+
+export type WhitelistableFeature = keyof typeof WHITELISTABLE_FEATURES_CONFIG;
+
 export function isWhitelistableFeature(
   feature: unknown
 ): feature is WhitelistableFeature {

--- a/sdks/js/src/types.ts
+++ b/sdks/js/src/types.ts
@@ -808,7 +808,6 @@ const WhitelistableFeaturesSchema = FlexibleEnumSchema<
   | "advanced_notion_management"
   | "advanced_search"
   | "agent_builder_v2"
-  | "agent_discovery"
   | "claude_3_7_reasoning"
   | "claude_4_opus_feature"
   | "co_edition"


### PR DESCRIPTION
## Description

Add a description for each feature flag and display it on poké. 
Goal is to help Success to understand what a feature flag is used for. 

<img width="1229" alt="Screenshot 2025-06-26 at 18 01 41" src="https://github.com/user-attachments/assets/1641256f-bf22-4a73-8521-bd14003ff1a2" />


Olympus task - created from Wendy's fresh eye report. 

## Tests

Locally. 

## Risk

Can be rolled back. 

## Deploy Plan

Deploy front. 