### PR TITLE
feat(reasoning): store provider and tokens

### DIFF
--- a/front/lib/api/assistant/agent.ts
+++ b/front/lib/api/assistant/agent.ts
@@ -892,10 +892,25 @@ async function* runMultiActionsAgent(
           return;
         }
 
+        const contents = (block.message.contents ?? []).map((content) => {
+          if (content.type === "reasoning") {
+            return {
+              ...content,
+              value: {
+                ...content.value,
+                // TODO(DURABLE-AGENTS 2025-07-16): correct value for tokens.
+                tokens: 0,
+                provider: model.providerId,
+              },
+            } satisfies ReasoningContentType;
+          }
+          return content;
+        });
+
         output = {
           actions: [],
           generation: null,
-          contents: block.message.contents ?? [],
+          contents,
         };
 
         if (block.message.function_calls?.length) {

--- a/front/lib/resources/agent_step_content_resource.ts
+++ b/front/lib/resources/agent_step_content_resource.ts
@@ -302,6 +302,19 @@ export class AgentStepContentResource extends BaseResource<AgentStepContentModel
   }
 
   toJSON(): AgentStepContentType {
+    let value = this.value;
+    if (this.type === "reasoning" && value.type === "reasoning") {
+      value = {
+        ...value,
+        value: {
+          ...value.value,
+          // TODO(DURABLE-AGENTS 2025-07-16): remove defaults once backfill is done.
+          tokens: value.value.tokens ?? 0,
+          provider: value.value.provider ?? "openai",
+        },
+      };
+    }
+
     const base: AgentStepContentType = {
       id: this.id,
       sId: this.sId,
@@ -312,7 +325,7 @@ export class AgentStepContentResource extends BaseResource<AgentStepContentModel
       index: this.index,
       version: this.version,
       type: this.type,
-      value: this.value,
+      value,
     };
 
     if ("agentMCPActions" in this && Array.isArray(this.agentMCPActions)) {

--- a/front/migrations/20250716_add_tokens_provider_to_reasoning_content.ts
+++ b/front/migrations/20250716_add_tokens_provider_to_reasoning_content.ts
@@ -1,0 +1,110 @@
+import { Op } from "sequelize";
+
+import { AgentStepContentModel } from "@app/lib/models/assistant/agent_step_content";
+import { concurrentExecutor } from "@app/lib/utils/async_utils";
+import { makeScript } from "@app/scripts/helpers";
+import type { AgentContentItemType } from "@app/types/assistant/agent_message_content";
+
+makeScript({}, async ({ execute }, logger) => {
+  let lastSeenId = 0;
+  const batchSize = 1000;
+  let totalProcessed = 0;
+  let totalUpdated = 0;
+
+  for (;;) {
+    // Find agent step contents with reasoning type
+    const stepContents = await AgentStepContentModel.findAll({
+      where: {
+        id: {
+          [Op.gt]: lastSeenId,
+        },
+        type: "reasoning",
+      },
+      order: [["id", "ASC"]],
+      limit: batchSize,
+    });
+
+    if (stepContents.length === 0) {
+      break;
+    }
+
+    logger.info(
+      `Processing ${stepContents.length} reasoning content items starting from ID ${lastSeenId}`
+    );
+
+    const toUpdate: Array<{
+      id: number;
+      updatedValue: AgentContentItemType;
+    }> = [];
+
+    for (const stepContent of stepContents) {
+      const value = stepContent.value as AgentContentItemType;
+      if (value.type !== "reasoning") {
+        throw new Error(
+          `Unreachable: expected reasoning content, got ${value.type} for step content ${stepContent.id}`
+        );
+      }
+
+      const needsUpdate =
+        value.value.tokens === undefined || value.value.provider === undefined;
+
+      if (needsUpdate) {
+        const updatedValue = {
+          ...value,
+          value: {
+            ...value.value,
+            tokens: value.value.tokens ?? 0,
+            provider: value.value.provider ?? "openai",
+          },
+        };
+
+        toUpdate.push({
+          id: stepContent.id,
+          updatedValue,
+        });
+      }
+    }
+
+    if (toUpdate.length > 0) {
+      logger.info(
+        `Found ${toUpdate.length} reasoning content items needing updates out of ${stepContents.length} checked`
+      );
+
+      if (execute) {
+        await concurrentExecutor(
+          toUpdate,
+          async ({ id, updatedValue }) => {
+            await AgentStepContentModel.update(
+              { value: updatedValue },
+              { where: { id } }
+            );
+          },
+          { concurrency: 10 }
+        );
+
+        logger.info(
+          `Updated ${toUpdate.length} reasoning content items with default tokens and provider`
+        );
+        totalUpdated += toUpdate.length;
+      } else {
+        logger.info(
+          `Dry run - would have updated ${toUpdate.length} reasoning content items`
+        );
+      }
+    }
+
+    totalProcessed += stepContents.length;
+    lastSeenId = stepContents[stepContents.length - 1].id;
+  }
+
+  logger.info(
+    {
+      totalProcessed,
+      totalUpdated: execute
+        ? totalUpdated
+        : `Would have updated ${totalUpdated}`,
+      execute,
+    },
+    "Backfill complete"
+  );
+});

--- a/front/types/assistant/agent_message_content.ts
+++ b/front/types/assistant/agent_message_content.ts
@@ -1,4 +1,5 @@
 import type { ModelId } from "@app/types";
+import type { ModelProviderIdType } from "@app/types/assistant/assistant";
 import type { FunctionCallType } from "@app/types/assistant/generation";
 
 export type TextContentType = {
@@ -11,6 +12,8 @@ export type ReasoningContentType = {
   value: {
     reasoning?: string;
     metadata: string;
+    tokens: number;
+    provider: ModelProviderIdType;
   };
 };
 


### PR DESCRIPTION
## Description

This PRs goal is to start storing more info on the reasoning items in AgentStepContent:
- the tokens count, which is needed when rendering the conversation for model to maintain an accurate count of tokens for the message
- the provider, which is needed as we don't want to send reasoning items from a different model provider

This also adds a backfill script

We temporarily have default values while the backfill isn't landed yet.

## Tests

Local

## Risk

N/A

## Deploy Plan

Deploy front