### PR TITLE
[front] Fix multi-mentions conversations in async loop

### DIFF
--- a/front/temporal/agent_loop/workflows.ts
+++ b/front/temporal/agent_loop/workflows.ts
@@ -87,10 +87,9 @@ export async function agentLoopWorkflow({
         }
       );
     } catch (err) {
-      if (err instanceof WorkflowExecutionAlreadyStartedError) {
-        return;
+      if (!(err instanceof WorkflowExecutionAlreadyStartedError)) {
+        throw err;
       }
-      throw err;
     }
   }
 


### PR DESCRIPTION
## Description

- This PR fixes an issue in the async loop occurring when multiple agents are mentioned in the same message, causing only the first agent to answering.
- The root cause was narrowed down to the conversation workflow already being started.

## Tests

- Tested locally (I could reproduce the issue).

## Risk

- Low.

## Deploy Plan

- Deploy front.
