### PR TITLE
Fix linter

### DIFF
--- a/front/components/agent_builder/AgentBuilderFormContext.tsx
+++ b/front/components/agent_builder/AgentBuilderFormContext.tsx
@@ -174,6 +174,7 @@ export const agentBuilderFormSchema = z.object({
   instructions: z.string().min(1, "Instructions are required"),
   generationSettings: generationSettingsSchema,
   actions: z.array(actionSchema),
+  maxStepsPerRun: z.number().min(1, "Max steps per run must be at least 1").default(8),
 });
 
 export type AgentBuilderFormData = z.infer<typeof agentBuilderFormSchema>;


### PR DESCRIPTION
## Description

Fix linter error by adding missing `maxStepsPerRun` field to the agent builder form schema. This adds proper validation for the max steps per run field with a minimum value of 1 and default value of 8.

## Tests

Manually verified that the linter error is resolved and the form schema validation works correctly.

## Risk

Low risk - this is a minor schema fix that adds validation for an existing field. The change is safe to rollback if needed.

## Deploy Plan

Standard deployment - no special considerations required. The change only affects form validation and doesn't impact existing data or functionality.