### PR TITLE
[front] Bump page size in `SpaceDataSourceViewContentList`

### DIFF
--- a/front/components/spaces/SpaceDataSourceViewContentList.tsx
+++ b/front/components/spaces/SpaceDataSourceViewContentList.tsx
@@ -66,7 +66,7 @@ import type {
 import { isValidContentNodesViewType } from "@app/types";
 
 const DEFAULT_VIEW_TYPE = "all";
-const PAGE_SIZE = 25;
+const PAGE_SIZE = 100;
 
 type RowData = DataSourceViewContentNode & {
   icon: React.ComponentType;


### PR DESCRIPTION
## Description

- This PR bumps the page size in `SpaceDataSourceViewContentList` from 25 to 100 following discussions in [this thread](https://dust4ai.slack.com/archives/C066R3PMUAU/p1751980427092779).
- Note: it completely beats the purpose of having a DataTable (it won't fit in a screen unless we zoom out by ~a lot), an actual solution that was proposed was to have infinite scroll instead, but won't fight it.

## Tests

- Checked locally.

## Risk

- None.

## Deploy Plan

- Deploy front.
