### PR TITLE
[front] Add a log to track successful retries

### DIFF
--- a/front/lib/api/assistant/agent.ts
+++ b/front/lib/api/assistant/agent.ts
@@ -220,6 +220,7 @@ async function runMultiActionsAgentLoop(
       let autoRetryCount = 0;
 
       do {
+        shouldRetry = false;
         const loopIterationStream = runMultiActionsAgent(auth.toJSON(), {
           agentConfiguration: configuration,
           conversation,
@@ -390,6 +391,17 @@ async function runMultiActionsAgentLoop(
               agentMessage.status = "succeeded";
 
               runIds.push(event.runId);
+
+              // Log to track retries that lead to completing successfully.
+              if (autoRetryCount > 0) {
+                localLogger.error(
+                  {
+                    elapsedTime: Date.now() - now,
+                    autoRetryCount,
+                  },
+                  "Multi-actions agent successfully completed after auto-retry."
+                );
+              }
 
               return updateResourceAndPublishEvent(
                 {


### PR DESCRIPTION
## Description

- This PR adds a log that tracks successful steps that have completed after an auto-retry.
- The goal is to have a metric of how useful the retry is, and more importantly to track the number of retries that were necessary to succeed. This will help tune the max number of retries.

## Tests

- Tested locally with the sampling described in https://github.com/dust-tt/dust/pull/14350 (the patch is provided in the PR description).

## Risk

- Low.

## Deploy Plan

- Deploy front.
