### PR TITLE
Handle auto and non-auto internal mcp servers differently

### DIFF
--- a/front/components/actions/mcp/AddActionMenu.tsx
+++ b/front/components/actions/mcp/AddActionMenu.tsx
@@ -77,8 +77,10 @@ export const AddActionMenu = ({
           </div>
         )}
         {availableMCPServers
+          .filter((mcpServer) => mcpServer.availability === "manual")
           .filter(
             (mcpServer) =>
+              mcpServer.allowMultipleInstances ||
               !enabledMCPServers.some((enabled) => enabled.id === mcpServer.sId)
           )
           .filter((mcpServer) => filterMCPServer(mcpServer, searchText))

--- a/front/components/assistant_builder/AssistantBuilderPreviewDrawer.tsx
+++ b/front/components/assistant_builder/AssistantBuilderPreviewDrawer.tsx
@@ -39,7 +39,7 @@ import type {
 } from "@app/components/assistant_builder/types";
 import { getDefaultMCPServerConfigurationWithId } from "@app/components/assistant_builder/types";
 import { ConfirmContext } from "@app/components/Confirm";
-import { internalMCPServerNameToSId } from "@app/lib/actions/mcp_helper";
+import { autoInternalMCPServerNameToSId } from "@app/lib/actions/mcp_helper";
 import type { InternalMCPServerNameType } from "@app/lib/actions/mcp_internal_actions/constants";
 import { MCP_SPECIFICATION } from "@app/lib/actions/utils";
 import type { MCPServerViewType } from "@app/lib/api/mcp";
@@ -157,7 +157,7 @@ export default function AssistantBuilderRightPanel({
     const mcpServerView = mcpServerViews.find(
       (mcpServerView) =>
         mcpServerView.server.sId ===
-        internalMCPServerNameToSId({
+        autoInternalMCPServerNameToSId({
           name: internalMcpServerName,
           workspaceId: owner.id,
         })

--- a/front/lib/actions/mcp_actions.ts
+++ b/front/lib/actions/mcp_actions.ts
@@ -34,7 +34,7 @@ import type {
 import { MCPServerPersonalAuthenticationRequiredError } from "@app/lib/actions/mcp_authentication";
 import { getServerTypeAndIdFromSId } from "@app/lib/actions/mcp_helper";
 import {
-  getInternalMCPServerAvailability,
+  getAvailabilityOfInternalMCPServerById,
   getInternalMCPServerNameAndWorkspaceId,
   INTERNAL_MCP_SERVERS,
 } from "@app/lib/actions/mcp_internal_actions/constants";
@@ -787,7 +787,7 @@ async function listToolsForServerSideMCPServer(
     return new Ok(serverSideToolConfigs);
   }
 
-  const availability = getInternalMCPServerAvailability(
+  const availability = getAvailabilityOfInternalMCPServerById(
     connectionParams.mcpServerId
   );
   const { serverType, id } = getServerTypeAndIdFromSId(
@@ -806,7 +806,7 @@ async function listToolsForServerSideMCPServer(
         return r;
       }
       const serverName = r.value.name;
-      toolsStakes = INTERNAL_MCP_SERVERS[serverName]?.tools_stakes || {};
+      toolsStakes = INTERNAL_MCP_SERVERS[serverName].tools_stakes || {};
       serverTimeoutMs = INTERNAL_MCP_SERVERS[serverName]?.timeoutMs;
       break;
     }

--- a/front/lib/actions/mcp_helper.ts
+++ b/front/lib/actions/mcp_helper.ts
@@ -1,6 +1,9 @@
 import type { AgentBuilderAction } from "@app/components/agent_builder/AgentBuilderFormContext";
 import type { AssistantBuilderMCPConfiguration } from "@app/components/assistant_builder/types";
-import type { InternalMCPServerNameType } from "@app/lib/actions/mcp_internal_actions/constants";
+import type {
+  AutoInternalMCPServerNameType,
+  InternalMCPServerNameType,
+} from "@app/lib/actions/mcp_internal_actions/constants";
 import {
   getInternalMCPServerNameAndWorkspaceId,
   INTERNAL_MCP_SERVERS,
@@ -42,11 +45,24 @@ export const getServerTypeAndIdFromSId = (
   }
 };
 
-export const internalMCPServerNameToSId = ({
+export const internalMCPServerNameToFirstId = ({
   name,
   workspaceId,
 }: {
   name: InternalMCPServerNameType;
+  workspaceId: ModelId;
+}): string => {
+  return makeSId("internal_mcp_server", {
+    id: INTERNAL_MCP_SERVERS[name].id,
+    workspaceId,
+  });
+};
+
+export const autoInternalMCPServerNameToSId = ({
+  name,
+  workspaceId,
+}: {
+  name: AutoInternalMCPServerNameType;
   workspaceId: ModelId;
 }): string => {
   return makeSId("internal_mcp_server", {

--- a/front/lib/actions/mcp_internal_actions/constants.ts
+++ b/front/lib/actions/mcp_internal_actions/constants.ts
@@ -68,26 +68,17 @@ export const isMCPServerAvailability = (
   );
 };
 
-export const INTERNAL_MCP_SERVERS: Record<
-  InternalMCPServerNameType,
-  {
-    id: number;
-    availability: MCPServerAvailability;
-    isRestricted?: (params: {
-      plan: PlanType;
-      featureFlags: WhitelistableFeature[];
-    }) => boolean;
-    isPreview?: boolean;
-    tools_stakes?: Record<string, MCPToolStakeLevelType>;
-    timeoutMs?: number;
-  }
-> = {
+export const INTERNAL_MCP_SERVERS = {
   // Note:
   // ids should be stable, do not change them when moving internal servers to production as it would break existing agents.
 
   github: {
     id: 1,
     availability: "manual",
+    // Github only allows one instance of the same app per user.
+    allowMultipleInstances: false,
+    isRestricted: undefined,
+    isPreview: false,
     tools_stakes: {
       create_issue: "low",
       add_issue_to_project: "low",
@@ -96,34 +87,61 @@ export const INTERNAL_MCP_SERVERS: Record<
       list_issues: "never_ask",
       get_issue: "never_ask",
     },
+    timeoutMs: undefined,
   },
   image_generation: {
     id: 2,
     availability: "auto",
+    allowMultipleInstances: false,
+    isRestricted: undefined,
+    isPreview: false,
+    tools_stakes: undefined,
+    timeoutMs: undefined,
   },
   file_generation: {
     id: 3,
     availability: "auto",
+    allowMultipleInstances: false,
+    isRestricted: undefined,
+    isPreview: false,
+    tools_stakes: undefined,
+    timeoutMs: undefined,
   },
   query_tables: {
     id: 4,
     availability: "auto",
+    allowMultipleInstances: false,
+    isRestricted: undefined,
+    isPreview: false,
+    tools_stakes: undefined,
+    timeoutMs: undefined,
   },
   "web_search_&_browse": {
     id: 5,
     availability: "auto",
+    allowMultipleInstances: false,
+    isRestricted: undefined,
+    isPreview: false,
+    tools_stakes: undefined,
+    timeoutMs: undefined,
   },
   think: {
     id: 6,
     availability: "auto",
+    allowMultipleInstances: false,
     isRestricted: ({ featureFlags }) => {
       return !featureFlags.includes("dev_mcp_actions");
     },
     isPreview: true,
+    tools_stakes: undefined,
+    timeoutMs: undefined,
   },
   hubspot: {
     id: 7,
     availability: "manual",
+    allowMultipleInstances: false,
+    isRestricted: undefined,
+    isPreview: false,
     tools_stakes: {
       // Get operations.
       get_object_properties: "never_ask",
@@ -164,22 +182,41 @@ export const INTERNAL_MCP_SERVERS: Record<
       update_deal: "high",
       remove_association: "high",
     },
+    timeoutMs: undefined,
   },
   agent_router: {
     id: 8,
     availability: "auto_hidden_builder",
+    allowMultipleInstances: false,
+    isRestricted: undefined,
+    isPreview: false,
+    tools_stakes: undefined,
+    timeoutMs: undefined,
   },
   include_data: {
     id: 9,
     availability: "auto",
+    allowMultipleInstances: false,
+    isRestricted: undefined,
+    isPreview: false,
+    tools_stakes: undefined,
+    timeoutMs: undefined,
   },
   run_dust_app: {
     id: 10,
     availability: "auto",
+    allowMultipleInstances: false,
+    isRestricted: undefined,
+    isPreview: false,
+    tools_stakes: undefined,
+    timeoutMs: undefined,
   },
   notion: {
     id: 11,
     availability: "manual",
+    allowMultipleInstances: false,
+    isRestricted: undefined,
+    isPreview: false,
     tools_stakes: {
       search: "never_ask",
       retrieve_page: "never_ask",
@@ -202,43 +239,64 @@ export const INTERNAL_MCP_SERVERS: Record<
       update_row_database: "low",
       update_schema_database: "low",
     },
+    timeoutMs: undefined,
   },
   extract_data: {
     id: 12,
     availability: "auto",
+    allowMultipleInstances: false,
+    isRestricted: undefined,
+    isPreview: false,
+    tools_stakes: undefined,
+    timeoutMs: undefined,
   },
   missing_action_catcher: {
     id: 13,
     availability: "auto_hidden_builder",
+    allowMultipleInstances: false,
+    isRestricted: undefined,
+    isPreview: false,
+    tools_stakes: undefined,
+    timeoutMs: undefined,
   },
   salesforce: {
     id: 14,
     availability: "manual",
+    allowMultipleInstances: false,
     isRestricted: ({ featureFlags, plan }) => {
       const isInPlan = plan.limits.connections.isSalesforceAllowed;
       const hasFeatureFlag = featureFlags.includes("salesforce_tool");
       const isAvailable = isInPlan || hasFeatureFlag;
       return !isAvailable;
     },
+    isPreview: false,
     tools_stakes: {
       execute_read_query: "never_ask",
       list_objects: "never_ask",
       describe_object: "never_ask",
     },
+    timeoutMs: undefined,
   },
   gmail: {
     id: 15,
     availability: "manual",
+    allowMultipleInstances: false,
+    isRestricted: undefined,
+    isPreview: false,
     tools_stakes: {
       get_drafts: "never_ask",
       create_draft: "low",
       get_messages: "low",
       create_reply_draft: "low",
     },
+    timeoutMs: undefined,
   },
   google_calendar: {
     id: 16,
     availability: "manual",
+    allowMultipleInstances: false,
+    isRestricted: undefined,
+    isPreview: false,
     tools_stakes: {
       list_calendars: "never_ask",
       list_events: "never_ask",
@@ -248,14 +306,23 @@ export const INTERNAL_MCP_SERVERS: Record<
       delete_event: "low",
       check_availability: "never_ask",
     },
+    timeoutMs: undefined,
   },
   conversation_files: {
     id: 17,
     availability: "auto_hidden_builder",
+    allowMultipleInstances: false,
+    isRestricted: undefined,
+    isPreview: false,
+    tools_stakes: undefined,
+    timeoutMs: undefined,
   },
   slack: {
     id: 18,
     availability: "manual",
+    allowMultipleInstances: false,
+    isRestricted: undefined,
+    isPreview: false,
     tools_stakes: {
       search_messages: "never_ask",
       list_users: "never_ask",
@@ -263,10 +330,12 @@ export const INTERNAL_MCP_SERVERS: Record<
       list_threads: "never_ask",
       post_message: "low",
     },
+    timeoutMs: undefined,
   },
   google_sheets: {
     id: 19,
     availability: "manual",
+    allowMultipleInstances: false,
     isRestricted: ({ featureFlags }) => {
       return !featureFlags.includes("google_sheets_tool");
     },
@@ -283,10 +352,12 @@ export const INTERNAL_MCP_SERVERS: Record<
       delete_worksheet: "low",
       format_cells: "low",
     },
+    timeoutMs: undefined,
   },
   monday: {
     id: 20,
     availability: "manual",
+    allowMultipleInstances: false,
     isRestricted: ({ featureFlags }) => {
       return !featureFlags.includes("monday_tool");
     },
@@ -321,14 +392,21 @@ export const INTERNAL_MCP_SERVERS: Record<
       delete_item: "high",
       delete_group: "high",
     },
+    timeoutMs: undefined,
   },
   agent_memory: {
     id: 21,
     availability: "auto",
+    allowMultipleInstances: false,
+    isRestricted: undefined,
+    isPreview: false,
+    tools_stakes: undefined,
+    timeoutMs: undefined,
   },
   jira: {
     id: 22,
     availability: "manual",
+    allowMultipleInstances: false,
     isRestricted: ({ featureFlags }) => {
       return !featureFlags.includes("jira_tool");
     },
@@ -354,18 +432,25 @@ export const INTERNAL_MCP_SERVERS: Record<
       create_issue_link: "low",
       delete_issue_link: "low",
     },
+    timeoutMs: undefined,
   },
   interactive_content: {
     id: 23,
     availability: "auto",
+    allowMultipleInstances: false,
     isRestricted: ({ featureFlags }) => {
       return !featureFlags.includes("interactive_content_server");
     },
     isPreview: true,
+    tools_stakes: undefined,
+    timeoutMs: undefined,
   },
   outlook: {
     id: 24,
     availability: "manual",
+    allowMultipleInstances: false,
+    isRestricted: undefined,
+    isPreview: false,
     tools_stakes: {
       get_messages: "never_ask",
       get_drafts: "never_ask",
@@ -376,10 +461,14 @@ export const INTERNAL_MCP_SERVERS: Record<
       create_contact: "high",
       update_contact: "high",
     },
+    timeoutMs: undefined,
   },
   outlook_calendar: {
     id: 25,
     availability: "manual",
+    allowMultipleInstances: false,
+    isRestricted: undefined,
+    isPreview: false,
     tools_stakes: {
       list_calendars: "never_ask",
       list_events: "never_ask",
@@ -389,10 +478,12 @@ export const INTERNAL_MCP_SERVERS: Record<
       delete_event: "low",
       check_availability: "never_ask",
     },
+    timeoutMs: undefined,
   },
   freshservice: {
     id: 26,
     availability: "manual",
+    allowMultipleInstances: false,
     isRestricted: ({ featureFlags }) => {
       return !featureFlags.includes("freshservice_tool");
     },
@@ -418,57 +509,122 @@ export const INTERNAL_MCP_SERVERS: Record<
       add_ticket_reply: "low",
       create_solution_article: "high",
     },
+    timeoutMs: undefined,
   },
   search: {
     id: 1006,
     availability: "auto",
+    allowMultipleInstances: false,
+    isRestricted: undefined,
+    isPreview: false,
+    tools_stakes: undefined,
+    timeoutMs: undefined,
   },
   run_agent: {
     id: 1008,
     availability: "auto",
+    allowMultipleInstances: false,
+    isRestricted: undefined,
+    isPreview: false,
+    tools_stakes: undefined,
     timeoutMs: 10 * 60 * 1000, // 10 minutes
   },
   primitive_types_debugger: {
     id: 1004,
     availability: "manual",
+    allowMultipleInstances: false,
+    isPreview: false,
     isRestricted: ({ featureFlags }) => {
       return !featureFlags.includes("dev_mcp_actions");
     },
+    tools_stakes: undefined,
+    timeoutMs: undefined,
   },
   reasoning: {
     id: 1007,
     availability: "auto",
+    allowMultipleInstances: false,
+    isRestricted: undefined,
+    isPreview: false,
+    tools_stakes: undefined,
+    timeoutMs: undefined,
   },
   query_tables_v2: {
     id: 1009,
     availability: "auto",
+    allowMultipleInstances: false,
     // We'll eventually switch everyone to this new tables query toolset.
     isRestricted: ({ featureFlags }) => {
       return !featureFlags.includes("exploded_tables_query");
     },
     isPreview: true,
+    tools_stakes: undefined,
+    timeoutMs: undefined,
   },
   data_sources_file_system: {
     id: 1010,
     availability: "auto",
+    allowMultipleInstances: false,
     // This server is hidden for everyone, it is only available through the search tool
     // when the advanced_search mode is enabled.
     isRestricted: () => true,
+    isPreview: false,
+    tools_stakes: undefined,
+    timeoutMs: undefined,
   },
   agent_management: {
     id: 1011,
     availability: "auto",
+    allowMultipleInstances: false,
+    isPreview: false,
     isRestricted: ({ featureFlags }) => {
       return !featureFlags.includes("agent_management_tool");
     },
     tools_stakes: {
       create_agent: "high",
     },
+    timeoutMs: undefined,
   },
-};
+  // Using satisfies here instead of : type to avoid typescript widening the type and breaking the type inference for AutoInternalMCPServerNameType.
+} satisfies Record<
+  InternalMCPServerNameType,
+  {
+    id: number;
+    availability: MCPServerAvailability;
+    allowMultipleInstances: boolean;
+    isRestricted:
+      | ((params: {
+          plan: PlanType;
+          featureFlags: WhitelistableFeature[];
+        }) => boolean)
+      | undefined;
+    isPreview: boolean;
+    tools_stakes: Record<string, MCPToolStakeLevelType> | undefined;
+    timeoutMs: number | undefined;
+  }
+>;
 
 export type InternalMCPServerNameType =
   (typeof AVAILABLE_INTERNAL_MCP_SERVER_NAMES)[number];
+
+type AutoServerKeys<T> = {
+  [K in keyof T]: T[K] extends { availability: "auto" | "auto_hidden_builder" }
+    ? K
+    : never;
+}[keyof T];
+
+export type AutoInternalMCPServerNameType = AutoServerKeys<
+  typeof INTERNAL_MCP_SERVERS
+>;
+
+export const isAutoInternalMCPServerName = (
+  name: InternalMCPServerNameType
+): name is AutoInternalMCPServerNameType => {
+  return (
+    INTERNAL_MCP_SERVERS[name].availability === "auto" ||
+    INTERNAL_MCP_SERVERS[name].availability === "auto_hidden_builder"
+  );
+};
 
 export const getAvailabilityOfInternalMCPServerByName = (
   name: InternalMCPServerNameType
@@ -476,7 +632,7 @@ export const getAvailabilityOfInternalMCPServerByName = (
   return INTERNAL_MCP_SERVERS[name].availability;
 };
 
-export const getInternalMCPServerAvailability = (
+export const getAvailabilityOfInternalMCPServerById = (
   sId: string
 ): MCPServerAvailability => {
   const r = getInternalMCPServerNameAndWorkspaceId(sId);
@@ -484,6 +640,16 @@ export const getInternalMCPServerAvailability = (
     return "manual";
   }
   return getAvailabilityOfInternalMCPServerByName(r.value.name);
+};
+
+export const getAllowMultipleInstancesOfInternalMCPServerById = (
+  sId: string
+): boolean => {
+  const r = getInternalMCPServerNameAndWorkspaceId(sId);
+  if (r.isErr()) {
+    return false;
+  }
+  return !!INTERNAL_MCP_SERVERS[r.value.name].allowMultipleInstances;
 };
 
 export const getInternalMCPServerNameAndWorkspaceId = (

--- a/front/lib/actions/mcp_metadata.ts
+++ b/front/lib/actions/mcp_metadata.ts
@@ -535,6 +535,7 @@ async function fetchRemoteServerMetaData(
       ...metadata,
       tools: serverTools,
       availability: "manual",
+      allowMultipleInstances: true,
     });
   } catch (e: unknown) {
     logger.error(

--- a/front/lib/agent_yaml_converter/converter.ts
+++ b/front/lib/agent_yaml_converter/converter.ts
@@ -3,7 +3,7 @@ import { z } from "zod";
 
 import type { AgentBuilderFormData } from "@app/components/agent_builder/AgentBuilderFormContext";
 import { ACTION_TYPE_TO_MCP_SERVER_MAP } from "@app/components/agent_builder/types";
-import type { InternalMCPServerNameType } from "@app/lib/actions/mcp_internal_actions/constants";
+import type { AutoInternalMCPServerNameType } from "@app/lib/actions/mcp_internal_actions/constants";
 import type { Authenticator } from "@app/lib/auth";
 import { MCPServerViewResource } from "@app/lib/resources/mcp_server_view_resource";
 import { concurrentExecutor } from "@app/lib/utils/async_utils";
@@ -293,7 +293,7 @@ export class AgentYAMLConverter {
 
   private static getMCPServerName(
     actionType: string
-  ): InternalMCPServerNameType | null {
+  ): AutoInternalMCPServerNameType | null {
     return (
       ACTION_TYPE_TO_MCP_SERVER_MAP[
         actionType as keyof typeof ACTION_TYPE_TO_MCP_SERVER_MAP

--- a/front/lib/api/assistant/global_agents.ts
+++ b/front/lib/api/assistant/global_agents.ts
@@ -13,7 +13,7 @@ import type {
   ServerSideMCPServerConfigurationType,
 } from "@app/lib/actions/mcp";
 import { TOOL_NAME_SEPARATOR } from "@app/lib/actions/mcp_actions";
-import { internalMCPServerNameToSId } from "@app/lib/actions/mcp_helper";
+import { autoInternalMCPServerNameToSId } from "@app/lib/actions/mcp_helper";
 import type { InternalMCPServerNameType } from "@app/lib/actions/mcp_internal_actions/constants";
 import { SUGGEST_AGENTS_TOOL_NAME } from "@app/lib/actions/mcp_internal_actions/servers/agent_router";
 import { getFavoriteStates } from "@app/lib/api/assistant/get_favorite_states";
@@ -293,7 +293,7 @@ function _getHelperGlobalAgent({
     ..._getAgentRouterToolsConfiguration(
       GLOBAL_AGENTS_SID.HELPER,
       agentRouterMCPServerView,
-      internalMCPServerNameToSId({
+      autoInternalMCPServerNameToSId({
         name: "agent_router",
         workspaceId: owner.id,
       })
@@ -1742,7 +1742,7 @@ The agent should not provide additional information or content that the user did
     ..._getAgentRouterToolsConfiguration(
       GLOBAL_AGENTS_SID.DUST,
       agentRouterMCPServerView,
-      internalMCPServerNameToSId({
+      autoInternalMCPServerNameToSId({
         name: "agent_router",
         workspaceId: owner.id,
       })

--- a/front/lib/api/mcp.ts
+++ b/front/lib/api/mcp.ts
@@ -48,6 +48,7 @@ export type MCPServerType = {
   authorization: AuthorizationInfo | null;
   tools: MCPToolType[];
   availability: MCPServerAvailability;
+  allowMultipleInstances: boolean;
   documentationUrl: string | null;
 };
 
@@ -57,6 +58,9 @@ export type RemoteMCPServerType = MCPServerType & {
   lastSyncAt?: Date | null;
   lastError?: string | null;
   icon: CustomServerIconType | InternalAllowedIconType;
+  // Always manual and allow multiple instances.
+  availability: "manual";
+  allowMultipleInstances: true;
 };
 
 export interface MCPServerViewType {
@@ -75,7 +79,7 @@ export interface MCPServerViewType {
 
 export type MCPServerDefinitionType = Omit<
   MCPServerType,
-  "tools" | "sId" | "availability"
+  "tools" | "sId" | "availability" | "allowMultipleInstances"
 >;
 
 type InternalMCPServerType = MCPServerType & {
@@ -85,7 +89,7 @@ type InternalMCPServerType = MCPServerType & {
 
 export type InternalMCPServerDefinitionType = Omit<
   InternalMCPServerType,
-  "tools" | "sId" | "availability"
+  "tools" | "sId" | "availability" | "allowMultipleInstances"
 >;
 
 export type MCPServerTypeWithViews = MCPServerType & {

--- a/front/lib/models/assistant/actions/mcp_server_view.ts
+++ b/front/lib/models/assistant/actions/mcp_server_view.ts
@@ -120,7 +120,7 @@ MCPServerViewModel.init(
       },
     ],
     hooks: {
-      beforeValidate: (config: MCPServerViewModel) => {
+      beforeValidate: async (config: MCPServerViewModel) => {
         if (config.serverType) {
           switch (config.serverType) {
             case "internal":

--- a/front/lib/models/assistant/actions/mcp_server_view.ts
+++ b/front/lib/models/assistant/actions/mcp_server_view.ts
@@ -120,7 +120,7 @@ MCPServerViewModel.init(
       },
     ],
     hooks: {
-      beforeValidate: async (config: MCPServerViewModel) => {
+      beforeValidate: (config: MCPServerViewModel) => {
         if (config.serverType) {
           switch (config.serverType) {
             case "internal":

--- a/front/lib/resources/default_remote_mcp_server_in_memory_resource.ts
+++ b/front/lib/resources/default_remote_mcp_server_in_memory_resource.ts
@@ -5,7 +5,7 @@ import {
   DEFAULT_REMOTE_MCP_SERVERS,
   getDefaultRemoteMCPServerById,
 } from "@app/lib/actions/mcp_internal_actions/remote_servers";
-import type { MCPServerType } from "@app/lib/api/mcp";
+import type { RemoteMCPServerType } from "@app/lib/api/mcp";
 import type { Authenticator } from "@app/lib/auth";
 
 export class DefaultRemoteMCPServerInMemoryResource {
@@ -52,7 +52,7 @@ export class DefaultRemoteMCPServerInMemoryResource {
     return resources;
   }
 
-  toJSON(): MCPServerType {
+  toJSON(): RemoteMCPServerType {
     return {
       sId: this.id,
       name: this.config.name,
@@ -67,8 +67,9 @@ export class DefaultRemoteMCPServerInMemoryResource {
             }
           : null,
       tools: [], // There are no predefined tools for default remote servers
-      availability: "manual" as const,
       documentationUrl: this.config.documentationUrl || null,
+      availability: "manual" as const,
+      allowMultipleInstances: true,
     };
   }
 }

--- a/front/lib/resources/mcp_server_view_resource.ts
+++ b/front/lib/resources/mcp_server_view_resource.ts
@@ -9,19 +9,20 @@ import type {
 import { Op } from "sequelize";
 
 import {
+  autoInternalMCPServerNameToSId,
   getServerTypeAndIdFromSId,
-  internalMCPServerNameToSId,
   remoteMCPServerNameToSId,
 } from "@app/lib/actions/mcp_helper";
 import { isEnabledForWorkspace } from "@app/lib/actions/mcp_internal_actions";
 import type {
-  InternalMCPServerNameType,
+  AutoInternalMCPServerNameType,
   MCPServerAvailability,
 } from "@app/lib/actions/mcp_internal_actions/constants";
 import {
   AVAILABLE_INTERNAL_MCP_SERVER_NAMES,
+  getAvailabilityOfInternalMCPServerById,
   getAvailabilityOfInternalMCPServerByName,
-  getInternalMCPServerAvailability,
+  isAutoInternalMCPServerName,
   isValidInternalMCPServerId,
 } from "@app/lib/actions/mcp_internal_actions/constants";
 import type { MCPServerViewType } from "@app/lib/api/mcp";
@@ -369,11 +370,11 @@ export class MCPServerViewResource extends ResourceWithSpace<MCPServerViewModel>
   // They can be null if ensureAllAutoToolsAreCreated has not been called.
   static async getMCPServerViewForAutoInternalTool(
     auth: Authenticator,
-    name: InternalMCPServerNameType
+    name: AutoInternalMCPServerNameType
   ) {
     const views = await this.listByMCPServer(
       auth,
-      internalMCPServerNameToSId({
+      autoInternalMCPServerNameToSId({
         name,
         workspaceId: auth.getNonNullableWorkspace().id,
       })
@@ -595,7 +596,7 @@ export class MCPServerViewResource extends ResourceWithSpace<MCPServerViewModel>
       return "manual";
     }
 
-    return getInternalMCPServerAvailability(this.internalMCPServerId);
+    return getAvailabilityOfInternalMCPServerById(this.internalMCPServerId);
   }
 
   static async ensureAllAutoToolsAreCreated(auth: Authenticator) {
@@ -604,12 +605,16 @@ export class MCPServerViewResource extends ResourceWithSpace<MCPServerViewModel>
 
       const autoInternalMCPServerIds: string[] = [];
       for (const name of names) {
+        if (!isAutoInternalMCPServerName(name)) {
+          continue;
+        }
+
         const isEnabled = await isEnabledForWorkspace(auth, name);
         const availability = getAvailabilityOfInternalMCPServerByName(name);
 
         if (isEnabled && availability !== "manual") {
           autoInternalMCPServerIds.push(
-            internalMCPServerNameToSId({
+            autoInternalMCPServerNameToSId({
               name,
               workspaceId: auth.getNonNullableWorkspace().id,
             })

--- a/front/lib/resources/remote_mcp_servers_resource.ts
+++ b/front/lib/resources/remote_mcp_servers_resource.ts
@@ -13,7 +13,7 @@ import type {
   CustomServerIconType,
   InternalAllowedIconType,
 } from "@app/lib/actions/mcp_icons";
-import type { MCPServerType, MCPToolType } from "@app/lib/api/mcp";
+import type { MCPToolType, RemoteMCPServerType } from "@app/lib/api/mcp";
 import type { Authenticator } from "@app/lib/auth";
 import { DustError } from "@app/lib/error";
 import { MCPServerConnection } from "@app/lib/models/assistant/actions/mcp_server_connection";
@@ -333,7 +333,10 @@ export class RemoteMCPServerResource extends BaseResource<RemoteMCPServerModel> 
   }
 
   // Serialization.
-  toJSON(): MCPServerType & {
+  toJSON(): Omit<
+    RemoteMCPServerType,
+    "url" | "lastSyncAt" | "lastError" | "sharedSecret"
+  > & {
     // Remote MCP Server specifics
 
     url: string;
@@ -363,7 +366,8 @@ export class RemoteMCPServerResource extends BaseResource<RemoteMCPServerModel> 
       tools: this.cachedTools,
 
       authorization: this.authorization,
-      availability: "manual", // So far we don't have auto remote MCP servers.
+      availability: "manual",
+      allowMultipleInstances: true,
 
       // Remote MCP Server specifics
       url: this.url,

--- a/front/lib/workspace_usage.ts
+++ b/front/lib/workspace_usage.ts
@@ -2,7 +2,7 @@ import { stringify } from "csv-stringify/sync";
 import { format } from "date-fns/format";
 import { Op, QueryTypes, Sequelize } from "sequelize";
 
-import { internalMCPServerNameToSId } from "@app/lib/actions/mcp_helper";
+import { internalMCPServerNameToFirstId } from "@app/lib/actions/mcp_helper";
 import { AVAILABLE_INTERNAL_MCP_SERVER_NAMES } from "@app/lib/actions/mcp_internal_actions/constants";
 import config from "@app/lib/api/config";
 import type { Authenticator } from "@app/lib/auth";
@@ -113,7 +113,7 @@ export async function unsafeGetUsageData(
   const wId = workspace.sId;
   const names = AVAILABLE_INTERNAL_MCP_SERVER_NAMES;
   const sids = names.map((name) =>
-    internalMCPServerNameToSId({ name, workspaceId: workspace.id })
+    internalMCPServerNameToFirstId({ name, workspaceId: workspace.id })
   );
 
   const readReplica = getFrontReplicaDbConnection();

--- a/front/tests/utils/AgentMCPServerConfigurationFactory.ts
+++ b/front/tests/utils/AgentMCPServerConfigurationFactory.ts
@@ -1,6 +1,6 @@
 import type { Transaction } from "sequelize";
 
-import { internalMCPServerNameToSId } from "@app/lib/actions/mcp_helper";
+import { autoInternalMCPServerNameToSId } from "@app/lib/actions/mcp_helper";
 import type { Authenticator } from "@app/lib/auth";
 import { AgentMCPServerConfiguration } from "@app/lib/models/assistant/actions/mcp";
 import type { SpaceResource } from "@app/lib/resources/space_resource";
@@ -18,7 +18,7 @@ export class AgentMCPServerConfigurationFactory {
     const agent = await AgentConfigurationFactory.createTestAgent(auth);
     const mcpServerView = await MCPServerViewFactory.create(
       owner,
-      internalMCPServerNameToSId({
+      autoInternalMCPServerNameToSId({
         name: "search",
         workspaceId: owner.id,
       }),


### PR DESCRIPTION
## Description

Improve typing and separate auto and non auto internal mcp servers to prepare for the upcoming PR where multiple instances of the same internal mcp tool could be allowed.

## Tests

Green + local

## Risk

Low

## Deploy Plan

Deploy `front`