### PR TITLE
Add fallback to associate remaining agent_mcp_action <>  agent_step_content

### DIFF
--- a/front/migrations/20250709_agent_mcp_action_fk_step_content.ts
+++ b/front/migrations/20250709_agent_mcp_action_fk_step_content.ts
@@ -158,6 +158,34 @@ async function attachStepContentToMcpActions({
           });
         }
 
+        // Fallback for actions with an urls param that can be matched to a step content.
+        if (
+          !matchingStepContent &&
+          Array.isArray(mcpAction.params?.urls) &&
+          mcpAction.params.urls.length > 0
+        ) {
+          matchingStepContent = stepContents.find((sc) => {
+            if (isFunctionCallContent(sc.value)) {
+              try {
+                return (
+                  sc.value.value.arguments === JSON.stringify(mcpAction.params)
+                );
+              } catch (e) {
+                logger.error(
+                  {
+                    workspaceId: workspace.sId,
+                    actionId: mcpAction.id,
+                    stepContentId: sc.id,
+                    error: e,
+                  },
+                  "Error parsing function call arguments."
+                );
+              }
+            }
+            return false;
+          });
+        }
+
         if (!matchingStepContent) {
           if (verbose) {
             logger.info(


### PR DESCRIPTION
## Description

We still have some dangling agent_mcp_action. 
Updating the script to handle I think the vast majority of those. 

Most of the time we can actually link them looking at the query param. 
Example here so you can quickly see the logic: https://metabase.dust.tt/dashboard/58-agent-message-debug?agentmessageid=1612750

## Tests

Will dry run first. 

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

Dry run.
Merge 
Run with execute.