### PR TITLE
[front] enh(WorkOS): skip webhooks on relocated workspaces

### DIFF
--- a/front/temporal/workos_events_queue/activities.ts
+++ b/front/temporal/workos_events_queue/activities.ts
@@ -18,6 +18,7 @@ import {
 import {
   findWorkspaceByWorkOSOrganizationId,
   getWorkspaceInfos,
+  isWorkspaceRelocationDone,
 } from "@app/lib/api/workspace";
 import {
   deleteWorkspaceDomain,
@@ -68,6 +69,16 @@ async function verifyWorkOSWorkspace<E extends object, R>(
     // This is expected in a multi-region setup. DataDog monitors these warnings
     // and will alert if they occur across all regions.
     return;
+  }
+  if (workspace) {
+    const workspaceHasBeenRelocated = isWorkspaceRelocationDone(workspace);
+    if (workspaceHasBeenRelocated) {
+      logger.info(
+        { workspaceId: workspace.sId },
+        "Workspace has been relocated, skipping event"
+      );
+      return;
+    }
   }
 
   return handler(workspace, event);


### PR DESCRIPTION
## Description

- This PR skips WorkOS webhooks on relocated workspaces.
- This prevents data from being created in the origin region.

## Tests

## Risk

## Deploy Plan

- Deploy front.
