### PR TITLE
[front] change input radius

### DIFF
--- a/front/components/assistant/conversation/input_bar/InputBar.tsx
+++ b/front/components/assistant/conversation/input_bar/InputBar.tsx
@@ -328,7 +328,7 @@ export function AssistantInputBar({
           <div
             className={classNames(
               "relative flex w-full flex-1 flex-col items-stretch gap-0 self-stretch pl-3 sm:flex-row",
-              "rounded-3xl transition-all",
+              "rounded-2xl transition-all",
               "bg-muted-background dark:bg-muted-background-night",
               "border",
               "border-border-dark dark:border-border-dark-night",


### PR DESCRIPTION
## Description
My daily challenge of improving the conversation UI #3, changing the corner radius of input bar from 3xl to 2xl. I would like to also change the conversation title height but that requires a bit more refactoring I expected so will do it separately 🙏

before:
<img width="842" height="146" alt="Screenshot 2025-08-05 at 11 25 44" src="https://github.com/user-attachments/assets/ff2eed0e-8c3a-4e54-a4ca-bdb6ac2d6516" />


after:
<img width="845" height="146" alt="Screenshot 2025-08-05 at 11 25 55" src="https://github.com/user-attachments/assets/f57fddee-a400-4481-bde4-824b1fe47370" />


<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
