### PR TITLE
AgentReasoningConfiguration has mandatory mcpServerConfigurationId

### DIFF
--- a/front/lib/models/assistant/actions/reasoning.ts
+++ b/front/lib/models/assistant/actions/reasoning.ts
@@ -18,7 +18,7 @@ export class AgentReasoningConfiguration extends WorkspaceAwareModel<AgentReason
 
   declare mcpServerConfigurationId: ForeignKey<
     AgentMCPServerConfiguration["id"]
-  > | null;
+  >;
 
   declare sId: string;
 }
@@ -74,10 +74,10 @@ AgentReasoningConfiguration.init(
 );
 
 AgentMCPServerConfiguration.hasMany(AgentReasoningConfiguration, {
-  foreignKey: { name: "mcpServerConfigurationId", allowNull: true },
+  foreignKey: { name: "mcpServerConfigurationId", allowNull: false },
   onDelete: "RESTRICT",
 });
 AgentReasoningConfiguration.belongsTo(AgentMCPServerConfiguration, {
-  foreignKey: { name: "mcpServerConfigurationId", allowNull: true },
+  foreignKey: { name: "mcpServerConfigurationId", allowNull: false },
   onDelete: "RESTRICT",
 });

--- a/front/migrations/db/migration_296.sql
+++ b/front/migrations/db/migration_296.sql
@@ -1,3 +1,2 @@
 -- Migration created on Jul 02, 2025
 ALTER TABLE "agent_reasoning_configurations" ALTER COLUMN "mcpServerConfigurationId" SET NOT NULL;
-ALTER TABLE "agent_reasoning_configurations"  ADD FOREIGN KEY ("mcpServerConfigurationId") REFERENCES "agent_mcp_server_configurations" ("id") ON DELETE RESTRICT ON UPDATE CASCADE;

--- a/front/migrations/db/migration_296.sql
+++ b/front/migrations/db/migration_296.sql
@@ -1,0 +1,3 @@
+-- Migration created on Jul 02, 2025
+ALTER TABLE "agent_reasoning_configurations" ALTER COLUMN "mcpServerConfigurationId" SET NOT NULL;
+ALTER TABLE "agent_reasoning_configurations"  ADD FOREIGN KEY ("mcpServerConfigurationId") REFERENCES "agent_mcp_server_configurations" ("id") ON DELETE RESTRICT ON UPDATE CASCADE;


### PR DESCRIPTION
## Description

`mcpServerConfigurationId` cannot be null on AgentMCPServerConfiguration.


`SELECT * FROM agent_reasoning_configurations WHERE "mcpServerConfigurationId" IS NULL;` has no results in both DBs.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

Run migration. 
Deploy code. 

(I think the opposite would also work)