### PR TITLE
[connectors] Add ticket filtering based on organization tags

### DIFF
--- a/connectors/migrations/db/migration_87.sql
+++ b/connectors/migrations/db/migration_87.sql
@@ -1,0 +1,3 @@
+-- Migration created on Jul 31, 2025
+ALTER TABLE "public"."zendesk_configurations" ADD COLUMN "organizationTagsIn" VARCHAR(255)[];
+ALTER TABLE "public"."zendesk_configurations" ADD COLUMN "organizationTagsNotIn" VARCHAR(255)[];

--- a/connectors/migrations/db/migration_87.sql
+++ b/connectors/migrations/db/migration_87.sql
@@ -1,3 +1,3 @@
 -- Migration created on Jul 31, 2025
-ALTER TABLE "public"."zendesk_configurations" ADD COLUMN "organizationTagsIn" VARCHAR(255)[];
-ALTER TABLE "public"."zendesk_configurations" ADD COLUMN "organizationTagsNotIn" VARCHAR(255)[];
+ALTER TABLE "public"."zendesk_configurations" ADD COLUMN "organizationTagsToInclude" VARCHAR(255)[];
+ALTER TABLE "public"."zendesk_configurations" ADD COLUMN "organizationTagsToExclude" VARCHAR(255)[];

--- a/connectors/src/connectors/zendesk/index.ts
+++ b/connectors/src/connectors/zendesk/index.ts
@@ -97,6 +97,8 @@ export class ZendeskConnectorManager extends BaseConnectorManager<null> {
         retentionPeriodDays: DEFAULT_RETENTION_DAYS,
         syncUnresolvedTickets: false,
         hideCustomerDetails: false,
+        organizationTagsIn: null,
+        organizationTagsNotIn: null,
       }
     );
     const loggerArgs = {

--- a/connectors/src/connectors/zendesk/index.ts
+++ b/connectors/src/connectors/zendesk/index.ts
@@ -97,8 +97,8 @@ export class ZendeskConnectorManager extends BaseConnectorManager<null> {
         retentionPeriodDays: DEFAULT_RETENTION_DAYS,
         syncUnresolvedTickets: false,
         hideCustomerDetails: false,
-        organizationTagsIn: null,
-        organizationTagsNotIn: null,
+        organizationTagsToInclude: null,
+        organizationTagsToExclude: null,
       }
     );
     const loggerArgs = {

--- a/connectors/src/connectors/zendesk/lib/cli.ts
+++ b/connectors/src/connectors/zendesk/lib/cli.ts
@@ -481,7 +481,7 @@ export const zendesk = async ({
     case "add-organization-tag": {
       const { tag, tagIn } = getOrganizationTagsArgs(args);
 
-      const column = tagIn ? "organizationTagsIn" : "organizationTagsNotIn";
+      const column = tagIn ? "organizationTagsToInclude" : "organizationTagsToExclude";
       const currentTags = configuration[column] || [];
       const localLogger = logger.child({ tag, column, currentTags });
 
@@ -502,7 +502,7 @@ export const zendesk = async ({
     case "remove-organization-tag": {
       const { tag, tagIn } = getOrganizationTagsArgs(args);
 
-      const column = tagIn ? "organizationTagsIn" : "organizationTagsNotIn";
+      const column = tagIn ? "organizationTagsToInclude" : "organizationTagsToExclude";
       const currentTags = configuration[column] || [];
       const localLogger = logger.child({ tag, column, currentTags });
 

--- a/connectors/src/connectors/zendesk/lib/cli.ts
+++ b/connectors/src/connectors/zendesk/lib/cli.ts
@@ -483,9 +483,10 @@ export const zendesk = async ({
 
       const column = tagIn ? "organizationTagsIn" : "organizationTagsNotIn";
       const currentTags = configuration[column] || [];
+      const localLogger = logger.child({ tag, column, currentTags });
 
       if (currentTags.includes(tag)) {
-        logger.info(`Tag "${tag}" already exists in ${column}`);
+        localLogger.info("Tag already exists.");
         return {
           success: true,
           message: `Tag "${tag}" already exists in ${column}`,
@@ -493,14 +494,9 @@ export const zendesk = async ({
       }
 
       const newTags = [...currentTags, tag];
-      await configuration.update({
-        [column]: newTags,
-      });
+      await configuration.update({ [column]: newTags });
 
-      logger.info(
-        { currentTags, newTags, tag, column },
-        `Successfully added tag.`
-      );
+      localLogger.info({ newTags }, "Successfully added tag.");
       return { success: true, message: `Added tag "${tag}" to ${column}` };
     }
     case "remove-organization-tag": {
@@ -508,9 +504,10 @@ export const zendesk = async ({
 
       const column = tagIn ? "organizationTagsIn" : "organizationTagsNotIn";
       const currentTags = configuration[column] || [];
+      const localLogger = logger.child({ tag, column, currentTags });
 
       if (!currentTags.includes(tag)) {
-        logger.info(`Tag "${tag}" does not exist in ${column}`);
+        localLogger.info("Tag does not exist.");
         return {
           success: true,
           message: `Tag "${tag}" does not exist in ${column}`,
@@ -518,14 +515,9 @@ export const zendesk = async ({
       }
 
       const newTags = currentTags.filter((t) => t !== tag);
-      await configuration.update({
-        [column]: newTags,
-      });
+      await configuration.update({ [column]: newTags });
 
-      logger.info(
-        { currentTags, newTags, tag, column },
-        `Successfully removed tag.`
-      );
+      localLogger.info({ newTags }, "Successfully removed tag.");
       return { success: true, message: `Removed tag "${tag}" from ${column}` };
     }
   }

--- a/connectors/src/connectors/zendesk/lib/cli.ts
+++ b/connectors/src/connectors/zendesk/lib/cli.ts
@@ -52,18 +52,18 @@ function getOrganizationTagsArgs(args: ZendeskCommandType["args"]) {
     throw new Error("Missing --tag argument");
   }
 
-  const tagIn = args.in === "true";
-  const tagNotIn = args.notIn === "true";
+  const include = args.include === "true";
+  const exclude = args.exclude === "true";
 
-  if (tagIn && tagNotIn) {
+  if (include && exclude) {
     throw new Error("Cannot specify both --in and --not-in options");
   }
 
-  if (!tagIn && !tagNotIn) {
+  if (!include && !exclude) {
     throw new Error("Must specify either --in or --not-in option");
   }
 
-  return { tag, tagIn, tagNotIn };
+  return { tag, include, exclude };
 }
 
 async function checkTicketShouldBeSynced(
@@ -479,26 +479,26 @@ export const zendesk = async ({
       return { success: true };
     }
     case "add-organization-tag": {
-      const { tag, tagIn, tagNotIn } = getOrganizationTagsArgs(args);
+      const { tag, include, exclude } = getOrganizationTagsArgs(args);
 
       const { wasAdded, message } = await configuration.addOrganizationTag({
         tag,
-        includeOrExclude: tagIn ? "include" : "exclude",
+        includeOrExclude: include ? "include" : "exclude",
       });
-      logger.info({ wasAdded, tag, tagIn, tagNotIn }, message);
+      logger.info({ wasAdded, tag, include, exclude }, message);
 
       return { success: true, message };
     }
     case "remove-organization-tag": {
-      const { tag, tagIn, tagNotIn } = getOrganizationTagsArgs(args);
+      const { tag, include, exclude } = getOrganizationTagsArgs(args);
 
       const { wasRemoved, message } = await configuration.removeOrganizationTag(
         {
           tag,
-          includeOrExclude: tagIn ? "include" : "exclude",
+          includeOrExclude: include ? "include" : "exclude",
         }
       );
-      logger.info({ wasRemoved, tag, tagIn, tagNotIn }, message);
+      logger.info({ wasRemoved, tag, include, exclude }, message);
 
       return { success: true, message };
     }

--- a/connectors/src/connectors/zendesk/lib/cli.ts
+++ b/connectors/src/connectors/zendesk/lib/cli.ts
@@ -84,17 +84,20 @@ async function checkTicketShouldBeSynced(
     return false;
   }
 
-  let organizationTags: string[] = [];
+  let organizationTags: string[] | null = null;
 
-  if (configuration.enforcesOrganizationTagConstraint()) {
+  if (
+    configuration.enforcesOrganizationTagConstraint() &&
+    ticket.organization_id
+  ) {
     const [organization] = await listZendeskOrganizations({
       accessToken,
       brandSubdomain,
-      organizationIds: [ticket?.organization_id],
+      organizationIds: [ticket.organization_id],
     });
     if (!organization) {
       logger.error(
-        { ticketId: ticket.id, organizationId: ticket?.organization_id },
+        { ticketId: ticket.id, organizationId: ticket.organization_id },
         "Organization not found."
       );
     } else {

--- a/connectors/src/connectors/zendesk/lib/cli.ts
+++ b/connectors/src/connectors/zendesk/lib/cli.ts
@@ -479,46 +479,28 @@ export const zendesk = async ({
       return { success: true };
     }
     case "add-organization-tag": {
-      const { tag, tagIn } = getOrganizationTagsArgs(args);
+      const { tag, tagIn, tagNotIn } = getOrganizationTagsArgs(args);
 
-      const column = tagIn ? "organizationTagsToInclude" : "organizationTagsToExclude";
-      const currentTags = configuration[column] || [];
-      const localLogger = logger.child({ tag, column, currentTags });
+      const { wasAdded, message } = await configuration.addOrganizationTag({
+        tag,
+        includeOrExclude: tagIn ? "include" : "exclude",
+      });
+      logger.info({ wasAdded, tag, tagIn, tagNotIn }, message);
 
-      if (currentTags.includes(tag)) {
-        localLogger.info("Tag already exists.");
-        return {
-          success: true,
-          message: `Tag "${tag}" already exists in ${column}`,
-        };
-      }
-
-      const newTags = [...currentTags, tag];
-      await configuration.update({ [column]: newTags });
-
-      localLogger.info({ newTags }, "Successfully added tag.");
-      return { success: true, message: `Added tag "${tag}" to ${column}` };
+      return { success: true, message };
     }
     case "remove-organization-tag": {
-      const { tag, tagIn } = getOrganizationTagsArgs(args);
+      const { tag, tagIn, tagNotIn } = getOrganizationTagsArgs(args);
 
-      const column = tagIn ? "organizationTagsToInclude" : "organizationTagsToExclude";
-      const currentTags = configuration[column] || [];
-      const localLogger = logger.child({ tag, column, currentTags });
+      const { wasRemoved, message } = await configuration.removeOrganizationTag(
+        {
+          tag,
+          includeOrExclude: tagIn ? "include" : "exclude",
+        }
+      );
+      logger.info({ wasRemoved, tag, tagIn, tagNotIn }, message);
 
-      if (!currentTags.includes(tag)) {
-        localLogger.info("Tag does not exist.");
-        return {
-          success: true,
-          message: `Tag "${tag}" does not exist in ${column}`,
-        };
-      }
-
-      const newTags = currentTags.filter((t) => t !== tag);
-      await configuration.update({ [column]: newTags });
-
-      localLogger.info({ newTags }, "Successfully removed tag.");
-      return { success: true, message: `Removed tag "${tag}" from ${column}` };
+      return { success: true, message };
     }
   }
 };

--- a/connectors/src/connectors/zendesk/lib/cli.ts
+++ b/connectors/src/connectors/zendesk/lib/cli.ts
@@ -84,7 +84,7 @@ async function checkTicketShouldBeSynced(
     return false;
   }
 
-  let organizationTags: string[] | null = null;
+  let organizationTags: string[] = [];
 
   if (
     configuration.enforcesOrganizationTagConstraint() &&

--- a/connectors/src/connectors/zendesk/lib/sync_ticket.ts
+++ b/connectors/src/connectors/zendesk/lib/sync_ticket.ts
@@ -33,7 +33,7 @@ export function shouldSyncTicket(
   {
     brandId,
     organizationTags,
-  }: { brandId?: number; organizationTags: string[] | null }
+  }: { brandId?: number; organizationTags: string[] }
 ): boolean {
   if (ticket.status === "deleted") {
     return false;
@@ -48,19 +48,21 @@ export function shouldSyncTicket(
     return false;
   }
 
+  // If we enforce an inclusion rule on tags, we must have at least one of the
+  // mandatory tags.
   if (
     configuration.organizationTagsToInclude &&
-    (organizationTags === null ||
-      configuration.organizationTagsToInclude.some(
-        (mandatoryTag) => !organizationTags.includes(mandatoryTag)
-      ))
+    !configuration.organizationTagsToInclude.some((mandatoryTag) =>
+      organizationTags.includes(mandatoryTag)
+    )
   ) {
     return false;
   }
 
+  // If we enforce an exclusion rule on tags, we must not have any of the
+  // excluded tags.
   if (
     configuration.organizationTagsToExclude &&
-    organizationTags !== null &&
     configuration.organizationTagsToExclude.some((prohibitedTag) =>
       organizationTags.includes(prohibitedTag)
     )

--- a/connectors/src/connectors/zendesk/lib/sync_ticket.ts
+++ b/connectors/src/connectors/zendesk/lib/sync_ticket.ts
@@ -32,8 +32,8 @@ export function shouldSyncTicket(
   configuration: ZendeskConfigurationResource,
   {
     brandId,
-    organizationTagsMap,
-  }: { brandId?: number; organizationTagsMap: Map<number, string[]> }
+    organizationTags,
+  }: { brandId?: number; organizationTags: string[] }
 ): boolean {
   if (ticket.status === "deleted") {
     return false;
@@ -46,21 +46,6 @@ export function shouldSyncTicket(
   }
   if (brandId && brandId !== ticket.brand_id) {
     return false;
-  }
-
-  const organizationTags = organizationTagsMap.get(ticket.organization_id);
-  if (!organizationTags) {
-    logger.error(
-      {
-        ticketId: ticket.id,
-        organizationId: ticket.organization_id,
-        connectorId: configuration.connectorId,
-      },
-      "Organization tags not found."
-    );
-    throw new Error(
-      `Tags not found for organization ${ticket.organization_id}.`
-    );
   }
 
   if (

--- a/connectors/src/connectors/zendesk/lib/sync_ticket.ts
+++ b/connectors/src/connectors/zendesk/lib/sync_ticket.ts
@@ -33,7 +33,7 @@ export function shouldSyncTicket(
   {
     brandId,
     organizationTags,
-  }: { brandId?: number; organizationTags: string[] }
+  }: { brandId?: number; organizationTags: string[] | null }
 ): boolean {
   if (ticket.status === "deleted") {
     return false;
@@ -49,14 +49,19 @@ export function shouldSyncTicket(
   }
 
   if (
-    configuration.organizationTagsIn?.some(
-      (mandatoryTag) => !organizationTags.includes(mandatoryTag)
-    )
+    configuration.organizationTagsIn &&
+    (organizationTags === null ||
+      configuration.organizationTagsIn.some(
+        (mandatoryTag) => !organizationTags.includes(mandatoryTag)
+      ))
   ) {
     return false;
   }
+
   if (
-    configuration.organizationTagsNotIn?.some((prohibitedTag) =>
+    configuration.organizationTagsNotIn &&
+    organizationTags !== null &&
+    configuration.organizationTagsNotIn.some((prohibitedTag) =>
       organizationTags.includes(prohibitedTag)
     )
   ) {

--- a/connectors/src/connectors/zendesk/lib/sync_ticket.ts
+++ b/connectors/src/connectors/zendesk/lib/sync_ticket.ts
@@ -49,9 +49,9 @@ export function shouldSyncTicket(
   }
 
   if (
-    configuration.organizationTagsIn &&
+    configuration.organizationTagsToInclude &&
     (organizationTags === null ||
-      configuration.organizationTagsIn.some(
+      configuration.organizationTagsToInclude.some(
         (mandatoryTag) => !organizationTags.includes(mandatoryTag)
       ))
   ) {
@@ -59,9 +59,9 @@ export function shouldSyncTicket(
   }
 
   if (
-    configuration.organizationTagsNotIn &&
+    configuration.organizationTagsToExclude &&
     organizationTags !== null &&
-    configuration.organizationTagsNotIn.some((prohibitedTag) =>
+    configuration.organizationTagsToExclude.some((prohibitedTag) =>
       organizationTags.includes(prohibitedTag)
     )
   ) {

--- a/connectors/src/connectors/zendesk/lib/types.ts
+++ b/connectors/src/connectors/zendesk/lib/types.ts
@@ -96,7 +96,7 @@ export interface ZendeskFetchedTicket {
   group_id: number;
   has_incidents: boolean;
   id: number;
-  organization_id: number;
+  organization_id: number | null;
   priority: string;
   problem_id: number;
   raw_subject: string;

--- a/connectors/src/connectors/zendesk/lib/types.ts
+++ b/connectors/src/connectors/zendesk/lib/types.ts
@@ -178,3 +178,20 @@ export interface ZendeskFetchedUser {
   url: string;
   verified: boolean;
 }
+
+export interface ZendeskFetchedOrganization {
+  id: number;
+  url: string;
+  external_id: string;
+  name: string;
+  domain_names: string[];
+  created_at: string;
+  details: string;
+  shared_comments: boolean;
+  shared_tickets: boolean;
+  tags: string[];
+  group_id: number | null;
+  notes: string | null;
+  organization_fields: Record<string, string | number | boolean>;
+  shared_brand_assets: boolean;
+}

--- a/connectors/src/connectors/zendesk/lib/zendesk_api.ts
+++ b/connectors/src/connectors/zendesk/lib/zendesk_api.ts
@@ -19,6 +19,8 @@ import logger from "@connectors/logger/logger";
 import type { ZendeskCategoryResource } from "@connectors/resources/zendesk_resources";
 import { ZendeskBrandResource } from "@connectors/resources/zendesk_resources";
 import type { ModelId } from "@connectors/types";
+import { ConnectorResource } from "@connectors/resources/connector_resource";
+import { removeNulls } from "@connectors/types/shared/utils/general";
 
 const ZENDESK_RATE_LIMIT_MAX_RETRIES = 5;
 const ZENDESK_RATE_LIMIT_TIMEOUT_SECONDS = 60;
@@ -673,4 +675,22 @@ export async function listZendeskCategories({
     }
     throw e;
   }
+}
+
+export async function getOrganizationTagMapForTickets(
+  tickets: ZendeskFetchedTicket[],
+  {
+    accessToken,
+    brandSubdomain,
+  }: { accessToken: string; brandSubdomain: string }
+) {
+  const organizationIds = removeNulls(
+    tickets.map((t) => t.organization_id ?? null)
+  );
+  const organizations = await listZendeskOrganizations({
+    accessToken,
+    brandSubdomain,
+    organizationIds,
+  });
+  return new Map(organizations.map((t) => [t.id, t.tags]));
 }

--- a/connectors/src/connectors/zendesk/lib/zendesk_api.ts
+++ b/connectors/src/connectors/zendesk/lib/zendesk_api.ts
@@ -19,7 +19,6 @@ import logger from "@connectors/logger/logger";
 import type { ZendeskCategoryResource } from "@connectors/resources/zendesk_resources";
 import { ZendeskBrandResource } from "@connectors/resources/zendesk_resources";
 import type { ModelId } from "@connectors/types";
-import { ConnectorResource } from "@connectors/resources/connector_resource";
 import { removeNulls } from "@connectors/types/shared/utils/general";
 
 const ZENDESK_RATE_LIMIT_MAX_RETRIES = 5;

--- a/connectors/src/connectors/zendesk/temporal/activities.ts
+++ b/connectors/src/connectors/zendesk/temporal/activities.ts
@@ -670,13 +670,14 @@ export async function syncZendeskTicketBatchActivity({
   }
 
   const ticketsToSync = tickets.filter((t) => {
-    let organizationTags = null;
+    let organizationTags: string[] = [];
     if (
       t.organization_id &&
       configuration.enforcesOrganizationTagConstraint()
     ) {
-      organizationTags = organizationTagsMap.get(t.organization_id);
-      assert(organizationTags, "Organization tags not found.");
+      const mapValue = organizationTagsMap.get(t.organization_id);
+      assert(mapValue, "Organization tags not found.");
+      organizationTags = mapValue;
     }
 
     return shouldSyncTicket(t, configuration, {

--- a/connectors/src/connectors/zendesk/temporal/activities.ts
+++ b/connectors/src/connectors/zendesk/temporal/activities.ts
@@ -1,3 +1,4 @@
+import assert from "assert";
 import _ from "lodash";
 
 import {
@@ -42,7 +43,6 @@ import {
 } from "@connectors/resources/zendesk_resources";
 import type { ModelId } from "@connectors/types";
 import { INTERNAL_MIME_TYPES } from "@connectors/types";
-import assert from "assert";
 
 /**
  * This activity is responsible for updating the lastSyncStartTime of the connector to now.

--- a/connectors/src/connectors/zendesk/temporal/activities.ts
+++ b/connectors/src/connectors/zendesk/temporal/activities.ts
@@ -671,7 +671,10 @@ export async function syncZendeskTicketBatchActivity({
 
   const ticketsToSync = tickets.filter((t) => {
     let organizationTags = null;
-    if (t.organization_id) {
+    if (
+      t.organization_id &&
+      configuration.enforcesOrganizationTagConstraint()
+    ) {
       organizationTags = organizationTagsMap.get(t.organization_id);
       assert(organizationTags, "Organization tags not found.");
     }

--- a/connectors/src/connectors/zendesk/temporal/activities.ts
+++ b/connectors/src/connectors/zendesk/temporal/activities.ts
@@ -42,6 +42,7 @@ import {
 } from "@connectors/resources/zendesk_resources";
 import type { ModelId } from "@connectors/types";
 import { INTERNAL_MIME_TYPES } from "@connectors/types";
+import assert from "assert";
 
 /**
  * This activity is responsible for updating the lastSyncStartTime of the connector to now.
@@ -669,17 +670,10 @@ export async function syncZendeskTicketBatchActivity({
   }
 
   const ticketsToSync = tickets.filter((t) => {
-    const organizationTags = organizationTagsMap.get(t.organization_id);
-    if (!organizationTags) {
-      logger.error(
-        {
-          ticketId: t.id,
-          organizationId: t.organization_id,
-          connectorId: configuration.connectorId,
-        },
-        "Organization tags not found."
-      );
-      throw new Error(`Tags not found for organization ${t.organization_id}.`);
+    let organizationTags = null;
+    if (t.organization_id) {
+      organizationTags = organizationTagsMap.get(t.organization_id);
+      assert(organizationTags, "Organization tags not found.");
     }
 
     return shouldSyncTicket(t, configuration, {

--- a/connectors/src/connectors/zendesk/temporal/activities.ts
+++ b/connectors/src/connectors/zendesk/temporal/activities.ts
@@ -10,15 +10,14 @@ import {
   shouldSyncTicket,
   syncTicket,
 } from "@connectors/connectors/zendesk/lib/sync_ticket";
-import type { ZendeskFetchedTicket } from "@connectors/connectors/zendesk/lib/types";
 import { getZendeskSubdomainAndAccessToken } from "@connectors/connectors/zendesk/lib/zendesk_access_token";
 import {
   fetchZendeskBrand,
   fetchZendeskCategory,
+  getOrganizationTagMapForTickets,
   getZendeskBrandSubdomain,
   listZendeskArticlesInCategory,
   listZendeskCategoriesInBrand,
-  listZendeskOrganizations,
   listZendeskSectionsByCategory,
   listZendeskTicketComments,
   listZendeskTickets,
@@ -43,7 +42,6 @@ import {
 } from "@connectors/resources/zendesk_resources";
 import type { ModelId } from "@connectors/types";
 import { INTERNAL_MIME_TYPES } from "@connectors/types";
-import { removeNulls } from "@connectors/types/shared/utils/general";
 
 /**
  * This activity is responsible for updating the lastSyncStartTime of the connector to now.
@@ -601,24 +599,6 @@ export async function syncZendeskArticleBatchActivity({
     }
   );
   return { hasMore, nextLink };
-}
-
-async function getOrganizationTagMapForTickets(
-  tickets: ZendeskFetchedTicket[],
-  {
-    accessToken,
-    brandSubdomain,
-  }: { accessToken: string; brandSubdomain: string }
-) {
-  const organizationIds = removeNulls(
-    tickets.map((t) => t.organization_id ?? null)
-  );
-  const organizations = await listZendeskOrganizations({
-    accessToken,
-    brandSubdomain,
-    organizationIds,
-  });
-  return new Map(organizations.map((t) => [t.id, t.tags]));
 }
 
 /**

--- a/connectors/src/connectors/zendesk/temporal/activities.ts
+++ b/connectors/src/connectors/zendesk/temporal/activities.ts
@@ -681,7 +681,7 @@ export async function syncZendeskTicketBatchActivity({
   }
 
   let organizationTagsMap = new Map<number, string[]>();
-  if (configuration.organizationTagsIn || configuration.organizationTagsNotIn) {
+  if (configuration.enforcesOrganizationTagConstraint()) {
     organizationTagsMap = await getOrganizationTagMapForTickets(tickets, {
       accessToken,
       brandSubdomain,

--- a/connectors/src/connectors/zendesk/temporal/incremental_activities.ts
+++ b/connectors/src/connectors/zendesk/temporal/incremental_activities.ts
@@ -320,13 +320,14 @@ export async function syncZendeskTicketUpdateBatchActivity({
         });
       }
 
-      let organizationTags = null;
+      let organizationTags: string[] = [];
       if (
         ticket.organization_id &&
         configuration.enforcesOrganizationTagConstraint()
       ) {
-        organizationTags = organizationTagsMap.get(ticket.organization_id);
-        assert(organizationTags, "Organization tags not found.");
+        const mapValue = organizationTagsMap.get(ticket.organization_id);
+        assert(mapValue, "Organization tags not found.");
+        organizationTags = mapValue;
       }
 
       if (

--- a/connectors/src/connectors/zendesk/temporal/incremental_activities.ts
+++ b/connectors/src/connectors/zendesk/temporal/incremental_activities.ts
@@ -30,6 +30,7 @@ import {
 } from "@connectors/resources/zendesk_resources";
 import type { ModelId } from "@connectors/types";
 import { INTERNAL_MIME_TYPES } from "@connectors/types";
+import assert from "assert";
 
 /**
  * Retrieves the timestamp cursor, which is the start date of the last successful incremental sync.
@@ -318,19 +319,10 @@ export async function syncZendeskTicketUpdateBatchActivity({
         });
       }
 
-      const organizationTags = organizationTagsMap.get(ticket.organization_id);
-      if (!organizationTags) {
-        logger.error(
-          {
-            ticketId: ticket.id,
-            organizationId: ticket.organization_id,
-            connectorId: configuration.connectorId,
-          },
-          "Organization tags not found."
-        );
-        throw new Error(
-          `Tags not found for organization ${ticket.organization_id}.`
-        );
+      let organizationTags = null;
+      if (ticket.organization_id) {
+        organizationTags = organizationTagsMap.get(ticket.organization_id);
+        assert(organizationTags, "Organization tags not found.");
       }
 
       if (

--- a/connectors/src/connectors/zendesk/temporal/incremental_activities.ts
+++ b/connectors/src/connectors/zendesk/temporal/incremental_activities.ts
@@ -321,7 +321,10 @@ export async function syncZendeskTicketUpdateBatchActivity({
       }
 
       let organizationTags = null;
-      if (ticket.organization_id) {
+      if (
+        ticket.organization_id &&
+        configuration.enforcesOrganizationTagConstraint()
+      ) {
         organizationTags = organizationTagsMap.get(ticket.organization_id);
         assert(organizationTags, "Organization tags not found.");
       }

--- a/connectors/src/connectors/zendesk/temporal/incremental_activities.ts
+++ b/connectors/src/connectors/zendesk/temporal/incremental_activities.ts
@@ -1,3 +1,5 @@
+import assert from "assert";
+
 import { syncArticle } from "@connectors/connectors/zendesk/lib/sync_article";
 import {
   deleteTicket,
@@ -30,7 +32,6 @@ import {
 } from "@connectors/resources/zendesk_resources";
 import type { ModelId } from "@connectors/types";
 import { INTERNAL_MIME_TYPES } from "@connectors/types";
-import assert from "assert";
 
 /**
  * Retrieves the timestamp cursor, which is the start date of the last successful incremental sync.

--- a/connectors/src/lib/models/zendesk.ts
+++ b/connectors/src/lib/models/zendesk.ts
@@ -50,6 +50,9 @@ export class ZendeskConfigurationModel extends ConnectorBaseModel<ZendeskConfigu
   declare retentionPeriodDays: number;
   declare syncUnresolvedTickets: boolean;
   declare hideCustomerDetails: boolean;
+
+  declare organizationTagsIn: string[] | null;
+  declare organizationTagsNotIn: string[] | null;
 }
 
 ZendeskConfigurationModel.init(
@@ -82,6 +85,14 @@ ZendeskConfigurationModel.init(
       type: DataTypes.BOOLEAN,
       allowNull: false,
       defaultValue: false,
+    },
+    organizationTagsIn: {
+      type: DataTypes.ARRAY(DataTypes.STRING),
+      allowNull: true,
+    },
+    organizationTagsNotIn: {
+      type: DataTypes.ARRAY(DataTypes.STRING),
+      allowNull: true,
     },
   },
   {

--- a/connectors/src/lib/models/zendesk.ts
+++ b/connectors/src/lib/models/zendesk.ts
@@ -51,8 +51,8 @@ export class ZendeskConfigurationModel extends ConnectorBaseModel<ZendeskConfigu
   declare syncUnresolvedTickets: boolean;
   declare hideCustomerDetails: boolean;
 
-  declare organizationTagsIn: string[] | null;
-  declare organizationTagsNotIn: string[] | null;
+  declare organizationTagsToInclude: string[] | null;
+  declare organizationTagsToExclude: string[] | null;
 }
 
 ZendeskConfigurationModel.init(
@@ -86,11 +86,11 @@ ZendeskConfigurationModel.init(
       allowNull: false,
       defaultValue: false,
     },
-    organizationTagsIn: {
+    organizationTagsToInclude: {
       type: DataTypes.ARRAY(DataTypes.STRING),
       allowNull: true,
     },
-    organizationTagsNotIn: {
+    organizationTagsToExclude: {
       type: DataTypes.ARRAY(DataTypes.STRING),
       allowNull: true,
     },

--- a/connectors/src/resources/zendesk_resources.ts
+++ b/connectors/src/resources/zendesk_resources.ts
@@ -107,8 +107,61 @@ export class ZendeskConfigurationResource extends BaseResource<ZendeskConfigurat
 
   enforcesOrganizationTagConstraint(): boolean {
     return (
-      this.organizationTagsToInclude !== null || this.organizationTagsToExclude !== null
+      this.organizationTagsToInclude !== null ||
+      this.organizationTagsToExclude !== null
     );
+  }
+
+  async addOrganizationTag({
+    tag,
+    includeOrExclude,
+  }: {
+    tag: string;
+    includeOrExclude: "include" | "exclude";
+  }): Promise<{ wasAdded: boolean; message: string }> {
+    const column =
+      includeOrExclude === "include"
+        ? "organizationTagsToInclude"
+        : "organizationTagsToExclude";
+
+    const currentTags = this.organizationTagsToInclude || [];
+    if (currentTags.includes(tag)) {
+      return {
+        wasAdded: false,
+        message: `Tag "${tag}" already exists in ${column}`,
+      };
+    }
+
+    const newTags = [...currentTags, tag];
+    await this.update({ [column]: newTags });
+
+    return { wasAdded: true, message: `Added tag "${tag}" to ${column}` };
+  }
+
+  async removeOrganizationTag({
+    tag,
+    includeOrExclude,
+  }: {
+    tag: string;
+    includeOrExclude: "include" | "exclude";
+  }): Promise<{ wasRemoved: boolean; message: string }> {
+    const column =
+      includeOrExclude === "include"
+        ? "organizationTagsToInclude"
+        : "organizationTagsToExclude";
+
+    const currentTags = this.organizationTagsToInclude || [];
+    if (!currentTags.includes(tag)) {
+      return {
+        wasRemoved: false,
+        message: `Tag "${tag}" does not exist in ${column}`,
+      };
+    }
+
+    const newTags = currentTags.filter((t) => t !== tag);
+    await this.update({ [column]: newTags });
+
+    return { wasRemoved: true, message: `Removed tag "${tag}" from ${column}` };
   }
 }
 

--- a/connectors/src/resources/zendesk_resources.ts
+++ b/connectors/src/resources/zendesk_resources.ts
@@ -104,6 +104,12 @@ export class ZendeskConfigurationResource extends BaseResource<ZendeskConfigurat
       connectorId: this.connectorId,
     };
   }
+
+  enforcesOrganizationTagConstraint(): boolean {
+    return (
+      this.organizationTagsIn !== null || this.organizationTagsNotIn !== null
+    );
+  }
 }
 
 // eslint-disable-next-line @typescript-eslint/no-empty-interface

--- a/connectors/src/resources/zendesk_resources.ts
+++ b/connectors/src/resources/zendesk_resources.ts
@@ -107,7 +107,7 @@ export class ZendeskConfigurationResource extends BaseResource<ZendeskConfigurat
 
   enforcesOrganizationTagConstraint(): boolean {
     return (
-      this.organizationTagsIn !== null || this.organizationTagsNotIn !== null
+      this.organizationTagsToInclude !== null || this.organizationTagsToExclude !== null
     );
   }
 }

--- a/connectors/src/types/admin/cli.ts
+++ b/connectors/src/types/admin/cli.ts
@@ -747,7 +747,7 @@ export type ZendeskGetRetentionPeriodResponseType = t.TypeOf<
 >;
 
 export const ZendeskOrganizationTagResponseSchema = t.type({
-  success: t.boolean,
+  success: t.literal(true),
   message: t.union([t.string, t.undefined]),
 });
 export type ZendeskOrganizationTagResponseType = t.TypeOf<

--- a/connectors/src/types/admin/cli.ts
+++ b/connectors/src/types/admin/cli.ts
@@ -686,6 +686,8 @@ export const ZendeskCommandSchema = t.type({
     t.literal("sync-ticket"),
     t.literal("get-retention-period"),
     t.literal("set-retention-period"),
+    t.literal("add-organization-tag"),
+    t.literal("remove-organization-tag"),
   ]),
   args: t.type({
     wId: t.union([t.string, t.undefined]),
@@ -697,6 +699,9 @@ export const ZendeskCommandSchema = t.type({
     ticketId: t.union([t.number, t.undefined]),
     ticketUrl: t.union([t.string, t.undefined]),
     retentionPeriodDays: t.union([t.number, t.undefined]),
+    tag: t.union([t.string, t.undefined]),
+    in: t.union([t.literal("true"), t.undefined]),
+    notIn: t.union([t.literal("true"), t.undefined]),
   }),
 });
 export type ZendeskCommandType = t.TypeOf<typeof ZendeskCommandSchema>;
@@ -739,6 +744,14 @@ export const ZendeskGetRetentionPeriodResponseSchema = t.type({
 });
 export type ZendeskGetRetentionPeriodResponseType = t.TypeOf<
   typeof ZendeskGetRetentionPeriodResponseSchema
+>;
+
+export const ZendeskOrganizationTagResponseSchema = t.type({
+  success: t.boolean,
+  message: t.union([t.string, t.undefined]),
+});
+export type ZendeskOrganizationTagResponseType = t.TypeOf<
+  typeof ZendeskOrganizationTagResponseSchema
 >;
 /**
  * </Zendesk>

--- a/connectors/src/types/admin/cli.ts
+++ b/connectors/src/types/admin/cli.ts
@@ -700,8 +700,8 @@ export const ZendeskCommandSchema = t.type({
     ticketUrl: t.union([t.string, t.undefined]),
     retentionPeriodDays: t.union([t.number, t.undefined]),
     tag: t.union([t.string, t.undefined]),
-    in: t.union([t.literal("true"), t.undefined]),
-    notIn: t.union([t.literal("true"), t.undefined]),
+    include: t.union([t.literal("true"), t.undefined]),
+    exclude: t.union([t.literal("true"), t.undefined]),
   }),
 });
 export type ZendeskCommandType = t.TypeOf<typeof ZendeskCommandSchema>;


### PR DESCRIPTION
## Description

- This PR implements a way of filtering tickets to ingest based on the organization tags.
- The filtering is controlled by two columns `organizationTagsIn` and `organizationTagsNotIn` on the configuration.
- This filtering is for now configurable through CLI commands.
- Potential follow up works:
  - Implement a user-facing UI to configure these tags.
  - Add a cleanup workflow, triggered on tag update.
  - Optimize the approach: it refetches the organizations on every batch of tickets. We can add cache or even exchange the tags through Temporal to cache at the workflow level.

## Tests

- Tested locally, we don't have organizations so it doesn't change anything.

## Risk

- Low.

## Deploy Plan

- Run migration.
- Deploy connectors.
