### PR TITLE
Don't mutate agentMessage in runModelActivity

### DIFF
--- a/front/temporal/agent_loop/activities/run_model.ts
+++ b/front/temporal/agent_loop/activities/run_model.ts
@@ -75,11 +75,9 @@ export async function runModelActivity({
     agentConfiguration,
     conversation,
     userMessage,
-    agentMessage: agentMessageMutable,
+    agentMessage,
     agentMessageRow,
   } = getRunAgentData(runAgentArgs);
-
-  const agentMessage = Object.freeze(agentMessageMutable);
 
   const now = Date.now();
 


### PR DESCRIPTION
## Description

This PR is better read commit by commit.

Refactors the `runModelActivity` to avoid mutating the `agentMessage` object directly. Instead of mutating properties like `chainOfThought`, `content`, and `status` on the original object, the code now creates a new object using spread operator and passes it to `updateResourceAndPublishEvent`. 

Also removes related TODO comments that were tracking this technical debt.

## Tests

Manually tested the agent loop functionality to ensure message handling continues to work correctly after removing the direct mutations.

## Risk

Low risk refactoring that improves code quality by avoiding object mutations. The change is localized to the `runModelActivity` function and maintains the same external behavior.

## Deploy Plan

Standard deployment - no special considerations needed as this is a code quality improvement without functional changes.