### PR TITLE
Make cookieBanner bigger

### DIFF
--- a/front/components/home/LandingLayout.tsx
+++ b/front/components/home/LandingLayout.tsx
@@ -115,7 +115,7 @@ export default function LandingLayout({
           {children}
         </div>
         <CookieBanner
-          className="fixed bottom-4 right-4"
+          className="fixed bottom-0 left-0 z-50 w-full"
           show={showCookieBanner}
           onClickAccept={() => {
             setAcceptedCookie("dust-cookies-accepted", "true", {
@@ -173,13 +173,13 @@ const CookieBanner = ({
   return (
     <div
       className={classNames(
-        "z-30 flex w-64 flex-col gap-3 rounded-xl border border-border bg-white p-4 shadow-xl",
+        "fixed bottom-0 left-0 z-30 flex w-full flex-col items-center justify-between gap-4 border-t border-border bg-blue-100 p-6 shadow-2xl md:flex-row",
         "s-transition-opacity s-duration-300 s-ease-in-out",
         isVisible ? "s-opacity-100" : "s-opacity-0",
         className || ""
       )}
     >
-      <div className="text-sm font-normal text-foreground">
+      <div className="text-sm font-normal text-foreground md:text-base">
         We use{" "}
         <A variant="primary">
           <Link


### PR DESCRIPTION
## Description

People don't seem to see the cookie banner well enough. We're making it more visible.

Before:
<img width="2132" alt="Screenshot 2025-07-08 at 09 35 36" src="https://github.com/user-attachments/assets/30ca8267-ba5b-4b4d-9e17-13a4b9a0170d" />


After:
<img width="1493" alt="Screenshot 2025-07-08 at 09 40 17" src="https://github.com/user-attachments/assets/db7e8ea8-d99f-4525-83f5-fe04bda45480" />
<img width="399" alt="Screenshot 2025-07-08 at 09 40 29" src="https://github.com/user-attachments/assets/8c329002-958d-4538-a395-475f864dc175" />


## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
