### PR TITLE
Fix Slack webhook timeout by keeping Cloud Run warm

### DIFF
--- a/cloud-functions/slack-webhook-router/deploy.sh
+++ b/cloud-functions/slack-webhook-router/deploy.sh
@@ -31,7 +31,7 @@ gcloud run deploy slack-webhook-router \
   --region us-central1 \
   --project "$GCP_GLOBAL_PROJECT_ID" \
   --allow-unauthenticated \
-  --min-instances 1 \
+  --min 1 \
   --startup-probe httpGet.path=/ready,initialDelaySeconds=0,failureThreshold=3,timeoutSeconds=4,periodSeconds=10 \
   --liveness-probe httpGet.path=/health,initialDelaySeconds=30,failureThreshold=3,timeoutSeconds=4,periodSeconds=30
 

--- a/cloud-functions/slack-webhook-router/deploy.sh
+++ b/cloud-functions/slack-webhook-router/deploy.sh
@@ -31,6 +31,7 @@ gcloud run deploy slack-webhook-router \
   --region us-central1 \
   --project "$GCP_GLOBAL_PROJECT_ID" \
   --allow-unauthenticated \
+  --min-instances 1 \
   --startup-probe httpGet.path=/ready,initialDelaySeconds=0,failureThreshold=3,timeoutSeconds=4,periodSeconds=10 \
   --liveness-probe httpGet.path=/health,initialDelaySeconds=30,failureThreshold=3,timeoutSeconds=4,periodSeconds=30
 

--- a/cloud-functions/slack-webhook-router/src/index.ts
+++ b/cloud-functions/slack-webhook-router/src/index.ts
@@ -1,4 +1,5 @@
 import express from "express";
+
 import { CONFIG } from "./config.js";
 import { createRoutes } from "./routes.js";
 import { SecretManager } from "./secrets.js";
@@ -12,7 +13,9 @@ async function main(): Promise<void> {
     // Create Express app.
     const app = express();
     app.use(express.json({ limit: CONFIG.REQUEST_SIZE_LIMIT }));
-    app.use(express.urlencoded({ extended: true, limit: CONFIG.REQUEST_SIZE_LIMIT }));
+    app.use(
+      express.urlencoded({ extended: true, limit: CONFIG.REQUEST_SIZE_LIMIT })
+    );
 
     // Start server.
     const server = app.listen(CONFIG.PORT, async () => {

--- a/cloud-functions/slack-webhook-router/src/routes.ts
+++ b/cloud-functions/slack-webhook-router/src/routes.ts
@@ -1,4 +1,5 @@
 import express from "express";
+
 import { WebhookForwarder } from "./forwarder.js";
 import type { SecretManager } from "./secrets.js";
 import type { GracefulServer } from "./server.js";


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
See debugging thread [here](https://dust4ai.slack.com/archives/C091PN4EK52/p1751031257234399?thread_ts=1751004896.260349&cid=C091PN4EK52).

When Slack calls our webhook, they aggressive retry policy sometimes ends up posting the Slack event to regions too many times leading to duplicates. This PR adds --min-instances 1 to deployment to prevent cold starts.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
- [ ] Run `num run deploy`
