### PR TITLE
[front] misc fixes for interactive content 

### DIFF
--- a/front/components/assistant/conversation/ShareInteractiveFilePopover.tsx
+++ b/front/components/assistant/conversation/ShareInteractiveFilePopover.tsx
@@ -55,7 +55,7 @@ export function ShareInteractiveFilePopover({
   const isLoading = isFileShareLoading || isUpdatingShare;
 
   return (
-    <PopoverRoot open={isOpen} onOpenChange={setIsOpen}>
+    <PopoverRoot open={isOpen} onOpenChange={setIsOpen} modal={true}>
       <PopoverTrigger asChild>
         <Button
           icon={LinkIcon}
@@ -65,11 +65,7 @@ export function ShareInteractiveFilePopover({
           disabled={disabled}
         />
       </PopoverTrigger>
-      <PopoverContent
-        className="flex h-48 w-96 flex-col"
-        align="end"
-        onInteractOutside={() => setIsOpen(false)}
-      >
+      <PopoverContent className="flex h-48 w-96 flex-col" align="end">
         <div className="flex flex-1 flex-col">
           <div className="mb-4">
             <div className="text-base font-semibold text-primary dark:text-primary-night">

--- a/front/components/assistant/conversation/content/PublicInteractiveContentHeader.tsx
+++ b/front/components/assistant/conversation/content/PublicInteractiveContentHeader.tsx
@@ -7,9 +7,10 @@ interface PublicInteractiveContentHeaderProps {
   title: string;
 }
 
-// Applying flex & justify-center to the title won't make it centered in the header since it has the logo on the left (and will soon have buttons on the right).
+// Applying flex & justify-center to the title won't make it centered in the header
+// since it has the logo on the left (and will soon have buttons on the right).
 // To make it perfectly centered, we need to set the same flex basis for both the right and left elements.
-// We can optimize more on mobile view once we have buttons and know what to show on mobile.
+// TODO: optimize the header for mobile views once we have buttons.
 export function PublicInteractiveContentHeader({
   title,
 }: PublicInteractiveContentHeaderProps) {

--- a/front/components/assistant/conversation/content/PublicInteractiveContentHeader.tsx
+++ b/front/components/assistant/conversation/content/PublicInteractiveContentHeader.tsx
@@ -7,18 +7,19 @@ interface PublicInteractiveContentHeaderProps {
   title: string;
 }
 
+// Applying flex & justify-center to the title won't make it centered in the header since it has the logo on the left (and will soon have buttons on the right).
+// To make it perfectly centered, we need to set the same flex basis for both the right and left elements.
+// We can optimize more on mobile view once we have buttons and know what to show on mobile.
 export function PublicInteractiveContentHeader({
   title,
 }: PublicInteractiveContentHeaderProps) {
   return (
-    <AppLayoutTitle className="bg-gray-50 @container dark:bg-gray-900">
+    <AppLayoutTitle className="h-12 bg-gray-50 @container dark:bg-gray-900">
       <div className="flex h-full min-w-0 max-w-full items-center">
-        {/* Logo - left side */}
-        <div className="flex shrink-0 items-center">
-          <PublicWebsiteLogo />
+        <div className="grow-1 flex shrink-0 items-center md:basis-60">
+          <PublicWebsiteLogo size="small" />
         </div>
 
-        {/* Title - centered */}
         <div className="flex flex-1 justify-center">
           <span
             className={cn(
@@ -29,6 +30,8 @@ export function PublicInteractiveContentHeader({
             {title}
           </span>
         </div>
+
+        <div className="md:grow-1 md:basis-60"></div>
       </div>
     </AppLayoutTitle>
   );

--- a/front/components/home/LandingLayout.tsx
+++ b/front/components/home/LandingLayout.tsx
@@ -342,15 +342,26 @@ const Header = () => {
   );
 };
 
-export const PublicWebsiteLogo = () => {
+interface PublicWebsiteLogo {
+  size?: "default" | "small";
+}
+
+export const PublicWebsiteLogo = ({ size = "default" }: PublicWebsiteLogo) => {
+  const dimensions =
+    size === "small"
+      ? { height: "h-[20px]", width: "w-[80px]" }
+      : { height: "h-[24px]", width: "w-[96px]" };
+
+  const className = `${dimensions.height} ${dimensions.width}`;
+
   return (
     <Link href="/home">
-      <Hover3D className="relative h-[24px] w-[96px]">
-        <Div3D depth={0} className="h-[24px] w-[96px]">
-          <DustLogoLayer1 className="h-[24px] w-[96px]" />
+      <Hover3D className={`relative ${className}`}>
+        <Div3D depth={0} className={className}>
+          <DustLogoLayer1 className={className} />
         </Div3D>
         <Div3D depth={25} className="absolute top-0">
-          <DustLogoLayer2 className="h-[24px] w-[96px]" />
+          <DustLogoLayer2 className={className} />
         </Div3D>
       </Hover3D>
     </Link>

--- a/front/components/home/LandingLayout.tsx
+++ b/front/components/home/LandingLayout.tsx
@@ -346,11 +346,11 @@ interface PublicWebsiteLogo {
   size?: "default" | "small";
 }
 
+const SMALL_SIZE = { height: "h-[20px]", width: "w-[80px]" };
+const DEFAULT_SIZE = { height: "h-[24px]", width: "w-[96px]" };
+
 export const PublicWebsiteLogo = ({ size = "default" }: PublicWebsiteLogo) => {
-  const dimensions =
-    size === "small"
-      ? { height: "h-[20px]", width: "w-[80px]" }
-      : { height: "h-[24px]", width: "w-[96px]" };
+  const dimensions = size === "small" ? SMALL_SIZE : DEFAULT_SIZE;
 
   const className = `${dimensions.height} ${dimensions.width}`;
 

--- a/front/components/home/LandingLayout.tsx
+++ b/front/components/home/LandingLayout.tsx
@@ -7,6 +7,7 @@ import {
   Hover3D,
   LoginIcon,
 } from "@dust-tt/sparkle";
+import { cva } from "class-variance-authority";
 import Head from "next/head";
 import Link from "next/link";
 import Script from "next/script";
@@ -346,15 +347,22 @@ interface PublicWebsiteLogoProps {
   size?: "default" | "small";
 }
 
-const SMALL_SIZE = { height: "h-[20px]", width: "w-[80px]" };
-const DEFAULT_SIZE = { height: "h-[24px]", width: "w-[96px]" };
+const logoVariants = cva("", {
+  variants: {
+    size: {
+      default: "h-[24px] w-[96px]",
+      small: "h-[20px] w-[80px]",
+    },
+  },
+  defaultVariants: {
+    size: "default",
+  },
+});
 
 export const PublicWebsiteLogo = ({
   size = "default",
 }: PublicWebsiteLogoProps) => {
-  const dimensions = size === "small" ? SMALL_SIZE : DEFAULT_SIZE;
-
-  const className = `${dimensions.height} ${dimensions.width}`;
+  const className = logoVariants({ size });
 
   return (
     <Link href="/home">

--- a/front/components/home/LandingLayout.tsx
+++ b/front/components/home/LandingLayout.tsx
@@ -342,14 +342,16 @@ const Header = () => {
   );
 };
 
-interface PublicWebsiteLogo {
+interface PublicWebsiteLogoProps {
   size?: "default" | "small";
 }
 
 const SMALL_SIZE = { height: "h-[20px]", width: "w-[80px]" };
 const DEFAULT_SIZE = { height: "h-[24px]", width: "w-[96px]" };
 
-export const PublicWebsiteLogo = ({ size = "default" }: PublicWebsiteLogo) => {
+export const PublicWebsiteLogo = ({
+  size = "default",
+}: PublicWebsiteLogoProps) => {
   const dimensions = size === "small" ? SMALL_SIZE : DEFAULT_SIZE;
 
   const className = `${dimensions.height} ${dimensions.width}`;


### PR DESCRIPTION
## Description

This PR is to add minor improvements on interactive content UI 

- Share button popover doesn't get closed when you click inside the iframe (if I understand it correctly, none of  `onPointerDownOutside`, `onFocusOutside`, `onInteractOutside` gets triggered when you click inside the iframe). I changed it to the modal, is it okay? 👶
- Add the size prop to the Dust logo so we can shrink the height of the interactive content preview
- The title of the header was not perfectly centered, there are several ways to fix it but since we will add buttons pretty soon I added an empty div on the right, and add flex basis to both left and right divs.

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
