### PR TITLE
Turn SAVE_TABLES_TO_GCS back on and fix a few things

### DIFF
--- a/core/src/databases/table.rs
+++ b/core/src/databases/table.rs
@@ -852,7 +852,7 @@ impl LocalTable {
                     tracing::error!("delete_row: failed to schedule background work: {:?}", e);
                 }
             } else {
-                info!("upsert_rows_to_gcs_or_queue_work: table not migrated to CSV, skipping GCS upsert for non-truncate");
+                info!("delete_row: table not migrated to CSV, skipping GCS delete non-truncate");
             }
             Ok(())
         } else {

--- a/core/src/databases/table_upserts_background_worker.rs
+++ b/core/src/databases/table_upserts_background_worker.rs
@@ -93,10 +93,12 @@ impl TableUpsertsBackgroundWorker {
             "TableUpsertsBackgroundWorker: Processing upserts"
         );
 
-        let local_table = LocalTable::from_table(table.clone())?;
-        local_table
-            .upsert_rows_gcs(&self.store, &self.gcs_db_store, rows, false)
-            .await?;
+        if !rows.is_empty() {
+            let local_table = LocalTable::from_table(table.clone())?;
+            local_table
+                .upsert_rows_gcs(&self.store, &self.gcs_db_store, rows, false)
+                .await?;
+        }
 
         let _: () = self
             .redis_conn

--- a/core/src/databases_store/store.rs
+++ b/core/src/databases_store/store.rs
@@ -6,7 +6,7 @@ use crate::databases::table_schema::TableSchema;
 
 // These flags are transitional while we migrate to GCS. Eventually, we will only use GCS.
 pub const SAVE_TABLES_TO_POSTGRES: bool = true;
-pub const SAVE_TABLES_TO_GCS: bool = false;
+pub const SAVE_TABLES_TO_GCS: bool = true;
 
 #[async_trait]
 pub trait DatabasesStore {


### PR DESCRIPTION
## Description

This addresses a few issues:
1. Delete operations on an unmigrated table were triggering errors. It wasn't doing anything bad, except logging errors which had caused us to turn off the feature.
1. The locks were not released right away if an error occurred while holding them. So they would wait for the lock timeout, causing long delays.
1. In the background loop, if an error occurred while processing one table, we'd also give up on the other ones. They would be retried later, but there is no reason to halt the whole processing.

## Tests

Lots of manual testing by sending requests via postman.

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
