### PR TITLE
[front] input: allow shift-enter even in cmd-enter mode

### DIFF
--- a/front/components/assistant/conversation/input_bar/editor/extensions/ParagraphExtension.ts
+++ b/front/components/assistant/conversation/input_bar/editor/extensions/ParagraphExtension.ts
@@ -12,10 +12,6 @@ export const ParagraphExtension = Paragraph.extend({
       ...this.parent?.(),
 
       "Shift-Enter": () => {
-        if (isCmdEnter) {
-          return false;
-        }
-
         // Chain is what Tiptap does by default for Enter:
         // - newlineInCode: insert line breaks in code blocks
         // - splitListItem: if in a list item, create new list item

--- a/front/components/assistant/conversation/input_bar/editor/extensions/ParagraphExtension.ts
+++ b/front/components/assistant/conversation/input_bar/editor/extensions/ParagraphExtension.ts
@@ -1,13 +1,7 @@
 import { Paragraph } from "@tiptap/extension-paragraph";
 
-import { isSubmitMessageKey } from "@app/lib/keymaps";
-
 export const ParagraphExtension = Paragraph.extend({
   addKeyboardShortcuts() {
-    const submitMessageKey = localStorage.getItem("submitMessageKey");
-    const isCmdEnter =
-      isSubmitMessageKey(submitMessageKey) && submitMessageKey === "cmd+enter";
-
     return {
       ...this.parent?.(),
 


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

closes https://github.com/dust-tt/tasks/issues/3356#issuecomment-3027425775
shift-enter did nothing in the cmd-enter mode. this now creates a new line as regular enter.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

tested by hand

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

low risks

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->

Deploy front