### PR TITLE
Limit max upsert table attempts

### DIFF
--- a/front/temporal/upsert_queue/workflows.ts
+++ b/front/temporal/upsert_queue/workflows.ts
@@ -2,8 +2,13 @@ import { proxyActivities } from "@temporalio/workflow";
 
 import type * as activities from "@app/temporal/upsert_queue/activities";
 
+const MAX_UPSERT_TABLE_ATTEMPTS = 10;
+
 const { upsertDocumentActivity } = proxyActivities<typeof activities>({
   startToCloseTimeout: "10 minutes",
+  retry: {
+    maximumAttempts: MAX_UPSERT_TABLE_ATTEMPTS,
+  },
 });
 
 export async function upsertDocumentWorkflow(


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
See incident thread [here](https://dust4ai.slack.com/archives/C05B529FHV1/p1753333756616699).

Until we properly address the memory issue on upsert table, this PR introduces a preemptive measure to add some kind of auto-healing system.

Looking at the metrics [here](https://app.datadoghq.eu/logs?query=service%3Afront-worker%20%22Activity%20failed%22%20%40attempt%3A%3E10%20%40activityName%3AupsertTableActivity&agg_m=count&agg_m_source=base&agg_t=count&clustering_pattern_field_path=message&cols=host%2Cservice&event=AwAAAZhARvWpr_AoIgAAABhBWmhBUndrVUFBQ2RwdUxVVkNtLVhRQVgAAAAkZjE5ODQwNGMtYmZiZC00NjEyLWEzNDMtNjVjZjNmYzM1ZDQwAAbHww&messageDisplay=inline&refresh_mode=sliding&storage=hot&stream_sort=desc&viz=stream&from_ts=1752827271495&to_ts=1753432071495&live=true) we can see that 10 attempts on `upsertTableActivity` is a sweetspot (we never had table upsert going up to 10 attempts before). 

This might be removed once we properly fix the memory issue.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
