### PR TITLE
[Retry] Fix duplicated agent message in conversation

### DIFF
--- a/front/lib/api/assistant/conversation.ts
+++ b/front/lib/api/assistant/conversation.ts
@@ -1323,7 +1323,6 @@ export async function retryAgentMessage(
   const agentMessageArray = conversation.content.find((messages) => {
     return messages.some((m) => m.sId === message.sId && isAgentMessageType(m));
   }) as AgentMessageType[];
-  agentMessageArray.push(agentMessage);
 
   // Finally, stitch the conversation.
   const newContent = [


### PR DESCRIPTION
## Description

Upon working on https://github.com/dust-tt/tasks/issues/3590 I discovered that the agent message appears twice in the stitched conversation, this PR fixes this issue.

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

## Tests

Manual tests locally

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

Low impact/Medium risk : it's in the critical path of the retry, tested manually, we don't have unit/e2e tests

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->

- front-edge
- front
