### PR TITLE
[front] - fix(agent_configurations): handle Dust App permissions 

### DIFF
--- a/front/lib/api/assistant/permissions.ts
+++ b/front/lib/api/assistant/permissions.ts
@@ -130,10 +130,11 @@ export async function getAgentConfigurationGroupIdsFromActions(
   }
 
   // Collect Dust App permissions by space.
-  const dustAppIds = actions
-    .filter((action) => isServerSideMCPServerConfiguration(action))
-    .map((action) => action.dustAppConfiguration?.appId)
-    .filter((appId) => appId !== undefined);
+  const dustAppIds = removeNulls(
+    actions
+      .filter(isServerSideMCPServerConfiguration)
+      .map((action) => action.dustAppConfiguration?.appId)
+  );
 
   if (dustAppIds.length > 0) {
     const dustApps = await AppResource.fetchByIds(auth, dustAppIds);

--- a/front/migrations/20250725_backfill_agent_configurations.ts
+++ b/front/migrations/20250725_backfill_agent_configurations.ts
@@ -1,0 +1,278 @@
+import * as _ from "lodash";
+import { Op } from "sequelize";
+
+import { isServerSideMCPServerConfiguration } from "@app/lib/actions/types/guards";
+import { getAgentConfigurations } from "@app/lib/api/assistant/configuration";
+import { getAgentConfigurationGroupIdsFromActions } from "@app/lib/api/assistant/permissions";
+import { Authenticator } from "@app/lib/auth";
+import { AgentMCPServerConfiguration } from "@app/lib/models/assistant/actions/mcp";
+import { AgentConfiguration } from "@app/lib/models/assistant/agent";
+import { WorkspaceModel } from "@app/lib/resources/storage/models/workspace";
+import { isArrayEqual2DUnordered, normalizeArrays } from "@app/lib/utils";
+import { concurrentExecutor } from "@app/lib/utils/async_utils";
+import type { Logger } from "@app/logger/logger";
+import { makeScript } from "@app/scripts/helpers";
+
+interface AgentUpdateStats {
+  total: number;
+  withDustApps: number;
+  updated: number;
+  errors: number;
+}
+
+async function updateAgentConfigurationGroupIds(
+  auth: Authenticator,
+  agent: AgentConfiguration,
+  execute: boolean,
+  logger: Logger
+): Promise<{ updated: boolean; error?: string }> {
+  try {
+    // Get the full agent configuration with actions
+    const agentConfiguration = await getAgentConfigurations({
+      auth,
+      agentsGetView: { agentIds: [agent.sId] },
+      variant: "full",
+      dangerouslySkipPermissionFiltering: true,
+    });
+
+    if (!agentConfiguration[0]) {
+      return { updated: false, error: "Agent configuration not found" };
+    }
+
+    const ac = agentConfiguration[0];
+
+    // Check if agent has any dust app configurations
+    const hasDustApps = ac.actions.some(
+      (action) =>
+        action.type === "mcp_server_configuration" &&
+        isServerSideMCPServerConfiguration(action) &&
+        action.dustAppConfiguration !== null
+    );
+
+    if (!hasDustApps) {
+      logger.debug(
+        { agentId: agent.sId },
+        "Agent has no dust app configurations, skipping"
+      );
+      return { updated: false };
+    }
+
+    // Calculate the correct group IDs using the updated function
+    const newRequestedGroupIds = await getAgentConfigurationGroupIdsFromActions(
+      auth,
+      { actions: ac.actions }
+    );
+
+    // Normalize the arrays for comparison
+    const normalizedNewGroupIds = normalizeArrays(newRequestedGroupIds);
+    const normalizedCurrentGroupIds = normalizeArrays(agent.requestedGroupIds);
+
+    // Check if the group IDs have changed
+    if (isArrayEqual2DUnordered(normalizedNewGroupIds, normalizedCurrentGroupIds)) {
+      logger.debug(
+        { agentId: agent.sId },
+        "Agent group IDs are already up to date"
+      );
+      return { updated: false };
+    }
+
+    logger.info(
+      {
+        agentId: agent.sId,
+        agentName: agent.name,
+        currentGroupIds: normalizedCurrentGroupIds,
+        newGroupIds: normalizedNewGroupIds,
+        execute,
+      },
+      "Updating agent configuration group IDs for dust app permissions"
+    );
+
+    if (execute) {
+      await AgentConfiguration.update(
+        { requestedGroupIds: normalizedNewGroupIds },
+        { where: { sId: agent.sId } }
+      );
+    }
+
+    return { updated: true };
+  } catch (error) {
+    const errorMessage = error instanceof Error ? error.message : "Unknown error";
+    logger.error(
+      { agentId: agent.sId, error: errorMessage },
+      "Error updating agent configuration group IDs"
+    );
+    return { updated: false, error: errorMessage };
+  }
+}
+
+async function updateAgentsForWorkspace(
+  workspaceId: number,
+  execute: boolean,
+  logger: Logger
+): Promise<AgentUpdateStats> {
+  const workspace = await WorkspaceModel.findByPk(workspaceId);
+  if (!workspace) {
+    logger.error({ workspaceId }, "Workspace not found");
+    return { total: 0, withDustApps: 0, updated: 0, errors: 0 };
+  }
+
+  logger.info(
+    { workspaceId, workspaceName: workspace.name, execute },
+    "Processing workspace"
+  );
+
+  const auth = await Authenticator.internalAdminForWorkspace(workspace.sId);
+
+  // Find all active agent configurations that have MCP actions with dust apps
+  const agentsWithDustApps = await AgentConfiguration.findAll({
+    where: {
+      workspaceId,
+      status: "active",
+      id: {
+        [Op.in]: await AgentMCPServerConfiguration.findAll({
+          where: {
+            workspaceId,
+            appId: { [Op.not]: null },
+          },
+          attributes: ["agentConfigurationId"],
+          group: ["agentConfigurationId"],
+        }).then((configs) => configs.map((c) => c.agentConfigurationId)),
+      },
+    },
+    attributes: ["id", "sId", "name", "requestedGroupIds"],
+  });
+
+  logger.info(
+    { workspaceId, agentCount: agentsWithDustApps.length },
+    "Found agents with dust app configurations"
+  );
+
+  const stats: AgentUpdateStats = {
+    total: agentsWithDustApps.length,
+    withDustApps: agentsWithDustApps.length,
+    updated: 0,
+    errors: 0,
+  };
+
+  // Process agents in chunks to avoid overwhelming the system
+  const agentChunks = _.chunk(agentsWithDustApps, 10);
+
+  for (const chunk of agentChunks) {
+    const results = await concurrentExecutor(
+      chunk,
+      async (agent) => updateAgentConfigurationGroupIds(auth, agent, execute, logger),
+      { concurrency: 5 }
+    );
+
+    for (const result of results) {
+      if (result.error) {
+        stats.errors++;
+      } else if (result.updated) {
+        stats.updated++;
+      }
+    }
+  }
+
+  logger.info(
+    {
+      workspaceId,
+      workspaceName: workspace.name,
+      stats,
+      execute
+    },
+    "Completed workspace processing"
+  );
+
+  return stats;
+}
+
+async function getWorkspacesWithDustApps(): Promise<number[]> {
+  // Find all workspaces that have agents with dust app configurations
+  const workspaceIds = await AgentMCPServerConfiguration.findAll({
+    where: {
+      appId: { [Op.not]: null },
+    },
+    attributes: ["workspaceId"],
+    group: ["workspaceId"],
+    raw: true,
+  });
+
+  return workspaceIds.map((entry) => entry.workspaceId);
+}
+
+makeScript(
+  {
+    workspaceId: {
+      type: "string",
+      description: "Specific workspace SID to process",
+      required: false,
+    },
+  },
+  async ({ execute, workspaceId }, logger) => {
+    logger.info(
+      { execute, workspaceId },
+      "Starting dust app agent group permissions fix"
+    );
+
+    let workspaceModelIds: number[] = [];
+
+    if (workspaceId) {
+      // Process specific workspace
+      const workspace = await WorkspaceModel.findOne({
+        where: { sId: workspaceId },
+      });
+      if (!workspace) {
+        throw new Error(`Workspace ${workspaceId} not found`);
+      }
+      workspaceModelIds = [workspace.id];
+    } else {
+      // Process all workspaces that have agents with dust apps
+      workspaceModelIds = await getWorkspacesWithDustApps();
+      logger.info(
+        { workspaceCount: workspaceModelIds.length },
+        "Found workspaces with dust app configurations"
+      );
+    }
+
+    const globalStats: AgentUpdateStats = {
+      total: 0,
+      withDustApps: 0,
+      updated: 0,
+      errors: 0,
+    };
+
+    // Process workspaces in chunks
+    const workspaceChunks = _.chunk(workspaceModelIds, 5);
+
+    for (const chunk of workspaceChunks) {
+      const results = await Promise.all(
+        chunk.map((id) => updateAgentsForWorkspace(id, execute, logger))
+      );
+
+      for (const stats of results) {
+        globalStats.total += stats.total;
+        globalStats.withDustApps += stats.withDustApps;
+        globalStats.updated += stats.updated;
+        globalStats.errors += stats.errors;
+      }
+    }
+
+    logger.info(
+      {
+        execute,
+        workspaceCount: workspaceModelIds.length,
+        globalStats,
+      },
+      execute
+        ? "Completed dust app agent group permissions fix"
+        : "Dry run completed - would have fixed dust app agent group permissions"
+    );
+
+    if (globalStats.errors > 0) {
+      logger.warn(
+        { errorCount: globalStats.errors },
+        "Some agents failed to update - check logs for details"
+      );
+    }
+  }
+);

--- a/front/migrations/20250725_backfill_agent_configurations.ts
+++ b/front/migrations/20250725_backfill_agent_configurations.ts
@@ -68,7 +68,9 @@ async function updateAgentConfigurationGroupIds(
     const normalizedCurrentGroupIds = normalizeArrays(agent.requestedGroupIds);
 
     // Check if the group IDs have changed
-    if (isArrayEqual2DUnordered(normalizedNewGroupIds, normalizedCurrentGroupIds)) {
+    if (
+      isArrayEqual2DUnordered(normalizedNewGroupIds, normalizedCurrentGroupIds)
+    ) {
       logger.debug(
         { agentId: agent.sId },
         "Agent group IDs are already up to date"
@@ -96,7 +98,8 @@ async function updateAgentConfigurationGroupIds(
 
     return { updated: true };
   } catch (error) {
-    const errorMessage = error instanceof Error ? error.message : "Unknown error";
+    const errorMessage =
+      error instanceof Error ? error.message : "Unknown error";
     logger.error(
       { agentId: agent.sId, error: errorMessage },
       "Error updating agent configuration group IDs"
@@ -160,7 +163,8 @@ async function updateAgentsForWorkspace(
   for (const chunk of agentChunks) {
     const results = await concurrentExecutor(
       chunk,
-      async (agent) => updateAgentConfigurationGroupIds(auth, agent, execute, logger),
+      async (agent) =>
+        updateAgentConfigurationGroupIds(auth, agent, execute, logger),
       { concurrency: 5 }
     );
 
@@ -178,7 +182,7 @@ async function updateAgentsForWorkspace(
       workspaceId,
       workspaceName: workspace.name,
       stats,
-      execute
+      execute,
     },
     "Completed workspace processing"
   );


### PR DESCRIPTION
## Description

This PR fixes a permissions issue where agent configurations were not correctly handling Dust App permissions in their requested group IDs. When an agent is configured to use a Dust App action, we now properly extract the Dust App IDs and fetch corresponding permissions to add them to the agent configuration's spacePermissions map.

## Tests

Locally

## Risk

High, if logic is wrong agents can have access to other spaces

## Deploy Plan

Deploy front
