### PR TITLE
gemini: add support for images

### DIFF
--- a/core/src/providers/anthropic/helpers.rs
+++ b/core/src/providers/anthropic/helpers.rs
@@ -5,7 +5,7 @@ use super::types::{
 };
 use crate::providers::{
     chat_messages::{AssistantContentItem, ChatMessage, ContentBlock, MixedContent},
-    helpers::{fetch_and_encode_images_from_messages, EncodedImageContent},
+    helpers::{fetch_and_encode_images_from_messages, Base64EncodedImageContent},
 };
 use anyhow::{anyhow, Result};
 use std::collections::HashMap;
@@ -46,7 +46,7 @@ pub async fn get_anthropic_chat_messages(
 
 fn convert_chat_message_to_anthropic_chat_message(
     chat_message: &ChatMessage,
-    base64_map: &HashMap<String, EncodedImageContent>,
+    base64_map: &HashMap<String, Base64EncodedImageContent>,
 ) -> Result<AnthropicChatMessage> {
     match chat_message {
         ChatMessage::System(system_msg) => Ok(AnthropicChatMessage {

--- a/core/src/providers/anthropic/helpers.rs
+++ b/core/src/providers/anthropic/helpers.rs
@@ -1,16 +1,14 @@
-use std::collections::HashMap;
-
-use crate::providers::chat_messages::{
-    AssistantContentItem, ChatMessage, ContentBlock, MixedContent,
-};
-
 use super::types::{
     AnthropicChatMessage, AnthropicChatMessageRole, AnthropicContent, AnthropicContentToolResult,
     AnthropicContentToolResultContent, AnthropicContentToolResultContentType,
-    AnthropicContentToolUse, AnthropicContentType, AnthropicImageContent,
+    AnthropicContentToolUse, AnthropicContentType,
+};
+use crate::providers::{
+    chat_messages::{AssistantContentItem, ChatMessage, ContentBlock, MixedContent},
+    helpers::{fetch_and_encode_images_from_messages, EncodedImageContent},
 };
 use anyhow::{anyhow, Result};
-use base64::{engine::general_purpose, Engine};
+use std::collections::HashMap;
 
 // Convert a vector of ChatMessages to a vector of AnthropicChatMessages.
 // This function will also fetch the images from URL and encode them to base64.
@@ -18,7 +16,7 @@ pub async fn get_anthropic_chat_messages(
     messages: Vec<ChatMessage>,
 ) -> Result<Vec<AnthropicChatMessage>> {
     // Fetch and encode any images in the messages.
-    let base64_map = fetch_and_encode_images(messages.clone()).await?;
+    let base64_map = fetch_and_encode_images_from_messages(&messages).await?;
 
     let anthropic_messages = messages
         .into_iter()
@@ -48,7 +46,7 @@ pub async fn get_anthropic_chat_messages(
 
 fn convert_chat_message_to_anthropic_chat_message(
     chat_message: &ChatMessage,
-    base64_map: &HashMap<String, AnthropicImageContent>,
+    base64_map: &HashMap<String, EncodedImageContent>,
 ) -> Result<AnthropicChatMessage> {
     match chat_message {
         ChatMessage::System(system_msg) => Ok(AnthropicChatMessage {
@@ -90,7 +88,7 @@ fn convert_chat_message_to_anthropic_chat_message(
 
                             Ok(AnthropicContent {
                                 r#type: AnthropicContentType::Image,
-                                source: Some(base64_data.clone()),
+                                source: Some(base64_data.clone().into()),
                                 text: None,
                                 tool_use: None,
                                 tool_result: None,
@@ -177,7 +175,7 @@ fn convert_chat_message_to_anthropic_chat_message(
                                 .ok_or(anyhow!("Invalid Image."))?;
                             Ok(AnthropicContentToolResultContent {
                                 r#type: AnthropicContentToolResultContentType::Image,
-                                source: Some(base64_data.clone()),
+                                source: Some(base64_data.clone().into()),
                                 text: None,
                             })
                         }
@@ -200,75 +198,4 @@ fn convert_chat_message_to_anthropic_chat_message(
             }
         },
     }
-}
-
-async fn fetch_image_base64(image_url: &str) -> Result<(String, AnthropicImageContent)> {
-    let response = reqwest::get(image_url)
-        .await
-        .map_err(|e| anyhow!("Invalid image: {}", e))?;
-
-    let mime_type = response
-        .headers()
-        .get(reqwest::header::CONTENT_TYPE)
-        .and_then(|ct| ct.to_str().ok())
-        .unwrap_or("application/octet-stream") // Default to a general binary type if MIME type is not found.
-        .to_string();
-
-    let bytes = response
-        .bytes()
-        .await
-        .map_err(|e| anyhow!("Invalid image, could not parse response {}", e))?;
-
-    Ok((
-        image_url.to_string(),
-        AnthropicImageContent {
-            r#type: "base64".to_string(),
-            media_type: mime_type,
-            data: general_purpose::STANDARD.encode(&bytes),
-        },
-    ))
-}
-
-async fn fetch_and_encode_images(
-    messages: Vec<ChatMessage>,
-) -> Result<HashMap<String, AnthropicImageContent>, anyhow::Error> {
-    let futures = messages
-        .into_iter()
-        .filter_map(|message| {
-            let mixed_content = match message {
-                ChatMessage::User(user_msg) => match user_msg.content {
-                    ContentBlock::Mixed(content) => Some(content),
-                    _ => None,
-                },
-                ChatMessage::Function(func_msg) => match func_msg.content {
-                    ContentBlock::Mixed(content) => Some(content),
-                    _ => None,
-                },
-                _ => None,
-            };
-
-            mixed_content.map(|content| {
-                content
-                    .into_iter()
-                    .filter_map(|content| {
-                        if let MixedContent::ImageContent(ic) = content {
-                            let url = ic.image_url.url.clone();
-                            Some(async move { fetch_image_base64(&url).await })
-                        } else {
-                            None
-                        }
-                    })
-                    .collect::<Vec<_>>()
-            })
-        })
-        .flatten()
-        .collect::<Vec<_>>();
-
-    let base64_pairs = futures::future::try_join_all(futures)
-        .await?
-        .into_iter()
-        .map(|(image_url, img_content)| (image_url.clone(), img_content))
-        .collect::<HashMap<_, _>>();
-
-    Ok(base64_pairs)
 }

--- a/core/src/providers/anthropic/types.rs
+++ b/core/src/providers/anthropic/types.rs
@@ -1,18 +1,17 @@
-use std::{
-    fmt::{self, Display},
-    str::FromStr,
-};
-
 use crate::providers::{
     chat_messages::{AssistantChatMessage, AssistantContentItem},
+    helpers::EncodedImageContent,
     llm::{ChatFunctionCall, ChatMessageRole},
 };
 use crate::utils::ParseError;
 use anyhow::Result;
-
 use hyper::StatusCode;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
+use std::{
+    fmt::{self, Display},
+    str::FromStr,
+};
 
 /*
 ** COMMON TYPES
@@ -150,6 +149,16 @@ pub struct AnthropicImageContent {
     pub r#type: String,
     pub media_type: String,
     pub data: String,
+}
+
+impl From<EncodedImageContent> for AnthropicImageContent {
+    fn from(encoded: EncodedImageContent) -> Self {
+        AnthropicImageContent {
+            r#type: encoded.r#type,
+            media_type: encoded.media_type,
+            data: encoded.data,
+        }
+    }
 }
 
 #[derive(Debug, Serialize, Deserialize, PartialEq, Clone)]

--- a/core/src/providers/anthropic/types.rs
+++ b/core/src/providers/anthropic/types.rs
@@ -1,6 +1,6 @@
 use crate::providers::{
     chat_messages::{AssistantChatMessage, AssistantContentItem},
-    helpers::EncodedImageContent,
+    helpers::Base64EncodedImageContent,
     llm::{ChatFunctionCall, ChatMessageRole},
 };
 use crate::utils::ParseError;
@@ -151,10 +151,10 @@ pub struct AnthropicImageContent {
     pub data: String,
 }
 
-impl From<EncodedImageContent> for AnthropicImageContent {
-    fn from(encoded: EncodedImageContent) -> Self {
+impl From<Base64EncodedImageContent> for AnthropicImageContent {
+    fn from(encoded: Base64EncodedImageContent) -> Self {
         AnthropicImageContent {
-            r#type: encoded.r#type,
+            r#type: "base64".to_string(),
             media_type: encoded.media_type,
             data: encoded.data,
         }

--- a/core/src/providers/helpers.rs
+++ b/core/src/providers/helpers.rs
@@ -1,7 +1,14 @@
 use super::{
-    chat_messages::{AssistantChatMessage, ChatMessage, UserChatMessage},
+    chat_messages::{FunctionChatMessage, ImageContent, ImageUrlContent},
     llm::ChatMessageRole,
 };
+use crate::providers::chat_messages::{
+    AssistantChatMessage, ChatMessage, ContentBlock, MixedContent, UserChatMessage,
+};
+use anyhow::{anyhow, Result};
+use base64::{engine::general_purpose, Engine};
+use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
 
 // Useful for models that don't support tools.
 // For assistant messages, we remove function/tool calls (and we format them inside of the "content" field instead).
@@ -54,4 +61,141 @@ pub fn strip_tools_from_chat_history(messages: &Vec<ChatMessage>) -> Vec<ChatMes
     }
 
     new_messages
+}
+
+#[derive(Debug, Serialize, Deserialize, PartialEq, Clone)]
+pub struct EncodedImageContent {
+    pub r#type: String,
+    pub media_type: String,
+    pub data: String,
+}
+
+async fn fetch_image_base64(image_url: &str) -> Result<(String, EncodedImageContent)> {
+    let response = reqwest::get(image_url)
+        .await
+        .map_err(|e| anyhow!("Invalid image: {}", e))?;
+
+    let mime_type = response
+        .headers()
+        .get(reqwest::header::CONTENT_TYPE)
+        .and_then(|ct| ct.to_str().ok())
+        .unwrap_or("application/octet-stream") // Default to a general binary type if MIME type is not found.
+        .to_string();
+
+    let bytes = response
+        .bytes()
+        .await
+        .map_err(|e| anyhow!("Invalid image, could not parse response {}", e))?;
+
+    Ok((
+        image_url.to_string(),
+        EncodedImageContent {
+            r#type: "base64".to_string(),
+            media_type: mime_type,
+            data: general_purpose::STANDARD.encode(&bytes),
+        },
+    ))
+}
+
+pub async fn fetch_and_encode_images_from_messages(
+    messages: &Vec<ChatMessage>,
+) -> Result<HashMap<String, EncodedImageContent>, anyhow::Error> {
+    let futures = messages
+        .into_iter()
+        .filter_map(|message| {
+            let mixed_content = match message {
+                ChatMessage::User(user_msg) => match user_msg.content.clone() {
+                    ContentBlock::Mixed(content) => Some(content),
+                    _ => None,
+                },
+                ChatMessage::Function(func_msg) => match func_msg.content.clone() {
+                    ContentBlock::Mixed(content) => Some(content),
+                    _ => None,
+                },
+                _ => None,
+            };
+
+            mixed_content.map(|content| {
+                content
+                    .into_iter()
+                    .filter_map(|content| {
+                        if let MixedContent::ImageContent(ic) = content {
+                            let url = ic.image_url.url.clone();
+                            Some(async move { fetch_image_base64(&url).await })
+                        } else {
+                            None
+                        }
+                    })
+                    .collect::<Vec<_>>()
+            })
+        })
+        .flatten()
+        .collect::<Vec<_>>();
+
+    let base64_pairs = futures::future::try_join_all(futures)
+        .await?
+        .into_iter()
+        //.map(|(image_url, img_content)| (image_url.clone(), img_content))
+        .collect::<HashMap<_, _>>();
+
+    Ok(base64_pairs)
+}
+
+pub fn convert_content_block_images_to_base64(
+    content: ContentBlock,
+    base64_map: &HashMap<String, EncodedImageContent>,
+) -> Result<ContentBlock> {
+    match content {
+        ContentBlock::Text(t) => Ok(ContentBlock::Text(t)),
+        ContentBlock::Mixed(m) => {
+            let mixed_content = m
+                .into_iter()
+                .map(|mb| match mb {
+                    MixedContent::TextContent(tc) => Ok(MixedContent::TextContent(tc)),
+                    MixedContent::ImageContent(ic) => {
+                        let base64_data = base64_map
+                            .get(&ic.image_url.url)
+                            .ok_or(anyhow!("Invalid Image."))?;
+                        Ok(MixedContent::ImageContent(ImageContent {
+                            r#type: ic.r#type,
+                            image_url: ImageUrlContent {
+                                url: format!(
+                                    "data:{};{},{}",
+                                    base64_data.media_type, base64_data.r#type, base64_data.data
+                                ),
+                            },
+                        }))
+                    }
+                })
+                .collect::<Result<Vec<MixedContent>>>()?;
+            Ok(ContentBlock::Mixed(mixed_content))
+        }
+    }
+}
+
+pub fn convert_message_images_to_base64(
+    message: ChatMessage,
+    base64_map: &HashMap<String, EncodedImageContent>,
+) -> Result<ChatMessage> {
+    match message {
+        ChatMessage::System(system_msg) => Ok(ChatMessage::System(system_msg)),
+        ChatMessage::User(user_msg) => {
+            let content = convert_content_block_images_to_base64(user_msg.content, base64_map)?;
+            Ok(ChatMessage::User(UserChatMessage {
+                content,
+                role: user_msg.role,
+                name: user_msg.name,
+            }))
+        }
+        ChatMessage::Assistant(assistant_msg) => Ok(ChatMessage::Assistant(assistant_msg)),
+        ChatMessage::Function(function_msg) => {
+            let content = convert_content_block_images_to_base64(function_msg.content, base64_map)?;
+            Ok(ChatMessage::Function(FunctionChatMessage {
+                content,
+                function_call_id: function_msg.function_call_id,
+                role: function_msg.role,
+                name: function_msg.name,
+            }))
+        }
+    }
 }


### PR DESCRIPTION
## Description

Fixes: https://github.com/dust-tt/tasks/issues/3250

As per https://ai.google.dev/gemini-api/docs/openai#image-understanding Gemini through the OpenAI compatibility layer only supports base64 data URLs.

This PR shuffles code a bit to reuse Anthropic's logic of downloading the image and turning it into a base64 representation to then repackage the ChatMessage that contain an image URL as data URLs for Google AI Studio.

r? @flvndvd as eng runner
cc @fontanierh as initial author

## Tests

Tested locally (both gemini and claude)

## Risk

Low this is plain broken right now

## Deploy Plan

- deploy `core`