### PR TITLE
Remove use of authorization.scope for slack to simplify code

### DIFF
--- a/front/lib/actions/mcp_internal_actions/servers/slack.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/slack.ts
@@ -37,9 +37,6 @@ const serverInfo: InternalMCPServerDefinitionType = {
   authorization: {
     provider: "slack" as const,
     supported_use_cases: ["personal_actions"] as const,
-    // Use a magic prefix to split the scopes into user and bot scopes which is a slack specific thing.
-    scope:
-      "user_scope:chat:write user_scope:search:read user_scope:users:read user_scope:channels:read" as const,
   },
   icon: "SlackLogo",
   documentationUrl: "https://docs.dust.tt/docs/slack-tool-setup",

--- a/front/lib/api/oauth/providers/slack.ts
+++ b/front/lib/api/oauth/providers/slack.ts
@@ -203,10 +203,7 @@ export class SlackOAuthProvider implements BaseOAuthStrategyProvider {
     return extraConfig;
   }
 
-  isExtraConfigValid(extraConfig: ExtraConfigType, useCase: OAuthUseCase) {
-    if (useCase === "personal_actions" || useCase === "platform_actions") {
-      return "scope" in extraConfig;
-    }
+  isExtraConfigValid(extraConfig: ExtraConfigType) {
     return Object.keys(extraConfig).length === 0;
   }
 

--- a/front/lib/api/oauth/providers/slack.ts
+++ b/front/lib/api/oauth/providers/slack.ts
@@ -203,7 +203,12 @@ export class SlackOAuthProvider implements BaseOAuthStrategyProvider {
     return extraConfig;
   }
 
-  isExtraConfigValid(extraConfig: ExtraConfigType) {
+  isExtraConfigValid(extraConfig: ExtraConfigType, useCase: OAuthUseCase) {
+    if (useCase === "personal_actions") {
+      return (
+        Object.keys(extraConfig).length === 1 && "mcp_server_id" in extraConfig
+      );
+    }
     return Object.keys(extraConfig).length === 0;
   }
 


### PR DESCRIPTION
## Description

Fixes https://github.com/dust-tt/tasks/issues/3269

Instead of relying on `authorization.scope` we rely on the use-case to define the scope of the slack connection.

## Tests

Tested locally for both the bot and the slack MCP server.

## Risk

Low, minor refactor

## Deploy Plan

- deploy `front`