### PR TITLE
[front] Fix action versioning

### DIFF
--- a/front/lib/resources/agent_step_content_resource.ts
+++ b/front/lib/resources/agent_step_content_resource.ts
@@ -19,6 +19,7 @@ import { AgentStepContentModel } from "@app/lib/models/assistant/agent_step_cont
 import { AgentMessage } from "@app/lib/models/assistant/conversation";
 import { BaseResource } from "@app/lib/resources/base_resource";
 import { FileResource } from "@app/lib/resources/file_resource";
+import { FileModel } from "@app/lib/resources/storage/models/files";
 import type { ReadonlyAttributesType } from "@app/lib/resources/storage/types";
 import { makeSId } from "@app/lib/resources/string_ids";
 import logger from "@app/logger/logger";
@@ -144,7 +145,14 @@ export class AgentStepContentResource extends BaseResource<AgentStepContentModel
           {
             model: AgentMCPActionOutputItem,
             as: "outputItems",
-            required: true,
+            required: false,
+            include: [
+              {
+                model: FileModel,
+                as: "file",
+                required: false,
+              },
+            ],
           },
         ],
       },


### PR DESCRIPTION
## Description

- Follow up on https://github.com/dust-tt/dust/pull/14430.
- This PR fixes a specific interaction with JIT actions, due to an incorrect `include` on `AgentMCPAction`, which was altered during the refactoring.

## Tests

- Tested locally but was already working.

## Risk

## Deploy Plan

- Deploy front.
