### PR TITLE
[front] Change color of warning

### DIFF
--- a/front/components/spaces/websites/SpaceWebsiteForm.tsx
+++ b/front/components/spaces/websites/SpaceWebsiteForm.tsx
@@ -80,7 +80,7 @@ export function SpaceWebsiteForm({
         <ContentMessage
           title="Ensure the website is public"
           icon={InformationCircleIcon}
-          variant="warning"
+          variant="golden"
         >
           Only public websites accessible without authentication will work.
         </ContentMessage>


### PR DESCRIPTION
## Description

- This PR changes the color of the warning "Ensure the website is public" from red to yellow.

Before:
<img width="570" height="408" alt="Screenshot 2025-08-06 at 5 52 50 PM" src="https://github.com/user-attachments/assets/c6f4f0fc-05a7-4fc7-ac44-5199c974b47b" />

After:
<img width="570" height="408" alt="Screenshot 2025-08-06 at 5 51 59 PM" src="https://github.com/user-attachments/assets/9f2d21f7-53a2-4e1a-b1f1-d4ae06c142d8" />

## Tests

- Checked locally.

## Risk

- None.

## Deploy Plan

- Deploy front.
