### PR TITLE
[front] fix non-scrollable popover in data source filtering 

### DIFF
--- a/front/components/assistant_builder/tags/DataSourceViewTagsFilterDropdown.tsx
+++ b/front/components/assistant_builder/tags/DataSourceViewTagsFilterDropdown.tsx
@@ -116,7 +116,10 @@ export function DataSourceViewTagsFilterDropdown({
             isCounter={tagsCounter !== null}
           />
         </PopoverTrigger>
-        <PopoverContent className="w-[600px] max-w-[600px]">
+        <PopoverContent
+          className="max-h-[var(--radix-popper-available-height)] w-[600px] max-w-[600px] overflow-scroll"
+          collisionPadding={20}
+        >
           <div className="flex flex-col gap-8 p-2">
             <div className="flex flex-col gap-2">
               <Page.SectionHeader


### PR DESCRIPTION
## Description
This PR is to add max height and overflow scroll to the popover content in data source filtering to fix https://github.com/dust-tt/tasks/issues/3417. I should probably add this to Sparkle Popover but will check it later.

https://github.com/user-attachments/assets/305ee013-9f73-4f46-93e5-cbb02f966d31


 

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
