### PR TITLE
[Microsoft Sync] Allow deleing client-deleted root nodes

### DIFF
--- a/connectors/src/connectors/microsoft/temporal/activities.ts
+++ b/connectors/src/connectors/microsoft/temporal/activities.ts
@@ -689,7 +689,14 @@ export async function syncDeltaForRootNodesInDrive({
       if (driveItem.deleted) {
         // no need to delete children here since they will all be listed
         // in the delta with the 'deleted' field set
-        await deleteFolder({ connectorId, dataSourceConfig, internalId });
+        // we can delete, even if it is not a root node, because microsoft
+        // tells us the client has already deleted the folder
+        await deleteFolder({
+          connectorId,
+          dataSourceConfig,
+          internalId,
+          deleteRootNode: true,
+        });
       } else {
         const isMoved = await isFolderMovedInSameRoot({
           connectorId,


### PR DESCRIPTION
Description
---
Fixes [this issue](https://dust4ai.slack.com/archives/C05F84CFP0E/p1751387919524569), see comment in code

Risk
---
standard, risk is deleting a root node that shouldn't be but here it seems it won't happen

Deploy
---
connectors