### PR TITLE
[front] fix copy on `Join` page

### DIFF
--- a/front/pages/w/[wId]/join.tsx
+++ b/front/pages/w/[wId]/join.tsx
@@ -207,7 +207,7 @@ export default function Join({
         </div>
         <div className="flex flex-col gap-3 pb-20">
           <p>
-            By signing-up, you accept Dust's{" "}
+            By signing up, you accept Dust's{" "}
             <Hoverable
               href="https://dust.tt/terms"
               variant="highlight"


### PR DESCRIPTION
## Description

- Fixes the copy on the Join page (`by signing-up` -> `by signing up`).
- Closes https://github.com/dust-tt/tasks/issues/3435.

## Tests

- Checked locally.

## Risk

- Low, very minor UI change.

## Deploy Plan

- Deploy front.
