### PR TITLE
Fix table name in migration (missing s)

### DIFF
--- a/front/migrations/db/migration_302.sql
+++ b/front/migrations/db/migration_302.sql
@@ -1,2 +1,2 @@
-DROP TABLE IF EXISTS agent_dust_app_run_action;
-DROP TABLE IF EXISTS agent_dust_app_run_configuration;
+DROP TABLE IF EXISTS agent_dust_app_run_actions;
+DROP TABLE IF EXISTS agent_dust_app_run_configurations;


### PR DESCRIPTION
## Description

Missed the s in the table name. 
Was not ran yet on prod. 

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

Merge and run migration