### PR TITLE
Fix: slack activities stuck

### DIFF
--- a/connectors/src/connectors/slack/temporal/activities.ts
+++ b/connectors/src/connectors/slack/temporal/activities.ts
@@ -1010,7 +1010,9 @@ export async function getChannel(
 ): Promise<Channel> {
   const slackClient = await getSlackClient(connectorId);
 
-  return getChannelById(slackClient, connectorId, channelId);
+  return withSlackErrorHandling(() =>
+    getChannelById(slackClient, connectorId, channelId)
+  );
 }
 
 function getTagsForPage({

--- a/connectors/src/connectors/slack/temporal/client.ts
+++ b/connectors/src/connectors/slack/temporal/client.ts
@@ -243,6 +243,17 @@ export async function launchSlackGarbageCollectWorkflow(connectorId: ModelId) {
   if (!connector) {
     return new Err(new Error(`Connector ${connectorId} not found`));
   }
+
+  if (connector.isPaused()) {
+    logger.info(
+      {
+        connectorId: connector.id,
+      },
+      "Skipping webhook for Slack connector because it is paused (garbage collect)."
+    );
+    return new Ok(undefined);
+  }
+
   const client = await getTemporalClient();
 
   const workflowId = slackGarbageCollectorWorkflowId(connectorId);

--- a/connectors/src/connectors/slack/temporal/client.ts
+++ b/connectors/src/connectors/slack/temporal/client.ts
@@ -99,7 +99,7 @@ export async function launchSlackSyncOneThreadWorkflow(
       {
         connectorId: connector.id,
       },
-      "Skipping webhook for Slack connector because it is paused (thread sync)."
+      "Skipping Slack connector because it is paused (thread sync)."
     );
 
     return new Ok(undefined);

--- a/connectors/src/connectors/slack/temporal/workflows.ts
+++ b/connectors/src/connectors/slack/temporal/workflows.ts
@@ -200,6 +200,7 @@ export async function syncOneThreadDebounced(
       debounceCount++;
       continue;
     }
+
     const channel = await getSlackActivities().getChannel(
       connectorId,
       channelId


### PR DESCRIPTION
## Description

Small changes to fix stuck workflows.
- Wrap api call in getChannel activity with withSlackErrorHandling
- Do not launch garbage collector workflow if the connector is paused

## Risk

Low

## Deploy Plan

Deploy connectors.