### PR TITLE
[front] - fix(ActivityReport): handle loading per month

### DIFF
--- a/front/components/workspace/ActivityReport.tsx
+++ b/front/components/workspace/ActivityReport.tsx
@@ -11,7 +11,7 @@ import { useState } from "react";
 
 interface ActivityReportProps {
   monthOptions: string[];
-  isDownloading: boolean;
+  downloadingMonth: string | null;
   handleDownload: (selectedMonth: string | null) => void;
 }
 
@@ -19,7 +19,7 @@ const maxItemsPerPage = 4;
 
 export function ActivityReport({
   monthOptions,
-  isDownloading,
+  downloadingMonth,
   handleDownload,
 }: ActivityReportProps) {
   const [pagination, setPagination] = useState({
@@ -75,8 +75,8 @@ export function ActivityReport({
                       onClick={() => {
                         handleDownload(item);
                       }}
-                      disabled={isDownloading}
-                      isLoading={isDownloading}
+                      disabled={downloadingMonth !== null}
+                      isLoading={downloadingMonth === item}
                     />
                   }
                 ></ContextItem>

--- a/front/pages/w/[wId]/analytics/index.tsx
+++ b/front/pages/w/[wId]/analytics/index.tsx
@@ -35,7 +35,7 @@ export default function Analytics({
   owner,
   subscription,
 }: InferGetServerSidePropsType<typeof getServerSideProps>) {
-  const [isDownloadingData, setIsDownloadingData] = useState(false);
+  const [downloadingMonth, setDownloadingMonth] = useState<string | null>(null);
 
   const { subscriptions } = useWorkspaceSubscriptions({
     owner,
@@ -48,7 +48,7 @@ export default function Analytics({
 
     const queryString = `mode=month&start=${selectedMonth}&table=all`;
 
-    setIsDownloadingData(true);
+    setDownloadingMonth(selectedMonth);
     try {
       const response = await fetch(
         `/api/w/${owner.sId}/workspace-usage?${queryString}`
@@ -98,7 +98,7 @@ export default function Analytics({
     } catch (error) {
       alert("Failed to download activity data.");
     } finally {
-      setIsDownloadingData(false);
+      setDownloadingMonth(null);
     }
   };
 
@@ -153,7 +153,7 @@ export default function Analytics({
           <div className="grid w-full grid-cols-1 gap-4 md:grid-cols-2">
             <QuickInsights owner={owner} />
             <ActivityReport
-              isDownloading={isDownloadingData}
+              downloadingMonth={downloadingMonth}
               monthOptions={monthOptions}
               handleDownload={handleDownload}
             />


### PR DESCRIPTION
## Description

This PR makes sure that when downloading the activity report for a given month we only show the loading button on that specific item instead of all the items.

## Tests

Locally

## Risk

Low

## Deploy Plan

Deploy front