### PR TITLE
Do not show private channels for slack_bot connectors

### DIFF
--- a/connectors/src/connectors/slack_bot/index.ts
+++ b/connectors/src/connectors/slack_bot/index.ts
@@ -592,6 +592,12 @@ async function getFilteredChannels(
       continue;
     }
 
+    // Skip private channels as the Slack ToS prevents showing private channels from Admin A to
+    // admin B.
+    if (remoteChannel.is_private) {
+      continue;
+    }
+
     slackChannels.push({
       slackChannelId: remoteChannel.id,
       slackChannelName: remoteChannel.name,


### PR DESCRIPTION
## Description

As per discussion with the App reviewer we can't support the private channel feature for the marketplace app as it is not authorized by Slack terms to show the private channels of admin A to admin B.

## Tests

Simple revert of https://github.com/dust-tt/dust/pull/13892

## Risk

N/A

## Deploy Plan

- deploy `connectors`