### PR TITLE
[front] Improve design for known agent errors

### DIFF
--- a/front/components/assistant/conversation/AgentMessage.tsx
+++ b/front/components/assistant/conversation/AgentMessage.tsx
@@ -551,6 +551,7 @@ export function AgentMessage({
             agentMessage.error || {
               message: "Unexpected Error",
               code: "unexpected_error",
+              metadata: {},
             }
           }
           retryHandler={async () => retryHandler(agentMessage)}

--- a/front/components/assistant/conversation/ErrorMessage.tsx
+++ b/front/components/assistant/conversation/ErrorMessage.tsx
@@ -9,6 +9,7 @@ import {
 
 import { useSubmitFunction } from "@app/lib/client/utils";
 import type { AgentErrorContent } from "@app/types";
+import { isAgentErrorCategory } from "@app/types";
 import { truncate } from "@app/types/shared/utils/string_utils";
 
 interface ErrorMessageProps {
@@ -28,7 +29,12 @@ export function ErrorMessage({ error, retryHandler }: ErrorMessageProps) {
     <div className="flex flex-col gap-9">
       <div className="flex flex-col gap-1 sm:flex-row">
         <Chip
-          color="warning"
+          color={
+            isAgentErrorCategory(error.metadata?.category) &&
+            error.metadata?.category === "retryable_model_error"
+              ? "golden"
+              : "warning"
+          }
           label={"Error: " + truncate(error.message, 30)}
           size="xs"
         />

--- a/front/components/assistant/conversation/ErrorMessage.tsx
+++ b/front/components/assistant/conversation/ErrorMessage.tsx
@@ -12,13 +12,6 @@ import type { AgentErrorContent } from "@app/types";
 import { isAgentErrorCategory } from "@app/types";
 import { truncate } from "@app/types/shared/utils/string_utils";
 
-function getErrorChipColor(error: AgentErrorContent) {
-  return isAgentErrorCategory(error.metadata?.category) &&
-    error.metadata?.category === "retryable_model_error"
-    ? "golden"
-    : "warning";
-}
-
 interface ErrorMessageProps {
   error: AgentErrorContent;
   retryHandler: () => void;
@@ -28,6 +21,10 @@ export function ErrorMessage({ error, retryHandler }: ErrorMessageProps) {
   const fullMessage =
     error.message + (error.code ? ` (code: ${error.code})` : "");
 
+  const errorIsRetryable =
+    isAgentErrorCategory(error.metadata?.category) &&
+    error.metadata?.category === "retryable_model_error";
+
   const { submit: retry, isSubmitting: isRetrying } = useSubmitFunction(
     async () => retryHandler()
   );
@@ -36,7 +33,7 @@ export function ErrorMessage({ error, retryHandler }: ErrorMessageProps) {
     <div className="flex flex-col gap-9">
       <div className="flex flex-col gap-1 sm:flex-row">
         <Chip
-          color={getErrorChipColor(error)}
+          color={errorIsRetryable ? "golden" : "warning"}
           label={"Error: " + truncate(error.message, 30)}
           size="xs"
         />

--- a/front/components/assistant/conversation/ErrorMessage.tsx
+++ b/front/components/assistant/conversation/ErrorMessage.tsx
@@ -17,7 +17,7 @@ interface ErrorMessageProps {
 
 export function ErrorMessage({ error, retryHandler }: ErrorMessageProps) {
   const fullMessage =
-    "ERROR: " + error.message + (error.code ? ` (code: ${error.code})` : "");
+    error.message + (error.code ? ` (code: ${error.code})` : "");
 
   const { submit: retry, isSubmitting: isRetrying } = useSubmitFunction(
     async () => retryHandler()
@@ -26,11 +26,7 @@ export function ErrorMessage({ error, retryHandler }: ErrorMessageProps) {
   return (
     <div className="flex flex-col gap-9">
       <div className="flex flex-col gap-1 sm:flex-row">
-        <Chip
-          color="warning"
-          label={"ERROR: " + truncate(error.message, 30)}
-          size="xs"
-        />
+        <Chip color="warning" label={truncate(error.message, 32)} size="xs" />
         <Popover
           popoverTriggerAsChild
           trigger={

--- a/front/components/assistant/conversation/ErrorMessage.tsx
+++ b/front/components/assistant/conversation/ErrorMessage.tsx
@@ -12,6 +12,13 @@ import type { AgentErrorContent } from "@app/types";
 import { isAgentErrorCategory } from "@app/types";
 import { truncate } from "@app/types/shared/utils/string_utils";
 
+function getErrorChipColor(error: AgentErrorContent) {
+  return isAgentErrorCategory(error.metadata?.category) &&
+    error.metadata?.category === "retryable_model_error"
+    ? "golden"
+    : "warning";
+}
+
 interface ErrorMessageProps {
   error: AgentErrorContent;
   retryHandler: () => void;
@@ -29,12 +36,7 @@ export function ErrorMessage({ error, retryHandler }: ErrorMessageProps) {
     <div className="flex flex-col gap-9">
       <div className="flex flex-col gap-1 sm:flex-row">
         <Chip
-          color={
-            isAgentErrorCategory(error.metadata?.category) &&
-            error.metadata?.category === "retryable_model_error"
-              ? "golden"
-              : "warning"
-          }
+          color={getErrorChipColor(error)}
           label={"Error: " + truncate(error.message, 30)}
           size="xs"
         />

--- a/front/components/assistant/conversation/ErrorMessage.tsx
+++ b/front/components/assistant/conversation/ErrorMessage.tsx
@@ -26,7 +26,11 @@ export function ErrorMessage({ error, retryHandler }: ErrorMessageProps) {
   return (
     <div className="flex flex-col gap-9">
       <div className="flex flex-col gap-1 sm:flex-row">
-        <Chip color="warning" label={truncate(error.message, 32)} size="xs" />
+        <Chip
+          color="warning"
+          label={"Error: " + truncate(error.message, 30)}
+          size="xs"
+        />
         <Popover
           popoverTriggerAsChild
           trigger={

--- a/front/components/assistant/conversation/ErrorMessage.tsx
+++ b/front/components/assistant/conversation/ErrorMessage.tsx
@@ -8,10 +8,11 @@ import {
 } from "@dust-tt/sparkle";
 
 import { useSubmitFunction } from "@app/lib/client/utils";
+import type { AgentErrorContent } from "@app/types";
 import { truncate } from "@app/types/shared/utils/string_utils";
 
 interface ErrorMessageProps {
-  error: { code: string; message: string };
+  error: AgentErrorContent;
   retryHandler: () => void;
 }
 

--- a/front/lib/api/assistant/agent.ts
+++ b/front/lib/api/assistant/agent.ts
@@ -228,7 +228,7 @@ async function runMultiActionsAgentLoop(
     for await (const event of loopIterationStream) {
       switch (event.type) {
         case "agent_error":
-          const { publicMessage } = categorizeAgentErrorMessage(event.error);
+          const { category, publicMessage } = categorizeAgentErrorMessage(event.error);
 
           localLogger.error(
             {
@@ -241,7 +241,13 @@ async function runMultiActionsAgentLoop(
 
           await publishEvent({
             ...event,
-            error: { ...event.error, message: publicMessage },
+            error: {
+              ...event.error,
+              message: publicMessage,
+              metadata: {
+                category
+              }
+            },
           });
           return;
         case "agent_actions":
@@ -693,7 +699,9 @@ async function* runMultiActionsAgent(
           error: {
             code: "multi_actions_error",
             message: `Error running agent: [${res.error.type}] ${res.error.message}`,
-            metadata: null,
+            metadata: {
+              category
+            },
           },
         } satisfies AgentErrorEvent;
 

--- a/front/lib/api/assistant/agent.ts
+++ b/front/lib/api/assistant/agent.ts
@@ -228,7 +228,9 @@ async function runMultiActionsAgentLoop(
     for await (const event of loopIterationStream) {
       switch (event.type) {
         case "agent_error":
-          const { category, publicMessage } = categorizeAgentErrorMessage(event.error);
+          const { category, publicMessage } = categorizeAgentErrorMessage(
+            event.error
+          );
 
           localLogger.error(
             {
@@ -245,8 +247,8 @@ async function runMultiActionsAgentLoop(
               ...event.error,
               message: publicMessage,
               metadata: {
-                category
-              }
+                category,
+              },
             },
           });
           return;
@@ -700,7 +702,7 @@ async function* runMultiActionsAgent(
             code: "multi_actions_error",
             message: `Error running agent: [${res.error.type}] ${res.error.message}`,
             metadata: {
-              category
+              category,
             },
           },
         } satisfies AgentErrorEvent;

--- a/front/lib/api/assistant/agent_errors.ts
+++ b/front/lib/api/assistant/agent_errors.ts
@@ -19,10 +19,13 @@ export const categorizeAgentErrorMessage = (error: {
   message: string;
   code: string;
 }): {
-  category?:
+  category:
     | "retryable_model_error"
     | "context_window_exceeded"
-    | "provider_internal_error";
+    | "provider_internal_error"
+    | "stream_error"
+    | "unknown_error"
+    | "invalid_response_format_configuration";
   publicMessage: string;
 } => {
   if (error.code == "multi_actions_error") {
@@ -64,6 +67,7 @@ export const categorizeAgentErrorMessage = (error: {
       } else if (error.message.includes("Invalid schema for response_format")) {
         const contextPart = error.message.split("In context=")[1];
         return {
+          category: "invalid_response_format_configuration",
           publicMessage: `Your agent is configured to return a response in a format that is not supported by the model: ${contextPart}. Please update your agent configuration in Instructions > Advanced Settings > Structured Response Format.`,
         };
       } else if (error.message.includes("server_error")) {
@@ -78,6 +82,7 @@ export const categorizeAgentErrorMessage = (error: {
       error.message.includes("Error parsing error")
     ) {
       return {
+        category: "stream_error",
         publicMessage:
           "There was an error streaming the answer to your query. Please try again.",
       };
@@ -85,6 +90,7 @@ export const categorizeAgentErrorMessage = (error: {
   }
   // The original message is used as a fallback.
   return {
+    category: "unknown_error",
     publicMessage: `Error running agent: [${error.code}] ${error.message}`,
   };
 };

--- a/front/lib/api/assistant/agent_errors.ts
+++ b/front/lib/api/assistant/agent_errors.ts
@@ -1,3 +1,5 @@
+import type { AgentErrorCategory } from "@app/types";
+
 /**
  * Get a user-friendly error message from an API error.
  * This function handles various error cases from different model providers (Anthropic, OpenAI)
@@ -19,13 +21,7 @@ export const categorizeAgentErrorMessage = (error: {
   message: string;
   code: string;
 }): {
-  category:
-    | "retryable_model_error"
-    | "context_window_exceeded"
-    | "provider_internal_error"
-    | "stream_error"
-    | "unknown_error"
-    | "invalid_response_format_configuration";
+  category: AgentErrorCategory;
   publicMessage: string;
 } => {
   if (error.code == "multi_actions_error") {

--- a/front/types/assistant/agent.ts
+++ b/front/types/assistant/agent.ts
@@ -1,7 +1,6 @@
 import type {
   ActionConfigurationType,
   AgentActionConfigurationType,
-  AgentActionSpecification,
 } from "@app/lib/actions/types/agent";
 import type {
   ReasoningContentType,
@@ -190,7 +189,7 @@ export const EXTENDED_MAX_STEPS_USE_PER_RUN_LIMIT = 128;
  * Agent events
  */
 
-// Event sent when an agent error occured before we have a agent message in the database.
+// Event sent when an agent error occurred before we have an agent message in the database.
 export type AgentMessageErrorEvent = {
   type: "agent_message_error";
   created: number;
@@ -201,18 +200,21 @@ export type AgentMessageErrorEvent = {
   };
 };
 
-// Generic event sent when an error occured (whether it's during the action or the message
+// Generic type for the content of an agent error.
+export type AgentErrorContent = {
+  code: string;
+  message: string;
+  metadata: Record<string, string | number | boolean> | null;
+};
+
+// Generic event sent when an error occurred (whether it's during the action or the message
 // generation).
 export type AgentErrorEvent = {
   type: "agent_error";
   created: number;
   configurationId: string;
   messageId: string;
-  error: {
-    code: string;
-    message: string;
-    metadata: Record<string, string | number | boolean> | null;
-  };
+  error: AgentErrorContent;
 };
 
 export type AgentDisabledErrorEvent = {

--- a/front/types/assistant/agent.ts
+++ b/front/types/assistant/agent.ts
@@ -189,13 +189,22 @@ export const EXTENDED_MAX_STEPS_USE_PER_RUN_LIMIT = 128;
  * Agent events
  */
 
-export type AgentErrorCategory =
-  | "retryable_model_error"
-  | "context_window_exceeded"
-  | "provider_internal_error"
-  | "stream_error"
-  | "unknown_error"
-  | "invalid_response_format_configuration";
+export const AgentErrorCategories = [
+  "retryable_model_error",
+  "context_window_exceeded",
+  "provider_internal_error",
+  "stream_error",
+  "unknown_error",
+  "invalid_response_format_configuration",
+] as const;
+
+export type AgentErrorCategory = (typeof AgentErrorCategories)[number];
+
+export function isAgentErrorCategory(
+  category: unknown
+): category is AgentErrorCategory {
+  return AgentErrorCategories.includes(category as AgentErrorCategory);
+}
 
 // Event sent when an agent error occurred before we have an agent message in the database.
 export type AgentMessageErrorEvent = {

--- a/front/types/assistant/agent.ts
+++ b/front/types/assistant/agent.ts
@@ -189,6 +189,14 @@ export const EXTENDED_MAX_STEPS_USE_PER_RUN_LIMIT = 128;
  * Agent events
  */
 
+export type AgentErrorCategory =
+  | "retryable_model_error"
+  | "context_window_exceeded"
+  | "provider_internal_error"
+  | "stream_error"
+  | "unknown_error"
+  | "invalid_response_format_configuration";
+
 // Event sent when an agent error occurred before we have an agent message in the database.
 export type AgentMessageErrorEvent = {
   type: "agent_message_error";

--- a/front/types/assistant/conversation.ts
+++ b/front/types/assistant/conversation.ts
@@ -9,6 +9,7 @@ import type { ModelId } from "../shared/model_id";
 import type { UserType, WorkspaceType } from "../user";
 import type {
   AgentConfigurationStatus,
+  AgentErrorContent,
   LightAgentConfigurationType,
 } from "./agent";
 import type { AgentContentItemType } from "./agent_message_content";
@@ -154,11 +155,7 @@ export type BaseAgentMessageType = {
   status: AgentMessageStatus;
   content: string | null;
   chainOfThought: string | null;
-  error: {
-    code: string;
-    message: string;
-    metadata: Record<string, string | number | boolean> | null;
-  } | null;
+  error: AgentErrorContent | null;
 };
 
 export type AgentMessageType = BaseAgentMessageType & {


### PR DESCRIPTION
## Description

- Part of https://github.com/dust-tt/tasks/issues/3467.
- This PR plugs the categorization of agent errors into the UI component.
- Retryable errors are shown in golden color instead of red.

<img width="396" height="174" alt="Screenshot 2025-07-16 at 4 16 32 PM" src="https://github.com/user-attachments/assets/838e570e-1921-4f85-9486-8495034a71cc" />

## Tests

- Tested locally.

## Risk

- Low.

## Deploy Plan

- Deploy front.
