### PR TITLE
Skip and log a warning when a tools arguments is badly named

### DIFF
--- a/front/lib/actions/mcp_actions.test.ts
+++ b/front/lib/actions/mcp_actions.test.ts
@@ -32,6 +32,13 @@ describe("getPrefixedToolName", () => {
     expect(result.value).toBe(`test_server${TOOL_NAME_SEPARATOR}my_tool`);
   });
 
+  it("should correctly prefix and slugify tool names with special characters", () => {
+    const result = getPrefixedToolName(mockConfig, "My Tool (123) $");
+    expect(result.isOk()).toBe(true);
+    assert(result.isOk());
+    expect(result.value).toBe(`test_server${TOOL_NAME_SEPARATOR}my_tool_123_`);
+  });
+
   it("should handle tool names that are too long for prefixing", () => {
     const longToolName = "a".repeat(60);
     const result = getPrefixedToolName(mockConfig, longToolName);


### PR DESCRIPTION
## Description

Skip the tool and log a warning if:
- the tool name couldn't be prefixed correctly.
- the tool has argument(s) with incomptible names.

## Tests

Local + added

## Risk

Low

## Deploy Plan

Deploy front