### PR TITLE
[connectors] Add script to cleanup Zendesk tickets

### DIFF
--- a/connectors/migrations/20250710_cleanup_duplicate_zendesk_tickets.ts
+++ b/connectors/migrations/20250710_cleanup_duplicate_zendesk_tickets.ts
@@ -17,7 +17,7 @@ async function checkTicketValidity(
     ticketId: ticket.ticketId,
   });
 
-  return fetchedTicket?.brand_id === ticket.brandId;
+  return fetchedTicket && fetchedTicket.brand_id === ticket.brandId;
 }
 
 async function migrateConnector(

--- a/connectors/migrations/20250710_cleanup_duplicate_zendesk_tickets.ts
+++ b/connectors/migrations/20250710_cleanup_duplicate_zendesk_tickets.ts
@@ -37,7 +37,7 @@ async function checkTicketValidity(
   return fetchedTicket && fetchedTicket.brand_id === ticket.brandId;
 }
 
-async function migrateConnector(
+async function cleanupConnector(
   connector: ConnectorResource,
   execute: boolean,
   logger: Logger
@@ -110,7 +110,7 @@ makeScript(
     }
 
     logger.info({ connectorId }, "Starting migration");
-    await migrateConnector(connector, execute, logger);
+    await cleanupConnector(connector, execute, logger);
     logger.info({ connectorId }, "Migration done");
   }
 );

--- a/connectors/migrations/20250710_cleanup_duplicate_zendesk_tickets.ts
+++ b/connectors/migrations/20250710_cleanup_duplicate_zendesk_tickets.ts
@@ -51,7 +51,7 @@ async function migrateConnector(
       },
       "Checked duplicate ticket"
     );
-    if (isValid) {
+    if (!isValid) {
       if (execute) {
         await ticket.destroy();
         logger.info(

--- a/connectors/migrations/20250710_cleanup_duplicate_zendesk_tickets.ts
+++ b/connectors/migrations/20250710_cleanup_duplicate_zendesk_tickets.ts
@@ -1,11 +1,11 @@
 import _ from "lodash";
+import type { Logger } from "pino";
 import { makeScript } from "scripts/helpers";
 
 import { getZendeskSubdomainAndAccessToken } from "@connectors/connectors/zendesk/lib/zendesk_access_token";
 import { fetchZendeskTicket } from "@connectors/connectors/zendesk/lib/zendesk_api";
 import { ZendeskTicketModel } from "@connectors/lib/models/zendesk";
 import { ConnectorResource } from "@connectors/resources/connector_resource";
-export type { Logger } from "pino";
 
 async function checkTicketValidity(
   ticket: ZendeskTicketModel,

--- a/connectors/migrations/20250710_cleanup_duplicate_zendesk_tickets.ts
+++ b/connectors/migrations/20250710_cleanup_duplicate_zendesk_tickets.ts
@@ -1,0 +1,89 @@
+import _ from "lodash";
+import { makeScript } from "scripts/helpers";
+
+import { getZendeskSubdomainAndAccessToken } from "@connectors/connectors/zendesk/lib/zendesk_access_token";
+import { fetchZendeskTicket } from "@connectors/connectors/zendesk/lib/zendesk_api";
+import { ZendeskTicketModel } from "@connectors/lib/models/zendesk";
+import { ConnectorResource } from "@connectors/resources/connector_resource";
+export type { Logger } from "pino";
+
+async function checkTicketValidity(
+  ticket: ZendeskTicketModel,
+  { accessToken, subdomain }: { accessToken: string; subdomain: string }
+) {
+  const fetchedTicket = await fetchZendeskTicket({
+    accessToken,
+    brandSubdomain: subdomain,
+    ticketId: ticket.ticketId,
+  });
+
+  return fetchedTicket?.brand_id === ticket.brandId;
+}
+
+async function migrateConnector(
+  connector: ConnectorResource,
+  execute: boolean,
+  logger: Logger
+) {
+  const { accessToken, subdomain } = await getZendeskSubdomainAndAccessToken(
+    connector.connectionId
+  );
+
+  const tickets = await ZendeskTicketModel.findAll({
+    where: { connectorId: connector.id },
+  });
+  const ticketsByTicketId = _.groupBy(tickets, (t) => t.ticketId);
+  const duplicateTickets = Object.values(ticketsByTicketId)
+    .filter((t) => t.length > 1)
+    .flat();
+
+  for (const ticket of duplicateTickets) {
+    const isValid = await checkTicketValidity(ticket, {
+      accessToken,
+      subdomain,
+    });
+    logger.info(
+      {
+        connectorId: connector.id,
+        ticketId: ticket.ticketId,
+        brandId: ticket.brandId,
+        isValid,
+      },
+      "Checked duplicate ticket"
+    );
+    if (isValid) {
+      if (execute) {
+        await ticket.destroy();
+        logger.info(
+          {
+            connectorId: connector.id,
+            ticketId: ticket.ticketId,
+            brandId: ticket.brandId,
+          },
+          "Destroyed duplicate ticket"
+        );
+      }
+    }
+  }
+}
+
+makeScript(
+  {
+    connectorId: { type: "number" },
+  },
+  async ({ execute, connectorId }, logger) => {
+    const connector = await ConnectorResource.fetchById(connectorId);
+    if (!connector) {
+      logger.error({ connectorId }, "Connector not found");
+      return;
+    }
+    if (connector.type !== "zendesk") {
+      logger.error({ connectorId }, "Not a Zendesk connector");
+      return;
+    }
+
+    logger.info({ connectorId }, "Starting migration");
+    await migrateConnector(connector, execute, logger);
+    logger.info({ connectorId }, "Migration done");
+  }
+);

--- a/connectors/migrations/20250710_cleanup_duplicate_zendesk_tickets.ts
+++ b/connectors/migrations/20250710_cleanup_duplicate_zendesk_tickets.ts
@@ -62,6 +62,15 @@ async function migrateConnector(
           },
           "Destroyed duplicate ticket"
         );
+      } else {
+        logger.info(
+          {
+            connectorId: connector.id,
+            ticketId: ticket.ticketId,
+            brandId: ticket.brandId,
+          },
+          "Would destroy duplicate ticket"
+        );
       }
     }
   }


### PR DESCRIPTION
## Description

- Up until now, we've worked under the assumption that a ticket discovered using the incremental endpoint belonged to the brand whose subdomain we're using, which turns out to be untrue.
- This issue was addressed in https://github.com/dust-tt/dust/pull/14255
- This PR adds a script to do the cleanup.

## Tests

- Tested locally.

## Risk

- None.

## Deploy Plan

- No deploy, dry run the script and then execute.
