### PR TITLE
[front] enh(FS tools): add `nodeIds` in search query output

### DIFF
--- a/front/lib/actions/mcp_internal_actions/rendering.ts
+++ b/front/lib/actions/mcp_internal_actions/rendering.ts
@@ -126,7 +126,7 @@ export function renderTagsForToolOutput(
 
 function renderSearchNodeIds(nodeIds?: string[]): string {
   return nodeIds && nodeIds.length > 0
-    ? ` within nodes ${nodeIds?.join(", ")}`
+    ? `within ${nodeIds.length} different subtrees `
     : "";
 }
 

--- a/front/lib/actions/mcp_internal_actions/rendering.ts
+++ b/front/lib/actions/mcp_internal_actions/rendering.ts
@@ -124,20 +124,28 @@ export function renderTagsForToolOutput(
   return `${tagsInAsString}${tagsNotAsString}`;
 }
 
+function renderSearchNodeIds(nodeIds?: string[]): string {
+  return nodeIds && nodeIds.length > 0
+    ? ` within nodes ${nodeIds?.join(", ")}`
+    : "";
+}
+
 export function makeQueryResource(
   query: string,
   relativeTimeFrame: TimeFrame | null,
   tagsIn?: string[],
-  tagsNot?: string[]
+  tagsNot?: string[],
+  nodeIds?: string[]
 ): SearchQueryResourceType {
   const timeFrameAsString =
     renderRelativeTimeFrameForToolOutput(relativeTimeFrame);
   const tagsAsString = renderTagsForToolOutput(tagsIn, tagsNot);
+  const nodeIdsAsString = renderSearchNodeIds(nodeIds);
 
   return {
     mimeType: INTERNAL_MIME_TYPES.TOOL_OUTPUT.DATA_SOURCE_SEARCH_QUERY,
     text: query
-      ? `Searching "${query}", ${timeFrameAsString}${tagsAsString}.`
+      ? `Searching "${query}" ${nodeIdsAsString}${timeFrameAsString}${tagsAsString}.`
       : `Searching ${timeFrameAsString}${tagsAsString}.`,
     uri: "",
   };

--- a/front/lib/actions/mcp_internal_actions/rendering.ts
+++ b/front/lib/actions/mcp_internal_actions/rendering.ts
@@ -130,15 +130,20 @@ function renderSearchNodeIds(nodeIds?: string[]): string {
     : "";
 }
 
-export function makeQueryResource(
-  query: string,
-  relativeTimeFrame: TimeFrame | null,
-  tagsIn?: string[],
-  tagsNot?: string[],
-  nodeIds?: string[]
-): SearchQueryResourceType {
-  const timeFrameAsString =
-    renderRelativeTimeFrameForToolOutput(relativeTimeFrame);
+export function makeQueryResource({
+  query,
+  timeFrame,
+  tagsIn,
+  tagsNot,
+  nodeIds,
+}: {
+  query: string;
+  timeFrame: TimeFrame | null;
+  tagsIn?: string[];
+  tagsNot?: string[];
+  nodeIds?: string[];
+}): SearchQueryResourceType {
+  const timeFrameAsString = renderRelativeTimeFrameForToolOutput(timeFrame);
   const tagsAsString = renderTagsForToolOutput(tagsIn, tagsNot);
   const nodeIdsAsString = renderSearchNodeIds(nodeIds);
 

--- a/front/lib/actions/mcp_internal_actions/servers/data_sources_file_system.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/data_sources_file_system.ts
@@ -348,7 +348,13 @@ async function searchCallback(
     content: [
       {
         type: "resource" as const,
-        resource: makeQueryResource(query, timeFrame, tagsIn, tagsNot, nodeIds),
+        resource: makeQueryResource({
+          query,
+          timeFrame,
+          tagsIn,
+          tagsNot,
+          nodeIds,
+        }),
       },
       ...(renderedNodes
         ? [{ type: "resource" as const, resource: renderedNodes }]

--- a/front/lib/actions/mcp_internal_actions/servers/data_sources_file_system.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/data_sources_file_system.ts
@@ -348,7 +348,7 @@ async function searchCallback(
     content: [
       {
         type: "resource" as const,
-        resource: makeQueryResource(query, timeFrame, tagsIn, tagsNot),
+        resource: makeQueryResource(query, timeFrame, tagsIn, tagsNot, nodeIds),
       },
       ...(renderedNodes
         ? [{ type: "resource" as const, resource: renderedNodes }]

--- a/front/lib/actions/mcp_internal_actions/servers/search.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/search.ts
@@ -230,7 +230,7 @@ export async function searchFunction({
       })),
       {
         type: "resource" as const,
-        resource: makeQueryResource(query, timeFrame, tagsIn, tagsNot),
+        resource: makeQueryResource({ query, timeFrame, tagsIn, tagsNot }),
       },
     ],
   };

--- a/front/lib/actions/mcp_internal_actions/servers/search.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/search.ts
@@ -230,7 +230,12 @@ export async function searchFunction({
       })),
       {
         type: "resource" as const,
-        resource: makeQueryResource({ query, timeFrame, tagsIn, tagsNot }),
+        resource: makeQueryResource({
+          query,
+          timeFrame,
+          tagsIn,
+          tagsNot,
+        }),
       },
     ],
   };


### PR DESCRIPTION
## Description

- Follow up on [this thread](https://dust4ai.slack.com/archives/C087M1PQKF0/p1751450577196999).
- This PR adds the mention of the subtrees that are visited by a call to the search tool.
- Technically we could have a more detailed description of where the search operates, notably because we have the distinction between data sources and nodes. This PR purposefully reads the raw input as is to prepare for a world where we will stop sending the inputs in the outputs and instead directly read them from the parameters.

## Tests

## Risk

- Very low.

## Deploy Plan

- Deploy front.
