### PR TITLE
Cleanup Extension following refactoring of legacy actions

### DIFF
--- a/extension/package-lock.json
+++ b/extension/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "@auth0/auth0-spa-js": "^2.1.3",
         "@datadog/browser-logs": "^6.13.0",
-        "@dust-tt/client": "^1.0.57",
+        "@dust-tt/client": "file:../sdks/js",
         "@dust-tt/sparkle": "^0.2.542",
         "@frontapp/plugin-sdk": "^1.8.1",
         "@modelcontextprotocol/sdk": "^1.9.0",
@@ -80,6 +80,31 @@
         "webpack-ext-reloader": "^1.1.13",
         "webpackbar": "^6.0.1",
         "zip-webpack-plugin": "^4.0.1"
+      }
+    },
+    "../sdks/js": {
+      "version": "1.0.57",
+      "license": "ISC",
+      "dependencies": {
+        "@modelcontextprotocol/sdk": "git://github.com:dust-tt/typescript-sdk.git#bca26e405d6db2cf71fd7211234a72ecc46d0215",
+        "@types/json-schema": "^7.0.15",
+        "event-source-polyfill": "^1.0.31",
+        "eventsource-parser": "^1.1.1",
+        "moment-timezone": "^0.5.46",
+        "zod": "^3.23.8"
+      },
+      "devDependencies": {
+        "@tsconfig/recommended": "^1.0.3",
+        "@types/event-source-polyfill": "^1.0.5",
+        "@types/node": "^22.7.5",
+        "@types/uuid": "^9.0.7",
+        "dts-cli": "^2.0.5",
+        "eslint-plugin-simple-import-sort": "^12.1.0",
+        "tslib": "^2.6.2",
+        "typescript": "^5.4.5"
+      },
+      "engines": {
+        "node": ">=20"
       }
     },
     "../types": {
@@ -340,21 +365,8 @@
       }
     },
     "node_modules/@dust-tt/client": {
-      "version": "1.0.57",
-      "resolved": "https://registry.npmjs.org/@dust-tt/client/-/client-1.0.57.tgz",
-      "integrity": "sha512-S48OrRsaSPI2fFhKJythZfRM+ijdmC8JviPMg5nW7k+Nlj/dLcG7c12ZUICeQlToKtpZteDbkTHo245usLua/A==",
-      "license": "ISC",
-      "dependencies": {
-        "@modelcontextprotocol/sdk": "git://github.com/dust-tt/typescript-sdk.git#bca26e405d6db2cf71fd7211234a72ecc46d0215",
-        "@types/json-schema": "^7.0.15",
-        "event-source-polyfill": "^1.0.31",
-        "eventsource-parser": "^1.1.1",
-        "moment-timezone": "^0.5.46",
-        "zod": "^3.23.8"
-      },
-      "engines": {
-        "node": ">=20"
-      }
+      "resolved": "../sdks/js",
+      "link": true
     },
     "node_modules/@dust-tt/sparkle": {
       "version": "0.2.542",
@@ -3467,7 +3479,8 @@
     "node_modules/@types/json-schema": {
       "version": "7.0.15",
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
-      "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA=="
+      "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
+      "dev": true
     },
     "node_modules/@types/json5": {
       "version": "0.0.29",
@@ -7270,14 +7283,6 @@
         "node": ">=18.0.0"
       }
     },
-    "node_modules/eventsource-parser": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/eventsource-parser/-/eventsource-parser-1.1.2.tgz",
-      "integrity": "sha512-v0eOBUbiaFojBu2s2NPBfYUoRR9GjcDNvCXVaqEf5vVfpIAh9f8RCo4vXTP8c63QRKCFwoLpMpTdPwwhEKVgzA==",
-      "engines": {
-        "node": ">=14.18"
-      }
-    },
     "node_modules/eventsource/node_modules/eventsource-parser": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/eventsource-parser/-/eventsource-parser-3.0.1.tgz",
@@ -11047,17 +11052,6 @@
       "version": "2.30.1",
       "resolved": "https://registry.npmjs.org/moment/-/moment-2.30.1.tgz",
       "integrity": "sha512-uEmtNhbDOrWPFS+hdjFCBfy9f2YoyzRpwcl+DqpC6taX21FzsTLQVbMV/W7PzNSX6x/bhC1zA3c2UQ5NzH6how==",
-      "engines": {
-        "node": "*"
-      }
-    },
-    "node_modules/moment-timezone": {
-      "version": "0.5.48",
-      "resolved": "https://registry.npmjs.org/moment-timezone/-/moment-timezone-0.5.48.tgz",
-      "integrity": "sha512-f22b8LV1gbTO2ms2j2z13MuPogNoh5UzxL3nzNAYKGraILnbGc9NEE6dyiiiLv46DGRb8A4kg8UKWLjPthxBHw==",
-      "dependencies": {
-        "moment": "^2.29.4"
-      },
       "engines": {
         "node": "*"
       }

--- a/extension/package-lock.json
+++ b/extension/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "@auth0/auth0-spa-js": "^2.1.3",
         "@datadog/browser-logs": "^6.13.0",
-        "@dust-tt/client": "file:../sdks/js",
+        "@dust-tt/client": "^1.1.0",
         "@dust-tt/sparkle": "^0.2.542",
         "@frontapp/plugin-sdk": "^1.8.1",
         "@modelcontextprotocol/sdk": "^1.9.0",
@@ -83,7 +83,8 @@
       }
     },
     "../sdks/js": {
-      "version": "1.0.57",
+      "name": "@dust-tt/client",
+      "version": "1.1.0",
       "license": "ISC",
       "dependencies": {
         "@modelcontextprotocol/sdk": "git://github.com:dust-tt/typescript-sdk.git#bca26e405d6db2cf71fd7211234a72ecc46d0215",

--- a/extension/package.json
+++ b/extension/package.json
@@ -58,7 +58,7 @@
   "dependencies": {
     "@auth0/auth0-spa-js": "^2.1.3",
     "@datadog/browser-logs": "^6.13.0",
-    "@dust-tt/client": "^1.0.57",
+    "@dust-tt/client": "file:../sdks/js",
     "@dust-tt/sparkle": "^0.2.542",
     "@frontapp/plugin-sdk": "^1.8.1",
     "@modelcontextprotocol/sdk": "^1.9.0",

--- a/extension/package.json
+++ b/extension/package.json
@@ -58,7 +58,7 @@
   "dependencies": {
     "@auth0/auth0-spa-js": "^2.1.3",
     "@datadog/browser-logs": "^6.13.0",
-    "@dust-tt/client": "file:../sdks/js",
+    "@dust-tt/client": "^1.1.0",
     "@dust-tt/sparkle": "^0.2.542",
     "@frontapp/plugin-sdk": "^1.8.1",
     "@modelcontextprotocol/sdk": "^1.9.0",

--- a/extension/ui/components/assistants/state/messageReducer.ts
+++ b/extension/ui/components/assistants/state/messageReducer.ts
@@ -142,26 +142,11 @@ export function messageReducer(
             (newState.message.chainOfThought || "") + event.text;
           break;
         default:
-          assertNever(event);
+          assertNever(event.classification);
       }
       newState.agentState = "thinking";
       return newState;
     }
-
-    case "browse_params":
-    case "conversation_include_file_params":
-    case "dust_app_run_block":
-    case "dust_app_run_params":
-    case "process_params":
-    case "reasoning_started":
-    case "reasoning_thinking":
-    case "reasoning_tokens":
-    case "retrieval_params":
-    case "search_labels_params":
-    case "tables_query_model_output":
-    case "tables_query_output":
-    case "tables_query_started":
-    case "websearch_params":
     case "tool_params":
       return {
         ...state,

--- a/extension/ui/components/conversation/AgentMessage.tsx
+++ b/extension/ui/components/conversation/AgentMessage.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/no-unused-vars */
 import { usePlatform } from "@app/shared/context/PlatformContext";
 import { retryMessage } from "@app/shared/lib/conversation";
 import type { StoredUser } from "@app/shared/services/auth";
@@ -25,16 +24,12 @@ import {
 } from "@app/ui/components/markdown/MentionBlock";
 import { useSubmitFunction } from "@app/ui/components/utils/useSubmitFunction";
 import { useEventSource } from "@app/ui/hooks/useEventSource";
-import { useTheme } from "@app/ui/hooks/useTheme";
 import type {
   AgentMessagePublicType,
   LightWorkspaceType,
   RetrievalDocumentPublicType,
   SearchResultResourceType,
-  WebsearchActionPublicType,
-  WebsearchResultPublicType,
   WebsearchResultResourceType,
-  WorkspaceType,
 } from "@dust-tt/client";
 import {
   assertNever,
@@ -74,7 +69,6 @@ import {
   useState,
 } from "react";
 import type { Components } from "react-markdown";
-import type { ReactMarkdownProps } from "react-markdown/lib/complex-types";
 import type { PluggableList } from "react-markdown/lib/react-markdown";
 import { visit } from "unist-util-visit";
 
@@ -83,13 +77,7 @@ function cleanUpCitations(message: string): string {
   return message.replace(regex, "");
 }
 
-export const FeedbackSelectorPopoverContent = ({
-  owner,
-  agentMessageToRender,
-}: {
-  owner: WorkspaceType;
-  agentMessageToRender: AgentMessagePublicType;
-}) => {
+export const FeedbackSelectorPopoverContent = () => {
   return (
     <div className="mb-4 mt-2 flex flex-col gap-2">
       <Page.P variant="secondary">
@@ -181,7 +169,6 @@ export function AgentMessage({
 }: AgentMessageProps) {
   const platform = usePlatform();
   const sendNotification = useSendNotification();
-  const { theme } = useTheme();
 
   const [messageStreamState, dispatch] = useReducer(
     messageReducer,
@@ -220,10 +207,6 @@ export function AgentMessage({
         assertNever(messageStreamState.message.status);
     }
   })();
-
-  const [lastTokenClassification, setLastTokenClassification] = useState<
-    null | "tokens" | "chain_of_thought"
-  >(null);
 
   const buildEventSourceURL = useCallback(
     (lastEvent: string | null) => {
@@ -416,7 +399,7 @@ export function AgentMessage({
 
   const additionalMarkdownComponents: Components = useMemo(
     () => ({
-      visualization: (props: ReactMarkdownProps) => (
+      visualization: () => (
         <div className="w-full flex justify-center">
           <Button
             label="See visualization on Dust website"
@@ -445,13 +428,8 @@ export function AgentMessage({
   );
 
   const PopoverContent = useCallback(
-    () => (
-      <FeedbackSelectorPopoverContent
-        owner={owner}
-        agentMessageToRender={agentMessageToRender}
-      />
-    ),
-    [owner, agentMessageToRender]
+    () => <FeedbackSelectorPopoverContent />,
+    []
   );
 
   const buttons =
@@ -521,7 +499,8 @@ export function AgentMessage({
           agentMessage: agentMessageToRender,
           references: references,
           streaming: shouldStream,
-          lastTokenClassification: lastTokenClassification,
+          lastTokenClassification:
+            messageStreamState.agentState === "thinking" ? "tokens" : null,
         })}
       </div>
       {/* Invisible div to act as a scroll anchor for detecting when the user has scrolled to the bottom */}

--- a/extension/ui/components/conversation/AgentMessageActions.tsx
+++ b/extension/ui/components/conversation/AgentMessageActions.tsx
@@ -1,10 +1,9 @@
 import type { AgentStateClassification } from "@app/ui/components/conversation/AgentMessage";
 import type {
-  AgentActionPublicType,
   AgentMessagePublicType,
   LightWorkspaceType,
 } from "@dust-tt/client";
-import { assertNever } from "@dust-tt/client";
+import { assertNever, TOOL_RUNNING_LABEL } from "@dust-tt/client";
 import { Chip } from "@dust-tt/sparkle";
 import { useEffect, useMemo, useState } from "react";
 interface AgentMessageActionsProps {
@@ -12,20 +11,6 @@ interface AgentMessageActionsProps {
   lastAgentStateClassification: AgentStateClassification;
   owner: LightWorkspaceType;
 }
-
-const ACTION_RUNNING_LABELS: Record<AgentActionPublicType["type"], string> = {
-  dust_app_run_action: "Running App",
-  process_action: "Extracting data",
-  retrieval_action: "Searching data",
-  tables_query_action: "Querying tables",
-  websearch_action: "Searching the web",
-  browse_action: "Browsing page",
-  conversation_list_files_action: "Listing files",
-  conversation_include_file_action: "Including file ",
-  reasoning_action: "Reasoning",
-  search_labels_action: "Searching labels",
-  tool_action: "Calling an external tool",
-};
 
 export function AgentMessageActions({
   agentMessage,
@@ -40,7 +25,7 @@ export function AgentMessageActions({
         break;
       case "acting":
         if (agentMessage.actions.length > 0) {
-          setChipLabel(renderActionName(agentMessage.actions));
+          setChipLabel(TOOL_RUNNING_LABEL);
         }
         break;
       case "done":
@@ -96,21 +81,4 @@ function ActionDetails({
       </div>
     )
   );
-}
-
-function renderActionName(actions: AgentActionPublicType[]): string {
-  const uniqueActionTypes = actions.reduce(
-    (acc, action) => {
-      if (!acc.includes(action.type)) {
-        acc.push(action.type);
-      }
-
-      return acc;
-    },
-    [] as AgentActionPublicType["type"][]
-  );
-
-  return uniqueActionTypes
-    .map((actionType) => ACTION_RUNNING_LABELS[actionType])
-    .join(", ");
 }


### PR DESCRIPTION
## Description

Update the extension following the cleanup of the SDK done here: https://github.com/dust-tt/dust/pull/14411

Out of convenience I replaced the fixed version of the SDK by a local version `"file:../sdks/js"` as we do on front & connectors. I don't remember exactly the reason for which we wanted a fixed version, iirc it was for two reasons: 
- we had one issue one day with someone building the extension with an outdated local sdk. 
- it was a good reason to force us to keep the SDK updated. 

-> I'm not sure it was still worth it because it's much more convenient to use as is. WDYT? 

## Tests

Can use the extension locally and call agents with actions. 

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

- Merge https://github.com/dust-tt/dust/pull/14411
- Add a commit here to reuse the updated version of the SDK. 
- Merge this one.
- Later submit a new version of the extension. 
