### PR TITLE
[front] enh: display stream errors in orange

### DIFF
--- a/front/components/assistant/conversation/ErrorMessage.tsx
+++ b/front/components/assistant/conversation/ErrorMessage.tsx
@@ -23,7 +23,8 @@ export function ErrorMessage({ error, retryHandler }: ErrorMessageProps) {
 
   const errorIsRetryable =
     isAgentErrorCategory(error.metadata?.category) &&
-    error.metadata?.category === "retryable_model_error";
+    (error.metadata?.category === "retryable_model_error" ||
+      error.metadata?.category === "stream_error");
 
   const { submit: retry, isSubmitting: isRetrying } = useSubmitFunction(
     async () => retryHandler()


### PR DESCRIPTION
## Description

- This PR changes the error chip for stream errors (error streaming chunks) to show it in orange instead of red.

## Tests

## Risk

- Very low, very minor surface change.

## Deploy Plan

- Deploy front.
