### PR TITLE
[front] Consolidate tool error handling around `withToolLogging` wrapper

### DIFF
--- a/front/lib/actions/mcp_errors.ts
+++ b/front/lib/actions/mcp_errors.ts
@@ -4,7 +4,7 @@ export class MCPServerNotFoundError extends Error {
   }
 }
 
-export class McpError extends Error {
+export class MCPError extends Error {
   // Whether the error should be tracked and reported on our observability stack.
   public readonly tracked: boolean;
   public readonly code?: number;

--- a/front/lib/actions/mcp_errors.ts
+++ b/front/lib/actions/mcp_errors.ts
@@ -5,10 +5,15 @@ export class MCPServerNotFoundError extends Error {
 }
 
 export class McpError extends Error {
+  public readonly tracked: boolean;
+  public readonly code: number;
+
   constructor(
     message: string,
-    public readonly code: number
+    { tracked = true, code }: { tracked?: boolean; code?: number }
   ) {
     super(message);
+    this.tracked = tracked;
+    this.code = code;
   }
 }

--- a/front/lib/actions/mcp_errors.ts
+++ b/front/lib/actions/mcp_errors.ts
@@ -6,11 +6,11 @@ export class MCPServerNotFoundError extends Error {
 
 export class McpError extends Error {
   public readonly tracked: boolean;
-  public readonly code: number;
+  public readonly code?: number;
 
   constructor(
     message: string,
-    { tracked = true, code }: { tracked?: boolean; code?: number }
+    { tracked = true, code }: { tracked?: boolean; code?: number } = {}
   ) {
     super(message);
     this.tracked = tracked;

--- a/front/lib/actions/mcp_errors.ts
+++ b/front/lib/actions/mcp_errors.ts
@@ -5,6 +5,7 @@ export class MCPServerNotFoundError extends Error {
 }
 
 export class McpError extends Error {
+  // Whether the error should be tracked and reported on our observability stack.
   public readonly tracked: boolean;
   public readonly code?: number;
 

--- a/front/lib/actions/mcp_internal_actions/servers/common/find_tags_tool.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/common/find_tags_tool.ts
@@ -5,14 +5,14 @@ import { z } from "zod";
 import type { DataSourcesToolConfigurationType } from "@app/lib/actions/mcp_internal_actions/input_schemas";
 import { ConfigurableToolInputSchemas } from "@app/lib/actions/mcp_internal_actions/input_schemas";
 import { getCoreSearchArgs } from "@app/lib/actions/mcp_internal_actions/servers/utils";
-import { makeMCPToolTextErrorResult } from "@app/lib/actions/mcp_internal_actions/utils";
 import { withToolLogging } from "@app/lib/actions/mcp_internal_actions/wrappers";
 import type { AgentLoopContextType } from "@app/lib/actions/types";
 import config from "@app/lib/api/config";
 import type { Authenticator } from "@app/lib/auth";
 import { concurrentExecutor } from "@app/lib/utils/async_utils";
 import logger from "@app/logger/logger";
-import { CoreAPI, removeNulls } from "@app/types";
+import { CoreAPI, Err, removeNulls } from "@app/types";
+import { Ok } from "@app/types";
 
 const DEFAULT_SEARCH_LABELS_LIMIT = 10;
 
@@ -56,7 +56,7 @@ export function makeFindTagsTool(
       );
 
       if (coreSearchArgsResults.some((res) => res.isErr())) {
-        return makeMCPToolTextErrorResult("Invalid data sources");
+        return new Err(new Error("Invalid data sources"));
       }
 
       const coreSearchArgs = removeNulls(
@@ -64,8 +64,10 @@ export function makeFindTagsTool(
       );
 
       if (coreSearchArgs.length === 0) {
-        return makeMCPToolTextErrorResult(
-          "Search action must have at least one data source configured."
+        return new Err(
+          new Error(
+            "Search action must have at least one data source configured."
+          )
         );
       }
 
@@ -78,7 +80,7 @@ export function makeFindTagsTool(
       });
 
       if (result.isErr()) {
-        return makeMCPToolTextErrorResult("Error searching for labels");
+        return new Err(new Error("Error searching for labels"));
       }
 
       return new Ok({

--- a/front/lib/actions/mcp_internal_actions/servers/common/find_tags_tool.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/common/find_tags_tool.ts
@@ -2,7 +2,7 @@ import { INTERNAL_MIME_TYPES } from "@dust-tt/client";
 import { trim } from "lodash";
 import { z } from "zod";
 
-import { McpError } from "@app/lib/actions/mcp_errors";
+import { MCPError } from "@app/lib/actions/mcp_errors";
 import type { DataSourcesToolConfigurationType } from "@app/lib/actions/mcp_internal_actions/input_schemas";
 import { ConfigurableToolInputSchemas } from "@app/lib/actions/mcp_internal_actions/input_schemas";
 import { getCoreSearchArgs } from "@app/lib/actions/mcp_internal_actions/servers/utils";
@@ -57,7 +57,7 @@ export function makeFindTagsTool(
       );
 
       if (coreSearchArgsResults.some((res) => res.isErr())) {
-        return new Err(new McpError("Invalid data sources"));
+        return new Err(new MCPError("Invalid data sources"));
       }
 
       const coreSearchArgs = removeNulls(
@@ -66,7 +66,7 @@ export function makeFindTagsTool(
 
       if (coreSearchArgs.length === 0) {
         return new Err(
-          new McpError(
+          new MCPError(
             "Search action must have at least one data source configured."
           )
         );
@@ -81,7 +81,7 @@ export function makeFindTagsTool(
       });
 
       if (result.isErr()) {
-        return new Err(new McpError("Error searching for labels"));
+        return new Err(new MCPError("Error searching for labels"));
       }
 
       return new Ok([

--- a/front/lib/actions/mcp_internal_actions/servers/common/find_tags_tool.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/common/find_tags_tool.ts
@@ -2,6 +2,7 @@ import { INTERNAL_MIME_TYPES } from "@dust-tt/client";
 import { trim } from "lodash";
 import { z } from "zod";
 
+import { McpError } from "@app/lib/actions/mcp_errors";
 import type { DataSourcesToolConfigurationType } from "@app/lib/actions/mcp_internal_actions/input_schemas";
 import { ConfigurableToolInputSchemas } from "@app/lib/actions/mcp_internal_actions/input_schemas";
 import { getCoreSearchArgs } from "@app/lib/actions/mcp_internal_actions/servers/utils";
@@ -56,7 +57,7 @@ export function makeFindTagsTool(
       );
 
       if (coreSearchArgsResults.some((res) => res.isErr())) {
-        return new Err(new Error("Invalid data sources"));
+        return new Err(new McpError("Invalid data sources"));
       }
 
       const coreSearchArgs = removeNulls(
@@ -65,7 +66,7 @@ export function makeFindTagsTool(
 
       if (coreSearchArgs.length === 0) {
         return new Err(
-          new Error(
+          new McpError(
             "Search action must have at least one data source configured."
           )
         );
@@ -80,26 +81,23 @@ export function makeFindTagsTool(
       });
 
       if (result.isErr()) {
-        return new Err(new Error("Error searching for labels"));
+        return new Err(new McpError("Error searching for labels"));
       }
 
-      return new Ok({
-        isError: false,
-        content: [
-          {
-            type: "text",
-            text:
-              "Labels found:\n\n" +
-              removeNulls(
-                result.value.tags.map((tag) =>
-                  tag.tag && trim(tag.tag)
-                    ? `${tag.tag} (${tag.match_count} matches)`
-                    : null
-                )
-              ).join("\n"),
-          },
-        ],
-      });
+      return new Ok([
+        {
+          type: "text",
+          text:
+            "Labels found:\n\n" +
+            removeNulls(
+              result.value.tags.map((tag) =>
+                tag.tag && trim(tag.tag)
+                  ? `${tag.tag} (${tag.match_count} matches)`
+                  : null
+              )
+            ).join("\n"),
+        },
+      ]);
     }
   );
 }

--- a/front/lib/actions/mcp_internal_actions/servers/common/find_tags_tool.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/common/find_tags_tool.ts
@@ -5,7 +5,7 @@ import { z } from "zod";
 import type { DataSourcesToolConfigurationType } from "@app/lib/actions/mcp_internal_actions/input_schemas";
 import { ConfigurableToolInputSchemas } from "@app/lib/actions/mcp_internal_actions/input_schemas";
 import { getCoreSearchArgs } from "@app/lib/actions/mcp_internal_actions/servers/utils";
-import { makeMCPToolTextError } from "@app/lib/actions/mcp_internal_actions/utils";
+import { makeMCPToolTextErrorResult } from "@app/lib/actions/mcp_internal_actions/utils";
 import { withToolLogging } from "@app/lib/actions/mcp_internal_actions/wrappers";
 import type { AgentLoopContextType } from "@app/lib/actions/types";
 import config from "@app/lib/api/config";
@@ -56,7 +56,7 @@ export function makeFindTagsTool(
       );
 
       if (coreSearchArgsResults.some((res) => res.isErr())) {
-        return makeMCPToolTextError("Invalid data sources");
+        return makeMCPToolTextErrorResult("Invalid data sources");
       }
 
       const coreSearchArgs = removeNulls(
@@ -64,7 +64,7 @@ export function makeFindTagsTool(
       );
 
       if (coreSearchArgs.length === 0) {
-        return makeMCPToolTextError(
+        return makeMCPToolTextErrorResult(
           "Search action must have at least one data source configured."
         );
       }
@@ -78,10 +78,10 @@ export function makeFindTagsTool(
       });
 
       if (result.isErr()) {
-        return makeMCPToolTextError("Error searching for labels");
+        return makeMCPToolTextErrorResult("Error searching for labels");
       }
 
-      return {
+      return new Ok({
         isError: false,
         content: [
           {
@@ -97,7 +97,7 @@ export function makeFindTagsTool(
               ).join("\n"),
           },
         ],
-      };
+      });
     }
   );
 }

--- a/front/lib/actions/mcp_internal_actions/servers/data_sources_file_system.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/data_sources_file_system.ts
@@ -49,7 +49,7 @@ import type {
   CoreAPISearchNodesResponse,
   Result,
 } from "@app/types";
-import { Err,Ok } from "@app/types";
+import { Err, Ok } from "@app/types";
 import {
   CoreAPI,
   DATA_SOURCE_NODE_ID,

--- a/front/lib/actions/mcp_internal_actions/servers/data_sources_file_system.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/data_sources_file_system.ts
@@ -148,7 +148,7 @@ async function searchCallback(
   const timeFrame = parseTimeFrame(relativeTimeFrame);
 
   if (!agentLoopContext?.runContext) {
-    throw new MCPError(
+    throw new Error(
       "agentLoopRunContext is required where the tool is called."
     );
   }

--- a/front/lib/actions/mcp_internal_actions/servers/data_sources_file_system.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/data_sources_file_system.ts
@@ -4,7 +4,7 @@ import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
 import assert from "assert";
 import { z } from "zod";
 
-import { McpError } from "@app/lib/actions/mcp_errors";
+import { MCPError } from "@app/lib/actions/mcp_errors";
 import { SEARCH_TOOL_NAME } from "@app/lib/actions/mcp_internal_actions/constants";
 import type { DataSourcesToolConfigurationType } from "@app/lib/actions/mcp_internal_actions/input_schemas";
 import { ConfigurableToolInputSchemas } from "@app/lib/actions/mcp_internal_actions/input_schemas";
@@ -142,13 +142,13 @@ async function searchCallback(
     relativeTimeFrame,
   }: z.infer<typeof SearchToolInputSchema>,
   { tagsIn, tagsNot }: { tagsIn?: string[]; tagsNot?: string[] } = {}
-): Promise<Result<CallToolResult["content"], McpError>> {
+): Promise<Result<CallToolResult["content"], MCPError>> {
   const coreAPI = new CoreAPI(config.getCoreAPIConfig(), logger);
   const credentials = dustManagedCredentials();
   const timeFrame = parseTimeFrame(relativeTimeFrame);
 
   if (!agentLoopContext?.runContext) {
-    throw new McpError(
+    throw new MCPError(
       "agentLoopRunContext is required where the tool is called."
     );
   }
@@ -161,7 +161,7 @@ async function searchCallback(
 
   if (agentDataSourceConfigurationsResult.isErr()) {
     return new Err(
-      new McpError(agentDataSourceConfigurationsResult.error.message)
+      new MCPError(agentDataSourceConfigurationsResult.error.message)
     );
   }
   const agentDataSourceConfigurations =
@@ -217,7 +217,7 @@ async function searchCallback(
 
   if (coreSearchArgs.length === 0) {
     return new Err(
-      new McpError(
+      new MCPError(
         "Search action must have at least one data source configured."
       )
     );
@@ -265,13 +265,13 @@ async function searchCallback(
 
   if (searchResults.isErr()) {
     return new Err(
-      new McpError(`Failed to search content: ${searchResults.error.message}`)
+      new MCPError(`Failed to search content: ${searchResults.error.message}`)
     );
   }
 
   if (citationsOffset + retrievalTopK > getRefs().length) {
     return new Err(
-      new McpError(
+      new MCPError(
         "The search exhausted the total number of references available for citations"
       )
     );
@@ -329,7 +329,7 @@ async function searchCallback(
 
     if (searchResult.isErr()) {
       return new Err(
-        new McpError(`Failed to search content: ${searchResult.error.message}`)
+        new MCPError(`Failed to search content: ${searchResult.error.message}`)
       );
     }
     renderedNodes = renderSearchResults(
@@ -409,7 +409,7 @@ const createServer = (
         );
 
         if (fetchResult.isErr()) {
-          return new Err(new McpError(fetchResult.error.message));
+          return new Err(new MCPError(fetchResult.error.message));
         }
         const agentDataSourceConfigurations = fetchResult.value;
 
@@ -453,7 +453,7 @@ const createServer = (
 
         if (!dataSource) {
           return new Err(
-            new McpError(`Could not find dataSource for node: ${nodeId}`)
+            new MCPError(`Could not find dataSource for node: ${nodeId}`)
           );
         }
 
@@ -475,7 +475,7 @@ const createServer = (
 
         if (readResult.isErr()) {
           return new Err(
-            new McpError(
+            new MCPError(
               `Could not read node: ${nodeId} (error: ${readResult.error})`
             )
           );
@@ -556,7 +556,7 @@ const createServer = (
         );
 
         if (fetchResult.isErr()) {
-          return new Err(new McpError(fetchResult.error.message));
+          return new Err(new MCPError(fetchResult.error.message));
         }
         const agentDataSourceConfigurations = fetchResult.value;
 
@@ -602,7 +602,7 @@ const createServer = (
 
         if (searchResult.isErr()) {
           return new Err(
-            new McpError(
+            new MCPError(
               `Failed to search content: ${searchResult.error.message}`
             )
           );
@@ -678,7 +678,7 @@ const createServer = (
         );
 
         if (fetchResult.isErr()) {
-          return new Err(new McpError(fetchResult.error.message));
+          return new Err(new MCPError(fetchResult.error.message));
         }
         const agentDataSourceConfigurations = fetchResult.value;
 
@@ -712,7 +712,7 @@ const createServer = (
           // If it's a data source node ID, extract the data source ID and list its root contents
           const dataSourceId = extractDataSourceIdFromNodeId(nodeId);
           if (!dataSourceId) {
-            return new Err(new McpError("Invalid data source node ID format"));
+            return new Err(new MCPError("Invalid data source node ID format"));
           }
 
           const dataSourceConfig = agentDataSourceConfigurations.find(
@@ -721,7 +721,7 @@ const createServer = (
 
           if (!dataSourceConfig) {
             return new Err(
-              new McpError(`Data source not found for ID: ${dataSourceId}`)
+              new MCPError(`Data source not found for ID: ${dataSourceId}`)
             );
           }
 
@@ -753,7 +753,7 @@ const createServer = (
         }
 
         if (searchResult.isErr()) {
-          return new Err(new McpError("Failed to list folder contents"));
+          return new Err(new MCPError("Failed to list folder contents"));
         }
 
         return new Ok([
@@ -865,14 +865,14 @@ const createServer = (
         );
 
         if (fetchResult.isErr()) {
-          return new Err(new McpError(fetchResult.error.message));
+          return new Err(new MCPError(fetchResult.error.message));
         }
         const agentDataSourceConfigurations = fetchResult.value;
 
         if (isDataSourceNodeId(nodeId)) {
           const dataSourceId = extractDataSourceIdFromNodeId(nodeId);
           if (!dataSourceId) {
-            return new Err(new McpError("Invalid data source node ID format"));
+            return new Err(new MCPError("Invalid data source node ID format"));
           }
 
           const dataSourceConfig = agentDataSourceConfigurations.find(
@@ -881,7 +881,7 @@ const createServer = (
 
           if (!dataSourceConfig) {
             return new Err(
-              new McpError(`Data source not found for ID: ${dataSourceId}`)
+              new MCPError(`Data source not found for ID: ${dataSourceId}`)
             );
           }
 
@@ -942,7 +942,7 @@ const createServer = (
           });
 
           if (pathSearchResult.isErr()) {
-            return new Err(new McpError("Failed to fetch nodes in the path"));
+            return new Err(new MCPError("Failed to fetch nodes in the path"));
           }
 
           for (const node of pathSearchResult.value.nodes) {
@@ -957,7 +957,7 @@ const createServer = (
 
         if (!dataSourceConfig) {
           return new Err(
-            new McpError("Could not find data source configuration")
+            new MCPError("Could not find data source configuration")
           );
         }
 

--- a/front/lib/actions/mcp_internal_actions/servers/data_sources_file_system.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/data_sources_file_system.ts
@@ -228,7 +228,7 @@ async function searchCallback(
     tagsNot,
   });
   if (conflictingTags) {
-    return new Ok([{ type: "text", text: conflictingTags }]);
+    return new Err(new MCPError(conflictingTags, { tracked: false }));
   }
 
   const searchResults = await coreAPI.searchDataSources(
@@ -424,25 +424,24 @@ const createServer = (
         });
 
         if (searchResult.isErr() || searchResult.value.nodes.length === 0) {
-          return new Ok([
-            {
-              type: "text",
-              text: `Could not find node: ${nodeId} (error: ${
+          return new Err(
+            new MCPError(
+              `Could not find node: ${nodeId} (error: ${
                 searchResult.isErr() ? searchResult.error : "No nodes found"
               })`,
-            },
-          ]);
+              { tracked: false }
+            )
+          );
         }
 
         const node = searchResult.value.nodes[0];
 
         if (node.node_type !== "document") {
-          return new Ok([
-            {
-              type: "text",
-              text: `Node is of type ${node.node_type}, not a document.`,
-            },
-          ]);
+          return new Err(
+            new MCPError(`Node is of type ${node.node_type}, not a document.`, {
+              tracked: false,
+            })
+          );
         }
 
         // Get dataSource from the data source configuration.
@@ -915,9 +914,9 @@ const createServer = (
         });
 
         if (searchResult.isErr() || searchResult.value.nodes.length === 0) {
-          return new Ok([
-            { type: "text", text: `Could not find node: ${nodeId}` },
-          ]);
+          return new Err(
+            new MCPError(`Could not find node: ${nodeId}`, { tracked: false })
+          );
         }
 
         const targetNode = searchResult.value.nodes[0];

--- a/front/lib/actions/mcp_internal_actions/servers/include.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/include.ts
@@ -1,6 +1,6 @@
 import { INTERNAL_MIME_TYPES } from "@dust-tt/client";
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
-import type { TextContent } from "@modelcontextprotocol/sdk/types.js";
+import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
 import assert from "assert";
 import { z } from "zod";
 
@@ -22,9 +22,7 @@ import {
   getCoreSearchArgs,
   shouldAutoGenerateTags,
 } from "@app/lib/actions/mcp_internal_actions/servers/utils";
-import { makeMCPToolTextError, makeMCPToolTextErrorResult } from "@app/lib/actions/mcp_internal_actions/utils";
 import { withToolLogging } from "@app/lib/actions/mcp_internal_actions/wrappers";
-import { Ok, Result } from "@app/types/shared/result";
 import type { AgentLoopContextType } from "@app/lib/actions/types";
 import { getRefs } from "@app/lib/api/assistant/citations";
 import config from "@app/lib/api/config";
@@ -36,7 +34,8 @@ import {
 } from "@app/lib/data_sources";
 import { concurrentExecutor } from "@app/lib/utils/async_utils";
 import logger from "@app/logger/logger";
-import type { CoreAPIDocument, TimeFrame } from "@app/types";
+import type { CoreAPIDocument, Result,TimeFrame } from "@app/types";
+import { Err, Ok } from "@app/types";
 import {
   CoreAPI,
   dustManagedCredentials,
@@ -188,12 +187,14 @@ function createServer(
     );
 
     if (searchResults.isErr()) {
-      return makeMCPToolTextErrorResult(searchResults.error.message);
+      return new Err(new Error(searchResults.error.message));
     }
 
     if (citationsOffset + retrievalTopK > getRefs().length) {
-      return makeMCPToolTextErrorResult(
-        "The inclusion exhausted the total number of references available for citations"
+      return new Err(
+        new Error(
+          "The inclusion exhausted the total number of references available for citations"
+        )
       );
     }
 

--- a/front/lib/actions/mcp_internal_actions/servers/include.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/include.ts
@@ -4,7 +4,7 @@ import type { TextContent } from "@modelcontextprotocol/sdk/types.js";
 import assert from "assert";
 import { z } from "zod";
 
-import { McpError } from "@app/lib/actions/mcp_errors";
+import { MCPError } from "@app/lib/actions/mcp_errors";
 import type { DataSourcesToolConfigurationType } from "@app/lib/actions/mcp_internal_actions/input_schemas";
 import { ConfigurableToolInputSchemas } from "@app/lib/actions/mcp_internal_actions/input_schemas";
 import type {
@@ -114,7 +114,7 @@ function createServer(
               | WarningResourceType;
           }
       )[],
-      McpError
+      MCPError
     >
   > {
     const coreAPI = new CoreAPI(config.getCoreAPIConfig(), logger);
@@ -198,12 +198,12 @@ function createServer(
     );
 
     if (searchResults.isErr()) {
-      return new Err(new McpError(searchResults.error.message));
+      return new Err(new MCPError(searchResults.error.message));
     }
 
     if (citationsOffset + retrievalTopK > getRefs().length) {
       return new Err(
-        new McpError(
+        new MCPError(
           "The inclusion exhausted the total number of references available for citations"
         )
       );

--- a/front/lib/actions/mcp_internal_actions/servers/include.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/include.ts
@@ -34,7 +34,7 @@ import {
 } from "@app/lib/data_sources";
 import { concurrentExecutor } from "@app/lib/utils/async_utils";
 import logger from "@app/logger/logger";
-import type { CoreAPIDocument, Result,TimeFrame } from "@app/types";
+import type { CoreAPIDocument, Result, TimeFrame } from "@app/types";
 import { Err, Ok } from "@app/types";
 import {
   CoreAPI,
@@ -91,7 +91,7 @@ function createServer(
     ? shouldAutoGenerateTags(agentLoopContext)
     : false;
 
-  const includeFunction = async ({
+  async function includeFunction({
     timeFrame,
     dataSources,
     tagsIn,
@@ -101,7 +101,7 @@ function createServer(
     dataSources: DataSourcesToolConfigurationType;
     tagsIn?: string[];
     tagsNot?: string[];
-  }): Promise<Result<CallToolResult, Error>> => {
+  }): Promise<Result<CallToolResult, Error>> {
     const coreAPI = new CoreAPI(config.getCoreAPIConfig(), logger);
     const credentials = dustManagedCredentials();
 
@@ -256,7 +256,7 @@ function createServer(
           : []),
       ],
     });
-  };
+  }
 
   if (!areTagsDynamic) {
     server.tool(

--- a/front/lib/actions/mcp_internal_actions/servers/include.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/include.ts
@@ -139,13 +139,15 @@ function createServer(
 
     // If any of the data sources are invalid, return an error message.
     if (coreSearchArgsResults.some((res) => res.isErr())) {
-      return new Ok(
-        removeNulls(
-          coreSearchArgsResults.map((res) => (res.isErr() ? res.error : null))
-        ).map((error) => ({
-          type: "text",
-          text: error.message,
-        }))
+      return new Err(
+        new MCPError(
+          removeNulls(
+            coreSearchArgsResults.map((res) => (res.isErr() ? res.error : null))
+          )
+            .map((error) => error.message)
+            .join("\n"),
+          { tracked: false }
+        )
       );
     }
 
@@ -158,7 +160,7 @@ function createServer(
       tagsNot,
     });
     if (conflictingTagsError) {
-      return new Ok([{ type: "text", text: conflictingTagsError }]);
+      return new Err(new MCPError(conflictingTagsError, { tracked: false }));
     }
 
     const searchResults = await coreAPI.searchDataSources(

--- a/front/lib/actions/mcp_internal_actions/servers/include.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/include.ts
@@ -1,6 +1,6 @@
 import { INTERNAL_MIME_TYPES } from "@dust-tt/client";
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
-import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
+import type { TextContent } from "@modelcontextprotocol/sdk/types.js";
 import assert from "assert";
 import { z } from "zod";
 
@@ -101,7 +101,23 @@ function createServer(
     dataSources: DataSourcesToolConfigurationType;
     tagsIn?: string[];
     tagsNot?: string[];
-  }): Promise<Result<CallToolResult, Error>> {
+  }): Promise<
+    Result<
+      {
+        isError: boolean;
+        content:
+          | TextContent[]
+          | {
+              type: "resource";
+              resource:
+                | IncludeResultResourceType
+                | IncludeQueryResourceType
+                | WarningResourceType;
+            }[];
+      },
+      Error
+    >
+  > {
     const coreAPI = new CoreAPI(config.getCoreAPIConfig(), logger);
     const credentials = dustManagedCredentials();
 

--- a/front/lib/actions/mcp_internal_actions/servers/interactive_content.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/interactive_content.ts
@@ -89,9 +89,11 @@ const createServer = (
       ) => {
         const { conversation } = agentLoopContext?.runContext ?? {};
         if (!conversation) {
-          return new Err(new Error(
-            "Conversation ID is required to create a client executable file."
-          ));
+          return new Err(
+            new Error(
+              "Conversation ID is required to create a client executable file."
+            )
+          );
         }
 
         const result = await createClientExecutableFile(auth, {

--- a/front/lib/actions/mcp_internal_actions/servers/interactive_content.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/interactive_content.ts
@@ -214,7 +214,9 @@ const createServer = (
         });
 
         if (result.isErr()) {
-          return new Err(new MCPError(result.error.message));
+          return new Err(
+            new MCPError(result.error.message, { tracked: false })
+          );
         }
 
         const { fileResource, replacementCount } = result.value;

--- a/front/lib/actions/mcp_internal_actions/servers/interactive_content.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/interactive_content.ts
@@ -3,7 +3,7 @@ import { INTERNAL_MIME_TYPES } from "@dust-tt/client";
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod";
 
-import { McpError } from "@app/lib/actions/mcp_errors";
+import { MCPError } from "@app/lib/actions/mcp_errors";
 import { withToolLogging } from "@app/lib/actions/mcp_internal_actions/wrappers";
 import type { AgentLoopContextType } from "@app/lib/actions/types";
 import {
@@ -91,7 +91,7 @@ const createServer = (
         const { conversation } = agentLoopContext?.runContext ?? {};
         if (!conversation) {
           return new Err(
-            new McpError(
+            new MCPError(
               "Conversation ID is required to create a client executable file."
             )
           );
@@ -105,7 +105,7 @@ const createServer = (
         });
 
         if (result.isErr()) {
-          return new Err(new McpError(result.error.message));
+          return new Err(new MCPError(result.error.message));
         }
 
         const { value: fileResource } = result;
@@ -214,7 +214,7 @@ const createServer = (
         });
 
         if (result.isErr()) {
-          return new Err(new McpError(result.error.message));
+          return new Err(new MCPError(result.error.message));
         }
 
         const { fileResource, replacementCount } = result.value;
@@ -278,7 +278,7 @@ const createServer = (
         const result = await getClientExecutableFileContent(auth, file_id);
 
         if (result.isErr()) {
-          return new Err(new McpError(result.error.message));
+          return new Err(new MCPError(result.error.message));
         }
 
         const { fileResource, content } = result.value;

--- a/front/lib/actions/mcp_internal_actions/servers/interactive_content.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/interactive_content.ts
@@ -213,9 +213,6 @@ const createServer = (
           expectedReplacements: expected_replacements,
         });
 
-        // Return a non-error response even when file editing fails, since this is an expected
-        // case when the model makes imprecise edits. The error message will help the model
-        // understand what went wrong and retry with corrected parameters.
         if (result.isErr()) {
           return new Err(new Error(result.error.message));
         }

--- a/front/lib/actions/mcp_internal_actions/servers/interactive_content.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/interactive_content.ts
@@ -12,6 +12,7 @@ import {
 } from "@app/lib/api/files/client_executable";
 import type { InternalMCPServerDefinitionType } from "@app/lib/api/mcp";
 import type { Authenticator } from "@app/lib/auth";
+import { McpError } from "@app/lib/actions/mcp_errors";
 import type { InteractiveFileContentType } from "@app/types";
 import { Err, Ok } from "@app/types";
 import { INTERACTIVE_FILE_FORMATS } from "@app/types";
@@ -90,7 +91,7 @@ const createServer = (
         const { conversation } = agentLoopContext?.runContext ?? {};
         if (!conversation) {
           return new Err(
-            new Error(
+            new McpError(
               "Conversation ID is required to create a client executable file."
             )
           );
@@ -104,7 +105,7 @@ const createServer = (
         });
 
         if (result.isErr()) {
-          return new Err(new Error(result.error.message));
+          return new Err(new McpError(result.error.message));
         }
 
         const { value: fileResource } = result;
@@ -137,23 +138,20 @@ const createServer = (
           await sendNotification(notification);
         }
 
-        return new Ok({
-          isError: false,
-          content: [
-            {
-              type: "resource",
-              resource: {
-                contentType: fileResource.contentType,
-                fileId: fileResource.sId,
-                mimeType: INTERNAL_MIME_TYPES.TOOL_OUTPUT.FILE,
-                snippet: fileResource.snippet,
-                text: responseText,
-                title: fileResource.fileName,
-                uri: fileResource.getPublicUrl(auth),
-              },
+        return new Ok([
+          {
+            type: "resource",
+            resource: {
+              contentType: fileResource.contentType,
+              fileId: fileResource.sId,
+              mimeType: INTERNAL_MIME_TYPES.TOOL_OUTPUT.FILE,
+              snippet: fileResource.snippet,
+              text: responseText,
+              title: fileResource.fileName,
+              uri: fileResource.getPublicUrl(auth),
             },
-          ],
-        });
+          },
+        ]);
       }
     )
   );
@@ -216,7 +214,7 @@ const createServer = (
         });
 
         if (result.isErr()) {
-          return new Err(new Error(result.error.message));
+          return new Err(new McpError(result.error.message));
         }
 
         const { fileResource, replacementCount } = result.value;
@@ -250,15 +248,12 @@ const createServer = (
           await sendNotification(notification);
         }
 
-        return new Ok({
-          isError: false,
-          content: [
-            {
-              type: "text",
-              text: responseText,
-            },
-          ],
-        });
+        return new Ok([
+          {
+            type: "text",
+            text: responseText,
+          },
+        ]);
       }
     )
   );
@@ -283,22 +278,19 @@ const createServer = (
         const result = await getClientExecutableFileContent(auth, file_id);
 
         if (result.isErr()) {
-          return new Err(new Error(result.error.message));
+          return new Err(new McpError(result.error.message));
         }
 
         const { fileResource, content } = result.value;
 
-        return new Ok({
-          isError: false,
-          content: [
-            {
-              type: "text",
-              text:
-                `File '${fileResource.sId}' (${fileResource.fileName}) retrieved ` +
-                `successfully. Content:\n\n${content}`,
-            },
-          ],
-        });
+        return new Ok([
+          {
+            type: "text",
+            text:
+              `File '${fileResource.sId}' (${fileResource.fileName}) retrieved ` +
+              `successfully. Content:\n\n${content}`,
+          },
+        ]);
       }
     )
   );

--- a/front/lib/actions/mcp_internal_actions/servers/interactive_content.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/interactive_content.ts
@@ -3,9 +3,7 @@ import { INTERNAL_MIME_TYPES } from "@dust-tt/client";
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod";
 
-import { makeMCPToolTextErrorResult } from "@app/lib/actions/mcp_internal_actions/utils";
 import { withToolLogging } from "@app/lib/actions/mcp_internal_actions/wrappers";
-import { Ok } from "@app/types/shared/result";
 import type { AgentLoopContextType } from "@app/lib/actions/types";
 import {
   createClientExecutableFile,
@@ -15,6 +13,7 @@ import {
 import type { InternalMCPServerDefinitionType } from "@app/lib/api/mcp";
 import type { Authenticator } from "@app/lib/auth";
 import type { InteractiveFileContentType } from "@app/types";
+import { Err, Ok } from "@app/types";
 import { INTERACTIVE_FILE_FORMATS } from "@app/types";
 
 const serverInfo: InternalMCPServerDefinitionType = {
@@ -90,9 +89,9 @@ const createServer = (
       ) => {
         const { conversation } = agentLoopContext?.runContext ?? {};
         if (!conversation) {
-          return makeMCPToolTextErrorResult(
+          return new Err(new Error(
             "Conversation ID is required to create a client executable file."
-          );
+          ));
         }
 
         const result = await createClientExecutableFile(auth, {
@@ -103,7 +102,7 @@ const createServer = (
         });
 
         if (result.isErr()) {
-          return makeMCPToolTextErrorResult(result.error.message);
+          return new Err(new Error(result.error.message));
         }
 
         const { value: fileResource } = result;
@@ -218,7 +217,7 @@ const createServer = (
         // case when the model makes imprecise edits. The error message will help the model
         // understand what went wrong and retry with corrected parameters.
         if (result.isErr()) {
-          return makeMCPToolTextErrorResult(result.error.message);
+          return new Err(new Error(result.error.message));
         }
 
         const { fileResource, replacementCount } = result.value;
@@ -285,7 +284,7 @@ const createServer = (
         const result = await getClientExecutableFileContent(auth, file_id);
 
         if (result.isErr()) {
-          return makeMCPToolTextErrorResult(result.error.message);
+          return new Err(new Error(result.error.message));
         }
 
         const { fileResource, content } = result.value;

--- a/front/lib/actions/mcp_internal_actions/servers/interactive_content.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/interactive_content.ts
@@ -3,6 +3,7 @@ import { INTERNAL_MIME_TYPES } from "@dust-tt/client";
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod";
 
+import { McpError } from "@app/lib/actions/mcp_errors";
 import { withToolLogging } from "@app/lib/actions/mcp_internal_actions/wrappers";
 import type { AgentLoopContextType } from "@app/lib/actions/types";
 import {
@@ -12,7 +13,6 @@ import {
 } from "@app/lib/api/files/client_executable";
 import type { InternalMCPServerDefinitionType } from "@app/lib/api/mcp";
 import type { Authenticator } from "@app/lib/auth";
-import { McpError } from "@app/lib/actions/mcp_errors";
 import type { InteractiveFileContentType } from "@app/types";
 import { Err, Ok } from "@app/types";
 import { INTERACTIVE_FILE_FORMATS } from "@app/types";

--- a/front/lib/actions/mcp_internal_actions/servers/process/index.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/process/index.ts
@@ -24,8 +24,9 @@ import {
   getDataSourceConfiguration,
   shouldAutoGenerateTags,
 } from "@app/lib/actions/mcp_internal_actions/servers/utils";
-import { makeMCPToolTextError } from "@app/lib/actions/mcp_internal_actions/utils";
+import { makeMCPToolTextErrorResult } from "@app/lib/actions/mcp_internal_actions/utils";
 import { withToolLogging } from "@app/lib/actions/mcp_internal_actions/wrappers";
+import { Ok } from "@app/types/shared/result";
 import { runActionStreamed } from "@app/lib/actions/server";
 import type {
   ActionGeneratedFileType,
@@ -222,7 +223,7 @@ function makeExtractInformationFromDocumentsTool(
         file: jsonFile,
       });
 
-      return processToolOutput;
+      return new Ok(processToolOutput);
     }
   );
 }
@@ -509,7 +510,7 @@ function processToolError({
     },
     "Error running process"
   );
-  return makeMCPToolTextError(`${errorMessage}: ${errorDetails}`);
+  return makeMCPToolTextErrorResult(`${errorMessage}: ${errorDetails}`);
 }
 
 async function generateProcessToolOutput({

--- a/front/lib/actions/mcp_internal_actions/servers/process/index.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/process/index.ts
@@ -10,6 +10,7 @@ import {
   uploadFileToConversationDataSource,
 } from "@app/lib/actions/action_file_helpers";
 import { PROCESS_ACTION_TOP_K } from "@app/lib/actions/constants";
+import { MCPError } from "@app/lib/actions/mcp_errors";
 import type { DataSourcesToolConfigurationType } from "@app/lib/actions/mcp_internal_actions/input_schemas";
 import {
   ConfigurableToolInputSchemas,
@@ -26,7 +27,6 @@ import {
 } from "@app/lib/actions/mcp_internal_actions/servers/utils";
 import { withToolLogging } from "@app/lib/actions/mcp_internal_actions/wrappers";
 import { runActionStreamed } from "@app/lib/actions/server";
-import { McpError } from "@app/lib/actions/mcp_errors";
 import type {
   ActionGeneratedFileType,
   AgentLoopContextType,
@@ -171,7 +171,7 @@ function makeExtractInformationFromDocumentsTool(
       );
       if (res.isErr()) {
         return new Err(
-          new McpError(
+          new MCPError(
             `Error running extract data action: ${res.error.message}`
           )
         );
@@ -182,7 +182,7 @@ function makeExtractInformationFromDocumentsTool(
       for await (const event of res.value.eventStream) {
         if (event.type === "error") {
           return new Err(
-            new McpError(
+            new MCPError(
               `"Error running extract data action": ${event.content.message ?? "Unknown error from event stream."}`
             )
           );
@@ -192,7 +192,7 @@ function makeExtractInformationFromDocumentsTool(
           const e = event.content.execution[0][0];
           if (e.error) {
             return new Err(
-              new McpError(
+              new MCPError(
                 `"Error running extract data action": ${e.error ?? "An unknown error occurred during block execution."}`
               )
             );

--- a/front/lib/actions/mcp_internal_actions/servers/process/index.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/process/index.ts
@@ -509,11 +509,7 @@ function processToolError({
     },
     "Error running process"
   );
-  return makeMCPToolTextError(`${errorMessage}: ${errorDetails}`, {
-    created: Date.now(),
-    workspaceId: conversation.owner.sId,
-    conversationId: conversation.sId,
-  });
+  return makeMCPToolTextError(`${errorMessage}: ${errorDetails}`);
 }
 
 async function generateProcessToolOutput({

--- a/front/lib/actions/mcp_internal_actions/servers/process/index.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/process/index.ts
@@ -41,7 +41,6 @@ import type { Authenticator } from "@app/lib/auth";
 import { cloneBaseConfig, getDustProdAction } from "@app/lib/registry";
 import { DataSourceViewResource } from "@app/lib/resources/data_source_view_resource";
 import { concurrentExecutor } from "@app/lib/utils/async_utils";
-import logger from "@app/logger/logger";
 import type {
   AgentConfigurationType,
   AgentModelConfigurationType,

--- a/front/lib/actions/mcp_internal_actions/servers/process/index.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/process/index.ts
@@ -24,9 +24,7 @@ import {
   getDataSourceConfiguration,
   shouldAutoGenerateTags,
 } from "@app/lib/actions/mcp_internal_actions/servers/utils";
-import { makeMCPToolTextErrorResult } from "@app/lib/actions/mcp_internal_actions/utils";
 import { withToolLogging } from "@app/lib/actions/mcp_internal_actions/wrappers";
-import { Ok } from "@app/types/shared/result";
 import { runActionStreamed } from "@app/lib/actions/server";
 import type {
   ActionGeneratedFileType,
@@ -44,13 +42,15 @@ import { cloneBaseConfig, getDustProdAction } from "@app/lib/registry";
 import { DataSourceViewResource } from "@app/lib/resources/data_source_view_resource";
 import { concurrentExecutor } from "@app/lib/utils/async_utils";
 import logger from "@app/logger/logger";
-import type {
+import {
   AgentConfigurationType,
   AgentModelConfigurationType,
   ConversationType,
+  Err,
   TimeFrame,
   UserMessageType,
 } from "@app/types";
+import { Ok } from "@app/types";
 import { isUserMessageType, timeFrameFromNow } from "@app/types";
 
 import { applyDataSourceFilters, getExtractFileTitle } from "./utils";
@@ -510,7 +510,7 @@ function processToolError({
     },
     "Error running process"
   );
-  return makeMCPToolTextErrorResult(`${errorMessage}: ${errorDetails}`);
+  return new Err(new Error(`${errorMessage}: ${errorDetails}`));
 }
 
 async function generateProcessToolOutput({

--- a/front/lib/actions/mcp_internal_actions/servers/process/index.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/process/index.ts
@@ -42,15 +42,14 @@ import { cloneBaseConfig, getDustProdAction } from "@app/lib/registry";
 import { DataSourceViewResource } from "@app/lib/resources/data_source_view_resource";
 import { concurrentExecutor } from "@app/lib/utils/async_utils";
 import logger from "@app/logger/logger";
-import {
+import type {
   AgentConfigurationType,
   AgentModelConfigurationType,
   ConversationType,
-  Err,
   TimeFrame,
   UserMessageType,
 } from "@app/types";
-import { Ok } from "@app/types";
+import { Err, Ok } from "@app/types";
 import { isUserMessageType, timeFrameFromNow } from "@app/types";
 
 import { applyDataSourceFilters, getExtractFileTitle } from "./utils";

--- a/front/lib/actions/mcp_internal_actions/servers/search.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/search.ts
@@ -4,7 +4,7 @@ import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
 import assert from "assert";
 import { z } from "zod";
 
-import { McpError } from "@app/lib/actions/mcp_errors";
+import { MCPError } from "@app/lib/actions/mcp_errors";
 import { SEARCH_TOOL_NAME } from "@app/lib/actions/mcp_internal_actions/constants";
 import type { DataSourcesToolConfigurationType } from "@app/lib/actions/mcp_internal_actions/input_schemas";
 import { ConfigurableToolInputSchemas } from "@app/lib/actions/mcp_internal_actions/input_schemas";
@@ -65,7 +65,7 @@ export async function searchFunction({
   tagsNot?: string[];
   auth: Authenticator;
   agentLoopContext?: AgentLoopContextType;
-}): Promise<Result<CallToolResult["content"], McpError>> {
+}): Promise<Result<CallToolResult["content"], MCPError>> {
   const coreAPI = new CoreAPI(config.getCoreAPIConfig(), logger);
   const credentials = dustManagedCredentials();
   const timeFrame = parseTimeFrame(relativeTimeFrame);
@@ -105,7 +105,7 @@ export async function searchFunction({
 
   if (coreSearchArgs.length === 0) {
     return new Err(
-      new McpError(
+      new MCPError(
         "Search action must have at least one data source configured."
       )
     );
@@ -154,12 +154,12 @@ export async function searchFunction({
   );
 
   if (searchResults.isErr()) {
-    return new Err(new McpError(searchResults.error.message));
+    return new Err(new MCPError(searchResults.error.message));
   }
 
   if (citationsOffset + retrievalTopK > getRefs().length) {
     return new Err(
-      new McpError(
+      new MCPError(
         "The search exhausted the total number of references available for citations"
       )
     );

--- a/front/lib/actions/mcp_internal_actions/servers/search.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/search.ts
@@ -19,9 +19,7 @@ import {
   getCoreSearchArgs,
 } from "@app/lib/actions/mcp_internal_actions/servers/utils";
 import { shouldAutoGenerateTags } from "@app/lib/actions/mcp_internal_actions/servers/utils";
-import { makeMCPToolTextErrorResult } from "@app/lib/actions/mcp_internal_actions/utils";
 import { withToolLogging } from "@app/lib/actions/mcp_internal_actions/wrappers";
-import { Ok, Result } from "@app/types/shared/result";
 import type { AgentLoopContextType } from "@app/lib/actions/types";
 import { getRefs } from "@app/lib/api/assistant/citations";
 import config from "@app/lib/api/config";
@@ -30,6 +28,8 @@ import type { Authenticator } from "@app/lib/auth";
 import { getDisplayNameForDocument } from "@app/lib/data_sources";
 import { concurrentExecutor } from "@app/lib/utils/async_utils";
 import logger from "@app/logger/logger";
+import type { Result } from "@app/types";
+import { Err, Ok } from "@app/types";
 import {
   CoreAPI,
   dustManagedCredentials,
@@ -104,8 +104,8 @@ export async function searchFunction({
   );
 
   if (coreSearchArgs.length === 0) {
-    return makeMCPToolTextErrorResult(
-      "Search action must have at least one data source configured."
+    return new Err(
+      new Error("Search action must have at least one data source configured.")
     );
   }
 
@@ -155,12 +155,14 @@ export async function searchFunction({
   );
 
   if (searchResults.isErr()) {
-    return makeMCPToolTextErrorResult(searchResults.error.message);
+    return new Err(new Error(searchResults.error.message));
   }
 
   if (citationsOffset + retrievalTopK > getRefs().length) {
-    return makeMCPToolTextErrorResult(
-      "The search exhausted the total number of references available for citations"
+    return new Err(
+      new Error(
+        "The search exhausted the total number of references available for citations"
+      )
     );
   }
 
@@ -195,7 +197,7 @@ export async function searchFunction({
     }
   );
 
-  return Ok({
+  return new Ok({
     isError: false,
     content: [
       ...results.map((result) => ({

--- a/front/lib/actions/mcp_internal_actions/servers/search.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/search.ts
@@ -89,13 +89,15 @@ export async function searchFunction({
 
   // If any of the data sources are invalid, return an error message.
   if (coreSearchArgsResults.some((res) => res.isErr())) {
-    return new Ok(
-      removeNulls(
-        coreSearchArgsResults.map((res) => (res.isErr() ? res.error : null))
-      ).map((error) => ({
-        type: "text",
-        text: error.message,
-      }))
+    return new Err(
+      new MCPError(
+        removeNulls(
+          coreSearchArgsResults.map((res) => (res.isErr() ? res.error : null))
+        )
+          .map((error) => error.message)
+          .join("\n"),
+        { tracked: false }
+      )
     );
   }
 
@@ -116,7 +118,7 @@ export async function searchFunction({
     tagsNot,
   });
   if (conflictingTagsError) {
-    return new Ok([{ type: "text", text: conflictingTagsError }]);
+    return new Err(new MCPError(conflictingTagsError, { tracked: false }));
   }
 
   // Now we can search each data source.

--- a/front/lib/actions/mcp_internal_actions/servers/search.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/search.ts
@@ -4,6 +4,7 @@ import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
 import assert from "assert";
 import { z } from "zod";
 
+import { McpError } from "@app/lib/actions/mcp_errors";
 import { SEARCH_TOOL_NAME } from "@app/lib/actions/mcp_internal_actions/constants";
 import type { DataSourcesToolConfigurationType } from "@app/lib/actions/mcp_internal_actions/input_schemas";
 import { ConfigurableToolInputSchemas } from "@app/lib/actions/mcp_internal_actions/input_schemas";
@@ -26,7 +27,6 @@ import config from "@app/lib/api/config";
 import type { InternalMCPServerDefinitionType } from "@app/lib/api/mcp";
 import type { Authenticator } from "@app/lib/auth";
 import { getDisplayNameForDocument } from "@app/lib/data_sources";
-import { McpError } from "@app/lib/actions/mcp_errors";
 import { concurrentExecutor } from "@app/lib/utils/async_utils";
 import logger from "@app/logger/logger";
 import type { Result } from "@app/types";

--- a/front/lib/actions/mcp_internal_actions/servers/tables_query/server_v2.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/tables_query/server_v2.ts
@@ -227,9 +227,7 @@ function createServer(
         if (queryResult.isErr()) {
           return new Ok({
             // Certain errors we don't track as they can occur in the context of a normal execution.
-            isError: !["too_many_result_rows", "table_not_found"].includes(
-              queryResult.error.code
-            ),
+            isError: true,
             content: [
               {
                 type: "resource",

--- a/front/lib/actions/mcp_internal_actions/servers/tables_query/server_v2.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/tables_query/server_v2.ts
@@ -7,6 +7,7 @@ import {
   generateSectionFile,
   uploadFileToConversationDataSource,
 } from "@app/lib/actions/action_file_helpers";
+import { McpError } from "@app/lib/actions/mcp_errors";
 import { ConfigurableToolInputSchemas } from "@app/lib/actions/mcp_internal_actions/input_schemas";
 import type {
   SqlQueryOutputType,
@@ -35,7 +36,6 @@ import config from "@app/lib/api/config";
 import type { CSVRecord } from "@app/lib/api/csv";
 import type { InternalMCPServerDefinitionType } from "@app/lib/api/mcp";
 import type { Authenticator } from "@app/lib/auth";
-import { McpError } from "@app/lib/actions/mcp_errors";
 import { DataSourceViewResource } from "@app/lib/resources/data_source_view_resource";
 import logger from "@app/logger/logger";
 import { Err, Ok } from "@app/types";

--- a/front/lib/actions/mcp_internal_actions/servers/tables_query/server_v2.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/tables_query/server_v2.ts
@@ -28,9 +28,8 @@ import {
   TABLES_QUERY_SECTION_FILE_MIN_COLUMN_LENGTH,
 } from "@app/lib/actions/mcp_internal_actions/servers/tables_query/server";
 import { fetchTableDataSourceConfigurations } from "@app/lib/actions/mcp_internal_actions/servers/utils";
-import { makeMCPToolTextError, makeMCPToolTextErrorResult } from "@app/lib/actions/mcp_internal_actions/utils";
+import { makeMCPToolTextError } from "@app/lib/actions/mcp_internal_actions/utils";
 import { withToolLogging } from "@app/lib/actions/mcp_internal_actions/wrappers";
-import { Ok } from "@app/types/shared/result";
 import type { AgentLoopContextType } from "@app/lib/actions/types";
 import config from "@app/lib/api/config";
 import type { CSVRecord } from "@app/lib/api/csv";
@@ -38,6 +37,7 @@ import type { InternalMCPServerDefinitionType } from "@app/lib/api/mcp";
 import type { Authenticator } from "@app/lib/auth";
 import { DataSourceViewResource } from "@app/lib/resources/data_source_view_resource";
 import logger from "@app/logger/logger";
+import { Err, Ok } from "@app/types";
 import { CoreAPI } from "@app/types/core/core_api";
 
 // Types for the resources that are output by the tools of this server.
@@ -178,8 +178,10 @@ function createServer(
           tables
         );
         if (tableConfigurationsRes.isErr()) {
-          return makeMCPToolTextErrorResult(
-            `Error fetching table configurations: ${tableConfigurationsRes.error.message}`
+          return new Err(
+            new Error(
+              `Error fetching table configurations: ${tableConfigurationsRes.error.message}`
+            )
           );
         }
         const tableConfigurations = tableConfigurationsRes.value;

--- a/front/lib/actions/mcp_internal_actions/servers/tables_query/server_v2.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/tables_query/server_v2.ts
@@ -187,12 +187,12 @@ function createServer(
         }
         const tableConfigurations = tableConfigurationsRes.value;
         if (tableConfigurations.length === 0) {
-          return new Ok([
-            {
-              type: "text",
-              text: "The agent does not have access to any tables. Please edit the agent's Query Tables tool to add tables, or remove the tool.",
-            },
-          ]);
+          return new Err(
+            new MCPError(
+              "The agent does not have access to any tables. Please edit the agent's Query Tables tool to add tables, or remove the tool.",
+              { tracked: false }
+            )
+          );
         }
         const dataSourceViews = await DataSourceViewResource.fetchByIds(auth, [
           ...new Set(tableConfigurations.map((t) => t.dataSourceViewId)),

--- a/front/lib/actions/mcp_internal_actions/servers/tables_query/server_v2.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/tables_query/server_v2.ts
@@ -7,7 +7,7 @@ import {
   generateSectionFile,
   uploadFileToConversationDataSource,
 } from "@app/lib/actions/action_file_helpers";
-import { McpError } from "@app/lib/actions/mcp_errors";
+import { MCPError } from "@app/lib/actions/mcp_errors";
 import { ConfigurableToolInputSchemas } from "@app/lib/actions/mcp_internal_actions/input_schemas";
 import type {
   SqlQueryOutputType,
@@ -180,7 +180,7 @@ function createServer(
         );
         if (tableConfigurationsRes.isErr()) {
           return new Err(
-            new McpError(
+            new MCPError(
               `Error fetching table configurations: ${tableConfigurationsRes.error.message}`
             )
           );
@@ -225,7 +225,7 @@ function createServer(
         if (queryResult.isErr()) {
           return new Err(
             // Certain errors we don't track as they can occur in the context of a normal execution.
-            new McpError(
+            new MCPError(
               "Error executing database query: " + queryResult.error.message,
               { tracked: false }
             )

--- a/front/lib/actions/mcp_internal_actions/utils.ts
+++ b/front/lib/actions/mcp_internal_actions/utils.ts
@@ -14,10 +14,7 @@ import { isServerSideMCPToolConfiguration } from "@app/lib/actions/types/guards"
  * Do not use if the intent is to show an issue to the agent as part of a normal tool execution,
  * only use if the error should be logged and tracked.
  */
-export function makeMCPToolTextError(
-  text: string,
-  metadata: Record<string, boolean | number | string> = {}
-): {
+export function makeMCPToolTextError(text: string): {
   isError: true;
   content: [TextContent];
 } {
@@ -26,7 +23,6 @@ export function makeMCPToolTextError(
     content: [
       {
         type: "text",
-        ...metadata,
         text,
       },
     ],

--- a/front/lib/actions/mcp_internal_actions/utils.ts
+++ b/front/lib/actions/mcp_internal_actions/utils.ts
@@ -5,6 +5,8 @@ import type {
 
 import type { AgentLoopContextType } from "@app/lib/actions/types";
 import { isServerSideMCPToolConfiguration } from "@app/lib/actions/types/guards";
+import { Err, Ok } from "@app/types/shared/result";
+import type { Result } from "@app/types";
 
 /**
  * Error tool result. Does not fail the agent loop (the text is shown to the model) but is logged.
@@ -30,6 +32,14 @@ export function makeMCPToolTextError(text: string): {
 }
 
 /**
+ * Error tool result for use with withToolLogging wrapper.
+ * Returns an Err result for use with withToolLogging wrapper.
+ */
+export function makeMCPToolTextErrorResult(text: string): Result<CallToolResult, Error> {
+  return new Err(new Error(text));
+}
+
+/**
  * Success tool result.
  *
  * Use this if the intent is to show an issue to the agent that does not need logging
@@ -43,6 +53,17 @@ export function makeMCPToolRecoverableErrorSuccess(errorText: string): {
     isError: false,
     content: [{ type: "text", text: errorText }],
   };
+}
+
+/**
+ * Success tool result for use with withToolLogging wrapper.
+ * Returns an Ok result for use with withToolLogging wrapper.
+ */
+export function makeMCPToolRecoverableErrorSuccessResult(errorText: string): Result<CallToolResult, Error> {
+  return new Ok({
+    isError: false,
+    content: [{ type: "text", text: errorText }],
+  });
 }
 
 export const makeMCPToolTextSuccess = ({
@@ -67,6 +88,28 @@ export const makeMCPToolTextSuccess = ({
   };
 };
 
+export const makeMCPToolTextSuccessResult = ({
+  message,
+  result,
+}: {
+  message: string;
+  result?: string;
+}): Result<CallToolResult, Error> => {
+  if (!result) {
+    return new Ok({
+      isError: false,
+      content: [{ type: "text", text: message }],
+    });
+  }
+  return new Ok({
+    isError: false,
+    content: [
+      { type: "text", text: message },
+      { type: "text", text: result },
+    ],
+  });
+};
+
 export const makeMCPToolJSONSuccess = ({
   message,
   result,
@@ -81,6 +124,22 @@ export const makeMCPToolJSONSuccess = ({
       { type: "text" as const, text: JSON.stringify(result, null, 2) },
     ],
   };
+};
+
+export const makeMCPToolJSONSuccessResult = ({
+  message,
+  result,
+}: {
+  message?: string;
+  result: object | string;
+}): Result<CallToolResult, Error> => {
+  return new Ok({
+    isError: false,
+    content: [
+      ...(message ? [{ type: "text" as const, text: message }] : []),
+      { type: "text" as const, text: JSON.stringify(result, null, 2) },
+    ],
+  });
 };
 
 /**

--- a/front/lib/actions/mcp_internal_actions/utils.ts
+++ b/front/lib/actions/mcp_internal_actions/utils.ts
@@ -5,8 +5,6 @@ import type {
 
 import type { AgentLoopContextType } from "@app/lib/actions/types";
 import { isServerSideMCPToolConfiguration } from "@app/lib/actions/types/guards";
-import { Err, Ok } from "@app/types/shared/result";
-import type { Result } from "@app/types";
 
 /**
  * Error tool result. Does not fail the agent loop (the text is shown to the model) but is logged.
@@ -31,41 +29,6 @@ export function makeMCPToolTextError(text: string): {
   };
 }
 
-/**
- * Error tool result for use with withToolLogging wrapper.
- * Returns an Err result for use with withToolLogging wrapper.
- */
-export function makeMCPToolTextErrorResult(text: string): Result<CallToolResult, Error> {
-  return new Err(new Error(text));
-}
-
-/**
- * Success tool result.
- *
- * Use this if the intent is to show an issue to the agent that does not need logging
- * and is part of a normal tool execution.
- */
-export function makeMCPToolRecoverableErrorSuccess(errorText: string): {
-  isError: false;
-  content: [TextContent];
-} {
-  return {
-    isError: false,
-    content: [{ type: "text", text: errorText }],
-  };
-}
-
-/**
- * Success tool result for use with withToolLogging wrapper.
- * Returns an Ok result for use with withToolLogging wrapper.
- */
-export function makeMCPToolRecoverableErrorSuccessResult(errorText: string): Result<CallToolResult, Error> {
-  return new Ok({
-    isError: false,
-    content: [{ type: "text", text: errorText }],
-  });
-}
-
 export const makeMCPToolTextSuccess = ({
   message,
   result,
@@ -88,28 +51,6 @@ export const makeMCPToolTextSuccess = ({
   };
 };
 
-export const makeMCPToolTextSuccessResult = ({
-  message,
-  result,
-}: {
-  message: string;
-  result?: string;
-}): Result<CallToolResult, Error> => {
-  if (!result) {
-    return new Ok({
-      isError: false,
-      content: [{ type: "text", text: message }],
-    });
-  }
-  return new Ok({
-    isError: false,
-    content: [
-      { type: "text", text: message },
-      { type: "text", text: result },
-    ],
-  });
-};
-
 export const makeMCPToolJSONSuccess = ({
   message,
   result,
@@ -124,22 +65,6 @@ export const makeMCPToolJSONSuccess = ({
       { type: "text" as const, text: JSON.stringify(result, null, 2) },
     ],
   };
-};
-
-export const makeMCPToolJSONSuccessResult = ({
-  message,
-  result,
-}: {
-  message?: string;
-  result: object | string;
-}): Result<CallToolResult, Error> => {
-  return new Ok({
-    isError: false,
-    content: [
-      ...(message ? [{ type: "text" as const, text: message }] : []),
-      { type: "text" as const, text: JSON.stringify(result, null, 2) },
-    ],
-  });
 };
 
 /**

--- a/front/lib/actions/mcp_internal_actions/utils.ts
+++ b/front/lib/actions/mcp_internal_actions/utils.ts
@@ -6,14 +6,6 @@ import type {
 import type { AgentLoopContextType } from "@app/lib/actions/types";
 import { isServerSideMCPToolConfiguration } from "@app/lib/actions/types/guards";
 
-/**
- * Error tool result. Does not fail the agent loop (the text is shown to the model) but is logged.
- * If the tool callback is wrapped by `withToolLogging`, the error will be tracked and the error
- * message will be shown in the logs to help debugging it.
- *
- * Do not use if the intent is to show an issue to the agent as part of a normal tool execution,
- * only use if the error should be logged and tracked.
- */
 export function makeMCPToolTextError(text: string): {
   isError: true;
   content: [TextContent];

--- a/front/lib/actions/mcp_internal_actions/wrappers.ts
+++ b/front/lib/actions/mcp_internal_actions/wrappers.ts
@@ -10,7 +10,6 @@ import type { Authenticator } from "@app/lib/auth";
 import logger from "@app/logger/logger";
 import { statsDClient } from "@app/logger/statsDClient";
 import type { Result } from "@app/types";
-import { makeMCPToolTextError } from "@app/lib/actions/mcp_internal_actions/utils";
 
 export function withToolLogging<T>(
   auth: Authenticator,
@@ -89,7 +88,15 @@ export function withToolLogging<T>(
         },
         "Tool execution error"
       );
-      return makeMCPToolTextError(error);
+      return {
+        isError: true,
+        content: [
+          {
+            type: "text",
+            text: error,
+          },
+        ],
+      };
     }
 
     const elapsed = performance.now() - startTime;

--- a/front/lib/actions/mcp_internal_actions/wrappers.ts
+++ b/front/lib/actions/mcp_internal_actions/wrappers.ts
@@ -82,7 +82,7 @@ export function withToolLogging<T>(
 
     const result = await toolCallback(params, extra);
 
-    // When we get an Err, we monitor it and return it as a text content.
+    // When we get an Err, we monitor it if tracked and return it as a text content.
     if (result.isErr()) {
       if (result.error.tracked) {
         statsDClient.increment("use_tools_error.count", 1, [

--- a/front/lib/actions/mcp_internal_actions/wrappers.ts
+++ b/front/lib/actions/mcp_internal_actions/wrappers.ts
@@ -11,6 +11,11 @@ import logger from "@app/logger/logger";
 import { statsDClient } from "@app/logger/statsDClient";
 import type { Result } from "@app/types";
 
+/**
+ * Wraps a tool callback with logging and monitoring.
+ * The tool callback is expected to return a `Result<CallToolResult, Error>`,
+ * Errors are caught and logged, and the error is returned as a text content.
+ */
 export function withToolLogging<T>(
   auth: Authenticator,
   {

--- a/front/lib/actions/mcp_internal_actions/wrappers.ts
+++ b/front/lib/actions/mcp_internal_actions/wrappers.ts
@@ -5,6 +5,7 @@ import type {
   ServerRequest,
 } from "@modelcontextprotocol/sdk/types.js";
 
+import type { McpError } from "@app/lib/actions/mcp_errors";
 import type { AgentLoopContextType } from "@app/lib/actions/types";
 import type { Authenticator } from "@app/lib/auth";
 import logger from "@app/logger/logger";
@@ -103,7 +104,7 @@ export function withToolLogging<T>(
         content: [
           {
             type: "text",
-            text: error,
+            text: result.error.message,
           },
         ],
       };

--- a/front/lib/actions/mcp_internal_actions/wrappers.ts
+++ b/front/lib/actions/mcp_internal_actions/wrappers.ts
@@ -24,7 +24,10 @@ export function withToolLogging<T>(
     params: T,
     extra: RequestHandlerExtra<ServerRequest, ServerNotification>
   ) => Promise<Result<CallToolResult, Error>>
-) {
+): (
+  params: T,
+  extra: RequestHandlerExtra<ServerRequest, ServerNotification>
+) => Promise<CallToolResult> {
   return async (
     params: T,
     extra: RequestHandlerExtra<ServerRequest, ServerNotification>

--- a/front/lib/actions/mcp_internal_actions/wrappers.ts
+++ b/front/lib/actions/mcp_internal_actions/wrappers.ts
@@ -10,6 +10,7 @@ import type { Authenticator } from "@app/lib/auth";
 import logger from "@app/logger/logger";
 import { statsDClient } from "@app/logger/statsDClient";
 import type { Result } from "@app/types";
+import { makeMCPToolTextError } from "@app/lib/actions/mcp_internal_actions/utils";
 
 export function withToolLogging<T>(
   auth: Authenticator,
@@ -88,7 +89,7 @@ export function withToolLogging<T>(
         },
         "Tool execution error"
       );
-      return { isError: true, content: [{ type: "text", value: result }] };
+      return makeMCPToolTextError(error);
     }
 
     const elapsed = performance.now() - startTime;

--- a/front/lib/actions/mcp_internal_actions/wrappers.ts
+++ b/front/lib/actions/mcp_internal_actions/wrappers.ts
@@ -90,10 +90,9 @@ export function withToolLogging<T>(
           ...tags,
         ]);
 
-        const error = result.error.message;
         logger.error(
           {
-            error,
+            error: result.error.message,
             ...loggerArgs,
           },
           "Tool execution error"

--- a/front/lib/actions/mcp_internal_actions/wrappers.ts
+++ b/front/lib/actions/mcp_internal_actions/wrappers.ts
@@ -14,8 +14,8 @@ import type { Result } from "@app/types";
 
 /**
  * Wraps a tool callback with logging and monitoring.
- * The tool callback is expected to return a `Result<CallToolResult, Error>`,
- * Errors are caught and logged, and the error is returned as a text content.
+ * The tool callback is expected to return a `Result<CallToolResult["content"], MCPError>`,
+ * Errors are caught and logged unless not tracked, and the error is returned as a text content.
  */
 export function withToolLogging<T>(
   auth: Authenticator,

--- a/front/lib/actions/mcp_internal_actions/wrappers.ts
+++ b/front/lib/actions/mcp_internal_actions/wrappers.ts
@@ -5,7 +5,7 @@ import type {
   ServerRequest,
 } from "@modelcontextprotocol/sdk/types.js";
 
-import type { McpError } from "@app/lib/actions/mcp_errors";
+import type { MCPError } from "@app/lib/actions/mcp_errors";
 import type { AgentLoopContextType } from "@app/lib/actions/types";
 import type { Authenticator } from "@app/lib/auth";
 import logger from "@app/logger/logger";
@@ -29,7 +29,7 @@ export function withToolLogging<T>(
   toolCallback: (
     params: T,
     extra: RequestHandlerExtra<ServerRequest, ServerNotification>
-  ) => Promise<Result<CallToolResult["content"], McpError>>
+  ) => Promise<Result<CallToolResult["content"], MCPError>>
 ): (
   params: T,
   extra: RequestHandlerExtra<ServerRequest, ServerNotification>

--- a/front/lib/api/assistant/agent_suggestion.ts
+++ b/front/lib/api/assistant/agent_suggestion.ts
@@ -9,7 +9,7 @@ import {
   isProviderWhitelisted,
   removeNulls,
 } from "@app/types";
-import { Ok } from "@app/types/shared/result";
+import { Ok } from "@app/types";
 
 export async function getSuggestedAgentsForContent(
   auth: Authenticator,


### PR DESCRIPTION
## Description

- This PR updates the wrapper `withToolLogging` to expect a Result type, with our own type of errors (`MCPError`) that specifies whether the error should be tracked.
- After this PR the behavior will be the following:
  - Internal tool return `Ok`/`Err` depending on whether they errored, optionally errors can be flagged as not tracked.
  - `isError` is set to `true` on `Err` values and `false` for `Ok` values.
- The way the type is defined discourages passing anything else than a string message to keep the logging straightforward.
- Note: not all internal servers actually rely on the `withToolLogging` wrapper. If the cost of the DD metric is not absurd (the metric does have a high cardinality given that it contains the `workspaceId` as a tag) we should add it to every internal MCP server, TBC.

## Tests

- Yes

## Risk

- Very low, well covered by `tsc`.

## Deploy Plan

- Deploy front.
