### PR TITLE
slack: remove rejectRateLimitedCalls + bump lib

### DIFF
--- a/connectors/migrations/20250429_autojoin_slack_channels.ts
+++ b/connectors/migrations/20250429_autojoin_slack_channels.ts
@@ -1,4 +1,5 @@
-import type { Channel } from "@slack/web-api/dist/response/ConversationsListResponse";
+// import type { Channel } from "@slack/web-api/dist/response/ConversationsListResponse";
+import type { Channel } from "@slack/web-api/dist/types/response/ConversationsInfoResponse";
 import { makeScript } from "scripts/helpers";
 
 import {

--- a/connectors/migrations/20250429_autojoin_slack_channels.ts
+++ b/connectors/migrations/20250429_autojoin_slack_channels.ts
@@ -1,4 +1,3 @@
-// import type { Channel } from "@slack/web-api/dist/response/ConversationsListResponse";
 import type { Channel } from "@slack/web-api/dist/types/response/ConversationsInfoResponse";
 import { makeScript } from "scripts/helpers";
 

--- a/connectors/package-lock.json
+++ b/connectors/package-lock.json
@@ -14,7 +14,7 @@
         "@microsoft/microsoft-graph-client": "^3.0.7",
         "@microsoft/microsoft-graph-types": "^2.40.0",
         "@notionhq/client": "^2.2.15",
-        "@slack/web-api": "^6.13.0",
+        "@slack/web-api": "^7.9.3",
         "@temporalio/activity": "^1.11.8",
         "@temporalio/client": "^1.11.8",
         "@temporalio/common": "^1.11.8",
@@ -2577,17 +2577,6 @@
         "node": ">= 14"
       }
     },
-    "node_modules/@google-cloud/common/node_modules/is-stream": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
-      "integrity": "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==",
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/@google-cloud/common/node_modules/jwa": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/jwa/-/jwa-2.0.0.tgz",
@@ -2771,17 +2760,6 @@
       },
       "engines": {
         "node": ">= 14"
-      }
-    },
-    "node_modules/@google-cloud/storage/node_modules/is-stream": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
-      "integrity": "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==",
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/@google-cloud/storage/node_modules/jwa": {
@@ -4295,15 +4273,15 @@
       }
     },
     "node_modules/@slack/logger": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@slack/logger/-/logger-3.0.0.tgz",
-      "integrity": "sha512-DTuBFbqu4gGfajREEMrkq5jBhcnskinhr4+AnfJEk48zhVeEv3XnUKGIX98B74kxhYsIMfApGGySTn7V3b5yBA==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@slack/logger/-/logger-4.0.0.tgz",
+      "integrity": "sha512-Wz7QYfPAlG/DR+DfABddUZeNgoeY7d1J39OCR2jR+v7VBsB8ezulDK5szTnDDPDwLH5IWhLvXIHlCFZV7MSKgA==",
       "dependencies": {
-        "@types/node": ">=12.0.0"
+        "@types/node": ">=18.0.0"
       },
       "engines": {
-        "node": ">= 12.13.0",
-        "npm": ">= 6.12.0"
+        "node": ">= 18",
+        "npm": ">= 8.6.0"
       }
     },
     "node_modules/@slack/types": {
@@ -4317,26 +4295,41 @@
       }
     },
     "node_modules/@slack/web-api": {
-      "version": "6.13.0",
-      "resolved": "https://registry.npmjs.org/@slack/web-api/-/web-api-6.13.0.tgz",
-      "integrity": "sha512-dv65crIgdh9ZYHrevLU6XFHTQwTyDmNqEqzuIrV+Vqe/vgiG6w37oex5ePDU1RGm2IJ90H8iOvHFvzdEO/vB+g==",
-      "license": "MIT",
+      "version": "7.9.3",
+      "resolved": "https://registry.npmjs.org/@slack/web-api/-/web-api-7.9.3.tgz",
+      "integrity": "sha512-xjnoldVJyoUe61Ltqjr2UVYBolcsTpp5ottqzSI3l41UCaJgHSHIOpGuYps+nhLFvDfGGpDGUeQ7BWiq3+ypqA==",
       "dependencies": {
-        "@slack/logger": "^3.0.0",
-        "@slack/types": "^2.11.0",
-        "@types/is-stream": "^1.1.0",
-        "@types/node": ">=12.0.0",
-        "axios": "^1.7.4",
-        "eventemitter3": "^3.1.0",
-        "form-data": "^2.5.0",
+        "@slack/logger": "^4.0.0",
+        "@slack/types": "^2.9.0",
+        "@types/node": ">=18.0.0",
+        "@types/retry": "0.12.0",
+        "axios": "^1.8.3",
+        "eventemitter3": "^5.0.1",
+        "form-data": "^4.0.0",
         "is-electron": "2.2.2",
-        "is-stream": "^1.1.0",
-        "p-queue": "^6.6.1",
-        "p-retry": "^4.0.0"
+        "is-stream": "^2",
+        "p-queue": "^6",
+        "p-retry": "^4",
+        "retry": "^0.13.1"
       },
       "engines": {
-        "node": ">= 12.13.0",
-        "npm": ">= 6.12.0"
+        "node": ">= 18",
+        "npm": ">= 8.6.0"
+      }
+    },
+    "node_modules/@slack/web-api/node_modules/form-data": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.4.tgz",
+      "integrity": "sha512-KrGhL9Q4zjj0kiUt5OO4Mr/A/jlI2jDYs5eHBpYHPcBEVSiipAvn2Ko2HnPe20rmcuuvMHNdZFp+4IlGTMF0Ow==",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "es-set-tostringtag": "^2.1.0",
+        "hasown": "^2.0.2",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/@slack/web-api/node_modules/p-queue": {
@@ -5603,14 +5596,6 @@
       "version": "4.0.4",
       "resolved": "https://registry.npmjs.org/@types/http-cache-semantics/-/http-cache-semantics-4.0.4.tgz",
       "integrity": "sha512-1m0bIFVc7eJWyve9S0RnuRgcQqF/Xd5QsUZAZeQFr1Q3/p9JWoQQEqmVy+DPTNpGXwhgIetAoYF8JSc33q29QA=="
-    },
-    "node_modules/@types/is-stream": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@types/is-stream/-/is-stream-1.1.0.tgz",
-      "integrity": "sha512-jkZatu4QVbR60mpIzjINmtS1ZF4a/FqdTUTBeQDVOQ2PYyidtwFKr0B5G6ERukKwliq+7mIXvxyppwzG5EgRYg==",
-      "dependencies": {
-        "@types/node": "*"
-      }
     },
     "node_modules/@types/jsdom": {
       "version": "21.1.7",
@@ -8755,9 +8740,9 @@
       }
     },
     "node_modules/eventemitter3": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-3.1.2.tgz",
-      "integrity": "sha512-tvtQIeLVHjDkJYnzf2dgVMxfuSGJeM/7UCG17TT4EumTfNtF+0nebF/4zWOIkCreAbtNqhGEboB6BWrwqNaw4Q=="
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.1.tgz",
+      "integrity": "sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA=="
     },
     "node_modules/events": {
       "version": "3.3.0",
@@ -9422,17 +9407,6 @@
       },
       "engines": {
         "node": ">=12"
-      }
-    },
-    "node_modules/gaxios/node_modules/is-stream": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
-      "integrity": "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==",
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/gcp-metadata": {
@@ -10808,11 +10782,14 @@
       }
     },
     "node_modules/is-stream": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
-      "integrity": "sha512-uQPm8kcs47jx38atAcWTVxyltQYoPT68y9aWYdV6yWXSyW8mzSat0TL6CiWdZeCdF3KrAvpVtnHbTv4RN+rqdQ==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
+      "integrity": "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==",
       "engines": {
-        "node": ">=0.10.0"
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/is-string": {
@@ -17212,17 +17189,6 @@
       },
       "engines": {
         "node": ">= 6"
-      }
-    },
-    "node_modules/winston/node_modules/is-stream": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
-      "integrity": "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==",
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/winston/node_modules/readable-stream": {

--- a/connectors/package.json
+++ b/connectors/package.json
@@ -23,7 +23,7 @@
     "@microsoft/microsoft-graph-client": "^3.0.7",
     "@microsoft/microsoft-graph-types": "^2.40.0",
     "@notionhq/client": "^2.2.15",
-    "@slack/web-api": "^6.13.0",
+    "@slack/web-api": "^7.9.3",
     "@temporalio/activity": "^1.11.8",
     "@temporalio/client": "^1.11.8",
     "@temporalio/common": "^1.11.8",

--- a/connectors/src/api/webhooks/webhook_slack.ts
+++ b/connectors/src/api/webhooks/webhook_slack.ts
@@ -152,10 +152,7 @@ const _webhookSlackAPIHandler = async (
               });
             }
 
-            const slackClient = await getSlackClient(slackConfig.connectorId, {
-              // Do not reject rate limited calls in webhook handler.
-              rejectRateLimitedCalls: false,
-            });
+            const slackClient = await getSlackClient(slackConfig.connectorId);
 
             const myUserId = await getBotUserIdMemoized(
               slackClient,
@@ -499,10 +496,7 @@ const _webhookSlackAPIHandler = async (
             });
           }
 
-          const slackClient = await getSlackClient(slackConfig.connectorId, {
-            // Do not reject rate limited calls in webhook handler.
-            rejectRateLimitedCalls: false,
-          });
+          const slackClient = await getSlackClient(slackConfig.connectorId);
 
           const myUserId = await getBotUserIdMemoized(
             slackClient,

--- a/connectors/src/api/webhooks/webhook_slack_bot.ts
+++ b/connectors/src/api/webhooks/webhook_slack_bot.ts
@@ -132,10 +132,7 @@ const _webhookSlackBotAPIHandler = async (
               });
             }
 
-            const slackClient = await getSlackClient(slackConfig.connectorId, {
-              // Do not reject rate limited calls in webhook handler.
-              rejectRateLimitedCalls: false,
-            });
+            const slackClient = await getSlackClient(slackConfig.connectorId);
 
             const myUserId = await getBotUserIdMemoized(
               slackClient,

--- a/connectors/src/connectors/slack/auto_read_channel.ts
+++ b/connectors/src/connectors/slack/auto_read_channel.ts
@@ -50,10 +50,7 @@ export async function autoReadChannel(
   if (!connector) {
     return new Err(new Error(`Connector ${connectorId} not found`));
   }
-  const slackClient = await getSlackClient(connectorId, {
-    // Do not reject rate limited calls in auto read channel. Mostly calls from webhooks.
-    rejectRateLimitedCalls: false,
-  });
+  const slackClient = await getSlackClient(connectorId);
 
   reportSlackUsage({
     connectorId,

--- a/connectors/src/connectors/slack/bot.ts
+++ b/connectors/src/connectors/slack/bot.ts
@@ -142,10 +142,7 @@ export async function botAnswerMessage(
       // This means that the message has been deleted, so we don't need to send an error message.
       return new Ok(undefined);
     }
-    const slackClient = await getSlackClient(connector.id, {
-      // Do not reject rate limited calls in bot answer message.
-      rejectRateLimitedCalls: false,
-    });
+    const slackClient = await getSlackClient(connector.id);
     try {
       reportSlackUsage({
         connectorId: connector.id,
@@ -220,10 +217,7 @@ export async function botReplaceMention(
       },
       "Unexpected exception updating mention on Chat Bot message"
     );
-    const slackClient = await getSlackClient(connector.id, {
-      // Do not reject rate limited calls in bot replace mention.
-      rejectRateLimitedCalls: false,
-    });
+    const slackClient = await getSlackClient(connector.id);
     reportSlackUsage({
       connectorId: connector.id,
       method: "chat.postMessage",
@@ -324,10 +318,7 @@ export async function botValidateToolExecution(
         );
       }
     }
-    const slackClient = await getSlackClient(connector.id, {
-      // Do not reject rate limited calls in bot validate tool execution.
-      rejectRateLimitedCalls: false,
-    });
+    const slackClient = await getSlackClient(connector.id);
 
     reportSlackUsage({
       connectorId: connector.id,
@@ -352,10 +343,7 @@ export async function botValidateToolExecution(
       },
       "Unexpected exception validating tool execution"
     );
-    const slackClient = await getSlackClient(connector.id, {
-      // Do not reject rate limited calls in bot validate tool execution.
-      rejectRateLimitedCalls: false,
-    });
+    const slackClient = await getSlackClient(connector.id);
 
     reportSlackUsage({
       connectorId: connector.id,
@@ -404,10 +392,7 @@ async function processErrorResult(
       slackChatBotMessage?.conversationId
     );
 
-    const slackClient = await getSlackClient(connector.id, {
-      // Do not reject rate limited calls in process error result.
-      rejectRateLimitedCalls: false,
-    });
+    const slackClient = await getSlackClient(connector.id);
 
     const errorPost = makeErrorBlock(
       conversationUrl,
@@ -479,10 +464,7 @@ async function answerMessage(
   }
 
   // We start by retrieving the slack user info.
-  const slackClient = await getSlackClient(connector.id, {
-    // Do not reject rate limited calls in answer message.
-    rejectRateLimitedCalls: false,
-  });
+  const slackClient = await getSlackClient(connector.id);
 
   let slackUserInfo: SlackUserInfo | null = null;
 

--- a/connectors/src/connectors/slack/bot.ts
+++ b/connectors/src/connectors/slack/bot.ts
@@ -16,7 +16,7 @@ import {
   removeNulls,
 } from "@dust-tt/client";
 import type { WebClient } from "@slack/web-api";
-import type { MessageElement } from "@slack/web-api/dist/response/ConversationsHistoryResponse";
+import type { MessageElement } from "@slack/web-api/dist/types/response/ConversationsRepliesResponse";
 import removeMarkdown from "remove-markdown";
 import jaroWinkler from "talisman/metrics/jaro-winkler";
 
@@ -409,7 +409,6 @@ async function processErrorResult(
       await slackClient.chat.update({
         ...errorPost,
         channel: slackChannel,
-        thread_ts: slackMessageTs,
         ts: mainMessage.ts,
       });
     } else {

--- a/connectors/src/connectors/slack/chat/stream_conversation_handler.ts
+++ b/connectors/src/connectors/slack/chat/stream_conversation_handler.ts
@@ -329,7 +329,7 @@ async function postSlackMessageUpdate(
   let lastSentDate = new Date();
   let backoffTime = initialBackoffTime;
 
-  const { slackChannelId, slackMessageTs, slackClient } = slack;
+  const { slackChannelId, slackClient } = slack;
   const conversationUrl = makeConversationUrl(
     connector.workspaceId,
     conversation.sId
@@ -355,7 +355,6 @@ async function postSlackMessageUpdate(
       messageUpdate
     ),
     channel: slackChannelId,
-    thread_ts: slackMessageTs,
     ts: mainMessage.ts as string,
   });
 

--- a/connectors/src/connectors/slack/index.ts
+++ b/connectors/src/connectors/slack/index.ts
@@ -124,10 +124,7 @@ export class SlackConnectorManager extends BaseConnectorManager<SlackConfigurati
 
     if (connectionId) {
       const accessToken = await getSlackAccessToken(connectionId);
-      const slackClient = await getSlackClient(accessToken, {
-        // Do not reject rate limited calls in update connector. Called from the API.
-        rejectRateLimitedCalls: false,
-      });
+      const slackClient = await getSlackClient(accessToken);
 
       reportSlackUsage({
         connectorId: c.id,
@@ -605,10 +602,7 @@ export async function uninstallSlack(
 
   try {
     const slackAccessToken = await getSlackAccessToken(connectionId);
-    const slackClient = await getSlackClient(slackAccessToken, {
-      // Do not reject rate limited calls in uninstall slack. Called from the API.
-      rejectRateLimitedCalls: false,
-    });
+    const slackClient = await getSlackClient(slackAccessToken);
     reportSlackUsage({
       connectorId: Number(connectionId),
       method: "auth.test",
@@ -725,10 +719,7 @@ async function getFilteredChannels(
       }))
     );
   } else {
-    const slackClient = await getSlackClient(connectorId, {
-      // Do not reject rate limited calls in update connector. Called from the API.
-      rejectRateLimitedCalls: false,
-    });
+    const slackClient = await getSlackClient(connectorId);
 
     const [remoteChannels, localChannels] = await Promise.all([
       getChannels(slackClient, connectorId, false),

--- a/connectors/src/connectors/slack/lib/bot_user_helpers.ts
+++ b/connectors/src/connectors/slack/lib/bot_user_helpers.ts
@@ -1,5 +1,5 @@
 import type { WebClient } from "@slack/web-api";
-import type { MessageElement } from "@slack/web-api/dist/response/ConversationsHistoryResponse";
+import type { MessageElement } from "@slack/web-api/dist/types/response/ConversationsHistoryResponse";
 
 import {
   isSlackWebAPIPlatformError,

--- a/connectors/src/connectors/slack/lib/channels.ts
+++ b/connectors/src/connectors/slack/lib/channels.ts
@@ -1,10 +1,7 @@
 import type { Result } from "@dust-tt/client";
 import { Err, Ok } from "@dust-tt/client";
 import type { WebClient } from "@slack/web-api";
-import type {
-  Channel,
-  ConversationsListResponse,
-} from "@slack/web-api/dist/response/ConversationsListResponse";
+import type { Channel } from "@slack/web-api/dist/types/response/ConversationsInfoResponse";
 import { Op } from "sequelize";
 
 import { isSlackWebAPIPlatformError } from "@connectors/connectors/slack/lib/errors";
@@ -313,7 +310,7 @@ async function _getTypedChannelsUncached(
       method: "conversations.list",
       useCase: "batch_sync",
     });
-    const c: ConversationsListResponse = await slackClient.conversations.list({
+    const c = await slackClient.conversations.list({
       types,
       // despite the limit being 1000, slack may return fewer channels
       // we observed ~50 channels per call at times see https://github.com/dust-tt/tasks/issues/1655

--- a/connectors/src/connectors/slack/lib/channels.ts
+++ b/connectors/src/connectors/slack/lib/channels.ts
@@ -159,10 +159,7 @@ export async function joinChannel(
     throw new Error(`Connector ${connectorId} not found`);
   }
 
-  const client = await getSlackClient(connector.id, {
-    // Do not reject rate limited calls in join channel.
-    rejectRateLimitedCalls: false,
-  });
+  const client = await getSlackClient(connector.id);
   try {
     reportSlackUsage({
       connectorId,

--- a/connectors/src/connectors/slack/lib/messages.ts
+++ b/connectors/src/connectors/slack/lib/messages.ts
@@ -1,5 +1,5 @@
 import type { WebClient } from "@slack/web-api";
-import type { MessageElement } from "@slack/web-api/dist/response/ConversationsRepliesResponse";
+import type { MessageElement } from "@slack/web-api/dist/types/response/ConversationsRepliesResponse";
 
 import {
   getBotOrUserName,

--- a/connectors/src/connectors/slack/lib/slack_client.ts
+++ b/connectors/src/connectors/slack/lib/slack_client.ts
@@ -96,19 +96,12 @@ function isWebAPIPlatformError(error: unknown): error is WebAPIPlatformError {
  * const result = await slackClient.conversations.list({ types: "public_channel" });
  * ```
  */
+export async function getSlackClient(connectorId: ModelId): Promise<WebClient>;
 export async function getSlackClient(
-  connectorId: ModelId,
-  options?: { rejectRateLimitedCalls?: boolean }
+  slackAccessToken: string
 ): Promise<WebClient>;
 export async function getSlackClient(
-  slackAccessToken: string,
-  options?: { rejectRateLimitedCalls?: boolean }
-): Promise<WebClient>;
-export async function getSlackClient(
-  connectorIdOrAccessToken: string | ModelId,
-  options: { rejectRateLimitedCalls?: boolean } = {
-    rejectRateLimitedCalls: true,
-  }
+  connectorIdOrAccessToken: string | ModelId
 ): Promise<WebClient> {
   let slackAccessToken: string | undefined = undefined;
   if (typeof connectorIdOrAccessToken === "number") {
@@ -124,7 +117,6 @@ export async function getSlackClient(
   }
   const slackClient = new WebClient(slackAccessToken, {
     timeout: SLACK_NETWORK_TIMEOUT_MS,
-    rejectRateLimitedCalls: options.rejectRateLimitedCalls ?? true,
     retryConfig: {
       retries: 1,
       factor: 1,

--- a/connectors/src/connectors/slack/lib/thread.ts
+++ b/connectors/src/connectors/slack/lib/thread.ts
@@ -1,6 +1,6 @@
 import type { WebClient } from "@slack/web-api";
-import type { MessageElement } from "@slack/web-api/dist/response/ConversationsHistoryResponse";
-import type { ConversationsRepliesResponse } from "@slack/web-api/dist/response/ConversationsRepliesResponse";
+import type { MessageElement } from "@slack/web-api/dist/types/response/ConversationsHistoryResponse";
+import type { ConversationsRepliesResponse } from "@slack/web-api/dist/types/response/ConversationsRepliesResponse";
 
 import mainLogger from "@connectors/logger/logger";
 import type { ModelId } from "@connectors/types";

--- a/connectors/src/connectors/slack/lib/workspace_limits.ts
+++ b/connectors/src/connectors/slack/lib/workspace_limits.ts
@@ -1,7 +1,7 @@
 import type { Result, WorkspaceDomainType } from "@dust-tt/client";
 import { DustAPI, Err, Ok } from "@dust-tt/client";
 import type { WebClient } from "@slack/web-api";
-import type {} from "@slack/web-api/dist/response/UsersInfoResponse";
+import type {} from "@slack/web-api/dist/types/response/UsersInfoResponse";
 
 import { SlackExternalUserError } from "@connectors/connectors/slack/lib/errors";
 import type { SlackUserInfo } from "@connectors/connectors/slack/lib/slack_client";

--- a/connectors/src/connectors/slack/temporal/activities.ts
+++ b/connectors/src/connectors/slack/temporal/activities.ts
@@ -4,11 +4,11 @@ import type {
   WebClient,
 } from "@slack/web-api";
 import { ErrorCode } from "@slack/web-api";
-import type { Channel } from "@slack/web-api/dist/response/ChannelsInfoResponse";
+import type { Channel } from "@slack/web-api/dist/types/response/ChannelsInfoResponse";
 import type {
   ConversationsHistoryResponse,
   MessageElement,
-} from "@slack/web-api/dist/response/ConversationsHistoryResponse";
+} from "@slack/web-api/dist/types/response/ConversationsHistoryResponse";
 import PQueue from "p-queue";
 import { Op, Sequelize } from "sequelize";
 

--- a/connectors/src/connectors/slack/temporal/activities.ts
+++ b/connectors/src/connectors/slack/temporal/activities.ts
@@ -91,11 +91,7 @@ export async function syncChannel(
     throw new Error(`Connector ${connectorId} not found`);
   }
 
-  const slackClient = await getSlackClient(connectorId, {
-    // Let the Slack client handle rate limited calls in the slow lane.
-    // TODO(SLACK-PANIC): Remove/uncomment.
-    rejectRateLimitedCalls: false, // !isSlowLaneQueue(Context.current().info.taskQueue),
-  });
+  const slackClient = await getSlackClient(connectorId);
 
   const remoteChannel = await withSlackErrorHandling(() =>
     getChannelById(slackClient, connectorId, channelId)
@@ -292,11 +288,7 @@ export async function getMessagesForChannel(
   limit = 100,
   nextCursor?: string
 ): Promise<ConversationsHistoryResponse> {
-  const slackClient = await getSlackClient(connectorId, {
-    // Let the Slack client handle rate limited calls in the slow lane.
-    // TODO(SLACK-PANIC): Remove/uncomment.
-    rejectRateLimitedCalls: false, // !isSlowLaneQueue(Context.current().info.taskQueue),
-  });
+  const slackClient = await getSlackClient(connectorId);
 
   reportSlackUsage({
     connectorId,
@@ -425,10 +417,7 @@ export async function syncNonThreaded({
     }
   }
 
-  const slackClient = await getSlackClient(connectorId, {
-    // Let the Slack client handle rate limited calls in the slow lane.
-    rejectRateLimitedCalls: false,
-  });
+  const slackClient = await getSlackClient(connectorId);
 
   let hasMore: boolean | undefined = undefined;
   let latestTsSec = endTsSec;
@@ -775,11 +764,7 @@ export async function syncThread(
     throw new Error(`Connector ${connectorId} not found`);
   }
   const dataSourceConfig = dataSourceConfigFromConnector(connector);
-  const slackClient = await getSlackClient(connectorId, {
-    // Let the Slack client handle rate limited calls in the slow lane.
-    // TODO(SLACK-PANIC): Remove/uncomment.
-    rejectRateLimitedCalls: false, // !isSlowLaneQueue(Context.current().info.taskQueue),
-  });
+  const slackClient = await getSlackClient(connectorId);
 
   let allMessages: MessageElement[] = [];
 
@@ -980,11 +965,7 @@ export async function syncThread(
 
 export async function fetchUsers(connectorId: ModelId) {
   let cursor: string | undefined;
-  const slackClient = await getSlackClient(connectorId, {
-    // Let the Slack client handle rate limited calls in the slow lane.
-    // TODO(SLACK-PANIC): Remove/uncomment.
-    rejectRateLimitedCalls: false, // !isSlowLaneQueue(Context.current().info.taskQueue),
-  });
+  const slackClient = await getSlackClient(connectorId);
   do {
     reportSlackUsage({
       connectorId,
@@ -1033,11 +1014,7 @@ export async function getChannel(
   connectorId: ModelId,
   channelId: string
 ): Promise<Channel> {
-  const slackClient = await getSlackClient(connectorId, {
-    // Let the Slack client handle rate limited calls in the slow lane.
-    // TODO(SLACK-PANIC): Remove/uncomment.
-    rejectRateLimitedCalls: false, // !isSlowLaneQueue(Context.current().info.taskQueue),
-  });
+  const slackClient = await getSlackClient(connectorId);
 
   return getChannelById(slackClient, connectorId, channelId);
 }
@@ -1110,11 +1087,7 @@ export async function getChannelsToGarbageCollect(
       .map((c) => c.slackChannelId)
   );
 
-  const slackClient = await getSlackClient(connectorId, {
-    // Let the Slack client handle rate limited calls in the slow lane.
-    // TODO(SLACK-PANIC): Remove/uncomment.
-    rejectRateLimitedCalls: false, // !isSlowLaneQueue(Context.current().info.taskQueue),
-  });
+  const slackClient = await getSlackClient(connectorId);
 
   const remoteChannels = new Set(
     (

--- a/connectors/src/connectors/slack/temporal/client.ts
+++ b/connectors/src/connectors/slack/temporal/client.ts
@@ -37,9 +37,7 @@ export async function launchSlackSyncWorkflow(
   }
 
   if (channelsToSync === null) {
-    const slackClient = await getSlackClient(connectorId, {
-      rejectRateLimitedCalls: false,
-    });
+    const slackClient = await getSlackClient(connectorId);
     channelsToSync = removeNulls(
       (await getChannelsToSync(slackClient, connectorId)).map(
         (c) => c.id || null

--- a/connectors/src/connectors/slack_bot/index.ts
+++ b/connectors/src/connectors/slack_bot/index.ts
@@ -56,10 +56,7 @@ export class SlackBotConnectorManager extends BaseConnectorManager<SlackConfigur
     configuration: SlackConfigurationType;
   }): Promise<Result<string, ConnectorManagerError<CreateConnectorErrorCode>>> {
     const accessToken = await getSlackAccessToken(connectionId);
-    const slackClient = await getSlackClient(accessToken, {
-      // Do not reject rate limited calls in update connector. Called from the API.
-      rejectRateLimitedCalls: false,
-    });
+    const slackClient = await getSlackClient(accessToken);
 
     const teamInfo = await slackClient.team.info();
     if (teamInfo.ok !== true) {
@@ -218,10 +215,7 @@ export class SlackBotConnectorManager extends BaseConnectorManager<SlackConfigur
 
     if (connectionId) {
       const accessToken = await getSlackAccessToken(connectionId);
-      const slackClient = await getSlackClient(accessToken, {
-        // Do not reject rate limited calls in update connector. Called from the API.
-        rejectRateLimitedCalls: false,
-      });
+      const slackClient = await getSlackClient(accessToken);
 
       reportSlackUsage({
         connectorId: c.id,
@@ -556,10 +550,7 @@ async function getFilteredChannels(
     return slackChannels;
   }
 
-  const slackClient = await getSlackClient(connectorId, {
-    // Do not reject rate limited calls in update connector. Called from the API.
-    rejectRateLimitedCalls: false,
-  });
+  const slackClient = await getSlackClient(connectorId);
 
   const [remoteChannels, localChannels] = await Promise.all([
     getChannels(slackClient, connectorId, true),


### PR DESCRIPTION
## Description

- Remove `rejectRateLimitedCalls` since unused. 
- Bumpds slack library

Want to deploy once with this completely cleaned-up. Will reintroduce if we decide to handle retry oursleves.

lib changelog is here: https://tools.slack.dev/node-slack-sdk/migration/migrating-web-api-package-to-v7/

## Tests

Tested locally + ngrok + slack

## Risk

None

## Deploy Plan

- deploy `connectors`