### PR TITLE
[front] Fix `disallow_agent_creation_to_users` feature flag description

### DIFF
--- a/front/types/shared/feature_flags.ts
+++ b/front/types/shared/feature_flags.ts
@@ -40,7 +40,8 @@ export const WHITELISTABLE_FEATURES_CONFIG = {
     description: "Disable logging of agent runs",
   },
   disallow_agent_creation_to_users: {
-    description: "Restrict agent creation to admins only",
+    description:
+      "Prevent users from creating agents, allowing only admins and builders",
   },
   exploded_tables_query: {
     description: "Enhanced table querying with exploded views",


### PR DESCRIPTION
## Description

- This PR fixes the description of the feature flag `disallow_agent_creation_to_users`.
- The feature flag always applies a restrictions on `!isBuilder(owner)`, so the description is incorrect (as hinted by the title actually).
- This description appears in Poke and is the primary information available to the support team to know about the behavior of a FF.

## Tests

- Checked locally.

## Risk

- N/A.

## Deploy Plan

- Deploy front.
