### PR TITLE
[front] chore: remove `specification` from `AgentActionsEvent` type

### DIFF
--- a/front/lib/api/assistant/agent.ts
+++ b/front/lib/api/assistant/agent.ts
@@ -948,8 +948,6 @@ async function* runMultiActionsAgent(
       actionNamesFromLLM.includes(ac.name)
     );
     let args = a.arguments;
-    let spec =
-      specifications.find((s) => actionNamesFromLLM.includes(s.name)) ?? null;
 
     if (!action) {
       if (!a.name) {
@@ -1054,19 +1052,12 @@ async function* runMultiActionsAgent(
 
         action = catchAllAction;
         args = {};
-        spec = {
-          description:
-            "The agent attempted to run an invalid action, this will catch it.",
-          inputSchema: {},
-          name: a.name,
-        };
       }
     }
 
     actions.push({
       action: action!,
       inputs: args ?? {},
-      specification: spec,
       functionCallId: a.functionCallId ?? null,
     });
   }

--- a/front/types/assistant/agent.ts
+++ b/front/types/assistant/agent.ts
@@ -259,7 +259,6 @@ export type AgentActionsEvent = {
   actions: Array<{
     action: ActionConfigurationType;
     inputs: Record<string, string | boolean | number>;
-    specification: AgentActionSpecification | null;
     functionCallId: string | null;
   }>;
 };


### PR DESCRIPTION
## Description

- This PR removes the field `specification` from the `AgentActionsEvent` type.
- This field is not used anymore, it used to be required in `runAction` for `dust_app_run` actions.

## Tests

- Checked locally.

## Risk

- Low.

## Deploy Plan

- Deploy front.
