### PR TITLE
Remove enforce_datasource_quota FF

### DIFF
--- a/front/pages/api/v1/w/[wId]/spaces/[spaceId]/data_sources/[dsId]/documents/[documentId]/index.ts
+++ b/front/pages/api/v1/w/[wId]/spaces/[spaceId]/data_sources/[dsId]/documents/[documentId]/index.ts
@@ -12,7 +12,6 @@ import apiConfig from "@app/lib/api/config";
 import { UNTITLED_TITLE } from "@app/lib/api/content_nodes";
 import { computeWorkspaceOverallSizeCached } from "@app/lib/api/data_sources";
 import type { Authenticator } from "@app/lib/auth";
-import { getFeatureFlags } from "@app/lib/auth";
 import { MAX_NODE_TITLE_LENGTH } from "@app/lib/content_nodes";
 import { runDocumentUpsertHooks } from "@app/lib/document_upsert_hooks/hooks";
 import { countActiveSeatsInWorkspaceCached } from "@app/lib/plans/usage/seats";
@@ -524,16 +523,13 @@ async function handler(
             },
             "Datasource quota exceeded for upsert document (overrun expected)"
           );
-          const flags = await getFeatureFlags(owner);
-          if (flags.includes("enforce_datasource_quota")) {
-            return apiError(req, res, {
-              status_code: 403,
-              api_error: {
-                type: "workspace_quota_error",
-                message: `You've exceeded your plan limit (${fileSizeToHumanReadable(quotaUsed)} used / ${fileSizeToHumanReadable(activeSeats * DATASOURCE_QUOTA_PER_SEAT)} allowed)`,
-              },
-            });
-          }
+          return apiError(req, res, {
+            status_code: 403,
+            api_error: {
+              type: "workspace_quota_error",
+              message: `You've exceeded your plan limit (${fileSizeToHumanReadable(quotaUsed)} used / ${fileSizeToHumanReadable(activeSeats * DATASOURCE_QUOTA_PER_SEAT)} allowed)`,
+            },
+          });
         }
       } catch (error) {
         logger.error(

--- a/front/types/shared/feature_flags.ts
+++ b/front/types/shared/feature_flags.ts
@@ -32,10 +32,6 @@ export const WHITELISTABLE_FEATURES_CONFIG = {
   disallow_agent_creation_to_users: {
     description: "Restrict agent creation to admins only",
   },
-  enforce_datasource_quota: {
-    description:
-      "Enforce datasource quota limits per seat (cf. pricing plan) for synced content",
-  },
   exploded_tables_query: {
     description: "Enhanced table querying with exploded views",
   },

--- a/sdks/js/src/types.ts
+++ b/sdks/js/src/types.ts
@@ -743,7 +743,6 @@ const WhitelistableFeaturesSchema = FlexibleEnumSchema<
   | "dev_mcp_actions"
   | "disable_run_logs"
   | "disallow_agent_creation_to_users"
-  | "enforce_datasource_quota"
   | "exploded_tables_query"
   | "extended_max_steps_per_run"
   | "google_ai_studio_experimental_models_feature"


### PR DESCRIPTION
## Description

Log shows we have only 2 workspaces impacted (see [logs](https://app.datadoghq.eu/logs?query=Datasource%20quota%20exceeded%20for%20upsert%20document&agg_m=count&agg_m_source=base&agg_q=%40workspace&agg_q_source=base&agg_t=count&analyticsOptions=%5B%22bars%22%2C%22dog_classic%22%2Cnull%2Cnull%5D&refresh_mode=sliding&saved-view-id=175873&storage=hot&top_n=100&top_o=top&viz=query_table&x_missing=true&from_ts=1751271947696&to_ts=1751876747696&live=true)) so we can safely remove the feature flag to actually enforce the quota

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
