### PR TITLE
[front] Make size consistent

### DIFF
--- a/front/components/sparkle/AppCenteredLayout.tsx
+++ b/front/components/sparkle/AppCenteredLayout.tsx
@@ -19,7 +19,9 @@ export function AppCenteredLayout({
   return (
     <AppContentLayout hasTitle={!!title} {...props}>
       {title && title}
-      <div className="flex h-full w-full flex-col items-center overflow-y-auto pt-8">
+      <div
+        className={`flex w-full flex-col items-center overflow-y-auto pt-4 ${title ? "h-[calc(100vh-4.5rem)]" : "h-full"}`}
+      >
         <div className="flex w-full max-w-4xl grow flex-col px-4 sm:px-8">
           {children}
         </div>

--- a/front/components/sparkle/AppCenteredLayout.tsx
+++ b/front/components/sparkle/AppCenteredLayout.tsx
@@ -1,3 +1,5 @@
+import { cn } from "@dust-tt/sparkle";
+
 import type { AppContentLayoutProps } from "@app/components/sparkle/AppContentLayout";
 import AppContentLayout from "@app/components/sparkle/AppContentLayout";
 
@@ -20,7 +22,10 @@ export function AppCenteredLayout({
     <AppContentLayout hasTitle={!!title} {...props}>
       {title && title}
       <div
-        className={`flex w-full flex-col items-center overflow-y-auto pt-4 ${title ? "h-[calc(100vh-3.5rem)]" : "h-full"}`}
+        className={cn(
+          "flex w-full flex-col items-center overflow-y-auto pt-4",
+          title ? "h-[calc(100vh-3.5rem)]" : "h-full"
+        )}
       >
         <div className="flex w-full max-w-4xl grow flex-col px-4 sm:px-8">
           {children}

--- a/front/components/sparkle/AppCenteredLayout.tsx
+++ b/front/components/sparkle/AppCenteredLayout.tsx
@@ -20,7 +20,7 @@ export function AppCenteredLayout({
     <AppContentLayout hasTitle={!!title} {...props}>
       {title && title}
       <div
-        className={`flex w-full flex-col items-center overflow-y-auto pt-4 ${title ? "h-[calc(100vh-4rem)]" : "h-full"}`}
+        className={`flex w-full flex-col items-center overflow-y-auto pt-4 ${title ? "h-[calc(100vh-3.5rem)]" : "h-full"}`}
       >
         <div className="flex w-full max-w-4xl grow flex-col px-4 sm:px-8">
           {children}

--- a/front/components/sparkle/AppCenteredLayout.tsx
+++ b/front/components/sparkle/AppCenteredLayout.tsx
@@ -20,7 +20,7 @@ export function AppCenteredLayout({
     <AppContentLayout hasTitle={!!title} {...props}>
       {title && title}
       <div
-        className={`flex w-full flex-col items-center overflow-y-auto pt-4 ${title ? "h-[calc(100vh-4.5rem)]" : "h-full"}`}
+        className={`flex w-full flex-col items-center overflow-y-auto pt-4 ${title ? "h-[calc(100vh-4rem)]" : "h-full"}`}
       >
         <div className="flex w-full max-w-4xl grow flex-col px-4 sm:px-8">
           {children}

--- a/front/components/sparkle/AppLayoutTitle.tsx
+++ b/front/components/sparkle/AppLayoutTitle.tsx
@@ -10,7 +10,7 @@ export function AppLayoutTitle({ children, className }: AppLayoutTitleProps) {
   return (
     <div
       className={cn(
-        "flex h-14 w-full shrink-0 flex-col border-b border-border px-4 pl-14 lg:pl-4",
+        "flex h-16 w-full shrink-0 flex-col border-b border-border px-4 pl-14 lg:pl-4",
         "bg-background dark:bg-background-night",
         "dark:border-border-night",
         // When no children, only show on mobile for hamburger menu alignment.

--- a/front/components/sparkle/AppLayoutTitle.tsx
+++ b/front/components/sparkle/AppLayoutTitle.tsx
@@ -10,7 +10,7 @@ export function AppLayoutTitle({ children, className }: AppLayoutTitleProps) {
   return (
     <div
       className={cn(
-        "flex h-16 w-full shrink-0 flex-col border-b border-border px-4 pl-14 lg:pl-4",
+        "flex h-14 w-full shrink-0 flex-col border-b border-border px-4 pl-14 lg:pl-4",
         "bg-background dark:bg-background-night",
         "dark:border-border-night",
         // When no children, only show on mobile for hamburger menu alignment.


### PR DESCRIPTION
fixes: https://github.com/dust-tt/tasks/issues/3727

## Description

Don't use `height:100%` when there's a header, remove the header height (AppLayoutTitle is h-14 = 3.5rem). 

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

deploy front
