### PR TITLE
Enforce a hard limit on actions output size by uploading full content…

### DIFF
--- a/front/lib/actions/action_file_helpers.ts
+++ b/front/lib/actions/action_file_helpers.ts
@@ -18,10 +18,12 @@ export async function generatePlainTextFile(
     title,
     conversationId,
     content,
+    snippet,
   }: {
     title: string;
     conversationId: string;
     content: string;
+    snippet?: string;
   }
 ): Promise<FileResource> {
   const workspace = auth.getNonNullableWorkspace();
@@ -37,6 +39,7 @@ export async function generatePlainTextFile(
     useCaseMetadata: {
       conversationId,
     },
+    snippet,
   });
 
   await processAndStoreFile(auth, {

--- a/front/lib/actions/mcp.ts
+++ b/front/lib/actions/mcp.ts
@@ -662,6 +662,7 @@ export async function* runToolWithStreaming(
     toolCallResult: toolCallResult.value,
     conversation,
     action,
+    actionConfiguration,
     localLogger,
   });
 

--- a/front/lib/actions/mcp_utils.ts
+++ b/front/lib/actions/mcp_utils.ts
@@ -1,6 +1,7 @@
 import { Err, isSupportedImageContentType } from "@dust-tt/client";
 import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
 
+import { MAX_RESOURCE_CONTENT_SIZE } from "@app/lib/actions/mcp_actions";
 import {
   isBlobResource,
   isSearchQueryResourceType,
@@ -31,8 +32,6 @@ import {
   isSupportedFileContentType,
   Ok,
 } from "@app/types";
-
-const MAX_BLOB_SIZE_BYTES = 1024 * 1024 * 10; // 10MB
 
 export function hideFileFromActionOutput({
   fileId,
@@ -157,7 +156,7 @@ export async function handleBase64Upload(
     };
   }
 
-  if (base64Data.length > MAX_BLOB_SIZE_BYTES) {
+  if (base64Data.length > MAX_RESOURCE_CONTENT_SIZE) {
     return {
       content: {
         type: "text",


### PR DESCRIPTION
## Context

Reopened from https://github.com/dust-tt/dust/pull/14698 that needed a bit rebase following a refactoring splitting files. 
Next step is adding some more tools to conversation_files so it can read a file with offset/limit and do grep. 

## Description

Related task: https://github.com/dust-tt/tasks/issues/3655

This PR changes the behavior of MCP actions:  If the output is very big, we will upload the full content in a file attached to the `agent_mcp_action_output_items` and will present a long snippet as output of the action. We do that if the output is type text or resource with a text, and we exclude the conversion_file server to not enter an infinite loop. 


Note: there was something done from `tryCallMCPTool` to limit the output size already but it was done for external servers only and it was raising an error: https://github.com/dust-tt/dust/blob/15e1ddf958c8ded887488d961540a8de4680262d/front/lib/actions/mcp_actions.ts#L459-L474
(Origin = this PR: https://github.com/dust-tt/dust/pull/13140/files).

## Tests

Tested locally. I edited a Salesforce action to return a huge output and I get this: 

It calls the huge action so content is put in a file, it tries to include it but too big also so it tries to do semantic search on it. 
<kbd>
<img width="756" height="572" alt="Screenshot 2025-07-31 at 12 17 41" src="https://github.com/user-attachments/assets/2adcc306-44b2-42b2-b37a-c88c9ff220c3" />
</kbd>

If we open the first action we appended a big snippet in the output.
<kbd>
<img width="766" height="713" alt="Screenshot 2025-07-31 at 12 16 32" src="https://github.com/user-attachments/assets/207d41cd-62b2-4e44-963f-2d3d44e4eb42" />
</kbd>


Note: Locally the semantic search breaks for me with error `Search action must have at least one data source configured.` which is an error we've already seen on prod (iirc we IRL talked about it last week) so I think not related to my change and needs investigation.  

## Risk

Can be rolled back. 

## Deploy Plan

Deploy front. 