### PR TITLE
Fix link to Dust Slack MCP documentation

### DIFF
--- a/front/lib/actions/mcp_internal_actions/servers/slack.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/slack.ts
@@ -39,7 +39,7 @@ const serverInfo: InternalMCPServerDefinitionType = {
     supported_use_cases: ["personal_actions"] as const,
   },
   icon: "SlackLogo",
-  documentationUrl: "https://docs.dust.tt/docs/slack-tool-setup",
+  documentationUrl: "https://docs.dust.tt/docs/slack-mcp",
 };
 
 const getSlackClient = async (accessToken?: string) => {


### PR DESCRIPTION
## Description

- As kindly reported by a customer, the link to the documentation of our Slack MCP tools is incorrect.
- This PR fixes that.
- Took this opportunity to check every other documentation link we use for MCP tools, they are all functional.

## Tests

- N/A.

## Risk

- N/A.

## Deploy Plan

- Deploy front.
