### PR TITLE
[sparkle] - refactor: update SheetFooter component layout

### DIFF
--- a/sparkle/src/components/Sheet.tsx
+++ b/sparkle/src/components/Sheet.tsx
@@ -173,7 +173,7 @@ const SheetFooter = ({
   <div
     className={cn(
       "s-flex s-flex-none s-flex-col s-gap-2",
-      "s-border-t s-border-border dark:s-border-border-night",
+      "s-border-border dark:s-border-border-night",
       className
     )}
     {...props}

--- a/sparkle/src/components/Sheet.tsx
+++ b/sparkle/src/components/Sheet.tsx
@@ -172,13 +172,14 @@ const SheetFooter = ({
 }: SheetFooterProps) => (
   <div
     className={cn(
-      "s-flex s-flex-none s-flex-col s-gap-2 s-border-t s-px-3 s-py-3",
-      "s-border-border dark:s-border-border-night",
+      "s-flex s-flex-none s-flex-col s-gap-2",
+      "s-border-t s-border-border dark:s-border-border-night",
       className
     )}
     {...props}
   >
-    <div className="s-flex s-flex-row s-gap-2">
+    {children}
+    <div className="s-flex s-flex-row s-gap-2 s-border-t s-border-border s-px-3 s-py-3 dark:s-border-border-night">
       {leftButtonProps &&
         (leftButtonProps.disabled ? (
           <Button {...leftButtonProps} />
@@ -205,7 +206,6 @@ const SheetFooter = ({
           </SheetClose>
         ))}
     </div>
-    {children}
   </div>
 );
 SheetFooter.displayName = "SheetFooter";


### PR DESCRIPTION
## Description

This PR moves the children rendering above the button row to adjust the component’s structure in the SheetFooter

## Deploy Plan

Publish sparkle