### PR TITLE
Revamp hubspot tools

### DIFF
--- a/front/lib/actions/mcp_internal_actions/constants.ts
+++ b/front/lib/actions/mcp_internal_actions/constants.ts
@@ -123,6 +123,11 @@ export const INTERNAL_MCP_SERVERS: Record<
       get_meeting: "never_ask",
       get_file_public_url: "never_ask",
       get_associated_meetings: "never_ask",
+      get_hubspot_link: "never_ask",
+      get_hubspot_portal_id: "never_ask",
+
+      count_objects_by_properties: "never_ask",
+      search_crm_objects: "never_ask",
 
       // Create operations.
       create_contact: "high",
@@ -139,10 +144,6 @@ export const INTERNAL_MCP_SERVERS: Record<
       update_contact: "high",
       update_company: "high",
       update_deal: "high",
-
-      // Other operations.
-      count_objects_by_properties: "never_ask",
-      search_crm_objects: "never_ask",
     },
   },
   agent_router: {

--- a/front/lib/actions/mcp_internal_actions/constants.ts
+++ b/front/lib/actions/mcp_internal_actions/constants.ts
@@ -125,6 +125,7 @@ export const INTERNAL_MCP_SERVERS: Record<
       get_associated_meetings: "never_ask",
       get_hubspot_link: "never_ask",
       get_hubspot_portal_id: "never_ask",
+      list_owners: "never_ask",
 
       count_objects_by_properties: "never_ask",
       search_crm_objects: "never_ask",

--- a/front/lib/actions/mcp_internal_actions/constants.ts
+++ b/front/lib/actions/mcp_internal_actions/constants.ts
@@ -126,9 +126,13 @@ export const INTERNAL_MCP_SERVERS: Record<
       get_hubspot_link: "never_ask",
       get_hubspot_portal_id: "never_ask",
       list_owners: "never_ask",
+      get_current_user_id: "never_ask",
+      get_user_activity: "never_ask",
+      list_associations: "never_ask",
 
       count_objects_by_properties: "never_ask",
       search_crm_objects: "never_ask",
+      export_crm_objects_csv: "never_ask",
 
       // Create operations.
       create_contact: "high",
@@ -140,11 +144,13 @@ export const INTERNAL_MCP_SERVERS: Record<
       create_note: "high",
       create_communication: "high",
       create_meeting: "high",
+      create_association: "high",
 
       // Update operations.
       update_contact: "high",
       update_company: "high",
       update_deal: "high",
+      remove_association: "high",
     },
   },
   agent_router: {

--- a/front/lib/actions/mcp_internal_actions/constants.ts
+++ b/front/lib/actions/mcp_internal_actions/constants.ts
@@ -126,6 +126,7 @@ export const INTERNAL_MCP_SERVERS: Record<
       get_hubspot_link: "never_ask",
       get_hubspot_portal_id: "never_ask",
       list_owners: "never_ask",
+      search_owners: "never_ask",
       get_current_user_id: "never_ask",
       get_user_activity: "never_ask",
       list_associations: "never_ask",

--- a/front/lib/actions/mcp_internal_actions/servers/hubspot/hubspot_api_helper.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/hubspot/hubspot_api_helper.ts
@@ -136,6 +136,56 @@ export const listOwners = async (
   }));
 };
 
+export const searchOwners = async (
+  accessToken: string,
+  searchQuery: string
+): Promise<
+  {
+    id: string;
+    email: string | null;
+    firstName: string | null;
+    lastName: string | null;
+    userId: number | null;
+    archived: boolean;
+  }[]
+> => {
+  const hubspotClient = new Client({ accessToken });
+  const owners = await hubspotClient.crm.owners.ownersApi.getPage();
+
+  const query = searchQuery.toLowerCase();
+
+  const filteredOwners = owners.results.filter((owner) => {
+    const emailMatch = owner.email?.toLowerCase().includes(query) || false;
+    const firstNameMatch =
+      owner.firstName?.toLowerCase().includes(query) || false;
+    const lastNameMatch =
+      owner.lastName?.toLowerCase().includes(query) || false;
+    const fullNameMatch = `${owner.firstName || ""} ${owner.lastName || ""}`
+      .toLowerCase()
+      .includes(query);
+    const idMatch = owner.id === searchQuery; // Exact match for ID
+    const userIdMatch = owner.userId?.toString() === searchQuery; // Exact match for userId
+
+    return (
+      emailMatch ||
+      firstNameMatch ||
+      lastNameMatch ||
+      fullNameMatch ||
+      idMatch ||
+      userIdMatch
+    );
+  });
+
+  return filteredOwners.map((owner) => ({
+    id: owner.id,
+    email: owner.email ?? null,
+    firstName: owner.firstName ?? null,
+    lastName: owner.lastName ?? null,
+    userId: owner.userId ?? null,
+    archived: owner.archived ?? false,
+  }));
+};
+
 interface HubspotFilter {
   propertyName: string;
   operator: FilterOperatorEnum;

--- a/front/lib/actions/mcp_internal_actions/servers/hubspot/hubspot_response_helpers.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/hubspot/hubspot_response_helpers.ts
@@ -121,28 +121,9 @@ export function formatHubSpotSearchResults(
   objects: SimplePublicObject[],
   objectType: string,
   portalId?: string
-): SearchResultResourceType[] {
-  return objects.map((object, index) => {
-    const formatted = formatHubSpotObject(object, objectType, portalId);
-
-    return {
-      mimeType: INTERNAL_MIME_TYPES.TOOL_OUTPUT.DATA_SOURCE_SEARCH_RESULT,
-      uri: formatted.url || "",
-      text: formatted.title,
-      id: formatted.id,
-      tags: [
-        objectType,
-        ...(formatted.created_at ? [`created: ${formatted.created_at}`] : []),
-        ...(formatted.updated_at ? [`updated: ${formatted.updated_at}`] : []),
-      ],
-      ref: `[${index + 1}]`,
-      chunks: Object.entries(formatted.properties).map(
-        ([key, value]) => `${key}: ${value}`
-      ),
-      source: {
-        provider: "hubspot",
-      },
-    };
+): HubSpotObjectSummary[] {
+  return objects.map((object) => {
+    return formatHubSpotObject(object, objectType, portalId);
   });
 }
 

--- a/front/lib/actions/mcp_internal_actions/servers/hubspot/hubspot_response_helpers.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/hubspot/hubspot_response_helpers.ts
@@ -1,0 +1,307 @@
+import { INTERNAL_MIME_TYPES } from "@dust-tt/client";
+import type { SimplePublicObject } from "@hubspot/api-client/lib/codegen/crm/objects/models/SimplePublicObject";
+import type { Property } from "@hubspot/api-client/lib/codegen/crm/properties/models/Property";
+
+import type { SearchResultResourceType } from "@app/lib/actions/mcp_internal_actions/output_schemas";
+
+// HubSpot-specific resource types
+export interface HubSpotObjectSummary {
+  id: string;
+  type: string;
+  title: string;
+  url?: string;
+  properties: Record<string, string>;
+  created_at?: string;
+  updated_at?: string;
+}
+
+export interface HubSpotPropertySummary {
+  name: string;
+  label: string;
+  type: string;
+  description?: string;
+  required?: boolean;
+  options?: Array<{ label: string; value: string }>;
+}
+
+/**
+ * Important date fields to always include for each object type
+ */
+const IMPORTANT_DATE_FIELDS: Record<string, string[]> = {
+  contacts: ["createdate", "lastmodifieddate"],
+  companies: ["createdate", "lastmodifieddate"],
+  deals: ["closedate", "createdate", "lastmodifieddate"],
+  tickets: ["createdate", "lastmodifieddate", "closedate"],
+};
+
+/**
+ * Transform a raw HubSpot SimplePublicObject into a clean summary
+ */
+export function formatHubSpotObject(
+  object: SimplePublicObject,
+  objectType: string,
+  portalId?: string
+): HubSpotObjectSummary {
+  const getTitleField = (type: string): string => {
+    switch (type) {
+      case "contacts":
+        return object.properties.firstname && object.properties.lastname
+          ? `${object.properties.firstname} ${object.properties.lastname}`
+          : object.properties.email ||
+              object.properties.firstname ||
+              object.properties.lastname ||
+              "Unnamed Contact";
+      case "companies":
+        return (
+          object.properties.name ||
+          object.properties.domain ||
+          "Unnamed Company"
+        );
+      case "deals":
+        return object.properties.dealname || "Unnamed Deal";
+      case "tickets":
+        return object.properties.subject || `Ticket #${object.id}`;
+      default:
+        return (
+          object.properties.name ||
+          object.properties.title ||
+          `${type.slice(0, -1)} #${object.id}`
+        );
+    }
+  };
+
+  const allowlist = IMPORTANT_DATE_FIELDS[objectType] || [];
+
+  const cleanProperties = Object.entries(object.properties)
+    .filter(
+      ([key, value]) =>
+        value !== null &&
+        value !== undefined &&
+        value !== "" &&
+        !key.startsWith("hs_") &&
+        !key.includes("_id") &&
+        key !== "hubspot_owner_id" &&
+        ((!key.includes("_date") && !key.includes("_timestamp")) ||
+          allowlist.includes(key)) // Only filter out _date/_timestamp if not in allowlist
+    )
+    .reduce(
+      (acc, [key, value]) => {
+        acc[key] = String(value);
+        return acc;
+      },
+      {} as Record<string, string>
+    );
+
+  const hubSpotUrl = portalId
+    ? `https://app.hubspot.com/contacts/${portalId}/${objectType}/${object.id}`
+    : undefined;
+
+  return {
+    id: object.id,
+    type: objectType,
+    title: getTitleField(objectType),
+    url: hubSpotUrl,
+    properties: cleanProperties,
+    created_at: object.properties.createdate || undefined,
+    updated_at: object.properties.lastmodifieddate || undefined,
+  };
+}
+
+/**
+ * Transform a raw HubSpot Property into a clean summary
+ */
+export function formatHubSpotProperty(
+  property: Property
+): HubSpotPropertySummary {
+  return {
+    name: property.name,
+    label: property.label || property.name,
+    type: property.type,
+    description: property.description || undefined,
+    required: false, // HubSpot API doesn't provide required info directly
+    options:
+      property.options?.slice(0, 20).map((option) => ({
+        label: option.label,
+        value: option.value,
+      })) || undefined,
+  };
+}
+
+/**
+ * Transform HubSpot objects into SearchResultResourceType format
+ */
+export function formatHubSpotSearchResults(
+  objects: SimplePublicObject[],
+  objectType: string,
+  query: string,
+  portalId?: string
+): SearchResultResourceType[] {
+  return objects.map((object, index) => {
+    const formatted = formatHubSpotObject(object, objectType, portalId);
+
+    return {
+      mimeType: INTERNAL_MIME_TYPES.TOOL_OUTPUT.DATA_SOURCE_SEARCH_RESULT,
+      uri: formatted.url || "",
+      text: formatted.title,
+      id: formatted.id,
+      tags: [
+        objectType,
+        ...(formatted.created_at ? [`created: ${formatted.created_at}`] : []),
+        ...(formatted.updated_at ? [`updated: ${formatted.updated_at}`] : []),
+      ],
+      ref: `[${index + 1}]`,
+      chunks: [
+        Object.entries(formatted.properties)
+          .map(([key, value]) => `${key}: ${value}`)
+          .join(", "),
+      ],
+      source: {
+        provider: "hubspot",
+      },
+    };
+  });
+}
+
+/**
+ * Create a formatted text summary of HubSpot objects
+ */
+export function formatHubSpotObjectsAsText(
+  objects: SimplePublicObject[],
+  objectType: string,
+  portalId?: string
+): string {
+  if (objects.length === 0) {
+    return `No ${objectType} found.`;
+  }
+
+  const formatted = objects
+    .map((object, index) => {
+      const summary = formatHubSpotObject(object, objectType, portalId);
+      const propertiesText = Object.entries(summary.properties)
+        .map(([key, value]) => `  ${key}: ${value}`)
+        .join("\n");
+
+      return `${index + 1}. ${summary.title} (ID: ${summary.id})${summary.url ? `\n   URL: ${summary.url}` : ""}${propertiesText ? `\n${propertiesText}` : ""}`;
+    })
+    .join("\n\n");
+
+  return `Found ${objects.length} ${objectType}:\n\n${formatted}`;
+}
+
+/**
+ * Format properties list as clean text
+ */
+export function formatHubSpotPropertiesAsText(
+  properties: Property[],
+  objectType: string,
+  creatableOnly: boolean = false
+): string {
+  if (properties.length === 0) {
+    return `No properties found for ${objectType}.`;
+  }
+
+  const formatted = properties
+    .map((property, index) => {
+      const summary = formatHubSpotProperty(property);
+      let text = `${index + 1}. ${summary.name} (${summary.label})`;
+      text += `\n   Type: ${summary.type}`;
+      if (summary.description) {
+        text += `\n   Description: ${summary.description}`;
+      }
+      if (summary.required) {
+        text += `\n   Required: Yes`;
+      }
+      if (summary.options && summary.options.length > 0) {
+        text += `\n   Options: ${summary.options.map((o) => o.label).join(", ")}`;
+      }
+      return text;
+    })
+    .join("\n\n");
+
+  const typeText = creatableOnly ? "creatable properties" : "properties";
+  return `Found ${properties.length} ${typeText} for ${objectType}:\n\n${formatted}`;
+}
+
+/**
+ * Format transformed properties list (from getObjectProperties) as clean text
+ */
+export function formatTransformedPropertiesAsText(
+  properties: Array<{
+    name: string;
+    label: string;
+    type: string;
+    description?: string;
+    options?: Array<{ label: string; value: string }>;
+  }>,
+  objectType: string,
+  creatableOnly: boolean = false
+): string {
+  if (properties.length === 0) {
+    return `No properties found for ${objectType}.`;
+  }
+
+  const formatted = properties
+    .map((property, index) => {
+      let text = `${index + 1}. ${property.name} (${property.label})`;
+      text += `\n   Type: ${property.type}`;
+      if (property.description) {
+        text += `\n   Description: ${property.description}`;
+      }
+      if (property.options && property.options.length > 0) {
+        text += `\n   Options: ${property.options.map((o) => o.label).join(", ")}`;
+      }
+      return text;
+    })
+    .join("\n\n");
+
+  const typeText = creatableOnly ? "creatable properties" : "properties";
+  return `Found ${properties.length} ${typeText} for ${objectType}:\n\n${formatted}`;
+}
+
+/**
+ * Create a simple creation success message
+ */
+export function formatHubSpotCreateSuccess(
+  object: SimplePublicObject,
+  objectType: string,
+  portalId?: string
+): { message: string; result: HubSpotObjectSummary } {
+  const formatted = formatHubSpotObject(object, objectType, portalId);
+
+  return {
+    message: `${objectType.slice(0, -1)} created successfully: ${formatted.title}`,
+    result: formatted,
+  };
+}
+
+/**
+ * Create a simple update success message
+ */
+export function formatHubSpotUpdateSuccess(
+  object: SimplePublicObject,
+  objectType: string,
+  portalId?: string
+): { message: string; result: HubSpotObjectSummary } {
+  const formatted = formatHubSpotObject(object, objectType, portalId);
+
+  return {
+    message: `${objectType.slice(0, -1)} updated successfully: ${formatted.title}`,
+    result: formatted,
+  };
+}
+
+/**
+ * Create a simple get success message
+ */
+export function formatHubSpotGetSuccess(
+  object: SimplePublicObject,
+  objectType: string,
+  portalId?: string
+): { message: string; result: HubSpotObjectSummary } {
+  const formatted = formatHubSpotObject(object, objectType, portalId);
+
+  return {
+    message: `${objectType.slice(0, -1)} retrieved successfully: ${formatted.title}`,
+    result: formatted,
+  };
+}

--- a/front/lib/actions/mcp_internal_actions/servers/hubspot/hubspot_response_helpers.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/hubspot/hubspot_response_helpers.ts
@@ -4,7 +4,6 @@ import type { Property } from "@hubspot/api-client/lib/codegen/crm/properties/mo
 
 import type { SearchResultResourceType } from "@app/lib/actions/mcp_internal_actions/output_schemas";
 
-// HubSpot-specific resource types
 export interface HubSpotObjectSummary {
   id: string;
   type: string;
@@ -24,9 +23,6 @@ export interface HubSpotPropertySummary {
   options?: Array<{ label: string; value: string }>;
 }
 
-/**
- * Important date fields to always include for each object type
- */
 const IMPORTANT_DATE_FIELDS: Record<string, string[]> = {
   contacts: ["createdate", "lastmodifieddate"],
   companies: ["createdate", "lastmodifieddate"],
@@ -34,9 +30,6 @@ const IMPORTANT_DATE_FIELDS: Record<string, string[]> = {
   tickets: ["createdate", "lastmodifieddate", "closedate"],
 };
 
-/**
- * Transform a raw HubSpot SimplePublicObject into a clean summary
- */
 export function formatHubSpotObject(
   object: SimplePublicObject,
   objectType: string,
@@ -82,7 +75,7 @@ export function formatHubSpotObject(
         !key.includes("_id") &&
         key !== "hubspot_owner_id" &&
         ((!key.includes("_date") && !key.includes("_timestamp")) ||
-          allowlist.includes(key)) // Only filter out _date/_timestamp if not in allowlist
+          allowlist.includes(key))
     )
     .reduce(
       (acc, [key, value]) => {
@@ -107,9 +100,6 @@ export function formatHubSpotObject(
   };
 }
 
-/**
- * Transform a raw HubSpot Property into a clean summary
- */
 export function formatHubSpotProperty(
   property: Property
 ): HubSpotPropertySummary {
@@ -118,7 +108,7 @@ export function formatHubSpotProperty(
     label: property.label || property.name,
     type: property.type,
     description: property.description || undefined,
-    required: false, // HubSpot API doesn't provide required info directly
+    required: false,
     options:
       property.options?.slice(0, 20).map((option) => ({
         label: option.label,
@@ -127,13 +117,9 @@ export function formatHubSpotProperty(
   };
 }
 
-/**
- * Transform HubSpot objects into SearchResultResourceType format
- */
 export function formatHubSpotSearchResults(
   objects: SimplePublicObject[],
   objectType: string,
-  query: string,
   portalId?: string
 ): SearchResultResourceType[] {
   return objects.map((object, index) => {
@@ -160,9 +146,6 @@ export function formatHubSpotSearchResults(
   });
 }
 
-/**
- * Create a formatted text summary of HubSpot objects
- */
 export function formatHubSpotObjectsAsText(
   objects: SimplePublicObject[],
   objectType: string,
@@ -186,9 +169,6 @@ export function formatHubSpotObjectsAsText(
   return `Found ${objects.length} ${objectType}:\n\n${formatted}`;
 }
 
-/**
- * Format properties list as clean text
- */
 export function formatHubSpotPropertiesAsText(
   properties: Property[],
   objectType: string,
@@ -220,9 +200,6 @@ export function formatHubSpotPropertiesAsText(
   return `Found ${properties.length} ${typeText} for ${objectType}:\n\n${formatted}`;
 }
 
-/**
- * Format transformed properties list (from getObjectProperties) as clean text
- */
 export function formatTransformedPropertiesAsText(
   properties: Array<{
     name: string;
@@ -256,9 +233,6 @@ export function formatTransformedPropertiesAsText(
   return `Found ${properties.length} ${typeText} for ${objectType}:\n\n${formatted}`;
 }
 
-/**
- * Create a simple creation success message
- */
 export function formatHubSpotCreateSuccess(
   object: SimplePublicObject,
   objectType: string,
@@ -272,9 +246,6 @@ export function formatHubSpotCreateSuccess(
   };
 }
 
-/**
- * Create a simple update success message
- */
 export function formatHubSpotUpdateSuccess(
   object: SimplePublicObject,
   objectType: string,
@@ -288,9 +259,6 @@ export function formatHubSpotUpdateSuccess(
   };
 }
 
-/**
- * Create a simple get success message
- */
 export function formatHubSpotGetSuccess(
   object: SimplePublicObject,
   objectType: string,

--- a/front/lib/actions/mcp_internal_actions/servers/hubspot/hubspot_response_helpers.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/hubspot/hubspot_response_helpers.ts
@@ -150,11 +150,9 @@ export function formatHubSpotSearchResults(
         ...(formatted.updated_at ? [`updated: ${formatted.updated_at}`] : []),
       ],
       ref: `[${index + 1}]`,
-      chunks: [
-        Object.entries(formatted.properties)
-          .map(([key, value]) => `${key}: ${value}`)
-          .join(", "),
-      ],
+      chunks: Object.entries(formatted.properties).map(
+        ([key, value]) => `${key}: ${value}`
+      ),
       source: {
         provider: "hubspot",
       },

--- a/front/lib/actions/mcp_internal_actions/servers/hubspot/server.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/hubspot/server.ts
@@ -147,7 +147,7 @@ const createServer = (): McpServer => {
 
   server.tool(
     "count_objects_by_properties",
-    `Count objects in Hubspot with matching properties. Supports ${SIMPLE_OBJECTS.join(", ")}. Returns exact count by paginating through results if needed. For date filtering, use properties like 'createdate' or 'lastmodifieddate' with operators like GTE/LTE (timestamps in milliseconds or ISO format).`,
+    `Count objects in Hubspot with matching properties. Supports ${SIMPLE_OBJECTS.join(", ")}.`,
     {
       objectType: z.enum(SIMPLE_OBJECTS),
       filters: z
@@ -196,7 +196,7 @@ const createServer = (): McpServer => {
 
   server.tool(
     "get_latest_objects",
-    `Get latest objects from Hubspot with optional filtering. Supports ${SIMPLE_OBJECTS.join(", ")}. Returns objects sorted by creation date (newest first). Handles pagination automatically.`,
+    `Get latest objects from Hubspot with optional filtering. Supports ${SIMPLE_OBJECTS.join(", ")}. Returns objects sorted by creation date (newest first).`,
     {
       objectType: z.enum(SIMPLE_OBJECTS),
       limit: z

--- a/front/lib/actions/mcp_internal_actions/servers/hubspot/server.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/hubspot/server.ts
@@ -24,6 +24,7 @@ import {
   getObjectByEmail,
   getObjectProperties,
   getUserDetails,
+  MAX_COUNT_LIMIT,
   MAX_LIMIT,
   searchCrmObjects,
   SIMPLE_OBJECTS,
@@ -31,6 +32,14 @@ import {
   updateContact,
   updateDeal,
 } from "@app/lib/actions/mcp_internal_actions/servers/hubspot/hubspot_api_helper";
+import {
+  formatHubSpotCreateSuccess,
+  formatHubSpotGetSuccess,
+  formatHubSpotObjectsAsText,
+  formatHubSpotSearchResults,
+  formatHubSpotUpdateSuccess,
+  formatTransformedPropertiesAsText,
+} from "@app/lib/actions/mcp_internal_actions/servers/hubspot/hubspot_response_helpers";
 import { HUBSPOT_ID_TO_OBJECT_TYPE } from "@app/lib/actions/mcp_internal_actions/servers/hubspot/hubspot_utils";
 import {
   ERROR_MESSAGES,
@@ -76,9 +85,14 @@ const createServer = (): McpServer => {
             objectType,
             creatableOnly,
           });
-          return makeMCPToolJSONSuccess({
-            message: "Operation completed successfully",
+          const formattedText = formatTransformedPropertiesAsText(
             result,
+            objectType,
+            creatableOnly
+          );
+          return makeMCPToolTextSuccess({
+            message: "Properties retrieved successfully",
+            result: formattedText,
           });
         },
         authInfo,
@@ -111,10 +125,8 @@ const createServer = (): McpServer => {
             properties,
             associations,
           });
-          return makeMCPToolJSONSuccess({
-            message: "Contact created successfully.",
-            result,
-          });
+          const formatted = formatHubSpotCreateSuccess(result, "contacts");
+          return makeMCPToolJSONSuccess(formatted);
         },
         authInfo,
       });
@@ -135,10 +147,27 @@ const createServer = (): McpServer => {
           if (!object) {
             return makeMCPToolTextError(ERROR_MESSAGES.OBJECT_NOT_FOUND);
           }
-          return makeMCPToolJSONSuccess({
-            message: "Operation completed successfully",
-            result: object,
-          });
+          // Handle different object types properly
+          if ("email" in object) {
+            // This is a SimplePublicObject
+            const formatted = formatHubSpotGetSuccess(
+              object as any,
+              objectType
+            );
+            return makeMCPToolJSONSuccess(formatted);
+          } else {
+            // This is a PublicOwner - return simpler format
+            const owner = object as any;
+            return makeMCPToolJSONSuccess({
+              message: `${objectType.slice(0, -1)} retrieved successfully`,
+              result: {
+                id: owner.id,
+                email: owner.email,
+                firstName: owner.firstName,
+                lastName: owner.lastName,
+              },
+            });
+          }
         },
         authInfo,
       });
@@ -147,7 +176,7 @@ const createServer = (): McpServer => {
 
   server.tool(
     "count_objects_by_properties",
-    `Count objects in Hubspot with matching properties. Supports ${SIMPLE_OBJECTS.join(", ")}.`,
+    `Count objects in Hubspot with matching properties. Supports ${SIMPLE_OBJECTS.join(", ")}. Max limit is ${MAX_COUNT_LIMIT} objects.`,
     {
       objectType: z.enum(SIMPLE_OBJECTS),
       filters: z
@@ -184,8 +213,14 @@ const createServer = (): McpServer => {
           if (!count) {
             return makeMCPToolTextError(ERROR_MESSAGES.NO_OBJECTS_FOUND);
           }
+          if (count >= MAX_COUNT_LIMIT) {
+            return makeMCPToolTextSuccess({
+              message: `Found ${MAX_COUNT_LIMIT}+ ${objectType} matching the filters (exact count unavailable due to API limits)`,
+              result: `${MAX_COUNT_LIMIT}+`,
+            });
+          }
           return makeMCPToolTextSuccess({
-            message: "Operation completed successfully",
+            message: `Found ${count} ${objectType} matching the specified filters`,
             result: count.toString(),
           });
         },
@@ -196,52 +231,26 @@ const createServer = (): McpServer => {
 
   server.tool(
     "get_latest_objects",
-    `Get latest objects from Hubspot with optional filtering. Supports ${SIMPLE_OBJECTS.join(", ")}. Returns objects sorted by creation date (newest first).`,
+    `Get latest objects from Hubspot. Supports ${SIMPLE_OBJECTS.join(", ")}. Limit is ${MAX_LIMIT}.`,
     {
       objectType: z.enum(SIMPLE_OBJECTS),
-      limit: z
-        .number()
-        .optional()
-        .describe("Maximum number of objects to return"),
-      filters: z
-        .array(
-          z.object({
-            propertyName: z
-              .string()
-              .describe(
-                "The property to filter by (e.g., 'createdate', 'lastmodifieddate')"
-              ),
-            operator: z
-              .nativeEnum(FilterOperatorEnum)
-              .describe("The operator for comparison"),
-            value: z
-              .string()
-              .optional()
-              .describe("The value to compare against"),
-            values: z
-              .array(z.string())
-              .optional()
-              .describe("Values for IN/NOT_IN operators"),
-          })
-        )
-        .optional()
-        .describe("Optional filters to apply (e.g., date ranges)"),
+      limit: z.number().optional(),
     },
-    async ({ objectType, limit = MAX_LIMIT, filters }, { authInfo }) => {
+    async ({ objectType, limit = MAX_LIMIT }, { authInfo }) => {
       return withAuth({
         action: async (accessToken) => {
           const objects = await getLatestObjects(
             accessToken,
             objectType,
-            limit,
-            filters
+            limit
           );
           if (!objects.length) {
             return makeMCPToolTextError(ERROR_MESSAGES.NO_OBJECTS_FOUND);
           }
-          return makeMCPToolJSONSuccess({
-            message: "Operation completed successfully",
-            result: objects,
+          const formattedText = formatHubSpotObjectsAsText(objects, objectType);
+          return makeMCPToolTextSuccess({
+            message: "Latest objects retrieved successfully",
+            result: formattedText,
           });
         },
         authInfo,
@@ -274,10 +283,8 @@ const createServer = (): McpServer => {
             properties,
             associations,
           });
-          return makeMCPToolJSONSuccess({
-            message: "Company created successfully.",
-            result,
-          });
+          const formatted = formatHubSpotCreateSuccess(result, "companies");
+          return makeMCPToolJSONSuccess(formatted);
         },
         authInfo,
       });
@@ -562,10 +569,8 @@ const createServer = (): McpServer => {
           if (!result) {
             return makeMCPToolTextError(ERROR_MESSAGES.OBJECT_NOT_FOUND);
           }
-          return makeMCPToolJSONSuccess({
-            message: "Contact retrieved successfully.",
-            result,
-          });
+          const formatted = formatHubSpotGetSuccess(result, "contacts");
+          return makeMCPToolJSONSuccess(formatted);
         },
         authInfo,
       });
@@ -586,10 +591,8 @@ const createServer = (): McpServer => {
           if (!result) {
             return makeMCPToolTextError(ERROR_MESSAGES.OBJECT_NOT_FOUND);
           }
-          return makeMCPToolJSONSuccess({
-            message: "Company retrieved successfully.",
-            result,
-          });
+          const formatted = formatHubSpotGetSuccess(result, "companies");
+          return makeMCPToolJSONSuccess(formatted);
         },
         authInfo,
       });
@@ -738,9 +741,8 @@ const createServer = (): McpServer => {
             contactId,
             properties,
           });
-          return makeMCPToolJSONSuccess({
-            result,
-          });
+          const formatted = formatHubSpotUpdateSuccess(result, "contacts");
+          return makeMCPToolJSONSuccess(formatted);
         },
         authInfo,
       });
@@ -805,7 +807,7 @@ const createServer = (): McpServer => {
 
   server.tool(
     "search_crm_objects",
-    "Searches CRM objects with advanced filtering, free-text search, and automatic pagination. Returns all matching results up to the specified limit.",
+    "Searches CRM objects of a specific type based on filters, query, and properties.",
     {
       objectType: searchableObjectTypes,
       filters: z
@@ -824,72 +826,42 @@ const createServer = (): McpServer => {
         .array(z.string())
         .optional()
         .describe("Specific properties to return."),
-      limit: z
-        .number()
-        .optional()
-        .describe("Maximum total results to return (default: 200)"),
-      getAllResults: z
-        .boolean()
-        .optional()
-        .describe(
-          "If true, retrieves all matching results regardless of limit"
-        ),
+      limit: z.number().optional().default(MAX_LIMIT),
+      after: z.string().optional().describe("Pagination cursor."),
     },
     async (input, { authInfo }) => {
       return withAuth({
         action: async (accessToken) => {
-          const { limit = MAX_LIMIT, getAllResults = false } = input;
-          const allResults: any[] = [];
-          let after: string | undefined = undefined;
-          let hasMore = true;
-
-          while (hasMore && (getAllResults || allResults.length < limit)) {
-            const result = await searchCrmObjects({
-              accessToken,
-              objectType: input.objectType,
-              filters: input.filters,
-              query: input.query,
-              propertiesToReturn: input.propertiesToReturn,
-              limit: getAllResults
-                ? MAX_LIMIT
-                : Math.min(MAX_LIMIT, limit - allResults.length),
-              after,
-            });
-
-            if (!result) {
-              break;
-            }
-
-            allResults.push(...result.results);
-
-            if (result.paging?.next?.after) {
-              after = result.paging.next.after;
-            } else {
-              hasMore = false;
-            }
-
-            // Stop if we've reached the desired limit (unless getAllResults is true)
-            if (!getAllResults && allResults.length >= limit) {
-              hasMore = false;
-            }
-          }
-
-          if (!allResults.length) {
-            return makeMCPToolTextError("Search returned no results.");
-          }
-
-          // Trim results to exact limit if needed
-          const finalResults = getAllResults
-            ? allResults
-            : allResults.slice(0, limit);
-
-          return makeMCPToolJSONSuccess({
-            message: `Found ${finalResults.length} objects${getAllResults && finalResults.length > limit ? ` (showing all ${finalResults.length} results)` : ""}.`,
-            result: {
-              results: finalResults,
-              total: finalResults.length,
-            },
+          const result = await searchCrmObjects({
+            accessToken,
+            objectType: input.objectType,
+            filters: input.filters,
+            query: input.query,
+            propertiesToReturn: input.propertiesToReturn,
+            limit: input.limit,
+            after: input.after,
           });
+          if (!result || result.results.length === 0) {
+            return makeMCPToolTextError(
+              "Search failed or returned no results."
+            );
+          }
+
+          const searchResults = formatHubSpotSearchResults(
+            result.results,
+            input.objectType,
+            input.query || "search"
+          );
+
+          return {
+            isError: false,
+            content: [
+              ...searchResults.map((searchResult) => ({
+                type: "resource" as const,
+                resource: searchResult,
+              })),
+            ],
+          };
         },
         authInfo,
       });
@@ -897,15 +869,15 @@ const createServer = (): McpServer => {
   );
 
   server.tool(
-    "hubspot-get-link",
-    `🎯 Purpose:
+    "get_hubspot_link",
+    `Purpose:
       1. Generates HubSpot UI links for different pages based on object types and IDs.
       2. Supports both index pages (lists of objects) and record pages (specific object details).
 
-    📋 Prerequisites:
+    Prerequisites:
       1. Use the hubspot-get-portal-id tool to get the PortalId and UiDomain.
 
-    🧭 Usage Guidance:
+    Usage Guidance:
       1. Use to generate links to HubSpot UI pages when users need to reference specific HubSpot records.
       2. Validates that object type IDs exist in the HubSpot system.
   `,
@@ -954,16 +926,16 @@ const createServer = (): McpServer => {
   );
 
   server.tool(
-    "hubspot-get-portal-id",
-    "Gets the current user's portal ID. To use before calling hubspot-get-link",
+    "get_hubspot_portal_id",
+    "Gets the current user's portal ID. To use before calling get_hubspot_link",
     {},
     async (_, { authInfo }) => {
       return withAuth({
         action: async (accessToken) => {
           const result = await getUserDetails(accessToken);
-          return makeMCPToolJSONSuccess({
-            message: "Portal ID retrieved successfully.",
-            result: result.hub_id,
+          return makeMCPToolTextSuccess({
+            message: "Portal information retrieved successfully",
+            result: `Portal ID: ${result.hub_id}\nUI Domain: app.hubspot.com`,
           });
         },
         authInfo,

--- a/front/lib/actions/mcp_internal_actions/servers/hubspot/server.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/hubspot/server.ts
@@ -888,8 +888,7 @@ const createServer = (): McpServer => {
 
           const searchResults = formatHubSpotSearchResults(
             result.results,
-            input.objectType,
-            input.query || "search"
+            input.objectType
           );
 
           return {


### PR DESCRIPTION

# Description
 
This PR increases the Hubspot API results limit from 50 to 200 (the maximum allowed by HubSpot) and adds pagination to handle counts above the 10k limit. The changes improve the reliability of operations like counting and searching objects by using pagination to get accurate results.
Additionally, the PR adds new HubSpot functionality including user activity tracking, association management between objects, and enhanced search capabilities with owner filtering.

# Risk

The changes modify how we interact with HubSpot's API limits but should be safe since we stay within their documented thresholds.

# Deploy Plan

Deploy requires no special steps - can be merged and deployed normally.

<img width="912" alt="Screenshot 2025-07-04 at 18 19 36" src="https://github.com/user-attachments/assets/51c8084b-0eeb-43bb-8a3f-d9245e5309aa" />
