### PR TITLE
[front] Add unique index to agent_mcp_actions table

### DIFF
--- a/front/lib/models/assistant/actions/mcp.ts
+++ b/front/lib/models/assistant/actions/mcp.ts
@@ -255,6 +255,12 @@ AgentMCPAction.init(
         fields: ["stepContentId"],
         concurrently: true,
       },
+      {
+        unique: true,
+        fields: ["workspaceId", "agentMessageId", "stepContentId", "version"],
+        concurrently: true,
+        name: "agent_mcp_actions_workspace_msg_step_version_unique",
+      },
     ],
   }
 );

--- a/front/migrations/db/migration_319.sql
+++ b/front/migrations/db/migration_319.sql
@@ -1,0 +1,2 @@
+-- Migration created on Jul 24, 2025
+CREATE UNIQUE INDEX CONCURRENTLY "agent_mcp_actions_workspace_msg_step_version_unique" ON "agent_mcp_actions" ("workspaceId", "agentMessageId", "stepContentId", "version");


### PR DESCRIPTION
## Description
Adds a unique index to the `agent_mcp_actions` table on the combination of workspace, agent message, step content, and version fields to ensure data integrity.

## Risks
Blast radius: agent_mcp_actions table operations
Risk: low

## Tests
Database migration tested locally

## Deploy Plan
- Run migration_319.sql after deploying the service