### PR TITLE
[front] - feat(AB v2): performance tab

### DIFF
--- a/front/components/agent_builder/AgentBuilder.tsx
+++ b/front/components/agent_builder/AgentBuilder.tsx
@@ -16,13 +16,20 @@ import { FormProvider } from "@app/components/sparkle/FormProvider";
 import { useSendNotification } from "@app/hooks/useNotification";
 import { useFeatureFlags } from "@app/lib/swr/workspaces";
 import logger from "@app/logger/logger";
+import type { AgentConfigurationType } from "@app/types";
 import {
   EXTENDED_MAX_STEPS_USE_PER_RUN_LIMIT,
   GPT_4O_MODEL_CONFIG,
   MAX_STEPS_USE_PER_RUN_LIMIT,
 } from "@app/types";
 
-export default function AgentBuilder() {
+interface AgentBuilderProps {
+  agentConfiguration?: AgentConfigurationType;
+}
+
+export default function AgentBuilder({
+  agentConfiguration,
+}: AgentBuilderProps) {
   const { owner, user, supportedDataSourceViews } = useAgentBuilderContext();
   const { mcpServerViews } = useMCPServerViewsContext();
   const router = useRouter();
@@ -120,7 +127,9 @@ export default function AgentBuilder() {
             isSaving={form.formState.isSubmitting}
           />
         }
-        rightPanel={<AgentBuilderRightPanel />}
+        rightPanel={
+          <AgentBuilderRightPanel agentConfiguration={agentConfiguration} />
+        }
       />
     </FormProvider>
   );

--- a/front/components/agent_builder/AgentBuilderPerformance.tsx
+++ b/front/components/agent_builder/AgentBuilderPerformance.tsx
@@ -1,0 +1,214 @@
+import {
+  Avatar,
+  Button,
+  CardGrid,
+  ChatBubbleLeftRightIcon,
+  ChatBubbleThoughtIcon,
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+  HandThumbDownIcon,
+  HandThumbUpIcon,
+  Page,
+  Spinner,
+  ValueCard,
+} from "@dust-tt/sparkle";
+import { useState } from "react";
+
+import { useAgentBuilderContext } from "@app/components/agent_builder/AgentBuilderContext";
+import { FeedbacksSection } from "@app/components/assistant_builder/FeedbacksSection";
+import { useAgentAnalytics } from "@app/lib/swr/assistants";
+import type { AgentConfigurationType } from "@app/types";
+import { removeNulls } from "@app/types";
+
+const PERIODS = [
+  { value: 7, label: "Last 7 days" },
+  { value: 15, label: "Last 15 days" },
+  { value: 30, label: "Last 30 days" },
+];
+
+const DEFAULT_PERIOD_VALUE = 30;
+
+function NoAgentState() {
+  return (
+    <div className="flex h-full min-h-0 items-center justify-center">
+      <div className="px-4 text-center">
+        <div className="mb-2 text-lg font-medium text-foreground">
+          No Performance Data Available
+        </div>
+        <div className="max-w-sm text-muted-foreground">
+          Performance metrics will be available after your agent is created and
+          used in conversations.
+        </div>
+      </div>
+    </div>
+  );
+}
+
+interface AgentBuilderPerformanceProps {
+  agentConfiguration?: AgentConfigurationType;
+}
+
+export function AgentBuilderPerformance({
+  agentConfiguration,
+}: AgentBuilderPerformanceProps) {
+  const { owner } = useAgentBuilderContext();
+  const [period, setPeriod] = useState(DEFAULT_PERIOD_VALUE);
+
+  const { agentAnalytics, isAgentAnalyticsLoading } = useAgentAnalytics({
+    workspaceId: owner.sId,
+    agentConfigurationId: agentConfiguration?.sId || null,
+    period,
+  });
+
+  if (!agentConfiguration) {
+    return <NoAgentState />;
+  }
+
+  return (
+    <div className="flex h-full flex-col space-y-4">
+      <div className="flex flex-row items-center justify-between gap-3">
+        <Page.H variant="h5">Analytics</Page.H>
+        <div className="self-end">
+          <DropdownMenu>
+            <DropdownMenuTrigger asChild>
+              <Button
+                label={PERIODS.find((p) => p.value === period)?.label}
+                variant="outline"
+                isSelect
+              />
+            </DropdownMenuTrigger>
+            <DropdownMenuContent>
+              {PERIODS.map((p) => (
+                <DropdownMenuItem
+                  key={p.value}
+                  label={p.label}
+                  onClick={() => {
+                    setPeriod(p.value);
+                  }}
+                />
+              ))}
+            </DropdownMenuContent>
+          </DropdownMenu>
+        </div>
+      </div>
+
+      {isAgentAnalyticsLoading ? (
+        <div className="w-full p-6">
+          <Spinner variant="dark" />
+        </div>
+      ) : (
+        <CardGrid>
+          <ValueCard
+            title="Active Users"
+            content={
+              <div className="heading-lg text-foreground dark:text-foreground-night">
+                <div className="heading-lg flex flex-col gap-1">
+                  {agentAnalytics?.users ? (
+                    <>
+                      <div className="truncate text-foreground dark:text-foreground-night">
+                        {agentAnalytics.users.length}
+                      </div>
+
+                      <Avatar.Stack
+                        size="md"
+                        hasMagnifier={false}
+                        avatars={removeNulls(
+                          agentAnalytics.users.map((top) => top.user)
+                        )
+                          .slice(0, 5)
+                          .map((user) => ({
+                            size: "sm",
+                            name: user.fullName,
+                            visual: user.image,
+                          }))}
+                      />
+                    </>
+                  ) : (
+                    "-"
+                  )}
+                </div>
+              </div>
+            }
+            className="h-32"
+          />
+
+          <ValueCard
+            title="Reactions"
+            content={
+              <div className="heading-lg flex flex-row gap-2">
+                {agentConfiguration.scope !== "global" &&
+                agentAnalytics?.feedbacks ? (
+                  <>
+                    <div className="flex flex-row items-center">
+                      <div>
+                        <HandThumbUpIcon className="h-6 w-6 pr-2 text-muted-foreground dark:text-muted-foreground-night" />
+                      </div>
+                      <div>{agentAnalytics.feedbacks.positiveFeedbacks}</div>
+                    </div>
+                    <div className="flex flex-row items-center">
+                      <div>
+                        <HandThumbDownIcon className="h-6 w-6 pr-2 text-muted-foreground dark:text-muted-foreground-night" />
+                      </div>
+                      <div>{agentAnalytics.feedbacks.negativeFeedbacks}</div>
+                    </div>
+                  </>
+                ) : (
+                  "-"
+                )}
+              </div>
+            }
+            className="h-32"
+          />
+          <ValueCard
+            title="Conversations"
+            content={
+              <div className="heading-lg flex flex-row gap-2">
+                <div className="flex flex-row items-center">
+                  <div>
+                    <ChatBubbleLeftRightIcon className="h-6 w-6 pr-2 text-muted-foreground dark:text-muted-foreground-night" />
+                  </div>
+                  <div>
+                    {agentAnalytics?.mentions
+                      ? `${agentAnalytics.mentions.conversationCount}`
+                      : "-"}
+                  </div>
+                </div>
+              </div>
+            }
+            className="h-32"
+          />
+          <ValueCard
+            title="Messages"
+            content={
+              <div className="heading-lg flex flex-row gap-2">
+                <div className="flex flex-row items-center">
+                  <div>
+                    <ChatBubbleThoughtIcon className="h-6 w-6 pr-2 text-muted-foreground dark:text-muted-foreground-night" />
+                  </div>
+                  <div>
+                    {agentAnalytics?.mentions
+                      ? `${agentAnalytics.mentions.messageCount}`
+                      : "-"}
+                  </div>
+                </div>
+              </div>
+            }
+            className="h-32"
+          />
+        </CardGrid>
+      )}
+      {agentConfiguration.scope !== "global" && (
+        <div className="flex-1 overflow-y-auto">
+          <Page.SectionHeader title="Feedback" />
+          <FeedbacksSection
+            owner={owner}
+            agentConfigurationId={agentConfiguration.sId}
+            gridMode={false}
+          />
+        </div>
+      )}
+    </div>
+  );
+}

--- a/front/components/agent_builder/AgentBuilderPerformance.tsx
+++ b/front/components/agent_builder/AgentBuilderPerformance.tsx
@@ -26,9 +26,10 @@ const PERIODS = [
   { value: 7, label: "Last 7 days" },
   { value: 15, label: "Last 15 days" },
   { value: 30, label: "Last 30 days" },
-];
+] as const;
 
-const DEFAULT_PERIOD_VALUE = 30;
+type PeriodValue = (typeof PERIODS)[number]["value"];
+const DEFAULT_PERIOD_VALUE: PeriodValue = 30;
 
 function NoAgentState() {
   return (

--- a/front/components/agent_builder/AgentBuilderRightPanel.tsx
+++ b/front/components/agent_builder/AgentBuilderRightPanel.tsx
@@ -11,11 +11,10 @@ import {
 } from "@dust-tt/sparkle";
 import React, { useContext, useState } from "react";
 
+import { AgentBuilderContext } from "@app/components/agent_builder/AgentBuilderContext";
+import { AgentBuilderPerformance } from "@app/components/agent_builder/AgentBuilderPerformance";
+import { AgentBuilderPreview } from "@app/components/agent_builder/AgentBuilderPreview";
 import type { AgentConfigurationType } from "@app/types";
-
-import { AgentBuilderContext } from "./AgentBuilderContext";
-import { AgentBuilderPerformance } from "./AgentBuilderPerformance";
-import { AgentBuilderPreview } from "./AgentBuilderPreview";
 
 type AgentBuilderRightPanelTabType = "testing" | "performance";
 

--- a/front/components/agent_builder/AgentBuilderRightPanel.tsx
+++ b/front/components/agent_builder/AgentBuilderRightPanel.tsx
@@ -1,6 +1,7 @@
 import {
   BarChartIcon,
   Button,
+  ScrollArea,
   SidebarRightCloseIcon,
   SidebarRightOpenIcon,
   Tabs,
@@ -8,10 +9,12 @@ import {
   TabsTrigger,
   TestTubeIcon,
 } from "@dust-tt/sparkle";
-import { ScrollArea } from "@dust-tt/sparkle";
 import React, { useContext, useState } from "react";
 
+import type { AgentConfigurationType } from "@app/types";
+
 import { AgentBuilderContext } from "./AgentBuilderContext";
+import { AgentBuilderPerformance } from "./AgentBuilderPerformance";
 import { AgentBuilderPreview } from "./AgentBuilderPreview";
 
 type AgentBuilderRightPanelTabType = "testing" | "performance";
@@ -103,9 +106,13 @@ function CollapsedTabs({ onTabSelect }: CollapsedTabsProps) {
 
 interface ExpandedContentProps {
   selectedTab: AgentBuilderRightPanelTabType;
+  agentConfiguration?: AgentConfigurationType;
 }
 
-function ExpandedContent({ selectedTab }: ExpandedContentProps) {
+function ExpandedContent({
+  selectedTab,
+  agentConfiguration,
+}: ExpandedContentProps) {
   return (
     <div className="flex min-h-0 flex-1 flex-col">
       {selectedTab === "testing" && (
@@ -115,14 +122,20 @@ function ExpandedContent({ selectedTab }: ExpandedContentProps) {
       )}
       {selectedTab === "performance" && (
         <div className="flex-1 overflow-y-auto p-4">
-          <div className="space-y-4">Performance</div>
+          <AgentBuilderPerformance agentConfiguration={agentConfiguration} />
         </div>
       )}
     </div>
   );
 }
 
-export function AgentBuilderRightPanel() {
+interface AgentBuilderRightPanelProps {
+  agentConfiguration?: AgentConfigurationType;
+}
+
+export function AgentBuilderRightPanel({
+  agentConfiguration,
+}: AgentBuilderRightPanelProps) {
   const { isPreviewPanelOpen, setIsPreviewPanelOpen } =
     useContext(AgentBuilderContext);
   const [selectedTab, setSelectedTab] =
@@ -150,7 +163,10 @@ export function AgentBuilderRightPanel() {
         onTabChange={handleTabChange}
       />
       {isPreviewPanelOpen ? (
-        <ExpandedContent selectedTab={selectedTab} />
+        <ExpandedContent
+          selectedTab={selectedTab}
+          agentConfiguration={agentConfiguration}
+        />
       ) : (
         <CollapsedTabs onTabSelect={handleTabSelect} />
       )}

--- a/front/components/assistant/AssistantDetailsPerformance.tsx
+++ b/front/components/assistant/AssistantDetailsPerformance.tsx
@@ -38,7 +38,7 @@ export function AssistantDetailsPerformance({
   gridMode,
 }: AssistantDetailsPerformanceProps) {
   const [period, setPeriod] = useState(30);
-  const { agentAnalytics, isAgentAnayticsLoading } = useAgentAnalytics({
+  const { agentAnalytics, isAgentAnalyticsLoading } = useAgentAnalytics({
     workspaceId: owner.sId,
     agentConfigurationId: agentConfiguration.sId,
     period,

--- a/front/components/assistant/AssistantDetailsPerformance.tsx
+++ b/front/components/assistant/AssistantDetailsPerformance.tsx
@@ -72,7 +72,7 @@ export function AssistantDetailsPerformance({
         </div>
       </div>
 
-      {isAgentAnayticsLoading ? (
+      {isAgentAnalyticsLoading ? (
         <div className="w-full p-6">
           <Spinner variant="dark" />
         </div>

--- a/front/lib/swr/assistants.ts
+++ b/front/lib/swr/assistants.ts
@@ -417,8 +417,8 @@ export function useAgentAnalytics({
 
   return {
     agentAnalytics: data ? data : null,
-    isAgentAnayticsLoading: !error && !data && !disabled,
-    isAgentAnayticsError: error,
+    isAgentAnalyticsLoading: !error && !data && !disabled,
+    isAgentAnalyticsError: error,
   };
 }
 


### PR DESCRIPTION
## Description

This PR adds a performance analytics tab to the Agent Builder v2 interface, displaying key metrics about agent usage including active users, reactions (thumbs up/down), conversation counts and message counts. The tab includes a period selector (7/15/30 days) and a feedback section for detailed user reactions.

**References:**
- https://github.com/dust-tt/tasks/issues/3373

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
