### PR TITLE
Allow CORS to ad tracker systems

### DIFF
--- a/front/next.config.js
+++ b/front/next.config.js
@@ -8,7 +8,7 @@ const CONTENT_SECURITY_POLICIES = [
   `script-src 'self' 'unsafe-inline' 'unsafe-eval' *.googletagmanager.com *.google-analytics.com *.hsforms.net *.hs-scripts.com *.hs-analytics.net *.hubspot.com *.hs-banner.com *.hscollectedforms.net *.usercentrics.eu *.cr-relay.com *.licdn.com *.datadoghq-browser-agent.com ${showReactScan ? "unpkg.com" : ""};`,
   `style-src 'self' 'unsafe-inline';`,
   `img-src 'self' data: https:;`,
-  `connect-src 'self' blob: browser-intake-datadoghq.eu *.google-analytics.com *.googlesyndication.com cdn.jsdelivr.net *.hsforms.com *.hscollectedforms.net *.hubspot.com *.cr-relay.com *.usercentrics.eu *.linkedin.com;`,
+  `connect-src 'self' blob: browser-intake-datadoghq.eu *.google-analytics.com *.googlesyndication.com cdn.jsdelivr.net *.hsforms.com *.hscollectedforms.net *.hubspot.com *.cr-relay.com *.usercentrics.eu *.linkedin.com *.google.com;`,
   `frame-src 'self' *.wistia.net eu.viz.dust.tt viz.dust.tt *.hsforms.net *.googletagmanager.com;`,
   `font-src 'self' data: dust.tt *.dust.tt;`,
   `object-src 'none';`,

--- a/front/next.config.js
+++ b/front/next.config.js
@@ -8,7 +8,7 @@ const CONTENT_SECURITY_POLICIES = [
   `script-src 'self' 'unsafe-inline' 'unsafe-eval' *.googletagmanager.com *.google-analytics.com *.hsforms.net *.hs-scripts.com *.hs-analytics.net *.hubspot.com *.hs-banner.com *.hscollectedforms.net *.usercentrics.eu *.cr-relay.com *.licdn.com *.datadoghq-browser-agent.com ${showReactScan ? "unpkg.com" : ""};`,
   `style-src 'self' 'unsafe-inline';`,
   `img-src 'self' data: https:;`,
-  `connect-src 'self' blob: browser-intake-datadoghq.eu *.google-analytics.com *.googlesyndication.com cdn.jsdelivr.net *.hsforms.com *.hscollectedforms.net *.hubspot.com *.cr-relay.com *.usercentrics.eu;`,
+  `connect-src 'self' blob: browser-intake-datadoghq.eu *.google-analytics.com *.googlesyndication.com cdn.jsdelivr.net *.hsforms.com *.hscollectedforms.net *.hubspot.com *.cr-relay.com *.usercentrics.eu *.linkedin.com;`,
   `frame-src 'self' *.wistia.net eu.viz.dust.tt viz.dust.tt *.hsforms.net *.googletagmanager.com;`,
   `font-src 'self' data: dust.tt *.dust.tt;`,
   `object-src 'none';`,

--- a/front/next.config.js
+++ b/front/next.config.js
@@ -8,7 +8,7 @@ const CONTENT_SECURITY_POLICIES = [
   `script-src 'self' 'unsafe-inline' 'unsafe-eval' *.googletagmanager.com *.google-analytics.com *.hsforms.net *.hs-scripts.com *.hs-analytics.net *.hubspot.com *.hs-banner.com *.hscollectedforms.net *.usercentrics.eu *.cr-relay.com *.licdn.com ${showReactScan ? "unpkg.com" : ""};`,
   `style-src 'self' 'unsafe-inline';`,
   `img-src 'self' data: https:;`,
-  `connect-src 'self' blob: browser-intake-datadoghq.eu *.google-analytics.com *.googlesyndication.com cdn.jsdelivr.net *.hsforms.com *.hscollectedforms.net *.hubspot.com *.cr-relay.com *.usercentrics.eu *.px.ads.linkedin.com *.google.com/ccm/;`,
+  `connect-src 'self' blob: browser-intake-datadoghq.eu *.google-analytics.com *.googlesyndication.com cdn.jsdelivr.net *.hsforms.com *.hscollectedforms.net *.hubspot.com *.cr-relay.com *.usercentrics.eu *px.ads.linkedin.com *.google.com/ccm/;`,
   `frame-src 'self' *.wistia.net eu.viz.dust.tt viz.dust.tt *.hsforms.net *.googletagmanager.com;`,
   `font-src 'self' data: dust.tt *.dust.tt;`,
   `object-src 'none';`,

--- a/front/next.config.js
+++ b/front/next.config.js
@@ -8,7 +8,7 @@ const CONTENT_SECURITY_POLICIES = [
   `script-src 'self' 'unsafe-inline' 'unsafe-eval' *.googletagmanager.com *.google-analytics.com *.hsforms.net *.hs-scripts.com *.hs-analytics.net *.hubspot.com *.hs-banner.com *.hscollectedforms.net *.usercentrics.eu *.cr-relay.com *.licdn.com *.datadoghq-browser-agent.com ${showReactScan ? "unpkg.com" : ""};`,
   `style-src 'self' 'unsafe-inline';`,
   `img-src 'self' data: https:;`,
-  `connect-src 'self' blob: browser-intake-datadoghq.eu *.google-analytics.com *.googlesyndication.com cdn.jsdelivr.net *.hsforms.com *.hscollectedforms.net *.hubspot.com *.cr-relay.com *.usercentrics.eu *.linkedin.com *.google.com;`,
+  `connect-src 'self' blob: browser-intake-datadoghq.eu *.google-analytics.com *.googlesyndication.com cdn.jsdelivr.net *.hsforms.com *.hscollectedforms.net *.hubspot.com *.cr-relay.com *.usercentrics.eu *.px.ads.linkedin.com *.google.com/ccm/;`,
   `frame-src 'self' *.wistia.net eu.viz.dust.tt viz.dust.tt *.hsforms.net *.googletagmanager.com;`,
   `font-src 'self' data: dust.tt *.dust.tt;`,
   `object-src 'none';`,

--- a/front/next.config.js
+++ b/front/next.config.js
@@ -8,7 +8,7 @@ const CONTENT_SECURITY_POLICIES = [
   `script-src 'self' 'unsafe-inline' 'unsafe-eval' *.googletagmanager.com *.google-analytics.com *.hsforms.net *.hs-scripts.com *.hs-analytics.net *.hubspot.com *.hs-banner.com *.hscollectedforms.net *.usercentrics.eu *.cr-relay.com *.licdn.com ${showReactScan ? "unpkg.com" : ""};`,
   `style-src 'self' 'unsafe-inline';`,
   `img-src 'self' data: https:;`,
-  `connect-src 'self' blob: browser-intake-datadoghq.eu *.google-analytics.com *.googlesyndication.com cdn.jsdelivr.net *.hsforms.com *.hscollectedforms.net *.hubspot.com *.cr-relay.com *.usercentrics.eu *px.ads.linkedin.com *.google.com/ccm/;`,
+  `connect-src 'self' blob: browser-intake-datadoghq.eu *.google-analytics.com *.googlesyndication.com cdn.jsdelivr.net *.hsforms.com *.hscollectedforms.net *.hubspot.com *.cr-relay.com *.usercentrics.eu *.ads.linkedin.com *.google.com/ccm/;`,
   `frame-src 'self' *.wistia.net eu.viz.dust.tt viz.dust.tt *.hsforms.net *.googletagmanager.com;`,
   `font-src 'self' data: dust.tt *.dust.tt;`,
   `object-src 'none';`,


### PR DESCRIPTION
## Description

Our ads campaign tracking is now using 2 providers : google and linkedin. 
Enabling CORS on these 2 domains allows to collect the origin of the add campaign that has lead the user to dust, and measure efficiency of our ad campaigns.

Currently, even without an ad blocker, all calls back to the tracking APIs are blocked
<img width="273" height="109" alt="image" src="https://github.com/user-attachments/assets/4b009ea7-a541-4951-990c-3874cec6fc86" />


## Tests

Tested on front edge.

## Deploy Plan

Front only
