### PR TITLE
[front] Cleanup action types part 3

### DIFF
--- a/front/components/assistant/conversation/actions/AgentMessageActionsDrawer.tsx
+++ b/front/components/assistant/conversation/actions/AgentMessageActionsDrawer.tsx
@@ -11,10 +11,7 @@ import { MCPActionDetails } from "@app/components/actions/mcp/details/MCPActionD
 import type { MCPActionType } from "@app/lib/actions/mcp";
 import type { ActionProgressState } from "@app/lib/assistant/state/messageReducer";
 import { useConversationMessage } from "@app/lib/swr/conversations";
-import type {
-  LightAgentMessageType,
-  LightWorkspaceType,
-} from "@app/types";
+import type { LightAgentMessageType, LightWorkspaceType } from "@app/types";
 
 interface AgentMessageActionsDrawerProps {
   conversationId: string;

--- a/front/components/assistant/conversation/actions/AgentMessageActionsDrawer.tsx
+++ b/front/components/assistant/conversation/actions/AgentMessageActionsDrawer.tsx
@@ -8,10 +8,10 @@ import {
 } from "@dust-tt/sparkle";
 
 import { MCPActionDetails } from "@app/components/actions/mcp/details/MCPActionDetails";
+import type { MCPActionType } from "@app/lib/actions/mcp";
 import type { ActionProgressState } from "@app/lib/assistant/state/messageReducer";
 import { useConversationMessage } from "@app/lib/swr/conversations";
 import type {
-  AgentActionType,
   LightAgentMessageType,
   LightWorkspaceType,
 } from "@app/types";
@@ -45,7 +45,7 @@ export function AgentMessageActionsDrawer({
     fullAgentMessage?.type === "agent_message" ? fullAgentMessage.actions : [];
 
   const groupedActionsByStep = actions
-    ? actions.reduce<Record<number, AgentActionType[]>>((acc, current) => {
+    ? actions.reduce<Record<number, MCPActionType[]>>((acc, current) => {
         const currentStep = current.step + 1;
         return {
           ...acc,

--- a/front/lib/actions/mcp_actions.ts
+++ b/front/lib/actions/mcp_actions.ts
@@ -595,7 +595,7 @@ export async function tryListMCPTools(
     ...agentLoopListToolsContext.agentConfiguration.actions,
     ...(agentLoopListToolsContext.clientSideActionConfigurations ?? []),
     ...(jitServers ?? []),
-  ].filter(isMCPServerConfiguration);
+  ];
 
   // Discover all tools exposed by all available MCP servers.
   const results = await concurrentExecutor(

--- a/front/lib/api/assistant/citations.ts
+++ b/front/lib/api/assistant/citations.ts
@@ -1,12 +1,12 @@
 import { removeNulls } from "@dust-tt/client";
 
+import type { MCPActionType } from "@app/lib/actions/mcp";
 import {
   isSearchResultResourceType,
   isWebsearchResultResourceType,
 } from "@app/lib/actions/mcp_internal_actions/output_schemas";
 import { rand } from "@app/lib/utils/seeded_random";
 import type {
-  AgentActionType,
   AgentMessageType,
   CitationType,
   LightAgentMessageType,
@@ -48,7 +48,7 @@ export function citationMetaPrompt() {
 }
 
 export const getCitationsFromActions = (
-  actions: AgentActionType[]
+  actions: MCPActionType[]
 ): Record<string, CitationType> => {
   // MCP actions with search results.
   const searchResultsWithDocs = removeNulls(

--- a/front/lib/assistant/state/messageReducer.ts
+++ b/front/lib/assistant/state/messageReducer.ts
@@ -1,8 +1,11 @@
-import type { ToolNotificationEvent } from "@app/lib/actions/mcp";
+import type {
+  MCPActionType,
+  ToolNotificationEvent,
+} from "@app/lib/actions/mcp";
 import type { ProgressNotificationContentType } from "@app/lib/actions/mcp_internal_actions/output_schemas";
 import { getLightAgentMessageFromAgentMessage } from "@app/lib/api/assistant/citations";
 import type { AgentMessageEvents } from "@app/lib/api/assistant/streaming/types";
-import type { AgentActionType, ModelId } from "@app/types";
+import type { ModelId } from "@app/types";
 import { assertNever } from "@app/types";
 import type { LightAgentMessageType } from "@app/types/assistant/conversation";
 
@@ -11,7 +14,7 @@ export type AgentStateClassification = "thinking" | "acting" | "done";
 export type ActionProgressState = Map<
   ModelId,
   {
-    action: AgentActionType;
+    action: MCPActionType;
     progress?: ProgressNotificationContentType;
   }
 >;
@@ -33,7 +36,7 @@ type AgentMessageStateEventWithoutToolApproveExecution = Exclude<
 
 function updateMessageWithAction(
   m: LightAgentMessageType,
-  action: AgentActionType
+  action: MCPActionType
 ): LightAgentMessageType {
   return {
     ...m,

--- a/front/types/assistant/agent.ts
+++ b/front/types/assistant/agent.ts
@@ -1,4 +1,5 @@
 import type {
+  MCPActionType,
   MCPServerConfigurationType,
   MCPToolConfigurationType,
 } from "@app/lib/actions/mcp";
@@ -11,10 +12,7 @@ import type {
   ModelIdType,
   ModelProviderIdType,
 } from "@app/types/assistant/assistant";
-import type {
-  AgentActionType,
-  AgentMessageType,
-} from "@app/types/assistant/conversation";
+import type { AgentMessageType } from "@app/types/assistant/conversation";
 import type { ModelId } from "@app/types/shared/model_id";
 import type { TagType } from "@app/types/tag";
 import type { UserType } from "@app/types/user";
@@ -263,7 +261,7 @@ export type AgentActionSuccessEvent = {
   created: number;
   configurationId: string;
   messageId: string;
-  action: AgentActionType;
+  action: MCPActionType;
 };
 
 // Event sent to stop the generation.

--- a/front/types/assistant/conversation.ts
+++ b/front/types/assistant/conversation.ts
@@ -116,9 +116,7 @@ export function isUserMessageType(
 /**
  * Agent messages
  */
-export type ConfigurableAgentActionType = MCPActionType;
-
-export type AgentActionType = ConfigurableAgentActionType;
+export type AgentActionType = MCPActionType;
 
 export type AgentMessageStatus =
   | "created"

--- a/front/types/assistant/conversation.ts
+++ b/front/types/assistant/conversation.ts
@@ -116,8 +116,6 @@ export function isUserMessageType(
 /**
  * Agent messages
  */
-export type AgentActionType = MCPActionType;
-
 export type AgentMessageStatus =
   | "created"
   | "succeeded"
@@ -156,7 +154,7 @@ export type AgentMessageType = BaseAgentMessageType & {
   visibility: MessageVisibility;
   configuration: LightAgentConfigurationType;
   skipToolsValidation: boolean;
-  actions: AgentActionType[];
+  actions: MCPActionType[];
   rawContents: Array<{
     step: number;
     content: string;


### PR DESCRIPTION
## Description

- Third installment of https://github.com/dust-tt/dust/pull/14548.
- Part of https://github.com/dust-tt/tasks/issues/3586.
- This PR removes the type aliases `AgentActionType` and `ConfigurableAgentActionType` (all directly mapping to `MCPActionType`).
- The next steps would be to move types out of `lib/actions/mcp.ts` and to turn `MCPActionType` into an actual type, consolidating rendering logic into the resource.

## Tests

- `tsc`

## Risk

- N/A.

## Deploy Plan

- Deploy front.
