### PR TITLE
[front] -  fix(AB v2): tweak inputs

### DIFF
--- a/front/components/agent_builder/instructions/AgentBuilderInstructionsEditor.tsx
+++ b/front/components/agent_builder/instructions/AgentBuilderInstructionsEditor.tsx
@@ -141,7 +141,7 @@ export function AgentBuilderInstructionsEditor({
 
   return (
     <div className="flex h-full flex-col gap-1">
-      <div className="relative h-full min-h-60 grow p-px">
+      <div className="relative h-full min-h-100 grow p-px">
         <EditorContent editor={editor} className="absolute inset-0" />
         <div className="absolute bottom-2 right-2">
           <InstructionTipsPopover owner={owner} />

--- a/front/components/agent_builder/settings/AgentBuilderSettingsBlock.tsx
+++ b/front/components/agent_builder/settings/AgentBuilderSettingsBlock.tsx
@@ -46,7 +46,7 @@ import type {
   WorkspaceType,
 } from "@app/types";
 
-const MIN_INSTRUCTIONS_LENGTH_FOR_SUGGESTION = 30;
+const MIN_INSTRUCTIONS_LENGTH = 20;
 
 async function getEmojiSuggestions({
   owner,
@@ -91,7 +91,11 @@ function AgentNameInput() {
   });
 
   const handleGenerateNameSuggestions = async () => {
-    if (isGenerating) {
+    if (
+      isGenerating ||
+      !instructions ||
+      instructions.length < MIN_INSTRUCTIONS_LENGTH
+    ) {
       return;
     }
 
@@ -151,6 +155,14 @@ function AgentNameInput() {
               icon={SparklesIcon}
               variant="outline"
               isSelect
+              disabled={
+                !instructions || instructions.length < MIN_INSTRUCTIONS_LENGTH
+              }
+              tooltip={
+                !instructions || instructions.length < MIN_INSTRUCTIONS_LENGTH
+                  ? `Add at least ${MIN_INSTRUCTIONS_LENGTH} characters to instructions to get suggestions`
+                  : undefined
+              }
             />
           </DropdownMenuTrigger>
           <DropdownMenuContent className="w-64">
@@ -206,7 +218,11 @@ function AgentDescriptionInput() {
   };
 
   const handleGenerateDescription = async () => {
-    if (isGenerating) {
+    if (
+      isGenerating ||
+      !instructions ||
+      instructions.length < MIN_INSTRUCTIONS_LENGTH
+    ) {
       return;
     }
 
@@ -265,6 +281,14 @@ function AgentDescriptionInput() {
               icon={SparklesIcon}
               variant="outline"
               isSelect
+              disabled={
+                !instructions || instructions.length < MIN_INSTRUCTIONS_LENGTH
+              }
+              tooltip={
+                !instructions || instructions.length < MIN_INSTRUCTIONS_LENGTH
+                  ? `Add at least 20 ${MIN_INSTRUCTIONS_LENGTH} to instructions to get suggestions`
+                  : undefined
+              }
             />
           </DropdownMenuTrigger>
           <DropdownMenuContent className="w-80">
@@ -344,7 +368,7 @@ function AgentPictureInput() {
     if (
       !field.value &&
       instructions &&
-      instructions.length >= MIN_INSTRUCTIONS_LENGTH_FOR_SUGGESTION
+      instructions.length >= MIN_INSTRUCTIONS_LENGTH
     ) {
       void updateEmojiFromSuggestions();
     }

--- a/front/components/agent_builder/settings/AgentBuilderSettingsBlock.tsx
+++ b/front/components/agent_builder/settings/AgentBuilderSettingsBlock.tsx
@@ -289,7 +289,7 @@ function AgentDescriptionInput() {
               tooltip={
                 !instructions ||
                 instructions.length < MIN_INSTRUCTIONS_LENGTH_SUGGESTIONS
-                  ? `Add at least 20 ${MIN_INSTRUCTIONS_LENGTH_SUGGESTIONS} to instructions to get suggestions`
+                  ? `Add at least ${MIN_INSTRUCTIONS_LENGTH_SUGGESTIONS} to the instructions to get suggestions`
                   : undefined
               }
             />

--- a/front/components/agent_builder/settings/AgentBuilderSettingsBlock.tsx
+++ b/front/components/agent_builder/settings/AgentBuilderSettingsBlock.tsx
@@ -13,7 +13,6 @@ import {
   PencilSquareIcon,
   SparklesIcon,
   Spinner,
-  TextArea,
 } from "@dust-tt/sparkle";
 import { useCallback, useEffect, useState } from "react";
 import { useController, useWatch } from "react-hook-form";
@@ -270,7 +269,7 @@ function AgentDescriptionInput() {
       </label>
       <div className="flex items-center gap-2">
         <div className="flex-grow">
-          <TextArea placeholder="Enter agent description" rows={3} {...field} />
+          <Input placeholder="Enter agent description" {...field} />
         </div>
         <DropdownMenu
           onOpenChange={(open) => open && handleGenerateDescription()}

--- a/front/components/agent_builder/settings/AgentBuilderSettingsBlock.tsx
+++ b/front/components/agent_builder/settings/AgentBuilderSettingsBlock.tsx
@@ -45,7 +45,7 @@ import type {
   WorkspaceType,
 } from "@app/types";
 
-const MIN_INSTRUCTIONS_LENGTH = 20;
+const MIN_INSTRUCTIONS_LENGTH_SUGGESTIONS = 20;
 
 async function getEmojiSuggestions({
   owner,
@@ -93,7 +93,7 @@ function AgentNameInput() {
     if (
       isGenerating ||
       !instructions ||
-      instructions.length < MIN_INSTRUCTIONS_LENGTH
+      instructions.length < MIN_INSTRUCTIONS_LENGTH_SUGGESTIONS
     ) {
       return;
     }
@@ -155,11 +155,13 @@ function AgentNameInput() {
               variant="outline"
               isSelect
               disabled={
-                !instructions || instructions.length < MIN_INSTRUCTIONS_LENGTH
+                !instructions ||
+                instructions.length < MIN_INSTRUCTIONS_LENGTH_SUGGESTIONS
               }
               tooltip={
-                !instructions || instructions.length < MIN_INSTRUCTIONS_LENGTH
-                  ? `Add at least ${MIN_INSTRUCTIONS_LENGTH} characters to instructions to get suggestions`
+                !instructions ||
+                instructions.length < MIN_INSTRUCTIONS_LENGTH_SUGGESTIONS
+                  ? `Add at least ${MIN_INSTRUCTIONS_LENGTH_SUGGESTIONS} characters to instructions to get suggestions`
                   : undefined
               }
             />
@@ -220,7 +222,7 @@ function AgentDescriptionInput() {
     if (
       isGenerating ||
       !instructions ||
-      instructions.length < MIN_INSTRUCTIONS_LENGTH
+      instructions.length < MIN_INSTRUCTIONS_LENGTH_SUGGESTIONS
     ) {
       return;
     }
@@ -281,11 +283,13 @@ function AgentDescriptionInput() {
               variant="outline"
               isSelect
               disabled={
-                !instructions || instructions.length < MIN_INSTRUCTIONS_LENGTH
+                !instructions ||
+                instructions.length < MIN_INSTRUCTIONS_LENGTH_SUGGESTIONS
               }
               tooltip={
-                !instructions || instructions.length < MIN_INSTRUCTIONS_LENGTH
-                  ? `Add at least 20 ${MIN_INSTRUCTIONS_LENGTH} to instructions to get suggestions`
+                !instructions ||
+                instructions.length < MIN_INSTRUCTIONS_LENGTH_SUGGESTIONS
+                  ? `Add at least 20 ${MIN_INSTRUCTIONS_LENGTH_SUGGESTIONS} to instructions to get suggestions`
                   : undefined
               }
             />
@@ -367,7 +371,7 @@ function AgentPictureInput() {
     if (
       !field.value &&
       instructions &&
-      instructions.length >= MIN_INSTRUCTIONS_LENGTH
+      instructions.length >= MIN_INSTRUCTIONS_LENGTH_SUGGESTIONS
     ) {
       void updateEmojiFromSuggestions();
     }

--- a/front/components/agent_builder/settings/TagsSection.tsx
+++ b/front/components/agent_builder/settings/TagsSection.tsx
@@ -25,6 +25,8 @@ import type {
 import { isBuilder } from "@app/types";
 import type { TagType } from "@app/types/tag";
 
+const MIN_INSTRUCTIONS_LENGTH_FOR_DROPDOWN_SUGGESTIONS = 20;
+
 async function getTagsSuggestions({
   owner,
   instructions,
@@ -74,11 +76,18 @@ export function TagsSection() {
       return;
     }
 
+    const instructions = getValues("instructions");
+    if (
+      !instructions ||
+      instructions.length < MIN_INSTRUCTIONS_LENGTH_FOR_DROPDOWN_SUGGESTIONS
+    ) {
+      return;
+    }
+
     setTagsSuggestionsLoading(true);
     setFilteredTagsSuggestions([]);
 
     try {
-      const instructions = getValues("instructions");
       const description = getValues("agentSettings.description");
 
       const tagsSuggestionsResult = await getTagsSuggestions({
@@ -146,6 +155,22 @@ export function TagsSection() {
                 icon={SparklesIcon}
                 variant="outline"
                 isSelect
+                disabled={(() => {
+                  const instructions = getValues("instructions");
+                  return (
+                    !instructions ||
+                    instructions.length <
+                      MIN_INSTRUCTIONS_LENGTH_FOR_DROPDOWN_SUGGESTIONS
+                  );
+                })()}
+                tooltip={(() => {
+                  const instructions = getValues("instructions");
+                  return !instructions ||
+                    instructions.length <
+                      MIN_INSTRUCTIONS_LENGTH_FOR_DROPDOWN_SUGGESTIONS
+                    ? "Add at least 20 characters to instructions to get suggestions"
+                    : undefined;
+                })()}
               />
             </PopoverTrigger>
             <PopoverContent className="w-64 p-3">

--- a/front/components/agent_builder/settings/TagsSection.tsx
+++ b/front/components/agent_builder/settings/TagsSection.tsx
@@ -7,7 +7,7 @@ import {
   Spinner,
 } from "@dust-tt/sparkle";
 import { PopoverRoot } from "@dust-tt/sparkle";
-import { useState } from "react";
+import { useMemo, useState } from "react";
 import { useController, useFormContext } from "react-hook-form";
 
 import { useAgentBuilderContext } from "@app/components/agent_builder/AgentBuilderContext";
@@ -71,12 +71,34 @@ export function TagsSection() {
   >([]);
   const [isTagsSuggestionLoading, setTagsSuggestionsLoading] = useState(false);
 
+  const instructions = getValues("instructions");
+
+  const isButtonDisabled = useMemo(() => {
+    return (
+      !instructions ||
+      instructions.length < MIN_INSTRUCTIONS_LENGTH_FOR_DROPDOWN_SUGGESTIONS ||
+      allTags.length === 0
+    );
+  }, [instructions, allTags.length]);
+
+  const buttonTooltip = useMemo(() => {
+    if (
+      !instructions ||
+      instructions.length < MIN_INSTRUCTIONS_LENGTH_FOR_DROPDOWN_SUGGESTIONS
+    ) {
+      return `Add at least ${MIN_INSTRUCTIONS_LENGTH_FOR_DROPDOWN_SUGGESTIONS} characters to instructions to get suggestions`;
+    }
+    if (allTags.length === 0) {
+      return "Create tags to start using suggestions";
+    }
+    return undefined;
+  }, [instructions, allTags.length]);
+
   const updateTagsSuggestions = async () => {
     if (isTagsSuggestionLoading) {
       return;
     }
 
-    const instructions = getValues("instructions");
     if (
       !instructions ||
       instructions.length < MIN_INSTRUCTIONS_LENGTH_FOR_DROPDOWN_SUGGESTIONS
@@ -156,22 +178,8 @@ export function TagsSection() {
                 icon={SparklesIcon}
                 variant="outline"
                 isSelect
-                disabled={(() => {
-                  const instructions = getValues("instructions");
-                  return (
-                    !instructions ||
-                    instructions.length <
-                      MIN_INSTRUCTIONS_LENGTH_FOR_DROPDOWN_SUGGESTIONS
-                  );
-                })()}
-                tooltip={(() => {
-                  const instructions = getValues("instructions");
-                  return !instructions ||
-                    instructions.length <
-                      MIN_INSTRUCTIONS_LENGTH_FOR_DROPDOWN_SUGGESTIONS
-                    ? "Add at least 20 characters to instructions to get suggestions"
-                    : undefined;
-                })()}
+                disabled={isButtonDisabled}
+                tooltip={buttonTooltip}
               />
             </PopoverTrigger>
             <PopoverContent className="w-64 p-3">

--- a/front/components/agent_builder/settings/TagsSection.tsx
+++ b/front/components/agent_builder/settings/TagsSection.tsx
@@ -141,7 +141,9 @@ export function TagsSection() {
 
   return (
     <div className="flex h-full flex-col gap-4">
-      <h3>Tags</h3>
+      <label className="text-sm font-medium text-foreground dark:text-foreground-night">
+        Tags
+      </label>
       <TagsSelector
         owner={owner}
         tags={selectedTags}
@@ -151,7 +153,6 @@ export function TagsSection() {
             <PopoverTrigger asChild>
               <Button
                 label="Suggest"
-                size="xs"
                 icon={SparklesIcon}
                 variant="outline"
                 isSelect

--- a/front/components/agent_builder/settings/TagsSelector.tsx
+++ b/front/components/agent_builder/settings/TagsSelector.tsx
@@ -87,7 +87,6 @@ export const TagsSelector = ({
           >
             <DropdownMenuTrigger asChild>
               <Button
-                size="xs"
                 icon={PlusIcon}
                 variant="outline"
                 label="Add"


### PR DESCRIPTION
## Description

This PR aims at tweaking the inputs in the agent builder and make sure that the "suggest" dropdowns are disabled if the instructions length are too short.

**References:**
- https://github.com/dust-tt/tasks/issues/3572

## Tests

Local

## Risk

Low, behind FF


## Deploy Plan

Deploy front