### PR TITLE
[front] fix(delete-ws): Remove wrong offset when deleting Runs

### DIFF
--- a/front/lib/resources/run_resource.ts
+++ b/front/lib/resources/run_resource.ts
@@ -119,7 +119,6 @@ export class RunResource extends BaseResource<RunModel> {
     workspace: LightWorkspaceType,
     options?: Pick<FetchRunOptions<boolean>, "since">
   ) {
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars -- Disabled error for unused includeDeleted
     const { where } = this.getOptions(options);
 
     return this.model.count({

--- a/front/poke/temporal/activities.ts
+++ b/front/poke/temporal/activities.ts
@@ -375,10 +375,7 @@ export async function deleteRunOnDustAppsActivity({
   let deletedRuns = 0;
 
   // Fetch the total of runs to fetch to max end to not go over.
-  const totalRunsToFetch = await RunResource.countByWorkspace(workspace, {
-    // We want to fetch ALL runs, not just the one created after the cutoff date
-    cutoffDays: false,
-  });
+  const totalRunsToFetch = await RunResource.countByWorkspace(workspace);
   hardDeleteLogger.info(
     { totalRuns: totalRunsToFetch },
     "Numbers of runs to be deleted"
@@ -387,8 +384,6 @@ export async function deleteRunOnDustAppsActivity({
   do {
     const runs = await RunResource.listByWorkspace(workspace, {
       includeApp: true,
-      // We want to fetch ALL runs, not just the one created after the cutoff date
-      cutoffDays: false,
       limit: BATCH_SIZE,
       order: [["createdAt", "ASC"]],
     });

--- a/front/poke/temporal/activities.ts
+++ b/front/poke/temporal/activities.ts
@@ -389,7 +389,7 @@ export async function deleteRunOnDustAppsActivity({
     });
 
     hardDeleteLogger.info(
-      { batchSize: runs.length, currentOffset: deletedRuns },
+      { batchSize: runs.length, deletedRuns },
       "Processing batch of runs"
     );
 

--- a/front/poke/temporal/activities.ts
+++ b/front/poke/temporal/activities.ts
@@ -376,7 +376,8 @@ export async function deleteRunOnDustAppsActivity({
 
   // Fetch the total of runs to fetch to max end to not go over.
   const totalRunsToFetch = await RunResource.countByWorkspace(workspace, {
-    skipCutoffDate: true,
+    // We want to fetch ALL runs, not just the one created after the cutoff date
+    cutoffDays: false,
   });
   hardDeleteLogger.info(
     { totalRuns: totalRunsToFetch },
@@ -387,7 +388,7 @@ export async function deleteRunOnDustAppsActivity({
     const runs = await RunResource.listByWorkspace(workspace, {
       includeApp: true,
       // We want to fetch ALL runs, not just the one created after the cutoff date
-      skipCutoffDate: true,
+      cutoffDays: false,
       limit: BATCH_SIZE,
       order: [["createdAt", "ASC"]],
     });

--- a/front/poke/temporal/activities.ts
+++ b/front/poke/temporal/activities.ts
@@ -372,7 +372,7 @@ export async function deleteRunOnDustAppsActivity({
   }
 
   const BATCH_SIZE = 10_000;
-  let currentOffset = 0;
+  let deletedRuns = 0;
 
   // Fetch the total of runs to fetch to max end to not go over.
   const totalRunsToFetch = await RunResource.countByWorkspace(workspace, {
@@ -389,12 +389,11 @@ export async function deleteRunOnDustAppsActivity({
       // We want to fetch ALL runs, not just the one created after the cutoff date
       skipCutoffDate: true,
       limit: BATCH_SIZE,
-      offset: currentOffset,
       order: [["createdAt", "ASC"]],
     });
 
     hardDeleteLogger.info(
-      { batchSize: runs.length, currentOffset },
+      { batchSize: runs.length, currentOffset: deletedRuns },
       "Processing batch of runs"
     );
 
@@ -421,8 +420,8 @@ export async function deleteRunOnDustAppsActivity({
     if (runs.length < BATCH_SIZE) {
       break;
     }
-    currentOffset += runs.length;
-  } while (currentOffset <= totalRunsToFetch);
+    deletedRuns += runs.length;
+  } while (deletedRuns <= totalRunsToFetch);
 }
 
 export const deleteRemoteMCPServersActivity = async ({

--- a/front/temporal/hard_delete/utils.ts
+++ b/front/temporal/hard_delete/utils.ts
@@ -12,7 +12,7 @@ export function getPurgeRunExecutionsScheduleId() {
   return "purge-run-executions-schedule";
 }
 
-const RUN_EXECUTIONS_RETENTION_DAYS_THRESHOLD = 30;
+export const RUN_EXECUTIONS_RETENTION_DAYS_THRESHOLD = 30;
 
 export function getRunExecutionsDeletionCutoffDate(): number {
   const cutoffDate = new Date();


### PR DESCRIPTION
## Description
- Related to https://github.com/dust-tt/tasks/issues/3249
- Fix from following comment: https://github.com/dust-tt/dust/pull/14163#discussion_r2191748778
- Having an offset when deleting rows is wrong. As the rows get deleted and the offset increase, it gets to the end much faster. Making the query at some point return 0 rows even though it should returns some.
- In addition, following up on https://github.com/dust-tt/dust/pull/14157#discussion_r2190836812 , for `listByWorkspace` and `countByWorkspace`, use a `since` attribute instead of the implicit  cutoff date.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk
- Low, deletion workflow only

## Deploy Plan
- Deploy front.
