### PR TITLE
[front] - fix(ProviderManagementModal): dynamic model 

### DIFF
--- a/front/components/workspace/ProviderManagementModal.tsx
+++ b/front/components/workspace/ProviderManagementModal.tsx
@@ -30,7 +30,7 @@ import { canUseModel } from "@app/lib/assistant";
 import { useFeatureFlags, useWorkspace } from "@app/lib/swr/workspaces";
 import type { ModelProviderIdType, WorkspaceType } from "@app/types";
 import { EMBEDDING_PROVIDER_IDS, MODEL_PROVIDER_IDS } from "@app/types";
-import { PlanType } from "@app/types";
+import type { PlanType } from "@app/types";
 
 type ProviderStates = Record<ModelProviderIdType, boolean>;
 

--- a/front/components/workspace/ProviderManagementModal.tsx
+++ b/front/components/workspace/ProviderManagementModal.tsx
@@ -29,8 +29,8 @@ import { useSendNotification } from "@app/hooks/useNotification";
 import { canUseModel } from "@app/lib/assistant";
 import { useFeatureFlags, useWorkspace } from "@app/lib/swr/workspaces";
 import type { ModelProviderIdType, WorkspaceType } from "@app/types";
-import { EMBEDDING_PROVIDER_IDS, MODEL_PROVIDER_IDS } from "@app/types";
 import type { PlanType } from "@app/types";
+import { EMBEDDING_PROVIDER_IDS, MODEL_PROVIDER_IDS } from "@app/types";
 
 type ProviderStates = Record<ModelProviderIdType, boolean>;
 

--- a/front/components/workspace/ProviderManagementModal.tsx
+++ b/front/components/workspace/ProviderManagementModal.tsx
@@ -26,9 +26,11 @@ import {
 } from "@app/components/providers/types";
 import { useTheme } from "@app/components/sparkle/ThemeContext";
 import { useSendNotification } from "@app/hooks/useNotification";
-import { useWorkspace } from "@app/lib/swr/workspaces";
+import { canUseModel } from "@app/lib/assistant";
+import { useFeatureFlags, useWorkspace } from "@app/lib/swr/workspaces";
 import type { ModelProviderIdType, WorkspaceType } from "@app/types";
 import { EMBEDDING_PROVIDER_IDS, MODEL_PROVIDER_IDS } from "@app/types";
+import { PlanType } from "@app/types";
 
 type ProviderStates = Record<ModelProviderIdType, boolean>;
 
@@ -43,26 +45,14 @@ const prettyfiedProviderNames: { [key in ModelProviderIdType]: string } = {
   xai: "xAI",
 };
 
-const modelProviders: Record<ModelProviderIdType, string[]> = uniqBy(
-  [...USED_MODEL_CONFIGS, ...REASONING_MODEL_CONFIGS],
-  (m) => `${m.providerId}__${m.modelId}`
-).reduce(
-  (acc, model) => {
-    if (!model.isLegacy) {
-      acc[model.providerId] = acc[model.providerId] || [];
-      acc[model.providerId].push(model.displayName);
-    }
-    return acc;
-  },
-  {} as Record<ModelProviderIdType, string[]>
-);
-
 interface ProviderManagementModalProps {
   owner: WorkspaceType;
+  plan: PlanType;
 }
 
 export function ProviderManagementModal({
   owner,
+  plan,
 }: ProviderManagementModalProps) {
   const { isDark } = useTheme();
   const sendNotifications = useSendNotification();
@@ -78,6 +68,28 @@ export function ProviderManagementModal({
     owner,
     disabled: !open,
   });
+
+  const { featureFlags } = useFeatureFlags({
+    workspaceId: owner.sId,
+    disabled: !open,
+  });
+
+  // Filter models based on feature flags and build modelProviders dynamically
+  const filteredModels = uniqBy(
+    [...USED_MODEL_CONFIGS, ...REASONING_MODEL_CONFIGS],
+    (m) => m.modelId
+  ).filter(
+    (model) => !model.isLegacy && canUseModel(model, featureFlags, plan, owner)
+  );
+
+  const modelProviders = filteredModels.reduce(
+    (acc, model) => {
+      acc[model.providerId] = acc[model.providerId] || [];
+      acc[model.providerId].push(model.displayName);
+      return acc;
+    },
+    {} as Record<ModelProviderIdType, string[]>
+  );
 
   // These two represent the local state
   const [providerStates, setProviderStates] = useState<ProviderStates>(

--- a/front/pages/w/[wId]/workspace/index.tsx
+++ b/front/pages/w/[wId]/workspace/index.tsx
@@ -226,7 +226,7 @@ export default function WorkspaceAdmin({
                 Select the models you want available to your workspace.
               </Page.P>
             </div>
-            <ProviderManagementModal owner={owner} plan={plan} />
+            <ProviderManagementModal owner={owner} plan={subscription.plan} />
           </div>
         </Page.Vertical>
         {!isSlackDataSourceBotEnabled && (

--- a/front/pages/w/[wId]/workspace/index.tsx
+++ b/front/pages/w/[wId]/workspace/index.tsx
@@ -226,7 +226,7 @@ export default function WorkspaceAdmin({
                 Select the models you want available to your workspace.
               </Page.P>
             </div>
-            <ProviderManagementModal owner={owner} />
+            <ProviderManagementModal owner={owner} plan={plan} />
           </div>
         </Page.Vertical>
         {!isSlackDataSourceBotEnabled && (


### PR DESCRIPTION
## Description

Refactors the `ProviderManagementModal` to dynamically filter model providers based on feature flags and workspace plan. The changes ensure that only models appropriate for the workspace's plan and enabled features are displayed.

**References:**
- https://github.com/dust-tt/tasks/issues/3584

## Tests

Locally

## Risk

Low as it's only changing display

## Deploy Plan

Deploy front