### PR TITLE
enh: disable visualization by default for new custom agents

### DIFF
--- a/front/components/assistant_builder/types.ts
+++ b/front/components/assistant_builder/types.ts
@@ -202,8 +202,6 @@ export type ActionSpecificationWithType = ActionSpecification & {
 // Creates a fresh instance of AssistantBuilderState to prevent unintended mutations of shared state.
 export function getDefaultAssistantState() {
   return {
-    // Data Visualization is not an action but we show it like an action.
-    // Visualization is now disabled by default.
     actions: [],
     handle: null,
     scope: "hidden",

--- a/front/components/assistant_builder/types.ts
+++ b/front/components/assistant_builder/types.ts
@@ -203,8 +203,8 @@ export type ActionSpecificationWithType = ActionSpecification & {
 export function getDefaultAssistantState() {
   return {
     // Data Visualization is not an action but we show it like an action.
-    // We enable it by default so we should push it to actions list.
-    actions: [getDataVisualizationActionConfiguration()],
+    // Visualization is now disabled by default.
+    actions: [],
     handle: null,
     scope: "hidden",
     description: null,
@@ -220,7 +220,7 @@ export function getDefaultAssistantState() {
         CLAUDE_4_SONNET_DEFAULT_MODEL_CONFIG.defaultReasoningEffort,
     },
     maxStepsPerRun: DEFAULT_MAX_STEPS_USE_PER_RUN,
-    visualizationEnabled: true,
+    visualizationEnabled: false,
     templateId: null,
     tags: [],
     editors: [],


### PR DESCRIPTION
## Summary
This PR disables the visualization capability by default when creating new custom agents in both the assistant builder and the new agent builder v2.

## Changes
- Set `visualizationEnabled` to `false` in the default assistant state
- Removed the DATA_VISUALIZATION action from the default actions array
- Updated the comment to reflect this change
