### PR TITLE
[front] Dry types between backend and frontend message events

### DIFF
--- a/front/lib/assistant/state/messageReducer.ts
+++ b/front/lib/assistant/state/messageReducer.ts
@@ -1,17 +1,9 @@
 import type { ToolNotificationEvent } from "@app/lib/actions/mcp";
 import type { ProgressNotificationContentType } from "@app/lib/actions/mcp_internal_actions/output_schemas";
 import type { BaseAction } from "@app/lib/actions/types";
-import type { AgentActionSpecificEvent } from "@app/lib/actions/types/agent";
 import { getLightAgentMessageFromAgentMessage } from "@app/lib/api/assistant/citations";
-import type {
-  AgentActionSuccessEvent,
-  AgentActionType,
-  AgentErrorEvent,
-  AgentGenerationCancelledEvent,
-  AgentMessageSuccessEvent,
-  GenerationTokensEvent,
-  ToolErrorEvent,
-} from "@app/types";
+import type { AgentMessageEvents } from "@app/lib/api/assistant/streaming/types";
+import type { AgentActionType } from "@app/types";
 import { assertNever } from "@app/types";
 import type { LightAgentMessageType } from "@app/types/assistant/conversation";
 
@@ -33,15 +25,7 @@ export interface MessageTemporaryState {
   actionProgress: ActionProgressState;
 }
 
-export type AgentMessageStateEvent =
-  | AgentActionSpecificEvent
-  | AgentActionSuccessEvent
-  | AgentErrorEvent
-  | ToolErrorEvent
-  | AgentGenerationCancelledEvent
-  | AgentMessageSuccessEvent
-  | GenerationTokensEvent
-  | ToolNotificationEvent;
+export type AgentMessageStateEvent = AgentMessageEvents | ToolNotificationEvent;
 
 type AgentMessageStateEventWithoutToolApproveExecution = Exclude<
   AgentMessageStateEvent,


### PR DESCRIPTION
## Description

- Follow up on https://dust4ai.slack.com/archives/C05B529FHV1/p1753203188554189.
- This PR aims at sharing a bit more typing between `AgentMessageStateEvent` (use by the message reducer in the frontend) and `AgentMessageEvents` (used in the event emitter).
- Currently the list is duplicated, which may prevent catching errors due to having added a type of events at one place but not another.

## Tests

- `tsc`

## Risk

- Very low, only type changes.

## Deploy Plan

- Deploy front.
