### PR TITLE
[Auth] Fix group deserialization permissions issue

### DIFF
--- a/front/lib/auth.ts
+++ b/front/lib/auth.ts
@@ -934,11 +934,16 @@ export class Authenticator {
 
     let groups: GroupResource[] = [];
     if (authType.groupIds.length > 0 && workspace) {
-      // Create a temporary authenticator for fetching groups
+      // Temporary authenticator used solely to fetch the group resources. We
+      // grant it the `admin` role so that it can read any group in the
+      // workspace, irrespective of membership. The returned authenticator
+      // (see below) will still use the original `authType.role`, so this
+      // escalation is confined to the internal bootstrap step and does not
+      // leak outside of this scope.
       const tempAuth = new Authenticator({
         workspace,
         user,
-        role: authType.role,
+        role: "admin",
         groups: [],
         subscription,
         key: authType.key,


### PR DESCRIPTION
## Description
Fix an issue where groups could not be properly loaded during authenticator deserialization when the user had limited permissions. The temporary authenticator used for group fetching now uses admin role exclusively for this bootstrap step, without affecting the returned authenticator's permissions.

Context: https://dust4ai.slack.com/archives/C050SM8NSPK/p1753197089039389?thread_ts=1753112945.691019&cid=C050SM8NSPK

## Risks
Blast radius: Authenticator deserialization logic
Risk: permissioning; ccing @spolu as permissioning owner to double check the validity

## Deploy Plan
- Deploy front