### PR TITLE
[URL Search] Fix: broken search on notion tables

### DIFF
--- a/front/components/data_source_view/DataSourceViewSelector.tsx
+++ b/front/components/data_source_view/DataSourceViewSelector.tsx
@@ -25,6 +25,7 @@ import { useDebounce } from "@app/hooks/useDebounce";
 import { getConnectorProviderLogoWithFallback } from "@app/lib/connector_providers";
 import type { NodeCandidate, UrlCandidate } from "@app/lib/connectors";
 import {
+  getViewTypeForURLNodeCandidateAccountingForNotion,
   isNodeCandidate,
   isUrlCandidate,
   nodeCandidateFromUrl,
@@ -344,7 +345,6 @@ export function DataSourceViewsSelector({
 
   const commonSearchParams = {
     owner,
-    viewType,
     spaceIds: [space.sId],
     disabled: !debouncedSearch,
     dataSourceViewIdsBySpaceId:
@@ -366,12 +366,17 @@ export function DataSourceViewsSelector({
           ...commonSearchParams,
           nodeIds: [nodeOrUrlCandidate.node],
           includeDataSources: false,
+          viewType: getViewTypeForURLNodeCandidateAccountingForNotion(
+            viewType,
+            nodeOrUrlCandidate.node
+          ),
         }
       : {
           ...commonSearchParams,
           search: debouncedSearch,
           searchSourceUrls: isUrlCandidate(nodeOrUrlCandidate),
           includeDataSources: true,
+          viewType: viewType,
         }
   );
 

--- a/front/components/data_source_view/DataSourceViewSelector.tsx
+++ b/front/components/data_source_view/DataSourceViewSelector.tsx
@@ -376,7 +376,7 @@ export function DataSourceViewsSelector({
           search: debouncedSearch,
           searchSourceUrls: isUrlCandidate(nodeOrUrlCandidate),
           includeDataSources: true,
-          viewType: viewType,
+          viewType,
         }
   );
 

--- a/front/components/spaces/SpaceSearchLayout.tsx
+++ b/front/components/spaces/SpaceSearchLayout.tsx
@@ -244,7 +244,6 @@ function BackendSearch({
 
   const commonSearchParams = {
     owner,
-    viewType,
     spaceIds: [space.sId],
     pagination: { cursor: cursorPagination.cursor, limit: PAGE_SIZE },
     // Required by search API to allow admins to search the system space
@@ -270,12 +269,17 @@ function BackendSearch({
           ...commonSearchParams,
           nodeIds: [nodeOrUrlCandidate.node],
           includeDataSources: false,
+          viewType: getViewTypeForNodeCandidateAccountingForNotion(
+            viewType,
+            nodeOrUrlCandidate.node
+          ),
         }
       : {
           ...commonSearchParams,
           search: debouncedSearch,
           searchSourceUrls: isUrlCandidate(nodeOrUrlCandidate),
           includeDataSources: true,
+          viewType,
         }
   );
 
@@ -657,4 +661,10 @@ function SearchResultsTable({
       isLoading={isLoading}
     />
   );
+}
+function getViewTypeForNodeCandidateAccountingForNotion(
+  viewType: string,
+  node: string
+): "table" | "document" | "all" {
+  throw new Error("Function not implemented.");
 }

--- a/front/components/spaces/SpaceSearchLayout.tsx
+++ b/front/components/spaces/SpaceSearchLayout.tsx
@@ -24,6 +24,7 @@ import { useDebounce } from "@app/hooks/useDebounce";
 import { useQueryParams } from "@app/hooks/useQueryParams";
 import type { NodeCandidate, UrlCandidate } from "@app/lib/connectors";
 import {
+  getViewTypeForURLNodeCandidateAccountingForNotion,
   isNodeCandidate,
   isUrlCandidate,
   nodeCandidateFromUrl,
@@ -269,7 +270,7 @@ function BackendSearch({
           ...commonSearchParams,
           nodeIds: [nodeOrUrlCandidate.node],
           includeDataSources: false,
-          viewType: getViewTypeForNodeCandidateAccountingForNotion(
+          viewType: getViewTypeForURLNodeCandidateAccountingForNotion(
             viewType,
             nodeOrUrlCandidate.node
           ),
@@ -661,10 +662,4 @@ function SearchResultsTable({
       isLoading={isLoading}
     />
   );
-}
-function getViewTypeForNodeCandidateAccountingForNotion(
-  viewType: string,
-  node: string
-): "table" | "document" | "all" {
-  throw new Error("Function not implemented.");
 }

--- a/front/lib/connectors.ts
+++ b/front/lib/connectors.ts
@@ -1,5 +1,5 @@
 import { CONNECTOR_CONFIGURATIONS } from "@app/lib/connector_providers";
-import type { ConnectorProvider } from "@app/types";
+import type { ConnectorProvider, ContentNodesViewType } from "@app/types";
 
 function getConnectorOrder() {
   return Object.keys(CONNECTOR_CONFIGURATIONS)
@@ -363,4 +363,17 @@ export function nodeCandidateFromUrl(
     console.error("Error parsing URL:", error);
     return null;
   }
+}
+
+// Notion databases have 2 entries in core:
+// - one of type "table" starting with "notion-";
+// - one of type "document" starting with "notion-database-".
+//
+// When we search by URL, we assume the user is looking for the table 99% of the
+// time, as the table is also the "container" of child pages of the database.
+export function getViewTypeForURLNodeCandidateAccountingForNotion(
+  viewType: ContentNodesViewType,
+  nodeId: string
+) {
+  return nodeId.startsWith("notion-") ? "table" : viewType;
 }


### PR DESCRIPTION
## Description
Fixes dust-tt/tasks#3400

Replaces https://github.com/dust-tt/dust/pull/14091.

Fixes the issue that when searching an url in assistant builder corresponding to a database, the node id returned was always "notion-[ID]", the one of type "table" --- so no result would be shown if viewType was set to "document".

Notion databases have 2 entries in core:

- one of type "table" starting with "notion-";
- one of type "document" starting with "notion-database-".

We need to pick the right one when searching by URL. We here assume the user is looking for the table 99% of the time, as the table is also the "container" of child pages of the database.


## Risk
low

## Deploy Plan
front