### PR TITLE
[extension] Reduce default token expiry for proactive refreshes

### DIFF
--- a/extension/platforms/chrome/background.ts
+++ b/extension/platforms/chrome/background.ts
@@ -17,7 +17,8 @@ import type { OAuthAuthorizeResponse } from "@app/shared/services/auth";
 import { jwtDecode } from "jwt-decode";
 
 const log = console.error;
-const DEFAULT_TOKEN_EXPIRY_IN_SECONDS = 5 * 60; // 5 minutes.
+// We set a value lower than the access token duration for a proactive refresh rather than a reactive one.
+const DEFAULT_TOKEN_EXPIRY_IN_SECONDS = 4 * 60; // 4 minutes
 
 // Initialize the platform service.
 const platform = new ChromeCorePlatformService();

--- a/extension/platforms/chrome/background.ts
+++ b/extension/platforms/chrome/background.ts
@@ -17,8 +17,7 @@ import type { OAuthAuthorizeResponse } from "@app/shared/services/auth";
 import { jwtDecode } from "jwt-decode";
 
 const log = console.error;
-// We set a value lower than the access token duration for a proactive refresh rather than a reactive one.
-const DEFAULT_TOKEN_EXPIRY_IN_SECONDS = 4 * 60; // 4 minutes
+const DEFAULT_TOKEN_EXPIRY_IN_SECONDS = 5 * 60; // 5 minutes.
 
 // Initialize the platform service.
 const platform = new ChromeCorePlatformService();

--- a/extension/ui/components/auth/useAuth.ts
+++ b/extension/ui/components/auth/useAuth.ts
@@ -8,6 +8,7 @@ import {
 import type { WorkspaceType } from "@dust-tt/client";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 
+const PROACTIVE_REFRESH_WINDOW_MS = 1000 * 60; // 1 minute
 const log = console.error;
 
 export const useAuthHook = () => {
@@ -102,7 +103,7 @@ export const useAuthHook = () => {
       setUser(savedUser);
 
       // Token refresh.
-      if (storedTokens.expiresAt <= Date.now()) {
+      if (storedTokens.expiresAt < Date.now() + PROACTIVE_REFRESH_WINDOW_MS) {
         await handleRefreshToken();
       }
 


### PR DESCRIPTION
## Description

- Follow up on https://github.com/dust-tt/dust/pull/13946 and [this thread](https://dust4ai.slack.com/archives/C050SM8NSPK/p1753174996580969).
- This PR reduces the default token expiry from 5 min (the actual access token duration), to 4 min to refresh it proactively and prevent race conditions between the check on the expiration and the actual expiration.

## Tests

- Tested locally, tracked the refreshes and did not get disconnected nor get any `expired_oauth_token` error.

## Risk

- Low.

## Deploy Plan

- Publish new version.
