### PR TITLE
feat: add headless auth

### DIFF
--- a/cli/README.md
+++ b/cli/README.md
@@ -85,7 +85,7 @@ dust [command] --wId <workspace-id> --api-key <your-api-key>
 - `DUST_API_KEY` (env) or `--api-key` (flag): Your API key for authentication
 - `DUST_WORKSPACE_ID` (env) or `--wId` (flag): Your workspace ID
 
-**Note:** Environment variables take precedence over command-line flags. If both are set, the environment variables will be used.
+**Note:** Command-line flags take precedence over environment variables. If both are set, the command line flags will be used.
 
 #### Examples
 
@@ -122,6 +122,7 @@ dust chat --sId 1234567890 --wId ws_abc123 --api-key sk_your_api_key_here
 #### When to Use Headless Auth
 
 Headless authentication is particularly useful for:
+
 - Automated scripts and workflows
 - CI/CD pipelines
 - Server environments without interactive terminals

--- a/cli/README.md
+++ b/cli/README.md
@@ -77,7 +77,7 @@ dust [command]
 Pass both required parameters with any command:
 
 ```bash
-dust [command] --wId <workspace-id> --api-key <your-api-key>
+dust [command] --workspaceId <workspace-id> --key <your-api-key>
 ```
 
 #### Parameters

--- a/cli/README.md
+++ b/cli/README.md
@@ -53,11 +53,28 @@ When no command is provided, the `chat` command will be used by default.
 
 ### Headless Authentication
 
-The Dust CLI supports headless authentication for automated workflows and CI/CD environments. This allows you to authenticate without interactive prompts by providing credentials directly via command-line arguments.
+The Dust CLI supports headless authentication for automated workflows and CI/CD environments. This allows you to authenticate without interactive prompts by providing credentials via environment variables or command-line arguments.
 
 #### Usage
 
-To use headless authentication, pass both required parameters with any command:
+**Method 1: Environment Variables (Recommended)**
+
+Set the following environment variables:
+
+```bash
+export DUST_API_KEY="sk_your_api_key_here"
+export DUST_WORKSPACE_ID="ws_abc123"
+```
+
+Then run any command normally:
+
+```bash
+dust [command]
+```
+
+**Method 2: Command-line Arguments**
+
+Pass both required parameters with any command:
 
 ```bash
 dust [command] --wId <workspace-id> --api-key <your-api-key>
@@ -65,10 +82,31 @@ dust [command] --wId <workspace-id> --api-key <your-api-key>
 
 #### Parameters
 
-- `--wId`: Your workspace ID
-- `--api-key`: Your API key for authentication
+- `DUST_API_KEY` (env) or `--api-key` (flag): Your API key for authentication
+- `DUST_WORKSPACE_ID` (env) or `--wId` (flag): Your workspace ID
+
+**Note:** Environment variables take precedence over command-line flags. If both are set, the environment variables will be used.
 
 #### Examples
+
+**Using Environment Variables:**
+
+```bash
+# Set environment variables once
+export DUST_API_KEY="sk_your_api_key_here"
+export DUST_WORKSPACE_ID="ws_abc123"
+
+# Chat with headless auth
+dust chat
+
+# Launch agents-mcp with headless auth
+dust agents-mcp --port 8080
+
+# Use with specific agent
+dust chat --sId 1234567890
+```
+
+**Using Command-line Arguments:**
 
 ```bash
 # Chat with headless auth
@@ -91,9 +129,10 @@ Headless authentication is particularly useful for:
 
 #### Security Considerations
 
-- Store API keys securely (use environment variables in production)
-- Avoid committing API keys to version control
+- **Use environment variables** instead of command-line flags when possible, as command-line arguments may be visible in process lists
+- Store API keys securely and avoid committing them to version control
 - Consider using secrets management tools for production deployments
+- Use `.env` files locally and proper secrets management in CI/CD environments
 
 ### Options
 

--- a/cli/README.md
+++ b/cli/README.md
@@ -51,6 +51,50 @@ When no command is provided, the `chat` command will be used by default.
 - **`help`**: Display help information.
   - `dust help`
 
+### Headless Authentication
+
+The Dust CLI supports headless authentication for automated workflows and CI/CD environments. This allows you to authenticate without interactive prompts by providing credentials directly via command-line arguments.
+
+#### Usage
+
+To use headless authentication, pass both required parameters with any command:
+
+```bash
+dust [command] --wId <workspace-id> --api-key <your-api-key>
+```
+
+#### Parameters
+
+- `--wId`: Your workspace ID
+- `--api-key`: Your API key for authentication
+
+#### Examples
+
+```bash
+# Chat with headless auth
+dust chat --wId ws_abc123 --api-key sk_your_api_key_here
+
+# Launch agents-mcp with headless auth
+dust agents-mcp --wId ws_abc123 --api-key sk_your_api_key_here --port 8080
+
+# Use with specific agent
+dust chat --sId 1234567890 --wId ws_abc123 --api-key sk_your_api_key_here
+```
+
+#### When to Use Headless Auth
+
+Headless authentication is particularly useful for:
+- Automated scripts and workflows
+- CI/CD pipelines
+- Server environments without interactive terminals
+- Batch processing operations
+
+#### Security Considerations
+
+- Store API keys securely (use environment variables in production)
+- Avoid committing API keys to version control
+- Consider using secrets management tools for production deployments
+
 ### Options
 
 - **`-v`, `--version`**: Display the installed CLI version.

--- a/cli/src/index.tsx
+++ b/cli/src/index.tsx
@@ -68,6 +68,14 @@ const cli = meow({
       type: "boolean",
       description: "Skip update check",
     },
+    apiKey: {
+      type: "string",
+      description: "API key for headless authentication",
+    },
+    wId: {
+      type: "string",
+      description: "Workspace ID for headless authentication",
+    },
   },
 });
 

--- a/cli/src/index.tsx
+++ b/cli/src/index.tsx
@@ -68,11 +68,11 @@ const cli = meow({
       type: "boolean",
       description: "Skip update check",
     },
-    apiKey: {
+    key: {
       type: "string",
-      description: "API key for headless authentication",
+      description: "Dust API key for headless authentication",
     },
-    wId: {
+    workspaceId: {
       type: "string",
       description: "Workspace ID for headless authentication",
     },

--- a/cli/src/ui/App.tsx
+++ b/cli/src/ui/App.tsx
@@ -61,10 +61,10 @@ interface AppProps {
     noUpdateCheck: {
       type: "boolean";
     };
-    apiKey: {
+    key: {
       type: "string";
     };
-    wId: {
+    workspaceId: {
       type: "string";
     };
   }>;
@@ -95,7 +95,9 @@ const App: FC<AppProps> = ({ cli }) => {
 
   switch (command) {
     case "login":
-      return <Auth force={flags.force} apiKey={flags.apiKey} wId={flags.wId} />;
+      return (
+        <Auth force={flags.force} apiKey={flags.key} wId={flags.workspaceId} />
+      );
     case "status":
       return <Status />;
     case "logout":

--- a/cli/src/ui/App.tsx
+++ b/cli/src/ui/App.tsx
@@ -61,6 +61,12 @@ interface AppProps {
     noUpdateCheck: {
       type: "boolean";
     };
+    apiKey: {
+      type: "string";
+    };
+    wId: {
+      type: "string";
+    };
   }>;
 }
 
@@ -89,7 +95,7 @@ const App: FC<AppProps> = ({ cli }) => {
 
   switch (command) {
     case "login":
-      return <Auth force={flags.force} />;
+      return <Auth force={flags.force} apiKey={flags.apiKey} wId={flags.wId} />;
     case "status":
       return <Status />;
     case "logout":

--- a/cli/src/ui/Help.tsx
+++ b/cli/src/ui/Help.tsx
@@ -102,7 +102,20 @@ const Help: FC = () => {
       </Box>
       <Box marginLeft={2}>
         <Text>
-          <Text bold>--auto</Text> Always accept edit operations without prompting for approval
+          <Text bold>--auto</Text> Always accept edit operations without
+          prompting for approval
+        </Text>
+      </Box>
+      <Box marginLeft={2}>
+        <Text>
+          <Text bold>--api-key</Text> API key for headless authentication (use
+          with --wId)
+        </Text>
+      </Box>
+      <Box marginLeft={2}>
+        <Text>
+          <Text bold>--wId</Text> Workspace ID for headless authentication (use
+          with --api-key)
         </Text>
       </Box>
     </Box>

--- a/cli/src/ui/Help.tsx
+++ b/cli/src/ui/Help.tsx
@@ -108,8 +108,8 @@ const Help: FC = () => {
       </Box>
       <Box marginLeft={2}>
         <Text>
-          <Text bold>--api-key</Text> API key for headless authentication (use
-          with --wId)
+          <Text bold>--key</Text> API key for headless authentication (use with
+          --workspaceId)
         </Text>
       </Box>
       <Box marginLeft={2}>

--- a/cli/src/ui/Help.tsx
+++ b/cli/src/ui/Help.tsx
@@ -118,6 +118,27 @@ const Help: FC = () => {
           with --api-key)
         </Text>
       </Box>
+      <Box marginTop={1}>
+        <Text>Environment Variables:</Text>
+      </Box>
+      <Box marginLeft={2}>
+        <Text>
+          <Text bold>DUST_API_KEY</Text> API key for headless authentication
+        </Text>
+      </Box>
+      <Box marginLeft={2}>
+        <Text>
+          <Text bold>DUST_WORKSPACE_ID</Text> Workspace ID for headless
+          authentication
+        </Text>
+      </Box>
+      <Box marginTop={1}>
+        <Text>
+          <Text italic>
+            Note: Environment variables take precedence over command-line flags
+          </Text>
+        </Text>
+      </Box>
     </Box>
   );
 };

--- a/cli/src/ui/commands/Auth.tsx
+++ b/cli/src/ui/commands/Auth.tsx
@@ -53,6 +53,12 @@ const Auth: FC<AuthProps> = ({ force = false, apiKey, wId }) => {
   const [isLoading, setIsLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
 
+  const [deviceCode, setDeviceCode] = useState<DeviceCodeResponse | null>(null);
+  const [isPolling, setIsPolling] = useState(false);
+  const [showWorkspaceSelector, setShowWorkspaceSelector] = useState(false);
+  const [authComplete, setAuthComplete] = useState(false);
+  const [userInfo, setUserInfo] = useState<MeResponseType["user"] | null>(null);
+
   // Check for environment variables first, then fall back to passed flags
   const effectiveApiKey = apiKey || process.env.DUST_API_KEY;
   const effectiveWId = wId || process.env.DUST_WORKSPACE_ID;
@@ -78,11 +84,6 @@ const Auth: FC<AuthProps> = ({ force = false, apiKey, wId }) => {
       </Box>
     );
   }
-  const [deviceCode, setDeviceCode] = useState<DeviceCodeResponse | null>(null);
-  const [isPolling, setIsPolling] = useState(false);
-  const [showWorkspaceSelector, setShowWorkspaceSelector] = useState(false);
-  const [authComplete, setAuthComplete] = useState(false);
-  const [userInfo, setUserInfo] = useState<MeResponseType["user"] | null>(null);
 
   const workOSDomain = process.env.WORKOS_DOMAIN || "";
   const clientId = process.env.WORKOS_CLIENT_ID || "";

--- a/cli/src/ui/commands/Auth.tsx
+++ b/cli/src/ui/commands/Auth.tsx
@@ -57,8 +57,6 @@ const Auth: FC<AuthProps> = ({ force = false, apiKey, wId }) => {
   const effectiveApiKey = process.env.DUST_API_KEY || apiKey;
   const effectiveWId = process.env.DUST_WORKSPACE_ID || wId;
 
-  console.log("effectiveApiKey:", effectiveApiKey);
-  console.log("effectiveWId:", effectiveWId);
   // Validate that both apiKey and wId are provided together (from either env vars or flags)
   const hasApiKey = Boolean(effectiveApiKey);
   const hasWId = Boolean(effectiveWId);

--- a/cli/src/ui/commands/Auth.tsx
+++ b/cli/src/ui/commands/Auth.tsx
@@ -54,8 +54,8 @@ const Auth: FC<AuthProps> = ({ force = false, apiKey, wId }) => {
   const [error, setError] = useState<string | null>(null);
 
   // Check for environment variables first, then fall back to passed flags
-  const effectiveApiKey = process.env.DUST_API_KEY || apiKey;
-  const effectiveWId = process.env.DUST_WORKSPACE_ID || wId;
+  const effectiveApiKey = apiKey || process.env.DUST_API_KEY;
+  const effectiveWId = wId || process.env.DUST_WORKSPACE_ID;
 
   // Validate that both apiKey and wId are provided together (from either env vars or flags)
   const hasApiKey = Boolean(effectiveApiKey);

--- a/cli/src/ui/commands/Auth.tsx
+++ b/cli/src/ui/commands/Auth.tsx
@@ -41,8 +41,11 @@ interface DecodedAccessToken {
 }
 
 interface AuthProps {
+  /** Force re-authentication even if already logged in */
   force?: boolean;
+  /** API key for headless authentication (must be used with wId) */
   apiKey?: string;
+  /** Workspace ID for headless authentication (must be used with apiKey) */
   wId?: string;
 }
 

--- a/cli/src/ui/commands/Chat.tsx
+++ b/cli/src/ui/commands/Chat.tsx
@@ -1253,7 +1253,8 @@ const CliChat: FC<CliChatProps> = ({
 
             const dustClient = dustClientRes.value;
             if (!dustClient) {
-              throw new Error("No Dust API set.");
+              setError("No Dust API set.");
+              return;
             }
             await useFileSystemServer(
               dustClient,

--- a/cli/src/ui/commands/Chat.tsx
+++ b/cli/src/ui/commands/Chat.tsx
@@ -1256,13 +1256,17 @@ const CliChat: FC<CliChatProps> = ({
               setError("No Dust API set.");
               return;
             }
-            await useFileSystemServer(
+
+            const useFsServerRes = await useFileSystemServer(
               dustClient,
               (serverId) => {
                 setFileSystemServerId(serverId);
               },
               requestDiffApproval
             );
+            if (useFsServerRes.isErr()) {
+              setError(useFsServerRes.error.message);
+            }
           }
           setChosenFileSystemUsage(true);
         }}

--- a/cli/src/utils/authService.ts
+++ b/cli/src/utils/authService.ts
@@ -68,6 +68,12 @@ export const AuthService = {
    * Gets a valid access token, refreshing if needed
    */
   async getValidAccessToken(): Promise<string | null> {
+    const accessToken = await TokenStorage.getAccessToken();
+
+    if (accessToken?.startsWith("sk-")) {
+      return accessToken;
+    }
+
     const isValid = await TokenStorage.hasValidAccessToken();
 
     if (!isValid) {

--- a/cli/src/utils/hooks/use_me.ts
+++ b/cli/src/utils/hooks/use_me.ts
@@ -30,6 +30,29 @@ export function useMe() {
         return;
       }
 
+      // Check if using API key authentication
+      const apiKey = await dustClient.getApiKey();
+      if (apiKey?.startsWith('sk-')) {
+        // For API key auth, create a mock user object since .me() won't work
+        // API keys don't have access to user information, so we create a placeholder
+        setMe({
+          sId: "api-user",
+          id: 0, // ModelId type, using 0 as placeholder
+          createdAt: Date.now(),
+          provider: "google", // Default provider
+          username: "api-user", 
+          email: "api-user@workspace",
+          firstName: "API",
+          lastName: "User",
+          fullName: "API User",
+          image: null,
+          workspaces: [] // Will be empty for API keys
+        });
+        setIsLoading(false);
+        return;
+      }
+
+      // For OAuth tokens, use existing .me() call
       const meRes = await dustClient.me();
 
       if (meRes.isErr()) {


### PR DESCRIPTION
## Description

Allows for automatted systems to use headless auth. Added Support for:
- api-key and wId flag
- env var injection for even easier access

## Tests

Manually tested.

## Risk

Security risk, but unlikely

## Deploy Plan

Deploy CLI
