### PR TITLE
[front] enh(provisioning): add origin to role column of `WorkspaceMembersList`

### DIFF
--- a/front/components/members/MembersList.tsx
+++ b/front/components/members/MembersList.tsx
@@ -158,6 +158,16 @@ const memberColumns = [
   },
 ];
 
+interface MembersListProps {
+  currentUser: UserType | null;
+  membersData: MembersData;
+  onRowClick: (user: UserTypeWithWorkspace) => void;
+  onRemoveMemberClick?: (user: UserTypeWithWorkspace) => void;
+  showColumns: ("name" | "email" | "role" | "remove" | "status" | "groups")[];
+  pagination?: PaginationState;
+  setPagination?: (pagination: PaginationState) => void;
+}
+
 export function MembersList({
   currentUser,
   membersData,
@@ -166,15 +176,7 @@ export function MembersList({
   showColumns,
   pagination,
   setPagination,
-}: {
-  currentUser: UserType | null;
-  membersData: MembersData;
-  onRowClick: (user: UserTypeWithWorkspace) => void;
-  onRemoveMemberClick?: (user: UserTypeWithWorkspace) => void;
-  showColumns: ("name" | "email" | "role" | "remove" | "status" | "groups")[];
-  pagination?: PaginationState;
-  setPagination?: (pagination: PaginationState) => void;
-}) {
+}: MembersListProps) {
   assert(
     !showColumns.includes("remove") || onRemoveMemberClick,
     "onRemoveMemberClick is required if remove column is shown"

--- a/front/components/members/MembersList.tsx
+++ b/front/components/members/MembersList.tsx
@@ -52,7 +52,7 @@ function getTableRows({
     name: user.fullName,
     userId: user.sId,
     email: user.email ?? "",
-    role: user.workspace.role,
+    role: `${user.workspace.role} (${user.origin})`,
     status: user.lastLoginAt === null ? "Unregistered" : "Active",
     groups: user.workspace.groups ?? [],
     isCurrentUser: user.sId === currentUserId,

--- a/front/components/members/MembersList.tsx
+++ b/front/components/members/MembersList.tsx
@@ -140,7 +140,9 @@ const memberColumns = [
       return (
         <DataTable.CellContent>
           {info.row.original.status +
-            (info.row.original.origin ? ` (${info.row.original.origin})` : "")}
+            (info.row.original.origin
+              ? ` (${_.capitalize(info.row.original.origin)})`
+              : "")}
         </DataTable.CellContent>
       );
     },

--- a/front/components/members/MembersList.tsx
+++ b/front/components/members/MembersList.tsx
@@ -25,7 +25,7 @@ type RowData = {
   name: string;
   userId: string;
   email: string;
-  role: RoleType;
+  role: `${RoleType} (${MembershipOriginType})` | RoleType;
   status: "Active" | "Unregistered";
   groups: string[];
   isCurrentUser: boolean;
@@ -52,7 +52,9 @@ function getTableRows({
     name: user.fullName,
     userId: user.sId,
     email: user.email ?? "",
-    role: `${user.workspace.role} (${user.origin})`,
+    role: user.origin
+      ? `${user.workspace.role} (${user.origin})`
+      : user.workspace.role,
     status: user.lastLoginAt === null ? "Unregistered" : "Active",
     groups: user.workspace.groups ?? [],
     isCurrentUser: user.sId === currentUserId,

--- a/front/components/members/MembersList.tsx
+++ b/front/components/members/MembersList.tsx
@@ -25,7 +25,7 @@ type RowData = {
   name: string;
   userId: string;
   email: string;
-  role: `${RoleType} (${MembershipOriginType})` | RoleType;
+  role: RoleType;
   status: "Active" | "Unregistered";
   groups: string[];
   isCurrentUser: boolean;
@@ -52,9 +52,7 @@ function getTableRows({
     name: user.fullName,
     userId: user.sId,
     email: user.email ?? "",
-    role: user.origin
-      ? `${user.workspace.role} (${user.origin})`
-      : user.workspace.role,
+    role: user.workspace.role,
     status: user.lastLoginAt === null ? "Unregistered" : "Active",
     groups: user.workspace.groups ?? [],
     isCurrentUser: user.sId === currentUserId,
@@ -141,7 +139,8 @@ const memberColumns = [
     cell: (info: Info) => {
       return (
         <DataTable.CellContent>
-          {info.row.original.status}
+          {info.row.original.status +
+            (info.row.original.origin ? ` (${info.row.original.origin})` : "")}
         </DataTable.CellContent>
       );
     },


### PR DESCRIPTION
## Description

- Context [here](https://dust4ai.slack.com/archives/C050A0S2Z7F/p1750408604836489).
- We now have a column `origin` on the table `memberships` that can be `invited`, `auto-joined` or `provisioned`.
- We want to display it in the UI.

<img width="599" alt="Screenshot 2025-07-01 at 8 03 08 AM" src="https://github.com/user-attachments/assets/59e3306b-1ad9-4d04-92ad-0f6a8cefd2f0" />

## Tests

- Tested locally.

## Risk

- Low, only UI changes, db already backfilled.

## Deploy Plan

- Deploy front.
