### PR TITLE
Don't serialize Row::is_delete

### DIFF
--- a/core/src/databases/table.rs
+++ b/core/src/databases/table.rs
@@ -971,7 +971,8 @@ pub struct Row {
     // To keep track of pending delete actions, we use a special marker row.
     // This allows us to keep all the row data in the same format, which keeps the
     // implementation simpler.
-    #[serde(default)]
+    // Note that this is internal state, and it is not serialized
+    #[serde(skip_serializing, default)]
     pub is_delete: bool,
 }
 


### PR DESCRIPTION
## Description

In addition to having its default state, we can simply mark it as `skip_serializing` to prevent it from making it out of any API.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
