### PR TITLE
Improve Vizualisation style robustness

### DIFF
--- a/front/lib/api/assistant/visualization.ts
+++ b/front/lib/api/assistant/visualization.ts
@@ -22,10 +22,10 @@ Guidelines using the :::visualization directive:
   - The component should be able to adapt to different screen sizes
   - The content should never overflow the viewport and should never have horizontal or vertical scrollbars
 - Styling:
-  - Tailwind's arbitrary values like \`h-[600px]\` must never be used, as they are not available in the visualization environment.
-  - No tailwind class that include a square bracket should ever be used in the visualization code, as they will cause the visualization to fail for the user.
-  - When arbitrary / specific values are required, regular CSS (using the \`style\` prop) can be used as a fallback.
-  - For all other styles, Tailwind CSS classes should be preferred
+  - Tailwind's arbitrary values like \`h-[600px]\` STRICTLY FORBIDDEN, and will cause immediate failure. ANY class with square brackets [ ] is prohibited.
+  - FORBIDDEN EXAMPLES: \`h-[600px]\`, \`w-[800px]\`, \`text-[14px]\`, \`bg-[#ff0000]\`, \`border-[2px]\`, \`p-[20px]\`, \`m-[10px]\`
+  - ALLOWED ALTERNATIVES: Use predefined classes: \`h-96\`, \`w-full\`, \`text-sm\`, \`bg-red-500\`, \`border-2\`, \`p-5\`, \`m-2\`
+  - For specific values: Use the \`style\` prop instead: \`style={{ height: '600px', width: '800px' }}\`
   - Always use padding around plots to ensure elements are fully visible and labels/legends do not overlap with the plot or with each other.
   - Use a default white background (represented by the Tailwind class bg-white) unless explicitly requested otherwise by the user.
   - If you need to generate a legend for a chart, ensure it uses relative positioning or follows the natural flow of the layout, avoiding \`position: absolute\`, to maintain responsiveness and adaptability.

--- a/viz/app/components/VisualizationWrapper.tsx
+++ b/viz/app/components/VisualizationWrapper.tsx
@@ -15,6 +15,49 @@ import { useResizeDetector } from "react-resize-detector";
 import { importCode, Runner } from "react-runner";
 import * as rechartsAll from "recharts";
 
+// Regular expression to capture the value inside a className attribute. This pattern assumes
+// double quotes for simplicity.
+const classNameRegex = /className\s*=\s*"([^"]*)"/g;
+
+// Regular expression to capture Tailwind arbitrary values:
+// Matches a word boundary, then one or more lowercase letters or hyphens,
+// followed by a dash, an opening bracket, one or more non-']' characters, and a closing bracket.
+const arbitraryRegex = /\b[a-z-]+-\[[^\]]+\]/g;
+
+/**
+ * Validates that the generated code doesn't contain Tailwind arbitrary values.
+ *
+ * Arbitrary values like h-[600px], w-[800px], bg-[#ff0000] cause visualization failures
+ * because they're not included in our pre-built CSS. This validation fails fast with
+ * a clear error message that gets exposed to the user, allowing them to retry which
+ * provides the error details to the model for correction.
+ */
+function validateTailwindCode(code: string): void {
+  const matches: string[] = [];
+  let classMatch: RegExpExecArray | null = null;
+
+  // Iterate through all occurrences of the className attribute in the code.
+  while ((classMatch = classNameRegex.exec(code)) !== null) {
+    const classContent = classMatch[1];
+    if (classContent) {
+      // Find all matching arbitrary values within the class attribute's value.
+      const arbitraryMatches = classContent.match(arbitraryRegex) || [];
+      matches.push(...arbitraryMatches);
+    }
+  }
+
+  // If we found any, remove duplicates and throw an error with up to three examples.
+  if (matches.length > 0) {
+    const uniqueMatches = Array.from(new Set(matches));
+    const examples = uniqueMatches.slice(0, 3).join(", ");
+    throw new Error(
+      `Forbidden Tailwind arbitrary values detected: ${examples}. ` +
+        `Arbitrary values like h-[600px], w-[800px], bg-[#ff0000] are not allowed. ` +
+        `Use predefined classes like h-96, w-full, bg-red-500 instead, or use the style prop for specific values.`
+    );
+  }
+}
+
 export function useVisualizationAPI(
   sendCrossDocumentMessage: ReturnType<typeof makeSendCrossDocumentMessage>
 ) {
@@ -203,6 +246,10 @@ export function VisualizationWrapper({
         if (!fetchedCode) {
           setErrorMessage(new Error("No visualization code found"));
         } else {
+          // Validate Tailwind code before processing to catch arbitrary values early. Error gets
+          // exposed to user for retry, providing feedback to the model
+          validateTailwindCode(fetchedCode);
+
           setRunnerParams({
             code: "() => {import Comp from '@dust/generated-code'; return (<Comp />);}",
             scope: {


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
This PR fixes https://github.com/dust-tt/tasks/issues/3245.

Agents often end up using arbitrary values (e.g `h-[500px]`) when providing React code that should be rendered in a vizualisation. This cause blank/empty vizualisations that users can't see.

This PR strengthen the instructions and add a check to ensure we don't attempt to render code that use arbitrary value and instead with an explicit error exposing the faulty style. User will be able to retry afterward hopefully for the model to get things right.

<img width="852" alt="image" src="https://github.com/user-attachments/assets/09f6e721-ce14-4151-9ba5-22fecb888de4" />

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
