### PR TITLE
[front] fix(delete-ws): Skip cutoff date when getting runs to be deleted

### DIFF
--- a/front/lib/resources/run_resource.ts
+++ b/front/lib/resources/run_resource.ts
@@ -46,7 +46,7 @@ export class RunResource extends BaseResource<RunModel> {
 
   static async listByWorkspace<T extends boolean>(
     workspace: LightWorkspaceType,
-    { includeApp }: { includeApp: T }
+    { includeApp, skipCutoffDate }: { includeApp: T; skipCutoffDate?: T }
   ): Promise<T extends true ? RunResourceWithApp[] : RunResource[]> {
     const include = includeApp
       ? [
@@ -59,9 +59,11 @@ export class RunResource extends BaseResource<RunModel> {
       : [];
 
     const runs = await this.model.findAll({
-      where: addCreatedAtClause({
-        workspaceId: workspace.id,
-      }),
+      where: skipCutoffDate
+        ? { workspaceId: workspace.id }
+        : addCreatedAtClause({
+            workspaceId: workspace.id,
+          }),
       include,
     });
 

--- a/front/poke/temporal/activities.ts
+++ b/front/poke/temporal/activities.ts
@@ -399,6 +399,8 @@ export async function deleteRunOnDustAppsActivity({
 
   const runs = await RunResource.listByWorkspace(workspace, {
     includeApp: true,
+    // We want to fetch ALL runs, not just the one created after the cutoff date
+    skipCutoffDate: true,
   });
 
   await concurrentExecutor(


### PR DESCRIPTION
## Description
While deleting the `runs` of a workspace in the `deleteRunOnDustAppsActivity`, we were only getting the last 30 days of runs, due to `RunResource.listByWorkspace` having a default filter on the workspace `createdAt`.
Not getting all runs makes the next step ( `deleteAppsActivity`) of the deletion workflow failed with foreign key violation as some runs/block_execution were not deleted.

This PR add a `skipCutoffDate` option to the `listByWorkspace` method, so we can get ALL runs for a given workspace during the deletion workflow.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk
- Low, only affect workspace being deleting.

## Deploy Plan
- Deploy front
