### PR TITLE
Opt: reduce memory usage when parsing CSV

### DIFF
--- a/core/src/databases/csv.rs
+++ b/core/src/databases/csv.rs
@@ -1,3 +1,5 @@
+use std::sync::Arc;
+
 use anyhow::{anyhow, Result};
 use cloud_storage::Object;
 use csv_async::AsyncReaderBuilder;
@@ -187,6 +189,7 @@ impl GoogleCloudStorageCSVContent {
             .create_reader(TokioAsyncReadCompatExt::compat(rdr));
 
         let headers = Self::sanitize_headers(csv.headers().await?.iter().collect::<Vec<&str>>())?;
+        let headers = Arc::new(headers);
 
         if headers.len() > MAX_TABLE_COLUMNS {
             Err(anyhow!("Too many columns in CSV file"))?;
@@ -195,13 +198,35 @@ impl GoogleCloudStorageCSVContent {
             Err(anyhow!("No columns in CSV file"))?;
         }
 
+        // If we have a __dust_id column, we need to remove it from the headers but save the column index for later.
+        let dust_id_pos = headers.iter().position(|h| h == "__dust_id");
+        let headers = match dust_id_pos {
+            Some(pos) => {
+                let mut headers = headers.iter().cloned().collect::<Vec<String>>();
+                headers.remove(pos);
+                Arc::new(headers)
+            }
+            None => headers,
+        };
+
         let mut rows = Vec::new();
 
         let mut records = csv.records();
         let mut row_idx = 0;
         while let Some(record) = records.next().await {
             let record = record?;
-            let row = Row::from_csv_record(&headers, record.iter().collect::<Vec<_>>(), row_idx)?;
+            let mut record = record.iter().collect::<Vec<_>>();
+
+            // If we have a __dust_id column, we need to remove it from the record and use it as the row id.
+            // It has been removed from the headers already.
+            let (row_id, record) = if let Some(pos) = dust_id_pos {
+                let row_id = record.remove(pos).trim().to_string();
+                (row_id, record)
+            } else {
+                (row_idx.to_string(), record)
+            };
+
+            let row = Row::from_csv_record(headers.clone(), record, row_id)?;
             row_idx += 1;
             if row_idx > MAX_TABLE_ROWS {
                 Err(anyhow!("Too many rows in CSV file"))?;
@@ -313,20 +338,22 @@ BAR,acme";
 
         // Test first row
         assert_eq!(rows[0].row_id, "0");
-        assert_eq!(rows[0].value["hellworld"], 1.0);
-        assert_eq!(rows[0].value["super_fast"], 2.23);
-        assert_eq!(rows[0].value["c_foo"], 3.0);
-        let date = rows[0].value["date"].as_object().unwrap();
+        assert_eq!(rows[0].value()["hellworld"], 1.0);
+        assert_eq!(rows[0].value()["super_fast"], 2.23);
+        assert_eq!(rows[0].value()["c_foo"], 3.0);
+        let value = rows[0].value();
+        let date = value["date"].as_object().unwrap();
         assert_eq!(date["type"], "datetime");
         assert_eq!(date["epoch"], 1739545612380i64);
         assert_eq!(date["string_value"], "2025-02-14T15:06:52.380Z");
 
         // Test second row
         assert_eq!(rows[1].row_id, "1");
-        assert_eq!(rows[1].value["hellworld"], 4.0);
-        assert_eq!(rows[1].value["super_fast"], "hello world");
-        assert_eq!(rows[1].value["c_foo"], 6.0);
-        let date = rows[1].value["date"].as_object().unwrap();
+        assert_eq!(rows[1].value()["hellworld"], 4.0);
+        assert_eq!(rows[1].value()["super_fast"], "hello world");
+        assert_eq!(rows[1].value()["c_foo"], 6.0);
+        let value = rows[1].value();
+        let date = value["date"].as_object().unwrap();
         assert_eq!(date["type"], "datetime");
         assert_eq!(date["epoch"], 1739545834000i64);
         assert_eq!(date["string_value"], "Fri, 14 Feb 2025 15:10:34 GMT");
@@ -341,6 +368,14 @@ BAR,acme";
         assert_eq!(rows.len(), 2);
         assert_eq!(rows[0].row_id, "MYID1");
         assert_eq!(rows[1].row_id, "MYID2");
+        assert_eq!(
+            rows[0].headers.iter().collect::<Vec<&String>>(),
+            &["super_fast", "c_foo", "date"]
+        );
+        assert_eq!(
+            rows[1].headers.iter().collect::<Vec<&String>>(),
+            &["super_fast", "c_foo", "date"]
+        );
 
         Ok(())
     }
@@ -362,7 +397,7 @@ BAR,acme";
 
         // Test that __dust_id is not inserted.
         let row_0_concatenated_keys = rows[0]
-            .value
+            .value()
             .keys()
             .into_iter()
             .map(|k| k.to_string())

--- a/core/src/databases/database.rs
+++ b/core/src/databases/database.rs
@@ -42,6 +42,12 @@ pub struct QueryResult {
 }
 
 pub trait HasValue {
+    /// Returns the headers (column names) and values for this item.
+    ///
+    /// # Returns
+    /// A tuple containing:
+    /// - `Vec<&String>`: Vector of references to column header names
+    /// - `Vec<&serde_json::Value>`: Vector of references to the corresponding column values
     fn value(&self) -> (Vec<&String>, Vec<&serde_json::Value>);
 }
 

--- a/core/src/databases/database.rs
+++ b/core/src/databases/database.rs
@@ -42,12 +42,12 @@ pub struct QueryResult {
 }
 
 pub trait HasValue {
-    fn value(&self) -> &serde_json::Map<String, serde_json::Value>;
+    fn value(&self) -> (Vec<&String>, Vec<&serde_json::Value>);
 }
 
 impl HasValue for QueryResult {
-    fn value(&self) -> &serde_json::Map<String, serde_json::Value> {
-        &self.value
+    fn value(&self) -> (Vec<&String>, Vec<&serde_json::Value>) {
+        (self.value.keys().collect(), self.value.values().collect())
     }
 }
 

--- a/core/src/databases/table.rs
+++ b/core/src/databases/table.rs
@@ -9,6 +9,7 @@ use chrono::{DateTime, NaiveDate, NaiveTime, Utc};
 use futures::future::try_join_all;
 use redis::AsyncCommands;
 use rslock::LockManager;
+use serde::de::Error;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 
@@ -804,42 +805,83 @@ impl Filterable for Table {
     }
 }
 
-#[derive(Debug, Deserialize, Serialize, Clone)]
+#[derive(Debug, Clone)]
 pub struct Row {
     pub row_id: String,
-    pub value: serde_json::Map<String, serde_json::Value>,
+
+    pub headers: Arc<Vec<String>>,
+    pub columns: Vec<serde_json::Value>,
+
     // To keep track of pending delete actions, we use a special marker row.
     // This allows us to keep all the row data in the same format, which keeps the
     // implementation simpler.
     // Note that this is internal state, and it is not serialized
-    #[serde(skip_serializing, default)]
     pub is_delete: bool,
 }
 
 impl Row {
-    pub fn new(row_id: String, value: serde_json::Map<String, serde_json::Value>) -> Self {
+    pub fn new(row_id: String, headers: Arc<Vec<String>>, columns: Vec<serde_json::Value>) -> Self {
         Row {
             row_id,
-            value,
+            headers,
+            columns,
             is_delete: false,
         }
     }
 
     pub fn new_delete_marker_row(row_id: String) -> Self {
+        let headers = Arc::new(vec![]);
+        let columns = vec![];
         Row {
             row_id,
-            value: serde_json::Map::new(),
+            headers,
+            columns,
             is_delete: true,
         }
     }
 
+    // Legacy constructor for backward compatibility - converts value map to headers/columns
+    pub fn new_with_value(
+        row_id: String,
+        value: serde_json::Map<String, serde_json::Value>,
+    ) -> Self {
+        let column_names: Vec<String> = value.keys().cloned().collect();
+        let column_values: Vec<serde_json::Value> = column_names
+            .iter()
+            .map(|key| value.get(key).cloned().unwrap_or(serde_json::Value::Null))
+            .collect();
+
+        let headers = Arc::new(column_names);
+
+        Row {
+            row_id,
+            headers,
+            columns: column_values,
+            is_delete: false,
+        }
+    }
+
+    // Compute value from headers and columns on-demand
+    pub fn value(&self) -> serde_json::Map<String, serde_json::Value> {
+        let mut value = serde_json::Map::new();
+        for (i, column_name) in self.headers.iter().enumerate() {
+            let column_value = self
+                .columns
+                .get(i)
+                .cloned()
+                .unwrap_or(serde_json::Value::Null);
+            value.insert(column_name.clone(), column_value);
+        }
+        value
+    }
+
     /// This method implements our interpretation of CSVs into Table rows.
     pub fn from_csv_record(
-        headers: &Vec<String>,
+        headers: Arc<Vec<String>>,
         record: Vec<&str>,
-        row_idx: usize,
+        row_id: String,
     ) -> Result<Row> {
-        let mut value_map = serde_json::Map::new();
+        let mut values = Vec::<serde_json::Value>::new();
 
         fn try_parse_float(s: &str) -> Result<serde_json::Number> {
             if let Ok(float) = s.parse::<f64>() {
@@ -861,7 +903,7 @@ impl Row {
             let trimmed = field.trim();
 
             if header == "__dust_id" {
-                continue;
+                Err(anyhow!("__dust_id is not a valid header. It should have been filtered out before calling this method."))?;
             }
 
             let parsed_value = if trimmed.is_empty() {
@@ -938,17 +980,10 @@ impl Row {
                 }
             };
 
-            value_map.insert(header.clone(), parsed_value);
+            values.push(parsed_value);
         }
 
-        let row_id = if let Some(pos) = headers.iter().position(|h| h == "__dust_id") {
-            record.get(pos).map(|id| id.trim().to_string())
-        } else {
-            None
-        }
-        .unwrap_or_else(|| row_idx.to_string());
-
-        Ok(Row::new(row_id, value_map))
+        Ok(Row::new(row_id, headers, values))
     }
 
     pub fn to_csv_record(&self, headers: &Vec<String>) -> Result<Vec<String>> {
@@ -993,14 +1028,45 @@ impl Row {
     pub fn row_id(&self) -> &str {
         &self.row_id
     }
-    pub fn content(&self) -> &serde_json::Map<String, serde_json::Value> {
-        &self.value
+    pub fn content(&self) -> serde_json::Map<String, serde_json::Value> {
+        self.value()
+    }
+}
+
+impl Serialize for Row {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        use serde::ser::SerializeStruct;
+        let mut state = serializer.serialize_struct("Row", 3)?;
+        state.serialize_field("row_id", &self.row_id)?;
+        state.serialize_field("value", &self.value())?;
+        // we do not serialize is_delete
+        state.end()
+    }
+}
+
+impl<'de> Deserialize<'de> for Row {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        let value = serde_json::Map::deserialize(deserializer)?;
+
+        match value["value"].as_object() {
+            Some(value) => Ok(Row::new_with_value(
+                value["row_id"].to_string(),
+                value.clone(),
+            )),
+            None => Err(D::Error::custom("Missing value in Row")),
+        }
     }
 }
 
 impl HasValue for Row {
-    fn value(&self) -> &serde_json::Map<String, serde_json::Value> {
-        &self.value
+    fn value(&self) -> (Vec<&String>, Vec<&serde_json::Value>) {
+        (self.headers.iter().collect(), self.columns.iter().collect())
     }
 }
 
@@ -1030,8 +1096,8 @@ mod tests {
         ]);
 
         let rows = Arc::new(vec![
-            Row::new("1".to_string(), row_1),
-            Row::new("2".to_string(), row_2),
+            Row::new_with_value("1".to_string(), row_1),
+            Row::new_with_value("2".to_string(), row_2),
         ]);
 
         let schema = TableSchema::from_rows_async(rows).await?;
@@ -1075,14 +1141,14 @@ mod tests {
 
     #[tokio::test]
     async fn test_row_from_csv_record() -> anyhow::Result<()> {
-        let headers = vec!["test".to_string(), "date".to_string()];
+        let headers = Arc::new(vec!["test".to_string(), "date".to_string()]);
 
         let record = vec!["1", "2021-01-01T00:00:00Z"];
-        let row = Row::from_csv_record(&headers, record, 0)?;
+        let row = Row::from_csv_record(headers.clone(), record, "0".to_string())?;
         assert_eq!(row.row_id(), "0");
         assert_eq!(
             row.content(),
-            &serde_json::Map::from_iter([
+            serde_json::Map::from_iter([
                 ("test".to_string(), 1.into()),
                 (
                     "date".to_string(),
@@ -1097,7 +1163,7 @@ mod tests {
         );
 
         let record = vec!["123a", "March 2, 2021"];
-        let row = Row::from_csv_record(&headers, record, 0)?;
+        let row = Row::from_csv_record(headers.clone(), record, "0".to_string())?;
         assert_eq!(row.content()["test"], Value::String("123a".to_string()));
         assert_eq!(
             row.content()["date"]["type"],
@@ -1109,7 +1175,7 @@ mod tests {
         );
 
         let record = vec!["true", "02-Jan-2021"];
-        let row = Row::from_csv_record(&headers, record, 0)?;
+        let row = Row::from_csv_record(headers.clone(), record, "0".to_string())?;
         assert_eq!(row.content()["test"], Value::Bool(true));
         assert_eq!(
             row.content()["date"]["string_value"],
@@ -1121,7 +1187,7 @@ mod tests {
         );
 
         let record = vec!["false", "2024-02-19 15:30:45"];
-        let row = Row::from_csv_record(&headers, record, 0)?;
+        let row = Row::from_csv_record(headers.clone(), record, "0".to_string())?;
         assert_eq!(row.content()["test"], Value::Bool(false));
         assert_eq!(
             row.content()["date"]["string_value"],
@@ -1133,7 +1199,7 @@ mod tests {
         );
 
         let record = vec!["", "2-Jan-2021"];
-        let row = Row::from_csv_record(&headers, record, 0)?;
+        let row = Row::from_csv_record(headers.clone(), record, "0".to_string())?;
         assert_eq!(
             row.content()["date"]["string_value"],
             Value::String("2-Jan-2021".to_string())
@@ -1144,7 +1210,7 @@ mod tests {
         );
 
         let record = vec!["", "January 02, 2021"];
-        let row = Row::from_csv_record(&headers, record, 0)?;
+        let row = Row::from_csv_record(headers.clone(), record, "0".to_string())?;
         assert_eq!(
             row.content()["date"]["string_value"],
             Value::String("January 02, 2021".to_string())
@@ -1155,7 +1221,7 @@ mod tests {
         );
 
         let record = vec!["", "Fri, 14 Feb 2025 15:10:34 GMT"];
-        let row = Row::from_csv_record(&headers, record, 0)?;
+        let row = Row::from_csv_record(headers.clone(), record, "0".to_string())?;
         assert_eq!(
             row.content()["date"]["string_value"],
             Value::String("Fri, 14 Feb 2025 15:10:34 GMT".to_string())
@@ -1165,9 +1231,9 @@ mod tests {
             Value::Number(1739545834000_i64.into())
         );
 
-        let headers = vec!["a".to_string(), "b".to_string(), "c".to_string()];
+        let headers = Arc::new(vec!["a".to_string(), "b".to_string(), "c".to_string()]);
         let record = vec!["2", "2.0", "0.1"];
-        let row = Row::from_csv_record(&headers, record, 0)?;
+        let row = Row::from_csv_record(headers.clone(), record, "0".to_string())?;
         assert_eq!(row.content()["a"], Value::Number(2.into()));
         assert_eq!(
             row.content()["b"],
@@ -1178,27 +1244,27 @@ mod tests {
             Value::Number(serde_json::Number::from_f64(0.1).unwrap())
         );
 
-        let headers = vec!["a".to_string(), "b".to_string()];
+        let headers = Arc::new(vec!["a".to_string(), "b".to_string()]);
         let record = vec!["true", "false"];
-        let row = Row::from_csv_record(&headers, record, 0)?;
+        let row = Row::from_csv_record(headers, record, "0".to_string())?;
         assert_eq!(row.content()["a"], Value::Bool(true));
         assert_eq!(row.content()["b"], Value::Bool(false));
 
-        let headers = vec!["a".to_string(), "b".to_string()];
+        let headers = Arc::new(vec!["a".to_string(), "b".to_string()]);
         let record = vec!["TRUE", "FALSE"];
-        let row = Row::from_csv_record(&headers, record, 0)?;
+        let row = Row::from_csv_record(headers, record, "0".to_string())?;
         assert_eq!(row.content()["a"], Value::Bool(true));
         assert_eq!(row.content()["b"], Value::Bool(false));
 
-        let headers = vec!["a".to_string(), "b".to_string()];
+        let headers = Arc::new(vec!["a".to_string(), "b".to_string()]);
         let record = vec!["t", "f"];
-        let row = Row::from_csv_record(&headers, record, 0)?;
+        let row = Row::from_csv_record(headers, record, "0".to_string())?;
         assert_eq!(row.content()["a"], Value::Bool(true));
         assert_eq!(row.content()["b"], Value::Bool(false));
 
-        let headers = vec!["a".to_string(), "b".to_string()];
+        let headers = Arc::new(vec!["a".to_string(), "b".to_string()]);
         let record = vec!["trUe", "fALse"];
-        let row = Row::from_csv_record(&headers, record, 0)?;
+        let row = Row::from_csv_record(headers, record, "0".to_string())?;
         assert_eq!(row.content()["a"], Value::Bool(true));
         assert_eq!(row.content()["b"], Value::Bool(false));
 
@@ -1216,19 +1282,21 @@ mod tests {
             ("null_col".to_string(), Value::Null),
         ]);
 
-        let simple_row = Row::new("test_row_id".to_string(), simple_row_data);
+        let simple_row = Row::new_with_value("test_row_id".to_string(), simple_row_data);
 
-        // Extract headers and ensure consistent ordering
-        let mut headers: Vec<String> = simple_row.value().keys().cloned().collect();
-        headers.sort();
+        // Extract headers
+        let headers = simple_row.headers.clone();
 
         // Convert row to CSV record and back
         let csv_record = simple_row.to_csv_record(&headers)?;
-        let reconstructed_row =
-            Row::from_csv_record(&headers, csv_record.iter().map(|s| s.as_str()).collect(), 0)?;
+        let reconstructed_row = Row::from_csv_record(
+            headers.clone(),
+            csv_record.iter().map(|s| s.as_str()).collect(),
+            "test_row_id".to_string(),
+        )?;
 
         // Content should be identical for simple data types
-        assert_eq!(simple_row.content(), reconstructed_row.content());
+        assert_eq!(&simple_row.content(), &reconstructed_row.content());
 
         // Test case 2: Verify expected transformations for edge cases
         let edge_case_data = serde_json::Map::from_iter([
@@ -1236,14 +1304,15 @@ mod tests {
             ("non_empty_string".to_string(), "not empty".into()),
         ]);
 
-        let edge_case_row = Row::new("edge_case_id".to_string(), edge_case_data);
-        let edge_headers: Vec<String> = edge_case_row.value().keys().cloned().collect();
+        let edge_case_row = Row::new_with_value("edge_case_id".to_string(), edge_case_data);
+        let edge_headers: Arc<Vec<String>> =
+            Arc::new(edge_case_row.value().keys().cloned().collect());
 
         let edge_csv_record = edge_case_row.to_csv_record(&edge_headers)?;
         let edge_reconstructed_row = Row::from_csv_record(
-            &edge_headers,
+            edge_headers,
             edge_csv_record.iter().map(|s| s.as_str()).collect(),
-            0,
+            "edge_case_id".to_string(),
         )?;
 
         // Empty strings become null when parsed from CSV - this is expected behavior
@@ -1256,25 +1325,7 @@ mod tests {
             Value::String("not empty".to_string())
         );
 
-        // Test case 3: Test with __dust_id to verify row_id preservation
-        let mut headers_with_id = headers.clone();
-        headers_with_id.insert(0, "__dust_id".to_string());
-
-        let mut csv_record_with_id = csv_record.clone();
-        csv_record_with_id.insert(0, simple_row.row_id().to_string());
-
-        let reconstructed_row_with_id = Row::from_csv_record(
-            &headers_with_id,
-            csv_record_with_id.iter().map(|s| s.as_str()).collect(),
-            0,
-        )?;
-
-        // Row ID should be preserved and content should still match
-        assert_eq!(simple_row.row_id(), "test_row_id");
-        assert_eq!(simple_row.row_id(), reconstructed_row_with_id.row_id());
-        assert_eq!(simple_row.content(), reconstructed_row_with_id.content());
-
-        // Test case 4: Date round trip test (dates may have format changes but should preserve epoch)
+        // Test case 3: Date round trip test (dates may have format changes but should preserve epoch)
         let date_data = serde_json::Map::from_iter([(
             "date_col".to_string(),
             serde_json::Map::from_iter([
@@ -1285,14 +1336,14 @@ mod tests {
             .into(),
         )]);
 
-        let date_row = Row::new("date_test_id".to_string(), date_data);
-        let date_headers: Vec<String> = date_row.value().keys().cloned().collect();
+        let date_row = Row::new_with_value("date_test_id".to_string(), date_data);
+        let date_headers: Arc<Vec<String>> = Arc::new(date_row.value().keys().cloned().collect());
 
         let date_csv_record = date_row.to_csv_record(&date_headers)?;
         let date_reconstructed_row = Row::from_csv_record(
-            &date_headers,
+            date_headers,
             date_csv_record.iter().map(|s| s.as_str()).collect(),
-            0,
+            "date_test_id".to_string(),
         )?;
 
         // The epoch should be preserved even if string format changes
@@ -1306,12 +1357,12 @@ mod tests {
         );
         // Note: string_value may change format during parsing, so we don't assert equality on it
 
-        // Test case 5: Test that the __dust_id field is present in the CSV record at the position of the field in the headers
-        let dust_id_row = Row::new(
+        // Test case 4: Test that the __dust_id field is present in the CSV record at the position of the field in the headers
+        let dust_id_row = Row::new_with_value(
             "dust_id_test_id".to_string(),
             serde_json::Map::from_iter([("property".to_string(), "value".into())]),
         );
-        let headers = vec!["property".to_string(), "__dust_id".to_string()];
+        let headers = Arc::new(vec!["property".to_string(), "__dust_id".to_string()]);
         let dust_id_csv_record = dust_id_row.to_csv_record(&headers)?;
         assert_eq!(
             dust_id_csv_record[dust_id_csv_record.len() - 1],

--- a/core/src/databases/table_schema.rs
+++ b/core/src/databases/table_schema.rs
@@ -494,8 +494,8 @@ mod tests {
             ),
         ]);
         let rows = &vec![
-            Row::new_with_value("1".to_string(), row_1),
-            Row::new_with_value("2".to_string(), row_2),
+            Row::new_from_value("1".to_string(), row_1),
+            Row::new_from_value("2".to_string(), row_2),
         ];
 
         let schema = TableSchema::from_rows(rows)?;
@@ -549,8 +549,8 @@ mod tests {
         let row_1: Map<String, Value> = json!({"field1": 1, "field2": 1.2, "field3": "text", "field4": true, "field6": ["array", "elements"], "field7": {"key": "value"}}).as_object().unwrap().clone();
         let row_2: Map<String, Value> = json!({"field1": 2, "field2": 2.4, "field3": "more text", "field4": false, "field5": "not null anymore", "field6": ["more", "elements"], "field7": {"anotherKey": "anotherValue"}}).as_object().unwrap().clone();
         let rows = &vec![
-            Row::new_with_value("1".to_string(), row_1),
-            Row::new_with_value("2".to_string(), row_2),
+            Row::new_from_value("1".to_string(), row_1),
+            Row::new_from_value("2".to_string(), row_2),
         ];
 
         match TableSchema::from_rows(rows) {
@@ -573,9 +573,9 @@ mod tests {
             .unwrap()
             .clone();
         let rows = &vec![
-            Row::new_with_value("1".to_string(), row_1),
-            Row::new_with_value("2".to_string(), row_2),
-            Row::new_with_value("3".to_string(), row_3),
+            Row::new_from_value("1".to_string(), row_1),
+            Row::new_from_value("2".to_string(), row_2),
+            Row::new_from_value("3".to_string(), row_3),
         ];
 
         let schema = TableSchema::from_rows(rows);
@@ -632,7 +632,7 @@ mod tests {
         let schema = create_test_schema();
         let conn = setup_in_memory_db(&schema)?;
 
-        let row = Row::new_with_value(
+        let row = Row::new_from_value(
             "row_1".to_string(),
             serde_json::Map::from_iter(
                 json!({"field1": 1, "field2": 2.4, "field3": "text", "field4": true})
@@ -685,7 +685,7 @@ mod tests {
         let (sql, field_names) = schema.get_insert_sql("test_table");
         let params = params_from_iter(schema.get_insert_params(
             &field_names,
-            &Row::new_with_value("1".to_string(), row_content),
+            &Row::new_from_value("1".to_string(), row_content),
         )?);
         let mut stmt = conn.prepare(&sql)?;
         stmt.execute(params)?;
@@ -916,8 +916,8 @@ mod tests {
                 .unwrap()
                 .clone(); // Corresponds to 2000-01-02 00:00:00
         let rows = &vec![
-            Row::new_with_value("1".to_string(), row_1.clone()),
-            Row::new_with_value("2".to_string(), row_2.clone()),
+            Row::new_from_value("1".to_string(), row_1.clone()),
+            Row::new_from_value("2".to_string(), row_2.clone()),
         ];
 
         let schema = TableSchema::from_rows(rows)?;
@@ -939,14 +939,14 @@ mod tests {
 
         let (sql, field_names) = schema.get_insert_sql("test_table");
         let params = params_from_iter(
-            schema.get_insert_params(&field_names, &Row::new_with_value("1".to_string(), row_1))?,
+            schema.get_insert_params(&field_names, &Row::new_from_value("1".to_string(), row_1))?,
         );
         let mut stmt = conn.prepare(&sql)?;
         stmt.execute(params)?;
 
         let (sql, field_names) = schema.get_insert_sql("test_table");
         let params = params_from_iter(
-            schema.get_insert_params(&field_names, &Row::new_with_value("2".to_string(), row_2))?,
+            schema.get_insert_params(&field_names, &Row::new_from_value("2".to_string(), row_2))?,
         );
         let mut stmt = conn.prepare(&sql)?;
         stmt.execute(params)?;


### PR DESCRIPTION
## Description

Reduce memory usage when parsing a CSV to `Row` by not repeating the headers in each rows.

## Tests

Run green.

## Risk

Medium as it's touches the representation of CSV and Row.

## Deploy Plan

Deploy core