### PR TITLE
Remove @auth0/nextjs-auth0

### DIFF
--- a/front/components/app/RootLayout.tsx
+++ b/front/components/app/RootLayout.tsx
@@ -1,4 +1,3 @@
-import { UserProvider } from "@auth0/nextjs-auth0/client";
 import { SparkleContext } from "@dust-tt/sparkle";
 import { Notification } from "@dust-tt/sparkle";
 import Link from "next/link";
@@ -87,13 +86,11 @@ export default function RootLayout({
           },
         }}
       >
-        <UserProvider>
-          <SidebarProvider>
-            <ConfirmPopupArea>
-              <Notification.Area>{children}</Notification.Area>
-            </ConfirmPopupArea>
-          </SidebarProvider>
-        </UserProvider>
+        <SidebarProvider>
+          <ConfirmPopupArea>
+            <Notification.Area>{children}</Notification.Area>
+          </ConfirmPopupArea>
+        </SidebarProvider>
       </SWRConfig>
     </SparkleContext.Provider>
   );

--- a/front/package-lock.json
+++ b/front/package-lock.json
@@ -5,7 +5,6 @@
   "packages": {
     "": {
       "dependencies": {
-        "@auth0/nextjs-auth0": "^3.5.0",
         "@datadog/browser-logs": "^6.13.0",
         "@dust-tt/client": "file:../sdks/js",
         "@dust-tt/sparkle": "^0.2.548",
@@ -506,28 +505,6 @@
       "dev": true,
       "engines": {
         "node": "20 || >=22"
-      }
-    },
-    "node_modules/@auth0/nextjs-auth0": {
-      "version": "3.6.0",
-      "resolved": "https://registry.npmjs.org/@auth0/nextjs-auth0/-/nextjs-auth0-3.6.0.tgz",
-      "integrity": "sha512-d29jmwmmmhQKJBrdBHQNlBf4rZLH/qz1522cyf8HQTGQYXqHRLh+X1KOG0FyNkao2GN4Xnb856/o1XIlPt5ELQ==",
-      "dependencies": {
-        "@panva/hkdf": "^1.0.2",
-        "cookie": "^0.7.1",
-        "debug": "^4.3.4",
-        "joi": "^17.6.0",
-        "jose": "^4.9.2",
-        "oauth4webapi": "^2.3.0",
-        "openid-client": "^5.2.1",
-        "tslib": "^2.4.0",
-        "url-join": "^4.0.1"
-      },
-      "engines": {
-        "node": ">=16"
-      },
-      "peerDependencies": {
-        "next": ">=10"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -2269,21 +2246,6 @@
         "node": ">=6"
       }
     },
-    "node_modules/@hapi/hoek": {
-      "version": "9.3.0",
-      "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-9.3.0.tgz",
-      "integrity": "sha512-/c6rf4UJlmHlC9b5BaNvzAcFv7HZ2QHaV0D4/HNlBdvFnvQq8RI4kYdhyPCl7Xj+oWvTWQ8ujhqS53LIgAe6KQ==",
-      "license": "BSD-3-Clause"
-    },
-    "node_modules/@hapi/topo": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/@hapi/topo/-/topo-5.1.0.tgz",
-      "integrity": "sha512-foQZKJig7Ob0BMAYBfcJk8d77QtOe7Wo4ox7ff1lQYoNNAb6jwcY1ncdoy2e9wQZzvNy7ODZCYJkK8kzmcAnAg==",
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "@hapi/hoek": "^9.0.0"
-      }
-    },
     "node_modules/@headlessui/react": {
       "version": "1.7.19",
       "resolved": "https://registry.npmjs.org/@headlessui/react/-/react-1.7.19.tgz",
@@ -3893,13 +3855,6 @@
       "license": "Apache-2.0",
       "engines": {
         "node": ">=14"
-      }
-    },
-    "node_modules/@panva/hkdf": {
-      "version": "1.1.1",
-      "license": "MIT",
-      "funding": {
-        "url": "https://github.com/sponsors/panva"
       }
     },
     "node_modules/@paralleldrive/cuid2": {
@@ -7982,27 +7937,6 @@
       "engines": {
         "node": ">=12.*"
       }
-    },
-    "node_modules/@sideway/address": {
-      "version": "4.1.5",
-      "resolved": "https://registry.npmjs.org/@sideway/address/-/address-4.1.5.tgz",
-      "integrity": "sha512-IqO/DUQHUkPeixNQ8n0JA6102hT9CmaljNTPmQ1u8MEhBo/R4Q8eKLN/vGZxuebwOroDB4cbpjheD4+/sKFK4Q==",
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "@hapi/hoek": "^9.0.0"
-      }
-    },
-    "node_modules/@sideway/formula": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/@sideway/formula/-/formula-3.0.1.tgz",
-      "integrity": "sha512-/poHZJJVjx3L+zVD6g9KgHfYnb443oi7wLu/XKojDviHy6HOEOA6z1Trk5aR1dGcmPenJEgb2sK2I80LeS3MIg==",
-      "license": "BSD-3-Clause"
-    },
-    "node_modules/@sideway/pinpoint": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@sideway/pinpoint/-/pinpoint-2.0.0.tgz",
-      "integrity": "sha512-RNiOoTPkptFtSVzQevY/yWtZwf/RxyVnPy/OcA9HBM3MlGDnBEYL5B41H0MTn0Uec8Hi+2qUtTfG2WWZBmMejQ==",
-      "license": "BSD-3-Clause"
     },
     "node_modules/@sindresorhus/is": {
       "version": "4.6.0",
@@ -18313,17 +18247,6 @@
         "jiti": "lib/jiti-cli.mjs"
       }
     },
-    "node_modules/joi": {
-      "version": "17.12.2",
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "@hapi/hoek": "^9.3.0",
-        "@hapi/topo": "^5.1.0",
-        "@sideway/address": "^4.1.5",
-        "@sideway/formula": "^3.0.1",
-        "@sideway/pinpoint": "^2.0.0"
-      }
-    },
     "node_modules/jose": {
       "version": "4.15.5",
       "license": "MIT",
@@ -21156,13 +21079,6 @@
       "integrity": "sha512-F1I/bimDpj3ncaNDhfyMWuFqmQDBwDB0Fogc2qpL3BWvkQteFD/8BzWuIRl83rq0DXfm8SGt/HFhLXZyljTXcQ==",
       "dev": true
     },
-    "node_modules/oauth4webapi": {
-      "version": "2.10.3",
-      "license": "MIT",
-      "funding": {
-        "url": "https://github.com/sponsors/panva"
-      }
-    },
     "node_modules/object-assign": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
@@ -21170,15 +21086,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
-      }
-    },
-    "node_modules/object-hash": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/object-hash/-/object-hash-2.2.0.tgz",
-      "integrity": "sha512-gScRMn0bS5fH+IuwyIFgnh9zBdo4DV+6GhygmWM9HyNJSgS0hScp1f5vjtm7oIIOiT9trXrShAkLFSc2IqKNgw==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 6"
       }
     },
     "node_modules/object-inspect": {
@@ -21293,13 +21200,6 @@
       "integrity": "sha512-PX1wu0AmAdPqOL1mWhqmlOd8kOIZQwGZw6rh7uby9fTc5lhaOWFLX3I6R1hrF9k3zUY40e6igsLGkDXK92LJNg==",
       "dev": true
     },
-    "node_modules/oidc-token-hash": {
-      "version": "5.0.3",
-      "license": "MIT",
-      "engines": {
-        "node": "^10.13.0 || >=12.0.0"
-      }
-    },
     "node_modules/on-exit-leak-free": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/on-exit-leak-free/-/on-exit-leak-free-2.1.2.tgz",
@@ -21408,31 +21308,6 @@
       "version": "12.1.3",
       "license": "MIT",
       "peer": true
-    },
-    "node_modules/openid-client": {
-      "version": "5.6.1",
-      "license": "MIT",
-      "dependencies": {
-        "jose": "^4.15.1",
-        "lru-cache": "^6.0.0",
-        "object-hash": "^2.2.0",
-        "oidc-token-hash": "^5.0.3"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/panva"
-      }
-    },
-    "node_modules/openid-client/node_modules/lru-cache": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
-      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-      "license": "ISC",
-      "dependencies": {
-        "yallist": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      }
     },
     "node_modules/opentracing": {
       "version": "0.14.7",
@@ -27416,12 +27291,6 @@
       "resolved": "https://registry.npmjs.org/uri-js-replace/-/uri-js-replace-1.0.1.tgz",
       "integrity": "sha512-W+C9NWNLFOoBI2QWDp4UT9pv65r2w5Cx+3sTYFvtMdDBxkKt1syCqsUdSFAChbEe1uK5TfS04wt/nGwmaeIQ0g==",
       "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/url-join": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/url-join/-/url-join-4.0.1.tgz",
-      "integrity": "sha512-jk1+QP6ZJqyOiuEI9AEWQfju/nB2Pw466kbA0LEZljHwKeMgd9WrAEgEGxjPDD2+TNbbb37rTyhEfrCXfuKXnA==",
       "license": "MIT"
     },
     "node_modules/url-parse": {

--- a/front/package.json
+++ b/front/package.json
@@ -22,7 +22,6 @@
     "debug:profiler": "tsx ./scripts/debug/run_profiler.ts"
   },
   "dependencies": {
-    "@auth0/nextjs-auth0": "^3.5.0",
     "@datadog/browser-logs": "^6.13.0",
     "@dust-tt/client": "file:../sdks/js",
     "@dust-tt/sparkle": "^0.2.548",


### PR DESCRIPTION
## Description

Remove @auth0/nextjs-auth0 dependency from the front-end application. This cleanup removes unused Auth0 Next.js integration code and dependency, reducing bundle size and removing unused imports from RootLayout.tsx.

## Motivation

Spotted via [Datadog RUM](https://app.datadoghq.eu/rum/performance-monitoring?query=%40session.type%3Auser%20%40application.id%3A5e9735e7-87c8-4093-b09f-49d708816bfd&agg_m=%40view.loading_time&fromUser=false&from_ts=1754027894961&to_ts=1754042294961&live=true) 100% of 404 on `/api/auth/me` endpoint

## Tests

Manual verification that the application builds and runs correctly without the @auth0/nextjs-auth0 dependency. Confirmed no breaking changes to existing authentication flows.

## Risk

Low risk. This change removes unused code and dependency. If Auth0 integration was still needed, it would have caused build errors which were not observed. Safe to rollback by reinstalling the dependency if needed.

## Deploy Plan

Standard deployment process. No special considerations needed as this is a dependency removal without functional changes to the application.