### PR TITLE
feat: implement searc content tool

### DIFF
--- a/cli/LICENSE
+++ b/cli/LICENSE
@@ -1,0 +1,14 @@
+Copyright 2025 Joshua Gisiger
+Copyright 2025 Google LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.

--- a/cli/src/mcp/tools/searchContent.ts
+++ b/cli/src/mcp/tools/searchContent.ts
@@ -1,0 +1,116 @@
+import { z } from "zod";
+
+import { normalizeError } from "../../utils/errors.js";
+import { MAX_LINE_LENGTH_TEXT_FILE } from "../../utils/fileHandling.js";
+import { formatGrepRes, performGrep } from "../../utils/grep.js";
+import type { McpTool } from "../types/tools.js";
+
+export class SearchContentTool implements McpTool {
+  name = "search_content";
+  description = "Search for content within files";
+
+  // is there a reason for the difference between using the word path and directory?
+  inputSchema = z.object({
+    pattern: z.string().describe("The text to search for"),
+    path: z
+      .string()
+      .optional()
+      .describe("Directory to search in (default: current directory)"),
+    file_pattern: z
+      .string()
+      .optional()
+      .describe("File pattern to search within (default: all files)"),
+  });
+
+  async execute({
+    pattern,
+    path = ".",
+    file_pattern = "*",
+  }: z.infer<typeof this.inputSchema>) {
+    try {
+      const grepRes = await performGrep(pattern, path, file_pattern);
+      const formattedGrep = formatGrepRes(grepRes, path);
+
+      if (formattedGrep.length === 0) {
+        return {
+          content: [
+            {
+              type: "text" as const,
+              text: `No matches found for: ${pattern}`,
+            },
+          ],
+        };
+      }
+
+      // Group results by file path and sort by line number
+      const fileGroups = new Map<
+        string,
+        Array<{ lineNumber: number; content: string }>
+      >();
+
+      formattedGrep.forEach((result) => {
+        if (!fileGroups.has(result.filePath)) {
+          fileGroups.set(result.filePath, []);
+        }
+        fileGroups.get(result.filePath)!.push({
+          lineNumber: result.lineNumber,
+          content: result.content,
+        });
+      });
+
+      // Sort each file's results by line number
+      fileGroups.forEach((results) => {
+        results.sort((a, b) => a.lineNumber - b.lineNumber);
+      });
+
+      // Format output with relative paths ordered by line number
+      let output = `Found ${formattedGrep.length} matches for "${pattern}" in the following directories:\n\n`;
+
+      Array.from(fileGroups.entries())
+        .sort(([a], [b]) => a.localeCompare(b))
+        .forEach(([filePath, results]) => {
+          output += `${filePath}:\n`;
+          results.forEach((result) => {
+            let truncated = false;
+            if (result.content.length > MAX_LINE_LENGTH_TEXT_FILE) {
+              truncated = true;
+            }
+            output += `  ${result.lineNumber}: ${result.content.substring(
+              0,
+              Math.min(MAX_LINE_LENGTH_TEXT_FILE, result.content.length)
+            )}`;
+            if (truncated) {
+              output += "... [cut]";
+            }
+            output += "\n";
+          });
+          output += "----------\n";
+        });
+
+      output =
+        `[The content of these files have been partially cut: some lines exceeded maximum length of ${MAX_LINE_LENGTH_TEXT_FILE} characters.]\n` +
+        output;
+
+      return {
+        content: [
+          {
+            type: "text" as const,
+            text: output.trim(),
+          },
+        ],
+      };
+    } catch (error) {
+      return {
+        content: [
+          {
+            type: "text" as const,
+            text: `Error searching for "${pattern}": ${
+              normalizeError(error).message
+            }`,
+          },
+        ],
+        isError: true,
+      };
+    }
+  }
+}

--- a/cli/src/utils/grep.ts
+++ b/cli/src/utils/grep.ts
@@ -1,0 +1,162 @@
+/**
+ * Copyright 2025 Google LLC
+ * Copyright 2025 Joshua Gisiger
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Modifications copyright 2025 Joshua Gisiger
+ * Changes: Adapted parts of the code to work with our existing structure and internal systems.
+ */
+
+import { spawn } from "child_process";
+import { EOL } from "os";
+import path from "path";
+
+import { normalizeError } from "./errors.js";
+
+interface grepRes {
+  filePath: string;
+  content: string;
+  lineNumber: number;
+}
+
+export async function performGrep(
+  pattern: string,
+  path: string,
+  file_pattern?: string
+): Promise<string> {
+  // recursive, number lines, include filename, no escape needed
+  const grepArgs = ["-r", "-n", "-H", "-E"];
+  const commonExcludes = [".git", "node_modules", "bower_components"];
+  commonExcludes.forEach((dir) => grepArgs.push(`--exclude-dir=${dir}`));
+  if (file_pattern) {
+    grepArgs.push(`--include=${file_pattern}`);
+  }
+  grepArgs.push(pattern);
+  // TODO: allow options for other paths?
+  grepArgs.push(".");
+
+  try {
+    const output = await new Promise<string>((resolve, reject) => {
+      const child = spawn("grep", grepArgs, {
+        cwd: path,
+        windowsHide: true,
+      });
+      const stdoutChunks: Buffer[] = [];
+      const stderrChunks: Buffer[] = [];
+
+      const onData = (chunk: Buffer) => stdoutChunks.push(chunk);
+      const onStderr = (chunk: Buffer) => {
+        const stderrStr = chunk.toString();
+        // Suppress common harmless stderr messages
+        if (
+          !stderrStr.includes("Permission denied") &&
+          !/grep:.*: Is a directory/i.test(stderrStr)
+        ) {
+          stderrChunks.push(chunk);
+        }
+      };
+      const onError = (err: Error) => {
+        cleanup();
+        reject(new Error(`Failed to start system grep: ${err.message}`));
+      };
+      const onClose = (code: number | null) => {
+        const stdoutData = Buffer.concat(stdoutChunks).toString("utf8");
+        const stderrData = Buffer.concat(stderrChunks).toString("utf8").trim();
+        cleanup();
+        if (code === 0) {
+          resolve(stdoutData);
+        } else if (code === 1) {
+          resolve("");
+        } // No matches
+        else {
+          if (stderrData) {
+            reject(
+              new Error(`System grep exited with code ${code}: ${stderrData}`)
+            );
+          } else {
+            resolve("");
+          } // Exit code > 1 but no stderr, likely just suppressed errors
+        }
+      };
+
+      const cleanup = () => {
+        child.stdout.removeListener("data", onData);
+        child.stderr.removeListener("data", onStderr);
+        child.removeListener("error", onError);
+        child.removeListener("close", onClose);
+        if (child.connected) {
+          child.disconnect();
+        }
+      };
+
+      child.stdout.on("data", onData);
+      child.stderr.on("data", onStderr);
+      child.on("error", onError);
+      child.on("close", onClose);
+    });
+
+    return output;
+  } catch (grepError: unknown) {
+    console.debug(
+      `GrepLogic: System grep failed: ${
+        normalizeError(grepError).message
+      }. Falling back...`
+    );
+    return "";
+  }
+}
+
+export function formatGrepRes(unformattedGrep: string, basePath: string) {
+  const grepRes: grepRes[] = [];
+
+  let grepLines = unformattedGrep.split(EOL);
+  grepLines.forEach((line) => {
+    if (!line.trim()) {
+      return;
+    }
+
+    const firstColon = line.indexOf(":");
+    if (firstColon == -1) {
+      return;
+    }
+    const secondColon = line.indexOf(":", firstColon + 1);
+    if (secondColon == -1) {
+      return;
+    }
+
+    // Handle path formatting
+    const unformattedFilePath = line.substring(0, firstColon);
+    const absPath = path.resolve(basePath, unformattedFilePath);
+    const relativePath = path.relative(basePath, absPath);
+
+    // Handle line number formatting
+    const sLineNumber = line.substring(firstColon + 1, secondColon);
+    const lineNumber = parseInt(sLineNumber);
+
+    if (isNaN(lineNumber)) {
+      return;
+    }
+
+    // Handle content formatting
+    const content = line.substring(secondColon + 1);
+
+    grepRes.push({
+      filePath: relativePath,
+      lineNumber: lineNumber,
+      content: content,
+    });
+  });
+
+  return grepRes;
+}

--- a/cli/src/utils/grep.ts
+++ b/cli/src/utils/grep.ts
@@ -24,7 +24,7 @@ import path from "path";
 
 import { normalizeError } from "./errors.js";
 
-interface grepRes {
+interface GrepResult {
   filePath: string;
   content: string;
   lineNumber: number;
@@ -118,7 +118,7 @@ export async function performGrep(
 }
 
 export function formatGrepRes(unformattedGrep: string, basePath: string) {
-  const grepRes: grepRes[] = [];
+  const grepResults: GrepResult[] = [];
 
   let grepLines = unformattedGrep.split(EOL);
   grepLines.forEach((line) => {
@@ -151,12 +151,12 @@ export function formatGrepRes(unformattedGrep: string, basePath: string) {
     // Handle content formatting
     const content = line.substring(secondColon + 1);
 
-    grepRes.push({
+    grepResults.push({
       filePath: relativePath,
       lineNumber: lineNumber,
       content: content,
     });
   });
 
-  return grepRes;
+  return grepResults;
 }

--- a/cli/src/utils/grep.ts
+++ b/cli/src/utils/grep.ts
@@ -18,12 +18,13 @@
  * Changes: Adapted parts of the code to work with our existing structure and internal systems.
  */
 
+import type { Result } from "@dust-tt/client";
+import { Err, Ok } from "@dust-tt/client";
 import { spawn } from "child_process";
 import { EOL } from "os";
 import path from "path";
 
 import { normalizeError } from "./errors.js";
-import { Err, Ok, Result } from "@dust-tt/client";
 
 interface GrepResult {
   filePath: string;


### PR DESCRIPTION
## Description

Implements a tool that can search through the content of text files in a directory and will later be used for the fsServer (file system) mcp server.

## Tests

Manually. 

## Risk

None. Currently no way to access the tool.

## Deploy Plan

Deploy cli.