### PR TITLE
[front] - feat(AB v2): save search config

### DIFF
--- a/front/components/agent_builder/AgentBuilder.tsx
+++ b/front/components/agent_builder/AgentBuilder.tsx
@@ -14,6 +14,7 @@ import { AgentBuilderLayout } from "@app/components/agent_builder/AgentBuilderLa
 import { AgentBuilderLeftPanel } from "@app/components/agent_builder/AgentBuilderLeftPanel";
 import { AgentBuilderRightPanel } from "@app/components/agent_builder/AgentBuilderRightPanel";
 import { submitAgentBuilderForm } from "@app/components/agent_builder/submitAgentBuilderForm";
+import { useMCPServerViewsContext } from "@app/components/assistant_builder/contexts/MCPServerViewsContext";
 import { appLayoutBack } from "@app/components/sparkle/AppContentLayout";
 import { useFeatureFlags } from "@app/lib/swr/workspaces";
 import logger from "@app/logger/logger";
@@ -25,6 +26,7 @@ import {
 
 export default function AgentBuilder() {
   const { owner } = useAgentBuilderContext();
+  const { mcpServerViews } = useMCPServerViewsContext();
   const router = useRouter();
   const sendNotification = useSendNotification();
 
@@ -64,6 +66,7 @@ export default function AgentBuilder() {
       const result = await submitAgentBuilderForm({
         formData,
         owner,
+        mcpServerViews,
         isDraft: false,
       });
 

--- a/front/components/agent_builder/capabilities/AddKnowledgeDropdown.tsx
+++ b/front/components/agent_builder/capabilities/AddKnowledgeDropdown.tsx
@@ -6,37 +6,22 @@ import {
   DropdownMenuItem,
   DropdownMenuTrigger,
 } from "@dust-tt/sparkle";
-import React, { useState } from "react";
+import React from "react";
 
-import { AddSearchSheet } from "@app/components/agent_builder/capabilities/knowledge/AddSearchSheet";
-import { isSearchServer } from "@app/components/agent_builder/capabilities/knowledge/utils";
 import { getAvatar } from "@app/lib/actions/mcp_icons";
 import type { MCPServerViewType } from "@app/lib/api/mcp";
 
 interface AddKnowledgeDropdownProps {
   mcpServerViewsWithKnowledge: (MCPServerViewType & { label: string })[];
-  onKnowledgeAdd: () => void;
+  onItemClick: (serverName: string) => void;
 }
 
 export function AddKnowledgeDropdown({
   mcpServerViewsWithKnowledge = [],
-  onKnowledgeAdd,
+  onItemClick,
 }: AddKnowledgeDropdownProps) {
-  const [isSearchSheetOpen, setIsSearchSheetOpen] = useState(false);
-
   const handleDropdownItemClick = (view: MCPServerViewType) => {
-    if (isSearchServer(view)) {
-      setIsSearchSheetOpen(true);
-    }
-  };
-
-  const handleSearchSheetSave = () => {
-    setIsSearchSheetOpen(false);
-    onKnowledgeAdd();
-  };
-
-  const handleSearchSheetClose = () => {
-    setIsSearchSheetOpen(false);
+    onItemClick(view.server.name);
   };
 
   return (
@@ -63,12 +48,6 @@ export function AddKnowledgeDropdown({
           ))}
         </DropdownMenuContent>
       </DropdownMenu>
-
-      <AddSearchSheet
-        onKnowledgeAdd={handleSearchSheetSave}
-        isOpen={isSearchSheetOpen}
-        onClose={handleSearchSheetClose}
-      />
     </>
   );
 }

--- a/front/components/agent_builder/capabilities/AddToolsDropdown.tsx
+++ b/front/components/agent_builder/capabilities/AddToolsDropdown.tsx
@@ -10,7 +10,7 @@ import {
 } from "@dust-tt/sparkle";
 import type { FieldArray, FieldArrayWithId } from "react-hook-form";
 
-import type { AgentBuilderAction } from "@app/components/agent_builder/AgentBuilderFormContext";
+import type { AgentBuilderAction } from "@app/components/agent_builder/types";
 import type { AgentBuilderFormData } from "@app/components/agent_builder/AgentBuilderFormContext";
 import { getDataVisualizationActionConfiguration } from "@app/components/assistant_builder/types";
 import { DATA_VISUALIZATION_SPECIFICATION } from "@app/lib/actions/utils";
@@ -31,10 +31,16 @@ export function AddToolsDropdown({ tools, addTools }: AddToolsDropdownProps) {
       return;
     }
 
-    // The configuration already has an id, but we ensure it matches our expected type
+    // Convert to the agent builder action format
     const newAction: AgentBuilderAction = {
-      ...dataVisualizationConfig,
       id: dataVisualizationConfig.id,
+      type: "DATA_VISUALIZATION",
+      name: dataVisualizationConfig.name,
+      description: dataVisualizationConfig.description,
+      noConfigurationRequired: dataVisualizationConfig.noConfigurationRequired,
+      configuration: {
+        type: "DATA_VISUALIZATION",
+      },
     };
     addTools(newAction);
   }

--- a/front/components/agent_builder/capabilities/AddToolsDropdown.tsx
+++ b/front/components/agent_builder/capabilities/AddToolsDropdown.tsx
@@ -10,8 +10,8 @@ import {
 } from "@dust-tt/sparkle";
 import type { FieldArray, FieldArrayWithId } from "react-hook-form";
 
-import type { AgentBuilderAction } from "@app/components/agent_builder/types";
 import type { AgentBuilderFormData } from "@app/components/agent_builder/AgentBuilderFormContext";
+import type { AgentBuilderAction } from "@app/components/agent_builder/types";
 import { getDataVisualizationActionConfiguration } from "@app/components/assistant_builder/types";
 import { DATA_VISUALIZATION_SPECIFICATION } from "@app/lib/actions/utils";
 

--- a/front/components/agent_builder/capabilities/AgentBuilderCapabilitiesBlock.tsx
+++ b/front/components/agent_builder/capabilities/AgentBuilderCapabilitiesBlock.tsx
@@ -27,6 +27,7 @@ import { isKnowledgeServerName } from "@app/components/agent_builder/types";
 import { useAgentBuilderTools } from "@app/hooks/useAgentBuilderTools";
 import { getActionSpecification } from "@app/lib/actions/utils";
 import { useFeatureFlags } from "@app/lib/swr/workspaces";
+import logger from "@app/logger/logger";
 import {
   EXTENDED_MAX_STEPS_USE_PER_RUN_LIMIT,
   MAX_STEPS_USE_PER_RUN_LIMIT,
@@ -175,7 +176,7 @@ export function AgentBuilderCapabilitiesBlock() {
     if (isKnowledgeServerName(serverName)) {
       setOpenSheet(serverName);
     } else {
-      console.warn(`Unknown knowledge server: ${serverName}`);
+      logger.warn({ serverName }, "Unknown knowledge server");
     }
   };
 

--- a/front/components/agent_builder/capabilities/knowledge/AddSearchSheet.tsx
+++ b/front/components/agent_builder/capabilities/knowledge/AddSearchSheet.tsx
@@ -5,10 +5,14 @@ import {
   MultiPageSheetContent,
   TextArea,
 } from "@dust-tt/sparkle";
-import type { SetStateAction } from "react";
-import { useState } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 
 import { useAgentBuilderContext } from "@app/components/agent_builder/AgentBuilderContext";
+import type {
+  AgentBuilderAction,
+  SearchAgentBuilderAction,
+} from "@app/components/agent_builder/types";
+import { isSearchAction } from "@app/components/agent_builder/types";
 import { useSpacesContext } from "@app/components/assistant_builder/contexts/SpacesContext";
 import { DataSourceViewsSpaceSelector } from "@app/components/data_source_view/DataSourceViewsSpaceSelector";
 import logger from "@app/logger/logger";
@@ -26,124 +30,148 @@ function isValidPageId(pageId: string): pageId is PageId {
 }
 
 interface AddSearchSheetProps {
-  onKnowledgeAdd: () => void;
+  onSave: (action: AgentBuilderAction) => void;
   isOpen: boolean;
   onClose: () => void;
+  action?: AgentBuilderAction;
 }
 
+const getDataSourceConfigurations = (
+  action?: AgentBuilderAction
+): DataSourceViewSelectionConfigurations => {
+  if (!action || !isSearchAction(action)) {
+    return {};
+  }
+  return action.configuration.dataSourceConfigurations;
+};
+
 export function AddSearchSheet({
-  onKnowledgeAdd,
+  onSave,
   isOpen,
   onClose,
+  action,
 }: AddSearchSheetProps) {
   const { owner, supportedDataSourceViews } = useAgentBuilderContext();
   const { spaces } = useSpacesContext();
+
   const [currentPageId, setCurrentPageId] = useState<PageId>(
     PAGE_IDS.DATA_SOURCE_SELECTION
   );
-  const [description, setDescription] = useState<string>("");
+  const [description, setDescription] = useState(action?.description || "");
   const [dataSourceConfigurations, setDataSourceConfigurations] =
-    useState<DataSourceViewSelectionConfigurations>({});
+    useState<DataSourceViewSelectionConfigurations>(
+      getDataSourceConfigurations(action)
+    );
 
-  const resetForm = () => {
-    setCurrentPageId(PAGE_IDS.DATA_SOURCE_SELECTION);
+  useEffect(() => {
+    setDescription(action?.description || "");
+    setDataSourceConfigurations(getDataSourceConfigurations(action));
+  }, [action]);
+
+  const handleClose = useCallback(() => {
+    onClose();
     setDescription("");
     setDataSourceConfigurations({});
-  };
+    setCurrentPageId(PAGE_IDS.DATA_SOURCE_SELECTION);
+  }, [onClose]);
 
-  const handleClose = () => {
-    resetForm();
-    onClose();
-  };
+  const hasDataSourceSelections = useMemo(() => {
+    return Object.keys(dataSourceConfigurations).length > 0;
+  }, [dataSourceConfigurations]);
 
-  const setSelectionConfigurationsCallback = (
-    func: SetStateAction<DataSourceViewSelectionConfigurations>
-  ) => {
-    setDataSourceConfigurations(func);
-  };
+  const handleSave = useCallback(() => {
+    const searchAction: SearchAgentBuilderAction = {
+      id: action?.id || `search_${Date.now()}`,
+      type: "SEARCH",
+      name: "Search",
+      description,
+      configuration: {
+        type: "SEARCH",
+        dataSourceConfigurations,
+      },
+      noConfigurationRequired: false,
+    };
+    onSave(searchAction);
+    handleClose();
+  }, [action?.id, description, dataSourceConfigurations, onSave, handleClose]);
 
-  const hasDataSourceSelections =
-    Object.keys(dataSourceConfigurations).length > 0;
-
-  const handleSave = () => {
-    if (hasDataSourceSelections && description.trim()) {
-      resetForm();
-      onKnowledgeAdd();
-    }
-  };
-
-  const handleDescriptionChange = (
-    e: React.ChangeEvent<HTMLTextAreaElement>
-  ) => {
-    setDescription(e.target.value);
-  };
-
-  const handlePageChange = (pageId: string) => {
+  const handlePageChange = useCallback((pageId: string) => {
     if (isValidPageId(pageId)) {
       setCurrentPageId(pageId);
     } else {
       logger.warn({ pageId }, "Invalid page ID received");
     }
-  };
+  }, []);
 
-  const pages: MultiPageSheetPage[] = [
-    {
-      id: PAGE_IDS.DATA_SOURCE_SELECTION,
-      title: "Select Data Sources",
-      description: "Choose which data sources to search across",
-      icon: MagnifyingGlassIcon,
-      content: (
-        <div className="space-y-4">
-          <div
-            id="dataSourceViewsSelector"
-            className="overflow-y-auto scrollbar-hide"
-          >
-            <DataSourceViewsSpaceSelector
-              useCase="assistantBuilder"
-              dataSourceViews={supportedDataSourceViews}
-              allowedSpaces={spaces}
-              owner={owner}
-              selectionConfigurations={dataSourceConfigurations}
-              setSelectionConfigurations={setSelectionConfigurationsCallback}
-              viewType="document"
-              isRootSelectable={true}
-            />
+  const pages: MultiPageSheetPage[] = useMemo(
+    () => [
+      {
+        id: PAGE_IDS.DATA_SOURCE_SELECTION,
+        title: "Select Data Sources",
+        description: "Choose which data sources to search across",
+        icon: MagnifyingGlassIcon,
+        content: (
+          <div className="space-y-4">
+            <div
+              id="dataSourceViewsSelector"
+              className="overflow-y-auto scrollbar-hide"
+            >
+              <DataSourceViewsSpaceSelector
+                useCase="assistantBuilder"
+                dataSourceViews={supportedDataSourceViews}
+                allowedSpaces={spaces}
+                owner={owner}
+                selectionConfigurations={dataSourceConfigurations}
+                setSelectionConfigurations={setDataSourceConfigurations}
+                viewType="document"
+                isRootSelectable={true}
+              />
+            </div>
           </div>
-        </div>
-      ),
-    },
-    {
-      id: PAGE_IDS.DESCRIPTION,
-      title: "Add Description",
-      description: "Describe what you want to search for",
-      icon: MagnifyingGlassIcon,
-      content: (
-        <div className="space-y-4">
-          <div>
-            <h3 className="mb-2 text-lg font-semibold">Search Configuration</h3>
-            <p className="text-sm text-muted-foreground">
-              Describe what information you want to search for across your
-              selected data sources.
-            </p>
-          </div>
+        ),
+      },
+      {
+        id: PAGE_IDS.DESCRIPTION,
+        title: "Add Description",
+        description: "Describe what you want to search for",
+        icon: MagnifyingGlassIcon,
+        content: (
+          <div className="space-y-4">
+            <div>
+              <h3 className="mb-2 text-lg font-semibold">
+                Search Configuration
+              </h3>
+              <p className="text-sm text-muted-foreground">
+                Describe what information you want to search for across your
+                selected data sources.
+              </p>
+            </div>
 
-          <div className="space-y-2">
-            <label className="text-sm font-medium">Search Description</label>
-            <TextArea
-              placeholder="Describe what you want to search for across your selected data sources..."
-              value={description}
-              onChange={handleDescriptionChange}
-              rows={4}
-            />
-            <p className="text-xs text-muted-foreground">
-              This description helps the agent understand what type of
-              information to search for.
-            </p>
+            <div className="space-y-2">
+              <label className="text-sm font-medium">Search Description</label>
+              <TextArea
+                placeholder="Describe what you want to search for across your selected data sources..."
+                value={description}
+                onChange={(e) => setDescription(e.target.value)}
+                rows={4}
+              />
+              <p className="text-xs text-muted-foreground">
+                This description helps the agent understand what type of
+                information to search for.
+              </p>
+            </div>
           </div>
-        </div>
-      ),
-    },
-  ];
+        ),
+      },
+    ],
+    [
+      supportedDataSourceViews,
+      spaces,
+      owner,
+      dataSourceConfigurations,
+      description,
+    ]
+  );
 
   return (
     <MultiPageSheet

--- a/front/components/agent_builder/capabilities/knowledge/utils.ts
+++ b/front/components/agent_builder/capabilities/knowledge/utils.ts
@@ -1,8 +1,0 @@
-import type { MCPServerViewType } from "@app/lib/api/mcp";
-
-/**
- * Helper function to identify search servers
- */
-export function isSearchServer(view: MCPServerViewType): boolean {
-  return view.server.name === "search";
-}

--- a/front/components/agent_builder/types.ts
+++ b/front/components/agent_builder/types.ts
@@ -1,5 +1,75 @@
-import type { SupportedModel } from "@app/types";
+import type {
+  SupportedModel,
+  DataSourceViewSelectionConfigurations,
+} from "@app/types";
 import { ioTsEnum } from "@app/types";
+
+// ===== Agent Builder Action Types =====
+
+// Search Action Configuration
+export interface SearchActionConfiguration {
+  type: "SEARCH";
+  dataSourceConfigurations: DataSourceViewSelectionConfigurations;
+}
+
+// Data Visualization Action Configuration
+export interface DataVisualizationActionConfiguration {
+  type: "DATA_VISUALIZATION";
+}
+
+// Union of all action configurations
+export type AgentBuilderActionConfiguration =
+  | SearchActionConfiguration
+  | DataVisualizationActionConfiguration;
+
+// Base Agent Builder Action
+export interface BaseAgentBuilderAction {
+  id: string;
+  name: string;
+  description: string;
+  noConfigurationRequired: boolean;
+}
+
+// Search Action
+export interface SearchAgentBuilderAction extends BaseAgentBuilderAction {
+  type: "SEARCH";
+  configuration: SearchActionConfiguration;
+}
+
+// Data Visualization Action
+export interface DataVisualizationAgentBuilderAction
+  extends BaseAgentBuilderAction {
+  type: "DATA_VISUALIZATION";
+  configuration: DataVisualizationActionConfiguration;
+}
+
+// Union of all agent builder actions
+export type AgentBuilderAction =
+  | SearchAgentBuilderAction
+  | DataVisualizationAgentBuilderAction;
+
+// Type guards
+export function isSearchAction(
+  action: AgentBuilderAction
+): action is SearchAgentBuilderAction {
+  return action.type === "SEARCH";
+}
+
+export function isDataVisualizationAction(
+  action: AgentBuilderAction
+): action is DataVisualizationAgentBuilderAction {
+  return action.type === "DATA_VISUALIZATION";
+}
+
+// Knowledge server names that require configuration sheets
+export const KNOWLEDGE_SERVER_NAMES = ["search"] as const;
+export type KnowledgeServerName = (typeof KNOWLEDGE_SERVER_NAMES)[number];
+
+export function isKnowledgeServerName(
+  serverName: string
+): serverName is KnowledgeServerName {
+  return KNOWLEDGE_SERVER_NAMES.includes(serverName as KnowledgeServerName);
+}
 
 export const AGENT_CREATIVITY_LEVELS = [
   "deterministic",

--- a/front/components/agent_builder/types.ts
+++ b/front/components/agent_builder/types.ts
@@ -1,52 +1,32 @@
-import type {
-  SupportedModel,
-  DataSourceViewSelectionConfigurations,
-} from "@app/types";
+import type { z } from "zod";
+
+import type { agentBuilderFormSchema } from "@app/components/agent_builder/AgentBuilderFormContext";
+import type { SupportedModel } from "@app/types";
 import { ioTsEnum } from "@app/types";
 
-// ===== Agent Builder Action Types =====
+type AgentBuilderFormData = z.infer<typeof agentBuilderFormSchema>;
 
-// Search Action Configuration
-export interface SearchActionConfiguration {
-  type: "SEARCH";
-  dataSourceConfigurations: DataSourceViewSelectionConfigurations;
-}
+export type AgentBuilderAction = AgentBuilderFormData["actions"][number];
 
-// Data Visualization Action Configuration
-export interface DataVisualizationActionConfiguration {
-  type: "DATA_VISUALIZATION";
-}
+export type SearchAgentBuilderAction = Extract<
+  AgentBuilderAction,
+  { type: "SEARCH" }
+>;
 
-// Union of all action configurations
+export type DataVisualizationAgentBuilderAction = Extract<
+  AgentBuilderAction,
+  { type: "DATA_VISUALIZATION" }
+>;
+
+export type SearchActionConfiguration =
+  SearchAgentBuilderAction["configuration"];
+
+export type DataVisualizationActionConfiguration =
+  DataVisualizationAgentBuilderAction["configuration"];
+
 export type AgentBuilderActionConfiguration =
   | SearchActionConfiguration
   | DataVisualizationActionConfiguration;
-
-// Base Agent Builder Action
-export interface BaseAgentBuilderAction {
-  id: string;
-  name: string;
-  description: string;
-  noConfigurationRequired: boolean;
-}
-
-// Search Action
-export interface SearchAgentBuilderAction extends BaseAgentBuilderAction {
-  type: "SEARCH";
-  configuration: SearchActionConfiguration;
-}
-
-// Data Visualization Action
-export interface DataVisualizationAgentBuilderAction
-  extends BaseAgentBuilderAction {
-  type: "DATA_VISUALIZATION";
-  configuration: DataVisualizationActionConfiguration;
-}
-
-// Union of all agent builder actions
-export type AgentBuilderAction =
-  | SearchAgentBuilderAction
-  | DataVisualizationAgentBuilderAction;
 
 // Type guards
 export function isSearchAction(

--- a/front/hooks/useAgentBuilderTools.ts
+++ b/front/hooks/useAgentBuilderTools.ts
@@ -1,10 +1,11 @@
 import { groupBy } from "lodash";
 import { useMemo } from "react";
+
 import { useMCPServerViewsContext } from "@app/components/assistant_builder/contexts/MCPServerViewsContext";
+import { useSpacesContext } from "@app/components/assistant_builder/contexts/SpacesContext";
 import { getMcpServerViewDisplayName } from "@app/lib/actions/mcp_helper";
 import { getMCPServerRequirements } from "@app/lib/actions/mcp_internal_actions/input_configuration";
 import type { MCPServerViewType } from "@app/lib/api/mcp";
-import { useSpacesContext } from "@app/components/assistant_builder/contexts/SpacesContext";
 
 function getGroupedMCPServerViews({
   mcpServerViews,

--- a/front/lib/actions/utils.ts
+++ b/front/lib/actions/utils.ts
@@ -1,4 +1,4 @@
-import { BarChartIcon, BoltIcon } from "@dust-tt/sparkle";
+import { BarChartIcon, BoltIcon, MagnifyingGlassIcon } from "@dust-tt/sparkle";
 
 import type { ActionSpecification } from "@app/components/assistant_builder/types";
 import type { MCPToolStakeLevelType } from "@app/lib/actions/constants";
@@ -38,6 +38,30 @@ export const DATA_VISUALIZATION_SPECIFICATION: ActionSpecification = {
   dropDownIcon: BarChartIcon,
   flag: null,
 };
+
+export const SEARCH_SPECIFICATION: ActionSpecification = {
+  label: "Search",
+  description: "Search across selected data sources",
+  cardIcon: MagnifyingGlassIcon,
+  dropDownIcon: MagnifyingGlassIcon,
+  flag: null,
+};
+
+// Mapping for action types to their specifications
+export const ACTION_SPECIFICATIONS_MAP = {
+  DATA_VISUALIZATION: DATA_VISUALIZATION_SPECIFICATION,
+  SEARCH: SEARCH_SPECIFICATION,
+} as const;
+
+export function getActionSpecification(
+  actionType: string
+): ActionSpecification | null {
+  return (
+    ACTION_SPECIFICATIONS_MAP[
+      actionType as keyof typeof ACTION_SPECIFICATIONS_MAP
+    ] || null
+  );
+}
 
 /**
  * This function computes the topK for retrieval actions. This is used by both the action (to


### PR DESCRIPTION
## Description

This PR implements saving search configurations in the Agent Builder v2. It introduces new interfaces and functionality to handle search action types, including data source selection and search description settings. The implementation includes:
- Type definitions for search actions and their configurations
- Conversion of search actions to MCP server configurations
- Support for dynamic data source selection with tag filtering
- Integration with the existing agent builder state management

Note: this is the follow up of this PR https://github.com/dust-tt/dust/pull/13909, which needs some tweaking

## Tests

Locally

## Risk

Behind FF

## Deploy Plan

Deploy front