### PR TITLE
DRY postUserMessage function

### DIFF
--- a/front/lib/api/assistant/conversation/title.ts
+++ b/front/lib/api/assistant/conversation/title.ts
@@ -1,0 +1,166 @@
+import { runActionStreamed } from "@app/lib/actions/server";
+import { renderConversationForModel } from "@app/lib/api/assistant/preprocessing";
+import { getConversationChannelId } from "@app/lib/api/assistant/streaming/helpers";
+import { getRedisHybridManager } from "@app/lib/api/redis-hybrid-manager";
+import type { Authenticator } from "@app/lib/auth";
+import { getDustProdAction } from "@app/lib/registry";
+import { cloneBaseConfig } from "@app/lib/registry";
+import { ConversationResource } from "@app/lib/resources/conversation_resource";
+import logger from "@app/logger/logger";
+import type { ConversationType, Result, UserMessageType } from "@app/types";
+import { Err, getLargeNonAnthropicWhitelistedModel, Ok } from "@app/types";
+
+const MIN_GENERATION_TOKENS = 1024;
+
+export async function ensureConversationTitle(
+  auth: Authenticator,
+  conversation: ConversationType,
+  userMessage: UserMessageType
+): Promise<void> {
+  // If the conversation has a title, return early.
+  if (conversation.title) {
+    return;
+  }
+
+  // TODO(DURABLE-AGENTS 2025-07-15): Add back the agent message before generating the title.
+  const titleRes = await generateConversationTitle(auth, {
+    ...conversation,
+    content: [...conversation.content, [userMessage]],
+  });
+
+  if (titleRes.isErr()) {
+    logger.error(
+      {
+        conversationId: conversation.sId,
+        error: titleRes.error,
+      },
+      "Conversation title generation error"
+    );
+    return;
+  }
+
+  const title = titleRes.value;
+  await ConversationResource.updateTitle(auth, conversation.sId, title);
+
+  // Enqueue the conversation_title event in Redis.
+  // TODO(DURABLE-AGENTS 2025-07-15): Move this to a common place.
+  const redisHybridManager = getRedisHybridManager();
+  await redisHybridManager.publish(
+    getConversationChannelId({ conversationId: conversation.sId }),
+    JSON.stringify({
+      type: "conversation_title",
+      created: Date.now(),
+      title,
+    }),
+    "user_message_events"
+  );
+}
+
+async function generateConversationTitle(
+  auth: Authenticator,
+  conversation: ConversationType
+): Promise<Result<string, Error>> {
+  const owner = auth.getNonNullableWorkspace();
+
+  const model = getLargeNonAnthropicWhitelistedModel(owner);
+  if (!model) {
+    return new Err(
+      new Error("Failed to find a whitelisted model to generate title")
+    );
+  }
+
+  // Turn the conversation into a digest that can be presented to the model.
+  const modelConversationRes = await renderConversationForModel(auth, {
+    conversation,
+    model,
+    prompt: "", // There is no prompt for title generation.
+    tools: "",
+    allowedTokenCount: model.contextSize - MIN_GENERATION_TOKENS,
+    excludeActions: true,
+    excludeImages: true,
+  });
+
+  if (modelConversationRes.isErr()) {
+    return modelConversationRes;
+  }
+
+  const { modelConversation: conv } = modelConversationRes.value;
+  if (conv.messages.length === 0) {
+    // It is possible that no message were selected if the context size of the small model was
+    // overflown by the initial user message. In that case we just skip title generation for now (it
+    // will get attempted again with follow-up messages being added to the conversation).
+    return new Err(
+      new Error(
+        "Error generating conversation title: rendered conversation is empty"
+      )
+    );
+  }
+
+  // Note: the last message is generally not a user message (though it can happen if no agent were
+  // mentioned) which, without stitching, will cause the title generation to fail since models
+  // expect a user message to be the last message. The stitching is done in the
+  // `assistant-v2-title-generator` app.
+  const config = cloneBaseConfig(
+    getDustProdAction("assistant-v2-title-generator").config
+  );
+  config.MODEL.provider_id = model.providerId;
+  config.MODEL.model_id = model.modelId;
+
+  const res = await runActionStreamed(
+    auth,
+    "assistant-v2-title-generator",
+    config,
+    [
+      {
+        conversation: conv,
+      },
+    ],
+    {
+      conversationId: conversation.sId,
+      workspaceId: conversation.owner.sId,
+    }
+  );
+
+  if (res.isErr()) {
+    return new Err(
+      new Error(`Error generating conversation title: ${res.error}`)
+    );
+  }
+
+  const { eventStream } = res.value;
+  let title: string | null = null;
+
+  for await (const event of eventStream) {
+    if (event.type === "error") {
+      return new Err(
+        new Error(
+          `Error generating conversation title: ${event.content.message}`
+        )
+      );
+    }
+
+    if (event.type === "block_execution") {
+      const e = event.content.execution[0][0];
+      if (e.error) {
+        return new Err(
+          new Error(`Error generating conversation title: ${e.error}`)
+        );
+      }
+
+      if (event.content.block_name === "OUTPUT" && e.value) {
+        const v = e.value as any;
+        if (v.conversation_title) {
+          title = v.conversation_title;
+        }
+      }
+    }
+  }
+
+  if (title === null) {
+    return new Err(
+      new Error("Error generating conversation title: malformed output")
+    );
+  }
+
+  return new Ok(title);
+}

--- a/front/lib/api/assistant/pubsub.ts
+++ b/front/lib/api/assistant/pubsub.ts
@@ -33,7 +33,6 @@ import type {
 } from "@app/types";
 import type {
   AgentMessageNewEvent,
-  ConversationTitleEvent,
   UserMessageErrorEvent,
   UserMessageNewEvent,
 } from "@app/types";
@@ -130,8 +129,7 @@ type ConversationAsyncEvents =
   | UserMessageErrorEvent
   | UserMessageNewEvent
   | AgentMessageNewEvent
-  | AgentDisabledErrorEvent
-  | ConversationTitleEvent;
+  | AgentDisabledErrorEvent;
 
 function isEndOfStreamEvent(
   event: ConversationAsyncEvents
@@ -185,8 +183,7 @@ async function handleUserMessageEvents(
         for await (const event of generator) {
           switch (event.type) {
             case "user_message_new":
-            case "agent_message_new":
-            case "conversation_title": {
+            case "agent_message_new": {
               const pubsubChannel = getConversationChannelId(conversation.sId);
 
               await publishEvent({
@@ -449,8 +446,7 @@ export async function* getConversationEvents({
     data:
       | UserMessageNewEvent
       | AgentMessageNewEvent
-      | AgentGenerationCancelledEvent
-      | ConversationTitleEvent;
+      | AgentGenerationCancelledEvent;
   },
   void
 > {

--- a/front/lib/api/assistant/streaming/helpers.ts
+++ b/front/lib/api/assistant/streaming/helpers.ts
@@ -1,3 +1,11 @@
 export function getAgentExecutionChannelId(agentMessageId: string) {
   return `agent-execution-${agentMessageId}`;
 }
+
+export function getConversationChannelId({
+  conversationId,
+}: {
+  conversationId: string;
+}) {
+  return `conversation-${conversationId}`;
+}


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
As part of https://github.com/dust-tt/tasks/issues/3436. The end goal is to have no more Redis proxy, and have `runAgent` directly post events in the redis channel so it can directly be consumed by the `/events` endpoints. This starts by moving the conversation title to a dedicated place which enqueues its own event. There is a (voluntary) regression introduced here, until we have `runAgent` running in a Temporal workflow, we run the title generation before getting the `AgentMessage` so it only uses user's input. This is temporary and will be fixed very soon.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->
Tested locally, event `conversation_title` is properly sent/received in the client.

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
