### PR TITLE
fix: disable extract on query-able attachments

### DIFF
--- a/front/lib/api/assistant/conversation/attachments.ts
+++ b/front/lib/api/assistant/conversation/attachments.ts
@@ -111,7 +111,9 @@ export function getAttachmentFromContentNodeContentFragment(
   const isSearchable =
     isSearchableContentType(cf.contentType) && !isUnmaterializedTable;
   const isExtractable =
-    isExtractableContentType(cf.contentType) && !isUnmaterializedTable;
+    isExtractableContentType(cf.contentType) &&
+    !isUnmaterializedTable &&
+    !isQueryable;
 
   const baseAttachment: BaseConversationAttachmentType = {
     title: cf.title,
@@ -149,7 +151,8 @@ export function getAttachmentFromFileContentFragment(
   const isQueryable = canDoJIT && isQueryableContentType(cf.contentType);
   const isIncludable = isConversationIncludableFileContentType(cf.contentType);
   const isSearchable = canDoJIT && isSearchableContentType(cf.contentType);
-  const isExtractable = canDoJIT && isExtractableContentType(cf.contentType);
+  const isExtractable =
+    canDoJIT && isExtractableContentType(cf.contentType) && !isQueryable;
   const baseAttachment: BaseConversationAttachmentType = {
     title: cf.title,
     contentType: cf.contentType,
@@ -190,7 +193,8 @@ export function getAttachmentFromToolOutput({
   const isIncludable = isConversationIncludableFileContentType(contentType);
   const isQueryable = canDoJIT && isQueryableContentType(contentType);
   const isSearchable = canDoJIT && isSearchableContentType(contentType);
-  const isExtractable = canDoJIT && isExtractableContentType(contentType);
+  const isExtractable =
+    canDoJIT && isExtractableContentType(contentType) && !isQueryable;
 
   return {
     fileId,


### PR DESCRIPTION
## Description

Extract data doesn't make much sense for files that can be queried with SQL, as the same is achievable through SQL.
Agents are biasing towards extract, which leads to bad results and is a regression

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
