### PR TITLE
enh(agent-thoughts): add tooltip

### DIFF
--- a/front/components/assistant/conversation/AgentMessage.tsx
+++ b/front/components/assistant/conversation/AgentMessage.tsx
@@ -15,6 +15,7 @@ import {
   InteractiveImageGrid,
   Markdown,
   Separator,
+  Tooltip,
   useCopyToClipboard,
 } from "@dust-tt/sparkle";
 import { marked } from "marked";
@@ -591,15 +592,23 @@ export function AgentMessage({
           />
 
           {agentMessage.chainOfThought?.trim().length ? (
-            <ContentMessage variant="primary">
-              <Markdown
-                content={agentMessage.chainOfThought}
-                isStreaming={false}
-                forcedTextSize="text-sm"
-                textColor="text-muted-foreground"
-                isLastMessage={false}
-              />
-            </ContentMessage>
+            <Tooltip
+              label="Agent thoughts"
+              trigger={
+                <div>
+                  <ContentMessage variant="primary">
+                    <Markdown
+                      content={agentMessage.chainOfThought}
+                      isStreaming={false}
+                      forcedTextSize="text-sm"
+                      textColor="text-muted-foreground"
+                      isLastMessage={false}
+                    />
+                  </ContentMessage>
+                </div>
+              }
+              tooltipTriggerAsChild
+            />
           ) : null}
         </div>
         {(inProgressImages.length > 0 || completedImages.length > 0) && (


### PR DESCRIPTION
## Description
<img width="1013" height="597" alt="Screenshot 2025-07-16 at 14 50 23" src="https://github.com/user-attachments/assets/c388535f-24ad-428b-85d8-2f225143f2a8" />

"Agent thoughts" tooltip visible on mouse hover

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
