### PR TITLE
Fix: do not add a jit tools if the agent already has it

### DIFF
--- a/front/temporal/agent_loop/activities/run_model.ts
+++ b/front/temporal/agent_loop/activities/run_model.ts
@@ -192,6 +192,7 @@ export async function runModelActivity({
 
   const attachments = listAttachments(conversation);
   const jitServers = await getJITServers(auth, {
+    agentConfiguration,
     conversation,
     attachments,
   });


### PR DESCRIPTION
## Description

Check if agent already has the jit tool, if so, do not add it.

## Tests

Local

## Risk

Low

## Deploy Plan

Deploy `front`