### PR TITLE
[front] Prevent `conversation_files__`🐈‍⬛  from outputting an empty content

### DIFF
--- a/front/lib/actions/mcp_internal_actions/servers/conversation_files.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/conversation_files.ts
@@ -244,6 +244,19 @@ function createServer(
 
       let text = content.text;
 
+      // Returning early with a custom message if the text is empty.
+      if (text.length === 0) {
+        return {
+          isError: false,
+          content: [
+            {
+              type: "text",
+              text: `No content retrieved for file ${title}.`,
+            },
+          ],
+        };
+      }
+
       // Apply offset and limit.
       if (offset !== undefined || limit !== undefined) {
         const start = offset || 0;
@@ -282,7 +295,7 @@ function createServer(
             `Invalid regular expression: ${grep}. Error: ${e instanceof Error ? e.message : String(e)}`
           );
         }
-        if (text === "") {
+        if (text.length === 0) {
           return makeMCPToolTextError(
             `No lines matched the grep pattern: ${grep}.`
           );

--- a/front/lib/actions/mcp_internal_actions/servers/conversation_files.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/conversation_files.ts
@@ -248,6 +248,15 @@ function createServer(
       if (offset !== undefined || limit !== undefined) {
         const start = offset || 0;
         const end = limit !== undefined ? start + limit : undefined;
+
+        if (start > text.length) {
+          return makeMCPToolTextError(
+            `Offset ${start} is out of bounds for file ${title}.`
+          );
+        }
+        if (limit === 0) {
+          return makeMCPToolTextError(`Limit cannot be equal to 0.`);
+        }
         text = text.slice(start, end);
       }
 
@@ -273,6 +282,11 @@ function createServer(
             `Invalid regular expression: ${grep}. Error: ${e instanceof Error ? e.message : String(e)}`
           );
         }
+        if (text === "") {
+          return makeMCPToolTextError(
+            `No lines matched the grep pattern: ${grep}.`
+          );
+        }
       }
 
       return {
@@ -280,7 +294,7 @@ function createServer(
         content: [
           {
             type: "text",
-            text: text,
+            text: text || `No content retrieved for file ${title}.`,
           },
         ],
       };

--- a/front/lib/actions/mcp_internal_actions/servers/conversation_files.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/conversation_files.ts
@@ -27,6 +27,7 @@ import type {
   Result,
   TextContent,
 } from "@app/types";
+import { normalizeError } from "@app/types";
 import { Err, isImageContent, isTextContent, Ok } from "@app/types";
 
 const MAX_FILE_SIZE_FOR_GREP = 20 * 1024 * 1024; // 20MB.
@@ -292,7 +293,7 @@ function createServer(
           text = matchedLines.join("\n");
         } catch (e) {
           return makeMCPToolTextError(
-            `Invalid regular expression: ${grep}. Error: ${e instanceof Error ? e.message : String(e)}`
+            `Invalid regular expression: ${grep}. Error: ${normalizeError(e)}`
           );
         }
         if (text.length === 0) {
@@ -307,7 +308,7 @@ function createServer(
         content: [
           {
             type: "text",
-            text: text || `No content retrieved for file ${title}.`,
+            text,
           },
         ],
       };


### PR DESCRIPTION
## Description

- Somewhat related to https://github.com/dust-tt/tasks/issues/3746.
- This PR prevents having empty content (`{"text": "", "type": "text"}`) as the output of a `cat` tool execution, replacing them with explicit messages.
- In [this run](https://dust.tt/w/78bda07b39/spaces/vlt_rICtlrSEpWqX/apps/0e9889c787/runs/93eb01abb3c6dd79fd8202d38faab46706099a7beb829715412743f6d9fe6a6f) for instance the `cat` ran with a `grep` that was too restrictive.

## Tests

- Tested locally, prompting heavily to use greps.

## Risk

- Low.

## Deploy Plan

- Deploy front.
