### PR TITLE
WIP Enforce a hard limit on actions output size by uploading full content on a file and returning a snippet 

### DIFF
--- a/front/lib/actions/action_file_helpers.ts
+++ b/front/lib/actions/action_file_helpers.ts
@@ -18,10 +18,12 @@ export async function generatePlainTextFile(
     title,
     conversationId,
     content,
+    snippet,
   }: {
     title: string;
     conversationId: string;
     content: string;
+    snippet?: string;
   }
 ): Promise<FileResource> {
   const workspace = auth.getNonNullableWorkspace();
@@ -37,6 +39,7 @@ export async function generatePlainTextFile(
     useCaseMetadata: {
       conversationId,
     },
+    snippet,
   });
 
   await processAndStoreFile(auth, {

--- a/front/lib/actions/mcp.ts
+++ b/front/lib/actions/mcp.ts
@@ -3,11 +3,18 @@ import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
 import { McpError } from "@modelcontextprotocol/sdk/types.js";
 import type { JSONSchema7 as JSONSchema } from "json-schema";
 
+import { generatePlainTextFile } from "@app/lib/actions/action_file_helpers";
 import type {
   MCPToolStakeLevelType,
   MCPValidationMetadataType,
 } from "@app/lib/actions/constants";
-import { tryCallMCPTool } from "@app/lib/actions/mcp_actions";
+import {
+  computeTextByteSize,
+  MAX_RESOURCE_CONTENT_SIZE,
+  MAX_TEXT_CONTENT_SIZE,
+  MAXED_OUTPUT_FILE_SNIPPET_LENGTH,
+  tryCallMCPTool,
+} from "@app/lib/actions/mcp_actions";
 import { MCPServerPersonalAuthenticationRequiredError } from "@app/lib/actions/mcp_authentication";
 import type {
   CustomServerIconType,
@@ -85,8 +92,6 @@ import {
   removeNulls,
   stripNullBytes,
 } from "@app/types";
-
-const MAX_BLOB_SIZE_BYTES = 1024 * 1024 * 10; // 10MB
 
 export type BaseMCPServerConfigurationType = {
   id: ModelId;
@@ -232,6 +237,7 @@ export type ActionBaseParams = Omit<
 >;
 
 export function hideFileFromActionOutput({
+  file,
   fileId,
   content,
   workspaceId,
@@ -260,9 +266,11 @@ export function hideFileFromActionOutput({
       contentType = "unknown";
       break;
   }
+
+  const snippet = file?.snippet ?? null;
   return {
     type: "text",
-    text: `A file of type ${contentType} with id ${sid} was generated successfully and made available to the conversation.`,
+    text: `A file of type ${contentType} with id ${sid} was generated successfully and made available to the conversation. ${snippet ? `\n\nSnippet:\n ${snippet}` : ""}`,
   };
 }
 
@@ -881,6 +889,35 @@ export async function* runToolWithStreaming(
     async (block) => {
       switch (block.type) {
         case "text": {
+          // If the text is too large we create a file and return a resource block that references the file.
+          if (
+            computeTextByteSize(block.text) > MAX_TEXT_CONTENT_SIZE &&
+            actionConfiguration.mcpServerName !== "conversation_files"
+          ) {
+            const fileName = `${actionConfiguration.mcpServerName}_${Date.now()}.txt`;
+            const snippet =
+              block.text.substring(0, MAXED_OUTPUT_FILE_SNIPPET_LENGTH) +
+              "... (truncated)";
+
+            const file = await generatePlainTextFile(auth, {
+              title: fileName,
+              conversationId: conversation.sId,
+              content: block.text,
+              snippet,
+            });
+            return {
+              content: {
+                type: "resource",
+                resource: {
+                  uri: file.getPublicUrl(auth),
+                  mimeType: "text/plain",
+                  text: block.text,
+                },
+              },
+              file,
+            };
+          }
+
           return {
             content: {
               type: block.type,
@@ -979,16 +1016,45 @@ export async function* runToolWithStreaming(
               file: fileUpsertResult.value,
             };
           } else {
-            // Generic case for other kinds of resources.
+            const text =
+              "text" in block.resource &&
+              typeof block.resource.text === "string"
+                ? stripNullBytes(block.resource.text)
+                : null;
+
+            // If the resource text is too large, we create a file and return a resource block that references the file.
+            if (text && computeTextByteSize(text) > MAX_RESOURCE_CONTENT_SIZE) {
+              const fileName =
+                block.resource.uri?.split("/").pop() ??
+                `resource_${Date.now()}.txt`;
+              const snippet =
+                text.substring(0, MAXED_OUTPUT_FILE_SNIPPET_LENGTH) +
+                "... (truncated)";
+
+              const file = await generatePlainTextFile(auth, {
+                title: fileName,
+                conversationId: conversation.sId,
+                content: text,
+                snippet,
+              });
+              return {
+                content: {
+                  type: block.type,
+                  resource: {
+                    ...block.resource,
+                    text: text,
+                  },
+                },
+                file,
+              };
+            }
+
             return {
               content: {
                 type: block.type,
                 resource: {
                   ...block.resource,
-                  ...("text" in block.resource &&
-                  typeof block.resource.text === "string"
-                    ? { text: stripNullBytes(block.resource.text) }
-                    : {}),
+                  ...(text ? { text } : {}),
                 },
               },
               file: null,
@@ -1116,7 +1182,7 @@ async function handleBase64Upload(
     };
   }
 
-  if (base64Data.length > MAX_BLOB_SIZE_BYTES) {
+  if (base64Data.length > MAX_RESOURCE_CONTENT_SIZE) {
     return {
       content: {
         type: "text",

--- a/front/lib/actions/mcp_actions.ts
+++ b/front/lib/actions/mcp_actions.ts
@@ -96,11 +96,22 @@ function isEmptyInputSchema(schema: JSONSchema7): boolean {
 
 const MAX_TOOL_NAME_LENGTH = 64;
 
-const MAX_TEXT_CONTENT_SIZE = 2 * 1024 * 1024;
-const MAX_IMAGE_CONTENT_SIZE = 2 * 1024 * 1024;
-const MAX_RESOURCE_CONTENT_SIZE = 10 * 1024 * 1024;
+// Size limits for MCP tool outputs
+export const MAX_TEXT_CONTENT_SIZE = 2 * 1024 * 1024; // 2MB
+export const MAX_IMAGE_CONTENT_SIZE = 2 * 1024 * 1024; // 2MB
+export const MAX_RESOURCE_CONTENT_SIZE = 10 * 1024 * 1024; // 10MB
+
+export const MAXED_OUTPUT_FILE_SNIPPET_LENGTH = 32_000;
 
 export const TOOL_NAME_SEPARATOR = "__";
+
+export function computeTextByteSize(text: string): number {
+  return text.length * 2; // UTF-8 approximate
+}
+
+export function computeBase64ByteSize(base64: string): number {
+  return Math.ceil((base64.length * 3) / 4);
+}
 
 // Define the new type here for now, or move to a dedicated types file later.
 export interface ServerToolsAndInstructions {
@@ -418,16 +429,22 @@ export async function* tryCallMCPTool(
     ): number => {
       switch (item.type) {
         case "text":
-          return item.text.length * 2;
+          return computeTextByteSize(item.text);
         case "image":
-          return Math.ceil((item.data.length * 3) / 4);
+          return computeBase64ByteSize(item.data);
         case "resource":
           if (
             "blob" in item.resource &&
             item.resource.blob &&
             typeof item.resource.blob === "string"
           ) {
-            return Math.ceil((item.resource.blob.length * 3) / 4);
+            return computeBase64ByteSize(item.resource.blob);
+          }
+          if (
+            "text" in item.resource &&
+            typeof item.resource.text === "string"
+          ) {
+            return computeTextByteSize(item.resource.text);
           }
           return 0;
         case "audio":


### PR DESCRIPTION
## Description

Related task: https://github.com/dust-tt/tasks/issues/3655

This PR changes the behavior of MCP actions:  If the output is very big, we will upload the full content in a file attached to the `agent_mcp_action_output_items` and will present a long snippet as output of the action. We do that if the output is type text or resource with a text, and we exclude the conversion_file server to not enter an infinite loop. 


Note: there was something done from `tryCallMCPTool` to limit the output size already but it was done for external servers only and it was raising an error: https://github.com/dust-tt/dust/blob/15e1ddf958c8ded887488d961540a8de4680262d/front/lib/actions/mcp_actions.ts#L459-L474
(Origin = this PR: https://github.com/dust-tt/dust/pull/13140/files).

## Tests

Tested locally. I edited a Salesforce action to return a huge output and I get this: 

It calls the huge action so content is put in a file, it tries to include it but too big also so it tries to do semantic search on it. 
<kbd>
<img width="756" height="572" alt="Screenshot 2025-07-31 at 12 17 41" src="https://github.com/user-attachments/assets/2adcc306-44b2-42b2-b37a-c88c9ff220c3" />
</kbd>

If we open the first action we appended a big snippet in the output.
<kbd>
<img width="766" height="713" alt="Screenshot 2025-07-31 at 12 16 32" src="https://github.com/user-attachments/assets/207d41cd-62b2-4e44-963f-2d3d44e4eb42" />
</kbd>


Note: Locally the semantic search breaks for me with error `Search action must have at least one data source configured.` which is an error we've already seen on prod (iirc we IRL talked about it last week) so I think not related to my change and needs investigation.  

## Risk

Can be rolled back. 

## Deploy Plan

Deploy front. 