### PR TITLE
[Durable Agents] Add startStep parameter for retry functionality

### DIFF
--- a/front/lib/api/assistant/conversation.ts
+++ b/front/lib/api/assistant/conversation.ts
@@ -694,7 +694,7 @@ export async function postUserMessage(
       void runAgentLoop(
         auth.toJSON(),
         { sync: true, inMemoryData },
-        { forceAsynchronousLoop }
+        { forceAsynchronousLoop, startStep: 0 }
       );
     },
     { concurrency: MAX_CONCURRENT_AGENT_EXECUTIONS_PER_USER_MESSAGE }
@@ -1135,7 +1135,7 @@ export async function editUserMessage(
       void runAgentLoop(
         auth.toJSON(),
         { sync: true, inMemoryData },
-        { forceAsynchronousLoop: false }
+        { forceAsynchronousLoop: false, startStep: 0 }
       );
     },
     { concurrency: MAX_CONCURRENT_AGENT_EXECUTIONS_PER_USER_MESSAGE }
@@ -1357,7 +1357,7 @@ export async function retryAgentMessage(
   void runAgentLoop(
     auth.toJSON(),
     { sync: true, inMemoryData },
-    { forceAsynchronousLoop: false }
+    { forceAsynchronousLoop: false, startStep: 0 }
   );
 
   // TODO(DURABLE-AGENTS 2025-07-17): Publish message events to all open tabs to maintain

--- a/front/temporal/agent_loop/activities/run_model.ts
+++ b/front/temporal/agent_loop/activities/run_model.ts
@@ -49,7 +49,6 @@ import type {
 } from "@app/types/assistant/agent_message_content";
 import type { RunAgentArgs } from "@app/types/assistant/agent_run";
 import { getRunAgentData } from "@app/types/assistant/agent_run";
-import { sliceConversationForAgentMessage } from "@app/temporal/agent_loop/lib/loop_utils";
 
 const CANCELLATION_CHECK_INTERVAL = 500;
 const MAX_AUTO_RETRY = 3;

--- a/front/temporal/agent_loop/client.ts
+++ b/front/temporal/agent_loop/client.ts
@@ -11,9 +11,11 @@ import { agentLoopWorkflow } from "./workflows";
 export async function launchAgentLoopWorkflow({
   authType,
   runAsynchronousAgentArgs,
+  startStep,
 }: {
   authType: AuthenticatorType;
   runAsynchronousAgentArgs: RunAgentAsynchronousArgs;
+  startStep: number;
 }): Promise<Result<undefined, Error>> {
   const client = await getTemporalClient();
 
@@ -23,7 +25,7 @@ export async function launchAgentLoopWorkflow({
   );
 
   await client.workflow.start(agentLoopWorkflow, {
-    args: [{ authType, runAsynchronousAgentArgs }],
+    args: [{ authType, runAsynchronousAgentArgs, startStep }],
     taskQueue: QUEUE_NAME,
     workflowId,
   });

--- a/front/temporal/agent_loop/lib/agent_loop_executor.ts
+++ b/front/temporal/agent_loop/lib/agent_loop_executor.ts
@@ -17,7 +17,8 @@ import type { AgentLoopActivities } from "./activity_interface";
 export async function executeAgentLoop(
   authType: AuthenticatorType,
   runAgentArgs: RunAgentArgs,
-  activities: AgentLoopActivities
+  activities: AgentLoopActivities,
+  startStep: number
 ): Promise<void> {
   // Citations references offset kept up to date across steps.
   let citationsRefsOffset = 0;
@@ -27,7 +28,7 @@ export async function executeAgentLoop(
   // Track step content IDs by function call ID for later use in actions.
   let functionCallStepContentIds: Record<string, ModelId> = {};
 
-  for (let i = 0; i < MAX_STEPS_USE_PER_RUN_LIMIT + 1; i++) {
+  for (let i = startStep; i < MAX_STEPS_USE_PER_RUN_LIMIT + 1; i++) {
     const result = await activities.runModelActivity({
       authType,
       runAgentArgs,

--- a/front/temporal/agent_loop/workflows.ts
+++ b/front/temporal/agent_loop/workflows.ts
@@ -51,9 +51,11 @@ export async function agentLoopConversationTitleWorkflow({
 export async function agentLoopWorkflow({
   authType,
   runAsynchronousAgentArgs,
+  startStep,
 }: {
   authType: AuthenticatorType;
   runAsynchronousAgentArgs: RunAgentAsynchronousArgs;
+  startStep: number;
 }) {
   const { searchAttributes: parentSearchAttributes, memo } = workflowInfo();
 
@@ -92,7 +94,7 @@ export async function agentLoopWorkflow({
     }
   }
 
-  await executeAgentLoop(authType, runAgentArgs, activities);
+  await executeAgentLoop(authType, runAgentArgs, activities, startStep);
 
   if (childWorkflowHandle) {
     await childWorkflowHandle.result();


### PR DESCRIPTION
## Description
Context: https://github.com/dust-tt/tasks/issues/3590

This PR adds a `startStep` parameter throughout the agent loop execution flow. This is a preliminary change to support future retry functionality that will allow retrying from a specific step in the agent loop.

## Risks
Blast radius: Agent loop execution flow
Risk: very low

**No prod behaviour change**: This change does not alter current behavior. All code paths continue to pass `startStep: 0`, maintaining the existing functionality of always starting from the beginning.


## Deploy Plan
- Deploy front service