### PR TITLE
feat(core): add debug logging to check_table command

### DIFF
--- a/core/bin/check_table.rs
+++ b/core/bin/check_table.rs
@@ -5,7 +5,7 @@ use dust::{
     project::Project,
     stores::{postgres, store},
 };
-use log::debug;
+use tracing::debug;
 
 #[derive(Parser)]
 #[command(
@@ -26,7 +26,8 @@ struct Args {
 
 #[tokio::main]
 async fn main() -> Result<()> {
-    env_logger::init();
+    tracing_subscriber::fmt::init();
+
     let args = Args::parse();
 
     let project = Project::new_from_id(args.project_id);
@@ -69,15 +70,25 @@ async fn main() -> Result<()> {
             println!("Remote database secret ID: {}", remote_database_secret_id);
 
             println!("\nInstantiating remote database connection...");
-            debug!("About to call get_remote_database with secret_id: {}", remote_database_secret_id);
+            debug!(
+                "About to call get_remote_database with secret_id: {}",
+                remote_database_secret_id
+            );
             let start_time = std::time::Instant::now();
             let remote_db = match get_remote_database(remote_database_secret_id).await {
                 Ok(db) => {
-                    debug!("Successfully created remote database connection in {:?}", start_time.elapsed());
+                    debug!(
+                        "Successfully created remote database connection in {:?}",
+                        start_time.elapsed()
+                    );
                     db
                 }
                 Err(e) => {
-                    debug!("Failed to create remote database connection after {:?}: {:?}", start_time.elapsed(), e);
+                    debug!(
+                        "Failed to create remote database connection after {:?}: {:?}",
+                        start_time.elapsed(),
+                        e
+                    );
                     return Err(e.into());
                 }
             };

--- a/core/src/databases/remote_databases/snowflake/api/auth.rs
+++ b/core/src/databases/remote_databases/snowflake/api/auth.rs
@@ -44,7 +44,7 @@ pub async fn login(
     let login_data = login_request_data(username, auth, config)?;
     debug!("Sending login request...");
     debug!("Query params: {:?}", queries);
-    
+
     let start_time = std::time::Instant::now();
     let response = match http
         .post(url)
@@ -53,17 +53,18 @@ pub async fn login(
             "data": login_data
         }))
         .send()
-        .await {
-            Ok(resp) => {
-                debug!("Got response after {:?}", start_time.elapsed());
-                resp
-            }
-            Err(e) => {
-                debug!("Request failed after {:?}: {:?}", start_time.elapsed(), e);
-                return Err(e.into());
-            }
-        };
-    
+        .await
+    {
+        Ok(resp) => {
+            debug!("Got response after {:?}", start_time.elapsed());
+            resp
+        }
+        Err(e) => {
+            debug!("Request failed after {:?}: {:?}", start_time.elapsed(), e);
+            return Err(e.into());
+        }
+    };
+
     let status = response.status();
     debug!("Response status: {}", status);
     let body = response.text().await?;

--- a/core/src/databases/remote_databases/snowflake/api/client.rs
+++ b/core/src/databases/remote_databases/snowflake/api/client.rs
@@ -43,12 +43,12 @@ impl SnowflakeClient {
             .gzip(true)
             .use_rustls_tls()
             .timeout(std::time::Duration::from_secs(60));
-        
+
         // Only enable verbose connection logging in debug mode
         if tracing::enabled!(tracing::Level::DEBUG) {
             builder = builder.connection_verbose(true);
         }
-        
+
         let client = builder.build()?;
         Ok(Self {
             http: client,
@@ -67,12 +67,12 @@ impl SnowflakeClient {
             .use_rustls_tls()
             .proxy(proxy)
             .timeout(std::time::Duration::from_secs(60));
-        
+
         // Only enable verbose connection logging in debug mode
         if tracing::enabled!(tracing::Level::DEBUG) {
             builder = builder.connection_verbose(true);
         }
-        
+
         let client = builder.build()?;
         Ok(Self {
             http: client,
@@ -85,7 +85,8 @@ impl SnowflakeClient {
     pub async fn create_session(&self) -> Result<SnowflakeSession> {
         debug!("SnowflakeClient::create_session() called");
         debug!("Attempting login for user: {}", self.username);
-        let session_token = match login(&self.http, &self.username, &self.auth, &self.config).await {
+        let session_token = match login(&self.http, &self.username, &self.auth, &self.config).await
+        {
             Ok(token) => {
                 debug!("Login successful, got session token");
                 token
@@ -95,7 +96,7 @@ impl SnowflakeClient {
                 return Err(e);
             }
         };
-        
+
         let session = SnowflakeSession {
             http: self.http.clone(),
             // Replace any `_` with `-` in the account name for nginx proxy.

--- a/core/src/databases/remote_databases/snowflake/snowflake.rs
+++ b/core/src/databases/remote_databases/snowflake/snowflake.rs
@@ -242,7 +242,7 @@ impl SnowflakeRemoteDatabase {
         debug!("  - account: {}", account);
         debug!("  - role: {}", role);
         debug!("  - warehouse: {}", warehouse);
-        
+
         let mut client = SnowflakeClient::new(
             &username,
             auth_method,
@@ -259,7 +259,7 @@ impl SnowflakeRemoteDatabase {
             debug!("Failed to create SnowflakeClient: {}", e);
             QueryDatabaseError::GenericError(anyhow!("Error creating Snowflake client: {}", e))
         })?;
-        
+
         debug!("SnowflakeClient created successfully");
 
         if let (Ok(proxy_host), Ok(proxy_port), Ok(proxy_user_name), Ok(proxy_user_password)) = (

--- a/core/src/databases/remote_databases/snowflake/snowflake.rs
+++ b/core/src/databases/remote_databases/snowflake/snowflake.rs
@@ -1,5 +1,5 @@
 use std::{collections::HashSet, env};
-use tracing::info;
+use tracing::{debug, info};
 
 use anyhow::{anyhow, Result};
 use async_trait::async_trait;
@@ -188,10 +188,14 @@ impl SnowflakeRemoteDatabase {
     pub fn new(
         credentials: serde_json::Map<String, serde_json::Value>,
     ) -> Result<Self, QueryDatabaseError> {
+        debug!("SnowflakeRemoteDatabase::new() called");
+        debug!("Deserializing credentials...");
         let connection_details: SnowflakeConnectionDetails =
             serde_json::from_value(serde_json::Value::Object(credentials)).map_err(|e| {
+                debug!("Failed to deserialize credentials: {}", e);
                 QueryDatabaseError::GenericError(anyhow!("Error deserializing credentials: {}", e))
             })?;
+        debug!("Successfully deserialized credentials");
 
         let (username, auth_method, account, role, warehouse) = match &connection_details {
             SnowflakeConnectionDetails::Password {
@@ -233,6 +237,12 @@ impl SnowflakeRemoteDatabase {
             }
         };
 
+        debug!("Creating SnowflakeClient with:");
+        debug!("  - username: {}", username);
+        debug!("  - account: {}", account);
+        debug!("  - role: {}", role);
+        debug!("  - warehouse: {}", warehouse);
+        
         let mut client = SnowflakeClient::new(
             &username,
             auth_method,
@@ -246,8 +256,11 @@ impl SnowflakeRemoteDatabase {
             },
         )
         .map_err(|e| {
+            debug!("Failed to create SnowflakeClient: {}", e);
             QueryDatabaseError::GenericError(anyhow!("Error creating Snowflake client: {}", e))
         })?;
+        
+        debug!("SnowflakeClient created successfully");
 
         if let (Ok(proxy_host), Ok(proxy_port), Ok(proxy_user_name), Ok(proxy_user_password)) = (
             env::var("PROXY_HOST"),
@@ -270,6 +283,7 @@ impl SnowflakeRemoteDatabase {
                 })?;
         }
 
+        debug!("SnowflakeRemoteDatabase created successfully");
         Ok(Self { client, warehouse })
     }
 


### PR DESCRIPTION
## Description

- Add comprehensive debug logging throughout Snowflake connection flow
- Replace eprintln\! with proper log::debug\!/tracing::debug\! macros
- Only enable verbose HTTP logging when RUST_LOG=debug is set
- Add timing information for connection and authentication steps
- Initialize env_logger in check_table binary

This helps diagnose Snowflake connectivity issues by providing detailed logs only when explicitly requested via RUST_LOG=debug.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
