### PR TITLE
[front] fix(agent_router): prevent showing tools twice

### DIFF
--- a/front/lib/actions/constants.ts
+++ b/front/lib/actions/constants.ts
@@ -17,6 +17,10 @@ export const DEFAULT_WEBSEARCH_ACTION_NAME = "web_search_&_browse";
 export const DEFAULT_WEBSEARCH_ACTION_DESCRIPTION =
   "Agent can search (Google) and retrieve information from specific websites.";
 
+export const DEFAULT_AGENT_ROUTER_ACTION_NAME = "agent_router";
+export const DEFAULT_AGENT_ROUTER_ACTION_DESCRIPTION =
+  "Tools with access to the published agents of the workspace.";
+
 // TODO(durable-agents): remove this (only used in the non-MCP variant, inlined in the MCP tool definition).
 export const DEFAULT_SEARCH_LABELS_ACTION_NAME = "search_labels";
 

--- a/front/lib/actions/constants.ts
+++ b/front/lib/actions/constants.ts
@@ -21,9 +21,6 @@ export const DEFAULT_AGENT_ROUTER_ACTION_NAME = "agent_router";
 export const DEFAULT_AGENT_ROUTER_ACTION_DESCRIPTION =
   "Tools with access to the published agents of the workspace.";
 
-// TODO(durable-agents): remove this (only used in the non-MCP variant, inlined in the MCP tool definition).
-export const DEFAULT_SEARCH_LABELS_ACTION_NAME = "search_labels";
-
 export const DEFAULT_CONVERSATION_LIST_FILES_ACTION_NAME = "list_files";
 
 export const DEFAULT_CONVERSATION_INCLUDE_FILE_ACTION_NAME = "include_file";

--- a/front/lib/actions/mcp_internal_actions/servers/agent_router.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/agent_router.ts
@@ -26,7 +26,7 @@ const serverInfo: InternalMCPServerDefinitionType = {
 };
 
 const MAX_INSTRUCTIONS_LENGTH = 1000;
-const LIST_AGENTS_TOOL_NAME = "list_all_published_agents";
+const LIST_ALL_AGENTS_TOOL_NAME = "list_all_published_agents";
 export const SUGGEST_AGENTS_TOOL_NAME = "suggest_agents_for_content";
 
 const SERVER_INSTRUCTIONS = `These tools provide discoverability to published agents available in the workspace.
@@ -39,7 +39,7 @@ const createServer = (auth: Authenticator): McpServer => {
   });
 
   server.tool(
-    LIST_AGENTS_TOOL_NAME,
+    LIST_ALL_AGENTS_TOOL_NAME,
     "Returns a complete list of all published agents in the workspace.",
     {},
     async () => {

--- a/front/lib/actions/mcp_internal_actions/servers/agent_router.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/agent_router.ts
@@ -26,6 +26,7 @@ const serverInfo: InternalMCPServerDefinitionType = {
 };
 
 const MAX_INSTRUCTIONS_LENGTH = 1000;
+const LIST_AGENTS_TOOL_NAME = "list_all_published_agents";
 export const SUGGEST_AGENTS_TOOL_NAME = "suggest_agents_for_content";
 
 const SERVER_INSTRUCTIONS = `These tools provide discoverability to published agents available in the workspace.
@@ -38,7 +39,7 @@ const createServer = (auth: Authenticator): McpServer => {
   });
 
   server.tool(
-    "list_all_published_agents",
+    LIST_AGENTS_TOOL_NAME,
     "Returns a complete list of all published agents in the workspace.",
     {},
     async () => {
@@ -95,7 +96,7 @@ const createServer = (auth: Authenticator): McpServer => {
   );
 
   server.tool(
-    "suggest_agents_for_content",
+    SUGGEST_AGENTS_TOOL_NAME,
     "Analyzes a user query and returns relevant specialized agents that might be better " +
       "suited to handling specific requests. The tool uses semantic matching to find agents " +
       "whose capabilities align with the query content.",

--- a/front/lib/actions/mcp_internal_actions/servers/agent_router.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/agent_router.ts
@@ -96,7 +96,9 @@ const createServer = (auth: Authenticator): McpServer => {
 
   server.tool(
     "suggest_agents_for_content",
-    "Analyzes a user query and returns relevant specialized agents that might be better suited to handle specific requests. The tool uses semantic matching to find agents whose capabilities align with the query content.",
+    "Analyzes a user query and returns relevant specialized agents that might be better " +
+      "suited to handling specific requests. The tool uses semantic matching to find agents " +
+      "whose capabilities align with the query content.",
     {
       userMessage: z.string().describe("The user's message."),
       conversationId: z.string().describe("The conversation id."),

--- a/front/lib/actions/mcp_internal_actions/servers/agent_router.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/agent_router.ts
@@ -2,6 +2,10 @@ import { DustAPI } from "@dust-tt/client";
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod";
 
+import {
+  DEFAULT_AGENT_ROUTER_ACTION_DESCRIPTION,
+  DEFAULT_AGENT_ROUTER_ACTION_NAME,
+} from "@app/lib/actions/constants";
 import { makeMCPToolTextError } from "@app/lib/actions/mcp_internal_actions/utils";
 import { getSuggestedAgentsForContent } from "@app/lib/api/assistant/agent_suggestion";
 import apiConfig from "@app/lib/api/config";
@@ -13,16 +17,15 @@ import type { LightAgentConfigurationType } from "@app/types";
 import { getHeaderFromGroupIds, getHeaderFromRole } from "@app/types/groups";
 
 const serverInfo: InternalMCPServerDefinitionType = {
-  name: "agent_router",
+  name: DEFAULT_AGENT_ROUTER_ACTION_NAME,
   version: "1.0.0",
-  description: "Tools with access to the published agents of the workspace.",
+  description: DEFAULT_AGENT_ROUTER_ACTION_DESCRIPTION,
   icon: "ActionRobotIcon",
   authorization: null,
   documentationUrl: null,
 };
 
 const MAX_INSTRUCTIONS_LENGTH = 1000;
-export const LIST_ALL_AGENTS_TOOL_NAME = "list_all_published_agents";
 export const SUGGEST_AGENTS_TOOL_NAME = "suggest_agents_for_content";
 
 const SERVER_INSTRUCTIONS = `These tools provide discoverability to published agents available in the workspace.
@@ -35,7 +38,7 @@ const createServer = (auth: Authenticator): McpServer => {
   });
 
   server.tool(
-    LIST_ALL_AGENTS_TOOL_NAME,
+    "list_all_published_agents",
     "Returns a complete list of all published agents in the workspace.",
     {},
     async () => {
@@ -92,7 +95,7 @@ const createServer = (auth: Authenticator): McpServer => {
   );
 
   server.tool(
-    SUGGEST_AGENTS_TOOL_NAME,
+    "suggest_agents_for_content",
     "Analyzes a user query and returns relevant specialized agents that might be better suited to handle specific requests. The tool uses semantic matching to find agents whose capabilities align with the query content.",
     {
       userMessage: z.string().describe("The user's message."),

--- a/front/lib/api/assistant/global_agents.ts
+++ b/front/lib/api/assistant/global_agents.ts
@@ -3,6 +3,8 @@ import path from "path";
 import { promisify } from "util";
 
 import {
+  DEFAULT_AGENT_ROUTER_ACTION_DESCRIPTION,
+  DEFAULT_AGENT_ROUTER_ACTION_NAME,
   DEFAULT_WEBSEARCH_ACTION_DESCRIPTION,
   DEFAULT_WEBSEARCH_ACTION_NAME,
 } from "@app/lib/actions/constants";
@@ -10,12 +12,10 @@ import type {
   MCPServerConfigurationType,
   ServerSideMCPServerConfigurationType,
 } from "@app/lib/actions/mcp";
+import { TOOL_NAME_SEPARATOR } from "@app/lib/actions/mcp_actions";
 import { internalMCPServerNameToSId } from "@app/lib/actions/mcp_helper";
 import type { InternalMCPServerNameType } from "@app/lib/actions/mcp_internal_actions/constants";
-import {
-  LIST_ALL_AGENTS_TOOL_NAME,
-  SUGGEST_AGENTS_TOOL_NAME,
-} from "@app/lib/actions/mcp_internal_actions/servers/agent_router";
+import { SUGGEST_AGENTS_TOOL_NAME } from "@app/lib/actions/mcp_internal_actions/servers/agent_router";
 import { getFavoriteStates } from "@app/lib/api/assistant/get_favorite_states";
 import { getGlobalAgentMetadata } from "@app/lib/api/assistant/global_agent_metadata";
 import config from "@app/lib/api/config";
@@ -181,27 +181,10 @@ function _getAgentRouterToolsConfiguration(
   return [
     {
       id: -1,
-      sId: agentId + "-agent-router-list-action",
+      sId: agentId + "-agent-router",
       type: "mcp_server_configuration",
-      name: LIST_ALL_AGENTS_TOOL_NAME,
-      description: "List the published agents of the workspace.",
-      mcpServerViewId: mcpServerView.sId,
-      internalMCPServerId,
-      dataSources: null,
-      tables: null,
-      childAgentId: null,
-      reasoningModel: null,
-      additionalConfiguration: {},
-      timeFrame: null,
-      dustAppConfiguration: null,
-      jsonSchema: null,
-    },
-    {
-      id: -1,
-      sId: agentId + "-agent-router-suggest-agents",
-      type: "mcp_server_configuration",
-      name: SUGGEST_AGENTS_TOOL_NAME,
-      description: "Suggest agents based on the user's query.",
+      name: DEFAULT_AGENT_ROUTER_ACTION_NAME satisfies InternalMCPServerNameType,
+      description: DEFAULT_AGENT_ROUTER_ACTION_DESCRIPTION,
       mcpServerViewId: mcpServerView.sId,
       internalMCPServerId,
       dataSources: null,
@@ -1611,7 +1594,8 @@ The agent should not provide additional information or content that the user did
    in which case it is better to search only on the specific data source.
    It's important to not pick a restrictive timeframe unless it's explicitly requested or obviously needed.
    If no relevant information is found but the user's question seems to be internal to the company,
-   the agent should use the ${SUGGEST_AGENTS_TOOL_NAME} tool to suggest an agent that might be able to handle the request.
+   the agent should use the ${DEFAULT_AGENT_ROUTER_ACTION_NAME}${TOOL_NAME_SEPARATOR}${SUGGEST_AGENTS_TOOL_NAME}
+   tool to suggest an agent that might be able to handle the request.
 
 2. If the user's question requires information that is recent and likely to be found on the public 
    internet, the agent should use the internet to answer the question.


### PR DESCRIPTION
## Description

- The `dust` and `helper` global agents currently have the agent router tools shown to them twice (example log [here](https://dust.tt/w/78bda07b39/spaces/vlt_rICtlrSEpWqX/apps/0e9889c787/runs/4a923a0ef537f3ed4dfce2d35fa623295425e4fb41cf596b099187a5bb1ce237)).
- We end up showing 4 tools with incorrect names:
  - `list_all_published_agents__list_all_published_agents`
  - `list_all_published_agents__suggest_agents_for_content`
  - `suggest_agents_for_content__list_all_published_agents`
  - `suggest_agents_for_content__suggest_agents_for_content`
- This PR fixes that.

## Tests

- Tested locally, we now show only 2 tools `agent_router__suggest_agents_for_content`, `agent_router__list_all_published_agents`.

<img width="599" height="140" alt="Screenshot 2025-07-17 at 3 22 08 PM" src="https://github.com/user-attachments/assets/95627d9f-ceb7-4bee-9697-631883ed0fcd" />

## Risk

- Low.

## Deploy Plan

- Deploy front.
