### PR TITLE
Flav/add parallelism to GitHub gcs

### DIFF
--- a/connectors/src/connectors/github/lib/code/gcs_repository.ts
+++ b/connectors/src/connectors/github/lib/code/gcs_repository.ts
@@ -9,6 +9,8 @@ import { isDevelopment } from "@connectors/types";
 export const DIRECTORY_PLACEHOLDER_FILE = ".gitkeep";
 export const DIRECTORY_PLACEHOLDER_METADATA = "isDirectoryPlaceholder";
 
+const DEFAULT_MAX_RESULTS = 1000;
+
 /**
  * A wrapper around GCS operations for GitHub repository code sync.
  * Handles the temporary storage of repository files during sync process.
@@ -45,10 +47,29 @@ export class GCSRepositoryManager {
   /**
    * List all files in a repository's GCS path.
    */
-  async listFiles(gcsBasePath: string): Promise<Array<File>> {
-    const [files] = await this.bucket.getFiles({ prefix: gcsBasePath });
+  async listFiles(
+    gcsBasePath: string,
+    options?: {
+      maxResults?: number;
+      pageToken?: string;
+    }
+  ): Promise<{
+    files: Array<File>;
+    nextPageToken?: string;
+    hasMore: boolean;
+  }> {
+    const [files, details] = await this.bucket.getFiles({
+      prefix: gcsBasePath,
+      maxResults: options?.maxResults,
+      pageToken: options?.pageToken,
+      autoPaginate: false, // Don't auto-paginate, we'll handle it manually.
+    });
 
-    return files;
+    return {
+      files,
+      nextPageToken: details?.pageToken,
+      hasMore: details?.pageToken !== undefined,
+    };
   }
 
   /**

--- a/connectors/src/connectors/github/lib/code/gcs_repository.ts
+++ b/connectors/src/connectors/github/lib/code/gcs_repository.ts
@@ -60,7 +60,7 @@ export class GCSRepositoryManager {
   }> {
     const [files, details] = await this.bucket.getFiles({
       prefix: gcsBasePath,
-      maxResults: options?.maxResults,
+      maxResults: options?.maxResults || DEFAULT_MAX_RESULTS,
       pageToken: options?.pageToken,
       autoPaginate: false, // Don't auto-paginate, we'll handle it manually.
     });

--- a/connectors/src/connectors/github/lib/code/tar_extraction.ts
+++ b/connectors/src/connectors/github/lib/code/tar_extraction.ts
@@ -2,6 +2,7 @@ import type { Result } from "@dust-tt/client";
 import { Err, Ok } from "@dust-tt/client";
 import assert from "assert";
 import gunzip from "gunzip-maybe";
+import PQueue from "p-queue";
 import type { Readable } from "stream";
 import { pipeline } from "stream/promises";
 import * as tar from "tar-stream";
@@ -21,6 +22,7 @@ import logger from "@connectors/logger/logger";
 
 const MAX_FILE_SIZE_BYTES = 1024 * 1024; // 1MB
 const GCS_RESUMABLE_UPLOAD_THRESHOLD_BYTES = 10 * 1024 * 1024; // 10MB
+const MAX_CONCURRENT_GCS_UPLOADS = 200;
 
 interface TarExtractionOptions {
   repoId: number;
@@ -133,6 +135,9 @@ export async function extractGitHubTarballToGCS(
   let filesSkipped = 0;
   const seenDirs = new Set<string>();
 
+  // Create upload queue to limit concurrent GCS uploads.
+  const uploadQueue = new PQueue({ concurrency: MAX_CONCURRENT_GCS_UPLOADS });
+
   // Create tar stream extractor.
   const extract = tar.extract();
 
@@ -166,23 +171,28 @@ export async function extractGitHubTarballToGCS(
             }
           }
 
-          // Upload file to GCS with sequential processing.
+          // Upload file to GCS using stream directly with queue.
           filesUploaded++;
-          logger.info({ gcsPath, fileName, filePath }, "Uploading file to GCS");
+          logger.info(
+            { gcsPath, fileName, filePath, filesUploaded },
+            "Uploading file to GCS"
+          );
 
-          pipeline(
-            stream,
-            gcsFile.createWriteStream({
-              metadata: {
-                contentType: "text/plain",
-              },
-              resumable:
-                (header.size ?? 0) >= GCS_RESUMABLE_UPLOAD_THRESHOLD_BYTES,
-              validation: false,
+          // Queue the upload but use stream directly
+          uploadQueue
+            .add(async () => {
+              return pipeline(
+                stream,
+                gcsFile.createWriteStream({
+                  metadata: {
+                    contentType: "text/plain",
+                  },
+                  resumable:
+                    (header.size ?? 0) >= GCS_RESUMABLE_UPLOAD_THRESHOLD_BYTES,
+                  validation: false,
+                })
+              );
             })
-          )
-            // The tar archive is streamed sequentially, call next() when done with this entry.
-            .then(() => next())
             .catch((error) => {
               logger.error(
                 {
@@ -195,9 +205,11 @@ export async function extractGitHubTarballToGCS(
                 },
                 "Failed to upload file to GCS"
               );
-              // Re-throw to let Temporal handle the failure.
               throw error;
             });
+
+          // Continue tar extraction immediately.
+          next();
         } else {
           // Skip filtered file but must drain stream to prevent backpressure.
           filesSkipped++;
@@ -261,12 +273,18 @@ export async function extractGitHubTarballToGCS(
   // Stream: GitHub tarball -> gunzip -> tar extract -> GCS upload.
   await pipeline(tarballStream, gunzip(), extract);
 
+  logger.info({ repoId, connectorId }, "All files uploaded");
+
   // Create directory placeholder files to preserve GitHub hierarchy.
-  const directoryPromises = Array.from(seenDirs).map(async (dirPath) =>
-    gcsManager.createDirectoryPlaceholder(gcsBasePath, dirPath)
+  // Use separate directory queue to avoid overwhelming GCS.
+  Array.from(seenDirs).map((dirPath) =>
+    uploadQueue.add(() =>
+      gcsManager.createDirectoryPlaceholder(gcsBasePath, dirPath)
+    )
   );
 
-  await Promise.all(directoryPromises);
+  // Wait for all queued uploads to complete.
+  await uploadQueue.onIdle();
 
   logger.info(
     {

--- a/connectors/src/connectors/github/lib/code/tar_extraction.ts
+++ b/connectors/src/connectors/github/lib/code/tar_extraction.ts
@@ -276,8 +276,7 @@ export async function extractGitHubTarballToGCS(
   logger.info({ repoId, connectorId }, "All files uploaded");
 
   // Create directory placeholder files to preserve GitHub hierarchy.
-  // Use separate directory queue to avoid overwhelming GCS.
-  Array.from(seenDirs).map((dirPath) =>
+  Array.from(seenDirs).forEach((dirPath) =>
     uploadQueue.add(() =>
       gcsManager.createDirectoryPlaceholder(gcsBasePath, dirPath)
     )

--- a/connectors/src/connectors/github/temporal/activities/sync_code.ts
+++ b/connectors/src/connectors/github/temporal/activities/sync_code.ts
@@ -189,12 +189,14 @@ export async function githubGetGcsFilesActivity({
   hasMore: boolean;
 }> {
   const gcsManager = new GCSRepositoryManager();
-  const allFiles = await gcsManager.listFiles(gcsBasePath);
-
-  // Simple offset-based pagination with validation.
-  const startIndex = pageToken ? Math.max(0, parseInt(pageToken) || 0) : 0;
-  const endIndex = Math.min(startIndex + batchSize, allFiles.length);
-  const paginatedFiles = allFiles.slice(startIndex, endIndex);
+  const {
+    files: paginatedFiles,
+    nextPageToken,
+    hasMore,
+  } = await gcsManager.listFiles(gcsBasePath, {
+    maxResults: batchSize,
+    pageToken,
+  });
 
   const directories: DirectoryListing[] = [];
   const files: FileListing[] = [];
@@ -231,8 +233,8 @@ export async function githubGetGcsFilesActivity({
   return {
     directories,
     files,
-    nextPageToken: endIndex < allFiles.length ? endIndex.toString() : undefined,
-    hasMore: endIndex < allFiles.length,
+    nextPageToken,
+    hasMore,
   };
 }
 

--- a/connectors/src/connectors/github/temporal/workflows.ts
+++ b/connectors/src/connectors/github/temporal/workflows.ts
@@ -78,7 +78,7 @@ const {
 const { githubExtractToGcsActivity } = proxyActivities<
   typeof activitiesSyncCode
 >({
-  startToCloseTimeout: "30 minute",
+  startToCloseTimeout: "60 minute",
 });
 
 const MAX_CONCURRENT_REPO_SYNC_WORKFLOWS = 3;


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
Playing a bit more with the `tar-stream` library sequential approach implemented [here](https://github.com/dust-tt/dust/pull/13877), can be highly improved in term of speed/performances.

This PR adds controlled concurrency on GCS uploads, as this part is the slowest one. Tried on a repo with 340k files and 170k folders.
- Streaming -> untar ~ 1m45 seconds (with sequential upserts ~ 45 minutes) with this approach ~ 15 minutes.

Even with this improvement, we bump `startToCloseTimeout` to 60 minutes for this one activity. We also implement proper pagination using GCS SDK.

We could even go one step further (will be tackled in another PR) so we remove the `.gitkeep` file added on folders to fully leverage the GCS API around virtual folders. 

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
