### PR TITLE
[front] Fix AB v2 preview re-rendering and refactor the logic 

### DIFF
--- a/front/components/agent_builder/AgentBuilderPreview.tsx
+++ b/front/components/agent_builder/AgentBuilderPreview.tsx
@@ -1,12 +1,10 @@
 import { Spinner } from "@dust-tt/sparkle";
 import React from "react";
-import { useWatch } from "react-hook-form";
 
 import { useAgentBuilderContext } from "@app/components/agent_builder/AgentBuilderContext";
-import type { AgentBuilderFormData } from "@app/components/agent_builder/AgentBuilderFormContext";
 import {
-  usePreviewAgent,
-  useTryAgentCore,
+  useDraftAgent,
+  usePreview,
 } from "@app/components/agent_builder/hooks/useAgentPreview";
 import { ActionValidationProvider } from "@app/components/assistant/conversation/ActionValidationProvider";
 import ConversationViewer from "@app/components/assistant/conversation/ConversationViewer";
@@ -55,13 +53,17 @@ export function AgentBuilderPreview() {
 
   const {
     draftAgent,
+    getDraftAgent,
     isSavingDraftAgent,
     draftCreationFailed,
     stickyMentions,
     setStickyMentions,
-    conversation,
-    handleSubmit,
-  } = usePreviewAgent();
+  } = useDraftAgent();
+
+  const { conversation, handleSubmit } = usePreview({
+    draftAgent,
+    getDraftAgent,
+  });
 
   const renderContent = () => {
     if (!draftAgent) {

--- a/front/components/agent_builder/AgentBuilderPreview.tsx
+++ b/front/components/agent_builder/AgentBuilderPreview.tsx
@@ -1,5 +1,6 @@
 import { Spinner } from "@dust-tt/sparkle";
 import React from "react";
+import { useFormContext } from "react-hook-form";
 
 import { useAgentBuilderContext } from "@app/components/agent_builder/AgentBuilderContext";
 import {
@@ -12,6 +13,8 @@ import { GenerationContextProvider } from "@app/components/assistant/conversatio
 import { AssistantInputBar } from "@app/components/assistant/conversation/input_bar/InputBar";
 import { useMCPServerViewsContext } from "@app/components/assistant_builder/contexts/MCPServerViewsContext";
 import { useUser } from "@app/lib/swr/user";
+
+import type { AgentBuilderFormData } from "./AgentBuilderFormContext";
 
 interface EmptyStateProps {
   message: string;
@@ -49,7 +52,11 @@ function LoadingState({ message }: LoadingStateProps) {
 export function AgentBuilderPreview() {
   const { owner } = useAgentBuilderContext();
   const { user } = useUser();
+  const { getValues } = useFormContext<AgentBuilderFormData>();
   const { isMCPServerViewsLoading } = useMCPServerViewsContext();
+
+  const hasContent =
+    !!getValues("instructions").trim() || getValues("actions").length > 0;
 
   const {
     draftAgent,
@@ -71,6 +78,15 @@ export function AgentBuilderPreview() {
     !draftAgent && (isMCPServerViewsLoading || isSavingDraftAgent);
 
   const renderContent = () => {
+    if (!hasContent) {
+      return (
+        <EmptyState
+          message="Ready to test your agent?"
+          description="Add some instructions or actions to your agent to start testing it here."
+        />
+      );
+    }
+
     if (draftCreationFailed) {
       return (
         <EmptyState
@@ -82,15 +98,6 @@ export function AgentBuilderPreview() {
 
     if (showLoader) {
       return <LoadingState message="Preparing your agent..." />;
-    }
-
-    if (!draftAgent) {
-      return (
-        <EmptyState
-          message="Ready to test your agent?"
-          description="Add some instructions or actions to your agent to start testing it here."
-        />
-      );
     }
 
     return (

--- a/front/components/agent_builder/AgentBuilderPreview.tsx
+++ b/front/components/agent_builder/AgentBuilderPreview.tsx
@@ -53,45 +53,24 @@ export function AgentBuilderPreview() {
   const { user } = useUser();
   const { isMCPServerViewsLoading } = useMCPServerViewsContext();
 
-  const instructions = useWatch<AgentBuilderFormData, "instructions">({
-    name: "instructions",
-  });
-  const name = useWatch<AgentBuilderFormData, "agentSettings.name">({
-    name: "agentSettings.name",
-  });
-
   const {
     draftAgent,
     isSavingDraftAgent,
     draftCreationFailed,
-    createDraftAgent,
+    stickyMentions,
+    setStickyMentions,
+    conversation,
+    handleSubmit,
   } = usePreviewAgent();
-  const { conversation, stickyMentions, setStickyMentions, handleSubmit } =
-    useTryAgentCore({
-      owner,
-      user,
-      agent: draftAgent,
-      createDraftAgent,
-    });
-
-  const hasContent = instructions.trim();
 
   const renderContent = () => {
-    if (!hasContent || !name) {
+    if (!draftAgent) {
       return (
         <EmptyState
           message="Ready to test your agent?"
           description="Add some instructions or actions to your agent to start testing it here."
         />
       );
-    }
-
-    if (
-      isMCPServerViewsLoading ||
-      isSavingDraftAgent ||
-      (!draftAgent && !draftCreationFailed)
-    ) {
-      return <LoadingState message="Preparing your agent..." />;
     }
 
     if (!draftAgent && draftCreationFailed) {
@@ -101,6 +80,10 @@ export function AgentBuilderPreview() {
           description="There was an issue creating a preview of your agent. Try making a small change to refresh."
         />
       );
+    }
+
+    if (!draftAgent && (isMCPServerViewsLoading || isSavingDraftAgent)) {
+      return <LoadingState message="Preparing your agent..." />;
     }
 
     return (

--- a/front/components/agent_builder/AgentBuilderPreview.tsx
+++ b/front/components/agent_builder/AgentBuilderPreview.tsx
@@ -4,7 +4,7 @@ import React from "react";
 import { useAgentBuilderContext } from "@app/components/agent_builder/AgentBuilderContext";
 import {
   useDraftAgent,
-  usePreview,
+  useDraftConversation,
 } from "@app/components/agent_builder/hooks/useAgentPreview";
 import { ActionValidationProvider } from "@app/components/assistant/conversation/ActionValidationProvider";
 import ConversationViewer from "@app/components/assistant/conversation/ConversationViewer";
@@ -60,7 +60,7 @@ export function AgentBuilderPreview() {
     setStickyMentions,
   } = useDraftAgent();
 
-  const { conversation, handleSubmit } = usePreview({
+  const { conversation, handleSubmit } = useDraftConversation({
     draftAgent,
     getDraftAgent,
   });

--- a/front/components/agent_builder/AgentBuilderPreview.tsx
+++ b/front/components/agent_builder/AgentBuilderPreview.tsx
@@ -65,17 +65,13 @@ export function AgentBuilderPreview() {
     getDraftAgent,
   });
 
-  const renderContent = () => {
-    if (!draftAgent) {
-      return (
-        <EmptyState
-          message="Ready to test your agent?"
-          description="Add some instructions or actions to your agent to start testing it here."
-        />
-      );
-    }
+  // Show loading spinner only when the first time we create a draft agent. After that the spinner is shown
+  // inside the button in the input bar. This way we don't have to unmount the conversation viewer every time.
+  const showLoader =
+    !draftAgent && (isMCPServerViewsLoading || isSavingDraftAgent);
 
-    if (!draftAgent && draftCreationFailed) {
+  const renderContent = () => {
+    if (draftCreationFailed) {
       return (
         <EmptyState
           message="Unable to create preview"
@@ -84,8 +80,17 @@ export function AgentBuilderPreview() {
       );
     }
 
-    if (!draftAgent && (isMCPServerViewsLoading || isSavingDraftAgent)) {
+    if (showLoader) {
       return <LoadingState message="Preparing your agent..." />;
+    }
+
+    if (!draftAgent) {
+      return (
+        <EmptyState
+          message="Ready to test your agent?"
+          description="Add some instructions or actions to your agent to start testing it here."
+        />
+      );
     }
 
     return (

--- a/front/components/agent_builder/SpacesContext.tsx
+++ b/front/components/agent_builder/SpacesContext.tsx
@@ -1,7 +1,7 @@
-import { useSendNotification } from "@dust-tt/sparkle";
 import type { ReactNode } from "react";
 import React, { createContext, useContext, useEffect, useMemo } from "react";
 
+import { useSendNotification } from "@app/hooks/useNotification";
 import { useSpaces } from "@app/lib/swr/spaces";
 import type { LightWorkspaceType, SpaceType } from "@app/types";
 

--- a/front/components/agent_builder/hooks/useAgentPreview.ts
+++ b/front/components/agent_builder/hooks/useAgentPreview.ts
@@ -1,5 +1,5 @@
 import { debounce, isEqual } from "lodash";
-import { useCallback, useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useFormContext, useWatch } from "react-hook-form";
 
 import { useAgentBuilderContext } from "@app/components/agent_builder/AgentBuilderContext";
@@ -89,13 +89,12 @@ export function useDraftAgent() {
       getValues,
     ]);
 
-  const debouncedCreateDraftAgent = useCallback(
-    debounce(() => {
-      void createDraftAgent();
-    }, 500),
-    []
-  );
-
+const debouncedCreateDraftAgent = useMemo(
+  () => debounce(() => {
+    void createDraftAgent();
+  }, 500),
+  [createDraftAgent]
+);
   const getDraftAgent =
     useCallback(async (): Promise<LightAgentConfigurationType | null> => {
       const formData = getValues();

--- a/front/components/agent_builder/hooks/useAgentPreview.ts
+++ b/front/components/agent_builder/hooks/useAgentPreview.ts
@@ -120,7 +120,7 @@ export function useDraftAgent() {
       return;
     }
 
-    // Create the first version here, after that we will update the draft agent on form submission.
+    // Create the first version here, after that we will update the draft agent on form submission or name changes.
     if (!draftAgent) {
       const hasContent =
         (formData.actions && formData.actions.length > 0) ||

--- a/front/components/agent_builder/hooks/useAgentPreview.ts
+++ b/front/components/agent_builder/hooks/useAgentPreview.ts
@@ -163,7 +163,7 @@ export function useDraftAgent() {
   };
 }
 
-export function usePreview({
+export function useDraftConversation({
   draftAgent,
   getDraftAgent,
 }: {

--- a/front/components/agent_builder/hooks/useAgentPreview.ts
+++ b/front/components/agent_builder/hooks/useAgentPreview.ts
@@ -1,5 +1,5 @@
-import { debounce, isEqual } from "lodash";
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { isEqual } from "lodash";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { useFormContext, useWatch } from "react-hook-form";
 
 import { useAgentBuilderContext } from "@app/components/agent_builder/AgentBuilderContext";
@@ -73,7 +73,7 @@ export function useDraftAgent() {
 
   useEffect(() => {
     setDebouncedAgentName(agentName);
-  }, [agentName, setDebouncedAgentName])
+  }, [agentName, setDebouncedAgentName]);
 
   const createDraftAgent =
     useCallback(async (): Promise<LightAgentConfigurationType | null> => {

--- a/front/components/agent_builder/hooks/useAgentPreview.ts
+++ b/front/components/agent_builder/hooks/useAgentPreview.ts
@@ -89,12 +89,13 @@ export function useDraftAgent() {
       getValues,
     ]);
 
-const debouncedCreateDraftAgent = useMemo(
-  () => debounce(() => {
-    void createDraftAgent();
-  }, 500),
-  [createDraftAgent]
-);
+  const debouncedCreateDraftAgent = useMemo(
+    () =>
+      debounce(() => {
+        void createDraftAgent();
+      }, 500),
+    [createDraftAgent]
+  );
   const getDraftAgent =
     useCallback(async (): Promise<LightAgentConfigurationType | null> => {
       const formData = getValues();

--- a/front/components/agent_builder/hooks/useAgentPreview.ts
+++ b/front/components/agent_builder/hooks/useAgentPreview.ts
@@ -58,7 +58,7 @@ export function useDraftAgent() {
     debouncedValue: debouncedInstructions,
     setValue: setDebouncedInstructions,
   } = useDebounce(instructions, {
-    delay: 300,
+    delay: 500,
   });
   const {
     debouncedValue: debouncedAgentName,
@@ -66,6 +66,8 @@ export function useDraftAgent() {
   } = useDebounce(agentName, { delay: 300 });
 
   useEffect(() => {
+    // show spinner already when a user starts typing
+    setIsSavingDraftAgent(true);
     setDebouncedInstructions(instructions);
   }, [instructions, setDebouncedInstructions]);
 
@@ -146,7 +148,7 @@ export function useDraftAgent() {
       const hasContent =
         (actions && actions.length > 0) || debouncedInstructions?.trim();
 
-      if (!isSavingDraftAgent && hasContent) {
+      if (hasContent) {
         void createDraftAgent();
       }
 

--- a/front/hooks/useDebounce.ts
+++ b/front/hooks/useDebounce.ts
@@ -1,5 +1,5 @@
 import { debounce } from "lodash";
-import { useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 
 interface UseDebounceOptions {
   delay?: number;
@@ -25,7 +25,7 @@ export function useDebounce(
   ).current;
 
   // Update function
-  const setValue = (value: string) => {
+  const setValue = useCallback((value: string) => {
     setInputValue(value);
 
     if (minLength > 0 && value.length < minLength) {
@@ -36,7 +36,7 @@ export function useDebounce(
     }
     setIsDebouncing(true);
     debouncedUpdate(value);
-  };
+  }, [debouncedUpdate, minLength]);
 
   // Cleanup on unmount
   useEffect(() => {

--- a/front/hooks/useDebounce.ts
+++ b/front/hooks/useDebounce.ts
@@ -25,18 +25,21 @@ export function useDebounce(
   ).current;
 
   // Update function
-  const setValue = useCallback((value: string) => {
-    setInputValue(value);
+  const setValue = useCallback(
+    (value: string) => {
+      setInputValue(value);
 
-    if (minLength > 0 && value.length < minLength) {
-      setDebouncedValue("");
-      setIsDebouncing(false);
-      debouncedUpdate.cancel();
-      return;
-    }
-    setIsDebouncing(true);
-    debouncedUpdate(value);
-  }, [debouncedUpdate, minLength]);
+      if (minLength > 0 && value.length < minLength) {
+        setDebouncedValue("");
+        setIsDebouncing(false);
+        debouncedUpdate.cancel();
+        return;
+      }
+      setIsDebouncing(true);
+      debouncedUpdate(value);
+    },
+    [debouncedUpdate, minLength]
+  );
 
   // Cleanup on unmount
   useEffect(() => {


### PR DESCRIPTION
## Description
This PR is to fix re-rendering issue in AB v2, and refactor all the logic to make it a bit more easier to understand. 

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

If I understand it correctly here is how it's supposed to work: 
- When you open the builder to create a new agent, we should create a draft agent only when there is either instructions or actions. Currently it fires immediately when you start typing, so I added debounced logic here (it is still probably useless but slightly better 🙃)
- When you open the builder to edit an existing agent, we should create a draft agent immediately.  
- When you have either instructions or actions, and if an agent name has been changed, we need to update an agent draft so that we can show the new name in the input bar. 
- Once you create the first version of draft agent, we will create an agent only when a user sends a message and there is a change in form data.

## Tests
- Open network tab and check when agent configuration POST is triggered.
- Check @mention gets updated when you change the agent name

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
