### PR TITLE
[extension] Improve design for known agent errors

### DIFF
--- a/extension/ui/components/conversation/AgentMessage.tsx
+++ b/extension/ui/components/conversation/AgentMessage.tsx
@@ -526,6 +526,7 @@ export function AgentMessage({
             agentMessage.error || {
               message: "Unexpected Error",
               code: "unexpected_error",
+              metadata: {},
             }
           }
           retryHandler={async () => retryHandler(agentMessage)}
@@ -631,11 +632,15 @@ function ErrorMessage({
   error,
   retryHandler,
 }: {
-  error: { code: string; message: string };
+  error: NonNullable<AgentMessagePublicType["error"]>;
   retryHandler: () => void;
 }) {
   const fullMessage =
     "ERROR: " + error.message + (error.code ? ` (code: ${error.code})` : "");
+
+  const errorIsRetryable =
+    error.metadata?.category === "retryable_model_error" ||
+    error.metadata?.category === "stream_error";
 
   const { submit: retry, isSubmitting: isRetrying } = useSubmitFunction(
     async () => retryHandler()
@@ -645,7 +650,7 @@ function ErrorMessage({
     <div className="flex flex-col gap-9">
       <div className="flex flex-col gap-1 sm:flex-row">
         <Chip
-          color="warning"
+          color={errorIsRetryable ? "golden" : "warning"}
           label={"ERROR: " + shortText(error.message)}
           size="xs"
         />

--- a/extension/ui/components/conversation/AgentMessage.tsx
+++ b/extension/ui/components/conversation/AgentMessage.tsx
@@ -659,7 +659,7 @@ function ErrorMessage({
       icon={InformationCircleIcon}
     >
       <div className="whitespace-normal break-words">{error.message}</div>
-      <div className="flex flex-col gap-2 pt-3 sm:flex-row">
+      <div className="flex flex-row gap-2 pt-3">
         <Button
           variant="outline"
           size="xs"

--- a/extension/ui/components/conversation/AgentMessage.tsx
+++ b/extension/ui/components/conversation/AgentMessage.tsx
@@ -54,6 +54,7 @@ import {
   DocumentPileIcon,
   DocumentTextIcon,
   EyeIcon,
+  InformationCircleIcon,
   Markdown,
   Page,
   Popover,
@@ -635,38 +636,52 @@ function ErrorMessage({
   error: NonNullable<AgentMessagePublicType["error"]>;
   retryHandler: () => void;
 }) {
-  const fullMessage =
-    "ERROR: " + error.message + (error.code ? ` (code: ${error.code})` : "");
-
   const errorIsRetryable =
     error.metadata?.category === "retryable_model_error" ||
     error.metadata?.category === "stream_error";
+
+  const debugInfo = [
+    error.metadata?.category ? `category: ${error.metadata?.category}` : "",
+    error.code ? `code: ${error.code}` : "",
+  ]
+    .filter((s) => s.length > 0)
+    .join(", ");
 
   const { submit: retry, isSubmitting: isRetrying } = useSubmitFunction(
     async () => retryHandler()
   );
 
   return (
-    <div className="flex flex-col gap-9">
-      <div className="flex flex-col gap-1 sm:flex-row">
-        <Chip
-          color={errorIsRetryable ? "golden" : "warning"}
-          label={"ERROR: " + shortText(error.message)}
+    <ContentMessage
+      title={`${error.metadata?.errorTitle || "Agent error"}`}
+      variant={errorIsRetryable ? "golden" : "warning"}
+      className="flex flex-col gap-3"
+      icon={InformationCircleIcon}
+    >
+      <div className="whitespace-normal break-words">{error.message}</div>
+      <div className="flex flex-col gap-2 pt-3 sm:flex-row">
+        <Button
+          variant="outline"
           size="xs"
+          icon={ArrowPathIcon}
+          label="Retry"
+          onClick={retry}
+          disabled={isRetrying}
         />
         <Popover
+          popoverTriggerAsChild
           trigger={
             <Button
-              variant="ghost"
+              variant="outline"
               size="xs"
               icon={EyeIcon}
-              label="See the error"
+              label="Details"
             />
           }
           content={
             <div className="flex flex-col gap-3">
-              <div className="text-sm font-normal text-warning-800">
-                {fullMessage}
+              <div className="whitespace-normal text-sm font-normal text-warning">
+                {debugInfo}
               </div>
               <div className="self-end">
                 <Button
@@ -675,7 +690,9 @@ function ErrorMessage({
                   icon={DocumentPileIcon}
                   label={"Copy"}
                   onClick={() =>
-                    void navigator.clipboard.writeText(fullMessage)
+                    void navigator.clipboard.writeText(
+                      error.message + (debugInfo ? ` (${debugInfo})` : "")
+                    )
                   }
                 />
               </div>
@@ -683,20 +700,6 @@ function ErrorMessage({
           }
         />
       </div>
-      <div>
-        <Button
-          variant="ghost"
-          size="sm"
-          icon={ArrowPathIcon}
-          label="Retry"
-          onClick={retry}
-          disabled={isRetrying}
-        />
-      </div>
-    </div>
+    </ContentMessage>
   );
-}
-
-function shortText(text: string, maxLength = 30) {
-  return text.length > maxLength ? text.substring(0, maxLength) + "..." : text;
 }

--- a/front/lib/actions/mcp.ts
+++ b/front/lib/actions/mcp.ts
@@ -215,6 +215,7 @@ type MCPErrorEvent = {
   error: {
     code: string;
     message: string;
+    // TODO(2025-07-22 aubin): make this non nullable (we can always pass an empty object).
     metadata: Record<string, string | number | boolean> | null;
   };
 };

--- a/sdks/js/src/types.ts
+++ b/sdks/js/src/types.ts
@@ -1087,6 +1087,7 @@ const AgentErrorEventSchema = z.object({
   error: z.object({
     code: z.string(),
     message: z.string(),
+    metadata: z.record(z.any()).optional(),
   }),
 });
 export type AgentErrorEvent = z.infer<typeof AgentErrorEventSchema>;

--- a/sdks/js/src/types.ts
+++ b/sdks/js/src/types.ts
@@ -909,7 +909,7 @@ const AgentMessageTypeSchema = z.object({
     .object({
       code: z.string(),
       message: z.string(),
-      metadata: z.record(z.any()).optional(),
+      metadata: z.record(z.any()).nullable(),
     })
     .nullable(),
 });
@@ -1088,7 +1088,7 @@ const AgentErrorEventSchema = z.object({
   error: z.object({
     code: z.string(),
     message: z.string(),
-    metadata: z.record(z.any()).optional(),
+    metadata: z.record(z.any()).nullable(),
   }),
 });
 export type AgentErrorEvent = z.infer<typeof AgentErrorEventSchema>;

--- a/sdks/js/src/types.ts
+++ b/sdks/js/src/types.ts
@@ -915,7 +915,7 @@ const AgentMessageTypeSchema = z.object({
 });
 export type AgentMessagePublicType = z.infer<typeof AgentMessageTypeSchema>;
 
-const AgentMesssageFeedbackSchema = z.object({
+const AgentMessageFeedbackSchema = z.object({
   messageId: z.string(),
   agentMessageId: z.number(),
   userId: z.number(),
@@ -1612,7 +1612,7 @@ export type CreateConversationResponseType = z.infer<
 >;
 
 export const GetFeedbacksResponseSchema = z.object({
-  feedbacks: z.array(AgentMesssageFeedbackSchema),
+  feedbacks: z.array(AgentMessageFeedbackSchema),
 });
 
 export type GetFeedbacksResponseType = z.infer<

--- a/sdks/js/src/types.ts
+++ b/sdks/js/src/types.ts
@@ -909,6 +909,7 @@ const AgentMessageTypeSchema = z.object({
     .object({
       code: z.string(),
       message: z.string(),
+      metadata: z.record(z.any()).optional(),
     })
     .nullable(),
 });


### PR DESCRIPTION
## Description

- Follow up on https://github.com/dust-tt/dust/pull/14418, it's the same but in the extension.
- This PR updates the display of certain known retryable errors to show them in a golden color instead of red.

<img width="394" height="240" alt="Screenshot 2025-07-22 at 3 07 57 PM" src="https://github.com/user-attachments/assets/57ad77dc-5d25-4a00-bfc4-fe141673dac4" />

## Tests

- Tested locally (sent errors in `streaming.rs` to simulate an Anthropic outage).

## Risk

- Low, only UI changes.

## Deploy Plan

- Publish new version of the extension.
