### PR TITLE
[front] Fix padding around conversation title in `Agent`/`AssistantBuilder`

### DIFF
--- a/front/components/agent_builder/AgentBuilderPreview.tsx
+++ b/front/components/agent_builder/AgentBuilderPreview.tsx
@@ -105,7 +105,7 @@ export function AgentBuilderPreview() {
     return (
       <div className="flex h-full flex-col">
         {conversation && (
-          <div className="flex items-center justify-between px-4 py-3">
+          <div className="flex items-center justify-between px-6 py-3">
             <h2 className="font-semibold text-foreground dark:text-foreground-night">
               {conversation.title}
             </h2>

--- a/front/components/assistant_builder/AssistantBuilderPreviewDrawer.tsx
+++ b/front/components/assistant_builder/AssistantBuilderPreviewDrawer.tsx
@@ -220,7 +220,7 @@ export default function AssistantBuilderRightPanel({
                   <GenerationContextProvider>
                     <div className="flex h-full flex-col">
                       {conversation && (
-                        <div className="flex items-center justify-between px-4 py-3">
+                        <div className="flex items-center justify-between py-3">
                           <h2 className="font-semibold text-foreground dark:text-foreground-night">
                             {conversation.title}
                           </h2>


### PR DESCRIPTION
## Description

- Follow up on https://github.com/dust-tt/dust/pull/14751.
- This PR fixes the padding around the conversation title + reset conversation button to align with the separator above.

## Tests

- Checked locally.

## Risk

- Very low, only UI.

## Deploy Plan

- Deploy front.
