### PR TITLE
Graceful shutdown of Connectors workers

### DIFF
--- a/connectors/admin/dev_worker.sh
+++ b/connectors/admin/dev_worker.sh
@@ -1,3 +1,3 @@
 #!/bin/sh
 
-NODE_ENV=development npx tsx --trace-warnings ./src/start_worker.ts
+NODE_ENV=development npx tsx --trace-warnings ./src/start_worker.ts "$@"

--- a/connectors/src/lib/redis.ts
+++ b/connectors/src/lib/redis.ts
@@ -44,3 +44,9 @@ export async function redisClient({
 
   return client;
 }
+
+export async function closeRedisClient() {
+  if (client) {
+    await client.quit();
+  }
+}

--- a/connectors/src/start_worker.ts
+++ b/connectors/src/start_worker.ts
@@ -68,7 +68,11 @@ async function runWorkers(workers: WorkerType[]) {
   }
 
   // Shutdown Temporal native runtime *once*
-  await Runtime.instance().shutdown();
+  // Fix the issue of connectors hanging after receiving SIGINT in dev
+  // We don't have this issue with front workers, and deserve an investigation (no appetite for now)
+  if (process.env.NODE_ENV === "development") {
+    await Runtime.instance().shutdown();
+  }
 
   // Shutdown potential Redis client
   await closeRedisClient();

--- a/connectors/src/start_worker.ts
+++ b/connectors/src/start_worker.ts
@@ -11,7 +11,7 @@ import { runSalesforceWorker } from "@connectors/connectors/salesforce/temporal/
 import { runSnowflakeWorker } from "@connectors/connectors/snowflake/temporal/worker";
 import { runWebCrawlerWorker } from "@connectors/connectors/webcrawler/temporal/worker";
 import { closeRedisClient } from "@connectors/lib/redis";
-import { setupGlobalErrorHandler } from "@connectors/types";
+import { isDevelopment, setupGlobalErrorHandler } from "@connectors/types";
 
 import { runGithubWorker } from "./connectors/github/temporal/worker";
 import { runGoogleWorkers } from "./connectors/google_drive/temporal/worker";
@@ -70,7 +70,7 @@ async function runWorkers(workers: WorkerType[]) {
   // Shutdown Temporal native runtime *once*
   // Fix the issue of connectors hanging after receiving SIGINT in dev
   // We don't have this issue with front workers, and deserve an investigation (no appetite for now)
-  if (process.env.NODE_ENV === "development") {
+  if (isDevelopment()) {
     await Runtime.instance().shutdown();
   }
 


### PR DESCRIPTION
## Description

### Motivation:

Upon termination of workers locally, the terminal often hangs, leaving no other choice than killing the process.

### Changes

Once all workers have stopped:
 - Shutdown Temporal runtime
 - Close Redis connection

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

## Tests

Tested locally.

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

Low: nothing is impacted except after worker termination

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
