### PR TITLE
Flav x Aubin: Agent builder instructions autocomplete

### DIFF
--- a/front/components/assistant/conversation/input_bar/editor/extensions/AgentBuilderInstructionsAutoCompleteExtension.ts
+++ b/front/components/assistant/conversation/input_bar/editor/extensions/AgentBuilderInstructionsAutoCompleteExtension.ts
@@ -17,6 +17,8 @@ const agentBuilderInstructionsAutoCompletePluginKey =
     AGENT_BUILDER_INSTRUCTIONS_AUTO_COMPLETE_EXTENSION_NAME
   );
 
+const MINIMUM_TEXT_LENGTH_FOR_SUGGESTIONS = 3;
+
 /**
  * Fetches autocompletion suggestions from the agent builder API.
  * This function is specific to the agent builder instructions context.
@@ -26,7 +28,7 @@ const fetchAgentBuilderSuggestions = async (
   owner: LightWorkspaceType | null,
   builderState: AssistantBuilderState | null
 ): Promise<string[]> => {
-  if (!owner || currentText.length === 0) {
+  if (!owner || currentText.length < MINIMUM_TEXT_LENGTH_FOR_SUGGESTIONS) {
     return [];
   }
 
@@ -186,7 +188,6 @@ const createSuggestionDecoration = (
       // TODO(2025-07-08): Add class `autocomplete-suggestion` to our style.
       parentNode.style.color = "#9ca3af";
       parentNode.style.fontStyle = "italic";
-      parentNode.classList.add("autocomplete-suggestion");
       return parentNode;
     },
     { side: 1 }

--- a/front/components/assistant/conversation/input_bar/editor/extensions/AgentBuilderInstructionsAutoCompleteExtension.ts
+++ b/front/components/assistant/conversation/input_bar/editor/extensions/AgentBuilderInstructionsAutoCompleteExtension.ts
@@ -139,12 +139,6 @@ const checkSuggestionMatch = (
     return { isValid: false, remainingSuggestion: "" };
   }
 
-  console.log("Checking suggestion match:", {
-    currentText,
-    suggestion,
-    normalizedOriginalText,
-  });
-
   // Normalize current text only once
   const normalizedCurrent = normalizeWhitespace(currentText);
 
@@ -158,8 +152,6 @@ const checkSuggestionMatch = (
     normalizedOriginalText.length
   );
 
-  console.log("Typed since suggestion (normalized):", typedSinceSuggestion);
-
   // Check if the normalized suggestion starts with what the user has typed
   if (!normalizedSuggestion.startsWith(typedSinceSuggestion)) {
     return { isValid: false, remainingSuggestion: "" };
@@ -167,7 +159,6 @@ const checkSuggestionMatch = (
 
   // Return the remaining part of the suggestion (original formatting)
   const remainingSuggestion = suggestion.substring(typedSinceSuggestion.length);
-  console.log("Remaining suggestion:", remainingSuggestion);
 
   return { isValid: true, remainingSuggestion };
 };
@@ -224,12 +215,6 @@ const cleanSuggestions = (
   rawSuggestions: string[]
 ): string[] => {
   const trimmedCurrentText = currentText.trim();
-
-  console.log("Cleaning suggestions:", {
-    currentText,
-    trimmedCurrentText,
-    rawSuggestions,
-  });
 
   return rawSuggestions
     .map((suggestion) => {
@@ -440,13 +425,6 @@ export const AgentBuilderInstructionsAutoCompleteExtension = Extension.create<
               void getSuggestions(
                 currentText,
                 (suggestions, originalRequestText) => {
-                  console.log(
-                    "Got raw suggestions:",
-                    suggestions,
-                    "for request:",
-                    originalRequestText
-                  );
-
                   // Get current text at the time the response arrives.
                   const currentTextNow = getCurrentTextFromView(view);
 

--- a/front/components/assistant/conversation/input_bar/editor/extensions/TextAutoCompleteExtension.ts
+++ b/front/components/assistant/conversation/input_bar/editor/extensions/TextAutoCompleteExtension.ts
@@ -1,4 +1,5 @@
 import type { LightWorkspaceType } from "@dust-tt/client";
+import type { Editor } from "@tiptap/core";
 import { Extension } from "@tiptap/core";
 import type { Node } from "@tiptap/pm/model";
 import { Plugin, PluginKey } from "@tiptap/pm/state";
@@ -19,6 +20,10 @@ const suggestionPluginKey = new PluginKey<DecorationSet>("suggestion");
 const normalizeWhitespace = (text: string): string => {
   return text.replace(/\s+/g, " ");
 };
+
+function getCurrentTextFromView(view: EditorView) {
+  return view.state.doc.textBetween(0, view.state.doc.content.size);
+}
 
 // Helper function to check if current suggestion is still valid
 const checkSuggestionMatch = (
@@ -224,10 +229,7 @@ export const TextAutoCompleteExtension = Extension.create<
               console.log("Accepting suggestion:", suggestionText);
 
               // Get current text to calculate remaining suggestion.
-              const currentText = editor.state.doc.textBetween(
-                0,
-                editor.state.doc.content.size
-              );
+              const currentText = getCurrentTextFromView(editor.view);
 
               // Use helper function to get remaining suggestion.
               const suggestionMatch = checkSuggestionMatch(
@@ -377,10 +379,7 @@ export const TextAutoCompleteExtension = Extension.create<
               }
 
               // Fetch a new suggestion.
-              const currentText = view.state.doc.textBetween(
-                0,
-                view.state.doc.content.size
-              );
+              const currentText = getCurrentTextFromView(view);
               console.log("Checking suggestion for:", currentText);
 
               // Check if current suggestion still matches before fetching new ones
@@ -449,10 +448,7 @@ export const TextAutoCompleteExtension = Extension.create<
                   );
 
                   // Get current text at the time the response arrives
-                  const currentTextNow = view.state.doc.textBetween(
-                    0,
-                    view.state.doc.content.size
-                  );
+                  const currentTextNow = getCurrentTextFromView(view);
 
                   // Always preserve suggestions in the array for potential future use
                   if (suggestions && suggestions.length > 0) {

--- a/front/components/assistant/conversation/input_bar/editor/extensions/TextAutoCompleteExtension.ts
+++ b/front/components/assistant/conversation/input_bar/editor/extensions/TextAutoCompleteExtension.ts
@@ -1,0 +1,300 @@
+import type { LightWorkspaceType } from "@dust-tt/client";
+import { Extension } from "@tiptap/core";
+import { Plugin, PluginKey } from "@tiptap/pm/state";
+import { Decoration, DecorationSet } from "@tiptap/pm/view";
+import { debounce } from "lodash";
+
+import type { AssistantBuilderState } from "@app/components/assistant_builder/types";
+
+// Create the plugin key outside so it can be shared
+const suggestionPluginKey = new PluginKey<DecorationSet>("suggestion");
+
+interface TextAutoCompleteExtensionOptions {
+  applySuggestionKey: string;
+  owner: LightWorkspaceType | null;
+  suggestionDebounce: number;
+}
+
+interface TextAutoCompleteExtensionStorage {
+  builderState: AssistantBuilderState | null;
+  currentSuggestion: string | null;
+  suggestions: string[];
+}
+
+export const TextAutoCompleteExtension = Extension.create<
+  TextAutoCompleteExtensionOptions,
+  TextAutoCompleteExtensionStorage
+>({
+  name: "suggestion",
+
+  addStorage() {
+    return {
+      builderState: null,
+      currentSuggestion: null,
+      suggestions: [],
+    };
+  },
+
+  addOptions() {
+    return {
+      applySuggestionKey: "Tab",
+      suggestionDebounce: 1500,
+      owner: null,
+    };
+  },
+
+  addKeyboardShortcuts() {
+    return {
+      Tab: ({ editor }) => {
+        const decorations = suggestionPluginKey.getState(editor.state);
+
+        // Check if there's a suggestion.
+        if (decorations && decorations.find().length > 0) {
+          const { selection } = editor.state;
+          const { from, to } = selection;
+
+          // Check if cursor is at the end of the content.
+          const docSize = editor.state.doc.content.size;
+          // TODO: Debug cursor logic here.
+          const isAtEnd = true; //from === to && from === docSize;
+
+          console.log("Suggestion exists, cursor at end:", isAtEnd, {
+            from,
+            to,
+            docSize,
+          });
+
+          if (isAtEnd) {
+            // Get the suggestion text from storage
+            const suggestionText = this.storage.currentSuggestion;
+            console.log("Current suggestion in storage:", suggestionText);
+
+            if (suggestionText) {
+              console.log("Accepting suggestion:", suggestionText);
+
+              // Insert the suggestion text
+              editor.chain().focus().insertContent(suggestionText).run();
+
+              // Clear the current suggestion - next suggestion will be shown on next keystroke
+              this.storage.currentSuggestion = null;
+
+              // Clear the decorations
+              const tr = editor.state.tr;
+              tr.setMeta(suggestionPluginKey, {
+                decorations: DecorationSet.empty,
+              });
+              editor.view.dispatch(tr);
+
+              return true; // Prevent default tab behavior
+            } else {
+              console.log("No suggestion in storage");
+            }
+          }
+        }
+
+        return false; // Allow default tab behavior
+      },
+    };
+  },
+
+  addProseMirrorPlugins() {
+    const pluginKey = suggestionPluginKey;
+    const extensionStorage = this.storage;
+
+    const fetchSuggestions = async (
+      previousText: string
+    ): Promise<string[]> => {
+      if (!this.options.owner) {
+        return [];
+      }
+
+      const res = await fetch(
+        `/api/w/${this.options.owner.sId}/assistant/builder/suggestions`,
+        {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+          },
+          body: JSON.stringify({
+            type: "autocompletion",
+            inputs: {
+              name: this.storage.builderState?.handle,
+              description: this.storage.builderState?.description,
+              instructions: previousText,
+              tools:
+                this.storage.builderState?.actions?.map((action) => ({
+                  name: action.name,
+                  description: action.description,
+                })) || [],
+            },
+          }),
+        }
+      );
+      if (!res.ok) {
+        console.error("Failed to get suggestions", res);
+        return [];
+      }
+      const data = await res.json();
+      console.log("Got suggestions:", data);
+      return data.suggestions || [];
+    };
+
+    // Simple debounced suggestion function - like the original working version.
+    const getSuggestions = debounce(
+      async (
+        previousText: string,
+        cb: (suggestions: string[] | null) => void
+      ) => {
+        console.log("Fetching suggestion for:", previousText);
+        try {
+          const suggestions = await fetchSuggestions(previousText);
+          console.log("Got suggestions:", suggestions);
+
+          if (suggestions.length > 0) {
+            cb(suggestions);
+          } else {
+            cb(null);
+          }
+        } catch (error) {
+          console.error("Error fetching suggestions:", error);
+          cb(null);
+        }
+      },
+      this.options.suggestionDebounce
+    );
+
+    return [
+      new Plugin({
+        key: pluginKey,
+        state: {
+          init() {
+            console.log("AutoComplete plugin initialized");
+            return DecorationSet.empty;
+          },
+          apply(tr, oldValue) {
+            if (tr.getMeta(pluginKey)) {
+              // Update the decoration state based on the async data
+              const { decorations } = tr.getMeta(pluginKey);
+              return decorations;
+            }
+            return tr.docChanged ? oldValue.map(tr.mapping, tr.doc) : oldValue;
+          },
+        },
+        view() {
+          return {
+            update(view, prevState) {
+              // This will add the widget decoration at the cursor position.
+              const selection = view.state.selection;
+              const cursorPos = selection.$head.pos;
+              const nextNode = view.state.doc.nodeAt(cursorPos);
+
+              // If cursor is not at block end and we have suggestion => hide
+              // suggestion.
+              if (
+                nextNode &&
+                !nextNode.isBlock &&
+                pluginKey.getState(view.state)?.find().length
+              ) {
+                const tr = view.state.tr;
+                tr.setMeta("addToHistory", false);
+                tr.setMeta(pluginKey, { decorations: DecorationSet.empty });
+                view.dispatch(tr);
+                return;
+              }
+
+              // If the document didn't change, do nothing.
+              if (prevState && prevState.doc.eq(view.state.doc)) {
+                return;
+              }
+
+              // Reset the suggestion before fetching a new one.
+              setTimeout(() => {
+                const tr = view.state.tr;
+                tr.setMeta("addToHistory", false);
+                tr.setMeta(pluginKey, { decorations: DecorationSet.empty });
+                view.dispatch(tr);
+              }, 0);
+
+              // Fetch a new suggestion.
+              const currentText = view.state.doc.textBetween(
+                0,
+                view.state.doc.content.size,
+                " "
+              );
+              console.log("Fetching suggestion for:", currentText);
+
+              // Simple debounced fetch like the original.
+              void getSuggestions(currentText, (suggestions) => {
+                console.log("Got suggestions:", suggestions);
+                if (!suggestions) {
+                  return;
+                }
+
+                if (suggestions) {
+                  extensionStorage.suggestions.push(...suggestions);
+                }
+
+                const [suggestion] = suggestions;
+                extensionStorage.currentSuggestion = suggestion;
+
+                const updatedState = view.state;
+                const cursorPos = updatedState.selection.$head.pos;
+                const suggestionDecoration = Decoration.widget(
+                  cursorPos,
+                  () => {
+                    const parentNode = document.createElement("span");
+                    const addSpace = nextNode && nextNode.isText ? " " : "";
+                    parentNode.innerHTML = `${addSpace}${suggestion}`;
+                    parentNode.style.color = "#9ca3af";
+                    parentNode.style.fontStyle = "italic";
+                    parentNode.classList.add("autocomplete-suggestion");
+                    return parentNode;
+                  },
+                  { side: 1 }
+                );
+
+                const decorations = DecorationSet.create(updatedState.doc, [
+                  suggestionDecoration,
+                ]);
+                const tr = view.state.tr;
+                tr.setMeta("addToHistory", false);
+                tr.setMeta(pluginKey, { decorations });
+                view.dispatch(tr);
+              });
+            },
+          };
+        },
+        props: {
+          decorations(editorState) {
+            return pluginKey.getState(editorState);
+          },
+
+          handleKeyDown(view, event) {
+            if (event.key === "Tab") {
+              const decorations = pluginKey.getState(view.state);
+              // If there is a decoration, we have a suggestion.
+              if (decorations && decorations.find().length > 0) {
+                event.preventDefault();
+                // Find the suggestion text and insert it.
+                const decoration = decorations.find()[0];
+                const suggestionElement = decoration.spec.widget;
+                if (suggestionElement) {
+                  const suggestionText = suggestionElement.textContent || "";
+                  const { selection } = view.state;
+                  const tr = view.state.tr.insertText(
+                    suggestionText,
+                    selection.from
+                  );
+                  tr.setMeta(pluginKey, { decorations: DecorationSet.empty });
+                  view.dispatch(tr);
+                  return true;
+                }
+              }
+            }
+            return false;
+          },
+        },
+      }),
+    ];
+  },
+});

--- a/front/components/assistant_builder/InstructionScreen.tsx
+++ b/front/components/assistant_builder/InstructionScreen.tsx
@@ -15,6 +15,7 @@ import { EditorContent, useEditor } from "@tiptap/react";
 import React, { useEffect, useMemo, useState } from "react";
 
 import { ParagraphExtension } from "@app/components/assistant/conversation/input_bar/editor/extensions/ParagraphExtension";
+import { TextAutoCompleteExtension } from "@app/components/assistant/conversation/input_bar/editor/extensions/TextAutoCompleteExtension";
 import { AdvancedSettings } from "@app/components/assistant_builder/AdvancedSettings";
 import { InstructionDiffExtension } from "@app/components/assistant_builder/instructions/InstructionDiffExtension";
 import { InstructionHistory } from "@app/components/assistant_builder/instructions/InstructionsHistory";
@@ -87,6 +88,9 @@ export function InstructionScreen({
       InstructionDiffExtension,
       CharacterCount.configure({
         limit: INSTRUCTIONS_MAXIMUM_CHARACTER_COUNT,
+      }),
+      TextAutoCompleteExtension.configure({
+        owner,
       }),
     ],
     editable: !doTypewriterEffect,
@@ -220,6 +224,20 @@ export function InstructionScreen({
       }
     }
   }, [isInstructionDiffMode, compareVersion, editor]);
+
+  // Update the autocomplete extension storage with current builder state
+  useEffect(() => {
+    if (!editor) {
+      return;
+    }
+
+    const extension = editor.extensionManager.extensions.find(
+      (ext) => ext.name === "suggestion"
+    );
+    if (extension) {
+      extension.storage.agentFormData = builderState;
+    }
+  }, [editor, builderState]);
 
   const dateFormatter = new Intl.DateTimeFormat("en-US", {
     year: "numeric",

--- a/front/components/assistant_builder/InstructionScreen.tsx
+++ b/front/components/assistant_builder/InstructionScreen.tsx
@@ -235,7 +235,7 @@ export function InstructionScreen({
       (ext) => ext.name === "suggestion"
     );
     if (extension) {
-      extension.storage.agentFormData = builderState;
+      extension.storage.builderState = builderState;
     }
   }, [editor, builderState]);
 

--- a/front/components/assistant_builder/InstructionScreen.tsx
+++ b/front/components/assistant_builder/InstructionScreen.tsx
@@ -99,11 +99,15 @@ export function InstructionScreen({
     workspaceId: owner.sId,
   });
 
-  const editor = useEditor({
-    extensions: getAgentBuilderInstructionsExtensionsForWorkspace(
+  const extensions = useMemo(() => {
+    return getAgentBuilderInstructionsExtensionsForWorkspace(
       owner,
       featureFlags
-    ),
+    );
+  }, [owner, featureFlags]);
+
+  const editor = useEditor({
+    extensions,
     editable: !doTypewriterEffect,
     content: tipTapContentFromPlainText(
       (!doTypewriterEffect && builderState.instructions) || ""

--- a/front/lib/registry.ts
+++ b/front/lib/registry.ts
@@ -181,7 +181,7 @@ export const BaseDustProdActionRegistry = {
     app: {
       appId: "eDoafmNqwn",
       appHash:
-        "840f1645921b7b96315a7a2aca27296d448b8cad0421e2be48862786dc3f9832",
+        "ea3910dfbb46286afe8fdba9a10d39136ed48f6f473f0bdcdddfb4079f631cb9",
     },
     config: {
       CREATE_SUGGESTIONS: {

--- a/front/lib/registry.ts
+++ b/front/lib/registry.ts
@@ -181,7 +181,7 @@ export const BaseDustProdActionRegistry = {
     app: {
       appId: "eDoafmNqwn",
       appHash:
-        "ea3910dfbb46286afe8fdba9a10d39136ed48f6f473f0bdcdddfb4079f631cb9",
+        "79ff579ada29a0e2726ee038890fba38e61082e30e11dac7a1fb2bf2dc035d80",
     },
     config: {
       CREATE_SUGGESTIONS: {

--- a/front/lib/registry.ts
+++ b/front/lib/registry.ts
@@ -177,6 +177,20 @@ export const BaseDustProdActionRegistry = {
       },
     },
   },
+  "assistant-builder-autocompletion-suggestions": {
+    app: {
+      appId: "eDoafmNqwn",
+      appHash:
+        "840f1645921b7b96315a7a2aca27296d448b8cad0421e2be48862786dc3f9832",
+    },
+    config: {
+      CREATE_SUGGESTIONS: {
+        // `provider_id` and `model_id` must be set by caller.
+        function_call: "autocomplete_instructions",
+        use_cache: false,
+      },
+    },
+  },
   "assistant-builder-name-suggestions": {
     app: {
       appId: "34a8c4a2aa",

--- a/front/pages/api/w/[wId]/assistant/builder/suggestions.ts
+++ b/front/pages/api/w/[wId]/assistant/builder/suggestions.ts
@@ -87,12 +87,16 @@ async function handler(
       );
       config.CREATE_SUGGESTIONS.provider_id = model.providerId;
       config.CREATE_SUGGESTIONS.model_id = model.modelId;
+      const additionalConfiguration = {
+        minSuggestionCount: 8,
+        maxSuggestionCount: 16,
+      };
 
       const suggestionsResponse = await runAction(
         auth,
         `assistant-builder-${suggestionsType}-suggestions`,
         config,
-        [suggestionsInputs]
+        [{ ...suggestionsInputs, ...additionalConfiguration }]
       );
 
       if (suggestionsResponse.isErr() || !suggestionsResponse.value.results) {

--- a/front/pages/api/w/[wId]/assistant/builder/suggestions.ts
+++ b/front/pages/api/w/[wId]/assistant/builder/suggestions.ts
@@ -56,6 +56,9 @@ async function handler(
         case "instructions":
           model = getLargeWhitelistedModel(owner);
           break;
+        case "autocompletion":
+          model = getLargeWhitelistedModel(owner);
+          break;
         case "name":
         case "description":
         case "emoji":

--- a/front/pages/api/w/[wId]/assistant/builder/suggestions.ts
+++ b/front/pages/api/w/[wId]/assistant/builder/suggestions.ts
@@ -24,6 +24,17 @@ import {
   InternalPostBuilderSuggestionsRequestBodySchema,
 } from "@app/types";
 
+// Minimum number of suggestions output by the suggestion app.
+const SUGGESTIONS_MIN_COUNT = 8;
+// Maximum number of suggestions output by the suggestion app.
+const SUGGESTIONS_MAX_COUNT = 16;
+// Maximum length of each suggestion, in number of characters.
+const SUGGESTION_MAX_LENGTH = 100;
+
+// Threshold on the score output by the suggestion app at which we consider the instructions
+// to be good enough and not require any additional suggestions.
+const SCORE_THRESHOLD = 50;
+
 async function handler(
   req: NextApiRequest,
   res: NextApiResponse<
@@ -87,8 +98,9 @@ async function handler(
       config.CREATE_SUGGESTIONS.provider_id = model.providerId;
       config.CREATE_SUGGESTIONS.model_id = model.modelId;
       const additionalConfiguration = {
-        minSuggestionCount: 8,
-        maxSuggestionCount: 16,
+        minSuggestionCount: SUGGESTIONS_MIN_COUNT,
+        maxSuggestionCount: SUGGESTIONS_MAX_COUNT,
+        maxSuggestionLength: SUGGESTION_MAX_LENGTH,
       };
 
       const suggestionsResponse = await runAction(
@@ -132,12 +144,19 @@ async function handler(
       const suggestions = responseValidation.right as {
         status: "ok";
         suggestions: string[] | null | undefined;
+        score: number | null | undefined;
       };
       if (suggestionsType === "name") {
         suggestions.suggestions = await filterSuggestedNames(
           owner,
           suggestions.suggestions
         );
+      }
+      if (
+        typeof suggestions.score === "number" &&
+        suggestions.score > SCORE_THRESHOLD
+      ) {
+        return res.status(200).json({ ...suggestions, suggestions: [] });
       }
 
       return res.status(200).json(suggestions);

--- a/front/pages/api/w/[wId]/assistant/builder/suggestions.ts
+++ b/front/pages/api/w/[wId]/assistant/builder/suggestions.ts
@@ -19,7 +19,6 @@ import {
   assertNever,
   BuilderEmojiSuggestionsResponseBodySchema,
   BuilderSuggestionsResponseBodySchema,
-  GEMINI_2_FLASH_LITE_MODEL_CONFIG,
   getLargeWhitelistedModel,
   getSmallWhitelistedModel,
   InternalPostBuilderSuggestionsRequestBodySchema,
@@ -58,7 +57,7 @@ async function handler(
           model = getLargeWhitelistedModel(owner);
           break;
         case "autocompletion":
-          model = GEMINI_2_FLASH_LITE_MODEL_CONFIG; //getLargeWhitelistedModel(owner);
+          model = getLargeWhitelistedModel(owner);
           break;
         case "name":
         case "description":

--- a/front/pages/api/w/[wId]/assistant/builder/suggestions.ts
+++ b/front/pages/api/w/[wId]/assistant/builder/suggestions.ts
@@ -19,6 +19,7 @@ import {
   assertNever,
   BuilderEmojiSuggestionsResponseBodySchema,
   BuilderSuggestionsResponseBodySchema,
+  GEMINI_2_FLASH_LITE_MODEL_CONFIG,
   getLargeWhitelistedModel,
   getSmallWhitelistedModel,
   InternalPostBuilderSuggestionsRequestBodySchema,
@@ -57,7 +58,7 @@ async function handler(
           model = getLargeWhitelistedModel(owner);
           break;
         case "autocompletion":
-          model = getLargeWhitelistedModel(owner);
+          model = GEMINI_2_FLASH_LITE_MODEL_CONFIG; //getLargeWhitelistedModel(owner);
           break;
         case "name":
         case "description":

--- a/front/types/api/internal/assistant.ts
+++ b/front/types/api/internal/assistant.ts
@@ -199,7 +199,9 @@ export const InternalPostBuilderSuggestionsRequestBodySchema = t.union([
   t.type({
     type: t.literal("autocompletion"),
     inputs: t.type({
+      description: t.union([t.null, t.string]),
       instructions: t.string,
+      name: t.union([t.null, t.string]),
       tools: t.array(t.type({ name: t.string, description: t.string })),
     }),
   }),

--- a/front/types/api/internal/assistant.ts
+++ b/front/types/api/internal/assistant.ts
@@ -197,6 +197,13 @@ export const InternalPostBuilderSuggestionsRequestBodySchema = t.union([
     inputs: t.type({ instructions: t.string }),
   }),
   t.type({
+    type: t.literal("autocompletion"),
+    inputs: t.type({
+      instructions: t.string,
+      tools: t.array(t.type({ name: t.string, description: t.string })),
+    }),
+  }),
+  t.type({
     type: t.literal("instructions"),
     inputs: t.type({
       current_instructions: t.string,

--- a/front/types/shared/feature_flags.ts
+++ b/front/types/shared/feature_flags.ts
@@ -8,6 +8,9 @@ export const WHITELISTABLE_FEATURES_CONFIG = {
   agent_builder_v2: {
     description: "Version 2 of the agent builder interface",
   },
+  agent_builder_instructions_autocomplete: {
+    description: "Autocomplete feature for agent builder instructions",
+  },
   claude_4_opus_feature: {
     description: "Access to Claude 4 Opus model",
   },

--- a/sdks/js/src/types.ts
+++ b/sdks/js/src/types.ts
@@ -735,6 +735,7 @@ const WhitelistableFeaturesSchema = FlexibleEnumSchema<
   | "advanced_notion_management"
   | "advanced_search"
   | "agent_builder_v2"
+  | "agent_builder_instructions_autocomplete"
   | "claude_4_opus_feature"
   | "co_edition"
   | "deepseek_feature"


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
This PR adds auto completion on the legacy agent builder instructions editor. The goal is to provide as you write instructions for your agent, suggestions to help you improve your agent. This ends up being pretty slow for a few reasons:
- This is only a PoC and we don't build proper tree, so we end up fetching suggestions pretty often
- We played with smaller/faster models, but the suggestions are definitely not as good as with larger/slower models. Among things that came up: repetitions, ends up being off once instructions are already pretty bigs, ...

The current algorithm is the following:
1. If no suggestions, we wait for a character before fetching suggestions from the remote
2. Once we have local suggestions, try to leverage them as much as possible
  i. If none match, request more suggestions, preserve older suggestions in the storage in case, user hits backspace
  ii. If one matches, try to stick to it as much as possible
  
To achieve this in a "smooth" way we normalize spaces and carriage returns to avoid re-computing suggestions.

The suggestions proposed here can be used by the user by hitting tab.

All of this is gated behind a FF. The goal is to play a bit with it in production see if any value can come from this approach.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
