### PR TITLE
Bump extension version in manifest

### DIFF
--- a/extension/platforms/chrome/manifests/manifest.base.json
+++ b/extension/platforms/chrome/manifests/manifest.base.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "Dust",
-  "version": "0.0.21",
+  "version": "0.0.22",
   "description": "Get more done, faster, with the power of your agents at your fingertips.",
   "icons": {
     "16": "images/dust16.png",


### PR DESCRIPTION
## Description

Bumping the manifest version to ship this fix: https://github.com/dust-tt/dust/pull/14542

## Tests

/

## Risk

/

## Deploy Plan

Merge and submit on the Chrome web store. 