### PR TITLE
[DURABLE-AGENTS] Refactor runAgent from async generator to Redis pub/sub (intermediary step)

### DIFF
--- a/front/lib/api/assistant/agent.ts
+++ b/front/lib/api/assistant/agent.ts
@@ -121,7 +121,7 @@ async function processEventForDatabase(
 
 // This interface is used to execute an agent. It is not in charge of creating the AgentMessage,
 // but it now handles updating it based on the execution results.
-export async function runAgent(
+export async function runAgentWithStreaming(
   auth: Authenticator,
   configuration: LightAgentConfigurationType,
   conversation: ConversationType,

--- a/front/lib/api/assistant/agent.ts
+++ b/front/lib/api/assistant/agent.ts
@@ -40,6 +40,7 @@ import { getSupportedModelConfig } from "@app/lib/assistant";
 import type { Authenticator } from "@app/lib/auth";
 import { AgentConfiguration } from "@app/lib/models/assistant/agent";
 import { AgentStepContentModel } from "@app/lib/models/assistant/agent_step_content";
+import type { AgentMessage } from "@app/lib/models/assistant/conversation";
 import { cloneBaseConfig, getDustProdAction } from "@app/lib/registry";
 import { MCPServerViewResource } from "@app/lib/resources/mcp_server_view_resource";
 import { generateRandomModelSId } from "@app/lib/resources/string_ids";
@@ -74,14 +75,60 @@ import type { TextContentType } from "@app/types/assistant/agent_message_content
 const CANCELLATION_CHECK_INTERVAL = 500;
 const MAX_ACTIONS_PER_STEP = 16;
 
+// Process database operations for agent events before publishing to Redis.
+async function processEventForDatabase(
+  event:
+    | AgentErrorEvent
+    | AgentActionSpecificEvent
+    | AgentActionSuccessEvent
+    | GenerationTokensEvent
+    | AgentGenerationCancelledEvent
+    | AgentMessageSuccessEvent,
+  agentMessageRow: AgentMessage
+): Promise<void> {
+  switch (event.type) {
+    case "agent_error":
+      // Store error in database.
+      await agentMessageRow.update({
+        status: "failed",
+        errorCode: event.error.code,
+        errorMessage: event.error.message,
+        errorMetadata: event.error.metadata,
+      });
+      break;
+
+    case "agent_generation_cancelled":
+      // Store cancellation in database.
+      await agentMessageRow.update({
+        status: "cancelled",
+      });
+      break;
+
+    case "agent_message_success":
+      // Store success and run IDs in database.
+      await agentMessageRow.update({
+        runIds: event.runIds,
+        status: "succeeded",
+      });
+
+      break;
+
+    default:
+      // Ensure we handle all event types.
+      break;
+  }
+}
+
 // This interface is used to execute an agent. It is not in charge of creating the AgentMessage,
-// nor updating it (responsibility of the caller based on the emitted events).
+// but it now handles updating it based on the execution results.
 export async function runAgent(
   auth: Authenticator,
   configuration: LightAgentConfigurationType,
   conversation: ConversationType,
   userMessage: UserMessageType,
+  // TODO(DURABLE-AGENTS 2025-07-10): DRY those two arguments to stick with only one.
   agentMessage: AgentMessageType,
+  agentMessageRow: AgentMessage,
   redisChannel: string
 ): Promise<void> {
   const [fullConfiguration] = await Promise.all([
@@ -109,6 +156,10 @@ export async function runAgent(
   );
 
   for await (const event of stream) {
+    // Process database operations BEFORE publishing to Redis.
+    await processEventForDatabase(event, agentMessageRow);
+
+    // Then publish the event to Redis for consumers.
     await redisHybridManager.publish(
       redisChannel,
       JSON.stringify(event),

--- a/front/lib/api/assistant/conversation.ts
+++ b/front/lib/api/assistant/conversation.ts
@@ -20,7 +20,9 @@ import {
   makeAgentMentionsRateLimitKeyForWorkspace,
   makeMessageRateLimitKeyForWorkspace,
 } from "@app/lib/api/assistant/rate_limits";
+import { getAgentExecutionChannelId } from "@app/lib/api/assistant/streaming/helpers";
 import { maybeUpsertFileAttachment } from "@app/lib/api/files/attachments";
+import { getRedisHybridManager } from "@app/lib/api/redis-hybrid-manager";
 import { getSupportedModelConfig } from "@app/lib/assistant";
 import type { Authenticator } from "@app/lib/auth";
 import { getFeatureFlags } from "@app/lib/auth";
@@ -96,6 +98,15 @@ import {
   Ok,
   removeNulls,
 } from "@app/types";
+
+// Type alias for agent execution events.
+type AgentExecutionEvent =
+  | AgentErrorEvent
+  | AgentActionSpecificEvent
+  | AgentActionSuccessEvent
+  | GenerationTokensEvent
+  | AgentGenerationCancelledEvent
+  | AgentMessageSuccessEvent;
 
 function getTimeframeSecondsFromLiteral(
   timeframeLiteral: MaxMessagesTimeframeType
@@ -913,7 +924,7 @@ export async function* postUserMessage(
   const eventStreamGenerators = agentMessages.map((agentMessage, i) => {
     // We stitch the conversation to add the user message and only that agent message
     // so that it can be used to prompt the agent.
-    const eventStream = runAgent(
+    return streamRunAgentEvents(
       auth,
       agentMessage.configuration,
       {
@@ -921,12 +932,6 @@ export async function* postUserMessage(
         content: [...conversation.content, [userMessage], [agentMessage]],
       },
       userMessage,
-      agentMessage
-    );
-
-    return streamRunAgentEvents(
-      auth,
-      eventStream,
       agentMessages[i],
       agentMessageRows[i]
     );
@@ -1446,7 +1451,7 @@ export async function* editUserMessage(
     }
     // We stitch the conversation to add the user message and only that agent message
     // so that it can be used to prompt the agent.
-    const eventStream = runAgent(
+    return streamRunAgentEvents(
       auth,
       agentMessage.configuration,
       {
@@ -1454,12 +1459,6 @@ export async function* editUserMessage(
         content: [...conversation.content, [userMessage], [agentMessage]],
       },
       userMessage,
-      agentMessage
-    );
-
-    return streamRunAgentEvents(
-      auth,
-      eventStream,
       agentMessages[i],
       agentMessageRows[i]
     );
@@ -1697,7 +1696,7 @@ export async function* retryAgentMessage(
     throw new Error("Unreachable: parent message must be a user message");
   }
 
-  const eventStream = runAgent(
+  yield* streamRunAgentEvents(
     auth,
     agentMessage.configuration,
     {
@@ -1705,10 +1704,9 @@ export async function* retryAgentMessage(
       content: newContent,
     },
     userMessage,
-    agentMessage
+    agentMessage,
+    agentMessageRow
   );
-
-  yield* streamRunAgentEvents(auth, eventStream, agentMessage, agentMessageRow);
 }
 
 // Injects a new content fragment in the conversation.
@@ -1828,26 +1826,12 @@ export async function postNewContentFragment(
 
 async function* streamRunAgentEvents(
   auth: Authenticator,
-  eventStream: AsyncGenerator<
-    | AgentErrorEvent
-    | AgentActionSpecificEvent
-    | AgentActionSuccessEvent
-    | GenerationTokensEvent
-    | AgentGenerationCancelledEvent
-    | AgentMessageSuccessEvent,
-    void
-  >,
+  agentConfiguration: LightAgentConfigurationType,
+  conversation: ConversationType,
+  userMessage: UserMessageType,
   agentMessage: AgentMessageType,
   agentMessageRow: AgentMessage
-): AsyncGenerator<
-  | AgentErrorEvent
-  | AgentActionSpecificEvent
-  | AgentActionSuccessEvent
-  | GenerationTokensEvent
-  | AgentGenerationCancelledEvent
-  | AgentMessageSuccessEvent,
-  void
-> {
+): AsyncGenerator<AgentExecutionEvent, void> {
   if (!canReadMessage(auth, agentMessage)) {
     yield {
       type: "agent_error",
@@ -1863,6 +1847,36 @@ async function* streamRunAgentEvents(
     return;
   }
 
+  const redisChannel = getAgentExecutionChannelId(agentMessage.sId);
+  const redisHybridManager = getRedisHybridManager();
+
+  // STEP 1: Subscribe to Redis channel FIRST
+  // This sets up the event consumer for real-time events only (no history replay).
+  // Must happen before agent execution starts to avoid missing events.
+  const { iterator: eventStream } =
+    await redisHybridManager.subscribeAsAsyncIterator<AgentExecutionEvent>({
+      channelName: redisChannel,
+      lastEventId: null,
+      origin: "agent_execution",
+      // Don't include history for now. Might be revisited when using a temporal workflow.
+      includeHistory: false,
+    });
+
+  // STEP 2: Start agent execution (fire-and-forget)
+  // We use 'void' to:
+  // - Start agent execution immediately without blocking
+  // - Avoid awaiting (which would cause deadlock since we need to consume events)
+  void runAgent(
+    auth,
+    agentConfiguration,
+    conversation,
+    userMessage,
+    agentMessage,
+    redisChannel
+  );
+
+  // STEP 3: Process events as they arrive
+  // Only real-time events will flow as the agent publishes them to Redis.
   for await (const event of eventStream) {
     switch (event.type) {
       case "agent_error":

--- a/front/lib/api/assistant/pubsub.ts
+++ b/front/lib/api/assistant/pubsub.ts
@@ -1,4 +1,9 @@
 import type { AgentActionSpecificEvent } from "@app/lib/actions/types/agent";
+import {
+  editUserMessage,
+  postUserMessage,
+  retryAgentMessage,
+} from "@app/lib/api/assistant/conversation";
 import { maybeTrackTokenUsageCost } from "@app/lib/api/public_api_limits";
 import type { RedisUsageTagsType } from "@app/lib/api/redis";
 import { getRedisClient } from "@app/lib/api/redis";
@@ -33,12 +38,6 @@ import type {
   UserMessageNewEvent,
 } from "@app/types";
 import { assertNever, Err, Ok } from "@app/types";
-
-import {
-  editUserMessage,
-  postUserMessage,
-  retryAgentMessage,
-} from "./conversation";
 
 export async function postUserMessageWithPubSub(
   auth: Authenticator,

--- a/front/lib/api/assistant/streaming/helpers.ts
+++ b/front/lib/api/assistant/streaming/helpers.ts
@@ -1,0 +1,3 @@
+export function getAgentExecutionChannelId(agentMessageId: string) {
+  return `agent-execution-${agentMessageId}`;
+}

--- a/front/lib/api/redis-hybrid-manager.ts
+++ b/front/lib/api/redis-hybrid-manager.ts
@@ -1,7 +1,9 @@
+import { EventEmitter } from "events";
 import type { RedisClientType } from "redis";
 import { createClient } from "redis";
 
 import type { RedisUsageTagsType } from "@app/lib/api/redis";
+import { fromEvent } from "@app/lib/utils/events";
 import logger from "@app/logger/logger";
 
 type EventCallback = (event: EventPayload | "close") => void;
@@ -419,6 +421,78 @@ class RedisHybridManager {
    */
   private getStreamName(channelName: string): string {
     return `${this.STREAM_PREFIX}${channelName}`;
+  }
+
+  /**
+   * Subscribe to a channel and return an async iterator for events using fromEvent helper
+   */
+  public async subscribeAsAsyncIterator<T>({
+    channelName,
+    includeHistory = true,
+    lastEventId,
+    origin,
+  }: {
+    channelName: string;
+    includeHistory: boolean;
+    lastEventId: string | null;
+    origin: RedisUsageTagsType;
+  }): Promise<{
+    iterator: AsyncGenerator<T, void, unknown>;
+    unsubscribe: () => Promise<void>;
+  }> {
+    // Create a temporary EventEmitter to bridge Redis to fromEvent.
+    const eventEmitter = new EventEmitter();
+
+    const { history, unsubscribe } = await this.subscribe(
+      channelName,
+      (event) => {
+        if (event === "close") {
+          eventEmitter.emit("end");
+          return;
+        }
+
+        try {
+          const parsedEvent = JSON.parse(event.message.payload) as T;
+          eventEmitter.emit("data", parsedEvent);
+        } catch (error) {
+          logger.error(
+            { error, channel: channelName },
+            "Error parsing Redis event"
+          );
+          eventEmitter.emit("error", error);
+        }
+      },
+      lastEventId,
+      origin
+    );
+
+    // Create the async iterator using fromEvent.
+    const iterator = fromEvent<T>(eventEmitter, "data");
+
+    // Emit history events first (on next tick to ensure iterator is ready).
+    if (includeHistory) {
+      process.nextTick(() => {
+        for (const historyEvent of history) {
+          try {
+            const parsedEvent = JSON.parse(historyEvent.message.payload) as T;
+            eventEmitter.emit("data", parsedEvent);
+          } catch (error) {
+            logger.error(
+              { error, channel: channelName },
+              "Error parsing Redis history event"
+            );
+          }
+        }
+      });
+    }
+
+    return {
+      iterator,
+      unsubscribe: async () => {
+        eventEmitter.emit("end");
+        await unsubscribe();
+      },
+    };
   }
 }
 

--- a/front/lib/api/redis.ts
+++ b/front/lib/api/redis.ts
@@ -8,6 +8,7 @@ let client: RedisClientType;
 
 export type RedisUsageTagsType =
   | "action_validation"
+  | "agent_execution"
   | "agent_recent_authors"
   | "agent_usage"
   | "assistant_generation"


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
This PR partially address https://github.com/dust-tt/tasks/issues/3436.

This PR refactors the `runAgent` function from an async generator pattern to a Redis pub/sub architecture. This is an intermediary step to enable `runAgent` to be used in Temporal workflows/activities, which cannot handle async generators.

### Background

The current `runAgent` function uses an async generator pattern that yields events directly to consumers. While this works well for synchronous execution, it prevents us from running agents in Temporal workflows since Temporal activities cannot return async generators. This refactoring moves to a Redis-based event system that decouples agent execution from event consumption.

### Changes Made

- `runAgent` Function Transformation
The core change transforms `runAgent` from async function* `runAgent()` to async function `runAgent()`. The function now takes a redisChannel parameter and publishes events to Redis instead of yielding them. 

- Database Operations Migration
All database state updates have been moved from `streamRunAgentEvents` into `runAgent`. This ensures that database state is updated before events are published to Redis, giving consumers a consistent view.

### Temporary Pass-Through Pattern

This PR introduces a temporary pass-through in `streamRunAgentEvents` where events are published to Redis by `runAgent`, consumed from Redis by `streamRunAgentEvents`, and then re-yielded to maintain backward compatibility. This pattern is intentionally temporary and allows us to refactor incrementally without breaking existing API endpoints.

Will follow-up to remove the event pass-through in `streamRunAgentEvents` and refactor API endpoints to consume events directly from Redis.
 
## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->
Tested locally and will test as well on front-edge.

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->
Pretty risky as we had yet another streaming in the already pretty complex logic.

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
