### PR TITLE
[front] fix(tests): run `MembershipFactory.associate` in a transaction

### DIFF
--- a/front/lib/actions/mcp_internal_actions/servers/utils.test.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/utils.test.ts
@@ -29,7 +29,8 @@ describe("MCP Internal Actions Server Utils", () => {
         await GroupFactory.defaults(workspace);
         const { agentOwnerAuth: auth } = await setupAgentOwner(
           workspace,
-          "admin"
+          "admin",
+          t
         );
 
         const otherSpace = await SpaceFactory.global(otherWorkspace, t);
@@ -121,7 +122,8 @@ describe("MCP Internal Actions Server Utils", () => {
         await GroupFactory.defaults(workspace);
         const { agentOwnerAuth: auth } = await setupAgentOwner(
           workspace,
-          "admin"
+          "admin",
+          t
         );
 
         await SpaceFactory.system(workspace, t);

--- a/front/lib/resources/data_source_view_resource.test.ts
+++ b/front/lib/resources/data_source_view_resource.test.ts
@@ -35,7 +35,12 @@ describe("DataSourceViewResource", () => {
         // Create a user for workspace1
         const { globalGroup } = await GroupFactory.defaults(workspace1);
         const user1 = await UserFactory.superUser();
-        await MembershipFactory.associate(workspace1, user1, "user");
+        await MembershipFactory.associate(
+          workspace1,
+          user1,
+          { role: "user" },
+          t
+        );
         await GroupSpaceFactory.associate(space1, globalGroup);
 
         const auth = await Authenticator.fromUserIdAndWorkspaceId(

--- a/front/lib/resources/mcp_server_connection_resource.test.ts
+++ b/front/lib/resources/mcp_server_connection_resource.test.ts
@@ -70,7 +70,12 @@ describe("MCPServerConnectionResource", () => {
 
         // Create a regular user in the same workspace
         const regularUser = await UserFactory.basic();
-        await MembershipFactory.associate(workspace, regularUser, "user");
+        await MembershipFactory.associate(
+          workspace,
+          regularUser,
+          { role: "user" },
+          t
+        );
         const regularUserAuthenticator =
           await Authenticator.fromUserIdAndWorkspaceId(
             regularUser.sId,
@@ -112,7 +117,12 @@ describe("MCPServerConnectionResource", () => {
 
         // Create second user in the same workspace
         const user2 = await UserFactory.basic();
-        await MembershipFactory.associate(workspace, user2, "user");
+        await MembershipFactory.associate(
+          workspace,
+          user2,
+          { role: "user" },
+          t
+        );
         const authenticator2 = await Authenticator.fromUserIdAndWorkspaceId(
           user2.sId,
           workspace.sId

--- a/front/lib/resources/mcp_server_view_resource.test.ts
+++ b/front/lib/resources/mcp_server_view_resource.test.ts
@@ -102,7 +102,7 @@ describe("MCPServerViewResource", () => {
         const { globalGroup, systemGroup } =
           await GroupFactory.defaults(workspace1);
         const user1 = await UserFactory.superUser();
-        await MembershipFactory.associate(workspace1, user1, "user");
+        await MembershipFactory.associate(workspace1, user1, { role: "user" }, t);
         await GroupSpaceFactory.associate(systemSpace1, systemGroup);
         await GroupSpaceFactory.associate(space1, globalGroup);
 

--- a/front/lib/resources/mcp_server_view_resource.test.ts
+++ b/front/lib/resources/mcp_server_view_resource.test.ts
@@ -102,7 +102,12 @@ describe("MCPServerViewResource", () => {
         const { globalGroup, systemGroup } =
           await GroupFactory.defaults(workspace1);
         const user1 = await UserFactory.superUser();
-        await MembershipFactory.associate(workspace1, user1, { role: "user" }, t);
+        await MembershipFactory.associate(
+          workspace1,
+          user1,
+          { role: "user" },
+          t
+        );
         await GroupSpaceFactory.associate(systemSpace1, systemGroup);
         await GroupSpaceFactory.associate(space1, globalGroup);
 

--- a/front/pages/api/w/[wId]/assistant/agent_configurations/[aId]/editors.test.ts
+++ b/front/pages/api/w/[wId]/assistant/agent_configurations/[aId]/editors.test.ts
@@ -56,7 +56,14 @@ async function setupTest(
     agentOwnerAuth = requestUserAuth;
   } else {
     agentOwner = await UserFactory.basic();
-    await MembershipFactory.associate(workspace, agentOwner, agentOwnerRole);
+    await MembershipFactory.associate(
+      workspace,
+      agentOwner,
+      {
+        role: agentOwnerRole,
+      },
+      t
+    );
     agentOwnerAuth = await Authenticator.fromUserIdAndWorkspaceId(
       agentOwner.sId,
       workspace.sId
@@ -157,7 +164,9 @@ describe("PATCH /api/w/[wId]/assistant/agent_configurations/[aId]/editors", () =
     });
 
     const newEditor = await UserFactory.basic();
-    await MembershipFactory.associate(workspace, newEditor, "builder");
+    await MembershipFactory.associate(workspace, newEditor, {
+      role: "builder",
+    });
 
     req.body = { addEditorIds: [newEditor.sId] };
 
@@ -178,7 +187,9 @@ describe("PATCH /api/w/[wId]/assistant/agent_configurations/[aId]/editors", () =
 
     // Add another editor first
     const editorToRemove = await UserFactory.basic();
-    await MembershipFactory.associate(workspace, editorToRemove, "builder");
+    await MembershipFactory.associate(workspace, editorToRemove, {
+      role: "builder",
+    });
     const agentOwnerAuth = await Authenticator.fromUserIdAndWorkspaceId(
       agentOwner.sId,
       workspace.sId
@@ -210,7 +221,7 @@ describe("PATCH /api/w/[wId]/assistant/agent_configurations/[aId]/editors", () =
     });
 
     const newEditor = await UserFactory.basic();
-    await MembershipFactory.associate(workspace, newEditor, "user");
+    await MembershipFactory.associate(workspace, newEditor, { role: "user" });
 
     req.body = { addEditorIds: [newEditor.sId] };
 
@@ -233,7 +244,9 @@ describe("PATCH /api/w/[wId]/assistant/agent_configurations/[aId]/editors", () =
 
     // Add another editor first
     const editorToRemove = await UserFactory.basic();
-    await MembershipFactory.associate(workspace, editorToRemove, "admin");
+    await MembershipFactory.associate(workspace, editorToRemove, {
+      role: "admin",
+    });
     const agentOwnerAuth = await Authenticator.fromUserIdAndWorkspaceId(
       requestUser.sId,
       workspace.sId
@@ -305,7 +318,7 @@ describe("PATCH /api/w/[wId]/assistant/agent_configurations/[aId]/editors", () =
     });
 
     const nonEditor = await UserFactory.basic();
-    await MembershipFactory.associate(workspace, nonEditor, "user");
+    await MembershipFactory.associate(workspace, nonEditor, { role: "user" });
 
     req.body = { removeEditorIds: [nonEditor.sId] };
 
@@ -418,7 +431,9 @@ describe("PATCH /api/w/[wId]/assistant/agent_configurations/[aId]/editors", () =
     });
 
     const editorToAdd = await UserFactory.basic();
-    await MembershipFactory.associate(workspace, editorToAdd, "builder");
+    await MembershipFactory.associate(workspace, editorToAdd, {
+      role: "builder",
+    });
 
     // Remove owner, add new editor
     req.body = {

--- a/front/pages/api/w/[wId]/assistant/agent_configurations/index.test.ts
+++ b/front/pages/api/w/[wId]/assistant/agent_configurations/index.test.ts
@@ -41,10 +41,16 @@ vi.mock("@app/lib/api/redis", () => ({
 
 export async function setupAgentOwner(
   workspace: LightWorkspaceType,
-  agentOwnerRole: "admin" | "builder" | "user"
+  agentOwnerRole: "admin" | "builder" | "user",
+  t: Transaction
 ) {
   const agentOwner = await UserFactory.basic();
-  await MembershipFactory.associate(workspace, agentOwner, agentOwnerRole);
+  await MembershipFactory.associate(
+    workspace,
+    agentOwner,
+    { role: agentOwnerRole },
+    t
+  );
   const agentOwnerAuth = await Authenticator.fromUserIdAndWorkspaceId(
     agentOwner.sId,
     workspace.sId
@@ -107,7 +113,7 @@ describe("GET /api/w/[wId]/assistant/agent_configurations", () => {
       const { req, res, workspace } = await createPrivateApiMockRequest({
         method: "GET",
       });
-      const { agentOwner } = await setupAgentOwner(workspace, "admin");
+      const { agentOwner } = await setupAgentOwner(workspace, "admin", t);
       await setupTestAgents(workspace, agentOwner, t);
       req.query.view = "list";
       await handler(req, res);

--- a/front/pages/api/w/[wId]/mcp/connections/[connectionType]/[cId]/index.test.ts
+++ b/front/pages/api/w/[wId]/mcp/connections/[connectionType]/[cId]/index.test.ts
@@ -133,7 +133,7 @@ describe("MCP Connection API Handler", () => {
 
       // Create an extra one for the same server, but for a different user
       const user2 = await UserFactory.basic();
-      await MembershipFactory.associate(workspace, user2, "user");
+      await MembershipFactory.associate(workspace, user2, { role: "user" }, t);
       const authenticator2 = await Authenticator.fromUserIdAndWorkspaceId(
         user2.sId,
         workspace.sId
@@ -248,7 +248,7 @@ describe("MCP Connection API Handler", () => {
       const remoteServer = await RemoteMCPServerFactory.create(workspace);
 
       const admin = await UserFactory.basic();
-      await MembershipFactory.associate(workspace, admin, "admin");
+      await MembershipFactory.associate(workspace, admin, { role: "admin" }, t);
       const adminAuthenticator = await Authenticator.fromUserIdAndWorkspaceId(
         admin.sId,
         workspace.sId
@@ -291,7 +291,7 @@ describe("MCP Connection API Handler", () => {
 
       // Create second user and try to delete first user's connection
       const user2 = await UserFactory.basic();
-      await MembershipFactory.associate(workspace, user2, "user");
+      await MembershipFactory.associate(workspace, user2, { role: "user" }, t);
 
       const { req, res } = await createPrivateApiMockRequest({
         method: "DELETE",

--- a/front/pages/api/w/[wId]/members/[uId]/index.test.ts
+++ b/front/pages/api/w/[wId]/members/[uId]/index.test.ts
@@ -86,7 +86,7 @@ describe("POST /api/w/[wId]/members/[uId]", () => {
 
         // Create another admin so current user is not sole admin
         const anotherAdmin = await UserFactory.basic();
-        await MembershipFactory.associate(workspace, anotherAdmin, "admin");
+        await MembershipFactory.associate(workspace, anotherAdmin, { role: "admin" });
 
         req.query.uId = user.sId;
         req.body = { role: "user" };
@@ -110,7 +110,7 @@ describe("POST /api/w/[wId]/members/[uId]", () => {
 
         // Create a user with user role
         const targetUser = await UserFactory.basic();
-        await MembershipFactory.associate(workspace, targetUser, "user");
+        await MembershipFactory.associate(workspace, targetUser, { role: "user" });
 
         req.query.uId = targetUser.sId;
         req.body = { role: "builder" };

--- a/front/pages/api/w/[wId]/members/[uId]/index.test.ts
+++ b/front/pages/api/w/[wId]/members/[uId]/index.test.ts
@@ -86,7 +86,9 @@ describe("POST /api/w/[wId]/members/[uId]", () => {
 
         // Create another admin so current user is not sole admin
         const anotherAdmin = await UserFactory.basic();
-        await MembershipFactory.associate(workspace, anotherAdmin, { role: "admin" });
+        await MembershipFactory.associate(workspace, anotherAdmin, {
+          role: "admin",
+        });
 
         req.query.uId = user.sId;
         req.body = { role: "user" };
@@ -110,7 +112,9 @@ describe("POST /api/w/[wId]/members/[uId]", () => {
 
         // Create a user with user role
         const targetUser = await UserFactory.basic();
-        await MembershipFactory.associate(workspace, targetUser, { role: "user" });
+        await MembershipFactory.associate(workspace, targetUser, {
+          role: "user",
+        });
 
         req.query.uId = targetUser.sId;
         req.body = { role: "builder" };

--- a/front/pages/api/w/[wId]/members/index.test.ts
+++ b/front/pages/api/w/[wId]/members/index.test.ts
@@ -25,7 +25,9 @@ describe("GET /api/w/[wId]/members", () => {
     ]);
 
     await Promise.all(
-      users.map((user) => MembershipFactory.associate(workspace, user, { role: "user" }))
+      users.map((user) =>
+        MembershipFactory.associate(workspace, user, { role: "user" })
+      )
     );
 
     await handler(req, res);
@@ -143,7 +145,9 @@ describe("GET /api/w/[wId]/members", () => {
     );
 
     await Promise.all(
-      users.map((user) => MembershipFactory.associate(workspace, user, { role: "user" }))
+      users.map((user) =>
+        MembershipFactory.associate(workspace, user, { role: "user" })
+      )
     );
 
     await handler(req, res);

--- a/front/pages/api/w/[wId]/members/index.test.ts
+++ b/front/pages/api/w/[wId]/members/index.test.ts
@@ -25,7 +25,7 @@ describe("GET /api/w/[wId]/members", () => {
     ]);
 
     await Promise.all(
-      users.map((user) => MembershipFactory.associate(workspace, user, "user"))
+      users.map((user) => MembershipFactory.associate(workspace, user, { role: "user" }))
     );
 
     await handler(req, res);
@@ -89,9 +89,9 @@ describe("GET /api/w/[wId]/members", () => {
       ]);
 
       await Promise.all([
-        MembershipFactory.associate(workspace, users[0], "admin"),
-        MembershipFactory.associate(workspace, users[1], "admin"),
-        MembershipFactory.associate(workspace, users[2], "user"),
+        MembershipFactory.associate(workspace, users[0], { role: "admin" }),
+        MembershipFactory.associate(workspace, users[1], { role: "admin" }),
+        MembershipFactory.associate(workspace, users[2], { role: "user" }),
       ]);
 
       // Add admin role query parameter
@@ -143,7 +143,7 @@ describe("GET /api/w/[wId]/members", () => {
     );
 
     await Promise.all(
-      users.map((user) => MembershipFactory.associate(workspace, user, "user"))
+      users.map((user) => MembershipFactory.associate(workspace, user, { role: "user" }))
     );
 
     await handler(req, res);
@@ -172,7 +172,7 @@ describe("GET /api/w/[wId]/members", () => {
 
       await Promise.all(
         users.map((user) =>
-          MembershipFactory.associate(workspace, user, "user")
+          MembershipFactory.associate(workspace, user, { role: "user" })
         )
       );
 
@@ -204,7 +204,7 @@ describe("GET /api/w/[wId]/members", () => {
 
       vi.useFakeTimers();
       vi.setSystemTime(createdAt);
-      await MembershipFactory.associate(workspace, user, "user");
+      await MembershipFactory.associate(workspace, user, { role: "user" });
       vi.useRealTimers();
 
       users.push(user);
@@ -246,7 +246,7 @@ describe("GET /api/w/[wId]/members", () => {
       const user = await UserFactory.withCreatedAt(createdAt);
       vi.useFakeTimers();
       vi.setSystemTime(createdAt);
-      await MembershipFactory.associate(workspace, user, "user");
+      await MembershipFactory.associate(workspace, user, { role: "user" });
       vi.useRealTimers();
 
       users.push(user);

--- a/front/pages/api/w/[wId]/members/search.test.ts
+++ b/front/pages/api/w/[wId]/members/search.test.ts
@@ -60,7 +60,9 @@ describe("GET /api/w/[wId]/members/search", () => {
     ]);
 
     await Promise.all(
-      users.map((user) => MembershipFactory.associate(workspace, user, "user"))
+      users.map((user) =>
+        MembershipFactory.associate(workspace, user, { role: "user" })
+      )
     );
 
     req.query.searchTerm = users[0].email;
@@ -87,7 +89,9 @@ describe("GET /api/w/[wId]/members/search", () => {
     ]);
 
     await Promise.all(
-      users.map((user) => MembershipFactory.associate(workspace, user, "user"))
+      users.map((user) =>
+        MembershipFactory.associate(workspace, user, { role: "user" })
+      )
     );
 
     req.query.searchEmails = users[0].email + "," + users[1].email;
@@ -141,7 +145,9 @@ describe("GET /api/w/[wId]/members/search", () => {
     );
 
     await Promise.all(
-      users.map((user) => MembershipFactory.associate(workspace, user, "user"))
+      users.map((user) =>
+        MembershipFactory.associate(workspace, user, { role: "user" })
+      )
     );
 
     req.query.limit = "20";

--- a/front/tests/utils/MembershipFactory.ts
+++ b/front/tests/utils/MembershipFactory.ts
@@ -1,3 +1,5 @@
+import type { Transaction } from "sequelize";
+
 import { MembershipResource } from "@app/lib/resources/membership_resource";
 import type { UserResource } from "@app/lib/resources/user_resource";
 import type {
@@ -10,14 +12,21 @@ export class MembershipFactory {
   static async associate(
     workspace: WorkspaceType,
     user: UserResource,
-    role: MembershipRoleType,
-    origin: MembershipOriginType = "invited"
+    {
+      role,
+      origin = "invited",
+    }: {
+      role: MembershipRoleType;
+      origin?: MembershipOriginType;
+    },
+    t?: Transaction
   ) {
     return MembershipResource.createMembership({
       workspace,
       user,
       role,
       origin,
+      transaction: t,
     });
   }
 }

--- a/front/tests/utils/generic_private_api_tests.ts
+++ b/front/tests/utils/generic_private_api_tests.ts
@@ -52,7 +52,9 @@ export const createPrivateApiMockRequest = async ({
     : UserFactory.basic());
   const { globalGroup, systemGroup } = await GroupFactory.defaults(workspace);
 
-  const membership = await MembershipFactory.associate(workspace, user, role);
+  const membership = await MembershipFactory.associate(workspace, user, {
+    role,
+  });
 
   // Mock the getSession function to return the user without going through the auth0 session
   vi.mocked(getSession).mockReturnValue(


### PR DESCRIPTION
## Description

- Follow up on https://github.com/dust-tt/dust/pull/14114 and on this [thread](https://dust4ai.slack.com/archives/C050SM8NSPK/p1751697906372359).
- We have observed some level of flakiness in the tests lately (random validation errors popping up on plan creation).
- This PR runs the `MembershipFactory.associate` in a transaction.

## Tests

## Risk

## Deploy Plan

- No deploy.
