### PR TITLE
[URL Search] Fix: broken search on notion tables

### DIFF
--- a/front/components/data_source_view/DataSourceViewSelector.tsx
+++ b/front/components/data_source_view/DataSourceViewSelector.tsx
@@ -335,7 +335,7 @@ export function DataSourceViewsSelector({
   // Check if the search term is a URL
   useEffect(() => {
     if (debouncedSearch.length >= MIN_SEARCH_QUERY_SIZE) {
-      const candidate = nodeCandidateFromUrl(debouncedSearch.trim());
+      const candidate = nodeCandidateFromUrl(debouncedSearch.trim(), viewType);
       setNodeOrUrlCandidate(candidate);
     } else {
       setNodeOrUrlCandidate(null);

--- a/front/components/data_source_view/DataSourceViewSelector.tsx
+++ b/front/components/data_source_view/DataSourceViewSelector.tsx
@@ -340,7 +340,7 @@ export function DataSourceViewsSelector({
     } else {
       setNodeOrUrlCandidate(null);
     }
-  }, [debouncedSearch]);
+  }, [debouncedSearch, viewType]);
 
   const commonSearchParams = {
     owner,

--- a/front/components/spaces/SpaceSearchLayout.tsx
+++ b/front/components/spaces/SpaceSearchLayout.tsx
@@ -217,7 +217,7 @@ function BackendSearch({
   // Check if the search term is a URL
   React.useEffect(() => {
     if (debouncedSearch.length >= MIN_SEARCH_QUERY_SIZE) {
-      const candidate = nodeCandidateFromUrl(debouncedSearch.trim());
+      const candidate = nodeCandidateFromUrl(debouncedSearch.trim(), viewType);
       setNodeOrUrlCandidate(candidate);
     } else {
       setNodeOrUrlCandidate(null);

--- a/front/components/spaces/SpaceSearchLayout.tsx
+++ b/front/components/spaces/SpaceSearchLayout.tsx
@@ -222,7 +222,7 @@ function BackendSearch({
     } else {
       setNodeOrUrlCandidate(null);
     }
-  }, [debouncedSearch]);
+  }, [debouncedSearch, viewType]);
 
   const shouldShowSearchResults = debouncedSearch.length > 0;
 


### PR DESCRIPTION
Description
---

Fixes https://github.com/dust-tt/tasks/issues/3400

Notion databases have 2 entries in core:
- one of type "table" starting with "notion-";
- one of type "document" starting with "notion-database-". We need to pick the right one depending on the view type. For view type "all", we return the "table" one.

Fixes the issue that when searching an url in assistant builder corresponding to a database, the node id returned was always "notion-[ID]", the one of type "table" --- so no result would be shown if viewType was set to "document".

Risks
---
Blast radius: url search
Risk low

Deploy
---
front

