### PR TITLE
Properly fix NEXT_PUBLIC_DATADOG_CLIENT_TOKEN not set

### DIFF
--- a/front/pages/_document.tsx
+++ b/front/pages/_document.tsx
@@ -37,15 +37,14 @@ class MyDocument extends Document {
           {/* Datadog RUM (Real User Monitoring) - Must be in _document.tsx with beforeInteractive
               strategy to ensure it loads before page becomes interactive and captures all user
               interactions from the beginning. This is the recommended setup for Pages Router. */}
-          {process.env.NEXT_PUBLIC_DATADOG_CLIENT_TOKEN && (
-            <Script id="datadog-rum" strategy="beforeInteractive">
-              {`
+          <Script id="datadog-rum" strategy="beforeInteractive">
+            {`
              (function(h,o,u,n,d) {
                h=h[d]=h[d]||{q:[],onReady:function(c){h.q.push(c)}}
                d=o.createElement(u);d.async=1;d.src=n
                n=o.getElementsByTagName(u)[0];n.parentNode.insertBefore(d,n)
              })(window,document,'script','https://www.datadoghq-browser-agent.com/eu1/v6/datadog-rum.js','DD_RUM')
-             window.DD_RUM.onReady(function() {
+             '${process.env.NEXT_PUBLIC_DATADOG_CLIENT_TOKEN || ""}' && window.DD_RUM.onReady(function() {
                window.DD_RUM.init({
                  clientToken: '${process.env.NEXT_PUBLIC_DATADOG_CLIENT_TOKEN}',
                  applicationId: '5e9735e7-87c8-4093-b09f-49d708816bfd',
@@ -59,8 +58,7 @@ class MyDocument extends Document {
                });
              })
            `}
-            </Script>
-          )}
+          </Script>
         </body>
       </Html>
     );


### PR DESCRIPTION
## Description

Fix issue when NEXT_PUBLIC_DATADOG_CLIENT_TOKEN is not set 

Initial problematic PR https://github.com/dust-tt/dust/pull/14737

Previously
```
${process.env.NEXT_PUBLIC_DATADOG_CLIENT_TOKEN}
```
now
```javascript
'${process.env.NEXT_PUBLIC_DATADOG_CLIENT_TOKEN || ""}'
```

This fixes an issue when NEXT_PUBLIC_DATADOG_CLIENT_TOKEN is an actual string, by adding proper quoting

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
