### PR TITLE
Don't show the Stakes UI for disabled tools

### DIFF
--- a/front/components/actions/mcp/ToolsList.tsx
+++ b/front/components/actions/mcp/ToolsList.tsx
@@ -158,7 +158,7 @@ export function ToolsList({
                         {tool.description}
                       </p>
                     )}
-                    {serverType === "remote" && (
+                    {serverType === "remote" && toolEnabled && (
                       <>
                         <Card variant="primary" className="flex-col">
                           <div className="heading-sm text-muted-foreground dark:text-muted-foreground-night">


### PR DESCRIPTION
## Description

Small thing I missed in first PR. When a tool is unchecked, we don't want to show the Stakes UI at all, as called out by https://github.com/dust-tt/decisions/issues/492.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
