### PR TITLE
Fix Dust app file output

### DIFF
--- a/front/components/actions/dust_app_run/utils.ts
+++ b/front/components/actions/dust_app_run/utils.ts
@@ -1,4 +1,5 @@
 import type { SupportedFileContentType } from "@app/types";
+import { extensionsForContentType } from "@app/types/files";
 
 export function getDustAppRunResultsFileTitle({
   appName,
@@ -7,10 +8,10 @@ export function getDustAppRunResultsFileTitle({
   appName: string;
   resultsFileContentType: SupportedFileContentType;
 }): string {
-  const extension = resultsFileContentType.split("/").pop();
+  const extensions = extensionsForContentType(resultsFileContentType);
   let title = `${appName}_output`;
-  if (extension) {
-    title += `.${extension}`;
+  if (extensions.length > 0) {
+    title += extensions[0];
   }
   return title;
 }

--- a/front/lib/actions/mcp_internal_actions/servers/run_dust_app.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/run_dust_app.ts
@@ -214,10 +214,10 @@ async function processDustFileOutput(
     let fileTitle = "";
     let file: FileResource | null = null;
 
-    const jsonOutput = safeParseJSON(
+    const jsonOutputRes = safeParseJSON(
       sanitizedOutput.__dust_file?.content ?? ""
     );
-    if (jsonOutput.isOk()) {
+    if (jsonOutputRes.isOk()) {
       // If the output is a valid json object, generate a json file.
       fileTitle = getDustAppRunResultsFileTitle({
         appName,
@@ -226,7 +226,7 @@ async function processDustFileOutput(
       const { jsonFile } = await generateJSONFileAndSnippet(auth, {
         title: fileTitle,
         conversationId: conversation.sId,
-        data: jsonOutput.value,
+        data: jsonOutputRes.value,
       });
       file = jsonFile;
     } else {


### PR DESCRIPTION
## Description

2 fixes for files generated by Dust apps: 
- Use a correct extension -> currently the output used is `xxx_output.plain` for plain text files. 
- Add some logic to return a json file if output is valid JSON. 

## Tests

Locally. 

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

Deploy front. 