### PR TITLE
[front] chore: stop tracking "no table" errors

### DIFF
--- a/front/lib/actions/mcp_internal_actions/servers/tables_query/server.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/tables_query/server.ts
@@ -133,9 +133,15 @@ function createServer(
         };
       });
       if (configuredTables.length === 0) {
-        return makeMCPToolTextError(
-          "The agent does not have access to any tables. Please edit the agent's Query Tables tool to add tables, or remove the tool."
-        );
+        return {
+          isError: false,
+          content: [
+            {
+              type: "text",
+              text: "The agent does not have access to any tables. Please edit the agent's Query Tables tool to add tables, or remove the tool.",
+            },
+          ],
+        };
       }
       config.DATABASE_SCHEMA = {
         type: "database_schema",


### PR DESCRIPTION
## Description

- Currently we get the error `The agent does not have access to any tables` a lot.
- We don't have a very good product integration to prevent these but these errors are not reasonably actionable on our end.

## Tests

## Risk

- None

## Deploy Plan

- Deploy front.
