### PR TITLE
Improve source maps

### DIFF
--- a/dockerfiles/front.Dockerfile
+++ b/dockerfiles/front.Dockerfile
@@ -50,7 +50,7 @@ RUN BUILD_WITH_SOURCE_MAPS=${DATADOG_API_KEY:+true} \
         npx --yes @datadog/datadog-ci sourcemaps upload ./.next \
         --minified-path-prefix=/_next/ \
         --repository-url=https://github.com/dust-tt/dust \
-        --project-path=front \
+        --project-path=front-browser \
         --release-version=$COMMIT_HASH \
         --service=$NEXT_PUBLIC_DATADOG_SERVICE && \
         find .next -type f -name "*.map" -print -delete; \

--- a/dockerfiles/front.Dockerfile
+++ b/dockerfiles/front.Dockerfile
@@ -47,10 +47,16 @@ RUN BUILD_WITH_SOURCE_MAPS=${DATADOG_API_KEY:+true} \
     if [ -n "$DATADOG_API_KEY" ]; then \
         DATADOG_SITE=datadoghq.eu \
         DATADOG_API_KEY=$DATADOG_API_KEY \
-        npx --yes @datadog/datadog-ci sourcemaps upload ./.next \
-        --minified-path-prefix=/_next/ \
+        npx --yes @datadog/datadog-ci sourcemaps upload ./.next/static \
+        --minified-path-prefix=/_next/static/ \
         --repository-url=https://github.com/dust-tt/dust \
         --project-path=front-browser \
+        --release-version=$COMMIT_HASH \
+        --service=$NEXT_PUBLIC_DATADOG_SERVICE && \
+        npx --yes @datadog/datadog-ci sourcemaps upload ./.next/server \
+        --minified-path-prefix=/ \
+        --repository-url=https://github.com/dust-tt/dust \
+        --project-path=front \
         --release-version=$COMMIT_HASH \
         --service=$NEXT_PUBLIC_DATADOG_SERVICE && \
         find .next -type f -name "*.map" -print -delete; \


### PR DESCRIPTION
## Description

Fix server-side sourcemap path mapping for Datadog error tracking. Server-side chunks in Next.js were being uploaded with incorrect path prefixes, causing stack traces to show `chunks/7150.js` while Datadog had them indexed as `/_next/server/chunks/7150.js`, preventing proper source mapping.

Split the sourcemap upload into two separate commands:
- Client-side code: `.next/static` with `/_next/static/` prefix
- Server-side code: `.next/server` with `/` prefix (no prefix)

This ensures server-side stack traces like `chunks/7150.js:5949:25` correctly match the uploaded sourcemaps in Datadog.

## Tests

Tested by examining the Next.js build output structure and confirming the path mismatch between uploaded symbols (`/_next/server/chunks/7150.js`) and runtime stack traces (`chunks/7150.js`). The fix aligns the upload paths with how Next.js runtime resolves server-side chunk paths.

## Risk

Low risk - this only affects sourcemap uploads to Datadog for debugging purposes. The change doesn't modify any runtime code, only the build process. If there are issues, we can easily revert to the previous single upload command.

## Deploy Plan

Standard deployment - the change only affects the Docker build process. No special deployment steps required. The improved sourcemap mapping will be available immediately after the next deployment for better error tracking in production.