### PR TITLE
[front] Improve error logging for TablesQuery v2

### DIFF
--- a/front/lib/actions/mcp_internal_actions/servers/tables_query/server_v2.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/tables_query/server_v2.ts
@@ -214,12 +214,6 @@ function createServer(
             isError: true,
             content: [
               {
-                type: "text",
-                text:
-                  "Error executing database query: " +
-                  queryResult.error.message,
-              },
-              {
                 type: "resource",
                 resource: {
                   text: EXECUTE_TABLES_QUERY_MARKER,

--- a/front/lib/actions/mcp_internal_actions/servers/tables_query/server_v2.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/tables_query/server_v2.ts
@@ -214,6 +214,12 @@ function createServer(
             isError: true,
             content: [
               {
+                type: "text",
+                text:
+                  "Error executing database query: " +
+                  queryResult.error.message,
+              },
+              {
                 type: "resource",
                 resource: {
                   text: EXECUTE_TABLES_QUERY_MARKER,

--- a/front/lib/actions/mcp_internal_actions/wrappers.ts
+++ b/front/lib/actions/mcp_internal_actions/wrappers.ts
@@ -1,11 +1,10 @@
 import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
 
+import { isExecuteTablesQueryErrorResourceType } from "@app/lib/actions/mcp_internal_actions/output_schemas";
 import type { Authenticator } from "@app/lib/auth";
 import logger from "@app/logger/logger";
 import { statsDClient } from "@app/logger/statsDClient";
 import { removeNulls } from "@app/types";
-
-import { INTERNAL_MIME_TYPES } from "../../../../sdks/js";
 
 export function withToolLogging<T>(
   auth: Authenticator,
@@ -42,14 +41,12 @@ export function withToolLogging<T>(
         ...tags,
       ]);
 
-      // Only process text and whitelisted resource content, other resources may be huge.
+      // Only process text content and known error resources, other resources may be huge.
       const error = removeNulls(
         result.content.map((c) =>
           c.type === "text"
             ? c.text
-            : c.type === "resource" &&
-                c.resource.mimeType ===
-                  INTERNAL_MIME_TYPES.TOOL_OUTPUT.EXECUTE_TABLES_QUERY_ERROR
+            : isExecuteTablesQueryErrorResourceType(c)
               ? c.resource.text
               : null
         )

--- a/front/lib/actions/mcp_internal_actions/wrappers.ts
+++ b/front/lib/actions/mcp_internal_actions/wrappers.ts
@@ -6,6 +6,18 @@ import logger from "@app/logger/logger";
 import { statsDClient } from "@app/logger/statsDClient";
 import { removeNulls } from "@app/types";
 
+function isKnownErrorResource(
+  outputBlock: CallToolResult["content"][number]
+): outputBlock is {
+  type: "resource";
+  resource: {
+    text: "string";
+    uri: string;
+  } & { [k: string]: unknown };
+} {
+  return isExecuteTablesQueryErrorResourceType(outputBlock);
+}
+
 export function withToolLogging<T>(
   auth: Authenticator,
   toolName: string,
@@ -46,7 +58,7 @@ export function withToolLogging<T>(
         result.content.map((c) =>
           c.type === "text"
             ? c.text
-            : isExecuteTablesQueryErrorResourceType(c)
+            : isKnownErrorResource(c)
               ? c.resource.text
               : null
         )

--- a/front/lib/actions/mcp_internal_actions/wrappers.ts
+++ b/front/lib/actions/mcp_internal_actions/wrappers.ts
@@ -1,4 +1,7 @@
-import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
+import type {
+  CallToolResult,
+  EmbeddedResource,
+} from "@modelcontextprotocol/sdk/types.js";
 
 import { isExecuteTablesQueryErrorResourceType } from "@app/lib/actions/mcp_internal_actions/output_schemas";
 import type { Authenticator } from "@app/lib/auth";
@@ -10,10 +13,7 @@ function isKnownErrorResource(
   outputBlock: CallToolResult["content"][number]
 ): outputBlock is {
   type: "resource";
-  resource: {
-    text: "string";
-    uri: string;
-  } & { [k: string]: unknown };
+  resource: { text: "string" } & EmbeddedResource["resource"];
 } {
   return isExecuteTablesQueryErrorResourceType(outputBlock);
 }


### PR DESCRIPTION
## Description

- The goal of this PR is to see the errors occurring at querying time [here](https://app.datadoghq.eu/logs?query=%22Tool%20execution%20error%22%20region%3Aus-central1%20%40toolName%3Atables_query&agg_m=count&agg_m_source=base&agg_t=count&cols=host%2Cworkspace.sId%2CtoolName%2Cerror&fromUser=true&messageDisplay=inline&refresh_mode=sliding&storage=hot&stream_sort=desc&viz=stream&from_ts=1752241786885&to_ts=1752242686885&live=true).
- This PR does not change what is displayed in the Tools inspection drawer.
- I have planned to improve this drawer very soon to prevent having to do this kind of stuff.

## Tests

## Risk

- None.

## Deploy Plan

- Deploy front.
