### PR TITLE
Switch google sheets to use token access

### DIFF
--- a/front/lib/actions/mcp_internal_actions/servers/google_sheets.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/google_sheets.ts
@@ -15,7 +15,7 @@ const serverInfo: InternalMCPServerDefinitionType = {
   version: "1.0.0",
   description: "Tools for managing Google Sheets spreadsheets and data.",
   authorization: {
-    provider: "google_drive",
+    provider: "gmail",
     supported_use_cases: ["personal_actions"] as const,
     scope:
       "https://www.googleapis.com/auth/spreadsheets https://www.googleapis.com/auth/drive.readonly" as const,


### PR DESCRIPTION
## Description

* https://github.com/dust-tt/tasks/issues/3485
* While waiting for Google scope approval, falling back to the method we used for gmail where a Google workspace user will need to set up an app. Feature will remain in beta while this is the case.

## Tests

* Localhost validation

## Risk

* Current behind FF

## Deploy Plan

* Deploy front