### PR TITLE
Fix: use quote in tables names for table query

### DIFF
--- a/core/src/sqlite_workers/sqlite_database.rs
+++ b/core/src/sqlite_workers/sqlite_database.rs
@@ -299,7 +299,7 @@ async fn create_in_memory_sqlite_db_with_csv(
             let temp_file_path = temp_file.path().to_str().unwrap().to_string();
             let schema = format!(
                 r#"
-                CREATE VIRTUAL TABLE {table_name}
+                CREATE VIRTUAL TABLE "{table_name}"
                 USING csv(filename='{temp_file_path}', header=yes, schema='{create_sql}')
                 "#
             );


### PR DESCRIPTION
## Description

Quote the table name in case it uses special characters such as nuber in the beggining.

## Tests

Local, before / after.

## Risk

Low

## Deploy Plan

Deploy sqlite