### PR TITLE
[WorkOS Events] Handle missing groups gracefully in deletion workflow

### DIFF
--- a/front/temporal/workos_events_queue/activities.ts
+++ b/front/temporal/workos_events_queue/activities.ts
@@ -670,7 +670,16 @@ async function handleGroupDelete(
   );
 
   if (!group) {
-    throw new Error("Group to delete not found");
+    // Group already deleted, log and return success to avoid blocking the workflow
+    logger.info(
+      {
+        workspaceId: workspace.sId,
+        directoryId: event.directoryId,
+        groupId: event.id,
+      },
+      "Group to delete not found, likely already deleted"
+    );
+    return;
   }
 
   await group.delete(auth);


### PR DESCRIPTION
## Description
Fixes [this issue](https://app.datadoghq.eu/logs?query=%28%22Activity%20failed%22%20OR%20%22Unhandled%20activity%20error%22%29%20%40attempt%3A%3E14%20%40dd.service%3Afront-worker%20region%3Aus-central1%20%40workflowId%3Aworkos-events-dsync.group.deleted-1751473592610&agg_m=count&agg_m_source=base&agg_t=count&clustering_pattern_field_path=message&cols=host%2Cservice&link_source=monitor_notif&messageDisplay=inline&refresh_mode=sliding&storage=hot&stream_sort=desc&viz=stream&from_ts=1751469651867&to_ts=1751484051867)

- Modified `handleGroupDelete` to handle cases where the group is already deleted
- Instead of throwing an error, we now log the event and return success
- This prevents temporal workflows from getting stuck in retry loops

## Risks
Blast radius: WorkOS group synchronization workflows
Risk: low

## Tests
Manual verification of the workflow behavior when group is missing

## Deploy Plan
- Deploy front service