### PR TITLE
[front] enh(tests): add factory for creating an agent with an MCP action

### DIFF
--- a/front/tests/utils/AgentConfigurationFactory.ts
+++ b/front/tests/utils/AgentConfigurationFactory.ts
@@ -3,6 +3,10 @@ import type { Transaction } from "sequelize";
 
 import { createAgentConfiguration } from "@app/lib/api/assistant/configuration";
 import type { Authenticator } from "@app/lib/auth";
+import { AgentMCPServerConfiguration } from "@app/lib/models/assistant/actions/mcp";
+import { generateRandomModelSId } from "@app/lib/resources/string_ids";
+import { MCPServerViewFactory } from "@app/tests/utils/MCPServerViewFactory";
+import { SpaceFactory } from "@app/tests/utils/SpaceFactory";
 import type {
   LightAgentConfigurationType,
   ModelIdType,
@@ -63,5 +67,38 @@ export class AgentConfigurationFactory {
     }
 
     return result.value;
+  }
+
+  static async createTestAgentWithMCPAction(
+    auth: Authenticator,
+    t: Transaction
+  ): Promise<LightAgentConfigurationType> {
+    const owner = auth.getNonNullableWorkspace();
+
+    const agent = await AgentConfigurationFactory.createTestAgent(auth, t);
+    const mcpServerView = await MCPServerViewFactory.create(
+      owner,
+      "dummy_mcp_server_id",
+      await SpaceFactory.global(owner, t)
+    );
+
+    await AgentMCPServerConfiguration.create(
+      {
+        sId: generateRandomModelSId(),
+        agentConfigurationId: agent.id,
+        workspaceId: owner.id,
+        mcpServerViewId: mcpServerView.id,
+        internalMCPServerId: "internal_mcp_server_id",
+        additionalConfiguration: {},
+        timeFrame: null,
+        jsonSchema: null,
+        name: null,
+        singleToolDescriptionOverride: null,
+        appId: null,
+      },
+      { transaction: t }
+    );
+
+    return agent;
   }
 }


### PR DESCRIPTION
## Description

- This PR adds a factory method on the AgentFactory to create an agent with an MCP server configured.
- This method will be needed following the changes in https://github.com/dust-tt/dust/pull/14013.

## Tests

- It is in the tests.

## Risk

- None, only affects the tests and not used atm.

## Deploy Plan

- No deploy.
