### PR TITLE
[public] do not parse cookie on reading

### DIFF
--- a/front/components/home/LandingLayout.tsx
+++ b/front/components/home/LandingLayout.tsx
@@ -17,7 +17,6 @@ import { A } from "@app/components/home/ContentComponents";
 import { FooterNavigation } from "@app/components/home/menu/FooterNavigation";
 import { MainNavigation } from "@app/components/home/menu/MainNavigation";
 import { MobileNavigation } from "@app/components/home/menu/MobileNavigation";
-// import Particles, { shapeNamesArray } from "@app/components/home/Particles";
 import ScrollingHeader from "@app/components/home/ScrollingHeader";
 import UTMButton from "@app/components/UTMButton";
 import UTMHandler from "@app/components/UTMHandler";
@@ -44,7 +43,9 @@ export default function LandingLayout({
     utmParams,
   } = pageProps;
 
-  const [cookies, setCookie] = useCookies(["dust-cookies-accepted"]);
+  const [cookies, setCookie] = useCookies(["dust-cookies-accepted"], {
+    doNotParse: true,
+  });
   const [showCookieBanner, setShowCookieBanner] = useState<boolean>(false);
   const cookieValue = cookies["dust-cookies-accepted"];
   const [hasAcceptedCookies, setHasAcceptedCookies] = useState<boolean>(


### PR DESCRIPTION
## Description
react-cookie automatically parse the cookie value by default when you read it, so string "true" becomes boolean true if we don't pass `doNotParse` option, so if you refresh the page it wasn't working 😄

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
