### PR TITLE
Fix Slack Bot reconnect flow

### DIFF
--- a/front/components/data_source/ConnectorPermissionsModal.tsx
+++ b/front/components/data_source/ConnectorPermissionsModal.tsx
@@ -122,7 +122,7 @@ export async function handleUpdatePermissions(
   if (updateRes.error) {
     sendNotification({
       type: "error",
-      title: "Failed to update the permissions",
+      title: "Failed to update the connection",
       description: updateRes.error,
     });
   } else {
@@ -134,9 +134,9 @@ export async function handleUpdatePermissions(
   }
 }
 
-async function updateConnectorConnectionId(
+export async function updateConnectorConnectionId(
   newConnectionId: string,
-  provider: string,
+  provider: ConnectorProvider,
   dataSource: DataSourceType,
   owner: LightWorkspaceType
 ) {
@@ -163,8 +163,7 @@ async function updateConnectorConnectionId(
   if (error.type === "connector_oauth_target_mismatch") {
     return {
       success: false,
-      error:
-        CONNECTOR_CONFIGURATIONS[provider as ConnectorProvider].mismatchError,
+      error: CONNECTOR_CONFIGURATIONS[provider].mismatchError,
     };
   }
   if (error.type === "connector_oauth_user_missing_rights") {

--- a/front/components/spaces/AddConnectionMenu.tsx
+++ b/front/components/spaces/AddConnectionMenu.tsx
@@ -35,6 +35,7 @@ import type {
   ConnectorType,
   DataSourceType,
   LightWorkspaceType,
+  OAuthUseCase,
   PlanType,
   Result,
   SpaceType,
@@ -64,10 +65,12 @@ type AddConnectionMenuProps = {
 export async function setupConnection({
   owner,
   provider,
+  useCase = "connection",
   extraConfig,
 }: {
   owner: LightWorkspaceType;
   provider: ConnectorProvider;
+  useCase?: OAuthUseCase;
   extraConfig: Record<string, string>;
 }): Promise<Result<string, Error>> {
   let connectionId: string;
@@ -78,7 +81,7 @@ export async function setupConnection({
       dustClientFacingUrl: `${process.env.NEXT_PUBLIC_DUST_CLIENT_FACING_URL}`,
       owner,
       provider,
-      useCase: "connection",
+      useCase,
       extraConfig,
     });
     if (!cRes.isOk()) {

--- a/front/lib/swr/connectors.ts
+++ b/front/lib/swr/connectors.ts
@@ -112,13 +112,13 @@ export function useConnectorConfig({
 }
 
 export function useConnector({
+  workspaceId,
   dataSource,
   disabled,
-  workspaceId,
 }: {
+  workspaceId: string;
   dataSource: DataSourceType;
   disabled?: boolean;
-  workspaceId: string;
 }) {
   const configFetcher: Fetcher<GetConnectorResponseBody> = fetcher;
 

--- a/front/pages/w/[wId]/workspace/index.tsx
+++ b/front/pages/w/[wId]/workspace/index.tsx
@@ -20,8 +20,8 @@ import {
 import type { InferGetServerSidePropsType } from "next";
 import { useCallback, useEffect, useState } from "react";
 
+import { updateConnectorConnectionId } from "@app/components/data_source/ConnectorPermissionsModal";
 import { subNavigationAdmin } from "@app/components/navigation/config";
-import { setupConnection } from "@app/components/spaces/AddConnectionMenu";
 import AppContentLayout from "@app/components/sparkle/AppContentLayout";
 import AppRootLayout from "@app/components/sparkle/AppRootLayout";
 import { ProviderManagementModal } from "@app/components/workspace/ProviderManagementModal";
@@ -318,30 +318,47 @@ function SlackBotToggle({
         hasSeparatorIfLast={true}
         action={
           <div className="flex flex-row items-center gap-2">
-            {isSlackBotEnabled && (
+            {isSlackBotEnabled && slackBotDataSource && (
               <Button
                 variant="outline"
                 label="Reconnect"
                 size="xs"
                 icon={ArrowPathIcon}
                 onClick={async () => {
-                  const connectionIdRes = await setupConnection({
+                  const cRes = await setupOAuthConnection({
+                    dustClientFacingUrl: `${process.env.NEXT_PUBLIC_DUST_CLIENT_FACING_URL}`,
                     owner,
-                    provider: "slack_bot",
+                    provider: "slack",
+                    useCase: "bot",
                     extraConfig: {},
                   });
-                  if (connectionIdRes.isErr()) {
+                  if (!cRes.isOk()) {
                     sendNotification({
                       type: "error",
                       title: "Failed to reconnect Slack Bot.",
                       description: "Could not reconnect the Dust Slack Bot.",
                     });
                   } else {
-                    sendNotification({
-                      type: "success",
-                      title: "Slack Bot reconnected.",
-                      description: "The Dust Slack Bot has been reconnected.",
-                    });
+                    const updateRes = await updateConnectorConnectionId(
+                      cRes.value.connection_id,
+                      "slack_bot",
+                      slackBotDataSource,
+                      owner
+                    );
+
+                    if (updateRes.error) {
+                      sendNotification({
+                        type: "error",
+                        title: "Failed to update the Slack Bot connection",
+                        description: updateRes.error,
+                      });
+                    } else {
+                      sendNotification({
+                        type: "success",
+                        title: "Successfully updated Slack Bot connection",
+                        description: "The connection was successfully updated.",
+                      });
+                    }
                   }
                 }}
               />

--- a/front/pages/w/[wId]/workspace/index.tsx
+++ b/front/pages/w/[wId]/workspace/index.tsx
@@ -22,6 +22,7 @@ import { useCallback, useEffect, useState } from "react";
 
 import { updateConnectorConnectionId } from "@app/components/data_source/ConnectorPermissionsModal";
 import { subNavigationAdmin } from "@app/components/navigation/config";
+import { setupConnection } from "@app/components/spaces/AddConnectionMenu";
 import AppContentLayout from "@app/components/sparkle/AppContentLayout";
 import AppRootLayout from "@app/components/sparkle/AppRootLayout";
 import { ProviderManagementModal } from "@app/components/workspace/ProviderManagementModal";
@@ -39,7 +40,6 @@ import type {
   SubscriptionType,
   WorkspaceType,
 } from "@app/types";
-import { setupOAuthConnection } from "@app/types";
 
 export const getServerSideProps = withDefaultUserAuthRequirements<{
   owner: WorkspaceType;
@@ -249,8 +249,7 @@ function SlackBotToggle({
   const createSlackBotConnectionAndDataSource = async () => {
     try {
       // OAuth flow
-      const cRes = await setupOAuthConnection({
-        dustClientFacingUrl: `${process.env.NEXT_PUBLIC_DUST_CLIENT_FACING_URL}`,
+      const cRes = await setupConnection({
         owner,
         provider: "slack",
         useCase: "bot",
@@ -269,7 +268,7 @@ function SlackBotToggle({
           },
           body: JSON.stringify({
             provider: "slack_bot",
-            connectionId: cRes.value.connection_id,
+            connectionId: cRes.value,
             name: undefined,
             configuration: null,
           } satisfies PostDataSourceRequestBody),
@@ -325,8 +324,7 @@ function SlackBotToggle({
                 size="xs"
                 icon={ArrowPathIcon}
                 onClick={async () => {
-                  const cRes = await setupOAuthConnection({
-                    dustClientFacingUrl: `${process.env.NEXT_PUBLIC_DUST_CLIENT_FACING_URL}`,
+                  const cRes = await setupConnection({
                     owner,
                     provider: "slack",
                     useCase: "bot",
@@ -340,7 +338,7 @@ function SlackBotToggle({
                     });
                   } else {
                     const updateRes = await updateConnectorConnectionId(
-                      cRes.value.connection_id,
+                      cRes.value,
                       "slack_bot",
                       slackBotDataSource,
                       owner


### PR DESCRIPTION
## Description

The reconnect flow was broken as it failed to update the underlying `slack_bot` connector's connectionId. This PR fixes that flow.

Fixes: https://github.com/dust-tt/tasks/issues/3345

## Tests

Tested locally

## Risk

Low

## Deploy Plan

- deploy `front`