### PR TITLE
[front] enh(FS tools): improve parameter descriptions

### DIFF
--- a/front/lib/actions/mcp_internal_actions/servers/data_sources_file_system.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/data_sources_file_system.ts
@@ -94,7 +94,8 @@ const OPTION_PARAMETERS = {
       "Field to sort the results by. 'title' sorts alphabetically A-Z, 'timestamp' sorts by " +
         "most recent first. If not specified, results are returned in default order, which is " +
         "folders first, then both documents and tables and alphabetically by title. " +
-        "The default order should be kept unless there is a specific reason to change it."
+        "The default order should be kept unless there is a specific reason to change it. " +
+        "This parameter is mutually exclusive with the query parameter."
     ),
   nextPageCursor: z
     .string()
@@ -121,7 +122,7 @@ const SearchToolInputSchema = z.object({
     .string()
     .describe(
       "The query to search for. This is a natural language query. It doesn't support any " +
-        "specific filter syntax."
+        "specific filter syntax. This parameter is mutually exclusive with the sortBy parameter."
     ),
   relativeTimeFrame: z
     .string()

--- a/front/lib/actions/mcp_internal_actions/servers/data_sources_file_system.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/data_sources_file_system.ts
@@ -122,7 +122,7 @@ const SearchToolInputSchema = z.object({
     .string()
     .describe(
       "The query to search for. This is a natural language query. It doesn't support any " +
-        "specific filter syntax. This parameter is mutually exclusive with the `sortBy` parameter."
+        "specific filter syntax."
     ),
   relativeTimeFrame: z
     .string()
@@ -515,7 +515,8 @@ const createServer = (
         .describe(
           "The title to search for. This supports partial matching and does not require the " +
             "exact title. For example, searching for 'budget' will find 'Budget 2024.xlsx', " +
-            "'Q1 Budget Report', etc."
+            "'Q1 Budget Report', etc. This parameter is mutually exclusive with the `sortBy` " +
+            "parameter."
         ),
       rootNodeId: z
         .string()

--- a/front/lib/actions/mcp_internal_actions/servers/data_sources_file_system.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/data_sources_file_system.ts
@@ -95,7 +95,7 @@ const OPTION_PARAMETERS = {
         "most recent first. If not specified, results are returned in default order, which is " +
         "folders first, then both documents and tables and alphabetically by title. " +
         "The default order should be kept unless there is a specific reason to change it. " +
-        "This parameter is mutually exclusive with the query parameter."
+        "This parameter is mutually exclusive with the `query` parameter."
     ),
   nextPageCursor: z
     .string()
@@ -122,7 +122,7 @@ const SearchToolInputSchema = z.object({
     .string()
     .describe(
       "The query to search for. This is a natural language query. It doesn't support any " +
-        "specific filter syntax. This parameter is mutually exclusive with the sortBy parameter."
+        "specific filter syntax. This parameter is mutually exclusive with the `sortBy` parameter."
     ),
   relativeTimeFrame: z
     .string()


### PR DESCRIPTION
## Description

- This PR improves the description of the parameters of the filesystem tools.
- More specifically it mentions that the `sortBy` and `query` parameters are mutually exclusive, which the model was not aware of otherwise and would be flagged as tool execution errors on our side (which was legit but is easily preventable).

## Tests

## Risk

- Low, very minor change.

## Deploy Plan

- Deploy front.
