### PR TITLE
[front] chore(delete-ws): Increase startToTimeout for `deleteRunOnDustAppsActivity`

### DIFF
--- a/front/poke/temporal/activities.ts
+++ b/front/poke/temporal/activities.ts
@@ -403,9 +403,11 @@ export async function deleteRunOnDustAppsActivity({
     skipCutoffDate: true,
   });
 
+  hardDeleteLogger.info({ runs: runs.length }, "Numbers of runs to be deleted");
+
   await concurrentExecutor(
     runs,
-    async (run) => {
+    async (run, idx) => {
       const res = await coreAPI.deleteRun({
         projectId: run.app.dustAPIProjectId,
         runId: run.dustRunId,
@@ -414,6 +416,10 @@ export async function deleteRunOnDustAppsActivity({
         throw new Error(`Error deleting Run from Core: ${res.error.message}`);
       }
       await run.delete(auth);
+
+      if (idx % 100) {
+        hardDeleteLogger.debug({ idx, runId: run.id }, "Run deleted");
+      }
     },
     { concurrency: 8 }
   );

--- a/front/poke/temporal/activities.ts
+++ b/front/poke/temporal/activities.ts
@@ -417,7 +417,7 @@ export async function deleteRunOnDustAppsActivity({
       }
       await run.delete(auth);
 
-      if (idx % 100) {
+      if (idx % 500) {
         hardDeleteLogger.debug({ idx, runId: run.id }, "Run deleted");
       }
     },

--- a/front/poke/temporal/activities.ts
+++ b/front/poke/temporal/activities.ts
@@ -421,7 +421,7 @@ export async function deleteRunOnDustAppsActivity({
         hardDeleteLogger.debug({ idx, runId: run.id }, "Run deleted");
       }
     },
-    { concurrency: 8 }
+    { concurrency: 12 }
   );
 }
 

--- a/front/poke/temporal/workflows.ts
+++ b/front/poke/temporal/workflows.ts
@@ -15,7 +15,6 @@ const {
   deleteAppsActivity,
   deleteMembersActivity,
   deletePluginRunsActivity,
-  deleteRunOnDustAppsActivity,
   deleteRemoteMCPServersActivity,
   deleteSpacesActivity,
   deleteTagsActivity,
@@ -27,8 +26,11 @@ const {
   scrubSpaceActivity,
 } = normalActivityProxies;
 
-const { deleteConversationsActivity, deleteWorkspaceActivity } =
-  longActivityProxies;
+const {
+  deleteConversationsActivity,
+  deleteWorkspaceActivity,
+  deleteRunOnDustAppsActivity,
+} = longActivityProxies;
 
 export async function scrubDataSourceWorkflow({
   dataSourceId,


### PR DESCRIPTION
## Description
- Related to https://github.com/dust-tt/tasks/issues/3249
- Due to https://github.com/dust-tt/dust/pull/14157, much more runs are retrieve. For big workspace, the `deleteRunOnDustAppsActivity` fail after the 60min of `startToTimeout`.
- This PR simply move that activity into the `longActivityProxies` (with a timeout of 180min), and add some logs to observe where we're stopping. 

Goals is to see if that's enough, or if we should update the `deleteWorkspaceWorkflow` to use `continueAsNew` and split the workflow.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk
- Low

## Deploy Plan
- Deploy front
