### PR TITLE
fix(OAI-reasoning): handling for several CoT summaries in same item

### DIFF
--- a/front/components/assistant/conversation/AgentMessage.tsx
+++ b/front/components/assistant/conversation/AgentMessage.tsx
@@ -590,8 +590,8 @@ export function AgentMessage({
             owner={owner}
           />
 
-          {agentMessage.chainOfThought?.length ? (
-            <ContentMessage title="Agent thoughts" variant="primary">
+          {agentMessage.chainOfThought?.trim().length ? (
+            <ContentMessage variant="primary">
               <Markdown
                 content={agentMessage.chainOfThought}
                 isStreaming={false}


### PR DESCRIPTION
## Description

Current code does not properly handle several CoT summaries coming in the same reasoning item.

This PR adds handling for it by:
- Joining them by `\n\n` in the output
- Streaming `\n\n` as reasoning tokens when a CoT summary is complete


Additional changes: 
- remove the title "Agent thoughts" in the UI
- don't display the agent thoughts box if the CoT is whitespace only

## Tests

Local

## Risk

Very low

## Deploy Plan

Deploy `core` and `front`