### PR TITLE
[front] Cleanup unreachable code path in `runModelActivity`

### DIFF
--- a/front/lib/actions/types/agent.ts
+++ b/front/lib/actions/types/agent.ts
@@ -15,20 +15,6 @@ export type AgentActionConfigurationType = MCPServerConfigurationType;
  */
 export type ActionConfigurationType = MCPToolConfigurationType;
 
-/**
- * Type guard to check if a value is of type ActionConfigurationType
- */
-export function isActionConfigurationType(
-  value: AgentActionConfigurationType | ActionConfigurationType
-): value is ActionConfigurationType {
-  switch (value.type) {
-    case "mcp_configuration":
-      return true;
-    case "mcp_server_configuration":
-      return false;
-  }
-}
-
 // We need to apply "Omit" to each member of the union separately rather than the whole union
 // because Omit<A | B, "k"> is different from Omit<A, "k"> | Omit<B, "k">.
 // The first form loses the discriminated union properties needed for type narrowing.

--- a/front/temporal/agent_loop/activities/run_model.ts
+++ b/front/temporal/agent_loop/activities/run_model.ts
@@ -209,13 +209,11 @@ export async function runModelActivity({
     );
   }
 
-  const isLastGenerationIteration = step === agentConfiguration.maxStepsPerRun;
+  const isLastStep = step === agentConfiguration.maxStepsPerRun;
 
   // If we already executed the maximum number of actions, we don't run anymore.
   // This will force the agent to run the generation.
-  const availableActions = isLastGenerationIteration
-    ? mcpActions.flatMap((s) => s.tools)
-    : [];
+  const availableActions = isLastStep ? mcpActions.flatMap((s) => s.tools) : [];
 
   let fallbackPrompt = "You are a conversational agent";
   if (
@@ -719,7 +717,9 @@ export async function runModelActivity({
     "[ASSISTANT_TRACE] Action inputs generation"
   );
 
-  if (isLastGenerationIteration) {
+  // If we have actions and we are on the last step, we error since returning actions would require
+  // doing one more step.
+  if (isLastStep) {
     await publishAgentError({
       code: "max_step_reached",
       message:

--- a/front/temporal/agent_loop/activities/run_model.ts
+++ b/front/temporal/agent_loop/activities/run_model.ts
@@ -11,10 +11,7 @@ import {
   runActionStreamed,
 } from "@app/lib/actions/server";
 import type { StepContext } from "@app/lib/actions/types";
-import type {
-  ActionConfigurationType,
-  AgentActionSpecification,
-} from "@app/lib/actions/types/agent";
+import type { AgentActionSpecification } from "@app/lib/actions/types/agent";
 import { computeStepContexts } from "@app/lib/actions/utils";
 import { createClientSideMCPServerConfigurations } from "@app/lib/api/actions/mcp_client_side";
 import { categorizeAgentErrorMessage } from "@app/lib/api/assistant/agent_errors";
@@ -214,12 +211,11 @@ export async function runModelActivity({
 
   const isLastGenerationIteration = step === agentConfiguration.maxStepsPerRun;
 
-  const availableActions: ActionConfigurationType[] = [];
   // If we already executed the maximum number of actions, we don't run anymore.
   // This will force the agent to run the generation.
-  if (!isLastGenerationIteration) {
-    availableActions.push(...mcpActions.flatMap((s) => s.tools));
-  }
+  const availableActions = isLastGenerationIteration
+    ? mcpActions.flatMap((s) => s.tools)
+    : [];
 
   let fallbackPrompt = "You are a conversational agent";
   if (

--- a/front/temporal/agent_loop/activities/run_model.ts
+++ b/front/temporal/agent_loop/activities/run_model.ts
@@ -720,12 +720,10 @@ export async function runModelActivity({
   );
 
   if (isLastGenerationIteration) {
-    // TODO(2025-07-25 aubin): fix this error, we reached the max step, we did not
-    //  reach the max tool use.
     await publishAgentError({
-      code: "tool_use_limit_reached",
+      code: "max_step_reached",
       message:
-        "The agent attempted to use too many tools. This model error can be safely retried.",
+        "The agent reached the maximum number of steps. This error can be safely retried.",
       metadata: null,
     });
     return null;

--- a/front/temporal/agent_loop/activities/run_model.ts
+++ b/front/temporal/agent_loop/activities/run_model.ts
@@ -211,9 +211,9 @@ export async function runModelActivity({
 
   const isLastStep = step === agentConfiguration.maxStepsPerRun;
 
-  // If we already executed the maximum number of actions, we don't run anymore.
+  // If we are on the last step, we don't show any action.
   // This will force the agent to run the generation.
-  const availableActions = isLastStep ? mcpActions.flatMap((s) => s.tools) : [];
+  const availableActions = isLastStep ? [] : mcpActions.flatMap((s) => s.tools);
 
   let fallbackPrompt = "You are a conversational agent";
   if (


### PR DESCRIPTION
## Description

- Follow up on https://github.com/dust-tt/dust/pull/14593.
- The type actually already states that the code path in question is unreachable.
- This PR cleans it up + fixes an error message that was incorrect.

## Tests

## Risk

- Low.

## Deploy Plan

- Deploy front.
