### PR TITLE
[front] feat(ab): Block selecting more than 1 spaces that is not global

### DIFF
--- a/extension/package-lock.json
+++ b/extension/package-lock.json
@@ -84,7 +84,7 @@
     },
     "../sdks/js": {
       "name": "@dust-tt/client",
-      "version": "1.1.3",
+      "version": "1.1.4",
       "bundleDependencies": [
         "@modelcontextprotocol/sdk"
       ],

--- a/extension/package.json
+++ b/extension/package.json
@@ -59,7 +59,7 @@
     "@auth0/auth0-spa-js": "^2.1.3",
     "@datadog/browser-logs": "^6.13.0",
     "@dust-tt/client": "^1.1.0",
-    "@dust-tt/sparkle": "^0.2.544",
+    "@dust-tt/sparkle": "^0.2.545",
     "@frontapp/plugin-sdk": "^1.8.1",
     "@modelcontextprotocol/sdk": "^1.9.0",
     "@tailwindcss/forms": "^0.5.9",

--- a/front/components/data_source_view/DataSourceBuilderSelector.tsx
+++ b/front/components/data_source_view/DataSourceBuilderSelector.tsx
@@ -3,6 +3,7 @@ import { Breadcrumbs, SearchInput, Spinner } from "@dust-tt/sparkle";
 import type { Dispatch, SetStateAction } from "react";
 import { useMemo, useState } from "react";
 
+import { useSpacesContext } from "@app/components/agent_builder/SpacesContext";
 import {
   DataSourceBuilderProvider,
   useDataSourceBuilderContext,
@@ -17,18 +18,13 @@ import { DataSourceCategoryBrowser } from "@app/components/data_source_view/Data
 import { DataSourceNodeTable } from "@app/components/data_source_view/DataSourceNodeTable";
 import { DataSourceSpaceSelector } from "@app/components/data_source_view/DataSourceSpaceSelector";
 import { CATEGORY_DETAILS } from "@app/lib/spaces";
-import {
-  useSpaceDataSourceViewsWithDetails,
-  useSpaces,
-} from "@app/lib/swr/spaces";
+import { useSpaceDataSourceViewsWithDetails } from "@app/lib/swr/spaces";
 import type {
   ContentNodesViewType,
-  DataSourceViewType,
-  SpaceType,
-} from "@app/types";
-import type {
   DataSourceViewSelectionConfigurations,
+  DataSourceViewType,
   LightWorkspaceType,
+  SpaceType,
 } from "@app/types";
 
 interface DataSourceBuilderSelectorProps {
@@ -45,9 +41,7 @@ interface DataSourceBuilderSelectorProps {
 export const DataSourceBuilderSelector = (
   props: DataSourceBuilderSelectorProps
 ) => {
-  const { spaces, isSpacesLoading } = useSpaces({
-    workspaceId: props.owner.sId,
-  });
+  const { spaces, isSpacesLoading } = useSpacesContext();
 
   if (isSpacesLoading) {
     return <Spinner />;

--- a/front/components/data_source_view/DataSourceCategoryBrowser.tsx
+++ b/front/components/data_source_view/DataSourceCategoryBrowser.tsx
@@ -55,6 +55,7 @@ export function DataSourceCategoryBrowser({
     removeNode,
     removeCurrentNavigationEntry,
     isRowSelected,
+    isRowSelectable,
     isCurrentNavigationEntrySelected,
   } = useDataSourceBuilderContext();
 
@@ -83,6 +84,7 @@ export function DataSourceCategoryBrowser({
           <Checkbox
             size="xs"
             checked={isCurrentNavigationEntrySelected()}
+            disabled={!isRowSelectable()}
             onClick={(event) => event.stopPropagation()}
             onCheckedChange={(state) => {
               if (state === "indeterminate") {
@@ -103,6 +105,7 @@ export function DataSourceCategoryBrowser({
             <Checkbox
               size="xs"
               checked={isRowSelected(row.original.id)}
+              disabled={!isRowSelectable(row.original.id)}
               onClick={(event) => event.stopPropagation()}
               onCheckedChange={(state) => {
                 if (state === "indeterminate") {
@@ -142,6 +145,7 @@ export function DataSourceCategoryBrowser({
     ],
     [
       isCurrentNavigationEntrySelected,
+      isRowSelectable,
       isRowSelected,
       removeCurrentNavigationEntry,
       removeNode,

--- a/front/components/data_source_view/DataSourceNodeTable.tsx
+++ b/front/components/data_source_view/DataSourceNodeTable.tsx
@@ -62,6 +62,7 @@ export function DataSourceNodeTable({
     removeNode,
     removeCurrentNavigationEntry,
     isRowSelected,
+    isRowSelectable,
     isCurrentNavigationEntrySelected,
   } = useDataSourceBuilderContext();
 
@@ -195,6 +196,7 @@ export function DataSourceNodeTable({
           <Checkbox
             size="xs"
             checked={isCurrentNavigationEntrySelected()}
+            disabled={!isRowSelectable()}
             onClick={(event) => event.stopPropagation()}
             onCheckedChange={(state) => {
               if (state === "indeterminate") {
@@ -215,7 +217,7 @@ export function DataSourceNodeTable({
             <Checkbox
               size="xs"
               checked={isRowSelected(row.original.id)}
-              disabled={!row.getCanSelect()}
+              disabled={!isRowSelectable(row.original.id)}
               onClick={(event) => event.stopPropagation()}
               onCheckedChange={(state) => {
                 if (state === "indeterminate") {
@@ -255,6 +257,7 @@ export function DataSourceNodeTable({
     ],
     [
       isCurrentNavigationEntrySelected,
+      isRowSelectable,
       isRowSelected,
       removeCurrentNavigationEntry,
       removeNode,

--- a/front/components/data_source_view/DataSourceSpaceSelector.tsx
+++ b/front/components/data_source_view/DataSourceSpaceSelector.tsx
@@ -8,10 +8,9 @@ import type { SpaceType } from "@app/types";
 
 type SpaceRowData = {
   id: string;
-  name: string;
   icon: React.ComponentType;
   onClick: () => void;
-};
+} & Pick<SpaceType, "name" | "kind">;
 
 export interface DataSourceSpaceSelectorProps {
   spaces: SpaceType[];
@@ -24,12 +23,13 @@ export function DataSourceSpaceSelector({
   allowedSpaces = [],
   onSelectSpace,
 }: DataSourceSpaceSelectorProps) {
-  const { selectNode, removeNode, isRowSelected } =
+  const { selectNode, removeNode, isRowSelected, isRowSelectable } =
     useDataSourceBuilderContext();
 
   const spaceRows: SpaceRowData[] = spaces.map((space) => ({
     id: space.sId,
     name: space.name,
+    kind: space.kind,
     icon: getSpaceIcon(space),
     onClick: () => onSelectSpace(space),
     disabled: allowedSpaces.find((s) => s.sId === space.sId) == null,
@@ -46,7 +46,10 @@ export function DataSourceSpaceSelector({
             <Checkbox
               size="xs"
               checked={isRowSelected(row.original.id)}
-              disabled={!row.getCanSelect()}
+              disabled={
+                row.original.kind !== "global" &&
+                !isRowSelectable(row.original.id)
+              }
               onClick={(event) => event.stopPropagation()}
               onCheckedChange={(state) => {
                 if (state === "indeterminate") {
@@ -84,7 +87,7 @@ export function DataSourceSpaceSelector({
         },
       },
     ],
-    [isRowSelected, removeNode, selectNode]
+    [isRowSelectable, isRowSelected, removeNode, selectNode]
   );
 
   return (

--- a/front/components/data_source_view/context/utils.ts
+++ b/front/components/data_source_view/context/utils.ts
@@ -2,6 +2,11 @@ import type {
   DataSourceBuilderTreeType,
   NavigationHistoryEntryType,
 } from "@app/components/data_source_view/context/types";
+import type {
+  DataSourceViewCategoryWithoutApps,
+  DataSourceViewContentNode,
+  SpaceType,
+} from "@app/types";
 
 function pathToString(path: string[]): string {
   return path.join(".");
@@ -198,4 +203,38 @@ export function computeNavigationPath(
         return entry.node.internalId;
     }
   });
+}
+
+export function findSpaceFromNavigationHistory(
+  navigationHistory: NavigationHistoryEntryType[]
+): SpaceType | null {
+  const entry = navigationHistory[1];
+  if (entry != null && entry.type === "space") {
+    return entry.space;
+  }
+
+  return null;
+}
+
+export function findCategoryFromNavigationHistory(
+  navigationHistory: NavigationHistoryEntryType[]
+): DataSourceViewCategoryWithoutApps | null {
+  const entry = navigationHistory[2];
+  if (entry != null && entry.type === "category") {
+    return entry.category;
+  }
+
+  return null;
+}
+
+export function getLatestNodeFromNavigationHistory(
+  navigationHistory: NavigationHistoryEntryType[]
+): DataSourceViewContentNode | null {
+  const latestEntry = navigationHistory[navigationHistory.length - 1];
+
+  if (latestEntry.type === "node") {
+    return latestEntry.node;
+  }
+
+  return null;
 }

--- a/front/package-lock.json
+++ b/front/package-lock.json
@@ -8,7 +8,7 @@
         "@auth0/nextjs-auth0": "^3.5.0",
         "@datadog/browser-logs": "^6.13.0",
         "@dust-tt/client": "file:../sdks/js",
-        "@dust-tt/sparkle": "^0.2.544",
+        "@dust-tt/sparkle": "^0.2.545",
         "@google-cloud/bigquery": "^7.9.1",
         "@google-cloud/storage-transfer": "^3.6.0",
         "@heroicons/react": "^2.0.11",
@@ -197,7 +197,7 @@
     },
     "../sdks/js": {
       "name": "@dust-tt/client",
-      "version": "1.1.3",
+      "version": "1.1.4",
       "bundleDependencies": [
         "@modelcontextprotocol/sdk"
       ],

--- a/front/package-lock.json
+++ b/front/package-lock.json
@@ -8,7 +8,7 @@
         "@auth0/nextjs-auth0": "^3.5.0",
         "@datadog/browser-logs": "^6.13.0",
         "@dust-tt/client": "file:../sdks/js",
-        "@dust-tt/sparkle": "^0.2.545",
+        "@dust-tt/sparkle": "^0.2.544",
         "@google-cloud/bigquery": "^7.9.1",
         "@google-cloud/storage-transfer": "^3.6.0",
         "@heroicons/react": "^2.0.11",

--- a/front/package.json
+++ b/front/package.json
@@ -25,7 +25,7 @@
     "@auth0/nextjs-auth0": "^3.5.0",
     "@datadog/browser-logs": "^6.13.0",
     "@dust-tt/client": "file:../sdks/js",
-    "@dust-tt/sparkle": "^0.2.544",
+    "@dust-tt/sparkle": "^0.2.545",
     "@google-cloud/bigquery": "^7.9.1",
     "@google-cloud/storage-transfer": "^3.6.0",
     "@heroicons/react": "^2.0.11",


### PR DESCRIPTION
## Description
- https://github.com/dust-tt/tasks/issues/3086
- Add `spaces` list in the context, more practical when using the included/excludes nodes and the current navigation state to know if we can select a given node.
- Also move some helpers function to the shared `utils.ts`

## Tests
- Locally
- Tested when selecting the space itself or a deep nested node.

## Risk
- Mid, could select more than what's allowed.

## Deploy Plan
- Deploy front
