### PR TITLE
Sparkle: Ability to display CodeBlockForExtendedSupport actions on hover for Pretty JSON rendering in Markdown

### DIFF
--- a/sparkle/src/components/markdown/CodeBlockWithExtendedSupport.tsx
+++ b/sparkle/src/components/markdown/CodeBlockWithExtendedSupport.tsx
@@ -390,6 +390,7 @@ export function CodeBlockWithExtendedSupport({
             }
           />
         }
+        displayActions="hover"
       >
         {showPrettyJson ? (
           <PrettyJsonViewer data={parsedJson} />

--- a/sparkle/src/components/markdown/ContentBlockWrapper.tsx
+++ b/sparkle/src/components/markdown/ContentBlockWrapper.tsx
@@ -36,6 +36,7 @@ interface ContentBlockWrapperProps {
   content?: ClipboardContent | string;
   getContentToDownload?: GetContentToDownloadFunction;
   actions?: React.ReactNode[] | React.ReactNode;
+  displayActions?: "hover" | "always";
 }
 
 export function ContentBlockWrapper({
@@ -44,6 +45,7 @@ export function ContentBlockWrapper({
   innerClassName,
   content,
   actions,
+  displayActions = "always",
   getContentToDownload,
 }: ContentBlockWrapperProps) {
   const [isCopied, copyToClipboard] = useCopyToClipboard();
@@ -91,14 +93,18 @@ export function ContentBlockWrapper({
     <div
       id="BlockWrapper"
       className={cn(
-        "s-relative s-mt-11 s-w-full !s-overflow-visible",
+        "s-group s-relative s-mt-11 s-w-full !s-overflow-visible",
         className
       )}
     >
       <div className="s-sticky s-top-11 s-z-[1] s-h-0">
         <div
           id="BlockActions"
-          className="s-absolute s-bottom-0 s-right-2 s-flex s-h-11 s-items-center s-gap-1 s-py-2"
+          className={cn(
+            "s-absolute s-bottom-0 s-right-2 s-flex s-h-11 s-items-center s-gap-1 s-py-2",
+            displayActions === "hover" &&
+              "s-opacity-0 s-transition-opacity s-duration-200 group-hover:s-opacity-100"
+          )}
         >
           {actions && actions}
           {getContentToDownload && (

--- a/sparkle/src/components/markdown/PrettyJsonViewer.tsx
+++ b/sparkle/src/components/markdown/PrettyJsonViewer.tsx
@@ -211,7 +211,7 @@ export function PrettyJsonViewer({ data, className }: JsonViewerProps) {
     <div
       className={cn(
         "s-bg-structure-50 dark:s-bg-structure-50-night",
-        "s-overflow-hidden s-rounded-lg s-p-6 s-text-base",
+        "s-overflow-hidden s-rounded-lg s-px-4 s-text-base",
         className
       )}
     >


### PR DESCRIPTION
## Description

Goal of this PR is to display the actions buttons of a pretty rendered JSON on hover instead of always. 

### Changes
- Update `ContentBlockWrapper` to add optional attribute to hide actions on hover - default is same behavior as before. 
- Update Rendering of JSON block to use this attribute to "hover" to hide the actions unless we're hovering on the block. 
- Fix very big margin in rendering of JSON block. 

### Demo
Cf screenshot, I'm hovering on the first block: 

<img width="1296" height="305" alt="Screenshot 2025-07-29 at 20 20 01" src="https://github.com/user-attachments/assets/68d59636-37ed-4fa9-8ee2-58f860668ac3" />

Change visible locally on http://localhost:6006/?path=/story/components-markdown--json-markdown-story


###  Why this change
If we want to display pretty JSON for actions input/output in the conversation drawer, it's ugly if we always display those action buttons 🙈 

## Tests

Locally on Storybook. 

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

Publish Sparkle. 