### PR TITLE
Refactor tests isolation with transaction

### DIFF
--- a/front/lib/actions/mcp_internal_actions/servers/utils.test.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/utils.test.ts
@@ -1,6 +1,5 @@
 import { INTERNAL_MIME_TYPES } from "@dust-tt/client";
-import type { Transaction } from "sequelize";
-import { describe, expect } from "vitest";
+import { describe, expect, it } from "vitest";
 
 import { Authenticator } from "@app/lib/auth";
 import { AgentDataSourceConfiguration } from "@app/lib/models/assistant/actions/data_sources";
@@ -12,191 +11,156 @@ import { AgentMCPServerConfigurationFactory } from "@app/tests/utils/AgentMCPSer
 import { DataSourceViewFactory } from "@app/tests/utils/DataSourceViewFactory";
 import { GroupFactory } from "@app/tests/utils/GroupFactory";
 import { SpaceFactory } from "@app/tests/utils/SpaceFactory";
-import { itInTransaction } from "@app/tests/utils/utils";
 import { WorkspaceFactory } from "@app/tests/utils/WorkspaceFactory";
 
 import { fetchTableDataSourceConfigurations, getCoreSearchArgs } from "./utils";
 
 describe("MCP Internal Actions Server Utils", () => {
   describe("fetchAgentTableConfigurations", () => {
-    itInTransaction(
-      "should return error when table configuration belongs to different workspace",
-      async (t: Transaction) => {
-        const workspace = await WorkspaceFactory.basic();
-        const otherWorkspace = await WorkspaceFactory.basic();
-        await SpaceFactory.system(workspace, t);
-        const globalSpace = await SpaceFactory.global(workspace, t);
-        await GroupFactory.defaults(workspace);
-        const { agentOwnerAuth: auth } = await setupAgentOwner(
-          workspace,
-          "admin",
-          t
-        );
+    it("should return error when table configuration belongs to different workspace", async () => {
+      const workspace = await WorkspaceFactory.basic();
+      const otherWorkspace = await WorkspaceFactory.basic();
+      await SpaceFactory.system(workspace);
+      const globalSpace = await SpaceFactory.global(workspace);
+      await GroupFactory.defaults(workspace);
+      const { agentOwnerAuth: auth } = await setupAgentOwner(
+        workspace,
+        "admin"
+      );
 
-        const otherSpace = await SpaceFactory.global(otherWorkspace, t);
-        const otherFolder = await DataSourceViewFactory.folder(
-          otherWorkspace,
-          otherSpace,
-          t
-        );
+      const otherSpace = await SpaceFactory.global(otherWorkspace);
+      const otherFolder = await DataSourceViewFactory.folder(
+        otherWorkspace,
+        otherSpace
+      );
 
-        await InternalMCPServerInMemoryResource.makeNew(
-          auth,
-          {
-            name: "search",
-            useCase: null,
-          },
-          t
-        );
-        const mcpServerConfiguration =
-          await AgentMCPServerConfigurationFactory.create(auth, globalSpace, t);
+      await InternalMCPServerInMemoryResource.makeNew(auth, {
+        name: "search",
+        useCase: null,
+      });
+      const mcpServerConfiguration =
+        await AgentMCPServerConfigurationFactory.create(auth, globalSpace);
 
-        // Create a table configuration in a different workspace
-        const tableConfig = await AgentTablesQueryConfigurationTable.create(
-          {
-            workspaceId: otherWorkspace.id,
-            tableId: "test_table",
-            dataSourceId: otherFolder.dataSource.id,
-            dataSourceViewId: otherFolder.id,
-            mcpServerConfigurationId: mcpServerConfiguration.id,
-          },
-          { transaction: t }
-        );
+      // Create a table configuration in a different workspace
+      const tableConfig = await AgentTablesQueryConfigurationTable.create({
+        workspaceId: otherWorkspace.id,
+        tableId: "test_table",
+        dataSourceId: otherFolder.dataSource.id,
+        dataSourceViewId: otherFolder.id,
+        mcpServerConfigurationId: mcpServerConfiguration.id,
+      });
 
-        const tableConfigId = makeSId("table_configuration", {
-          id: tableConfig.id,
-          workspaceId: otherWorkspace.id,
-        });
-        const tablesConfiguration = [
-          {
-            uri: `table_configuration://dust/w/${otherWorkspace.sId}/table_configurations/${tableConfigId}`,
-            mimeType: INTERNAL_MIME_TYPES.TOOL_INPUT.TABLE,
-          },
-        ];
+      const tableConfigId = makeSId("table_configuration", {
+        id: tableConfig.id,
+        workspaceId: otherWorkspace.id,
+      });
+      const tablesConfiguration = [
+        {
+          uri: `table_configuration://dust/w/${otherWorkspace.sId}/table_configurations/${tableConfigId}`,
+          mimeType: INTERNAL_MIME_TYPES.TOOL_INPUT.TABLE,
+        },
+      ];
 
-        const result = await fetchTableDataSourceConfigurations(
-          auth,
-          tablesConfiguration
-        );
-        expect(result.isErr()).toBe(true);
-        if (result.isErr()) {
-          expect(result.error.message).toContain(
-            "does not belong to workspace"
-          );
-        }
+      const result = await fetchTableDataSourceConfigurations(
+        auth,
+        tablesConfiguration
+      );
+      expect(result.isErr()).toBe(true);
+      if (result.isErr()) {
+        expect(result.error.message).toContain("does not belong to workspace");
       }
-    );
+    });
 
-    itInTransaction(
-      "should return error for invalid table configuration URI",
-      async () => {
-        const workspace = await WorkspaceFactory.basic();
-        const auth = await Authenticator.internalAdminForWorkspace(
-          workspace.sId
+    it("should return error for invalid table configuration URI", async () => {
+      const workspace = await WorkspaceFactory.basic();
+      const auth = await Authenticator.internalAdminForWorkspace(workspace.sId);
+
+      const tablesConfiguration = [
+        {
+          uri: "invalid_uri",
+          mimeType: INTERNAL_MIME_TYPES.TOOL_INPUT.TABLE,
+        },
+      ];
+
+      const result = await fetchTableDataSourceConfigurations(
+        auth,
+        tablesConfiguration
+      );
+      expect(result.isErr()).toBe(true);
+      if (result.isErr()) {
+        expect(result.error.message).toContain(
+          "Invalid URI for a table configuration"
         );
-
-        const tablesConfiguration = [
-          {
-            uri: "invalid_uri",
-            mimeType: INTERNAL_MIME_TYPES.TOOL_INPUT.TABLE,
-          },
-        ];
-
-        const result = await fetchTableDataSourceConfigurations(
-          auth,
-          tablesConfiguration
-        );
-        expect(result.isErr()).toBe(true);
-        if (result.isErr()) {
-          expect(result.error.message).toContain(
-            "Invalid URI for a table configuration"
-          );
-        }
       }
-    );
+    });
 
-    itInTransaction(
-      "should return table configurations when they belong to the workspace",
-      async (t: Transaction) => {
-        const workspace = await WorkspaceFactory.basic();
-        await GroupFactory.defaults(workspace);
-        const { agentOwnerAuth: auth } = await setupAgentOwner(
-          workspace,
-          "admin",
-          t
-        );
+    it("should return table configurations when they belong to the workspace", async () => {
+      const workspace = await WorkspaceFactory.basic();
+      await GroupFactory.defaults(workspace);
+      const { agentOwnerAuth: auth } = await setupAgentOwner(
+        workspace,
+        "admin"
+      );
 
-        await SpaceFactory.system(workspace, t);
-        const space = await SpaceFactory.global(workspace, t);
-        const folder = await DataSourceViewFactory.folder(workspace, space, t);
-        await InternalMCPServerInMemoryResource.makeNew(
-          auth,
-          {
-            name: "search",
-            useCase: null,
-          },
-          t
-        );
-        const mcpServerConfiguration =
-          await AgentMCPServerConfigurationFactory.create(auth, space, t);
+      await SpaceFactory.system(workspace);
+      const space = await SpaceFactory.global(workspace);
+      const folder = await DataSourceViewFactory.folder(workspace, space);
+      await InternalMCPServerInMemoryResource.makeNew(auth, {
+        name: "search",
+        useCase: null,
+      });
+      const mcpServerConfiguration =
+        await AgentMCPServerConfigurationFactory.create(auth, space);
 
-        // Create a table configuration in the workspace
-        const tableConfig = await AgentTablesQueryConfigurationTable.create(
-          {
-            workspaceId: workspace.id,
-            tableId: "test_table",
-            dataSourceId: folder.dataSource.id,
-            dataSourceViewId: folder.id,
-            mcpServerConfigurationId: mcpServerConfiguration.id,
-          },
-          { transaction: t }
-        );
+      // Create a table configuration in the workspace
+      const tableConfig = await AgentTablesQueryConfigurationTable.create({
+        workspaceId: workspace.id,
+        tableId: "test_table",
+        dataSourceId: folder.dataSource.id,
+        dataSourceViewId: folder.id,
+        mcpServerConfigurationId: mcpServerConfiguration.id,
+      });
 
-        // Also create a table configuration in a different workspace
-        const otherWorkspace = await WorkspaceFactory.basic();
-        const otherSpace = await SpaceFactory.global(otherWorkspace, t);
-        const otherFolder = await DataSourceViewFactory.folder(
-          otherWorkspace,
-          otherSpace,
-          t
-        );
-        await AgentTablesQueryConfigurationTable.create(
-          {
-            workspaceId: otherWorkspace.id,
-            tableId: "test_table",
-            dataSourceId: otherFolder.dataSource.id,
-            dataSourceViewId: otherFolder.id,
-            mcpServerConfigurationId: mcpServerConfiguration.id,
-          },
-          { transaction: t }
-        );
-        // End of creation of table configuration in a different workspace
+      // Also create a table configuration in a different workspace
+      const otherWorkspace = await WorkspaceFactory.basic();
+      const otherSpace = await SpaceFactory.global(otherWorkspace);
+      const otherFolder = await DataSourceViewFactory.folder(
+        otherWorkspace,
+        otherSpace
+      );
+      await AgentTablesQueryConfigurationTable.create({
+        workspaceId: otherWorkspace.id,
+        tableId: "test_table",
+        dataSourceId: otherFolder.dataSource.id,
+        dataSourceViewId: otherFolder.id,
+        mcpServerConfigurationId: mcpServerConfiguration.id,
+      });
+      // End of creation of table configuration in a different workspace
 
-        const tableConfigId = makeSId("table_configuration", {
-          id: tableConfig.id,
-          workspaceId: workspace.id,
-        });
-        const tablesConfiguration = [
-          {
-            uri: `table_configuration://dust/w/${workspace.sId}/table_configurations/${tableConfigId}`,
-            mimeType: INTERNAL_MIME_TYPES.TOOL_INPUT.TABLE,
-          },
-        ];
+      const tableConfigId = makeSId("table_configuration", {
+        id: tableConfig.id,
+        workspaceId: workspace.id,
+      });
+      const tablesConfiguration = [
+        {
+          uri: `table_configuration://dust/w/${workspace.sId}/table_configurations/${tableConfigId}`,
+          mimeType: INTERNAL_MIME_TYPES.TOOL_INPUT.TABLE,
+        },
+      ];
 
-        const result = await fetchTableDataSourceConfigurations(
-          auth,
-          tablesConfiguration
-        );
-        expect(result.isOk()).toBe(true);
-        if (result.isOk()) {
-          expect(result.value).toHaveLength(1);
-          expect(result.value[0].tableId).toBe(tableConfig.tableId);
-          expect(result.value[0].workspaceId).toBe(workspace.sId);
-        }
+      const result = await fetchTableDataSourceConfigurations(
+        auth,
+        tablesConfiguration
+      );
+      expect(result.isOk()).toBe(true);
+      if (result.isOk()) {
+        expect(result.value).toHaveLength(1);
+        expect(result.value[0].tableId).toBe(tableConfig.tableId);
+        expect(result.value[0].workspaceId).toBe(workspace.sId);
       }
-    );
+    });
 
-    itInTransaction("should handle dynamic table configurations", async () => {
+    it("should handle dynamic table configurations", async () => {
       const workspace = await WorkspaceFactory.basic();
       const auth = await Authenticator.internalAdminForWorkspace(workspace.sId);
 
@@ -222,138 +186,110 @@ describe("MCP Internal Actions Server Utils", () => {
   });
 
   describe("getCoreSearchArgs", () => {
-    itInTransaction(
-      "should return error when data source configuration belongs to different workspace",
-      async (t: Transaction) => {
-        const workspace = await WorkspaceFactory.basic();
-        const otherWorkspace = await WorkspaceFactory.basic();
-        const auth = await Authenticator.internalAdminForWorkspace(
-          workspace.sId
+    it("should return error when data source configuration belongs to different workspace", async () => {
+      const workspace = await WorkspaceFactory.basic();
+      const otherWorkspace = await WorkspaceFactory.basic();
+      const auth = await Authenticator.internalAdminForWorkspace(workspace.sId);
+
+      const otherSpace = await SpaceFactory.global(otherWorkspace);
+      const otherFolder = await DataSourceViewFactory.folder(
+        otherWorkspace,
+        otherSpace
+      );
+
+      const dataSourceConfig = await AgentDataSourceConfiguration.create({
+        workspaceId: otherWorkspace.id,
+        dataSourceId: otherFolder.dataSource.id,
+        dataSourceViewId: otherFolder.id,
+        tagsMode: null,
+        tagsIn: null,
+        tagsNotIn: null,
+      });
+
+      const dataSourceConfigId = makeSId("data_source_configuration", {
+        id: dataSourceConfig.id,
+        workspaceId: otherWorkspace.id,
+      });
+      const dataSourceConfiguration = {
+        uri: `data_source_configuration://dust/w/${otherWorkspace.sId}/data_source_configurations/${dataSourceConfigId}`,
+        mimeType: INTERNAL_MIME_TYPES.TOOL_INPUT.DATA_SOURCE,
+      };
+
+      const result = await getCoreSearchArgs(auth, dataSourceConfiguration);
+      expect(result.isErr()).toBe(true);
+    });
+
+    it("should return error for invalid data source configuration URI", async () => {
+      const workspace = await WorkspaceFactory.basic();
+      const auth = await Authenticator.internalAdminForWorkspace(workspace.sId);
+
+      const dataSourceConfiguration = {
+        uri: "invalid_uri",
+        mimeType: INTERNAL_MIME_TYPES.TOOL_INPUT.DATA_SOURCE,
+      };
+
+      const result = await getCoreSearchArgs(auth, dataSourceConfiguration);
+      expect(result.isErr()).toBe(true);
+      if (result.isErr()) {
+        expect(result.error.message).toContain(
+          "Invalid URI for a data source configuration"
         );
-
-        const otherSpace = await SpaceFactory.global(otherWorkspace, t);
-        const otherFolder = await DataSourceViewFactory.folder(
-          otherWorkspace,
-          otherSpace,
-          t
-        );
-
-        const dataSourceConfig = await AgentDataSourceConfiguration.create(
-          {
-            workspaceId: otherWorkspace.id,
-            dataSourceId: otherFolder.dataSource.id,
-            dataSourceViewId: otherFolder.id,
-            tagsMode: null,
-            tagsIn: null,
-            tagsNotIn: null,
-          },
-          { transaction: t }
-        );
-
-        const dataSourceConfigId = makeSId("data_source_configuration", {
-          id: dataSourceConfig.id,
-          workspaceId: otherWorkspace.id,
-        });
-        const dataSourceConfiguration = {
-          uri: `data_source_configuration://dust/w/${otherWorkspace.sId}/data_source_configurations/${dataSourceConfigId}`,
-          mimeType: INTERNAL_MIME_TYPES.TOOL_INPUT.DATA_SOURCE,
-        };
-
-        const result = await getCoreSearchArgs(auth, dataSourceConfiguration);
-        expect(result.isErr()).toBe(true);
       }
-    );
+    });
 
-    itInTransaction(
-      "should return error for invalid data source configuration URI",
-      async () => {
-        const workspace = await WorkspaceFactory.basic();
-        const auth = await Authenticator.internalAdminForWorkspace(
-          workspace.sId
+    it("should return core search args when data source configuration belongs to the workspace", async () => {
+      const workspace = await WorkspaceFactory.basic();
+      const auth = await Authenticator.internalAdminForWorkspace(workspace.sId);
+
+      const space = await SpaceFactory.global(workspace);
+      const folder = await DataSourceViewFactory.folder(workspace, space);
+
+      const dataSourceConfig = await AgentDataSourceConfiguration.create({
+        workspaceId: workspace.id,
+        dataSourceId: folder.dataSource.id,
+        dataSourceViewId: folder.id,
+        tagsMode: null,
+        tagsIn: null,
+        tagsNotIn: null,
+      });
+
+      // Also create a data source configuration in a different workspace
+      const otherWorkspace = await WorkspaceFactory.basic();
+      const otherSpace = await SpaceFactory.global(otherWorkspace);
+      const otherFolder = await DataSourceViewFactory.folder(
+        otherWorkspace,
+        otherSpace
+      );
+      await AgentDataSourceConfiguration.create({
+        workspaceId: otherWorkspace.id,
+        dataSourceId: otherFolder.dataSource.id,
+        dataSourceViewId: otherFolder.id,
+        tagsMode: null,
+        tagsIn: null,
+        tagsNotIn: null,
+      });
+      // End of creation of data source configuration in a different workspace
+
+      const dataSourceConfigId = makeSId("data_source_configuration", {
+        id: dataSourceConfig.id,
+        workspaceId: workspace.id,
+      });
+      const dataSourceConfiguration = {
+        uri: `data_source_configuration://dust/w/${workspace.sId}/data_source_configurations/${dataSourceConfigId}`,
+        mimeType: INTERNAL_MIME_TYPES.TOOL_INPUT.DATA_SOURCE,
+      };
+
+      const result = await getCoreSearchArgs(auth, dataSourceConfiguration);
+      expect(result.isOk()).toBe(true);
+      if (result.isOk()) {
+        expect(result.value.projectId).toBe(folder.dataSource.dustAPIProjectId);
+        expect(result.value.dataSourceId).toBe(
+          folder.dataSource.dustAPIDataSourceId
         );
-
-        const dataSourceConfiguration = {
-          uri: "invalid_uri",
-          mimeType: INTERNAL_MIME_TYPES.TOOL_INPUT.DATA_SOURCE,
-        };
-
-        const result = await getCoreSearchArgs(auth, dataSourceConfiguration);
-        expect(result.isErr()).toBe(true);
-        if (result.isErr()) {
-          expect(result.error.message).toContain(
-            "Invalid URI for a data source configuration"
-          );
-        }
+        expect(result.value.filter.tags.in).toBeNull();
+        expect(result.value.filter.tags.not).toBeNull();
+        expect(result.value.dataSourceView).toBeDefined();
       }
-    );
-
-    itInTransaction(
-      "should return core search args when data source configuration belongs to the workspace",
-      async (t: Transaction) => {
-        const workspace = await WorkspaceFactory.basic();
-        const auth = await Authenticator.internalAdminForWorkspace(
-          workspace.sId
-        );
-
-        const space = await SpaceFactory.global(workspace, t);
-        const folder = await DataSourceViewFactory.folder(workspace, space, t);
-
-        const dataSourceConfig = await AgentDataSourceConfiguration.create(
-          {
-            workspaceId: workspace.id,
-            dataSourceId: folder.dataSource.id,
-            dataSourceViewId: folder.id,
-            tagsMode: null,
-            tagsIn: null,
-            tagsNotIn: null,
-          },
-          { transaction: t }
-        );
-
-        // Also create a data source configuration in a different workspace
-        const otherWorkspace = await WorkspaceFactory.basic();
-        const otherSpace = await SpaceFactory.global(otherWorkspace, t);
-        const otherFolder = await DataSourceViewFactory.folder(
-          otherWorkspace,
-          otherSpace,
-          t
-        );
-        await AgentDataSourceConfiguration.create(
-          {
-            workspaceId: otherWorkspace.id,
-            dataSourceId: otherFolder.dataSource.id,
-            dataSourceViewId: otherFolder.id,
-            tagsMode: null,
-            tagsIn: null,
-            tagsNotIn: null,
-          },
-          { transaction: t }
-        );
-        // End of creation of data source configuration in a different workspace
-
-        const dataSourceConfigId = makeSId("data_source_configuration", {
-          id: dataSourceConfig.id,
-          workspaceId: workspace.id,
-        });
-        const dataSourceConfiguration = {
-          uri: `data_source_configuration://dust/w/${workspace.sId}/data_source_configurations/${dataSourceConfigId}`,
-          mimeType: INTERNAL_MIME_TYPES.TOOL_INPUT.DATA_SOURCE,
-        };
-
-        const result = await getCoreSearchArgs(auth, dataSourceConfiguration);
-        expect(result.isOk()).toBe(true);
-        if (result.isOk()) {
-          expect(result.value.projectId).toBe(
-            folder.dataSource.dustAPIProjectId
-          );
-          expect(result.value.dataSourceId).toBe(
-            folder.dataSource.dustAPIDataSourceId
-          );
-          expect(result.value.filter.tags.in).toBeNull();
-          expect(result.value.filter.tags.not).toBeNull();
-          expect(result.value.dataSourceView).toBeDefined();
-        }
-      }
-    );
+    });
   });
 });

--- a/front/lib/api/assistant/configuration/actions.ts
+++ b/front/lib/api/assistant/configuration/actions.ts
@@ -18,8 +18,8 @@ import { AgentReasoningConfiguration } from "@app/lib/models/assistant/actions/r
 import { AgentTablesQueryConfigurationTable } from "@app/lib/models/assistant/actions/tables_query";
 import { DataSourceViewResource } from "@app/lib/resources/data_source_view_resource";
 import { MCPServerViewResource } from "@app/lib/resources/mcp_server_view_resource";
-import { frontSequelize } from "@app/lib/resources/storage";
 import { generateRandomModelSId } from "@app/lib/resources/string_ids";
+import { withTransaction } from "@app/lib/utils/sql_utils";
 import logger from "@app/logger/logger";
 import type { LightAgentConfigurationType, Result } from "@app/types";
 import type { ReasoningModelConfigurationType } from "@app/types";
@@ -38,7 +38,7 @@ export async function createAgentActionConfiguration(
 
   assert(isServerSideMCPServerConfiguration(action));
 
-  return frontSequelize.transaction(async (t) => {
+  return withTransaction(async (t) => {
     const mcpServerView = await MCPServerViewResource.fetchById(
       auth,
       action.mcpServerViewId

--- a/front/lib/api/assistant/configuration/agent.ts
+++ b/front/lib/api/assistant/configuration/agent.ts
@@ -32,12 +32,8 @@ import {
 import { TagAgentModel } from "@app/lib/models/assistant/tag_agent";
 import { DataSourceViewResource } from "@app/lib/resources/data_source_view_resource";
 import { GroupResource } from "@app/lib/resources/group_resource";
-<<<<<<< HEAD
 import { MCPServerViewResource } from "@app/lib/resources/mcp_server_view_resource";
 import { SpaceResource } from "@app/lib/resources/space_resource";
-import { frontSequelize } from "@app/lib/resources/storage";
-=======
->>>>>>> 086f386872 (Introduce withTransaction wrapper)
 import { generateRandomModelSId } from "@app/lib/resources/string_ids";
 import { TagResource } from "@app/lib/resources/tags_resource";
 import { TemplateResource } from "@app/lib/resources/template_resource";

--- a/front/lib/api/assistant/configuration/agent.ts
+++ b/front/lib/api/assistant/configuration/agent.ts
@@ -32,13 +32,17 @@ import {
 import { TagAgentModel } from "@app/lib/models/assistant/tag_agent";
 import { DataSourceViewResource } from "@app/lib/resources/data_source_view_resource";
 import { GroupResource } from "@app/lib/resources/group_resource";
+<<<<<<< HEAD
 import { MCPServerViewResource } from "@app/lib/resources/mcp_server_view_resource";
 import { SpaceResource } from "@app/lib/resources/space_resource";
 import { frontSequelize } from "@app/lib/resources/storage";
+=======
+>>>>>>> 086f386872 (Introduce withTransaction wrapper)
 import { generateRandomModelSId } from "@app/lib/resources/string_ids";
 import { TagResource } from "@app/lib/resources/tags_resource";
 import { TemplateResource } from "@app/lib/resources/template_resource";
 import { normalizeArrays } from "@app/lib/utils";
+import { withTransaction } from "@app/lib/utils/sql_utils";
 import logger from "@app/logger/logger";
 import type {
   AgentConfigurationScope,
@@ -508,9 +512,7 @@ export async function createAgentConfiguration(
       return agentConfigurationInstance;
     };
 
-    const agent = await (transaction
-      ? performCreation(transaction)
-      : frontSequelize.transaction(performCreation));
+    const agent = await withTransaction(performCreation, transaction);
 
     /*
      * Final rendering.
@@ -998,7 +1000,7 @@ export async function updateAgentPermissions(
   // The canWrite check for agent_editors groups (allowing members and admins)
   // is implicitly handled by addMembers and removeMembers.
   try {
-    return await frontSequelize.transaction(async (t) => {
+    return await withTransaction(async (t) => {
       if (usersToAdd.length > 0) {
         const addRes = await editorGroupRes.value.addMembers(auth, usersToAdd, {
           transaction: t,

--- a/front/lib/api/assistant/conversation.ts
+++ b/front/lib/api/assistant/conversation.ts
@@ -45,6 +45,7 @@ import { ServerSideTracking } from "@app/lib/tracking/server";
 import { isEmailValid, normalizeArrays } from "@app/lib/utils";
 import { concurrentExecutor } from "@app/lib/utils/async_utils";
 import { rateLimiter } from "@app/lib/utils/rate_limiter";
+import { withTransaction } from "@app/lib/utils/sql_utils";
 import logger from "@app/logger/logger";
 import type {
   AgentMessageType,
@@ -461,7 +462,7 @@ export async function postUserMessage(
 
   // In one big transaction create all Message, UserMessage, AgentMessage and Mention rows.
   const { userMessage, agentMessages, agentMessageRows } =
-    await frontSequelize.transaction(async (t) => {
+    await withTransaction(async (t) => {
       // Since we are getting a transaction level lock, we can't execute any other SQL query outside of
       // this transaction, otherwise this other query will be competing for a connection in the database
       // connection pool, resulting in a deadlock.
@@ -863,7 +864,7 @@ export async function editUserMessage(
 
   try {
     // In one big transaction creante all Message, UserMessage, AgentMessage and Mention rows.
-    const result = await frontSequelize.transaction(async (t) => {
+    const result = await withTransaction(async (t) => {
       // Since we are getting a transaction level lock, we can't execute any other SQL query outside of
       // this transaction, otherwise this other query will be competing for a connection in the database
       // connection pool, resulting in a deadlock.
@@ -1198,7 +1199,7 @@ export async function retryAgentMessage(
     agentMessageRow: AgentMessage;
   } | null = null;
   try {
-    agentMessageResult = await frontSequelize.transaction(async (t) => {
+    agentMessageResult = await withTransaction(async (t) => {
       await getConversationRankVersionLock(conversation, t);
 
       const messageRow = await Message.findOne({
@@ -1437,63 +1438,61 @@ export async function postNewContentFragment(
     }
   }
 
-  const { contentFragment, messageRow } = await frontSequelize.transaction(
-    async (t) => {
-      await getConversationRankVersionLock(conversation, t);
+  const { contentFragment, messageRow } = await withTransaction(async (t) => {
+    await getConversationRankVersionLock(conversation, t);
 
-      const fullBlob = {
-        ...cfBlobRes.value,
-        userId: auth.user()?.id,
-        userContextProfilePictureUrl: context?.profilePictureUrl,
-        userContextEmail: context?.email,
-        userContextFullName: context?.fullName,
-        userContextUsername: context?.username,
-        workspaceId: owner.id,
-      };
+    const fullBlob = {
+      ...cfBlobRes.value,
+      userId: auth.user()?.id,
+      userContextProfilePictureUrl: context?.profilePictureUrl,
+      userContextEmail: context?.email,
+      userContextFullName: context?.fullName,
+      userContextUsername: context?.username,
+      workspaceId: owner.id,
+    };
 
-      const contentFragment = await (() => {
-        if (supersededContentFragmentId) {
-          return ContentFragmentResource.makeNewVersion(
-            supersededContentFragmentId,
-            fullBlob,
-            t
-          );
-        } else {
-          return ContentFragmentResource.makeNew(fullBlob, t);
-        }
-      })();
-
-      const nextMessageRank =
-        ((await Message.max<number | null, Message>("rank", {
-          where: {
-            conversationId: conversation.id,
-          },
-          transaction: t,
-        })) ?? -1) + 1;
-      const messageRow = await Message.create(
-        {
-          sId: messageId,
-          rank: nextMessageRank,
-          conversationId: conversation.id,
-          contentFragmentId: contentFragment.id,
-          workspaceId: owner.id,
-        },
-        {
-          transaction: t,
-        }
-      );
-
-      if (isContentFragmentInputWithContentNode(cf)) {
-        await updateConversationRequestedGroupIds(auth, {
-          contentFragment: cf,
-          conversation,
-          t,
-        });
+    const contentFragment = await (() => {
+      if (supersededContentFragmentId) {
+        return ContentFragmentResource.makeNewVersion(
+          supersededContentFragmentId,
+          fullBlob,
+          t
+        );
+      } else {
+        return ContentFragmentResource.makeNew(fullBlob, t);
       }
+    })();
 
-      return { contentFragment, messageRow };
+    const nextMessageRank =
+      ((await Message.max<number | null, Message>("rank", {
+        where: {
+          conversationId: conversation.id,
+        },
+        transaction: t,
+      })) ?? -1) + 1;
+    const messageRow = await Message.create(
+      {
+        sId: messageId,
+        rank: nextMessageRank,
+        conversationId: conversation.id,
+        contentFragmentId: contentFragment.id,
+        workspaceId: owner.id,
+      },
+      {
+        transaction: t,
+      }
+    );
+
+    if (isContentFragmentInputWithContentNode(cf)) {
+      await updateConversationRequestedGroupIds(auth, {
+        contentFragment: cf,
+        conversation,
+        t,
+      });
     }
-  );
+
+    return { contentFragment, messageRow };
+  });
   const render = await contentFragment.renderFromMessage({
     auth,
     conversationId: conversation.sId,

--- a/front/lib/api/data_sources.ts
+++ b/front/lib/api/data_sources.ts
@@ -31,6 +31,7 @@ import { ServerSideTracking } from "@app/lib/tracking/server";
 import { enqueueUpsertTable } from "@app/lib/upsert_queue";
 import { concurrentExecutor } from "@app/lib/utils/async_utils";
 import { cacheWithRedis } from "@app/lib/utils/cache";
+import { withTransaction } from "@app/lib/utils/sql_utils";
 import { cleanTimestamp } from "@app/lib/utils/timestamps";
 import logger from "@app/logger/logger";
 import { launchScrubDataSourceWorkflow } from "@app/poke/temporal/client";
@@ -68,7 +69,6 @@ import {
 } from "@app/types";
 
 import { ConversationResource } from "../resources/conversation_resource";
-import { frontSequelize } from "../resources/storage";
 
 // Number of files we pull from GCS at once for deletion.
 // If we have 10k documents of 100kB each (which is a lot) we are at 1GB here.
@@ -950,7 +950,7 @@ export async function createDataSourceWithoutProvider(
     });
   }
 
-  return frontSequelize.transaction(
+  return withTransaction(
     async (
       t
     ): Promise<Result<DataSourceViewResource, DataSourceCreationError>> => {

--- a/front/lib/api/files/upsert.test.ts
+++ b/front/lib/api/files/upsert.test.ts
@@ -1,5 +1,5 @@
 import { INTERNAL_MIME_TYPES } from "@dust-tt/client";
-import { beforeEach, describe, expect, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import { createDataSourceFolder, upsertTable } from "@app/lib/api/data_sources";
 import { processAndStoreFile } from "@app/lib/api/files/upload";
@@ -9,7 +9,6 @@ import type { Authenticator } from "@app/lib/auth";
 import { DataSourceViewFactory } from "@app/tests/utils/DataSourceViewFactory";
 import { FileFactory } from "@app/tests/utils/FileFactory";
 import { SpaceFactory } from "@app/tests/utils/SpaceFactory";
-import { itInTransaction } from "@app/tests/utils/utils";
 import { WorkspaceFactory } from "@app/tests/utils/WorkspaceFactory";
 import type { WorkspaceType } from "@app/types";
 import { Ok, slugify, TABLE_PREFIX } from "@app/types";
@@ -85,153 +84,133 @@ describe("processAndUpsertToDataSource", () => {
     vi.clearAllMocks();
   });
 
-  itInTransaction(
-    "should call upsertTable with the right parameters for a CSV file",
-    async (t) => {
-      // Create a file
-      const file = await FileFactory.csv(workspace, null, {
-        useCase: "conversation",
-        fileName: "test-file.csv",
-        status: "ready",
-        useCaseMetadata: {
-          conversationId: "test-conversation-id",
-          generatedTables: [],
-        },
-      });
+  it("should call upsertTable with the right parameters for a CSV file", async () => {
+    // Create a file
+    const file = await FileFactory.csv(workspace, null, {
+      useCase: "conversation",
+      fileName: "test-file.csv",
+      status: "ready",
+      useCaseMetadata: {
+        conversationId: "test-conversation-id",
+        generatedTables: [],
+      },
+    });
 
-      const space = await SpaceFactory.global(workspace, t);
+    const space = await SpaceFactory.global(workspace);
 
-      const datasourceView = await DataSourceViewFactory.folder(
-        workspace,
-        space,
-        t
-      );
-      // Call processAndUpsertToDataSource which internally calls maybeApplyProcessing
-      const result = await processAndUpsertToDataSource(
-        auth,
-        datasourceView.dataSource,
-        {
-          file,
-        }
-      );
-
-      // Verify the result
-      expect(result.isOk()).toBe(true);
-
-      // Verify upsertTable was called with the right parameters
-      expect(upsertTable).toHaveBeenCalledTimes(1);
-
-      const upsertTableCall = vi.mocked(upsertTable).mock.calls[0][0];
-
-      // Check auth and dataSource
-      expect(upsertTableCall.auth).toBe(auth);
-      expect(upsertTableCall.dataSource).toBe(datasourceView.dataSource);
-
-      // Check params
-      const params = upsertTableCall.params;
-      expect(params.tableId).toBe(file.sId);
-      expect(params.name).toBe(slugify(file.fileName));
-      expect(params.title).toBe(file.fileName);
-      expect(params.tags).toContain(`fileId:${file.sId}`);
-      expect(params.tags).toContain(`fileName:${file.fileName}`);
-      expect(params.tags).toContain(`title:${file.fileName}`);
-      expect(params.mimeType).toBe("text/csv");
-
-      // Verify file useCaseMetadata was updated
-      // Since we can't directly call reload(), we'll check if the file was updated
-      if (result.isOk()) {
-        const updatedFile = result.value;
-        expect(updatedFile.useCaseMetadata).not.toBeNull();
-        expect(updatedFile.useCaseMetadata?.generatedTables).toContain(
-          params.tableId
-        );
+    const datasourceView = await DataSourceViewFactory.folder(workspace, space);
+    // Call processAndUpsertToDataSource which internally calls maybeApplyProcessing
+    const result = await processAndUpsertToDataSource(
+      auth,
+      datasourceView.dataSource,
+      {
+        file,
       }
+    );
+
+    // Verify the result
+    expect(result.isOk()).toBe(true);
+
+    // Verify upsertTable was called with the right parameters
+    expect(upsertTable).toHaveBeenCalledTimes(1);
+
+    const upsertTableCall = vi.mocked(upsertTable).mock.calls[0][0];
+
+    // Check auth and dataSource
+    expect(upsertTableCall.auth).toBe(auth);
+    expect(upsertTableCall.dataSource).toBe(datasourceView.dataSource);
+
+    // Check params
+    const params = upsertTableCall.params;
+    expect(params.tableId).toBe(file.sId);
+    expect(params.name).toBe(slugify(file.fileName));
+    expect(params.title).toBe(file.fileName);
+    expect(params.tags).toContain(`fileId:${file.sId}`);
+    expect(params.tags).toContain(`fileName:${file.fileName}`);
+    expect(params.tags).toContain(`title:${file.fileName}`);
+    expect(params.mimeType).toBe("text/csv");
+
+    // Verify file useCaseMetadata was updated
+    // Since we can't directly call reload(), we'll check if the file was updated
+    if (result.isOk()) {
+      const updatedFile = result.value;
+      expect(updatedFile.useCaseMetadata).not.toBeNull();
+      expect(updatedFile.useCaseMetadata?.generatedTables).toContain(
+        params.tableId
+      );
     }
-  );
+  });
 
-  itInTransaction(
-    "should append to existing generatedTables when processing a CSV file",
-    async (t) => {
-      // Create a file with existing useCaseMetadata containing generatedTables
-      const existingTableId = "existing-table-id";
-      const file = await FileFactory.csv(workspace, null, {
-        useCase: "conversation",
-        fileName: "test-file-with-existing-tables.csv",
-        status: "ready",
-        useCaseMetadata: {
-          generatedTables: [existingTableId],
-          conversationId: "test-conversation-id",
-        },
-      });
+  it("should append to existing generatedTables when processing a CSV file", async () => {
+    // Create a file with existing useCaseMetadata containing generatedTables
+    const existingTableId = "existing-table-id";
+    const file = await FileFactory.csv(workspace, null, {
+      useCase: "conversation",
+      fileName: "test-file-with-existing-tables.csv",
+      status: "ready",
+      useCaseMetadata: {
+        generatedTables: [existingTableId],
+        conversationId: "test-conversation-id",
+      },
+    });
 
-      const space = await SpaceFactory.global(workspace, t);
+    const space = await SpaceFactory.global(workspace);
 
-      // Create a data source using a transaction
-      const datasourceView = await DataSourceViewFactory.folder(
-        workspace,
-        space,
-        t
-      );
+    // Create a data source using a transaction
+    const datasourceView = await DataSourceViewFactory.folder(workspace, space);
 
-      // Call processAndUpsertToDataSource which internally calls maybeApplyProcessing
-      const result = await processAndUpsertToDataSource(
-        auth,
-        datasourceView.dataSource,
-        {
-          file,
-        }
-      );
-
-      // Verify the result
-      expect(result.isOk()).toBe(true);
-
-      // Verify upsertTable was called with the right parameters
-      expect(upsertTable).toHaveBeenCalledTimes(1);
-
-      // Verify file useCaseMetadata was updated correctly
-      if (result.isOk()) {
-        const updatedFile = result.value;
-        expect(updatedFile.useCaseMetadata).not.toBeNull();
-
-        // Should contain both the existing table ID and the new one
-        const generatedTables =
-          updatedFile.useCaseMetadata?.generatedTables || [];
-        expect(generatedTables).toContain(existingTableId);
-        expect(generatedTables).toContain(file.sId);
-        expect(generatedTables.length).toBe(2);
+    // Call processAndUpsertToDataSource which internally calls maybeApplyProcessing
+    const result = await processAndUpsertToDataSource(
+      auth,
+      datasourceView.dataSource,
+      {
+        file,
       }
+    );
+
+    // Verify the result
+    expect(result.isOk()).toBe(true);
+
+    // Verify upsertTable was called with the right parameters
+    expect(upsertTable).toHaveBeenCalledTimes(1);
+
+    // Verify file useCaseMetadata was updated correctly
+    if (result.isOk()) {
+      const updatedFile = result.value;
+      expect(updatedFile.useCaseMetadata).not.toBeNull();
+
+      // Should contain both the existing table ID and the new one
+      const generatedTables =
+        updatedFile.useCaseMetadata?.generatedTables || [];
+      expect(generatedTables).toContain(existingTableId);
+      expect(generatedTables).toContain(file.sId);
+      expect(generatedTables.length).toBe(2);
     }
-  );
+  });
 
-  itInTransaction(
-    "should process an Excel file with multiple sheets with conversation usecase",
-    async (t) => {
-      // Create an Excel file
-      const file = await FileFactory.create(workspace, null, {
-        contentType:
-          "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
-        fileName: "test-excel-file.xlsx",
-        fileSize: 1000,
-        status: "ready",
-        useCase: "conversation",
-        useCaseMetadata: {
-          conversationId: "test-conversation-id",
-          generatedTables: [],
-        },
-      });
+  it("should process an Excel file with multiple sheets with conversation usecase", async () => {
+    // Create an Excel file
+    const file = await FileFactory.create(workspace, null, {
+      contentType:
+        "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+      fileName: "test-excel-file.xlsx",
+      fileSize: 1000,
+      status: "ready",
+      useCase: "conversation",
+      useCaseMetadata: {
+        conversationId: "test-conversation-id",
+        generatedTables: [],
+      },
+    });
 
-      const space = await SpaceFactory.global(workspace, t);
+    const space = await SpaceFactory.global(workspace);
 
-      // Create a data source using a transaction
-      const dataSourceView = await DataSourceViewFactory.folder(
-        workspace,
-        space,
-        t
-      );
+    // Create a data source using a transaction
+    const dataSourceView = await DataSourceViewFactory.folder(workspace, space);
 
-      // Mock getFileContent to return fake content with two sheets
+    // Mock getFileContent to return fake content with two sheets
 
-      const fakeExcelContent = `${TABLE_PREFIX}Sheet1
+    const fakeExcelContent = `${TABLE_PREFIX}Sheet1
 id,name,value
 1,Item 1,100
 2,Item 2,200
@@ -242,96 +221,89 @@ id,category,description
 2,Category B,Description for item 2
 3,Category C,Description for item 3`;
 
-      vi.mocked(getFileContent).mockResolvedValue(fakeExcelContent);
+    vi.mocked(getFileContent).mockResolvedValue(fakeExcelContent);
 
-      // Call processAndUpsertToDataSource
-      const result = await processAndUpsertToDataSource(
-        auth,
-        dataSourceView.dataSource,
-        {
-          file,
-        }
-      );
-
-      // Verify the result
-      expect(result.isOk()).toBe(true);
-
-      // Verify getFileContent was called
-      expect(getFileContent).toHaveBeenCalledTimes(1);
-      expect(getFileContent).toHaveBeenCalledWith(auth, file);
-
-      // Verify processAndStoreFile was called twice (once for each sheet)
-      expect(processAndStoreFile).toHaveBeenCalledTimes(2);
-
-      // Verify upsertTable was called twice (once for each sheet)
-      expect(upsertTable).toHaveBeenCalledTimes(2);
-
-      // Check the first upsertTable call
-      const firstUpsertCall = vi.mocked(upsertTable).mock.calls[0][0];
-      expect(firstUpsertCall.params.title).toContain("Sheet1");
-      expect(firstUpsertCall.params.tableId).toContain(
-        `${file.sId}-${slugify("Sheet1")}`
-      );
-      expect(firstUpsertCall.params.parentId).toBe(file.sId);
-      expect(firstUpsertCall.params.parents).toEqual([
-        `${file.sId}-${slugify("Sheet1")}`,
-      ]);
-      expect(firstUpsertCall.params.mimeType).toBe("text/csv");
-
-      // Check the second upsertTable call
-      const secondUpsertCall = vi.mocked(upsertTable).mock.calls[1][0];
-      expect(secondUpsertCall.params.title).toContain("Sheet2");
-      expect(secondUpsertCall.params.tableId).toContain(
-        `${file.sId}-${slugify("Sheet2")}`
-      );
-      expect(secondUpsertCall.params.parentId).toBe(file.sId);
-      expect(secondUpsertCall.params.parents).toEqual([
-        `${file.sId}-${slugify("Sheet2")}`,
-      ]);
-      expect(secondUpsertCall.params.mimeType).toBe("text/csv");
-
-      // Verify file useCaseMetadata was updated with both table IDs
-      if (result.isOk()) {
-        const updatedFile = result.value;
-        expect(updatedFile.useCaseMetadata).not.toBeNull();
-
-        const generatedTables =
-          updatedFile.useCaseMetadata?.generatedTables || [];
-        expect(generatedTables).toContain(`${file.sId}-${slugify("Sheet1")}`);
-        expect(generatedTables).toContain(`${file.sId}-${slugify("Sheet2")}`);
-        expect(generatedTables.length).toBe(2);
+    // Call processAndUpsertToDataSource
+    const result = await processAndUpsertToDataSource(
+      auth,
+      dataSourceView.dataSource,
+      {
+        file,
       }
+    );
+
+    // Verify the result
+    expect(result.isOk()).toBe(true);
+
+    // Verify getFileContent was called
+    expect(getFileContent).toHaveBeenCalledTimes(1);
+    expect(getFileContent).toHaveBeenCalledWith(auth, file);
+
+    // Verify processAndStoreFile was called twice (once for each sheet)
+    expect(processAndStoreFile).toHaveBeenCalledTimes(2);
+
+    // Verify upsertTable was called twice (once for each sheet)
+    expect(upsertTable).toHaveBeenCalledTimes(2);
+
+    // Check the first upsertTable call
+    const firstUpsertCall = vi.mocked(upsertTable).mock.calls[0][0];
+    expect(firstUpsertCall.params.title).toContain("Sheet1");
+    expect(firstUpsertCall.params.tableId).toContain(
+      `${file.sId}-${slugify("Sheet1")}`
+    );
+    expect(firstUpsertCall.params.parentId).toBe(file.sId);
+    expect(firstUpsertCall.params.parents).toEqual([
+      `${file.sId}-${slugify("Sheet1")}`,
+    ]);
+    expect(firstUpsertCall.params.mimeType).toBe("text/csv");
+
+    // Check the second upsertTable call
+    const secondUpsertCall = vi.mocked(upsertTable).mock.calls[1][0];
+    expect(secondUpsertCall.params.title).toContain("Sheet2");
+    expect(secondUpsertCall.params.tableId).toContain(
+      `${file.sId}-${slugify("Sheet2")}`
+    );
+    expect(secondUpsertCall.params.parentId).toBe(file.sId);
+    expect(secondUpsertCall.params.parents).toEqual([
+      `${file.sId}-${slugify("Sheet2")}`,
+    ]);
+    expect(secondUpsertCall.params.mimeType).toBe("text/csv");
+
+    // Verify file useCaseMetadata was updated with both table IDs
+    if (result.isOk()) {
+      const updatedFile = result.value;
+      expect(updatedFile.useCaseMetadata).not.toBeNull();
+
+      const generatedTables =
+        updatedFile.useCaseMetadata?.generatedTables || [];
+      expect(generatedTables).toContain(`${file.sId}-${slugify("Sheet1")}`);
+      expect(generatedTables).toContain(`${file.sId}-${slugify("Sheet2")}`);
+      expect(generatedTables.length).toBe(2);
     }
-  );
+  });
 
-  itInTransaction(
-    "should process an Excel file with multiple sheets with upsert_table usecase",
-    async (t) => {
-      // Create an Excel file
-      const file = await FileFactory.create(workspace, null, {
-        contentType:
-          "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
-        fileName: "test-excel-file.xlsx",
-        fileSize: 1000,
-        status: "ready",
-        useCase: "upsert_table",
-        useCaseMetadata: {
-          generatedTables: [],
-        },
-      });
+  it("should process an Excel file with multiple sheets with upsert_table usecase", async () => {
+    // Create an Excel file
+    const file = await FileFactory.create(workspace, null, {
+      contentType:
+        "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+      fileName: "test-excel-file.xlsx",
+      fileSize: 1000,
+      status: "ready",
+      useCase: "upsert_table",
+      useCaseMetadata: {
+        generatedTables: [],
+      },
+    });
 
-      const space = await SpaceFactory.global(workspace, t);
+    const space = await SpaceFactory.global(workspace);
 
-      // Create a data source using a transaction
-      const dataSourceView = await DataSourceViewFactory.folder(
-        workspace,
-        space,
-        t
-      );
+    // Create a data source using a transaction
+    const dataSourceView = await DataSourceViewFactory.folder(workspace, space);
 
-      // Mock getFileContent to return fake content with two sheets
+    // Mock getFileContent to return fake content with two sheets
 
-      const fakeExcelContent = `${TABLE_PREFIX}Sheet1
+    const fakeExcelContent = `${TABLE_PREFIX}Sheet1
 id,name,value
 1,Item 1,100
 2,Item 2,200
@@ -342,79 +314,78 @@ id,category,description
 2,Category B,Description for item 2
 3,Category C,Description for item 3`;
 
-      vi.mocked(getFileContent).mockResolvedValue(fakeExcelContent);
+    vi.mocked(getFileContent).mockResolvedValue(fakeExcelContent);
 
-      // Call processAndUpsertToDataSource
-      const result = await processAndUpsertToDataSource(
-        auth,
-        dataSourceView.dataSource,
-        {
-          file,
-        }
-      );
-
-      // Verify the result
-      expect(result.isOk()).toBe(true);
-
-      // Verify getFileContent was called
-      expect(getFileContent).toHaveBeenCalledTimes(1);
-      expect(getFileContent).toHaveBeenCalledWith(auth, file);
-
-      // Verify processAndStoreFile was called twice (once for each sheet)
-      expect(processAndStoreFile).toHaveBeenCalledTimes(2);
-
-      // Verify upsertTable was called twice (once for each sheet)
-      expect(upsertTable).toHaveBeenCalledTimes(2);
-
-      // Verify createDataSourceFolder was called once (one for the workbook)
-      expect(createDataSourceFolder).toHaveBeenCalledTimes(1);
-
-      // Check the createDataSourceFolder call
-      const createDataSourceFolderCall = vi.mocked(createDataSourceFolder).mock
-        .calls[0];
-      expect(createDataSourceFolderCall[0]).toBe(dataSourceView.dataSource);
-      expect(createDataSourceFolderCall[1].title).toBe(file.fileName);
-      expect(createDataSourceFolderCall[1].mimeType).toBe(
-        INTERNAL_MIME_TYPES.FOLDER.SPREADSHEET
-      );
-
-      // Check the first upsertTable call
-      const firstUpsertCall = vi.mocked(upsertTable).mock.calls[0][0];
-      expect(firstUpsertCall.params.title).toContain("Sheet1");
-      expect(firstUpsertCall.params.tableId).toContain(
-        `${file.sId}-${slugify("Sheet1")}`
-      );
-      expect(firstUpsertCall.params.parentId).toBe(file.sId);
-      expect(firstUpsertCall.params.parents).toEqual([
-        `${file.sId}-${slugify("Sheet1")}`,
-        file.sId,
-      ]);
-      expect(firstUpsertCall.params.mimeType).toBe("text/csv");
-
-      // Check the second upsertTable call
-      const secondUpsertCall = vi.mocked(upsertTable).mock.calls[1][0];
-      expect(secondUpsertCall.params.title).toContain("Sheet2");
-      expect(secondUpsertCall.params.tableId).toContain(
-        `${file.sId}-${slugify("Sheet2")}`
-      );
-      expect(secondUpsertCall.params.parentId).toBe(file.sId);
-      expect(secondUpsertCall.params.parents).toEqual([
-        `${file.sId}-${slugify("Sheet2")}`,
-        file.sId,
-      ]);
-      expect(secondUpsertCall.params.mimeType).toBe("text/csv");
-
-      // Verify file useCaseMetadata was updated with both table IDs
-      if (result.isOk()) {
-        const updatedFile = result.value;
-        expect(updatedFile.useCaseMetadata).not.toBeNull();
-
-        const generatedTables =
-          updatedFile.useCaseMetadata?.generatedTables || [];
-        expect(generatedTables).toContain(`${file.sId}-${slugify("Sheet1")}`);
-        expect(generatedTables).toContain(`${file.sId}-${slugify("Sheet2")}`);
-        expect(generatedTables.length).toBe(2);
+    // Call processAndUpsertToDataSource
+    const result = await processAndUpsertToDataSource(
+      auth,
+      dataSourceView.dataSource,
+      {
+        file,
       }
+    );
+
+    // Verify the result
+    expect(result.isOk()).toBe(true);
+
+    // Verify getFileContent was called
+    expect(getFileContent).toHaveBeenCalledTimes(1);
+    expect(getFileContent).toHaveBeenCalledWith(auth, file);
+
+    // Verify processAndStoreFile was called twice (once for each sheet)
+    expect(processAndStoreFile).toHaveBeenCalledTimes(2);
+
+    // Verify upsertTable was called twice (once for each sheet)
+    expect(upsertTable).toHaveBeenCalledTimes(2);
+
+    // Verify createDataSourceFolder was called once (one for the workbook)
+    expect(createDataSourceFolder).toHaveBeenCalledTimes(1);
+
+    // Check the createDataSourceFolder call
+    const createDataSourceFolderCall = vi.mocked(createDataSourceFolder).mock
+      .calls[0];
+    expect(createDataSourceFolderCall[0]).toBe(dataSourceView.dataSource);
+    expect(createDataSourceFolderCall[1].title).toBe(file.fileName);
+    expect(createDataSourceFolderCall[1].mimeType).toBe(
+      INTERNAL_MIME_TYPES.FOLDER.SPREADSHEET
+    );
+
+    // Check the first upsertTable call
+    const firstUpsertCall = vi.mocked(upsertTable).mock.calls[0][0];
+    expect(firstUpsertCall.params.title).toContain("Sheet1");
+    expect(firstUpsertCall.params.tableId).toContain(
+      `${file.sId}-${slugify("Sheet1")}`
+    );
+    expect(firstUpsertCall.params.parentId).toBe(file.sId);
+    expect(firstUpsertCall.params.parents).toEqual([
+      `${file.sId}-${slugify("Sheet1")}`,
+      file.sId,
+    ]);
+    expect(firstUpsertCall.params.mimeType).toBe("text/csv");
+
+    // Check the second upsertTable call
+    const secondUpsertCall = vi.mocked(upsertTable).mock.calls[1][0];
+    expect(secondUpsertCall.params.title).toContain("Sheet2");
+    expect(secondUpsertCall.params.tableId).toContain(
+      `${file.sId}-${slugify("Sheet2")}`
+    );
+    expect(secondUpsertCall.params.parentId).toBe(file.sId);
+    expect(secondUpsertCall.params.parents).toEqual([
+      `${file.sId}-${slugify("Sheet2")}`,
+      file.sId,
+    ]);
+    expect(secondUpsertCall.params.mimeType).toBe("text/csv");
+
+    // Verify file useCaseMetadata was updated with both table IDs
+    if (result.isOk()) {
+      const updatedFile = result.value;
+      expect(updatedFile.useCaseMetadata).not.toBeNull();
+
+      const generatedTables =
+        updatedFile.useCaseMetadata?.generatedTables || [];
+      expect(generatedTables).toContain(`${file.sId}-${slugify("Sheet1")}`);
+      expect(generatedTables).toContain(`${file.sId}-${slugify("Sheet2")}`);
+      expect(generatedTables.length).toBe(2);
     }
-  );
+  });
 });

--- a/front/lib/api/invitation.ts
+++ b/front/lib/api/invitation.ts
@@ -14,6 +14,7 @@ import { MembershipInvitationModel } from "@app/lib/models/membership_invitation
 import { MembershipResource } from "@app/lib/resources/membership_resource";
 import { generateRandomModelSId } from "@app/lib/resources/string_ids";
 import { isEmailValid } from "@app/lib/utils";
+import { withTransaction } from "@app/lib/utils/sql_utils";
 import logger from "@app/logger/logger";
 import type {
   ActiveRoleType,
@@ -27,8 +28,6 @@ import type {
   WorkspaceType,
 } from "@app/types";
 import { Err, Ok, sanitizeString } from "@app/types";
-
-import { frontSequelize } from "../resources/storage";
 
 // Make token expires after 7 days
 const INVITATION_EXPIRATION_TIME_SEC = 60 * 60 * 24 * 7;
@@ -351,7 +350,7 @@ export async function handleMembershipInvitations(
 ): Promise<Result<HandleMembershipInvitationResult[], APIErrorWithStatusCode>> {
   const { maxUsers } = subscription.plan.limits.users;
 
-  const result = await frontSequelize.transaction(
+  const result = await withTransaction(
     async (
       t
     ): Promise<

--- a/front/lib/api/spaces.ts
+++ b/front/lib/api/spaces.ts
@@ -16,11 +16,11 @@ import { DataSourceViewResource } from "@app/lib/resources/data_source_view_reso
 import { GroupResource } from "@app/lib/resources/group_resource";
 import { KeyResource } from "@app/lib/resources/key_resource";
 import { SpaceResource } from "@app/lib/resources/space_resource";
-import { frontSequelize } from "@app/lib/resources/storage";
 import { GroupSpaceModel } from "@app/lib/resources/storage/models/group_spaces";
 import { UserResource } from "@app/lib/resources/user_resource";
 import { isPrivateSpacesLimitReached } from "@app/lib/spaces";
 import { concurrentExecutor } from "@app/lib/utils/async_utils";
+import { withTransaction } from "@app/lib/utils/sql_utils";
 import logger from "@app/logger/logger";
 import { launchScrubSpaceWorkflow } from "@app/poke/temporal/client";
 import type { DataSourceWithAgentsUsageType, Result } from "@app/types";
@@ -89,7 +89,7 @@ export async function softDeleteSpaceAndLaunchScrubWorkflow(
     );
   }
 
-  await frontSequelize.transaction(async (t) => {
+  await withTransaction(async (t) => {
     // Soft delete all data source views.
     await concurrentExecutor(
       dataSourceViews,
@@ -215,7 +215,7 @@ export async function hardDeleteSpace(
     }
   }
 
-  await frontSequelize.transaction(async (t) => {
+  await withTransaction(async (t) => {
     // Delete all spaces groups.
     for (const group of space.groups) {
       // Skip deleting global groups for regular spaces.
@@ -264,7 +264,7 @@ export async function createRegularSpaceAndGroup(
   const owner = auth.getNonNullableWorkspace();
   const plan = auth.getNonNullablePlan();
 
-  const result = await frontSequelize.transaction(async (t) => {
+  const result = await withTransaction(async (t) => {
     await getWorkspaceAdministrationVersionLock(owner, t);
 
     const all = await SpaceResource.listWorkspaceSpaces(auth, undefined, t);

--- a/front/lib/resources/agent_memory_resource.ts
+++ b/front/lib/resources/agent_memory_resource.ts
@@ -7,13 +7,13 @@ import type {
 
 import type { Authenticator } from "@app/lib/auth";
 import { BaseResource } from "@app/lib/resources/base_resource";
-import { frontSequelize } from "@app/lib/resources/storage";
 import { AgentMemoryModel } from "@app/lib/resources/storage/models/agent_memories";
 import type { ReadonlyAttributesType } from "@app/lib/resources/storage/types";
 import type { ModelStaticWorkspaceAware } from "@app/lib/resources/storage/wrappers/workspace_models";
 import { getResourceIdFromSId, makeSId } from "@app/lib/resources/string_ids";
 import type { ResourceFindOptions } from "@app/lib/resources/types";
 import { concurrentExecutor } from "@app/lib/utils/async_utils";
+import { withTransaction } from "@app/lib/utils/sql_utils";
 import type {
   LightAgentConfigurationType,
   ModelId,
@@ -205,7 +205,7 @@ export class AgentMemoryResource extends BaseResource<AgentMemoryModel> {
       indexes: number[];
     }
   ): Promise<{ lastUpdated: Date; content: string }[]> {
-    await frontSequelize.transaction(async (t) => {
+    await withTransaction(async (t) => {
       const memories = (
         await this.findByAgentConfigurationAndUser(
           auth,
@@ -244,7 +244,7 @@ export class AgentMemoryResource extends BaseResource<AgentMemoryModel> {
       edits: { index: number; content: string }[];
     }
   ): Promise<{ lastUpdated: Date; content: string }[]> {
-    await frontSequelize.transaction(async (t) => {
+    await withTransaction(async (t) => {
       const memories = (
         await this.findByAgentConfigurationAndUser(
           auth,

--- a/front/lib/resources/agent_step_content_resource.ts
+++ b/front/lib/resources/agent_step_content_resource.ts
@@ -26,10 +26,10 @@ import {
 } from "@app/lib/models/assistant/conversation";
 import { BaseResource } from "@app/lib/resources/base_resource";
 import { FileResource } from "@app/lib/resources/file_resource";
-import { frontSequelize } from "@app/lib/resources/storage";
 import { FileModel } from "@app/lib/resources/storage/models/files";
 import type { ReadonlyAttributesType } from "@app/lib/resources/storage/types";
 import { makeSId } from "@app/lib/resources/string_ids";
+import { withTransaction } from "@app/lib/utils/sql_utils";
 import logger from "@app/logger/logger";
 import type { GetMCPActionsResult } from "@app/pages/api/w/[wId]/labs/mcp_actions/[agentId]";
 import type { ModelId, Result } from "@app/types";
@@ -404,7 +404,7 @@ export class AgentStepContentResource extends BaseResource<AgentStepContentModel
     CreationAttributes<AgentStepContentModel>,
     "version"
   >): Promise<AgentStepContentResource> {
-    return frontSequelize.transaction(async (transaction: Transaction) => {
+    return withTransaction(async (transaction: Transaction) => {
       const existingContent = await this.model.findAll({
         where: {
           agentMessageId,

--- a/front/lib/resources/app_resource.ts
+++ b/front/lib/resources/app_resource.ts
@@ -10,11 +10,11 @@ import { DatasetResource } from "@app/lib/resources/dataset_resource";
 import { ResourceWithSpace } from "@app/lib/resources/resource_with_space";
 import { RunResource } from "@app/lib/resources/run_resource";
 import type { SpaceResource } from "@app/lib/resources/space_resource";
-import { frontSequelize } from "@app/lib/resources/storage";
 import { AppModel, Clone } from "@app/lib/resources/storage/models/apps";
 import type { ReadonlyAttributesType } from "@app/lib/resources/storage/types";
 import { generateRandomModelSId } from "@app/lib/resources/string_ids";
 import type { ResourceFindOptions } from "@app/lib/resources/types";
+import { withTransaction } from "@app/lib/utils/sql_utils";
 import type { AppType, LightWorkspaceType, Result } from "@app/types";
 import type { SpecificationType } from "@app/types";
 import { Err, Ok } from "@app/types";
@@ -252,7 +252,7 @@ export class AppResource extends ResourceWithSpace<AppModel> {
   protected async hardDelete(
     auth: Authenticator
   ): Promise<Result<number, Error>> {
-    const deletedCount = await frontSequelize.transaction(async (t) => {
+    const deletedCount = await withTransaction(async (t) => {
       await RunResource.deleteAllByAppId(this.id, t);
 
       await Clone.destroy({

--- a/front/lib/resources/conversation_resource.ts
+++ b/front/lib/resources/conversation_resource.ts
@@ -16,6 +16,7 @@ import {
 } from "@app/lib/models/assistant/conversation";
 import { BaseResource } from "@app/lib/resources/base_resource";
 import type { ReadonlyAttributesType } from "@app/lib/resources/storage/types";
+import { withTransaction } from "@app/lib/utils/sql_utils";
 import type {
   ConversationType,
   ConversationVisibility,
@@ -26,7 +27,6 @@ import type {
 import { ConversationError, Err, normalizeError, Ok } from "@app/types";
 
 import { GroupResource } from "./group_resource";
-import { frontSequelize } from "./storage";
 import type { ModelStaticWorkspaceAware } from "./storage/wrappers/workspace_models";
 import type { ResourceFindOptions } from "./types";
 
@@ -429,7 +429,7 @@ export class ConversationResource extends BaseResource<ConversationModel> {
       return;
     }
 
-    await frontSequelize.transaction(async (t) => {
+    await withTransaction(async (t) => {
       const participant = await ConversationParticipantModel.findOne({
         where: {
           workspaceId: auth.getNonNullableWorkspace().id,

--- a/front/lib/resources/data_source_view_resource.test.ts
+++ b/front/lib/resources/data_source_view_resource.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect } from "vitest";
+import { describe, expect, it } from "vitest";
 
 import { Authenticator } from "@app/lib/auth";
 import { DataSourceViewResource } from "@app/lib/resources/data_source_view_resource";
@@ -8,172 +8,141 @@ import { GroupSpaceFactory } from "@app/tests/utils/GroupSpaceFactory";
 import { MembershipFactory } from "@app/tests/utils/MembershipFactory";
 import { SpaceFactory } from "@app/tests/utils/SpaceFactory";
 import { UserFactory } from "@app/tests/utils/UserFactory";
-import { itInTransaction } from "@app/tests/utils/utils";
 import { WorkspaceFactory } from "@app/tests/utils/WorkspaceFactory";
 
 describe("DataSourceViewResource", () => {
   describe("listByWorkspace", () => {
-    itInTransaction(
-      "should only return views for the current workspace",
-      async (t) => {
-        // Create two workspaces
-        const workspace1 = await WorkspaceFactory.basic();
-        const workspace2 = await WorkspaceFactory.basic();
+    it("should only return views for the current workspace", async () => {
+      // Create two workspaces
+      const workspace1 = await WorkspaceFactory.basic();
+      const workspace2 = await WorkspaceFactory.basic();
 
-        // Create spaces for each workspace
-        const space1 = await SpaceFactory.regular(workspace1, t);
-        const space2 = await SpaceFactory.regular(workspace2, t);
-        await SpaceFactory.conversations(workspace1, t);
-        await SpaceFactory.conversations(workspace2, t);
+      // Create spaces for each workspace
+      const space1 = await SpaceFactory.regular(workspace1);
+      const space2 = await SpaceFactory.regular(workspace2);
+      await SpaceFactory.conversations(workspace1);
+      await SpaceFactory.conversations(workspace2);
 
-        // Create data source views for both workspaces
-        await DataSourceViewFactory.folder(workspace1, space1, t);
-        await DataSourceViewFactory.folder(workspace1, space1, t);
-        await DataSourceViewFactory.folder(workspace2, space2, t);
-        await DataSourceViewFactory.folder(workspace2, space2, t);
+      // Create data source views for both workspaces
+      await DataSourceViewFactory.folder(workspace1, space1);
+      await DataSourceViewFactory.folder(workspace1, space1);
+      await DataSourceViewFactory.folder(workspace2, space2);
+      await DataSourceViewFactory.folder(workspace2, space2);
 
-        // Create a user for workspace1
-        const { globalGroup } = await GroupFactory.defaults(workspace1);
-        const user1 = await UserFactory.superUser();
-        await MembershipFactory.associate(
-          workspace1,
-          user1,
-          { role: "user" },
-          t
-        );
-        await GroupSpaceFactory.associate(space1, globalGroup);
+      // Create a user for workspace1
+      const { globalGroup } = await GroupFactory.defaults(workspace1);
+      const user1 = await UserFactory.superUser();
+      await MembershipFactory.associate(workspace1, user1, { role: "user" });
+      await GroupSpaceFactory.associate(space1, globalGroup);
 
-        const auth = await Authenticator.fromUserIdAndWorkspaceId(
-          user1.sId,
-          workspace1.sId
-        );
+      const auth = await Authenticator.fromUserIdAndWorkspaceId(
+        user1.sId,
+        workspace1.sId
+      );
 
-        // List views for workspace1
-        const views1 = await DataSourceViewResource.listByWorkspace(auth);
+      // List views for workspace1
+      const views1 = await DataSourceViewResource.listByWorkspace(auth);
 
-        // Verify we only get views for workspace1
-        expect(views1).toHaveLength(2);
-        expect(views1[0].workspaceId).toBe(workspace1.id);
-        expect(views1[1].workspaceId).toBe(workspace1.id);
+      // Verify we only get views for workspace1
+      expect(views1).toHaveLength(2);
+      expect(views1[0].workspaceId).toBe(workspace1.id);
+      expect(views1[1].workspaceId).toBe(workspace1.id);
 
-        // Create auth for workspace2
-        const auth2 = await Authenticator.internalAdminForWorkspace(
-          workspace2.sId
-        );
+      // Create auth for workspace2
+      const auth2 = await Authenticator.internalAdminForWorkspace(
+        workspace2.sId
+      );
 
-        // List views for workspace2
-        const views2 = await DataSourceViewResource.listByWorkspace(auth2);
+      // List views for workspace2
+      const views2 = await DataSourceViewResource.listByWorkspace(auth2);
 
-        // Verify we only get views for workspace2
-        expect(views2).toHaveLength(2);
-        expect(views2[0].workspaceId).toBe(workspace2.id);
-        expect(views2[1].workspaceId).toBe(workspace2.id);
-      }
-    );
+      // Verify we only get views for workspace2
+      expect(views2).toHaveLength(2);
+      expect(views2[0].workspaceId).toBe(workspace2.id);
+      expect(views2[1].workspaceId).toBe(workspace2.id);
+    });
 
-    itInTransaction(
-      "should respect fetchDataSourceViewOptions parameters",
-      async (t) => {
-        // Create workspace and spaces
-        const workspace = await WorkspaceFactory.basic();
-        const space = await SpaceFactory.regular(workspace, t);
-        await SpaceFactory.conversations(workspace, t);
+    it("should respect fetchDataSourceViewOptions parameters", async () => {
+      // Create workspace and spaces
+      const workspace = await WorkspaceFactory.basic();
+      const space = await SpaceFactory.regular(workspace);
+      await SpaceFactory.conversations(workspace);
 
-        // Create data source views
-        const editor = await UserFactory.basic();
-        const view1 = await DataSourceViewFactory.folder(
-          workspace,
-          space,
-          t,
-          editor
-        );
-        const view2 = await DataSourceViewFactory.folder(
-          workspace,
-          space,
-          t,
-          editor
-        );
-        const view3 = await DataSourceViewFactory.folder(
-          workspace,
-          space,
-          t,
-          editor
-        );
+      // Create data source views
+      const editor = await UserFactory.basic();
+      const view1 = await DataSourceViewFactory.folder(
+        workspace,
+        space,
+        editor
+      );
+      const view2 = await DataSourceViewFactory.folder(
+        workspace,
+        space,
+        editor
+      );
+      const view3 = await DataSourceViewFactory.folder(
+        workspace,
+        space,
+        editor
+      );
 
-        // Create auth
-        const auth = await Authenticator.internalAdminForWorkspace(
-          workspace.sId
-        );
+      // Create auth
+      const auth = await Authenticator.internalAdminForWorkspace(workspace.sId);
 
-        // Test limit parameter
-        const limitedViews = await DataSourceViewResource.listByWorkspace(
-          auth,
-          {
-            limit: 2,
-          }
-        );
-        expect(limitedViews).toHaveLength(2);
+      // Test limit parameter
+      const limitedViews = await DataSourceViewResource.listByWorkspace(auth, {
+        limit: 2,
+      });
+      expect(limitedViews).toHaveLength(2);
 
-        // Test order parameter
-        const orderedViews = await DataSourceViewResource.listByWorkspace(
-          auth,
-          {
-            order: [["createdAt", "DESC"]],
-          }
-        );
-        expect(orderedViews).toHaveLength(3);
-        expect(orderedViews[0].id).toBe(view3.id);
-        expect(orderedViews[1].id).toBe(view2.id);
-        expect(orderedViews[2].id).toBe(view1.id);
+      // Test order parameter
+      const orderedViews = await DataSourceViewResource.listByWorkspace(auth, {
+        order: [["createdAt", "DESC"]],
+      });
+      expect(orderedViews).toHaveLength(3);
+      expect(orderedViews[0].id).toBe(view3.id);
+      expect(orderedViews[1].id).toBe(view2.id);
+      expect(orderedViews[2].id).toBe(view1.id);
 
-        // Test includeEditedBy parameter
-        const viewsWithEditedBy = await DataSourceViewResource.listByWorkspace(
-          auth,
-          {
-            includeEditedBy: true,
-          }
-        );
-        expect(viewsWithEditedBy).toHaveLength(3);
-        expect(viewsWithEditedBy[0].editedByUser).toBeDefined();
-      }
-    );
+      // Test includeEditedBy parameter
+      const viewsWithEditedBy = await DataSourceViewResource.listByWorkspace(
+        auth,
+        {
+          includeEditedBy: true,
+        }
+      );
+      expect(viewsWithEditedBy).toHaveLength(3);
+      expect(viewsWithEditedBy[0].editedByUser).toBeDefined();
+    });
 
-    itInTransaction(
-      "should respect includeConversationDataSources parameter",
-      async (t) => {
-        // Create workspace
-        const workspace = await WorkspaceFactory.basic();
+    it("should respect includeConversationDataSources parameter", async () => {
+      // Create workspace
+      const workspace = await WorkspaceFactory.basic();
 
-        // Create regular space and conversation space
-        const regularSpace = await SpaceFactory.regular(workspace, t);
-        const conversationSpace = await SpaceFactory.conversations(
-          workspace,
-          t
-        );
+      // Create regular space and conversation space
+      const regularSpace = await SpaceFactory.regular(workspace);
+      const conversationSpace = await SpaceFactory.conversations(workspace);
 
-        // Create data source views in both spaces
-        await DataSourceViewFactory.folder(workspace, regularSpace, t);
-        await DataSourceViewFactory.folder(workspace, conversationSpace, t);
+      // Create data source views in both spaces
+      await DataSourceViewFactory.folder(workspace, regularSpace);
+      await DataSourceViewFactory.folder(workspace, conversationSpace);
 
-        // Create auth
-        const auth = await Authenticator.internalAdminForWorkspace(
-          workspace.sId
-        );
+      // Create auth
+      const auth = await Authenticator.internalAdminForWorkspace(workspace.sId);
 
-        // Test without including conversation data sources
-        const viewsWithoutConversations =
-          await DataSourceViewResource.listByWorkspace(auth, undefined, false);
-        expect(viewsWithoutConversations).toHaveLength(1);
-        expect(viewsWithoutConversations[0].space.id).toBe(regularSpace.id);
+      // Test without including conversation data sources
+      const viewsWithoutConversations =
+        await DataSourceViewResource.listByWorkspace(auth, undefined, false);
+      expect(viewsWithoutConversations).toHaveLength(1);
+      expect(viewsWithoutConversations[0].space.id).toBe(regularSpace.id);
 
-        // Test including conversation data sources
-        const viewsWithConversations =
-          await DataSourceViewResource.listByWorkspace(auth, undefined, true);
-        expect(viewsWithConversations).toHaveLength(2);
-        expect(viewsWithConversations.map((v) => v.space.id).sort()).toEqual(
-          [regularSpace.id, conversationSpace.id].sort()
-        );
-      }
-    );
+      // Test including conversation data sources
+      const viewsWithConversations =
+        await DataSourceViewResource.listByWorkspace(auth, undefined, true);
+      expect(viewsWithConversations).toHaveLength(2);
+      expect(viewsWithConversations.map((v) => v.space.id).sort()).toEqual(
+        [regularSpace.id, conversationSpace.id].sort()
+      );
+    });
   });
 });

--- a/front/lib/resources/data_source_view_resource.ts
+++ b/front/lib/resources/data_source_view_resource.ts
@@ -23,7 +23,6 @@ import { DataSourceResource } from "@app/lib/resources/data_source_resource";
 import { GroupResource } from "@app/lib/resources/group_resource";
 import { ResourceWithSpace } from "@app/lib/resources/resource_with_space";
 import { SpaceResource } from "@app/lib/resources/space_resource";
-import { frontSequelize } from "@app/lib/resources/storage";
 import { ContentFragmentModel } from "@app/lib/resources/storage/models/content_fragment";
 import { DataSourceModel } from "@app/lib/resources/storage/models/data_source";
 import { DataSourceViewModel } from "@app/lib/resources/storage/models/data_source_view";
@@ -35,6 +34,7 @@ import {
   makeSId,
 } from "@app/lib/resources/string_ids";
 import type { ResourceFindOptions } from "@app/lib/resources/types";
+import { withTransaction } from "@app/lib/utils/sql_utils";
 import logger from "@app/logger/logger";
 import type {
   ConversationType,
@@ -129,7 +129,7 @@ export class DataSourceViewResource extends ResourceWithSpace<DataSourceViewMode
     editedByUser?: UserResource | null,
     transaction?: Transaction
   ) {
-    const createDataSourceAndView = async (t: Transaction) => {
+    return withTransaction(async (t: Transaction) => {
       const dataSource = await DataSourceResource.makeNew(
         blob,
         space,
@@ -142,13 +142,7 @@ export class DataSourceViewResource extends ResourceWithSpace<DataSourceViewMode
         editedByUser?.toJSON(),
         t
       );
-    };
-
-    if (transaction) {
-      return createDataSourceAndView(transaction);
-    }
-
-    return frontSequelize.transaction(createDataSourceAndView);
+    }, transaction);
   }
 
   static async createViewInSpaceFromDataSource(

--- a/front/lib/resources/mcp_server_connection_resource.test.ts
+++ b/front/lib/resources/mcp_server_connection_resource.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect } from "vitest";
+import { describe, expect, it } from "vitest";
 
 import { Authenticator } from "@app/lib/auth";
 import { MCPServerConnectionResource } from "@app/lib/resources/mcp_server_connection_resource";
@@ -8,152 +8,134 @@ import { MembershipFactory } from "@app/tests/utils/MembershipFactory";
 import { RemoteMCPServerFactory } from "@app/tests/utils/RemoteMCPServerFactory";
 import { SpaceFactory } from "@app/tests/utils/SpaceFactory";
 import { UserFactory } from "@app/tests/utils/UserFactory";
-import { itInTransaction } from "@app/tests/utils/utils";
 
 describe("MCPServerConnectionResource", () => {
   describe("findByMCPServer", () => {
-    itInTransaction(
-      "should return error for non-related authenticator trying to access personal connection",
-      async (t) => {
-        // Create first workspace and its connection
-        const { workspace: workspace1, authenticator: authenticator1 } =
-          await createPrivateApiMockRequest({
-            method: "GET",
-          });
-        await SpaceFactory.system(workspace1, t);
-        const remoteServer1 = await RemoteMCPServerFactory.create(workspace1);
-        await MCPServerConnectionFactory.remote(
-          authenticator1,
-          remoteServer1,
-          "personal"
-        );
+    it("should return error for non-related authenticator trying to access personal connection", async () => {
+      // Create first workspace and its connection
+      const { workspace: workspace1, authenticator: authenticator1 } =
+        await createPrivateApiMockRequest({
+          method: "GET",
+        });
+      await SpaceFactory.system(workspace1);
+      const remoteServer1 = await RemoteMCPServerFactory.create(workspace1);
+      await MCPServerConnectionFactory.remote(
+        authenticator1,
+        remoteServer1,
+        "personal"
+      );
 
-        // Create second workspace and try to access connection1
-        const { workspace: workspace2, authenticator: authenticator2 } =
-          await createPrivateApiMockRequest({
-            method: "GET",
-          });
-        await SpaceFactory.system(workspace2, t);
+      // Create second workspace and try to access connection1
+      const { workspace: workspace2, authenticator: authenticator2 } =
+        await createPrivateApiMockRequest({
+          method: "GET",
+        });
+      await SpaceFactory.system(workspace2);
 
-        const result = await MCPServerConnectionResource.findByMCPServer(
-          authenticator2,
-          {
-            mcpServerId: remoteServer1.sId,
-            connectionType: "personal",
-          }
-        );
-
-        expect(result.isErr()).toBe(true);
-        if (result.isErr()) {
-          expect(result.error.message).toBe("Connection not found");
+      const result = await MCPServerConnectionResource.findByMCPServer(
+        authenticator2,
+        {
+          mcpServerId: remoteServer1.sId,
+          connectionType: "personal",
         }
+      );
+
+      expect(result.isErr()).toBe(true);
+      if (result.isErr()) {
+        expect(result.error.message).toBe("Connection not found");
       }
-    );
+    });
 
-    itInTransaction(
-      "should allow any workspace member to access workspace connection",
-      async (t) => {
-        const { workspace, authenticator: adminAuthenticator } =
-          await createPrivateApiMockRequest({
-            method: "GET",
-            role: "admin",
-          });
-        await SpaceFactory.system(workspace, t);
-        const remoteServer = await RemoteMCPServerFactory.create(workspace);
+    it("should allow any workspace member to access workspace connection", async () => {
+      const { workspace, authenticator: adminAuthenticator } =
+        await createPrivateApiMockRequest({
+          method: "GET",
+          role: "admin",
+        });
+      await SpaceFactory.system(workspace);
+      const remoteServer = await RemoteMCPServerFactory.create(workspace);
 
-        // Create workspace connection as admin
-        const workspaceConnection = await MCPServerConnectionFactory.remote(
-          adminAuthenticator,
-          remoteServer,
-          "workspace"
-        );
+      // Create workspace connection as admin
+      const workspaceConnection = await MCPServerConnectionFactory.remote(
+        adminAuthenticator,
+        remoteServer,
+        "workspace"
+      );
 
-        // Create a regular user in the same workspace
-        const regularUser = await UserFactory.basic();
-        await MembershipFactory.associate(
-          workspace,
-          regularUser,
-          { role: "user" },
-          t
-        );
-        const regularUserAuthenticator =
-          await Authenticator.fromUserIdAndWorkspaceId(
-            regularUser.sId,
-            workspace.sId
-          );
-
-        // Try to access workspace connection as regular user
-        const result = await MCPServerConnectionResource.findByMCPServer(
-          regularUserAuthenticator,
-          {
-            mcpServerId: remoteServer.sId,
-            connectionType: "workspace",
-          }
-        );
-
-        expect(result.isOk()).toBe(true);
-        if (result.isOk()) {
-          expect(result.value.sId).toBe(workspaceConnection.sId);
-        }
-      }
-    );
-
-    itInTransaction(
-      "should only allow related authenticator to access personal connection",
-      async (t) => {
-        const { workspace, authenticator: authenticator1 } =
-          await createPrivateApiMockRequest({
-            method: "GET",
-          });
-        await SpaceFactory.system(workspace, t);
-        const remoteServer = await RemoteMCPServerFactory.create(workspace);
-
-        // Create personal connection for first user
-        const connection1 = await MCPServerConnectionFactory.remote(
-          authenticator1,
-          remoteServer,
-          "personal"
-        );
-
-        // Create second user in the same workspace
-        const user2 = await UserFactory.basic();
-        await MembershipFactory.associate(
-          workspace,
-          user2,
-          { role: "user" },
-          t
-        );
-        const authenticator2 = await Authenticator.fromUserIdAndWorkspaceId(
-          user2.sId,
+      // Create a regular user in the same workspace
+      const regularUser = await UserFactory.basic();
+      await MembershipFactory.associate(workspace, regularUser, {
+        role: "user",
+      });
+      const regularUserAuthenticator =
+        await Authenticator.fromUserIdAndWorkspaceId(
+          regularUser.sId,
           workspace.sId
         );
 
-        // Try to access connection as second user
-        const result = await MCPServerConnectionResource.findByMCPServer(
-          authenticator2,
-          {
-            mcpServerId: remoteServer.sId,
-            connectionType: "personal",
-          }
-        );
-
-        expect(result.isErr()).toBe(true);
-        if (result.isErr()) {
-          expect(result.error.message).toBe("Connection not found");
+      // Try to access workspace connection as regular user
+      const result = await MCPServerConnectionResource.findByMCPServer(
+        regularUserAuthenticator,
+        {
+          mcpServerId: remoteServer.sId,
+          connectionType: "workspace",
         }
+      );
 
-        // Verify original user can still access their connection
-        const originalUserResult =
-          await MCPServerConnectionResource.findByMCPServer(authenticator1, {
-            mcpServerId: remoteServer.sId,
-            connectionType: "personal",
-          });
-
-        expect(originalUserResult.isOk()).toBe(true);
-        if (originalUserResult.isOk()) {
-          expect(originalUserResult.value.sId).toBe(connection1.sId);
-        }
+      expect(result.isOk()).toBe(true);
+      if (result.isOk()) {
+        expect(result.value.sId).toBe(workspaceConnection.sId);
       }
-    );
+    });
+
+    it("should only allow related authenticator to access personal connection", async () => {
+      const { workspace, authenticator: authenticator1 } =
+        await createPrivateApiMockRequest({
+          method: "GET",
+        });
+      await SpaceFactory.system(workspace);
+      const remoteServer = await RemoteMCPServerFactory.create(workspace);
+
+      // Create personal connection for first user
+      const connection1 = await MCPServerConnectionFactory.remote(
+        authenticator1,
+        remoteServer,
+        "personal"
+      );
+
+      // Create second user in the same workspace
+      const user2 = await UserFactory.basic();
+      await MembershipFactory.associate(workspace, user2, { role: "user" });
+      const authenticator2 = await Authenticator.fromUserIdAndWorkspaceId(
+        user2.sId,
+        workspace.sId
+      );
+
+      // Try to access connection as second user
+      const result = await MCPServerConnectionResource.findByMCPServer(
+        authenticator2,
+        {
+          mcpServerId: remoteServer.sId,
+          connectionType: "personal",
+        }
+      );
+
+      expect(result.isErr()).toBe(true);
+      if (result.isErr()) {
+        expect(result.error.message).toBe("Connection not found");
+      }
+
+      // Verify original user can still access their connection
+      const originalUserResult =
+        await MCPServerConnectionResource.findByMCPServer(authenticator1, {
+          mcpServerId: remoteServer.sId,
+          connectionType: "personal",
+        });
+
+      expect(originalUserResult.isOk()).toBe(true);
+      if (originalUserResult.isOk()) {
+        expect(originalUserResult.value.sId).toBe(connection1.sId);
+      }
+    });
   });
 });

--- a/front/lib/resources/mcp_server_view_resource.test.ts
+++ b/front/lib/resources/mcp_server_view_resource.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect } from "vitest";
+import { describe, expect, it } from "vitest";
 
 import { INTERNAL_MCP_SERVERS } from "@app/lib/actions/mcp_internal_actions/constants";
 import { Authenticator } from "@app/lib/auth";
@@ -11,127 +11,108 @@ import { MCPServerViewFactory } from "@app/tests/utils/MCPServerViewFactory";
 import { MembershipFactory } from "@app/tests/utils/MembershipFactory";
 import { SpaceFactory } from "@app/tests/utils/SpaceFactory";
 import { UserFactory } from "@app/tests/utils/UserFactory";
-import { itInTransaction } from "@app/tests/utils/utils";
 import { WorkspaceFactory } from "@app/tests/utils/WorkspaceFactory";
 import type { PlanType, WhitelistableFeature } from "@app/types";
 
 describe("MCPServerViewResource", () => {
   describe("listByWorkspace", () => {
-    itInTransaction(
-      "should only return views for the current workspace",
-      async (t) => {
-        // Create two workspaces
-        const workspace1 = await WorkspaceFactory.basic();
-        const workspace2 = await WorkspaceFactory.basic();
+    it("should only return views for the current workspace", async () => {
+      // Create two workspaces
+      const workspace1 = await WorkspaceFactory.basic();
+      const workspace2 = await WorkspaceFactory.basic();
 
-        // Create spaces for each workspace
-        const systemSpace1 = await SpaceFactory.system(workspace1, t);
-        await SpaceFactory.system(workspace2, t);
-        const space1 = await SpaceFactory.regular(workspace1, t);
-        const space2 = await SpaceFactory.regular(workspace2, t);
+      // Create spaces for each workspace
+      const systemSpace1 = await SpaceFactory.system(workspace1);
+      await SpaceFactory.system(workspace2);
+      const space1 = await SpaceFactory.regular(workspace1);
+      const space2 = await SpaceFactory.regular(workspace2);
 
-        // Create internals servers for each workspace
+      // Create internals servers for each workspace
 
-        await FeatureFlagFactory.basic("dev_mcp_actions", workspace1);
-        await FeatureFlagFactory.basic("dev_mcp_actions", workspace2);
+      await FeatureFlagFactory.basic("dev_mcp_actions", workspace1);
+      await FeatureFlagFactory.basic("dev_mcp_actions", workspace2);
 
-        // Mock the INTERNAL_MCP_SERVERS to override the "think" server config
-        // so that the test passes even if we edit the server config.
-        const originalThinkConfig = INTERNAL_MCP_SERVERS["think"];
-        Object.defineProperty(INTERNAL_MCP_SERVERS, "think", {
-          value: {
-            ...originalThinkConfig,
-            availability: "auto",
-            isRestricted: ({
-              featureFlags,
-            }: {
-              plan: PlanType;
-              featureFlags: WhitelistableFeature[];
-            }) => {
-              return !featureFlags.includes("dev_mcp_actions");
-            },
+      // Mock the INTERNAL_MCP_SERVERS to override the "think" server config
+      // so that the test passes even if we edit the server config.
+      const originalThinkConfig = INTERNAL_MCP_SERVERS["think"];
+      Object.defineProperty(INTERNAL_MCP_SERVERS, "think", {
+        value: {
+          ...originalThinkConfig,
+          availability: "auto",
+          isRestricted: ({
+            featureFlags,
+          }: {
+            plan: PlanType;
+            featureFlags: WhitelistableFeature[];
+          }) => {
+            return !featureFlags.includes("dev_mcp_actions");
           },
-          writable: true,
-          configurable: true,
-        });
+        },
+        writable: true,
+        configurable: true,
+      });
 
-        expect(INTERNAL_MCP_SERVERS["think"].availability).toBe("auto");
+      expect(INTERNAL_MCP_SERVERS["think"].availability).toBe("auto");
 
-        // Get auth for workspace1
-        const auth1 = await Authenticator.internalAdminForWorkspace(
-          workspace1.sId
-        );
+      // Get auth for workspace1
+      const auth1 = await Authenticator.internalAdminForWorkspace(
+        workspace1.sId
+      );
 
-        // Get auth for workspace2
-        const auth2 = await Authenticator.internalAdminForWorkspace(
-          workspace2.sId
-        );
+      // Get auth for workspace2
+      const auth2 = await Authenticator.internalAdminForWorkspace(
+        workspace2.sId
+      );
 
-        // Internal server in the right workspace
-        const internalServer1 = await InternalMCPServerInMemoryResource.makeNew(
-          auth1,
-          {
-            name: "think",
-            useCase: null,
-          },
-          t
-        );
+      // Internal server in the right workspace
+      const internalServer1 = await InternalMCPServerInMemoryResource.makeNew(
+        auth1,
+        {
+          name: "think",
+          useCase: null,
+        }
+      );
 
-        const internalServer2 = await InternalMCPServerInMemoryResource.makeNew(
-          auth2,
-          {
-            name: "think",
-            useCase: null,
-          },
-          t
-        );
+      const internalServer2 = await InternalMCPServerInMemoryResource.makeNew(
+        auth2,
+        {
+          name: "think",
+          useCase: null,
+        }
+      );
 
-        // Create MCP server views for both workspaces
-        await MCPServerViewFactory.create(
-          workspace1,
-          internalServer1.id,
-          space1
-        );
-        await MCPServerViewFactory.create(
-          workspace2,
-          internalServer2.id,
-          space2
-        );
+      // Create MCP server views for both workspaces
+      await MCPServerViewFactory.create(workspace1, internalServer1.id, space1);
+      await MCPServerViewFactory.create(workspace2, internalServer2.id, space2);
 
-        // Create a real user for workspace1
-        const { globalGroup, systemGroup } =
-          await GroupFactory.defaults(workspace1);
-        const user1 = await UserFactory.superUser();
-        await MembershipFactory.associate(
-          workspace1,
-          user1,
-          { role: "user" },
-          t
-        );
-        await GroupSpaceFactory.associate(systemSpace1, systemGroup);
-        await GroupSpaceFactory.associate(space1, globalGroup);
+      // Create a real user for workspace1
+      const { globalGroup, systemGroup } =
+        await GroupFactory.defaults(workspace1);
+      const user1 = await UserFactory.superUser();
+      await MembershipFactory.associate(workspace1, user1, { role: "user" });
+      await GroupSpaceFactory.associate(systemSpace1, systemGroup);
+      await GroupSpaceFactory.associate(space1, globalGroup);
 
-        const auth = await Authenticator.fromUserIdAndWorkspaceId(
-          user1.sId,
-          workspace1.sId
-        );
+      const auth = await Authenticator.fromUserIdAndWorkspaceId(
+        user1.sId,
+        workspace1.sId
+      );
 
-        // List views for workspace1
-        const views1 = await MCPServerViewResource.listByWorkspace(auth);
+      // List views for workspace1
+      const views1 = await MCPServerViewResource.listByWorkspace(auth);
 
-        // Verify we only get views for workspace1
-        expect(views1).toHaveLength(2);
-        expect(views1[0].workspaceId).toBe(workspace1.id);
-        expect(views1[1].workspaceId).toBe(workspace1.id);
+      // Verify we only get views for workspace1
+      expect(views1).toHaveLength(2);
+      expect(views1[0].workspaceId).toBe(workspace1.id);
+      expect(views1[1].workspaceId).toBe(workspace1.id);
 
-        // List views for workspace2
-        const views2 = await MCPServerViewResource.listByWorkspace(auth2);
+      // List views for workspace2
+      const views2 = await MCPServerViewResource.listByWorkspace(auth2);
 
-        // Verify we only get views for workspace2
-        expect(views2).toHaveLength(2);
-        expect(views2[0].workspaceId).toBe(workspace2.id);
-        expect(views2[1].workspaceId).toBe(workspace2.id);
-      }
-    );
+      // Verify we only get views for workspace2
+      expect(views2).toHaveLength(2);
+      expect(views2[0].workspaceId).toBe(workspace2.id);
+      expect(views2[1].workspaceId).toBe(workspace2.id);
+    });
   });
 });

--- a/front/lib/resources/space_resource.ts
+++ b/front/lib/resources/space_resource.ts
@@ -12,7 +12,6 @@ import type { Authenticator } from "@app/lib/auth";
 import { DustError } from "@app/lib/error";
 import { BaseResource } from "@app/lib/resources/base_resource";
 import { GroupResource } from "@app/lib/resources/group_resource";
-import { frontSequelize } from "@app/lib/resources/storage";
 import { GroupSpaceModel } from "@app/lib/resources/storage/models/group_spaces";
 import { GroupModel } from "@app/lib/resources/storage/models/groups";
 import { SpaceModel } from "@app/lib/resources/storage/models/spaces";
@@ -22,6 +21,7 @@ import { getResourceIdFromSId, makeSId } from "@app/lib/resources/string_ids";
 import type { ResourceFindOptions } from "@app/lib/resources/types";
 import { UserResource } from "@app/lib/resources/user_resource";
 import { concurrentExecutor } from "@app/lib/utils/async_utils";
+import { withTransaction } from "@app/lib/utils/sql_utils";
 import { launchUpdateSpacePermissionsWorkflow } from "@app/temporal/permissions_queue/client";
 import type {
   CombinedResourcePermissions,
@@ -62,7 +62,7 @@ export class SpaceResource extends BaseResource<SpaceModel> {
     groups: GroupResource[],
     transaction?: Transaction
   ) {
-    const createSpace = async (t: Transaction) => {
+    return withTransaction(async (t: Transaction) => {
       const space = await SpaceModel.create(blob, { transaction: t });
 
       for (const group of groups) {
@@ -77,13 +77,7 @@ export class SpaceResource extends BaseResource<SpaceModel> {
       }
 
       return new this(SpaceModel, space.get(), groups);
-    };
-
-    if (transaction) {
-      return createSpace(transaction);
-    }
-
-    return frontSequelize.transaction(createSpace);
+    }, transaction);
   }
 
   static async makeDefaultsForWorkspace(
@@ -489,7 +483,7 @@ export class SpaceResource extends BaseResource<SpaceModel> {
 
     const globalGroup = groupRes.value;
 
-    return frontSequelize.transaction(async (t) => {
+    return withTransaction(async (t) => {
       // Update managementMode if provided
       if (isRestricted) {
         const { managementMode } = params;

--- a/front/lib/resources/storage/index.ts
+++ b/front/lib/resources/storage/index.ts
@@ -1,5 +1,5 @@
 import assert from "assert";
-import { default as cls } from "cls-hooked";
+//import { default as cls } from "cls-hooked";
 import { Sequelize } from "sequelize";
 
 import { dbConfig } from "@app/lib/resources/storage/config";
@@ -32,13 +32,6 @@ types.setTypeParser(types.builtins.INT8, function (val: unknown) {
   );
   return Number(val);
 });
-
-if (process.env.NODE_ENV === "test") {
-  const namespace = cls.createNamespace("test-namespace");
-
-  // eslint-disable-next-line react-hooks/rules-of-hooks
-  Sequelize.useCLS(namespace);
-}
 
 export const statsDClient = getStatsDClient();
 const CONNECTION_ACQUISITION_THRESHOLD_MS = 100;

--- a/front/lib/resources/subscription_resource.ts
+++ b/front/lib/resources/subscription_resource.ts
@@ -29,11 +29,11 @@ import { getTrialVersionForPlan, isTrial } from "@app/lib/plans/trial";
 import { countActiveSeatsInWorkspace } from "@app/lib/plans/usage/seats";
 import { REPORT_USAGE_METADATA_KEY } from "@app/lib/plans/usage/types";
 import { BaseResource } from "@app/lib/resources/base_resource";
-import { frontSequelize } from "@app/lib/resources/storage";
 import { WorkspaceModel } from "@app/lib/resources/storage/models/workspace";
 import type { ReadonlyAttributesType } from "@app/lib/resources/storage/types";
 import type { ModelStaticWorkspaceAware } from "@app/lib/resources/storage/wrappers/workspace_models";
 import { generateRandomModelSId } from "@app/lib/resources/string_ids";
+import { withTransaction } from "@app/lib/utils/sql_utils";
 import { getWorkspaceFirstAdmin } from "@app/lib/workspace";
 import { checkWorkspaceActivity } from "@app/lib/workspace_usage";
 import logger from "@app/logger/logger";
@@ -312,7 +312,7 @@ export class SubscriptionResource extends BaseResource<Subscription> {
     }
 
     // Proceed to the termination of the active subscription (if any) and creation of the new one
-    const newSubscription = await frontSequelize.transaction(async (t) => {
+    const newSubscription = await withTransaction(async (t) => {
       if (activeSubscription) {
         const endedStatus = activeSubscription.stripeSubscriptionId
           ? "ended_backend_only"
@@ -732,7 +732,7 @@ export class SubscriptionResource extends BaseResource<Subscription> {
     });
 
     if (activeSubscription) {
-      await frontSequelize.transaction(async (t) => {
+      await withTransaction(async (t) => {
         // End the subscription
         const endedStatus = activeSubscription.stripeSubscriptionId
           ? "ended_backend_only"

--- a/front/lib/resources/tracker_resource.ts
+++ b/front/lib/resources/tracker_resource.ts
@@ -14,13 +14,13 @@ import {
 import { DataSourceViewResource } from "@app/lib/resources/data_source_view_resource";
 import { ResourceWithSpace } from "@app/lib/resources/resource_with_space";
 import type { SpaceResource } from "@app/lib/resources/space_resource";
-import { frontSequelize } from "@app/lib/resources/storage";
 import { DataSourceModel } from "@app/lib/resources/storage/models/data_source";
 import { WorkspaceModel } from "@app/lib/resources/storage/models/workspace";
 import type { ReadonlyAttributesType } from "@app/lib/resources/storage/types";
 import type { ModelStaticWorkspaceAware } from "@app/lib/resources/storage/wrappers/workspace_models";
 import { getResourceIdFromSId, makeSId } from "@app/lib/resources/string_ids";
 import type { ResourceFindOptions } from "@app/lib/resources/types";
+import { withTransaction } from "@app/lib/utils/sql_utils";
 import logger from "@app/logger/logger";
 import type {
   ModelId,
@@ -75,7 +75,7 @@ export class TrackerConfigurationResource extends ResourceWithSpace<TrackerConfi
     watchedDataSources: TrackerDataSourceConfigurationType[],
     space: SpaceResource
   ) {
-    return frontSequelize.transaction(async (transaction) => {
+    return withTransaction(async (transaction) => {
       const tracker = await TrackerConfigurationModel.create(
         {
           ...blob,
@@ -187,7 +187,7 @@ export class TrackerConfigurationResource extends ResourceWithSpace<TrackerConfi
   ): Promise<Result<TrackerConfigurationResource, Error>> {
     assert(this.canWrite(auth), "Unauthorized write attempt");
 
-    return frontSequelize.transaction(async (transaction) => {
+    return withTransaction(async (transaction) => {
       await this.update(blob);
 
       await TrackerDataSourceConfigurationModel.destroy({
@@ -319,7 +319,7 @@ export class TrackerConfigurationResource extends ResourceWithSpace<TrackerConfi
       return new Err(new Error("Tracker not found"));
     }
 
-    return frontSequelize.transaction(async (transaction) => {
+    return withTransaction(async (transaction) => {
       await tracker.update(
         { lastNotifiedAt: new Date(currentRunMs) },
         transaction
@@ -620,7 +620,7 @@ export class TrackerConfigurationResource extends ResourceWithSpace<TrackerConfi
     auth: Authenticator
   ): Promise<Result<number, Error>> {
     const workspaceId = auth.getNonNullableWorkspace().id;
-    const deletedCount = await frontSequelize.transaction(async (t) => {
+    const deletedCount = await withTransaction(async (t) => {
       await TrackerGenerationModel.destroy({
         where: {
           trackerConfigurationId: this.id,
@@ -652,7 +652,7 @@ export class TrackerConfigurationResource extends ResourceWithSpace<TrackerConfi
     auth: Authenticator
   ): Promise<Result<number, Error>> {
     const workspaceId = auth.getNonNullableWorkspace().id;
-    const deletedCount = await frontSequelize.transaction(async (t) => {
+    const deletedCount = await withTransaction(async (t) => {
       await TrackerGenerationModel.destroy({
         where: {
           trackerConfigurationId: this.id,

--- a/front/lib/utils/sql_utils.ts
+++ b/front/lib/utils/sql_utils.ts
@@ -59,5 +59,11 @@ export async function withTransaction<T>(
   }
 
   // Create new transaction if no transaction in CLS.
+  if (process.env.NODE_ENV === "test") {
+    throw new Error(
+      "No transaction provided and no transaction in CLS while running tests, this should not happen. Action: make sure to use it() in tests instead of it(), also you might want to avoid using beforeXXX() and afterXXX()."
+    );
+  }
+
   return frontSequelize.transaction(fn);
 }

--- a/front/lib/utils/sql_utils.ts
+++ b/front/lib/utils/sql_utils.ts
@@ -1,3 +1,5 @@
+import type { Transaction } from "sequelize";
+import { Sequelize } from "sequelize";
 import { injectReplacements } from "sequelize/lib/utils/sql";
 
 import { frontSequelize } from "@app/lib/resources/storage";
@@ -33,4 +35,29 @@ export function getInsertSQL(model: any, data: any) {
       parameterizedQuery.bind
     );
   }
+}
+
+function getCurrentTransaction(): Transaction | null {
+  // We use CLS in tests to isolate tests in separate transactions.
+  // Transactions are created in itInTransaction and used implicitely by Sequelize thanks to CLS.
+  // This return the current transaction in CLS.
+  return (Sequelize as any)._cls?.get("transaction") || null;
+}
+
+export async function withTransaction<T>(
+  fn: (transaction: Transaction) => Promise<T>,
+  transaction?: Transaction
+): Promise<T> {
+  if (transaction) {
+    return fn(transaction);
+  }
+
+  // Check if there's already a transaction in CLS (see above).
+  const clsTransaction = getCurrentTransaction();
+  if (clsTransaction) {
+    return fn(clsTransaction);
+  }
+
+  // Create new transaction if no transaction in CLS.
+  return frontSequelize.transaction(fn);
 }

--- a/front/pages/api/poke/region.test.ts
+++ b/front/pages/api/poke/region.test.ts
@@ -1,8 +1,7 @@
-import { describe, expect, vi } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 
 import { config } from "@app/lib/api/regions/config";
 import { createPrivateApiMockRequest } from "@app/tests/utils/generic_private_api_tests";
-import { itInTransaction } from "@app/tests/utils/utils";
 
 import handler from "./region";
 
@@ -18,41 +17,35 @@ vi.mock(import("../../../lib/api/regions/config"), async (importOriginal) => {
 });
 
 describe("GET /api/poke/region", () => {
-  itInTransaction(
-    "returns correct region data when in us-central1",
-    async () => {
-      vi.mocked(config.getCurrentRegion).mockReturnValue("us-central1");
-      const { req, res } = await createPrivateApiMockRequest({
-        isSuperUser: true,
-      });
+  it("returns correct region data when in us-central1", async () => {
+    vi.mocked(config.getCurrentRegion).mockReturnValue("us-central1");
+    const { req, res } = await createPrivateApiMockRequest({
+      isSuperUser: true,
+    });
 
-      await handler(req, res);
+    await handler(req, res);
 
-      expect(res._getStatusCode()).toBe(200);
-      expect(res._getJSONData()).toEqual({
-        region: "us-central1",
-      });
-    }
-  );
+    expect(res._getStatusCode()).toBe(200);
+    expect(res._getJSONData()).toEqual({
+      region: "us-central1",
+    });
+  });
 
-  itInTransaction(
-    "returns correct region data when in europe-west1",
-    async () => {
-      vi.mocked(config.getCurrentRegion).mockReturnValue("europe-west1");
-      const { req, res } = await createPrivateApiMockRequest({
-        isSuperUser: true,
-      });
+  it("returns correct region data when in europe-west1", async () => {
+    vi.mocked(config.getCurrentRegion).mockReturnValue("europe-west1");
+    const { req, res } = await createPrivateApiMockRequest({
+      isSuperUser: true,
+    });
 
-      await handler(req, res);
+    await handler(req, res);
 
-      expect(res._getStatusCode()).toBe(200);
-      expect(res._getJSONData()).toEqual({
-        region: "europe-west1",
-      });
-    }
-  );
+    expect(res._getStatusCode()).toBe(200);
+    expect(res._getJSONData()).toEqual({
+      region: "europe-west1",
+    });
+  });
 
-  itInTransaction("returns 200 when the user is a super user", async () => {
+  it("returns 200 when the user is a super user", async () => {
     const { req, res } = await createPrivateApiMockRequest({
       isSuperUser: true,
     });
@@ -65,7 +58,7 @@ describe("GET /api/poke/region", () => {
     });
   });
 
-  itInTransaction("returns 401 when the user is not a super user", async () => {
+  it("returns 401 when the user is not a super user", async () => {
     const { req, res } = await createPrivateApiMockRequest({
       isSuperUser: false,
     });
@@ -81,7 +74,7 @@ describe("GET /api/poke/region", () => {
     });
   });
 
-  itInTransaction("only supports GET method", async () => {
+  it("only supports GET method", async () => {
     for (const method of ["DELETE", "POST", "PUT", "PATCH"] as const) {
       const { req, res } = await createPrivateApiMockRequest({
         method,

--- a/front/pages/api/stripe/webhook.ts
+++ b/front/pages/api/stripe/webhook.ts
@@ -19,12 +19,12 @@ import {
   getStripeClient,
 } from "@app/lib/plans/stripe";
 import { countActiveSeatsInWorkspace } from "@app/lib/plans/usage/seats";
-import { frontSequelize } from "@app/lib/resources/storage";
 import { WorkspaceModel } from "@app/lib/resources/storage/models/workspace";
 import { generateRandomModelSId } from "@app/lib/resources/string_ids";
 import { SubscriptionResource } from "@app/lib/resources/subscription_resource";
 import { WorkspaceResource } from "@app/lib/resources/workspace_resource";
 import { ServerSideTracking } from "@app/lib/tracking/server";
+import { withTransaction } from "@app/lib/utils/sql_utils";
 import { renderLightWorkspaceType } from "@app/lib/workspace";
 import logger from "@app/logger/logger";
 import { apiError, withLogging } from "@app/logger/withlogging";
@@ -172,7 +172,7 @@ async function handler(
               );
             }
 
-            await frontSequelize.transaction(async (t) => {
+            await withTransaction(async (t) => {
               const activeSubscription = await Subscription.findOne({
                 where: { workspaceId: workspace.id, status: "active" },
                 include: [

--- a/front/pages/api/templates/[tId]/index.test.ts
+++ b/front/pages/api/templates/[tId]/index.test.ts
@@ -1,9 +1,8 @@
 import type { NextApiRequest, NextApiResponse } from "next";
 import { createMocks } from "node-mocks-http";
-import { describe, expect, vi } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 
 import { TemplateFactory } from "@app/tests/utils/TemplateFactory";
-import { itInTransaction } from "@app/tests/utils/utils";
 
 import handler from "./index";
 
@@ -17,7 +16,7 @@ vi.mock(import("../../../../lib/auth"), async (importOriginal) => {
 });
 
 describe("GET /api/templates/[tId]", () => {
-  itInTransaction("returns 404 when template id is not provided", async () => {
+  it("returns 404 when template id is not provided", async () => {
     const { req, res } = createMocks<NextApiRequest, NextApiResponse>({
       method: "GET",
       query: {},
@@ -35,7 +34,7 @@ describe("GET /api/templates/[tId]", () => {
     });
   });
 
-  itInTransaction("returns 404 when template does not exist", async () => {
+  it("returns 404 when template does not exist", async () => {
     const { req, res } = createMocks<NextApiRequest, NextApiResponse>({
       method: "GET",
       query: { tId: "non-existent-id" },
@@ -53,7 +52,7 @@ describe("GET /api/templates/[tId]", () => {
     });
   });
 
-  itInTransaction("returns 404 when template is not published", async () => {
+  it("returns 404 when template is not published", async () => {
     const template = await TemplateFactory.draft();
 
     const { req, res } = createMocks<NextApiRequest, NextApiResponse>({
@@ -73,29 +72,26 @@ describe("GET /api/templates/[tId]", () => {
     });
   });
 
-  itInTransaction(
-    "returns template when it exists and is published",
-    async () => {
-      const template = await TemplateFactory.published();
+  it("returns template when it exists and is published", async () => {
+    const template = await TemplateFactory.published();
 
-      const { req, res } = createMocks<NextApiRequest, NextApiResponse>({
-        method: "GET",
-        query: { tId: template.sId },
-        headers: {},
-      });
+    const { req, res } = createMocks<NextApiRequest, NextApiResponse>({
+      method: "GET",
+      query: { tId: template.sId },
+      headers: {},
+    });
 
-      await handler(req, res);
+    await handler(req, res);
 
-      expect(res._getStatusCode()).toBe(200);
-      expect(res._getJSONData()).toEqual(
-        expect.objectContaining({
-          handle: template.handle,
-        })
-      );
-    }
-  );
+    expect(res._getStatusCode()).toBe(200);
+    expect(res._getJSONData()).toEqual(
+      expect.objectContaining({
+        handle: template.handle,
+      })
+    );
+  });
 
-  itInTransaction("returns 405 for non-GET methods", async () => {
+  it("returns 405 for non-GET methods", async () => {
     for (const method of ["POST", "PUT", "DELETE", "PATCH"] as const) {
       const { req, res } = createMocks<NextApiRequest, NextApiResponse>({
         method,

--- a/front/pages/api/templates/index.test.ts
+++ b/front/pages/api/templates/index.test.ts
@@ -1,9 +1,8 @@
 import type { NextApiRequest, NextApiResponse } from "next";
 import { createMocks } from "node-mocks-http";
-import { describe, expect, vi } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 
 import { TemplateFactory } from "@app/tests/utils/TemplateFactory";
-import { itInTransaction } from "@app/tests/utils/utils";
 
 import handler from "./index";
 
@@ -18,22 +17,19 @@ vi.mock(import("../../../lib/auth"), async (importOriginal) => {
 });
 
 describe("GET /api/templates", () => {
-  itInTransaction(
-    "returns empty array when no published templates exist",
-    async () => {
-      const { req, res } = createMocks<NextApiRequest, NextApiResponse>({
-        method: "GET",
-        headers: {},
-      });
+  it("returns empty array when no published templates exist", async () => {
+    const { req, res } = createMocks<NextApiRequest, NextApiResponse>({
+      method: "GET",
+      headers: {},
+    });
 
-      await handler(req, res);
+    await handler(req, res);
 
-      expect(res._getStatusCode()).toBe(200);
-      expect(res._getJSONData()).toEqual({ templates: [] });
-    }
-  );
+    expect(res._getStatusCode()).toBe(200);
+    expect(res._getJSONData()).toEqual({ templates: [] });
+  });
 
-  itInTransaction("returns only published templates", async () => {
+  it("returns only published templates", async () => {
     const { req, res } = createMocks<NextApiRequest, NextApiResponse>({
       method: "GET",
       headers: {},
@@ -61,7 +57,7 @@ describe("GET /api/templates", () => {
     );
   });
 
-  itInTransaction("returns 405 for non-GET methods", async () => {
+  it("returns 405 for non-GET methods", async () => {
     for (const method of ["POST", "PUT", "DELETE", "PATCH"] as const) {
       const { req, res } = createMocks<NextApiRequest, NextApiResponse>({
         method,

--- a/front/pages/api/user/index.test.ts
+++ b/front/pages/api/user/index.test.ts
@@ -1,13 +1,12 @@
-import { describe, expect } from "vitest";
+import { describe, expect, it } from "vitest";
 
 import { UserResource } from "@app/lib/resources/user_resource";
 import { createPrivateApiMockRequest } from "@app/tests/utils/generic_private_api_tests";
-import { itInTransaction } from "@app/tests/utils/utils";
 
 import handler from "./index";
 
 describe("GET /api/user", () => {
-  itInTransaction("returns 200 when the user is authenticated", async () => {
+  it("returns 200 when the user is authenticated", async () => {
     const { req, res, user, workspace, membership } =
       await createPrivateApiMockRequest();
 
@@ -45,7 +44,7 @@ describe("GET /api/user", () => {
     });
   });
 
-  itInTransaction("update the user on patch request", async () => {
+  it("update the user on patch request", async () => {
     const { req, res, user } = await createPrivateApiMockRequest({
       method: "PATCH",
     });
@@ -67,7 +66,7 @@ describe("GET /api/user", () => {
     expect(userAfterUpdate?.lastName).toBe("Doe");
   });
 
-  itInTransaction("update requires firstName and lastName", async () => {
+  it("update requires firstName and lastName", async () => {
     const { req, res } = await createPrivateApiMockRequest({
       method: "PATCH",
     });
@@ -85,7 +84,7 @@ describe("GET /api/user", () => {
     });
   });
 
-  itInTransaction("update ignores unknown fields", async () => {
+  it("update ignores unknown fields", async () => {
     const { req, res } = await createPrivateApiMockRequest({
       method: "PATCH",
     });
@@ -104,7 +103,7 @@ describe("GET /api/user", () => {
     });
   });
 
-  itInTransaction("only support GET and PATCH", async () => {
+  it("only support GET and PATCH", async () => {
     for (const method of ["DELETE", "POST", "PUT"] as const) {
       const { req, res } = await createPrivateApiMockRequest({
         method,

--- a/front/pages/api/v1/w/[wId]/data_sources/index.test.ts
+++ b/front/pages/api/v1/w/[wId]/data_sources/index.test.ts
@@ -1,18 +1,15 @@
-import { describe, expect } from "vitest";
+import { describe, expect, it } from "vitest";
 
 import { DataSourceViewFactory } from "@app/tests/utils/DataSourceViewFactory";
 import { createPublicApiMockRequest } from "@app/tests/utils/generic_public_api_tests";
 import { GroupSpaceFactory } from "@app/tests/utils/GroupSpaceFactory";
 import { SpaceFactory } from "@app/tests/utils/SpaceFactory";
-import {
-  expectArrayOfObjectsWithSpecificLength,
-  itInTransaction,
-} from "@app/tests/utils/utils";
+import { expectArrayOfObjectsWithSpecificLength } from "@app/tests/utils/utils";
 
 import handler from "./index";
 
 describe("GET /api/v1/w/[wId]/data_sources (legacy endpoint)", () => {
-  itInTransaction("returns 500 if no global space exists", async () => {
+  it("returns 500 if no global space exists", async () => {
     const { req, res } = await createPublicApiMockRequest();
 
     await handler(req, res);
@@ -20,22 +17,22 @@ describe("GET /api/v1/w/[wId]/data_sources (legacy endpoint)", () => {
     expect(res._getStatusCode()).toBe(500);
   });
 
-  itInTransaction("returns data sources for the global space", async (t) => {
+  it("returns data sources for the global space", async () => {
     const { req, res, workspace, globalGroup } =
       await createPublicApiMockRequest();
 
-    const space = await SpaceFactory.global(workspace, t);
+    const space = await SpaceFactory.global(workspace);
     await GroupSpaceFactory.associate(space, globalGroup);
 
     // Create test data source views to the space
-    await DataSourceViewFactory.folder(workspace, space, t);
-    await DataSourceViewFactory.folder(workspace, space, t);
+    await DataSourceViewFactory.folder(workspace, space);
+    await DataSourceViewFactory.folder(workspace, space);
 
     // Create another space
-    const space2 = await SpaceFactory.regular(workspace, t);
+    const space2 = await SpaceFactory.regular(workspace);
 
     // Create test data source views to the space (they should not be returned)
-    await DataSourceViewFactory.folder(workspace, space2, t);
+    await DataSourceViewFactory.folder(workspace, space2);
 
     // Execute request
     await handler(req, res);

--- a/front/pages/api/v1/w/[wId]/files/index.test.ts
+++ b/front/pages/api/v1/w/[wId]/files/index.test.ts
@@ -1,10 +1,9 @@
-import { describe, expect, vi } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 
 import {
   createPublicApiAuthenticationTests,
   createPublicApiMockRequest,
 } from "@app/tests/utils/generic_public_api_tests";
-import { itInTransaction } from "@app/tests/utils/utils";
 
 import handler from "./index";
 
@@ -20,7 +19,7 @@ vi.mock(import("@app/lib/api/config"), (() => ({
 })) as any);
 
 describe("POST /api/w/[wId]/files", () => {
-  itInTransaction("creates file upload URL successfully", async () => {
+  it("creates file upload URL successfully", async () => {
     const { req, res } = await createPublicApiMockRequest({
       method: "POST",
     });
@@ -45,27 +44,24 @@ describe("POST /api/w/[wId]/files", () => {
     expect(data.file.sId).toBeDefined();
   });
 
-  itInTransaction(
-    "refuses non public use-case without a system API key",
-    async () => {
-      const { req, res } = await createPublicApiMockRequest({
-        method: "POST",
-      });
+  it("refuses non public use-case without a system API key", async () => {
+    const { req, res } = await createPublicApiMockRequest({
+      method: "POST",
+    });
 
-      req.body = {
-        contentType: "text/csv",
-        fileName: "test.csv",
-        fileSize: 1024,
-        useCase: "upsert_table",
-      };
+    req.body = {
+      contentType: "text/csv",
+      fileName: "test.csv",
+      fileSize: 1024,
+      useCase: "upsert_table",
+    };
 
-      await handler(req, res);
+    await handler(req, res);
 
-      expect(res._getStatusCode()).toBe(400);
-    }
-  );
+    expect(res._getStatusCode()).toBe(400);
+  });
 
-  itInTransaction("refuses invalid use-cases", async () => {
+  it("refuses invalid use-cases", async () => {
     const { req, res } = await createPublicApiMockRequest({
       method: "POST",
       systemKey: true,
@@ -83,24 +79,21 @@ describe("POST /api/w/[wId]/files", () => {
     expect(res._getStatusCode()).toBe(400);
   });
 
-  itInTransaction(
-    "accepts non public use-case with a system API key",
-    async () => {
-      const { req, res } = await createPublicApiMockRequest({
-        method: "POST",
-        systemKey: true,
-      });
+  it("accepts non public use-case with a system API key", async () => {
+    const { req, res } = await createPublicApiMockRequest({
+      method: "POST",
+      systemKey: true,
+    });
 
-      req.body = {
-        contentType: "text/csv",
-        fileName: "test.csv",
-        fileSize: 1024,
-        useCase: "upsert_table",
-      };
+    req.body = {
+      contentType: "text/csv",
+      fileName: "test.csv",
+      fileSize: 1024,
+      useCase: "upsert_table",
+    };
 
-      await handler(req, res);
+    await handler(req, res);
 
-      expect(res._getStatusCode()).toBe(200);
-    }
-  );
+    expect(res._getStatusCode()).toBe(200);
+  });
 });

--- a/front/pages/api/v1/w/[wId]/spaces/[spaceId]/data_sources/index.test.ts
+++ b/front/pages/api/v1/w/[wId]/spaces/[spaceId]/data_sources/index.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect } from "vitest";
+import { describe, expect, it } from "vitest";
 
 import { DataSourceViewFactory } from "@app/tests/utils/DataSourceViewFactory";
 import {
@@ -7,10 +7,7 @@ import {
 } from "@app/tests/utils/generic_public_api_tests";
 import { GroupSpaceFactory } from "@app/tests/utils/GroupSpaceFactory";
 import { SpaceFactory } from "@app/tests/utils/SpaceFactory";
-import {
-  expectArrayOfObjectsWithSpecificLength,
-  itInTransaction,
-} from "@app/tests/utils/utils";
+import { expectArrayOfObjectsWithSpecificLength } from "@app/tests/utils/utils";
 
 import handler from "./index";
 
@@ -20,53 +17,47 @@ describe(
 );
 
 describe("GET /api/v1/w/[wId]/spaces/[spaceId]/data_sources", () => {
-  itInTransaction(
-    "returns an empty list when no data sources exist",
-    async (t) => {
-      const { req, res, workspace, globalGroup } =
-        await createPublicApiMockRequest();
+  it("returns an empty list when no data sources exist", async () => {
+    const { req, res, workspace, globalGroup } =
+      await createPublicApiMockRequest();
 
-      const space = await SpaceFactory.global(workspace, t);
-      await GroupSpaceFactory.associate(space, globalGroup);
+    const space = await SpaceFactory.global(workspace);
+    await GroupSpaceFactory.associate(space, globalGroup);
 
-      req.query.spaceId = space.sId;
+    req.query.spaceId = space.sId;
 
-      await handler(req, res);
+    await handler(req, res);
 
-      expect(res._getStatusCode()).toBe(200);
-      expect(res._getJSONData()).toEqual({ data_sources: [] });
-    }
-  );
+    expect(res._getStatusCode()).toBe(200);
+    expect(res._getJSONData()).toEqual({ data_sources: [] });
+  });
 
-  itInTransaction(
-    "returns accessible data sources for the space",
-    async (t) => {
-      const { req, res, workspace, globalGroup } =
-        await createPublicApiMockRequest();
+  it("returns accessible data sources for the space", async () => {
+    const { req, res, workspace, globalGroup } =
+      await createPublicApiMockRequest();
 
-      const space = await SpaceFactory.global(workspace, t);
-      await GroupSpaceFactory.associate(space, globalGroup);
+    const space = await SpaceFactory.global(workspace);
+    await GroupSpaceFactory.associate(space, globalGroup);
 
-      req.query.spaceId = space.sId;
+    req.query.spaceId = space.sId;
 
-      // Create test data source views to the space
-      await DataSourceViewFactory.folder(workspace, space, t);
-      await DataSourceViewFactory.folder(workspace, space, t);
+    // Create test data source views to the space
+    await DataSourceViewFactory.folder(workspace, space);
+    await DataSourceViewFactory.folder(workspace, space);
 
-      // Create another space
-      const space2 = await SpaceFactory.regular(workspace, t);
+    // Create another space
+    const space2 = await SpaceFactory.regular(workspace);
 
-      // Create test data source views to the space (they should not be returned)
-      await DataSourceViewFactory.folder(workspace, space2, t);
+    // Create test data source views to the space (they should not be returned)
+    await DataSourceViewFactory.folder(workspace, space2);
 
-      // Execute request
-      await handler(req, res);
+    // Execute request
+    await handler(req, res);
 
-      // Verify response
-      expect(res._getStatusCode()).toBe(200);
+    // Verify response
+    expect(res._getStatusCode()).toBe(200);
 
-      const { data_sources } = res._getJSONData();
-      expectArrayOfObjectsWithSpecificLength(data_sources, 2);
-    }
-  );
+    const { data_sources } = res._getJSONData();
+    expectArrayOfObjectsWithSpecificLength(data_sources, 2);
+  });
 });

--- a/front/pages/api/v1/w/[wId]/spaces/index.test.ts
+++ b/front/pages/api/v1/w/[wId]/spaces/index.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect } from "vitest";
+import { describe, expect, it } from "vitest";
 
 import {
   createPublicApiAuthenticationTests,
@@ -6,10 +6,7 @@ import {
 } from "@app/tests/utils/generic_public_api_tests";
 import { GroupSpaceFactory } from "@app/tests/utils/GroupSpaceFactory";
 import { SpaceFactory } from "@app/tests/utils/SpaceFactory";
-import {
-  expectArrayOfObjectsWithSpecificLength,
-  itInTransaction,
-} from "@app/tests/utils/utils";
+import { expectArrayOfObjectsWithSpecificLength } from "@app/tests/utils/utils";
 
 import handler from "./index";
 
@@ -19,7 +16,7 @@ describe(
 );
 
 describe("GET /api/v1/w/[wId]/spaces", () => {
-  itInTransaction("returns an empty list when no spaces exist", async () => {
+  it("returns an empty list when no spaces exist", async () => {
     const { req, res } = await createPublicApiMockRequest();
 
     await handler(req, res);
@@ -28,17 +25,17 @@ describe("GET /api/v1/w/[wId]/spaces", () => {
     expect(res._getJSONData()).toEqual({ spaces: [] });
   });
 
-  itInTransaction("returns accessible spaces for the workspace", async (t) => {
+  it("returns accessible spaces for the workspace", async () => {
     // Setup
     const { req, res, workspace, globalGroup } =
       await createPublicApiMockRequest();
 
     // Create test spaces
-    const globalSpace = await SpaceFactory.global(workspace, t);
-    await SpaceFactory.system(workspace, t); // System spaces should not be returned unless your are admin (public api keys are builders)
-    const regularSpace1 = await SpaceFactory.regular(workspace, t);
-    const regularSpace2 = await SpaceFactory.regular(workspace, t);
-    await SpaceFactory.regular(workspace, t); // Unassociated space
+    const globalSpace = await SpaceFactory.global(workspace);
+    await SpaceFactory.system(workspace); // System spaces should not be returned unless your are admin (public api keys are builders)
+    const regularSpace1 = await SpaceFactory.regular(workspace);
+    const regularSpace2 = await SpaceFactory.regular(workspace);
+    await SpaceFactory.regular(workspace); // Unassociated space
 
     // Associate spaces with the global group
     await GroupSpaceFactory.associate(regularSpace1, globalGroup);

--- a/front/pages/api/w/[wId]/assistant/agent_configurations/[aId]/editors.test.ts
+++ b/front/pages/api/w/[wId]/assistant/agent_configurations/[aId]/editors.test.ts
@@ -1,5 +1,4 @@
 import type { RequestMethod } from "node-mocks-http";
-import type { Transaction } from "sequelize";
 import { describe, expect, it, vi } from "vitest";
 
 import { updateAgentPermissions } from "@app/lib/api/assistant/configuration/agent";
@@ -9,7 +8,6 @@ import { AgentConfigurationFactory } from "@app/tests/utils/AgentConfigurationFa
 import { createPrivateApiMockRequest } from "@app/tests/utils/generic_private_api_tests";
 import { MembershipFactory } from "@app/tests/utils/MembershipFactory";
 import { UserFactory } from "@app/tests/utils/UserFactory";
-import { itInTransaction } from "@app/tests/utils/utils";
 import type { UserType } from "@app/types";
 
 import handler from "./editors";
@@ -24,8 +22,7 @@ async function setupTest(
     agentOwnerRole?: "admin" | "builder" | "user";
     requestUserRole?: "admin" | "builder" | "user";
     method?: RequestMethod;
-  } = {},
-  t?: Transaction
+  } = {}
 ) {
   const agentOwnerRole = options.agentOwnerRole ?? "admin";
   const requestUserRole = options.requestUserRole ?? "admin";
@@ -56,14 +53,9 @@ async function setupTest(
     agentOwnerAuth = requestUserAuth;
   } else {
     agentOwner = await UserFactory.basic();
-    await MembershipFactory.associate(
-      workspace,
-      agentOwner,
-      {
-        role: agentOwnerRole,
-      },
-      t
-    );
+    await MembershipFactory.associate(workspace, agentOwner, {
+      role: agentOwnerRole,
+    });
     agentOwnerAuth = await Authenticator.fromUserIdAndWorkspaceId(
       agentOwner.sId,
       workspace.sId
@@ -71,10 +63,7 @@ async function setupTest(
   }
 
   // Create agent owned by agentOwner
-  const agent = await AgentConfigurationFactory.createTestAgent(
-    agentOwnerAuth,
-    t
-  );
+  const agent = await AgentConfigurationFactory.createTestAgent(agentOwnerAuth);
 
   // Regenerate the agentOwnerAuth who's now in the agent editors group.
   agentOwnerAuth = await Authenticator.fromUserIdAndWorkspaceId(
@@ -102,47 +91,35 @@ async function setupTest(
 }
 
 describe("GET /api/w/[wId]/assistant/agent_configurations/[aId]/editors", () => {
-  itInTransaction(
-    "should return 200 and the editor list for admin",
-    async (t) => {
-      const { req, res, agentOwner } = await setupTest(
-        {
-          requestUserRole: "admin",
-        },
-        t
-      );
+  it("should return 200 and the editor list for admin", async () => {
+    const { req, res, agentOwner } = await setupTest({
+      requestUserRole: "admin",
+    });
 
-      await handler(req, res);
-      expect(res._getStatusCode()).toBe(200);
-      const data = res._getJSONData();
-      expect(data).toHaveProperty("editors");
-      expect(data.editors).toBeInstanceOf(Array);
-      expect(data.editors).toHaveLength(1); // Agent owner is the default editor
-      expect(data.editors[0].id).toBe(agentOwner.id);
-    }
-  );
+    await handler(req, res);
+    expect(res._getStatusCode()).toBe(200);
+    const data = res._getJSONData();
+    expect(data).toHaveProperty("editors");
+    expect(data.editors).toBeInstanceOf(Array);
+    expect(data.editors).toHaveLength(1); // Agent owner is the default editor
+    expect(data.editors[0].id).toBe(agentOwner.id);
+  });
 
-  itInTransaction(
-    "should return 200 and the editor list for editor",
-    async (t) => {
-      const { req, res, agentOwner } = await setupTest(
-        {
-          agentOwnerRole: "builder",
-          requestUserRole: "builder",
-        },
-        t
-      );
+  it("should return 200 and the editor list for editor", async () => {
+    const { req, res, agentOwner } = await setupTest({
+      agentOwnerRole: "builder",
+      requestUserRole: "builder",
+    });
 
-      await handler(req, res);
-      expect(res._getStatusCode()).toBe(200);
-      const data = res._getJSONData();
-      expect(data.editors).toHaveLength(1);
-      expect(data.editors[0].id).toBe(agentOwner.id);
-    }
-  );
+    await handler(req, res);
+    expect(res._getStatusCode()).toBe(200);
+    const data = res._getJSONData();
+    expect(data.editors).toHaveLength(1);
+    expect(data.editors[0].id).toBe(agentOwner.id);
+  });
 
-  itInTransaction("should return 404 for non-existent agent", async (t) => {
-    const { req, res } = await setupTest({}, t);
+  it("should return 404 for non-existent agent", async () => {
+    const { req, res } = await setupTest();
     req.query.aId = "non_existent_agent_sid";
 
     await handler(req, res);
@@ -271,14 +248,11 @@ describe("PATCH /api/w/[wId]/assistant/agent_configurations/[aId]/editors", () =
     expect(data.editors[0].sId).toBe(agentOwner.sId); // Only original editor remains
   });
 
-  itInTransaction("should return 403 for non-editor user", async (t) => {
-    const { req, res } = await setupTest(
-      {
-        requestUserRole: "user",
-        method: "PATCH",
-      },
-      t
-    );
+  it("should return 403 for non-editor user", async () => {
+    const { req, res } = await setupTest({
+      requestUserRole: "user",
+      method: "PATCH",
+    });
 
     req.body = { addEditorIds: ["some_user_sid"] }; // Body doesn't matter, auth fails first
 
@@ -332,97 +306,73 @@ describe("PATCH /api/w/[wId]/assistant/agent_configurations/[aId]/editors", () =
     });
   });
 
-  itInTransaction(
-    "should return 404 when adding non-existent user",
-    async (t) => {
-      const { req, res } = await setupTest(
-        {
-          requestUserRole: "admin",
-          method: "PATCH",
-        },
-        t
-      );
+  it("should return 404 when adding non-existent user", async () => {
+    const { req, res } = await setupTest({
+      requestUserRole: "admin",
+      method: "PATCH",
+    });
 
-      req.body = { addEditorIds: ["user_not_exists_sid"] };
+    req.body = { addEditorIds: ["user_not_exists_sid"] };
 
-      await handler(req, res);
-      expect(res._getStatusCode()).toBe(404);
-      expect(res._getJSONData()).toEqual({
-        error: {
-          type: "user_not_found",
-          message: "Some users were not found: user_not_exists_sid",
-        },
-      });
-    }
-  );
+    await handler(req, res);
+    expect(res._getStatusCode()).toBe(404);
+    expect(res._getJSONData()).toEqual({
+      error: {
+        type: "user_not_found",
+        message: "Some users were not found: user_not_exists_sid",
+      },
+    });
+  });
 
-  itInTransaction(
-    "should return 404 when removing non-existent user",
-    async (t) => {
-      const { req, res } = await setupTest(
-        {
-          requestUserRole: "admin",
-          method: "PATCH",
-        },
-        t
-      );
+  it("should return 404 when removing non-existent user", async () => {
+    const { req, res } = await setupTest({
+      requestUserRole: "admin",
+      method: "PATCH",
+    });
 
-      req.body = { removeEditorIds: ["user_not_exists_sid"] };
+    req.body = { removeEditorIds: ["user_not_exists_sid"] };
 
-      await handler(req, res);
-      expect(res._getStatusCode()).toBe(404);
-      expect(res._getJSONData()).toEqual({
-        error: {
-          type: "user_not_found",
-          message: "Some users were not found: user_not_exists_sid",
-        },
-      });
-    }
-  );
+    await handler(req, res);
+    expect(res._getStatusCode()).toBe(404);
+    expect(res._getJSONData()).toEqual({
+      error: {
+        type: "user_not_found",
+        message: "Some users were not found: user_not_exists_sid",
+      },
+    });
+  });
 
-  itInTransaction(
-    "should return 400 for invalid request body (empty)",
-    async (t) => {
-      const { req, res } = await setupTest(
-        {
-          requestUserRole: "admin",
-          method: "PATCH",
-        },
-        t
-      );
+  it("should return 400 for invalid request body (empty)", async () => {
+    const { req, res } = await setupTest({
+      requestUserRole: "admin",
+      method: "PATCH",
+    });
 
-      req.body = {};
+    req.body = {};
 
-      await handler(req, res);
-      expect(res._getStatusCode()).toBe(400);
-      expect(res._getJSONData().error.type).toBe("invalid_request_error");
-      expect(res._getJSONData().error.message).toContain(
-        "Either addEditorIds or removeEditorIds must be provided"
-      );
-    }
-  );
+    await handler(req, res);
+    expect(res._getStatusCode()).toBe(400);
+    expect(res._getJSONData().error.type).toBe("invalid_request_error");
+    expect(res._getJSONData().error.message).toContain(
+      "Either addEditorIds or removeEditorIds must be provided"
+    );
+  });
 
-  itInTransaction(
-    "should return 400 for invalid request body (empty arrays)",
-    async (t) => {
-      const { req, res } = await setupTest(
-        {
-          requestUserRole: "admin",
-          method: "PATCH",
-        },
-        t
-      );
+  it("should return 400 for invalid request body (empty arrays)", async () => {
+    const { req, res } = await setupTest({
+      requestUserRole: "admin",
+      method: "PATCH",
+    });
 
-      req.body = { addEditorIds: [], removeEditorIds: [] };
+    req.body = { addEditorIds: [], removeEditorIds: [] };
 
-      await handler(req, res);
-      expect(res._getStatusCode()).toBe(400);
-      expect(res._getJSONData().error.type).toBe("invalid_request_error");
-      expect(res._getJSONData().error.message).toContain(
-        "Either addEditorIds or removeEditorIds must be provided"
-      );
-    }
-  );
+    await handler(req, res);
+    expect(res._getStatusCode()).toBe(400);
+    expect(res._getJSONData().error.type).toBe("invalid_request_error");
+    expect(res._getJSONData().error.message).toContain(
+      "Either addEditorIds or removeEditorIds must be provided"
+    );
+  });
 
   it("should successfully add and remove editors in same request", async () => {
     const { req, res, workspace, agentOwner } = await setupTest({
@@ -448,8 +398,8 @@ describe("PATCH /api/w/[wId]/assistant/agent_configurations/[aId]/editors", () =
     expect(data.editors[0].sId).toBe(editorToAdd.sId);
   });
 
-  itInTransaction("should return 404 for non-existent agent", async (t) => {
-    const { req, res } = await setupTest({ method: "PATCH" }, t);
+  it("should return 404 for non-existent agent", async () => {
+    const { req, res } = await setupTest({ method: "PATCH" });
     req.query.aId = "non_existent_agent_sid";
     req.body = { addEditorIds: ["any_user_sid"] }; // Need a valid body
 
@@ -465,9 +415,9 @@ describe("PATCH /api/w/[wId]/assistant/agent_configurations/[aId]/editors", () =
 });
 
 describe("Method Support /api/w/[wId]/assistant/agent_configurations/[aId]/editors", () => {
-  itInTransaction("only supports GET and PATCH methods", async (t) => {
+  it("only supports GET and PATCH methods", async () => {
     for (const method of ["POST", "PUT", "DELETE"] as const) {
-      const { req, res } = await setupTest({ method }, t);
+      const { req, res } = await setupTest({ method });
 
       await handler(req, res);
 

--- a/front/pages/api/w/[wId]/assistant/agent_configurations/index.test.ts
+++ b/front/pages/api/w/[wId]/assistant/agent_configurations/index.test.ts
@@ -1,5 +1,4 @@
-import type { Transaction } from "sequelize";
-import { describe, expect, vi } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 
 import { Authenticator } from "@app/lib/auth";
 import type { UserResource } from "@app/lib/resources/user_resource";
@@ -7,7 +6,6 @@ import { AgentConfigurationFactory } from "@app/tests/utils/AgentConfigurationFa
 import { createPrivateApiMockRequest } from "@app/tests/utils/generic_private_api_tests";
 import { MembershipFactory } from "@app/tests/utils/MembershipFactory";
 import { UserFactory } from "@app/tests/utils/UserFactory";
-import { itInTransaction } from "@app/tests/utils/utils";
 import type {
   LightAgentConfigurationType,
   LightWorkspaceType,
@@ -41,16 +39,12 @@ vi.mock("@app/lib/api/redis", () => ({
 
 export async function setupAgentOwner(
   workspace: LightWorkspaceType,
-  agentOwnerRole: "admin" | "builder" | "user",
-  t: Transaction
+  agentOwnerRole: "admin" | "builder" | "user"
 ) {
   const agentOwner = await UserFactory.basic();
-  await MembershipFactory.associate(
-    workspace,
-    agentOwner,
-    { role: agentOwnerRole },
-    t
-  );
+  await MembershipFactory.associate(workspace, agentOwner, {
+    role: agentOwnerRole,
+  });
   const agentOwnerAuth = await Authenticator.fromUserIdAndWorkspaceId(
     agentOwner.sId,
     workspace.sId
@@ -60,8 +54,7 @@ export async function setupAgentOwner(
 
 async function setupTestAgents(
   workspace: LightWorkspaceType,
-  user: UserResource,
-  t: Transaction
+  user: UserResource
 ) {
   workspaceId = workspace.sId;
   const auth = await Authenticator.fromUserIdAndWorkspaceId(
@@ -71,12 +64,12 @@ async function setupTestAgents(
 
   // Create a few test agents with different configurations
   testAgents = await Promise.all([
-    AgentConfigurationFactory.createTestAgent(auth, t, {
+    AgentConfigurationFactory.createTestAgent(auth, {
       name: `Test Agent / Hidden / ${user.name}`,
       description: "Hidden test agent",
       scope: "hidden",
     }),
-    AgentConfigurationFactory.createTestAgent(auth, t, {
+    AgentConfigurationFactory.createTestAgent(auth, {
       name: `Test Agent / Visible / ${user.name}`,
       description: "Visible test agent",
       scope: "visible",
@@ -85,102 +78,90 @@ async function setupTestAgents(
 }
 
 describe("GET /api/w/[wId]/assistant/agent_configurations", () => {
-  itInTransaction(
-    "returns agent list configurations successfully should include all agents",
-    async (t) => {
-      const { req, res, workspace, user } = await createPrivateApiMockRequest({
-        method: "GET",
-      });
+  it("returns agent list configurations successfully should include all agents", async () => {
+    const { req, res, workspace, user } = await createPrivateApiMockRequest({
+      method: "GET",
+    });
 
-      await setupTestAgents(workspace, user, t);
-      req.query.view = "list";
-      await handler(req, res);
+    await setupTestAgents(workspace, user);
+    req.query.view = "list";
+    await handler(req, res);
 
-      expect(res._getStatusCode()).toBe(200);
-      const data: { agentConfigurations: LightAgentConfigurationType[] } =
-        JSON.parse(res._getData());
-      expect(data.agentConfigurations).toBeDefined();
-      expect(Array.isArray(data.agentConfigurations)).toBe(true);
-      expect(
-        data.agentConfigurations.filter((a) => a.scope !== "global").length
-      ).toBe(testAgents.length);
-    }
-  );
+    expect(res._getStatusCode()).toBe(200);
+    const data: { agentConfigurations: LightAgentConfigurationType[] } =
+      JSON.parse(res._getData());
+    expect(data.agentConfigurations).toBeDefined();
+    expect(Array.isArray(data.agentConfigurations)).toBe(true);
+    expect(
+      data.agentConfigurations.filter((a) => a.scope !== "global").length
+    ).toBe(testAgents.length);
+  });
 
-  itInTransaction(
-    "returns agent list configurations successfully - should not include other users' agents",
-    async (t) => {
-      const { req, res, workspace } = await createPrivateApiMockRequest({
-        method: "GET",
-      });
-      const { agentOwner } = await setupAgentOwner(workspace, "admin", t);
-      await setupTestAgents(workspace, agentOwner, t);
-      req.query.view = "list";
-      await handler(req, res);
+  it("returns agent list configurations successfully - should not include other users' agents", async () => {
+    const { req, res, workspace } = await createPrivateApiMockRequest({
+      method: "GET",
+    });
+    const { agentOwner } = await setupAgentOwner(workspace, "admin");
+    await setupTestAgents(workspace, agentOwner);
+    req.query.view = "list";
+    await handler(req, res);
 
-      expect(res._getStatusCode()).toBe(200);
-      const data: { agentConfigurations: LightAgentConfigurationType[] } =
-        JSON.parse(res._getData());
-      expect(data.agentConfigurations).toBeDefined();
-      expect(Array.isArray(data.agentConfigurations)).toBe(true);
-      expect(
-        data.agentConfigurations.filter((a) => a.scope !== "global").length
-      ).toBe(
-        testAgents.filter((a) =>
-          ["workspace", "published", "visible"].includes(a.scope)
-        ).length
-      );
-    }
-  );
+    expect(res._getStatusCode()).toBe(200);
+    const data: { agentConfigurations: LightAgentConfigurationType[] } =
+      JSON.parse(res._getData());
+    expect(data.agentConfigurations).toBeDefined();
+    expect(Array.isArray(data.agentConfigurations)).toBe(true);
+    expect(
+      data.agentConfigurations.filter((a) => a.scope !== "global").length
+    ).toBe(
+      testAgents.filter((a) =>
+        ["workspace", "published", "visible"].includes(a.scope)
+      ).length
+    );
+  });
 
-  itInTransaction(
-    "returns workspace agent configurations successfully",
-    async (t) => {
-      const { req, res, workspace, user } = await createPrivateApiMockRequest({
-        method: "GET",
-      });
+  it("returns workspace agent configurations successfully", async () => {
+    const { req, res, workspace, user } = await createPrivateApiMockRequest({
+      method: "GET",
+    });
 
-      await setupTestAgents(workspace, user, t);
-      req.query.view = "published";
-      await handler(req, res);
+    await setupTestAgents(workspace, user);
+    req.query.view = "published";
+    await handler(req, res);
 
-      expect(res._getStatusCode()).toBe(200);
-      const data = JSON.parse(res._getData());
-      expect(data.agentConfigurations).toBeDefined();
-      expect(Array.isArray(data.agentConfigurations)).toBe(true);
-      expect(data.agentConfigurations.length).toBe(1);
-    }
-  );
+    expect(res._getStatusCode()).toBe(200);
+    const data = JSON.parse(res._getData());
+    expect(data.agentConfigurations).toBeDefined();
+    expect(Array.isArray(data.agentConfigurations)).toBe(true);
+    expect(data.agentConfigurations.length).toBe(1);
+  });
 
-  itInTransaction(
-    "returns agent configurations with feedback data",
-    async (t) => {
-      const { req, res, workspace, user } = await createPrivateApiMockRequest({
-        method: "GET",
-      });
+  it("returns agent configurations with feedback data", async () => {
+    const { req, res, workspace, user } = await createPrivateApiMockRequest({
+      method: "GET",
+    });
 
-      await setupTestAgents(workspace, user, t);
+    await setupTestAgents(workspace, user);
 
-      req.query.wId = workspaceId;
-      req.query.withFeedbacks = "true";
+    req.query.wId = workspaceId;
+    req.query.withFeedbacks = "true";
 
-      await handler(req, res);
+    await handler(req, res);
 
-      expect(res._getStatusCode()).toBe(200);
-      const data = JSON.parse(res._getData());
-      expect(data.agentConfigurations).toBeDefined();
-      expect(Array.isArray(data.agentConfigurations)).toBe(true);
-      // Check that feedback data is included
-      expect(data.agentConfigurations[0].feedbacks).toBeDefined();
-    }
-  );
+    expect(res._getStatusCode()).toBe(200);
+    const data = JSON.parse(res._getData());
+    expect(data.agentConfigurations).toBeDefined();
+    expect(Array.isArray(data.agentConfigurations)).toBe(true);
+    // Check that feedback data is included
+    expect(data.agentConfigurations[0].feedbacks).toBeDefined();
+  });
 
-  itInTransaction("returns 400 for invalid query parameters", async (t) => {
+  it("returns 400 for invalid query parameters", async () => {
     const { req, res, workspace, user } = await createPrivateApiMockRequest({
       method: "GET",
     });
     workspaceId = workspace.sId;
-    await setupTestAgents(workspace, user, t);
+    await setupTestAgents(workspace, user);
 
     req.query.wId = workspaceId;
     req.query.limit = "invalid";
@@ -193,30 +174,27 @@ describe("GET /api/w/[wId]/assistant/agent_configurations", () => {
     expect(data.error.type).toBe("invalid_request_error");
   });
 
-  itInTransaction(
-    "returns 404 for admin_internal view without super user",
-    async (t) => {
-      const { req, res, workspace, user } = await createPrivateApiMockRequest({
-        method: "GET",
-      });
+  it("returns 404 for admin_internal view without super user", async () => {
+    const { req, res, workspace, user } = await createPrivateApiMockRequest({
+      method: "GET",
+    });
 
-      await setupTestAgents(workspace, user, t);
+    await setupTestAgents(workspace, user);
 
-      req.query.wId = workspaceId;
-      req.query.view = "admin_internal";
+    req.query.wId = workspaceId;
+    req.query.view = "admin_internal";
 
-      await handler(req, res);
+    await handler(req, res);
 
-      expect(res._getStatusCode()).toBe(404);
-      const data = JSON.parse(res._getData());
-      expect(data.error).toBeDefined();
-      expect(data.error.type).toBe("app_auth_error");
-    }
-  );
+    expect(res._getStatusCode()).toBe(404);
+    const data = JSON.parse(res._getData());
+    expect(data.error).toBeDefined();
+    expect(data.error.type).toBe("app_auth_error");
+  });
 });
 
 describe("Method Support /api/w/[wId]/assistant/agent_configurations", () => {
-  itInTransaction("only supports GET and POST methods", async () => {
+  it("only supports GET and POST methods", async () => {
     for (const method of ["DELETE", "PUT", "PATCH"] as const) {
       const { req, res } = await createPrivateApiMockRequest({
         method,

--- a/front/pages/api/w/[wId]/index.test.ts
+++ b/front/pages/api/w/[wId]/index.test.ts
@@ -1,16 +1,15 @@
 import { faker } from "@faker-js/faker";
 import type { Organization } from "@workos-inc/node";
-import { describe, expect, vi } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 
 import * as workosClient from "@app/lib/api/workos/client";
 import { WorkspaceHasDomainModel } from "@app/lib/resources/storage/models/workspace_has_domain";
 import { createPrivateApiMockRequest } from "@app/tests/utils/generic_private_api_tests";
-import { itInTransaction } from "@app/tests/utils/utils";
 
 import handler from "./index";
 
 describe("GET /api/w/[wId]", () => {
-  itInTransaction("returns 403 when user is not admin", async () => {
+  it("returns 403 when user is not admin", async () => {
     const { req, res } = await createPrivateApiMockRequest({
       method: "GET",
       role: "user",
@@ -28,7 +27,7 @@ describe("GET /api/w/[wId]", () => {
     });
   });
 
-  itInTransaction("returns the workspace", async () => {
+  it("returns the workspace", async () => {
     const { req, res, workspace } = await createPrivateApiMockRequest({
       method: "GET",
       role: "admin",
@@ -47,7 +46,7 @@ describe("GET /api/w/[wId]", () => {
 });
 
 describe("POST /api/w/[wId]", () => {
-  itInTransaction("returns 403 when user is not admin", async () => {
+  it("returns 403 when user is not admin", async () => {
     const { req, res } = await createPrivateApiMockRequest({
       method: "POST",
       role: "user",
@@ -65,7 +64,7 @@ describe("POST /api/w/[wId]", () => {
     });
   });
 
-  itInTransaction("updates workspace name", async () => {
+  it("updates workspace name", async () => {
     const getOrganizationByExternalIdSpy = vi.fn().mockResolvedValue({
       id: "org_123",
       name: "Old Workspace Name - sId123",
@@ -126,7 +125,7 @@ describe("POST /api/w/[wId]", () => {
     expect(updateOrganizationSpy).toHaveBeenCalled();
   });
 
-  itInTransaction("updates SSO enforcement", async () => {
+  it("updates SSO enforcement", async () => {
     const { req, res, workspace } = await createPrivateApiMockRequest({
       method: "POST",
       role: "admin",
@@ -147,33 +146,30 @@ describe("POST /api/w/[wId]", () => {
     });
   });
 
-  itInTransaction(
-    "updates whitelisted providers and default embedding provider",
-    async () => {
-      const { req, res, workspace } = await createPrivateApiMockRequest({
-        method: "POST",
-        role: "admin",
-      });
+  it("updates whitelisted providers and default embedding provider", async () => {
+    const { req, res, workspace } = await createPrivateApiMockRequest({
+      method: "POST",
+      role: "admin",
+    });
 
-      req.body = {
+    req.body = {
+      whiteListedProviders: ["openai", "anthropic"],
+      defaultEmbeddingProvider: "openai",
+    };
+
+    await handler(req, res);
+
+    expect(res._getStatusCode()).toBe(200);
+    expect(res._getJSONData()).toEqual({
+      workspace: expect.objectContaining({
+        id: workspace.id,
         whiteListedProviders: ["openai", "anthropic"],
         defaultEmbeddingProvider: "openai",
-      };
+      }),
+    });
+  });
 
-      await handler(req, res);
-
-      expect(res._getStatusCode()).toBe(200);
-      expect(res._getJSONData()).toEqual({
-        workspace: expect.objectContaining({
-          id: workspace.id,
-          whiteListedProviders: ["openai", "anthropic"],
-          defaultEmbeddingProvider: "openai",
-        }),
-      });
-    }
-  );
-
-  itInTransaction("updates domain auto join settings", async () => {
+  it("updates domain auto join settings", async () => {
     const { req, res, workspace } = await createPrivateApiMockRequest({
       method: "POST",
       role: "admin",
@@ -206,7 +202,7 @@ describe("POST /api/w/[wId]", () => {
     expect(updatedDomain?.domainAutoJoinEnabled).toBe(true);
   });
 
-  itInTransaction("returns 400 when updating non-existent domain", async () => {
+  it("returns 400 when updating non-existent domain", async () => {
     const { req, res } = await createPrivateApiMockRequest({
       method: "POST",
       role: "admin",
@@ -228,7 +224,7 @@ describe("POST /api/w/[wId]", () => {
     });
   });
 
-  itInTransaction("returns 400 on invalid request body", async () => {
+  it("returns 400 on invalid request body", async () => {
     const { req, res } = await createPrivateApiMockRequest({
       method: "POST",
       role: "admin",
@@ -244,7 +240,7 @@ describe("POST /api/w/[wId]", () => {
     expect(res._getJSONData().error.type).toBe("invalid_request_error");
   });
 
-  itInTransaction("returns 405 for non-POST methods", async () => {
+  it("returns 405 for non-POST methods", async () => {
     for (const method of ["PUT", "DELETE"] as const) {
       const { req, res } = await createPrivateApiMockRequest({
         method,

--- a/front/pages/api/w/[wId]/mcp/[serverId]/index.test.ts
+++ b/front/pages/api/w/[wId]/mcp/[serverId]/index.test.ts
@@ -1,17 +1,15 @@
 import type { RequestMethod } from "node-mocks-http";
-import { describe, expect } from "vitest";
+import { describe, expect, it } from "vitest";
 
 import { RemoteMCPServerResource } from "@app/lib/resources/remote_mcp_servers_resource";
 import { makeSId } from "@app/lib/resources/string_ids";
 import { createPrivateApiMockRequest } from "@app/tests/utils/generic_private_api_tests";
 import { RemoteMCPServerFactory } from "@app/tests/utils/RemoteMCPServerFactory";
 import { SpaceFactory } from "@app/tests/utils/SpaceFactory";
-import { itInTransaction } from "@app/tests/utils/utils";
 
 import handler from "./index";
 
 async function setupTest(
-  t: any,
   role: "builder" | "user" | "admin" = "admin",
   method: RequestMethod = "GET"
 ) {
@@ -21,7 +19,7 @@ async function setupTest(
       method,
     });
 
-  const space = await SpaceFactory.system(workspace, t);
+  const space = await SpaceFactory.system(workspace);
 
   // Set up common query parameters
   req.query.wId = workspace.sId;
@@ -31,8 +29,8 @@ async function setupTest(
 }
 
 describe("GET /api/w/[wId]/mcp/[serverId]", () => {
-  itInTransaction("should return server details", async (t) => {
-    const { req, res, workspace } = await setupTest(t);
+  it("should return server details", async () => {
+    const { req, res, workspace } = await setupTest();
 
     const server = await RemoteMCPServerFactory.create(workspace);
     req.query.serverId = server.sId;
@@ -45,8 +43,8 @@ describe("GET /api/w/[wId]/mcp/[serverId]", () => {
     expect(responseData).toHaveProperty("server");
   });
 
-  itInTransaction("should return 404 when server doesn't exist", async (t) => {
-    const { req, res, workspace } = await setupTest(t);
+  it("should return 404 when server doesn't exist", async () => {
+    const { req, res, workspace } = await setupTest();
     req.query.serverId = makeSId("remote_mcp_server", {
       id: 1000,
       workspaceId: workspace.id,
@@ -65,27 +63,24 @@ describe("GET /api/w/[wId]/mcp/[serverId]", () => {
 });
 
 describe("PATCH /api/w/[wId]/mcp/[serverId]", () => {
-  itInTransaction(
-    "should return 400 when no update fields are provided",
-    async (t) => {
-      const { req, res, workspace } = await setupTest(t, "admin", "PATCH");
+  it("should return 400 when no update fields are provided", async () => {
+    const { req, res, workspace } = await setupTest("admin", "PATCH");
 
-      const server = await RemoteMCPServerFactory.create(workspace);
-      req.query.serverId = server.sId;
-      req.body = {};
+    const server = await RemoteMCPServerFactory.create(workspace);
+    req.query.serverId = server.sId;
+    req.body = {};
 
-      await handler(req, res);
+    await handler(req, res);
 
-      expect(res._getStatusCode()).toBe(400);
-      const responseData = res._getJSONData();
-      expect(responseData.error.message).toContain("Validation error:");
-    }
-  );
+    expect(res._getStatusCode()).toBe(400);
+    const responseData = res._getJSONData();
+    expect(responseData.error.message).toContain("Validation error:");
+  });
 });
 
 describe("DELETE /api/w/[wId]/mcp/[serverId]", () => {
-  itInTransaction("should delete a server when admin", async (t) => {
-    const { req, res, workspace } = await setupTest(t, "admin", "DELETE");
+  it("should delete a server when admin", async () => {
+    const { req, res, workspace } = await setupTest("admin", "DELETE");
 
     const server = await RemoteMCPServerFactory.create(workspace);
     req.query.serverId = server.sId;
@@ -107,8 +102,8 @@ describe("DELETE /api/w/[wId]/mcp/[serverId]", () => {
 });
 
 describe("DELETE /api/w/[wId]/mcp/[serverId]", () => {
-  itInTransaction("should fail to delete a server when user", async (t) => {
-    const { req, res, workspace } = await setupTest(t, "user", "DELETE");
+  it("should fail to delete a server when user", async () => {
+    const { req, res, workspace } = await setupTest("user", "DELETE");
 
     const server = await RemoteMCPServerFactory.create(workspace);
     req.query.serverId = server.sId;
@@ -130,8 +125,8 @@ describe("DELETE /api/w/[wId]/mcp/[serverId]", () => {
 });
 
 describe("Method Support /api/w/[wId]/mcp/[serverId]", () => {
-  itInTransaction("supports GET, PATCH, and DELETE methods", async (t) => {
-    const { req, res, workspace, space } = await setupTest(t, "admin", "PUT");
+  it("supports GET, PATCH, and DELETE methods", async () => {
+    const { req, res, workspace, space } = await setupTest("admin", "PUT");
 
     const server = await RemoteMCPServerFactory.create(workspace, space);
     req.query.serverId = server.sId;

--- a/front/pages/api/w/[wId]/mcp/[serverId]/sync.test.ts
+++ b/front/pages/api/w/[wId]/mcp/[serverId]/sync.test.ts
@@ -1,15 +1,13 @@
 import type { RequestMethod } from "node-mocks-http";
-import { describe, expect, vi } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 
 import { createPrivateApiMockRequest } from "@app/tests/utils/generic_private_api_tests";
 import { RemoteMCPServerFactory } from "@app/tests/utils/RemoteMCPServerFactory";
 import { SpaceFactory } from "@app/tests/utils/SpaceFactory";
-import { itInTransaction } from "@app/tests/utils/utils";
 
 import handler from "./sync";
 
 async function setupTest(
-  t: any,
   role: "builder" | "user" | "admin" = "admin",
   method: RequestMethod = "GET"
 ) {
@@ -18,7 +16,7 @@ async function setupTest(
     method,
   });
 
-  const space = await SpaceFactory.system(workspace, t);
+  const space = await SpaceFactory.system(workspace);
 
   // Set up common query parameters
   req.query.wId = workspace.sId;
@@ -42,8 +40,8 @@ vi.mock(import("@app/lib/actions/mcp_actions"), async (importOriginal) => {
 });
 
 describe("POST /api/w/[wId]/mcp/[serverId]/sync", () => {
-  itInTransaction("should return 404 when server doesn't exist", async (t) => {
-    const { req, res } = await setupTest(t, "admin", "POST");
+  it("should return 404 when server doesn't exist", async () => {
+    const { req, res } = await setupTest("admin", "POST");
     req.query.serverId = "non-existent-server-id";
 
     await handler(req, res);
@@ -57,8 +55,8 @@ describe("POST /api/w/[wId]/mcp/[serverId]/sync", () => {
     });
   });
 
-  itInTransaction("should return 403 when user is not an admin", async (t) => {
-    const { req, res, workspace, space } = await setupTest(t, "user", "POST");
+  it("should return 403 when user is not an admin", async () => {
+    const { req, res, workspace, space } = await setupTest("user", "POST");
     const server = await RemoteMCPServerFactory.create(workspace, space);
     req.query.serverId = server.sId;
 
@@ -73,13 +71,9 @@ describe("POST /api/w/[wId]/mcp/[serverId]/sync", () => {
     });
   });
 
-  itInTransaction("only POST method is supported", async (t) => {
+  it("only POST method is supported", async () => {
     for (const method of ["GET", "DELETE", "PUT", "PATCH"] as const) {
-      const { req, res, workspace, space } = await setupTest(
-        t,
-        "admin",
-        method
-      );
+      const { req, res, workspace, space } = await setupTest("admin", method);
       const server = await RemoteMCPServerFactory.create(workspace, space);
       req.query.serverId = server.sId;
 

--- a/front/pages/api/w/[wId]/mcp/connections/[connectionType]/[cId]/index.test.ts
+++ b/front/pages/api/w/[wId]/mcp/connections/[connectionType]/[cId]/index.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect } from "vitest";
+import { it } from "vitest";
 
 import { Authenticator } from "@app/lib/auth";
 import { MCPServerConnectionResource } from "@app/lib/resources/mcp_server_connection_resource";
@@ -8,17 +9,16 @@ import { MembershipFactory } from "@app/tests/utils/MembershipFactory";
 import { RemoteMCPServerFactory } from "@app/tests/utils/RemoteMCPServerFactory";
 import { SpaceFactory } from "@app/tests/utils/SpaceFactory";
 import { UserFactory } from "@app/tests/utils/UserFactory";
-import { itInTransaction } from "@app/tests/utils/utils";
 
 import handler from "./index";
 
 describe("MCP Connection API Handler", () => {
-  itInTransaction("GET should return the connection", async (t) => {
+  it("GET should return the connection", async () => {
     const { req, res, workspace, authenticator } =
       await createPrivateApiMockRequest({
         method: "GET",
       });
-    await SpaceFactory.system(workspace, t);
+    await SpaceFactory.system(workspace);
     const remoteServer = await RemoteMCPServerFactory.create(workspace);
 
     const connection = await MCPServerConnectionFactory.remote(
@@ -36,272 +36,251 @@ describe("MCP Connection API Handler", () => {
     expect(response.connection.sId).toBe(connection.sId);
   });
 
-  itInTransaction(
-    "GET cannot return a connection from another workspace",
-    async (t) => {
-      // Create first workspace and its connection
-      const { workspace: workspace1, authenticator: authenticator1 } =
-        await createPrivateApiMockRequest({
-          method: "GET",
-        });
-      await SpaceFactory.system(workspace1, t);
-      const remoteServer1 = await RemoteMCPServerFactory.create(workspace1);
-      const connection1 = await MCPServerConnectionFactory.remote(
-        authenticator1,
-        remoteServer1,
-        "personal"
-      );
-
-      // Create second workspace and try to access connection1
-      const { req, res } = await createPrivateApiMockRequest({
+  it("GET cannot return a connection from another workspace", async () => {
+    // Create first workspace and its connection
+    const { workspace: workspace1, authenticator: authenticator1 } =
+      await createPrivateApiMockRequest({
         method: "GET",
       });
-      req.query.connectionType = "personal";
-      req.query.cId = connection1.sId;
-      await handler(req, res);
+    await SpaceFactory.system(workspace1);
+    const remoteServer1 = await RemoteMCPServerFactory.create(workspace1);
+    const connection1 = await MCPServerConnectionFactory.remote(
+      authenticator1,
+      remoteServer1,
+      "personal"
+    );
 
-      expect(res._getStatusCode()).toBe(404);
-      expect(res._getJSONData()).toEqual({
-        error: {
-          type: "mcp_server_connection_not_found",
-          message: "Connection not found",
-        },
-      });
-    }
-  );
+    // Create second workspace and try to access connection1
+    const { req, res } = await createPrivateApiMockRequest({
+      method: "GET",
+    });
+    req.query.connectionType = "personal";
+    req.query.cId = connection1.sId;
+    await handler(req, res);
 
-  itInTransaction(
-    "GET cannot return a connection from another user in the same workspace",
-    async (t) => {
-      const { workspace, authenticator: authenticator1 } =
-        await createPrivateApiMockRequest({
-          method: "GET",
-        });
-      await SpaceFactory.system(workspace, t);
-      const remoteServer = await RemoteMCPServerFactory.create(workspace);
+    expect(res._getStatusCode()).toBe(404);
+    expect(res._getJSONData()).toEqual({
+      error: {
+        type: "mcp_server_connection_not_found",
+        message: "Connection not found",
+      },
+    });
+  });
 
-      // Create connection for first user
-      const connection1 = await MCPServerConnectionFactory.remote(
-        authenticator1,
-        remoteServer,
-        "personal"
-      );
-
-      // Create second user in the same workspace
-      await UserFactory.basic();
-      const { req, res } = await createPrivateApiMockRequest({
+  it("GET cannot return a connection from another user in the same workspace", async () => {
+    const { workspace, authenticator: authenticator1 } =
+      await createPrivateApiMockRequest({
         method: "GET",
       });
-      req.query.cId = connection1.sId;
-      await handler(req, res);
+    await SpaceFactory.system(workspace);
+    const remoteServer = await RemoteMCPServerFactory.create(workspace);
 
-      expect(res._getStatusCode()).toBe(404);
-      expect(res._getJSONData()).toEqual({
-        error: {
-          type: "mcp_server_connection_not_found",
-          message: "Connection not found",
-        },
+    // Create connection for first user
+    const connection1 = await MCPServerConnectionFactory.remote(
+      authenticator1,
+      remoteServer,
+      "personal"
+    );
+
+    // Create second user in the same workspace
+    await UserFactory.basic();
+    const { req, res } = await createPrivateApiMockRequest({
+      method: "GET",
+    });
+    req.query.cId = connection1.sId;
+    await handler(req, res);
+
+    expect(res._getStatusCode()).toBe(404);
+    expect(res._getJSONData()).toEqual({
+      error: {
+        type: "mcp_server_connection_not_found",
+        message: "Connection not found",
+      },
+    });
+  });
+
+  it("DELETE personal connection deletes all personal connections for the same server of the same user", async () => {
+    const {
+      req: deleteReq,
+      res: deleteRes,
+      workspace,
+      authenticator,
+    } = await createPrivateApiMockRequest({
+      method: "DELETE",
+    });
+    await SpaceFactory.system(workspace);
+    const remoteServer = await RemoteMCPServerFactory.create(workspace);
+
+    // Create two personal connections for the same server
+    const connection1 = await MCPServerConnectionFactory.remote(
+      authenticator,
+      remoteServer,
+      "personal"
+    );
+    await MCPServerConnectionFactory.remote(
+      authenticator,
+      remoteServer,
+      "personal"
+    );
+
+    // Create an extra one for the same server, but for a different user
+    const user2 = await UserFactory.basic();
+    await MembershipFactory.associate(workspace, user2, { role: "user" });
+    const authenticator2 = await Authenticator.fromUserIdAndWorkspaceId(
+      user2.sId,
+      workspace.sId
+    );
+    await MCPServerConnectionFactory.remote(
+      authenticator2,
+      remoteServer,
+      "personal"
+    );
+
+    // Delete the first connection
+    deleteReq.query.connectionType = "personal";
+    deleteReq.query.cId = connection1.sId;
+    await handler(deleteReq, deleteRes);
+
+    expect(deleteRes._getStatusCode()).toBe(200);
+    expect(deleteRes._getJSONData()).toEqual({ success: true });
+
+    const remainingPersonalConnections =
+      await MCPServerConnectionResource.listByWorkspace(authenticator, {
+        connectionType: "personal",
       });
-    }
-  );
+    expect(remainingPersonalConnections).toHaveLength(0);
 
-  itInTransaction(
-    "DELETE personal connection deletes all personal connections for the same server of the same user",
-    async (t) => {
-      const {
-        req: deleteReq,
-        res: deleteRes,
-        workspace,
-        authenticator,
-      } = await createPrivateApiMockRequest({
-        method: "DELETE",
+    const remainingUser2PersonalConnections =
+      await MCPServerConnectionResource.listByWorkspace(authenticator2, {
+        connectionType: "personal",
       });
-      await SpaceFactory.system(workspace, t);
-      const remoteServer = await RemoteMCPServerFactory.create(workspace);
+    expect(remainingUser2PersonalConnections).toHaveLength(1);
+  });
 
-      // Create two personal connections for the same server
-      const connection1 = await MCPServerConnectionFactory.remote(
-        authenticator,
-        remoteServer,
-        "personal"
-      );
-      await MCPServerConnectionFactory.remote(
-        authenticator,
-        remoteServer,
-        "personal"
-      );
+  it("DELETE workspace connection deletes all connections for the same server", async () => {
+    const {
+      req: deleteReq,
+      res: deleteRes,
+      workspace,
+      authenticator,
+    } = await createPrivateApiMockRequest({
+      method: "DELETE",
+      role: "admin",
+    });
+    await SpaceFactory.system(workspace);
+    const remoteServer = await RemoteMCPServerFactory.create(workspace);
 
-      // Create an extra one for the same server, but for a different user
-      const user2 = await UserFactory.basic();
-      await MembershipFactory.associate(workspace, user2, { role: "user" }, t);
-      const authenticator2 = await Authenticator.fromUserIdAndWorkspaceId(
-        user2.sId,
-        workspace.sId
-      );
-      await MCPServerConnectionFactory.remote(
-        authenticator2,
-        remoteServer,
-        "personal"
-      );
+    // Create both personal and workspace connections for the same server
+    await MCPServerConnectionFactory.remote(
+      authenticator,
+      remoteServer,
+      "personal"
+    );
 
-      // Delete the first connection
-      deleteReq.query.connectionType = "personal";
-      deleteReq.query.cId = connection1.sId;
-      await handler(deleteReq, deleteRes);
+    const workspaceConnection = await MCPServerConnectionFactory.remote(
+      authenticator,
+      remoteServer,
+      "workspace"
+    );
 
-      expect(deleteRes._getStatusCode()).toBe(200);
-      expect(deleteRes._getJSONData()).toEqual({ success: true });
+    // Delete the workspace connection
+    deleteReq.query.connectionType = "workspace";
+    deleteReq.query.cId = workspaceConnection.sId;
+    await handler(deleteReq, deleteRes);
 
-      const remainingPersonalConnections =
-        await MCPServerConnectionResource.listByWorkspace(authenticator, {
-          connectionType: "personal",
-        });
-      expect(remainingPersonalConnections).toHaveLength(0);
+    expect(deleteRes._getStatusCode()).toBe(200);
+    expect(deleteRes._getJSONData()).toEqual({ success: true });
 
-      const remainingUser2PersonalConnections =
-        await MCPServerConnectionResource.listByWorkspace(authenticator2, {
-          connectionType: "personal",
-        });
-      expect(remainingUser2PersonalConnections).toHaveLength(1);
-    }
-  );
-
-  itInTransaction(
-    "DELETE workspace connection deletes all connections for the same server",
-    async (t) => {
-      const {
-        req: deleteReq,
-        res: deleteRes,
-        workspace,
-        authenticator,
-      } = await createPrivateApiMockRequest({
-        method: "DELETE",
-        role: "admin",
+    // Verify both connections are deleted
+    const remainingWorkspaceConnections =
+      await MCPServerConnectionResource.listByWorkspace(authenticator, {
+        connectionType: "workspace",
       });
-      await SpaceFactory.system(workspace, t);
-      const remoteServer = await RemoteMCPServerFactory.create(workspace);
+    expect(remainingWorkspaceConnections).toHaveLength(0);
 
-      // Create both personal and workspace connections for the same server
-      await MCPServerConnectionFactory.remote(
-        authenticator,
-        remoteServer,
-        "personal"
-      );
+    const remainingPersonalConnections =
+      await MCPServerConnectionResource.listByWorkspace(authenticator, {
+        connectionType: "personal",
+      });
+    expect(remainingPersonalConnections).toHaveLength(0);
+  });
 
-      const workspaceConnection = await MCPServerConnectionFactory.remote(
-        authenticator,
-        remoteServer,
-        "workspace"
-      );
+  it("GET a non-existing connection should return 404", async () => {
+    const { req, res } = await createPrivateApiMockRequest({
+      method: "GET",
+    });
+    req.query.connectionType = "personal";
+    req.query.cId = "non_existing_connection_id";
+    await handler(req, res);
 
-      // Delete the workspace connection
-      deleteReq.query.connectionType = "workspace";
-      deleteReq.query.cId = workspaceConnection.sId;
-      await handler(deleteReq, deleteRes);
+    expect(res._getStatusCode()).toBe(404);
+    expect(res._getJSONData()).toEqual({
+      error: {
+        type: "mcp_server_connection_not_found",
+        message: "Connection not found",
+      },
+    });
+  });
 
-      expect(deleteRes._getStatusCode()).toBe(200);
-      expect(deleteRes._getJSONData()).toEqual({ success: true });
+  it("DELETE a workspace connection as non-admin should return 500", async () => {
+    const { req, res, workspace } = await createPrivateApiMockRequest({
+      method: "DELETE",
+      role: "user", // Explicitly set as non-admin
+    });
+    await SpaceFactory.system(workspace);
+    const remoteServer = await RemoteMCPServerFactory.create(workspace);
 
-      // Verify both connections are deleted
-      const remainingWorkspaceConnections =
-        await MCPServerConnectionResource.listByWorkspace(authenticator, {
-          connectionType: "workspace",
-        });
-      expect(remainingWorkspaceConnections).toHaveLength(0);
+    const admin = await UserFactory.basic();
+    await MembershipFactory.associate(workspace, admin, { role: "admin" });
+    const adminAuthenticator = await Authenticator.fromUserIdAndWorkspaceId(
+      admin.sId,
+      workspace.sId
+    );
+    const workspaceConnection = await MCPServerConnectionFactory.remote(
+      adminAuthenticator,
+      remoteServer,
+      "workspace"
+    );
 
-      const remainingPersonalConnections =
-        await MCPServerConnectionResource.listByWorkspace(authenticator, {
-          connectionType: "personal",
-        });
-      expect(remainingPersonalConnections).toHaveLength(0);
-    }
-  );
+    req.query.connectionType = "workspace";
+    req.query.cId = workspaceConnection.sId;
+    await handler(req, res);
 
-  itInTransaction(
-    "GET a non-existing connection should return 404",
-    async () => {
-      const { req, res } = await createPrivateApiMockRequest({
+    expect(res._getStatusCode()).toBe(500);
+    expect(res._getJSONData()).toEqual({
+      error: {
+        type: "internal_server_error",
+        message: "Failed to delete connection",
+      },
+    });
+  });
+
+  it("DELETE a personal connection as non-admin and wrong user should return 404", async () => {
+    // Create first user and their connection
+    const { workspace, authenticator: authenticator1 } =
+      await createPrivateApiMockRequest({
         method: "GET",
       });
-      req.query.connectionType = "personal";
-      req.query.cId = "non_existing_connection_id";
-      await handler(req, res);
+    await SpaceFactory.system(workspace);
+    const remoteServer = await RemoteMCPServerFactory.create(workspace);
+    const connection1 = await MCPServerConnectionFactory.remote(
+      authenticator1,
+      remoteServer,
+      "personal"
+    );
 
-      expect(res._getStatusCode()).toBe(404);
-      expect(res._getJSONData()).toEqual({
-        error: {
-          type: "mcp_server_connection_not_found",
-          message: "Connection not found",
-        },
-      });
-    }
-  );
+    // Create second user and try to delete first user's connection
+    const user2 = await UserFactory.basic();
+    await MembershipFactory.associate(workspace, user2, { role: "user" });
 
-  itInTransaction(
-    "DELETE a workspace connection as non-admin should return 500",
-    async (t) => {
-      const { req, res, workspace } = await createPrivateApiMockRequest({
-        method: "DELETE",
-        role: "user", // Explicitly set as non-admin
-      });
-      await SpaceFactory.system(workspace, t);
-      const remoteServer = await RemoteMCPServerFactory.create(workspace);
+    const { req, res } = await createPrivateApiMockRequest({
+      method: "DELETE",
+      role: "user",
+    });
+    req.query.connectionType = "personal";
+    req.query.cId = connection1.sId;
+    await handler(req, res);
 
-      const admin = await UserFactory.basic();
-      await MembershipFactory.associate(workspace, admin, { role: "admin" }, t);
-      const adminAuthenticator = await Authenticator.fromUserIdAndWorkspaceId(
-        admin.sId,
-        workspace.sId
-      );
-      const workspaceConnection = await MCPServerConnectionFactory.remote(
-        adminAuthenticator,
-        remoteServer,
-        "workspace"
-      );
-
-      req.query.connectionType = "workspace";
-      req.query.cId = workspaceConnection.sId;
-      await handler(req, res);
-
-      expect(res._getStatusCode()).toBe(500);
-      expect(res._getJSONData()).toEqual({
-        error: {
-          type: "internal_server_error",
-          message: "Failed to delete connection",
-        },
-      });
-    }
-  );
-
-  itInTransaction(
-    "DELETE a personal connection as non-admin and wrong user should return 404",
-    async (t) => {
-      // Create first user and their connection
-      const { workspace, authenticator: authenticator1 } =
-        await createPrivateApiMockRequest({
-          method: "GET",
-        });
-      await SpaceFactory.system(workspace, t);
-      const remoteServer = await RemoteMCPServerFactory.create(workspace);
-      const connection1 = await MCPServerConnectionFactory.remote(
-        authenticator1,
-        remoteServer,
-        "personal"
-      );
-
-      // Create second user and try to delete first user's connection
-      const user2 = await UserFactory.basic();
-      await MembershipFactory.associate(workspace, user2, { role: "user" }, t);
-
-      const { req, res } = await createPrivateApiMockRequest({
-        method: "DELETE",
-        role: "user",
-      });
-      req.query.connectionType = "personal";
-      req.query.cId = connection1.sId;
-      await handler(req, res);
-
-      expect(res._getStatusCode()).toBe(404);
-    }
-  );
+    expect(res._getStatusCode()).toBe(404);
+  });
 });

--- a/front/pages/api/w/[wId]/mcp/connections/[connectionType]/index.test.ts
+++ b/front/pages/api/w/[wId]/mcp/connections/[connectionType]/index.test.ts
@@ -1,51 +1,47 @@
-import { describe, expect } from "vitest";
+import { describe, expect, it } from "vitest";
 
 import type { MCPServerConnectionType } from "@app/lib/resources/mcp_server_connection_resource";
 import { createPrivateApiMockRequest } from "@app/tests/utils/generic_private_api_tests";
 import { MCPServerConnectionFactory } from "@app/tests/utils/MCPServerConnectionFactory";
 import { RemoteMCPServerFactory } from "@app/tests/utils/RemoteMCPServerFactory";
 import { SpaceFactory } from "@app/tests/utils/SpaceFactory";
-import { itInTransaction } from "@app/tests/utils/utils";
 
 import handler from "./index";
 
 describe("MCP Connections API Handler", () => {
-  itInTransaction(
-    "should return personal connections filtered by user ID",
-    async (t) => {
-      const { req, res, workspace, authenticator } =
-        await createPrivateApiMockRequest({
-          method: "GET",
-        });
-      req.query.connectionType = "personal";
+  it("should return personal connections filtered by user ID", async () => {
+    const { req, res, workspace, authenticator } =
+      await createPrivateApiMockRequest({
+        method: "GET",
+      });
+    req.query.connectionType = "personal";
 
-      // Create a system space to hold the Remote MCP servers.
-      await SpaceFactory.system(workspace, t);
+    // Create a system space to hold the Remote MCP servers.
+    await SpaceFactory.system(workspace);
 
-      const remoteServer = await RemoteMCPServerFactory.create(workspace);
+    const remoteServer = await RemoteMCPServerFactory.create(workspace);
 
-      // Create two connections for the same server, one newer than the other
-      await MCPServerConnectionFactory.remote(
-        authenticator,
-        remoteServer,
-        "personal"
-      );
-      const connection2 = await MCPServerConnectionFactory.remote(
-        authenticator,
-        remoteServer,
-        "personal"
-      );
+    // Create two connections for the same server, one newer than the other
+    await MCPServerConnectionFactory.remote(
+      authenticator,
+      remoteServer,
+      "personal"
+    );
+    const connection2 = await MCPServerConnectionFactory.remote(
+      authenticator,
+      remoteServer,
+      "personal"
+    );
 
-      await handler(req, res);
+    await handler(req, res);
 
-      expect(res._getStatusCode()).toBe(200);
-      const response = res._getJSONData();
-      expect(response.connections).toHaveLength(1);
-      expect(response.connections[0].sId).toBe(connection2.sId); // Should return the latest connection.
-    }
-  );
+    expect(res._getStatusCode()).toBe(200);
+    const response = res._getJSONData();
+    expect(response.connections).toHaveLength(1);
+    expect(response.connections[0].sId).toBe(connection2.sId); // Should return the latest connection.
+  });
 
-  itInTransaction("should return workspace connections", async (t) => {
+  it("should return workspace connections", async () => {
     const { req, res, workspace, authenticator } =
       await createPrivateApiMockRequest({
         method: "GET",
@@ -54,7 +50,7 @@ describe("MCP Connections API Handler", () => {
     req.query.connectionType = "workspace";
 
     // Create a system space to hold the Remote MCP servers
-    await SpaceFactory.system(workspace, t);
+    await SpaceFactory.system(workspace);
 
     const remoteServer = await RemoteMCPServerFactory.create(workspace);
     const now = new Date();
@@ -81,7 +77,7 @@ describe("MCP Connections API Handler", () => {
     expect(response.connections[0].sId).toBe(connection2.sId); // Should return the latest connection.
   });
 
-  itInTransaction("should handle different server IDs correctly", async (t) => {
+  it("should handle different server IDs correctly", async () => {
     const { req, res, workspace, authenticator } =
       await createPrivateApiMockRequest({
         method: "GET",
@@ -89,7 +85,7 @@ describe("MCP Connections API Handler", () => {
     req.query.connectionType = "personal";
 
     // Create a system space to hold the Remote MCP servers
-    await SpaceFactory.system(workspace, t);
+    await SpaceFactory.system(workspace);
 
     const remoteServer1 = await RemoteMCPServerFactory.create(workspace);
     const remoteServer2 = await RemoteMCPServerFactory.create(workspace);
@@ -116,7 +112,7 @@ describe("MCP Connections API Handler", () => {
     ).toEqual([connection1.sId, connection2.sId].sort());
   });
 
-  itInTransaction("should handle internal server connections", async () => {
+  it("should handle internal server connections", async () => {
     const { req, res, authenticator } = await createPrivateApiMockRequest({
       method: "GET",
     });
@@ -146,7 +142,7 @@ describe("MCP Connections API Handler", () => {
     expect(response.connections[0].sId).toBe(connection2.sId); // Should return the latest connection.
   });
 
-  itInTransaction("should return 400 for invalid connection type", async () => {
+  it("should return 400 for invalid connection type", async () => {
     const { req, res } = await createPrivateApiMockRequest({
       method: "GET",
     });
@@ -163,97 +159,91 @@ describe("MCP Connections API Handler", () => {
     });
   });
 
-  itInTransaction(
-    "should not leak personal connections across workspaces",
-    async (t) => {
-      // Create first workspace and its connections.
-      const { workspace: workspace1, authenticator: authenticator1 } =
-        await createPrivateApiMockRequest({
-          method: "GET",
-        });
-      await SpaceFactory.system(workspace1, t);
-      const remoteServer1 = await RemoteMCPServerFactory.create(workspace1);
-      const connection1 = await MCPServerConnectionFactory.remote(
-        authenticator1,
-        remoteServer1,
-        "personal"
-      );
-
-      // Create second workspace and its connections.
-      const {
-        req,
-        res,
-        workspace: workspace2,
-        authenticator: authenticator2,
-      } = await createPrivateApiMockRequest({
+  it("should not leak personal connections across workspaces", async () => {
+    // Create first workspace and its connections.
+    const { workspace: workspace1, authenticator: authenticator1 } =
+      await createPrivateApiMockRequest({
         method: "GET",
       });
-      req.query.connectionType = "personal";
-      await SpaceFactory.system(workspace2, t);
-      const remoteServer2 = await RemoteMCPServerFactory.create(workspace2);
-      const connection2 = await MCPServerConnectionFactory.remote(
-        authenticator2,
-        remoteServer2,
-        "personal"
-      );
+    await SpaceFactory.system(workspace1);
+    const remoteServer1 = await RemoteMCPServerFactory.create(workspace1);
+    const connection1 = await MCPServerConnectionFactory.remote(
+      authenticator1,
+      remoteServer1,
+      "personal"
+    );
 
-      // Query connections from workspace2.
-      await handler(req, res);
+    // Create second workspace and its connections.
+    const {
+      req,
+      res,
+      workspace: workspace2,
+      authenticator: authenticator2,
+    } = await createPrivateApiMockRequest({
+      method: "GET",
+    });
+    req.query.connectionType = "personal";
+    await SpaceFactory.system(workspace2);
+    const remoteServer2 = await RemoteMCPServerFactory.create(workspace2);
+    const connection2 = await MCPServerConnectionFactory.remote(
+      authenticator2,
+      remoteServer2,
+      "personal"
+    );
 
-      // Should only see connections from workspace2.
-      expect(res._getStatusCode()).toBe(200);
-      const response = res._getJSONData();
-      expect(response.connections).toHaveLength(1);
-      expect(response.connections[0].sId).toBe(connection2.sId);
-      expect(response.connections[0].sId).not.toBe(connection1.sId);
-    }
-  );
+    // Query connections from workspace2.
+    await handler(req, res);
 
-  itInTransaction(
-    "should not leak workspace connections across workspaces",
-    async (t) => {
-      // Create first workspace and its connections.
-      const { workspace: workspace1, authenticator: authenticator1 } =
-        await createPrivateApiMockRequest({
-          method: "GET",
-          role: "admin",
-        });
-      await SpaceFactory.system(workspace1, t);
-      const remoteServer1 = await RemoteMCPServerFactory.create(workspace1);
-      const connection1 = await MCPServerConnectionFactory.remote(
-        authenticator1,
-        remoteServer1,
-        "workspace"
-      );
+    // Should only see connections from workspace2.
+    expect(res._getStatusCode()).toBe(200);
+    const response = res._getJSONData();
+    expect(response.connections).toHaveLength(1);
+    expect(response.connections[0].sId).toBe(connection2.sId);
+    expect(response.connections[0].sId).not.toBe(connection1.sId);
+  });
 
-      // Create second workspace and its connections.
-      const {
-        req,
-        res,
-        workspace: workspace2,
-        authenticator: authenticator2,
-      } = await createPrivateApiMockRequest({
+  it("should not leak workspace connections across workspaces", async () => {
+    // Create first workspace and its connections.
+    const { workspace: workspace1, authenticator: authenticator1 } =
+      await createPrivateApiMockRequest({
         method: "GET",
         role: "admin",
       });
-      req.query.connectionType = "workspace";
-      await SpaceFactory.system(workspace2, t);
-      const remoteServer2 = await RemoteMCPServerFactory.create(workspace2);
-      const connection2 = await MCPServerConnectionFactory.remote(
-        authenticator2,
-        remoteServer2,
-        "workspace"
-      );
+    await SpaceFactory.system(workspace1);
+    const remoteServer1 = await RemoteMCPServerFactory.create(workspace1);
+    const connection1 = await MCPServerConnectionFactory.remote(
+      authenticator1,
+      remoteServer1,
+      "workspace"
+    );
 
-      // Query connections from workspace2.
-      await handler(req, res);
+    // Create second workspace and its connections.
+    const {
+      req,
+      res,
+      workspace: workspace2,
+      authenticator: authenticator2,
+    } = await createPrivateApiMockRequest({
+      method: "GET",
+      role: "admin",
+    });
+    req.query.connectionType = "workspace";
+    await SpaceFactory.system(workspace2);
+    const remoteServer2 = await RemoteMCPServerFactory.create(workspace2);
+    const connection2 = await MCPServerConnectionFactory.remote(
+      authenticator2,
+      remoteServer2,
+      "workspace"
+    );
 
-      // Should only see connections from workspace2.
-      expect(res._getStatusCode()).toBe(200);
-      const response = res._getJSONData();
-      expect(response.connections).toHaveLength(1);
-      expect(response.connections[0].sId).toBe(connection2.sId);
-      expect(response.connections[0].sId).not.toBe(connection1.sId);
-    }
-  );
+    // Query connections from workspace2.
+    await handler(req, res);
+
+    // Should only see connections from workspace2.
+    expect(res._getStatusCode()).toBe(200);
+    const response = res._getJSONData();
+    expect(response.connections).toHaveLength(1);
+    expect(response.connections[0].sId).toBe(connection2.sId);
+    expect(response.connections[0].sId).not.toBe(connection1.sId);
+  });
 });

--- a/front/pages/api/w/[wId]/mcp/index.test.ts
+++ b/front/pages/api/w/[wId]/mcp/index.test.ts
@@ -1,10 +1,9 @@
 import type { RequestMethod } from "node-mocks-http";
-import { describe, expect, vi } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 
 import { createPrivateApiMockRequest } from "@app/tests/utils/generic_private_api_tests";
 import { RemoteMCPServerFactory } from "@app/tests/utils/RemoteMCPServerFactory";
 import { SpaceFactory } from "@app/tests/utils/SpaceFactory";
-import { itInTransaction } from "@app/tests/utils/utils";
 import { Ok } from "@app/types";
 
 import handler from "./index";
@@ -28,7 +27,6 @@ vi.mock(
 );
 
 async function setupTest(
-  t: any,
   role: "builder" | "user" | "admin" = "admin",
   method: RequestMethod = "GET"
 ) {
@@ -38,7 +36,7 @@ async function setupTest(
   });
 
   // Create a system space to hold the Remote MCP servers
-  await SpaceFactory.system(workspace, t);
+  await SpaceFactory.system(workspace);
 
   // Set up common query parameters
   req.query.wId = workspace.sId;
@@ -59,8 +57,8 @@ vi.mock(import("@app/lib/actions/mcp_actions"), async (importOriginal) => {
 });
 
 describe("GET /api/w/[wId]/mcp/", () => {
-  itInTransaction("should return a list of servers", async (t) => {
-    const { req, res, workspace } = await setupTest(t);
+  it("should return a list of servers", async () => {
+    const { req, res, workspace } = await setupTest();
 
     req.query.filter = "remote";
 
@@ -98,28 +96,25 @@ describe("GET /api/w/[wId]/mcp/", () => {
     expect(responseData.servers).toHaveLength(2);
   });
 
-  itInTransaction(
-    "should return empty array when no servers exist",
-    async (t) => {
-      const { req, res } = await setupTest(t);
+  it("should return empty array when no servers exist", async () => {
+    const { req, res } = await setupTest();
 
-      req.query.filter = "remote";
+    req.query.filter = "remote";
 
-      await handler(req, res);
+    await handler(req, res);
 
-      expect(res._getStatusCode()).toBe(200);
+    expect(res._getStatusCode()).toBe(200);
 
-      const responseData = res._getJSONData();
-      expect(responseData).toHaveProperty("servers");
-      expect(responseData.servers).toBeInstanceOf(Array);
-      expect(responseData.servers).toHaveLength(0);
-    }
-  );
+    const responseData = res._getJSONData();
+    expect(responseData).toHaveProperty("servers");
+    expect(responseData.servers).toBeInstanceOf(Array);
+    expect(responseData.servers).toHaveLength(0);
+  });
 });
 
 describe("POST /api/w/[wId]/mcp/", () => {
-  itInTransaction("should return 400 when URL is missing", async (t) => {
-    const { req, res } = await setupTest(t, "admin", "POST");
+  it("should return 400 when URL is missing", async () => {
+    const { req, res } = await setupTest("admin", "POST");
 
     req.body = {};
 
@@ -136,9 +131,9 @@ describe("POST /api/w/[wId]/mcp/", () => {
 });
 
 describe("Method Support /api/w/[wId]/mcp", () => {
-  itInTransaction("only supports GET and POST methods", async (t) => {
+  it("only supports GET and POST methods", async () => {
     for (const method of ["DELETE", "PUT", "PATCH"] as const) {
-      const { req, res } = await setupTest(t, "admin", method);
+      const { req, res } = await setupTest("admin", method);
 
       await handler(req, res);
 

--- a/front/pages/api/w/[wId]/mcp/views/[viewId]/index.test.ts
+++ b/front/pages/api/w/[wId]/mcp/views/[viewId]/index.test.ts
@@ -1,5 +1,6 @@
 import type { RequestMethod } from "node-mocks-http";
 import { describe, expect } from "vitest";
+import { it } from "vitest";
 
 import { InternalMCPServerInMemoryResource } from "@app/lib/resources/internal_mcp_server_in_memory_resource";
 import { MCPServerViewResource } from "@app/lib/resources/mcp_server_view_resource";
@@ -8,12 +9,10 @@ import { createPrivateApiMockRequest } from "@app/tests/utils/generic_private_ap
 import { MCPServerViewFactory } from "@app/tests/utils/MCPServerViewFactory";
 import { RemoteMCPServerFactory } from "@app/tests/utils/RemoteMCPServerFactory";
 import { SpaceFactory } from "@app/tests/utils/SpaceFactory";
-import { itInTransaction } from "@app/tests/utils/utils";
 
 import handler from "./index";
 
 async function setupTest(
-  t: any,
   role: "builder" | "user" | "admin" = "admin",
   method: RequestMethod = "GET"
 ) {
@@ -23,7 +22,7 @@ async function setupTest(
       method,
     });
 
-  const systemSpace = await SpaceFactory.system(workspace, t);
+  const systemSpace = await SpaceFactory.system(workspace);
 
   // Set up common query parameters
   req.query.wId = workspace.sId;
@@ -32,296 +31,250 @@ async function setupTest(
 }
 
 describe("PATCH /api/w/[wId]/mcp/views/[viewId]", () => {
-  itInTransaction(
-    "should return 400 when no update fields are provided",
-    async (t) => {
-      const { req, res, workspace, auth } = await setupTest(
-        t,
-        "admin",
-        "PATCH"
-      );
+  it("should return 400 when no update fields are provided", async () => {
+    const { req, res, workspace, auth } = await setupTest("admin", "PATCH");
 
-      const server = await RemoteMCPServerFactory.create(workspace);
+    const server = await RemoteMCPServerFactory.create(workspace);
 
-      const systemView =
-        await MCPServerViewResource.getMCPServerViewForSystemSpace(
-          auth,
-          server.sId
-        );
-
-      expect(systemView).toBeDefined();
-
-      req.query.viewId = systemView!.sId;
-      req.body = {};
-
-      await handler(req, res);
-
-      expect(res._getStatusCode()).toBe(400);
-      const responseData = res._getJSONData();
-      expect(responseData.error.message).toContain("Validation error:");
-    }
-  );
-
-  itInTransaction(
-    "should return 400 when trying to update non-system view",
-    async (t) => {
-      const { req, res, workspace } = await setupTest(t, "admin", "PATCH");
-
-      const server = await RemoteMCPServerFactory.create(workspace);
-
-      // Create a view in global space (not system space)
-      const globalSpace = await SpaceFactory.global(workspace, t);
-      const serverView = await MCPServerViewFactory.create(
-        workspace,
-        server.sId,
-        globalSpace,
-        t
-      );
-
-      req.query.viewId = serverView.sId;
-      req.body = {
-        oAuthUseCase: "platform_actions",
-      };
-
-      await handler(req, res);
-
-      expect(res._getStatusCode()).toBe(400);
-      const responseData = res._getJSONData();
-      expect(responseData.error.type).toBe("invalid_request_error");
-      expect(responseData.error.message).toBe(
-        "Updates can only be performed on system views."
-      );
-    }
-  );
-
-  itInTransaction(
-    "should update oAuthUseCase for all views of the same MCP server when admin",
-    async (t) => {
-      const { req, res, workspace, auth } = await setupTest(
-        t,
-        "admin",
-        "PATCH"
-      );
-
-      const server = await RemoteMCPServerFactory.create(workspace);
-
-      const systemView =
-        await MCPServerViewResource.getMCPServerViewForSystemSpace(
-          auth,
-          server.sId
-        );
-
-      expect(systemView).toBeDefined();
-
-      req.query.viewId = systemView!.sId;
-
-      // Create additional views in global space for the same server
-      const globalSpace = await SpaceFactory.global(workspace, t);
-      await MCPServerViewFactory.create(workspace, server.sId, globalSpace, t);
-
-      // Verify initial state
-      const initialViews = await MCPServerViewResource.listByMCPServer(
+    const systemView =
+      await MCPServerViewResource.getMCPServerViewForSystemSpace(
         auth,
         server.sId
       );
-      for (const view of initialViews) {
-        expect(view.oAuthUseCase).toBeNull();
-      }
 
-      // Update via system view
-      req.query.viewId = systemView!.sId;
-      req.body = { oAuthUseCase: "platform_actions" };
-      await handler(req, res);
+    expect(systemView).toBeDefined();
 
-      expect(res._getStatusCode()).toBe(200);
-      const responseData = res._getJSONData();
-      expect(responseData.success).toBe(true);
-      expect(responseData.serverView.oAuthUseCase).toBe("platform_actions");
+    req.query.viewId = systemView!.sId;
+    req.body = {};
 
-      // Verify all views were updated
-      const updatedViews = await MCPServerViewResource.listByMCPServer(
+    await handler(req, res);
+
+    expect(res._getStatusCode()).toBe(400);
+    const responseData = res._getJSONData();
+    expect(responseData.error.message).toContain("Validation error:");
+  });
+
+  it("should return 400 when trying to update non-system view", async () => {
+    const { req, res, workspace } = await setupTest("admin", "PATCH");
+
+    const server = await RemoteMCPServerFactory.create(workspace);
+
+    // Create a view in global space (not system space)
+    const globalSpace = await SpaceFactory.global(workspace);
+    const serverView = await MCPServerViewFactory.create(
+      workspace,
+      server.sId,
+      globalSpace
+    );
+
+    req.query.viewId = serverView.sId;
+    req.body = {
+      oAuthUseCase: "platform_actions",
+    };
+
+    await handler(req, res);
+
+    expect(res._getStatusCode()).toBe(400);
+    const responseData = res._getJSONData();
+    expect(responseData.error.type).toBe("invalid_request_error");
+    expect(responseData.error.message).toBe(
+      "Updates can only be performed on system views."
+    );
+  });
+
+  it("should update oAuthUseCase for all views of the same MCP server when admin", async () => {
+    const { req, res, workspace, auth } = await setupTest("admin", "PATCH");
+
+    const server = await RemoteMCPServerFactory.create(workspace);
+
+    const systemView =
+      await MCPServerViewResource.getMCPServerViewForSystemSpace(
         auth,
         server.sId
       );
-      for (const view of updatedViews) {
-        expect(view.oAuthUseCase).toBe("platform_actions");
-      }
+
+    expect(systemView).toBeDefined();
+
+    req.query.viewId = systemView!.sId;
+
+    // Create additional views in global space for the same server
+    const globalSpace = await SpaceFactory.global(workspace);
+    await MCPServerViewFactory.create(workspace, server.sId, globalSpace);
+
+    // Verify initial state
+    const initialViews = await MCPServerViewResource.listByMCPServer(
+      auth,
+      server.sId
+    );
+    for (const view of initialViews) {
+      expect(view.oAuthUseCase).toBeNull();
     }
-  );
 
-  itInTransaction(
-    "should update name and description for all views of the same MCP server when admin",
-    async (t) => {
-      const { req, res, workspace, auth } = await setupTest(
-        t,
-        "admin",
-        "PATCH"
-      );
+    // Update via system view
+    req.query.viewId = systemView!.sId;
+    req.body = { oAuthUseCase: "platform_actions" };
+    await handler(req, res);
 
-      const server = await RemoteMCPServerFactory.create(workspace);
+    expect(res._getStatusCode()).toBe(200);
+    const responseData = res._getJSONData();
+    expect(responseData.success).toBe(true);
+    expect(responseData.serverView.oAuthUseCase).toBe("platform_actions");
 
-      const systemView =
-        await MCPServerViewResource.getMCPServerViewForSystemSpace(
-          auth,
-          server.sId
-        );
+    // Verify all views were updated
+    const updatedViews = await MCPServerViewResource.listByMCPServer(
+      auth,
+      server.sId
+    );
+    for (const view of updatedViews) {
+      expect(view.oAuthUseCase).toBe("platform_actions");
+    }
+  });
 
-      expect(systemView).toBeDefined();
+  it("should update name and description for all views of the same MCP server when admin", async () => {
+    const { req, res, workspace, auth } = await setupTest("admin", "PATCH");
 
-      // Create additional views in global space for the same server
-      const globalSpace = await SpaceFactory.global(workspace, t);
-      await MCPServerViewFactory.create(workspace, server.sId, globalSpace);
+    const server = await RemoteMCPServerFactory.create(workspace);
 
-      // Update via system view
-      req.query.viewId = systemView!.sId;
-      req.body = {
-        name: "Updated View Name",
-        description: "Updated Description",
-      };
-      await handler(req, res);
-
-      expect(res._getStatusCode()).toBe(200);
-      const responseData = res._getJSONData();
-      expect(responseData.success).toBe(true);
-      expect(responseData.serverView.name).toBe("Updated View Name");
-      expect(responseData.serverView.description).toBe("Updated Description");
-
-      // Verify all views were updated
-      const updatedViews = await MCPServerViewResource.listByMCPServer(
+    const systemView =
+      await MCPServerViewResource.getMCPServerViewForSystemSpace(
         auth,
         server.sId
       );
-      for (const view of updatedViews) {
-        expect(view.name).toBe("Updated View Name");
-        expect(view.description).toBe("Updated Description");
-      }
+
+    expect(systemView).toBeDefined();
+
+    // Create additional views in global space for the same server
+    const globalSpace = await SpaceFactory.global(workspace);
+    await MCPServerViewFactory.create(workspace, server.sId, globalSpace);
+
+    // Update via system view
+    req.query.viewId = systemView!.sId;
+    req.body = {
+      name: "Updated View Name",
+      description: "Updated Description",
+    };
+    await handler(req, res);
+
+    expect(res._getStatusCode()).toBe(200);
+    const responseData = res._getJSONData();
+    expect(responseData.success).toBe(true);
+    expect(responseData.serverView.name).toBe("Updated View Name");
+    expect(responseData.serverView.description).toBe("Updated Description");
+
+    // Verify all views were updated
+    const updatedViews = await MCPServerViewResource.listByMCPServer(
+      auth,
+      server.sId
+    );
+    for (const view of updatedViews) {
+      expect(view.name).toBe("Updated View Name");
+      expect(view.description).toBe("Updated Description");
     }
-  );
+  });
 
-  itInTransaction(
-    "should fail to update view when user has insufficient permissions",
-    async (t) => {
-      const { req, res, workspace, auth } = await setupTest(t, "user", "PATCH");
+  it("should fail to update view when user has insufficient permissions", async () => {
+    const { req, res, workspace, auth } = await setupTest("user", "PATCH");
 
-      const server = await RemoteMCPServerFactory.create(workspace);
-      const systemView =
-        await MCPServerViewResource.getMCPServerViewForSystemSpace(
-          auth,
-          server.sId
-        );
-
-      expect(systemView).toBeDefined();
-
-      req.query.viewId = systemView!.sId;
-
-      req.body = { oAuthUseCase: "platform_actions" };
-      await handler(req, res);
-
-      expect(res._getStatusCode()).toBe(401);
-      const responseData = res._getJSONData();
-      expect(responseData.error.type).toBe("workspace_auth_error");
-    }
-  );
-
-  itInTransaction(
-    "should work with internal MCP servers and update all views",
-    async (t) => {
-      const { req, res, workspace, auth } = await setupTest(
-        t,
-        "admin",
-        "PATCH"
-      );
-
-      // Create an internal MCP server
-      await FeatureFlagFactory.basic("dev_mcp_actions", workspace);
-      const server = await InternalMCPServerInMemoryResource.makeNew(
+    const server = await RemoteMCPServerFactory.create(workspace);
+    const systemView =
+      await MCPServerViewResource.getMCPServerViewForSystemSpace(
         auth,
-        {
-          name: "primitive_types_debugger",
-          useCase: null,
-        },
-        t
+        server.sId
       );
 
-      const systemView =
-        await MCPServerViewResource.getMCPServerViewForSystemSpace(
-          auth,
-          server.id
-        );
+    expect(systemView).toBeDefined();
 
-      expect(systemView).toBeDefined();
+    req.query.viewId = systemView!.sId;
 
-      // Create additional views in global space
-      const globalSpace = await SpaceFactory.global(workspace, t);
-      await MCPServerViewFactory.create(workspace, server.id, globalSpace);
+    req.body = { oAuthUseCase: "platform_actions" };
+    await handler(req, res);
 
-      // Verify initial state
-      const initialViews = await MCPServerViewResource.listByMCPServer(
+    expect(res._getStatusCode()).toBe(401);
+    const responseData = res._getJSONData();
+    expect(responseData.error.type).toBe("workspace_auth_error");
+  });
+
+  it("should work with internal MCP servers and update all views", async () => {
+    const { req, res, workspace, auth } = await setupTest("admin", "PATCH");
+
+    // Create an internal MCP server
+    await FeatureFlagFactory.basic("dev_mcp_actions", workspace);
+    const server = await InternalMCPServerInMemoryResource.makeNew(auth, {
+      name: "primitive_types_debugger",
+      useCase: null,
+    });
+
+    const systemView =
+      await MCPServerViewResource.getMCPServerViewForSystemSpace(
         auth,
         server.id
       );
-      for (const view of initialViews) {
-        expect(view.oAuthUseCase).toBeNull();
-      }
 
-      // Update via system view
-      req.query.viewId = systemView!.sId;
-      req.body = { oAuthUseCase: "personal_actions" };
-      await handler(req, res);
+    expect(systemView).toBeDefined();
 
-      expect(res._getStatusCode()).toBe(200);
-      const responseData = res._getJSONData();
-      expect(responseData.success).toBe(true);
-      expect(responseData.serverView.oAuthUseCase).toBe("personal_actions");
+    // Create additional views in global space
+    const globalSpace = await SpaceFactory.global(workspace);
+    await MCPServerViewFactory.create(workspace, server.id, globalSpace);
 
-      // Verify all views were updated
-      const updatedViews = await MCPServerViewResource.listByMCPServer(
+    // Verify initial state
+    const initialViews = await MCPServerViewResource.listByMCPServer(
+      auth,
+      server.id
+    );
+    for (const view of initialViews) {
+      expect(view.oAuthUseCase).toBeNull();
+    }
+
+    // Update via system view
+    req.query.viewId = systemView!.sId;
+    req.body = { oAuthUseCase: "personal_actions" };
+    await handler(req, res);
+
+    expect(res._getStatusCode()).toBe(200);
+    const responseData = res._getJSONData();
+    expect(responseData.success).toBe(true);
+    expect(responseData.serverView.oAuthUseCase).toBe("personal_actions");
+
+    // Verify all views were updated
+    const updatedViews = await MCPServerViewResource.listByMCPServer(
+      auth,
+      server.id
+    );
+    for (const view of updatedViews) {
+      expect(view.oAuthUseCase).toBe("personal_actions");
+    }
+  });
+
+  it("should support updating null name and description", async () => {
+    const { req, res, workspace, auth } = await setupTest("admin", "PATCH");
+
+    const server = await RemoteMCPServerFactory.create(workspace);
+    const systemView =
+      await MCPServerViewResource.getMCPServerViewForSystemSpace(
         auth,
-        server.id
-      );
-      for (const view of updatedViews) {
-        expect(view.oAuthUseCase).toBe("personal_actions");
-      }
-    }
-  );
-
-  itInTransaction(
-    "should support updating null name and description",
-    async (t) => {
-      const { req, res, workspace, auth } = await setupTest(
-        t,
-        "admin",
-        "PATCH"
+        server.sId
       );
 
-      const server = await RemoteMCPServerFactory.create(workspace);
-      const systemView =
-        await MCPServerViewResource.getMCPServerViewForSystemSpace(
-          auth,
-          server.sId
-        );
+    expect(systemView).toBeDefined();
 
-      expect(systemView).toBeDefined();
+    req.query.viewId = systemView!.sId;
+    req.body = {
+      name: null,
+      description: null,
+    };
+    await handler(req, res);
 
-      req.query.viewId = systemView!.sId;
-      req.body = {
-        name: null,
-        description: null,
-      };
-      await handler(req, res);
-
-      expect(res._getStatusCode()).toBe(200);
-      const responseData = res._getJSONData();
-      expect(responseData.success).toBe(true);
-      expect(responseData.serverView.name).toBeNull();
-      expect(responseData.serverView.description).toBeNull();
-    }
-  );
+    expect(res._getStatusCode()).toBe(200);
+    const responseData = res._getJSONData();
+    expect(responseData.success).toBe(true);
+    expect(responseData.serverView.name).toBeNull();
+    expect(responseData.serverView.description).toBeNull();
+  });
 });
 
 describe("Method Support /api/w/[wId]/mcp/views/[viewId]", () => {
-  itInTransaction("supports only PATCH method", async (t) => {
-    const { req, res, workspace, auth } = await setupTest(t, "admin", "DELETE");
+  it("supports only PATCH method", async () => {
+    const { req, res, workspace, auth } = await setupTest("admin", "DELETE");
 
     const server = await RemoteMCPServerFactory.create(workspace);
     const systemView =

--- a/front/pages/api/w/[wId]/members/[uId]/index.test.ts
+++ b/front/pages/api/w/[wId]/members/[uId]/index.test.ts
@@ -1,156 +1,135 @@
-import { describe, expect } from "vitest";
+import { describe, expect, it } from "vitest";
 
 import { createPrivateApiMockRequest } from "@app/tests/utils/generic_private_api_tests";
 import { MembershipFactory } from "@app/tests/utils/MembershipFactory";
 import { UserFactory } from "@app/tests/utils/UserFactory";
-import { itInTransaction } from "@app/tests/utils/utils";
 
 import handler from "./index";
 
 describe("POST /api/w/[wId]/members/[uId]", () => {
   describe("sole admin protection", () => {
-    itInTransaction(
-      "should return 400 when sole admin tries to change own role to user",
-      async () => {
-        const { req, res, user } = await createPrivateApiMockRequest({
-          method: "POST",
-          role: "admin",
-        });
+    it("should return 400 when sole admin tries to change own role to user", async () => {
+      const { req, res, user } = await createPrivateApiMockRequest({
+        method: "POST",
+        role: "admin",
+      });
 
-        // Set the user ID in the query to match the authenticated user (self-modification)
-        req.query.uId = user.sId;
-        req.body = { role: "user" }; // Trying to change from admin to user
+      // Set the user ID in the query to match the authenticated user (self-modification)
+      req.query.uId = user.sId;
+      req.body = { role: "user" }; // Trying to change from admin to user
 
-        await handler(req, res);
+      await handler(req, res);
 
-        expect(res._getStatusCode()).toBe(400);
-        const data = res._getJSONData();
-        expect(data.error.type).toBe("invalid_request_error");
-        expect(data.error.message).toBe(
-          "Cannot change your role as you are the sole admin of this workspace."
-        );
-      }
-    );
+      expect(res._getStatusCode()).toBe(400);
+      const data = res._getJSONData();
+      expect(data.error.type).toBe("invalid_request_error");
+      expect(data.error.message).toBe(
+        "Cannot change your role as you are the sole admin of this workspace."
+      );
+    });
 
-    itInTransaction(
-      "should return 400 when sole admin tries to change own role to builder",
-      async () => {
-        const { req, res, user } = await createPrivateApiMockRequest({
-          method: "POST",
-          role: "admin",
-        });
+    it("should return 400 when sole admin tries to change own role to builder", async () => {
+      const { req, res, user } = await createPrivateApiMockRequest({
+        method: "POST",
+        role: "admin",
+      });
 
-        req.query.uId = user.sId;
-        req.body = { role: "builder" };
+      req.query.uId = user.sId;
+      req.body = { role: "builder" };
 
-        await handler(req, res);
+      await handler(req, res);
 
-        expect(res._getStatusCode()).toBe(400);
-        const data = res._getJSONData();
-        expect(data.error.type).toBe("invalid_request_error");
-        expect(data.error.message).toBe(
-          "Cannot change your role as you are the sole admin of this workspace."
-        );
-      }
-    );
+      expect(res._getStatusCode()).toBe(400);
+      const data = res._getJSONData();
+      expect(data.error.type).toBe("invalid_request_error");
+      expect(data.error.message).toBe(
+        "Cannot change your role as you are the sole admin of this workspace."
+      );
+    });
 
-    itInTransaction(
-      "should return 200 when sole admin keeps their admin role",
-      async () => {
-        const { req, res, user } = await createPrivateApiMockRequest({
-          method: "POST",
-          role: "admin",
-        });
+    it("should return 200 when sole admin keeps their admin role", async () => {
+      const { req, res, user } = await createPrivateApiMockRequest({
+        method: "POST",
+        role: "admin",
+      });
 
-        req.query.uId = user.sId;
-        req.body = { role: "admin" }; // Staying as admin
+      req.query.uId = user.sId;
+      req.body = { role: "admin" }; // Staying as admin
 
-        await handler(req, res);
+      await handler(req, res);
 
-        expect(res._getStatusCode()).toBe(200);
-        const data = res._getJSONData();
-        expect(data.member).toBeDefined();
-        expect(data.member.workspaces[0].role).toBe("admin");
-      }
-    );
+      expect(res._getStatusCode()).toBe(200);
+      const data = res._getJSONData();
+      expect(data.member).toBeDefined();
+      expect(data.member.workspaces[0].role).toBe("admin");
+    });
 
-    itInTransaction(
-      "should return 200 when admin changes role with multiple admins present",
-      async () => {
-        const { req, res, workspace, user } = await createPrivateApiMockRequest(
-          {
-            method: "POST",
-            role: "admin",
-          }
-        );
+    it("should return 200 when admin changes role with multiple admins present", async () => {
+      const { req, res, workspace, user } = await createPrivateApiMockRequest({
+        method: "POST",
+        role: "admin",
+      });
 
-        // Create another admin so current user is not sole admin
-        const anotherAdmin = await UserFactory.basic();
-        await MembershipFactory.associate(workspace, anotherAdmin, {
-          role: "admin",
-        });
+      // Create another admin so current user is not sole admin
+      const anotherAdmin = await UserFactory.basic();
+      await MembershipFactory.associate(workspace, anotherAdmin, {
+        role: "admin",
+      });
 
-        req.query.uId = user.sId;
-        req.body = { role: "user" };
+      req.query.uId = user.sId;
+      req.body = { role: "user" };
 
-        await handler(req, res);
+      await handler(req, res);
 
-        expect(res._getStatusCode()).toBe(200);
-        const data = res._getJSONData();
-        expect(data.member).toBeDefined();
-        expect(data.member.workspaces[0].role).toBe("user");
-      }
-    );
+      expect(res._getStatusCode()).toBe(200);
+      const data = res._getJSONData();
+      expect(data.member).toBeDefined();
+      expect(data.member.workspaces[0].role).toBe("user");
+    });
 
-    itInTransaction(
-      "should return 200 when admin changes non-admin user's role",
-      async () => {
-        const { req, res, workspace } = await createPrivateApiMockRequest({
-          method: "POST",
-          role: "admin",
-        });
+    it("should return 200 when admin changes non-admin user's role", async () => {
+      const { req, res, workspace } = await createPrivateApiMockRequest({
+        method: "POST",
+        role: "admin",
+      });
 
-        // Create a user with user role
-        const targetUser = await UserFactory.basic();
-        await MembershipFactory.associate(workspace, targetUser, {
-          role: "user",
-        });
+      // Create a user with user role
+      const targetUser = await UserFactory.basic();
+      await MembershipFactory.associate(workspace, targetUser, {
+        role: "user",
+      });
 
-        req.query.uId = targetUser.sId;
-        req.body = { role: "builder" };
+      req.query.uId = targetUser.sId;
+      req.body = { role: "builder" };
 
-        await handler(req, res);
+      await handler(req, res);
 
-        expect(res._getStatusCode()).toBe(200);
-        const data = res._getJSONData();
-        expect(data.member).toBeDefined();
-        expect(data.member.workspaces[0].role).toBe("builder");
-      }
-    );
+      expect(res._getStatusCode()).toBe(200);
+      const data = res._getJSONData();
+      expect(data.member).toBeDefined();
+      expect(data.member.workspaces[0].role).toBe("builder");
+    });
 
-    itInTransaction(
-      "should return 403 when non-admin user tries to change own role",
-      async () => {
-        const { req, res, user } = await createPrivateApiMockRequest({
-          method: "POST",
-          role: "user",
-        });
+    it("should return 403 when non-admin user tries to change own role", async () => {
+      const { req, res, user } = await createPrivateApiMockRequest({
+        method: "POST",
+        role: "user",
+      });
 
-        req.query.uId = user.sId;
-        req.body = { role: "admin" };
+      req.query.uId = user.sId;
+      req.body = { role: "admin" };
 
-        await handler(req, res);
+      await handler(req, res);
 
-        // Should fail with 403 due to insufficient permissions, not sole admin protection
-        expect(res._getStatusCode()).toBe(403);
-        const data = res._getJSONData();
-        expect(data.error.type).toBe("workspace_auth_error");
-      }
-    );
+      // Should fail with 403 due to insufficient permissions, not sole admin protection
+      expect(res._getStatusCode()).toBe(403);
+      const data = res._getJSONData();
+      expect(data.error.type).toBe("workspace_auth_error");
+    });
   });
 
   describe("existing role management functionality", () => {
-    itInTransaction("should return 403 when user is not admin", async () => {
+    it("should return 403 when user is not admin", async () => {
       const { req, res, user } = await createPrivateApiMockRequest({
         method: "POST",
         role: "user",
@@ -166,26 +145,23 @@ describe("POST /api/w/[wId]/members/[uId]", () => {
       expect(data.error.type).toBe("workspace_auth_error");
     });
 
-    itInTransaction(
-      "should return 400 for invalid role parameter",
-      async () => {
-        const { req, res, user } = await createPrivateApiMockRequest({
-          method: "POST",
-          role: "admin",
-        });
+    it("should return 400 for invalid role parameter", async () => {
+      const { req, res, user } = await createPrivateApiMockRequest({
+        method: "POST",
+        role: "admin",
+      });
 
-        req.query.uId = user.sId;
-        req.body = { role: "invalid_role" };
+      req.query.uId = user.sId;
+      req.body = { role: "invalid_role" };
 
-        await handler(req, res);
+      await handler(req, res);
 
-        expect(res._getStatusCode()).toBe(400);
-        const data = res._getJSONData();
-        expect(data.error.type).toBe("invalid_request_error");
-      }
-    );
+      expect(res._getStatusCode()).toBe(400);
+      const data = res._getJSONData();
+      expect(data.error.type).toBe("invalid_request_error");
+    });
 
-    itInTransaction("should return 404 when user is not found", async () => {
+    it("should return 404 when user is not found", async () => {
       const { req, res } = await createPrivateApiMockRequest({
         method: "POST",
         role: "admin",
@@ -201,7 +177,7 @@ describe("POST /api/w/[wId]/members/[uId]", () => {
       expect(data.error.type).toBe("workspace_user_not_found");
     });
 
-    itInTransaction("should return 400 for missing uId parameter", async () => {
+    it("should return 400 for missing uId parameter", async () => {
       const { req, res } = await createPrivateApiMockRequest({
         method: "POST",
         role: "admin",
@@ -220,7 +196,7 @@ describe("POST /api/w/[wId]/members/[uId]", () => {
   });
 
   describe("method validation", () => {
-    itInTransaction("should return 405 for non-POST methods", async () => {
+    it("should return 405 for non-POST methods", async () => {
       const methods = ["GET", "PUT", "DELETE", "PATCH"] as const;
 
       for (const method of methods) {

--- a/front/pages/api/w/[wId]/members/search.test.ts
+++ b/front/pages/api/w/[wId]/members/search.test.ts
@@ -1,16 +1,15 @@
-import { describe, expect } from "vitest";
+import { describe, expect, it } from "vitest";
 
 import { MAX_SEARCH_EMAILS } from "@app/lib/memberships";
 import { createPrivateApiMockRequest } from "@app/tests/utils/generic_private_api_tests";
 import { MembershipFactory } from "@app/tests/utils/MembershipFactory";
 import { UserFactory } from "@app/tests/utils/UserFactory";
-import { itInTransaction } from "@app/tests/utils/utils";
 
 import handler from "./search";
 
 describe("GET /api/w/[wId]/members/search", () => {
   // We need search to work for all users as they can be added as editors of an agent by anyone.
-  itInTransaction("allows users to search members", async () => {
+  it("allows users to search members", async () => {
     const { req, res, user } = await createPrivateApiMockRequest({
       method: "GET",
       role: "user",
@@ -27,7 +26,7 @@ describe("GET /api/w/[wId]/members/search", () => {
     expect(data.members[0].workspace.role).toBe("user");
   });
 
-  itInTransaction("returns 405 for non-GET methods", async () => {
+  it("returns 405 for non-GET methods", async () => {
     for (const method of ["POST", "PUT", "DELETE"] as const) {
       const { req, res } = await createPrivateApiMockRequest({
         method,
@@ -46,7 +45,7 @@ describe("GET /api/w/[wId]/members/search", () => {
     }
   });
 
-  itInTransaction("handles search by term", async () => {
+  it("handles search by term", async () => {
     const { req, res, workspace } = await createPrivateApiMockRequest({
       method: "GET",
       role: "admin",
@@ -76,7 +75,7 @@ describe("GET /api/w/[wId]/members/search", () => {
     expect(data.members[0].id).toBe(users[0].id);
   });
 
-  itInTransaction("handles search by emails", async () => {
+  it("handles search by emails", async () => {
     const { req, res, workspace } = await createPrivateApiMockRequest({
       method: "GET",
       role: "admin",
@@ -106,7 +105,7 @@ describe("GET /api/w/[wId]/members/search", () => {
     expect(data.members.map((m: any) => m.email)).toContain(users[1].email);
   });
 
-  itInTransaction("returns 400 when too many emails provided", async () => {
+  it("returns 400 when too many emails provided", async () => {
     const { req, res } = await createPrivateApiMockRequest({
       method: "GET",
       role: "admin",
@@ -131,7 +130,7 @@ describe("GET /api/w/[wId]/members/search", () => {
     });
   });
 
-  itInTransaction("handles pagination with search results", async () => {
+  it("handles pagination with search results", async () => {
     const { req, res, workspace } = await createPrivateApiMockRequest({
       method: "GET",
       role: "admin",
@@ -161,7 +160,7 @@ describe("GET /api/w/[wId]/members/search", () => {
     expect(data.members).toHaveLength(20);
   });
 
-  itInTransaction("handles empty search results", async () => {
+  it("handles empty search results", async () => {
     const { req, res } = await createPrivateApiMockRequest({
       method: "GET",
       role: "admin",

--- a/front/pages/api/w/[wId]/spaces/[spaceId]/data_source_views/[dsvId]/tables/search.test.ts
+++ b/front/pages/api/w/[wId]/spaces/[spaceId]/data_source_views/[dsvId]/tables/search.test.ts
@@ -1,9 +1,8 @@
-import { describe, expect, vi } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 
 import { DataSourceViewFactory } from "@app/tests/utils/DataSourceViewFactory";
 import { createPrivateApiMockRequest } from "@app/tests/utils/generic_private_api_tests";
 import { SpaceFactory } from "@app/tests/utils/SpaceFactory";
-import { itInTransaction } from "@app/tests/utils/utils";
 
 import handler from "./search";
 
@@ -111,18 +110,14 @@ vi.mock(
 );
 
 describe("GET /api/w/[wId]/spaces/[spaceId]/data_source_views/[dsvId]/tables/search", () => {
-  itInTransaction("blocks non-GET methods", async (t) => {
+  it("blocks non-GET methods", async () => {
     const { req, res, workspace } = await createPrivateApiMockRequest({
       method: "POST",
       role: "admin",
     });
 
-    const space = await SpaceFactory.global(workspace, t);
-    const dataSourceView = await DataSourceViewFactory.folder(
-      workspace,
-      space,
-      t
-    );
+    const space = await SpaceFactory.global(workspace);
+    const dataSourceView = await DataSourceViewFactory.folder(workspace, space);
 
     req.query = {
       ...req.query,
@@ -135,18 +130,14 @@ describe("GET /api/w/[wId]/spaces/[spaceId]/data_source_views/[dsvId]/tables/sea
     expect(res._getStatusCode()).toBe(405);
   });
 
-  itInTransaction("requires minimum query length", async (t) => {
+  it("requires minimum query length", async () => {
     const { req, res, workspace } = await createPrivateApiMockRequest({
       method: "GET",
       role: "admin",
     });
 
-    const space = await SpaceFactory.global(workspace, t);
-    const dataSourceView = await DataSourceViewFactory.folder(
-      workspace,
-      space,
-      t
-    );
+    const space = await SpaceFactory.global(workspace);
+    const dataSourceView = await DataSourceViewFactory.folder(workspace, space);
 
     req.query = {
       ...req.query,
@@ -159,18 +150,14 @@ describe("GET /api/w/[wId]/spaces/[spaceId]/data_source_views/[dsvId]/tables/sea
     expect(res._getStatusCode()).toBe(400);
   });
 
-  itInTransaction("returns tables with search results", async (t) => {
+  it("returns tables with search results", async () => {
     const { req, res, workspace } = await createPrivateApiMockRequest({
       method: "GET",
       role: "admin",
     });
 
-    const space = await SpaceFactory.global(workspace, t);
-    const dataSourceView = await DataSourceViewFactory.folder(
-      workspace,
-      space,
-      t
-    );
+    const space = await SpaceFactory.global(workspace);
+    const dataSourceView = await DataSourceViewFactory.folder(workspace, space);
 
     req.query = {
       ...req.query,
@@ -186,18 +173,14 @@ describe("GET /api/w/[wId]/spaces/[spaceId]/data_source_views/[dsvId]/tables/sea
     true; // Skip for now, I have trouble mocking correctly the CoreAPI.searchNodes
   });
 
-  itInTransaction("handles empty results", async (t) => {
+  it("handles empty results", async () => {
     const { req, res, workspace } = await createPrivateApiMockRequest({
       method: "GET",
       role: "admin",
     });
 
-    const space = await SpaceFactory.global(workspace, t);
-    const dataSourceView = await DataSourceViewFactory.folder(
-      workspace,
-      space,
-      t
-    );
+    const space = await SpaceFactory.global(workspace);
+    const dataSourceView = await DataSourceViewFactory.folder(workspace, space);
 
     req.query = {
       ...req.query,
@@ -210,18 +193,14 @@ describe("GET /api/w/[wId]/spaces/[spaceId]/data_source_views/[dsvId]/tables/sea
     true; // Skip for now, I have trouble mocking correctly the CoreAPI.searchNodes
   });
 
-  itInTransaction("propagates warnings", async (t) => {
+  it("propagates warnings", async () => {
     const { req, res, workspace } = await createPrivateApiMockRequest({
       method: "GET",
       role: "admin",
     });
 
-    const space = await SpaceFactory.global(workspace, t);
-    const dataSourceView = await DataSourceViewFactory.folder(
-      workspace,
-      space,
-      t
-    );
+    const space = await SpaceFactory.global(workspace);
+    const dataSourceView = await DataSourceViewFactory.folder(workspace, space);
 
     req.query = {
       ...req.query,

--- a/front/pages/api/w/[wId]/spaces/[spaceId]/mcp/available.test.ts
+++ b/front/pages/api/w/[wId]/spaces/[spaceId]/mcp/available.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect } from "vitest";
+import { describe, expect, it } from "vitest";
 
 import { INTERNAL_MCP_SERVERS } from "@app/lib/actions/mcp_internal_actions/constants";
 import { Authenticator } from "@app/lib/auth";
@@ -9,7 +9,6 @@ import { GroupSpaceFactory } from "@app/tests/utils/GroupSpaceFactory";
 import { MCPServerViewFactory } from "@app/tests/utils/MCPServerViewFactory";
 import { RemoteMCPServerFactory } from "@app/tests/utils/RemoteMCPServerFactory";
 import { SpaceFactory } from "@app/tests/utils/SpaceFactory";
-import { itInTransaction } from "@app/tests/utils/utils";
 import { WorkspaceFactory } from "@app/tests/utils/WorkspaceFactory";
 import type { WhitelistableFeature } from "@app/types";
 import type { PlanType } from "@app/types";
@@ -17,7 +16,7 @@ import type { PlanType } from "@app/types";
 import handler from "./available";
 
 describe("GET /api/w/[wId]/spaces/[spaceId]/mcp/available", () => {
-  itInTransaction("returns available servers for regular user", async (t) => {
+  it("returns available servers for regular user", async () => {
     // Create mock request
     const { req, res, workspace, globalGroup } =
       await createPrivateApiMockRequest({
@@ -25,9 +24,9 @@ describe("GET /api/w/[wId]/spaces/[spaceId]/mcp/available", () => {
         role: "user",
       });
     // Create workspace and space
-    const space = await SpaceFactory.regular(workspace, t);
+    const space = await SpaceFactory.regular(workspace);
     await GroupSpaceFactory.associate(space, globalGroup);
-    await SpaceFactory.system(workspace, t);
+    await SpaceFactory.system(workspace);
 
     // Get auth
     const auth = await Authenticator.internalAdminForWorkspace(workspace.sId);
@@ -62,8 +61,7 @@ describe("GET /api/w/[wId]/spaces/[spaceId]/mcp/available", () => {
       {
         name: "primitive_types_debugger",
         useCase: null,
-      },
-      t
+      }
     );
 
     const remoteServer = await RemoteMCPServerFactory.create(workspace);
@@ -73,7 +71,7 @@ describe("GET /api/w/[wId]/spaces/[spaceId]/mcp/available", () => {
 
     // Create another server in another workspace
     const workspace2 = await WorkspaceFactory.basic();
-    await SpaceFactory.system(workspace2, t);
+    await SpaceFactory.system(workspace2);
     await RemoteMCPServerFactory.create(workspace2);
 
     // Add query params

--- a/front/pages/api/w/[wId]/spaces/[spaceId]/mcp_views/index.test.ts
+++ b/front/pages/api/w/[wId]/spaces/[spaceId]/mcp_views/index.test.ts
@@ -1,19 +1,18 @@
-import { describe, expect } from "vitest";
+import { describe, expect, it } from "vitest";
 
 import { createPrivateApiMockRequest } from "@app/tests/utils/generic_private_api_tests";
 import { SpaceFactory } from "@app/tests/utils/SpaceFactory";
-import { itInTransaction } from "@app/tests/utils/utils";
 
 import handler from "./index";
 
 describe("GET /api/w/[wId]/spaces/[spaceId]/mcp_views", () => {
-  itInTransaction("returns MCP servers views", async (t) => {
+  it("returns MCP servers views", async () => {
     const { req, res, workspace } = await createPrivateApiMockRequest({
       role: "admin",
     });
 
     // Create a system space
-    const systemSpace = await SpaceFactory.system(workspace, t);
+    const systemSpace = await SpaceFactory.system(workspace);
     req.query.spaceId = systemSpace.sId;
 
     await handler(req, res);

--- a/front/pages/api/w/[wId]/spaces/[spaceId]/mcp_views/not_activated.test.ts
+++ b/front/pages/api/w/[wId]/spaces/[spaceId]/mcp_views/not_activated.test.ts
@@ -1,30 +1,29 @@
-import { describe, expect } from "vitest";
+import { describe, expect, it } from "vitest";
 
 import { createPrivateApiMockRequest } from "@app/tests/utils/generic_private_api_tests";
 import { GroupSpaceFactory } from "@app/tests/utils/GroupSpaceFactory";
 import { MCPServerViewFactory } from "@app/tests/utils/MCPServerViewFactory";
 import { RemoteMCPServerFactory } from "@app/tests/utils/RemoteMCPServerFactory";
 import { SpaceFactory } from "@app/tests/utils/SpaceFactory";
-import { itInTransaction } from "@app/tests/utils/utils";
 
 import handler from "./not_activated";
 
 describe("GET /api/w/[wId]/spaces/[spaceId]/mcp_views/not_activated", () => {
-  itInTransaction("returns activable MCP servers views", async (t) => {
+  it("returns activable MCP servers views", async () => {
     const { req, res, workspace, globalGroup } =
       await createPrivateApiMockRequest({
         role: "admin",
       });
 
     // Create a system space
-    const systemSpace = await SpaceFactory.system(workspace, t);
+    const systemSpace = await SpaceFactory.system(workspace);
     req.query.spaceId = systemSpace.sId;
 
     // Create global space
-    const globalSpace = await SpaceFactory.global(workspace, t);
+    const globalSpace = await SpaceFactory.global(workspace);
 
     // Create a regular space to test the endpoint on
-    const space = await SpaceFactory.regular(workspace, t);
+    const space = await SpaceFactory.regular(workspace);
     await GroupSpaceFactory.associate(space, globalGroup);
 
     // Create two test servers

--- a/front/pages/api/w/[wId]/subscriptions/index.test.ts
+++ b/front/pages/api/w/[wId]/subscriptions/index.test.ts
@@ -1,8 +1,7 @@
 import type { Stripe } from "stripe";
-import { beforeEach, describe, expect, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import { createPrivateApiMockRequest } from "@app/tests/utils/generic_private_api_tests";
-import { itInTransaction } from "@app/tests/utils/utils";
 
 import handler from "./index";
 
@@ -27,7 +26,7 @@ describe("POST /api/w/[wId]/subscriptions", () => {
     vi.clearAllMocks();
   });
 
-  itInTransaction("returns 400 on invalid request body", async () => {
+  it("returns 400 on invalid request body", async () => {
     const { req, res } = await createPrivateApiMockRequest({
       method: "POST",
       role: "admin",
@@ -43,39 +42,36 @@ describe("POST /api/w/[wId]/subscriptions", () => {
     expect(res._getJSONData().error.type).toBe("invalid_request_error");
   });
 
-  itInTransaction(
-    "returns checkoutUrl and plan details for new subscription",
-    async () => {
-      const { req, res } = await createPrivateApiMockRequest({
-        method: "POST",
-        role: "admin",
-      });
+  it("returns checkoutUrl and plan details for new subscription", async () => {
+    const { req, res } = await createPrivateApiMockRequest({
+      method: "POST",
+      role: "admin",
+    });
 
-      req.body = {
-        billingPeriod: "monthly",
-      };
+    req.body = {
+      billingPeriod: "monthly",
+    };
 
-      await handler(req, res);
+    await handler(req, res);
 
-      expect(res._getStatusCode()).toBe(200);
-      const data = res._getJSONData();
-      expect(data.checkoutUrl).toEqual(TEST_CHECKOUT_URL);
-      expect(data.plan).toEqual(
-        expect.objectContaining({
-          code: expect.any(String),
-          name: expect.any(String),
-          limits: expect.objectContaining({
-            users: expect.objectContaining({
-              maxUsers: expect.any(Number),
-            }),
-            dataSources: expect.any(Object),
+    expect(res._getStatusCode()).toBe(200);
+    const data = res._getJSONData();
+    expect(data.checkoutUrl).toEqual(TEST_CHECKOUT_URL);
+    expect(data.plan).toEqual(
+      expect.objectContaining({
+        code: expect.any(String),
+        name: expect.any(String),
+        limits: expect.objectContaining({
+          users: expect.objectContaining({
+            maxUsers: expect.any(Number),
           }),
-        })
-      );
-    }
-  );
+          dataSources: expect.any(Object),
+        }),
+      })
+    );
+  });
 
-  itInTransaction("handles yearly billing period", async () => {
+  it("handles yearly billing period", async () => {
     const { req, res } = await createPrivateApiMockRequest({
       method: "POST",
       role: "admin",
@@ -93,7 +89,7 @@ describe("POST /api/w/[wId]/subscriptions", () => {
     expect(data.plan).toBeDefined();
   });
 
-  itInTransaction("returns 403 when user is not admin", async () => {
+  it("returns 403 when user is not admin", async () => {
     const { req, res } = await createPrivateApiMockRequest({
       method: "POST",
       role: "user",

--- a/front/pages/api/w/[wId]/tags/[tId]/index.test.ts
+++ b/front/pages/api/w/[wId]/tags/[tId]/index.test.ts
@@ -1,10 +1,9 @@
-import { afterEach, describe, expect, vi } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 
 import { Authenticator } from "@app/lib/auth";
 import { TagResource } from "@app/lib/resources/tags_resource";
 import { createPrivateApiMockRequest } from "@app/tests/utils/generic_private_api_tests";
 import { TagFactory } from "@app/tests/utils/TagFactory";
-import { itInTransaction } from "@app/tests/utils/utils";
 
 import handler from "./index";
 
@@ -13,7 +12,7 @@ describe("DELETE /api/w/[wId]/tags/[tId]", () => {
     vi.clearAllMocks();
   });
 
-  itInTransaction("should not delete a tag if user is not admin", async () => {
+  it("should not delete a tag if user is not admin", async () => {
     const { req, res, workspace } = await createPrivateApiMockRequest({
       method: "DELETE",
     });
@@ -31,7 +30,7 @@ describe("DELETE /api/w/[wId]/tags/[tId]", () => {
     });
   });
 
-  itInTransaction("should delete a tag", async () => {
+  it("should delete a tag", async () => {
     const { req, res, workspace } = await createPrivateApiMockRequest({
       method: "DELETE",
       role: "admin",
@@ -50,7 +49,7 @@ describe("DELETE /api/w/[wId]/tags/[tId]", () => {
     expect(deletedTag).toBeNull();
   });
 
-  itInTransaction("should return 404 if tag not found", async () => {
+  it("should return 404 if tag not found", async () => {
     const { req, res } = await createPrivateApiMockRequest({
       method: "DELETE",
       role: "admin",

--- a/front/pages/api/w/[wId]/tags/index.test.ts
+++ b/front/pages/api/w/[wId]/tags/index.test.ts
@@ -1,14 +1,12 @@
 import type { RequestMethod } from "node-mocks-http";
-import { describe, expect } from "vitest";
+import { describe, expect, it } from "vitest";
 
 import { createPrivateApiMockRequest } from "@app/tests/utils/generic_private_api_tests";
 import { TagFactory } from "@app/tests/utils/TagFactory";
-import { itInTransaction } from "@app/tests/utils/utils";
 
 import handler from "./index";
 
 async function setupTest(
-  t: any,
   role: "builder" | "user" | "admin" = "admin",
   method: RequestMethod = "GET"
 ) {
@@ -24,8 +22,8 @@ async function setupTest(
 }
 
 describe("GET /api/w/[wId]/tags/", () => {
-  itInTransaction("should return a list of tags", async (t) => {
-    const { req, res, workspace } = await setupTest(t);
+  it("should return a list of tags", async () => {
+    const { req, res, workspace } = await setupTest();
 
     // Create two test tags
     await TagFactory.create(workspace, {
@@ -45,8 +43,8 @@ describe("GET /api/w/[wId]/tags/", () => {
     expect(responseData.tags).toHaveLength(2);
   });
 
-  itInTransaction("should return empty array when no tags exist", async (t) => {
-    const { req, res } = await setupTest(t);
+  it("should return empty array when no tags exist", async () => {
+    const { req, res } = await setupTest();
 
     await handler(req, res);
 
@@ -60,8 +58,8 @@ describe("GET /api/w/[wId]/tags/", () => {
 });
 
 describe("POST /api/w/[wId]/tags/", () => {
-  itInTransaction("should return 400 when name is missing", async (t) => {
-    const { req, res } = await setupTest(t, "admin", "POST");
+  it("should return 400 when name is missing", async () => {
+    const { req, res } = await setupTest("admin", "POST");
 
     req.body = {};
 
@@ -76,32 +74,29 @@ describe("POST /api/w/[wId]/tags/", () => {
     });
   });
 
-  itInTransaction(
-    "should return 400 when tag with name already exists",
-    async (t) => {
-      const { req, res, workspace } = await setupTest(t, "admin", "POST");
+  it("should return 400 when tag with name already exists", async () => {
+    const { req, res, workspace } = await setupTest("admin", "POST");
 
-      const existingName = "Existing Tag";
-      await TagFactory.create(workspace, {
-        name: existingName,
-      });
+    const existingName = "Existing Tag";
+    await TagFactory.create(workspace, {
+      name: existingName,
+    });
 
-      req.body = { name: existingName };
+    req.body = { name: existingName };
 
-      await handler(req, res);
+    await handler(req, res);
 
-      expect(res._getStatusCode()).toBe(400);
-      expect(res._getJSONData()).toEqual({
-        error: {
-          type: "invalid_request_error",
-          message: "A tag with this name already exists",
-        },
-      });
-    }
-  );
+    expect(res._getStatusCode()).toBe(400);
+    expect(res._getJSONData()).toEqual({
+      error: {
+        type: "invalid_request_error",
+        message: "A tag with this name already exists",
+      },
+    });
+  });
 
-  itInTransaction("should create a new tag successfully", async (t) => {
-    const { req, res } = await setupTest(t, "admin", "POST");
+  it("should create a new tag successfully", async () => {
+    const { req, res } = await setupTest("admin", "POST");
 
     const tagName = "New Test Tag";
     req.body = { name: tagName };
@@ -116,9 +111,9 @@ describe("POST /api/w/[wId]/tags/", () => {
 });
 
 describe("Method Support /api/w/[wId]/tags", () => {
-  itInTransaction("only supports GET and POST methods", async (t) => {
+  it("only supports GET and POST methods", async () => {
     for (const method of ["DELETE", "PUT", "PATCH"] as const) {
-      const { req, res } = await setupTest(t, "admin", method);
+      const { req, res } = await setupTest("admin", method);
 
       await handler(req, res);
 

--- a/front/scripts/rotate_dust_api_key.ts
+++ b/front/scripts/rotate_dust_api_key.ts
@@ -4,6 +4,7 @@ import config from "@app/lib/production_checks/config";
 import { KeyResource } from "@app/lib/resources/key_resource";
 import { frontSequelize } from "@app/lib/resources/storage";
 import { WorkspaceResource } from "@app/lib/resources/workspace_resource";
+import { withTransaction } from "@app/lib/utils/sql_utils";
 import { renderLightWorkspaceType } from "@app/lib/workspace";
 import { makeScript } from "@app/scripts/helpers";
 
@@ -85,7 +86,7 @@ makeScript(
 
     // Using transactions to ensure that we don't end up with a key that is not in sync between the
     // front and connectors databases. Explicitly aborting both transactions if an error occurs.
-    await frontSequelize.transaction(async (frontTransaction) => {
+    await withTransaction(async (frontTransaction) => {
       await connectorsDb.transaction(async (connectorsTransaction) => {
         try {
           const [affectedCount] = await keyToRotate.rotateSecret(

--- a/front/temporal/relocation/activities/destination_region/front/sql.ts
+++ b/front/temporal/relocation/activities/destination_region/front/sql.ts
@@ -3,6 +3,7 @@ import { QueryTypes } from "sequelize";
 
 import type { RegionType } from "@app/lib/api/regions/config";
 import { frontSequelize } from "@app/lib/resources/storage";
+import { withTransaction } from "@app/lib/utils/sql_utils";
 import logger from "@app/logger/logger";
 import type {
   CoreEntitiesRelocationBlob,
@@ -47,7 +48,7 @@ export async function writeCoreEntitiesToDestinationRegion({
 
   // 2) Create users in transaction.
   for (const { sql, params } of blob.statements.users) {
-    await frontSequelize.transaction(async (transaction) => {
+    await withTransaction(async (transaction) => {
       await frontSequelize.query(sql, {
         bind: params,
         type: QueryTypes.INSERT,
@@ -58,7 +59,7 @@ export async function writeCoreEntitiesToDestinationRegion({
 
   // 3) Create users metadata in transaction.
   for (const { sql, params } of blob.statements.user_metadata) {
-    await frontSequelize.transaction(async (transaction) => {
+    await withTransaction(async (transaction) => {
       await frontSequelize.query(sql, {
         bind: params,
         type: QueryTypes.INSERT,
@@ -69,7 +70,7 @@ export async function writeCoreEntitiesToDestinationRegion({
 
   // 4) Create plans that the workspace uses if not already existing.
   for (const { sql, params } of blob.statements.plans) {
-    await frontSequelize.transaction(async (transaction) => {
+    await withTransaction(async (transaction) => {
       await frontSequelize.query(sql, {
         bind: params,
         type: QueryTypes.INSERT,
@@ -130,7 +131,7 @@ export async function processFrontTableChunk({
     );
 
     for (const { sql, params } of statements) {
-      await frontSequelize.transaction(async (transaction) =>
+      await withTransaction(async (transaction) =>
         frontSequelize.query(sql, {
           bind: params,
           type: QueryTypes.INSERT,

--- a/front/tests/utils/AgentConfigurationFactory.ts
+++ b/front/tests/utils/AgentConfigurationFactory.ts
@@ -1,5 +1,4 @@
 import assert from "assert";
-import type { Transaction } from "sequelize";
 
 import { createAgentConfiguration } from "@app/lib/api/assistant/configuration/agent";
 import type { Authenticator } from "@app/lib/auth";
@@ -12,7 +11,6 @@ import type {
 export class AgentConfigurationFactory {
   static async createTestAgent(
     auth: Authenticator,
-    t?: Transaction,
     overrides: Partial<{
       name: string;
       description: string;
@@ -34,28 +32,24 @@ export class AgentConfigurationFactory {
     const user = auth.user();
     assert(user, "User is required");
 
-    const result = await createAgentConfiguration(
-      auth,
-      {
-        name,
-        description,
-        instructions: "Test Instructions",
-        visualizationEnabled: false,
-        pictureUrl: "https://dust.tt/static/systemavatar/test_avatar_1.png",
-        status: "active",
-        scope,
-        model: {
-          providerId,
-          modelId,
-          temperature,
-        },
-        templateId: null,
-        requestedGroupIds: [], // Let createAgentConfiguration handle group creation
-        tags: [], // Added missing tags property
-        editors: [user.toJSON()],
+    const result = await createAgentConfiguration(auth, {
+      name,
+      description,
+      instructions: "Test Instructions",
+      visualizationEnabled: false,
+      pictureUrl: "https://dust.tt/static/systemavatar/test_avatar_1.png",
+      status: "active",
+      scope,
+      model: {
+        providerId,
+        modelId,
+        temperature,
       },
-      t
-    );
+      templateId: null,
+      requestedGroupIds: [], // Let createAgentConfiguration handle group creation
+      tags: [], // Added missing tags property
+      editors: [user.toJSON()],
+    });
 
     if (result.isErr()) {
       throw result.error;

--- a/front/tests/utils/AgentMCPServerConfigurationFactory.ts
+++ b/front/tests/utils/AgentMCPServerConfigurationFactory.ts
@@ -11,37 +11,32 @@ import { MCPServerViewFactory } from "@app/tests/utils/MCPServerViewFactory";
 export class AgentMCPServerConfigurationFactory {
   static async create(
     auth: Authenticator,
-    space: SpaceResource,
-    t: Transaction
+    space: SpaceResource
   ): Promise<AgentMCPServerConfiguration> {
     const owner = auth.getNonNullableWorkspace();
 
-    const agent = await AgentConfigurationFactory.createTestAgent(auth, t);
+    const agent = await AgentConfigurationFactory.createTestAgent(auth);
     const mcpServerView = await MCPServerViewFactory.create(
       owner,
       internalMCPServerNameToSId({
         name: "search",
         workspaceId: owner.id,
       }),
-      space,
-      t
+      space
     );
 
-    return AgentMCPServerConfiguration.create(
-      {
-        sId: generateRandomModelSId(),
-        agentConfigurationId: agent.id,
-        workspaceId: owner.id,
-        mcpServerViewId: mcpServerView.id,
-        internalMCPServerId: "internal_mcp_server_id",
-        additionalConfiguration: {},
-        timeFrame: null,
-        jsonSchema: null,
-        name: null,
-        singleToolDescriptionOverride: null,
-        appId: null,
-      },
-      { transaction: t }
-    );
+    return AgentMCPServerConfiguration.create({
+      sId: generateRandomModelSId(),
+      agentConfigurationId: agent.id,
+      workspaceId: owner.id,
+      mcpServerViewId: mcpServerView.id,
+      internalMCPServerId: "internal_mcp_server_id",
+      additionalConfiguration: {},
+      timeFrame: null,
+      jsonSchema: null,
+      name: null,
+      singleToolDescriptionOverride: null,
+      appId: null,
+    });
   }
 }

--- a/front/tests/utils/DataSourceViewFactory.ts
+++ b/front/tests/utils/DataSourceViewFactory.ts
@@ -1,5 +1,4 @@
 import { faker } from "@faker-js/faker";
-import type { Transaction } from "sequelize";
 
 import { DataSourceViewResource } from "@app/lib/resources/data_source_view_resource";
 import type { SpaceResource } from "@app/lib/resources/space_resource";
@@ -10,7 +9,6 @@ export class DataSourceViewFactory {
   static async folder(
     workspace: WorkspaceType,
     space: SpaceResource,
-    t: Transaction,
     editedByUser?: UserResource | null
   ) {
     return DataSourceViewResource.createDataSourceAndDefaultView(
@@ -23,8 +21,7 @@ export class DataSourceViewFactory {
         workspaceId: workspace.id,
       },
       space,
-      editedByUser,
-      t
+      editedByUser
     );
   }
 }

--- a/front/tests/utils/SpaceFactory.ts
+++ b/front/tests/utils/SpaceFactory.ts
@@ -6,40 +6,35 @@ import { SpaceResource } from "@app/lib/resources/space_resource";
 import type { WorkspaceType } from "@app/types";
 
 export class SpaceFactory {
-  static async global(workspace: WorkspaceType, t: Transaction) {
+  static async global(workspace: WorkspaceType) {
     return SpaceResource.makeNew(
       {
         name: "space " + faker.string.alphanumeric(8),
         kind: "global",
         workspaceId: workspace.id,
       },
-      [], // TODO: Add groups
-      t
+      [] // TODO: Add groups
     );
   }
 
-  static async system(workspace: WorkspaceType, t: Transaction) {
+  static async system(workspace: WorkspaceType) {
     return SpaceResource.makeNew(
       {
         name: "space " + faker.string.alphanumeric(8),
         kind: "system",
         workspaceId: workspace.id,
       },
-      [], // TODO: Add groups
-      t
+      [] // TODO: Add groups
     );
   }
 
-  static async regular(workspace: WorkspaceType, t: Transaction) {
+  static async regular(workspace: WorkspaceType) {
     const name = "space " + faker.string.alphanumeric(8);
-    const group = await GroupResource.makeNew(
-      {
-        name: `Group for space ${name}`,
-        workspaceId: workspace.id,
-        kind: "regular",
-      },
-      { transaction: t }
-    );
+    const group = await GroupResource.makeNew({
+      name: `Group for space ${name}`,
+      workspaceId: workspace.id,
+      kind: "regular",
+    });
 
     return SpaceResource.makeNew(
       {
@@ -47,20 +42,18 @@ export class SpaceFactory {
         kind: "regular",
         workspaceId: workspace.id,
       },
-      [group],
-      t
+      [group]
     );
   }
 
-  static async conversations(workspace: WorkspaceType, t: Transaction) {
+  static async conversations(workspace: WorkspaceType) {
     return SpaceResource.makeNew(
       {
         name: "space " + faker.string.alphanumeric(8),
         kind: "conversations",
         workspaceId: workspace.id,
       },
-      [],
-      t
+      []
     );
   }
 }

--- a/front/tests/utils/WorkspaceFactory.ts
+++ b/front/tests/utils/WorkspaceFactory.ts
@@ -1,4 +1,5 @@
 import { faker } from "@faker-js/faker";
+import { expect } from "vitest";
 
 import { Plan, Subscription } from "@app/lib/models/plan";
 import { PRO_PLAN_SEAT_29_CODE } from "@app/lib/plans/plan_codes";
@@ -14,7 +15,7 @@ export class WorkspaceFactory {
     const workspace = await WorkspaceModel.create({
       sId: generateRandomModelSId(),
       name: faker.company.name(),
-      description: faker.company.catchPhrase(),
+      description: `[DEBUG] Created for the test: ${expect.getState().currentTestName}\n\n${faker.company.catchPhrase()}`,
       workOSOrganizationId: faker.string.alpha(10),
     });
 

--- a/front/tests/utils/utils.ts
+++ b/front/tests/utils/utils.ts
@@ -1,29 +1,4 @@
-import type { Transaction } from "sequelize";
-import { expect, it } from "vitest";
-
-import { frontSequelize } from "@app/lib/resources/storage";
-
-export const itInTransaction = function (
-  title: string,
-  fn: (t: Transaction) => Promise<void>,
-  skip: boolean = false
-) {
-  return it.skipIf(skip)(title, async function () {
-    try {
-      await frontSequelize.transaction(async (t) => {
-        await fn(t);
-        throw "Rollback"; // Force rollback after successful execution
-      });
-    } catch (err) {
-      if (err === "Rollback") {
-        return;
-      }
-      console.log("Error in test:");
-      console.log(err);
-      throw err;
-    }
-  });
-};
+import { expect } from "vitest";
 
 export const expectArrayOfObjectsWithSpecificLength = (
   value: any,

--- a/front/vite.config.mjs
+++ b/front/vite.config.mjs
@@ -9,6 +9,15 @@ export default defineConfig({
     environment: "jsdom",
     setupFiles: "./vite.setup.ts",
     globalSetup: "./vite.globalSetup.ts",
+
+    // We uses forks instead of threads to isolate tests in separate processes that can rely on CLS for transactions isolation.
+    pool: "forks",
+    poolOptions: {
+      forks: {
+        singleFork: false, // Use multiple forks for parallelism
+        isolate: true, // Each test file gets its own process
+      },
+    },
   },
   resolve: {
     alias: {

--- a/front/vite.setup.ts
+++ b/front/vite.setup.ts
@@ -2,12 +2,39 @@ import "@testing-library/jest-dom/vitest";
 import "vitest-canvas-mock";
 
 import { cleanup } from "@testing-library/react";
+import { default as cls } from "cls-hooked";
+import { Sequelize } from "sequelize";
 import { afterEach, beforeEach, vi } from "vitest";
 
-beforeEach(() => {
+import { frontSequelize } from "@app/lib/resources/storage";
+
+beforeEach(async (c) => {
   vi.clearAllMocks();
+  const namespace = cls.createNamespace("test-namespace");
+
+  // We use CLS to create a namespace and a transaction to isolate each test.
+  // See https://github.com/sequelize/sequelize/issues/11408#issuecomment-563962996
+  // And https://sequelize.org/docs/v6/other-topics/transactions/#automatically-pass-transactions-to-all-queries
+  Sequelize.useCLS(namespace);
+  const context = namespace.createContext();
+  namespace.enter(context);
+  const transaction = await frontSequelize.transaction({
+    autocommit: false,
+  });
+  namespace.set("transaction", transaction);
+
+  // @ts-expect-error - storing context in the test context
+  c["namespace"] = namespace;
+  // @ts-expect-error - storing context in the test context
+  c["context"] = context;
+  // @ts-expect-error - storing context in the test context
+  c["transaction"] = transaction;
 });
 
-afterEach(() => {
+afterEach(async (c2) => {
+  // @ts-expect-error - storing context in the test context
+  c2["transaction"].rollback();
+  // @ts-expect-error - storing context in the test context
+  c2["namespace"].exit(c2["context"]);
   cleanup();
 });


### PR DESCRIPTION
## Description

Simplify and strenghten our tests isolation system.

### withTransaction()

086f3868720853189e30d4e9579023b319961efa A wrapper that will leverage the current transaction from test context (cls) if possible otherwise create a new transaction to replace manual `frontSequelize.transaction(() => {})` calls.

### Improve transaction in tests.

60bd5ee7a014a41f168fcc3b15699fd54d5d5cf0 Instead of using a custom itInTransaction method, now we create the transaction in a global beforeEach and roll it back in a global afterEach.
So now every test is wrapped in the transaction without beeing explicit about it.
And beforeXXX and afterXXX are run within the transaction too.
Removed all custom `itInTransaction` and transactions passed around in test.

## Tests

Green + checked that nothing remained in the DB after the tests are run.

## Risk

Low as it should be 1-1 in the production code everything else is tests code.

## Deploy Plan

Deploy `front`