### PR TITLE
Upload client-side and server-side sourcemaps separately

### DIFF
--- a/dockerfiles/front.Dockerfile
+++ b/dockerfiles/front.Dockerfile
@@ -47,8 +47,16 @@ RUN BUILD_WITH_SOURCE_MAPS=${DATADOG_API_KEY:+true} \
     if [ -n "$DATADOG_API_KEY" ]; then \
         DATADOG_SITE=datadoghq.eu \
         DATADOG_API_KEY=$DATADOG_API_KEY \
-        npx --yes @datadog/datadog-ci sourcemaps upload ./.next \
-        --minified-path-prefix=/_next/ \
+        npx --yes @datadog/datadog-ci sourcemaps upload ./.next/static \
+        --minified-path-prefix=/_next/static/ \
+        --repository-url=https://github.com/dust-tt/dust \
+        --project-path=front-browser \
+        --release-version=$COMMIT_HASH \
+        --service=$NEXT_PUBLIC_DATADOG_SERVICE && \
+        DATADOG_SITE=datadoghq.eu \
+        DATADOG_API_KEY=$DATADOG_API_KEY \
+        npx --yes @datadog/datadog-ci sourcemaps upload ./.next/server \
+        --minified-path-prefix=/ \
         --repository-url=https://github.com/dust-tt/dust \
         --project-path=front \
         --release-version=$COMMIT_HASH \

--- a/dockerfiles/front.Dockerfile
+++ b/dockerfiles/front.Dockerfile
@@ -45,16 +45,13 @@ RUN BUILD_WITH_SOURCE_MAPS=${DATADOG_API_KEY:+true} \
     FRONT_DATABASE_URI="sqlite:foo.sqlite" \
     npm run build && \
     if [ -n "$DATADOG_API_KEY" ]; then \
-        DATADOG_SITE=datadoghq.eu \
-        DATADOG_API_KEY=$DATADOG_API_KEY \
+        export DATADOG_SITE=datadoghq.eu DATADOG_API_KEY=$DATADOG_API_KEY; \
         npx --yes @datadog/datadog-ci sourcemaps upload ./.next/static \
         --minified-path-prefix=/_next/static/ \
         --repository-url=https://github.com/dust-tt/dust \
         --project-path=front-browser \
         --release-version=$COMMIT_HASH \
         --service=$NEXT_PUBLIC_DATADOG_SERVICE && \
-        DATADOG_SITE=datadoghq.eu \
-        DATADOG_API_KEY=$DATADOG_API_KEY \
         npx --yes @datadog/datadog-ci sourcemaps upload ./.next/server \
         --minified-path-prefix=/ \
         --repository-url=https://github.com/dust-tt/dust \


### PR DESCRIPTION
## Description

Follow up of https://github.com/dust-tt/dust/pull/14771 that got reverted

The key change is to export variables since they are now used for 2 commands, not just one:

https://github.com/dust-tt/dust/blob/8bbdfca47bc92bf635d2cad657c57c49f6c03f91/dockerfiles/front.Dockerfile#L48



Fix server-side sourcemap path mapping for Datadog error tracking. Server-side chunks in Next.js were being uploaded with incorrect path prefixes, causing stack traces to show `chunks/7150.js` while Datadog had them indexed as `/_next/server/chunks/7150.js`, preventing proper source mapping.

Split the sourcemap upload into two separate commands:
- Client-side code: `.next/static` with `/_next/static/` prefix
- Server-side code: `.next/server` with `/` prefix (no prefix)

This ensures server-side stack traces like `chunks/7150.js:5949:25` correctly match the uploaded sourcemaps in Datadog.

## Tests

Job tested completed successfuly ✅ https://github.com/dust-tt/dust/actions/runs/16707915477/job/47288632421

Tested by examining the Next.js build output structure and confirming the path mismatch between uploaded symbols (`/_next/server/chunks/7150.js`) and runtime stack traces (`chunks/7150.js`). The fix aligns the upload paths with how Next.js runtime resolves server-side chunk paths.

## Risk

Low risk - this only affects sourcemap uploads to Datadog for debugging purposes. The change doesn't modify any runtime code, only the build process. If there are issues, we can easily revert to the previous single upload command.

## Deploy Plan

Standard deployment - the change only affects the Docker build process. No special deployment steps required. The improved sourcemap mapping will be available immediately after the next deployment for better error tracking in production.