### PR TITLE
[front] add instrumentation to investigate readiness when prestopped

### DIFF
--- a/front/pages/api/[preStopSecret]/prestop.ts
+++ b/front/pages/api/[preStopSecret]/prestop.ts
@@ -1,8 +1,11 @@
+import { StatsD } from "hot-shots";
 import type { NextApiRequest, NextApiResponse } from "next";
 
 import { wakeLockIsFree } from "@app/lib/wake_lock";
 import logger from "@app/logger/logger";
 import { withLogging } from "@app/logger/withlogging";
+
+export const statsDClient = new StatsD();
 
 async function handler(
   req: NextApiRequest,
@@ -21,6 +24,8 @@ async function handler(
     res.status(404).end();
     return;
   }
+
+  statsDClient.set("prestop.request", 100);
 
   logger.info("Received prestop request, waiting 10s");
   await new Promise((resolve) => setTimeout(resolve, 10000));

--- a/front/pages/api/healthz.ts
+++ b/front/pages/api/healthz.ts
@@ -11,6 +11,8 @@ export default async function handler(
 
   res.status(200).send("ok");
 
+  statsDClient.decrement("prestop.request", 1);
+
   const elapsed = performance.now() - start;
 
   statsDClient.distribution("requests.health.check", elapsed);


### PR DESCRIPTION
## Description

- This PR adds a datadog metric `prestop.request` set to 100 when the prestop is called and decremented by 1 by the `/healthz` check.
- The goal is to investigate this interaction between the prestop and the liveness check.

## Tests

## Risk

## Deploy Plan

- Deploy front.
