### PR TITLE
[front] Clear cookies from multiple domain if needed

### DIFF
--- a/front/lib/api/workos/user.ts
+++ b/front/lib/api/workos/user.ts
@@ -46,10 +46,10 @@ export function getDomainCookieClauseFromRequest(
     const [hostName] = host.split(":");
 
     if (hostName.endsWith("dust.tt")) {
-      return "Domain=dust.tt; ";
+      return "dust.tt";
     }
 
-    return `Domain=${hostName}; `;
+    return hostName;
   }
   return "";
 }
@@ -66,9 +66,11 @@ export async function getWorkOSSession(
       if (domain) {
         res.setHeader("Set-Cookie", [
           "workos_session=; Path=/; Expires=Thu, 01 Jan 1970 00:00:00 GMT; SameSite=Lax",
-          `workos_session=; ${domain} Path=/; Expires=Thu, 01 Jan 1970 00:00:00 GMT; SameSite=Lax`,
+          `workos_session=; Domain=${domain}; Path=/; Expires=Thu, 01 Jan 1970 00:00:00 GMT; SameSite=Lax`,
+          `workos_session=; Domain=.${domain}; Path=/; Expires=Thu, 01 Jan 1970 00:00:00 GMT; SameSite=Lax`,
           "sessionType=; Path=/; Expires=Thu, 01 Jan 1970 00:00:00 GMT; SameSite=Lax",
-          `sessionType=; ${domain} Path=/; Expires=Thu, 01 Jan 1970 00:00:00 GMT; SameSite=Lax`,
+          `sessionType=; Domain=${domain}; Path=/; Expires=Thu, 01 Jan 1970 00:00:00 GMT; SameSite=Lax`,
+          `sessionType=; Domain=.${domain}; Path=/; Expires=Thu, 01 Jan 1970 00:00:00 GMT; SameSite=Lax`,
         ]);
       } else {
         res.setHeader("Set-Cookie", [

--- a/front/lib/api/workos/user.ts
+++ b/front/lib/api/workos/user.ts
@@ -63,12 +63,19 @@ export async function getWorkOSSession(
     const result = await getWorkOSSessionFromCookie(workOSSessionCookie);
     const domain = getDomainCookieClauseFromRequest(req);
     if (result.cookie === "") {
-      res.setHeader("Set-Cookie", [
-        "workos_session=; Path=/; Expires=Thu, 01 Jan 1970 00:00:00 GMT; SameSite=Lax",
-        "sessionType=; Path=/; Expires=Thu, 01 Jan 1970 00:00:00 GMT; SameSite=Lax",
-        `workos_session=; ${domain} Path=/; Expires=Thu, 01 Jan 1970 00:00:00 GMT; SameSite=Lax`,
-        `sessionType=; ${domain} Path=/; Expires=Thu, 01 Jan 1970 00:00:00 GMT; SameSite=Lax`,
-      ]);
+      if (domain) {
+        res.setHeader("Set-Cookie", [
+          "workos_session=; Path=/; Expires=Thu, 01 Jan 1970 00:00:00 GMT; SameSite=Lax",
+          `workos_session=; ${domain} Path=/; Expires=Thu, 01 Jan 1970 00:00:00 GMT; SameSite=Lax`,
+          "sessionType=; Path=/; Expires=Thu, 01 Jan 1970 00:00:00 GMT; SameSite=Lax",
+          `sessionType=; ${domain} Path=/; Expires=Thu, 01 Jan 1970 00:00:00 GMT; SameSite=Lax`,
+        ]);
+      } else {
+        res.setHeader("Set-Cookie", [
+          "workos_session=; Path=/; Expires=Thu, 01 Jan 1970 00:00:00 GMT; HttpOnly; SameSite=Lax",
+          "sessionType=; Path=/; Expires=Thu, 01 Jan 1970 00:00:00 GMT; SameSite=Lax",
+        ]);
+      }
     } else if (result.cookie) {
       res.setHeader("Set-Cookie", [
         `workos_session=${result.cookie}; Path=/; HttpOnly; Secure; SameSite=Lax; Max-Age=2592000`,

--- a/front/lib/api/workos/user.ts
+++ b/front/lib/api/workos/user.ts
@@ -37,6 +37,23 @@ export function getUserNicknameFromEmail(email: string) {
   return email.split("@")[0] ?? "";
 }
 
+export function getDomainCookieClauseFromRequest(
+  req: NextApiRequest | GetServerSidePropsContext["req"]
+) {
+  // Get domain from request URL, falling back to host header if not available
+  const host = req.headers.host;
+  if (host) {
+    const [hostName] = host.split(":");
+
+    if (hostName.endsWith("dust.tt")) {
+      return "Domain=dust.tt; ";
+    }
+
+    return `Domain=${hostName}; `;
+  }
+  return "";
+}
+
 export async function getWorkOSSession(
   req: NextApiRequest | GetServerSidePropsContext["req"],
   res: NextApiResponse | GetServerSidePropsContext["res"]
@@ -44,11 +61,13 @@ export async function getWorkOSSession(
   const workOSSessionCookie = req.cookies["workos_session"];
   if (workOSSessionCookie) {
     const result = await getWorkOSSessionFromCookie(workOSSessionCookie);
-
+    const domain = getDomainCookieClauseFromRequest(req);
     if (result.cookie === "") {
       res.setHeader("Set-Cookie", [
         "workos_session=; Path=/; Expires=Thu, 01 Jan 1970 00:00:00 GMT; SameSite=Lax",
         "sessionType=; Path=/; Expires=Thu, 01 Jan 1970 00:00:00 GMT; SameSite=Lax",
+        `workos_session=; ${domain} Path=/; Expires=Thu, 01 Jan 1970 00:00:00 GMT; SameSite=Lax`,
+        `sessionType=; ${domain} Path=/; Expires=Thu, 01 Jan 1970 00:00:00 GMT; SameSite=Lax`,
       ]);
     } else if (result.cookie) {
       res.setHeader("Set-Cookie", [

--- a/front/pages/api/workos/[action].ts
+++ b/front/pages/api/workos/[action].ts
@@ -304,14 +304,22 @@ async function handleLogout(req: NextApiRequest, res: NextApiResponse) {
   }
 
   const domain = getDomainCookieClauseFromRequest(req);
-  res.setHeader("Set-Cookie", [
-    "workos_session=; Path=/; Expires=Thu, 01 Jan 1970 00:00:00 GMT; HttpOnly; SameSite=Lax",
-    `workos_session=; ${domain} Path=/; Expires=Thu, 01 Jan 1970 00:00:00 GMT; HttpOnly; SameSite=Lax`,
-    "appSession=; Path=/; Expires=Thu, 01 Jan 1970 00:00:00 GMT; HttpOnly; SameSite=Lax",
-    `appSession=; ${domain} Path=/; Expires=Thu, 01 Jan 1970 00:00:00 GMT; HttpOnly; SameSite=Lax`,
-    "sessionType=; Path=/; Expires=Thu, 01 Jan 1970 00:00:00 GMT; SameSite=Lax",
-    `sessionType=; ${domain} Path=/; Expires=Thu, 01 Jan 1970 00:00:00 GMT; SameSite=Lax`,
-  ]);
+  if (domain) {
+    res.setHeader("Set-Cookie", [
+      "workos_session=; Path=/; Expires=Thu, 01 Jan 1970 00:00:00 GMT; HttpOnly; SameSite=Lax",
+      `workos_session=; ${domain} Path=/; Expires=Thu, 01 Jan 1970 00:00:00 GMT; HttpOnly; SameSite=Lax`,
+      "appSession=; Path=/; Expires=Thu, 01 Jan 1970 00:00:00 GMT; HttpOnly; SameSite=Lax",
+      `appSession=; ${domain} Path=/; Expires=Thu, 01 Jan 1970 00:00:00 GMT; HttpOnly; SameSite=Lax`,
+      "sessionType=; Path=/; Expires=Thu, 01 Jan 1970 00:00:00 GMT; SameSite=Lax",
+      `sessionType=; ${domain} Path=/; Expires=Thu, 01 Jan 1970 00:00:00 GMT; SameSite=Lax`,
+    ]);
+  } else {
+    res.setHeader("Set-Cookie", [
+      "workos_session=; Path=/; Expires=Thu, 01 Jan 1970 00:00:00 GMT; HttpOnly; SameSite=Lax",
+      "appSession=; Path=/; Expires=Thu, 01 Jan 1970 00:00:00 GMT; HttpOnly; SameSite=Lax",
+      "sessionType=; Path=/; Expires=Thu, 01 Jan 1970 00:00:00 GMT; SameSite=Lax",
+    ]);
+  }
 
   res.redirect(returnTo as string);
 }

--- a/front/pages/api/workos/[action].ts
+++ b/front/pages/api/workos/[action].ts
@@ -12,7 +12,10 @@ import { checkUserRegionAffinity } from "@app/lib/api/regions/lookup";
 import { getWorkOS } from "@app/lib/api/workos/client";
 import { isOrganizationSelectionRequiredError } from "@app/lib/api/workos/types";
 import type { SessionCookie } from "@app/lib/api/workos/user";
-import { setRegionForUser } from "@app/lib/api/workos/user";
+import {
+  getDomainCookieClauseFromRequest,
+  setRegionForUser,
+} from "@app/lib/api/workos/user";
 import { getSession } from "@app/lib/auth";
 import { MembershipInvitationResource } from "@app/lib/resources/membership_invitation_resource";
 import logger from "@app/logger/logger";
@@ -300,10 +303,14 @@ async function handleLogout(req: NextApiRequest, res: NextApiResponse) {
     }
   }
 
+  const domain = getDomainCookieClauseFromRequest(req);
   res.setHeader("Set-Cookie", [
     "workos_session=; Path=/; Expires=Thu, 01 Jan 1970 00:00:00 GMT; HttpOnly; SameSite=Lax",
+    `workos_session=; ${domain} Path=/; Expires=Thu, 01 Jan 1970 00:00:00 GMT; HttpOnly; SameSite=Lax`,
     "appSession=; Path=/; Expires=Thu, 01 Jan 1970 00:00:00 GMT; HttpOnly; SameSite=Lax",
+    `appSession=; ${domain} Path=/; Expires=Thu, 01 Jan 1970 00:00:00 GMT; HttpOnly; SameSite=Lax`,
     "sessionType=; Path=/; Expires=Thu, 01 Jan 1970 00:00:00 GMT; SameSite=Lax",
+    `sessionType=; ${domain} Path=/; Expires=Thu, 01 Jan 1970 00:00:00 GMT; SameSite=Lax`,
   ]);
 
   res.redirect(returnTo as string);

--- a/front/pages/api/workos/[action].ts
+++ b/front/pages/api/workos/[action].ts
@@ -307,11 +307,14 @@ async function handleLogout(req: NextApiRequest, res: NextApiResponse) {
   if (domain) {
     res.setHeader("Set-Cookie", [
       "workos_session=; Path=/; Expires=Thu, 01 Jan 1970 00:00:00 GMT; HttpOnly; SameSite=Lax",
-      `workos_session=; ${domain} Path=/; Expires=Thu, 01 Jan 1970 00:00:00 GMT; HttpOnly; SameSite=Lax`,
+      `workos_session=; Domain=${domain}; Path=/; Expires=Thu, 01 Jan 1970 00:00:00 GMT; HttpOnly; SameSite=Lax`,
+      `workos_session=; Domain=.${domain}; Path=/; Expires=Thu, 01 Jan 1970 00:00:00 GMT; HttpOnly; SameSite=Lax`,
       "appSession=; Path=/; Expires=Thu, 01 Jan 1970 00:00:00 GMT; HttpOnly; SameSite=Lax",
-      `appSession=; ${domain} Path=/; Expires=Thu, 01 Jan 1970 00:00:00 GMT; HttpOnly; SameSite=Lax`,
+      `appSession=; Domain=${domain}; Path=/; Expires=Thu, 01 Jan 1970 00:00:00 GMT; HttpOnly; SameSite=Lax`,
+      `appSession=; Domain=.${domain}; Path=/; Expires=Thu, 01 Jan 1970 00:00:00 GMT; HttpOnly; SameSite=Lax`,
       "sessionType=; Path=/; Expires=Thu, 01 Jan 1970 00:00:00 GMT; SameSite=Lax",
-      `sessionType=; ${domain} Path=/; Expires=Thu, 01 Jan 1970 00:00:00 GMT; SameSite=Lax`,
+      `sessionType=; Domain=${domain}; Path=/; Expires=Thu, 01 Jan 1970 00:00:00 GMT; SameSite=Lax`,
+      `sessionType=; Domain=.${domain}; Path=/; Expires=Thu, 01 Jan 1970 00:00:00 GMT; SameSite=Lax`,
     ]);
   } else {
     res.setHeader("Set-Cookie", [


### PR DESCRIPTION
## Description

Some cookies may have been set with a specific domain while https://github.com/dust-tt/dust/pull/14615 was deployed, this is to ensure logout and invalid session properly remove all of them.
This clear the cookies with no domain (default), with `dust.tt` and `.dust.tt`

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

deploy front
