### PR TITLE
Fallback for script matching mcp_action with step content when no functionCallId in action

### DIFF
--- a/front/migrations/20250709_agent_mcp_action_fk_step_content.ts
+++ b/front/migrations/20250709_agent_mcp_action_fk_step_content.ts
@@ -123,11 +123,16 @@ async function attachStepContentToMcpActions({
           return false;
         }
 
-        const matchingStepContent = stepContents.find(
+        let matchingStepContent = stepContents.find(
           (sc) =>
             isFunctionCallContent(sc.value) &&
             sc.value.value.id === mcpAction.functionCallId
         );
+
+        // Fallback for actions without functionCallId.
+        if (!matchingStepContent && stepContents.length === 1) {
+          matchingStepContent = stepContents[0];
+        }
 
         if (!matchingStepContent) {
           if (verbose) {


### PR DESCRIPTION
## Description

A lot of agent_mcp_actions have no functionCallId. 
We will still attempt to match them with an agent_step_contents if there's only one for this message/step/version.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

Run migration. 