### PR TITLE
Fix breaking poké export/import agent

### DIFF
--- a/front/pages/api/poke/workspaces/[wId]/agent_configurations/[aId]/export.ts
+++ b/front/pages/api/poke/workspaces/[wId]/agent_configurations/[aId]/export.ts
@@ -118,6 +118,7 @@ async function handler(
           tags: agentConfiguration.tags,
           canRead: agentConfiguration.canRead,
           canEdit: agentConfiguration.canEdit,
+          editors: [],
         },
       });
       return;


### PR DESCRIPTION
## Description

Fixes https://github.com/dust-tt/tasks/issues/3519

Error was: 
```
Failed to import agent. Invalid request body: Expecting Array<{ sId: string }> at assistant.editors but instead got: undefined
```

I'm passing an empty array since source editors might not be in the destination workspace. 
I think this is good enough. 


## Tests

Locally I can import/export an agent. 

## Risk

/ 

## Deploy Plan

Deploy front. 