### PR TITLE
Fix oauth login with auth0

### DIFF
--- a/front/lib/api/auth0.ts
+++ b/front/lib/api/auth0.ts
@@ -296,6 +296,12 @@ export async function verifyAuth0Token(
 export async function getUserFromAuth0Token(
   accessToken: Auth0JwtPayload
 ): Promise<UserResource | null> {
+  const workOSID = accessToken["https://dust.tt/workos_user_id"];
+
+  if (workOSID) {
+    return UserResource.fetchByWorkOSUserId(workOSID);
+  }
+
   return UserResource.fetchByAuth0Sub(accessToken.sub);
 }
 


### PR DESCRIPTION
## Description

If claim has a workUserId, use it in priority. 
Users who have been created first on workos then on auth0 do not have their auth0Sub set, we need to rely on workOSId.

## Tests

locally

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

deploy front 
