### PR TITLE
[front] - chore(AB v2): change knowledge configuration flow

### DIFF
--- a/front/components/agent_builder/capabilities/AddKnowledgeDropdown.tsx
+++ b/front/components/agent_builder/capabilities/AddKnowledgeDropdown.tsx
@@ -16,21 +16,40 @@ interface AddKnowledgeDropdownProps {
   mcpServerViewsWithKnowledge: (MCPServerViewType & { label: string })[];
   onItemClick: (serverName: string) => void;
   isMCPServerViewsLoading: boolean;
+  selectedServerName?: string | null;
 }
 
 export function AddKnowledgeDropdown({
   mcpServerViewsWithKnowledge = [],
   onItemClick,
   isMCPServerViewsLoading,
+  selectedServerName,
 }: AddKnowledgeDropdownProps) {
   const handleDropdownItemClick = (view: MCPServerViewType) => {
     onItemClick(view.server.name);
   };
 
+  const selectedView = selectedServerName
+    ? mcpServerViewsWithKnowledge.find(
+        (view) => view.server.name === selectedServerName
+      )
+    : null;
+
+  const icon =
+    selectedView && getAvatar(selectedView.server, "sm")
+      ? () => getAvatar(selectedView.server, "xs")
+      : BookOpenIcon;
+
   return (
     <DropdownMenu modal={false}>
       <DropdownMenuTrigger asChild>
-        <Button label="Add knowledge" size="sm" icon={BookOpenIcon} isSelect />
+        <Button
+          variant="outline"
+          label={selectedView ? selectedView.label : "Select knowledge type"}
+          size="md"
+          icon={icon}
+          isSelect
+        />
       </DropdownMenuTrigger>
       <DropdownMenuContent className="md-w-100 w-80">
         {isMCPServerViewsLoading && (

--- a/front/components/agent_builder/capabilities/AgentBuilderCapabilitiesBlock.tsx
+++ b/front/components/agent_builder/capabilities/AgentBuilderCapabilitiesBlock.tsx
@@ -237,18 +237,15 @@ export function AgentBuilderCapabilitiesBlock() {
 
   const handleActionEdit = (action: AgentBuilderAction, index: number) => {
     setEditingAction({ action, index });
+    if (isSupportedAgentBuilderAction(action)) {
+      setIsKnowledgeSheetOpen(true);
+    }
   };
 
   const handleCloseSheet = () => {
     setEditingAction(null);
     setIsKnowledgeSheetOpen(false);
   };
-
-  const isEditingKnowledgeAction =
-    !!editingAction && isSupportedAgentBuilderAction(editingAction.action);
-
-  const shouldShowKnowledgeSheet =
-    isEditingKnowledgeAction || isKnowledgeSheetOpen;
 
   const dropdownButtons = (
     <>
@@ -257,7 +254,7 @@ export function AgentBuilderCapabilitiesBlock() {
         onOpen={() => setIsKnowledgeSheetOpen(true)}
         onSave={handleEditSave}
         action={editingAction?.action}
-        open={shouldShowKnowledgeSheet}
+        open={isKnowledgeSheetOpen}
       />
       <AddToolsDropdown
         tools={fields}

--- a/front/components/agent_builder/capabilities/AgentBuilderCapabilitiesBlock.tsx
+++ b/front/components/agent_builder/capabilities/AgentBuilderCapabilitiesBlock.tsx
@@ -20,7 +20,10 @@ import { KnowledgeConfigurationSheet } from "@app/components/agent_builder/capab
 import type { MCPServerViewTypeWithLabel } from "@app/components/agent_builder/MCPServerViewsContext";
 import { useMCPServerViewsContext } from "@app/components/agent_builder/MCPServerViewsContext";
 import type { AgentBuilderAction } from "@app/components/agent_builder/types";
-import { isDefaultActionName } from "@app/components/agent_builder/types";
+import {
+  isDefaultActionName,
+  isSupportedAgentBuilderAction,
+} from "@app/components/agent_builder/types";
 import { getMcpServerViewDisplayName } from "@app/lib/actions/mcp_helper";
 import { getAvatar } from "@app/lib/actions/mcp_icons";
 import {
@@ -199,6 +202,8 @@ export function AgentBuilderCapabilitiesBlock() {
     index: number;
   } | null>(null);
 
+  const [isKnowledgeSheetOpen, setIsKnowledgeSheetOpen] = useState(false);
+
   // TODO: Open single sheet for selected MCP action.
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   const [selectedAction, setSelectedAction] =
@@ -236,22 +241,25 @@ export function AgentBuilderCapabilitiesBlock() {
 
   const handleCloseSheet = () => {
     setEditingAction(null);
+    setIsKnowledgeSheetOpen(false);
   };
 
   // Check if we're editing a knowledge-based action
   const isEditingKnowledgeAction =
-    !!editingAction &&
-    ["SEARCH", "INCLUDE_DATA", "EXTRACT_DATA", "QUERY_TABLES"].includes(
-      editingAction.action.type
-    );
+    !!editingAction && isSupportedAgentBuilderAction(editingAction.action);
+
+  // Sheet should be open for editing existing actions or creating new ones
+  const shouldShowKnowledgeSheet =
+    isEditingKnowledgeAction || isKnowledgeSheetOpen;
 
   const dropdownButtons = (
     <>
       <KnowledgeConfigurationSheet
         onClose={handleCloseSheet}
+        onOpen={() => setIsKnowledgeSheetOpen(true)}
         onSave={handleEditSave}
         action={editingAction?.action}
-        {...(isEditingKnowledgeAction ? { open: true } : {})}
+        open={shouldShowKnowledgeSheet}
       />
       <AddToolsDropdown
         tools={fields}

--- a/front/components/agent_builder/capabilities/AgentBuilderCapabilitiesBlock.tsx
+++ b/front/components/agent_builder/capabilities/AgentBuilderCapabilitiesBlock.tsx
@@ -244,11 +244,9 @@ export function AgentBuilderCapabilitiesBlock() {
     setIsKnowledgeSheetOpen(false);
   };
 
-  // Check if we're editing a knowledge-based action
   const isEditingKnowledgeAction =
     !!editingAction && isSupportedAgentBuilderAction(editingAction.action);
 
-  // Sheet should be open for editing existing actions or creating new ones
   const shouldShowKnowledgeSheet =
     isEditingKnowledgeAction || isKnowledgeSheetOpen;
 

--- a/front/components/agent_builder/capabilities/AgentBuilderCapabilitiesBlock.tsx
+++ b/front/components/agent_builder/capabilities/AgentBuilderCapabilitiesBlock.tsx
@@ -241,7 +241,7 @@ export function AgentBuilderCapabilitiesBlock() {
   // Check if we're editing a knowledge-based action
   const isEditingKnowledgeAction =
     !!editingAction &&
-    ["SEARCH", "INCLUDE_DATA", "EXTRACT_DATA"].includes(
+    ["SEARCH", "INCLUDE_DATA", "EXTRACT_DATA", "QUERY_TABLES"].includes(
       editingAction.action.type
     );
 

--- a/front/components/agent_builder/capabilities/MCPServerViewsKnowledgeDropdown.tsx
+++ b/front/components/agent_builder/capabilities/MCPServerViewsKnowledgeDropdown.tsx
@@ -12,19 +12,19 @@ import React from "react";
 import { getAvatar } from "@app/lib/actions/mcp_icons";
 import type { MCPServerViewType } from "@app/lib/api/mcp";
 
-interface AddKnowledgeDropdownProps {
+interface MCPServerViewsKnowledgeDropdownProps {
   mcpServerViewsWithKnowledge: (MCPServerViewType & { label: string })[];
   onItemClick: (serverName: string) => void;
   isMCPServerViewsLoading: boolean;
   selectedServerName?: string | null;
 }
 
-export function AddKnowledgeDropdown({
+export function MCPServerViewsKnowledgeDropdown({
   mcpServerViewsWithKnowledge = [],
   onItemClick,
   isMCPServerViewsLoading,
   selectedServerName,
-}: AddKnowledgeDropdownProps) {
+}: MCPServerViewsKnowledgeDropdownProps) {
   const handleDropdownItemClick = (view: MCPServerViewType) => {
     onItemClick(view.server.name);
   };

--- a/front/components/agent_builder/capabilities/knowledge/KnowledgeConfigurationSheet.tsx
+++ b/front/components/agent_builder/capabilities/knowledge/KnowledgeConfigurationSheet.tsx
@@ -6,6 +6,7 @@ import {
   ScrollArea,
 } from "@dust-tt/sparkle";
 import { Button } from "@dust-tt/sparkle";
+import { BookOpenIcon } from "@dust-tt/sparkle";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { useEffect, useMemo, useState } from "react";
 import {
@@ -100,9 +101,8 @@ export function KnowledgeConfigurationSheet({
 
   // Memoize default values based on action (React Hook Form best practice)
   const defaultValues = useMemo(() => {
-    const dataSourceTree = action
-      ? getDataSourceTree(action)
-      : { in: [], notIn: [] };
+    const dataSourceTree =
+      action && open ? getDataSourceTree(action) : { in: [], notIn: [] };
 
     return {
       sources: dataSourceTree,
@@ -110,7 +110,7 @@ export function KnowledgeConfigurationSheet({
       timeFrame: getTimeFrame(action),
       jsonSchema: getJsonSchema(action),
     };
-  }, [action]);
+  }, [action, open]);
 
   const formMethods = useForm<CapabilityFormData>({
     resolver: zodResolver(capabilityFormSchema),
@@ -137,7 +137,11 @@ export function KnowledgeConfigurationSheet({
   return (
     <MultiPageSheet open={open} onOpenChange={handleOpenChange}>
       <MultiPageSheetTrigger asChild>
-        <Button label="Add knowledge" onClick={handleTriggerClick} />
+        <Button
+          label="Add knowledge"
+          onClick={handleTriggerClick}
+          icon={BookOpenIcon}
+        />
       </MultiPageSheetTrigger>
       <FormProvider {...formMethods}>
         <KnowledgeConfigurationSheetContent

--- a/front/components/agent_builder/capabilities/knowledge/KnowledgeConfigurationSheet.tsx
+++ b/front/components/agent_builder/capabilities/knowledge/KnowledgeConfigurationSheet.tsx
@@ -198,7 +198,7 @@ function KnowledgeConfigurationSheetContent({
       if (serverName && isKnowledgeServerName(serverName)) {
         setConfig(CAPABILITY_CONFIGS[serverName]);
       }
-    } else if (!isOpen && !action) {
+    } else if (!isOpen) {
       setCurrentPageId(CONFIGURATION_SHEET_PAGE_IDS.DATA_SOURCE_SELECTION);
       setSelectedMCPServerName("search");
       setConfig(CAPABILITY_CONFIGS["search"]);

--- a/front/components/agent_builder/capabilities/knowledge/KnowledgeConfigurationSheet.tsx
+++ b/front/components/agent_builder/capabilities/knowledge/KnowledgeConfigurationSheet.tsx
@@ -34,7 +34,6 @@ import { useMCPServerViewsContext } from "@app/components/agent_builder/MCPServe
 import type {
   CapabilityFormData,
   ConfigurationSheetPageId,
-  KnowledgeServerName,
 } from "@app/components/agent_builder/types";
 import type { AgentBuilderAction } from "@app/components/agent_builder/types";
 import {
@@ -49,7 +48,6 @@ import { DataSourceBuilderSelector } from "@app/components/data_source_view/Data
 import type { DataSourceViewSelectionConfigurations } from "@app/types";
 
 interface KnowledgeConfigurationSheetProps {
-  capability?: KnowledgeServerName | null;
   onSave: (action: AgentBuilderAction) => void;
   onClose: () => void;
   onOpen?: () => void;
@@ -58,7 +56,6 @@ interface KnowledgeConfigurationSheetProps {
 }
 
 export function KnowledgeConfigurationSheet({
-  capability,
   onSave,
   onClose,
   onOpen,
@@ -66,9 +63,6 @@ export function KnowledgeConfigurationSheet({
   open,
 }: KnowledgeConfigurationSheetProps) {
   const [config, setConfig] = useState<CapabilityConfig | null>(() => {
-    if (capability) {
-      return CAPABILITY_CONFIGS[capability];
-    }
     if (action && isSupportedAgentBuilderAction(action)) {
       const serverName = ACTION_TYPE_TO_MCP_SERVER_MAP[action.type];
       return serverName && isKnowledgeServerName(serverName)

--- a/front/components/agent_builder/capabilities/knowledge/KnowledgeConfigurationSheet.tsx
+++ b/front/components/agent_builder/capabilities/knowledge/KnowledgeConfigurationSheet.tsx
@@ -2,8 +2,10 @@ import type { MultiPageSheetPage } from "@dust-tt/sparkle";
 import {
   MultiPageSheet,
   MultiPageSheetContent,
+  MultiPageSheetTrigger,
   ScrollArea,
 } from "@dust-tt/sparkle";
+import { Button } from "@dust-tt/sparkle";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { useEffect, useMemo, useState } from "react";
 import type { Control } from "react-hook-form";
@@ -11,6 +13,7 @@ import { createFormControl, useFormState, useWatch } from "react-hook-form";
 
 import { useAgentBuilderContext } from "@app/components/agent_builder/AgentBuilderContext";
 import type { AgentBuilderFormData } from "@app/components/agent_builder/AgentBuilderFormContext";
+import { AddKnowledgeDropdown } from "@app/components/agent_builder/capabilities/AddKnowledgeDropdown";
 import { DescriptionSection } from "@app/components/agent_builder/capabilities/knowledge/shared/DescriptionSection";
 import { JsonSchemaSection } from "@app/components/agent_builder/capabilities/knowledge/shared/JsonSchemaSection";
 import {
@@ -27,37 +30,43 @@ import {
   generateActionFromFormData,
 } from "@app/components/agent_builder/capabilities/knowledge/utils";
 import { useDataSourceViewsContext } from "@app/components/agent_builder/DataSourceViewsContext";
+import { useMCPServerViewsContext } from "@app/components/agent_builder/MCPServerViewsContext";
 import type {
   CapabilityFormData,
   ConfigurationSheetPageId,
   KnowledgeServerName,
+  SupportedAgentBuilderActionType,
 } from "@app/components/agent_builder/types";
 import type { AgentBuilderAction } from "@app/components/agent_builder/types";
 import {
+  ACTION_TYPE_TO_MCP_SERVER_MAP,
   capabilityFormSchema,
   CONFIGURATION_SHEET_PAGE_IDS,
+  isKnowledgeServerName,
 } from "@app/components/agent_builder/types";
 import { useSpacesContext } from "@app/components/assistant_builder/contexts/SpacesContext";
 import { DataSourceBuilderSelector } from "@app/components/data_source_view/DataSourceBuilderSelector";
 import type { DataSourceViewSelectionConfigurations } from "@app/types";
 
 interface KnowledgeConfigurationSheetProps {
-  capability: KnowledgeServerName | null;
+  capability?: KnowledgeServerName | null;
   onSave: (action: AgentBuilderAction) => void;
-  isOpen: boolean;
   onClose: () => void;
   action?: AgentBuilderAction;
+  open?: boolean;
 }
 
 export function KnowledgeConfigurationSheet({
   capability,
   onSave,
-  isOpen,
   onClose,
   action,
+  open,
 }: KnowledgeConfigurationSheetProps) {
   // We store as state to control the timing to update the content for exit animation.
-  const [config, setConfig] = useState<CapabilityConfig | null>(null);
+  const [config, setConfig] = useState<CapabilityConfig | null>(
+    capability ? CAPABILITY_CONFIGS[capability] : null
+  );
 
   const handleClose = () => {
     onClose();
@@ -71,15 +80,11 @@ export function KnowledgeConfigurationSheet({
 
   const handleSave = (
     formData: CapabilityFormData,
-    dataSourceConfigurations: DataSourceViewSelectionConfigurations
+    dataSourceConfigurations: DataSourceViewSelectionConfigurations,
+    configToUse: CapabilityConfig
   ) => {
-    if (!config) {
-      // never going here
-      return;
-    }
-
     const newAction = generateActionFromFormData({
-      config,
+      config: configToUse,
       formData,
       dataSourceConfigurations,
       actionId: action?.id,
@@ -92,55 +97,58 @@ export function KnowledgeConfigurationSheet({
     handleClose();
   };
 
-  useEffect(() => {
-    if (isOpen) {
-      setConfig(capability ? CAPABILITY_CONFIGS[capability] : null);
-    }
-  }, [capability, isOpen]);
-
-  const { control, handleSubmit } = createFormControl<CapabilityFormData>({
-    resolver: zodResolver(capabilityFormSchema),
-    defaultValues: {
-      sources: action
-        ? getDataSourceTree(action)
-        : {
-            in: [],
-            notIn: [],
-          },
-      description: action?.description ?? "",
-      timeFrame: getTimeFrame(action),
-      jsonSchema: getJsonSchema(action),
-    },
-  });
+  const { control, handleSubmit } = useMemo(
+    () =>
+      createFormControl<CapabilityFormData>({
+        resolver: zodResolver(capabilityFormSchema),
+        defaultValues: {
+          sources: action
+            ? getDataSourceTree(action)
+            : {
+                in: [],
+                notIn: [],
+              },
+          description: action?.description ?? "",
+          timeFrame: getTimeFrame(action),
+          jsonSchema: getJsonSchema(action),
+        },
+      }),
+    [action]
+  );
   return (
     <MultiPageSheet
-      open={isOpen}
-      onOpenChange={(open) => {
-        if (!open) {
+      open={open}
+      onOpenChange={(isOpen) => {
+        if (!isOpen) {
           handleClose();
+        } else {
+          setConfig(capability ? CAPABILITY_CONFIGS[capability] : null);
         }
       }}
     >
-      {config && (
-        <KnowledgeConfigurationSheetContent
-          config={config}
-          onClose={handleClose}
-          action={action}
-          onSave={handleSave}
-          control={control}
-          handleSubmit={handleSubmit}
-        />
-      )}
+      <MultiPageSheetTrigger asChild>
+        <Button label="Add knowledge" />
+      </MultiPageSheetTrigger>
+      <KnowledgeConfigurationSheetContent
+        key={action?.id || "new"}
+        config={config}
+        onClose={handleClose}
+        action={action}
+        onSave={handleSave}
+        control={control}
+        handleSubmit={handleSubmit}
+      />
     </MultiPageSheet>
   );
 }
 
 interface KnowledgeConfigurationSheetContentProps {
-  config: CapabilityConfig;
+  config: CapabilityConfig | null;
   action?: AgentBuilderAction;
   onSave: (
     formData: CapabilityFormData,
-    dataSourceConfigurations: DataSourceViewSelectionConfigurations
+    dataSourceConfigurations: DataSourceViewSelectionConfigurations,
+    configToUse: CapabilityConfig
   ) => void;
   onClose: () => void;
   control: Control<CapabilityFormData>;
@@ -160,13 +168,46 @@ function KnowledgeConfigurationSheetContent({
   const { owner } = useAgentBuilderContext();
   const { supportedDataSourceViews } = useDataSourceViewsContext();
   const { spaces } = useSpacesContext();
+  const { mcpServerViewsWithKnowledge, isMCPServerViewsLoading } =
+    useMCPServerViewsContext();
 
   const instructions = useWatch<AgentBuilderFormData, "instructions">({
     name: "instructions",
   });
 
-  const [currentPageId, setCurrentPageId] = useState<ConfigurationSheetPageId>(
-    CONFIGURATION_SHEET_PAGE_IDS.DATA_SOURCE_SELECTION
+  // If editing an existing action, initialize with the config and skip to configuration page
+  const initialPageId = action
+    ? CONFIGURATION_SHEET_PAGE_IDS.CONFIGURATION
+    : CONFIGURATION_SHEET_PAGE_IDS.DATA_SOURCE_SELECTION;
+
+  const [currentPageId, setCurrentPageId] =
+    useState<ConfigurationSheetPageId>(initialPageId);
+
+  // Update currentPageId when action changes (for edit mode)
+  useEffect(() => {
+    if (action) {
+      setCurrentPageId(CONFIGURATION_SHEET_PAGE_IDS.CONFIGURATION);
+      const serverName =
+        ACTION_TYPE_TO_MCP_SERVER_MAP[
+          action.type as SupportedAgentBuilderActionType
+        ];
+      setSelectedMCPServerName(serverName);
+      if (serverName && isKnowledgeServerName(serverName)) {
+        setDynamicConfig(CAPABILITY_CONFIGS[serverName]);
+      }
+    }
+  }, [action]);
+  const [selectedMCPServerName, setSelectedMCPServerName] = useState<
+    string | null
+  >(
+    action
+      ? ACTION_TYPE_TO_MCP_SERVER_MAP[
+          action.type as SupportedAgentBuilderActionType
+        ]
+      : "search"
+  );
+  const [dynamicConfig, setDynamicConfig] = useState<CapabilityConfig | null>(
+    config || CAPABILITY_CONFIGS["search"]
   );
 
   const handlePageChange = (pageId: string) => {
@@ -175,12 +216,19 @@ function KnowledgeConfigurationSheetContent({
     }
   };
 
+  const handleMCPServerSelection = (serverName: string) => {
+    setSelectedMCPServerName(serverName);
+    if (isKnowledgeServerName(serverName)) {
+      setDynamicConfig(CAPABILITY_CONFIGS[serverName]);
+    }
+  };
+
   const pages: MultiPageSheetPage[] = [
     {
       id: CONFIGURATION_SHEET_PAGE_IDS.DATA_SOURCE_SELECTION,
-      title: config.title,
-      description: config.description,
-      icon: config.icon,
+      title: "Select Data Sources",
+      description: "Choose the data sources to include in your knowledge base",
+      icon: undefined,
       content: (
         <div className="space-y-4">
           <ScrollArea>
@@ -197,32 +245,66 @@ function KnowledgeConfigurationSheetContent({
     },
     {
       id: CONFIGURATION_SHEET_PAGE_IDS.CONFIGURATION,
-      title: config.configPageTitle,
-      description: config.configPageDescription,
-      icon: config.icon,
+      title: dynamicConfig?.configPageTitle || "Configure Knowledge",
+      description:
+        dynamicConfig?.configPageDescription ||
+        "Select knowledge type and configure settings",
+      icon: dynamicConfig?.icon,
       content: (
         <div className="space-y-6">
-          {config.hasTimeFrame && (
-            <TimeFrameSection
-              control={control}
-              actionType={
-                config.name === "extract_data" ? "extract" : "include"
-              }
-            />
+          {/* MCP Server View Selection Section */}
+          <div className="space-y-4">
+            <h3 className="text-lg font-semibold">
+              Choose your processing method
+            </h3>
+            <span className="text-sm text-muted-foreground dark:text-muted-foreground-night">
+              Smart data access through search, extraction, and queries.
+            </span>
+            <div className="flex flex-col items-start">
+              <AddKnowledgeDropdown
+                mcpServerViewsWithKnowledge={mcpServerViewsWithKnowledge}
+                onItemClick={handleMCPServerSelection}
+                isMCPServerViewsLoading={isMCPServerViewsLoading}
+                selectedServerName={selectedMCPServerName}
+              />
+            </div>
+          </div>
+
+          {/* Configuration Section - Only show when MCP server is selected */}
+          {selectedMCPServerName && dynamicConfig && (
+            <>
+              <hr className="border-gray-200" />
+              <div className="space-y-6">
+                <h3 className="text-lg font-semibold">Configuration</h3>
+                {dynamicConfig.hasTimeFrame && (
+                  <TimeFrameSection
+                    control={control}
+                    actionType={
+                      dynamicConfig.name === "extract_data"
+                        ? "extract"
+                        : "include"
+                    }
+                  />
+                )}
+                {dynamicConfig.hasJsonSchema && (
+                  <JsonSchemaSection
+                    control={control}
+                    initialSchemaString={
+                      action && getJsonSchema(action)
+                        ? JSON.stringify(getJsonSchema(action), null, 2)
+                        : null
+                    }
+                    agentInstructions={instructions}
+                    owner={owner}
+                  />
+                )}
+                <DescriptionSection
+                  control={control}
+                  {...dynamicConfig.descriptionConfig}
+                />
+              </div>
+            </>
           )}
-          {config.hasJsonSchema && (
-            <JsonSchemaSection
-              control={control}
-              initialSchemaString={
-                action && getJsonSchema(action)
-                  ? JSON.stringify(getJsonSchema(action), null, 2)
-                  : null
-              }
-              agentInstructions={instructions}
-              owner={owner}
-            />
-          )}
-          <DescriptionSection control={control} {...config.descriptionConfig} />
         </div>
       ),
     },
@@ -234,12 +316,33 @@ function KnowledgeConfigurationSheetContent({
     control,
     name: "sources",
   });
+
+  const description = useWatch({
+    control,
+    name: "description",
+  });
+
   const disableNext = useMemo(() => {
     if (currentPageId === CONFIGURATION_SHEET_PAGE_IDS.DATA_SOURCE_SELECTION) {
       return sources.in.length === 0;
     }
+    if (currentPageId === CONFIGURATION_SHEET_PAGE_IDS.CONFIGURATION) {
+      return !selectedMCPServerName;
+    }
     return false;
-  }, [currentPageId, sources.in.length]);
+  }, [currentPageId, sources.in.length, selectedMCPServerName]);
+
+  const disableSave = useMemo(() => {
+    const hasDataSources = sources.in.length > 0;
+    const hasMCPSelection = !!selectedMCPServerName;
+    const hasDescription = description && description.trim().length > 0;
+
+    if (action) {
+      return !(hasDataSources && hasMCPSelection && hasDescription && isDirty);
+    } else {
+      return !(hasDataSources && hasMCPSelection && hasDescription);
+    }
+  }, [action, isDirty, sources.in.length, selectedMCPServerName, description]);
 
   return (
     <MultiPageSheetContent
@@ -247,17 +350,20 @@ function KnowledgeConfigurationSheetContent({
       currentPageId={currentPageId}
       onPageChange={handlePageChange}
       onSave={handleSubmit((formData) => {
+        if (!dynamicConfig) {
+          return;
+        }
         // Transform the tree structure to selection configurations
         const dataSourceConfigurations = transformTreeToSelectionConfigurations(
           formData.sources,
           supportedDataSourceViews
         );
-        onSave(formData, dataSourceConfigurations);
+        onSave(formData, dataSourceConfigurations, dynamicConfig);
       })}
       size="xl"
       showNavigation
       disableNext={disableNext}
-      disableSave={!isDirty}
+      disableSave={disableSave}
     />
   );
 }

--- a/front/components/agent_builder/capabilities/knowledge/KnowledgeConfigurationSheet.tsx
+++ b/front/components/agent_builder/capabilities/knowledge/KnowledgeConfigurationSheet.tsx
@@ -191,25 +191,19 @@ function KnowledgeConfigurationSheetContent({
     useState<ConfigurationSheetPageId>(initialPageId);
 
   useEffect(() => {
-    if (action) {
-      if (isSupportedAgentBuilderAction(action)) {
-        setCurrentPageId(CONFIGURATION_SHEET_PAGE_IDS.CONFIGURATION);
-        const serverName = ACTION_TYPE_TO_MCP_SERVER_MAP[action.type];
-        setSelectedMCPServerName(serverName);
-        if (serverName && isKnowledgeServerName(serverName)) {
-          setConfig(CAPABILITY_CONFIGS[serverName]);
-        }
+    if (action && isSupportedAgentBuilderAction(action)) {
+      setCurrentPageId(CONFIGURATION_SHEET_PAGE_IDS.CONFIGURATION);
+      const serverName = ACTION_TYPE_TO_MCP_SERVER_MAP[action.type];
+      setSelectedMCPServerName(serverName);
+      if (serverName && isKnowledgeServerName(serverName)) {
+        setConfig(CAPABILITY_CONFIGS[serverName]);
       }
-    }
-  }, [action, setConfig]);
-
-  useEffect(() => {
-    if (!isOpen && !action) {
+    } else if (!isOpen && !action) {
       setCurrentPageId(CONFIGURATION_SHEET_PAGE_IDS.DATA_SOURCE_SELECTION);
       setSelectedMCPServerName("search");
       setConfig(CAPABILITY_CONFIGS["search"]);
     }
-  }, [isOpen, action, setConfig]);
+  }, [action, isOpen, setConfig]);
 
   const [selectedMCPServerName, setSelectedMCPServerName] = useState<
     string | null

--- a/front/components/agent_builder/capabilities/knowledge/KnowledgeConfigurationSheet.tsx
+++ b/front/components/agent_builder/capabilities/knowledge/KnowledgeConfigurationSheet.tsx
@@ -204,12 +204,10 @@ function KnowledgeConfigurationSheetContent({
   }, [action]);
 
   useEffect(() => {
-    if (!isOpen) {
-      if (!action) {
-        setCurrentPageId(CONFIGURATION_SHEET_PAGE_IDS.DATA_SOURCE_SELECTION);
-        setSelectedMCPServerName("search");
-        setDynamicConfig(CAPABILITY_CONFIGS["search"]);
-      }
+    if (!isOpen && !action) {
+      setCurrentPageId(CONFIGURATION_SHEET_PAGE_IDS.DATA_SOURCE_SELECTION);
+      setSelectedMCPServerName("search");
+      setDynamicConfig(CAPABILITY_CONFIGS["search"]);
     }
   }, [isOpen, action]);
 
@@ -323,9 +321,6 @@ function KnowledgeConfigurationSheetContent({
       ),
     },
   ];
-
-  // Always allow users to try navigating and saving
-  // Let form validation and save logic handle any issues
 
   return (
     <MultiPageSheetContent

--- a/front/components/agent_builder/capabilities/knowledge/shared/DescriptionSection.tsx
+++ b/front/components/agent_builder/capabilities/knowledge/shared/DescriptionSection.tsx
@@ -1,5 +1,4 @@
 import { TextArea } from "@dust-tt/sparkle";
-import type { Control } from "react-hook-form";
 import { useController } from "react-hook-form";
 
 import type { CapabilityFormData } from "@app/components/agent_builder/types";
@@ -11,7 +10,6 @@ interface DescriptionSectionProps {
   placeholder: string;
   helpText?: string;
   maxLength?: number;
-  control: Control<CapabilityFormData>;
 }
 
 export function DescriptionSection({
@@ -20,10 +18,8 @@ export function DescriptionSection({
   label,
   placeholder,
   helpText,
-  control,
 }: DescriptionSectionProps) {
-  const { field, fieldState } = useController({
-    control,
+  const { field, fieldState } = useController<CapabilityFormData>({
     name: "description",
   });
 

--- a/front/components/agent_builder/capabilities/knowledge/shared/JsonSchemaSection.tsx
+++ b/front/components/agent_builder/capabilities/knowledge/shared/JsonSchemaSection.tsx
@@ -1,6 +1,5 @@
 import { Button, SparklesIcon, TextArea } from "@dust-tt/sparkle";
 import { useEffect, useState } from "react";
-import type { Control } from "react-hook-form";
 import { useController, useFormContext } from "react-hook-form";
 
 import type { CapabilityFormData } from "@app/components/agent_builder/types";
@@ -15,7 +14,6 @@ interface JsonSchemaSectionProps {
   helpText?: string;
   agentInstructions?: string;
   owner: WorkspaceType;
-  control: Control<CapabilityFormData>;
 }
 
 export function JsonSchemaSection({
@@ -25,12 +23,10 @@ export function JsonSchemaSection({
   helpText,
   agentInstructions,
   owner,
-  control,
 }: JsonSchemaSectionProps) {
   // eslint-disable-next-line @typescript-eslint/no-unused-vars -- Left it here, unused due to NOTE below
   const { getValues } = useFormContext();
-  const { field } = useController({
-    control,
+  const { field } = useController<CapabilityFormData>({
     name: "jsonSchema",
   });
 

--- a/front/components/agent_builder/capabilities/knowledge/shared/TimeFrameSection.tsx
+++ b/front/components/agent_builder/capabilities/knowledge/shared/TimeFrameSection.tsx
@@ -8,7 +8,6 @@ import {
   DropdownMenuTrigger,
   Input,
 } from "@dust-tt/sparkle";
-import type { Control } from "react-hook-form";
 import { useController } from "react-hook-form";
 
 import type { CapabilityFormData } from "@app/components/agent_builder/types";
@@ -43,14 +42,12 @@ const ACTION_CONFIG: Record<
 
 interface TimeFrameSectionProps {
   actionType: ActionType;
-  control: Control<CapabilityFormData>;
 }
 
-export function TimeFrameSection({
-  actionType,
-  control,
-}: TimeFrameSectionProps) {
-  const { field: timeFrame } = useController({ control, name: "timeFrame" });
+export function TimeFrameSection({ actionType }: TimeFrameSectionProps) {
+  const { field: timeFrame } = useController<CapabilityFormData>({
+    name: "timeFrame",
+  });
   const isChecked = timeFrame.value;
 
   const { actionText, contextText } = ACTION_CONFIG[actionType];
@@ -100,7 +97,11 @@ export function TimeFrameSection({
           <DropdownMenuTrigger asChild>
             <Button
               isSelect
-              label={TIME_FRAME_UNIT_TO_LABEL[timeFrame.value?.unit ?? "day"]}
+              label={
+                TIME_FRAME_UNIT_TO_LABEL[
+                  (timeFrame.value?.unit as TimeFrame["unit"]) ?? "day"
+                ]
+              }
               variant="outline"
               size="sm"
               disabled={!isChecked}

--- a/front/components/agent_builder/capabilities/knowledge/transformations.ts
+++ b/front/components/agent_builder/capabilities/knowledge/transformations.ts
@@ -54,9 +54,38 @@ export function transformTreeToSelectionConfigurations(
       };
     }
 
-    // If it's not a full data source selection, mark as partial
-    if (!isFullDataSource && !configurations[dataSourceView.sId].isSelectAll) {
+    // If it's not a full data source selection, extract the selected nodes
+    if (!isFullDataSource) {
       configurations[dataSourceView.sId].isSelectAll = false;
+
+      // Extract node information from the path
+      const nodeIds = parts.slice(dsvIdIndex + 1);
+      if (nodeIds.length > 0) {
+        // Create a resource entry for this selection
+        const nodeId = nodeIds[nodeIds.length - 1]; // Last part is the selected node
+        const parentId =
+          nodeIds.length > 1 ? nodeIds[nodeIds.length - 2] : null;
+
+        // Add to selectedResources if not already present
+        const config = configurations[dataSourceView.sId];
+        const existingResource = config.selectedResources.find(
+          (res) => res.internalId === nodeId
+        );
+
+        if (!existingResource) {
+          config.selectedResources.push({
+            internalId: nodeId,
+            parentInternalId: parentId,
+            title: nodeId, // Use nodeId as title fallback
+            type: "file", // Default type - this might need to be more sophisticated
+            dustDocumentId: null,
+            lastUpdatedAt: null,
+            expandable: false,
+            permission: "read",
+            sourceUrl: null,
+          });
+        }
+      }
     }
   }
 

--- a/front/components/agent_builder/capabilities/knowledge/transformations.ts
+++ b/front/components/agent_builder/capabilities/knowledge/transformations.ts
@@ -1,15 +1,45 @@
 import type { DataSourceBuilderTreeType } from "@app/components/data_source_view/context/types";
 import type {
+  DataSourceViewContentNode,
   DataSourceViewSelectionConfigurations,
   DataSourceViewType,
 } from "@app/types";
 
 /**
+ * Creates a placeholder DataSourceViewContentNode with minimal information.
+ * The actual content node data will be resolved on the backend when this
+ * configuration is used.
+ */
+function getPlaceholderResource(
+  nodeId: string,
+  parentId: string | null,
+  dataSourceView: DataSourceViewType
+): DataSourceViewContentNode {
+  return {
+    internalId: nodeId,
+    parentInternalId: parentId,
+    parentInternalIds: parentId ? [parentId] : null,
+    parentTitle: null,
+    title: nodeId,
+    type: "document",
+    mimeType: "application/octet-stream",
+    lastUpdatedAt: null,
+    expandable: false,
+    permission: "read",
+    providerVisibility: null,
+    sourceUrl: null,
+    preventSelection: false,
+    dataSourceView,
+  };
+}
+
+/**
  * Transforms DataSourceBuilderTreeType to DataSourceViewSelectionConfigurations
  *
  * This creates a simplified transformation that works with the path structure
- * used in the tree. Since we don't have access to all nodes at save time,
- * we create placeholder configurations that will be properly resolved on the backend.
+ * used in the tree. For paths that represent full data source selections,
+ * we set isSelectAll=true. For specific node selections, we create minimal
+ * resource entries that will be expanded on the backend.
  */
 export function transformTreeToSelectionConfigurations(
   tree: DataSourceBuilderTreeType,
@@ -73,17 +103,9 @@ export function transformTreeToSelectionConfigurations(
         );
 
         if (!existingResource) {
-          config.selectedResources.push({
-            internalId: nodeId,
-            parentInternalId: parentId,
-            title: nodeId, // Use nodeId as title fallback
-            type: "file", // Default type - this might need to be more sophisticated
-            dustDocumentId: null,
-            lastUpdatedAt: null,
-            expandable: false,
-            permission: "read",
-            sourceUrl: null,
-          });
+          config.selectedResources.push(
+            getPlaceholderResource(nodeId, parentId, dataSourceView)
+          );
         }
       }
     }

--- a/front/components/agent_builder/types.ts
+++ b/front/components/agent_builder/types.ts
@@ -3,13 +3,12 @@ import { uniqueId } from "lodash";
 import { z } from "zod";
 
 import type { agentBuilderFormSchema } from "@app/components/agent_builder/AgentBuilderFormContext";
+import { dataSourceBuilderTreeType } from "@app/components/data_source_view/context/types";
 import { DEFAULT_MCP_ACTION_NAME } from "@app/lib/actions/constants";
 import { getMCPServerRequirements } from "@app/lib/actions/mcp_internal_actions/input_configuration";
 import type { MCPServerViewType } from "@app/lib/api/mcp";
 import type { SupportedModel, WhitelistableFeature } from "@app/types";
 import { ioTsEnum } from "@app/types";
-
-import { dataSourceBuilderTreeType } from "../data_source_view/context/types";
 
 type AgentBuilderFormData = z.infer<typeof agentBuilderFormSchema>;
 

--- a/front/components/agent_builder/types.ts
+++ b/front/components/agent_builder/types.ts
@@ -34,6 +34,11 @@ export type ExtractDataAgentBuilderAction = Extract<
   { type: "EXTRACT_DATA" }
 >;
 
+export type QueryTablesAgentBuilderAction = Extract<
+  AgentBuilderAction,
+  { type: "QUERY_TABLES" }
+>;
+
 export type SearchActionConfiguration =
   SearchAgentBuilderAction["configuration"];
 
@@ -46,11 +51,15 @@ export type IncludeDataActionConfiguration =
 export type ExtractDataActionConfiguration =
   ExtractDataAgentBuilderAction["configuration"];
 
+export type QueryTablesActionConfiguration =
+  QueryTablesAgentBuilderAction["configuration"];
+
 export type AgentBuilderActionConfiguration =
   | SearchActionConfiguration
   | DataVisualizationActionConfiguration
   | IncludeDataActionConfiguration
-  | ExtractDataActionConfiguration;
+  | ExtractDataActionConfiguration
+  | QueryTablesActionConfiguration;
 
 // Type guards
 export function isSearchAction(
@@ -75,6 +84,23 @@ export function isExtractDataAction(
   action: AgentBuilderAction
 ): action is ExtractDataAgentBuilderAction {
   return action.type === "EXTRACT_DATA";
+}
+
+export type SupportedAgentBuilderAction =
+  | SearchAgentBuilderAction
+  | IncludeDataAgentBuilderAction
+  | ExtractDataAgentBuilderAction
+  | QueryTablesAgentBuilderAction;
+
+export function isSupportedAgentBuilderAction(
+  action: AgentBuilderAction
+): action is SupportedAgentBuilderAction {
+  return (
+    action.type === "SEARCH" ||
+    action.type === "INCLUDE_DATA" ||
+    action.type === "EXTRACT_DATA" ||
+    action.type === "QUERY_TABLES"
+  );
 }
 
 // MCP server names that map to agent builder actions

--- a/front/components/agent_builder/types.ts
+++ b/front/components/agent_builder/types.ts
@@ -108,7 +108,6 @@ export const AGENT_BUILDER_MCP_SERVERS = [
   "extract_data",
   "search",
   "include_data",
-  "extract_data",
   "query_tables",
 ] as const;
 export type AgentBuilderMCPServerName =


### PR DESCRIPTION
## Description

This PR revamps the knowledge configuration flow in the Agent Builder v2. The key change is moving the knowledge server selection (search, include, or extract data) to after the data source selection, making the flow more intuitive. When configuring a knowledge capability, users now:
1. Select their data sources first
2. Choose the processing method (search, include, or extract) and configure the associated parameters
3. Add a description of how the knowledge should be used

Note: design is not final + I will add some smarter logic to suggest which tool to use instead of defaulting to search

## Tests

Locally


## Risk

Low, behind FF

## Deploy Plan

Deploy front