### PR TITLE
fix: select default reaasoning for model

### DIFF
--- a/front/components/agent_builder/instructions/ModelSelectionSubmenu.tsx
+++ b/front/components/agent_builder/instructions/ModelSelectionSubmenu.tsx
@@ -46,22 +46,30 @@ function ModelRadioItem({
 
 export function ModelSelectionSubmenu({ models }: ModelSelectionSubmenuProps) {
   const { isDark } = useTheme();
-  const { field } = useController<
+  const { field: modelField } = useController<
     AgentBuilderFormData,
     "generationSettings.modelSettings"
   >({
     name: "generationSettings.modelSettings",
   });
+  const { field: reasoningEffortField } = useController<
+    AgentBuilderFormData,
+    "generationSettings.reasoningEffort"
+  >({
+    name: "generationSettings.reasoningEffort",
+  });
   const { bestPerformingModelConfigs, otherModelConfigs } =
     categorizeModels(models);
 
-  const currentModelKey = field.value.modelId;
+  const currentModelKey = modelField.value.modelId;
 
   const handleModelSelection = (modelConfig: ModelConfigurationType) => {
-    field.onChange({
+    modelField.onChange({
       modelId: modelConfig.modelId,
       providerId: modelConfig.providerId,
     });
+    // Set reasoning effort to the model's default
+    reasoningEffortField.onChange(modelConfig.defaultReasoningEffort);
   };
 
   return (

--- a/front/components/assistant_builder/AdvancedSettings.tsx
+++ b/front/components/assistant_builder/AdvancedSettings.tsx
@@ -31,7 +31,6 @@ import {
   GPT_4O_MODEL_ID,
   isSupportingResponseFormat,
   MISTRAL_LARGE_MODEL_ID,
-  REASONING_EFFORT_IDS,
 } from "@app/types";
 
 const CodeEditor = dynamic(
@@ -135,31 +134,13 @@ export function AdvancedSettings({
                   description={modelConfig.shortDescription}
                   label={modelConfig.displayName}
                   onClick={() => {
-                    const currentReasoningEffort =
-                      generationSettings.reasoningEffort;
-                    const reasoningEffortIndex = REASONING_EFFORT_IDS.indexOf(
-                      currentReasoningEffort
-                    );
-                    const minIndex = REASONING_EFFORT_IDS.indexOf(
-                      modelConfig.minimumReasoningEffort
-                    );
-                    const maxIndex = REASONING_EFFORT_IDS.indexOf(
-                      modelConfig.maximumReasoningEffort
-                    );
-
-                    const newReasoningEffort =
-                      reasoningEffortIndex < minIndex ||
-                      reasoningEffortIndex > maxIndex
-                        ? modelConfig.defaultReasoningEffort
-                        : currentReasoningEffort;
-
                     setGenerationSettings({
                       ...generationSettings,
                       modelSettings: {
                         modelId: modelConfig.modelId,
                         providerId: modelConfig.providerId,
                       },
-                      reasoningEffort: newReasoningEffort,
+                      reasoningEffort: modelConfig.defaultReasoningEffort,
                     });
                   }}
                 />
@@ -178,31 +159,13 @@ export function AdvancedSettings({
                   description={modelConfig.shortDescription}
                   label={modelConfig.displayName}
                   onClick={() => {
-                    const currentReasoningEffort =
-                      generationSettings.reasoningEffort;
-                    const reasoningEffortIndex = REASONING_EFFORT_IDS.indexOf(
-                      currentReasoningEffort
-                    );
-                    const minIndex = REASONING_EFFORT_IDS.indexOf(
-                      modelConfig.minimumReasoningEffort
-                    );
-                    const maxIndex = REASONING_EFFORT_IDS.indexOf(
-                      modelConfig.maximumReasoningEffort
-                    );
-
-                    const newReasoningEffort =
-                      reasoningEffortIndex < minIndex ||
-                      reasoningEffortIndex > maxIndex
-                        ? modelConfig.defaultReasoningEffort
-                        : currentReasoningEffort;
-
                     setGenerationSettings({
                       ...generationSettings,
                       modelSettings: {
                         modelId: modelConfig.modelId,
                         providerId: modelConfig.providerId,
                       },
-                      reasoningEffort: newReasoningEffort,
+                      reasoningEffort: modelConfig.defaultReasoningEffort,
                     });
                   }}
                 />


### PR DESCRIPTION
## Description

When switching between models in the builder, we need to automatically select the default reasoning effort for the model.
## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
