### PR TITLE
slack_bot: hide config if slack connector has bot enabled

### DIFF
--- a/front/pages/w/[wId]/workspace/index.tsx
+++ b/front/pages/w/[wId]/workspace/index.tsx
@@ -59,20 +59,9 @@ export const getServerSideProps = withDefaultUserAuthRequirements<{
     };
   }
 
-  const [slackBotDataSource, slackDataSource] = await Promise.all([
-    (async () => {
-      return (
-        (
-          await DataSourceResource.listByConnectorProvider(auth, "slack_bot")
-        )[0] ?? null
-      );
-    })(),
-    (async () => {
-      return (
-        (await DataSourceResource.listByConnectorProvider(auth, "slack"))[0] ??
-        null
-      );
-    })(),
+  const [[slackDataSource], [slackBotDataSource]] = await Promise.all([
+    DataSourceResource.listByConnectorProvider(auth, "slack"),
+    DataSourceResource.listByConnectorProvider(auth, "slack_bot"),
   ]);
 
   let isSlackDataSourceBotEnabled = false;


### PR DESCRIPTION
## Description

Hides the slack configuration in workspace settings if the slack bot is enabled on the Slack connecotr (creation errors otherwise)

## Tests

Tested locally with and without slack connection with and without slack bot enabled.

## Risk

Low

## Deploy Plan

- deploy `front`