### PR TITLE
[front] fail liveness check after the prestop has been called

### DIFF
--- a/front/pages/api/[preStopSecret]/prestop.ts
+++ b/front/pages/api/[preStopSecret]/prestop.ts
@@ -28,7 +28,7 @@ async function handler(
   logger.info("Received prestop request, setting shutdown state in Redis");
 
   await runOnRedis({ origin: "lock" }, async (redis) => {
-    await redis.setEx(PRESTOP_SHUTDOWN_KEY, 60, "true");
+    await redis.set(PRESTOP_SHUTDOWN_KEY, "true");
   });
 
   logger.info("Prestop state set, waiting 10s");

--- a/front/pages/api/[preStopSecret]/prestop.ts
+++ b/front/pages/api/[preStopSecret]/prestop.ts
@@ -27,7 +27,6 @@ async function handler(
 
   logger.info("Received prestop request, setting shutdown state in Redis");
 
-  // Set prestop state in Redis with 60 second TTL
   await runOnRedis({ origin: "lock" }, async (redis) => {
     await redis.setEx(PRESTOP_SHUTDOWN_KEY, 60, "true");
   });

--- a/front/pages/api/[preStopSecret]/prestop.ts
+++ b/front/pages/api/[preStopSecret]/prestop.ts
@@ -24,14 +24,11 @@ async function handler(
   }
 
   logger.info("Received prestop request, setting shutdown state in Redis");
-  
+
   // Set prestop state in Redis with 60 second TTL
-  await runOnRedis(
-    { origin: "lock" },
-    async (redis) => {
-      await redis.setEx("prestop:shutdown", 60, "true");
-    }
-  );
+  await runOnRedis({ origin: "lock" }, async (redis) => {
+    await redis.setEx("prestop:shutdown", 60, "true");
+  });
 
   logger.info("Prestop state set, waiting 10s");
   await new Promise((resolve) => setTimeout(resolve, 10000));

--- a/front/pages/api/[preStopSecret]/prestop.ts
+++ b/front/pages/api/[preStopSecret]/prestop.ts
@@ -5,6 +5,8 @@ import { wakeLockIsFree } from "@app/lib/wake_lock";
 import logger from "@app/logger/logger";
 import { withLogging } from "@app/logger/withlogging";
 
+export const PRESTOP_SHUTDOWN_KEY = "prestop:shutdown";
+
 async function handler(
   req: NextApiRequest,
   res: NextApiResponse
@@ -27,7 +29,7 @@ async function handler(
 
   // Set prestop state in Redis with 60 second TTL
   await runOnRedis({ origin: "lock" }, async (redis) => {
-    await redis.setEx("prestop:shutdown", 60, "true");
+    await redis.setEx(PRESTOP_SHUTDOWN_KEY, 60, "true");
   });
 
   logger.info("Prestop state set, waiting 10s");

--- a/front/pages/api/healthz.ts
+++ b/front/pages/api/healthz.ts
@@ -2,6 +2,7 @@ import { StatsD } from "hot-shots";
 import type { NextApiRequest, NextApiResponse } from "next";
 
 import { runOnRedis } from "@app/lib/api/redis";
+import { PRESTOP_SHUTDOWN_KEY } from "@app/pages/api/[preStopSecret]/prestop";
 
 export const statsDClient = new StatsD();
 
@@ -13,7 +14,7 @@ export default async function handler(
 
   // Check if prestop has been called
   const isShuttingDown = await runOnRedis({ origin: "lock" }, async (redis) => {
-    const prestopState = await redis.get("prestop:shutdown");
+    const prestopState = await redis.get(PRESTOP_SHUTDOWN_KEY);
     return prestopState === "true";
   });
 

--- a/front/pages/api/healthz.ts
+++ b/front/pages/api/healthz.ts
@@ -12,13 +12,10 @@ export default async function handler(
   const start = performance.now();
 
   // Check if prestop has been called
-  const isShuttingDown = await runOnRedis(
-    { origin: "lock" },
-    async (redis) => {
-      const prestopState = await redis.get("prestop:shutdown");
-      return prestopState === "true";
-    }
-  );
+  const isShuttingDown = await runOnRedis({ origin: "lock" }, async (redis) => {
+    const prestopState = await redis.get("prestop:shutdown");
+    return prestopState === "true";
+  });
 
   if (isShuttingDown) {
     res.status(503).send("shutting down");


### PR DESCRIPTION
## Description

We have observed that during a deployment, the `front-internal` pods that will be eviceted still receive some traffic after having called the prestop. (notebook [here](https://app.datadoghq.eu/notebook/230990/econnrefused-connectors-front-internal?range=14400000&start=1751358220289&live=true)).
This PR adds an interaction between the prestop and the `/healthz` endpoint through a state stored on Redis.
The prestop sets this state and the endpoint reads it to return a 503 if we've called the prestop.

## Tests

## Risk

## Deploy Plan

- Deploy front.
