### PR TITLE
[front] fix HTML violation error in Error Message 

### DIFF
--- a/front/components/assistant/conversation/ErrorMessage.tsx
+++ b/front/components/assistant/conversation/ErrorMessage.tsx
@@ -32,6 +32,7 @@ export function ErrorMessage({ error, retryHandler }: ErrorMessageProps) {
           size="xs"
         />
         <Popover
+          popoverTriggerAsChild
           trigger={
             <Button
               variant="outline"


### PR DESCRIPTION
## Description
I randomly noticed that we have an error when we show an error message component, since we render button inside the button:
<img width="300" alt="Screenshot 2025-06-30 at 18 13 03" src="https://github.com/user-attachments/assets/3207bb14-66d1-4e29-9bde-7bc5f46e5fb2" />



## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
