### PR TITLE
agent_memory: improve tools

### DIFF
--- a/front/lib/actions/mcp_internal_actions/servers/agent_memory.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/agent_memory.ts
@@ -84,6 +84,37 @@ const createServer = (
     return server;
   }
 
+  const renderMemory = (
+    memory: { lastUpdated: Date; content: string }[]
+  ): {
+    isError: boolean;
+    content: { type: "text"; text: string }[];
+  } => {
+    if (memory.length === 0) {
+      return {
+        isError: false,
+        content: [
+          {
+            type: "text",
+            text: "(memory empty)",
+          },
+        ],
+      };
+    }
+
+    return {
+      isError: false,
+      content: [
+        {
+          type: "text",
+          text: memory
+            .map((entry, i) => `[${i}] ${entry.content}`)
+            .join("\n---\n"),
+        },
+      ],
+    };
+  };
+
   server.tool(
     "retrieve",
     `Retrieve all agent memories${isUserScopedMemory ? " for the current user" : ""}`,
@@ -102,30 +133,7 @@ const createServer = (
         agentConfiguration,
         user: user.toJSON(),
       });
-
-      if (memory.length === 0) {
-        return {
-          isError: false,
-          content: [
-            {
-              type: "text",
-              text: "(memory empty)",
-            },
-          ],
-        };
-      }
-
-      return {
-        isError: false,
-        content: [
-          {
-            type: "text",
-            text: memory
-              .map((entry, i) => `[${i + 1}] ${entry.content}`)
-              .join("\n---\n"),
-          },
-        ],
-      };
+      return renderMemory(memory);
     }
   );
 
@@ -146,21 +154,12 @@ const createServer = (
       );
       const { agentConfiguration } = agentLoopContext.runContext;
 
-      await AgentMemoryResource.recordEntries(auth, {
+      const memory = await AgentMemoryResource.recordEntries(auth, {
         agentConfiguration,
         user: user.toJSON(),
         entries,
       });
-
-      return {
-        isError: false,
-        content: [
-          {
-            type: "text",
-            text: "Memory entries recorded.",
-          },
-        ],
-      };
+      return renderMemory(memory);
     }
   );
 
@@ -181,21 +180,12 @@ const createServer = (
       );
       const { agentConfiguration } = agentLoopContext.runContext;
 
-      await AgentMemoryResource.eraseEntries(auth, {
+      const memory = await AgentMemoryResource.eraseEntries(auth, {
         agentConfiguration,
         user: user.toJSON(),
         indexes,
       });
-
-      return {
-        isError: false,
-        content: [
-          {
-            type: "text",
-            text: "Memory entries erased.",
-          },
-        ],
-      };
+      return renderMemory(memory);
     }
   );
 
@@ -225,21 +215,12 @@ const createServer = (
       );
       const { agentConfiguration } = agentLoopContext.runContext;
 
-      await AgentMemoryResource.editEntries(auth, {
+      const memory = await AgentMemoryResource.editEntries(auth, {
         agentConfiguration,
         user: user.toJSON(),
         edits,
       });
-
-      return {
-        isError: false,
-        content: [
-          {
-            type: "text",
-            text: "Memory overwritten.",
-          },
-        ],
-      };
+      return renderMemory(memory);
     }
   );
 

--- a/front/lib/resources/agent_memory_resource.ts
+++ b/front/lib/resources/agent_memory_resource.ts
@@ -135,7 +135,7 @@ export class AgentMemoryResource extends BaseResource<AgentMemoryModel> {
       user: UserType | null;
       entries: string[];
     }
-  ): Promise<undefined> {
+  ): Promise<{ lastUpdated: Date; content: string }[]> {
     await concurrentExecutor(
       entries,
       async (content) => {
@@ -147,6 +147,11 @@ export class AgentMemoryResource extends BaseResource<AgentMemoryModel> {
       },
       { concurrency: 4 }
     );
+
+    return AgentMemoryResource.retrieveMemory(auth, {
+      agentConfiguration,
+      user,
+    });
   }
 
   static async eraseEntries(
@@ -160,7 +165,7 @@ export class AgentMemoryResource extends BaseResource<AgentMemoryModel> {
       user: UserType | null;
       indexes: number[];
     }
-  ): Promise<undefined> {
+  ): Promise<{ lastUpdated: Date; content: string }[]> {
     await frontSequelize.transaction(async (t) => {
       const memories = (
         await this.findByAgentConfigurationAndUser(
@@ -181,6 +186,11 @@ export class AgentMemoryResource extends BaseResource<AgentMemoryModel> {
         { concurrency: 4 }
       );
     });
+
+    return AgentMemoryResource.retrieveMemory(auth, {
+      agentConfiguration,
+      user,
+    });
   }
 
   static async editEntries(
@@ -194,7 +204,7 @@ export class AgentMemoryResource extends BaseResource<AgentMemoryModel> {
       user: UserType | null;
       edits: { index: number; content: string }[];
     }
-  ): Promise<undefined> {
+  ): Promise<{ lastUpdated: Date; content: string }[]> {
     await frontSequelize.transaction(async (t) => {
       const memories = (
         await this.findByAgentConfigurationAndUser(
@@ -228,6 +238,11 @@ export class AgentMemoryResource extends BaseResource<AgentMemoryModel> {
         },
         { concurrency: 4 }
       );
+    });
+
+    return AgentMemoryResource.retrieveMemory(auth, {
+      agentConfiguration,
+      user,
     });
   }
 


### PR DESCRIPTION
## Description

The agent would be confused by the lastUpdated desc ordering + 1-indexation (quite obviously). This is more token angry but should solve entirely the issues.

- Use 0-based index to display memories since indexes are used fro edits and erasuse
- Return the state of the memory on all edits.

## Tests

Tested locally

## Risk

Low (feature flag)

## Deploy Plan

- deploy `front`