### PR TITLE
[front] show template tab by default in AB 

### DIFF
--- a/front/components/assistant_builder/AssistantBuilderPreviewDrawer.tsx
+++ b/front/components/assistant_builder/AssistantBuilderPreviewDrawer.tsx
@@ -77,7 +77,7 @@ export default function AssistantBuilderRightPanel({
   mcpServerViews,
 }: AssistantBuilderRightPanelProps) {
   const [rightPanelTab, setRightPanelTab] =
-    useState<AssistantBuilderRightPanelTabType>("Preview");
+    useState<AssistantBuilderRightPanelTabType>("Template");
 
   const { draftAssistant, isSavingDraftAgent, createDraftAgent } =
     usePreviewAssistant({

--- a/front/components/assistant_builder/AssistantBuilderPreviewDrawer.tsx
+++ b/front/components/assistant_builder/AssistantBuilderPreviewDrawer.tsx
@@ -77,7 +77,9 @@ export default function AssistantBuilderRightPanel({
   mcpServerViews,
 }: AssistantBuilderRightPanelProps) {
   const [rightPanelTab, setRightPanelTab] =
-    useState<AssistantBuilderRightPanelTabType>("Template");
+    useState<AssistantBuilderRightPanelTabType>(
+      template ? "Template" : "Preview"
+    );
 
   const { draftAssistant, isSavingDraftAgent, createDraftAgent } =
     usePreviewAssistant({


### PR DESCRIPTION
## Description

Per [thibauld's request](https://dust4ai.slack.com/archives/C066R3PMUAU/p1751538874321849) on Slack, this PR is to change the default tab to Template instead of Preview 


https://github.com/user-attachments/assets/17eff47e-571b-406d-b8f8-6117990c4b66


<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
