### PR TITLE
Add Vertex AI fallback for Anthropic models

### DIFF
--- a/core/bin/core_api.rs
+++ b/core/bin/core_api.rs
@@ -903,6 +903,17 @@ async fn runs_create(
         },
         None => (),
     };
+
+    match headers.get("X-Dust-Feature-Flags") {
+        Some(v) => match v.to_str() {
+            Ok(v) => {
+                credentials.insert("DUST_FEATURE_FLAGS".to_string(), v.to_string());
+            }
+            _ => (),
+        },
+        None => (),
+    };
+
     match headers.get("X-Dust-Group-Ids") {
         Some(v) => match v.to_str() {
             Ok(v) => {
@@ -975,6 +986,17 @@ async fn runs_create_stream(
         },
         None => (),
     };
+
+    match headers.get("X-Dust-Feature-Flags") {
+        Some(v) => match v.to_str() {
+            Ok(v) => {
+                credentials.insert("DUST_FEATURE_FLAGS".to_string(), v.to_string());
+            }
+            _ => (),
+        },
+        None => (),
+    };
+
     match headers.get("X-Dust-Group-Ids") {
         Some(v) => match v.to_str() {
             Ok(v) => {

--- a/core/src/gcp_auth.rs
+++ b/core/src/gcp_auth.rs
@@ -1,0 +1,56 @@
+use once_cell::sync::Lazy;
+use serde::Deserialize;
+use std::sync::{Arc, Mutex};
+use tokio::time::{Duration, Instant};
+
+static GCP_TOKEN_CACHE: Lazy<Arc<Mutex<Option<(String, Instant)>>>> =
+    Lazy::new(|| Arc::new(Mutex::new(None)));
+
+#[derive(Deserialize)]
+struct TokenResponse {
+    access_token: String,
+    expires_in: u64,
+}
+
+pub async fn get_gcp_access_token() -> Result<String, anyhow::Error> {
+    // Check cache first, scope block ensures mutex lock is released immediately.
+    {
+        let cache = GCP_TOKEN_CACHE.lock().unwrap();
+        if let Some((token, expires_at)) = cache.as_ref() {
+            if Instant::now() < *expires_at {
+                return Ok(token.clone());
+            }
+        }
+    }
+
+    // Try environment variable first (for local dev).
+    if let Ok(token) = std::env::var("GOOGLE_CLOUD_ACCESS_TOKEN") {
+        // Update cache - scope block ensures mutex lock is released immediately.
+        {
+            let mut cache = GCP_TOKEN_CACHE.lock().unwrap();
+            // Environment tokens don't have expiry info, cache for 50min.
+            let expires_at = Instant::now() + Duration::from_secs(50 * 60);
+            *cache = Some((token.clone(), expires_at));
+        }
+        return Ok(token);
+    }
+
+    // Fallback to metadata server (for production).
+    let client = reqwest::Client::new();
+    let response = client
+        .get("http://metadata.google.internal/computeMetadata/v1/instance/service-accounts/default/token")
+        .header("Metadata-Flavor", "Google")
+        .send()
+        .await?;
+
+    let token_response: TokenResponse = response.json().await?;
+
+    // Update cache - scope block ensures mutex lock is released immediately.
+    {
+        let mut cache = GCP_TOKEN_CACHE.lock().unwrap();
+        let expires_at = Instant::now() + Duration::from_secs(token_response.expires_in - 300);
+        *cache = Some((token_response.access_token.clone(), expires_at));
+    }
+
+    Ok(token_response.access_token)
+}

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -50,6 +50,7 @@ pub mod databases {
     pub mod table_upserts_background_worker;
     pub mod transient_database;
 }
+pub mod gcp_auth;
 pub mod project;
 pub mod run;
 pub mod search_filter;

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -71,6 +71,7 @@ pub mod providers {
     }
     pub mod anthropic {
         pub mod anthropic;
+        pub mod backend;
         pub mod helpers;
         pub mod streaming;
         pub mod types;

--- a/core/src/providers/anthropic/anthropic.rs
+++ b/core/src/providers/anthropic/anthropic.rs
@@ -108,17 +108,14 @@ impl AnthropicLLM {
             body["system"] = json!(system);
         }
 
-        // FIXME: Make this more functional.
-        if thinking.is_some() {
-            if let Some((thinking_type, thinking_budget_tokens)) = thinking {
-                body["thinking"] = json!({
-                    "type": thinking_type,
-                    "budget_tokens": thinking_budget_tokens,
-                });
-                // We can't pass a temperature different from 1.0 in thinking mode: https://docs.anthropic.com/en/docs/build-with-claude/extended-thinking#important-considerations-when-using-extended-thinking
-                body["temperature"] = 1.0f32.into();
-                body.as_object_mut().unwrap().remove("top_p");
-            }
+        if let Some((thinking_type, thinking_budget_tokens)) = thinking {
+            body["thinking"] = json!({
+                "type": thinking_type,
+                "budget_tokens": thinking_budget_tokens,
+            });
+            // We can't pass a temperature different from 1.0 in thinking mode: https://docs.anthropic.com/en/docs/build-with-claude/extended-thinking#important-considerations-when-using-extended-thinking
+            body["temperature"] = 1.0f32.into();
+            body.as_object_mut().unwrap().remove("top_p");
         }
 
         if !tools.is_empty() {

--- a/core/src/providers/anthropic/anthropic.rs
+++ b/core/src/providers/anthropic/anthropic.rs
@@ -83,7 +83,6 @@ impl AnthropicLLM {
         beta_flags: &Vec<&str>,
     ) -> Value {
         let mut body = json!({
-            // "model": self.id.clone(),
             "messages": messages,
             "max_tokens": max_tokens,
             "temperature": temperature,

--- a/core/src/providers/anthropic/anthropic.rs
+++ b/core/src/providers/anthropic/anthropic.rs
@@ -1,3 +1,6 @@
+use crate::providers::anthropic::backend::{
+    should_use_vertex_for_model, AnthropicBackend, DirectAnthropicBackend, VertexAnthropicBackend,
+};
 use crate::providers::anthropic::helpers::get_anthropic_chat_messages;
 use crate::providers::anthropic::streaming::handle_streaming_response;
 use crate::providers::anthropic::types::{
@@ -16,7 +19,7 @@ use crate::utils;
 use anyhow::{anyhow, Result};
 use async_trait::async_trait;
 use eventsource_client as es;
-use hyper::{body::Buf, Uri};
+use hyper::body::Buf;
 use serde_json::{json, Value};
 use std::io::prelude::*;
 use std::str::FromStr;
@@ -26,6 +29,7 @@ use tokio::sync::mpsc::UnboundedSender;
 pub struct AnthropicLLM {
     id: String,
     api_key: Option<String>,
+    backend: Box<dyn AnthropicBackend + Send + Sync>,
     user_id: Option<String>,
 }
 
@@ -47,13 +51,8 @@ impl AnthropicLLM {
             id,
             api_key: None,
             user_id: None,
+            backend: Box::new(DirectAnthropicBackend::new()),
         }
-    }
-
-    fn messages_uri(&self) -> Result<Uri> {
-        Ok("https://api.anthropic.com/v1/messages"
-            .to_string()
-            .parse::<Uri>()?)
     }
 
     fn placehodler_tool(&self) -> AnthropicTool {
@@ -69,22 +68,22 @@ impl AnthropicLLM {
         }
     }
 
-    async fn chat_completion(
+    fn build_base_request_body(
         &self,
-        system: Option<String>,
         messages: &Vec<AnthropicChatMessage>,
+        system: Option<String>,
         tools: Vec<AnthropicTool>,
         tool_choice: Option<AnthropicToolChoice>,
         temperature: f32,
         top_p: f32,
         stop_sequences: &Vec<String>,
         max_tokens: i32,
+        stream: bool,
+        thinking: Option<(String, u64)>,
         beta_flags: &Vec<&str>,
-    ) -> Result<(ChatResponse, Option<String>)> {
-        assert!(self.api_key.is_some());
-
+    ) -> Value {
         let mut body = json!({
-            "model": self.id.clone(),
+            // "model": self.id.clone(),
             "messages": messages,
             "max_tokens": max_tokens,
             "temperature": temperature,
@@ -95,6 +94,10 @@ impl AnthropicLLM {
             },
         });
 
+        if stream {
+            body["stream"] = json!(true);
+        }
+
         if let Some(user_id) = self.user_id.as_ref() {
             body["metadata"] = json!({
                 "user_id": user_id,
@@ -103,6 +106,19 @@ impl AnthropicLLM {
 
         if system.is_some() {
             body["system"] = json!(system);
+        }
+
+        // FIXME: Make this more functional.
+        if thinking.is_some() {
+            if let Some((thinking_type, thinking_budget_tokens)) = thinking {
+                body["thinking"] = json!({
+                    "type": thinking_type,
+                    "budget_tokens": thinking_budget_tokens,
+                });
+                // We can't pass a temperature different from 1.0 in thinking mode: https://docs.anthropic.com/en/docs/build-with-claude/extended-thinking#important-considerations-when-using-extended-thinking
+                body["temperature"] = 1.0f32.into();
+                body.as_object_mut().unwrap().remove("top_p");
+            }
         }
 
         if !tools.is_empty() {
@@ -128,21 +144,43 @@ impl AnthropicLLM {
             }
         }
 
-        let api_key = match self.api_key.clone() {
-            Some(key) => key,
-            None => Err(anyhow!("ANTHROPIC_API_KEY is not set."))?,
-        };
-        let mut headers = reqwest::header::HeaderMap::new();
-        headers.insert("Content-Type", "application/json".parse()?);
-        headers.insert("X-API-Key", api_key.parse()?);
-        headers.insert("anthropic-version", "2023-06-01".parse()?);
+        body
+    }
 
-        for flag in beta_flags {
-            headers.insert("anthropic-beta", flag.parse()?);
-        }
+    async fn chat_completion(
+        &self,
+        system: Option<String>,
+        messages: &Vec<AnthropicChatMessage>,
+        tools: Vec<AnthropicTool>,
+        tool_choice: Option<AnthropicToolChoice>,
+        temperature: f32,
+        top_p: f32,
+        stop_sequences: &Vec<String>,
+        max_tokens: i32,
+        beta_flags: &Vec<&str>,
+    ) -> Result<(ChatResponse, Option<String>)> {
+        assert!(self.api_key.is_some());
+
+        let base_body = self.build_base_request_body(
+            messages,
+            system,
+            tools,
+            tool_choice,
+            temperature,
+            top_p,
+            stop_sequences,
+            max_tokens,
+            false,
+            None,
+            beta_flags,
+        );
+
+        let body = self.backend.build_request_body(base_body, &self.id);
+
+        let headers = self.backend.build_headers(beta_flags)?;
 
         let res = reqwest::Client::new()
-            .post(self.messages_uri()?.to_string())
+            .post(self.backend.messages_uri(&self.id)?.to_string())
             .headers(headers)
             .json(&body)
             .send()
@@ -201,70 +239,23 @@ impl AnthropicLLM {
         event_sender: UnboundedSender<Value>,
         thinking: Option<(String, u64)>,
     ) -> Result<(ChatResponse, Option<String>)> {
-        assert!(self.api_key.is_some());
+        let base_body = self.build_base_request_body(
+            messages,
+            system,
+            tools,
+            tool_choice,
+            temperature,
+            top_p,
+            stop_sequences,
+            max_tokens,
+            true,
+            thinking,
+            beta_flags,
+        );
 
-        let mut body = json!({
-            "model": self.id.clone(),
-            "messages": messages,
-            "max_tokens": max_tokens,
-            "temperature": temperature,
-            "top_p": top_p,
-            "stop_sequences": match stop_sequences.len() {
-                0 => None,
-                _ => Some(stop_sequences),
-            },
-            "stream": true,
-        });
+        let body = self.backend.build_request_body(base_body, &self.id);
 
-        if let Some(user_id) = self.user_id.as_ref() {
-            body["metadata"] = json!({
-                "user_id": user_id,
-            });
-        }
-
-        if system.is_some() {
-            body["system"] = json!(system);
-        }
-
-        if !tools.is_empty() {
-            body["tools"] = json!(tools);
-            if tool_choice.is_some() {
-                body["tool_choice"] = json!(tool_choice);
-            }
-        } else {
-            let has_tool_choice_none_flag = beta_flags
-                .iter()
-                .any(|flag| flag.starts_with("tool-choice-none"));
-
-            if !has_tool_choice_none_flag
-                && messages.iter().any(|m| {
-                    m.content
-                        .iter()
-                        .any(|c| c.tool_use.is_some() || c.tool_result.is_some())
-                })
-            {
-                // Add only if we have tool_use or tool_result in the messages and we are
-                //not using the tool-choice-none beta flag
-                body["tools"] = json!(vec![self.placehodler_tool()]);
-            }
-        }
-
-        if let Some((thinking_type, thinking_budget_tokens)) = thinking {
-            body["thinking"] = json!({
-                "type": thinking_type,
-                "budget_tokens": thinking_budget_tokens,
-            });
-            // We can't pass a temperature different from 1.0 in thinking mode: https://docs.anthropic.com/en/docs/build-with-claude/extended-thinking#important-considerations-when-using-extended-thinking
-            body["temperature"] = 1.0f32.into();
-            body.as_object_mut().unwrap().remove("top_p");
-        }
-
-        let api_key = match self.api_key.clone() {
-            Some(key) => key,
-            None => Err(anyhow!("ANTHROPIC_API_KEY is not set."))?,
-        };
-
-        let url = self.messages_uri()?.to_string();
+        let url = self.backend.messages_uri(&self.id)?.to_string();
 
         let mut builder = match es::ClientBuilder::for_url(url.as_str()) {
             Ok(builder) => builder,
@@ -277,24 +268,10 @@ impl AnthropicLLM {
         };
 
         builder = builder.method(String::from("POST"));
-        builder = match builder.header("Content-Type", "application/json") {
-            Ok(builder) => builder,
-            Err(e) => return Err(anyhow!("Error setting header: {:?}", e)),
-        };
-        builder = match builder.header("X-API-Key", api_key.as_str()) {
-            Ok(builder) => builder,
-            Err(e) => return Err(anyhow!("Error setting header: {:?}", e)),
-        };
-        builder = match builder.header("anthropic-version", "2023-06-01") {
-            Ok(builder) => builder,
-            Err(e) => return Err(anyhow!("Error setting header: {:?}", e)),
-        };
 
-        for flag in beta_flags {
-            builder = match builder.header("anthropic-beta", flag) {
-                Ok(builder) => builder,
-                Err(e) => return Err(anyhow!("Error setting header: {:?}", e)),
-            }
+        let headers = self.backend.build_headers(beta_flags)?;
+        for (name, value) in headers.iter() {
+            builder = builder.header(name.as_str(), value.to_str()?)?;
         }
 
         let client = builder.body(body.to_string()).build();
@@ -310,20 +287,24 @@ impl LLM for AnthropicLLM {
     }
 
     async fn initialize(&mut self, credentials: Credentials) -> Result<()> {
-        match credentials.get("ANTHROPIC_API_KEY") {
-            Some(api_key) => {
-                self.api_key = Some(api_key.clone());
-            }
-            None => match tokio::task::spawn_blocking(|| std::env::var("ANTHROPIC_API_KEY")).await?
-            {
-                Ok(key) => {
-                    self.api_key = Some(key);
-                }
-                Err(_) => Err(anyhow!(
-                    "Credentials or environment variable `ANTHROPIC_API_KEY` is not set."
-                ))?,
-            },
+        let feature_flags = credentials
+            .get("DUST_FEATURE_FLAGS")
+            .map(|s| s.split(',').collect::<Vec<_>>())
+            .unwrap_or_default();
+
+        let use_vertex = feature_flags.contains(&"anthropic_vertex_fallback")
+            && should_use_vertex_for_model(&self.id);
+
+        if use_vertex {
+            self.backend = Box::new(VertexAnthropicBackend::new());
+        } else {
+            self.backend = Box::new(DirectAnthropicBackend::new());
         }
+
+        // Initialize the backend.
+        let api_key = self.backend.initialize(&credentials).await?;
+        self.api_key = Some(api_key);
+
         match credentials.get("DUST_WORKSPACE_ID") {
             Some(workspace_id) => {
                 self.user_id = Some(workspace_id.clone());

--- a/core/src/providers/anthropic/backend.rs
+++ b/core/src/providers/anthropic/backend.rs
@@ -1,0 +1,243 @@
+use crate::info;
+use crate::run::Credentials;
+use anyhow::{anyhow, Result};
+use hyper::Uri;
+use reqwest::header::HeaderMap;
+use serde_json::{json, Value};
+use std::str::FromStr;
+
+#[async_trait::async_trait]
+pub trait AnthropicBackend {
+    async fn initialize(&mut self, credentials: &Credentials) -> Result<String>;
+    fn messages_uri(&self, model_id: &str) -> Result<Uri>;
+    fn build_headers(&self, beta_flags: &[&str]) -> Result<HeaderMap>;
+    fn build_request_body(&self, base_body: Value, model_id: &str) -> Value;
+}
+
+// Direct Anthropic backend.
+
+pub struct DirectAnthropicBackend {
+    api_key: Option<String>,
+}
+
+impl DirectAnthropicBackend {
+    pub fn new() -> Self {
+        Self { api_key: None }
+    }
+}
+
+#[async_trait::async_trait]
+impl AnthropicBackend for DirectAnthropicBackend {
+    async fn initialize(&mut self, credentials: &Credentials) -> Result<String> {
+        let api_key = match credentials.get("ANTHROPIC_API_KEY") {
+            Some(api_key) => api_key.clone(),
+            None => match tokio::task::spawn_blocking(|| std::env::var("ANTHROPIC_API_KEY")).await?
+            {
+                Ok(key) => key,
+                Err(_) => {
+                    return Err(anyhow!(
+                        "Credentials or environment variable `ANTHROPIC_API_KEY` is not set."
+                    ))
+                }
+            },
+        };
+
+        self.api_key = Some(api_key.clone());
+        Ok(api_key)
+    }
+
+    fn messages_uri(&self, _model_id: &str) -> Result<Uri> {
+        Ok("https://api.anthropic.com/v1/messages".parse()?)
+    }
+
+    fn build_headers(&self, beta_flags: &[&str]) -> Result<HeaderMap> {
+        let mut headers = HeaderMap::new();
+        headers.insert("Content-Type", "application/json".parse()?);
+
+        let api_key = self
+            .api_key
+            .as_ref()
+            .ok_or_else(|| anyhow!("ANTHROPIC_API_KEY is not set."))?;
+
+        headers.insert("X-API-Key", api_key.parse()?);
+        headers.insert("anthropic-version", "2023-06-01".parse()?);
+
+        for flag in beta_flags {
+            headers.insert("anthropic-beta", flag.parse()?);
+        }
+        Ok(headers)
+    }
+
+    fn build_request_body(&self, mut base_body: Value, model_id: &str) -> Value {
+        base_body["model"] = json!(model_id);
+        base_body
+    }
+}
+
+// Fallback.
+
+/// Anthropic models that can be routed through Vertex AI as a fallback.
+///
+/// This enum serves as a type-safe registry of models that have verified mappings to Vertex AI's
+/// Anthropic publisher models. Only models listed here will be eligible for Vertex AI fallback
+/// when the feature flag `anthropic_vertex_fallback` is enabled.
+///
+/// # Adding New Models
+///
+/// To add support for a new model:
+/// 1. Add a new variant to this enum
+/// 2. Update the `FromStr` implementation to parse the model ID
+/// 3. Update `vertex_model_name()` to provide the Vertex AI mapping
+///
+/// # Fallback Strategy
+///
+/// Some mappings may not be 1:1 - we can map newer/unavailable Anthropic models to the closest
+/// available model on Vertex AI (e.g., Opus -> Sonnet).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum VertexSupportedModel {
+    Claude4Sonnet20250514,
+}
+
+impl FromStr for VertexSupportedModel {
+    type Err = anyhow::Error;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "claude-4-sonnet-20250514" => Ok(Self::Claude4Sonnet20250514),
+            _ => Err(anyhow::anyhow!("Model {} not supported on Vertex AI", s)),
+        }
+    }
+}
+
+impl VertexSupportedModel {
+    pub fn vertex_model_name(self) -> &'static str {
+        match self {
+            Self::Claude4Sonnet20250514 => "claude-sonnet-4@20250514",
+        }
+    }
+}
+
+pub fn should_use_vertex_for_model(model_id: &str) -> bool {
+    model_id.parse::<VertexSupportedModel>().is_ok()
+}
+
+pub fn map_anthropic_model_to_vertex_model(model_id: &str) -> Result<String, anyhow::Error> {
+    let model: VertexSupportedModel = model_id.parse()?;
+    Ok(model.vertex_model_name().to_string())
+}
+
+// Vertex Anthropic backend.
+
+pub struct VertexAnthropicBackend {
+    api_key: Option<String>,
+    project_id: Option<String>,
+    location: Option<String>,
+}
+
+impl VertexAnthropicBackend {
+    pub fn new() -> Self {
+        Self {
+            api_key: None,
+            project_id: None,
+            location: None,
+        }
+    }
+}
+
+#[async_trait::async_trait]
+impl AnthropicBackend for VertexAnthropicBackend {
+    async fn initialize(&mut self, credentials: &Credentials) -> Result<String> {
+        let api_key = match credentials.get("GOOGLE_CLOUD_API_KEY") {
+            Some(api_key) => api_key.clone(),
+            None => {
+                match tokio::task::spawn_blocking(|| std::env::var("GOOGLE_CLOUD_API_KEY")).await? {
+                    Ok(key) => key,
+                    Err(_) => {
+                        return Err(anyhow!(
+                        "Credentials or environment variable `GOOGLE_CLOUD_API_KEY` is not set."
+                    ))
+                    }
+                }
+            }
+        };
+
+        let project_id = match credentials.get("GOOGLE_CLOUD_PROJECT_ID") {
+            Some(project_id) => project_id.clone(),
+            None => {
+                match tokio::task::spawn_blocking(|| std::env::var("GOOGLE_CLOUD_PROJECT_ID"))
+                    .await?
+                {
+                    Ok(project_id) => project_id,
+                    Err(_) => {
+                        return Err(anyhow!(
+                        "Credentials or environment variable `GOOGLE_CLOUD_PROJECT_ID` is not set."
+                    ))
+                    }
+                }
+            }
+        };
+
+        let location = match credentials.get("GOOGLE_CLOUD_LOCATION") {
+            Some(location) => location.clone(),
+            None => match tokio::task::spawn_blocking(|| std::env::var("GOOGLE_CLOUD_LOCATION"))
+                .await?
+            {
+                Ok(location) => location,
+                Err(_) => "us-east5".to_string(), // Default fallback region.
+            },
+        };
+
+        self.api_key = Some(api_key.clone());
+        self.project_id = Some(project_id);
+        self.location = Some(location);
+
+        Ok(api_key)
+    }
+
+    fn messages_uri(&self, model_id: &str) -> Result<Uri> {
+        let project_id = self
+            .project_id
+            .as_ref()
+            .ok_or_else(|| anyhow!("VertexAnthropicBackend not initialized: missing project_id"))?;
+        let location = self
+            .location
+            .as_ref()
+            .ok_or_else(|| anyhow!("VertexAnthropicBackend not initialized: missing location"))?;
+        let vertex_model_id = match map_anthropic_model_to_vertex_model(model_id) {
+            Ok(model) => model,
+            Err(_) => return Err(anyhow!("Unsupported model: {}", model_id)),
+        };
+
+        info!(
+            model_id = model_id,
+            fallback_model = vertex_model_id,
+            "Fallback to Vertex Anthropic"
+        );
+
+        let uri = format!(
+            "https://{}-aiplatform.googleapis.com/v1/projects/{}/locations/{}/publishers/anthropic/models/{}:streamRawPredict",
+            location, project_id, location, vertex_model_id
+        );
+        Ok(uri.parse()?)
+    }
+
+    fn build_headers(&self, _beta_flags: &[&str]) -> Result<HeaderMap> {
+        let mut headers = HeaderMap::new();
+        headers.insert("Content-Type", "application/json".parse()?);
+
+        let api_key = self
+            .api_key
+            .as_ref()
+            .ok_or_else(|| anyhow!("GOOGLE_CLOUD_API_KEY is not set."))?;
+
+        headers.insert("Authorization", format!("Bearer {}", api_key).parse()?);
+
+        Ok(headers)
+    }
+
+    fn build_request_body(&self, mut base_body: Value, _model_id: &str) -> Value {
+        base_body["anthropic_version"] = json!("vertex-2023-10-16");
+        // Don't include model in body for Vertex (it's in URL)
+        base_body
+    }
+}

--- a/front/pages/api/v1/w/[wId]/spaces/[spaceId]/apps/[aId]/runs/index.ts
+++ b/front/pages/api/v1/w/[wId]/spaces/[spaceId]/apps/[aId]/runs/index.ts
@@ -290,8 +290,14 @@ async function handler(
         }
       }
 
+      // Fetch the feature flags of the app's workspace.
       const flags = await getFeatureFlags(owner);
       const storeBlocksResults = !flags.includes("disable_run_logs");
+
+      // Fetch the feature flags for the owner of the run.
+      const keyWorkspaceFlags = await getFeatureFlags(
+        keyAuth.getNonNullableWorkspace()
+      );
 
       logger.info(
         {
@@ -306,6 +312,7 @@ async function handler(
 
       const runRes = await coreAPI.createRunStream(
         keyAuth.getNonNullableWorkspace(),
+        keyWorkspaceFlags,
         keyAuth.groups(),
         {
           projectId: app.dustAPIProjectId,

--- a/front/pages/api/w/[wId]/spaces/[spaceId]/apps/[aId]/runs/index.ts
+++ b/front/pages/api/w/[wId]/spaces/[spaceId]/apps/[aId]/runs/index.ts
@@ -125,19 +125,27 @@ async function handler(
       const flags = await getFeatureFlags(owner);
       const storeBlocksResults = !flags.includes("disable_run_logs");
 
-      const dustRun = await coreAPI.createRun(owner, auth.groups(), {
-        projectId: app.dustAPIProjectId,
-        runType: "local",
-        specification: dumpSpecification(
-          JSON.parse(req.body.specification),
-          latestDatasets
-        ),
-        datasetId: inputDataset,
-        config: { blocks: config },
-        credentials: credentialsFromProviders(providers),
-        secrets,
-        storeBlocksResults,
-      });
+      // Fetch the feature flags of the app's workspace.
+      const keyWorkspaceFlags = await getFeatureFlags(owner);
+
+      const dustRun = await coreAPI.createRun(
+        owner,
+        keyWorkspaceFlags,
+        auth.groups(),
+        {
+          projectId: app.dustAPIProjectId,
+          runType: "local",
+          specification: dumpSpecification(
+            JSON.parse(req.body.specification),
+            latestDatasets
+          ),
+          datasetId: inputDataset,
+          config: { blocks: config },
+          credentials: credentialsFromProviders(providers),
+          secrets,
+          storeBlocksResults,
+        }
+      );
 
       if (dustRun.isErr()) {
         return apiError(req, res, {

--- a/front/types/core/core_api.ts
+++ b/front/types/core/core_api.ts
@@ -30,6 +30,7 @@ import type {
   RunStatus,
   TraceType,
 } from "@app/types/run";
+import type { WhitelistableFeature } from "@app/types/shared/feature_flags";
 import type { LoggerInterface } from "@app/types/shared/logger";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
@@ -530,6 +531,7 @@ export class CoreAPI {
 
   async createRun(
     workspace: LightWorkspaceType,
+    featureFlags: WhitelistableFeature[],
     groups: GroupType[],
     {
       projectId,
@@ -551,9 +553,10 @@ export class CoreAPI {
         method: "POST",
         headers: {
           "Content-Type": "application/json",
-          "X-Dust-Workspace-Id": workspace.sId,
+          "X-Dust-Feature-Flags": featureFlags.join(","),
           "X-Dust-Group-Ids": groups.map((g) => g.sId).join(","),
           "X-Dust-IsSystemRun": isSystemKey ? "true" : "false",
+          "X-Dust-Workspace-Id": workspace.sId,
         },
         body: JSON.stringify({
           run_type: runType,
@@ -574,6 +577,7 @@ export class CoreAPI {
 
   async createRunStream(
     workspace: LightWorkspaceType,
+    featureFlags: WhitelistableFeature[],
     groups: GroupType[],
     {
       projectId,
@@ -600,9 +604,10 @@ export class CoreAPI {
         method: "POST",
         headers: {
           "Content-Type": "application/json",
-          "X-Dust-Workspace-Id": workspace.sId,
+          "X-Dust-Feature-Flags": featureFlags.join(","),
           "X-Dust-Group-Ids": groups.map((g) => g.sId).join(","),
           "X-Dust-IsSystemRun": isSystemKey ? "true" : "false",
+          "X-Dust-Workspace-Id": workspace.sId,
         },
         body: JSON.stringify({
           run_type: runType,

--- a/front/types/shared/feature_flags.ts
+++ b/front/types/shared/feature_flags.ts
@@ -3,6 +3,9 @@ export const WHITELISTABLE_FEATURES_CONFIG = {
     description:
       "Advanced features for Notion workspace management shown to admins",
   },
+  anthropic_vertex_fallback: {
+    description: "Fallback to Vertex Anthropic for some Anthropic models",
+  },
   notion_private_integration: {
     description: "Setup Notion private integration tokens",
   },

--- a/sdks/js/src/types.ts
+++ b/sdks/js/src/types.ts
@@ -593,6 +593,7 @@ export type RetrievalDocumentPublicType = z.infer<
 
 const WhitelistableFeaturesSchema = FlexibleEnumSchema<
   | "advanced_notion_management"
+  | "anthropic_vertex_fallback"
   | "notion_private_integration"
   | "advanced_search"
   | "agent_builder_instructions_autocomplete"


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
This PR implements Vertex AI fallback for some Anthropic models. When the `anthropic_vertex_fallback` feature flag is enabled, supported Anthropic models (currently `claude-4-sonnet-20250514`) will automatically route through Google Cloud's Vertex AI instead of the direct Anthropic API.

The idea here is not to support all Anthropic models but to explicitly map some Anthropic models to Vertex AI models (assuming they have been properly provisioned on our account). For now, there is no automatic fallback, it's based on a FF at the workspace level. Even though capacities seems to show that Vertex AI is fine with our current load (QPM / throughput) we still want to test a bit before going full automatic.

Vertex AI quotas doc: [here](https://cloud.google.com/vertex-ai/docs/quotas#request_quotas)
Our usage patterns viz: [here](https://dust.tt/w/0ec9852c2f/assistant/9owUfPrDsQ#?icid=fil_IxvcBSy16URaJH)

Having distinct regions for US and EU is out-of-scope of this first version.

**Key Changes:**
- Added `AnthropicBackend` trait with `DirectAnthropicBackend` and `VertexAnthropicBackend` implementations
- Created type-safe `VertexSupportedModel` enum for model mapping and validation
- Credentials for Vertex AI is TBD in production

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->
Tested locally and works like a charm:
```
{"v":0,"name":"dust_api","msg":"Fallback to Vertex Anthropic","level":30,"hostname":"Flaviens-MacBook-Pro-2.local","pid":72013,"time":"2025-07-24T14:13:37.535535Z","fallback_model":"claude-sonnet-4@20250514","model_id":"claude-4-sonnet-20250514","timestamp":"1753366417535"}
```

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

- [x] Provision Claude 4 Sonnet in the US project
- [x] Fix GCP Authentication mechanism on this API
- [x] Add `GOOGLE_CLOUD_PROJECT_ID` secrets