### PR TITLE
feat: get rid of emulated action

### DIFF
--- a/front/lib/actions/conversation/list_files.ts
+++ b/front/lib/actions/conversation/list_files.ts
@@ -1,10 +1,4 @@
-import {
-  DEFAULT_CONVERSATION_EXTRACT_ACTION_NAME,
-  DEFAULT_CONVERSATION_INCLUDE_FILE_ACTION_NAME,
-  DEFAULT_CONVERSATION_LIST_FILES_ACTION_NAME,
-  DEFAULT_CONVERSATION_QUERY_TABLES_ACTION_NAME,
-  DEFAULT_CONVERSATION_SEARCH_ACTION_NAME,
-} from "@app/lib/actions/constants";
+import { DEFAULT_CONVERSATION_LIST_FILES_ACTION_NAME } from "@app/lib/actions/constants";
 import type { ExtractActionBlob } from "@app/lib/actions/types";
 import { BaseAction } from "@app/lib/actions/types";
 import type { ConversationAttachmentType } from "@app/lib/api/assistant/conversation/attachments";
@@ -47,15 +41,7 @@ export class ConversationListFilesActionType extends BaseAction {
   }
 
   async renderForMultiActionsModel(): Promise<FunctionMessageTypeModel> {
-    let content =
-      `When a user attaches a file to the conversation, an <attachment> tag marks its position in the conversation history. ` +
-      `This tag indicates when the file was attached but does not contain its content. ` +
-      `Files attached to the conversation are listed below with their content type and status (includable, queryable, searchable):\n\n` +
-      `// includable: full content can be retrieved using \`${DEFAULT_CONVERSATION_INCLUDE_FILE_ACTION_NAME}\`\n` +
-      `// queryable: represents tabular data that can be queried alongside other queryable files' tabular data using \`${DEFAULT_CONVERSATION_QUERY_TABLES_ACTION_NAME}\`\n` +
-      `// searchable: content can be searched alongside other searchable files' content using \`${DEFAULT_CONVERSATION_SEARCH_ACTION_NAME}\`\n` +
-      `// extractable: files can also be processed to extract structured data using \`${DEFAULT_CONVERSATION_EXTRACT_ACTION_NAME}\`\n` +
-      `Other tools that accept files (referenced by their id) as arguments can be available. Rely on their description and the files mime types to decide which tool to use on which file.`;
+    let content = `The following files are currently attached to the conversation:\n`;
     for (const [i, attachment] of this.files.entries()) {
       if (i > 0) {
         content += "\n";

--- a/front/lib/api/assistant/generation.ts
+++ b/front/lib/api/assistant/generation.ts
@@ -1,5 +1,11 @@
 import moment from "moment-timezone";
 
+import {
+  DEFAULT_CONVERSATION_EXTRACT_ACTION_NAME,
+  DEFAULT_CONVERSATION_INCLUDE_FILE_ACTION_NAME,
+  DEFAULT_CONVERSATION_QUERY_TABLES_ACTION_NAME,
+  DEFAULT_CONVERSATION_SEARCH_ACTION_NAME,
+} from "@app/lib/actions/constants";
 import type { ServerToolsAndInstructions } from "@app/lib/actions/mcp_actions";
 import {
   isMCPConfigurationForInternalNotion,
@@ -120,6 +126,18 @@ export async function constructPromptMultiActions(
 
   toolsSection += toolServersPrompt;
 
+  const attachmentsSection =
+    "# ATTACHMENTS\n" +
+    "The conversation history may contain file attachments, indicated by <attachment> tags. " +
+    "Attachments may originate from the user directly or from tool outputs. " +
+    "These tags indicate when the file was attached but do not always contain the full contents (it may contain a small snippet or description of the file).\n" +
+    "Each file attachment has a specific content type and status (includable, queryable, searchable, extractable):\n\n" +
+    `// includable: full content can be retrieved using \`${DEFAULT_CONVERSATION_INCLUDE_FILE_ACTION_NAME}\`\n` +
+    `// queryable: represents tabular data that can be queried alongside other queryable files' tabular data using \`${DEFAULT_CONVERSATION_QUERY_TABLES_ACTION_NAME}\`\n` +
+    `// searchable: content can be searched alongside other searchable files' content using \`${DEFAULT_CONVERSATION_SEARCH_ACTION_NAME}\`\n` +
+    `// extractable: files can also be processed to extract structured data using \`${DEFAULT_CONVERSATION_EXTRACT_ACTION_NAME}\`\n` +
+    "Other tools that accept files (referenced by their id) as arguments can be available. Rely on their description and the files mime types to decide which tool to use on which file.\n";
+
   // GUIDELINES section
   let guidelinesSection = "# GUIDELINES\n";
   const canRetrieveDocuments = agentConfiguration.actions.some(
@@ -174,7 +192,7 @@ export async function constructPromptMultiActions(
     );
   }
 
-  const prompt = `${context}\n${toolsSection}\n${guidelinesSection}\n${instructions}`;
+  const prompt = `${context}\n${toolsSection}\n${attachmentsSection}\n${guidelinesSection}\n${instructions}`;
 
   return prompt;
 }

--- a/front/lib/api/assistant/jit_actions.ts
+++ b/front/lib/api/assistant/jit_actions.ts
@@ -6,7 +6,6 @@ import {
   DEFAULT_CONVERSATION_QUERY_TABLES_ACTION_DATA_DESCRIPTION,
   DEFAULT_CONVERSATION_QUERY_TABLES_ACTION_NAME,
 } from "@app/lib/actions/constants";
-import { makeConversationListFilesAction } from "@app/lib/actions/conversation/list_files";
 import type {
   MCPServerConfigurationType,
   ServerSideMCPServerConfigurationType,
@@ -23,10 +22,7 @@ import {
   isFileAttachmentType,
 } from "@app/lib/api/assistant/conversation/attachments";
 import { isMultiSheetSpreadsheetContentType } from "@app/lib/api/assistant/conversation/content_types";
-import {
-  isSearchableFolder,
-  listAttachments,
-} from "@app/lib/api/assistant/jit_utils";
+import { isSearchableFolder } from "@app/lib/api/assistant/jit_utils";
 import config from "@app/lib/api/config";
 import type { Authenticator } from "@app/lib/auth";
 import { DataSourceViewResource } from "@app/lib/resources/data_source_view_resource";
@@ -34,14 +30,10 @@ import { MCPServerViewResource } from "@app/lib/resources/mcp_server_view_resour
 import { generateRandomModelSId } from "@app/lib/resources/string_ids";
 import { concurrentExecutor } from "@app/lib/utils/async_utils";
 import logger from "@app/logger/logger";
-import type {
-  AgentActionType,
-  AgentMessageType,
-  ConversationType,
-} from "@app/types";
+import type { ConversationType } from "@app/types";
 import { assertNever, CoreAPI } from "@app/types";
 
-async function getJITServers(
+export async function getJITServers(
   auth: Authenticator,
   {
     conversation,
@@ -372,44 +364,6 @@ async function getJITServers(
   }
 
   return jitServers;
-}
-
-export async function getEmulatedActionsAndJITServers(
-  auth: Authenticator,
-  {
-    agentMessage,
-    conversation,
-  }: {
-    agentMessage: AgentMessageType;
-    conversation: ConversationType;
-  }
-): Promise<{
-  emulatedActions: AgentActionType[];
-  jitServers: MCPServerConfigurationType[];
-}> {
-  const emulatedActions: AgentActionType[] = [];
-
-  const attachments = listAttachments(conversation);
-  const a = makeConversationListFilesAction({
-    agentMessage,
-    attachments,
-  });
-  if (a) {
-    emulatedActions.push(a);
-  }
-
-  const jitServers = await getJITServers(auth, {
-    conversation,
-    attachments,
-  });
-
-  // We ensure that all emulated actions are injected with step -1.
-  assert(
-    emulatedActions.every((a) => a.step === -1),
-    "Emulated actions must have step -1"
-  );
-
-  return { emulatedActions, jitServers };
 }
 
 async function getTablesFromMultiSheetSpreadsheet(


### PR DESCRIPTION
## Description

- remove emulated action for "list files". Instead the model relies on conversation history to know which files are available
- add a prompt section in the meta prompt to guide usage of attachments (mostly moved from the list files instructions)


## Tests

Heavily tested locally

## Risk

Files can go out of scope and be forgotten (just like other messages)

## Deploy Plan

Deploy front