### PR TITLE
[front] - feat(AB v2): Improve suggestions in agent builder

### DIFF
--- a/front/components/agent_builder/settings/AgentBuilderSettingsBlock.tsx
+++ b/front/components/agent_builder/settings/AgentBuilderSettingsBlock.tsx
@@ -149,12 +149,7 @@ function AgentNameInput() {
           <DropdownMenuTrigger asChild>
             <Button
               icon={SparklesIcon}
-              variant={
-                !instructions ||
-                instructions.length < MIN_INSTRUCTIONS_LENGTH_SUGGESTIONS
-                  ? "ghost"
-                  : "outline"
-              }
+              variant="outline"
               size="xs"
               className="absolute right-0 top-1/2 mr-1 h-7 w-7 -translate-y-1/2 rounded-lg p-0"
               disabled={
@@ -273,17 +268,9 @@ function AgentDescriptionInput() {
         />
         <Button
           icon={isGenerating ? () => <Spinner size="xs" /> : SparklesIcon}
-          variant={
-            isGenerating ||
-            !instructions ||
-            instructions.length < MIN_INSTRUCTIONS_LENGTH_SUGGESTIONS
-              ? "ghost"
-              : "outline"
-          }
+          variant="outline"
           size="xs"
-          className={`absolute right-0 top-1/2 mr-1 h-7 w-7 -translate-y-1/2 rounded-lg p-0 ${
-            isGenerating ? "bg-transparent" : ""
-          }`}
+          className="absolute right-0 top-1/2 mr-1 h-7 w-7 -translate-y-1/2 rounded-lg p-0"
           disabled={
             isGenerating ||
             !instructions ||

--- a/front/components/agent_builder/settings/AgentBuilderSettingsBlock.tsx
+++ b/front/components/agent_builder/settings/AgentBuilderSettingsBlock.tsx
@@ -151,7 +151,7 @@ function AgentNameInput() {
               icon={SparklesIcon}
               variant="ghost"
               size="xs"
-              className="absolute right-0 top-1/2 mr-1 h-7 w-7 -translate-y-1/2 rounded-none border-0 bg-transparent p-0 text-gray-400 hover:rounded-lg hover:bg-gray-100 hover:text-gray-600"
+              className="absolute right-0 top-1/2 mr-1 h-7 w-7 -translate-y-1/2 rounded-lg border-0 bg-transparent p-0 text-gray-400 hover:rounded-lg hover:bg-gray-100 hover:text-gray-600"
               disabled={
                 !instructions ||
                 instructions.length < MIN_INSTRUCTIONS_LENGTH_SUGGESTIONS
@@ -267,18 +267,21 @@ function AgentDescriptionInput() {
       <label className="text-sm font-medium text-foreground dark:text-foreground-night">
         Description
       </label>
-      <div className="flex items-center gap-2">
-        <div className="flex-grow">
-          <Input placeholder="Enter agent description" {...field} />
-        </div>
+      <div className="relative">
+        <Input
+          placeholder="Enter agent description"
+          {...field}
+          className="pr-10"
+        />
         <DropdownMenu
           onOpenChange={(open) => open && handleGenerateDescription()}
         >
           <DropdownMenuTrigger asChild>
             <Button
               icon={SparklesIcon}
-              variant="outline"
-              isSelect
+              variant="ghost"
+              size="xs"
+              className="absolute right-0 top-1/2 mr-1 h-7 w-7 -translate-y-1/2 rounded-lg border-0 bg-transparent p-0 text-gray-400 hover:rounded-lg hover:bg-gray-100 hover:text-gray-600"
               disabled={
                 !instructions ||
                 instructions.length < MIN_INSTRUCTIONS_LENGTH_SUGGESTIONS
@@ -287,7 +290,7 @@ function AgentDescriptionInput() {
                 !instructions ||
                 instructions.length < MIN_INSTRUCTIONS_LENGTH_SUGGESTIONS
                   ? `Add at least ${MIN_INSTRUCTIONS_LENGTH_SUGGESTIONS} to the instructions to get suggestions`
-                  : undefined
+                  : "Get description suggestions"
               }
             />
           </DropdownMenuTrigger>

--- a/front/components/agent_builder/settings/AgentBuilderSettingsBlock.tsx
+++ b/front/components/agent_builder/settings/AgentBuilderSettingsBlock.tsx
@@ -208,18 +208,11 @@ function AgentDescriptionInput() {
   const sendNotification = useSendNotification();
 
   const [isGenerating, setIsGenerating] = useState(false);
-  const [descriptionSuggestions, setDescriptionSuggestions] = useState<
-    string[]
-  >([]);
 
   const { field, fieldState } = useController<
     AgentBuilderFormData,
     "agentSettings.description"
   >({ name: "agentSettings.description" });
-
-  const handleSelectDescriptionSuggestion = (suggestion: string) => {
-    field.onChange(suggestion);
-  };
 
   const handleGenerateDescription = async () => {
     if (
@@ -231,7 +224,6 @@ function AgentDescriptionInput() {
     }
 
     setIsGenerating(true);
-    setDescriptionSuggestions([]);
 
     const result = await getDescriptionSuggestion({
       owner,
@@ -255,7 +247,8 @@ function AgentDescriptionInput() {
       result.value.suggestions &&
       result.value.suggestions.length > 0
     ) {
-      setDescriptionSuggestions(result.value.suggestions);
+      // Apply the first suggestion directly
+      field.onChange(result.value.suggestions[0]);
     } else {
       sendNotification({
         type: "info",
@@ -278,53 +271,34 @@ function AgentDescriptionInput() {
           {...field}
           className="pr-10"
         />
-        <DropdownMenu
-          onOpenChange={(open) => open && handleGenerateDescription()}
-        >
-          <DropdownMenuTrigger asChild>
-            <Button
-              icon={SparklesIcon}
-              variant={
-                !instructions ||
-                instructions.length < MIN_INSTRUCTIONS_LENGTH_SUGGESTIONS
-                  ? "ghost"
-                  : "outline"
-              }
-              size="xs"
-              className="absolute right-0 top-1/2 mr-1 h-7 w-7 -translate-y-1/2 rounded-lg p-0"
-              disabled={
-                !instructions ||
-                instructions.length < MIN_INSTRUCTIONS_LENGTH_SUGGESTIONS
-              }
-              tooltip={
-                !instructions ||
-                instructions.length < MIN_INSTRUCTIONS_LENGTH_SUGGESTIONS
-                  ? `Add at least ${MIN_INSTRUCTIONS_LENGTH_SUGGESTIONS} to the instructions to get suggestions`
-                  : "Get description suggestions"
-              }
-            />
-          </DropdownMenuTrigger>
-          <DropdownMenuContent className="w-80" sideOffset={8}>
-            {isGenerating ? (
-              <div className="flex items-center justify-center p-4">
-                <Spinner size="sm" />
-              </div>
-            ) : descriptionSuggestions.length > 0 ? (
-              descriptionSuggestions.map((suggestion, index) => (
-                <DropdownMenuItem
-                  key={`description-suggestion-${index}`}
-                  label={suggestion}
-                  onClick={() => handleSelectDescriptionSuggestion(suggestion)}
-                  truncateText={false}
-                />
-              ))
-            ) : (
-              <div className="flex items-center justify-center p-4 text-sm text-muted-foreground">
-                No suggestions available
-              </div>
-            )}
-          </DropdownMenuContent>
-        </DropdownMenu>
+        <Button
+          icon={isGenerating ? () => <Spinner size="xs" /> : SparklesIcon}
+          variant={
+            isGenerating ||
+            !instructions ||
+            instructions.length < MIN_INSTRUCTIONS_LENGTH_SUGGESTIONS
+              ? "ghost"
+              : "outline"
+          }
+          size="xs"
+          className={`absolute right-0 top-1/2 mr-1 h-7 w-7 -translate-y-1/2 rounded-lg p-0 ${
+            isGenerating ? "bg-transparent" : ""
+          }`}
+          disabled={
+            isGenerating ||
+            !instructions ||
+            instructions.length < MIN_INSTRUCTIONS_LENGTH_SUGGESTIONS
+          }
+          onClick={handleGenerateDescription}
+          tooltip={
+            isGenerating
+              ? "Generating description..."
+              : !instructions ||
+                  instructions.length < MIN_INSTRUCTIONS_LENGTH_SUGGESTIONS
+                ? `Add at least ${MIN_INSTRUCTIONS_LENGTH_SUGGESTIONS} characters to the instructions to get suggestions`
+                : "Generate description"
+          }
+        />
       </div>
       {fieldState.error && (
         <p className="text-sm text-warning-500">{fieldState.error.message}</p>

--- a/front/components/agent_builder/settings/AgentBuilderSettingsBlock.tsx
+++ b/front/components/agent_builder/settings/AgentBuilderSettingsBlock.tsx
@@ -138,7 +138,7 @@ function AgentNameInput() {
 
   return (
     <div className="max-w-md space-y-2">
-      <label className="text-sm font-medium text-foreground dark:text-foreground-night">
+      <label className="text-sm font-semibold text-foreground dark:text-foreground-night">
         Name
       </label>
       <div className="relative">
@@ -264,7 +264,7 @@ function AgentDescriptionInput() {
 
   return (
     <div className="space-y-2">
-      <label className="text-sm font-medium text-foreground dark:text-foreground-night">
+      <label className="text-sm font-semibold text-foreground dark:text-foreground-night">
         Description
       </label>
       <div className="relative">

--- a/front/components/agent_builder/settings/AgentBuilderSettingsBlock.tsx
+++ b/front/components/agent_builder/settings/AgentBuilderSettingsBlock.tsx
@@ -141,18 +141,17 @@ function AgentNameInput() {
       <label className="text-sm font-medium text-foreground dark:text-foreground-night">
         Name
       </label>
-      <div className="flex items-center gap-2">
-        <div className="flex-grow">
-          <Input placeholder="Enter agent name" {...field} />
-        </div>
+      <div className="relative">
+        <Input placeholder="Enter agent name" {...field} className="pr-10" />
         <DropdownMenu
           onOpenChange={(open) => open && handleGenerateNameSuggestions()}
         >
           <DropdownMenuTrigger asChild>
             <Button
               icon={SparklesIcon}
-              variant="outline"
-              isSelect
+              variant="ghost"
+              size="xs"
+              className="absolute right-0 top-1/2 mr-1 h-7 w-7 -translate-y-1/2 rounded-none border-0 bg-transparent p-0 text-gray-400 hover:rounded-lg hover:bg-gray-100 hover:text-gray-600"
               disabled={
                 !instructions ||
                 instructions.length < MIN_INSTRUCTIONS_LENGTH_SUGGESTIONS
@@ -161,7 +160,7 @@ function AgentNameInput() {
                 !instructions ||
                 instructions.length < MIN_INSTRUCTIONS_LENGTH_SUGGESTIONS
                   ? `Add at least ${MIN_INSTRUCTIONS_LENGTH_SUGGESTIONS} characters to instructions to get suggestions`
-                  : undefined
+                  : "Get name suggestions"
               }
             />
           </DropdownMenuTrigger>

--- a/front/components/agent_builder/settings/AgentBuilderSettingsBlock.tsx
+++ b/front/components/agent_builder/settings/AgentBuilderSettingsBlock.tsx
@@ -164,7 +164,7 @@ function AgentNameInput() {
               }
             />
           </DropdownMenuTrigger>
-          <DropdownMenuContent className="w-64" sideOffset={8}>
+          <DropdownMenuContent className="w-64">
             {isGenerating ? (
               <div className="flex items-center justify-center p-4">
                 <Spinner size="sm" />

--- a/front/components/agent_builder/settings/AgentBuilderSettingsBlock.tsx
+++ b/front/components/agent_builder/settings/AgentBuilderSettingsBlock.tsx
@@ -164,7 +164,7 @@ function AgentNameInput() {
               }
             />
           </DropdownMenuTrigger>
-          <DropdownMenuContent className="w-64">
+          <DropdownMenuContent className="w-64" sideOffset={8}>
             {isGenerating ? (
               <div className="flex items-center justify-center p-4">
                 <Spinner size="sm" />
@@ -294,7 +294,7 @@ function AgentDescriptionInput() {
               }
             />
           </DropdownMenuTrigger>
-          <DropdownMenuContent className="w-80">
+          <DropdownMenuContent className="w-80" sideOffset={8}>
             {isGenerating ? (
               <div className="flex items-center justify-center p-4">
                 <Spinner size="sm" />

--- a/front/components/agent_builder/settings/AgentBuilderSettingsBlock.tsx
+++ b/front/components/agent_builder/settings/AgentBuilderSettingsBlock.tsx
@@ -451,13 +451,9 @@ export function AgentBuilderSettingsBlock({
                 </div>
                 <AgentPictureInput />
               </div>
-              <div className="flex gap-8">
-                <div className="flex-1">
-                  <TagsSection />
-                </div>
-                <div className="flex-1">
-                  <AgentAccessAndPublication />
-                </div>
+              <div className="space-y-4">
+                <TagsSection />
+                <AgentAccessAndPublication />
               </div>
             </div>
           </div>

--- a/front/components/agent_builder/settings/AgentBuilderSettingsBlock.tsx
+++ b/front/components/agent_builder/settings/AgentBuilderSettingsBlock.tsx
@@ -150,7 +150,6 @@ function AgentNameInput() {
         >
           <DropdownMenuTrigger asChild>
             <Button
-              label="Suggest"
               icon={SparklesIcon}
               variant="outline"
               isSelect
@@ -278,7 +277,6 @@ function AgentDescriptionInput() {
         >
           <DropdownMenuTrigger asChild>
             <Button
-              label="Suggest"
               icon={SparklesIcon}
               variant="outline"
               isSelect

--- a/front/components/agent_builder/settings/AgentBuilderSettingsBlock.tsx
+++ b/front/components/agent_builder/settings/AgentBuilderSettingsBlock.tsx
@@ -149,9 +149,14 @@ function AgentNameInput() {
           <DropdownMenuTrigger asChild>
             <Button
               icon={SparklesIcon}
-              variant="ghost"
+              variant={
+                !instructions ||
+                instructions.length < MIN_INSTRUCTIONS_LENGTH_SUGGESTIONS
+                  ? "ghost"
+                  : "outline"
+              }
               size="xs"
-              className="absolute right-0 top-1/2 mr-1 h-7 w-7 -translate-y-1/2 rounded-lg border-0 bg-transparent p-0 text-gray-400 hover:rounded-lg hover:bg-gray-100 hover:text-gray-600"
+              className="absolute right-0 top-1/2 mr-1 h-7 w-7 -translate-y-1/2 rounded-lg p-0"
               disabled={
                 !instructions ||
                 instructions.length < MIN_INSTRUCTIONS_LENGTH_SUGGESTIONS
@@ -279,9 +284,14 @@ function AgentDescriptionInput() {
           <DropdownMenuTrigger asChild>
             <Button
               icon={SparklesIcon}
-              variant="ghost"
+              variant={
+                !instructions ||
+                instructions.length < MIN_INSTRUCTIONS_LENGTH_SUGGESTIONS
+                  ? "ghost"
+                  : "outline"
+              }
               size="xs"
-              className="absolute right-0 top-1/2 mr-1 h-7 w-7 -translate-y-1/2 rounded-lg border-0 bg-transparent p-0 text-gray-400 hover:rounded-lg hover:bg-gray-100 hover:text-gray-600"
+              className="absolute right-0 top-1/2 mr-1 h-7 w-7 -translate-y-1/2 rounded-lg p-0"
               disabled={
                 !instructions ||
                 instructions.length < MIN_INSTRUCTIONS_LENGTH_SUGGESTIONS

--- a/front/components/agent_builder/settings/TagsSection.tsx
+++ b/front/components/agent_builder/settings/TagsSection.tsx
@@ -163,7 +163,7 @@ export function TagsSection() {
 
   return (
     <div className="flex h-full flex-col gap-4">
-      <label className="text-sm font-medium text-foreground dark:text-foreground-night">
+      <label className="text-sm font-semibold text-foreground dark:text-foreground-night">
         Tags
       </label>
       <TagsSelector


### PR DESCRIPTION
## Description

- Improved suggestion buttons in the new agent builder. Buttons are minimal, without labels,  and are visually part of the input field. 
- Moved Access and Publication sections below Tags section to declutter the UX.

## Tests

Locally.

## Risk

Low, behind FF.

## Deploy Plan

Deploy front.
