### PR TITLE
Release SF tool for enteprise plans

### DIFF
--- a/front/lib/actions/mcp_internal_actions/constants.ts
+++ b/front/lib/actions/mcp_internal_actions/constants.ts
@@ -186,10 +186,11 @@ export const INTERNAL_MCP_SERVERS: Record<
   salesforce: {
     id: 14,
     availability: "manual",
-    isRestricted: ({ featureFlags }) => {
-      // When we are ready to release the feature, the condition will be:
-      // return !featureFlags.includes("salesforce_tool") && !plan.limits.connections.isSalesforceAllowed;
-      return !featureFlags.includes("salesforce_tool");
+    isRestricted: ({ featureFlags, plan }) => {
+      const isInPlan = plan.limits.connections.isSalesforceAllowed;
+      const hasFeatureFlag = featureFlags.includes("salesforce_tool");
+      const isAvailable = isInPlan || hasFeatureFlag;
+      return !isAvailable;
     },
     tools_stakes: {
       execute_read_query: "low",


### PR DESCRIPTION
## Description

Release the Salesforce tool for all workspaces that have it enabled on their plan (enterprises).
We also keep the feature flag to be able to activate for specific workspaces. 
You need one of both to have it available. 

Note: We're thinking about adding Writing tools but since it will likely come with a tool selector for when the tool is set up we can already release. 

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

Can be rolled back. 

## Deploy Plan

Deploy front. 