### PR TITLE
[front] fix conversation include files action migration script

### DIFF
--- a/front/migrations/20250702_move_conversation_include_file_actions_to_mcp.ts
+++ b/front/migrations/20250702_move_conversation_include_file_actions_to_mcp.ts
@@ -321,6 +321,18 @@ async function migrateWorkspaceConversationIncludeFileActions(
         );
         assert(agentMessage, "Agent message must exist");
 
+        if (agentMessage.agentConfigurationId === "deepseek") {
+          logger.error(
+            {
+              agentMessageId: agentMessage.id,
+              agentConfigurationId: agentMessage.agentConfigurationId,
+              agentConfigurationVersion: agentMessage.agentConfigurationVersion,
+            },
+            "Agent configuration deepseek does not exist anymore"
+          );
+          return;
+        }
+
         const agentConfiguration = agentConfigurationsMap.get(
           `${agentMessage.agentConfigurationId}-${agentMessage.agentConfigurationVersion}`
         );

--- a/front/migrations/20250702_move_conversation_include_file_actions_to_mcp.ts
+++ b/front/migrations/20250702_move_conversation_include_file_actions_to_mcp.ts
@@ -23,7 +23,11 @@ import { MCPServerViewResource } from "@app/lib/resources/mcp_server_view_resour
 import { concurrentExecutor } from "@app/lib/utils/async_utils";
 import { makeScript } from "@app/scripts/helpers";
 import { runOnAllWorkspaces } from "@app/scripts/workspace_helpers";
-import type { LightWorkspaceType, ModelConfigurationType } from "@app/types";
+import {
+  LightWorkspaceType,
+  ModelConfigurationType,
+  stripNullBytes,
+} from "@app/types";
 import { isGlobalAgentId, isImageContent, isTextContent } from "@app/types";
 
 const WORKSPACE_CONCURRENCY = 50;
@@ -150,7 +154,7 @@ async function getContentForConversationIncludeFileAction(
   if (isTextContent(content)) {
     return {
       type: "text",
-      text: content.text,
+      text: stripNullBytes(content.text),
     };
   } else if (isImageContent(content)) {
     // For images, we return the URL as a resource with the correct MIME type
@@ -159,7 +163,7 @@ async function getContentForConversationIncludeFileAction(
       resource: {
         uri: content.image_url.url,
         mimeType: attachment?.contentType || "application/octet-stream",
-        text: `Image: ${attachment.title}`,
+        text: `Image: ${stripNullBytes(attachment.title)}`,
       },
     };
   }


### PR DESCRIPTION
## Description

- This PR fixes the conversation include files action migration script by ignoring the deepseek agent and stripping null bytes from content that will be written in db.

## Tests

## Risk

## Deploy Plan

- No deploy.
