### PR TITLE
Tool Output: Render JSON as pretty JSON

### DIFF
--- a/extension/package-lock.json
+++ b/extension/package-lock.json
@@ -12,7 +12,7 @@
         "@auth0/auth0-spa-js": "^2.1.3",
         "@datadog/browser-logs": "^6.13.0",
         "@dust-tt/client": "1.1.4",
-        "@dust-tt/sparkle": "^0.2.545",
+        "@dust-tt/sparkle": "^0.2.548",
         "@frontapp/plugin-sdk": "^1.8.1",
         "@modelcontextprotocol/sdk": "^1.9.0",
         "@tailwindcss/forms": "^0.5.9",
@@ -1254,9 +1254,9 @@
       }
     },
     "node_modules/@dust-tt/sparkle": {
-      "version": "0.2.545",
-      "resolved": "https://registry.npmjs.org/@dust-tt/sparkle/-/sparkle-0.2.545.tgz",
-      "integrity": "sha512-5qbsg9JOOl9+wbfp6T1iUBTT1qlCqySsMG0qOZdDufv469vbHVhfbs5mnCIOlASm3qoau2d6MQMxq4KPlF3ikA==",
+      "version": "0.2.548",
+      "resolved": "https://registry.npmjs.org/@dust-tt/sparkle/-/sparkle-0.2.548.tgz",
+      "integrity": "sha512-sXOpnRmEjeaf3j9zPLwNUuWF2bmTwyZJag5qgk2p8ivOg6KMC6TXYfge2rSlAPEc3ruu8G7mIKEUlC0jjIC7VA==",
       "dependencies": {
         "@emoji-mart/data": "^1.1.2",
         "@emoji-mart/react": "^1.1.1",

--- a/extension/package.json
+++ b/extension/package.json
@@ -59,7 +59,7 @@
     "@auth0/auth0-spa-js": "^2.1.3",
     "@datadog/browser-logs": "^6.13.0",
     "@dust-tt/client": "1.1.4",
-    "@dust-tt/sparkle": "^0.2.545",
+    "@dust-tt/sparkle": "^0.2.548",
     "@frontapp/plugin-sdk": "^1.8.1",
     "@modelcontextprotocol/sdk": "^1.9.0",
     "@tailwindcss/forms": "^0.5.9",

--- a/front/components/actions/mcp/details/MCPActionDetails.tsx
+++ b/front/components/actions/mcp/details/MCPActionDetails.tsx
@@ -2,10 +2,11 @@ import {
   ActionDocumentTextIcon,
   ClockIcon,
   cn,
-  CodeBlock,
   CollapsibleComponent,
+  ContentMessage,
   GlobeAltIcon,
   MagnifyingGlassIcon,
+  Markdown,
 } from "@dust-tt/sparkle";
 
 import { ActionDetailsWrapper } from "@app/components/actions/ActionDetailsWrapper";
@@ -24,6 +25,7 @@ import type { MCPActionType } from "@app/lib/actions/mcp";
 import { SEARCH_TOOL_NAME } from "@app/lib/actions/mcp_internal_actions/constants";
 import type { ProgressNotificationContentType } from "@app/lib/actions/mcp_internal_actions/output_schemas";
 import {
+  getOutputText,
   isBrowseResultResourceType,
   isDataSourceNodeContentType,
   isDataSourceNodeListType,
@@ -33,13 +35,16 @@ import {
   isGetDatabaseSchemaMarkerResourceType,
   isIncludeResultResourceType,
   isReasoningSuccessOutput,
+  isResourceContentWithText,
   isRunAgentProgressOutput,
   isRunAgentResultResourceType,
   isSearchResultResourceType,
   isSqlQueryOutput,
+  isTextContent,
   isWebsearchResultResourceType,
 } from "@app/lib/actions/mcp_internal_actions/output_schemas";
 import { MCP_SPECIFICATION } from "@app/lib/actions/utils";
+import { isValidJSON } from "@app/lib/utils/json";
 import type { LightWorkspaceType } from "@app/types";
 import { isSupportedImageContentType } from "@app/types";
 
@@ -145,6 +150,8 @@ export function GenericActionDetails({
   action,
   defaultOpen,
 }: MCPActionDetailsProps) {
+  const inputs = JSON.stringify(action.params, undefined, 2) ?? "";
+
   return (
     <ActionDetailsWrapper
       actionName={action.functionCallName ?? "Calling MCP Server"}
@@ -164,11 +171,7 @@ export function GenericActionDetails({
               <span className="heading-base">Inputs</span>
             </div>
           }
-          contentChildren={
-            <CodeBlock wrapLongLines className="language-json">
-              {JSON.stringify(action.params, undefined, 2) ?? ""}
-            </CodeBlock>
-          }
+          contentChildren={<RenderToolItemMarkdown text={inputs} />}
         />
 
         {action.output && (
@@ -185,16 +188,18 @@ export function GenericActionDetails({
               </div>
             }
             contentChildren={
-              <CodeBlock wrapLongLines>
+              <div className="flex flex-col gap-2">
                 {action.output
                   .filter(
-                    (o) => o.text || (o.type === "resource" && o.resource.text)
+                    (o) => isTextContent(o) || isResourceContentWithText(o)
                   )
-                  .map(
-                    (o) => o.text || (o.type === "resource" && o.resource.text)
-                  )
-                  .join("\n")}
-              </CodeBlock>
+                  .map((o, index) => (
+                    <RenderToolItemMarkdown
+                      key={index}
+                      text={getOutputText(o)}
+                    />
+                  ))}
+              </div>
             }
           />
         )}
@@ -234,3 +239,15 @@ export function GenericActionDetails({
     </ActionDetailsWrapper>
   );
 }
+
+const RenderToolItemMarkdown = ({ text }: { text: string }) => {
+  if (isValidJSON(text)) {
+    return <Markdown content={`\`\`\`json\n${text}\n\`\`\``} />;
+  }
+
+  return (
+    <ContentMessage variant="primary" size="lg">
+      <Markdown content={text} />
+    </ContentMessage>
+  );
+};

--- a/front/lib/actions/mcp_internal_actions/output_schemas.ts
+++ b/front/lib/actions/mcp_internal_actions/output_schemas.ts
@@ -813,3 +813,35 @@ export function isTextContent(
 ): content is { type: "text"; text: string } {
   return content.type === "text";
 }
+
+export function isResourceContentWithText(
+  content: CallToolResult["content"][number]
+): content is {
+  type: "resource";
+  resource: {
+    [x: string]: unknown;
+    text: string;
+    uri: string;
+    mimeType?: string | undefined;
+  };
+} {
+  return (
+    content.type === "resource" &&
+    typeof content.resource === "object" &&
+    content.resource !== null &&
+    "text" in content.resource &&
+    typeof (content.resource as any).text === "string"
+  );
+}
+
+export const getOutputText = (
+  output: CallToolResult["content"][number]
+): string => {
+  if (isTextContent(output)) {
+    return output.text;
+  }
+  if (isResourceContentWithText(output)) {
+    return output.resource.text;
+  }
+  return "";
+};

--- a/front/lib/utils/json.ts
+++ b/front/lib/utils/json.ts
@@ -1,0 +1,8 @@
+export const isValidJSON = (text: string) => {
+  try {
+    JSON.parse(text);
+    return true;
+  } catch {
+    return false;
+  }
+};

--- a/front/package-lock.json
+++ b/front/package-lock.json
@@ -8,7 +8,7 @@
         "@auth0/nextjs-auth0": "^3.5.0",
         "@datadog/browser-logs": "^6.13.0",
         "@dust-tt/client": "file:../sdks/js",
-        "@dust-tt/sparkle": "^0.2.545",
+        "@dust-tt/sparkle": "^0.2.548",
         "@google-cloud/bigquery": "^7.9.1",
         "@google-cloud/storage-transfer": "^3.6.0",
         "@heroicons/react": "^2.0.11",
@@ -1131,9 +1131,10 @@
       "link": true
     },
     "node_modules/@dust-tt/sparkle": {
-      "version": "0.2.545",
-      "resolved": "https://registry.npmjs.org/@dust-tt/sparkle/-/sparkle-0.2.545.tgz",
-      "integrity": "sha512-5qbsg9JOOl9+wbfp6T1iUBTT1qlCqySsMG0qOZdDufv469vbHVhfbs5mnCIOlASm3qoau2d6MQMxq4KPlF3ikA==",
+      "version": "0.2.548",
+      "resolved": "https://registry.npmjs.org/@dust-tt/sparkle/-/sparkle-0.2.548.tgz",
+      "integrity": "sha512-sXOpnRmEjeaf3j9zPLwNUuWF2bmTwyZJag5qgk2p8ivOg6KMC6TXYfge2rSlAPEc3ruu8G7mIKEUlC0jjIC7VA==",
+      "license": "ISC",
       "dependencies": {
         "@emoji-mart/data": "^1.1.2",
         "@emoji-mart/react": "^1.1.1",

--- a/front/package.json
+++ b/front/package.json
@@ -25,7 +25,7 @@
     "@auth0/nextjs-auth0": "^3.5.0",
     "@datadog/browser-logs": "^6.13.0",
     "@dust-tt/client": "file:../sdks/js",
-    "@dust-tt/sparkle": "^0.2.545",
+    "@dust-tt/sparkle": "^0.2.548",
     "@google-cloud/bigquery": "^7.9.1",
     "@google-cloud/storage-transfer": "^3.6.0",
     "@heroicons/react": "^2.0.11",


### PR DESCRIPTION
## Description

Goal of this PR is to improve the UI of the tool input/output in the Tool Inspection modal. 
- Inputs are displayed using the "Pretty JSON" view of our Markdown component. 
- Outputs are displayed in blocks and use the "Pretty JSON" view when output is JSON. 


Seen with Design already, said good to go as is! 

| Before    | After |
| -------- | ------- |
| <img width="763" height="1212" alt="Screenshot 2025-07-30 at 09 43 01" src="https://github.com/user-attachments/assets/e28d3723-f174-4de5-8bea-aa6fe93ac50a" />  | <img width="760" height="1633" alt="Screenshot 2025-07-30 at 09 43 18" src="https://github.com/user-attachments/assets/527e5c88-0531-4e9e-a33b-83f41685da90" />   |

By hovering on the content you can switch back to raw json!

## Tests

Locally, on front edge. 

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

Deploy front. 