### PR TITLE
[front] chore: clean `ConversationIncludeFileAction` code

### DIFF
--- a/front/lib/actions/runners.ts
+++ b/front/lib/actions/runners.ts
@@ -1,5 +1,3 @@
-import type { ConversationIncludeFileConfigurationType } from "@app/lib/actions/conversation/include_file";
-import { ConversationIncludeFileConfigurationServerRunner } from "@app/lib/actions/conversation/include_file";
 import type { DustAppRunConfigurationType } from "@app/lib/actions/dust_app_run";
 import { DustAppRunConfigurationServerRunner } from "@app/lib/actions/dust_app_run";
 import type { MCPToolConfigurationType } from "@app/lib/actions/mcp";
@@ -14,14 +12,12 @@ import type {
 import type { ActionConfigurationType } from "@app/lib/actions/types/agent";
 
 interface ActionToConfigTypeMap {
-  conversation_include_file_configuration: ConversationIncludeFileConfigurationType;
   dust_app_run_configuration: DustAppRunConfigurationType;
   search_labels_configuration: SearchLabelsConfigurationType;
   mcp_configuration: MCPToolConfigurationType;
 }
 
 interface ActionTypeToClassMap {
-  conversation_include_file_configuration: ConversationIncludeFileConfigurationServerRunner;
   dust_app_run_configuration: DustAppRunConfigurationServerRunner;
   search_labels_configuration: SearchLabelsConfigurationServerRunner;
   mcp_configuration: MCPConfigurationServerRunner;
@@ -63,8 +59,6 @@ export const ACTION_TYPE_TO_CONFIGURATION_SERVER_RUNNER: {
       CombinedMap[K]["configType"]
     >;
 } = {
-  conversation_include_file_configuration:
-    ConversationIncludeFileConfigurationServerRunner,
   dust_app_run_configuration: DustAppRunConfigurationServerRunner,
   search_labels_configuration: SearchLabelsConfigurationServerRunner,
   mcp_configuration: MCPConfigurationServerRunner,

--- a/front/lib/actions/types/agent.ts
+++ b/front/lib/actions/types/agent.ts
@@ -1,9 +1,6 @@
 import type { JSONSchema7 as JSONSchema } from "json-schema";
 
-import type {
-  ConversationIncludeFileActionRunningEvents,
-  ConversationIncludeFileConfigurationType,
-} from "@app/lib/actions/conversation/include_file";
+import type { ConversationIncludeFileActionRunningEvents } from "@app/lib/actions/conversation/include_file";
 import type {
   DustAppRunActionRunningEvents,
   DustAppRunConfigurationType,
@@ -33,8 +30,7 @@ export type AgentActionConfigurationType =
 export type ActionConfigurationType =
   | Exclude<AgentActionConfigurationType, MCPServerConfigurationType>
   | MCPToolConfigurationType
-  | SearchLabelsConfigurationType
-  | ConversationIncludeFileConfigurationType;
+  | SearchLabelsConfigurationType;
 
 /**
  * Type guard to check if a value is of type ActionConfigurationType
@@ -43,7 +39,6 @@ export function isActionConfigurationType(
   value: AgentActionConfigurationType | ActionConfigurationType
 ): value is ActionConfigurationType {
   switch (value.type) {
-    case "conversation_include_file_configuration":
     case "dust_app_run_configuration":
     case "mcp_configuration":
     case "search_labels_configuration":

--- a/front/lib/actions/types/guards.ts
+++ b/front/lib/actions/types/guards.ts
@@ -1,7 +1,3 @@
-import type {
-  ConversationIncludeFileActionType,
-  ConversationIncludeFileConfigurationType,
-} from "@app/lib/actions/conversation/include_file";
 import type { DustAppRunConfigurationType } from "@app/lib/actions/dust_app_run";
 import type {
   ClientSideMCPToolConfigurationType,
@@ -201,23 +197,6 @@ export function isClientSideMCPToolConfiguration(
   arg: ActionConfigurationType
 ): arg is ClientSideMCPToolConfigurationType {
   return isMCPToolConfiguration(arg) && "clientSideMcpServerId" in arg;
-}
-
-export function isConversationIncludeFileConfiguration(
-  arg: unknown
-): arg is ConversationIncludeFileConfigurationType {
-  return (
-    !!arg &&
-    typeof arg === "object" &&
-    "type" in arg &&
-    arg.type === "conversation_include_file_configuration"
-  );
-}
-
-export function isConversationIncludeFileConfigurationActionType(
-  arg: AgentActionType
-): arg is ConversationIncludeFileActionType {
-  return arg.type === "conversation_include_file_action";
 }
 
 export function throwIfInvalidAgentConfiguration(

--- a/front/lib/actions/utils.ts
+++ b/front/lib/actions/utils.ts
@@ -177,7 +177,6 @@ export function getCitationsCount({
 
   switch (action.type) {
     case "dust_app_run_configuration":
-    case "conversation_include_file_configuration":
     case "search_labels_configuration":
       return 0;
     case "mcp_configuration":

--- a/front/lib/api/assistant/agent.ts
+++ b/front/lib/api/assistant/agent.ts
@@ -17,7 +17,6 @@ import type {
 } from "@app/lib/actions/types/agent";
 import { isActionConfigurationType } from "@app/lib/actions/types/agent";
 import {
-  isConversationIncludeFileConfiguration,
   isDustAppRunConfiguration,
   isMCPToolConfiguration,
   isSearchLabelsConfiguration,
@@ -1208,54 +1207,6 @@ async function* runAction(
           yield event;
           break;
         case "dust_app_run_success":
-          yield {
-            type: "agent_action_success",
-            created: event.created,
-            configurationId: configuration.sId,
-            messageId: agentMessage.sId,
-            action: event.action,
-          };
-
-          // We stitch the action into the agent message. The conversation is expected to include
-          // the agentMessage object, updating this object will update the conversation as well.
-          agentMessage.actions.push(event.action);
-          break;
-
-        default:
-          assertNever(event);
-      }
-    }
-  } else if (isConversationIncludeFileConfiguration(actionConfiguration)) {
-    const eventStream = getRunnerForActionConfiguration(
-      actionConfiguration
-    ).run(auth, {
-      agentConfiguration: configuration,
-      conversation,
-      agentMessage,
-      rawInputs: inputs,
-      functionCallId,
-      step,
-    });
-
-    for await (const event of eventStream) {
-      switch (event.type) {
-        case "conversation_include_file_params":
-          yield event;
-          break;
-        case "conversation_include_file_error":
-          yield {
-            type: "agent_error",
-            created: event.created,
-            configurationId: configuration.sId,
-            messageId: agentMessage.sId,
-            error: {
-              code: event.error.code,
-              message: event.error.message,
-              metadata: null,
-            },
-          };
-          return;
-        case "conversation_include_file_success":
           yield {
             type: "agent_action_success",
             created: event.created,


### PR DESCRIPTION
## Description

- Part of the step 3 of https://github.com/dust-tt/tasks/issues/3278.
- This PR removes the runner + configuration code of the legacy (non-MCP) conversation include file action.

## Tests

- Tested locally.
- Will test on front-edge (TBC, will edit here).

## Risk

- Medium, all code paths are unreachable

## Deploy Plan

- Deploy front.
