### PR TITLE
Bump Axum from 0.7.4 to 0.8.4

### DIFF
--- a/core/Cargo.lock
+++ b/core/Cargo.lock
@@ -363,8 +363,35 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "edca88bc138befd0323b20752846e6587272d3b03b0343c8ea28a6f819e6e71f"
 dependencies = [
  "async-trait",
- "axum-core",
+ "axum-core 0.4.5",
  "bytes",
+ "futures-util",
+ "http 1.3.1",
+ "http-body 1.0.1",
+ "http-body-util",
+ "itoa",
+ "matchit 0.7.3",
+ "memchr",
+ "mime",
+ "percent-encoding",
+ "pin-project-lite",
+ "rustversion",
+ "serde",
+ "sync_wrapper 1.0.2",
+ "tower 0.5.2",
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
+name = "axum"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "021e862c184ae977658b36c4500f7feac3221ca5da43e3f25bd04ab6c79a29b5"
+dependencies = [
+ "axum-core 0.5.2",
+ "bytes",
+ "form_urlencoded",
  "futures-util",
  "http 1.3.1",
  "http-body 1.0.1",
@@ -372,7 +399,7 @@ dependencies = [
  "hyper 1.6.0",
  "hyper-util",
  "itoa",
- "matchit",
+ "matchit 0.8.4",
  "memchr",
  "mime",
  "percent-encoding",
@@ -408,19 +435,38 @@ dependencies = [
  "sync_wrapper 1.0.2",
  "tower-layer",
  "tower-service",
+]
+
+[[package]]
+name = "axum-core"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68464cd0412f486726fb3373129ef5d2993f90c34bc2bc1c1e9943b2f4fc7ca6"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "http 1.3.1",
+ "http-body 1.0.1",
+ "http-body-util",
+ "mime",
+ "pin-project-lite",
+ "rustversion",
+ "sync_wrapper 1.0.2",
+ "tower-layer",
+ "tower-service",
  "tracing",
 ]
 
 [[package]]
 name = "axum-test"
-version = "16.4.1"
+version = "17.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "63e3a443d2608936a02a222da7b746eb412fede7225b3030b64fe9be99eab8dc"
+checksum = "0eb1dfb84bd48bad8e4aa1acb82ed24c2bb5e855b659959b4e03b4dca118fcac"
 dependencies = [
  "anyhow",
  "assert-json-diff",
  "auto-future",
- "axum",
+ "axum 0.8.4",
  "bytes",
  "bytesize",
  "cookie",
@@ -686,9 +732,9 @@ checksum = "d71b6127be86fdcfddb610f7182ac57211d4b18a3e9c82eb2d17662f2227ad6a"
 
 [[package]]
 name = "bytesize"
-version = "1.3.3"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e93abca9e28e0a1b9877922aacb20576e05d4679ffa78c3d6dc22a26a216659"
+checksum = "a3c8f83209414aacf0eeae3cf730b18d6981697fba62f200fcfb92b9f082acba"
 
 [[package]]
 name = "cbc"
@@ -1291,7 +1337,7 @@ dependencies = [
  "async-std",
  "async-stream",
  "async-trait",
- "axum",
+ "axum 0.8.4",
  "axum-test",
  "base64 0.22.1",
  "bb8",
@@ -2580,6 +2626,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0e7465ac9959cc2b1404e8e2367b43684a6d13790fe23056cc8c6c5a6b7bcb94"
 
 [[package]]
+name = "matchit"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47e1ffaa40ddd1f3ed91f717a33c8c0ee23fff369e3aa8772b9605cc1d22f4c3"
+
+[[package]]
 name = "md-5"
 version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3816,18 +3868,17 @@ dependencies = [
 
 [[package]]
 name = "rust-multipart-rfc7578_2"
-version = "0.6.1"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03b748410c0afdef2ebbe3685a6a862e2ee937127cdaae623336a459451c8d57"
+checksum = "c839d037155ebc06a571e305af66ff9fd9063a6e662447051737e1ac75beea41"
 dependencies = [
  "bytes",
  "futures-core",
  "futures-util",
- "http 0.2.12",
+ "http 1.3.1",
  "mime",
- "mime_guess",
- "rand 0.8.5",
- "thiserror 1.0.69",
+ "rand 0.9.1",
+ "thiserror 2.0.12",
 ]
 
 [[package]]
@@ -4894,7 +4945,7 @@ checksum = "877c5b330756d856ffcc4553ab34a5684481ade925ecc54bcd1bf02b1d0d4d52"
 dependencies = [
  "async-stream",
  "async-trait",
- "axum",
+ "axum 0.7.9",
  "base64 0.22.1",
  "bytes",
  "flate2",

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -110,7 +110,7 @@ regex = "1.10"
 rand = "0.8"
 uuid = { version = "1.8", features = ["v4"] }
 parking_lot = "0.12"
-axum = "0.7.4"
+axum = "0.8.4"
 rusqlite = { version = "0.31", features = ["bundled"] }
 tokio-postgres = { version = "0.7", features = ["with-serde_json-1"] }
 bb8 = "0.8"
@@ -145,7 +145,7 @@ ring = "0.17.14"
 jsonwebtoken = "9.3.0"
 rslock = { version = "0.4.0", default-features = false, features = ["tokio-comp"] }
 gcp-bigquery-client = "0.25.1"
-axum-test = "16.0.0"
+axum-test = "17.3.0"
 csv-async = "1.3.0"
 csv = "1.3.0"
 tikv-jemallocator = "0.6"

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -91,72 +91,72 @@ path = "src/oauth/tests/functional_credentials.rs"
 
 [dependencies]
 anyhow = "1.0"
-serde = { version = "1.0", features = ["rc", "derive"] }
-serde_json = "1.0"
-pest = "2.7"
-pest_derive = "2.7"
-shellexpand = "2.1"
-blake3 = "1.3"
-async-trait = "0.1"
-tokio = { version = "1.38", features = ["full"] }
-tokio-stream = "0.1"
-tokio-util = { version = "0.7", features = ["compat"] }
-hyper = { version = "1.3.1", features = ["full"] }
-itertools = "0.10"
-futures = "0.3"
+async-recursion = "1.1"
 async-std = "1.12"
-lazy_static = "1.4"
-regex = "1.10"
-rand = "0.8"
-uuid = { version = "1.8", features = ["v4"] }
-parking_lot = "0.12"
+async-stream = "0.3"
+async-trait = "0.1"
 axum = "0.8.4"
-rusqlite = { version = "0.31", features = ["bundled"] }
-tokio-postgres = { version = "0.7", features = ["with-serde_json-1"] }
+axum-test = "17.3.0"
+base64 = "0.22"
 bb8 = "0.8"
 bb8-postgres = "0.8"
-urlencoding = "2.1"
-url = "2.5"
-dns-lookup = "1.0"
-async-stream = "0.3"
-eventsource-client = { git = "https://github.com/dust-tt/rust-eventsource-client", rev = "148050f8fb9f8abb25ca171aa68ea817277ca4f6" }
-tera = "1.20"
-fancy-regex = "0.13"
-rustc-hash = "1.1"
+blake3 = "1.3"
 bstr = "1.9"
-base64 = "0.22"
-cloud-storage = { version = "0.11", features = ["global-client"] }
-qdrant-client = "1.11"
-tower-http = {version = "0.5", features = ["full"]}
-tracing = "0.1"
-tracing-subscriber = { version = "0.3", features = ["env-filter", "json"] }
-deno_core = "0.292"
-rayon = "1.10"
-clap = { version = "4.5", features = ["derive"] }
-async-recursion = "1.1"
 chrono = "0.4"
-thiserror = "1.0.57"
-sentencepiece = { version = "0.11", features = ["static"] }
-reqwest = { version = "0.12", features = ["json"] }
-tracing-bunyan-formatter = "0.3.9"
-http = "1.1.0"
-sqids = "0.4.1"
-ring = "0.17.14"
-jsonwebtoken = "9.3.0"
-rslock = { version = "0.4.0", default-features = false, features = ["tokio-comp"] }
-gcp-bigquery-client = "0.25.1"
-axum-test = "17.3.0"
-csv-async = "1.3.0"
+clap = { version = "4.5", features = ["derive"] }
+cloud-storage = { version = "0.11", features = ["global-client"] }
 csv = "1.3.0"
-tikv-jemallocator = "0.6"
+csv-async = "1.3.0"
+dateparser = "0.2.1"
+deno_core = "0.292"
+dns-lookup = "1.0"
 elasticsearch = "8.15.0-alpha.1"
 elasticsearch-dsl = "0.4"
-unicode-normalization = "0.1.24"
-dateparser = "0.2.1"
-once_cell = "1.18"
-redis = { version = "0.24.0", features = ["tokio-comp"] }
-humantime = "2.2.0"
+eventsource-client = { git = "https://github.com/dust-tt/rust-eventsource-client", rev = "148050f8fb9f8abb25ca171aa68ea817277ca4f6" }
+fancy-regex = "0.13"
 flate2 = "1.0"
-rsa = { version = "0.9.4", features = ["pem"] }
+futures = "0.3"
+gcp-bigquery-client = "0.25.1"
+http = "1.1.0"
+humantime = "2.2.0"
+hyper = { version = "1.3.1", features = ["full"] }
+itertools = "0.10"
+jsonwebtoken = "9.3.0"
+lazy_static = "1.4"
+once_cell = "1.18"
+parking_lot = "0.12"
+pest = "2.7"
+pest_derive = "2.7"
 pkcs8 = { version = "0.10", features = ["pem", "pkcs5", "encryption"] }
+qdrant-client = "1.11"
+rand = "0.8"
+rayon = "1.10"
+redis = { version = "0.24.0", features = ["tokio-comp"] }
+regex = "1.10"
+reqwest = { version = "0.12", features = ["json"] }
+ring = "0.17.14"
+rsa = { version = "0.9.4", features = ["pem"] }
+rslock = { version = "0.4.0", default-features = false, features = ["tokio-comp"] }
+rusqlite = { version = "0.31", features = ["bundled"] }
+rustc-hash = "1.1"
+sentencepiece = { version = "0.11", features = ["static"] }
+serde = { version = "1.0", features = ["rc", "derive"] }
+serde_json = "1.0"
 sha2 = "0.10.8"
+shellexpand = "2.1"
+sqids = "0.4.1"
+tera = "1.20"
+thiserror = "1.0.57"
+tikv-jemallocator = "0.6"
+tokio = { version = "1.38", features = ["full"] }
+tokio-postgres = { version = "0.7", features = ["with-serde_json-1"] }
+tokio-stream = "0.1"
+tokio-util = { version = "0.7", features = ["compat"] }
+tower-http = {version = "0.5", features = ["full"]}
+tracing = "0.1"
+tracing-bunyan-formatter = "0.3.9"
+tracing-subscriber = { version = "0.3", features = ["env-filter", "json"] }
+unicode-normalization = "0.1.24"
+url = "2.5"
+urlencoding = "2.1"
+uuid = { version = "1.8", features = ["v4"] }

--- a/core/bin/core_api.rs
+++ b/core/bin/core_api.rs
@@ -4103,170 +4103,170 @@ fn main() {
         let router = Router::new()
         // Projects
         .route("/projects", post(projects_create))
-        .route("/projects/:project_id", delete(projects_delete))
-        .route("/projects/:project_id/clone", post(projects_clone))
+        .route("/projects/{project_id}", delete(projects_delete))
+        .route("/projects/{project_id}/clone", post(projects_clone))
         // Specifications
         .route(
-            "/projects/:project_id/specifications/check",
+            "/projects/{project_id}/specifications/check",
             post(specifications_check),
         )
         .route(
-            "/projects/:project_id/specifications/:hash",
+            "/projects/{project_id}/specifications/{hash}",
             get(specifications_retrieve),
         )
         .route(
-            "/projects/:project_id/specifications",
+            "/projects/{project_id}/specifications",
             get(specifications_get),
         )
         .route(
-            "/projects/:project_id/specifications",
+            "/projects/{project_id}/specifications",
             post(specifications_post),
         )
 
         // Datasets
-        .route("/projects/:project_id/datasets", post(datasets_register))
-        .route("/projects/:project_id/datasets", get(datasets_list))
+        .route("/projects/{project_id}/datasets", post(datasets_register))
+        .route("/projects/{project_id}/datasets", get(datasets_list))
         .route(
-            "/projects/:project_id/datasets/:dataset_id/:hash",
+            "/projects/{project_id}/datasets/{dataset_id}/{hash}",
             get(datasets_retrieve),
         )
         // Runs
-        .route("/projects/:project_id/runs", post(runs_create))
+        .route("/projects/{project_id}/runs", post(runs_create))
         .route(
-            "/projects/:project_id/runs/stream",
+            "/projects/{project_id}/runs/stream",
             post(runs_create_stream),
         )
-        .route("/projects/:project_id/runs", get(runs_list))
+        .route("/projects/{project_id}/runs", get(runs_list))
         .route(
-            "/projects/:project_id/runs/batch",
+            "/projects/{project_id}/runs/batch",
             post(runs_retrieve_batch),
         )
-        .route("/projects/:project_id/runs/:run_id", get(runs_retrieve))
+        .route("/projects/{project_id}/runs/{run_id}", get(runs_retrieve))
         .route(
-            "/projects/:project_id/runs/:run_id",
+            "/projects/{project_id}/runs/{run_id}",
             delete(runs_delete),
         )
         .route(
-            "/projects/:project_id/runs/:run_id/blocks/:block_type/:block_name",
+            "/projects/{project_id}/runs/{run_id}/blocks/{block_type}/{block_name}",
             get(runs_retrieve_block),
         )
         .route(
-            "/projects/:project_id/runs/:run_id/status",
+            "/projects/{project_id}/runs/{run_id}/status",
             get(runs_retrieve_status),
         )
         // DataSources
         .route(
-            "/projects/:project_id/data_sources",
+            "/projects/{project_id}/data_sources",
             post(data_sources_register),
         )
         .route(
-            "/projects/:project_id/data_sources/:data_source_id",
+            "/projects/{project_id}/data_sources/{data_source_id}",
             patch(data_sources_update),
         )
         .route(
-            "/projects/:project_id/data_sources/:data_source_id",
+            "/projects/{project_id}/data_sources/{data_source_id}",
             get(data_sources_retrieve),
         )
         .route(
-            "/projects/:project_id/data_sources/:data_source_id/tokenize",
+            "/projects/{project_id}/data_sources/{data_source_id}/tokenize",
             post(data_sources_tokenize),
         )
         .route(
-            "/projects/:project_id/data_sources/:data_source_id/documents/:document_id/versions",
+            "/projects/{project_id}/data_sources/{data_source_id}/documents/{document_id}/versions",
             get(data_sources_documents_versions_list),
         )
         .route(
-            "/projects/:project_id/data_sources/:data_source_id/documents",
+            "/projects/{project_id}/data_sources/{data_source_id}/documents",
             post(data_sources_documents_upsert),
         )
         .route(
-            "/projects/:project_id/data_sources/:data_source_id/documents/:document_id/blob",
+            "/projects/{project_id}/data_sources/{data_source_id}/documents/{document_id}/blob",
             get(data_sources_documents_retrieve_blob),
         )
         .route(
-            "/projects/:project_id/data_sources/:data_source_id/documents/:document_id/tags",
+            "/projects/{project_id}/data_sources/{data_source_id}/documents/{document_id}/tags",
             patch(data_sources_documents_update_tags),
         )
         .route(
-            "/projects/:project_id/data_sources/:data_source_id/documents/:document_id/parents",
+            "/projects/{project_id}/data_sources/{data_source_id}/documents/{document_id}/parents",
             patch(data_sources_documents_update_parents),
         )
         // Provided by the data_source block.
         .route(
-            "/projects/:project_id/data_sources/:data_source_id/search",
+            "/projects/{project_id}/data_sources/{data_source_id}/search",
             post(data_sources_search),
         )
         .route(
-            "/projects/:project_id/data_sources/:data_source_id/documents",
+            "/projects/{project_id}/data_sources/{data_source_id}/documents",
             get(data_sources_documents_list),
         )
         .route(
-            "/projects/:project_id/data_sources/:data_source_id/documents/:document_id",
+            "/projects/{project_id}/data_sources/{data_source_id}/documents/{document_id}",
             get(data_sources_documents_retrieve),
         )
         .route(
-            "/projects/:project_id/data_sources/:data_source_id/documents/:document_id/text",
+            "/projects/{project_id}/data_sources/{data_source_id}/documents/{document_id}/text",
             get(data_sources_documents_retrieve_text),
         )
         .route(
-            "/projects/:project_id/data_sources/:data_source_id/documents/:document_id",
+            "/projects/{project_id}/data_sources/{data_source_id}/documents/{document_id}",
             delete(data_sources_documents_delete),
         )
         .route(
-            "/projects/:project_id/data_sources/:data_source_id/documents/:document_id/scrub_deleted_versions",
+            "/projects/{project_id}/data_sources/{data_source_id}/documents/{document_id}/scrub_deleted_versions",
             post(data_sources_documents_scrub_deleted_versions),
         )
         .route(
-            "/projects/:project_id/data_sources/:data_source_id",
+            "/projects/{project_id}/data_sources/{data_source_id}",
             delete(data_sources_delete),
         )
         // Databases
         .route(
-            "/projects/:project_id/data_sources/:data_source_id/tables/validate_csv_content",
+            "/projects/{project_id}/data_sources/{data_source_id}/tables/validate_csv_content",
             post(tables_validate_csv_content),
         )
         .route(
-            "/projects/:project_id/data_sources/:data_source_id/tables",
+            "/projects/{project_id}/data_sources/{data_source_id}/tables",
             post(tables_upsert),
         )
         .route(
-            "/projects/:project_id/data_sources/:data_source_id/tables/:table_id/parents",
+            "/projects/{project_id}/data_sources/{data_source_id}/tables/{table_id}/parents",
             patch(tables_update_parents),
         )
         .route(
-            "/projects/:project_id/data_sources/:data_source_id/tables/:table_id",
+            "/projects/{project_id}/data_sources/{data_source_id}/tables/{table_id}",
             get(tables_retrieve),
         )
         .route(
-            "/projects/:project_id/data_sources/:data_source_id/tables",
+            "/projects/{project_id}/data_sources/{data_source_id}/tables",
             get(tables_list),
         )
         .route(
-            "/projects/:project_id/data_sources/:data_source_id/tables/:table_id",
+            "/projects/{project_id}/data_sources/{data_source_id}/tables/{table_id}",
             delete(tables_delete),
         )
         .route(
-            "/projects/:project_id/data_sources/:data_source_id/tables/:table_id/blob",
+            "/projects/{project_id}/data_sources/{data_source_id}/tables/{table_id}/blob",
             get(tables_retrieve_blob),
         )
         .route(
-            "/projects/:project_id/data_sources/:data_source_id/tables/:table_id/rows",
+            "/projects/{project_id}/data_sources/{data_source_id}/tables/{table_id}/rows",
             post(tables_rows_upsert),
         )
         .route(
-            "/projects/:project_id/data_sources/:data_source_id/tables/:table_id/csv",
+            "/projects/{project_id}/data_sources/{data_source_id}/tables/{table_id}/csv",
             post(tables_csv_upsert),
         )
         .route(
-            "/projects/:project_id/data_sources/:data_source_id/tables/:table_id/rows/:row_id",
+            "/projects/{project_id}/data_sources/{data_source_id}/tables/{table_id}/rows/{row_id}",
             get(tables_rows_retrieve),
         )
         .route(
-            "/projects/:project_id/data_sources/:data_source_id/tables/:table_id/rows/:row_id",
+            "/projects/{project_id}/data_sources/{data_source_id}/tables/{table_id}/rows/{row_id}",
             delete(tables_rows_delete),
         )
         .route(
-            "/projects/:project_id/data_sources/:data_source_id/tables/:table_id/rows",
+            "/projects/{project_id}/data_sources/{data_source_id}/tables/{table_id}/rows",
             get(tables_rows_list),
         )
         .route(
@@ -4281,25 +4281,25 @@ fn main() {
 
         // Folders
         .route(
-            "/projects/:project_id/data_sources/:data_source_id/folders",
+            "/projects/{project_id}/data_sources/{data_source_id}/folders",
             post(folders_upsert),
         )
         .route(
-            "/projects/:project_id/data_sources/:data_source_id/folders/:folder_id",
+            "/projects/{project_id}/data_sources/{data_source_id}/folders/{folder_id}",
             get(folders_retrieve),
         )
         .route(
-            "/projects/:project_id/data_sources/:data_source_id/folders",
+            "/projects/{project_id}/data_sources/{data_source_id}/folders",
             get(folders_list),
         )
         .route(
-            "/projects/:project_id/data_sources/:data_source_id/folders/:folder_id",
+            "/projects/{project_id}/data_sources/{data_source_id}/folders/{folder_id}",
             delete(folders_delete),
         )
 
         //Search
         .route("/nodes/search", post(nodes_search))
-        .route("/projects/:project_id/data_sources/:data_source_id/stats", get(data_sources_stats))
+        .route("/projects/{project_id}/data_sources/{data_source_id}/stats", get(data_sources_stats))
         .route("/tags/search", post(tags_search))
 
         // Misc

--- a/core/src/oauth/app.rs
+++ b/core/src/oauth/app.rs
@@ -431,24 +431,24 @@ pub async fn create_app() -> Result<Router> {
         // Connections
         .route("/connections", post(connections_create))
         .route(
-            "/connections/:connection_id/finalize",
+            "/connections/{connection_id}/finalize",
             post(connections_finalize),
         )
         .route(
-            "/connections/:connection_id/access_token",
+            "/connections/{connection_id}/access_token",
             post(deprecated_connections_access_token),
         )
         .route(
-            "/connections/:connection_id/access_token",
+            "/connections/{connection_id}/access_token",
             get(connections_access_token),
         )
         .route(
-            "/connections/:connection_id/metadata",
+            "/connections/{connection_id}/metadata",
             get(connections_metadata),
         )
         .route("/credentials", post(credentials_create))
-        .route("/credentials/:credential_id", get(credentials_retrieve))
-        .route("/credentials/:credential_id", delete(credentials_delete))
+        .route("/credentials/{credential_id}", get(credentials_retrieve))
+        .route("/credentials/{credential_id}", delete(credentials_delete))
         // Extensions
         .layer(
             TraceLayer::new_for_http()


### PR DESCRIPTION
## Description

Bump Axum from 0.7.4 to 0.8.4 (this PR has been extract from it's original one https://github.com/dust-tt/dust/pull/13454)

## Tests

It's been tested locally on `Oauth` and `Core` apps.

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

👉 We bumped Axium from `0.7.4` to `0.8.4`, which has an impact on all endpoints served by Rust

Looking at the current usage and the breaking changes in Axum 0.8, here are the main risks:

### Major Breaking Changes

**Path Parameter Syntax** [1,2] ✅
- Routes with `/:param` and `/*rest` must be changed to `/{param}` and `/{*rest}`
- This affects **many routes** in your codebase [3] - you have dozens of routes like `/projects/:project_id/data_sources/:data_source_id/documents/:document_id`

**`#[async_trait]` Removal** [1] ✅
- Custom extractors implementing `FromRequest` or `FromRequestParts` need `#[async_trait]` removed
- Our current #[async_trait] usage is unrelated to Axum extractors. The Axum 0.8 change only affects custom extractors implementing Axum's FromRequest/FromRequestParts traits, which you don't have.

**`Option<T>` Extractor Changes** [1] ✅
- `Option<T>` extractors now require `T` to implement `OptionalFromRequestParts`/`OptionalFromRequest`
- Since core API uses standard extractors and we're not seeing compilation errors, we can trust that the behavior will remain the same. 

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
