### PR TITLE
Handle nested root selection

### DIFF
--- a/connectors/src/connectors/microsoft/temporal/activities.ts
+++ b/connectors/src/connectors/microsoft/temporal/activities.ts
@@ -1062,20 +1062,14 @@ export async function microsoftDeletionActivity({
   const results = await concurrentExecutor(
     nodeIdsToDelete,
     async (nodeId) => {
-      // First check if the parent is still there.
+      // First check if we have a parentInternalId.
       // This means an ancestors is selected, and this node should not be removed
       const node = await MicrosoftNodeResource.fetchByInternalId(
         connectorId,
         nodeId
       );
       if (node && node.parentInternalId) {
-        const parent = await MicrosoftNodeResource.fetchByInternalId(
-          connectorId,
-          node.parentInternalId
-        );
-        if (parent) {
-          return [];
-        }
+        return [];
       }
 
       // Node has no parent and has been removed from selection - delete recursively

--- a/connectors/src/connectors/microsoft/temporal/activities.ts
+++ b/connectors/src/connectors/microsoft/temporal/activities.ts
@@ -1063,7 +1063,7 @@ export async function microsoftDeletionActivity({
     nodeIdsToDelete,
     async (nodeId) => {
       // First check if we have a parentInternalId.
-      // This means an ancestors is selected, and this node should not be removed
+      // This means an ancestor is selected, and this node should not be removed
       const node = await MicrosoftNodeResource.fetchByInternalId(
         connectorId,
         nodeId

--- a/connectors/src/connectors/microsoft/temporal/activities.ts
+++ b/connectors/src/connectors/microsoft/temporal/activities.ts
@@ -38,14 +38,12 @@ import {
   isAlreadySeenItem,
   recursiveNodeDeletion,
   syncOneFile,
+  updateDescendantsParentsInCore,
 } from "@connectors/connectors/microsoft/temporal/file";
 import { getMimeTypesToSync } from "@connectors/connectors/microsoft/temporal/mime_types";
 import { dataSourceConfigFromConnector } from "@connectors/lib/api/data_source_config";
 import { concurrentExecutor } from "@connectors/lib/async_utils";
-import {
-  updateDataSourceDocumentParents,
-  upsertDataSourceFolder,
-} from "@connectors/lib/data_sources";
+import { upsertDataSourceFolder } from "@connectors/lib/data_sources";
 import { ExternalOAuthTokenError } from "@connectors/lib/error";
 import { heartbeat } from "@connectors/lib/temporal";
 import { getActivityLogger } from "@connectors/logger/logger";
@@ -55,7 +53,7 @@ import {
   MicrosoftNodeResource,
   MicrosoftRootResource,
 } from "@connectors/resources/microsoft_resource";
-import type { DataSourceConfig, ModelId } from "@connectors/types";
+import type { ModelId } from "@connectors/types";
 import { cacheWithRedis, INTERNAL_MIME_TYPES } from "@connectors/types";
 
 const FILES_SYNC_CONCURRENCY = 10;
@@ -804,15 +802,20 @@ export async function syncDeltaForRootNodesInDrive({
 
         // add parent information to new node resource. for the toplevel folder,
         // parent is null
-        // todo check filter
-        const parentInternalId =
+        const parentInternalId = getParentReferenceInternalId(
+          driveItem.parentReference
+        );
+
+        const isTopLevel =
           resource.internalId === driveId ||
-          rootNodeIds.indexOf(resource.internalId) !== -1
-            ? null
-            : getParentReferenceInternalId(driveItem.parentReference);
+          (rootNodeIds.indexOf(resource.internalId) !== -1 &&
+            !(await MicrosoftNodeResource.fetchByInternalId(
+              connectorId,
+              parentInternalId
+            )));
 
         await resource.update({
-          parentInternalId,
+          parentInternalId: isTopLevel ? null : parentInternalId,
         });
 
         const parents = await getParents({
@@ -1043,73 +1046,6 @@ async function isFolderMovedInSameRoot({
   return oldParentId !== newParentId;
 }
 
-async function updateDescendantsParentsInCore({
-  folder,
-  dataSourceConfig,
-  startSyncTs,
-}: {
-  folder: MicrosoftNodeResource;
-  dataSourceConfig: DataSourceConfig;
-  startSyncTs: number;
-}) {
-  const children = await folder.fetchChildren();
-  const files = children.filter((child) => child.nodeType === "file");
-  const folders = children.filter((child) => child.nodeType === "folder");
-
-  const parents = await getParents({
-    connectorId: folder.connectorId,
-    internalId: folder.internalId,
-    startSyncTs,
-  });
-  await upsertDataSourceFolder({
-    dataSourceConfig,
-    folderId: folder.internalId,
-    parents,
-    parentId: parents[1] || null,
-    title: folder.name ?? "Untitled Folder",
-    mimeType: INTERNAL_MIME_TYPES.MICROSOFT.FOLDER,
-    sourceUrl: folder.webUrl ?? undefined,
-  });
-
-  await concurrentExecutor(
-    files,
-    async (file) => updateParentsField({ file, dataSourceConfig, startSyncTs }),
-    {
-      concurrency: 10,
-    }
-  );
-  for (const childFolder of folders) {
-    await updateDescendantsParentsInCore({
-      dataSourceConfig,
-      folder: childFolder,
-      startSyncTs,
-    });
-  }
-}
-
-async function updateParentsField({
-  file,
-  dataSourceConfig,
-  startSyncTs,
-}: {
-  file: MicrosoftNodeResource;
-  dataSourceConfig: DataSourceConfig;
-  startSyncTs: number;
-}) {
-  const parents = await getParents({
-    connectorId: file.connectorId,
-    internalId: file.internalId,
-    startSyncTs,
-  });
-
-  await updateDataSourceDocumentParents({
-    dataSourceConfig,
-    documentId: file.internalId,
-    parents,
-    parentId: parents[1] || null,
-  });
-}
-
 export async function microsoftDeletionActivity({
   connectorId,
   nodeIdsToDelete,
@@ -1125,12 +1061,30 @@ export async function microsoftDeletionActivity({
 
   const results = await concurrentExecutor(
     nodeIdsToDelete,
-    async (nodeId) =>
-      recursiveNodeDeletion({
+    async (nodeId) => {
+      // First check if the parent is still there.
+      // This means an ancestors is selected, and this node should not be removed
+      const node = await MicrosoftNodeResource.fetchByInternalId(
+        connectorId,
+        nodeId
+      );
+      if (node && node.parentInternalId) {
+        const parent = await MicrosoftNodeResource.fetchByInternalId(
+          connectorId,
+          node.parentInternalId
+        );
+        if (parent) {
+          return [];
+        }
+      }
+
+      // Node has no parent and has been removed from selection - delete recursively
+      return recursiveNodeDeletion({
         nodeId,
         connectorId,
         dataSourceConfig,
-      }),
+      });
+    },
     { concurrency: DELETE_CONCURRENCY }
   );
 

--- a/connectors/src/connectors/microsoft/temporal/file.ts
+++ b/connectors/src/connectors/microsoft/temporal/file.ts
@@ -25,10 +25,6 @@ import {
 import { filterCustomTags } from "@connectors/connectors/shared/tags";
 import type { CoreAPIDataSourceDocumentSection } from "@connectors/lib/data_sources";
 import {
-  updateDataSourceDocumentParents,
-  upsertDataSourceFolder,
-} from "@connectors/lib/data_sources";
-import {
   deleteDataSourceDocument,
   deleteDataSourceFolder,
   MAX_DOCUMENT_TXT_LEN,
@@ -36,6 +32,7 @@ import {
   MAX_LARGE_DOCUMENT_TXT_LEN,
   renderDocumentTitleAndContent,
   sectionLength,
+  updateDataSourceDocumentParents,
   upsertDataSourceDocument,
   upsertDataSourceFolder,
 } from "@connectors/lib/data_sources";

--- a/connectors/src/connectors/microsoft/temporal/file.ts
+++ b/connectors/src/connectors/microsoft/temporal/file.ts
@@ -25,6 +25,10 @@ import {
 import { filterCustomTags } from "@connectors/connectors/shared/tags";
 import type { CoreAPIDataSourceDocumentSection } from "@connectors/lib/data_sources";
 import {
+  updateDataSourceDocumentParents,
+  upsertDataSourceFolder,
+} from "@connectors/lib/data_sources";
+import {
   deleteDataSourceDocument,
   deleteDataSourceFolder,
   MAX_DOCUMENT_TXT_LEN,
@@ -47,7 +51,11 @@ import {
   MicrosoftRootResource,
 } from "@connectors/resources/microsoft_resource";
 import type { DataSourceConfig, ModelId } from "@connectors/types";
-import { cacheWithRedis, INTERNAL_MIME_TYPES } from "@connectors/types";
+import {
+  cacheWithRedis,
+  concurrentExecutor,
+  INTERNAL_MIME_TYPES,
+} from "@connectors/types";
 
 const PARENT_SYNC_CACHE_TTL_MS = 30 * 60 * 1000;
 

--- a/connectors/src/connectors/microsoft/temporal/spreadsheets.ts
+++ b/connectors/src/connectors/microsoft/temporal/spreadsheets.ts
@@ -282,7 +282,7 @@ export async function handleSpreadSheet({
   parentInternalId: string;
   localLogger: Logger;
   startSyncTs: number;
-  heartbeat: () => void;
+  heartbeat: () => Promise<void>;
 }): Promise<Result<null, Error>> {
   const connector = await ConnectorResource.fetchById(connectorId);
 


### PR DESCRIPTION
## Description

Better handling of nested "root" (selected) nodes. The UI does not allow to select nested root (when a node is checked, the checkboxes for sub nodes are disabled) but it does happens for some reason. It's actually possible to select first a node, then an ancestor. 
This PR is trying to fix the behaviour when it happens.

Currently if a node is "root", the parentInternalId is always null - even if it's nested in another root. This moves the node outside of its hierarchy. 
- Do not set parent to null if we have a selected ancestor. Just check if the parent is synced - in that case, use this parent id.
- When deselecting a nested root, don't remove it - just skip and do nothing.
- When deselecting an ancestor root, do not remove the nested root (it was already handled) but update the parent to set it to null.

## Tests

testing locally

## Risk

impact parents, can change and break node hierarchy 

## Deploy Plan

deploy connectors
