### PR TITLE
MCP server preview config

### DIFF
--- a/front/lib/actions/mcp_helper.ts
+++ b/front/lib/actions/mcp_helper.ts
@@ -123,7 +123,7 @@ export function getMcpServerDisplayName(
 
     const serverConfig = INTERNAL_MCP_SERVERS[res.value.name];
 
-    if (serverConfig.isRestricted !== undefined) {
+    if (serverConfig.isPreview === true) {
       displayName += " (Preview)";
     }
     // Will append Dust App name.

--- a/front/lib/actions/mcp_internal_actions/constants.ts
+++ b/front/lib/actions/mcp_internal_actions/constants.ts
@@ -73,6 +73,7 @@ export const INTERNAL_MCP_SERVERS: Record<
       plan: PlanType;
       featureFlags: WhitelistableFeature[];
     }) => boolean;
+    isPreview?: boolean;
     tools_stakes?: Record<string, MCPToolStakeLevelType>;
     timeoutMs?: number;
   }
@@ -114,6 +115,7 @@ export const INTERNAL_MCP_SERVERS: Record<
     isRestricted: ({ featureFlags }) => {
       return !featureFlags.includes("dev_mcp_actions");
     },
+    isPreview: true,
   },
   hubspot: {
     id: 7,
@@ -265,6 +267,7 @@ export const INTERNAL_MCP_SERVERS: Record<
     isRestricted: ({ featureFlags }) => {
       return !featureFlags.includes("google_sheets_tool");
     },
+    isPreview: true,
     tools_stakes: {
       list_spreadsheets: "never_ask",
       get_spreadsheet: "never_ask",
@@ -284,6 +287,7 @@ export const INTERNAL_MCP_SERVERS: Record<
     isRestricted: ({ featureFlags }) => {
       return !featureFlags.includes("monday_tool");
     },
+    isPreview: true,
     tools_stakes: {
       // Read operations
       get_boards: "never_ask",
@@ -325,6 +329,7 @@ export const INTERNAL_MCP_SERVERS: Record<
     isRestricted: ({ featureFlags }) => {
       return !featureFlags.includes("jira_tool");
     },
+    isPreview: true,
     tools_stakes: {
       // Read operations - never ask (no side effects)
       get_issue: "never_ask",
@@ -352,6 +357,7 @@ export const INTERNAL_MCP_SERVERS: Record<
     isRestricted: ({ featureFlags }) => {
       return !featureFlags.includes("interactive_content_server");
     },
+    isPreview: true,
   },
   search: {
     id: 1006,
@@ -380,6 +386,7 @@ export const INTERNAL_MCP_SERVERS: Record<
     isRestricted: ({ featureFlags }) => {
       return !featureFlags.includes("exploded_tables_query");
     },
+    isPreview: true,
   },
   data_sources_file_system: {
     id: 1010,


### PR DESCRIPTION
## Description

Displaying that a tool is in preview is not necessarily attach to the fact it is restricted. Ex: Salesforce is not in preview anymore but is restricted, and some dev tools are not in preview but are also meant to stay restricted. 

## Tests

Locally. 

## Risk

Can be rolled back. 

## Deploy Plan

Deploy front. 