### PR TITLE
Add more logging to diagnose 'Could not find Dust app' errors

### DIFF
--- a/front/lib/auth.ts
+++ b/front/lib/auth.ts
@@ -951,6 +951,15 @@ export class Authenticator {
 
       if (groupsResult.isOk()) {
         groups = groupsResult.value;
+      } else {
+        logger.error(
+          {
+            workspaceId: workspace.sId,
+            groupIds: authType.groupIds,
+            error: groupsResult.error,
+          },
+          "[Authenticator.fromJSON] Failed to fetch groups"
+        );
       }
     }
 


### PR DESCRIPTION
## Description

Users are encountering "Could not find Dust app" errors when agents try to use the run_dust_app tool, even for apps in the global space that should be accessible to all users. The error started appearing yesterday evening.

Logs added on my last PR show I think that auth.groups() returns an empty array when the error occurs, indicating users are missing group membership at the time of the MCP server execution (cause the groupIds does not appear on my DD log)


  These new logs will help identify:
  - Whether groups are missing from the initial auth context
  - If there's a specific pattern to when groups are empty
  - Whether this is related to how auth is passed to MCP servers

The root cause is still under investigation - the logging will provide the data needed to identify why users are missing group membership in certain contexts.


## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

Deploy front. 