### PR TITLE
[sparkle] - fix(Sheet): sheet footer children

### DIFF
--- a/sparkle/src/components/MultiPageSheet.tsx
+++ b/sparkle/src/components/MultiPageSheet.tsx
@@ -159,38 +159,37 @@ const MultiPageSheetContent = React.forwardRef<
             variant: "outline",
             size: "sm",
           }}
+          rightButtonProps={
+            showNavigation && pages.length > 1 && hasPrevious
+              ? {
+                  label: "Previous",
+                  variant: "outline",
+                  size: "sm",
+                  onClick: handlePrevious,
+                }
+              : undefined
+          }
+          rightEndButtonProps={
+            showNavigation && pages.length > 1 && hasNext
+              ? {
+                  label: "Next",
+                  variant: "outline",
+                  size: "sm",
+                  disabled: disableNext,
+                  onClick: handleNext,
+                }
+              : showNavigation && pages.length > 1 && !hasNext && onSave
+                ? {
+                    label: "Save changes",
+                    variant: "primary",
+                    size: "sm",
+                    disabled: disableSave,
+                    onClick: onSave,
+                  }
+                : undefined
+          }
         >
-          <div className="s-ml-auto s-flex s-items-center s-gap-2">
-            {showNavigation && pages.length > 1 && hasPrevious && (
-              <Button
-                label="Previous"
-                icon={ChevronLeftIcon}
-                variant="outline"
-                size="sm"
-                onClick={handlePrevious}
-              />
-            )}
-            {showNavigation && pages.length > 1 && hasNext && (
-              <Button
-                label="Next"
-                icon={ChevronRightIcon}
-                variant="outline"
-                size="sm"
-                disabled={disableNext}
-                onClick={handleNext}
-              />
-            )}
-            {showNavigation && pages.length > 1 && !hasNext && onSave && (
-              <Button
-                label="Save changes"
-                variant="primary"
-                size="sm"
-                disabled={disableSave}
-                onClick={onSave}
-              />
-            )}
-            {footerContent}
-          </div>
+          {footerContent}
         </SheetFooter>
       </SheetContent>
     );

--- a/sparkle/src/components/Sheet.tsx
+++ b/sparkle/src/components/Sheet.tsx
@@ -172,37 +172,39 @@ const SheetFooter = ({
 }: SheetFooterProps) => (
   <div
     className={cn(
-      "s-flex s-flex-none s-flex-row s-gap-2 s-border-t s-px-3 s-py-3",
+      "s-flex s-flex-none s-flex-col s-gap-2 s-border-t s-px-3 s-py-3",
       "s-border-border dark:s-border-border-night",
       className
     )}
     {...props}
   >
-    {leftButtonProps &&
-      (leftButtonProps.disabled ? (
-        <Button {...leftButtonProps} />
-      ) : (
-        <SheetClose className={sheetCloseClassName} asChild>
+    <div className="s-flex s-flex-row s-gap-2">
+      {leftButtonProps &&
+        (leftButtonProps.disabled ? (
           <Button {...leftButtonProps} />
-        </SheetClose>
-      ))}
-    <div className="s-flex-grow" />
-    {rightButtonProps &&
-      (rightButtonProps.disabled ? (
-        <Button {...rightButtonProps} />
-      ) : (
-        <SheetClose className={sheetCloseClassName} asChild>
+        ) : (
+          <SheetClose className={sheetCloseClassName} asChild>
+            <Button {...leftButtonProps} />
+          </SheetClose>
+        ))}
+      <div className="s-flex-grow" />
+      {rightButtonProps &&
+        (rightButtonProps.disabled ? (
           <Button {...rightButtonProps} />
-        </SheetClose>
-      ))}
-    {rightEndButtonProps &&
-      (rightEndButtonProps.disabled ? (
-        <Button {...rightEndButtonProps} />
-      ) : (
-        <SheetClose className={sheetCloseClassName} asChild>
+        ) : (
+          <SheetClose className={sheetCloseClassName} asChild>
+            <Button {...rightButtonProps} />
+          </SheetClose>
+        ))}
+      {rightEndButtonProps &&
+        (rightEndButtonProps.disabled ? (
           <Button {...rightEndButtonProps} />
-        </SheetClose>
-      ))}
+        ) : (
+          <SheetClose className={sheetCloseClassName} asChild>
+            <Button {...rightEndButtonProps} />
+          </SheetClose>
+        ))}
+    </div>
     {children}
   </div>
 );

--- a/sparkle/src/stories/MultiPageSheet.stories.tsx
+++ b/sparkle/src/stories/MultiPageSheet.stories.tsx
@@ -458,7 +458,7 @@ export const WithConditionalNavigation: Story = {
           disableSave={!description.trim()}
           footerContent={
             <div className="s-w-full s-border s-border-border-dark">
-              Hello bro
+              This is a footer content
             </div>
           }
         />

--- a/sparkle/src/stories/MultiPageSheet.stories.tsx
+++ b/sparkle/src/stories/MultiPageSheet.stories.tsx
@@ -456,6 +456,11 @@ export const WithConditionalNavigation: Story = {
             currentPageId === "data-selection" && selectedItems.length === 0
           }
           disableSave={!description.trim()}
+          footerContent={
+            <div className="s-w-full s-border s-border-border-dark">
+              Hello bro
+            </div>
+          }
         />
       </MultiPageSheet>
     );


### PR DESCRIPTION
## Description

This PR streamlines the button rendering in `MultiPageSheet` by moving conditional logic for navigation buttons into `rightButtonProps` and `rightEndButtonProps`. The `SheetFooter` has been reorganized to support conditional rendering of buttons with a better structure using `SheetClose` wrapping.

## Risk

UX break

## Deploy Plan

Publish sparkle
