### PR TITLE
Slack sync non threaded

### DIFF
--- a/connectors/src/connectors/slack/temporal/activities.ts
+++ b/connectors/src/connectors/slack/temporal/activities.ts
@@ -480,7 +480,6 @@ export async function syncNonThreaded({
           channelId,
           startTsMs,
           endTsMs,
-          latestTsSec,
           nextCursor,
         },
         "Giving up on syncNonThreaded: too many messages"


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
See Slack [thread](https://dust4ai.slack.com/archives/C050SM8NSPK/p1752646627040639).

This PR re-instantiates the previous `syncNonThread` activity that sync all messages non threaded from the current week. Even though not ideal, some complexity was oversaw in the previous attempts.

We will rework this part later to have a proper incremental sync approach like we have for threaded messages. 

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->
Tested locally and confirm that it works.

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
- [ ] Deploy
- [ ] Resync channels that got non threaded messages last week
