### PR TITLE
Fix workspace usage query

### DIFF
--- a/front/lib/workspace_usage.ts
+++ b/front/lib/workspace_usage.ts
@@ -135,16 +135,12 @@ export async function unsafeGetUsageData(
         COALESCE(ac."sId", am."agentConfigurationId") AS "assistantId",
         COALESCE(ac."name", am."agentConfigurationId") AS "assistantName",
         CASE
-            WHEN COUNT(DISTINCT arc."id") > 0 AND COUNT(DISTINCT atqc."id") = 0 AND COUNT(DISTINCT adarc."id") = 0 AND COUNT(DISTINCT msv."id") = 0 THEN 'retrieval'
-            WHEN COUNT(DISTINCT arc."id") = 0 AND COUNT(DISTINCT atqc."id") > 0 AND COUNT(DISTINCT adarc."id") = 0 AND COUNT(DISTINCT msv."id") = 0 THEN 'tablesQuery'
-            WHEN COUNT(DISTINCT arc."id") = 0 AND COUNT(DISTINCT atqc."id") = 0 AND COUNT(DISTINCT adarc."id") > 0 AND COUNT(DISTINCT msv."id") = 0 THEN 'dustAppRun'
-            WHEN COUNT(DISTINCT arc."id") = 0 AND COUNT(DISTINCT atqc."id") = 0 AND COUNT(DISTINCT adarc."id") = 0 AND COUNT(DISTINCT msv."id") > 0 THEN 
-              CASE 
-                WHEN msv."internalMCPServerId" IN (:sids) THEN 
+            WHEN COUNT(DISTINCT msv."id") > 0 THEN
+              CASE
+                WHEN msv."internalMCPServerId" IN (:sids) THEN
                   (SELECT name FROM (SELECT unnest(ARRAY[:sids]) as sid, unnest(ARRAY[:names]) as name) as t WHERE t.sid = msv."internalMCPServerId")
                 ELSE msv."internalMCPServerId"
               END
-            WHEN COUNT(DISTINCT arc."id") + COUNT(DISTINCT atqc."id") + COUNT(DISTINCT adarc."id") + COUNT(DISTINCT msv."id") > 1 THEN 'multiActions'
             ELSE NULL
         END AS "actionType",
         um."userContextOrigin" AS "source"


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
This PR fixes https://github.com/dust-tt/tasks/issues/3437#issuecomment-3051464368.

As we started removing legacy code, we ended up breaking the raw SQL query that compute workspace usage. This PR fixes it.
Providing some colors around what this query does, it returns a result set with the following columns:
  - `createdAt`: Message creation timestamp (formatted as 'YYYY-MM-DD HH24:MI:SS')
  - `conversationInternalId`: Internal conversation ID
  - `messageId`: Message sId
  - `parentMessageId`: Parent message sId
  - `messageType`: Either 'user', 'assistant', or 'content_fragment'
  - `userFullName`: Full name from user context
  - `userEmail`: Email from user context
  - `assistantId`: Assistant configuration sId
  - `assistantName`: Assistant configuration name
  - `actionType`: Categorizes the action as 'retrieval', 'tablesQuery', 'dustAppRun', MCP server name, 'multiActions', or NULL
  - `source`: User context origin

With the recent clean up, only MCP remains, which yields any of those two values:
- Internal MCP server names - The names from `AVAILABLE_INTERNAL_MCP_SERVER_NAMES` constant
- External MCP server IDs - The raw internalMCPServerId value for MCP servers not in the predefined list

We could eventually remove the `WHEN/CASE` but the field is still nullable in DB, will keep for now.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->
Tested locally. Example:

<details>

<summary>Click to expand example</summary>

```
createdAt,conversationInternalId,messageId,parentMessageId,messageType,userFullName,userEmail,assistantId,assistantName,actionType,source
2025-07-02 11:00:44,1809,Mbnze0e5Wq,,user,Flavien David,flavien@dust.tt,,,,web
2025-07-02 09:00:37,1808,MKH271O7Pp,NlSDL1FD2y,assistant,,,LecKCGPlw4,image,image_generation,
2025-07-02 09:00:37,1808,NlSDL1FD2y,,user,Flavien David,flavien@dust.tt,,,,web
2025-07-02 08:50:52,1807,35sIyuCt5Q,zB9KwvnTRf,assistant,,,LecKCGPlw4,image,image_generation,
2025-07-02 08:50:52,1807,zB9KwvnTRf,,user,Flavien David,flavien@dust.tt,,,,web
2025-07-02 08:24:56,1806,Z2OczfIIXg,LVO25bTdDO,assistant,,,LecKCGPlw4,image,image_generation,
2025-07-01 19:17:44,1806,JDxpS0K2o4,LVO25bTdDO,assistant,,,LecKCGPlw4,image,image_generation,
2025-07-01 18:59:21,1806,d8wmGKSQRB,LVO25bTdDO,assistant,,,LecKCGPlw4,image,image_generation,
2025-07-01 17:32:53,1806,jQQ5hgjeED,LVO25bTdDO,assistant,,,LecKCGPlw4,image,image_generation,
2025-07-01 17:22:12,1806,i1jXuQpkzQ,LVO25bTdDO,assistant,,,LecKCGPlw4,image,image_generation,
2025-07-01 17:19:16,1806,bRcihvFKO1,LVO25bTdDO,assistant,,,LecKCGPlw4,image,image_generation,
2025-07-01 17:19:16,1806,LVO25bTdDO,,user,Flavien David,flavien@dust.tt,,,,web
```

</details>

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
