### PR TITLE
Return serializable values in getBotName

### DIFF
--- a/connectors/src/connectors/slack/lib/bot_user_helpers.ts
+++ b/connectors/src/connectors/slack/lib/bot_user_helpers.ts
@@ -116,7 +116,7 @@ async function getBotName({
   botId: string;
   connectorId: ModelId;
   slackClient: WebClient;
-}): Promise<string | undefined> {
+}): Promise<string | null> {
   try {
     const slackBotOrWorkflowInfo = await getSlackBotInfo(
       connectorId,
@@ -124,7 +124,9 @@ async function getBotName({
       botId
     );
 
-    return slackBotOrWorkflowInfo.display_name;
+    // Return null instead of undefined to avoid Redis "Invalid argument type" error
+    // when caching the result - undefined cannot be JSON.stringified properly for Redis storage.
+    return slackBotOrWorkflowInfo.display_name ?? null;
   } catch (err) {
     if (isSlackWebAPIPlatformErrorBotNotFound(err)) {
       logger.info(
@@ -135,7 +137,9 @@ async function getBotName({
         "Slack bot not found, skipping message"
       );
 
-      return undefined;
+      // Return null instead of undefined to avoid Redis "Invalid argument type" error
+      // when caching the result - undefined cannot be JSON.stringified properly for Redis storage.
+      return null;
     }
 
     logger.error(

--- a/connectors/src/connectors/slack/lib/bot_user_helpers.ts
+++ b/connectors/src/connectors/slack/lib/bot_user_helpers.ts
@@ -46,7 +46,7 @@ export async function getUserName(
   slackUserId: string,
   connectorId: ModelId,
   slackClient: WebClient
-): Promise<string | undefined> {
+): Promise<string | null> {
   const fromCache = await cacheGet(getUserCacheKey(slackUserId, connectorId));
   if (fromCache) {
     return fromCache;
@@ -66,17 +66,17 @@ export async function getUserName(
 
       if (userName) {
         await cacheSet(getUserCacheKey(slackUserId, connectorId), userName);
-        return info.user.name;
+        return userName;
       }
     }
 
-    return undefined;
+    return null;
   } catch (err) {
     if (isSlackWebAPIPlatformError(err)) {
       if (err.data.error === "user_not_found") {
         logger.info({ connectorId, slackUserId }, "Slack user not found.");
 
-        return undefined;
+        return null;
       }
     }
 
@@ -196,7 +196,7 @@ export async function getBotOrUserName(
   message: MessageElement,
   connectorId: ModelId,
   slackClient: WebClient
-): Promise<string | undefined> {
+): Promise<string | null> {
   return message.bot_id
     ? getBotNameMemoized({ botId: message.bot_id, connectorId, slackClient })
     : getUserName(message.user as string, connectorId, slackClient);


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
See [thread](https://dust4ai.slack.com/archives/C091PN4EK52/p1752067130836429?thread_ts=1752066836.039239&cid=C091PN4EK52).

If bot name is undefined, the issue is that we return `undefined` which can't be serialized in Redis leading to error:
```
 error: TypeError: Invalid argument type
      at encodeCommand (/app/node_modules/@redis/client/dist/lib/client/RESP2/encoder.js:17:19)
      at RedisCommandQueue.getCommandToSend (/app/node_modules/@redis/client/dist/lib/client/commands-queue.js:138:45)
      at Commander._RedisClient_tick (/app/node_modules/@redis/client/dist/lib/client/index.js:519:76)
      at Commander._RedisClient_sendCommand (/app/node_modules/@redis/client/dist/lib/client/index.js:506:82)
      at Commander.commandsExecutor (/app/node_modules/@redis/client/dist/lib/client/index.js:189:154)
      at BaseClass.<computed> [as set] (/app/node_modules/@redis/client/dist/lib/commander.js:8:29)
      at <anonymous> (/app/src/types/shared/cache.ts:82:24)
      at process.processTicksAndRejections (node:internal/process/task_queues:95:5)
      at async isWhitelistedBotOrWorkflow (/app/src/connectors/slack/lib/bot_user_helpers.ts:177:21)
      at async syncNonThreadedChunk (/app/src/connectors/slack/temporal/activities.ts:475:27)
```

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
