### PR TITLE
[front] Fix assert imports

### DIFF
--- a/front/lib/actions/mcp_internal_actions/servers/gmail.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/gmail.ts
@@ -1,5 +1,5 @@
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
-import { assert } from "console";
+import assert from "assert";
 import { z } from "zod";
 
 import {
@@ -150,8 +150,8 @@ const createServer = (): McpServer => {
       );
 
       if (!response.ok) {
-        console.log(response, await response.json());
-        return makeMCPToolTextError("Failed to create draft");
+        const responseText = await response.text();
+        return makeMCPToolTextError(`Failed to create draft: ${responseText}`);
       }
 
       const result = await response.json();

--- a/front/lib/resources/group_resource.ts
+++ b/front/lib/resources/group_resource.ts
@@ -2,7 +2,7 @@ import type {
   DirectoryGroup,
   DirectoryGroup as WorkOSGroup,
 } from "@workos-inc/node";
-import { assert } from "console";
+import assert from "assert";
 import type {
   Attributes,
   CreationAttributes,


### PR DESCRIPTION
## Description

- This PR fixes a few `assert` imports that were incorrectly imported from `console` instead of `assert` like we usually do.

## Tests

## Risk

## Deploy Plan

- Deploy front.
