### PR TITLE
[front] - feat(AB v2): agent from YAML

### DIFF
--- a/front/components/agent_builder/types.ts
+++ b/front/components/agent_builder/types.ts
@@ -105,6 +105,16 @@ export const MCP_SERVER_TO_ACTION_TYPE_MAP: Record<
   query_tables: "QUERY_TABLES",
 } as const;
 
+export const ACTION_TYPE_TO_MCP_SERVER_MAP: Record<
+  SupportedAgentBuilderActionType,
+  AgentBuilderMCPServerName
+> = {
+  EXTRACT_DATA: "extract_data",
+  SEARCH: "search",
+  INCLUDE_DATA: "include_data",
+  QUERY_TABLES: "query_tables",
+} as const;
+
 // Legacy alias for backward compatibility
 export const KNOWLEDGE_SERVER_NAMES = AGENT_BUILDER_MCP_SERVERS;
 export type KnowledgeServerName = AgentBuilderMCPServerName;

--- a/front/pages/w/[wId]/builder/agents/create.tsx
+++ b/front/pages/w/[wId]/builder/agents/create.tsx
@@ -26,12 +26,7 @@ import { getFeatureFlags } from "@app/lib/auth";
 import { isRestrictedFromAgentCreation } from "@app/lib/auth";
 import { withDefaultUserAuthRequirements } from "@app/lib/iam/session";
 import { useAssistantTemplates } from "@app/lib/swr/assistants";
-import type {
-  SubscriptionType,
-  TemplateTagCodeType,
-  TemplateTagsType,
-  WorkspaceType,
-} from "@app/types";
+import type { SubscriptionType, TemplateTagCodeType, TemplateTagsType, WorkspaceType } from "@app/types";
 import { isTemplateTagCodeArray, TEMPLATES_TAGS_CONFIG } from "@app/types";
 
 export const getServerSideProps = withDefaultUserAuthRequirements<{
@@ -205,7 +200,6 @@ export default function CreateAgent({
       // Clear the file input
       event.target.value = "";
     } catch (error) {
-      console.error("Error uploading YAML:", error);
       sendNotification({
         title: "Error creating agent",
         description:

--- a/front/pages/w/[wId]/builder/agents/create.tsx
+++ b/front/pages/w/[wId]/builder/agents/create.tsx
@@ -6,6 +6,7 @@ import {
   Page,
   PencilSquareIcon,
   SearchInput,
+  FolderOpenIcon,
 } from "@dust-tt/sparkle";
 import type { InferGetServerSidePropsType } from "next";
 import { useRouter } from "next/router";
@@ -20,6 +21,7 @@ import { AppCenteredLayout } from "@app/components/sparkle/AppCenteredLayout";
 import { appLayoutBack } from "@app/components/sparkle/AppContentLayout";
 import { AppLayoutSimpleCloseTitle } from "@app/components/sparkle/AppLayoutTitle";
 import AppRootLayout from "@app/components/sparkle/AppRootLayout";
+import { useSendNotification } from "@app/hooks/useNotification";
 import { getFeatureFlags } from "@app/lib/auth";
 import { isRestrictedFromAgentCreation } from "@app/lib/auth";
 import { withDefaultUserAuthRequirements } from "@app/lib/iam/session";
@@ -86,6 +88,8 @@ export default function CreateAgent({
   const [selectedTemplateId, setSelectedTemplateId] = useState<string | null>(
     (router.query.templateId as string) ?? null
   );
+  const [isUploadingYAML, setIsUploadingYAML] = useState(false);
+  const sendNotification = useSendNotification();
 
   const { assistantTemplates } = useAssistantTemplates();
 
@@ -146,6 +150,73 @@ export default function CreateAgent({
     );
   };
 
+  const handleYAMLUpload = async (
+    event: React.ChangeEvent<HTMLInputElement>
+  ) => {
+    const file = event.target.files?.[0];
+    if (!file) {
+      return;
+    }
+
+    if (!file.name.endsWith(".yaml") && !file.name.endsWith(".yml")) {
+      sendNotification({
+        title: "Invalid file type",
+        description: "Please select a YAML file (.yaml or .yml)",
+        type: "error",
+      });
+      return;
+    }
+
+    setIsUploadingYAML(true);
+    try {
+      const yamlContent = await file.text();
+
+      const response = await fetch(
+        `/api/w/${owner.sId}/assistant/agent_configurations/new/yaml`,
+        {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+          },
+          body: JSON.stringify({ yamlContent }),
+        }
+      );
+
+      if (!response.ok) {
+        const errorData = await response.json();
+        throw new Error(
+          errorData.error?.message || "Failed to create agent from YAML"
+        );
+      }
+
+      const result = await response.json();
+
+      sendNotification({
+        title: "Agent created successfully",
+        description: `Agent "${result.agentConfiguration.name}" was created from YAML`,
+        type: "success",
+      });
+
+      // Redirect to the newly created agent
+      await router.push(
+        `/w/${owner.sId}/builder/agents/${result.agentConfiguration.sId}`
+      );
+
+      // Clear the file input
+      event.target.value = "";
+    } catch (error) {
+      console.error("Error uploading YAML:", error);
+      sendNotification({
+        title: "Error creating agent",
+        description:
+          error instanceof Error ? error.message : "Unknown error occurred",
+        type: "error",
+      });
+    } finally {
+      setIsUploadingYAML(false);
+    }
+  };
+
   return (
     <AppCenteredLayout
       subscription={subscription}
@@ -172,15 +243,33 @@ export default function CreateAgent({
                 />
                 <Page.Header title="Start new" />
               </div>
-              <Button
-                icon={DocumentIcon}
-                label="New Agent"
-                data-gtm-label="assistantCreationButton"
-                data-gtm-location="assistantCreationPage"
-                size="md"
-                variant="highlight"
-                href={`/w/${owner.sId}/builder/agents/new`}
-              />
+              <div className="flex flex-row gap-3">
+                <Button
+                  icon={DocumentIcon}
+                  label="New Agent"
+                  data-gtm-label="assistantCreationButton"
+                  data-gtm-location="assistantCreationPage"
+                  size="md"
+                  variant="highlight"
+                  href={`/w/${owner.sId}/builder/agents/new`}
+                />
+                <Button
+                  icon={FolderOpenIcon}
+                  label={isUploadingYAML ? "Uploading..." : "Upload from YAML"}
+                  data-gtm-label="yamlUploadButton"
+                  data-gtm-location="assistantCreationPage"
+                  size="md"
+                  variant="outline"
+                  disabled={isUploadingYAML}
+                  onClick={() => {
+                    const input = document.createElement("input");
+                    input.type = "file";
+                    input.accept = ".yaml,.yml";
+                    input.onchange = (e) => handleYAMLUpload(e as any);
+                    input.click();
+                  }}
+                />
+              </div>
             </div>
 
             <Page.Separator />

--- a/front/pages/w/[wId]/builder/agents/create.tsx
+++ b/front/pages/w/[wId]/builder/agents/create.tsx
@@ -1,12 +1,12 @@
 import {
   Button,
   DocumentIcon,
+  FolderOpenIcon,
   Icon,
   MagicIcon,
   Page,
   PencilSquareIcon,
   SearchInput,
-  FolderOpenIcon,
 } from "@dust-tt/sparkle";
 import type { InferGetServerSidePropsType } from "next";
 import { useRouter } from "next/router";
@@ -26,7 +26,12 @@ import { getFeatureFlags } from "@app/lib/auth";
 import { isRestrictedFromAgentCreation } from "@app/lib/auth";
 import { withDefaultUserAuthRequirements } from "@app/lib/iam/session";
 import { useAssistantTemplates } from "@app/lib/swr/assistants";
-import type { SubscriptionType, TemplateTagCodeType, TemplateTagsType, WorkspaceType } from "@app/types";
+import type {
+  SubscriptionType,
+  TemplateTagCodeType,
+  TemplateTagsType,
+  WorkspaceType,
+} from "@app/types";
 import { isTemplateTagCodeArray, TEMPLATES_TAGS_CONFIG } from "@app/types";
 
 export const getServerSideProps = withDefaultUserAuthRequirements<{
@@ -145,10 +150,9 @@ export default function CreateAgent({
     );
   };
 
-  const handleYAMLUpload = async (
-    event: React.ChangeEvent<HTMLInputElement>
-  ) => {
-    const file = event.target.files?.[0];
+  const handleYAMLUpload = async (event: Event) => {
+    const target = event.target as HTMLInputElement;
+    const file = target.files?.[0];
     if (!file) {
       return;
     }
@@ -198,7 +202,7 @@ export default function CreateAgent({
       );
 
       // Clear the file input
-      event.target.value = "";
+      target.value = "";
     } catch (error) {
       sendNotification({
         title: "Error creating agent",
@@ -259,7 +263,7 @@ export default function CreateAgent({
                     const input = document.createElement("input");
                     input.type = "file";
                     input.accept = ".yaml,.yml";
-                    input.onchange = (e) => handleYAMLUpload(e);
+                    input.onchange = handleYAMLUpload;
                     input.click();
                   }}
                 />

--- a/front/pages/w/[wId]/builder/agents/create.tsx
+++ b/front/pages/w/[wId]/builder/agents/create.tsx
@@ -259,7 +259,7 @@ export default function CreateAgent({
                     const input = document.createElement("input");
                     input.type = "file";
                     input.accept = ".yaml,.yml";
-                    input.onchange = (e) => handleYAMLUpload(e as any);
+                    input.onchange = (e) => handleYAMLUpload(e);
                     input.click();
                   }}
                 />


### PR DESCRIPTION
## Description

Implements functionality to create agents from YAML files, allowing users to upload YAML configurations that get converted into MCP server configurations. The YAML action to MCP server configuration conversion handles different action types and provides proper validation with detailed error messages.

## Tests

Locally with the below file:

<details>
<summary>Expand YAML</summary>

```yaml
agent:
  avatar_url: https://dust.tt/static/emojis/bg-gray-100/heart_eyes/1f60d
  description: DataBroExtract
  handle: DataBroExtract
  max_steps_per_run: 10
  scope: visible
  visualization_enabled: true
editors:
  - email: jules@dust.tt
    full_name: Jules Belveze
    user_id: HO4B1MwSPk
generation_settings:
  model_id: gpt-4o
  provider_id: openai
  reasoning_effort: none
  temperature: 0.7
instructions: |
  Write a configuration with what I'm telling you bro
metadata:
  agent_id: 9kt53oIZGk
  created_by: HO4B1MwSPk
  last_modified: "2025-07-21T14:32:36.665Z"
  version: "7"
tags: []
toolset:
  - configuration:
      data_sources:
        dsv_VZXFmQUYye:
          is_select_all: false
          selected_resources:
            - gdrive-0AHg4obkq7gi_Uk9PVA
            - gdrive-0ALwIjTgiwbvYUk9PVA
          tags_filter: null
          view_id: dsv_VZXFmQUYye
    description: data
    id: msv_HbVDtNjDoS
    name: search
    type: SEARCH
  - configuration:
      data_sources:
        dsv_VZXFmQUYye:
          is_select_all: true
          selected_resources: []
          tags_filter: null
          view_id: dsv_VZXFmQUYye
      json_schema: null
      time_frame: null
    description: data
    id: msv_xioeCy7ILT
    name: Extract Data
    type: EXTRACT_DATA
  - configuration: {}
    description: Generate a data visualization.
    id: "1"
    name: data_visualization
    type: DATA_VISUALIZATION

```

</details>

## Risk

Low, behind FF

## Deploy Plan

Deploy front