### PR TITLE
Fix script Slack add channels to Company Space should use strict prefix

### DIFF
--- a/front/migrations/20250502_batch_add_to_company_space.ts
+++ b/front/migrations/20250502_batch_add_to_company_space.ts
@@ -45,7 +45,15 @@ async function getParentsToAdd({
       throw searchResult.error;
     }
 
-    nodes = searchResult.value.nodes;
+    // The Elasticsearch analyzer splits punctuation (like '#inc-') into tokens,
+    // causing the search to match documents containing the prefix anywhere in the title,
+    // not just at the beginning. This post-search filter ensures we only get
+    // documents whose titles actually start with the specified prefix.
+    const filteredNodes = searchResult.value.nodes.filter((node: any) =>
+      node.title.toLowerCase().startsWith(namePrefix.toLowerCase())
+    );
+
+    nodes = filteredNodes;
 
     if (execute) {
       logger.info(`Found ${nodes.length} parents to add.`);


### PR DESCRIPTION
## Description

Filter is not strict enough and would match more channels.

Prefix "#inc- " could return: 
- "#incident-soupinou"
- "#inc-soupinou"
- "#soupinou-inc"

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

Deploy front. 