### PR TITLE
[front] enh(preview): Add a "Reset conversation" button

### DIFF
--- a/front/components/agent_builder/AgentBuilderPreview.tsx
+++ b/front/components/agent_builder/AgentBuilderPreview.tsx
@@ -1,4 +1,4 @@
-import { Button, Spinner } from "@dust-tt/sparkle";
+import { ArrowPathIcon, Button, Spinner } from "@dust-tt/sparkle";
 import React from "react";
 import { useFormContext } from "react-hook-form";
 
@@ -104,16 +104,6 @@ export function AgentBuilderPreview() {
 
     return (
       <div className="flex h-full flex-col">
-        {conversation && (
-          <div className="flex-shrink-0 border-b border-border p-2">
-            <Button
-              variant="ghost"
-              size="sm"
-              onClick={resetConversation}
-              label="Reset conversation"
-            />
-          </div>
-        )}
         <div className="flex-1 overflow-y-auto">
           {conversation && user && (
             <InteractiveContentProvider>
@@ -129,6 +119,17 @@ export function AgentBuilderPreview() {
           )}
         </div>
         <div className="flex-shrink-0 p-4">
+          {conversation && (
+            <div className="mb-2">
+              <Button
+                variant="outline"
+                size="sm"
+                icon={ArrowPathIcon}
+                onClick={resetConversation}
+                label="Reset conversation"
+              />
+            </div>
+          )}
           <AssistantInputBar
             disableButton={isSavingDraftAgent}
             owner={owner}

--- a/front/components/agent_builder/AgentBuilderPreview.tsx
+++ b/front/components/agent_builder/AgentBuilderPreview.tsx
@@ -1,4 +1,4 @@
-import { Spinner } from "@dust-tt/sparkle";
+import { Button, Spinner } from "@dust-tt/sparkle";
 import React from "react";
 import { useFormContext } from "react-hook-form";
 
@@ -68,10 +68,11 @@ export function AgentBuilderPreview() {
     setStickyMentions,
   } = useDraftAgent();
 
-  const { conversation, handleSubmit } = useDraftConversation({
-    draftAgent,
-    getDraftAgent,
-  });
+  const { conversation, handleSubmit, resetConversation } =
+    useDraftConversation({
+      draftAgent,
+      getDraftAgent,
+    });
 
   // Show loading spinner only when the first time we create a draft agent. After that the spinner is shown
   // inside the button in the input bar. This way we don't have to unmount the conversation viewer every time.
@@ -103,6 +104,16 @@ export function AgentBuilderPreview() {
 
     return (
       <div className="flex h-full flex-col">
+        {conversation && (
+          <div className="flex-shrink-0 border-b border-border p-2">
+            <Button
+              variant="ghost"
+              size="sm"
+              onClick={resetConversation}
+              label="Reset conversation"
+            />
+          </div>
+        )}
         <div className="flex-1 overflow-y-auto">
           {conversation && user && (
             <InteractiveContentProvider>

--- a/front/components/agent_builder/hooks/useAgentPreview.ts
+++ b/front/components/agent_builder/hooks/useAgentPreview.ts
@@ -293,9 +293,14 @@ export function useDraftConversation({
     }
   };
 
+  const resetConversation = useCallback(() => {
+    setConversation(null);
+  }, []);
+
   return {
     conversation,
     setConversation,
     handleSubmit,
+    resetConversation,
   };
 }

--- a/front/components/assistant_builder/AssistantBuilderPreviewDrawer.tsx
+++ b/front/components/assistant_builder/AssistantBuilderPreviewDrawer.tsx
@@ -1,4 +1,5 @@
 import {
+  ArrowPathIcon,
   BarChartIcon,
   Button,
   ChatBubbleBottomCenterTextIcon,
@@ -89,13 +90,18 @@ export default function AssistantBuilderRightPanel({
     });
 
   const { user } = useUser();
-  const { conversation, stickyMentions, setStickyMentions, handleSubmit } =
-    useTryAssistantCore({
-      owner,
-      user,
-      assistant: draftAssistant,
-      createDraftAgent,
-    });
+  const {
+    conversation,
+    stickyMentions,
+    setStickyMentions,
+    handleSubmit,
+    resetConversation,
+  } = useTryAssistantCore({
+    owner,
+    user,
+    assistant: draftAssistant,
+    createDraftAgent,
+  });
 
   const isBuilderStateEmpty =
     !builderState.instructions?.trim() && !builderState.actions.length;
@@ -227,6 +233,17 @@ export default function AssistantBuilderRightPanel({
                       )}
                     </div>
                     <div className="shrink-0">
+                      {conversation && (
+                        <div className="mb-2 px-4">
+                          <Button
+                            variant="outline"
+                            size="sm"
+                            icon={ArrowPathIcon}
+                            onClick={resetConversation}
+                            label="Reset conversation"
+                          />
+                        </div>
+                      )}
                       <AssistantInputBar
                         disableButton={isSavingDraftAgent}
                         owner={owner}

--- a/front/components/assistant_builder/TryAssistant.tsx
+++ b/front/components/assistant_builder/TryAssistant.tsx
@@ -270,11 +270,16 @@ export function useTryAssistantCore({
     setStickyMentions([{ configurationId: assistant?.sId as string }]);
   }, [assistant]);
 
+  const resetConversation = useCallback(() => {
+    setConversation(null);
+  }, []);
+
   return {
     stickyMentions,
     setStickyMentions,
     conversation,
     setConversation,
     handleSubmit,
+    resetConversation,
   };
 }


### PR DESCRIPTION
## Description

- This PR adds a button in the agent/assistant builder preview to reset the ongoing conversation with the preview.

<img width="692" height="152" alt="Screenshot 2025-08-01 at 1 20 16 PM" src="https://github.com/user-attachments/assets/192210b3-da58-40b3-9168-06dbd8b4bf5c" />

## Tests

- yes

## Risk

- Low.

## Deploy Plan

- Deploy front.
