### PR TITLE
[connectors] fix(crawler): Fix pause side effect

### DIFF
--- a/connectors/package-lock.json
+++ b/connectors/package-lock.json
@@ -95,7 +95,10 @@
     },
     "../sdks/js": {
       "name": "@dust-tt/client",
-      "version": "1.1.1",
+      "version": "1.1.3",
+      "bundleDependencies": [
+        "@modelcontextprotocol/sdk"
+      ],
       "license": "ISC",
       "dependencies": {
         "@modelcontextprotocol/sdk": "git://github.com:dust-tt/typescript-sdk.git#bca26e405d6db2cf71fd7211234a72ecc46d0215",

--- a/connectors/src/connectors/webcrawler/index.ts
+++ b/connectors/src/connectors/webcrawler/index.ts
@@ -135,12 +135,17 @@ export class WebcrawlerConnectorManager extends BaseConnectorManager<WebCrawlerC
       try {
         await getFirecrawl().cancelCrawl(webConfig.crawlId);
       } catch (error) {
+        // If we don't find the job, we might just have an expired ID, so it's safe to continue.
         if (!(error instanceof FirecrawlError) || error.statusCode !== 404) {
-          // If we don't find the job, we might just have an expired ID, so it's safe to continue.
           return new Err(
             new Error(
               `Error cancelling crawl on Firecrawl: ${normalizeError(error)}`
             )
+          );
+        } else {
+          logger.info(
+            { connectorId: this.connectorId, webConfigId: webConfig.id },
+            "Firecrawl job not found. Nothing to cancel."
           );
         }
       }

--- a/connectors/src/connectors/webcrawler/index.ts
+++ b/connectors/src/connectors/webcrawler/index.ts
@@ -144,7 +144,7 @@ export class WebcrawlerConnectorManager extends BaseConnectorManager<WebCrawlerC
           );
         } else {
           logger.info(
-            { connectorId: this.connectorId, webConfigId: webConfig.id },
+            { connectorId: this.connectorId, crawlId: webConfig.crawlId },
             "Firecrawl job not found. Nothing to cancel."
           );
         }

--- a/connectors/src/connectors/webcrawler/temporal/activities.ts
+++ b/connectors/src/connectors/webcrawler/temporal/activities.ts
@@ -472,6 +472,17 @@ export async function firecrawlCrawlPage(
   });
 
   const connector = await ConnectorResource.fetchById(connectorId);
+
+  if (connector && connector.isPaused()) {
+    localLogger.info(
+      {
+        connectorId,
+      },
+      "Connector is paused, skipping"
+    );
+    return;
+  }
+
   const webCrawlerConfig =
     await WebCrawlerConfigurationResource.fetchByConnectorId(connectorId);
 


### PR DESCRIPTION
## Description
 - Slack [thread](https://dust4ai.slack.com/archives/C050SM8NSPK/p1753285760070459) for context
 - When trying to pause a webcrawler, we also need to cancel the job on Firecrawl. If cancelling it gives us a 404, it means we have an expired `crawlId`, so there is nothing to cancel we can safely ignore that error. Just added a log in case.
 - Cancelling the job on Firecrawl will not send more page to ingest, but we can still receive the `crawl.complete` event. Keeping this one to clean properly the connector once received.
 -  As we can have current workflow in queue, we just skip those ones so they can all finish very fast.

## Tests
- Locally
  - Create a large crawl job (250 pages)
  - Started it
  - Paused the connector while having page workflows in queue and not having scraped all of links.
  - No error in logs, connectors correctly skipped the page workflows that were in queue before the pause.

## Risk
- Low. Skipping some error and 

## Deploy Plan
- Deploy connectors
