### PR TITLE
Improve agent name displayed in Slack + cutover

### DIFF
--- a/connectors/src/connectors/slack/bot.ts
+++ b/connectors/src/connectors/slack/bot.ts
@@ -813,7 +813,6 @@ async function answerMessage(
     ...makeMessageUpdateBlocksAndText(null, connector.workspaceId, {
       assistantName: mention.assistantName,
       agentConfigurations: mostPopularAgentConfigurations,
-      isComplete: false,
       isThinking: true,
     }),
     channel: slackChannel,

--- a/connectors/src/connectors/slack/chat/blocks.ts
+++ b/connectors/src/connectors/slack/chat/blocks.ts
@@ -60,12 +60,17 @@ function makeFootnotesBlock(footnotes: SlackMessageFootnotes) {
   };
 }
 
-function makeContextSectionBlocks(
-  isComplete: boolean,
-  conversationUrl: string | null,
-  footnotes: SlackMessageFootnotes | undefined,
-  workspaceId: string
-) {
+function makeContextSectionBlocks({
+  assistantName,
+  conversationUrl,
+  footnotes,
+  workspaceId,
+}: {
+  assistantName: string;
+  conversationUrl: string | null;
+  footnotes: SlackMessageFootnotes | undefined;
+  workspaceId: string;
+}) {
   const blocks = [];
 
   if (footnotes && footnotes.length > 0) {
@@ -75,27 +80,33 @@ function makeContextSectionBlocks(
     }
   }
 
-  blocks.push(makeFooterBlock(conversationUrl, workspaceId));
+  blocks.push(
+    makeFooterBlock({
+      assistantName,
+      conversationUrl,
+      workspaceId,
+    })
+  );
 
   const resultBlocks = blocks.length ? [makeDividerBlock(), ...blocks] : [];
 
   return resultBlocks;
 }
 
-function makeThinkingBlock(
-  assistantName: string,
-  isThinking: boolean,
-  thinkingText: string
-) {
-  return assistantName
+function makeThinkingBlock({
+  isThinking,
+  thinkingText,
+}: {
+  isThinking: boolean;
+  thinkingText: string;
+}) {
+  return isThinking
     ? [
         {
           type: "section",
           text: {
             type: "mrkdwn",
-            text: isThinking
-              ? `@${assistantName}: _${thinkingText}_`
-              : `@${assistantName}`,
+            text: `_${thinkingText}_`,
           },
         },
       ]
@@ -135,7 +146,6 @@ export function makeAssistantSelectionBlock(
 }
 
 export type SlackMessageUpdate = {
-  isComplete: boolean;
   isThinking?: boolean;
   thinkingAction?: string;
   assistantName: string;
@@ -144,19 +154,26 @@ export type SlackMessageUpdate = {
   footnotes?: SlackMessageFootnotes;
 };
 
-export function makeFooterBlock(
-  conversationUrl: string | null,
-  workspaceId: string
-) {
+export function makeFooterBlock({
+  assistantName,
+  conversationUrl,
+  workspaceId,
+}: {
+  assistantName?: string;
+  conversationUrl: string | null;
+  workspaceId: string;
+}) {
   const assistantsUrl = makeDustAppUrl(`/w/${workspaceId}/assistant/new`);
   const baseHeader = `<${assistantsUrl}|Browse agents> | <${SLACK_HELP_URL}|Use Dust in Slack> | <${DUST_URL}|Learn more>`;
+  const attribution = assistantName ? `Answered by *${assistantName}* | ` : "";
+
   return {
     type: "context",
     elements: [
       {
         type: "mrkdwn",
         text: conversationUrl
-          ? `<${conversationUrl}|Go to full conversation> | ${baseHeader}`
+          ? `${attribution}<${conversationUrl}|Go to full conversation> | ${baseHeader}`
           : baseHeader,
       },
     ],
@@ -168,33 +185,26 @@ export function makeMessageUpdateBlocksAndText(
   workspaceId: string,
   messageUpdate: SlackMessageUpdate
 ) {
-  const {
-    isComplete,
-    isThinking,
-    thinkingAction,
-    assistantName,
-    text,
-    footnotes,
-  } = messageUpdate;
-  const thinkingText = "is thinking...";
+  const { isThinking, thinkingAction, assistantName, text, footnotes } =
+    messageUpdate;
+  const thinkingText = "Agent is thinking...";
   const thinkingTextWithAction = thinkingAction
     ? `${thinkingText}... (${thinkingAction})`
     : thinkingText;
 
   return {
     blocks: [
-      ...makeThinkingBlock(
-        assistantName,
-        isThinking ?? false,
-        thinkingTextWithAction
-      ),
+      ...makeThinkingBlock({
+        isThinking: isThinking ?? false,
+        thinkingText: thinkingTextWithAction,
+      }),
       ...makeMarkdownBlock(text),
-      ...makeContextSectionBlocks(
-        isComplete,
+      ...makeContextSectionBlocks({
+        assistantName,
         conversationUrl,
         footnotes,
-        workspaceId
-      ),
+        workspaceId,
+      }),
     ],
     // TODO(2024-06-17 flav) We should not return markdown here.
     // Provide plain text for places where the content cannot be rendered (e.g push notifications).
@@ -221,7 +231,10 @@ export function makeErrorBlock(
         },
       },
       makeDividerBlock(),
-      makeFooterBlock(conversationUrl, workspaceId),
+      makeFooterBlock({
+        conversationUrl,
+        workspaceId,
+      }),
     ],
     mrkdwn: true,
     unfurl_links: false,

--- a/connectors/src/connectors/slack/chat/stream_conversation_handler.ts
+++ b/connectors/src/connectors/slack/chat/stream_conversation_handler.ts
@@ -73,7 +73,6 @@ export async function streamConversationToSlack(
   await postSlackMessageUpdate(
     {
       messageUpdate: {
-        isComplete: false,
         isThinking: true,
         assistantName,
         agentConfigurations,
@@ -133,7 +132,6 @@ async function streamAgentAnswerToSlack(
         await postSlackMessageUpdate(
           {
             messageUpdate: {
-              isComplete: false,
               isThinking: true,
               assistantName,
               agentConfigurations,
@@ -231,7 +229,6 @@ async function streamAgentAnswerToSlack(
         }
         await postSlackMessageUpdate({
           messageUpdate: {
-            isComplete: false,
             text: slackContent,
             assistantName,
             agentConfigurations,
@@ -256,7 +253,6 @@ async function streamAgentAnswerToSlack(
         await postSlackMessageUpdate(
           {
             messageUpdate: {
-              isComplete: true,
               text: slackContent,
               assistantName,
               agentConfigurations,

--- a/connectors/src/connectors/slack/lib/channels.ts
+++ b/connectors/src/connectors/slack/lib/channels.ts
@@ -423,40 +423,31 @@ export async function migrateChannelsFromLegacyBotToNewBot(
 
   const slackClient = await getSlackClient(slackConnector.id);
 
+  const childLogger = logger.child({
+    slackBotConnectorId: slackBotConnector.id,
+    slackConnectorId: slackConnector.id,
+  });
+
   // Fetch all channels that the deprecated bot is a member of.
   const channels = await getChannels(slackClient, slackConnector.id, true);
-  logger.info(
+  const publicChannels = channels.filter((c) => !c.is_private);
+
+  childLogger.info(
     {
       channelsCount: channels.length,
-      slackBotConnectorId: slackBotConnector.id,
-      slackConnectorId: slackConnector.id,
+      publicChannelsCount: publicChannels.length,
     },
     "Found channels to migrate"
   );
 
-  for (const channel of channels) {
+  for (const channel of publicChannels) {
     if (!channel.id) {
       continue;
     }
 
-    if (channel.is_private) {
-      logger.info(
-        {
-          channelId: channel.id,
-          slackBotConnectorId: slackBotConnector.id,
-          slackConnectorId: slackConnector.id,
-        },
-        "Skipping private channel"
-      );
-      continue;
-    }
-
-    logger.info(
+    childLogger.info(
       {
         channelId: channel.id,
-        slackBotConnectorId: slackBotConnector.id,
-        slackConnectorId: slackConnector.id,
-        isPrivate: channel.is_private,
       },
       "Migrating channel"
     );
@@ -464,15 +455,36 @@ export async function migrateChannelsFromLegacyBotToNewBot(
     // Surround with try/catch as the new scope might not always be available.
     try {
       // Leave the channel but keep it in the database as it's still use to be indexed.
-      await slackClient.conversations.leave({ channel: channel.id });
+      const res = await slackClient.conversations.leave({
+        channel: channel.id,
+      });
+
+      if (res.ok) {
+        childLogger.info(
+          {
+            channelId: channel.id,
+          },
+          "Left channel"
+        );
+      }
+
+      if (res.error) {
+        childLogger.error(
+          { error: res.error, channelId: channel.id },
+          "Could not leave channel"
+        );
+      }
     } catch (error) {
-      logger.error({ error, channelId: channel.id }, "Could not leave channel");
+      childLogger.error(
+        { error, channelId: channel.id },
+        "Could not leave channel"
+      );
     }
 
     // Join the new bot to the channel.
     const joinRes = await joinChannel(slackBotConnector.id, channel.id);
     if (joinRes.isErr()) {
-      logger.error(
+      childLogger.error(
         { error: joinRes.error, channelId: channel.id },
         "Could not join channel"
       );


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
This PR improves:
- The way we display the agent that answered in Slack. Today we use to do `@Dust` and Slack was considering it an handle and mentioning random app. We now move the agent name in the footer, see below.
- Improve the cutover instrumentation

**Before**
<img width="529" height="221" alt="test-foo2__Channel__-_Dust_-_117_new_items_-_Slack" src="https://github.com/user-attachments/assets/f6b1a1da-13f7-4c2f-9300-9e61dae46b66" />

**After**

<img width="534" height="374" alt="image" src="https://github.com/user-attachments/assets/6fd7be0e-b8f3-486f-ae53-42422cdceae9" />

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
