### PR TITLE
[front] fix: Missing scroll when clicking new on the /assistant/new page

### DIFF
--- a/front/components/assistant/conversation/SidebarMenu.tsx
+++ b/front/components/assistant/conversation/SidebarMenu.tsx
@@ -25,8 +25,10 @@ import type { NextRouter } from "next/router";
 import { useRouter } from "next/router";
 import React, { useCallback, useContext, useState } from "react";
 
+import { CONVERSATION_VIEW_SCROLL_LAYOUT } from "@app/components/assistant/conversation/constant";
 import { useConversationsNavigation } from "@app/components/assistant/conversation/ConversationsNavigationProvider";
 import { DeleteConversationsDialog } from "@app/components/assistant/conversation/DeleteConversationsDialog";
+import { InputBarContext } from "@app/components/assistant/conversation/input_bar/InputBarContext";
 import { SidebarContext } from "@app/components/sparkle/SidebarContext";
 import {
   useConversations,
@@ -36,9 +38,6 @@ import { useFeatureFlags } from "@app/lib/swr/workspaces";
 import { removeDiacritics, subFilter } from "@app/lib/utils";
 import type { ConversationWithoutContentType, WorkspaceType } from "@app/types";
 import { isBuilder } from "@app/types";
-
-import { CONVERSATION_VIEW_SCROLL_LAYOUT } from "./constant";
-import { InputBarContext } from "./input_bar/InputBarContext";
 
 type AssistantSidebarMenuProps = {
   owner: WorkspaceType;

--- a/front/components/assistant/conversation/SidebarMenu.tsx
+++ b/front/components/assistant/conversation/SidebarMenu.tsx
@@ -37,6 +37,9 @@ import { removeDiacritics, subFilter } from "@app/lib/utils";
 import type { ConversationWithoutContentType, WorkspaceType } from "@app/types";
 import { isBuilder } from "@app/types";
 
+import { CONVERSATION_VIEW_SCROLL_LAYOUT } from "./constant";
+import { InputBarContext } from "./input_bar/InputBarContext";
+
 type AssistantSidebarMenuProps = {
   owner: WorkspaceType;
 };
@@ -183,9 +186,20 @@ export function AssistantSidebarMenu({ owner }: AssistantSidebarMenuProps) {
     ? groupConversationsByDate(conversations)
     : ({} as Record<GroupLabel, ConversationWithoutContentType[]>);
 
+  const { setAnimate } = useContext(InputBarContext);
+
   const handleNewClick = useCallback(async () => {
     setSidebarOpen(false);
-  }, [setSidebarOpen]);
+    const { cId } = router.query;
+    const isNewConversation =
+      router.pathname === "/w/[wId]/assistant/[cId]" &&
+      typeof cId === "string" &&
+      cId === "new";
+    if (isNewConversation) {
+      setAnimate(true);
+      document.getElementById(CONVERSATION_VIEW_SCROLL_LAYOUT)?.scrollTo(0, 0);
+    }
+  }, [setSidebarOpen, router, setAnimate]);
 
   return (
     <>


### PR DESCRIPTION
## Description
Related to https://github.com/dust-tt/dust/pull/14022q
_Handle missing edge case that was tested before some other changes introduced in the previous PR_:
Add animation when clicking on "New" when already in the `/assistant/new` page

## Tests
- Locally

## Risk
- Low, at worst wrong scroll

## Deploy Plan
- Deploy front
