### PR TITLE
slack: remove all retries

### DIFF
--- a/connectors/src/connectors/slack/lib/slack_client.ts
+++ b/connectors/src/connectors/slack/lib/slack_client.ts
@@ -117,10 +117,11 @@ export async function getSlackClient(
   }
   const slackClient = new WebClient(slackAccessToken, {
     timeout: SLACK_NETWORK_TIMEOUT_MS,
-    retryConfig: {
-      retries: 1,
-      factor: 1,
-    },
+    rejectRateLimitedCalls: true,
+    // retryConfig: {
+    //   retries: 1,
+    //   factor: 1,
+    // },
   });
 
   return slackClient;


### PR DESCRIPTION
## Description

Remove retries from slack WebClient to test hypothesis that the worker crash are coming from there.

## Tests

N/A

## Risk

Low, potential small impact on bot but I don't believe the bot does a lot of retries today

## Deploy Plan

- deploy `connectors`