### PR TITLE
Adjust GitHub code sync chunk size

### DIFF
--- a/connectors/src/connectors/github/lib/code/gcs_repository.ts
+++ b/connectors/src/connectors/github/lib/code/gcs_repository.ts
@@ -324,19 +324,17 @@ export class GCSRepositoryManager {
           directories: [], // No directories in file chunks.
           indexNumber: index,
           totalFileIndexes: fileChunks.length,
-          totalDirectoryIndexes: directoryChunks.length,
           createdAt: new Date().toISOString(),
         },
       })),
       // Directory chunks.
       ...directoryChunks.map((directoryChunk, index) => ({
         index: fileChunks.length + index, // Continue numbering after file chunks.
-        path: `${indexBasePath}_directories_${fileChunks.length + index}.json`,
+        path: `${indexBasePath}_directories_${index}.json`,
         data: {
           files: [], // No files in directory chunks.
           directories: directoryChunk,
-          indexNumber: fileChunks.length + index,
-          totalFileIndexes: fileChunks.length,
+          indexNumber: index,
           totalDirectoryIndexes: directoryChunks.length,
           createdAt: new Date().toISOString(),
         },

--- a/connectors/src/connectors/github/lib/code/gcs_repository.ts
+++ b/connectors/src/connectors/github/lib/code/gcs_repository.ts
@@ -19,7 +19,7 @@ const DUST_INTERNAL_INDEX_FILE = "DUST_INTERNAL_INDEX_v1";
 const DUST_INTERNAL_INDEX_FILE_PREFIX = "._dust_internal_index";
 
 const DEFAULT_MAX_RESULTS = 1000;
-const STREAM_THRESHOLD_BYTES = 3 * 1024 * 1024; // 3MB - files smaller than this will be buffered.
+const STREAM_THRESHOLD_BYTES = 2 * 1024 * 1024; // 2MB - files smaller than this will be buffered.
 const GCS_RESUMABLE_UPLOAD_THRESHOLD_BYTES = 10 * 1024 * 1024; // 10MB
 
 // Files are faster to upsert than directories, so we can afford to have more files per index file.

--- a/connectors/src/connectors/github/lib/code/gcs_repository.ts
+++ b/connectors/src/connectors/github/lib/code/gcs_repository.ts
@@ -22,7 +22,10 @@ const DEFAULT_MAX_RESULTS = 1000;
 const STREAM_THRESHOLD_BYTES = 3 * 1024 * 1024; // 3MB - files smaller than this will be buffered.
 const GCS_RESUMABLE_UPLOAD_THRESHOLD_BYTES = 10 * 1024 * 1024; // 10MB
 
-const ITEMS_PER_INDEX = 3000; // Files/directories per index file.
+// Files are faster to read than directories, so we can afford to have more files per index file.
+const FILES_PER_INDEX = 4000; // Files per index file.
+const DIRECTORIES_PER_INDEX = 1500; // Directories per index file.
+
 const PARALLEL_INDEX_UPLOADS = 10; // Concurrent index file uploads.
 
 interface DirectoryListing {
@@ -293,33 +296,52 @@ export class GCSRepositoryManager {
       pageToken = result.nextPageToken;
     } while (pageToken);
 
+    // Split files and directories into separate chunks.
+    const fileChunks = chunk(files, FILES_PER_INDEX);
+    const directoryChunks = chunk(directories, DIRECTORIES_PER_INDEX);
+
     childLogger.info(
       {
         gcsBasePath,
         totalFiles: files.length,
         totalDirectories: directories.length,
+        totalFileChunks: fileChunks.length,
+        totalDirectoryChunks: directoryChunks.length,
+        totalIndexFiles: fileChunks.length + directoryChunks.length,
       },
-      "Creating multiple index files for repository"
+      "Creating separate index files for files and directories"
     );
-
-    // Split files and directories into multiple index files.
-    const fileChunks = chunk(files, ITEMS_PER_INDEX);
-    const directoryChunks = chunk(directories, ITEMS_PER_INDEX);
-    const totalChunks = Math.max(fileChunks.length, directoryChunks.length);
     const indexPaths: string[] = [];
 
-    // Create index data for all chunks.
-    const indexChunks = Array.from({ length: totalChunks }, (_, index) => ({
-      index,
-      path: `${indexBasePath}_${index}.json`,
-      data: {
-        files: fileChunks[index] || [], // Empty array if no files for this chunk.
-        directories: directoryChunks[index] || [], // Empty array if no directories for this chunk.
-        indexNumber: index,
-        totalIndexes: totalChunks,
-        createdAt: new Date().toISOString(),
-      },
-    }));
+    // Create separate chunks for files and directories.
+    const indexChunks = [
+      // File chunks.
+      ...fileChunks.map((fileChunk, index) => ({
+        index: index,
+        path: `${indexBasePath}_files_${index}.json`,
+        data: {
+          files: fileChunk,
+          directories: [], // No directories in file chunks.
+          indexNumber: index,
+          totalFileIndexes: fileChunks.length,
+          totalDirectoryIndexes: directoryChunks.length,
+          createdAt: new Date().toISOString(),
+        },
+      })),
+      // Directory chunks.
+      ...directoryChunks.map((directoryChunk, index) => ({
+        index: fileChunks.length + index, // Continue numbering after file chunks.
+        path: `${indexBasePath}_directories_${index}.json`,
+        data: {
+          files: [], // No files in directory chunks.
+          directories: directoryChunk,
+          indexNumber: index,
+          totalFileIndexes: fileChunks.length,
+          totalDirectoryIndexes: directoryChunks.length,
+          createdAt: new Date().toISOString(),
+        },
+      })),
+    ];
 
     // Upload index files.
     await concurrentExecutor(
@@ -345,10 +367,10 @@ export class GCSRepositoryManager {
       {
         gcsBasePath,
         totalIndexes: indexPaths.length,
-        itemsPerIndex: ITEMS_PER_INDEX,
-        totalIndexFiles: indexPaths.length,
+        totalFileChunks: fileChunks.length,
+        totalDirectoryChunks: directoryChunks.length,
       },
-      "Created multiple index files for repository"
+      "Created separate index files for files and directories"
     );
 
     return indexPaths;

--- a/connectors/src/connectors/github/lib/code/gcs_repository.ts
+++ b/connectors/src/connectors/github/lib/code/gcs_repository.ts
@@ -22,7 +22,7 @@ const DEFAULT_MAX_RESULTS = 1000;
 const STREAM_THRESHOLD_BYTES = 3 * 1024 * 1024; // 3MB - files smaller than this will be buffered.
 const GCS_RESUMABLE_UPLOAD_THRESHOLD_BYTES = 10 * 1024 * 1024; // 10MB
 
-// Files are faster to read than directories, so we can afford to have more files per index file.
+// Files are faster to upsert than directories, so we can afford to have more files per index file.
 const FILES_PER_INDEX = 4000; // Files per index file.
 const DIRECTORIES_PER_INDEX = 1500; // Directories per index file.
 
@@ -317,7 +317,7 @@ export class GCSRepositoryManager {
     const indexChunks = [
       // File chunks.
       ...fileChunks.map((fileChunk, index) => ({
-        index: index,
+        index,
         path: `${indexBasePath}_files_${index}.json`,
         data: {
           files: fileChunk,
@@ -331,11 +331,11 @@ export class GCSRepositoryManager {
       // Directory chunks.
       ...directoryChunks.map((directoryChunk, index) => ({
         index: fileChunks.length + index, // Continue numbering after file chunks.
-        path: `${indexBasePath}_directories_${index}.json`,
+        path: `${indexBasePath}_directories_${fileChunks.length + index}.json`,
         data: {
           files: [], // No files in directory chunks.
           directories: directoryChunk,
-          indexNumber: index,
+          indexNumber: fileChunks.length + index,
           totalFileIndexes: fileChunks.length,
           totalDirectoryIndexes: directoryChunks.length,
           createdAt: new Date().toISOString(),

--- a/connectors/src/connectors/github/lib/code/tar_extraction.ts
+++ b/connectors/src/connectors/github/lib/code/tar_extraction.ts
@@ -20,7 +20,7 @@ import {
 import { ExternalOAuthTokenError } from "@connectors/lib/error";
 import type { Logger } from "@connectors/logger/logger";
 
-const MAX_FILE_SIZE_BYTES = 3 * 1024 * 1024; // 3MB
+const MAX_FILE_SIZE_BYTES = 2 * 1024 * 1024; // 2MB
 const MAX_CONCURRENT_GCS_UPLOADS = 200;
 
 interface TarExtractionOptions {


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
Current implementation can batch up to 3k files and 3k directories in the same batch. This has been hitting the 30 minutes start to close timeout too often. We know that folder upsert is actually pretty slow. This PR ensures that we don't mix up directories and files within the same chunk to avoid hitting the timeout.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
