### PR TITLE
[front] chore: cleanup default action names

### DIFF
--- a/front/lib/actions/constants.ts
+++ b/front/lib/actions/constants.ts
@@ -16,8 +16,6 @@ export const DEFAULT_BROWSE_ACTION_DESCRIPTION =
 export const DEFAULT_PROCESS_ACTION_NAME =
   "extract_structured_data_from_data_sources";
 
-export const DEFAULT_RETRIEVAL_ACTION_NAME = "search_data_sources";
-
 export const DEFAULT_RETRIEVAL_NO_QUERY_ACTION_NAME = "include_data_sources";
 
 export const DEFAULT_WEBSEARCH_ACTION_NAME = "web_search_&_browse";

--- a/front/lib/actions/constants.ts
+++ b/front/lib/actions/constants.ts
@@ -12,8 +12,6 @@ export const PROCESS_ACTION_TOP_K = 768;
 export const DEFAULT_PROCESS_ACTION_NAME =
   "extract_structured_data_from_data_sources";
 
-export const DEFAULT_RETRIEVAL_NO_QUERY_ACTION_NAME = "include_data_sources";
-
 export const DEFAULT_WEBSEARCH_ACTION_NAME = "web_search_&_browse";
 export const DEFAULT_WEBSEARCH_ACTION_DESCRIPTION =
   "Agent can search (Google) and retrieve information from specific websites.";

--- a/front/lib/actions/constants.ts
+++ b/front/lib/actions/constants.ts
@@ -9,14 +9,16 @@ import type {
 // future based on user feedback.
 export const PROCESS_ACTION_TOP_K = 768;
 
+export const DEFAULT_BROWSE_ACTION_NAME = "browse";
+export const DEFAULT_BROWSE_ACTION_DESCRIPTION =
+  "Browse the content of a web page";
+
 export const DEFAULT_PROCESS_ACTION_NAME =
   "extract_structured_data_from_data_sources";
 
-export const DEFAULT_RETRIEVAL_ACTION_NAME = "semantic_search";
-export const DEFAULT_RETRIEVAL_ACTION_DESCRIPTION =
-  "Search the data sources specified by the user." +
-  " The search is based on semantic similarity between the query and chunks of information" +
-  " from the data sources.";
+export const DEFAULT_RETRIEVAL_ACTION_NAME = "search_data_sources";
+
+export const DEFAULT_RETRIEVAL_NO_QUERY_ACTION_NAME = "include_data_sources";
 
 export const DEFAULT_WEBSEARCH_ACTION_NAME = "web_search_&_browse";
 export const DEFAULT_WEBSEARCH_ACTION_DESCRIPTION =

--- a/front/lib/actions/constants.ts
+++ b/front/lib/actions/constants.ts
@@ -39,10 +39,6 @@ export const DEFAULT_CONVERSATION_EXTRACT_ACTION_DATA_DESCRIPTION = `Extract str
 export const DUST_CONVERSATION_HISTORY_MAGIC_INPUT_KEY =
   "__dust_conversation_history";
 
-export const DEFAULT_REASONING_ACTION_NAME = "advanced_reasoning";
-export const DEFAULT_REASONING_ACTION_DESCRIPTION =
-  "Offload a reasoning-heavy task to a powerful reasoning model. The reasoning model does not have access to any tools.";
-
 export const DEFAULT_DATA_VISUALIZATION_NAME = "data_visualization";
 export const DEFAULT_DATA_VISUALIZATION_DESCRIPTION =
   "Generate a data visualization.";

--- a/front/lib/actions/constants.ts
+++ b/front/lib/actions/constants.ts
@@ -39,7 +39,6 @@ export const DEFAULT_CONVERSATION_QUERY_TABLES_ACTION_DATA_DESCRIPTION = `The ta
 
 export const DEFAULT_CONVERSATION_SEARCH_ACTION_NAME =
   "search_conversation_files";
-export const DEFAULT_CONVERSATION_SEARCH_ACTION_DATA_DESCRIPTION = `Search within the 'searchable' conversation files as returned by \`${DEFAULT_CONVERSATION_LIST_FILES_ACTION_NAME}\``;
 
 export const DEFAULT_CONVERSATION_EXTRACT_ACTION_NAME =
   "extract_conversation_files";

--- a/front/lib/actions/constants.ts
+++ b/front/lib/actions/constants.ts
@@ -23,6 +23,8 @@ export const DEFAULT_WEBSEARCH_ACTION_DESCRIPTION =
   "Agent can search (Google) and retrieve information from specific websites.";
 
 export const DEFAULT_TABLES_QUERY_ACTION_NAME = "query_tables";
+export const DEFAULT_TABLES_QUERY_ACTION_DESCRIPTION =
+  "Tables, Spreadsheets, Notion DBs (quantitative).";
 
 export const DEFAULT_CONVERSATION_LIST_FILES_ACTION_NAME =
   "list_conversation_files";

--- a/front/lib/actions/constants.ts
+++ b/front/lib/actions/constants.ts
@@ -16,10 +16,6 @@ export const DEFAULT_WEBSEARCH_ACTION_NAME = "web_search_&_browse";
 export const DEFAULT_WEBSEARCH_ACTION_DESCRIPTION =
   "Agent can search (Google) and retrieve information from specific websites.";
 
-export const DEFAULT_TABLES_QUERY_ACTION_NAME = "query_tables";
-export const DEFAULT_TABLES_QUERY_ACTION_DESCRIPTION =
-  "Tables, Spreadsheets, Notion DBs (quantitative).";
-
 export const DEFAULT_CONVERSATION_LIST_FILES_ACTION_NAME =
   "list_conversation_files";
 

--- a/front/lib/actions/constants.ts
+++ b/front/lib/actions/constants.ts
@@ -9,16 +9,14 @@ import type {
 // future based on user feedback.
 export const PROCESS_ACTION_TOP_K = 768;
 
-export const DEFAULT_BROWSE_ACTION_NAME = "browse";
-export const DEFAULT_BROWSE_ACTION_DESCRIPTION =
-  "Browse the content of a web page";
-
 export const DEFAULT_PROCESS_ACTION_NAME =
   "extract_structured_data_from_data_sources";
 
-export const DEFAULT_RETRIEVAL_ACTION_NAME = "search_data_sources";
-
-export const DEFAULT_RETRIEVAL_NO_QUERY_ACTION_NAME = "include_data_sources";
+export const DEFAULT_RETRIEVAL_ACTION_NAME = "semantic_search";
+export const DEFAULT_RETRIEVAL_ACTION_DESCRIPTION =
+  "Search the data sources specified by the user." +
+  " The search is based on semantic similarity between the query and chunks of information" +
+  " from the data sources.";
 
 export const DEFAULT_WEBSEARCH_ACTION_NAME = "web_search_&_browse";
 export const DEFAULT_WEBSEARCH_ACTION_DESCRIPTION =

--- a/front/lib/actions/constants.ts
+++ b/front/lib/actions/constants.ts
@@ -9,10 +9,6 @@ import type {
 // future based on user feedback.
 export const PROCESS_ACTION_TOP_K = 768;
 
-export const DEFAULT_BROWSE_ACTION_NAME = "browse";
-export const DEFAULT_BROWSE_ACTION_DESCRIPTION =
-  "Browse the content of a web page";
-
 export const DEFAULT_PROCESS_ACTION_NAME =
   "extract_structured_data_from_data_sources";
 

--- a/front/lib/actions/constants.ts
+++ b/front/lib/actions/constants.ts
@@ -12,6 +12,10 @@ export const PROCESS_ACTION_TOP_K = 768;
 export const DEFAULT_PROCESS_ACTION_NAME =
   "extract_structured_data_from_data_sources";
 
+// If we have actions that used in global agents, we define the name and description of the action
+// (<=> of the internal MCP server) here and use it from here in both the internal MCP server
+// and `global_agents.ts`.
+
 export const DEFAULT_WEBSEARCH_ACTION_NAME = "web_search_&_browse";
 export const DEFAULT_WEBSEARCH_ACTION_DESCRIPTION =
   "Agent can search (Google) and retrieve information from specific websites.";

--- a/front/lib/actions/constants.ts
+++ b/front/lib/actions/constants.ts
@@ -20,8 +20,9 @@ export const DEFAULT_RETRIEVAL_ACTION_NAME = "search_data_sources";
 
 export const DEFAULT_RETRIEVAL_NO_QUERY_ACTION_NAME = "include_data_sources";
 
-export const DEFAULT_WEBSEARCH_ACTION_NAME = "web_search";
-export const DEFAULT_WEBSEARCH_ACTION_DESCRIPTION = "Perform a web search";
+export const DEFAULT_WEBSEARCH_ACTION_NAME = "web_search_&_browse";
+export const DEFAULT_WEBSEARCH_ACTION_DESCRIPTION =
+  "Agent can search (Google) and retrieve information from specific websites.";
 
 export const DEFAULT_TABLES_QUERY_ACTION_NAME = "query_tables";
 

--- a/front/lib/actions/constants.ts
+++ b/front/lib/actions/constants.ts
@@ -50,7 +50,7 @@ export const DUST_CONVERSATION_HISTORY_MAGIC_INPUT_KEY =
 
 export const DEFAULT_REASONING_ACTION_NAME = "advanced_reasoning";
 export const DEFAULT_REASONING_ACTION_DESCRIPTION =
-  "Offload a reasoning-heavy task to to a powerful reasoning model. The reasoning model does not have access to any tools.";
+  "Offload a reasoning-heavy task to a powerful reasoning model. The reasoning model does not have access to any tools.";
 
 export const DEFAULT_DATA_VISUALIZATION_NAME = "data_visualization";
 export const DEFAULT_DATA_VISUALIZATION_DESCRIPTION =

--- a/front/lib/actions/constants.ts
+++ b/front/lib/actions/constants.ts
@@ -12,7 +12,7 @@ export const PROCESS_ACTION_TOP_K = 768;
 export const DEFAULT_PROCESS_ACTION_NAME =
   "extract_structured_data_from_data_sources";
 
-// If we have actions that used in global agents, we define the name and description of the action
+// If we have actions that are used in global agents, we define the name and description of the action
 // (<=> of the internal MCP server) here and use it from here in both the internal MCP server
 // and `global_agents.ts`.
 

--- a/front/lib/actions/mcp_internal_actions/servers/reasoning.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/reasoning.ts
@@ -1,10 +1,6 @@
 import { assertNever, INTERNAL_MIME_TYPES } from "@dust-tt/client";
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 
-import {
-  DEFAULT_REASONING_ACTION_DESCRIPTION,
-  DEFAULT_REASONING_ACTION_NAME,
-} from "@app/lib/actions/constants";
 import { ConfigurableToolInputSchemas } from "@app/lib/actions/mcp_internal_actions/input_schemas";
 import type { MCPProgressNotificationType } from "@app/lib/actions/mcp_internal_actions/output_schemas";
 import { makeMCPToolTextError } from "@app/lib/actions/mcp_internal_actions/utils";
@@ -31,8 +27,8 @@ function createServer(
   const server = new McpServer(serverInfo);
 
   server.tool(
-    DEFAULT_REASONING_ACTION_NAME,
-    DEFAULT_REASONING_ACTION_DESCRIPTION,
+    "advanced_reasoning",
+    "Offload a reasoning-heavy task to a powerful reasoning model. The reasoning model does not have access to any tools.",
     {
       model:
         ConfigurableToolInputSchemas[

--- a/front/lib/actions/mcp_internal_actions/servers/search.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/search.ts
@@ -4,6 +4,10 @@ import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
 import assert from "assert";
 import { z } from "zod";
 
+import {
+  DEFAULT_RETRIEVAL_ACTION_DESCRIPTION,
+  DEFAULT_RETRIEVAL_ACTION_NAME,
+} from "@app/lib/actions/constants";
 import type { DataSourcesToolConfigurationType } from "@app/lib/actions/mcp_internal_actions/input_schemas";
 import { ConfigurableToolInputSchemas } from "@app/lib/actions/mcp_internal_actions/input_schemas";
 import type { SearchResultResourceType } from "@app/lib/actions/mcp_internal_actions/output_schemas";
@@ -45,8 +49,6 @@ const serverInfo: InternalMCPServerDefinitionType = {
   authorization: null,
   documentationUrl: null,
 };
-
-const SEARCH_TOOL_NAME = "semantic_search";
 
 export async function searchFunction({
   query,
@@ -287,33 +289,29 @@ function createServer(
 
   if (!areTagsDynamic) {
     server.tool(
-      SEARCH_TOOL_NAME,
-      "Search the data sources specified by the user." +
-        " The search is based on semantic similarity between the query and chunks of information" +
-        " from the data sources.",
+      DEFAULT_RETRIEVAL_ACTION_NAME,
+      DEFAULT_RETRIEVAL_ACTION_DESCRIPTION,
       commonInputsSchema,
-      withToolLogging(auth, SEARCH_TOOL_NAME, async (args) =>
+      withToolLogging(auth, DEFAULT_RETRIEVAL_ACTION_NAME, async (args) =>
         searchFunction({ ...args, auth, agentLoopContext })
       )
     );
   } else {
     server.tool(
-      SEARCH_TOOL_NAME,
-      "Search the data sources specified by the user." +
-        " The search is based on semantic similarity between the query and chunks of information" +
-        " from the data sources.",
+      DEFAULT_RETRIEVAL_ACTION_NAME,
+      DEFAULT_RETRIEVAL_ACTION_DESCRIPTION,
       {
         ...commonInputsSchema,
         ...tagsInputSchema,
       },
-      withToolLogging(auth, SEARCH_TOOL_NAME, async (args) =>
+      withToolLogging(auth, DEFAULT_RETRIEVAL_ACTION_NAME, async (args) =>
         searchFunction({ ...args, auth, agentLoopContext })
       )
     );
 
     server.tool(
       "find_tags",
-      makeFindTagsDescription(SEARCH_TOOL_NAME),
+      makeFindTagsDescription(DEFAULT_RETRIEVAL_ACTION_NAME),
       findTagsSchema,
       makeFindTagsTool(auth)
     );

--- a/front/lib/actions/mcp_internal_actions/servers/search.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/search.ts
@@ -4,10 +4,6 @@ import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
 import assert from "assert";
 import { z } from "zod";
 
-import {
-  DEFAULT_RETRIEVAL_ACTION_DESCRIPTION,
-  DEFAULT_RETRIEVAL_ACTION_NAME,
-} from "@app/lib/actions/constants";
 import type { DataSourcesToolConfigurationType } from "@app/lib/actions/mcp_internal_actions/input_schemas";
 import { ConfigurableToolInputSchemas } from "@app/lib/actions/mcp_internal_actions/input_schemas";
 import type { SearchResultResourceType } from "@app/lib/actions/mcp_internal_actions/output_schemas";
@@ -49,6 +45,8 @@ const serverInfo: InternalMCPServerDefinitionType = {
   authorization: null,
   documentationUrl: null,
 };
+
+const SEARCH_TOOL_NAME = "semantic_search";
 
 export async function searchFunction({
   query,
@@ -289,29 +287,33 @@ function createServer(
 
   if (!areTagsDynamic) {
     server.tool(
-      DEFAULT_RETRIEVAL_ACTION_NAME,
-      DEFAULT_RETRIEVAL_ACTION_DESCRIPTION,
+      SEARCH_TOOL_NAME,
+      "Search the data sources specified by the user." +
+        " The search is based on semantic similarity between the query and chunks of information" +
+        " from the data sources.",
       commonInputsSchema,
-      withToolLogging(auth, DEFAULT_RETRIEVAL_ACTION_NAME, async (args) =>
+      withToolLogging(auth, SEARCH_TOOL_NAME, async (args) =>
         searchFunction({ ...args, auth, agentLoopContext })
       )
     );
   } else {
     server.tool(
-      DEFAULT_RETRIEVAL_ACTION_NAME,
-      DEFAULT_RETRIEVAL_ACTION_DESCRIPTION,
+      SEARCH_TOOL_NAME,
+      "Search the data sources specified by the user." +
+        " The search is based on semantic similarity between the query and chunks of information" +
+        " from the data sources.",
       {
         ...commonInputsSchema,
         ...tagsInputSchema,
       },
-      withToolLogging(auth, DEFAULT_RETRIEVAL_ACTION_NAME, async (args) =>
+      withToolLogging(auth, SEARCH_TOOL_NAME, async (args) =>
         searchFunction({ ...args, auth, agentLoopContext })
       )
     );
 
     server.tool(
       "find_tags",
-      makeFindTagsDescription(DEFAULT_RETRIEVAL_ACTION_NAME),
+      makeFindTagsDescription(SEARCH_TOOL_NAME),
       findTagsSchema,
       makeFindTagsTool(auth)
     );

--- a/front/lib/actions/mcp_internal_actions/servers/tables_query/server.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/tables_query/server.ts
@@ -6,7 +6,10 @@ import {
   generateSectionFile,
   uploadFileToConversationDataSource,
 } from "@app/lib/actions/action_file_helpers";
-import { DEFAULT_TABLES_QUERY_ACTION_NAME } from "@app/lib/actions/constants";
+import {
+  DEFAULT_TABLES_QUERY_ACTION_DESCRIPTION,
+  DEFAULT_TABLES_QUERY_ACTION_NAME,
+} from "@app/lib/actions/constants";
 import { ConfigurableToolInputSchemas } from "@app/lib/actions/mcp_internal_actions/input_schemas";
 import type {
   ExecuteTablesQueryErrorResourceType,
@@ -45,7 +48,7 @@ export const TABLES_QUERY_SECTION_FILE_MIN_COLUMN_LENGTH = 500;
 const serverInfo: InternalMCPServerDefinitionType = {
   name: DEFAULT_TABLES_QUERY_ACTION_NAME,
   version: "1.0.0",
-  description: "Tables, Spreadsheets, Notion DBs (quantitative).",
+  description: DEFAULT_TABLES_QUERY_ACTION_DESCRIPTION,
   icon: "ActionTableIcon",
   authorization: null,
   documentationUrl: null,

--- a/front/lib/actions/mcp_internal_actions/servers/tables_query/server.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/tables_query/server.ts
@@ -6,10 +6,6 @@ import {
   generateSectionFile,
   uploadFileToConversationDataSource,
 } from "@app/lib/actions/action_file_helpers";
-import {
-  DEFAULT_TABLES_QUERY_ACTION_DESCRIPTION,
-  DEFAULT_TABLES_QUERY_ACTION_NAME,
-} from "@app/lib/actions/constants";
 import { ConfigurableToolInputSchemas } from "@app/lib/actions/mcp_internal_actions/input_schemas";
 import type {
   ExecuteTablesQueryErrorResourceType,
@@ -46,9 +42,9 @@ const RENDERED_CONVERSATION_MIN_TOKEN = 4_000;
 export const TABLES_QUERY_SECTION_FILE_MIN_COLUMN_LENGTH = 500;
 
 const serverInfo: InternalMCPServerDefinitionType = {
-  name: DEFAULT_TABLES_QUERY_ACTION_NAME,
+  name: "query_tables",
   version: "1.0.0",
-  description: DEFAULT_TABLES_QUERY_ACTION_DESCRIPTION,
+  description: "Tables, Spreadsheets, Notion DBs (quantitative).",
   icon: "ActionTableIcon",
   authorization: null,
   documentationUrl: null,

--- a/front/lib/actions/mcp_internal_actions/servers/webtools.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/webtools.ts
@@ -2,6 +2,10 @@ import { INTERNAL_MIME_TYPES } from "@dust-tt/client";
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod";
 
+import {
+  DEFAULT_WEBSEARCH_ACTION_DESCRIPTION,
+  DEFAULT_WEBSEARCH_ACTION_NAME,
+} from "@app/lib/actions/constants";
 import type {
   BrowseResultResourceType,
   WebsearchResultResourceType,
@@ -18,10 +22,9 @@ import {
 import { webSearch } from "@app/lib/utils/websearch";
 
 export const serverInfo: InternalMCPServerDefinitionType = {
-  name: "web_search_&_browse",
+  name: DEFAULT_WEBSEARCH_ACTION_NAME,
   version: "1.0.0",
-  description:
-    "Agent can search (Google) and retrieve information from specific websites.",
+  description: DEFAULT_WEBSEARCH_ACTION_DESCRIPTION,
   icon: "ActionGlobeAltIcon",
   authorization: null,
   documentationUrl: null,

--- a/front/lib/actions/mcp_internal_actions/servers/webtools.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/webtools.ts
@@ -16,9 +16,7 @@ import {
   isBrowseScrapeSuccessResponse,
 } from "@app/lib/utils/webbrowse";
 import { webSearch } from "@app/lib/utils/websearch";
-import type { OAuthProvider } from "@app/types";
 
-export const provider: OAuthProvider = "google_drive" as const;
 export const serverInfo: InternalMCPServerDefinitionType = {
   name: "web_search_&_browse",
   version: "1.0.0",

--- a/front/lib/api/assistant/configuration.ts
+++ b/front/lib/api/assistant/configuration.ts
@@ -1148,7 +1148,7 @@ export async function createAgentActionConfiguration(
         mcpConfig,
       });
     }
-    // Creating the AgentTablesQueryConfigurationTable if configured
+    // Creating the AgentReasoningConfiguration if configured
     if (action.reasoningModel) {
       await createReasoningConfiguration(auth, t, {
         reasoningModel: action.reasoningModel,

--- a/front/lib/api/assistant/global_agents.ts
+++ b/front/lib/api/assistant/global_agents.ts
@@ -2,7 +2,11 @@ import fs from "fs";
 import path from "path";
 import { promisify } from "util";
 
-import { DEFAULT_RETRIEVAL_ACTION_NAME } from "@app/lib/actions/constants";
+import {
+  DEFAULT_RETRIEVAL_ACTION_NAME,
+  DEFAULT_WEBSEARCH_ACTION_DESCRIPTION,
+  DEFAULT_WEBSEARCH_ACTION_NAME,
+} from "@app/lib/actions/constants";
 import type {
   MCPServerConfigurationType,
   ServerSideMCPServerConfigurationType,
@@ -150,11 +154,10 @@ function _getDefaultWebActionsForGlobalAgent({
       id: -1,
       sId: agentId + "-websearch-browse-action",
       type: "mcp_server_configuration",
-      name: "web_search_&_browse" satisfies InternalMCPServerNameType,
+      name: DEFAULT_WEBSEARCH_ACTION_NAME satisfies InternalMCPServerNameType,
       // Putting a description here is important as it prevents the global agent being detected as
       // a legacy agent (see isLegacyAgent) and being capped to 1 action.
-      description:
-        "Agent can search (Google) and retrieve information from specific websites.",
+      description: DEFAULT_WEBSEARCH_ACTION_DESCRIPTION,
       mcpServerViewId: webSearchBrowseMCPServerView.sId,
       internalMCPServerId: webSearchBrowseMCPServerView.internalMCPServerId,
       dataSources: null,

--- a/front/lib/api/assistant/global_agents.ts
+++ b/front/lib/api/assistant/global_agents.ts
@@ -3,7 +3,6 @@ import path from "path";
 import { promisify } from "util";
 
 import {
-  DEFAULT_RETRIEVAL_ACTION_NAME,
   DEFAULT_WEBSEARCH_ACTION_DESCRIPTION,
   DEFAULT_WEBSEARCH_ACTION_NAME,
 } from "@app/lib/actions/constants";
@@ -1369,7 +1368,7 @@ function _getManagedDataSourceAgent(
       id: -1,
       sId: agentId + "-search-action",
       type: "mcp_server_configuration",
-      name: DEFAULT_RETRIEVAL_ACTION_NAME,
+      name: "search_data_sources",
       description: `The user's ${connectorProvider} data source.`,
       mcpServerViewId: searchMCPServerView.sId,
       internalMCPServerId: searchMCPServerView.internalMCPServerId,

--- a/front/migrations/20250516_migrate_retrieval_to_mcp.ts
+++ b/front/migrations/20250516_migrate_retrieval_to_mcp.ts
@@ -1,293 +1,293 @@
-// import fs from "fs";
-// import { Op } from "sequelize";
-//
-// import {
-//   DEFAULT_RETRIEVAL_ACTION_NAME,
-//   DEFAULT_RETRIEVAL_NO_QUERY_ACTION_NAME,
-// } from "@app/lib/actions/constants";
-// import { Authenticator } from "@app/lib/auth";
-// import { AgentDataSourceConfiguration } from "@app/lib/models/assistant/actions/data_sources";
-// import { AgentMCPServerConfiguration } from "@app/lib/models/assistant/actions/mcp";
-// import { AgentRetrievalConfiguration } from "@app/lib/models/assistant/actions/retrieval";
-// import { AgentConfiguration } from "@app/lib/models/assistant/agent";
-// import { MCPServerViewResource } from "@app/lib/resources/mcp_server_view_resource";
-// import { WorkspaceModel } from "@app/lib/resources/storage/models/workspace";
-// import { generateRandomModelSId } from "@app/lib/resources/string_ids";
-// import { concurrentExecutor } from "@app/lib/utils/async_utils";
-// import { getInsertSQL } from "@app/lib/utils/sql_utils";
-// import type Logger from "@app/logger/logger";
-// import { makeScript } from "@app/scripts/helpers";
-// import type { ModelId } from "@app/types";
-//
-// type AgentStatus = "active" | "archived" | "draft";
-//
-// async function findWorkspacesWithRetrievalConfigurations(
-//   agentStatus: AgentStatus
-// ): Promise<ModelId[]> {
-//   const retrievalConfigurations = await AgentRetrievalConfiguration.findAll({
-//     attributes: ["workspaceId"],
-//     // Filter on active agents.
-//     include: [
-//       {
-//         attributes: [],
-//         model: AgentConfiguration,
-//         required: true,
-//         where: {
-//           status: agentStatus,
-//         },
-//       },
-//     ],
-//     order: [["id", "ASC"]],
-//   });
-//
-//   return retrievalConfigurations.map((config) => config.workspaceId);
-// }
-//
-// /**
-//  * Migrates retrieval actions from non-MCP to MCP version for a specific workspace.
-//  * If query is "auto", migrates to search MCP action.
-//  * If query is "none", migrates to include MCP action.
-//  */
-// async function migrateWorkspaceRetrievalActions(
-//   auth: Authenticator,
-//   {
-//     execute,
-//     parentLogger,
-//     agentStatus,
-//   }: {
-//     execute: boolean;
-//     parentLogger: typeof Logger;
-//     agentStatus: AgentStatus;
-//   }
-// ): Promise<string> {
-//   const logger = parentLogger.child({
-//     workspaceId: auth.getNonNullableWorkspace().sId,
-//   });
-//
-//   logger.info("Starting migration of retrieval actions to MCP.");
-//
-//   // Find all existing retrieval configurations that are linked to an agent configuration
-//   // (non-MCP version) and not yet linked to an MCP server configuration.
-//   const retrievalConfigs = await AgentRetrievalConfiguration.findAll({
-//     where: {
-//       workspaceId: auth.getNonNullableWorkspace().id,
-//     },
-//     // Filter on active agents.
-//     include: [
-//       {
-//         attributes: [],
-//         model: AgentConfiguration,
-//         required: true,
-//         where: {
-//           status: agentStatus,
-//         },
-//       },
-//     ],
-//     order: [["id", "ASC"]],
-//   });
-//
-//   if (retrievalConfigs.length === 0) {
-//     return "";
-//   }
-//
-//   logger.info(
-//     `Found ${retrievalConfigs.length} retrieval configurations to migrate.`
-//   );
-//
-//   if (execute) {
-//     // Create the MCP server views in system and global spaces.
-//     try {
-//       await MCPServerViewResource.ensureAllAutoToolsAreCreated(auth);
-//     } catch (e) {
-//       logger.error(
-//         { error: e },
-//         "Error creating MCP server views, skipping migration."
-//       );
-//       return "";
-//     }
-//   }
-//
-//   let revertSql = "";
-//
-//   // For each retrieval configuration, create an MCP server configuration and link it.
-//   await concurrentExecutor(
-//     retrievalConfigs,
-//     async (retrievalConfig) => {
-//       if (!retrievalConfig.agentConfigurationId) {
-//         // This should never happen since we fetch where agentConfigurationId is not null.
-//         logger.info(
-//           { retrievalConfigurationId: retrievalConfig.id },
-//           `Already an MCP retrieval config, skipping.`
-//         );
-//         return;
-//       }
-//
-//       // Determine which MCP server view to use based on the query property
-//       const mcpServerViewName =
-//         retrievalConfig.query === "auto" ? "search" : "include_data";
-//       const mcpServerView =
-//         await MCPServerViewResource.getMCPServerViewForAutoInternalTool(
-//           auth,
-//           mcpServerViewName
-//         );
-//       if (!mcpServerView) {
-//         throw new Error(`${mcpServerViewName} MCP server view not found.`);
-//       }
-//
-//       if (execute) {
-//         const mcpConfig = await AgentMCPServerConfiguration.create({
-//           sId: generateRandomModelSId(),
-//           agentConfigurationId: retrievalConfig.agentConfigurationId,
-//           workspaceId: auth.getNonNullableWorkspace().id,
-//           mcpServerViewId: mcpServerView.id,
-//           internalMCPServerId: mcpServerView.mcpServerId,
-//           additionalConfiguration: {},
-//           timeFrame:
-//             retrievalConfig.relativeTimeFrameDuration &&
-//             retrievalConfig.relativeTimeFrameUnit
-//               ? {
-//                   duration: retrievalConfig.relativeTimeFrameDuration,
-//                   unit: retrievalConfig.relativeTimeFrameUnit,
-//                 }
-//               : null,
-//           name:
-//             !retrievalConfig.name ||
-//             [
-//               DEFAULT_RETRIEVAL_ACTION_NAME,
-//               DEFAULT_RETRIEVAL_NO_QUERY_ACTION_NAME,
-//             ].includes(retrievalConfig.name)
-//               ? null
-//               : retrievalConfig.name,
-//           singleToolDescriptionOverride: retrievalConfig.description,
-//           appId: null,
-//           jsonSchema: null,
-//         });
-//
-//         // Move the datasources to the new MCP server configuration.
-//         const datasources = await AgentDataSourceConfiguration.findAll({
-//           where: {
-//             workspaceId: auth.getNonNullableWorkspace().id,
-//             retrievalConfigurationId: retrievalConfig.id,
-//           },
-//         });
-//
-//         // Before due to foreign key constraint.
-//         revertSql +=
-//           getInsertSQL(
-//             AgentRetrievalConfiguration,
-//             retrievalConfig.get({ plain: true })
-//           ) + "\n";
-//
-//         for (const datasource of datasources) {
-//           await datasource.update({
-//             retrievalConfigurationId: null,
-//             mcpServerConfigurationId: mcpConfig.id,
-//           });
-//           revertSql += `UPDATE "agent_data_source_configurations" SET "retrievalConfigurationId" = ${retrievalConfig.id}, "mcpServerConfigurationId" = NULL WHERE "id" = '${datasource.id}';\n`;
-//         }
-//
-//         await retrievalConfig.destroy();
-//
-//         // After due to foreign key constraint.
-//         revertSql += `DELETE FROM "agent_mcp_server_configurations" WHERE "id" = '${mcpConfig.id}';\n`;
-//
-//         // Log the model IDs for an easier rollback.
-//         logger.info(
-//           {
-//             retrievalConfigurationId: retrievalConfig.id,
-//             mcpServerConfigurationId: mcpConfig.id,
-//             mcpServerViewName,
-//           },
-//           `Migrated retrieval config to MCP server config.`
-//         );
-//       } else {
-//         logger.info(
-//           {
-//             retrievalConfigurationId: retrievalConfig.id,
-//             mcpServerViewName,
-//           },
-//           `Would create MCP server config and migrate retrieval config to it.`
-//         );
-//       }
-//     },
-//     { concurrency: 10 }
-//   );
-//
-//   if (execute) {
-//     logger.info(
-//       `Successfully migrated ${retrievalConfigs.length} retrieval configurations to MCP.`
-//     );
-//   } else {
-//     logger.info(
-//       `Would have migrated ${retrievalConfigs.length} retrieval configurations to MCP.`
-//     );
-//   }
-//
-//   return revertSql;
-// }
-//
-// makeScript(
-//   {
-//     workspaceId: {
-//       type: "string",
-//       description: "Workspace SID to migrate",
-//       required: false,
-//     },
-//     agentStatus: {
-//       type: "string",
-//       description: "Agent status to filter on",
-//       required: false,
-//       default: "active",
-//       choices: ["active", "archived", "draft"],
-//     },
-//   },
-//   async ({ execute, workspaceId, agentStatus }, parentLogger) => {
-//     const now = new Date().toISOString().slice(0, 16).replace(/-/g, "");
-//
-//     let workspaces: WorkspaceModel[] = [];
-//     if (workspaceId) {
-//       const workspace = await WorkspaceModel.findOne({
-//         where: {
-//           sId: workspaceId,
-//         },
-//       });
-//       if (!workspace) {
-//         throw new Error(`Workspace with SID ${workspaceId} not found.`);
-//       }
-//       workspaces = [workspace];
-//     } else {
-//       const workspaceIds = await findWorkspacesWithRetrievalConfigurations(
-//         agentStatus as AgentStatus
-//       );
-//       workspaces = await WorkspaceModel.findAll({
-//         where: {
-//           id: { [Op.in]: workspaceIds },
-//         },
-//         order: [["id", "ASC"]],
-//       });
-//     }
-//
-//     let revertSql = "";
-//     for (const workspace of workspaces) {
-//       const auth = await Authenticator.internalAdminForWorkspace(workspace.sId);
-//
-//       const workspaceRevertSql = await migrateWorkspaceRetrievalActions(auth, {
-//         execute,
-//         parentLogger,
-//         agentStatus: agentStatus as AgentStatus,
-//       });
-//
-//       if (execute) {
-//         fs.writeFileSync(
-//           `${now}_retrieval_to_mcp_revert_${workspace.sId}.sql`,
-//           workspaceRevertSql
-//         );
-//       }
-//       revertSql += workspaceRevertSql;
-//     }
-//
-//     if (execute) {
-//       fs.writeFileSync(`${now}_retrieval_to_mcp_revert_all.sql`, revertSql);
-//     }
-//   }
-// );
+import fs from "fs";
+import { Op } from "sequelize";
+
+import {
+  DEFAULT_RETRIEVAL_ACTION_NAME,
+  DEFAULT_RETRIEVAL_NO_QUERY_ACTION_NAME,
+} from "@app/lib/actions/constants";
+import { Authenticator } from "@app/lib/auth";
+import { AgentDataSourceConfiguration } from "@app/lib/models/assistant/actions/data_sources";
+import { AgentMCPServerConfiguration } from "@app/lib/models/assistant/actions/mcp";
+import { AgentRetrievalConfiguration } from "@app/lib/models/assistant/actions/retrieval";
+import { AgentConfiguration } from "@app/lib/models/assistant/agent";
+import { MCPServerViewResource } from "@app/lib/resources/mcp_server_view_resource";
+import { WorkspaceModel } from "@app/lib/resources/storage/models/workspace";
+import { generateRandomModelSId } from "@app/lib/resources/string_ids";
+import { concurrentExecutor } from "@app/lib/utils/async_utils";
+import { getInsertSQL } from "@app/lib/utils/sql_utils";
+import type Logger from "@app/logger/logger";
+import { makeScript } from "@app/scripts/helpers";
+import type { ModelId } from "@app/types";
+
+type AgentStatus = "active" | "archived" | "draft";
+
+async function findWorkspacesWithRetrievalConfigurations(
+  agentStatus: AgentStatus
+): Promise<ModelId[]> {
+  const retrievalConfigurations = await AgentRetrievalConfiguration.findAll({
+    attributes: ["workspaceId"],
+    // Filter on active agents.
+    include: [
+      {
+        attributes: [],
+        model: AgentConfiguration,
+        required: true,
+        where: {
+          status: agentStatus,
+        },
+      },
+    ],
+    order: [["id", "ASC"]],
+  });
+
+  return retrievalConfigurations.map((config) => config.workspaceId);
+}
+
+/**
+ * Migrates retrieval actions from non-MCP to MCP version for a specific workspace.
+ * If query is "auto", migrates to search MCP action.
+ * If query is "none", migrates to include MCP action.
+ */
+async function migrateWorkspaceRetrievalActions(
+  auth: Authenticator,
+  {
+    execute,
+    parentLogger,
+    agentStatus,
+  }: {
+    execute: boolean;
+    parentLogger: typeof Logger;
+    agentStatus: AgentStatus;
+  }
+): Promise<string> {
+  const logger = parentLogger.child({
+    workspaceId: auth.getNonNullableWorkspace().sId,
+  });
+
+  logger.info("Starting migration of retrieval actions to MCP.");
+
+  // Find all existing retrieval configurations that are linked to an agent configuration
+  // (non-MCP version) and not yet linked to an MCP server configuration.
+  const retrievalConfigs = await AgentRetrievalConfiguration.findAll({
+    where: {
+      workspaceId: auth.getNonNullableWorkspace().id,
+    },
+    // Filter on active agents.
+    include: [
+      {
+        attributes: [],
+        model: AgentConfiguration,
+        required: true,
+        where: {
+          status: agentStatus,
+        },
+      },
+    ],
+    order: [["id", "ASC"]],
+  });
+
+  if (retrievalConfigs.length === 0) {
+    return "";
+  }
+
+  logger.info(
+    `Found ${retrievalConfigs.length} retrieval configurations to migrate.`
+  );
+
+  if (execute) {
+    // Create the MCP server views in system and global spaces.
+    try {
+      await MCPServerViewResource.ensureAllAutoToolsAreCreated(auth);
+    } catch (e) {
+      logger.error(
+        { error: e },
+        "Error creating MCP server views, skipping migration."
+      );
+      return "";
+    }
+  }
+
+  let revertSql = "";
+
+  // For each retrieval configuration, create an MCP server configuration and link it.
+  await concurrentExecutor(
+    retrievalConfigs,
+    async (retrievalConfig) => {
+      if (!retrievalConfig.agentConfigurationId) {
+        // This should never happen since we fetch where agentConfigurationId is not null.
+        logger.info(
+          { retrievalConfigurationId: retrievalConfig.id },
+          `Already an MCP retrieval config, skipping.`
+        );
+        return;
+      }
+
+      // Determine which MCP server view to use based on the query property
+      const mcpServerViewName =
+        retrievalConfig.query === "auto" ? "search" : "include_data";
+      const mcpServerView =
+        await MCPServerViewResource.getMCPServerViewForAutoInternalTool(
+          auth,
+          mcpServerViewName
+        );
+      if (!mcpServerView) {
+        throw new Error(`${mcpServerViewName} MCP server view not found.`);
+      }
+
+      if (execute) {
+        const mcpConfig = await AgentMCPServerConfiguration.create({
+          sId: generateRandomModelSId(),
+          agentConfigurationId: retrievalConfig.agentConfigurationId,
+          workspaceId: auth.getNonNullableWorkspace().id,
+          mcpServerViewId: mcpServerView.id,
+          internalMCPServerId: mcpServerView.mcpServerId,
+          additionalConfiguration: {},
+          timeFrame:
+            retrievalConfig.relativeTimeFrameDuration &&
+            retrievalConfig.relativeTimeFrameUnit
+              ? {
+                  duration: retrievalConfig.relativeTimeFrameDuration,
+                  unit: retrievalConfig.relativeTimeFrameUnit,
+                }
+              : null,
+          name:
+            !retrievalConfig.name ||
+            [
+              DEFAULT_RETRIEVAL_ACTION_NAME,
+              DEFAULT_RETRIEVAL_NO_QUERY_ACTION_NAME,
+            ].includes(retrievalConfig.name)
+              ? null
+              : retrievalConfig.name,
+          singleToolDescriptionOverride: retrievalConfig.description,
+          appId: null,
+          jsonSchema: null,
+        });
+
+        // Move the datasources to the new MCP server configuration.
+        const datasources = await AgentDataSourceConfiguration.findAll({
+          where: {
+            workspaceId: auth.getNonNullableWorkspace().id,
+            retrievalConfigurationId: retrievalConfig.id,
+          },
+        });
+
+        // Before due to foreign key constraint.
+        revertSql +=
+          getInsertSQL(
+            AgentRetrievalConfiguration,
+            retrievalConfig.get({ plain: true })
+          ) + "\n";
+
+        for (const datasource of datasources) {
+          await datasource.update({
+            retrievalConfigurationId: null,
+            mcpServerConfigurationId: mcpConfig.id,
+          });
+          revertSql += `UPDATE "agent_data_source_configurations" SET "retrievalConfigurationId" = ${retrievalConfig.id}, "mcpServerConfigurationId" = NULL WHERE "id" = '${datasource.id}';\n`;
+        }
+
+        await retrievalConfig.destroy();
+
+        // After due to foreign key constraint.
+        revertSql += `DELETE FROM "agent_mcp_server_configurations" WHERE "id" = '${mcpConfig.id}';\n`;
+
+        // Log the model IDs for an easier rollback.
+        logger.info(
+          {
+            retrievalConfigurationId: retrievalConfig.id,
+            mcpServerConfigurationId: mcpConfig.id,
+            mcpServerViewName,
+          },
+          `Migrated retrieval config to MCP server config.`
+        );
+      } else {
+        logger.info(
+          {
+            retrievalConfigurationId: retrievalConfig.id,
+            mcpServerViewName,
+          },
+          `Would create MCP server config and migrate retrieval config to it.`
+        );
+      }
+    },
+    { concurrency: 10 }
+  );
+
+  if (execute) {
+    logger.info(
+      `Successfully migrated ${retrievalConfigs.length} retrieval configurations to MCP.`
+    );
+  } else {
+    logger.info(
+      `Would have migrated ${retrievalConfigs.length} retrieval configurations to MCP.`
+    );
+  }
+
+  return revertSql;
+}
+
+makeScript(
+  {
+    workspaceId: {
+      type: "string",
+      description: "Workspace SID to migrate",
+      required: false,
+    },
+    agentStatus: {
+      type: "string",
+      description: "Agent status to filter on",
+      required: false,
+      default: "active",
+      choices: ["active", "archived", "draft"],
+    },
+  },
+  async ({ execute, workspaceId, agentStatus }, parentLogger) => {
+    const now = new Date().toISOString().slice(0, 16).replace(/-/g, "");
+
+    let workspaces: WorkspaceModel[] = [];
+    if (workspaceId) {
+      const workspace = await WorkspaceModel.findOne({
+        where: {
+          sId: workspaceId,
+        },
+      });
+      if (!workspace) {
+        throw new Error(`Workspace with SID ${workspaceId} not found.`);
+      }
+      workspaces = [workspace];
+    } else {
+      const workspaceIds = await findWorkspacesWithRetrievalConfigurations(
+        agentStatus as AgentStatus
+      );
+      workspaces = await WorkspaceModel.findAll({
+        where: {
+          id: { [Op.in]: workspaceIds },
+        },
+        order: [["id", "ASC"]],
+      });
+    }
+
+    let revertSql = "";
+    for (const workspace of workspaces) {
+      const auth = await Authenticator.internalAdminForWorkspace(workspace.sId);
+
+      const workspaceRevertSql = await migrateWorkspaceRetrievalActions(auth, {
+        execute,
+        parentLogger,
+        agentStatus: agentStatus as AgentStatus,
+      });
+
+      if (execute) {
+        fs.writeFileSync(
+          `${now}_retrieval_to_mcp_revert_${workspace.sId}.sql`,
+          workspaceRevertSql
+        );
+      }
+      revertSql += workspaceRevertSql;
+    }
+
+    if (execute) {
+      fs.writeFileSync(`${now}_retrieval_to_mcp_revert_all.sql`, revertSql);
+    }
+  }
+);

--- a/front/migrations/20250516_migrate_retrieval_to_mcp.ts
+++ b/front/migrations/20250516_migrate_retrieval_to_mcp.ts
@@ -1,293 +1,291 @@
-// import fs from "fs";
-// import { Op } from "sequelize";
-//
-// import {
-//   DEFAULT_RETRIEVAL_ACTION_NAME,
-//   DEFAULT_RETRIEVAL_NO_QUERY_ACTION_NAME,
-// } from "@app/lib/actions/constants";
-// import { Authenticator } from "@app/lib/auth";
-// import { AgentDataSourceConfiguration } from "@app/lib/models/assistant/actions/data_sources";
-// import { AgentMCPServerConfiguration } from "@app/lib/models/assistant/actions/mcp";
-// import { AgentRetrievalConfiguration } from "@app/lib/models/assistant/actions/retrieval";
-// import { AgentConfiguration } from "@app/lib/models/assistant/agent";
-// import { MCPServerViewResource } from "@app/lib/resources/mcp_server_view_resource";
-// import { WorkspaceModel } from "@app/lib/resources/storage/models/workspace";
-// import { generateRandomModelSId } from "@app/lib/resources/string_ids";
-// import { concurrentExecutor } from "@app/lib/utils/async_utils";
-// import { getInsertSQL } from "@app/lib/utils/sql_utils";
-// import type Logger from "@app/logger/logger";
-// import { makeScript } from "@app/scripts/helpers";
-// import type { ModelId } from "@app/types";
-//
-// type AgentStatus = "active" | "archived" | "draft";
-//
-// async function findWorkspacesWithRetrievalConfigurations(
-//   agentStatus: AgentStatus
-// ): Promise<ModelId[]> {
-//   const retrievalConfigurations = await AgentRetrievalConfiguration.findAll({
-//     attributes: ["workspaceId"],
-//     // Filter on active agents.
-//     include: [
-//       {
-//         attributes: [],
-//         model: AgentConfiguration,
-//         required: true,
-//         where: {
-//           status: agentStatus,
-//         },
-//       },
-//     ],
-//     order: [["id", "ASC"]],
-//   });
-//
-//   return retrievalConfigurations.map((config) => config.workspaceId);
-// }
-//
-// /**
-//  * Migrates retrieval actions from non-MCP to MCP version for a specific workspace.
-//  * If query is "auto", migrates to search MCP action.
-//  * If query is "none", migrates to include MCP action.
-//  */
-// async function migrateWorkspaceRetrievalActions(
-//   auth: Authenticator,
-//   {
-//     execute,
-//     parentLogger,
-//     agentStatus,
-//   }: {
-//     execute: boolean;
-//     parentLogger: typeof Logger;
-//     agentStatus: AgentStatus;
-//   }
-// ): Promise<string> {
-//   const logger = parentLogger.child({
-//     workspaceId: auth.getNonNullableWorkspace().sId,
-//   });
-//
-//   logger.info("Starting migration of retrieval actions to MCP.");
-//
-//   // Find all existing retrieval configurations that are linked to an agent configuration
-//   // (non-MCP version) and not yet linked to an MCP server configuration.
-//   const retrievalConfigs = await AgentRetrievalConfiguration.findAll({
-//     where: {
-//       workspaceId: auth.getNonNullableWorkspace().id,
-//     },
-//     // Filter on active agents.
-//     include: [
-//       {
-//         attributes: [],
-//         model: AgentConfiguration,
-//         required: true,
-//         where: {
-//           status: agentStatus,
-//         },
-//       },
-//     ],
-//     order: [["id", "ASC"]],
-//   });
-//
-//   if (retrievalConfigs.length === 0) {
-//     return "";
-//   }
-//
-//   logger.info(
-//     `Found ${retrievalConfigs.length} retrieval configurations to migrate.`
-//   );
-//
-//   if (execute) {
-//     // Create the MCP server views in system and global spaces.
-//     try {
-//       await MCPServerViewResource.ensureAllAutoToolsAreCreated(auth);
-//     } catch (e) {
-//       logger.error(
-//         { error: e },
-//         "Error creating MCP server views, skipping migration."
-//       );
-//       return "";
-//     }
-//   }
-//
-//   let revertSql = "";
-//
-//   // For each retrieval configuration, create an MCP server configuration and link it.
-//   await concurrentExecutor(
-//     retrievalConfigs,
-//     async (retrievalConfig) => {
-//       if (!retrievalConfig.agentConfigurationId) {
-//         // This should never happen since we fetch where agentConfigurationId is not null.
-//         logger.info(
-//           { retrievalConfigurationId: retrievalConfig.id },
-//           `Already an MCP retrieval config, skipping.`
-//         );
-//         return;
-//       }
-//
-//       // Determine which MCP server view to use based on the query property
-//       const mcpServerViewName =
-//         retrievalConfig.query === "auto" ? "search" : "include_data";
-//       const mcpServerView =
-//         await MCPServerViewResource.getMCPServerViewForAutoInternalTool(
-//           auth,
-//           mcpServerViewName
-//         );
-//       if (!mcpServerView) {
-//         throw new Error(`${mcpServerViewName} MCP server view not found.`);
-//       }
-//
-//       if (execute) {
-//         const mcpConfig = await AgentMCPServerConfiguration.create({
-//           sId: generateRandomModelSId(),
-//           agentConfigurationId: retrievalConfig.agentConfigurationId,
-//           workspaceId: auth.getNonNullableWorkspace().id,
-//           mcpServerViewId: mcpServerView.id,
-//           internalMCPServerId: mcpServerView.mcpServerId,
-//           additionalConfiguration: {},
-//           timeFrame:
-//             retrievalConfig.relativeTimeFrameDuration &&
-//             retrievalConfig.relativeTimeFrameUnit
-//               ? {
-//                   duration: retrievalConfig.relativeTimeFrameDuration,
-//                   unit: retrievalConfig.relativeTimeFrameUnit,
-//                 }
-//               : null,
-//           name:
-//             !retrievalConfig.name ||
-//             [
-//               DEFAULT_RETRIEVAL_ACTION_NAME,
-//               DEFAULT_RETRIEVAL_NO_QUERY_ACTION_NAME,
-//             ].includes(retrievalConfig.name)
-//               ? null
-//               : retrievalConfig.name,
-//           singleToolDescriptionOverride: retrievalConfig.description,
-//           appId: null,
-//           jsonSchema: null,
-//         });
-//
-//         // Move the datasources to the new MCP server configuration.
-//         const datasources = await AgentDataSourceConfiguration.findAll({
-//           where: {
-//             workspaceId: auth.getNonNullableWorkspace().id,
-//             retrievalConfigurationId: retrievalConfig.id,
-//           },
-//         });
-//
-//         // Before due to foreign key constraint.
-//         revertSql +=
-//           getInsertSQL(
-//             AgentRetrievalConfiguration,
-//             retrievalConfig.get({ plain: true })
-//           ) + "\n";
-//
-//         for (const datasource of datasources) {
-//           await datasource.update({
-//             retrievalConfigurationId: null,
-//             mcpServerConfigurationId: mcpConfig.id,
-//           });
-//           revertSql += `UPDATE "agent_data_source_configurations" SET "retrievalConfigurationId" = ${retrievalConfig.id}, "mcpServerConfigurationId" = NULL WHERE "id" = '${datasource.id}';\n`;
-//         }
-//
-//         await retrievalConfig.destroy();
-//
-//         // After due to foreign key constraint.
-//         revertSql += `DELETE FROM "agent_mcp_server_configurations" WHERE "id" = '${mcpConfig.id}';\n`;
-//
-//         // Log the model IDs for an easier rollback.
-//         logger.info(
-//           {
-//             retrievalConfigurationId: retrievalConfig.id,
-//             mcpServerConfigurationId: mcpConfig.id,
-//             mcpServerViewName,
-//           },
-//           `Migrated retrieval config to MCP server config.`
-//         );
-//       } else {
-//         logger.info(
-//           {
-//             retrievalConfigurationId: retrievalConfig.id,
-//             mcpServerViewName,
-//           },
-//           `Would create MCP server config and migrate retrieval config to it.`
-//         );
-//       }
-//     },
-//     { concurrency: 10 }
-//   );
-//
-//   if (execute) {
-//     logger.info(
-//       `Successfully migrated ${retrievalConfigs.length} retrieval configurations to MCP.`
-//     );
-//   } else {
-//     logger.info(
-//       `Would have migrated ${retrievalConfigs.length} retrieval configurations to MCP.`
-//     );
-//   }
-//
-//   return revertSql;
-// }
-//
-// makeScript(
-//   {
-//     workspaceId: {
-//       type: "string",
-//       description: "Workspace SID to migrate",
-//       required: false,
-//     },
-//     agentStatus: {
-//       type: "string",
-//       description: "Agent status to filter on",
-//       required: false,
-//       default: "active",
-//       choices: ["active", "archived", "draft"],
-//     },
-//   },
-//   async ({ execute, workspaceId, agentStatus }, parentLogger) => {
-//     const now = new Date().toISOString().slice(0, 16).replace(/-/g, "");
-//
-//     let workspaces: WorkspaceModel[] = [];
-//     if (workspaceId) {
-//       const workspace = await WorkspaceModel.findOne({
-//         where: {
-//           sId: workspaceId,
-//         },
-//       });
-//       if (!workspace) {
-//         throw new Error(`Workspace with SID ${workspaceId} not found.`);
-//       }
-//       workspaces = [workspace];
-//     } else {
-//       const workspaceIds = await findWorkspacesWithRetrievalConfigurations(
-//         agentStatus as AgentStatus
-//       );
-//       workspaces = await WorkspaceModel.findAll({
-//         where: {
-//           id: { [Op.in]: workspaceIds },
-//         },
-//         order: [["id", "ASC"]],
-//       });
-//     }
-//
-//     let revertSql = "";
-//     for (const workspace of workspaces) {
-//       const auth = await Authenticator.internalAdminForWorkspace(workspace.sId);
-//
-//       const workspaceRevertSql = await migrateWorkspaceRetrievalActions(auth, {
-//         execute,
-//         parentLogger,
-//         agentStatus: agentStatus as AgentStatus,
-//       });
-//
-//       if (execute) {
-//         fs.writeFileSync(
-//           `${now}_retrieval_to_mcp_revert_${workspace.sId}.sql`,
-//           workspaceRevertSql
-//         );
-//       }
-//       revertSql += workspaceRevertSql;
-//     }
-//
-//     if (execute) {
-//       fs.writeFileSync(`${now}_retrieval_to_mcp_revert_all.sql`, revertSql);
-//     }
-//   }
-// );
+import fs from "fs";
+import { Op } from "sequelize";
+
+import { Authenticator } from "@app/lib/auth";
+import { AgentDataSourceConfiguration } from "@app/lib/models/assistant/actions/data_sources";
+import { AgentMCPServerConfiguration } from "@app/lib/models/assistant/actions/mcp";
+import { AgentRetrievalConfiguration } from "@app/lib/models/assistant/actions/retrieval";
+import { AgentConfiguration } from "@app/lib/models/assistant/agent";
+import { MCPServerViewResource } from "@app/lib/resources/mcp_server_view_resource";
+import { WorkspaceModel } from "@app/lib/resources/storage/models/workspace";
+import { generateRandomModelSId } from "@app/lib/resources/string_ids";
+import { concurrentExecutor } from "@app/lib/utils/async_utils";
+import { getInsertSQL } from "@app/lib/utils/sql_utils";
+import type Logger from "@app/logger/logger";
+import { makeScript } from "@app/scripts/helpers";
+import type { ModelId } from "@app/types";
+
+type AgentStatus = "active" | "archived" | "draft";
+
+async function findWorkspacesWithRetrievalConfigurations(
+  agentStatus: AgentStatus
+): Promise<ModelId[]> {
+  const retrievalConfigurations = await AgentRetrievalConfiguration.findAll({
+    attributes: ["workspaceId"],
+    // Filter on active agents.
+    include: [
+      {
+        attributes: [],
+        model: AgentConfiguration,
+        required: true,
+        where: {
+          status: agentStatus,
+        },
+      },
+    ],
+    order: [["id", "ASC"]],
+  });
+
+  return retrievalConfigurations.map((config) => config.workspaceId);
+}
+
+/**
+ * Migrates retrieval actions from non-MCP to MCP version for a specific workspace.
+ * If query is "auto", migrates to search MCP action.
+ * If query is "none", migrates to include MCP action.
+ */
+async function migrateWorkspaceRetrievalActions(
+  auth: Authenticator,
+  {
+    execute,
+    parentLogger,
+    agentStatus,
+  }: {
+    execute: boolean;
+    parentLogger: typeof Logger;
+    agentStatus: AgentStatus;
+  }
+): Promise<string> {
+  const logger = parentLogger.child({
+    workspaceId: auth.getNonNullableWorkspace().sId,
+  });
+
+  logger.info("Starting migration of retrieval actions to MCP.");
+
+  // Find all existing retrieval configurations that are linked to an agent configuration
+  // (non-MCP version) and not yet linked to an MCP server configuration.
+  const retrievalConfigs = await AgentRetrievalConfiguration.findAll({
+    where: {
+      workspaceId: auth.getNonNullableWorkspace().id,
+    },
+    // Filter on active agents.
+    include: [
+      {
+        attributes: [],
+        model: AgentConfiguration,
+        required: true,
+        where: {
+          status: agentStatus,
+        },
+      },
+    ],
+    order: [["id", "ASC"]],
+  });
+
+  if (retrievalConfigs.length === 0) {
+    return "";
+  }
+
+  logger.info(
+    `Found ${retrievalConfigs.length} retrieval configurations to migrate.`
+  );
+
+  if (execute) {
+    // Create the MCP server views in system and global spaces.
+    try {
+      await MCPServerViewResource.ensureAllAutoToolsAreCreated(auth);
+    } catch (e) {
+      logger.error(
+        { error: e },
+        "Error creating MCP server views, skipping migration."
+      );
+      return "";
+    }
+  }
+
+  let revertSql = "";
+
+  // For each retrieval configuration, create an MCP server configuration and link it.
+  await concurrentExecutor(
+    retrievalConfigs,
+    async (retrievalConfig) => {
+      if (!retrievalConfig.agentConfigurationId) {
+        // This should never happen since we fetch where agentConfigurationId is not null.
+        logger.info(
+          { retrievalConfigurationId: retrievalConfig.id },
+          `Already an MCP retrieval config, skipping.`
+        );
+        return;
+      }
+
+      // Determine which MCP server view to use based on the query property
+      const mcpServerViewName =
+        retrievalConfig.query === "auto" ? "search" : "include_data";
+      const mcpServerView =
+        await MCPServerViewResource.getMCPServerViewForAutoInternalTool(
+          auth,
+          mcpServerViewName
+        );
+      if (!mcpServerView) {
+        throw new Error(`${mcpServerViewName} MCP server view not found.`);
+      }
+
+      if (execute) {
+        const mcpConfig = await AgentMCPServerConfiguration.create({
+          sId: generateRandomModelSId(),
+          agentConfigurationId: retrievalConfig.agentConfigurationId,
+          workspaceId: auth.getNonNullableWorkspace().id,
+          mcpServerViewId: mcpServerView.id,
+          internalMCPServerId: mcpServerView.mcpServerId,
+          additionalConfiguration: {},
+          timeFrame:
+            retrievalConfig.relativeTimeFrameDuration &&
+            retrievalConfig.relativeTimeFrameUnit
+              ? {
+                  duration: retrievalConfig.relativeTimeFrameDuration,
+                  unit: retrievalConfig.relativeTimeFrameUnit,
+                }
+              : null,
+          name:
+            !retrievalConfig.name ||
+            [
+              // "search_data_sources" is the value we used to have in DEFAULT_RETRIEVAL_ACTION_NAME
+              "search_data_sources",
+              // "include_data_sources" is the value we used to have in DEFAULT_RETRIEVAL_NO_QUERY_ACTION_NAME
+              "include_data_sources",
+            ].includes(retrievalConfig.name)
+              ? null
+              : retrievalConfig.name,
+          singleToolDescriptionOverride: retrievalConfig.description,
+          appId: null,
+          jsonSchema: null,
+        });
+
+        // Move the datasources to the new MCP server configuration.
+        const datasources = await AgentDataSourceConfiguration.findAll({
+          where: {
+            workspaceId: auth.getNonNullableWorkspace().id,
+            retrievalConfigurationId: retrievalConfig.id,
+          },
+        });
+
+        // Before due to foreign key constraint.
+        revertSql +=
+          getInsertSQL(
+            AgentRetrievalConfiguration,
+            retrievalConfig.get({ plain: true })
+          ) + "\n";
+
+        for (const datasource of datasources) {
+          await datasource.update({
+            retrievalConfigurationId: null,
+            mcpServerConfigurationId: mcpConfig.id,
+          });
+          revertSql += `UPDATE "agent_data_source_configurations" SET "retrievalConfigurationId" = ${retrievalConfig.id}, "mcpServerConfigurationId" = NULL WHERE "id" = '${datasource.id}';\n`;
+        }
+
+        await retrievalConfig.destroy();
+
+        // After due to foreign key constraint.
+        revertSql += `DELETE FROM "agent_mcp_server_configurations" WHERE "id" = '${mcpConfig.id}';\n`;
+
+        // Log the model IDs for an easier rollback.
+        logger.info(
+          {
+            retrievalConfigurationId: retrievalConfig.id,
+            mcpServerConfigurationId: mcpConfig.id,
+            mcpServerViewName,
+          },
+          `Migrated retrieval config to MCP server config.`
+        );
+      } else {
+        logger.info(
+          {
+            retrievalConfigurationId: retrievalConfig.id,
+            mcpServerViewName,
+          },
+          `Would create MCP server config and migrate retrieval config to it.`
+        );
+      }
+    },
+    { concurrency: 10 }
+  );
+
+  if (execute) {
+    logger.info(
+      `Successfully migrated ${retrievalConfigs.length} retrieval configurations to MCP.`
+    );
+  } else {
+    logger.info(
+      `Would have migrated ${retrievalConfigs.length} retrieval configurations to MCP.`
+    );
+  }
+
+  return revertSql;
+}
+
+makeScript(
+  {
+    workspaceId: {
+      type: "string",
+      description: "Workspace SID to migrate",
+      required: false,
+    },
+    agentStatus: {
+      type: "string",
+      description: "Agent status to filter on",
+      required: false,
+      default: "active",
+      choices: ["active", "archived", "draft"],
+    },
+  },
+  async ({ execute, workspaceId, agentStatus }, parentLogger) => {
+    const now = new Date().toISOString().slice(0, 16).replace(/-/g, "");
+
+    let workspaces: WorkspaceModel[] = [];
+    if (workspaceId) {
+      const workspace = await WorkspaceModel.findOne({
+        where: {
+          sId: workspaceId,
+        },
+      });
+      if (!workspace) {
+        throw new Error(`Workspace with SID ${workspaceId} not found.`);
+      }
+      workspaces = [workspace];
+    } else {
+      const workspaceIds = await findWorkspacesWithRetrievalConfigurations(
+        agentStatus as AgentStatus
+      );
+      workspaces = await WorkspaceModel.findAll({
+        where: {
+          id: { [Op.in]: workspaceIds },
+        },
+        order: [["id", "ASC"]],
+      });
+    }
+
+    let revertSql = "";
+    for (const workspace of workspaces) {
+      const auth = await Authenticator.internalAdminForWorkspace(workspace.sId);
+
+      const workspaceRevertSql = await migrateWorkspaceRetrievalActions(auth, {
+        execute,
+        parentLogger,
+        agentStatus: agentStatus as AgentStatus,
+      });
+
+      if (execute) {
+        fs.writeFileSync(
+          `${now}_retrieval_to_mcp_revert_${workspace.sId}.sql`,
+          workspaceRevertSql
+        );
+      }
+      revertSql += workspaceRevertSql;
+    }
+
+    if (execute) {
+      fs.writeFileSync(`${now}_retrieval_to_mcp_revert_all.sql`, revertSql);
+    }
+  }
+);

--- a/front/migrations/20250516_migrate_retrieval_to_mcp.ts
+++ b/front/migrations/20250516_migrate_retrieval_to_mcp.ts
@@ -1,293 +1,293 @@
-import fs from "fs";
-import { Op } from "sequelize";
-
-import {
-  DEFAULT_RETRIEVAL_ACTION_NAME,
-  DEFAULT_RETRIEVAL_NO_QUERY_ACTION_NAME,
-} from "@app/lib/actions/constants";
-import { Authenticator } from "@app/lib/auth";
-import { AgentDataSourceConfiguration } from "@app/lib/models/assistant/actions/data_sources";
-import { AgentMCPServerConfiguration } from "@app/lib/models/assistant/actions/mcp";
-import { AgentRetrievalConfiguration } from "@app/lib/models/assistant/actions/retrieval";
-import { AgentConfiguration } from "@app/lib/models/assistant/agent";
-import { MCPServerViewResource } from "@app/lib/resources/mcp_server_view_resource";
-import { WorkspaceModel } from "@app/lib/resources/storage/models/workspace";
-import { generateRandomModelSId } from "@app/lib/resources/string_ids";
-import { concurrentExecutor } from "@app/lib/utils/async_utils";
-import { getInsertSQL } from "@app/lib/utils/sql_utils";
-import type Logger from "@app/logger/logger";
-import { makeScript } from "@app/scripts/helpers";
-import type { ModelId } from "@app/types";
-
-type AgentStatus = "active" | "archived" | "draft";
-
-async function findWorkspacesWithRetrievalConfigurations(
-  agentStatus: AgentStatus
-): Promise<ModelId[]> {
-  const retrievalConfigurations = await AgentRetrievalConfiguration.findAll({
-    attributes: ["workspaceId"],
-    // Filter on active agents.
-    include: [
-      {
-        attributes: [],
-        model: AgentConfiguration,
-        required: true,
-        where: {
-          status: agentStatus,
-        },
-      },
-    ],
-    order: [["id", "ASC"]],
-  });
-
-  return retrievalConfigurations.map((config) => config.workspaceId);
-}
-
-/**
- * Migrates retrieval actions from non-MCP to MCP version for a specific workspace.
- * If query is "auto", migrates to search MCP action.
- * If query is "none", migrates to include MCP action.
- */
-async function migrateWorkspaceRetrievalActions(
-  auth: Authenticator,
-  {
-    execute,
-    parentLogger,
-    agentStatus,
-  }: {
-    execute: boolean;
-    parentLogger: typeof Logger;
-    agentStatus: AgentStatus;
-  }
-): Promise<string> {
-  const logger = parentLogger.child({
-    workspaceId: auth.getNonNullableWorkspace().sId,
-  });
-
-  logger.info("Starting migration of retrieval actions to MCP.");
-
-  // Find all existing retrieval configurations that are linked to an agent configuration
-  // (non-MCP version) and not yet linked to an MCP server configuration.
-  const retrievalConfigs = await AgentRetrievalConfiguration.findAll({
-    where: {
-      workspaceId: auth.getNonNullableWorkspace().id,
-    },
-    // Filter on active agents.
-    include: [
-      {
-        attributes: [],
-        model: AgentConfiguration,
-        required: true,
-        where: {
-          status: agentStatus,
-        },
-      },
-    ],
-    order: [["id", "ASC"]],
-  });
-
-  if (retrievalConfigs.length === 0) {
-    return "";
-  }
-
-  logger.info(
-    `Found ${retrievalConfigs.length} retrieval configurations to migrate.`
-  );
-
-  if (execute) {
-    // Create the MCP server views in system and global spaces.
-    try {
-      await MCPServerViewResource.ensureAllAutoToolsAreCreated(auth);
-    } catch (e) {
-      logger.error(
-        { error: e },
-        "Error creating MCP server views, skipping migration."
-      );
-      return "";
-    }
-  }
-
-  let revertSql = "";
-
-  // For each retrieval configuration, create an MCP server configuration and link it.
-  await concurrentExecutor(
-    retrievalConfigs,
-    async (retrievalConfig) => {
-      if (!retrievalConfig.agentConfigurationId) {
-        // This should never happen since we fetch where agentConfigurationId is not null.
-        logger.info(
-          { retrievalConfigurationId: retrievalConfig.id },
-          `Already an MCP retrieval config, skipping.`
-        );
-        return;
-      }
-
-      // Determine which MCP server view to use based on the query property
-      const mcpServerViewName =
-        retrievalConfig.query === "auto" ? "search" : "include_data";
-      const mcpServerView =
-        await MCPServerViewResource.getMCPServerViewForAutoInternalTool(
-          auth,
-          mcpServerViewName
-        );
-      if (!mcpServerView) {
-        throw new Error(`${mcpServerViewName} MCP server view not found.`);
-      }
-
-      if (execute) {
-        const mcpConfig = await AgentMCPServerConfiguration.create({
-          sId: generateRandomModelSId(),
-          agentConfigurationId: retrievalConfig.agentConfigurationId,
-          workspaceId: auth.getNonNullableWorkspace().id,
-          mcpServerViewId: mcpServerView.id,
-          internalMCPServerId: mcpServerView.mcpServerId,
-          additionalConfiguration: {},
-          timeFrame:
-            retrievalConfig.relativeTimeFrameDuration &&
-            retrievalConfig.relativeTimeFrameUnit
-              ? {
-                  duration: retrievalConfig.relativeTimeFrameDuration,
-                  unit: retrievalConfig.relativeTimeFrameUnit,
-                }
-              : null,
-          name:
-            !retrievalConfig.name ||
-            [
-              DEFAULT_RETRIEVAL_ACTION_NAME,
-              DEFAULT_RETRIEVAL_NO_QUERY_ACTION_NAME,
-            ].includes(retrievalConfig.name)
-              ? null
-              : retrievalConfig.name,
-          singleToolDescriptionOverride: retrievalConfig.description,
-          appId: null,
-          jsonSchema: null,
-        });
-
-        // Move the datasources to the new MCP server configuration.
-        const datasources = await AgentDataSourceConfiguration.findAll({
-          where: {
-            workspaceId: auth.getNonNullableWorkspace().id,
-            retrievalConfigurationId: retrievalConfig.id,
-          },
-        });
-
-        // Before due to foreign key constraint.
-        revertSql +=
-          getInsertSQL(
-            AgentRetrievalConfiguration,
-            retrievalConfig.get({ plain: true })
-          ) + "\n";
-
-        for (const datasource of datasources) {
-          await datasource.update({
-            retrievalConfigurationId: null,
-            mcpServerConfigurationId: mcpConfig.id,
-          });
-          revertSql += `UPDATE "agent_data_source_configurations" SET "retrievalConfigurationId" = ${retrievalConfig.id}, "mcpServerConfigurationId" = NULL WHERE "id" = '${datasource.id}';\n`;
-        }
-
-        await retrievalConfig.destroy();
-
-        // After due to foreign key constraint.
-        revertSql += `DELETE FROM "agent_mcp_server_configurations" WHERE "id" = '${mcpConfig.id}';\n`;
-
-        // Log the model IDs for an easier rollback.
-        logger.info(
-          {
-            retrievalConfigurationId: retrievalConfig.id,
-            mcpServerConfigurationId: mcpConfig.id,
-            mcpServerViewName,
-          },
-          `Migrated retrieval config to MCP server config.`
-        );
-      } else {
-        logger.info(
-          {
-            retrievalConfigurationId: retrievalConfig.id,
-            mcpServerViewName,
-          },
-          `Would create MCP server config and migrate retrieval config to it.`
-        );
-      }
-    },
-    { concurrency: 10 }
-  );
-
-  if (execute) {
-    logger.info(
-      `Successfully migrated ${retrievalConfigs.length} retrieval configurations to MCP.`
-    );
-  } else {
-    logger.info(
-      `Would have migrated ${retrievalConfigs.length} retrieval configurations to MCP.`
-    );
-  }
-
-  return revertSql;
-}
-
-makeScript(
-  {
-    workspaceId: {
-      type: "string",
-      description: "Workspace SID to migrate",
-      required: false,
-    },
-    agentStatus: {
-      type: "string",
-      description: "Agent status to filter on",
-      required: false,
-      default: "active",
-      choices: ["active", "archived", "draft"],
-    },
-  },
-  async ({ execute, workspaceId, agentStatus }, parentLogger) => {
-    const now = new Date().toISOString().slice(0, 16).replace(/-/g, "");
-
-    let workspaces: WorkspaceModel[] = [];
-    if (workspaceId) {
-      const workspace = await WorkspaceModel.findOne({
-        where: {
-          sId: workspaceId,
-        },
-      });
-      if (!workspace) {
-        throw new Error(`Workspace with SID ${workspaceId} not found.`);
-      }
-      workspaces = [workspace];
-    } else {
-      const workspaceIds = await findWorkspacesWithRetrievalConfigurations(
-        agentStatus as AgentStatus
-      );
-      workspaces = await WorkspaceModel.findAll({
-        where: {
-          id: { [Op.in]: workspaceIds },
-        },
-        order: [["id", "ASC"]],
-      });
-    }
-
-    let revertSql = "";
-    for (const workspace of workspaces) {
-      const auth = await Authenticator.internalAdminForWorkspace(workspace.sId);
-
-      const workspaceRevertSql = await migrateWorkspaceRetrievalActions(auth, {
-        execute,
-        parentLogger,
-        agentStatus: agentStatus as AgentStatus,
-      });
-
-      if (execute) {
-        fs.writeFileSync(
-          `${now}_retrieval_to_mcp_revert_${workspace.sId}.sql`,
-          workspaceRevertSql
-        );
-      }
-      revertSql += workspaceRevertSql;
-    }
-
-    if (execute) {
-      fs.writeFileSync(`${now}_retrieval_to_mcp_revert_all.sql`, revertSql);
-    }
-  }
-);
+// import fs from "fs";
+// import { Op } from "sequelize";
+//
+// import {
+//   DEFAULT_RETRIEVAL_ACTION_NAME,
+//   DEFAULT_RETRIEVAL_NO_QUERY_ACTION_NAME,
+// } from "@app/lib/actions/constants";
+// import { Authenticator } from "@app/lib/auth";
+// import { AgentDataSourceConfiguration } from "@app/lib/models/assistant/actions/data_sources";
+// import { AgentMCPServerConfiguration } from "@app/lib/models/assistant/actions/mcp";
+// import { AgentRetrievalConfiguration } from "@app/lib/models/assistant/actions/retrieval";
+// import { AgentConfiguration } from "@app/lib/models/assistant/agent";
+// import { MCPServerViewResource } from "@app/lib/resources/mcp_server_view_resource";
+// import { WorkspaceModel } from "@app/lib/resources/storage/models/workspace";
+// import { generateRandomModelSId } from "@app/lib/resources/string_ids";
+// import { concurrentExecutor } from "@app/lib/utils/async_utils";
+// import { getInsertSQL } from "@app/lib/utils/sql_utils";
+// import type Logger from "@app/logger/logger";
+// import { makeScript } from "@app/scripts/helpers";
+// import type { ModelId } from "@app/types";
+//
+// type AgentStatus = "active" | "archived" | "draft";
+//
+// async function findWorkspacesWithRetrievalConfigurations(
+//   agentStatus: AgentStatus
+// ): Promise<ModelId[]> {
+//   const retrievalConfigurations = await AgentRetrievalConfiguration.findAll({
+//     attributes: ["workspaceId"],
+//     // Filter on active agents.
+//     include: [
+//       {
+//         attributes: [],
+//         model: AgentConfiguration,
+//         required: true,
+//         where: {
+//           status: agentStatus,
+//         },
+//       },
+//     ],
+//     order: [["id", "ASC"]],
+//   });
+//
+//   return retrievalConfigurations.map((config) => config.workspaceId);
+// }
+//
+// /**
+//  * Migrates retrieval actions from non-MCP to MCP version for a specific workspace.
+//  * If query is "auto", migrates to search MCP action.
+//  * If query is "none", migrates to include MCP action.
+//  */
+// async function migrateWorkspaceRetrievalActions(
+//   auth: Authenticator,
+//   {
+//     execute,
+//     parentLogger,
+//     agentStatus,
+//   }: {
+//     execute: boolean;
+//     parentLogger: typeof Logger;
+//     agentStatus: AgentStatus;
+//   }
+// ): Promise<string> {
+//   const logger = parentLogger.child({
+//     workspaceId: auth.getNonNullableWorkspace().sId,
+//   });
+//
+//   logger.info("Starting migration of retrieval actions to MCP.");
+//
+//   // Find all existing retrieval configurations that are linked to an agent configuration
+//   // (non-MCP version) and not yet linked to an MCP server configuration.
+//   const retrievalConfigs = await AgentRetrievalConfiguration.findAll({
+//     where: {
+//       workspaceId: auth.getNonNullableWorkspace().id,
+//     },
+//     // Filter on active agents.
+//     include: [
+//       {
+//         attributes: [],
+//         model: AgentConfiguration,
+//         required: true,
+//         where: {
+//           status: agentStatus,
+//         },
+//       },
+//     ],
+//     order: [["id", "ASC"]],
+//   });
+//
+//   if (retrievalConfigs.length === 0) {
+//     return "";
+//   }
+//
+//   logger.info(
+//     `Found ${retrievalConfigs.length} retrieval configurations to migrate.`
+//   );
+//
+//   if (execute) {
+//     // Create the MCP server views in system and global spaces.
+//     try {
+//       await MCPServerViewResource.ensureAllAutoToolsAreCreated(auth);
+//     } catch (e) {
+//       logger.error(
+//         { error: e },
+//         "Error creating MCP server views, skipping migration."
+//       );
+//       return "";
+//     }
+//   }
+//
+//   let revertSql = "";
+//
+//   // For each retrieval configuration, create an MCP server configuration and link it.
+//   await concurrentExecutor(
+//     retrievalConfigs,
+//     async (retrievalConfig) => {
+//       if (!retrievalConfig.agentConfigurationId) {
+//         // This should never happen since we fetch where agentConfigurationId is not null.
+//         logger.info(
+//           { retrievalConfigurationId: retrievalConfig.id },
+//           `Already an MCP retrieval config, skipping.`
+//         );
+//         return;
+//       }
+//
+//       // Determine which MCP server view to use based on the query property
+//       const mcpServerViewName =
+//         retrievalConfig.query === "auto" ? "search" : "include_data";
+//       const mcpServerView =
+//         await MCPServerViewResource.getMCPServerViewForAutoInternalTool(
+//           auth,
+//           mcpServerViewName
+//         );
+//       if (!mcpServerView) {
+//         throw new Error(`${mcpServerViewName} MCP server view not found.`);
+//       }
+//
+//       if (execute) {
+//         const mcpConfig = await AgentMCPServerConfiguration.create({
+//           sId: generateRandomModelSId(),
+//           agentConfigurationId: retrievalConfig.agentConfigurationId,
+//           workspaceId: auth.getNonNullableWorkspace().id,
+//           mcpServerViewId: mcpServerView.id,
+//           internalMCPServerId: mcpServerView.mcpServerId,
+//           additionalConfiguration: {},
+//           timeFrame:
+//             retrievalConfig.relativeTimeFrameDuration &&
+//             retrievalConfig.relativeTimeFrameUnit
+//               ? {
+//                   duration: retrievalConfig.relativeTimeFrameDuration,
+//                   unit: retrievalConfig.relativeTimeFrameUnit,
+//                 }
+//               : null,
+//           name:
+//             !retrievalConfig.name ||
+//             [
+//               DEFAULT_RETRIEVAL_ACTION_NAME,
+//               DEFAULT_RETRIEVAL_NO_QUERY_ACTION_NAME,
+//             ].includes(retrievalConfig.name)
+//               ? null
+//               : retrievalConfig.name,
+//           singleToolDescriptionOverride: retrievalConfig.description,
+//           appId: null,
+//           jsonSchema: null,
+//         });
+//
+//         // Move the datasources to the new MCP server configuration.
+//         const datasources = await AgentDataSourceConfiguration.findAll({
+//           where: {
+//             workspaceId: auth.getNonNullableWorkspace().id,
+//             retrievalConfigurationId: retrievalConfig.id,
+//           },
+//         });
+//
+//         // Before due to foreign key constraint.
+//         revertSql +=
+//           getInsertSQL(
+//             AgentRetrievalConfiguration,
+//             retrievalConfig.get({ plain: true })
+//           ) + "\n";
+//
+//         for (const datasource of datasources) {
+//           await datasource.update({
+//             retrievalConfigurationId: null,
+//             mcpServerConfigurationId: mcpConfig.id,
+//           });
+//           revertSql += `UPDATE "agent_data_source_configurations" SET "retrievalConfigurationId" = ${retrievalConfig.id}, "mcpServerConfigurationId" = NULL WHERE "id" = '${datasource.id}';\n`;
+//         }
+//
+//         await retrievalConfig.destroy();
+//
+//         // After due to foreign key constraint.
+//         revertSql += `DELETE FROM "agent_mcp_server_configurations" WHERE "id" = '${mcpConfig.id}';\n`;
+//
+//         // Log the model IDs for an easier rollback.
+//         logger.info(
+//           {
+//             retrievalConfigurationId: retrievalConfig.id,
+//             mcpServerConfigurationId: mcpConfig.id,
+//             mcpServerViewName,
+//           },
+//           `Migrated retrieval config to MCP server config.`
+//         );
+//       } else {
+//         logger.info(
+//           {
+//             retrievalConfigurationId: retrievalConfig.id,
+//             mcpServerViewName,
+//           },
+//           `Would create MCP server config and migrate retrieval config to it.`
+//         );
+//       }
+//     },
+//     { concurrency: 10 }
+//   );
+//
+//   if (execute) {
+//     logger.info(
+//       `Successfully migrated ${retrievalConfigs.length} retrieval configurations to MCP.`
+//     );
+//   } else {
+//     logger.info(
+//       `Would have migrated ${retrievalConfigs.length} retrieval configurations to MCP.`
+//     );
+//   }
+//
+//   return revertSql;
+// }
+//
+// makeScript(
+//   {
+//     workspaceId: {
+//       type: "string",
+//       description: "Workspace SID to migrate",
+//       required: false,
+//     },
+//     agentStatus: {
+//       type: "string",
+//       description: "Agent status to filter on",
+//       required: false,
+//       default: "active",
+//       choices: ["active", "archived", "draft"],
+//     },
+//   },
+//   async ({ execute, workspaceId, agentStatus }, parentLogger) => {
+//     const now = new Date().toISOString().slice(0, 16).replace(/-/g, "");
+//
+//     let workspaces: WorkspaceModel[] = [];
+//     if (workspaceId) {
+//       const workspace = await WorkspaceModel.findOne({
+//         where: {
+//           sId: workspaceId,
+//         },
+//       });
+//       if (!workspace) {
+//         throw new Error(`Workspace with SID ${workspaceId} not found.`);
+//       }
+//       workspaces = [workspace];
+//     } else {
+//       const workspaceIds = await findWorkspacesWithRetrievalConfigurations(
+//         agentStatus as AgentStatus
+//       );
+//       workspaces = await WorkspaceModel.findAll({
+//         where: {
+//           id: { [Op.in]: workspaceIds },
+//         },
+//         order: [["id", "ASC"]],
+//       });
+//     }
+//
+//     let revertSql = "";
+//     for (const workspace of workspaces) {
+//       const auth = await Authenticator.internalAdminForWorkspace(workspace.sId);
+//
+//       const workspaceRevertSql = await migrateWorkspaceRetrievalActions(auth, {
+//         execute,
+//         parentLogger,
+//         agentStatus: agentStatus as AgentStatus,
+//       });
+//
+//       if (execute) {
+//         fs.writeFileSync(
+//           `${now}_retrieval_to_mcp_revert_${workspace.sId}.sql`,
+//           workspaceRevertSql
+//         );
+//       }
+//       revertSql += workspaceRevertSql;
+//     }
+//
+//     if (execute) {
+//       fs.writeFileSync(`${now}_retrieval_to_mcp_revert_all.sql`, revertSql);
+//     }
+//   }
+// );

--- a/front/migrations/20250516_migrate_tables_query_to_mcp_globally.ts
+++ b/front/migrations/20250516_migrate_tables_query_to_mcp_globally.ts
@@ -2,7 +2,6 @@
 // import fs from "fs";
 // import { Op } from "sequelize";
 //
-// import { DEFAULT_TABLES_QUERY_ACTION_NAME } from "@app/lib/actions/constants";
 // import { Authenticator } from "@app/lib/auth";
 // import { AgentMCPServerConfiguration } from "@app/lib/models/assistant/actions/mcp";
 // import {
@@ -150,7 +149,8 @@
 //           additionalConfiguration: {},
 //           timeFrame: null,
 //           name:
-//             tablesQueryConfig.name === DEFAULT_TABLES_QUERY_ACTION_NAME
+//             // "query_tables" is the value we used to have in DEFAULT_TABLES_QUERY_ACTION_NAME.
+//             tablesQueryConfig.name === "query_tables"
 //               ? null
 //               : tablesQueryConfig.name,
 //           singleToolDescriptionOverride: tablesQueryConfig.description,


### PR DESCRIPTION
## Description

Following the sunset of non-MCP actions, we now have dangling variables for the default action names and descriptions.
This PR brings order on the matter by defining these rules:
- If we use an `MCPServerConfiguration` to a global agent, we share the name and description between the internal MCP server and the configuration added to the global agent.
- Otherwise we can just inline the name and descriptions of MCP servers if not used anywhere else.

This PR is really about removing some global variables.

## Tests

## Risk

- Low.

## Deploy Plan

- Deploy front.
