### PR TITLE
Move set and clear user outside of _app

### DIFF
--- a/front/components/UserMenu.tsx
+++ b/front/components/UserMenu.tsx
@@ -1,3 +1,4 @@
+import { datadogLogs } from "@datadog/browser-logs";
 import {
   Avatar,
   ChevronDownIcon,
@@ -167,6 +168,7 @@ export function UserMenu({
           label="Sign&nbsp;out"
           icon={LogoutIcon}
           onClick={() => {
+            datadogLogs.clearUser();
             if (document.cookie.includes("sessionType=workos")) {
               window.location.href = "/api/workos/logout";
             } else {

--- a/front/components/sparkle/AppRootLayout.tsx
+++ b/front/components/sparkle/AppRootLayout.tsx
@@ -5,6 +5,7 @@ import React, { useEffect } from "react";
 import { WelcomeTourGuideProvider } from "@app/components/assistant/WelcomeTourGuideProvider";
 import { QuickStartGuide } from "@app/components/QuickStartGuide";
 import { ThemeProvider } from "@app/components/sparkle/ThemeContext";
+import { useDatadogLogs } from "@app/hooks/useDatadogLogs";
 import { useUser } from "@app/lib/swr/user";
 
 // TODO(2025-04-11 yuka) We need to refactor AppLayout to avoid re-mounting on every page navigation.
@@ -16,6 +17,7 @@ export default function AppRootLayout({
   children: React.ReactNode;
 }) {
   const { user } = useUser();
+  useDatadogLogs();
 
   useEffect(() => {
     if (typeof window !== "undefined" && user?.sId) {

--- a/front/hooks/useDatadogLogs.ts
+++ b/front/hooks/useDatadogLogs.ts
@@ -1,0 +1,31 @@
+import { datadogLogs } from "@datadog/browser-logs";
+import { useRouter } from "next/router";
+import { useEffect } from "react";
+
+import { useUser } from "@app/lib/swr/user";
+
+export function useDatadogLogs() {
+  const { user } = useUser();
+  const userId = user?.sId;
+
+  const router = useRouter();
+  const { wId } = router.query;
+
+  useEffect(() => {
+    if (userId) {
+      datadogLogs.setUser({
+        id: userId,
+      });
+    }
+  }, [userId]);
+
+  useEffect(() => {
+    if (wId) {
+      datadogLogs.setGlobalContext({
+        workspaceId: wId,
+      });
+    } else {
+      datadogLogs.setGlobalContext({});
+    }
+  }, [wId]);
+}

--- a/front/pages/_app.tsx
+++ b/front/pages/_app.tsx
@@ -8,11 +8,8 @@ import "@app/styles/components.css";
 import { datadogLogs } from "@datadog/browser-logs";
 import type { NextPage } from "next";
 import type { AppProps } from "next/app";
-import { useRouter } from "next/router";
-import { useEffect } from "react";
 
 import RootLayout from "@app/components/app/RootLayout";
-import { useUser } from "@app/lib/swr/user";
 
 if (process.env.NEXT_PUBLIC_DATADOG_CLIENT_TOKEN) {
   datadogLogs.init({
@@ -40,38 +37,6 @@ type AppPropsWithLayout = AppProps & {
 export default function App({ Component, pageProps }: AppPropsWithLayout) {
   // Use the layout defined at the page level, if available.
   const getLayout = Component.getLayout ?? ((page) => page);
-
-  const router = useRouter();
-  const { wId } = router.query;
-  useEffect(() => {
-    const updateLoggerContext = () => {
-      if (wId) {
-        datadogLogs.setGlobalContext({
-          workspaceId: wId,
-        });
-      } else {
-        datadogLogs.setGlobalContext({});
-      }
-    };
-
-    updateLoggerContext();
-    router.events.on("routeChangeComplete", updateLoggerContext);
-    return () => {
-      router.events.off("routeChangeComplete", updateLoggerContext);
-    };
-  }, [wId, router.events]);
-
-  const { user } = useUser();
-  const userId = user?.sId;
-  useEffect(() => {
-    if (userId) {
-      datadogLogs.setUser({
-        id: userId,
-      });
-    } else {
-      datadogLogs.clearUser();
-    }
-  }, [userId]);
 
   return (
     <RootLayout>


### PR DESCRIPTION
## Description

Move set and clear user functionality outside of _app component to improve code organization and separation of concerns. This refactoring moves user-related logic from the main app component to more appropriate locations in the component hierarchy.

## Tests

Manual testing to ensure user functionality continues to work correctly after the refactoring.

## Risk

Low risk - This is a refactoring that moves existing functionality without changing the core logic. The changes are safe to rollback if any issues are discovered.

## Deploy Plan

Standard deployment process. No special considerations needed as this is a code organization improvement that doesn't affect user-facing functionality.