### PR TITLE
[front] Refactor `cacheWithRedis` to name parameters

### DIFF
--- a/front/lib/actions/mcp_internal_actions/servers/file_generation.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/file_generation.ts
@@ -119,7 +119,9 @@ const createServer = (auth: Authenticator): McpServer => {
           return formats;
         },
         () => `get_source_format_to_convert_to_${output_format}`,
-        60 * 60 * 24 * 1000
+        {
+          ttlMs: 60 * 60 * 24 * 1000,
+        }
       )();
 
       return {

--- a/front/lib/api/data_sources.ts
+++ b/front/lib/api/data_sources.ts
@@ -1322,5 +1322,7 @@ export const computeWorkspaceOverallSizeCached = cacheWithRedis(
     const workspaceId = auth.getNonNullableWorkspace().sId;
     return `compute-datasource-stats:${workspaceId}`;
   },
-  60 * 10 * 1000 // 10 minutes
+  {
+    ttlMs: 60 * 10 * 1000, // 10 minutes
+  }
 );

--- a/front/lib/api/status/index.ts
+++ b/front/lib/api/status/index.ts
@@ -57,7 +57,9 @@ export const getProviderStatusMemoized = cacheWithRedis(
   },
   // Caches data for 2 minutes to limit frequent API calls.
   // Status page rate limit is pretty aggressive.
-  2 * 60 * 1000
+  {
+    ttlMs: 2 * 60 * 1000,
+  }
 );
 
 export const getDustStatusMemoized = cacheWithRedis(
@@ -67,5 +69,7 @@ export const getDustStatusMemoized = cacheWithRedis(
   },
   // Caches data for 2 minutes to limit frequent API calls.
   // Status page rate limit is pretty aggressive.
-  2 * 60 * 1000
+  {
+    ttlMs: 2 * 60 * 1000,
+  }
 );

--- a/front/lib/api/workos/user.ts
+++ b/front/lib/api/workos/user.ts
@@ -100,7 +100,6 @@ const getRefreshedCookie = cacheWithRedis(
   },
   {
     ttlMs: 60 * 10 * 1000,
-    redisUri: undefined,
     useDistributedLock: true,
   }
 );

--- a/front/lib/api/workos/user.ts
+++ b/front/lib/api/workos/user.ts
@@ -98,9 +98,11 @@ const getRefreshedCookie = cacheWithRedis(
   (workOSSessionCookie) => {
     return `workos_session_refresh:${sha256(workOSSessionCookie)}`;
   },
-  60 * 10 * 1000,
-  undefined,
-  true
+  {
+    ttlMs: 60 * 10 * 1000,
+    redisUri: undefined,
+    useDistributedLock: true,
+  }
 );
 
 export async function getWorkOSSessionFromCookie(

--- a/front/lib/plans/usage/seats.ts
+++ b/front/lib/plans/usage/seats.ts
@@ -22,5 +22,7 @@ export const countActiveSeatsInWorkspaceCached = cacheWithRedis(
   (workspaceId) => {
     return `count-active-seats-in-workspace:${workspaceId}`;
   },
-  60 * 10 * 1000 // 10 minutes
+  {
+    ttlMs: 60 * 10 * 1000, // 10 minutes
+  }
 );

--- a/front/lib/resources/internal_mcp_server_in_memory_resource.ts
+++ b/front/lib/resources/internal_mcp_server_in_memory_resource.ts
@@ -66,7 +66,9 @@ const getCachedMetadata = cacheWithRedis(
     return metadata;
   },
   (_auth: Authenticator, id: string) => `internal-mcp-server-metadata-${id}`,
-  isDevelopment() ? 1000 : METADATA_CACHE_TTL_MS
+  {
+    ttlMs: isDevelopment() ? 1000 : METADATA_CACHE_TTL_MS,
+  }
 );
 
 export class InternalMCPServerInMemoryResource {

--- a/front/lib/utils/cache.ts
+++ b/front/lib/utils/cache.ts
@@ -33,14 +33,20 @@ type KeyResolver<Args extends unknown[]> = (...args: Args) => string;
 // const cachedFn = cacheWithRedis(fn, (fnArg1, fnArg2, ...) => `${fnArg1}-${fnArg2}`, 60 * 10 * 1000);
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 
-// if caching big objects, there is a possible race condition (mulitple calls to
+// if caching big objects, there is a possible race condition (multiple calls to
 // caching), therefore, we use a lock
 export function cacheWithRedis<T, Args extends unknown[]>(
   fn: CacheableFunction<JsonSerializable<T>, Args>,
   resolver: KeyResolver<Args>,
-  ttlMs: number,
-  redisUri?: string,
-  useDistributedLock: boolean = false
+  {
+    ttlMs,
+    redisUri,
+    useDistributedLock = false,
+  }: {
+    ttlMs: number;
+    redisUri?: string;
+    useDistributedLock?: boolean;
+  }
 ): (...args: Args) => Promise<JsonSerializable<T>> {
   if (ttlMs > 60 * 60 * 24 * 1000) {
     throw new Error("ttlMs should be less than 24 hours");


### PR DESCRIPTION
## Description

- This PR introduces a minor refactor on the `cacheWithRedis` function by naming the parameters `ttlMs`, `redisUri`, `useDistributedLock`.
- The idea is to be able to search `useDistributedLock: true` to find call sites that put this to true.
- Will do it in `connectors` in a separate PR.

## Tests

- Checked locally.

## Risk

- Very low, only a minor refactoring, no behavior change.

## Deploy Plan

- Deploy front.
