### PR TITLE
Fix script migrate reasonning actions loop

### DIFF
--- a/front/migrations/20250630_move_reasoning_actions_to_mcp.ts
+++ b/front/migrations/20250630_move_reasoning_actions_to_mcp.ts
@@ -86,6 +86,7 @@ async function migrateWorkspaceReasoningActions(
       reasoningConfigurations,
       async (reasoningConfiguration) => {
         await migrateReasoningActionsForActionConfiguration({
+          workspace,
           reasoningConfiguration,
           mcpServerViewForReasoning: mcpServerViewForReasoning,
           logger,
@@ -103,10 +104,12 @@ async function migrateWorkspaceReasoningActions(
  * Migrate the actions for a single reasoning configuration.
  */
 async function migrateReasoningActionsForActionConfiguration({
+  workspace,
   reasoningConfiguration,
   logger,
   execute,
 }: {
+  workspace: LightWorkspaceType;
   reasoningConfiguration: AgentReasoningConfiguration;
   mcpServerViewForReasoning: MCPServerViewResource;
   logger: Logger;
@@ -127,6 +130,7 @@ async function migrateReasoningActionsForActionConfiguration({
   const reasoningActions = await AgentReasoningAction.findAll({
     where: {
       reasoningConfigurationId: reasoningConfiguration.sId,
+      workspaceId: workspace.id,
     },
   });
 


### PR DESCRIPTION
## Description

The loop on my script was wrong -> if a workspace had more than 200 AgentReasoningConfiguration it would have looped forever and ever and ever. 

Fix: Fetch the AgentReasoningActions -> group by AgentReasoningConfiguration and process those. 

Script was not run yet on prod. 

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

Merge and run script. 