### PR TITLE
[connectors] fix(GitHub): rectify whitelisting of `.authors` file

### DIFF
--- a/connectors/src/connectors/github/lib/code/supported_files.ts
+++ b/connectors/src/connectors/github/lib/code/supported_files.ts
@@ -100,9 +100,6 @@ const EXTENSION_WHITELIST = [
   ".liquid",
   ".mustache",
   ".handlebars",
-
-  // Miscellaneous
-  ".authors",
 ];
 
 const SUFFIX_BLACKLIST = [".min.js", ".min.css"];
@@ -112,6 +109,7 @@ const FILENAME_WHITELIST = [
   "Dockerfile",
   "package.json",
   "Cargo.toml",
+  ".authors",
 ];
 
 const DIRECTORY_BLACKLIST = [


### PR DESCRIPTION
## Description

- Follow up on https://github.com/dust-tt/dust/pull/14081.

## Tests

## Risk

## Deploy Plan

- Deploy connectors.
