### PR TITLE
Refactor token error in slack

### DIFF
--- a/front/lib/actions/mcp_actions.ts
+++ b/front/lib/actions/mcp_actions.ts
@@ -330,13 +330,17 @@ export async function* tryCallMCPTool(
         if (jsonContent?.type === "text") {
           try {
             const parsed = JSON.parse(jsonContent.text);
-            if (parsed?.__dust_auth_required) {
+            if (
+              parsed?.__dust_auth_required &&
+              connectionParamsRes.value.type === "mcpServerId" &&
+              connectionParamsRes.value.oAuthUseCase === "personal_actions"
+            ) {
               const authReq = parsed.__dust_auth_required;
               yield {
                 type: "result",
                 result: new Err(
                   new MCPServerPersonalAuthenticationRequiredError(
-                    authReq.mcpServerId,
+                    connectionParamsRes.value.mcpServerId,
                     authReq.provider
                   )
                 ),

--- a/front/lib/actions/mcp_internal_actions/servers/slack.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/slack.ts
@@ -14,7 +14,6 @@ import type {
 } from "@app/lib/actions/mcp_internal_actions/output_schemas";
 import { renderRelativeTimeFrameForToolOutput } from "@app/lib/actions/mcp_internal_actions/rendering";
 import {
-  getMcpServerIdFromContext,
   makeMCPToolJSONSuccess,
   makeMCPToolTextError,
 } from "@app/lib/actions/mcp_internal_actions/utils";
@@ -99,10 +98,7 @@ function isSlackTokenRevoked(error: unknown): boolean {
   );
 }
 
-function makeSlackTokenRevokedError(
-  agentLoopContext?: AgentLoopContextType
-): CallToolResult {
-  const mcpServerId = getMcpServerIdFromContext(agentLoopContext);
+function makeSlackTokenRevokedError(): CallToolResult {
   return {
     isError: true,
     content: [
@@ -110,8 +106,7 @@ function makeSlackTokenRevokedError(
         type: "text" as const,
         text: JSON.stringify({
           __dust_auth_required: {
-            mcpServerId,
-            provider: "slack",
+            provider: serverInfo.authorization?.provider,
           },
         }),
       },
@@ -346,7 +341,7 @@ const createServer = (
         }
       } catch (error) {
         if (isSlackTokenRevoked(error)) {
-          return makeSlackTokenRevokedError(agentLoopContext);
+          return makeSlackTokenRevokedError();
         }
         return makeMCPToolTextError(`Error searching messages: ${error}`);
       }
@@ -476,7 +471,7 @@ const createServer = (
         }
       } catch (error) {
         if (isSlackTokenRevoked(error)) {
-          return makeSlackTokenRevokedError(agentLoopContext);
+          return makeSlackTokenRevokedError();
         }
         return makeMCPToolTextError(`Error listing threads: ${error}`);
       }
@@ -538,7 +533,7 @@ const createServer = (
         });
       } catch (error) {
         if (isSlackTokenRevoked(error)) {
-          return makeSlackTokenRevokedError(agentLoopContext);
+          return makeSlackTokenRevokedError();
         }
         return makeMCPToolTextError(`Error posting message: ${error}`);
       }
@@ -614,7 +609,7 @@ const createServer = (
         });
       } catch (error) {
         if (isSlackTokenRevoked(error)) {
-          return makeSlackTokenRevokedError(agentLoopContext);
+          return makeSlackTokenRevokedError();
         }
         return makeMCPToolTextError(`Error listing users: ${error}`);
       }
@@ -689,7 +684,7 @@ const createServer = (
         });
       } catch (error) {
         if (isSlackTokenRevoked(error)) {
-          return makeSlackTokenRevokedError(agentLoopContext);
+          return makeSlackTokenRevokedError();
         }
         return makeMCPToolTextError(`Error listing channels: ${error}`);
       }

--- a/front/lib/actions/mcp_internal_actions/utils.ts
+++ b/front/lib/actions/mcp_internal_actions/utils.ts
@@ -3,9 +3,6 @@ import type {
   TextContent,
 } from "@modelcontextprotocol/sdk/types.js";
 
-import type { AgentLoopContextType } from "@app/lib/actions/types";
-import { isServerSideMCPToolConfiguration } from "@app/lib/actions/types/guards";
-
 export function makeMCPToolTextError(text: string): {
   isError: true;
   content: [TextContent];
@@ -57,17 +54,4 @@ export const makeMCPToolJSONSuccess = ({
       { type: "text" as const, text: JSON.stringify(result, null, 2) },
     ],
   };
-};
-
-/**
- * Helper to get MCP server ID from agent loop context
- */
-export const getMcpServerIdFromContext = (
-  agentLoopContext?: AgentLoopContextType
-): string | null => {
-  const actionConfig = agentLoopContext?.runContext?.actionConfiguration;
-  if (actionConfig && isServerSideMCPToolConfiguration(actionConfig)) {
-    return actionConfig.internalMCPServerId || null;
-  }
-  return null;
 };


### PR DESCRIPTION
## Description

Stumbled upon this when looking at something else.
I refactored a bit to avoid passing things around when not needed (i believe it also possible to avoid the "provider" part).
Makes it slightly more robust because it implied that slack is using personal connexion and someone could have copy pasted it without realizing that.

## Risk

Low

## Deploy Plan

Deploy front