### PR TITLE
Handle team id correctly

### DIFF
--- a/core/src/oauth/connection.rs
+++ b/core/src/oauth/connection.rs
@@ -14,7 +14,7 @@ use crate::oauth::{
 };
 use crate::utils;
 use crate::utils::ParseError;
-use anyhow::Result;
+use anyhow::{anyhow, Result};
 use async_trait::async_trait;
 use lazy_static::lazy_static;
 use rslock::LockManager;
@@ -134,6 +134,7 @@ pub struct FinalizeResult {
     pub access_token_expiry: Option<u64>,
     pub refresh_token: Option<String>,
     pub raw_json: serde_json::Value,
+    pub extra_metadata: Option<serde_json::Map<String, serde_json::Value>>,
 }
 
 #[derive(Debug, Clone, Serialize, PartialEq, Deserialize)]
@@ -644,6 +645,19 @@ impl Connection {
         };
         self.encrypted_raw_json = Some(seal_str(&serde_json::to_string(&finalize.raw_json)?)?);
         store.update_connection_secrets(self).await?;
+
+        // If the provider has extra metadata, merge it with the connection metadata.
+        if let Some(extra_metadata) = finalize.extra_metadata {
+            let mut merged_metadata = match self.metadata.clone() {
+                serde_json::Value::Object(map) => map,
+                _ => Err(anyhow!("Invalid `metadata` stored on connection."))?,
+            };
+            for (key, value) in extra_metadata {
+                merged_metadata.insert(key.clone(), value.clone());
+            }
+            self.metadata = serde_json::Value::Object(merged_metadata);
+            store.update_connection_metadata(self).await?;
+        }
 
         info!(
             connection_id = self.connection_id(),

--- a/core/src/oauth/providers/confluence.rs
+++ b/core/src/oauth/providers/confluence.rs
@@ -94,6 +94,7 @@ impl Provider for ConfluenceConnectionProvider {
             ),
             refresh_token: Some(refresh_token.to_string()),
             raw_json,
+            extra_metadata: None,
         })
     }
 

--- a/core/src/oauth/providers/github.rs
+++ b/core/src/oauth/providers/github.rs
@@ -171,6 +171,7 @@ impl Provider for GithubConnectionProvider {
             access_token_expiry: Some(expiry),
             refresh_token: None,
             raw_json,
+            extra_metadata: None,
         })
     }
 

--- a/core/src/oauth/providers/gmail.rs
+++ b/core/src/oauth/providers/gmail.rs
@@ -114,6 +114,7 @@ impl Provider for GmailConnectionProvider {
             ),
             refresh_token: Some(refresh_token.to_string()),
             raw_json,
+            extra_metadata: None,
         })
     }
 

--- a/core/src/oauth/providers/gong.rs
+++ b/core/src/oauth/providers/gong.rs
@@ -93,6 +93,7 @@ impl Provider for GongConnectionProvider {
             ),
             refresh_token: Some(refresh_token.to_string()),
             raw_json,
+            extra_metadata: None,
         })
     }
 

--- a/core/src/oauth/providers/google_drive.rs
+++ b/core/src/oauth/providers/google_drive.rs
@@ -99,6 +99,7 @@ impl Provider for GoogleDriveConnectionProvider {
             ),
             refresh_token: Some(refresh_token.to_string()),
             raw_json,
+            extra_metadata: None,
         })
     }
 

--- a/core/src/oauth/providers/hubspot.rs
+++ b/core/src/oauth/providers/hubspot.rs
@@ -72,6 +72,7 @@ impl Provider for HubspotConnectionProvider {
             ),
             refresh_token: result["refresh_token"].as_str().map(|s| s.to_string()),
             raw_json: result,
+            extra_metadata: None,
         })
     }
 

--- a/core/src/oauth/providers/intercom.rs
+++ b/core/src/oauth/providers/intercom.rs
@@ -68,6 +68,7 @@ impl Provider for IntercomConnectionProvider {
             access_token_expiry: None,
             refresh_token: None,
             raw_json,
+            extra_metadata: None,
         })
     }
 

--- a/core/src/oauth/providers/mcp.rs
+++ b/core/src/oauth/providers/mcp.rs
@@ -139,6 +139,7 @@ impl Provider for MCPConnectionProvider {
             ),
             refresh_token: refresh_token,
             raw_json,
+            extra_metadata: None,
         })
     }
 

--- a/core/src/oauth/providers/microsoft.rs
+++ b/core/src/oauth/providers/microsoft.rs
@@ -135,6 +135,7 @@ impl Provider for MicrosoftConnectionProvider {
             ),
             refresh_token: refresh_token.map(|s| s.to_string()),
             raw_json,
+            extra_metadata: None,
         })
     }
 

--- a/core/src/oauth/providers/mock.rs
+++ b/core/src/oauth/providers/mock.rs
@@ -40,6 +40,7 @@ impl Provider for MockConnectionProvider {
             access_token_expiry: Some(utils::now() + ACCESS_TOKEN_REFRESH_BUFFER_MILLIS + 1000),
             refresh_token: Some("mock_refresh_token".to_string()),
             raw_json: json!({}),
+            extra_metadata: None,
         })
     }
 

--- a/core/src/oauth/providers/notion.rs
+++ b/core/src/oauth/providers/notion.rs
@@ -106,6 +106,7 @@ impl Provider for NotionConnectionProvider {
             access_token_expiry: None,
             refresh_token: None,
             raw_json,
+            extra_metadata: None,
         })
     }
 

--- a/core/src/oauth/providers/salesforce.rs
+++ b/core/src/oauth/providers/salesforce.rs
@@ -126,6 +126,7 @@ impl Provider for SalesforceConnectionProvider {
             access_token_expiry: Some(utils::now() + 15 * 60 * 1000),
             refresh_token: Some(refresh_token.to_string()),
             raw_json,
+            extra_metadata: None,
         })
     }
 

--- a/core/src/oauth/providers/slack_bot.rs
+++ b/core/src/oauth/providers/slack_bot.rs
@@ -77,6 +77,7 @@ impl Provider for SlackBotConnectionProvider {
             access_token_expiry: None,
             refresh_token: None,
             raw_json,
+            extra_metadata: None,
         })
     }
 

--- a/core/src/oauth/providers/zendesk.rs
+++ b/core/src/oauth/providers/zendesk.rs
@@ -85,6 +85,7 @@ impl Provider for ZendeskConnectionProvider {
             access_token_expiry: None,
             refresh_token: None,
             raw_json,
+            extra_metadata: None,
         })
     }
 

--- a/front/lib/api/oauth/providers/base_oauth_stragegy_provider.ts
+++ b/front/lib/api/oauth/providers/base_oauth_stragegy_provider.ts
@@ -7,29 +7,9 @@ import type { OAuthConnectionType } from "@app/types/oauth/lib";
 import type { OAuthUseCase } from "@app/types/oauth/lib";
 
 // Use this if you need to associate credentials with the connection (eg: custom client_secret).
-// You need to return an updatedConfig (usually because you remove the secret that you added to credentials).
-export type UpdatedExtraConfigAndRelatedCredential = {
-  updatedConfig: ExtraConfigType;
-  credential: {
-    content: Record<string, string>;
-    metadata: { workspace_id: string; user_id: string };
-  };
-};
-
-export function isUpdatedExtraConfigAndRelatedCredential(
-  result: UpdatedExtraConfigAndRelatedCredential | UpdatedExtraConfig
-): result is UpdatedExtraConfigAndRelatedCredential {
-  return (
-    "credential" in result &&
-    result.credential !== undefined &&
-    "updatedConfig" in result &&
-    result.updatedConfig !== undefined
-  );
-}
-
-// Use this if you just want to enrich the config (eg: add PKCE, some metadata..)
-export type UpdatedExtraConfig = {
-  updatedConfig: ExtraConfigType;
+export type RelatedCredential = {
+  content: Record<string, string>;
+  metadata: { workspace_id: string; user_id: string };
 };
 
 export interface BaseOAuthStrategyProvider {
@@ -62,7 +42,7 @@ export interface BaseOAuthStrategyProvider {
   ) => boolean;
 
   // If the provider has a method for getting the related credential and/or if we need to update the config.
-  updateConfigAndGetRelatedCredential?: (
+  getRelatedCredential?: (
     auth: Authenticator,
     {
       extraConfig,
@@ -75,9 +55,18 @@ export interface BaseOAuthStrategyProvider {
       userId: string;
       useCase: OAuthUseCase;
     }
-  ) => Promise<
-    UpdatedExtraConfigAndRelatedCredential | UpdatedExtraConfig | null
-  >;
+  ) => Promise<RelatedCredential>;
+
+  getUpdatedExtraConfig?: (
+    auth: Authenticator,
+    {
+      extraConfig,
+      useCase,
+    }: {
+      extraConfig: ExtraConfigType;
+      useCase: OAuthUseCase;
+    }
+  ) => Promise<ExtraConfigType>;
 
   isExtraConfigValidPostRelatedCredential?: (
     extraConfig: ExtraConfigType,

--- a/front/lib/api/oauth/providers/base_oauth_stragegy_provider.ts
+++ b/front/lib/api/oauth/providers/base_oauth_stragegy_provider.ts
@@ -2,8 +2,35 @@ import type { ParsedUrlQuery } from "querystring";
 
 import type { Authenticator } from "@app/lib/auth";
 import type { ExtraConfigType } from "@app/pages/w/[wId]/oauth/[provider]/setup";
+import type { Result } from "@app/types";
 import type { OAuthConnectionType } from "@app/types/oauth/lib";
 import type { OAuthUseCase } from "@app/types/oauth/lib";
+
+// Use this if you need to associate credentials with the connection (eg: custom client_secret).
+// You need to return an updatedConfig (usually because you remove the secret that you added to credentials).
+export type UpdatedExtraConfigAndRelatedCredential = {
+  updatedConfig: ExtraConfigType;
+  credential: {
+    content: Record<string, string>;
+    metadata: { workspace_id: string; user_id: string };
+  };
+};
+
+export function isUpdatedExtraConfigAndRelatedCredential(
+  result: UpdatedExtraConfigAndRelatedCredential | UpdatedExtraConfig
+): result is UpdatedExtraConfigAndRelatedCredential {
+  return (
+    "credential" in result &&
+    result.credential !== undefined &&
+    "updatedConfig" in result &&
+    result.updatedConfig !== undefined
+  );
+}
+
+// Use this if you just want to enrich the config (eg: add PKCE, some metadata..)
+export type UpdatedExtraConfig = {
+  updatedConfig: ExtraConfigType;
+};
 
 export interface BaseOAuthStrategyProvider {
   setupUri: ({
@@ -34,23 +61,30 @@ export interface BaseOAuthStrategyProvider {
     useCase: OAuthUseCase
   ) => boolean;
 
-  // If the provider has a method for getting the related credential, it must return a cleaned config.
-  getRelatedCredential?: (
+  // If the provider has a method for getting the related credential and/or if we need to update the config.
+  updateConfigAndGetRelatedCredential?: (
     auth: Authenticator,
-    extraConfig: ExtraConfigType,
-    workspaceId: string,
-    userId: string,
-    useCase: OAuthUseCase
-  ) => Promise<{
-    credential: {
-      content: Record<string, string>;
-      metadata: { workspace_id: string; user_id: string };
-    };
-    cleanedConfig: ExtraConfigType;
-  } | null>;
+    {
+      extraConfig,
+      workspaceId,
+      userId,
+      useCase,
+    }: {
+      extraConfig: ExtraConfigType;
+      workspaceId: string;
+      userId: string;
+      useCase: OAuthUseCase;
+    }
+  ) => Promise<
+    UpdatedExtraConfigAndRelatedCredential | UpdatedExtraConfig | null
+  >;
 
   isExtraConfigValidPostRelatedCredential?: (
     extraConfig: ExtraConfigType,
     useCase: OAuthUseCase
   ) => boolean;
+
+  checkConnectionValidPostFinalize?: (
+    connection: OAuthConnectionType
+  ) => Result<void, { message: string }>;
 }

--- a/front/lib/api/oauth/providers/gmail.ts
+++ b/front/lib/api/oauth/providers/gmail.ts
@@ -2,7 +2,10 @@ import type { ParsedUrlQuery } from "querystring";
 import querystring from "querystring";
 
 import config from "@app/lib/api/config";
-import type { BaseOAuthStrategyProvider } from "@app/lib/api/oauth/providers/base_oauth_stragegy_provider";
+import type {
+  BaseOAuthStrategyProvider,
+  UpdatedExtraConfigAndRelatedCredential,
+} from "@app/lib/api/oauth/providers/base_oauth_stragegy_provider";
 import {
   finalizeUriForProvider,
   getStringFromQuery,
@@ -62,19 +65,20 @@ export class GmailOAuthProvider implements BaseOAuthStrategyProvider {
     return Object.keys(extraConfig).length === 0;
   }
 
-  async getRelatedCredential(
+  async updateConfigAndGetRelatedCredential(
     auth: Authenticator,
-    extraConfig: ExtraConfigType,
-    workspaceId: string,
-    userId: string,
-    useCase: OAuthUseCase
-  ): Promise<{
-    credential: {
-      content: Record<string, string>;
-      metadata: { workspace_id: string; user_id: string };
-    };
-    cleanedConfig: ExtraConfigType;
-  } | null> {
+    {
+      extraConfig,
+      workspaceId,
+      userId,
+      useCase,
+    }: {
+      extraConfig: ExtraConfigType;
+      workspaceId: string;
+      userId: string;
+      useCase: OAuthUseCase;
+    }
+  ): Promise<UpdatedExtraConfigAndRelatedCredential | null> {
     if (useCase === "personal_actions") {
       // For personal actions we reuse the existing connection credential id from the existing
       // workspace connection (setup by admin) if we have it, otherwise we fallback to assuming
@@ -109,7 +113,7 @@ export class GmailOAuthProvider implements BaseOAuthStrategyProvider {
             },
             metadata: { workspace_id: workspaceId, user_id: userId },
           },
-          cleanedConfig: {
+          updatedConfig: {
             client_id: connection.metadata.client_id,
             ...restConfig,
           },
@@ -127,7 +131,7 @@ export class GmailOAuthProvider implements BaseOAuthStrategyProvider {
         },
         metadata: { workspace_id: workspaceId, user_id: userId },
       },
-      cleanedConfig: restConfig,
+      updatedConfig: restConfig,
     };
   }
 }

--- a/front/lib/api/oauth/providers/gmail.ts
+++ b/front/lib/api/oauth/providers/gmail.ts
@@ -4,7 +4,7 @@ import querystring from "querystring";
 import config from "@app/lib/api/config";
 import type {
   BaseOAuthStrategyProvider,
-  UpdatedExtraConfigAndRelatedCredential,
+  RelatedCredential,
 } from "@app/lib/api/oauth/providers/base_oauth_stragegy_provider";
 import {
   finalizeUriForProvider,
@@ -65,7 +65,7 @@ export class GmailOAuthProvider implements BaseOAuthStrategyProvider {
     return Object.keys(extraConfig).length === 0;
   }
 
-  async updateConfigAndGetRelatedCredential(
+  async getRelatedCredential(
     auth: Authenticator,
     {
       extraConfig,
@@ -78,7 +78,70 @@ export class GmailOAuthProvider implements BaseOAuthStrategyProvider {
       userId: string;
       useCase: OAuthUseCase;
     }
-  ): Promise<UpdatedExtraConfigAndRelatedCredential | null> {
+  ): Promise<RelatedCredential> {
+    if (useCase === "personal_actions") {
+      // For personal actions we reuse the existing connection credential id from the existing
+      // workspace connection (setup by admin) if we have it, otherwise we fallback to assuming
+      // we have client_secret (initial admin setup).
+      const { mcp_server_id } = extraConfig;
+
+      if (mcp_server_id) {
+        const mcpServerConnectionRes =
+          await MCPServerConnectionResource.findByMCPServer(auth, {
+            mcpServerId: mcp_server_id,
+            connectionType: "workspace",
+          });
+
+        if (mcpServerConnectionRes.isErr()) {
+          throw new Error(
+            "Failed to find MCP server connection: " +
+              mcpServerConnectionRes.error.message
+          );
+        }
+
+        const oauthApi = new OAuthAPI(config.getOAuthAPIConfig(), logger);
+        const connectionRes = await oauthApi.getAccessToken({
+          connectionId: mcpServerConnectionRes.value.connectionId,
+        });
+        if (connectionRes.isErr()) {
+          throw new Error(
+            "Failed to get connection metadata: " + connectionRes.error.message
+          );
+        }
+        const connection = connectionRes.value.connection;
+        const connectionId = connection.connection_id;
+
+        return {
+          content: {
+            from_connection_id: connectionId,
+          },
+          metadata: { workspace_id: workspaceId, user_id: userId },
+        };
+      }
+    }
+
+    const { client_secret } = extraConfig;
+
+    return {
+      content: {
+        client_secret: client_secret,
+        client_id: extraConfig.client_id,
+      },
+      metadata: { workspace_id: workspaceId, user_id: userId },
+    };
+  }
+
+  async getUpdatedExtraConfig(
+    auth: Authenticator,
+    {
+      extraConfig,
+
+      useCase,
+    }: {
+      extraConfig: ExtraConfigType;
+      useCase: OAuthUseCase;
+    }
+  ): Promise<ExtraConfigType> {
     if (useCase === "personal_actions") {
       // For personal actions we reuse the existing connection credential id from the existing
       // workspace connection (setup by admin) if we have it, otherwise we fallback to assuming
@@ -93,7 +156,10 @@ export class GmailOAuthProvider implements BaseOAuthStrategyProvider {
           });
 
         if (mcpServerConnectionRes.isErr()) {
-          return null;
+          throw new Error(
+            "Failed to find MCP server connection: " +
+              mcpServerConnectionRes.error.message
+          );
         }
 
         const oauthApi = new OAuthAPI(config.getOAuthAPIConfig(), logger);
@@ -101,37 +167,22 @@ export class GmailOAuthProvider implements BaseOAuthStrategyProvider {
           connectionId: mcpServerConnectionRes.value.connectionId,
         });
         if (connectionRes.isErr()) {
-          return null;
+          throw new Error(
+            "Failed to get connection metadata: " + connectionRes.error.message
+          );
         }
         const connection = connectionRes.value.connection;
-        const connectionId = connection.connection_id;
 
         return {
-          credential: {
-            content: {
-              from_connection_id: connectionId,
-            },
-            metadata: { workspace_id: workspaceId, user_id: userId },
-          },
-          updatedConfig: {
-            client_id: connection.metadata.client_id,
-            ...restConfig,
-          },
+          client_id: connection.metadata.client_id,
+          ...restConfig,
         };
       }
     }
 
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars -- we filter out the client_secret from the extraConfig.
     const { client_secret, ...restConfig } = extraConfig;
-    // Keep client_id in metadata in clear text.
-    return {
-      credential: {
-        content: {
-          client_secret: client_secret,
-          client_id: extraConfig.client_id,
-        },
-        metadata: { workspace_id: workspaceId, user_id: userId },
-      },
-      updatedConfig: restConfig,
-    };
+
+    return restConfig;
   }
 }

--- a/front/lib/api/oauth/providers/microsoft.ts
+++ b/front/lib/api/oauth/providers/microsoft.ts
@@ -4,7 +4,7 @@ import querystring from "querystring";
 import config from "@app/lib/api/config";
 import type {
   BaseOAuthStrategyProvider,
-  UpdatedExtraConfigAndRelatedCredential,
+  RelatedCredential,
 } from "@app/lib/api/oauth/providers/base_oauth_stragegy_provider";
 import {
   finalizeUriForProvider,
@@ -68,8 +68,7 @@ export class MicrosoftOAuthProvider implements BaseOAuthStrategyProvider {
       )
     );
   }
-
-  async updateConfigAndGetRelatedCredential(
+  async getRelatedCredential(
     auth: Authenticator,
     {
       extraConfig,
@@ -80,20 +79,31 @@ export class MicrosoftOAuthProvider implements BaseOAuthStrategyProvider {
       workspaceId: string;
       userId: string;
     }
-  ): Promise<UpdatedExtraConfigAndRelatedCredential | null> {
-    const { client_id, client_secret, ...restConfig } = extraConfig;
+  ): Promise<RelatedCredential> {
+    const { client_id, client_secret } = extraConfig;
     if (!client_id || !client_secret) {
-      return null;
+      throw new Error("Client ID and client secret are required");
     }
     return {
-      credential: {
-        content: {
-          client_id,
-          client_secret,
-        },
-        metadata: { workspace_id: workspaceId, user_id: userId },
+      content: {
+        client_id,
+        client_secret,
       },
-      updatedConfig: restConfig,
+      metadata: { workspace_id: workspaceId, user_id: userId },
     };
+  }
+
+  async getUpdatedExtraConfig(
+    auth: Authenticator,
+    {
+      extraConfig,
+    }: {
+      extraConfig: ExtraConfigType;
+    }
+  ): Promise<ExtraConfigType> {
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars -- we filter out the client_id and client_secret from the extraConfig.
+    const { client_secret, ...restConfig } = extraConfig;
+
+    return restConfig;
   }
 }

--- a/front/lib/api/oauth/providers/microsoft.ts
+++ b/front/lib/api/oauth/providers/microsoft.ts
@@ -2,7 +2,10 @@ import type { ParsedUrlQuery } from "querystring";
 import querystring from "querystring";
 
 import config from "@app/lib/api/config";
-import type { BaseOAuthStrategyProvider } from "@app/lib/api/oauth/providers/base_oauth_stragegy_provider";
+import type {
+  BaseOAuthStrategyProvider,
+  UpdatedExtraConfigAndRelatedCredential,
+} from "@app/lib/api/oauth/providers/base_oauth_stragegy_provider";
 import {
   finalizeUriForProvider,
   getStringFromQuery,
@@ -66,12 +69,18 @@ export class MicrosoftOAuthProvider implements BaseOAuthStrategyProvider {
     );
   }
 
-  async getRelatedCredential(
+  async updateConfigAndGetRelatedCredential(
     auth: Authenticator,
-    extraConfig: ExtraConfigType,
-    workspaceId: string,
-    userId: string
-  ) {
+    {
+      extraConfig,
+      workspaceId,
+      userId,
+    }: {
+      extraConfig: ExtraConfigType;
+      workspaceId: string;
+      userId: string;
+    }
+  ): Promise<UpdatedExtraConfigAndRelatedCredential | null> {
     const { client_id, client_secret, ...restConfig } = extraConfig;
     if (!client_id || !client_secret) {
       return null;
@@ -84,7 +93,7 @@ export class MicrosoftOAuthProvider implements BaseOAuthStrategyProvider {
         },
         metadata: { workspace_id: workspaceId, user_id: userId },
       },
-      cleanedConfig: restConfig,
+      updatedConfig: restConfig,
     };
   }
 }

--- a/front/lib/api/oauth/providers/salesforce.ts
+++ b/front/lib/api/oauth/providers/salesforce.ts
@@ -1,7 +1,10 @@
 import type { ParsedUrlQuery } from "querystring";
 
 import config from "@app/lib/api/config";
-import type { BaseOAuthStrategyProvider } from "@app/lib/api/oauth/providers/base_oauth_stragegy_provider";
+import type {
+  BaseOAuthStrategyProvider,
+  UpdatedExtraConfigAndRelatedCredential,
+} from "@app/lib/api/oauth/providers/base_oauth_stragegy_provider";
 import {
   finalizeUriForProvider,
   getStringFromQuery,
@@ -70,19 +73,20 @@ export class SalesforceOAuthProvider implements BaseOAuthStrategyProvider {
     return isValidSalesforceDomain(extraConfig.instance_url);
   }
 
-  async getRelatedCredential(
+  async updateConfigAndGetRelatedCredential(
     auth: Authenticator,
-    extraConfig: ExtraConfigType,
-    workspaceId: string,
-    userId: string,
-    useCase: OAuthUseCase
-  ): Promise<{
-    credential: {
-      content: Record<string, string>;
-      metadata: { workspace_id: string; user_id: string };
-    };
-    cleanedConfig: ExtraConfigType;
-  } | null> {
+    {
+      extraConfig,
+      workspaceId,
+      userId,
+      useCase,
+    }: {
+      extraConfig: ExtraConfigType;
+      workspaceId: string;
+      userId: string;
+      useCase: OAuthUseCase;
+    }
+  ): Promise<UpdatedExtraConfigAndRelatedCredential | null> {
     if (useCase === "personal_actions") {
       // For personal actions we reuse the existing connection credential id from the existing
       // workspace connection (setup by admin) if we have it, otherwise we fallback to assuming
@@ -119,7 +123,7 @@ export class SalesforceOAuthProvider implements BaseOAuthStrategyProvider {
             },
             metadata: { workspace_id: workspaceId, user_id: userId },
           },
-          cleanedConfig: {
+          updatedConfig: {
             ...restConfig,
             client_id: connection.metadata.client_id,
             instance_url: connection.metadata.instance_url,
@@ -142,7 +146,7 @@ export class SalesforceOAuthProvider implements BaseOAuthStrategyProvider {
         },
         metadata: { workspace_id: workspaceId, user_id: userId },
       },
-      cleanedConfig: {
+      updatedConfig: {
         ...restConfig,
         code_verifier,
         code_challenge,

--- a/front/lib/api/oauth/providers/salesforce.ts
+++ b/front/lib/api/oauth/providers/salesforce.ts
@@ -3,7 +3,7 @@ import type { ParsedUrlQuery } from "querystring";
 import config from "@app/lib/api/config";
 import type {
   BaseOAuthStrategyProvider,
-  UpdatedExtraConfigAndRelatedCredential,
+  RelatedCredential,
 } from "@app/lib/api/oauth/providers/base_oauth_stragegy_provider";
 import {
   finalizeUriForProvider,
@@ -73,7 +73,7 @@ export class SalesforceOAuthProvider implements BaseOAuthStrategyProvider {
     return isValidSalesforceDomain(extraConfig.instance_url);
   }
 
-  async updateConfigAndGetRelatedCredential(
+  async getRelatedCredential(
     auth: Authenticator,
     {
       extraConfig,
@@ -86,7 +86,69 @@ export class SalesforceOAuthProvider implements BaseOAuthStrategyProvider {
       userId: string;
       useCase: OAuthUseCase;
     }
-  ): Promise<UpdatedExtraConfigAndRelatedCredential | null> {
+  ): Promise<RelatedCredential> {
+    if (useCase === "personal_actions") {
+      // For personal actions we reuse the existing connection credential id from the existing
+      // workspace connection (setup by admin) if we have it, otherwise we fallback to assuming
+      // we have client_secret and instance_url (initial admin setup).
+      const { mcp_server_id } = extraConfig;
+
+      if (mcp_server_id) {
+        const mcpServerConnectionRes =
+          await MCPServerConnectionResource.findByMCPServer(auth, {
+            mcpServerId: mcp_server_id,
+            connectionType: "workspace",
+          });
+
+        if (mcpServerConnectionRes.isErr()) {
+          throw new Error(
+            "Failed to find MCP server connection: " +
+              mcpServerConnectionRes.error.message
+          );
+        }
+
+        const oauthApi = new OAuthAPI(config.getOAuthAPIConfig(), logger);
+        const connectionRes = await oauthApi.getConnectionMetadata({
+          connectionId: mcpServerConnectionRes.value.connectionId,
+        });
+        if (connectionRes.isErr()) {
+          throw new Error(
+            "Failed to get connection metadata: " + connectionRes.error.message
+          );
+        }
+        const connection = connectionRes.value.connection;
+        const connectionId = connection.connection_id;
+
+        return {
+          content: {
+            from_connection_id: connectionId,
+          },
+          metadata: { workspace_id: workspaceId, user_id: userId },
+        };
+      }
+    }
+
+    const { client_secret } = extraConfig;
+
+    return {
+      content: {
+        client_secret,
+        client_id: extraConfig.client_id,
+      },
+      metadata: { workspace_id: workspaceId, user_id: userId },
+    };
+  }
+
+  async getUpdatedExtraConfig(
+    auth: Authenticator,
+    {
+      extraConfig,
+      useCase,
+    }: {
+      extraConfig: ExtraConfigType;
+      useCase: OAuthUseCase;
+    }
+  ): Promise<ExtraConfigType> {
     if (useCase === "personal_actions") {
       // For personal actions we reuse the existing connection credential id from the existing
       // workspace connection (setup by admin) if we have it, otherwise we fallback to assuming
@@ -101,7 +163,10 @@ export class SalesforceOAuthProvider implements BaseOAuthStrategyProvider {
           });
 
         if (mcpServerConnectionRes.isErr()) {
-          return null;
+          throw new Error(
+            "Failed to find MCP server connection: " +
+              mcpServerConnectionRes.error.message
+          );
         }
 
         const oauthApi = new OAuthAPI(config.getOAuthAPIConfig(), logger);
@@ -109,48 +174,33 @@ export class SalesforceOAuthProvider implements BaseOAuthStrategyProvider {
           connectionId: mcpServerConnectionRes.value.connectionId,
         });
         if (connectionRes.isErr()) {
-          return null;
+          throw new Error(
+            "Failed to get connection metadata: " + connectionRes.error.message
+          );
         }
         const connection = connectionRes.value.connection;
-        const connectionId = connection.connection_id;
 
         const { code_verifier, code_challenge } = await getPKCEConfig();
 
         return {
-          credential: {
-            content: {
-              from_connection_id: connectionId,
-            },
-            metadata: { workspace_id: workspaceId, user_id: userId },
-          },
-          updatedConfig: {
-            ...restConfig,
-            client_id: connection.metadata.client_id,
-            instance_url: connection.metadata.instance_url,
-            code_verifier,
-            code_challenge,
-          },
+          ...restConfig,
+          client_id: connection.metadata.client_id,
+          instance_url: connection.metadata.instance_url,
+          code_verifier,
+          code_challenge,
         };
       }
     }
 
     const { code_verifier, code_challenge } = await getPKCEConfig();
 
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars -- we filter out the client_secret from the extraConfig.
     const { client_secret, ...restConfig } = extraConfig;
-    // Keep client_id in metadata in clear text.
+
     return {
-      credential: {
-        content: {
-          client_secret,
-          client_id: extraConfig.client_id,
-        },
-        metadata: { workspace_id: workspaceId, user_id: userId },
-      },
-      updatedConfig: {
-        ...restConfig,
-        code_verifier,
-        code_challenge,
-      },
+      ...restConfig,
+      code_verifier,
+      code_challenge,
     };
   }
 }

--- a/front/lib/api/oauth/providers/slack.ts
+++ b/front/lib/api/oauth/providers/slack.ts
@@ -1,12 +1,19 @@
 import type { ParsedUrlQuery } from "querystring";
 
 import config from "@app/lib/api/config";
-import type { BaseOAuthStrategyProvider } from "@app/lib/api/oauth/providers/base_oauth_stragegy_provider";
+import type {
+  BaseOAuthStrategyProvider,
+  UpdatedExtraConfig,
+} from "@app/lib/api/oauth/providers/base_oauth_stragegy_provider";
 import {
   finalizeUriForProvider,
   getStringFromQuery,
 } from "@app/lib/api/oauth/utils";
+import type { Authenticator } from "@app/lib/auth";
+import { MCPServerConnectionResource } from "@app/lib/resources/mcp_server_connection_resource";
+import logger from "@app/logger/logger";
 import type { ExtraConfigType } from "@app/pages/w/[wId]/oauth/[provider]/setup";
+import { Err, OAuthAPI, Ok } from "@app/types";
 import type { OAuthConnectionType, OAuthUseCase } from "@app/types/oauth/lib";
 
 export class SlackOAuthProvider implements BaseOAuthStrategyProvider {
@@ -68,6 +75,12 @@ export class SlackOAuthProvider implements BaseOAuthStrategyProvider {
         ? `&user_scope=${encodeURIComponent(user_scopes.join(" "))}`
         : "") +
       `&redirect_uri=${encodeURIComponent(finalizeUriForProvider("slack"))}` +
+      // Force the team id to be the same as the admin-setup.
+      // Edge-case: if the user is not in the team of not logged, it might still connect to the wrong team.
+      // We catch it in the `checkConnectionValidPostFinalize` method.
+      (extraConfig?.requested_team_id
+        ? `&team=${extraConfig.requested_team_id}`
+        : "") +
       `&state=${connection.connection_id}`
     );
   }
@@ -80,10 +93,88 @@ export class SlackOAuthProvider implements BaseOAuthStrategyProvider {
     return getStringFromQuery(query, "state");
   }
 
+  async updateConfigAndGetRelatedCredential(
+    auth: Authenticator,
+    {
+      extraConfig,
+      useCase,
+    }: {
+      extraConfig: ExtraConfigType;
+      workspaceId: string;
+      userId: string;
+      useCase: OAuthUseCase;
+    }
+  ): Promise<UpdatedExtraConfig | null> {
+    if (useCase === "personal_actions") {
+      // For personal actions we fetch the team id of the admin-setup to enforce the team id to be the same as the admin-setup.
+      // workspace connection (setup by admin) if we have it.
+      const { mcp_server_id, ...restConfig } = extraConfig;
+
+      if (mcp_server_id) {
+        const mcpServerConnectionRes =
+          await MCPServerConnectionResource.findByMCPServer(auth, {
+            mcpServerId: mcp_server_id,
+            connectionType: "workspace",
+          });
+
+        if (mcpServerConnectionRes.isErr()) {
+          return null;
+        }
+
+        const oauthApi = new OAuthAPI(config.getOAuthAPIConfig(), logger);
+        const connectionRes = await oauthApi.getConnectionMetadata({
+          connectionId: mcpServerConnectionRes.value.connectionId,
+        });
+        if (connectionRes.isErr()) {
+          logger.error(
+            "Failed to get access token for admin-setup connection when updating the config for personal actions",
+            {
+              error: connectionRes.error,
+            }
+          );
+          return null;
+        }
+
+        const teamId = connectionRes.value.connection.metadata.team_id;
+        const teamName = connectionRes.value.connection.metadata.team_name;
+
+        return {
+          updatedConfig: {
+            ...restConfig,
+            requested_team_id: teamId,
+            requested_team_name: teamName,
+          },
+        };
+      }
+    }
+
+    return null;
+  }
+
   isExtraConfigValid(extraConfig: ExtraConfigType, useCase: OAuthUseCase) {
     if (useCase === "personal_actions" || useCase === "platform_actions") {
       return "scope" in extraConfig;
     }
     return Object.keys(extraConfig).length === 0;
+  }
+
+  checkConnectionValidPostFinalize(connection: OAuthConnectionType) {
+    // If a team was requested, we need to check that the team id is the same as the requested team id.
+    if ("requested_team_id" in connection.metadata) {
+      if (
+        connection.metadata.team_id === connection.metadata.requested_team_id
+      ) {
+        return new Ok(undefined);
+      }
+      return new Err({
+        message:
+          "You must select `" +
+          connection.metadata.requested_team_name +
+          "` as the team to connect, instead of `" +
+          connection.metadata.team_name +
+          "`.",
+      });
+    }
+    return new Ok(undefined);
   }
 }

--- a/front/lib/swr/oauth.ts
+++ b/front/lib/swr/oauth.ts
@@ -1,10 +1,17 @@
-import type { OAuthProvider } from "@app/types";
+import type {
+  APIError,
+  OAuthConnectionType,
+  OAuthProvider,
+  Result,
+  WithAPIErrorResponse,
+} from "@app/types";
+import { Err, isAPIErrorResponse, Ok } from "@app/types";
 
 export const useFinalize = () => {
   const doFinalize = async (
     provider: OAuthProvider,
     queryParams: Record<string, string | string[] | undefined>
-  ) => {
+  ): Promise<Result<OAuthConnectionType, APIError>> => {
     const params = new URLSearchParams();
     for (const [key, value] of Object.entries(queryParams)) {
       if (Array.isArray(value)) {
@@ -14,7 +21,25 @@ export const useFinalize = () => {
       }
     }
 
-    return fetch(`/api/oauth/${provider}/finalize?${params.toString()}`);
+    const res = await fetch(
+      `/api/oauth/${provider}/finalize?${params.toString()}`
+    );
+
+    const result: WithAPIErrorResponse<{ connection: OAuthConnectionType }> =
+      await res.json();
+
+    if (isAPIErrorResponse(result)) {
+      return new Err(result.error);
+    }
+
+    if (!res.ok) {
+      return new Err({
+        type: "internal_server_error",
+        message: `Failed to finalize OAuth: ${res.statusText}`,
+      });
+    }
+
+    return new Ok(result.connection);
   };
 
   return doFinalize;

--- a/front/pages/oauth/[provider]/finalize.tsx
+++ b/front/pages/oauth/[provider]/finalize.tsx
@@ -47,21 +47,19 @@ export default function Finalize({
         const res = await doFinalize(provider, queryParams);
         // Send a message `connection_finalized` to the window that opened
         // this one, with either an error or the connection data.
-        if (!res.ok) {
+        if (res.isErr()) {
           window.opener.postMessage(
             {
               type: "connection_finalized",
-              error: "Failed to finalize connection",
+              error: res.error.message || "Failed to finalize connection",
             },
             window.location.origin
           );
         } else {
-          const data = await res.json();
-
           window.opener.postMessage(
             {
               type: "connection_finalized",
-              connection: data.connection,
+              connection: res.value,
             },
             window.location.origin
           );


### PR DESCRIPTION
## Description

**What**
Add support to enforce a specific team when connecting a slack personal connection.

**How**
- (oauth) Get the team id and name from the slack token response.
- (oauth) Merge it with the existing metadata.
- (front) Get the team id from the admin-setup connection and pass it to slack oauth page (it forces the choice if you are already logged in)
- (front) Added a final check after finalize to verify if the connection is valid.

Notes:
- Improved typing and error messages
- Renamed methods to make their purpose clearer

## Tests

Locally
<img width="408" alt="image" src="https://github.com/user-attachments/assets/8eb3dc6a-ee50-4c73-ae1e-47b5a6e39ecb" />

## Risk

Low

## Deploy Plan

Deploy oauth & front