### PR TITLE
bigquery: less concurrency more logging

### DIFF
--- a/connectors/src/connectors/bigquery/lib/bigquery_api.ts
+++ b/connectors/src/connectors/bigquery/lib/bigquery_api.ts
@@ -94,18 +94,20 @@ export const fetchDatasets = async ({
 }: {
   credentials: BigQueryCredentialsWithLocation;
   connection?: BigQuery;
-  logger: Logger;
+  logger?: Logger;
 }): Promise<Result<Array<RemoteDBSchema>, Error>> => {
   const conn = connection ?? connectToBigQuery(credentials);
   try {
     const r = await conn.getDatasets();
     const datasets = r[0];
-    logger.info(
-      {
-        datasetsCount: datasets.length,
-      },
-      "[BigQuery] fetchDatasets"
-    );
+    if (logger) {
+      logger.info(
+        {
+          datasetsCount: datasets.length,
+        },
+        "[BigQuery] fetchDatasets"
+      );
+    }
     return new Ok(
       removeNulls(
         datasets.map((dataset) => {
@@ -148,7 +150,7 @@ export const fetchTables = async ({
   dataset: string;
   fetchTablesDescription: boolean;
   connection?: BigQuery;
-  logger: Logger;
+  logger?: Logger;
 }): Promise<Result<Array<RemoteDBTable>, Error>> => {
   const conn = connection ?? connectToBigQuery(credentials);
   try {
@@ -161,7 +163,7 @@ export const fetchTables = async ({
     const d = conn.dataset(dataset);
     const r = await d.getTables();
     const tables = r[0];
-    logger.info(
+    logger?.info(
       {
         tablesCount: tables.length,
         dataset,
@@ -179,7 +181,7 @@ export const fetchTables = async ({
           if (fetchTablesDescription) {
             try {
               const metadata = await table.getMetadata();
-              logger.info(
+              logger?.info(
                 {
                   dataset,
                   table: table.id,
@@ -202,7 +204,7 @@ export const fetchTables = async ({
                   typeof error.message === "string"
                     ? error.message
                     : "Permission denied";
-                logger.warn(
+                logger?.warn(
                   {
                     projectId: credentials.project_id,
                     dataset,

--- a/connectors/src/connectors/bigquery/lib/bigquery_api.ts
+++ b/connectors/src/connectors/bigquery/lib/bigquery_api.ts
@@ -65,6 +65,10 @@ export function connectToBigQuery(
     credentials,
     scopes: ["https://www.googleapis.com/auth/bigquery.readonly"],
     location: credentials.location,
+    retryOptions: {
+      autoRetry: true,
+      maxRetries: 3,
+    },
   });
 }
 
@@ -144,7 +148,7 @@ export const fetchTables = async ({
     }
 
     // Get the dataset specified by the schema
-    const d = await conn.dataset(dataset);
+    const d = conn.dataset(dataset);
     const r = await d.getTables();
     const tables = r[0];
 
@@ -198,7 +202,7 @@ export const fetchTables = async ({
           }
         },
         {
-          concurrency: 10,
+          concurrency: 4,
         }
       )
     );
@@ -216,7 +220,7 @@ export const fetchTree = async ({
   credentials: BigQueryCredentialsWithLocation;
   fetchTablesDescription: boolean;
 }): Promise<Result<RemoteDBTree, Error>> => {
-  const databases = await fetchDatabases({ credentials });
+  const databases = fetchDatabases({ credentials });
 
   const schemasRes = await fetchDatasets({ credentials });
   if (schemasRes.isErr()) {

--- a/connectors/src/connectors/bigquery/temporal/activities.ts
+++ b/connectors/src/connectors/bigquery/temporal/activities.ts
@@ -6,7 +6,7 @@ import { BigQueryConfigurationModel } from "@connectors/lib/models/bigquery";
 import { sync } from "@connectors/lib/remote_databases/activities";
 import { getConnectorAndCredentials } from "@connectors/lib/remote_databases/utils";
 import { syncStarted, syncSucceeded } from "@connectors/lib/sync_status";
-import logger from "@connectors/logger/logger";
+import logger, { getActivityLogger } from "@connectors/logger/logger";
 import type { ModelId } from "@connectors/types";
 import {
   INTERNAL_MIME_TYPES,
@@ -47,9 +47,12 @@ export async function syncBigQueryConnection(connectorId: ModelId) {
 
   const useMetadataForDBML = connectorConfig.useMetadataForDBML;
 
+  const activityLogger = getActivityLogger(connector);
+
   const treeRes = await fetchTree({
     credentials,
     fetchTablesDescription: useMetadataForDBML,
+    logger: activityLogger,
   });
   if (treeRes.isErr()) {
     throw treeRes.error;

--- a/connectors/src/connectors/bigquery/temporal/workflows.ts
+++ b/connectors/src/connectors/bigquery/temporal/workflows.ts
@@ -5,7 +5,7 @@ import { resyncSignal } from "@connectors/connectors/bigquery/temporal/signals";
 import type { ModelId } from "@connectors/types";
 
 const { syncBigQueryConnection } = proxyActivities<typeof activities>({
-  startToCloseTimeout: "30 minutes",
+  startToCloseTimeout: "60 minutes",
 });
 
 export async function bigquerySyncWorkflow({


### PR DESCRIPTION
## Description

We're hitting rate limits for bigquery on large-ish connections. The PR attempts to reduce concurrency and add more logging to better understand the dynamics and possibly fix it.

## Tests

None

## Risk

Low

## Deploy Plan

- deploy `connectors`