### PR TITLE
[front] - fix(DataSourceViewResource): hardDelete method

### DIFF
--- a/front/lib/resources/data_source_view_resource.ts
+++ b/front/lib/resources/data_source_view_resource.ts
@@ -671,19 +671,6 @@ export class DataSourceViewResource extends ResourceWithSpace<DataSourceViewMode
       )
     );
 
-    // Delete associated MCP server configurations.
-    if (mcpServerConfigurationIds.length > 0) {
-      await AgentMCPServerConfiguration.destroy({
-        where: {
-          id: {
-            [Op.in]: mcpServerConfigurationIds,
-          },
-          workspaceId,
-        },
-        transaction,
-      });
-    }
-
     await AgentDataSourceConfiguration.destroy({
       where: {
         dataSourceViewId: this.id,
@@ -699,6 +686,19 @@ export class DataSourceViewResource extends ResourceWithSpace<DataSourceViewMode
       },
       transaction,
     });
+
+    // Delete associated MCP server configurations.
+    if (mcpServerConfigurationIds.length > 0) {
+      await AgentMCPServerConfiguration.destroy({
+        where: {
+          id: {
+            [Op.in]: mcpServerConfigurationIds,
+          },
+          workspaceId,
+        },
+        transaction,
+      });
+    }
 
     const deletedCount = await DataSourceViewModel.destroy({
       where: {


### PR DESCRIPTION
## Description

 This PR shifted deletion of associated MCP server configurations to after `AgentDataSourceConfiguration` and `AgentDataSourceParameter` destruction. It ensures that the MCP server configurations are deleted within the same transaction for consistency and data integrity

We were hitting this error:
```
ForeignKeyConstraintError: update or delete on table "agent_mcp_server_configurations" violates foreign key constraint "agent_data_source_configurations_mcpServerConfigurationId_fkey" on table "agent_data_source_configurations"
```

## Risk

Low, `hardDelete` flow is already broken

## Deploy Plan

Deploy front