### PR TITLE
[front] Simplify agent loop activities typing

### DIFF
--- a/front/lib/api/assistant/agent.ts
+++ b/front/lib/api/assistant/agent.ts
@@ -6,7 +6,6 @@ import { wakeLock } from "@app/lib/wake_lock";
 import { runModelActivity } from "@app/temporal/agent_loop/activities/run_model";
 import { runToolActivity } from "@app/temporal/agent_loop/activities/run_tool";
 import { launchAgentLoopWorkflow } from "@app/temporal/agent_loop/client";
-import type { AgentLoopActivities } from "@app/temporal/agent_loop/lib/activity_interface";
 import { executeAgentLoop } from "@app/temporal/agent_loop/lib/agent_loop_executor";
 import { launchUpdateUsageWorkflow } from "@app/temporal/usage_queue/client";
 import type {
@@ -27,14 +26,11 @@ async function runAgentSynchronousWithStreaming(
 
   const titlePromise = ensureConversationTitle(authType, runAgentArgs);
 
-  // Create direct activities for non-Temporal execution.
-  const directActivities: AgentLoopActivities = {
-    runModelActivity: (args) => runModelActivity(args),
-    runToolActivity: (authType, args) => runToolActivity(authType, args),
-  };
-
   await wakeLock(async () => {
-    await executeAgentLoop(authType, runAgentArgs, directActivities);
+    await executeAgentLoop(authType, runAgentArgs, {
+      runModelActivity,
+      runToolActivity,
+    });
   });
 
   await titlePromise;

--- a/front/temporal/agent_loop/activities/run_tool.ts
+++ b/front/temporal/agent_loop/activities/run_tool.ts
@@ -6,10 +6,9 @@ import { Authenticator } from "@app/lib/auth";
 import { AgentStepContentResource } from "@app/lib/resources/agent_step_content_resource";
 import { updateResourceAndPublishEvent } from "@app/temporal/agent_loop/activities/common";
 import { assertNever } from "@app/types";
+import { isFunctionCallContent } from "@app/types/assistant/agent_message_content";
 import type { RunAgentArgs } from "@app/types/assistant/agent_run";
 import { getRunAgentData } from "@app/types/assistant/agent_run";
-import type { FunctionCallContentType } from "@app/types/assistant/agent_message_content";
-import { isFunctionCallContent } from "@app/types/assistant/agent_message_content";
 import type { ModelId } from "@app/types/shared/model_id";
 
 export async function runToolActivity(

--- a/front/temporal/agent_loop/lib/activity_interface.ts
+++ b/front/temporal/agent_loop/lib/activity_interface.ts
@@ -1,33 +1,7 @@
-import type { StepContext } from "@app/lib/actions/types";
-import type { ActionConfigurationType } from "@app/lib/actions/types/agent";
-import type { AuthenticatorType } from "@app/lib/auth";
-import type { ModelId } from "@app/types";
-import type { AgentActionsEvent } from "@app/types/assistant/agent";
-import type { RunAgentArgs } from "@app/types/assistant/agent_run";
+import type { runModelActivity } from "@app/temporal/agent_loop/activities/run_model";
+import type { runToolActivity } from "@app/temporal/agent_loop/activities/run_tool";
 
 export interface AgentLoopActivities {
-  runModelActivity(args: {
-    authType: AuthenticatorType;
-    runAgentArgs: RunAgentArgs;
-    runIds: string[];
-    step: number;
-    functionCallStepContentIds: Record<string, ModelId>;
-    citationsRefsOffset: number;
-    autoRetryCount?: number;
-  }): Promise<{
-    actions: AgentActionsEvent["actions"];
-    runId: string;
-    functionCallStepContentIds: Record<string, ModelId>;
-    stepContexts: StepContext[];
-  } | null>;
-
-  runToolActivity(
-    authType: AuthenticatorType,
-    args: {
-      runAgentArgs: RunAgentArgs;
-      action: ActionConfigurationType;
-      stepContext: StepContext;
-      stepContentId: ModelId;
-    }
-  ): Promise<void>;
+  runModelActivity: typeof runModelActivity;
+  runToolActivity: typeof runToolActivity;
 }


### PR DESCRIPTION
## Description

- Follow up on https://dust4ai.slack.com/archives/C050SM8NSPK/p1753444297349429
- This PR simplifies the typing around agent loop activities (`runModelActivities` and `runToolActivity`) by removing a repetition of the type.

## Tests

- tsc

## Risk

- N/A.

## Deploy Plan

- Deploy front.
