### PR TITLE
[front] Add index on `agent_mcp_actions` unique by function call

### DIFF
--- a/front/lib/models/assistant/actions/mcp.ts
+++ b/front/lib/models/assistant/actions/mcp.ts
@@ -255,6 +255,12 @@ AgentMCPAction.init(
         fields: ["stepContentId"],
         concurrently: true,
       },
+      {
+        fields: ["workspaceId", "agentMessageId", "stepContentId", "version"],
+        name: "agent_mcp_action_workspace_agent_message_step_content_version",
+        unique: true,
+        concurrently: true,
+      },
     ],
   }
 );

--- a/front/migrations/db/migration_319.sql
+++ b/front/migrations/db/migration_319.sql
@@ -1,0 +1,2 @@
+-- Migration created on Jul 25, 2025
+CREATE UNIQUE INDEX CONCURRENTLY "agent_mcp_action_workspace_agent_message_step_content_version" ON "agent_mcp_actions" ("workspaceId", "agentMessageId", "stepContentId", "version");


### PR DESCRIPTION
## Description

- Following up on the discussion in https://github.com/dust-tt/tasks/issues/3596.
- This PR adds a unique index (`workspaceId`, `agentMessageId`, `stepContentId`, `version`) on `agent_mcp_actions`.
- This enforces a hard contract that we don't add new rows on `agent_mcp_actions` for the same function call.

## Tests

## Risk

## Deploy Plan

- Deploy front.
- Run migration.
