### PR TITLE
[front] fix: connector tree parent selection

### DIFF
--- a/front/components/data_source/ConnectorPermissionsModal.tsx
+++ b/front/components/data_source/ConnectorPermissionsModal.tsx
@@ -618,6 +618,13 @@ export function ConnectorPermissionsModal({
     dataSource.connectorProvider === "notion" &&
     featureFlags.includes("advanced_notion_management");
 
+  const getNodeParents = (node: ContentNodeWithParent) => {
+    if (node.parentInternalId) {
+      return [node.parentInternalId];
+    }
+    return node.parentInternalIds ?? [];
+  };
+
   const initialTreeSelectionModel = useMemo(
     () =>
       allSelectedResources.reduce<
@@ -628,7 +635,7 @@ export function ConnectorPermissionsModal({
           [r.internalId]: {
             isSelected: true,
             node: r,
-            parents: r.parentInternalIds ?? [],
+            parents: getNodeParents(r),
           },
         }),
         {}


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

closes https://github.com/dust-tt/tasks/issues/3244#issuecomment-3048787551
this PR allows to bring up a level the checkedState of the nodes. if a children is selected => parent is partially selected.

<img width="705" alt="Capture d’écran 2025-07-08 à 15 08 55" src="https://github.com/user-attachments/assets/b42864e1-2471-472e-965a-3fb078df6b64" />

we have no way to have context on the whole tree apart from changing the way we store the data in connectors, or fetching the all connector and rebuilding the tree from the ground up, so it's not possible to bubble it back all the way up without circumvoluted solutions

this is best effort, 80

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

tested by hand, works

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

low risks

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->

deploy front