### PR TITLE
[Front] Standardize error logging

### DIFF
--- a/front/lib/resources/storage/wrappers/workspace_models.ts
+++ b/front/lib/resources/storage/wrappers/workspace_models.ts
@@ -135,6 +135,10 @@ export class WorkspaceAwareModel<M extends Model = any> extends BaseModel<M> {
               model: this.name,
               query_type: "find",
               stack_trace: stack,
+              error: {
+                message: "workspace_isolation_violation",
+                stack,
+              },
               where: whereClause,
             },
             "workspace_isolation_violation"


### PR DESCRIPTION
## Description

Standardize error logging so we can have proper stack traces in Datadog

cf. documentation https://docs.datadoghq.com/logs/error_tracking/backend?tab=serilog#nodejs

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

## Tests

We expect this [logs](https://app.datadoghq.eu/logs?query=service%3Afront%20-source%3Abrowser%20%40apiErrorHandlerCallStack%3A%2A%20%40apiError.api_error.message%3A%2A&agg_m=count&agg_m_source=base&agg_t=count&clustering_pattern_field_path=message&cols=host%2Cservice&event=AwAAAZgStWDo22jEEAAAABhBWmdTdFhJZUFBQkFORjZTNThGT0ZnQUgAAAAkMDE5ODEyYjUtY2U0MS00ZTBhLWIwYTYtOWM1YzE2NjM5OGY4AAPI6w&messageDisplay=inline&refresh_mode=sliding&storage=hot&stream_sort=desc&viz=stream&from_ts=1752483948265&to_ts=1752656748265&live=true) to have proper stack traces

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

N/A

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

- Deploy `front`

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
