### PR TITLE
[front,connectors] enh(Zendesk): make brand ID optional in ticket check

### DIFF
--- a/connectors/src/connectors/zendesk/lib/cli.ts
+++ b/connectors/src/connectors/zendesk/lib/cli.ts
@@ -272,25 +272,27 @@ export const zendesk = async ({
       }
 
       const brandId = args.brandId ?? null;
-      if (!brandId) {
-        throw new Error(`Missing --brandId argument`);
-      }
       const ticketId = args.ticketId ?? null;
       if (!ticketId) {
         throw new Error(`Missing --ticketId argument`);
       }
-      const ticketOnDb = await ZendeskTicketResource.fetchByTicketId({
-        connectorId: connector.id,
-        brandId,
-        ticketId,
-      });
 
-      const brandSubdomain = await getZendeskBrandSubdomain({
-        connectorId: connector.id,
-        brandId,
-        subdomain,
-        accessToken,
-      });
+      let ticketOnDb = null;
+      let brandSubdomain = subdomain;
+
+      if (brandId) {
+        ticketOnDb = await ZendeskTicketResource.fetchByTicketId({
+          connectorId: connector.id,
+          brandId,
+          ticketId,
+        });
+        brandSubdomain = await getZendeskBrandSubdomain({
+          connectorId: connector.id,
+          brandId,
+          subdomain,
+          accessToken,
+        });
+      }
 
       const ticket = await fetchZendeskTicket({
         accessToken,
@@ -301,7 +303,7 @@ export const zendesk = async ({
       const shouldSyncTicket = await checkTicketShouldBeSynced(
         ticket,
         configuration,
-        { brandId, accessToken, brandSubdomain },
+        { brandId: brandId ?? undefined, accessToken, brandSubdomain },
         logger
       );
 

--- a/connectors/src/types/admin/cli.ts
+++ b/connectors/src/types/admin/cli.ts
@@ -694,7 +694,7 @@ export const ZendeskCommandSchema = t.type({
     wId: t.union([t.string, t.undefined]),
     dsId: t.union([t.string, t.undefined]),
     connectorId: t.union([t.number, t.undefined]),
-    brandId: t.union([t.number, t.undefined]),
+    brandId: t.union([t.number, t.null, t.undefined]),
     query: t.union([t.string, t.undefined]),
     forceResync: t.union([t.literal("true"), t.undefined]),
     ticketId: t.union([t.number, t.undefined]),

--- a/front/pages/poke/[wId]/data_sources/[dsId]/index.tsx
+++ b/front/pages/poke/[wId]/data_sources/[dsId]/index.tsx
@@ -758,7 +758,7 @@ async function handleCheckOrFindNotionUrl(
 
 async function handleCheckZendeskTicket(
   args:
-    | { brandId: number; ticketId: number; wId: string; dsId: string }
+    | { brandId: number | null; ticketId: number; wId: string; dsId: string }
     | { ticketUrl: string; wId: string; dsId: string }
 ): Promise<ZendeskFetchTicketResponseType | null> {
   const res = await fetch(`/api/poke/admin`, {
@@ -989,9 +989,9 @@ function ZendeskTicketCheck({
           variant="outline"
           icon={idsIsLoading ? Spinner : MagnifyingGlassIcon}
           label={idsIsLoading ? undefined : "Check"}
-          disabled={!ticketId || !brandId || idsIsLoading}
+          disabled={!ticketId || idsIsLoading}
           onClick={async () => {
-            if (brandId && ticketId) {
+            if (ticketId) {
               setIdsIsLoading(true);
               setTicketDetails(
                 await handleCheckZendeskTicket({

--- a/front/types/connectors/admin/cli.ts
+++ b/front/types/connectors/admin/cli.ts
@@ -694,7 +694,7 @@ export const ZendeskCommandSchema = t.type({
     wId: t.union([t.string, t.undefined]),
     dsId: t.union([t.string, t.undefined]),
     connectorId: t.union([t.number, t.undefined]),
-    brandId: t.union([t.number, t.undefined]),
+    brandId: t.union([t.number, t.null, t.undefined]),
     query: t.union([t.string, t.undefined]),
     forceResync: t.union([t.literal("true"), t.undefined]),
     ticketId: t.union([t.number, t.undefined]),


### PR DESCRIPTION
## Description

- This PR makes the brand ID optional when checking Zendesk tickets through the CLI or the poke component.

## Tests

- Tested e2e locally.

## Risk

- Very low.

## Deploy Plan

- Deploy connectors.
- Deploy front.
