### PR TITLE
[front] refactor: remove `getFull/LightAgentConfiguration` functions

### DIFF
--- a/front/lib/api/assistant/configuration/agent.ts
+++ b/front/lib/api/assistant/configuration/agent.ts
@@ -254,30 +254,6 @@ export async function getAgentConfiguration<V extends AgentFetchVariant>(
   });
 }
 
-export async function getLightAgentConfiguration(
-  auth: Authenticator,
-  agentId: string
-): Promise<LightAgentConfigurationType | null> {
-  return getAgentConfiguration(auth, { agentId, variant: "light" });
-}
-
-export async function getFullAgentConfiguration(
-  auth: Authenticator,
-  configuration: LightAgentConfigurationType
-): Promise<AgentConfigurationType> {
-  const fullConfiguration = await getAgentConfiguration(auth, {
-    agentId: configuration.sId,
-    variant: "full",
-  });
-
-  assert(
-    fullConfiguration,
-    "Unreachable: could not find detailed configuration for agent"
-  );
-
-  return fullConfiguration;
-}
-
 /**
  * Search agent configurations by name.
  */

--- a/front/pages/api/v1/w/[wId]/assistant/agent_configurations/[sId]/index.ts
+++ b/front/pages/api/v1/w/[wId]/assistant/agent_configurations/[sId]/index.ts
@@ -3,7 +3,7 @@ import { PatchAgentConfigurationRequestSchema } from "@dust-tt/client";
 import type { NextApiRequest, NextApiResponse } from "next";
 import { fromError } from "zod-validation-error";
 
-import { getLightAgentConfiguration } from "@app/lib/api/assistant/configuration/agent";
+import { getAgentConfiguration } from "@app/lib/api/assistant/configuration/agent";
 import { setAgentUserFavorite } from "@app/lib/api/assistant/user_relation";
 import { withPublicAPIAuthentication } from "@app/lib/api/auth_wrappers";
 import type { Authenticator } from "@app/lib/auth";
@@ -121,7 +121,10 @@ async function handler(
     });
   }
 
-  const agentConfiguration = await getLightAgentConfiguration(auth, sId);
+  const agentConfiguration = await getAgentConfiguration(auth, {
+    agentId: sId,
+    variant: "light",
+  });
 
   if (!agentConfiguration) {
     return apiError(req, res, {


### PR DESCRIPTION
## Description

- This PR inlines the functions `getLightAgentConfiguration` and `getFullAgentConfiguration`. They implicitly fetch the latest version (unlike `getAgentConfiguration` where you can pass the version) + I want to minimize the number of entry points for fetching agent configurations.

## Tests

- Tested locally.

## Risk

- Low, purely a refactoring.

## Deploy Plan

- Deploy front.
