### PR TITLE
Cleanup SDK following refactoring of actions

### DIFF
--- a/connectors/src/connectors/slack/chat/stream_conversation_handler.ts
+++ b/connectors/src/connectors/slack/chat/stream_conversation_handler.ts
@@ -6,7 +6,7 @@ import type {
   Result,
   UserMessageType,
 } from "@dust-tt/client";
-import { ACTION_RUNNING_LABELS, assertNever, Err, Ok } from "@dust-tt/client";
+import { assertNever, Err, Ok, TOOL_RUNNING_LABEL } from "@dust-tt/client";
 import type { ChatPostMessageResponse, WebClient } from "@slack/web-api";
 import * as t from "io-ts";
 import slackifyMarkdown from "slackify-markdown";
@@ -128,8 +128,6 @@ async function streamAgentAnswerToSlack(
   const actions: AgentActionPublicType[] = [];
   for await (const event of streamRes.value.eventStream) {
     switch (event.type) {
-      case "conversation_include_file_params":
-      case "process_params":
       case "tool_params":
       case "tool_notification":
         await postSlackMessageUpdate(
@@ -140,7 +138,7 @@ async function streamAgentAnswerToSlack(
               assistantName,
               agentConfigurations,
               text: answer,
-              thinkingAction: ACTION_RUNNING_LABELS[event.action.type],
+              thinkingAction: TOOL_RUNNING_LABEL,
             },
             ...conversationData,
           },

--- a/front/components/actions/types.ts
+++ b/front/components/actions/types.ts
@@ -1,7 +1,8 @@
+import { TOOL_RUNNING_LABEL } from "@dust-tt/client";
+
 import { MCPActionDetails } from "@app/components/actions/mcp/details/MCPActionDetails";
 import type { ProgressNotificationContentType } from "@app/lib/actions/mcp_internal_actions/output_schemas";
 import type { AgentActionType, LightWorkspaceType } from "@app/types";
-import { ACTION_RUNNING_LABELS } from "@app/types";
 
 export interface ActionDetailsComponentBaseProps<
   T extends AgentActionType = AgentActionType,
@@ -26,7 +27,7 @@ type ActionSpecifications = {
 const actionsSpecification: ActionSpecifications = {
   tool_action: {
     detailsComponent: MCPActionDetails,
-    runningLabel: ACTION_RUNNING_LABELS.tool_action,
+    runningLabel: TOOL_RUNNING_LABEL,
   },
 };
 

--- a/front/types/assistant/conversation.ts
+++ b/front/types/assistant/conversation.ts
@@ -129,10 +129,6 @@ export type AgentMessageStatus =
   | "failed"
   | "cancelled";
 
-export const ACTION_RUNNING_LABELS: Record<AgentActionType["type"], string> = {
-  tool_action: "Using a tool",
-};
-
 export interface CitationType {
   description?: string;
   href?: string;

--- a/sdks/js/package-lock.json
+++ b/sdks/js/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@dust-tt/client",
-  "version": "1.0.57",
+  "version": "1.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@dust-tt/client",
-      "version": "1.0.57",
+      "version": "1.1.0",
       "license": "ISC",
       "dependencies": {
         "@modelcontextprotocol/sdk": "git://github.com:dust-tt/typescript-sdk.git#bca26e405d6db2cf71fd7211234a72ecc46d0215",

--- a/sdks/js/package.json
+++ b/sdks/js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dust-tt/client",
-  "version": "1.0.57",
+  "version": "1.1.0",
   "description": "Client for Dust API",
   "repository": {
     "type": "git",

--- a/sdks/js/src/types.ts
+++ b/sdks/js/src/types.ts
@@ -1,4 +1,3 @@
-import type { JSONSchema7 } from "json-schema";
 import moment from "moment-timezone";
 import { z } from "zod";
 
@@ -553,75 +552,6 @@ const BaseActionSchema = z.object({
   type: BaseActionTypeSchema,
 });
 
-const ConversationIncludeFileActionTypeSchema = BaseActionSchema.extend({
-  agentMessageId: ModelIdSchema,
-  params: z.object({
-    fileId: z.string(),
-  }),
-  tokensCount: z.number().nullable(),
-  fileTitle: z.string().nullable(),
-  functionCallId: z.string().nullable(),
-  functionCallName: z.string().nullable(),
-  step: z.number(),
-  type: z.literal("conversation_include_file_action"),
-});
-
-const ConversationAttachmentTypeSchema = z.union([
-  // File case
-  z.object({
-    fileId: z.string(),
-    contentFragmentId: z.undefined(),
-    nodeDataSourceViewId: z.undefined(),
-    title: z.string(),
-    contentType: SupportedContentFragmentTypeSchema,
-  }),
-  // Node case
-  z.object({
-    fileId: z.undefined(),
-    contentFragmentId: z.string(),
-    nodeDataSourceViewId: z.string(),
-    title: z.string(),
-    contentType: SupportedContentFragmentTypeSchema,
-  }),
-]);
-
-const ConversationListFilesActionTypeSchema = BaseActionSchema.extend({
-  files: z.array(ConversationAttachmentTypeSchema),
-  functionCallId: z.string().nullable(),
-  functionCallName: z.string().nullable(),
-  agentMessageId: ModelIdSchema,
-  step: z.number(),
-  type: z.literal("conversation_list_files_action"),
-});
-
-const DustAppParametersSchema = z.record(
-  z.union([z.string(), z.number(), z.boolean()])
-);
-
-const DustAppRunActionTypeSchema = BaseActionSchema.extend({
-  agentMessageId: ModelIdSchema,
-  appWorkspaceId: z.string(),
-  appId: z.string(),
-  appName: z.string(),
-  params: DustAppParametersSchema,
-  runningBlock: z
-    .object({
-      type: z.string(),
-      name: z.string(),
-      status: z.enum(["running", "succeeded", "errored"]),
-    })
-    .nullable(),
-  output: z.unknown().nullable(),
-  functionCallId: z.string().nullable(),
-  functionCallName: z.string().nullable(),
-  step: z.number(),
-  type: z.literal("dust_app_run_action"),
-}).transform((o) => ({
-  ...o,
-  output: o.output,
-}));
-type DustAppRunActionPublicType = z.infer<typeof DustAppRunActionTypeSchema>;
-
 const DataSourceViewKindSchema = FlexibleEnumSchema<"default" | "custom">();
 
 const DataSourceViewSchema = z.object({
@@ -637,29 +567,6 @@ const DataSourceViewSchema = z.object({
   spaceId: z.string(),
 });
 export type DataSourceViewType = z.infer<typeof DataSourceViewSchema>;
-
-const TIME_FRAME_UNITS = ["hour", "day", "week", "month", "year"] as const;
-const TimeframeUnitSchema = z.enum(TIME_FRAME_UNITS);
-
-const TimeFrameSchema = z.object({
-  duration: z.number(),
-  unit: TimeframeUnitSchema,
-});
-
-const DataSourceFilterSchema = z.object({
-  parents: z
-    .object({
-      in: z.array(z.string()),
-      not: z.array(z.string()),
-    })
-    .nullable(),
-});
-
-const DataSourceConfigurationSchema = z.object({
-  workspaceId: z.string(),
-  dataSourceViewId: z.string(),
-  filter: DataSourceFilterSchema,
-});
 
 const RetrievalDocumentChunkTypeSchema = z.object({
   offset: z.number(),
@@ -682,33 +589,6 @@ export const RetrievalDocumentTypeSchema = z.object({
 export type RetrievalDocumentPublicType = z.infer<
   typeof RetrievalDocumentTypeSchema
 >;
-
-const ProcessSchemaPropertySchema = z.union([
-  z.custom<JSONSchema7>(),
-  z.null(),
-]);
-
-const ProcessActionOutputsSchema = z.object({
-  data: z.array(z.unknown()),
-  min_timestamp: z.number(),
-  total_documents: z.number(),
-  total_chunks: z.number(),
-  total_tokens: z.number(),
-});
-
-const ProcessActionTypeSchema = BaseActionSchema.extend({
-  agentMessageId: ModelIdSchema,
-  params: z.object({
-    relativeTimeFrame: TimeFrameSchema.nullable(),
-  }),
-  jsonSchema: ProcessSchemaPropertySchema,
-  outputs: ProcessActionOutputsSchema.nullable(),
-  functionCallId: z.string().nullable(),
-  functionCallName: z.string().nullable(),
-  step: z.number(),
-  type: z.literal("process_action"),
-});
-type ProcessActionPublicType = z.infer<typeof ProcessActionTypeSchema>;
 
 const WhitelistableFeaturesSchema = FlexibleEnumSchema<
   | "advanced_notion_management"
@@ -996,14 +876,7 @@ export type UserMessageWithRankType = z.infer<
   typeof UserMessageWithRankTypeSchema
 >;
 
-const AgentActionTypeSchema = z.union([
-  DustAppRunActionTypeSchema,
-  ProcessActionTypeSchema,
-  ConversationListFilesActionTypeSchema,
-  ConversationIncludeFileActionTypeSchema,
-  MCPActionTypeSchema,
-]);
-export type AgentActionPublicType = z.infer<typeof AgentActionTypeSchema>;
+export type AgentActionPublicType = z.infer<typeof MCPActionTypeSchema>;
 
 const AgentMessageStatusSchema = FlexibleEnumSchema<
   "created" | "succeeded" | "failed" | "cancelled"
@@ -1020,7 +893,7 @@ const AgentMessageTypeSchema = z.object({
   parentMessageId: z.string().nullable(),
   configuration: LightAgentConfigurationSchema,
   status: AgentMessageStatusSchema,
-  actions: z.array(AgentActionTypeSchema),
+  actions: z.array(MCPActionTypeSchema),
   content: z.string().nullable(),
   chainOfThought: z.string().nullable(),
   rawContents: z.array(
@@ -1106,23 +979,6 @@ const ConversationMessageReactionsSchema = z.array(
 export type ConversationMessageReactionsType = z.infer<
   typeof ConversationMessageReactionsSchema
 >;
-
-const ConversationIncludeFileParamsEventSchema = z.object({
-  type: z.literal("conversation_include_file_params"),
-  created: z.number(),
-  configurationId: z.string(),
-  messageId: z.string(),
-  action: ConversationIncludeFileActionTypeSchema,
-});
-
-const ProcessParamsEventSchema = z.object({
-  type: z.literal("process_params"),
-  created: z.number(),
-  configurationId: z.string(),
-  messageId: z.string(),
-  dataSources: z.array(DataSourceConfigurationSchema),
-  action: ProcessActionTypeSchema,
-});
 
 const MCPStakeLevelSchema = z.enum(["low", "high", "never_ask"]).optional();
 
@@ -1232,8 +1088,6 @@ const AgentErrorEventSchema = z.object({
 export type AgentErrorEvent = z.infer<typeof AgentErrorEventSchema>;
 
 const AgentActionSpecificEventSchema = z.union([
-  ConversationIncludeFileParamsEventSchema,
-  ProcessParamsEventSchema,
   MCPParamsEventSchema,
   ToolNotificationEventSchema,
   MCPApproveExecutionEventSchema,
@@ -1247,7 +1101,7 @@ const AgentActionSuccessEventSchema = z.object({
   created: z.number(),
   configurationId: z.string(),
   messageId: z.string(),
-  action: AgentActionTypeSchema,
+  action: MCPActionTypeSchema,
 });
 export type AgentActionSuccessEvent = z.infer<
   typeof AgentActionSuccessEventSchema
@@ -2540,18 +2394,6 @@ export function isMCPActionType(
   return action.type === "tool_action";
 }
 
-export function isDustAppRunActionType(
-  action: AgentActionPublicType
-): action is DustAppRunActionPublicType {
-  return action.type === "dust_app_run_action";
-}
-
-export function isProcessActionType(
-  action: AgentActionPublicType
-): action is ProcessActionPublicType {
-  return action.type === "process_action";
-}
-
 export function isAgentMention(arg: AgentMentionType): arg is AgentMentionType {
   return (arg as AgentMentionType).configurationId !== undefined;
 }
@@ -2727,17 +2569,7 @@ export type PostWorkspaceSearchResponseBodyType = z.infer<
   typeof PostWorkspaceSearchResponseBodySchema
 >;
 
-// TODO(mcp) move somewhere else as we'll need dynamic labels for MCP.
-export const ACTION_RUNNING_LABELS: Record<
-  AgentActionPublicType["type"],
-  string
-> = {
-  conversation_include_file_action: "Reading file",
-  conversation_list_files_action: "Listing files",
-  dust_app_run_action: "Running App",
-  process_action: "Extracting data",
-  tool_action: "Using a tool",
-};
+export const TOOL_RUNNING_LABEL = "Using a tool";
 
 // MCP Related.
 


### PR DESCRIPTION
## Description

Cleaning up the SDK following migration of legacy actions execution.
Bumping from `1.0.57` to `1.1.0`.

## Tests

SDK compiles.
I momentarily updating the extension to call SDK from sources (as done in front/connectors) and it works as expected. 

## Risk

If error on front or connectors ->  can be rolled back. 
No risk for extensions as they are using a fixed version from npm. 

## Deploy Plan

Merge. 
Publish new version of the SDK. 
Deploy front. 
Deploy connectors. 