### PR TITLE
Refactor check on agent_memory to avoid magic string

### DIFF
--- a/front/components/assistant/AssistantDetails.tsx
+++ b/front/components/assistant/AssistantDetails.tsx
@@ -36,6 +36,7 @@ import { ReadOnlyTextArea } from "@app/components/assistant/ReadOnlyTextArea";
 import { RestoreAssistantDialog } from "@app/components/assistant/RestoreAssistantDialog";
 import { AddEditorDropdown } from "@app/components/members/AddEditorsDropdown";
 import { MembersList } from "@app/components/members/MembersList";
+import { isMCPConfigurationForAgentMemory } from "@app/lib/actions/types/guards";
 import { useAgentConfiguration } from "@app/lib/swr/assistants";
 import { useEditors, useUpdateEditors } from "@app/lib/swr/editors";
 import type {
@@ -253,7 +254,7 @@ export function AssistantDetails({
   const [showRestoreModal, setShowRestoreModal] = useState(false);
   const showEditorsTabs = assistantId != null && !isGlobalAgent;
   const showAgentMemory = !!agentConfiguration?.actions.find(
-    (a) => a.mcpServerName === "agent_memory"
+    isMCPConfigurationForAgentMemory
   );
 
   const showPerformanceTabs =

--- a/front/lib/actions/types/guards.ts
+++ b/front/lib/actions/types/guards.ts
@@ -86,6 +86,7 @@ export function isMCPConfigurationForInternalNotion(
     isInternalMCPServerOfName(arg.internalMCPServerId, "notion")
   );
 }
+
 export function isMCPConfigurationForDustAppRun(
   arg: MCPServerConfigurationType
 ): arg is ServerSideMCPServerConfigurationType {
@@ -95,6 +96,14 @@ export function isMCPConfigurationForDustAppRun(
   );
 }
 
+export function isMCPConfigurationForAgentMemory(
+  arg: MCPServerConfigurationType
+): arg is ServerSideMCPServerConfigurationType {
+  return (
+    isServerSideMCPServerConfiguration(arg) &&
+    isInternalMCPServerOfName(arg.internalMCPServerId, "agent_memory")
+  );
+}
 // MCP Tools
 
 export function isMCPToolConfiguration(


### PR DESCRIPTION
## Description

Fix [this comment](https://github.com/dust-tt/dust/pull/14572#discussion_r2229493082) and strenghten the code.
I believe mcpServerName could be removed now.

## Tests

Locally

## Risk

Low

## Deploy Plan

Deploy front