### PR TITLE
Fix output of Notion search displayed as search tool

### DIFF
--- a/front/components/actions/mcp/details/MCPActionDetails.tsx
+++ b/front/components/actions/mcp/details/MCPActionDetails.tsx
@@ -22,6 +22,7 @@ import { MCPTablesQueryActionDetails } from "@app/components/actions/mcp/details
 import { SearchResultDetails } from "@app/components/actions/mcp/details/MCPToolOutputDetails";
 import type { ActionDetailsComponentBaseProps } from "@app/components/actions/types";
 import type { MCPActionType } from "@app/lib/actions/mcp";
+import { SEARCH_TOOL_NAME } from "@app/lib/actions/mcp_internal_actions/constants";
 import {
   isBrowseResultResourceType,
   isDataSourceNodeContentType,
@@ -72,7 +73,7 @@ export function MCPActionDetails(
 
   if (isSearch) {
     const fcName = props.action.functionCallName;
-    const isSearchTool = fcName?.startsWith("search");
+    const isSearchTool = fcName?.endsWith(SEARCH_TOOL_NAME);
     const actionName = fcName && !isSearchTool ? fcName : "Search data";
     const visual = isSearchTool
       ? MagnifyingGlassIcon

--- a/front/components/actions/mcp/details/MCPActionDetails.tsx
+++ b/front/components/actions/mcp/details/MCPActionDetails.tsx
@@ -71,12 +71,18 @@ export function MCPActionDetails(
   const isFilesystemPath = props.action.output?.some(isFilesystemPathType);
 
   if (isSearch) {
+    const fcName = props.action.functionCallName;
+    const isSearchTool = fcName?.startsWith("search");
+    const actionName = fcName && !isSearchTool ? fcName : "Search data";
+    const visual = isSearchTool
+      ? MagnifyingGlassIcon
+      : MCP_SPECIFICATION.cardIcon;
     return (
       <SearchResultDetails
-        actionName="Search data"
+        actionName={actionName}
         actionOutput={props.action.output}
         defaultOpen={props.defaultOpen}
-        visual={MagnifyingGlassIcon}
+        visual={visual}
       />
     );
   } else if (isInclude) {

--- a/front/lib/actions/mcp_internal_actions/constants.ts
+++ b/front/lib/actions/mcp_internal_actions/constants.ts
@@ -9,6 +9,7 @@ import type {
 import { Err, Ok } from "@app/types";
 
 export const ADVANCED_SEARCH_SWITCH = "advanced_search";
+export const SEARCH_TOOL_NAME = "semantic_search";
 
 export const AVAILABLE_INTERNAL_MCP_SERVER_NAMES = [
   // Note:

--- a/front/lib/actions/mcp_internal_actions/servers/data_sources_file_system.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/data_sources_file_system.ts
@@ -4,6 +4,7 @@ import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
 import assert from "assert";
 import { z } from "zod";
 
+import { SEARCH_TOOL_NAME } from "@app/lib/actions/mcp_internal_actions/constants";
 import type { DataSourcesToolConfigurationType } from "@app/lib/actions/mcp_internal_actions/input_schemas";
 import { ConfigurableToolInputSchemas } from "@app/lib/actions/mcp_internal_actions/input_schemas";
 import type {
@@ -63,7 +64,6 @@ import {
   timeFrameFromNow,
 } from "@app/types";
 
-const SEARCH_TOOL_NAME = "semantic_search";
 const FILESYSTEM_TOOL_NAME = "filesystem_navigation";
 
 const serverInfo: InternalMCPServerDefinitionType = {
@@ -792,7 +792,7 @@ const createServer = (
 
   if (!areTagsDynamic) {
     server.tool(
-      "search",
+      SEARCH_TOOL_NAME,
       "Perform a semantic search within the folders and files designated by `nodeIds`. All " +
         "children of the designated nodes will be searched.",
       SearchToolInputSchema.shape,
@@ -811,7 +811,7 @@ const createServer = (
     );
 
     server.tool(
-      "search",
+      SEARCH_TOOL_NAME,
       "Perform a semantic search within the folders and files designated by `nodeIds`. All " +
         "children of the designated nodes will be searched.",
       {

--- a/front/lib/actions/mcp_internal_actions/servers/search.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/search.ts
@@ -4,6 +4,7 @@ import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
 import assert from "assert";
 import { z } from "zod";
 
+import { SEARCH_TOOL_NAME } from "@app/lib/actions/mcp_internal_actions/constants";
 import type { DataSourcesToolConfigurationType } from "@app/lib/actions/mcp_internal_actions/input_schemas";
 import { ConfigurableToolInputSchemas } from "@app/lib/actions/mcp_internal_actions/input_schemas";
 import type { SearchResultResourceType } from "@app/lib/actions/mcp_internal_actions/output_schemas";
@@ -46,8 +47,6 @@ const serverInfo: InternalMCPServerDefinitionType = {
   authorization: null,
   documentationUrl: null,
 };
-
-const SEARCH_TOOL_NAME = "semantic_search";
 
 export async function searchFunction({
   query,


### PR DESCRIPTION
## Description

Our Notion mcp server has a search tool that return a result typed as `INTERNAL_MIME_TYPES.TOOL_OUTPUT.DATA_SOURCE_SEARCH_RESULT` which is great because it means it's a pretty output and not the raw JSON we usually have. 💅🏻 

Only problem with that is it can be very confusing cause it gives the impression it used retrieval and not the search from MCP tool. This PR adds a little hack so we display the title and icon for search only if search tool. 

Before: 
<kbd>
<img width="755" height="734" alt="Screenshot 2025-07-15 at 14 51 06" src="https://github.com/user-attachments/assets/b223061c-3d3c-4285-8361-bb2a9c1f04a8" />
</kbd>



After:
<kbd>

<img width="768" height="759" alt="Screenshot 2025-07-15 at 14 50 49" src="https://github.com/user-attachments/assets/7eff9d90-91ae-4d9f-897c-04a67671cc18" />
</kbd>


## Tests

Locally. 

## Risk

Can be rolled back. 

## Deploy Plan

Deploy front. 