### PR TITLE
Always have Dust agent active

### DIFF
--- a/front/lib/api/assistant/global_agents.ts
+++ b/front/lib/api/assistant/global_agents.ts
@@ -1493,6 +1493,7 @@ The agent should not provide additional information or content that the user did
     };
   }
 
+  // This only happens when we fetch the list version of the agent.
   if (!preFetchedDataSources) {
     return {
       ...dustAgent,
@@ -1502,21 +1503,14 @@ The agent should not provide additional information or content that the user did
     };
   }
 
+  const actions: MCPServerConfigurationType[] = [];
+
   const dataSourceViews = preFetchedDataSources.dataSourceViews.filter(
     (dsView) => dsView.dataSource.assistantDefaultSelected === true
   );
 
-  if (dataSourceViews.length === 0) {
-    return {
-      ...dustAgent,
-      status: "disabled_missing_datasource",
-      actions: [],
-      maxStepsPerRun: 0,
-    };
-  }
-  const actions: MCPServerConfigurationType[] = [];
-
-  if (searchMCPServerView) {
+  // Only add the action if there are data sources and the search MCPServer is available.
+  if (dataSourceViews.length > 0 && searchMCPServerView) {
     // We push one action with all data sources
     actions.push({
       id: -1,


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
See thread with full context [here](https://dust4ai.slack.com/archives/C050SM8NSPK/p1751011163147969).

Current issue is that `@dust` wrongly shows up in the list of active agents on the workspace because when `viewType` is set to `light` we don't prefetch data sources, which makes us return early here and mark it as active:
https://github.com/dust-tt/dust/blob/15266a73e5f06999b902354b9992278684cefe38/front/lib/api/assistant/global_agents.ts#L1496-L1503

However, in the agent loop, there we fetch the `full` view type which does fetch the data sources and will eventually yields the status `disabled_missing_datasource`.

This creates a bug where the `@dust` agent can't interact with any just-in-time actions/tools, this impacts:
- uploading files in the input bar
- the new slack bot connect which does not set `assistantDefaultSelected` to true

This PR takes a departure from the existing behavior, `@Dust` used to only be active if the workspace have at least one data source with `assistantDefaultSelected` set to `true`. Here we change this behavior so `@dust` is always active.

_Note:_ Looking a more I can't remove all the logic around `disabled_missing_datasource` because some legacy data source agents still rely on it.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
