### PR TITLE
Restore conversation Poke plugin

### DIFF
--- a/front/lib/api/poke/plugins/workspaces/index.ts
+++ b/front/lib/api/poke/plugins/workspaces/index.ts
@@ -13,6 +13,7 @@ export * from "./invite_user";
 export * from "./manage_authorized_domains";
 export * from "./rename_workspace";
 export * from "./reset_message_rate_limit";
+export * from "./restore_conversation";
 export * from "./revoke_users";
 export * from "./set_public_api_limits";
 export * from "./toggle_feature_flag";

--- a/front/lib/api/poke/plugins/workspaces/restore_conversation.ts
+++ b/front/lib/api/poke/plugins/workspaces/restore_conversation.ts
@@ -1,0 +1,54 @@
+import { createPlugin } from "@app/lib/api/poke/types";
+import { ConversationResource } from "@app/lib/resources/conversation_resource";
+import { Err, Ok } from "@app/types";
+
+export const restoreConversationPlugin = createPlugin({
+  manifest: {
+    id: "restore-conversation",
+    name: "Restore conversations",
+    description: "Restore deleted conversations by resetting their visibility",
+    resourceTypes: ["workspaces"],
+    args: {
+      conversationIds: {
+        type: "text",
+        label: "Conversation IDs",
+        description: "Comma separated list of conversation sIds to restore",
+      },
+    },
+  },
+  execute: async (auth, _, args) => {
+    const conversationIds = args.conversationIds.trim();
+    if (!conversationIds) {
+      return new Err(new Error("conversationIds is required"));
+    }
+
+    const conversationIdsArray = conversationIds
+      .split(",")
+      .map((id) => id.trim());
+
+    const conversations = await ConversationResource.fetchByIds(
+      auth,
+      conversationIdsArray,
+      { includeDeleted: true }
+    );
+
+    const missingConversations = conversationIdsArray.filter(
+      (id) => !conversations.some((c) => c.sId === id)
+    );
+
+    if (missingConversations.length > 0) {
+      return new Err(
+        new Error(`Conversations not found: ${missingConversations.join(", ")}`)
+      );
+    }
+
+    for (const conversation of conversations) {
+      await conversation.updateVisibilityToUnlisted();
+    }
+
+    return new Ok({
+      display: "text",
+      value: `Restored ${conversations.length} conversations`,
+    });
+  },
+});

--- a/front/lib/resources/conversation_resource.ts
+++ b/front/lib/resources/conversation_resource.ts
@@ -501,6 +501,10 @@ export class ConversationResource extends BaseResource<ConversationModel> {
     return this.update({ visibility: "deleted" });
   }
 
+  async updateVisibilityToUnlisted() {
+    return this.update({ visibility: "unlisted" });
+  }
+
   async updateRequestedGroupIds(
     requestedGroupIds: number[][],
     transaction?: Transaction


### PR DESCRIPTION
## Description

This plugin is scoped on a workspace, and allows Dust support team to restore one or multiple conversations that were deleted by mistake by users.

Takes a single, or multiple conversationIDs as an input.

Voluntarily simplistic as this use case does not happen often, and the only way to get the ID is through DB queries (hence only support can know which IDs to restore)

Does not run if any conversation id is not found.

## Tests

Local

## Risk

Some users share accounts, and if one makes the restoration request, it might cause issues for the second user.

## Deploy Plan

Front only
