### PR TITLE
[front] feat(ab): Connect selected sources state to a form

### DIFF
--- a/front/components/agent_builder/capabilities/knowledge/KnowledgeConfigurationSheet.tsx
+++ b/front/components/agent_builder/capabilities/knowledge/KnowledgeConfigurationSheet.tsx
@@ -1,5 +1,9 @@
 import type { MultiPageSheetPage } from "@dust-tt/sparkle";
-import { MultiPageSheet, MultiPageSheetContent, ScrollArea } from "@dust-tt/sparkle";
+import {
+  MultiPageSheet,
+  MultiPageSheetContent,
+  ScrollArea,
+} from "@dust-tt/sparkle";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { useEffect, useMemo, useState } from "react";
 import type { Control } from "react-hook-form";
@@ -16,9 +20,7 @@ import {
   isValidPage,
 } from "@app/components/agent_builder/capabilities/knowledge/shared/sheetUtils";
 import { TimeFrameSection } from "@app/components/agent_builder/capabilities/knowledge/shared/TimeFrameSection";
-import {
-  transformTreeToSelectionConfigurations,
-} from "@app/components/agent_builder/capabilities/knowledge/transformations";
+import { transformTreeToSelectionConfigurations } from "@app/components/agent_builder/capabilities/knowledge/transformations";
 import type { CapabilityConfig } from "@app/components/agent_builder/capabilities/knowledge/utils";
 import {
   CAPABILITY_CONFIGS,
@@ -31,7 +33,10 @@ import type {
   KnowledgeServerName,
 } from "@app/components/agent_builder/types";
 import type { AgentBuilderAction } from "@app/components/agent_builder/types";
-import { capabilityFormSchema, CONFIGURATION_SHEET_PAGE_IDS } from "@app/components/agent_builder/types";
+import {
+  capabilityFormSchema,
+  CONFIGURATION_SHEET_PAGE_IDS,
+} from "@app/components/agent_builder/types";
 import { useSpacesContext } from "@app/components/assistant_builder/contexts/SpacesContext";
 import { DataSourceBuilderSelector } from "@app/components/data_source_view/DataSourceBuilderSelector";
 import type { DataSourceViewSelectionConfigurations } from "@app/types";
@@ -249,7 +254,7 @@ function KnowledgeConfigurationSheetContent({
         );
         onSave(formData, dataSourceConfigurations);
       })}
-      size="lg"
+      size="xl"
       showNavigation
       disableNext={disableNext}
       disableSave={!isDirty}

--- a/front/components/agent_builder/capabilities/knowledge/KnowledgeConfigurationSheet.tsx
+++ b/front/components/agent_builder/capabilities/knowledge/KnowledgeConfigurationSheet.tsx
@@ -1,9 +1,5 @@
 import type { MultiPageSheetPage } from "@dust-tt/sparkle";
-import {
-  MultiPageSheet,
-  MultiPageSheetContent,
-  ScrollArea,
-} from "@dust-tt/sparkle";
+import { MultiPageSheet, MultiPageSheetContent, ScrollArea } from "@dust-tt/sparkle";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { useEffect, useMemo, useState } from "react";
 import type { Control } from "react-hook-form";
@@ -14,19 +10,20 @@ import type { AgentBuilderFormData } from "@app/components/agent_builder/AgentBu
 import { DescriptionSection } from "@app/components/agent_builder/capabilities/knowledge/shared/DescriptionSection";
 import { JsonSchemaSection } from "@app/components/agent_builder/capabilities/knowledge/shared/JsonSchemaSection";
 import {
-  getDataSourceConfigurations,
   getDataSourceTree,
   getJsonSchema,
   getTimeFrame,
   isValidPage,
 } from "@app/components/agent_builder/capabilities/knowledge/shared/sheetUtils";
 import { TimeFrameSection } from "@app/components/agent_builder/capabilities/knowledge/shared/TimeFrameSection";
+import {
+  transformTreeToSelectionConfigurations,
+} from "@app/components/agent_builder/capabilities/knowledge/transformations";
 import type { CapabilityConfig } from "@app/components/agent_builder/capabilities/knowledge/utils";
 import {
   CAPABILITY_CONFIGS,
   generateActionFromFormData,
 } from "@app/components/agent_builder/capabilities/knowledge/utils";
-import { transformTreeToSelectionConfigurations } from "@app/components/agent_builder/capabilities/knowledge/utils/transformations";
 import { useDataSourceViewsContext } from "@app/components/agent_builder/DataSourceViewsContext";
 import type {
   CapabilityFormData,
@@ -34,10 +31,7 @@ import type {
   KnowledgeServerName,
 } from "@app/components/agent_builder/types";
 import type { AgentBuilderAction } from "@app/components/agent_builder/types";
-import {
-  capabilityFormSchema,
-  CONFIGURATION_SHEET_PAGE_IDS,
-} from "@app/components/agent_builder/types";
+import { capabilityFormSchema, CONFIGURATION_SHEET_PAGE_IDS } from "@app/components/agent_builder/types";
 import { useSpacesContext } from "@app/components/assistant_builder/contexts/SpacesContext";
 import { DataSourceBuilderSelector } from "@app/components/data_source_view/DataSourceBuilderSelector";
 import type { DataSourceViewSelectionConfigurations } from "@app/types";

--- a/front/components/agent_builder/capabilities/knowledge/KnowledgeConfigurationSheet.tsx
+++ b/front/components/agent_builder/capabilities/knowledge/KnowledgeConfigurationSheet.tsx
@@ -7,7 +7,7 @@ import {
 import { zodResolver } from "@hookform/resolvers/zod";
 import { useEffect, useMemo, useState } from "react";
 import type { Control } from "react-hook-form";
-import { createFormControl, useWatch } from "react-hook-form";
+import { createFormControl, useFormState, useWatch } from "react-hook-form";
 
 import { useAgentBuilderContext } from "@app/components/agent_builder/AgentBuilderContext";
 import type { AgentBuilderFormData } from "@app/components/agent_builder/AgentBuilderFormContext";
@@ -17,7 +17,6 @@ import {
   getDataSourceConfigurations,
   getJsonSchema,
   getTimeFrame,
-  hasDataSourceSelections,
   isValidPage,
 } from "@app/components/agent_builder/capabilities/knowledge/shared/sheetUtils";
 import { TimeFrameSection } from "@app/components/agent_builder/capabilities/knowledge/shared/TimeFrameSection";
@@ -160,8 +159,6 @@ function KnowledgeConfigurationSheetContent({
       getDataSourceConfigurations(action)
     );
 
-  const hasDataSources = hasDataSourceSelections(dataSourceConfigurations);
-
   const handlePageChange = (pageId: string) => {
     if (isValidPage(pageId, CONFIGURATION_SHEET_PAGE_IDS)) {
       setCurrentPageId(pageId);
@@ -223,6 +220,8 @@ function KnowledgeConfigurationSheetContent({
     },
   ];
 
+  const { isDirty } = useFormState({ control });
+
   const sources = useWatch({
     control,
     name: "sources",
@@ -246,7 +245,7 @@ function KnowledgeConfigurationSheetContent({
       size="lg"
       showNavigation
       disableNext={disableNext}
-      disableSave={!hasDataSources}
+      disableSave={!isDirty}
     />
   );
 }

--- a/front/components/agent_builder/capabilities/knowledge/shared/DescriptionSection.tsx
+++ b/front/components/agent_builder/capabilities/knowledge/shared/DescriptionSection.tsx
@@ -1,5 +1,6 @@
 import { TextArea } from "@dust-tt/sparkle";
-import { useController, useFormContext } from "react-hook-form";
+import type { Control } from "react-hook-form";
+import { useController } from "react-hook-form";
 
 import type { CapabilityFormData } from "@app/components/agent_builder/types";
 
@@ -10,9 +11,8 @@ interface DescriptionSectionProps {
   placeholder: string;
   helpText?: string;
   maxLength?: number;
+  control: Control<CapabilityFormData>;
 }
-
-const FIELD_NAME = "description";
 
 export function DescriptionSection({
   title,
@@ -20,10 +20,11 @@ export function DescriptionSection({
   label,
   placeholder,
   helpText,
+  control,
 }: DescriptionSectionProps) {
-  const { register } = useFormContext();
-  const { fieldState } = useController<CapabilityFormData, typeof FIELD_NAME>({
-    name: FIELD_NAME,
+  const { field, fieldState } = useController({
+    control,
+    name: "description",
   });
 
   return (
@@ -37,7 +38,7 @@ export function DescriptionSection({
         {label && <label className="text-sm font-medium">{label}</label>}
         <TextArea
           placeholder={placeholder}
-          {...register(FIELD_NAME)}
+          {...field}
           rows={4}
           showErrorLabel={true}
           error={fieldState.error?.message}

--- a/front/components/agent_builder/capabilities/knowledge/shared/JsonSchemaSection.tsx
+++ b/front/components/agent_builder/capabilities/knowledge/shared/JsonSchemaSection.tsx
@@ -1,5 +1,6 @@
 import { Button, SparklesIcon, TextArea } from "@dust-tt/sparkle";
 import { useEffect, useState } from "react";
+import type { Control } from "react-hook-form";
 import { useController, useFormContext } from "react-hook-form";
 
 import type { CapabilityFormData } from "@app/components/agent_builder/types";
@@ -14,6 +15,7 @@ interface JsonSchemaSectionProps {
   helpText?: string;
   agentInstructions?: string;
   owner: WorkspaceType;
+  control: Control<CapabilityFormData>;
 }
 
 export function JsonSchemaSection({
@@ -23,9 +25,11 @@ export function JsonSchemaSection({
   helpText,
   agentInstructions,
   owner,
+  control,
 }: JsonSchemaSectionProps) {
   const { getValues } = useFormContext();
-  const { field } = useController<CapabilityFormData, "jsonSchema">({
+  const { field } = useController({
+    control,
     name: "jsonSchema",
   });
 

--- a/front/components/agent_builder/capabilities/knowledge/shared/JsonSchemaSection.tsx
+++ b/front/components/agent_builder/capabilities/knowledge/shared/JsonSchemaSection.tsx
@@ -27,6 +27,7 @@ export function JsonSchemaSection({
   owner,
   control,
 }: JsonSchemaSectionProps) {
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars -- Left it here, unused due to NOTE below
   const { getValues } = useFormContext();
   const { field } = useController({
     control,
@@ -65,11 +66,12 @@ export function JsonSchemaSection({
     setIsGeneratingSchema(true);
 
     try {
-      let fullInstructions = agentInstructions;
-      const agentDescription = getValues("agentDescription");
-      if (agentDescription) {
-        fullInstructions += `\n\nTool description:\n${agentDescription}`;
-      }
+      const fullInstructions = agentInstructions;
+      // NOTE: commented, don't know where that agentDescription comes from. Not in AgentBuilderFormData
+      // const agentDescription = getValues("agentDescription");
+      // if (agentDescription) {
+      //   fullInstructions += `\n\nTool description:\n${agentDescription}`;
+      // }
 
       const res = await fetch(
         `/api/w/${owner.sId}/assistant/builder/process/generate_schema`,

--- a/front/components/agent_builder/capabilities/knowledge/shared/TimeFrameSection.tsx
+++ b/front/components/agent_builder/capabilities/knowledge/shared/TimeFrameSection.tsx
@@ -9,6 +9,7 @@ import {
   Input,
 } from "@dust-tt/sparkle";
 import { useState } from "react";
+import type { Control } from "react-hook-form";
 import { useController, useFormContext } from "react-hook-form";
 
 import type { CapabilityFormData } from "@app/components/agent_builder/types";
@@ -43,23 +44,23 @@ const ACTION_CONFIG: Record<
 
 interface TimeFrameSectionProps {
   actionType: ActionType;
+  control: Control<CapabilityFormData>;
 }
 
-export function TimeFrameSection({ actionType }: TimeFrameSectionProps) {
+export function TimeFrameSection({
+  actionType,
+  control,
+}: TimeFrameSectionProps) {
   const { setValue, getValues } = useFormContext();
   const [isChecked, setIsChecked] = useState(() => !!getValues("timeFrame"));
 
-  const { field: durationField } = useController<
-    CapabilityFormData,
-    "timeFrame.duration"
-  >({
+  const { field: durationField } = useController({
+    control,
     name: "timeFrame.duration",
   });
 
-  const { field: unitField } = useController<
-    CapabilityFormData,
-    "timeFrame.unit"
-  >({
+  const { field: unitField } = useController({
+    control,
     name: "timeFrame.unit",
   });
 

--- a/front/components/agent_builder/capabilities/knowledge/shared/TimeFrameSection.tsx
+++ b/front/components/agent_builder/capabilities/knowledge/shared/TimeFrameSection.tsx
@@ -8,9 +8,8 @@ import {
   DropdownMenuTrigger,
   Input,
 } from "@dust-tt/sparkle";
-import { useState } from "react";
 import type { Control } from "react-hook-form";
-import { useController, useFormContext } from "react-hook-form";
+import { useController } from "react-hook-form";
 
 import type { CapabilityFormData } from "@app/components/agent_builder/types";
 import type { TimeFrame } from "@app/types";
@@ -51,18 +50,8 @@ export function TimeFrameSection({
   actionType,
   control,
 }: TimeFrameSectionProps) {
-  const { setValue, getValues } = useFormContext();
-  const [isChecked, setIsChecked] = useState(() => !!getValues("timeFrame"));
-
-  const { field: durationField } = useController({
-    control,
-    name: "timeFrame.duration",
-  });
-
-  const { field: unitField } = useController({
-    control,
-    name: "timeFrame.unit",
-  });
+  const { field: timeFrame } = useController({ control, name: "timeFrame" });
+  const isChecked = timeFrame.value;
 
   const { actionText, contextText } = ACTION_CONFIG[actionType];
 
@@ -79,16 +68,15 @@ export function TimeFrameSection({
 
       <div className="flex flex-row items-center gap-4 pb-4">
         <Checkbox
-          checked={isChecked}
+          checked={timeFrame.value != null}
           onCheckedChange={(checked) => {
-            setIsChecked(Boolean(checked));
-            setValue("timeFrame", checked ? DEFAULT_TIME_FRAME : null);
+            timeFrame.onChange(checked ? DEFAULT_TIME_FRAME : null);
           }}
         />
         <div
           className={classNames(
             "text-sm font-semibold",
-            !getValues("timeFrame")
+            !isChecked
               ? "text-muted-foreground dark:text-muted-foreground-night"
               : "text-foreground dark:text-foreground-night"
           )}
@@ -98,10 +86,13 @@ export function TimeFrameSection({
         <Input
           type="number"
           min="1"
-          value={durationField?.value?.toString() ?? ""}
+          value={timeFrame.value?.duration.toString() ?? ""}
           onChange={(e) => {
             const duration = Math.max(1, parseInt(e.target.value, 10) || 1);
-            durationField.onChange(duration);
+            timeFrame.onChange({
+              ...timeFrame.value,
+              duration,
+            });
           }}
           disabled={!isChecked}
         />
@@ -109,7 +100,7 @@ export function TimeFrameSection({
           <DropdownMenuTrigger asChild>
             <Button
               isSelect
-              label={TIME_FRAME_UNIT_TO_LABEL[unitField.value ?? "day"]}
+              label={TIME_FRAME_UNIT_TO_LABEL[timeFrame.value?.unit ?? "day"]}
               variant="outline"
               size="sm"
               disabled={!isChecked}
@@ -122,7 +113,10 @@ export function TimeFrameSection({
                 label={value}
                 onClick={() => {
                   if (isTimeFrameUnit(key)) {
-                    unitField.onChange(key);
+                    timeFrame.onChange({
+                      ...timeFrame.value,
+                      unit: key,
+                    });
                   }
                 }}
               />

--- a/front/components/agent_builder/capabilities/knowledge/shared/sheetUtils.ts
+++ b/front/components/agent_builder/capabilities/knowledge/shared/sheetUtils.ts
@@ -6,6 +6,8 @@ import {
   isIncludeDataAction,
   isSearchAction,
 } from "@app/components/agent_builder/types";
+import type { DataSourceBuilderTreeType } from "@app/components/data_source_view/context/types";
+import { transformSelectionConfigurationsToTree } from "@app/components/agent_builder/capabilities/knowledge/utils/transformations";
 import type {
   DataSourceViewSelectionConfigurations,
   TimeFrame,
@@ -58,4 +60,11 @@ export function isValidPage<T extends Record<string, string>>(
   pageIds: T
 ): pageId is T[keyof T] {
   return Object.values(pageIds).includes(pageId);
+}
+
+export function getDataSourceTree(
+  action?: AgentBuilderAction
+): DataSourceBuilderTreeType {
+  const configurations = getDataSourceConfigurations(action);
+  return transformSelectionConfigurationsToTree(configurations);
 }

--- a/front/components/agent_builder/capabilities/knowledge/shared/sheetUtils.ts
+++ b/front/components/agent_builder/capabilities/knowledge/shared/sheetUtils.ts
@@ -1,5 +1,6 @@
 import type { JSONSchema7 as JSONSchema } from "json-schema";
 
+import { transformSelectionConfigurationsToTree } from "@app/components/agent_builder/capabilities/knowledge/transformations";
 import type { AgentBuilderAction } from "@app/components/agent_builder/types";
 import {
   isExtractDataAction,
@@ -7,7 +8,6 @@ import {
   isSearchAction,
 } from "@app/components/agent_builder/types";
 import type { DataSourceBuilderTreeType } from "@app/components/data_source_view/context/types";
-import { transformSelectionConfigurationsToTree } from "@app/components/agent_builder/capabilities/knowledge/transformations";
 import type {
   DataSourceViewSelectionConfigurations,
   TimeFrame,

--- a/front/components/agent_builder/capabilities/knowledge/shared/sheetUtils.ts
+++ b/front/components/agent_builder/capabilities/knowledge/shared/sheetUtils.ts
@@ -7,7 +7,7 @@ import {
   isSearchAction,
 } from "@app/components/agent_builder/types";
 import type { DataSourceBuilderTreeType } from "@app/components/data_source_view/context/types";
-import { transformSelectionConfigurationsToTree } from "@app/components/agent_builder/capabilities/knowledge/utils/transformations";
+import { transformSelectionConfigurationsToTree } from "@app/components/agent_builder/capabilities/knowledge/transformations";
 import type {
   DataSourceViewSelectionConfigurations,
   TimeFrame,

--- a/front/components/agent_builder/capabilities/knowledge/shared/sheetUtils.ts
+++ b/front/components/agent_builder/capabilities/knowledge/shared/sheetUtils.ts
@@ -41,12 +41,6 @@ export function getTimeFrame(action?: AgentBuilderAction): TimeFrame | null {
   return null;
 }
 
-export function hasDataSourceSelections(
-  dataSourceConfigurations: DataSourceViewSelectionConfigurations
-): boolean {
-  return Object.keys(dataSourceConfigurations).length > 0;
-}
-
 export function getJsonSchema(action?: AgentBuilderAction): JSONSchema | null {
   if (!action) {
     return null;

--- a/front/components/agent_builder/capabilities/knowledge/utils/transformations.ts
+++ b/front/components/agent_builder/capabilities/knowledge/utils/transformations.ts
@@ -1,0 +1,155 @@
+import type { DataSourceBuilderTreeType } from "@app/components/data_source_view/context/types";
+import type { NavigationHistoryEntryType } from "@app/components/data_source_view/context/types";
+import { computeNavigationPath } from "@app/components/data_source_view/context/utils";
+import type {
+  DataSourceViewContentNode,
+  DataSourceViewSelectionConfigurations,
+  DataSourceViewType,
+} from "@app/types";
+
+/**
+ * Transforms DataSourceBuilderTreeType to DataSourceViewSelectionConfigurations
+ *
+ * This creates a simplified transformation that works with the path structure
+ * used in the tree. Since we don't have access to all nodes at save time,
+ * we create placeholder configurations that will be properly resolved on the backend.
+ */
+export function transformTreeToSelectionConfigurations(
+  tree: DataSourceBuilderTreeType,
+  dataSourceViews: DataSourceViewType[]
+): DataSourceViewSelectionConfigurations {
+  const configurations: DataSourceViewSelectionConfigurations = {};
+
+  // Parse the tree paths to extract data source configurations
+  for (const path of tree.in) {
+    const parts = path.split(".");
+    if (parts.length < 2) continue;
+
+    // Expected format: root.spaceId.category.dataSourceId.nodeId...
+    // or root.spaceId.dataSourceId.nodeId...
+    const spaceId = parts[1];
+
+    // Find the data source view that matches this path
+    const dataSourceView = dataSourceViews.find((dsv) => {
+      // Check if the path includes this data source
+      return path.includes(dsv.sId) && dsv.spaceId === spaceId;
+    });
+
+    if (!dataSourceView) continue;
+
+    // Check if this is a full data source selection or specific nodes
+    const dsIndex = parts.indexOf(dataSourceView.sId);
+    const isFullDataSource = dsIndex === parts.length - 1;
+
+    if (!configurations[dataSourceView.sId]) {
+      configurations[dataSourceView.sId] = {
+        dataSourceView,
+        selectedResources: [],
+        isSelectAll: isFullDataSource,
+        tagsFilter: null,
+      };
+    }
+
+    // If it's not a full data source selection, we need to handle individual nodes
+    // For now, we'll mark it as having selected resources even though we don't have the full node data
+    if (!isFullDataSource && !configurations[dataSourceView.sId].isSelectAll) {
+      // We'll need the backend to resolve the actual nodes from paths
+      // For now, just ensure it's not marked as select all
+      configurations[dataSourceView.sId].isSelectAll = false;
+    }
+  }
+
+  return configurations;
+}
+
+/**
+ * Transforms DataSourceViewSelectionConfigurations to DataSourceBuilderTreeType
+ *
+ * This function converts node-based selection configurations back to
+ * path-based selection (in/notIn arrays).
+ *
+ * The path structure is: root.spaceId.category.dataSourceId.nodeId1.nodeId2...
+ */
+export function transformSelectionConfigurationsToTree(
+  configurations: DataSourceViewSelectionConfigurations
+): DataSourceBuilderTreeType {
+  const inPaths: string[] = [];
+  const notInPaths: string[] = [];
+
+  for (const [dsId, config] of Object.entries(configurations)) {
+    const { dataSourceView } = config;
+
+    // Build the base path components exactly matching navigation structure
+    const baseParts = ["root", dataSourceView.spaceId];
+
+    // Add category - this is critical for proper path reconstruction
+    if (dataSourceView.category) {
+      baseParts.push(dataSourceView.category);
+    }
+
+    // Add data source ID (dsv_...)
+    baseParts.push(dataSourceView.sId);
+
+    if (config.isSelectAll) {
+      // If all nodes are selected, just add the data source path
+      inPaths.push(baseParts.join("."));
+    } else if (config.selectedResources.length > 0) {
+      // Group selected resources by parent to understand folder structure
+      const resourcesByParent = new Map<
+        string | null,
+        typeof config.selectedResources
+      >();
+
+      config.selectedResources.forEach((node) => {
+        const parentId = node.parentInternalId || null;
+        if (!resourcesByParent.has(parentId)) {
+          resourcesByParent.set(parentId, []);
+        }
+        resourcesByParent.get(parentId)!.push(node);
+      });
+
+      // For each parent folder that has selected children, we need to:
+      // 1. Add paths for the individual files
+      // 2. Store metadata about parent folders for partial selection detection
+      for (const [parentId, nodes] of resourcesByParent) {
+        if (parentId) {
+          // There's a parent folder - add it to a special tracking system
+          // Add individual file paths
+          nodes.forEach((node) => {
+            const filePath = [...baseParts, parentId, node.internalId].join(
+              "."
+            );
+            inPaths.push(filePath);
+          });
+        } else {
+          // Files directly under data source
+          nodes.forEach((node) => {
+            const filePath = [...baseParts, node.internalId].join(".");
+            inPaths.push(filePath);
+          });
+        }
+      }
+    }
+  }
+
+  const result = {
+    in: deduplicatePaths(inPaths),
+    notIn: deduplicatePaths(notInPaths),
+  };
+
+  return result;
+}
+
+/**
+ * Removes duplicate paths and paths that are already covered by parent paths
+ */
+function deduplicatePaths(paths: string[]): string[] {
+  const uniquePaths = [...new Set(paths)];
+
+  // Remove paths that are covered by parent paths
+  return uniquePaths.filter((path) => {
+    return !uniquePaths.some(
+      (otherPath) => otherPath !== path && path.startsWith(otherPath + ".")
+    );
+  });
+}

--- a/front/components/agent_builder/types.ts
+++ b/front/components/agent_builder/types.ts
@@ -170,10 +170,17 @@ export const DESCRIPTION_MAX_LENGTH = 800;
 
 // TODO: use mcpFormSchema for all tools.
 export const capabilityFormSchema = z.object({
-  sources: z.object({
-    in: z.string().array(),
-    notIn: z.string().array(),
-  }),
+  sources: z
+    .object({
+      in: z.string().array(),
+      notIn: z.string().array(),
+    })
+    .refine(
+      (val) => {
+        return val.in.length > 0;
+      },
+      { message: "You must select at least on data sources" }
+    ),
   description: z
     .string()
     .min(1, "Description is required")

--- a/front/components/agent_builder/types.ts
+++ b/front/components/agent_builder/types.ts
@@ -9,6 +9,8 @@ import type { MCPServerViewType } from "@app/lib/api/mcp";
 import type { SupportedModel, WhitelistableFeature } from "@app/types";
 import { ioTsEnum } from "@app/types";
 
+import { dataSourceBuilderTreeType } from "../data_source_view/context/types";
+
 type AgentBuilderFormData = z.infer<typeof agentBuilderFormSchema>;
 
 export type AgentBuilderAction = AgentBuilderFormData["actions"][number];
@@ -170,17 +172,12 @@ export const DESCRIPTION_MAX_LENGTH = 800;
 
 // TODO: use mcpFormSchema for all tools.
 export const capabilityFormSchema = z.object({
-  sources: z
-    .object({
-      in: z.string().array(),
-      notIn: z.string().array(),
-    })
-    .refine(
-      (val) => {
-        return val.in.length > 0;
-      },
-      { message: "You must select at least on data sources" }
-    ),
+  sources: dataSourceBuilderTreeType.refine(
+    (val) => {
+      return val.in.length > 0;
+    },
+    { message: "You must select at least on data sources" }
+  ),
   description: z
     .string()
     .min(1, "Description is required")

--- a/front/components/agent_builder/types.ts
+++ b/front/components/agent_builder/types.ts
@@ -170,6 +170,10 @@ export const DESCRIPTION_MAX_LENGTH = 800;
 
 // TODO: use mcpFormSchema for all tools.
 export const capabilityFormSchema = z.object({
+  sources: z.object({
+    in: z.string().array(),
+    notIn: z.string().array(),
+  }),
   description: z
     .string()
     .min(1, "Description is required")

--- a/front/components/data_source_view/DataSourceBuilderSelector.tsx
+++ b/front/components/data_source_view/DataSourceBuilderSelector.tsx
@@ -2,8 +2,10 @@ import type { BreadcrumbItem } from "@dust-tt/sparkle";
 import { Breadcrumbs, SearchInput, Spinner } from "@dust-tt/sparkle";
 import type { Dispatch, SetStateAction } from "react";
 import { useMemo, useState } from "react";
+import type { Control } from "react-hook-form";
 
 import { useSpacesContext } from "@app/components/agent_builder/SpacesContext";
+import type { CapabilityFormData } from "@app/components/agent_builder/types";
 import {
   DataSourceBuilderProvider,
   useDataSourceBuilderContext,
@@ -36,6 +38,7 @@ interface DataSourceBuilderSelectorProps {
     SetStateAction<DataSourceViewSelectionConfigurations>
   >;
   viewType: ContentNodesViewType;
+  control: Control<CapabilityFormData>;
 }
 
 export const DataSourceBuilderSelector = (
@@ -48,7 +51,7 @@ export const DataSourceBuilderSelector = (
   }
 
   return (
-    <DataSourceBuilderProvider spaces={spaces}>
+    <DataSourceBuilderProvider control={props.control} spaces={spaces}>
       <DataSourceBuilderSelectorContent {...props} />
     </DataSourceBuilderProvider>
   );

--- a/front/components/data_source_view/DataSourceBuilderSelector.tsx
+++ b/front/components/data_source_view/DataSourceBuilderSelector.tsx
@@ -1,6 +1,5 @@
 import type { BreadcrumbItem } from "@dust-tt/sparkle";
 import { Breadcrumbs, SearchInput, Spinner } from "@dust-tt/sparkle";
-import type { Dispatch, SetStateAction } from "react";
 import { useMemo, useState } from "react";
 import type { Control } from "react-hook-form";
 
@@ -23,7 +22,6 @@ import { CATEGORY_DETAILS } from "@app/lib/spaces";
 import { useSpaceDataSourceViewsWithDetails } from "@app/lib/swr/spaces";
 import type {
   ContentNodesViewType,
-  DataSourceViewSelectionConfigurations,
   DataSourceViewType,
   LightWorkspaceType,
   SpaceType,
@@ -33,10 +31,6 @@ type DataSourceBuilderSelectorProps = {
   allowedSpaces?: SpaceType[];
   owner: LightWorkspaceType;
   dataSourceViews: DataSourceViewType[];
-  selectionConfigurations: DataSourceViewSelectionConfigurations;
-  setSelectionConfigurations: Dispatch<
-    SetStateAction<DataSourceViewSelectionConfigurations>
-  >;
   viewType: ContentNodesViewType;
   control: Control<CapabilityFormData>;
 };

--- a/front/components/data_source_view/DataSourceBuilderSelector.tsx
+++ b/front/components/data_source_view/DataSourceBuilderSelector.tsx
@@ -29,7 +29,7 @@ import type {
   SpaceType,
 } from "@app/types";
 
-interface DataSourceBuilderSelectorProps {
+type DataSourceBuilderSelectorProps = {
   allowedSpaces?: SpaceType[];
   owner: LightWorkspaceType;
   dataSourceViews: DataSourceViewType[];
@@ -39,11 +39,12 @@ interface DataSourceBuilderSelectorProps {
   >;
   viewType: ContentNodesViewType;
   control: Control<CapabilityFormData>;
-}
+};
 
-export const DataSourceBuilderSelector = (
-  props: DataSourceBuilderSelectorProps
-) => {
+export const DataSourceBuilderSelector = ({
+  control,
+  ...props
+}: DataSourceBuilderSelectorProps) => {
   const { spaces, isSpacesLoading } = useSpacesContext();
 
   if (isSpacesLoading) {
@@ -51,7 +52,7 @@ export const DataSourceBuilderSelector = (
   }
 
   return (
-    <DataSourceBuilderProvider control={props.control} spaces={spaces}>
+    <DataSourceBuilderProvider control={control} spaces={spaces}>
       <DataSourceBuilderSelectorContent {...props} />
     </DataSourceBuilderProvider>
   );
@@ -62,7 +63,7 @@ export const DataSourceBuilderSelectorContent = ({
   dataSourceViews,
   owner,
   viewType,
-}: DataSourceBuilderSelectorProps) => {
+}: Omit<DataSourceBuilderSelectorProps, "control">) => {
   const {
     spaces,
     navigationHistory,

--- a/front/components/data_source_view/DataSourceNodeTable.tsx
+++ b/front/components/data_source_view/DataSourceNodeTable.tsx
@@ -192,48 +192,59 @@ export function DataSourceNodeTable({
         id: "select",
         enableSorting: false,
         enableHiding: false,
-        header: () => (
-          <Checkbox
-            size="xs"
-            checked={isCurrentNavigationEntrySelected()}
-            disabled={!isRowSelectable()}
-            onClick={(event) => event.stopPropagation()}
-            onCheckedChange={(state) => {
-              if (state === "indeterminate") {
-                removeCurrentNavigationEntry();
-                return;
-              }
-
-              if (state) {
-                selectCurrentNavigationEntry();
-              } else {
-                removeCurrentNavigationEntry();
-              }
-            }}
-          />
-        ),
-        cell: ({ row }) => (
-          <div className="flex h-full w-full items-center">
+        header: () => {
+          const selectionState = isCurrentNavigationEntrySelected();
+          return (
             <Checkbox
+              key={`header-${selectionState}`}
               size="xs"
-              checked={isRowSelected(row.original.id)}
-              disabled={!isRowSelectable(row.original.id)}
+              checked={selectionState}
+              disabled={!isRowSelectable()}
               onClick={(event) => event.stopPropagation()}
               onCheckedChange={(state) => {
-                if (state === "indeterminate") {
-                  removeNode(row.original.id);
+                // When clicking a partial checkbox, select all
+                if (selectionState === "partial") {
+                  selectCurrentNavigationEntry();
                   return;
                 }
 
                 if (state) {
-                  selectNode(row.original.id);
+                  selectCurrentNavigationEntry();
                 } else {
-                  removeNode(row.original.id);
+                  removeCurrentNavigationEntry();
                 }
               }}
             />
-          </div>
-        ),
+          );
+        },
+        cell: ({ row }) => {
+          const selectionState = isRowSelected(row.original.id);
+
+          return (
+            <div className="flex h-full w-full items-center">
+              <Checkbox
+                key={`${row.original.id}-${selectionState}`}
+                size="xs"
+                checked={selectionState}
+                disabled={!isRowSelectable(row.original.id)}
+                onClick={(event) => event.stopPropagation()}
+                onCheckedChange={(state) => {
+                  // When clicking a partial checkbox, select all
+                  if (selectionState === "partial") {
+                    selectNode(row.original.id);
+                    return;
+                  }
+
+                  if (state) {
+                    selectNode(row.original.id);
+                  } else {
+                    removeNode(row.original.id);
+                  }
+                }}
+              />
+            </div>
+          );
+        },
         meta: {
           sizeRatio: 5,
         },

--- a/front/components/data_source_view/context/DataSourceBuilderContext.tsx
+++ b/front/components/data_source_view/context/DataSourceBuilderContext.tsx
@@ -37,7 +37,9 @@ import {
   useMemo,
   useReducer,
 } from "react";
+import type { Control } from "react-hook-form";
 
+import type { CapabilityFormData } from "@app/components/agent_builder/types";
 import type {
   DataSourceBuilderTreeType,
   NavigationHistoryEntryType,
@@ -232,6 +234,7 @@ export function DataSourceBuilderProvider({
 }: {
   spaces: SpaceType[];
   children: React.ReactNode;
+  control: Control<CapabilityFormData>;
 }) {
   const [state, dispatch] = useReducer(dataSourceBuilderReducer, {
     spaces,

--- a/front/components/data_source_view/context/DataSourceBuilderContext.tsx
+++ b/front/components/data_source_view/context/DataSourceBuilderContext.tsx
@@ -44,6 +44,7 @@ import type { CapabilityFormData } from "@app/components/agent_builder/types";
 import type {
   DataSourceBuilderTreeType,
   NavigationHistoryEntryType,
+  NodeSelectionState,
 } from "@app/components/data_source_view/context/types";
 import {
   addNodeToTree,
@@ -99,7 +100,7 @@ type DataSourceBuilderState = StateType & {
    * Check selection status for the specific row.
    * Total path is deduced from the current navigationHistory state.
    */
-  isRowSelected: (rowId: string) => boolean | "partial";
+  isRowSelected: (rowId: string) => NodeSelectionState;
 
   /**
    * Check if the row is selectable.
@@ -112,7 +113,7 @@ type DataSourceBuilderState = StateType & {
   /**
    * Use the current navigationHistory entry and check its selection status
    */
-  isCurrentNavigationEntrySelected: () => boolean | "partial";
+  isCurrentNavigationEntrySelected: () => NodeSelectionState;
 
   /**
    * Add the current selected space

--- a/front/components/data_source_view/context/DataSourceBuilderContext.tsx
+++ b/front/components/data_source_view/context/DataSourceBuilderContext.tsx
@@ -137,14 +137,6 @@ type DataSourceBuilderState = StateType & {
 
 type ActionType =
   | {
-      type: "SELECT_DATA_SOURCE_NODE";
-      payload: { rowId?: string };
-    }
-  | {
-      type: "REMOVE_DATA_SOURCE_NODE";
-      payload: { rowId?: string };
-    }
-  | {
       type: "NAVIGATION_SET_SPACE";
       payload: { space: SpaceType };
     }
@@ -202,12 +194,6 @@ function dataSourceBuilderReducer(
         ...state,
         navigationHistory: state.navigationHistory.slice(0, payload.index + 1),
       };
-    }
-    case "SELECT_DATA_SOURCE_NODE": {
-      return state;
-    }
-    case "REMOVE_DATA_SOURCE_NODE": {
-      return state;
     }
     default:
       assertNever(type);

--- a/front/components/data_source_view/context/types.ts
+++ b/front/components/data_source_view/context/types.ts
@@ -1,13 +1,18 @@
+import { z } from "zod";
+
 import type {
   DataSourceViewCategoryWithoutApps,
   DataSourceViewContentNode,
   SpaceType,
 } from "@app/types";
 
-export type DataSourceBuilderTreeType = {
-  in: string[];
-  notIn: string[];
-};
+export const dataSourceBuilderTreeType = z.object({
+  in: z.string().array(),
+  notIn: z.string().array(),
+});
+export type DataSourceBuilderTreeType = z.infer<
+  typeof dataSourceBuilderTreeType
+>;
 
 export type NavigationHistoryEntryType =
   | { type: "root" }

--- a/front/components/data_source_view/context/types.ts
+++ b/front/components/data_source_view/context/types.ts
@@ -19,3 +19,5 @@ export type NavigationHistoryEntryType =
   | { type: "space"; space: SpaceType }
   | { type: "category"; category: DataSourceViewCategoryWithoutApps }
   | { type: "node"; node: DataSourceViewContentNode };
+
+export type NodeSelectionState = boolean | "partial";

--- a/front/components/data_source_view/context/utils.ts
+++ b/front/components/data_source_view/context/utils.ts
@@ -1,6 +1,7 @@
 import type {
   DataSourceBuilderTreeType,
   NavigationHistoryEntryType,
+  NodeSelectionState,
 } from "@app/components/data_source_view/context/types";
 import type {
   DataSourceViewCategoryWithoutApps,
@@ -152,7 +153,7 @@ export function removeNodeFromTree(
 export function isNodeSelected(
   tree: DataSourceBuilderTreeType,
   path: string[]
-): boolean | "partial" {
+): NodeSelectionState {
   const pathStr = pathToString(path);
   const pathPrefix = getPathPrefix(pathStr);
 

--- a/front/components/data_source_view/context/utils.ts
+++ b/front/components/data_source_view/context/utils.ts
@@ -181,11 +181,13 @@ export function isNodeSelected(
     }
   }
 
-  if (isIncluded) {
-    return hasChildExclusions ? "partial" : true;
-  }
-
-  return hasChildInclusions ? "partial" : false;
+  return isIncluded
+    ? hasChildExclusions
+      ? "partial"
+      : true
+    : hasChildInclusions
+      ? "partial"
+      : false;
 }
 
 export function computeNavigationPath(

--- a/front/package-lock.json
+++ b/front/package-lock.json
@@ -4,7 +4,6 @@
   "requires": true,
   "packages": {
     "": {
-      "name": "front",
       "dependencies": {
         "@auth0/nextjs-auth0": "^3.5.0",
         "@datadog/browser-logs": "^6.13.0",
@@ -103,7 +102,7 @@
         "react-cookie": "^7.2.2",
         "react-dom": "^18.3.1",
         "react-dropzone": "^14.2.3",
-        "react-hook-form": "^7.51.1",
+        "react-hook-form": "^7.61.1",
         "react-image-crop": "^10.1.8",
         "react-intersection-observer": "^9.13.1",
         "react-markdown": "^8.0.7",
@@ -23082,17 +23081,19 @@
       }
     },
     "node_modules/react-hook-form": {
-      "version": "7.51.1",
+      "version": "7.61.1",
+      "resolved": "https://registry.npmjs.org/react-hook-form/-/react-hook-form-7.61.1.tgz",
+      "integrity": "sha512-2vbXUFDYgqEgM2RcXcAT2PwDW/80QARi+PKmHy5q2KhuKvOlG8iIYgf7eIlIANR5trW9fJbP4r5aub3a4egsew==",
       "license": "MIT",
       "engines": {
-        "node": ">=12.22.0"
+        "node": ">=18.0.0"
       },
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/react-hook-form"
       },
       "peerDependencies": {
-        "react": "^16.8.0 || ^17 || ^18"
+        "react": "^16.8.0 || ^17 || ^18 || ^19"
       }
     },
     "node_modules/react-image-crop": {

--- a/front/package.json
+++ b/front/package.json
@@ -119,7 +119,7 @@
     "react-cookie": "^7.2.2",
     "react-dom": "^18.3.1",
     "react-dropzone": "^14.2.3",
-    "react-hook-form": "^7.51.1",
+    "react-hook-form": "^7.61.1",
     "react-image-crop": "^10.1.8",
     "react-intersection-observer": "^9.13.1",
     "react-markdown": "^8.0.7",


### PR DESCRIPTION
## Description
Goals was to use existing form managed by `capabilityFormSchema` in the `KnowledgeConfigurationSheet`.
As the `MultiPageSheetContent` need to be able to know if it can go to the next page (`disableNext`), we need to give him access to the `DataSourceBuilderTreeType` state that is in the context. Putting the context above `KnowledgeConfigurationSheet` is not great and we would still need a way to sync state between context and form.
So to keep one source of truth, I moved the `DataSourceBuilderTreeType` in the the `CapabilityFormData`. 
- To do so, I updated the context to instead get and set the selected nodes from the form.
  - Because only function are exposed, didn't need to update components that used it, their behaviour didn't change.
- Move the form a couple of layers above to be able to use the form state in the `MultiPageSheetContent` and disabled or not the next page or the saving button. 

To have 2 react-hook-form working together, I remove the `FormProvider` for the `CapabilityFormData` and instead use a more manual `createFormControl`. By passing down a `control`, that give us a granular access to the form state, controllers and watchers. If for example a `useController` is used without a `control` options, it will get the most up FormProvider, in that case it would be `AgentBuilderFormData`. 

### What's missing
- I didn't make the transformation between `DataSourceBuilderTreeType` ↔️  `DataSourceViewSelectionConfigurations`

## Tests
- Locally

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan
- Deploy front
