### PR TITLE
[Durable Agents] Add feature flag for asynchronous conversation processing

### DIFF
--- a/front/pages/api/w/[wId]/assistant/conversations/[cId]/messages/index.ts
+++ b/front/pages/api/w/[wId]/assistant/conversations/[cId]/messages/index.ts
@@ -10,6 +10,7 @@ import { fetchConversationMessages } from "@app/lib/api/assistant/messages";
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
 import { getPaginationParams } from "@app/lib/api/pagination";
 import type { Authenticator } from "@app/lib/auth";
+import { getFeatureFlags } from "@app/lib/auth";
 import { concurrentExecutor } from "@app/lib/utils/async_utils";
 import { statsDClient } from "@app/logger/statsDClient";
 import { apiError } from "@app/logger/withlogging";
@@ -42,7 +43,11 @@ async function handler(
   }
 
   const conversationId = req.query.cId;
-  const forceAsynchronousLoop = req.query.async === "true";
+
+  const featureFlags = await getFeatureFlags(auth.getNonNullableWorkspace());
+  const hasAsyncLoopFeature = featureFlags.includes("async_loop");
+  const forceAsynchronousLoop =
+    req.query.async === "true" || hasAsyncLoopFeature;
 
   switch (req.method) {
     case "GET":

--- a/front/pages/api/w/[wId]/assistant/conversations/[cId]/messages/index.ts
+++ b/front/pages/api/w/[wId]/assistant/conversations/[cId]/messages/index.ts
@@ -47,7 +47,8 @@ async function handler(
   const featureFlags = await getFeatureFlags(auth.getNonNullableWorkspace());
   const hasAsyncLoopFeature = featureFlags.includes("async_loop");
   const forceAsynchronousLoop =
-    req.query.async === "true" || hasAsyncLoopFeature;
+    req.query.async === "true" ||
+    (req.query.async !== "false" && hasAsyncLoopFeature);
 
   switch (req.method) {
     case "GET":

--- a/front/pages/api/w/[wId]/assistant/conversations/index.ts
+++ b/front/pages/api/w/[wId]/assistant/conversations/index.ts
@@ -12,6 +12,7 @@ import { getConversation } from "@app/lib/api/assistant/conversation/fetch";
 import { apiErrorForConversation } from "@app/lib/api/assistant/conversation/helper";
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
 import type { Authenticator } from "@app/lib/auth";
+import { getFeatureFlags } from "@app/lib/auth";
 import { ConversationResource } from "@app/lib/resources/conversation_resource";
 import { concurrentExecutor } from "@app/lib/utils/async_utils";
 import { apiError } from "@app/logger/withlogging";
@@ -74,7 +75,12 @@ async function handler(
       const { title, visibility, message, contentFragments } =
         bodyValidation.right;
 
-      const forceAsynchronousLoop = req.query.async === "true";
+      const featureFlags = await getFeatureFlags(
+        auth.getNonNullableWorkspace()
+      );
+      const hasAsyncLoopFeature = featureFlags.includes("async_loop");
+      const forceAsynchronousLoop =
+        req.query.async === "true" || hasAsyncLoopFeature;
 
       if (message?.context.clientSideMCPServerIds) {
         const hasServerAccess = await concurrentExecutor(

--- a/front/pages/api/w/[wId]/assistant/conversations/index.ts
+++ b/front/pages/api/w/[wId]/assistant/conversations/index.ts
@@ -80,7 +80,8 @@ async function handler(
       );
       const hasAsyncLoopFeature = featureFlags.includes("async_loop");
       const forceAsynchronousLoop =
-        req.query.async === "true" || hasAsyncLoopFeature;
+        req.query.async === "true" ||
+        (req.query.async !== "false" && hasAsyncLoopFeature);
 
       if (message?.context.clientSideMCPServerIds) {
         const hasServerAccess = await concurrentExecutor(

--- a/front/types/shared/feature_flags.ts
+++ b/front/types/shared/feature_flags.ts
@@ -108,6 +108,9 @@ export const WHITELISTABLE_FEATURES_CONFIG = {
   monday_tool: {
     description: "Monday MCP tool",
   },
+  async_loop: {
+    description: "Asynchronous loop for conversation processing",
+  },
 } as const;
 
 export const WHITELISTABLE_FEATURES = Object.keys(

--- a/sdks/js/src/types.ts
+++ b/sdks/js/src/types.ts
@@ -588,6 +588,7 @@ const WhitelistableFeaturesSchema = FlexibleEnumSchema<
   | "agent_builder_instructions_autocomplete"
   | "agent_builder_v2"
   | "anthropic_vertex_fallback"
+  | "async_loop"
   | "claude_4_opus_feature"
   | "co_edition"
   | "deepseek_feature"


### PR DESCRIPTION
## Description
Fixes https://github.com/dust-tt/tasks/issues/3511

This PR adds a feature flag `async_loop` to enable asynchronous conversation processing for specific workspaces.

## Risk
Blast radius: Conversation creation and message posting endpoints
Risk: low

## Deploy Plan
- Deploy front service
- :warning: fix https://github.com/dust-tt/tasks/issues/3596 before enabling the flag