### PR TITLE
Allow writes to data source if canWrite OR system API key

### DIFF
--- a/front/pages/api/v1/w/[wId]/spaces/[spaceId]/data_sources/[dsId]/documents/[documentId]/index.ts
+++ b/front/pages/api/v1/w/[wId]/spaces/[spaceId]/data_sources/[dsId]/documents/[documentId]/index.ts
@@ -375,6 +375,17 @@ async function handler(
         });
       }
 
+      // To write we must have canWrite or be a systemAPIKey
+      if (!(dataSource.canWrite(auth) || auth.isSystemKey())) {
+        return apiError(req, res, {
+          status_code: 403,
+          api_error: {
+            type: "data_source_auth_error",
+            message: "You are not allowed to update data in this data source.",
+          },
+        });
+      }
+
       if (!auth.isSystemKey()) {
         const remaining = await rateLimiter({
           key: `upsert-document-w-${owner.sId}`,
@@ -725,6 +736,17 @@ async function handler(
           api_error: {
             type: "data_source_auth_error",
             message: "You cannot delete a document from a managed data source.",
+          },
+        });
+      }
+
+      // To write we must have canWrite or be a systemAPIKey
+      if (!(dataSource.canWrite(auth) || auth.isSystemKey())) {
+        return apiError(req, res, {
+          status_code: 403,
+          api_error: {
+            type: "data_source_auth_error",
+            message: "You are not allowed to update data in this data source.",
           },
         });
       }

--- a/front/pages/api/v1/w/[wId]/spaces/[spaceId]/data_sources/[dsId]/documents/[documentId]/parents.ts
+++ b/front/pages/api/v1/w/[wId]/spaces/[spaceId]/data_sources/[dsId]/documents/[documentId]/parents.ts
@@ -140,7 +140,8 @@ async function handler(
 
   switch (req.method) {
     case "POST":
-      if (!dataSource.canWrite(auth)) {
+      // To write we must have canWrite or be a systemAPIKey
+      if (!(dataSource.canWrite(auth) || auth.isSystemKey())) {
         return apiError(req, res, {
           status_code: 403,
           api_error: {

--- a/front/pages/api/v1/w/[wId]/spaces/[spaceId]/data_sources/[dsId]/folders/[fId].ts
+++ b/front/pages/api/v1/w/[wId]/spaces/[spaceId]/data_sources/[dsId]/folders/[fId].ts
@@ -91,7 +91,8 @@ async function handler(
       return;
 
     case "POST":
-      if (!dataSource.canWrite(auth)) {
+      // To write we must have canWrite or be a systemAPIKey
+      if (!(dataSource.canWrite(auth) || auth.isSystemKey())) {
         return apiError(req, res, {
           status_code: 403,
           api_error: {
@@ -198,7 +199,8 @@ async function handler(
       return;
 
     case "DELETE":
-      if (!dataSource.canWrite(auth)) {
+      // To write we must have canWrite or be a systemAPIKey
+      if (!(dataSource.canWrite(auth) || auth.isSystemKey())) {
         return apiError(req, res, {
           status_code: 403,
           api_error: {

--- a/front/pages/api/v1/w/[wId]/spaces/[spaceId]/data_sources/[dsId]/tables/[tId]/index.ts
+++ b/front/pages/api/v1/w/[wId]/spaces/[spaceId]/data_sources/[dsId]/tables/[tId]/index.ts
@@ -225,7 +225,8 @@ async function handler(
           },
         });
       }
-      if (!dataSource.canWrite(auth)) {
+      // To write we must have canWrite or be a systemAPIKey
+      if (!(dataSource.canWrite(auth) || auth.isSystemKey())) {
         return apiError(req, res, {
           status_code: 403,
           api_error: {

--- a/front/pages/api/v1/w/[wId]/spaces/[spaceId]/data_sources/[dsId]/tables/[tId]/rows/[rId].ts
+++ b/front/pages/api/v1/w/[wId]/spaces/[spaceId]/data_sources/[dsId]/tables/[tId]/rows/[rId].ts
@@ -216,7 +216,8 @@ async function handler(
       return res.status(200).json({ row });
 
     case "DELETE":
-      if (!dataSource.canWrite(auth)) {
+      // To write we must have canWrite or be a systemAPIKey
+      if (!(dataSource.canWrite(auth) || auth.isSystemKey())) {
         return apiError(req, res, {
           status_code: 403,
           api_error: {

--- a/front/pages/api/v1/w/[wId]/spaces/[spaceId]/data_sources/[dsId]/tables/[tId]/rows/index.ts
+++ b/front/pages/api/v1/w/[wId]/spaces/[spaceId]/data_sources/[dsId]/tables/[tId]/rows/index.ts
@@ -265,7 +265,8 @@ async function handler(
       return res.status(200).json({ rows: rowsList, offset, limit, total });
 
     case "POST":
-      if (!dataSource.canWrite(auth)) {
+      // To write we must have canWrite or be a systemAPIKey
+      if (!(dataSource.canWrite(auth) || auth.isSystemKey())) {
         return apiError(req, res, {
           status_code: 403,
           api_error: {

--- a/front/pages/api/v1/w/[wId]/spaces/[spaceId]/data_sources/[dsId]/tables/index.ts
+++ b/front/pages/api/v1/w/[wId]/spaces/[spaceId]/data_sources/[dsId]/tables/index.ts
@@ -242,7 +242,8 @@ async function handler(
       });
 
     case "POST":
-      if (!dataSource.canWrite(auth)) {
+      // To write we must have canWrite or be a systemAPIKey
+      if (!(dataSource.canWrite(auth) || auth.isSystemKey())) {
         return apiError(req, res, {
           status_code: 403,
           api_error: {


### PR DESCRIPTION
## Description

The check canWrite was not present on regular document upsert (not great but not really a big problem since canRead == canWrite for regular API keys here).

For all writes operations on api/v1 we check canWrite or system API key.

We need system API Key write for websites that are in restricted space as the admin can Administrate but not canWrite but the system API key should as part of being used from connectors for webcrawler.

## Tests

N/A

## Risk

High for the change on api/v1/data_sources/documents but we do everything from connectors with system API key so should be no change.

## Deploy Plan

- deploy `front`