### PR TITLE
[front] add ability to force provider on log in

### DIFF
--- a/front/pages/api/v1/auth/[action].ts
+++ b/front/pages/api/v1/auth/[action].ts
@@ -1,9 +1,9 @@
 import type { NextApiRequest, NextApiResponse } from "next";
 
 import config from "@app/lib/api/config";
-import logger from "@app/logger/logger";
 import { getWorkOS } from "@app/lib/api/workos/client";
 import { WorkspaceModel } from "@app/lib/resources/storage/models/workspace";
+import logger from "@app/logger/logger";
 
 type Provider = {
   name: "workos" | "auth0";
@@ -131,8 +131,6 @@ async function handleAuthorize(req: NextApiRequest, res: NextApiResponse) {
     code_challenge: `${query.code_challenge}`,
   });
 
-  console.log(params);
-
   const authorizeUrl = `https://${provider.authorizeUri}?${params}`;
   res.redirect(authorizeUrl);
 }
@@ -140,7 +138,6 @@ async function handleAuthorize(req: NextApiRequest, res: NextApiResponse) {
 async function handleAuthenticate(req: NextApiRequest, res: NextApiResponse) {
   try {
     const provider = getProvider(req.query);
-    console.log(`Authenticating with provider: ${provider.name}`);
     const response = await fetch(`https://${provider.authenticateUri}`, {
       method: "POST",
       headers: {

--- a/front/pages/api/v1/auth/[action].ts
+++ b/front/pages/api/v1/auth/[action].ts
@@ -2,8 +2,11 @@ import type { NextApiRequest, NextApiResponse } from "next";
 
 import config from "@app/lib/api/config";
 import logger from "@app/logger/logger";
+import { getWorkOS } from "@app/lib/api/workos/client";
+import { WorkspaceModel } from "@app/lib/resources/storage/models/workspace";
 
 type Provider = {
+  name: "workos" | "auth0";
   authorizeUri: string;
   authenticateUri: string;
   logoutUri: string;
@@ -13,6 +16,7 @@ type Provider = {
 
 const providers: Record<string, Provider> = {
   workos: {
+    name: "workos",
     authorizeUri: "api.workos.com/user_management/authorize",
     authenticateUri: "api.workos.com/user_management/authenticate",
     logoutUri: "api.workos.com/user_management/sessions/logout",
@@ -20,6 +24,7 @@ const providers: Record<string, Provider> = {
     scopes: "openid profile email",
   },
   auth0: {
+    name: "auth0",
     authorizeUri: config.getAuth0TenantUrl() + "/authorize",
     authenticateUri: config.getAuth0TenantUrl() + "/oauth/token",
     logoutUri: config.getAuth0TenantUrl() + "/v2/logout",
@@ -29,8 +34,14 @@ const providers: Record<string, Provider> = {
   },
 };
 
-function getProvider(): Provider {
-  const provider = config.getOAuthProvider();
+function getProvider(
+  query: Partial<{
+    [key: string]: string | string[];
+  }>
+): Provider {
+  const forcedProvider =
+    typeof query.forcedProvider === "string" ? query.forcedProvider : undefined;
+  const provider = forcedProvider || config.getOAuthProvider();
   return providers[provider];
 }
 
@@ -57,22 +68,80 @@ export default async function handler(
 
 async function handleAuthorize(req: NextApiRequest, res: NextApiResponse) {
   const { query } = req;
+  const provider = getProvider(query);
+  const workspace =
+    typeof query.organization_id === "string" &&
+    query.organization_id.startsWith("workspace-")
+      ? query.organization_id.split("workspace-")[1]
+      : undefined;
+
+  const options: Record<string, string | undefined> = {
+    client_id: provider.clientId,
+    scope: provider.scopes,
+  };
+
+  if (provider.name === "workos") {
+    options.provider = `${query.provider}`;
+
+    if (workspace) {
+      const w = await WorkspaceModel.findOne({
+        where: {
+          sId: workspace,
+        },
+      });
+      if (!w) {
+        logger.error(
+          `Workspace with sId ${workspace} not found for WorkOS SSO connection.`
+        );
+        res.status(404).json({ error: "Workspace not found" });
+        return;
+      }
+
+      const organizationId = w.workOSOrganizationId;
+      if (!organizationId) {
+        logger.error(
+          `Workspace with sId ${workspace} does not have a WorkOS organization ID.`
+        );
+        res.status(400).json({
+          error: "Workspace does not have a WorkOS organization ID",
+        });
+        return;
+      }
+
+      const connections = await getWorkOS().sso.listConnections({
+        organizationId,
+      });
+
+      options.connectionId =
+        connections.data.length > 0 ? connections.data[0]?.id : undefined;
+    }
+  } else {
+    query.organization_id
+      ? (options.connection = `${query.organization_id}`)
+      : undefined;
+    options.prompt = `${query.prompt}`;
+    options.audience = `${query.audience}`;
+  }
+
   const params = new URLSearchParams({
-    ...query,
-    client_id: getProvider().clientId,
-    scope: getProvider().scopes,
-    // TODO(provisioning) AUTH0 temporary code, remove when we switch ext to WorkOS
-    ...(query.organization_id
-      ? { connection: `${query.organization_id}` }
-      : {}),
-  }).toString();
-  const authorizeUrl = `https://${getProvider().authorizeUri}?${params}`;
+    ...options,
+    response_type: `${query.response_type}`,
+    redirect_uri: `${query.redirect_uri}`,
+    code_challenge_method: `${query.code_challenge_method}`,
+    code_challenge: `${query.code_challenge}`,
+  });
+
+  console.log(params);
+
+  const authorizeUrl = `https://${provider.authorizeUri}?${params}`;
   res.redirect(authorizeUrl);
 }
 
 async function handleAuthenticate(req: NextApiRequest, res: NextApiResponse) {
   try {
-    const response = await fetch(`https://${getProvider().authenticateUri}`, {
+    const provider = getProvider(req.query);
+    console.log(`Authenticating with provider: ${provider.name}`);
+    const response = await fetch(`https://${provider.authenticateUri}`, {
       method: "POST",
       headers: {
         "Content-Type": "application/x-www-form-urlencoded",
@@ -81,7 +150,7 @@ async function handleAuthenticate(req: NextApiRequest, res: NextApiResponse) {
       credentials: "include",
       body: new URLSearchParams({
         ...req.body,
-        client_id: getProvider().clientId,
+        client_id: provider.clientId,
       }).toString(),
     });
     const data = await response.json();
@@ -94,10 +163,11 @@ async function handleAuthenticate(req: NextApiRequest, res: NextApiResponse) {
 
 async function handleLogout(req: NextApiRequest, res: NextApiResponse) {
   const { query } = req;
+  const provider = getProvider(query);
   const params = new URLSearchParams({
     ...query,
-    client_id: getProvider().clientId,
+    client_id: provider.clientId,
   }).toString();
-  const authorizeUrl = `https://${getProvider().logoutUri}?${params}`;
+  const authorizeUrl = `https://${provider.logoutUri}?${params}`;
   res.redirect(authorizeUrl);
 }

--- a/front/pages/api/v1/auth/[action].ts
+++ b/front/pages/api/v1/auth/[action].ts
@@ -81,7 +81,7 @@ async function handleAuthorize(req: NextApiRequest, res: NextApiResponse) {
   };
 
   if (provider.name === "workos") {
-    options.provider = `${query.provider}`;
+    options.provider = "authkit";
 
     if (workspace) {
       const w = await WorkspaceModel.findOne({
@@ -112,13 +112,14 @@ async function handleAuthorize(req: NextApiRequest, res: NextApiResponse) {
         organizationId,
       });
 
+      options.organizationId = organizationId;
       options.connectionId =
         connections.data.length > 0 ? connections.data[0]?.id : undefined;
     }
   } else {
-    query.organization_id
-      ? (options.connection = `${query.organization_id}`)
-      : undefined;
+    if (query.organization_id) {
+      options.connection = `${query.organization_id}`;
+    }
     options.prompt = `${query.prompt}`;
     options.audience = `${query.audience}`;
   }


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

To easily debug in production, we need to be able to pass a forceProvider attribute to the query parameters of api/v1/auth.

Just add &forcedProvider=auth0 or &forcedProvider=workos at the end of the URLs of the API to choose the authentication provider you want to use.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

Tested by hand.

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

Low risks.

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->

Deploy front.