### PR TITLE
[front] connections: don't close bq modal on error

### DIFF
--- a/front/components/data_source/CreateOrUpdateConnectionBigQueryModal.tsx
+++ b/front/components/data_source/CreateOrUpdateConnectionBigQueryModal.tsx
@@ -138,7 +138,7 @@ export function CreateOrUpdateConnectionBigQueryModal({
     setError(null);
   }
 
-  const createBigQueryConnection = async () => {
+  const createBigQueryConnection = async (): Promise<boolean> => {
     if (!onSuccess || !createDatasource) {
       // Should never happen.
       throw new Error("onCreated and createDatasource are required");
@@ -167,7 +167,7 @@ export function CreateOrUpdateConnectionBigQueryModal({
     if (!createCredentialsRes.ok) {
       setError("Failed to create connection: cannot verify those credentials.");
       setIsLoading(false);
-      return;
+      return false;
     }
 
     // Then we can try to create the connector.
@@ -194,7 +194,7 @@ export function CreateOrUpdateConnectionBigQueryModal({
       }
 
       setIsLoading(false);
-      return;
+      return false;
     }
 
     const createdManagedDataSource: {
@@ -204,9 +204,10 @@ export function CreateOrUpdateConnectionBigQueryModal({
 
     onSuccess(createdManagedDataSource.dataSource);
     setIsLoading(false);
+    return true;
   };
 
-  const updateBigQueryConnection = async () => {
+  const updateBigQueryConnection = async (): Promise<boolean> => {
     if (!dataSourceToUpdate) {
       // Should never happen.
       throw new Error("dataSourceToUpdate is required");
@@ -237,7 +238,7 @@ export function CreateOrUpdateConnectionBigQueryModal({
     if (!credentialsRes.ok) {
       setError("Failed to update connection: cannot verify those credentials.");
       setIsLoading(false);
-      return;
+      return false;
     }
 
     const data = await credentialsRes.json();
@@ -272,10 +273,11 @@ export function CreateOrUpdateConnectionBigQueryModal({
         setError(`Failed to update BigQuery connection: ${err.error.message}`);
       }
 
-      return;
+      return false;
     }
 
     onSuccess(dataSourceToUpdate);
+    return true;
   };
 
   return (
@@ -382,12 +384,12 @@ export function CreateOrUpdateConnectionBigQueryModal({
               e.preventDefault();
               e.stopPropagation();
               setIsLoading(true);
-              dataSourceToUpdate
+              const success = dataSourceToUpdate
                 ? await updateBigQueryConnection()
                 : await createBigQueryConnection();
-
               setIsLoading(false);
-              if (!error) {
+
+              if (success) {
                 onClose();
               }
             },

--- a/front/components/data_source/CreateOrUpdateConnectionBigQueryModal.tsx
+++ b/front/components/data_source/CreateOrUpdateConnectionBigQueryModal.tsx
@@ -135,6 +135,7 @@ export function CreateOrUpdateConnectionBigQueryModal({
   function onSuccess(ds: DataSourceType) {
     setCredentials("");
     _onSuccess(ds);
+    setError(null);
   }
 
   const createBigQueryConnection = async () => {
@@ -386,7 +387,9 @@ export function CreateOrUpdateConnectionBigQueryModal({
                 : await createBigQueryConnection();
 
               setIsLoading(false);
-              onClose();
+              if (!error) {
+                onClose();
+              }
             },
             isLoading: isLoading || isLocationsLoading,
             disabled:


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

Closes https://github.com/dust-tt/tasks/issues/3394
This PR displays an error if the connection to bigquery fails instead of closing the modal without informing the user.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

Tested by hand.

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

Low risks

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->

Deploy front