### PR TITLE
fix: add dummy function result when missing

### DIFF
--- a/front/lib/api/assistant/preprocessing.ts
+++ b/front/lib/api/assistant/preprocessing.ts
@@ -225,14 +225,16 @@ export async function renderConversationForModel(
       // For each step, we look at the contents to find the function calls.
       // If some function calls have no associated action, we make a dummy "errored" one.
       steps = steps.map((step) => {
+        const functionResultByCallId: Record<string, FunctionMessageTypeModel> =
+          {};
         const actions = step.actions;
+        for (const action of actions) {
+          functionResultByCallId[action.call.id] = action.result;
+        }
         for (const content of step.contents) {
           if (content.type === "function_call") {
             const functionCall = content.value;
-            const action = step.actions.find(
-              (a) => a.call.id === functionCall.id
-            );
-            if (!action) {
+            if (!functionResultByCallId[functionCall.id]) {
               logger.warn(
                 {
                   workspaceId: conversation.owner.sId,

--- a/front/lib/api/assistant/preprocessing.ts
+++ b/front/lib/api/assistant/preprocessing.ts
@@ -226,31 +226,31 @@ export async function renderConversationForModel(
       // If some function calls have no associated action, we make a dummy "errored" one.
       steps = steps.map((step) => {
         const actions = step.actions;
-        const functionCalls = step.contents.filter(
-          (c) => c.type === "function_call"
-        );
-        for (const functionCall of functionCalls) {
-          const action = step.actions.find(
-            (a) => a.call.id === functionCall.value.id
-          );
-          if (!action) {
-            logger.warn(
-              {
-                workspaceId: conversation.owner.sId,
-                conversationId: conversation.sId,
-                agentMessageId: m.sId,
-              },
-              "Unexpected state, agent message step with no action for function call"
+        for (const content of step.contents) {
+          if (content.type === "function_call") {
+            const functionCall = content.value;
+            const action = step.actions.find(
+              (a) => a.call.id === functionCall.id
             );
-            actions.push({
-              call: functionCall.value,
-              result: {
-                role: "function",
-                name: functionCall.value.name,
-                function_call_id: functionCall.value.id,
-                content: "Error: tool execution failed",
-              },
-            });
+            if (!action) {
+              logger.warn(
+                {
+                  workspaceId: conversation.owner.sId,
+                  conversationId: conversation.sId,
+                  agentMessageId: m.sId,
+                },
+                "Unexpected state, agent message step with no action for function call"
+              );
+              actions.push({
+                call: functionCall,
+                result: {
+                  role: "function",
+                  name: functionCall.name,
+                  function_call_id: functionCall.id,
+                  content: "Error: tool execution failed",
+                },
+              });
+            }
           }
         }
         return { ...step, actions };


### PR DESCRIPTION
## Description

We have some conversations in a corrupted state (some function calls have no results).
Some of them are due to an old bug (no fixed, but state is still inconsistent), some of them are due to a new, active bug (related to async loop, only affecting dust workspace).

This inconsistent state is causing blocking errors that make the conversation unusable. It is desirable to let the conversations go through.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

low

## Deploy Plan

Deploy front