### PR TITLE
[front] enh(title_generation): use a large model instead of a small one

### DIFF
--- a/front/lib/api/assistant/conversation.ts
+++ b/front/lib/api/assistant/conversation.ts
@@ -85,7 +85,7 @@ import {
   assertNever,
   ConversationError,
   Err,
-  getSmallWhitelistedModel,
+  getLargeWhitelistedModel,
   isAgentMention,
   isAgentMessageType,
   isContentFragmentInputWithContentNode,
@@ -355,7 +355,7 @@ export async function generateConversationTitle(
 ): Promise<Result<string, Error>> {
   const owner = auth.getNonNullableWorkspace();
 
-  const model = getSmallWhitelistedModel(owner);
+  const model = getLargeWhitelistedModel(owner);
   if (!model) {
     return new Err(
       new Error(`Failed to find a whitelisted model to generate title`)


### PR DESCRIPTION
## Description

- This PR switches the model used in the `assistant-v2-title-generator` app.
- It switches a small model (almost always GPT 4.1 mini) for a large one (always GPT 4.1).
- The latency is not a real issue here.

## Tests

- Tested locally.

## Risk

- Low.

## Deploy Plan

- Deploy front.
