### PR TITLE
Fixes for file generation tool

### DIFF
--- a/front/lib/actions/mcp.ts
+++ b/front/lib/actions/mcp.ts
@@ -1014,7 +1014,7 @@ export class MCPConfigurationServerRunner extends BaseActionConfigurationServerR
               if (isBlobResource(block)) {
                 const fileName = isResourceWithName(block)
                   ? block.name
-                  : `generated-file-${Date.now()}.${extensionsForContentType(block.resource.mimeType as SupportedFileContentType)[0]}`;
+                  : `generated-file-${Date.now()}${extensionsForContentType(block.resource.mimeType as SupportedFileContentType)[0]}`;
 
                 return handleBase64Upload(
                   block.resource.blob,


### PR DESCRIPTION
## Description

- Currently the files generated have to dots so we cannot open them, ex: `soupinou..txt`.
- Trying to generate a doc or pdf file is not working, I cannot open the files locally. 

## Tests

Locally I can now generate .docx and .pdf

## Risk

Can be rolled back.

## Deploy Plan

Deploy front. 