### PR TITLE
[front] Remove `stepActions` from `runToolActivity`'s inputs

### DIFF
--- a/front/lib/actions/mcp.ts
+++ b/front/lib/actions/mcp.ts
@@ -34,9 +34,7 @@ import type {
   ActionGeneratedFileType,
   AgentLoopRunContextType,
 } from "@app/lib/actions/types";
-import type {
-  AgentActionSpecification,
-} from "@app/lib/actions/types/agent";
+import type { AgentActionSpecification } from "@app/lib/actions/types/agent";
 import { getExecutionStatusFromConfig } from "@app/lib/actions/utils";
 import type { StepContext } from "@app/lib/actions/utils";
 import type { TableDataSourceConfiguration } from "@app/lib/api/assistant/configuration";

--- a/front/lib/actions/mcp.ts
+++ b/front/lib/actions/mcp.ts
@@ -34,8 +34,8 @@ import type {
   ActionGeneratedFileType,
   AgentLoopRunContextType,
 } from "@app/lib/actions/types";
+import type { StepContext } from "@app/lib/actions/types";
 import type { AgentActionSpecification } from "@app/lib/actions/types/agent";
-import type { StepContext } from "@app/lib/actions/utils";
 import { getExecutionStatusFromConfig } from "@app/lib/actions/utils";
 import type { TableDataSourceConfiguration } from "@app/lib/api/assistant/configuration";
 import type { DataSourceConfiguration } from "@app/lib/api/assistant/configuration";

--- a/front/lib/actions/mcp.ts
+++ b/front/lib/actions/mcp.ts
@@ -35,8 +35,8 @@ import type {
   AgentLoopRunContextType,
 } from "@app/lib/actions/types";
 import type { AgentActionSpecification } from "@app/lib/actions/types/agent";
-import { getExecutionStatusFromConfig } from "@app/lib/actions/utils";
 import type { StepContext } from "@app/lib/actions/utils";
+import { getExecutionStatusFromConfig } from "@app/lib/actions/utils";
 import type { TableDataSourceConfiguration } from "@app/lib/api/assistant/configuration";
 import type { DataSourceConfiguration } from "@app/lib/api/assistant/configuration";
 import {

--- a/front/lib/actions/mcp.ts
+++ b/front/lib/actions/mcp.ts
@@ -489,7 +489,6 @@ export async function* runToolWithStreaming(
     functionCallId,
     step,
     stepContentId,
-    stepActionIndex,
     stepContext,
   }: {
     agentConfiguration: AgentConfigurationType;
@@ -499,7 +498,6 @@ export async function* runToolWithStreaming(
     functionCallId: string;
     step: number;
     stepContentId: ModelId;
-    stepActionIndex: number;
     stepContext: StepContext;
   }
 ): AsyncGenerator<
@@ -732,7 +730,6 @@ export async function* runToolWithStreaming(
     agentConfiguration,
     conversation,
     agentMessage,
-    stepActionIndex,
     stepContext,
   };
 

--- a/front/lib/actions/mcp.ts
+++ b/front/lib/actions/mcp.ts
@@ -35,10 +35,10 @@ import type {
   AgentLoopRunContextType,
 } from "@app/lib/actions/types";
 import type {
-  ActionConfigurationType,
   AgentActionSpecification,
 } from "@app/lib/actions/types/agent";
 import { getExecutionStatusFromConfig } from "@app/lib/actions/utils";
+import type { StepContext } from "@app/lib/actions/utils";
 import type { TableDataSourceConfiguration } from "@app/lib/api/assistant/configuration";
 import type { DataSourceConfiguration } from "@app/lib/api/assistant/configuration";
 import {
@@ -492,8 +492,7 @@ export async function* runToolWithStreaming(
     step,
     stepContentId,
     stepActionIndex,
-    stepActions,
-    citationsRefsOffset,
+    stepContext,
   }: {
     agentConfiguration: AgentConfigurationType;
     conversation: ConversationType;
@@ -503,8 +502,7 @@ export async function* runToolWithStreaming(
     step: number;
     stepContentId: ModelId;
     stepActionIndex: number;
-    stepActions: ActionConfigurationType[];
-    citationsRefsOffset: number;
+    stepContext: StepContext;
   }
 ): AsyncGenerator<
   | MCPParamsEvent
@@ -737,8 +735,7 @@ export async function* runToolWithStreaming(
     conversation,
     agentMessage,
     stepActionIndex,
-    stepActions,
-    citationsRefsOffset,
+    stepContext,
   };
 
   let toolCallResult: Result<

--- a/front/lib/actions/mcp_internal_actions/servers/data_sources_file_system.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/data_sources_file_system.ts
@@ -38,7 +38,6 @@ import {
 } from "@app/lib/actions/mcp_internal_actions/utils";
 import { withToolLogging } from "@app/lib/actions/mcp_internal_actions/wrappers";
 import type { AgentLoopContextType } from "@app/lib/actions/types";
-import { actionRefsOffset, getRetrievalTopK } from "@app/lib/actions/utils";
 import { getRefs } from "@app/lib/api/assistant/citations";
 import config from "@app/lib/api/config";
 import { ROOT_PARENT_ID } from "@app/lib/api/data_source_view";
@@ -158,9 +157,10 @@ async function searchCallback(
 
   // Get the topK and refsOffset from pre-computed step context.
   const topK = agentLoopContext.runContext.stepContext.retrievalTopK;
-  const refsOffset = agentLoopContext.runContext.stepContext.citationsOffsets.get(
-    agentLoopContext.runContext.stepActionIndex
-  ) ?? 0;
+  const refsOffset =
+    agentLoopContext.runContext.stepContext.citationsOffsets.get(
+      agentLoopContext.runContext.stepActionIndex
+    ) ?? 0;
 
   const agentDataSourceConfigurationsResult =
     await getAgentDataSourceConfigurations(auth, dataSources);

--- a/front/lib/actions/mcp_internal_actions/servers/data_sources_file_system.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/data_sources_file_system.ts
@@ -157,10 +157,7 @@ async function searchCallback(
 
   // Get the topK and refsOffset from pre-computed step context.
   const topK = agentLoopContext.runContext.stepContext.retrievalTopK;
-  const refsOffset =
-    agentLoopContext.runContext.stepContext.citationsOffsets.get(
-      agentLoopContext.runContext.stepActionIndex
-    ) ?? 0;
+  const refsOffset = agentLoopContext.runContext.stepContext.citationsOffset;
 
   const agentDataSourceConfigurationsResult =
     await getAgentDataSourceConfigurations(auth, dataSources);

--- a/front/lib/actions/mcp_internal_actions/servers/data_sources_file_system.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/data_sources_file_system.ts
@@ -156,17 +156,11 @@ async function searchCallback(
     );
   }
 
-  // Compute the topK and refsOffset for the search.
-  const topK = getRetrievalTopK({
-    agentConfiguration: agentLoopContext.runContext.agentConfiguration,
-    stepActions: agentLoopContext.runContext.stepActions,
-  });
-  const refsOffset = actionRefsOffset({
-    agentConfiguration: agentLoopContext.runContext.agentConfiguration,
-    stepActionIndex: agentLoopContext.runContext.stepActionIndex,
-    stepActions: agentLoopContext.runContext.stepActions,
-    refsOffset: agentLoopContext.runContext.citationsRefsOffset,
-  });
+  // Get the topK and refsOffset from pre-computed step context.
+  const topK = agentLoopContext.runContext.stepContext.retrievalTopK;
+  const refsOffset = agentLoopContext.runContext.stepContext.citationsOffsets.get(
+    agentLoopContext.runContext.stepActionIndex
+  ) ?? 0;
 
   const agentDataSourceConfigurationsResult =
     await getAgentDataSourceConfigurations(auth, dataSources);

--- a/front/lib/actions/mcp_internal_actions/servers/data_sources_file_system.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/data_sources_file_system.ts
@@ -155,9 +155,8 @@ async function searchCallback(
     );
   }
 
-  // Get the topK and refsOffset from pre-computed step context.
-  const topK = agentLoopContext.runContext.stepContext.retrievalTopK;
-  const refsOffset = agentLoopContext.runContext.stepContext.citationsOffset;
+  const { retrievalTopK, citationsOffset } =
+    agentLoopContext.runContext.stepContext;
 
   const agentDataSourceConfigurationsResult =
     await getAgentDataSourceConfigurations(auth, dataSources);
@@ -237,7 +236,7 @@ async function searchCallback(
 
   const searchResults = await coreAPI.searchDataSources(
     query,
-    topK,
+    retrievalTopK,
     credentials,
     false,
     coreSearchArgs.map((args) => {
@@ -273,13 +272,16 @@ async function searchCallback(
     );
   }
 
-  if (refsOffset + topK > getRefs().length) {
+  if (citationsOffset + retrievalTopK > getRefs().length) {
     return makeMCPToolTextError(
       "The search exhausted the total number of references available for citations"
     );
   }
 
-  const refs = getRefs().slice(refsOffset, refsOffset + topK);
+  const refs = getRefs().slice(
+    citationsOffset,
+    citationsOffset + retrievalTopK
+  );
 
   const results = searchResults.value.documents.map(
     (doc): SearchResultResourceType => {

--- a/front/lib/actions/mcp_internal_actions/servers/include.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/include.ts
@@ -124,10 +124,7 @@ function createServer(
 
     // Get the topK and refsOffset from pre-computed step context.
     const topK = agentLoopContext.runContext.stepContext.retrievalTopK;
-    const refsOffset =
-      agentLoopContext.runContext.stepContext.citationsOffsets.get(
-        agentLoopContext.runContext.stepActionIndex
-      ) ?? 0;
+    const refsOffset = agentLoopContext.runContext.stepContext.citationsOffset;
 
     // Get the core search args for each data source, fail if any of them are invalid.
     const coreSearchArgsResults = await concurrentExecutor(

--- a/front/lib/actions/mcp_internal_actions/servers/include.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/include.ts
@@ -123,17 +123,11 @@ function createServer(
       );
     }
 
-    // Compute the topK and refsOffset for the search.
-    const topK = getRetrievalTopK({
-      agentConfiguration: agentLoopContext.runContext.agentConfiguration,
-      stepActions: agentLoopContext.runContext.stepActions,
-    });
-    const refsOffset = actionRefsOffset({
-      agentConfiguration: agentLoopContext.runContext.agentConfiguration,
-      stepActionIndex: agentLoopContext.runContext.stepActionIndex,
-      stepActions: agentLoopContext.runContext.stepActions,
-      refsOffset: agentLoopContext.runContext.citationsRefsOffset,
-    });
+    // Get the topK and refsOffset from pre-computed step context.
+    const topK = agentLoopContext.runContext.stepContext.retrievalTopK;
+    const refsOffset = agentLoopContext.runContext.stepContext.citationsOffsets.get(
+      agentLoopContext.runContext.stepActionIndex
+    ) ?? 0;
 
     // Get the core search args for each data source, fail if any of them are invalid.
     const coreSearchArgsResults = await concurrentExecutor(

--- a/front/lib/actions/mcp_internal_actions/servers/include.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/include.ts
@@ -25,7 +25,6 @@ import {
 import { makeMCPToolTextError } from "@app/lib/actions/mcp_internal_actions/utils";
 import { withToolLogging } from "@app/lib/actions/mcp_internal_actions/wrappers";
 import type { AgentLoopContextType } from "@app/lib/actions/types";
-import { actionRefsOffset, getRetrievalTopK } from "@app/lib/actions/utils";
 import { getRefs } from "@app/lib/api/assistant/citations";
 import config from "@app/lib/api/config";
 import type { InternalMCPServerDefinitionType } from "@app/lib/api/mcp";
@@ -125,9 +124,10 @@ function createServer(
 
     // Get the topK and refsOffset from pre-computed step context.
     const topK = agentLoopContext.runContext.stepContext.retrievalTopK;
-    const refsOffset = agentLoopContext.runContext.stepContext.citationsOffsets.get(
-      agentLoopContext.runContext.stepActionIndex
-    ) ?? 0;
+    const refsOffset =
+      agentLoopContext.runContext.stepContext.citationsOffsets.get(
+        agentLoopContext.runContext.stepActionIndex
+      ) ?? 0;
 
     // Get the core search args for each data source, fail if any of them are invalid.
     const coreSearchArgsResults = await concurrentExecutor(

--- a/front/lib/actions/mcp_internal_actions/servers/notion.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/notion.ts
@@ -366,12 +366,11 @@ const createServer = (
           ],
         };
       } else {
-        const refsOffset =
-          agentLoopContext.runContext.stepContext.citationsOffset;
+        const { citationsOffset } = agentLoopContext.runContext.stepContext;
 
         const refs = getRefs().slice(
-          refsOffset,
-          refsOffset + NOTION_SEARCH_ACTION_NUM_RESULTS
+          citationsOffset,
+          citationsOffset + NOTION_SEARCH_ACTION_NUM_RESULTS
         );
 
         const resultResources = results.map((result) => {

--- a/front/lib/actions/mcp_internal_actions/servers/notion.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/notion.ts
@@ -367,9 +367,7 @@ const createServer = (
         };
       } else {
         const refsOffset =
-          agentLoopContext.runContext.stepContext.citationsOffsets.get(
-            agentLoopContext.runContext.stepActionIndex
-          ) ?? 0;
+          agentLoopContext.runContext.stepContext.citationsOffset;
 
         const refs = getRefs().slice(
           refsOffset,

--- a/front/lib/actions/mcp_internal_actions/servers/notion.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/notion.ts
@@ -22,10 +22,7 @@ import {
   makeMCPToolTextError,
 } from "@app/lib/actions/mcp_internal_actions/utils";
 import type { AgentLoopContextType } from "@app/lib/actions/types";
-import {
-  actionRefsOffset,
-  NOTION_SEARCH_ACTION_NUM_RESULTS,
-} from "@app/lib/actions/utils";
+import { NOTION_SEARCH_ACTION_NUM_RESULTS } from "@app/lib/actions/utils";
 import { getRefs } from "@app/lib/api/assistant/citations";
 import type { InternalMCPServerDefinitionType } from "@app/lib/api/mcp";
 import type { Authenticator } from "@app/lib/auth";
@@ -369,9 +366,10 @@ const createServer = (
           ],
         };
       } else {
-        const refsOffset = agentLoopContext.runContext.stepContext.citationsOffsets.get(
-          agentLoopContext.runContext.stepActionIndex
-        ) ?? 0;
+        const refsOffset =
+          agentLoopContext.runContext.stepContext.citationsOffsets.get(
+            agentLoopContext.runContext.stepActionIndex
+          ) ?? 0;
 
         const refs = getRefs().slice(
           refsOffset,

--- a/front/lib/actions/mcp_internal_actions/servers/notion.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/notion.ts
@@ -369,12 +369,9 @@ const createServer = (
           ],
         };
       } else {
-        const refsOffset = actionRefsOffset({
-          agentConfiguration: agentLoopContext.runContext.agentConfiguration,
-          stepActionIndex: agentLoopContext.runContext.stepActionIndex,
-          stepActions: agentLoopContext.runContext.stepActions,
-          refsOffset: agentLoopContext.runContext.citationsRefsOffset,
-        });
+        const refsOffset = agentLoopContext.runContext.stepContext.citationsOffsets.get(
+          agentLoopContext.runContext.stepActionIndex
+        ) ?? 0;
 
         const refs = getRefs().slice(
           refsOffset,

--- a/front/lib/actions/mcp_internal_actions/servers/search.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/search.ts
@@ -22,7 +22,6 @@ import { shouldAutoGenerateTags } from "@app/lib/actions/mcp_internal_actions/se
 import { makeMCPToolTextError } from "@app/lib/actions/mcp_internal_actions/utils";
 import { withToolLogging } from "@app/lib/actions/mcp_internal_actions/wrappers";
 import type { AgentLoopContextType } from "@app/lib/actions/types";
-import { actionRefsOffset, getRetrievalTopK } from "@app/lib/actions/utils";
 import { getRefs } from "@app/lib/api/assistant/citations";
 import config from "@app/lib/api/config";
 import type { InternalMCPServerDefinitionType } from "@app/lib/api/mcp";
@@ -77,9 +76,10 @@ export async function searchFunction({
 
   // Get the topK and refsOffset from pre-computed step context.
   const topK = agentLoopContext.runContext.stepContext.retrievalTopK;
-  const refsOffset = agentLoopContext.runContext.stepContext.citationsOffsets.get(
-    agentLoopContext.runContext.stepActionIndex
-  ) ?? 0;
+  const refsOffset =
+    agentLoopContext.runContext.stepContext.citationsOffsets.get(
+      agentLoopContext.runContext.stepActionIndex
+    ) ?? 0;
 
   // Get the core search args for each data source, fail if any of them are invalid.
   const coreSearchArgsResults = await concurrentExecutor(

--- a/front/lib/actions/mcp_internal_actions/servers/search.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/search.ts
@@ -75,17 +75,11 @@ export async function searchFunction({
     );
   }
 
-  // Compute the topK and refsOffset for the search.
-  const topK = getRetrievalTopK({
-    agentConfiguration: agentLoopContext.runContext.agentConfiguration,
-    stepActions: agentLoopContext.runContext.stepActions,
-  });
-  const refsOffset = actionRefsOffset({
-    agentConfiguration: agentLoopContext.runContext.agentConfiguration,
-    stepActionIndex: agentLoopContext.runContext.stepActionIndex,
-    stepActions: agentLoopContext.runContext.stepActions,
-    refsOffset: agentLoopContext.runContext.citationsRefsOffset,
-  });
+  // Get the topK and refsOffset from pre-computed step context.
+  const topK = agentLoopContext.runContext.stepContext.retrievalTopK;
+  const refsOffset = agentLoopContext.runContext.stepContext.citationsOffsets.get(
+    agentLoopContext.runContext.stepActionIndex
+  ) ?? 0;
 
   // Get the core search args for each data source, fail if any of them are invalid.
   const coreSearchArgsResults = await concurrentExecutor(

--- a/front/lib/actions/mcp_internal_actions/servers/search.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/search.ts
@@ -76,10 +76,7 @@ export async function searchFunction({
 
   // Get the topK and refsOffset from pre-computed step context.
   const topK = agentLoopContext.runContext.stepContext.retrievalTopK;
-  const refsOffset =
-    agentLoopContext.runContext.stepContext.citationsOffsets.get(
-      agentLoopContext.runContext.stepActionIndex
-    ) ?? 0;
+  const refsOffset = agentLoopContext.runContext.stepContext.citationsOffset;
 
   // Get the core search args for each data source, fail if any of them are invalid.
   const coreSearchArgsResults = await concurrentExecutor(

--- a/front/lib/actions/mcp_internal_actions/servers/slack.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/slack.ts
@@ -17,10 +17,7 @@ import {
   makeMCPToolTextError,
 } from "@app/lib/actions/mcp_internal_actions/utils";
 import type { AgentLoopContextType } from "@app/lib/actions/types";
-import {
-  actionRefsOffset,
-  SLACK_SEARCH_ACTION_NUM_RESULTS,
-} from "@app/lib/actions/utils";
+import { SLACK_SEARCH_ACTION_NUM_RESULTS } from "@app/lib/actions/utils";
 import { getRefs } from "@app/lib/api/assistant/citations";
 import config from "@app/lib/api/config";
 import type { InternalMCPServerDefinitionType } from "@app/lib/api/mcp";
@@ -269,9 +266,10 @@ const createServer = (
             ],
           };
         } else {
-          const refsOffset = agentLoopContext.runContext.stepContext.citationsOffsets.get(
-            agentLoopContext.runContext.stepActionIndex
-          ) ?? 0;
+          const refsOffset =
+            agentLoopContext.runContext.stepContext.citationsOffsets.get(
+              agentLoopContext.runContext.stepActionIndex
+            ) ?? 0;
 
           const refs = getRefs().slice(
             refsOffset,
@@ -398,9 +396,10 @@ const createServer = (
             ],
           };
         } else {
-          const refsOffset = agentLoopContext.runContext.stepContext.citationsOffsets.get(
-            agentLoopContext.runContext.stepActionIndex
-          ) ?? 0;
+          const refsOffset =
+            agentLoopContext.runContext.stepContext.citationsOffsets.get(
+              agentLoopContext.runContext.stepActionIndex
+            ) ?? 0;
 
           const refs = getRefs().slice(
             refsOffset,

--- a/front/lib/actions/mcp_internal_actions/servers/slack.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/slack.ts
@@ -269,12 +269,9 @@ const createServer = (
             ],
           };
         } else {
-          const refsOffset = actionRefsOffset({
-            agentConfiguration: agentLoopContext.runContext.agentConfiguration,
-            stepActionIndex: agentLoopContext.runContext.stepActionIndex,
-            stepActions: agentLoopContext.runContext.stepActions,
-            refsOffset: agentLoopContext.runContext.citationsRefsOffset,
-          });
+          const refsOffset = agentLoopContext.runContext.stepContext.citationsOffsets.get(
+            agentLoopContext.runContext.stepActionIndex
+          ) ?? 0;
 
           const refs = getRefs().slice(
             refsOffset,
@@ -401,12 +398,9 @@ const createServer = (
             ],
           };
         } else {
-          const refsOffset = actionRefsOffset({
-            agentConfiguration: agentLoopContext.runContext.agentConfiguration,
-            stepActionIndex: agentLoopContext.runContext.stepActionIndex,
-            stepActions: agentLoopContext.runContext.stepActions,
-            refsOffset: agentLoopContext.runContext.citationsRefsOffset,
-          });
+          const refsOffset = agentLoopContext.runContext.stepContext.citationsOffsets.get(
+            agentLoopContext.runContext.stepActionIndex
+          ) ?? 0;
 
           const refs = getRefs().slice(
             refsOffset,

--- a/front/lib/actions/mcp_internal_actions/servers/slack.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/slack.ts
@@ -266,12 +266,11 @@ const createServer = (
             ],
           };
         } else {
-          const refsOffset =
-            agentLoopContext.runContext.stepContext.citationsOffset;
+          const { citationsOffset } = agentLoopContext.runContext.stepContext;
 
           const refs = getRefs().slice(
-            refsOffset,
-            refsOffset + SLACK_SEARCH_ACTION_NUM_RESULTS
+            citationsOffset,
+            citationsOffset + SLACK_SEARCH_ACTION_NUM_RESULTS
           );
 
           const results: SearchResultResourceType[] = matches.map(
@@ -394,12 +393,11 @@ const createServer = (
             ],
           };
         } else {
-          const refsOffset =
-            agentLoopContext.runContext.stepContext.citationsOffset;
+          const { citationsOffset } = agentLoopContext.runContext.stepContext;
 
           const refs = getRefs().slice(
-            refsOffset,
-            refsOffset + SLACK_SEARCH_ACTION_NUM_RESULTS
+            citationsOffset,
+            citationsOffset + SLACK_SEARCH_ACTION_NUM_RESULTS
           );
 
           const results: SearchResultResourceType[] = matches.map(

--- a/front/lib/actions/mcp_internal_actions/servers/slack.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/slack.ts
@@ -267,9 +267,7 @@ const createServer = (
           };
         } else {
           const refsOffset =
-            agentLoopContext.runContext.stepContext.citationsOffsets.get(
-              agentLoopContext.runContext.stepActionIndex
-            ) ?? 0;
+            agentLoopContext.runContext.stepContext.citationsOffset;
 
           const refs = getRefs().slice(
             refsOffset,
@@ -397,9 +395,7 @@ const createServer = (
           };
         } else {
           const refsOffset =
-            agentLoopContext.runContext.stepContext.citationsOffsets.get(
-              agentLoopContext.runContext.stepActionIndex
-            ) ?? 0;
+            agentLoopContext.runContext.stepContext.citationsOffset;
 
           const refs = getRefs().slice(
             refsOffset,

--- a/front/lib/actions/mcp_internal_actions/servers/webtools.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/webtools.ts
@@ -65,9 +65,7 @@ const createServer = (agentLoopContext?: AgentLoopContextType): McpServer => {
 
       const agentLoopRunContext = agentLoopContext.runContext;
 
-      const numResults = getWebsearchNumResults({
-        stepActions: agentLoopRunContext.stepActions,
-      });
+      const numResults = agentLoopRunContext.stepContext.websearchResultCount;
 
       const websearchRes = await webSearch({
         provider: "serpapi",
@@ -82,12 +80,9 @@ const createServer = (agentLoopContext?: AgentLoopContextType): McpServer => {
         );
       }
 
-      const refsOffset = actionRefsOffset({
-        agentConfiguration: agentLoopRunContext.agentConfiguration,
-        stepActionIndex: agentLoopRunContext.stepActionIndex,
-        stepActions: agentLoopRunContext.stepActions,
-        refsOffset: agentLoopRunContext.citationsRefsOffset,
-      });
+      const refsOffset = agentLoopRunContext.stepContext.citationsOffsets.get(
+        agentLoopRunContext.stepActionIndex
+      ) ?? 0;
       const refs = getRefs().slice(refsOffset, refsOffset + numResults);
 
       const results: WebsearchResultResourceType[] = [];

--- a/front/lib/actions/mcp_internal_actions/servers/webtools.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/webtools.ts
@@ -40,8 +40,8 @@ const createServer = (agentLoopContext?: AgentLoopContextType): McpServer => {
       query: z
         .string()
         .describe(
-          "The query used to perform the google search. If requested by the " +
-            "user, use the google syntax `site:` to restrict the the search " +
+          "The query used to perform the Google search. If requested by the " +
+            "user, use the Google syntax `site:` to restrict the search " +
             "to a particular website or domain. " +
             "Unicode characters are not supported."
         ),
@@ -50,7 +50,7 @@ const createServer = (agentLoopContext?: AgentLoopContextType): McpServer => {
         .optional()
         .describe(
           "A 1-indexed page number used to paginate through the search results." +
-            " Should only be provided if page is stricly greater than 1 in order" +
+            " Should only be provided if the page is strictly greater than 1 in order" +
             " to go deeper into the search results for a specific query."
         ),
     },

--- a/front/lib/actions/mcp_internal_actions/servers/webtools.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/webtools.ts
@@ -63,13 +63,14 @@ const createServer = (agentLoopContext?: AgentLoopContextType): McpServer => {
 
       const agentLoopRunContext = agentLoopContext.runContext;
 
-      const numResults = agentLoopRunContext.stepContext.websearchResultCount;
+      const { websearchResultCount, citationsOffset } =
+        agentLoopRunContext.stepContext;
 
       const websearchRes = await webSearch({
         provider: "serpapi",
         query,
         page,
-        num: numResults,
+        num: websearchResultCount,
       });
 
       if (websearchRes.isErr()) {
@@ -78,8 +79,10 @@ const createServer = (agentLoopContext?: AgentLoopContextType): McpServer => {
         );
       }
 
-      const refsOffset = agentLoopRunContext.stepContext.citationsOffset;
-      const refs = getRefs().slice(refsOffset, refsOffset + numResults);
+      const refs = getRefs().slice(
+        citationsOffset,
+        citationsOffset + websearchResultCount
+      );
 
       const results: WebsearchResultResourceType[] = [];
       for (const result of websearchRes.value) {

--- a/front/lib/actions/mcp_internal_actions/servers/webtools.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/webtools.ts
@@ -12,8 +12,6 @@ import type {
 } from "@app/lib/actions/mcp_internal_actions/output_schemas";
 import { makeMCPToolTextError } from "@app/lib/actions/mcp_internal_actions/utils";
 import type { AgentLoopContextType } from "@app/lib/actions/types";
-import { actionRefsOffset } from "@app/lib/actions/utils";
-import { getWebsearchNumResults } from "@app/lib/actions/utils";
 import { getRefs } from "@app/lib/api/assistant/citations";
 import type { InternalMCPServerDefinitionType } from "@app/lib/api/mcp";
 import {
@@ -80,9 +78,10 @@ const createServer = (agentLoopContext?: AgentLoopContextType): McpServer => {
         );
       }
 
-      const refsOffset = agentLoopRunContext.stepContext.citationsOffsets.get(
-        agentLoopRunContext.stepActionIndex
-      ) ?? 0;
+      const refsOffset =
+        agentLoopRunContext.stepContext.citationsOffsets.get(
+          agentLoopRunContext.stepActionIndex
+        ) ?? 0;
       const refs = getRefs().slice(refsOffset, refsOffset + numResults);
 
       const results: WebsearchResultResourceType[] = [];

--- a/front/lib/actions/mcp_internal_actions/servers/webtools.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/webtools.ts
@@ -78,10 +78,7 @@ const createServer = (agentLoopContext?: AgentLoopContextType): McpServer => {
         );
       }
 
-      const refsOffset =
-        agentLoopRunContext.stepContext.citationsOffsets.get(
-          agentLoopRunContext.stepActionIndex
-        ) ?? 0;
+      const refsOffset = agentLoopRunContext.stepContext.citationsOffset;
       const refs = getRefs().slice(refsOffset, refsOffset + numResults);
 
       const results: WebsearchResultResourceType[] = [];

--- a/front/lib/actions/types/index.ts
+++ b/front/lib/actions/types/index.ts
@@ -3,13 +3,18 @@ import type {
   MCPServerConfigurationType,
   MCPToolConfigurationType,
 } from "@app/lib/actions/mcp";
-import type { StepContext } from "@app/lib/actions/utils";
 import type {
   AgentConfigurationType,
   AgentMessageType,
   AllSupportedFileContentType,
   ConversationType,
 } from "@app/types";
+
+export type StepContext = {
+  retrievalTopK: number;
+  citationsOffset: number;
+  websearchResultCount: number;
+};
 
 export type ActionGeneratedFileType = {
   fileId: string;

--- a/front/lib/actions/types/index.ts
+++ b/front/lib/actions/types/index.ts
@@ -4,6 +4,8 @@ import type {
   MCPToolConfigurationType,
 } from "@app/lib/actions/mcp";
 import type { ActionConfigurationType } from "@app/lib/actions/types/agent";
+import type { StepContext } from "@app/lib/actions/utils";
+import type { Authenticator } from "@app/lib/auth";
 import type {
   AgentConfigurationType,
   AgentMessageType,
@@ -25,8 +27,7 @@ export type AgentLoopRunContextType = {
   conversation: ConversationType;
   agentMessage: AgentMessageType;
   stepActionIndex: number;
-  stepActions: ActionConfigurationType[];
-  citationsRefsOffset: number;
+  stepContext: StepContext;
 };
 
 export type AgentLoopListToolsContextType = {

--- a/front/lib/actions/types/index.ts
+++ b/front/lib/actions/types/index.ts
@@ -3,9 +3,7 @@ import type {
   MCPServerConfigurationType,
   MCPToolConfigurationType,
 } from "@app/lib/actions/mcp";
-import type { ActionConfigurationType } from "@app/lib/actions/types/agent";
 import type { StepContext } from "@app/lib/actions/utils";
-import type { Authenticator } from "@app/lib/auth";
 import type {
   AgentConfigurationType,
   AgentMessageType,

--- a/front/lib/actions/types/index.ts
+++ b/front/lib/actions/types/index.ts
@@ -13,6 +13,7 @@ import type {
 export type StepContext = {
   retrievalTopK: number;
   citationsOffset: number;
+  citationsCount: number;
   websearchResultCount: number;
 };
 

--- a/front/lib/actions/types/index.ts
+++ b/front/lib/actions/types/index.ts
@@ -24,7 +24,6 @@ export type AgentLoopRunContextType = {
   clientSideActionConfigurations?: ClientSideMCPServerConfigurationType[];
   conversation: ConversationType;
   agentMessage: AgentMessageType;
-  stepActionIndex: number;
   stepContext: StepContext;
 };
 

--- a/front/lib/actions/utils.ts
+++ b/front/lib/actions/utils.ts
@@ -29,7 +29,7 @@ export const NOTION_SEARCH_ACTION_NUM_RESULTS = 16;
 
 export type StepContext = {
   retrievalTopK: number;
-  citationsOffsets: Map<number, number>;
+  citationsOffset: number;
   websearchResultCount: number;
 };
 
@@ -242,7 +242,7 @@ export function computeStepContext({
   agentConfiguration: AgentConfigurationType;
   stepActions: ActionConfigurationType[];
   citationsRefsOffset: number;
-}): { stepContext: StepContext; totalCitationsIncrement: number } {
+}): { stepContexts: StepContext[]; totalCitationsIncrement: number } {
   const retrievalTopK = getRetrievalTopK({
     agentConfiguration,
     stepActions,
@@ -252,8 +252,7 @@ export function computeStepContext({
     stepActions,
   });
 
-  const citationsOffsets = new Map<number, number>();
-
+  const stepContexts: StepContext[] = [];
   let currentOffset = citationsRefsOffset;
 
   for (let i = 0; i < stepActions.length; i++) {
@@ -263,16 +262,17 @@ export function computeStepContext({
       stepActionIndex: i,
     });
 
-    citationsOffsets.set(i, currentOffset);
+    stepContexts.push({
+      retrievalTopK,
+      citationsOffset: currentOffset,
+      websearchResultCount: websearchResults,
+    });
+
     currentOffset += citationCount;
   }
 
   return {
-    stepContext: {
-      retrievalTopK,
-      citationsOffsets,
-      websearchResultCount: websearchResults,
-    },
+    stepContexts,
     totalCitationsIncrement: currentOffset - citationsRefsOffset,
   };
 }

--- a/front/lib/actions/utils.ts
+++ b/front/lib/actions/utils.ts
@@ -204,7 +204,7 @@ export function computeStepContexts({
   agentConfiguration: AgentConfigurationType;
   stepActions: ActionConfigurationType[];
   citationsRefsOffset: number;
-}): { stepContexts: StepContext[]; totalCitationsIncrement: number } {
+}): StepContext[] {
   const retrievalTopK = getRetrievalTopK({
     agentConfiguration,
     stepActions,
@@ -218,7 +218,7 @@ export function computeStepContexts({
   let currentOffset = citationsRefsOffset;
 
   for (let i = 0; i < stepActions.length; i++) {
-    const citationCount = getCitationsCount({
+    const citationsCount = getCitationsCount({
       agentConfiguration,
       stepActions,
       stepActionIndex: i,
@@ -227,16 +227,14 @@ export function computeStepContexts({
     stepContexts.push({
       retrievalTopK,
       citationsOffset: currentOffset,
+      citationsCount,
       websearchResultCount: websearchResults,
     });
 
-    currentOffset += citationCount;
+    currentOffset += citationsCount;
   }
 
-  return {
-    stepContexts,
-    totalCitationsIncrement: currentOffset - citationsRefsOffset,
-  };
+  return stepContexts;
 }
 
 export function getMCPApprovalKey({

--- a/front/lib/actions/utils.ts
+++ b/front/lib/actions/utils.ts
@@ -9,6 +9,7 @@ import {
 import type { ActionSpecification } from "@app/components/assistant_builder/types";
 import type { MCPToolStakeLevelType } from "@app/lib/actions/constants";
 import type { MCPToolConfigurationType } from "@app/lib/actions/mcp";
+import type { StepContext } from "@app/lib/actions/types";
 import type { ActionConfigurationType } from "@app/lib/actions/types/agent";
 import {
   isMCPInternalDataSourceFileSystem,
@@ -26,12 +27,6 @@ import { assertNever } from "@app/types";
 export const WEBSEARCH_ACTION_NUM_RESULTS = 16;
 export const SLACK_SEARCH_ACTION_NUM_RESULTS = 24;
 export const NOTION_SEARCH_ACTION_NUM_RESULTS = 16;
-
-export type StepContext = {
-  retrievalTopK: number;
-  citationsOffset: number;
-  websearchResultCount: number;
-};
 
 export const MCP_SPECIFICATION: ActionSpecification = {
   label: "More...",

--- a/front/lib/actions/utils.ts
+++ b/front/lib/actions/utils.ts
@@ -201,7 +201,7 @@ export function getCitationsCount({
   });
 }
 
-export function computeStepContext({
+export function computeStepContexts({
   agentConfiguration,
   stepActions,
   citationsRefsOffset,

--- a/front/lib/actions/utils.ts
+++ b/front/lib/actions/utils.ts
@@ -201,39 +201,6 @@ export function getCitationsCount({
   });
 }
 
-/**
- * This is shared across action runners and used to compute the local step refsOffset (the current
- * refsOffset for the agent actions up to the current step (`refsOffset`) to which we add the
- * actions that comes before the current action in the current step).
- *
- * @param agentConfiguration The agent configuration.
- * @param stepActionIndex The index of the current action in the current step.
- * @param stepActions The actions in the current step.
- * @param refsOffset The current refsOffset up to the current step.
- * @returns The updated refsOffset for the action at stepActionIndex.
- */
-export function actionRefsOffset({
-  agentConfiguration,
-  stepActionIndex,
-  stepActions,
-  refsOffset,
-}: {
-  agentConfiguration: AgentConfigurationType;
-  stepActionIndex: number;
-  stepActions: ActionConfigurationType[];
-  refsOffset: number;
-}): number {
-  for (let i = 0; i < stepActionIndex; i++) {
-    refsOffset += getCitationsCount({
-      agentConfiguration,
-      stepActions,
-      stepActionIndex: i,
-    });
-  }
-
-  return refsOffset;
-}
-
 export function computeStepContext({
   agentConfiguration,
   stepActions,

--- a/front/temporal/agent_loop/activities/run_model.ts
+++ b/front/temporal/agent_loop/activities/run_model.ts
@@ -1,11 +1,11 @@
 import { removeNulls } from "@dust-tt/client";
 
+import { buildToolSpecification } from "@app/lib/actions/mcp";
 import {
   TOOL_NAME_SEPARATOR,
   tryListMCPTools,
 } from "@app/lib/actions/mcp_actions";
 import type { InternalMCPServerNameType } from "@app/lib/actions/mcp_internal_actions/constants";
-import { buildToolSpecification } from "@app/lib/actions/mcp";
 import {
   isDustAppChatBlockType,
   runActionStreamed,
@@ -15,8 +15,8 @@ import type {
   AgentActionSpecification,
 } from "@app/lib/actions/types/agent";
 import { isActionConfigurationType } from "@app/lib/actions/types/agent";
-import { computeStepContext } from "@app/lib/actions/utils";
 import type { StepContext } from "@app/lib/actions/utils";
+import { computeStepContext } from "@app/lib/actions/utils";
 import { createClientSideMCPServerConfigurations } from "@app/lib/api/actions/mcp_client_side";
 import { categorizeAgentErrorMessage } from "@app/lib/api/assistant/agent_errors";
 import {
@@ -79,7 +79,7 @@ export async function runModelActivity({
   actions: AgentActionsEvent["actions"];
   runId: string;
   functionCallStepContentIds: Record<string, ModelId>;
-  stepContext: StepContext;
+  stepContexts: StepContext[];
   totalCitationsIncrement: number;
 } | null> {
   const runAgentDataRes = await getRunAgentData(authType, runAgentArgs);
@@ -855,7 +855,7 @@ export async function runModelActivity({
   }));
   agentMessage.contents.push(...newContents);
 
-  const { stepContext, totalCitationsIncrement } = computeStepContext({
+  const { stepContexts, totalCitationsIncrement } = computeStepContext({
     agentConfiguration,
     stepActions: actions.map((a) => a.action),
     citationsRefsOffset,
@@ -865,7 +865,7 @@ export async function runModelActivity({
     actions,
     runId: await dustRunId,
     functionCallStepContentIds: updatedFunctionCallStepContentIds,
-    stepContext,
+    stepContexts,
     totalCitationsIncrement,
   };
 }

--- a/front/temporal/agent_loop/activities/run_model.ts
+++ b/front/temporal/agent_loop/activities/run_model.ts
@@ -80,7 +80,6 @@ export async function runModelActivity({
   runId: string;
   functionCallStepContentIds: Record<string, ModelId>;
   stepContexts: StepContext[];
-  totalCitationsIncrement: number;
 } | null> {
   const runAgentDataRes = await getRunAgentData(authType, runAgentArgs);
   if (runAgentDataRes.isErr()) {
@@ -855,7 +854,7 @@ export async function runModelActivity({
   }));
   agentMessage.contents.push(...newContents);
 
-  const { stepContexts, totalCitationsIncrement } = computeStepContexts({
+  const stepContexts = computeStepContexts({
     agentConfiguration,
     stepActions: actions.map((a) => a.action),
     citationsRefsOffset,
@@ -866,6 +865,5 @@ export async function runModelActivity({
     runId: await dustRunId,
     functionCallStepContentIds: updatedFunctionCallStepContentIds,
     stepContexts,
-    totalCitationsIncrement,
   };
 }

--- a/front/temporal/agent_loop/activities/run_model.ts
+++ b/front/temporal/agent_loop/activities/run_model.ts
@@ -855,18 +855,11 @@ export async function runModelActivity({
   }));
   agentMessage.contents.push(...newContents);
 
-  // Compute StepContext for the actions that will be executed
-  const stepContext = computeStepContext({
+  const { stepContext, totalCitationsIncrement } = computeStepContext({
     agentConfiguration,
-    stepActions: actions.map(a => a.action),
+    stepActions: actions.map((a) => a.action),
     citationsRefsOffset,
   });
-
-  // Calculate total citations increment for this step
-  const totalCitationsIncrement = Array.from(stepContext.citationsAllocation.values()).reduce(
-    (acc, curr) => acc + curr,
-    0
-  );
 
   return {
     actions,

--- a/front/temporal/agent_loop/activities/run_model.ts
+++ b/front/temporal/agent_loop/activities/run_model.ts
@@ -10,12 +10,12 @@ import {
   isDustAppChatBlockType,
   runActionStreamed,
 } from "@app/lib/actions/server";
+import type { StepContext } from "@app/lib/actions/types";
 import type {
   ActionConfigurationType,
   AgentActionSpecification,
 } from "@app/lib/actions/types/agent";
 import { isActionConfigurationType } from "@app/lib/actions/types/agent";
-import type { StepContext } from "@app/lib/actions/utils";
 import { computeStepContext } from "@app/lib/actions/utils";
 import { createClientSideMCPServerConfigurations } from "@app/lib/api/actions/mcp_client_side";
 import { categorizeAgentErrorMessage } from "@app/lib/api/assistant/agent_errors";

--- a/front/temporal/agent_loop/activities/run_model.ts
+++ b/front/temporal/agent_loop/activities/run_model.ts
@@ -16,7 +16,7 @@ import type {
   AgentActionSpecification,
 } from "@app/lib/actions/types/agent";
 import { isActionConfigurationType } from "@app/lib/actions/types/agent";
-import { computeStepContext } from "@app/lib/actions/utils";
+import { computeStepContexts } from "@app/lib/actions/utils";
 import { createClientSideMCPServerConfigurations } from "@app/lib/api/actions/mcp_client_side";
 import { categorizeAgentErrorMessage } from "@app/lib/api/assistant/agent_errors";
 import {
@@ -855,7 +855,7 @@ export async function runModelActivity({
   }));
   agentMessage.contents.push(...newContents);
 
-  const { stepContexts, totalCitationsIncrement } = computeStepContext({
+  const { stepContexts, totalCitationsIncrement } = computeStepContexts({
     agentConfiguration,
     stepActions: actions.map((a) => a.action),
     citationsRefsOffset,

--- a/front/temporal/agent_loop/activities/run_tool.ts
+++ b/front/temporal/agent_loop/activities/run_tool.ts
@@ -16,7 +16,6 @@ export async function runToolActivity(
     inputs,
     functionCallId,
     step,
-    stepActionIndex,
     action,
     stepContext,
     stepContentId,
@@ -25,7 +24,6 @@ export async function runToolActivity(
     inputs: Record<string, string | boolean | number>;
     functionCallId: string;
     step: number;
-    stepActionIndex: number;
     action: ActionConfigurationType;
     stepContext: StepContext;
     stepContentId: ModelId;
@@ -48,7 +46,6 @@ export async function runToolActivity(
     rawInputs: inputs,
     functionCallId,
     step,
-    stepActionIndex,
     stepContext,
     stepContentId,
   });

--- a/front/temporal/agent_loop/activities/run_tool.ts
+++ b/front/temporal/agent_loop/activities/run_tool.ts
@@ -17,6 +17,7 @@ export async function runToolActivity(
     functionCallId,
     step,
     stepActionIndex,
+    action,
     stepActions,
     citationsRefsOffset,
     stepContentId,
@@ -26,6 +27,7 @@ export async function runToolActivity(
     functionCallId: string;
     step: number;
     stepActionIndex: number;
+    action: ActionConfigurationType;
     stepActions: ActionConfigurationType[];
     citationsRefsOffset: number;
     stepContentId: ModelId;
@@ -33,7 +35,6 @@ export async function runToolActivity(
 ): Promise<{ citationsIncrement: number }> {
   const auth = await Authenticator.fromJSON(authType);
 
-  const actionConfiguration = stepActions[stepActionIndex];
   const runAgentDataRes = await getRunAgentData(authType, runAgentArgs);
   if (runAgentDataRes.isErr()) {
     throw runAgentDataRes.error;
@@ -42,7 +43,7 @@ export async function runToolActivity(
   const { agentConfiguration, conversation, agentMessage, agentMessageRow } =
     runAgentDataRes.value;
 
-  const eventStream = runToolWithStreaming(auth, actionConfiguration, {
+  const eventStream = runToolWithStreaming(auth, action, {
     agentConfiguration: agentConfiguration,
     conversation,
     agentMessage,

--- a/front/temporal/agent_loop/activities/run_tool.ts
+++ b/front/temporal/agent_loop/activities/run_tool.ts
@@ -1,6 +1,6 @@
 import { runToolWithStreaming } from "@app/lib/actions/mcp";
 import type { ActionConfigurationType } from "@app/lib/actions/types/agent";
-import { getCitationsCount } from "@app/lib/actions/utils";
+import type { StepContext } from "@app/lib/actions/utils";
 import type { AuthenticatorType } from "@app/lib/auth";
 import { Authenticator } from "@app/lib/auth";
 import { updateResourceAndPublishEvent } from "@app/temporal/agent_loop/activities/common";
@@ -18,8 +18,7 @@ export async function runToolActivity(
     step,
     stepActionIndex,
     action,
-    stepActions,
-    citationsRefsOffset,
+    stepContext,
     stepContentId,
   }: {
     runAgentArgs: RunAgentArgs;
@@ -28,11 +27,10 @@ export async function runToolActivity(
     step: number;
     stepActionIndex: number;
     action: ActionConfigurationType;
-    stepActions: ActionConfigurationType[];
-    citationsRefsOffset: number;
+    stepContext: StepContext;
     stepContentId: ModelId;
   }
-): Promise<{ citationsIncrement: number }> {
+): Promise<void> {
   const auth = await Authenticator.fromJSON(authType);
 
   const runAgentDataRes = await getRunAgentData(authType, runAgentArgs);
@@ -51,8 +49,7 @@ export async function runToolActivity(
     functionCallId,
     step,
     stepActionIndex,
-    stepActions,
-    citationsRefsOffset,
+    stepContext,
     stepContentId,
   });
 
@@ -75,7 +72,7 @@ export async function runToolActivity(
           agentMessageRow,
           step
         );
-        return { citationsIncrement: 0 };
+        return;
 
       case "tool_success":
         await updateResourceAndPublishEvent(
@@ -111,12 +108,4 @@ export async function runToolActivity(
         assertNever(event);
     }
   }
-
-  return {
-    citationsIncrement: getCitationsCount({
-      agentConfiguration: agentConfiguration,
-      stepActions: stepActions,
-      stepActionIndex: stepActionIndex,
-    }),
-  };
 }

--- a/front/temporal/agent_loop/activities/run_tool.ts
+++ b/front/temporal/agent_loop/activities/run_tool.ts
@@ -1,6 +1,6 @@
 import { runToolWithStreaming } from "@app/lib/actions/mcp";
+import type { StepContext } from "@app/lib/actions/types";
 import type { ActionConfigurationType } from "@app/lib/actions/types/agent";
-import type { StepContext } from "@app/lib/actions/utils";
 import type { AuthenticatorType } from "@app/lib/auth";
 import { Authenticator } from "@app/lib/auth";
 import { updateResourceAndPublishEvent } from "@app/temporal/agent_loop/activities/common";

--- a/front/temporal/agent_loop/lib/activity_interface.ts
+++ b/front/temporal/agent_loop/lib/activity_interface.ts
@@ -26,6 +26,7 @@ export interface AgentLoopActivities {
       functionCallId: string;
       step: number;
       stepActionIndex: number;
+      action: ActionConfigurationType;
       stepActions: ActionConfigurationType[];
       citationsRefsOffset: number;
       stepContentId: ModelId;

--- a/front/temporal/agent_loop/lib/activity_interface.ts
+++ b/front/temporal/agent_loop/lib/activity_interface.ts
@@ -18,7 +18,7 @@ export interface AgentLoopActivities {
     actions: AgentActionsEvent["actions"];
     runId: string;
     functionCallStepContentIds: Record<string, ModelId>;
-    stepContext: StepContext;
+    stepContexts: StepContext[];
     totalCitationsIncrement: number;
   } | null>;
 

--- a/front/temporal/agent_loop/lib/activity_interface.ts
+++ b/front/temporal/agent_loop/lib/activity_interface.ts
@@ -29,7 +29,6 @@ export interface AgentLoopActivities {
       inputs: Record<string, string | boolean | number>;
       functionCallId: string;
       step: number;
-      stepActionIndex: number;
       action: ActionConfigurationType;
       stepContext: StepContext;
       stepContentId: ModelId;

--- a/front/temporal/agent_loop/lib/activity_interface.ts
+++ b/front/temporal/agent_loop/lib/activity_interface.ts
@@ -1,5 +1,5 @@
+import type { StepContext } from "@app/lib/actions/types";
 import type { ActionConfigurationType } from "@app/lib/actions/types/agent";
-import type { StepContext } from "@app/lib/actions/utils";
 import type { AuthenticatorType } from "@app/lib/auth";
 import type { ModelId } from "@app/types";
 import type { AgentActionsEvent } from "@app/types/assistant/agent";

--- a/front/temporal/agent_loop/lib/activity_interface.ts
+++ b/front/temporal/agent_loop/lib/activity_interface.ts
@@ -19,7 +19,6 @@ export interface AgentLoopActivities {
     runId: string;
     functionCallStepContentIds: Record<string, ModelId>;
     stepContexts: StepContext[];
-    totalCitationsIncrement: number;
   } | null>;
 
   runToolActivity(

--- a/front/temporal/agent_loop/lib/activity_interface.ts
+++ b/front/temporal/agent_loop/lib/activity_interface.ts
@@ -1,4 +1,5 @@
 import type { ActionConfigurationType } from "@app/lib/actions/types/agent";
+import type { StepContext } from "@app/lib/actions/utils";
 import type { AuthenticatorType } from "@app/lib/auth";
 import type { ModelId } from "@app/types";
 import type { AgentActionsEvent } from "@app/types/assistant/agent";
@@ -11,11 +12,14 @@ export interface AgentLoopActivities {
     runIds: string[];
     step: number;
     functionCallStepContentIds: Record<string, ModelId>;
+    citationsRefsOffset: number;
     autoRetryCount?: number;
   }): Promise<{
     actions: AgentActionsEvent["actions"];
     runId: string;
     functionCallStepContentIds: Record<string, ModelId>;
+    stepContext: StepContext;
+    totalCitationsIncrement: number;
   } | null>;
 
   runToolActivity(
@@ -27,9 +31,8 @@ export interface AgentLoopActivities {
       step: number;
       stepActionIndex: number;
       action: ActionConfigurationType;
-      stepActions: ActionConfigurationType[];
-      citationsRefsOffset: number;
+      stepContext: StepContext;
       stepContentId: ModelId;
     }
-  ): Promise<{ citationsIncrement: number }>;
+  ): Promise<void>;
 }

--- a/front/temporal/agent_loop/lib/agent_loop_executor.ts
+++ b/front/temporal/agent_loop/lib/agent_loop_executor.ts
@@ -43,7 +43,7 @@ export async function executeAgentLoop(
       return;
     }
 
-    const { runId, stepContexts, totalCitationsIncrement } = result;
+    const { runId, stepContexts } = result;
 
     // Update state with results from runMultiActionsAgent.
     runIds.push(runId);
@@ -69,6 +69,9 @@ export async function executeAgentLoop(
     );
 
     // Update citations offset with pre-computed increment
-    citationsRefsOffset += totalCitationsIncrement;
+    citationsRefsOffset += stepContexts.reduce(
+      (acc, context) => acc + context.citationsCount,
+      0
+    );
   }
 }

--- a/front/temporal/agent_loop/lib/agent_loop_executor.ts
+++ b/front/temporal/agent_loop/lib/agent_loop_executor.ts
@@ -61,7 +61,6 @@ export async function executeAgentLoop(
           inputs,
           functionCallId,
           step: i,
-          stepActionIndex: index,
           action,
           stepContext: stepContexts[index],
           stepContentId: functionCallStepContentIds[functionCallId],

--- a/front/temporal/agent_loop/lib/agent_loop_executor.ts
+++ b/front/temporal/agent_loop/lib/agent_loop_executor.ts
@@ -52,13 +52,14 @@ export async function executeAgentLoop(
     const actionsToRun = result.actions.slice(0, MAX_ACTIONS_PER_STEP);
 
     const citationsIncrements = await Promise.all(
-      actionsToRun.map(({ inputs, functionCallId }, index) =>
+      actionsToRun.map(({ inputs, functionCallId, action }, index) =>
         activities.runToolActivity(authType, {
           runAgentArgs,
           inputs,
           functionCallId,
           step: i,
           stepActionIndex: index,
+          action,
           stepActions: actionsToRun.map((a) => a.action),
           citationsRefsOffset,
           stepContentId: functionCallStepContentIds[functionCallId],

--- a/front/temporal/agent_loop/lib/agent_loop_executor.ts
+++ b/front/temporal/agent_loop/lib/agent_loop_executor.ts
@@ -43,10 +43,11 @@ export async function executeAgentLoop(
       return;
     }
 
+    const { runId, stepContexts, totalCitationsIncrement } = result;
+
     // Update state with results from runMultiActionsAgent.
-    runIds.push(result.runId);
+    runIds.push(runId);
     functionCallStepContentIds = result.functionCallStepContentIds;
-    const { stepContext, totalCitationsIncrement } = result;
 
     // We received the actions to run, but will enforce a limit on the number of actions
     // which is very high. Over that the latency will just be too high. This is a guardrail
@@ -62,7 +63,7 @@ export async function executeAgentLoop(
           step: i,
           stepActionIndex: index,
           action,
-          stepContext,
+          stepContext: stepContexts[index],
           stepContentId: functionCallStepContentIds[functionCallId],
         })
       )


### PR DESCRIPTION
## Description

- Part of https://github.com/dust-tt/tasks/issues/3527.
- Currently we pass around all `stepActions` when running each tool, they are used to compute citation offsets, topK, and other similar values.
- This is not ideal as we wish each runToolActivity to be somewhat independent.
- Everything can be computed beforehand, this is what this PR does.

## Tests

- Tested locally with a conversation where the agent does a search + a websearch at step 1 and then a search at step 2. Checked that I get the same `topK` (16), `websearchResultCount` (16) and citation offsets (0, 16, 32) within each tool.

## Risk

- High blast radius as it affects major actions (retrieval, websearch).

## Deploy Plan

- Deploy front.
