### PR TITLE
[front] fix: Fix scrollTo w/ cmd+click

### DIFF
--- a/front/components/assistant/conversation/SidebarMenu.tsx
+++ b/front/components/assistant/conversation/SidebarMenu.tsx
@@ -25,7 +25,6 @@ import type { NextRouter } from "next/router";
 import { useRouter } from "next/router";
 import React, { useCallback, useContext, useState } from "react";
 
-import { CONVERSATION_VIEW_SCROLL_LAYOUT } from "@app/components/assistant/conversation/constant";
 import { useConversationsNavigation } from "@app/components/assistant/conversation/ConversationsNavigationProvider";
 import { DeleteConversationsDialog } from "@app/components/assistant/conversation/DeleteConversationsDialog";
 import { InputBarContext } from "@app/components/assistant/conversation/input_bar/InputBarContext";
@@ -187,10 +186,6 @@ export function AssistantSidebarMenu({ owner }: AssistantSidebarMenuProps) {
 
   const { setAnimate } = useContext(InputBarContext);
 
-  const triggerInputAnimation = useCallback(() => {
-    setAnimate(true);
-  }, [setAnimate]);
-
   const handleNewClick = useCallback(async () => {
     setSidebarOpen(false);
     const { cId } = router.query;
@@ -199,14 +194,10 @@ export function AssistantSidebarMenu({ owner }: AssistantSidebarMenuProps) {
       typeof cId === "string" &&
       cId === "new";
 
-    if (isNewConversation && triggerInputAnimation) {
-      triggerInputAnimation();
-    } else {
-      await router.push(`/w/${owner.sId}/assistant/new`);
+    if (isNewConversation) {
+      setAnimate(true);
     }
-
-    document.getElementById(CONVERSATION_VIEW_SCROLL_LAYOUT)?.scrollTo(0, 0);
-  }, [owner.sId, router, setSidebarOpen, triggerInputAnimation]);
+  }, [router, setSidebarOpen, setAnimate]);
 
   return (
     <>
@@ -247,6 +238,7 @@ export function AssistantSidebarMenu({ owner }: AssistantSidebarMenuProps) {
                 />
                 <Button
                   label="New"
+                  href={`/w/${owner.sId}/assistant/new`}
                   icon={ChatBubbleBottomCenterTextIcon}
                   className="shrink"
                   tooltip="Create a new conversation"

--- a/front/components/assistant/conversation/SidebarMenu.tsx
+++ b/front/components/assistant/conversation/SidebarMenu.tsx
@@ -27,7 +27,6 @@ import React, { useCallback, useContext, useState } from "react";
 
 import { useConversationsNavigation } from "@app/components/assistant/conversation/ConversationsNavigationProvider";
 import { DeleteConversationsDialog } from "@app/components/assistant/conversation/DeleteConversationsDialog";
-import { InputBarContext } from "@app/components/assistant/conversation/input_bar/InputBarContext";
 import { SidebarContext } from "@app/components/sparkle/SidebarContext";
 import {
   useConversations,
@@ -184,20 +183,9 @@ export function AssistantSidebarMenu({ owner }: AssistantSidebarMenuProps) {
     ? groupConversationsByDate(conversations)
     : ({} as Record<GroupLabel, ConversationWithoutContentType[]>);
 
-  const { setAnimate } = useContext(InputBarContext);
-
   const handleNewClick = useCallback(async () => {
     setSidebarOpen(false);
-    const { cId } = router.query;
-    const isNewConversation =
-      router.pathname === "/w/[wId]/assistant/[cId]" &&
-      typeof cId === "string" &&
-      cId === "new";
-
-    if (isNewConversation) {
-      setAnimate(true);
-    }
-  }, [router, setSidebarOpen, setAnimate]);
+  }, [setSidebarOpen]);
 
   return (
     <>

--- a/front/components/assistant/conversation/input_bar/InputBarContainer.tsx
+++ b/front/components/assistant/conversation/input_bar/InputBarContainer.tsx
@@ -216,11 +216,12 @@ const InputBarContainer = ({
   useEffect(() => {
     if (animate) {
       editorService.focusEnd();
-      /**
-       * Scroll to top when animate change
-       */
-      document.getElementById(CONVERSATION_VIEW_SCROLL_LAYOUT)?.scrollTo(0, 0);
     }
+    /**
+     * Scroll to top when animate change or the editorService re-render.
+     * Which so far are good enough to scroll to the top.
+     */
+    document.getElementById(CONVERSATION_VIEW_SCROLL_LAYOUT)?.scrollTo(0, 0);
   }, [animate, editorService]);
 
   useHandleMentions(

--- a/front/components/assistant/conversation/input_bar/InputBarContainer.tsx
+++ b/front/components/assistant/conversation/input_bar/InputBarContainer.tsx
@@ -40,6 +40,8 @@ import type {
 } from "@app/types";
 import { getSupportedFileExtensions } from "@app/types";
 
+import { CONVERSATION_VIEW_SCROLL_LAYOUT } from "../constant";
+
 export const INPUT_BAR_ACTIONS = [
   "attachment",
   "assistants-list",
@@ -214,6 +216,10 @@ const InputBarContainer = ({
   useEffect(() => {
     if (animate) {
       editorService.focusEnd();
+      /**
+       * Scroll to top when animate change
+       */
+      document.getElementById(CONVERSATION_VIEW_SCROLL_LAYOUT)?.scrollTo(0, 0);
     }
   }, [animate, editorService]);
 

--- a/front/components/assistant/conversation/input_bar/InputBarContainer.tsx
+++ b/front/components/assistant/conversation/input_bar/InputBarContainer.tsx
@@ -40,8 +40,6 @@ import type {
 } from "@app/types";
 import { getSupportedFileExtensions } from "@app/types";
 
-import { CONVERSATION_VIEW_SCROLL_LAYOUT } from "../constant";
-
 export const INPUT_BAR_ACTIONS = [
   "attachment",
   "assistants-list",
@@ -217,11 +215,6 @@ const InputBarContainer = ({
     if (animate) {
       editorService.focusEnd();
     }
-    /**
-     * Scroll to top when animate change or the editorService re-render.
-     * Which so far are good enough to scroll to the top.
-     */
-    document.getElementById(CONVERSATION_VIEW_SCROLL_LAYOUT)?.scrollTo(0, 0);
   }, [animate, editorService]);
 
   useHandleMentions(

--- a/front/pages/w/[wId]/assistant/[cId]/index.tsx
+++ b/front/pages/w/[wId]/assistant/[cId]/index.tsx
@@ -2,11 +2,11 @@ import type { InferGetServerSidePropsType } from "next";
 import { useRouter } from "next/router";
 import { useEffect, useState } from "react";
 
+import { CONVERSATION_VIEW_SCROLL_LAYOUT } from "@app/components/assistant/conversation/constant";
 import { ConversationContainer } from "@app/components/assistant/conversation/ConversationContainer";
 import type { ConversationLayoutProps } from "@app/components/assistant/conversation/ConversationLayout";
 import ConversationLayout from "@app/components/assistant/conversation/ConversationLayout";
 import { useConversationsNavigation } from "@app/components/assistant/conversation/ConversationsNavigationProvider";
-import { CONVERSATION_PARENT_SCROLL_DIV_ID } from "@app/components/assistant/conversation/lib";
 import AppRootLayout from "@app/components/sparkle/AppRootLayout";
 import config from "@app/lib/api/config";
 import { withDefaultUserAuthRequirements } from "@app/lib/iam/session";
@@ -82,14 +82,7 @@ export default function AssistantConversation({
       // Force re-render by setting a new key with a random number.
       setConversationKey(`new_${Math.random() * 1000}`);
 
-      // Scroll to the top of the conversation container when clicking on "new".
-      const mainTag = document.getElementById(
-        CONVERSATION_PARENT_SCROLL_DIV_ID["page"]
-      );
-
-      if (mainTag) {
-        mainTag.scrollTo(0, 0);
-      }
+      document.getElementById(CONVERSATION_VIEW_SCROLL_LAYOUT)?.scrollTo(0, 0);
     }
 
     const agentId = assistant ?? null;


### PR DESCRIPTION
## Description
- https://github.com/dust-tt/tasks/issues/3354
Previous PR https://github.com/dust-tt/dust/pull/13733 removed the `href` element from the "New" conversation button. This PR put it back and fix other edge cases. Reuse a previous behavior of scrolling to top in the `AssistantConversation`, just replace with the correct element id. 

## Tests
- [x] click "New" from a conv: scroll to top
- [x] cmd+click from a conv: new page, so at the top already
- [x] click "Chat" from a conv: scroll to top
- [x] click link to `/new?assistant=@...` from a conv: scroll to top
- [x] tested the same on mobile

## Risk
- Low, at worst scroll wrongly

## Deploy Plan
- Deploy front
