### PR TITLE
[front] chore: drop `AgentTablesQueryConfiguration` and update data model

### DIFF
--- a/front/admin/db.ts
+++ b/front/admin/db.ts
@@ -24,10 +24,7 @@ import { RemoteMCPServerModel } from "@app/lib/models/assistant/actions/remote_m
 import { RemoteMCPServerToolMetadataModel } from "@app/lib/models/assistant/actions/remote_mcp_server_tool_metadata";
 import { AgentRetrievalConfiguration } from "@app/lib/models/assistant/actions/retrieval";
 import { AgentSearchLabelsAction } from "@app/lib/models/assistant/actions/search_labels";
-import {
-  AgentTablesQueryConfiguration,
-  AgentTablesQueryConfigurationTable,
-} from "@app/lib/models/assistant/actions/tables_query";
+import { AgentTablesQueryConfigurationTable } from "@app/lib/models/assistant/actions/tables_query";
 import {
   AgentConfiguration,
   AgentUserRelation,
@@ -153,7 +150,6 @@ async function main() {
   await AgentMCPServerConfiguration.sync({ alter: true });
   await AgentRetrievalConfiguration.sync({ alter: true });
   await AgentDustAppRunConfiguration.sync({ alter: true });
-  await AgentTablesQueryConfiguration.sync({ alter: true });
   await AgentTablesQueryConfigurationTable.sync({ alter: true });
   await AgentProcessConfiguration.sync({ alter: true });
   await AgentReasoningConfiguration.sync({ alter: true });

--- a/front/lib/api/agent_data_sources.ts
+++ b/front/lib/api/agent_data_sources.ts
@@ -8,10 +8,7 @@ import { AgentDataSourceConfiguration } from "@app/lib/models/assistant/actions/
 import { AgentMCPServerConfiguration } from "@app/lib/models/assistant/actions/mcp";
 import { AgentProcessConfiguration } from "@app/lib/models/assistant/actions/process";
 import { AgentRetrievalConfiguration } from "@app/lib/models/assistant/actions/retrieval";
-import {
-  AgentTablesQueryConfiguration,
-  AgentTablesQueryConfigurationTable,
-} from "@app/lib/models/assistant/actions/tables_query";
+import { AgentTablesQueryConfigurationTable } from "@app/lib/models/assistant/actions/tables_query";
 import { AgentConfiguration } from "@app/lib/models/assistant/agent";
 import type { DataSourceResource } from "@app/lib/resources/data_source_resource";
 import type { DataSourceViewResource } from "@app/lib/resources/data_source_view_resource";
@@ -282,71 +279,6 @@ export async function getDataSourceViewsUsageByCategory({
           attributes: [],
           required: true,
           include: [agentConfigurationInclude],
-        },
-      ],
-    }),
-    AgentTablesQueryConfigurationTable.findAll({
-      raw: true,
-      group: ["dataSourceView.id"],
-      where: {
-        workspaceId: owner.id,
-      },
-      attributes: [
-        [Sequelize.col("dataSourceView.id"), "dataSourceViewId"],
-        [
-          Sequelize.fn(
-            "array_agg",
-            Sequelize.literal(
-              '"agent_tables_query_configuration->agent_configuration"."name" ORDER BY "agent_tables_query_configuration->agent_configuration"."name"'
-            )
-          ),
-          "names",
-        ],
-        [
-          Sequelize.fn(
-            "array_agg",
-            Sequelize.literal(
-              '"agent_tables_query_configuration->agent_configuration"."sId" ORDER BY "agent_tables_query_configuration->agent_configuration"."name"'
-            )
-          ),
-          "sIds",
-        ],
-      ],
-      include: [
-        {
-          model: DataSourceViewModel,
-          as: "dataSourceView",
-          attributes: [],
-          required: true,
-          include: [
-            {
-              model: DataSourceModel,
-              as: "dataSourceForView",
-              attributes: [],
-              required: true,
-              where: {
-                connectorProvider: connectorProvider,
-              },
-            },
-          ],
-        },
-        {
-          model: AgentTablesQueryConfiguration,
-          as: "agent_tables_query_configuration",
-          attributes: [],
-          required: true,
-          include: [
-            {
-              model: AgentConfiguration,
-              as: "agent_configuration",
-              attributes: [],
-              required: true,
-              where: {
-                status: "active",
-                workspaceId: owner.id,
-              },
-            },
-          ],
         },
       ],
     }),
@@ -677,63 +609,6 @@ export async function getDataSourcesUsageByCategory({
           Sequelize.fn(
             "array_agg",
             Sequelize.literal(
-              '"agent_tables_query_configuration->agent_configuration"."name" ORDER BY "agent_tables_query_configuration->agent_configuration"."name"'
-            )
-          ),
-          "names",
-        ],
-        [
-          Sequelize.fn(
-            "array_agg",
-            Sequelize.literal(
-              '"agent_tables_query_configuration->agent_configuration"."sId" ORDER BY "agent_tables_query_configuration->agent_configuration"."name"'
-            )
-          ),
-          "sIds",
-        ],
-      ],
-      include: [
-        {
-          model: DataSourceModel,
-          as: "dataSource",
-          attributes: [],
-          required: true,
-          where: {
-            connectorProvider: connectorProvider,
-          },
-        },
-        {
-          model: AgentTablesQueryConfiguration,
-          as: "agent_tables_query_configuration",
-          attributes: [],
-          required: true,
-          include: [
-            {
-              model: AgentConfiguration,
-              as: "agent_configuration",
-              attributes: [],
-              required: true,
-              where: {
-                status: "active",
-                workspaceId: owner.id,
-              },
-            },
-          ],
-        },
-      ],
-    }),
-    AgentTablesQueryConfigurationTable.findAll({
-      raw: true,
-      group: ["dataSource.id"],
-      where: {
-        workspaceId: owner.id,
-      },
-      attributes: [
-        [Sequelize.col("dataSource.id"), "dataSourceId"],
-        [
-          Sequelize.fn(
-            "array_agg",
-            Sequelize.literal(
               '"agent_mcp_server_configuration->agent_configuration"."name" ORDER BY "agent_mcp_server_configuration->agent_configuration"."name"'
             )
           ),
@@ -992,53 +867,6 @@ export async function getDataSourceUsage({
           Sequelize.fn(
             "array_agg",
             Sequelize.literal(
-              '"agent_tables_query_configuration->agent_configuration"."name" ORDER BY "agent_tables_query_configuration->agent_configuration"."name"'
-            )
-          ),
-          "names",
-        ],
-        [
-          Sequelize.fn(
-            "array_agg",
-            Sequelize.literal(
-              '"agent_tables_query_configuration->agent_configuration"."sId" ORDER BY "agent_tables_query_configuration->agent_configuration"."name"'
-            )
-          ),
-          "sIds",
-        ],
-      ],
-      where: {
-        workspaceId: owner.id,
-        dataSourceId: dataSource.id,
-      },
-      include: [
-        {
-          model: AgentTablesQueryConfiguration,
-          as: "agent_tables_query_configuration",
-          attributes: [],
-          required: true,
-          include: [
-            {
-              model: AgentConfiguration,
-              as: "agent_configuration",
-              attributes: [],
-              required: true,
-              where: {
-                status: "active",
-                workspaceId: owner.id,
-              },
-            },
-          ],
-        },
-      ],
-    }),
-    AgentTablesQueryConfigurationTable.findOne({
-      raw: true,
-      attributes: [
-        [
-          Sequelize.fn(
-            "array_agg",
-            Sequelize.literal(
               '"agent_mcp_server_configuration->agent_configuration"."name" ORDER BY "agent_mcp_server_configuration->agent_configuration"."name"'
             )
           ),
@@ -1254,53 +1082,6 @@ export async function getDataSourceViewUsage({
         {
           model: AgentMCPServerConfiguration,
           as: "agent_mcp_server_configuration",
-          attributes: [],
-          required: true,
-          include: [
-            {
-              model: AgentConfiguration,
-              as: "agent_configuration",
-              attributes: [],
-              required: true,
-              where: {
-                status: "active",
-                workspaceId: owner.id,
-              },
-            },
-          ],
-        },
-      ],
-    }),
-    AgentTablesQueryConfigurationTable.findOne({
-      raw: true,
-      attributes: [
-        [
-          Sequelize.fn(
-            "array_agg",
-            Sequelize.literal(
-              '"agent_tables_query_configuration->agent_configuration"."name" ORDER BY "agent_tables_query_configuration->agent_configuration"."name"'
-            )
-          ),
-          "names",
-        ],
-        [
-          Sequelize.fn(
-            "array_agg",
-            Sequelize.literal(
-              '"agent_tables_query_configuration->agent_configuration"."sId" ORDER BY "agent_tables_query_configuration->agent_configuration"."name"'
-            )
-          ),
-          "sIds",
-        ],
-      ],
-      where: {
-        workspaceId: owner.id,
-        dataSourceViewId: dataSourceView.id,
-      },
-      include: [
-        {
-          model: AgentTablesQueryConfiguration,
-          as: "agent_tables_query_configuration",
           attributes: [],
           required: true,
           include: [

--- a/front/lib/api/assistant/configuration.ts
+++ b/front/lib/api/assistant/configuration.ts
@@ -36,7 +36,6 @@ import {
 import type { AgentProcessConfiguration } from "@app/lib/models/assistant/actions/process";
 import { AgentReasoningConfiguration } from "@app/lib/models/assistant/actions/reasoning";
 import type { AgentRetrievalConfiguration } from "@app/lib/models/assistant/actions/retrieval";
-import type { AgentTablesQueryConfiguration } from "@app/lib/models/assistant/actions/tables_query";
 import { AgentTablesQueryConfigurationTable } from "@app/lib/models/assistant/actions/tables_query";
 import {
   AgentConfiguration,
@@ -1143,7 +1142,6 @@ export async function createAgentActionConfiguration(
     if (action.tables) {
       await createTableDataSourceConfiguration(auth, t, {
         tableConfigurations: action.tables,
-        tablesQueryConfig: null,
         mcpConfig,
       });
     }
@@ -1278,12 +1276,10 @@ async function createTableDataSourceConfiguration(
   t: Transaction,
   {
     tableConfigurations,
-    tablesQueryConfig,
     mcpConfig,
   }: {
     tableConfigurations: TableDataSourceConfiguration[];
-    tablesQueryConfig: AgentTablesQueryConfiguration | null;
-    mcpConfig: AgentMCPServerConfiguration | null;
+    mcpConfig: AgentMCPServerConfiguration;
   }
 ) {
   const owner = auth.getNonNullableWorkspace();
@@ -1321,8 +1317,7 @@ async function createTableDataSourceConfiguration(
         dataSourceId: dataSource.id,
         dataSourceViewId: dataSourceView.id,
         tableId: tc.tableId,
-        tablesQueryConfigurationId: tablesQueryConfig?.id || null,
-        mcpServerConfigurationId: mcpConfig?.id || null,
+        mcpServerConfigurationId: mcpConfig.id,
         workspaceId: owner.id,
       };
     })

--- a/front/lib/models/assistant/actions/tables_query.ts
+++ b/front/lib/models/assistant/actions/tables_query.ts
@@ -2,78 +2,10 @@ import type { CreationOptional, ForeignKey, NonAttribute } from "sequelize";
 import { DataTypes } from "sequelize";
 
 import { AgentMCPServerConfiguration } from "@app/lib/models/assistant/actions/mcp";
-import { AgentConfiguration } from "@app/lib/models/assistant/agent";
 import { frontSequelize } from "@app/lib/resources/storage";
 import { DataSourceModel } from "@app/lib/resources/storage/models/data_source";
 import { DataSourceViewModel } from "@app/lib/resources/storage/models/data_source_view";
 import { WorkspaceAwareModel } from "@app/lib/resources/storage/wrappers/workspace_models";
-
-export class AgentTablesQueryConfiguration extends WorkspaceAwareModel<AgentTablesQueryConfiguration> {
-  declare createdAt: CreationOptional<Date>;
-  declare updatedAt: CreationOptional<Date>;
-
-  declare agentConfigurationId: ForeignKey<AgentConfiguration["id"]>;
-
-  declare sId: string;
-
-  declare name: string | null;
-  declare description: string | null;
-}
-
-AgentTablesQueryConfiguration.init(
-  {
-    createdAt: {
-      type: DataTypes.DATE,
-      allowNull: false,
-      defaultValue: DataTypes.NOW,
-    },
-    updatedAt: {
-      type: DataTypes.DATE,
-      allowNull: false,
-      defaultValue: DataTypes.NOW,
-    },
-    sId: {
-      type: DataTypes.STRING,
-      allowNull: false,
-    },
-    name: {
-      type: DataTypes.STRING,
-      allowNull: true,
-    },
-    description: {
-      type: DataTypes.TEXT,
-      allowNull: true,
-    },
-  },
-  {
-    modelName: "agent_tables_query_configuration",
-    indexes: [
-      {
-        unique: true,
-        fields: ["sId"],
-        name: "agent_tables_query_configuration_s_id",
-      },
-      // TODO(WORKSPACE_ID_ISOLATION 2025-05-13): Remove this index.
-      {
-        fields: ["agentConfigurationId"],
-        concurrently: true,
-      },
-      {
-        fields: ["workspaceId", "agentConfigurationId"],
-        name: "agent_tables_query_config_workspace_id_agent_config_id",
-        concurrently: true,
-      },
-    ],
-    sequelize: frontSequelize,
-  }
-);
-
-AgentConfiguration.hasMany(AgentTablesQueryConfiguration, {
-  foreignKey: { name: "agentConfigurationId", allowNull: false },
-});
-AgentTablesQueryConfiguration.belongsTo(AgentConfiguration, {
-  foreignKey: { name: "agentConfigurationId", allowNull: false },
-});
 
 export class AgentTablesQueryConfigurationTable extends WorkspaceAwareModel<AgentTablesQueryConfigurationTable> {
   declare createdAt: CreationOptional<Date>;
@@ -83,9 +15,6 @@ export class AgentTablesQueryConfigurationTable extends WorkspaceAwareModel<Agen
 
   declare dataSourceId: ForeignKey<DataSourceModel["id"]> | null;
   declare dataSourceViewId: ForeignKey<DataSourceViewModel["id"]>;
-  declare tablesQueryConfigurationId: ForeignKey<
-    AgentTablesQueryConfiguration["id"]
-  > | null;
   declare mcpServerConfigurationId: ForeignKey<
     AgentMCPServerConfiguration["id"]
   > | null;
@@ -147,16 +76,6 @@ AgentTablesQueryConfigurationTable.init(
     sequelize: frontSequelize,
   }
 );
-
-// Table query config <> Table config
-AgentTablesQueryConfiguration.hasMany(AgentTablesQueryConfigurationTable, {
-  foreignKey: { name: "tablesQueryConfigurationId", allowNull: true },
-  onDelete: "RESTRICT",
-});
-AgentTablesQueryConfigurationTable.belongsTo(AgentTablesQueryConfiguration, {
-  foreignKey: { name: "tablesQueryConfigurationId", allowNull: true },
-  onDelete: "RESTRICT",
-});
 
 // MCP server config <> Table config
 AgentMCPServerConfiguration.hasMany(AgentTablesQueryConfigurationTable, {

--- a/front/lib/models/assistant/actions/tables_query.ts
+++ b/front/lib/models/assistant/actions/tables_query.ts
@@ -43,16 +43,6 @@ AgentTablesQueryConfigurationTable.init(
   {
     modelName: "agent_tables_query_configuration_table",
     indexes: [
-      {
-        unique: true,
-        fields: ["dataSourceViewId", "tableId", "tablesQueryConfigurationId"],
-        name: "agent_tables_query_configuration_table_unique_dsv",
-      },
-      {
-        fields: ["workspaceId", "tablesQueryConfigurationId"],
-        concurrently: true,
-        name: "agent_tables_query_config_table_w_id_tables_query_config_id",
-      },
       // TODO(WORKSPACE_ID_ISOLATION 2025-05-14): Remove index
       { fields: ["dataSourceId"] },
       {

--- a/front/migrations/20250514_migrate_tables_query_to_mcp.ts
+++ b/front/migrations/20250514_migrate_tables_query_to_mcp.ts
@@ -1,210 +1,210 @@
-import { format } from "date-fns";
-import fs from "fs";
-import { Op } from "sequelize";
-
-import { Authenticator } from "@app/lib/auth";
-import { AgentMCPServerConfiguration } from "@app/lib/models/assistant/actions/mcp";
-import {
-  AgentTablesQueryConfiguration,
-  AgentTablesQueryConfigurationTable,
-} from "@app/lib/models/assistant/actions/tables_query";
-import { AgentConfiguration } from "@app/lib/models/assistant/agent";
-import { MCPServerViewResource } from "@app/lib/resources/mcp_server_view_resource";
-import { generateRandomModelSId } from "@app/lib/resources/string_ids";
-import { concurrentExecutor } from "@app/lib/utils/async_utils";
-import type Logger from "@app/logger/logger";
-import { makeScript } from "@app/scripts/helpers";
-import { removeNulls } from "@app/types";
-
-/**
- * Migrates tables query actions from non-MCP to MCP version for a specific workspace.
- * Overall plan is to find the tables configurations,
- */
-async function migrateWorkspaceTablesQueryActions({
-  wId,
-  execute,
-  parentLogger,
-}: {
-  wId: string;
-  execute: boolean;
-  parentLogger: typeof Logger;
-}): Promise<string> {
-  const logger = parentLogger.child({
-    workspaceId: wId,
-  });
-
-  logger.info("Starting migration of tables query actions to MCP.");
-
-  // Get admin auth for the workspace
-  const auth = await Authenticator.internalAdminForWorkspace(wId);
-  const workspace = auth.getNonNullableWorkspace();
-
-  // Find all existing tables query configurations that are linked to an active agent configuration
-  // First, get all the unique tablesQueryConfigurationIds that need migration
-  const tableConfigurations = await AgentTablesQueryConfigurationTable.findAll({
-    where: {
-      workspaceId: workspace.id,
-      tablesQueryConfigurationId: { [Op.not]: null },
-      mcpServerConfigurationId: null,
-    },
-    include: [
-      {
-        model: AgentTablesQueryConfiguration,
-        required: true,
-        include: [
-          {
-            model: AgentConfiguration,
-            required: true,
-            where: {
-              status: "active",
-            },
-          },
-        ],
-      },
-    ],
-  });
-
-  const tablesQueryConfigIds = removeNulls(
-    tableConfigurations.map((config) => config.tablesQueryConfigurationId)
-  );
-
-  if (tablesQueryConfigIds.length === 0) {
-    return "";
-  }
-
-  const tablesQueryConfigs = await AgentTablesQueryConfiguration.findAll({
-    where: {
-      id: { [Op.in]: tablesQueryConfigIds },
-      workspaceId: workspace.id,
-    },
-  });
-
-  logger.info(
-    `Found ${tablesQueryConfigs.length} tables query configurations to migrate.`
-  );
-
-  // Create the MCP server views in system and global spaces.
-  await MCPServerViewResource.ensureAllAutoToolsAreCreated(auth);
-
-  const mcpServerView =
-    await MCPServerViewResource.getMCPServerViewForAutoInternalTool(
-      auth,
-      "query_tables"
-    );
-  if (!mcpServerView) {
-    throw new Error("Tables Query MCP server view not found.");
-  }
-
-  let revertSql = "";
-
-  // Replace each agent_tables_query_configuration with an MCP server configuration
-  // and link the corresponding agent_tables_query_configuration_tables to the MCP server configuration.
-  await concurrentExecutor(
-    tablesQueryConfigs,
-    async (tablesQueryConfig) => {
-      const tables = tableConfigurations.filter(
-        (table) => table.tablesQueryConfigurationId === tablesQueryConfig.id
-      );
-
-      if (execute) {
-        // Create the MCP server configuration.
-        const mcpConfig = await AgentMCPServerConfiguration.create({
-          sId: generateRandomModelSId(),
-          agentConfigurationId: tablesQueryConfig.agentConfigurationId,
-          workspaceId: workspace.id,
-          mcpServerViewId: mcpServerView.id,
-          internalMCPServerId: mcpServerView.internalMCPServerId,
-          additionalConfiguration: {},
-          timeFrame: null,
-          name: tablesQueryConfig.name,
-          singleToolDescriptionOverride: tablesQueryConfig.description,
-          appId: null,
-          jsonSchema: null,
-        });
-
-        // Reverse: create the tables query configuration.
-        revertSql +=
-          `INSERT INTO "agent_tables_query_configurations" ` +
-          `("id", "sId", "agentConfigurationId", "workspaceId", "name", "description", "createdAt", "updatedAt") ` +
-          `VALUES ('${tablesQueryConfig.id}', '${tablesQueryConfig.sId}', '${tablesQueryConfig.agentConfigurationId}', ` +
-          `'${tablesQueryConfig.workspaceId}', '${tablesQueryConfig.name}', '${tablesQueryConfig.description}', ` +
-          `'${format(tablesQueryConfig.createdAt, "yyyy-MM-dd")}', ` +
-          `'${format(tablesQueryConfig.updatedAt, "yyyy-MM-dd")}');\n`;
-
-        // Update the tables query configuration tables to link to the new MCP server configuration.
-        for (const table of tables) {
-          // Reverse: link to the tables query configuration instead of the MCP server configuration.
-          revertSql +=
-            `UPDATE "agent_tables_query_configuration_tables" ` +
-            `SET "tablesQueryConfigurationId" = '${tablesQueryConfig.id}', "mcpServerConfigurationId" = NULL ` +
-            `WHERE "id" = '${table.id}';\n`;
-
-          await table.update({
-            mcpServerConfigurationId: mcpConfig.id,
-            tablesQueryConfigurationId: null,
-          });
-        }
-
-        // Delete the tables query configuration.
-        await tablesQueryConfig.destroy();
-
-        // Reverse: delete the MCP server configuration.
-        revertSql += `DELETE FROM "agent_mcp_server_configurations" WHERE "id" = '${mcpConfig.id}';\n`;
-
-        logger.info(
-          {
-            tablesQueryConfigurationId: tablesQueryConfig.id,
-            mcpServerConfigurationId: mcpConfig.id,
-            agentConfigurationId: tablesQueryConfig.agentConfigurationId,
-            tablesCount: tables.length,
-          },
-          `Migrated tables query config to MCP server config.`
-        );
-      } else {
-        logger.info(
-          {
-            tablesQueryConfigurationId: tablesQueryConfig.id,
-            agentConfigurationId: tablesQueryConfig.agentConfigurationId,
-            tablesCount: tables.length,
-          },
-          `Would create MCP server config and migrate tables query config to it.`
-        );
-      }
-    },
-    { concurrency: 10 }
-  );
-
-  if (execute) {
-    logger.info(
-      `Successfully migrated ${tablesQueryConfigs.length} tables query configurations to MCP.`
-    );
-  } else {
-    logger.info(
-      `Would have migrated ${tablesQueryConfigs.length} tables query configurations to MCP.`
-    );
-  }
-
-  return revertSql;
-}
-
-makeScript(
-  {
-    wId: {
-      type: "string",
-      description: "Workspace ID to migrate",
-      required: true,
-    },
-  },
-  async ({ execute, wId }, parentLogger) => {
-    const revertSql = await migrateWorkspaceTablesQueryActions({
-      wId,
-      execute,
-      parentLogger,
-    });
-
-    if (execute && revertSql) {
-      const now = new Date().toISOString().slice(0, 10).replace(/-/g, "");
-      fs.writeFileSync(`${now}_tables_query_to_mcp_revert.sql`, revertSql);
-    }
-  }
-);
+// import { format } from "date-fns";
+// import fs from "fs";
+// import { Op } from "sequelize";
+//
+// import { Authenticator } from "@app/lib/auth";
+// import { AgentMCPServerConfiguration } from "@app/lib/models/assistant/actions/mcp";
+// import {
+//   AgentTablesQueryConfiguration,
+//   AgentTablesQueryConfigurationTable,
+// } from "@app/lib/models/assistant/actions/tables_query";
+// import { AgentConfiguration } from "@app/lib/models/assistant/agent";
+// import { MCPServerViewResource } from "@app/lib/resources/mcp_server_view_resource";
+// import { generateRandomModelSId } from "@app/lib/resources/string_ids";
+// import { concurrentExecutor } from "@app/lib/utils/async_utils";
+// import type Logger from "@app/logger/logger";
+// import { makeScript } from "@app/scripts/helpers";
+// import { removeNulls } from "@app/types";
+//
+// /**
+//  * Migrates tables query actions from non-MCP to MCP version for a specific workspace.
+//  * Overall plan is to find the tables configurations,
+//  */
+// async function migrateWorkspaceTablesQueryActions({
+//   wId,
+//   execute,
+//   parentLogger,
+// }: {
+//   wId: string;
+//   execute: boolean;
+//   parentLogger: typeof Logger;
+// }): Promise<string> {
+//   const logger = parentLogger.child({
+//     workspaceId: wId,
+//   });
+//
+//   logger.info("Starting migration of tables query actions to MCP.");
+//
+//   // Get admin auth for the workspace
+//   const auth = await Authenticator.internalAdminForWorkspace(wId);
+//   const workspace = auth.getNonNullableWorkspace();
+//
+//   // Find all existing tables query configurations that are linked to an active agent configuration
+//   // First, get all the unique tablesQueryConfigurationIds that need migration
+//   const tableConfigurations = await AgentTablesQueryConfigurationTable.findAll({
+//     where: {
+//       workspaceId: workspace.id,
+//       tablesQueryConfigurationId: { [Op.not]: null },
+//       mcpServerConfigurationId: null,
+//     },
+//     include: [
+//       {
+//         model: AgentTablesQueryConfiguration,
+//         required: true,
+//         include: [
+//           {
+//             model: AgentConfiguration,
+//             required: true,
+//             where: {
+//               status: "active",
+//             },
+//           },
+//         ],
+//       },
+//     ],
+//   });
+//
+//   const tablesQueryConfigIds = removeNulls(
+//     tableConfigurations.map((config) => config.tablesQueryConfigurationId)
+//   );
+//
+//   if (tablesQueryConfigIds.length === 0) {
+//     return "";
+//   }
+//
+//   const tablesQueryConfigs = await AgentTablesQueryConfiguration.findAll({
+//     where: {
+//       id: { [Op.in]: tablesQueryConfigIds },
+//       workspaceId: workspace.id,
+//     },
+//   });
+//
+//   logger.info(
+//     `Found ${tablesQueryConfigs.length} tables query configurations to migrate.`
+//   );
+//
+//   // Create the MCP server views in system and global spaces.
+//   await MCPServerViewResource.ensureAllAutoToolsAreCreated(auth);
+//
+//   const mcpServerView =
+//     await MCPServerViewResource.getMCPServerViewForAutoInternalTool(
+//       auth,
+//       "query_tables"
+//     );
+//   if (!mcpServerView) {
+//     throw new Error("Tables Query MCP server view not found.");
+//   }
+//
+//   let revertSql = "";
+//
+//   // Replace each agent_tables_query_configuration with an MCP server configuration
+//   // and link the corresponding agent_tables_query_configuration_tables to the MCP server configuration.
+//   await concurrentExecutor(
+//     tablesQueryConfigs,
+//     async (tablesQueryConfig) => {
+//       const tables = tableConfigurations.filter(
+//         (table) => table.tablesQueryConfigurationId === tablesQueryConfig.id
+//       );
+//
+//       if (execute) {
+//         // Create the MCP server configuration.
+//         const mcpConfig = await AgentMCPServerConfiguration.create({
+//           sId: generateRandomModelSId(),
+//           agentConfigurationId: tablesQueryConfig.agentConfigurationId,
+//           workspaceId: workspace.id,
+//           mcpServerViewId: mcpServerView.id,
+//           internalMCPServerId: mcpServerView.internalMCPServerId,
+//           additionalConfiguration: {},
+//           timeFrame: null,
+//           name: tablesQueryConfig.name,
+//           singleToolDescriptionOverride: tablesQueryConfig.description,
+//           appId: null,
+//           jsonSchema: null,
+//         });
+//
+//         // Reverse: create the tables query configuration.
+//         revertSql +=
+//           `INSERT INTO "agent_tables_query_configurations" ` +
+//           `("id", "sId", "agentConfigurationId", "workspaceId", "name", "description", "createdAt", "updatedAt") ` +
+//           `VALUES ('${tablesQueryConfig.id}', '${tablesQueryConfig.sId}', '${tablesQueryConfig.agentConfigurationId}', ` +
+//           `'${tablesQueryConfig.workspaceId}', '${tablesQueryConfig.name}', '${tablesQueryConfig.description}', ` +
+//           `'${format(tablesQueryConfig.createdAt, "yyyy-MM-dd")}', ` +
+//           `'${format(tablesQueryConfig.updatedAt, "yyyy-MM-dd")}');\n`;
+//
+//         // Update the tables query configuration tables to link to the new MCP server configuration.
+//         for (const table of tables) {
+//           // Reverse: link to the tables query configuration instead of the MCP server configuration.
+//           revertSql +=
+//             `UPDATE "agent_tables_query_configuration_tables" ` +
+//             `SET "tablesQueryConfigurationId" = '${tablesQueryConfig.id}', "mcpServerConfigurationId" = NULL ` +
+//             `WHERE "id" = '${table.id}';\n`;
+//
+//           await table.update({
+//             mcpServerConfigurationId: mcpConfig.id,
+//             tablesQueryConfigurationId: null,
+//           });
+//         }
+//
+//         // Delete the tables query configuration.
+//         await tablesQueryConfig.destroy();
+//
+//         // Reverse: delete the MCP server configuration.
+//         revertSql += `DELETE FROM "agent_mcp_server_configurations" WHERE "id" = '${mcpConfig.id}';\n`;
+//
+//         logger.info(
+//           {
+//             tablesQueryConfigurationId: tablesQueryConfig.id,
+//             mcpServerConfigurationId: mcpConfig.id,
+//             agentConfigurationId: tablesQueryConfig.agentConfigurationId,
+//             tablesCount: tables.length,
+//           },
+//           `Migrated tables query config to MCP server config.`
+//         );
+//       } else {
+//         logger.info(
+//           {
+//             tablesQueryConfigurationId: tablesQueryConfig.id,
+//             agentConfigurationId: tablesQueryConfig.agentConfigurationId,
+//             tablesCount: tables.length,
+//           },
+//           `Would create MCP server config and migrate tables query config to it.`
+//         );
+//       }
+//     },
+//     { concurrency: 10 }
+//   );
+//
+//   if (execute) {
+//     logger.info(
+//       `Successfully migrated ${tablesQueryConfigs.length} tables query configurations to MCP.`
+//     );
+//   } else {
+//     logger.info(
+//       `Would have migrated ${tablesQueryConfigs.length} tables query configurations to MCP.`
+//     );
+//   }
+//
+//   return revertSql;
+// }
+//
+// makeScript(
+//   {
+//     wId: {
+//       type: "string",
+//       description: "Workspace ID to migrate",
+//       required: true,
+//     },
+//   },
+//   async ({ execute, wId }, parentLogger) => {
+//     const revertSql = await migrateWorkspaceTablesQueryActions({
+//       wId,
+//       execute,
+//       parentLogger,
+//     });
+//
+//     if (execute && revertSql) {
+//       const now = new Date().toISOString().slice(0, 10).replace(/-/g, "");
+//       fs.writeFileSync(`${now}_tables_query_to_mcp_revert.sql`, revertSql);
+//     }
+//   }
+// );

--- a/front/migrations/20250516_migrate_tables_query_to_mcp_globally.ts
+++ b/front/migrations/20250516_migrate_tables_query_to_mcp_globally.ts
@@ -1,283 +1,283 @@
-import { format } from "date-fns";
-import fs from "fs";
-import { Op } from "sequelize";
-
-import { DEFAULT_TABLES_QUERY_ACTION_NAME } from "@app/lib/actions/constants";
-import { Authenticator } from "@app/lib/auth";
-import { AgentMCPServerConfiguration } from "@app/lib/models/assistant/actions/mcp";
-import {
-  AgentTablesQueryConfiguration,
-  AgentTablesQueryConfigurationTable,
-} from "@app/lib/models/assistant/actions/tables_query";
-import { AgentConfiguration } from "@app/lib/models/assistant/agent";
-import { MCPServerViewResource } from "@app/lib/resources/mcp_server_view_resource";
-import { WorkspaceModel } from "@app/lib/resources/storage/models/workspace";
-import { generateRandomModelSId } from "@app/lib/resources/string_ids";
-import { concurrentExecutor } from "@app/lib/utils/async_utils";
-import type Logger from "@app/logger/logger";
-import { makeScript } from "@app/scripts/helpers";
-import type { AgentStatus, ModelId } from "@app/types";
-import { removeNulls } from "@app/types";
-
-async function findWorkspacesWithTablesConfigurations({
-  agentStatus,
-}: {
-  agentStatus: AgentStatus;
-}): Promise<ModelId[]> {
-  const tableConfigurations = await AgentTablesQueryConfigurationTable.findAll({
-    attributes: ["workspaceId"],
-    where: {
-      tablesQueryConfigurationId: { [Op.not]: null },
-      mcpServerConfigurationId: null,
-    },
-    include: [
-      {
-        model: AgentTablesQueryConfiguration,
-        required: true,
-        include: [
-          {
-            model: AgentConfiguration,
-            required: true,
-            where: {
-              status: agentStatus,
-            },
-          },
-        ],
-      },
-    ],
-  });
-
-  return tableConfigurations.map((config) => config.workspaceId);
-}
-
-/**
- * Migrates tables query actions from non-MCP to MCP version for a specific workspace.
- */
-async function migrateWorkspaceTablesQueryActions(
-  auth: Authenticator,
-  {
-    execute,
-    parentLogger,
-    agentStatus,
-  }: {
-    execute: boolean;
-    parentLogger: typeof Logger;
-    agentStatus: AgentStatus;
-  }
-): Promise<string> {
-  const owner = auth.getNonNullableWorkspace();
-  const logger = parentLogger.child({
-    workspaceId: owner.sId,
-  });
-
-  logger.info("Starting migration of tables query actions to MCP.");
-
-  // Find all existing tables query configurations that are linked to an active agent configuration
-  // First, get all the unique tablesQueryConfigurationIds that need migration
-  const tableConfigurations = await AgentTablesQueryConfigurationTable.findAll({
-    where: {
-      workspaceId: owner.id,
-      tablesQueryConfigurationId: { [Op.not]: null },
-      mcpServerConfigurationId: null,
-    },
-    include: [
-      {
-        model: AgentTablesQueryConfiguration,
-        required: true,
-        include: [
-          {
-            model: AgentConfiguration,
-            required: true,
-            where: {
-              status: agentStatus,
-            },
-          },
-        ],
-      },
-    ],
-  });
-
-  const tablesQueryConfigIds = removeNulls(
-    tableConfigurations.map((config) => config.tablesQueryConfigurationId)
-  );
-
-  if (tablesQueryConfigIds.length === 0) {
-    return "";
-  }
-
-  const tablesQueryConfigs = await AgentTablesQueryConfiguration.findAll({
-    where: {
-      id: { [Op.in]: tablesQueryConfigIds },
-      workspaceId: owner.id,
-    },
-  });
-
-  logger.info(
-    `Found ${tablesQueryConfigs.length} tables query configurations to migrate.`
-  );
-
-  // Create the MCP server views in system and global spaces.
-  await MCPServerViewResource.ensureAllAutoToolsAreCreated(auth);
-
-  const mcpServerView =
-    await MCPServerViewResource.getMCPServerViewForAutoInternalTool(
-      auth,
-      "query_tables"
-    );
-  if (!mcpServerView) {
-    throw new Error("Tables Query MCP server view not found.");
-  }
-
-  let revertSql = "";
-
-  // Replace each agent_tables_query_configuration with an MCP server configuration
-  // and link the corresponding agent_tables_query_configuration_tables to the MCP server configuration.
-  await concurrentExecutor(
-    tablesQueryConfigs,
-    async (tablesQueryConfig) => {
-      const tables = tableConfigurations.filter(
-        (table) => table.tablesQueryConfigurationId === tablesQueryConfig.id
-      );
-
-      if (execute) {
-        // Create the MCP server configuration.
-        const mcpConfig = await AgentMCPServerConfiguration.create({
-          sId: generateRandomModelSId(),
-          agentConfigurationId: tablesQueryConfig.agentConfigurationId,
-          workspaceId: owner.id,
-          mcpServerViewId: mcpServerView.id,
-          internalMCPServerId: mcpServerView.internalMCPServerId,
-          additionalConfiguration: {},
-          timeFrame: null,
-          name:
-            tablesQueryConfig.name === DEFAULT_TABLES_QUERY_ACTION_NAME
-              ? null
-              : tablesQueryConfig.name,
-          singleToolDescriptionOverride: tablesQueryConfig.description,
-          appId: null,
-          jsonSchema: null,
-        });
-
-        // Reverse: create the tables query configuration.
-        revertSql +=
-          `INSERT INTO "agent_tables_query_configurations" ` +
-          `("id", "sId", "agentConfigurationId", "workspaceId", "name", "description", "createdAt", "updatedAt") ` +
-          `VALUES ('${tablesQueryConfig.id}', '${tablesQueryConfig.sId}', '${tablesQueryConfig.agentConfigurationId}', ` +
-          `'${tablesQueryConfig.workspaceId}', '${tablesQueryConfig.name}', '${tablesQueryConfig.description}', ` +
-          `'${format(tablesQueryConfig.createdAt, "yyyy-MM-dd")}', ` +
-          `'${format(tablesQueryConfig.updatedAt, "yyyy-MM-dd")}');\n`;
-
-        // Update the tables query configuration tables to link to the new MCP server configuration.
-        for (const table of tables) {
-          // Reverse: link to the tables query configuration instead of the MCP server configuration.
-          revertSql +=
-            `UPDATE "agent_tables_query_configuration_tables" ` +
-            `SET "tablesQueryConfigurationId" = '${tablesQueryConfig.id}', "mcpServerConfigurationId" = NULL ` +
-            `WHERE "id" = '${table.id}';\n`;
-
-          await table.update({
-            mcpServerConfigurationId: mcpConfig.id,
-            tablesQueryConfigurationId: null,
-          });
-        }
-
-        // Delete the tables query configuration.
-        await tablesQueryConfig.destroy();
-
-        // Reverse: delete the MCP server configuration.
-        revertSql += `DELETE FROM "agent_mcp_server_configurations" WHERE "id" = '${mcpConfig.id}';\n`;
-
-        logger.info(
-          {
-            tablesQueryConfigurationId: tablesQueryConfig.id,
-            mcpServerConfigurationId: mcpConfig.id,
-            agentConfigurationId: tablesQueryConfig.agentConfigurationId,
-            tablesCount: tables.length,
-          },
-          `Migrated tables query config to MCP server config.`
-        );
-      } else {
-        logger.info(
-          {
-            tablesQueryConfigurationId: tablesQueryConfig.id,
-            agentConfigurationId: tablesQueryConfig.agentConfigurationId,
-            tablesCount: tables.length,
-          },
-          `Would create MCP server config and migrate tables query config to it.`
-        );
-      }
-    },
-    { concurrency: 10 }
-  );
-
-  if (execute) {
-    logger.info(
-      `Successfully migrated ${tablesQueryConfigs.length} tables query configurations to MCP.`
-    );
-  } else {
-    logger.info(
-      `Would have migrated ${tablesQueryConfigs.length} tables query configurations to MCP.`
-    );
-  }
-
-  return revertSql;
-}
-
-makeScript(
-  {
-    startFromWorkspaceId: {
-      type: "number",
-      description: "Workspace ID to start from",
-      required: false,
-    },
-    agentStatus: {
-      type: "string",
-      description: "Agent status to filter on",
-      required: false,
-      default: "active",
-      choices: ["active", "archived", "draft"],
-    },
-  },
-  async ({ execute, startFromWorkspaceId, agentStatus }, parentLogger) => {
-    const now = new Date().toISOString().slice(0, 10).replace(/-/g, "");
-    let revertSql = "";
-
-    const workspaceIds = await findWorkspacesWithTablesConfigurations({
-      agentStatus: agentStatus as AgentStatus,
-    });
-    const workspaces = await WorkspaceModel.findAll({
-      where: {
-        id: { [Op.in]: workspaceIds },
-        ...(startFromWorkspaceId
-          ? { id: { [Op.gte]: startFromWorkspaceId } }
-          : {}),
-      },
-      order: [["id", "ASC"]],
-    });
-
-    for (const workspace of workspaces) {
-      const auth = await Authenticator.internalAdminForWorkspace(workspace.sId);
-
-      const workspaceRevertSql = await migrateWorkspaceTablesQueryActions(
-        auth,
-        {
-          execute,
-          parentLogger,
-          agentStatus: agentStatus as AgentStatus,
-        }
-      );
-
-      if (execute) {
-        fs.writeFileSync(
-          `${now}_tables_query_to_mcp_revert_${workspace.sId}.sql`,
-          workspaceRevertSql
-        );
-      }
-      revertSql += workspaceRevertSql;
-    }
-
-    if (execute) {
-      fs.writeFileSync(`${now}_tables_query_to_mcp_revert_all.sql`, revertSql);
-    }
-  }
-);
+// import { format } from "date-fns";
+// import fs from "fs";
+// import { Op } from "sequelize";
+//
+// import { DEFAULT_TABLES_QUERY_ACTION_NAME } from "@app/lib/actions/constants";
+// import { Authenticator } from "@app/lib/auth";
+// import { AgentMCPServerConfiguration } from "@app/lib/models/assistant/actions/mcp";
+// import {
+//   AgentTablesQueryConfiguration,
+//   AgentTablesQueryConfigurationTable,
+// } from "@app/lib/models/assistant/actions/tables_query";
+// import { AgentConfiguration } from "@app/lib/models/assistant/agent";
+// import { MCPServerViewResource } from "@app/lib/resources/mcp_server_view_resource";
+// import { WorkspaceModel } from "@app/lib/resources/storage/models/workspace";
+// import { generateRandomModelSId } from "@app/lib/resources/string_ids";
+// import { concurrentExecutor } from "@app/lib/utils/async_utils";
+// import type Logger from "@app/logger/logger";
+// import { makeScript } from "@app/scripts/helpers";
+// import type { AgentStatus, ModelId } from "@app/types";
+// import { removeNulls } from "@app/types";
+//
+// async function findWorkspacesWithTablesConfigurations({
+//   agentStatus,
+// }: {
+//   agentStatus: AgentStatus;
+// }): Promise<ModelId[]> {
+//   const tableConfigurations = await AgentTablesQueryConfigurationTable.findAll({
+//     attributes: ["workspaceId"],
+//     where: {
+//       tablesQueryConfigurationId: { [Op.not]: null },
+//       mcpServerConfigurationId: null,
+//     },
+//     include: [
+//       {
+//         model: AgentTablesQueryConfiguration,
+//         required: true,
+//         include: [
+//           {
+//             model: AgentConfiguration,
+//             required: true,
+//             where: {
+//               status: agentStatus,
+//             },
+//           },
+//         ],
+//       },
+//     ],
+//   });
+//
+//   return tableConfigurations.map((config) => config.workspaceId);
+// }
+//
+// /**
+//  * Migrates tables query actions from non-MCP to MCP version for a specific workspace.
+//  */
+// async function migrateWorkspaceTablesQueryActions(
+//   auth: Authenticator,
+//   {
+//     execute,
+//     parentLogger,
+//     agentStatus,
+//   }: {
+//     execute: boolean;
+//     parentLogger: typeof Logger;
+//     agentStatus: AgentStatus;
+//   }
+// ): Promise<string> {
+//   const owner = auth.getNonNullableWorkspace();
+//   const logger = parentLogger.child({
+//     workspaceId: owner.sId,
+//   });
+//
+//   logger.info("Starting migration of tables query actions to MCP.");
+//
+//   // Find all existing tables query configurations that are linked to an active agent configuration
+//   // First, get all the unique tablesQueryConfigurationIds that need migration
+//   const tableConfigurations = await AgentTablesQueryConfigurationTable.findAll({
+//     where: {
+//       workspaceId: owner.id,
+//       tablesQueryConfigurationId: { [Op.not]: null },
+//       mcpServerConfigurationId: null,
+//     },
+//     include: [
+//       {
+//         model: AgentTablesQueryConfiguration,
+//         required: true,
+//         include: [
+//           {
+//             model: AgentConfiguration,
+//             required: true,
+//             where: {
+//               status: agentStatus,
+//             },
+//           },
+//         ],
+//       },
+//     ],
+//   });
+//
+//   const tablesQueryConfigIds = removeNulls(
+//     tableConfigurations.map((config) => config.tablesQueryConfigurationId)
+//   );
+//
+//   if (tablesQueryConfigIds.length === 0) {
+//     return "";
+//   }
+//
+//   const tablesQueryConfigs = await AgentTablesQueryConfiguration.findAll({
+//     where: {
+//       id: { [Op.in]: tablesQueryConfigIds },
+//       workspaceId: owner.id,
+//     },
+//   });
+//
+//   logger.info(
+//     `Found ${tablesQueryConfigs.length} tables query configurations to migrate.`
+//   );
+//
+//   // Create the MCP server views in system and global spaces.
+//   await MCPServerViewResource.ensureAllAutoToolsAreCreated(auth);
+//
+//   const mcpServerView =
+//     await MCPServerViewResource.getMCPServerViewForAutoInternalTool(
+//       auth,
+//       "query_tables"
+//     );
+//   if (!mcpServerView) {
+//     throw new Error("Tables Query MCP server view not found.");
+//   }
+//
+//   let revertSql = "";
+//
+//   // Replace each agent_tables_query_configuration with an MCP server configuration
+//   // and link the corresponding agent_tables_query_configuration_tables to the MCP server configuration.
+//   await concurrentExecutor(
+//     tablesQueryConfigs,
+//     async (tablesQueryConfig) => {
+//       const tables = tableConfigurations.filter(
+//         (table) => table.tablesQueryConfigurationId === tablesQueryConfig.id
+//       );
+//
+//       if (execute) {
+//         // Create the MCP server configuration.
+//         const mcpConfig = await AgentMCPServerConfiguration.create({
+//           sId: generateRandomModelSId(),
+//           agentConfigurationId: tablesQueryConfig.agentConfigurationId,
+//           workspaceId: owner.id,
+//           mcpServerViewId: mcpServerView.id,
+//           internalMCPServerId: mcpServerView.internalMCPServerId,
+//           additionalConfiguration: {},
+//           timeFrame: null,
+//           name:
+//             tablesQueryConfig.name === DEFAULT_TABLES_QUERY_ACTION_NAME
+//               ? null
+//               : tablesQueryConfig.name,
+//           singleToolDescriptionOverride: tablesQueryConfig.description,
+//           appId: null,
+//           jsonSchema: null,
+//         });
+//
+//         // Reverse: create the tables query configuration.
+//         revertSql +=
+//           `INSERT INTO "agent_tables_query_configurations" ` +
+//           `("id", "sId", "agentConfigurationId", "workspaceId", "name", "description", "createdAt", "updatedAt") ` +
+//           `VALUES ('${tablesQueryConfig.id}', '${tablesQueryConfig.sId}', '${tablesQueryConfig.agentConfigurationId}', ` +
+//           `'${tablesQueryConfig.workspaceId}', '${tablesQueryConfig.name}', '${tablesQueryConfig.description}', ` +
+//           `'${format(tablesQueryConfig.createdAt, "yyyy-MM-dd")}', ` +
+//           `'${format(tablesQueryConfig.updatedAt, "yyyy-MM-dd")}');\n`;
+//
+//         // Update the tables query configuration tables to link to the new MCP server configuration.
+//         for (const table of tables) {
+//           // Reverse: link to the tables query configuration instead of the MCP server configuration.
+//           revertSql +=
+//             `UPDATE "agent_tables_query_configuration_tables" ` +
+//             `SET "tablesQueryConfigurationId" = '${tablesQueryConfig.id}', "mcpServerConfigurationId" = NULL ` +
+//             `WHERE "id" = '${table.id}';\n`;
+//
+//           await table.update({
+//             mcpServerConfigurationId: mcpConfig.id,
+//             tablesQueryConfigurationId: null,
+//           });
+//         }
+//
+//         // Delete the tables query configuration.
+//         await tablesQueryConfig.destroy();
+//
+//         // Reverse: delete the MCP server configuration.
+//         revertSql += `DELETE FROM "agent_mcp_server_configurations" WHERE "id" = '${mcpConfig.id}';\n`;
+//
+//         logger.info(
+//           {
+//             tablesQueryConfigurationId: tablesQueryConfig.id,
+//             mcpServerConfigurationId: mcpConfig.id,
+//             agentConfigurationId: tablesQueryConfig.agentConfigurationId,
+//             tablesCount: tables.length,
+//           },
+//           `Migrated tables query config to MCP server config.`
+//         );
+//       } else {
+//         logger.info(
+//           {
+//             tablesQueryConfigurationId: tablesQueryConfig.id,
+//             agentConfigurationId: tablesQueryConfig.agentConfigurationId,
+//             tablesCount: tables.length,
+//           },
+//           `Would create MCP server config and migrate tables query config to it.`
+//         );
+//       }
+//     },
+//     { concurrency: 10 }
+//   );
+//
+//   if (execute) {
+//     logger.info(
+//       `Successfully migrated ${tablesQueryConfigs.length} tables query configurations to MCP.`
+//     );
+//   } else {
+//     logger.info(
+//       `Would have migrated ${tablesQueryConfigs.length} tables query configurations to MCP.`
+//     );
+//   }
+//
+//   return revertSql;
+// }
+//
+// makeScript(
+//   {
+//     startFromWorkspaceId: {
+//       type: "number",
+//       description: "Workspace ID to start from",
+//       required: false,
+//     },
+//     agentStatus: {
+//       type: "string",
+//       description: "Agent status to filter on",
+//       required: false,
+//       default: "active",
+//       choices: ["active", "archived", "draft"],
+//     },
+//   },
+//   async ({ execute, startFromWorkspaceId, agentStatus }, parentLogger) => {
+//     const now = new Date().toISOString().slice(0, 10).replace(/-/g, "");
+//     let revertSql = "";
+//
+//     const workspaceIds = await findWorkspacesWithTablesConfigurations({
+//       agentStatus: agentStatus as AgentStatus,
+//     });
+//     const workspaces = await WorkspaceModel.findAll({
+//       where: {
+//         id: { [Op.in]: workspaceIds },
+//         ...(startFromWorkspaceId
+//           ? { id: { [Op.gte]: startFromWorkspaceId } }
+//           : {}),
+//       },
+//       order: [["id", "ASC"]],
+//     });
+//
+//     for (const workspace of workspaces) {
+//       const auth = await Authenticator.internalAdminForWorkspace(workspace.sId);
+//
+//       const workspaceRevertSql = await migrateWorkspaceTablesQueryActions(
+//         auth,
+//         {
+//           execute,
+//           parentLogger,
+//           agentStatus: agentStatus as AgentStatus,
+//         }
+//       );
+//
+//       if (execute) {
+//         fs.writeFileSync(
+//           `${now}_tables_query_to_mcp_revert_${workspace.sId}.sql`,
+//           workspaceRevertSql
+//         );
+//       }
+//       revertSql += workspaceRevertSql;
+//     }
+//
+//     if (execute) {
+//       fs.writeFileSync(`${now}_tables_query_to_mcp_revert_all.sql`, revertSql);
+//     }
+//   }
+// );

--- a/front/migrations/db/migration_292.sql
+++ b/front/migrations/db/migration_292.sql
@@ -1,2 +1,5 @@
 -- Migration created on Jul 02, 2025
-ALTER TABLE "public"."agent_tables_query_configuration_tables" DROP COLUMN "tablesQueryConfigurationId";
+ALTER TABLE "public"."agent_tables_query_configuration_tables"
+    DROP COLUMN "tablesQueryConfigurationId";
+ALTER TABLE "public"."agent_tables_query_configuration_tables"
+    ALTER COLUMN "mcpServerConfigurationId" DROP NOT NULL;

--- a/front/migrations/db/migration_292.sql
+++ b/front/migrations/db/migration_292.sql
@@ -1,0 +1,2 @@
+-- Migration created on Jul 02, 2025
+ALTER TABLE "public"."agent_tables_query_configuration_tables" DROP COLUMN "tablesQueryConfigurationId";

--- a/front/migrations/db/migration_292.sql
+++ b/front/migrations/db/migration_292.sql
@@ -1,5 +1,5 @@
 -- Migration created on Jul 02, 2025
-ALTER TABLE "public"."agent_tables_query_configuration_tables"
-    DROP COLUMN "tablesQueryConfigurationId";
-ALTER TABLE "public"."agent_tables_query_configuration_tables"
-    ALTER COLUMN "mcpServerConfigurationId" DROP NOT NULL;
+ALTER TABLE "public"."agent_tables_query_configuration_tables" DROP COLUMN "tablesQueryConfigurationId";
+ALTER TABLE "public"."agent_tables_query_configuration_tables" ALTER COLUMN "mcpServerConfigurationId" DROP NOT NULL;
+DROP INDEX IF EXISTS "agent_tables_query_configuration_table_unique_dsv";
+DROP INDEX IF EXISTS "agent_tables_query_config_table_w_id_tables_query_config_id";

--- a/front/migrations/db/migration_293.sql
+++ b/front/migrations/db/migration_293.sql
@@ -1,0 +1,2 @@
+-- Migration created on Jul 02, 2025
+DROP TABLE agent_tables_query_configurations;

--- a/front/poke/temporal/activities.ts
+++ b/front/poke/temporal/activities.ts
@@ -34,10 +34,7 @@ import {
   AgentReasoningConfiguration,
 } from "@app/lib/models/assistant/actions/reasoning";
 import { AgentRetrievalConfiguration } from "@app/lib/models/assistant/actions/retrieval";
-import {
-  AgentTablesQueryConfiguration,
-  AgentTablesQueryConfigurationTable,
-} from "@app/lib/models/assistant/actions/tables_query";
+import { AgentTablesQueryConfigurationTable } from "@app/lib/models/assistant/actions/tables_query";
 import {
   AgentConfiguration,
   AgentUserRelation,
@@ -245,7 +242,7 @@ export async function deleteAgentsActivity({
     });
     await AgentTablesQueryConfigurationTable.destroy({
       where: {
-        tablesQueryConfigurationId: {
+        mcpServerConfigurationId: {
           [Op.in]: mcpServerConfigurations.map((r) => r.id),
         },
       },
@@ -361,27 +358,6 @@ export async function deleteAgentsActivity({
       },
     });
     await AgentDustAppRunConfiguration.destroy({
-      where: {
-        agentConfigurationId: agent.id,
-        workspaceId: workspace.id,
-      },
-    });
-
-    const tablesQueryConfigurations =
-      await AgentTablesQueryConfiguration.findAll({
-        where: {
-          agentConfigurationId: agent.id,
-          workspaceId: workspace.id,
-        },
-      });
-    await AgentTablesQueryConfigurationTable.destroy({
-      where: {
-        tablesQueryConfigurationId: {
-          [Op.in]: tablesQueryConfigurations.map((r) => r.id),
-        },
-      },
-    });
-    await AgentTablesQueryConfiguration.destroy({
       where: {
         agentConfigurationId: agent.id,
         workspaceId: workspace.id,

--- a/front/scripts/remove_draft_agent_configurations.ts
+++ b/front/scripts/remove_draft_agent_configurations.ts
@@ -3,10 +3,6 @@ import { Op } from "sequelize";
 import { AgentDataSourceConfiguration } from "@app/lib/models/assistant/actions/data_sources";
 import { AgentDustAppRunConfiguration } from "@app/lib/models/assistant/actions/dust_app_run";
 import { AgentRetrievalConfiguration } from "@app/lib/models/assistant/actions/retrieval";
-import {
-  AgentTablesQueryConfiguration,
-  AgentTablesQueryConfigurationTable,
-} from "@app/lib/models/assistant/actions/tables_query";
 import { AgentConfiguration } from "@app/lib/models/assistant/agent";
 import { Mention } from "@app/lib/models/assistant/conversation";
 import { WorkspaceModel } from "@app/lib/resources/storage/models/workspace";
@@ -69,36 +65,6 @@ async function deleteDustAppRunConfigurationForAgent(
   });
 }
 
-async function deleteTableQueryConfigurationForAgent(
-  agent: AgentConfiguration
-) {
-  const tableQueryConfigurations = await AgentTablesQueryConfiguration.findAll({
-    where: {
-      agentConfigurationId: agent.id,
-      workspaceId: agent.workspaceId,
-    },
-  });
-
-  if (tableQueryConfigurations.length === 0) {
-    return;
-  }
-
-  await AgentTablesQueryConfigurationTable.destroy({
-    where: {
-      tablesQueryConfigurationId: {
-        [Op.in]: tableQueryConfigurations.map((r) => r.id),
-      },
-    },
-  });
-
-  await AgentTablesQueryConfiguration.destroy({
-    where: {
-      agentConfigurationId: agent.id,
-      workspaceId: agent.workspaceId,
-    },
-  });
-}
-
 /**
  * Destroys a draft agent configuration and all associated configurations.
  * Avoids using transactions to prevent locks.
@@ -140,9 +106,6 @@ async function deleteDraftAgentConfigurationAndRelatedResources(
 
   // Delete the dust app run configurations.
   await deleteDustAppRunConfigurationForAgent(agent);
-
-  // Delete the table query configurations.
-  await deleteTableQueryConfigurationForAgent(agent);
 
   // Finally delete the agent configuration.
   await AgentConfiguration.destroy({


### PR DESCRIPTION
## Description

- This PR removes the Sequelize model `AgentTablesQueryConfiguration` and drops the corresponding table.
- The data model is also updated: the FK `AgentTablesQueryConfigurationTable`->`AgentMCPServerConfiguration` is now non nullable and the column `tablesQueryConfigurationId` is also dropped.

## Tests

- Checked that the table is now empty in both regions and that there is no `AgentTablesQueryConfigurationTable` with a reference to an `AgentTablesQueryConfiguration`.
```sql
SELECT * FROM agent_tables_query_configurations;

SELECT * FROM agent_tables_query_configuration_tables WHERE "tablesQueryConfigurationId" IS NOT NULL;
```
- Tested locally.

## Risk

- Only affects unreachable code paths.

## Deploy Plan

- Deploy main.
- Run `migration_292.sql`.
