### PR TITLE
[Delete Workspace] Fix: delete agent child server configurations

### DIFF
--- a/front/poke/temporal/activities.ts
+++ b/front/poke/temporal/activities.ts
@@ -21,6 +21,7 @@ import {
   AgentDustAppRunConfiguration,
 } from "@app/lib/models/assistant/actions/dust_app_run";
 import {
+  AgentChildAgentConfiguration,
   AgentMCPAction,
   AgentMCPActionOutputItem,
   AgentMCPServerConfiguration,
@@ -273,6 +274,12 @@ export async function deleteAgentsActivity({
         mcpServerConfigurationId: {
           [Op.in]: mcpServerConfigurations.map((r) => `${r.id}`),
         },
+      },
+    });
+    await AgentChildAgentConfiguration.destroy({
+      where: {
+        agentConfigurationId: agent.id,
+        workspaceId: workspace.id,
       },
     });
     await AgentMCPServerConfiguration.destroy({


### PR DESCRIPTION
Description
---
Fixes [this issue](https://dust4ai.slack.com/archives/C050SM8NSPK/p1751529214430199) avoiding fk constraints when deleting mcp server configs

Risks
---
low

Deploy
---
front
