### PR TITLE
[Gmail] Fix emoji handling in email subject lines

### DIFF
--- a/front/lib/actions/mcp_internal_actions/servers/gmail.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/gmail.ts
@@ -108,12 +108,15 @@ const createServer = (): McpServer => {
     async ({ to, cc, bcc, subject, contentType, body }, { authInfo }) => {
       const accessToken = authInfo?.token;
 
+      // Always encode subject line using RFC 2047 to handle any special characters
+      const encodedSubject = `=?UTF-8?B?${Buffer.from(subject, "utf-8").toString("base64")}?=`;
+
       // Create the email message with proper headers and content.
       const message = [
         `To: ${to.join(", ")}`,
         cc?.length ? `Cc: ${cc.join(", ")}` : "",
         bcc?.length ? `Bcc: ${bcc.join(", ")}` : "",
-        `Subject: ${subject}`,
+        `Subject: ${encodedSubject}`,
         "Content-Type: " + contentType,
         "MIME-Version: 1.0",
         "",

--- a/front/lib/actions/mcp_internal_actions/servers/gmail.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/gmail.ts
@@ -114,15 +114,15 @@ const createServer = (): McpServer => {
       // Create the email message with proper headers and content.
       const message = [
         `To: ${to.join(", ")}`,
-        cc?.length ? `Cc: ${cc.join(", ")}` : "",
-        bcc?.length ? `Bcc: ${bcc.join(", ")}` : "",
+        cc?.length ? `Cc: ${cc.join(", ")}` : null,
+        bcc?.length ? `Bcc: ${bcc.join(", ")}` : null,
         `Subject: ${encodedSubject}`,
         "Content-Type: " + contentType,
         "MIME-Version: 1.0",
         "",
         body,
       ]
-        .filter(Boolean)
+        .filter((line) => line !== null)
         .join("\n");
 
       // Encode the message in base64 as required by the Gmail API.


### PR DESCRIPTION
## Description

This PR fixes two issues with Gmail draft creation:

1. **Malformed drafts with emoji subjects**: Gmail drafts with emojis or non-ASCII characters in the subject line would become malformed, showing weird characters in the subject.
2. **Missing first line of email body**: The first line of the email body was being lost due to incorrect filtering of the email header/body separator.

### Changes:
- Implemented RFC 2047 encoding for all email subject lines (always encode to ensure consistent handling)
- Fixed email message construction to preserve the mandatory empty line between headers and body by using `null` instead of empty strings for optional headers and filtering only null values

## Risks

Blast radius: Gmail draft creation functionality
Risk: low

## Tests

N/A

## Deploy Plan

- Deploy front service