### PR TITLE
[connectors] Reduce `maximumInterval` on Confluence activities

### DIFF
--- a/connectors/src/connectors/confluence/temporal/workflows.ts
+++ b/connectors/src/connectors/confluence/temporal/workflows.ts
@@ -49,7 +49,7 @@ const {
   retry: {
     initialInterval: "60 seconds",
     backoffCoefficient: 2,
-    maximumInterval: "3600 seconds",
+    maximumInterval: "600 seconds",
   },
 });
 


### PR DESCRIPTION
## Description

- This PR reduces the maximum interval for Confluence activities from 1h to 10 min.
- This interval is the maximum interval between retries (exponential backoff).

## Tests

## Risk

- None

## Deploy Plan

- Deploy connectors.
