### PR TITLE
[front] Create new versions of `AgentStepContent` instead of setting versions manually

### DIFF
--- a/front/lib/resources/agent_step_content_resource.ts
+++ b/front/lib/resources/agent_step_content_resource.ts
@@ -94,7 +94,7 @@ export class AgentStepContentResource extends BaseResource<AgentStepContentModel
     }
   }
 
-  static async makeNew(
+  private static async makeNew(
     blob: CreationAttributes<AgentStepContentModel>,
     transaction?: Transaction
   ): Promise<AgentStepContentResource> {

--- a/front/lib/resources/agent_step_content_resource.ts
+++ b/front/lib/resources/agent_step_content_resource.ts
@@ -420,14 +420,10 @@ export class AgentStepContentResource extends BaseResource<AgentStepContentModel
     index,
     type,
     value,
-  }: {
-    agentMessageId: ModelId;
-    workspaceId: ModelId;
-    step: number;
-    index: number;
-    type: "text_content" | "reasoning" | "function_call";
-    value: AgentContentItemType;
-  }): Promise<AgentStepContentResource> {
+  }: Omit<
+    CreationAttributes<AgentStepContentModel>,
+    "version"
+  >): Promise<AgentStepContentResource> {
     return frontSequelize.transaction(async (transaction: Transaction) => {
       const existingContent = await this.model.findAll({
         where: {

--- a/front/lib/resources/agent_step_content_resource.ts
+++ b/front/lib/resources/agent_step_content_resource.ts
@@ -27,10 +27,7 @@ import logger from "@app/logger/logger";
 import type { ModelId, Result } from "@app/types";
 import { removeNulls } from "@app/types";
 import { Err, Ok } from "@app/types";
-import type {
-  AgentContentItemType,
-  AgentStepContentType,
-} from "@app/types/assistant/agent_message_content";
+import type { AgentStepContentType } from "@app/types/assistant/agent_message_content";
 
 // Attributes are marked as read-only to reflect the stateless nature of our Resource.
 // eslint-disable-next-line @typescript-eslint/no-empty-interface, @typescript-eslint/no-unsafe-declaration-merging

--- a/front/temporal/agent_loop/activities/common.ts
+++ b/front/temporal/agent_loop/activities/common.ts
@@ -22,7 +22,7 @@ async function processEventForDatabase(
       });
 
       if (event.type === "agent_error") {
-        await AgentStepContentResource.makeNew({
+        await AgentStepContentResource.createNewVersion({
           workspaceId: agentMessageRow.workspaceId,
           agentMessageId: agentMessageRow.id,
           step,
@@ -39,7 +39,6 @@ async function processEventForDatabase(
               },
             },
           },
-          version: 0,
         });
       }
       break;

--- a/front/temporal/agent_loop/activities/run_model.ts
+++ b/front/temporal/agent_loop/activities/run_model.ts
@@ -651,12 +651,11 @@ export async function runModelActivity({
   // Create AgentStepContent for each content item (reasoning, text, function calls)
   // This replaces the original agent_step_content event emission
   for (const [index, content] of output.contents.entries()) {
-    const stepContent = await AgentStepContentResource.makeNew({
+    const stepContent = await AgentStepContentResource.createNewVersion({
       workspaceId: conversation.owner.id,
       agentMessageId: agentMessage.agentMessageId,
       step,
       index,
-      version: autoRetryCount,
       type: content.type,
       value: content,
     });


### PR DESCRIPTION
## Description

- This PR follows up on https://github.com/dust-tt/dust/pull/14298.
- Part of https://github.com/dust-tt/tasks/issues/3415.
- This PR uses `createNewVersion` to create new versions instead of creating entries with a set version using `makeNew`, which is then made private.

## Tests

- Tested locally.
- Tested on front-edge.

## Risk

- Quite a critical code path.
- Impact on latency should be very slow but needs monitoring (in particular the query plan).

## Deploy Plan

- Deploy front.
