### PR TITLE
Improve GitHub code sync workflow

### DIFF
--- a/connectors/src/connectors/github/lib/code/gcs_repository.ts
+++ b/connectors/src/connectors/github/lib/code/gcs_repository.ts
@@ -1,19 +1,29 @@
 import type { Bucket, File } from "@google-cloud/storage";
 import { Storage } from "@google-cloud/storage";
+import { chunk } from "lodash";
 import type { Readable } from "stream";
 import { pipeline } from "stream/promises";
 
+import { getCodeDirInternalId } from "@connectors/connectors/github/lib/utils";
 import { connectorsConfig } from "@connectors/connectors/shared/config";
+import { concurrentExecutor } from "@connectors/lib/async_utils";
 import type { Logger } from "@connectors/logger/logger";
 import logger from "@connectors/logger/logger";
 import { isDevelopment } from "@connectors/types";
 
 export const DIRECTORY_PLACEHOLDER_FILE = ".gitkeep";
 export const DIRECTORY_PLACEHOLDER_METADATA = "isDirectoryPlaceholder";
+const DUST_INTERNAL_MARKER = "dustInternalMarker";
+const DUST_INTERNAL_INDEX_FILE = "DUST_INTERNAL_INDEX_v1";
+
+const DUST_INTERNAL_INDEX_FILE_PREFIX = "._dust_internal_index";
 
 const DEFAULT_MAX_RESULTS = 1000;
 const STREAM_THRESHOLD_BYTES = 1024 * 1024; // 1MB - files smaller than this will be buffered.
 const GCS_RESUMABLE_UPLOAD_THRESHOLD_BYTES = 10 * 1024 * 1024; // 10MB
+
+const ITEMS_PER_INDEX = 5000; // Files/directories per index file.
+const PARALLEL_INDEX_UPLOADS = 10; // Concurrent index file uploads.
 
 /**
  * A wrapper around GCS operations for GitHub repository code sync.
@@ -106,9 +116,14 @@ export class GCSRepositoryManager {
       await file.save(content, {
         metadata: {
           contentType: options?.contentType || "text/plain",
-          customMetadata: options?.metadata,
         },
       });
+
+      if (options?.metadata) {
+        await file.setMetadata({
+          metadata: options.metadata,
+        });
+      }
     } catch (error) {
       logger.error({ error, gcsPath }, "Failed to upload file to GCS");
       throw new Error(`Failed to upload file: ${gcsPath}`);
@@ -204,5 +219,202 @@ export class GCSRepositoryManager {
       );
       throw new Error(`Failed to upload file stream: ${gcsPath}`);
     }
+  }
+
+  /**
+   * Create an index file containing all file and directory paths for the repository.
+   * This is used to optimize memory usage in temporal workflows by storing paths in GCS
+   * instead of passing large arrays through temporal activities.
+   */
+  async createIndexFiles(
+    gcsBasePath: string,
+    repoId: number,
+    options?: {
+      batchSize?: number;
+      childLogger?: Logger;
+    }
+  ): Promise<string[]> {
+    const { batchSize = DEFAULT_MAX_RESULTS, childLogger = logger } =
+      options || {};
+
+    const indexBasePath = `${gcsBasePath}/${DUST_INTERNAL_INDEX_FILE_PREFIX}`;
+    const directories: Array<{
+      dirPath: string;
+      gcsPath: string;
+      internalId: string;
+      parentInternalId: string | null;
+    }> = [];
+    const files: Array<{
+      gcsPath: string;
+      relativePath: string;
+    }> = [];
+
+    // Collect all files and directories with pagination.
+    let pageToken: string | undefined;
+    do {
+      const result = await this.listFiles(gcsBasePath, {
+        maxResults: batchSize,
+        pageToken,
+      });
+
+      for (const file of result.files) {
+        const relativePath = file.name.replace(`${gcsBasePath}/`, "");
+
+        if (file.name.endsWith(`/${DIRECTORY_PLACEHOLDER_FILE}`)) {
+          // This is a directory placeholder.
+          const dirPath = relativePath.replace(
+            `/${DIRECTORY_PLACEHOLDER_FILE}`,
+            ""
+          );
+          directories.push({
+            gcsPath: file.name,
+            dirPath,
+            internalId: getCodeDirInternalId(repoId, dirPath),
+            parentInternalId: dirPath.includes("/")
+              ? getCodeDirInternalId(
+                  repoId,
+                  dirPath.split("/").slice(0, -1).join("/")
+                )
+              : null,
+          });
+        } else {
+          // This is a regular file.
+          files.push({
+            gcsPath: file.name,
+            relativePath,
+          });
+        }
+      }
+
+      pageToken = result.nextPageToken;
+    } while (pageToken);
+
+    childLogger.info(
+      {
+        gcsBasePath,
+        totalFiles: files.length,
+        totalDirectories: directories.length,
+      },
+      "Creating multiple index files for repository"
+    );
+
+    // Split files and directories into multiple index files.
+    const fileChunks = chunk(files, ITEMS_PER_INDEX);
+    const directoryChunks = chunk(directories, ITEMS_PER_INDEX);
+    const totalChunks = Math.max(fileChunks.length, directoryChunks.length);
+    const indexPaths: string[] = [];
+
+    // Create index data for all chunks.
+    const indexChunks = Array.from({ length: totalChunks }, (_, index) => ({
+      index,
+      path: `${indexBasePath}_${index}.json`,
+      data: {
+        files: fileChunks[index] || [], // Empty array if no files for this chunk.
+        directories: directoryChunks[index] || [], // Empty array if no directories for this chunk.
+        indexNumber: index,
+        totalIndexes: totalChunks,
+        createdAt: new Date().toISOString(),
+      },
+    }));
+
+    // Upload index files.
+    await concurrentExecutor(
+      indexChunks,
+      async (chunk) => {
+        await this.uploadFile(chunk.path, JSON.stringify(chunk.data), {
+          contentType: "application/json",
+          metadata: {
+            [DUST_INTERNAL_MARKER]: DUST_INTERNAL_INDEX_FILE,
+            repoId: repoId.toString(),
+            gcsBasePath,
+            indexNumber: chunk.index.toString(),
+          },
+        });
+
+        indexPaths.push(chunk.path);
+        return chunk.path;
+      },
+      { concurrency: PARALLEL_INDEX_UPLOADS }
+    );
+
+    childLogger.info(
+      {
+        gcsBasePath,
+        totalIndexes: indexPaths.length,
+        itemsPerIndex: ITEMS_PER_INDEX,
+        totalIndexFiles: indexPaths.length,
+      },
+      "Created multiple index files for repository"
+    );
+
+    return indexPaths;
+  }
+
+  /**
+   * Validate that an index file was created by Dust and is safe to read.
+   */
+  private async validateIndexFile(
+    indexPath: string,
+    expectedGcsBasePath: string
+  ): Promise<void> {
+    const file = this.bucket.file(indexPath);
+    const [metadata] = await file.getMetadata();
+
+    // Check if this is a Dust internal index file.
+    if (
+      metadata.metadata?.[DUST_INTERNAL_MARKER] !== DUST_INTERNAL_INDEX_FILE
+    ) {
+      throw new Error("Invalid index file: not a Dust internal index file");
+    }
+
+    // Validate that the index file matches the expected GCS base path.
+    if (metadata.metadata.gcsBasePath !== expectedGcsBasePath) {
+      throw new Error("Invalid index file: GCS base path mismatch");
+    }
+  }
+
+  /**
+   * Read all files from a specific index file.
+   */
+  async readFilesFromIndex(
+    indexPath: string,
+    expectedGcsBasePath: string
+  ): Promise<
+    Array<{
+      gcsPath: string;
+      relativePath: string;
+    }>
+  > {
+    await this.validateIndexFile(indexPath, expectedGcsBasePath);
+
+    const indexContent = await this.downloadFile(indexPath);
+    const indexData = JSON.parse(indexContent.toString());
+
+    return indexData.files;
+  }
+
+  /**
+   * Read all directories from a specific index file.
+   */
+  async readDirectoriesFromIndex({
+    indexPath,
+    expectedGcsBasePath,
+  }: {
+    indexPath: string;
+    expectedGcsBasePath: string;
+  }): Promise<
+    Array<{
+      dirPath: string;
+      gcsPath: string;
+      internalId: string;
+      parentInternalId: string | null;
+    }>
+  > {
+    await this.validateIndexFile(indexPath, expectedGcsBasePath);
+
+    const indexContent = await this.downloadFile(indexPath);
+    const indexData = JSON.parse(indexContent.toString());
+
+    return indexData.directories;
   }
 }


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
This PR refactors the recently introduced `code-sync-stateless` workflow to reduce Temporal workflow memory usage and improve scalability. The current version relies on batching files/directories by fetching them and passing them as arguments to the next activity, which leads to large workflow histories and memory consumption.

### Problem
- Large payloads: For repos with 400k+ files, the workflow was passing ~61MB of file path data through Temporal activities
- Memory bottlenecks: Each activity had to process large arrays of file/directory objects

### Solution
This PR creates multiple index files that serve as the source of truth for files and directories that must be created in Dust. It maps out the GitHub repo structure so we can simply pass GCS index file paths to activities instead of large data payloads.

### Key Changes
1. Multiple Index Files: Split files/directories into multiple index files (5-10k items each)
2. One Activity per Index: Each activity processes a complete index file (both files and directories)
4. Security Validation: GCS metadata validation prevents malicious index file attacks

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->
Tested locally.

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->
Will create non determinism errors, will restart all impacted workflows.

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
