### PR TITLE
chore: refactor content fragments & attachments (step 1)

### DIFF
--- a/front/components/assistant/conversation/AttachmentCitation.tsx
+++ b/front/components/assistant/conversation/AttachmentCitation.tsx
@@ -17,6 +17,11 @@ import React from "react";
 
 import { getConnectorProviderLogoWithFallback } from "@app/lib/connector_providers";
 import type { ContentFragmentType } from "@app/types";
+import {
+  assertNever,
+  isContentNodeContentFragment,
+  isFileContentFragment,
+} from "@app/types";
 
 export type FileAttachment = {
   type: "file";
@@ -153,7 +158,7 @@ export function contentFragmentToAttachmentCitation(
     };
   }
 
-  if (contentFragment.contentNodeData) {
+  if (isContentNodeContentFragment(contentFragment)) {
     const { provider, nodeType } = contentFragment.contentNodeData;
     const logo = getConnectorProviderLogoWithFallback({ provider });
 
@@ -182,16 +187,20 @@ export function contentFragmentToAttachmentCitation(
       visual,
       spaceName: contentFragment.contentNodeData.spaceName,
     };
+  } else if (isFileContentFragment(contentFragment)) {
+    const isImageType = contentFragment.contentType.startsWith("image/");
+    return {
+      type: "file",
+      id: contentFragment.sId,
+      title: contentFragment.title,
+      sourceUrl: contentFragment.sourceUrl,
+      visual: (
+        <Icon visual={isImageType ? ImageIcon : DocumentIcon} size="md" />
+      ),
+    };
+  } else {
+    assertNever(contentFragment);
   }
-
-  const isImageType = contentFragment.contentType.startsWith("image/");
-  return {
-    type: "file",
-    id: contentFragment.sId,
-    title: contentFragment.title,
-    sourceUrl: contentFragment.sourceUrl,
-    visual: <Icon visual={isImageType ? ImageIcon : DocumentIcon} size="md" />,
-  };
 }
 
 export function attachmentToAttachmentCitation(

--- a/front/pages/poke/[wId]/conversations/[cId]/index.tsx
+++ b/front/pages/poke/[wId]/conversations/[cId]/index.tsx
@@ -27,7 +27,7 @@ import type {
   UserMessageType,
   WorkspaceType,
 } from "@app/types";
-import { assertNever } from "@app/types";
+import { assertNever, isFileContentFragment } from "@app/types";
 
 export const getServerSideProps = withSuperUserAuthRequirements<{
   workspace: WorkspaceType;
@@ -246,10 +246,11 @@ const ContentFragmentView = ({ message }: ContentFragmentViewProps) => {
         <div className="text-sm text-muted-foreground dark:text-muted-foreground-night">
           date : {new Date(message.created).toLocaleString()}
           version :{message.version} {" • "}
-          textBytes :{message.textBytes}
+          textBytes :
+          {isFileContentFragment(message) ? message.textBytes : "N/A"}
         </div>
         <div className="text-sm text-muted-foreground dark:text-muted-foreground-night">
-          textBytes={message.textBytes}
+          textBytes={isFileContentFragment(message) ? message.textBytes : "N/A"}
         </div>
         {message.sourceUrl && (
           <a
@@ -261,7 +262,7 @@ const ContentFragmentView = ({ message }: ContentFragmentViewProps) => {
           </a>
         )}{" "}
         <a
-          href={message.textUrl ?? ""}
+          href={isFileContentFragment(message) ? message.textUrl : ""}
           target="_blank"
           className="text-highlight-500"
         >

--- a/front/types/content_fragment.ts
+++ b/front/types/content_fragment.ts
@@ -34,30 +34,42 @@ export type ContentFragmentNodeData = {
   spaceName: string;
 };
 
-export type ContentFragmentType = {
+export type BaseContentFragmentType = {
+  type: "content_fragment";
   id: ModelId;
   sId: string;
-  fileId: string | null;
-  nodeId: string | null;
-  nodeDataSourceViewId: string | null;
-  nodeType: ContentNodeType | null;
-  snippet: string | null;
-  generatedTables: string[];
   created: number;
-  type: "content_fragment";
   visibility: MessageVisibility;
   version: number;
   sourceUrl: string | null;
-  textUrl: string;
-  textBytes: number | null;
   title: string;
   contentType: SupportedContentFragmentType;
   context: ContentFragmentContextType;
   contentFragmentId: string;
   contentFragmentVersion: ContentFragmentVersion;
-  contentNodeData: ContentFragmentNodeData | null;
   expiredReason: ContentFragmentExpiredReason | null;
 };
+
+export type ContentNodeContentFragmentType = BaseContentFragmentType & {
+  contentFragmentType: "content_node";
+  nodeId: string;
+  nodeDataSourceViewId: string;
+  nodeType: ContentNodeType;
+  contentNodeData: ContentFragmentNodeData;
+};
+
+export type FileContentFragmentType = BaseContentFragmentType & {
+  contentFragmentType: "file";
+  fileId: string | null;
+  snippet: string | null;
+  generatedTables: string[];
+  textUrl: string;
+  textBytes: number | null;
+};
+
+export type ContentFragmentType =
+  | FileContentFragmentType
+  | ContentNodeContentFragmentType;
 
 export type UploadedContentFragment = {
   fileId: string;
@@ -75,18 +87,14 @@ export function isContentFragmentType(
   return arg.type === "content_fragment";
 }
 
-export function isFileAttachment(
+export function isFileContentFragment(
   arg: ContentFragmentType
-): arg is ContentFragmentType & { fileId: string } {
-  return !!arg.fileId;
+): arg is FileContentFragmentType {
+  return arg.contentFragmentType === "file";
 }
 
-export function isContentNodeAttachment(
+export function isContentNodeContentFragment(
   arg: ContentFragmentType
-): arg is ContentFragmentType & {
-  nodeId: string;
-  nodeDataSourceViewId: string;
-  nodeType: ContentNodeType;
-} {
-  return !!arg.nodeId && !!arg.nodeDataSourceViewId;
+): arg is ContentNodeContentFragmentType {
+  return arg.contentFragmentType === "content_node";
 }

--- a/sdks/js/src/types.ts
+++ b/sdks/js/src/types.ts
@@ -1028,17 +1028,14 @@ const ContentFragmentNodeData = z.object({
   spaceName: z.string(),
 });
 
-const ContentFragmentSchema = z.object({
+const BaseContentFragmentSchema = z.object({
+  type: z.literal("content_fragment"),
   id: ModelIdSchema,
   sId: z.string(),
-  fileId: z.string().nullable(),
   created: z.number(),
-  type: z.literal("content_fragment"),
   visibility: VisibilitySchema,
   version: z.number(),
   sourceUrl: z.string().nullable(),
-  textUrl: z.string(),
-  textBytes: z.number().nullable(),
   title: z.string(),
   contentType: SupportedContentFragmentTypeSchema,
   context: ContentFragmentContextSchema,
@@ -1047,8 +1044,30 @@ const ContentFragmentSchema = z.object({
     z.literal("latest"),
     z.literal("superseded"),
   ]),
-  contentNodeData: ContentFragmentNodeData.nullable(),
 });
+
+const FileContentFragmentSchema = BaseContentFragmentSchema.extend({
+  contentFragmentType: z.literal("file"),
+  fileId: z.string().nullable(),
+  snippet: z.string().nullable(),
+  generatedTables: z.array(z.string()),
+  textUrl: z.string(),
+  textBytes: z.number().nullable(),
+});
+
+const ContentNodeContentFragmentSchema = BaseContentFragmentSchema.extend({
+  contentFragmentType: z.literal("content_node"),
+  nodeId: z.string(),
+  nodeDataSourceViewId: z.string(),
+  nodeType: ContentNodeTypeSchema,
+  contentNodeData: ContentFragmentNodeData,
+});
+
+const ContentFragmentSchema = z.union([
+  FileContentFragmentSchema,
+  ContentNodeContentFragmentSchema,
+]);
+
 export type ContentFragmentType = z.infer<typeof ContentFragmentSchema>;
 
 export type UploadedContentFragmentType = {


### PR DESCRIPTION
## Description

The current code related to content fragments, attachments and files is messy: 
- `ContentFragment` can be several subtypes, but there's not a finite enum
- We have many slightly different ways to render attachments in a conversation
- There's a bunch of duplicated code and the overall flow is hard to follow

This PR is the first step of the refactor: it introduces an enum type to properly distinguish "file" content fragments from "content node" content fragments.
There are associated changes in the way we create the "ConversationFileAttachment" objects (proper split) and in the UI.

## Tests

Extensively tested locally

## Risk

Critical path (but well tested)

## Deploy Plan
Deploy `front`