### PR TITLE
[front] enh(Zendesk modal): add input placeholder

### DIFF
--- a/front/components/data_source/ZendeskConfigView.tsx
+++ b/front/components/data_source/ZendeskConfigView.tsx
@@ -47,7 +47,7 @@ export function ZendeskConfigView({
     configKey: hideCustomerDetailsConfigKey,
   });
   const {
-    configValue: retentionPeriodConfigValue,
+    configValue: retentionPeriodDays,
     mutateConfig: mutateRetentionPeriodConfig,
   } = useConnectorConfig({
     owner,
@@ -58,8 +58,6 @@ export function ZendeskConfigView({
   const syncUnresolvedTicketsEnabled =
     syncUnresolvedTicketsConfigValue === "true";
   const hideCustomerDetailsEnabled = hideCustomerDetailsConfigValue === "true";
-
-  const retentionPeriodDays = retentionPeriodConfigValue;
 
   const sendNotification = useSendNotification();
   const [loading, setLoading] = useState(false);
@@ -205,6 +203,7 @@ export function ZendeskConfigView({
               type="number"
               onChange={(e) => setRetentionInput(e.target.value)}
               disabled={readOnly || !isAdmin || loading}
+              placeholder={retentionPeriodDays ?? undefined}
               className="w-20"
             />
             <span className="text-sm text-muted-foreground">days</span>


### PR DESCRIPTION
## Description

- This PR adds a placeholder in the input, equal to the value prior to editing it.
- This placeholder will give a visual hint that matches the behavior of the button being disabled if the value input is equal to the currently configured value.

## Tests

- Tested locally.

## Risk

- Very low, only minor UI changes, scoped to the Zendesk option component.

## Deploy Plan

- Deploy front.
