### PR TITLE
[front] Fix latest version filtering on `AgentStepContentResource.fetchByAgentMessages`

### DIFF
--- a/front/lib/resources/agent_step_content_resource.ts
+++ b/front/lib/resources/agent_step_content_resource.ts
@@ -232,7 +232,11 @@ export class AgentStepContentResource extends BaseResource<AgentStepContentModel
     });
 
     if (latestVersionsOnly) {
-      contents = this.filterLatestVersions(contents, ["step", "index"]);
+      contents = this.filterLatestVersions(contents, [
+        "agentMessageId",
+        "step",
+        "index",
+      ]);
 
       // Also filter MCP actions to latest versions
       if (includeMCPActions) {


### PR DESCRIPTION
## Description

- This PR fixes the filtering that we do when fetching agent step content by `agentMessageIds`.
- The filtering clause was missing the `agentMessageId`, even though we may batch fetch across multiple agent messages.
- Part of https://github.com/dust-tt/tasks/issues/3415 in a way.

```sql
SELECT st.* FROM agent_step_contents st
JOIN agent_mcp_actions mcp
ON mcp."stepContentId" = st.id
LEFT JOIN agent_mcp_action_output_items o
ON o."agentMCPActionId" = mcp.id
LEFT JOIN files f
ON f.id = o."fileId"
WHERE st."agentMessageId" in (14324856, 14320740, 14320011, 13959577);

SELECT mcp.* FROM agent_mcp_actions mcp
LEFT JOIN agent_mcp_action_output_items o
ON o."agentMCPActionId" = mcp.id
LEFT JOIN files f
ON f.id = o."fileId"
WHERE mcp."agentMessageId" in (14324856, 14320740, 14320011, 13959577);
```

## Tests

- Tested locally.

## Risk

- Low, behind a shadow read.

## Deploy Plan

- Deploy front.
