### PR TITLE
[front] Implement atomic version cutting on `AgentStepContent`

### DIFF
--- a/front/lib/resources/agent_step_content_resource.ts
+++ b/front/lib/resources/agent_step_content_resource.ts
@@ -429,18 +429,6 @@ export class AgentStepContentResource extends BaseResource<AgentStepContentModel
     value: AgentContentItemType;
   }): Promise<AgentStepContentResource> {
     return frontSequelize.transaction(async (transaction: Transaction) => {
-      // Acquire advisory lock for this step-index combination
-      const hash = md5(
-        `agent_step_content_version_${agentMessageId}_${step}_${index}`
-      );
-
-      // We need to set a lock directly.
-      // eslint-disable-next-line dust/no-raw-sql
-      await frontSequelize.query("SELECT pg_advisory_xact_lock(:key)", {
-        transaction,
-        replacements: { key: parseInt(hash, 16) % 9999999999 },
-      });
-
       const existingContent = await AgentStepContentModel.findAll({
         where: {
           agentMessageId,

--- a/front/lib/resources/agent_step_content_resource.ts
+++ b/front/lib/resources/agent_step_content_resource.ts
@@ -443,7 +443,6 @@ export class AgentStepContentResource extends BaseResource<AgentStepContentModel
     index,
     type,
     value,
-    transaction,
   }: {
     agentMessageId: ModelId;
     workspaceId: ModelId;
@@ -451,9 +450,8 @@ export class AgentStepContentResource extends BaseResource<AgentStepContentModel
     index: number;
     type: "text_content" | "reasoning" | "function_call";
     value: any;
-    transaction: Transaction;
   }): Promise<AgentStepContentResource> {
-    return frontSequelize.transaction(async (t: Transaction) => {
+    return frontSequelize.transaction(async (transaction: Transaction) => {
       // Acquire advisory lock for this step-index combination
       const hash = md5(
         `agent_step_content_version_${agentMessageId}_${step}_${index}`
@@ -472,7 +470,7 @@ export class AgentStepContentResource extends BaseResource<AgentStepContentModel
           step,
           index,
         },
-        t
+        transaction
       );
 
       const existingContent = await AgentStepContentModel.findOne({
@@ -482,7 +480,7 @@ export class AgentStepContentResource extends BaseResource<AgentStepContentModel
           index,
           version: currentMaxVersion,
         },
-        transaction: t,
+        transaction,
       });
 
       if (existingContent) {
@@ -501,7 +499,7 @@ export class AgentStepContentResource extends BaseResource<AgentStepContentModel
           type,
           value,
         },
-        t
+        transaction
       );
     });
   }

--- a/front/lib/resources/agent_step_content_resource.ts
+++ b/front/lib/resources/agent_step_content_resource.ts
@@ -436,6 +436,7 @@ export class AgentStepContentResource extends BaseResource<AgentStepContentModel
           index,
         },
         order: [["version", "DESC"]],
+        attributes: ["version"],
         limit: 1,
         transaction,
       });

--- a/front/lib/resources/agent_step_content_resource.ts
+++ b/front/lib/resources/agent_step_content_resource.ts
@@ -429,7 +429,7 @@ export class AgentStepContentResource extends BaseResource<AgentStepContentModel
     value: AgentContentItemType;
   }): Promise<AgentStepContentResource> {
     return frontSequelize.transaction(async (transaction: Transaction) => {
-      const existingContent = await AgentStepContentModel.findAll({
+      const existingContent = await this.model.findAll({
         where: {
           agentMessageId,
           step,
@@ -443,7 +443,7 @@ export class AgentStepContentResource extends BaseResource<AgentStepContentModel
       const currentMaxVersion =
         existingContent.length > 0 ? existingContent[0].version + 1 : 0;
 
-      return AgentStepContentResource.makeNew(
+      return this.makeNew(
         {
           agentMessageId,
           workspaceId,

--- a/front/lib/resources/agent_step_content_resource.ts
+++ b/front/lib/resources/agent_step_content_resource.ts
@@ -473,22 +473,6 @@ export class AgentStepContentResource extends BaseResource<AgentStepContentModel
         transaction
       );
 
-      const existingContent = await AgentStepContentModel.findOne({
-        where: {
-          agentMessageId,
-          step,
-          index,
-          version: currentMaxVersion,
-        },
-        transaction,
-      });
-
-      if (existingContent) {
-        throw new Error(
-          `Agent step content version ${currentMaxVersion} for step ${step}, index ${index} already exists`
-        );
-      }
-
       return AgentStepContentResource.makeNew(
         {
           agentMessageId,

--- a/front/lib/resources/agent_step_content_resource.ts
+++ b/front/lib/resources/agent_step_content_resource.ts
@@ -19,14 +19,14 @@ import { AgentStepContentModel } from "@app/lib/models/assistant/agent_step_cont
 import { AgentMessage } from "@app/lib/models/assistant/conversation";
 import { BaseResource } from "@app/lib/resources/base_resource";
 import { FileResource } from "@app/lib/resources/file_resource";
-import { FileModel } from "@app/lib/resources/storage/models/files";
 import { frontSequelize } from "@app/lib/resources/storage";
+import { FileModel } from "@app/lib/resources/storage/models/files";
 import type { ReadonlyAttributesType } from "@app/lib/resources/storage/types";
 import { makeSId } from "@app/lib/resources/string_ids";
 import logger from "@app/logger/logger";
 import type { ModelId, Result } from "@app/types";
 import { removeNulls } from "@app/types";
-import { Err, md5, Ok } from "@app/types";
+import { Err, Ok } from "@app/types";
 import type {
   AgentContentItemType,
   AgentStepContentType,

--- a/front/lib/resources/agent_step_content_resource.ts
+++ b/front/lib/resources/agent_step_content_resource.ts
@@ -27,7 +27,10 @@ import logger from "@app/logger/logger";
 import type { ModelId, Result } from "@app/types";
 import { removeNulls } from "@app/types";
 import { Err, md5, Ok } from "@app/types";
-import type { AgentStepContentType } from "@app/types/assistant/agent_message_content";
+import type {
+  AgentContentItemType,
+  AgentStepContentType,
+} from "@app/types/assistant/agent_message_content";
 
 // Attributes are marked as read-only to reflect the stateless nature of our Resource.
 // eslint-disable-next-line @typescript-eslint/no-empty-interface, @typescript-eslint/no-unsafe-declaration-merging
@@ -423,7 +426,7 @@ export class AgentStepContentResource extends BaseResource<AgentStepContentModel
     step: number;
     index: number;
     type: "text_content" | "reasoning" | "function_call";
-    value: any;
+    value: AgentContentItemType;
   }): Promise<AgentStepContentResource> {
     return frontSequelize.transaction(async (transaction: Transaction) => {
       // Acquire advisory lock for this step-index combination

--- a/front/lib/resources/agent_step_content_resource.ts
+++ b/front/lib/resources/agent_step_content_resource.ts
@@ -411,10 +411,16 @@ export class AgentStepContentResource extends BaseResource<AgentStepContentModel
   }
 
   private static async getNextVersionForStepContent(
-    agentMessageId: ModelId,
-    step: number,
-    index: number,
-    transaction?: Transaction
+    {
+      agentMessageId,
+      step,
+      index,
+    }: {
+      agentMessageId: ModelId;
+      step: number;
+      index: number;
+    },
+    transaction: Transaction
   ): Promise<number> {
     const existingContent = await AgentStepContentModel.findAll({
       where: {
@@ -461,9 +467,11 @@ export class AgentStepContentResource extends BaseResource<AgentStepContentModel
       });
 
       const currentMaxVersion = await this.getNextVersionForStepContent(
-        agentMessageId,
-        step,
-        index,
+        {
+          agentMessageId,
+          step,
+          index,
+        },
         t
       );
 


### PR DESCRIPTION
## Description

- Closes https://github.com/dust-tt/tasks/issues/3415.
- This PR implements a logic for cutting a new version of an agent step content atomically, similarly to how we do it for messages.

## Tests

## Risk

- Low, unused for now.

## Deploy Plan

- Deploy front.
