### PR TITLE
enh(attachments): get rid of JIT extract

### DIFF
--- a/front/lib/actions/constants.ts
+++ b/front/lib/actions/constants.ts
@@ -30,9 +30,6 @@ export const DEFAULT_CONVERSATION_QUERY_TABLES_ACTION_NAME =
 export const DEFAULT_CONVERSATION_SEARCH_ACTION_NAME =
   "search_conversation_files";
 
-export const DEFAULT_CONVERSATION_EXTRACT_ACTION_NAME =
-  "extract_conversation_files";
-
 export const DUST_CONVERSATION_HISTORY_MAGIC_INPUT_KEY =
   "__dust_conversation_history";
 

--- a/front/lib/api/assistant/conversation/attachments.ts
+++ b/front/lib/api/assistant/conversation/attachments.ts
@@ -3,7 +3,6 @@ import assert from "assert";
 
 import {
   isConversationIncludableFileContentType,
-  isExtractableContentType,
   isQueryableContentType,
   isSearchableContentType,
 } from "@app/lib/api/assistant/conversation/content_types";
@@ -32,7 +31,6 @@ export type BaseConversationAttachmentType = {
   isIncludable: boolean;
   isSearchable: boolean;
   isQueryable: boolean;
-  isExtractable: boolean;
 };
 
 export type FileAttachmentType = BaseConversationAttachmentType & {
@@ -110,10 +108,6 @@ export function getAttachmentFromContentNodeContentFragment(
     isQueryable && cf.contentType !== CONTENT_NODE_MIME_TYPES.NOTION.DATABASE;
   const isSearchable =
     isSearchableContentType(cf.contentType) && !isUnmaterializedTable;
-  const isExtractable =
-    isExtractableContentType(cf.contentType) &&
-    !isUnmaterializedTable &&
-    !isQueryable;
 
   const baseAttachment: BaseConversationAttachmentType = {
     title: cf.title,
@@ -126,7 +120,6 @@ export function getAttachmentFromContentNodeContentFragment(
     isIncludable,
     isQueryable,
     isSearchable,
-    isExtractable,
   };
 
   return {
@@ -151,8 +144,6 @@ export function getAttachmentFromFileContentFragment(
   const isQueryable = canDoJIT && isQueryableContentType(cf.contentType);
   const isIncludable = isConversationIncludableFileContentType(cf.contentType);
   const isSearchable = canDoJIT && isSearchableContentType(cf.contentType);
-  const isExtractable =
-    canDoJIT && isExtractableContentType(cf.contentType) && !isQueryable;
   const baseAttachment: BaseConversationAttachmentType = {
     title: cf.title,
     contentType: cf.contentType,
@@ -169,7 +160,6 @@ export function getAttachmentFromFileContentFragment(
     isIncludable,
     isQueryable,
     isSearchable,
-    isExtractable,
   };
 
   return {
@@ -193,8 +183,6 @@ export function getAttachmentFromToolOutput({
   const isIncludable = isConversationIncludableFileContentType(contentType);
   const isQueryable = canDoJIT && isQueryableContentType(contentType);
   const isSearchable = canDoJIT && isSearchableContentType(contentType);
-  const isExtractable =
-    canDoJIT && isExtractableContentType(contentType) && !isQueryable;
 
   return {
     fileId,
@@ -207,7 +195,6 @@ export function getAttachmentFromToolOutput({
     isIncludable,
     isQueryable,
     isSearchable,
-    isExtractable,
   };
 }
 
@@ -226,7 +213,6 @@ export function renderAttachmentXml({
     `isIncludable="${attachment.isIncludable}"`,
     `isQueryable="${attachment.isQueryable}"`,
     `isSearchable="${attachment.isSearchable}"`,
-    `isExtractable="${attachment.isExtractable}"`,
   ];
 
   let tag = `<attachment ${params.join(" ")}`;

--- a/front/lib/api/assistant/conversation/content_types.ts
+++ b/front/lib/api/assistant/conversation/content_types.ts
@@ -54,12 +54,3 @@ export function isSearchableContentType(
   // For now we allow searching everything else.
   return true;
 }
-
-export function isExtractableContentType(
-  contentType: SupportedContentFragmentType
-): boolean {
-  if (isSupportedImageContentType(contentType)) {
-    return false;
-  }
-  return true;
-}

--- a/front/lib/api/assistant/generation.ts
+++ b/front/lib/api/assistant/generation.ts
@@ -1,7 +1,6 @@
 import moment from "moment-timezone";
 
 import {
-  DEFAULT_CONVERSATION_EXTRACT_ACTION_NAME,
   DEFAULT_CONVERSATION_INCLUDE_FILE_ACTION_NAME,
   DEFAULT_CONVERSATION_QUERY_TABLES_ACTION_NAME,
   DEFAULT_CONVERSATION_SEARCH_ACTION_NAME,
@@ -135,11 +134,10 @@ export async function constructPromptMultiActions(
     "The conversation history may contain file attachments, indicated by <attachment> tags. " +
     "Attachments may originate from the user directly or from tool outputs. " +
     "These tags indicate when the file was attached but do not always contain the full contents (it may contain a small snippet or description of the file).\n" +
-    "Each file attachment has a specific content type and status (includable, queryable, searchable, extractable):\n\n" +
+    "Each file attachment has a specific content type and status (includable, queryable, searchable):\n\n" +
     `// includable: full content can be retrieved using \`${DEFAULT_CONVERSATION_INCLUDE_FILE_ACTION_NAME}\`\n` +
     `// queryable: represents tabular data that can be queried alongside other queryable files' tabular data using \`${DEFAULT_CONVERSATION_QUERY_TABLES_ACTION_NAME}\`\n` +
     `// searchable: content can be searched alongside other searchable files' content using \`${DEFAULT_CONVERSATION_SEARCH_ACTION_NAME}\`\n` +
-    `// extractable: files can also be processed to extract structured data using \`${DEFAULT_CONVERSATION_EXTRACT_ACTION_NAME}\`\n` +
     "Other tools that accept files (referenced by their id) as arguments can be available. Rely on their description and the files mime types to decide which tool to use on which file.\n";
 
   // GUIDELINES section


### PR DESCRIPTION
## Description

JIT extract is confusing, and prevents the model from properly using JIT tables query on notion databases.
Similarly, it causes the model to almost always run an extract on folder attachements when the correct course of action would be to use the DS file system.

Next step: JIT ds file system instead of conversation files.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
