### PR TITLE
Agent Memory: UI to introspect memory + delete

### DIFF
--- a/front/components/assistant/AssistantDetails.tsx
+++ b/front/components/assistant/AssistantDetails.tsx
@@ -253,7 +253,7 @@ export function AssistantDetails({
   const [showRestoreModal, setShowRestoreModal] = useState(false);
   const showEditorsTabs = assistantId != null && !isGlobalAgent;
   const showAgentMemory = !!agentConfiguration?.actions.find(
-    (a) => a.name === "agent_memory"
+    (a) => a.mcpServerName === "agent_memory"
   );
 
   const showPerformanceTabs =

--- a/front/components/assistant/AssistantDetails.tsx
+++ b/front/components/assistant/AssistantDetails.tsx
@@ -23,15 +23,19 @@ import {
   UserGroupIcon,
 } from "@dust-tt/sparkle";
 import { VisuallyHidden } from "@radix-ui/react-visually-hidden";
+import { BrainIcon } from "lucide-react";
 import { useEffect, useState } from "react";
 
 import { AssistantDetailsButtonBar } from "@app/components/assistant/AssistantDetailsButtonBar";
 import { AssistantDetailsPerformance } from "@app/components/assistant/AssistantDetailsPerformance";
+import { AgentMemorySection } from "@app/components/assistant/details/AgentMemorySection";
 import { AssistantEditedSection } from "@app/components/assistant/details/AssistantEditedSection";
 import { AssistantKnowledgeSection } from "@app/components/assistant/details/AssistantKnowledgeSection";
 import { AssistantToolsSection } from "@app/components/assistant/details/AssistantToolsSection";
 import { ReadOnlyTextArea } from "@app/components/assistant/ReadOnlyTextArea";
 import { RestoreAssistantDialog } from "@app/components/assistant/RestoreAssistantDialog";
+import { AddEditorDropdown } from "@app/components/members/AddEditorsDropdown";
+import { MembersList } from "@app/components/members/MembersList";
 import { useAgentConfiguration } from "@app/lib/swr/assistants";
 import { useEditors, useUpdateEditors } from "@app/lib/swr/editors";
 import type {
@@ -42,9 +46,6 @@ import type {
   WorkspaceType,
 } from "@app/types";
 import { GLOBAL_AGENTS_SID, isAdmin } from "@app/types";
-
-import { AddEditorDropdown } from "../members/AddEditorsDropdown";
-import { MembersList } from "../members/MembersList";
 
 export const SCOPE_INFO: Record<
   AgentConfigurationScope,
@@ -228,7 +229,7 @@ export function AssistantDetails({
   user,
 }: AssistantDetailsProps) {
   const [selectedTab, setSelectedTab] = useState<
-    "info" | "performance" | "editors"
+    "info" | "performance" | "editors" | "agent_memory"
   >("info");
   const {
     agentConfiguration,
@@ -251,6 +252,9 @@ export function AssistantDetails({
 
   const [showRestoreModal, setShowRestoreModal] = useState(false);
   const showEditorsTabs = assistantId != null && !isGlobalAgent;
+  const showAgentMemory = !!agentConfiguration?.actions.find(
+    (a) => a.name === "agent_memory"
+  );
 
   const showPerformanceTabs =
     (agentConfiguration?.canEdit || isAdmin(owner)) &&
@@ -364,6 +368,14 @@ export function AssistantDetails({
                         onClick={() => setSelectedTab("editors")}
                       />
                     )}
+                    {showAgentMemory && (
+                      <TabsTrigger
+                        value="agent_memory"
+                        label="Memory"
+                        icon={BrainIcon}
+                        onClick={() => setSelectedTab("agent_memory")}
+                      />
+                    )}
                   </TabsList>
                 </Tabs>
               ) : (
@@ -392,6 +404,14 @@ export function AssistantDetails({
                       user={user}
                       agentConfiguration={agentConfiguration}
                     />
+                  )}
+                  {showAgentMemory && selectedTab === "agent_memory" && (
+                    <>
+                      <AgentMemorySection
+                        owner={owner}
+                        agentConfiguration={agentConfiguration}
+                      />
+                    </>
                   )}
                 </>
               )}

--- a/front/components/assistant/details/AgentMemorySection.tsx
+++ b/front/components/assistant/details/AgentMemorySection.tsx
@@ -9,7 +9,7 @@ import {
   DialogTitle,
   Page,
   Spinner,
-  XMarkIcon,
+  TrashIcon,
 } from "@dust-tt/sparkle";
 import { useState } from "react";
 
@@ -113,7 +113,10 @@ export function AgentMemorySection({
       )}
 
       <div className="flex flex-col gap-4">
-        <Page.P variant="secondary">Memories the agent has about you:</Page.P>
+        <Page.SectionHeader
+          title="Saved memories"
+          description="Personal details this assistant remembers from your conversations."
+        />
 
         {isMemoriesLoading ? (
           <div className="mt-6 flex h-full w-full items-center justify-center">
@@ -135,7 +138,7 @@ export function AgentMemorySection({
                     action={
                       <CardActionButton
                         size="mini"
-                        icon={XMarkIcon}
+                        icon={TrashIcon}
                         onClick={() => {
                           setMemoryToDelete(memory.sId);
                         }}

--- a/front/components/assistant/details/AgentMemorySection.tsx
+++ b/front/components/assistant/details/AgentMemorySection.tsx
@@ -1,0 +1,17 @@
+import type { AgentConfigurationType, LightWorkspaceType } from "@app/types";
+
+interface AgentMemorySectionProps {
+  owner: LightWorkspaceType;
+  agentConfiguration: AgentConfigurationType;
+}
+
+export function AgentMemorySection({
+  owner,
+  agentConfiguration,
+}: AgentMemorySectionProps) {
+  return (
+    <>
+      <div>Mem2</div>
+    </>
+  );
+}

--- a/front/components/assistant/details/AgentMemorySection.tsx
+++ b/front/components/assistant/details/AgentMemorySection.tsx
@@ -1,4 +1,84 @@
+import {
+  Card,
+  CardActionButton,
+  Dialog,
+  DialogContainer,
+  DialogContent,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  Page,
+  Spinner,
+  XMarkIcon,
+} from "@dust-tt/sparkle";
+
+import {
+  useAgentMemoriesForUser,
+  useDeleteAgentMemory,
+} from "@app/lib/swr/agent_memories";
+import { timeAgoFrom } from "@app/lib/utils";
 import type { AgentConfigurationType, LightWorkspaceType } from "@app/types";
+import { useState } from "react";
+
+type DeleteMemoryDialogProps = {
+  owner: LightWorkspaceType;
+  onClose: (deleted: boolean) => void;
+  memoryId: string;
+  agentConfiguration: AgentConfigurationType;
+  isOpen: boolean;
+};
+
+function DeleteMemoryDialog({
+  owner,
+  agentConfiguration,
+  memoryId,
+  isOpen,
+  onClose,
+}: DeleteMemoryDialogProps) {
+  const { deleteMemory } = useDeleteAgentMemory({ owner, agentConfiguration });
+
+  const [isLoading, setIsLoading] = useState(false);
+
+  return (
+    <Dialog
+      open={isOpen}
+      onOpenChange={(open) => {
+        if (!open) {
+          onClose(false);
+        }
+      }}
+    >
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>Confirm Deletion</DialogTitle>
+        </DialogHeader>
+        <DialogContainer>
+          <div>Are you sure you want to delete this memory ?</div>
+        </DialogContainer>
+        <DialogFooter
+          leftButtonProps={{
+            label: "Cancel",
+            disabled: isLoading,
+            variant: "outline",
+            onClick: onClose,
+          }}
+          rightButtonProps={{
+            isLoading,
+            label: "Delete",
+            variant: "warning",
+            disabled: isLoading,
+            onClick: async () => {
+              setIsLoading(true);
+              await deleteMemory(memoryId);
+              setIsLoading(false);
+              onClose(true);
+            },
+          }}
+        />
+      </DialogContent>
+    </Dialog>
+  );
+}
 
 interface AgentMemorySectionProps {
   owner: LightWorkspaceType;
@@ -9,9 +89,70 @@ export function AgentMemorySection({
   owner,
   agentConfiguration,
 }: AgentMemorySectionProps) {
+  const { memories, isMemoriesLoading } = useAgentMemoriesForUser({
+    owner,
+    agentConfiguration,
+  });
+
+  const [memoryToDelete, setMemoryToDelete] = useState<string | undefined>(
+    undefined
+  );
+
   return (
     <>
-      <div>Mem2</div>
+      {memoryToDelete && (
+        <DeleteMemoryDialog
+          owner={owner}
+          agentConfiguration={agentConfiguration}
+          memoryId={memoryToDelete}
+          isOpen={memoryToDelete !== undefined}
+          onClose={() => {
+            setMemoryToDelete(undefined);
+          }}
+        />
+      )}
+
+      <div className="flex flex-col gap-4">
+        <Page.P variant="secondary">Memories the agent has about you:</Page.P>
+
+        {isMemoriesLoading && (
+          <div className="mt-6 flex h-full w-full items-center justify-center">
+            <Spinner size="md" />
+          </div>
+        )}
+
+        {memories.length === 0 ? (
+          <div className="text-sm text-muted-foreground">No memories yet.</div>
+        ) : (
+          <div className="flex flex-col gap-3">
+            {memories.map((memory) => (
+              <Card
+                key={memory.sId}
+                size={"md"}
+                className="flex flex-col gap-2"
+                action={
+                  <CardActionButton
+                    size="mini"
+                    icon={XMarkIcon}
+                    onClick={() => {
+                      setMemoryToDelete(memory.sId);
+                    }}
+                  />
+                }
+              >
+                <div className="flex flex-col gap-2">
+                  <div className="text-xs text-muted-foreground">
+                    {timeAgoFrom(new Date(memory.lastUpdated).getTime())} ago
+                  </div>
+                  <div className="text-sm text-foreground">
+                    {memory.content}
+                  </div>
+                </div>
+              </Card>
+            ))}
+          </div>
+        )}
+      </div>
     </>
   );
 }

--- a/front/components/assistant/details/AgentMemorySection.tsx
+++ b/front/components/assistant/details/AgentMemorySection.tsx
@@ -115,42 +115,47 @@ export function AgentMemorySection({
       <div className="flex flex-col gap-4">
         <Page.P variant="secondary">Memories the agent has about you:</Page.P>
 
-        {isMemoriesLoading && (
+        {isMemoriesLoading ? (
           <div className="mt-6 flex h-full w-full items-center justify-center">
             <Spinner size="md" />
           </div>
-        )}
-
-        {memories.length === 0 ? (
-          <div className="text-sm text-muted-foreground">No memories yet.</div>
         ) : (
-          <div className="flex flex-col gap-3">
-            {memories.map((memory) => (
-              <Card
-                key={memory.sId}
-                size={"md"}
-                className="flex flex-col gap-2"
-                action={
-                  <CardActionButton
-                    size="mini"
-                    icon={XMarkIcon}
-                    onClick={() => {
-                      setMemoryToDelete(memory.sId);
-                    }}
-                  />
-                }
-              >
-                <div className="flex flex-col gap-2">
-                  <div className="text-xs text-muted-foreground">
-                    {timeAgoFrom(new Date(memory.lastUpdated).getTime())} ago
-                  </div>
-                  <div className="text-sm text-foreground">
-                    {memory.content}
-                  </div>
-                </div>
-              </Card>
-            ))}
-          </div>
+          <>
+            {memories.length === 0 ? (
+              <div className="text-sm text-muted-foreground">
+                No memories yet.
+              </div>
+            ) : (
+              <div className="flex flex-col gap-3">
+                {memories.map((memory) => (
+                  <Card
+                    key={memory.sId}
+                    size={"md"}
+                    className="flex flex-col gap-2"
+                    action={
+                      <CardActionButton
+                        size="mini"
+                        icon={XMarkIcon}
+                        onClick={() => {
+                          setMemoryToDelete(memory.sId);
+                        }}
+                      />
+                    }
+                  >
+                    <div className="flex flex-col gap-2">
+                      <div className="text-xs text-muted-foreground">
+                        {timeAgoFrom(new Date(memory.lastUpdated).getTime())}{" "}
+                        ago
+                      </div>
+                      <div className="text-sm text-foreground">
+                        {memory.content}
+                      </div>
+                    </div>
+                  </Card>
+                ))}
+              </div>
+            )}
+          </>
         )}
       </div>
     </>

--- a/front/components/assistant/details/AgentMemorySection.tsx
+++ b/front/components/assistant/details/AgentMemorySection.tsx
@@ -11,6 +11,7 @@ import {
   Spinner,
   XMarkIcon,
 } from "@dust-tt/sparkle";
+import { useState } from "react";
 
 import {
   useAgentMemoriesForUser,
@@ -18,7 +19,6 @@ import {
 } from "@app/lib/swr/agent_memories";
 import { timeAgoFrom } from "@app/lib/utils";
 import type { AgentConfigurationType, LightWorkspaceType } from "@app/types";
-import { useState } from "react";
 
 type DeleteMemoryDialogProps = {
   owner: LightWorkspaceType;

--- a/front/lib/actions/configuration/mcp.ts
+++ b/front/lib/actions/configuration/mcp.ts
@@ -164,7 +164,7 @@ export async function fetchMCPServerActionConfigurations(
         icon: serverIcon,
         mcpServerViewId: mcpServerView?.sId ?? "",
         internalMCPServerId: config.internalMCPServerId,
-        mcpServerName: mcpServerView?.toJSON().server.name ?? null,
+        mcpServerName: serverName,
         dataSources: dataSourceConfigurations.map(
           renderDataSourceConfiguration
         ),

--- a/front/lib/actions/configuration/mcp.ts
+++ b/front/lib/actions/configuration/mcp.ts
@@ -164,6 +164,7 @@ export async function fetchMCPServerActionConfigurations(
         icon: serverIcon,
         mcpServerViewId: mcpServerView?.sId ?? "",
         internalMCPServerId: config.internalMCPServerId,
+        mcpServerName: mcpServerView?.toJSON().server.name ?? null,
         dataSources: dataSourceConfigurations.map(
           renderDataSourceConfiguration
         ),

--- a/front/lib/actions/mcp.ts
+++ b/front/lib/actions/mcp.ts
@@ -96,6 +96,8 @@ export type BaseMCPServerConfigurationType = {
   type: "mcp_server_configuration";
 
   name: string;
+  mcpServerName: string | null;
+
   description: string | null;
   icon?: CustomServerIconType | InternalAllowedIconType;
 };

--- a/front/lib/actions/mcp_actions.test.ts
+++ b/front/lib/actions/mcp_actions.test.ts
@@ -14,6 +14,7 @@ describe("getPrefixedToolName", () => {
     id: 1,
     description: "Test server description",
     mcpServerViewId: "test-view-id",
+    mcpServerName: "test_server",
     dataSources: null,
     tables: null,
     childAgentId: null,

--- a/front/lib/actions/types/agent.ts
+++ b/front/lib/actions/types/agent.ts
@@ -32,7 +32,7 @@ export function isActionConfigurationType(
 // We need to apply "Omit" to each member of the union separately rather than the whole union
 // because Omit<A | B, "k"> is different from Omit<A, "k"> | Omit<B, "k">.
 // The first form loses the discriminated union properties needed for type narrowing.
-type UnsavedConfiguration<T> = Omit<T, "id" | "sId">;
+type UnsavedConfiguration<T> = Omit<T, "id" | "sId" | "mcpServerName">;
 export type UnsavedAgentActionConfigurationType = {
   [K in AgentActionConfigurationType["type"]]: UnsavedConfiguration<
     Extract<AgentActionConfigurationType, { type: K }>

--- a/front/lib/api/actions/mcp_client_side.ts
+++ b/front/lib/api/actions/mcp_client_side.ts
@@ -118,6 +118,8 @@ export async function createClientSideMCPServerConfigurations(
     name:
       metadata.find((m) => m?.serverId === serverId)?.serverName ||
       `MCP Server ${serverId}`,
+    mcpServerName:
+      metadata.find((m) => m?.serverId === serverId)?.serverName || null,
     sId: serverId,
     type: "mcp_server_configuration",
   }));

--- a/front/lib/api/assistant/configuration.ts
+++ b/front/lib/api/assistant/configuration.ts
@@ -1137,6 +1137,7 @@ export async function createAgentActionConfiguration(
       name: action.name,
       description: action.description,
       mcpServerViewId: action.mcpServerViewId,
+      mcpServerName: action.mcpServerName,
       internalMCPServerId: action.internalMCPServerId,
       dataSources: action.dataSources,
       tables: action.tables,

--- a/front/lib/api/assistant/global_agents.ts
+++ b/front/lib/api/assistant/global_agents.ts
@@ -157,6 +157,7 @@ function _getDefaultWebActionsForGlobalAgent({
       // a legacy agent (see isLegacyAgent) and being capped to 1 action.
       description: DEFAULT_WEBSEARCH_ACTION_DESCRIPTION,
       mcpServerViewId: webSearchBrowseMCPServerView.sId,
+      mcpServerName: webSearchBrowseMCPServerView.toJSON().server.name,
       internalMCPServerId: webSearchBrowseMCPServerView.internalMCPServerId,
       dataSources: null,
       tables: null,
@@ -187,6 +188,7 @@ function _getAgentRouterToolsConfiguration(
       description: DEFAULT_AGENT_ROUTER_ACTION_DESCRIPTION,
       mcpServerViewId: mcpServerView.sId,
       internalMCPServerId,
+      mcpServerName: mcpServerView.toJSON().server.name,
       dataSources: null,
       tables: null,
       childAgentId: null,
@@ -258,6 +260,7 @@ function _getHelperGlobalAgent({
       name: "search_dust_docs",
       description: "The documentation of the Dust platform.",
       mcpServerViewId: searchMCPServerView.sId,
+      mcpServerName: searchMCPServerView.toJSON().server.name,
       internalMCPServerId: searchMCPServerView.internalMCPServerId,
       dataSources: [
         {
@@ -1373,6 +1376,7 @@ function _getManagedDataSourceAgent(
       name: "search_data_sources",
       description: `The user's ${connectorProvider} data source.`,
       mcpServerViewId: searchMCPServerView.sId,
+      mcpServerName: searchMCPServerView.toJSON().server.name,
       internalMCPServerId: searchMCPServerView.internalMCPServerId,
       dataSources: filteredDataSourceViews.map((dsView) => ({
         dataSourceViewId: dsView.sId,
@@ -1673,6 +1677,7 @@ The agent should not provide additional information or content that the user did
       description: "The user's entire workspace data sources",
       mcpServerViewId: searchMCPServerView.sId,
       internalMCPServerId: searchMCPServerView.internalMCPServerId,
+      mcpServerName: searchMCPServerView.toJSON().server.name,
       dataSources: dataSourceViews.map((dsView) => ({
         dataSourceViewId: dsView.sId,
         workspaceId: preFetchedDataSources.workspaceId,
@@ -1709,6 +1714,7 @@ The agent should not provide additional information or content that the user did
           name: "hidden_dust_search_" + dsView.dataSource.name,
           description: `The user's ${dsView.dataSource.connectorProvider} data source.`,
           mcpServerViewId: searchMCPServerView.sId,
+          mcpServerName: searchMCPServerView.toJSON().server.name,
           internalMCPServerId: searchMCPServerView.internalMCPServerId,
           dataSources: [
             {

--- a/front/lib/api/assistant/jit_actions.ts
+++ b/front/lib/api/assistant/jit_actions.ts
@@ -74,6 +74,7 @@ export async function getJITServers(
     jsonSchema: null,
     additionalConfiguration: {},
     mcpServerViewId: conversationFilesView.sId,
+    mcpServerName: conversationFilesView.toJSON().server.name,
     dustAppConfiguration: null,
     internalMCPServerId: conversationFilesView.mcpServerId,
   };
@@ -175,6 +176,7 @@ export async function getJITServers(
       jsonSchema: null,
       additionalConfiguration: {},
       mcpServerViewId: queryTablesView.sId,
+      mcpServerName: queryTablesView.toJSON().server.name,
       dustAppConfiguration: null,
       internalMCPServerId: queryTablesView.mcpServerId,
     };
@@ -234,7 +236,8 @@ export async function getJITServers(
       timeFrame: null,
       jsonSchema: null,
       additionalConfiguration: {},
-      mcpServerViewId: retrievalView.sId,
+      mcpServerViewId: retrievalView.sId ,
+      mcpServerName: retrievalView.toJSON().server.name,
       dustAppConfiguration: null,
       internalMCPServerId: retrievalView.mcpServerId,
     };

--- a/front/lib/api/assistant/jit_actions.ts
+++ b/front/lib/api/assistant/jit_actions.ts
@@ -236,7 +236,7 @@ export async function getJITServers(
       timeFrame: null,
       jsonSchema: null,
       additionalConfiguration: {},
-      mcpServerViewId: retrievalView.sId ,
+      mcpServerViewId: retrievalView.sId,
       mcpServerName: retrievalView.toJSON().server.name,
       dustAppConfiguration: null,
       internalMCPServerId: retrievalView.mcpServerId,
@@ -288,6 +288,7 @@ export async function getJITServers(
       mcpServerViewId: retrievalView.sId,
       dustAppConfiguration: null,
       internalMCPServerId: retrievalView.mcpServerId,
+      mcpServerName: retrievalView.toJSON().server.name,
     };
     jitServers.push(folderSearchServer);
   }

--- a/front/lib/swr/agent_memories.ts
+++ b/front/lib/swr/agent_memories.ts
@@ -1,0 +1,137 @@
+import { useCallback } from "react";
+import type { Fetcher } from "swr";
+
+import { useSendNotification } from "@app/hooks/useNotification";
+import { emptyArray, fetcher, useSWRWithDefaults } from "@app/lib/swr/swr";
+import type { GetAgentMemoriesResponseBody } from "@app/pages/api/w/[wId]/assistant/agent_configurations/[aId]/memories";
+import type { PatchAgentMemoryRequestBody } from "@app/pages/api/w/[wId]/assistant/agent_configurations/[aId]/memories/[mId]";
+import type { AgentConfigurationType, LightWorkspaceType } from "@app/types";
+
+export function useAgentMemoriesForUser({
+  owner,
+  agentConfiguration,
+  disabled,
+}: {
+  owner: LightWorkspaceType;
+  agentConfiguration: AgentConfigurationType;
+  disabled?: boolean;
+}) {
+  const memoriesFetcher: Fetcher<GetAgentMemoriesResponseBody> = fetcher;
+
+  const { data, error, mutate } = useSWRWithDefaults(
+    `/api/w/${owner.sId}/assistant/agent_configurations/${agentConfiguration.sId}/memories`,
+    memoriesFetcher,
+    {
+      disabled,
+    }
+  );
+
+  return {
+    memories: data?.memories ?? emptyArray(),
+    isMemoriesLoading: !error && !data && !disabled,
+    isMemoriesError: !!error,
+    mutateMemories: mutate,
+  };
+}
+
+export function useUpdateAgentMemory({
+  owner,
+  agentConfiguration,
+}: {
+  owner: LightWorkspaceType;
+  agentConfiguration: AgentConfigurationType;
+}) {
+  const sendNotification = useSendNotification();
+  const { mutateMemories } = useAgentMemoriesForUser({
+    owner,
+    agentConfiguration,
+    disabled: true,
+  });
+
+  const updateMemory = useCallback(
+    async (memoryId: string, body: PatchAgentMemoryRequestBody) => {
+      const res = await fetch(
+        `/api/w/${owner.sId}/assistant/agent_configurations/${agentConfiguration.sId}/memories/${memoryId}`,
+        {
+          method: "PATCH",
+          headers: {
+            "Content-Type": "application/json",
+          },
+          body: JSON.stringify(body),
+        }
+      );
+
+      if (!res.ok) {
+        const json = await res.json();
+        sendNotification({
+          type: "error",
+          title: "Failed to update memory",
+          description: json.error?.message || "Failed to update memory",
+        });
+        return null;
+      }
+
+      sendNotification({
+        type: "success",
+        title: "Memory updated",
+      });
+
+      void mutateMemories();
+      const json = await res.json();
+      return json.memory;
+    },
+    [owner.sId, agentConfiguration, sendNotification, mutateMemories]
+  );
+
+  return { updateMemory };
+}
+
+export function useDeleteAgentMemory({
+  owner,
+  agentConfiguration,
+}: {
+  owner: LightWorkspaceType;
+  agentConfiguration: AgentConfigurationType;
+}) {
+  const sendNotification = useSendNotification();
+  const { mutateMemories } = useAgentMemoriesForUser({
+    owner,
+    agentConfiguration,
+    disabled: true,
+  });
+
+  const deleteMemory = useCallback(
+    async (memoryId: string) => {
+      const res = await fetch(
+        `/api/w/${owner.sId}/assistant/agent_configurations/${agentConfiguration.sId}/memories/${memoryId}`,
+        {
+          method: "DELETE",
+          headers: {
+            "Content-Type": "application/json",
+          },
+        }
+      );
+
+      if (!res.ok) {
+        const json = await res.json();
+        sendNotification({
+          type: "error",
+          title: "Failed to delete memory",
+          description: json.error?.message || "Failed to delete memory",
+        });
+        return false;
+      }
+
+      sendNotification({
+        type: "success",
+        title: "Memory deleted",
+      });
+
+      void mutateMemories();
+      return true;
+    },
+    [owner.sId, agentConfiguration, sendNotification, mutateMemories]
+  );
+
+  return { deleteMemory };
+}

--- a/front/package-lock.json
+++ b/front/package-lock.json
@@ -8,7 +8,7 @@
         "@auth0/nextjs-auth0": "^3.5.0",
         "@datadog/browser-logs": "^6.13.0",
         "@dust-tt/client": "file:../sdks/js",
-        "@dust-tt/sparkle": "^0.2.545",
+        "@dust-tt/sparkle": "^0.2.544",
         "@google-cloud/bigquery": "^7.9.1",
         "@google-cloud/storage-transfer": "^3.6.0",
         "@heroicons/react": "^2.0.11",

--- a/front/pages/api/w/[wId]/assistant/agent_configurations/[aId]/memories/[mId]/index.ts
+++ b/front/pages/api/w/[wId]/assistant/agent_configurations/[aId]/memories/[mId]/index.ts
@@ -1,0 +1,131 @@
+import { isLeft } from "fp-ts/lib/Either";
+import * as t from "io-ts";
+import * as reporter from "io-ts-reporters";
+import type { NextApiRequest, NextApiResponse } from "next";
+
+import { getAgentConfiguration } from "@app/lib/api/assistant/configuration";
+import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
+import type { Authenticator } from "@app/lib/auth";
+import { AgentMemoryResource } from "@app/lib/resources/agent_memory_resource";
+import { apiError, withLogging } from "@app/logger/withlogging";
+import type { WithAPIErrorResponse } from "@app/types";
+
+export const PatchAgentMemoryRequestBodySchema = t.type({
+  content: t.string,
+});
+
+export type PatchAgentMemoryRequestBody = t.TypeOf<
+  typeof PatchAgentMemoryRequestBodySchema
+>;
+
+export interface PatchAgentMemoryResponseBody {
+  memory: {
+    sId: string;
+    lastUpdated: Date;
+    content: string;
+  };
+}
+
+async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse<
+    WithAPIErrorResponse<PatchAgentMemoryResponseBody | void>
+  >,
+  auth: Authenticator
+): Promise<void> {
+  const agentConfigurationId = req.query.aId as string;
+  const memoryId = req.query.mId as string;
+
+  const agentConfiguration = await getAgentConfiguration(
+    auth,
+    agentConfigurationId,
+    "light"
+  );
+  if (!agentConfiguration || !agentConfiguration.canRead) {
+    return apiError(req, res, {
+      status_code: 404,
+      api_error: {
+        type: "agent_configuration_not_found",
+        message: "The agent configuration was not found.",
+      },
+    });
+  }
+
+  const user = auth.user();
+  if (!user) {
+    return apiError(req, res, {
+      status_code: 401,
+      api_error: {
+        type: "user_authentication_required",
+        message: "You must be authenticated as a user to access this resource.",
+      },
+    });
+  }
+
+  const memory = await AgentMemoryResource.fetchByIdForUser(auth, {
+    memoryId,
+    user: user.toJSON(),
+  });
+  if (!memory) {
+    return apiError(req, res, {
+      status_code: 404,
+      api_error: {
+        type: "agent_memory_not_found",
+        message: "The agent memory was not found.",
+      },
+    });
+  }
+
+  switch (req.method) {
+    case "PATCH": {
+      const bodyValidation = PatchAgentMemoryRequestBodySchema.decode(req.body);
+      if (isLeft(bodyValidation)) {
+        const pathError = reporter.formatValidationErrors(bodyValidation.left);
+        return apiError(req, res, {
+          status_code: 400,
+          api_error: {
+            type: "invalid_request_error",
+            message: `Invalid request body: ${pathError}`,
+          },
+        });
+      }
+
+      const { content } = bodyValidation.right;
+
+      // Update the memory content
+      await memory.updateContent(auth, content);
+
+      return res.status(200).json({
+        memory: memory.toJSON(),
+      });
+    }
+
+    case "DELETE": {
+      const result = await memory.delete(auth, {});
+      if (result.isErr()) {
+        return apiError(req, res, {
+          status_code: 500,
+          api_error: {
+            type: "internal_server_error",
+            message: "Failed to delete memory.",
+          },
+        });
+      }
+
+      res.status(204).end();
+      return;
+    }
+
+    default:
+      return apiError(req, res, {
+        status_code: 405,
+        api_error: {
+          type: "method_not_supported_error",
+          message:
+            "The method passed is not supported, PATCH or DELETE is expected.",
+        },
+      });
+  }
+}
+
+export default withLogging(withSessionAuthenticationForWorkspace(handler));

--- a/front/pages/api/w/[wId]/assistant/agent_configurations/[aId]/memories/index.ts
+++ b/front/pages/api/w/[wId]/assistant/agent_configurations/[aId]/memories/index.ts
@@ -1,0 +1,71 @@
+import type { NextApiRequest, NextApiResponse } from "next";
+
+import { getAgentConfiguration } from "@app/lib/api/assistant/configuration";
+import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
+import type { Authenticator } from "@app/lib/auth";
+import { AgentMemoryResource } from "@app/lib/resources/agent_memory_resource";
+import { apiError, withLogging } from "@app/logger/withlogging";
+import type { WithAPIErrorResponse } from "@app/types";
+
+export interface GetAgentMemoriesResponseBody {
+  memories: Array<{
+    sId: string;
+    lastUpdated: Date;
+    content: string;
+  }>;
+}
+
+async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse<WithAPIErrorResponse<GetAgentMemoriesResponseBody>>,
+  auth: Authenticator
+): Promise<void> {
+  const agentConfigurationId = req.query.aId as string;
+
+  const agentConfiguration = await getAgentConfiguration(
+    auth,
+    agentConfigurationId,
+    "light"
+  );
+  if (!agentConfiguration || !agentConfiguration.canRead) {
+    return apiError(req, res, {
+      status_code: 404,
+      api_error: {
+        type: "agent_configuration_not_found",
+        message: "The agent configuration was not found.",
+      },
+    });
+  }
+
+  const user = auth.user();
+  if (!user) {
+    return res.status(200).json({
+      memories: [],
+    });
+  }
+
+  switch (req.method) {
+    case "GET": {
+      const memories =
+        await AgentMemoryResource.findByAgentConfigurationAndUser(auth, {
+          agentConfiguration,
+          user: user.toJSON(),
+        });
+
+      return res.status(200).json({
+        memories: memories.map((memory) => memory.toJSON()),
+      });
+    }
+
+    default:
+      return apiError(req, res, {
+        status_code: 405,
+        api_error: {
+          type: "method_not_supported_error",
+          message: "The method passed is not supported, GET is expected.",
+        },
+      });
+  }
+}
+
+export default withLogging(withSessionAuthenticationForWorkspace(handler));

--- a/front/pages/w/[wId]/builder/assistants/create.tsx
+++ b/front/pages/w/[wId]/builder/assistants/create.tsx
@@ -18,9 +18,7 @@ import { TemplateGrid } from "@app/components/assistant_builder/TemplateGrid";
 import type { BuilderFlow } from "@app/components/assistant_builder/types";
 import { BUILDER_FLOWS } from "@app/components/assistant_builder/types";
 import { AppCenteredLayout } from "@app/components/sparkle/AppCenteredLayout";
-import AppContentLayout, {
-  appLayoutBack,
-} from "@app/components/sparkle/AppContentLayout";
+import { appLayoutBack } from "@app/components/sparkle/AppContentLayout";
 import { AppLayoutSimpleCloseTitle } from "@app/components/sparkle/AppLayoutTitle";
 import AppRootLayout from "@app/components/sparkle/AppRootLayout";
 import { isRestrictedFromAgentCreation } from "@app/lib/auth";

--- a/front/types/error.ts
+++ b/front/types/error.ts
@@ -124,6 +124,8 @@ const API_ERROR_TYPES = [
   "workos_server_error",
   "workos_multiple_sso_connections_not_supported",
   "workos_multiple_directories_not_supported",
+  "user_authentication_required",
+  "agent_memory_not_found",
 ] as const;
 
 export type APIErrorType = (typeof API_ERROR_TYPES)[number];


### PR DESCRIPTION
## Description

Adds a UI in the AssistantDetails panel to introspect memory about the user + delete selected memories.

<img width="596" height="579" alt="Screenshot from 2025-07-24 22-12-58" src="https://github.com/user-attachments/assets/a3be6321-f168-4d74-a435-9066bb2ef7bd" />

<img width="1388" height="1304" alt="Screenshot from 2025-07-24 22-13-03" src="https://github.com/user-attachments/assets/f60af782-5472-448a-a084-c08b5edbf606" />


## Tests

Tested locally

## Risk

Low

## Deploy Plan

- deploy `front`