### PR TITLE
[front] chore(delete-ws): Batch fetch the number of runs

### DIFF
--- a/front/lib/resources/types.ts
+++ b/front/lib/resources/types.ts
@@ -47,6 +47,7 @@ export type ResourceFindOptions<M extends Model> = {
   attributes?: FindOptions<M>["attributes"];
   includes?: TypedIncludeable<M>[];
   limit?: number;
+  offset?: number;
   order?: FindOptions<M>["order"];
   where?: WhereOptions<M>;
 } & (M extends SoftDeletableWorkspaceAwareModel

--- a/front/poke/temporal/activities.ts
+++ b/front/poke/temporal/activities.ts
@@ -397,32 +397,57 @@ export async function deleteRunOnDustAppsActivity({
     throw new Error("Could not find the workspace.");
   }
 
-  const runs = await RunResource.listByWorkspace(workspace, {
-    includeApp: true,
-    // We want to fetch ALL runs, not just the one created after the cutoff date
+  const BATCH_SIZE = 10_000;
+  let currentOffset = 0;
+
+  // Fetch the total of runs to fetch to max end to not go over.
+  const totalRunsToFetch = await RunResource.countByWorkspace(workspace, {
     skipCutoffDate: true,
   });
-
-  hardDeleteLogger.info({ runs: runs.length }, "Numbers of runs to be deleted");
-
-  await concurrentExecutor(
-    runs,
-    async (run, idx) => {
-      const res = await coreAPI.deleteRun({
-        projectId: run.app.dustAPIProjectId,
-        runId: run.dustRunId,
-      });
-      if (res.isErr()) {
-        throw new Error(`Error deleting Run from Core: ${res.error.message}`);
-      }
-      await run.delete(auth);
-
-      if (idx % 500) {
-        hardDeleteLogger.debug({ idx, runId: run.id }, "Run deleted");
-      }
-    },
-    { concurrency: 12 }
+  hardDeleteLogger.info(
+    { totalRuns: totalRunsToFetch },
+    "Numbers of runs to be deleted"
   );
+
+  do {
+    const runs = await RunResource.listByWorkspace(workspace, {
+      includeApp: true,
+      // We want to fetch ALL runs, not just the one created after the cutoff date
+      skipCutoffDate: true,
+      limit: BATCH_SIZE,
+      offset: currentOffset,
+    });
+
+    hardDeleteLogger.info(
+      { batchSize: runs.length, currentOffset },
+      "Processing batch of runs"
+    );
+
+    await concurrentExecutor(
+      runs,
+      async (run, idx) => {
+        const res = await coreAPI.deleteRun({
+          projectId: run.app.dustAPIProjectId,
+          runId: run.dustRunId,
+        });
+        if (res.isErr()) {
+          throw new Error(`Error deleting Run from Core: ${res.error.message}`);
+        }
+        await run.delete(auth);
+
+        if (idx % 500) {
+          hardDeleteLogger.debug({ idx, runId: run.id }, "Run deleted");
+        }
+      },
+      { concurrency: 12 }
+    );
+
+    // The last fetch was less than the batch size, so we know there is no batch after that.
+    if (runs.length < BATCH_SIZE) {
+      break;
+    }
+    currentOffset += runs.length;
+  } while (currentOffset <= totalRunsToFetch);
 }
 
 export const deleteRemoteMCPServersActivity = async ({

--- a/front/poke/temporal/activities.ts
+++ b/front/poke/temporal/activities.ts
@@ -416,6 +416,7 @@ export async function deleteRunOnDustAppsActivity({
       skipCutoffDate: true,
       limit: BATCH_SIZE,
       offset: currentOffset,
+      order: [["createdAt", "ASC"]],
     });
 
     hardDeleteLogger.info(


### PR DESCRIPTION
## Description
- Related to https://github.com/dust-tt/tasks/issues/3249
- Follow up of https://github.com/dust-tt/dust/pull/14161, logs don't show up. I highly believe it's due to the humongous runs to fetch (3.5M). Probably not getting into the JS array.
- This PR batch fetch the runs (10k)
- Add the pattern of `FetchXXXOptions` to give access to `limit` and `offset` to the `listByWorkspace` method. Also add a new `countByWorkspace` helper method.
  - Only does the options pattern for those method, just to limit the number of changes right now. 
- Using `countByWorkspace` help for logging purpose as well as getting an end limit on the `do while` loop. In any case, if we get less than the batch size we break the loop.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk
- Low, workspace deletion flow only.

## Deploy Plan
- Deploy front
