### PR TITLE
allow admins to set the retention period

### DIFF
--- a/front/components/data_source/ZendeskConfigView.tsx
+++ b/front/components/data_source/ZendeskConfigView.tsx
@@ -13,8 +13,6 @@ import { useSendNotification } from "@app/hooks/useNotification";
 import { useConnectorConfig } from "@app/lib/swr/connectors";
 import type { DataSourceType, WorkspaceType } from "@app/types";
 
-const DEFAULT_RETENTION_PERIOD_DAYS = 180;
-
 export function ZendeskConfigView({
   owner,
   readOnly,
@@ -206,7 +204,6 @@ export function ZendeskConfigView({
               value={retentionInput}
               type="number"
               onChange={(e) => setRetentionInput(e.target.value)}
-              placeholder={DEFAULT_RETENTION_PERIOD_DAYS.toString()}
               disabled={readOnly || !isAdmin || loading}
               className="w-20"
             />
@@ -218,7 +215,7 @@ export function ZendeskConfigView({
                 readOnly ||
                 !isAdmin ||
                 loading ||
-                retentionInput === retentionPeriodDays.toString()
+                retentionInput === retentionPeriodDays?.toString()
               }
               label="Save"
             />
@@ -227,9 +224,8 @@ export function ZendeskConfigView({
       >
         <ContextItem.Description>
           <div className="text-muted-foreground dark:text-muted-foreground-night">
-            Set how long Zendesk data should be retained in days. Leave empty or
-            set to {DEFAULT_RETENTION_PERIOD_DAYS} for default. Increasing the
-            retention period will trigger a sync to fetch older data.
+            Set the duration of the retention period: tickets older than the
+            retention period will be cleaned on a daily basis.
           </div>
         </ContextItem.Description>
       </ContextItem>

--- a/front/components/data_source/ZendeskConfigView.tsx
+++ b/front/components/data_source/ZendeskConfigView.tsx
@@ -103,16 +103,20 @@ export function ZendeskConfigView({
 
   const handleRetentionPeriodSave = async () => {
     const value = retentionInput.trim();
-    const numValue = parseInt(value, 10);
+    let numValue: number;
 
-    if (value !== "" && (isNaN(numValue) || numValue < 0)) {
-      sendNotification({
-        type: "error",
-        title: "Invalid retention period",
-        description:
-          "Retention period must be a non-negative integer or empty to use default.",
-      });
-      return;
+    if (value === "") {
+      numValue = DEFAULT_RETENTION_PERIOD_DAYS;
+    } else {
+      numValue = parseInt(value, 10);
+      if (isNaN(numValue) || numValue < 0) {
+        sendNotification({
+          type: "error",
+          title: "Invalid retention period",
+          description: "Retention period must be a non-negative integer.",
+        });
+        return;
+      }
     }
 
     if (numValue > MAX_RETENTION_DAYS) {
@@ -125,6 +129,11 @@ export function ZendeskConfigView({
     }
 
     await handleSetNewConfig(retentionPeriodConfigKey, numValue);
+    sendNotification({
+      type: "success",
+      title: "Retention period updated",
+      description: `Data retention period set to ${numValue} days.`,
+    });
   };
 
   return (

--- a/front/components/data_source/ZendeskConfigView.tsx
+++ b/front/components/data_source/ZendeskConfigView.tsx
@@ -60,14 +60,13 @@ export function ZendeskConfigView({
   const syncUnresolvedTicketsEnabled =
     syncUnresolvedTicketsConfigValue === "true";
   const hideCustomerDetailsEnabled = hideCustomerDetailsConfigValue === "true";
-  const retentionPeriodDays = retentionPeriodConfigValue
-    ? parseInt(retentionPeriodConfigValue, 10)
-    : DEFAULT_RETENTION_PERIOD_DAYS;
+
+  const retentionPeriodDays = retentionPeriodConfigValue;
 
   const sendNotification = useSendNotification();
   const [loading, setLoading] = useState(false);
   const [retentionInput, setRetentionInput] = useState(
-    retentionPeriodDays.toString()
+    retentionPeriodDays?.toString() || ""
   );
 
   const handleSetNewConfig = async (
@@ -113,23 +112,19 @@ export function ZendeskConfigView({
 
   const handleRetentionPeriodSave = async () => {
     const value = retentionInput.trim();
-    let numValue: number;
 
-    if (value === "") {
-      numValue = DEFAULT_RETENTION_PERIOD_DAYS;
-    } else {
-      numValue = parseInt(value, 10);
+    if (value !== "") {
+      const numValue = parseInt(value, 10);
       if (isNaN(numValue) || numValue < 0) {
         sendNotification({
-          type: "error",
+          type: "info",
           title: "Invalid retention period",
           description: "Retention period must be a non-negative integer.",
         });
         return;
       }
+      await handleSetNewConfig(retentionPeriodConfigKey, numValue);
     }
-
-    await handleSetNewConfig(retentionPeriodConfigKey, numValue);
   };
 
   return (

--- a/front/components/data_source/ZendeskConfigView.tsx
+++ b/front/components/data_source/ZendeskConfigView.tsx
@@ -113,11 +113,11 @@ export function ZendeskConfigView({
 
     if (value !== "") {
       const numValue = parseInt(value, 10);
-      if (isNaN(numValue) || numValue < 0) {
+      if (isNaN(numValue) || numValue <= 0) {
         sendNotification({
           type: "info",
           title: "Invalid retention period",
-          description: "Retention period must be a non-negative integer.",
+          description: "Retention period must be a positive integer.",
         });
         return;
       }

--- a/front/components/data_source/ZendeskConfigView.tsx
+++ b/front/components/data_source/ZendeskConfigView.tsx
@@ -14,7 +14,7 @@ import { useConnectorConfig } from "@app/lib/swr/connectors";
 import type { DataSourceType, WorkspaceType } from "@app/types";
 
 const DEFAULT_RETENTION_PERIOD_DAYS = 180;
-const MAX_RETENTION_DAYS = 365;
+const MAX_RETENTION_PERIOD_DAYS = 365;
 
 export function ZendeskConfigView({
   owner,
@@ -119,11 +119,11 @@ export function ZendeskConfigView({
       }
     }
 
-    if (numValue > MAX_RETENTION_DAYS) {
+    if (numValue > MAX_RETENTION_PERIOD_DAYS) {
       sendNotification({
         type: "error",
         title: "Invalid retention period",
-        description: `Retention period cannot exceed ${MAX_RETENTION_DAYS} days.`,
+        description: `Retention period cannot exceed ${MAX_RETENTION_PERIOD_DAYS} days.`,
       });
       return;
     }
@@ -236,7 +236,7 @@ export function ZendeskConfigView({
         <ContextItem.Description>
           <div className="text-muted-foreground dark:text-muted-foreground-night">
             Set how long Zendesk data should be retained in days (0-
-            {MAX_RETENTION_DAYS}). Leave empty or set to{" "}
+            {MAX_RETENTION_PERIOD_DAYS}). Leave empty or set to{" "}
             {DEFAULT_RETENTION_PERIOD_DAYS} for default. Increasing the
             retention period will trigger a sync to fetch older data.
           </div>

--- a/front/pages/api/w/[wId]/data_sources/[dsId]/managed/config/[key]/index.ts
+++ b/front/pages/api/w/[wId]/data_sources/[dsId]/managed/config/[key]/index.ts
@@ -86,6 +86,7 @@ async function handler(
       "intercomConversationsNotesSyncEnabled",
       "zendeskSyncUnresolvedTicketsEnabled",
       "zendeskHideCustomerDetails",
+      "zendeskRetentionPeriodDays",
       "gongRetentionPeriodDays",
       "gongTrackersEnabled",
       "privateIntegrationCredentialId",


### PR DESCRIPTION
## Description

Allow admins to set the retention policy in the Zendesk connector settings. 

## Tests

Locally

## Deploy
Front only

## Risks

Users can now decrease the retention period for their tickets, effectively running the risk of keeping too few tickets in sync.
Monitoring the calls to the zendesk connector would be a way to check if changes to the retention period are frequent once we allow users to access this setting

