### PR TITLE
[front] Add log on missing `stepContent`

### DIFF
--- a/front/lib/api/assistant/agent.ts
+++ b/front/lib/api/assistant/agent.ts
@@ -273,6 +273,13 @@ async function runMultiActionsAgentLoop(
             ? functionCallStepContentIds[functionCallId]
             : undefined;
 
+          if (!stepContentId) {
+            localLogger.error(
+              { functionCallId, actionId: action.id },
+              "No step content for function call"
+            );
+          }
+
           return runAction(auth, {
             configuration,
             actionConfiguration: action,

--- a/front/lib/api/assistant/agent.ts
+++ b/front/lib/api/assistant/agent.ts
@@ -275,7 +275,11 @@ async function runMultiActionsAgentLoop(
 
           if (!stepContentId) {
             localLogger.error(
-              { functionCallId, actionId: action.id },
+              {
+                functionCallId,
+                actionConfigurationId: action.sId,
+                agentConfigurationId: configuration.sId,
+              },
               "No step content for function call"
             );
           }


### PR DESCRIPTION
## Description

- This PR adds a log to track missing `stepContentId` when running an action.
- This should never happen, the goal here is to understand why this happens.

## Tests

- Tested locally, couldn't trigger the log.

## Risk

- Low, only added log.

## Deploy Plan

- Deploy front.
