### PR TITLE
[sparkle] Adjust markdown font size

### DIFF
--- a/sparkle/src/components/markdown/Markdown.tsx
+++ b/sparkle/src/components/markdown/Markdown.tsx
@@ -29,12 +29,12 @@ import { cn } from "@sparkle/lib/utils";
 
 const sizes = {
   p: "s-copy-sm @sm:s-text-base @sm:s-leading-7",
-  h1: "s-heading-3xl",
-  h2: "s-heading-2xl",
-  h3: "s-heading-xl",
-  h4: "s-heading-lg",
-  h5: "s-text-base s-font-bold",
-  h6: "s-text-base s-font-regular s-italic",
+  h1: "s-heading-2xl",
+  h2: "s-heading-xl",
+  h3: "s-heading-lg",
+  h4: "s-text-base s-font-semibold",
+  h5: "s-text-sm s-font-semibold",
+  h6: "s-text-sm s-font-regular s-italic",
 };
 
 function showUnsupportedDirective() {

--- a/sparkle/src/stories/Markdown.stories.tsx
+++ b/sparkle/src/stories/Markdown.stories.tsx
@@ -29,6 +29,13 @@ const example = `
 
 ### Level 3 Title
 
+#### Level 4 Title
+
+##### Level 5 Title
+
+###### Level 6 Title
+
+
 This is a paragraph with **bold** text and *italic* text. This is \`code\` block:
 \`\`\`
 Block 


### PR DESCRIPTION
## Description
This PR is to scale down the font size of heading in markdown, since it's currently too big 🥺

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
