### PR TITLE
Better handle GitHub tar-stream

### DIFF
--- a/connectors/src/connectors/github/lib/code/tar_extraction.ts
+++ b/connectors/src/connectors/github/lib/code/tar_extraction.ts
@@ -2,7 +2,7 @@ import type { Result } from "@dust-tt/client";
 import { Err, Ok } from "@dust-tt/client";
 import assert from "assert";
 import gunzip from "gunzip-maybe";
-import type { PassThrough, Readable } from "stream";
+import type { Readable } from "stream";
 import { pipeline } from "stream/promises";
 import * as tar from "tar-stream";
 


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
We keep observing intermittent GCS uploading issue despite https://github.com/dust-tt/dust/pull/13855 and poor performances. After some investigation, we discovered that our the `tar-stream` library must be used sequentially, as it puts backpressure on the main stream, reducing overall speed.

From their [doc](https://www.npmjs.com/package/tar-stream):
> "The tar archive is streamed sequentially, meaning you must drain each entry's stream as you get them or else the main extract stream will receive backpressure and stop reading."

Key issues identified:
1. Premature next() calls - We were calling next() immediately instead of waiting for each stream to complete
2. Concurrent processing assumption - We incorrectly assumed tar entries could be processed in parallel
3. Memory accumulation - Multiple streams were active simultaneously, causing memory bloat

This PR removes all concurrency from this part, ensuring no backpressure mechanism is triggered on the main stream.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->
Tested locally!

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
