### PR TITLE
Update User menu to mention Chrome extension

### DIFF
--- a/extension/package-lock.json
+++ b/extension/package-lock.json
@@ -12,7 +12,7 @@
         "@auth0/auth0-spa-js": "^2.1.3",
         "@datadog/browser-logs": "^6.13.0",
         "@dust-tt/client": "^1.1.0",
-        "@dust-tt/sparkle": "^0.2.543",
+        "@dust-tt/sparkle": "^0.2.544",
         "@frontapp/plugin-sdk": "^1.8.1",
         "@modelcontextprotocol/sdk": "^1.9.0",
         "@tailwindcss/forms": "^0.5.9",
@@ -84,7 +84,10 @@
     },
     "../sdks/js": {
       "name": "@dust-tt/client",
-      "version": "1.1.1",
+      "version": "1.1.3",
+      "bundleDependencies": [
+        "@modelcontextprotocol/sdk"
+      ],
       "license": "ISC",
       "dependencies": {
         "@modelcontextprotocol/sdk": "git://github.com:dust-tt/typescript-sdk.git#bca26e405d6db2cf71fd7211234a72ecc46d0215",
@@ -370,10 +373,9 @@
       "link": true
     },
     "node_modules/@dust-tt/sparkle": {
-      "version": "0.2.543",
-      "resolved": "https://registry.npmjs.org/@dust-tt/sparkle/-/sparkle-0.2.543.tgz",
-      "integrity": "sha512-1J+2cxuL9b1y9WFJbK/BzJmmY22LxdnH6+brKII7ayxgA/n5sotj3Yqm2ov9p6vozHS/NMdDkLFDcqIJ1D9FmA==",
-      "license": "ISC",
+      "version": "0.2.544",
+      "resolved": "https://registry.npmjs.org/@dust-tt/sparkle/-/sparkle-0.2.544.tgz",
+      "integrity": "sha512-bG3xRSTUcNlq2BJAEkFcYMVvHlZqq0TSnq+wSDx2iIBpBLDNvGDSlbNStonGbxgNssYNkRWCBTY2Pu2BD5tCFw==",
       "dependencies": {
         "@emoji-mart/data": "^1.1.2",
         "@emoji-mart/react": "^1.1.1",

--- a/extension/package.json
+++ b/extension/package.json
@@ -59,7 +59,7 @@
     "@auth0/auth0-spa-js": "^2.1.3",
     "@datadog/browser-logs": "^6.13.0",
     "@dust-tt/client": "^1.1.0",
-    "@dust-tt/sparkle": "^0.2.543",
+    "@dust-tt/sparkle": "^0.2.544",
     "@frontapp/plugin-sdk": "^1.8.1",
     "@modelcontextprotocol/sdk": "^1.9.0",
     "@tailwindcss/forms": "^0.5.9",

--- a/front/components/UserMenu.tsx
+++ b/front/components/UserMenu.tsx
@@ -2,6 +2,7 @@ import { datadogLogs } from "@datadog/browser-logs";
 import {
   Avatar,
   ChevronDownIcon,
+  ChromeLogo,
   cn,
   DropdownMenu,
   DropdownMenuContent,
@@ -13,7 +14,6 @@ import {
   DropdownMenuSubContent,
   DropdownMenuSubTrigger,
   DropdownMenuTrigger,
-  GoogleLogo,
   Icon,
   LightbulbIcon,
   LogoutIcon,
@@ -23,7 +23,7 @@ import {
   UserIcon,
 } from "@dust-tt/sparkle";
 import { useRouter } from "next/router";
-import { useEffect, useMemo, useState } from "react";
+import { useMemo } from "react";
 
 import { useSendNotification } from "@app/hooks/useNotification";
 import { usePersistedNavigationSelection } from "@app/hooks/usePersistedNavigationSelection";
@@ -52,18 +52,6 @@ export function UserMenu({
 
   const sendNotification = useSendNotification();
   const { setNavigationSelection } = usePersistedNavigationSelection();
-
-  const [isChrome, setIsChrome] = useState(false);
-
-  useEffect(() => {
-    const hasChromeObject = !!(window as any).chrome;
-    const hasChromeUserAgent =
-      navigator.userAgent.includes("Chrome") ||
-      navigator.userAgent.includes("Chromium");
-
-    const isChromeDetected = hasChromeObject && hasChromeUserAgent;
-    setIsChrome(isChromeDetected);
-  }, []);
 
   const forceRoleUpdate = useMemo(
     () => async (role: "user" | "builder" | "admin") => {
@@ -170,17 +158,13 @@ export function UserMenu({
           </>
         )}
 
-        {isChrome && (
-          <>
-            <DropdownMenuLabel label="Extension" />
-            <DropdownMenuItem
-              label="Install Chrome Extension"
-              icon={GoogleLogo} // TODO Use a Chrome icon from Sparkle.
-              href="https://chromewebstore.google.com/detail/dust/fnkfcndbgingjcbdhaofkcnhcjpljhdn?authuser=0&hl=fr"
-              target="_blank"
-            />
-          </>
-        )}
+        <DropdownMenuLabel label="Extension" />
+        <DropdownMenuItem
+          label="Dust Chrome Extension"
+          icon={ChromeLogo}
+          href="https://chromewebstore.google.com/detail/dust/fnkfcndbgingjcbdhaofkcnhcjpljhdn?authuser=0&hl=fr"
+          target="_blank"
+        />
 
         <DropdownMenuLabel label="Account" />
         {subscription?.plan.limits.canUseProduct && (

--- a/front/components/UserMenu.tsx
+++ b/front/components/UserMenu.tsx
@@ -13,6 +13,7 @@ import {
   DropdownMenuSubContent,
   DropdownMenuSubTrigger,
   DropdownMenuTrigger,
+  GoogleLogo,
   Icon,
   LightbulbIcon,
   LogoutIcon,
@@ -22,7 +23,7 @@ import {
   UserIcon,
 } from "@dust-tt/sparkle";
 import { useRouter } from "next/router";
-import { useMemo } from "react";
+import { useEffect, useMemo, useState } from "react";
 
 import { useSendNotification } from "@app/hooks/useNotification";
 import { usePersistedNavigationSelection } from "@app/hooks/usePersistedNavigationSelection";
@@ -51,6 +52,18 @@ export function UserMenu({
 
   const sendNotification = useSendNotification();
   const { setNavigationSelection } = usePersistedNavigationSelection();
+
+  const [isChrome, setIsChrome] = useState(false);
+
+  useEffect(() => {
+    const hasChromeObject = !!(window as any).chrome;
+    const hasChromeUserAgent =
+      navigator.userAgent.includes("Chrome") ||
+      navigator.userAgent.includes("Chromium");
+
+    const isChromeDetected = hasChromeObject && hasChromeUserAgent;
+    setIsChrome(isChromeDetected);
+  }, []);
 
   const forceRoleUpdate = useMemo(
     () => async (role: "user" | "builder" | "admin") => {
@@ -153,6 +166,18 @@ export function UserMenu({
               label="Exploratory features"
               icon={TestTubeIcon}
               href={`/w/${owner.sId}/labs`}
+            />
+          </>
+        )}
+
+        {isChrome && (
+          <>
+            <DropdownMenuLabel label="Extension" />
+            <DropdownMenuItem
+              label="Install Chrome Extension"
+              icon={GoogleLogo} // TODO Use a Chrome icon from Sparkle.
+              href="https://chromewebstore.google.com/detail/dust/fnkfcndbgingjcbdhaofkcnhcjpljhdn?authuser=0&hl=fr"
+              target="_blank"
             />
           </>
         )}

--- a/front/package-lock.json
+++ b/front/package-lock.json
@@ -8,7 +8,7 @@
         "@auth0/nextjs-auth0": "^3.5.0",
         "@datadog/browser-logs": "^6.13.0",
         "@dust-tt/client": "file:../sdks/js",
-        "@dust-tt/sparkle": "^0.2.543",
+        "@dust-tt/sparkle": "^0.2.544",
         "@google-cloud/bigquery": "^7.9.1",
         "@google-cloud/storage-transfer": "^3.6.0",
         "@heroicons/react": "^2.0.11",
@@ -1131,10 +1131,9 @@
       "link": true
     },
     "node_modules/@dust-tt/sparkle": {
-      "version": "0.2.543",
-      "resolved": "https://registry.npmjs.org/@dust-tt/sparkle/-/sparkle-0.2.543.tgz",
-      "integrity": "sha512-1J+2cxuL9b1y9WFJbK/BzJmmY22LxdnH6+brKII7ayxgA/n5sotj3Yqm2ov9p6vozHS/NMdDkLFDcqIJ1D9FmA==",
-      "license": "ISC",
+      "version": "0.2.544",
+      "resolved": "https://registry.npmjs.org/@dust-tt/sparkle/-/sparkle-0.2.544.tgz",
+      "integrity": "sha512-bG3xRSTUcNlq2BJAEkFcYMVvHlZqq0TSnq+wSDx2iIBpBLDNvGDSlbNStonGbxgNssYNkRWCBTY2Pu2BD5tCFw==",
       "dependencies": {
         "@emoji-mart/data": "^1.1.2",
         "@emoji-mart/react": "^1.1.1",

--- a/front/package.json
+++ b/front/package.json
@@ -25,7 +25,7 @@
     "@auth0/nextjs-auth0": "^3.5.0",
     "@datadog/browser-logs": "^6.13.0",
     "@dust-tt/client": "file:../sdks/js",
-    "@dust-tt/sparkle": "^0.2.543",
+    "@dust-tt/sparkle": "^0.2.544",
     "@google-cloud/bigquery": "^7.9.1",
     "@google-cloud/storage-transfer": "^3.6.0",
     "@heroicons/react": "^2.0.11",


### PR DESCRIPTION
## Description

Fixes https://github.com/dust-tt/tasks/issues/3389
Adds a link to open the Chrome extension page (in a new tab) from user menu. 
We display it always even if the user is not on Chrome or already have the extension installed. 

<kbd>
<img width="211" height="503" alt="Screenshot 2025-07-24 at 10 10 40" src="https://github.com/user-attachments/assets/590acb5a-72aa-4fcc-a9ea-3c0af14b7df1" />
</kbd>


## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

Deploy front. 