### PR TITLE
[front] enh(poke): add WorkOS organization id to `WorkspaceInfoTable`

### DIFF
--- a/front/components/poke/workspace/table.tsx
+++ b/front/components/poke/workspace/table.tsx
@@ -121,6 +121,14 @@ export function WorkspaceInfoTable({
               </PokeTableCell>
             </PokeTableRow>
             <PokeTableRow>
+              <PokeTableCell className="max-w-48">
+                WorkOS organization
+              </PokeTableCell>
+              <PokeTableCell>
+                {owner.workOSOrganizationId ?? "None"}
+              </PokeTableCell>
+            </PokeTableRow>
+            <PokeTableRow>
               <PokeTableCell>Directory Sync</PokeTableCell>
               <PokeTableCell>
                 <Chip


### PR DESCRIPTION
## Description

- This PR adds the workOS organization to the poke workspace page, in the info table.
- Would add a link to the WorkOS page but we can't really hardcode the environment id.

## Tests

- Tested locally.

## Risk

- None

## Deploy Plan

- Deploy front.
