### PR TITLE
[CLI] Add --messageId and --details flag to inspect agent messages

### DIFF
--- a/cli/package-lock.json
+++ b/cli/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@dust-tt/dust-cli",
-  "version": "0.1.18",
+  "version": "0.1.19",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@dust-tt/dust-cli",
-      "version": "0.1.18",
+      "version": "0.1.19",
       "license": "MIT",
       "dependencies": {
         "@dust-tt/client": "^1.0.57",

--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dust-tt/dust-cli",
-  "version": "0.1.18",
+  "version": "0.1.19",
   "description": "A command-line interface for interacting with Dust.",
   "type": "module",
   "main": "dist/index.js",

--- a/cli/src/index.tsx
+++ b/cli/src/index.tsx
@@ -6,7 +6,7 @@ import React from "react";
 import updateNotifier from "update-notifier";
 
 import pkg from "../package.json" with { type: "json" };
-import App from "./ui/App.js"; 
+import App from "./ui/App.js";
 
 updateNotifier({
   pkg,
@@ -56,16 +56,19 @@ const cli = meow({
     conversationId: {
       type: "string",
       shortFlag: "c",
-      description: "Conversation ID (use with --agent and --message, or with --messageId)",
+      description:
+        "Conversation ID (use with --agent and --message, or with --messageId)",
     },
     messageId: {
       type: "string",
-      description: "Display details of a specific message (requires --conversationId)",
+      description:
+        "Display details of a specific message (requires --conversationId)",
     },
     details: {
       type: "boolean",
       shortFlag: "d",
-      description: "Show detailed message information (requires --agent and --message)",
+      description:
+        "Show detailed message information (requires --agent and --message)",
     },
   },
 });

--- a/cli/src/index.tsx
+++ b/cli/src/index.tsx
@@ -56,11 +56,11 @@ const cli = meow({
     conversationId: {
       type: "string",
       shortFlag: "c",
-      description: "Send message to an existing conversation (requires --agent and --message)",
+      description: "Conversation ID (use with --agent and --message, or with --messageId)",
     },
     messageId: {
       type: "string",
-      description: "Display details of a specific message (exclusive with -a, -m, -c)",
+      description: "Display details of a specific message (requires --conversationId)",
     },
     details: {
       type: "boolean",

--- a/cli/src/index.tsx
+++ b/cli/src/index.tsx
@@ -58,6 +58,15 @@ const cli = meow({
       shortFlag: "c",
       description: "Send message to an existing conversation (requires --agent and --message)",
     },
+    messageId: {
+      type: "string",
+      description: "Display details of a specific message (exclusive with -a, -m, -c)",
+    },
+    details: {
+      type: "boolean",
+      shortFlag: "d",
+      description: "Show detailed message information (requires --agent and --message)",
+    },
   },
 });
 

--- a/cli/src/ui/App.tsx
+++ b/cli/src/ui/App.tsx
@@ -93,7 +93,13 @@ const App: FC<AppProps> = ({ cli }) => {
         );
       }
       // Interactive chat
-      return <Chat sId={flags.sId?.[0]} agentSearch={flags.agent} conversationId={flags.conversationId} />;
+      return (
+        <Chat
+          sId={flags.sId?.[0]}
+          agentSearch={flags.agent}
+          conversationId={flags.conversationId}
+        />
+      );
     case "cache:clear":
       return <Cache />;
     case "help":

--- a/cli/src/ui/App.tsx
+++ b/cli/src/ui/App.tsx
@@ -7,8 +7,8 @@ import AgentsMCP from "./commands/AgentsMCP.js";
 import Auth from "./commands/Auth.js";
 import Cache from "./commands/Cache.js";
 import Chat from "./commands/Chat.js";
-import NonInteractiveChat from "./commands/NonInteractiveChat.js";
 import Logout from "./commands/Logout.js";
+import NonInteractiveChat from "./commands/NonInteractiveChat.js";
 import Status from "./commands/Status.js";
 import Help from "./Help.js";
 

--- a/cli/src/ui/App.tsx
+++ b/cli/src/ui/App.tsx
@@ -46,6 +46,13 @@ interface AppProps {
       type: "string";
       shortFlag: "c";
     };
+    messageId: {
+      type: "string";
+    };
+    details: {
+      type: "boolean";
+      shortFlag: "d";
+    };
   }>;
 }
 
@@ -72,7 +79,7 @@ const App: FC<AppProps> = ({ cli }) => {
     case "agents-mcp":
       return <AgentsMCP port={flags.port} sId={flags.sId} />;
     case "chat":
-      return <Chat sId={flags.sId?.[0]} agentSearch={flags.agent} message={flags.message} conversationId={flags.conversationId} />;
+      return <Chat sId={flags.sId?.[0]} agentSearch={flags.agent} message={flags.message} conversationId={flags.conversationId} messageId={flags.messageId} details={flags.details} />;
     case "cache:clear":
       return <Cache />;
     case "help":

--- a/cli/src/ui/App.tsx
+++ b/cli/src/ui/App.tsx
@@ -7,6 +7,7 @@ import AgentsMCP from "./commands/AgentsMCP.js";
 import Auth from "./commands/Auth.js";
 import Cache from "./commands/Cache.js";
 import Chat from "./commands/Chat.js";
+import NonInteractiveChat from "./commands/NonInteractiveChat.js";
 import Logout from "./commands/Logout.js";
 import Status from "./commands/Status.js";
 import Help from "./Help.js";
@@ -79,7 +80,20 @@ const App: FC<AppProps> = ({ cli }) => {
     case "agents-mcp":
       return <AgentsMCP port={flags.port} sId={flags.sId} />;
     case "chat":
-      return <Chat sId={flags.sId?.[0]} agentSearch={flags.agent} message={flags.message} conversationId={flags.conversationId} messageId={flags.messageId} details={flags.details} />;
+      // Check if this is a non-interactive chat operation
+      if (flags.message || flags.messageId) {
+        return (
+          <NonInteractiveChat
+            agentSearch={flags.agent}
+            message={flags.message}
+            conversationId={flags.conversationId}
+            messageId={flags.messageId}
+            details={flags.details}
+          />
+        );
+      }
+      // Interactive chat
+      return <Chat sId={flags.sId?.[0]} agentSearch={flags.agent} conversationId={flags.conversationId} />;
     case "cache:clear":
       return <Cache />;
     case "help":

--- a/cli/src/ui/Help.tsx
+++ b/cli/src/ui/Help.tsx
@@ -78,22 +78,26 @@ const Help: FC = () => {
       </Box>
       <Box marginLeft={2}>
         <Text>
-          <Text bold>-m, --message</Text> Send a message non-interactively (requires --agent)
+          <Text bold>-m, --message</Text> Send a message non-interactively
+          (requires --agent)
         </Text>
       </Box>
       <Box marginLeft={2}>
         <Text>
-          <Text bold>-c, --conversationId</Text> Conversation ID (use with --agent and --message, or with --messageId)
+          <Text bold>-c, --conversationId</Text> Conversation ID (use with
+          --agent and --message, or with --messageId)
         </Text>
       </Box>
       <Box marginLeft={2}>
         <Text>
-          <Text bold>--messageId</Text> Display details of a specific message (requires --conversationId)
+          <Text bold>--messageId</Text> Display details of a specific message
+          (requires --conversationId)
         </Text>
       </Box>
       <Box marginLeft={2}>
         <Text>
-          <Text bold>-d, --details</Text> Show detailed message information (requires --agent and --message)
+          <Text bold>-d, --details</Text> Show detailed message information
+          (requires --agent and --message)
         </Text>
       </Box>
     </Box>

--- a/cli/src/ui/Help.tsx
+++ b/cli/src/ui/Help.tsx
@@ -83,12 +83,12 @@ const Help: FC = () => {
       </Box>
       <Box marginLeft={2}>
         <Text>
-          <Text bold>-c, --conversationId</Text> Send to existing conversation (requires --agent and --message)
+          <Text bold>-c, --conversationId</Text> Conversation ID (use with --agent and --message, or with --messageId)
         </Text>
       </Box>
       <Box marginLeft={2}>
         <Text>
-          <Text bold>--messageId</Text> Display details of a specific message (exclusive with -a, -m, -c)
+          <Text bold>--messageId</Text> Display details of a specific message (requires --conversationId)
         </Text>
       </Box>
       <Box marginLeft={2}>

--- a/cli/src/ui/Help.tsx
+++ b/cli/src/ui/Help.tsx
@@ -86,6 +86,16 @@ const Help: FC = () => {
           <Text bold>-c, --conversationId</Text> Send to existing conversation (requires --agent and --message)
         </Text>
       </Box>
+      <Box marginLeft={2}>
+        <Text>
+          <Text bold>--messageId</Text> Display details of a specific message (exclusive with -a, -m, -c)
+        </Text>
+      </Box>
+      <Box marginLeft={2}>
+        <Text>
+          <Text bold>-d, --details</Text> Show detailed message information (requires --agent and --message)
+        </Text>
+      </Box>
     </Box>
   );
 };

--- a/cli/src/ui/commands/AgentsMCP.tsx
+++ b/cli/src/ui/commands/AgentsMCP.tsx
@@ -2,7 +2,7 @@ import type { GetAgentConfigurationsResponseType } from "@dust-tt/client";
 import clipboardy from "clipboardy";
 import { Box, Text, useInput } from "ink";
 import Spinner from "ink-spinner";
-import type { FC} from "react";
+import type { FC } from "react";
 import React, { useEffect, useState } from "react";
 
 import { useClearTerminalOnMount } from "../../utils/hooks/use_clear_terminal_on_mount.js";

--- a/cli/src/ui/commands/Chat.tsx
+++ b/cli/src/ui/commands/Chat.tsx
@@ -75,7 +75,7 @@ const CliChat: FC<CliChatProps> = ({
     validateNonInteractiveFlags(message, agentSearch, conversationId, messageId, details);
   }, [message, agentSearch, conversationId, messageId, details]);
   
-  // Handle messageId mode - fetch and display message details
+  // Handle messageId mode - fetch agent message from conversation
   useEffect(() => {
     if (messageId && conversationId) {
       void fetchAgentMessageFromConversation(conversationId, messageId);

--- a/cli/src/ui/commands/Chat.tsx
+++ b/cli/src/ui/commands/Chat.tsx
@@ -299,7 +299,6 @@ const CliChat: FC<CliChatProps> = ({
     ]);
   }, [agentSearch, allAgents, selectedAgent]);
 
-
   const canSubmit =
     me &&
     !meError &&
@@ -536,9 +535,9 @@ const CliChat: FC<CliChatProps> = ({
                     type: "agent_message_content_line",
                     text: line || " ",
                     index,
-                  } satisfies ConversationItem & {
+                  }) satisfies ConversationItem & {
                     type: "agent_message_content_line";
-                  })
+                  }
               )
               .filter((item) => !prevIds.has(item.key))
               .slice(0, isStreaming ? -1 : undefined);
@@ -560,9 +559,9 @@ const CliChat: FC<CliChatProps> = ({
                       type: "agent_message_cot_line",
                       text: line,
                       index,
-                    } satisfies ConversationItem & {
+                    }) satisfies ConversationItem & {
                       type: "agent_message_cot_line";
-                    })
+                    }
                 )
                 .filter((item) => !prevIds.has(item.key))
                 .slice(0, isStreaming && !contentItems.length ? -1 : undefined);
@@ -1059,7 +1058,6 @@ const CliChat: FC<CliChatProps> = ({
       }
     }
   });
-
 
   // Show loading state while searching for agent
   if (agentSearch && agentsIsLoading) {

--- a/cli/src/ui/commands/Logout.tsx
+++ b/cli/src/ui/commands/Logout.tsx
@@ -1,6 +1,6 @@
 import { Box, Text } from "ink";
 import Spinner from "ink-spinner";
-import type { FC} from "react";
+import type { FC } from "react";
 import React, { useEffect, useState } from "react";
 
 import AuthService from "../../utils/authService.js";

--- a/cli/src/ui/commands/NonInteractiveChat.tsx
+++ b/cli/src/ui/commands/NonInteractiveChat.tsx
@@ -26,7 +26,13 @@ const NonInteractiveChat: FC<NonInteractiveChatProps> = ({
 }) => {
   // Validate flags usage
   useEffect(() => {
-    validateNonInteractiveFlags(message, agentSearch, conversationId, messageId, details);
+    validateNonInteractiveFlags(
+      message,
+      agentSearch,
+      conversationId,
+      messageId,
+      details
+    );
   }, [message, agentSearch, conversationId, messageId, details]);
 
   // Handle all non-interactive operations
@@ -47,20 +53,24 @@ const NonInteractiveChat: FC<NonInteractiveChatProps> = ({
         // Get dust client
         const dustClient = await getDustClient();
         if (!dustClient) {
-          console.error(JSON.stringify({
-            error: "Authentication required",
-            details: "Run `dust login` first"
-          }));
+          console.error(
+            JSON.stringify({
+              error: "Authentication required",
+              details: "Run `dust login` first",
+            })
+          );
           process.exit(1);
         }
 
         // Get current user info
         const meRes = await dustClient.me();
         if (meRes.isErr()) {
-          console.error(JSON.stringify({
-            error: "Authentication error",
-            details: meRes.error.message
-          }));
+          console.error(
+            JSON.stringify({
+              error: "Authentication error",
+              details: meRes.error.message,
+            })
+          );
           process.exit(1);
         }
         const me = meRes.value;
@@ -68,19 +78,23 @@ const NonInteractiveChat: FC<NonInteractiveChatProps> = ({
         // Get all agents
         const agentsRes = await dustClient.getAgentConfigurations({});
         if (agentsRes.isErr()) {
-          console.error(JSON.stringify({
-            error: "Failed to load agents",
-            details: agentsRes.error.message
-          }));
+          console.error(
+            JSON.stringify({
+              error: "Failed to load agents",
+              details: agentsRes.error.message,
+            })
+          );
           process.exit(1);
         }
 
         const allAgents = agentsRes.value;
         if (!allAgents || allAgents.length === 0) {
-          console.error(JSON.stringify({
-            error: "No agents available",
-            details: "No agents found for the current user"
-          }));
+          console.error(
+            JSON.stringify({
+              error: "No agents available",
+              details: "No agents found for the current user",
+            })
+          );
           process.exit(1);
         }
 
@@ -91,30 +105,42 @@ const NonInteractiveChat: FC<NonInteractiveChatProps> = ({
         );
 
         if (matchingAgents.length === 0) {
-          console.error(JSON.stringify({
-            error: "Agent not found",
-            details: `No agent found matching "${agentSearch}"`
-          }));
+          console.error(
+            JSON.stringify({
+              error: "Agent not found",
+              details: `No agent found matching "${agentSearch}"`,
+            })
+          );
           process.exit(1);
         }
 
         if (matchingAgents.length > 1) {
-          console.error(JSON.stringify({
-            error: "Multiple agents found",
-            details: `Multiple agents match "${agentSearch}": ${matchingAgents.map(a => a.name).join(", ")}`
-          }));
+          console.error(
+            JSON.stringify({
+              error: "Multiple agents found",
+              details: `Multiple agents match "${agentSearch}": ${matchingAgents.map((a) => a.name).join(", ")}`,
+            })
+          );
           process.exit(1);
         }
 
         const selectedAgent = matchingAgents[0];
 
         // Call the standalone function
-        await sendNonInteractiveMessage(message, selectedAgent, me, conversationId, details);
+        await sendNonInteractiveMessage(
+          message,
+          selectedAgent,
+          me,
+          conversationId,
+          details
+        );
       } catch (error) {
-        console.error(JSON.stringify({
-          error: "Unexpected error",
-          details: normalizeError(error).message
-        }));
+        console.error(
+          JSON.stringify({
+            error: "Unexpected error",
+            details: normalizeError(error).message,
+          })
+        );
         process.exit(1);
       }
     }
@@ -127,3 +153,4 @@ const NonInteractiveChat: FC<NonInteractiveChatProps> = ({
 };
 
 export default NonInteractiveChat;
+

--- a/cli/src/ui/commands/NonInteractiveChat.tsx
+++ b/cli/src/ui/commands/NonInteractiveChat.tsx
@@ -1,13 +1,13 @@
 import type { FC } from "react";
-import React, { useEffect } from "react";
+import { useEffect } from "react";
 
+import { useAgents } from "../../utils/hooks/use_agents.js";
+import { useMe } from "../../utils/hooks/use_me.js";
 import {
   fetchAgentMessageFromConversation,
   sendNonInteractiveMessage,
   validateNonInteractiveFlags,
 } from "./chat/nonInteractive.js";
-import { useAgents } from "../../utils/hooks/use_agents.js";
-import { useMe } from "../../utils/hooks/use_me.js";
 
 interface NonInteractiveChatProps {
   agentSearch?: string;

--- a/cli/src/ui/commands/NonInteractiveChat.tsx
+++ b/cli/src/ui/commands/NonInteractiveChat.tsx
@@ -1,0 +1,116 @@
+import type { FC } from "react";
+import React, { useEffect } from "react";
+
+import {
+  fetchAgentMessageFromConversation,
+  sendNonInteractiveMessage,
+  validateNonInteractiveFlags,
+} from "./chat/nonInteractive.js";
+import { useAgents } from "../../utils/hooks/use_agents.js";
+import { useMe } from "../../utils/hooks/use_me.js";
+
+interface NonInteractiveChatProps {
+  agentSearch?: string;
+  message?: string;
+  conversationId?: string;
+  messageId?: string;
+  details?: boolean;
+}
+
+const NonInteractiveChat: FC<NonInteractiveChatProps> = ({
+  agentSearch,
+  message,
+  conversationId,
+  messageId,
+  details,
+}) => {
+  const { me, isLoading: isMeLoading, error: meError } = useMe();
+  const { allAgents, error: agentsError, isLoading: agentsIsLoading } = useAgents();
+
+  // Validate flags usage
+  useEffect(() => {
+    validateNonInteractiveFlags(message, agentSearch, conversationId, messageId, details);
+  }, [message, agentSearch, conversationId, messageId, details]);
+
+  // Handle messageId mode - fetch agent message from conversation
+  useEffect(() => {
+    if (messageId && conversationId) {
+      void fetchAgentMessageFromConversation(conversationId, messageId);
+    }
+  }, [messageId, conversationId]);
+
+  // Handle agent search and message sending
+  useEffect(() => {
+    if (!message || !agentSearch) {
+      return;
+    }
+
+    // Wait for authentication to load
+    if (isMeLoading) {
+      return;
+    }
+
+    // Check for authentication errors
+    if (!me || meError) {
+      console.error(JSON.stringify({
+        error: "Authentication error",
+        details: meError || "Not authenticated"
+      }));
+      process.exit(1);
+    }
+
+    // Wait for agents to load
+    if (agentsIsLoading) {
+      return;
+    }
+
+    // Check for agents loading error
+    if (agentsError) {
+      console.error(JSON.stringify({
+        error: "Failed to load agents",
+        details: agentsError
+      }));
+      process.exit(1);
+    }
+
+    if (!allAgents || allAgents.length === 0) {
+      console.error(JSON.stringify({
+        error: "No agents available",
+        details: "No agents found for the current user"
+      }));
+      process.exit(1);
+    }
+
+    // Search for agents matching the search string (case-insensitive)
+    const searchLower = agentSearch.toLowerCase();
+    const matchingAgents = allAgents.filter((agent) =>
+      agent.name.toLowerCase().startsWith(searchLower)
+    );
+
+    if (matchingAgents.length === 0) {
+      console.error(JSON.stringify({
+        error: "Agent not found",
+        details: `No agent found matching "${agentSearch}"`
+      }));
+      process.exit(1);
+    }
+
+    if (matchingAgents.length > 1) {
+      console.error(JSON.stringify({
+        error: "Multiple agents found",
+        details: `Multiple agents match "${agentSearch}": ${matchingAgents.map(a => a.name).join(", ")}`
+      }));
+      process.exit(1);
+    }
+
+    const selectedAgent = matchingAgents[0];
+
+    // Call the standalone function
+    void sendNonInteractiveMessage(message, selectedAgent, me, conversationId, details);
+  }, [message, agentSearch, me, meError, isMeLoading, conversationId, details, allAgents, agentsError, agentsIsLoading]);
+
+  // Don't render anything - all output is handled via console.log/console.error
+  return null;
+};
+
+export default NonInteractiveChat;

--- a/cli/src/ui/commands/Status.tsx
+++ b/cli/src/ui/commands/Status.tsx
@@ -1,7 +1,7 @@
 import type { MeResponseType, WorkspaceType } from "@dust-tt/client";
 import { Box, Text } from "ink";
 import Spinner from "ink-spinner";
-import type { FC} from "react";
+import type { FC } from "react";
 import React, { useEffect, useState } from "react";
 
 import AuthService from "../../utils/authService.js";

--- a/cli/src/ui/commands/chat/nonInteractive.ts
+++ b/cli/src/ui/commands/chat/nonInteractive.ts
@@ -288,7 +288,9 @@ export async function fetchAgentMessageFromConversation(
           break;
         }
       }
-      if (agentMessage) break;
+      if (agentMessage) {
+        break;
+      }
     }
 
     if (!agentMessage) {

--- a/cli/src/ui/components/AgentSelector.tsx
+++ b/cli/src/ui/components/AgentSelector.tsx
@@ -1,11 +1,11 @@
 import type { GetAgentConfigurationsResponseType } from "@dust-tt/client";
 import { Box, Text, useStdout } from "ink";
 import Spinner from "ink-spinner";
-import type { FC, ReactNode} from "react";
+import type { FC, ReactNode } from "react";
 import React, { useCallback, useEffect } from "react";
 
 import { useAgents } from "../../utils/hooks/use_agents.js";
-import type { BaseItem} from "./SelectWithSearch.js";
+import type { BaseItem } from "./SelectWithSearch.js";
 import { SelectWithSearch } from "./SelectWithSearch.js";
 
 type AgentConfiguration =

--- a/cli/src/ui/components/WorkspaceSelector.tsx
+++ b/cli/src/ui/components/WorkspaceSelector.tsx
@@ -2,8 +2,8 @@ import type { WorkspaceType } from "@dust-tt/client";
 import { Box, Text } from "ink";
 import SelectInput from "ink-select-input";
 import Spinner from "ink-spinner";
-import type { FC} from "react";
-import React, { useCallback,useEffect, useState } from "react";
+import type { FC } from "react";
+import React, { useCallback, useEffect, useState } from "react";
 
 import { getDustClient } from "../../utils/dustClient.js";
 import TokenStorage from "../../utils/tokenStorage.js";

--- a/cli/src/utils/fileHandling.ts
+++ b/cli/src/utils/fileHandling.ts
@@ -1,5 +1,4 @@
-import type {
-  SupportedFileContentType} from "@dust-tt/client";
+import type { SupportedFileContentType } from "@dust-tt/client";
 import {
   isSupportedFileContentType,
   supportedFileExtensions,

--- a/cli/src/utils/mcpServer.ts
+++ b/cli/src/utils/mcpServer.ts
@@ -260,7 +260,8 @@ export async function startMcpServer(
 
       httpServer.listen(port, () => {
         const address = httpServer.address();
-        const boundPort = typeof address === "string" ? 0 : address?.port ?? 0;
+        const boundPort =
+          typeof address === "string" ? 0 : (address?.port ?? 0);
         resolve(boundPort);
       });
     });

--- a/cli/src/utils/tokenStorage.ts
+++ b/cli/src/utils/tokenStorage.ts
@@ -44,7 +44,9 @@ export const TokenStorage = {
    */
   async hasValidAccessToken(): Promise<boolean> {
     const accessToken = await this.getAccessToken();
-    if (!accessToken) {return false;}
+    if (!accessToken) {
+      return false;
+    }
 
     const decoded = jwtDecode<JWTPayload>(accessToken);
     const currentTime = Math.floor(Date.now() / 1000);


### PR DESCRIPTION
## Description
- Added message sId to JSON response when using --message flag
- Added --messageId flag (exclusive with -a, -m, -c) to display message details  
- Added --details flag (requires -a and -m) to show detailed info during message sending
- Updated flag validation to enforce exclusivity and requirements
- Updated help documentation for new flags

## Risks
Blast radius: CLI non-interactive mode only
Risk: low

## Tests
- [x] Test --message flag returns messageId in JSON
- [x] Test --details flag shows event details
- [x] Test --messageId flag shows not implemented error
- [x] Test flag validation (exclusivity and requirements)

## Deploy Plan
- Deploy CLI (no migrations needed)