### PR TITLE
[poke] chore(workos): Do a metadata update after the domain update

### DIFF
--- a/front/lib/api/workos/organization.ts
+++ b/front/lib/api/workos/organization.ts
@@ -133,7 +133,7 @@ export async function addWorkOSOrganizationDomain(
   await getWorkOS().organizations.updateOrganization({
     organization: organization.id,
     metadata: {
-      _keyTrigger: uniqueId(),
+      _webhookTrigger: uniqueId(),
     },
   });
 
@@ -175,7 +175,7 @@ export async function removeWorkOSOrganizationDomain(
   await getWorkOS().organizations.updateOrganization({
     organization: organization.id,
     metadata: {
-      _keyTrigger: uniqueId(),
+      _webhookTrigger: uniqueId(),
     },
   });
 

--- a/front/lib/api/workos/organization.ts
+++ b/front/lib/api/workos/organization.ts
@@ -5,6 +5,7 @@ import {
   OrganizationDomainState,
 } from "@workos-inc/node";
 import assert from "assert";
+import { uniqueId } from "lodash";
 
 import { config } from "@app/lib/api/regions/config";
 import { getWorkOS } from "@app/lib/api/workos/client";
@@ -126,6 +127,16 @@ export async function addWorkOSOrganizationDomain(
     ],
   });
 
+  // WARN: Hacky update done after the domain data, so that it trigger
+  // the webhook. Should be remove once WorkOS send us webhook when just
+  // the domains change.
+  await getWorkOS().organizations.updateOrganization({
+    organization: organization.id,
+    metadata: {
+      _keyTrigger: uniqueId(),
+    },
+  });
+
   return new Ok(undefined);
 }
 
@@ -156,6 +167,16 @@ export async function removeWorkOSOrganizationDomain(
         domain: d.domain,
         state: DomainDataState.Verified,
       })),
+  });
+
+  // WARN: Hacky update done after the domain data, so that it trigger
+  // the webhook. Should be remove once WorkOS send us webhook when just
+  // the domains change.
+  await getWorkOS().organizations.updateOrganization({
+    organization: organization.id,
+    metadata: {
+      _keyTrigger: uniqueId(),
+    },
   });
 
   return new Ok(undefined);


### PR DESCRIPTION
## Description
- **Issue**: when updating the `domainData`, workOS doesn't sent us the `organization.updated` event. 
- **Fix**: To artificially trigger that, I added a metadata update call right after. The information inside of it isn't important, so I just added a random id.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk
- Low

## Deploy Plan
- Deploy front
