### PR TITLE
Add Stripe Remote MCP Server

### DIFF
--- a/extension/package-lock.json
+++ b/extension/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "@auth0/auth0-spa-js": "^2.1.3",
         "@dust-tt/client": "^1.0.57",
-        "@dust-tt/sparkle": "^0.2.533",
+        "@dust-tt/sparkle": "^0.2.534",
         "@frontapp/plugin-sdk": "^1.8.1",
         "@modelcontextprotocol/sdk": "^1.9.0",
         "@tailwindcss/forms": "^0.5.9",
@@ -335,9 +335,9 @@
       }
     },
     "node_modules/@dust-tt/sparkle": {
-      "version": "0.2.533",
-      "resolved": "https://registry.npmjs.org/@dust-tt/sparkle/-/sparkle-0.2.533.tgz",
-      "integrity": "sha512-ztZYMDZ75lHhlxGfK1XUj0+s/i27h9XcQH41dr9BM7m1J4gBlEa19am//yzjD2mKgNU3DFYJxtWLVj089iXzig==",
+      "version": "0.2.534",
+      "resolved": "https://registry.npmjs.org/@dust-tt/sparkle/-/sparkle-0.2.534.tgz",
+      "integrity": "sha512-t5/6miwIqh2rvK2XgTs2cHi0/ecyDVDxYsOQSlfGhvsYbgQP4fR6SvVaHoQSHyolltfJL0ZLPK/S09GiW7C5eA==",
       "dependencies": {
         "@emoji-mart/data": "^1.1.2",
         "@emoji-mart/react": "^1.1.1",

--- a/extension/package.json
+++ b/extension/package.json
@@ -58,7 +58,7 @@
   "dependencies": {
     "@auth0/auth0-spa-js": "^2.1.3",
     "@dust-tt/client": "^1.0.57",
-    "@dust-tt/sparkle": "^0.2.533",
+    "@dust-tt/sparkle": "^0.2.534",
     "@frontapp/plugin-sdk": "^1.8.1",
     "@modelcontextprotocol/sdk": "^1.9.0",
     "@tailwindcss/forms": "^0.5.9",

--- a/front/components/actions/mcp/AddActionMenu.tsx
+++ b/front/components/actions/mcp/AddActionMenu.tsx
@@ -65,7 +65,7 @@ export const AddActionMenu = ({
             <Button
               icon={PlusIcon}
               label="Add MCP Server"
-              // Required given onClick passes a MouseEvent
+              // Empty call is required given onClick passes a MouseEvent
               onClick={() => createRemoteMCPServer()}
             />
           }

--- a/front/components/actions/mcp/AddActionMenu.tsx
+++ b/front/components/actions/mcp/AddActionMenu.tsx
@@ -12,7 +12,7 @@ import { useState } from "react";
 
 import { getMcpServerDisplayName } from "@app/lib/actions/mcp_helper";
 import { getAvatar } from "@app/lib/actions/mcp_icons";
-import type {DefaultRemoteMCPServerConfig} from "@app/lib/actions/mcp_internal_actions/remote_servers";
+import type { DefaultRemoteMCPServerConfig } from "@app/lib/actions/mcp_internal_actions/remote_servers";
 import {
   getDefaultRemoteMCPServerByName
 } from "@app/lib/actions/mcp_internal_actions/remote_servers";

--- a/front/components/actions/mcp/AddActionMenu.tsx
+++ b/front/components/actions/mcp/AddActionMenu.tsx
@@ -65,7 +65,8 @@ export const AddActionMenu = ({
             <Button
               icon={PlusIcon}
               label="Add MCP Server"
-              onClick={() => createRemoteMCPServer(undefined)}
+              // Required given onClick passes a MouseEvent
+              onClick={() => createRemoteMCPServer()}
             />
           }
         />

--- a/front/components/actions/mcp/AddActionMenu.tsx
+++ b/front/components/actions/mcp/AddActionMenu.tsx
@@ -12,6 +12,10 @@ import { useState } from "react";
 
 import { getMcpServerDisplayName } from "@app/lib/actions/mcp_helper";
 import { getAvatar } from "@app/lib/actions/mcp_icons";
+import type {DefaultRemoteMCPServerConfig} from "@app/lib/actions/mcp_internal_actions/remote_servers";
+import {
+  getDefaultRemoteMCPServerByName
+} from "@app/lib/actions/mcp_internal_actions/remote_servers";
 import type { MCPServerType } from "@app/lib/api/mcp";
 import { filterMCPServer } from "@app/lib/mcp";
 import { useAvailableMCPServers } from "@app/lib/swr/mcp_servers";
@@ -22,7 +26,9 @@ type AddActionMenuProps = {
   enabledMCPServers: string[];
   buttonVariant?: "primary" | "outline";
   createInternalMCPServer: (mcpServer: MCPServerType) => void;
-  createRemoteMCPServer: () => void;
+  createRemoteMCPServer: (
+    defaultServerConfig?: DefaultRemoteMCPServerConfig
+  ) => void;
   setIsLoading: (isLoading: boolean) => void;
 };
 
@@ -80,7 +86,14 @@ export const AddActionMenu = ({
               icon={() => getAvatar(mcpServer, "xs")}
               description={mcpServer.description}
               onClick={async () => {
-                createInternalMCPServer(mcpServer);
+                const remoteMcpServer = getDefaultRemoteMCPServerByName(
+                  mcpServer.name
+                );
+                if (remoteMcpServer) {
+                  createRemoteMCPServer(remoteMcpServer);
+                } else {
+                  createInternalMCPServer(mcpServer);
+                }
               }}
             />
           ))}

--- a/front/components/actions/mcp/AddActionMenu.tsx
+++ b/front/components/actions/mcp/AddActionMenu.tsx
@@ -13,9 +13,7 @@ import { useState } from "react";
 import { getMcpServerDisplayName } from "@app/lib/actions/mcp_helper";
 import { getAvatar } from "@app/lib/actions/mcp_icons";
 import type { DefaultRemoteMCPServerConfig } from "@app/lib/actions/mcp_internal_actions/remote_servers";
-import {
-  getDefaultRemoteMCPServerByName
-} from "@app/lib/actions/mcp_internal_actions/remote_servers";
+import { getDefaultRemoteMCPServerByName } from "@app/lib/actions/mcp_internal_actions/remote_servers";
 import type { MCPServerType } from "@app/lib/api/mcp";
 import { filterMCPServer } from "@app/lib/mcp";
 import { useAvailableMCPServers } from "@app/lib/swr/mcp_servers";
@@ -67,7 +65,7 @@ export const AddActionMenu = ({
             <Button
               icon={PlusIcon}
               label="Add MCP Server"
-              onClick={createRemoteMCPServer}
+              onClick={() => createRemoteMCPServer(undefined)}
             />
           }
         />

--- a/front/components/actions/mcp/AdminActionsList.tsx
+++ b/front/components/actions/mcp/AdminActionsList.tsx
@@ -18,6 +18,7 @@ import {
   mcpServersSortingFn,
 } from "@app/lib/actions/mcp_helper";
 import { getAvatar } from "@app/lib/actions/mcp_icons";
+import type {DefaultRemoteMCPServerConfig} from "@app/lib/actions/mcp_internal_actions/remote_servers";
 import type { MCPServerType, MCPServerViewType } from "@app/lib/api/mcp";
 import { filterMCPServer } from "@app/lib/mcp";
 import {
@@ -86,6 +87,9 @@ export const AdminActionsList = ({
   const [internalMCPServerToCreate, setInternalMCPServerToCreate] = useState<
     MCPServerType | undefined
   >();
+  const [defaultServerConfig, setDefaultServerConfig] = useState<
+    DefaultRemoteMCPServerConfig | undefined
+  >();
   const { spaces } = useSpacesAsAdmin({
     workspaceId: owner.sId,
     disabled: false,
@@ -110,14 +114,18 @@ export const AdminActionsList = ({
     containerId: ACTION_BUTTONS_CONTAINER_ID,
   });
 
-  const onCreateRemoteMCPServer = () => {
+  const onCreateRemoteMCPServer = (
+    defaultServerConfig?: DefaultRemoteMCPServerConfig
+  ) => {
     setInternalMCPServerToCreate(undefined);
+    setDefaultServerConfig(defaultServerConfig);
     setIsCreateOpen(true);
   };
 
   const onCreateInternalMCPServer = async (mcpServer: MCPServerType) => {
     if (mcpServer.authorization) {
       setInternalMCPServerToCreate(mcpServer);
+      setDefaultServerConfig(undefined);
       setIsCreateOpen(true);
     } else {
       setIsLoading(true);
@@ -261,6 +269,7 @@ export const AdminActionsList = ({
         setIsLoading={setIsLoading}
         owner={owner}
         setMCPServerToShow={setMcpServerToShow}
+        defaultServerConfig={defaultServerConfig}
       />
       {rows.length > 0 &&
         portalToHeader(

--- a/front/components/actions/mcp/AdminActionsList.tsx
+++ b/front/components/actions/mcp/AdminActionsList.tsx
@@ -18,7 +18,7 @@ import {
   mcpServersSortingFn,
 } from "@app/lib/actions/mcp_helper";
 import { getAvatar } from "@app/lib/actions/mcp_icons";
-import type {DefaultRemoteMCPServerConfig} from "@app/lib/actions/mcp_internal_actions/remote_servers";
+import type { DefaultRemoteMCPServerConfig } from "@app/lib/actions/mcp_internal_actions/remote_servers";
 import type { MCPServerType, MCPServerViewType } from "@app/lib/api/mcp";
 import { filterMCPServer } from "@app/lib/mcp";
 import {

--- a/front/components/actions/mcp/CreateMCPServerDialog.tsx
+++ b/front/components/actions/mcp/CreateMCPServerDialog.tsx
@@ -1,12 +1,10 @@
 import {
-  Button,
   Dialog,
   DialogContainer,
   DialogContent,
   DialogFooter,
   DialogHeader,
   DialogTitle,
-  ExternalLinkIcon,
   Input,
   Label,
   SliderToggle,
@@ -84,10 +82,7 @@ export function CreateMCPServerDialog({
       setRemoteServerUrl(defaultServerConfig.url);
     }
     if (defaultServerConfig && isOpen) {
-      setRequiresBearerToken(
-        defaultServerConfig.authMethod === "bearer" &&
-          defaultServerConfig.requiresAuth
-      );
+      setRequiresBearerToken(defaultServerConfig.authMethod === "bearer");
     }
   }, [defaultServerConfig, isOpen]);
 
@@ -271,72 +266,63 @@ export function CreateMCPServerDialog({
           <DialogTitle>
             {internalMCPServer
               ? `Add ${getMcpServerDisplayName(internalMCPServer)}`
-              : "Add MCP Server"}
+              : defaultServerConfig
+                ? `Add ${defaultServerConfig.name}`
+                : "Add MCP Server"}
           </DialogTitle>
         </DialogHeader>
         <DialogContainer>
           {!internalMCPServer && !authorization && (
             <>
               {defaultServerConfig && (
-                <div className="space-y-4 rounded-lg border bg-muted/50 p-4">
-                  <div className="flex items-start justify-between">
-                    <div>
-                      <h3 className="text-sm font-semibold">
-                        {defaultServerConfig.name} Remote Server
-                      </h3>
-                      <p className="mt-1 text-sm text-muted-foreground">
-                        {defaultServerConfig.description}
-                      </p>
-                    </div>
+                <div className="mb-4">
+                  <p className="text-sm text-muted-foreground">
+                    {defaultServerConfig.description}
                     {defaultServerConfig.documentationUrl && (
-                      <Button
-                        variant="ghost"
-                        size="sm"
-                        onClick={() =>
-                          window.open(
-                            defaultServerConfig.documentationUrl,
-                            "_blank"
-                          )
-                        }
-                        icon={ExternalLinkIcon}
-                        label="Documentation"
-                      />
+                      <>
+                        {" "}
+                        <a
+                          href={defaultServerConfig.documentationUrl}
+                          target="_blank"
+                          rel="noopener noreferrer"
+                          className="text-primary hover:underline"
+                        >
+                          See {defaultServerConfig.name} documentation.
+                        </a>
+                      </>
                     )}
-                  </div>
+                  </p>
                   {defaultServerConfig.connectionInstructions && (
-                    <div className="text-sm text-muted-foreground">
+                    <p className="mt-2 text-sm text-muted-foreground">
                       {defaultServerConfig.connectionInstructions}
-                    </div>
+                    </p>
                   )}
                 </div>
               )}
 
-              <div className="space-y-2">
-                <Label htmlFor="url">URL</Label>
-                <div className="flex space-x-2">
-                  <div className="flex-grow">
-                    <Input
-                      id="url"
-                      placeholder="https://example.com/api/mcp"
-                      value={remoteServerUrl}
-                      onChange={(e) => setRemoteServerUrl(e.target.value)}
-                      isError={!!error}
-                      message={error}
-                      autoFocus
-                      disabled={!!defaultServerConfig?.url}
-                    />
+              {!defaultServerConfig?.url && (
+                <div className="space-y-2">
+                  <Label htmlFor="url">URL</Label>
+                  <div className="flex space-x-2">
+                    <div className="flex-grow">
+                      <Input
+                        id="url"
+                        placeholder="https://example.com/api/mcp"
+                        value={remoteServerUrl}
+                        onChange={(e) => setRemoteServerUrl(e.target.value)}
+                        isError={!!error}
+                        message={error}
+                        autoFocus
+                      />
+                    </div>
                   </div>
                 </div>
-                {defaultServerConfig?.url && (
-                  <div className="text-sm text-muted-foreground">
-                    This is a trusted remote MCP server. The URL is
-                    pre-configured and cannot be changed.
-                  </div>
-                )}
-              </div>
+              )}
               <div className="space-y-2">
                 <Label htmlFor="requiresBearerToken">
-                  Requires Bearer Token
+                  {defaultServerConfig?.authMethod === "bearer"
+                    ? `${defaultServerConfig.name} API Key`
+                    : "Authentication"}
                 </Label>
                 <div className="flex items-center space-x-2">
                   {!defaultServerConfig && (
@@ -365,7 +351,8 @@ export function CreateMCPServerDialog({
                       value={sharedSecret}
                       onChange={(e) => setSharedSecret(e.target.value)}
                       isError={
-                        defaultServerConfig?.requiresAuth && !sharedSecret
+                        defaultServerConfig?.authMethod === "bearer" &&
+                        !sharedSecret
                       }
                     />
                   </div>
@@ -404,7 +391,7 @@ export function CreateMCPServerDialog({
             disabled:
               !isOAuthFormValid ||
               (authorization && !useCase) ||
-              (defaultServerConfig?.requiresAuth && !sharedSecret) ||
+              (defaultServerConfig?.authMethod === "bearer" && !sharedSecret) ||
               isLoading,
           }}
         />

--- a/front/components/actions/mcp/CreateMCPServerDialog.tsx
+++ b/front/components/actions/mcp/CreateMCPServerDialog.tsx
@@ -336,9 +336,7 @@ export function CreateMCPServerDialog({
               </div>
               <div className="space-y-2">
                 <Label htmlFor="requiresBearerToken">
-                  {defaultServerConfig?.authMethod === "bearer"
-                    ? `${defaultServerConfig.authMethod === "bearer" ? "Bearer Token" : "Authentication"} (Required)`
-                    : "Requires Bearer Token"}
+                  Requires Bearer Token
                 </Label>
                 <div className="flex items-center space-x-2">
                   {!defaultServerConfig && (

--- a/front/components/actions/mcp/RemoteMCPForm.tsx
+++ b/front/components/actions/mcp/RemoteMCPForm.tsx
@@ -20,6 +20,7 @@ import { z } from "zod";
 
 import { DEFAULT_MCP_ACTION_DESCRIPTION } from "@app/lib/actions/constants";
 import { getMcpServerDisplayName } from "@app/lib/actions/mcp_helper";
+import { isDefaultRemoteMcpServerURL } from "@app/lib/actions/mcp_internal_actions/remote_servers";
 import type { RemoteMCPServerType } from "@app/lib/api/mcp";
 import {
   useSyncRemoteMCPServer,
@@ -44,6 +45,9 @@ export type MCPFormType = z.infer<typeof MCPFormSchema>;
 export function RemoteMCPForm({ owner, mcpServer }: RemoteMCPFormProps) {
   const [isSynchronizing, setIsSynchronizing] = useState(false);
   const [isPopoverOpen, setIsPopoverOpen] = useState(false);
+
+  // Check if this is a default server (should be read-only for name/description)
+  const isDefaultServer = isDefaultRemoteMcpServerURL(mcpServer.url);
 
   const form = useForm<MCPFormType>({
     resolver: zodResolver(MCPFormSchema),
@@ -130,6 +134,7 @@ export function RemoteMCPForm({ owner, mcpServer }: RemoteMCPFormProps) {
               <Input
                 {...field}
                 label="Name"
+                disabled={isDefaultServer}
                 isError={!!form.formState.errors.name}
                 message={form.formState.errors.name?.message}
                 placeholder={mcpServer.cachedName}
@@ -155,6 +160,7 @@ export function RemoteMCPForm({ owner, mcpServer }: RemoteMCPFormProps) {
                     icon={CurrentIconComponent}
                     onClick={() => setIsPopoverOpen(true)}
                     isSelect
+                    disabled={isDefaultServer}
                   />
                 </PopoverTrigger>
                 <PopoverContent
@@ -186,6 +192,7 @@ export function RemoteMCPForm({ owner, mcpServer }: RemoteMCPFormProps) {
               <Input
                 {...field}
                 label="Description"
+                disabled={isDefaultServer}
                 isError={!!form.formState.errors.description?.message}
                 message={form.formState.errors.description?.message}
                 placeholder={

--- a/front/lib/actions/configuration/mcp.ts
+++ b/front/lib/actions/configuration/mcp.ts
@@ -7,8 +7,8 @@ import {
 } from "@app/lib/actions/configuration/helpers";
 import type { MCPServerConfigurationType } from "@app/lib/actions/mcp";
 import type {
+  CustomServerIconType,
   InternalAllowedIconType,
-  RemoteAllowedIconType,
 } from "@app/lib/actions/mcp_icons";
 import type { Authenticator } from "@app/lib/auth";
 import { AgentDataSourceConfiguration } from "@app/lib/models/assistant/actions/data_sources";
@@ -133,10 +133,8 @@ export async function fetchMCPServerActionConfigurations(
     );
     let serverName: string | null = null;
     let serverDescription: string | null = null;
-    let serverIcon:
-      | InternalAllowedIconType
-      | RemoteAllowedIconType
-      | undefined = undefined;
+    let serverIcon: InternalAllowedIconType | CustomServerIconType | undefined =
+      undefined;
 
     if (!mcpServerView) {
       logger.warn(

--- a/front/lib/actions/constants.ts
+++ b/front/lib/actions/constants.ts
@@ -52,11 +52,11 @@ export const DEFAULT_MCP_ACTION_VERSION = "1.0.0";
 export const DEFAULT_MCP_ACTION_DESCRIPTION =
   "Call a tool to answer a question.";
 
-export const REMOTE_MCP_TOOL_STAKE_LEVELS = ["high", "low"] as const;
-export type RemoteMCPToolStakeLevelType =
-  (typeof REMOTE_MCP_TOOL_STAKE_LEVELS)[number];
+export const CUSTOM_REMOTE_MCP_TOOL_STAKE_LEVELS = ["high", "low"] as const;
+export type CustomRemoteMCPToolStakeLevelType =
+  (typeof CUSTOM_REMOTE_MCP_TOOL_STAKE_LEVELS)[number];
 export const MCP_TOOL_STAKE_LEVELS = [
-  ...REMOTE_MCP_TOOL_STAKE_LEVELS,
+  ...CUSTOM_REMOTE_MCP_TOOL_STAKE_LEVELS,
   "never_ask",
 ] as const;
 export type MCPToolStakeLevelType = (typeof MCP_TOOL_STAKE_LEVELS)[number];

--- a/front/lib/actions/constants.ts
+++ b/front/lib/actions/constants.ts
@@ -1,6 +1,6 @@
 import type {
+  CustomServerIconType,
   InternalAllowedIconType,
-  RemoteAllowedIconType,
 } from "@app/lib/actions/mcp_icons";
 
 // Stored in a separate file to prevent a circular dependency issue.
@@ -79,5 +79,5 @@ export type MCPValidationMetadataType = {
   mcpServerName: string;
   agentName: string;
   pubsubMessageId?: string;
-  icon?: InternalAllowedIconType | RemoteAllowedIconType;
+  icon?: InternalAllowedIconType | CustomServerIconType;
 };

--- a/front/lib/actions/mcp.ts
+++ b/front/lib/actions/mcp.ts
@@ -11,8 +11,8 @@ import type { DustAppRunConfigurationType } from "@app/lib/actions/dust_app_run"
 import { tryCallMCPTool } from "@app/lib/actions/mcp_actions";
 import { MCPServerPersonalAuthenticationRequiredError } from "@app/lib/actions/mcp_authentication";
 import type {
+  CustomServerIconType,
   InternalAllowedIconType,
-  RemoteAllowedIconType,
 } from "@app/lib/actions/mcp_icons";
 import type { MCPServerAvailability } from "@app/lib/actions/mcp_internal_actions/constants";
 import {
@@ -104,7 +104,7 @@ export type BaseMCPServerConfigurationType = {
 
   name: string;
   description: string | null;
-  icon?: RemoteAllowedIconType | InternalAllowedIconType;
+  icon?: CustomServerIconType | InternalAllowedIconType;
 };
 
 // Server-side MCP server = Remote MCP Server OR our own MCP server.
@@ -373,7 +373,7 @@ export class MCPActionType extends BaseAction {
     const totalTextLength =
       this.output?.reduce(
         (acc, curr) =>
-          acc + (curr.type === "text" ? curr.text?.length ?? 0 : 0),
+          acc + (curr.type === "text" ? (curr.text?.length ?? 0) : 0),
         0
       ) ?? 0;
 
@@ -1023,7 +1023,7 @@ export class MCPConfigurationServerRunner extends BaseActionConfigurationServerR
 
               const fileName = isResourceWithName(block.resource)
                 ? block.resource.name
-                : block.resource.uri.split("/").pop() ?? "generated-file";
+                : (block.resource.uri.split("/").pop() ?? "generated-file");
 
               const fileUpsertResult = await processAndStoreFromUrl(auth, {
                 url: block.resource.uri,

--- a/front/lib/actions/mcp.ts
+++ b/front/lib/actions/mcp.ts
@@ -373,7 +373,7 @@ export class MCPActionType extends BaseAction {
     const totalTextLength =
       this.output?.reduce(
         (acc, curr) =>
-          acc + (curr.type === "text" ? (curr.text?.length ?? 0) : 0),
+          acc + (curr.type === "text" ? curr.text?.length ?? 0 : 0),
         0
       ) ?? 0;
 
@@ -1023,7 +1023,7 @@ export class MCPConfigurationServerRunner extends BaseActionConfigurationServerR
 
               const fileName = isResourceWithName(block.resource)
                 ? block.resource.name
-                : (block.resource.uri.split("/").pop() ?? "generated-file");
+                : block.resource.uri.split("/").pop() ?? "generated-file";
 
               const fileUpsertResult = await processAndStoreFromUrl(auth, {
                 url: block.resource.uri,

--- a/front/lib/actions/mcp_actions.ts
+++ b/front/lib/actions/mcp_actions.ts
@@ -34,6 +34,7 @@ import {
 import { findMatchingSubSchemas } from "@app/lib/actions/mcp_internal_actions/input_configuration";
 import type { MCPProgressNotificationType } from "@app/lib/actions/mcp_internal_actions/output_schemas";
 import { isMCPProgressNotificationType } from "@app/lib/actions/mcp_internal_actions/output_schemas";
+import { getDefaultRemoteMCPServerById } from "@app/lib/actions/mcp_internal_actions/remote_servers";
 import type {
   MCPConnectionParams,
   ServerSideMCPConnectionParams,
@@ -792,6 +793,14 @@ async function listToolsForServerSideMCPServer(
         },
         {}
       );
+
+      // If no database overrides exist, fall back to default server configuration
+      if (Object.keys(toolsStakes).length === 0) {
+        const defaultServerConfig = getDefaultRemoteMCPServerById(id);
+        if (defaultServerConfig?.toolStakes) {
+          toolsStakes = defaultServerConfig.toolStakes;
+        }
+      }
       break;
     }
     default:

--- a/front/lib/actions/mcp_actions.ts
+++ b/front/lib/actions/mcp_actions.ts
@@ -34,7 +34,6 @@ import {
 import { findMatchingSubSchemas } from "@app/lib/actions/mcp_internal_actions/input_configuration";
 import type { MCPProgressNotificationType } from "@app/lib/actions/mcp_internal_actions/output_schemas";
 import { isMCPProgressNotificationType } from "@app/lib/actions/mcp_internal_actions/output_schemas";
-import { getDefaultRemoteMCPServerById } from "@app/lib/actions/mcp_internal_actions/remote_servers";
 import type {
   MCPConnectionParams,
   ServerSideMCPConnectionParams,
@@ -793,14 +792,6 @@ async function listToolsForServerSideMCPServer(
         },
         {}
       );
-
-      // If no database overrides exist, fall back to default server configuration
-      if (Object.keys(toolsStakes).length === 0) {
-        const defaultServerConfig = getDefaultRemoteMCPServerById(id);
-        if (defaultServerConfig?.toolStakes) {
-          toolsStakes = defaultServerConfig.toolStakes;
-        }
-      }
       break;
     }
     default:

--- a/front/lib/actions/mcp_icons.tsx
+++ b/front/lib/actions/mcp_icons.tsx
@@ -23,6 +23,7 @@ import {
   NotionLogo,
   SalesforceLogo,
   SlackLogo,
+  StripeLogo,
 } from "@dust-tt/sparkle";
 import type React from "react";
 import type { ComponentProps } from "react";
@@ -31,7 +32,7 @@ import type { MCPServerType } from "@app/lib/api/mcp";
 
 export const DEFAULT_MCP_SERVER_ICON = "ActionCommand1Icon" as const;
 
-export const REMOTE_ALLOWED_ICONS = Object.keys(ActionIcons);
+export const CUSTOM_SERVER_ALLOWED = Object.keys(ActionIcons);
 
 export const InternalActionIcons = {
   ActionBrainIcon,
@@ -56,16 +57,17 @@ export const InternalActionIcons = {
   GmailLogo,
   GcalLogo,
   SlackLogo,
+  StripeLogo,
 };
 
 export const INTERNAL_ALLOWED_ICONS = Object.keys(InternalActionIcons);
 
-export type RemoteAllowedIconType = keyof typeof ActionIcons;
+export type CustomServerIconType = keyof typeof ActionIcons;
 
-export const isRemoteAllowedIconType = (
+export const isCustomServerIconType = (
   icon: string
-): icon is RemoteAllowedIconType =>
-  REMOTE_ALLOWED_ICONS.includes(icon as RemoteAllowedIconType);
+): icon is CustomServerIconType =>
+  CUSTOM_SERVER_ALLOWED.includes(icon as CustomServerIconType);
 
 export type InternalAllowedIconType = keyof typeof InternalActionIcons;
 
@@ -82,10 +84,10 @@ export const getAvatar = (
 };
 
 export const getAvatarFromIcon = (
-  icon: InternalAllowedIconType | RemoteAllowedIconType,
+  icon: InternalAllowedIconType | CustomServerIconType,
   size: ComponentProps<typeof Avatar>["size"] = "sm"
 ): React.ReactNode => {
-  if (isRemoteAllowedIconType(icon)) {
+  if (isCustomServerIconType(icon)) {
     return <Avatar icon={ActionIcons[icon]} size={size} />;
   }
 

--- a/front/lib/actions/mcp_internal_actions/output_schemas.ts
+++ b/front/lib/actions/mcp_internal_actions/output_schemas.ts
@@ -8,12 +8,12 @@ import { z } from "zod";
 
 import { MCP_TOOL_STAKE_LEVELS } from "@app/lib/actions/constants";
 import type {
+  CustomServerIconType,
   InternalAllowedIconType,
-  RemoteAllowedIconType,
 } from "@app/lib/actions/mcp_icons";
 import {
+  CUSTOM_SERVER_ALLOWED,
   INTERNAL_ALLOWED_ICONS,
-  REMOTE_ALLOWED_ICONS,
 } from "@app/lib/actions/mcp_icons";
 import type { SupportedFileContentType } from "@app/types";
 import { CONNECTOR_PROVIDERS } from "@app/types";
@@ -674,8 +674,8 @@ const InternalAllowedIconSchema = z.enum(
   ]
 );
 
-const RemoteAllowedIconSchema = z.enum(
-  REMOTE_ALLOWED_ICONS as [RemoteAllowedIconType, ...RemoteAllowedIconType[]]
+const CustomServerIconSchema = z.enum(
+  CUSTOM_SERVER_ALLOWED as [CustomServerIconType, ...CustomServerIconType[]]
 );
 
 // Schema for the resource of a notification where the tool is asking for tool approval.
@@ -694,7 +694,7 @@ const NotificationToolApproveBubbleUpContentSchema = z.object({
     toolName: z.string(),
     agentName: z.string(),
     icon: z
-      .union([InternalAllowedIconSchema, RemoteAllowedIconSchema])
+      .union([InternalAllowedIconSchema, CustomServerIconSchema])
       .optional(),
   }),
 });

--- a/front/lib/actions/mcp_internal_actions/remote_servers.ts
+++ b/front/lib/actions/mcp_internal_actions/remote_servers.ts
@@ -10,10 +10,9 @@ export type DefaultRemoteMCPServerConfig = {
   icon: InternalAllowedIconType;
   documentationUrl?: string;
   connectionInstructions?: string;
-  authMethod: "bearer" | "oauth";
+  authMethod: "bearer" | "oauth" | null;
   supportedOAuthUseCases?: MCPOAuthUseCase[];
-  requiresAuth: boolean;
-  toolStakes?: Record<string, "high" | "low">;
+  toolStakes?: Record<string, "high" | "low" | "never_ask">;
 };
 
 export const DEFAULT_REMOTE_MCP_SERVERS: DefaultRemoteMCPServerConfig[] = [
@@ -27,9 +26,8 @@ export const DEFAULT_REMOTE_MCP_SERVERS: DefaultRemoteMCPServerConfig[] = [
     connectionInstructions:
       "You will need to provide your Stripe API key as a bearer token. We recommend using restricted API keys to limit access to the functionality your agents require.",
     authMethod: "bearer",
-    requiresAuth: true,
     toolStakes: {
-      search_documentation: "low",
+      search_documentation: "never_ask",
       list_customers: "low",
       list_products: "low",
       list_prices: "low",
@@ -62,7 +60,7 @@ export const isDefaultRemoteMcpServerURL = (url: string | undefined) => {
 };
 
 export const getDefaultRemoteMCPServerByURL = (
-  url: string
+  url: string | undefined
 ): DefaultRemoteMCPServerConfig | null => {
   return (
     DEFAULT_REMOTE_MCP_SERVERS.find((server) => server.url === url) || null

--- a/front/lib/actions/mcp_internal_actions/remote_servers.ts
+++ b/front/lib/actions/mcp_internal_actions/remote_servers.ts
@@ -1,0 +1,84 @@
+import type { MCPOAuthUseCase } from "@app/types";
+
+import type { InternalAllowedIconType } from "../mcp_icons";
+
+export type DefaultRemoteMCPServerConfig = {
+  id: number;
+  name: string;
+  description: string;
+  url: string;
+  icon: InternalAllowedIconType;
+  documentationUrl?: string;
+  connectionInstructions?: string;
+  authMethod: "bearer" | "oauth";
+  supportedOAuthUseCases?: MCPOAuthUseCase[];
+  requiresAuth: boolean;
+  toolStakes?: Record<string, "high" | "low">;
+};
+
+export const DEFAULT_REMOTE_MCP_SERVERS: DefaultRemoteMCPServerConfig[] = [
+  {
+    id: 10000,
+    name: "Stripe",
+    description: "Stripe tools for secure payment and billing operations.",
+    url: "https://mcp.stripe.com",
+    icon: "StripeLogo",
+    documentationUrl: "https://docs.stripe.com/building-with-llms",
+    connectionInstructions:
+      "You will need to provide your Stripe API key as a bearer token. We recommend using restricted API keys to limit access to the functionality your agents require.",
+    authMethod: "bearer",
+    requiresAuth: true,
+    toolStakes: {
+      search_documentation: "low",
+      list_customers: "low",
+      list_products: "low",
+      list_prices: "low",
+      list_invoices: "low",
+      list_payment_intents: "low",
+      list_subscriptions: "low",
+      list_coupons: "low",
+      list_disputes: "low",
+      get_stripe_account_info: "low",
+
+      create_customer: "high",
+      create_product: "high",
+      create_price: "high",
+      create_payment_link: "high",
+      create_invoice: "high",
+      create_invoice_item: "high",
+      finalize_invoice: "high",
+      retrieve_balance: "high",
+      create_refund: "high",
+      cancel_subscription: "high",
+      update_subscription: "high",
+      create_coupon: "high",
+      update_dispute: "high",
+    },
+  },
+];
+
+export const isDefaultRemoteMcpServerURL = (url: string | undefined) => {
+  return DEFAULT_REMOTE_MCP_SERVERS.some((server) => server.url === url);
+};
+
+export const getDefaultRemoteMCPServerByURL = (
+  url: string
+): DefaultRemoteMCPServerConfig | null => {
+  return (
+    DEFAULT_REMOTE_MCP_SERVERS.find((server) => server.url === url) || null
+  );
+};
+
+export const getDefaultRemoteMCPServerById = (
+  id: number
+): DefaultRemoteMCPServerConfig | null => {
+  return DEFAULT_REMOTE_MCP_SERVERS.find((server) => server.id === id) || null;
+};
+
+export const getDefaultRemoteMCPServerByName = (
+  name: string
+): DefaultRemoteMCPServerConfig | null => {
+  return (
+    DEFAULT_REMOTE_MCP_SERVERS.find((server) => server.name === name) || null
+  );
+};

--- a/front/lib/api/mcp.ts
+++ b/front/lib/api/mcp.ts
@@ -2,8 +2,8 @@ import type { JSONSchema7 as JSONSchema } from "json-schema";
 
 import type { MCPToolStakeLevelType } from "@app/lib/actions/constants";
 import type {
+  CustomServerIconType,
   InternalAllowedIconType,
-  RemoteAllowedIconType,
 } from "@app/lib/actions/mcp_icons";
 import type {
   InternalMCPServerNameType,
@@ -44,7 +44,7 @@ export type MCPServerType = {
   name: string;
   version: string;
   description: string;
-  icon: RemoteAllowedIconType | InternalAllowedIconType;
+  icon: CustomServerIconType | InternalAllowedIconType;
   authorization: AuthorizationInfo | null;
   tools: MCPToolType[];
   availability: MCPServerAvailability;
@@ -58,7 +58,7 @@ export type RemoteMCPServerType = MCPServerType & {
   sharedSecret?: string | null;
   lastSyncAt?: Date | null;
   lastError?: string | null;
-  icon: RemoteAllowedIconType; // We enforce that we pass an icon here (among the ones we allow).
+  icon: CustomServerIconType | InternalAllowedIconType;
 };
 
 export interface MCPServerViewType {

--- a/front/lib/models/assistant/actions/remote_mcp_server.ts
+++ b/front/lib/models/assistant/actions/remote_mcp_server.ts
@@ -2,7 +2,10 @@ import type { CreationOptional } from "sequelize";
 import { DataTypes } from "sequelize";
 
 import { DEFAULT_MCP_ACTION_VERSION } from "@app/lib/actions/constants";
-import type { RemoteAllowedIconType } from "@app/lib/actions/mcp_icons";
+import type {
+  CustomServerIconType,
+  InternalAllowedIconType,
+} from "@app/lib/actions/mcp_icons";
 import type { AuthorizationInfo } from "@app/lib/actions/mcp_metadata";
 import type { MCPToolType } from "@app/lib/api/mcp";
 import { frontSequelize } from "@app/lib/resources/storage";
@@ -15,7 +18,7 @@ export class RemoteMCPServerModel extends WorkspaceAwareModel<RemoteMCPServerMod
   declare url: string;
   declare name: string;
   declare description: string;
-  declare icon: RemoteAllowedIconType;
+  declare icon: CustomServerIconType | InternalAllowedIconType;
   declare version: string;
 
   declare cachedName: string;

--- a/front/lib/models/assistant/actions/remote_mcp_server_tool_metadata.ts
+++ b/front/lib/models/assistant/actions/remote_mcp_server_tool_metadata.ts
@@ -1,7 +1,7 @@
 import type { CreationOptional, ForeignKey } from "sequelize";
 import { DataTypes } from "sequelize";
 
-import type { RemoteMCPToolStakeLevelType } from "@app/lib/actions/constants";
+import type { MCPToolStakeLevelType } from "@app/lib/actions/constants";
 import { RemoteMCPServerModel } from "@app/lib/models/assistant/actions/remote_mcp_server";
 import { frontSequelize } from "@app/lib/resources/storage";
 import { WorkspaceAwareModel } from "@app/lib/resources/storage/wrappers/workspace_models";
@@ -12,7 +12,7 @@ export class RemoteMCPServerToolMetadataModel extends WorkspaceAwareModel<Remote
 
   declare remoteMCPServerId: ForeignKey<RemoteMCPServerModel["id"]>;
   declare toolName: string;
-  declare permission: RemoteMCPToolStakeLevelType;
+  declare permission: MCPToolStakeLevelType;
 }
 
 RemoteMCPServerToolMetadataModel.init(

--- a/front/lib/resources/remote_mcp_server_tool_metadata_resource.ts
+++ b/front/lib/resources/remote_mcp_server_tool_metadata_resource.ts
@@ -5,7 +5,7 @@ import type {
   Transaction,
 } from "sequelize";
 
-import type { RemoteMCPToolStakeLevelType } from "@app/lib/actions/constants";
+import type { MCPToolStakeLevelType } from "@app/lib/actions/constants";
 import type { Authenticator } from "@app/lib/auth";
 import { DustError } from "@app/lib/error";
 import { RemoteMCPServerToolMetadataModel } from "@app/lib/models/assistant/actions/remote_mcp_server_tool_metadata";
@@ -132,7 +132,7 @@ export class RemoteMCPServerToolMetadataResource extends BaseResource<RemoteMCPS
     }: {
       serverId: number;
       toolName: string;
-      permission: RemoteMCPToolStakeLevelType;
+      permission: MCPToolStakeLevelType;
     }
   ) {
     const canAdministrate =
@@ -191,7 +191,7 @@ export class RemoteMCPServerToolMetadataResource extends BaseResource<RemoteMCPS
   toJSON(): {
     remoteMCPServerId: number;
     toolName: string;
-    permission: RemoteMCPToolStakeLevelType;
+    permission: MCPToolStakeLevelType;
   } {
     return {
       remoteMCPServerId: this.remoteMCPServerId,

--- a/front/lib/resources/remote_mcp_servers_resource.ts
+++ b/front/lib/resources/remote_mcp_servers_resource.ts
@@ -12,7 +12,10 @@ import {
   DEFAULT_MCP_ACTION_NAME,
 } from "@app/lib/actions/constants";
 import { remoteMCPServerNameToSId } from "@app/lib/actions/mcp_helper";
-import type { RemoteAllowedIconType } from "@app/lib/actions/mcp_icons";
+import type {
+  CustomServerIconType,
+  InternalAllowedIconType,
+} from "@app/lib/actions/mcp_icons";
 import type { MCPServerType, MCPToolType } from "@app/lib/api/mcp";
 import type { Authenticator } from "@app/lib/auth";
 import { DustError } from "@app/lib/error";
@@ -288,7 +291,7 @@ export class RemoteMCPServerResource extends BaseResource<RemoteMCPServerModel> 
     }: {
       name?: string;
       description?: string;
-      icon?: RemoteAllowedIconType;
+      icon?: CustomServerIconType | InternalAllowedIconType;
       sharedSecret?: string;
       cachedName?: string;
       cachedDescription?: string;

--- a/front/lib/swr/mcp_servers.ts
+++ b/front/lib/swr/mcp_servers.ts
@@ -2,7 +2,7 @@ import { useSendNotification } from "@dust-tt/sparkle";
 import { useCallback, useMemo } from "react";
 import type { Fetcher } from "swr";
 
-import type { RemoteMCPToolStakeLevelType } from "@app/lib/actions/constants";
+import type { MCPToolStakeLevelType } from "@app/lib/actions/constants";
 import { mcpServerViewSortingFn } from "@app/lib/actions/mcp_helper";
 import {
   getMcpServerDisplayName,
@@ -713,7 +713,7 @@ export function useUpdateMCPServerToolsPermissions({
     permission,
   }: {
     toolName: string;
-    permission: RemoteMCPToolStakeLevelType;
+    permission: MCPToolStakeLevelType;
   }): Promise<PatchMCPServerToolsPermissionsResponseBody> => {
     const response = await fetch(
       `/api/w/${owner.sId}/mcp/${serverId}/tools/${toolName}`,

--- a/front/package-lock.json
+++ b/front/package-lock.json
@@ -7,7 +7,7 @@
       "dependencies": {
         "@auth0/nextjs-auth0": "^3.5.0",
         "@dust-tt/client": "file:../sdks/js",
-        "@dust-tt/sparkle": "^0.2.533",
+        "@dust-tt/sparkle": "^0.2.534",
         "@google-cloud/bigquery": "^7.9.1",
         "@google-cloud/storage-transfer": "^3.6.0",
         "@heroicons/react": "^2.0.11",
@@ -1105,9 +1105,9 @@
       "link": true
     },
     "node_modules/@dust-tt/sparkle": {
-      "version": "0.2.533",
-      "resolved": "https://registry.npmjs.org/@dust-tt/sparkle/-/sparkle-0.2.533.tgz",
-      "integrity": "sha512-ztZYMDZ75lHhlxGfK1XUj0+s/i27h9XcQH41dr9BM7m1J4gBlEa19am//yzjD2mKgNU3DFYJxtWLVj089iXzig==",
+      "version": "0.2.534",
+      "resolved": "https://registry.npmjs.org/@dust-tt/sparkle/-/sparkle-0.2.534.tgz",
+      "integrity": "sha512-t5/6miwIqh2rvK2XgTs2cHi0/ecyDVDxYsOQSlfGhvsYbgQP4fR6SvVaHoQSHyolltfJL0ZLPK/S09GiW7C5eA==",
       "dependencies": {
         "@emoji-mart/data": "^1.1.2",
         "@emoji-mart/react": "^1.1.1",

--- a/front/package.json
+++ b/front/package.json
@@ -24,7 +24,7 @@
   "dependencies": {
     "@auth0/nextjs-auth0": "^3.5.0",
     "@dust-tt/client": "file:../sdks/js",
-    "@dust-tt/sparkle": "^0.2.533",
+    "@dust-tt/sparkle": "^0.2.534",
     "@google-cloud/bigquery": "^7.9.1",
     "@google-cloud/storage-transfer": "^3.6.0",
     "@heroicons/react": "^2.0.11",

--- a/front/package.json
+++ b/front/package.json
@@ -24,7 +24,7 @@
   "dependencies": {
     "@auth0/nextjs-auth0": "^3.5.0",
     "@dust-tt/client": "file:../sdks/js",
-    "@dust-tt/sparkle": "^0.2.534",
+    "@dust-tt/sparkle": "^0.2.533",
     "@google-cloud/bigquery": "^7.9.1",
     "@google-cloud/storage-transfer": "^3.6.0",
     "@heroicons/react": "^2.0.11",

--- a/front/pages/api/w/[wId]/mcp/[serverId]/tools/index.ts
+++ b/front/pages/api/w/[wId]/mcp/[serverId]/tools/index.ts
@@ -1,6 +1,6 @@
 import type { NextApiRequest, NextApiResponse } from "next";
 
-import type { RemoteMCPToolStakeLevelType } from "@app/lib/actions/constants";
+import type { MCPToolStakeLevelType } from "@app/lib/actions/constants";
 import { getServerTypeAndIdFromSId } from "@app/lib/actions/mcp_helper";
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
 import type { Authenticator } from "@app/lib/auth";
@@ -11,7 +11,7 @@ import { assertNever } from "@app/types";
 
 export type GetMCPServerToolsPermissionsResponseBody = {
   permissions: {
-    [toolId: string]: RemoteMCPToolStakeLevelType;
+    [toolId: string]: MCPToolStakeLevelType;
   };
 };
 
@@ -56,7 +56,7 @@ async function handler(
             await RemoteMCPServerToolMetadataResource.fetchByServerId(auth, id);
 
           const permissions = resources.reduce(
-            (acc: { [key: string]: RemoteMCPToolStakeLevelType }, resource) => {
+            (acc: { [key: string]: MCPToolStakeLevelType }, resource) => {
               acc[resource.toolName] = resource.permission;
               return acc;
             },

--- a/front/pages/api/w/[wId]/mcp/available.ts
+++ b/front/pages/api/w/[wId]/mcp/available.ts
@@ -3,6 +3,7 @@ import type { NextApiRequest, NextApiResponse } from "next";
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
 import type { MCPServerType } from "@app/lib/api/mcp";
 import type { Authenticator } from "@app/lib/auth";
+import { DefaultRemoteMCPServerInMemoryResource } from "@app/lib/resources/default_remote_mcp_server_in_memory_resource";
 import { InternalMCPServerInMemoryResource } from "@app/lib/resources/internal_mcp_server_in_memory_resource";
 import { apiError } from "@app/logger/withlogging";
 import type { WithAPIErrorResponse } from "@app/types";
@@ -21,13 +22,23 @@ async function handler(
 
   switch (method) {
     case "GET": {
+      // Get internal servers
+      const internalServers = (
+        await InternalMCPServerInMemoryResource.listAvailableInternalMCPServers(
+          auth
+        )
+      ).map((r) => r.toJSON());
+
+      // Get default remote servers
+      const defaultRemoteServers = (
+        await DefaultRemoteMCPServerInMemoryResource.listAvailableDefaultRemoteMCPServers(
+          auth
+        )
+      ).map((r) => r.toJSON());
+
       return res.status(200).json({
         success: true,
-        servers: (
-          await InternalMCPServerInMemoryResource.listAvailableInternalMCPServers(
-            auth
-          )
-        ).map((r) => r.toJSON()),
+        servers: [...internalServers, ...defaultRemoteServers],
       });
     }
 

--- a/sdks/js/src/mcp_icon_types.ts
+++ b/sdks/js/src/mcp_icon_types.ts
@@ -23,6 +23,7 @@ export const MCPInternalActionIconSchema = z.enum([
   "GmailLogo",
   "GcalLogo",
   "SlackLogo",
+  "StripeLogo",
 ]);
 
 export const MCPExternalActionIconSchema = z.enum([

--- a/sparkle/package.json
+++ b/sparkle/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dust-tt/sparkle",
-  "version": "0.2.534",
+  "version": "0.2.533",
   "scripts": {
     "build": "rm -rf dist && npm run tailwind && npm run build:esm && npm run build:cjs",
     "tailwind": "tailwindcss -i ./src/styles/tailwind.css -o dist/sparkle.css",

--- a/sparkle/package.json
+++ b/sparkle/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dust-tt/sparkle",
-  "version": "0.2.533",
+  "version": "0.2.534",
   "scripts": {
     "build": "rm -rf dist && npm run tailwind && npm run build:esm && npm run build:cjs",
     "tailwind": "tailwindcss -i ./src/styles/tailwind.css -o dist/sparkle.css",


### PR DESCRIPTION
## Description

* Adding Stripe remote server that shows up in the available tool list by default. This works the same as custom remote servers, except the description and url cannot be changed
* Setting default tool stakes for known actions, but admin can override
* Setting static ID starting at 10000 (intentionally out of the range of internal MCP servers since they are defined separately)

Note: Will publish https://github.com/dust-tt/dust/pull/13991 first and bump the sparkle version in this PR. This should fix the lint errors.

See open decision: https://github.com/dust-tt/decisions/issues/474

## Tests

<img width="554" alt="Screenshot 2025-07-01 at 8 10 15 PM" src="https://github.com/user-attachments/assets/9c0e6725-c10e-4a42-9f1a-2acccb807c6e" />
<img width="557" alt="Screenshot 2025-07-02 at 3 43 26 PM" src="https://github.com/user-attachments/assets/53fa3221-6b0f-492b-b3d0-a0447f525172" />

<img width="612" alt="Screenshot 2025-07-01 at 10 26 31 PM" src="https://github.com/user-attachments/assets/2c436901-b218-4d2e-bc9c-9ed1ffd9d805" />


## Risk

* Only intended to be additive. First introduction of "default" remote server

## Deploy Plan

1. Publish sparkle version - https://github.com/dust-tt/dust/pull/13991
2. Bump spark version ID in this package
3. Deploy front

Migration should not be required for this change.