### PR TITLE
[connectors] fix(Zendesk) handle 404 in `/comments`

### DIFF
--- a/connectors/src/connectors/zendesk/lib/zendesk_api.ts
+++ b/connectors/src/connectors/zendesk/lib/zendesk_api.ts
@@ -470,10 +470,17 @@ export async function listZendeskTicketComments({
   let hasMore = true;
 
   while (hasMore) {
-    const response = await fetchFromZendeskWithRetries({ url, accessToken });
-    comments.push(...response.comments);
-    hasMore = response.hasMore || false;
-    url = response.nextLink;
+    try {
+      const response = await fetchFromZendeskWithRetries({ url, accessToken });
+      comments.push(...response.comments);
+      hasMore = response.hasMore || false;
+      url = response.nextLink;
+    } catch (e) {
+      if (isZendeskNotFoundError(e)) {
+        return [];
+      }
+      throw e;
+    }
   }
   return comments;
 }

--- a/connectors/src/connectors/zendesk/temporal/activities.ts
+++ b/connectors/src/connectors/zendesk/temporal/activities.ts
@@ -665,12 +665,20 @@ export async function syncZendeskTicketBatchActivity({
 
   const comments2d = await concurrentExecutor(
     ticketsToSync,
-    async (ticket) =>
-      listZendeskTicketComments({
+    async (ticket) => {
+      const comments = await listZendeskTicketComments({
         accessToken,
         brandSubdomain,
         ticketId: ticket.id,
-      }),
+      });
+      if (comments.length > 0) {
+        logger.info(
+          { ...loggerArgs, ticketId: ticket.id },
+          "[Zendesk] No comment for ticket."
+        );
+      }
+      return comments;
+    },
     { concurrency: 3, onBatchComplete: heartbeat }
   );
   const users = configuration.hideCustomerDetails

--- a/connectors/src/connectors/zendesk/temporal/incremental_activities.ts
+++ b/connectors/src/connectors/zendesk/temporal/incremental_activities.ts
@@ -264,11 +264,18 @@ export async function syncZendeskTicketUpdateBatchActivity({
   await concurrentExecutor(
     tickets,
     async (ticket) => {
-      commentsPerTicket[ticket.id] = await listZendeskTicketComments({
+      const comments = await listZendeskTicketComments({
         accessToken,
         brandSubdomain,
         ticketId: ticket.id,
       });
+      if (comments.length > 0) {
+        logger.info(
+          { ...loggerArgs, ticketId: ticket.id },
+          "[Zendesk] No comment for ticket."
+        );
+      }
+      commentsPerTicket[ticket.id] = comments;
     },
     { concurrency: 10 }
   );

--- a/connectors/src/connectors/zendesk/temporal/incremental_activities.ts
+++ b/connectors/src/connectors/zendesk/temporal/incremental_activities.ts
@@ -277,7 +277,7 @@ export async function syncZendeskTicketUpdateBatchActivity({
       }
       commentsPerTicket[ticket.id] = comments;
     },
-    { concurrency: 10 }
+    { concurrency: 3 }
   );
 
   // If we hide customer details, we don't need to fetch the users at all.


### PR DESCRIPTION
## Description

- We have observed 404 in the `/comments` endpoint (logs [here](https://app.datadoghq.eu/logs?query=%28%22Activity%20failed%22%20OR%20%22Unhandled%20activity%20error%22%29%20%40attempt%3A%3E19%20%40dd.service%3Aconnectors-worker%20region%3Aus-central1&agg_m=count&agg_m_source=base&agg_t=count&cols=host%2Cservice&event=AwAAAZewwZenHXaWcwAAABhBWmV3d2F4c0FBRG1RY1NjMnAzbHBRQ1UAAAAkMDE5N2IwYzItNmRjZC00YTdmLTlhZDMtYmU1OGI3MzM2NzEzAAAKmA&link_source=monitor_notif&messageDisplay=inline&refresh_mode=sliding&storage=hot&stream_sort=desc&viz=stream&from_ts=1751003039653&to_ts=1751017439653&live=true)).
- This PR adds handling around that.

## Tests

## Risk

## Deploy Plan

- Deploy connectors.
