### PR TITLE
build: version patch

### DIFF
--- a/cli/package-lock.json
+++ b/cli/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@dust-tt/dust-cli",
-  "version": "0.2.5",
+  "version": "0.2.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@dust-tt/dust-cli",
-      "version": "0.2.5",
+      "version": "0.2.6",
       "license": "MIT",
       "dependencies": {
         "@dust-tt/client": "^1.1.2",

--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dust-tt/dust-cli",
-  "version": "0.2.5",
+  "version": "0.2.6",
   "description": "A command-line interface for interacting with Dust.",
   "type": "module",
   "main": "dist/index.js",

--- a/cli/src/ui/commands/Chat.tsx
+++ b/cli/src/ui/commands/Chat.tsx
@@ -495,6 +495,9 @@ const CliChat: FC<CliChatProps> = ({
                 fullName: me.fullName,
                 email: me.email,
                 origin: "api",
+                clientSideMCPServerIds: fileSystemServerId
+                  ? [fileSystemServerId]
+                  : null,
               },
             },
             contentFragments,


### PR DESCRIPTION
## Description

Patch Bump. Needed to build prod cli instead of using local build which will use localhost:3000 incorrectly
_Note: I also added the fix for not sending the mcp tools on first message. Now sends them first message_

## Tests

Not needed.

## Risk

None.

## Deploy Plan

Deploy cli