### PR TITLE
[front] - feat(AB v2): "Search" configuration

### DIFF
--- a/extension/package-lock.json
+++ b/extension/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "@auth0/auth0-spa-js": "^2.1.3",
         "@dust-tt/client": "^1.0.57",
-        "@dust-tt/sparkle": "^0.2.530",
+        "@dust-tt/sparkle": "^0.2.533",
         "@frontapp/plugin-sdk": "^1.8.1",
         "@modelcontextprotocol/sdk": "^1.9.0",
         "@tailwindcss/forms": "^0.5.9",
@@ -335,9 +335,9 @@
       }
     },
     "node_modules/@dust-tt/sparkle": {
-      "version": "0.2.530",
-      "resolved": "https://registry.npmjs.org/@dust-tt/sparkle/-/sparkle-0.2.530.tgz",
-      "integrity": "sha512-Jtzo86rRU1rr9E0wowzBbP64s1vauAXl+g0G1emp3UlLQ47kfu1x352I4ETJGRV3FR26lH+GyOLbnOiRezHORA==",
+      "version": "0.2.533",
+      "resolved": "https://registry.npmjs.org/@dust-tt/sparkle/-/sparkle-0.2.533.tgz",
+      "integrity": "sha512-ztZYMDZ75lHhlxGfK1XUj0+s/i27h9XcQH41dr9BM7m1J4gBlEa19am//yzjD2mKgNU3DFYJxtWLVj089iXzig==",
       "dependencies": {
         "@emoji-mart/data": "^1.1.2",
         "@emoji-mart/react": "^1.1.1",

--- a/extension/package.json
+++ b/extension/package.json
@@ -58,7 +58,7 @@
   "dependencies": {
     "@auth0/auth0-spa-js": "^2.1.3",
     "@dust-tt/client": "^1.0.57",
-    "@dust-tt/sparkle": "^0.2.530",
+    "@dust-tt/sparkle": "^0.2.533",
     "@frontapp/plugin-sdk": "^1.8.1",
     "@modelcontextprotocol/sdk": "^1.9.0",
     "@tailwindcss/forms": "^0.5.9",

--- a/front/components/agent_builder/capabilities/AddKnowledgeDropdown.tsx
+++ b/front/components/agent_builder/capabilities/AddKnowledgeDropdown.tsx
@@ -6,33 +6,69 @@ import {
   DropdownMenuItem,
   DropdownMenuTrigger,
 } from "@dust-tt/sparkle";
+import React, { useState } from "react";
 
+import { AddSearchSheet } from "@app/components/agent_builder/capabilities/knowledge/AddSearchSheet";
+import { isSearchServer } from "@app/components/agent_builder/capabilities/knowledge/utils";
 import { getAvatar } from "@app/lib/actions/mcp_icons";
 import type { MCPServerViewType } from "@app/lib/api/mcp";
 
 interface AddKnowledgeDropdownProps {
-  mcpServerViewsWithKnowledge?: (MCPServerViewType & { label: string })[];
+  mcpServerViewsWithKnowledge: (MCPServerViewType & { label: string })[];
+  onKnowledgeAdd: () => void;
 }
 
 export function AddKnowledgeDropdown({
   mcpServerViewsWithKnowledge = [],
+  onKnowledgeAdd,
 }: AddKnowledgeDropdownProps) {
+  const [isSearchSheetOpen, setIsSearchSheetOpen] = useState(false);
+
+  const handleDropdownItemClick = (view: MCPServerViewType) => {
+    if (isSearchServer(view)) {
+      setIsSearchSheetOpen(true);
+    }
+  };
+
+  const handleSearchSheetSave = () => {
+    setIsSearchSheetOpen(false);
+    onKnowledgeAdd();
+  };
+
+  const handleSearchSheetClose = () => {
+    setIsSearchSheetOpen(false);
+  };
+
   return (
-    <DropdownMenu modal={false}>
-      <DropdownMenuTrigger asChild>
-        <Button label="Add knowledge" size="sm" icon={BookOpenIcon} isSelect />
-      </DropdownMenuTrigger>
-      <DropdownMenuContent>
-        {mcpServerViewsWithKnowledge.map((view) => (
-          <DropdownMenuItem
-            truncateText
-            key={view.id}
-            icon={getAvatar(view.server)}
-            label={view.label}
-            description={view.server.description}
+    <>
+      <DropdownMenu modal={false}>
+        <DropdownMenuTrigger asChild>
+          <Button
+            label="Add knowledge"
+            size="sm"
+            icon={BookOpenIcon}
+            isSelect
           />
-        ))}
-      </DropdownMenuContent>
-    </DropdownMenu>
+        </DropdownMenuTrigger>
+        <DropdownMenuContent>
+          {mcpServerViewsWithKnowledge.map((view) => (
+            <DropdownMenuItem
+              truncateText
+              key={view.id}
+              icon={getAvatar(view.server, "sm")}
+              label={view.label}
+              description={view.server.description}
+              onClick={() => handleDropdownItemClick(view)}
+            />
+          ))}
+        </DropdownMenuContent>
+      </DropdownMenu>
+
+      <AddSearchSheet
+        onKnowledgeAdd={handleSearchSheetSave}
+        isOpen={isSearchSheetOpen}
+        onClose={handleSearchSheetClose}
+      />
+    </>
   );
 }

--- a/front/components/agent_builder/capabilities/AgentBuilderCapabilitiesBlock.tsx
+++ b/front/components/agent_builder/capabilities/AgentBuilderCapabilitiesBlock.tsx
@@ -23,6 +23,7 @@ import type {
 } from "@app/components/agent_builder/AgentBuilderFormContext";
 import { AddKnowledgeDropdown } from "@app/components/agent_builder/capabilities/AddKnowledgeDropdown";
 import { AddToolsDropdown } from "@app/components/agent_builder/capabilities/AddToolsDropdown";
+import { useAgentBuilderTools } from "@app/hooks/useAgentBuilderTools";
 import { DATA_VISUALIZATION_SPECIFICATION } from "@app/lib/actions/utils";
 import { useFeatureFlags } from "@app/lib/swr/workspaces";
 import {
@@ -136,6 +137,8 @@ export function AgentBuilderCapabilitiesBlock() {
     name: "actions",
   });
 
+  const { mcpServerViewsWithKnowledge } = useAgentBuilderTools();
+
   function removeAction(index: number) {
     remove(index);
   }
@@ -153,7 +156,10 @@ export function AgentBuilderCapabilitiesBlock() {
           <div className="flex items-center gap-2">
             {fields.length > 0 && (
               <>
-                <AddKnowledgeDropdown />
+                <AddKnowledgeDropdown
+                  onKnowledgeAdd={() => {}}
+                  mcpServerViewsWithKnowledge={mcpServerViewsWithKnowledge}
+                />
                 <AddToolsDropdown tools={fields} addTools={append} />
               </>
             )}
@@ -167,7 +173,10 @@ export function AgentBuilderCapabilitiesBlock() {
             message="No tools added yet. Add knowledge and tools to enhance your agent's capabilities."
             action={
               <div className="flex items-center gap-2">
-                <AddKnowledgeDropdown />
+                <AddKnowledgeDropdown
+                  onKnowledgeAdd={() => {}}
+                  mcpServerViewsWithKnowledge={mcpServerViewsWithKnowledge}
+                />
                 <AddToolsDropdown tools={fields} addTools={append} />
               </div>
             }

--- a/front/components/agent_builder/capabilities/knowledge/AddSearchSheet.tsx
+++ b/front/components/agent_builder/capabilities/knowledge/AddSearchSheet.tsx
@@ -1,5 +1,10 @@
 import type { MultiPageSheetPage } from "@dust-tt/sparkle";
-import { MagnifyingGlassIcon, MultiPageSheet, MultiPageSheetContent, TextArea } from "@dust-tt/sparkle";
+import {
+  MagnifyingGlassIcon,
+  MultiPageSheet,
+  MultiPageSheetContent,
+  TextArea,
+} from "@dust-tt/sparkle";
 import type { SetStateAction } from "react";
 import { useCallback, useEffect, useMemo, useState } from "react";
 

--- a/front/components/agent_builder/capabilities/knowledge/AddSearchSheet.tsx
+++ b/front/components/agent_builder/capabilities/knowledge/AddSearchSheet.tsx
@@ -6,7 +6,7 @@ import {
   TextArea,
 } from "@dust-tt/sparkle";
 import type { SetStateAction } from "react";
-import { useCallback, useEffect, useState } from "react";
+import { useEffect, useState } from "react";
 
 import { useAgentBuilderContext } from "@app/components/agent_builder/AgentBuilderContext";
 import { DataSourceViewsSpaceSelector } from "@app/components/data_source_view/DataSourceViewsSpaceSelector";
@@ -51,12 +51,11 @@ export function AddSearchSheet({
     }
   }, [isOpen]);
 
-  const setSelectionConfigurationsCallback = useCallback(
-    (func: SetStateAction<DataSourceViewSelectionConfigurations>) => {
-      setDataSourceConfigurations(func);
-    },
-    [setDataSourceConfigurations]
-  );
+  const setSelectionConfigurationsCallback = (
+    func: SetStateAction<DataSourceViewSelectionConfigurations>
+  ) => {
+    setDataSourceConfigurations(func);
+  };
 
   const hasDataSourceSelections =
     Object.keys(dataSourceConfigurations).length > 0;

--- a/front/components/agent_builder/capabilities/knowledge/AddSearchSheet.tsx
+++ b/front/components/agent_builder/capabilities/knowledge/AddSearchSheet.tsx
@@ -9,6 +9,7 @@ import type { SetStateAction } from "react";
 import { useState } from "react";
 
 import { useAgentBuilderContext } from "@app/components/agent_builder/AgentBuilderContext";
+import { useSpacesContext } from "@app/components/assistant_builder/contexts/SpacesContext";
 import { DataSourceViewsSpaceSelector } from "@app/components/data_source_view/DataSourceViewsSpaceSelector";
 import logger from "@app/logger/logger";
 import type { DataSourceViewSelectionConfigurations } from "@app/types";
@@ -35,7 +36,8 @@ export function AddSearchSheet({
   isOpen,
   onClose,
 }: AddSearchSheetProps) {
-  const { owner, spaces, supportedDataSourceViews } = useAgentBuilderContext();
+  const { owner, supportedDataSourceViews } = useAgentBuilderContext();
+  const { spaces } = useSpacesContext();
   const [currentPageId, setCurrentPageId] = useState<PageId>(
     PAGE_IDS.DATA_SOURCE_SELECTION
   );

--- a/front/components/agent_builder/capabilities/knowledge/AddSearchSheet.tsx
+++ b/front/components/agent_builder/capabilities/knowledge/AddSearchSheet.tsx
@@ -1,10 +1,5 @@
 import type { MultiPageSheetPage } from "@dust-tt/sparkle";
-import {
-  MagnifyingGlassIcon,
-  MultiPageSheet,
-  MultiPageSheetContent,
-  TextArea,
-} from "@dust-tt/sparkle";
+import { MagnifyingGlassIcon, MultiPageSheet, MultiPageSheetContent, TextArea } from "@dust-tt/sparkle";
 import type { SetStateAction } from "react";
 import { useCallback, useEffect, useMemo, useState } from "react";
 
@@ -45,14 +40,12 @@ export function AddSearchSheet({
   const [dataSourceConfigurations, setDataSourceConfigurations] =
     useState<DataSourceViewSelectionConfigurations>({});
 
-  // Fetch data source views for this workspace
   const { dataSourceViews } = useDataSourceViews(owner);
 
   const { featureFlags } = useFeatureFlags({
     workspaceId: owner.sId,
   });
 
-  // Reset state when sheet opens/closes
   useEffect(() => {
     if (isOpen) {
       setCurrentPageId("data-source-selection");
@@ -171,6 +164,7 @@ export function AddSearchSheet({
           currentPageId === PAGE_IDS.DATA_SOURCE_SELECTION &&
           !hasDataSourceSelections
         }
+        disableSave={!hasDataSourceSelections || !description.trim()}
       />
     </MultiPageSheet>
   );

--- a/front/components/agent_builder/capabilities/knowledge/AddSearchSheet.tsx
+++ b/front/components/agent_builder/capabilities/knowledge/AddSearchSheet.tsx
@@ -1,0 +1,177 @@
+import type { MultiPageSheetPage } from "@dust-tt/sparkle";
+import {
+  MagnifyingGlassIcon,
+  MultiPageSheet,
+  MultiPageSheetContent,
+  TextArea,
+} from "@dust-tt/sparkle";
+import type { SetStateAction } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
+
+import { useAgentBuilderContext } from "@app/components/agent_builder/AgentBuilderContext";
+import { DataSourceViewsSpaceSelector } from "@app/components/data_source_view/DataSourceViewsSpaceSelector";
+import { supportsDocumentsData } from "@app/lib/data_sources";
+import { useDataSourceViews } from "@app/lib/swr/data_source_views";
+import { useFeatureFlags } from "@app/lib/swr/workspaces";
+import type { DataSourceViewSelectionConfigurations } from "@app/types";
+
+const PAGE_IDS = {
+  DATA_SOURCE_SELECTION: "data-source-selection",
+  DESCRIPTION: "description",
+} as const;
+
+type PageId = (typeof PAGE_IDS)[keyof typeof PAGE_IDS];
+
+function isValidPageId(pageId: string): pageId is PageId {
+  return Object.values(PAGE_IDS).includes(pageId as PageId);
+}
+
+interface AddSearchSheetProps {
+  onKnowledgeAdd: () => void;
+  isOpen: boolean;
+  onClose: () => void;
+}
+
+export function AddSearchSheet({
+  onKnowledgeAdd,
+  isOpen,
+  onClose,
+}: AddSearchSheetProps) {
+  const { owner, spaces } = useAgentBuilderContext();
+  const [currentPageId, setCurrentPageId] = useState<PageId>(
+    PAGE_IDS.DATA_SOURCE_SELECTION
+  );
+  const [description, setDescription] = useState<string>("");
+  const [dataSourceConfigurations, setDataSourceConfigurations] =
+    useState<DataSourceViewSelectionConfigurations>({});
+
+  // Fetch data source views for this workspace
+  const { dataSourceViews } = useDataSourceViews(owner);
+
+  const { featureFlags } = useFeatureFlags({
+    workspaceId: owner.sId,
+  });
+
+  // Reset state when sheet opens/closes
+  useEffect(() => {
+    if (isOpen) {
+      setCurrentPageId("data-source-selection");
+      setDescription("");
+      setDataSourceConfigurations({});
+    }
+  }, [isOpen]);
+
+  const setSelectionConfigurationsCallback = useCallback(
+    (func: SetStateAction<DataSourceViewSelectionConfigurations>) => {
+      setDataSourceConfigurations(func);
+    },
+    [setDataSourceConfigurations]
+  );
+
+  // Filter data sources for document search (excluding table-only sources)
+  const supportedDataSourceViews = useMemo(() => {
+    return dataSourceViews.filter((dsv) =>
+      supportsDocumentsData(dsv.dataSource, featureFlags)
+    );
+  }, [dataSourceViews, featureFlags]);
+
+  const hasDataSourceSelections = useMemo(() => {
+    return Object.keys(dataSourceConfigurations).length > 0;
+  }, [dataSourceConfigurations]);
+
+  const handleSave = () => {
+    if (hasDataSourceSelections && description.trim()) {
+      onKnowledgeAdd();
+    }
+  };
+
+  const handleDescriptionChange = (
+    e: React.ChangeEvent<HTMLTextAreaElement>
+  ) => {
+    setDescription(e.target.value);
+  };
+
+  const handlePageChange = (pageId: string) => {
+    if (isValidPageId(pageId)) {
+      setCurrentPageId(pageId);
+    } else {
+      console.warn(`Invalid page ID received: ${pageId}`);
+    }
+  };
+
+  const pages: MultiPageSheetPage[] = [
+    {
+      id: PAGE_IDS.DATA_SOURCE_SELECTION,
+      title: "Select Data Sources",
+      description: "Choose which data sources to search across",
+      icon: MagnifyingGlassIcon,
+      content: (
+        <div className="space-y-4">
+          <div
+            id="dataSourceViewsSelector"
+            className="overflow-y-auto scrollbar-hide"
+          >
+            <DataSourceViewsSpaceSelector
+              useCase="assistantBuilder"
+              dataSourceViews={supportedDataSourceViews}
+              allowedSpaces={spaces}
+              owner={owner}
+              selectionConfigurations={dataSourceConfigurations}
+              setSelectionConfigurations={setSelectionConfigurationsCallback}
+              viewType="document"
+              isRootSelectable={true}
+            />
+          </div>
+        </div>
+      ),
+    },
+    {
+      id: PAGE_IDS.DESCRIPTION,
+      title: "Add Description",
+      description: "Describe what you want to search for",
+      icon: MagnifyingGlassIcon,
+      content: (
+        <div className="space-y-4">
+          <div>
+            <h3 className="mb-2 text-lg font-semibold">Search Configuration</h3>
+            <p className="text-sm text-muted-foreground">
+              Describe what information you want to search for across your
+              selected data sources.
+            </p>
+          </div>
+
+          <div className="space-y-2">
+            <label className="text-sm font-medium">Search Description</label>
+            <TextArea
+              placeholder="Describe what you want to search for across your selected data sources..."
+              value={description}
+              onChange={handleDescriptionChange}
+              rows={4}
+            />
+            <p className="text-xs text-muted-foreground">
+              This description helps the agent understand what type of
+              information to search for.
+            </p>
+          </div>
+        </div>
+      ),
+    },
+  ];
+
+  return (
+    <MultiPageSheet open={isOpen} onOpenChange={(open) => !open && onClose()}>
+      <MultiPageSheetContent
+        pages={pages}
+        currentPageId={currentPageId}
+        onPageChange={handlePageChange}
+        size="lg"
+        onSave={handleSave}
+        showNavigation={true}
+        disableNext={
+          currentPageId === PAGE_IDS.DATA_SOURCE_SELECTION &&
+          !hasDataSourceSelections
+        }
+      />
+    </MultiPageSheet>
+  );
+}

--- a/front/components/agent_builder/capabilities/knowledge/AddSearchSheet.tsx
+++ b/front/components/agent_builder/capabilities/knowledge/AddSearchSheet.tsx
@@ -6,7 +6,7 @@ import {
   TextArea,
 } from "@dust-tt/sparkle";
 import type { SetStateAction } from "react";
-import { useEffect, useState } from "react";
+import { useState } from "react";
 
 import { useAgentBuilderContext } from "@app/components/agent_builder/AgentBuilderContext";
 import { DataSourceViewsSpaceSelector } from "@app/components/data_source_view/DataSourceViewsSpaceSelector";
@@ -43,13 +43,16 @@ export function AddSearchSheet({
   const [dataSourceConfigurations, setDataSourceConfigurations] =
     useState<DataSourceViewSelectionConfigurations>({});
 
-  useEffect(() => {
-    if (isOpen) {
-      setCurrentPageId(PAGE_IDS.DATA_SOURCE_SELECTION);
-      setDescription("");
-      setDataSourceConfigurations({});
-    }
-  }, [isOpen]);
+  const resetForm = () => {
+    setCurrentPageId(PAGE_IDS.DATA_SOURCE_SELECTION);
+    setDescription("");
+    setDataSourceConfigurations({});
+  };
+
+  const handleClose = () => {
+    resetForm();
+    onClose();
+  };
 
   const setSelectionConfigurationsCallback = (
     func: SetStateAction<DataSourceViewSelectionConfigurations>
@@ -62,6 +65,7 @@ export function AddSearchSheet({
 
   const handleSave = () => {
     if (hasDataSourceSelections && description.trim()) {
+      resetForm();
       onKnowledgeAdd();
     }
   };
@@ -140,7 +144,10 @@ export function AddSearchSheet({
   ];
 
   return (
-    <MultiPageSheet open={isOpen} onOpenChange={(open) => !open && onClose()}>
+    <MultiPageSheet
+      open={isOpen}
+      onOpenChange={(open) => !open && handleClose()}
+    >
       <MultiPageSheetContent
         pages={pages}
         currentPageId={currentPageId}

--- a/front/components/agent_builder/capabilities/knowledge/utils.ts
+++ b/front/components/agent_builder/capabilities/knowledge/utils.ts
@@ -1,0 +1,8 @@
+import type { MCPServerViewType } from "@app/lib/api/mcp";
+
+/**
+ * Helper function to identify search servers
+ */
+export function isSearchServer(view: MCPServerViewType): boolean {
+  return view.server.name === "search";
+}

--- a/front/hooks/useAgentBuilderTools.ts
+++ b/front/hooks/useAgentBuilderTools.ts
@@ -1,11 +1,10 @@
 import { groupBy } from "lodash";
 import { useMemo } from "react";
-
-import { useAgentBuilderContext } from "@app/components/agent_builder/AgentBuilderContext";
 import { useMCPServerViewsContext } from "@app/components/assistant_builder/contexts/MCPServerViewsContext";
 import { getMcpServerViewDisplayName } from "@app/lib/actions/mcp_helper";
 import { getMCPServerRequirements } from "@app/lib/actions/mcp_internal_actions/input_configuration";
 import type { MCPServerViewType } from "@app/lib/api/mcp";
+import { useSpacesContext } from "@app/components/assistant_builder/contexts/SpacesContext";
 
 function getGroupedMCPServerViews({
   mcpServerViews,
@@ -79,7 +78,7 @@ function getGroupedMCPServerViews({
 }
 
 export const useAgentBuilderTools = () => {
-  const { spaces } = useAgentBuilderContext();
+  const { spaces } = useSpacesContext();
   const { mcpServerViews } = useMCPServerViewsContext();
 
   const {

--- a/front/hooks/useAgentBuilderTools.ts
+++ b/front/hooks/useAgentBuilderTools.ts
@@ -53,8 +53,6 @@ function getGroupedMCPServerViews({
     };
   });
 
-  // We show the MCP actions with data sources in Knowledge dropdown,
-  // and the ones without data sources in Tools dropdown.
   const { mcpServerViewsWithKnowledge, mcpServerViewsWithoutKnowledge } =
     groupBy(mcpServerViewsWithLabel, (view) => {
       const requirements = getMCPServerRequirements(view);

--- a/front/hooks/useAgentBuilderTools.ts
+++ b/front/hooks/useAgentBuilderTools.ts
@@ -1,0 +1,100 @@
+import { groupBy } from "lodash";
+import { useMemo } from "react";
+
+import { useAgentBuilderContext } from "@app/components/agent_builder/AgentBuilderContext";
+import { useMCPServerViewsContext } from "@app/components/assistant_builder/contexts/MCPServerViewsContext";
+import { getMcpServerViewDisplayName } from "@app/lib/actions/mcp_helper";
+import { getMCPServerRequirements } from "@app/lib/actions/mcp_internal_actions/input_configuration";
+import type { MCPServerViewType } from "@app/lib/api/mcp";
+
+function getGroupedMCPServerViews({
+  mcpServerViews,
+  spaces,
+}: {
+  mcpServerViews: MCPServerViewType[];
+  spaces: any[];
+}) {
+  if (!mcpServerViews || !Array.isArray(mcpServerViews)) {
+    return {
+      mcpServerViewsWithKnowledge: [],
+      defaultMCPServerViews: [],
+      nonDefaultMCPServerViews: [],
+    };
+  }
+
+  const serverIdToCount = mcpServerViews.reduce(
+    (acc, view) => {
+      acc[view.server.sId] = (acc[view.server.sId] || 0) + 1;
+      return acc;
+    },
+    {} as Record<string, number>
+  );
+
+  const mcpServerViewsWithLabel = mcpServerViews.map((view) => {
+    const displayName = getMcpServerViewDisplayName(view);
+
+    // There can be the same tool available in different spaces, in that case we need to show the space name.
+    if (serverIdToCount[view.server.sId] > 1) {
+      const spaceName = spaces.find(
+        (space) => space.sId === view.spaceId
+      )?.name;
+
+      if (spaceName) {
+        return {
+          ...view,
+          label: `${displayName} (${spaceName})`,
+        };
+      }
+    }
+
+    return {
+      ...view,
+      label: displayName,
+    };
+  });
+
+  // We show the MCP actions with data sources in Knowledge dropdown,
+  // and the ones without data sources in Tools dropdown.
+  const { mcpServerViewsWithKnowledge, mcpServerViewsWithoutKnowledge } =
+    groupBy(mcpServerViewsWithLabel, (view) => {
+      const requirements = getMCPServerRequirements(view);
+
+      const isWithKnowledge =
+        requirements.requiresDataSourceConfiguration ||
+        requirements.requiresTableConfiguration;
+
+      return isWithKnowledge
+        ? "mcpServerViewsWithKnowledge"
+        : "mcpServerViewsWithoutKnowledge";
+    });
+
+  const grouped = groupBy(
+    mcpServerViewsWithoutKnowledge,
+    (view) => view.server.availability
+  );
+
+  return {
+    mcpServerViewsWithKnowledge: mcpServerViewsWithKnowledge || [],
+    defaultMCPServerViews: grouped.auto || [],
+    nonDefaultMCPServerViews: grouped.manual || [],
+  };
+}
+
+export const useAgentBuilderTools = () => {
+  const { spaces } = useAgentBuilderContext();
+  const { mcpServerViews } = useMCPServerViewsContext();
+
+  const {
+    mcpServerViewsWithKnowledge,
+    defaultMCPServerViews,
+    nonDefaultMCPServerViews,
+  } = useMemo(() => {
+    return getGroupedMCPServerViews({ mcpServerViews, spaces });
+  }, [mcpServerViews, spaces]);
+
+  return {
+    mcpServerViewsWithKnowledge,
+    defaultMCPServerViews,
+    nonDefaultMCPServerViews,
+  };
+};

--- a/front/package-lock.json
+++ b/front/package-lock.json
@@ -7,7 +7,7 @@
       "dependencies": {
         "@auth0/nextjs-auth0": "^3.5.0",
         "@dust-tt/client": "file:../sdks/js",
-        "@dust-tt/sparkle": "^0.2.530",
+        "@dust-tt/sparkle": "^0.2.533",
         "@google-cloud/bigquery": "^7.9.1",
         "@google-cloud/storage-transfer": "^3.6.0",
         "@heroicons/react": "^2.0.11",
@@ -1105,9 +1105,9 @@
       "link": true
     },
     "node_modules/@dust-tt/sparkle": {
-      "version": "0.2.530",
-      "resolved": "https://registry.npmjs.org/@dust-tt/sparkle/-/sparkle-0.2.530.tgz",
-      "integrity": "sha512-Jtzo86rRU1rr9E0wowzBbP64s1vauAXl+g0G1emp3UlLQ47kfu1x352I4ETJGRV3FR26lH+GyOLbnOiRezHORA==",
+      "version": "0.2.533",
+      "resolved": "https://registry.npmjs.org/@dust-tt/sparkle/-/sparkle-0.2.533.tgz",
+      "integrity": "sha512-ztZYMDZ75lHhlxGfK1XUj0+s/i27h9XcQH41dr9BM7m1J4gBlEa19am//yzjD2mKgNU3DFYJxtWLVj089iXzig==",
       "dependencies": {
         "@emoji-mart/data": "^1.1.2",
         "@emoji-mart/react": "^1.1.1",

--- a/front/package.json
+++ b/front/package.json
@@ -24,7 +24,7 @@
   "dependencies": {
     "@auth0/nextjs-auth0": "^3.5.0",
     "@dust-tt/client": "file:../sdks/js",
-    "@dust-tt/sparkle": "^0.2.530",
+    "@dust-tt/sparkle": "^0.2.533",
     "@google-cloud/bigquery": "^7.9.1",
     "@google-cloud/storage-transfer": "^3.6.0",
     "@heroicons/react": "^2.0.11",


### PR DESCRIPTION
## Description

Implements a new configuration flow for adding search capabilities to agents in the Agent Builder. The PR introduces a stateful dropdown for search server selection and a new AddSearchSheet component with a multi-page configuration interface. The first page allows data source selection, while the second page lets users configure the search description.

Note: currently saving a "Search" doesn't modify the agent state. It will be implemented in a follow up PR for the sake of keeping the PR reviewable.


![Screenshot 2025-06-30 at 13 51 49](https://github.com/user-attachments/assets/009d7a3a-b242-4bf5-9bfe-4c66e9031b73)
![Screenshot 2025-06-30 at 13 52 08](https://github.com/user-attachments/assets/1c96bc57-a538-4c93-bf28-fbd98f2bb9f7)

## Risk

Low

## Deploy Plan

Deploy front