### PR TITLE
Handle all write operations in GCS

### DIFF
--- a/core/src/databases/csv.rs
+++ b/core/src/databases/csv.rs
@@ -12,7 +12,7 @@ use unicode_normalization::UnicodeNormalization;
 
 use crate::{databases::table::Row, utils};
 
-pub struct UpsertQueueCSVContent {
+pub struct GoogleCloudStorageCSVContent {
     pub bucket: String,
     pub bucket_csv_path: String,
 }
@@ -21,7 +21,7 @@ const MAX_TABLE_COLUMNS: usize = 512;
 const MAX_COLUMN_NAME_LENGTH: usize = 1024;
 const MAX_TABLE_ROWS: usize = 500_000;
 
-impl UpsertQueueCSVContent {
+impl GoogleCloudStorageCSVContent {
     pub async fn parse(&self) -> Result<Vec<Row>> {
         let now = utils::now();
         let bucket = &self.bucket;
@@ -186,9 +186,7 @@ impl UpsertQueueCSVContent {
             .flexible(true)
             .create_reader(TokioAsyncReadCompatExt::compat(rdr));
 
-        let headers = UpsertQueueCSVContent::sanitize_headers(
-            csv.headers().await?.iter().collect::<Vec<&str>>(),
-        )?;
+        let headers = Self::sanitize_headers(csv.headers().await?.iter().collect::<Vec<&str>>())?;
 
         if headers.len() > MAX_TABLE_COLUMNS {
             Err(anyhow!("Too many columns in CSV file"))?;
@@ -227,12 +225,12 @@ mod tests {
     async fn test_find_delimiter() -> anyhow::Result<()> {
         let csv = "a,b,c\n1,2,3\n4,5,6";
         let (delimiter, _) =
-            UpsertQueueCSVContent::find_delimiter(std::io::Cursor::new(csv)).await?;
+            GoogleCloudStorageCSVContent::find_delimiter(std::io::Cursor::new(csv)).await?;
         assert_eq!(delimiter, b',');
 
         let csv = "a;b;c\n1;2;3\n4;5;6";
         let (delimiter, mut rdr) =
-            UpsertQueueCSVContent::find_delimiter(std::io::Cursor::new(csv)).await?;
+            GoogleCloudStorageCSVContent::find_delimiter(std::io::Cursor::new(csv)).await?;
         assert_eq!(delimiter, b';');
 
         // read content of rdr to a string
@@ -244,7 +242,7 @@ mod tests {
 FOO,swap\tblocked\tstyle-src-elem\ttheme.js:2\n\
 BAR,acme";
         let (delimiter, _) =
-            UpsertQueueCSVContent::find_delimiter(std::io::Cursor::new(csv)).await?;
+            GoogleCloudStorageCSVContent::find_delimiter(std::io::Cursor::new(csv)).await?;
         assert_eq!(delimiter, b',');
 
         Ok(())
@@ -275,7 +273,7 @@ BAR,acme";
             "旧_Offered price per video(2024.7)",
             "🦄 IG User ID",
         ];
-        let sanitized = UpsertQueueCSVContent::sanitize_headers(headers)?;
+        let sanitized = GoogleCloudStorageCSVContent::sanitize_headers(headers)?;
         assert_eq!(
             sanitized,
             vec![
@@ -308,8 +306,8 @@ BAR,acme";
                    1,2.23,3,2025-02-14T15:06:52.380Z\n\
                    4,hello world,6,\"Fri, 14 Feb 2025 15:10:34 GMT\"";
         let (delimiter, rdr) =
-            UpsertQueueCSVContent::find_delimiter(std::io::Cursor::new(csv)).await?;
-        let rows = UpsertQueueCSVContent::csv_to_rows(rdr, delimiter).await?;
+            GoogleCloudStorageCSVContent::find_delimiter(std::io::Cursor::new(csv)).await?;
+        let rows = GoogleCloudStorageCSVContent::csv_to_rows(rdr, delimiter).await?;
 
         assert_eq!(rows.len(), 2);
 
@@ -337,8 +335,8 @@ BAR,acme";
                    MYID1,2.23,3,2025-02-14T15:06:52.380Z\n\
                    MYID2,hello world,6,\"Fri, 14 Feb 2025 15:10:34 GMT\"";
         let (delimiter, rdr) =
-            UpsertQueueCSVContent::find_delimiter(std::io::Cursor::new(csv)).await?;
-        let rows = UpsertQueueCSVContent::csv_to_rows(rdr, delimiter).await?;
+            GoogleCloudStorageCSVContent::find_delimiter(std::io::Cursor::new(csv)).await?;
+        let rows = GoogleCloudStorageCSVContent::csv_to_rows(rdr, delimiter).await?;
 
         assert_eq!(rows.len(), 2);
         assert_eq!(rows[0].row_id, "MYID1");
@@ -353,8 +351,8 @@ BAR,acme";
                    1,2.23,foo0,3,2025-02-14T15:06:52.380Z\n\
                    4,hello world,foo1,6,\"Fri, 14 Feb 2025 15:10:34 GMT\"";
         let (delimiter, rdr) =
-            UpsertQueueCSVContent::find_delimiter(std::io::Cursor::new(csv)).await?;
-        let rows = UpsertQueueCSVContent::csv_to_rows(rdr, delimiter).await?;
+            GoogleCloudStorageCSVContent::find_delimiter(std::io::Cursor::new(csv)).await?;
+        let rows = GoogleCloudStorageCSVContent::csv_to_rows(rdr, delimiter).await?;
 
         assert_eq!(rows.len(), 2);
 
@@ -381,16 +379,16 @@ BAR,acme";
         // Test empty CSV
         let csv = "";
         let (delimiter, rdr) =
-            UpsertQueueCSVContent::find_delimiter(std::io::Cursor::new(csv)).await?;
-        assert!(UpsertQueueCSVContent::csv_to_rows(rdr, delimiter)
+            GoogleCloudStorageCSVContent::find_delimiter(std::io::Cursor::new(csv)).await?;
+        assert!(GoogleCloudStorageCSVContent::csv_to_rows(rdr, delimiter)
             .await
             .is_err());
 
         // Test CSV with only headers
         let csv = "header1,header2";
         let (delimiter, rdr) =
-            UpsertQueueCSVContent::find_delimiter(std::io::Cursor::new(csv)).await?;
-        let rows = UpsertQueueCSVContent::csv_to_rows(rdr, delimiter).await?;
+            GoogleCloudStorageCSVContent::find_delimiter(std::io::Cursor::new(csv)).await?;
+        let rows = GoogleCloudStorageCSVContent::csv_to_rows(rdr, delimiter).await?;
         assert_eq!(rows.len(), 0);
 
         // Test CSV with too many columns (if MAX_TABLE_COLUMNS is defined)
@@ -402,8 +400,8 @@ BAR,acme";
             csv.push_str(&format!("header{}", i));
         }
         let (delimiter, rdr) =
-            UpsertQueueCSVContent::find_delimiter(std::io::Cursor::new(csv)).await?;
-        assert!(UpsertQueueCSVContent::csv_to_rows(rdr, delimiter)
+            GoogleCloudStorageCSVContent::find_delimiter(std::io::Cursor::new(csv)).await?;
+        assert!(GoogleCloudStorageCSVContent::csv_to_rows(rdr, delimiter)
             .await
             .is_err());
 
@@ -421,8 +419,8 @@ BAR,acme";
                     , , ,t , \n\
                    bar,0,23123.0,false,\"Fri, 14 Feb 2025 15:10:34 GMT\"";
         let (delimiter, rdr) =
-            UpsertQueueCSVContent::find_delimiter(std::io::Cursor::new(csv)).await?;
-        let rows = Arc::new(UpsertQueueCSVContent::csv_to_rows(rdr, delimiter).await?);
+            GoogleCloudStorageCSVContent::find_delimiter(std::io::Cursor::new(csv)).await?;
+        let rows = Arc::new(GoogleCloudStorageCSVContent::csv_to_rows(rdr, delimiter).await?);
         let schema = TableSchema::from_rows_async(rows).await?;
 
         assert_eq!(schema.columns()[0].value_type, TableSchemaFieldType::Text);

--- a/core/src/databases_store/gcs.rs
+++ b/core/src/databases_store/gcs.rs
@@ -1,0 +1,214 @@
+use std::{collections::HashMap, sync::Arc};
+
+use anyhow::{anyhow, Result};
+use async_trait::async_trait;
+use cloud_storage::Object;
+use csv::Writer;
+use tracing::info;
+
+use crate::{
+    databases::{
+        csv::UpsertQueueCSVContent,
+        table::{Row, Table},
+        table_schema::TableSchema,
+    },
+    utils::{self},
+};
+
+use super::store::DatabasesStore;
+
+#[derive(Clone)]
+pub struct GoogleCloudStorageDatabasesStore {}
+
+impl GoogleCloudStorageDatabasesStore {
+    pub fn new() -> Self {
+        Self {}
+    }
+
+    pub fn get_bucket() -> Result<String> {
+        match std::env::var("DUST_TABLES_BUCKET") {
+            Ok(bucket) => Ok(bucket),
+            Err(_) => Err(anyhow!("DUST_TABLES_BUCKET is not set")),
+        }
+    }
+
+    pub fn get_csv_storage_file_path(table: &Table) -> String {
+        format!(
+            "project-{}/{}/{}.csv",
+            table.project().project_id(),
+            table.data_source_id(),
+            table.unique_id()
+        )
+    }
+
+    pub async fn get_rows_from_csv(table: &Table) -> Result<Vec<Row>> {
+        let csv = UpsertQueueCSVContent {
+            bucket: Self::get_bucket()?,
+            bucket_csv_path: Self::get_csv_storage_file_path(table),
+        };
+        csv.parse().await
+    }
+
+    pub async fn write_rows_to_csv(
+        table: &Table,
+        schema: &TableSchema,
+        rows: &Vec<Row>,
+    ) -> Result<(), anyhow::Error> {
+        let field_names = schema
+            .columns()
+            .iter()
+            .map(|c| c.name.clone())
+            .collect::<Vec<_>>();
+
+        // Read all rows and upload to GCS
+        let mut wtr = Writer::from_writer(vec![]);
+
+        // Write the header row.
+        wtr.write_record(field_names.as_slice())?;
+        for row in rows.iter() {
+            wtr.write_record(row.to_csv_record(&field_names)?.as_slice())?;
+        }
+
+        let csv = wtr.into_inner()?;
+
+        Object::create(
+            &Self::get_bucket()?,
+            csv,
+            &Self::get_csv_storage_file_path(table),
+            "text/csv",
+        )
+        .await?;
+
+        Ok(())
+    }
+}
+
+#[async_trait]
+impl DatabasesStore for GoogleCloudStorageDatabasesStore {
+    async fn load_table_row(&self, table: &Table, row_id: &str) -> Result<Option<Row>> {
+        let rows = Self::get_rows_from_csv(table).await?;
+        let row = rows.iter().find(|r| r.row_id == row_id);
+        Ok(row.cloned())
+    }
+
+    async fn list_table_rows(
+        &self,
+        table: &Table,
+        limit_offset: Option<(usize, usize)>,
+    ) -> Result<(Vec<Row>, usize)> {
+        let rows = Self::get_rows_from_csv(table).await?;
+        match limit_offset {
+            Some((limit, offset)) => {
+                let total = rows.len();
+                let rows = rows.into_iter().skip(offset).take(limit).collect();
+                Ok((rows, total))
+            }
+            None => {
+                let total = rows.len();
+                Ok((rows, total))
+            }
+        }
+    }
+
+    async fn batch_upsert_table_rows(
+        &self,
+        table: &Table,
+        rows: &Vec<Row>,
+        truncate: bool,
+    ) -> Result<()> {
+        let mut now = utils::now();
+        let mut new_rows = rows.clone();
+        let mut merge_rows_duration = 0;
+
+        // We need to merge the existing rows with the new rows based on the row_id.
+        if !truncate {
+            // We download all the rows from the CSV and merge them with the new rows.
+            // This is not super efficient if we get rows one by one but it's simple and works.
+            // Non-truncate upserts are < 4% of our total upserts.
+
+            let previous_rows = Self::get_rows_from_csv(table).await?;
+
+            // Use Hashmaps with the row_id as the key.
+            let previous_rows_map = previous_rows
+                .into_iter()
+                .map(|r| (r.row_id.clone(), r.clone()))
+                .collect::<HashMap<_, _>>();
+
+            let new_rows_map = new_rows
+                .into_iter()
+                .map(|r| (r.row_id.clone(), r.clone()))
+                .collect::<HashMap<_, _>>();
+
+            // Merge the two maps to get the final rows.
+            let merged_rows_map = previous_rows_map
+                .into_iter()
+                .chain(new_rows_map.into_iter())
+                .collect::<HashMap<_, _>>();
+
+            new_rows = merged_rows_map.into_values().collect();
+
+            merge_rows_duration = utils::now() - now;
+            now = utils::now();
+        }
+
+        let rows = Arc::new(new_rows.clone());
+
+        // Compute the schema from the rows.
+        let schema = TableSchema::from_rows_async(rows).await?;
+
+        let schema_duration = utils::now() - now;
+        now = utils::now();
+
+        // Write the rows to the CSV file.
+        Self::write_rows_to_csv(table, &schema, &new_rows).await?;
+        let write_rows_to_csv_duration = utils::now() - now;
+
+        info!(
+            truncate,
+            rows_count = new_rows.len(),
+            duration = merge_rows_duration + schema_duration + write_rows_to_csv_duration,
+            merge_rows_duration,
+            schema_duration,
+            write_rows_to_csv_duration,
+            table_id = table.unique_id(),
+            "DSSTRUCTSTAT [upsert_rows CSV] operation completed"
+        );
+
+        Ok(())
+    }
+
+    async fn delete_table_rows(&self, table: &Table) -> Result<()> {
+        if table.migrated_to_csv() {
+            Object::delete(
+                &Self::get_bucket()?,
+                &Self::get_csv_storage_file_path(table),
+            )
+            .await?;
+        }
+        Ok(())
+    }
+
+    async fn delete_table_row(&self, table: &Table, row_id: &str) -> Result<()> {
+        if table.migrated_to_csv() {
+            let rows = Self::get_rows_from_csv(table).await?;
+            let previous_rows_count = rows.len();
+            let new_rows = rows
+                .iter()
+                .filter(|r| r.row_id != row_id)
+                .cloned()
+                .collect::<Vec<_>>();
+
+            if previous_rows_count != new_rows.len() {
+                let rows = Arc::new(new_rows.clone());
+                let schema = TableSchema::from_rows_async(rows).await?;
+                Self::write_rows_to_csv(table, &schema, &new_rows).await?;
+            }
+        }
+
+        Ok(())
+    }
+
+    fn clone_box(&self) -> Box<dyn DatabasesStore + Sync + Send> {
+        Box::new(self.clone())
+    }
+}

--- a/core/src/databases_store/postgres.rs
+++ b/core/src/databases_store/postgres.rs
@@ -9,6 +9,7 @@ use tracing::info;
 
 use crate::{
     databases::table::{Row, Table},
+    databases::table_schema::TableSchema,
     databases_store::store::DatabasesStore,
     utils,
 };
@@ -127,6 +128,7 @@ impl DatabasesStore for PostgresDatabasesStore {
     async fn batch_upsert_table_rows(
         &self,
         table: &Table,
+        _schema: &TableSchema,
         rows: &Vec<Row>,
         truncate: bool,
     ) -> Result<()> {
@@ -257,7 +259,7 @@ impl DatabasesStore for PostgresDatabasesStore {
         Ok(())
     }
 
-    async fn delete_table_rows(&self, table: &Table) -> Result<()> {
+    async fn delete_table_data(&self, table: &Table) -> Result<()> {
         let pool = self.pool.clone();
         let c = pool.get().await?;
 

--- a/core/src/databases_store/store.rs
+++ b/core/src/databases_store/store.rs
@@ -2,6 +2,7 @@ use anyhow::Result;
 use async_trait::async_trait;
 
 use crate::databases::table::{Row, Table};
+use crate::databases::table_schema::TableSchema;
 
 #[async_trait]
 pub trait DatabasesStore {
@@ -14,10 +15,11 @@ pub trait DatabasesStore {
     async fn batch_upsert_table_rows(
         &self,
         table: &Table,
+        schema: &TableSchema,
         rows: &Vec<Row>,
         truncate: bool,
     ) -> Result<()>;
-    async fn delete_table_rows(&self, table: &Table) -> Result<()>;
+    async fn delete_table_data(&self, table: &Table) -> Result<()>;
     async fn delete_table_row(&self, table: &Table, row_id: &str) -> Result<()>;
 
     fn clone_box(&self) -> Box<dyn DatabasesStore + Sync + Send>;

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -118,6 +118,7 @@ pub mod deno {
 }
 
 pub mod databases_store {
+    pub mod gcs;
     pub mod postgres;
     pub mod store;
 }

--- a/core/src/sqlite_workers/sqlite_database.rs
+++ b/core/src/sqlite_workers/sqlite_database.rs
@@ -4,7 +4,7 @@ use crate::{
         table::{LocalTable, Row, Table},
         transient_database::get_transient_database_unique_table_names,
     },
-    databases_store::store::DatabasesStore,
+    databases_store::{gcs::GoogleCloudStorageDatabasesStore, store::DatabasesStore},
     utils,
 };
 use anyhow::{anyhow, Result};
@@ -263,12 +263,8 @@ async fn create_in_memory_sqlite_db_with_csv(
 
             async move {
                 let mut stream = Object::download_streamed(
-                    &LocalTable::get_bucket()?,
-                    &LocalTable::get_csv_storage_file_path(
-                        &table.table.project().project_id(),
-                        &table.table.data_source_id(),
-                        &table.table.table_id(),
-                    ),
+                    &GoogleCloudStorageDatabasesStore::get_bucket()?,
+                    &GoogleCloudStorageDatabasesStore::get_csv_storage_file_path(&table.table),
                 )
                 .await?;
                 let mut temp_file = NamedTempFile::new()?;

--- a/core/src/stores/postgres.rs
+++ b/core/src/stores/postgres.rs
@@ -2,8 +2,6 @@ use anyhow::{anyhow, Result};
 use async_trait::async_trait;
 use bb8::Pool;
 use bb8_postgres::PostgresConnectionManager;
-use cloud_storage::Object;
-use csv::Writer;
 use futures::future::try_join_all;
 use serde_json::Value;
 use std::collections::hash_map::DefaultHasher;
@@ -17,7 +15,6 @@ use tracing::info;
 
 use crate::data_sources::data_source::DocumentStatus;
 use crate::data_sources::node::{Node, NodeESDocument, NodeType, ProviderVisibility};
-use crate::databases::table::LocalTable;
 use crate::search_filter::Filterable;
 use crate::{
     blocks::block::BlockType,
@@ -26,7 +23,7 @@ use crate::{
     data_sources::data_source::{DataSource, DataSourceConfig, Document, DocumentVersion},
     data_sources::folder::Folder,
     databases::{
-        table::{get_table_unique_id, Row, Table},
+        table::{get_table_unique_id, Table},
         table_schema::TableSchema,
         transient_database::TransientDatabase,
     },
@@ -2948,13 +2945,12 @@ impl Store for PostgresStore {
         Ok(())
     }
 
-    async fn store_data_source_table_csv(
+    async fn set_data_source_table_migrated_to_csv(
         &self,
         project: &Project,
         data_source_id: &str,
         table_id: &str,
-        schema: &TableSchema,
-        rows: &Vec<Row>,
+        migrated_to_csv: bool,
     ) -> Result<()> {
         let project_id = project.project_id();
         let data_source_id = data_source_id.to_string();
@@ -2975,101 +2971,15 @@ impl Store for PostgresStore {
             1 => r[0].get(0),
             _ => unreachable!(),
         };
-
-        let now = utils::now();
-
-        let field_names = schema
-            .columns()
-            .iter()
-            .map(|c| c.name.clone())
-            .collect::<Vec<_>>();
-
-        // Read all rows and upload to GCS
-        let mut wtr = Writer::from_writer(vec![]);
-        // Write the header row.
-        wtr.write_record(field_names.as_slice())?;
-        for row in rows {
-            wtr.write_record(row.to_csv_record(&field_names)?.as_slice())?;
-        }
-        let content_duration = utils::now() - now;
-        let now = utils::now();
-
-        let csv = wtr.into_inner()?;
-
-        Object::create(
-            &LocalTable::get_bucket()?,
-            csv,
-            &LocalTable::get_csv_storage_file_path(&project_id, &data_source_id, &table_id),
-            "text/csv",
-        )
-        .await?;
 
         // Update migration flag.
         let stmt = c
             .prepare(
-                "UPDATE tables SET migrated_to_csv = true WHERE data_source = $1 AND table_id = $2",
+                "UPDATE tables SET migrated_to_csv = $1 WHERE data_source = $2 AND table_id = $3",
             )
             .await?;
-        c.query(&stmt, &[&data_source_row_id, &table_id]).await?;
-
-        let upload_duration = utils::now() - now;
-
-        info!(
-            content_duration = content_duration,
-            upload_duration = upload_duration,
-            "CSV upload"
-        );
-
-        Ok(())
-    }
-
-    async fn delete_data_source_table_csv(
-        &self,
-        project: &Project,
-        data_source_id: &str,
-        table_id: &str,
-    ) -> Result<()> {
-        let project_id = project.project_id();
-        let data_source_id = data_source_id.to_string();
-        let table_id = table_id.to_string();
-
-        let pool = self.pool.clone();
-        let c = pool.get().await?;
-
-        // Get the data source row id.
-        let stmt = c
-            .prepare(
-                "SELECT id FROM data_sources WHERE project = $1 AND data_source_id = $2 LIMIT 1",
-            )
+        c.query(&stmt, &[&migrated_to_csv, &data_source_row_id, &table_id])
             .await?;
-        let r = c.query(&stmt, &[&project_id, &data_source_id]).await?;
-        let data_source_row_id: i64 = match r.len() {
-            0 => Err(anyhow!("Unknown DataSource: {}", data_source_id))?,
-            1 => r[0].get(0),
-            _ => unreachable!(),
-        };
-
-        // Remove from GCS.
-        match Object::delete(
-            LocalTable::get_bucket()?.as_str(),
-            &LocalTable::get_csv_storage_file_path(&project_id, &data_source_id, &table_id),
-        )
-        .await
-        {
-            Ok(_) => {
-                // Clear the migration flag.
-                let stmt = c.prepare(
-                    "UPDATE tables SET migrated_to_csv = false WHERE data_source = $1 AND table_id = $2",
-                ).await?;
-                c.query(&stmt, &[&data_source_row_id, &table_id]).await?;
-            }
-            Err(e) => {
-                info!(
-                    "Error deleting CSV file from GCS: {}. It's safe to continue.",
-                    e.to_string()
-                );
-            }
-        }
 
         Ok(())
     }

--- a/core/src/stores/store.rs
+++ b/core/src/stores/store.rs
@@ -14,9 +14,7 @@ use crate::{
         folder::Folder,
         node::{Node, ProviderVisibility},
     },
-    databases::{
-        table::Row, table::Table, table_schema::TableSchema, transient_database::TransientDatabase,
-    },
+    databases::{table::Table, table_schema::TableSchema, transient_database::TransientDatabase},
     dataset::Dataset,
     http::request::{HttpRequest, HttpResponse},
     project::Project,
@@ -301,19 +299,12 @@ pub trait Store {
         data_source_id: &str,
         table_id: &str,
     ) -> Result<()>;
-    async fn store_data_source_table_csv(
+    async fn set_data_source_table_migrated_to_csv(
         &self,
         project: &Project,
         data_source_id: &str,
         table_id: &str,
-        schema: &TableSchema,
-        rows: &Vec<Row>,
-    ) -> Result<()>;
-    async fn delete_data_source_table_csv(
-        &self,
-        project: &Project,
-        data_source_id: &str,
-        table_id: &str,
+        migrated_to_csv: bool,
     ) -> Result<()>;
     async fn load_data_source_table(
         &self,


### PR DESCRIPTION
## Description

Implemented a GCS databases store and call in on all write operations.
For now, read operations (except when doing the actual query) only happen on the postgres store.

Once the migration is complete, we will likely invert:
- main database store will be GCS
- postgres only for duplicate writes

And finally, after confirming everything is ok, stop writing to postgres, remove the validation (sync) + upsert (async) calls and simplify with one sync upsert call.

## Tests

Locally

## Risk

Medium as it's basically the same state than today but with a more principled coding pattern.

## Deploy Plan

Deploy core.