### PR TITLE
[front] workos: update org name when workspace name changes

### DIFF
--- a/front/lib/api/workos/organization.ts
+++ b/front/lib/api/workos/organization.ts
@@ -213,9 +213,7 @@ export async function updateWorkOSOrganizationName(
       workspaceId: workspace.id,
       organizationId: organization.id,
     });
-    return new Err(
-      new Error(`Failed to update WorkOS organization name: ${e.message}`)
-    );
+    return new Ok(undefined);
   }
 
   return new Ok(undefined);

--- a/front/lib/api/workos/organization.ts
+++ b/front/lib/api/workos/organization.ts
@@ -182,6 +182,45 @@ export async function removeWorkOSOrganizationDomain(
   return new Ok(undefined);
 }
 
+export async function updateWorkOSOrganizationName(
+  workspace: LightWorkspaceType
+): Promise<Result<void, Error>> {
+  const organizationRes = await getWorkOSOrganization(workspace);
+  if (organizationRes.isErr()) {
+    return new Err(organizationRes.error);
+  }
+
+  const organization = organizationRes.value;
+  if (!organization) {
+    return new Ok(undefined);
+  }
+
+  const newName = `${workspace.name} - ${workspace.sId}`;
+
+  if (organization.name === newName) {
+    return new Ok(undefined);
+  }
+
+  try {
+    await getWorkOS().organizations.updateOrganization({
+      organization: organization.id,
+      name: newName,
+    });
+  } catch (error) {
+    const e = normalizeError(error);
+    logger.error("Failed to update WorkOS organization name", {
+      error: e,
+      workspaceId: workspace.id,
+      organizationId: organization.id,
+    });
+    return new Err(
+      new Error(`Failed to update WorkOS organization name: ${e.message}`)
+    );
+  }
+
+  return new Ok(undefined);
+}
+
 export async function listWorkOSOrganizationsWithDomain(
   domain: string
 ): Promise<Organization[]> {

--- a/front/pages/api/w/[wId]/index.test.ts
+++ b/front/pages/api/w/[wId]/index.test.ts
@@ -66,38 +66,40 @@ describe("POST /api/w/[wId]", () => {
   });
 
   itInTransaction("updates workspace name", async () => {
+    const getOrganizationByExternalIdSpy = vi.fn().mockResolvedValue({
+      id: "org_123",
+      name: "Old Workspace Name - sId123",
+      object: "organization",
+      allowProfilesOutsideOrganization: false,
+      createdAt: new Date().toISOString(),
+      updatedAt: new Date().toISOString(),
+      domains: [],
+      externalId: "sId123",
+      metadata: {},
+      connectionCount: 0,
+      state: "active",
+    } as Organization);
+
+    const updateOrganizationSpy = vi.fn().mockResolvedValue({
+      id: "org_123",
+      name: "New Workspace Name - sId123",
+      object: "organization",
+      allowProfilesOutsideOrganization: false,
+      createdAt: new Date().toISOString(),
+      updatedAt: new Date().toISOString(),
+      domains: [],
+      externalId: "sId123",
+      metadata: {},
+      connectionCount: 0,
+      state: "active",
+    } as Organization);
+
     vi.spyOn(workosClient, "getWorkOS").mockImplementation(
       () =>
         ({
           organizations: {
-            getOrganizationByExternalId: async () =>
-              ({
-                id: "org_123",
-                name: "Old Workspace Name - sId123",
-                object: "organization",
-                allowProfilesOutsideOrganization: false,
-                createdAt: new Date().toISOString(),
-                updatedAt: new Date().toISOString(),
-                domains: [],
-                externalId: "sId123",
-                metadata: {},
-                connectionCount: 0,
-                state: "active",
-              }) as Organization,
-            updateOrganization: async () =>
-              ({
-                id: "org_123",
-                name: "New Workspace Name - sId123",
-                object: "organization",
-                allowProfilesOutsideOrganization: false,
-                createdAt: new Date().toISOString(),
-                updatedAt: new Date().toISOString(),
-                domains: [],
-                externalId: "sId123",
-                metadata: {},
-                connectionCount: 0,
-                state: "active",
-              }) as Organization,
+            getOrganizationByExternalId: getOrganizationByExternalIdSpy,
+            updateOrganization: updateOrganizationSpy,
           },
         }) as any
     );
@@ -120,6 +122,8 @@ describe("POST /api/w/[wId]", () => {
         name: "New Workspace Name",
       }),
     });
+
+    expect(updateOrganizationSpy).toHaveBeenCalled();
   });
 
   itInTransaction("updates SSO enforcement", async () => {

--- a/front/pages/api/w/[wId]/index.test.ts
+++ b/front/pages/api/w/[wId]/index.test.ts
@@ -1,6 +1,8 @@
 import { faker } from "@faker-js/faker";
-import { describe, expect } from "vitest";
+import type { Organization } from "@workos-inc/node";
+import { describe, expect, vi } from "vitest";
 
+import * as workosClient from "@app/lib/api/workos/client";
 import { WorkspaceHasDomainModel } from "@app/lib/resources/storage/models/workspace_has_domain";
 import { createPrivateApiMockRequest } from "@app/tests/utils/generic_private_api_tests";
 import { itInTransaction } from "@app/tests/utils/utils";
@@ -64,6 +66,42 @@ describe("POST /api/w/[wId]", () => {
   });
 
   itInTransaction("updates workspace name", async () => {
+    vi.spyOn(workosClient, "getWorkOS").mockImplementation(
+      () =>
+        ({
+          organizations: {
+            getOrganizationByExternalId: async () =>
+              ({
+                id: "org_123",
+                name: "Old Workspace Name - sId123",
+                object: "organization",
+                allowProfilesOutsideOrganization: false,
+                createdAt: new Date().toISOString(),
+                updatedAt: new Date().toISOString(),
+                domains: [],
+                externalId: "sId123",
+                metadata: {},
+                connectionCount: 0,
+                state: "active",
+              }) as Organization,
+            updateOrganization: async () =>
+              ({
+                id: "org_123",
+                name: "New Workspace Name - sId123",
+                object: "organization",
+                allowProfilesOutsideOrganization: false,
+                createdAt: new Date().toISOString(),
+                updatedAt: new Date().toISOString(),
+                domains: [],
+                externalId: "sId123",
+                metadata: {},
+                connectionCount: 0,
+                state: "active",
+              }) as Organization,
+          },
+        }) as any
+    );
+
     const { req, res, workspace } = await createPrivateApiMockRequest({
       method: "POST",
       role: "admin",

--- a/front/pages/api/w/[wId]/index.ts
+++ b/front/pages/api/w/[wId]/index.ts
@@ -5,6 +5,7 @@ import * as reporter from "io-ts-reporters";
 import type { NextApiRequest, NextApiResponse } from "next";
 
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
+import { updateWorkOSOrganizationName } from "@app/lib/api/workos/organization";
 import type { Authenticator } from "@app/lib/auth";
 import { WorkspaceModel } from "@app/lib/resources/storage/models/workspace";
 import { WorkspaceHasDomainModel } from "@app/lib/resources/storage/models/workspace_has_domain";
@@ -107,6 +108,17 @@ async function handler(
           name: escape(body.name),
         });
         owner.name = body.name;
+
+        const updateRes = await updateWorkOSOrganizationName(owner);
+        if (updateRes.isErr()) {
+          return apiError(req, res, {
+            status_code: 500,
+            api_error: {
+              type: "internal_server_error",
+              message: `Failed to update WorkOS organization name: ${updateRes.error.message}`,
+            },
+          });
+        }
       } else if ("ssoEnforced" in body) {
         await w.update({
           ssoEnforced: body.ssoEnforced,

--- a/front/tests/utils/WorkspaceFactory.ts
+++ b/front/tests/utils/WorkspaceFactory.ts
@@ -15,6 +15,7 @@ export class WorkspaceFactory {
       sId: generateRandomModelSId(),
       name: faker.company.name(),
       description: faker.company.catchPhrase(),
+      workOSOrganizationId: faker.string.alpha(10),
     });
 
     const newPlan = await Plan.findOne({


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

closes https://github.com/dust-tt/tasks/issues/3387
we currently don't update organization name in workos when worksapce name changes
this fix makes finding an organization easier

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

tested by hand, updates workos successfully

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

low risks

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->

deploy front