### PR TITLE
[front] - fix(UserMenu): improve items display

### DIFF
--- a/front/components/UserMenu.tsx
+++ b/front/components/UserMenu.tsx
@@ -28,7 +28,11 @@ import { useSendNotification } from "@app/hooks/useNotification";
 import { usePersistedNavigationSelection } from "@app/hooks/usePersistedNavigationSelection";
 import { forceUserRole, showDebugTools } from "@app/lib/development";
 import { useFeatureFlags } from "@app/lib/swr/workspaces";
-import type { SubscriptionType, UserTypeWithWorkspaces, WorkspaceType } from "@app/types";
+import type {
+  SubscriptionType,
+  UserTypeWithWorkspaces,
+  WorkspaceType,
+} from "@app/types";
 import { isOnlyAdmin, isOnlyBuilder, isOnlyUser } from "@app/types";
 
 export function UserMenu({

--- a/front/components/UserMenu.tsx
+++ b/front/components/UserMenu.tsx
@@ -28,11 +28,7 @@ import { useSendNotification } from "@app/hooks/useNotification";
 import { usePersistedNavigationSelection } from "@app/hooks/usePersistedNavigationSelection";
 import { forceUserRole, showDebugTools } from "@app/lib/development";
 import { useFeatureFlags } from "@app/lib/swr/workspaces";
-import type {
-  SubscriptionType,
-  UserTypeWithWorkspaces,
-  WorkspaceType,
-} from "@app/types";
+import type { SubscriptionType, UserTypeWithWorkspaces, WorkspaceType } from "@app/types";
 import { isOnlyAdmin, isOnlyBuilder, isOnlyUser } from "@app/types";
 
 export function UserMenu({
@@ -99,7 +95,7 @@ export function UserMenu({
           <div className="flex min-w-0 flex-1 flex-col items-start">
             <span
               className={cn(
-                "heading-sm transition-colors duration-200",
+                "heading-sm w-full truncate transition-colors duration-200",
                 "text-foreground group-hover:text-primary-600 group-active:text-primary-950 dark:text-foreground-night dark:group-hover:text-muted-foreground-night dark:group-active:text-primary-700"
               )}
             >
@@ -109,10 +105,12 @@ export function UserMenu({
               {owner.name}
             </span>
           </div>
-          <Icon
-            visual={ChevronDownIcon}
-            className="text-muted-foreground group-hover:text-primary-400 group-active:text-primary-950 dark:text-muted-foreground-night dark:group-hover:text-foreground-night dark:group-active:text-primary-700"
-          />
+          <div className="flex-shrink-0">
+            <Icon
+              visual={ChevronDownIcon}
+              className="text-muted-foreground group-hover:text-primary-400 group-active:text-primary-950 dark:text-muted-foreground-night dark:group-hover:text-foreground-night dark:group-active:text-primary-700"
+            />
+          </div>
         </div>
       </DropdownMenuTrigger>
 

--- a/front/components/UserMenu.tsx
+++ b/front/components/UserMenu.tsx
@@ -96,7 +96,7 @@ export function UserMenu({
             }
             clickable
           />
-          <div className="flex flex-col items-start">
+          <div className="flex min-w-0 flex-1 flex-col items-start">
             <span
               className={cn(
                 "heading-sm transition-colors duration-200",
@@ -105,7 +105,7 @@ export function UserMenu({
             >
               {user.firstName}
             </span>
-            <span className="-mt-1 text-sm text-muted-foreground dark:text-muted-foreground-night">
+            <span className="w-full truncate text-sm text-muted-foreground dark:text-muted-foreground-night">
               {owner.name}
             </span>
           </div>

--- a/front/components/navigation/NavigationSidebar.tsx
+++ b/front/components/navigation/NavigationSidebar.tsx
@@ -173,12 +173,13 @@ export const NavigationSidebar = React.forwardRef<
       {user && (
         <div
           className={classNames(
-            "flex items-center justify-between gap-2 border-t p-2",
+            "flex items-center border-t px-1 py-2",
             "border-border-dark dark:border-border-dark-night",
             "text-foreground dark:text-foreground-night"
           )}
         >
           <UserMenu user={user} owner={owner} subscription={subscription} />
+          <div className="flex-1" />
           <HelpDropdown owner={owner} user={user} />
         </div>
       )}

--- a/front/components/navigation/NavigationSidebar.tsx
+++ b/front/components/navigation/NavigationSidebar.tsx
@@ -173,13 +173,12 @@ export const NavigationSidebar = React.forwardRef<
       {user && (
         <div
           className={classNames(
-            "flex items-center gap-2 border-t p-2",
+            "flex items-center justify-between gap-2 border-t p-2",
             "border-border-dark dark:border-border-dark-night",
             "text-foreground dark:text-foreground-night"
           )}
         >
           <UserMenu user={user} owner={owner} subscription={subscription} />
-          <div className="flex-grow" />
           <HelpDropdown owner={owner} user={user} />
         </div>
       )}


### PR DESCRIPTION
## Description

Ensure long owner names are truncated properly to maintain the menu layout
<img width="267" height="56" alt="Screenshot 2025-07-16 at 18 01 46" src="https://github.com/user-attachments/assets/d262e494-4c42-478d-b3d0-574326d68165" />

## Risk

Low, breaking UX

## Deploy Plan

Deploy front