### PR TITLE
[connectors] Fix detection of invalid token errors from Zendesk API

### DIFF
--- a/connectors/src/connectors/zendesk/lib/errors.ts
+++ b/connectors/src/connectors/zendesk/lib/errors.ts
@@ -30,7 +30,17 @@ export function isNodeZendeskForbiddenError(
 }
 
 export function isZendeskForbiddenError(err: unknown): err is ZendeskApiError {
-  return err instanceof ZendeskApiError && err.status === 403;
+  return (
+    err instanceof ZendeskApiError &&
+    (err.status === 403 ||
+      (err.status === 401 &&
+        typeof err.data === "object" &&
+        "response" in err.data &&
+        typeof err.data.response === "object" &&
+        err.data.response !== null &&
+        "error" in err.data.response &&
+        err.data?.response.error === "invalid_token"))
+  );
 }
 
 export function isZendeskExpiredCursorError(


### PR DESCRIPTION
## Description

- Some invalid_token errors are not correctly detected on our end ([logs](https://app.datadoghq.eu/logs?query=%22Zendesk%20API%20error%22&agg_m=count&agg_m_source=base&agg_t=count&clustering_pattern_field_path=message&cols=host%2Cservice&event=AwAAAZhRes_lKqFQDgAAABhBWmhSZXQ1SUFBQlhKMmZOYWFaRDZ3QUEAAAAkZjE5ODUxN2EtZTA5OC00ZDZhLWFiMmUtYTYyYjkyZTZlMmRmAAAAbA&fromUser=true&messageDisplay=inline&refresh_mode=sliding&storage=hot&stream_sort=desc&viz=stream&from_ts=1733653464474&to_ts=1733657064474&live=true))
- This PR fixes that.

## Tests

- N/A.

## Risk

- N/A.

## Deploy Plan

- Deploy connectors.
