### PR TITLE
Make MCP client secret ID optional

### DIFF
--- a/core/src/oauth/credential.rs
+++ b/core/src/oauth/credential.rs
@@ -214,7 +214,7 @@ impl Credential {
                 vec!["client_id", "client_secret"]
             }
             CredentialProvider::Mcp => {
-                vec!["client_id", "client_secret"]
+                vec!["client_id"]
             }
             CredentialProvider::Notion => {
                 vec!["integration_token"]

--- a/front/lib/actions/mcp_oauth_provider.ts
+++ b/front/lib/actions/mcp_oauth_provider.ts
@@ -58,12 +58,6 @@ export class MCPOAuthProvider implements OAuthClientProvider {
       throw new Error("Metadata not found, unable to create an oauth flow.");
     }
 
-    if (!clientInformation.client_secret) {
-      throw new Error(
-        "Client secret not found, unable to create an oauth flow."
-      );
-    }
-
     const responseType = "code";
     const codeChallengeMethod = "S256";
 
@@ -88,7 +82,7 @@ export class MCPOAuthProvider implements OAuthClientProvider {
     // We pass the metadata to the client to allow them to handle the oauth flow.
     throw new MCPOAuthRequiredError({
       client_id: clientInformation.client_id,
-      client_secret: clientInformation.client_secret,
+      client_secret: clientInformation.client_secret || "",
       token_endpoint: this.metadata.token_endpoint,
       authorization_endpoint: this.metadata.authorization_endpoint,
     });

--- a/front/lib/api/oauth/providers/mcp.ts
+++ b/front/lib/api/oauth/providers/mcp.ts
@@ -28,7 +28,7 @@ const BaseMCPMetadataSchema = z.object({
 });
 
 const MCPOAuthConnectionMetadataSchema = BaseMCPMetadataSchema.extend({
-  client_secret: z.string(),
+  client_secret: z.string().optional(),
 });
 
 const MCPMetadataSchema = BaseMCPMetadataSchema.extend({
@@ -156,11 +156,17 @@ export class MCPOAuthProvider implements BaseOAuthStrategyProvider {
     } else if (useCase === "platform_actions") {
       const { client_secret } = extraConfig;
 
+      const content: { client_id: string; client_secret?: string } = {
+        client_id: extraConfig.client_id,
+      };
+
+      // Only include client_secret if it's provided
+      if (client_secret) {
+        content.client_secret = client_secret;
+      }
+
       return {
-        content: {
-          client_secret,
-          client_id: extraConfig.client_id,
-        },
+        content,
         metadata: { workspace_id: workspaceId, user_id: userId },
       };
     }


### PR DESCRIPTION
## Description

* Making client secret optional for mcp oauth
* Enables us to use Datadog remote MCP server with oauth (instead of header tokens)
* Datadog requires public client oauth (no client secret). PKCE provides security in lieu of client secret.
* If you attempt to add the MCP server today, it will show "client_secret missing" exception

## Tests

1. Validated can add Datadog MCP server using oauth
2. Validated can still add other MCP servers using oauth

## Risk

* Unforeseen consequences of removing client secret requirement

## Deploy Plan

1. Deploy core
3. Deploy front
