### PR TITLE
Handle token error for confluence

### DIFF
--- a/connectors/src/lib/oauth.ts
+++ b/connectors/src/lib/oauth.ts
@@ -37,7 +37,9 @@ export async function getOAuthConnectionAccessTokenWithThrow({
 
     if (
       tokRes.error.code === "token_revoked_error" ||
-      tokRes.error.code === "connection_not_found"
+      tokRes.error.code === "connection_not_found" ||
+      (tokRes.error.code === "provider_access_token_refresh_error" &&
+        tokRes.error.message.includes("Token was globally revoked"))
     ) {
       throw new ExternalOAuthTokenError(new Error(tokRes.error.message));
     } else {


### PR DESCRIPTION
## Description

Handle correctly when the token is no longer valid for confluence.
See [this](https://app.datadoghq.eu/dashboard/eza-jyh-pwy/stuck-connectors-worker?query=%28%28%22Activity%20failed%22%20OR%20%22Unhandled%20activity%20error%22%29%20%40attempt%3A%3E19%20%40dd.service%3Aconnectors-worker%20region%3Aus-central1%29%20AND%20%40workflowId%3Aconfluence-sync-26568-space-2531197460-top-level-page-2531221814&fromUser=false&index=%2A&panelFrom=1753867494994&panelStorageType=hot&panelTo=1753868394994&panelType=logs&refresh_mode=sliding&from_ts=1753867478213&to_ts=1753868378213&live=true)

## Risk

Low

## Deploy Plan

Deploy connectors