### PR TITLE
fix: return error if no message fit in context

### DIFF
--- a/front/lib/api/assistant/preprocessing.ts
+++ b/front/lib/api/assistant/preprocessing.ts
@@ -348,6 +348,12 @@ export async function renderConversationForModel(
     selected.shift();
   }
 
+  if (selected.length === 0) {
+    return new Err(
+      new Error("Context window exceeded: at least one message is required")
+    );
+  }
+
   logger.info(
     {
       workspaceId: conversation.owner.sId,


### PR DESCRIPTION
## Description

Some providers don't error on empty conversations, meaning that we end up looping in the void if we exceed context.
In some instances, we've had agent loops get close to the max 128 steps, probably only killed by a deployment.

## Tests

Local

## Risk

Low

## Deploy Plan

Deploy front