### PR TITLE
enh: one true way to handle conversation attachments

### DIFF
--- a/front/lib/actions/action_file_helpers.ts
+++ b/front/lib/actions/action_file_helpers.ts
@@ -292,19 +292,3 @@ export async function generateJSONFileAndSnippet(
 
   return { jsonFile, jsonSnippet };
 }
-
-export function getJSONFileAttachment({
-  jsonFileId,
-  jsonFileSnippet,
-  title,
-}: {
-  jsonFileId: string | null;
-  jsonFileSnippet: string | null;
-  title: string;
-}): string | null {
-  if (!jsonFileId || !jsonFileSnippet) {
-    return null;
-  }
-
-  return `<file id="${jsonFileId}" type="application/json" title="${title}">\n${jsonFileSnippet}\n</file>`;
-}

--- a/front/lib/actions/conversation/list_files.ts
+++ b/front/lib/actions/conversation/list_files.ts
@@ -1,5 +1,3 @@
-import _ from "lodash";
-
 import {
   DEFAULT_CONVERSATION_EXTRACT_ACTION_NAME,
   DEFAULT_CONVERSATION_INCLUDE_FILE_ACTION_NAME,
@@ -9,75 +7,14 @@ import {
 } from "@app/lib/actions/constants";
 import type { ExtractActionBlob } from "@app/lib/actions/types";
 import { BaseAction } from "@app/lib/actions/types";
+import type { ConversationAttachmentType } from "@app/lib/api/assistant/conversation/attachments";
+import { renderAttachmentXml } from "@app/lib/api/assistant/conversation/attachments";
 import type {
   AgentMessageType,
-  ContentFragmentInputWithContentNode,
-  ContentFragmentVersion,
-  ContentNodeType,
   FunctionCallType,
   FunctionMessageTypeModel,
   ModelId,
-  SupportedContentFragmentType,
 } from "@app/types";
-import { DATA_SOURCE_NODE_ID } from "@app/types";
-
-export type BaseConversationAttachmentType = {
-  title: string;
-  contentType: SupportedContentFragmentType;
-  contentFragmentVersion: ContentFragmentVersion;
-  snippet: string | null;
-  generatedTables: string[];
-  isIncludable: boolean;
-  isSearchable: boolean;
-  isQueryable: boolean;
-  isExtractable: boolean;
-};
-
-export type ConversationFileType = BaseConversationAttachmentType & {
-  fileId: string;
-};
-
-export type ConversationContentNodeType = BaseConversationAttachmentType & {
-  contentFragmentId: string;
-  nodeId: string;
-  nodeDataSourceViewId: string;
-  nodeType: ContentNodeType;
-};
-
-export type ConversationAttachmentType =
-  | ConversationFileType
-  | ConversationContentNodeType;
-
-export function isConversationFileType(
-  attachment: ConversationAttachmentType
-): attachment is ConversationFileType {
-  return "fileId" in attachment;
-}
-
-export function isConversationContentNodeType(
-  attachment: ConversationAttachmentType
-): attachment is ConversationContentNodeType {
-  return "contentFragmentId" in attachment;
-}
-
-export function isContentFragmentDataSourceNode(
-  attachment: ConversationContentNodeType | ContentFragmentInputWithContentNode
-): attachment is ConversationContentNodeType & {
-  nodeId: typeof DATA_SOURCE_NODE_ID;
-} {
-  return attachment.nodeId === DATA_SOURCE_NODE_ID;
-}
-
-// If updating this function, make sure to update `contentFragmentId` when we render the conversation
-// for the model. So there is a consistent way to reference content fragments across different actions.
-export function conversationAttachmentId(
-  attachment: ConversationAttachmentType
-): string {
-  if (isConversationFileType(attachment)) {
-    return attachment.fileId;
-  }
-  return attachment.contentFragmentId;
-}
 
 type ConversationListFilesActionBlob =
   ExtractActionBlob<ConversationListFilesActionType>;
@@ -119,14 +56,11 @@ export class ConversationListFilesActionType extends BaseAction {
       `// searchable: content can be searched alongside other searchable files' content using \`${DEFAULT_CONVERSATION_SEARCH_ACTION_NAME}\`\n` +
       `// extractable: files can also be processed to extract structured data using \`${DEFAULT_CONVERSATION_EXTRACT_ACTION_NAME}\`\n` +
       `Other tools that accept files (referenced by their id) as arguments can be available. Rely on their description and the files mime types to decide which tool to use on which file.`;
-    for (const f of this.files) {
-      content += `<file id="${conversationAttachmentId(f)}" name="${_.escape(f.title)}" type="${f.contentType}" includable="${f.isIncludable}" queryable="${f.isQueryable}" searchable="${f.isSearchable}"`;
-
-      if (f.snippet) {
-        content += ` snippet="${_.escape(f.snippet)}"`;
+    for (const [i, attachment] of this.files.entries()) {
+      if (i > 0) {
+        content += "\n";
       }
-
-      content += "/>\n";
+      content += renderAttachmentXml({ attachment });
     }
 
     return {
@@ -141,12 +75,12 @@ export class ConversationListFilesActionType extends BaseAction {
 
 export function makeConversationListFilesAction({
   agentMessage,
-  files,
+  attachments,
 }: {
   agentMessage: AgentMessageType;
-  files: ConversationAttachmentType[];
+  attachments: ConversationAttachmentType[];
 }): ConversationListFilesActionType | null {
-  if (files.length === 0) {
+  if (attachments.length === 0) {
     return null;
   }
 
@@ -154,7 +88,7 @@ export function makeConversationListFilesAction({
     id: -1,
     functionCallId: "call_" + Math.random().toString(36).substring(7),
     functionCallName: DEFAULT_CONVERSATION_LIST_FILES_ACTION_NAME,
-    files,
+    files: attachments,
     agentMessageId: agentMessage.agentMessageId,
     step: -1,
     type: "conversation_list_files_action",

--- a/front/lib/actions/dust_app_run.ts
+++ b/front/lib/actions/dust_app_run.ts
@@ -21,6 +21,10 @@ import {
   dustAppRunInputsToInputSchema,
   inputSchemaToDustAppRunInputs,
 } from "@app/lib/actions/types/agent";
+import {
+  getAttachmentFromToolOutput,
+  renderAttachmentXml,
+} from "@app/lib/api/assistant/conversation/attachments";
 import { renderConversationForModel } from "@app/lib/api/assistant/preprocessing";
 import config from "@app/lib/api/config";
 import { getDatasetSchema } from "@app/lib/api/datasets";
@@ -164,15 +168,18 @@ export class DustAppRunActionType extends BaseAction {
       this.resultsFileContentType;
 
     if (hasResultsFile) {
-      const attachment = getDustAppRunResultsFileAttachment({
-        resultsFileId: this.resultsFileId,
-        resultsFileSnippet: this.resultsFileSnippet,
-        resultsFileContentType: this.resultsFileContentType,
-        includeSnippet: true,
-        appName: this.appName,
+      const attachment = getAttachmentFromToolOutput({
+        fileId: this.resultsFileId,
+        contentType: this.resultsFileContentType,
+        title: getDustAppRunResultsFileTitle({
+          appName: this.appName,
+          resultsFileContentType: this.resultsFileContentType,
+        }),
+        snippet: this.resultsFileSnippet,
       });
+      const xml = renderAttachmentXml({ attachment });
 
-      content += `${attachment}\n\n`;
+      content += `${xml}\n\n`;
     }
 
     // Note action.output can be any valid JSON including null.
@@ -888,36 +895,6 @@ export async function dustAppRunTypesFromAgentMessageIds(
       type: "dust_app_run_action",
     });
   });
-}
-
-export function getDustAppRunResultsFileAttachment({
-  resultsFileId,
-  resultsFileSnippet,
-  resultsFileContentType,
-  includeSnippet = true,
-  appName,
-}: {
-  resultsFileId: string | null;
-  resultsFileSnippet: string | null;
-  resultsFileContentType: SupportedFileContentType;
-  includeSnippet: boolean;
-  appName: string;
-}): string | null {
-  if (!resultsFileId || !resultsFileSnippet) {
-    return null;
-  }
-
-  const attachment =
-    `<file ` +
-    `id="${resultsFileId}" type="${resultsFileContentType}" title=${getDustAppRunResultsFileTitle(
-      { appName, resultsFileContentType }
-    )}`;
-
-  if (!includeSnippet) {
-    return `${attachment} />`;
-  }
-
-  return `${attachment}>\n${resultsFileSnippet}\n</file>`;
 }
 
 function containsValidJsonOutput(output: unknown): output is {

--- a/front/lib/actions/mcp_internal_actions/servers/conversation_files.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/conversation_files.ts
@@ -2,10 +2,10 @@ import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod";
 
 import { ConversationIncludeFileActionType } from "@app/lib/actions/conversation/include_file";
-import { conversationAttachmentId } from "@app/lib/actions/conversation/list_files";
 import { makeMCPToolTextError } from "@app/lib/actions/mcp_internal_actions/utils";
 import type { AgentLoopContextType } from "@app/lib/actions/types";
-import { listFiles } from "@app/lib/api/assistant/jit_utils";
+import { conversationAttachmentId } from "@app/lib/api/assistant/conversation/attachments";
+import { listAttachments } from "@app/lib/api/assistant/jit_utils";
 import type { InternalMCPServerDefinitionType } from "@app/lib/api/mcp";
 import { getSupportedModelConfig } from "@app/lib/assistant";
 import type { Authenticator } from "@app/lib/auth";
@@ -70,8 +70,10 @@ function createServer(
       const { content, title } = fileRes.value;
 
       // Get the file metadata to extract the actual content type
-      const files = listFiles(conversation);
-      const file = files.find((f) => conversationAttachmentId(f) === fileId);
+      const attachments = listAttachments(conversation);
+      const attachment = attachments.find(
+        (a) => conversationAttachmentId(a) === fileId
+      );
 
       if (isTextContent(content)) {
         return {
@@ -92,7 +94,7 @@ function createServer(
               type: "resource",
               resource: {
                 uri: content.image_url.url,
-                mimeType: file?.contentType || "application/octet-stream",
+                mimeType: attachment?.contentType || "application/octet-stream",
                 text: `Image: ${title}`,
               },
             },
@@ -101,7 +103,7 @@ function createServer(
       }
 
       return makeMCPToolTextError(
-        `File ${file?.title || fileId} of type ${file?.contentType || "unknown"} has no text or image content`
+        `File ${attachment?.title || fileId} of type ${attachment?.contentType || "unknown"} has no text or image content`
       );
     }
   );

--- a/front/lib/api/assistant/conversation/attachments.ts
+++ b/front/lib/api/assistant/conversation/attachments.ts
@@ -1,0 +1,240 @@
+import { assertNever, CONTENT_NODE_MIME_TYPES } from "@dust-tt/client";
+import assert from "assert";
+
+import {
+  isConversationIncludableFileContentType,
+  isExtractableContentType,
+  isQueryableContentType,
+  isSearchableContentType,
+} from "@app/lib/api/assistant/conversation/content_types";
+import type {
+  ContentFragmentInputWithContentNode,
+  ContentFragmentType,
+  ContentFragmentVersion,
+  ContentNodeContentFragmentType,
+  ContentNodeType,
+  FileContentFragmentType,
+  SupportedContentFragmentType,
+  SupportedFileContentType,
+} from "@app/types";
+import {
+  DATA_SOURCE_NODE_ID,
+  isContentNodeContentFragment,
+  isFileContentFragment,
+} from "@app/types";
+
+export type BaseConversationAttachmentType = {
+  title: string;
+  contentType: SupportedContentFragmentType;
+  contentFragmentVersion: ContentFragmentVersion;
+  snippet: string | null;
+  generatedTables: string[];
+  isIncludable: boolean;
+  isSearchable: boolean;
+  isQueryable: boolean;
+  isExtractable: boolean;
+};
+
+export type FileAttachmentType = BaseConversationAttachmentType & {
+  fileId: string;
+};
+
+export type ContentNodeAttachmentType = BaseConversationAttachmentType & {
+  contentFragmentId: string;
+  nodeId: string;
+  nodeDataSourceViewId: string;
+  nodeType: ContentNodeType;
+};
+
+export type ConversationAttachmentType =
+  | FileAttachmentType
+  | ContentNodeAttachmentType;
+
+export function isFileAttachmentType(
+  attachment: ConversationAttachmentType
+): attachment is FileAttachmentType {
+  return "fileId" in attachment;
+}
+
+export function isContentNodeAttachmentType(
+  attachment: ConversationAttachmentType
+): attachment is ContentNodeAttachmentType {
+  return "contentFragmentId" in attachment;
+}
+
+export function isContentFragmentDataSourceNode(
+  attachment: ContentNodeAttachmentType | ContentFragmentInputWithContentNode
+): attachment is ContentNodeAttachmentType & {
+  nodeId: typeof DATA_SOURCE_NODE_ID;
+} {
+  return attachment.nodeId === DATA_SOURCE_NODE_ID;
+}
+
+// If updating this function, make sure to update `contentFragmentId` when we render the conversation
+// for the model. So there is a consistent way to reference content fragments across different actions.
+export function conversationAttachmentId(
+  attachment: ConversationAttachmentType
+): string {
+  if (isFileAttachmentType(attachment)) {
+    return attachment.fileId;
+  }
+  return attachment.contentFragmentId;
+}
+
+export function getAttachmentFromContentFragment(
+  cf: ContentFragmentType
+): ConversationAttachmentType {
+  if (isContentNodeContentFragment(cf)) {
+    return getAttachmentFromContentNodeContentFragment(cf);
+  }
+  if (isFileContentFragment(cf)) {
+    return getAttachmentFromFileContentFragment(cf);
+  }
+  assertNever(cf);
+}
+
+export function getAttachmentFromContentNodeContentFragment(
+  cf: ContentNodeContentFragmentType
+): ContentNodeAttachmentType {
+  const isQueryable =
+    isQueryableContentType(cf.contentType) || cf.nodeType === "table";
+  const isIncludable =
+    cf.nodeType !== "folder" &&
+    isConversationIncludableFileContentType(cf.contentType) &&
+    // Tables from knowledge are not materialized as raw content. As such, they cannot be
+    // included.
+    !isQueryable;
+  // Tables from knowledge are not materialized as raw content. As such, they cannot be
+  // searched--except for notion databases, that may have children.
+  const isUnmaterializedTable =
+    isQueryable && cf.contentType !== CONTENT_NODE_MIME_TYPES.NOTION.DATABASE;
+  const isSearchable =
+    isSearchableContentType(cf.contentType) && !isUnmaterializedTable;
+  const isExtractable =
+    isExtractableContentType(cf.contentType) && !isUnmaterializedTable;
+
+  const baseAttachment: BaseConversationAttachmentType = {
+    title: cf.title,
+    contentType: cf.contentType,
+    snippet: null,
+    contentFragmentVersion: cf.contentFragmentVersion,
+    // Backward compatibility: we fallback to the fileId if no generated tables are mentionned
+    // but the file is queryable.
+    generatedTables: isQueryable ? [cf.nodeId] : [],
+    isIncludable,
+    isQueryable,
+    isSearchable,
+    isExtractable,
+  };
+
+  return {
+    ...baseAttachment,
+    nodeDataSourceViewId: cf.nodeDataSourceViewId,
+    contentFragmentId: cf.contentFragmentId,
+    nodeId: cf.nodeId,
+    nodeType: cf.nodeType,
+  };
+}
+
+export function getAttachmentFromFileContentFragment(
+  cf: FileContentFragmentType
+): FileAttachmentType {
+  const fileId = cf.fileId;
+  assert(fileId, `File attachment must have a fileId (sId: ${cf.sId})`);
+
+  // Here, snippet not null is actually to detect file attachments that are prior to the JIT
+  // actions, and differentiate them from the newer file attachments that do have a snippet.
+  // Former ones cannot be used in JIT.
+  const canDoJIT = cf.snippet !== null;
+  const isQueryable = canDoJIT && isQueryableContentType(cf.contentType);
+  const isIncludable = isConversationIncludableFileContentType(cf.contentType);
+  const isSearchable = canDoJIT && isSearchableContentType(cf.contentType);
+  const isExtractable = canDoJIT && isExtractableContentType(cf.contentType);
+  const baseAttachment: BaseConversationAttachmentType = {
+    title: cf.title,
+    contentType: cf.contentType,
+    snippet: cf.snippet,
+    contentFragmentVersion: cf.contentFragmentVersion,
+    // Backward compatibility: we fallback to the fileId if no generated tables are mentionned
+    // but the file is queryable.
+    generatedTables:
+      cf.generatedTables.length > 0
+        ? cf.generatedTables
+        : isQueryable
+          ? [fileId]
+          : [],
+    isIncludable,
+    isQueryable,
+    isSearchable,
+    isExtractable,
+  };
+
+  return {
+    ...baseAttachment,
+    fileId,
+  };
+}
+
+export function getAttachmentFromToolOutput({
+  fileId,
+  contentType,
+  title,
+  snippet,
+}: {
+  fileId: string;
+  contentType: SupportedFileContentType;
+  title: string;
+  snippet: string | null;
+}): FileAttachmentType {
+  const canDoJIT = snippet != null;
+  const isIncludable = isConversationIncludableFileContentType(contentType);
+  const isQueryable = canDoJIT && isQueryableContentType(contentType);
+  const isSearchable = canDoJIT && isSearchableContentType(contentType);
+  const isExtractable = canDoJIT && isExtractableContentType(contentType);
+
+  return {
+    fileId,
+    contentType,
+    title,
+    snippet,
+    // For simplicity later, we always set the generatedTables to the fileId if the file is queryable for agent generated files.
+    generatedTables: isQueryable ? [fileId] : [],
+    contentFragmentVersion: "latest",
+    isIncludable,
+    isQueryable,
+    isSearchable,
+    isExtractable,
+  };
+}
+
+export function renderAttachmentXml({
+  attachment,
+  content = null,
+}: {
+  attachment: ConversationAttachmentType;
+  content?: string | null;
+}): string {
+  const params = [
+    `id="${conversationAttachmentId(attachment)}"`,
+    `type="${attachment.contentType}"`,
+    `title="${attachment.title}"`,
+    `version="${attachment.contentFragmentVersion}"`,
+    `isIncludable="${attachment.isIncludable}"`,
+    `isQueryable="${attachment.isQueryable}"`,
+    `isSearchable="${attachment.isSearchable}"`,
+    `isExtractable="${attachment.isExtractable}"`,
+  ];
+
+  let tag = `<attachment ${params.join(" ")}`;
+
+  const contentToRender = content ?? attachment.snippet;
+
+  if (contentToRender) {
+    tag += ">";
+    tag += `${contentToRender}\n</attachment>`;
+  } else {
+    tag += "/>";
+  }
+
+  return tag;
+}

--- a/front/lib/api/assistant/conversation/attachments.ts
+++ b/front/lib/api/assistant/conversation/attachments.ts
@@ -186,7 +186,7 @@ export function getAttachmentFromToolOutput({
   title: string;
   snippet: string | null;
 }): FileAttachmentType {
-  const canDoJIT = snippet != null;
+  const canDoJIT = snippet !== null;
   const isIncludable = isConversationIncludableFileContentType(contentType);
   const isQueryable = canDoJIT && isQueryableContentType(contentType);
   const isSearchable = canDoJIT && isSearchableContentType(contentType);
@@ -230,8 +230,7 @@ export function renderAttachmentXml({
   const contentToRender = content ?? attachment.snippet;
 
   if (contentToRender) {
-    tag += ">";
-    tag += `${contentToRender}\n</attachment>`;
+    tag += `>${contentToRender}\n</attachment>`;
   } else {
     tag += "/>";
   }

--- a/front/lib/api/assistant/conversation/content_fragment.ts
+++ b/front/lib/api/assistant/conversation/content_fragment.ts
@@ -1,7 +1,7 @@
 import type { DustMimeType } from "@dust-tt/client";
 import { DATA_SOURCE_MIME_TYPE } from "@dust-tt/client";
 
-import { isContentFragmentDataSourceNode } from "@app/lib/actions/conversation/list_files";
+import { isContentFragmentDataSourceNode } from "@app/lib/api/assistant/conversation/attachments";
 import config from "@app/lib/api/config";
 import { getContentNodeFromCoreNode } from "@app/lib/api/content_nodes";
 import type { ProcessAndStoreFileError } from "@app/lib/api/files/upload";

--- a/front/lib/api/assistant/conversation/content_types.ts
+++ b/front/lib/api/assistant/conversation/content_types.ts
@@ -1,0 +1,65 @@
+import {
+  CONTENT_NODE_MIME_TYPES,
+  isDustMimeType,
+  isIncludableInternalMimeType,
+  isSupportedImageContentType,
+} from "@dust-tt/client";
+
+import type { SupportedContentFragmentType } from "@app/types";
+import { isSupportedDelimitedTextContentType } from "@app/types";
+
+export function isConversationIncludableFileContentType(
+  contentType: SupportedContentFragmentType
+): boolean {
+  if (isDustMimeType(contentType)) {
+    return isIncludableInternalMimeType(contentType);
+  }
+  return true;
+}
+
+export function isQueryableContentType(
+  contentType: SupportedContentFragmentType
+): boolean {
+  // For now we only allow querying tabular files and multi-sheet spreadsheets
+  // from connections.
+  if (
+    isSupportedDelimitedTextContentType(contentType) ||
+    isMultiSheetSpreadsheetContentType(contentType)
+  ) {
+    return true;
+  }
+  return false;
+}
+
+export function isMultiSheetSpreadsheetContentType(
+  contentType: SupportedContentFragmentType
+): contentType is
+  | typeof CONTENT_NODE_MIME_TYPES.MICROSOFT.SPREADSHEET
+  | typeof CONTENT_NODE_MIME_TYPES.GOOGLE_DRIVE.SPREADSHEET {
+  return (
+    contentType === CONTENT_NODE_MIME_TYPES.MICROSOFT.SPREADSHEET ||
+    contentType === CONTENT_NODE_MIME_TYPES.GOOGLE_DRIVE.SPREADSHEET
+  );
+}
+
+export function isSearchableContentType(
+  contentType: SupportedContentFragmentType
+): boolean {
+  if (isSupportedImageContentType(contentType)) {
+    return false;
+  }
+  if (isSupportedDelimitedTextContentType(contentType)) {
+    return false;
+  }
+  // For now we allow searching everything else.
+  return true;
+}
+
+export function isExtractableContentType(
+  contentType: SupportedContentFragmentType
+): boolean {
+  if (isSupportedImageContentType(contentType)) {
+    return false;
+  }
+  return true;
+}

--- a/front/lib/api/assistant/jit_utils.ts
+++ b/front/lib/api/assistant/jit_utils.ts
@@ -1,174 +1,24 @@
-import {
-  assertNever,
-  CONTENT_NODE_MIME_TYPES,
-  isDustMimeType,
-  isIncludableInternalMimeType,
-} from "@dust-tt/client";
-import assert from "assert";
+import { CONTENT_NODE_MIME_TYPES } from "@dust-tt/client";
 
 import type {
-  BaseConversationAttachmentType,
+  ContentNodeAttachmentType,
   ConversationAttachmentType,
-  ConversationContentNodeType,
-  ConversationFileType,
-} from "@app/lib/actions/conversation/list_files";
-import type {
-  ContentNodeContentFragmentType,
-  ConversationType,
-  FileContentFragmentType,
-  SupportedContentFragmentType,
-} from "@app/types";
+} from "@app/lib/api/assistant/conversation/attachments";
+import {
+  getAttachmentFromContentFragment,
+  getAttachmentFromToolOutput,
+} from "@app/lib/api/assistant/conversation/attachments";
+import type { ConversationType } from "@app/types";
 import {
   isAgentMessageType,
   isContentFragmentType,
-  isContentNodeContentFragment,
-  isFileContentFragment,
-  isSupportedDelimitedTextContentType,
   isSupportedImageContentType,
 } from "@app/types";
 
-function isConversationIncludableFileContentType(
-  contentType: SupportedContentFragmentType
-): boolean {
-  if (isDustMimeType(contentType)) {
-    return isIncludableInternalMimeType(contentType);
-  }
-  return true;
-}
-
-function isQueryableContentType(
-  contentType: SupportedContentFragmentType
-): boolean {
-  // For now we only allow querying tabular files and multi-sheet spreadsheets
-  // from connections.
-  if (
-    isSupportedDelimitedTextContentType(contentType) ||
-    isMultiSheetSpreadsheetContentType(contentType)
-  ) {
-    return true;
-  }
-  return false;
-}
-
-export function isMultiSheetSpreadsheetContentType(
-  contentType: SupportedContentFragmentType
-): contentType is
-  | typeof CONTENT_NODE_MIME_TYPES.MICROSOFT.SPREADSHEET
-  | typeof CONTENT_NODE_MIME_TYPES.GOOGLE_DRIVE.SPREADSHEET {
-  return (
-    contentType === CONTENT_NODE_MIME_TYPES.MICROSOFT.SPREADSHEET ||
-    contentType === CONTENT_NODE_MIME_TYPES.GOOGLE_DRIVE.SPREADSHEET
-  );
-}
-
-function isSearchableContentType(
-  contentType: SupportedContentFragmentType
-): boolean {
-  if (isSupportedImageContentType(contentType)) {
-    return false;
-  }
-  if (isSupportedDelimitedTextContentType(contentType)) {
-    return false;
-  }
-  // For now we allow searching everything else.
-  return true;
-}
-
-function isExtractableContentType(
-  contentType: SupportedContentFragmentType
-): boolean {
-  if (isSupportedImageContentType(contentType)) {
-    return false;
-  }
-  return true;
-}
-
-export function getContentFragmentFileAttachment(
-  cf: FileContentFragmentType
-): ConversationFileType {
-  const fileId = cf.fileId;
-  assert(fileId, `File attachment must have a fileId (sId: ${cf.sId})`);
-
-  // Here, snippet not null is actually to detect file attachments that are prior to the JIT
-  // actions, and differentiate them from the newer file attachments that do have a snippet.
-  // Former ones cannot be used in JIT.
-  const canDoJIT = cf.snippet !== null;
-  const isQueryable = canDoJIT && isQueryableContentType(cf.contentType);
-  const isIncludable = isConversationIncludableFileContentType(cf.contentType);
-  const isSearchable = canDoJIT && isSearchableContentType(cf.contentType);
-  const isExtractable = canDoJIT && isExtractableContentType(cf.contentType);
-  const baseAttachment: BaseConversationAttachmentType = {
-    title: cf.title,
-    contentType: cf.contentType,
-    snippet: cf.snippet,
-    contentFragmentVersion: cf.contentFragmentVersion,
-    // Backward compatibility: we fallback to the fileId if no generated tables are mentionned
-    // but the file is queryable.
-    generatedTables:
-      cf.generatedTables.length > 0
-        ? cf.generatedTables
-        : isQueryable
-          ? [fileId]
-          : [],
-    isIncludable,
-    isQueryable,
-    isSearchable,
-    isExtractable,
-  };
-
-  return {
-    ...baseAttachment,
-    fileId,
-  };
-}
-
-export function getContentFragmentContentNodeAttachment(
-  cf: ContentNodeContentFragmentType
-): ConversationContentNodeType {
-  const isQueryable =
-    isQueryableContentType(cf.contentType) || cf.nodeType === "table";
-  const isIncludable =
-    cf.nodeType !== "folder" &&
-    isConversationIncludableFileContentType(cf.contentType) &&
-    // Tables from knowledge are not materialized as raw content. As such, they cannot be
-    // included.
-    !isQueryable;
-  // Tables from knowledge are not materialized as raw content. As such, they cannot be
-  // searched--except for notion databases, that may have children.
-  const isUnmaterializedTable =
-    isQueryable && cf.contentType !== CONTENT_NODE_MIME_TYPES.NOTION.DATABASE;
-  const isSearchable =
-    isSearchableContentType(cf.contentType) && !isUnmaterializedTable;
-  const isExtractable =
-    isExtractableContentType(cf.contentType) && !isUnmaterializedTable;
-
-  const baseAttachment: BaseConversationAttachmentType = {
-    title: cf.title,
-    contentType: cf.contentType,
-    snippet: null,
-    contentFragmentVersion: cf.contentFragmentVersion,
-    // Backward compatibility: we fallback to the fileId if no generated tables are mentionned
-    // but the file is queryable.
-    generatedTables: isQueryable ? [cf.nodeId] : [],
-    isIncludable,
-    isQueryable,
-    isSearchable,
-    isExtractable,
-  };
-
-  return {
-    ...baseAttachment,
-    nodeDataSourceViewId: cf.nodeDataSourceViewId,
-    contentFragmentId: cf.contentFragmentId,
-    nodeId: cf.nodeId,
-    nodeType: cf.nodeType,
-  };
-}
-
-export function listFiles(
+export function listAttachments(
   conversation: ConversationType
 ): ConversationAttachmentType[] {
-  const files: ConversationAttachmentType[] = [];
+  const attachments: ConversationAttachmentType[] = [];
   for (const versions of conversation.content) {
     const m = versions[versions.length - 1];
 
@@ -183,46 +33,26 @@ export function listFiles(
         continue;
       }
 
-      if (isFileContentFragment(m)) {
-        files.push(getContentFragmentFileAttachment(m));
-      } else if (isContentNodeContentFragment(m)) {
-        files.push(getContentFragmentContentNodeAttachment(m));
-      } else {
-        assertNever(m);
-      }
+      attachments.push(getAttachmentFromContentFragment(m));
     } else if (isAgentMessageType(m)) {
       const generatedFiles = m.actions.flatMap((a) => a.getGeneratedFiles());
 
       for (const f of generatedFiles) {
-        const canDoJIT = f.snippet != null;
-        const isIncludable = isConversationIncludableFileContentType(
-          f.contentType
+        attachments.push(
+          getAttachmentFromToolOutput({
+            fileId: f.fileId,
+            contentType: f.contentType,
+            title: f.title,
+            snippet: f.snippet,
+          })
         );
-        const isQueryable = canDoJIT && isQueryableContentType(f.contentType);
-        const isSearchable = canDoJIT && isSearchableContentType(f.contentType);
-        const isExtractable =
-          canDoJIT && isExtractableContentType(f.contentType);
-
-        files.push({
-          fileId: f.fileId,
-          contentType: f.contentType,
-          title: f.title,
-          snippet: f.snippet,
-          // For simplicity later, we always set the generatedTables to the fileId if the file is queryable for agent generated files.
-          generatedTables: isQueryable ? [f.fileId] : [],
-          contentFragmentVersion: "latest",
-          isIncludable,
-          isQueryable,
-          isSearchable,
-          isExtractable,
-        });
       }
     } else {
       continue;
     }
   }
 
-  return files;
+  return attachments;
 }
 
 /**
@@ -234,7 +64,7 @@ export function listFiles(
  *   have multiple children) but are not searchable; their children are
  *   table-queryable only.
  */
-export function isSearchableFolder(m: ConversationContentNodeType): boolean {
+export function isSearchableFolder(m: ContentNodeAttachmentType): boolean {
   return (
     (m.nodeType === "folder" ||
       m.contentType === CONTENT_NODE_MIME_TYPES.NOTION.PAGE ||

--- a/front/lib/api/assistant/visualization.ts
+++ b/front/lib/api/assistant/visualization.ts
@@ -67,7 +67,7 @@ if (file) {
 }
 \`\`\`
 
-\`fileId\` can be extracted from the \`<file id="\${FILE_ID}" type... name...>\` tags returned by the \`list_conversation_files\` action.
+\`fileId\` can be extracted from the \`<attachment id="\${FILE_ID}" type... name...>\` tags returned by the \`list_conversation_files\` action.
 
 Example using the \`triggerUserFileDownload\` hook:
 


### PR DESCRIPTION
## Description

Dust has this concept of "conversation attachments". Conversation attachments can come:
- from user in-conversation uploads (eg I add a text file that the agent should use as reference to answer my questions)
- from tool outputs (eg after using tables query, there's a new CSV file attachment)
- from data sources (user wants to attach a specific data source content node to the conversation to let the agent use it / search to answer user requests)

Dust also has the concept of "content fragment". Content fragments are materialized as a database table on dust, and were initially intended to store static strings to be injected into conversations, for example a slack thread. This object has been overloaded over time to add support for images, user-uploaded files, and data source content nodes.

When rendering conversation for the model, content fragments and attachments become mostly the same thing. We render them as XML tags.

Today, we have many different (4 or 5) implementations of rendering these XML tags, that take diferent parameters, render things slightly differently, include snippets or not etc..
We also sometimes talk of "files" sometimes of "attachments" and sometimes of "content fragments", in an almost interchangeable way, to the point that it becomes very hard to wrap our minds around it.

As we're moving towards the modern models API (`contents` array), we need to remove emulated function calls (won't go into details now), and this requires refactoring this whole thing first.

This PR simplifies how all of this works:
- one true way of rendering the XML tags, where the input is an `attachment`
- ability to convert a content fragment into an attachment

overall logic is streamlined

## Tests

Heavily tested locally

## Risk

There is some behavior change. We now always render the XML tags in the same way, including all information about whether the file / node is includable/searchable/extractable etc.. We render the snippet if it exists.

## Deploy Plan

Deploy front