### PR TITLE
[front] Add option to skip the check on missing actions

### DIFF
--- a/front/lib/actions/mcp_internal_actions/servers/reasoning.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/reasoning.ts
@@ -215,6 +215,7 @@ async function* runReasoning(
     tools: "",
     allowedTokenCount: supportedModel.contextSize - REASONING_GENERATION_TOKENS,
     excludeImages: true,
+    checkMissingActions: false,
   });
   if (renderedConversationRes.isErr()) {
     yield {

--- a/front/lib/actions/mcp_internal_actions/servers/run_dust_app.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/run_dust_app.ts
@@ -326,6 +326,7 @@ async function prepareParamsWithHistory(
         tools: "",
         allowedTokenCount,
         excludeImages: true,
+        checkMissingActions: false,
       });
 
       if (convoRes.isOk()) {

--- a/front/lib/actions/mcp_internal_actions/servers/tables_query/server.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/tables_query/server.ts
@@ -96,6 +96,7 @@ function createServer(
         tools: "",
         allowedTokenCount,
         excludeImages: true,
+        checkMissingActions: false,
       });
       if (renderedConversationRes.isErr()) {
         return makeMCPToolTextError(

--- a/front/lib/api/assistant/preprocessing.ts
+++ b/front/lib/api/assistant/preprocessing.ts
@@ -49,6 +49,7 @@ export async function renderConversationForModel(
     allowedTokenCount,
     excludeActions,
     excludeImages,
+    checkMissingActions = true,
   }: {
     conversation: ConversationType;
     model: ModelConfigurationType;
@@ -57,6 +58,7 @@ export async function renderConversationForModel(
     allowedTokenCount: number;
     excludeActions?: boolean;
     excludeImages?: boolean;
+    checkMissingActions?: boolean;
   }
 ): Promise<
   Result<
@@ -80,6 +82,7 @@ export async function renderConversationForModel(
         message: m,
         workspaceId: conversation.owner.sId,
         conversationId: conversation.sId,
+        checkMissingActions,
       });
 
       if (excludeActions) {
@@ -328,11 +331,13 @@ async function getSteps(
     message,
     workspaceId,
     conversationId,
+    checkMissingActions,
   }: {
     model: ModelConfigurationType;
     message: AgentMessageType;
     workspaceId: string;
     conversationId: string;
+    checkMissingActions: boolean;
   }
 ): Promise<Step[]> {
   const supportedModel = getSupportedModelConfig(model);
@@ -404,28 +409,29 @@ async function getSteps(
         for (const action of actions) {
           functionResultByCallId[action.call.id] = action.result;
         }
-        for (const content of step.contents) {
-          if (content.type === "function_call") {
-            const functionCall = content.value;
-            if (!functionResultByCallId[functionCall.id]) {
-              logger.warn(
-                {
-                  workspaceId,
-                  conversationId,
-                  agentMessageId: message.sId,
-                  functionCallId: functionCall.id,
-                },
-                "Unexpected state, agent message step with no action for function call"
-              );
-              actions.push({
-                call: functionCall,
-                result: {
-                  role: "function",
-                  name: functionCall.name,
-                  function_call_id: functionCall.id,
-                  content: "Error: tool execution failed",
-                },
-              });
+        if (checkMissingActions) {
+          for (const content of step.contents) {
+            if (content.type === "function_call") {
+              const functionCall = content.value;
+              if (!functionResultByCallId[functionCall.id]) {
+                logger.warn(
+                  {
+                    workspaceId,
+                    conversationId,
+                    agentMessageId: message.sId,
+                    functionCallId: functionCall.id,},
+                  "Unexpected state, agent message step with no action for function call"
+                );
+                actions.push({
+                  call: functionCall,
+                  result: {
+                    role: "function",
+                    name: functionCall.name,
+                    function_call_id: functionCall.id,
+                    content: "Error: tool execution failed",
+                  },
+                });
+              }
             }
           }
         }

--- a/front/lib/api/assistant/preprocessing.ts
+++ b/front/lib/api/assistant/preprocessing.ts
@@ -419,7 +419,8 @@ async function getSteps(
                     workspaceId,
                     conversationId,
                     agentMessageId: message.sId,
-                    functionCallId: functionCall.id,},
+                    functionCallId: functionCall.id,
+                  },
                   "Unexpected state, agent message step with no action for function call"
                 );
                 actions.push({


### PR DESCRIPTION
## Description

- A dummy result was added in place of missing `function_results` (function call without an action) in https://github.com/dust-tt/dust/pull/14692
- This causes the actions relying on `renderConversationForModel` (which should not do that but that's a different debate) to see this dummy result telling them that an action failed even though it only hasn't happened yet.

## Tests

- Tested locally.

## Risk

- Low.

## Deploy Plan

- Deploy front.
