### PR TITLE
[Microsoft] Handle item not found error in incremental sync

### DIFF
--- a/connectors/src/connectors/microsoft/temporal/cast_known_errors.ts
+++ b/connectors/src/connectors/microsoft/temporal/cast_known_errors.ts
@@ -1,3 +1,4 @@
+import { GraphError } from "@microsoft/microsoft-graph-client";
 import type {
   ActivityExecuteInput,
   ActivityInboundCallsInterceptor,
@@ -17,6 +18,14 @@ export function isMicrosoftSignInError(err: unknown): err is Error {
       "Error retrieving access token from microsoft: code=provider_access_token_refresh_error"
     ) &&
     knownMicrosoftSignInErrors.some((code) => err.message.includes(code))
+  );
+}
+
+export function isItemNotFoundError(err: unknown): err is GraphError {
+  return (
+    err instanceof GraphError &&
+    err.statusCode === 404 &&
+    err.code === "itemNotFound"
   );
 }
 


### PR DESCRIPTION
## Description
Fixes an error that occurs when a resource is deleted or access is revoked during incremental sync. The error `itemNotFound - The resource could not be found` with status 404 was causing the sync activity to fail repeatedly.

This PR adds:
- A new `isItemNotFoundError` helper function in `cast_known_errors.ts` to detect GraphError with 404 status and itemNotFound code
- Error handling in the `syncDeltaForRootNodesInDrive` activity to catch and skip missing resources
- Filtering of null values from the results to ensure only valid nodes are processed

## Risks
Blast radius: Microsoft incremental sync activity only
Risk: low

## Deploy Plan
- Deploy connectors service