### PR TITLE
[Google Drive] Handle shared drive not found error in incremental sync

### DIFF
--- a/connectors/src/connectors/google_drive/temporal/activities/incremental_sync.ts
+++ b/connectors/src/connectors/google_drive/temporal/activities/incremental_sync.ts
@@ -19,6 +19,7 @@ import {
   getCachedLabels,
   getDriveClient,
   getInternalId,
+  isSharedDriveNotFoundError,
 } from "@connectors/connectors/google_drive/temporal/utils";
 import { dataSourceConfigFromConnector } from "@connectors/lib/api/data_source_config";
 import {
@@ -278,6 +279,15 @@ export async function incrementalSync(
           error: e.message,
         },
         `Looks like we lost access to this drive. Skipping`
+      );
+      return undefined;
+    } else if (isSharedDriveNotFoundError(e)) {
+      localLogger.error(
+        {
+          error: e instanceof Error ? e.message : "Unknown error",
+          driveId,
+        },
+        `Shared drive not found. Skipping`
       );
       return undefined;
     } else {

--- a/connectors/src/connectors/google_drive/temporal/utils.ts
+++ b/connectors/src/connectors/google_drive/temporal/utils.ts
@@ -335,19 +335,9 @@ export function isSharedDriveNotFoundError(error: unknown): boolean {
     return false;
   }
 
-  // Check if the error message contains "Shared drive not found"
-  if (errorData.message?.includes("Shared drive not found")) {
-    return true;
-  }
-
-  // Also check in the errors array
   const errors = errorData.errors;
   if (Array.isArray(errors)) {
-    return errors.some(
-      (err) =>
-        err.reason === "notFound" &&
-        err.message?.includes("Shared drive not found")
-    );
+    return errors.some((err) => err.reason === "notFound");
   }
 
   return false;


### PR DESCRIPTION
## Description
Fixes an error that occurs when a shared drive is deleted or access is revoked during incremental sync. The error `Shared drive not found: XXXX` was causing the sync activity to fail repeatedly.

This PR adds:
- A new `isSharedDriveNotFoundError` helper function to detect this specific error
- Error handling in the incremental sync activity to catch and skip missing shared drives

## Risks
Blast radius: Google Drive incremental sync activity only
Risk: low

## Deploy Plan
- Deploy connectors service