### PR TITLE
[front] - fix(AB v2): "Shift+Enter" in instructions

### DIFF
--- a/front/components/agent_builder/instructions/AgentBuilderInstructionsEditor.tsx
+++ b/front/components/agent_builder/instructions/AgentBuilderInstructionsEditor.tsx
@@ -2,10 +2,10 @@ import { cn } from "@dust-tt/sparkle";
 import { CharacterCount } from "@tiptap/extension-character-count";
 import Document from "@tiptap/extension-document";
 import { History } from "@tiptap/extension-history";
+import { ListItem } from "@tiptap/extension-list-item";
 import Text from "@tiptap/extension-text";
 import { EditorContent, useEditor } from "@tiptap/react";
 import { cva } from "class-variance-authority";
-import { ListItem } from "@tiptap/extension-list-item";
 import React, { useEffect, useMemo } from "react";
 import { useController, useWatch } from "react-hook-form";
 

--- a/front/components/agent_builder/instructions/AgentBuilderInstructionsEditor.tsx
+++ b/front/components/agent_builder/instructions/AgentBuilderInstructionsEditor.tsx
@@ -5,6 +5,7 @@ import { History } from "@tiptap/extension-history";
 import Text from "@tiptap/extension-text";
 import { EditorContent, useEditor } from "@tiptap/react";
 import { cva } from "class-variance-authority";
+import { ListItem } from "@tiptap/extension-list-item";
 import React, { useEffect, useMemo } from "react";
 import { useController, useWatch } from "react-hook-form";
 
@@ -105,6 +106,7 @@ export function AgentBuilderInstructionsEditor({
 
   const extensions = useMemo(() => {
     const baseExtensions = [
+      ListItem,
       Document,
       Text,
       ParagraphExtension,


### PR DESCRIPTION
## Description

 This PR includes `ListItem` extension from `@tiptap/extension-list-item`, it was previously breaking when hitting "Shift+Enter".

## Tests

Locally

## Risk

None

## Deploy Plan

Deploy front