### PR TITLE
[front] fix origin for enterprise auto-join users

### DIFF
--- a/front/lib/api/signup.ts
+++ b/front/lib/api/signup.ts
@@ -225,7 +225,7 @@ export async function handleEnterpriseSignUpFlow(
       workspace,
       user,
       role: pendingMembershipInvitation?.initialRole ?? "user",
-      origin: pendingMembershipInvitation ? "invited" : "provisioned",
+      origin: pendingMembershipInvitation ? "invited" : "auto-joined",
     });
   }
 


### PR DESCRIPTION
## Description

- Fix the origin for enterprise users who auto-join their workspace.

## Tests

## Risk

## Deploy Plan

- Deploy front.
- Backfill for existing users (only 2 users).
