### PR TITLE
[front] Remove workspace name from action logging

### DIFF
--- a/front/lib/actions/mcp_internal_actions/wrappers.ts
+++ b/front/lib/actions/mcp_internal_actions/wrappers.ts
@@ -16,7 +16,6 @@ export function withToolLogging<T>(
     const loggerArgs = {
       workspace: {
         sId: owner.sId,
-        name: owner.name,
         plan_code: auth.plan()?.code || null,
       },
       toolName,

--- a/front/lib/actions/mcp_internal_actions/wrappers.ts
+++ b/front/lib/actions/mcp_internal_actions/wrappers.ts
@@ -27,7 +27,6 @@ export function withToolLogging<T>(
     const tags = [
       `action:${toolName}`,
       `workspace:${owner.sId}`,
-      `workspace_name:${owner.name}`,
       `workspace_plan_code:${auth.plan()?.code || null}`,
     ];
 


### PR DESCRIPTION
## Description

- This PR removes the workspace name from the `use_actions.count` and `use_actions_error.count` metrics + the associated logs.
- We already have the workspace ID there, and there's a 1-1 mapping between the two.
- The plan code is kept, in case we need to plot usage by plan (initial PR https://github.com/dust-tt/dust/pull/2509).

## Tests

## Risk

- Low, no dashboard/notebook relying on it.

## Deploy Plan

- Deploy front.
