### PR TITLE
Allow text substitution in interactive files

### DIFF
--- a/front/components/assistant/conversation/content/useAutoOpenInteractiveContent.ts
+++ b/front/components/assistant/conversation/content/useAutoOpenInteractiveContent.ts
@@ -27,7 +27,19 @@ export function useAutoOpenInteractiveContent({
 }: UseAutoOpenInteractiveContentProps) {
   const { openContent } = useInteractiveContentContext();
 
-  // Track which fileId was last opened to prevent progress->generated blinks.
+  // Track the last opened fileId to prevent double-opening glitch.
+  //
+  // Problem: Progress notifications and generated files represent the same content but have
+  // different hash formats:
+  // - Progress notifications: "fileId@updatedAt" (includes timestamp for real-time refresh)
+  // - Generated files: "fileId" (no updatedAt)
+  //
+  // Without tracking, the hook would open the drawer twice:
+  // 1. Progress phase: opens with "fileId@timestamp"
+  // 2. Completion phase: progress clears, opens again with "fileId"
+  //
+  // Solution: Track opened fileIds to prevent progress→generated blinks while still
+  // allowing generated→progress refreshes (when file is updated with new timestamp).
   const lastOpenedFileIdRef = React.useRef<string | null>(null);
 
   // Get interactive files from progress notifications.

--- a/front/lib/actions/mcp_internal_actions/servers/interactive_content.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/interactive_content.ts
@@ -162,7 +162,7 @@ const createServer = (
       "Performs single substitution by default, or multiple substitutions when " +
       "`expected_replacements` is defined. This function demands comprehensive contextual " +
       "information surrounding the target modification to ensure accurate targeting. " +
-      `Always utilize the ${RETRIEVE_INTERACTIVE_FILE_TOOL_NAME} tool to review the file's ` +
+      `Use the ${RETRIEVE_INTERACTIVE_FILE_TOOL_NAME} tool to review the file's ` +
       "existing content prior to executing any text substitution. Requirements: " +
       "1. `old_string` MUST contain the precise literal content for substitution " +
       "(preserving all spacing, formatting, line breaks). " +
@@ -265,7 +265,7 @@ const createServer = (
     RETRIEVE_INTERACTIVE_FILE_TOOL_NAME,
     "Retrieve the current content of an existing interactive file by its file ID. " +
       "Use this to read back the content of interactive files you have previously created or " +
-      `updated. Always use this tool before calling interactive_content${EDIT_INTERACTIVE_FILE_TOOL_NAME} to ` +
+      `updated. Use this tool before calling ${EDIT_INTERACTIVE_FILE_TOOL_NAME} to ` +
       "understand the current file state and identify the exact text to replace.",
     {
       file_id: z

--- a/front/lib/actions/mcp_internal_actions/servers/interactive_content.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/interactive_content.ts
@@ -224,8 +224,6 @@ const createServer = (
           `File '${fileResource.sId}' updated successfully. Made ` +
           `${replacementCount} replacement${pluralS}`;
 
-        console.log(">>> _meta", _meta);
-
         if (_meta?.progressToken) {
           const notification: MCPProgressNotificationType = {
             method: "notifications/progress",

--- a/front/lib/api/assistant/visualization_with_interactive_content.ts
+++ b/front/lib/api/assistant/visualization_with_interactive_content.ts
@@ -122,9 +122,9 @@ ${CREATE_INTERACTIVE_FILE_TOOL_NAME}({
 })
 \`\`\`
 
-Example File Editing Workflow - ALWAYS RETRIEVE FIRST:
+Example File Editing Workflow:
 
-**Step 1: Always retrieve the current file content first**
+**Step 1: Retrieve the current file content first**
 \`\`\`
 ${RETRIEVE_INTERACTIVE_FILE_TOOL_NAME}({
   file_id: "fil_abc123"
@@ -132,7 +132,7 @@ ${RETRIEVE_INTERACTIVE_FILE_TOOL_NAME}({
 // This returns the current file content - examine it carefully to identify the exact text to replace
 \`\`\`
 
-**Step 2: Use the retrieved content to make targeted edits**
+**Step 2: Make targeted edits using the retrieved content**
 \`\`\`
 ${EDIT_INTERACTIVE_FILE_TOOL_NAME}({
   file_id: "fil_abc123",
@@ -142,7 +142,7 @@ ${EDIT_INTERACTIVE_FILE_TOOL_NAME}({
 })
 \`\`\`
 
-**CRITICAL:** Never edit a file without first using ${RETRIEVE_INTERACTIVE_FILE_TOOL_NAME}. The old_string must exactly match what's currently in the file, including all whitespace, indentation, and line breaks.
+The edit tool requires exact text matching, so retrieving the current content first ensures your edits will succeed.
 
 General example of a React component for interactive content:
 

--- a/front/lib/api/assistant/visualization_with_interactive_content.ts
+++ b/front/lib/api/assistant/visualization_with_interactive_content.ts
@@ -3,6 +3,7 @@ import {
   EDIT_INTERACTIVE_FILE_TOOL_NAME,
   RETRIEVE_INTERACTIVE_FILE_TOOL_NAME,
 } from "@app/lib/actions/mcp_internal_actions/servers/interactive_content";
+import { clientExecutableContentType } from "@app/types";
 
 export const visualizationWithInteractiveContentSystemPrompt = () => `\
 ## CREATING VISUALIZATIONS WITH INTERACTIVE CONTENT
@@ -11,7 +12,7 @@ You have access to an interactive content system that allows you to create and u
 
 ### File Management Guidelines:
 - Use the \`${CREATE_INTERACTIVE_FILE_TOOL_NAME}\` tool to create JavaScript/TypeScript files
-- Use MIME type: \`application/vnd.dust.client-executable\`
+- Use MIME type: \`${clientExecutableContentType}\`
 - Supported file extensions: .js, .jsx, .ts, .tsx
 - Files are automatically made available to the user for execution
 
@@ -116,7 +117,7 @@ Example File Creation:
 \`\`\`
 ${CREATE_INTERACTIVE_FILE_TOOL_NAME}({
   file_name: "SineCosineChart.tsx",
-  mime_type: "application/vnd.dust.client-executable",
+  mime_type: "${clientExecutableContentType}",
   content: \`[React component code shown below]\`
 })
 \`\`\`

--- a/front/lib/api/assistant/visualization_with_interactive_content.ts
+++ b/front/lib/api/assistant/visualization_with_interactive_content.ts
@@ -1,15 +1,25 @@
-import { CREATE_INTERACTIVE_FILE_TOOL_NAME } from "@app/lib/actions/mcp_internal_actions/servers/interactive_content";
+import {
+  CREATE_INTERACTIVE_FILE_TOOL_NAME,
+  EDIT_INTERACTIVE_FILE_TOOL_NAME,
+  RETRIEVE_INTERACTIVE_FILE_TOOL_NAME,
+} from "@app/lib/actions/mcp_internal_actions/servers/interactive_content";
 
 export const visualizationWithInteractiveContentSystemPrompt = () => `\
 ## CREATING VISUALIZATIONS WITH INTERACTIVE CONTENT
 
 You have access to an interactive content system that allows you to create and update executable files. When creating visualizations, you should create files instead of using the :::visualization directive.
 
-### File Creation Guidelines:
+### File Management Guidelines:
 - Use the \`${CREATE_INTERACTIVE_FILE_TOOL_NAME}\` tool to create JavaScript/TypeScript files
 - Use MIME type: \`application/vnd.dust.client-executable\`
 - Supported file extensions: .js, .jsx, .ts, .tsx
 - Files are automatically made available to the user for execution
+
+### Updating Existing Files:
+- To modify existing interactive files, always use \`${RETRIEVE_INTERACTIVE_FILE_TOOL_NAME}\` first to read the current content
+- Then use \`${EDIT_INTERACTIVE_FILE_TOOL_NAME}\` to make targeted changes by replacing specific text
+- The edit tool requires exact text matching - include surrounding context for unique identification
+- Never attempt to edit without first retrieving the current file content
 
 ### React Component Guidelines:
 - The generated component should always be exported as default
@@ -69,16 +79,6 @@ You have access to an interactive content system that allows you to create and u
   - Create files for interactive React components that require user interaction
   - Create files for complex visualizations that benefit from being standalone components
 
-Example File Creation:
-
-\`\`\`
-${CREATE_INTERACTIVE_FILE_TOOL_NAME}({
-  file_name: "SineCosineChart.tsx",
-  mime_type: "application/vnd.dust.client-executable",
-  content: \`[Use the same React component code as shown in the Examples section above]\`
-})
-\`\`\`
-
 Example using the \`useFile\` hook:
 
 \`\`\`
@@ -111,9 +111,39 @@ import { triggerUserFileDownload } from "@dust/react-hooks";
 </button>
 \`\`\`
 
-General example of a visualization component:
+Example File Creation:
 
-In response of a user asking a plot of sine and cosine functions the following :::visualization directive can be inlined anywhere in the agent response:
+\`\`\`
+${CREATE_INTERACTIVE_FILE_TOOL_NAME}({
+  file_name: "SineCosineChart.tsx",
+  mime_type: "application/vnd.dust.client-executable",
+  content: \`[React component code shown below]\`
+})
+\`\`\`
+
+Example File Editing Workflow - ALWAYS RETRIEVE FIRST:
+
+**Step 1: Always retrieve the current file content first**
+\`\`\`
+${RETRIEVE_INTERACTIVE_FILE_TOOL_NAME}({
+  file_id: "fil_abc123"
+})
+// This returns the current file content - examine it carefully to identify the exact text to replace
+\`\`\`
+
+**Step 2: Use the retrieved content to make targeted edits**
+\`\`\`
+${EDIT_INTERACTIVE_FILE_TOOL_NAME}({
+  file_id: "fil_abc123",
+  old_string: "  for (let x = 0; x <= 360; x += 10) {\\n    const radians = (x * Math.PI) / 180;\\n    data.push({",
+  new_string: "  for (let x = 0; x <= 720; x += 5) {\\n    const radians = (x * Math.PI) / 180;\\n    data.push({",
+  expected_replacements: 1,
+})
+\`\`\`
+
+**CRITICAL:** Never edit a file without first using ${RETRIEVE_INTERACTIVE_FILE_TOOL_NAME}. The old_string must exactly match what's currently in the file, including all whitespace, indentation, and line breaks.
+
+General example of a React component for interactive content:
 
 import React from "react";
 import {

--- a/front/lib/api/files/utils.ts
+++ b/front/lib/api/files/utils.ts
@@ -6,7 +6,10 @@ import { pipeline } from "stream/promises";
 
 import type { Authenticator } from "@app/lib/auth";
 import type { DustError } from "@app/lib/error";
-import type { FileResource } from "@app/lib/resources/file_resource";
+import type {
+  FileResource,
+  FileVersion,
+} from "@app/lib/resources/file_resource";
 import type { Result } from "@app/types";
 import { Err, Ok } from "@app/types";
 
@@ -106,16 +109,14 @@ class MemoryWritable extends Writable {
 
 export async function getFileContent(
   auth: Authenticator,
-  file: FileResource
+  file: FileResource,
+  version: FileVersion = "processed"
 ): Promise<string | null> {
   // Create a stream to hold the content of the file
   const writableStream = new MemoryWritable();
 
   // Read from the processed file
-  await pipeline(
-    file.getReadStream({ auth, version: "processed" }),
-    writableStream
-  );
+  await pipeline(file.getReadStream({ auth, version }), writableStream);
 
   const content = writableStream.getContent();
 

--- a/front/lib/resources/file_resource.ts
+++ b/front/lib/resources/file_resource.ts
@@ -216,6 +216,10 @@ export class FileResource extends BaseResource<FileModel> {
     return this.status === "failed";
   }
 
+  get updatedAtMs(): number {
+    return this.updatedAt.getTime();
+  }
+
   // Cloud storage logic.
 
   getPrivateUrl(auth: Authenticator): string {


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
This PR goes one step further on the interactive file management by offering an edit tool that let you do a text substitution. as generating code can be pretty slow. The goal here is to let the model only replace part of the code. This tool is highly inspired from here:
https://github.com/dust-tt/dust/blob/781b5f8e1b0327856d7b096ae60404d1b1303cf4/cli/src/mcp/tools/editFile.ts#L8-L153

Interestingly, mentioning to use the retrieve tool before using the edit tool on their respective description is not enough, the real catch here is the example in the system prompt attached to interactive files. 

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
