### PR TITLE
Handle attachment picker side explicitly

### DIFF
--- a/extension/ui/components/conversation/ConversationContainer.tsx
+++ b/extension/ui/components/conversation/ConversationContainer.tsx
@@ -259,6 +259,7 @@ export function ConversationContainer({
                 setIncludeContent(includeTab);
               }}
               conversation={conversation ?? undefined}
+              attachmentPickerSide="top"
             />
           </div>
 

--- a/extension/ui/components/input_bar/InputBar.tsx
+++ b/extension/ui/components/input_bar/InputBar.tsx
@@ -50,6 +50,7 @@ export function AssistantInputBar({
   isTabIncluded,
   setIncludeTab,
   isSubmitting,
+  attachmentPickerSide,
 }: {
   owner: ExtensionWorkspaceType;
   onSubmit: (
@@ -64,6 +65,7 @@ export function AssistantInputBar({
   isTabIncluded: boolean;
   setIncludeTab: (includeTab: boolean) => void;
   isSubmitting?: boolean;
+  attachmentPickerSide?: "top" | "right" | "bottom" | "left";
 }) {
   const platform = usePlatform();
   const dustAPI = useDustAPI();
@@ -378,6 +380,7 @@ export function AssistantInputBar({
                 onNodeSelect={handleNodesAttachmentSelect}
                 onNodeUnselect={handleNodesAttachmentRemove}
                 attachedNodes={attachedNodes}
+                attachmentPickerSide={attachmentPickerSide}
               />
             </div>
           </div>

--- a/extension/ui/components/input_bar/InputBarAttachmentPicker.tsx
+++ b/extension/ui/components/input_bar/InputBarAttachmentPicker.tsx
@@ -40,6 +40,7 @@ interface InputBarAttachmentsPickerProps {
   onNodeUnselect: (node: DataSourceViewContentNodeType) => void;
   isLoading?: boolean;
   attachedNodes: DataSourceViewContentNodeType[];
+  side?: "top" | "right" | "bottom" | "left";
 }
 
 export const InputBarAttachmentsPicker = ({
@@ -48,6 +49,7 @@ export const InputBarAttachmentsPicker = ({
   onNodeUnselect,
   attachedNodes,
   isLoading = false,
+  side = "bottom",
 }: InputBarAttachmentsPickerProps) => {
   const fileInputRef = useRef<HTMLInputElement>(null);
   const itemsContainerRef = useRef<HTMLDivElement>(null);
@@ -136,7 +138,7 @@ export const InputBarAttachmentsPicker = ({
       </DropdownMenuTrigger>
       <DropdownMenuContent
         className="min-w-64 max-w-96"
-        side="bottom"
+        side={side}
         align="end"
         onInteractOutside={() => setIsOpen(false)}
         onEscapeKeyDown={() => setIsOpen(false)}

--- a/extension/ui/components/input_bar/InputBarContainer.tsx
+++ b/extension/ui/components/input_bar/InputBarContainer.tsx
@@ -44,6 +44,7 @@ export interface InputBarContainerProps {
   onNodeUnselect: (node: DataSourceViewContentNodeType) => void;
   attachedNodes: DataSourceViewContentNodeType[];
   isSubmitting: boolean;
+  attachmentPickerSide?: "top" | "right" | "bottom" | "left";
 }
 
 export const InputBarContainer = ({
@@ -61,6 +62,7 @@ export const InputBarContainer = ({
   onNodeUnselect,
   attachedNodes,
   isSubmitting,
+  attachmentPickerSide = "bottom",
 }: InputBarContainerProps) => {
   const platform = usePlatform();
   const suggestions = usePublicAssistantSuggestions(agentConfigurations);
@@ -250,6 +252,7 @@ export const InputBarContainer = ({
             onNodeSelect={onNodeSelect}
             onNodeUnselect={onNodeUnselect}
             attachedNodes={attachedNodes}
+            side={attachmentPickerSide}
           />
           <AssistantPicker
             owner={owner}


### PR DESCRIPTION
## Description

Handle attachment picker side explicitly in the extension UI components. This change improves the attachment picker functionality by explicitly managing the side behavior across the ConversationContainer, InputBar, InputBarAttachmentPicker, and InputBarContainer components.

See discussion in [Slack](https://dust4ai.slack.com/archives/C050SM8NSPK/p1752678960096439?thread_ts=1752049706.878129&cid=C050SM8NSPK)

## Tests

Manual testing of the attachment picker functionality in the extension to verify the side behavior is correctly handled.

## Risk

Low risk - this is a UI improvement that makes the attachment picker behavior more explicit. The changes are localized to the extension's input bar components and are safe to rollback if needed.

## Deploy Plan

Standard deployment - no special considerations needed. The changes are self-contained within the extension's UI components.