### PR TITLE
Allow .module file in GitHub supported file EXTENSION_WHITELIST

### DIFF
--- a/connectors/src/connectors/github/lib/code/supported_files.ts
+++ b/connectors/src/connectors/github/lib/code/supported_files.ts
@@ -23,6 +23,7 @@ const EXTENSION_WHITELIST = [
   ".neon", // PHP configuration
   ".phtml", // PHP template
   ".twig", // PHP template
+  ".module", // Drupal module
 
   ".xhtml", // XML/HTML
   ".xsd", // XML Schema Definition


### PR DESCRIPTION
## Description

Adding a new extension type for Github code sync. 
module files are used in Drupal projects. 

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

Deploy connectors. 