### PR TITLE
Add a 🐈‍⬛ tool to conversation_files

### DIFF
--- a/front/lib/actions/action_output_limits.ts
+++ b/front/lib/actions/action_output_limits.ts
@@ -1,0 +1,62 @@
+import type { CallToolResult } from "@dust-tt/client/dist/raw_mcp_types";
+
+// Size limits for MCP tool outputs
+export const MAX_TEXT_CONTENT_SIZE = 2 * 1024 * 1024; // 2MB.
+export const MAX_IMAGE_CONTENT_SIZE = 2 * 1024 * 1024; // 2MB.
+export const MAX_RESOURCE_CONTENT_SIZE = 10 * 1024 * 1024; // 10MB.
+
+export const MAXED_OUTPUT_FILE_SNIPPET_LENGTH = 64_000; // Approximately 16K tokens.
+
+export function computeTextByteSize(text: string): number {
+  return text.length * 2; // UTF-8 approximate
+}
+
+export function computeBase64ByteSize(base64: string): number {
+  return Math.ceil((base64.length * 3) / 4);
+}
+
+export const getMaxSize = (item: CallToolResult["content"][number]) => {
+  switch (item.type) {
+    case "text":
+      return MAX_TEXT_CONTENT_SIZE;
+    case "image":
+      return MAX_IMAGE_CONTENT_SIZE;
+    case "resource":
+      return MAX_RESOURCE_CONTENT_SIZE;
+    default:
+      return 1 * 1024 * 1024; // 1MB default
+  }
+};
+
+export const calculateContentSize = (
+  item: CallToolResult["content"][number]
+): number => {
+  switch (item.type) {
+    case "text":
+      return computeTextByteSize(item.text);
+    case "image":
+      return computeBase64ByteSize(item.data);
+    case "resource":
+      if (
+        "blob" in item.resource &&
+        item.resource.blob &&
+        typeof item.resource.blob === "string"
+      ) {
+        return computeBase64ByteSize(item.resource.blob);
+      }
+      if ("text" in item.resource && typeof item.resource.text === "string") {
+        return computeTextByteSize(item.resource.text);
+      }
+      return 0;
+    case "audio":
+      return item.data.length;
+    default:
+      return 0;
+  }
+};
+
+export const isValidContentSize = (
+  content: CallToolResult["content"]
+): boolean => {
+  return !content.some((item) => calculateContentSize(item) > getMaxSize(item));
+};

--- a/front/lib/actions/mcp_execution.ts
+++ b/front/lib/actions/mcp_execution.ts
@@ -3,19 +3,19 @@ import type { McpError } from "@modelcontextprotocol/sdk/types.js";
 import type { Logger } from "pino";
 
 import { generatePlainTextFile } from "@app/lib/actions/action_file_helpers";
+import {
+  computeTextByteSize,
+  MAX_RESOURCE_CONTENT_SIZE,
+  MAX_TEXT_CONTENT_SIZE,
+  MAXED_OUTPUT_FILE_SNIPPET_LENGTH,
+} from "@app/lib/actions/action_output_limits";
 import type {
   MCPActionType,
   MCPApproveExecutionEvent,
   MCPToolConfigurationType,
   ToolNotificationEvent,
 } from "@app/lib/actions/mcp";
-import {
-  computeTextByteSize,
-  MAX_RESOURCE_CONTENT_SIZE,
-  MAX_TEXT_CONTENT_SIZE,
-  MAXED_OUTPUT_FILE_SNIPPET_LENGTH,
-  tryCallMCPTool,
-} from "@app/lib/actions/mcp_actions";
+import { tryCallMCPTool } from "@app/lib/actions/mcp_actions";
 import type { MCPServerPersonalAuthenticationRequiredError } from "@app/lib/actions/mcp_authentication";
 import { augmentInputsWithConfiguration } from "@app/lib/actions/mcp_internal_actions/input_configuration";
 import {

--- a/front/lib/actions/mcp_utils.ts
+++ b/front/lib/actions/mcp_utils.ts
@@ -1,7 +1,7 @@
 import { Err, isSupportedImageContentType } from "@dust-tt/client";
 import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
 
-import { MAX_RESOURCE_CONTENT_SIZE } from "@app/lib/actions/mcp_actions";
+import { MAX_RESOURCE_CONTENT_SIZE } from "@app/lib/actions/action_output_limits";
 import {
   isBlobResource,
   isSearchQueryResourceType,


### PR DESCRIPTION
## Description

Task: Add more tools to conversation_files tool to handle very large files. [#3707](https://github.com/dust-tt/tasks/issues/3707)


On this PR: 
- Add a `cat` tool to conversation_files
- Set a limit for `include` tool cause trying to include a huge file breaks my local. 

## Tests

Locally. 

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

Deploy front. 