### PR TITLE
Fix support for new tool_error in agentMessage reducer

### DIFF
--- a/front/lib/assistant/state/messageReducer.ts
+++ b/front/lib/assistant/state/messageReducer.ts
@@ -10,6 +10,7 @@ import type {
   AgentGenerationCancelledEvent,
   AgentMessageSuccessEvent,
   GenerationTokensEvent,
+  ToolErrorEvent,
 } from "@app/types";
 import { assertNever } from "@app/types";
 import type { LightAgentMessageType } from "@app/types/assistant/conversation";
@@ -36,6 +37,7 @@ export type AgentMessageStateEvent =
   | AgentActionSpecificEvent
   | AgentActionSuccessEvent
   | AgentErrorEvent
+  | ToolErrorEvent
   | AgentGenerationCancelledEvent
   | AgentMessageSuccessEvent
   | GenerationTokensEvent
@@ -110,6 +112,17 @@ export function messageReducer(
     }
 
     case "agent_error":
+      return {
+        ...state,
+        message: {
+          ...state.message,
+          status: "failed",
+          error: event.error,
+        },
+        agentState: "done",
+      };
+
+    case "tool_error":
       return {
         ...state,
         message: {

--- a/front/lib/assistant/state/messageReducer.ts
+++ b/front/lib/assistant/state/messageReducer.ts
@@ -111,18 +111,8 @@ export function messageReducer(
       return updateProgress(state, event);
     }
 
-    case "agent_error":
-      return {
-        ...state,
-        message: {
-          ...state.message,
-          status: "failed",
-          error: event.error,
-        },
-        agentState: "done",
-      };
-
     case "tool_error":
+    case "agent_error":
       return {
         ...state,
         message: {


### PR DESCRIPTION
## Description

New ToolErrorEvent was introduced in a previous PR which was not ported to the agentMessage reducer (reason why the type system accepted has yet to be investigated)

This adds ToolErrorEvent and process it accordingly

Context (incident): https://dust4ai.slack.com/archives/C05B529FHV1/p1753203188554189

cc @fontanierh @philipperolet the `tool_error` type I think is a bit overloaded now. Maybe we should rename it `agent_tool_error` to distinguish from `tool_error` that pre-exists right?

## Tests

Tested locally

## Risk

Low (fixes an assert never)

## Deploy Plan

- deploy `front`