### PR TITLE
[core] Prevent empty strings as `functionCallId` on Gemini models

### DIFF
--- a/core/src/providers/openai_compatible_helpers.rs
+++ b/core/src/providers/openai_compatible_helpers.rs
@@ -140,7 +140,7 @@ impl TryFrom<&OpenAIToolCall> for ChatFunctionCall {
 
     fn try_from(tc: &OpenAIToolCall) -> Result<Self, Self::Error> {
         // Some providers don't provide a function call ID (eg google_ai_studio)
-        // or provide an empty string ID
+        // or provide an empty string ID.
         let id = tc
             .id
             .clone()

--- a/core/src/providers/openai_compatible_helpers.rs
+++ b/core/src/providers/openai_compatible_helpers.rs
@@ -140,9 +140,11 @@ impl TryFrom<&OpenAIToolCall> for ChatFunctionCall {
 
     fn try_from(tc: &OpenAIToolCall) -> Result<Self, Self::Error> {
         // Some providers don't provide a function call ID (eg google_ai_studio)
+        // or provide an empty string ID
         let id = tc
             .id
             .clone()
+            .filter(|id| !id.is_empty())
             .unwrap_or(format!("fc_{}", utils::new_id()[0..9].to_string()));
 
         Ok(ChatFunctionCall {


### PR DESCRIPTION
## Description

We have some entries in db where we got an empty `functionCallId` from a provider's API:
```sql
SELECT * FROM agent_mcp_actions mcp
JOIN messages m
ON m."agentMessageId" = mcp."agentMessageId"
JOIN conversations c
ON c.id = m."conversationId"
WHERE c."sId" = '4oK4bhmpNV'
AND mcp."functionCallId" = '';
```

The issue seems to be scoped to Gemini models.
```sql
SELECT ac."sId",ac."modelId",ac."providerId" FROM agent_mcp_actions mcp
JOIN agent_messages m
ON mcp."agentMessageId" = m.id
JOIN agent_configurations ac
ON ac."sId" = m."agentConfigurationId"
AND ac.version = m."agentConfigurationVersion"
WHERE "functionCallId" = '';
```
This causes an issue due to a weak comparison when matching function call IDs with agent step content IDs https://github.com/dust-tt/dust/blob/c2848c06b6f36734222d8074773d0d4c5cb7a6bd/front/lib/api/assistant/agent.ts#L189

This PR addresses this issue by correctly using the fallback generated value for `functionCallId` (same handling as for `None` values).

## Tests

- Tested locally, but didn't reproduce anyway.

## Risk

- Low.

## Deploy Plan

- Deploy core.
