### PR TITLE
Improve Remote Server MCP Ux

### DIFF
--- a/front/components/actions/mcp/CreateMCPServerDialog.tsx
+++ b/front/components/actions/mcp/CreateMCPServerDialog.tsx
@@ -5,9 +5,12 @@ import {
   DialogFooter,
   DialogHeader,
   DialogTitle,
+  Icon,
+  InformationCircleIcon,
   Input,
   Label,
   SliderToggle,
+  Tooltip,
 } from "@dust-tt/sparkle";
 import { useCallback, useEffect, useState } from "react";
 
@@ -320,24 +323,36 @@ export function CreateMCPServerDialog({
               )}
               {defaultServerConfig?.authMethod !== "oauth" && (
                 <div className="space-y-2">
-                  <Label htmlFor="requiresBearerToken">
-                    {defaultServerConfig?.authMethod === "bearer"
-                      ? `${defaultServerConfig.name} API Key`
-                      : "Authentication"}
-                  </Label>
-                  <div className="flex items-center space-x-2">
+                  <div className="flex items-center justify-between">
+                    <div className="flex items-center space-x-2">
+                      <Label htmlFor="requiresBearerToken">
+                        {defaultServerConfig?.authMethod === "bearer"
+                          ? `${defaultServerConfig.name} API Key`
+                          : "Enable Bearer Token Authentication"}
+                      </Label>
+                      <Tooltip
+                        trigger={
+                          <Icon
+                            visual={InformationCircleIcon}
+                            size="xs"
+                            className="text-gray-400"
+                          />
+                        }
+                        label="Dust will automatically discover if OAuth authentication is required. If OAuth is not needed, the server will be accessed without authentication. You can also enable bearer token authentication if your server requires an API key."
+                      />
+                    </div>
                     {!defaultServerConfig && (
-                      <div>
-                        <SliderToggle
-                          disabled={false}
-                          selected={requiresBearerToken}
-                          onClick={() =>
-                            setRequiresBearerToken(!requiresBearerToken)
-                          }
-                        />
-                      </div>
+                      <SliderToggle
+                        disabled={false}
+                        selected={requiresBearerToken}
+                        onClick={() =>
+                          setRequiresBearerToken(!requiresBearerToken)
+                        }
+                      />
                     )}
-
+                  </div>
+                  {(requiresBearerToken ||
+                    defaultServerConfig?.authMethod === "bearer") && (
                     <div className="flex-grow">
                       <Input
                         id="sharedSecret"
@@ -357,7 +372,7 @@ export function CreateMCPServerDialog({
                         }
                       />
                     </div>
-                  </div>
+                  )}
                 </div>
               )}
             </>


### PR DESCRIPTION
## Description

* Adding ability to specify custom authentication headers when creating a new remote mcp server. This is necessary due to the Datadog mcp server requiring specific header names / values as opposed to just a bearer token (full oauth is still a work in progress by them).
* Added ability to specify headers upon MCP creation
* Added ability to edit headers for existing MCP server
* Required migration to store specified headers

## Tests

<img width="560" height="333" alt="Screenshot 2025-07-18 at 4 05 46 PM" src="https://github.com/user-attachments/assets/6d4bd5d7-f3f6-4fa0-832d-190b9bed15d0" />

<img width="567" height="317" alt="Screenshot 2025-07-18 at 4 05 53 PM" src="https://github.com/user-attachments/assets/10394cbd-a6a3-4a1e-9790-c51164cc1981" />
<img width="556" height="395" alt="Screenshot 2025-07-18 at 4 06 00 PM" src="https://github.com/user-attachments/assets/ceaa6890-c0eb-4352-810c-66bd507e5995" />


## Risk

* No intended impact to existing logic or existing MCP configs
## Deploy Plan

1. Run migration
2. Deploy front