### PR TITLE
Fix remote server ID assignment

### DIFF
--- a/front/components/actions/mcp/AddActionMenu.tsx
+++ b/front/components/actions/mcp/AddActionMenu.tsx
@@ -21,8 +21,7 @@ import type { WorkspaceType } from "@app/types";
 
 type AddActionMenuProps = {
   owner: WorkspaceType;
-  enabledMCPServerIds: string[];
-  enabledMCPServerNames: string[];
+  enabledMCPServers: { id: string; name: string }[];
   buttonVariant?: "primary" | "outline";
   createInternalMCPServer: (mcpServer: MCPServerType) => void;
   createRemoteMCPServer: (
@@ -33,8 +32,7 @@ type AddActionMenuProps = {
 
 export const AddActionMenu = ({
   owner,
-  enabledMCPServerIds: enabledMCPServers,
-  enabledMCPServerNames: enabledMCPServerNames,
+  enabledMCPServers,
   createInternalMCPServer,
   createRemoteMCPServer,
   buttonVariant = "primary",
@@ -78,10 +76,16 @@ export const AddActionMenu = ({
           </div>
         )}
         {availableMCPServers
-          .filter((mcpServer) => !enabledMCPServers.includes(mcpServer.sId))
+          .filter(
+            (mcpServer) =>
+              !enabledMCPServers.some((enabled) => enabled.id === mcpServer.sId)
+          )
           // ID is auto-incremented, so we need to filter out default servers with matching names
           .filter(
-            (mcpServer) => !enabledMCPServerNames.includes(mcpServer.name)
+            (mcpServer) =>
+              !enabledMCPServers.some(
+                (enabled) => enabled.name === mcpServer.name
+              )
           )
           .filter((mcpServer) => filterMCPServer(mcpServer, searchText))
           .map((mcpServer) => (

--- a/front/components/actions/mcp/AddActionMenu.tsx
+++ b/front/components/actions/mcp/AddActionMenu.tsx
@@ -21,7 +21,8 @@ import type { WorkspaceType } from "@app/types";
 
 type AddActionMenuProps = {
   owner: WorkspaceType;
-  enabledMCPServers: string[];
+  enabledMCPServerIds: string[];
+  enabledMCPServerNames: string[];
   buttonVariant?: "primary" | "outline";
   createInternalMCPServer: (mcpServer: MCPServerType) => void;
   createRemoteMCPServer: (
@@ -32,7 +33,8 @@ type AddActionMenuProps = {
 
 export const AddActionMenu = ({
   owner,
-  enabledMCPServers,
+  enabledMCPServerIds: enabledMCPServers,
+  enabledMCPServerNames: enabledMCPServerNames,
   createInternalMCPServer,
   createRemoteMCPServer,
   buttonVariant = "primary",
@@ -77,6 +79,10 @@ export const AddActionMenu = ({
         )}
         {availableMCPServers
           .filter((mcpServer) => !enabledMCPServers.includes(mcpServer.sId))
+          // ID is auto-incremented, so we need to filter out default servers with matching names
+          .filter(
+            (mcpServer) => !enabledMCPServerNames.includes(mcpServer.name)
+          )
           .filter((mcpServer) => filterMCPServer(mcpServer, searchText))
           .map((mcpServer) => (
             <DropdownMenuItem

--- a/front/components/actions/mcp/AdminActionsList.tsx
+++ b/front/components/actions/mcp/AdminActionsList.tsx
@@ -137,7 +137,8 @@ export const AdminActionsList = ({
     }
   };
 
-  const enabledMCPServers = mcpServers.map((s) => s.sId);
+  const enabledMCPServerIds = mcpServers.map((s) => s.sId);
+  const enabledMCPServerNames = mcpServers.map((s) => s.name);
 
   const rows: RowData[] = useMemo(
     () =>
@@ -275,7 +276,8 @@ export const AdminActionsList = ({
         portalToHeader(
           <AddActionMenu
             owner={owner}
-            enabledMCPServers={enabledMCPServers}
+            enabledMCPServerIds={enabledMCPServerIds}
+            enabledMCPServerNames={enabledMCPServerNames}
             setIsLoading={setIsLoading}
             createRemoteMCPServer={onCreateRemoteMCPServer}
             createInternalMCPServer={onCreateInternalMCPServer}
@@ -296,7 +298,8 @@ export const AdminActionsList = ({
               <AddActionMenu
                 buttonVariant="outline"
                 owner={owner}
-                enabledMCPServers={enabledMCPServers}
+                enabledMCPServerIds={enabledMCPServerIds}
+                enabledMCPServerNames={enabledMCPServerNames}
                 setIsLoading={setIsLoading}
                 createRemoteMCPServer={onCreateRemoteMCPServer}
                 createInternalMCPServer={onCreateInternalMCPServer}

--- a/front/components/actions/mcp/AdminActionsList.tsx
+++ b/front/components/actions/mcp/AdminActionsList.tsx
@@ -137,8 +137,10 @@ export const AdminActionsList = ({
     }
   };
 
-  const enabledMCPServerIds = mcpServers.map((s) => s.sId);
-  const enabledMCPServerNames = mcpServers.map((s) => s.name);
+  const enabledMCPServers = mcpServers.map((s) => ({
+    id: s.sId,
+    name: s.name,
+  }));
 
   const rows: RowData[] = useMemo(
     () =>
@@ -276,8 +278,7 @@ export const AdminActionsList = ({
         portalToHeader(
           <AddActionMenu
             owner={owner}
-            enabledMCPServerIds={enabledMCPServerIds}
-            enabledMCPServerNames={enabledMCPServerNames}
+            enabledMCPServers={enabledMCPServers}
             setIsLoading={setIsLoading}
             createRemoteMCPServer={onCreateRemoteMCPServer}
             createInternalMCPServer={onCreateInternalMCPServer}
@@ -298,8 +299,7 @@ export const AdminActionsList = ({
               <AddActionMenu
                 buttonVariant="outline"
                 owner={owner}
-                enabledMCPServerIds={enabledMCPServerIds}
-                enabledMCPServerNames={enabledMCPServerNames}
+                enabledMCPServers={enabledMCPServers}
                 setIsLoading={setIsLoading}
                 createRemoteMCPServer={onCreateRemoteMCPServer}
                 createInternalMCPServer={onCreateInternalMCPServer}

--- a/front/lib/resources/remote_mcp_servers_resource.ts
+++ b/front/lib/resources/remote_mcp_servers_resource.ts
@@ -16,7 +16,6 @@ import type {
   CustomServerIconType,
   InternalAllowedIconType,
 } from "@app/lib/actions/mcp_icons";
-import { getDefaultRemoteMCPServerByURL } from "@app/lib/actions/mcp_internal_actions/remote_servers";
 import type { MCPServerType, MCPToolType } from "@app/lib/api/mcp";
 import type { Authenticator } from "@app/lib/auth";
 import { DustError } from "@app/lib/error";
@@ -76,12 +75,6 @@ export class RemoteMCPServerResource extends BaseResource<RemoteMCPServerModel> 
       lastSyncAt: new Date(),
       authorization: blob.authorization,
     };
-
-    // If this is a default server, use its predefined ID
-    const defaultConfig = getDefaultRemoteMCPServerByURL(blob.url);
-    if (defaultConfig) {
-      serverData.id = defaultConfig.id;
-    }
 
     const server = await RemoteMCPServerModel.create(serverData, {
       transaction,


### PR DESCRIPTION
## Description

* Stripe tool was failing to create because it was using the predefined ID, as opposed to auto-incrementing like other remote servers.
* Now Auto-incrementing ID and filtering out already enabled servers based on name for default remote servers (which should be constant)

## Tests

<img width="1247" alt="Screenshot 2025-07-07 at 7 11 59 PM" src="https://github.com/user-attachments/assets/ae201777-21b7-4108-92da-d95498bd64bc" />


## Risk

* Minimal

## Deploy Plan

* Deploy front