### PR TITLE
[front] Lower log level on actions shadow-read logs

### DIFF
--- a/front/lib/api/assistant/messages.ts
+++ b/front/lib/api/assistant/messages.ts
@@ -247,12 +247,18 @@ async function batchRenderAgentMessages<V extends RenderMessageVariant>(
     ]);
 
   if (newAgentMCPActions.length !== agentMCPActions.length) {
+    const correctIds = new Set(agentMCPActions.map((a) => a.id));
+    const newIds = new Set(newAgentMCPActions.map((a) => a.id));
     logger.warn(
       {
         workspaceId: auth.getNonNullableWorkspace().sId,
         agentMessageIds,
-        newAgentMCPActions: newAgentMCPActions.map((a) => a.id),
-        agentMCPActions: agentMCPActions.map((a) => a.id),
+        missingActions: agentMCPActions
+          .map((a) => a.id)
+          .filter((id) => !newIds.has(id)),
+        extraActions: newAgentMCPActions
+          .map((a) => a.id)
+          .filter((id) => !correctIds.has(id)),
       },
       "[Shadow read] Agent MCP actions mismatch"
     );

--- a/front/lib/api/assistant/messages.ts
+++ b/front/lib/api/assistant/messages.ts
@@ -247,7 +247,7 @@ async function batchRenderAgentMessages<V extends RenderMessageVariant>(
     ]);
 
   if (newAgentMCPActions.length !== agentMCPActions.length) {
-    logger.error(
+    logger.warn(
       {
         workspaceId: auth.getNonNullableWorkspace().sId,
         agentMessageIds,


### PR DESCRIPTION
## Description

- We currently have a shadow read on `AgentMCPActions`, introduced in https://github.com/dust-tt/dust/pull/14458.
- I ended up not finding the root cause today. In the meantime this PR replaces the error logs with warns.

## Tests

## Risk

- None.

## Deploy Plan

- Deploy front.
