### PR TITLE
[ext] fix paste url that renders multiple attachments

### DIFF
--- a/extension/ui/components/input_bar/InputBar.tsx
+++ b/extension/ui/components/input_bar/InputBar.tsx
@@ -186,7 +186,15 @@ export function AssistantInputBar({
   }, []);
 
   const handleNodesAttachmentSelect = (node: DataSourceViewContentNodeType) => {
-    setAttachedNodes((prev) => [...prev, node]);
+    const isNodeAlreadyAttached = attachedNodes.some(
+      (attachedNode) =>
+        attachedNode.internalId === node.internalId &&
+        attachedNode.dataSourceView.dataSource.sId ===
+          node.dataSourceView.dataSource.sId
+    );
+    if (!isNodeAlreadyAttached) {
+      setAttachedNodes((prev) => [...prev, node]);
+    }
   };
 
   const handleNodesAttachmentRemove = (node: DataSourceViewContentNodeType) => {


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

In front, we were checking before adding the attached nodes to the input bar, to see if the node was already attached or not. We're not doing that in the extension. This ports the behaviour to extension.

Fixes https://github.com/dust-tt/tasks/issues/3471

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

Tested by hand

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

Low

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->

Deploy extension