### PR TITLE
Add script to cleanup Zendesk dangling data

### DIFF
--- a/front/migrations/20250729_cleanup_zendesk_old_format.ts
+++ b/front/migrations/20250729_cleanup_zendesk_old_format.ts
@@ -1,0 +1,206 @@
+import type { Logger } from "pino";
+import { QueryTypes } from "sequelize";
+
+import config from "@app/lib/api/config";
+import { getCorePrimaryDbConnection } from "@app/lib/production_checks/utils";
+import { concurrentExecutor } from "@app/lib/utils/async_utils";
+import { makeScript } from "@app/scripts/helpers";
+import { CoreAPI } from "@app/types";
+import { DataSourceResource } from "@app/lib/resources/data_source_resource";
+
+const BATCH_SIZE = 512;
+const CONCURRENCY = 8;
+
+interface ZendeskTicketNode {
+  node_id: string;
+  id: number;
+}
+
+async function getCoreDataSourceId(
+  {
+    projectId,
+    dataSourceId,
+  }: {
+    projectId: string;
+    dataSourceId: string;
+  },
+  logger: Logger
+): Promise<number | null> {
+  const coreSequelize = getCorePrimaryDbConnection();
+
+  // eslint-disable-next-line dust/no-raw-sql
+  const [row] = await coreSequelize.query<{ id: number }>(
+    `SELECT id
+     FROM data_sources
+     WHERE project = :projectId
+       AND data_source_id = :dataSourceId`,
+    {
+      replacements: { projectId, dataSourceId },
+      type: QueryTypes.SELECT,
+    }
+  );
+
+  if (!row) {
+    logger.error("Core data source not found");
+    return null;
+  }
+
+  return row.id;
+}
+
+async function getZendeskTicketNodeBatch({
+  coreDataSourceId,
+  nextId,
+}: {
+  coreDataSourceId: number;
+  nextId: number;
+}): Promise<{ hasMore: boolean; nextId: number; nodes: ZendeskTicketNode[] }> {
+  const coreSequelize = getCorePrimaryDbConnection();
+
+  // eslint-disable-next-line dust/no-raw-sql
+  const nodes = await coreSequelize.query<ZendeskTicketNode>(
+    `SELECT id, node_id
+     FROM data_sources_nodes
+     WHERE data_source = :coreDataSourceId
+       AND node_id NOT LIKE 'zendesk-ticket-%-%-%'
+       AND id > :nextId
+     ORDER BY id
+     LIMIT :batchSize`,
+    {
+      replacements: {
+        coreDataSourceId,
+        nextId,
+        batchSize: BATCH_SIZE,
+      },
+      type: QueryTypes.SELECT,
+    }
+  );
+
+  nextId = nodes[nodes.length - 1].id;
+  return { nodes, nextId, hasMore: nodes.length === BATCH_SIZE };
+}
+
+async function deleteNodeFromCore(
+  {
+    projectId,
+    dataSourceId,
+    nodeId,
+  }: {
+    projectId: string;
+    dataSourceId: string;
+    nodeId: string;
+  },
+  logger: Logger
+): Promise<void> {
+  const coreAPI = new CoreAPI(config.getCoreAPIConfig(), logger);
+
+  const result = await coreAPI.deleteDataSourceDocument({
+    projectId,
+    dataSourceId,
+    documentId: nodeId,
+  });
+
+  if (result.isErr()) {
+    throw new Error(`Failed to delete node ${nodeId}: ${result.error.message}`);
+  }
+}
+
+async function processTicketNodes(
+  nodes: ZendeskTicketNode[],
+  {
+    projectId,
+    dataSourceId,
+    execute,
+  }: {
+    connectorId: number;
+    projectId: string;
+    dataSourceId: string;
+    execute: boolean;
+  },
+  logger: Logger
+): Promise<void> {
+  await concurrentExecutor(
+    nodes,
+    async ({ node_id }) => {
+      const nodeLogger = logger.child({
+        nodeId: node_id,
+      });
+
+      if (execute) {
+        await deleteNodeFromCore(
+          {
+            projectId,
+            dataSourceId,
+            nodeId: node_id,
+          },
+          nodeLogger
+        );
+        nodeLogger.info("Deleted node from core");
+      } else {
+        nodeLogger.info("Would delete node from core");
+      }
+    },
+    { concurrency: CONCURRENCY }
+  );
+}
+
+makeScript(
+  {
+    connectorId: { type: "number" },
+  },
+  async ({ execute, connectorId }, logger) => {
+    const dataSource = await DataSourceResource.model.findOne({
+      where: { connectorId },
+    });
+    if (!dataSource) {
+      logger.error("No data source found for connector ID");
+      return;
+    }
+    const { dustAPIProjectId: projectId, dustAPIDataSourceId: dataSourceId } =
+      dataSource;
+
+    const coreDataSourceId = await getCoreDataSourceId(
+      {
+        projectId,
+        dataSourceId,
+      },
+      logger
+    );
+
+    if (!coreDataSourceId) {
+      return;
+    }
+
+    logger.info({ coreDataSourceId }, "Found core data source");
+
+    let nextId = 0;
+    let hasMore = false;
+
+    do {
+      const nodesResult = await getZendeskTicketNodeBatch({
+        coreDataSourceId,
+        nextId,
+      });
+      nextId = nodesResult.nextId;
+      hasMore = nodesResult.hasMore;
+
+      logger.info(
+        { nodeCount: nodesResult.nodes.length },
+        `Found ticket nodes in core.`
+      );
+
+      await processTicketNodes(
+        nodesResult.nodes,
+        {
+          connectorId,
+          projectId,
+          dataSourceId,
+          execute,
+        },
+        logger
+      );
+    } while (hasMore);
+
+    logger.info("Cleanup completed");
+  }
+);

--- a/front/migrations/20250729_cleanup_zendesk_old_format.ts
+++ b/front/migrations/20250729_cleanup_zendesk_old_format.ts
@@ -62,6 +62,7 @@ async function getZendeskTicketNodeBatch({
     `SELECT id, node_id
      FROM data_sources_nodes
      WHERE data_source = :coreDataSourceId
+       AND node_id LIKE 'zendesk-ticket-%-%'
        AND node_id NOT LIKE 'zendesk-ticket-%-%-%'
        AND id > :nextId
      ORDER BY id

--- a/front/migrations/20250729_cleanup_zendesk_old_format.ts
+++ b/front/migrations/20250729_cleanup_zendesk_old_format.ts
@@ -3,10 +3,10 @@ import { QueryTypes } from "sequelize";
 
 import config from "@app/lib/api/config";
 import { getCorePrimaryDbConnection } from "@app/lib/production_checks/utils";
+import { DataSourceResource } from "@app/lib/resources/data_source_resource";
 import { concurrentExecutor } from "@app/lib/utils/async_utils";
 import { makeScript } from "@app/scripts/helpers";
 import { CoreAPI } from "@app/types";
-import { DataSourceResource } from "@app/lib/resources/data_source_resource";
 
 const BATCH_SIZE = 512;
 const CONCURRENCY = 8;

--- a/front/migrations/20250729_cleanup_zendesk_old_format.ts
+++ b/front/migrations/20250729_cleanup_zendesk_old_format.ts
@@ -61,7 +61,7 @@ async function getZendeskTicketNodeBatch({
   const nodes = await coreSequelize.query<ZendeskTicketNode>(
     `SELECT id, node_id
      FROM data_sources_nodes
-     WHERE data_source = :coreDataSourceId
+     WHERE data_source = :coreDataSourceId -- leverages the index (data_source, node_id)
        AND node_id LIKE 'zendesk-ticket-%-%'
        AND node_id NOT LIKE 'zendesk-ticket-%-%-%'
        AND id > :nextId


### PR DESCRIPTION
## Description

- Turns out we have tickets in core following the old format `zendesk-ticket-${connectorId}-${ticketId}`, which was changed since to `zendesk-ticket-${connectorId}-${brandId}-${ticketId}`.
- This data is dangling: it cannot be GC-ed by the connector and will live forever.
- This PR adds a script that cleans them up.

## Tests

- Tested locally (added altered `nodeIds` manually).

## Risk

- Low, well covered by the dry run.

## Deploy Plan

- No deploy.
