### PR TITLE
[front] Add `functionCallId` to log on missing action

### DIFF
--- a/front/lib/api/assistant/preprocessing.ts
+++ b/front/lib/api/assistant/preprocessing.ts
@@ -413,6 +413,7 @@ async function getSteps(
                   workspaceId,
                   conversationId,
                   agentMessageId: message.sId,
+                  functionCallId: functionCall.id,
                 },
                 "Unexpected state, agent message step with no action for function call"
               );


### PR DESCRIPTION
## Description

- This PR adds the `functionCallId` to the log on `Unexpected state, agent message step with no action for function call`.

## Tests

- N/A.

## Risk

- N/A.

## Deploy Plan

- Deploy front.
