### PR TITLE
[sparkle] - fix(index): export MultiPageDialog components

### DIFF
--- a/sparkle/src/components/index.ts
+++ b/sparkle/src/components/index.ts
@@ -97,6 +97,16 @@ export { LinkWrapper } from "./LinkWrapper";
 export { LoadingBlock } from "./LoadingBlock";
 export * from "./markdown";
 export { markdownStyles } from "./markdown/styles";
+export type {
+  MultiPageDialogPage,
+  MultiPageDialogProps,
+} from "./MultiPageDialog";
+export {
+  MultiPageDialog,
+  MultiPageDialogClose,
+  MultiPageDialogContent,
+  MultiPageDialogTrigger,
+} from "./MultiPageDialog";
 export {
   MultiPageSheet,
   MultiPageSheetClose,


### PR DESCRIPTION
## Description

This PR properly export the `MultiPageDialog` components and types.

## Risk

Low

## Deploy Plan

N/A