### PR TITLE
Add personal connection retrigger for invalid token error

### DIFF
--- a/front/lib/actions/mcp_actions.ts
+++ b/front/lib/actions/mcp_actions.ts
@@ -23,7 +23,7 @@ import type {
   ServerSideMCPServerConfigurationType,
   ServerSideMCPToolConfigurationType,
 } from "@app/lib/actions/mcp";
-import type { MCPServerPersonalAuthenticationRequiredError } from "@app/lib/actions/mcp_authentication";
+import { MCPServerPersonalAuthenticationRequiredError } from "@app/lib/actions/mcp_authentication";
 import { CallToolResultSchemaWithoutBase64Validation } from "@app/lib/actions/mcp_call_tool_result_schema";
 import { getServerTypeAndIdFromSId } from "@app/lib/actions/mcp_helper";
 import {
@@ -320,6 +320,34 @@ export async function* tryCallMCPTool(
     // Do not raise an error here as it will break the conversation.
     // Let the model decide what to do.
     if (toolCallResult.isError) {
+      // Check if MCP tool called for personal re-authentication
+      if (
+        Array.isArray(toolCallResult.content) &&
+        toolCallResult.content.length > 0
+      ) {
+        const jsonContent = toolCallResult.content[0];
+        if (jsonContent?.type === "text") {
+          try {
+            const parsed = JSON.parse(jsonContent.text);
+            if (parsed?.__dust_auth_required) {
+              const authReq = parsed.__dust_auth_required;
+              yield {
+                type: "result",
+                result: new Err(
+                  new MCPServerPersonalAuthenticationRequiredError(
+                    authReq.mcpServerId,
+                    authReq.provider
+                  )
+                ),
+              };
+              return;
+            }
+          } catch {
+            // Not valid JSON, continue with normal processing
+          }
+        }
+      }
+
       logger.error(
         {
           conversationId,

--- a/front/lib/actions/mcp_internal_actions/servers/slack.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/slack.ts
@@ -90,33 +90,33 @@ function makeQueryResource(
   };
 }
 
-function handleSlackTokenRevokedError(
-  error: unknown,
-  agentLoopContext?: AgentLoopContextType
-): CallToolResult | null {
-  if (
+function isSlackTokenRevoked(error: unknown): boolean {
+  return (
     typeof error === "object" &&
     error !== null &&
     (error as any).message &&
     (error as any).message.toString().includes("token_revoked")
-  ) {
-    const mcpServerId = getMcpServerIdFromContext(agentLoopContext);
-    return {
-      isError: true,
-      content: [
-        {
-          type: "text" as const,
-          text: JSON.stringify({
-            __dust_auth_required: {
-              mcpServerId,
-              provider: "slack",
-            },
-          }),
-        },
-      ],
-    };
-  }
-  return null;
+  );
+}
+
+function makeSlackTokenRevokedError(
+  agentLoopContext?: AgentLoopContextType
+): CallToolResult {
+  const mcpServerId = getMcpServerIdFromContext(agentLoopContext);
+  return {
+    isError: true,
+    content: [
+      {
+        type: "text" as const,
+        text: JSON.stringify({
+          __dust_auth_required: {
+            mcpServerId,
+            provider: "slack",
+          },
+        }),
+      },
+    ],
+  };
 }
 
 const createServer = (
@@ -345,9 +345,8 @@ const createServer = (
           };
         }
       } catch (error) {
-        const revoked = handleSlackTokenRevokedError(error, agentLoopContext);
-        if (revoked) {
-          return revoked;
+        if (isSlackTokenRevoked(error)) {
+          return makeSlackTokenRevokedError(agentLoopContext);
         }
         return makeMCPToolTextError(`Error searching messages: ${error}`);
       }
@@ -476,9 +475,8 @@ const createServer = (
           };
         }
       } catch (error) {
-        const revoked = handleSlackTokenRevokedError(error, agentLoopContext);
-        if (revoked) {
-          return revoked;
+        if (isSlackTokenRevoked(error)) {
+          return makeSlackTokenRevokedError(agentLoopContext);
         }
         return makeMCPToolTextError(`Error listing threads: ${error}`);
       }
@@ -539,9 +537,8 @@ const createServer = (
           result: response,
         });
       } catch (error) {
-        const revoked = handleSlackTokenRevokedError(error, agentLoopContext);
-        if (revoked) {
-          return revoked;
+        if (isSlackTokenRevoked(error)) {
+          return makeSlackTokenRevokedError(agentLoopContext);
         }
         return makeMCPToolTextError(`Error posting message: ${error}`);
       }
@@ -616,9 +613,8 @@ const createServer = (
           result: users,
         });
       } catch (error) {
-        const revoked = handleSlackTokenRevokedError(error, agentLoopContext);
-        if (revoked) {
-          return revoked;
+        if (isSlackTokenRevoked(error)) {
+          return makeSlackTokenRevokedError(agentLoopContext);
         }
         return makeMCPToolTextError(`Error listing users: ${error}`);
       }
@@ -692,9 +688,8 @@ const createServer = (
           result: channels,
         });
       } catch (error) {
-        const revoked = handleSlackTokenRevokedError(error, agentLoopContext);
-        if (revoked) {
-          return revoked;
+        if (isSlackTokenRevoked(error)) {
+          return makeSlackTokenRevokedError(agentLoopContext);
         }
         return makeMCPToolTextError(`Error listing channels: ${error}`);
       }

--- a/front/lib/actions/mcp_internal_actions/utils.ts
+++ b/front/lib/actions/mcp_internal_actions/utils.ts
@@ -3,6 +3,9 @@ import type {
   TextContent,
 } from "@modelcontextprotocol/sdk/types.js";
 
+import type { AgentLoopContextType } from "@app/lib/actions/types";
+import { isServerSideMCPToolConfiguration } from "@app/lib/actions/types/guards";
+
 /**
  * Error tool result. Does not fail the agent loop (the text is shown to the model) but is logged.
  * If the tool callback is wrapped by `withToolLogging`, the error will be tracked and the error
@@ -82,4 +85,17 @@ export const makeMCPToolJSONSuccess = ({
       { type: "text" as const, text: JSON.stringify(result, null, 2) },
     ],
   };
+};
+
+/**
+ * Helper to get MCP server ID from agent loop context
+ */
+export const getMcpServerIdFromContext = (
+  agentLoopContext?: AgentLoopContextType
+): string | null => {
+  const actionConfig = agentLoopContext?.runContext?.actionConfiguration;
+  if (actionConfig && isServerSideMCPToolConfiguration(actionConfig)) {
+    return actionConfig.internalMCPServerId || null;
+  }
+  return null;
 };

--- a/front/lib/api/oauth/providers/slack.ts
+++ b/front/lib/api/oauth/providers/slack.ts
@@ -34,6 +34,8 @@ export class SlackOAuthProvider implements BaseOAuthStrategyProvider {
               "search:read",
               "users:read",
               "channels:read",
+              "reactions:read",
+              "reactions:write",
             ],
             bot_scopes: [],
           };


### PR DESCRIPTION
## Description

* Catching invalid tokens from Slack tool and re-trigger personal connection flow to re-authenticate
* Adding reaction actions as this will be required in the near future (oauth app already updated with these actions)

## Tests

* Invalidated local token
* Tested workflow
* Ensured could call slack

## Risk

* Mitigating risk of existing incident

## Deploy Plan

* Deploy front