### PR TITLE
[front ] - feat(AB v2): add nodes selection tracker

### DIFF
--- a/extension/package-lock.json
+++ b/extension/package-lock.json
@@ -12,7 +12,7 @@
         "@auth0/auth0-spa-js": "^2.1.3",
         "@datadog/browser-logs": "^6.13.0",
         "@dust-tt/client": "^1.0.57",
-        "@dust-tt/sparkle": "^0.2.540",
+        "@dust-tt/sparkle": "^0.2.541",
         "@frontapp/plugin-sdk": "^1.8.1",
         "@modelcontextprotocol/sdk": "^1.9.0",
         "@tailwindcss/forms": "^0.5.9",
@@ -357,9 +357,9 @@
       }
     },
     "node_modules/@dust-tt/sparkle": {
-      "version": "0.2.540",
-      "resolved": "https://registry.npmjs.org/@dust-tt/sparkle/-/sparkle-0.2.540.tgz",
-      "integrity": "sha512-JNwHwQ7uxrDknwUgUAWUVFK9Lql6QJTlfw/He78BsqTGh8CgJu0/T0hhsDOvkLQfe9huBYvTOAEjSQE+uEHLlw==",
+      "version": "0.2.541",
+      "resolved": "https://registry.npmjs.org/@dust-tt/sparkle/-/sparkle-0.2.541.tgz",
+      "integrity": "sha512-E+wrOHI2FpjQQC/c4jlIO2W+q+tdFJpxnxOExyEj5604ACtm9ZDDhlM3Jk4H47GrS1i+RP2GThWQhKVoaPIgZQ==",
       "dependencies": {
         "@emoji-mart/data": "^1.1.2",
         "@emoji-mart/react": "^1.1.1",

--- a/extension/package.json
+++ b/extension/package.json
@@ -59,7 +59,7 @@
     "@auth0/auth0-spa-js": "^2.1.3",
     "@datadog/browser-logs": "^6.13.0",
     "@dust-tt/client": "^1.0.57",
-    "@dust-tt/sparkle": "^0.2.540",
+    "@dust-tt/sparkle": "^0.2.541",
     "@frontapp/plugin-sdk": "^1.8.1",
     "@modelcontextprotocol/sdk": "^1.9.0",
     "@tailwindcss/forms": "^0.5.9",

--- a/front/components/agent_builder/capabilities/knowledge/AddExtractSheet.tsx
+++ b/front/components/agent_builder/capabilities/knowledge/AddExtractSheet.tsx
@@ -30,6 +30,7 @@ import type {
   DataSourceViewSelectionConfigurations,
   TimeFrame,
 } from "@app/types";
+import { SelectionDisplay } from "@app/components/agent_builder/capabilities/knowledge/shared/SelectionDisplay";
 
 const DESCRIPTION_MAX_LENGTH = 800;
 
@@ -191,6 +192,11 @@ export function AddExtractSheet({
         }
         disableSave={
           !hasDataSources || !description.trim() || description.length > 800
+        }
+        footerContent={
+          <SelectionDisplay
+            selectionConfigurations={dataSourceConfigurations}
+          />
         }
       />
     </MultiPageSheet>

--- a/front/components/agent_builder/capabilities/knowledge/AddExtractSheet.tsx
+++ b/front/components/agent_builder/capabilities/knowledge/AddExtractSheet.tsx
@@ -12,6 +12,7 @@ import { useAgentBuilderContext } from "@app/components/agent_builder/AgentBuild
 import type { AgentBuilderFormData } from "@app/components/agent_builder/AgentBuilderFormContext";
 import { DescriptionSection } from "@app/components/agent_builder/capabilities/knowledge/shared/DescriptionSection";
 import { JsonSchemaSection } from "@app/components/agent_builder/capabilities/knowledge/shared/JsonSchemaSection";
+import { SelectionDisplay } from "@app/components/agent_builder/capabilities/knowledge/shared/SelectionDisplay";
 import {
   getDataSourceConfigurations,
   getJsonSchema,
@@ -30,7 +31,6 @@ import type {
   DataSourceViewSelectionConfigurations,
   TimeFrame,
 } from "@app/types";
-import { SelectionDisplay } from "@app/components/agent_builder/capabilities/knowledge/shared/SelectionDisplay";
 
 const DESCRIPTION_MAX_LENGTH = 800;
 

--- a/front/components/agent_builder/capabilities/knowledge/AddIncludeDataSheet.tsx
+++ b/front/components/agent_builder/capabilities/knowledge/AddIncludeDataSheet.tsx
@@ -25,6 +25,7 @@ import type {
   DataSourceViewSelectionConfigurations,
   TimeFrame,
 } from "@app/types";
+import { SelectionDisplay } from "@app/components/agent_builder/capabilities/knowledge/shared/SelectionDisplay";
 
 const PAGE_IDS = {
   DATA_SOURCE_SELECTION: "data-source-selection",
@@ -169,6 +170,11 @@ export function AddIncludeDataSheet({
           currentPageId === PAGE_IDS.DATA_SOURCE_SELECTION && !hasDataSources
         }
         disableSave={!hasDataSources || !description.trim()}
+        footerContent={
+          <SelectionDisplay
+            selectionConfigurations={dataSourceConfigurations}
+          />
+        }
       />
     </MultiPageSheet>
   );

--- a/front/components/agent_builder/capabilities/knowledge/AddIncludeDataSheet.tsx
+++ b/front/components/agent_builder/capabilities/knowledge/AddIncludeDataSheet.tsx
@@ -8,6 +8,7 @@ import { useEffect, useState } from "react";
 
 import { useAgentBuilderContext } from "@app/components/agent_builder/AgentBuilderContext";
 import { DescriptionSection } from "@app/components/agent_builder/capabilities/knowledge/shared/DescriptionSection";
+import { SelectionDisplay } from "@app/components/agent_builder/capabilities/knowledge/shared/SelectionDisplay";
 import {
   getDataSourceConfigurations,
   getTimeFrame,
@@ -25,7 +26,6 @@ import type {
   DataSourceViewSelectionConfigurations,
   TimeFrame,
 } from "@app/types";
-import { SelectionDisplay } from "@app/components/agent_builder/capabilities/knowledge/shared/SelectionDisplay";
 
 const PAGE_IDS = {
   DATA_SOURCE_SELECTION: "data-source-selection",

--- a/front/components/agent_builder/capabilities/knowledge/AddSearchSheet.tsx
+++ b/front/components/agent_builder/capabilities/knowledge/AddSearchSheet.tsx
@@ -8,6 +8,7 @@ import { useEffect, useState } from "react";
 
 import { useAgentBuilderContext } from "@app/components/agent_builder/AgentBuilderContext";
 import { DescriptionSection } from "@app/components/agent_builder/capabilities/knowledge/shared/DescriptionSection";
+import { SelectionDisplay } from "@app/components/agent_builder/capabilities/knowledge/shared/SelectionDisplay";
 import {
   getDataSourceConfigurations,
   hasDataSourceSelections,
@@ -152,6 +153,11 @@ export function AddSearchSheet({
           currentPageId === PAGE_IDS.DATA_SOURCE_SELECTION && !hasDataSources
         }
         disableSave={!hasDataSources || !description.trim()}
+        footerContent={
+          <SelectionDisplay
+            selectionConfigurations={dataSourceConfigurations}
+          />
+        }
       />
     </MultiPageSheet>
   );

--- a/front/components/agent_builder/capabilities/knowledge/shared/SelectionDisplay.tsx
+++ b/front/components/agent_builder/capabilities/knowledge/shared/SelectionDisplay.tsx
@@ -1,0 +1,86 @@
+import { Button, FolderIcon, MoreIcon } from "@dust-tt/sparkle";
+import { ScrollArea } from "@dust-tt/sparkle";
+import { useMemo } from "react";
+
+import type { DataSourceViewSelectionConfigurations } from "@app/types";
+
+interface SelectionDisplayProps {
+  selectionConfigurations: DataSourceViewSelectionConfigurations;
+}
+
+export function SelectionDisplay({
+  selectionConfigurations,
+}: SelectionDisplayProps) {
+  const selectedItems = useMemo(() => {
+    const items: Array<{
+      id: string;
+      title: string;
+      path: string;
+      dataSourceViewName: string;
+    }> = [];
+
+    Object.values(selectionConfigurations).forEach((config) => {
+      config.selectedResources.forEach((resource) => {
+        items.push({
+          id: resource.internalId,
+          title: resource.title,
+          path: resource.parentTitle || "Root",
+          dataSourceViewName: config.dataSourceView.dataSource.name,
+        });
+      });
+
+      if (config.isSelectAll) {
+        items.push({
+          id: `${config.dataSourceView.sId}-all`,
+          title: `All files from ${config.dataSourceView.dataSource.name}`,
+          path: "Root",
+          dataSourceViewName: config.dataSourceView.dataSource.name,
+        });
+      }
+    });
+
+    return items;
+  }, [selectionConfigurations]);
+
+  if (selectedItems.length === 0) {
+    return null;
+  }
+
+  return (
+    <div className="py-4">
+      <div className="mb-4 flex items-center justify-between">
+        <h3 className="text-lg font-medium text-gray-900">
+          Selection ({selectedItems.length} items)
+        </h3>
+      </div>
+      <ScrollArea className="flex max-h-60 flex-col">
+        <div className="space-y-2">
+          {selectedItems.map((item) => (
+            <div
+              key={item.id}
+              className="flex items-center gap-3 rounded-lg border border-gray-200 bg-gray-50 p-3 shadow-sm"
+            >
+              <FolderIcon className="h-6 w-6 flex-shrink-0 text-gray-600" />
+              <div className="min-w-0 flex-1">
+                <div className="truncate font-medium text-gray-900">
+                  {item.title}
+                </div>
+                <div className="truncate text-sm text-gray-500">
+                  {item.dataSourceViewName}/{item.path}
+                </div>
+              </div>
+              <Button
+                variant="ghost"
+                size="xs"
+                icon={MoreIcon}
+                onClick={() => {
+                  // TODO: Implement item menu
+                }}
+              />
+            </div>
+          ))}
+        </div>
+      </ScrollArea>
+    </div>
+  );
+}

--- a/front/package-lock.json
+++ b/front/package-lock.json
@@ -8,7 +8,7 @@
         "@auth0/nextjs-auth0": "^3.5.0",
         "@datadog/browser-logs": "^6.13.0",
         "@dust-tt/client": "file:../sdks/js",
-        "@dust-tt/sparkle": "^0.2.540",
+        "@dust-tt/sparkle": "^0.2.541",
         "@google-cloud/bigquery": "^7.9.1",
         "@google-cloud/storage-transfer": "^3.6.0",
         "@heroicons/react": "^2.0.11",
@@ -1127,9 +1127,9 @@
       "link": true
     },
     "node_modules/@dust-tt/sparkle": {
-      "version": "0.2.540",
-      "resolved": "https://registry.npmjs.org/@dust-tt/sparkle/-/sparkle-0.2.540.tgz",
-      "integrity": "sha512-JNwHwQ7uxrDknwUgUAWUVFK9Lql6QJTlfw/He78BsqTGh8CgJu0/T0hhsDOvkLQfe9huBYvTOAEjSQE+uEHLlw==",
+      "version": "0.2.541",
+      "resolved": "https://registry.npmjs.org/@dust-tt/sparkle/-/sparkle-0.2.541.tgz",
+      "integrity": "sha512-E+wrOHI2FpjQQC/c4jlIO2W+q+tdFJpxnxOExyEj5604ACtm9ZDDhlM3Jk4H47GrS1i+RP2GThWQhKVoaPIgZQ==",
       "dependencies": {
         "@emoji-mart/data": "^1.1.2",
         "@emoji-mart/react": "^1.1.1",

--- a/front/package.json
+++ b/front/package.json
@@ -25,7 +25,7 @@
     "@auth0/nextjs-auth0": "^3.5.0",
     "@datadog/browser-logs": "^6.13.0",
     "@dust-tt/client": "file:../sdks/js",
-    "@dust-tt/sparkle": "^0.2.540",
+    "@dust-tt/sparkle": "^0.2.541",
     "@google-cloud/bigquery": "^7.9.1",
     "@google-cloud/storage-transfer": "^3.6.0",
     "@heroicons/react": "^2.0.11",


### PR DESCRIPTION
## Description

This PR adds a new footer component to display selected data source configurations in the Agent Builder's knowledge configuration sheets (AddSearchSheet, AddExtractSheet, AddIncludeDataSheet). This provides better visibility of selected items during the configuration process.

<img width="464" height="1048" alt="Screenshot 2025-07-12 at 01 48 14" src="https://github.com/user-attachments/assets/86b4f727-6bd4-4933-918b-7874d9ce4e6d" />

Note: this is a first version, we will refine and stick to the designs once the data selection is shipped.

**References:**
- https://github.com/dust-tt/tasks/issues/3037

## Risk

Low

## Deploy Plan

Deploy front