### PR TITLE
[sdk] Cleanup action types

### DIFF
--- a/connectors/src/connectors/slack/chat/citations.ts
+++ b/connectors/src/connectors/slack/chat/citations.ts
@@ -1,6 +1,5 @@
 import type { AgentActionPublicType } from "@dust-tt/client";
 import {
-  isMCPActionType,
   isSearchResultResourceType,
   isWebsearchResultResourceType,
 } from "@dust-tt/client";
@@ -26,7 +25,7 @@ export function annotateCitations(
   } = {};
 
   for (const action of actions) {
-    if (action && isMCPActionType(action) && action.output) {
+    if (action && action.output) {
       // Handle MCP search results
       action.output?.filter(isSearchResultResourceType).forEach((o) => {
         if (o.type === "resource" && o.resource.ref) {

--- a/sdks/js/package-lock.json
+++ b/sdks/js/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@dust-tt/client",
-  "version": "1.1.3",
+  "version": "1.1.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@dust-tt/client",
-      "version": "1.1.3",
+      "version": "1.1.4",
       "bundleDependencies": [
         "@modelcontextprotocol/sdk"
       ],

--- a/sdks/js/package.json
+++ b/sdks/js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dust-tt/client",
-  "version": "1.1.3",
+  "version": "1.1.4",
   "description": "Client for Dust API",
   "repository": {
     "type": "git",

--- a/sdks/js/src/types.ts
+++ b/sdks/js/src/types.ts
@@ -584,12 +584,11 @@ export type RetrievalDocumentPublicType = z.infer<
 
 const WhitelistableFeaturesSchema = FlexibleEnumSchema<
   | "advanced_notion_management"
-  | "anthropic_vertex_fallback"
-  | "notion_private_integration"
   | "advanced_search"
   | "agent_builder_instructions_autocomplete"
   | "agent_builder_v2"
   | "agent_memory_tools"
+  | "anthropic_vertex_fallback"
   | "claude_4_opus_feature"
   | "co_edition"
   | "deepseek_feature"
@@ -607,6 +606,7 @@ const WhitelistableFeaturesSchema = FlexibleEnumSchema<
   | "labs_trackers"
   | "labs_transcripts"
   | "monday_tool"
+  | "notion_private_integration"
   | "okta_enterprise_connection"
   | "openai_o1_custom_assistants_feature"
   | "openai_o1_feature"
@@ -618,8 +618,8 @@ const WhitelistableFeaturesSchema = FlexibleEnumSchema<
   | "salesforce_tool"
   | "show_debug_tools"
   | "usage_data_api"
-  | "workos_user_provisioning"
   | "workos"
+  | "workos_user_provisioning"
   | "xai_feature"
 >();
 
@@ -688,8 +688,6 @@ const MCPActionTypeSchema = z.object({
   output: CallToolResultSchema.shape.content.nullable(),
   type: z.literal("tool_action"),
 });
-
-export type MCPActionPublicType = z.infer<typeof MCPActionTypeSchema>;
 
 const GlobalAgentStatusSchema = FlexibleEnumSchema<
   | "active"
@@ -2384,12 +2382,6 @@ export type CancelMessageGenerationRequestType = z.infer<
 >;
 
 // Typeguards.
-
-export function isMCPActionType(
-  action: AgentActionPublicType
-): action is MCPActionPublicType {
-  return action.type === "tool_action";
-}
 
 export function isAgentMention(arg: AgentMentionType): arg is AgentMentionType {
   return (arg as AgentMentionType).configurationId !== undefined;

--- a/sdks/js/src/types.ts
+++ b/sdks/js/src/types.ts
@@ -544,15 +544,6 @@ export const GenerationTokensEventSchema = z.object({
 });
 export type GenerationTokensEvent = z.infer<typeof GenerationTokensEventSchema>;
 
-const BaseActionTypeSchema = FlexibleEnumSchema<
-  "dust_app_run_action" | "process_action" | "visualization_action"
->();
-
-const BaseActionSchema = z.object({
-  id: ModelIdSchema,
-  type: BaseActionTypeSchema,
-});
-
 const DataSourceViewKindSchema = FlexibleEnumSchema<"default" | "custom">();
 
 const DataSourceViewSchema = z.object({
@@ -689,7 +680,8 @@ export const WebsearchResultSchema = z.object({
 
 export type WebsearchResultPublicType = z.infer<typeof WebsearchResultSchema>;
 
-const MCPActionTypeSchema = BaseActionSchema.extend({
+const MCPActionTypeSchema = z.object({
+  id: ModelIdSchema,
   agentMessageId: ModelIdSchema,
   functionCallName: z.string().nullable(),
   params: z.unknown(),
@@ -1279,7 +1271,6 @@ const APIErrorTypeSchema = FlexibleEnumSchema<
   | "subscription_state_invalid"
   | "table_not_found"
   | "template_not_found"
-  | "template_not_found"
   | "transcripts_configuration_already_exists"
   | "transcripts_configuration_default_not_allowed"
   | "transcripts_configuration_not_found"
@@ -1289,7 +1280,6 @@ const APIErrorTypeSchema = FlexibleEnumSchema<
   | "unexpected_response_format"
   | "user_not_found"
   | "workspace_auth_error"
-  | "workspace_not_found"
   | "workspace_not_found"
   | "workspace_user_not_found"
 >();


### PR DESCRIPTION
## Description

- Part of https://github.com/dust-tt/tasks/issues/3586.
- This PR simplifies the types in the SDK a little by removing the `BaseActionSchema` (not exported so no impact).
- It also removes the duplicate type `MCPActionPublicType` (duplicate of `AgentActionPublicType`) and the `isMCPActionType` typeguard, which does not do anything. Hopefully no one relies on them, in any case I bumped the version.

## Tests

- Compiles.

## Risk

- Low.

## Deploy Plan

- Publish new version.
- Deploy connectors.
