### PR TITLE
Set workspaceId with setGlobalContext and user with setUser

### DIFF
--- a/front/pages/_app.tsx
+++ b/front/pages/_app.tsx
@@ -5,7 +5,6 @@ import "@dust-tt/sparkle/dist/sparkle.css";
 // Local tailwind components override sparkle styles
 import "@app/styles/components.css";
 
-import { useUser } from "@app/lib/swr/user";
 import { datadogLogs } from "@datadog/browser-logs";
 import type { NextPage } from "next";
 import type { AppProps } from "next/app";
@@ -13,6 +12,7 @@ import { useRouter } from "next/router";
 import { useEffect } from "react";
 
 import RootLayout from "@app/components/app/RootLayout";
+import { useUser } from "@app/lib/swr/user";
 
 if (process.env.NEXT_PUBLIC_DATADOG_CLIENT_TOKEN) {
   datadogLogs.init({

--- a/front/pages/_app.tsx
+++ b/front/pages/_app.tsx
@@ -5,9 +5,12 @@ import "@dust-tt/sparkle/dist/sparkle.css";
 // Local tailwind components override sparkle styles
 import "@app/styles/components.css";
 
+import { useUser } from "@app/lib/swr/user";
 import { datadogLogs } from "@datadog/browser-logs";
 import type { NextPage } from "next";
 import type { AppProps } from "next/app";
+import { useRouter } from "next/router";
+import { useEffect } from "react";
 
 import RootLayout from "@app/components/app/RootLayout";
 
@@ -37,6 +40,38 @@ type AppPropsWithLayout = AppProps & {
 export default function App({ Component, pageProps }: AppPropsWithLayout) {
   // Use the layout defined at the page level, if available.
   const getLayout = Component.getLayout ?? ((page) => page);
+
+  const router = useRouter();
+  const { wId } = router.query;
+  useEffect(() => {
+    const updateLoggerContext = () => {
+      if (wId) {
+        datadogLogs.setGlobalContext({
+          workspaceId: wId,
+        });
+      } else {
+        datadogLogs.setGlobalContext({});
+      }
+    };
+
+    updateLoggerContext();
+    router.events.on("routeChangeComplete", updateLoggerContext);
+    return () => {
+      router.events.off("routeChangeComplete", updateLoggerContext);
+    };
+  }, [wId, router.events]);
+
+  const { user } = useUser();
+  const userId = user?.sId;
+  useEffect(() => {
+    if (userId) {
+      datadogLogs.setUser({
+        id: userId,
+      });
+    } else {
+      datadogLogs.clearUser();
+    }
+  }, [userId]);
 
   return (
     <RootLayout>


### PR DESCRIPTION
## Description

This PR enhances browser logging by adding user and workspace context to Datadog logs. The implementation automatically sets the workspaceId in the global logging context when users navigate to workspace pages (routes starting with `/w/`), and includes user information (ID) when available.

Key changes:

- Added automatic workspaceId context setting based on current route
- Added user context with ID when user is logged in
- Proper cleanup of context when navigating away from workspace pages or when user logs out

## Tests

Manually tested by:

- Navigating to workspace pages and verifying workspaceId is set in browser logs
- Logging in/out to verify user context is properly set/cleared
- Route changes to confirm context updates correctly

## Risk

Low risk changes:

- Only affects browser logging context, doesn't change application logic
- Graceful handling of missing user or workspace data
- Proper cleanup prevents memory leaks from event listeners

## Deploy Plan

Standard deployment - no special considerations needed:

1. Deploy to front-edge for verification
2. Monitor browser logs to ensure context is being set correctly
3. Deploy to production
