### PR TITLE
[connectors] fix(Zendesk): add brand mismatch detection

### DIFF
--- a/connectors/src/connectors/zendesk/lib/cli.ts
+++ b/connectors/src/connectors/zendesk/lib/cli.ts
@@ -184,7 +184,10 @@ export const zendesk = async ({
         return {
           ticket: ticket as { [key: string]: unknown } | null,
           shouldSyncTicket:
-            ticket !== null && shouldSyncTicket(ticket, configuration),
+            ticket !== null &&
+            shouldSyncTicket(ticket, configuration, {
+              brandId: brand?.brandId,
+            }),
           isTicketOnDb: ticketOnDb !== null,
         };
       }
@@ -219,7 +222,10 @@ export const zendesk = async ({
       return {
         ticket: ticket as { [key: string]: unknown } | null,
         shouldSyncTicket:
-          ticket !== null && shouldSyncTicket(ticket, configuration),
+          ticket !== null &&
+          shouldSyncTicket(ticket, configuration, {
+            brandId,
+          }),
         isTicketOnDb: ticketOnDb !== null,
       };
     }
@@ -315,7 +321,7 @@ export const zendesk = async ({
         throw new Error(`Ticket ${ticketId} not found`);
       }
 
-      if (!shouldSyncTicket(ticket, configuration)) {
+      if (!shouldSyncTicket(ticket, configuration, { brandId })) {
         logger.info(
           { ticketId, brandId, status: ticket.status },
           "Ticket should not be synced based on status and configuration."

--- a/connectors/src/connectors/zendesk/lib/sync_ticket.ts
+++ b/connectors/src/connectors/zendesk/lib/sync_ticket.ts
@@ -29,15 +29,19 @@ function apiUrlToDocumentUrl(apiUrl: string): string {
 
 export function shouldSyncTicket(
   ticket: ZendeskFetchedTicket,
-  configuration: ZendeskConfigurationResource
+  configuration: ZendeskConfigurationResource,
+  { brandId }: { brandId?: number }
 ): boolean {
-  return [
-    "closed",
-    "solved",
-    ...(configuration.syncUnresolvedTickets
-      ? ["new", "open", "pending", "hold"]
-      : []),
-  ].includes(ticket.status);
+  return (
+    [
+      "closed",
+      "solved",
+      ...(configuration.syncUnresolvedTickets
+        ? ["new", "open", "pending", "hold"]
+        : []),
+    ].includes(ticket.status) &&
+    (!brandId || brandId === ticket.brand_id)
+  );
 }
 
 export function extractMetadataFromDocumentUrl(ticketUrl: string): {

--- a/connectors/src/connectors/zendesk/lib/types.ts
+++ b/connectors/src/connectors/zendesk/lib/types.ts
@@ -79,6 +79,7 @@ export interface ZendeskFetchedArticle {
 
 export interface ZendeskFetchedTicket {
   assignee_id: number;
+  brand_id: number;
   collaborator_ids: number[];
   created_at: string; // ISO 8601 date string
   custom_fields: {

--- a/connectors/src/connectors/zendesk/temporal/activities.ts
+++ b/connectors/src/connectors/zendesk/temporal/activities.ts
@@ -660,7 +660,7 @@ export async function syncZendeskTicketBatchActivity({
   }
 
   const ticketsToSync = tickets.filter((t) =>
-    shouldSyncTicket(t, configuration)
+    shouldSyncTicket(t, configuration, { brandId })
   );
 
   const comments2d = await concurrentExecutor(

--- a/connectors/src/connectors/zendesk/temporal/incremental_activities.ts
+++ b/connectors/src/connectors/zendesk/temporal/incremental_activities.ts
@@ -307,7 +307,7 @@ export async function syncZendeskTicketUpdateBatchActivity({
           dataSourceConfig,
           loggerArgs,
         });
-      } else if (shouldSyncTicket(ticket, configuration)) {
+      } else if (shouldSyncTicket(ticket, configuration, { brandId })) {
         const comments = commentsPerTicket[ticket.id];
         if (!comments) {
           throw new Error(


### PR DESCRIPTION
## Description

- This PR adds a coherence check on tickets fetched belonging to the expected brand.
- Found out that you can fetch tickets from a different brand albeit using the brand subdomain in the URL.

## Tests

## Risk

- Low.

## Deploy Plan

- Deploy connectors.
