### PR TITLE
[sparkle] - refact(ReadOnlyTextArea): move from front to sparkle

### DIFF
--- a/sparkle/src/components/TextArea.tsx
+++ b/sparkle/src/components/TextArea.tsx
@@ -110,4 +110,19 @@ const TextArea = React.forwardRef<HTMLTextAreaElement, TextareaProps>(
 );
 TextArea.displayName = "TextArea";
 
-export { TextArea };
+const ReadOnlyTextArea = ({ content }: { content: string | null }) => {
+  return (
+    <TextArea
+      disabled
+      isDisplay
+      className={cn(
+        "s-copy-sm s-h-full s-min-h-60 s-w-full s-min-w-0 s-rounded-xl",
+        "s-resize-none s-border-border s-bg-muted-background",
+        "dark:s-border-border-night dark:s-bg-muted-background-night"
+      )}
+      defaultValue={content ?? ""}
+    />
+  );
+};
+
+export { ReadOnlyTextArea, TextArea };

--- a/sparkle/src/components/index.ts
+++ b/sparkle/src/components/index.ts
@@ -162,7 +162,7 @@ export { SliderToggle } from "./SliderToggle";
 export { default as Spinner } from "./Spinner";
 export { FlexSplitButton, SplitButton } from "./SplitButton";
 export { Tabs, TabsContent, TabsList, TabsTrigger } from "./Tabs";
-export { TextArea } from "./TextArea";
+export { ReadOnlyTextArea, TextArea } from "./TextArea";
 export {
   Tooltip,
   TooltipContent,


### PR DESCRIPTION
## Description

This PR moves the `ReadOnlyTextArea` component from front to sparkle.

## Risk

Low

## Deploy Plan

Publish sparkle
