### PR TITLE
Simplify output memory for better styling

### DIFF
--- a/front/lib/actions/mcp_internal_actions/servers/agent_memory.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/agent_memory.ts
@@ -107,9 +107,7 @@ const createServer = (
       content: [
         {
           type: "text",
-          text: memory
-            .map((entry, i) => `[${i}] ${entry.content}`)
-            .join("\n---\n"),
+          text: memory.map((entry, i) => `[${i}] ${entry.content}`).join("\n"),
         },
       ],
     };


### PR DESCRIPTION
## Description

Assuming the "---" was useful to have a pretty display on the tool output. 
This is not necessary anymore since we display the output as markdown. 

Before: 
<kbd>
<img width="702" height="664" alt="Screenshot 2025-08-01 at 15 34 00" src="https://github.com/user-attachments/assets/8226af22-f5a0-4d26-9be2-852a36a585dc" />
</kbd>
After: 
<kbd>
<img width="488" height="568" alt="Screenshot 2025-08-01 at 15 35 43" src="https://github.com/user-attachments/assets/6985d351-5606-4cec-80cf-cd918a175a12" />
</kbd>


## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

Deploy front. 