### PR TITLE
[front] Refactor agentic loop activities to rely on step content

### DIFF
--- a/front/temporal/agent_loop/activities/run_model.ts
+++ b/front/temporal/agent_loop/activities/run_model.ts
@@ -759,7 +759,6 @@ export async function runModelActivity({
     let action = availableActions.find((ac) =>
       actionNamesFromLLM.includes(ac.name)
     );
-    let args = a.arguments;
 
     if (!action) {
       if (!a.name) {
@@ -823,12 +822,10 @@ export async function runModelActivity({
         toolServerId: mcpServerView.sId,
         mcpServerName: "missing_action_catcher" as InternalMCPServerNameType,
       };
-      args = {};
     }
 
     actions.push({
       action,
-      inputs: args ?? {},
       functionCallId: a.functionCallId ?? null,
     });
   }

--- a/front/temporal/agent_loop/activities/run_tool.ts
+++ b/front/temporal/agent_loop/activities/run_tool.ts
@@ -29,28 +29,20 @@ export async function runToolActivity(
   const auth = await Authenticator.fromJSON(authType);
 
   // Fetch step content to derive inputs, functionCallId, and step
-  const stepContent = await AgentStepContentResource.fetchByModelId(
-    stepContentId
-  );
+  const stepContent =
+    await AgentStepContentResource.fetchByModelId(stepContentId);
   if (!stepContent) {
     throw new Error(
       `Step content not found for stepContentId: ${stepContentId}`
     );
   }
-
   if (!isFunctionCallContent(stepContent.value)) {
     throw new Error(
       `Expected step content to be a function call, got: ${stepContent.value.type}`
     );
   }
 
-  const functionCallContent = stepContent.value as FunctionCallContentType;
-  const inputs = JSON.parse(functionCallContent.value.arguments) as Record<
-    string,
-    string | boolean | number
-  >;
-  const functionCallId = functionCallContent.value.id;
-  const step = stepContent.step;
+  const { step } = stepContent;
 
   const runAgentDataRes = await getRunAgentData(authType, runAgentArgs);
   if (runAgentDataRes.isErr()) {
@@ -64,8 +56,8 @@ export async function runToolActivity(
     agentConfiguration: agentConfiguration,
     conversation,
     agentMessage,
-    rawInputs: inputs,
-    functionCallId,
+    rawInputs: JSON.parse(stepContent.value.value.arguments),
+    functionCallId: stepContent.value.value.id,
     step,
     stepContext,
     stepContentId,

--- a/front/temporal/agent_loop/activities/run_tool.ts
+++ b/front/temporal/agent_loop/activities/run_tool.ts
@@ -3,33 +3,54 @@ import type { StepContext } from "@app/lib/actions/types";
 import type { ActionConfigurationType } from "@app/lib/actions/types/agent";
 import type { AuthenticatorType } from "@app/lib/auth";
 import { Authenticator } from "@app/lib/auth";
+import { AgentStepContentResource } from "@app/lib/resources/agent_step_content_resource";
 import { updateResourceAndPublishEvent } from "@app/temporal/agent_loop/activities/common";
 import { assertNever } from "@app/types";
 import type { RunAgentArgs } from "@app/types/assistant/agent_run";
 import { getRunAgentData } from "@app/types/assistant/agent_run";
+import type { FunctionCallContentType } from "@app/types/assistant/agent_message_content";
+import { isFunctionCallContent } from "@app/types/assistant/agent_message_content";
 import type { ModelId } from "@app/types/shared/model_id";
 
 export async function runToolActivity(
   authType: AuthenticatorType,
   {
     runAgentArgs,
-    inputs,
-    functionCallId,
-    step,
     action,
     stepContext,
     stepContentId,
   }: {
     runAgentArgs: RunAgentArgs;
-    inputs: Record<string, string | boolean | number>;
-    functionCallId: string;
-    step: number;
     action: ActionConfigurationType;
     stepContext: StepContext;
     stepContentId: ModelId;
   }
 ): Promise<void> {
   const auth = await Authenticator.fromJSON(authType);
+
+  // Fetch step content to derive inputs, functionCallId, and step
+  const stepContent = await AgentStepContentResource.fetchByModelId(
+    stepContentId
+  );
+  if (!stepContent) {
+    throw new Error(
+      `Step content not found for stepContentId: ${stepContentId}`
+    );
+  }
+
+  if (!isFunctionCallContent(stepContent.value)) {
+    throw new Error(
+      `Expected step content to be a function call, got: ${stepContent.value.type}`
+    );
+  }
+
+  const functionCallContent = stepContent.value as FunctionCallContentType;
+  const inputs = JSON.parse(functionCallContent.value.arguments) as Record<
+    string,
+    string | boolean | number
+  >;
+  const functionCallId = functionCallContent.value.id;
+  const step = stepContent.step;
 
   const runAgentDataRes = await getRunAgentData(authType, runAgentArgs);
   if (runAgentDataRes.isErr()) {

--- a/front/temporal/agent_loop/lib/activity_interface.ts
+++ b/front/temporal/agent_loop/lib/activity_interface.ts
@@ -25,9 +25,6 @@ export interface AgentLoopActivities {
     authType: AuthenticatorType,
     args: {
       runAgentArgs: RunAgentArgs;
-      inputs: Record<string, string | boolean | number>;
-      functionCallId: string;
-      step: number;
       action: ActionConfigurationType;
       stepContext: StepContext;
       stepContentId: ModelId;

--- a/front/temporal/agent_loop/lib/agent_loop_executor.ts
+++ b/front/temporal/agent_loop/lib/agent_loop_executor.ts
@@ -55,12 +55,9 @@ export async function executeAgentLoop(
     const actionsToRun = result.actions.slice(0, MAX_ACTIONS_PER_STEP);
 
     await Promise.all(
-      actionsToRun.map(({ inputs, functionCallId, action }, index) =>
+      actionsToRun.map(({ functionCallId, action }, index) =>
         activities.runToolActivity(authType, {
           runAgentArgs,
-          inputs,
-          functionCallId,
-          step: i,
           action,
           stepContext: stepContexts[index],
           stepContentId: functionCallStepContentIds[functionCallId],

--- a/front/types/assistant/agent.ts
+++ b/front/types/assistant/agent.ts
@@ -293,7 +293,6 @@ export type AgentActionsEvent = {
   runId: string;
   actions: Array<{
     action: ActionConfigurationType;
-    inputs: Record<string, string | boolean | number>;
     functionCallId: string;
   }>;
 };


### PR DESCRIPTION
## Description

- Part of https://github.com/dust-tt/tasks/issues/3591.
- This PR refactors `runModelActivity` and `runToolActivity` to exchange only step content IDs instead of full inputs, which can be huge, for the interactive content it's a whole file for instance, and go through Temporal.
- Will have to be rebased on https://github.com/dust-tt/dust/pull/14557 (or the other way around, in any case there's some cleanup that has to be done once we have both).

## Tests

## Risk

- High blast radius (actions).
- Adds a fetch (simple fetch on a PK) on tool executions.

## Deploy Plan

- Deploy front.
