### PR TITLE
Fix fetchByNameAndOrId

### DIFF
--- a/front/admin/init_dust_apps.ts
+++ b/front/admin/init_dust_apps.ts
@@ -1,4 +1,3 @@
-import _ from "lodash";
 import parseArgs from "minimist";
 
 import { Authenticator } from "@app/lib/auth";
@@ -20,11 +19,15 @@ const DEFAULT_SPACE_NAME = "Public Dust Apps";
 async function main() {
   const argv = parseArgs(process.argv.slice(2));
 
-  const where = _.pick(argv, ["name", "sId"]);
-  if (!where.name && !where.sId) {
-    throw new Error("Please provide name and/or sId for the workspace");
+  let w: WorkspaceResource | null;
+  if (argv.sId) {
+    w = await WorkspaceResource.fetchByModelId(argv.sId);
+  } else if (argv.name) {
+    w = await WorkspaceResource.fetchByName(argv.name);
+  } else {
+    throw new Error("Please provide the name or sId for the workspace");
   }
-  let w = await WorkspaceResource.fetchByNameAndOrId(where);
+
   if (!w) {
     console.log("Creating workspace");
     w = await WorkspaceResource.makeNew({

--- a/front/admin/init_dust_apps.ts
+++ b/front/admin/init_dust_apps.ts
@@ -21,10 +21,7 @@ async function main() {
   const argv = parseArgs(process.argv.slice(2));
 
   const where = _.pick(argv, ["name", "sId"]);
-  if (!where.name && !where.sId) {
-    throw new Error("Please provide name and/or sId for the workspace");
-  }
-  let w = await WorkspaceResource.fetchByNameAndId(where);
+  let w = await WorkspaceResource.fetchByNameAndOrId(where);
   if (!w) {
     console.log("Creating workspace");
     w = await WorkspaceResource.makeNew({

--- a/front/admin/init_dust_apps.ts
+++ b/front/admin/init_dust_apps.ts
@@ -21,6 +21,9 @@ async function main() {
   const argv = parseArgs(process.argv.slice(2));
 
   const where = _.pick(argv, ["name", "sId"]);
+  if (!where.name && !where.sId) {
+    throw new Error("Please provide name and/or sId for the workspace");
+  }
   let w = await WorkspaceResource.fetchByNameAndOrId(where);
   if (!w) {
     console.log("Creating workspace");

--- a/front/admin/init_dust_apps.ts
+++ b/front/admin/init_dust_apps.ts
@@ -21,7 +21,7 @@ async function main() {
 
   let w: WorkspaceResource | null;
   if (argv.sId) {
-    w = await WorkspaceResource.fetchByModelId(argv.sId);
+    w = await WorkspaceResource.fetchById(argv.sId);
   } else if (argv.name) {
     w = await WorkspaceResource.fetchByName(argv.name);
   } else {

--- a/front/lib/resources/workspace_resource.ts
+++ b/front/lib/resources/workspace_resource.ts
@@ -9,7 +9,7 @@ import type { ReadonlyAttributesType } from "@app/lib/resources/storage/types";
 import type { ModelId, Result } from "@app/types";
 import { Err, normalizeError, Ok } from "@app/types";
 
-type WorkspaceWhere =
+type FetchByNameAndIdWhere =
   | { sId: string; name?: string }
   | { sId?: string; name: string };
 
@@ -51,7 +51,7 @@ export class WorkspaceResource extends BaseResource<WorkspaceModel> {
   }
 
   static async fetchByNameAndOrId(
-    where: WorkspaceWhere
+    where: FetchByNameAndIdWhere
   ): Promise<WorkspaceResource | null> {
     const workspace = await this.model.findOne({ where });
     return workspace ? new this(this.model, workspace.get()) : null;

--- a/front/lib/resources/workspace_resource.ts
+++ b/front/lib/resources/workspace_resource.ts
@@ -9,6 +9,10 @@ import type { ReadonlyAttributesType } from "@app/lib/resources/storage/types";
 import type { ModelId, Result } from "@app/types";
 import { Err, normalizeError, Ok } from "@app/types";
 
+type WorkspaceWhere =
+  | { sId: string; name?: string }
+  | { sId?: string; name: string };
+
 // Attributes are marked as read-only to reflect the stateless nature of our Resource.
 // This design will be moved up to BaseResource once we transition away from Sequelize.
 // eslint-disable-next-line @typescript-eslint/no-empty-interface, @typescript-eslint/no-unsafe-declaration-merging
@@ -46,14 +50,9 @@ export class WorkspaceResource extends BaseResource<WorkspaceModel> {
     return workspace ? new this(this.model, workspace.get()) : null;
   }
 
-  static async fetchByNameAndOrId(where: {
-    sId?: string;
-    name?: string;
-  }): Promise<WorkspaceResource | null> {
-    if (!where.name && !where.sId) {
-      throw new Error("Please provide name and/or sId for the workspace");
-    }
-
+  static async fetchByNameAndOrId(
+    where: WorkspaceWhere
+  ): Promise<WorkspaceResource | null> {
     const workspace = await this.model.findOne({
       where,
     });

--- a/front/lib/resources/workspace_resource.ts
+++ b/front/lib/resources/workspace_resource.ts
@@ -53,9 +53,7 @@ export class WorkspaceResource extends BaseResource<WorkspaceModel> {
   static async fetchByNameAndOrId(
     where: WorkspaceWhere
   ): Promise<WorkspaceResource | null> {
-    const workspace = await this.model.findOne({
-      where,
-    });
+    const workspace = await this.model.findOne({ where });
     return workspace ? new this(this.model, workspace.get()) : null;
   }
 

--- a/front/lib/resources/workspace_resource.ts
+++ b/front/lib/resources/workspace_resource.ts
@@ -46,15 +46,16 @@ export class WorkspaceResource extends BaseResource<WorkspaceModel> {
     return workspace ? new this(this.model, workspace.get()) : null;
   }
 
-  static async fetchByNameAndId({
-    name,
-    sId: wId,
-  }: {
-    name: string;
-    sId: string;
+  static async fetchByNameAndOrId(where: {
+    sId?: string;
+    name?: string;
   }): Promise<WorkspaceResource | null> {
+    if (!where.name && !where.sId) {
+      throw new Error("Please provide name and/or sId for the workspace");
+    }
+
     const workspace = await this.model.findOne({
-      where: { name, sId: wId },
+      where,
     });
     return workspace ? new this(this.model, workspace.get()) : null;
   }

--- a/front/lib/resources/workspace_resource.ts
+++ b/front/lib/resources/workspace_resource.ts
@@ -9,10 +9,6 @@ import type { ReadonlyAttributesType } from "@app/lib/resources/storage/types";
 import type { ModelId, Result } from "@app/types";
 import { Err, normalizeError, Ok } from "@app/types";
 
-type FetchByNameAndIdWhere =
-  | { sId: string; name?: string }
-  | { sId?: string; name: string };
-
 // Attributes are marked as read-only to reflect the stateless nature of our Resource.
 // This design will be moved up to BaseResource once we transition away from Sequelize.
 // eslint-disable-next-line @typescript-eslint/no-empty-interface, @typescript-eslint/no-unsafe-declaration-merging
@@ -50,10 +46,10 @@ export class WorkspaceResource extends BaseResource<WorkspaceModel> {
     return workspace ? new this(this.model, workspace.get()) : null;
   }
 
-  static async fetchByNameAndOrId(
-    where: FetchByNameAndIdWhere
-  ): Promise<WorkspaceResource | null> {
-    const workspace = await this.model.findOne({ where });
+  static async fetchByName(name: string): Promise<WorkspaceResource | null> {
+    const workspace = await this.model.findOne({
+      where: { name },
+    });
     return workspace ? new this(this.model, workspace.get()) : null;
   }
 


### PR DESCRIPTION
## Description

My earlier workspace_resource refactoring broke init_dust_apps.ts, because sequelize can't handle undefined values, e.g. if only the `name` is passed in:

`Error: WHERE parameter "sId" has invalid "undefined" value`

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
