### PR TITLE
Revert "Do not join Slack channels to sync"

### DIFF
--- a/connectors/src/connectors/slack/lib/channels.ts
+++ b/connectors/src/connectors/slack/lib/channels.ts
@@ -458,39 +458,6 @@ export async function migrateChannelsFromLegacyBotToNewBot(
       "Migrating channel"
     );
 
-    // Surround with try/catch as the new scope might not always be available.
-    try {
-      // Leave the channel but keep it in the database as it's still use to be indexed.
-      const channelId = channel.id;
-
-      const res = await withSlackErrorHandling(() =>
-        slackClient.conversations.leave({
-          channel: channelId,
-        })
-      );
-
-      if (res.ok) {
-        childLogger.info(
-          {
-            channelId: channel.id,
-          },
-          "Left channel"
-        );
-      }
-
-      if (res.error) {
-        childLogger.error(
-          { error: res.error, channelId: channel.id },
-          "Could not leave channel"
-        );
-      }
-    } catch (error) {
-      childLogger.error(
-        { error, channelId: channel.id },
-        "Could not leave channel"
-      );
-    }
-
     // Join the new bot to the channel.
     const joinRes = await joinChannel(slackBotConnector.id, channel.id);
     if (joinRes.isErr()) {

--- a/connectors/src/connectors/slack/lib/channels.ts
+++ b/connectors/src/connectors/slack/lib/channels.ts
@@ -364,8 +364,7 @@ export async function getChannelsToSync(
   connectorId: number
 ) {
   const [remoteChannels, localChannels] = await Promise.all([
-    // Fetch all the channels, not just the joined ones. The state in DB is the source of truth.
-    getChannels(slackClient, connectorId, false /* joinedOnly */),
+    getChannels(slackClient, connectorId, true),
     SlackChannel.findAll({
       where: {
         connectorId,

--- a/connectors/src/connectors/slack/lib/cli.ts
+++ b/connectors/src/connectors/slack/lib/cli.ts
@@ -1,5 +1,6 @@
 import {
   getChannelById,
+  joinChannel,
   updateSlackChannelInConnectorsDb,
 } from "@connectors/connectors/slack/lib/channels";
 import { getSlackClient } from "@connectors/connectors/slack/lib/slack_client";
@@ -448,6 +449,13 @@ export const slack = async ({
       if (!remoteChannel.name) {
         throw new Error(
           `Could not find channel name for channel ${args.channelId}`
+        );
+      }
+
+      const joinRes = await joinChannel(connector.id, args.channelId);
+      if (joinRes.isErr()) {
+        throw new Error(
+          `Could not join channel ${args.channelId}: ${joinRes.error}`
         );
       }
 

--- a/connectors/src/connectors/slack/temporal/activities.ts
+++ b/connectors/src/connectors/slack/temporal/activities.ts
@@ -1093,8 +1093,7 @@ export async function getChannelsToGarbageCollect(
   const remoteChannels = new Set(
     (
       await withSlackErrorHandling(() =>
-        // Fetch all the channels, not just the joined ones. The state in DB is the source of truth.
-        getChannels(slackClient, connectorId, false)
+        getChannels(slackClient, connectorId, true)
       )
     )
       .filter((c) => c.id)


### PR DESCRIPTION
Reverts dust-tt/dust#14720
Reverts dust-tt/dust#14719

We wanted to remove the deprecated app from the Slack channels, but it turns our that because we use bot tokens we can't perform some operations on channels unless the app is a proper member 🤯.

I also remove the "leave" step as we can't do it for now.