### PR TITLE
[front] fix file generation tool for generating files

### DIFF
--- a/front/lib/actions/mcp_internal_actions/servers/file_generation.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/file_generation.ts
@@ -237,7 +237,7 @@ const createServer = (auth: Authenticator): McpServer => {
         return makeMCPToolTextError("Missing environment variable.");
       }
 
-      // Remove the leading dot.
+      // Remove the leading dot from the extension.
       const extension = extname(file_name).replace(/^\./, "");
       if (!isValidOutputType(extension)) {
         return {

--- a/front/lib/actions/mcp_internal_actions/servers/file_generation.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/file_generation.ts
@@ -237,7 +237,8 @@ const createServer = (auth: Authenticator): McpServer => {
         return makeMCPToolTextError("Missing environment variable.");
       }
 
-      const extension = extname(file_name);
+      // Remove the leading dot.
+      const extension = extname(file_name).replace(/^\./, "");
       if (!isValidOutputType(extension)) {
         return {
           isError: false,

--- a/front/lib/actions/mcp_internal_actions/servers/file_generation.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/file_generation.ts
@@ -148,11 +148,11 @@ const createServer = (auth: Authenticator): McpServer => {
         return makeMCPToolTextError("Missing environment variable.");
       }
 
-      let contentType: SupportedFileContentType | null =
-        getContentTypeFromOutputFormat(output_format);
+      const contentType = getContentTypeFromOutputFormat(output_format);
 
       const convertapi = new ConvertAPI(process.env.CONVERTAPI_API_KEY);
       let url: string | UploadResult = input;
+
       if (!validateUrl(input).valid) {
         const r = getResourceNameAndIdFromSId(input);
         if (r && r.resourceName === "file") {
@@ -161,14 +161,14 @@ const createServer = (auth: Authenticator): McpServer => {
             auth,
             resourceModelId
           );
-          if (file) {
-            url = await convertapi.upload(
-              file.getReadStream({ auth, version: "original" }),
-              `${file_name}.${source_format}`
-            );
-          } else {
+          if (!file) {
             return makeMCPToolTextError(`File not found: ${input}`);
           }
+
+          url = await convertapi.upload(
+            file.getReadStream({ auth, version: "original" }),
+            `${file_name}.${source_format}`
+          );
         } else {
           url = await convertapi.upload(
             Readable.from(input),
@@ -191,7 +191,7 @@ const createServer = (auth: Authenticator): McpServer => {
           resource: {
             mimeType: contentType,
             uri: file.url,
-            text: `Your file was generated successfully.`,
+            text: "Your file was generated successfully.",
           },
         }));
 

--- a/front/lib/actions/mcp_internal_actions/servers/file_generation.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/file_generation.ts
@@ -3,6 +3,7 @@ import { Readable } from "node:stream";
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import type { UploadResult } from "convertapi";
 import ConvertAPI from "convertapi";
+import { extname } from "path";
 import { z } from "zod";
 
 import { makeMCPToolTextError } from "@app/lib/actions/mcp_internal_actions/utils";
@@ -41,8 +42,14 @@ const OUTPUT_FORMATS = [
   "xml",
 ] as const;
 
+type OutputFormatType = (typeof OUTPUT_FORMATS)[number];
+
+function isValidOutputType(extension: string): extension is OutputFormatType {
+  return OUTPUT_FORMATS.includes(extension as OutputFormatType);
+}
+
 function getContentTypeFromOutputFormat(
-  outputFormat: (typeof OUTPUT_FORMATS)[number]
+  outputFormat: OutputFormatType
 ): SupportedFileContentType {
   switch (outputFormat) {
     case "md":
@@ -120,19 +127,18 @@ const createServer = (auth: Authenticator): McpServer => {
   );
 
   server.tool(
-    "generate_file",
-    "Generate a file by converting between formats. Only use this tool when the source_format differs from the output_format. If the formats are the same, the file can be used directly.",
+    "convert_file_format",
+    "Converts a file from one format to another.",
     {
       file_name: z
         .string()
         .describe(
           "The name of the file to generate. Must be a valid filename without the format extension."
         ),
-      input: z
+      file_id_or_url: z
         .string()
-        .max(64000)
         .describe(
-          "The content of the file to generate. You can either provide the id of a file in the conversation (note: if the file ID is already in the desired format, no conversion is needed), the url to a file or the content directly."
+          "The ID or URL of the file to convert. You can either provide the ID of a file in the conversation (note: if the file ID is already in the desired format, no conversion is needed) or the URL to a file."
         ),
       source_format: z
         .string()
@@ -143,7 +149,7 @@ const createServer = (auth: Authenticator): McpServer => {
         .enum(OUTPUT_FORMATS)
         .describe("The format of the output file."),
     },
-    async ({ file_name, input, source_format, output_format }) => {
+    async ({ file_name, file_id_or_url, source_format, output_format }) => {
       if (!process.env.CONVERTAPI_API_KEY) {
         return makeMCPToolTextError("Missing environment variable.");
       }
@@ -151,18 +157,20 @@ const createServer = (auth: Authenticator): McpServer => {
       const contentType = getContentTypeFromOutputFormat(output_format);
 
       const convertapi = new ConvertAPI(process.env.CONVERTAPI_API_KEY);
-      let url: string | UploadResult = input;
+      let url: string | UploadResult = file_id_or_url;
 
-      if (!validateUrl(input).valid) {
-        const r = getResourceNameAndIdFromSId(input);
+      if (!validateUrl(file_id_or_url).valid) {
+        const r = getResourceNameAndIdFromSId(file_id_or_url);
+
         if (r && r.resourceName === "file") {
           const { resourceModelId } = r;
+
           const file = await FileResource.fetchByModelIdWithAuth(
             auth,
             resourceModelId
           );
           if (!file) {
-            return makeMCPToolTextError(`File not found: ${input}`);
+            return makeMCPToolTextError(`File not found: ${file_id_or_url}`);
           }
 
           url = await convertapi.upload(
@@ -171,7 +179,7 @@ const createServer = (auth: Authenticator): McpServer => {
           );
         } else {
           url = await convertapi.upload(
-            Readable.from(input),
+            Readable.from(file_id_or_url),
             `${file_name}.${source_format}`
           );
         }
@@ -201,9 +209,65 @@ const createServer = (auth: Authenticator): McpServer => {
         };
       } catch (e) {
         return makeMCPToolTextError(
-          `There was an error generating your file: ${normalizeError(e)}, maybe you can chain multiple conversions to get the result you want, pay attention to the source format you use.`
+          `There was an error generating your file: ${normalizeError(e)}. ` +
+            "You may be able to get the desired result by chaining multiple conversions, look closely to the source format you use."
         );
       }
+    }
+  );
+
+  server.tool(
+    "generate_file",
+    "Generate a file with some content.",
+    {
+      file_name: z
+        .string()
+        .describe(
+          "The name of the file to generate. Must be a valid filename with the format extension."
+        ),
+      file_content: z
+        .string()
+        .max(64000)
+        .describe(
+          "The content of the file to generate. You can either provide the id of a file in the conversation (note: if the file ID is already in the desired format, no conversion is needed), the url to a file or the content directly."
+        ),
+    },
+    async ({ file_name, file_content }) => {
+      if (!process.env.CONVERTAPI_API_KEY) {
+        return makeMCPToolTextError("Missing environment variable.");
+      }
+
+      const extension = extname(file_name);
+      if (!isValidOutputType(extension)) {
+        return {
+          isError: false,
+          content: [
+            {
+              type: "text",
+              text: `The format ${extension} is not supported.`,
+            },
+          ],
+        };
+      }
+
+      const contentType = getContentTypeFromOutputFormat(extension);
+
+      return {
+        isError: false,
+        content: [
+          {
+            type: "resource" as const,
+            // We return a base64 blob, it will be uploaded in MCPConfigurationServerRunner.run.
+            resource: {
+              name: file_name,
+              blob: Buffer.from(file_content).toString("base64"),
+              text: "Your file was generated successfully.",
+              mimeType: contentType,
+              uri: "",
+            },
+          },
+        ],
+      };
     }
   );
 

--- a/front/lib/actions/mcp_internal_actions/servers/file_generation.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/file_generation.ts
@@ -251,8 +251,6 @@ const createServer = (auth: Authenticator): McpServer => {
         };
       }
 
-      const contentType = getContentTypeFromOutputFormat(extension);
-
       return {
         isError: false,
         content: [
@@ -263,7 +261,7 @@ const createServer = (auth: Authenticator): McpServer => {
               name: file_name,
               blob: Buffer.from(file_content).toString("base64"),
               text: "Your file was generated successfully.",
-              mimeType: contentType,
+              mimeType: getContentTypeFromOutputFormat(extension),
               uri: "",
             },
           },

--- a/front/lib/actions/mcp_internal_actions/servers/file_generation.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/file_generation.ts
@@ -41,6 +41,45 @@ const OUTPUT_FORMATS = [
   "xml",
 ] as const;
 
+function getContentTypeFromOutputFormat(
+  outputFormat: (typeof OUTPUT_FORMATS)[number]
+): SupportedFileContentType {
+  switch (outputFormat) {
+    case "md":
+      return "text/markdown";
+    case "gif":
+      return "image/gif";
+    case "pdf":
+      return "application/pdf";
+    case "doc":
+      return "application/msword";
+    case "docx":
+      return "application/vnd.openxmlformats-officedocument.wordprocessingml.document";
+    case "pptx":
+      return "application/vnd.openxmlformats-officedocument.presentationml.presentation";
+    case "csv":
+      return "text/csv";
+    case "txt":
+      return "text/plain";
+    case "html":
+      return "text/html";
+    case "jpg":
+      return "image/jpeg";
+    case "png":
+      return "image/png";
+    case "xml":
+      return "text/xml";
+    case "xls":
+      return "application/vnd.ms-excel";
+    case "xlsx":
+      return "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet";
+    case "webp":
+      return "image/webp";
+    default:
+      assertNever(outputFormat);
+  }
+}
+
 const createServer = (auth: Authenticator): McpServer => {
   const server = new McpServer(serverInfo);
   server.tool(
@@ -109,60 +148,8 @@ const createServer = (auth: Authenticator): McpServer => {
         return makeMCPToolTextError("Missing environment variable.");
       }
 
-      let contentType: SupportedFileContentType | null;
-      switch (output_format) {
-        case "md":
-          contentType = "text/markdown";
-          break;
-        case "gif":
-          contentType = "image/gif";
-          break;
-        case "pdf":
-          contentType = "application/pdf";
-          break;
-        case "doc":
-          contentType = "application/msword";
-          break;
-        case "docx":
-          contentType =
-            "application/vnd.openxmlformats-officedocument.wordprocessingml.document";
-          break;
-        case "pptx":
-          contentType =
-            "application/vnd.openxmlformats-officedocument.presentationml.presentation";
-          break;
-        case "csv":
-          contentType = "text/csv";
-          break;
-        case "txt":
-          contentType = "text/plain";
-          break;
-        case "html":
-          contentType = "text/html";
-          break;
-        case "jpg":
-          contentType = "image/jpeg";
-          break;
-        case "png":
-          contentType = "image/png";
-          break;
-        case "xml":
-          contentType = "text/xml";
-          break;
-        case "xls":
-          contentType = "application/vnd.ms-excel";
-          break;
-        case "xlsx":
-          contentType =
-            "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet";
-          break;
-        case "webp":
-          contentType = "image/webp";
-          break;
-
-        default:
-          assertNever(output_format);
-      }
+      let contentType: SupportedFileContentType | null =
+        getContentTypeFromOutputFormat(output_format);
 
       const convertapi = new ConvertAPI(process.env.CONVERTAPI_API_KEY);
       let url: string | UploadResult = input;

--- a/front/pages/api/v1/w/[wId]/files/[fileId].ts
+++ b/front/pages/api/v1/w/[wId]/files/[fileId].ts
@@ -16,7 +16,7 @@ import logger from "@app/logger/logger";
 import { apiError } from "@app/logger/withlogging";
 import { getSecureFileAction } from "@app/pages/api/w/[wId]/files/[fileId]";
 import type { WithAPIErrorResponse } from "@app/types";
-import { isPublicySupportedUseCase } from "@app/types";
+import { isPubliclySupportedUseCase } from "@app/types";
 
 export const config = {
   api: {
@@ -58,7 +58,7 @@ async function handler(
 
   if (!auth.isSystemKey()) {
     // Limit use-case if not a system key.
-    if (!isPublicySupportedUseCase(file.useCase)) {
+    if (!isPubliclySupportedUseCase(file.useCase)) {
       return apiError(req, res, {
         status_code: 400,
         api_error: {

--- a/front/pages/api/v1/w/[wId]/files/index.ts
+++ b/front/pages/api/v1/w/[wId]/files/index.ts
@@ -13,7 +13,7 @@ import { apiError } from "@app/logger/withlogging";
 import type { WithAPIErrorResponse } from "@app/types";
 import {
   ensureFileSize,
-  isPublicySupportedUseCase,
+  isPubliclySupportedUseCase,
   isSupportedFileContentType,
 } from "@app/types";
 
@@ -129,7 +129,7 @@ async function handler(
         }
 
         // Limit use-case if not a system key.
-        if (!isPublicySupportedUseCase(useCase)) {
+        if (!isPubliclySupportedUseCase(useCase)) {
           return apiError(req, res, {
             status_code: 400,
             api_error: {

--- a/front/types/files.ts
+++ b/front/types/files.ts
@@ -342,7 +342,7 @@ export function isSupportedFileContentType(
 }
 
 // UseCases supported on the public API
-export function isPublicySupportedUseCase(
+export function isPubliclySupportedUseCase(
   useCase: string
 ): useCase is FileUseCase {
   return ["conversation"].includes(useCase);


### PR DESCRIPTION
## Description

- Closes https://github.com/dust-tt/tasks/issues/3424.
- Currently the file generation tool cannot generate files from content directly. Instead the agent has to find out that it has to generate a file in a different format and then convert it (example [here](https://dust.tt/w/0ec9852c2f/assistant/fhVIKFsEMq)).

## Tests

- Tested locally.

## Risk

- Low.

## Deploy Plan

- Deploy front.
