### PR TITLE
fix(snowflake): replace underscore in account name

### DIFF
--- a/connectors/src/connectors/snowflake/lib/snowflake_api.ts
+++ b/connectors/src/connectors/snowflake/lib/snowflake_api.ts
@@ -130,7 +130,8 @@ export async function connectToSnowflake(
   });
   try {
     const connectionOptions: ConnectionOptions = {
-      account: credentials.account,
+      // Replace any `_` with `-` in the account name for nginx proxy.
+      account: credentials.account.replace(/_/g, "-"),
       username: credentials.username,
       role: credentials.role,
       warehouse: credentials.warehouse,

--- a/core/src/databases/remote_databases/snowflake/api/client.rs
+++ b/core/src/databases/remote_databases/snowflake/api/client.rs
@@ -68,7 +68,8 @@ impl SnowflakeClient {
         let session_token = login(&self.http, &self.username, &self.auth, &self.config).await?;
         Ok(SnowflakeSession {
             http: self.http.clone(),
-            account: self.config.account.clone(),
+            // Replace any `_` with `-` in the account name for nginx proxy.
+            account: self.config.account.clone().replace('_', "-"),
             session_token,
             timeout: self.config.timeout,
         })


### PR DESCRIPTION
## Description

nginx drops headers that contain an `_` which makes it fail for snowflake accounts that contain an underscore. An easy fix is to replace with a hyphen.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
