### PR TITLE
Refactor workspace usage to add the names outside of SQL & allow custom sid prefixes.

### DIFF
--- a/front/lib/actions/mcp_helper.ts
+++ b/front/lib/actions/mcp_helper.ts
@@ -14,7 +14,9 @@ import type {
   RemoteMCPServerType,
 } from "@app/lib/api/mcp";
 import {
+  dangerouslyMakeSIdWithCustomFirstPrefix,
   getResourceNameAndIdFromSId,
+  LEGACY_REGION_BIT,
   makeSId,
 } from "@app/lib/resources/string_ids";
 import type { ModelId } from "@app/types";
@@ -52,9 +54,10 @@ export const internalMCPServerNameToFirstId = ({
   name: InternalMCPServerNameType;
   workspaceId: ModelId;
 }): string => {
-  return makeSId("internal_mcp_server", {
+  return dangerouslyMakeSIdWithCustomFirstPrefix("internal_mcp_server", {
     id: INTERNAL_MCP_SERVERS[name].id,
     workspaceId,
+    firstPrefix: LEGACY_REGION_BIT,
   });
 };
 
@@ -65,9 +68,10 @@ export const autoInternalMCPServerNameToSId = ({
   name: AutoInternalMCPServerNameType;
   workspaceId: ModelId;
 }): string => {
-  return makeSId("internal_mcp_server", {
+  return dangerouslyMakeSIdWithCustomFirstPrefix("internal_mcp_server", {
     id: INTERNAL_MCP_SERVERS[name].id,
     workspaceId,
+    firstPrefix: LEGACY_REGION_BIT,
   });
 };
 

--- a/front/lib/resources/string_ids.ts
+++ b/front/lib/resources/string_ids.ts
@@ -16,8 +16,8 @@ const sqids = new Sqids({
 // backwards compatibility with existing string IDs.
 // They were originally used for sharding and region information but are no longer functionally
 // needed after migration to cross-region architecture.
+export const LEGACY_REGION_BIT = 1; // Previously indicated US region.
 const LEGACY_SHARD_BIT = 1;
-const LEGACY_REGION_BIT = 1; // Previously indicated US region.
 
 const RESOURCES_PREFIX = {
   file: "fil",
@@ -57,8 +57,27 @@ type ResourceNameType = keyof typeof RESOURCES_PREFIX;
 
 const sIdCache = new Map<string, string>();
 
+export function dangerouslyMakeSIdWithCustomFirstPrefix(
+  resourceName: "internal_mcp_server",
+  {
+    id,
+    workspaceId,
+    firstPrefix,
+  }: {
+    id: ModelId;
+    workspaceId: ModelId;
+    firstPrefix: number;
+  }
+): string {
+  return _makeSId(resourceName, {
+    id,
+    workspaceId,
+    customFirstPrefix: firstPrefix,
+  });
+}
+
 export function makeSId(
-  resourceName: ResourceNameType,
+  resourceName: Exclude<ResourceNameType, "internal_mcp_server">,
   {
     id,
     workspaceId,
@@ -67,7 +86,27 @@ export function makeSId(
     workspaceId: ModelId;
   }
 ): string {
-  const idsToEncode = [LEGACY_REGION_BIT, LEGACY_SHARD_BIT, workspaceId, id];
+  return _makeSId(resourceName, {
+    id,
+    workspaceId,
+  });
+}
+
+function _makeSId(
+  resourceName: ResourceNameType,
+  {
+    id,
+    workspaceId,
+    customFirstPrefix = LEGACY_REGION_BIT,
+    customSecondPrefix = LEGACY_SHARD_BIT,
+  }: {
+    id: ModelId;
+    workspaceId: ModelId;
+    customFirstPrefix?: number;
+    customSecondPrefix?: number;
+  }
+): string {
+  const idsToEncode = [customFirstPrefix, customSecondPrefix, workspaceId, id];
 
   // Computing the sId is relatively expensive and we have a lot of them.
   // We cache them in memory to avoid recomputing them, they are immutable.

--- a/front/lib/workspace_usage.ts
+++ b/front/lib/workspace_usage.ts
@@ -2,8 +2,7 @@ import { stringify } from "csv-stringify/sync";
 import { format } from "date-fns/format";
 import { Op, QueryTypes, Sequelize } from "sequelize";
 
-import { internalMCPServerNameToFirstId } from "@app/lib/actions/mcp_helper";
-import { AVAILABLE_INTERNAL_MCP_SERVER_NAMES } from "@app/lib/actions/mcp_internal_actions/constants";
+import { getInternalMCPServerNameAndWorkspaceId } from "@app/lib/actions/mcp_internal_actions/constants";
 import config from "@app/lib/api/config";
 import type { Authenticator } from "@app/lib/auth";
 import { AgentConfiguration } from "@app/lib/models/assistant/agent";
@@ -111,12 +110,9 @@ export async function unsafeGetUsageData(
   workspace: WorkspaceType
 ): Promise<string> {
   const wId = workspace.sId;
-  const names = AVAILABLE_INTERNAL_MCP_SERVER_NAMES;
-  const sids = names.map((name) =>
-    internalMCPServerNameToFirstId({ name, workspaceId: workspace.id })
-  );
 
   const readReplica = getFrontReplicaDbConnection();
+
   // eslint-disable-next-line dust/no-raw-sql -- Leggit
   const results = await readReplica.query<WorkspaceUsageQueryResult>(
     `
@@ -134,15 +130,7 @@ export async function unsafeGetUsageData(
         um."userContextEmail" AS "userEmail",
         COALESCE(ac."sId", am."agentConfigurationId") AS "assistantId",
         COALESCE(ac."name", am."agentConfigurationId") AS "assistantName",
-        CASE
-            WHEN COUNT(DISTINCT msv."id") > 0 THEN
-              CASE
-                WHEN msv."internalMCPServerId" IN (:sids) THEN
-                  (SELECT name FROM (SELECT unnest(ARRAY[:sids]) as sid, unnest(ARRAY[:names]) as name) as t WHERE t.sid = msv."internalMCPServerId")
-                ELSE msv."internalMCPServerId"
-              END
-            ELSE NULL
-        END AS "actionType",
+        msv."internalMCPServerId" AS "actionType",
         um."userContextOrigin" AS "source"
     FROM
         "messages" m
@@ -179,14 +167,32 @@ export async function unsafeGetUsageData(
         wId,
         startDate: format(startDate, "yyyy-MM-dd'T'00:00:00"), // Use first day of start month
         endDate: format(endDate, "yyyy-MM-dd'T'23:59:59"), // Use last day of end month
-        sids,
-        names,
       },
       type: QueryTypes.SELECT,
     }
   );
   if (!results.length) {
     return "No data available for the selected period.";
+  } else {
+    // Do a second pass to replace the internalMCPServerId with the names.
+    const lookup = new Map<string, string>();
+    for (const result of results) {
+      if (!result.actionType) {
+        continue;
+      }
+
+      let name = lookup.get(result.actionType);
+      if (!name) {
+        const r = getInternalMCPServerNameAndWorkspaceId(result.actionType);
+        if (r.isOk()) {
+          name = r.value.name;
+        } else {
+          name = "unknown";
+        }
+        lookup.set(result.actionType, name);
+      }
+      result.actionType = name;
+    }
   }
   return generateCsvFromQueryResult(results);
 }


### PR DESCRIPTION
## Description

One step closer to having multiple instances of internal MCP tools.
This introduce the ability to use the "legacy bit" of our sid but only for internal mcp server.

@flvndvd for the SID part
@btoueg for the workspace usage part (where now multiple SIDs might point to the same name)

## Tests

Locally

## Risk

Medium as it should be iso for 99% of the code but it touches SIDs so...

## Deploy Plan

Deploy `front`