### PR TITLE
[front] enh(provisioning): prevent revoking provisioned members

### DIFF
--- a/front/components/members/MembersList.tsx
+++ b/front/components/members/MembersList.tsx
@@ -118,7 +118,8 @@ const memberColumns = [
     header: "",
     cell: (info: Info) => (
       <DataTable.CellContent>
-        {info.row.original.isCurrentUser ? (
+        {info.row.original.isCurrentUser ||
+        info.row.original.origin === "provisioned" ? (
           <></>
         ) : (
           <IconButton

--- a/front/components/members/MembersList.tsx
+++ b/front/components/members/MembersList.tsx
@@ -13,7 +13,12 @@ import type { KeyedMutator } from "swr";
 
 import { displayRole, ROLES_DATA } from "@app/components/members/Roles";
 import type { SearchMembersResponseBody } from "@app/pages/api/w/[wId]/members/search";
-import type { RoleType, UserType, UserTypeWithWorkspace } from "@app/types";
+import type {
+  MembershipOriginType,
+  RoleType,
+  UserType,
+  UserTypeWithWorkspace,
+} from "@app/types";
 
 type RowData = {
   icon: string;
@@ -26,6 +31,7 @@ type RowData = {
   isCurrentUser: boolean;
   onClick: () => void;
   onRemoveMemberClick?: () => void;
+  origin: MembershipOriginType;
 };
 
 type Info = CellContext<RowData, string>;
@@ -52,6 +58,7 @@ function getTableRows({
     isCurrentUser: user.sId === currentUserId,
     onClick: () => onClick(user),
     onRemoveMemberClick: () => onRemoveMemberClick?.(user),
+    origin: user.origin,
   }));
 }
 

--- a/front/components/members/MembersList.tsx
+++ b/front/components/members/MembersList.tsx
@@ -31,7 +31,7 @@ type RowData = {
   isCurrentUser: boolean;
   onClick: () => void;
   onRemoveMemberClick?: () => void;
-  origin: MembershipOriginType;
+  origin?: MembershipOriginType;
 };
 
 type Info = CellContext<RowData, string>;

--- a/front/components/poke/members/columns.tsx
+++ b/front/components/poke/members/columns.tsx
@@ -17,7 +17,7 @@ export type MemberDisplayType = {
   provider: string | null;
   role: RoleType;
   sId: string;
-  origin: MembershipOriginType;
+  origin?: MembershipOriginType;
 };
 
 export function makeColumnsForMembers({

--- a/front/components/poke/members/columns.tsx
+++ b/front/components/poke/members/columns.tsx
@@ -3,7 +3,11 @@ import { ArrowsUpDownIcon } from "@heroicons/react/20/solid";
 import type { ColumnDef } from "@tanstack/react-table";
 
 import { formatTimestampToFriendlyDate } from "@app/lib/utils";
-import type { ActiveRoleType, RoleType } from "@app/types";
+import type {
+  ActiveRoleType,
+  MembershipOriginType,
+  RoleType,
+} from "@app/types";
 import { ACTIVE_ROLES } from "@app/types";
 
 export type MemberDisplayType = {
@@ -13,6 +17,7 @@ export type MemberDisplayType = {
   provider: string | null;
   role: RoleType;
   sId: string;
+  origin: MembershipOriginType;
 };
 
 export function makeColumnsForMembers({

--- a/front/components/poke/members/columns.tsx
+++ b/front/components/poke/members/columns.tsx
@@ -145,7 +145,8 @@ export function makeColumnsForMembers({
       cell: ({ row }) => {
         const member = row.original;
 
-        return member.role !== "none" ? (
+        // Hide the revoke button for provisioned users and users with no role.
+        return member.role !== "none" && member.origin !== "provisioned" ? (
           <IconButton
             icon={TrashIcon}
             size="xs"

--- a/front/components/poke/members/table.tsx
+++ b/front/components/poke/members/table.tsx
@@ -21,6 +21,7 @@ function prepareMembersForDisplay(
       provider: m.provider,
       role: m.workspaces[0].role,
       sId: m.sId,
+      origin: m.origin,
     };
   });
 }

--- a/front/components/workspace/ChangeMemberModal.tsx
+++ b/front/components/workspace/ChangeMemberModal.tsx
@@ -118,8 +118,9 @@ export function ChangeMemberModal({
                           size="sm"
                           disabled={member.origin === "provisioned"}
                           tooltip={
-                            member.origin === "provisioned" &&
-                            "This user is managed by your identity provider."
+                            member.origin === "provisioned"
+                              ? "This user is managed by your identity provider."
+                              : undefined
                           }
                         />
                       </DialogTrigger>

--- a/front/components/workspace/ChangeMemberModal.tsx
+++ b/front/components/workspace/ChangeMemberModal.tsx
@@ -108,64 +108,67 @@ export function ChangeMemberModal({
                   </Page.P>
                 </div>
 
-                <div className="flex flex-none flex-col gap-2">
-                  <div className="flex-none">
-                    <Dialog>
-                      <DialogTrigger asChild>
-                        <Button
-                          variant="warning"
-                          label="Revoke member access"
-                          size="sm"
-                        />
-                      </DialogTrigger>
-                      <DialogContent>
-                        <DialogHeader>
-                          <DialogTitle>Confirm deletion</DialogTitle>
-                        </DialogHeader>
-                        {isSaving ? (
-                          <div className="flex justify-center py-8">
-                            <Spinner variant="dark" size="md" />
-                          </div>
-                        ) : (
-                          <>
-                            <DialogContainer>
-                              <div>
-                                Revoke access for user{" "}
-                                <span className="font-bold">
-                                  {member.fullName}
-                                </span>
-                                ?
-                              </div>
-                            </DialogContainer>
-                            <DialogFooter
-                              leftButtonProps={{
-                                label: "Cancel",
-                                variant: "outline",
-                              }}
-                              rightButtonProps={{
-                                label: "Yes, revoke",
-                                variant: "warning",
-                                onClick: async () => {
-                                  await handleMembersRoleChange({
-                                    members: [member],
-                                    role: "none",
-                                    sendNotification,
-                                  });
-                                  await mutateMembers();
-                                  onClose();
-                                },
-                              }}
-                            />
-                          </>
-                        )}
-                      </DialogContent>
-                    </Dialog>
+                {member.origin !== "provisioned" && (
+                  <div className="flex flex-none flex-col gap-2">
+                    <div className="flex-none">
+                      <Dialog>
+                        <DialogTrigger asChild>
+                          <Button
+                            variant="warning"
+                            label="Revoke member access"
+                            size="sm"
+                          />
+                        </DialogTrigger>
+                        <DialogContent>
+                          <DialogHeader>
+                            <DialogTitle>Confirm deletion</DialogTitle>
+                          </DialogHeader>
+                          {isSaving ? (
+                            <div className="flex justify-center py-8">
+                              <Spinner variant="dark" size="md" />
+                            </div>
+                          ) : (
+                            <>
+                              <DialogContainer>
+                                <div>
+                                  Revoke access for user{" "}
+                                  <span className="font-bold">
+                                    {member.fullName}
+                                  </span>
+                                  ?
+                                </div>
+                              </DialogContainer>
+                              <DialogFooter
+                                leftButtonProps={{
+                                  label: "Cancel",
+                                  variant: "outline",
+                                }}
+                                rightButtonProps={{
+                                  label: "Yes, revoke",
+                                  variant: "warning",
+                                  onClick: async () => {
+                                    await handleMembersRoleChange({
+                                      members: [member],
+                                      role: "none",
+                                      sendNotification,
+                                    });
+                                    await mutateMembers();
+                                    onClose();
+                                  },
+                                }}
+                              />
+                            </>
+                          )}
+                        </DialogContent>
+                      </Dialog>
+                    </div>
+                    <Page.P>
+                      Deleting a member will remove them from the workspace.
+                      They will be able to rejoin if they have an invitation
+                      link.
+                    </Page.P>
                   </div>
-                  <Page.P>
-                    Deleting a member will remove them from the workspace. They
-                    will be able to rejoin if they have an invitation link.
-                  </Page.P>
-                </div>
+                )}
               </div>
             </SheetContainer>
             <SheetFooter

--- a/front/components/workspace/ChangeMemberModal.tsx
+++ b/front/components/workspace/ChangeMemberModal.tsx
@@ -108,67 +108,72 @@ export function ChangeMemberModal({
                   </Page.P>
                 </div>
 
-                {member.origin !== "provisioned" && (
-                  <div className="flex flex-none flex-col gap-2">
-                    <div className="flex-none">
-                      <Dialog>
-                        <DialogTrigger asChild>
-                          <Button
-                            variant="warning"
-                            label="Revoke member access"
-                            size="sm"
-                          />
-                        </DialogTrigger>
-                        <DialogContent>
-                          <DialogHeader>
-                            <DialogTitle>Confirm deletion</DialogTitle>
-                          </DialogHeader>
-                          {isSaving ? (
-                            <div className="flex justify-center py-8">
-                              <Spinner variant="dark" size="md" />
-                            </div>
-                          ) : (
-                            <>
-                              <DialogContainer>
-                                <div>
-                                  Revoke access for user{" "}
-                                  <span className="font-bold">
-                                    {member.fullName}
-                                  </span>
-                                  ?
-                                </div>
-                              </DialogContainer>
-                              <DialogFooter
-                                leftButtonProps={{
-                                  label: "Cancel",
-                                  variant: "outline",
-                                }}
-                                rightButtonProps={{
-                                  label: "Yes, revoke",
-                                  variant: "warning",
-                                  onClick: async () => {
-                                    await handleMembersRoleChange({
-                                      members: [member],
-                                      role: "none",
-                                      sendNotification,
-                                    });
-                                    await mutateMembers();
-                                    onClose();
-                                  },
-                                }}
-                              />
-                            </>
-                          )}
-                        </DialogContent>
-                      </Dialog>
-                    </div>
+                <div className="flex flex-none flex-col gap-2">
+                  <div className="flex-none">
+                    <Dialog>
+                      <DialogTrigger asChild>
+                        <Button
+                          variant="warning"
+                          label="Revoke member access"
+                          size="sm"
+                          disabled={member.origin === "provisioned"}
+                          tooltip={
+                            member.origin === "provisioned" &&
+                            "This user is managed by your identity provider."
+                          }
+                        />
+                      </DialogTrigger>
+                      <DialogContent>
+                        <DialogHeader>
+                          <DialogTitle>Confirm deletion</DialogTitle>
+                        </DialogHeader>
+                        {isSaving ? (
+                          <div className="flex justify-center py-8">
+                            <Spinner variant="dark" size="md" />
+                          </div>
+                        ) : (
+                          <>
+                            <DialogContainer>
+                              <div>
+                                Revoke access for user{" "}
+                                <span className="font-bold">
+                                  {member.fullName}
+                                </span>
+                                ?
+                              </div>
+                            </DialogContainer>
+                            <DialogFooter
+                              leftButtonProps={{
+                                label: "Cancel",
+                                variant: "outline",
+                              }}
+                              rightButtonProps={{
+                                label: "Yes, revoke",
+                                variant: "warning",
+                                onClick: async () => {
+                                  await handleMembersRoleChange({
+                                    members: [member],
+                                    role: "none",
+                                    sendNotification,
+                                  });
+                                  await mutateMembers();
+                                  onClose();
+                                },
+                              }}
+                            />
+                          </>
+                        )}
+                      </DialogContent>
+                    </Dialog>
+                  </div>
+                  {member.origin !== "provisioned" && (
                     <Page.P>
                       Deleting a member will remove them from the workspace.
                       They will be able to rejoin if they have an invitation
                       link.
                     </Page.P>
-                  </div>
-                )}
+                  )}
+                </div>
               </div>
             </SheetContainer>
             <SheetFooter

--- a/front/lib/api/workspace.ts
+++ b/front/lib/api/workspace.ts
@@ -162,7 +162,7 @@ export async function getMembers(
   const usersWithWorkspaces = await Promise.all(
     memberships.map(async (m) => {
       let role = "none" as RoleType;
-      let origin: MembershipOriginType;
+      let origin: MembershipOriginType = undefined;
       if (m && !m.isRevoked()) {
         switch (m.role) {
           case "admin":
@@ -247,7 +247,7 @@ export async function searchMembers(
       const [m] = u.memberships ?? [];
       let role: RoleType = "none";
       let groups: string[] | undefined;
-      let origin: MembershipOriginType;
+      let origin: MembershipOriginType = undefined;
 
       if (m) {
         const membership = new MembershipResource(

--- a/front/lib/api/workspace.ts
+++ b/front/lib/api/workspace.ts
@@ -22,6 +22,7 @@ import { launchDeleteWorkspaceWorkflow } from "@app/poke/temporal/client";
 import type {
   GroupKind,
   LightWorkspaceType,
+  MembershipOriginType,
   MembershipRoleType,
   PublicAPILimitsType,
   Result,
@@ -161,6 +162,7 @@ export async function getMembers(
   const usersWithWorkspaces = await Promise.all(
     memberships.map(async (m) => {
       let role = "none" as RoleType;
+      let origin: MembershipOriginType;
       if (m && !m.isRevoked()) {
         switch (m.role) {
           case "admin":
@@ -171,6 +173,7 @@ export async function getMembers(
           default:
             role = "none";
         }
+        origin = m.origin;
       }
 
       let user: UserResource | null;
@@ -187,6 +190,7 @@ export async function getMembers(
       return {
         ...user.toJSON(),
         workspaces: [{ ...owner, role, flags: null }],
+        origin,
       };
     })
   );
@@ -243,6 +247,7 @@ export async function searchMembers(
       const [m] = u.memberships ?? [];
       let role: RoleType = "none";
       let groups: string[] | undefined;
+      let origin: MembershipOriginType;
 
       if (m) {
         const membership = new MembershipResource(
@@ -255,6 +260,8 @@ export async function searchMembers(
             ? membership.role
             : "none"
           : "none";
+
+        origin = membership.origin;
       }
 
       if (options.groupKind) {
@@ -270,6 +277,7 @@ export async function searchMembers(
       return {
         ...u.toJSON(),
         workspace: { ...owner, role, groups, flags: null },
+        origin,
       };
     })
   );

--- a/front/lib/api/workspace.ts
+++ b/front/lib/api/workspace.ts
@@ -162,7 +162,7 @@ export async function getMembers(
   const usersWithWorkspaces = await Promise.all(
     memberships.map(async (m) => {
       let role = "none" as RoleType;
-      let origin: MembershipOriginType = undefined;
+      let origin: MembershipOriginType | undefined = undefined;
       if (m && !m.isRevoked()) {
         switch (m.role) {
           case "admin":
@@ -247,7 +247,7 @@ export async function searchMembers(
       const [m] = u.memberships ?? [];
       let role: RoleType = "none";
       let groups: string[] | undefined;
-      let origin: MembershipOriginType = undefined;
+      let origin: MembershipOriginType | undefined = undefined;
 
       if (m) {
         const membership = new MembershipResource(

--- a/front/types/user.ts
+++ b/front/types/user.ts
@@ -4,6 +4,7 @@ import type {
   EmbeddingProviderIdType,
   ModelProviderIdType,
 } from "./assistant/assistant";
+import type { MembershipOriginType } from "./memberships";
 import type { ModelId } from "./shared/model_id";
 import { assertNever } from "./shared/utils/assert_never";
 
@@ -100,10 +101,12 @@ export type UserType = {
 
 export type UserTypeWithWorkspace = UserType & {
   workspace: WorkspaceType;
+  origin: MembershipOriginType;
 };
 
 export type UserTypeWithWorkspaces = UserType & {
   workspaces: WorkspaceType[];
+  origin: MembershipOriginType;
 };
 
 export type UserTypeWithExtensionWorkspaces = UserType & {

--- a/front/types/user.ts
+++ b/front/types/user.ts
@@ -101,12 +101,12 @@ export type UserType = {
 
 export type UserTypeWithWorkspace = UserType & {
   workspace: WorkspaceType;
-  origin: MembershipOriginType;
+  origin?: MembershipOriginType;
 };
 
 export type UserTypeWithWorkspaces = UserType & {
   workspaces: WorkspaceType[];
-  origin: MembershipOriginType;
+  origin?: MembershipOriginType;
 };
 
 export type UserTypeWithExtensionWorkspaces = UserType & {


### PR DESCRIPTION
## Description

- This PR hides the revoke button for provisioned members.
- The goal is to let provisioned users' memberships be handled on the provider's side.

## Tests

- Tested locally.

## Risk

- Low.

## Deploy Plan

- Deploy front.
