### PR TITLE
[front] Improve error message component

### DIFF
--- a/front/components/assistant/conversation/ErrorMessage.tsx
+++ b/front/components/assistant/conversation/ErrorMessage.tsx
@@ -61,7 +61,7 @@ export function ErrorMessage({ error, retryHandler }: ErrorMessageProps) {
           }
           content={
             <div className="flex flex-col gap-3">
-              <div className="whitespace-normal text-sm font-normal text-warning-800">
+              <div className="whitespace-normal text-sm font-normal text-warning">
                 {debugInfo}
               </div>
               <div className="self-end">

--- a/front/components/assistant/conversation/ErrorMessage.tsx
+++ b/front/components/assistant/conversation/ErrorMessage.tsx
@@ -4,6 +4,7 @@ import {
   ContentMessage,
   DocumentPileIcon,
   EyeIcon,
+  InformationCircleIcon,
   Popover,
 } from "@dust-tt/sparkle";
 
@@ -38,6 +39,7 @@ export function ErrorMessage({ error, retryHandler }: ErrorMessageProps) {
       title={`${error.metadata?.errorTitle || "Agent error"}`}
       variant={errorIsRetryable ? "golden" : "warning"}
       className="flex flex-col gap-3"
+      icon={InformationCircleIcon}
     >
       <div className="whitespace-normal break-words">{error.message}</div>
       <div className="flex flex-col gap-2 pt-3 sm:flex-row">

--- a/front/components/assistant/conversation/ErrorMessage.tsx
+++ b/front/components/assistant/conversation/ErrorMessage.tsx
@@ -60,9 +60,7 @@ export function ErrorMessage({ error, retryHandler }: ErrorMessageProps) {
       variant={errorIsRetryable ? "golden" : "warning"}
       className="flex flex-col gap-3"
     >
-      <div className="whitespace-normal break-words">
-        {fullMessage}
-      </div>
+      <div className="whitespace-normal break-words">{fullMessage}</div>
       <div className="flex flex-col gap-2 sm:flex-row">
         <Button
           variant="outline"

--- a/front/components/assistant/conversation/ErrorMessage.tsx
+++ b/front/components/assistant/conversation/ErrorMessage.tsx
@@ -72,7 +72,7 @@ export function ErrorMessage({ error, retryHandler }: ErrorMessageProps) {
                   label={"Copy"}
                   onClick={() =>
                     void navigator.clipboard.writeText(
-                      error.message + debugInfo ? ` (${debugInfo})` : ""
+                      error.message + (debugInfo ? ` (${debugInfo})` : "")
                     )
                   }
                 />

--- a/front/components/assistant/conversation/ErrorMessage.tsx
+++ b/front/components/assistant/conversation/ErrorMessage.tsx
@@ -17,13 +17,17 @@ interface ErrorMessageProps {
 }
 
 export function ErrorMessage({ error, retryHandler }: ErrorMessageProps) {
-  const fullMessage =
-    error.message + (error.code ? ` (code: ${error.code})` : "");
-
   const errorIsRetryable =
     isAgentErrorCategory(error.metadata?.category) &&
     (error.metadata?.category === "retryable_model_error" ||
       error.metadata?.category === "stream_error");
+
+  const debugInfo = [
+    error.metadata?.category ? `category: ${error.metadata?.category}` : "",
+    error.code ? `code: ${error.code}` : "",
+  ]
+    .filter((s) => s.length > 0)
+    .join(", ");
 
   const { submit: retry, isSubmitting: isRetrying } = useSubmitFunction(
     async () => retryHandler()
@@ -35,8 +39,8 @@ export function ErrorMessage({ error, retryHandler }: ErrorMessageProps) {
       variant={errorIsRetryable ? "golden" : "warning"}
       className="flex flex-col gap-3"
     >
-      <div className="whitespace-normal break-words">{fullMessage}</div>
-      <div className="flex flex-col gap-2 sm:flex-row pt-3">
+      <div className="whitespace-normal break-words">{error.message}</div>
+      <div className="flex flex-col gap-2 pt-3 sm:flex-row">
         <Button
           variant="outline"
           size="sm"
@@ -57,8 +61,8 @@ export function ErrorMessage({ error, retryHandler }: ErrorMessageProps) {
           }
           content={
             <div className="flex flex-col gap-3">
-              <div className="whitespace-normal break-words text-sm font-normal text-warning-800">
-                {fullMessage}
+              <div className="whitespace-normal text-sm font-normal text-warning-800">
+                {debugInfo}
               </div>
               <div className="self-end">
                 <Button
@@ -67,7 +71,9 @@ export function ErrorMessage({ error, retryHandler }: ErrorMessageProps) {
                   icon={DocumentPileIcon}
                   label={"Copy"}
                   onClick={() =>
-                    void navigator.clipboard.writeText(fullMessage)
+                    void navigator.clipboard.writeText(
+                      error.message + debugInfo ? ` (${debugInfo})` : ""
+                    )
                   }
                 />
               </div>

--- a/front/components/assistant/conversation/ErrorMessage.tsx
+++ b/front/components/assistant/conversation/ErrorMessage.tsx
@@ -56,7 +56,7 @@ export function ErrorMessage({ error, retryHandler }: ErrorMessageProps) {
               variant="outline"
               size="xs"
               icon={EyeIcon}
-              label="See the error"
+              label="Details"
             />
           }
           content={

--- a/front/components/assistant/conversation/ErrorMessage.tsx
+++ b/front/components/assistant/conversation/ErrorMessage.tsx
@@ -43,7 +43,7 @@ export function ErrorMessage({ error, retryHandler }: ErrorMessageProps) {
       <div className="flex flex-col gap-2 pt-3 sm:flex-row">
         <Button
           variant="outline"
-          size="sm"
+          size="xs"
           icon={ArrowPathIcon}
           label="Retry"
           onClick={retry}
@@ -54,7 +54,7 @@ export function ErrorMessage({ error, retryHandler }: ErrorMessageProps) {
           trigger={
             <Button
               variant="outline"
-              size="sm"
+              size="xs"
               icon={EyeIcon}
               label="See the error"
             />

--- a/front/components/assistant/conversation/ErrorMessage.tsx
+++ b/front/components/assistant/conversation/ErrorMessage.tsx
@@ -16,29 +16,6 @@ interface ErrorMessageProps {
   retryHandler: () => void;
 }
 
-function getErrorTitle(error: AgentErrorContent): string | undefined {
-  if (!isAgentErrorCategory(error.metadata?.category)) {
-    return undefined;
-  }
-
-  switch (error.metadata?.category) {
-    case "retryable_model_error":
-      return "Model Error";
-    case "context_window_exceeded":
-      return "Context Window Exceeded";
-    case "provider_internal_error":
-      return "Provider Internal Error";
-    case "stream_error":
-      return "Stream Error";
-    case "unknown_error":
-      return "Unknown Error";
-    case "invalid_response_format_configuration":
-      return "Invalid Response Format Configuration";
-    default:
-      return undefined;
-  }
-}
-
 export function ErrorMessage({ error, retryHandler }: ErrorMessageProps) {
   const fullMessage =
     error.message + (error.code ? ` (code: ${error.code})` : "");
@@ -52,11 +29,9 @@ export function ErrorMessage({ error, retryHandler }: ErrorMessageProps) {
     async () => retryHandler()
   );
 
-  const errorTitle = getErrorTitle(error) || "Error";
-
   return (
     <ContentMessage
-      title={errorTitle}
+      title={`${error.metadata?.errorTitle || "Agent error"}`}
       variant={errorIsRetryable ? "golden" : "warning"}
       className="flex flex-col gap-3"
     >

--- a/front/components/assistant/conversation/ErrorMessage.tsx
+++ b/front/components/assistant/conversation/ErrorMessage.tsx
@@ -61,7 +61,7 @@ export function ErrorMessage({ error, retryHandler }: ErrorMessageProps) {
       className="flex flex-col gap-3"
     >
       <div className="whitespace-normal break-words">{fullMessage}</div>
-      <div className="flex flex-col gap-2 sm:flex-row">
+      <div className="flex flex-col gap-2 sm:flex-row pt-3">
         <Button
           variant="outline"
           size="sm"

--- a/front/lib/api/assistant/agent.ts
+++ b/front/lib/api/assistant/agent.ts
@@ -233,9 +233,8 @@ async function runMultiActionsAgentLoop(
         for await (const event of loopIterationStream) {
           switch (event.type) {
             case "agent_error":
-              const { category, publicMessage } = categorizeAgentErrorMessage(
-                event.error
-              );
+              const { category, errorTitle, publicMessage } =
+                categorizeAgentErrorMessage(event.error);
 
               shouldRetry = ["stream_error", "retryable_model_error"].includes(
                 category
@@ -260,6 +259,7 @@ async function runMultiActionsAgentLoop(
                       message: publicMessage,
                       metadata: {
                         category,
+                        errorTitle,
                       },
                     },
                   },

--- a/front/lib/api/assistant/agent_errors.ts
+++ b/front/lib/api/assistant/agent_errors.ts
@@ -22,6 +22,7 @@ export const categorizeAgentErrorMessage = (error: {
   code: string;
 }): {
   category: AgentErrorCategory;
+  errorTitle: string;
   publicMessage: string;
 } => {
   if (error.code == "multi_actions_error") {
@@ -32,6 +33,7 @@ export const categorizeAgentErrorMessage = (error: {
       ) {
         return {
           category: "retryable_model_error",
+          errorTitle: "Anthropic service disruption",
           publicMessage:
             "Anthropic is currently experiencing issues and cannot process requests for " +
             "this model. You can temporarily switch your agent to use a different model " +
@@ -43,12 +45,14 @@ export const categorizeAgentErrorMessage = (error: {
       ) {
         return {
           category: "context_window_exceeded",
+          errorTitle: "Context limit exceeded",
           publicMessage:
             "Context window (the amount of data the agent can process) exceeded. This can happen if your first message was very long or if the agent retrieved a lot of data while helping you. Try breaking your request into smaller parts or updating your agent configuration to output less data.",
         };
       } else if (error.message.includes("Internal server error")) {
         return {
           category: "provider_internal_error",
+          errorTitle: "Anthropic server error",
           publicMessage:
             "Anthropic (provider of Claude) encountered an internal server error. Please try again.",
         };
@@ -57,6 +61,7 @@ export const categorizeAgentErrorMessage = (error: {
       if (error.message.includes("maximum context length")) {
         return {
           category: "context_window_exceeded",
+          errorTitle: "Context limit exceeded",
           publicMessage:
             "Context window (the amount of data the agent can process) exceeded. This can happen if your first message was very long or if the agent retrieved a lot of data while helping you. Try breaking your request into smaller parts or updating your agent configuration to output less data.",
         };
@@ -64,11 +69,13 @@ export const categorizeAgentErrorMessage = (error: {
         const contextPart = error.message.split("In context=")[1];
         return {
           category: "invalid_response_format_configuration",
+          errorTitle: "Invalid response format",
           publicMessage: `Your agent is configured to return a response in a format that is not supported by the model: ${contextPart}. Please update your agent configuration in Instructions > Advanced Settings > Structured Response Format.`,
         };
       } else if (error.message.includes("server_error")) {
         return {
           category: "provider_internal_error",
+          errorTitle: "OpenAI server error",
           publicMessage:
             "OpenAI (provider of GPT) encountered an internal server error. Please try again.",
         };
@@ -79,6 +86,7 @@ export const categorizeAgentErrorMessage = (error: {
     ) {
       return {
         category: "stream_error",
+        errorTitle: "Streaming error",
         publicMessage:
           "There was an error streaming the answer to your query. Please try again.",
       };
@@ -87,6 +95,7 @@ export const categorizeAgentErrorMessage = (error: {
   // The original message is used as a fallback.
   return {
     category: "unknown_error",
+    errorTitle: "Agent error",
     publicMessage: `Error running agent: [${error.code}] ${error.message}`,
   };
 };

--- a/front/lib/api/assistant/agent_errors.ts
+++ b/front/lib/api/assistant/agent_errors.ts
@@ -1,5 +1,10 @@
 import type { AgentErrorCategory } from "@app/types";
 
+const CONTEXT_WINDOW_EXCEEDED_TITLE = "Context window exceeded";
+const CONTEXT_WINDOW_EXCEEDED_MESSAGE =
+  "Your message or retrieved data is too large. " +
+  "Break your request into smaller parts or reduce agent output.";
+
 /**
  * Get a user-friendly error message from an API error.
  * This function handles various error cases from different model providers (Anthropic, OpenAI)
@@ -36,8 +41,7 @@ export const categorizeAgentErrorMessage = (error: {
           errorTitle: "Anthropic service disruption",
           publicMessage:
             "Anthropic is currently experiencing issues and cannot process requests for " +
-            "this model. You can temporarily switch your agent to use a different model " +
-            "(like GPT-4.1) in the agent settings to continue working.",
+            "this model. You can temporarily switch to a different model such as GPT-4.1.",
         };
       } else if (
         error.message.includes("at least one message is required") ||
@@ -45,39 +49,39 @@ export const categorizeAgentErrorMessage = (error: {
       ) {
         return {
           category: "context_window_exceeded",
-          errorTitle: "Context limit exceeded",
-          publicMessage:
-            "Context window (the amount of data the agent can process) exceeded. This can happen if your first message was very long or if the agent retrieved a lot of data while helping you. Try breaking your request into smaller parts or updating your agent configuration to output less data.",
+          errorTitle: CONTEXT_WINDOW_EXCEEDED_TITLE,
+          publicMessage: CONTEXT_WINDOW_EXCEEDED_MESSAGE,
         };
       } else if (error.message.includes("Internal server error")) {
         return {
           category: "provider_internal_error",
           errorTitle: "Anthropic server error",
           publicMessage:
-            "Anthropic (provider of Claude) encountered an internal server error. Please try again.",
+            "Anthropic (Claude's provider) encountered an error. Please try again.",
         };
       }
     } else if (error.message.includes("OpenAIError")) {
       if (error.message.includes("maximum context length")) {
         return {
           category: "context_window_exceeded",
-          errorTitle: "Context limit exceeded",
-          publicMessage:
-            "Context window (the amount of data the agent can process) exceeded. This can happen if your first message was very long or if the agent retrieved a lot of data while helping you. Try breaking your request into smaller parts or updating your agent configuration to output less data.",
+          errorTitle: CONTEXT_WINDOW_EXCEEDED_TITLE,
+          publicMessage: CONTEXT_WINDOW_EXCEEDED_MESSAGE,
         };
       } else if (error.message.includes("Invalid schema for response_format")) {
         const contextPart = error.message.split("In context=")[1];
         return {
           category: "invalid_response_format_configuration",
           errorTitle: "Invalid response format",
-          publicMessage: `Your agent is configured to return a response in a format that is not supported by the model: ${contextPart}. Please update your agent configuration in Instructions > Advanced Settings > Structured Response Format.`,
+          publicMessage:
+            "Your agent is configured to return a response in a format that is not supported by " +
+            `the model: ${contextPart}. Please update your agent configuration in Instructions > ` +
+            "Advanced Settings > Structured Response Format.",
         };
       } else if (error.message.includes("server_error")) {
         return {
           category: "provider_internal_error",
           errorTitle: "OpenAI server error",
-          publicMessage:
-            "OpenAI (provider of GPT) encountered an internal server error. Please try again.",
+          publicMessage: "OpenAI encountered an error. Please try again.",
         };
       }
     } else if (
@@ -88,7 +92,7 @@ export const categorizeAgentErrorMessage = (error: {
         category: "stream_error",
         errorTitle: "Streaming error",
         publicMessage:
-          "There was an error streaming the answer to your query. Please try again.",
+          "Connection interrupted while receiving your answer. Please try again.",
       };
     }
   }


### PR DESCRIPTION
## Description

- This PR improves the `ErrorMessage` component by using a `ContentMessage` rather than a `Chip`.
- This change allows adding a title and showing the message in its entirety.
- The messages were shortened to fit better this use.

<img width="425" height="171" alt="Screenshot 2025-07-18 at 11 57 30 AM" src="https://github.com/user-attachments/assets/22910cfd-836a-4419-b71e-f86a4bf9383d" />

The debug information with the error code was moved to the "See the error" button (renamed into "Details"), which now contains less information.

<img width="425" height="240" alt="Screenshot 2025-07-18 at 11 57 40 AM" src="https://github.com/user-attachments/assets/c87a82ac-be54-41ba-8c15-f7a4cc04a642" />

## Tests

- Checked locally.

## Risk

- Low, only UI change.

## Deploy Plan

- Deploy front.
