### PR TITLE
[Connectors Microsoft] Add heartbeat for large spreadsheet sync

### DIFF
--- a/connectors/src/connectors/microsoft/temporal/activities.ts
+++ b/connectors/src/connectors/microsoft/temporal/activities.ts
@@ -469,6 +469,7 @@ export async function syncFiles({
         file: child,
         parentInternalId,
         startSyncTs,
+        heartbeat,
       }),
     { concurrency: FILES_SYNC_CONCURRENCY }
   );
@@ -683,6 +684,7 @@ export async function syncDeltaForRootNodesInDrive({
             driveItem.parentReference
           ),
           startSyncTs,
+          heartbeat,
         });
       }
     } else if (driveItem.folder) {

--- a/connectors/src/connectors/microsoft/temporal/file.ts
+++ b/connectors/src/connectors/microsoft/temporal/file.ts
@@ -58,6 +58,7 @@ export async function syncOneFile({
   parentInternalId,
   startSyncTs,
   isBatchSync = false,
+  heartbeat,
 }: {
   connectorId: ModelId;
   dataSourceConfig: DataSourceConfig;
@@ -66,6 +67,7 @@ export async function syncOneFile({
   parentInternalId: string;
   startSyncTs: number;
   isBatchSync?: boolean;
+  heartbeat: () => Promise<void>;
 }) {
   const connector = await ConnectorResource.fetchById(connectorId);
   if (!connector) {
@@ -286,6 +288,7 @@ export async function syncOneFile({
       parentInternalId,
       localLogger,
       startSyncTs,
+      heartbeat,
     });
 
     if (result.isErr()) {

--- a/connectors/src/connectors/microsoft/temporal/spreadsheets.ts
+++ b/connectors/src/connectors/microsoft/temporal/spreadsheets.ts
@@ -275,12 +275,14 @@ export async function handleSpreadSheet({
   parentInternalId,
   localLogger,
   startSyncTs,
+  heartbeat,
 }: {
   connectorId: number;
   file: DriveItem;
   parentInternalId: string;
   localLogger: Logger;
   startSyncTs: number;
+  heartbeat: () => void;
 }): Promise<Result<null, Error>> {
   const connector = await ConnectorResource.fetchById(connectorId);
 
@@ -340,6 +342,7 @@ export async function handleSpreadSheet({
 
   const successfulSheetIdImports: string[] = [];
   for (const worksheet of worksheetsRes.value) {
+    await heartbeat();
     if (worksheet.id) {
       const worksheetInternalId = getWorksheetInternalId(worksheet, documentId);
       const importResult = await processSheet({


### PR DESCRIPTION
## Description
In our microsoft sync activities, some spreadsheets are fat and take more than 5mn to ingest (5mn is the heartbeat timeout). This generates activity monitors, and likely unhandled rejections.

This PR heartbeats sheet by sheet for large spreadsheets, avoiding the issue.

## Risks
Blast radius: Microsoft connector spreadsheet synchronization
Risk: low

## Deploy Plan
- Deploy connectors service