### PR TITLE
feat: add gated support for notion private integrations

### DIFF
--- a/connectors/migrations/db/migration_84.sql
+++ b/connectors/migrations/db/migration_84.sql
@@ -1,0 +1,3 @@
+-- Add privateIntegrationCredentialId column to notion_connector_states table
+ALTER TABLE notion_connector_states 
+ADD COLUMN IF NOT EXISTS "privateIntegrationCredentialId" VARCHAR(255);

--- a/connectors/src/connectors/notion/index.ts
+++ b/connectors/src/connectors/notion/index.ts
@@ -523,12 +523,68 @@ export class NotionConnectorManager extends BaseConnectorManager<null> {
     );
   }
 
-  async setConfigurationKey(): Promise<Result<void, Error>> {
-    throw new Error("Method not implemented.");
+  async setConfigurationKey({
+    configKey,
+    configValue,
+  }: {
+    configKey: string;
+    configValue: string;
+  }): Promise<Result<void, Error>> {
+    if (configKey !== "privateIntegrationCredentialId") {
+      return new Err(new Error(`Unknown configuration key: ${configKey}`));
+    }
+
+    const connector = await ConnectorResource.fetchById(this.connectorId);
+    if (!connector) {
+      return new Err(new Error(`Connector ${this.connectorId} not found`));
+    }
+
+    const notionConnectorState = await NotionConnectorState.findOne({
+      where: { connectorId: connector.id },
+    });
+
+    if (!notionConnectorState) {
+      return new Err(
+        new Error(
+          `NotionConnectorState not found for connector ${connector.id}`
+        )
+      );
+    }
+
+    await notionConnectorState.update({
+      privateIntegrationCredentialId: configValue,
+    });
+
+    return new Ok(undefined);
   }
 
-  async getConfigurationKey(): Promise<Result<string | null, Error>> {
-    throw new Error("Method not implemented.");
+  async getConfigurationKey({
+    configKey,
+  }: {
+    configKey: string;
+  }): Promise<Result<string | null, Error>> {
+    if (configKey !== "privateIntegrationCredentialId") {
+      return new Err(new Error(`Unknown configuration key: ${configKey}`));
+    }
+
+    const connector = await ConnectorResource.fetchById(this.connectorId);
+    if (!connector) {
+      return new Err(new Error(`Connector ${this.connectorId} not found`));
+    }
+
+    const notionConnectorState = await NotionConnectorState.findOne({
+      where: { connectorId: connector.id },
+    });
+
+    if (!notionConnectorState) {
+      return new Err(
+        new Error(
+          `NotionConnectorState not found for connector ${connector.id}`
+        )
+      );
+    }
+
+    return new Ok(notionConnectorState.privateIntegrationCredentialId || null);
   }
 
   async garbageCollect(): Promise<Result<string, Error>> {

--- a/connectors/src/connectors/notion/lib/access_token.ts
+++ b/connectors/src/connectors/notion/lib/access_token.ts
@@ -1,0 +1,70 @@
+import { apiConfig } from "@connectors/lib/api/config";
+import { NotionConnectorState } from "@connectors/lib/models/notion";
+import { getOAuthConnectionAccessTokenWithThrow } from "@connectors/lib/oauth";
+import mainLogger from "@connectors/logger/logger";
+import { ConnectorResource } from "@connectors/resources/connector_resource";
+import type { ModelId } from "@connectors/types";
+import { getConnectionCredentials } from "@connectors/types/oauth/client/credentials";
+
+const logger = mainLogger.child({ provider: "notion" });
+
+export async function getNotionAccessToken(
+  connectorId: ModelId
+): Promise<string> {
+  // Fetch connector and notion connector state concurrently
+  const [connector, notionConnectorState] = await Promise.all([
+    ConnectorResource.fetchById(connectorId),
+    NotionConnectorState.findOne({
+      where: { connectorId },
+    }),
+  ]);
+
+  if (!connector) {
+    throw new Error(`Connector not found: ${connectorId}`);
+  }
+
+  if (!notionConnectorState) {
+    throw new Error(
+      `NotionConnectorState not found for connector: ${connectorId}`
+    );
+  }
+
+  // Use OAuth token if no private integration credential ID (regular case).
+  if (!notionConnectorState.privateIntegrationCredentialId) {
+    const token = await getOAuthConnectionAccessTokenWithThrow({
+      logger,
+      provider: "notion",
+      connectionId: connector.connectionId,
+    });
+    return token.access_token;
+  }
+
+  // Use private integration credential ID if it exists.
+  const credentialsRes = await getConnectionCredentials({
+    config: apiConfig.getOAuthAPIConfig(),
+    logger,
+    credentialsId: notionConnectorState.privateIntegrationCredentialId,
+  });
+
+  if (credentialsRes.isErr()) {
+    throw new Error(
+      `Failed to retrieve private integration credentials: ${credentialsRes.error.message}`
+    );
+  }
+
+  const credentials = credentialsRes.value.credential;
+  if (credentials.provider !== "notion") {
+    throw new Error(
+      `Invalid credential provider: expected 'notion', got '${credentials.provider}'`
+    );
+  }
+
+  const notionCredentials = credentials.content as {
+    integration_token: string;
+  };
+  if (!notionCredentials.integration_token) {
+    throw new Error("Invalid Notion credentials: missing integration_token");
+  }
+
+  return notionCredentials.integration_token;
+}

--- a/connectors/src/connectors/notion/lib/cli.ts
+++ b/connectors/src/connectors/notion/lib/cli.ts
@@ -1,13 +1,13 @@
 import { Client, isFullDatabase, isFullPage } from "@notionhq/client";
 import { Op } from "sequelize";
 
+import { getNotionAccessToken } from "@connectors/connectors/notion/lib/access_token";
 import { updateAllParentsFields } from "@connectors/connectors/notion/lib/parents";
 import { pageOrDbIdFromUrl } from "@connectors/connectors/notion/lib/utils";
 import {
   clearParentsLastUpdatedAt,
   deleteDatabase,
   deletePage,
-  getNotionAccessToken,
   updateParentsFields,
 } from "@connectors/connectors/notion/temporal/activities";
 import {
@@ -84,14 +84,13 @@ async function listSkippedDatabaseIdsForConnectorId(connectorId: ModelId) {
 
 export async function searchNotionPagesForQuery({
   connectorId,
-  connectionId,
   query,
 }: {
   connectorId: ModelId;
   connectionId: string;
   query: string;
 }) {
-  const notionAccessToken = await getNotionAccessToken(connectionId);
+  const notionAccessToken = await getNotionAccessToken(connectorId);
 
   const notionClient = new Client({
     auth: notionAccessToken,
@@ -209,7 +208,7 @@ export async function checkNotionUrl({
   connectionId: string;
   url: string;
 }) {
-  const notionAccessToken = await getNotionAccessToken(connectionId);
+  const notionAccessToken = await getNotionAccessToken(connectorId);
 
   const pageOrDbId = pageOrDbIdFromUrl(url);
 
@@ -636,9 +635,7 @@ export const notion = async ({
     case "me": {
       const connector = await getConnector(args);
 
-      const notionAccessToken = await getNotionAccessToken(
-        connector.connectionId
-      );
+      const notionAccessToken = await getNotionAccessToken(connector.id);
 
       const notionClient = new Client({
         auth: notionAccessToken,

--- a/connectors/src/lib/models/notion.ts
+++ b/connectors/src/lib/models/notion.ts
@@ -15,6 +15,7 @@ export class NotionConnectorState extends ConnectorBaseModel<NotionConnectorStat
   declare parentsLastUpdatedAt?: Date | null;
 
   declare notionWorkspaceId: string;
+  declare privateIntegrationCredentialId?: string | null;
 }
 NotionConnectorState.init(
   {
@@ -43,6 +44,10 @@ NotionConnectorState.init(
     notionWorkspaceId: {
       type: DataTypes.STRING,
       allowNull: false,
+    },
+    privateIntegrationCredentialId: {
+      type: DataTypes.STRING,
+      allowNull: true,
     },
   },
   {

--- a/connectors/src/types/oauth/lib.ts
+++ b/connectors/src/types/oauth/lib.ts
@@ -87,6 +87,7 @@ export const CREDENTIALS_PROVIDERS = [
   "snowflake",
   "bigquery",
   "salesforce",
+  "notion",
   // Labs
   "modjo",
   "hubspot",
@@ -199,11 +200,17 @@ export type SalesforceCredentials = t.TypeOf<
   typeof SalesforceCredentialsSchema
 >;
 
+export const NotionCredentialsSchema = t.type({
+  integration_token: t.string,
+});
+export type NotionCredentials = t.TypeOf<typeof NotionCredentialsSchema>;
+
 export type ConnectionCredentials =
   | SnowflakeCredentials
   | ModjoCredentials
   | BigQueryCredentialsWithLocation
-  | SalesforceCredentials;
+  | SalesforceCredentials
+  | NotionCredentials;
 
 export function isSnowflakeCredentials(
   credentials: ConnectionCredentials

--- a/core/src/oauth/credential.rs
+++ b/core/src/oauth/credential.rs
@@ -26,6 +26,7 @@ pub enum CredentialProvider {
     Jira,
     Monday,
     Mcp,
+    Notion,
 }
 
 impl From<ConnectionProvider> for CredentialProvider {
@@ -214,6 +215,9 @@ impl Credential {
             }
             CredentialProvider::Mcp => {
                 vec!["client_id", "client_secret"]
+            }
+            CredentialProvider::Notion => {
+                vec!["integration_token"]
             }
         };
 

--- a/front/components/data_source/ConnectorPermissionsModal.tsx
+++ b/front/components/data_source/ConnectorPermissionsModal.tsx
@@ -42,6 +42,7 @@ import { ContentNodeTree } from "@app/components/ContentNodeTree";
 import { CreateOrUpdateConnectionBigQueryModal } from "@app/components/data_source/CreateOrUpdateConnectionBigQueryModal";
 import { CreateOrUpdateConnectionSnowflakeModal } from "@app/components/data_source/CreateOrUpdateConnectionSnowflakeModal";
 import { RequestDataSourceModal } from "@app/components/data_source/RequestDataSourceModal";
+import { SetupNotionPrivateIntegrationModal } from "@app/components/data_source/SetupNotionPrivateIntegrationModal";
 import { setupConnection } from "@app/components/spaces/AddConnectionMenu";
 import { AdvancedNotionManagement } from "@app/components/spaces/AdvancedNotionManagement";
 import { ConnectorDataUpdatedModal } from "@app/components/spaces/ConnectorDataUpdatedModal";
@@ -650,7 +651,12 @@ export function ConnectorPermissionsModal({
   }, [initialTreeSelectionModel, isOpen]);
 
   const [modalToShow, setModalToShow] = useState<
-    "data_updated" | "edition" | "selection" | "deletion" | null
+    | "data_updated"
+    | "edition"
+    | "selection"
+    | "deletion"
+    | "private_integration"
+    | null
   >(null);
 
   const { activeSubscription } = useWorkspaceActiveSubscription({
@@ -821,6 +827,15 @@ export function ConnectorPermissionsModal({
                       disabled={permissionsConfigurable.blocked}
                     />
                   )}
+                  {dataSource.connectorProvider === "notion" &&
+                    featureFlags.includes("notion_private_integration") && (
+                      <Button
+                        label="Setup Private Integration"
+                        variant="outline"
+                        icon={LockIcon}
+                        onClick={() => setModalToShow("private_integration")}
+                      />
+                    )}
                   {isDeletable && (
                     <Button
                       label="Delete connection"
@@ -948,6 +963,21 @@ export function ConnectorPermissionsModal({
           case "google_drive":
           case "intercom":
           case "notion":
+            if (modalToShow === "private_integration") {
+              return (
+                <SetupNotionPrivateIntegrationModal
+                  isOpen={true}
+                  onClose={() => closeModal(false)}
+                  dataSource={dataSource}
+                  owner={owner}
+                  onSuccess={() => {
+                    closeModal(false);
+                  }}
+                  sendNotification={sendNotification}
+                />
+              );
+            }
+          // Fall through to OAuth modal
           case "slack":
           case "microsoft":
           case "zendesk":

--- a/front/components/data_source/SetupNotionPrivateIntegrationModal.tsx
+++ b/front/components/data_source/SetupNotionPrivateIntegrationModal.tsx
@@ -1,0 +1,151 @@
+import type { NotificationType } from "@dust-tt/sparkle";
+import {
+  Dialog,
+  DialogContent,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  Input,
+  Page,
+} from "@dust-tt/sparkle";
+import { useState } from "react";
+
+import type { DataSourceType, LightWorkspaceType } from "@app/types";
+
+interface SetupNotionPrivateIntegrationModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  dataSource: DataSourceType;
+  owner: LightWorkspaceType;
+  onSuccess: (credentialId: string) => void;
+  sendNotification: (notification: NotificationType) => void;
+}
+
+export function SetupNotionPrivateIntegrationModal({
+  isOpen,
+  onClose,
+  dataSource,
+  owner,
+  onSuccess,
+  sendNotification,
+}: SetupNotionPrivateIntegrationModalProps) {
+  const [integrationToken, setIntegrationToken] = useState("");
+  const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const handleSave = async () => {
+    setIsLoading(true);
+    setError(null);
+
+    try {
+      const response = await fetch(`/api/w/${owner.sId}/credentials`, {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({
+          provider: "notion",
+          credentials: {
+            integration_token: integrationToken,
+          },
+        }),
+      });
+
+      if (!response.ok) {
+        const error = await response.json();
+        throw new Error(error.error?.message || "Failed to create credential");
+      }
+
+      const data = await response.json();
+      const credentialId = data.credentials.id;
+
+      // Set the credential ID on the connector
+      const configRes = await fetch(
+        `/api/w/${owner.sId}/data_sources/${dataSource.sId}/managed/config/privateIntegrationCredentialId`,
+        {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+          },
+          body: JSON.stringify({
+            configValue: credentialId,
+          }),
+        }
+      );
+
+      if (!configRes.ok) {
+        const error = await configRes.json();
+        throw new Error(
+          error.error?.message || "Failed to set connector configuration"
+        );
+      }
+
+      sendNotification({
+        type: "success",
+        title: "Private integration setup successfully",
+        description:
+          "Your Notion connector will now use the private integration token.",
+      });
+
+      onSuccess(credentialId);
+    } catch (err) {
+      sendNotification({
+        type: "error",
+        title: "Failed to setup private integration",
+        description: err instanceof Error ? err.message : "An error occurred",
+      });
+      setError(err instanceof Error ? err.message : "An error occurred");
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  return (
+    <Dialog open={isOpen} onOpenChange={(open) => !open && onClose()}>
+      <DialogContent size="lg">
+        <DialogHeader>
+          <DialogTitle>Setup Notion Private Integration</DialogTitle>
+        </DialogHeader>
+
+        <div className="mx-4 mt-5">
+          <div>
+            <Page.SectionHeader title="Integration Token" />
+            <p className="mb-4 mt-2 text-sm text-muted-foreground">
+              Paste your Notion integration token below.
+            </p>
+            <Input
+              type="text"
+              name="notion-integration-token"
+              value={integrationToken}
+              onChange={(e) => {
+                setIntegrationToken(e.target.value);
+                setError(null);
+              }}
+              isError={!!error}
+              autoComplete="off"
+              autoCorrect="off"
+              autoCapitalize="off"
+              spellCheck="false"
+              data-lpignore="true"
+              data-form-type="other"
+            />
+            {error && <p className="text-error-500 mt-2 text-sm">{error}</p>}
+          </div>
+        </div>
+
+        <DialogFooter
+          leftButtonProps={{
+            label: "Cancel",
+            variant: "outline",
+            onClick: onClose,
+          }}
+          rightButtonProps={{
+            label: isLoading ? "Saving..." : "Save",
+            onClick: handleSave,
+            disabled: isLoading || !integrationToken.trim(),
+          }}
+        />
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/front/pages/api/w/[wId]/credentials/index.ts
+++ b/front/pages/api/w/[wId]/credentials/index.ts
@@ -11,6 +11,7 @@ import { apiError } from "@app/logger/withlogging";
 import type { WithAPIErrorResponse } from "@app/types";
 import {
   BigQueryCredentialsWithLocationSchema,
+  NotionCredentialsSchema,
   OAuthAPI,
   SalesforceCredentialsSchema,
   SnowflakeCredentialsSchema,
@@ -31,10 +32,16 @@ const PostSalesforceCredentialsBodySchema = t.type({
   credentials: SalesforceCredentialsSchema,
 });
 
+const PostNotionCredentialsBodySchema = t.type({
+  provider: t.literal("notion"),
+  credentials: NotionCredentialsSchema,
+});
+
 const PostCredentialsBodySchema = t.union([
   PostSnowflakeCredentialsBodySchema,
   PostBigQueryCredentialsBodySchema,
   PostSalesforceCredentialsBodySchema,
+  PostNotionCredentialsBodySchema,
 ]);
 
 export type PostCredentialsBody = t.TypeOf<typeof PostCredentialsBodySchema>;

--- a/front/pages/api/w/[wId]/data_sources/[dsId]/managed/config/[key]/index.ts
+++ b/front/pages/api/w/[wId]/data_sources/[dsId]/managed/config/[key]/index.ts
@@ -88,6 +88,7 @@ async function handler(
       "zendeskHideCustomerDetails",
       "gongRetentionPeriodDays",
       "gongTrackersEnabled",
+      "privateIntegrationCredentialId",
     ].includes(configKey)
   ) {
     return apiError(req, res, {

--- a/front/types/oauth/lib.ts
+++ b/front/types/oauth/lib.ts
@@ -228,6 +228,7 @@ export const CREDENTIALS_PROVIDERS = [
   "snowflake",
   "bigquery",
   "salesforce",
+  "notion",
   // LABS
   "modjo",
 ] as const;
@@ -345,13 +346,19 @@ export type SalesforceCredentials = t.TypeOf<
   typeof SalesforceCredentialsSchema
 >;
 
+export const NotionCredentialsSchema = t.type({
+  integration_token: t.string,
+});
+export type NotionCredentials = t.TypeOf<typeof NotionCredentialsSchema>;
+
 export type ConnectionCredentials =
   | SnowflakeCredentials
   | BigQueryCredentialsWithLocation
   | SalesforceCredentials
   | ModjoCredentials
   | HubspotCredentials
-  | LinearCredentials;
+  | LinearCredentials
+  | NotionCredentials;
 
 export function isSnowflakeCredentials(
   credentials: ConnectionCredentials
@@ -402,6 +409,12 @@ export function isSalesforceCredentials(
   credentials: ConnectionCredentials
 ): credentials is SalesforceCredentials {
   return "client_id" in credentials && "client_secret" in credentials;
+}
+
+export function isNotionCredentials(
+  credentials: ConnectionCredentials
+): credentials is NotionCredentials {
+  return "integration_token" in credentials;
 }
 
 export type OauthAPIPostCredentialsResponse = {

--- a/front/types/shared/feature_flags.ts
+++ b/front/types/shared/feature_flags.ts
@@ -3,6 +3,9 @@ export const WHITELISTABLE_FEATURES_CONFIG = {
     description:
       "Advanced features for Notion workspace management shown to admins",
   },
+  notion_private_integration: {
+    description: "Setup Notion private integration tokens",
+  },
   advanced_search: {
     description:
       "Activates the advanced search option: browse selected data like a file system",

--- a/sdks/js/src/types.ts
+++ b/sdks/js/src/types.ts
@@ -592,6 +592,7 @@ export type RetrievalDocumentPublicType = z.infer<
 
 const WhitelistableFeaturesSchema = FlexibleEnumSchema<
   | "advanced_notion_management"
+  | "notion_private_integration"
   | "advanced_search"
   | "agent_builder_instructions_autocomplete"
   | "agent_builder_v2"


### PR DESCRIPTION
## Description

Feature is gated by a feature flag.

Allows a Dust admin to go into the settings of their notion connector to set a [Notion Private Integration](https://www.notion.com/help/create-integrations-with-the-notion-api#create-an-internal-integration) to use instead of the oauth-based one

## Tests

Tested locally

## Risk

- On critical path for the notion connector as it has changes to `getNotionAccessToken` which is used everywhere we use notion access tokens
- Has a DB migration

## Deploy Plan

Apply DB migration, deploy oauth, deploy front, deploy connectors