### PR TITLE
[connectors] Add not synced reason to ticket check

### DIFF
--- a/connectors/src/connectors/zendesk/lib/cli.ts
+++ b/connectors/src/connectors/zendesk/lib/cli.ts
@@ -45,6 +45,7 @@ import type {
   ZendeskGetRetentionPeriodResponseType,
   ZendeskOrganizationTagResponseType,
 } from "@connectors/types";
+import { normalizeError } from "@connectors/types";
 
 function getTagsArgs(args: ZendeskCommandType["args"]) {
   const tag = args.tag;
@@ -81,7 +82,7 @@ async function checkTicketShouldBeSynced(
   logger: Logger
 ) {
   if (!ticket) {
-    return false;
+    return { shouldSync: false, reason: "Ticket not found" };
   }
 
   let organizationTags: string[] = [];
@@ -232,7 +233,10 @@ export const zendesk = async ({
         } catch (e) {
           return {
             ticket: null,
-            shouldSyncTicket: false,
+            shouldSyncTicket: {
+              shouldSync: false,
+              reason: `Error getting ticket metadata: ${normalizeError(e).message}`,
+            },
             isTicketOnDb: false,
           };
         }

--- a/connectors/src/connectors/zendesk/lib/sync_ticket.ts
+++ b/connectors/src/connectors/zendesk/lib/sync_ticket.ts
@@ -35,18 +35,24 @@ export function shouldSyncTicket(
     organizationTags = [],
     ticketTags = [],
   }: { brandId?: number; organizationTags?: string[]; ticketTags?: string[] }
-): boolean {
+): { shouldSync: false; reason: string } | { shouldSync: true; reason: null } {
   if (ticket.status === "deleted") {
-    return false;
+    return { shouldSync: false, reason: "Ticket is deleted." };
   }
   if (
     !configuration.syncUnresolvedTickets &&
     !["closed", "solved"].includes(ticket.status)
   ) {
-    return false;
+    return {
+      shouldSync: false,
+      reason: `Ticket is not resolved, status: ${ticket.status}.`,
+    };
   }
   if (brandId && brandId !== ticket.brand_id) {
-    return false;
+    return {
+      shouldSync: false,
+      reason: `Ticket does not belong to the brand, ticket brand: ${ticket.brand_id}, expected: ${brandId}.`,
+    };
   }
 
   // If we enforce an inclusion rule on organization tags, all tickets must have at least one of the
@@ -58,7 +64,10 @@ export function shouldSyncTicket(
       organizationTags.includes(mandatoryTag)
     )
   ) {
-    return false;
+    return {
+      shouldSync: false,
+      reason: "Ticket does not match any of the required organization tags.",
+    };
   }
 
   // If we enforce an exclusion rule on organization tags, we must not have any of the
@@ -70,7 +79,10 @@ export function shouldSyncTicket(
       organizationTags.includes(prohibitedTag)
     )
   ) {
-    return false;
+    return {
+      shouldSync: false,
+      reason: "Ticket contains prohibited organization tags.",
+    };
   }
 
   // If we enforce an inclusion rule on ticket tags, we must have at least one of the
@@ -82,7 +94,10 @@ export function shouldSyncTicket(
       ticketTags.includes(mandatoryTag)
     )
   ) {
-    return false;
+    return {
+      shouldSync: false,
+      reason: "Ticket does not match any of the required tags.",
+    };
   }
 
   // If we enforce an exclusion rule on ticket tags, we must not have any of the
@@ -94,11 +109,11 @@ export function shouldSyncTicket(
       ticketTags.includes(prohibitedTag)
     )
   ) {
-    return false;
+    return { shouldSync: false, reason: "Ticket contains prohibited tags." };
   }
 
   // All checks passed.
-  return true;
+  return { shouldSync: true, reason: null };
 }
 
 export function extractMetadataFromDocumentUrl(ticketUrl: string): {

--- a/connectors/src/connectors/zendesk/temporal/activities.ts
+++ b/connectors/src/connectors/zendesk/temporal/activities.ts
@@ -684,7 +684,7 @@ export async function syncZendeskTicketBatchActivity({
       brandId,
       organizationTags,
       ticketTags: t.tags,
-    });
+    }).shouldSync;
   });
 
   const comments2d = await concurrentExecutor(

--- a/connectors/src/connectors/zendesk/temporal/incremental_activities.ts
+++ b/connectors/src/connectors/zendesk/temporal/incremental_activities.ts
@@ -335,7 +335,7 @@ export async function syncZendeskTicketUpdateBatchActivity({
           brandId,
           organizationTags,
           ticketTags: ticket.tags,
-        })
+        }).shouldSync
       ) {
         const comments = commentsPerTicket[ticket.id];
         if (!comments) {

--- a/connectors/src/types/admin/cli.ts
+++ b/connectors/src/types/admin/cli.ts
@@ -725,7 +725,10 @@ export type ZendeskCountTicketsResponseType = t.TypeOf<
 
 export const ZendeskFetchTicketResponseSchema = t.type({
   ticket: t.union([t.UnknownRecord, t.null]), // Zendesk type, can't be iots'd,
-  shouldSyncTicket: t.boolean,
+  shouldSyncTicket: t.type({
+    shouldSync: t.boolean,
+    reason: t.union([t.string, t.null]),
+  }),
   isTicketOnDb: t.boolean,
 });
 export type ZendeskFetchTicketResponseType = t.TypeOf<

--- a/front/pages/poke/[wId]/data_sources/[dsId]/index.tsx
+++ b/front/pages/poke/[wId]/data_sources/[dsId]/index.tsx
@@ -1073,20 +1073,21 @@ function ZendeskTicketCheck({
               {ticketDetails.ticket && (
                 <Tooltip
                   label={
-                    ticketDetails.shouldSyncTicket
-                      ? "Looking at its state, the ticket should be synced with Dust."
-                      : "Looking at its state, the ticket should not be synced with Dust."
+                    ticketDetails.shouldSyncTicket.reason ??
+                    "Looking at its state, the ticket should be synced with Dust."
                   }
                   className="max-w-md"
                   trigger={
                     <Chip
                       label={
-                        ticketDetails.shouldSyncTicket
+                        ticketDetails.shouldSyncTicket.shouldSync
                           ? "Should be synced"
                           : "Should not be synced"
                       }
                       color={
-                        ticketDetails.shouldSyncTicket ? "success" : "info"
+                        ticketDetails.shouldSyncTicket.shouldSync
+                          ? "success"
+                          : "info"
                       }
                     />
                   }

--- a/front/types/connectors/admin/cli.ts
+++ b/front/types/connectors/admin/cli.ts
@@ -725,7 +725,10 @@ export type ZendeskCountTicketsResponseType = t.TypeOf<
 
 export const ZendeskFetchTicketResponseSchema = t.type({
   ticket: t.union([t.UnknownRecord, t.null]), // Zendesk type, can't be iots'd,
-  shouldSyncTicket: t.boolean,
+  shouldSyncTicket: t.type({
+    shouldSync: t.boolean,
+    reason: t.union([t.string, t.null]),
+  }),
   isTicketOnDb: t.boolean,
 });
 export type ZendeskFetchTicketResponseType = t.TypeOf<


### PR DESCRIPTION
## Description

- This PR adds a `reason` metadata to the check on ticket that should be synced or not.
- This reason is exposed in the poke connector page (in the tooltip of the third chip).

<img width="534" height="169" alt="Screenshot 2025-08-04 at 11 00 57 AM" src="https://github.com/user-attachments/assets/5c26f14c-afe1-4b3c-aa67-8f7640e7aa9d" />

## Tests

- Tested through the CLI + poke.

## Risk

- Low.

## Deploy Plan

- Deploy connectors.
- Deploy front (will create a weird behavior on the poke plugin for a few minutes but really ok).
