### PR TITLE
[Durable Agents] Fix conversation slicing for retry functionality

### DIFF
--- a/front/temporal/agent_loop/activities/run_tool.ts
+++ b/front/temporal/agent_loop/activities/run_tool.ts
@@ -5,6 +5,7 @@ import type { AuthenticatorType } from "@app/lib/auth";
 import { Authenticator } from "@app/lib/auth";
 import { AgentStepContentResource } from "@app/lib/resources/agent_step_content_resource";
 import { updateResourceAndPublishEvent } from "@app/temporal/agent_loop/activities/common";
+import { sliceConversationForAgentMessage } from "@app/temporal/agent_loop/lib/loop_utils";
 import { assertNever } from "@app/types";
 import { isFunctionCallContent } from "@app/types/assistant/agent_message_content";
 import type { RunAgentArgs } from "@app/types/assistant/agent_run";
@@ -43,13 +44,31 @@ export async function runToolActivity(
 
   const { step } = stepContent;
 
-  const runAgentDataRes = await getRunAgentData(authType, runAgentArgs, step);
+  const runAgentDataRes = await getRunAgentData(authType, runAgentArgs);
+
   if (runAgentDataRes.isErr()) {
     throw runAgentDataRes.error;
   }
 
-  const { agentConfiguration, conversation, agentMessage, agentMessageRow } =
-    runAgentDataRes.value;
+  const {
+    agentConfiguration,
+    conversation: originalConversation,
+    agentMessage: originalAgentMessage,
+    agentMessageRow,
+  } = runAgentDataRes.value;
+
+  const { slicedConversation: conversation, slicedAgentMessage: agentMessage } =
+    sliceConversationForAgentMessage(originalConversation, {
+      agentMessageId: originalAgentMessage.sId,
+      agentMessageVersion: originalAgentMessage.version,
+      // Include the current step output.
+      //
+      // TODO(DURABLE-AGENTS 2025-07-27): Change this as part of the
+      // retryOnlyBlockedTools effort (the whole step should not be included,
+      // tools successfully ran should be removed, this should be an arg to
+      // sliceConversationForAgentMessage)
+      step: step + 1,
+    });
 
   const eventStream = runToolWithStreaming(auth, action, {
     agentConfiguration: agentConfiguration,

--- a/front/temporal/agent_loop/lib/loop_utils.ts
+++ b/front/temporal/agent_loop/lib/loop_utils.ts
@@ -1,8 +1,8 @@
-import {
-  isAgentMessageType,
-  type AgentMessageType,
-  type ConversationType,
-} from "@app/types";
+import type {
+  ConversationType,
+  AgentMessageType,
+} from "@app/types/assistant/conversation";
+import { isAgentMessageType } from "@app/types";
 import assert from "assert";
 
 // TODO(DURABLE-AGENTS 2025-07-25): Consider moving inside this function the "conversation has
@@ -25,7 +25,10 @@ export function sliceConversationForAgentMessage(
     agentMessageVersion: number;
     step: number;
   }
-): ConversationType {
+): {
+  slicedConversation: ConversationType;
+  slicedAgentMessage: AgentMessageType;
+} {
   const slicedConversation = { ...conversation };
   const slicedAgentMessage = slicedConversation.content.findLast(
     (versions) =>
@@ -54,5 +57,8 @@ export function sliceConversationForAgentMessage(
     (action) => action.step < step
   );
 
-  return slicedConversation;
+  return {
+    slicedConversation,
+    slicedAgentMessage,
+  };
 }

--- a/front/types/assistant/agent_run.ts
+++ b/front/types/assistant/agent_run.ts
@@ -20,7 +20,6 @@ import {
   isAgentMessageType,
   isUserMessageType,
 } from "@app/types/assistant/conversation";
-import { sliceConversationForAgentMessage } from "@app/temporal/agent_loop/lib/loop_utils";
 
 export type RunAgentAsynchronousArgs = {
   agentMessageId: string;
@@ -51,8 +50,7 @@ export type RunAgentArgs =
 
 export async function getRunAgentData(
   authType: AuthenticatorType,
-  runAgentArgs: RunAgentArgs,
-  step?: number
+  runAgentArgs: RunAgentArgs
 ): Promise<Result<RunAgentSynchronousArgs, Error>> {
   if (runAgentArgs.sync) {
     return new Ok(runAgentArgs.inMemoryData);
@@ -74,13 +72,7 @@ export async function getRunAgentData(
     );
   }
 
-  const conversation = step
-    ? sliceConversationForAgentMessage(conversationRes.value, {
-        agentMessageId,
-        agentMessageVersion,
-        step,
-      })
-    : conversationRes.value;
+  const conversation = conversationRes.value;
 
   // Find the agent message group by searching in reverse order.
   // All messages of the same group should be of the same type and of same sId.


### PR DESCRIPTION
## Description
This PR fixes the conversation slicing logic that was moved out of `getRunAgentData` and into the appropriate activity functions (`runModelActivity` and `runToolActivity`). This ensures that the conversation is properly sliced based on the current step when processing agent messages in the sync loop (getRunAgentData did only account for async loop).

The key changes:
- Moved conversation slicing from `getRunAgentData` to `runModelActivity` and `runToolActivity`
- Updated `sliceConversationForAgentMessage` to return both the sliced conversation and agent message
- Added proper slicing in `runToolActivity` with step + 1 to include the current step output

## Risks
Blast radius: Agent loop execution, specifically conversation slicing during model and tool runs
Risk: low: limited changes, tested, no new logic in prod for existing code paths

## Deploy Plan
- Deploy front service