### PR TITLE
[front] Drop nullability on `agent_mcp_actions`.`stepContentId`

### DIFF
--- a/front/lib/actions/mcp.ts
+++ b/front/lib/actions/mcp.ts
@@ -536,7 +536,7 @@ export class MCPConfigurationServerRunner extends BaseActionConfigurationServerR
       isError: false,
       executionState: "pending",
       version: 0,
-      stepContentId: stepContentId || null,
+      stepContentId,
     });
 
     const mcpAction = new MCPActionType({

--- a/front/lib/actions/types/index.ts
+++ b/front/lib/actions/types/index.ts
@@ -99,7 +99,7 @@ export interface BaseActionRunParams {
   rawInputs: Record<string, unknown>;
   functionCallId: string;
   step: number;
-  stepContentId?: ModelId;
+  stepContentId: ModelId;
 }
 
 export abstract class BaseActionConfigurationServerRunner<

--- a/front/lib/api/assistant/agent.ts
+++ b/front/lib/api/assistant/agent.ts
@@ -53,13 +53,8 @@ export async function runAgentWithStreaming(
       const actionsToRun = result.actions.slice(0, MAX_ACTIONS_PER_STEP);
 
       const citationsIncrements = await Promise.all(
-        actionsToRun.map(({ inputs, functionCallId }, index) => {
-          // Find the step content ID for this function call
-          const stepContentId = functionCallId
-            ? functionCallStepContentIds[functionCallId]
-            : undefined;
-
-          return runToolActivity(authType, {
+        actionsToRun.map(({ inputs, functionCallId }, index) =>
+          runToolActivity(authType, {
             runAgentArgs,
             inputs,
             functionCallId,
@@ -67,9 +62,9 @@ export async function runAgentWithStreaming(
             stepActionIndex: index,
             stepActions: actionsToRun.map((a) => a.action),
             citationsRefsOffset,
-            stepContentId,
-          });
-        })
+            stepContentId: functionCallStepContentIds[functionCallId],
+          })
+        )
       );
 
       citationsRefsOffset += citationsIncrements.reduce(

--- a/front/lib/models/assistant/actions/mcp.ts
+++ b/front/lib/models/assistant/actions/mcp.ts
@@ -192,7 +192,7 @@ export class AgentMCPAction extends WorkspaceAwareModel<AgentMCPAction> {
   declare step: number;
   declare version: number;
   declare agentMessageId: ForeignKey<AgentMessage["id"]>;
-  declare stepContentId: ForeignKey<AgentStepContentModel["id"]> | null;
+  declare stepContentId: ForeignKey<AgentStepContentModel["id"]>;
 
   declare isError: boolean;
   declare executionState:

--- a/front/lib/models/assistant/actions/mcp.ts
+++ b/front/lib/models/assistant/actions/mcp.ts
@@ -288,12 +288,12 @@ AgentMessage.hasMany(AgentMCPAction, {
 });
 
 AgentMCPAction.belongsTo(AgentStepContentModel, {
-  foreignKey: { name: "stepContentId", allowNull: true },
+  foreignKey: { name: "stepContentId", allowNull: false },
   onDelete: "RESTRICT",
 });
 
 AgentStepContentModel.hasMany(AgentMCPAction, {
-  foreignKey: { name: "stepContentId", allowNull: true },
+  foreignKey: { name: "stepContentId", allowNull: false },
   as: "agentMCPActions",
 });
 

--- a/front/migrations/20250709_agent_mcp_action_fk_step_content.ts
+++ b/front/migrations/20250709_agent_mcp_action_fk_step_content.ts
@@ -1,302 +1,302 @@
-import { Op } from "sequelize";
-
-import { getWorkspaceInfos } from "@app/lib/api/workspace";
-import { AgentMCPAction } from "@app/lib/models/assistant/actions/mcp";
-import { AgentStepContentModel } from "@app/lib/models/assistant/agent_step_content";
-import { concurrentExecutor } from "@app/lib/utils/async_utils";
-import type { Logger } from "@app/logger/logger";
-import { makeScript } from "@app/scripts/helpers";
-import { runOnAllWorkspaces } from "@app/scripts/workspace_helpers";
-import type { LightWorkspaceType } from "@app/types";
-import { isFunctionCallContent } from "@app/types/assistant/agent_message_content";
-
-const FETCH_ACTIONS_BATCH_SIZE = 200;
-const WORKSPACE_CONCURRENCY = 5;
-const UPDATE_ACTION_CONCURRENCY = 10;
-
-/**
- * Attach an AgentStepContent to all AgentMCPActions that don't have one for a given workspace.
- *
- * If no matching step content is found we skip the action. We do not warn or error log, unprocessed actions will be seen in DB.
- * We only log at the end of the loop the number of actions skipped, updated and processed.
- */
-async function attachStepContentToMcpActions({
-  workspace,
-  execute,
-  verbose,
-  logger,
-}: {
-  workspace: LightWorkspaceType;
-  execute: boolean;
-  verbose: boolean;
-  logger: Logger;
-}): Promise<{
-  workspaceId: string;
-  nbActionsToProcess: number;
-  nbActionsLinked: number;
-  nbActionsSkipped: number;
-}> {
-  let nbActionsToProcess = 0;
-  let nbActionsLinked = 0;
-  let nbActionsSkipped = 0;
-  let hasMore = false;
-  let lastId = 0;
-  let batchNumber = 0;
-
-  if (verbose) {
-    // Count total actions first.
-    const totalCount = await AgentMCPAction.count({
-      where: {
-        workspaceId: workspace.id,
-        stepContentId: {
-          [Op.is]: null,
-        },
-      },
-    });
-    logger.info(
-      { workspaceId: workspace.sId, totalCount },
-      "Starting to process workspace. Total MCP actions without stepContentId"
-    );
-
-    if (totalCount === 0) {
-      return {
-        workspaceId: workspace.sId,
-        nbActionsToProcess: 0,
-        nbActionsLinked: 0,
-        nbActionsSkipped: 0,
-      };
-    }
-  }
-
-  do {
-    batchNumber++;
-    if (verbose) {
-      logger.info(
-        {
-          workspaceId: workspace.sId,
-          batchNumber,
-          lastId,
-          batchSize: FETCH_ACTIONS_BATCH_SIZE,
-        },
-        "Fetching next batch of MCP actions..."
-      );
-    }
-
-    const mcpActions = await AgentMCPAction.findAll({
-      where: {
-        workspaceId: workspace.id,
-        id: {
-          [Op.gt]: lastId,
-        },
-        stepContentId: {
-          [Op.is]: null,
-        },
-      },
-      limit: FETCH_ACTIONS_BATCH_SIZE,
-      order: [["id", "ASC"]],
-    });
-
-    if (mcpActions.length === 0) {
-      return {
-        workspaceId: workspace.sId,
-        nbActionsToProcess: 0,
-        nbActionsLinked: 0,
-        nbActionsSkipped: 0,
-      };
-    }
-
-    const result = await concurrentExecutor(
-      mcpActions,
-      async (mcpAction) => {
-        // We look for a matching agent step content.
-        const stepContents = await AgentStepContentModel.findAll({
-          where: {
-            agentMessageId: mcpAction.agentMessageId,
-            step: mcpAction.step,
-            workspaceId: workspace.id,
-            type: "function_call",
-            version: mcpAction.version,
-          },
-        });
-
-        if (stepContents.length === 0) {
-          return false;
-        }
-
-        let matchingStepContent = stepContents.find(
-          (sc) =>
-            isFunctionCallContent(sc.value) &&
-            sc.value.value.id === mcpAction.functionCallId
-        );
-
-        // Fallback for actions without functionCallId.
-        if (!matchingStepContent && stepContents.length === 1) {
-          matchingStepContent = stepContents[0];
-        }
-
-        // Fallback for actions with a query param that can be matched to a step content.
-        if (!matchingStepContent && mcpAction.params?.query) {
-          const query = mcpAction.params.query;
-          matchingStepContent = stepContents.find((sc) => {
-            if (isFunctionCallContent(sc.value)) {
-              try {
-                const functionCallArgs = JSON.parse(sc.value.value.arguments);
-                return functionCallArgs.query === query;
-              } catch (e) {
-                logger.error(
-                  {
-                    workspaceId: workspace.sId,
-                    actionId: mcpAction.id,
-                    stepContentId: sc.id,
-                    error: e,
-                  },
-                  "Error parsing function call arguments."
-                );
-              }
-            }
-            return false;
-          });
-        }
-
-        // Fallback for actions with an urls param that can be matched to a step content.
-        if (
-          !matchingStepContent &&
-          Array.isArray(mcpAction.params?.urls) &&
-          mcpAction.params.urls.length > 0
-        ) {
-          matchingStepContent = stepContents.find((sc) => {
-            if (isFunctionCallContent(sc.value)) {
-              try {
-                return (
-                  sc.value.value.arguments === JSON.stringify(mcpAction.params)
-                );
-              } catch (e) {
-                logger.error(
-                  {
-                    workspaceId: workspace.sId,
-                    actionId: mcpAction.id,
-                    stepContentId: sc.id,
-                    error: e,
-                  },
-                  "Error parsing function call arguments."
-                );
-              }
-            }
-            return false;
-          });
-        }
-
-        if (!matchingStepContent) {
-          if (verbose) {
-            logger.info(
-              { workspaceId: workspace.sId, actionId: mcpAction.id },
-              "No matching step content found"
-            );
-          }
-          return false;
-        }
-
-        // If the step content is found, we can attach it to the MCP action.
-        if (execute) {
-          await mcpAction.update({ stepContentId: matchingStepContent.id });
-        }
-        return true;
-      },
-      { concurrency: UPDATE_ACTION_CONCURRENCY }
-    );
-
-    nbActionsToProcess += result.length;
-    nbActionsLinked += result.filter((r) => r === true).length;
-    nbActionsSkipped += result.filter((r) => r === false).length;
-    hasMore = mcpActions.length === FETCH_ACTIONS_BATCH_SIZE;
-    if (mcpActions.length > 0) {
-      lastId = mcpActions[mcpActions.length - 1].id;
-    }
-
-    if (verbose) {
-      logger.info(
-        {
-          workspaceId: workspace.sId,
-          batchNumber,
-          progress: {
-            processed: nbActionsToProcess,
-            linked: nbActionsLinked,
-            skipped: nbActionsSkipped,
-          },
-        },
-        "Batch completed."
-      );
-    }
-  } while (hasMore);
-
-  return {
-    workspaceId: workspace.sId,
-    nbActionsToProcess,
-    nbActionsLinked,
-    nbActionsSkipped,
-  };
-}
-
-/**
- * Run the migration for a given workspace.
- */
-async function migrateForWorkspace(
-  workspace: LightWorkspaceType,
-  {
-    execute,
-    logger,
-    verbose,
-  }: { execute: boolean; logger: Logger; verbose: boolean }
-) {
-  const stats = await attachStepContentToMcpActions({
-    workspace,
-    execute,
-    verbose,
-    logger,
-  });
-  if (stats.nbActionsToProcess > 0 || verbose) {
-    logger.info(stats, "Completed processing MCP actions for workspace.");
-  }
-}
-
-/**
- * This migration attaches an AgentStepContent to all AgentMCPActions that don't have one.
- * Can be run on a single workspace or (default) all workspaces.
- */
-makeScript(
-  {
-    workspaceId: {
-      type: "string",
-      description: "Workspace ID to migrate",
-      required: false,
-    },
-    verbose: {
-      type: "boolean",
-      description: "Enable verbose logging to debug slow queries",
-      required: false,
-      default: false,
-    },
-  },
-  async ({ execute, workspaceId, verbose }, logger) => {
-    if (verbose) {
-      logger.info(
-        { execute, workspaceId },
-        "Starting migration with verbose logging enabled"
-      );
-    }
-    if (workspaceId) {
-      const workspace = await getWorkspaceInfos(workspaceId);
-      if (!workspace) {
-        throw new Error(`Workspace ${workspaceId} not found`);
-      }
-      await migrateForWorkspace(workspace, { execute, logger, verbose });
-    } else {
-      return runOnAllWorkspaces(
-        async (workspace) => {
-          await migrateForWorkspace(workspace, { execute, logger, verbose });
-        },
-        { concurrency: WORKSPACE_CONCURRENCY }
-      );
-    }
-  }
-);
+// import { Op } from "sequelize";
+//
+// import { getWorkspaceInfos } from "@app/lib/api/workspace";
+// import { AgentMCPAction } from "@app/lib/models/assistant/actions/mcp";
+// import { AgentStepContentModel } from "@app/lib/models/assistant/agent_step_content";
+// import { concurrentExecutor } from "@app/lib/utils/async_utils";
+// import type { Logger } from "@app/logger/logger";
+// import { makeScript } from "@app/scripts/helpers";
+// import { runOnAllWorkspaces } from "@app/scripts/workspace_helpers";
+// import type { LightWorkspaceType } from "@app/types";
+// import { isFunctionCallContent } from "@app/types/assistant/agent_message_content";
+//
+// const FETCH_ACTIONS_BATCH_SIZE = 200;
+// const WORKSPACE_CONCURRENCY = 5;
+// const UPDATE_ACTION_CONCURRENCY = 10;
+//
+// /**
+//  * Attach an AgentStepContent to all AgentMCPActions that don't have one for a given workspace.
+//  *
+//  * If no matching step content is found we skip the action. We do not warn or error log, unprocessed actions will be seen in DB.
+//  * We only log at the end of the loop the number of actions skipped, updated and processed.
+//  */
+// async function attachStepContentToMcpActions({
+//   workspace,
+//   execute,
+//   verbose,
+//   logger,
+// }: {
+//   workspace: LightWorkspaceType;
+//   execute: boolean;
+//   verbose: boolean;
+//   logger: Logger;
+// }): Promise<{
+//   workspaceId: string;
+//   nbActionsToProcess: number;
+//   nbActionsLinked: number;
+//   nbActionsSkipped: number;
+// }> {
+//   let nbActionsToProcess = 0;
+//   let nbActionsLinked = 0;
+//   let nbActionsSkipped = 0;
+//   let hasMore = false;
+//   let lastId = 0;
+//   let batchNumber = 0;
+//
+//   if (verbose) {
+//     // Count total actions first.
+//     const totalCount = await AgentMCPAction.count({
+//       where: {
+//         workspaceId: workspace.id,
+//         stepContentId: {
+//           [Op.is]: null,
+//         },
+//       },
+//     });
+//     logger.info(
+//       { workspaceId: workspace.sId, totalCount },
+//       "Starting to process workspace. Total MCP actions without stepContentId"
+//     );
+//
+//     if (totalCount === 0) {
+//       return {
+//         workspaceId: workspace.sId,
+//         nbActionsToProcess: 0,
+//         nbActionsLinked: 0,
+//         nbActionsSkipped: 0,
+//       };
+//     }
+//   }
+//
+//   do {
+//     batchNumber++;
+//     if (verbose) {
+//       logger.info(
+//         {
+//           workspaceId: workspace.sId,
+//           batchNumber,
+//           lastId,
+//           batchSize: FETCH_ACTIONS_BATCH_SIZE,
+//         },
+//         "Fetching next batch of MCP actions..."
+//       );
+//     }
+//
+//     const mcpActions = await AgentMCPAction.findAll({
+//       where: {
+//         workspaceId: workspace.id,
+//         id: {
+//           [Op.gt]: lastId,
+//         },
+//         stepContentId: {
+//           [Op.is]: null,
+//         },
+//       },
+//       limit: FETCH_ACTIONS_BATCH_SIZE,
+//       order: [["id", "ASC"]],
+//     });
+//
+//     if (mcpActions.length === 0) {
+//       return {
+//         workspaceId: workspace.sId,
+//         nbActionsToProcess: 0,
+//         nbActionsLinked: 0,
+//         nbActionsSkipped: 0,
+//       };
+//     }
+//
+//     const result = await concurrentExecutor(
+//       mcpActions,
+//       async (mcpAction) => {
+//         // We look for a matching agent step content.
+//         const stepContents = await AgentStepContentModel.findAll({
+//           where: {
+//             agentMessageId: mcpAction.agentMessageId,
+//             step: mcpAction.step,
+//             workspaceId: workspace.id,
+//             type: "function_call",
+//             version: mcpAction.version,
+//           },
+//         });
+//
+//         if (stepContents.length === 0) {
+//           return false;
+//         }
+//
+//         let matchingStepContent = stepContents.find(
+//           (sc) =>
+//             isFunctionCallContent(sc.value) &&
+//             sc.value.value.id === mcpAction.functionCallId
+//         );
+//
+//         // Fallback for actions without functionCallId.
+//         if (!matchingStepContent && stepContents.length === 1) {
+//           matchingStepContent = stepContents[0];
+//         }
+//
+//         // Fallback for actions with a query param that can be matched to a step content.
+//         if (!matchingStepContent && mcpAction.params?.query) {
+//           const query = mcpAction.params.query;
+//           matchingStepContent = stepContents.find((sc) => {
+//             if (isFunctionCallContent(sc.value)) {
+//               try {
+//                 const functionCallArgs = JSON.parse(sc.value.value.arguments);
+//                 return functionCallArgs.query === query;
+//               } catch (e) {
+//                 logger.error(
+//                   {
+//                     workspaceId: workspace.sId,
+//                     actionId: mcpAction.id,
+//                     stepContentId: sc.id,
+//                     error: e,
+//                   },
+//                   "Error parsing function call arguments."
+//                 );
+//               }
+//             }
+//             return false;
+//           });
+//         }
+//
+//         // Fallback for actions with an urls param that can be matched to a step content.
+//         if (
+//           !matchingStepContent &&
+//           Array.isArray(mcpAction.params?.urls) &&
+//           mcpAction.params.urls.length > 0
+//         ) {
+//           matchingStepContent = stepContents.find((sc) => {
+//             if (isFunctionCallContent(sc.value)) {
+//               try {
+//                 return (
+//                   sc.value.value.arguments === JSON.stringify(mcpAction.params)
+//                 );
+//               } catch (e) {
+//                 logger.error(
+//                   {
+//                     workspaceId: workspace.sId,
+//                     actionId: mcpAction.id,
+//                     stepContentId: sc.id,
+//                     error: e,
+//                   },
+//                   "Error parsing function call arguments."
+//                 );
+//               }
+//             }
+//             return false;
+//           });
+//         }
+//
+//         if (!matchingStepContent) {
+//           if (verbose) {
+//             logger.info(
+//               { workspaceId: workspace.sId, actionId: mcpAction.id },
+//               "No matching step content found"
+//             );
+//           }
+//           return false;
+//         }
+//
+//         // If the step content is found, we can attach it to the MCP action.
+//         if (execute) {
+//           await mcpAction.update({ stepContentId: matchingStepContent.id });
+//         }
+//         return true;
+//       },
+//       { concurrency: UPDATE_ACTION_CONCURRENCY }
+//     );
+//
+//     nbActionsToProcess += result.length;
+//     nbActionsLinked += result.filter((r) => r === true).length;
+//     nbActionsSkipped += result.filter((r) => r === false).length;
+//     hasMore = mcpActions.length === FETCH_ACTIONS_BATCH_SIZE;
+//     if (mcpActions.length > 0) {
+//       lastId = mcpActions[mcpActions.length - 1].id;
+//     }
+//
+//     if (verbose) {
+//       logger.info(
+//         {
+//           workspaceId: workspace.sId,
+//           batchNumber,
+//           progress: {
+//             processed: nbActionsToProcess,
+//             linked: nbActionsLinked,
+//             skipped: nbActionsSkipped,
+//           },
+//         },
+//         "Batch completed."
+//       );
+//     }
+//   } while (hasMore);
+//
+//   return {
+//     workspaceId: workspace.sId,
+//     nbActionsToProcess,
+//     nbActionsLinked,
+//     nbActionsSkipped,
+//   };
+// }
+//
+// /**
+//  * Run the migration for a given workspace.
+//  */
+// async function migrateForWorkspace(
+//   workspace: LightWorkspaceType,
+//   {
+//     execute,
+//     logger,
+//     verbose,
+//   }: { execute: boolean; logger: Logger; verbose: boolean }
+// ) {
+//   const stats = await attachStepContentToMcpActions({
+//     workspace,
+//     execute,
+//     verbose,
+//     logger,
+//   });
+//   if (stats.nbActionsToProcess > 0 || verbose) {
+//     logger.info(stats, "Completed processing MCP actions for workspace.");
+//   }
+// }
+//
+// /**
+//  * This migration attaches an AgentStepContent to all AgentMCPActions that don't have one.
+//  * Can be run on a single workspace or (default) all workspaces.
+//  */
+// makeScript(
+//   {
+//     workspaceId: {
+//       type: "string",
+//       description: "Workspace ID to migrate",
+//       required: false,
+//     },
+//     verbose: {
+//       type: "boolean",
+//       description: "Enable verbose logging to debug slow queries",
+//       required: false,
+//       default: false,
+//     },
+//   },
+//   async ({ execute, workspaceId, verbose }, logger) => {
+//     if (verbose) {
+//       logger.info(
+//         { execute, workspaceId },
+//         "Starting migration with verbose logging enabled"
+//       );
+//     }
+//     if (workspaceId) {
+//       const workspace = await getWorkspaceInfos(workspaceId);
+//       if (!workspace) {
+//         throw new Error(`Workspace ${workspaceId} not found`);
+//       }
+//       await migrateForWorkspace(workspace, { execute, logger, verbose });
+//     } else {
+//       return runOnAllWorkspaces(
+//         async (workspace) => {
+//           await migrateForWorkspace(workspace, { execute, logger, verbose });
+//         },
+//         { concurrency: WORKSPACE_CONCURRENCY }
+//       );
+//     }
+//   }
+// );

--- a/front/migrations/20250709_agent_mcp_action_fk_step_content.ts
+++ b/front/migrations/20250709_agent_mcp_action_fk_step_content.ts
@@ -1,302 +1,304 @@
-// import { Op } from "sequelize";
-//
-// import { getWorkspaceInfos } from "@app/lib/api/workspace";
-// import { AgentMCPAction } from "@app/lib/models/assistant/actions/mcp";
-// import { AgentStepContentModel } from "@app/lib/models/assistant/agent_step_content";
-// import { concurrentExecutor } from "@app/lib/utils/async_utils";
-// import type { Logger } from "@app/logger/logger";
-// import { makeScript } from "@app/scripts/helpers";
-// import { runOnAllWorkspaces } from "@app/scripts/workspace_helpers";
-// import type { LightWorkspaceType } from "@app/types";
-// import { isFunctionCallContent } from "@app/types/assistant/agent_message_content";
-//
-// const FETCH_ACTIONS_BATCH_SIZE = 200;
-// const WORKSPACE_CONCURRENCY = 5;
-// const UPDATE_ACTION_CONCURRENCY = 10;
-//
-// /**
-//  * Attach an AgentStepContent to all AgentMCPActions that don't have one for a given workspace.
-//  *
-//  * If no matching step content is found we skip the action. We do not warn or error log, unprocessed actions will be seen in DB.
-//  * We only log at the end of the loop the number of actions skipped, updated and processed.
-//  */
-// async function attachStepContentToMcpActions({
-//   workspace,
-//   execute,
-//   verbose,
-//   logger,
-// }: {
-//   workspace: LightWorkspaceType;
-//   execute: boolean;
-//   verbose: boolean;
-//   logger: Logger;
-// }): Promise<{
-//   workspaceId: string;
-//   nbActionsToProcess: number;
-//   nbActionsLinked: number;
-//   nbActionsSkipped: number;
-// }> {
-//   let nbActionsToProcess = 0;
-//   let nbActionsLinked = 0;
-//   let nbActionsSkipped = 0;
-//   let hasMore = false;
-//   let lastId = 0;
-//   let batchNumber = 0;
-//
-//   if (verbose) {
-//     // Count total actions first.
-//     const totalCount = await AgentMCPAction.count({
-//       where: {
-//         workspaceId: workspace.id,
-//         stepContentId: {
-//           [Op.is]: null,
-//         },
-//       },
-//     });
-//     logger.info(
-//       { workspaceId: workspace.sId, totalCount },
-//       "Starting to process workspace. Total MCP actions without stepContentId"
-//     );
-//
-//     if (totalCount === 0) {
-//       return {
-//         workspaceId: workspace.sId,
-//         nbActionsToProcess: 0,
-//         nbActionsLinked: 0,
-//         nbActionsSkipped: 0,
-//       };
-//     }
-//   }
-//
-//   do {
-//     batchNumber++;
-//     if (verbose) {
-//       logger.info(
-//         {
-//           workspaceId: workspace.sId,
-//           batchNumber,
-//           lastId,
-//           batchSize: FETCH_ACTIONS_BATCH_SIZE,
-//         },
-//         "Fetching next batch of MCP actions..."
-//       );
-//     }
-//
-//     const mcpActions = await AgentMCPAction.findAll({
-//       where: {
-//         workspaceId: workspace.id,
-//         id: {
-//           [Op.gt]: lastId,
-//         },
-//         stepContentId: {
-//           [Op.is]: null,
-//         },
-//       },
-//       limit: FETCH_ACTIONS_BATCH_SIZE,
-//       order: [["id", "ASC"]],
-//     });
-//
-//     if (mcpActions.length === 0) {
-//       return {
-//         workspaceId: workspace.sId,
-//         nbActionsToProcess: 0,
-//         nbActionsLinked: 0,
-//         nbActionsSkipped: 0,
-//       };
-//     }
-//
-//     const result = await concurrentExecutor(
-//       mcpActions,
-//       async (mcpAction) => {
-//         // We look for a matching agent step content.
-//         const stepContents = await AgentStepContentModel.findAll({
-//           where: {
-//             agentMessageId: mcpAction.agentMessageId,
-//             step: mcpAction.step,
-//             workspaceId: workspace.id,
-//             type: "function_call",
-//             version: mcpAction.version,
-//           },
-//         });
-//
-//         if (stepContents.length === 0) {
-//           return false;
-//         }
-//
-//         let matchingStepContent = stepContents.find(
-//           (sc) =>
-//             isFunctionCallContent(sc.value) &&
-//             sc.value.value.id === mcpAction.functionCallId
-//         );
-//
-//         // Fallback for actions without functionCallId.
-//         if (!matchingStepContent && stepContents.length === 1) {
-//           matchingStepContent = stepContents[0];
-//         }
-//
-//         // Fallback for actions with a query param that can be matched to a step content.
-//         if (!matchingStepContent && mcpAction.params?.query) {
-//           const query = mcpAction.params.query;
-//           matchingStepContent = stepContents.find((sc) => {
-//             if (isFunctionCallContent(sc.value)) {
-//               try {
-//                 const functionCallArgs = JSON.parse(sc.value.value.arguments);
-//                 return functionCallArgs.query === query;
-//               } catch (e) {
-//                 logger.error(
-//                   {
-//                     workspaceId: workspace.sId,
-//                     actionId: mcpAction.id,
-//                     stepContentId: sc.id,
-//                     error: e,
-//                   },
-//                   "Error parsing function call arguments."
-//                 );
-//               }
-//             }
-//             return false;
-//           });
-//         }
-//
-//         // Fallback for actions with an urls param that can be matched to a step content.
-//         if (
-//           !matchingStepContent &&
-//           Array.isArray(mcpAction.params?.urls) &&
-//           mcpAction.params.urls.length > 0
-//         ) {
-//           matchingStepContent = stepContents.find((sc) => {
-//             if (isFunctionCallContent(sc.value)) {
-//               try {
-//                 return (
-//                   sc.value.value.arguments === JSON.stringify(mcpAction.params)
-//                 );
-//               } catch (e) {
-//                 logger.error(
-//                   {
-//                     workspaceId: workspace.sId,
-//                     actionId: mcpAction.id,
-//                     stepContentId: sc.id,
-//                     error: e,
-//                   },
-//                   "Error parsing function call arguments."
-//                 );
-//               }
-//             }
-//             return false;
-//           });
-//         }
-//
-//         if (!matchingStepContent) {
-//           if (verbose) {
-//             logger.info(
-//               { workspaceId: workspace.sId, actionId: mcpAction.id },
-//               "No matching step content found"
-//             );
-//           }
-//           return false;
-//         }
-//
-//         // If the step content is found, we can attach it to the MCP action.
-//         if (execute) {
-//           await mcpAction.update({ stepContentId: matchingStepContent.id });
-//         }
-//         return true;
-//       },
-//       { concurrency: UPDATE_ACTION_CONCURRENCY }
-//     );
-//
-//     nbActionsToProcess += result.length;
-//     nbActionsLinked += result.filter((r) => r === true).length;
-//     nbActionsSkipped += result.filter((r) => r === false).length;
-//     hasMore = mcpActions.length === FETCH_ACTIONS_BATCH_SIZE;
-//     if (mcpActions.length > 0) {
-//       lastId = mcpActions[mcpActions.length - 1].id;
-//     }
-//
-//     if (verbose) {
-//       logger.info(
-//         {
-//           workspaceId: workspace.sId,
-//           batchNumber,
-//           progress: {
-//             processed: nbActionsToProcess,
-//             linked: nbActionsLinked,
-//             skipped: nbActionsSkipped,
-//           },
-//         },
-//         "Batch completed."
-//       );
-//     }
-//   } while (hasMore);
-//
-//   return {
-//     workspaceId: workspace.sId,
-//     nbActionsToProcess,
-//     nbActionsLinked,
-//     nbActionsSkipped,
-//   };
-// }
-//
-// /**
-//  * Run the migration for a given workspace.
-//  */
-// async function migrateForWorkspace(
-//   workspace: LightWorkspaceType,
-//   {
-//     execute,
-//     logger,
-//     verbose,
-//   }: { execute: boolean; logger: Logger; verbose: boolean }
-// ) {
-//   const stats = await attachStepContentToMcpActions({
-//     workspace,
-//     execute,
-//     verbose,
-//     logger,
-//   });
-//   if (stats.nbActionsToProcess > 0 || verbose) {
-//     logger.info(stats, "Completed processing MCP actions for workspace.");
-//   }
-// }
-//
-// /**
-//  * This migration attaches an AgentStepContent to all AgentMCPActions that don't have one.
-//  * Can be run on a single workspace or (default) all workspaces.
-//  */
-// makeScript(
-//   {
-//     workspaceId: {
-//       type: "string",
-//       description: "Workspace ID to migrate",
-//       required: false,
-//     },
-//     verbose: {
-//       type: "boolean",
-//       description: "Enable verbose logging to debug slow queries",
-//       required: false,
-//       default: false,
-//     },
-//   },
-//   async ({ execute, workspaceId, verbose }, logger) => {
-//     if (verbose) {
-//       logger.info(
-//         { execute, workspaceId },
-//         "Starting migration with verbose logging enabled"
-//       );
-//     }
-//     if (workspaceId) {
-//       const workspace = await getWorkspaceInfos(workspaceId);
-//       if (!workspace) {
-//         throw new Error(`Workspace ${workspaceId} not found`);
-//       }
-//       await migrateForWorkspace(workspace, { execute, logger, verbose });
-//     } else {
-//       return runOnAllWorkspaces(
-//         async (workspace) => {
-//           await migrateForWorkspace(workspace, { execute, logger, verbose });
-//         },
-//         { concurrency: WORKSPACE_CONCURRENCY }
-//       );
-//     }
-//   }
-// );
+// @ts-nocheck
+// This migration file references the old data model where stepContentId was nullable.
+import { Op } from "sequelize";
+
+import { getWorkspaceInfos } from "@app/lib/api/workspace";
+import { AgentMCPAction } from "@app/lib/models/assistant/actions/mcp";
+import { AgentStepContentModel } from "@app/lib/models/assistant/agent_step_content";
+import { concurrentExecutor } from "@app/lib/utils/async_utils";
+import type { Logger } from "@app/logger/logger";
+import { makeScript } from "@app/scripts/helpers";
+import { runOnAllWorkspaces } from "@app/scripts/workspace_helpers";
+import type { LightWorkspaceType } from "@app/types";
+import { isFunctionCallContent } from "@app/types/assistant/agent_message_content";
+
+const FETCH_ACTIONS_BATCH_SIZE = 200;
+const WORKSPACE_CONCURRENCY = 5;
+const UPDATE_ACTION_CONCURRENCY = 10;
+
+/**
+ * Attach an AgentStepContent to all AgentMCPActions that don't have one for a given workspace.
+ *
+ * If no matching step content is found we skip the action. We do not warn or error log, unprocessed actions will be seen in DB.
+ * We only log at the end of the loop the number of actions skipped, updated and processed.
+ */
+async function attachStepContentToMcpActions({
+  workspace,
+  execute,
+  verbose,
+  logger,
+}: {
+  workspace: LightWorkspaceType;
+  execute: boolean;
+  verbose: boolean;
+  logger: Logger;
+}): Promise<{
+  workspaceId: string;
+  nbActionsToProcess: number;
+  nbActionsLinked: number;
+  nbActionsSkipped: number;
+}> {
+  let nbActionsToProcess = 0;
+  let nbActionsLinked = 0;
+  let nbActionsSkipped = 0;
+  let hasMore = false;
+  let lastId = 0;
+  let batchNumber = 0;
+
+  if (verbose) {
+    // Count total actions first.
+    const totalCount = await AgentMCPAction.count({
+      where: {
+        workspaceId: workspace.id,
+        stepContentId: {
+          [Op.is]: null,
+        },
+      },
+    });
+    logger.info(
+      { workspaceId: workspace.sId, totalCount },
+      "Starting to process workspace. Total MCP actions without stepContentId"
+    );
+
+    if (totalCount === 0) {
+      return {
+        workspaceId: workspace.sId,
+        nbActionsToProcess: 0,
+        nbActionsLinked: 0,
+        nbActionsSkipped: 0,
+      };
+    }
+  }
+
+  do {
+    batchNumber++;
+    if (verbose) {
+      logger.info(
+        {
+          workspaceId: workspace.sId,
+          batchNumber,
+          lastId,
+          batchSize: FETCH_ACTIONS_BATCH_SIZE,
+        },
+        "Fetching next batch of MCP actions..."
+      );
+    }
+
+    const mcpActions = await AgentMCPAction.findAll({
+      where: {
+        workspaceId: workspace.id,
+        id: {
+          [Op.gt]: lastId,
+        },
+        stepContentId: {
+          [Op.is]: null,
+        },
+      },
+      limit: FETCH_ACTIONS_BATCH_SIZE,
+      order: [["id", "ASC"]],
+    });
+
+    if (mcpActions.length === 0) {
+      return {
+        workspaceId: workspace.sId,
+        nbActionsToProcess: 0,
+        nbActionsLinked: 0,
+        nbActionsSkipped: 0,
+      };
+    }
+
+    const result = await concurrentExecutor(
+      mcpActions,
+      async (mcpAction) => {
+        // We look for a matching agent step content.
+        const stepContents = await AgentStepContentModel.findAll({
+          where: {
+            agentMessageId: mcpAction.agentMessageId,
+            step: mcpAction.step,
+            workspaceId: workspace.id,
+            type: "function_call",
+            version: mcpAction.version,
+          },
+        });
+
+        if (stepContents.length === 0) {
+          return false;
+        }
+
+        let matchingStepContent = stepContents.find(
+          (sc) =>
+            isFunctionCallContent(sc.value) &&
+            sc.value.value.id === mcpAction.functionCallId
+        );
+
+        // Fallback for actions without functionCallId.
+        if (!matchingStepContent && stepContents.length === 1) {
+          matchingStepContent = stepContents[0];
+        }
+
+        // Fallback for actions with a query param that can be matched to a step content.
+        if (!matchingStepContent && mcpAction.params?.query) {
+          const query = mcpAction.params.query;
+          matchingStepContent = stepContents.find((sc) => {
+            if (isFunctionCallContent(sc.value)) {
+              try {
+                const functionCallArgs = JSON.parse(sc.value.value.arguments);
+                return functionCallArgs.query === query;
+              } catch (e) {
+                logger.error(
+                  {
+                    workspaceId: workspace.sId,
+                    actionId: mcpAction.id,
+                    stepContentId: sc.id,
+                    error: e,
+                  },
+                  "Error parsing function call arguments."
+                );
+              }
+            }
+            return false;
+          });
+        }
+
+        // Fallback for actions with an urls param that can be matched to a step content.
+        if (
+          !matchingStepContent &&
+          Array.isArray(mcpAction.params?.urls) &&
+          mcpAction.params.urls.length > 0
+        ) {
+          matchingStepContent = stepContents.find((sc) => {
+            if (isFunctionCallContent(sc.value)) {
+              try {
+                return (
+                  sc.value.value.arguments === JSON.stringify(mcpAction.params)
+                );
+              } catch (e) {
+                logger.error(
+                  {
+                    workspaceId: workspace.sId,
+                    actionId: mcpAction.id,
+                    stepContentId: sc.id,
+                    error: e,
+                  },
+                  "Error parsing function call arguments."
+                );
+              }
+            }
+            return false;
+          });
+        }
+
+        if (!matchingStepContent) {
+          if (verbose) {
+            logger.info(
+              { workspaceId: workspace.sId, actionId: mcpAction.id },
+              "No matching step content found"
+            );
+          }
+          return false;
+        }
+
+        // If the step content is found, we can attach it to the MCP action.
+        if (execute) {
+          await mcpAction.update({ stepContentId: matchingStepContent.id });
+        }
+        return true;
+      },
+      { concurrency: UPDATE_ACTION_CONCURRENCY }
+    );
+
+    nbActionsToProcess += result.length;
+    nbActionsLinked += result.filter((r) => r === true).length;
+    nbActionsSkipped += result.filter((r) => r === false).length;
+    hasMore = mcpActions.length === FETCH_ACTIONS_BATCH_SIZE;
+    if (mcpActions.length > 0) {
+      lastId = mcpActions[mcpActions.length - 1].id;
+    }
+
+    if (verbose) {
+      logger.info(
+        {
+          workspaceId: workspace.sId,
+          batchNumber,
+          progress: {
+            processed: nbActionsToProcess,
+            linked: nbActionsLinked,
+            skipped: nbActionsSkipped,
+          },
+        },
+        "Batch completed."
+      );
+    }
+  } while (hasMore);
+
+  return {
+    workspaceId: workspace.sId,
+    nbActionsToProcess,
+    nbActionsLinked,
+    nbActionsSkipped,
+  };
+}
+
+/**
+ * Run the migration for a given workspace.
+ */
+async function migrateForWorkspace(
+  workspace: LightWorkspaceType,
+  {
+    execute,
+    logger,
+    verbose,
+  }: { execute: boolean; logger: Logger; verbose: boolean }
+) {
+  const stats = await attachStepContentToMcpActions({
+    workspace,
+    execute,
+    verbose,
+    logger,
+  });
+  if (stats.nbActionsToProcess > 0 || verbose) {
+    logger.info(stats, "Completed processing MCP actions for workspace.");
+  }
+}
+
+/**
+ * This migration attaches an AgentStepContent to all AgentMCPActions that don't have one.
+ * Can be run on a single workspace or (default) all workspaces.
+ */
+makeScript(
+  {
+    workspaceId: {
+      type: "string",
+      description: "Workspace ID to migrate",
+      required: false,
+    },
+    verbose: {
+      type: "boolean",
+      description: "Enable verbose logging to debug slow queries",
+      required: false,
+      default: false,
+    },
+  },
+  async ({ execute, workspaceId, verbose }, logger) => {
+    if (verbose) {
+      logger.info(
+        { execute, workspaceId },
+        "Starting migration with verbose logging enabled"
+      );
+    }
+    if (workspaceId) {
+      const workspace = await getWorkspaceInfos(workspaceId);
+      if (!workspace) {
+        throw new Error(`Workspace ${workspaceId} not found`);
+      }
+      await migrateForWorkspace(workspace, { execute, logger, verbose });
+    } else {
+      return runOnAllWorkspaces(
+        async (workspace) => {
+          await migrateForWorkspace(workspace, { execute, logger, verbose });
+        },
+        { concurrency: WORKSPACE_CONCURRENCY }
+      );
+    }
+  }
+);

--- a/front/migrations/db/migration_313.sql
+++ b/front/migrations/db/migration_313.sql
@@ -1,0 +1,2 @@
+-- Migration created on Jul 22, 2025
+ALTER TABLE "agent_mcp_actions" ALTER COLUMN "stepContentId" SET NOT NULL;

--- a/front/temporal/agent_loop/activities/run_tool.ts
+++ b/front/temporal/agent_loop/activities/run_tool.ts
@@ -29,7 +29,7 @@ export async function runToolActivity(
     stepActionIndex: number;
     stepActions: ActionConfigurationType[];
     citationsRefsOffset: number;
-    stepContentId?: ModelId;
+    stepContentId: ModelId;
   }
 ): Promise<{ citationsIncrement: number }> {
   const auth = await Authenticator.fromJSON(authType);
@@ -37,17 +37,6 @@ export async function runToolActivity(
   const actionConfiguration = stepActions[stepActionIndex];
   const { agentConfiguration, conversation, agentMessage, agentMessageRow } =
     getRunAgentData(runAgentArgs);
-
-  if (!stepContentId) {
-    logger.error(
-      {
-        functionCallId,
-        actionConfigurationId: actionConfiguration.sId,
-        agentConfigurationId: agentConfiguration.sId,
-      },
-      "No step content for function call"
-    );
-  }
 
   if (isMCPToolConfiguration(actionConfiguration)) {
     const eventStream = getRunnerForActionConfiguration(


### PR DESCRIPTION
## Description

- Part of https://github.com/dust-tt/tasks/issues/3420.
- This PR makes the FK between `agent_mcp_actions` and `agent_step_contents` not nullable.
- No row in db with a null `stepContentId`: `SELECT * FROM agent_mcp_actions WHERE "stepContentId" IS NULL;`.

## Tests

- Tested locally.

## Risk

- No more logs observed [here](https://app.datadoghq.eu/logs?query=%22No%20step%20content%20for%20function%20call%22&agg_m=count&agg_m_source=base&agg_t=count&cols=host%2Cservice&fromUser=true&messageDisplay=inline&refresh_mode=sliding&storage=hot&stream_sort=desc&viz=stream&from_ts=1753172072317&to_ts=1753186472317&live=true).
- The type already forbids having null `functionCallId` and the logic to match based on the `functionCallId` is fully there.

## Deploy Plan

- Deploy front.
- Run `migration_313.sql`.
