### PR TITLE
[connectors] Refactor `cacheWithRedis` signature

### DIFF
--- a/connectors/src/connectors/google_drive/lib.ts
+++ b/connectors/src/connectors/google_drive/lib.ts
@@ -120,7 +120,9 @@ export const getLocalParents = cacheWithRedis(
   (connectorId, contentNodeInternalId, memoizationKey) => {
     return `${connectorId}:${contentNodeInternalId}:${memoizationKey}`;
   },
-  60 * 10 * 1000
+  {
+    ttlMs: 60 * 10 * 1000,
+  }
 );
 
 export async function internalDeleteFile(

--- a/connectors/src/connectors/google_drive/lib/google_drive_api.ts
+++ b/connectors/src/connectors/google_drive/lib/google_drive_api.ts
@@ -66,7 +66,9 @@ const cachedGetGoogleDriveObject = cacheWithRedis<
   ({ driveObjectId, cacheKey }) => {
     return `${cacheKey.connectorId}:${driveObjectId}:${cacheKey.ts}`;
   },
-  60 * 10 * 1000
+  {
+    ttlMs: 60 * 10 * 1000,
+  }
 );
 
 export async function getGoogleDriveObject({

--- a/connectors/src/connectors/google_drive/lib/hierarchy.ts
+++ b/connectors/src/connectors/google_drive/lib/hierarchy.ts
@@ -103,5 +103,7 @@ export const getFileParentsMemoized = cacheWithRedis(
 
     return cacheKey;
   },
-  60 * 10 * 1000
+  {
+    ttlMs: 60 * 10 * 1000,
+  }
 );

--- a/connectors/src/connectors/google_drive/temporal/utils.ts
+++ b/connectors/src/connectors/google_drive/temporal/utils.ts
@@ -50,7 +50,9 @@ export const getMyDriveIdCached = cacheWithRedis(
     }
     return auth_credentials.credentials.access_token;
   },
-  60 * 10 * 1000 // 10 minutes
+  {
+    ttlMs: 60 * 10 * 1000, // 10 minutes
+  }
 );
 
 // Turn the labels into a string array of formatted string such as labelTitle:labelValue
@@ -289,7 +291,9 @@ export const getCachedLabels = cacheWithRedis(
     }
     return `${connectorId}-labels`;
   },
-  60 * 10 * 1000 // 10 minutes
+  {
+    ttlMs: 60 * 10 * 1000, // 10 minutes
+  }
 );
 
 // Get the list of published labels

--- a/connectors/src/connectors/microsoft/lib/utils.ts
+++ b/connectors/src/connectors/microsoft/lib/utils.ts
@@ -102,7 +102,9 @@ export const getCachedListColumns = cacheWithRedis(
   ({ siteId, listId }) => {
     return `${siteId}-${listId}`;
   },
-  60 * 10 * 1000 // 10 minutes
+  {
+    ttlMs: 60 * 10 * 1000, // 10 minutes
+  }
 );
 
 export async function _getListColumns({

--- a/connectors/src/connectors/microsoft/temporal/activities.ts
+++ b/connectors/src/connectors/microsoft/temporal/activities.ts
@@ -1306,7 +1306,9 @@ const cachedGetParentFromGraphAPI = cacheWithRedis(
     startGarbageCollectionTs: number;
   }) =>
     `microsoft-garbage-collection-ts-${startGarbageCollectionTs}-node-${parentInternalId}`,
-  60 * 60 * 24 * 1000
+  {
+    ttlMs: 60 * 60 * 24 * 1000,
+  }
 );
 
 async function isOutsideRootNodes({

--- a/connectors/src/connectors/microsoft/temporal/file.ts
+++ b/connectors/src/connectors/microsoft/temporal/file.ts
@@ -474,7 +474,9 @@ const getParentId = cacheWithRedis(
   },
   (connectorId, internalId, startSyncTs) =>
     `microsoft-${connectorId}-parent-${internalId}-syncms-${startSyncTs}`,
-  PARENT_SYNC_CACHE_TTL_MS
+  {
+    ttlMs: PARENT_SYNC_CACHE_TTL_MS,
+  }
 );
 
 export async function deleteFolder({

--- a/connectors/src/connectors/notion/lib/notion_api.ts
+++ b/connectors/src/connectors/notion/lib/notion_api.ts
@@ -576,7 +576,9 @@ export const getBlockParentMemoized = cacheWithRedis(
   ) => {
     return blockId;
   },
-  60 * 10 * 1000
+  {
+    ttlMs: 60 * 10 * 1000,
+  }
 );
 
 export async function getParsedDatabase(

--- a/connectors/src/connectors/notion/lib/parents.ts
+++ b/connectors/src/connectors/notion/lib/parents.ts
@@ -123,7 +123,9 @@ export const getParents = cacheWithRedis(
     return `${connectorId}:${pageOrDbId}:${memoizationKey}`;
   },
   // parents should be stable over the maximum time if memoized (almost a day).
-  23 * 60 * 60 * 1000
+  {
+    ttlMs: 23 * 60 * 60 * 1000,
+  }
 );
 
 export async function updateAllParentsFields(

--- a/connectors/src/connectors/slack/lib/bot_user_helpers.ts
+++ b/connectors/src/connectors/slack/lib/bot_user_helpers.ts
@@ -39,7 +39,9 @@ async function getBotUserId(
 export const getBotUserIdMemoized = cacheWithRedis(
   getBotUserId,
   (slackClient, connectorId) => connectorId.toString(),
-  60 * 10 * 1000
+  {
+    ttlMs: 60 * 10 * 1000,
+  }
 );
 
 export async function getUserName(
@@ -158,7 +160,9 @@ async function getBotName({
 export const getBotNameMemoized = cacheWithRedis(
   getBotName,
   ({ botId, connectorId }) => `slack-bot-name-${connectorId}-${botId}`,
-  BOT_NAME_CACHE_TTL
+  {
+    ttlMs: BOT_NAME_CACHE_TTL,
+  }
 );
 
 export async function isWhitelistedBotOrWorkflow(

--- a/connectors/src/connectors/slack/lib/channels.ts
+++ b/connectors/src/connectors/slack/lib/channels.ts
@@ -273,7 +273,9 @@ export const getChannels = cacheWithRedis(
   _getChannelsUncached,
   (slackClient, connectorId, joinedOnly) =>
     `slack-channels-${connectorId}-${joinedOnly}`,
-  5 * 60 * 1000
+  {
+    ttlMs: 5 * 60 * 1000,
+  }
 );
 
 async function _getChannelsUncached(

--- a/connectors/src/connectors/slack/lib/workspace_limits.ts
+++ b/connectors/src/connectors/slack/lib/workspace_limits.ts
@@ -58,7 +58,9 @@ export const getActiveMemberEmailsMemoized = cacheWithRedis(
   },
   // Caches data for 2 minutes to limit frequent API calls.
   // Note: Updates (e.g., new members added by an admin) may take up to 2 minutes to be reflected.
-  2 * 10 * 1000
+  {
+    ttlMs: 2 * 10 * 1000,
+  }
 );
 
 async function getVerifiedDomainsForWorkspace(
@@ -88,7 +90,9 @@ export const getVerifiedDomainsForWorkspaceMemoized = cacheWithRedis(
   },
   // Caches data for 15 minutes to limit frequent API calls.
   // Note: Updates (e.g., workspace verified domains) may take up to 15 minutes to be reflected.
-  15 * 10 * 1000
+  {
+    ttlMs: 15 * 10 * 1000,
+  }
 );
 
 function getSlackUserEmailFromProfile(

--- a/connectors/src/types/shared/cache.ts
+++ b/connectors/src/types/shared/cache.ts
@@ -38,8 +38,13 @@ type KeyResolver<Args extends unknown[]> = (...args: Args) => string;
 export function cacheWithRedis<T, Args extends unknown[]>(
   fn: CacheableFunction<JsonSerializable<T>, Args>,
   resolver: KeyResolver<Args>,
-  ttlMs: number,
-  redisUri?: string
+  {
+    ttlMs,
+    redisUri,
+  }: {
+    ttlMs: number;
+    redisUri?: string;
+  }
 ): (...args: Args) => Promise<JsonSerializable<T>> {
   if (ttlMs > 60 * 60 * 24 * 1000) {
     throw new Error("ttlMs should be less than 24 hours");


### PR DESCRIPTION
## Description

- This PR changes the signature of `cacheWithRedis` to take in input an object. The goal is to name each parameter, instead of having a number value passed directly we know it's the TTL in ms.

## Tests

- `tsc`

## Risk

- Very low.

## Deploy Plan

- Deploy connectors.
