### PR TITLE
[front] Show title in conversation previews

### DIFF
--- a/front/components/agent_builder/AgentBuilderPreview.tsx
+++ b/front/components/agent_builder/AgentBuilderPreview.tsx
@@ -106,9 +106,9 @@ export function AgentBuilderPreview() {
       <div className="flex h-full flex-col">
         {conversation && (
           <div className="flex items-center justify-between px-4 py-3">
-            <h3 className="text-sm font-medium text-foreground dark:text-foreground-night">
+            <h2 className="font-semibold text-foreground dark:text-foreground-night">
               {conversation.title}
-            </h3>
+            </h2>
             <Button
               variant="outline"
               size="sm"

--- a/front/components/agent_builder/AgentBuilderPreview.tsx
+++ b/front/components/agent_builder/AgentBuilderPreview.tsx
@@ -1,4 +1,4 @@
-import { ArrowPathIcon, Button, Spinner, TrashIcon } from "@dust-tt/sparkle";
+import { ArrowPathIcon, Button, Spinner } from "@dust-tt/sparkle";
 import React from "react";
 import { useFormContext } from "react-hook-form";
 
@@ -68,7 +68,7 @@ export function AgentBuilderPreview() {
     setStickyMentions,
   } = useDraftAgent();
 
-  const { conversation, setConversation, handleSubmit, resetConversation } =
+  const { conversation, handleSubmit, resetConversation } =
     useDraftConversation({
       draftAgent,
       getDraftAgent,
@@ -105,9 +105,10 @@ export function AgentBuilderPreview() {
     return (
       <div className="flex h-full flex-col">
         {conversation && (
-          <div className="flex items-center justify-between border-b border-border px-4 py-3">
-            <h3 className="text-sm font-medium text-foreground">
-              {conversation.title || `Trying @${draftAgent?.name || "your agent"}`}
+          <div className="flex items-center justify-between px-4 py-3">
+            <h3 className="text-sm font-medium text-foreground dark:text-foreground-night">
+              {conversation.title ||
+                `Trying @${draftAgent?.name || "your agent"}`}
             </h3>
             <Button
               variant="outline"

--- a/front/components/agent_builder/AgentBuilderPreview.tsx
+++ b/front/components/agent_builder/AgentBuilderPreview.tsx
@@ -1,4 +1,4 @@
-import { ArrowPathIcon, Button, Spinner } from "@dust-tt/sparkle";
+import { ArrowPathIcon, Button, Spinner, TrashIcon } from "@dust-tt/sparkle";
 import React from "react";
 import { useFormContext } from "react-hook-form";
 
@@ -68,7 +68,7 @@ export function AgentBuilderPreview() {
     setStickyMentions,
   } = useDraftAgent();
 
-  const { conversation, handleSubmit, resetConversation } =
+  const { conversation, setConversation, handleSubmit, resetConversation } =
     useDraftConversation({
       draftAgent,
       getDraftAgent,
@@ -104,6 +104,20 @@ export function AgentBuilderPreview() {
 
     return (
       <div className="flex h-full flex-col">
+        {conversation && (
+          <div className="flex items-center justify-between border-b border-border px-4 py-3">
+            <h3 className="text-sm font-medium text-foreground">
+              {conversation.title || `Trying @${draftAgent?.name || "your agent"}`}
+            </h3>
+            <Button
+              variant="outline"
+              size="sm"
+              icon={ArrowPathIcon}
+              onClick={resetConversation}
+              label="Reset conversation"
+            />
+          </div>
+        )}
         <div className="flex-1 overflow-y-auto">
           {conversation && user && (
             <InteractiveContentProvider>
@@ -119,17 +133,6 @@ export function AgentBuilderPreview() {
           )}
         </div>
         <div className="flex-shrink-0 p-4">
-          {conversation && (
-            <div className="mb-2">
-              <Button
-                variant="outline"
-                size="sm"
-                icon={ArrowPathIcon}
-                onClick={resetConversation}
-                label="Reset conversation"
-              />
-            </div>
-          )}
           <AssistantInputBar
             disableButton={isSavingDraftAgent}
             owner={owner}

--- a/front/components/agent_builder/AgentBuilderPreview.tsx
+++ b/front/components/agent_builder/AgentBuilderPreview.tsx
@@ -107,8 +107,7 @@ export function AgentBuilderPreview() {
         {conversation && (
           <div className="flex items-center justify-between px-4 py-3">
             <h3 className="text-sm font-medium text-foreground dark:text-foreground-night">
-              {conversation.title ||
-                `Trying @${draftAgent?.name || "your agent"}`}
+              {conversation.title}
             </h3>
             <Button
               variant="outline"

--- a/front/components/agent_builder/hooks/useAgentPreview.ts
+++ b/front/components/agent_builder/hooks/useAgentPreview.ts
@@ -13,6 +13,7 @@ import { useMCPServerViewsContext } from "@app/components/assistant_builder/cont
 import { useDebounce } from "@app/hooks/useDebounce";
 import { useSendNotification } from "@app/hooks/useNotification";
 import type { DustError } from "@app/lib/error";
+import { useConversation } from "@app/lib/swr/conversations";
 import { useUser } from "@app/lib/swr/user";
 import type {
   AgentMention,
@@ -197,9 +198,17 @@ export function useDraftConversation({
   const { user } = useUser();
   const sendNotification = useSendNotification();
 
-  const [conversation, setConversation] = useState<ConversationType | null>(
-    null
-  );
+  const [conversationId, setConversationId] = useState<string | null>(null);
+
+  const { conversation: swrConversation } = useConversation({
+    conversationId: conversationId || "",
+    workspaceId: owner.sId,
+    options: {
+      disabled: !conversationId,
+    },
+  });
+
+  const conversation = swrConversation || null;
 
   const conversationTitle = `Trying @${draftAgent?.name || "your agent"}`;
 
@@ -252,7 +261,7 @@ export function useDraftConversation({
       });
 
       if (result.isOk()) {
-        setConversation(result.value);
+        setConversationId(result.value.sId);
         return new Ok(undefined);
       }
 
@@ -296,6 +305,10 @@ export function useDraftConversation({
   const resetConversation = useCallback(() => {
     setConversation(null);
   }, []);
+
+  const setConversation = (newConversation: ConversationType | null) => {
+    setConversationId(newConversation?.sId || null);
+  };
 
   return {
     conversation,

--- a/front/components/agent_builder/hooks/useAgentPreview.ts
+++ b/front/components/agent_builder/hooks/useAgentPreview.ts
@@ -210,8 +210,6 @@ export function useDraftConversation({
 
   const conversation = swrConversation || null;
 
-  const conversationTitle = `Trying @${draftAgent?.name || "your agent"}`;
-
   const handleSubmit = async (
     input: string,
     mentions: MentionType[],
@@ -257,7 +255,6 @@ export function useDraftConversation({
         user,
         messageData,
         visibility: "test",
-        title: conversationTitle,
       });
 
       if (result.isOk()) {

--- a/front/components/assistant_builder/AssistantBuilderPreviewDrawer.tsx
+++ b/front/components/assistant_builder/AssistantBuilderPreviewDrawer.tsx
@@ -90,9 +90,7 @@ export default function AssistantBuilderRightPanel({
     });
 
   const { user } = useUser();
-  const {
-    conversation,
-    stickyMentions,
+  const { conversation, setConversation, stickyMentions,
     setStickyMentions,
     handleSubmit,
     resetConversation,
@@ -218,23 +216,12 @@ export default function AssistantBuilderRightPanel({
               <ConversationsNavigationProvider>
                 <ActionValidationProvider owner={owner}>
                   <GenerationContextProvider>
-                    <div className="flex-grow overflow-y-auto">
+                    <div className="flex h-full flex-col">
                       {conversation && (
-                        <InteractiveContentProvider>
-                          <ConversationViewer
-                            owner={owner}
-                            user={user}
-                            conversationId={conversation.sId}
-                            onStickyMentionsChange={setStickyMentions}
-                            isInModal
-                            key={conversation.sId}
-                          />
-                        </InteractiveContentProvider>
-                      )}
-                    </div>
-                    <div className="shrink-0">
-                      {conversation && (
-                        <div className="mb-2 px-4">
+                        <div className="flex items-center justify-between border-b border-border px-4 py-3">
+                          <h3 className="text-sm font-medium text-foreground">
+                            {conversation.title || `Trying @${draftAssistant?.name || "your assistant"}`}
+                          </h3>
                           <Button
                             variant="outline"
                             size="sm"
@@ -244,19 +231,35 @@ export default function AssistantBuilderRightPanel({
                           />
                         </div>
                       )}
-                      <AssistantInputBar
-                        disableButton={isSavingDraftAgent}
-                        owner={owner}
-                        onSubmit={handleSubmit}
-                        stickyMentions={stickyMentions}
-                        conversationId={conversation?.sId || null}
-                        additionalAgentConfiguration={
-                          draftAssistant ?? undefined
-                        }
-                        actions={["attachment"]}
-                        disableAutoFocus
-                        isFloating={false}
-                      />
+                      <div className="flex-grow overflow-y-auto">
+                        {conversation && (
+                          <InteractiveContentProvider>
+                            <ConversationViewer
+                              owner={owner}
+                              user={user}
+                              conversationId={conversation.sId}
+                              onStickyMentionsChange={setStickyMentions}
+                              isInModal
+                              key={conversation.sId}
+                            />
+                          </InteractiveContentProvider>
+                        )}
+                      </div>
+                      <div className="shrink-0">
+                        <AssistantInputBar
+                          disableButton={isSavingDraftAgent}
+                          owner={owner}
+                          onSubmit={handleSubmit}
+                          stickyMentions={stickyMentions}
+                          conversationId={conversation?.sId || null}
+                          additionalAgentConfiguration={
+                            draftAssistant ?? undefined
+                          }
+                          actions={["attachment"]}
+                          disableAutoFocus
+                          isFloating={false}
+                        />
+                      </div>
                     </div>
                   </GenerationContextProvider>
                 </ActionValidationProvider>

--- a/front/components/assistant_builder/AssistantBuilderPreviewDrawer.tsx
+++ b/front/components/assistant_builder/AssistantBuilderPreviewDrawer.tsx
@@ -90,7 +90,9 @@ export default function AssistantBuilderRightPanel({
     });
 
   const { user } = useUser();
-  const { conversation, setConversation, stickyMentions,
+  const {
+    conversation,
+    stickyMentions,
     setStickyMentions,
     handleSubmit,
     resetConversation,
@@ -218,9 +220,10 @@ export default function AssistantBuilderRightPanel({
                   <GenerationContextProvider>
                     <div className="flex h-full flex-col">
                       {conversation && (
-                        <div className="flex items-center justify-between border-b border-border px-4 py-3">
-                          <h3 className="text-sm font-medium text-foreground">
-                            {conversation.title || `Trying @${draftAssistant?.name || "your assistant"}`}
+                        <div className="flex items-center justify-between px-4 py-3">
+                          <h3 className="text-sm font-medium text-foreground dark:text-foreground-night">
+                            {conversation.title ||
+                              `Trying @${draftAssistant?.name || "your assistant"}`}
                           </h3>
                           <Button
                             variant="outline"

--- a/front/components/assistant_builder/AssistantBuilderPreviewDrawer.tsx
+++ b/front/components/assistant_builder/AssistantBuilderPreviewDrawer.tsx
@@ -222,8 +222,7 @@ export default function AssistantBuilderRightPanel({
                       {conversation && (
                         <div className="flex items-center justify-between px-4 py-3">
                           <h3 className="text-sm font-medium text-foreground dark:text-foreground-night">
-                            {conversation.title ||
-                              `Trying @${draftAssistant?.name || "your assistant"}`}
+                            {conversation.title}
                           </h3>
                           <Button
                             variant="outline"

--- a/front/components/assistant_builder/AssistantBuilderPreviewDrawer.tsx
+++ b/front/components/assistant_builder/AssistantBuilderPreviewDrawer.tsx
@@ -221,9 +221,9 @@ export default function AssistantBuilderRightPanel({
                     <div className="flex h-full flex-col">
                       {conversation && (
                         <div className="flex items-center justify-between px-4 py-3">
-                          <h3 className="text-sm font-medium text-foreground dark:text-foreground-night">
+                          <h2 className="font-semibold text-foreground dark:text-foreground-night">
                             {conversation.title}
-                          </h3>
+                          </h2>
                           <Button
                             variant="outline"
                             size="sm"

--- a/front/components/assistant_builder/TryAssistant.tsx
+++ b/front/components/assistant_builder/TryAssistant.tsx
@@ -175,7 +175,6 @@ export function useTryAssistantCore({
   );
   const sendNotification = useSendNotification();
 
-  // Use SWR hook to get conversation with real-time updates
   const { conversation: swrConversation } = useConversation({
     conversationId: conversationId || "",
     workspaceId: owner.sId,
@@ -238,7 +237,6 @@ export function useTryAssistantCore({
         user,
         messageData,
         visibility: "test",
-        title: `Trying @${currentAssistant?.name}`,
       });
       if (result.isOk()) {
         setConversationId(result.value.sId);

--- a/front/components/assistant_builder/TryAssistant.tsx
+++ b/front/components/assistant_builder/TryAssistant.tsx
@@ -10,6 +10,7 @@ import { submitAssistantBuilderForm } from "@app/components/assistant_builder/su
 import type { AssistantBuilderState } from "@app/components/assistant_builder/types";
 import { useSendNotification } from "@app/hooks/useNotification";
 import type { DustError } from "@app/lib/error";
+import { useConversation } from "@app/lib/swr/conversations";
 import type {
   AgentMention,
   ContentFragmentsType,
@@ -169,10 +170,21 @@ export function useTryAssistantCore({
   const [stickyMentions, setStickyMentions] = useState<AgentMention[]>([
     { configurationId: assistant?.sId as string },
   ]);
-  const [conversation, setConversation] = useState<ConversationType | null>(
-    openWithConversation ?? null
+  const [conversationId, setConversationId] = useState<string | null>(
+    openWithConversation?.sId ?? null
   );
   const sendNotification = useSendNotification();
+
+  // Use SWR hook to get conversation with real-time updates
+  const { conversation: swrConversation } = useConversation({
+    conversationId: conversationId || "",
+    workspaceId: owner.sId,
+    options: {
+      disabled: !conversationId,
+    },
+  });
+
+  const conversation = swrConversation || null;
 
   const handleSubmit = async (
     input: string,
@@ -229,7 +241,7 @@ export function useTryAssistantCore({
         title: `Trying @${currentAssistant?.name}`,
       });
       if (result.isOk()) {
-        setConversation(result.value);
+        setConversationId(result.value.sId);
         return new Ok(undefined);
       }
       sendNotification({
@@ -273,6 +285,10 @@ export function useTryAssistantCore({
   const resetConversation = useCallback(() => {
     setConversation(null);
   }, []);
+
+  const setConversation = (newConversation: ConversationType | null) => {
+    setConversationId(newConversation?.sId || null);
+  };
 
   return {
     stickyMentions,


### PR DESCRIPTION
## Description

- Closes https://github.com/dust-tt/tasks/issues/3709.
- This PR updates the conversation preview in Agent/Assistant Builder to show the title of the ongoing conversation.
- The clear conversation button is also moved up next to the title.

<img width="495" height="180" alt="Screenshot 2025-08-04 at 9 36 06 AM" src="https://github.com/user-attachments/assets/9c1732f3-89f0-4891-a2f5-0d2b2e91adbd" />

## Tests

- Tested locally.

## Risk

- Low, mostly UI.

## Deploy Plan

- Deploy front.
