### PR TITLE
[front] Store citation count on `AgentMCPAction`, remove `citationsRefsOffset`

### DIFF
--- a/front/lib/actions/mcp.ts
+++ b/front/lib/actions/mcp.ts
@@ -557,6 +557,7 @@ export async function* runToolWithStreaming(
     executionState: "pending",
     version: 0,
     stepContentId,
+    citationsAllocated: stepContext.citationsCount,
   });
 
   const mcpAction = new MCPActionType({

--- a/front/lib/actions/mcp.ts
+++ b/front/lib/actions/mcp.ts
@@ -334,6 +334,7 @@ export class MCPActionType {
   readonly functionCallName: string | null;
   readonly step: number = -1;
   readonly isError: boolean = false;
+  readonly citationsAllocated: number = 0;
   // TODO(2025-07-24 aubin): remove the type here.
   readonly type = "tool_action" as const;
 
@@ -351,6 +352,7 @@ export class MCPActionType {
     this.functionCallId = blob.functionCallId;
     this.functionCallName = blob.functionCallName;
     this.step = blob.step;
+    this.citationsAllocated = blob.citationsAllocated;
   }
 
   getGeneratedFiles(): ActionGeneratedFileType[] {
@@ -527,6 +529,7 @@ export async function* runToolWithStreaming(
     mcpServerConfigurationId: `${actionConfiguration.id}`,
     params: rawInputs,
     step,
+    citationsAllocated: stepContext.citationsCount,
   };
 
   for (const value of Object.values(rawInputs)) {

--- a/front/lib/models/assistant/actions/mcp.ts
+++ b/front/lib/models/assistant/actions/mcp.ts
@@ -195,6 +195,8 @@ export class AgentMCPAction extends WorkspaceAwareModel<AgentMCPAction> {
     | "allowed_implicitly"
     | "denied";
 
+  declare citationsAllocated: number;
+
   declare outputItems: NonAttribute<AgentMCPActionOutputItem[]>;
   declare agentMessage?: NonAttribute<AgentMessage>;
 }
@@ -239,6 +241,11 @@ AgentMCPAction.init(
       type: DataTypes.BOOLEAN,
       allowNull: false,
       defaultValue: false,
+    },
+    citationsAllocated: {
+      type: DataTypes.INTEGER,
+      allowNull: false,
+      defaultValue: 0,
     },
   },
   {

--- a/front/lib/resources/agent_step_content_resource.ts
+++ b/front/lib/resources/agent_step_content_resource.ts
@@ -402,6 +402,7 @@ export class AgentStepContentResource extends BaseResource<AgentStepContentModel
               executionState: action.executionState,
               isError: action.isError,
               type: "tool_action",
+              citationsAllocated: action.citationsAllocated,
               generatedFiles: removeNulls(
                 action.outputItems.map((o) => {
                   if (!o.file) {

--- a/front/migrations/db/migration_322.sql
+++ b/front/migrations/db/migration_322.sql
@@ -1,0 +1,2 @@
+-- Migration created on Jul 29, 2025
+ALTER TABLE "public"."agent_mcp_actions" ADD COLUMN "citationsAllocated" INTEGER NOT NULL DEFAULT 0;

--- a/front/temporal/agent_loop/activities/run_model.ts
+++ b/front/temporal/agent_loop/activities/run_model.ts
@@ -62,7 +62,6 @@ export async function runModelActivity({
   runIds,
   step,
   functionCallStepContentIds,
-  citationsRefsOffset,
   autoRetryCount = 0,
 }: {
   authType: AuthenticatorType;
@@ -70,7 +69,6 @@ export async function runModelActivity({
   runIds: string[];
   step: number;
   functionCallStepContentIds: Record<string, ModelId>;
-  citationsRefsOffset: number;
   autoRetryCount?: number;
 }): Promise<{
   actions: AgentActionsEvent["actions"];
@@ -98,6 +96,12 @@ export async function runModelActivity({
       agentMessageVersion: originalAgentMessage.version,
       step,
     });
+
+  // Compute the citations offset by summing citations allocated to all past actions for this message.
+  const citationsRefsOffset = originalAgentMessage.actions.reduce(
+    (total, action) => total + (action.citationsAllocated || 0),
+    0
+  );
 
   const now = Date.now();
 
@@ -404,7 +408,6 @@ export async function runModelActivity({
         runIds,
         step,
         functionCallStepContentIds,
-        citationsRefsOffset,
         autoRetryCount: autoRetryCount + 1,
       });
     }

--- a/front/temporal/agent_loop/lib/agent_loop_executor.ts
+++ b/front/temporal/agent_loop/lib/agent_loop_executor.ts
@@ -20,9 +20,6 @@ export async function executeAgentLoop(
   activities: AgentLoopActivities,
   startStep: number
 ): Promise<void> {
-  // Citations references offset kept up to date across steps.
-  let citationsRefsOffset = 0;
-
   const runIds: string[] = [];
 
   // Track step content IDs by function call ID for later use in actions.
@@ -35,7 +32,6 @@ export async function executeAgentLoop(
       runIds,
       step: i,
       functionCallStepContentIds,
-      citationsRefsOffset,
       autoRetryCount: 0,
     });
 
@@ -64,12 +60,6 @@ export async function executeAgentLoop(
           stepContentId: functionCallStepContentIds[functionCallId],
         })
       )
-    );
-
-    // Update citations offset with pre-computed increment
-    citationsRefsOffset += stepContexts.reduce(
-      (acc, context) => acc + context.citationsCount,
-      0
     );
   }
 }


### PR DESCRIPTION
## Description

- Closes https://github.com/dust-tt/tasks/issues/3411.
- This PR adds a column `citationsAllocated` to `AgentMCPAction` that records the number of citations allocated to each action in order to remove the workflow state `citationsRefsOffset`, which can then be recomputed using the action.
- If carefully executed, it does not require a backfill: we can ship the bump in citation count from 2 characters to 3 with this PR, removing the need to account for citations used by past actions.

## Tests

## Risk

- Quite high, relies on a carefully executed deploy plan.

## Deploy Plan

- Run migration.
- Deploy front.
