### PR TITLE
[front] fix: Fix same name workspace selector

### DIFF
--- a/front/components/UserMenu.tsx
+++ b/front/components/UserMenu.tsx
@@ -123,12 +123,12 @@ export function UserMenu({
         {hasMultipleWorkspaces && (
           <>
             <DropdownMenuLabel label="Workspace" />
-            <DropdownMenuRadioGroup value={owner.name}>
+            <DropdownMenuRadioGroup value={owner.sId}>
               {"workspaces" in user &&
                 user.workspaces.map((w) => (
                   <DropdownMenuRadioItem
                     key={w.sId}
-                    value={w.name}
+                    value={w.sId}
                     onClick={async () => {
                       await setNavigationSelection({
                         lastWorkspaceId: w.sId,

--- a/front/components/WorkspacePicker.tsx
+++ b/front/components/WorkspacePicker.tsx
@@ -37,7 +37,7 @@ export default function WorkspacePicker({
           />
         </DropdownMenuTrigger>
         <DropdownMenuContent>
-          <DropdownMenuRadioGroup value={workspace.name}>
+          <DropdownMenuRadioGroup value={workspace.sId}>
             {user.workspaces.map((w) => {
               return (
                 <DropdownMenuRadioItem
@@ -46,7 +46,7 @@ export default function WorkspacePicker({
                     await setNavigationSelection({ lastWorkspaceId: w.sId });
                     void onWorkspaceUpdate(w);
                   }}
-                  value={w.name}
+                  value={w.sId}
                 >
                   {w.name}
                 </DropdownMenuRadioItem>


### PR DESCRIPTION
## Description
- If a user has more than one workspace with the same name, and because we use the name as a key, it's not unique so we don't display correctly the one they're in
<img width="318" height="225" alt="Capture d’écran 2025-08-04 à 10 12 25" src="https://github.com/user-attachments/assets/d7e4dc41-1ac9-4c4d-9f43-94e29fe95339" />
<img width="322" height="563" alt="Capture d’écran 2025-08-04 à 10 09 55" src="https://github.com/user-attachments/assets/5aab1d7b-9b29-4ed2-9f78-5e4a1a297f35" />

- Use the `sId` instead to make sure its a unique key.
## Tests
- Locally, switch still work as the link is using the `sId`

## Risk
- Low, could block users to switch workspaces. But very light PR, easy to review and to revert

## Deploy Plan
- Deploy front
