### PR TITLE
bump startToCloseTimeout of githubProcessIndexFileActivity

### DIFF
--- a/connectors/src/connectors/github/temporal/workflows.ts
+++ b/connectors/src/connectors/github/temporal/workflows.ts
@@ -52,19 +52,15 @@ const { githubUpsertIssueActivity, githubUpsertDiscussionActivity } =
     startToCloseTimeout: "60 minute",
   });
 
-const {
-  githubEnsureCodeSyncEnabledActivity,
-  githubCreateGcsIndexActivity,
-  githubProcessIndexFileActivity,
-} = proxyActivities<typeof activitiesSyncCode>({
-  startToCloseTimeout: "10 minute",
-});
+const { githubEnsureCodeSyncEnabledActivity, githubCreateGcsIndexActivity } =
+  proxyActivities<typeof activitiesSyncCode>({
+    startToCloseTimeout: "10 minute",
+  });
 
-const { githubCleanupCodeSyncActivity } = proxyActivities<
-  typeof activitiesSyncCode
->({
-  startToCloseTimeout: "20 minute",
-});
+const { githubCleanupCodeSyncActivity, githubProcessIndexFileActivity } =
+  proxyActivities<typeof activitiesSyncCode>({
+    startToCloseTimeout: "20 minute",
+  });
 
 const { githubExtractToGcsActivity } = proxyActivities<
   typeof activitiesSyncCode


### PR DESCRIPTION
## Description

Context: https://dust4ai.slack.com/archives/C05F84CFP0E/p1752600752060349

Seeing a lot of startToCloseTimeout for this activity

## Tests

N/A

## Risk

Low

## Deploy Plan

- deploy `connectors`