### PR TITLE
Poké Slackbot plugin: display valid Metabase Query depending on Region

### DIFF
--- a/front/lib/api/poke/plugins/data_sources/slack_whitelist_bot.ts
+++ b/front/lib/api/poke/plugins/data_sources/slack_whitelist_bot.ts
@@ -1,5 +1,6 @@
 import config from "@app/lib/api/config";
 import { createPlugin } from "@app/lib/api/poke/types";
+import { config as regionsConfig } from "@app/lib/api/regions/config";
 import { GroupResource } from "@app/lib/resources/group_resource";
 import logger from "@app/logger/logger";
 import type { AdminCommandType } from "@app/types";
@@ -124,9 +125,10 @@ export const slackWhitelistBotPlugin = createPlugin({
       );
     }
 
-    const metabaseUrl =
-      `https://metabase.dust.tt/question/637-whitelisted-bots-given-connector` +
-      `?connectorId=${resource.connectorId}`;
+    const isEU = regionsConfig.getCurrentRegion() === "europe-west1";
+    const metabaseUrl = isEU
+      ? `https://eu.metabase.dust.tt/question/46-whitelisted-bots-given-connector?connectorId=${resource.connectorId}`
+      : `https://metabase.dust.tt/question/637-whitelisted-bots-given-connector?connectorId=${resource.connectorId}`;
 
     return new Ok({
       display: "textWithLink",


### PR DESCRIPTION
## Description

The link to the Metabase query was always US -> User runner was confused about why they were seeing no results after using the plugin. 

I created the query on Metabase EU and updated the link on the Poké plugin depending on the current region. 

## Tests

Locally. 

## Risk

Can be rolled back. 
## Deploy Plan

Deploy front. 