### PR TITLE
[front] chore: Update query to account for ws with expired subscription

### DIFF
--- a/front/migrations/20250626_clean_workos_organizations.ts
+++ b/front/migrations/20250626_clean_workos_organizations.ts
@@ -7,6 +7,7 @@ import { z } from "zod";
 import { getWorkOS } from "@app/lib/api/workos/client";
 import { concurrentExecutor } from "@app/lib/utils/async_utils";
 import { makeScript } from "@app/scripts/helpers";
+import { normalizeError } from "@app/types";
 
 const csvSchema = z.array(
   z.object({
@@ -111,6 +112,7 @@ makeScript(
           }
         } catch (err) {
           domainRecord.missingOrg = true;
+          domainRecord.error = normalizeError(err).message;
         }
 
         return domainRecord;

--- a/front/migrations/20250626_clean_workos_organizations.ts
+++ b/front/migrations/20250626_clean_workos_organizations.ts
@@ -121,7 +121,12 @@ makeScript(
     );
 
     if (output) {
-      writeFileSync(output, stringify(records));
+      writeFileSync(
+        output,
+        stringify(records, {
+          header: true,
+        })
+      );
       logger.info(`File saved`);
     }
   }

--- a/front/migrations/20250626_clean_workos_organizations.ts
+++ b/front/migrations/20250626_clean_workos_organizations.ts
@@ -1,64 +1,55 @@
-/* eslint-disable dust/no-raw-sql */
-
 import { stringify } from "csv-stringify/sync";
 import { format } from "date-fns";
-import { writeFileSync } from "fs";
-import { QueryTypes } from "sequelize";
+import { writeFileSync, readFileSync } from "fs";
+import { parse } from "csv-parse/sync";
+import { z } from "zod";
 
 import { getWorkOS } from "@app/lib/api/workos/client";
-import { frontSequelize } from "@app/lib/resources/storage";
 import { concurrentExecutor } from "@app/lib/utils/async_utils";
 import { makeScript } from "@app/scripts/helpers";
 
+const csvSchema = z.array(
+  z.object({
+    sId: z.string(),
+    name: z.string(),
+    domain: z.string(),
+    workOSOrganizationId: z.string(),
+  })
+);
+
 makeScript(
   {
-    file: {
-      alias: "f",
+    input: {
+      alias: "i",
+      type: "string",
+      describe:
+        "List of workspaces to update. Columns must be sId, name, domain and workOSOrganizationId",
+    },
+    output: {
+      alias: "o",
+      type: "string",
       describe: "If provided, file to save the found domains to",
     },
   },
-  async ({ execute, file }, logger) => {
-    const domains = await frontSequelize.query<{
-      sId: string;
-      name: string;
-      domain: string;
-      workOSOrganizationId: string;
-    }>(
-      `
-SELECT DISTINCT
-  w."sId",
-  w.name,
-  ws.domain,
-  w."workOSOrganizationId"
-FROM
-  workspaces w
-  JOIN workspace_has_domains ws ON w."id" = ws."workspaceId"
-  LEFT JOIN subscriptions s ON w."id" = s."workspaceId"
-WHERE
-  ws."domainAutoJoinEnabled" = FALSE
-  AND w."workOSOrganizationId" IS NOT NULL
-  AND NOT EXISTS ( -- Ensure there are no active subscriptions
-    SELECT
-      1
-    FROM
-      "subscriptions" "s2"
-    WHERE
-      "s2"."workspaceId" = "w"."id"
-      AND "s2"."endDate" IS NULL
-  )
-  AND (
-    "s"."id" IS NULL -- Include workspaces with no subscriptions
-    OR "s"."endDate" < NOW() - INTERVAL '1 month' -- Or subscriptions that ended more than a month ago
-    OR (
-      "s"."endDate" IS NOT NULL
-      AND "s"."endDate" < NOW() - INTERVAL '1 month' -- Redundant check for clarity
-    )
-  );
-`,
-      { type: QueryTypes.SELECT }
-    );
+  async ({ execute, input, output }, logger) => {
+    if (!input) {
+      logger.error("Missing --input args");
+      return;
+    }
 
-    logger.info(`${domains.length} found`);
+    const inputContent = readFileSync(input, { encoding: "utf8" });
+    const parsedInput = parse(inputContent, {
+      columns: true,
+    });
+
+    const parseResult = csvSchema.safeParse(parsedInput);
+    if (!parseResult.success) {
+      logger.error({ error: parseResult.error }, "Wrong CSV format");
+      return;
+    }
+    const domains = parseResult.data;
+
+    logger.info(`${domains.length} in the given CSV`);
 
     const workOS = getWorkOS();
 
@@ -129,8 +120,8 @@ WHERE
       }
     );
 
-    if (file) {
-      writeFileSync(file, stringify(records));
+    if (output) {
+      writeFileSync(output, stringify(records));
       logger.info(`File saved`);
     }
   }

--- a/front/migrations/20250626_clean_workos_organizations.ts
+++ b/front/migrations/20250626_clean_workos_organizations.ts
@@ -31,14 +31,20 @@ SELECT
   ws.domain,
   w."workOSOrganizationId"
 FROM
-  workspace_has_domains ws,
-  workspaces w
-  LEFT OUTER JOIN subscriptions s ON s."workspaceId" = w.id
+  workspace_has_domains AS ws
+  INNER JOIN workspaces AS w ON w.id = ws."workspaceId"
 WHERE
-  w.id = ws."workspaceId"
-  AND ws."domainAutoJoinEnabled" = FALSE
-  AND s.id IS NULL
+  ws."domainAutoJoinEnabled" = FALSE
   AND w."workOSOrganizationId" IS NOT NULL
+  AND NOT EXISTS (
+    SELECT 1 
+    FROM subscriptions s 
+    WHERE s."workspaceId" = w.id 
+    AND (
+      s."endDate" IS NULL
+      OR s."endDate" > CURRENT_DATE - INTERVAL '1 month'
+    )
+  )
 `,
       { type: QueryTypes.SELECT }
     );

--- a/front/migrations/20250626_clean_workos_organizations.ts
+++ b/front/migrations/20250626_clean_workos_organizations.ts
@@ -1,7 +1,7 @@
+import { parse } from "csv-parse/sync";
 import { stringify } from "csv-stringify/sync";
 import { format } from "date-fns";
-import { writeFileSync, readFileSync } from "fs";
-import { parse } from "csv-parse/sync";
+import { readFileSync, writeFileSync } from "fs";
 import { z } from "zod";
 
 import { getWorkOS } from "@app/lib/api/workos/client";


### PR DESCRIPTION
## Description
- Per slack [thread](https://dust4ai.slack.com/archives/C050SM8NSPK/p1752586808792849)
Update the query that can clean WorkOS (and workspaces) attached domains. Before it was only checking for workspaces that didn't have any subscription, now we're checking for workspace that either:
- Don't have a subscription
- Have their subscription expired more than a month ago.
- We also removed the SQL query from the script, so we can be more precise in case we want to override it.

## Tests
- Ran the query on metabase
- Ran the following query. Goal was to select the latest query status and double check if they all appear as ended. Only 2 appeared as active even though their `endData` was correctly more than a month ago ( _So just an other issue to check on the side_).  The rest is correctly ended.
- All workspaces found have correctly their last subscription `endDate` more than a month ago
```sql
SELECT
  w."sId",
  w.name,
  ws.domain,
  w."workOSOrganizationId",
  latest_subscription.status AS latest_subscription_status,
  latest_subscription."endDate" AS latest_subscription_end
FROM
  workspace_has_domains AS ws
  INNER JOIN workspaces AS w ON w.id = ws."workspaceId"
-- Get the latest subscription for the workspaces
  LEFT JOIN (
    SELECT
      s."workspaceId",
      s.status,
      ROW_NUMBER() OVER (PARTITION BY s."workspaceId" ORDER BY s."startDate" DESC) AS rn,
	  s."endDate"
    FROM
      subscriptions s
    WHERE
      s."endDate" IS NOT NULL
  ) AS latest_subscription ON latest_subscription."workspaceId" = w.id AND latest_subscription.rn = 1
-- Same WHERE than the code query
WHERE
  ws."domainAutoJoinEnabled" = FALSE
  AND w."workOSOrganizationId" IS NOT NULL
  AND NOT EXISTS (
    SELECT 1 
    FROM subscriptions s 
    WHERE s."workspaceId" = w.id 
    AND (
      s."endDate" IS NULL
      OR s."endDate" > CURRENT_DATE - INTERVAL '1 month'
    )
  )
ORDER BY latest_subscription_end DESC
```

## Risk
- High: If request is wrong, worst is remove the domains for legit workspaces and messing up with their login flow.

## Deploy Plan
- Run on prodbox.
