### PR TITLE
Update WorkOS event replay script

### DIFF
--- a/front/scripts/process_workos_events_from_jsonl.ts
+++ b/front/scripts/process_workos_events_from_jsonl.ts
@@ -7,6 +7,20 @@ import { launchWorkOSEventsWorkflow } from "@app/temporal/workos_events_queue/cl
 
 import { makeScript } from "./helpers";
 
+function snakeToCamelCase(obj: any): any {
+  if (Array.isArray(obj)) {
+    return obj.map(snakeToCamelCase);
+  } else if (obj && typeof obj === "object") {
+    return Object.fromEntries(
+      Object.entries(obj).map(([key, value]) => [
+        key.replace(/_([a-z])/g, (_, letter) => letter.toUpperCase()),
+        snakeToCamelCase(value),
+      ])
+    );
+  }
+  return obj;
+}
+
 async function processJsonlFile(filePath: string): Promise<Event[]> {
   const events: Event[] = [];
   const fileStream = fs.createReadStream(filePath);
@@ -25,7 +39,7 @@ async function processJsonlFile(filePath: string): Promise<Event[]> {
     }
 
     try {
-      const event = JSON.parse(line) as Event;
+      const event = snakeToCamelCase(JSON.parse(line)) as Event;
       events.push(event);
     } catch (error) {
       logger.error({ lineNumber, line, error }, "Failed to parse JSON on line");


### PR DESCRIPTION
## Description

- [Thread](https://dust4ai.slack.com/archives/C050SM8NSPK/p1753889552451769).
- The events we can get from Datadog logs contain events with keys in `snake_case`, usually this conversion is handled by `validateWorkOSWebhookEvent`.
- This PR updates the script that replays WorkOS events to handle this conversation.

## Tests

## Risk

## Deploy Plan

- Deploy front (to have the new script on front-worker pods).
