### PR TITLE
[connectors] feat(crawl): sitemap only

### DIFF
--- a/connectors/migrations/db/migration_85.sql
+++ b/connectors/migrations/db/migration_85.sql
@@ -1,3 +1,3 @@
--- Migration created on Jul 11, 2025
+-- Migration created on Jul 21, 2025
 ALTER TABLE "webcrawler_configuration" ADD COLUMN "sitemapOnly" boolean NOT NULL DEFAULT FALSE;
 UPDATE "webcrawler_configuration" SET "sitemapOnly" = FALSE;

--- a/connectors/migrations/db/migration_85.sql
+++ b/connectors/migrations/db/migration_85.sql
@@ -1,0 +1,3 @@
+-- Migration created on Jul 11, 2025
+ALTER TABLE "webcrawler_configuration" ADD COLUMN "sitemapOnly" boolean NOT NULL DEFAULT FALSE;
+UPDATE "webcrawler_configuration" SET "sitemapOnly" = FALSE;

--- a/connectors/src/api/webhooks/webhook_firecrawl.ts
+++ b/connectors/src/api/webhooks/webhook_firecrawl.ts
@@ -30,7 +30,15 @@ const _webhookFirecrawlAPIHandler = async (
     FirecrawlWebhookResBody,
     {
       success: boolean;
-      type: "crawl.started" | "crawl.page" | "crawl.completed" | "crawl.failed";
+      type:
+        | "crawl.started"
+        | "crawl.page"
+        | "crawl.completed"
+        | "crawl.failed"
+        | "batch_scrape.started"
+        | "batch_scrape.page"
+        | "batch_scrape.failed"
+        | "batch_scrape.completed";
       id: string;
       data: Array<{
         markdown: string;
@@ -82,6 +90,7 @@ const _webhookFirecrawlAPIHandler = async (
   }
 
   switch (type) {
+    case "batch_scrape.started":
     case "crawl.started": {
       logger.info(
         {
@@ -109,6 +118,7 @@ const _webhookFirecrawlAPIHandler = async (
       }
       break;
     }
+    case "batch_scrape.page":
     case "crawl.page": {
       if (data && data.length > 0) {
         for (const page of data) {
@@ -164,6 +174,7 @@ const _webhookFirecrawlAPIHandler = async (
       }
       break;
     }
+    case "batch_scrape.completed":
     case "crawl.completed": {
       logger.info(
         { id, metadata, connectorId: connector.id },
@@ -187,6 +198,7 @@ const _webhookFirecrawlAPIHandler = async (
       }
       break;
     }
+    case "batch_scrape.failed":
     case "crawl.failed": {
       logger.info(
         { id, metadata, connectorId: connector.id, error },

--- a/connectors/src/connectors/webcrawler/index.ts
+++ b/connectors/src/connectors/webcrawler/index.ts
@@ -74,6 +74,7 @@ export class WebcrawlerConnectorManager extends BaseConnectorManager<WebCrawlerC
       crawlFrequency: configuration.crawlFrequency,
       lastCrawledAt: null,
       headers: configuration.headers,
+      sitemapOnly: false,
     };
 
     const connector = await ConnectorResource.makeNew(

--- a/connectors/src/connectors/webcrawler/lib/utils.test.ts
+++ b/connectors/src/connectors/webcrawler/lib/utils.test.ts
@@ -1,38 +1,35 @@
 import { describe, expect, test } from "vitest";
 
+import { WebCrawlerConfigurationResourceFactory } from "@connectors/tests/utils/WebCrawlerConfigurationFactory";
+
 import { shouldCrawlLink } from "./utils";
 
 describe("shouldCrawlLink", () => {
-  // Base configuration for tests
-  const baseConfig = {
-    url: "https://example.com/blog",
-    depth: 3,
-    crawlMode: "website",
-  };
+  const baseConfig = WebCrawlerConfigurationResourceFactory.createMock();
 
   describe("Domain and path validation", () => {
     test("should return true for links on the same domain", () => {
       const link = "https://example.com/about";
-      const result = shouldCrawlLink(link, baseConfig, 0);
+      const result = shouldCrawlLink(link, baseConfig);
       expect(result).toBe(true);
     });
 
     test("should return true for child paths of config URL", () => {
       const link = "https://example.com/blog/post-1";
-      const result = shouldCrawlLink(link, baseConfig, 0);
+      const result = shouldCrawlLink(link, baseConfig);
       expect(result).toBe(true);
     });
 
     test("should return false for different domains", () => {
       const link = "https://different-domain.com/blog";
-      const result = shouldCrawlLink(link, baseConfig, 0);
+      const result = shouldCrawlLink(link, baseConfig);
       expect(result).toBe(false);
     });
 
     test("should handle relative URLs correctly", () => {
       // This would be resolved relative to baseConfig.url in the actual function
       const link = "https://example.com/blog/category/post";
-      const result = shouldCrawlLink(link, baseConfig, 0);
+      const result = shouldCrawlLink(link, baseConfig);
       expect(result).toBe(true);
     });
   });
@@ -40,96 +37,86 @@ describe("shouldCrawlLink", () => {
   describe("Depth limitations", () => {
     test("should return true when current depth + 1 is less than config depth", () => {
       const link = "https://example.com/blog/post";
-      const result = shouldCrawlLink(link, baseConfig, 1); // 1 + 1 < 3
+      const result = shouldCrawlLink(link, baseConfig);
       expect(result).toBe(true);
     });
 
-    test("should return false when current depth + 1 equals config depth", () => {
-      const link = "https://example.com/blog/post";
-      const result = shouldCrawlLink(link, baseConfig, 2); // 2 + 1 = 3
-      expect(result).toBe(false);
-    });
-
-    test("should return false when current depth + 1 exceeds config depth", () => {
-      const link = "https://example.com/blog/post";
-      const result = shouldCrawlLink(link, baseConfig, 3); // 3 + 1 > 3
-      expect(result).toBe(false);
-    });
-
-    test("should return false when current depth + 1 equals WEBCRAWLER_MAX_DEPTH", () => {
-      const link = "https://example.com/blog/post";
-      const deepConfig = { ...baseConfig, depth: 10 }; // Higher than WEBCRAWLER_MAX_DEPTH
-      const result = shouldCrawlLink(link, deepConfig, 4); // 4 + 1 = 5 (WEBCRAWLER_MAX_DEPTH)
-      expect(result).toBe(false);
-    });
-
-    test("should return false when current depth + 1 exceeds WEBCRAWLER_MAX_DEPTH", () => {
-      const link = "https://example.com/blog/post";
-      const deepConfig = { ...baseConfig, depth: 10 };
-      const result = shouldCrawlLink(link, deepConfig, 5); // 5 + 1 > 5
+    test("should return false when depth exceeds WEBCRAWLER_MAX_DEPTH", () => {
+      const link = "https://example.com/blog/post/foo/bar/hello/foor";
+      const deepConfig = WebCrawlerConfigurationResourceFactory.createMock({
+        depth: 5,
+      });
+      const result = shouldCrawlLink(link, deepConfig);
       expect(result).toBe(false);
     });
   });
 
   describe("Crawl mode restrictions", () => {
     test('should return true for child paths when crawlMode is "child"', () => {
-      const childConfig = { ...baseConfig, crawlMode: "child" };
+      const childConfig = WebCrawlerConfigurationResourceFactory.createMock({
+        crawlMode: "child",
+      });
       const link = "https://example.com/blog/post";
-      const result = shouldCrawlLink(link, childConfig, 0);
+      const result = shouldCrawlLink(link, childConfig);
       expect(result).toBe(true);
     });
 
     test('should return false for non-child paths when crawlMode is "child"', () => {
-      const childConfig = { ...baseConfig, crawlMode: "child" };
+      const childConfig = WebCrawlerConfigurationResourceFactory.createMock({
+        crawlMode: "child",
+      });
       const link = "https://example.com/about"; // Not a child of /blog
-      const result = shouldCrawlLink(link, childConfig, 0);
+      const result = shouldCrawlLink(link, childConfig);
       expect(result).toBe(false);
     });
 
     test('should return true for same domain paths when crawlMode is not "child"', () => {
-      const allConfig = { ...baseConfig, crawlMode: "website" };
       const link = "https://example.com/about"; // Not a child but same domain
-      const result = shouldCrawlLink(link, allConfig, 0);
+      const result = shouldCrawlLink(link, baseConfig);
       expect(result).toBe(true);
     });
   });
 
   describe("Edge cases and combinations", () => {
     test("should return false when domain matches but depth exceeds limits", () => {
-      const link = "https://example.com/blog/post";
-      const result = shouldCrawlLink(link, baseConfig, 3); // Depth exceeds
+      const link = "https://example.com/blog/post/foo/bar";
+      const result = shouldCrawlLink(link, baseConfig); // Depth exceeds
       expect(result).toBe(false);
     });
 
     test("should return false when path is child but domain is different", () => {
       const link = "https://different.com/blog/post"; // Child path but wrong domain
-      const result = shouldCrawlLink(link, baseConfig, 0);
+      const result = shouldCrawlLink(link, baseConfig);
       expect(result).toBe(false);
     });
 
     test("should return false when all conditions fail", () => {
-      const childConfig = { ...baseConfig, crawlMode: "child" };
+      const childConfig = WebCrawlerConfigurationResourceFactory.createMock({
+        crawlMode: "child",
+      });
       const link = "https://different.com/about"; // Wrong domain, not child, wrong mode
-      const result = shouldCrawlLink(link, childConfig, 4); // Depth also exceeds
+      const result = shouldCrawlLink(link, childConfig); // Depth also exceeds
       expect(result).toBe(false);
     });
 
     test("should return true when all conditions pass", () => {
-      const childConfig = { ...baseConfig, crawlMode: "child" };
+      const childConfig = WebCrawlerConfigurationResourceFactory.createMock({
+        crawlMode: "child",
+      });
       const link = "https://example.com/blog/post"; // Right domain, is child
-      const result = shouldCrawlLink(link, childConfig, 0); // Depth is fine
+      const result = shouldCrawlLink(link, childConfig);
       expect(result).toBe(true);
     });
 
     test("should handle URLs with query parameters correctly", () => {
       const link = "https://example.com/blog/post?id=123&sort=asc";
-      const result = shouldCrawlLink(link, baseConfig, 0);
+      const result = shouldCrawlLink(link, baseConfig);
       expect(result).toBe(true);
     });
 
     test("should handle URLs with hash fragments correctly", () => {
       const link = "https://example.com/blog/post#section1";
-      const result = shouldCrawlLink(link, baseConfig, 0);
+      const result = shouldCrawlLink(link, baseConfig);
       expect(result).toBe(true);
     });
   });
@@ -137,26 +124,26 @@ describe("shouldCrawlLink", () => {
   describe("Subdomain handling", () => {
     test("should return false for different subdomains", () => {
       const link = "https://subdomain.example.com/blog";
-      const result = shouldCrawlLink(link, baseConfig, 0);
+      const result = shouldCrawlLink(link, baseConfig);
       expect(result).toBe(false);
     });
   });
 
   describe("URL path normalization", () => {
     test("should handle trailing slashes correctly", () => {
-      const configWithTrailingSlash = {
-        ...baseConfig,
-        url: "https://example.com/blog/",
-      };
+      const configWithTrailingSlash =
+        WebCrawlerConfigurationResourceFactory.createMock({
+          url: "https://example.com/blog/",
+        });
 
       const link = "https://example.com/blog/post";
-      const result = shouldCrawlLink(link, configWithTrailingSlash, 0);
+      const result = shouldCrawlLink(link, configWithTrailingSlash);
       expect(result).toBe(true);
     });
 
     test("should handle double slashes in paths correctly", () => {
       const link = "https://example.com/blog//post";
-      const result = shouldCrawlLink(link, baseConfig, 0);
+      const result = shouldCrawlLink(link, baseConfig);
       expect(result).toBe(true);
     });
   });

--- a/connectors/src/connectors/webcrawler/temporal/activities.ts
+++ b/connectors/src/connectors/webcrawler/temporal/activities.ts
@@ -18,6 +18,7 @@ import {
   getFolderForUrl,
   getParentsForPage,
   isTopFolder,
+  shouldCrawlLink,
   stableIdForUrl,
 } from "@connectors/connectors/webcrawler/lib/utils";
 import { apiConfig } from "@connectors/lib/api/config";
@@ -305,7 +306,10 @@ async function startBatchScrapeJob(
     return;
   }
 
-  const filteredUrl = mapUrlResult.links ?? [];
+  const filteredUrl =
+    mapUrlResult.links
+      ?.filter((link) => shouldCrawlLink(link, webCrawlerConfig))
+      ?.slice(0, webCrawlerConfig.maxPageToCrawl ?? WEBCRAWLER_MAX_PAGES) ?? [];
   const batchScrapeResponse = await firecrawlApp.asyncBatchScrapeUrls(
     filteredUrl,
     getFirecrawlScrapeOptions(webCrawlerConfig),

--- a/connectors/src/connectors/webcrawler/temporal/activities.ts
+++ b/connectors/src/connectors/webcrawler/temporal/activities.ts
@@ -202,7 +202,8 @@ function formatDocumentContent({
 
 function getFirecrawlScrapeOptions(
   webCrawlerConfig: WebCrawlerConfigurationResource
-): ScrapeParams {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- For a weird reason if the generic is not provided, lint fails in CI
+): ScrapeParams<any, Action[]> {
   return {
     onlyMainContent: true,
     formats: ["markdown"],

--- a/connectors/src/connectors/webcrawler/temporal/activities.ts
+++ b/connectors/src/connectors/webcrawler/temporal/activities.ts
@@ -291,6 +291,7 @@ async function startBatchScrapeJob(
     logger,
   }: FirecrawlJobHelpersParams
 ) {
+  // Gets us all urls from the sitemaps
   const mapUrlResult = await firecrawlApp.mapUrl(url, {
     ignoreSitemap: false,
     sitemapOnly: true,

--- a/connectors/src/connectors/webcrawler/temporal/activities.ts
+++ b/connectors/src/connectors/webcrawler/temporal/activities.ts
@@ -202,15 +202,15 @@ function formatDocumentContent({
 
 function getFirecrawlScrapeOptions(
   webCrawlerConfig: WebCrawlerConfigurationResource
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- For a weird reason if the generic is not provided, lint fails in CI
-): ScrapeParams<any, Action[]> {
+) {
   return {
     onlyMainContent: true,
     formats: ["markdown"],
     headers: webCrawlerConfig.getCustomHeaders(),
     maxAge: 43_200_000, // Use last 12h of cache
     actions: webCrawlerConfig.actions ?? undefined,
-  };
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  } satisfies ScrapeParams<any, Action[]>;
 }
 
 function getFirecrawlWebhookConfig(connector: ConnectorResource) {

--- a/connectors/src/connectors/webcrawler/temporal/activities.ts
+++ b/connectors/src/connectors/webcrawler/temporal/activities.ts
@@ -200,17 +200,20 @@ function formatDocumentContent({
   };
 }
 
-function getFirecrawlScrapeOptions(
+function getFirecrawlScrapeOptions<
+  // Need that extra extend so that tsc is happy.
+  ActionSchema extends Action[] | undefined = undefined,
+>(
   webCrawlerConfig: WebCrawlerConfigurationResource
-) {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+): ScrapeParams<any, ActionSchema> {
   return {
     onlyMainContent: true,
     formats: ["markdown"],
     headers: webCrawlerConfig.getCustomHeaders(),
     maxAge: 43_200_000, // Use last 12h of cache
-    actions: webCrawlerConfig.actions ?? undefined,
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  } satisfies ScrapeParams<any, Action[]>;
+    actions: (webCrawlerConfig.actions as ActionSchema) ?? undefined,
+  };
 }
 
 function getFirecrawlWebhookConfig(connector: ConnectorResource) {

--- a/connectors/src/connectors/webcrawler/temporal/activities.ts
+++ b/connectors/src/connectors/webcrawler/temporal/activities.ts
@@ -52,8 +52,6 @@ import {
   normalizeError,
   stripNullBytes,
   validateUrl,
-  WEBCRAWLER_MAX_DEPTH,
-  WEBCRAWLER_MAX_PAGES,
 } from "@connectors/types";
 
 export async function markAsCrawled(connectorId: ModelId) {
@@ -239,11 +237,10 @@ async function startCrawlJob(
     logger,
   }: FirecrawlJobHelpersParams
 ) {
-  const maxRequestsPerCrawl =
-    webCrawlerConfig.maxPageToCrawl || WEBCRAWLER_MAX_PAGES;
+  const maxRequestsPerCrawl = webCrawlerConfig.getMaxPagesToCrawl();
 
   const crawlerResponse = await firecrawlApp.asyncCrawlUrl(url, {
-    maxDiscoveryDepth: webCrawlerConfig.depth ?? WEBCRAWLER_MAX_DEPTH,
+    maxDiscoveryDepth: webCrawlerConfig.getDepth(),
     limit: maxRequestsPerCrawl,
     crawlEntireDomain: webCrawlerConfig.crawlMode === "website",
     maxConcurrency: 2,
@@ -309,7 +306,7 @@ async function startBatchScrapeJob(
   const filteredUrl =
     mapUrlResult.links
       ?.filter((link) => shouldCrawlLink(link, webCrawlerConfig))
-      ?.slice(0, webCrawlerConfig.maxPageToCrawl ?? WEBCRAWLER_MAX_PAGES) ?? [];
+      ?.slice(0, webCrawlerConfig.getMaxPagesToCrawl()) ?? [];
   const batchScrapeResponse = await firecrawlApp.asyncBatchScrapeUrls(
     filteredUrl,
     getFirecrawlScrapeOptions(webCrawlerConfig),

--- a/connectors/src/lib/models/webcrawler.ts
+++ b/connectors/src/lib/models/webcrawler.ts
@@ -17,6 +17,7 @@ export class WebCrawlerConfigurationModel extends ConnectorBaseModel<WebCrawlerC
   declare lastCrawledAt: Date | null;
   declare crawlId: string | null;
   declare actions: Action[] | null;
+  declare sitemapOnly: boolean;
 }
 
 WebCrawlerConfigurationModel.init(
@@ -66,6 +67,11 @@ WebCrawlerConfigurationModel.init(
       type: DataTypes.JSONB,
       allowNull: true,
       defaultValue: null,
+    },
+    sitemapOnly: {
+      type: DataTypes.BOOLEAN,
+      allowNull: false,
+      defaultValue: false,
     },
   },
   {

--- a/connectors/src/resources/webcrawler_resource.ts
+++ b/connectors/src/resources/webcrawler_resource.ts
@@ -257,6 +257,10 @@ export class WebCrawlerConfigurationResource extends BaseResource<WebCrawlerConf
     return this.update({ actions });
   }
 
+  async setSitemap(sitemapOnly: boolean) {
+    return this.update({ sitemapOnly });
+  }
+
   async delete(transaction?: Transaction): Promise<Result<undefined, Error>> {
     await WebCrawlerPage.destroy({
       where: {

--- a/connectors/src/resources/webcrawler_resource.ts
+++ b/connectors/src/resources/webcrawler_resource.ts
@@ -25,6 +25,8 @@ import type { WebCrawlerConfigurationType } from "@connectors/types";
 import type { ModelId } from "@connectors/types";
 import {
   CrawlingFrequencies,
+  WEBCRAWLER_MAX_DEPTH,
+  WEBCRAWLER_MAX_PAGES,
   WebCrawlerHeaderRedactedValue,
 } from "@connectors/types";
 
@@ -243,6 +245,20 @@ export class WebCrawlerConfigurationResource extends BaseResource<WebCrawlerConf
 
   getCustomHeaders(): Record<string, string> {
     return this.headers;
+  }
+
+  /**
+   * Get the depth, or default to WEBCRAWLER_MAX_DEPTH
+   */
+  getDepth(): number {
+    return this.depth ?? WEBCRAWLER_MAX_DEPTH;
+  }
+
+  /**
+   * Get the maxPageToCrawl, or default to WEBCRAWLER_MAX_PAGES
+   */
+  getMaxPagesToCrawl(): number {
+    return this.maxPageToCrawl ?? WEBCRAWLER_MAX_PAGES;
   }
 
   async updateCrawlFrequency(crawlFrequency: CrawlingFrequency) {

--- a/connectors/src/tests/utils/WebCrawlerConfigurationFactory.ts
+++ b/connectors/src/tests/utils/WebCrawlerConfigurationFactory.ts
@@ -1,0 +1,36 @@
+import type { Attributes } from "sequelize";
+
+import { WebCrawlerConfigurationModel } from "@connectors/lib/models/webcrawler";
+import { WebCrawlerConfigurationResource } from "@connectors/resources/webcrawler_resource";
+
+export class WebCrawlerConfigurationResourceFactory {
+  /**
+   * Create a mock resource that isn't store in database
+   */
+  static createMock(
+    overrides: Partial<Attributes<WebCrawlerConfigurationModel>> = {}
+  ): WebCrawlerConfigurationResource {
+    const baseConfig = {
+      id: 1,
+      connectorId: 1,
+      url: "https://example.com/blog",
+      depth: 3,
+      maxPageToCrawl: 50,
+      crawlMode: "website",
+      crawlFrequency: "daily",
+      lastCrawledAt: null,
+      crawlId: null,
+      createdAt: new Date(),
+      updatedAt: new Date(),
+      sitemapOnly: false,
+      actions: null,
+    } satisfies Attributes<WebCrawlerConfigurationModel>;
+
+    // Create a new resource with the model and merged configuration
+    const config = { ...baseConfig, ...overrides };
+    return new WebCrawlerConfigurationResource(
+      WebCrawlerConfigurationModel,
+      config
+    );
+  }
+}


### PR DESCRIPTION
## Description
- Follow up of https://github.com/dust-tt/dust/pull/14308

Some website struggle to get crawl properly, it can have authentication layer, redirect after auth, iframe and so one. But they give a extensive sitemap with all URLs to scrape. So for those website we can now put them in `sitemapOnly` mode, this will:
1. Get the urls from the sitemap using `/map` endpoint from Firecrawl
2. Use `batch/scrape` endpoint to scrape all of those urls (with a filter based on the rules of the crawler)

It plugs nicely with our current webhook setup as batch scrape sends them the same way it does for the crawl.
Updated the method and the related test for `shouldCrawLink`, which is the method to filter link that should be scrape coming from the sitemap.

## Tests
- Setup ngrok for webhook
- Locally set a website to `sitemapOnly`, scrape said website, on top of using `actions` to authenticate ourselves.
- Got the events back in temporal
  - pages were upserted properly
  - correct markdown in the webcrawler pages

## Risk
- Low, it's a manual process to set `sitemapOnly`. We don't even have a poke plugin for that yet (coming later). This is needed only for a couple of webcrawler for the same customer for now.  Easy to switch if any issue arise.

## Deploy Plan
- [ ] Run migration to add new column and its default value
- [ ] Deploy connectors
