### PR TITLE
Reduce getDataSourceTables batch size

### DIFF
--- a/front/temporal/relocation/activities/types.ts
+++ b/front/temporal/relocation/activities/types.ts
@@ -28,7 +28,7 @@ export interface ReadTableChunkParams {
 }
 
 export const CORE_API_CONCURRENCY_LIMIT = 48;
-export const CORE_API_LIST_NODES_BATCH_SIZE = 64;
+export const CORE_API_LIST_NODES_BATCH_SIZE = 16;
 
 // Core.
 


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
In the relocation process, we end up copying a batch of tables too big, leading to:

```
RangeError: Invalid string length
```

This PR reduces the batch size.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
