### PR TITLE
Resolve "Maximum call stack size exceeded" error with large base64 images in MCP tools

### DIFF
--- a/front/lib/actions/mcp_actions.ts
+++ b/front/lib/actions/mcp_actions.ts
@@ -24,6 +24,7 @@ import type {
   ServerSideMCPToolConfigurationType,
 } from "@app/lib/actions/mcp";
 import type { MCPServerPersonalAuthenticationRequiredError } from "@app/lib/actions/mcp_authentication";
+import { CallToolResultSchemaWithoutBase64Validation } from "@app/lib/actions/mcp_call_tool_result_schema";
 import { getServerTypeAndIdFromSId } from "@app/lib/actions/mcp_helper";
 import {
   getInternalMCPServerAvailability,
@@ -69,7 +70,6 @@ import { fromEvent } from "@app/lib/utils/events";
 import logger from "@app/logger/logger";
 import type { ModelId, Result } from "@app/types";
 import { assertNever, Err, normalizeError, Ok, slugify } from "@app/types";
-import { CallToolResultSchemaWithoutBase64Validation } from "@app/lib/actions/mcp_call_tool_result_schema";
 
 const MAX_OUTPUT_ITEMS = 128;
 

--- a/front/lib/actions/mcp_call_tool_result_schema.ts
+++ b/front/lib/actions/mcp_call_tool_result_schema.ts
@@ -1,3 +1,12 @@
+import {
+  AudioContentSchema,
+  EmbeddedResourceSchema,
+  CallToolResultSchema as OriginalCallToolResultSchema,
+  ImageContentSchema as OriginalImageContentSchema,
+  TextContentSchema,
+} from "@modelcontextprotocol/sdk/types.js";
+import { z } from "zod";
+
 /**
  * Forked MCP CallToolResult schemas to fix base64 validation circular reference issue.
  *
@@ -34,15 +43,6 @@
  * @see https://github.com/modelcontextprotocol/typescript-sdk for upstream MCP SDK
  */
 
-import { z } from "zod";
-import {
-  CallToolResultSchema as OriginalCallToolResultSchema,
-  TextContentSchema,
-  AudioContentSchema,
-  EmbeddedResourceSchema,
-  ImageContentSchema as OriginalImageContentSchema,
-} from "@modelcontextprotocol/sdk/types.js";
-
 // FORKED: Fixed ImageContentSchema without .base64() validation.
 export const ImageContentSchema = OriginalImageContentSchema.extend({
   /**
@@ -64,10 +64,11 @@ export const ContentBlockSchema = z.union([
 ]);
 
 // FORKED: CallToolResultSchema using our fixed ContentBlockSchema
-export const CallToolResultSchemaWithoutBase64Validation = OriginalCallToolResultSchema.extend({
-  /**
-   * Override content array to use our fixed ContentBlockSchema that doesn't
-   * validate base64 format for images.
-   */
-  content: z.array(ContentBlockSchema).default([]),
-});
+export const CallToolResultSchemaWithoutBase64Validation =
+  OriginalCallToolResultSchema.extend({
+    /**
+     * Override content array to use our fixed ContentBlockSchema that doesn't
+     * validate base64 format for images.
+     */
+    content: z.array(ContentBlockSchema).default([]),
+  });

--- a/front/lib/actions/mcp_call_tool_result_schema.ts
+++ b/front/lib/actions/mcp_call_tool_result_schema.ts
@@ -1,7 +1,7 @@
 import {
   AudioContentSchema,
-  EmbeddedResourceSchema,
   CallToolResultSchema as OriginalCallToolResultSchema,
+  EmbeddedResourceSchema,
   ImageContentSchema as OriginalImageContentSchema,
   TextContentSchema,
 } from "@modelcontextprotocol/sdk/types.js";

--- a/front/lib/actions/mcp_call_tool_result_schema.ts
+++ b/front/lib/actions/mcp_call_tool_result_schema.ts
@@ -1,0 +1,83 @@
+/**
+ * Forked MCP CallToolResult schemas to fix base64 validation circular reference issue.
+ *
+ * PROBLEM:
+ * The original MCP SDK's ImageContentSchema uses `z.string().base64()` which causes
+ * "RangeError: Maximum call stack size exceeded" errors when validating large base64
+ * image data (typically >1MB). This is a known bug in Zod's base64 validation regex
+ * that creates infinite recursion with large strings.
+ *
+ * ROOT CAUSE:
+ * - Zod's `.base64()` validator uses a complex regex that can cause stack overflow
+ * - The issue affects both Zod v3 and v4, particularly with large base64 strings
+ * - Image generation tools often return multi-MB base64 encoded images
+ * - The MCP SDK's strict validation triggers this bug during tool response processing
+ *
+ * RELATED ISSUES:
+ * - https://github.com/colinhacks/zod/issues/4283 (base64 validation stack overflow)
+ *
+ * SOLUTION:
+ * We fork only the ImageContentSchema to remove the `.base64()` validation while
+ * keeping all other MCP SDK type safety. This allows large image data to pass through
+ * without validation while maintaining the expected schema structure.
+ *
+ * TRADE-OFFS:
+ * - We lose base64 format validation for image data
+ * - We trust MCP servers to provide valid base64 (which they should anyway)
+ * - We avoid the stack overflow and maintain functionality
+ *
+ * TODO:
+ * Remove this workaround when either:
+ * 1. Zod fixes the base64 validation recursion bug, OR
+ * 2. MCP SDK switches to a different validation approach for large binary data
+ *
+ * @see https://github.com/modelcontextprotocol/typescript-sdk for upstream MCP SDK
+ */
+
+import { z } from "zod";
+import {
+  CallToolResultSchema as OriginalCallToolResultSchema,
+  TextContentSchema,
+  AudioContentSchema,
+  EmbeddedResourceSchema,
+} from "@modelcontextprotocol/sdk/types.js";
+
+// FORKED: Fixed ImageContentSchema without .base64() validation.
+export const ImageContentSchema = z
+  .object({
+    type: z.literal("image"),
+    /**
+     * The base64-encoded image data.
+     *
+     * IMPORTANT: We removed .base64() validation here to prevent "Maximum call stack
+     * size exceeded" errors with large image data. The MCP server is trusted to
+     * provide valid base64 encoding.
+     */
+    data: z.string(), // FIXED: was z.string().base64().
+    /**
+     * The MIME type of the image. Different providers may support different image types.
+     */
+    mimeType: z.string(),
+    /**
+     * See MCP specification for notes on _meta usage.
+     */
+    _meta: z.optional(z.object({}).passthrough()),
+  })
+  .passthrough();
+
+// FORKED: ContentBlockSchema using our fixed ImageContentSchema
+export const ContentBlockSchema = z.union([
+  TextContentSchema,
+  ImageContentSchema, // Uses our fixed version without base64 validation
+  AudioContentSchema,
+  EmbeddedResourceSchema,
+]);
+
+// FORKED: CallToolResultSchema using our fixed ContentBlockSchema
+export const CallToolResultSchemaWithoutBase64Validation = OriginalCallToolResultSchema.extend({
+  /**
+   * Override content array to use our fixed ContentBlockSchema that doesn't
+   * validate base64 format for images.
+   */
+  content: z.array(ContentBlockSchema).default([]),
+});

--- a/front/lib/actions/mcp_call_tool_result_schema.ts
+++ b/front/lib/actions/mcp_call_tool_result_schema.ts
@@ -40,30 +40,20 @@ import {
   TextContentSchema,
   AudioContentSchema,
   EmbeddedResourceSchema,
+  ImageContentSchema as OriginalImageContentSchema,
 } from "@modelcontextprotocol/sdk/types.js";
 
 // FORKED: Fixed ImageContentSchema without .base64() validation.
-export const ImageContentSchema = z
-  .object({
-    type: z.literal("image"),
-    /**
-     * The base64-encoded image data.
-     *
-     * IMPORTANT: We removed .base64() validation here to prevent "Maximum call stack
-     * size exceeded" errors with large image data. The MCP server is trusted to
-     * provide valid base64 encoding.
-     */
-    data: z.string(), // FIXED: was z.string().base64().
-    /**
-     * The MIME type of the image. Different providers may support different image types.
-     */
-    mimeType: z.string(),
-    /**
-     * See MCP specification for notes on _meta usage.
-     */
-    _meta: z.optional(z.object({}).passthrough()),
-  })
-  .passthrough();
+export const ImageContentSchema = OriginalImageContentSchema.extend({
+  /**
+   * The base64-encoded image data.
+   *
+   * IMPORTANT: We removed .base64() validation here to prevent "Maximum call stack
+   * size exceeded" errors with large image data. The MCP server is trusted to
+   * provide valid base64 encoding.
+   */
+  data: z.string(), // FIXED: was z.string().base64().
+});
 
 // FORKED: ContentBlockSchema using our fixed ImageContentSchema
 export const ContentBlockSchema = z.union([

--- a/front/lib/actions/mcp_internal_actions/servers/image_generation.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/image_generation.ts
@@ -176,6 +176,20 @@ const createServer = (auth: Authenticator): McpServer => {
           "Error generating image."
         );
 
+        if (error instanceof OpenAI.APIError) {
+          return {
+            isError: true,
+            content: [
+              {
+                type: "text",
+                text:
+                  `Error generating image. Image generation service error: Status: ` +
+                  `${error.status}, Code: ${error.code}, Message: ${error.message}`,
+              },
+            ],
+          };
+        }
+
         return {
           isError: true,
           content: [


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
This PR fixes: https://github.com/dust-tt/tasks/issues/3376

Image generation tools were failing with RangeError: Maximum call stack size exceeded when processing large base64-encoded images (typically >1MB). This error occurred during MCP SDK's response validation, specifically in Zod's base64 validation regex ([logs](https://app.datadoghq.eu/logs?query=%22Error%20calling%20MCP%20tool%20on%20run.%22%20%40actionName%3Aimage_generation__generate_image%20%40error%3A%22Maximum%20call%20stack%20size%20exceeded%22&agg_m=count&agg_m_source=base&agg_t=count&clustering_pattern_field_path=message&cols=host%2Cservice&messageDisplay=inline&refresh_mode=sliding&storage=hot&stream_sort=desc&viz=stream&from_ts=1750842303087&to_ts=1751447103087&live=true)).

**Stack trace:**
```
RangeError: Maximum call stack size exceeded
    at RegExp.test (<anonymous>)
    at ZodString._parse (/node_modules/zod/lib/types.js:804:34)
    at ZodUnion._parse (/node_modules/zod/lib/types.js:2376:39)
    at ZodArray._parse (/node_modules/zod/lib/types.js:1856:38)
    at /node_modules/@modelcontextprotocol/sdk/dist/cjs/shared/protocol.js:287:49
```

### Root Cause

This is a known bug in Zod's .base64() validator that affects both v3 and v4:

- Zod Issue: https://github.com/colinhacks/zod/issues/4283
- MCP SDK's ImageContentSchema uses z.string().base64() which triggers this bug with large image data
- Upgrading Zod version didn't resolve the issue - the bug persists even in Zod 3.25.67 -- we would need to upgrade to v4.

### Solution

Created a minimal workaround that removes only the problematic base64 validation while preserving all other type safety:
1. Forked MCP schemas with base64 validation removed, used default string
2. Minimal override: Used `OriginalImageContentSchema.extend()` to only change the data field validation
3. Preserved type safety: All other MCP SDK validation and types remain the same

I took the opportunity to improve the error exposed to the model as we get quite some failures ([logs](https://app.datadoghq.eu/logs?query=%22Error%20generating%20image.%22&agg_m=count&agg_m_source=base&agg_t=count&clustering_pattern_field_path=message&cols=host%2Cservice&event=AwAAAZfGeMcBF_yVnwAAABhBWmZHZU5tYUFBQTR1bnZxbnlQTkl3QUcAAAAkMDE5N2M2ODAtMzcxZi00M2Q5LTg4YzMtZGY1YTVmY2Q5MGE5AAQuXw&messageDisplay=inline&refresh_mode=sliding&storage=hot&stream_sort=desc&viz=stream&from_ts=1751127849524&to_ts=1751387049524&live=true)).

### Trade-offs
- ✅ Fixes: Stack overflow errors with large base64 images
- ✅ Maintains: All other MCP SDK type safety and validation
- ✅ Future-proof: Automatically inherits new MCP SDK schema updates
- ⚠️ Loses: Base64 format validation for image data (trusts MCP servers)

### Future Work

This workaround can be removed when either:
1. Zod backports the base64 validation recursion bug to 3.x version, or
2. MCP SDK switches to a different validation approach for large binary data

I may submit a PR to the MCP SDK repository to address this upstream, but this workaround ensures our image generation functionality works reliably in the meantime.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->
Tested image generation with some heavy prompt. Works like a charm!

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
