### PR TITLE
Remove route tagging from request metrics to reduce costs

### DIFF
--- a/front/logger/withlogging.ts
+++ b/front/logger/withlogging.ts
@@ -140,9 +140,10 @@ export function withLogging<T>(
 
     const elapsed = new Date().getTime() - now.getTime();
 
+    // Keep metric cardinality low for cost optimization
+    // Previously tagging by route created high cardinality (~$3k/month for 2 metrics)
     const tags = [
       `method:${req.method}`,
-      `route:${route}`,
       streaming ? `streaming:true` : `streaming:false`,
       `status_code:${res.statusCode}`,
     ];


### PR DESCRIPTION
## Description

After auditing `dust-infra`, no monitors are currently using the `route` tag from our StatsD metrics. Meanwhile, we have APM enabled which provides latency metrics at no additional cost.

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
