### PR TITLE
Add asynchronous agent loop version

### DIFF
--- a/front/admin/cli.ts
+++ b/front/admin/cli.ts
@@ -2,7 +2,7 @@ import fs from "fs/promises";
 import parseArgs from "minimist";
 import path from "path";
 
-import { getConversation } from "@app/lib/api/assistant/conversation";
+import { getConversation } from "@app/lib/api/assistant/conversation/fetch";
 import { renderConversationForModel } from "@app/lib/api/assistant/preprocessing";
 import { getTextRepresentationFromMessages } from "@app/lib/api/assistant/utils";
 import { default as config } from "@app/lib/api/config";

--- a/front/components/assistant/conversation/ConversationContainer.tsx
+++ b/front/components/assistant/conversation/ConversationContainer.tsx
@@ -62,6 +62,10 @@ export function ConversationContainer({
 
   const router = useRouter();
 
+  // TODO(DURABLE_AGENT 2025-07-22): Remove this once we have a proper way to handle
+  // asynchronous loops.
+  const { async } = router.query;
+
   const sendNotification = useSendNotification();
 
   const { mutateConversations } = useConversations({
@@ -130,6 +134,7 @@ export function ConversationContainer({
             user,
             conversationId: activeConversationId,
             messageData,
+            forceAsync: async === "true",
           });
 
           // Replace placeholder message with API response.
@@ -219,6 +224,7 @@ export function ConversationContainer({
           contentFragments,
           clientSideMCPServerIds: removeNulls([serverId]),
         },
+        forceAsync: async === "true",
       });
 
       setIsSubmitting(false);

--- a/front/components/assistant/conversation/lib.ts
+++ b/front/components/assistant/conversation/lib.ts
@@ -74,6 +74,7 @@ export async function submitMessage({
   user,
   conversationId,
   messageData,
+  forceAsync = false,
 }: {
   owner: WorkspaceType;
   user: UserType;
@@ -84,6 +85,7 @@ export async function submitMessage({
     contentFragments: ContentFragmentsType;
     clientSideMCPServerIds?: string[];
   };
+  forceAsync?: boolean;
 }): Promise<Result<{ message: UserMessageWithRankType }, SubmitMessageError>> {
   const { input, mentions, contentFragments, clientSideMCPServerIds } =
     messageData;
@@ -151,8 +153,9 @@ export async function submitMessage({
   }
 
   // Create a new user message.
+  const queryParams = forceAsync ? "?async=true" : "";
   const mRes = await fetch(
-    `/api/w/${owner.sId}/assistant/conversations/${conversationId}/messages`,
+    `/api/w/${owner.sId}/assistant/conversations/${conversationId}/messages${queryParams}`,
     {
       method: "POST",
       headers: {
@@ -227,6 +230,7 @@ export async function createConversationWithMessage({
   messageData,
   visibility = "unlisted",
   title,
+  forceAsync = false,
 }: {
   owner: WorkspaceType;
   user: UserType;
@@ -238,6 +242,7 @@ export async function createConversationWithMessage({
   };
   visibility?: ConversationVisibility;
   title?: string;
+  forceAsync?: boolean;
 }): Promise<Result<ConversationType, SubmitMessageError>> {
   const { input, mentions, contentFragments, clientSideMCPServerIds } =
     messageData;
@@ -288,13 +293,17 @@ export async function createConversationWithMessage({
   };
 
   // Create new conversation and post the initial message at the same time.
-  const cRes = await fetch(`/api/w/${owner.sId}/assistant/conversations`, {
-    method: "POST",
-    headers: {
-      "Content-Type": "application/json",
-    },
-    body: JSON.stringify(body),
-  });
+  const queryParams = forceAsync ? "?async=true" : "";
+  const cRes = await fetch(
+    `/api/w/${owner.sId}/assistant/conversations${queryParams}`,
+    {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify(body),
+    }
+  );
 
   if (!cRes.ok) {
     const data = await cRes.json();

--- a/front/lib/api/assistant/agent.ts
+++ b/front/lib/api/assistant/agent.ts
@@ -52,7 +52,7 @@ async function runAgentSynchronousWithStreaming(
  * Higher-level function that serves as single entry point to either synchronous or asynchronous
  * execution based on the RunAgentArgs type.
  */
-export async function runAgentWithStreaming(
+export async function runAgentLoop(
   authType: AuthenticatorType,
   runAgentArgs: RunAgentArgs,
   { forceAsynchronousLoop = false }: { forceAsynchronousLoop?: boolean } = {}
@@ -67,7 +67,9 @@ export async function runAgentWithStreaming(
       authType,
       runAsynchronousAgentArgs: {
         agentMessageId: agentMessage.sId,
+        agentMessageVersion: agentMessage.version,
         conversationId: conversation.sId,
+        conversationTitle: conversation.title,
         userMessageId: userMessage.sId,
       },
     });

--- a/front/lib/api/assistant/agent.ts
+++ b/front/lib/api/assistant/agent.ts
@@ -71,6 +71,7 @@ export async function runAgentLoop(
         conversationId: conversation.sId,
         conversationTitle: conversation.title,
         userMessageId: userMessage.sId,
+        userMessageVersion: userMessage.version,
       },
     });
   } else {

--- a/front/lib/api/assistant/agent.ts
+++ b/front/lib/api/assistant/agent.ts
@@ -5,78 +5,36 @@ import type { AuthenticatorType } from "@app/lib/auth";
 import { wakeLock } from "@app/lib/wake_lock";
 import { runModelActivity } from "@app/temporal/agent_loop/activities/run_model";
 import { runToolActivity } from "@app/temporal/agent_loop/activities/run_tool";
+import { launchAgentLoopWorkflow } from "@app/temporal/agent_loop/client";
+import type { AgentLoopActivities } from "@app/temporal/agent_loop/lib/activity_interface";
+import { executeAgentLoop } from "@app/temporal/agent_loop/lib/agent_loop_executor";
 import { launchUpdateUsageWorkflow } from "@app/temporal/usage_queue/client";
-import type { ModelId, RunAgentArgs } from "@app/types";
-import { MAX_STEPS_USE_PER_RUN_LIMIT } from "@app/types";
-
-const MAX_ACTIONS_PER_STEP = 16;
+import type {
+  RunAgentArgs,
+  RunAgentSynchronousArgs,
+} from "@app/types/assistant/agent_run";
 
 // This interface is used to execute an agent. It is not in charge of creating the AgentMessage,
 // but it now handles updating it based on the execution results.
-export async function runAgentWithStreaming(
+async function runAgentSynchronousWithStreaming(
   authType: AuthenticatorType,
-  runAgentArgs: RunAgentArgs
+  runAgentSynchronousArgs: RunAgentSynchronousArgs
 ): Promise<void> {
+  const runAgentArgs: RunAgentArgs = {
+    sync: true,
+    inMemoryData: runAgentSynchronousArgs,
+  };
+
   const titlePromise = ensureConversationTitle(authType, runAgentArgs);
 
-  // Citations references offset kept up to date across steps.
-  let citationsRefsOffset = 0;
-
-  const runIds: string[] = [];
-
-  // Track step content IDs by function call ID for later use in actions.
-  let functionCallStepContentIds: Record<string, ModelId> = {};
+  // Create direct activities for non-Temporal execution.
+  const directActivities: AgentLoopActivities = {
+    runModelActivity: (args) => runModelActivity(args),
+    runToolActivity: (authType, args) => runToolActivity(authType, args),
+  };
 
   await wakeLock(async () => {
-    for (let i = 0; i < MAX_STEPS_USE_PER_RUN_LIMIT + 1; i++) {
-      const result = await runModelActivity({
-        authType,
-        runAgentArgs,
-        runIds,
-        step: i,
-        functionCallStepContentIds,
-        autoRetryCount: 0,
-      });
-
-      if (!result) {
-        // Generation completed or error occurred
-        return;
-      }
-
-      // Update state with results from runMultiActionsAgent
-      runIds.push(result.runId);
-      functionCallStepContentIds = result.functionCallStepContentIds;
-
-      // We received the actions to run, but will enforce a limit on the number of actions (16)
-      // which is very high. Over that the latency will just be too high. This is a guardrail
-      // against the model outputting something unreasonable.
-      const actionsToRun = result.actions.slice(0, MAX_ACTIONS_PER_STEP);
-
-      const citationsIncrements = await Promise.all(
-        actionsToRun.map(({ inputs, functionCallId }, index) => {
-          // Find the step content ID for this function call
-          const stepContentId = functionCallId
-            ? functionCallStepContentIds[functionCallId]
-            : undefined;
-
-          return runToolActivity(authType, {
-            runAgentArgs,
-            inputs,
-            functionCallId,
-            step: i,
-            stepActionIndex: index,
-            stepActions: actionsToRun.map((a) => a.action),
-            citationsRefsOffset,
-            stepContentId,
-          });
-        })
-      );
-
-      citationsRefsOffset += citationsIncrements.reduce(
-        (acc, curr) => acc + curr.citationsIncrement,
-        0
-      );
-    }
+    await executeAgentLoop(authType, runAgentArgs, directActivities);
   });
 
   await titlePromise;
@@ -88,4 +46,35 @@ export async function runAgentWithStreaming(
   await launchUpdateUsageWorkflow({
     workspaceId: authType.workspaceId,
   });
+}
+
+/**
+ * Higher-level function that serves as single entry point to either synchronous or asynchronous
+ * execution based on the RunAgentArgs type.
+ */
+export async function runAgentWithStreaming(
+  authType: AuthenticatorType,
+  runAgentArgs: RunAgentArgs,
+  { forceAsynchronousLoop = false }: { forceAsynchronousLoop?: boolean } = {}
+): Promise<void> {
+  if (runAgentArgs.sync && !forceAsynchronousLoop) {
+    await runAgentSynchronousWithStreaming(authType, runAgentArgs.inMemoryData);
+  } else if (runAgentArgs.sync) {
+    const { agentMessage, conversation, userMessage } =
+      runAgentArgs.inMemoryData;
+
+    await launchAgentLoopWorkflow({
+      authType,
+      runAsynchronousAgentArgs: {
+        agentMessageId: agentMessage.sId,
+        conversationId: conversation.sId,
+        userMessageId: userMessage.sId,
+      },
+    });
+  } else {
+    await launchAgentLoopWorkflow({
+      authType,
+      runAsynchronousAgentArgs: runAgentArgs.idArgs,
+    });
+  }
 }

--- a/front/lib/api/assistant/conversation.ts
+++ b/front/lib/api/assistant/conversation.ts
@@ -339,12 +339,14 @@ export async function postUserMessage(
     mentions,
     context,
     skipToolsValidation,
+    forceAsynchronousLoop = false,
   }: {
     conversation: ConversationType;
     content: string;
     mentions: MentionType[];
     context: UserMessageContext;
     skipToolsValidation: boolean;
+    forceAsynchronousLoop?: boolean;
   }
 ): Promise<
   Result<
@@ -689,7 +691,11 @@ export async function postUserMessage(
         agentMessageRow,
       };
 
-      void runAgentWithStreaming(auth.toJSON(), { sync: true, inMemoryData });
+      void runAgentWithStreaming(
+        auth.toJSON(),
+        { sync: true, inMemoryData },
+        { forceAsynchronousLoop }
+      );
     },
     { concurrency: MAX_CONCURRENT_AGENT_EXECUTIONS_PER_USER_MESSAGE }
   );
@@ -1126,7 +1132,11 @@ export async function editUserMessage(
         agentMessageRow,
       };
 
-      void runAgentWithStreaming(auth.toJSON(), { sync: true, inMemoryData });
+      void runAgentWithStreaming(
+        auth.toJSON(),
+        { sync: true, inMemoryData },
+        { forceAsynchronousLoop: false }
+      );
     },
     { concurrency: MAX_CONCURRENT_AGENT_EXECUTIONS_PER_USER_MESSAGE }
   );
@@ -1344,7 +1354,11 @@ export async function retryAgentMessage(
     agentMessageRow,
   };
 
-  void runAgentWithStreaming(auth.toJSON(), { sync: true, inMemoryData });
+  void runAgentWithStreaming(
+    auth.toJSON(),
+    { sync: true, inMemoryData },
+    { forceAsynchronousLoop: false }
+  );
 
   // TODO(DURABLE-AGENTS 2025-07-17): Publish message events to all open tabs to maintain
   // conversation state synchronization in multiplex mode. This is a temporary solution -

--- a/front/lib/api/assistant/conversation.ts
+++ b/front/lib/api/assistant/conversation.ts
@@ -2,7 +2,7 @@ import assert from "assert";
 import _, { isEqual, sortBy } from "lodash";
 import type { Transaction } from "sequelize";
 
-import { runAgentWithStreaming } from "@app/lib/api/assistant/agent";
+import { runAgentLoop } from "@app/lib/api/assistant/agent";
 import { signalAgentUsage } from "@app/lib/api/assistant/agent_usage";
 import {
   getAgentConfigurations,
@@ -691,7 +691,7 @@ export async function postUserMessage(
         agentMessageRow,
       };
 
-      void runAgentWithStreaming(
+      void runAgentLoop(
         auth.toJSON(),
         { sync: true, inMemoryData },
         { forceAsynchronousLoop }
@@ -1132,7 +1132,7 @@ export async function editUserMessage(
         agentMessageRow,
       };
 
-      void runAgentWithStreaming(
+      void runAgentLoop(
         auth.toJSON(),
         { sync: true, inMemoryData },
         { forceAsynchronousLoop: false }
@@ -1354,7 +1354,7 @@ export async function retryAgentMessage(
     agentMessageRow,
   };
 
-  void runAgentWithStreaming(
+  void runAgentLoop(
     auth.toJSON(),
     { sync: true, inMemoryData },
     { forceAsynchronousLoop: false }

--- a/front/lib/api/assistant/conversation.ts
+++ b/front/lib/api/assistant/conversation.ts
@@ -10,11 +10,8 @@ import {
   getLightAgentConfiguration,
 } from "@app/lib/api/assistant/configuration";
 import { getContentFragmentBlob } from "@app/lib/api/assistant/conversation/content_fragment";
-import {
-  batchRenderMessages,
-  canReadMessage,
-  getMaximalVersionAgentStepContent,
-} from "@app/lib/api/assistant/messages";
+import { getConversation } from "@app/lib/api/assistant/conversation/fetch";
+import { canReadMessage } from "@app/lib/api/assistant/messages";
 import { getContentFragmentGroupIds } from "@app/lib/api/assistant/permissions";
 import {
   makeAgentMentionsRateLimitKeyForWorkspace,
@@ -28,7 +25,6 @@ import { maybeUpsertFileAttachment } from "@app/lib/api/files/attachments";
 import { getSupportedModelConfig } from "@app/lib/assistant";
 import type { Authenticator } from "@app/lib/auth";
 import { getFeatureFlags } from "@app/lib/auth";
-import { AgentStepContentModel } from "@app/lib/models/assistant/agent_step_content";
 import {
   AgentMessage,
   Mention,
@@ -41,7 +37,6 @@ import { ConversationResource } from "@app/lib/resources/conversation_resource";
 import { GroupResource } from "@app/lib/resources/group_resource";
 import { MembershipResource } from "@app/lib/resources/membership_resource";
 import { frontSequelize } from "@app/lib/resources/storage";
-import { ContentFragmentModel } from "@app/lib/resources/storage/models/content_fragment";
 import {
   generateRandomModelSId,
   getResourceIdFromSId,
@@ -206,115 +201,6 @@ export async function deleteConversation(
     await conversation.updateVisibilityToDeleted();
   }
   return new Ok({ success: true });
-}
-
-export async function getConversation(
-  auth: Authenticator,
-  conversationId: string,
-  includeDeleted: boolean = false
-): Promise<Result<ConversationType, ConversationError>> {
-  const owner = auth.getNonNullableWorkspace();
-
-  const conversation = await ConversationResource.fetchById(
-    auth,
-    conversationId,
-    { includeDeleted }
-  );
-
-  if (!conversation) {
-    return new Err(new ConversationError("conversation_not_found"));
-  }
-
-  if (!ConversationResource.canAccessConversation(auth, conversation)) {
-    return new Err(new ConversationError("conversation_access_restricted"));
-  }
-
-  const messages = await Message.findAll({
-    where: {
-      conversationId: conversation.id,
-      workspaceId: owner.id,
-    },
-    order: [
-      ["rank", "ASC"],
-      ["version", "ASC"],
-    ],
-    include: [
-      {
-        model: UserMessage,
-        as: "userMessage",
-        required: false,
-      },
-      {
-        model: AgentMessage,
-        as: "agentMessage",
-        required: false,
-        include: [
-          {
-            model: AgentStepContentModel,
-            as: "agentStepContents",
-            required: false,
-          },
-        ],
-      },
-      // We skip ContentFragmentResource here for efficiency reasons (retrieving contentFragments
-      // along with messages in one query). Only once we move to a MessageResource will we be able
-      // to properly abstract this.
-      {
-        model: ContentFragmentModel,
-        as: "contentFragment",
-        required: false,
-      },
-    ],
-  });
-
-  // Filter to only keep the step content with the maximum version for each step and index combination.
-  for (const message of messages) {
-    if (message.agentMessage && message.agentMessage.agentStepContents) {
-      message.agentMessage.agentStepContents =
-        getMaximalVersionAgentStepContent(
-          message.agentMessage.agentStepContents
-        );
-    }
-  }
-
-  const renderRes = await batchRenderMessages(
-    auth,
-    conversation.sId,
-    messages,
-    "full"
-  );
-
-  if (renderRes.isErr()) {
-    return new Err(renderRes.error);
-  }
-
-  const render = renderRes.value;
-
-  // We need to escape the type system here to create content. We pre-create an array that will hold
-  // the versions of each User/Assistant/ContentFragment message. The lenght of that array is by definition the
-  // maximal rank of the conversation messages we just retrieved. In the case there is no message
-  // the rank is -1 and the array length is 0 as expected.
-  const content: any[] = Array.from(
-    { length: messages.reduce((acc, m) => Math.max(acc, m.rank), -1) + 1 },
-    () => []
-  );
-
-  for (const { rank, ...m } of render) {
-    content[rank] = [...content[rank], m];
-  }
-
-  return new Ok({
-    id: conversation.id,
-    created: conversation.createdAt.getTime(),
-    sId: conversation.sId,
-    owner,
-    title: conversation.title,
-    visibility: conversation.visibility,
-    depth: conversation.depth,
-    content,
-    requestedGroupIds:
-      conversation.getConversationRequestedGroupIdsFromModel(auth),
-  });
 }
 
 export async function getConversationMessageType(

--- a/front/lib/api/assistant/conversation/fetch.ts
+++ b/front/lib/api/assistant/conversation/fetch.ts
@@ -1,0 +1,124 @@
+import {
+  batchRenderMessages,
+  getMaximalVersionAgentStepContent,
+} from "@app/lib/api/assistant/messages";
+import type { Authenticator } from "@app/lib/auth";
+import { AgentStepContentModel } from "@app/lib/models/assistant/agent_step_content";
+import {
+  AgentMessage,
+  Message,
+  UserMessage,
+} from "@app/lib/models/assistant/conversation";
+import { ConversationResource } from "@app/lib/resources/conversation_resource";
+import { ContentFragmentModel } from "@app/lib/resources/storage/models/content_fragment";
+import type { ConversationType, Result } from "@app/types";
+import { ConversationError, Err, Ok } from "@app/types";
+
+export async function getConversation(
+  auth: Authenticator,
+  conversationId: string,
+  includeDeleted: boolean = false
+): Promise<Result<ConversationType, ConversationError>> {
+  const owner = auth.getNonNullableWorkspace();
+
+  const conversation = await ConversationResource.fetchById(
+    auth,
+    conversationId,
+    { includeDeleted }
+  );
+
+  if (!conversation) {
+    return new Err(new ConversationError("conversation_not_found"));
+  }
+
+  if (!ConversationResource.canAccessConversation(auth, conversation)) {
+    return new Err(new ConversationError("conversation_access_restricted"));
+  }
+
+  const messages = await Message.findAll({
+    where: {
+      conversationId: conversation.id,
+      workspaceId: owner.id,
+    },
+    order: [
+      ["rank", "ASC"],
+      ["version", "ASC"],
+    ],
+    include: [
+      {
+        model: UserMessage,
+        as: "userMessage",
+        required: false,
+      },
+      {
+        model: AgentMessage,
+        as: "agentMessage",
+        required: false,
+        include: [
+          {
+            model: AgentStepContentModel,
+            as: "agentStepContents",
+            required: false,
+          },
+        ],
+      },
+      // We skip ContentFragmentResource here for efficiency reasons (retrieving contentFragments
+      // along with messages in one query). Only once we move to a MessageResource will we be able
+      // to properly abstract this.
+      {
+        model: ContentFragmentModel,
+        as: "contentFragment",
+        required: false,
+      },
+    ],
+  });
+
+  // Filter to only keep the step content with the maximum version for each step and index combination.
+  for (const message of messages) {
+    if (message.agentMessage && message.agentMessage.agentStepContents) {
+      message.agentMessage.agentStepContents =
+        getMaximalVersionAgentStepContent(
+          message.agentMessage.agentStepContents
+        );
+    }
+  }
+
+  const renderRes = await batchRenderMessages(
+    auth,
+    conversation.sId,
+    messages,
+    "full"
+  );
+
+  if (renderRes.isErr()) {
+    return new Err(renderRes.error);
+  }
+
+  const render = renderRes.value;
+
+  // We need to escape the type system here to create content. We pre-create an array that will hold
+  // the versions of each User/Assistant/ContentFragment message. The lenght of that array is by definition the
+  // maximal rank of the conversation messages we just retrieved. In the case there is no message
+  // the rank is -1 and the array length is 0 as expected.
+  const content: any[] = Array.from(
+    { length: messages.reduce((acc, m) => Math.max(acc, m.rank), -1) + 1 },
+    () => []
+  );
+
+  for (const { rank, ...m } of render) {
+    content[rank] = [...content[rank], m];
+  }
+
+  return new Ok({
+    id: conversation.id,
+    created: conversation.createdAt.getTime(),
+    sId: conversation.sId,
+    owner,
+    title: conversation.title,
+    visibility: conversation.visibility,
+    depth: conversation.depth,
+    content,
+    requestedGroupIds:
+      conversation.getConversationRequestedGroupIdsFromModel(auth),
+  });
+}

--- a/front/lib/api/assistant/conversation/title.ts
+++ b/front/lib/api/assistant/conversation/title.ts
@@ -8,13 +8,10 @@ import { getDustProdAction } from "@app/lib/registry";
 import { cloneBaseConfig } from "@app/lib/registry";
 import { ConversationResource } from "@app/lib/resources/conversation_resource";
 import logger from "@app/logger/logger";
-import type { ConversationType, Result, RunAgentArgs } from "@app/types";
-import {
-  Err,
-  getLargeNonAnthropicWhitelistedModel,
-  getRunAgentData,
-  Ok,
-} from "@app/types";
+import type { ConversationType, Result } from "@app/types";
+import { Err, getLargeNonAnthropicWhitelistedModel, Ok } from "@app/types";
+import type { RunAgentArgs } from "@app/types/assistant/agent_run";
+import { getRunAgentData } from "@app/types/assistant/agent_run";
 
 const MIN_GENERATION_TOKENS = 1024;
 
@@ -22,7 +19,12 @@ export async function ensureConversationTitle(
   authType: AuthenticatorType,
   runAgentArgs: RunAgentArgs
 ): Promise<void> {
-  const { conversation, userMessage } = getRunAgentData(runAgentArgs);
+  const runAgentDataRes = await getRunAgentData(authType, runAgentArgs);
+  if (runAgentDataRes.isErr()) {
+    throw runAgentDataRes.error;
+  }
+
+  const { conversation, userMessage } = runAgentDataRes.value;
 
   // If the conversation has a title, return early.
   if (conversation.title) {

--- a/front/lib/api/assistant/email_trigger.ts
+++ b/front/lib/api/assistant/email_trigger.ts
@@ -5,9 +5,9 @@ import { Op } from "sequelize";
 import { getAgentConfigurations } from "@app/lib/api/assistant/configuration";
 import {
   createConversation,
-  getConversation,
   postNewContentFragment,
 } from "@app/lib/api/assistant/conversation";
+import { getConversation } from "@app/lib/api/assistant/conversation/fetch";
 import { postUserMessageAndWaitForCompletion } from "@app/lib/api/assistant/streaming/blocking";
 import { sendEmail } from "@app/lib/api/email";
 import type { Authenticator } from "@app/lib/auth";

--- a/front/lib/poke/conversations.ts
+++ b/front/lib/poke/conversations.ts
@@ -1,4 +1,4 @@
-import { getConversation } from "@app/lib/api/assistant/conversation";
+import { getConversation } from "@app/lib/api/assistant/conversation/fetch";
 import type { Authenticator } from "@app/lib/auth";
 import { AgentMessage } from "@app/lib/models/assistant/conversation";
 import type {

--- a/front/pages/api/v1/w/[wId]/assistant/conversations/[cId]/content_fragments.ts
+++ b/front/pages/api/v1/w/[wId]/assistant/conversations/[cId]/content_fragments.ts
@@ -3,11 +3,9 @@ import { PublicPostContentFragmentRequestBodySchema } from "@dust-tt/client";
 import type { NextApiRequest, NextApiResponse } from "next";
 import { fromError } from "zod-validation-error";
 
-import {
-  getConversation,
-  postNewContentFragment,
-} from "@app/lib/api/assistant/conversation";
+import { postNewContentFragment } from "@app/lib/api/assistant/conversation";
 import { toFileContentFragment } from "@app/lib/api/assistant/conversation/content_fragment";
+import { getConversation } from "@app/lib/api/assistant/conversation/fetch";
 import { apiErrorForConversation } from "@app/lib/api/assistant/conversation/helper";
 import { withPublicAPIAuthentication } from "@app/lib/api/auth_wrappers";
 import type { Authenticator } from "@app/lib/auth";

--- a/front/pages/api/v1/w/[wId]/assistant/conversations/[cId]/index.ts
+++ b/front/pages/api/v1/w/[wId]/assistant/conversations/[cId]/index.ts
@@ -1,7 +1,7 @@
 import type { GetConversationResponseType } from "@dust-tt/client";
 import type { NextApiRequest, NextApiResponse } from "next";
 
-import { getConversation } from "@app/lib/api/assistant/conversation";
+import { getConversation } from "@app/lib/api/assistant/conversation/fetch";
 import { apiErrorForConversation } from "@app/lib/api/assistant/conversation/helper";
 import { withPublicAPIAuthentication } from "@app/lib/api/auth_wrappers";
 import type { Authenticator } from "@app/lib/auth";

--- a/front/pages/api/v1/w/[wId]/assistant/conversations/[cId]/messages/[mId]/edit.ts
+++ b/front/pages/api/v1/w/[wId]/assistant/conversations/[cId]/messages/[mId]/edit.ts
@@ -3,10 +3,8 @@ import { PublicPostEditMessagesRequestBodySchema } from "@dust-tt/client";
 import type { NextApiRequest, NextApiResponse } from "next";
 import { fromError } from "zod-validation-error";
 
-import {
-  editUserMessage,
-  getConversation,
-} from "@app/lib/api/assistant/conversation";
+import { editUserMessage } from "@app/lib/api/assistant/conversation";
+import { getConversation } from "@app/lib/api/assistant/conversation/fetch";
 import { apiErrorForConversation } from "@app/lib/api/assistant/conversation/helper";
 import { withPublicAPIAuthentication } from "@app/lib/api/auth_wrappers";
 import type { Authenticator } from "@app/lib/auth";

--- a/front/pages/api/v1/w/[wId]/assistant/conversations/[cId]/messages/[mId]/retry.ts
+++ b/front/pages/api/v1/w/[wId]/assistant/conversations/[cId]/messages/[mId]/retry.ts
@@ -3,10 +3,8 @@ import * as t from "io-ts";
 import * as reporter from "io-ts-reporters";
 import type { NextApiRequest, NextApiResponse } from "next";
 
-import {
-  getConversation,
-  retryAgentMessage,
-} from "@app/lib/api/assistant/conversation";
+import { retryAgentMessage } from "@app/lib/api/assistant/conversation";
+import { getConversation } from "@app/lib/api/assistant/conversation/fetch";
 import { apiErrorForConversation } from "@app/lib/api/assistant/conversation/helper";
 import { withPublicAPIAuthentication } from "@app/lib/api/auth_wrappers";
 import type { Authenticator } from "@app/lib/auth";

--- a/front/pages/api/v1/w/[wId]/assistant/conversations/[cId]/messages/[mId]/validate-action.ts
+++ b/front/pages/api/v1/w/[wId]/assistant/conversations/[cId]/messages/[mId]/validate-action.ts
@@ -3,7 +3,7 @@ import { ValidateActionRequestBodySchema } from "@dust-tt/client";
 import type { NextApiRequest, NextApiResponse } from "next";
 
 import { MCPActionType } from "@app/lib/actions/mcp";
-import { getConversation } from "@app/lib/api/assistant/conversation";
+import { getConversation } from "@app/lib/api/assistant/conversation/fetch";
 import { apiErrorForConversation } from "@app/lib/api/assistant/conversation/helper";
 import { validateAction } from "@app/lib/api/assistant/conversation/validate_actions";
 import { withPublicAPIAuthentication } from "@app/lib/api/auth_wrappers";

--- a/front/pages/api/v1/w/[wId]/assistant/conversations/[cId]/messages/index.ts
+++ b/front/pages/api/v1/w/[wId]/assistant/conversations/[cId]/messages/index.ts
@@ -4,10 +4,8 @@ import type { NextApiRequest, NextApiResponse } from "next";
 import { fromError } from "zod-validation-error";
 
 import { validateMCPServerAccess } from "@app/lib/api/actions/mcp/client_side_registry";
-import {
-  getConversation,
-  postUserMessage,
-} from "@app/lib/api/assistant/conversation";
+import { postUserMessage } from "@app/lib/api/assistant/conversation";
+import { getConversation } from "@app/lib/api/assistant/conversation/fetch";
 import {
   apiErrorForConversation,
   isUserMessageContextOverflowing,

--- a/front/pages/api/v1/w/[wId]/assistant/conversations/index.ts
+++ b/front/pages/api/v1/w/[wId]/assistant/conversations/index.ts
@@ -9,11 +9,11 @@ import { fromError } from "zod-validation-error";
 import { validateMCPServerAccess } from "@app/lib/api/actions/mcp/client_side_registry";
 import {
   createConversation,
-  getConversation,
   postNewContentFragment,
   postUserMessage,
 } from "@app/lib/api/assistant/conversation";
 import { toFileContentFragment } from "@app/lib/api/assistant/conversation/content_fragment";
+import { getConversation } from "@app/lib/api/assistant/conversation/fetch";
 import {
   apiErrorForConversation,
   isUserMessageContextOverflowing,

--- a/front/pages/api/w/[wId]/assistant/conversations/[cId]/content_fragment/index.ts
+++ b/front/pages/api/w/[wId]/assistant/conversations/[cId]/content_fragment/index.ts
@@ -2,10 +2,8 @@ import { isLeft } from "fp-ts/lib/Either";
 import * as reporter from "io-ts-reporters";
 import type { NextApiRequest, NextApiResponse } from "next";
 
-import {
-  getConversation,
-  postNewContentFragment,
-} from "@app/lib/api/assistant/conversation";
+import { postNewContentFragment } from "@app/lib/api/assistant/conversation";
+import { getConversation } from "@app/lib/api/assistant/conversation/fetch";
 import { apiErrorForConversation } from "@app/lib/api/assistant/conversation/helper";
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
 import type { Authenticator } from "@app/lib/auth";

--- a/front/pages/api/w/[wId]/assistant/conversations/[cId]/messages/[mId]/edit.ts
+++ b/front/pages/api/w/[wId]/assistant/conversations/[cId]/messages/[mId]/edit.ts
@@ -3,10 +3,8 @@ import * as t from "io-ts";
 import * as reporter from "io-ts-reporters";
 import type { NextApiRequest, NextApiResponse } from "next";
 
-import {
-  editUserMessage,
-  getConversation,
-} from "@app/lib/api/assistant/conversation";
+import { editUserMessage } from "@app/lib/api/assistant/conversation";
+import { getConversation } from "@app/lib/api/assistant/conversation/fetch";
 import { apiErrorForConversation } from "@app/lib/api/assistant/conversation/helper";
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
 import type { Authenticator } from "@app/lib/auth";

--- a/front/pages/api/w/[wId]/assistant/conversations/[cId]/messages/[mId]/raw_content_fragment/index.ts
+++ b/front/pages/api/w/[wId]/assistant/conversations/[cId]/messages/[mId]/raw_content_fragment/index.ts
@@ -1,7 +1,7 @@
 import { IncomingForm } from "formidable";
 import type { NextApiRequest, NextApiResponse } from "next";
 
-import { getConversation } from "@app/lib/api/assistant/conversation";
+import { getConversation } from "@app/lib/api/assistant/conversation/fetch";
 import { apiErrorForConversation } from "@app/lib/api/assistant/conversation/helper";
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
 import type { Authenticator } from "@app/lib/auth";

--- a/front/pages/api/w/[wId]/assistant/conversations/[cId]/messages/[mId]/retry.ts
+++ b/front/pages/api/w/[wId]/assistant/conversations/[cId]/messages/[mId]/retry.ts
@@ -3,10 +3,8 @@ import * as t from "io-ts";
 import * as reporter from "io-ts-reporters";
 import type { NextApiRequest, NextApiResponse } from "next";
 
-import {
-  getConversation,
-  retryAgentMessage,
-} from "@app/lib/api/assistant/conversation";
+import { retryAgentMessage } from "@app/lib/api/assistant/conversation";
+import { getConversation } from "@app/lib/api/assistant/conversation/fetch";
 import { apiErrorForConversation } from "@app/lib/api/assistant/conversation/helper";
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
 import type { Authenticator } from "@app/lib/auth";

--- a/front/pages/api/w/[wId]/assistant/conversations/[cId]/messages/[mId]/validate-action.ts
+++ b/front/pages/api/w/[wId]/assistant/conversations/[cId]/messages/[mId]/validate-action.ts
@@ -1,7 +1,7 @@
 import type { NextApiRequest, NextApiResponse } from "next";
 import { z } from "zod";
 
-import { getConversation } from "@app/lib/api/assistant/conversation";
+import { getConversation } from "@app/lib/api/assistant/conversation/fetch";
 import { apiErrorForConversation } from "@app/lib/api/assistant/conversation/helper";
 import { validateAction } from "@app/lib/api/assistant/conversation/validate_actions";
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";

--- a/front/pages/api/w/[wId]/assistant/conversations/[cId]/messages/index.ts
+++ b/front/pages/api/w/[wId]/assistant/conversations/[cId]/messages/index.ts
@@ -3,10 +3,8 @@ import * as reporter from "io-ts-reporters";
 import type { NextApiRequest, NextApiResponse } from "next";
 
 import { validateMCPServerAccess } from "@app/lib/api/actions/mcp/client_side_registry";
-import {
-  getConversation,
-  postUserMessage,
-} from "@app/lib/api/assistant/conversation";
+import { postUserMessage } from "@app/lib/api/assistant/conversation";
+import { getConversation } from "@app/lib/api/assistant/conversation/fetch";
 import { apiErrorForConversation } from "@app/lib/api/assistant/conversation/helper";
 import { fetchConversationMessages } from "@app/lib/api/assistant/messages";
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";

--- a/front/pages/api/w/[wId]/assistant/conversations/[cId]/messages/index.ts
+++ b/front/pages/api/w/[wId]/assistant/conversations/[cId]/messages/index.ts
@@ -42,6 +42,7 @@ async function handler(
   }
 
   const conversationId = req.query.cId;
+  const forceAsynchronousLoop = req.query.async === "true";
 
   switch (req.method) {
     case "GET":
@@ -157,6 +158,7 @@ async function handler(
         },
         // For now we never skip tools when interacting with agents from the web client.
         skipToolsValidation: false,
+        forceAsynchronousLoop,
       });
 
       if (messageRes.isErr()) {

--- a/front/pages/api/w/[wId]/assistant/conversations/index.ts
+++ b/front/pages/api/w/[wId]/assistant/conversations/index.ts
@@ -5,10 +5,10 @@ import type { NextApiRequest, NextApiResponse } from "next";
 import { validateMCPServerAccess } from "@app/lib/api/actions/mcp/client_side_registry";
 import {
   createConversation,
-  getConversation,
   postNewContentFragment,
   postUserMessage,
 } from "@app/lib/api/assistant/conversation";
+import { getConversation } from "@app/lib/api/assistant/conversation/fetch";
 import { apiErrorForConversation } from "@app/lib/api/assistant/conversation/helper";
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
 import type { Authenticator } from "@app/lib/auth";

--- a/front/pages/api/w/[wId]/assistant/conversations/index.ts
+++ b/front/pages/api/w/[wId]/assistant/conversations/index.ts
@@ -74,6 +74,8 @@ async function handler(
       const { title, visibility, message, contentFragments } =
         bodyValidation.right;
 
+      const forceAsynchronousLoop = req.query.async === "true";
+
       if (message?.context.clientSideMCPServerIds) {
         const hasServerAccess = await concurrentExecutor(
           message.context.clientSideMCPServerIds,
@@ -179,6 +181,7 @@ async function handler(
           },
           // For now we never skip tools when interacting with agents from the web client.
           skipToolsValidation: false,
+          forceAsynchronousLoop,
         });
         if (messageRes.isErr()) {
           return apiError(req, res, messageRes.error);

--- a/front/temporal/agent_loop/activities/ensure_conversation_title.ts
+++ b/front/temporal/agent_loop/activities/ensure_conversation_title.ts
@@ -1,0 +1,10 @@
+import { ensureConversationTitle } from "@app/lib/api/assistant/conversation/title";
+import type { AuthenticatorType } from "@app/lib/auth";
+import type { RunAgentArgs } from "@app/types/assistant/agent_run";
+
+export async function ensureConversationTitleActivity(
+  authType: AuthenticatorType,
+  runAgentArgs: RunAgentArgs
+): Promise<void> {
+  await ensureConversationTitle(authType, runAgentArgs);
+}

--- a/front/temporal/agent_loop/activities/run_model.ts
+++ b/front/temporal/agent_loop/activities/run_model.ts
@@ -39,13 +39,14 @@ import { generateRandomModelSId } from "@app/lib/resources/string_ids";
 import logger from "@app/logger/logger";
 import { statsDClient } from "@app/logger/statsDClient";
 import { updateResourceAndPublishEvent } from "@app/temporal/agent_loop/activities/common";
-import type { AgentActionsEvent, ModelId, RunAgentArgs } from "@app/types";
-import { getRunAgentData } from "@app/types";
+import type { AgentActionsEvent, ModelId } from "@app/types";
 import type {
   FunctionCallContentType,
   ReasoningContentType,
   TextContentType,
 } from "@app/types/assistant/agent_message_content";
+import type { RunAgentArgs } from "@app/types/assistant/agent_run";
+import { getRunAgentData } from "@app/types/assistant/agent_run";
 
 const CANCELLATION_CHECK_INTERVAL = 500;
 const MAX_AUTO_RETRY = 3;
@@ -75,13 +76,18 @@ export async function runModelActivity({
   runId: string;
   functionCallStepContentIds: Record<string, ModelId>;
 } | null> {
+  const runAgentDataRes = await getRunAgentData(authType, runAgentArgs);
+  if (runAgentDataRes.isErr()) {
+    throw runAgentDataRes.error;
+  }
+
   const {
     agentConfiguration,
     conversation,
     userMessage,
     agentMessage,
     agentMessageRow,
-  } = getRunAgentData(runAgentArgs);
+  } = runAgentDataRes.value;
 
   const now = Date.now();
 

--- a/front/temporal/agent_loop/activities/run_tool.ts
+++ b/front/temporal/agent_loop/activities/run_tool.ts
@@ -6,8 +6,9 @@ import type { AuthenticatorType } from "@app/lib/auth";
 import { Authenticator } from "@app/lib/auth";
 import logger from "@app/logger/logger";
 import { updateResourceAndPublishEvent } from "@app/temporal/agent_loop/activities/common";
-import type { RunAgentArgs } from "@app/types";
-import { assertNever, getRunAgentData } from "@app/types";
+import { assertNever } from "@app/types";
+import type { RunAgentArgs } from "@app/types/assistant/agent_run";
+import { getRunAgentData } from "@app/types/assistant/agent_run";
 import type { ModelId } from "@app/types/shared/model_id";
 
 export async function runToolActivity(
@@ -35,8 +36,13 @@ export async function runToolActivity(
   const auth = await Authenticator.fromJSON(authType);
 
   const actionConfiguration = stepActions[stepActionIndex];
+  const runAgentDataRes = await getRunAgentData(authType, runAgentArgs);
+  if (runAgentDataRes.isErr()) {
+    throw runAgentDataRes.error;
+  }
+
   const { agentConfiguration, conversation, agentMessage, agentMessageRow } =
-    getRunAgentData(runAgentArgs);
+    runAgentDataRes.value;
 
   if (!stepContentId) {
     logger.error(

--- a/front/temporal/agent_loop/client.ts
+++ b/front/temporal/agent_loop/client.ts
@@ -1,24 +1,29 @@
+import type { AuthenticatorType } from "@app/lib/auth";
 import { getTemporalClient } from "@app/lib/temporal";
-import type { Result, RunAgentArgs } from "@app/types";
+import { makeAgentLoopWorkflowId } from "@app/temporal/agent_loop/lib/workflow_ids";
+import type { Result } from "@app/types";
 import { Ok } from "@app/types";
+import type { RunAgentAsynchronousArgs } from "@app/types/assistant/agent_run";
 
 import { QUEUE_NAME } from "./config";
 import { agentLoopWorkflow } from "./workflows";
-import { AuthenticatorType } from "@app/lib/auth";
 
 export async function launchAgentLoopWorkflow({
   authType,
-  runAgentArgs,
+  runAsynchronousAgentArgs,
 }: {
   authType: AuthenticatorType;
-  runAgentArgs: RunAgentArgs;
+  runAsynchronousAgentArgs: RunAgentAsynchronousArgs;
 }): Promise<Result<undefined, Error>> {
   const client = await getTemporalClient();
 
-  const workflowId = `TODO`;
+  const workflowId = makeAgentLoopWorkflowId(
+    authType,
+    runAsynchronousAgentArgs
+  );
 
   await client.workflow.start(agentLoopWorkflow, {
-    args: [{ authType: authType, runAgentArgs: runAgentArgs }],
+    args: [{ authType, runAsynchronousAgentArgs }],
     taskQueue: QUEUE_NAME,
     workflowId,
   });

--- a/front/temporal/agent_loop/lib/activity_interface.ts
+++ b/front/temporal/agent_loop/lib/activity_interface.ts
@@ -28,7 +28,7 @@ export interface AgentLoopActivities {
       stepActionIndex: number;
       stepActions: ActionConfigurationType[];
       citationsRefsOffset: number;
-      stepContentId?: ModelId;
+      stepContentId: ModelId;
     }
   ): Promise<{ citationsIncrement: number }>;
 }

--- a/front/temporal/agent_loop/lib/activity_interface.ts
+++ b/front/temporal/agent_loop/lib/activity_interface.ts
@@ -1,0 +1,34 @@
+import type { ActionConfigurationType } from "@app/lib/actions/types/agent";
+import type { AuthenticatorType } from "@app/lib/auth";
+import type { ModelId } from "@app/types";
+import type { AgentActionsEvent } from "@app/types/assistant/agent";
+import type { RunAgentArgs } from "@app/types/assistant/agent_run";
+
+export interface AgentLoopActivities {
+  runModelActivity(args: {
+    authType: AuthenticatorType;
+    runAgentArgs: RunAgentArgs;
+    runIds: string[];
+    step: number;
+    functionCallStepContentIds: Record<string, ModelId>;
+    autoRetryCount?: number;
+  }): Promise<{
+    actions: AgentActionsEvent["actions"];
+    runId: string;
+    functionCallStepContentIds: Record<string, ModelId>;
+  } | null>;
+
+  runToolActivity(
+    authType: AuthenticatorType,
+    args: {
+      runAgentArgs: RunAgentArgs;
+      inputs: Record<string, string | boolean | number>;
+      functionCallId: string;
+      step: number;
+      stepActionIndex: number;
+      stepActions: ActionConfigurationType[];
+      citationsRefsOffset: number;
+      stepContentId?: ModelId;
+    }
+  ): Promise<{ citationsIncrement: number }>;
+}

--- a/front/temporal/agent_loop/lib/agent_loop_executor.ts
+++ b/front/temporal/agent_loop/lib/agent_loop_executor.ts
@@ -52,13 +52,8 @@ export async function executeAgentLoop(
     const actionsToRun = result.actions.slice(0, MAX_ACTIONS_PER_STEP);
 
     const citationsIncrements = await Promise.all(
-      actionsToRun.map(({ inputs, functionCallId }, index) => {
-        // Find the step content ID for this function call
-        const stepContentId = functionCallId
-          ? functionCallStepContentIds[functionCallId]
-          : undefined;
-
-        return activities.runToolActivity(authType, {
+      actionsToRun.map(({ inputs, functionCallId }, index) =>
+        activities.runToolActivity(authType, {
           runAgentArgs,
           inputs,
           functionCallId,
@@ -66,9 +61,9 @@ export async function executeAgentLoop(
           stepActionIndex: index,
           stepActions: actionsToRun.map((a) => a.action),
           citationsRefsOffset,
-          stepContentId,
-        });
-      })
+          stepContentId: functionCallStepContentIds[functionCallId],
+        })
+      )
     );
 
     citationsRefsOffset += citationsIncrements.reduce(

--- a/front/temporal/agent_loop/lib/agent_loop_executor.ts
+++ b/front/temporal/agent_loop/lib/agent_loop_executor.ts
@@ -1,0 +1,79 @@
+import type { AuthenticatorType } from "@app/lib/auth";
+import type { ModelId } from "@app/types";
+import {
+  MAX_ACTIONS_PER_STEP,
+  MAX_STEPS_USE_PER_RUN_LIMIT,
+} from "@app/types/assistant/agent";
+import type { RunAgentArgs } from "@app/types/assistant/agent_run";
+
+import type { AgentLoopActivities } from "./activity_interface";
+
+/**
+ * Core agent loop executor that works with both Temporal workflows and direct execution.
+ *
+ * IMPORTANT: This code runs in Temporal workflows. Changes to this function affect workflow
+ * versions and require careful migration planning for existing running workflows.
+ */
+export async function executeAgentLoop(
+  authType: AuthenticatorType,
+  runAgentArgs: RunAgentArgs,
+  activities: AgentLoopActivities
+): Promise<void> {
+  // Citations references offset kept up to date across steps.
+  let citationsRefsOffset = 0;
+
+  const runIds: string[] = [];
+
+  // Track step content IDs by function call ID for later use in actions.
+  let functionCallStepContentIds: Record<string, ModelId> = {};
+
+  for (let i = 0; i < MAX_STEPS_USE_PER_RUN_LIMIT + 1; i++) {
+    const result = await activities.runModelActivity({
+      authType,
+      runAgentArgs,
+      runIds,
+      step: i,
+      functionCallStepContentIds,
+      autoRetryCount: 0,
+    });
+
+    if (!result) {
+      // Generation completed or error occurred.
+      return;
+    }
+
+    // Update state with results from runMultiActionsAgent.
+    runIds.push(result.runId);
+    functionCallStepContentIds = result.functionCallStepContentIds;
+
+    // We received the actions to run, but will enforce a limit on the number of actions
+    // which is very high. Over that the latency will just be too high. This is a guardrail
+    // against the model outputting something unreasonable.
+    const actionsToRun = result.actions.slice(0, MAX_ACTIONS_PER_STEP);
+
+    const citationsIncrements = await Promise.all(
+      actionsToRun.map(({ inputs, functionCallId }, index) => {
+        // Find the step content ID for this function call
+        const stepContentId = functionCallId
+          ? functionCallStepContentIds[functionCallId]
+          : undefined;
+
+        return activities.runToolActivity(authType, {
+          runAgentArgs,
+          inputs,
+          functionCallId,
+          step: i,
+          stepActionIndex: index,
+          stepActions: actionsToRun.map((a) => a.action),
+          citationsRefsOffset,
+          stepContentId,
+        });
+      })
+    );
+
+    citationsRefsOffset += citationsIncrements.reduce(
+      (acc, curr) => acc + curr.citationsIncrement,
+      0
+    );
+  }
+}

--- a/front/temporal/agent_loop/lib/workflow_ids.ts
+++ b/front/temporal/agent_loop/lib/workflow_ids.ts
@@ -18,5 +18,5 @@ export function makeAgentLoopConversationTitleWorkflowId(
   const { workspaceId } = authType;
   const { conversationId } = runAgentArgs;
 
-  return `agent-loop-conv-title-workflow-${workspaceId}-${conversationId}`;
+  return `agent-loop-conversation-title-workflow-${workspaceId}-${conversationId}`;
 }

--- a/front/temporal/agent_loop/lib/workflow_ids.ts
+++ b/front/temporal/agent_loop/lib/workflow_ids.ts
@@ -1,0 +1,22 @@
+import type { AuthenticatorType } from "@app/lib/auth";
+import type { RunAgentAsynchronousArgs } from "@app/types/assistant/agent_run";
+
+export function makeAgentLoopWorkflowId(
+  authType: AuthenticatorType,
+  runAgentArgs: RunAgentAsynchronousArgs
+) {
+  const { workspaceId } = authType;
+  const { agentMessageId, conversationId } = runAgentArgs;
+
+  return `agent-loop-workflow-${workspaceId}-${conversationId}-${agentMessageId}`;
+}
+
+export function makeAgentLoopConversationTitleWorkflowId(
+  authType: AuthenticatorType,
+  runAgentArgs: RunAgentAsynchronousArgs
+) {
+  const { workspaceId } = authType;
+  const { conversationId } = runAgentArgs;
+
+  return `agent-loop-conv-title-workflow-${workspaceId}-${conversationId}`;
+}

--- a/front/temporal/agent_loop/worker.ts
+++ b/front/temporal/agent_loop/worker.ts
@@ -31,7 +31,9 @@ export async function runAgentLoopWorker() {
       ],
     },
     bundlerOptions: {
-      // Update the webpack config to use aliases from our tsconfig.json.
+      // Update the webpack config to use aliases from our tsconfig.json. This let us import code
+      // in the workflows and activities files using the @app/ prefix. We also need to ignore some
+      // modules that are not available in Temporal environment.
       webpackConfigHook: (config) => {
         const plugins = config.resolve?.plugins ?? [];
         // eslint-disable-next-line @typescript-eslint/no-non-null-assertion

--- a/front/temporal/agent_loop/worker.ts
+++ b/front/temporal/agent_loop/worker.ts
@@ -6,7 +6,6 @@ import { getTemporalWorkerConnection } from "@app/lib/temporal";
 import { ActivityInboundLogInterceptor } from "@app/lib/temporal_monitoring";
 import logger from "@app/logger/logger";
 import { ensureConversationTitleActivity } from "@app/temporal/agent_loop/activities/ensure_conversation_title";
-// TODO:REFACTOR
 import { runModelActivity } from "@app/temporal/agent_loop/activities/run_model";
 import { runToolActivity } from "@app/temporal/agent_loop/activities/run_tool";
 import { QUEUE_NAME } from "@app/temporal/agent_loop/config";

--- a/front/temporal/agent_loop/worker.ts
+++ b/front/temporal/agent_loop/worker.ts
@@ -1,13 +1,15 @@
 import type { Context } from "@temporalio/activity";
 import { Worker } from "@temporalio/worker";
+import TsconfigPathsPlugin from "tsconfig-paths-webpack-plugin";
 
 import { getTemporalWorkerConnection } from "@app/lib/temporal";
 import { ActivityInboundLogInterceptor } from "@app/lib/temporal_monitoring";
 import logger from "@app/logger/logger";
+import { ensureConversationTitleActivity } from "@app/temporal/agent_loop/activities/ensure_conversation_title";
+// TODO:REFACTOR
 import { runModelActivity } from "@app/temporal/agent_loop/activities/run_model";
 import { runToolActivity } from "@app/temporal/agent_loop/activities/run_tool";
-
-import { QUEUE_NAME } from "./config";
+import { QUEUE_NAME } from "@app/temporal/agent_loop/config";
 
 export async function runAgentLoopWorker() {
   const { connection, namespace } = await getTemporalWorkerConnection();
@@ -17,6 +19,7 @@ export async function runAgentLoopWorker() {
     activities: {
       runModelActivity,
       runToolActivity,
+      ensureConversationTitleActivity,
     },
     taskQueue: QUEUE_NAME,
     connection,
@@ -27,6 +30,16 @@ export async function runAgentLoopWorker() {
           return new ActivityInboundLogInterceptor(ctx, logger);
         },
       ],
+    },
+    bundlerOptions: {
+      // Update the webpack config to use aliases from our tsconfig.json.
+      webpackConfigHook: (config) => {
+        const plugins = config.resolve?.plugins ?? [];
+        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+        config.resolve!.plugins = [...plugins, new TsconfigPathsPlugin({})];
+        return config;
+      },
+      ignoreModules: ["child_process", "crypto", "stream"],
     },
   });
 

--- a/front/temporal/agent_loop/workflows.ts
+++ b/front/temporal/agent_loop/workflows.ts
@@ -1,23 +1,90 @@
-import { proxyActivities } from "@temporalio/workflow";
+import type { ChildWorkflowHandle } from "@temporalio/workflow";
+import {
+  proxyActivities,
+  startChild,
+  WorkflowExecutionAlreadyStartedError,
+  workflowInfo,
+} from "@temporalio/workflow";
 
-import type { runModelActivity } from "@app/temporal/agent_loop/activities/run_model";
-import type { runToolActivity } from "@app/temporal/agent_loop/activities/run_tool";
+import type { AuthenticatorType } from "@app/lib/auth";
+import type * as ensureTitleActivities from "@app/temporal/agent_loop/activities/ensure_conversation_title";
+import type * as runModelActivities from "@app/temporal/agent_loop/activities/run_model";
+import type * as runToolActivities from "@app/temporal/agent_loop/activities/run_tool";
+import type { AgentLoopActivities } from "@app/temporal/agent_loop/lib/activity_interface";
+import { executeAgentLoop } from "@app/temporal/agent_loop/lib/agent_loop_executor";
+import { makeAgentLoopConversationTitleWorkflowId } from "@app/temporal/agent_loop/lib/workflow_ids";
+import type {
+  RunAgentArgs,
+  RunAgentAsynchronousArgs,
+} from "@app/types/assistant/agent_run";
 
-const activities = proxyActivities<{
-  runModelActivity: typeof runModelActivity;
-  runToolActivity: typeof runToolActivity;
-}>({
-  startToCloseTimeout: "5 minute",
+const activities: AgentLoopActivities = {
+  runModelActivity: proxyActivities<typeof runModelActivities>({
+    startToCloseTimeout: "10 minutes",
+  }).runModelActivity,
+  runToolActivity: proxyActivities<typeof runToolActivities>({
+    startToCloseTimeout: "10 minutes",
+  }).runToolActivity,
+};
+
+const { ensureConversationTitleActivity } = proxyActivities<
+  typeof ensureTitleActivities
+>({
+  startToCloseTimeout: "5 minutes",
 });
+
+export async function agentLoopConversationTitleWorkflow({
+  authType,
+  runAsynchronousAgentArgs,
+}: {
+  authType: AuthenticatorType;
+  runAsynchronousAgentArgs: RunAgentAsynchronousArgs;
+}) {
+  const runAgentArgs: RunAgentArgs = {
+    sync: false,
+    idArgs: runAsynchronousAgentArgs,
+  };
+
+  await ensureConversationTitleActivity(authType, runAgentArgs);
+}
 
 export async function agentLoopWorkflow({
   authType,
-  runAgentArgs,
+  runAsynchronousAgentArgs,
 }: {
-  authType: any; // Will be fixed when we have proper types
-  runAgentArgs: any; // Will be fixed when we have proper types
+  authType: AuthenticatorType;
+  runAsynchronousAgentArgs: RunAgentAsynchronousArgs;
 }) {
-  // This workflow is a placeholder that will be filled in when we migrate
-  // the agent loop to temporal workflows
-  throw new Error("Not implemented yet");
+  const { searchAttributes: parentSearchAttributes, memo } = workflowInfo();
+
+  const runAgentArgs: RunAgentArgs = {
+    sync: false,
+    idArgs: runAsynchronousAgentArgs,
+  };
+
+  // Start a child workflow to compute the conversation title. Do not await it.
+  // Swallow the error if one is already running.
+  let childWorkflowHandle: ChildWorkflowHandle<
+    typeof agentLoopConversationTitleWorkflow
+  >;
+  try {
+    childWorkflowHandle = await startChild(agentLoopConversationTitleWorkflow, {
+      workflowId: makeAgentLoopConversationTitleWorkflowId(
+        authType,
+        runAsynchronousAgentArgs
+      ),
+      searchAttributes: parentSearchAttributes,
+      args: [{ authType, runAsynchronousAgentArgs }],
+      memo,
+    });
+  } catch (err) {
+    if (err instanceof WorkflowExecutionAlreadyStartedError) {
+      return;
+    }
+    throw err;
+  }
+
+  await executeAgentLoop(authType, runAgentArgs, activities);
+
+  await childWorkflowHandle.result();
 }

--- a/front/temporal/agent_loop/workflows.ts
+++ b/front/temporal/agent_loop/workflows.ts
@@ -62,8 +62,9 @@ export async function agentLoopWorkflow({
     idArgs: runAsynchronousAgentArgs,
   };
 
-  // Start a child workflow to compute the conversation title. Do not await it.
-  // Swallow the error if one is already running.
+  // Launch a child workflow to generate the conversation title in the background.
+  // If a workflow with the same ID is already running, ignore the error and continue.
+  // Do not wait for the child workflow to complete at this point.
   let childWorkflowHandle: ChildWorkflowHandle<
     typeof agentLoopConversationTitleWorkflow
   >;

--- a/front/temporal/labs/transcripts/activities.ts
+++ b/front/temporal/labs/transcripts/activities.ts
@@ -5,10 +5,10 @@ import { UniqueConstraintError } from "sequelize";
 import { getAgentConfiguration } from "@app/lib/api/assistant/configuration";
 import {
   createConversation,
-  getConversation,
   postNewContentFragment,
 } from "@app/lib/api/assistant/conversation";
 import { toFileContentFragment } from "@app/lib/api/assistant/conversation/content_fragment";
+import { getConversation } from "@app/lib/api/assistant/conversation/fetch";
 import { postUserMessageAndWaitForCompletion } from "@app/lib/api/assistant/streaming/blocking";
 import config from "@app/lib/api/config";
 import { sendEmailWithTemplate } from "@app/lib/api/email";

--- a/front/types/assistant/agent.ts
+++ b/front/types/assistant/agent.ts
@@ -191,6 +191,7 @@ export function isTemplateAgentConfiguration(
 
 export const DEFAULT_MAX_STEPS_USE_PER_RUN = 8;
 export const MAX_STEPS_USE_PER_RUN_LIMIT = 128;
+export const MAX_ACTIONS_PER_STEP = 16;
 
 /**
  * Agent events
@@ -325,38 +326,3 @@ export type AgentStepContentEvent = {
   index: number;
   content: TextContentType | FunctionCallContentType | ReasoningContentType;
 };
-
-/**
- * Run agent arguments
- */
-
-export type RunAgentIdArgs = {
-  agentMessageId: string;
-  conversationId: string;
-  userMessageId: string;
-};
-
-export type RunAgentFullArgs = {
-  agentMessage: AgentMessageType;
-  agentMessageRow: AgentMessage;
-  conversation: ConversationType;
-  userMessage: UserMessageType;
-  agentConfiguration: AgentConfigurationType;
-};
-
-export type RunAgentArgs =
-  | {
-      sync: true;
-      inMemoryData: RunAgentFullArgs;
-    }
-  | {
-      sync: false;
-      idArgs: RunAgentIdArgs;
-    };
-
-export function getRunAgentData(runAgentArgs: RunAgentArgs): RunAgentFullArgs {
-  if (runAgentArgs.sync) {
-    return runAgentArgs.inMemoryData;
-  }
-  throw new Error("Not implemented");
-}

--- a/front/types/assistant/agent_run.ts
+++ b/front/types/assistant/agent_run.ts
@@ -102,9 +102,6 @@ export async function getRunAgentData(
   // We assume that the message group is ordered by version ASC. Message version starts from 0.
   const userMessage = userMessageGroup?.[userMessageVersion];
 
-  console.log("agentMessageGroup", agentMessageGroup);
-  console.log("userMessageGroup", userMessageGroup);
-
   if (
     !userMessage ||
     !isUserMessageType(userMessage) ||

--- a/front/types/assistant/agent_run.ts
+++ b/front/types/assistant/agent_run.ts
@@ -83,7 +83,7 @@ export async function getRunAgentData(
     return new Err(new Error("Agent message not found"));
   }
 
-  // Get the AgentMessage database row by querying through Message model
+  // Get the AgentMessage database row by querying through Message model.
   const agentMessageRow = await Message.findOne({
     where: {
       sId: agentMessageId,

--- a/front/types/assistant/agent_run.ts
+++ b/front/types/assistant/agent_run.ts
@@ -1,0 +1,121 @@
+/**
+ * Run agent arguments
+ */
+
+import type { Result } from "@dust-tt/client";
+import { Err, Ok } from "@dust-tt/client";
+
+import { getAgentConfiguration } from "@app/lib/api/assistant/configuration";
+import { getConversation } from "@app/lib/api/assistant/conversation/fetch";
+import type { AuthenticatorType } from "@app/lib/auth";
+import { Authenticator } from "@app/lib/auth";
+import { AgentMessage, Message } from "@app/lib/models/assistant/conversation";
+import type { AgentConfigurationType } from "@app/types/assistant/agent";
+import type {
+  AgentMessageType,
+  ConversationType,
+  UserMessageType,
+} from "@app/types/assistant/conversation";
+import {
+  isAgentMessageType,
+  isUserMessageType,
+} from "@app/types/assistant/conversation";
+
+export type RunAgentAsynchronousArgs = {
+  agentMessageId: string;
+  conversationId: string;
+  userMessageId: string;
+};
+
+export type RunAgentSynchronousArgs = {
+  agentConfiguration: AgentConfigurationType;
+  agentMessage: AgentMessageType;
+  agentMessageRow: AgentMessage;
+  conversation: ConversationType;
+  userMessage: UserMessageType;
+};
+
+export type RunAgentArgs =
+  | {
+      sync: true;
+      inMemoryData: RunAgentSynchronousArgs;
+    }
+  | {
+      sync: false;
+      idArgs: RunAgentAsynchronousArgs;
+    };
+
+export async function getRunAgentData(
+  authType: AuthenticatorType,
+  runAgentArgs: RunAgentArgs
+): Promise<Result<RunAgentSynchronousArgs, Error>> {
+  if (runAgentArgs.sync) {
+    return new Ok(runAgentArgs.inMemoryData);
+  }
+
+  const auth = await Authenticator.fromJSON(authType);
+
+  const { agentMessageId, conversationId, userMessageId } = runAgentArgs.idArgs;
+  const conversationRes = await getConversation(auth, conversationId);
+  if (conversationRes.isErr()) {
+    return new Err(
+      new Error(`Conversation not found: ${conversationRes.error.message}`)
+    );
+  }
+
+  const conversation = conversationRes.value;
+
+  // Here, we assume that both the user message and agent message have been added to the
+  // conversation.content array. Flatten all message arrays to find individual messages.
+  const allMessages = conversation.content.flat();
+
+  const userMessage = allMessages.find(
+    (m) => m.sId === userMessageId && isUserMessageType(m)
+  );
+  if (!userMessage || !isUserMessageType(userMessage)) {
+    return new Err(new Error("User message not found"));
+  }
+
+  const agentMessage = allMessages.find(
+    (m) => m.sId === agentMessageId && isAgentMessageType(m)
+  );
+  if (!agentMessage || !isAgentMessageType(agentMessage)) {
+    return new Err(new Error("Agent message not found"));
+  }
+
+  // Get the AgentMessage database row by querying through Message model
+  const agentMessageRow = await Message.findOne({
+    where: {
+      sId: agentMessageId,
+      workspaceId: auth.getNonNullableWorkspace().id,
+    },
+    include: [
+      {
+        model: AgentMessage,
+        as: "agentMessage",
+        required: true,
+      },
+    ],
+  });
+
+  if (!agentMessageRow?.agentMessage) {
+    return new Err(new Error("Agent message database row not found"));
+  }
+
+  const agentConfiguration = await getAgentConfiguration(
+    auth,
+    agentMessage.configuration.sId,
+    "full"
+  );
+  if (!agentConfiguration) {
+    return new Err(new Error("Agent configuration not found"));
+  }
+
+  return new Ok({
+    agentMessage,
+    agentMessageRow: agentMessageRow.agentMessage,
+    conversation,
+    userMessage,
+    agentConfiguration,
+  });
+}


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
This PR adds the asynchronous version of the agent loop. This agent loop runs in a dedicated Temporal workflow. This workflow is not yet running but will be deployed on it's own deployment in our k8s cluster (infra PR is here: https://github.com/dust-tt/dust-infra/pull/403).

As we aim to preserve the two loops (asynchronous and synchronous), I had to move a bunch of files around to avoid circular dependencies and keep some common code so we don't end up with duplicated code. There are a few explanations regarding where the code lives today:
- We want to avoid pulling Temporal dependencies everywhere in the app
- We want to keep the code close to Temporal as changing it could actually break Temporal determinism

There are two duplicated parts:
- Title generation:
  - In the asynchronous approach we start a child workflow
  - In the synchronous approach we initialize the promise but don't await it
- Usage workflow:
  - We can't start it from anywhere

The single entry point function becomes `runAgentWithStreaming` which will automatically route to the right loop. It can be override by adding an `async=true` parameter un the conversation URL to test until we have proper logic to route you there. It exclusively applies to creating a conversation and posting new messages.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
