### PR TITLE
[front] - fix(usage): user computation

### DIFF
--- a/front/lib/models/assistant/conversation.ts
+++ b/front/lib/models/assistant/conversation.ts
@@ -234,6 +234,7 @@ UserMessage.init(
   {
     modelName: "user_message",
     sequelize: frontSequelize,
+    indexes: [{ fields: ["userContextOrigin"], concurrently: true }],
   }
 );
 

--- a/front/lib/workspace_usage.ts
+++ b/front/lib/workspace_usage.ts
@@ -373,6 +373,9 @@ export async function getUserUsageData(
               userId: {
                 [Op.not]: null,
               },
+              userContextOrigin: {
+                [Op.not]: "run_agent",
+              },
             },
           },
           {

--- a/front/migrations/db/migration_320.sql
+++ b/front/migrations/db/migration_320.sql
@@ -1,0 +1,2 @@
+-- Migration created on Jul 28, 2025
+CREATE INDEX CONCURRENTLY "user_messages_user_context_origin" ON "user_messages" ("userContextOrigin");


### PR DESCRIPTION
## Description

This PR aims at fixing the way we compute the user usage data in workspace usage. After we added sub-agents we now have agents that are "communicating" with other agents -> they appear in our user messages.

To fix this we exclude `userMessage` with a `userContextOrigin` equal to "run_agent".

**References:**
- https://github.com/dust-tt/tasks/issues/3642

## Tests

Locally

## Risk

Low, we only adding an extra filter to the query. However, this might make it even slower.

## Deploy Plan

- Apply migration
- Deploy front
