### PR TITLE
[front] - feat(AB v2): Agent builder hidden right panel on mobile

### DIFF
--- a/front/components/agent_builder/AgentBuilderLayout.tsx
+++ b/front/components/agent_builder/AgentBuilderLayout.tsx
@@ -104,7 +104,6 @@ export function AgentBuilderLayout({
                     !isResizing
                       ? "overflow-hidden transition-all duration-300 ease-in-out"
                       : "overflow-hidden",
-                    // Mobile: overlay full screen when open, hidden when closed
                     !isPreviewPanelOpen && "hidden md:block",
                     isPreviewPanelOpen && "md:relative",
                     isPreviewPanelOpen &&
@@ -117,7 +116,6 @@ export function AgentBuilderLayout({
                 </ResizablePanel>
               </ResizablePanelGroup>
 
-              {/* Mobile Preview button */}
               {!isPreviewPanelOpen && (
                 <Button
                   label="Preview"

--- a/front/components/agent_builder/AgentBuilderLayout.tsx
+++ b/front/components/agent_builder/AgentBuilderLayout.tsx
@@ -1,7 +1,9 @@
 import {
+  Button,
   ResizableHandle,
   ResizablePanel,
   ResizablePanelGroup,
+  TestTubeIcon,
 } from "@dust-tt/sparkle";
 import { cn } from "@dust-tt/sparkle";
 import Head from "next/head";
@@ -99,17 +101,32 @@ export function AgentBuilderLayout({
                   collapsible={true}
                   onCollapse={handlePanelCollapse}
                   onExpand={handlePanelExpand}
-                  className={
+                  className={cn(
                     !isResizing
                       ? "overflow-hidden transition-all duration-300 ease-in-out"
-                      : "overflow-hidden"
-                  }
+                      : "overflow-hidden",
+                    // Mobile: overlay full screen when open, hidden when closed
+                    !isPreviewPanelOpen && "hidden md:block",
+                    isPreviewPanelOpen && "md:relative",
+                    isPreviewPanelOpen &&
+                      "absolute inset-0 z-50 bg-background md:relative md:inset-auto md:z-auto"
+                  )}
                 >
                   <div className="h-full w-full overflow-y-auto">
                     {rightPanel}
                   </div>
                 </ResizablePanel>
               </ResizablePanelGroup>
+
+              {/* Mobile floating Testing button */}
+              {!isPreviewPanelOpen && (
+                <Button
+                  icon={TestTubeIcon}
+                  onClick={handlePanelExpand}
+                  className="fixed bottom-20 right-4 z-40 h-12 w-12 rounded-full border border-border bg-white text-foreground shadow-sm hover:bg-muted hover:shadow-md md:hidden"
+                  aria-label="Open testing panel"
+                />
+              )}
             </div>
           )}
         </main>

--- a/front/components/agent_builder/AgentBuilderLayout.tsx
+++ b/front/components/agent_builder/AgentBuilderLayout.tsx
@@ -12,7 +12,7 @@ import type { ImperativePanelHandle } from "react-resizable-panels";
 import { useAgentBuilderContext } from "@app/components/agent_builder/AgentBuilderContext";
 import { usePreviewPanelContext } from "@app/components/agent_builder/PreviewPanelContext";
 
-const COLLAPSED_RIGHT_PANEL_SIZE = 3;
+const COLLAPSED_RIGHT_PANEL_SIZE = 5;
 const MIN_EXPANDED_RIGHT_PANEL_SIZE = 20;
 const DEFAULT_RIGHT_PANEL_SIZE = 30;
 

--- a/front/components/agent_builder/AgentBuilderLayout.tsx
+++ b/front/components/agent_builder/AgentBuilderLayout.tsx
@@ -1,5 +1,4 @@
 import {
-  Button,
   ResizableHandle,
   ResizablePanel,
   ResizablePanelGroup,
@@ -104,10 +103,7 @@ export function AgentBuilderLayout({
                     !isResizing
                       ? "overflow-hidden transition-all duration-300 ease-in-out"
                       : "overflow-hidden",
-                    !isPreviewPanelOpen && "hidden md:block",
-                    isPreviewPanelOpen && "md:relative",
-                    isPreviewPanelOpen &&
-                      "absolute inset-0 z-50 bg-background md:relative md:inset-auto md:z-auto"
+                    "hidden md:block"
                   )}
                 >
                   <div className="h-full w-full overflow-y-auto">
@@ -115,16 +111,6 @@ export function AgentBuilderLayout({
                   </div>
                 </ResizablePanel>
               </ResizablePanelGroup>
-
-              {!isPreviewPanelOpen && (
-                <Button
-                  label="Preview"
-                  variant="ghost"
-                  onClick={handlePanelExpand}
-                  className="fixed bottom-3 left-4 z-40 md:hidden"
-                  aria-label="Open preview panel"
-                />
-              )}
             </div>
           )}
         </main>

--- a/front/components/agent_builder/AgentBuilderLayout.tsx
+++ b/front/components/agent_builder/AgentBuilderLayout.tsx
@@ -99,12 +99,11 @@ export function AgentBuilderLayout({
                   collapsible={true}
                   onCollapse={handlePanelCollapse}
                   onExpand={handlePanelExpand}
-                  className={cn(
+                  className={
                     !isResizing
-                      ? "overflow-hidden transition-all duration-300 ease-in-out"
-                      : "overflow-hidden",
-                    "hidden md:block"
-                  )}
+                      ? "overflow-hidden transition-all duration-300 ease-in-out hidden md:block"
+                      : "overflow-hidden hidden md:block"
+                  }
                 >
                   <div className="h-full w-full overflow-y-auto">
                     {rightPanel}

--- a/front/components/agent_builder/AgentBuilderLayout.tsx
+++ b/front/components/agent_builder/AgentBuilderLayout.tsx
@@ -3,7 +3,6 @@ import {
   ResizableHandle,
   ResizablePanel,
   ResizablePanelGroup,
-  TestTubeIcon,
 } from "@dust-tt/sparkle";
 import { cn } from "@dust-tt/sparkle";
 import Head from "next/head";
@@ -78,7 +77,7 @@ export function AgentBuilderLayout({
                 className="h-full w-full"
               >
                 <ResizablePanel defaultSize={70} minSize={30}>
-                  <div className="h-full w-full overflow-y-auto px-6">
+                  <div className="h-full w-full overflow-y-auto px-0 md:px-6">
                     {leftPanel}
                   </div>
                 </ResizablePanel>
@@ -118,13 +117,14 @@ export function AgentBuilderLayout({
                 </ResizablePanel>
               </ResizablePanelGroup>
 
-              {/* Mobile floating Testing button */}
+              {/* Mobile Preview button */}
               {!isPreviewPanelOpen && (
                 <Button
-                  icon={TestTubeIcon}
+                  label="Preview"
+                  variant="ghost"
                   onClick={handlePanelExpand}
-                  className="fixed bottom-20 right-4 z-40 h-12 w-12 rounded-full border border-border bg-white text-foreground shadow-sm hover:bg-muted hover:shadow-md md:hidden"
-                  aria-label="Open testing panel"
+                  className="fixed bottom-3 left-4 z-40 md:hidden"
+                  aria-label="Open preview panel"
                 />
               )}
             </div>

--- a/front/components/agent_builder/AgentBuilderLayout.tsx
+++ b/front/components/agent_builder/AgentBuilderLayout.tsx
@@ -14,7 +14,7 @@ import type { ImperativePanelHandle } from "react-resizable-panels";
 import { useAgentBuilderContext } from "@app/components/agent_builder/AgentBuilderContext";
 import { usePreviewPanelContext } from "@app/components/agent_builder/PreviewPanelContext";
 
-const COLLAPSED_RIGHT_PANEL_SIZE = 5;
+const COLLAPSED_RIGHT_PANEL_SIZE = 3;
 const MIN_EXPANDED_RIGHT_PANEL_SIZE = 20;
 const DEFAULT_RIGHT_PANEL_SIZE = 30;
 

--- a/front/components/agent_builder/AgentBuilderRightPanel.tsx
+++ b/front/components/agent_builder/AgentBuilderRightPanel.tsx
@@ -8,7 +8,6 @@ import {
   TabsList,
   TabsTrigger,
   TestTubeIcon,
-  XMarkIcon,
 } from "@dust-tt/sparkle";
 import React, { useState } from "react";
 
@@ -78,45 +77,6 @@ function PanelHeader({
   );
 }
 
-function MobileHeader({
-  selectedTab,
-  onTabChange,
-  onTogglePanel,
-}: {
-  selectedTab: AgentBuilderRightPanelTabType;
-  onTabChange: (tab: AgentBuilderRightPanelTabType) => void;
-  onTogglePanel: () => void;
-}) {
-  return (
-    <div className="flex items-center justify-between bg-background py-2 pl-2 pr-4 md:hidden">
-      <div className="flex-1">
-        <Tabs value={selectedTab} className="w-full">
-          <TabsList>
-            <TabsTrigger
-              value="preview"
-              label="Preview"
-              icon={TestTubeIcon}
-              onClick={() => onTabChange("preview")}
-            />
-            <TabsTrigger
-              value="performance"
-              label="Performance"
-              icon={BarChartIcon}
-              onClick={() => onTabChange("performance")}
-            />
-          </TabsList>
-        </Tabs>
-      </div>
-      <Button
-        size="sm"
-        icon={XMarkIcon}
-        variant="ghost"
-        tooltip="Close"
-        onClick={onTogglePanel}
-      />
-    </div>
-  );
-}
 
 interface CollapsedTabsProps {
   onTabSelect: (tab: AgentBuilderRightPanelTabType) => void;
@@ -199,22 +159,12 @@ export function AgentBuilderRightPanel({
 
   return (
     <div className="flex h-full flex-col">
-      {isPreviewPanelOpen && (
-        <MobileHeader
-          selectedTab={selectedTab}
-          onTabChange={handleTabChange}
-          onTogglePanel={handleTogglePanel}
-        />
-      )}
-
-      <div className="hidden md:block">
-        <PanelHeader
-          isPreviewPanelOpen={isPreviewPanelOpen}
-          selectedTab={selectedTab}
-          onTogglePanel={handleTogglePanel}
-          onTabChange={handleTabChange}
-        />
-      </div>
+      <PanelHeader
+        isPreviewPanelOpen={isPreviewPanelOpen}
+        selectedTab={selectedTab}
+        onTogglePanel={handleTogglePanel}
+        onTabChange={handleTabChange}
+      />
       {isPreviewPanelOpen ? (
         <ExpandedContent
           selectedTab={selectedTab}

--- a/front/components/agent_builder/AgentBuilderRightPanel.tsx
+++ b/front/components/agent_builder/AgentBuilderRightPanel.tsx
@@ -78,6 +78,46 @@ function PanelHeader({
   );
 }
 
+function MobileHeader({
+  selectedTab,
+  onTabChange,
+  onTogglePanel,
+}: {
+  selectedTab: AgentBuilderRightPanelTabType;
+  onTabChange: (tab: AgentBuilderRightPanelTabType) => void;
+  onTogglePanel: () => void;
+}) {
+  return (
+    <div className="flex items-center justify-between bg-background py-2 pl-2 pr-4 md:hidden">
+      <div className="flex-1">
+        <Tabs value={selectedTab} className="w-full">
+          <TabsList>
+            <TabsTrigger
+              value="preview"
+              label="Preview"
+              icon={TestTubeIcon}
+              onClick={() => onTabChange("preview")}
+            />
+            <TabsTrigger
+              value="performance"
+              label="Performance"
+              icon={BarChartIcon}
+              onClick={() => onTabChange("performance")}
+            />
+          </TabsList>
+        </Tabs>
+      </div>
+      <Button
+        size="sm"
+        icon={XMarkIcon}
+        variant="ghost"
+        tooltip="Close"
+        onClick={onTogglePanel}
+      />
+    </div>
+  );
+}
+
 interface CollapsedTabsProps {
   onTabSelect: (tab: AgentBuilderRightPanelTabType) => void;
 }
@@ -159,35 +199,12 @@ export function AgentBuilderRightPanel({
 
   return (
     <div className="flex h-full flex-col">
-      {/* Mobile header with tabs */}
       {isPreviewPanelOpen && (
-        <div className="flex items-center justify-between bg-background py-2 pl-2 pr-4 md:hidden">
-          <div className="flex-1">
-            <Tabs value={selectedTab} className="w-full">
-              <TabsList>
-                <TabsTrigger
-                  value="preview"
-                  label="Preview"
-                  icon={TestTubeIcon}
-                  onClick={() => handleTabChange("preview")}
-                />
-                <TabsTrigger
-                  value="performance"
-                  label="Performance"
-                  icon={BarChartIcon}
-                  onClick={() => handleTabChange("performance")}
-                />
-              </TabsList>
-            </Tabs>
-          </div>
-          <Button
-            size="sm"
-            icon={XMarkIcon}
-            variant="ghost"
-            tooltip="Close"
-            onClick={handleTogglePanel}
-          />
-        </div>
+        <MobileHeader
+          selectedTab={selectedTab}
+          onTabChange={handleTabChange}
+          onTogglePanel={handleTogglePanel}
+        />
       )}
 
       <div className="hidden md:block">

--- a/front/components/agent_builder/AgentBuilderRightPanel.tsx
+++ b/front/components/agent_builder/AgentBuilderRightPanel.tsx
@@ -8,6 +8,7 @@ import {
   TabsList,
   TabsTrigger,
   TestTubeIcon,
+  XMarkIcon,
 } from "@dust-tt/sparkle";
 import React, { useState } from "react";
 
@@ -33,7 +34,7 @@ function PanelHeader({
   return (
     <div className="flex h-16 items-end">
       {isPreviewPanelOpen ? (
-        <div className="flex w-full items-center px-6">
+        <div className="flex w-full items-center px-0 md:px-6">
           <ScrollArea aria-orientation="horizontal" className="flex-1">
             <Tabs value={selectedTab} className="w-full">
               <TabsList>
@@ -42,6 +43,7 @@ function PanelHeader({
                   size="sm"
                   variant="ghost-secondary"
                   tooltip="Hide preview"
+                  className="hidden md:flex"
                   onClick={onTogglePanel}
                 />
                 <TabsTrigger
@@ -64,7 +66,7 @@ function PanelHeader({
         <div className="flex h-full w-full items-center justify-center">
           <Button
             icon={SidebarRightOpenIcon}
-            className="h-9 w-9"
+            className="h-9 w-9 hidden md:flex"
             size="sm"
             variant="ghost-secondary"
             tooltip="Open preview"
@@ -157,12 +159,45 @@ export function AgentBuilderRightPanel({
 
   return (
     <div className="flex h-full flex-col">
-      <PanelHeader
-        isPreviewPanelOpen={isPreviewPanelOpen}
-        selectedTab={selectedTab}
-        onTogglePanel={handleTogglePanel}
-        onTabChange={handleTabChange}
-      />
+      {/* Mobile header with tabs */}
+      {isPreviewPanelOpen && (
+        <div className="flex items-center justify-between bg-background pl-2 pr-4 py-2 md:hidden">
+          <div className="flex-1">
+            <Tabs value={selectedTab} className="w-full">
+              <TabsList>
+                <TabsTrigger
+                  value="testing"
+                  label="Testing"
+                  icon={TestTubeIcon}
+                  onClick={() => handleTabChange("testing")}
+                />
+                <TabsTrigger
+                  value="performance"
+                  label="Performance"
+                  icon={BarChartIcon}
+                  onClick={() => handleTabChange("performance")}
+                />
+              </TabsList>
+            </Tabs>
+          </div>
+          <Button
+            size="sm"
+            icon={XMarkIcon}
+            variant="ghost"
+            tooltip="Close"
+            onClick={handleTogglePanel}
+          />
+        </div>
+      )}
+      
+      <div className="hidden md:block">
+        <PanelHeader
+          isPreviewPanelOpen={isPreviewPanelOpen}
+          selectedTab={selectedTab}
+          onTogglePanel={handleTogglePanel}
+          onTabChange={handleTabChange}
+        />
+      </div>
       {isPreviewPanelOpen ? (
         <ExpandedContent
           selectedTab={selectedTab}

--- a/front/components/agent_builder/AgentBuilderRightPanel.tsx
+++ b/front/components/agent_builder/AgentBuilderRightPanel.tsx
@@ -16,7 +16,7 @@ import { AgentBuilderPerformance } from "@app/components/agent_builder/AgentBuil
 import { AgentBuilderPreview } from "@app/components/agent_builder/AgentBuilderPreview";
 import { usePreviewPanelContext } from "@app/components/agent_builder/PreviewPanelContext";
 
-type AgentBuilderRightPanelTabType = "testing" | "performance";
+type AgentBuilderRightPanelTabType = "preview" | "performance";
 
 interface PanelHeaderProps {
   isPreviewPanelOpen: boolean;
@@ -47,10 +47,10 @@ function PanelHeader({
                   onClick={onTogglePanel}
                 />
                 <TabsTrigger
-                  value="testing"
-                  label="Testing"
+                  value="preview"
+                  label="Preview"
                   icon={TestTubeIcon}
-                  onClick={() => onTabChange("testing")}
+                  onClick={() => onTabChange("preview")}
                 />
                 <TabsTrigger
                   value="performance"
@@ -66,7 +66,7 @@ function PanelHeader({
         <div className="flex h-full w-full items-center justify-center">
           <Button
             icon={SidebarRightOpenIcon}
-            className="h-9 w-9 hidden md:flex"
+            className="hidden h-9 w-9 md:flex"
             size="sm"
             variant="ghost-secondary"
             tooltip="Open preview"
@@ -90,8 +90,8 @@ function CollapsedTabs({ onTabSelect }: CollapsedTabsProps) {
         className="h-9 w-9"
         variant="ghost"
         size="sm"
-        tooltip="Testing"
-        onClick={() => onTabSelect("testing")}
+        tooltip="Preview"
+        onClick={() => onTabSelect("preview")}
       />
       <Button
         icon={BarChartIcon}
@@ -116,7 +116,7 @@ function ExpandedContent({
 }: ExpandedContentProps) {
   return (
     <div className="flex min-h-0 flex-1 flex-col">
-      {selectedTab === "testing" && (
+      {selectedTab === "preview" && (
         <div className="min-h-0 flex-1">
           <AgentBuilderPreview />
         </div>
@@ -142,7 +142,7 @@ export function AgentBuilderRightPanel({
   const { isPreviewPanelOpen, setIsPreviewPanelOpen } =
     usePreviewPanelContext();
   const [selectedTab, setSelectedTab] =
-    useState<AgentBuilderRightPanelTabType>("testing");
+    useState<AgentBuilderRightPanelTabType>("preview");
 
   const handleTogglePanel = () => {
     setIsPreviewPanelOpen(!isPreviewPanelOpen);
@@ -161,15 +161,15 @@ export function AgentBuilderRightPanel({
     <div className="flex h-full flex-col">
       {/* Mobile header with tabs */}
       {isPreviewPanelOpen && (
-        <div className="flex items-center justify-between bg-background pl-2 pr-4 py-2 md:hidden">
+        <div className="flex items-center justify-between bg-background py-2 pl-2 pr-4 md:hidden">
           <div className="flex-1">
             <Tabs value={selectedTab} className="w-full">
               <TabsList>
                 <TabsTrigger
-                  value="testing"
-                  label="Testing"
+                  value="preview"
+                  label="Preview"
                   icon={TestTubeIcon}
-                  onClick={() => handleTabChange("testing")}
+                  onClick={() => handleTabChange("preview")}
                 />
                 <TabsTrigger
                   value="performance"
@@ -189,7 +189,7 @@ export function AgentBuilderRightPanel({
           />
         </div>
       )}
-      
+
       <div className="hidden md:block">
         <PanelHeader
           isPreviewPanelOpen={isPreviewPanelOpen}

--- a/front/components/agent_builder/AgentBuilderRightPanel.tsx
+++ b/front/components/agent_builder/AgentBuilderRightPanel.tsx
@@ -61,9 +61,10 @@ function PanelHeader({
           </ScrollArea>
         </div>
       ) : (
-        <div className="flex h-full w-full items-end justify-center">
+        <div className="flex h-full w-full items-center justify-center">
           <Button
             icon={SidebarRightOpenIcon}
+            className="h-9 w-9"
             size="sm"
             variant="ghost-secondary"
             tooltip="Open preview"
@@ -84,6 +85,7 @@ function CollapsedTabs({ onTabSelect }: CollapsedTabsProps) {
     <div className="flex flex-1 flex-col items-center justify-center gap-4">
       <Button
         icon={TestTubeIcon}
+        className="h-9 w-9"
         variant="ghost"
         size="sm"
         tooltip="Testing"
@@ -91,6 +93,7 @@ function CollapsedTabs({ onTabSelect }: CollapsedTabsProps) {
       />
       <Button
         icon={BarChartIcon}
+        className="h-9 w-9"
         variant="ghost"
         size="sm"
         tooltip="Performance"


### PR DESCRIPTION
## Description

- Agent builder right panel is hidden better on mobile.
- Testing section is renamed to Preview.
- Paddings of buttons in the right panel.

## Tests

Locally.

## Risk

Low, behind FF

## Deploy Plan

Deploy front.
