### PR TITLE
[front] Increase citation lengths to 3 characters

### DIFF
--- a/front/components/markdown/CiteBlock.tsx
+++ b/front/components/markdown/CiteBlock.tsx
@@ -94,7 +94,7 @@ export function getCiteDirective() {
           const references = node.children[0]?.value
             .split(",")
             .map((s: string) => s.trim())
-            .filter((s: string) => s.length == 2)
+            .filter((s: string) => s.length === 2 || s.length === 3)
             .map((ref: string) => ({
               counter: counter(ref),
               ref,

--- a/front/components/markdown/CiteBlock.tsx
+++ b/front/components/markdown/CiteBlock.tsx
@@ -94,6 +94,8 @@ export function getCiteDirective() {
           const references = node.children[0]?.value
             .split(",")
             .map((s: string) => s.trim())
+            // Citations used to be 2 characters long, but are now 3 characters long.
+            // We support both for backward compatibility.
             .filter((s: string) => s.length === 2 || s.length === 3)
             .map((ref: string) => ({
               counter: counter(ref),

--- a/front/lib/actions/utils.ts
+++ b/front/lib/actions/utils.ts
@@ -115,19 +115,9 @@ export function getRetrievalTopK({
   }
 
   const topKs = searchActions
-    .map(() => {
-      return model.recommendedTopK;
-    })
-    .concat(
-      includeActions.map(() => {
-        return model.recommendedExhaustiveTopK;
-      })
-    )
-    .concat(
-      dsFsActions.map(() => {
-        return model.recommendedTopK;
-      })
-    );
+    .map(() => model.recommendedTopK)
+    .concat(includeActions.map(() => model.recommendedExhaustiveTopK))
+    .concat(dsFsActions.map(() => model.recommendedTopK));
 
   return Math.ceil(Math.max(...topKs) / actionsCount);
 }

--- a/front/lib/api/assistant/citations.ts
+++ b/front/lib/api/assistant/citations.ts
@@ -18,11 +18,14 @@ const getRand = rand("chawarma");
 export const getRefs = () => {
   const alphabet = "abcdefghijklmnopqrstuvwxyz0123456789".split("");
   if (REFS === null) {
-    REFS = alphabet.flatMap((c) =>
-      alphabet.flatMap((n) =>
-        alphabet.map((m) => `${c}${n}${m}`)
-      )
-    );
+    REFS = [];
+    for (const c1 of alphabet) {
+      for (const c2 of alphabet) {
+        for (const c3 of alphabet) {
+          REFS.push(`${c1}${c2}${c3}`);
+        }
+      }
+    }
     // Randomize.
     REFS.sort(() => (getRand() > 0.5 ? 1 : -1));
   }

--- a/front/lib/api/assistant/citations.ts
+++ b/front/lib/api/assistant/citations.ts
@@ -16,20 +16,11 @@ let REFS: string[] | null = null;
 const getRand = rand("chawarma");
 
 export const getRefs = () => {
+  const alphabet = "abcdefghijklmnopqrstuvwxyz0123456789".split("");
   if (REFS === null) {
-    REFS = "abcdefghijklmnopqrstuvwxyz0123456789"
-      .split("")
-      .map((c) => {
-        return "abcdefghijklmnopqrstuvwxyz0123456789".split("").map((n) => {
-          return `${c}${n}`;
-        });
-      })
-      .flat();
-    // randomize
-    REFS.sort(() => {
-      const r = getRand();
-      return r > 0.5 ? 1 : -1;
-    });
+    REFS = alphabet.flatMap((c) => alphabet.map((n) => `${c}${n}`));
+    // Randomize.
+    REFS.sort(() => (getRand() > 0.5 ? 1 : -1));
   }
   return REFS;
 };

--- a/front/lib/api/assistant/citations.ts
+++ b/front/lib/api/assistant/citations.ts
@@ -18,7 +18,11 @@ const getRand = rand("chawarma");
 export const getRefs = () => {
   const alphabet = "abcdefghijklmnopqrstuvwxyz0123456789".split("");
   if (REFS === null) {
-    REFS = alphabet.flatMap((c) => alphabet.map((n) => `${c}${n}`));
+    REFS = alphabet.flatMap((c) =>
+      alphabet.flatMap((n) =>
+        alphabet.map((m) => `${c}${n}${m}`)
+      )
+    );
     // Randomize.
     REFS.sort(() => (getRand() > 0.5 ? 1 : -1));
   }
@@ -31,9 +35,9 @@ export const getRefs = () => {
 export function citationMetaPrompt() {
   return (
     "## CITING DOCUMENTS\n" +
-    "To cite documents or web pages retrieved with a 2-character REFERENCE, " +
+    "To cite documents or web pages retrieved with a 3-character REFERENCE, " +
     "use the markdown directive :cite[REFERENCE] " +
-    "(eg :cite[xx] or :cite[xx,xx] but not :cite[xx][xx]). " +
+    "(eg :cite[xxx] or :cite[xxx,xxx] but not :cite[xxx][xxx]). " +
     "Ensure citations are placed as close as possible to the related information."
   );
 }


### PR DESCRIPTION
## Description

- Part of https://github.com/dust-tt/tasks/issues/3411.
- The goal of this PR is to increase our citations pool from 2 characters to 3, which will bump the number of possible citation refs to 46,656 references vs 1,296 currently (we have 36 possible characters: letter/digit).
- The RegExp we use to strip the Markdown directive in the front end already supports an arbitrary number (>= 1) of citations https://github.com/dust-tt/dust/blob/main/front/components/assistant/conversation/AgentMessage.tsx#L390.
- The goal of this PR is to start using 3-letters long citations in a backward compatible manner.

## Tests

- Tested locally.

## Risk

- Blast radius quite high as it affects citations.
- Risk of the model not willing to write or not using well 3-char long citations but low IHMO.

## Deploy Plan

- Deploy front.
