### PR TITLE
Use virtual table for csv

### DIFF
--- a/core/Cargo.lock
+++ b/core/Cargo.lock
@@ -1387,6 +1387,7 @@ dependencies = [
  "sha2",
  "shellexpand",
  "sqids",
+ "tempfile",
  "tera",
  "thiserror 1.0.69",
  "tikv-jemallocator",
@@ -3859,6 +3860,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b838eba278d213a8beaf485bd313fd580ca4505a00d5871caeb1457c55322cae"
 dependencies = [
  "bitflags 2.9.1",
+ "csv",
  "fallible-iterator 0.3.0",
  "fallible-streaming-iterator",
  "hashlink",

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -137,7 +137,7 @@ reqwest = { version = "0.12", features = ["json"] }
 ring = "0.17.14"
 rsa = { version = "0.9.4", features = ["pem"] }
 rslock = { version = "0.4.0", default-features = false, features = ["tokio-comp"] }
-rusqlite = { version = "0.31", features = ["bundled"] }
+rusqlite = { version = "0.31", features = ["bundled", "csvtab"] }
 rustc-hash = "1.1"
 sentencepiece = { version = "0.11", features = ["static"] }
 serde = { version = "1.0", features = ["rc", "derive"] }
@@ -145,6 +145,7 @@ serde_json = "1.0"
 sha2 = "0.10.8"
 shellexpand = "2.1"
 sqids = "0.4.1"
+tempfile = "3.20.0"
 tera = "1.20"
 thiserror = "1.0.57"
 tikv-jemallocator = "0.6"

--- a/core/src/databases/table.rs
+++ b/core/src/databases/table.rs
@@ -336,6 +336,7 @@ impl Table {
     }
 }
 
+#[derive(Debug, Clone)]
 pub struct LocalTable {
     pub table: Table,
 }


### PR DESCRIPTION
## Description

(based on an unmerged PR)

This enable usage of the stored csv in the sql lite worker via csv virtual table.

It completely removes the need to retrieve from psql and to insert the rows in sqllite ([a major factor in the cost](https://app.datadoghq.eu/dashboard/6h5-65h-p7a/table-query?fromUser=false&refresh_mode=sliding&from_ts=1750183108296&to_ts=1751392708296&live=true)) operating directly on the CSV.

The CSV file has been cleaned up when it was received and we pass the infered schema so it should be ISO with today behavior.

From my testing on a 50k rows db, it's quite performant.

Major cost now is downloading the file, we could add a cache there.

Once migration is done, we will remove support for the non csv code path.

## Tests

Locally

## Risk

Medium as it changes the codepath for table query.

## Deploy Plan

Deploy sql lite worker.