### PR TITLE
Mcp action step content fk

### DIFF
--- a/front/lib/actions/mcp.ts
+++ b/front/lib/actions/mcp.ts
@@ -469,6 +469,7 @@ export class MCPConfigurationServerRunner extends BaseActionConfigurationServerR
       rawInputs,
       functionCallId,
       step,
+      stepContentId,
       stepActionIndex,
       stepActions,
       citationsRefsOffset,
@@ -531,6 +532,7 @@ export class MCPConfigurationServerRunner extends BaseActionConfigurationServerR
       isError: false,
       executionState: "pending",
       version: 0,
+      stepContentId: stepContentId || null,
     });
 
     const mcpAction = new MCPActionType({

--- a/front/lib/actions/types/index.ts
+++ b/front/lib/actions/types/index.ts
@@ -99,6 +99,7 @@ export interface BaseActionRunParams {
   rawInputs: Record<string, unknown>;
   functionCallId: string | null;
   step: number;
+  stepContentId?: ModelId;
 }
 
 export abstract class BaseActionConfigurationServerRunner<

--- a/front/lib/models/assistant/actions/mcp.ts
+++ b/front/lib/models/assistant/actions/mcp.ts
@@ -5,6 +5,7 @@ import { DataTypes } from "sequelize";
 
 import { MCPServerViewModel } from "@app/lib/models/assistant/actions/mcp_server_view";
 import { AgentConfiguration } from "@app/lib/models/assistant/agent";
+import { AgentStepContentModel } from "@app/lib/models/assistant/agent_step_content";
 import { AgentMessage } from "@app/lib/models/assistant/conversation";
 import { frontSequelize } from "@app/lib/resources/storage";
 import { FileModel } from "@app/lib/resources/storage/models/files";
@@ -190,6 +191,7 @@ export class AgentMCPAction extends WorkspaceAwareModel<AgentMCPAction> {
   declare step: number;
   declare version: number;
   declare agentMessageId: ForeignKey<AgentMessage["id"]>;
+  declare stepContentId: ForeignKey<AgentStepContentModel["id"]> | null;
 
   declare isError: boolean;
   declare executionState:
@@ -278,6 +280,15 @@ AgentMCPAction.belongsTo(AgentMessage, {
 
 AgentMessage.hasMany(AgentMCPAction, {
   foreignKey: { name: "agentMessageId", allowNull: false },
+});
+
+AgentMCPAction.belongsTo(AgentStepContentModel, {
+  foreignKey: { name: "stepContentId", allowNull: true },
+  onDelete: "RESTRICT",
+});
+
+AgentStepContentModel.hasMany(AgentMCPAction, {
+  foreignKey: { name: "stepContentId", allowNull: true },
 });
 
 export class AgentMCPActionOutputItem extends WorkspaceAwareModel<AgentMCPActionOutputItem> {

--- a/front/migrations/db/migration_307.sql
+++ b/front/migrations/db/migration_307.sql
@@ -1,0 +1,2 @@
+-- Migration created on Jul 09, 2025
+ALTER TABLE "public"."agent_mcp_actions" ADD COLUMN "stepContentId" BIGINT REFERENCES "agent_step_contents" ("id") ON DELETE RESTRICT ON UPDATE CASCADE;

--- a/front/poke/temporal/activities.ts
+++ b/front/poke/temporal/activities.ts
@@ -246,28 +246,6 @@ export async function deleteAgentsActivity({
       },
     });
 
-    const mcpActions = await AgentMCPAction.findAll({
-      where: {
-        mcpServerConfigurationId: {
-          [Op.in]: mcpServerConfigurations.map((r) => `${r.id}`),
-        },
-      },
-    });
-
-    await AgentMCPActionOutputItem.destroy({
-      where: {
-        agentMCPActionId: {
-          [Op.in]: mcpActions.map((r) => r.id),
-        },
-      },
-    });
-    await AgentMCPAction.destroy({
-      where: {
-        mcpServerConfigurationId: {
-          [Op.in]: mcpServerConfigurations.map((r) => `${r.id}`),
-        },
-      },
-    });
     await AgentChildAgentConfiguration.destroy({
       where: {
         mcpServerConfigurationId: {


### PR DESCRIPTION
## Description

- Adds a new FK `stepContentId` on `AgentMCPAction` pointing to `AgentStepContent`. Make it delete `RESTRICT`.
- Update agent loop to start filling it. 
- Kinda unrelated but fix poké `deleteAgentsActivity`: it should not delete `AgentMCPActionOutputItem` and `AgentMCPAction` as this is the job of conversation destroy which is done before deleting the agents. 



Next PR is doing a migration to fill the existing items. 
Then we will be able to make the FK non nullable and cleanup some fields in `AgentMCPAction`.

## Tests

Locally I see it fills. 

## Risk

Can be rolled back. 
FK is nullable. 

## Deploy Plan

Merge. 
Run migration. 
Deploy front. 
