### PR TITLE
Further fix CSP violations

### DIFF
--- a/front/next.config.js
+++ b/front/next.config.js
@@ -5,10 +5,10 @@ const showReactScan =
 
 const CONTENT_SECURITY_POLICIES = [
   "default-src 'none';",
-  `script-src 'self' 'unsafe-inline' 'unsafe-eval' dust.tt *.dust.tt *.googletagmanager.com *.google-analytics.com *.hsforms.net *.hs-scripts.com *.hs-analytics.net *.hubspot.com *.hs-banner.com *.hscollectedforms.net *.usercentrics.eu *.cr-relay.com *.licdn.com *.datadoghq-browser-agent.com *.doubleclick.net ${showReactScan ? "unpkg.com" : ""};`,
+  `script-src 'self' 'unsafe-inline' 'unsafe-eval' https://dust.tt https://*.dust.tt *.googletagmanager.com *.google-analytics.com *.hsforms.net *.hs-scripts.com *.hs-analytics.net *.hubspot.com *.hs-banner.com *.hscollectedforms.net *.usercentrics.eu *.cr-relay.com *.licdn.com *.datadoghq-browser-agent.com *.doubleclick.net *.hsadspixel.net ${showReactScan ? "unpkg.com" : ""};`,
   `style-src 'self' 'unsafe-inline' *.fontawesome.com *.googleapis.com;`,
   `img-src 'self' data: https:;`,
-  `connect-src 'self' blob: browser-intake-datadoghq.eu *.google-analytics.com *.googlesyndication.com cdn.jsdelivr.net *.hsforms.com *.hscollectedforms.net *.hubspot.com *.cr-relay.com *.usercentrics.eu *.ads.linkedin.com px.ads.linkedin.com *.google.com;`,
+  `connect-src 'self' blob: https://dust.tt https://*.dust.tt browser-intake-datadoghq.eu *.google-analytics.com *.googlesyndication.com *.googleadservices.com cdn.jsdelivr.net *.hsforms.com *.hscollectedforms.net *.hubspot.com *.cr-relay.com *.usercentrics.eu *.ads.linkedin.com px.ads.linkedin.com google.com *.google.com;`,
   `frame-src 'self' *.wistia.net eu.viz.dust.tt viz.dust.tt *.hsforms.net *.googletagmanager.com *.doubleclick.net;`,
   `font-src 'self' data: dust.tt *.dust.tt *.gstatic.com;`,
   `media-src 'self' data:;`,

--- a/front/pages/_app.tsx
+++ b/front/pages/_app.tsx
@@ -15,7 +15,7 @@ if (process.env.NEXT_PUBLIC_DATADOG_CLIENT_TOKEN) {
   datadogLogs.init({
     clientToken: process.env.NEXT_PUBLIC_DATADOG_CLIENT_TOKEN,
     env: process.env.NODE_ENV === "production" ? "prod" : "dev",
-    service: process.env.NEXT_PUBLIC_DATADOG_SERVICE,
+    service: `${process.env.NEXT_PUBLIC_DATADOG_SERVICE}-browser`,
     version: process.env.NEXT_PUBLIC_COMMIT_HASH || "",
     site: "datadoghq.eu",
     forwardErrorsToLogs: true,

--- a/front/pages/_document.tsx
+++ b/front/pages/_document.tsx
@@ -49,7 +49,7 @@ class MyDocument extends Document {
                  clientToken: '${process.env.NEXT_PUBLIC_DATADOG_CLIENT_TOKEN}',
                  applicationId: '5e9735e7-87c8-4093-b09f-49d708816bfd',
                  site: 'datadoghq.eu',
-                 service: 'front',
+                 service: '${process.env.NEXT_PUBLIC_DATADOG_SERVICE}-browser',
                  env: '${process.env.NODE_ENV === "production" ? "prod" : "dev"}',
                  version: '${process.env.NEXT_PUBLIC_COMMIT_HASH || ""}',
                  allowedTracingUrls: [


### PR DESCRIPTION
## Description

This PR is better read commit by commit.

Further fixes to CSP (Content Security Policy) configuration:
- Add specific service name for `front-browser` telemetry tracking
- Update CSP policy in Next.js configuration

For reference, there's still one remaining error that is not addressed in this PR

```
> script-src: csp_violation: 'eval' blocked by 'script-src' directive
  script-src: 'eval' blocked by 'script-src' directive of the policy "default-src 'self'; script-src 'self' 
  'nonce-gY/eLeyY7uOT2CXROCA05A==' 'unsafe-inline' https://chall..."
    at <anonymous> @ https://signin.dust.tt/_next/static/chunks/3106.819cc9503df02772.js:421:2539v
```

> The error seems to be coming from signin.dust.tt which might be a separate deployment or subdomain. Since
>   the error shows a different CSP policy format (with nonces), this might be handled by a different system
>   (like WorkOS SSO).
> 
>   If this is affecting your current application, you might need to coordinate with whoever manages the
>   signin.dust.tt subdomain to ensure their CSP allows 'unsafe-eval' if needed, or check if there are
>   additional CSP headers being set elsewhere in your application.
> 
>   For now, your main dust.tt CSP in next.config.js already includes 'unsafe-eval', so this error is likely
>   from the signin subdomain's separate CSP configuration.

## Tests

Tested manually to ensure:
- CSP policy changes don't break existing functionality
- Service name updates are properly reflected in telemetry

## Risk

Low risk changes focused on configuration updates:
- CSP policy updates are incremental improvements to existing security configuration
- Service name changes are for telemetry tracking and don't affect core functionality
- Changes are safe to rollback if any issues arise

## Deploy Plan

Standard deployment:
1. Deploy to staging environment first to validate CSP changes
2. Monitor for any CSP violations or telemetry issues
3. Deploy to production after validation
4. Monitor telemetry to ensure service names are properly tracked