### PR TITLE
[front] List provisioned groups in `api-keys` and in poke DataTable

### DIFF
--- a/front/lib/resources/group_resource.ts
+++ b/front/lib/resources/group_resource.ts
@@ -695,7 +695,7 @@ export class GroupResource extends BaseResource<GroupModel> {
     auth: Authenticator,
     options: { groupKinds?: GroupKind[] } = {}
   ): Promise<GroupResource[]> {
-    const { groupKinds = ["global", "regular"] } = options;
+    const { groupKinds = ["global", "regular", "provisioned"] } = options;
     const groups = await this.baseFetch(auth, {
       where: {
         kind: {

--- a/front/pages/api/poke/workspaces/[wId]/groups/index.ts
+++ b/front/pages/api/poke/workspaces/[wId]/groups/index.ts
@@ -43,7 +43,9 @@ async function handler(
 
   switch (req.method) {
     case "GET":
-      const groups = await GroupResource.listAllWorkspaceGroups(auth);
+      const groups = await GroupResource.listAllWorkspaceGroups(auth, {
+        groupKinds: ["global", "regular", "provisioned"],
+      });
 
       return res.status(200).json({
         groups: groups.map((g) => g.toJSON()),


### PR DESCRIPTION
## Description

- This PR includes the provisioned groups in the poke DataTable and in the dropdown list when creating an API key.
- API keys are associated to groups and not directly to spaces, which means that up to now, if a key is created for the group associated to a space, switching this space to a group-based management invalidates the key, and there is no way to create a key for it anymore.

## Tests

- Checked locally.

## Risk

- Low.

## Deploy Plan

- Deploy front.
