### PR TITLE
[front] Remove `AgentMCPActionType`

### DIFF
--- a/front/lib/resources/agent_mcp_action_resource.ts
+++ b/front/lib/resources/agent_mcp_action_resource.ts
@@ -23,6 +23,9 @@ type AgentMCPActionWithConversation = AgentMCPAction & {
   };
 };
 
+// Resource for AgentMCPAction.
+// Only used for analytics purposes, the rendering is handled AgentStepContentResource.
+
 // Attributes are marked as read-only to reflect the stateless nature of our Resource.
 // eslint-disable-next-line @typescript-eslint/no-empty-interface, @typescript-eslint/no-unsafe-declaration-merging
 export interface AgentMCPActionResource

--- a/front/lib/resources/agent_mcp_action_resource.ts
+++ b/front/lib/resources/agent_mcp_action_resource.ts
@@ -9,7 +9,6 @@ import {
   ConversationModel,
   Message,
 } from "@app/lib/models/assistant/conversation";
-import { AgentStepContentResource } from "@app/lib/resources/agent_step_content_resource";
 import { BaseResource } from "@app/lib/resources/base_resource";
 import type { ReadonlyAttributesType } from "@app/lib/resources/storage/types";
 import logger from "@app/logger/logger";
@@ -44,42 +43,6 @@ export class AgentMCPActionResource extends BaseResource<AgentMCPAction> {
     return new Err(
       new Error("Direct deletion of MCP actions is not supported")
     );
-  }
-
-  static modelIdToSId({
-    id,
-    workspaceId,
-  }: {
-    id: number;
-    workspaceId: number;
-  }): string {
-    return MCPActionType.modelIdToSId({ id, workspaceId });
-  }
-
-  get sId(): string {
-    return AgentMCPActionResource.modelIdToSId({
-      id: this.id,
-      workspaceId: this.workspaceId,
-    });
-  }
-
-  toJSON() {
-    const stepContentSId = this.stepContentId
-      ? AgentStepContentResource.modelIdToSId({
-          id: this.stepContentId,
-          workspaceId: this.workspaceId,
-        })
-      : undefined;
-
-    return {
-      sId: this.sId,
-      createdAt: this.createdAt.toISOString(),
-      functionCallName: this.functionCallName,
-      params: this.params,
-      executionState: this.executionState,
-      isError: this.isError,
-      stepContentSId,
-    };
   }
 
   static async getMCPActionsForAgent(

--- a/front/lib/resources/agent_mcp_action_resource.ts
+++ b/front/lib/resources/agent_mcp_action_resource.ts
@@ -9,9 +9,9 @@ import {
   ConversationModel,
   Message,
 } from "@app/lib/models/assistant/conversation";
+import { AgentStepContentResource } from "@app/lib/resources/agent_step_content_resource";
 import { BaseResource } from "@app/lib/resources/base_resource";
 import type { ReadonlyAttributesType } from "@app/lib/resources/storage/types";
-import { makeSId } from "@app/lib/resources/string_ids";
 import logger from "@app/logger/logger";
 import type { Result } from "@app/types";
 import { Err, Ok } from "@app/types";
@@ -65,7 +65,7 @@ export class AgentMCPActionResource extends BaseResource<AgentMCPAction> {
 
   toJSON() {
     const stepContentSId = this.stepContentId
-      ? makeSId("agent_step_content", {
+      ? AgentStepContentResource.modelIdToSId({
           id: this.stepContentId,
           workspaceId: this.workspaceId,
         })

--- a/front/types/assistant/agent_message_content.ts
+++ b/front/types/assistant/agent_message_content.ts
@@ -62,22 +62,6 @@ export function isErrorContent(
   return content.type === "error";
 }
 
-// Type matching AgentMCPActionResource.toJSON() output
-export type AgentMCPActionType = {
-  sId: string;
-  createdAt: string;
-  functionCallName: string | null;
-  params: Record<string, unknown>;
-  executionState:
-    | "pending"
-    | "timeout"
-    | "allowed_explicitly"
-    | "allowed_implicitly"
-    | "denied";
-  isError: boolean;
-  stepContentSId?: string;
-};
-
 export type AgentStepContentType = {
   id: ModelId;
   sId: string;


### PR DESCRIPTION
## Description

- Quick follow up on https://github.com/dust-tt/dust/pull/14430.
- Closes https://github.com/dust-tt/tasks/issues/3520.
- This PR removes the type `AgentMCPActionType`.
- The class `AgentMCPActionResource` is kept as it's being used for the labs dashboard, the idea is that this resource will do no rendering and only be used for analytics relative to mcp actions.

## Tests

- Tested locally.

## Risk

-  Low, only removes unused code.

## Deploy Plan

- Deploy front.
