### PR TITLE
Allow multiple remote mcp server with same url

### DIFF
--- a/front/components/actions/mcp/RemoteMCPForm.tsx
+++ b/front/components/actions/mcp/RemoteMCPForm.tsx
@@ -19,7 +19,6 @@ import { Controller, useForm } from "react-hook-form";
 import { z } from "zod";
 
 import { DEFAULT_MCP_ACTION_DESCRIPTION } from "@app/lib/actions/constants";
-import { getMcpServerDisplayName } from "@app/lib/actions/mcp_helper";
 import { isDefaultRemoteMcpServerURL } from "@app/lib/actions/mcp_internal_actions/remote_servers";
 import type { RemoteMCPServerType } from "@app/lib/api/mcp";
 import {
@@ -52,8 +51,9 @@ export function RemoteMCPForm({ owner, mcpServer }: RemoteMCPFormProps) {
   const form = useForm<MCPFormType>({
     resolver: zodResolver(MCPFormSchema),
     defaultValues: {
-      name: getMcpServerDisplayName(mcpServer),
-      description: mcpServer.description,
+      name: mcpServer.name || mcpServer.cachedName,
+      description:
+        (mcpServer.description || mcpServer.cachedDescription) ?? undefined,
       icon: mcpServer.icon,
       sharedSecret: mcpServer.sharedSecret || "",
     },

--- a/front/lib/actions/mcp_helper.ts
+++ b/front/lib/actions/mcp_helper.ts
@@ -102,9 +102,6 @@ export function getMcpServerViewDisplayName(
   view: MCPServerViewType,
   action?: AssistantBuilderMCPConfiguration | AgentBuilderAction
 ) {
-  if (view.name) {
-    return view.name;
-  }
   return getMcpServerDisplayName(view.server, action);
 }
 

--- a/front/lib/actions/mcp_helper.ts
+++ b/front/lib/actions/mcp_helper.ts
@@ -102,6 +102,9 @@ export function getMcpServerViewDisplayName(
   view: MCPServerViewType,
   action?: AssistantBuilderMCPConfiguration | AgentBuilderAction
 ) {
+  if (view.name) {
+    return view.name;
+  }
   return getMcpServerDisplayName(view.server, action);
 }
 

--- a/front/lib/api/mcp.ts
+++ b/front/lib/api/mcp.ts
@@ -65,6 +65,7 @@ export interface MCPServerViewType {
   id: ModelId;
   sId: string;
   name: string | null; // Can be null if the user did not set a custom name.
+  description: string | null; // Can be null if the user did not set a custom description.
   createdAt: number;
   updatedAt: number;
   spaceId: string;

--- a/front/lib/api/mcp.ts
+++ b/front/lib/api/mcp.ts
@@ -64,6 +64,7 @@ export type RemoteMCPServerType = MCPServerType & {
 export interface MCPServerViewType {
   id: ModelId;
   sId: string;
+  name: string | null; // Can be null if the user did not set a custom name.
   createdAt: number;
   updatedAt: number;
   spaceId: string;

--- a/front/lib/models/assistant/actions/mcp_server_view.ts
+++ b/front/lib/models/assistant/actions/mcp_server_view.ts
@@ -21,8 +21,9 @@ export class MCPServerViewModel extends SoftDeletableWorkspaceAwareModel<MCPServ
   declare internalMCPServerId: string | null;
   declare remoteMCPServerId: ForeignKey<RemoteMCPServerModel["id"]> | null;
 
-  // Can be null if the user did not set a custom name.
-  //declare name: string | null;
+  // Can be null if the user did not set a custom name or description.
+  declare name: string | null;
+  declare description: string | null;
 
   declare vaultId: ForeignKey<SpaceModel["id"]>;
 
@@ -53,6 +54,14 @@ MCPServerViewModel.init(
       validate: {
         isIn: [["internal", "remote"]],
       },
+    },
+    name: {
+      type: DataTypes.STRING,
+      allowNull: true,
+    },
+    description: {
+      type: DataTypes.STRING,
+      allowNull: true,
     },
     internalMCPServerId: {
       type: DataTypes.STRING,
@@ -92,6 +101,14 @@ MCPServerViewModel.init(
         },
         unique: true,
         name: "mcp_server_views_workspace_remote_mcp_server_vault_active",
+      },
+      {
+        fields: ["workspaceId", "name", "vaultId"],
+        where: {
+          deletedAt: null,
+        },
+        unique: true,
+        name: "mcp_server_views_workspace_name_vault_active",
       },
       {
         fields: ["workspaceId", "internalMCPServerId", "vaultId"],

--- a/front/lib/models/assistant/actions/mcp_server_view.ts
+++ b/front/lib/models/assistant/actions/mcp_server_view.ts
@@ -21,6 +21,9 @@ export class MCPServerViewModel extends SoftDeletableWorkspaceAwareModel<MCPServ
   declare internalMCPServerId: string | null;
   declare remoteMCPServerId: ForeignKey<RemoteMCPServerModel["id"]> | null;
 
+  // Can be null if the user did not set a custom name.
+  //declare name: string | null;
+
   declare vaultId: ForeignKey<SpaceModel["id"]>;
 
   declare editedByUser: NonAttribute<UserModel>;

--- a/front/lib/models/assistant/actions/remote_mcp_server.ts
+++ b/front/lib/models/assistant/actions/remote_mcp_server.ts
@@ -100,5 +100,12 @@ RemoteMCPServerModel.init(
   {
     sequelize: frontSequelize,
     modelName: "remote_mcp_server",
+    indexes: [
+      {
+        fields: ["workspaceId", "name"],
+        unique: true,
+        name: "remote_mcp_server_workspace_name",
+      },
+    ],
   }
 );

--- a/front/lib/resources/mcp_server_view_resource.ts
+++ b/front/lib/resources/mcp_server_view_resource.ts
@@ -193,9 +193,11 @@ export class MCPServerViewResource extends ResourceWithSpace<MCPServerViewModel>
         serverType,
         internalMCPServerId: serverType === "internal" ? mcpServerId : null,
         remoteMCPServerId: serverType === "remote" ? id : null,
-        // Always copy the oAuthUseCase from the system view to the custom view.
+        // Always copy the oAuthUseCase, name and description from the system view to the custom view.
         // This way, it's always available on the MCP server view without having to fetch the system view.
         oAuthUseCase: systemView.oAuthUseCase,
+        name: systemView.name,
+        description: systemView.description,
       },
       space,
       auth.user() ?? undefined,

--- a/front/lib/resources/mcp_server_view_resource.ts
+++ b/front/lib/resources/mcp_server_view_resource.ts
@@ -682,6 +682,7 @@ export class MCPServerViewResource extends ResourceWithSpace<MCPServerViewModel>
     return {
       id: this.id,
       sId: this.sId,
+      name: null,
       createdAt: this.createdAt.getTime(),
       updatedAt: this.updatedAt.getTime(),
       spaceId: this.space.sId,

--- a/front/lib/resources/mcp_server_view_resource.ts
+++ b/front/lib/resources/mcp_server_view_resource.ts
@@ -683,6 +683,7 @@ export class MCPServerViewResource extends ResourceWithSpace<MCPServerViewModel>
       id: this.id,
       sId: this.sId,
       name: null,
+      description: null,
       createdAt: this.createdAt.getTime(),
       updatedAt: this.updatedAt.getTime(),
       spaceId: this.space.sId,

--- a/front/lib/resources/remote_mcp_servers_resource.ts
+++ b/front/lib/resources/remote_mcp_servers_resource.ts
@@ -159,13 +159,31 @@ export class RemoteMCPServerResource extends BaseResource<RemoteMCPServerModel> 
     return this.baseFetch(auth);
   }
 
+  /**
+   * Find remote MCP servers by URL within the authenticated workspace.
+   * Note: Multiple servers with the same URL can exist per workspace,
+   * as users may configure the same remote server with different settings
+   * (e.g., different authentication methods, use cases, or permissions).
+   */
   static async findByUrl(auth: Authenticator, url: string) {
-    const servers = await this.baseFetch(auth, {
+    return this.baseFetch(auth, {
       where: {
         url,
       },
     });
+  }
 
+  /**
+   * Find a remote MCP server by name within the authenticated workspace.
+   * Note: Only one server with the same name can exist per workspace,
+   * as server names must be unique within a workspace scope.
+   */
+  static async findByName(auth: Authenticator, name: string) {
+    const servers = await this.baseFetch(auth, {
+      where: {
+        name,
+      },
+    });
     return servers.length > 0 ? servers[0] : null;
   }
 

--- a/front/lib/swr/mcp_servers.ts
+++ b/front/lib/swr/mcp_servers.ts
@@ -865,6 +865,7 @@ const getOptimisticDataForCreate = (
             {
               id: -1, // The ID is not known at optimistic data creation time.
               sId: "global",
+              name: null,
               createdAt: Date.now(),
               updatedAt: Date.now(),
               serverType: "internal" as const,

--- a/front/lib/swr/mcp_servers.ts
+++ b/front/lib/swr/mcp_servers.ts
@@ -866,6 +866,7 @@ const getOptimisticDataForCreate = (
               id: -1, // The ID is not known at optimistic data creation time.
               sId: "global",
               name: null,
+              description: null,
               createdAt: Date.now(),
               updatedAt: Date.now(),
               serverType: "internal" as const,

--- a/front/migrations/db/migration_325.sql
+++ b/front/migrations/db/migration_325.sql
@@ -1,0 +1,2 @@
+-- Migration created on Aug 01, 2025
+CREATE UNIQUE INDEX "remote_mcp_server_workspace_name" ON "remote_mcp_servers" ("workspaceId", "name");

--- a/front/migrations/db/migration_325.sql
+++ b/front/migrations/db/migration_325.sql
@@ -1,2 +1,12 @@
 -- Migration created on Aug 01, 2025
 CREATE UNIQUE INDEX "remote_mcp_server_workspace_name" ON "remote_mcp_servers" ("workspaceId", "name");
+
+ALTER TABLE "public"."mcp_server_views"
+ADD COLUMN "name" VARCHAR(255);
+
+ALTER TABLE "public"."mcp_server_views"
+ADD COLUMN "description" VARCHAR(255);
+
+CREATE UNIQUE INDEX "mcp_server_views_workspace_name_vault_active" ON "mcp_server_views" ("workspaceId", "name", "vaultId")
+WHERE
+    "deletedAt" IS NULL;

--- a/front/pages/api/w/[wId]/mcp/index.test.ts
+++ b/front/pages/api/w/[wId]/mcp/index.test.ts
@@ -150,11 +150,8 @@ describe("POST /api/w/[wId]/mcp/", () => {
       await handler(req, res);
 
       expect(res._getStatusCode()).toBe(201);
-      expect(res._getJSONData()).toMatchObject({
-        server: {
-          name: "Test Server (2)",
-        },
-      });
+      const responseData = res._getJSONData();
+      expect(responseData.server.name).toContain("Test Server #");
     }
   );
 });

--- a/front/pages/api/w/[wId]/mcp/index.test.ts
+++ b/front/pages/api/w/[wId]/mcp/index.test.ts
@@ -5,8 +5,27 @@ import { createPrivateApiMockRequest } from "@app/tests/utils/generic_private_ap
 import { RemoteMCPServerFactory } from "@app/tests/utils/RemoteMCPServerFactory";
 import { SpaceFactory } from "@app/tests/utils/SpaceFactory";
 import { itInTransaction } from "@app/tests/utils/utils";
+import { Ok } from "@app/types";
 
 import handler from "./index";
+
+// Mock the data_sources module to spy on upsertTable
+vi.mock(
+  import("../../../../../lib/actions/mcp_metadata"),
+  async (importOriginal) => {
+    const mod = await importOriginal();
+    return {
+      ...mod,
+      fetchRemoteServerMetaDataByURL: vi.fn().mockImplementation(() => {
+        return new Ok({
+          name: "Test Server",
+          description: "Test description",
+          tools: [{ name: "test-tool", description: "Test tool description" }],
+        });
+      }),
+    };
+  }
+);
 
 async function setupTest(
   t: any,
@@ -116,13 +135,13 @@ describe("POST /api/w/[wId]/mcp/", () => {
   });
 
   itInTransaction(
-    "should return 400 when server with URL already exists",
+    "should append a number to the name when server with URL already exists",
     async (t) => {
       const { req, res, workspace } = await setupTest(t, "admin", "POST");
 
       const existingUrl = "https://existing-server.example.com";
       await RemoteMCPServerFactory.create(workspace, {
-        name: "Existing Server",
+        name: "Test Server",
         url: existingUrl,
       });
 
@@ -130,11 +149,10 @@ describe("POST /api/w/[wId]/mcp/", () => {
 
       await handler(req, res);
 
-      expect(res._getStatusCode()).toBe(400);
-      expect(res._getJSONData()).toEqual({
-        error: {
-          type: "invalid_request_error",
-          message: "A server with this URL already exists",
+      expect(res._getStatusCode()).toBe(201);
+      expect(res._getJSONData()).toMatchObject({
+        server: {
+          name: "Test Server (2)",
         },
       });
     }

--- a/front/pages/api/w/[wId]/mcp/index.ts
+++ b/front/pages/api/w/[wId]/mcp/index.ts
@@ -128,21 +128,6 @@ async function handler(
           });
         }
 
-        const existingServer = await RemoteMCPServerResource.findByUrl(
-          auth,
-          url
-        );
-
-        if (existingServer) {
-          return apiError(req, res, {
-            status_code: 400,
-            api_error: {
-              type: "invalid_request_error",
-              message: "A server with this URL already exists",
-            },
-          });
-        }
-
         // Default to the shared secret if it exists.
         let bearerToken = sharedSecret || null;
         let authorization: AuthorizationInfo | null = null;
@@ -197,10 +182,21 @@ async function handler(
           (config) => config.url === url
         );
 
+        let name = defaultConfig?.name || metadata.name;
+
+        const existingServer = await RemoteMCPServerResource.findByName(
+          auth,
+          name
+        );
+
+        if (existingServer) {
+          name = `${name} (2)`;
+        }
+
         const newRemoteMCPServer = await RemoteMCPServerResource.makeNew(auth, {
           workspaceId: auth.getNonNullableWorkspace().id,
           url: url,
-          cachedName: defaultConfig?.name || metadata.name,
+          cachedName: name,
           cachedDescription: defaultConfig?.description || metadata.description,
           cachedTools: metadata.tools,
           icon:
@@ -300,7 +296,7 @@ async function handler(
             status_code: 400,
             api_error: {
               type: "invalid_request_error",
-              message: "A server with this URL already exists",
+              message: "This internal tool has already been added",
             },
           });
         }

--- a/front/pages/api/w/[wId]/mcp/index.ts
+++ b/front/pages/api/w/[wId]/mcp/index.ts
@@ -190,7 +190,9 @@ async function handler(
         );
 
         if (existingServer) {
-          name = `${name} (2)`;
+          const existingServersWithSameUrl =
+            await RemoteMCPServerResource.findByUrl(auth, url);
+          name = `${name} (${existingServersWithSameUrl.length + 1})`;
         }
 
         const newRemoteMCPServer = await RemoteMCPServerResource.makeNew(auth, {

--- a/front/pages/api/w/[wId]/mcp/index.ts
+++ b/front/pages/api/w/[wId]/mcp/index.ts
@@ -21,6 +21,7 @@ import { MCPServerViewResource } from "@app/lib/resources/mcp_server_view_resour
 import { RemoteMCPServerToolMetadataResource } from "@app/lib/resources/remote_mcp_server_tool_metadata_resource";
 import { RemoteMCPServerResource } from "@app/lib/resources/remote_mcp_servers_resource";
 import { SpaceResource } from "@app/lib/resources/space_resource";
+import { generateRandomModelSId } from "@app/lib/resources/string_ids";
 import { concurrentExecutor } from "@app/lib/utils/async_utils";
 import logger from "@app/logger/logger";
 import { apiError } from "@app/logger/withlogging";
@@ -190,9 +191,8 @@ async function handler(
         );
 
         if (existingServer) {
-          const existingServersWithSameUrl =
-            await RemoteMCPServerResource.findByUrl(auth, url);
-          name = `${name} (${existingServersWithSameUrl.length + 1})`;
+          const uuid = generateRandomModelSId();
+          name = `${name} #${uuid.substring(0, 4).toLowerCase()}`;
         }
 
         const newRemoteMCPServer = await RemoteMCPServerResource.makeNew(auth, {

--- a/front/tests/utils/RemoteMCPServerFactory.ts
+++ b/front/tests/utils/RemoteMCPServerFactory.ts
@@ -17,7 +17,7 @@ export class RemoteMCPServerFactory {
       tools?: MCPToolType[];
     } = {}
   ) {
-    const cachedName = options.name || "Test Server";
+    const cachedName = options.name || "Test Server" + faker.number.int(1000);
     const url = options.url || `https://${faker.internet.domainName()}`;
     const cachedDescription = options.description || `${name} description`;
     const tools: MCPToolType[] = options.tools || [


### PR DESCRIPTION
## Description

- Remove the check on url and auto append number to the name
- Add unique index on `remote_server`: name & workspaceId
- Add unique index on `mcp_server_view`: name & workspaceId & vaultId (aka spaceId)

Next: will remove name & description from `remote_mcp_server` table to use `mcp_server_view` instead, that way both internal remote mcp servers will be able to override name and description.

## Tests

Updated + local

## Risk

Low

## Deploy Plan

Block, migrate, unblock, deploy