### PR TITLE
swap order of the extensions for docx primary mimetype

### DIFF
--- a/front/types/files.ts
+++ b/front/types/files.ts
@@ -197,7 +197,7 @@ export const FILE_FORMATS = {
   },
   "application/vnd.openxmlformats-officedocument.wordprocessingml.document": {
     cat: "data",
-    exts: [".doc", ".docx"],
+    exts: [".docx", ".doc"],
     isSafeToDisplay: true,
   },
   "application/vnd.ms-powerpoint": {


### PR DESCRIPTION
## Description

Solves https://github.com/dust-tt/tasks/issues/3496

Allow documents to be exported as .docx



The export function cares about the order of the exts
https://github.com/dust-tt/dust/blob/061fe0e1ed498e9892853053ecca3a618847563f/front/lib/actions/mcp.ts#L1017

https://github.com/dust-tt/dust/blob/061fe0e1ed498e9892853053ecca3a618847563f/front/lib/actions/mcp_internal_actions/servers/run_dust_app.ts#L81