### PR TITLE
[connectors] opt: small optimizations, add logging

### DIFF
--- a/connectors/src/connectors/microsoft/temporal/activities.ts
+++ b/connectors/src/connectors/microsoft/temporal/activities.ts
@@ -662,19 +662,19 @@ export async function syncDeltaForRootNodesInDrive({
   const uniqueChangedItems = removeAllButLastOccurences(results);
 
   const sortedChangedItems: DriveItem[] = [];
-  const containWholeDrive = rootNodeIds.some(
+  const containsWholeDrive = rootNodeIds.some(
     (nodeId) => typeAndPathFromInternalId(nodeId).nodeType === "drive"
   );
 
   logger.info(
     {
       uniqueChangedItems: uniqueChangedItems.length,
-      containWholeDrive,
+      containsWholeDrive,
     },
     "Changes to process"
   );
 
-  if (containWholeDrive) {
+  if (containsWholeDrive) {
     sortedChangedItems.push(...sortForIncrementalUpdate(uniqueChangedItems));
   } else {
     const microsoftNodes = await concurrentExecutor(

--- a/connectors/src/connectors/microsoft/temporal/activities.ts
+++ b/connectors/src/connectors/microsoft/temporal/activities.ts
@@ -10,7 +10,6 @@ import {
   extractPath,
   getAllPaginatedEntities,
   getDeltaResults,
-  getDriveInternalId,
   getDriveInternalIdFromItem,
   getDriveItemInternalId,
   getDrives,
@@ -56,8 +55,7 @@ import {
   MicrosoftNodeResource,
   MicrosoftRootResource,
 } from "@connectors/resources/microsoft_resource";
-import type { ModelId } from "@connectors/types";
-import type { DataSourceConfig } from "@connectors/types";
+import type { DataSourceConfig, ModelId } from "@connectors/types";
 import { cacheWithRedis, INTERNAL_MIME_TYPES } from "@connectors/types";
 
 const FILES_SYNC_CONCURRENCY = 10;
@@ -721,10 +719,11 @@ export async function syncDeltaForRootNodesInDrive({
   }
   let count = 0;
   for (const driveItem of sortedChangedItems) {
+    count++;
     if (count % 1000 === 0) {
       logger.info({ count }, "Processing delta changes");
     }
-    count++;
+
     await heartbeat();
     if (!driveItem.parentReference) {
       throw new Error(`Unexpected: parent reference missing: ${driveItem}`);

--- a/connectors/src/connectors/microsoft/temporal/file.ts
+++ b/connectors/src/connectors/microsoft/temporal/file.ts
@@ -36,7 +36,7 @@ import {
 } from "@connectors/lib/data_sources";
 import type { MicrosoftNodeModel } from "@connectors/lib/models/microsoft";
 import { heartbeat } from "@connectors/lib/temporal";
-import logger from "@connectors/logger/logger";
+import logger, { getActivityLogger } from "@connectors/logger/logger";
 import { statsDClient } from "@connectors/logger/withlogging";
 import type { WithCreationAttributes } from "@connectors/resources/connector/strategy";
 import { ConnectorResource } from "@connectors/resources/connector_resource";
@@ -45,8 +45,7 @@ import {
   MicrosoftNodeResource,
   MicrosoftRootResource,
 } from "@connectors/resources/microsoft_resource";
-import type { ModelId } from "@connectors/types";
-import type { DataSourceConfig } from "@connectors/types";
+import type { DataSourceConfig, ModelId } from "@connectors/types";
 import { cacheWithRedis } from "@connectors/types";
 
 const PARENT_SYNC_CACHE_TTL_MS = 30 * 60 * 1000;
@@ -79,13 +78,10 @@ export async function syncOneFile({
   }
 
   const documentId = getDriveItemInternalId(file);
-
-  const localLogger = logger.child({
-    provider: "microsoft",
-    connectorId,
+  const localLogger = getActivityLogger(connector, {
     internalId: documentId,
-    originalId: file.id,
-    name: file.name,
+    originalId: file.id || null,
+    name: file.name || null,
   });
 
   // If the file is too big to be downloaded, we skip it.


### PR DESCRIPTION
## Description

We have some workflows with huge number of changes stuck if changes processing loop - no log appear for more than an hour, as all first nodes are already processed and skipped. This tries to optimize the check to see if a node is already processed or not (do it earlier) and add some logs to check where we are in the process.

- Add some logs to check delta processing progress
- Check lastSeen on folders earlier

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

minimal

## Deploy Plan

deploy connectors