### PR TITLE
Show "no matching content" for pasted URLs without node ID

### DIFF
--- a/extension/ui/hooks/useSpacesSearch.ts
+++ b/extension/ui/hooks/useSpacesSearch.ts
@@ -69,7 +69,7 @@ export function useSpacesSearch({
     // Example: a user pastes a Google Drive folder link
     // It matches a valid provider but we extract no node IDs,
     // and we don't want to support fetching all contents of a folder.
-    if ((searchQuery.nodeIds?.length ?? 0) === 0) {
+    if (!searchQuery.nodeIds?.length) {
       return [];
     }
     const res = await dustAPI.searchNodes(searchQuery);

--- a/extension/ui/hooks/useSpacesSearch.ts
+++ b/extension/ui/hooks/useSpacesSearch.ts
@@ -65,6 +65,13 @@ export function useSpacesSearch({
     if (disabled) {
       return null;
     }
+    // Skip the query if no node IDs were extracted.
+    // Example: a user pastes a Google Drive folder link
+    // It matches a valid provider but we extract no node IDs,
+    // and we don't want to support fetching all contents of a folder.
+    if ((searchQuery.nodeIds?.length ?? 0) === 0) {
+      return [];
+    }
     const res = await dustAPI.searchNodes(searchQuery);
     if (res.isOk()) {
       return res.value;


### PR DESCRIPTION
## Description

Follow up fix for https://github.com/dust-tt/tasks/issues/3471

Show "no matching content" for pasted URLs without node ID to improve user experience when pasting unsupported URL formats.

This change adds a check in the `useSpacesSearch` hook to skip queries when no node IDs are extracted from pasted URLs. This prevents unnecessary API calls and provides better user feedback for cases like Google Drive folder links that match a valid provider but don't contain extractable node IDs.

## Tests

Manually tested by pasting Google Drive folder links and verifying that the search now returns an empty result instead of attempting to fetch all folder contents.

## Risk

Low risk - this is a defensive change that prevents unnecessary API calls and improves user experience. The change is safe and easily rollbackable.

## Deploy Plan

Standard deployment - no special considerations needed. The change is backward compatible and doesn't affect existing functionality.