### PR TITLE
[front] fix(MCP): fix handling of failed tool executions

### DIFF
--- a/front/lib/api/assistant/agent.ts
+++ b/front/lib/api/assistant/agent.ts
@@ -297,28 +297,24 @@ async function runMultiActionsAgentLoop(
               event.actions = event.actions.slice(0, MAX_ACTIONS_PER_STEP);
 
               await Promise.all(
-                event.actions.map(
-                  ({ action, inputs, functionCallId }, index) => {
+                event.actions.map(({ action, inputs, functionCallId }, index) =>
+                  runAction(auth, {
+                    configuration,
+                    actionConfiguration: action,
+                    conversation,
+                    agentMessage,
+                    inputs,
+                    functionCallId,
+                    step: i,
+                    stepActionIndex: index,
+                    stepActions: event.actions.map((a) => a.action),
+                    citationsRefsOffset,
                     // Find the step content ID for this function call
-                    const stepContentId = functionCallId
+                    stepContentId: functionCallId
                       ? functionCallStepContentIds[functionCallId]
-                      : undefined;
-
-                    return runAction(auth, {
-                      configuration,
-                      actionConfiguration: action,
-                      conversation,
-                      agentMessage,
-                      inputs,
-                      functionCallId,
-                      step: i,
-                      stepActionIndex: index,
-                      stepActions: event.actions.map((a) => a.action),
-                      citationsRefsOffset,
-                      stepContentId,
-                      agentMessageRow,
-                    });
-                  }
+                      : undefined,
+                    agentMessageRow,
+                  })
                 )
               );
               // After we are done running actions, we update the inter-step refsOffset.


### PR DESCRIPTION
## Description

- On tool errors we can currently create states in db where an `agent_mcp_actions` has no output item, causing the error `tool_use` block must have a corresponding `tool_result` block in the next message.
- This PR fixes that by ensuring that the state in db matches the `MCPActionType` we create.

## Tests

- Tested locally with throws inserted in tool code.

## Risk

## Deploy Plan

- Deploy front.
