### PR TITLE
[front] Refactor `AgentMCPAction` versioning around `AgentStepContentResource`

### DIFF
--- a/front/lib/actions/mcp.ts
+++ b/front/lib/actions/mcp.ts
@@ -234,7 +234,7 @@ export type ActionBaseParams = Omit<
   "id" | "type" | "executionState" | "output" | "isError"
 >;
 
-function hideFileFromActionOutput({
+export function hideFileFromActionOutput({
   fileId,
   content,
   workspaceId,
@@ -1171,44 +1171,4 @@ async function handleBase64Upload(
       file: null,
     };
   }
-}
-
-/**
- * Action rendering.
- */
-
-export function renderAgentMCPAction(action: AgentMCPAction): MCPActionType {
-  return new MCPActionType({
-    id: action.id,
-    params: action.params,
-    output: removeNulls(action.outputItems.map(hideFileFromActionOutput)),
-    functionCallId: action.functionCallId,
-    functionCallName: action.functionCallName,
-    agentMessageId: action.agentMessageId,
-    step: action.step,
-    mcpServerConfigurationId: action.mcpServerConfigurationId,
-    executionState: action.executionState,
-    isError: action.isError,
-    type: "tool_action",
-    generatedFiles: removeNulls(
-      action.outputItems.map((o) => {
-        if (!o.file) {
-          return null;
-        }
-
-        const file = o.file;
-        const fileSid = FileResource.modelIdToSId({
-          id: file.id,
-          workspaceId: action.workspaceId,
-        });
-
-        return {
-          fileId: fileSid,
-          contentType: file.contentType,
-          title: file.fileName,
-          snippet: file.snippet,
-        };
-      })
-    ),
-  });
 }

--- a/front/lib/actions/mcp.ts
+++ b/front/lib/actions/mcp.ts
@@ -61,7 +61,6 @@ import {
   AgentMCPActionOutputItem,
 } from "@app/lib/models/assistant/actions/mcp";
 import { FileResource } from "@app/lib/resources/file_resource";
-import { FileModel } from "@app/lib/resources/storage/models/files";
 import { getResourceIdFromSId, makeSId } from "@app/lib/resources/string_ids";
 import { concurrentExecutor } from "@app/lib/utils/async_utils";
 import logger from "@app/logger/logger";
@@ -92,7 +91,6 @@ import {
   removeNulls,
   stripNullBytes,
 } from "@app/types";
-import { AgentMCPActionType } from "@app/types/assistant/agent_message_content";
 
 const MAX_BLOB_SIZE_BYTES = 1024 * 1024 * 10; // 10MB
 
@@ -1179,17 +1177,14 @@ async function handleBase64Upload(
  * Action rendering.
  */
 
-export function renderAgentMCPAction(
-  auth: Authenticator,
-  action: AgentMCPActionType
-): MCPActionType {
+export function renderAgentMCPAction(action: AgentMCPAction): MCPActionType {
   return new MCPActionType({
     id: action.id,
     params: action.params,
     output: removeNulls(action.outputItems.map(hideFileFromActionOutput)),
     functionCallId: action.functionCallId,
     functionCallName: action.functionCallName,
-    agentMessageId: action.agentMessageModelId,
+    agentMessageId: action.agentMessageId,
     step: action.step,
     mcpServerConfigurationId: action.mcpServerConfigurationId,
     executionState: action.executionState,
@@ -1204,7 +1199,7 @@ export function renderAgentMCPAction(
         const file = o.file;
         const fileSid = FileResource.modelIdToSId({
           id: file.id,
-          workspaceId: auth.getNonNullableWorkspace().id,
+          workspaceId: action.workspaceId,
         });
 
         return {

--- a/front/lib/actions/mcp.ts
+++ b/front/lib/actions/mcp.ts
@@ -92,6 +92,7 @@ import {
   removeNulls,
   stripNullBytes,
 } from "@app/types";
+import { AgentMCPActionType } from "@app/types/assistant/agent_message_content";
 
 const MAX_BLOB_SIZE_BYTES = 1024 * 1024 * 10; // 10MB
 
@@ -1178,68 +1179,41 @@ async function handleBase64Upload(
  * Action rendering.
  */
 
-// Internal interface for the retrieval and rendering of an MCPAction action. Should not be used
-// outside api/assistant. We allow a ModelId interface here because we don't have `sId` on actions
-// (the `sId` is on the `Message` object linked to the `UserMessage` parent of this action).
-// This function only returns the actions with the maximum version for each step.
-export async function mcpActionTypesFromAgentMessageIds(
+export function renderAgentMCPAction(
   auth: Authenticator,
-  { agentMessageIds }: { agentMessageIds: ModelId[] }
-): Promise<MCPActionType[]> {
-  const actions = await AgentMCPAction.findAll({
-    where: {
-      agentMessageId: agentMessageIds,
-      workspaceId: auth.getNonNullableWorkspace().id,
-    },
-    include: [
-      {
-        model: AgentMCPActionOutputItem,
-        as: "outputItems",
-        required: false,
-        include: [
-          {
-            model: FileModel,
-            as: "file",
-            required: false,
-          },
-        ],
-      },
-    ],
-  });
+  action: AgentMCPActionType
+): MCPActionType {
+  return new MCPActionType({
+    id: action.id,
+    params: action.params,
+    output: removeNulls(action.outputItems.map(hideFileFromActionOutput)),
+    functionCallId: action.functionCallId,
+    functionCallName: action.functionCallName,
+    agentMessageId: action.agentMessageModelId,
+    step: action.step,
+    mcpServerConfigurationId: action.mcpServerConfigurationId,
+    executionState: action.executionState,
+    isError: action.isError,
+    type: "tool_action",
+    generatedFiles: removeNulls(
+      action.outputItems.map((o) => {
+        if (!o.file) {
+          return null;
+        }
 
-  return actions.map((action) => {
-    return new MCPActionType({
-      id: action.id,
-      params: action.params,
-      output: removeNulls(action.outputItems.map(hideFileFromActionOutput)),
-      functionCallId: action.functionCallId,
-      functionCallName: action.functionCallName,
-      agentMessageId: action.agentMessageId,
-      step: action.step,
-      mcpServerConfigurationId: action.mcpServerConfigurationId,
-      executionState: action.executionState,
-      isError: action.isError,
-      type: "tool_action",
-      generatedFiles: removeNulls(
-        action.outputItems.map((o) => {
-          if (!o.file) {
-            return null;
-          }
+        const file = o.file;
+        const fileSid = FileResource.modelIdToSId({
+          id: file.id,
+          workspaceId: auth.getNonNullableWorkspace().id,
+        });
 
-          const file = o.file;
-          const fileSid = FileResource.modelIdToSId({
-            id: file.id,
-            workspaceId: action.workspaceId,
-          });
-
-          return {
-            fileId: fileSid,
-            contentType: file.contentType,
-            title: file.fileName,
-            snippet: file.snippet,
-          };
-        })
-      ),
-    });
+        return {
+          fileId: fileSid,
+          contentType: file.contentType,
+          title: file.fileName,
+          snippet: file.snippet,
+        };
+      })
+    ),
   });
 }

--- a/front/lib/api/assistant/messages.ts
+++ b/front/lib/api/assistant/messages.ts
@@ -39,7 +39,6 @@ import type {
   ReasoningContentType,
   TextContentType,
 } from "@app/types/assistant/agent_message_content";
-import { renderAgentMCPAction } from "@app/lib/actions/mcp";
 
 export function getMaximalVersionAgentStepContent(
   agentStepContents: AgentStepContentModel[]
@@ -193,7 +192,7 @@ async function batchRenderAgentMessages<V extends RenderMessageVariant>(
       const agentMessage = message.agentMessage;
 
       const actions = agentMCPActions
-        .filter((a) => a.agentMessageModelId === agentMessage.id)
+        .filter((a) => a.agentMessageId === agentMessage.id)
         .sort((a, b) => a.step - b.step);
 
       const agentConfiguration = agentConfigurations.find(
@@ -286,7 +285,7 @@ async function batchRenderAgentMessages<V extends RenderMessageVariant>(
         parentMessageId:
           messages.find((m) => m.id === message.parentId)?.sId ?? null,
         status: agentMessage.status,
-        actions: actions.map((a) => renderAgentMCPAction(auth, a)),
+        actions,
         content,
         chainOfThought,
         rawContents: textContents.map((c) => ({

--- a/front/lib/models/assistant/actions/mcp.ts
+++ b/front/lib/models/assistant/actions/mcp.ts
@@ -293,6 +293,7 @@ AgentMCPAction.belongsTo(AgentStepContentModel, {
 
 AgentStepContentModel.hasMany(AgentMCPAction, {
   foreignKey: { name: "stepContentId", allowNull: true },
+  as: "agentMCPActions",
 });
 
 export class AgentMCPActionOutputItem extends WorkspaceAwareModel<AgentMCPActionOutputItem> {

--- a/front/lib/models/assistant/agent_step_content.ts
+++ b/front/lib/models/assistant/agent_step_content.ts
@@ -1,6 +1,7 @@
 import type { CreationOptional, ForeignKey, NonAttribute } from "sequelize";
 import { DataTypes } from "sequelize";
 
+import type { AgentMCPAction } from "@app/lib/models/assistant/actions/mcp";
 import { AgentMessage } from "@app/lib/models/assistant/conversation";
 import { frontSequelize } from "@app/lib/resources/storage";
 import { WorkspaceAwareModel } from "@app/lib/resources/storage/wrappers/workspace_models";
@@ -18,6 +19,7 @@ export class AgentStepContentModel extends WorkspaceAwareModel<AgentStepContentM
   declare value: AgentContentItemType;
 
   declare agentMessage?: NonAttribute<AgentMessage>;
+  declare agentMCPActions?: NonAttribute<AgentMCPAction[]>;
 }
 
 AgentStepContentModel.init(

--- a/front/lib/resources/agent_mcp_action_resource.ts
+++ b/front/lib/resources/agent_mcp_action_resource.ts
@@ -15,7 +15,6 @@ import { makeSId } from "@app/lib/resources/string_ids";
 import logger from "@app/logger/logger";
 import type { Result } from "@app/types";
 import { Err, Ok } from "@app/types";
-import type { AgentMCPActionType } from "@app/types/assistant/agent_message_content";
 
 type AgentMCPActionWithConversation = AgentMCPAction & {
   agent_message: AgentMessage & {

--- a/front/lib/resources/agent_mcp_action_resource.ts
+++ b/front/lib/resources/agent_mcp_action_resource.ts
@@ -15,6 +15,7 @@ import { makeSId } from "@app/lib/resources/string_ids";
 import logger from "@app/logger/logger";
 import type { Result } from "@app/types";
 import { Err, Ok } from "@app/types";
+import type { AgentMCPActionType } from "@app/types/assistant/agent_message_content";
 
 type AgentMCPActionWithConversation = AgentMCPAction & {
   agent_message: AgentMessage & {
@@ -63,7 +64,7 @@ export class AgentMCPActionResource extends BaseResource<AgentMCPAction> {
     });
   }
 
-  toJSON() {
+  toJSON(): AgentMCPActionType {
     const stepContentSId = this.stepContentId
       ? makeSId("agent_step_content", {
           id: this.stepContentId,
@@ -72,13 +73,19 @@ export class AgentMCPActionResource extends BaseResource<AgentMCPAction> {
       : undefined;
 
     return {
+      id: this.id,
       sId: this.sId,
       createdAt: this.createdAt.toISOString(),
+      functionCallId: this.functionCallId,
       functionCallName: this.functionCallName,
       params: this.params,
       executionState: this.executionState,
       isError: this.isError,
       stepContentSId,
+      step: this.step,
+      version: this.version,
+      agentMessageModelId: this.agentMessageId,
+      mcpServerConfigurationId: this.mcpServerConfigurationId,
     };
   }
 

--- a/front/lib/resources/agent_mcp_action_resource.ts
+++ b/front/lib/resources/agent_mcp_action_resource.ts
@@ -64,7 +64,7 @@ export class AgentMCPActionResource extends BaseResource<AgentMCPAction> {
     });
   }
 
-  toJSON(): AgentMCPActionType {
+  toJSON() {
     const stepContentSId = this.stepContentId
       ? makeSId("agent_step_content", {
           id: this.stepContentId,
@@ -73,19 +73,13 @@ export class AgentMCPActionResource extends BaseResource<AgentMCPAction> {
       : undefined;
 
     return {
-      id: this.id,
       sId: this.sId,
       createdAt: this.createdAt.toISOString(),
-      functionCallId: this.functionCallId,
       functionCallName: this.functionCallName,
       params: this.params,
       executionState: this.executionState,
       isError: this.isError,
       stepContentSId,
-      step: this.step,
-      version: this.version,
-      agentMessageModelId: this.agentMessageId,
-      mcpServerConfigurationId: this.mcpServerConfigurationId,
     };
   }
 

--- a/front/lib/resources/agent_step_content_resource.ts
+++ b/front/lib/resources/agent_step_content_resource.ts
@@ -60,7 +60,7 @@ export class AgentStepContentResource extends BaseResource<AgentStepContentModel
     });
 
     assert(
-      agentMessages.length !== uniqueAgentMessageIds.length,
+      agentMessages.length === uniqueAgentMessageIds.length,
       "Unexpected: missing agent messages"
     );
 

--- a/front/lib/resources/agent_step_content_resource.ts
+++ b/front/lib/resources/agent_step_content_resource.ts
@@ -59,7 +59,7 @@ export class AgentStepContentResource extends BaseResource<AgentStepContentModel
 
     assert(
       agentMessages.length !== uniqueAgentMessageIds.length,
-      "Unexpected: Agent messages not all found"
+      "Unexpected: missing agent messages"
     );
 
     const uniqueAgentIds = [

--- a/front/lib/resources/agent_step_content_resource.ts
+++ b/front/lib/resources/agent_step_content_resource.ts
@@ -1,3 +1,4 @@
+import assert from "assert";
 import _ from "lodash";
 import type {
   Attributes,
@@ -54,17 +55,10 @@ export class AgentStepContentResource extends BaseResource<AgentStepContentModel
       },
     });
 
-    if (agentMessages.length !== agentMessageIds.length) {
-      logger.error(
-        {
-          workspaceId: auth.getNonNullableWorkspace().sId,
-          agentMessageIds,
-          found: agentMessages.map((a) => a.id),
-        },
-        "Agent message not found"
-      );
-      throw new Error(`Unexpected: Agent messages not all found`);
-    }
+    assert(
+      agentMessages.length !== agentMessageIds.length,
+      "Unexpected: Agent messages not all found"
+    );
 
     const uniqueAgentIds = [
       ...new Set(agentMessages.map((a) => a.agentConfigurationId)),

--- a/front/lib/resources/agent_step_content_resource.ts
+++ b/front/lib/resources/agent_step_content_resource.ts
@@ -172,19 +172,20 @@ export class AgentStepContentResource extends BaseResource<AgentStepContentModel
     );
   }
 
-  static async fetchByAgentMessages({
-    auth,
-    agentMessageIds,
-    transaction,
-    includeMCPActions = false,
-    latestVersionsOnly = false,
-  }: {
-    auth: Authenticator;
-    agentMessageIds: number[];
-    transaction?: Transaction;
-    includeMCPActions?: boolean;
-    latestVersionsOnly?: boolean;
-  }): Promise<AgentStepContentResource[]> {
+  static async fetchByAgentMessages(
+    auth: Authenticator,
+    {
+      agentMessageIds,
+      transaction,
+      includeMCPActions = false,
+      latestVersionsOnly = false,
+    }: {
+      agentMessageIds: number[];
+      transaction?: Transaction;
+      includeMCPActions?: boolean;
+      latestVersionsOnly?: boolean;
+    }
+  ): Promise<AgentStepContentResource[]> {
     const owner = auth.getNonNullableWorkspace();
 
     // Check authorization - will throw if unauthorized
@@ -231,21 +232,22 @@ export class AgentStepContentResource extends BaseResource<AgentStepContentModel
     return this.createResources(contents);
   }
 
-  static async fetchByAgentMessageAndStep({
-    auth,
-    agentMessageId,
-    step,
-    transaction,
-    includeMCPActions = false,
-    latestVersionsOnly = false,
-  }: {
-    auth: Authenticator;
-    agentMessageId: number;
-    step: number;
-    transaction?: Transaction;
-    includeMCPActions?: boolean;
-    latestVersionsOnly?: boolean;
-  }): Promise<AgentStepContentResource[]> {
+  static async fetchByAgentMessageAndStep(
+    auth: Authenticator,
+    {
+      agentMessageId,
+      step,
+      transaction,
+      includeMCPActions = false,
+      latestVersionsOnly = false,
+    }: {
+      agentMessageId: number;
+      step: number;
+      transaction?: Transaction;
+      includeMCPActions?: boolean;
+      latestVersionsOnly?: boolean;
+    }
+  ): Promise<AgentStepContentResource[]> {
     const owner = auth.getNonNullableWorkspace();
 
     // Check authorization - will throw if unauthorized

--- a/front/lib/resources/agent_step_content_resource.ts
+++ b/front/lib/resources/agent_step_content_resource.ts
@@ -7,12 +7,12 @@ import type {
 } from "sequelize";
 import { Op } from "sequelize";
 
+import { renderAgentMCPAction } from "@app/lib/actions/mcp";
 import { getAgentConfigurations } from "@app/lib/api/assistant/configuration";
 import type { Authenticator } from "@app/lib/auth";
 import { AgentMCPAction } from "@app/lib/models/assistant/actions/mcp";
 import { AgentStepContentModel } from "@app/lib/models/assistant/agent_step_content";
 import { AgentMessage } from "@app/lib/models/assistant/conversation";
-import { AgentMCPActionResource } from "@app/lib/resources/agent_mcp_action_resource";
 import { BaseResource } from "@app/lib/resources/base_resource";
 import type { ReadonlyAttributesType } from "@app/lib/resources/storage/types";
 import { makeSId } from "@app/lib/resources/string_ids";
@@ -349,16 +349,10 @@ export class AgentStepContentResource extends BaseResource<AgentStepContentModel
     };
 
     if ("agentMCPActions" in this && Array.isArray(this.agentMCPActions)) {
-      const mcpActions = this.agentMCPActions as AgentMCPAction[];
-
       // MCP actions filtering already happened in fetch methods if latestVersionsOnly was requested
-      base.mcpActions = mcpActions.map((action: AgentMCPAction) => {
-        const resource = new AgentMCPActionResource(
-          AgentMCPAction,
-          action.get ? action.get() : action
-        );
-        return resource.toJSON();
-      });
+      base.mcpActions = this.agentMCPActions.map((action: AgentMCPAction) =>
+        renderAgentMCPAction(action)
+      );
     }
 
     return base;

--- a/front/lib/resources/agent_step_content_resource.ts
+++ b/front/lib/resources/agent_step_content_resource.ts
@@ -83,7 +83,7 @@ export class AgentStepContentResource extends BaseResource<AgentStepContentModel
         },
         "User does not have access to agents"
       );
-      throw new Error(`Unexpected: User does not have access to all agents`);
+      throw new Error("Unexpected: User does not have access to all agents");
     }
   }
 

--- a/front/lib/resources/agent_step_content_resource.ts
+++ b/front/lib/resources/agent_step_content_resource.ts
@@ -49,14 +49,16 @@ export class AgentStepContentResource extends BaseResource<AgentStepContentModel
     auth: Authenticator,
     agentMessageIds: ModelId[]
   ): Promise<void> {
+    const uniqueAgentMessageIds = [...new Set(agentMessageIds)];
+
     const agentMessages = await AgentMessage.findAll({
       where: {
-        id: { [Op.in]: agentMessageIds },
+        id: { [Op.in]: uniqueAgentMessageIds },
       },
     });
 
     assert(
-      agentMessages.length !== agentMessageIds.length,
+      agentMessages.length !== uniqueAgentMessageIds.length,
       "Unexpected: Agent messages not all found"
     );
 

--- a/front/lib/resources/agent_step_content_resource.ts
+++ b/front/lib/resources/agent_step_content_resource.ts
@@ -43,7 +43,7 @@ export class AgentStepContentResource extends BaseResource<AgentStepContentModel
    */
   private static async checkAgentMessageAccess(
     auth: Authenticator,
-    agentMessageIds: number[]
+    agentMessageIds: ModelId[]
   ): Promise<void> {
     const agentMessages = await AgentMessage.findAll({
       where: {
@@ -180,7 +180,7 @@ export class AgentStepContentResource extends BaseResource<AgentStepContentModel
       includeMCPActions = false,
       latestVersionsOnly = false,
     }: {
-      agentMessageIds: number[];
+      agentMessageIds: ModelId[];
       transaction?: Transaction;
       includeMCPActions?: boolean;
       latestVersionsOnly?: boolean;
@@ -241,7 +241,7 @@ export class AgentStepContentResource extends BaseResource<AgentStepContentModel
       includeMCPActions = false,
       latestVersionsOnly = false,
     }: {
-      agentMessageId: number;
+      agentMessageId: ModelId;
       step: number;
       transaction?: Transaction;
       includeMCPActions?: boolean;

--- a/front/lib/resources/agent_step_content_resource.ts
+++ b/front/lib/resources/agent_step_content_resource.ts
@@ -10,7 +10,10 @@ import { Op } from "sequelize";
 import { renderAgentMCPAction } from "@app/lib/actions/mcp";
 import { getAgentConfigurations } from "@app/lib/api/assistant/configuration";
 import type { Authenticator } from "@app/lib/auth";
-import { AgentMCPAction } from "@app/lib/models/assistant/actions/mcp";
+import {
+  AgentMCPAction,
+  AgentMCPActionOutputItem,
+} from "@app/lib/models/assistant/actions/mcp";
 import { AgentStepContentModel } from "@app/lib/models/assistant/agent_step_content";
 import { AgentMessage } from "@app/lib/models/assistant/conversation";
 import { BaseResource } from "@app/lib/resources/base_resource";
@@ -139,6 +142,13 @@ export class AgentStepContentResource extends BaseResource<AgentStepContentModel
         model: AgentMCPAction,
         as: "agentMCPActions",
         required: false,
+        include: [
+          {
+            model: AgentMCPActionOutputItem,
+            as: "outputItems",
+            required: true,
+          },
+        ],
       },
     ];
   }

--- a/front/types/assistant/agent_message_content.ts
+++ b/front/types/assistant/agent_message_content.ts
@@ -47,9 +47,11 @@ export function isFunctionCallContent(
 
 // Type matching AgentMCPActionResource.toJSON() output
 export type AgentMCPActionType = {
+  id: ModelId;
   sId: string;
   createdAt: string;
   functionCallName: string | null;
+  functionCallId: string | null;
   params: Record<string, unknown>;
   executionState:
     | "pending"
@@ -59,6 +61,10 @@ export type AgentMCPActionType = {
     | "denied";
   isError: boolean;
   stepContentSId?: string;
+  step: number;
+  version: number;
+  agentMessageModelId: ModelId;
+  mcpServerConfigurationId: string;
 };
 
 export type AgentStepContentType = {

--- a/front/types/assistant/agent_message_content.ts
+++ b/front/types/assistant/agent_message_content.ts
@@ -1,4 +1,3 @@
-import type { MCPActionType } from "@app/lib/actions/mcp";
 import type { ModelId } from "@app/types";
 import type { ModelProviderIdType } from "@app/types/assistant/assistant";
 import type { FunctionCallType } from "@app/types/assistant/generation";
@@ -48,11 +47,9 @@ export function isFunctionCallContent(
 
 // Type matching AgentMCPActionResource.toJSON() output
 export type AgentMCPActionType = {
-  id: ModelId;
   sId: string;
   createdAt: string;
   functionCallName: string | null;
-  functionCallId: string | null;
   params: Record<string, unknown>;
   executionState:
     | "pending"
@@ -62,10 +59,6 @@ export type AgentMCPActionType = {
     | "denied";
   isError: boolean;
   stepContentSId?: string;
-  step: number;
-  version: number;
-  agentMessageModelId: ModelId;
-  mcpServerConfigurationId: string;
 };
 
 export type AgentStepContentType = {
@@ -80,5 +73,5 @@ export type AgentStepContentType = {
   type: AgentContentItemType["type"];
   value: AgentContentItemType;
   // Array of MCP actions that reference this step content.
-  mcpActions?: MCPActionType[];
+  mcpActions?: AgentMCPActionType[];
 };

--- a/front/types/assistant/agent_message_content.ts
+++ b/front/types/assistant/agent_message_content.ts
@@ -1,3 +1,4 @@
+import { MCPActionType } from "@app/lib/actions/mcp";
 import type { ModelId } from "@app/types";
 import type { ModelProviderIdType } from "@app/types/assistant/assistant";
 import type { FunctionCallType } from "@app/types/assistant/generation";
@@ -73,5 +74,5 @@ export type AgentStepContentType = {
   type: AgentContentItemType["type"];
   value: AgentContentItemType;
   // Array of MCP actions that reference this step content.
-  mcpActions?: AgentMCPActionType[];
+  mcpActions?: MCPActionType[];
 };

--- a/front/types/assistant/agent_message_content.ts
+++ b/front/types/assistant/agent_message_content.ts
@@ -1,3 +1,4 @@
+import type { MCPActionType } from "@app/lib/actions/mcp";
 import type { ModelId } from "@app/types";
 import type { ModelProviderIdType } from "@app/types/assistant/assistant";
 import type { FunctionCallType } from "@app/types/assistant/generation";
@@ -79,5 +80,5 @@ export type AgentStepContentType = {
   type: AgentContentItemType["type"];
   value: AgentContentItemType;
   // Array of MCP actions that reference this step content.
-  mcpActions?: AgentMCPActionType[];
+  mcpActions?: MCPActionType[];
 };


### PR DESCRIPTION
## Description

- This PR consolidates the versioning of actions in the `AgentStepContentResource`.

## Tests

- Tested locally and on front-edge.

## Risk

- High blast radius as it affects the rendering of actions.
- Idea is to monitor [here](https://app.datadoghq.eu/notebook/254243/multi-actions-agent-auto-retries).

## Deploy Plan

- No migration, dangerJS triggered on a newly added `NonAttribute`
- Deploy front.
