### PR TITLE
[front] Add log to check code path reachability

### DIFF
--- a/front/temporal/agent_loop/activities/run_model.ts
+++ b/front/temporal/agent_loop/activities/run_model.ts
@@ -191,6 +191,7 @@ export async function runModelActivity({
 
   for (const agentAction of agentActions) {
     if (isActionConfigurationType(agentAction)) {
+      logger.info("Found an available action on the agentConfiguration.");
       availableActions.push(agentAction);
     }
   }


### PR DESCRIPTION
## Description

- Pretty sure the code path where, when running a model, we add to the available actions something that was directly found from the `agentConfiguration` is not reachable.
- This PR adds a log to check whether this is actually the case. I'll let this run for a bit and if we don't get anything will cleanup this code path.

## Tests

- N/A.

## Risk

- N/A.

## Deploy Plan

- Deploy front.
