### PR TITLE
Keys: Add scope to handle special case where we restrict a regular key to its restricted Space only

### DIFF
--- a/front/lib/resources/key_resource.ts
+++ b/front/lib/resources/key_resource.ts
@@ -42,15 +42,15 @@ export class KeyResource extends BaseResource<KeyModel> {
   }
 
   static async makeNew(
-    blob: Omit<CreationAttributes<KeyModel>, "secret" | "groupId">,
+    blob: Omit<CreationAttributes<KeyModel>, "secret" | "groupId" | "scope">,
     group: GroupResource
   ) {
     const secret = this.createNewSecret();
-
     const key = await KeyResource.model.create({
       ...blob,
       groupId: group.id,
       secret,
+      scope: "default",
     });
 
     return new this(KeyResource.model, key.get());
@@ -236,6 +236,7 @@ export class KeyResource extends BaseResource<KeyModel> {
       status: this.status,
       groupId: this.groupId,
       role: this.role,
+      scope: this.scope,
     };
   }
 

--- a/front/lib/resources/storage/models/keys.ts
+++ b/front/lib/resources/storage/models/keys.ts
@@ -16,6 +16,7 @@ export class KeyModel extends WorkspaceAwareModel<KeyModel> {
   declare status: "active" | "disabled";
   declare isSystem: boolean;
   declare role: RoleType;
+  declare scope: "default" | "restricted_group_only";
 
   declare userId: ForeignKey<UserModel["id"]>;
   declare groupId: ForeignKey<GroupModel["id"]>;
@@ -61,6 +62,11 @@ KeyModel.init(
       defaultValue: "builder",
       allowNull: false,
     },
+    scope: {
+      type: DataTypes.STRING,
+      allowNull: false,
+      defaultValue: "default",
+    },
   },
   {
     modelName: "keys",
@@ -83,3 +89,4 @@ GroupModel.hasMany(KeyModel, {
 });
 
 KeyModel.belongsTo(UserModel);
+KeyModel.belongsTo(GroupModel);

--- a/front/migrations/20250723_update_keys_scope_for_regular_groups.ts
+++ b/front/migrations/20250723_update_keys_scope_for_regular_groups.ts
@@ -1,0 +1,59 @@
+import { GroupModel } from "@app/lib/resources/storage/models/groups";
+import { KeyModel } from "@app/lib/resources/storage/models/keys";
+import { concurrentExecutor } from "@app/lib/utils/async_utils";
+import logger from "@app/logger/logger";
+import { makeScript } from "@app/scripts/helpers";
+
+const KEY_UPDATE_CONCURRENCY = 5;
+
+const updateKeyScopeForRegularGroups = async (execute: boolean) => {
+  // Find all keys that are not system keys and are linked to regular groups
+  const keysToUpdate = await KeyModel.findAll({
+    where: {
+      isSystem: false,
+      scope: "default",
+    },
+    include: [
+      {
+        model: GroupModel,
+        where: {
+          kind: "regular",
+        },
+        required: true,
+      },
+    ],
+  });
+
+  logger.info(
+    { count: keysToUpdate.length },
+    execute
+      ? `Updating ${keysToUpdate.length} keys to scope='restricted_group_only'`
+      : `Would update ${keysToUpdate.length} keys to scope='restricted_group_only'`
+  );
+
+  if (execute) {
+    let updated = 0;
+
+    await concurrentExecutor(
+      keysToUpdate,
+      async (key) => {
+        await key.update({ scope: "restricted_group_only" });
+        updated++;
+
+        if (updated % 100 === 0) {
+          logger.info({ updated }, `Progress: updated ${updated} keys`);
+        }
+      },
+      { concurrency: KEY_UPDATE_CONCURRENCY }
+    );
+
+    logger.info(
+      { updated },
+      `Completed: updated all ${updated} keys to scope='restricted_group_only'`
+    );
+  }
+};
+
+makeScript({}, async ({ execute }) => {
+  await updateKeyScopeForRegularGroups(execute);
+});

--- a/front/migrations/db/migration_315.sql
+++ b/front/migrations/db/migration_315.sql
@@ -1,0 +1,2 @@
+-- Migration created on Jul 23, 2025
+ALTER TABLE "public"."keys" ADD COLUMN "scope" VARCHAR(255) NOT NULL DEFAULT 'default';

--- a/front/types/key.ts
+++ b/front/types/key.ts
@@ -11,4 +11,5 @@ export type KeyType = {
   name: string | null;
   groupId?: ModelId;
   role: RoleType;
+  scope: "default" | "restricted_group_only";
 };


### PR DESCRIPTION
## Description

**This PR:**
- Introduces a new scope column to the API keys model to better categorize and control key permissions based on their associated groups. 
- Adds a script to backfill this column. 
- Modifies GroupResource.listForKey() to ensure new restricted API keys always have access to both the Company Data Space and the restricted Space, and no change on existing API keys. 

**Initial bug**
Restricted API keys could not retrieve agent configurations or create conversations. Users with restricted scope API keys were experiencing:
- `/api/v1/w/{workspaceId}/assistant/agent_configurations` returning 200 but no data.
- `/api/v1/w/{workspaceId}/assistant/conversations` returning 200 but no conversation content.

**Root Cause**
Internal MCP servers are attached to the global space. Restricted API keys were only able to access their associated group, preventing them from accessing these tools needed for agent configurations and conversations to function properly.

**Solution**
Modified GroupResource.listForKey() to ensure restricted API keys always have access to both their associated group (for restricted permissions) & the global group (for essential workspace resources).
To make sure we do not change the behavior for existing key we rely on this new scope. 

**TLDR**

For system keys: No change - continues to fetch all groups.
For existing restricted keys: No change - continues to fetch only the restricted groups.
For new restricted keys: Now fetches both the associated group AND the global group using an OR condition.

## Tests

Locally. 

## Risk

There should be no different behavior for existing keys thanks to the script. 
Can be rolled back if needed. 

## Deploy Plan

Merge. 
On prodbox run migration_315, run backfill script. 
Deploy front. 
