### PR TITLE
[sparkle] - refact(Bar): streamline bar component with `ButtonProps`

### DIFF
--- a/sparkle/src/components/Bar.tsx
+++ b/sparkle/src/components/Bar.tsx
@@ -117,14 +117,6 @@ export type BarButtonBarProps =
   | BarButtonBarValidateProps
   | BarButtonBarConversationProps;
 
-function ValidateSaveButton(props: BarButtonBarValidateProps) {
-  if (!props.saveButtonProps) {
-    return null;
-  }
-
-  return <Button {...props.saveButtonProps} />;
-}
-
 Bar.ButtonBar = function (props: BarButtonBarProps) {
   switch (props.variant) {
     case "back":
@@ -151,7 +143,7 @@ Bar.ButtonBar = function (props: BarButtonBarProps) {
       return (
         <>
           {props.cancelButtonProps && <Button {...props.cancelButtonProps} />}
-          <ValidateSaveButton {...props} />
+          {props.saveButtonProps && <Button {...props.saveButtonProps} />}
         </>
       );
     case "conversation":

--- a/sparkle/src/components/Bar.tsx
+++ b/sparkle/src/components/Bar.tsx
@@ -10,7 +10,7 @@ import {
 } from "@sparkle/icons/app";
 import { cn } from "@sparkle/lib/utils";
 
-import { Button } from "./Button";
+import { Button, type ButtonProps } from "./Button";
 
 const barVariants = cva(
   "s-flex s-h-16 s-flex-row s-items-center s-gap-3 s-px-4",
@@ -101,13 +101,8 @@ type BarButtonBarBackProps = {
 
 type BarButtonBarValidateProps = {
   variant: "validate";
-  onCancel?: () => void;
-  onSave?: () => void;
-  saveLabel?: string;
-  isSaving?: boolean;
-  isDisabled?: boolean;
-  savingLabel?: string;
-  saveTooltip?: string;
+  cancelButtonProps?: ButtonProps;
+  saveButtonProps?: ButtonProps;
 };
 
 type BarButtonBarConversationProps = {
@@ -123,25 +118,11 @@ export type BarButtonBarProps =
   | BarButtonBarConversationProps;
 
 function ValidateSaveButton(props: BarButtonBarValidateProps) {
-  const button = (
-    <Button
-      size="sm"
-      label={
-        props.isSaving
-          ? props.savingLabel || "Processing..."
-          : props.saveLabel || "Save"
-      }
-      variant="primary"
-      onClick={props.onSave}
-      disabled={!props.onSave || props.isSaving}
-    />
-  );
+  if (!props.saveButtonProps) {
+    return null;
+  }
 
-  return props.saveTooltip ? (
-    <Tooltip label={props.saveTooltip} side="left" trigger={button} />
-  ) : (
-    button
-  );
+  return <Button {...props.saveButtonProps} />;
 }
 
 Bar.ButtonBar = function (props: BarButtonBarProps) {
@@ -169,13 +150,7 @@ Bar.ButtonBar = function (props: BarButtonBarProps) {
     case "validate":
       return (
         <>
-          <Button
-            size="sm"
-            label="Cancel"
-            variant="ghost"
-            onClick={props.onCancel}
-            disabled={!props.onCancel || props.isSaving || props.isDisabled}
-          />
+          {props.cancelButtonProps && <Button {...props.cancelButtonProps} />}
           <ValidateSaveButton {...props} />
         </>
       );

--- a/sparkle/src/stories/Bar.stories.tsx
+++ b/sparkle/src/stories/Bar.stories.tsx
@@ -44,13 +44,18 @@ export const BasicBarHeaderValidate = () => {
         rightActions={
           <Bar.ButtonBar
             variant="validate"
-            isSaving={isSaving}
-            onSave={() => {
-              setIsSaving(true);
-              setTimeout(() => {
-                setIsSaving(false);
-                alert("Save !");
-              }, 2000);
+            saveButtonProps={{
+              size: "sm",
+              label: isSaving ? "Saving..." : "Save",
+              variant: "primary",
+              onClick: () => {
+                setIsSaving(true);
+                setTimeout(() => {
+                  setIsSaving(false);
+                  alert("Save !");
+                }, 2000);
+              },
+              disabled: isSaving,
             }}
           />
         }
@@ -111,14 +116,24 @@ export const BasicBarFooterValidate = () => {
         rightActions={
           <Bar.ButtonBar
             variant="validate"
-            isSaving={isSaving}
-            onCancel={() => alert("Cancelled!")}
-            onSave={() => {
-              setIsSaving(true);
-              setTimeout(() => {
-                setIsSaving(false);
-                alert("Saved!");
-              }, 2000);
+            cancelButtonProps={{
+              size: "sm",
+              label: "Cancel",
+              variant: "ghost",
+              onClick: () => alert("Cancelled!"),
+            }}
+            saveButtonProps={{
+              size: "sm",
+              label: isSaving ? "Saving..." : "Save",
+              variant: "primary",
+              onClick: () => {
+                setIsSaving(true);
+                setTimeout(() => {
+                  setIsSaving(false);
+                  alert("Saved!");
+                }, 2000);
+              },
+              disabled: isSaving,
             }}
           />
         }
@@ -168,14 +183,24 @@ export const HeaderAndFooterCombined = () => {
         rightActions={
           <Bar.ButtonBar
             variant="validate"
-            isSaving={isSaving}
-            onCancel={() => alert("Cancelled!")}
-            onSave={() => {
-              setIsSaving(true);
-              setTimeout(() => {
-                setIsSaving(false);
-                alert("Saved!");
-              }, 2000);
+            cancelButtonProps={{
+              size: "sm",
+              label: "Cancel",
+              variant: "ghost",
+              onClick: () => alert("Cancelled!"),
+            }}
+            saveButtonProps={{
+              size: "sm",
+              label: isSaving ? "Saving..." : "Save",
+              variant: "primary",
+              onClick: () => {
+                setIsSaving(true);
+                setTimeout(() => {
+                  setIsSaving(false);
+                  alert("Saved!");
+                }, 2000);
+              },
+              disabled: isSaving,
             }}
           />
         }
@@ -220,14 +245,24 @@ export const DefaultVariantInPanel = () => {
               rightActions={
                 <Bar.ButtonBar
                   variant="validate"
-                  isSaving={isSaving}
-                  onCancel={() => alert("Cancelled!")}
-                  onSave={() => {
-                    setIsSaving(true);
-                    setTimeout(() => {
-                      setIsSaving(false);
-                      alert("Saved!");
-                    }, 2000);
+                  cancelButtonProps={{
+                    size: "sm",
+                    label: "Cancel",
+                    variant: "ghost",
+                    onClick: () => alert("Cancelled!"),
+                  }}
+                  saveButtonProps={{
+                    size: "sm",
+                    label: isSaving ? "Saving..." : "Save",
+                    variant: "primary",
+                    onClick: () => {
+                      setIsSaving(true);
+                      setTimeout(() => {
+                        setIsSaving(false);
+                        alert("Saved!");
+                      }, 2000);
+                    },
+                    disabled: isSaving,
                   }}
                 />
               }
@@ -267,8 +302,18 @@ export const DefaultVariantInPanel = () => {
               rightActions={
                 <Bar.ButtonBar
                   variant="validate"
-                  onCancel={() => alert("Cancelled!")}
-                  onSave={() => alert("Saved!")}
+                  cancelButtonProps={{
+                    size: "sm",
+                    label: "Cancel",
+                    variant: "ghost",
+                    onClick: () => alert("Cancelled!"),
+                  }}
+                  saveButtonProps={{
+                    size: "sm",
+                    label: "Save",
+                    variant: "primary",
+                    onClick: () => alert("Saved!"),
+                  }}
                 />
               }
             />


### PR DESCRIPTION
## Description

This PR streamlines the `Bar` component's button handling by replacing individual button props with the more structured ButtonProps type. This change reduces prop redundancy and improves code maintainability by leveraging the existing `ButtonProps` interface for both cancel and save buttons in the Bar's validate variant.

## Risk

Medium, introduces non-backward compatible changes

## Deploy Plan

- Publish sparkle RC
- Update front
- Publish sparkle
- Update front
