### PR TITLE
Stop saving table query data to Postgres

### DIFF
--- a/core/src/databases_store/store.rs
+++ b/core/src/databases_store/store.rs
@@ -5,7 +5,7 @@ use crate::databases::table::{Row, Table};
 use crate::databases::table_schema::TableSchema;
 
 // These flags are transitional while we migrate to GCS. Eventually, we will only use GCS.
-pub const SAVE_TABLES_TO_POSTGRES: bool = true;
+pub const SAVE_TABLES_TO_POSTGRES: bool = false;
 pub const SAVE_TABLES_TO_GCS: bool = true;
 
 #[async_trait]


### PR DESCRIPTION
## Description

Fixes https://github.com/dust-tt/tasks/issues/3556

After this change, GCS becomes the only store for table query data.
Also, small logging changes.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
