### PR TITLE
Retry directly at a given step

### DIFF
--- a/front/lib/api/assistant/conversation/retry_from_step.ts
+++ b/front/lib/api/assistant/conversation/retry_from_step.ts
@@ -1,0 +1,123 @@
+import { runAgentLoop } from "@app/lib/api/assistant/agent";
+import { getFullAgentConfiguration } from "@app/lib/api/assistant/configuration/agent";
+import type { Authenticator } from "@app/lib/auth";
+import { AgentMessage, Message } from "@app/lib/models/assistant/conversation";
+import type {
+  AgentMessageType,
+  AgentMessageWithRankType,
+  APIErrorWithStatusCode,
+  ConversationType,
+  Result,
+} from "@app/types";
+import { Err, isUserMessageType, Ok } from "@app/types";
+
+export async function retryAgentMessageFromStep(
+  auth: Authenticator,
+  {
+    conversation,
+    message,
+    startStep,
+  }: {
+    conversation: ConversationType;
+    message: AgentMessageType;
+    startStep: number;
+  }
+): Promise<Result<AgentMessageWithRankType, APIErrorWithStatusCode>> {
+  const agentMessage = message;
+
+  // First, find the array of the parent message in conversation.content.
+  const parentMessageIndex = conversation.content.findIndex((messages) => {
+    return messages.some((m) => m.sId === agentMessage.parentMessageId);
+  });
+  if (parentMessageIndex === -1) {
+    return new Err({
+      status_code: 400,
+      api_error: {
+        type: "message_not_found",
+        message: `Parent message ${agentMessage.parentMessageId} not found in conversation`,
+      },
+    });
+  }
+
+  const userMessage =
+    conversation.content[parentMessageIndex][
+      conversation.content[parentMessageIndex].length - 1
+    ];
+  if (!isUserMessageType(userMessage)) {
+    return new Err({
+      status_code: 400,
+      api_error: {
+        type: "message_not_found",
+        message: "Parent message must be a user message",
+      },
+    });
+  }
+
+  const messageRow = await Message.findOne({
+    where: {
+      workspaceId: auth.getNonNullableWorkspace().id,
+      conversationId: conversation.id,
+      id: agentMessage.id,
+    },
+    include: [
+      {
+        model: AgentMessage,
+        as: "agentMessage",
+        required: true,
+      },
+    ],
+  });
+  if (!messageRow) {
+    return new Err({
+      status_code: 400,
+      api_error: {
+        type: "message_not_found",
+        message: `Message row ${agentMessage.id} not found`,
+      },
+    });
+  }
+
+  // we need to refetch by why?
+  const agentMessageRow = await AgentMessage.findOne({
+    where: {
+      id: message.agentMessageId,
+      workspaceId: conversation.owner.id,
+    },
+  });
+  if (!agentMessageRow) {
+    return new Err({
+      status_code: 400,
+      api_error: {
+        type: "message_not_found",
+        message: `Agent message row ${agentMessage.id} not found`,
+      },
+    });
+  }
+
+  const agentMessageWithRank: AgentMessageWithRankType = {
+    ...agentMessage,
+    rank: messageRow.rank,
+  };
+
+  // reset agentMessage content
+  agentMessage.content = "";
+
+  const inMemoryData = {
+    agentConfiguration: await getFullAgentConfiguration(
+      auth,
+      agentMessage.configuration
+    ),
+    conversation,
+    userMessage,
+    agentMessage,
+    agentMessageRow,
+  };
+
+  void runAgentLoop(
+    auth.toJSON(),
+    { sync: true, inMemoryData },
+    { forceAsynchronousLoop: false, startStep }
+  );
+
+  return new Ok(agentMessageWithRank);
+}

--- a/front/lib/api/assistant/conversation/retry_from_step.ts
+++ b/front/lib/api/assistant/conversation/retry_from_step.ts
@@ -15,16 +15,14 @@ export async function retryAgentMessageFromStep(
   auth: Authenticator,
   {
     conversation,
-    message,
+    agentMessage,
     startStep,
   }: {
     conversation: ConversationType;
-    message: AgentMessageType;
+    agentMessage: AgentMessageType;
     startStep: number;
   }
 ): Promise<Result<AgentMessageWithRankType, APIErrorWithStatusCode>> {
-  const agentMessage = message;
-
   // First, find the array of the parent message in conversation.content.
   const parentMessageIndex = conversation.content.findIndex((messages) => {
     return messages.some((m) => m.sId === agentMessage.parentMessageId);
@@ -80,7 +78,7 @@ export async function retryAgentMessageFromStep(
   // we need to refetch by why?
   const agentMessageRow = await AgentMessage.findOne({
     where: {
-      id: message.agentMessageId,
+      id: agentMessage.agentMessageId,
       workspaceId: conversation.owner.id,
     },
   });

--- a/front/lib/api/assistant/conversation/retry_from_step.ts
+++ b/front/lib/api/assistant/conversation/retry_from_step.ts
@@ -97,9 +97,6 @@ export async function retryAgentMessageFromStep(
     rank: messageRow.rank,
   };
 
-  // reset agentMessage content
-  agentMessage.content = "";
-
   const inMemoryData = {
     agentConfiguration: await getFullAgentConfiguration(
       auth,
@@ -107,7 +104,10 @@ export async function retryAgentMessageFromStep(
     ),
     conversation,
     userMessage,
-    agentMessage,
+    agentMessage: {
+      ...agentMessage,
+      content: "", // reset agentMessage content
+    },
     agentMessageRow,
   };
 

--- a/front/pages/api/v1/w/[wId]/assistant/conversations/[cId]/messages/[mId]/run/steps/[stepIndex]/retry.ts
+++ b/front/pages/api/v1/w/[wId]/assistant/conversations/[cId]/messages/[mId]/run/steps/[stepIndex]/retry.ts
@@ -5,9 +5,10 @@ import type { NextApiRequest, NextApiResponse } from "next";
 
 import { getConversation } from "@app/lib/api/assistant/conversation/fetch";
 import { apiErrorForConversation } from "@app/lib/api/assistant/conversation/helper";
+import { retryAgentMessageFromStep } from "@app/lib/api/assistant/conversation/retry_from_step";
+import { canReadMessage } from "@app/lib/api/assistant/messages";
 import { withPublicAPIAuthentication } from "@app/lib/api/auth_wrappers";
 import type { Authenticator } from "@app/lib/auth";
-import logger from "@app/logger/logger";
 import { apiError } from "@app/logger/withlogging";
 import type {
   AgentMessageType,
@@ -15,7 +16,7 @@ import type {
   UserMessageType,
   WithAPIErrorResponse,
 } from "@app/types";
-import { isString, Ok } from "@app/types";
+import { isString } from "@app/types";
 
 const ConversationsMessagesRunStepsRetrySchema = t.type({
   retryBlockedToolsOnly: t.boolean,
@@ -119,6 +120,16 @@ async function handler(
   }
   const agentMessage = messageAnyType;
 
+  if (!canReadMessage(auth, agentMessage)) {
+    return apiError(req, res, {
+      status_code: 403,
+      api_error: {
+        type: "invalid_request_error",
+        message: "The message to retry is not accessible.",
+      },
+    });
+  }
+
   switch (req.method) {
     case "POST":
       const bodyValidation = ConversationsMessagesRunStepsRetrySchema.decode(
@@ -134,26 +145,17 @@ async function handler(
           },
         });
       }
-      // TODO(DURABLE-AGENTS 2025-07-21): Use step index, version and retryBlockedToolsOnly.
-      // const result = await launchAgentLoopWorkflow();
-      logger.info("endpoint called", {
-        cId,
-        mId,
-        agentMessage,
+      const result = await retryAgentMessageFromStep(auth, {
+        conversation,
+        message: agentMessage,
+        startStep: stepIndex,
       });
-      const result = new Ok({});
 
       if (result.isErr()) {
-        return apiError(req, res, {
-          status_code: 500,
-          api_error: {
-            type: "internal_server_error",
-            message: "Failed to launch workflow",
-          },
-        });
+        return apiError(req, res, result.error);
       }
 
-      return res.status(200).json(result.value);
+      return res.status(200).json({});
 
     default:
       res.status(405).end();

--- a/front/pages/api/v1/w/[wId]/assistant/conversations/[cId]/messages/[mId]/run/steps/[stepIndex]/retry.ts
+++ b/front/pages/api/v1/w/[wId]/assistant/conversations/[cId]/messages/[mId]/run/steps/[stepIndex]/retry.ts
@@ -147,7 +147,7 @@ async function handler(
       }
       const result = await retryAgentMessageFromStep(auth, {
         conversation,
-        message: agentMessage,
+        agentMessage,
         startStep: stepIndex,
       });
 

--- a/front/pages/api/v1/w/[wId]/assistant/conversations/[cId]/messages/[mId]/run/steps/[stepIndex]/retry.ts
+++ b/front/pages/api/v1/w/[wId]/assistant/conversations/[cId]/messages/[mId]/run/steps/[stepIndex]/retry.ts
@@ -152,7 +152,10 @@ async function handler(
       });
 
       if (result.isErr()) {
-        return apiError(req, res, result.error);
+        return apiError(req, res, {
+          status_code: 400,
+          api_error: result.error,
+        });
       }
 
       return res.status(200).json({});

--- a/front/pages/api/w/[wId]/assistant/conversations/[cId]/messages/[mId]/run/steps/[stepIndex]/retry.ts
+++ b/front/pages/api/w/[wId]/assistant/conversations/[cId]/messages/[mId]/run/steps/[stepIndex]/retry.ts
@@ -149,7 +149,10 @@ async function handler(
       });
 
       if (result.isErr()) {
-        return apiError(req, res, result.error);
+        return apiError(req, res, {
+          status_code: 400,
+          api_error: result.error,
+        });
       }
 
       return res.status(200).json({});

--- a/front/pages/api/w/[wId]/assistant/conversations/[cId]/messages/[mId]/run/steps/[stepIndex]/retry.ts
+++ b/front/pages/api/w/[wId]/assistant/conversations/[cId]/messages/[mId]/run/steps/[stepIndex]/retry.ts
@@ -144,7 +144,7 @@ async function handler(
       }
       const result = await retryAgentMessageFromStep(auth, {
         conversation,
-        message: agentMessage,
+        agentMessage,
         startStep: stepIndex,
       });
 


### PR DESCRIPTION
## Description

Fix https://github.com/dust-tt/tasks/issues/3590

Implements retry functionality for agent messages from a specific step, replacing placeholder implementations. 

This change introduces a new `retryAgentMessageFromStep` function that properly handles retrying agent messages without duplicating steps or agent messages. The implementation includes proper authentication checks and integrates with the existing agent loop system.

Key changes:
- Added `retry_from_step.ts` with core retry logic that resets agent message content and runs the agent loop from a specified step
- Updated both public and workspace API endpoints to use the new retry function instead of placeholder logging
- Added authentication validation using `canReadMessage` to ensure users can only retry messages they have access to
- Enhanced test coverage to include authentication failure scenarios
- Removed TODO comments indicating incomplete functionality

## Tests

- Added test case for failure when user cannot read the message
- Existing test suite continues to pass
- Manual testing confirmed retry functionality works without duplicating agent messages or steps

## Risk

Low risk change that replaces non-functional placeholder code with working implementation. The new code includes proper error handling and authentication checks. Safe to rollback as it only affects the retry endpoint functionality.

## Deploy Plan

Standard deployment - no special considerations needed. The changes are backwards compatible and only improve existing functionality that was previously non-functional.