### PR TITLE
Enable logs collection in Dust Chrome extension

### DIFF
--- a/.github/workflows/build-and-lint-extension.yml
+++ b/.github/workflows/build-and-lint-extension.yml
@@ -23,3 +23,5 @@ jobs:
           cache-dependency-path: ./extension/package-lock.json
       - working-directory: extension
         run: npm install && npm run lint && npm run format:check && npm run package:chrome:production
+        env:
+          DATADOG_CLIENT_TOKEN: ${{ secrets.DD_CLIENT_TOKEN }}

--- a/extension/package-lock.json
+++ b/extension/package-lock.json
@@ -10,6 +10,7 @@
       "license": "ISC",
       "dependencies": {
         "@auth0/auth0-spa-js": "^2.1.3",
+        "@datadog/browser-logs": "^6.13.0",
         "@dust-tt/client": "^1.0.57",
         "@dust-tt/sparkle": "^0.2.534",
         "@frontapp/plugin-sdk": "^1.8.1",
@@ -306,6 +307,27 @@
       },
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/@datadog/browser-core": {
+      "version": "6.13.0",
+      "resolved": "https://registry.npmjs.org/@datadog/browser-core/-/browser-core-6.13.0.tgz",
+      "integrity": "sha512-wWhQ22F8pDjh7kGtvBetJhX5luyKsIVzJQTisjM/6p+A2nchDuoOiZ0GdjajRA5LlPa9pj/PlOoe/g+B9AMELg=="
+    },
+    "node_modules/@datadog/browser-logs": {
+      "version": "6.13.0",
+      "resolved": "https://registry.npmjs.org/@datadog/browser-logs/-/browser-logs-6.13.0.tgz",
+      "integrity": "sha512-P8GCuPOzvfMWFxFzx8xu/i1lD+IoeH0kh+XKeg+s2Axhn/Q4h+SZf2zGSCUU2gKMkdBIfF3tGm9kKncQrYjq1Q==",
+      "dependencies": {
+        "@datadog/browser-core": "6.13.0"
+      },
+      "peerDependencies": {
+        "@datadog/browser-rum": "6.13.0"
+      },
+      "peerDependenciesMeta": {
+        "@datadog/browser-rum": {
+          "optional": true
+        }
       }
     },
     "node_modules/@discoveryjs/json-ext": {

--- a/extension/package.json
+++ b/extension/package.json
@@ -57,6 +57,7 @@
   },
   "dependencies": {
     "@auth0/auth0-spa-js": "^2.1.3",
+    "@datadog/browser-logs": "^6.13.0",
     "@dust-tt/client": "^1.0.57",
     "@dust-tt/sparkle": "^0.2.534",
     "@frontapp/plugin-sdk": "^1.8.1",

--- a/extension/platforms/chrome/main.tsx
+++ b/extension/platforms/chrome/main.tsx
@@ -15,6 +15,7 @@ import {
 } from "@app/shared/context/PlatformContext";
 import { AuthProvider } from "@app/ui/components/auth/AuthProvider";
 import { routes } from "@app/ui/pages/routes";
+import { datadogLogs } from "@datadog/browser-logs";
 import {
   Button,
   classNames,
@@ -26,6 +27,21 @@ import { compare } from "compare-versions";
 import React from "react";
 import ReactDOM from "react-dom/client";
 import { createBrowserRouter, RouterProvider } from "react-router-dom";
+
+if (process.env.DATADOG_CLIENT_TOKEN) {
+  datadogLogs.init({
+    clientToken: process.env.DATADOG_CLIENT_TOKEN,
+    site: "datadoghq.eu",
+    service: "dust-chrome-extension",
+    env: process.env.DATADOG_ENV,
+    version: process.env.VERSION,
+    forwardErrorsToLogs: true,
+    sessionSampleRate: 100,
+  });
+}
+
+const logger = datadogLogs.logger;
+logger.info("Dust extension loaded");
 
 const router = createBrowserRouter(routes);
 

--- a/extension/platforms/chrome/main.tsx
+++ b/extension/platforms/chrome/main.tsx
@@ -35,6 +35,7 @@ if (process.env.DATADOG_CLIENT_TOKEN) {
     service: "dust-chrome-extension",
     env: process.env.DATADOG_ENV,
     version: process.env.VERSION,
+    forwardConsoleLogs: ["error"],
     forwardErrorsToLogs: true,
     sessionSampleRate: 100,
   });

--- a/extension/platforms/chrome/manifests/manifest.base.json
+++ b/extension/platforms/chrome/manifests/manifest.base.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "Dust",
-  "version": "0.0.20",
+  "version": "0.0.21",
   "description": "Get more done, faster, with the power of your agents at your fingertips.",
   "icons": {
     "16": "images/dust16.png",

--- a/extension/platforms/chrome/manifests/manifest.development.json
+++ b/extension/platforms/chrome/manifests/manifest.development.json
@@ -1,3 +1,6 @@
 {
+  "content_security_policy": {
+    "extension_pages": "script-src 'self'; object-src 'self'; connect-src 'self' https://browser-intake-datadoghq.eu ws://localhost:* http://localhost:3000"
+  },
   "key": "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAu2kn2r/3emY/9AwPzAH0qb1KskhZCqLp4PE3o1PqD1hyLTf9fJ+VC0CPyy3F6bep/6mjVZaN+Ufw7bTn3XFoj3TW+Xg5e/KLg+qUn2pUS973j68IyhyIamydfx90ZZajCU1XwB666+8dFwgB6sy4sGe86WNKu0Be+EDhhVFCFVI2D7CyJjlmQXUXTYDr6U41MsdI1DlDK6jrv6N9IkHKhvq1o06GN0W8CpoPJ554iBHWcw5UYNHi6ySxA+u7OoV58tDkTyVOS9sQ8WGIge3hDmhc2jcUhsJTzkeAS3ijShKVdYC0i+5n5g6SnQ4N7y2xehEYsms0ARqkUkF/QPwmTQIDAQAB"
 }

--- a/extension/platforms/chrome/manifests/manifest.production.json
+++ b/extension/platforms/chrome/manifests/manifest.production.json
@@ -1,3 +1,6 @@
 {
+  "content_security_policy": {
+    "extension_pages": "script-src 'self'; object-src 'self'; connect-src 'self' https://browser-intake-datadoghq.eu https://dust.tt/ https://eu.dust.tt/"
+  },
   "key": "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAu2kn2r/3emY/9AwPzAH0qb1KskhZCqLp4PE3o1PqD1hyLTf9fJ+VC0CPyy3F6bep/6mjVZaN+Ufw7bTn3XFoj3TW+Xg5e/KLg+qUn2pUS973j68IyhyIamydfx90ZZajCU1XwB666+8dFwgB6sy4sGe86WNKu0Be+EDhhVFCFVI2D7CyJjlmQXUXTYDr6U41MsdI1DlDK6jrv6N9IkHKhvq1o06GN0W8CpoPJ554iBHWcw5UYNHi6ySxA+u7OoV58tDkTyVOS9sQ8WGIge3hDmhc2jcUhsJTzkeAS3ijShKVdYC0i+5n5g6SnQ4N7y2xehEYsms0ARqkUkF/QPwmTQIDAQAB"
 }

--- a/extension/platforms/chrome/manifests/manifest.release.json
+++ b/extension/platforms/chrome/manifests/manifest.release.json
@@ -1,1 +1,5 @@
-{}
+{
+  "content_security_policy": {
+    "extension_pages": "script-src 'self'; object-src 'self'; connect-src 'self' https://browser-intake-datadoghq.eu https://dust.tt/ https://eu.dust.tt/"
+  }
+}

--- a/extension/platforms/chrome/webpack.config.ts
+++ b/extension/platforms/chrome/webpack.config.ts
@@ -41,6 +41,12 @@ export const getConfig = async ({
   shouldBuild: "none" | "prod" | "analyze";
 }): Promise<Configuration> => {
   const isDevelopment = env === "development";
+  if (!isDevelopment && !process.env.DATADOG_CLIENT_TOKEN) {
+    throw new Error(
+      "❌ DATADOG_CLIENT_TOKEN=[Chrome extension logs collection token] must be set when building for production or release.\n" +
+        "The token can be found on https://app.datadoghq.eu/organization-settings/client-tokens"
+    );
+  }
   const baseManifestPath = resolvePath("./manifests/manifest.base.json");
   const envManifestPath = resolvePath(`./manifests/manifest.${env}.json`);
 
@@ -143,6 +149,8 @@ export const getConfig = async ({
       new webpack.EnvironmentPlugin({
         VERSION: version,
         COMMIT_HASH: getCommitHash(),
+        DATADOG_CLIENT_TOKEN: process.env.DATADOG_CLIENT_TOKEN || "",
+        DATADOG_ENV: isDevelopment ? "dev" : "prod",
       }),
       new webpack.ProvidePlugin({
         Buffer: ["buffer", "Buffer"],

--- a/extension/ui/components/assistants/state/messageReducer.ts
+++ b/extension/ui/components/assistants/state/messageReducer.ts
@@ -157,6 +157,7 @@ export function messageReducer(
     case "reasoning_thinking":
     case "reasoning_tokens":
     case "retrieval_params":
+    case "search_labels_params":
     case "tables_query_model_output":
     case "tables_query_output":
     case "tables_query_started":


### PR DESCRIPTION
## Description

This PR is better read commit by commit.

This PR enables logs collection for the extension using Datadog browser logs. The implementation includes:

- Added `@datadog/browser-logs` dependency for log collection
- Updated content security policy in all manifest files to allow Datadog logging endpoints ⚠️
- Initialized Datadog logging in the extension's main entry point with proper configuration
- Fixed typing issues in the message reducer

## Tests

Manual testing of the extension to ensure:
- Datadog logs are properly initialized and configured
- Extension functionality remains unaffected
- No console errors related to CSP violations
- Logs are correctly sent to Datadog endpoints

## Risk

High risk changes:
- Content-security-policy is more restrictive, let's double check nothing is missing

Low risk changes focused on logging infrastructure:
- New dependency is well-established and maintained by Datadog
- CSP changes are minimal and targeted only to allow logging endpoints
- Logging is non-blocking and shouldn't affect extension performance
- Changes are additive and don't modify existing functionality
- Safe to rollback by reverting the commits

## Deploy Plan

1. Deploy to development environment first to verify log collection works ✅
2. Monitor Datadog for incoming logs ✅
3. Deploy to production once log collection is confirmed working
4. No special deployment considerations needed - standard extension deployment process applies