### PR TITLE
[front] refactor(MCP): uniformize tool error handling

### DIFF
--- a/front/lib/actions/mcp_internal_actions/servers/agent_router.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/agent_router.ts
@@ -2,6 +2,7 @@ import { DustAPI } from "@dust-tt/client";
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod";
 
+import { makeMCPToolTextError } from "@app/lib/actions/mcp_internal_actions/utils";
 import { getSuggestedAgentsForContent } from "@app/lib/api/assistant/agent_suggestion";
 import apiConfig from "@app/lib/api/config";
 import type { InternalMCPServerDefinitionType } from "@app/lib/api/mcp";
@@ -62,12 +63,7 @@ const createServer = (auth: Authenticator): McpServer => {
         view: "all",
       });
       if (res.isErr()) {
-        return {
-          isError: true,
-          content: [
-            { type: "text", text: "Error fetching agent configurations" },
-          ],
-        };
+        return makeMCPToolTextError("Error fetching agent configurations");
       }
 
       const agents = res.value;
@@ -127,12 +123,7 @@ const createServer = (auth: Authenticator): McpServer => {
         view: "all",
       });
       if (getAgentsRes.isErr()) {
-        return {
-          isError: true,
-          content: [
-            { type: "text", text: "Error fetching agent configurations" },
-          ],
-        };
+        return makeMCPToolTextError("Error fetching agent configurations");
       }
       const agents = getAgentsRes.value as LightAgentConfigurationType[];
 
@@ -142,15 +133,9 @@ const createServer = (auth: Authenticator): McpServer => {
       });
 
       if (suggestedAgentsRes.isErr()) {
-        return {
-          isError: true,
-          content: [
-            {
-              type: "text",
-              text: `Error suggesting agents: ${suggestedAgentsRes.error}`,
-            },
-          ],
-        };
+        return makeMCPToolTextError(
+          `Error suggesting agents: ${suggestedAgentsRes.error}`
+        );
       }
 
       const suggestedAgents = suggestedAgentsRes.value;

--- a/front/lib/actions/mcp_internal_actions/servers/common/find_tags_tool.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/common/find_tags_tool.ts
@@ -5,6 +5,7 @@ import { z } from "zod";
 import type { DataSourcesToolConfigurationType } from "@app/lib/actions/mcp_internal_actions/input_schemas";
 import { ConfigurableToolInputSchemas } from "@app/lib/actions/mcp_internal_actions/input_schemas";
 import { getCoreSearchArgs } from "@app/lib/actions/mcp_internal_actions/servers/utils";
+import { makeMCPToolTextError } from "@app/lib/actions/mcp_internal_actions/utils";
 import { withToolLogging } from "@app/lib/actions/mcp_internal_actions/wrappers";
 import config from "@app/lib/api/config";
 import type { Authenticator } from "@app/lib/auth";
@@ -51,10 +52,7 @@ export function makeFindTagsTool(auth: Authenticator) {
       );
 
       if (coreSearchArgsResults.some((res) => res.isErr())) {
-        return {
-          isError: true,
-          content: [{ type: "text", text: "Invalid data sources" }],
-        };
+        return makeMCPToolTextError("Invalid data sources");
       }
 
       const coreSearchArgs = removeNulls(
@@ -62,15 +60,9 @@ export function makeFindTagsTool(auth: Authenticator) {
       );
 
       if (coreSearchArgs.length === 0) {
-        return {
-          isError: true,
-          content: [
-            {
-              type: "text",
-              text: "Search action must have at least one data source configured.",
-            },
-          ],
-        };
+        return makeMCPToolTextError(
+          "Search action must have at least one data source configured."
+        );
       }
 
       const coreAPI = new CoreAPI(config.getCoreAPIConfig(), logger);
@@ -82,10 +74,7 @@ export function makeFindTagsTool(auth: Authenticator) {
       });
 
       if (result.isErr()) {
-        return {
-          isError: true,
-          content: [{ type: "text", text: "Error searching for labels" }],
-        };
+        return makeMCPToolTextError("Error searching for labels");
       }
 
       return {

--- a/front/lib/actions/mcp_internal_actions/servers/file_generation.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/file_generation.ts
@@ -5,6 +5,7 @@ import type { UploadResult } from "convertapi";
 import ConvertAPI from "convertapi";
 import { z } from "zod";
 
+import { makeMCPToolTextError } from "@app/lib/actions/mcp_internal_actions/utils";
 import type { InternalMCPServerDefinitionType } from "@app/lib/api/mcp";
 import type { Authenticator } from "@app/lib/auth";
 import { FileResource } from "@app/lib/resources/file_resource";
@@ -105,15 +106,7 @@ const createServer = (auth: Authenticator): McpServer => {
     },
     async ({ file_name, input, source_format, output_format }) => {
       if (!process.env.CONVERTAPI_API_KEY) {
-        return {
-          isError: true,
-          content: [
-            {
-              type: "text",
-              text: "Missing environment variable.",
-            },
-          ],
-        };
+        return makeMCPToolTextError("Missing environment variable.");
       }
 
       let contentType: SupportedFileContentType | null;
@@ -187,15 +180,7 @@ const createServer = (auth: Authenticator): McpServer => {
               `${file_name}.${source_format}`
             );
           } else {
-            return {
-              isError: true,
-              content: [
-                {
-                  type: "text",
-                  text: `File not found: ${input}`,
-                },
-              ],
-            };
+            return makeMCPToolTextError(`File not found: ${input}`);
           }
         } else {
           url = await convertapi.upload(
@@ -228,15 +213,9 @@ const createServer = (auth: Authenticator): McpServer => {
           content,
         };
       } catch (e) {
-        return {
-          isError: true,
-          content: [
-            {
-              type: "text",
-              text: `There was an error generating your file: ${normalizeError(e)}, maybe you can chain multiple conversions to get the result you want, pay attention to the source format you use.`,
-            },
-          ],
-        };
+        return makeMCPToolTextError(
+          `There was an error generating your file: ${normalizeError(e)}, maybe you can chain multiple conversions to get the result you want, pay attention to the source format you use.`
+        );
       }
     }
   );

--- a/front/lib/actions/mcp_internal_actions/servers/include.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/include.ts
@@ -22,6 +22,7 @@ import {
   getCoreSearchArgs,
   shouldAutoGenerateTags,
 } from "@app/lib/actions/mcp_internal_actions/servers/utils";
+import { makeMCPToolTextError } from "@app/lib/actions/mcp_internal_actions/utils";
 import { withToolLogging } from "@app/lib/actions/mcp_internal_actions/wrappers";
 import type { AgentLoopContextType } from "@app/lib/actions/types";
 import { actionRefsOffset, getRetrievalTopK } from "@app/lib/actions/utils";
@@ -207,27 +208,13 @@ function createServer(
     );
 
     if (searchResults.isErr()) {
-      return {
-        isError: true,
-        content: [
-          {
-            type: "text",
-            text: searchResults.error.message,
-          },
-        ],
-      };
+      return makeMCPToolTextError(searchResults.error.message);
     }
 
     if (refsOffset + topK > getRefs().length) {
-      return {
-        isError: true,
-        content: [
-          {
-            type: "text",
-            text: "The inclusion exhausted the total number of references available for citations",
-          },
-        ],
-      };
+      return makeMCPToolTextError(
+        "The inclusion exhausted the total number of references available for citations"
+      );
     }
 
     const refs = getRefs().slice(refsOffset, refsOffset + topK);

--- a/front/lib/actions/mcp_internal_actions/servers/missing_action_catcher.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/missing_action_catcher.ts
@@ -1,5 +1,6 @@
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 
+import { makeMCPToolTextError } from "@app/lib/actions/mcp_internal_actions/utils";
 import type { AgentLoopContextType } from "@app/lib/actions/types";
 import type { InternalMCPServerDefinitionType } from "@app/lib/api/mcp";
 import type { Authenticator } from "@app/lib/auth";
@@ -28,20 +29,13 @@ const createServer = (
     }
 
     server.tool(actionName, "", {}, async () => {
-      return {
-        isError: true,
-        content: [
-          {
-            type: "text",
-            text:
-              `Tool "${actionName}" not found. ` +
-              "This answer to the function call is a catch-all. " +
-              "Please verify that the function name is correct : " +
-              "pay attention to case sensitivity and separators between words in the name. " +
-              "It's safe to retry automatically with another name.",
-          },
-        ],
-      };
+      return makeMCPToolTextError(
+        `Tool "${actionName}" not found. ` +
+          "This answer to the function call is a catch-all. " +
+          "Please verify that the function name is correct : " +
+          "pay attention to case sensitivity and separators between words in the name. " +
+          "It's safe to retry automatically with another name."
+      );
     });
   } else {
     server.tool(

--- a/front/lib/actions/mcp_internal_actions/servers/process/index.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/process/index.ts
@@ -508,6 +508,7 @@ function processToolError({
     "Error running process"
   );
   return {
+    isError: true,
     content: [
       {
         type: "text" as const,
@@ -517,7 +518,6 @@ function processToolError({
         text: `${errorMessage}: ${errorDetails}`,
       },
     ],
-    isError: true,
   };
 }
 

--- a/front/lib/actions/mcp_internal_actions/servers/process/index.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/process/index.ts
@@ -24,6 +24,7 @@ import {
   getDataSourceConfiguration,
   shouldAutoGenerateTags,
 } from "@app/lib/actions/mcp_internal_actions/servers/utils";
+import { makeMCPToolTextError } from "@app/lib/actions/mcp_internal_actions/utils";
 import { withToolLogging } from "@app/lib/actions/mcp_internal_actions/wrappers";
 import { runActionStreamed } from "@app/lib/actions/server";
 import type {
@@ -507,18 +508,11 @@ function processToolError({
     },
     "Error running process"
   );
-  return {
-    isError: true,
-    content: [
-      {
-        type: "text" as const,
-        created: Date.now(),
-        workspaceId: conversation.owner.sId,
-        conversationId: conversation.sId,
-        text: `${errorMessage}: ${errorDetails}`,
-      },
-    ],
-  };
+  return makeMCPToolTextError(`${errorMessage}: ${errorDetails}`, {
+    created: Date.now(),
+    workspaceId: conversation.owner.sId,
+    conversationId: conversation.sId,
+  });
 }
 
 async function generateProcessToolOutput({

--- a/front/lib/actions/mcp_internal_actions/servers/run_agent.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/run_agent.ts
@@ -153,17 +153,7 @@ export default async function createServer(
         childAgent:
           ConfigurableToolInputSchemas[INTERNAL_MIME_TYPES.TOOL_INPUT.AGENT],
       },
-      async () => {
-        return {
-          isError: true,
-          content: [
-            {
-              type: "text",
-              text: "No child agent configured",
-            },
-          ],
-        };
-      }
+      async () => makeMCPToolTextError("No child agent configured")
     );
     return server;
   }

--- a/front/lib/actions/mcp_internal_actions/servers/search.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/search.ts
@@ -18,6 +18,7 @@ import {
   getCoreSearchArgs,
 } from "@app/lib/actions/mcp_internal_actions/servers/utils";
 import { shouldAutoGenerateTags } from "@app/lib/actions/mcp_internal_actions/servers/utils";
+import { makeMCPToolTextError } from "@app/lib/actions/mcp_internal_actions/utils";
 import { withToolLogging } from "@app/lib/actions/mcp_internal_actions/wrappers";
 import type { AgentLoopContextType } from "@app/lib/actions/types";
 import { actionRefsOffset, getRetrievalTopK } from "@app/lib/actions/utils";
@@ -113,15 +114,9 @@ export async function searchFunction({
   );
 
   if (coreSearchArgs.length === 0) {
-    return {
-      isError: true,
-      content: [
-        {
-          type: "text",
-          text: "Search action must have at least one data source configured.",
-        },
-      ],
-    };
+    return makeMCPToolTextError(
+      "Search action must have at least one data source configured."
+    );
   }
 
   const conflictingTagsError = checkConflictingTags(coreSearchArgs, {
@@ -170,27 +165,13 @@ export async function searchFunction({
   );
 
   if (searchResults.isErr()) {
-    return {
-      isError: true,
-      content: [
-        {
-          type: "text",
-          text: searchResults.error.message,
-        },
-      ],
-    };
+    return makeMCPToolTextError(searchResults.error.message);
   }
 
   if (refsOffset + topK > getRefs().length) {
-    return {
-      isError: true,
-      content: [
-        {
-          type: "text",
-          text: "The search exhausted the total number of references available for citations",
-        },
-      ],
-    };
+    return makeMCPToolTextError(
+      "The search exhausted the total number of references available for citations"
+    );
   }
 
   const refs = getRefs().slice(refsOffset, refsOffset + topK);

--- a/front/lib/actions/mcp_internal_actions/servers/webtools.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/webtools.ts
@@ -10,6 +10,7 @@ import type {
   BrowseResultResourceType,
   WebsearchResultResourceType,
 } from "@app/lib/actions/mcp_internal_actions/output_schemas";
+import { makeMCPToolTextError } from "@app/lib/actions/mcp_internal_actions/utils";
 import type { AgentLoopContextType } from "@app/lib/actions/types";
 import { actionRefsOffset } from "@app/lib/actions/utils";
 import { getWebsearchNumResults } from "@app/lib/actions/utils";
@@ -76,15 +77,9 @@ const createServer = (agentLoopContext?: AgentLoopContextType): McpServer => {
       });
 
       if (websearchRes.isErr()) {
-        return {
-          isError: true,
-          content: [
-            {
-              type: "text",
-              text: `Failed to search: ${websearchRes.error.message}`,
-            },
-          ],
-        };
+        return makeMCPToolTextError(
+          `Failed to search: ${websearchRes.error.message}`
+        );
       }
 
       const refsOffset = actionRefsOffset({

--- a/front/lib/actions/mcp_internal_actions/utils.ts
+++ b/front/lib/actions/mcp_internal_actions/utils.ts
@@ -12,13 +12,22 @@ import type {
  * Do not use if the intent is to show an issue to the agent as part of a normal tool execution,
  * only use if the error should be logged and tracked.
  */
-export function makeMCPToolTextError(text: string): {
+export function makeMCPToolTextError(
+  text: string,
+  metadata: Record<string, boolean | number | string> = {}
+): {
   isError: true;
   content: [TextContent];
 } {
   return {
     isError: true,
-    content: [{ type: "text", text }],
+    content: [
+      {
+        type: "text",
+        ...metadata,
+        text,
+      },
+    ],
   };
 }
 

--- a/front/lib/actions/mcp_internal_actions/utils.ts
+++ b/front/lib/actions/mcp_internal_actions/utils.ts
@@ -3,6 +3,8 @@ import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
 /**
  * Error tool result. This won't fail in the agent loop but will be logged.
  * The text will be shown to the model.
+ * The error will be logged by the wrapper `withToolLogging` and the error message will be shown
+ * in the logs to help debugging it.
  *
  * Do not use if the intent is to show an issue to the agent as part of a normal tool execution,
  * only use if the error should be logged and tracked.

--- a/front/lib/actions/mcp_internal_actions/utils.ts
+++ b/front/lib/actions/mcp_internal_actions/utils.ts
@@ -1,4 +1,7 @@
-import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
+import type {
+  CallToolResult,
+  TextContent,
+} from "@modelcontextprotocol/sdk/types.js";
 
 /**
  * Error tool result. This won't fail in the agent loop but will be logged.
@@ -9,7 +12,10 @@ import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
  * Do not use if the intent is to show an issue to the agent as part of a normal tool execution,
  * only use if the error should be logged and tracked.
  */
-export function makeMCPToolTextError(text: string): CallToolResult {
+export function makeMCPToolTextError(text: string): {
+  isError: true;
+  content: [TextContent];
+} {
   return {
     isError: true,
     content: [{ type: "text", text }],
@@ -22,9 +28,10 @@ export function makeMCPToolTextError(text: string): CallToolResult {
  * Use this if the intent is to show an issue to the agent that does not need logging
  * and is part of a normal tool execution.
  */
-export function makeMCPToolRecoverableErrorSuccess(
-  errorText: string
-): CallToolResult {
+export function makeMCPToolRecoverableErrorSuccess(errorText: string): {
+  isError: false;
+  content: [TextContent];
+} {
   return {
     isError: false,
     content: [{ type: "text", text: errorText }],

--- a/front/lib/actions/mcp_internal_actions/utils.ts
+++ b/front/lib/actions/mcp_internal_actions/utils.ts
@@ -4,10 +4,9 @@ import type {
 } from "@modelcontextprotocol/sdk/types.js";
 
 /**
- * Error tool result. This won't fail in the agent loop but will be logged.
- * The text will be shown to the model.
- * The error will be logged by the wrapper `withToolLogging` and the error message will be shown
- * in the logs to help debugging it.
+ * Error tool result. Does not fail the agent loop (the text is shown to the model) but is logged.
+ * If the tool callback is wrapped by `withToolLogging`, the error will be tracked and the error
+ * message will be shown in the logs to help debugging it.
  *
  * Do not use if the intent is to show an issue to the agent as part of a normal tool execution,
  * only use if the error should be logged and tracked.


### PR DESCRIPTION
## Description

- After the addition of a monitor on tool errors, we want to make it very explicit what is considered as a tool error and thus triggers the new monitor.
- This PR improves the description of the `makeMCPToolTextError` util function and uniformizes error handling around it.
- Alternatively we could remove the wrapper everywhere and document some other way that passing `isError: true` will log it and that the text will be logged., I'm hesitant between the two.

## Tests

## Risk

- Low, only refactoring.

## Deploy Plan

- Deploy front.
