### PR TITLE
[MCP Extract] Fix table names with spaces in DBML schema generation

### DIFF
--- a/core/src/databases/table_schema.rs
+++ b/core/src/databases/table_schema.rs
@@ -427,7 +427,7 @@ impl TableSchema {
         use_column_description: bool,
     ) -> String {
         let mut result = format!(
-            "Table {} {{\n{}",
+            "Table \"{}\" {{\n{}",
             name,
             self.columns()
                 .iter()
@@ -960,6 +960,28 @@ mod tests {
         assert!(rows.next()?.is_none());
 
         Ok(())
+    }
+
+    #[test]
+    fn test_render_dbml_with_spaces_in_table_name() {
+        let schema = create_test_schema();
+        let dbml = schema.render_dbml("my table", "A table with spaces", true);
+        
+        assert!(dbml.contains("Table \"my table\" {"));
+        assert!(dbml.contains("field1 INT"));
+        assert!(dbml.contains("field2 REAL"));
+        assert!(dbml.contains("field3 TEXT"));
+        assert!(dbml.contains("field4 BOOLEAN"));
+        assert!(dbml.contains("Note: 'A table with spaces'"));
+    }
+
+    #[test]
+    fn test_render_dbml_without_spaces_in_table_name() {
+        let schema = create_test_schema();
+        let dbml = schema.render_dbml("mytable", "", false);
+        
+        assert!(dbml.contains("Table \"mytable\" {"));
+        assert!(!dbml.contains("Note:"));
     }
 
     // Helper function to set up an in-memory database with a test table

--- a/core/src/databases/table_schema.rs
+++ b/core/src/databases/table_schema.rs
@@ -966,22 +966,13 @@ mod tests {
     fn test_render_dbml_with_spaces_in_table_name() {
         let schema = create_test_schema();
         let dbml = schema.render_dbml("my table", "A table with spaces", true);
-        
+
         assert!(dbml.contains("Table \"my table\" {"));
         assert!(dbml.contains("field1 INT"));
         assert!(dbml.contains("field2 REAL"));
         assert!(dbml.contains("field3 TEXT"));
         assert!(dbml.contains("field4 BOOLEAN"));
         assert!(dbml.contains("Note: 'A table with spaces'"));
-    }
-
-    #[test]
-    fn test_render_dbml_without_spaces_in_table_name() {
-        let schema = create_test_schema();
-        let dbml = schema.render_dbml("mytable", "", false);
-        
-        assert!(dbml.contains("Table \"mytable\" {"));
-        assert!(!dbml.contains("Note:"));
     }
 
     // Helper function to set up an in-memory database with a test table


### PR DESCRIPTION
## Description
Fixes https://github.com/dust-tt/tasks/issues/2443

When table names contain spaces (e.g., "my table"), the DBML schema generation was not properly quoting the table name. This caused invalid DBML syntax, which led to SQL generation issues where only the first word of the table name was used in queries.

The fix adds proper quoting around table names in the DBML output format, following the DBML specification for identifiers with spaces.

## Risk
Blast radius: Table query functionality for tables with spaces in their names
Risk: low

## Test
Added unit tests to verify DBML generation properly quotes table names with spaces.

## Deploy Plan
- Deploy core service with the fix