### PR TITLE
[front] Remove citation offset computation from workflow state

### DIFF
--- a/front/temporal/agent_loop/activities/run_model.ts
+++ b/front/temporal/agent_loop/activities/run_model.ts
@@ -65,7 +65,6 @@ export async function runModelActivity({
   runIds,
   step,
   functionCallStepContentIds,
-  citationsRefsOffset,
   autoRetryCount = 0,
 }: {
   authType: AuthenticatorType;
@@ -73,7 +72,6 @@ export async function runModelActivity({
   runIds: string[];
   step: number;
   functionCallStepContentIds: Record<string, ModelId>;
-  citationsRefsOffset: number;
   autoRetryCount?: number;
 }): Promise<{
   actions: AgentActionsEvent["actions"];
@@ -415,7 +413,6 @@ export async function runModelActivity({
         runIds,
         step,
         functionCallStepContentIds,
-        citationsRefsOffset,
         autoRetryCount: autoRetryCount + 1,
       });
     }
@@ -854,7 +851,6 @@ export async function runModelActivity({
   const stepContexts = computeStepContexts({
     agentConfiguration,
     stepActions: actions.map((a) => a.action),
-    citationsRefsOffset,
   });
 
   return {

--- a/front/temporal/agent_loop/lib/agent_loop_executor.ts
+++ b/front/temporal/agent_loop/lib/agent_loop_executor.ts
@@ -19,9 +19,6 @@ export async function executeAgentLoop(
   runAgentArgs: RunAgentArgs,
   activities: AgentLoopActivities
 ): Promise<void> {
-  // Citations references offset kept up to date across steps.
-  let citationsRefsOffset = 0;
-
   const runIds: string[] = [];
 
   // Track step content IDs by function call ID for later use in actions.
@@ -34,7 +31,6 @@ export async function executeAgentLoop(
       runIds,
       step: i,
       functionCallStepContentIds,
-      citationsRefsOffset,
       autoRetryCount: 0,
     });
 
@@ -63,12 +59,6 @@ export async function executeAgentLoop(
           stepContentId: functionCallStepContentIds[functionCallId],
         })
       )
-    );
-
-    // Update citations offset with pre-computed increment
-    citationsRefsOffset += stepContexts.reduce(
-      (acc, context) => acc + context.citationsCount,
-      0
     );
   }
 }

--- a/front/types/assistant/conversation.ts
+++ b/front/types/assistant/conversation.ts
@@ -116,9 +116,8 @@ export function isUserMessageType(
 /**
  * Agent messages
  */
-export type ConfigurableAgentActionType = MCPActionType;
 
-export type AgentActionType = ConfigurableAgentActionType;
+export type AgentActionType = MCPActionType;
 
 export type AgentMessageStatus =
   | "created"


### PR DESCRIPTION
## Description

- Closes https://github.com/dust-tt/tasks/issues/3411.
- This PR removes the stored state `citationsRefsOffset` from the workflow, instead retrieving it at the beginning of a `runToolActivity`.
- The intra-step offsets are still computed in `runModelActivity` to enable coordination between the actions of a step.
- The global offset, accounting for past actions is computed at the beginning of `runToolActivity`.

## Tests

## Risk

## Deploy Plan

- Deploy front.
