### PR TITLE
Add: dedicated app for Slack tools

### DIFF
--- a/core/src/oauth/providers/slack.rs
+++ b/core/src/oauth/providers/slack.rs
@@ -23,6 +23,11 @@ lazy_static! {
         env::var("OAUTH_SLACK_BOT_CLIENT_ID").expect("OAUTH_SLACK_BOT_CLIENT_ID must be set");
     static ref OAUTH_SLACK_BOT_CLIENT_SECRET: String = env::var("OAUTH_SLACK_BOT_CLIENT_SECRET")
         .expect("OAUTH_SLACK_BOT_CLIENT_SECRET must be set");
+    static ref OAUTH_SLACK_TOOLS_CLIENT_ID: String =
+        env::var("OAUTH_SLACK_TOOLS_CLIENT_ID").expect("OAUTH_SLACK_TOOLS_CLIENT_ID must be set");
+    static ref OAUTH_SLACK_TOOLS_CLIENT_SECRET: String =
+        env::var("OAUTH_SLACK_TOOLS_CLIENT_SECRET")
+            .expect("OAUTH_SLACK_TOOLS_CLIENT_SECRET must be set");
 }
 
 /// We support three Slack apps. Our default `connection` app (for data source connections) a
@@ -53,12 +58,10 @@ impl SlackConnectionProvider {
                 "{}:{}",
                 *OAUTH_SLACK_BOT_CLIENT_ID, *OAUTH_SLACK_BOT_CLIENT_SECRET
             )),
-            // TODO(spolu): the tools related use-cases are currently supported by the main app as
-            // connections but this will be migrated soon to a new app.
             SlackUseCase::PlatformActions | SlackUseCase::PersonalActions => {
                 general_purpose::STANDARD.encode(&format!(
                     "{}:{}",
-                    *OAUTH_SLACK_CLIENT_ID, *OAUTH_SLACK_CLIENT_SECRET
+                    *OAUTH_SLACK_TOOLS_CLIENT_ID, *OAUTH_SLACK_TOOLS_CLIENT_SECRET
                 ))
             }
         }

--- a/front/lib/api/config.ts
+++ b/front/lib/api/config.ts
@@ -168,6 +168,9 @@ const config = {
   getOAuthSlackBotClientId: (): string => {
     return EnvironmentConfig.getEnvVariable("OAUTH_SLACK_BOT_CLIENT_ID");
   },
+  getOAuthSlackToolsClientId: (): string => {
+    return EnvironmentConfig.getEnvVariable("OAUTH_SLACK_TOOLS_CLIENT_ID");
+  },
   getOAuthIntercomClientId: (): string => {
     return EnvironmentConfig.getEnvVariable("OAUTH_INTERCOM_CLIENT_ID");
   },

--- a/front/lib/api/oauth/providers/slack.ts
+++ b/front/lib/api/oauth/providers/slack.ts
@@ -106,6 +106,7 @@ export class SlackOAuthProvider implements BaseOAuthStrategyProvider {
       switch (useCase) {
         case "personal_actions":
         case "platform_actions":
+          return config.getOAuthSlackToolsClientId();
         case "connection": {
           return config.getOAuthSlackClientId();
         }


### PR DESCRIPTION
## Description

Use a dedicated app for Slack Tools.

## Tests

Locally
Will do a test in prod once deployed.
 
## Risk

Low

## Deploy Plan

Deploy front & oauth. (new secrets already deployed)