### PR TITLE
[front] Fix fetching of global agents

### DIFF
--- a/front/types/assistant/agent_run.ts
+++ b/front/types/assistant/agent_run.ts
@@ -137,9 +137,9 @@ export async function getRunAgentData(
   const agentConfiguration = await getAgentConfiguration(auth, {
     agentId: agentMessage.configuration.sId,
     // We do define agentMessage.configuration.version for global agent, ignoring this value here.
-    agentVersion: !isGlobalAgentId(agentMessage.configuration.sId)
-      ? agentMessage.configuration.version
-      : undefined,
+    agentVersion: isGlobalAgentId(agentMessage.configuration.sId)
+      ? undefined
+      : agentMessage.configuration.version,
     variant: "full",
   });
   if (!agentConfiguration) {

--- a/front/types/assistant/agent_run.ts
+++ b/front/types/assistant/agent_run.ts
@@ -20,6 +20,7 @@ import {
   isAgentMessageType,
   isUserMessageType,
 } from "@app/types/assistant/conversation";
+import { isGlobalAgentId } from "@app/types";
 
 export type RunAgentAsynchronousArgs = {
   agentMessageId: string;
@@ -135,7 +136,10 @@ export async function getRunAgentData(
   // Fetch the agent configuration as we need the full version of the agent configuration.
   const agentConfiguration = await getAgentConfiguration(auth, {
     agentId: agentMessage.configuration.sId,
-    agentVersion: agentMessage.configuration.version,
+    // We do define agentMessage.configuration.version for global agent, ignoring this value here.
+    agentVersion: !isGlobalAgentId(agentMessage.configuration.sId)
+      ? agentMessage.configuration.version
+      : undefined,
     variant: "full",
   });
   if (!agentConfiguration) {


### PR DESCRIPTION
## Description

- A regression was introduced in https://github.com/dust-tt/dust/pull/14748 for the async loop data fetching, where we would attempt to fetch global agents with a version even though they don't have one.
- This PR fixes that by explicitly ignoring the version for global agents.
- This fix will unblock the conversations on the next retry.

## Tests

## Risk

- Low.

## Deploy Plan

- Deploy front.
