### PR TITLE
[front] - refactor(poke): plugin for data source deletion

### DIFF
--- a/front/components/poke/data_sources/columns.tsx
+++ b/front/components/poke/data_sources/columns.tsx
@@ -1,4 +1,4 @@
-import { IconButton, LinkWrapper, TrashIcon } from "@dust-tt/sparkle";
+import { IconButton, LinkWrapper } from "@dust-tt/sparkle";
 import { ArrowsUpDownIcon } from "@heroicons/react/20/solid";
 import type { ColumnDef } from "@tanstack/react-table";
 
@@ -15,8 +15,7 @@ interface DataSources {
 }
 
 export function makeColumnsForDataSources(
-  owner: WorkspaceType,
-  onDeleted: () => Promise<void>
+  owner: WorkspaceType
 ): ColumnDef<DataSources>[] {
   return [
     {
@@ -83,62 +82,5 @@ export function makeColumnsForDataSources(
         return formatTimestampToFriendlyDate(editedAt);
       },
     },
-    {
-      id: "actions",
-      cell: ({ row }) => {
-        const dataSource = row.original;
-
-        return (
-          <IconButton
-            icon={TrashIcon}
-            size="xs"
-            variant="outline"
-            onClick={async () => {
-              await deleteDataSource(owner, dataSource.sId, onDeleted);
-            }}
-          />
-        );
-      },
-    },
   ];
-}
-
-async function deleteDataSource(
-  owner: WorkspaceType,
-  dataSourceId: string,
-  onDeleted: () => Promise<void>
-) {
-  if (
-    !window.confirm(
-      `Are you sure you want to delete the ${dataSourceId} data source? There is no going back.`
-    )
-  ) {
-    return;
-  }
-
-  if (!window.confirm(`really, Really, REALLY sure ?`)) {
-    return;
-  }
-
-  try {
-    const r = await fetch(
-      `/api/poke/workspaces/${owner.sId}/data_sources/${dataSourceId}`,
-      {
-        method: "DELETE",
-        headers: {
-          "Content-Type": "application/json",
-        },
-      }
-    );
-    if (!r.ok) {
-      const text = await r.text();
-
-      throw new Error(`Failed to delete data source: ${text}`);
-    }
-
-    await onDeleted();
-  } catch (e) {
-    console.error(e);
-    window.alert(e);
-  }
 }

--- a/front/components/poke/data_sources/table.tsx
+++ b/front/components/poke/data_sources/table.tsx
@@ -25,7 +25,7 @@ export function DataSourceDataTable({ owner }: DataSourceDataTableProps) {
       owner={owner}
       useSWRHook={usePokeDataSources}
     >
-      {(data, mutate) => (
+      {(data) => (
         <PokeDataTable
           columns={makeColumnsForDataSources(owner)}
           data={prepareDataSourceForDisplay(data)}

--- a/front/components/poke/data_sources/table.tsx
+++ b/front/components/poke/data_sources/table.tsx
@@ -27,9 +27,7 @@ export function DataSourceDataTable({ owner }: DataSourceDataTableProps) {
     >
       {(data, mutate) => (
         <PokeDataTable
-          columns={makeColumnsForDataSources(owner, async () => {
-            await mutate();
-          })}
+          columns={makeColumnsForDataSources(owner)}
           data={prepareDataSourceForDisplay(data)}
         />
       )}

--- a/front/lib/api/poke/plugins/data_sources/delete_data_source.ts
+++ b/front/lib/api/poke/plugins/data_sources/delete_data_source.ts
@@ -71,7 +71,7 @@ export const deleteDataSourcePlugin = createPlugin({
 
     return new Ok({
       display: "text",
-      value: `✅ Data source ${dataSource.sId} has been successfully deleted (soft delete). along with the associated tools in ${viewsUsedByAgentsName.size} agent(s)`,
+      value: `✅ Data source ${dataSource.sId} has been successfully deleted (soft delete), along with the associated tools in the following agents: ${Array.from(viewsUsedByAgentsName).join(", ")}`,
     });
   },
 });

--- a/front/lib/api/poke/plugins/data_sources/delete_data_source.ts
+++ b/front/lib/api/poke/plugins/data_sources/delete_data_source.ts
@@ -1,0 +1,89 @@
+import {
+  hardDeleteDataSource,
+  softDeleteDataSourceAndLaunchScrubWorkflow,
+} from "@app/lib/api/data_sources";
+import { createPlugin } from "@app/lib/api/poke/types";
+import { DataSourceViewResource } from "@app/lib/resources/data_source_view_resource";
+import { Err, Ok } from "@app/types";
+
+export const deleteDataSourcePlugin = createPlugin({
+  manifest: {
+    id: "delete-data-source",
+    name: "⚠️ Delete Data Source",
+    description:
+      "Permanently delete this data source. This action cannot be undone.",
+    resourceTypes: ["data_sources"],
+    args: {
+      forceDelete: {
+        type: "boolean",
+        label: "🔴 Force delete (hard delete) - DANGEROUS",
+        description:
+          "WARNING: This will immediately and permanently delete ALL files and bypass safety checks. The data will be unrecoverable. Only use if you are absolutely certain.",
+      },
+    },
+  },
+  execute: async (auth, dataSource, args) => {
+    if (!dataSource) {
+      return new Err(new Error("Data source not found."));
+    }
+
+    const { forceDelete } = args;
+
+    try {
+      if (!forceDelete) {
+        const dataSourceViews = await DataSourceViewResource.listForDataSources(
+          auth,
+          [dataSource]
+        );
+        const viewsUsageByAgentsRes = await Promise.all(
+          dataSourceViews.map((view) => view.getUsagesByAgents(auth))
+        );
+
+        const viewsUsedByAgentsName = viewsUsageByAgentsRes.reduce(
+          (acc, usageRes) => {
+            if (usageRes.isOk() && usageRes.value.count > 0) {
+              usageRes.value.agents
+                .map((a) => a.name)
+                .forEach((name) => acc.add(name));
+            }
+
+            return acc;
+          },
+          new Set<string>()
+        );
+
+        if (viewsUsedByAgentsName.size > 0) {
+          return new Err(
+            new Error(
+              `Cannot delete: This data source is being used by ${viewsUsedByAgentsName.size} agent(s) [${Array.from(viewsUsedByAgentsName).join(", ")}]. Enable "Force delete" to bypass this safety check.`
+            )
+          );
+        }
+
+        const delRes = await softDeleteDataSourceAndLaunchScrubWorkflow(
+          auth,
+          dataSource
+        );
+        if (delRes.isErr()) {
+          return new Err(
+            new Error(`Failed to delete data source: ${delRes.error.message}`)
+          );
+        }
+
+        return new Ok({
+          display: "text",
+          value: `✅ Data source ${dataSource.sId} has been successfully deleted (soft delete).`,
+        });
+      } else {
+        await hardDeleteDataSource(auth, dataSource);
+
+        return new Ok({
+          display: "text",
+          value: `🔴 PERMANENT DELETION COMPLETED. Data source ${dataSource.sId} has been permanently hard deleted. All files have been removed and this action cannot be undone.`,
+        });
+      }
+    } catch (error) {
+      return new Err(new Error(`❌ Failed to delete data source: ${error}`));
+    }
+  },
+});

--- a/front/lib/api/poke/plugins/data_sources/index.ts
+++ b/front/lib/api/poke/plugins/data_sources/index.ts
@@ -1,5 +1,6 @@
 export * from "./compute_statistics";
 export * from "./confluence_page_checker";
+export * from "./delete_data_source";
 export * from "./garbage_collect_google_drive_document";
 export * from "./mark_connector_as_error";
 export * from "./notion_unstuck_syncing_nodes";


### PR DESCRIPTION
## Description

Move data source deletion functionality from UI components into a new poke plugin. This refactoring extracts the deletion logic from the data sources table to handle it through a plugin interface with proper safety checks and force delete options.

## Tests

Locally

## Risk

High, if deletion flow is wrong we could have broken state

## Deploy Plan

Deploy front