### PR TITLE
[Agent Loop] Support rendering conversation up to specific step

### DIFF
--- a/front/temporal/agent_loop/activities/run_model.ts
+++ b/front/temporal/agent_loop/activities/run_model.ts
@@ -49,6 +49,7 @@ import type {
 } from "@app/types/assistant/agent_message_content";
 import type { RunAgentArgs } from "@app/types/assistant/agent_run";
 import { getRunAgentData } from "@app/types/assistant/agent_run";
+import { sliceConversation } from "@app/temporal/agent_loop/lib/loop_utils";
 
 const CANCELLATION_CHECK_INTERVAL = 500;
 const MAX_AUTO_RETRY = 3;
@@ -82,17 +83,23 @@ export async function runModelActivity({
   stepContexts: StepContext[];
 } | null> {
   const runAgentDataRes = await getRunAgentData(authType, runAgentArgs);
+
   if (runAgentDataRes.isErr()) {
     throw runAgentDataRes.error;
   }
 
   const {
     agentConfiguration,
-    conversation,
+    conversation: fullConversation,
     userMessage,
     agentMessage,
     agentMessageRow,
   } = runAgentDataRes.value;
+
+  const conversation = sliceConversation(fullConversation, {
+    agentMessage,
+    step,
+  });
 
   const now = Date.now();
 

--- a/front/temporal/agent_loop/activities/run_model.ts
+++ b/front/temporal/agent_loop/activities/run_model.ts
@@ -49,7 +49,7 @@ import type {
 } from "@app/types/assistant/agent_message_content";
 import type { RunAgentArgs } from "@app/types/assistant/agent_run";
 import { getRunAgentData } from "@app/types/assistant/agent_run";
-import { sliceConversation } from "@app/temporal/agent_loop/lib/loop_utils";
+import { sliceConversationForAgentMessage } from "@app/temporal/agent_loop/lib/loop_utils";
 
 const CANCELLATION_CHECK_INTERVAL = 500;
 const MAX_AUTO_RETRY = 3;
@@ -82,7 +82,7 @@ export async function runModelActivity({
   functionCallStepContentIds: Record<string, ModelId>;
   stepContexts: StepContext[];
 } | null> {
-  const runAgentDataRes = await getRunAgentData(authType, runAgentArgs);
+  const runAgentDataRes = await getRunAgentData(authType, runAgentArgs, step);
 
   if (runAgentDataRes.isErr()) {
     throw runAgentDataRes.error;
@@ -90,16 +90,11 @@ export async function runModelActivity({
 
   const {
     agentConfiguration,
-    conversation: fullConversation,
+    conversation,
     userMessage,
     agentMessage,
     agentMessageRow,
   } = runAgentDataRes.value;
-
-  const conversation = sliceConversation(fullConversation, {
-    agentMessage,
-    step,
-  });
 
   const now = Date.now();
 

--- a/front/temporal/agent_loop/activities/run_tool.ts
+++ b/front/temporal/agent_loop/activities/run_tool.ts
@@ -43,7 +43,7 @@ export async function runToolActivity(
 
   const { step } = stepContent;
 
-  const runAgentDataRes = await getRunAgentData(authType, runAgentArgs);
+  const runAgentDataRes = await getRunAgentData(authType, runAgentArgs, step);
   if (runAgentDataRes.isErr()) {
     throw runAgentDataRes.error;
   }

--- a/front/temporal/agent_loop/lib/loop_utils.ts
+++ b/front/temporal/agent_loop/lib/loop_utils.ts
@@ -5,6 +5,9 @@ import {
 } from "@app/types";
 import assert from "assert";
 
+// TODO(DURABLE-AGENTS 2025-07-25): Consider moving inside this function the "conversation has
+// already been prepared appropriately" part mentioned below, referring to
+// e.g. front/lib/api/assistant/conversation.ts#retryAgentMessageL1308
 /**
  * Cuts the conversation at the given step, exclusive, for the given agent
  * message. Conversation has already been prepared appropriately before for the

--- a/front/temporal/agent_loop/lib/loop_utils.ts
+++ b/front/temporal/agent_loop/lib/loop_utils.ts
@@ -1,0 +1,49 @@
+import {
+  isAgentMessageType,
+  type AgentMessageType,
+  type ConversationType,
+} from "@app/types";
+import assert from "assert";
+
+/**
+ * Cuts the conversation at the given step, exclusive, for the given agent
+ * message. Conversation has already been prepared appropriately before for the
+ * use case (post / edit / retry), this function only handles the step slicing
+ * for a given agent message.
+ * @param conversation
+ * @param param1
+ * @returns
+ */
+export function sliceConversation(
+  conversation: ConversationType,
+  { agentMessage, step }: { agentMessage: AgentMessageType; step: number }
+): ConversationType {
+  const slicedConversation = { ...conversation };
+  const conversationAgentMessage = slicedConversation.content.findLast(
+    (messages) =>
+      messages.length > agentMessage.version &&
+      messages[agentMessage.version].sId === agentMessage.sId
+  )?.[agentMessage.version];
+
+  assert(
+    conversationAgentMessage && isAgentMessageType(conversationAgentMessage),
+    "Unreachable"
+  );
+
+  // Mutation remains local to this function since conversation was first copied
+  // into `slicedConversation`.
+  conversationAgentMessage.contents = conversationAgentMessage.contents.filter(
+    (content) => content.step < step
+  );
+
+  conversationAgentMessage.rawContents =
+    conversationAgentMessage.rawContents.filter(
+      (content) => content.step < step
+    );
+
+  conversationAgentMessage.actions = conversationAgentMessage.actions.filter(
+    (action) => action.step < step
+  );
+
+  return slicedConversation;
+}

--- a/front/temporal/agent_loop/lib/loop_utils.ts
+++ b/front/temporal/agent_loop/lib/loop_utils.ts
@@ -13,9 +13,6 @@ import assert from "assert";
  * message. Conversation has already been prepared appropriately before for the
  * use case (post / edit / retry), this function only handles the step slicing
  * for a given agent message.
- * @param conversation
- * @param param1
- * @returns
  */
 export function sliceConversationForAgentMessage(
   conversation: ConversationType,
@@ -31,14 +28,16 @@ export function sliceConversationForAgentMessage(
 ): ConversationType {
   const slicedConversation = { ...conversation };
   const slicedAgentMessage = slicedConversation.content.findLast(
-    (messages) =>
-      messages.length > agentMessageVersion &&
-      messages[agentMessageVersion].sId === agentMessageId
+    (versions) =>
+      versions.length > agentMessageVersion &&
+      versions[agentMessageVersion].sId === agentMessageId
   )?.[agentMessageVersion];
 
   assert(
-    slicedAgentMessage && isAgentMessageType(slicedAgentMessage),
-    "Unreachable"
+    slicedAgentMessage &&
+      isAgentMessageType(slicedAgentMessage) &&
+      slicedAgentMessage.version === agentMessageVersion,
+    "Unreachable: Agent message not found or mismatched."
   );
 
   // Mutation remains local to this function since conversation was first copied

--- a/front/temporal/agent_loop/lib/loop_utils.ts
+++ b/front/temporal/agent_loop/lib/loop_utils.ts
@@ -14,34 +14,41 @@ import assert from "assert";
  * @param param1
  * @returns
  */
-export function sliceConversation(
+export function sliceConversationForAgentMessage(
   conversation: ConversationType,
-  { agentMessage, step }: { agentMessage: AgentMessageType; step: number }
+  {
+    agentMessageId,
+    agentMessageVersion,
+    step,
+  }: {
+    agentMessageId: string;
+    agentMessageVersion: number;
+    step: number;
+  }
 ): ConversationType {
   const slicedConversation = { ...conversation };
-  const conversationAgentMessage = slicedConversation.content.findLast(
+  const slicedAgentMessage = slicedConversation.content.findLast(
     (messages) =>
-      messages.length > agentMessage.version &&
-      messages[agentMessage.version].sId === agentMessage.sId
-  )?.[agentMessage.version];
+      messages.length > agentMessageVersion &&
+      messages[agentMessageVersion].sId === agentMessageId
+  )?.[agentMessageVersion];
 
   assert(
-    conversationAgentMessage && isAgentMessageType(conversationAgentMessage),
+    slicedAgentMessage && isAgentMessageType(slicedAgentMessage),
     "Unreachable"
   );
 
   // Mutation remains local to this function since conversation was first copied
   // into `slicedConversation`.
-  conversationAgentMessage.contents = conversationAgentMessage.contents.filter(
+  slicedAgentMessage.contents = slicedAgentMessage.contents.filter(
     (content) => content.step < step
   );
 
-  conversationAgentMessage.rawContents =
-    conversationAgentMessage.rawContents.filter(
-      (content) => content.step < step
-    );
+  slicedAgentMessage.rawContents = slicedAgentMessage.rawContents.filter(
+    (content) => content.step < step
+  );
 
-  conversationAgentMessage.actions = conversationAgentMessage.actions.filter(
+  slicedAgentMessage.actions = slicedAgentMessage.actions.filter(
     (action) => action.step < step
   );
 


### PR DESCRIPTION
## Description
Fixes https://github.com/dust-tt/tasks/issues/3567

Refactored `renderConversationForModel` to support rendering conversations only up to a given step by:
- Creating conversation slicing logic 
- added it into `getRunAgentData` with optional `step` parameter
- Updated `runModelActivity` and `runToolActivity` to pass step parameter

## Risk
Blast radius: Agent message rendering and model/tool execution workflows
Risk: standard

## Deploy Plan
- Deploy front service