### PR TITLE
Reduce table batch size

### DIFF
--- a/front/temporal/relocation/activities/types.ts
+++ b/front/temporal/relocation/activities/types.ts
@@ -28,7 +28,7 @@ export interface ReadTableChunkParams {
 }
 
 export const CORE_API_CONCURRENCY_LIMIT = 48;
-export const CORE_API_LIST_NODES_BATCH_SIZE = 16;
+export const CORE_API_LIST_NODES_BATCH_SIZE = 8;
 
 // Core.
 


### PR DESCRIPTION
## Description

Tables are too big (~40Mb each) and break JSON.stringify . Reduce the batch size

## Tests

tested on prod data

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

deploy front