### PR TITLE
Update generateParameterizedInsertStatements in reloc script - no need to check for JSONB in agent_dust_app_run_actions since DROPPED

### DIFF
--- a/front/temporal/relocation/lib/sql/insert.ts
+++ b/front/temporal/relocation/lib/sql/insert.ts
@@ -5,10 +5,6 @@ const DEFAULT_CHUNK_SIZE = 250;
 // Temporary solution to handle JSONB columns.
 const JSONB_COLUMNS = [
   {
-    tableName: "agent_dust_app_run_actions",
-    columns: ["params", "output"],
-  },
-  {
     tableName: "agent_configurations",
     columns: ["responseFormat"],
   },


### PR DESCRIPTION
## Description

Update `generateParameterizedInsertStatements` from relocation script:  we do no need to check for JSONB in `agent_dust_app_run_actions` since I am dropping this table today (script already merged - migration 302). 

In any case the tables `agent_dust_app_run_actions` and `agent_dust_app_run_configurations` are already empty. 

## Tests

Not tested. 

## Risk

Can be rolled back. 

## Deploy Plan

Run migration 302 that drops the tables. 
Deploy front. 