### PR TITLE
Temporary let Slack SDK handles rate limit

### DIFF
--- a/connectors/src/connectors/slack/temporal/activities.ts
+++ b/connectors/src/connectors/slack/temporal/activities.ts
@@ -9,7 +9,6 @@ import type {
   ConversationsHistoryResponse,
   MessageElement,
 } from "@slack/web-api/dist/response/ConversationsHistoryResponse";
-import { Context } from "@temporalio/activity";
 import PQueue from "p-queue";
 import { Op, Sequelize } from "sequelize";
 
@@ -55,7 +54,6 @@ import {
   syncSucceeded,
 } from "@connectors/lib/sync_status";
 import { heartbeat } from "@connectors/lib/temporal";
-import { isSlowLaneQueue } from "@connectors/lib/temporal_queue_routing";
 import mainLogger from "@connectors/logger/logger";
 import { ConnectorResource } from "@connectors/resources/connector_resource";
 import { SlackConfigurationResource } from "@connectors/resources/slack_configuration_resource";

--- a/connectors/src/connectors/slack/temporal/activities.ts
+++ b/connectors/src/connectors/slack/temporal/activities.ts
@@ -91,7 +91,8 @@ export async function syncChannel(
 
   const slackClient = await getSlackClient(connectorId, {
     // Let the Slack client handle rate limited calls in the slow lane.
-    rejectRateLimitedCalls: !isSlowLaneQueue(Context.current().info.taskQueue),
+    // TODO(SLACK-PANIC): Remove/uncomment.
+    rejectRateLimitedCalls: false, // !isSlowLaneQueue(Context.current().info.taskQueue),
   });
 
   const remoteChannel = await withSlackErrorHandling(() =>
@@ -300,7 +301,8 @@ export async function getMessagesForChannel(
 ): Promise<ConversationsHistoryResponse> {
   const slackClient = await getSlackClient(connectorId, {
     // Let the Slack client handle rate limited calls in the slow lane.
-    rejectRateLimitedCalls: !isSlowLaneQueue(Context.current().info.taskQueue),
+    // TODO(SLACK-PANIC): Remove/uncomment.
+    rejectRateLimitedCalls: false, // !isSlowLaneQueue(Context.current().info.taskQueue),
   });
 
   reportSlackUsage({
@@ -389,7 +391,8 @@ export async function syncNonThreadedChunk({
   const dataSourceConfig = dataSourceConfigFromConnector(connector);
   const slackClient = await getSlackClient(connectorId, {
     // Let the Slack client handle rate limited calls in the slow lane.
-    rejectRateLimitedCalls: !isSlowLaneQueue(Context.current().info.taskQueue),
+    // TODO(SLACK-PANIC): Remove/uncomment.
+    rejectRateLimitedCalls: false, // !isSlowLaneQueue(Context.current().info.taskQueue),
   });
   const messages: MessageElement[] = [];
 
@@ -800,7 +803,8 @@ export async function syncThread(
   const dataSourceConfig = dataSourceConfigFromConnector(connector);
   const slackClient = await getSlackClient(connectorId, {
     // Let the Slack client handle rate limited calls in the slow lane.
-    rejectRateLimitedCalls: !isSlowLaneQueue(Context.current().info.taskQueue),
+    // TODO(SLACK-PANIC): Remove/uncomment.
+    rejectRateLimitedCalls: false, // !isSlowLaneQueue(Context.current().info.taskQueue),
   });
 
   let allMessages: MessageElement[] = [];
@@ -996,7 +1000,8 @@ export async function fetchUsers(connectorId: ModelId) {
   let cursor: string | undefined;
   const slackClient = await getSlackClient(connectorId, {
     // Let the Slack client handle rate limited calls in the slow lane.
-    rejectRateLimitedCalls: !isSlowLaneQueue(Context.current().info.taskQueue),
+    // TODO(SLACK-PANIC): Remove/uncomment.
+    rejectRateLimitedCalls: false, // !isSlowLaneQueue(Context.current().info.taskQueue),
   });
   do {
     reportSlackUsage({
@@ -1048,7 +1053,8 @@ export async function getChannel(
 ): Promise<Channel> {
   const slackClient = await getSlackClient(connectorId, {
     // Let the Slack client handle rate limited calls in the slow lane.
-    rejectRateLimitedCalls: !isSlowLaneQueue(Context.current().info.taskQueue),
+    // TODO(SLACK-PANIC): Remove/uncomment.
+    rejectRateLimitedCalls: false, // !isSlowLaneQueue(Context.current().info.taskQueue),
   });
 
   return getChannelById(slackClient, connectorId, channelId);
@@ -1116,7 +1122,8 @@ export async function getChannelsToGarbageCollect(
 
   const slackClient = await getSlackClient(connectorId, {
     // Let the Slack client handle rate limited calls in the slow lane.
-    rejectRateLimitedCalls: !isSlowLaneQueue(Context.current().info.taskQueue),
+    // TODO(SLACK-PANIC): Remove/uncomment.
+    rejectRateLimitedCalls: false, // !isSlowLaneQueue(Context.current().info.taskQueue),
   });
 
   const remoteChannels = new Set(

--- a/connectors/src/connectors/slack/temporal/worker.ts
+++ b/connectors/src/connectors/slack/temporal/worker.ts
@@ -27,7 +27,7 @@ async function runSlackNormalWorker() {
     activities,
     taskQueue: QUEUE_NAME,
     connection,
-    reuseV8Context: false,
+    reuseV8Context: true,
     namespace,
     maxConcurrentActivityTaskExecutions: 16,
     maxCachedWorkflows: TEMPORAL_MAXED_CACHED_WORKFLOWS,
@@ -51,7 +51,7 @@ async function runSlackSlowWorker() {
     activities,
     taskQueue: SLOW_QUEUE_NAME,
     connection,
-    reuseV8Context: false,
+    reuseV8Context: true,
     namespace,
     maxConcurrentActivityTaskExecutions: 4, // Lower concurrency for slow lane.
     maxCachedWorkflows: TEMPORAL_MAXED_CACHED_WORKFLOWS,


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
Our Slack deployments keep restarting for some panic async hooks stack corruption. This started when we decided to handle Slack client rate limit outside of their SDK. This PR temporary rollbacks this change to see if it helps.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->
We should expect backlog to slightly grow as activity will remain "running" even when rate limited. Safe to rollback.

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
