### PR TITLE
[front] chore: cleanup conversation tool names + meta prompt

### DIFF
--- a/front/lib/actions/constants.ts
+++ b/front/lib/actions/constants.ts
@@ -9,9 +9,6 @@ import type {
 // future based on user feedback.
 export const PROCESS_ACTION_TOP_K = 768;
 
-export const DEFAULT_PROCESS_ACTION_NAME =
-  "extract_structured_data_from_data_sources";
-
 // If we have actions that are used in global agents, we define the name and description of the action
 // (<=> of the internal MCP server) here and use it from here in both the internal MCP server
 // and `global_agents.ts`.
@@ -20,24 +17,21 @@ export const DEFAULT_WEBSEARCH_ACTION_NAME = "web_search_&_browse";
 export const DEFAULT_WEBSEARCH_ACTION_DESCRIPTION =
   "Agent can search (Google) and retrieve information from specific websites.";
 
-export const DEFAULT_CONVERSATION_LIST_FILES_ACTION_NAME =
-  "list_conversation_files";
-
+// TODO(durable-agents): remove this (only used in the non-MCP variant, inlined in the MCP tool definition).
 export const DEFAULT_SEARCH_LABELS_ACTION_NAME = "search_labels";
 
-export const DEFAULT_CONVERSATION_INCLUDE_FILE_ACTION_NAME =
-  "include_conversation_file";
+export const DEFAULT_CONVERSATION_LIST_FILES_ACTION_NAME = "list_files";
+
+export const DEFAULT_CONVERSATION_INCLUDE_FILE_ACTION_NAME = "include_file";
 
 export const DEFAULT_CONVERSATION_QUERY_TABLES_ACTION_NAME =
   "query_conversation_tables";
-export const DEFAULT_CONVERSATION_QUERY_TABLES_ACTION_DATA_DESCRIPTION = `The tables associated with the 'queryable' conversation files as returned by \`${DEFAULT_CONVERSATION_LIST_FILES_ACTION_NAME}\``;
 
 export const DEFAULT_CONVERSATION_SEARCH_ACTION_NAME =
   "search_conversation_files";
 
 export const DEFAULT_CONVERSATION_EXTRACT_ACTION_NAME =
   "extract_conversation_files";
-export const DEFAULT_CONVERSATION_EXTRACT_ACTION_DATA_DESCRIPTION = `Extract structured data from the 'extractable' conversation files as returned by \`${DEFAULT_CONVERSATION_LIST_FILES_ACTION_NAME}\``;
 
 export const DUST_CONVERSATION_HISTORY_MAGIC_INPUT_KEY =
   "__dust_conversation_history";

--- a/front/lib/actions/mcp_internal_actions/servers/conversation_files.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/conversation_files.ts
@@ -1,6 +1,10 @@
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod";
 
+import {
+  DEFAULT_CONVERSATION_INCLUDE_FILE_ACTION_NAME,
+  DEFAULT_CONVERSATION_LIST_FILES_ACTION_NAME,
+} from "@app/lib/actions/constants";
 import { makeMCPToolTextError } from "@app/lib/actions/mcp_internal_actions/utils";
 import type { AgentLoopContextType } from "@app/lib/actions/types";
 import {
@@ -48,7 +52,7 @@ function createServer(
   const server = new McpServer(serverInfo);
 
   server.tool(
-    "include_file",
+    DEFAULT_CONVERSATION_INCLUDE_FILE_ACTION_NAME,
     "Include the content of a file from the conversation attachments. Use this to access the full content of files that have been attached to the conversation.",
     {
       fileId: z
@@ -121,7 +125,7 @@ function createServer(
   );
 
   server.tool(
-    "list_files",
+    DEFAULT_CONVERSATION_LIST_FILES_ACTION_NAME,
     "List all files attached to the conversation.",
     {},
     async () => {

--- a/front/lib/api/assistant/jit_actions.ts
+++ b/front/lib/api/assistant/jit_actions.ts
@@ -1,10 +1,10 @@
 import assert from "assert";
 
 import {
-  DEFAULT_CONVERSATION_EXTRACT_ACTION_DATA_DESCRIPTION,
   DEFAULT_CONVERSATION_EXTRACT_ACTION_NAME,
-  DEFAULT_CONVERSATION_QUERY_TABLES_ACTION_DATA_DESCRIPTION,
+  DEFAULT_CONVERSATION_LIST_FILES_ACTION_NAME,
   DEFAULT_CONVERSATION_QUERY_TABLES_ACTION_NAME,
+  DEFAULT_CONVERSATION_SEARCH_ACTION_NAME,
 } from "@app/lib/actions/constants";
 import type {
   MCPServerConfigurationType,
@@ -171,7 +171,7 @@ export async function getJITServers(
       sId: generateRandomModelSId(),
       type: "mcp_server_configuration",
       name: DEFAULT_CONVERSATION_QUERY_TABLES_ACTION_NAME,
-      description: DEFAULT_CONVERSATION_QUERY_TABLES_ACTION_DATA_DESCRIPTION,
+      description: `The tables associated with the 'queryable' conversation files as returned by \`${DEFAULT_CONVERSATION_LIST_FILES_ACTION_NAME}\``,
       dataSources: null,
       tables,
       childAgentId: null,
@@ -242,7 +242,7 @@ export async function getJITServers(
       id: -1,
       sId: generateRandomModelSId(),
       type: "mcp_server_configuration",
-      name: "conversation_search",
+      name: DEFAULT_CONVERSATION_SEARCH_ACTION_NAME,
       description: "Semantic search over all files from the conversation",
       dataSources,
       tables: null,
@@ -292,7 +292,7 @@ export async function getJITServers(
       sId: generateRandomModelSId(),
       type: "mcp_server_configuration",
       name: DEFAULT_CONVERSATION_EXTRACT_ACTION_NAME,
-      description: DEFAULT_CONVERSATION_EXTRACT_ACTION_DATA_DESCRIPTION,
+      description: `Extract structured data from the 'extractable' conversation files as returned by \`${DEFAULT_CONVERSATION_LIST_FILES_ACTION_NAME}\``,
       dataSources,
       tables: null,
       childAgentId: null,

--- a/front/migrations/20250526_migrate_extract_to_mcp.ts
+++ b/front/migrations/20250526_migrate_extract_to_mcp.ts
@@ -3,7 +3,6 @@
 import fs from "fs";
 import { Op } from "sequelize";
 
-import { DEFAULT_PROCESS_ACTION_NAME } from "@app/lib/actions/constants";
 import { Authenticator } from "@app/lib/auth";
 import { AgentDataSourceConfiguration } from "@app/lib/models/assistant/actions/data_sources";
 import { AgentMCPServerConfiguration } from "@app/lib/models/assistant/actions/mcp";
@@ -17,6 +16,8 @@ import { getInsertSQL } from "@app/lib/utils/sql_utils";
 import type Logger from "@app/logger/logger";
 import { makeScript } from "@app/scripts/helpers";
 import type { ModelId } from "@app/types";
+
+const DEFAULT_PROCESS_ACTION_NAME = "extract_structured_data_from_data_sources";
 
 async function findWorkspacesWithProcessConfigurations(): Promise<ModelId[]> {
   const processConfigurations = await AgentProcessConfiguration.findAll({


### PR DESCRIPTION
## Description

- In `constructPromptMultiActions` we mention tools that do not exist anymore: we mention the non-MCP conversation tools, which were renamed when moving to MCP.
- This PR aligns the names used in the meta prompt with the names of the tools currently used. The prompt is changed but not the tool name to avoid confusing the model on existing conversations that used the tool.

## Tests

- Tested locally, no real change observed (the change is quite subtle).

## Risk

- Low, except for the one comment.

## Deploy Plan

- Deploy front.
