### PR TITLE
[front] fix(tests): remove unnecessary plan upserts

### DIFF
--- a/front/pages/api/w/[wId]/subscriptions/index.test.ts
+++ b/front/pages/api/w/[wId]/subscriptions/index.test.ts
@@ -1,7 +1,6 @@
 import type { Stripe } from "stripe";
 import { beforeEach, describe, expect, vi } from "vitest";
 
-import { upsertProPlans } from "@app/lib/plans/pro_plans";
 import { createPrivateApiMockRequest } from "@app/tests/utils/generic_private_api_tests";
 import { itInTransaction } from "@app/tests/utils/utils";
 

--- a/front/pages/api/w/[wId]/subscriptions/index.test.ts
+++ b/front/pages/api/w/[wId]/subscriptions/index.test.ts
@@ -56,9 +56,6 @@ describe("POST /api/w/[wId]/subscriptions", () => {
         billingPeriod: "monthly",
       };
 
-      // Seed plans in the database
-      await upsertProPlans();
-
       await handler(req, res);
 
       expect(res._getStatusCode()).toBe(200);
@@ -88,9 +85,6 @@ describe("POST /api/w/[wId]/subscriptions", () => {
     req.body = {
       billingPeriod: "yearly",
     };
-
-    // Seed plans in the database
-    await upsertProPlans();
 
     await handler(req, res);
 


### PR DESCRIPTION
## Description

- This PR removes two unnecessary plan upserts in the tests on the `/subscriptions` endpoint.
- Tests fail at times on this upsert, example https://github.com/dust-tt/dust/pull/14115/checks?check_run_id=45399003166.
- The pro plans are upserted in db in `WorkspaceFactory.basic`, which is called in `createPrivateApiMockRequest`.

## Tests

- Yes

## Risk

- N/A.

## Deploy Plan

- No deploy.
