### PR TITLE
Fix wakeLock usage in agent loop

### DIFF
--- a/front/lib/api/assistant/agent.ts
+++ b/front/lib/api/assistant/agent.ts
@@ -346,7 +346,6 @@ async function runMultiActionsAgentLoop(
             break;
 
           case "generation_cancel":
-            await updateResourceAndPublishEvent(
             return updateResourceAndPublishEvent(
               {
                 type: "agent_generation_cancelled",
@@ -395,6 +394,7 @@ async function runMultiActionsAgentLoop(
             assertNever(event);
         }
       }
+    }
   });
 }
 

--- a/front/lib/api/assistant/agent.ts
+++ b/front/lib/api/assistant/agent.ts
@@ -196,36 +196,36 @@ async function runMultiActionsAgentLoop(
   // Track step content IDs by function call ID for later use in actions.
   const functionCallStepContentIds: Record<string, ModelId> = {};
 
-  for (let i = 0; i < maxStepsPerRun + 1; i++) {
-    const localLogger = logger.child({
-      workspaceId: conversation.owner.sId,
-      conversationId: conversation.sId,
-      multiActionLoopIteration: i,
-    });
+  await wakeLock(async () => {
+    for (let i = 0; i < maxStepsPerRun + 1; i++) {
+      const localLogger = logger.child({
+        workspaceId: conversation.owner.sId,
+        conversationId: conversation.sId,
+        multiActionLoopIteration: i,
+      });
 
-    localLogger.info("Starting multi-action loop iteration");
+      localLogger.info("Starting multi-action loop iteration");
 
-    const isLastGenerationIteration = i === maxStepsPerRun;
+      const isLastGenerationIteration = i === maxStepsPerRun;
 
-    const actions =
-      // If we already executed the maximum number of actions, we don't run anymore.
-      // This will force the agent to run the generation.
-      isLastGenerationIteration
-        ? []
-        : // Otherwise, we let the agent decide which action to run (if any).
-          configuration.actions;
+      const actions =
+        // If we already executed the maximum number of actions, we don't run anymore.
+        // This will force the agent to run the generation.
+        isLastGenerationIteration
+          ? []
+          : // Otherwise, we let the agent decide which action to run (if any).
+            configuration.actions;
 
-    const loopIterationStream = runMultiActionsAgent(auth.toJSON(), {
-      agentConfiguration: configuration,
-      conversation,
-      userMessage,
-      agentMessage,
-      agentActions: actions,
-      isLastGenerationIteration,
-      isLegacyAgent,
-    });
+      const loopIterationStream = runMultiActionsAgent(auth.toJSON(), {
+        agentConfiguration: configuration,
+        conversation,
+        userMessage,
+        agentMessage,
+        agentActions: actions,
+        isLastGenerationIteration,
+        isLegacyAgent,
+      });
 
-    await wakeLock(async () => {
       for await (const event of loopIterationStream) {
         switch (event.type) {
           case "agent_error":
@@ -347,6 +347,7 @@ async function runMultiActionsAgentLoop(
 
           case "generation_cancel":
             await updateResourceAndPublishEvent(
+            return updateResourceAndPublishEvent(
               {
                 type: "agent_generation_cancelled",
                 created: event.created,
@@ -356,7 +357,6 @@ async function runMultiActionsAgentLoop(
               conversation,
               agentMessageRow
             );
-            return;
 
           case "generation_success":
             if (event.chainOfThought.length) {
@@ -370,7 +370,7 @@ async function runMultiActionsAgentLoop(
 
             runIds.push(event.runId);
 
-            await updateResourceAndPublishEvent(
+            return updateResourceAndPublishEvent(
               {
                 type: "agent_message_success",
                 created: Date.now(),
@@ -382,7 +382,6 @@ async function runMultiActionsAgentLoop(
               conversation,
               agentMessageRow
             );
-            return;
 
           case "agent_chain_of_thought":
             if (!agentMessage.chainOfThought) {
@@ -396,8 +395,7 @@ async function runMultiActionsAgentLoop(
             assertNever(event);
         }
       }
-    });
-  }
+  });
 }
 
 // This method is used by the multi-actions execution loop to pick the next action to execute and


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
This PR fixes a regression that happened when solving conflicts of https://github.com/dust-tt/dust/pull/14378 with `main`. The `wakeLock` was moved to the wrong place leading to several `AgentStepContent` created. 

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
