### PR TITLE
[viz] fix button style and cropped screenshot

### DIFF
--- a/viz/app/components/VisualizationWrapper.tsx
+++ b/viz/app/components/VisualizationWrapper.tsx
@@ -355,18 +355,18 @@ export function VisualizationWrapper({
         isFullHeight ? "h-screen" : ""
       }`}
     >
-      <div className="flex flex-row gap-2 absolute top-2 right-2 bg-white rounded transition opacity-0 group-hover/viz:opacity-100 z-50">
+      <div className="flex flex-row gap-2 absolute top-2 right-2 rounded transition opacity-0 group-hover/viz:opacity-100 z-50">
         <button
           onClick={handleScreenshotDownload}
           title="Download screenshot"
-          className="h-7 px-2.5 rounded-lg label-xs inline-flex items-center justify-center border border-border dark:border-border-night text-primary dark:text-primary-night bg-background dark:bg-background-night hover:text-primary dark:hover:text-primary-night hover:bg-primary-100 dark:hover:bg-primary-900 hover:border-primary-150 dark:hover:border-border-night active:bg-primary-300 dark:active:bg-primary-900"
+          className="h-7 px-2.5 rounded-lg label-xs inline-flex items-center justify-center border border-border text-primary bg-white"
         >
           Png
         </button>
         <button
           onClick={handleSVGDownload}
           title="Download SVG"
-          className="h-7 px-2.5 rounded-lg label-xs inline-flex items-center justify-center border border-border dark:border-border-night text-primary dark:text-primary-night bg-background dark:bg-background-night hover:text-primary dark:hover:text-primary-night hover:bg-primary-100 dark:hover:bg-primary-900 hover:border-primary-150 dark:hover:border-border-night active:bg-primary-300 dark:active:bg-primary-900"
+          className="h-7 px-2.5 rounded-lg label-xs inline-flex items-center justify-center border border-border text-primary bg-white"
         >
           Svg
         </button>
@@ -374,13 +374,13 @@ export function VisualizationWrapper({
           <button
             title="Show code"
             onClick={handleDisplayCode}
-            className="h-7 px-2.5 rounded-lg label-xs inline-flex items-center justify-center border border-border dark:border-border-night text-primary dark:text-primary-night bg-background dark:bg-background-night hover:text-primary dark:hover:text-primary-night hover:bg-primary-100 dark:hover:bg-primary-900 hover:border-primary-150 dark:hover:border-border-night active:bg-primary-300 dark:active:bg-primary-900"
+            className="h-7 px-2.5 rounded-lg label-xs inline-flex items-center justify-center border border-border text-primary bg-white"
           >
             Code
           </button>
         )}
       </div>
-      <div ref={ref} className={isFullHeight ? "h-full" : ""}>
+      <div ref={ref}>
         <Runner
           code={runnerParams.code}
           scope={runnerParams.scope}


### PR DESCRIPTION
## Description
This PR is to improve the UI of new viz slightly by removing the background color in buttons and removing full height so that screenshot won't be cropped. Apparently Flavien will improve further today but I did it anyway because I couldn't resist 🦊 
 
<img width="634" height="174" alt="Screenshot 2025-07-22 at 13 12 42" src="https://github.com/user-attachments/assets/7ec7a0b9-dae2-4ca8-8e42-eabb309ad6c7" />


<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
