### PR TITLE
[Durable Agents] Fix agent message content duplication on refresh

### DIFF
--- a/front/components/assistant/conversation/AgentMessage.tsx
+++ b/front/components/assistant/conversation/AgentMessage.tsx
@@ -150,7 +150,7 @@ export function AgentMessage({
 
   // Track if this is a fresh mount (no lastEventId) with existing content
   const isFreshMountWithContent = React.useRef(
-    message.status === "created" && !!message.content
+    message.status === "created" && (!!message.content || !!message.chainOfThought)
   );
 
   const buildEventSourceURL = React.useCallback(
@@ -217,7 +217,8 @@ export function AgentMessage({
       if (
         isFreshMountWithContent.current &&
         eventType === "generation_tokens" &&
-        eventPayload.data.classification === "tokens"
+        (eventPayload.data.classification === "tokens" ||
+          eventPayload.data.classification === "chain_of_thought")
       ) {
         // Clear the existing content from the state
         dispatch({

--- a/front/components/assistant/conversation/AgentMessage.tsx
+++ b/front/components/assistant/conversation/AgentMessage.tsx
@@ -57,7 +57,10 @@ import type {
   AgentMessageStateEvent,
   MessageTemporaryState,
 } from "@app/lib/assistant/state/messageReducer";
-import { messageReducer } from "@app/lib/assistant/state/messageReducer";
+import {
+  CLEAR_CONTENT_EVENT,
+  messageReducer,
+} from "@app/lib/assistant/state/messageReducer";
 import { useConversationMessage } from "@app/lib/swr/conversations";
 import type {
   LightAgentMessageType,
@@ -150,7 +153,8 @@ export function AgentMessage({
 
   // Track if this is a fresh mount (no lastEventId) with existing content
   const isFreshMountWithContent = React.useRef(
-    message.status === "created" && (!!message.content || !!message.chainOfThought)
+    message.status === "created" &&
+      (!!message.content || !!message.chainOfThought)
   );
 
   const buildEventSourceURL = React.useCallback(
@@ -221,9 +225,7 @@ export function AgentMessage({
           eventPayload.data.classification === "chain_of_thought")
       ) {
         // Clear the existing content from the state
-        dispatch({
-          type: "clear_content",
-        } as any);
+        dispatch(CLEAR_CONTENT_EVENT);
         isFreshMountWithContent.current = false;
       }
 

--- a/front/lib/assistant/state/messageReducer.ts
+++ b/front/lib/assistant/state/messageReducer.ts
@@ -87,6 +87,7 @@ export function messageReducer(
         message: {
           ...state.message,
           content: null,
+          chainOfThought: null,
         },
       };
     case "agent_action_success":

--- a/front/lib/assistant/state/messageReducer.ts
+++ b/front/lib/assistant/state/messageReducer.ts
@@ -25,7 +25,10 @@ export interface MessageTemporaryState {
   actionProgress: ActionProgressState;
 }
 
-export type AgentMessageStateEvent = AgentMessageEvents | ToolNotificationEvent;
+export type AgentMessageStateEvent =
+  | AgentMessageEvents
+  | ToolNotificationEvent
+  | { type: "clear_content" };
 
 type AgentMessageStateEventWithoutToolApproveExecution = Exclude<
   AgentMessageStateEvent,
@@ -78,6 +81,14 @@ export function messageReducer(
   event: AgentMessageStateEventWithoutToolApproveExecution
 ): MessageTemporaryState {
   switch (event.type) {
+    case "clear_content":
+      return {
+        ...state,
+        message: {
+          ...state.message,
+          content: null,
+        },
+      };
     case "agent_action_success":
       return {
         ...state,

--- a/front/lib/assistant/state/messageReducer.ts
+++ b/front/lib/assistant/state/messageReducer.ts
@@ -25,10 +25,7 @@ export interface MessageTemporaryState {
   actionProgress: ActionProgressState;
 }
 
-export type AgentMessageStateEvent =
-  | AgentMessageEvents
-  | ToolNotificationEvent
-  | { type: "clear_content" };
+export type AgentMessageStateEvent = AgentMessageEvents | ToolNotificationEvent;
 
 type AgentMessageStateEventWithoutToolApproveExecution = Exclude<
   AgentMessageStateEvent,
@@ -76,9 +73,13 @@ function updateProgress(
   return newState;
 }
 
+export const CLEAR_CONTENT_EVENT = { type: "clear_content" as const };
+
+export type ClearContentEvent = typeof CLEAR_CONTENT_EVENT;
+
 export function messageReducer(
   state: MessageTemporaryState,
-  event: AgentMessageStateEventWithoutToolApproveExecution
+  event: AgentMessageStateEventWithoutToolApproveExecution | ClearContentEvent
 ): MessageTemporaryState {
   switch (event.type) {
     case "clear_content":


### PR DESCRIPTION
## Description

Fixes the bug where agent message content gets duplicated when refreshing the page during message generation.

<img width="1152" height="849" alt="Screenshot From 2025-07-23 21-16-36" src="https://github.com/user-attachments/assets/12387c7f-6ed5-49ea-bddd-64077d792bd8" />


## Risks

Blast radius: Agent message rendering in conversations
Risk: low

## Tests

Tested manually by:
1. Starting an agent message generation
2. Refreshing the page while content is being streamed
3. Verifying that content is not duplicated

## Deploy Plan

- Deploy front service