### PR TITLE
[front] Cleanup action types part 2

### DIFF
--- a/extension/package.json
+++ b/extension/package.json
@@ -59,7 +59,7 @@
     "@auth0/auth0-spa-js": "^2.1.3",
     "@datadog/browser-logs": "^6.13.0",
     "@dust-tt/client": "^1.1.0",
-    "@dust-tt/sparkle": "^0.2.545",
+    "@dust-tt/sparkle": "^0.2.544",
     "@frontapp/plugin-sdk": "^1.8.1",
     "@modelcontextprotocol/sdk": "^1.9.0",
     "@tailwindcss/forms": "^0.5.9",

--- a/front/components/actions/types.ts
+++ b/front/components/actions/types.ts
@@ -4,6 +4,7 @@ import { MCPActionDetails } from "@app/components/actions/mcp/details/MCPActionD
 import type { ProgressNotificationContentType } from "@app/lib/actions/mcp_internal_actions/output_schemas";
 import type { AgentActionType, LightWorkspaceType } from "@app/types";
 
+// TODO(2025-07-24 aubin): cleanup here.
 export interface ActionDetailsComponentBaseProps<
   T extends AgentActionType = AgentActionType,
 > {

--- a/front/components/assistant/conversation/ConversationContainer.tsx
+++ b/front/components/assistant/conversation/ConversationContainer.tsx
@@ -259,6 +259,7 @@ export function ConversationContainer({
       }
     },
     [
+      async,
       isSubmitting,
       owner,
       user,

--- a/front/components/assistant/conversation/actions/AgentMessageActions.tsx
+++ b/front/components/assistant/conversation/actions/AgentMessageActions.tsx
@@ -1,12 +1,8 @@
+import { TOOL_RUNNING_LABEL } from "@dust-tt/client";
 import { Button, Chip, CommandLineIcon } from "@dust-tt/sparkle";
 import { useEffect, useMemo, useState } from "react";
 
-import { getActionSpecification } from "@app/components/actions/types";
 import { AgentMessageActionsDrawer } from "@app/components/assistant/conversation/actions/AgentMessageActionsDrawer";
-import type {
-  BaseActionType,
-  BaseAgentActionType,
-} from "@app/lib/actions/types";
 import type { ActionProgressState } from "@app/lib/assistant/state/messageReducer";
 import type { AgentStateClassification } from "@app/lib/assistant/state/messageReducer";
 import type { LightAgentMessageType, LightWorkspaceType } from "@app/types";
@@ -37,7 +33,7 @@ export function AgentMessageActions({
         break;
       case "acting":
         if (agentMessage.actions && agentMessage.actions.length > 0) {
-          setChipLabel(renderActionName(agentMessage.actions));
+          setChipLabel(TOOL_RUNNING_LABEL);
         }
         break;
       case "done":
@@ -106,18 +102,4 @@ function ActionDetails({
       onClick={onClick}
     />
   );
-}
-
-function renderActionName(actions: BaseAgentActionType[]): string {
-  const uniqueActionTypes = actions.reduce<BaseActionType[]>((acc, action) => {
-    if (!acc.includes(action.type)) {
-      acc.push(action.type);
-    }
-
-    return acc;
-  }, []);
-
-  return uniqueActionTypes
-    .map((actionType) => getActionSpecification(actionType).runningLabel)
-    .join(", ");
 }

--- a/front/lib/actions/mcp.ts
+++ b/front/lib/actions/mcp.ts
@@ -334,6 +334,7 @@ export class MCPActionType {
   readonly functionCallName: string | null;
   readonly step: number = -1;
   readonly isError: boolean = false;
+  // TODO(2025-07-24 aubin): remove the type here.
   readonly type = "tool_action" as const;
 
   constructor(blob: MCPActionBlob) {

--- a/front/lib/actions/types/guards.ts
+++ b/front/lib/actions/types/guards.ts
@@ -1,6 +1,5 @@
 import type {
   ClientSideMCPToolConfigurationType,
-  MCPActionType,
   MCPServerConfigurationType,
   MCPToolConfigurationType,
   ServerSideMCPServerConfigurationType,
@@ -13,7 +12,6 @@ import type {
   UnsavedAgentActionConfigurationType,
 } from "@app/lib/actions/types/agent";
 import type {
-  AgentActionType,
   AgentConfigurationType,
   DustAppRunConfigurationType,
   TemplateAgentConfigurationType,

--- a/front/lib/actions/types/guards.ts
+++ b/front/lib/actions/types/guards.ts
@@ -30,10 +30,6 @@ export function isDustAppRunConfiguration(
   );
 }
 
-export function isMCPActionType(arg: AgentActionType): arg is MCPActionType {
-  return arg.type === "tool_action";
-}
-
 export function isMCPServerConfiguration(
   arg: unknown
 ): arg is MCPServerConfigurationType {

--- a/front/lib/actions/types/index.ts
+++ b/front/lib/actions/types/index.ts
@@ -5,19 +5,12 @@ import type {
 } from "@app/lib/actions/mcp";
 import type {
   ActionConfigurationType,
-  AgentActionSpecification,
 } from "@app/lib/actions/types/agent";
-import type { Authenticator } from "@app/lib/auth";
 import type {
   AgentConfigurationType,
   AgentMessageType,
   AllSupportedFileContentType,
   ConversationType,
-  FunctionCallType,
-  FunctionMessageTypeModel,
-  ModelConfigurationType,
-  ModelId,
-  Result,
 } from "@app/types";
 
 export type ActionGeneratedFileType = {
@@ -26,110 +19,6 @@ export type ActionGeneratedFileType = {
   contentType: AllSupportedFileContentType;
   snippet: string | null;
 };
-
-export type BaseActionType = "tool_action";
-
-export interface BaseAgentActionType {
-  type: BaseActionType;
-  id: ModelId;
-}
-export abstract class BaseAction implements BaseAgentActionType {
-  readonly id: ModelId;
-  readonly type: BaseActionType;
-  readonly generatedFiles: ActionGeneratedFileType[];
-
-  constructor(
-    id: ModelId,
-    type: BaseActionType,
-    generatedFiles: ActionGeneratedFileType[] = []
-  ) {
-    this.id = id;
-    this.type = type;
-    this.generatedFiles = generatedFiles;
-  }
-
-  getGeneratedFiles(): ActionGeneratedFileType[] {
-    return this.generatedFiles;
-  }
-
-  abstract renderForFunctionCall(): FunctionCallType;
-  abstract renderForMultiActionsModel(
-    auth: Authenticator,
-    {
-      conversation,
-      model,
-    }: {
-      conversation: ConversationType;
-      model: ModelConfigurationType;
-    }
-  ): Promise<FunctionMessageTypeModel>;
-}
-
-export type ExtractActionBlob<T extends BaseAction> = Pick<
-  T,
-  {
-    // eslint-disable-next-line @typescript-eslint/ban-types
-    [K in keyof T]: T[K] extends Function ? never : K;
-  }[keyof T]
->;
-
-export interface BaseActionConfigurationServerRunnerConstructor<
-  T extends BaseActionConfigurationServerRunner<V>,
-  V extends ActionConfigurationType,
-> {
-  new (actionConfiguration: V): T;
-}
-
-export interface BaseActionConfigurationStaticMethods<
-  T extends BaseActionConfigurationServerRunner<V>,
-  V extends ActionConfigurationType,
-> {
-  fromActionConfiguration(
-    this: BaseActionConfigurationServerRunnerConstructor<T, V>,
-    actionConfiguration: V
-  ): T;
-
-  // Other methods.
-}
-
-export interface BaseActionRunParams {
-  agentConfiguration: AgentConfigurationType;
-  conversation: ConversationType;
-  agentMessage: AgentMessageType;
-  rawInputs: Record<string, unknown>;
-  functionCallId: string;
-  step: number;
-  stepContentId: ModelId;
-}
-
-export abstract class BaseActionConfigurationServerRunner<
-  T extends ActionConfigurationType,
-> {
-  constructor(protected readonly actionConfiguration: T) {}
-
-  static fromActionConfiguration<
-    T extends BaseActionConfigurationServerRunner<V>,
-    V extends ActionConfigurationType,
-  >(
-    this: BaseActionConfigurationServerRunnerConstructor<T, V>,
-    actionConfiguration: V
-  ) {
-    return new this(actionConfiguration);
-  }
-
-  // Action rendering.
-  abstract buildSpecification(
-    auth: Authenticator,
-    { name, description }: { name: string | null; description: string | null }
-  ): Promise<Result<AgentActionSpecification, Error>>;
-
-  // Action execution.
-  abstract run(
-    auth: Authenticator,
-    runParams: BaseActionRunParams,
-    customParams: Record<string, unknown>
-  ): AsyncGenerator<unknown>;
-}
 
 export type AgentLoopRunContextType = {
   agentConfiguration: AgentConfigurationType;

--- a/front/lib/actions/types/index.ts
+++ b/front/lib/actions/types/index.ts
@@ -3,9 +3,7 @@ import type {
   MCPServerConfigurationType,
   MCPToolConfigurationType,
 } from "@app/lib/actions/mcp";
-import type {
-  ActionConfigurationType,
-} from "@app/lib/actions/types/agent";
+import type { ActionConfigurationType } from "@app/lib/actions/types/agent";
 import type {
   AgentConfigurationType,
   AgentMessageType,

--- a/front/lib/api/assistant/citations.ts
+++ b/front/lib/api/assistant/citations.ts
@@ -4,7 +4,6 @@ import {
   isSearchResultResourceType,
   isWebsearchResultResourceType,
 } from "@app/lib/actions/mcp_internal_actions/output_schemas";
-import { isMCPActionType } from "@app/lib/actions/types/guards";
 import { rand } from "@app/lib/utils/seeded_random";
 import type {
   AgentActionType,
@@ -53,11 +52,9 @@ export const getCitationsFromActions = (
 ): Record<string, CitationType> => {
   // MCP actions with search results.
   const searchResultsWithDocs = removeNulls(
-    actions
-      .filter(isMCPActionType)
-      .flatMap((action) =>
-        action.output?.filter(isSearchResultResourceType).map((o) => o.resource)
-      )
+    actions.flatMap((action) =>
+      action.output?.filter(isSearchResultResourceType).map((o) => o.resource)
+    )
   );
   const allMCPSearchResultsReferences = searchResultsWithDocs.reduce<{
     [key: string]: CitationType;
@@ -74,9 +71,9 @@ export const getCitationsFromActions = (
   );
 
   const websearchResultsWithDocs = removeNulls(
-    actions
-      .filter(isMCPActionType)
-      .flatMap((action) => action.output?.filter(isWebsearchResultResourceType))
+    actions.flatMap((action) =>
+      action.output?.filter(isWebsearchResultResourceType)
+    )
   );
 
   const allMCPWebsearchResultsReferences = websearchResultsWithDocs.reduce<{

--- a/front/lib/assistant/state/messageReducer.ts
+++ b/front/lib/assistant/state/messageReducer.ts
@@ -1,16 +1,15 @@
 import type { ToolNotificationEvent } from "@app/lib/actions/mcp";
 import type { ProgressNotificationContentType } from "@app/lib/actions/mcp_internal_actions/output_schemas";
-import type { BaseAction } from "@app/lib/actions/types";
 import { getLightAgentMessageFromAgentMessage } from "@app/lib/api/assistant/citations";
 import type { AgentMessageEvents } from "@app/lib/api/assistant/streaming/types";
-import type { AgentActionType } from "@app/types";
+import type { AgentActionType, ModelId } from "@app/types";
 import { assertNever } from "@app/types";
 import type { LightAgentMessageType } from "@app/types/assistant/conversation";
 
 export type AgentStateClassification = "thinking" | "acting" | "done";
 
 export type ActionProgressState = Map<
-  BaseAction["id"],
+  ModelId,
   {
     action: AgentActionType;
     progress?: ProgressNotificationContentType;

--- a/front/package.json
+++ b/front/package.json
@@ -25,7 +25,7 @@
     "@auth0/nextjs-auth0": "^3.5.0",
     "@datadog/browser-logs": "^6.13.0",
     "@dust-tt/client": "file:../sdks/js",
-    "@dust-tt/sparkle": "^0.2.545",
+    "@dust-tt/sparkle": "^0.2.544",
     "@google-cloud/bigquery": "^7.9.1",
     "@google-cloud/storage-transfer": "^3.6.0",
     "@heroicons/react": "^2.0.11",

--- a/front/types/assistant/conversation.ts
+++ b/front/types/assistant/conversation.ts
@@ -1,8 +1,5 @@
 import type { MCPActionType } from "@app/lib/actions/mcp";
-import type {
-  ActionGeneratedFileType,
-  BaseAgentActionType,
-} from "@app/lib/actions/types";
+import type { ActionGeneratedFileType } from "@app/lib/actions/types";
 
 import type { ContentFragmentType } from "../content_fragment";
 import type { ModelId } from "../shared/model_id";
@@ -178,7 +175,10 @@ export type LightAgentMessageType = BaseAgentMessageType & {
     canRead: boolean;
     requestedGroupIds: string[][];
   };
-  actions: BaseAgentActionType[];
+  actions: {
+    type: "tool_action";
+    id: ModelId;
+  }[];
   citations: Record<string, CitationType>;
   generatedFiles: Omit<ActionGeneratedFileType, "snippet">[];
 };

--- a/front/types/assistant/conversation.ts
+++ b/front/types/assistant/conversation.ts
@@ -176,6 +176,7 @@ export type LightAgentMessageType = BaseAgentMessageType & {
     requestedGroupIds: string[][];
   };
   actions: {
+    // TODO(2025-07-24 aubin): remove the type here.
     type: "tool_action";
     id: ModelId;
   }[];


### PR DESCRIPTION
## Description

- Part of https://github.com/dust-tt/tasks/issues/3586.
- This PR removes the `BaseAction` type, inlining it in `MCPActionType`.
- It also removes the mechanism to render an action name (it's always the same since there's only 1 name).

## Tests

- tsc + tested locally.

## Risk

- Low, only refactoring and mostly on types.

## Deploy Plan

- Deploy front.
