### PR TITLE
[connectors] enh: whitelist `.authors` file

### DIFF
--- a/connectors/src/connectors/github/lib/code/supported_files.ts
+++ b/connectors/src/connectors/github/lib/code/supported_files.ts
@@ -100,6 +100,9 @@ const EXTENSION_WHITELIST = [
   ".liquid",
   ".mustache",
   ".handlebars",
+
+  // Miscellaneous
+  ".authors",
 ];
 
 const SUFFIX_BLACKLIST = [".min.js", ".min.css"];


### PR DESCRIPTION
## Description

- This PR allows syncing `.authors` files in the GitHub connector.

## Tests

- N/A.

## Risk

- N/A.

## Deploy Plan

- Deploy connectors.
