### PR TITLE
Implement graceful shutdown on agent loop

### DIFF
--- a/front/temporal/agent_loop/worker.ts
+++ b/front/temporal/agent_loop/worker.ts
@@ -10,6 +10,9 @@ import { runModelActivity } from "@app/temporal/agent_loop/activities/run_model"
 import { runToolActivity } from "@app/temporal/agent_loop/activities/run_tool";
 import { QUEUE_NAME } from "@app/temporal/agent_loop/config";
 
+// We need to give the worker some time to finish the current activity before shutting down.
+const SHUTDOWN_GRACE_TIME = "2 minutes";
+
 export async function runAgentLoopWorker() {
   const { connection, namespace } = await getTemporalWorkerConnection();
 
@@ -23,6 +26,7 @@ export async function runAgentLoopWorker() {
     taskQueue: QUEUE_NAME,
     connection,
     namespace,
+    shutdownGraceTime: SHUTDOWN_GRACE_TIME,
     interceptors: {
       activityInbound: [
         (ctx: Context) => {


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
This PR fixes https://github.com/dust-tt/tasks/issues/3609.

It leverages [shutdowngracetime](https://typescript.temporal.io/api/interfaces/worker.WorkerOptions#shutdowngracetime) attributes on the worker option.

Tested locally, once signal is received, the worker stop processing new activities and awaits up to X minutes for ongoing activity to finish. The activity can check if it has been canceled by leveraging  Temporal's context. For now this is left outside of the picture but we might want to implement it for the `runModelActivity` at least since there is no timeout. `runToolActivity` has a 2 minutes timeout.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->
Tested locally with:

```
 ps aux | grep start_worker
 
 kill -TERM <pid>
```

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
