### PR TITLE
Remove xrho.com

### DIFF
--- a/front/lib/utils/blacklisted_email_domains.ts
+++ b/front/lib/utils/blacklisted_email_domains.ts
@@ -3637,7 +3637,6 @@ const BLACKLISTED_EMAIL_DOMAINS = new Set([
   "xoxox.cc",
   "xperiae5.com",
   "xrap.de",
-  "xrho.com",
   "xvx.us",
   "xww.ro",
   "xxhamsterxx.ga",


### PR DESCRIPTION
## Description

Not a disposable email domain

```
;; QUESTION SECTION:
;xrho.com.                      IN      MX

;; ANSWER SECTION:
xrho.com.               300     IN      MX      39 route1.mx.cloudflare.net.
xrho.com.               300     IN      MX      72 route3.mx.cloudflare.net.
xrho.com.               300     IN      MX      54 route2.mx.cloudflare.net.
```

## Tests

N/A

## Risk

N/A

## Deploy Plan

N/A
