### PR TITLE
[Webcrawler] Increase Firecrawl worker concurrent activities to 16

### DIFF
--- a/connectors/src/connectors/webcrawler/temporal/worker.ts
+++ b/connectors/src/connectors/webcrawler/temporal/worker.ts
@@ -53,7 +53,7 @@ export async function runWebCrawlerWorker() {
       connection,
       reuseV8Context: true,
       namespace,
-      maxConcurrentActivityTaskExecutions: 3,
+      maxConcurrentActivityTaskExecutions: 16,
       maxCachedWorkflows: TEMPORAL_MAXED_CACHED_WORKFLOWS,
       interceptors: {
         activityInbound: [


### PR DESCRIPTION
## Description
Context: [slack thread](https://dust4ai.slack.com/archives/C050SM8NSPK/p1751737851786209)

Increases the maximum concurrent activity task executions for the Firecrawl temporal worker from 3 to 16 to address workflow failures where activities start 6 days after being scheduled.

## Risks
Blast radius: Webcrawler Firecrawl temporal worker performance
Risk: low

## Tests
Manual testing of the webcrawler after deployment

## Deploy Plan
- Deploy connectors service