### PR TITLE
[connectors] - fix(slack bot): add company space by default

### DIFF
--- a/connectors/src/connectors/slack/lib/cli.ts
+++ b/connectors/src/connectors/slack/lib/cli.ts
@@ -294,7 +294,11 @@ export const slack = async ({
       );
 
       if (slackConfig) {
-        await slackConfig.whitelistBot(botName, [groupId], whitelistType);
+        // Handle groupId as either a single string or comma-separated string of group IDs
+        const groupIds = groupId.includes(",")
+          ? groupId.split(",").map((id) => id.trim())
+          : [groupId];
+        await slackConfig.whitelistBot(botName, groupIds, whitelistType);
       }
 
       return { success: true };

--- a/front/lib/api/poke/plugins/data_sources/slack_whitelist_bot.ts
+++ b/front/lib/api/poke/plugins/data_sources/slack_whitelist_bot.ts
@@ -109,7 +109,7 @@ export const slackWhitelistBotPlugin = createPlugin({
     }
 
     // Combine the selected group with the Workspace group (avoid duplicates)
-    const groupIds = [groupId];
+    const groupIds: string[] = [groupId];
     if (workspaceGroupRes.value.sId !== groupId) {
       groupIds.push(workspaceGroupRes.value.sId);
     }

--- a/front/lib/api/poke/plugins/data_sources/slack_whitelist_bot.ts
+++ b/front/lib/api/poke/plugins/data_sources/slack_whitelist_bot.ts
@@ -101,6 +101,19 @@ export const slackWhitelistBotPlugin = createPlugin({
       );
     }
 
+    // Always include the Workspace (global) group
+    const workspaceGroupRes =
+      await GroupResource.fetchWorkspaceGlobalGroup(auth);
+    if (workspaceGroupRes.isErr()) {
+      return new Err(new Error("Failed to fetch workspace global group"));
+    }
+
+    // Combine the selected group with the Workspace group (avoid duplicates)
+    const groupIds = [groupId];
+    if (workspaceGroupRes.value.sId !== groupId) {
+      groupIds.push(workspaceGroupRes.value.sId);
+    }
+
     const connectorsAPI = new ConnectorsAPI(
       config.getConnectorsAPIConfig(),
       logger
@@ -112,7 +125,7 @@ export const slackWhitelistBotPlugin = createPlugin({
       args: {
         botName,
         wId: owner.sId,
-        groupId,
+        groupId: groupIds.join(","),
         whitelistType,
         providerType: resource.connectorProvider,
       },
@@ -134,7 +147,7 @@ export const slackWhitelistBotPlugin = createPlugin({
       display: "textWithLink",
       value:
         `Successfully whitelisted Slack bot "${botName}" for ${whitelistType} in the ` +
-        "selected group.",
+        "selected group and the Workspace group.",
       link: metabaseUrl,
       linkText: "View all whitelisted bots for this workspace",
     });


### PR DESCRIPTION
## Description

Fix an issue where whitelisting a Slack bot for summon_agent would ignore the specified group parameter. When whitelisting a bot or workflow, we now ensure the Workspace (global) group is always included alongside any explicitly selected group to maintain proper access controls.

**References:**
- [Slack thread](https://dust4ai.slack.com/archives/C050SM8NSPK/p1753784662094549?thread_ts=1753738296.325249&cid=C050SM8NSPK)

## Tests

Locally

## Risk

Important as it touches permissions.

## Deploy Plan

- Deploy front
- Deploy connectors
