### PR TITLE
Remove prefetch-src CSP

### DIFF
--- a/front/next.config.js
+++ b/front/next.config.js
@@ -12,7 +12,6 @@ const CONTENT_SECURITY_POLICIES = [
   `frame-src 'self' *.wistia.net eu.viz.dust.tt viz.dust.tt *.hsforms.net *.googletagmanager.com *.doubleclick.net;`,
   `font-src 'self' data: dust.tt *.dust.tt *.gstatic.com;`,
   `media-src 'self' data:;`,
-  `prefetch-src 'self';`,
   `object-src 'none';`,
   `form-action 'self';`,
   `base-uri 'self';`,


### PR DESCRIPTION
## Description

Previously added in this PR https://github.com/dust-tt/dust/pull/14750 but apparently deprecated 🤷🏻‍♂️

`datadog-rum.js:1 Unrecognized Content-Security-Policy directive 'prefetch-src'.`

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
