### PR TITLE
bigquery: add concurrentExecutor to process databases

### DIFF
--- a/connectors/src/connectors/bigquery/lib/bigquery_api.ts
+++ b/connectors/src/connectors/bigquery/lib/bigquery_api.ts
@@ -257,8 +257,9 @@ export const fetchTree = async ({
   const schemas = schemasRes.value;
 
   const tree = {
-    databases: await Promise.all(
-      databases.map(async (db) => {
+    databases: await concurrentExecutor(
+      databases,
+      async (db) => {
         return {
           ...db,
           schemas: await Promise.all(
@@ -297,7 +298,10 @@ export const fetchTree = async ({
               })
           ),
         };
-      })
+      },
+      {
+        concurrency: 4,
+      }
     ),
   };
 

--- a/connectors/src/connectors/bigquery/temporal/workflows.ts
+++ b/connectors/src/connectors/bigquery/temporal/workflows.ts
@@ -5,7 +5,7 @@ import { resyncSignal } from "@connectors/connectors/bigquery/temporal/signals";
 import type { ModelId } from "@connectors/types";
 
 const { syncBigQueryConnection } = proxyActivities<typeof activities>({
-  startToCloseTimeout: "60 minutes",
+  startToCloseTimeout: "180 minutes",
 });
 
 export async function bigquerySyncWorkflow({


### PR DESCRIPTION
## Description

That Promise.all is a killer a user has 378 of them so the promise.all will necessarily bump into the 100 req/s limit

https://app.datadoghq.eu/logs?query=%40workflowId%3Abigquery-sync-17739%20%22%5BBigQuery%5D%20fetchDatasets%22&agg_m=count&agg_m_source=base&agg_t=count&clustering_pattern_field_path=message&cols=host%2Cservice%2C%40workflowId%2C%40activityName&event=AwAAAZgZEBjHiUf4PgAAABhBWmdaRUNVMUFBQnVLWE83TENHWlp3QVUAAAAkZjE5ODE5MTAtMmMxZi00ODdmLTg5YmQtZjMwMjZhNmY2NTA5AAAEMQ&link_source=monitor_notif&messageDisplay=inline&refresh_mode=sliding&storage=hot&stream_sort=time%2Cdesc&viz=stream&from_ts=1752761105416&to_ts=1752764705416&live=true

Also bump startToCloseTimeout because it will take some time to get all those datasets and tables in.

## Tests

None

## Risk

Low (daily sync)

## Deploy Plan

- deploy `conectors`