### PR TITLE
[connectors] chore(Confluence): remove `ignoreNearRateLimit` mechanism

### DIFF
--- a/connectors/migrations/db/migration_83.sql
+++ b/connectors/migrations/db/migration_83.sql
@@ -1,0 +1,2 @@
+-- Migration created on Jul 08, 2025
+ALTER TABLE "public"."confluence_configurations" DROP COLUMN "ignoreNearRateLimit";

--- a/connectors/src/connectors/confluence/index.ts
+++ b/connectors/src/connectors/confluence/index.ts
@@ -76,7 +76,6 @@ export class ConfluenceConnectorManager extends BaseConnectorManager<null> {
 
     const confluenceConfigurationBlob = {
       cloudId,
-      ignoreNearRateLimit: false,
       url: cloudUrl,
       userAccountId,
     };

--- a/connectors/src/connectors/confluence/lib/cli.ts
+++ b/connectors/src/connectors/confluence/lib/cli.ts
@@ -183,18 +183,6 @@ export const confluence = async ({
       return { success: true };
     }
 
-    case "ignore-near-rate-limit": {
-      await confluenceConfig.update({ ignoreNearRateLimit: true });
-
-      return { success: true };
-    }
-
-    case "unignore-near-rate-limit": {
-      await confluenceConfig.update({ ignoreNearRateLimit: false });
-
-      return { success: true };
-    }
-
     case "check-page-exists": {
       assert(
         args.url && typeof args.url === "string",

--- a/connectors/src/connectors/confluence/lib/confluence_client.ts
+++ b/connectors/src/connectors/confluence/lib/confluence_client.ts
@@ -280,23 +280,19 @@ export class ConfluenceClient {
   private readonly restApiBaseUrl: string;
   private readonly legacyRestApiBaseUrl: string;
   private readonly proxyAgent?: ProxyAgent;
-  private readonly ignoreNearRateLimit?: boolean;
 
   constructor(
     private readonly authToken: string,
     {
       cloudId,
-      ignoreNearRateLimit,
       useProxy = false,
     }: {
       cloudId?: string;
-      ignoreNearRateLimit?: boolean;
       useProxy?: boolean;
     } = {}
   ) {
     this.restApiBaseUrl = `/ex/confluence/${cloudId}/wiki/api/v2`;
     this.legacyRestApiBaseUrl = `/ex/confluence/${cloudId}/wiki/rest/api`;
-    this.ignoreNearRateLimit = ignoreNearRateLimit;
     if (useProxy) {
       this.proxyAgent = new ProxyAgent(
         `http://${EnvironmentConfig.getEnvVariable(
@@ -499,11 +495,7 @@ export class ConfluenceClient {
 
     // When approaching the rate limit (using adaptive throttle ratio based on limit size), we slow down
     // the query pace by waiting NEAR_RATE_LIMIT_DELAY ms.
-    if (
-      !bypassThrottle &&
-      !this.ignoreNearRateLimit &&
-      checkNearRateLimit(response.headers)
-    ) {
+    if (!bypassThrottle && checkNearRateLimit(response.headers)) {
       statsDClient.increment("external.api.calls", 1, [
         "provider:confluence",
         "status:near_rate_limit",

--- a/connectors/src/connectors/confluence/temporal/activities.ts
+++ b/connectors/src/connectors/confluence/temporal/activities.ts
@@ -92,22 +92,20 @@ async function getConfluenceAccessTokenWithThrow(connectionId: string) {
 
 export async function getConfluenceClient(config: {
   cloudId?: string;
-  ignoreNearRateLimit?: boolean;
   connectorId: ModelId;
 }): Promise<ConfluenceClient>;
 export async function getConfluenceClient(
-  config: { cloudId?: string; ignoreNearRateLimit?: boolean },
+  config: { cloudId?: string },
   connector: ConnectorResource
 ): Promise<ConfluenceClient>;
 export async function getConfluenceClient(
   config: {
     cloudId?: string;
-    ignoreNearRateLimit?: boolean;
     connectorId?: ModelId;
   },
   connector?: ConnectorResource
 ) {
-  const { cloudId, connectorId, ignoreNearRateLimit } = config;
+  const { cloudId, connectorId } = config;
 
   // Ensure the connector is fetched if not directly provided.
   const effectiveConnector =
@@ -124,7 +122,6 @@ export async function getConfluenceClient(
 
   return new ConfluenceClient(accessToken, {
     cloudId,
-    ignoreNearRateLimit,
     useProxy: effectiveConnector.useProxy ?? false,
   });
 }
@@ -445,7 +442,6 @@ export async function confluenceCheckAndUpsertSinglePageActivity({
   const client = await getConfluenceClient(
     {
       cloudId: confluenceConfig.cloudId,
-      ignoreNearRateLimit: confluenceConfig.ignoreNearRateLimit,
     },
     connector
   );
@@ -589,7 +585,6 @@ export async function confluenceUpsertPageWithFullParentsActivity({
   const client = await getConfluenceClient(
     {
       cloudId: confluenceConfig.cloudId,
-      ignoreNearRateLimit: confluenceConfig.ignoreNearRateLimit,
     },
     connector
   );

--- a/connectors/src/lib/models/confluence.ts
+++ b/connectors/src/lib/models/confluence.ts
@@ -11,7 +11,6 @@ export class ConfluenceConfiguration extends ConnectorBaseModel<ConfluenceConfig
   declare cloudId: string;
   declare url: string;
   declare userAccountId: string;
-  declare ignoreNearRateLimit: boolean;
 }
 ConfluenceConfiguration.init(
   {
@@ -36,11 +35,6 @@ ConfluenceConfiguration.init(
     userAccountId: {
       type: DataTypes.STRING,
       allowNull: false,
-    },
-    ignoreNearRateLimit: {
-      type: DataTypes.BOOLEAN,
-      allowNull: true,
-      defaultValue: false,
     },
   },
   {


### PR DESCRIPTION
## Description

- We introduced in https://github.com/dust-tt/dust/pull/12258 a mechanism to the ignore near rate limit throttling at the level of the connector.
- This specific throttling was significantly changed since, and having this toggle at the connector level does not have any use anymore.
- This PR removes it altogether.

## Tests

- Checked locally.

## Risk

- Low.

## Deploy Plan

- Deploy connectors.
- Run `migration_83.sql`.
