### PR TITLE
[front] Use distributed lock

### DIFF
--- a/front/lib/api/workos/user.ts
+++ b/front/lib/api/workos/user.ts
@@ -88,7 +88,6 @@ export async function _getRefreshedCookie(
         password: config.getWorkOSCookiePassword(),
       }
     );
-
     return sealedCookie;
   } else {
     logger.info(
@@ -107,7 +106,9 @@ const getRefreshedCookie = cacheWithRedis(
   (workOSSessionCookie) => {
     return `workos_session_refresh:${sha256(workOSSessionCookie)}`;
   },
-  60 * 10 * 1000
+  60 * 10 * 1000,
+  undefined,
+  true
 );
 
 export async function getWorkOSSessionFromCookie(


### PR DESCRIPTION
## Description

thread : https://dust4ai.slack.com/archives/C05B529FHV1/p1750942286565099

Use distributed lock when refreshing session. When users comes after 10 min and multiple  swr revalidation requests are done at the same time, the GCLB cookie has expired and requests are spread across nodes. We need to ensure one single node will do the refresh and that the new session will be shared by all nodes.


## Tests

Locally - (without lb)

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

deploy front
