### PR TITLE
[core] enh(ES): increase default tag aggregation size limit

### DIFF
--- a/core/src/search_stores/search_store.rs
+++ b/core/src/search_stores/search_store.rs
@@ -37,6 +37,8 @@ const MAX_PAGE_SIZE: u64 = 1000;
 const MAX_TOTAL_HITS_TRACKED: i64 = 10000;
 const MAX_ES_QUERY_CLAUSES: usize = 1024; // Default Elasticsearch limit.
 
+const DEFAULT_TAG_AGGREGATION_SIZE_LIMIT: u64 = 100;
+
 #[derive(serde::Deserialize, Debug)]
 #[serde(rename_all = "lowercase")]
 pub enum SortDirection {
@@ -616,10 +618,10 @@ impl SearchStore for ElasticsearchSearchStore {
         };
         let aggregate =
             aggregate.aggregate("tags_in_datasource", Aggregation::terms("data_source_id"));
-        let search = Search::new()
-            .size(0)
-            .query(bool_query)
-            .aggregate("unique_tags", aggregate.size(limit.unwrap_or(100)));
+        let search = Search::new().size(0).query(bool_query).aggregate(
+            "unique_tags",
+            aggregate.size(limit.unwrap_or(DEFAULT_TAG_AGGREGATION_SIZE_LIMIT)),
+        );
 
         let response = self
             .client

--- a/core/src/search_stores/search_store.rs
+++ b/core/src/search_stores/search_store.rs
@@ -37,7 +37,7 @@ const MAX_PAGE_SIZE: u64 = 1000;
 const MAX_TOTAL_HITS_TRACKED: i64 = 10000;
 const MAX_ES_QUERY_CLAUSES: usize = 1024; // Default Elasticsearch limit.
 
-const DEFAULT_TAG_AGGREGATION_SIZE_LIMIT: u64 = 100;
+const DEFAULT_TAG_AGGREGATION_SIZE_LIMIT: u64 = 200;
 
 #[derive(serde::Deserialize, Debug)]
 #[serde(rename_all = "lowercase")]


### PR DESCRIPTION
## Description

- This PR adds a variable for the default tag aggregation size limit and bumps the default value from 100 to 200.
- The goal is to fix an issue where some very non-frequent tags do not appear in the autocompletion when configuring a filtering on a data source.

## Tests

- Tested locally, no regression.

## Risk

- Low, may increase memory usage.

## Deploy Plan

- Deploy core.
