### PR TITLE
[front] Append cookie, don't reset other values

### DIFF
--- a/front/lib/api/auth_wrappers.ts
+++ b/front/lib/api/auth_wrappers.ts
@@ -139,7 +139,7 @@ export function withSessionAuthenticationForWorkspace<T>(
       }
 
       // Set permanent cookie with current workspace ID
-      res.setHeader(
+      res.appendHeader(
         "Set-Cookie",
         `lastWorkspaceId=${wId}; Path=/; SameSite=Lax; Max-Age=31536000`
       );


### PR DESCRIPTION
## Description

`res.setHeader("Set-Cookie", ..)` replace the whole Set-Cookie values, and so will remove the workos cookie response sent after a refresh. This is impacting all endpoints using `withSessionAuthenticationForWorkspace`. In the case the browser is standing by on a conv without any interactions, only /events request are sent, which are in this case - the new sessions are never sent.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

none

## Deploy Plan

deploy front
