### PR TITLE
Update message rendering to use maximal versions of step content

### DIFF
--- a/front/lib/actions/mcp.ts
+++ b/front/lib/actions/mcp.ts
@@ -1187,8 +1187,8 @@ export async function mcpActionTypesFromAgentMessageIds(
   });
 
   const maxVersionActions = allActions.reduce((acc, current) => {
-    // TODO(durable-agents): remove the default value of -1 once not nullable.
-    const key = current.stepContentId ?? -1;
+    // TODO(durable-agents): remove the default value once stepContentId is not nullable.
+    const key = current.stepContentId ?? current.step;
     const existing = acc.get(key);
     if (!existing || current.version > existing.version) {
       acc.set(key, current);

--- a/front/lib/api/assistant/conversation.ts
+++ b/front/lib/api/assistant/conversation.ts
@@ -13,6 +13,7 @@ import { getContentFragmentBlob } from "@app/lib/api/assistant/conversation/cont
 import {
   batchRenderMessages,
   canReadMessage,
+  getMaximalVersionAgentStepContent,
 } from "@app/lib/api/assistant/messages";
 import { getContentFragmentGroupIds } from "@app/lib/api/assistant/permissions";
 import { renderConversationForModel } from "@app/lib/api/assistant/preprocessing";
@@ -270,6 +271,16 @@ export async function getConversation(
       },
     ],
   });
+
+  // Filter to only keep the step content with the maximum version for each step and index combination.
+  for (const message of messages) {
+    if (message.agentMessage && message.agentMessage.agentStepContents) {
+      message.agentMessage.agentStepContents =
+        getMaximalVersionAgentStepContent(
+          message.agentMessage.agentStepContents
+        );
+    }
+  }
 
   const renderRes = await batchRenderMessages(
     auth,

--- a/front/lib/api/assistant/messages.ts
+++ b/front/lib/api/assistant/messages.ts
@@ -223,7 +223,6 @@ async function batchRenderAgentMessages<V extends RenderMessageVariant>(
             step: sc.step,
             content: sc.value,
           })) ?? [];
-
       const textContents: Array<{ step: number; content: TextContentType }> =
         [];
       for (const content of agentStepContents) {

--- a/front/lib/api/assistant/messages.ts
+++ b/front/lib/api/assistant/messages.ts
@@ -41,6 +41,21 @@ import type {
   TextContentType,
 } from "@app/types/assistant/agent_message_content";
 
+export function getMaximalVersionAgentStepContent(
+  agentStepContents: AgentStepContentModel[]
+): AgentStepContentModel[] {
+  const maxVersionStepContents = agentStepContents.reduce((acc, current) => {
+    const key = `${current.step}-${current.index}`;
+    const existing = acc.get(key);
+    if (!existing || current.version > existing.version) {
+      acc.set(key, current);
+    }
+    return acc;
+  }, new Map<string, AgentStepContentModel>());
+
+  return Array.from(maxVersionStepContents.values());
+}
+
 async function batchRenderUserMessages(
   auth: Authenticator,
   messages: Message[]
@@ -201,27 +216,13 @@ async function batchRenderAgentMessages<V extends RenderMessageVariant>(
         };
       }
 
-      // Filter to only keep records with the maximum version for each step and index combination
-      const maxVersionStepContents = agentMessage.agentStepContents?.reduce(
-        (acc, current) => {
-          const key = `${current.step}-${current.index}`;
-          const existing = acc.get(key);
-          if (!existing || current.version > existing.version) {
-            acc.set(key, current);
-          }
-          return acc;
-        },
-        new Map<string, AgentStepContentModel>()
-      );
-
-      const agentStepContents = Array.from(
-        maxVersionStepContents?.values() ?? []
-      )
-        .sort((a, b) => a.step - b.step || a.index - b.index)
-        .map((sc) => ({
-          step: sc.step,
-          content: sc.value,
-        }));
+      const agentStepContents =
+        agentMessage.agentStepContents
+          ?.sort((a, b) => a.step - b.step || a.index - b.index)
+          .map((sc) => ({
+            step: sc.step,
+            content: sc.value,
+          })) ?? [];
 
       const textContents: Array<{ step: number; content: TextContentType }> =
         [];
@@ -437,6 +438,16 @@ async function fetchMessagesForPage(
       },
     ],
   });
+
+  // Filter to only keep the step content with the maximum version for each step and index combination.
+  for (const message of messages) {
+    if (message.agentMessage && message.agentMessage.agentStepContents) {
+      message.agentMessage.agentStepContents =
+        getMaximalVersionAgentStepContent(
+          message.agentMessage.agentStepContents
+        );
+    }
+  }
 
   return {
     hasMore,


### PR DESCRIPTION
## Description

- Part of https://github.com/dust-tt/tasks/issues/3414.
- This PR updates the rendering of agent messages to only fetch `AgentMCPActions` with maximal versions.

## Tests

- Testing on front-edge.

## Risk

- Blast radius high, but changes very much in surface.

## Deploy Plan

- Deploy front.
