### PR TITLE
[WorkOS] Handle already_revoked error gracefully in user deletion workflow

### DIFF
--- a/front/temporal/workos_events_queue/activities.ts
+++ b/front/temporal/workos_events_queue/activities.ts
@@ -649,6 +649,16 @@ async function handleDeleteWorkOSUser(
   });
 
   if (membershipRevokeResult.isErr()) {
+    if (membershipRevokeResult.error.type === "already_revoked") {
+      logger.info(
+        {
+          userId: user.sId,
+          workspaceId: workspace.sId,
+        },
+        "User membership already revoked, skipping"
+      );
+      return;
+    }
     throw membershipRevokeResult.error;
   }
 


### PR DESCRIPTION
## Summary
- Handle the `already_revoked` error case in the `handleDeleteWorkOSUser` function
- Log the condition instead of throwing an error when membership is already revoked
- Prevents workflow from retrying unnecessarily (attempt #307 in the error log)

## Risks
Blast radius: WorkOS user deletion events processing
Risk: low

## Tests
- The change adds idempotency to the user deletion handler
- When a membership is already revoked, the workflow will log and return successfully
- This prevents the infinite retry loop that was causing the error

## Deploy Plan
- Deploy front-worker service