### PR TITLE
[Durable Agents] Push all event publication from runMultiActionsAgentLoop to runMultiActionsAgent

### DIFF
--- a/front/lib/api/assistant/agent.ts
+++ b/front/lib/api/assistant/agent.ts
@@ -364,9 +364,7 @@ async function runMultiActionsAgent(
         conversationId: conversation.sId,
         configurationId: agentConfiguration.sId,
         messageId: agentMessage.sId,
-        errorCode: error.code,
-        errorMessage: error.message,
-        errorMetadata: error.metadata,
+        error,
       },
       `Agent error: ${error.message}`
     );

--- a/front/lib/api/assistant/agent.ts
+++ b/front/lib/api/assistant/agent.ts
@@ -48,6 +48,7 @@ import { MCPServerViewResource } from "@app/lib/resources/mcp_server_view_resour
 import { generateRandomModelSId } from "@app/lib/resources/string_ids";
 import { wakeLock } from "@app/lib/wake_lock";
 import logger from "@app/logger/logger";
+import { statsDClient } from "@app/logger/statsDClient";
 import { launchUpdateUsageWorkflow } from "@app/temporal/usage_queue/client";
 import type {
   AgentActionsEvent,
@@ -959,6 +960,12 @@ async function runMultiActionsAgent(
     await agentMessageRow.update({
       status: "succeeded",
     });
+    // Track retries that lead to completing successfully.
+    if (autoRetryCount > 0) {
+      statsDClient.increment("successful_auto_retry.count", 1, [
+        `retryCount:${autoRetryCount}`,
+      ]);
+    }
 
     return null;
   }

--- a/front/lib/api/assistant/agent.ts
+++ b/front/lib/api/assistant/agent.ts
@@ -300,7 +300,7 @@ async function runMultiActionsAgentLoop(
         configurationId: configuration.sId,
         messageId: agentMessage.sId,
         message: agentMessage,
-        runIds: runIds,
+        runIds,
       },
       conversation,
       agentMessageRow
@@ -361,9 +361,16 @@ async function runMultiActionsAgent(
   }): Promise<void> {
     // Check if this is a multi_actions_error that hit max retries
     let logMessage = `Agent error: ${error.message}`;
-    if (error.code === "multi_actions_error" && error.metadata?.retriesAttempted === MAX_AUTO_RETRY) {
+    if (
+      error.code === "multi_actions_error" &&
+      error.metadata?.retriesAttempted === MAX_AUTO_RETRY
+    ) {
       logMessage = `Agent error: ${error.message} (max retries reached)`;
-    } else if (error.code === "multi_actions_error" && error.metadata?.category && error.metadata.category !== "retryable_model_error") {
+    } else if (
+      error.code === "multi_actions_error" &&
+      error.metadata?.category &&
+      error.metadata.category !== "retryable_model_error"
+    ) {
       logMessage = `Agent error: ${error.message} (not retryable)`;
     }
 
@@ -390,7 +397,7 @@ async function runMultiActionsAgent(
       agentMessageRow
     );
   }
-  
+
   // Helper function to flush all pending tokens from the content parser
   async function flushParserTokens(): Promise<void> {
     for await (const tokenEvent of contentParser.flushTokens()) {
@@ -927,6 +934,7 @@ async function runMultiActionsAgent(
   // These will be added to agentMessage.contents in the calling function
 
   if (!output.actions.length) {
+    // Successful generation.
     const processedContent = contentParser.getContent() ?? "";
     if (!processedContent.length) {
       logger.warn(
@@ -955,7 +963,7 @@ async function runMultiActionsAgent(
         configurationId: agentConfiguration.sId,
         messageId: agentMessage.sId,
         message: agentMessage,
-        runIds: runIds,
+        runIds,
       },
       conversation,
       agentMessageRow

--- a/front/lib/api/assistant/agent.ts
+++ b/front/lib/api/assistant/agent.ts
@@ -927,6 +927,19 @@ async function runMultiActionsAgent(
       ]);
     }
 
+    // TODO(DURABLE-AGENTS 2025-07-20): Avoid mutating agentMessage here
+    const chainOfThought =
+      (nativeChainOfThought || contentParser.getChainOfThought()) ?? "";
+
+    if (chainOfThought.length) {
+      if (!agentMessage.chainOfThought) {
+        agentMessage.chainOfThought = "";
+      }
+      agentMessage.chainOfThought += chainOfThought;
+    }
+    agentMessage.content = (agentMessage.content ?? "") + processedContent;
+    agentMessage.status = "succeeded";
+
     await updateResourceAndPublishEvent(
       {
         type: "agent_message_success",
@@ -939,19 +952,6 @@ async function runMultiActionsAgent(
       conversation,
       agentMessageRow
     );
-
-    // TODO(DURABLE-AGENTS 2025-07-20): Avoid mutating agentMessage here
-    const chainOfThought =
-      (nativeChainOfThought || contentParser.getChainOfThought()) ?? "";
-
-    if (chainOfThought.length) {
-      if (!agentMessage.chainOfThought) {
-        agentMessage.chainOfThought = "";
-      }
-      agentMessage.chainOfThought += chainOfThought;
-    }
-    agentMessage.content += processedContent;
-    agentMessage.status = "succeeded";
 
     return null;
   }
@@ -1071,7 +1071,8 @@ async function runMultiActionsAgent(
   const chainOfThought =
     (nativeChainOfThought || contentParser.getChainOfThought()) ?? "";
 
-  agentMessage.content += contentParser.getContent() ?? "";
+  agentMessage.content =
+    (agentMessage.content ?? "") + (contentParser.getContent() ?? "");
 
   if (chainOfThought.length) {
     if (!agentMessage.chainOfThought) {

--- a/front/lib/api/assistant/agent.ts
+++ b/front/lib/api/assistant/agent.ts
@@ -357,7 +357,7 @@ async function runMultiActionsAgent(
   async function publishAgentError(error: {
     code: string;
     message: string;
-    metadata: any;
+    metadata: Record<string, string | number | boolean> | null;
   }): Promise<void> {
     logger.error(
       {

--- a/front/lib/api/assistant/agent.ts
+++ b/front/lib/api/assistant/agent.ts
@@ -47,7 +47,6 @@ import { MCPServerViewResource } from "@app/lib/resources/mcp_server_view_resour
 import { generateRandomModelSId } from "@app/lib/resources/string_ids";
 import { wakeLock } from "@app/lib/wake_lock";
 import logger from "@app/logger/logger";
-import { statsDClient } from "@app/logger/statsDClient";
 import { launchUpdateUsageWorkflow } from "@app/temporal/usage_queue/client";
 import type {
   AgentActionsEvent,
@@ -350,7 +349,7 @@ async function runMultiActionsAgent(
 
   const model = getSupportedModelConfig(agentConfiguration.model);
   
-  let autoRetryCount = 0;
+  const autoRetryCount = 0;
   let isRetryableModelError = false;
 
   if (!model) {

--- a/front/lib/api/assistant/agent.ts
+++ b/front/lib/api/assistant/agent.ts
@@ -1073,12 +1073,14 @@ async function runMultiActionsAgent(
     (nativeChainOfThought || contentParser.getChainOfThought()) ?? "";
 
   agentMessage.content += contentParser.getContent() ?? "";
+
   if (chainOfThought.length) {
     if (!agentMessage.chainOfThought) {
       agentMessage.chainOfThought = "";
     }
     agentMessage.chainOfThought += chainOfThought;
   }
+
   const newContents = output.contents.map((content) => ({
     step,
     content,

--- a/front/lib/api/assistant/agent.ts
+++ b/front/lib/api/assistant/agent.ts
@@ -185,7 +185,6 @@ async function runMultiActionsAgentLoop(
   // Citations references offset kept up to date across steps.
   let citationsRefsOffset = 0;
 
-  let processedContent = "";
   const runIds: string[] = [];
 
   // Track step content IDs by function call ID for later use in actions.
@@ -231,7 +230,6 @@ async function runMultiActionsAgentLoop(
       }
 
       // Update state with results from runMultiActionsAgent
-      processedContent = result.processedContent;
       runIds.push(result.runId);
       functionCallStepContentIds = result.functionCallStepContentIds;
       agentMessage.contents.push(...result.newContents);
@@ -327,7 +325,6 @@ async function runMultiActionsAgent(
 ): Promise<{
   actions: AgentActionsEvent["actions"];
   runId: string;
-  processedContent: string;
   functionCallStepContentIds: Record<string, ModelId>;
   newContents: { step: number; content: AgentContentItemType }[];
   chainOfThought?: string;
@@ -963,7 +960,7 @@ async function runMultiActionsAgent(
       }
       agentMessage.chainOfThought += chainOfThought;
     }
-    agentMessage.content = processedContent;
+    agentMessage.content += processedContent;
     agentMessage.status = "succeeded";
 
     return null;
@@ -1084,12 +1081,12 @@ async function runMultiActionsAgent(
   const chainOfThought =
     (nativeChainOfThought || contentParser.getChainOfThought()) ?? "";
 
+  agentMessage.content += contentParser.getContent() ?? "";
   // Chain of thought is stored in the result and will be added to agentMessage
   // in the calling function
   return {
     actions,
     runId: await dustRunId,
-    processedContent: contentParser.getContent() ?? "",
     functionCallStepContentIds: updatedFunctionCallStepContentIds,
     newContents: output.contents.map((content) => ({
       step,

--- a/front/lib/api/assistant/agent.ts
+++ b/front/lib/api/assistant/agent.ts
@@ -284,8 +284,8 @@ async function runMultiActionsAgentLoop(
 // This method is used by the multi-actions execution loop to pick the next
 // action to execute and generate its inputs.
 //
-// TODO(DURABLE-AGENTS 2025-07-20): The method mutates agentMessage,we should
-// find a way to avoid this.
+// TODO(DURABLE-AGENTS 2025-07-20): The method mutates agentMessage, this must
+// be refactored in a follow up PR.
 async function runMultiActionsAgent(
   authType: AuthenticatorType,
   {

--- a/front/lib/api/assistant/agent.ts
+++ b/front/lib/api/assistant/agent.ts
@@ -62,7 +62,6 @@ import type {
 } from "@app/types";
 import { assertNever, removeNulls } from "@app/types";
 import type {
-  AgentContentItemType,
   FunctionCallContentType,
   ReasoningContentType,
   TextContentType,
@@ -928,7 +927,7 @@ async function runMultiActionsAgent(
       ]);
     }
 
-    updateResourceAndPublishEvent(
+    await updateResourceAndPublishEvent(
       {
         type: "agent_message_success",
         created: Date.now(),

--- a/front/lib/api/assistant/agent.ts
+++ b/front/lib/api/assistant/agent.ts
@@ -232,7 +232,7 @@ async function runMultiActionsAgentLoop(
 
       // Update state with results from runMultiActionsAgent
       processedContent = result.processedContent;
-      runIds.push(...result.runIds);
+      runIds.push(result.runId);
       functionCallStepContentIds = result.functionCallStepContentIds;
       agentMessage.contents.push(...result.newContents);
       if (result.chainOfThought) {
@@ -343,7 +343,6 @@ async function runMultiActionsAgent(
   actions: AgentActionsEvent["actions"];
   runId: string;
   processedContent: string;
-  runIds: string[];
   functionCallStepContentIds: Record<string, ModelId>;
   newContents: { step: number; content: AgentContentItemType }[];
   chainOfThought?: string;
@@ -963,7 +962,7 @@ async function runMultiActionsAgent(
         configurationId: agentConfiguration.sId,
         messageId: agentMessage.sId,
         message: agentMessage,
-        runIds,
+        runIds: [...runIds, await dustRunId],
       },
       conversation,
       agentMessageRow
@@ -981,8 +980,6 @@ async function runMultiActionsAgent(
     }
     agentMessage.content = processedContent;
     agentMessage.status = "succeeded";
-
-    runIds.push(runId);
 
     return null;
   }
@@ -1104,15 +1101,10 @@ async function runMultiActionsAgent(
 
   // Chain of thought is stored in the result and will be added to agentMessage
   // in the calling function
-
-  // Raw content is included in the result to be processed by the caller
-
-  // Return the result with all necessary data
   return {
     actions,
     runId: await dustRunId,
     processedContent: contentParser.getContent() ?? "",
-    runIds,
     functionCallStepContentIds: updatedFunctionCallStepContentIds,
     newContents: output.contents.map((content) => ({
       step,

--- a/front/lib/api/assistant/agent.ts
+++ b/front/lib/api/assistant/agent.ts
@@ -232,13 +232,6 @@ async function runMultiActionsAgentLoop(
       // Update state with results from runMultiActionsAgent
       runIds.push(result.runId);
       functionCallStepContentIds = result.functionCallStepContentIds;
-      agentMessage.contents.push(...result.newContents);
-      if (result.chainOfThought) {
-        if (!agentMessage.chainOfThought) {
-          agentMessage.chainOfThought = "";
-        }
-        agentMessage.chainOfThought += result.chainOfThought;
-      }
 
       // We have actions to run
       localLogger.info(
@@ -326,8 +319,6 @@ async function runMultiActionsAgent(
   actions: AgentActionsEvent["actions"];
   runId: string;
   functionCallStepContentIds: Record<string, ModelId>;
-  newContents: { step: number; content: AgentContentItemType }[];
-  chainOfThought?: string;
 } | null> {
   // Recreate the Authenticator instance from the serialized type
   const auth = await Authenticator.fromJSON(authType);
@@ -1088,14 +1079,15 @@ async function runMultiActionsAgent(
     }
     agentMessage.chainOfThought += chainOfThought;
   }
+  const newContents = output.contents.map((content) => ({
+    step,
+    content,
+  }));
+  agentMessage.contents.push(...newContents);
   return {
     actions,
     runId: await dustRunId,
     functionCallStepContentIds: updatedFunctionCallStepContentIds,
-    newContents: output.contents.map((content) => ({
-      step,
-      content,
-    })),
   };
 }
 

--- a/front/lib/api/assistant/agent.ts
+++ b/front/lib/api/assistant/agent.ts
@@ -287,29 +287,14 @@ async function runMultiActionsAgentLoop(
         });
       }
     }
-
-    // Update final agent message state
-    agentMessage.content = processedContent;
-    agentMessage.status = "succeeded";
-
-    // Publish success event
-    await updateResourceAndPublishEvent(
-      {
-        type: "agent_message_success",
-        created: Date.now(),
-        configurationId: configuration.sId,
-        messageId: agentMessage.sId,
-        message: agentMessage,
-        runIds,
-      },
-      conversation,
-      agentMessageRow
-    );
   });
 }
 
-// This method is used by the multi-actions execution loop to pick the next action to execute and
-// generate its inputs.
+// This method is used by the multi-actions execution loop to pick the next
+// action to execute and generate its inputs.
+//
+// TODO(DURABLE-AGENTS 2025-07-20): The method mutates agentMessage,we should
+// find a way to avoid this.
 async function runMultiActionsAgent(
   authType: AuthenticatorType,
   {

--- a/front/lib/api/assistant/agent.ts
+++ b/front/lib/api/assistant/agent.ts
@@ -927,7 +927,7 @@ async function runMultiActionsAgent(
       agentMessageId: agentMessage.agentMessageId,
       step,
       index,
-      version: 0,
+      version: autoRetryCount,
       type: content.type,
       value: content,
     });

--- a/front/lib/api/assistant/agent.ts
+++ b/front/lib/api/assistant/agent.ts
@@ -1082,8 +1082,12 @@ async function runMultiActionsAgent(
     (nativeChainOfThought || contentParser.getChainOfThought()) ?? "";
 
   agentMessage.content += contentParser.getContent() ?? "";
-  // Chain of thought is stored in the result and will be added to agentMessage
-  // in the calling function
+  if (chainOfThought.length) {
+    if (!agentMessage.chainOfThought) {
+      agentMessage.chainOfThought = "";
+    }
+    agentMessage.chainOfThought += chainOfThought;
+  }
   return {
     actions,
     runId: await dustRunId,
@@ -1092,7 +1096,6 @@ async function runMultiActionsAgent(
       step,
       content,
     })),
-    chainOfThought,
   };
 }
 


### PR DESCRIPTION
## Description
Fixes https://github.com/dust-tt/tasks/issues/3439

This PR continues the work from #14331 and #14332 to push event publication further down the call stack as part of the Durable Agents architecture.

The key change is converting `runMultiActionsAgent` from an async generator to a regular async function that returns actions or null, moving all event publishing out of `runMultiActionsAgentLoop`.

In the process, the rawContent, that seemed unused, was removed. The `agent_message_contents` and `processedContent` variable in the global loop were replaced by incremental updates of agentMessage.content.

## Risks
Blast radius: Agent execution flow for multi-action agents
Risk: standard-high

## Deploy Plan
- Deploy front service