### PR TITLE
Run CSV parses and deletes concurrently + increase lock TTL

### DIFF
--- a/core/src/databases/csv.rs
+++ b/core/src/databases/csv.rs
@@ -46,7 +46,7 @@ impl GoogleCloudStorageCSVContent {
         let csv_to_rows_duration = utils::now() - now;
 
         info!(
-            rows_count = rows.len(),
+            row_count = rows.len(),
             download_duration = download_duration,
             delimiter_duration = delimiter_duration,
             csv_to_rows_duration = csv_to_rows_duration,

--- a/core/src/databases/table.rs
+++ b/core/src/databases/table.rs
@@ -423,7 +423,7 @@ impl LocalTable {
         info!(
             duration = utils::now() - now,
             table_id = self.table.table_id(),
-            rows_count = rows.len(),
+            row_count = rows.len(),
             "DSSTRUCTSTAT [upsert_rows] validation"
         );
 
@@ -476,7 +476,7 @@ impl LocalTable {
         info!(
             duration = utils::now() - now,
             table_id = self.table.table_id(),
-            rows_count = rows.len(),
+            row_count = rows.len(),
             "DSSTRUCTSTAT [upsert_rows] table schema"
         );
 
@@ -532,7 +532,7 @@ impl LocalTable {
         info!(
             duration = utils::now() - now,
             table_id = self.table.table_id(),
-            rows_count = rows.len(),
+            row_count = rows.len(),
             "DSSTRUCTSTAT [upsert_rows] rows upsert"
         );
 
@@ -621,7 +621,9 @@ impl LocalTable {
                 // For non-truncate, use the background worker
                 self.schedule_background_upsert_or_delete(rows).await
             } else {
-                info!("upsert_rows_to_gcs_or_queue_work: table not migrated to CSV, skipping GCS upsert for non-truncate");
+                info!(
+                    table_id = self.table.table_id(),
+                    "upsert_rows_to_gcs_or_queue_work: table not migrated to CSV, skipping GCS upsert for non-truncate");
                 Ok(())
             }
         }
@@ -654,7 +656,7 @@ impl LocalTable {
         info!(
             duration = utils::now() - now,
             table_id = self.table.table_id(),
-            rows_count = rows.len(),
+            row_count = rows.len(),
             "DSSTRUCTSTAT [upsert_rows_gcs] table schema"
         );
 
@@ -721,7 +723,7 @@ impl LocalTable {
         info!(
             duration = utils::now() - now,
             table_id = self.table.table_id(),
-            rows_count = rows.len(),
+            row_count = rows.len(),
             "DSSTRUCTSTAT [upsert_rows_gcs] rows upsert"
         );
 
@@ -788,7 +790,7 @@ impl LocalTable {
         info!(
             duration = utils::now() - now,
             table_id = self.table.table_id(),
-            rows_count = rows_arc.len(),
+            row_count = rows_arc.len(),
             "DSSTRUCTSTAT [schedule_background_upsert_or_delete]"
         );
 

--- a/core/src/databases/table_upserts_background_worker.rs
+++ b/core/src/databases/table_upserts_background_worker.rs
@@ -201,11 +201,10 @@ impl TableUpsertsBackgroundWorker {
                         );
                     }
 
-                    let lock_held_duration = utils::now() - now;
                     lock_manager.unlock(&lock).await;
                     info!(
                         table_id = table.table_id(),
-                        duration = lock_held_duration,
+                        duration = utils::now() - now,
                         "TableUpsertsBackgroundWorker: Upsert lock released"
                     );
                 }

--- a/core/src/databases_store/gcs.rs
+++ b/core/src/databases_store/gcs.rs
@@ -199,11 +199,11 @@ impl DatabasesStore for GoogleCloudStorageDatabasesStore {
 
         info!(
             truncate,
-            rows_count = new_rows.len(),
+            row_count = new_rows.len(),
             duration = merge_rows_duration + write_rows_to_csv_duration,
             merge_rows_duration,
             write_rows_to_csv_duration,
-            table_id = table.unique_id(),
+            table_id = table.table_id(),
             "DSSTRUCTSTAT [upsert_rows CSV] operation completed"
         );
 


### PR DESCRIPTION
## Description

Ran into a situation where there were 883 Notion upserts calls, each containing one change. So we ended up with 883 files for the worker to process. Just reading those files from GCS and parsing them took 47 seconds, way more than the 15 second TTL.

To address this, I changed the logic to read the files concurrently from GCS. Note that GCS doesn't care how many files we try to access at the same time. It just doesn't like many write access to the **same** file, which is not relevant here.

While I was at it, I also changed the GCS file deletion logic to be concurrent.

I also raised the TTL to 60 seconds, although that's probably not necessary with the concurrency changes.

This PR also includes small logging cleanups.

## Tests

Tested on my machine with about 20 upserts to make sure the read/delete logic works as expected.

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
