### PR TITLE
Add gmail get messages and reply to a thread ability

### DIFF
--- a/front/lib/actions/mcp_internal_actions/constants.ts
+++ b/front/lib/actions/mcp_internal_actions/constants.ts
@@ -222,6 +222,8 @@ export const INTERNAL_MCP_SERVERS: Record<
     tools_stakes: {
       get_drafts: "never_ask",
       create_draft: "low",
+      get_messages: "low",
+      create_reply_draft: "low",
     },
   },
   google_calendar: {

--- a/front/lib/actions/mcp_internal_actions/servers/gmail.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/gmail.ts
@@ -554,7 +554,9 @@ const createServer = (): McpServer => {
 const decodeMessageBody = (
   payload: GmailMessagePayload | undefined
 ): string => {
-  if (!payload) return "";
+  if (!payload) {
+    return "";
+  }
 
   if (payload.mimeType === "text/plain" && payload.body?.data) {
     const base64 = payload.body.data.replace(/-/g, "+").replace(/_/g, "/");
@@ -564,7 +566,9 @@ const decodeMessageBody = (
   if (payload.parts) {
     for (const part of payload.parts) {
       const found = decodeMessageBody(part);
-      if (found) return found;
+      if (found) {
+        return found;
+      }
     }
   }
 
@@ -583,7 +587,9 @@ const createQuoteSection = (
   originalDate: string | undefined,
   originalFrom: string | undefined
 ): string => {
-  if (!originalBody) return "";
+  if (!originalBody) {
+    return "";
+  }
 
   const separator =
     originalDate && originalFrom


### PR DESCRIPTION
## Description

* Adding ability to create a draft to an existing thread. Formatted draft the exact way you see it when you do it via the gmail app
* Adding ability to read messages

## Tests

* Get messages + created thread reply in localhost. See formatting:
<img width="1453" height="328" alt="Screenshot 2025-07-11 at 10 57 58 AM" src="https://github.com/user-attachments/assets/c27331b9-621e-4421-9ca3-dae2502e5f23" />


## Risk

* Should only be additive. No need for oauth scope change.

## Deploy Plan

* Deploy front