### PR TITLE
[front] - feat(AB v2): instruction blocks

### DIFF
--- a/front/components/agent_builder/instructions/AgentBuilderInstructionsEditor.tsx
+++ b/front/components/agent_builder/instructions/AgentBuilderInstructionsEditor.tsx
@@ -12,6 +12,7 @@ import { useAgentBuilderContext } from "@app/components/agent_builder/AgentBuild
 import type { AgentBuilderFormData } from "@app/components/agent_builder/AgentBuilderFormContext";
 import { AgentBuilderInstructionsAutoCompleteExtension } from "@app/components/agent_builder/instructions/AgentBuilderInstructionsAutoCompleteExtension";
 import { AgentInstructionDiffExtension } from "@app/components/agent_builder/instructions/AgentInstructionDiffExtension";
+import { InstructionBlockExtension } from "@app/components/agent_builder/instructions/InstructionBlockExtension";
 import { InstructionTipsPopover } from "@app/components/agent_builder/instructions/InstructionsTipsPopover";
 import { ParagraphExtension } from "@app/components/assistant/conversation/input_bar/editor/extensions/ParagraphExtension";
 import {
@@ -109,6 +110,7 @@ export function AgentBuilderInstructionsEditor({
       Text,
       ParagraphExtension,
       History,
+      InstructionBlockExtension,
       AgentInstructionDiffExtension,
       CharacterCount.configure({
         limit: INSTRUCTIONS_MAXIMUM_CHARACTER_COUNT,

--- a/front/components/agent_builder/instructions/InstructionBlockExtension.tsx
+++ b/front/components/agent_builder/instructions/InstructionBlockExtension.tsx
@@ -9,10 +9,8 @@ import {
 } from "@tiptap/react";
 import React from "react";
 
-export type InstructionBlockType = "info" | "approach" | "tools";
-
 export interface InstructionBlockAttributes {
-  type: InstructionBlockType;
+  type: string;
 }
 
 declare module "@tiptap/core" {
@@ -21,19 +19,13 @@ declare module "@tiptap/core" {
       setInstructionBlock: (
         attributes: InstructionBlockAttributes
       ) => ReturnType;
-      insertInstructionBlock: (type: InstructionBlockType) => ReturnType;
+      insertInstructionBlock: (type: string) => ReturnType;
     };
   }
 }
 
 const InstructionBlockComponent: React.FC<NodeViewProps> = ({ node }) => {
   const { type } = node.attrs as InstructionBlockAttributes;
-
-  const labels: Record<InstructionBlockType, string> = {
-    info: "INFO",
-    approach: "APPROACH",
-    tools: "TOOLS",
-  };
 
   return (
     <NodeViewWrapper className="my-4">
@@ -43,7 +35,7 @@ const InstructionBlockComponent: React.FC<NodeViewProps> = ({ node }) => {
             className="select-none text-sm font-semibold uppercase tracking-wider text-muted-foreground"
             contentEditable={false}
           >
-            {labels[type]}
+            {type.toUpperCase()}
           </span>
         </div>
         <div className="min-h-[3rem] rounded border border-border/50 bg-background p-3">
@@ -65,11 +57,9 @@ export const InstructionBlockExtension =
     addAttributes() {
       return {
         type: {
-          default: "info" as InstructionBlockType,
+          default: "info",
           parseHTML: (element) =>
-            (element.getAttribute(
-              "data-instruction-type"
-            ) as InstructionBlockType) || "info",
+            element.getAttribute("data-instruction-type") || "info",
           renderHTML: (attributes) => ({
             "data-instruction-type": attributes.type,
           }),
@@ -81,18 +71,6 @@ export const InstructionBlockExtension =
       return [
         {
           tag: "div[data-type='instruction-block']",
-        },
-        {
-          tag: "info",
-          getAttrs: () => ({ type: "info" }),
-        },
-        {
-          tag: "approach",
-          getAttrs: () => ({ type: "approach" }),
-        },
-        {
-          tag: "tools",
-          getAttrs: () => ({ type: "tools" }),
         },
       ];
     },
@@ -132,9 +110,9 @@ export const InstructionBlockExtension =
     addInputRules() {
       return [
         new InputRule({
-          find: /<(INFO|APPROACH|TOOLS)>$/,
+          find: /<(\w+)>$/,
           handler: ({ range, match, commands }) => {
-            const type = match[1].toLowerCase() as InstructionBlockType;
+            const type = match[1].toLowerCase();
 
             commands.insertContentAt(
               { from: range.from, to: range.to },
@@ -166,13 +144,13 @@ export const InstructionBlockExtension =
                 return;
               }
 
-              const regex = /<(INFO|APPROACH|TOOLS)>([\s\S]*?)<\/\1>/g;
+              const regex = /<(\w+)>([\s\S]*?)<\/\1>/g;
               let match;
 
               while ((match = regex.exec(node.text)) !== null) {
                 const matchStart = pos + match.index;
                 const matchEnd = matchStart + match[0].length;
-                const type = match[1].toLowerCase() as InstructionBlockType;
+                const type = match[1].toLowerCase();
                 const content = match[2].trim();
 
                 // Create paragraph nodes from content

--- a/front/components/agent_builder/instructions/InstructionBlockExtension.tsx
+++ b/front/components/agent_builder/instructions/InstructionBlockExtension.tsx
@@ -1,6 +1,9 @@
 import { InputRule, mergeAttributes, Node } from "@tiptap/core";
+import type { Node as ProseMirrorNode } from "@tiptap/pm/model";
+import type { Slice } from "@tiptap/pm/model";
 import { Plugin, PluginKey } from "@tiptap/pm/state";
 import { TextSelection } from "@tiptap/pm/state";
+import type { EditorView } from "@tiptap/pm/view";
 import type { NodeViewProps } from "@tiptap/react";
 import {
   NodeViewContent,
@@ -8,9 +11,14 @@ import {
   ReactNodeViewRenderer,
 } from "@tiptap/react";
 import React from "react";
-import { Slice, Fragment } from "@tiptap/pm/model";
-import type { Node as ProseMirrorNode } from "@tiptap/pm/model";
-import type { EditorView } from "@tiptap/pm/view";
+
+import {
+  createProseMirrorInstructionBlock,
+  INSTRUCTION_BLOCK_REGEX,
+  OPENING_TAG_REGEX,
+  parseInstructionBlockMatches,
+  splitTextAroundBlocks,
+} from "@app/lib/client/assistant_builder/instructionBlockUtils";
 
 export interface InstructionBlockAttributes {
   type: string;
@@ -113,7 +121,7 @@ export const InstructionBlockExtension =
     addInputRules() {
       return [
         new InputRule({
-          find: /<(\w+)>$/,
+          find: OPENING_TAG_REGEX,
           handler: ({ range, match, commands }) => {
             const type = match[1].toLowerCase();
 
@@ -152,22 +160,18 @@ export const InstructionBlockExtension =
               );
 
               // Check if there are any XML tags
-              const regex = /<(\w+)>([\s\S]*?)<\/\1>/g;
-              if (!regex.test(textContent)) {
+              if (!INSTRUCTION_BLOCK_REGEX.test(textContent)) {
                 return false; // Let default paste behavior handle it
               }
 
               // Parse the content and create nodes
               const nodes: ProseMirrorNode[] = [];
-              let lastIndex = 0;
-              let match;
+              const segments = splitTextAroundBlocks(textContent);
 
-              regex.lastIndex = 0; // Reset regex
-              while ((match = regex.exec(textContent)) !== null) {
-                // Add text before the XML tag as paragraphs
-                if (match.index > lastIndex) {
-                  const beforeText = textContent.slice(lastIndex, match.index);
-                  const lines = beforeText
+              segments.forEach((segment) => {
+                if (segment.type === "text") {
+                  // Add text as paragraphs
+                  const lines = segment.content
                     .split("\n")
                     .filter((line) => line.trim());
                   lines.forEach((line) => {
@@ -175,47 +179,21 @@ export const InstructionBlockExtension =
                       schema.nodes.paragraph.create({}, [schema.text(line)])
                     );
                   });
+                } else if (segment.type === "block" && segment.blockType) {
+                  // Add instruction block
+                  const instructionBlock = createProseMirrorInstructionBlock(
+                    segment.blockType,
+                    segment.content,
+                    this.type,
+                    schema
+                  );
+                  nodes.push(instructionBlock);
                 }
-
-                // Process the XML tag
-                const type = match[1].toLowerCase();
-                const content = match[2].trim();
-
-                // Create paragraph nodes from content
-                const paragraphs = content.split("\n").map((line) => {
-                  const trimmedLine = line.trim();
-                  return schema.nodes.paragraph.create(
-                    {},
-                    trimmedLine ? [schema.text(trimmedLine)] : []
-                  );
-                });
-
-                const blockContent =
-                  paragraphs.length > 0
-                    ? paragraphs
-                    : [schema.nodes.paragraph.create()];
-
-                nodes.push(this.type.create({ type }, blockContent));
-
-                lastIndex = match.index + match[0].length;
-              }
-
-              // Add remaining text
-              if (lastIndex < textContent.length) {
-                const remainingText = textContent.slice(lastIndex);
-                const lines = remainingText
-                  .split("\n")
-                  .filter((line) => line.trim());
-                lines.forEach((line) => {
-                  nodes.push(
-                    schema.nodes.paragraph.create({}, [schema.text(line)])
-                  );
-                });
-              }
+              });
 
               // Insert the nodes
               const { from } = state.selection;
-              nodes.forEach((node, index) => {
+              nodes.forEach((node) => {
                 const pos = tr.mapping.map(from);
                 tr.insert(pos, node);
               });
@@ -237,32 +215,17 @@ export const InstructionBlockExtension =
                 return;
               }
 
-              const regex = /<(\w+)>([\s\S]*?)<\/\1>/g;
-              let match;
+              const matches = parseInstructionBlockMatches(node.text);
 
-              while ((match = regex.exec(node.text)) !== null) {
-                const matchStart = pos + match.index;
-                const matchEnd = matchStart + match[0].length;
-                const type = match[1].toLowerCase();
-                const content = match[2].trim();
+              matches.forEach((match) => {
+                const matchStart = pos + match.start;
+                const matchEnd = pos + match.end;
 
-                // Create paragraph nodes from content
-                const paragraphs = content.split("\n").map((line) => {
-                  const trimmedLine = line.trim();
-                  return schema.nodes.paragraph.create(
-                    {},
-                    trimmedLine ? [schema.text(trimmedLine)] : []
-                  );
-                });
-
-                const blockContent =
-                  paragraphs.length > 0
-                    ? paragraphs
-                    : [schema.nodes.paragraph.create()];
-
-                const instructionBlock = this.type.create(
-                  { type },
-                  blockContent
+                const instructionBlock = createProseMirrorInstructionBlock(
+                  match.type,
+                  match.content,
+                  this.type,
+                  schema
                 );
 
                 tr.replaceWith(matchStart, matchEnd, instructionBlock);
@@ -273,7 +236,7 @@ export const InstructionBlockExtension =
                 tr.setSelection(TextSelection.create(tr.doc, paragraphPos));
 
                 modified = true;
-              }
+              });
             });
 
             return modified ? tr : null;

--- a/front/components/agent_builder/instructions/InstructionBlockExtension.tsx
+++ b/front/components/agent_builder/instructions/InstructionBlockExtension.tsx
@@ -1,17 +1,17 @@
-import { mergeAttributes, Node, nodeInputRule, InputRule } from "@tiptap/core";
+import { InputRule, mergeAttributes, Node } from "@tiptap/core";
 import { Plugin, PluginKey } from "@tiptap/pm/state";
 import { TextSelection } from "@tiptap/pm/state";
-import { ReactNodeViewRenderer } from "@tiptap/react";
+import type { NodeViewProps } from "@tiptap/react";
 import {
   NodeViewContent,
   NodeViewWrapper,
-  type NodeViewProps,
+  ReactNodeViewRenderer,
 } from "@tiptap/react";
 import React from "react";
 
-type InstructionBlockType = "info" | "approach" | "tools";
+export type InstructionBlockType = "info" | "approach" | "tools";
 
-interface InstructionBlockAttributes {
+export interface InstructionBlockAttributes {
   type: InstructionBlockType;
 }
 
@@ -19,19 +19,17 @@ declare module "@tiptap/core" {
   interface Commands<ReturnType> {
     instructionBlock: {
       setInstructionBlock: (
-        attributes?: InstructionBlockAttributes
+        attributes: InstructionBlockAttributes
       ) => ReturnType;
       insertInstructionBlock: (type: InstructionBlockType) => ReturnType;
-      insertParagraphAfterBlock: () => ReturnType;
-      insertParagraphBeforeBlock: () => ReturnType;
     };
   }
 }
 
-const InstructionBlockComponent = ({ node }: NodeViewProps) => {
+const InstructionBlockComponent: React.FC<NodeViewProps> = ({ node }) => {
   const { type } = node.attrs as InstructionBlockAttributes;
 
-  const typeDisplayMap: Record<InstructionBlockType, string> = {
+  const labels: Record<InstructionBlockType, string> = {
     info: "INFO",
     approach: "APPROACH",
     tools: "TOOLS",
@@ -40,17 +38,14 @@ const InstructionBlockComponent = ({ node }: NodeViewProps) => {
   return (
     <NodeViewWrapper className="my-4">
       <div className="rounded-lg border border-border bg-muted-background p-4">
-        {/* Section Header */}
         <div className="mb-3">
           <span
             className="select-none text-sm font-semibold uppercase tracking-wider text-muted-foreground"
             contentEditable={false}
           >
-            {typeDisplayMap[type]}
+            {labels[type]}
           </span>
         </div>
-
-        {/* Editable Content Area */}
         <div className="min-h-[3rem] rounded border border-border/50 bg-background p-3">
           <NodeViewContent className="prose prose-sm max-w-none outline-none" />
         </div>
@@ -71,18 +66,13 @@ export const InstructionBlockExtension =
       return {
         type: {
           default: "info" as InstructionBlockType,
-          parseHTML: (element) => {
-            const dataType = element.getAttribute("data-instruction-type");
-            return (dataType as InstructionBlockType) || "info";
-          },
-          renderHTML: (attributes) => {
-            if (!attributes.type) {
-              return {};
-            }
-            return {
-              "data-instruction-type": attributes.type,
-            };
-          },
+          parseHTML: (element) =>
+            (element.getAttribute(
+              "data-instruction-type"
+            ) as InstructionBlockType) || "info",
+          renderHTML: (attributes) => ({
+            "data-instruction-type": attributes.type,
+          }),
         },
       };
     },
@@ -92,7 +82,6 @@ export const InstructionBlockExtension =
         {
           tag: "div[data-type='instruction-block']",
         },
-        // Parse XML-style tags directly from HTML content
         {
           tag: "info",
           getAttrs: () => ({ type: "info" }),
@@ -108,15 +97,7 @@ export const InstructionBlockExtension =
       ];
     },
 
-    renderHTML({ HTMLAttributes, node }) {
-      const { type } = node.attrs as InstructionBlockAttributes;
-
-      // For serialization to XML format, render as the XML tag
-      if (HTMLAttributes["data-serialize-as-xml"]) {
-        return [type.toUpperCase(), {}, 0];
-      }
-
-      // For normal HTML rendering, use div with data attributes
+    renderHTML({ HTMLAttributes }) {
       return [
         "div",
         mergeAttributes(HTMLAttributes, {
@@ -130,140 +111,17 @@ export const InstructionBlockExtension =
       return {
         setInstructionBlock:
           (attributes) =>
-          ({ commands }) => {
-            return commands.setNode(this.name, attributes);
-          },
+          ({ commands }) =>
+            commands.setNode(this.name, attributes),
 
         insertInstructionBlock:
-          (type: InstructionBlockType) =>
-          ({ commands }) => {
-            return commands.insertContent({
+          (type) =>
+          ({ commands }) =>
+            commands.insertContent({
               type: this.name,
               attrs: { type },
               content: [{ type: "paragraph" }],
-            });
-          },
-
-        insertParagraphAfterBlock:
-          () =>
-          ({ state, dispatch }) => {
-            const { selection } = state;
-            const { $from } = selection;
-
-            // Find if we're in an instruction block
-            for (let depth = $from.depth; depth >= 0; depth--) {
-              const node = $from.node(depth);
-              if (node.type.name === this.name) {
-                const blockPos = $from.start(depth);
-                const blockEnd = blockPos + node.nodeSize;
-
-                if (dispatch) {
-                  const tr = state.tr.insert(
-                    blockEnd,
-                    state.schema.nodes.paragraph.create()
-                  );
-                  tr.setSelection(
-                    TextSelection.near(tr.doc.resolve(blockEnd + 1))
-                  );
-                  dispatch(tr);
-                }
-                return true;
-              }
-            }
-            return false;
-          },
-
-        insertParagraphBeforeBlock:
-          () =>
-          ({ state, dispatch }) => {
-            const { selection } = state;
-            const { $from } = selection;
-
-            // Find if we're in an instruction block
-            for (let depth = $from.depth; depth >= 0; depth--) {
-              const node = $from.node(depth);
-              if (node.type.name === this.name) {
-                const blockPos = $from.start(depth);
-
-                if (dispatch) {
-                  const tr = state.tr.insert(
-                    blockPos,
-                    state.schema.nodes.paragraph.create()
-                  );
-                  tr.setSelection(
-                    TextSelection.near(tr.doc.resolve(blockPos + 1))
-                  );
-                  dispatch(tr);
-                }
-                return true;
-              }
-            }
-            return false;
-          },
-      };
-    },
-
-    addKeyboardShortcuts() {
-      return {
-        "Mod-Shift-i": () => {
-          return this.editor.commands.insertInstructionBlock("info");
-        },
-        "Mod-Shift-a": () => {
-          return this.editor.commands.insertInstructionBlock("approach");
-        },
-        "Mod-Shift-t": () => {
-          return this.editor.commands.insertInstructionBlock("tools");
-        },
-        "Mod-Enter": ({ editor }) => {
-          // Create paragraph after block
-          return editor.commands.insertParagraphAfterBlock();
-        },
-        "Mod-Shift-Enter": ({ editor }) => {
-          // Create paragraph before block
-          return editor.commands.insertParagraphBeforeBlock();
-        },
-        ArrowUp: ({ editor }) => {
-          const { selection, doc } = editor.state;
-          const { $from } = selection;
-
-          // Check if we're at the start of an instruction block
-          if (
-            $from.depth >= 2 &&
-            $from.node($from.depth - 1).type.name === this.name
-          ) {
-            const blockPos = $from.start($from.depth - 1);
-            if ($from.parentOffset === 0 && $from.pos === $from.start()) {
-              // We're at the very start of the block content, move cursor before the block
-              const newPos = Math.max(0, blockPos - 1);
-              editor.commands.setTextSelection(newPos);
-              return true;
-            }
-          }
-          return false;
-        },
-        ArrowDown: ({ editor }) => {
-          const { selection, doc } = editor.state;
-          const { $from } = selection;
-
-          // Check if we're at the end of an instruction block
-          if (
-            $from.depth >= 2 &&
-            $from.node($from.depth - 1).type.name === this.name
-          ) {
-            const blockNode = $from.node($from.depth - 1);
-            const blockPos = $from.start($from.depth - 1);
-            const blockEnd = blockPos + blockNode.nodeSize;
-
-            // Check if we're at the end of the block content
-            if ($from.pos === $from.end()) {
-              // Move cursor after the block
-              const newPos = Math.min(doc.content.size, blockEnd);
-              editor.commands.setTextSelection(newPos);
-              return true;
-            }
-          }
-          return false;
-        },
+            }),
       };
     },
 
@@ -271,86 +129,13 @@ export const InstructionBlockExtension =
       return ReactNodeViewRenderer(InstructionBlockComponent);
     },
 
-    addProseMirrorPlugins() {
-      return [
-        new Plugin({
-          key: new PluginKey("instructionBlockAutoConvert"),
-          appendTransaction: (transactions, oldState, newState) => {
-            const docChanged = transactions.some((tr) => tr.docChanged);
-            if (!docChanged) return null;
-
-            const { doc, tr } = newState;
-            const { schema } = newState;
-            let modified = false;
-
-            // Find text nodes that contain complete instruction block patterns
-            doc.descendants((node, pos) => {
-              if (node.type.name === "text" && node.text) {
-                const text = node.text;
-                const regex = /<(INFO|APPROACH|TOOLS)>([\s\S]*?)<\/\1>/g;
-                let match;
-
-                while ((match = regex.exec(text)) !== null) {
-                  const matchStart = pos + match.index;
-                  const matchEnd = matchStart + match[0].length;
-                  const type = match[1].toLowerCase() as InstructionBlockType;
-                  const content = match[2].trim();
-
-                  // Create paragraphs from content
-                  const lines = content.split("\n");
-                  const paragraphs = lines.map((line) => {
-                    const trimmedLine = line.trim();
-                    return schema.nodes.paragraph.create(
-                      {},
-                      trimmedLine ? [schema.text(trimmedLine)] : []
-                    );
-                  });
-
-                  const blockContent =
-                    paragraphs.length > 0
-                      ? paragraphs
-                      : [schema.nodes.paragraph.create()];
-                  const instructionBlock = this.type.create(
-                    { type },
-                    blockContent
-                  );
-
-                  tr.replaceWith(matchStart, matchEnd, instructionBlock);
-
-                  // Set cursor inside the new block
-                  const newBlockPos = matchStart + 1; // Position after the block node
-                  const resolvedPos = tr.doc.resolve(newBlockPos);
-                  if (resolvedPos.depth > 0) {
-                    // Find the first paragraph inside the block and position cursor there
-                    const blockNode = resolvedPos.nodeAfter;
-                    if (blockNode && blockNode.content.size > 0) {
-                      const firstParagraphPos = newBlockPos + 1;
-                      tr.setSelection(
-                        TextSelection.create(tr.doc, firstParagraphPos)
-                      );
-                    }
-                  }
-
-                  modified = true;
-                }
-              }
-            });
-
-            return modified ? tr : null;
-          },
-        }),
-      ];
-    },
-
     addInputRules() {
       return [
-        // Custom input rule for opening tags
         new InputRule({
           find: /<(INFO|APPROACH|TOOLS)>$/,
-          handler: ({ state, range, match, commands }) => {
+          handler: ({ range, match, commands }) => {
             const type = match[1].toLowerCase() as InstructionBlockType;
 
-            // Use the insertContent command to properly insert the block
             commands.insertContentAt(
               { from: range.from, to: range.to },
               {
@@ -359,9 +144,68 @@ export const InstructionBlockExtension =
                 content: [{ type: "paragraph" }],
               }
             );
+          },
+        }),
+      ];
+    },
 
-            // Focus will be handled automatically by TipTap
-            return null;
+    addProseMirrorPlugins() {
+      return [
+        new Plugin({
+          key: new PluginKey("instructionBlockAutoConvert"),
+          appendTransaction: (transactions, oldState, newState) => {
+            if (!transactions.some((tr) => tr.docChanged)) {
+              return null;
+            }
+
+            const { doc, tr, schema } = newState;
+            let modified = false;
+
+            doc.descendants((node, pos) => {
+              if (node.type.name !== "text" || !node.text) {
+                return;
+              }
+
+              const regex = /<(INFO|APPROACH|TOOLS)>([\s\S]*?)<\/\1>/g;
+              let match;
+
+              while ((match = regex.exec(node.text)) !== null) {
+                const matchStart = pos + match.index;
+                const matchEnd = matchStart + match[0].length;
+                const type = match[1].toLowerCase() as InstructionBlockType;
+                const content = match[2].trim();
+
+                // Create paragraph nodes from content
+                const paragraphs = content.split("\n").map((line) => {
+                  const trimmedLine = line.trim();
+                  return schema.nodes.paragraph.create(
+                    {},
+                    trimmedLine ? [schema.text(trimmedLine)] : []
+                  );
+                });
+
+                const blockContent =
+                  paragraphs.length > 0
+                    ? paragraphs
+                    : [schema.nodes.paragraph.create()];
+
+                const instructionBlock = this.type.create(
+                  { type },
+                  blockContent
+                );
+
+                tr.replaceWith(matchStart, matchEnd, instructionBlock);
+
+                // Position cursor in the block
+                const blockPos = matchStart + 1;
+                const paragraphPos = blockPos + 1;
+                tr.setSelection(TextSelection.create(tr.doc, paragraphPos));
+
+                modified = true;
+              }
+            });
+
+            return modified ? tr : null;
           },
         }),
       ];

--- a/front/components/agent_builder/instructions/InstructionBlockExtension.tsx
+++ b/front/components/agent_builder/instructions/InstructionBlockExtension.tsx
@@ -1,0 +1,369 @@
+import { mergeAttributes, Node, nodeInputRule, InputRule } from "@tiptap/core";
+import { Plugin, PluginKey } from "@tiptap/pm/state";
+import { TextSelection } from "@tiptap/pm/state";
+import { ReactNodeViewRenderer } from "@tiptap/react";
+import {
+  NodeViewContent,
+  NodeViewWrapper,
+  type NodeViewProps,
+} from "@tiptap/react";
+import React from "react";
+
+type InstructionBlockType = "info" | "approach" | "tools";
+
+interface InstructionBlockAttributes {
+  type: InstructionBlockType;
+}
+
+declare module "@tiptap/core" {
+  interface Commands<ReturnType> {
+    instructionBlock: {
+      setInstructionBlock: (
+        attributes?: InstructionBlockAttributes
+      ) => ReturnType;
+      insertInstructionBlock: (type: InstructionBlockType) => ReturnType;
+      insertParagraphAfterBlock: () => ReturnType;
+      insertParagraphBeforeBlock: () => ReturnType;
+    };
+  }
+}
+
+const InstructionBlockComponent = ({ node }: NodeViewProps) => {
+  const { type } = node.attrs as InstructionBlockAttributes;
+
+  const typeDisplayMap: Record<InstructionBlockType, string> = {
+    info: "INFO",
+    approach: "APPROACH",
+    tools: "TOOLS",
+  };
+
+  return (
+    <NodeViewWrapper className="my-4">
+      <div className="rounded-lg border border-border bg-muted-background p-4">
+        {/* Section Header */}
+        <div className="mb-3">
+          <span
+            className="select-none text-sm font-semibold uppercase tracking-wider text-muted-foreground"
+            contentEditable={false}
+          >
+            {typeDisplayMap[type]}
+          </span>
+        </div>
+
+        {/* Editable Content Area */}
+        <div className="min-h-[3rem] rounded border border-border/50 bg-background p-3">
+          <NodeViewContent className="prose prose-sm max-w-none outline-none" />
+        </div>
+      </div>
+    </NodeViewWrapper>
+  );
+};
+
+export const InstructionBlockExtension =
+  Node.create<InstructionBlockAttributes>({
+    name: "instructionBlock",
+    group: "block",
+    content: "block+",
+    defining: true,
+    draggable: true,
+
+    addAttributes() {
+      return {
+        type: {
+          default: "info" as InstructionBlockType,
+          parseHTML: (element) => {
+            const dataType = element.getAttribute("data-instruction-type");
+            return (dataType as InstructionBlockType) || "info";
+          },
+          renderHTML: (attributes) => {
+            if (!attributes.type) {
+              return {};
+            }
+            return {
+              "data-instruction-type": attributes.type,
+            };
+          },
+        },
+      };
+    },
+
+    parseHTML() {
+      return [
+        {
+          tag: "div[data-type='instruction-block']",
+        },
+        // Parse XML-style tags directly from HTML content
+        {
+          tag: "info",
+          getAttrs: () => ({ type: "info" }),
+        },
+        {
+          tag: "approach",
+          getAttrs: () => ({ type: "approach" }),
+        },
+        {
+          tag: "tools",
+          getAttrs: () => ({ type: "tools" }),
+        },
+      ];
+    },
+
+    renderHTML({ HTMLAttributes, node }) {
+      const { type } = node.attrs as InstructionBlockAttributes;
+
+      // For serialization to XML format, render as the XML tag
+      if (HTMLAttributes["data-serialize-as-xml"]) {
+        return [type.toUpperCase(), {}, 0];
+      }
+
+      // For normal HTML rendering, use div with data attributes
+      return [
+        "div",
+        mergeAttributes(HTMLAttributes, {
+          "data-type": "instruction-block",
+        }),
+        0,
+      ];
+    },
+
+    addCommands() {
+      return {
+        setInstructionBlock:
+          (attributes) =>
+          ({ commands }) => {
+            return commands.setNode(this.name, attributes);
+          },
+
+        insertInstructionBlock:
+          (type: InstructionBlockType) =>
+          ({ commands }) => {
+            return commands.insertContent({
+              type: this.name,
+              attrs: { type },
+              content: [{ type: "paragraph" }],
+            });
+          },
+
+        insertParagraphAfterBlock:
+          () =>
+          ({ state, dispatch }) => {
+            const { selection } = state;
+            const { $from } = selection;
+
+            // Find if we're in an instruction block
+            for (let depth = $from.depth; depth >= 0; depth--) {
+              const node = $from.node(depth);
+              if (node.type.name === this.name) {
+                const blockPos = $from.start(depth);
+                const blockEnd = blockPos + node.nodeSize;
+
+                if (dispatch) {
+                  const tr = state.tr.insert(
+                    blockEnd,
+                    state.schema.nodes.paragraph.create()
+                  );
+                  tr.setSelection(
+                    TextSelection.near(tr.doc.resolve(blockEnd + 1))
+                  );
+                  dispatch(tr);
+                }
+                return true;
+              }
+            }
+            return false;
+          },
+
+        insertParagraphBeforeBlock:
+          () =>
+          ({ state, dispatch }) => {
+            const { selection } = state;
+            const { $from } = selection;
+
+            // Find if we're in an instruction block
+            for (let depth = $from.depth; depth >= 0; depth--) {
+              const node = $from.node(depth);
+              if (node.type.name === this.name) {
+                const blockPos = $from.start(depth);
+
+                if (dispatch) {
+                  const tr = state.tr.insert(
+                    blockPos,
+                    state.schema.nodes.paragraph.create()
+                  );
+                  tr.setSelection(
+                    TextSelection.near(tr.doc.resolve(blockPos + 1))
+                  );
+                  dispatch(tr);
+                }
+                return true;
+              }
+            }
+            return false;
+          },
+      };
+    },
+
+    addKeyboardShortcuts() {
+      return {
+        "Mod-Shift-i": () => {
+          return this.editor.commands.insertInstructionBlock("info");
+        },
+        "Mod-Shift-a": () => {
+          return this.editor.commands.insertInstructionBlock("approach");
+        },
+        "Mod-Shift-t": () => {
+          return this.editor.commands.insertInstructionBlock("tools");
+        },
+        "Mod-Enter": ({ editor }) => {
+          // Create paragraph after block
+          return editor.commands.insertParagraphAfterBlock();
+        },
+        "Mod-Shift-Enter": ({ editor }) => {
+          // Create paragraph before block
+          return editor.commands.insertParagraphBeforeBlock();
+        },
+        ArrowUp: ({ editor }) => {
+          const { selection, doc } = editor.state;
+          const { $from } = selection;
+
+          // Check if we're at the start of an instruction block
+          if (
+            $from.depth >= 2 &&
+            $from.node($from.depth - 1).type.name === this.name
+          ) {
+            const blockPos = $from.start($from.depth - 1);
+            if ($from.parentOffset === 0 && $from.pos === $from.start()) {
+              // We're at the very start of the block content, move cursor before the block
+              const newPos = Math.max(0, blockPos - 1);
+              editor.commands.setTextSelection(newPos);
+              return true;
+            }
+          }
+          return false;
+        },
+        ArrowDown: ({ editor }) => {
+          const { selection, doc } = editor.state;
+          const { $from } = selection;
+
+          // Check if we're at the end of an instruction block
+          if (
+            $from.depth >= 2 &&
+            $from.node($from.depth - 1).type.name === this.name
+          ) {
+            const blockNode = $from.node($from.depth - 1);
+            const blockPos = $from.start($from.depth - 1);
+            const blockEnd = blockPos + blockNode.nodeSize;
+
+            // Check if we're at the end of the block content
+            if ($from.pos === $from.end()) {
+              // Move cursor after the block
+              const newPos = Math.min(doc.content.size, blockEnd);
+              editor.commands.setTextSelection(newPos);
+              return true;
+            }
+          }
+          return false;
+        },
+      };
+    },
+
+    addNodeView() {
+      return ReactNodeViewRenderer(InstructionBlockComponent);
+    },
+
+    addProseMirrorPlugins() {
+      return [
+        new Plugin({
+          key: new PluginKey("instructionBlockAutoConvert"),
+          appendTransaction: (transactions, oldState, newState) => {
+            const docChanged = transactions.some((tr) => tr.docChanged);
+            if (!docChanged) return null;
+
+            const { doc, tr } = newState;
+            const { schema } = newState;
+            let modified = false;
+
+            // Find text nodes that contain complete instruction block patterns
+            doc.descendants((node, pos) => {
+              if (node.type.name === "text" && node.text) {
+                const text = node.text;
+                const regex = /<(INFO|APPROACH|TOOLS)>([\s\S]*?)<\/\1>/g;
+                let match;
+
+                while ((match = regex.exec(text)) !== null) {
+                  const matchStart = pos + match.index;
+                  const matchEnd = matchStart + match[0].length;
+                  const type = match[1].toLowerCase() as InstructionBlockType;
+                  const content = match[2].trim();
+
+                  // Create paragraphs from content
+                  const lines = content.split("\n");
+                  const paragraphs = lines.map((line) => {
+                    const trimmedLine = line.trim();
+                    return schema.nodes.paragraph.create(
+                      {},
+                      trimmedLine ? [schema.text(trimmedLine)] : []
+                    );
+                  });
+
+                  const blockContent =
+                    paragraphs.length > 0
+                      ? paragraphs
+                      : [schema.nodes.paragraph.create()];
+                  const instructionBlock = this.type.create(
+                    { type },
+                    blockContent
+                  );
+
+                  tr.replaceWith(matchStart, matchEnd, instructionBlock);
+
+                  // Set cursor inside the new block
+                  const newBlockPos = matchStart + 1; // Position after the block node
+                  const resolvedPos = tr.doc.resolve(newBlockPos);
+                  if (resolvedPos.depth > 0) {
+                    // Find the first paragraph inside the block and position cursor there
+                    const blockNode = resolvedPos.nodeAfter;
+                    if (blockNode && blockNode.content.size > 0) {
+                      const firstParagraphPos = newBlockPos + 1;
+                      tr.setSelection(
+                        TextSelection.create(tr.doc, firstParagraphPos)
+                      );
+                    }
+                  }
+
+                  modified = true;
+                }
+              }
+            });
+
+            return modified ? tr : null;
+          },
+        }),
+      ];
+    },
+
+    addInputRules() {
+      return [
+        // Custom input rule for opening tags
+        new InputRule({
+          find: /<(INFO|APPROACH|TOOLS)>$/,
+          handler: ({ state, range, match, commands }) => {
+            const type = match[1].toLowerCase() as InstructionBlockType;
+
+            // Use the insertContent command to properly insert the block
+            commands.insertContentAt(
+              { from: range.from, to: range.to },
+              {
+                type: this.name,
+                attrs: { type },
+                content: [{ type: "paragraph" }],
+              }
+            );
+
+            // Focus will be handled automatically by TipTap
+            return null;
+          },
+        }),
+      ];
+    },
+  });

--- a/front/components/agent_builder/instructions/InstructionBlockExtension.tsx
+++ b/front/components/agent_builder/instructions/InstructionBlockExtension.tsx
@@ -41,14 +41,12 @@ const InstructionBlockComponent: React.FC<NodeViewProps> = ({ node }) => {
   return (
     <NodeViewWrapper className="my-4">
       <div className="rounded-lg border border-border bg-muted-background p-4">
-        <div className="mb-3">
-          <span
-            className="text-sm font-semibold text-muted-foreground"
-            contentEditable={false}
-          >
-            {type.toUpperCase()}
-          </span>
-        </div>
+        <span
+          className="text-sm font-semibold text-muted-foreground"
+          contentEditable={false}
+        >
+          {type.toUpperCase()}
+        </span>
         <div className="min-h-12 rounded border border-border/50 bg-background p-3">
           <NodeViewContent className="prose prose-sm" />
         </div>

--- a/front/components/agent_builder/instructions/InstructionBlockExtension.tsx
+++ b/front/components/agent_builder/instructions/InstructionBlockExtension.tsx
@@ -43,14 +43,14 @@ const InstructionBlockComponent: React.FC<NodeViewProps> = ({ node }) => {
       <div className="rounded-lg border border-border bg-muted-background p-4">
         <div className="mb-3">
           <span
-            className="select-none text-sm font-semibold uppercase tracking-wider text-muted-foreground"
+            className="text-sm font-semibold text-muted-foreground"
             contentEditable={false}
           >
             {type.toUpperCase()}
           </span>
         </div>
-        <div className="min-h-[3rem] rounded border border-border/50 bg-background p-3">
-          <NodeViewContent className="prose prose-sm max-w-none outline-none" />
+        <div className="min-h-12 rounded border border-border/50 bg-background p-3">
+          <NodeViewContent className="prose prose-sm" />
         </div>
       </div>
     </NodeViewWrapper>
@@ -63,7 +63,6 @@ export const InstructionBlockExtension =
     group: "block",
     content: "block+",
     defining: true,
-    draggable: true,
 
     addAttributes() {
       return {

--- a/front/lib/client/assistant_builder/instructionBlockUtils.ts
+++ b/front/lib/client/assistant_builder/instructionBlockUtils.ts
@@ -1,0 +1,161 @@
+import type { Node as ProseMirrorNode, Schema } from "@tiptap/pm/model";
+import type { JSONContent } from "@tiptap/react";
+
+/**
+ * Regex pattern for matching XML-style instruction blocks
+ */
+export const INSTRUCTION_BLOCK_REGEX = /<(\w+)>([\s\S]*?)<\/\1>/g;
+
+/**
+ * Regex pattern for matching opening XML tags
+ */
+export const OPENING_TAG_REGEX = /<(\w+)>$/;
+
+/**
+ * Interface for parsed instruction block match
+ */
+export interface InstructionBlockMatch {
+  fullMatch: string;
+  type: string;
+  content: string;
+  start: number;
+  end: number;
+}
+
+/**
+ * Parse instruction block matches from text
+ */
+export function parseInstructionBlockMatches(text: string): InstructionBlockMatch[] {
+  const matches: InstructionBlockMatch[] = [];
+  const regex = new RegExp(INSTRUCTION_BLOCK_REGEX.source, INSTRUCTION_BLOCK_REGEX.flags);
+  let match;
+
+  while ((match = regex.exec(text)) !== null) {
+    matches.push({
+      fullMatch: match[0],
+      type: match[1].toLowerCase(),
+      content: match[2].trim(),
+      start: match.index,
+      end: match.index + match[0].length,
+    });
+  }
+
+  return matches;
+}
+
+/**
+ * Convert text content to paragraph JSONContent nodes
+ */
+export function textToParagraphNodes(content: string): JSONContent[] {
+  const lines = content.split("\n");
+  return lines.map((line) => ({
+    type: "paragraph",
+    content: line.trim() ? [{ type: "text", text: line.trim() }] : [],
+  }));
+}
+
+/**
+ * Convert text content to ProseMirror paragraph nodes
+ */
+export function textToProseMirrorParagraphs(content: string, schema: Schema): ProseMirrorNode[] {
+  const lines = content.split("\n");
+  return lines.map((line) => {
+    const trimmedLine = line.trim();
+    return schema.nodes.paragraph.create(
+      {},
+      trimmedLine ? [schema.text(trimmedLine)] : []
+    );
+  });
+}
+
+/**
+ * Create instruction block JSONContent
+ */
+export function createInstructionBlockNode(type: string, content: string): JSONContent {
+  const paragraphs = textToParagraphNodes(content);
+  const blockContent = paragraphs.length > 0 ? paragraphs : [{ type: "paragraph", content: [] }];
+
+  return {
+    type: "instructionBlock",
+    attrs: { type },
+    content: blockContent,
+  };
+}
+
+/**
+ * Create ProseMirror instruction block node
+ */
+export function createProseMirrorInstructionBlock(
+  type: string, 
+  content: string, 
+  nodeType: any, 
+  schema: Schema
+): ProseMirrorNode {
+  const paragraphs = textToProseMirrorParagraphs(content, schema);
+  const blockContent = paragraphs.length > 0 ? paragraphs : [schema.nodes.paragraph.create()];
+  
+  return nodeType.create({ type }, blockContent);
+}
+
+/**
+ * Process text and split around instruction blocks
+ */
+export function splitTextAroundBlocks(text: string): Array<{
+  type: "text" | "block";
+  content: string;
+  blockType?: string;
+  start: number;
+  end: number;
+}> {
+  const result: Array<{
+    type: "text" | "block";
+    content: string;
+    blockType?: string;
+    start: number;
+    end: number;
+  }> = [];
+  
+  const matches = parseInstructionBlockMatches(text);
+  let lastIndex = 0;
+
+  matches.forEach((match) => {
+    // Add text before the block
+    if (match.start > lastIndex) {
+      const beforeText = text.slice(lastIndex, match.start).trim();
+      if (beforeText) {
+        result.push({
+          type: "text",
+          content: beforeText,
+          start: lastIndex,
+          end: match.start,
+        });
+      }
+    }
+
+    // Add the block
+    result.push({
+      type: "block",
+      content: match.content,
+      blockType: match.type,
+      start: match.start,
+      end: match.end,
+    });
+
+    lastIndex = match.end;
+  });
+
+  // Add remaining text
+  if (lastIndex < text.length) {
+    const remainingText = text.slice(lastIndex).trim();
+    if (remainingText) {
+      result.push({
+        type: "text",
+        content: remainingText,
+        start: lastIndex,
+        end: text.length,
+      });
+    }
+  }
+
+  return result;
+}

--- a/front/lib/client/assistant_builder/instructionBlockUtils.ts
+++ b/front/lib/client/assistant_builder/instructionBlockUtils.ts
@@ -1,4 +1,5 @@
 import type { Node as ProseMirrorNode, Schema } from "@tiptap/pm/model";
+import { NodeType } from "@tiptap/pm/model";
 import type { JSONContent } from "@tiptap/react";
 
 /**
@@ -25,9 +26,14 @@ export interface InstructionBlockMatch {
 /**
  * Parse instruction block matches from text
  */
-export function parseInstructionBlockMatches(text: string): InstructionBlockMatch[] {
+export function parseInstructionBlockMatches(
+  text: string
+): InstructionBlockMatch[] {
   const matches: InstructionBlockMatch[] = [];
-  const regex = new RegExp(INSTRUCTION_BLOCK_REGEX.source, INSTRUCTION_BLOCK_REGEX.flags);
+  const regex = new RegExp(
+    INSTRUCTION_BLOCK_REGEX.source,
+    INSTRUCTION_BLOCK_REGEX.flags
+  );
   let match;
 
   while ((match = regex.exec(text)) !== null) {
@@ -57,7 +63,10 @@ export function textToParagraphNodes(content: string): JSONContent[] {
 /**
  * Convert text content to ProseMirror paragraph nodes
  */
-export function textToProseMirrorParagraphs(content: string, schema: Schema): ProseMirrorNode[] {
+export function textToProseMirrorParagraphs(
+  content: string,
+  schema: Schema
+): ProseMirrorNode[] {
   const lines = content.split("\n");
   return lines.map((line) => {
     const trimmedLine = line.trim();
@@ -71,9 +80,13 @@ export function textToProseMirrorParagraphs(content: string, schema: Schema): Pr
 /**
  * Create instruction block JSONContent
  */
-export function createInstructionBlockNode(type: string, content: string): JSONContent {
+export function createInstructionBlockNode(
+  type: string,
+  content: string
+): JSONContent {
   const paragraphs = textToParagraphNodes(content);
-  const blockContent = paragraphs.length > 0 ? paragraphs : [{ type: "paragraph", content: [] }];
+  const blockContent =
+    paragraphs.length > 0 ? paragraphs : [{ type: "paragraph", content: [] }];
 
   return {
     type: "instructionBlock",
@@ -86,14 +99,15 @@ export function createInstructionBlockNode(type: string, content: string): JSONC
  * Create ProseMirror instruction block node
  */
 export function createProseMirrorInstructionBlock(
-  type: string, 
-  content: string, 
-  nodeType: any, 
+  type: string,
+  content: string,
+  nodeType: NodeType,
   schema: Schema
 ): ProseMirrorNode {
   const paragraphs = textToProseMirrorParagraphs(content, schema);
-  const blockContent = paragraphs.length > 0 ? paragraphs : [schema.nodes.paragraph.create()];
-  
+  const blockContent =
+    paragraphs.length > 0 ? paragraphs : [schema.nodes.paragraph.create()];
+
   return nodeType.create({ type }, blockContent);
 }
 
@@ -114,7 +128,7 @@ export function splitTextAroundBlocks(text: string): Array<{
     start: number;
     end: number;
   }> = [];
-  
+
   const matches = parseInstructionBlockMatches(text);
   let lastIndex = 0;
 

--- a/front/lib/client/assistant_builder/instructionBlockUtils.ts
+++ b/front/lib/client/assistant_builder/instructionBlockUtils.ts
@@ -1,5 +1,5 @@
 import type { Node as ProseMirrorNode, Schema } from "@tiptap/pm/model";
-import { NodeType } from "@tiptap/pm/model";
+import type { NodeType } from "@tiptap/pm/model";
 import type { JSONContent } from "@tiptap/react";
 
 /**

--- a/front/lib/client/assistant_builder/instructions.ts
+++ b/front/lib/client/assistant_builder/instructions.ts
@@ -47,7 +47,7 @@ export function plainTextFromTipTapContent(root: JSONContent): string {
 
 function parseInstructionBlocks(text: string): JSONContent[] {
   const content: JSONContent[] = [];
-  const instructionBlockRegex = /<(INFO|APPROACH|TOOLS)>([\s\S]*?)<\/\1>/gi;
+  const instructionBlockRegex = /<(\w+)>([\s\S]*?)<\/\1>/gi;
   let lastIndex = 0;
   let match;
 
@@ -65,7 +65,7 @@ function parseInstructionBlocks(text: string): JSONContent[] {
     }
 
     // Add the instruction block
-    const type = match[1].toLowerCase() as "info" | "approach" | "tools";
+    const type = match[1].toLowerCase();
     const blockContent = match[2].trim();
 
     // Parse content inside the block as paragraphs

--- a/front/lib/client/assistant_builder/instructions.ts
+++ b/front/lib/client/assistant_builder/instructions.ts
@@ -1,9 +1,9 @@
 import type { JSONContent } from "@tiptap/react";
+
 import {
-  parseInstructionBlockMatches,
   createInstructionBlockNode,
-  textToParagraphNodes,
   splitTextAroundBlocks,
+  textToParagraphNodes,
 } from "@app/lib/client/assistant_builder/instructionBlockUtils";
 
 function serializeNodeToText(node: JSONContent): string {
@@ -56,13 +56,16 @@ function parseInstructionBlocks(text: string): JSONContent[] {
   const segments = splitTextAroundBlocks(text);
 
   segments.forEach((segment) => {
-    if (segment.type === 'text') {
+    if (segment.type === "text") {
       // Add text as paragraphs
       const paragraphs = textToParagraphNodes(segment.content);
       content.push(...paragraphs);
-    } else if (segment.type === 'block' && segment.blockType) {
+    } else if (segment.type === "block" && segment.blockType) {
       // Add instruction block
-      const blockNode = createInstructionBlockNode(segment.blockType, segment.content);
+      const blockNode = createInstructionBlockNode(
+        segment.blockType,
+        segment.content
+      );
       content.push(blockNode);
     }
   });

--- a/front/lib/client/assistant_builder/instructions.ts
+++ b/front/lib/client/assistant_builder/instructions.ts
@@ -1,38 +1,120 @@
 import type { JSONContent } from "@tiptap/react";
 
+function serializeNodeToText(node: JSONContent): string {
+  if (node.type === "instructionBlock") {
+    const type = node.attrs?.type as string;
+    const tagName = type?.toUpperCase() || "INFO";
+
+    // Serialize content inside the block
+    const content = node.content?.map(serializeNodeToText).join("") || "";
+
+    return `<${tagName}>\n${content}</${tagName}>\n`;
+  }
+
+  if (node.type === "paragraph") {
+    if (!node.content || !node.content.length) {
+      return "\n";
+    }
+
+    if (node.content.length === 1 && node.content[0].type === "text") {
+      return `${node.content[0].text}\n`;
+    }
+
+    // Handle multiple nodes in paragraph
+    const text = node.content.map(serializeNodeToText).join("");
+    return text ? `${text}\n` : "\n";
+  }
+
+  if (node.type === "text") {
+    return node.text || "";
+  }
+
+  // Handle other node types by recursing into their content
+  if (node.content) {
+    return node.content.map(serializeNodeToText).join("");
+  }
+
+  return "";
+}
+
 export function plainTextFromTipTapContent(root: JSONContent): string {
   if (root.type !== "doc" || !root.content) {
     return "";
   }
 
-  return root.content.reduce((acc, p) => {
-    // Ignore non-paragraph nodes
-    if (p.type !== "paragraph") {
-      return acc;
+  return root.content.map(serializeNodeToText).join("");
+}
+
+function parseInstructionBlocks(text: string): JSONContent[] {
+  const content: JSONContent[] = [];
+  const instructionBlockRegex = /<(INFO|APPROACH|TOOLS)>([\s\S]*?)<\/\1>/gi;
+  let lastIndex = 0;
+  let match;
+
+  while ((match = instructionBlockRegex.exec(text)) !== null) {
+    // Add content before the instruction block as regular paragraphs
+    const beforeBlock = text.slice(lastIndex, match.index).trim();
+    if (beforeBlock) {
+      const lines = beforeBlock.split("\n");
+      content.push(
+        ...lines.map((l) => ({
+          type: "paragraph",
+          content: l.trim() ? [{ type: "text", text: l.trim() }] : [],
+        }))
+      );
     }
 
-    // Empty paragraphs or paragraphs with multiple nodes are treated as newlines.
-    if (!p.content || !p.content.length || p.content.length > 1) {
-      return acc + "\n";
-    }
+    // Add the instruction block
+    const type = match[1].toLowerCase() as "info" | "approach" | "tools";
+    const blockContent = match[2].trim();
 
-    // Only paragraphs with a single text node are considered.
-    const textNode = p.content && p.content[0];
-    if (textNode.type !== "text") {
-      return acc;
-    }
+    // Parse content inside the block as paragraphs
+    const blockLines = blockContent.split("\n");
+    const blockParagraphs = blockLines.map((l) => ({
+      type: "paragraph",
+      content: l.trim() ? [{ type: "text", text: l.trim() }] : [],
+    }));
 
-    return acc + `${textNode.text}\n`;
-  }, "");
+    content.push({
+      type: "instructionBlock",
+      attrs: { type },
+      content:
+        blockParagraphs.length > 0
+          ? blockParagraphs
+          : [{ type: "paragraph", content: [] }],
+    });
+
+    lastIndex = instructionBlockRegex.lastIndex;
+  }
+
+  // Add remaining content as regular paragraphs
+  const remainingText = text.slice(lastIndex).trim();
+  if (remainingText) {
+    const lines = remainingText.split("\n");
+    content.push(
+      ...lines.map((l) => ({
+        type: "paragraph",
+        content: l.trim() ? [{ type: "text", text: l.trim() }] : [],
+      }))
+    );
+  }
+
+  return content;
 }
 
 export function tipTapContentFromPlainText(text: string): JSONContent {
-  const lines = text.split("\n");
+  if (!text.trim()) {
+    return {
+      type: "doc",
+      content: [{ type: "paragraph", content: [] }],
+    };
+  }
+
+  const content = parseInstructionBlocks(text);
+
   return {
     type: "doc",
-    content: lines.map((l) => ({
-      type: "paragraph",
-      content: l ? [{ type: "text", text: l }] : [],
-    })),
+    content:
+      content.length > 0 ? content : [{ type: "paragraph", content: [] }],
   };
 }


### PR DESCRIPTION
## Description

This PR implements instruction blocks in the Agent Builder editor, enabling structured sections using XML-style tags. The extension adds support for creating, editing, and pasting XML-formatted instruction blocks with custom types. The blocks are visually rendered as distinct sections with type labels and formatted content.

<img width="938" height="417" alt="Screenshot 2025-08-03 at 20 50 26" src="https://github.com/user-attachments/assets/adf3ab23-5e61-47b4-8cce-524c137f4fb9" />

Disclaimer: this is a POC and isn't fully functional.

## Risk

None

## Deploy Plan

Deploy front