### PR TITLE
Refine browser logs

### DIFF
--- a/front/components/assistant/conversation/AgentMessage.tsx
+++ b/front/components/assistant/conversation/AgentMessage.tsx
@@ -112,6 +112,7 @@ function logFailedAgentMessageOncePerSession(
 
   let seenErrors = loggedAgentErrorsPerSession.get(sessionId);
   if (!seenErrors) {
+    loggedAgentErrorsPerSession.clear(); // reset the map to prevent memory leak
     seenErrors = new Set();
     loggedAgentErrorsPerSession.set(sessionId, seenErrors);
   }

--- a/front/components/assistant/conversation/AgentMessage.tsx
+++ b/front/components/assistant/conversation/AgentMessage.tsx
@@ -532,9 +532,12 @@ export function AgentMessage({
     lastTokenClassification: null | "tokens" | "chain_of_thought";
   }) {
     if (agentMessage.status === "failed") {
-      datadogLogs.logger.info("Failed agent message rendered", {
-        agentMessage,
-      });
+      datadogLogs.logger.info(
+        `Failed agent message rendered${agentMessage.error ? `: ${agentMessage.error.code}` : ""}`,
+        {
+          ...(agentMessage.error ? agentMessage.error : {}),
+        }
+      );
       if (
         agentMessage.error &&
         agentMessage.error.code ===

--- a/front/hooks/useNotification.ts
+++ b/front/hooks/useNotification.ts
@@ -10,9 +10,12 @@ export const useSendNotification = () => {
     (notification: NotificationType) => {
       if (notification.type === "error") {
         datadogLogs.logger.info(
-          `UI error notification: ${notification.title}`,
+          `UI notification error: ${notification.title}`,
           {
-            notification,
+            error: {
+              short: notification.title,
+              long: notification.description,
+            },
           }
         );
       }


### PR DESCRIPTION
## Description

Refines browser error logging to improve consistency and reduce noise. The changes focus on:

1. **Failed agent message logging deduplication**: Implements session-based tracking to ensure each failed agent message is logged only once per user session, preventing log spam from repeated renders
2. **Consistent error log formatting**: Standardizes error object structure across UI notification and agent message logging for better log analysis

The changes affect logging in `AgentMessage.tsx` and `useNotification.ts`, improving the quality and consistency of error telemetry data.

## Tests

Manual testing - verified that failed agent messages are logged only once per session and that error log formats are consistent across different error types.

## Risk

Low risk changes focused on logging improvements. The modifications:
- Don't affect user-facing functionality
- Only change how errors are logged to Datadog
- Include session-based deduplication logic that gracefully handles edge cases
- Are safe to rollback as they don't modify core application behavior
- A Map<string, Set<string>> kept in memory for the lifetime of the tab is lightweight

## Deploy Plan

Standard deployment - no special considerations needed. The changes only affect client-side logging behavior and don't require database migrations or API changes.