### PR TITLE
[Process Actions] Fix migration 298 to drop FK constraint

### DIFF
--- a/front/migrations/db/migration_298.sql
+++ b/front/migrations/db/migration_298.sql
@@ -1,8 +1,11 @@
 -- Migration created on Jul 01, 2025
--- Remove processConfigurationId column from agent_data_source_configurations
+-- Remove processConfigurationId column from agent_data_source_configurations and prepare for dropping process tables
 
 -- Drop the foreign key constraint from agent_data_source_configurations
 ALTER TABLE agent_data_source_configurations DROP CONSTRAINT IF EXISTS agent_data_source_configurations_processConfigurationId_fkey;
 
 -- Drop the processConfigurationId column from agent_data_source_configurations
 ALTER TABLE agent_data_source_configurations DROP COLUMN IF EXISTS "processConfigurationId";
+
+-- Drop the foreign key constraint from agent_process_configurations to agent_configurations
+ALTER TABLE agent_process_configurations DROP CONSTRAINT IF EXISTS agent_process_configurations_agentConfigurationId_fkey;


### PR DESCRIPTION
## Description
Fixes migration 298 to properly drop the foreign key constraint from `agent_process_configurations` to `agent_configurations` before the table is dropped in migration 299.

Context: PR #13960 removed legacy process action code, but migration 298 was missing the removal of the FK constraint `agent_process_configurations_agentConfigurationId_fkey`.

## Risks
Blast radius: Database migration for process configurations
Risk: low (additive change to existing migration)

## Deploy Plan
1. Run migration 298 to drop constraints and columns