### PR TITLE
[front] fix(dsync): bubble up failed group deletion

### DIFF
--- a/front/temporal/workos_events_queue/activities.ts
+++ b/front/temporal/workos_events_queue/activities.ts
@@ -682,5 +682,8 @@ async function handleGroupDelete(
     return;
   }
 
-  await group.delete(auth);
+  const deleteResult = await group.delete(auth);
+  if (deleteResult.isErr()) {
+    throw deleteResult.error;
+  }
 }


### PR DESCRIPTION
## Description

- When receiving `dsync.group.deleted` events from WorkOS, we do delete the group.
- However, we simply discard any error that may happen during the process.
- This PR fixes that by bubbling up and throwing for Temporal so that we can be informed of the issue.

## Tests

## Risk

- Low.

## Deploy Plan

- Deploy front.
