### PR TITLE
[front] - feat(AB v2): preview tab

### DIFF
--- a/front/components/agent_builder/AgentBuilderLayout.tsx
+++ b/front/components/agent_builder/AgentBuilderLayout.tsx
@@ -53,18 +53,18 @@ export function AgentBuilderLayout({
   };
 
   return (
-    <div className="flex h-full flex-row">
+    <div className="flex h-screen flex-row">
       <Head>
         <title>{`Dust - ${owner.name}`}</title>
       </Head>
       <div
         className={cn(
-          "relative h-full w-full flex-1 flex-col overflow-x-hidden overflow-y-hidden",
+          "relative h-full w-full flex-1 flex-col overflow-hidden",
           "bg-background text-foreground",
           "dark:bg-background-night dark:text-foreground-night"
         )}
       >
-        <main className="flex h-full w-full flex-col items-center overflow-y-auto">
+        <main className="flex h-full w-full flex-col items-center">
           {loaded && (
             <div className="flex h-full w-full">
               <ResizablePanelGroup

--- a/front/components/agent_builder/AgentBuilderPreview.tsx
+++ b/front/components/agent_builder/AgentBuilderPreview.tsx
@@ -14,13 +14,12 @@ import { GenerationContextProvider } from "@app/components/assistant/conversatio
 import { AssistantInputBar } from "@app/components/assistant/conversation/input_bar/InputBar";
 import { useUser } from "@app/lib/swr/user";
 
-function EmptyState({
-  message,
-  description,
-}: {
+interface EmptyStateProps {
   message: string;
   description: string;
-}) {
+}
+
+function EmptyState({ message, description }: EmptyStateProps) {
   return (
     <div className="flex h-full min-h-0 items-center justify-center">
       <div className="px-4 text-center">
@@ -33,7 +32,11 @@ function EmptyState({
   );
 }
 
-function LoadingState({ message }: { message: string }) {
+interface LoadingStateProps {
+  message: string;
+}
+
+function LoadingState({ message }: LoadingStateProps) {
   return (
     <div className="flex h-full min-h-0 items-center justify-center">
       <div className="flex items-center gap-3">

--- a/front/components/agent_builder/AgentBuilderPreview.tsx
+++ b/front/components/agent_builder/AgentBuilderPreview.tsx
@@ -22,7 +22,7 @@ function EmptyState({
   description: string;
 }) {
   return (
-    <div className="flex h-full items-center justify-center">
+    <div className="flex h-full min-h-0 items-center justify-center">
       <div className="px-4 text-center">
         <div className="mb-2 text-lg font-medium text-foreground">
           {message}
@@ -35,7 +35,7 @@ function EmptyState({
 
 function LoadingState({ message }: { message: string }) {
   return (
-    <div className="flex h-full items-center justify-center">
+    <div className="flex h-full min-h-0 items-center justify-center">
       <div className="flex items-center gap-3">
         <Spinner />
         <span className="text-muted-foreground">{message}</span>
@@ -91,10 +91,10 @@ export const AgentBuilderPreview = React.memo(function AgentBuilderPreview() {
       );
     }
 
-    // Show the actual conversation interface
+    // Show the actual conversation interface with proper flex layout
     return (
-      <>
-        <div className="flex-grow overflow-y-auto">
+      <div className="flex h-full flex-col">
+        <div className="flex-1 overflow-y-auto">
           {conversation ? (
             <ConversationViewer
               owner={owner}
@@ -111,7 +111,7 @@ export const AgentBuilderPreview = React.memo(function AgentBuilderPreview() {
             />
           )}
         </div>
-        <div className="shrink-0">
+        <div className="flex-shrink-0 border-t border-border">
           <AssistantInputBar
             disableButton={isSavingDraftAgent}
             owner={owner}
@@ -124,7 +124,7 @@ export const AgentBuilderPreview = React.memo(function AgentBuilderPreview() {
             isFloating={false}
           />
         </div>
-      </>
+      </div>
     );
   };
 

--- a/front/components/agent_builder/AgentBuilderPreview.tsx
+++ b/front/components/agent_builder/AgentBuilderPreview.tsx
@@ -1,13 +1,10 @@
 import { Spinner } from "@dust-tt/sparkle";
-import React, { useMemo } from "react";
+import React from "react";
 import { useFormContext } from "react-hook-form";
 
 import { useAgentBuilderContext } from "@app/components/agent_builder/AgentBuilderContext";
 import type { AgentBuilderFormData } from "@app/components/agent_builder/AgentBuilderFormContext";
-import {
-  usePreviewAgent,
-  useTryAgentCore,
-} from "@app/components/agent_builder/hooks/useAgentPreview";
+import { usePreviewAgent, useTryAgentCore } from "@app/components/agent_builder/hooks/useAgentPreview";
 import { ActionValidationProvider } from "@app/components/assistant/conversation/ActionValidationProvider";
 import ConversationViewer from "@app/components/assistant/conversation/ConversationViewer";
 import { GenerationContextProvider } from "@app/components/assistant/conversation/GenerationContextProvider";
@@ -44,11 +41,13 @@ function LoadingState({ message }: { message: string }) {
   );
 }
 
-export const AgentBuilderPreview = React.memo(function AgentBuilderPreview() {
+export function AgentBuilderPreview()  {
   const { owner } = useAgentBuilderContext();
   const { user } = useUser();
+
   const form = useFormContext<AgentBuilderFormData>();
   const formData = form.watch();
+
   const { draftAgent, isSavingDraftAgent, createDraftAgent } =
     usePreviewAgent();
   const { conversation, stickyMentions, setStickyMentions, handleSubmit } =
@@ -59,16 +58,9 @@ export const AgentBuilderPreview = React.memo(function AgentBuilderPreview() {
       createDraftAgent,
     });
 
-  const hasContent = useMemo(() => {
-    return formData.instructions?.trim() || formData.actions.length > 0;
-  }, [formData.instructions, formData.actions.length]);
+  const hasContent = formData.instructions?.trim() || formData.actions.length > 0;
 
-  // Determine what to render in the main content area
   const renderContent = () => {
-    if (!user) {
-      return <LoadingState message="Loading user..." />;
-    }
-
     if (!hasContent) {
       return (
         <EmptyState
@@ -91,11 +83,10 @@ export const AgentBuilderPreview = React.memo(function AgentBuilderPreview() {
       );
     }
 
-    // Show the actual conversation interface with proper flex layout
     return (
       <div className="flex h-full flex-col">
         <div className="flex-1 overflow-y-auto">
-          {conversation ? (
+          {conversation && user ? (
             <ConversationViewer
               owner={owner}
               user={user}
@@ -139,4 +130,4 @@ export const AgentBuilderPreview = React.memo(function AgentBuilderPreview() {
       </ActionValidationProvider>
     </div>
   );
-});
+}

--- a/front/components/agent_builder/AgentBuilderPreview.tsx
+++ b/front/components/agent_builder/AgentBuilderPreview.tsx
@@ -54,6 +54,9 @@ export function AgentBuilderPreview() {
   const instructions = useWatch<AgentBuilderFormData, "instructions">({
     name: "instructions",
   });
+  const name = useWatch<AgentBuilderFormData, "agentSettings.name">({
+    name: "agentSettings.name",
+  });
 
   const { draftAgent, isSavingDraftAgent, createDraftAgent } =
     usePreviewAgent();
@@ -68,7 +71,7 @@ export function AgentBuilderPreview() {
   const hasContent = instructions.trim();
 
   const renderContent = () => {
-    if (!hasContent) {
+    if (!hasContent || !name) {
       return (
         <EmptyState
           message="Ready to test your agent?"

--- a/front/components/agent_builder/AgentBuilderPreview.tsx
+++ b/front/components/agent_builder/AgentBuilderPreview.tsx
@@ -1,10 +1,13 @@
 import { Spinner } from "@dust-tt/sparkle";
 import React from "react";
-import { useFormContext } from "react-hook-form";
+import { useWatch } from "react-hook-form";
 
 import { useAgentBuilderContext } from "@app/components/agent_builder/AgentBuilderContext";
 import type { AgentBuilderFormData } from "@app/components/agent_builder/AgentBuilderFormContext";
-import { usePreviewAgent, useTryAgentCore } from "@app/components/agent_builder/hooks/useAgentPreview";
+import {
+  usePreviewAgent,
+  useTryAgentCore,
+} from "@app/components/agent_builder/hooks/useAgentPreview";
 import { ActionValidationProvider } from "@app/components/assistant/conversation/ActionValidationProvider";
 import ConversationViewer from "@app/components/assistant/conversation/ConversationViewer";
 import { GenerationContextProvider } from "@app/components/assistant/conversation/GenerationContextProvider";
@@ -41,12 +44,13 @@ function LoadingState({ message }: { message: string }) {
   );
 }
 
-export function AgentBuilderPreview()  {
+export function AgentBuilderPreview() {
   const { owner } = useAgentBuilderContext();
   const { user } = useUser();
 
-  const form = useFormContext<AgentBuilderFormData>();
-  const formData = form.watch();
+  const instructions = useWatch<AgentBuilderFormData, "instructions">({
+    name: "instructions",
+  });
 
   const { draftAgent, isSavingDraftAgent, createDraftAgent } =
     usePreviewAgent();
@@ -58,7 +62,7 @@ export function AgentBuilderPreview()  {
       createDraftAgent,
     });
 
-  const hasContent = formData.instructions?.trim() || formData.actions.length > 0;
+  const hasContent = instructions.trim();
 
   const renderContent = () => {
     if (!hasContent) {

--- a/front/components/agent_builder/AgentBuilderPreview.tsx
+++ b/front/components/agent_builder/AgentBuilderPreview.tsx
@@ -1,0 +1,142 @@
+import { Spinner } from "@dust-tt/sparkle";
+import React, { useMemo } from "react";
+import { useFormContext } from "react-hook-form";
+
+import { useAgentBuilderContext } from "@app/components/agent_builder/AgentBuilderContext";
+import type { AgentBuilderFormData } from "@app/components/agent_builder/AgentBuilderFormContext";
+import {
+  usePreviewAgent,
+  useTryAgentCore,
+} from "@app/components/agent_builder/hooks/useAgentPreview";
+import { ActionValidationProvider } from "@app/components/assistant/conversation/ActionValidationProvider";
+import ConversationViewer from "@app/components/assistant/conversation/ConversationViewer";
+import { GenerationContextProvider } from "@app/components/assistant/conversation/GenerationContextProvider";
+import { AssistantInputBar } from "@app/components/assistant/conversation/input_bar/InputBar";
+import { useUser } from "@app/lib/swr/user";
+
+function EmptyState({
+  message,
+  description,
+}: {
+  message: string;
+  description: string;
+}) {
+  return (
+    <div className="flex h-full items-center justify-center">
+      <div className="px-4 text-center">
+        <div className="mb-2 text-lg font-medium text-foreground">
+          {message}
+        </div>
+        <div className="max-w-sm text-muted-foreground">{description}</div>
+      </div>
+    </div>
+  );
+}
+
+function LoadingState({ message }: { message: string }) {
+  return (
+    <div className="flex h-full items-center justify-center">
+      <div className="flex items-center gap-3">
+        <Spinner />
+        <span className="text-muted-foreground">{message}</span>
+      </div>
+    </div>
+  );
+}
+
+export const AgentBuilderPreview = React.memo(function AgentBuilderPreview() {
+  const { owner } = useAgentBuilderContext();
+  const { user } = useUser();
+  const form = useFormContext<AgentBuilderFormData>();
+  const formData = form.watch();
+  const { draftAgent, isSavingDraftAgent, createDraftAgent } =
+    usePreviewAgent();
+  const { conversation, stickyMentions, setStickyMentions, handleSubmit } =
+    useTryAgentCore({
+      owner,
+      user,
+      agent: draftAgent,
+      createDraftAgent,
+    });
+
+  const hasContent = useMemo(() => {
+    return formData.instructions?.trim() || formData.actions.length > 0;
+  }, [formData.instructions, formData.actions.length]);
+
+  // Determine what to render in the main content area
+  const renderContent = () => {
+    if (!user) {
+      return <LoadingState message="Loading user..." />;
+    }
+
+    if (!hasContent) {
+      return (
+        <EmptyState
+          message="Ready to test your agent?"
+          description="Add some instructions or actions to your agent to start testing it here."
+        />
+      );
+    }
+
+    if (isSavingDraftAgent && !draftAgent) {
+      return <LoadingState message="Preparing your agent..." />;
+    }
+
+    if (!draftAgent && !isSavingDraftAgent) {
+      return (
+        <EmptyState
+          message="Unable to create preview"
+          description="There was an issue creating a preview of your agent. Try making a small change to refresh."
+        />
+      );
+    }
+
+    // Show the actual conversation interface
+    return (
+      <>
+        <div className="flex-grow overflow-y-auto">
+          {conversation ? (
+            <ConversationViewer
+              owner={owner}
+              user={user}
+              conversationId={conversation.sId}
+              onStickyMentionsChange={setStickyMentions}
+              isInModal
+              key={conversation.sId}
+            />
+          ) : (
+            <EmptyState
+              message="Start a conversation"
+              description="Send a message below to test your agent and see how it responds."
+            />
+          )}
+        </div>
+        <div className="shrink-0">
+          <AssistantInputBar
+            disableButton={isSavingDraftAgent}
+            owner={owner}
+            onSubmit={handleSubmit}
+            stickyMentions={stickyMentions}
+            conversationId={conversation?.sId || null}
+            additionalAgentConfiguration={draftAgent ?? undefined}
+            actions={["attachment"]}
+            disableAutoFocus
+            isFloating={false}
+          />
+        </div>
+      </>
+    );
+  };
+
+  return (
+    <div
+      className="flex h-full w-full flex-col"
+      role="main"
+      aria-label="Agent preview"
+    >
+      <ActionValidationProvider owner={owner}>
+        <GenerationContextProvider>{renderContent()}</GenerationContextProvider>
+      </ActionValidationProvider>
+    </div>
+  );
+});

--- a/front/components/agent_builder/AgentBuilderRightPanel.tsx
+++ b/front/components/agent_builder/AgentBuilderRightPanel.tsx
@@ -107,14 +107,14 @@ interface ExpandedContentProps {
 
 function ExpandedContent({ selectedTab }: ExpandedContentProps) {
   return (
-    <div className="flex flex-1 flex-col">
+    <div className="flex flex-1 flex-col min-h-0">
       {selectedTab === "testing" && (
-        <div className="flex-1 h-full min-h-0">
+        <div className="flex-1 min-h-0">
           <AgentBuilderPreview />
         </div>
       )}
       {selectedTab === "performance" && (
-        <div className="flex-1 p-4">
+        <div className="flex-1 overflow-y-auto p-4">
           <div className="space-y-4">Performance</div>
         </div>
       )}

--- a/front/components/agent_builder/AgentBuilderRightPanel.tsx
+++ b/front/components/agent_builder/AgentBuilderRightPanel.tsx
@@ -109,7 +109,7 @@ function ExpandedContent({ selectedTab }: ExpandedContentProps) {
   return (
     <div className="flex flex-1 flex-col">
       {selectedTab === "testing" && (
-        <div className="flex-1">
+        <div className="flex-1 h-full min-h-0">
           <AgentBuilderPreview />
         </div>
       )}

--- a/front/components/agent_builder/AgentBuilderRightPanel.tsx
+++ b/front/components/agent_builder/AgentBuilderRightPanel.tsx
@@ -107,9 +107,9 @@ interface ExpandedContentProps {
 
 function ExpandedContent({ selectedTab }: ExpandedContentProps) {
   return (
-    <div className="flex flex-1 flex-col min-h-0">
+    <div className="flex min-h-0 flex-1 flex-col">
       {selectedTab === "testing" && (
-        <div className="flex-1 min-h-0">
+        <div className="min-h-0 flex-1">
           <AgentBuilderPreview />
         </div>
       )}

--- a/front/components/agent_builder/AgentBuilderRightPanel.tsx
+++ b/front/components/agent_builder/AgentBuilderRightPanel.tsx
@@ -12,6 +12,7 @@ import { ScrollArea } from "@dust-tt/sparkle";
 import React, { useContext, useState } from "react";
 
 import { AgentBuilderContext } from "./AgentBuilderContext";
+import { AgentBuilderPreview } from "./AgentBuilderPreview";
 
 type AgentBuilderRightPanelTabType = "testing" | "performance";
 
@@ -107,12 +108,16 @@ interface ExpandedContentProps {
 function ExpandedContent({ selectedTab }: ExpandedContentProps) {
   return (
     <div className="flex flex-1 flex-col">
-      <div className="flex-1 p-4">
-        {selectedTab === "testing" && <div className="space-y-4">Testing</div>}
-        {selectedTab === "performance" && (
+      {selectedTab === "testing" && (
+        <div className="flex-1">
+          <AgentBuilderPreview />
+        </div>
+      )}
+      {selectedTab === "performance" && (
+        <div className="flex-1 p-4">
           <div className="space-y-4">Performance</div>
-        )}
-      </div>
+        </div>
+      )}
     </div>
   );
 }

--- a/front/components/agent_builder/hooks/useAgentPreview.ts
+++ b/front/components/agent_builder/hooks/useAgentPreview.ts
@@ -6,10 +6,7 @@ import { useFormContext } from "react-hook-form";
 import { useAgentBuilderContext } from "@app/components/agent_builder/AgentBuilderContext";
 import type { AgentBuilderFormData } from "@app/components/agent_builder/AgentBuilderFormContext";
 import { submitAgentBuilderForm } from "@app/components/agent_builder/submitAgentBuilderForm";
-import {
-  createConversationWithMessage,
-  submitMessage,
-} from "@app/components/assistant/conversation/lib";
+import { createConversationWithMessage, submitMessage } from "@app/components/assistant/conversation/lib";
 import { useMCPServerViewsContext } from "@app/components/assistant_builder/contexts/MCPServerViewsContext";
 import type { DustError } from "@app/lib/error";
 import type {
@@ -27,6 +24,7 @@ import { Err, Ok } from "@app/types";
 export function usePreviewAgent() {
   const { owner } = useAgentBuilderContext();
   const { mcpServerViews } = useMCPServerViewsContext();
+  // const allForm = useWatch<AgentBuilderFormData>()
   const form = useFormContext<AgentBuilderFormData>();
   const formData = form.watch();
 

--- a/front/components/agent_builder/hooks/useAgentPreview.ts
+++ b/front/components/agent_builder/hooks/useAgentPreview.ts
@@ -46,7 +46,11 @@ export function usePreviewAgent() {
 
   const createDraftAgent =
     useCallback(async (): Promise<LightAgentConfigurationType | null> => {
-      if (draftAgent && isEqual(lastFormDataRef.current, formData)) {
+      // Always create a new draft if form data has changed
+      if (!isEqual(lastFormDataRef.current, formData)) {
+        // Form data has changed, we need to create a new draft
+      } else if (draftAgent) {
+        // Form data hasn't changed and we have a draft, return existing
         return draftAgent;
       }
 

--- a/front/components/agent_builder/hooks/useAgentPreview.ts
+++ b/front/components/agent_builder/hooks/useAgentPreview.ts
@@ -6,7 +6,10 @@ import { useFormContext } from "react-hook-form";
 import { useAgentBuilderContext } from "@app/components/agent_builder/AgentBuilderContext";
 import type { AgentBuilderFormData } from "@app/components/agent_builder/AgentBuilderFormContext";
 import { submitAgentBuilderForm } from "@app/components/agent_builder/submitAgentBuilderForm";
-import { createConversationWithMessage, submitMessage } from "@app/components/assistant/conversation/lib";
+import {
+  createConversationWithMessage,
+  submitMessage,
+} from "@app/components/assistant/conversation/lib";
 import { useMCPServerViewsContext } from "@app/components/assistant_builder/contexts/MCPServerViewsContext";
 import type { DustError } from "@app/lib/error";
 import type {
@@ -24,7 +27,7 @@ import { Err, Ok } from "@app/types";
 export function usePreviewAgent() {
   const { owner } = useAgentBuilderContext();
   const { mcpServerViews } = useMCPServerViewsContext();
-  // const allForm = useWatch<AgentBuilderFormData>()
+
   const form = useFormContext<AgentBuilderFormData>();
   const formData = form.watch();
 

--- a/front/components/agent_builder/hooks/useAgentPreview.ts
+++ b/front/components/agent_builder/hooks/useAgentPreview.ts
@@ -1,0 +1,286 @@
+import { useSendNotification } from "@dust-tt/sparkle";
+import { isEqual } from "lodash";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { useFormContext } from "react-hook-form";
+
+import { useAgentBuilderContext } from "@app/components/agent_builder/AgentBuilderContext";
+import type { AgentBuilderFormData } from "@app/components/agent_builder/AgentBuilderFormContext";
+import { submitAgentBuilderForm } from "@app/components/agent_builder/submitAgentBuilderForm";
+import {
+  createConversationWithMessage,
+  submitMessage,
+} from "@app/components/assistant/conversation/lib";
+import { useMCPServerViewsContext } from "@app/components/assistant_builder/contexts/MCPServerViewsContext";
+import type { DustError } from "@app/lib/error";
+import type {
+  AgentMention,
+  ContentFragmentsType,
+  ConversationType,
+  LightAgentConfigurationType,
+  MentionType,
+  Result,
+  UserType,
+  WorkspaceType,
+} from "@app/types";
+import { Err, Ok } from "@app/types";
+
+export function usePreviewAgent() {
+  const { owner } = useAgentBuilderContext();
+  const { mcpServerViews } = useMCPServerViewsContext();
+  const form = useFormContext<AgentBuilderFormData>();
+  const formData = form.watch();
+
+  const [draftAgent, setDraftAgent] =
+    useState<LightAgentConfigurationType | null>(null);
+  const [isSavingDraftAgent, setIsSavingDraftAgent] = useState(false);
+  const [draftCreationFailed, setDraftCreationFailed] = useState(false);
+
+  const sendNotification = useSendNotification();
+  const lastFormDataRef = useRef<AgentBuilderFormData>(formData);
+  const nameDebounceTimeoutRef = useRef<NodeJS.Timeout | null>(null);
+
+  // Memoize the form data to check for meaningful content
+  const hasContent = useMemo(() => {
+    return formData.instructions?.trim() || formData.actions.length > 0;
+  }, [formData.instructions, formData.actions.length]);
+
+  const createDraftAgent =
+    useCallback(async (): Promise<LightAgentConfigurationType | null> => {
+      if (draftAgent && isEqual(lastFormDataRef.current, formData)) {
+        return draftAgent;
+      }
+
+      setIsSavingDraftAgent(true);
+      setDraftCreationFailed(false);
+
+      const aRes = await submitAgentBuilderForm({
+        formData: {
+          ...formData,
+          agentSettings: {
+            ...formData.agentSettings,
+            name: formData.agentSettings.name || "Draft Agent",
+            description:
+              formData.agentSettings.description || "Draft Agent for Testing",
+            pictureUrl:
+              formData.agentSettings.pictureUrl ||
+              "https://dust.tt/static/assistants/logo.svg",
+          },
+        },
+        owner,
+        mcpServerViews,
+        agentConfigurationId: null,
+        isDraft: true,
+      });
+
+      if (!aRes.isOk()) {
+        sendNotification({
+          title: "Error saving Draft Agent",
+          description: aRes.error.message,
+          type: "error",
+        });
+        setIsSavingDraftAgent(false);
+        setDraftCreationFailed(true);
+        return null;
+      }
+
+      setDraftAgent(aRes.value);
+      lastFormDataRef.current = formData;
+      setIsSavingDraftAgent(false);
+
+      return aRes.value;
+    }, [draftAgent, owner, formData, mcpServerViews, sendNotification]);
+
+  useEffect(() => {
+    const createDraftAgentIfNeeded = async () => {
+      if (
+        hasContent &&
+        !draftAgent &&
+        !isSavingDraftAgent &&
+        !draftCreationFailed
+      ) {
+        await createDraftAgent();
+      } else if (!hasContent) {
+        setIsSavingDraftAgent(false);
+        setDraftCreationFailed(false);
+      }
+    };
+
+    void createDraftAgentIfNeeded();
+  }, [
+    hasContent,
+    draftAgent,
+    isSavingDraftAgent,
+    draftCreationFailed,
+    createDraftAgent,
+  ]);
+
+  useEffect(() => {
+    if (!isEqual(lastFormDataRef.current, formData)) {
+      setDraftCreationFailed(false);
+    }
+  }, [formData]);
+
+  // Debounced draft creation for agent name changes
+  useEffect(() => {
+    const previousName = lastFormDataRef.current.agentSettings.name;
+    const currentName = formData.agentSettings.name;
+
+    // Only trigger debounced creation if name changed and we have content
+    if (previousName !== currentName && currentName?.trim() && hasContent) {
+      if (nameDebounceTimeoutRef.current) {
+        clearTimeout(nameDebounceTimeoutRef.current);
+      }
+
+      nameDebounceTimeoutRef.current = setTimeout(() => {
+        void createDraftAgent();
+      }, 1000);
+    }
+  }, [formData.agentSettings.name, hasContent, createDraftAgent]);
+
+  useEffect(() => {
+    return () => {
+      // Cleanup debounce timeout on unmount
+      if (nameDebounceTimeoutRef.current) {
+        clearTimeout(nameDebounceTimeoutRef.current);
+      }
+      // Note: We don't delete the draft agent here as it may be referenced
+      // in conversations. Draft agents are cleaned up by a background process
+      // that only removes unused drafts.
+    };
+  }, []);
+
+  return {
+    draftAgent,
+    isSavingDraftAgent,
+    createDraftAgent,
+  };
+}
+
+export function useTryAgentCore({
+  owner,
+  user,
+  agent,
+  createDraftAgent,
+}: {
+  owner: WorkspaceType;
+  user: UserType | null;
+  agent: LightAgentConfigurationType | null;
+  createDraftAgent?: () => Promise<LightAgentConfigurationType | null>;
+}) {
+  const [stickyMentions, setStickyMentions] = useState<AgentMention[]>(
+    agent?.sId ? [{ configurationId: agent.sId }] : []
+  );
+  const [conversation, setConversation] = useState<ConversationType | null>(
+    null
+  );
+  const sendNotification = useSendNotification();
+
+  // Memoize the conversation title to avoid unnecessary string concatenation
+  const conversationTitle = useMemo(() => {
+    return `Trying @${agent?.name || "your agent"}`;
+  }, [agent?.name]);
+
+  const handleSubmit = async (
+    input: string,
+    mentions: MentionType[],
+    contentFragments: ContentFragmentsType
+  ): Promise<Result<undefined, DustError>> => {
+    if (!user) {
+      return new Err({
+        code: "internal_error",
+        name: "No user",
+        message: "No user found",
+      });
+    }
+
+    // Create or update draft agent before submitting message if createDraftAgent is provided
+    let currentAgent = agent;
+    if (createDraftAgent) {
+      try {
+        currentAgent = await createDraftAgent();
+        if (!currentAgent) {
+          return new Err({
+            code: "internal_error",
+            name: "Draft Agent Creation Failed",
+            message: "Failed to create draft agent before submitting message",
+          });
+        }
+
+        // Update sticky mentions with the newly created draft agent
+        setStickyMentions([{ configurationId: currentAgent.sId }]);
+
+        // Update mentions in the message data to use the newly created draft agent
+        const updatedMentions = mentions.map((mention) =>
+          mention.configurationId === agent?.sId && currentAgent?.sId
+            ? { ...mention, configurationId: currentAgent.sId }
+            : mention
+        );
+        mentions = updatedMentions;
+      } catch (error) {
+        return new Err({
+          code: "internal_error",
+          name: "Draft Agent Creation Failed",
+          message: "Failed to create draft agent before submitting message",
+        });
+      }
+    }
+
+    const messageData = { input, mentions, contentFragments };
+    if (!conversation) {
+      const result = await createConversationWithMessage({
+        owner,
+        user,
+        messageData,
+        visibility: "test",
+        title: conversationTitle,
+      });
+      if (result.isOk()) {
+        setConversation(result.value);
+        return new Ok(undefined);
+      }
+      sendNotification({
+        title: result.error.title,
+        description: result.error.message,
+        type: "error",
+      });
+      return new Err({
+        code: "internal_error",
+        name: result.error.title,
+        message: result.error.message,
+      });
+    } else {
+      const result = await submitMessage({
+        owner,
+        user,
+        conversationId: conversation.sId as string,
+        messageData,
+      });
+      if (result.isOk()) {
+        return new Ok(undefined);
+      }
+      sendNotification({
+        title: result.error.title,
+        description: result.error.message,
+        type: "error",
+      });
+
+      return new Err({
+        code: "internal_error",
+        name: result.error.title,
+        message: result.error.message,
+      });
+    }
+  };
+
+  useEffect(() => {
+    setStickyMentions(agent?.sId ? [{ configurationId: agent.sId }] : []);
+  }, [agent]);
+
+  return {
+    stickyMentions,
+    setStickyMentions,
+    conversation,
+    setConversation,
+    handleSubmit,
+  };
+}

--- a/front/components/agent_builder/hooks/useAgentPreview.ts
+++ b/front/components/agent_builder/hooks/useAgentPreview.ts
@@ -3,7 +3,6 @@ import { isEqual } from "lodash";
 import { useCallback, useEffect, useRef, useState } from "react";
 import { useFormContext } from "react-hook-form";
 
-import { useDebounce } from "@app/hooks/useDebounce";
 import { useAgentBuilderContext } from "@app/components/agent_builder/AgentBuilderContext";
 import type { AgentBuilderFormData } from "@app/components/agent_builder/AgentBuilderFormContext";
 import { submitAgentBuilderForm } from "@app/components/agent_builder/submitAgentBuilderForm";
@@ -12,6 +11,7 @@ import {
   submitMessage,
 } from "@app/components/assistant/conversation/lib";
 import { useMCPServerViewsContext } from "@app/components/assistant_builder/contexts/MCPServerViewsContext";
+import { useDebounce } from "@app/hooks/useDebounce";
 import type { DustError } from "@app/lib/error";
 import type {
   AgentMention,


### PR DESCRIPTION
## Description

This PR implements a preview tab in the Agent Builder v2 that allows testing draft agents before publishing them. The preview component creates a temporary draft agent configuration based on the current form data. When form data changes, a new draft agent is automatically created to reflect the latest configuration.

**References:**
- https://github.com/dust-tt/tasks/issues/3320

## Risk

Low

## Deploy Plan

Deploy front