### PR TITLE
[front] poke: Fix origin for revoked users

### DIFF
--- a/front/lib/api/workspace.ts
+++ b/front/lib/api/workspace.ts
@@ -150,7 +150,7 @@ export async function getMembers(
     memberships.map(async (m) => {
       let role = "none" as RoleType;
       let origin: MembershipOriginType | undefined = undefined;
-      if (m && !m.isRevoked()) {
+      if (!m.isRevoked()) {
         switch (m.role) {
           case "admin":
           case "builder":
@@ -160,8 +160,8 @@ export async function getMembers(
           default:
             role = "none";
         }
-        origin = m.origin;
       }
+      origin = m.origin;
 
       let user: UserResource | null;
       if (!m.user) {


### PR DESCRIPTION
## Description

When listing all members, origin is not set on revoked members, crashing poke members pages

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

deploy front
