### PR TITLE
[front] Add shadow read on `AgentMCPActions`

### DIFF
--- a/front/lib/api/assistant/messages.ts
+++ b/front/lib/api/assistant/messages.ts
@@ -183,6 +183,7 @@ async function batchRenderAgentMessages<V extends RenderMessageVariant>(
           .map((sc) => sc.toJSON().mcpActions ?? [])
           .flat();
       })(),
+      // TODO(2025-07-21, durable agents): remove this shadow read.
       (async () => {
         const actions = await AgentMCPAction.findAll({
           where: {

--- a/front/lib/api/assistant/messages.ts
+++ b/front/lib/api/assistant/messages.ts
@@ -1,6 +1,7 @@
 import type { WhereOptions } from "sequelize";
 import { Op, Sequelize } from "sequelize";
 
+import { hideFileFromActionOutput, MCPActionType } from "@app/lib/actions/mcp";
 import {
   AgentMessageContentParser,
   getDelimitersConfiguration,
@@ -9,6 +10,10 @@ import { getLightAgentMessageFromAgentMessage } from "@app/lib/api/assistant/cit
 import { getAgentConfigurations } from "@app/lib/api/assistant/configuration";
 import type { PaginationParams } from "@app/lib/api/pagination";
 import { Authenticator } from "@app/lib/auth";
+import {
+  AgentMCPAction,
+  AgentMCPActionOutputItem,
+} from "@app/lib/models/assistant/actions/mcp";
 import { AgentStepContentModel } from "@app/lib/models/assistant/agent_step_content";
 import {
   AgentMessage,
@@ -19,8 +24,11 @@ import {
 import { AgentStepContentResource } from "@app/lib/resources/agent_step_content_resource";
 import { ContentFragmentResource } from "@app/lib/resources/content_fragment_resource";
 import { ConversationResource } from "@app/lib/resources/conversation_resource";
+import { FileResource } from "@app/lib/resources/file_resource";
 import { ContentFragmentModel } from "@app/lib/resources/storage/models/content_fragment";
+import { FileModel } from "@app/lib/resources/storage/models/files";
 import { UserResource } from "@app/lib/resources/user_resource";
+import logger from "@app/logger/logger";
 import type {
   AgentMessageType,
   ContentFragmentType,
@@ -39,14 +47,6 @@ import type {
   ReasoningContentType,
   TextContentType,
 } from "@app/types/assistant/agent_message_content";
-import {
-  AgentMCPAction,
-  AgentMCPActionOutputItem,
-} from "@app/lib/models/assistant/actions/mcp";
-import { FileModel } from "@app/lib/resources/storage/models/files";
-import { MCPActionType, hideFileFromActionOutput } from "@app/lib/actions/mcp";
-import { FileResource } from "@app/lib/resources/file_resource";
-import logger from "@app/logger/logger";
 
 export function getMaximalVersionAgentStepContent(
   agentStepContents: AgentStepContentModel[]


### PR DESCRIPTION
## Description

- This PR follows up on https://github.com/dust-tt/dust/pull/14430 by replacing the new read by a shadow read, keeping the old way of fetching `AgentMCPActions`.
- We indeed have observed issues in production with conversations reaching a weird state.
- This PR aims at helping investigating those, by adding a very temporary shadow read.

## Tests

- Tested locally and on front-edge.

## Risk

- Increased latency.

## Deploy Plan

- Deploy front.
