### PR TITLE
Add ability to zendesk syncs by ticket tags

### DIFF
--- a/connectors/migrations/db/migration_88.sql
+++ b/connectors/migrations/db/migration_88.sql
@@ -1,0 +1,3 @@
+-- Migration created on Jul 31, 2025
+ALTER TABLE "public"."zendesk_configurations" ADD COLUMN "ticketTagsToInclude" VARCHAR(255)[];
+ALTER TABLE "public"."zendesk_configurations" ADD COLUMN "ticketTagsToExclude" VARCHAR(255)[];

--- a/connectors/src/connectors/zendesk/index.ts
+++ b/connectors/src/connectors/zendesk/index.ts
@@ -59,6 +59,12 @@ const SYNC_UNRESOLVED_TICKETS_CONFIG_KEY =
   "zendeskSyncUnresolvedTicketsEnabled";
 const HIDE_CUSTOMER_DETAILS_CONFIG_KEY = "zendeskHideCustomerDetails";
 export const RETENTION_PERIOD_CONFIG_KEY = "zendeskRetentionPeriodDays";
+const TICKET_TAGS_TO_INCLUDE_CONFIG_KEY = "zendeskTicketTagsToInclude";
+const TICKET_TAGS_TO_EXCLUDE_CONFIG_KEY = "zendeskTicketTagsToExclude";
+const ORGANIZATION_TAGS_TO_INCLUDE_CONFIG_KEY =
+  "zendeskOrganizationTagsToInclude";
+const ORGANIZATION_TAGS_TO_EXCLUDE_CONFIG_KEY =
+  "zendeskOrganizationTagsToExclude";
 const MAX_RETENTION_DAYS = 365;
 const DEFAULT_RETENTION_DAYS = 180;
 
@@ -99,6 +105,8 @@ export class ZendeskConnectorManager extends BaseConnectorManager<null> {
         hideCustomerDetails: false,
         organizationTagsToInclude: null,
         organizationTagsToExclude: null,
+        ticketTagsToInclude: null,
+        ticketTagsToExclude: null,
       }
     );
     const loggerArgs = {
@@ -634,6 +642,54 @@ export class ZendeskConnectorManager extends BaseConnectorManager<null> {
         }
         return new Ok(undefined);
       }
+      case TICKET_TAGS_TO_INCLUDE_CONFIG_KEY: {
+        const tags = configValue.trim() === "" ? null : JSON.parse(configValue);
+        if (tags !== null && !Array.isArray(tags)) {
+          return new Err(
+            new Error("Ticket tags to include must be an array or empty.")
+          );
+        }
+        await zendeskConfiguration.update({
+          ticketTagsToInclude: tags,
+        });
+        return new Ok(undefined);
+      }
+      case TICKET_TAGS_TO_EXCLUDE_CONFIG_KEY: {
+        const tags = configValue.trim() === "" ? null : JSON.parse(configValue);
+        if (tags !== null && !Array.isArray(tags)) {
+          return new Err(
+            new Error("Ticket tags to exclude must be an array or empty.")
+          );
+        }
+        await zendeskConfiguration.update({
+          ticketTagsToExclude: tags,
+        });
+        return new Ok(undefined);
+      }
+      case ORGANIZATION_TAGS_TO_INCLUDE_CONFIG_KEY: {
+        const tags = configValue.trim() === "" ? null : JSON.parse(configValue);
+        if (tags !== null && !Array.isArray(tags)) {
+          return new Err(
+            new Error("Organization tags to include must be an array or empty.")
+          );
+        }
+        await zendeskConfiguration.update({
+          organizationTagsToInclude: tags,
+        });
+        return new Ok(undefined);
+      }
+      case ORGANIZATION_TAGS_TO_EXCLUDE_CONFIG_KEY: {
+        const tags = configValue.trim() === "" ? null : JSON.parse(configValue);
+        if (tags !== null && !Array.isArray(tags)) {
+          return new Err(
+            new Error("Organization tags to exclude must be an array or empty.")
+          );
+        }
+        await zendeskConfiguration.update({
+          organizationTagsToExclude: tags,
+        });
+        return new Ok(undefined);
+      }
       default: {
         return new Err(new Error(`Invalid config key ${configKey}`));
       }
@@ -668,6 +724,34 @@ export class ZendeskConnectorManager extends BaseConnectorManager<null> {
       }
       case RETENTION_PERIOD_CONFIG_KEY: {
         return new Ok(zendeskConfiguration.retentionPeriodDays.toString());
+      }
+      case TICKET_TAGS_TO_INCLUDE_CONFIG_KEY: {
+        return new Ok(
+          zendeskConfiguration.ticketTagsToInclude
+            ? JSON.stringify(zendeskConfiguration.ticketTagsToInclude)
+            : ""
+        );
+      }
+      case TICKET_TAGS_TO_EXCLUDE_CONFIG_KEY: {
+        return new Ok(
+          zendeskConfiguration.ticketTagsToExclude
+            ? JSON.stringify(zendeskConfiguration.ticketTagsToExclude)
+            : ""
+        );
+      }
+      case ORGANIZATION_TAGS_TO_INCLUDE_CONFIG_KEY: {
+        return new Ok(
+          zendeskConfiguration.organizationTagsToInclude
+            ? JSON.stringify(zendeskConfiguration.organizationTagsToInclude)
+            : ""
+        );
+      }
+      case ORGANIZATION_TAGS_TO_EXCLUDE_CONFIG_KEY: {
+        return new Ok(
+          zendeskConfiguration.organizationTagsToExclude
+            ? JSON.stringify(zendeskConfiguration.organizationTagsToExclude)
+            : ""
+        );
       }
       default:
         return new Err(new Error(`Invalid config key ${configKey}`));

--- a/connectors/src/connectors/zendesk/lib/cli.ts
+++ b/connectors/src/connectors/zendesk/lib/cli.ts
@@ -46,7 +46,7 @@ import type {
   ZendeskOrganizationTagResponseType,
 } from "@connectors/types";
 
-function getOrganizationTagsArgs(args: ZendeskCommandType["args"]) {
+function getTagsArgs(args: ZendeskCommandType["args"]) {
   const tag = args.tag;
   if (!tag) {
     throw new Error("Missing --tag argument");
@@ -108,6 +108,7 @@ async function checkTicketShouldBeSynced(
   return shouldSyncTicket(ticket, configuration, {
     brandId,
     organizationTags,
+    ticketTags: ticket.tags,
   });
 }
 
@@ -479,7 +480,7 @@ export const zendesk = async ({
       return { success: true };
     }
     case "add-organization-tag": {
-      const { tag, include, exclude } = getOrganizationTagsArgs(args);
+      const { tag, include, exclude } = getTagsArgs(args);
 
       const { wasAdded, message } = await configuration.addOrganizationTag({
         tag,
@@ -490,7 +491,7 @@ export const zendesk = async ({
       return { success: true, message };
     }
     case "remove-organization-tag": {
-      const { tag, include, exclude } = getOrganizationTagsArgs(args);
+      const { tag, include, exclude } = getTagsArgs(args);
 
       const { wasRemoved, message } = await configuration.removeOrganizationTag(
         {
@@ -501,6 +502,31 @@ export const zendesk = async ({
       logger.info({ wasRemoved, tag, include, exclude }, message);
 
       return { success: true, message };
+    }
+    case "add-ticket-tag": {
+      const { tag, include, exclude } = getTagsArgs(args);
+
+      const { wasAdded, message } = await configuration.addTicketTag({
+        tag,
+        includeOrExclude: include ? "include" : "exclude",
+      });
+      logger.info({ wasAdded, tag, include, exclude }, message);
+
+      return { success: true, message };
+    }
+    case "remove-ticket-tag": {
+      const { tag, include, exclude } = getTagsArgs(args);
+
+      const { wasRemoved, message } = await configuration.removeTicketTag({
+        tag,
+        includeOrExclude: include ? "include" : "exclude",
+      });
+      logger.info({ wasRemoved, tag, include, exclude }, message);
+
+      return { success: true, message };
+    }
+    default: {
+      throw new Error(`Unknown command: ${command}`);
     }
   }
 };

--- a/connectors/src/connectors/zendesk/lib/sync_ticket.ts
+++ b/connectors/src/connectors/zendesk/lib/sync_ticket.ts
@@ -32,8 +32,9 @@ export function shouldSyncTicket(
   configuration: ZendeskConfigurationResource,
   {
     brandId,
-    organizationTags,
-  }: { brandId?: number; organizationTags: string[] }
+    organizationTags = [],
+    ticketTags = [],
+  }: { brandId?: number; organizationTags?: string[]; ticketTags?: string[] }
 ): boolean {
   if (ticket.status === "deleted") {
     return false;
@@ -48,10 +49,11 @@ export function shouldSyncTicket(
     return false;
   }
 
-  // If we enforce an inclusion rule on tags, we must have at least one of the
+  // If we enforce an inclusion rule on organization tags, all tickets must have at least one of the
   // mandatory tags.
   if (
     configuration.organizationTagsToInclude &&
+    configuration.organizationTagsToInclude.length > 0 &&
     !configuration.organizationTagsToInclude.some((mandatoryTag) =>
       organizationTags.includes(mandatoryTag)
     )
@@ -59,12 +61,37 @@ export function shouldSyncTicket(
     return false;
   }
 
-  // If we enforce an exclusion rule on tags, we must not have any of the
+  // If we enforce an exclusion rule on organization tags, we must not have any of the
   // excluded tags.
   if (
     configuration.organizationTagsToExclude &&
+    configuration.organizationTagsToExclude.length > 0 &&
     configuration.organizationTagsToExclude.some((prohibitedTag) =>
       organizationTags.includes(prohibitedTag)
+    )
+  ) {
+    return false;
+  }
+
+  // If we enforce an inclusion rule on ticket tags, we must have at least one of the
+  // mandatory tags.
+  if (
+    configuration.ticketTagsToInclude &&
+    configuration.ticketTagsToInclude.length > 0 &&
+    !configuration.ticketTagsToInclude.some((mandatoryTag) =>
+      ticketTags.includes(mandatoryTag)
+    )
+  ) {
+    return false;
+  }
+
+  // If we enforce an exclusion rule on ticket tags, we must not have any of the
+  // excluded tags.
+  if (
+    configuration.ticketTagsToExclude &&
+    configuration.ticketTagsToExclude.length > 0 &&
+    configuration.ticketTagsToExclude.some((prohibitedTag) =>
+      ticketTags.includes(prohibitedTag)
     )
   ) {
     return false;

--- a/connectors/src/connectors/zendesk/temporal/activities.ts
+++ b/connectors/src/connectors/zendesk/temporal/activities.ts
@@ -683,6 +683,7 @@ export async function syncZendeskTicketBatchActivity({
     return shouldSyncTicket(t, configuration, {
       brandId,
       organizationTags,
+      ticketTags: t.tags,
     });
   });
 

--- a/connectors/src/connectors/zendesk/temporal/incremental_activities.ts
+++ b/connectors/src/connectors/zendesk/temporal/incremental_activities.ts
@@ -331,7 +331,11 @@ export async function syncZendeskTicketUpdateBatchActivity({
       }
 
       if (
-        shouldSyncTicket(ticket, configuration, { brandId, organizationTags })
+        shouldSyncTicket(ticket, configuration, {
+          brandId,
+          organizationTags,
+          ticketTags: ticket.tags,
+        })
       ) {
         const comments = commentsPerTicket[ticket.id];
         if (!comments) {

--- a/connectors/src/lib/models/zendesk.ts
+++ b/connectors/src/lib/models/zendesk.ts
@@ -53,6 +53,9 @@ export class ZendeskConfigurationModel extends ConnectorBaseModel<ZendeskConfigu
 
   declare organizationTagsToInclude: string[] | null;
   declare organizationTagsToExclude: string[] | null;
+
+  declare ticketTagsToInclude: string[] | null;
+  declare ticketTagsToExclude: string[] | null;
 }
 
 ZendeskConfigurationModel.init(
@@ -91,6 +94,14 @@ ZendeskConfigurationModel.init(
       allowNull: true,
     },
     organizationTagsToExclude: {
+      type: DataTypes.ARRAY(DataTypes.STRING),
+      allowNull: true,
+    },
+    ticketTagsToInclude: {
+      type: DataTypes.ARRAY(DataTypes.STRING),
+      allowNull: true,
+    },
+    ticketTagsToExclude: {
       type: DataTypes.ARRAY(DataTypes.STRING),
       allowNull: true,
     },

--- a/connectors/src/resources/zendesk_resources.ts
+++ b/connectors/src/resources/zendesk_resources.ts
@@ -113,8 +113,8 @@ export class ZendeskConfigurationResource extends BaseResource<ZendeskConfigurat
 
   enforcesOrganizationTagConstraint(): boolean {
     return (
-      this.organizationTagsToInclude !== null ||
-      this.organizationTagsToExclude !== null
+      (this.organizationTagsToInclude !== null && this.organizationTagsToInclude.length > 0) ||
+      (this.organizationTagsToExclude !== null && this.organizationTagsToExclude.length > 0)
     );
   }
 

--- a/connectors/src/resources/zendesk_resources.ts
+++ b/connectors/src/resources/zendesk_resources.ts
@@ -113,8 +113,10 @@ export class ZendeskConfigurationResource extends BaseResource<ZendeskConfigurat
 
   enforcesOrganizationTagConstraint(): boolean {
     return (
-      (this.organizationTagsToInclude !== null && this.organizationTagsToInclude.length > 0) ||
-      (this.organizationTagsToExclude !== null && this.organizationTagsToExclude.length > 0)
+      (this.organizationTagsToInclude !== null &&
+        this.organizationTagsToInclude.length > 0) ||
+      (this.organizationTagsToExclude !== null &&
+        this.organizationTagsToExclude.length > 0)
     );
   }
 

--- a/connectors/src/resources/zendesk_resources.ts
+++ b/connectors/src/resources/zendesk_resources.ts
@@ -100,6 +100,12 @@ export class ZendeskConfigurationResource extends BaseResource<ZendeskConfigurat
 
       subdomain: this.subdomain,
       retentionPeriodDays: this.retentionPeriodDays,
+      syncUnresolvedTickets: this.syncUnresolvedTickets,
+      hideCustomerDetails: this.hideCustomerDetails,
+      organizationTagsToInclude: this.organizationTagsToInclude,
+      organizationTagsToExclude: this.organizationTagsToExclude,
+      ticketTagsToInclude: this.ticketTagsToInclude,
+      ticketTagsToExclude: this.ticketTagsToExclude,
 
       connectorId: this.connectorId,
     };
@@ -151,6 +157,66 @@ export class ZendeskConfigurationResource extends BaseResource<ZendeskConfigurat
         : "organizationTagsToExclude";
 
     const currentTags = this.organizationTagsToInclude || [];
+    if (!currentTags.includes(tag)) {
+      return {
+        wasRemoved: false,
+        message: `Tag "${tag}" does not exist in ${column}`,
+      };
+    }
+
+    const newTags = currentTags.filter((t) => t !== tag);
+    await this.update({ [column]: newTags });
+
+    return { wasRemoved: true, message: `Removed tag "${tag}" from ${column}` };
+  }
+
+  async addTicketTag({
+    tag,
+    includeOrExclude,
+  }: {
+    tag: string;
+    includeOrExclude: "include" | "exclude";
+  }): Promise<{ wasAdded: boolean; message: string }> {
+    const column =
+      includeOrExclude === "include"
+        ? "ticketTagsToInclude"
+        : "ticketTagsToExclude";
+
+    const currentTags =
+      includeOrExclude === "include"
+        ? this.ticketTagsToInclude || []
+        : this.ticketTagsToExclude || [];
+
+    if (currentTags.includes(tag)) {
+      return {
+        wasAdded: false,
+        message: `Tag "${tag}" already exists in ${column}`,
+      };
+    }
+
+    const newTags = [...currentTags, tag];
+    await this.update({ [column]: newTags });
+
+    return { wasAdded: true, message: `Added tag "${tag}" to ${column}` };
+  }
+
+  async removeTicketTag({
+    tag,
+    includeOrExclude,
+  }: {
+    tag: string;
+    includeOrExclude: "include" | "exclude";
+  }): Promise<{ wasRemoved: boolean; message: string }> {
+    const column =
+      includeOrExclude === "include"
+        ? "ticketTagsToInclude"
+        : "ticketTagsToExclude";
+
+    const currentTags =
+      includeOrExclude === "include"
+        ? this.ticketTagsToInclude || []
+        : this.ticketTagsToExclude || [];
+
     if (!currentTags.includes(tag)) {
       return {
         wasRemoved: false,

--- a/connectors/src/types/admin/cli.ts
+++ b/connectors/src/types/admin/cli.ts
@@ -687,6 +687,8 @@ export const ZendeskCommandSchema = t.type({
     t.literal("set-retention-period"),
     t.literal("add-organization-tag"),
     t.literal("remove-organization-tag"),
+    t.literal("add-ticket-tag"),
+    t.literal("remove-ticket-tag"),
   ]),
   args: t.type({
     wId: t.union([t.string, t.undefined]),

--- a/front/components/data_source/ZendeskConfigView.tsx
+++ b/front/components/data_source/ZendeskConfigView.tsx
@@ -8,6 +8,8 @@ import {
 } from "@dust-tt/sparkle";
 import { useState } from "react";
 
+import { ZendeskOrganizationTagFilters } from "@app/components/data_source/ZendeskOrganizationTagFilters";
+import { ZendeskTicketTagFilters } from "@app/components/data_source/ZendeskTicketTagFilters";
 import { useTheme } from "@app/components/sparkle/ThemeContext";
 import { useSendNotification } from "@app/hooks/useNotification";
 import { useConnectorConfig } from "@app/lib/swr/connectors";
@@ -228,6 +230,18 @@ export function ZendeskConfigView({
           </div>
         </ContextItem.Description>
       </ContextItem>
+      <ZendeskTicketTagFilters
+        owner={owner}
+        readOnly={readOnly}
+        isAdmin={isAdmin}
+        dataSource={dataSource}
+      />
+      <ZendeskOrganizationTagFilters
+        owner={owner}
+        readOnly={readOnly}
+        isAdmin={isAdmin}
+        dataSource={dataSource}
+      />
     </ContextItem.List>
   );
 }

--- a/front/components/data_source/ZendeskOrganizationTagFilters.tsx
+++ b/front/components/data_source/ZendeskOrganizationTagFilters.tsx
@@ -25,7 +25,13 @@ export function ZendeskOrganizationTagFilters({
       readOnly={readOnly}
       isAdmin={isAdmin}
       title="Organization Tag Filters"
-      description="Configure organization tags to control which tickets are synced based on their associated organization. Include tags to sync only tickets from organizations with those tags, or exclude tags to filter out tickets from organizations with specific tags. These filters only apply to future syncing and will not retroactively remove already-synced tickets."
+      description={
+        "Configure organization tags to control which tickets are synced based on their " +
+        "associated organization. Add 'Included' tags to sync only tickets from organizations with " +
+        "those tags, or add 'Excluded' tags to filter out tickets from organizations with specific " +
+        "tags. These filters only apply to future syncing and will not retroactively remove " +
+        "already-synced tickets."
+      }
       tagFilters={organizationTagFilters}
       addTag={addOrganizationTag}
       removeTag={removeOrganizationTag}

--- a/front/components/data_source/ZendeskOrganizationTagFilters.tsx
+++ b/front/components/data_source/ZendeskOrganizationTagFilters.tsx
@@ -1,0 +1,36 @@
+import { ZendeskTagFilters } from "@app/components/data_source/ZendeskTagFilters";
+import { useZendeskOrganizationTagFilters } from "@app/hooks/useZendeskOrganizationTagFilters";
+import type { DataSourceType, WorkspaceType } from "@app/types";
+
+export function ZendeskOrganizationTagFilters({
+  owner,
+  readOnly,
+  isAdmin,
+  dataSource,
+}: {
+  owner: WorkspaceType;
+  readOnly: boolean;
+  isAdmin: boolean;
+  dataSource: DataSourceType;
+}) {
+  const {
+    organizationTagFilters,
+    addOrganizationTag,
+    removeOrganizationTag,
+    loading,
+  } = useZendeskOrganizationTagFilters({ owner, dataSource });
+
+  return (
+    <ZendeskTagFilters
+      readOnly={readOnly}
+      isAdmin={isAdmin}
+      title="Organization Tag Filters"
+      description="Configure organization tags to control which tickets are synced based on their associated organization. Include tags to sync only tickets from organizations with those tags, or exclude tags to filter out tickets from organizations with specific tags. These filters only apply to future syncing and will not retroactively remove already-synced tickets."
+      tagFilters={organizationTagFilters}
+      addTag={addOrganizationTag}
+      removeTag={removeOrganizationTag}
+      loading={loading}
+      placeholder="Enter tag name"
+    />
+  );
+}

--- a/front/components/data_source/ZendeskTagFilters.tsx
+++ b/front/components/data_source/ZendeskTagFilters.tsx
@@ -51,21 +51,13 @@ export function ZendeskTagFilters({
       return;
     }
 
-    try {
-      await addTag(inputValue.trim(), activeTab);
-      setInputValue("");
-      setIsEditing(false);
-    } catch (error) {
-      // Error is handled by the hook with user notifications
-    }
+    await addTag(inputValue.trim(), activeTab);
+    setInputValue("");
+    setIsEditing(false);
   };
 
   const handleRemoveTag = async (tag: string, type: "include" | "exclude") => {
-    try {
-      await removeTag(tag, type);
-    } catch (error) {
-      // Error is handled by the hook with user notifications
-    }
+    await removeTag(tag, type);
   };
 
   const handleEdit = () => {
@@ -214,7 +206,7 @@ export function ZendeskTagFilters({
           )}
 
           <p className="mt-2 text-xs text-muted-foreground">
-            Enter one tag at a time. Exclude tags take precedence over include
+            Enter one tag at a time. Excluded tags take precedence over included
             tags.
           </p>
         </div>

--- a/front/components/data_source/ZendeskTagFilters.tsx
+++ b/front/components/data_source/ZendeskTagFilters.tsx
@@ -1,0 +1,224 @@
+import {
+  Button,
+  ContextItem,
+  Input,
+  Tabs,
+  TabsList,
+  TabsTrigger,
+  XMarkIcon,
+  ZendeskLogo,
+  ZendeskWhiteLogo,
+} from "@dust-tt/sparkle";
+import { useState } from "react";
+
+import { useTheme } from "@app/components/sparkle/ThemeContext";
+
+interface TagFilters {
+  includedTags: string[];
+  excludedTags: string[];
+}
+
+interface ZendeskTagFiltersProps {
+  readOnly: boolean;
+  isAdmin: boolean;
+  title: string;
+  description: string;
+  tagFilters: TagFilters;
+  addTag: (tag: string, type: "include" | "exclude") => Promise<void>;
+  removeTag: (tag: string, type: "include" | "exclude") => Promise<void>;
+  loading: boolean;
+  placeholder?: string;
+}
+
+export function ZendeskTagFilters({
+  readOnly,
+  isAdmin,
+  title,
+  description,
+  tagFilters,
+  addTag,
+  removeTag,
+  loading,
+  placeholder = "Enter tag name",
+}: ZendeskTagFiltersProps) {
+  const { isDark } = useTheme();
+  const [inputValue, setInputValue] = useState("");
+  const [isEditing, setIsEditing] = useState(false);
+  const [activeTab, setActiveTab] = useState<"include" | "exclude">("exclude");
+
+  const handleSave = async () => {
+    if (!inputValue.trim()) {
+      return;
+    }
+
+    try {
+      await addTag(inputValue.trim(), activeTab);
+      setInputValue("");
+      setIsEditing(false);
+    } catch (error) {
+      // Error is handled by the hook with user notifications
+    }
+  };
+
+  const handleRemoveTag = async (tag: string, type: "include" | "exclude") => {
+    try {
+      await removeTag(tag, type);
+    } catch (error) {
+      // Error is handled by the hook with user notifications
+    }
+  };
+
+  const handleEdit = () => {
+    setIsEditing(true);
+  };
+
+  const handleCancel = () => {
+    setInputValue("");
+    setIsEditing(false);
+  };
+
+  const handleKeyDown = (e: React.KeyboardEvent) => {
+    if (e.key === "Enter") {
+      e.preventDefault();
+      void handleSave();
+    }
+  };
+
+  const includedTags = tagFilters.includedTags || [];
+  const excludedTags = tagFilters.excludedTags || [];
+  const hasIncludedTags = includedTags.length > 0;
+  const hasExcludedTags = excludedTags.length > 0;
+  const hasTags = hasIncludedTags || hasExcludedTags;
+
+  const renderTagList = (
+    tags: string[],
+    type: "include" | "exclude",
+    bgColor: string,
+    textColor: string
+  ) => (
+    <div className="flex flex-wrap gap-2">
+      {tags.map((tag: string) => (
+        <span
+          key={tag}
+          className={`inline-flex items-center gap-1 rounded-md px-3 py-1 text-sm font-medium ${bgColor} ${textColor}`}
+        >
+          {tag}
+          {!readOnly && isAdmin && (
+            <button
+              onClick={() => handleRemoveTag(tag, type)}
+              disabled={loading}
+              className="ml-1 hover:opacity-70 disabled:opacity-50"
+            >
+              <XMarkIcon className="h-3 w-3" />
+            </button>
+          )}
+        </span>
+      ))}
+    </div>
+  );
+
+  return (
+    <ContextItem
+      title={title}
+      visual={
+        <ContextItem.Visual visual={isDark ? ZendeskWhiteLogo : ZendeskLogo} />
+      }
+      action={
+        <div className="flex items-center gap-2">
+          {isEditing ? (
+            <>
+              <div className="flex flex-col gap-2">
+                <Tabs
+                  value={activeTab}
+                  onValueChange={(value) =>
+                    setActiveTab(value as "include" | "exclude")
+                  }
+                >
+                  <TabsList>
+                    <TabsTrigger value="include" label="Include Tags" />
+                    <TabsTrigger value="exclude" label="Exclude Tags" />
+                  </TabsList>
+                </Tabs>
+                <Input
+                  value={inputValue}
+                  onChange={(e) => setInputValue(e.target.value)}
+                  onKeyDown={handleKeyDown}
+                  placeholder={placeholder}
+                  disabled={readOnly || !isAdmin || loading}
+                  className="w-80"
+                />
+              </div>
+              <Button
+                size="sm"
+                onClick={handleSave}
+                disabled={readOnly || !isAdmin || loading || !inputValue.trim()}
+                label="Add"
+              />
+              <Button
+                size="sm"
+                variant="ghost-secondary"
+                onClick={handleCancel}
+                disabled={readOnly || !isAdmin || loading}
+                label="Cancel"
+              />
+            </>
+          ) : (
+            <>
+              <Button
+                size="sm"
+                onClick={handleEdit}
+                disabled={readOnly || !isAdmin || loading}
+                label="Add Tags"
+              />
+            </>
+          )}
+        </div>
+      }
+    >
+      <ContextItem.Description>
+        <div className="text-muted-foreground dark:text-muted-foreground-night">
+          <p className="mb-4">{description}</p>
+
+          {hasIncludedTags && (
+            <div className="mb-4">
+              <p className="mb-2 text-sm font-medium text-green-800 dark:text-green-200">
+                Include Tags (sync only items with these tags):
+              </p>
+              {renderTagList(
+                includedTags,
+                "include",
+                "bg-green-100 dark:bg-green-900",
+                "text-green-800 dark:text-green-200"
+              )}
+            </div>
+          )}
+
+          {hasExcludedTags && (
+            <div className="mb-4">
+              <p className="mb-2 text-sm font-medium text-red-800 dark:text-red-200">
+                Exclude Tags (don't sync items with these tags):
+              </p>
+              {renderTagList(
+                excludedTags,
+                "exclude",
+                "bg-red-100 dark:bg-red-900",
+                "text-red-800 dark:text-red-200"
+              )}
+            </div>
+          )}
+
+          {!hasTags && (
+            <p className="mb-4 text-sm text-muted-foreground">
+              No tag filters configured. All items will be synced.
+            </p>
+          )}
+
+          <p className="mt-2 text-xs text-muted-foreground">
+            Enter one tag at a time. Exclude tags take precedence over include
+            tags.
+          </p>
+        </div>
+      </ContextItem.Description>
+    </ContextItem>
+  );
+}

--- a/front/components/data_source/ZendeskTicketTagFilters.tsx
+++ b/front/components/data_source/ZendeskTicketTagFilters.tsx
@@ -21,7 +21,12 @@ export function ZendeskTicketTagFilters({
       readOnly={readOnly}
       isAdmin={isAdmin}
       title="Ticket Tag Filters"
-      description="Configure tags to control which tickets are synced to Dust. Include tags to sync only tickets with those tags, or exclude tags to filter out tickets with specific tags. These filters only apply to future syncing and will not retroactively remove already-synced tickets."
+      description={
+        "Configure tags to control which tickets are synced to Dust. Add 'Included' tags to sync " +
+        "only tickets with those tags, or add 'Excluded' tags to filter out tickets with those " +
+        "tags. These filters only apply to future syncing and will not retroactively remove " +
+        "already-synced tickets."
+      }
       tagFilters={ticketTagFilters}
       addTag={addTicketTag}
       removeTag={removeTicketTag}

--- a/front/components/data_source/ZendeskTicketTagFilters.tsx
+++ b/front/components/data_source/ZendeskTicketTagFilters.tsx
@@ -1,0 +1,32 @@
+import { ZendeskTagFilters } from "@app/components/data_source/ZendeskTagFilters";
+import { useZendeskTicketTagFilters } from "@app/hooks/useZendeskTicketTagFilters";
+import type { DataSourceType, WorkspaceType } from "@app/types";
+
+export function ZendeskTicketTagFilters({
+  owner,
+  readOnly,
+  isAdmin,
+  dataSource,
+}: {
+  owner: WorkspaceType;
+  readOnly: boolean;
+  isAdmin: boolean;
+  dataSource: DataSourceType;
+}) {
+  const { ticketTagFilters, addTicketTag, removeTicketTag, loading } =
+    useZendeskTicketTagFilters({ owner, dataSource });
+
+  return (
+    <ZendeskTagFilters
+      readOnly={readOnly}
+      isAdmin={isAdmin}
+      title="Ticket Tag Filters"
+      description="Configure tags to control which tickets are synced to Dust. Include tags to sync only tickets with those tags, or exclude tags to filter out tickets with specific tags. These filters only apply to future syncing and will not retroactively remove already-synced tickets."
+      tagFilters={ticketTagFilters}
+      addTag={addTicketTag}
+      removeTag={removeTicketTag}
+      loading={loading}
+      placeholder="Enter tag name"
+    />
+  );
+}

--- a/front/hooks/useZendeskOrganizationTagFilters.ts
+++ b/front/hooks/useZendeskOrganizationTagFilters.ts
@@ -2,6 +2,7 @@ import { useCallback } from "react";
 
 import { useSendNotification } from "@app/hooks/useNotification";
 import { useConnectorConfig } from "@app/lib/swr/connectors";
+import { ZENDESK_CONFIG_KEYS } from "@app/lib/constants/zendesk";
 import type { DataSourceType, WorkspaceType } from "@app/types";
 
 export function useZendeskOrganizationTagFilters({
@@ -18,7 +19,7 @@ export function useZendeskOrganizationTagFilters({
     mutateConfig: mutateIncludedTags,
     isResourcesLoading: loadingIncluded,
   } = useConnectorConfig({
-    configKey: "zendeskOrganizationTagsToInclude",
+    configKey: ZENDESK_CONFIG_KEYS.ORGANIZATION_TAGS_TO_INCLUDE,
     dataSource,
     owner,
   });
@@ -28,7 +29,7 @@ export function useZendeskOrganizationTagFilters({
     mutateConfig: mutateExcludedTags,
     isResourcesLoading: loadingExcluded,
   } = useConnectorConfig({
-    configKey: "zendeskOrganizationTagsToExclude",
+    configKey: ZENDESK_CONFIG_KEYS.ORGANIZATION_TAGS_TO_EXCLUDE,
     dataSource,
     owner,
   });
@@ -41,8 +42,8 @@ export function useZendeskOrganizationTagFilters({
       try {
         const configKey =
           type === "include"
-            ? "zendeskOrganizationTagsToInclude"
-            : "zendeskOrganizationTagsToExclude";
+            ? ZENDESK_CONFIG_KEYS.ORGANIZATION_TAGS_TO_INCLUDE
+            : ZENDESK_CONFIG_KEYS.ORGANIZATION_TAGS_TO_EXCLUDE;
         const currentTags = type === "include" ? includedTags : excludedTags;
 
         if (currentTags.includes(tag)) {
@@ -108,8 +109,8 @@ export function useZendeskOrganizationTagFilters({
       try {
         const configKey =
           type === "include"
-            ? "zendeskOrganizationTagsToInclude"
-            : "zendeskOrganizationTagsToExclude";
+            ? ZENDESK_CONFIG_KEYS.ORGANIZATION_TAGS_TO_INCLUDE
+            : ZENDESK_CONFIG_KEYS.ORGANIZATION_TAGS_TO_EXCLUDE;
         const currentTags = type === "include" ? includedTags : excludedTags;
 
         if (!currentTags.includes(tag)) {

--- a/front/hooks/useZendeskOrganizationTagFilters.ts
+++ b/front/hooks/useZendeskOrganizationTagFilters.ts
@@ -1,0 +1,183 @@
+import { useCallback } from "react";
+
+import { useSendNotification } from "@app/hooks/useNotification";
+import { useConnectorConfig } from "@app/lib/swr/connectors";
+import type { DataSourceType, WorkspaceType } from "@app/types";
+
+export function useZendeskOrganizationTagFilters({
+  owner,
+  dataSource,
+}: {
+  owner: WorkspaceType;
+  dataSource: DataSourceType;
+}) {
+  const sendNotification = useSendNotification();
+
+  const {
+    configValue: includedTagsConfig,
+    mutateConfig: mutateIncludedTags,
+    isResourcesLoading: loadingIncluded,
+  } = useConnectorConfig({
+    configKey: "zendeskOrganizationTagsToInclude",
+    dataSource,
+    owner,
+  });
+
+  const {
+    configValue: excludedTagsConfig,
+    mutateConfig: mutateExcludedTags,
+    isResourcesLoading: loadingExcluded,
+  } = useConnectorConfig({
+    configKey: "zendeskOrganizationTagsToExclude",
+    dataSource,
+    owner,
+  });
+
+  const includedTags = includedTagsConfig ? JSON.parse(includedTagsConfig) : [];
+  const excludedTags = excludedTagsConfig ? JSON.parse(excludedTagsConfig) : [];
+
+  const addOrganizationTag = useCallback(
+    async (tag: string, type: "include" | "exclude") => {
+      try {
+        const configKey =
+          type === "include"
+            ? "zendeskOrganizationTagsToInclude"
+            : "zendeskOrganizationTagsToExclude";
+        const currentTags = type === "include" ? includedTags : excludedTags;
+
+        if (currentTags.includes(tag)) {
+          sendNotification({
+            type: "info",
+            title: "Tag already exists",
+            description: `The tag "${tag}" is already in the ${type} list.`,
+          });
+          return;
+        }
+
+        const newTags = [...currentTags, tag];
+        const res = await fetch(
+          `/api/w/${owner.sId}/data_sources/${dataSource.sId}/managed/config/${configKey}`,
+          {
+            headers: { "Content-Type": "application/json" },
+            method: "POST",
+            body: JSON.stringify({ configValue: JSON.stringify(newTags) }),
+          }
+        );
+
+        if (res.ok) {
+          if (type === "include") {
+            await mutateIncludedTags();
+          } else {
+            await mutateExcludedTags();
+          }
+          sendNotification({
+            type: "success",
+            title: "Tag added",
+            description: `Added "${tag}" to ${type} list.`,
+          });
+        } else {
+          const err = await res.json();
+          sendNotification({
+            type: "error",
+            title: "Failed to add tag",
+            description:
+              err.error?.connectors_error?.message ||
+              "An unknown error occurred",
+          });
+        }
+      } catch (error) {
+        sendNotification({
+          type: "error",
+          title: "Failed to add tag",
+          description: "An error occurred while adding the tag.",
+        });
+      }
+    },
+    [
+      owner.sId,
+      dataSource.sId,
+      includedTags,
+      excludedTags,
+      mutateIncludedTags,
+      mutateExcludedTags,
+    ]
+  );
+
+  const removeOrganizationTag = useCallback(
+    async (tag: string, type: "include" | "exclude") => {
+      try {
+        const configKey =
+          type === "include"
+            ? "zendeskOrganizationTagsToInclude"
+            : "zendeskOrganizationTagsToExclude";
+        const currentTags = type === "include" ? includedTags : excludedTags;
+
+        if (!currentTags.includes(tag)) {
+          sendNotification({
+            type: "info",
+            title: "Tag not found",
+            description: `The tag "${tag}" is not in the ${type} list.`,
+          });
+          return;
+        }
+
+        const newTags = currentTags.filter((t: string) => t !== tag);
+        const res = await fetch(
+          `/api/w/${owner.sId}/data_sources/${dataSource.sId}/managed/config/${configKey}`,
+          {
+            headers: { "Content-Type": "application/json" },
+            method: "POST",
+            body: JSON.stringify({ configValue: JSON.stringify(newTags) }),
+          }
+        );
+
+        if (res.ok) {
+          if (type === "include") {
+            await mutateIncludedTags();
+          } else {
+            await mutateExcludedTags();
+          }
+          sendNotification({
+            type: "success",
+            title: "Tag removed",
+            description: `Removed "${tag}" from ${type} list.`,
+          });
+        } else {
+          const err = await res.json();
+          sendNotification({
+            type: "error",
+            title: "Failed to remove tag",
+            description:
+              err.error?.connectors_error?.message ||
+              "An unknown error occurred",
+          });
+        }
+      } catch (error) {
+        sendNotification({
+          type: "error",
+          title: "Failed to remove tag",
+          description: "An error occurred while removing the tag.",
+        });
+      }
+    },
+    [
+      owner.sId,
+      dataSource.sId,
+      includedTags,
+      excludedTags,
+      mutateIncludedTags,
+      mutateExcludedTags,
+    ]
+  );
+
+  return {
+    organizationTagFilters: {
+      includedTags,
+      excludedTags,
+    },
+    addOrganizationTag,
+    removeOrganizationTag,
+    loading: loadingIncluded || loadingExcluded,
+    error: null,
+  };
+}

--- a/front/hooks/useZendeskTicketTagFilters.ts
+++ b/front/hooks/useZendeskTicketTagFilters.ts
@@ -2,6 +2,7 @@ import { useCallback } from "react";
 
 import { useSendNotification } from "@app/hooks/useNotification";
 import { useConnectorConfig } from "@app/lib/swr/connectors";
+import { ZENDESK_CONFIG_KEYS } from "@app/lib/constants/zendesk";
 import type { DataSourceType, WorkspaceType } from "@app/types";
 
 export function useZendeskTicketTagFilters({
@@ -18,7 +19,7 @@ export function useZendeskTicketTagFilters({
     mutateConfig: mutateIncludedTags,
     isResourcesLoading: loadingIncluded,
   } = useConnectorConfig({
-    configKey: "zendeskTicketTagsToInclude",
+    configKey: ZENDESK_CONFIG_KEYS.TICKET_TAGS_TO_INCLUDE,
     dataSource,
     owner,
   });
@@ -28,7 +29,7 @@ export function useZendeskTicketTagFilters({
     mutateConfig: mutateExcludedTags,
     isResourcesLoading: loadingExcluded,
   } = useConnectorConfig({
-    configKey: "zendeskTicketTagsToExclude",
+    configKey: ZENDESK_CONFIG_KEYS.TICKET_TAGS_TO_EXCLUDE,
     dataSource,
     owner,
   });
@@ -41,8 +42,8 @@ export function useZendeskTicketTagFilters({
       try {
         const configKey =
           type === "include"
-            ? "zendeskTicketTagsToInclude"
-            : "zendeskTicketTagsToExclude";
+            ? ZENDESK_CONFIG_KEYS.TICKET_TAGS_TO_INCLUDE
+            : ZENDESK_CONFIG_KEYS.TICKET_TAGS_TO_EXCLUDE;
         const currentTags = type === "include" ? includedTags : excludedTags;
 
         if (currentTags.includes(tag)) {
@@ -108,8 +109,8 @@ export function useZendeskTicketTagFilters({
       try {
         const configKey =
           type === "include"
-            ? "zendeskTicketTagsToInclude"
-            : "zendeskTicketTagsToExclude";
+            ? ZENDESK_CONFIG_KEYS.TICKET_TAGS_TO_INCLUDE
+            : ZENDESK_CONFIG_KEYS.TICKET_TAGS_TO_EXCLUDE;
         const currentTags = type === "include" ? includedTags : excludedTags;
 
         if (!currentTags.includes(tag)) {

--- a/front/hooks/useZendeskTicketTagFilters.ts
+++ b/front/hooks/useZendeskTicketTagFilters.ts
@@ -1,0 +1,183 @@
+import { useCallback } from "react";
+
+import { useSendNotification } from "@app/hooks/useNotification";
+import { useConnectorConfig } from "@app/lib/swr/connectors";
+import type { DataSourceType, WorkspaceType } from "@app/types";
+
+export function useZendeskTicketTagFilters({
+  owner,
+  dataSource,
+}: {
+  owner: WorkspaceType;
+  dataSource: DataSourceType;
+}) {
+  const sendNotification = useSendNotification();
+
+  const {
+    configValue: includedTagsConfig,
+    mutateConfig: mutateIncludedTags,
+    isResourcesLoading: loadingIncluded,
+  } = useConnectorConfig({
+    configKey: "zendeskTicketTagsToInclude",
+    dataSource,
+    owner,
+  });
+
+  const {
+    configValue: excludedTagsConfig,
+    mutateConfig: mutateExcludedTags,
+    isResourcesLoading: loadingExcluded,
+  } = useConnectorConfig({
+    configKey: "zendeskTicketTagsToExclude",
+    dataSource,
+    owner,
+  });
+
+  const includedTags = includedTagsConfig ? JSON.parse(includedTagsConfig) : [];
+  const excludedTags = excludedTagsConfig ? JSON.parse(excludedTagsConfig) : [];
+
+  const addTicketTag = useCallback(
+    async (tag: string, type: "include" | "exclude") => {
+      try {
+        const configKey =
+          type === "include"
+            ? "zendeskTicketTagsToInclude"
+            : "zendeskTicketTagsToExclude";
+        const currentTags = type === "include" ? includedTags : excludedTags;
+
+        if (currentTags.includes(tag)) {
+          sendNotification({
+            type: "info",
+            title: "Tag already exists",
+            description: `The tag "${tag}" is already in the ${type} list.`,
+          });
+          return;
+        }
+
+        const newTags = [...currentTags, tag];
+        const res = await fetch(
+          `/api/w/${owner.sId}/data_sources/${dataSource.sId}/managed/config/${configKey}`,
+          {
+            headers: { "Content-Type": "application/json" },
+            method: "POST",
+            body: JSON.stringify({ configValue: JSON.stringify(newTags) }),
+          }
+        );
+
+        if (res.ok) {
+          if (type === "include") {
+            await mutateIncludedTags();
+          } else {
+            await mutateExcludedTags();
+          }
+          sendNotification({
+            type: "success",
+            title: "Tag added",
+            description: `Added "${tag}" to ${type} list.`,
+          });
+        } else {
+          const err = await res.json();
+          sendNotification({
+            type: "error",
+            title: "Failed to add tag",
+            description:
+              err.error?.connectors_error?.message ||
+              "An unknown error occurred",
+          });
+        }
+      } catch (error) {
+        sendNotification({
+          type: "error",
+          title: "Failed to add tag",
+          description: "An error occurred while adding the tag.",
+        });
+      }
+    },
+    [
+      owner.sId,
+      dataSource.sId,
+      includedTags,
+      excludedTags,
+      mutateIncludedTags,
+      mutateExcludedTags,
+    ]
+  );
+
+  const removeTicketTag = useCallback(
+    async (tag: string, type: "include" | "exclude") => {
+      try {
+        const configKey =
+          type === "include"
+            ? "zendeskTicketTagsToInclude"
+            : "zendeskTicketTagsToExclude";
+        const currentTags = type === "include" ? includedTags : excludedTags;
+
+        if (!currentTags.includes(tag)) {
+          sendNotification({
+            type: "info",
+            title: "Tag not found",
+            description: `The tag "${tag}" is not in the ${type} list.`,
+          });
+          return;
+        }
+
+        const newTags = currentTags.filter((t: string) => t !== tag);
+        const res = await fetch(
+          `/api/w/${owner.sId}/data_sources/${dataSource.sId}/managed/config/${configKey}`,
+          {
+            headers: { "Content-Type": "application/json" },
+            method: "POST",
+            body: JSON.stringify({ configValue: JSON.stringify(newTags) }),
+          }
+        );
+
+        if (res.ok) {
+          if (type === "include") {
+            await mutateIncludedTags();
+          } else {
+            await mutateExcludedTags();
+          }
+          sendNotification({
+            type: "success",
+            title: "Tag removed",
+            description: `Removed "${tag}" from ${type} list.`,
+          });
+        } else {
+          const err = await res.json();
+          sendNotification({
+            type: "error",
+            title: "Failed to remove tag",
+            description:
+              err.error?.connectors_error?.message ||
+              "An unknown error occurred",
+          });
+        }
+      } catch (error) {
+        sendNotification({
+          type: "error",
+          title: "Failed to remove tag",
+          description: "An error occurred while removing the tag.",
+        });
+      }
+    },
+    [
+      owner.sId,
+      dataSource.sId,
+      includedTags,
+      excludedTags,
+      mutateIncludedTags,
+      mutateExcludedTags,
+    ]
+  );
+
+  return {
+    ticketTagFilters: {
+      includedTags,
+      excludedTags,
+    },
+    addTicketTag,
+    removeTicketTag,
+    loading: loadingIncluded || loadingExcluded,
+    error: null,
+  };
+}

--- a/front/lib/constants/zendesk.ts
+++ b/front/lib/constants/zendesk.ts
@@ -1,0 +1,6 @@
+export const ZENDESK_CONFIG_KEYS = {
+  TICKET_TAGS_TO_INCLUDE: "zendeskTicketTagsToInclude",
+  TICKET_TAGS_TO_EXCLUDE: "zendeskTicketTagsToExclude",
+  ORGANIZATION_TAGS_TO_INCLUDE: "zendeskOrganizationTagsToInclude",
+  ORGANIZATION_TAGS_TO_EXCLUDE: "zendeskOrganizationTagsToExclude",
+} as const;

--- a/front/pages/api/w/[wId]/data_sources/[dsId]/managed/config/[key]/index.ts
+++ b/front/pages/api/w/[wId]/data_sources/[dsId]/managed/config/[key]/index.ts
@@ -74,8 +74,6 @@ async function handler(
     });
   }
 
-  // We only allow setting and retrieving `botEnabled` (Slack), `codeSyncEnabled` (GitHub), `useMetadataForDBML` (BigQuery),
-  // `intercomConversationsNotesSyncEnabled` (Intercom), `zendeskSyncUnresolvedTicketsEnabled` and `zendeskHideCustomerDetails`.
   // This is mainly to prevent users from enabling other configs that are not released
   if (
     ![
@@ -87,6 +85,10 @@ async function handler(
       "zendeskSyncUnresolvedTicketsEnabled",
       "zendeskHideCustomerDetails",
       "zendeskRetentionPeriodDays",
+      "zendeskTicketTagsToInclude",
+      "zendeskTicketTagsToExclude",
+      "zendeskOrganizationTagsToInclude",
+      "zendeskOrganizationTagsToExclude",
       "gongRetentionPeriodDays",
       "gongTrackersEnabled",
       "privateIntegrationCredentialId",

--- a/front/types/connectors/admin/cli.ts
+++ b/front/types/connectors/admin/cli.ts
@@ -687,6 +687,8 @@ export const ZendeskCommandSchema = t.type({
     t.literal("set-retention-period"),
     t.literal("add-organization-tag"),
     t.literal("remove-organization-tag"),
+    t.literal("add-ticket-tag"),
+    t.literal("remove-ticket-tag"),
   ]),
   args: t.type({
     wId: t.union([t.string, t.undefined]),


### PR DESCRIPTION
## Description

* Following same logic as Zendesk organization tag filter. Enabled "included" and "excluded" Zendesk tags
* Added UX for admins to manage both organization and ticket tags

## Tests

* Created zendesk tickets with excluded tag. Confirmed only tags sync without that tag.

<img width="752" height="493" alt="Screenshot 2025-07-31 at 10 48 38 PM" src="https://github.com/user-attachments/assets/699f6e09-0909-46b8-b752-b01a51365520" />
<img width="740" height="412" alt="Screenshot 2025-07-31 at 10 48 44 PM" src="https://github.com/user-attachments/assets/efd6717e-5ed9-4fd6-a6fc-1abcf643b74f" />

## Risk

* Unintended consequences for zendesky sync

## Deploy Plan

1. deploy front
2. Connector migration
3. deploy connector