### PR TITLE
[front] Add timestamp-based sort on `SpaceDataSourceViewContentList`

### DIFF
--- a/front/components/spaces/SpaceDataSourceViewContentList.tsx
+++ b/front/components/spaces/SpaceDataSourceViewContentList.tsx
@@ -12,7 +12,7 @@ import {
   Tooltip,
   useHashParam,
 } from "@dust-tt/sparkle";
-import type { CellContext, ColumnDef } from "@tanstack/react-table";
+import type { CellContext, ColumnDef, SortingState } from "@tanstack/react-table";
 import { useRouter } from "next/router";
 import * as React from "react";
 import {
@@ -179,6 +179,7 @@ const getTableColumns = (showSpaceUsage: boolean): ColumnDef<RowData>[] => {
     header: "Last updated",
     id: "lastUpdatedAt",
     accessorKey: "lastUpdatedAt",
+    enableSorting: true,
     meta: {
       className: "w-20",
     },
@@ -270,6 +271,7 @@ export const SpaceDataSourceViewContentList = ({
 }: SpaceDataSourceViewContentListProps) => {
   const [showConnectorPermissionsModal, setShowConnectorPermissionsModal] =
     useState(false);
+  const [sorting, setSorting] = useState<SortingState>([]);
   const sendNotification = useSendNotification();
   const contentActionsRef = useRef<ContentActionsRef>(null);
 
@@ -304,12 +306,23 @@ export const SpaceDataSourceViewContentList = ({
     [resetPagination, setViewType, viewType]
   );
 
+  // Reset pagination when sorting changes
+  useEffect(() => {
+    resetPagination();
+  }, [JSON.stringify(sorting), resetPagination]);
+
   const { setIsSearchDisabled } = useContext(SpaceSearchContext);
 
   const columns = useMemo(
     () => getTableColumns(showSpaceUsage),
     [showSpaceUsage]
   );
+
+  // Convert DataTable sorting format to our API format
+  const apiSorting = sorting.map((sort) => ({
+    id: sort.id,
+    order: sort.desc ? ("desc" as const) : ("asc" as const),
+  }));
 
   const {
     isNodesLoading,
@@ -326,6 +339,7 @@ export const SpaceDataSourceViewContentList = ({
     viewType: isValidContentNodesViewType(viewType)
       ? viewType
       : DEFAULT_VIEW_TYPE,
+    sorting: apiSorting,
   });
 
   const { hasContent: hasDocuments, isNodesValidating: isDocumentsValidating } =
@@ -672,6 +686,9 @@ export const SpaceDataSourceViewContentList = ({
             setPagination={(newTablePagination) =>
               handlePaginationChange(newTablePagination, nextPageCursor)
             }
+            sorting={sorting}
+            setSorting={setSorting}
+            isServerSideSorting={true}
             columnsBreakpoints={columnsBreakpoints}
             disablePaginationNumbers
           />

--- a/front/components/spaces/SpaceDataSourceViewContentList.tsx
+++ b/front/components/spaces/SpaceDataSourceViewContentList.tsx
@@ -12,7 +12,11 @@ import {
   Tooltip,
   useHashParam,
 } from "@dust-tt/sparkle";
-import type { CellContext, ColumnDef, SortingState } from "@tanstack/react-table";
+import type {
+  CellContext,
+  ColumnDef,
+  SortingState,
+} from "@tanstack/react-table";
 import { useRouter } from "next/router";
 import * as React from "react";
 import {

--- a/front/components/spaces/SpaceDataSourceViewContentList.tsx
+++ b/front/components/spaces/SpaceDataSourceViewContentList.tsx
@@ -324,8 +324,8 @@ export const SpaceDataSourceViewContentList = ({
 
   // Convert DataTable sorting format to our API format
   const apiSorting = sorting.map((sort) => ({
-    id: sort.id,
-    order: sort.desc ? ("desc" as const) : ("asc" as const),
+    field: sort.id,
+    direction: sort.desc ? ("desc" as const) : ("asc" as const),
   }));
 
   const {

--- a/front/lib/api/data_source_view.ts
+++ b/front/lib/api/data_source_view.ts
@@ -27,6 +27,7 @@ interface GetContentNodesForDataSourceViewParams {
   parentId?: string;
   pagination?: CursorPaginationParams;
   viewType: ContentNodesViewType;
+  sorting?: { id: string; order: "asc" | "desc" }[];
 }
 
 interface GetContentNodesForDataSourceViewResult {
@@ -135,6 +136,7 @@ export async function getContentNodesForDataSourceView(
     parentId,
     viewType,
     pagination,
+    sorting,
   }: GetContentNodesForDataSourceViewParams
 ): Promise<Result<GetContentNodesForDataSourceViewResult, Error>> {
   const limit = pagination?.limit ?? DEFAULT_PAGINATION_LIMIT;
@@ -169,6 +171,12 @@ export async function getContentNodesForDataSourceView(
 
   let nextPageCursor: string | null = pagination ? pagination.cursor : null;
 
+  // Convert sorting parameter to CoreAPI format
+  const coreAPISorting = sorting?.map((sort) => ({
+    field: sort.id === "lastUpdatedAt" ? "timestamp" : sort.id,
+    direction: sort.order,
+  }));
+
   let resultNodes: CoreAPIContentNode[] = [];
   let hitCount;
   let hiddenNodesCount = 0;
@@ -186,6 +194,7 @@ export async function getContentNodesForDataSourceView(
         // we still need to make sure we get a correct nextPageCursor at the end of this loop.
         limit: limit - resultNodes.length,
         cursor: nextPageCursor ?? undefined,
+        sort: coreAPISorting,
       },
     });
 

--- a/front/lib/api/data_source_view.ts
+++ b/front/lib/api/data_source_view.ts
@@ -3,7 +3,10 @@ import {
   FOLDERS_TO_HIDE_IF_EMPTY_MIME_TYPES,
   getContentNodeFromCoreNode,
 } from "@app/lib/api/content_nodes";
-import type { CursorPaginationParams } from "@app/lib/api/pagination";
+import type {
+  CursorPaginationParams,
+  SortingParams,
+} from "@app/lib/api/pagination";
 import type { Authenticator } from "@app/lib/auth";
 import type { DustError } from "@app/lib/error";
 import { DataSourceViewResource } from "@app/lib/resources/data_source_view_resource";
@@ -27,7 +30,7 @@ interface GetContentNodesForDataSourceViewParams {
   parentId?: string;
   pagination?: CursorPaginationParams;
   viewType: ContentNodesViewType;
-  sorting?: { id: string; order: "asc" | "desc" }[];
+  sorting?: SortingParams;
 }
 
 interface GetContentNodesForDataSourceViewResult {
@@ -173,8 +176,8 @@ export async function getContentNodesForDataSourceView(
 
   // Convert sorting parameter to CoreAPI format
   const coreAPISorting = sorting?.map((sort) => ({
-    field: sort.id === "lastUpdatedAt" ? "timestamp" : sort.id,
-    direction: sort.order,
+    field: sort.field === "lastUpdatedAt" ? "timestamp" : sort.field,
+    direction: sort.direction,
   }));
 
   let resultNodes: CoreAPIContentNode[] = [];

--- a/front/lib/api/pagination.ts
+++ b/front/lib/api/pagination.ts
@@ -85,6 +85,15 @@ export function getPaginationParams(
   return new Ok(queryValidation.right);
 }
 
+export const SortingParamsCodec = t.array(
+  t.type({
+    field: t.string,
+    direction: t.union([t.literal("asc"), t.literal("desc")]),
+  })
+);
+
+export type SortingParams = t.TypeOf<typeof SortingParamsCodec>;
+
 // Cursor pagination.
 
 const CursorPaginationParamsCodec = t.type({

--- a/front/lib/swr/data_source_views.ts
+++ b/front/lib/swr/data_source_views.ts
@@ -1,7 +1,10 @@
 import { useEffect, useMemo, useState } from "react";
 import type { Fetcher, KeyedMutator, SWRConfiguration } from "swr";
 
-import type { CursorPaginationParams } from "@app/lib/api/pagination";
+import type {
+  CursorPaginationParams,
+  SortingParams,
+} from "@app/lib/api/pagination";
 import {
   emptyArray,
   fetcher,
@@ -210,7 +213,7 @@ export function useDataSourceViewContentNodes({
   parentId?: string;
   pagination?: CursorPaginationParams;
   viewType?: ContentNodesViewType;
-  sorting?: { id: string; order: "asc" | "desc" }[];
+  sorting?: SortingParams;
   disabled?: boolean;
   swrOptions?: SWRConfiguration;
 }): {

--- a/front/lib/swr/data_source_views.ts
+++ b/front/lib/swr/data_source_views.ts
@@ -200,6 +200,7 @@ export function useDataSourceViewContentNodes({
   parentId,
   pagination,
   viewType,
+  sorting,
   disabled = false,
   swrOptions,
 }: {
@@ -209,6 +210,7 @@ export function useDataSourceViewContentNodes({
   parentId?: string;
   pagination?: CursorPaginationParams;
   viewType?: ContentNodesViewType;
+  sorting?: { id: string; order: "asc" | "desc" }[];
   disabled?: boolean;
   swrOptions?: SWRConfiguration;
 }): {
@@ -238,6 +240,7 @@ export function useDataSourceViewContentNodes({
     internalIds,
     parentId,
     viewType,
+    sorting,
   };
 
   const fetchKey = JSON.stringify([url + "?" + params.toString(), body]);
@@ -252,7 +255,7 @@ export function useDataSourceViewContentNodes({
 
         return fetcherWithBody([
           url,
-          { internalIds, parentId, viewType },
+          { internalIds, parentId, viewType, sorting },
           "POST",
         ]);
       },

--- a/front/pages/api/w/[wId]/spaces/[spaceId]/data_source_views/[dsvId]/content-nodes.ts
+++ b/front/pages/api/w/[wId]/spaces/[spaceId]/data_source_views/[dsvId]/content-nodes.ts
@@ -5,7 +5,10 @@ import type { NextApiRequest, NextApiResponse } from "next";
 
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
 import { getContentNodesForDataSourceView } from "@app/lib/api/data_source_view";
-import { getCursorPaginationParams } from "@app/lib/api/pagination";
+import {
+  getCursorPaginationParams,
+  SortingParamsCodec,
+} from "@app/lib/api/pagination";
 import { withResourceFetchingFromRoute } from "@app/lib/api/resource_wrappers";
 import type { Authenticator } from "@app/lib/auth";
 import type { DataSourceViewResource } from "@app/lib/resources/data_source_view_resource";
@@ -20,15 +23,7 @@ const GetContentNodesOrChildrenRequestBody = t.type({
   internalIds: t.union([t.array(t.union([t.string, t.null])), t.undefined]),
   parentId: t.union([t.string, t.undefined]),
   viewType: ContentNodesViewTypeCodec,
-  sorting: t.union([
-    t.array(
-      t.type({
-        id: t.string,
-        order: t.union([t.literal("asc"), t.literal("desc")]),
-      })
-    ),
-    t.undefined,
-  ]),
+  sorting: t.union([SortingParamsCodec, t.undefined]),
 });
 
 export type GetDataSourceViewContentNodes = {

--- a/front/pages/api/w/[wId]/spaces/[spaceId]/data_source_views/[dsvId]/content-nodes.ts
+++ b/front/pages/api/w/[wId]/spaces/[spaceId]/data_source_views/[dsvId]/content-nodes.ts
@@ -20,6 +20,15 @@ const GetContentNodesOrChildrenRequestBody = t.type({
   internalIds: t.union([t.array(t.union([t.string, t.null])), t.undefined]),
   parentId: t.union([t.string, t.undefined]),
   viewType: ContentNodesViewTypeCodec,
+  sorting: t.union([
+    t.array(
+      t.type({
+        id: t.string,
+        order: t.union([t.literal("asc"), t.literal("desc")]),
+      })
+    ),
+    t.undefined,
+  ]),
 });
 
 export type GetDataSourceViewContentNodes = {
@@ -72,7 +81,7 @@ async function handler(
     });
   }
 
-  const { internalIds, parentId, viewType } = bodyValidation.right;
+  const { internalIds, parentId, viewType, sorting } = bodyValidation.right;
 
   if (parentId && internalIds) {
     return apiError(req, res, {
@@ -102,6 +111,7 @@ async function handler(
       parentId,
       pagination: paginationRes.value,
       viewType,
+      sorting,
     }
   );
 


### PR DESCRIPTION
## Description

- This PR allows sorting by timestamp by clicking on the "last updated" column of the space data source view data table.
- The sorting is already supported on `core`'s side.

## Tests

- Tested locally.

## Risk

- Low, mostly an additive change.

## Deploy Plan

- Deploy front.
