### PR TITLE
Add explicit favicon HTML tag to prevent 404 on favicon.ico

### DIFF
--- a/front/components/home/LandingLayout.tsx
+++ b/front/components/home/LandingLayout.tsx
@@ -257,6 +257,7 @@ const Header = () => {
     <Head>
       <title>Accelerate your entire organization with custom AI agents</title>
       <link rel="shortcut icon" href="/static/favicon.png" />
+      <link rel="icon" type="image/png" href="/static/favicon.png" />
       <link
         rel="preload"
         href="/static/fonts/Geist-Regular.woff2"

--- a/front/components/sparkle/AppRootLayout.tsx
+++ b/front/components/sparkle/AppRootLayout.tsx
@@ -43,6 +43,7 @@ export default function AppRootLayout({
       <WelcomeTourGuideProvider>
         <Head>
           <link rel="shortcut icon" href="/static/favicon.png" />
+          <link rel="icon" type="image/png" href="/static/favicon.png" />
 
           <meta name="apple-mobile-web-app-title" content="Dust" />
           <link rel="apple-touch-icon" href="/static/AppIcon.png" />

--- a/front/components/sparkle/OnboardingLayout.tsx
+++ b/front/components/sparkle/OnboardingLayout.tsx
@@ -21,6 +21,7 @@ export default function OnboardingLayout({
       <Head>
         <title>{`Dust - ${owner.name || "Onboarding"}`}</title>
         <link rel="shortcut icon" href="/static/favicon.png" />
+        <link rel="icon" type="image/png" href="/static/favicon.png" />
 
         <meta name="apple-mobile-web-app-title" content="Dust" />
         <link rel="apple-touch-icon" href="/static/AppIcon.png" />

--- a/front/pages/share/file/[shortToken].tsx
+++ b/front/pages/share/file/[shortToken].tsx
@@ -34,6 +34,7 @@ export default function SharedFilePage({ shortToken }: SharedFilePageProps) {
         <meta name="description" content="Shared interactive content" />
         <meta name="robots" content="noindex, nofollow" />
         <link rel="shortcut icon" href="/static/favicon.png" />
+        <link rel="icon" type="image/png" href="/static/favicon.png" />
       </Head>
       <div className="flex h-screen w-full">
         <PublicInteractiveContentContainer shareToken={shortToken} />


### PR DESCRIPTION
## Description

Fixes 404 errors for favicon.ico requests reported in Datadog RUM by adding explicit favicon HTML tags to layout components.

Previously, browsers were making automatic requests to `/favicon.ico` which resulted in 404 errors since the application uses `/static/favicon.png`. This change adds standard `<link rel="icon" type="image/png" href="/static/favicon.png" />` tags alongside existing legacy `rel="shortcut icon"` tags to explicitly tell browsers where to find the favicon, preventing the default `/favicon.ico` requests.

## Tests

Tested manually by verifying that browsers no longer request `/favicon.ico` when explicit favicon meta tags are present in the HTML head. The solution addresses the root cause by providing proper favicon declarations in all major layout components.

## Risk

Low risk change that only adds HTML meta tags without modifying application logic. The changes are purely additive and maintain backward compatibility by keeping existing `rel="shortcut icon"` tags. Safe to rollback by removing the added lines.

## Deploy Plan

Standard deployment process. No special considerations needed as this is a frontend-only change that improves browser behavior without affecting functionality.