### PR TITLE
[front] Remove nullability on `functionCallId` when applicable

### DIFF
--- a/front/lib/actions/mcp.ts
+++ b/front/lib/actions/mcp.ts
@@ -322,7 +322,7 @@ export class MCPActionType extends BaseAction {
   readonly mcpServerConfigurationId: string;
   readonly params: Record<string, unknown>; // Hold the inputs for the action.
   readonly output: CallToolResult["content"] | null;
-  // TODO(durable-agents): make this non nullable.
+  // TODO(durable-agents): drop this column.
   readonly functionCallId: string | null;
   readonly functionCallName: string | null;
   readonly step: number = -1;

--- a/front/lib/actions/mcp.ts
+++ b/front/lib/actions/mcp.ts
@@ -322,6 +322,7 @@ export class MCPActionType extends BaseAction {
   readonly mcpServerConfigurationId: string;
   readonly params: Record<string, unknown>; // Hold the inputs for the action.
   readonly output: CallToolResult["content"] | null;
+  // TODO(durable-agents): make this non nullable.
   readonly functionCallId: string | null;
   readonly functionCallName: string | null;
   readonly step: number = -1;

--- a/front/lib/actions/types/index.ts
+++ b/front/lib/actions/types/index.ts
@@ -97,7 +97,7 @@ export interface BaseActionRunParams {
   conversation: ConversationType;
   agentMessage: AgentMessageType;
   rawInputs: Record<string, unknown>;
-  functionCallId: string | null;
+  functionCallId: string;
   step: number;
   stepContentId?: ModelId;
 }

--- a/front/lib/models/assistant/actions/mcp.ts
+++ b/front/lib/models/assistant/actions/mcp.ts
@@ -185,6 +185,7 @@ export class AgentMCPAction extends WorkspaceAwareModel<AgentMCPAction> {
 
   declare params: Record<string, unknown>;
 
+  // TODO(durable-agents): make this non nullable.
   declare functionCallId: string | null;
   declare functionCallName: string | null;
 

--- a/front/lib/models/assistant/actions/mcp.ts
+++ b/front/lib/models/assistant/actions/mcp.ts
@@ -185,7 +185,7 @@ export class AgentMCPAction extends WorkspaceAwareModel<AgentMCPAction> {
 
   declare params: Record<string, unknown>;
 
-  // TODO(durable-agents): make this non nullable.
+  // TODO(durable-agents): drop this column (in addition to params and functionCallName).
   declare functionCallId: string | null;
   declare functionCallName: string | null;
 

--- a/front/temporal/agent_loop/activities/run_model.ts
+++ b/front/temporal/agent_loop/activities/run_model.ts
@@ -429,7 +429,7 @@ export async function runModelActivity({
   const { eventStream, dustRunId } = res.value;
   let output: {
     actions: Array<{
-      functionCallId: string | null;
+      functionCallId: string;
       name: string | null;
       arguments: Record<string, string | boolean | number> | null;
     }>;

--- a/front/temporal/agent_loop/activities/run_tool.ts
+++ b/front/temporal/agent_loop/activities/run_tool.ts
@@ -24,7 +24,7 @@ export async function runToolActivity(
   }: {
     runAgentArgs: RunAgentArgs;
     inputs: Record<string, string | boolean | number>;
-    functionCallId: string | null;
+    functionCallId: string;
     step: number;
     stepActionIndex: number;
     stepActions: ActionConfigurationType[];

--- a/front/types/assistant/agent.ts
+++ b/front/types/assistant/agent.ts
@@ -285,7 +285,7 @@ export type AgentActionsEvent = {
   actions: Array<{
     action: ActionConfigurationType;
     inputs: Record<string, string | boolean | number>;
-    functionCallId: string | null;
+    functionCallId: string;
   }>;
 };
 


### PR DESCRIPTION
## Description

- The goal of this PR is to ensure that functionCallId is not nullable when possible, which includes the content that is retrieved from  the blocks (the type in `core` ensure that it's not null).
- The column in db is still nullable, this cannot be fixed without a backfill; some values are null currently, interestingly they were all updated either on July 15, 2025 around 9:40 AM or on July 16, 2025 around 11:30 PM, which matches the execution date of `20250709_agent_mcp_action_fk_step_content.ts`, meaning that it either introduced the issue or affects the same rows exactly.
```sql
SELECT MIN("updatedAt"),MAX("updatedAt") FROM agent_mcp_actions mcp WHERE "functionCallId" IS NULL;
```

## Tests

- `tsc`

## Risk

- Low, only type changes + TODOs.

## Deploy Plan

- Deploy front.
