### PR TITLE
[front] invites: better UI errors

### DIFF
--- a/front/components/members/InviteEmailButtonWithModal.tsx
+++ b/front/components/members/InviteEmailButtonWithModal.tsx
@@ -109,14 +109,13 @@ export function InviteEmailButtonWithModal({
 
     const invitesByCase = {
       activeSameRole: existingMembers.filter(
-        (m) => m && m.workspaces && m.workspaces.role === invitationRole
+        (m) => m && m.workspaces?.role === invitationRole
       ),
       activeDifferentRole: existingMembers.filter(
         (m) =>
           m &&
-          m.workspaces &&
-          m.workspaces.role !== invitationRole &&
-          m.workspaces.role !== "none"
+          m.workspaces?.role !== invitationRole &&
+          m.workspaces?.role !== "none"
       ),
       notInWorkspace: inviteEmailsList.filter(
         (m) =>

--- a/front/components/members/InviteEmailButtonWithModal.tsx
+++ b/front/components/members/InviteEmailButtonWithModal.tsx
@@ -109,18 +109,20 @@ export function InviteEmailButtonWithModal({
 
     const invitesByCase = {
       activeSameRole: existingMembers.filter(
-        (m) => m && m.workspaces.role === invitationRole
+        (m) => m && m.workspaces && m.workspaces.role === invitationRole
       ),
       activeDifferentRole: existingMembers.filter(
         (m) =>
           m &&
+          m.workspaces &&
           m.workspaces.role !== invitationRole &&
           m.workspaces.role !== "none"
       ),
       notInWorkspace: inviteEmailsList.filter(
         (m) =>
           !existingMembers.find((x) => x.email === m) ||
-          existingMembers.find((x) => x.email === m)?.workspaces.role === "none"
+          existingMembers.find((x) => x.email === m)?.workspaces?.role ===
+            "none"
       ),
     };
 

--- a/front/lib/invitations.ts
+++ b/front/lib/invitations.ts
@@ -135,9 +135,7 @@ export async function sendInvitations({
       sendNotification({
         type: "error",
         title: "Some invites failed",
-        description:
-          result[0].error_message ||
-          `Failed to invite ${failures} new member(s) to workspace.`,
+        description: `Failed to invite ${failures.map((f) => f.email).join(", ")} to the workspace.`,
       });
     } else {
       sendNotification({

--- a/front/lib/invitations.ts
+++ b/front/lib/invitations.ts
@@ -135,7 +135,10 @@ export async function sendInvitations({
       sendNotification({
         type: "error",
         title: "Some invites failed",
-        description: `Failed to invite ${failures.map((f) => f.email).join(", ")} to the workspace.`,
+        description: result
+          .filter((r) => r.error_message)
+          .map((r) => r.error_message)
+          .join(", "),
       });
     } else {
       sendNotification({


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

closes https://github.com/dust-tt/tasks/issues/3406

In the invite user to the workspace modal, in case of failure, UI was not giving details on which invites failed to the admin. This PR shows more granularity (showing the exact e-mails that failed).

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

Tested by hand.

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

Low risks

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->

Deploy front