### PR TITLE
Refine RUM tracking

### DIFF
--- a/front/pages/_document.tsx
+++ b/front/pages/_document.tsx
@@ -63,6 +63,20 @@ class MyDocument extends Document {
                  sessionSampleRate: 100,
                  sessionReplaySampleRate: 5,
                  defaultPrivacyLevel: 'mask',
+                 beforeSend: (event) => {
+                  if (event.type === 'action' && event.action && event.action.target && event.action.target.name && event.action.target.name.includes('@')) {
+                    const el = event._dd && event._dd.target; // Get the actual DOM element from Datadog's internal properties
+                    if (el) {
+                      var selector = el.tagName.toLowerCase();
+                      if (el.id) selector += '#' + el.id;
+                      if (el.className) selector += '.' + el.className.trim().replace(/\\s+/g, '.');
+                      event.action.target.name = selector;
+                    } else {
+                      event.action.target.name = '[redacted]';
+                    }
+                  }
+                  return true;
+                }
                });
              })
            `}

--- a/front/pages/_document.tsx
+++ b/front/pages/_document.tsx
@@ -52,8 +52,16 @@ class MyDocument extends Document {
                  service: 'front',
                  env: '${process.env.NODE_ENV === "production" ? "prod" : "dev"}',
                  version: '${process.env.NEXT_PUBLIC_COMMIT_HASH || ""}',
+                 allowedTracingUrls: [
+                  "https://dust.tt",
+                  "https://eu.dust.tt",
+                  "https://front-edge.dust.tt",
+                  "https://eu.front-edge.dust.tt",
+                 ],
+                 traceSampleRate: 5,
+                 traceContextInjection: 'sampled',
                  sessionSampleRate: 100,
-                 sessionReplaySampleRate: 1,
+                 sessionReplaySampleRate: 5,
                  defaultPrivacyLevel: 'mask',
                });
              })

--- a/front/pages/_document.tsx
+++ b/front/pages/_document.tsx
@@ -37,15 +37,14 @@ class MyDocument extends Document {
           {/* Datadog RUM (Real User Monitoring) - Must be in _document.tsx with beforeInteractive
               strategy to ensure it loads before page becomes interactive and captures all user
               interactions from the beginning. This is the recommended setup for Pages Router. */}
-          {process.env.NEXT_PUBLIC_DATADOG_CLIENT_TOKEN && (
-            <Script id="datadog-rum" strategy="beforeInteractive">
-              {`
+          <Script id="datadog-rum" strategy="beforeInteractive">
+            {`
              (function(h,o,u,n,d) {
                h=h[d]=h[d]||{q:[],onReady:function(c){h.q.push(c)}}
                d=o.createElement(u);d.async=1;d.src=n
                n=o.getElementsByTagName(u)[0];n.parentNode.insertBefore(d,n)
              })(window,document,'script','https://www.datadoghq-browser-agent.com/eu1/v6/datadog-rum.js','DD_RUM')
-             window.DD_RUM.onReady(function() {
+             '${process.env.NEXT_PUBLIC_DATADOG_CLIENT_TOKEN || ""}' && window.DD_RUM.onReady(function() {
                window.DD_RUM.init({
                  clientToken: '${process.env.NEXT_PUBLIC_DATADOG_CLIENT_TOKEN}',
                  applicationId: '5e9735e7-87c8-4093-b09f-49d708816bfd',
@@ -59,8 +58,7 @@ class MyDocument extends Document {
                });
              })
            `}
-            </Script>
-          )}
+          </Script>
         </body>
       </Html>
     );


### PR DESCRIPTION
This PR is better read commit by commit.

## Description

This PR refines the RUM (Real User Monitoring) configuration with two focused improvements:

1. **Enhanced APM and SessionReplay configuration**: Added APM tracing capabilities with proper URL allowlisting, sample rates, and trace context injection for better observability across Dust environments.

2. **Privacy protection for click actions**: Implemented redaction of target names containing sensitive information in click action events to prevent PII leakage in monitoring data (see [saved view](https://app.datadoghq.eu/rum/sessions?saved-view-id=179436))

## Tests

Manual testing to verify:
- APM traces are properly collected and filtered to allowed URLs
- SessionReplay sampling rate adjustment works as expected
- Click actions containing email addresses in target names are properly redacted while preserving useful selector information
- Existing RUM functionality remains unaffected

## Risk

**Low risk** - Changes are additive and privacy-focused:
- APM configuration enhances monitoring without breaking existing functionality
- Privacy redaction only affects events with email addresses in target names
- Fallback to `[redacted]` ensures no monitoring data loss
- Changes are isolated to the RUM initialization in `_document.tsx`

Safe to rollback by reverting the commits if any issues arise.

## Deploy Plan

Standard deployment - no special considerations needed:
1. Deploy to staging and verify RUM data collection
2. Monitor APM traces and SessionReplay data for expected behavior  
3. Deploy to production
4. Verify privacy redaction is working in production RUM data