### PR TITLE
Add script to cleanup Zendesk duplicate data

### DIFF
--- a/front/migrations/20250729_cleanup_zendesk_delta.ts
+++ b/front/migrations/20250729_cleanup_zendesk_delta.ts
@@ -102,16 +102,13 @@ function parseZendeskTicketNodeId(nodeId: string): {
   };
 }
 
-async function checkTicketsExistInConnectors(
-  {
-    connectorId,
-    ticketIds,
-  }: {
-    connectorId: number;
-    ticketIds: { brandId: number; ticketId: number }[];
-  },
-  logger: Logger
-): Promise<Set<string>> {
+async function checkTicketsExistInConnectors({
+  connectorId,
+  ticketIds,
+}: {
+  connectorId: number;
+  ticketIds: { brandId: number; ticketId: number }[];
+}): Promise<Set<string>> {
   const connectorsSequelize = getConnectorsPrimaryDbConnection();
 
   if (ticketIds.length === 0) {
@@ -134,10 +131,6 @@ async function checkTicketsExistInConnectors(
       },
       type: QueryTypes.SELECT,
     }
-  );
-
-  logger.info(
-    `Found ${existingTickets.length} existing tickets out of ${ticketIds.length} checked`
   );
 
   return new Set(existingTickets.map((t) => `${t.brandId}-${t.ticketId}`));
@@ -214,13 +207,10 @@ async function processTicketNodes(
   }));
 
   // Check which tickets exist in connectors db.
-  const existingTickets = await checkTicketsExistInConnectors(
-    {
-      connectorId,
-      ticketIds,
-    },
-    logger
-  );
+  const existingTickets = await checkTicketsExistInConnectors({
+    connectorId,
+    ticketIds,
+  });
 
   const nodesToDelete = parsedNodes.filter(({ parsed }) => {
     const ticketKey = `${parsed!.brandId}-${parsed!.ticketId}`;

--- a/front/migrations/20250729_cleanup_zendesk_delta.ts
+++ b/front/migrations/20250729_cleanup_zendesk_delta.ts
@@ -179,10 +179,17 @@ async function deleteNodeFromCore(
 
 async function processTicketNodes(
   nodes: ZendeskTicketNode[],
-  connectorId: number,
-  projectId: string,
-  dataSourceId: string,
-  execute: boolean,
+  {
+    connectorId,
+    projectId,
+    dataSourceId,
+    execute,
+  }: {
+    connectorId: number;
+    projectId: string;
+    dataSourceId: string;
+    execute: boolean;
+  },
   logger: Logger
 ): Promise<void> {
   // Parse all ticket IDs and validate their format.
@@ -306,10 +313,12 @@ makeScript(
       logger.info(`Processing batch ${index + 1}/${batches.length}`);
       await processTicketNodes(
         batch,
-        connectorId,
-        projectId,
-        dataSourceId,
-        execute,
+        {
+          connectorId,
+          projectId,
+          dataSourceId,
+          execute,
+        },
         logger
       );
     }

--- a/front/migrations/20250729_cleanup_zendesk_delta.ts
+++ b/front/migrations/20250729_cleanup_zendesk_delta.ts
@@ -1,0 +1,319 @@
+import type { Logger } from "pino";
+import { QueryTypes } from "sequelize";
+
+import config from "@app/lib/api/config";
+import {
+  getConnectorsPrimaryDbConnection,
+  getCorePrimaryDbConnection,
+} from "@app/lib/production_checks/utils";
+import { concurrentExecutor } from "@app/lib/utils/async_utils";
+import { makeScript } from "@app/scripts/helpers";
+import { CoreAPI } from "@app/types";
+
+const BATCH_SIZE = 256;
+const CONCURRENCY = 8;
+
+interface ZendeskTicketNode {
+  node_id: string;
+  id: number;
+}
+
+interface ConnectorTicket {
+  ticketId: number;
+  brandId: number;
+}
+
+async function getCoreDataSourceId(
+  {
+    projectId,
+    dataSourceId,
+  }: {
+    projectId: string;
+    dataSourceId: string;
+  },
+  logger: Logger
+): Promise<number | null> {
+  const coreSequelize = getCorePrimaryDbConnection();
+
+  // eslint-disable-next-line dust/no-raw-sql
+  const [row] = await coreSequelize.query<{ id: number }>(
+    `SELECT id FROM data_sources WHERE project = :projectId AND data_source_id = :dataSourceId`,
+    {
+      replacements: { projectId, dataSourceId },
+      type: QueryTypes.SELECT,
+    }
+  );
+
+  if (!row) {
+    logger.error("Core data source not found");
+    return null;
+  }
+
+  return row.id;
+}
+
+async function getZendeskTicketNodes(
+  { coreDataSourceId }: { coreDataSourceId: number },
+  logger: Logger
+): Promise<ZendeskTicketNode[]> {
+  const coreSequelize = getCorePrimaryDbConnection();
+  const nodes: ZendeskTicketNode[] = [];
+  let nextId = 0;
+
+  do {
+    // eslint-disable-next-line dust/no-raw-sql
+    const batch = await coreSequelize.query<ZendeskTicketNode>(
+      `SELECT id, node_id
+       FROM data_sources_nodes
+       WHERE data_source = :coreDataSourceId
+         AND node_id LIKE 'zendesk-ticket-%'
+         AND id > :nextId
+       ORDER BY id
+       LIMIT :batchSize`,
+      {
+        replacements: {
+          coreDataSourceId,
+          nextId,
+          batchSize: BATCH_SIZE,
+        },
+        type: QueryTypes.SELECT,
+      }
+    );
+
+    nodes.push(...batch);
+
+    if (batch.length === 0) {
+      break;
+    }
+
+    nextId = batch[batch.length - 1].id;
+    logger.info(`Found ${batch.length} ticket nodes (total: ${nodes.length})`);
+  } while (nodes.length % BATCH_SIZE === 0);
+
+  return nodes;
+}
+
+function parseZendeskTicketNodeId(nodeId: string): {
+  connectorId: number;
+  brandId: number;
+  ticketId: number;
+} | null {
+  // Expected format: zendesk-ticket-{connectorId}-{brandId}-{ticketId}.
+  const match = nodeId.match(/^zendesk-ticket-(\d+)-(\d+)-(\d+)$/);
+  if (!match) {
+    return null;
+  }
+
+  return {
+    connectorId: parseInt(match[1], 10),
+    brandId: parseInt(match[2], 10),
+    ticketId: parseInt(match[3], 10),
+  };
+}
+
+async function checkTicketsExistInConnectors(
+  {
+    connectorId,
+    ticketIds,
+  }: {
+    connectorId: number;
+    ticketIds: { brandId: number; ticketId: number }[];
+  },
+  logger: Logger
+): Promise<Set<string>> {
+  const connectorsSequelize = getConnectorsPrimaryDbConnection();
+
+  if (ticketIds.length === 0) {
+    return new Set();
+  }
+
+  const ticketPairs = ticketIds
+    .map((t) => `(${t.brandId}, ${t.ticketId})`)
+    .join(", ");
+
+  // eslint-disable-next-line dust/no-raw-sql
+  const existingTickets = await connectorsSequelize.query<ConnectorTicket>(
+    `SELECT "ticketId", "brandId" 
+     FROM zendesk_tickets 
+     WHERE "connectorId" = :connectorId 
+       AND ("brandId", "ticketId") IN (${ticketPairs})`,
+    {
+      replacements: {
+        connectorId,
+      },
+      type: QueryTypes.SELECT,
+    }
+  );
+
+  logger.info(
+    `Found ${existingTickets.length} existing tickets out of ${ticketIds.length} checked`
+  );
+
+  return new Set(existingTickets.map((t) => `${t.brandId}-${t.ticketId}`));
+}
+
+async function deleteNodeFromCore(
+  {
+    projectId,
+    dataSourceId,
+    nodeId,
+  }: {
+    projectId: string;
+    dataSourceId: string;
+    nodeId: string;
+  },
+  logger: Logger
+): Promise<void> {
+  const coreAPI = new CoreAPI(config.getCoreAPIConfig(), logger);
+
+  const result = await coreAPI.deleteDataSourceDocument({
+    projectId,
+    dataSourceId,
+    documentId: nodeId,
+  });
+
+  if (result.isErr()) {
+    throw new Error(`Failed to delete node ${nodeId}: ${result.error.message}`);
+  }
+}
+
+async function processTicketNodes(
+  nodes: ZendeskTicketNode[],
+  connectorId: number,
+  projectId: string,
+  dataSourceId: string,
+  execute: boolean,
+  logger: Logger
+): Promise<void> {
+  // Parse all ticket IDs and validate their format.
+  const parsedNodes = nodes
+    .map((node) => ({
+      node,
+      parsed: parseZendeskTicketNodeId(node.node_id),
+    }))
+    .filter(({ parsed, node }) => {
+      if (!parsed) {
+        logger.warn(`Invalid ticket node ID format: ${node.node_id}`);
+        return false;
+      }
+      if (parsed.connectorId !== connectorId) {
+        logger.warn(
+          `Node ${node.node_id} has connector ID ${parsed.connectorId}, expected ${connectorId}`
+        );
+        return false;
+      }
+      return true;
+    });
+
+  if (parsedNodes.length === 0) {
+    logger.info("No valid ticket nodes to process");
+    return;
+  }
+
+  const ticketIds = parsedNodes.map(({ parsed }) => ({
+    brandId: parsed!.brandId,
+    ticketId: parsed!.ticketId,
+  }));
+
+  // Check which tickets exist in connectors db.
+  const existingTickets = await checkTicketsExistInConnectors(
+    {
+      connectorId,
+      ticketIds,
+    },
+    logger
+  );
+
+  const nodesToDelete = parsedNodes.filter(({ parsed }) => {
+    const ticketKey = `${parsed!.brandId}-${parsed!.ticketId}`;
+    return !existingTickets.has(ticketKey);
+  });
+
+  logger.info(
+    `Found ${nodesToDelete.length} nodes to delete out of ${parsedNodes.length} total`
+  );
+
+  if (nodesToDelete.length === 0) {
+    return;
+  }
+
+  // Delete nodes that don't exist in connectors database
+  await concurrentExecutor(
+    nodesToDelete,
+    async ({ node, parsed }) => {
+      const nodeLogger = logger.child({
+        nodeId: node.node_id,
+        brandId: parsed!.brandId,
+        ticketId: parsed!.ticketId,
+      });
+
+      if (execute) {
+        await deleteNodeFromCore(
+          {
+            projectId,
+            dataSourceId,
+            nodeId: node.node_id,
+          },
+          nodeLogger
+        );
+        nodeLogger.info("Deleted node from core");
+      } else {
+        nodeLogger.info("Would delete node from core");
+      }
+    },
+    { concurrency: CONCURRENCY }
+  );
+}
+
+makeScript(
+  {
+    connectorId: { type: "number" },
+    projectId: { type: "string" },
+    dataSourceId: { type: "string" },
+  },
+  async ({ execute, connectorId, projectId, dataSourceId }, logger) => {
+    const coreDataSourceId = await getCoreDataSourceId(
+      {
+        projectId,
+        dataSourceId,
+      },
+      logger
+    );
+
+    if (!coreDataSourceId) {
+      return;
+    }
+
+    logger.info({ coreDataSourceId }, "Found core data source");
+
+    const ticketNodes = await getZendeskTicketNodes(
+      { coreDataSourceId },
+      logger
+    );
+    logger.info(`Found ${ticketNodes.length} zendesk ticket nodes in core`);
+
+    if (ticketNodes.length === 0) {
+      logger.info("No zendesk ticket nodes found");
+      return;
+    }
+
+    const batches = [];
+    for (let i = 0; i < ticketNodes.length; i += BATCH_SIZE) {
+      batches.push(ticketNodes.slice(i, i + BATCH_SIZE));
+    }
+
+    for (const [index, batch] of batches.entries()) {
+      logger.info(`Processing batch ${index + 1}/${batches.length}`);
+      await processTicketNodes(
+        batch,
+        connectorId,
+        projectId,
+        dataSourceId,
+        execute,
+        logger
+      );
+    }
+
+    logger.info("Cleanup completed");
+  }
+);

--- a/front/migrations/20250729_cleanup_zendesk_delta.ts
+++ b/front/migrations/20250729_cleanup_zendesk_delta.ts
@@ -52,10 +52,13 @@ async function getCoreDataSourceId(
   return row.id;
 }
 
-async function getZendeskTicketNodeBatch(
-  { coreDataSourceId, nextId }: { coreDataSourceId: number; nextId: number },
-  logger: Logger
-): Promise<{ hasMore: boolean; nextId: number; nodes: ZendeskTicketNode[] }> {
+async function getZendeskTicketNodeBatch({
+  coreDataSourceId,
+  nextId,
+}: {
+  coreDataSourceId: number;
+  nextId: number;
+}): Promise<{ hasMore: boolean; nextId: number; nodes: ZendeskTicketNode[] }> {
   const coreSequelize = getCorePrimaryDbConnection();
 
   // eslint-disable-next-line dust/no-raw-sql
@@ -78,7 +81,6 @@ async function getZendeskTicketNodeBatch(
   );
 
   nextId = nodes[nodes.length - 1].id;
-  logger.info(`Found ${nodes.length} ticket nodes (total: ${nodes.length})`);
   return { nodes, nextId, hasMore: nodes.length === BATCH_SIZE };
 }
 
@@ -286,10 +288,10 @@ makeScript(
     let hasMore = false;
 
     do {
-      const nodesResult = await getZendeskTicketNodeBatch(
-        { coreDataSourceId, nextId },
-        logger
-      );
+      const nodesResult = await getZendeskTicketNodeBatch({
+        coreDataSourceId,
+        nextId,
+      });
       nextId = nodesResult.nextId;
       hasMore = nodesResult.hasMore;
 

--- a/front/migrations/20250729_cleanup_zendesk_delta.ts
+++ b/front/migrations/20250729_cleanup_zendesk_delta.ts
@@ -228,7 +228,7 @@ async function processTicketNodes(
   });
 
   logger.info(
-    `Found ${nodesToDelete.length} nodes to delete out of ${parsedNodes.length} total`
+    `Found ${nodesToDelete.length} nodes to delete out of ${parsedNodes.length}.`
   );
 
   if (nodesToDelete.length === 0) {
@@ -296,7 +296,7 @@ makeScript(
       hasMore = nodesResult.hasMore;
 
       logger.info(
-        `Found ${nodesResult.nodes.length} zendesk ticket nodes in core`
+        `Found ${nodesResult.nodes.length} Zendesk ticket nodes in core.`
       );
 
       await processTicketNodes(

--- a/front/migrations/20250729_cleanup_zendesk_delta.ts
+++ b/front/migrations/20250729_cleanup_zendesk_delta.ts
@@ -228,7 +228,8 @@ async function processTicketNodes(
   });
 
   logger.info(
-    `Found ${nodesToDelete.length} nodes to delete out of ${parsedNodes.length}.`
+    { nodesToDelete: nodesToDelete.length, nodesChecked: parsedNodes.length },
+    `Found nodes to delete.`
   );
 
   if (nodesToDelete.length === 0) {
@@ -296,7 +297,8 @@ makeScript(
       hasMore = nodesResult.hasMore;
 
       logger.info(
-        `Found ${nodesResult.nodes.length} Zendesk ticket nodes in core.`
+        { nodeCount: nodesResult.nodes.length },
+        `Found ticket nodes in core.`
       );
 
       await processTicketNodes(

--- a/front/migrations/20250729_cleanup_zendesk_delta.ts
+++ b/front/migrations/20250729_cleanup_zendesk_delta.ts
@@ -10,7 +10,7 @@ import { concurrentExecutor } from "@app/lib/utils/async_utils";
 import { makeScript } from "@app/scripts/helpers";
 import { CoreAPI } from "@app/types";
 
-const BATCH_SIZE = 256;
+const BATCH_SIZE = 512;
 const CONCURRENCY = 8;
 
 interface ZendeskTicketNode {


### PR DESCRIPTION
## Description

- We do have some delta between what's in `core` and `connectors` for Zendesk tickets.
- This delta seems to be incredibly old (so we can safely assume that there is no code path allowing this), the source of the issue is unclear.
- This PR adds a script that fetches the data from `core`, checks whether the tickets exist in `connectors` db and delete them if they don't.

## Tests

- Tested locally by deleting rows from connectors.

## Risk

## Deploy Plan

- No deploy.
