### PR TITLE
Update `front` APM tracing

### DIFF
--- a/front/logger/withlogging.ts
+++ b/front/logger/withlogging.ts
@@ -42,9 +42,28 @@ export function withLogging<T>(
     req: NextApiRequestWithContext,
     res: NextApiResponse<WithAPIErrorResponse<T>>
   ): Promise<void> => {
-    const ddtraceSpan = tracer.scope().active();
-    if (ddtraceSpan) {
-      ddtraceSpan.setTag("streaming", streaming);
+    const ddtraceNextRequestSpan = tracer.scope().active();
+    if (ddtraceNextRequestSpan) {
+      // Tag the current active span (usually `next.request`) with a "streaming" flag
+      // so we can filter these requests later in Datadog traces and analytics.
+      ddtraceNextRequestSpan.setTag("streaming", streaming);
+
+      if (streaming) {
+        // For streaming requests, change the operation name of the *current span*
+        // from `next.request` to `next.request.streaming` so that:
+        //   1. It appears as a separate operation in the Datadog APM "operation" dropdown,
+        //      making it easy to isolate streaming traffic from regular requests.
+        //   2. You can analyze streaming request performance and error rates independently,
+        //      without mixing them into standard request metrics.
+        //   3. Without this separation, the long-lived nature of streaming requests would
+        //      inflate and skew p95/p99 latency metrics, making them unrepresentative of
+        //      typical request performance.
+        //
+        // Note: This changes only the Next.js request span, not the root `web.request` span.
+        // That means streaming requests will still be counted in `web.request` service-level
+        // latency metrics unless you also update the root span.
+        ddtraceNextRequestSpan.setOperationName("next.request.streaming");
+      }
     }
     const now = new Date();
 


### PR DESCRIPTION
## Description

Enhanced APM tracing for streaming requests by improving Datadog span tagging and operation naming. This change separates streaming requests from regular requests in APM analytics, allowing for better performance monitoring and preventing streaming request latency from skewing standard request metrics.

Key improvements:
- Added detailed comments explaining the APM strategy
- Renamed streaming request spans from `next.request` to `next.request.streaming` for better isolation
- Enhanced tagging with streaming flags for improved filtering in Datadog

## Tests

Tested manually by verifying that streaming requests now appear as separate operations in Datadog APM dashboard and that the streaming tag is properly applied to traces.

## Risk

Low risk change. This only affects APM telemetry and span naming, with no impact on application functionality. Changes are purely observational and can be safely rolled back if needed.

## Deploy Plan

Standard deployment - no special considerations required. The changes only affect tracing metadata and will take effect immediately upon deployment.