### PR TITLE
[front] Handle organization selection in case of multiple org memberships

### DIFF
--- a/front/lib/api/workos/types.ts
+++ b/front/lib/api/workos/types.ts
@@ -1,0 +1,15 @@
+export type OrganizationSelectionRequiredError = {
+  code: "organization_selection_required";
+  pending_authentication_token: string;
+};
+
+export function isOrganizationSelectionRequiredError(
+  error: unknown
+): error is OrganizationSelectionRequiredError {
+  return (
+    typeof error === "object" &&
+    error !== null &&
+    (error as any).code === "organization_selection_required" &&
+    typeof (error as any).pending_authentication_token === "string"
+  );
+}


### PR DESCRIPTION
## Description

When using sso enforced redirection with organizationId specified, we don't have the organization chooser and need to call the authenticateWithOrganizationSelection directly.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

low

## Deploy Plan

deploy front
