### PR TITLE
[front] Add support for fetching a specific version of an agent

### DIFF
--- a/front/lib/api/assistant/configuration.ts
+++ b/front/lib/api/assistant/configuration.ts
@@ -415,6 +415,7 @@ async function fetchWorkspaceAgentConfigurationsWithoutActions(
         },
       });
     default:
+      // Variant where we have agent IDs and either fetch all versions or only the latest.
       if (typeof agentsGetView === "object" && "agentIds" in agentsGetView) {
         if (agentsGetView.allVersions) {
           return AgentConfiguration.findAll({
@@ -449,6 +450,7 @@ async function fetchWorkspaceAgentConfigurationsWithoutActions(
           order: [["version", "DESC"]],
         });
       }
+      // Variant where we have agent with specific versions.
       if (Array.isArray(agentsGetView)) {
         const workspaceAgents = agentsGetView.filter(
           (a) => !isGlobalAgentId(a.agentId)

--- a/front/lib/api/assistant/configuration.ts
+++ b/front/lib/api/assistant/configuration.ts
@@ -419,35 +419,10 @@ async function fetchWorkspaceAgentConfigurationsWithoutActions(
       });
     default:
       if (typeof agentsGetView === "object" && "agentIds" in agentsGetView) {
-        if (agentsGetView.allVersions) {
-          return AgentConfiguration.findAll({
-            where: {
-              workspaceId: owner.id,
-              sId: agentsGetView.agentIds.filter((id) => !isGlobalAgentId(id)),
-            },
-            order: [["version", "DESC"]],
-          });
-        }
-        const latestVersions = (await AgentConfiguration.findAll({
-          attributes: [
-            "sId",
-            [Sequelize.fn("MAX", Sequelize.col("version")), "max_version"],
-          ],
-          where: {
-            workspaceId: owner.id,
-            sId: agentsGetView.agentIds.filter((id) => !isGlobalAgentId(id)),
-          },
-          group: ["sId"],
-          raw: true,
-        })) as unknown as { sId: string; max_version: number }[];
-
         return AgentConfiguration.findAll({
           where: {
             workspaceId: owner.id,
-            [Op.or]: latestVersions.map((v) => ({
-              sId: v.sId,
-              version: v.max_version,
-            })),
+            sId: agentsGetView.agentIds.filter((id) => !isGlobalAgentId(id)),
           },
           order: [["version", "DESC"]],
         });

--- a/front/lib/api/assistant/configuration.ts
+++ b/front/lib/api/assistant/configuration.ts
@@ -380,11 +380,9 @@ async function getAgentConfigurationWithVersion<V extends AgentFetchVariant>(
 }
 
 /**
- * Get latest versions of multiple agents
+ * Get the latest versions of multiple agents.
  */
-export async function getAgentConfigurationsLatestVersion<
-  V extends AgentFetchVariant,
->(
+export async function getAgentConfigurations<V extends AgentFetchVariant>(
   auth: Authenticator,
   {
     agentIds,
@@ -396,7 +394,7 @@ export async function getAgentConfigurationsLatestVersion<
 ): Promise<
   V extends "full" ? AgentConfigurationType[] : LightAgentConfigurationType[]
 > {
-  return tracer.trace("getLatestVersionsForMultipleAgents", async () => {
+  return tracer.trace("getAgentConfigurations", async () => {
     const owner = auth.workspace();
     if (!owner || !auth.isUser()) {
       throw new Error("Unexpected `auth` without `workspace`.");
@@ -437,9 +435,6 @@ export async function getAgentConfigurationsLatestVersion<
   });
 }
 
-/**
- * Get an agent configuration (legacy function - now uses new functions)
- */
 export async function getAgentConfiguration<V extends AgentFetchVariant>(
   auth: Authenticator,
   {
@@ -459,7 +454,7 @@ export async function getAgentConfiguration<V extends AgentFetchVariant>(
         variant,
       });
     }
-    const [agent] = await getAgentConfigurationsLatestVersion(auth, {
+    const [agent] = await getAgentConfigurations(auth, {
       agentIds: [agentId],
       variant,
     });
@@ -491,7 +486,7 @@ export async function searchAgentConfigurationsByName(
     },
   });
   const r = removeNulls(
-    await getAgentConfigurationsLatestVersion(auth, {
+    await getAgentConfigurations(auth, {
       agentIds: agentConfigurations.map(({ sId }) => sId),
       variant: "light",
     })
@@ -870,7 +865,9 @@ async function fetchWorkspaceAgentConfigurationsForView(
   return agentConfigurationTypes;
 }
 
-export async function getAgentConfigurations<V extends AgentFetchVariant>({
+export async function getAgentConfigurationsForView<
+  V extends AgentFetchVariant,
+>({
   auth,
   agentsGetView,
   agentPrefix,

--- a/front/lib/api/assistant/configuration.ts
+++ b/front/lib/api/assistant/configuration.ts
@@ -419,10 +419,35 @@ async function fetchWorkspaceAgentConfigurationsWithoutActions(
       });
     default:
       if (typeof agentsGetView === "object" && "agentIds" in agentsGetView) {
-        return AgentConfiguration.findAll({
+        if (agentsGetView.allVersions) {
+          return AgentConfiguration.findAll({
+            where: {
+              workspaceId: owner.id,
+              sId: agentsGetView.agentIds.filter((id) => !isGlobalAgentId(id)),
+            },
+            order: [["version", "DESC"]],
+          });
+        }
+        const latestVersions = (await AgentConfiguration.findAll({
+          attributes: [
+            "sId",
+            [Sequelize.fn("MAX", Sequelize.col("version")), "max_version"],
+          ],
           where: {
             workspaceId: owner.id,
             sId: agentsGetView.agentIds.filter((id) => !isGlobalAgentId(id)),
+          },
+          group: ["sId"],
+          raw: true,
+        })) as unknown as { sId: string; max_version: number }[];
+
+        return AgentConfiguration.findAll({
+          where: {
+            workspaceId: owner.id,
+            [Op.or]: latestVersions.map((v) => ({
+              sId: v.sId,
+              version: v.max_version,
+            })),
           },
           order: [["version", "DESC"]],
         });

--- a/front/lib/api/assistant/configuration.ts
+++ b/front/lib/api/assistant/configuration.ts
@@ -453,13 +453,6 @@ function makeApplySortAndLimit(sort?: SortStrategyType, limit?: number) {
   };
 }
 
-export async function getLightAgentConfiguration(
-  auth: Authenticator,
-  agentId: string
-): Promise<LightAgentConfigurationType | null> {
-  return getAgentConfiguration(auth, { agentId, variant: "light" });
-}
-
 // Global agent configurations.
 
 function determineGlobalAgentIdsToFetch(
@@ -1638,6 +1631,13 @@ export async function updateAgentRequestedGroupIds(
   );
 
   return new Ok(updated[0] > 0);
+}
+
+export async function getLightAgentConfiguration(
+  auth: Authenticator,
+  agentId: string
+): Promise<LightAgentConfigurationType | null> {
+  return getAgentConfiguration(auth, { agentId, variant: "light" });
 }
 
 export async function getFullAgentConfiguration(

--- a/front/lib/api/assistant/configuration.ts
+++ b/front/lib/api/assistant/configuration.ts
@@ -465,12 +465,12 @@ export async function searchAgentConfigurationsByName(
       },
     },
   });
-  return removeNulls(
-    await getAgentConfigurations(auth, {
-      agentIds: agentConfigurations.map(({ sId }) => sId),
-      variant: "light",
-    })
-  );
+  const agents = await getAgentConfigurations(auth, {
+    agentIds: agentConfigurations.map(({ sId }) => sId),
+    variant: "light",
+  });
+
+  return removeNulls(agents);
 }
 
 function makeApplySortAndLimit(sort?: SortStrategyType, limit?: number) {

--- a/front/lib/api/assistant/conversation.ts
+++ b/front/lib/api/assistant/conversation.ts
@@ -401,10 +401,11 @@ export async function postUserMessage(
   const results = await Promise.all([
     getAgentConfigurations({
       auth,
-      agentsGetView: mentions
-        .filter(isAgentMention)
-        .map((mention) => mention.configurationId)
-        .map((id) => ({ agentId: id })),
+      agentsGetView: {
+        agentIds: mentions
+          .filter(isAgentMention)
+          .map((mention) => mention.configurationId),
+      },
       variant: "light",
     }),
     (() => {

--- a/front/lib/api/assistant/conversation.ts
+++ b/front/lib/api/assistant/conversation.ts
@@ -5,7 +5,7 @@ import type { Transaction } from "sequelize";
 import { runAgentLoop } from "@app/lib/api/assistant/agent";
 import { signalAgentUsage } from "@app/lib/api/assistant/agent_usage";
 import {
-  getAgentConfigurationsLatestVersion,
+  getAgentConfigurations,
   getFullAgentConfiguration,
   getLightAgentConfiguration,
 } from "@app/lib/api/assistant/configuration";
@@ -399,7 +399,7 @@ export async function postUserMessage(
   }
 
   const results = await Promise.all([
-    getAgentConfigurationsLatestVersion(auth, {
+    getAgentConfigurations(auth, {
       agentIds: mentions
         .filter(isAgentMention)
         .map((mention) => mention.configurationId),

--- a/front/lib/api/assistant/conversation.ts
+++ b/front/lib/api/assistant/conversation.ts
@@ -5,7 +5,7 @@ import type { Transaction } from "sequelize";
 import { runAgentLoop } from "@app/lib/api/assistant/agent";
 import { signalAgentUsage } from "@app/lib/api/assistant/agent_usage";
 import {
-  getAgentConfigurations,
+  getAgentConfigurationsLatestVersion,
   getFullAgentConfiguration,
   getLightAgentConfiguration,
 } from "@app/lib/api/assistant/configuration";
@@ -399,13 +399,10 @@ export async function postUserMessage(
   }
 
   const results = await Promise.all([
-    getAgentConfigurations({
-      auth,
-      agentsGetView: {
-        agentIds: mentions
-          .filter(isAgentMention)
-          .map((mention) => mention.configurationId),
-      },
+    getAgentConfigurationsLatestVersion(auth, {
+      agentIds: mentions
+        .filter(isAgentMention)
+        .map((mention) => mention.configurationId),
       variant: "light",
     }),
     (() => {

--- a/front/lib/api/assistant/conversation.ts
+++ b/front/lib/api/assistant/conversation.ts
@@ -401,11 +401,10 @@ export async function postUserMessage(
   const results = await Promise.all([
     getAgentConfigurations({
       auth,
-      agentsGetView: {
-        agentIds: mentions
-          .filter(isAgentMention)
-          .map((mention) => mention.configurationId),
-      },
+      agentsGetView: mentions
+        .filter(isAgentMention)
+        .map((mention) => mention.configurationId)
+        .map((id) => ({ agentId: id })),
       variant: "light",
     }),
     (() => {

--- a/front/lib/api/assistant/email_trigger.ts
+++ b/front/lib/api/assistant/email_trigger.ts
@@ -2,7 +2,7 @@ import { marked } from "marked";
 import sanitizeHtml from "sanitize-html";
 import { Op } from "sequelize";
 
-import { getAgentConfigurations } from "@app/lib/api/assistant/configuration";
+import { getAgentConfigurationsForView } from "@app/lib/api/assistant/configuration";
 import {
   createConversation,
   postNewContentFragment,
@@ -199,7 +199,7 @@ export async function emailAssistantMatcher({
     EmailTriggerError
   >
 > {
-  const agentConfigurations = await getAgentConfigurations({
+  const agentConfigurations = await getAgentConfigurationsForView({
     auth,
     agentsGetView: "list",
     variant: "light",

--- a/front/lib/api/assistant/feedback.ts
+++ b/front/lib/api/assistant/feedback.ts
@@ -200,11 +200,10 @@ export async function getAgentFeedbacks({
   const owner = auth.getNonNullableWorkspace();
 
   // Make sure the user has access to the agent
-  const agentConfiguration = await getAgentConfiguration(
-    auth,
-    agentConfigurationId,
-    "light"
-  );
+  const agentConfiguration = await getAgentConfiguration(auth, {
+    agentId: agentConfigurationId,
+    variant: "light",
+  });
   if (!agentConfiguration) {
     return new Err(new Error("agent_configuration_not_found"));
   }

--- a/front/lib/api/assistant/messages.ts
+++ b/front/lib/api/assistant/messages.ts
@@ -155,7 +155,9 @@ async function batchRenderAgentMessages<V extends RenderMessageVariant>(
       );
       const agents = await getAgentConfigurations({
         auth,
-        agentsGetView: { agentIds: [...agentConfigurationIds] },
+        agentsGetView: [...agentConfigurationIds].map((id) => ({
+          agentId: id,
+        })),
         variant: "extra_light",
       });
       if (agents.some((a) => !a)) {

--- a/front/lib/api/assistant/messages.ts
+++ b/front/lib/api/assistant/messages.ts
@@ -6,7 +6,7 @@ import {
   getDelimitersConfiguration,
 } from "@app/lib/api/assistant/agent_message_content_parser";
 import { getLightAgentMessageFromAgentMessage } from "@app/lib/api/assistant/citations";
-import { getAgentConfigurations } from "@app/lib/api/assistant/configuration";
+import { getAgentConfigurationsLatestVersion } from "@app/lib/api/assistant/configuration";
 import type { PaginationParams } from "@app/lib/api/pagination";
 import { Authenticator } from "@app/lib/auth";
 import { AgentStepContentModel } from "@app/lib/models/assistant/agent_step_content";
@@ -153,9 +153,8 @@ async function batchRenderAgentMessages<V extends RenderMessageVariant>(
         },
         new Set<string>()
       );
-      const agents = await getAgentConfigurations({
-        auth,
-        agentsGetView: { agentIds: [...agentConfigurationIds] },
+      const agents = await getAgentConfigurationsLatestVersion(auth, {
+        agentIds: [...agentConfigurationIds],
         variant: "extra_light",
       });
       if (agents.some((a) => !a)) {

--- a/front/lib/api/assistant/messages.ts
+++ b/front/lib/api/assistant/messages.ts
@@ -6,7 +6,7 @@ import {
   getDelimitersConfiguration,
 } from "@app/lib/api/assistant/agent_message_content_parser";
 import { getLightAgentMessageFromAgentMessage } from "@app/lib/api/assistant/citations";
-import { getAgentConfigurationsLatestVersion } from "@app/lib/api/assistant/configuration";
+import { getAgentConfigurations } from "@app/lib/api/assistant/configuration";
 import type { PaginationParams } from "@app/lib/api/pagination";
 import { Authenticator } from "@app/lib/auth";
 import { AgentStepContentModel } from "@app/lib/models/assistant/agent_step_content";
@@ -153,7 +153,7 @@ async function batchRenderAgentMessages<V extends RenderMessageVariant>(
         },
         new Set<string>()
       );
-      const agents = await getAgentConfigurationsLatestVersion(auth, {
+      const agents = await getAgentConfigurations(auth, {
         agentIds: [...agentConfigurationIds],
         variant: "extra_light",
       });

--- a/front/lib/api/assistant/messages.ts
+++ b/front/lib/api/assistant/messages.ts
@@ -155,9 +155,7 @@ async function batchRenderAgentMessages<V extends RenderMessageVariant>(
       );
       const agents = await getAgentConfigurations({
         auth,
-        agentsGetView: [...agentConfigurationIds].map((id) => ({
-          agentId: id,
-        })),
+        agentsGetView: { agentIds: [...agentConfigurationIds] },
         variant: "extra_light",
       });
       if (agents.some((a) => !a)) {

--- a/front/lib/api/assistant/participants.ts
+++ b/front/lib/api/assistant/participants.ts
@@ -1,6 +1,6 @@
 import { Op } from "sequelize";
 
-import { getAgentConfigurationsLatestVersion } from "@app/lib/api/assistant/configuration";
+import { getAgentConfigurations } from "@app/lib/api/assistant/configuration";
 import type { Authenticator } from "@app/lib/auth";
 import {
   AgentMessage,
@@ -43,7 +43,7 @@ async function fetchAllAgentsById(
   auth: Authenticator,
   agentConfigurationIds: string[]
 ): Promise<AgentParticipantType[]> {
-  const agents = await getAgentConfigurationsLatestVersion(auth, {
+  const agents = await getAgentConfigurations(auth, {
     agentIds: agentConfigurationIds,
     variant: "light",
   });

--- a/front/lib/api/assistant/participants.ts
+++ b/front/lib/api/assistant/participants.ts
@@ -45,7 +45,7 @@ async function fetchAllAgentsById(
 ): Promise<AgentParticipantType[]> {
   const agents = await getAgentConfigurations({
     auth,
-    agentsGetView: { agentIds: agentConfigurationIds },
+    agentsGetView: agentConfigurationIds.map((id) => ({ agentId: id })),
     variant: "light",
   });
 

--- a/front/lib/api/assistant/participants.ts
+++ b/front/lib/api/assistant/participants.ts
@@ -45,7 +45,7 @@ async function fetchAllAgentsById(
 ): Promise<AgentParticipantType[]> {
   const agents = await getAgentConfigurations({
     auth,
-    agentsGetView: agentConfigurationIds.map((id) => ({ agentId: id })),
+    agentsGetView: { agentIds: agentConfigurationIds },
     variant: "light",
   });
 

--- a/front/lib/api/assistant/participants.ts
+++ b/front/lib/api/assistant/participants.ts
@@ -1,6 +1,6 @@
 import { Op } from "sequelize";
 
-import { getAgentConfigurations } from "@app/lib/api/assistant/configuration";
+import { getAgentConfigurationsLatestVersion } from "@app/lib/api/assistant/configuration";
 import type { Authenticator } from "@app/lib/auth";
 import {
   AgentMessage,
@@ -43,9 +43,8 @@ async function fetchAllAgentsById(
   auth: Authenticator,
   agentConfigurationIds: string[]
 ): Promise<AgentParticipantType[]> {
-  const agents = await getAgentConfigurations({
-    auth,
-    agentsGetView: { agentIds: agentConfigurationIds },
+  const agents = await getAgentConfigurationsLatestVersion(auth, {
+    agentIds: agentConfigurationIds,
     variant: "light",
   });
 

--- a/front/lib/api/assistant/user_relation.ts
+++ b/front/lib/api/assistant/user_relation.ts
@@ -21,11 +21,10 @@ export async function setAgentUserFavorite({
     Error
   >
 > {
-  const agentConfiguration = await getAgentConfiguration(
-    auth,
+  const agentConfiguration = await getAgentConfiguration(auth, {
     agentId,
-    "light"
-  );
+    variant: "light",
+  });
   if (!agentConfiguration) {
     return new Err(new Error(`Could not find agent configuration ${agentId}`));
   }

--- a/front/lib/api/spaces.ts
+++ b/front/lib/api/spaces.ts
@@ -145,7 +145,7 @@ export async function softDeleteSpaceAndLaunchScrubWorkflow(
         async (agentId) => {
           const [agentConfig] = await getAgentConfigurations({
             auth,
-            agentsGetView: { agentIds: [agentId] },
+            agentsGetView: [{ agentId: agentId }],
             variant: "full",
             dangerouslySkipPermissionFiltering: true,
           });

--- a/front/lib/api/spaces.ts
+++ b/front/lib/api/spaces.ts
@@ -3,7 +3,7 @@ import { uniq } from "lodash";
 
 import { hardDeleteApp } from "@app/lib/api/apps";
 import {
-  getAgentConfigurations,
+  getAgentConfigurationsLatestVersion,
   updateAgentRequestedGroupIds,
 } from "@app/lib/api/assistant/configuration";
 import { getAgentConfigurationGroupIdsFromActions } from "@app/lib/api/assistant/permissions";
@@ -143,12 +143,11 @@ export async function softDeleteSpaceAndLaunchScrubWorkflow(
       await concurrentExecutor(
         agentIds,
         async (agentId) => {
-          const [agentConfig] = await getAgentConfigurations({
-            auth,
-            agentsGetView: { agentIds: [agentId] },
+          const agentConfigs = await getAgentConfigurationsLatestVersion(auth, {
+            agentIds: [agentId],
             variant: "full",
-            dangerouslySkipPermissionFiltering: true,
           });
+          const [agentConfig] = agentConfigs;
 
           // Get the required group IDs from the agent's actions
           const requestedGroupIds =

--- a/front/lib/api/spaces.ts
+++ b/front/lib/api/spaces.ts
@@ -3,7 +3,7 @@ import { uniq } from "lodash";
 
 import { hardDeleteApp } from "@app/lib/api/apps";
 import {
-  getAgentConfigurationsLatestVersion,
+  getAgentConfigurations,
   updateAgentRequestedGroupIds,
 } from "@app/lib/api/assistant/configuration";
 import { getAgentConfigurationGroupIdsFromActions } from "@app/lib/api/assistant/permissions";
@@ -143,7 +143,7 @@ export async function softDeleteSpaceAndLaunchScrubWorkflow(
       await concurrentExecutor(
         agentIds,
         async (agentId) => {
-          const agentConfigs = await getAgentConfigurationsLatestVersion(auth, {
+          const agentConfigs = await getAgentConfigurations(auth, {
             agentIds: [agentId],
             variant: "full",
           });

--- a/front/lib/api/spaces.ts
+++ b/front/lib/api/spaces.ts
@@ -145,7 +145,7 @@ export async function softDeleteSpaceAndLaunchScrubWorkflow(
         async (agentId) => {
           const [agentConfig] = await getAgentConfigurations({
             auth,
-            agentsGetView: [{ agentId: agentId }],
+            agentsGetView: { agentIds: [agentId] },
             variant: "full",
             dangerouslySkipPermissionFiltering: true,
           });

--- a/front/lib/resources/agent_step_content_resource.ts
+++ b/front/lib/resources/agent_step_content_resource.ts
@@ -11,7 +11,7 @@ import type {
 import { Op } from "sequelize";
 
 import { hideFileFromActionOutput, MCPActionType } from "@app/lib/actions/mcp";
-import { getAgentConfigurations } from "@app/lib/api/assistant/configuration";
+import { getAgentConfigurationsLatestVersion } from "@app/lib/api/assistant/configuration";
 import type { Authenticator } from "@app/lib/auth";
 import {
   AgentMCPAction,
@@ -77,11 +77,13 @@ export class AgentStepContentResource extends BaseResource<AgentStepContentModel
       ...new Set(agentMessages.map((a) => a.agentConfigurationId)),
     ];
     // Fetch agent configuration to check permissions
-    const agentConfigurations = await getAgentConfigurations({
+    const agentConfigurations = await getAgentConfigurationsLatestVersion(
       auth,
-      agentsGetView: { agentIds: uniqueAgentIds },
-      variant: "light",
-    });
+      {
+        agentIds: uniqueAgentIds,
+        variant: "light",
+      }
+    );
 
     if (agentConfigurations.length !== uniqueAgentIds.length) {
       logger.error(

--- a/front/lib/resources/agent_step_content_resource.ts
+++ b/front/lib/resources/agent_step_content_resource.ts
@@ -79,7 +79,7 @@ export class AgentStepContentResource extends BaseResource<AgentStepContentModel
     // Fetch agent configuration to check permissions
     const agentConfigurations = await getAgentConfigurations({
       auth,
-      agentsGetView: uniqueAgentIds.map((id) => ({ agentId: id })),
+      agentsGetView: { agentIds: uniqueAgentIds },
       variant: "light",
     });
 

--- a/front/lib/resources/agent_step_content_resource.ts
+++ b/front/lib/resources/agent_step_content_resource.ts
@@ -79,9 +79,7 @@ export class AgentStepContentResource extends BaseResource<AgentStepContentModel
     // Fetch agent configuration to check permissions
     const agentConfigurations = await getAgentConfigurations({
       auth,
-      agentsGetView: {
-        agentIds: uniqueAgentIds,
-      },
+      agentsGetView: uniqueAgentIds.map((id) => ({ agentId: id })),
       variant: "light",
     });
 

--- a/front/lib/resources/agent_step_content_resource.ts
+++ b/front/lib/resources/agent_step_content_resource.ts
@@ -11,7 +11,7 @@ import type {
 import { Op } from "sequelize";
 
 import { hideFileFromActionOutput, MCPActionType } from "@app/lib/actions/mcp";
-import { getAgentConfigurationsLatestVersion } from "@app/lib/api/assistant/configuration";
+import { getAgentConfigurations } from "@app/lib/api/assistant/configuration";
 import type { Authenticator } from "@app/lib/auth";
 import {
   AgentMCPAction,
@@ -77,13 +77,10 @@ export class AgentStepContentResource extends BaseResource<AgentStepContentModel
       ...new Set(agentMessages.map((a) => a.agentConfigurationId)),
     ];
     // Fetch agent configuration to check permissions
-    const agentConfigurations = await getAgentConfigurationsLatestVersion(
-      auth,
-      {
-        agentIds: uniqueAgentIds,
-        variant: "light",
-      }
-    );
+    const agentConfigurations = await getAgentConfigurations(auth, {
+      agentIds: uniqueAgentIds,
+      variant: "light",
+    });
 
     if (agentConfigurations.length !== uniqueAgentIds.length) {
       logger.error(

--- a/front/migrations/20250429_update_agent_scopes.ts
+++ b/front/migrations/20250429_update_agent_scopes.ts
@@ -69,7 +69,7 @@ const migrateWorkspace = async (
     if (previousScope === "workspace" && agent.status === "active") {
       const agentConfigs = await getAgentConfigurations({
         auth,
-        agentsGetView: { agentIds: [agent.sId] },
+        agentsGetView: [{ agentId: agent.sId }],
         variant: "light",
       });
       const agentConfig = agentConfigs[0];

--- a/front/migrations/20250429_update_agent_scopes.ts
+++ b/front/migrations/20250429_update_agent_scopes.ts
@@ -69,7 +69,7 @@ const migrateWorkspace = async (
     if (previousScope === "workspace" && agent.status === "active") {
       const agentConfigs = await getAgentConfigurations({
         auth,
-        agentsGetView: [{ agentId: agent.sId }],
+        agentsGetView: { agentIds: [agent.sId] },
         variant: "light",
       });
       const agentConfig = agentConfigs[0];

--- a/front/migrations/20250429_update_agent_scopes.ts
+++ b/front/migrations/20250429_update_agent_scopes.ts
@@ -1,6 +1,6 @@
 import type { Logger } from "pino";
 
-import { getAgentConfigurations } from "@app/lib/api/assistant/configuration";
+import { getAgentConfigurationsLatestVersion } from "@app/lib/api/assistant/configuration";
 import { Authenticator } from "@app/lib/auth";
 import { AgentConfiguration } from "@app/lib/models/assistant/agent";
 import { WorkspaceModel } from "@app/lib/resources/storage/models/workspace";
@@ -67,9 +67,8 @@ const migrateWorkspace = async (
     }
     // @ts-ignore
     if (previousScope === "workspace" && agent.status === "active") {
-      const agentConfigs = await getAgentConfigurations({
-        auth,
-        agentsGetView: { agentIds: [agent.sId] },
+      const agentConfigs = await getAgentConfigurationsLatestVersion(auth, {
+        agentIds: [agent.sId],
         variant: "light",
       });
       const agentConfig = agentConfigs[0];

--- a/front/migrations/20250429_update_agent_scopes.ts
+++ b/front/migrations/20250429_update_agent_scopes.ts
@@ -1,6 +1,6 @@
 import type { Logger } from "pino";
 
-import { getAgentConfigurationsLatestVersion } from "@app/lib/api/assistant/configuration";
+import { getAgentConfigurations } from "@app/lib/api/assistant/configuration";
 import { Authenticator } from "@app/lib/auth";
 import { AgentConfiguration } from "@app/lib/models/assistant/agent";
 import { WorkspaceModel } from "@app/lib/resources/storage/models/workspace";
@@ -67,7 +67,7 @@ const migrateWorkspace = async (
     }
     // @ts-ignore
     if (previousScope === "workspace" && agent.status === "active") {
-      const agentConfigs = await getAgentConfigurationsLatestVersion(auth, {
+      const agentConfigs = await getAgentConfigurations(auth, {
         agentIds: [agent.sId],
         variant: "light",
       });

--- a/front/migrations/20250725_backfill_agent_configurations.ts
+++ b/front/migrations/20250725_backfill_agent_configurations.ts
@@ -2,7 +2,7 @@ import * as _ from "lodash";
 import { Op } from "sequelize";
 
 import { isServerSideMCPServerConfiguration } from "@app/lib/actions/types/guards";
-import { getAgentConfigurationsLatestVersion } from "@app/lib/api/assistant/configuration";
+import { getAgentConfigurations } from "@app/lib/api/assistant/configuration";
 import { getAgentConfigurationGroupIdsFromActions } from "@app/lib/api/assistant/permissions";
 import { Authenticator } from "@app/lib/auth";
 import { AgentMCPServerConfiguration } from "@app/lib/models/assistant/actions/mcp";
@@ -28,13 +28,10 @@ async function updateAgentConfigurationGroupIds(
 ): Promise<{ updated: boolean; error?: string }> {
   try {
     // Get the full agent configuration with actions
-    const agentConfigurationList = await getAgentConfigurationsLatestVersion(
-      auth,
-      {
-        agentIds: [agent.sId],
-        variant: "full",
-      }
-    );
+    const agentConfigurationList = await getAgentConfigurations(auth, {
+      agentIds: [agent.sId],
+      variant: "full",
+    });
     const agentConfiguration = agentConfigurationList;
 
     if (!agentConfiguration[0]) {

--- a/front/migrations/20250725_backfill_agent_configurations.ts
+++ b/front/migrations/20250725_backfill_agent_configurations.ts
@@ -30,7 +30,7 @@ async function updateAgentConfigurationGroupIds(
     // Get the full agent configuration with actions
     const agentConfiguration = await getAgentConfigurations({
       auth,
-      agentsGetView: { agentIds: [agent.sId] },
+      agentsGetView: [{ agentId: agent.sId }],
       variant: "full",
       dangerouslySkipPermissionFiltering: true,
     });

--- a/front/migrations/20250725_backfill_agent_configurations.ts
+++ b/front/migrations/20250725_backfill_agent_configurations.ts
@@ -30,7 +30,7 @@ async function updateAgentConfigurationGroupIds(
     // Get the full agent configuration with actions
     const agentConfiguration = await getAgentConfigurations({
       auth,
-      agentsGetView: [{ agentId: agent.sId }],
+      agentsGetView: { agentIds: [agent.sId] },
       variant: "full",
       dangerouslySkipPermissionFiltering: true,
     });

--- a/front/migrations/20250725_backfill_agent_configurations.ts
+++ b/front/migrations/20250725_backfill_agent_configurations.ts
@@ -2,7 +2,7 @@ import * as _ from "lodash";
 import { Op } from "sequelize";
 
 import { isServerSideMCPServerConfiguration } from "@app/lib/actions/types/guards";
-import { getAgentConfigurations } from "@app/lib/api/assistant/configuration";
+import { getAgentConfigurationsLatestVersion } from "@app/lib/api/assistant/configuration";
 import { getAgentConfigurationGroupIdsFromActions } from "@app/lib/api/assistant/permissions";
 import { Authenticator } from "@app/lib/auth";
 import { AgentMCPServerConfiguration } from "@app/lib/models/assistant/actions/mcp";
@@ -28,12 +28,14 @@ async function updateAgentConfigurationGroupIds(
 ): Promise<{ updated: boolean; error?: string }> {
   try {
     // Get the full agent configuration with actions
-    const agentConfiguration = await getAgentConfigurations({
+    const agentConfigurationList = await getAgentConfigurationsLatestVersion(
       auth,
-      agentsGetView: { agentIds: [agent.sId] },
-      variant: "full",
-      dangerouslySkipPermissionFiltering: true,
-    });
+      {
+        agentIds: [agent.sId],
+        variant: "full",
+      }
+    );
+    const agentConfiguration = agentConfigurationList;
 
     if (!agentConfiguration[0]) {
       return { updated: false, error: "Agent configuration not found" };

--- a/front/pages/api/poke/workspaces/[wId]/agent_configurations/[aId]/export.ts
+++ b/front/pages/api/poke/workspaces/[wId]/agent_configurations/[aId]/export.ts
@@ -64,7 +64,10 @@ async function handler(
     });
   }
 
-  const agentConfiguration = await getAgentConfiguration(auth, aId, "full");
+  const agentConfiguration = await getAgentConfiguration(auth, {
+    agentId: aId,
+    variant: "full",
+  });
   if (!agentConfiguration) {
     return apiError(req, res, {
       status_code: 404,

--- a/front/pages/api/poke/workspaces/[wId]/agent_configurations/[aId]/index.ts
+++ b/front/pages/api/poke/workspaces/[wId]/agent_configurations/[aId]/index.ts
@@ -49,11 +49,10 @@ async function handler(
         });
       }
 
-      const agentConfiguration = await getAgentConfiguration(
-        auth,
-        req.query.aId as string,
-        "light"
-      );
+      const agentConfiguration = await getAgentConfiguration(auth, {
+        agentId: req.query.aId as string,
+        variant: "light",
+      });
       if (!agentConfiguration) {
         return apiError(req, res, {
           status_code: 404,

--- a/front/pages/api/poke/workspaces/[wId]/agent_configurations/[aId]/restore.ts
+++ b/front/pages/api/poke/workspaces/[wId]/agent_configurations/[aId]/restore.ts
@@ -49,11 +49,10 @@ async function handler(
         });
       }
 
-      const agentConfiguration = await getAgentConfiguration(
-        auth,
-        req.query.aId as string,
-        "light"
-      );
+      const agentConfiguration = await getAgentConfiguration(auth, {
+        agentId: req.query.aId as string,
+        variant: "light",
+      });
       if (!agentConfiguration) {
         return apiError(req, res, {
           status_code: 404,

--- a/front/pages/api/poke/workspaces/[wId]/agent_configurations/index.ts
+++ b/front/pages/api/poke/workspaces/[wId]/agent_configurations/index.ts
@@ -3,7 +3,7 @@ import * as t from "io-ts";
 import * as reporter from "io-ts-reporters";
 import type { NextApiRequest, NextApiResponse } from "next";
 
-import { getAgentConfigurations } from "@app/lib/api/assistant/configuration";
+import { getAgentConfigurationsForView } from "@app/lib/api/assistant/configuration";
 import { withSessionAuthenticationForPoke } from "@app/lib/api/auth_wrappers";
 import { Authenticator } from "@app/lib/auth";
 import type { SessionWithUser } from "@app/lib/iam/provider";
@@ -56,7 +56,7 @@ async function handler(
       const { view } = queryValidation.right;
       const viewParam = view;
 
-      const agentConfigurations = await getAgentConfigurations({
+      const agentConfigurations = await getAgentConfigurationsForView({
         auth,
         agentsGetView: viewParam,
         variant: "light",

--- a/front/pages/api/v1/w/[wId]/assistant/agent_configurations.ts
+++ b/front/pages/api/v1/w/[wId]/assistant/agent_configurations.ts
@@ -4,7 +4,7 @@ import * as t from "io-ts";
 import * as reporter from "io-ts-reporters";
 import type { NextApiRequest, NextApiResponse } from "next";
 
-import { getAgentConfigurations } from "@app/lib/api/assistant/configuration";
+import { getAgentConfigurationsForView } from "@app/lib/api/assistant/configuration";
 import { getAgentsRecentAuthors } from "@app/lib/api/assistant/recent_authors";
 import { withPublicAPIAuthentication } from "@app/lib/api/auth_wrappers";
 import type { Authenticator } from "@app/lib/auth";
@@ -127,7 +127,7 @@ async function handler(
       const agentsGetView = queryValidation.right.view ?? defaultAgentGetView;
       const withAuthors = queryValidation.right.withAuthors === "true";
 
-      let agentConfigurations = await getAgentConfigurations({
+      let agentConfigurations = await getAgentConfigurationsForView({
         auth,
         agentsGetView:
           agentsGetView === "workspace"

--- a/front/pages/api/w/[wId]/assistant/agent_configurations/[aId]/analytics.ts
+++ b/front/pages/api/w/[wId]/assistant/agent_configurations/[aId]/analytics.ts
@@ -54,11 +54,10 @@ async function handler(
   >,
   auth: Authenticator
 ): Promise<void> {
-  const assistant = await getAgentConfiguration(
-    auth,
-    req.query.aId as string,
-    "light"
-  );
+  const assistant = await getAgentConfiguration(auth, {
+    agentId: req.query.aId as string,
+    variant: "light",
+  });
 
   if (!assistant || (!assistant.canRead && !auth.isAdmin())) {
     return apiError(req, res, {

--- a/front/pages/api/w/[wId]/assistant/agent_configurations/[aId]/editors.ts
+++ b/front/pages/api/w/[wId]/assistant/agent_configurations/[aId]/editors.ts
@@ -59,11 +59,10 @@ async function handler(
 ): Promise<void> {
   const agentConfigurationId = req.query.aId as string;
 
-  const agent = await getAgentConfiguration(
-    auth,
-    agentConfigurationId,
-    "light"
-  );
+  const agent = await getAgentConfiguration(auth, {
+    agentId: agentConfigurationId,
+    variant: "light",
+  });
   if (!agent) {
     return apiError(req, res, {
       status_code: 404,

--- a/front/pages/api/w/[wId]/assistant/agent_configurations/[aId]/feedbacks.ts
+++ b/front/pages/api/w/[wId]/assistant/agent_configurations/[aId]/feedbacks.ts
@@ -32,7 +32,10 @@ async function handler(
   }
 
   // IMPORTANT: make sure the agent configuration is accessible by the user.
-  const agentConfiguration = await getAgentConfiguration(auth, aId, "light");
+  const agentConfiguration = await getAgentConfiguration(auth, {
+    agentId: aId,
+    variant: "light",
+  });
   if (!agentConfiguration) {
     return apiError(req, res, {
       status_code: 404,

--- a/front/pages/api/w/[wId]/assistant/agent_configurations/[aId]/history/index.ts
+++ b/front/pages/api/w/[wId]/assistant/agent_configurations/[aId]/history/index.ts
@@ -38,7 +38,10 @@ async function handler(
   }
 
   // Check that user has access to this agent
-  const assistant = await getAgentConfiguration(auth, aId, "light");
+  const assistant = await getAgentConfiguration(auth, {
+    agentId: aId,
+    variant: "light",
+  });
   if (!assistant || (!assistant.canRead && !auth.isAdmin())) {
     return apiError(req, res, {
       status_code: 404,

--- a/front/pages/api/w/[wId]/assistant/agent_configurations/[aId]/history/index.ts
+++ b/front/pages/api/w/[wId]/assistant/agent_configurations/[aId]/history/index.ts
@@ -77,8 +77,10 @@ async function handler(
 
       let agentConfigurations = await getAllVersionsForAgentConfiguration(
         auth,
-        aId,
-        "light"
+        {
+          agentId: aId,
+          variant: "light",
+        }
       );
 
       // Return the latest versions first (sort by version DESC, which is already done in getAllVersionsForOneAgent)

--- a/front/pages/api/w/[wId]/assistant/agent_configurations/[aId]/history/index.ts
+++ b/front/pages/api/w/[wId]/assistant/agent_configurations/[aId]/history/index.ts
@@ -4,7 +4,7 @@ import type { NextApiRequest, NextApiResponse } from "next";
 
 import {
   getAgentConfiguration,
-  getAllVersionsForAgentConfiguration,
+  listsAgentConfigurationVersions,
 } from "@app/lib/api/assistant/configuration";
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
 import type { Authenticator } from "@app/lib/auth";
@@ -75,13 +75,10 @@ async function handler(
 
       const { limit } = queryValidation.right;
 
-      let agentConfigurations = await getAllVersionsForAgentConfiguration(
-        auth,
-        {
-          agentId: aId,
-          variant: "light",
-        }
-      );
+      let agentConfigurations = await listsAgentConfigurationVersions(auth, {
+        agentId: aId,
+        variant: "light",
+      });
 
       // Return the latest versions first (sort by version DESC, which is already done in getAllVersionsForOneAgent)
       if (limit) {

--- a/front/pages/api/w/[wId]/assistant/agent_configurations/[aId]/history/index.ts
+++ b/front/pages/api/w/[wId]/assistant/agent_configurations/[aId]/history/index.ts
@@ -4,7 +4,7 @@ import type { NextApiRequest, NextApiResponse } from "next";
 
 import {
   getAgentConfiguration,
-  getAgentConfigurations,
+  getAllVersionsForAgentConfiguration,
 } from "@app/lib/api/assistant/configuration";
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
 import type { Authenticator } from "@app/lib/auth";
@@ -75,17 +75,16 @@ async function handler(
 
       const { limit } = queryValidation.right;
 
-      const agentConfigurations = await getAgentConfigurations({
+      let agentConfigurations = await getAllVersionsForAgentConfiguration(
         auth,
-        agentsGetView: {
-          agentIds: [aId],
-          allVersions: true,
-        },
-        variant: "light",
-        // Return the latest versions first
-        sort: "updatedAt",
-        limit,
-      });
+        aId,
+        "light"
+      );
+
+      // Return the latest versions first (sort by version DESC, which is already done in getAllVersionsForOneAgent)
+      if (limit) {
+        agentConfigurations = agentConfigurations.slice(0, limit);
+      }
 
       if (!agentConfigurations || !agentConfigurations[0].canRead) {
         return apiError(req, res, {

--- a/front/pages/api/w/[wId]/assistant/agent_configurations/[aId]/index.ts
+++ b/front/pages/api/w/[wId]/assistant/agent_configurations/[aId]/index.ts
@@ -33,11 +33,10 @@ async function handler(
   >,
   auth: Authenticator
 ): Promise<void> {
-  const agent = await getAgentConfiguration(
-    auth,
-    req.query.aId as string,
-    "full"
-  );
+  const agent = await getAgentConfiguration(auth, {
+    agentId: req.query.aId as string,
+    variant: "full",
+  });
   if (!agent || (!agent.canRead && !auth.isAdmin())) {
     return apiError(req, res, {
       status_code: 404,

--- a/front/pages/api/w/[wId]/assistant/agent_configurations/[aId]/last_author.ts
+++ b/front/pages/api/w/[wId]/assistant/agent_configurations/[aId]/last_author.ts
@@ -18,11 +18,10 @@ async function handler(
 ): Promise<void> {
   switch (req.method) {
     case "GET":
-      const agentConfiguration = await getAgentConfiguration(
-        auth,
-        req.query.aId as string,
-        "light"
-      );
+      const agentConfiguration = await getAgentConfiguration(auth, {
+        agentId: req.query.aId as string,
+        variant: "light",
+      });
       if (!agentConfiguration) {
         return apiError(req, res, {
           status_code: 404,

--- a/front/pages/api/w/[wId]/assistant/agent_configurations/[aId]/linked_slack_channels.ts
+++ b/front/pages/api/w/[wId]/assistant/agent_configurations/[aId]/linked_slack_channels.ts
@@ -87,11 +87,10 @@ async function handler(
   }
 
   const agentConfigurationSid = req.query.aId as string;
-  const agentConfiguration = await getAgentConfiguration(
-    auth,
-    agentConfigurationSid,
-    "light"
-  );
+  const agentConfiguration = await getAgentConfiguration(auth, {
+    agentId: agentConfigurationSid,
+    variant: "light",
+  });
   if (!agentConfiguration) {
     return apiError(req, res, {
       status_code: 404,

--- a/front/pages/api/w/[wId]/assistant/agent_configurations/[aId]/memories/[mId]/index.ts
+++ b/front/pages/api/w/[wId]/assistant/agent_configurations/[aId]/memories/[mId]/index.ts
@@ -36,11 +36,10 @@ async function handler(
   const agentConfigurationId = req.query.aId as string;
   const memoryId = req.query.mId as string;
 
-  const agentConfiguration = await getAgentConfiguration(
-    auth,
-    agentConfigurationId,
-    "light"
-  );
+  const agentConfiguration = await getAgentConfiguration(auth, {
+    agentId: agentConfigurationId,
+    variant: "light",
+  });
   if (!agentConfiguration || !agentConfiguration.canRead) {
     return apiError(req, res, {
       status_code: 404,

--- a/front/pages/api/w/[wId]/assistant/agent_configurations/[aId]/memories/index.ts
+++ b/front/pages/api/w/[wId]/assistant/agent_configurations/[aId]/memories/index.ts
@@ -22,11 +22,10 @@ async function handler(
 ): Promise<void> {
   const agentConfigurationId = req.query.aId as string;
 
-  const agentConfiguration = await getAgentConfiguration(
-    auth,
-    agentConfigurationId,
-    "light"
-  );
+  const agentConfiguration = await getAgentConfiguration(auth, {
+    agentId: agentConfigurationId,
+    variant: "light",
+  });
   if (!agentConfiguration || !agentConfiguration.canRead) {
     return apiError(req, res, {
       status_code: 404,

--- a/front/pages/api/w/[wId]/assistant/agent_configurations/[aId]/restore.ts
+++ b/front/pages/api/w/[wId]/assistant/agent_configurations/[aId]/restore.ts
@@ -22,11 +22,10 @@ async function handler(
 ): Promise<void> {
   switch (req.method) {
     case "POST":
-      const agentConfiguration = await getAgentConfiguration(
-        auth,
-        req.query.aId as string,
-        "light"
-      );
+      const agentConfiguration = await getAgentConfiguration(auth, {
+        agentId: req.query.aId as string,
+        variant: "light",
+      });
       if (
         !agentConfiguration ||
         (!agentConfiguration.canEdit && !auth.isAdmin())

--- a/front/pages/api/w/[wId]/assistant/agent_configurations/[aId]/tags.ts
+++ b/front/pages/api/w/[wId]/assistant/agent_configurations/[aId]/tags.ts
@@ -45,11 +45,10 @@ async function handler(
 ): Promise<void> {
   const agentConfigurationId = req.query.aId as string;
 
-  const agent = await getAgentConfiguration(
-    auth,
-    agentConfigurationId,
-    "light"
-  );
+  const agent = await getAgentConfiguration(auth, {
+    agentId: agentConfigurationId,
+    variant: "light",
+  });
   if (!agent) {
     return apiError(req, res, {
       status_code: 404,

--- a/front/pages/api/w/[wId]/assistant/agent_configurations/[aId]/usage.ts
+++ b/front/pages/api/w/[wId]/assistant/agent_configurations/[aId]/usage.ts
@@ -20,11 +20,10 @@ async function handler(
 
   switch (req.method) {
     case "GET":
-      const agentConfiguration = await getAgentConfiguration(
-        auth,
-        req.query.aId as string,
-        "light"
-      );
+      const agentConfiguration = await getAgentConfiguration(auth, {
+        agentId: req.query.aId as string,
+        variant: "light",
+      });
       if (!agentConfiguration) {
         return apiError(req, res, {
           status_code: 404,

--- a/front/pages/api/w/[wId]/assistant/agent_configurations/batch_update_scope.ts
+++ b/front/pages/api/w/[wId]/assistant/agent_configurations/batch_update_scope.ts
@@ -57,7 +57,10 @@ async function handler(
   await concurrentExecutor(
     agentIds,
     async (agentId) => {
-      const agent = await getAgentConfiguration(auth, agentId, "light");
+      const agent = await getAgentConfiguration(auth, {
+        agentId,
+        variant: "light",
+      });
       if (!agent) {
         return; // Skip if agent not found
       }

--- a/front/pages/api/w/[wId]/assistant/agent_configurations/batch_update_tags.ts
+++ b/front/pages/api/w/[wId]/assistant/agent_configurations/batch_update_tags.ts
@@ -71,7 +71,10 @@ async function handler(
   await concurrentExecutor(
     agentIds,
     async (agentId) => {
-      const agent = await getAgentConfiguration(auth, agentId, "light");
+      const agent = await getAgentConfiguration(auth, {
+        agentId,
+        variant: "light",
+      });
       if (!agent) {
         return; // Skip if agent not found
       }

--- a/front/pages/api/w/[wId]/assistant/agent_configurations/delete.ts
+++ b/front/pages/api/w/[wId]/assistant/agent_configurations/delete.ts
@@ -46,8 +46,7 @@ async function handler(
 
       const agentConfigurations = await getAgentConfigurations({
         auth,
-        agentsGetView: agentConfigurationIds.map((id) => ({ agentId: id })),
-
+        agentsGetView: { agentIds: agentConfigurationIds },
         variant: "light",
       });
       const toDelete = agentConfigurations.filter((a) => a.status === "active");

--- a/front/pages/api/w/[wId]/assistant/agent_configurations/delete.ts
+++ b/front/pages/api/w/[wId]/assistant/agent_configurations/delete.ts
@@ -46,10 +46,7 @@ async function handler(
 
       const agentConfigurations = await getAgentConfigurations({
         auth,
-        agentsGetView: {
-          agentIds: agentConfigurationIds,
-          allVersions: false,
-        },
+        agentsGetView: agentConfigurationIds.map((id) => ({ agentId: id })),
 
         variant: "light",
       });

--- a/front/pages/api/w/[wId]/assistant/agent_configurations/delete.ts
+++ b/front/pages/api/w/[wId]/assistant/agent_configurations/delete.ts
@@ -5,7 +5,7 @@ import type { NextApiRequest, NextApiResponse } from "next";
 
 import {
   archiveAgentConfiguration,
-  getAgentConfigurationsLatestVersion,
+  getAgentConfigurations,
 } from "@app/lib/api/assistant/configuration";
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
 import type { Authenticator } from "@app/lib/auth";
@@ -44,13 +44,10 @@ async function handler(
 
       const { agentConfigurationIds } = bodyValidation.right;
 
-      const agentConfigurations = await getAgentConfigurationsLatestVersion(
-        auth,
-        {
-          agentIds: agentConfigurationIds,
-          variant: "light",
-        }
-      );
+      const agentConfigurations = await getAgentConfigurations(auth, {
+        agentIds: agentConfigurationIds,
+        variant: "light",
+      });
       const toDelete = agentConfigurations.filter((a) => a.status === "active");
       if (toDelete.length !== agentConfigurationIds.length) {
         return apiError(req, res, {

--- a/front/pages/api/w/[wId]/assistant/agent_configurations/delete.ts
+++ b/front/pages/api/w/[wId]/assistant/agent_configurations/delete.ts
@@ -5,7 +5,7 @@ import type { NextApiRequest, NextApiResponse } from "next";
 
 import {
   archiveAgentConfiguration,
-  getAgentConfigurations,
+  getAgentConfigurationsLatestVersion,
 } from "@app/lib/api/assistant/configuration";
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
 import type { Authenticator } from "@app/lib/auth";
@@ -44,11 +44,13 @@ async function handler(
 
       const { agentConfigurationIds } = bodyValidation.right;
 
-      const agentConfigurations = await getAgentConfigurations({
+      const agentConfigurations = await getAgentConfigurationsLatestVersion(
         auth,
-        agentsGetView: { agentIds: agentConfigurationIds },
-        variant: "light",
-      });
+        {
+          agentIds: agentConfigurationIds,
+          variant: "light",
+        }
+      );
       const toDelete = agentConfigurations.filter((a) => a.status === "active");
       if (toDelete.length !== agentConfigurationIds.length) {
         return apiError(req, res, {

--- a/front/pages/api/w/[wId]/assistant/agent_configurations/index.ts
+++ b/front/pages/api/w/[wId]/assistant/agent_configurations/index.ts
@@ -10,7 +10,7 @@ import { getAgentsUsage } from "@app/lib/api/assistant/agent_usage";
 import {
   createAgentActionConfiguration,
   createAgentConfiguration,
-  getAgentConfigurations,
+  getAgentConfigurationsForView,
   unsafeHardDeleteAgentConfiguration,
 } from "@app/lib/api/assistant/configuration";
 import { getAgentConfigurationGroupIdsFromActions } from "@app/lib/api/assistant/permissions";
@@ -92,7 +92,7 @@ async function handler(
           },
         });
       }
-      let agentConfigurations = await getAgentConfigurations({
+      let agentConfigurations = await getAgentConfigurationsForView({
         auth,
         agentsGetView:
           viewParam === "workspace"

--- a/front/pages/api/w/[wId]/assistant/conversations/[cId]/suggest.ts
+++ b/front/pages/api/w/[wId]/assistant/conversations/[cId]/suggest.ts
@@ -3,7 +3,7 @@ import * as t from "io-ts";
 import type { NextApiRequest, NextApiResponse } from "next";
 
 import { getSuggestedAgentsForContent } from "@app/lib/api/assistant/agent_suggestion";
-import { getAgentConfigurations } from "@app/lib/api/assistant/configuration";
+import { getAgentConfigurationsForView } from "@app/lib/api/assistant/configuration";
 import { getLastUserMessage } from "@app/lib/api/assistant/conversation";
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
 import type { Authenticator } from "@app/lib/auth";
@@ -75,7 +75,7 @@ async function handler(
     });
   }
 
-  const agents = await getAgentConfigurations({
+  const agents = await getAgentConfigurationsForView({
     auth,
     agentsGetView: "list",
     variant: "light",

--- a/front/pages/api/w/[wId]/builder/assistants/[aId]/actions.ts
+++ b/front/pages/api/w/[wId]/builder/assistants/[aId]/actions.ts
@@ -42,7 +42,10 @@ async function handler(
   }
 
   try {
-    const agentConfiguration = await getAgentConfiguration(auth, aId, "full");
+    const agentConfiguration = await getAgentConfiguration(auth, {
+      agentId: aId,
+      variant: "full",
+    });
     if (!agentConfiguration) {
       return apiError(req, res, {
         status_code: 404,

--- a/front/pages/api/w/[wId]/labs/mcp_actions/[agentId]/index.ts
+++ b/front/pages/api/w/[wId]/labs/mcp_actions/[agentId]/index.ts
@@ -92,11 +92,10 @@ async function handler(
       }
 
       // Verify the agent exists and user has access
-      const agentConfiguration = await getAgentConfiguration(
-        auth,
+      const agentConfiguration = await getAgentConfiguration(auth, {
         agentId,
-        "light"
-      );
+        variant: "light",
+      });
       if (!agentConfiguration) {
         return apiError(req, res, {
           status_code: 404,

--- a/front/pages/api/w/[wId]/members/me/agent_favorite.ts
+++ b/front/pages/api/w/[wId]/members/me/agent_favorite.ts
@@ -48,11 +48,10 @@ async function handler(
 
       const { agentId, userFavorite } = bodyValidation.right;
 
-      const agentConfiguration = await getAgentConfiguration(
-        auth,
+      const agentConfiguration = await getAgentConfiguration(auth, {
         agentId,
-        "light"
-      );
+        variant: "light",
+      });
       if (!agentConfiguration) {
         return apiError(req, res, {
           status_code: 404,

--- a/front/pages/api/w/[wId]/tags/suggest_from_agents.ts
+++ b/front/pages/api/w/[wId]/tags/suggest_from_agents.ts
@@ -4,7 +4,7 @@ import * as reporter from "io-ts-reporters";
 import type { NextApiRequest, NextApiResponse } from "next";
 
 import { runAction } from "@app/lib/actions/server";
-import { getAgentConfigurations } from "@app/lib/api/assistant/configuration";
+import { getAgentConfigurationsForView } from "@app/lib/api/assistant/configuration";
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
 import type { Authenticator } from "@app/lib/auth";
 import { cloneBaseConfig, getDustProdActionRegistry } from "@app/lib/registry";
@@ -84,7 +84,7 @@ async function handler(
 
   switch (req.method) {
     case "GET":
-      const agents = await getAgentConfigurations({
+      const agents = await getAgentConfigurationsForView({
         auth,
         agentsGetView: "list",
         variant: "extra_light",

--- a/front/pages/poke/[wId]/assistants/[aId]/index.tsx
+++ b/front/pages/poke/[wId]/assistants/[aId]/index.tsx
@@ -15,7 +15,7 @@ import type { ReactElement } from "react";
 
 import PokeLayout from "@app/components/poke/PokeLayout";
 import { useTheme } from "@app/components/sparkle/ThemeContext";
-import { getAgentConfigurations } from "@app/lib/api/assistant/configuration";
+import { getAllVersionsForAgentConfiguration } from "@app/lib/api/assistant/configuration";
 import { getAuthors, getEditors } from "@app/lib/api/assistant/editors";
 import { withSuperUserAuthRequirements } from "@app/lib/iam/session";
 import type {
@@ -38,11 +38,11 @@ export const getServerSideProps = withSuperUserAuthRequirements<{
     };
   }
 
-  const agentConfigurations = await getAgentConfigurations({
+  const agentConfigurations = await getAllVersionsForAgentConfiguration(
     auth,
-    agentsGetView: { agentIds: [aId], allVersions: true },
-    variant: "full",
-  });
+    aId,
+    "full"
+  );
 
   const lastVersionEditors = await getEditors(auth, agentConfigurations[0]);
 

--- a/front/pages/poke/[wId]/assistants/[aId]/index.tsx
+++ b/front/pages/poke/[wId]/assistants/[aId]/index.tsx
@@ -38,11 +38,10 @@ export const getServerSideProps = withSuperUserAuthRequirements<{
     };
   }
 
-  const agentConfigurations = await getAllVersionsForAgentConfiguration(
-    auth,
-    aId,
-    "full"
-  );
+  const agentConfigurations = await getAllVersionsForAgentConfiguration(auth, {
+    agentId: aId,
+    variant: "full",
+  });
 
   const lastVersionEditors = await getEditors(auth, agentConfigurations[0]);
 

--- a/front/pages/poke/[wId]/assistants/[aId]/index.tsx
+++ b/front/pages/poke/[wId]/assistants/[aId]/index.tsx
@@ -15,7 +15,7 @@ import type { ReactElement } from "react";
 
 import PokeLayout from "@app/components/poke/PokeLayout";
 import { useTheme } from "@app/components/sparkle/ThemeContext";
-import { getAllVersionsForAgentConfiguration } from "@app/lib/api/assistant/configuration";
+import { listsAgentConfigurationVersions } from "@app/lib/api/assistant/configuration";
 import { getAuthors, getEditors } from "@app/lib/api/assistant/editors";
 import { withSuperUserAuthRequirements } from "@app/lib/iam/session";
 import type {
@@ -38,7 +38,7 @@ export const getServerSideProps = withSuperUserAuthRequirements<{
     };
   }
 
-  const agentConfigurations = await getAllVersionsForAgentConfiguration(auth, {
+  const agentConfigurations = await listsAgentConfigurationVersions(auth, {
     agentId: aId,
     variant: "full",
   });

--- a/front/pages/w/[wId]/builder/agents/[aId]/index.tsx
+++ b/front/pages/w/[wId]/builder/agents/[aId]/index.tsx
@@ -43,7 +43,10 @@ export const getServerSideProps = withDefaultUserAuthRequirements<{
     }
 
     const [configuration] = await Promise.all([
-      getAgentConfiguration(auth, context.params?.aId as string, "light"),
+      getAgentConfiguration(auth, {
+        agentId: context.params?.aId as string,
+        variant: "light",
+      }),
       MCPServerViewResource.ensureAllAutoToolsAreCreated(auth),
     ]);
 

--- a/front/pages/w/[wId]/builder/agents/new.tsx
+++ b/front/pages/w/[wId]/builder/agents/new.tsx
@@ -81,7 +81,10 @@ export const getServerSideProps = withDefaultUserAuthRequirements<{
     context.query
   );
   if (duplicate) {
-    configuration = await getAgentConfiguration(auth, duplicate, "full");
+    configuration = await getAgentConfiguration(auth, {
+      agentId: duplicate,
+      variant: "full",
+    });
 
     if (!configuration) {
       return {

--- a/front/pages/w/[wId]/builder/assistants/[aId]/index.tsx
+++ b/front/pages/w/[wId]/builder/assistants/[aId]/index.tsx
@@ -45,7 +45,10 @@ export const getServerSideProps = withDefaultUserAuthRequirements<{
     }
 
     const [configuration] = await Promise.all([
-      getAgentConfiguration(auth, context.params?.aId as string, "light"),
+      getAgentConfiguration(auth, {
+        agentId: context.params?.aId as string,
+        variant: "light",
+      }),
       MCPServerViewResource.ensureAllAutoToolsAreCreated(auth),
     ]);
 

--- a/front/pages/w/[wId]/builder/assistants/new.tsx
+++ b/front/pages/w/[wId]/builder/assistants/new.tsx
@@ -77,7 +77,10 @@ export const getServerSideProps = withDefaultUserAuthRequirements<{
     context.query
   );
   if (duplicate) {
-    configuration = await getAgentConfiguration(auth, duplicate, "full");
+    configuration = await getAgentConfiguration(auth, {
+      agentId: duplicate,
+      variant: "full",
+    });
 
     if (!configuration) {
       return {

--- a/front/pages/w/[wId]/labs/mcp_actions/[agentId]/index.tsx
+++ b/front/pages/w/[wId]/labs/mcp_actions/[agentId]/index.tsx
@@ -58,7 +58,10 @@ export const getServerSideProps = withDefaultUserAuthRequirements<{
     };
   }
 
-  const agent = await getAgentConfiguration(auth, agentId, "light");
+  const agent = await getAgentConfiguration(auth, {
+    agentId,
+    variant: "light",
+  });
   if (!agent) {
     return {
       notFound: true,

--- a/front/temporal/agent_loop/activities/run_model.ts
+++ b/front/temporal/agent_loop/activities/run_model.ts
@@ -19,7 +19,7 @@ import {
   AgentMessageContentParser,
   getDelimitersConfiguration,
 } from "@app/lib/api/assistant/agent_message_content_parser";
-import { getAgentConfigurations } from "@app/lib/api/assistant/configuration";
+import { getAgentConfigurationsForView } from "@app/lib/api/assistant/configuration";
 import { constructPromptMultiActions } from "@app/lib/api/assistant/generation";
 import { getJITServers } from "@app/lib/api/assistant/jit_actions";
 import { listAttachments } from "@app/lib/api/assistant/jit_utils";
@@ -242,7 +242,7 @@ export async function runModelActivity({
   const agentsList = agentConfiguration.instructions?.includes(
     "{ASSISTANTS_LIST}"
   )
-    ? await getAgentConfigurations({
+    ? await getAgentConfigurationsForView({
         auth,
         agentsGetView: auth.user() ? "list" : "all",
         variant: "light",

--- a/front/temporal/labs/transcripts/activities.ts
+++ b/front/temporal/labs/transcripts/activities.ts
@@ -560,11 +560,10 @@ export async function processTranscriptActivity(
       return;
     }
 
-    const agent = await getAgentConfiguration(
-      auth,
-      agentConfigurationId,
-      "light"
-    );
+    const agent = await getAgentConfiguration(auth, {
+      agentId: agentConfigurationId,
+      variant: "light",
+    });
 
     if (!agent) {
       await stopRetrieveTranscriptsWorkflow(transcriptsConfiguration);

--- a/front/temporal/permissions_queue/activities.ts
+++ b/front/temporal/permissions_queue/activities.ts
@@ -1,6 +1,6 @@
 import assert from "assert";
 
-import { getAgentConfigurations } from "@app/lib/api/assistant/configuration";
+import { getAgentConfigurationsLatestVersion } from "@app/lib/api/assistant/configuration";
 import {
   getAgentConfigurationGroupIdsFromActions,
   listAgentConfigurationsForGroups,
@@ -65,12 +65,11 @@ export async function updateSpacePermissions({
 
   // Update the permissions of all the agent configurations.
   for (const acId of agentConfigurationIds) {
-    const [ac] = await getAgentConfigurations({
-      auth,
-      agentsGetView: { agentIds: [acId] },
+    const acList = await getAgentConfigurationsLatestVersion(auth, {
+      agentIds: [acId],
       variant: "full",
-      dangerouslySkipPermissionFiltering: true,
     });
+    const [ac] = acList;
     if (!ac) {
       logger.warn(
         {

--- a/front/temporal/permissions_queue/activities.ts
+++ b/front/temporal/permissions_queue/activities.ts
@@ -67,9 +67,7 @@ export async function updateSpacePermissions({
   for (const acId of agentConfigurationIds) {
     const [ac] = await getAgentConfigurations({
       auth,
-      agentsGetView: {
-        agentIds: [acId],
-      },
+      agentsGetView: [{ agentId: acId }],
       variant: "full",
       dangerouslySkipPermissionFiltering: true,
     });

--- a/front/temporal/permissions_queue/activities.ts
+++ b/front/temporal/permissions_queue/activities.ts
@@ -1,6 +1,6 @@
 import assert from "assert";
 
-import { getAgentConfigurationsLatestVersion } from "@app/lib/api/assistant/configuration";
+import { getAgentConfigurations } from "@app/lib/api/assistant/configuration";
 import {
   getAgentConfigurationGroupIdsFromActions,
   listAgentConfigurationsForGroups,
@@ -65,7 +65,7 @@ export async function updateSpacePermissions({
 
   // Update the permissions of all the agent configurations.
   for (const acId of agentConfigurationIds) {
-    const acList = await getAgentConfigurationsLatestVersion(auth, {
+    const acList = await getAgentConfigurations(auth, {
       agentIds: [acId],
       variant: "full",
     });

--- a/front/temporal/permissions_queue/activities.ts
+++ b/front/temporal/permissions_queue/activities.ts
@@ -67,7 +67,7 @@ export async function updateSpacePermissions({
   for (const acId of agentConfigurationIds) {
     const [ac] = await getAgentConfigurations({
       auth,
-      agentsGetView: [{ agentId: acId }],
+      agentsGetView: { agentIds: [acId] },
       variant: "full",
       dangerouslySkipPermissionFiltering: true,
     });

--- a/front/temporal/scrub_workspace/activities.ts
+++ b/front/temporal/scrub_workspace/activities.ts
@@ -2,7 +2,7 @@ import _ from "lodash";
 
 import {
   archiveAgentConfiguration,
-  getAgentConfigurations,
+  getAgentConfigurationsForView,
 } from "@app/lib/api/assistant/configuration";
 import { destroyConversation } from "@app/lib/api/assistant/conversation/destroy";
 import config from "@app/lib/api/config";
@@ -148,7 +148,7 @@ export async function deleteAllConversations(auth: Authenticator) {
 }
 
 async function archiveAssistants(auth: Authenticator) {
-  const agentConfigurations = await getAgentConfigurations({
+  const agentConfigurations = await getAgentConfigurationsForView({
     auth,
     agentsGetView: "admin_internal",
     variant: "light",

--- a/front/types/assistant/agent.ts
+++ b/front/types/assistant/agent.ts
@@ -70,7 +70,8 @@ export type AgentConfigurationScope =
  */
 // TODO(agent-discovery) remove workspace, published, global
 export type AgentsGetViewType =
-  | { agentIds: string[]; allVersions?: boolean }
+  | { agentIds: string[]; allVersions: true }
+  | { agentId: string; agentVersion?: number }[]
   | "current_user"
   | "list"
   | "all"

--- a/front/types/assistant/agent.ts
+++ b/front/types/assistant/agent.ts
@@ -70,8 +70,8 @@ export type AgentConfigurationScope =
  */
 // TODO(agent-discovery) remove workspace, published, global
 export type AgentsGetViewType =
-  | { agentIds: string[]; allVersions: true }
-  | { agentId: string; agentVersion?: number }[]
+  | { agentIds: string[]; allVersions?: boolean }
+  | { agentId: string; agentVersion: number }[]
   | "current_user"
   | "list"
   | "all"

--- a/front/types/assistant/agent.ts
+++ b/front/types/assistant/agent.ts
@@ -57,7 +57,6 @@ export type AgentConfigurationScope =
  * 'views':
  * - 'current_user': Retrieves agents created or edited by the current user.
  * - 'list': Retrieves all active agents accessible to the user
- * - {agentIds: string}: Retrieves specific agents by their sIds.
  * - 'all': All non-private agents (so combines workspace, published and global
  *   agents); used e.g. for non-user calls such as API
  * - 'published': Retrieves all published agents.
@@ -67,11 +66,10 @@ export type AgentConfigurationScope =
  * - 'archived': Retrieves all agents that are archived. Only available to super
  *   users. Intended strictly for internal use with necessary superuser or admin
  *   authorization.
+ * - 'favorites': Retrieves all agents marked as favorites by the current user.
  */
 // TODO(agent-discovery) remove workspace, published, global
 export type AgentsGetViewType =
-  | { agentIds: string[]; allVersions?: boolean }
-  | { agentId: string; agentVersion: number }[]
   | "current_user"
   | "list"
   | "all"

--- a/front/types/assistant/agent_run.ts
+++ b/front/types/assistant/agent_run.ts
@@ -133,11 +133,10 @@ export async function getRunAgentData(
   }
 
   // Fetch the agent configuration as we need the full version of the agent configuration.
-  const agentConfiguration = await getAgentConfiguration(
-    auth,
-    agentMessage.configuration.sId,
-    "full"
-  );
+  const agentConfiguration = await getAgentConfiguration(auth, {
+    agentId: agentMessage.configuration.sId,
+    variant: "full",
+  });
   if (!agentConfiguration) {
     return new Err(new Error("Agent configuration not found"));
   }


### PR DESCRIPTION
## Description

- Part of https://github.com/dust-tt/tasks/issues/3622.
- This PR updates `fetchWorkspaceAgentConfigurationsWithoutActions`, `getAgentConfiguration` and `agentGetViewType` to support fetching one specific version of an agent.
- The entry points for fetching agents are now the following:
  - `listsAgentConfigurationVersions`
  - `getAgentConfigurations` (gets the latest version)
  - `getAgentConfiguration` (gets one version)
- In a separate PR we'll rely on it to pin down the version used by an agentic loop (keeping them separate so that we have one PR that induces no change).
- Planned to split `lib/api/assistant/configuration.ts` in several files in a follow up PR.

## Tests

- Tested locally.

## Risk

- Affects agent versioning.

## Deploy Plan

- Deploy front.
