### PR TITLE
[front] fix(`run_dust_app`): handle apps without a dataset name

### DIFF
--- a/front/lib/actions/mcp_internal_actions/servers/run_dust_app.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/run_dust_app.ts
@@ -296,6 +296,10 @@ export default async function createServer(
       agentLoopContext.listToolsContext.agentActionConfiguration
     );
 
+    if (!app.description) {
+      throw new Error("Missing app description");
+    }
+
     server.tool(
       app.name,
       app.description,
@@ -306,7 +310,7 @@ export default async function createServer(
           content: [
             {
               type: "text",
-              text: "Successfully listed Dust App configuration",
+              text: "Successfully list Dust App configuration",
             },
           ],
         };
@@ -323,6 +327,10 @@ export default async function createServer(
       auth,
       agentLoopContext.runContext.actionConfiguration
     );
+
+    if (!app.description) {
+      throw new Error("Missing app description");
+    }
 
     server.tool(
       app.name,

--- a/front/lib/actions/mcp_internal_actions/servers/run_dust_app.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/run_dust_app.ts
@@ -31,7 +31,7 @@ import { extractConfig } from "@app/lib/config";
 import { AppResource } from "@app/lib/resources/app_resource";
 import { sanitizeJSONOutput } from "@app/lib/utils";
 import logger from "@app/logger/logger";
-import type { DatasetSchema } from "@app/types";
+import type { BlockRunConfig, DatasetSchema } from "@app/types";
 import type { SpecificationBlockType } from "@app/types";
 import {
   getHeaderFromGroupIds,
@@ -93,7 +93,11 @@ async function prepareAppContext(
   actionConfig:
     | ServerSideMCPServerConfigurationType
     | ServerSideMCPToolConfigurationType
-) {
+): Promise<{
+  app: AppResource;
+  schema: DatasetSchema | null;
+  appConfig: BlockRunConfig;
+}> {
   if (!actionConfig.dustAppConfiguration?.appId) {
     throw new Error("Missing Dust app ID");
   }
@@ -115,8 +119,12 @@ async function prepareAppContext(
   const inputConfig = inputSpec ? appConfig[inputSpec.name] : null;
   const datasetName = inputConfig?.dataset;
 
-  if (!datasetName || !app.description) {
-    throw new Error("Missing dataset name or app description");
+  if (!app.description) {
+    throw new Error("Missing app description");
+  }
+
+  if (!datasetName) {
+    return { app, schema: null, appConfig };
   }
 
   const schema = await getDatasetSchema(auth, app, datasetName);

--- a/front/lib/actions/mcp_internal_actions/servers/run_dust_app.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/run_dust_app.ts
@@ -296,10 +296,6 @@ export default async function createServer(
       agentLoopContext.listToolsContext.agentActionConfiguration
     );
 
-    if (!app.description) {
-      throw new Error("Missing app description");
-    }
-
     server.tool(
       app.name,
       app.description,
@@ -310,7 +306,7 @@ export default async function createServer(
           content: [
             {
               type: "text",
-              text: "Successfully list Dust App configuration",
+              text: "Successfully listed Dust App configuration",
             },
           ],
         };
@@ -327,10 +323,6 @@ export default async function createServer(
       auth,
       agentLoopContext.runContext.actionConfiguration
     );
-
-    if (!app.description) {
-      throw new Error("Missing app description");
-    }
 
     server.tool(
       app.name,

--- a/front/lib/actions/mcp_internal_actions/servers/run_dust_app.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/run_dust_app.ts
@@ -119,10 +119,6 @@ async function prepareAppContext(
   const inputConfig = inputSpec ? appConfig[inputSpec.name] : null;
   const datasetName = inputConfig?.dataset;
 
-  if (!app.description) {
-    throw new Error("Missing app description");
-  }
-
   if (!datasetName) {
     return { app, schema: null, appConfig };
   }

--- a/front/lib/actions/mcp_internal_actions/servers/run_dust_app.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/run_dust_app.ts
@@ -236,7 +236,7 @@ async function processDustFileOutput(
 
 async function prepareParamsWithHistory(
   params: any,
-  schema: DatasetSchema,
+  schema: DatasetSchema | null,
   agentLoopRunContext: AgentLoopRunContextType,
   auth: Authenticator
 ) {


### PR DESCRIPTION
## Description

- Context [here](https://dust4ai.slack.com/archives/C050SM8NSPK/p1751376144299429).
- Logs [here](https://app.datadoghq.eu/logs?query=service%3Afront%20status%3Aerror%20%40dd.env%3Aprod%20-%40apiError.api_error.type%3A%28workspace_auth_error%20OR%20not_authenticated%20OR%20invalid_api_key_error%29%20%22Error%3A%20Missing%20dataset%20name%20or%20app%20description%22&agg_m=count&agg_m_source=base&agg_q=%40workspaceId&agg_q_source=base&agg_t=count&clustering_pattern_field_path=message&cols=host%2Cservice&fromUser=true&messageDisplay=inline&refresh_mode=sliding&storage=hot&stream_sort=desc&top_n=10&top_o=top&viz=stream&x_missing=true&from_ts=1750080948526&to_ts=1751376948526&live=true).
- Dust apps that have no dataset name is currently not supported even though legit.
- This PR fixes that.

## Tests

- Tested locally.

## Risk

- N/A.

## Deploy Plan

- Deploy front.
