### PR TITLE
[front] allow users to upload to restricted space

### DIFF
--- a/front/components/data_source/TableUploadOrEditModal.tsx
+++ b/front/components/data_source/TableUploadOrEditModal.tsx
@@ -86,6 +86,9 @@ export const TableUploadOrEditModal = ({
   const fileUploaderService = useFileUploaderService({
     owner,
     useCase: "upsert_table",
+    useCaseMetadata: {
+      spaceId: dataSourceView.spaceId,
+    },
   });
   const [fileId, setFileId] = useState<string | null>(null);
   const doUpsertFileAsDataSourceEntry = useUpsertFileAsDatasourceEntry(

--- a/front/pages/api/v1/w/[wId]/files/[fileId].ts
+++ b/front/pages/api/v1/w/[wId]/files/[fileId].ts
@@ -89,7 +89,7 @@ async function handler(
       });
     }
   } else if (
-    file.useCase === "folders_document" &&
+    (file.useCase === "folders_document" || file.useCase === "upsert_table") &&
     file.useCaseMetadata?.spaceId
   ) {
     // For folder documents, check if the user has access to the space

--- a/front/pages/api/v1/w/[wId]/files/[fileId].ts
+++ b/front/pages/api/v1/w/[wId]/files/[fileId].ts
@@ -89,7 +89,7 @@ async function handler(
       });
     }
   } else if (
-    (file.useCase === "folders_document" || file.useCase === "upsert_table") &&
+    file.useCase === "folders_document" &&
     file.useCaseMetadata?.spaceId
   ) {
     // For folder documents, check if the user has access to the space

--- a/front/pages/api/w/[wId]/files/[fileId]/index.ts
+++ b/front/pages/api/w/[wId]/files/[fileId]/index.ts
@@ -103,6 +103,20 @@ async function handler(
     });
   }
 
+  let space: SpaceResource | null = null;
+  if (file.useCaseMetadata?.spaceId) {
+    space = await SpaceResource.fetchById(auth, file.useCaseMetadata.spaceId);
+  }
+  if (file.useCase === "folders_document" && (!space || !space.canRead(auth))) {
+    return apiError(req, res, {
+      status_code: 404,
+      api_error: {
+        type: "file_not_found",
+        message: "File not found.",
+      },
+    });
+  }
+
   // Check permissions based on useCase and useCaseMetadata
   if (file.useCase === "conversation" && file.useCaseMetadata?.conversationId) {
     const conversation = await ConversationResource.fetchById(
@@ -113,23 +127,6 @@ async function handler(
       !conversation ||
       !ConversationResource.canAccessConversation(auth, conversation)
     ) {
-      return apiError(req, res, {
-        status_code: 404,
-        api_error: {
-          type: "file_not_found",
-          message: "File not found.",
-        },
-      });
-    }
-  } else if (
-    file.useCase === "folders_document" &&
-    file.useCaseMetadata?.spaceId
-  ) {
-    const space = await SpaceResource.fetchById(
-      auth,
-      file.useCaseMetadata.spaceId
-    );
-    if (!space || !space.canRead(auth)) {
       return apiError(req, res, {
         status_code: 404,
         api_error: {
@@ -175,13 +172,27 @@ async function handler(
 
     case "DELETE": {
       // Check if the user is a builder for the workspace or it's a conversation file
-      if (!auth.isBuilder() && file.useCase !== "conversation") {
+      if (
+        (file.useCase === "folders_document" ||
+          file.useCase === "upsert_table") &&
+        space &&
+        !space.canWrite(auth)
+      ) {
+        console.log("here");
+        return apiError(req, res, {
+          status_code: 403,
+          api_error: {
+            type: "workspace_auth_error",
+            message: "You cannot edit files in that space.",
+          },
+        });
+      } else if (!auth.isBuilder() && file.useCase !== "conversation") {
         return apiError(req, res, {
           status_code: 403,
           api_error: {
             type: "workspace_auth_error",
             message:
-              "Only users that are `builders` for the current workspace can delete files.",
+              "Only users that are `builders` for the current workspace can modify files.",
           },
         });
       }
@@ -204,6 +215,20 @@ async function handler(
     case "POST": {
       // Check if the user is a builder for the workspace or it's a conversation file or avatar
       if (
+        (file.useCase === "folders_document" ||
+          file.useCase === "upsert_table") &&
+        space &&
+        !space.canWrite(auth)
+      ) {
+        return apiError(req, res, {
+          status_code: 403,
+          api_error: {
+            type: "workspace_auth_error",
+            message: "You cannot edit files in that space.",
+          },
+        });
+      } else if (
+        !space &&
         !auth.isBuilder() &&
         file.useCase !== "conversation" &&
         file.useCase !== "avatar"

--- a/front/pages/api/w/[wId]/files/index.ts
+++ b/front/pages/api/w/[wId]/files/index.ts
@@ -41,12 +41,20 @@ const FileUploadUrlRequestSchema = t.union([
     contentType: t.string,
     fileName: t.string,
     fileSize: t.number,
-    useCase: t.union([
-      t.literal("avatar"),
-      t.literal("upsert_document"),
-      t.literal("upsert_table"),
-    ]),
+    useCase: t.union([t.literal("avatar"), t.literal("upsert_document")]),
     useCaseMetadata: t.undefined,
+  }),
+  t.type({
+    contentType: t.string,
+    fileName: t.string,
+    fileSize: t.number,
+    useCase: t.literal("upsert_table"),
+    useCaseMetadata: t.union([
+      t.type({
+        spaceId: t.string,
+      }),
+      t.undefined,
+    ]),
   }),
 ]);
 


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

Parts of https://github.com/dust-tt/tasks/issues/3466

PR #12417 introduced a regression 2 months ago where users with "user" role can no longer upload files (including CSV files) even in private spaces. This was done to fix a security issue.

This PR introduces a check to the space.canWrite method instead of auth.isBuilder for the document upload / table upserts

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

Tested by hand

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

Low risks

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->

Deploy front