### PR TITLE
Split monitoring of Dust apps from tool executions

### DIFF
--- a/front/lib/actions/mcp_internal_actions/wrappers.ts
+++ b/front/lib/actions/mcp_internal_actions/wrappers.ts
@@ -76,7 +76,7 @@ export function withToolLogging<T>(
 
     const elapsed = performance.now() - startTime;
     statsDClient.distribution(
-      "run_action.duration.distribution",
+      "run_tool.duration.distribution",
       elapsed,
       tags
     );

--- a/front/lib/actions/mcp_internal_actions/wrappers.ts
+++ b/front/lib/actions/mcp_internal_actions/wrappers.ts
@@ -75,11 +75,7 @@ export function withToolLogging<T>(
     }
 
     const elapsed = performance.now() - startTime;
-    statsDClient.distribution(
-      "run_tool.duration.distribution",
-      elapsed,
-      tags
-    );
+    statsDClient.distribution("run_tool.duration.distribution", elapsed, tags);
 
     return result;
   };

--- a/front/lib/actions/mcp_internal_actions/wrappers.ts
+++ b/front/lib/actions/mcp_internal_actions/wrappers.ts
@@ -37,18 +37,18 @@ export function withToolLogging<T>(
     logger.info(loggerArgs, "Tool execution start");
 
     const tags = [
-      `action:${toolName}`,
+      `tool:${toolName}`,
       `workspace:${owner.sId}`,
       `workspace_plan_code:${auth.plan()?.code || null}`,
     ];
 
-    statsDClient.increment("use_actions.count", 1, tags);
+    statsDClient.increment("use_tools.count", 1, tags);
     const startTime = performance.now();
 
     const result = await toolCallback(params);
 
     if (result.isError) {
-      statsDClient.increment("use_actions_error.count", 1, [
+      statsDClient.increment("use_tools_error.count", 1, [
         "error_type:run_error",
         ...tags,
       ]);


### PR DESCRIPTION
## Description

- This PR changes the name of the metrics used to monitor tool executions.
- The goal is to stop having overlap with `runActionStreamed`, which we is not controlled the same way (the error handling is in `core` and is far more generic than for tool executions, where we explicitly flag code paths that should be tracked).
- Associated PR on monitors: https://github.com/dust-tt/dust-infra/pull/390
- The dashboards have also already been updated accordingly.

## Tests

## Risk

- Will create a discontinuity in the metrics.
- Should not have a major impact on cost given that we already have a tag for the workspace.

## Deploy Plan

- Deploy front.
