### PR TITLE
Fix: we should not delete the whole table when we fail a non truncating table upsert

### DIFF
--- a/front/lib/api/tables.ts
+++ b/front/lib/api/tables.ts
@@ -221,26 +221,30 @@ export async function upsertTableFromCsv({
         "Error upserting CSV in CoreAPI."
       );
 
-      const delRes = await coreAPI.deleteTable({
-        projectId: dataSource.dustAPIProjectId,
-        dataSourceId: dataSource.dustAPIDataSourceId,
-        tableId,
-      });
+      // Only delete the table if we are truncating.
+      // Otherwise, we will delete the whole previous data while we just failed an upsert.
+      if (truncate) {
+        const delRes = await coreAPI.deleteTable({
+          projectId: dataSource.dustAPIProjectId,
+          dataSourceId: dataSource.dustAPIDataSourceId,
+          tableId,
+        });
 
-      if (delRes.isErr()) {
-        logger.error(
-          {
-            type: "internal_server_error",
-            coreAPIError: delRes.error,
-            projectId: dataSource.dustAPIProjectId,
-            dataSourceId: dataSource.dustAPIDataSourceId,
-            dataSourceName: dataSource.name,
-            workspaceId: owner.sId,
-            tableId,
-            tableName,
-          },
-          "Failed to delete table after failed CSV upsert."
-        );
+        if (delRes.isErr()) {
+          logger.error(
+            {
+              type: "internal_server_error",
+              coreAPIError: delRes.error,
+              projectId: dataSource.dustAPIProjectId,
+              dataSourceId: dataSource.dustAPIDataSourceId,
+              dataSourceName: dataSource.name,
+              workspaceId: owner.sId,
+              tableId,
+              tableName,
+            },
+            "Failed to delete table after failed CSV upsert."
+          );
+        }
       }
       return new Err(errorDetails);
     }


### PR DESCRIPTION
## Description

I noticed due to an error with notion table (we sometime truncate, sometime not) and it was raising an issue.

## Tests

Hard to repro locally.

## Risk

Medium because worst case we do not delete something we used to delete.

## Deploy Plan

Deploy front