### PR TITLE
Fix Members Groups List

### DIFF
--- a/front/pages/w/[wId]/members/index.tsx
+++ b/front/pages/w/[wId]/members/index.tsx
@@ -1,7 +1,6 @@
 import {
   Page,
   SearchInput,
-  Spinner,
   Tabs,
   TabsContent,
   TabsList,
@@ -29,7 +28,6 @@ import { getWorkspaceVerifiedDomains } from "@app/lib/api/workspace_domains";
 import { withDefaultUserAuthRequirements } from "@app/lib/iam/session";
 import { isUpgraded } from "@app/lib/plans/plan_codes";
 import { useSearchMembers } from "@app/lib/swr/memberships";
-import { useWorkOSSSOStatus } from "@app/lib/swr/workos";
 import { useFeatureFlags } from "@app/lib/swr/workspaces";
 import type {
   PlanType,

--- a/front/pages/w/[wId]/members/index.tsx
+++ b/front/pages/w/[wId]/members/index.tsx
@@ -181,29 +181,19 @@ export default function WorkspaceAdmin({
 
 const DEFAULT_PAGE_SIZE = 25;
 
-interface WorkspaceMembersListProps {
+interface WorkspaceMembersGroupsListProps {
   currentUser: UserType | null;
+  isProvisioningEnabled: boolean;
   owner: WorkspaceType;
   searchTerm: string;
-  isProvisioningEnabled: boolean;
 }
 
 function WorkspaceMembersGroupsList({
   currentUser,
+  isProvisioningEnabled,
   owner,
   searchTerm,
-  isProvisioningEnabled,
-}: WorkspaceMembersListProps) {
-  const { isLoading } = useWorkOSSSOStatus({ owner });
-
-  if (isLoading) {
-    return (
-      <div className="flex items-center justify-center py-8">
-        <Spinner size="lg" />
-      </div>
-    );
-  }
-
+}: WorkspaceMembersGroupsListProps) {
   return (
     <div className="flex flex-col gap-1 pt-2">
       <Tabs defaultValue="members">


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
This aims at fixing https://github.com/dust-tt/tasks/issues/3406.

The current implementation of the `WorkspaceMembersGroupsList` has a useless dependency on the sso status. This causes an issue on the workspaces where the flag `okta_enterprise_connections` isn't set as the `/sso` endpoint has an early 403 return if this FF is not enabled. 

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
