### PR TITLE
[connectors] enh(Microsoft): heartbeat in `recursiveNodeDeletion`

### DIFF
--- a/connectors/src/connectors/microsoft/temporal/file.ts
+++ b/connectors/src/connectors/microsoft/temporal/file.ts
@@ -35,6 +35,7 @@ import {
   upsertDataSourceDocument,
 } from "@connectors/lib/data_sources";
 import type { MicrosoftNodeModel } from "@connectors/lib/models/microsoft";
+import { heartbeat } from "@connectors/lib/temporal";
 import logger from "@connectors/logger/logger";
 import { statsDClient } from "@connectors/logger/withlogging";
 import type { WithCreationAttributes } from "@connectors/resources/connector/strategy";
@@ -581,6 +582,7 @@ export async function recursiveNodeDeletion({
   connectorId: ModelId;
   dataSourceConfig: DataSourceConfig;
 }): Promise<string[]> {
+  await heartbeat();
   const node = await MicrosoftNodeResource.fetchByInternalId(
     connectorId,
     nodeId


### PR DESCRIPTION
## Description

- In remediation of https://github.com/dust-tt/tasks/issues/3325.
- This PR adds a heartbeat when deleting nodes recursively.
- The incremental sync is heartbeat-timing out.
- This deletion seems to be possibly quite long if we have a lot of data to delete.

## Tests

## Risk

- Add some latency.

## Deploy Plan

- Deploy connectors.
