### PR TITLE
Improve GitHub code sync performance

### DIFF
--- a/connectors/src/connectors/github/lib/code/gcs_repository.ts
+++ b/connectors/src/connectors/github/lib/code/gcs_repository.ts
@@ -22,7 +22,7 @@ const DEFAULT_MAX_RESULTS = 1000;
 const STREAM_THRESHOLD_BYTES = 1024 * 1024; // 1MB - files smaller than this will be buffered.
 const GCS_RESUMABLE_UPLOAD_THRESHOLD_BYTES = 10 * 1024 * 1024; // 10MB
 
-const ITEMS_PER_INDEX = 5000; // Files/directories per index file.
+const ITEMS_PER_INDEX = 3000; // Files/directories per index file.
 const PARALLEL_INDEX_UPLOADS = 10; // Concurrent index file uploads.
 
 interface DirectoryListing {

--- a/connectors/src/connectors/github/temporal/activities/sync_code.ts
+++ b/connectors/src/connectors/github/temporal/activities/sync_code.ts
@@ -41,8 +41,10 @@ import logger from "@connectors/logger/logger";
 import { ConnectorResource } from "@connectors/resources/connector_resource";
 import type { DataSourceConfig } from "@connectors/types";
 
-const PARALLEL_FILE_UPLOADS = 15;
-const PARALLEL_DIRECTORY_UPLOADS = 10;
+// Files are uploaded asynchronously, so we can use a high number of parallel uploads.
+const PARALLEL_FILE_UPLOADS = 128;
+// Directories are uploaded synchronously, so we need to use a lower number of parallel uploads.
+const PARALLEL_DIRECTORY_UPLOADS = 64;
 const GCS_FILES_BATCH_SIZE = 500;
 
 const GITHUB_TARBALL_DOWNLOAD_TIMEOUT_MS = 20 * 60 * 1000; // 20 minutes.


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
With https://github.com/dust-tt/dust/pull/14321 we often hit `startToCloseTimeout` on the `githubProcessIndexFileActivity` activity. This stems for low parallelization on the upsert side. Tested on a repo with a few thousands files and directories, with this PR it goes from 24+ minutes down to ~5 minutes.

Some logs will be added by @spolu.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
