### PR TITLE
Pass Table instead of table_id

### DIFF
--- a/core/src/databases/table.rs
+++ b/core/src/databases/table.rs
@@ -262,7 +262,7 @@ impl Table {
             .await?;
 
             // Delete the table rows.
-            databases_store.delete_table_rows(&self.unique_id()).await?;
+            databases_store.delete_table_rows(&self).await?;
         }
 
         store
@@ -482,7 +482,7 @@ impl LocalTable {
         // backward-compatible with the previous one. The other way around would not be true -- old
         // schema doesn't necessarily work with the new rows. This is why we cannot `try_join_all`.
         databases_store
-            .batch_upsert_table_rows(&self.table.unique_id(), &rows, truncate)
+            .batch_upsert_table_rows(&self.table, &rows, truncate)
             .await?;
         info!(
             duration = utils::now() - now,
@@ -594,9 +594,7 @@ impl LocalTable {
         databases_store: Box<dyn DatabasesStore + Sync + Send>,
         row_id: &str,
     ) -> Result<Option<Row>> {
-        databases_store
-            .load_table_row(&self.table.unique_id(), row_id)
-            .await
+        databases_store.load_table_row(&self.table, row_id).await
     }
 
     pub async fn delete_row(
@@ -604,9 +602,7 @@ impl LocalTable {
         databases_store: Box<dyn DatabasesStore + Sync + Send>,
         row_id: &str,
     ) -> Result<()> {
-        databases_store
-            .delete_table_row(&self.table.unique_id(), row_id)
-            .await
+        databases_store.delete_table_row(&self.table, row_id).await
     }
 
     pub async fn list_rows(
@@ -615,7 +611,7 @@ impl LocalTable {
         limit_offset: Option<(usize, usize)>,
     ) -> Result<(Vec<Row>, usize)> {
         databases_store
-            .list_table_rows(&self.table.unique_id(), limit_offset)
+            .list_table_rows(&self.table, limit_offset)
             .await
     }
 

--- a/core/src/databases_store/store.rs
+++ b/core/src/databases_store/store.rs
@@ -1,24 +1,24 @@
 use anyhow::Result;
 use async_trait::async_trait;
 
-use crate::databases::table::Row;
+use crate::databases::table::{Row, Table};
 
 #[async_trait]
 pub trait DatabasesStore {
-    async fn load_table_row(&self, table_id: &str, row_id: &str) -> Result<Option<Row>>;
+    async fn load_table_row(&self, table: &Table, row_id: &str) -> Result<Option<Row>>;
     async fn list_table_rows(
         &self,
-        table_id: &str,
+        table: &Table,
         limit_offset: Option<(usize, usize)>,
     ) -> Result<(Vec<Row>, usize)>;
     async fn batch_upsert_table_rows(
         &self,
-        table_id: &str,
+        table: &Table,
         rows: &Vec<Row>,
         truncate: bool,
     ) -> Result<()>;
-    async fn delete_table_rows(&self, table_id: &str) -> Result<()>;
-    async fn delete_table_row(&self, table_id: &str, row_id: &str) -> Result<()>;
+    async fn delete_table_rows(&self, table: &Table) -> Result<()>;
+    async fn delete_table_row(&self, table: &Table, row_id: &str) -> Result<()>;
 
     fn clone_box(&self) -> Box<dyn DatabasesStore + Sync + Send>;
 }

--- a/core/src/sqlite_workers/sqlite_database.rs
+++ b/core/src/sqlite_workers/sqlite_database.rs
@@ -338,9 +338,7 @@ async fn create_in_memory_sqlite_db_without_csv(
     let tables_with_rows: Vec<(Table, Vec<Row>)> = try_join_all(tables.iter().map(|lt| {
         let databases_store = databases_store.clone();
         async move {
-            let (rows, _) = databases_store
-                .list_table_rows(&lt.table.unique_id(), None)
-                .await?;
+            let (rows, _) = databases_store.list_table_rows(&lt.table, None).await?;
             Ok::<_, anyhow::Error>((lt.table.clone(), rows))
         }
     }))


### PR DESCRIPTION
## Description

table.unique_id() will not be enough for GCS databases store so pass the full table instead.

## Tests

Local

## Risk

Low

## Deploy Plan

Deploy core