### PR TITLE
github: limit code files to 2mb

### DIFF
--- a/connectors/src/connectors/github/lib/code/file_operations.ts
+++ b/connectors/src/connectors/github/lib/code/file_operations.ts
@@ -18,8 +18,8 @@ import { ConnectorResource } from "@connectors/resources/connector_resource";
 import type { DataSourceConfig, ModelId } from "@connectors/types";
 import { INTERNAL_MIME_TYPES } from "@connectors/types";
 
-// Only allow documents up to 5mb to be processed.
-const MAX_DOCUMENT_TXT_LEN = 5 * 1000 * 1000; // 5MB
+// Only allow documents up to 2mb to be processed.
+const MAX_DOCUMENT_TXT_LEN = 2 * 1000 * 1000; // 5MB
 
 export async function formatCodeContentForUpsert(
   dataSourceConfig: DataSourceConfig,


### PR DESCRIPTION
## Description

Most plans limit to 2mb and anyway that's not code if more than 2mb
Context: https://app.datadoghq.eu/logs?query=%28%22Activity%20failed%22%20OR%20%22Unhandled%20activity%20error%22%29%20%40attempt%3A%3E19%20%40dd.service%3Aconnectors-worker&agg_m=count&agg_m_source=base&agg_t=count&clustering_pattern_field_path=message&cols=host%2Cservice%2C%40workflowId%2C%40activityName&event=AwAAAZgfH_LXDxkxuQAAABhBWmdmSF9sTUFBQ3plbFdQbnRlYThnQUUAAAAkZjE5ODFmMWYtZmFhZi00MjAxLThhZWMtYmM1NjQwNzQ5MGI3AAAAUQ&link_source=monitor_notif&messageDisplay=inline&refresh_mode=sliding&storage=hot&stream_sort=time%2Cdesc&viz=stream&from_ts=1752782576216&to_ts=1752868976216&live=true

## Tests

N/A

## Risk

None

## Deploy Plan

- deploy `connectors`