### PR TITLE
Update message rendering to use maximal versions of MCP actions

### DIFF
--- a/front/lib/actions/mcp.ts
+++ b/front/lib/actions/mcp.ts
@@ -2,7 +2,6 @@ import { isSupportedImageContentType } from "@dust-tt/client";
 import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
 import { McpError } from "@modelcontextprotocol/sdk/types.js";
 import type { JSONSchema7 as JSONSchema } from "json-schema";
-import { Sequelize } from "sequelize";
 
 import type { DustAppRunConfigurationType } from "@app/components/actions/dust_app_run/utils";
 import type {

--- a/front/lib/actions/mcp.ts
+++ b/front/lib/actions/mcp.ts
@@ -1178,7 +1178,7 @@ export async function mcpActionTypesFromAgentMessageIds(
       agentMessageId: agentMessageIds,
       workspaceId: owner.id,
     },
-    group: ["step", "agentMessageId"],
+    group: ["stepContentId", "agentMessageId"],
   });
 
   const actionIds = maxVersionActions.map((action) => action.id);


### PR DESCRIPTION
## Description

- Part of https://github.com/dust-tt/tasks/issues/3414.
- This PR updates the rendering of agent messages to only fetch `AgentStepContent` with maximal versions.

## Tests

- Testing on front-edge.

## Risk

- Blast radius high, notably in terms of performance. Has to be monitored (notably whether the index behaves well).

## Deploy Plan

- Deploy front.
