### PR TITLE
[front] - feat(AB v2): new footer/header

### DIFF
--- a/extension/package-lock.json
+++ b/extension/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "@auth0/auth0-spa-js": "^2.1.3",
         "@dust-tt/client": "^1.0.57",
-        "@dust-tt/sparkle": "^0.2.534",
+        "@dust-tt/sparkle": "^0.2.539",
         "@frontapp/plugin-sdk": "^1.8.1",
         "@modelcontextprotocol/sdk": "^1.9.0",
         "@tailwindcss/forms": "^0.5.9",
@@ -335,9 +335,9 @@
       }
     },
     "node_modules/@dust-tt/sparkle": {
-      "version": "0.2.534",
-      "resolved": "https://registry.npmjs.org/@dust-tt/sparkle/-/sparkle-0.2.534.tgz",
-      "integrity": "sha512-t5/6miwIqh2rvK2XgTs2cHi0/ecyDVDxYsOQSlfGhvsYbgQP4fR6SvVaHoQSHyolltfJL0ZLPK/S09GiW7C5eA==",
+      "version": "0.2.539",
+      "resolved": "https://registry.npmjs.org/@dust-tt/sparkle/-/sparkle-0.2.539.tgz",
+      "integrity": "sha512-+8pe2XuRU5GWF+078FcI4tu5UxiEWx86anHMGbSK9q4SR+kVX6N6xni3dYkDd/tJlVDHp0wngQqx/vdsn/WOnQ==",
       "dependencies": {
         "@emoji-mart/data": "^1.1.2",
         "@emoji-mart/react": "^1.1.1",

--- a/extension/package.json
+++ b/extension/package.json
@@ -58,7 +58,7 @@
   "dependencies": {
     "@auth0/auth0-spa-js": "^2.1.3",
     "@dust-tt/client": "^1.0.57",
-    "@dust-tt/sparkle": "^0.2.534",
+    "@dust-tt/sparkle": "^0.2.539",
     "@frontapp/plugin-sdk": "^1.8.1",
     "@modelcontextprotocol/sdk": "^1.9.0",
     "@tailwindcss/forms": "^0.5.9",

--- a/front/components/agent_builder/AgentBuilderLeftPanel.tsx
+++ b/front/components/agent_builder/AgentBuilderLeftPanel.tsx
@@ -1,9 +1,10 @@
-import { BarHeader } from "@dust-tt/sparkle";
+import { BarFooter, BarHeader, Button, XMarkIcon } from "@dust-tt/sparkle";
 import React from "react";
 
 import { AgentBuilderCapabilitiesBlock } from "@app/components/agent_builder/capabilities/AgentBuilderCapabilitiesBlock";
 import { AgentBuilderInstructionsBlock } from "@app/components/agent_builder/instructions/AgentBuilderInstructionsBlock";
 import { AgentBuilderSettingsBlock } from "@app/components/agent_builder/settings/AgentBuilderSettingsBlock";
+import { ConfirmContext } from "@app/components/Confirm";
 
 interface AgentBuilderLeftPanelProps {
   title: string;
@@ -18,22 +19,36 @@ export function AgentBuilderLeftPanel({
   onCancel,
   isSaving,
 }: AgentBuilderLeftPanelProps) {
+  const confirm = React.useContext(ConfirmContext);
+
+  const handleCancel = async () => {
+    const confirmed = await confirm({
+      title: "Confirm Exit",
+      message:
+        "Are you sure you want to exit? Any unsaved changes will be lost.",
+      validateLabel: "Yes",
+      validateVariant: "warning",
+    });
+
+    if (confirmed) {
+      onCancel();
+    }
+  };
   return (
     <div className="flex h-full flex-col">
-      <div className="sticky top-0 z-10">
-        <BarHeader
-          variant="default"
-          title={title}
-          rightActions={
-            <BarHeader.ButtonBar
-              variant="validate"
-              onCancel={onCancel}
-              onSave={onSave}
-              isSaving={isSaving}
-            />
-          }
-        />
-      </div>
+      <BarHeader
+        variant="default"
+        title={title}
+        rightActions={
+          <Button
+            size="sm"
+            icon={XMarkIcon}
+            variant="ghost"
+            tooltip="Close"
+            onClick={handleCancel}
+          />
+        }
+      />
       <div className="flex-1 overflow-y-auto">
         <div className="space-y-6 p-4">
           <AgentBuilderInstructionsBlock />
@@ -41,6 +56,17 @@ export function AgentBuilderLeftPanel({
           <AgentBuilderSettingsBlock />
         </div>
       </div>
+      <BarFooter
+        variant="default"
+        rightActions={
+          <BarFooter.ButtonBar
+            variant="validate"
+            onCancel={handleCancel}
+            onSave={onSave}
+            isSaving={isSaving}
+          />
+        }
+      />
     </div>
   );
 }

--- a/front/package-lock.json
+++ b/front/package-lock.json
@@ -8,7 +8,7 @@
         "@auth0/nextjs-auth0": "^3.5.0",
         "@datadog/browser-logs": "^6.13.0",
         "@dust-tt/client": "file:../sdks/js",
-        "@dust-tt/sparkle": "^0.2.535",
+        "@dust-tt/sparkle": "^0.2.539",
         "@google-cloud/bigquery": "^7.9.1",
         "@google-cloud/storage-transfer": "^3.6.0",
         "@heroicons/react": "^2.0.11",
@@ -1127,9 +1127,9 @@
       "link": true
     },
     "node_modules/@dust-tt/sparkle": {
-      "version": "0.2.535",
-      "resolved": "https://registry.npmjs.org/@dust-tt/sparkle/-/sparkle-0.2.535.tgz",
-      "integrity": "sha512-3GbZLrybPhW4zDRKtiaCUlC8ON8imafxuRLI3cXytO6xUQhHZ7TqCt2lNtRjnllbUs1rDUXZh506rP62ATMWTQ==",
+      "version": "0.2.539",
+      "resolved": "https://registry.npmjs.org/@dust-tt/sparkle/-/sparkle-0.2.539.tgz",
+      "integrity": "sha512-+8pe2XuRU5GWF+078FcI4tu5UxiEWx86anHMGbSK9q4SR+kVX6N6xni3dYkDd/tJlVDHp0wngQqx/vdsn/WOnQ==",
       "dependencies": {
         "@emoji-mart/data": "^1.1.2",
         "@emoji-mart/react": "^1.1.1",

--- a/front/package.json
+++ b/front/package.json
@@ -25,7 +25,7 @@
     "@auth0/nextjs-auth0": "^3.5.0",
     "@datadog/browser-logs": "^6.13.0",
     "@dust-tt/client": "file:../sdks/js",
-    "@dust-tt/sparkle": "^0.2.534",
+    "@dust-tt/sparkle": "^0.2.539",
     "@google-cloud/bigquery": "^7.9.1",
     "@google-cloud/storage-transfer": "^3.6.0",
     "@heroicons/react": "^2.0.11",


### PR DESCRIPTION
## Description

Replaces the sticky header in the new Agent Builder with a combination of BarHeader and BarFooter components to improve UI consistency. The header/footer handles navigation and save/cancel actions, with a confirmation dialog added to prevent accidental loss of unsaved changes.

**References:**
- https://github.com/dust-tt/tasks/issues/3465

## Risk

Low

## Deploy Plan

Deploy front