### PR TITLE
CodeBlock supports pretty rendering of markdown

### DIFF
--- a/sparkle/src/components/markdown/CodeBlockWithExtendedSupport.tsx
+++ b/sparkle/src/components/markdown/CodeBlockWithExtendedSupport.tsx
@@ -305,13 +305,12 @@ export function CodeBlockWithExtendedSupport({
         })
       : undefined;
 
+  // Check for valid Mermaid and JSON.
   useEffect(() => {
     if (isStreaming || !validChildrenContent) {
       return;
     }
-
-    // Check for valid Mermaid
-    if (language === "mermaid" && !isValidMermaid && !showMermaid) {
+    if (language === "mermaid") {
       const checkValidMermaid = async () => {
         try {
           await mermaid.parse(validChildrenContent);
@@ -324,8 +323,6 @@ export function CodeBlockWithExtendedSupport({
       };
       void checkValidMermaid();
     }
-
-    // Check for valid JSON
     if (language === "json") {
       try {
         const parsed = JSON.parse(validChildrenContent);
@@ -336,13 +333,7 @@ export function CodeBlockWithExtendedSupport({
         setShowPrettyJson(false);
       }
     }
-  }, [
-    isStreaming,
-    isValidMermaid,
-    showMermaid,
-    language,
-    validChildrenContent,
-  ]);
+  }, [isStreaming, language, validChildrenContent]);
 
   if (inline) {
     return (
@@ -350,7 +341,9 @@ export function CodeBlockWithExtendedSupport({
         {children}
       </CodeBlock>
     );
-  } else if (!inline && isValidMermaid) {
+  }
+
+  if (isValidMermaid) {
     return (
       <ContentBlockWrapper
         content={validChildrenContent}
@@ -375,7 +368,9 @@ export function CodeBlockWithExtendedSupport({
         )}
       </ContentBlockWrapper>
     );
-  } else if (!inline && language === "json" && parsedJson !== null) {
+  }
+
+  if (parsedJson !== null) {
     return (
       <ContentBlockWrapper
         content={validChildrenContent}
@@ -402,16 +397,16 @@ export function CodeBlockWithExtendedSupport({
         )}
       </ContentBlockWrapper>
     );
-  } else {
-    return (
-      <ContentBlockWrapper
-        content={validChildrenContent}
-        getContentToDownload={getContentToDownload}
-      >
-        <CodeBlock className={className} inline={inline}>
-          {children}
-        </CodeBlock>
-      </ContentBlockWrapper>
-    );
   }
+
+  return (
+    <ContentBlockWrapper
+      content={validChildrenContent}
+      getContentToDownload={getContentToDownload}
+    >
+      <CodeBlock className={className} inline={inline}>
+        {children}
+      </CodeBlock>
+    </ContentBlockWrapper>
+  );
 }

--- a/sparkle/src/components/markdown/CodeBlockWithExtendedSupport.tsx
+++ b/sparkle/src/components/markdown/CodeBlockWithExtendedSupport.tsx
@@ -21,7 +21,10 @@ import {
 } from "@sparkle/components";
 import { CodeBlock } from "@sparkle/components/markdown/CodeBlock";
 import { MarkdownContentContext } from "@sparkle/components/markdown/MarkdownContentContext";
-import { PrettyJsonViewer } from "@sparkle/components/markdown/PrettyJsonViewer";
+import {
+  JsonValueType,
+  PrettyJsonViewer,
+} from "@sparkle/components/markdown/PrettyJsonViewer";
 import { CommandLineIcon, SparklesIcon } from "@sparkle/icons/app";
 import { cn } from "@sparkle/lib/utils";
 
@@ -287,7 +290,7 @@ export function CodeBlockWithExtendedSupport({
   const [showMermaid, setShowMermaid] = useState<boolean>(false);
   const [isValidMermaid, setIsValidMermaid] = useState<boolean>(false);
   const [showPrettyJson, setShowPrettyJson] = useState<boolean>(false);
-  const [parsedJson, setParsedJson] = useState<unknown>(null);
+  const [parsedJson, setParsedJson] = useState<JsonValueType | null>(null);
   const { isStreaming } = useContext(MarkdownContentContext);
 
   // Detect language from className

--- a/sparkle/src/components/markdown/PrettyJsonViewer.tsx
+++ b/sparkle/src/components/markdown/PrettyJsonViewer.tsx
@@ -1,0 +1,224 @@
+import React from "react";
+
+import { Chip } from "@sparkle/components/Chip";
+import { cn } from "@sparkle/lib/utils";
+
+// Constants for consistent styling
+const VALUE_CLASSES =
+  "s-text-primary-700 dark:s-text-primary-700-night s-pt-1 s-text-sm";
+const EMPTY_CLASSES =
+  "s-text-primary-500 dark:s-text-primary-500-night s-pt-1 s-text-sm s-italic";
+const INDENT_CLASSES =
+  "s-border-structure-200 dark:s-border-structure-200-night s-max-w-full s-border-l s-pl-4 s-ml-4";
+
+interface JsonViewerProps {
+  data: unknown;
+  className?: string;
+}
+
+type JsonValueType =
+  | string
+  | number
+  | boolean
+  | null
+  | undefined
+  | JsonValueType[]
+  | { [key: string]: JsonValueType };
+
+// Helper component for rendering key-value pairs with consistent styling.
+function KeyValuePair({
+  keyName,
+  value,
+  depth,
+  chipColor,
+  isRootLevel = false,
+}: {
+  keyName: string;
+  value: JsonValueType;
+  depth: number;
+  chipColor: "info" | "highlight";
+  isRootLevel?: boolean;
+}) {
+  const isComplexValue = typeof value === "object" && value !== null;
+
+  if (isComplexValue) {
+    return (
+      <>
+        <Chip
+          size="xs"
+          color={chipColor}
+          label={formatKey(keyName)}
+          className="s-mb-2"
+        />
+        <div className={cn("s-max-w-full", isRootLevel && "s-ml-4")}>
+          <JsonValue value={value} depth={depth + 1} />
+        </div>
+      </>
+    );
+  }
+
+  return (
+    <div
+      className={cn(
+        "s-flex s-items-start",
+        isRootLevel ? "s-gap-3" : "s-gap-2"
+      )}
+    >
+      <Chip size="xs" color={chipColor} label={formatKey(keyName)} />
+      <JsonValue value={value} depth={depth + 1} />
+    </div>
+  );
+}
+
+function JsonValue({
+  value,
+  depth = 0,
+}: {
+  value: JsonValueType;
+  depth?: number;
+}) {
+  if (value === null || value === undefined) {
+    return <span className={EMPTY_CLASSES}>empty</span>;
+  }
+
+  if (typeof value === "boolean") {
+    return <span className={VALUE_CLASSES}>{value ? "Yes" : "No"}</span>;
+  }
+
+  if (typeof value === "number") {
+    return <span className={VALUE_CLASSES}>{value}</span>;
+  }
+
+  if (typeof value === "string") {
+    return (
+      <span className={`${VALUE_CLASSES} s-whitespace-pre-wrap s-break-normal`}>
+        {value}
+      </span>
+    );
+  }
+
+  if (Array.isArray(value)) {
+    if (value.length === 0) {
+      return <span className={EMPTY_CLASSES}>empty list</span>;
+    }
+
+    // Check if it's a simple array of primitives.
+    const isSimpleArray = value.every(
+      (item) => typeof item !== "object" || item === null
+    );
+
+    if (isSimpleArray && value.length <= 5) {
+      return (
+        <span className={VALUE_CLASSES}>
+          {value.map((item, index) => (
+            <span key={index}>
+              <JsonValue value={item} depth={depth + 1} />
+              {index < value.length - 1 && ", "}
+            </span>
+          ))}
+        </span>
+      );
+    }
+
+    return (
+      <div className="s-mt-2">
+        {value.map((item, index) => (
+          <div key={index} className={cn(INDENT_CLASSES)}>
+            <div className="s-flex s-flex-col s-gap-2">
+              <Chip size="xs" color="primary" label={`Item ${index + 1}`} />
+              <div className="s-max-w-full">
+                <JsonValue value={item} depth={depth + 1} />
+              </div>
+            </div>
+          </div>
+        ))}
+      </div>
+    );
+  }
+
+  if (typeof value === "object") {
+    const entries = Object.entries(value);
+    if (entries.length === 0) {
+      return <span className={EMPTY_CLASSES}>empty</span>;
+    }
+
+    // For nested objects, use a card-like layout with vertical bars.
+    if (depth > 0) {
+      return (
+        <div className="s-space-y-2">
+          {entries.map(([key, val]) => (
+            <div key={key} className={cn(INDENT_CLASSES)}>
+              <KeyValuePair
+                keyName={key}
+                value={val}
+                depth={depth}
+                chipColor="info"
+              />
+            </div>
+          ))}
+        </div>
+      );
+    }
+
+    // Root level objects use a table-like layout.
+    return (
+      <div className="s-max-w-full s-space-y-3">
+        {entries.map(([key, val]) => (
+          <div
+            key={key}
+            className={cn(
+              "s-max-w-full s-border-b s-pb-3 last:s-border-0",
+              "s-border-structure-200 dark:s-border-structure-200-night"
+            )}
+          >
+            <KeyValuePair
+              keyName={key}
+              value={val}
+              depth={depth}
+              chipColor="highlight"
+              isRootLevel
+            />
+          </div>
+        ))}
+      </div>
+    );
+  }
+
+  return (
+    <span
+      className={cn(
+        "s-text-sm",
+        "s-text-element-700 dark:s-text-element-700-night"
+      )}
+    >
+      {String(value)}
+    </span>
+  );
+}
+
+function formatKey(key: string): string {
+  // Convert snake_case or camelCase to Title Case.
+  return key
+    .replace(/_/g, " ")
+    .replace(/([A-Z])/g, " $1")
+    .trim()
+    .split(" ")
+    .map((word) => word.charAt(0).toUpperCase() + word.slice(1).toLowerCase())
+    .join(" ");
+}
+
+export function PrettyJsonViewer({ data, className }: JsonViewerProps) {
+  return (
+    <div
+      className={cn(
+        "s-bg-structure-50 dark:s-bg-structure-50-night",
+        "s-overflow-hidden s-rounded-lg s-p-6 s-text-base",
+        className
+      )}
+    >
+      <div className="s-max-w-full s-overflow-x-auto">
+        <JsonValue value={data as JsonValueType} />
+      </div>
+    </div>
+  );
+}

--- a/sparkle/src/components/markdown/PrettyJsonViewer.tsx
+++ b/sparkle/src/components/markdown/PrettyJsonViewer.tsx
@@ -11,12 +11,7 @@ const EMPTY_CLASSES =
 const INDENT_CLASSES =
   "s-border-structure-200 dark:s-border-structure-200-night s-max-w-full s-border-l s-pl-4 s-ml-4";
 
-interface JsonViewerProps {
-  data: unknown;
-  className?: string;
-}
-
-type JsonValueType =
+export type JsonValueType =
   | string
   | number
   | boolean
@@ -207,6 +202,10 @@ function formatKey(key: string): string {
     .join(" ");
 }
 
+interface JsonViewerProps {
+  data: JsonValueType;
+  className?: string;
+}
 export function PrettyJsonViewer({ data, className }: JsonViewerProps) {
   return (
     <div
@@ -217,7 +216,7 @@ export function PrettyJsonViewer({ data, className }: JsonViewerProps) {
       )}
     >
       <div className="s-max-w-full s-overflow-x-auto">
-        <JsonValue value={data as JsonValueType} />
+        <JsonValue value={data} />
       </div>
     </div>
   );

--- a/sparkle/src/components/markdown/index.ts
+++ b/sparkle/src/components/markdown/index.ts
@@ -3,5 +3,6 @@ export * from "./CodeBlockWithExtendedSupport";
 export * from "./ContentBlockWrapper";
 export * from "./Markdown";
 export * from "./MarkdownContentContext";
+export * from "./PrettyJsonViewer";
 export * from "./TableBlock";
 export * from "./utils";

--- a/sparkle/src/stories/Markdown.stories.tsx
+++ b/sparkle/src/stories/Markdown.stories.tsx
@@ -359,6 +359,13 @@ pie title Distribution
 
 \`\`\`json
 {
+  "message": "Invalid JSON should not be pretty printed",
+  "status": "success",
+}
+\`\`\`
+
+\`\`\`json
+{
   "message": "Soupi soupi soupinou ! Youhou !",
   "status": "success",
   "data": null

--- a/sparkle/src/stories/Markdown.stories.tsx
+++ b/sparkle/src/stories/Markdown.stories.tsx
@@ -345,3 +345,75 @@ export const ExtendedMarkdownStory: Story = {
     content: example,
   },
 };
+
+const mermaidAndJSON = `
+\`\`\`mermaid pie chart
+pie title Distribution
+    "Category A" : 30
+    "Category B" : 20
+    "Category C" : 15
+    "Category D" : 10
+    "Category E" : 25
+\`\`\`
+
+
+\`\`\`json
+{
+  "message": "Soupi soupi soupinou ! Youhou !",
+  "status": "success",
+  "data": null
+}
+\`\`\`
+
+\`\`\`json
+{
+  "query": "SELECT COUNT() FROM Account"
+}
+\`\`\`
+
+\`\`\`json
+{
+  "records": [
+    {
+      "attributes": {
+        "type": "Account",
+        "url": "/services/data/v57.0/sobjects/Account/001Qy00000ccRXcIAM"
+      },
+      "Name": "Awesome Company",
+      "Type": "Customer - Direct",
+      "Industry": "Apparel",
+      "BillingCountry": "USA"
+    },
+    {
+      "attributes": {
+        "type": "Account",
+        "url": "/services/data/v57.0/sobjects/Account/001Qy00000ccRXeIAM"
+      },
+      "Name": "Awesomest Company",
+      "Type": "Customer - Channel",
+      "Industry": "Consulting",
+      "BillingCountry": "USA"
+    },
+    {
+      "attributes": {
+        "type": "Account",
+        "url": "/services/data/v57.0/sobjects/Account/001Qy00000ccRXbIAM"
+      },
+      "Name": "Awesomer Company",
+      "Type": "Customer - Direct",
+      "Industry": "Electronics",
+      "BillingCountry": null
+    }
+  ],
+  "totalSize": 18,
+  "done": true
+}
+\`\`\`
+
+`;
+
+export const JSONMarkdownStory: Story = {
+  args: {
+    content: mermaidAndJSON,
+  },
+};


### PR DESCRIPTION
## Description

Goal of this PR is to extend our CodeBlock to support pretty JSON rendering. 
As we do for Mermaid, you can switch between pretty and raw JSON. 

Can be tested locally here: http://localhost:6006/?path=/story/components-markdown--json-markdown-story

<img width="1795" alt="Screenshot 2025-07-03 at 11 41 38" src="https://github.com/user-attachments/assets/5205904c-5ad6-480f-a6dd-e6f87208e3af" />


## Tests

Locally. 

## Risk

Can be rolled back. 

## Deploy Plan

Once PR approved I'll bump and publish sparkle to then use it on front. 
