### PR TITLE
[front] - chore(AB v2): default state AgentBuilderSettingsBlock

### DIFF
--- a/front/components/agent_builder/AgentBuilderLeftPanel.tsx
+++ b/front/components/agent_builder/AgentBuilderLeftPanel.tsx
@@ -64,7 +64,9 @@ export function AgentBuilderLeftPanel({
           <Separator />
           <AgentBuilderCapabilitiesBlock />
           <Separator />
-          <AgentBuilderSettingsBlock />
+          <AgentBuilderSettingsBlock
+            isSettingBlocksOpen={!agentConfigurationId}
+          />
         </div>
       </div>
       <BarFooter

--- a/front/components/agent_builder/settings/AgentBuilderSettingsBlock.tsx
+++ b/front/components/agent_builder/settings/AgentBuilderSettingsBlock.tsx
@@ -418,8 +418,14 @@ function AgentAccessAndPublication() {
   );
 }
 
-export function AgentBuilderSettingsBlock() {
-  const [isOpen, setIsOpen] = useState(false);
+interface AgentBuilderSettingsBlockProps {
+  isSettingBlocksOpen: boolean;
+}
+
+export function AgentBuilderSettingsBlock({
+  isSettingBlocksOpen,
+}: AgentBuilderSettingsBlockProps) {
+  const [isOpen, setIsOpen] = useState(isSettingBlocksOpen);
 
   return (
     <div className="flex h-full flex-col gap-4">


### PR DESCRIPTION
## Description

The AgentBuilderSettingsBlock now defaults to an open state when there's no agent configuration ID

**References:**
- https://github.com/dust-tt/tasks/issues/3602

## Tests

Locally

## Risk

None

## Deploy Plan

Deploy front