### PR TITLE
[extension] auth: fix default refresh time for chrome

### DIFF
--- a/extension/platforms/chrome/background.ts
+++ b/extension/platforms/chrome/background.ts
@@ -16,7 +16,7 @@ import type { OAuthAuthorizeResponse } from "@app/shared/services/auth";
 import { jwtDecode } from "jwt-decode";
 
 const log = console.error;
-const DEFAULT_TOKEN_EXPIRY_IN_SECONDS = 3600; // 1 hour.
+const DEFAULT_TOKEN_EXPIRY_IN_SECONDS = 5 * 60; // 5 minutes.
 
 // Initialize the platform service.
 const platform = new ChromeCorePlatformService();


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

WorkOS tokens have a 5 minutes lifetime. Our default refresh was after one hour. This made everyone disconnected after 5 minutes.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

Logged in, and refresh successfully my token.

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

Low risks.

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->

Deploy ext