### PR TITLE
[front] Remove shadow read on actions

### DIFF
--- a/front/lib/api/assistant/messages.ts
+++ b/front/lib/api/assistant/messages.ts
@@ -1,7 +1,6 @@
 import type { WhereOptions } from "sequelize";
 import { Op, Sequelize } from "sequelize";
 
-import { hideFileFromActionOutput, MCPActionType } from "@app/lib/actions/mcp";
 import {
   AgentMessageContentParser,
   getDelimitersConfiguration,
@@ -10,10 +9,6 @@ import { getLightAgentMessageFromAgentMessage } from "@app/lib/api/assistant/cit
 import { getAgentConfigurations } from "@app/lib/api/assistant/configuration";
 import type { PaginationParams } from "@app/lib/api/pagination";
 import { Authenticator } from "@app/lib/auth";
-import {
-  AgentMCPAction,
-  AgentMCPActionOutputItem,
-} from "@app/lib/models/assistant/actions/mcp";
 import { AgentStepContentModel } from "@app/lib/models/assistant/agent_step_content";
 import {
   AgentMessage,
@@ -24,11 +19,8 @@ import {
 import { AgentStepContentResource } from "@app/lib/resources/agent_step_content_resource";
 import { ContentFragmentResource } from "@app/lib/resources/content_fragment_resource";
 import { ConversationResource } from "@app/lib/resources/conversation_resource";
-import { FileResource } from "@app/lib/resources/file_resource";
 import { ContentFragmentModel } from "@app/lib/resources/storage/models/content_fragment";
-import { FileModel } from "@app/lib/resources/storage/models/files";
 import { UserResource } from "@app/lib/resources/user_resource";
-import logger from "@app/logger/logger";
 import type {
   AgentMessageType,
   ContentFragmentType,


### PR DESCRIPTION
## Description

- This PR removes the shadow read on MCP actions that was introduced in https://github.com/dust-tt/dust/pull/14458.
- It switches to the fetch via `AgentStepContentResource` rather than a direct fetch using the Sequelize model `AgentMCPAction`.

## Tests

- Tested locally.
- No more logs [here](https://app.datadoghq.eu/logs?query=%22%5BShadow%20read%5D%20Agent%20MCP%20actions%20mismatch%22&agg_m=count&agg_m_source=base&agg_t=count&cols=host%2Cservice&fromUser=true&messageDisplay=inline&refresh_mode=paused&saved-view-id=178093&storage=hot&stream_sort=desc&viz=stream&from_ts=1753256753045&to_ts=1753258216000&live=false).

## Risk

- High blast radius as it's on the path for rendering agent messages.

## Deploy Plan

- Deploy front.
