### PR TITLE
[connectors,front] Add support for Zendesk custom fields

### DIFF
--- a/connectors/migrations/db/migration_90.sql
+++ b/connectors/migrations/db/migration_90.sql
@@ -1,0 +1,2 @@
+-- Migration created on Aug 06, 2025
+ALTER TABLE "public"."zendesk_configurations" ADD COLUMN "customFieldsConfig" JSONB NOT NULL DEFAULT '[]';

--- a/connectors/src/connectors/zendesk/index.ts
+++ b/connectors/src/connectors/zendesk/index.ts
@@ -814,9 +814,7 @@ export class ZendeskConnectorManager extends BaseConnectorManager<null> {
       case CUSTOM_FIELDS_CONFIG_KEY: {
         return new Ok(
           zendeskConfiguration.customFieldsConfig
-            ? JSON.stringify(
-                zendeskConfiguration.customFieldsConfig.map((f) => f.name)
-              )
+            ? JSON.stringify(zendeskConfiguration.customFieldsConfig)
             : ""
         );
       }

--- a/connectors/src/connectors/zendesk/index.ts
+++ b/connectors/src/connectors/zendesk/index.ts
@@ -56,17 +56,17 @@ import type {
 } from "@connectors/types";
 import type { DataSourceConfig } from "@connectors/types";
 
-const SYNC_UNRESOLVED_TICKETS_CONFIG_KEY =
-  "zendeskSyncUnresolvedTicketsEnabled";
-const HIDE_CUSTOMER_DETAILS_CONFIG_KEY = "zendeskHideCustomerDetails";
-export const RETENTION_PERIOD_CONFIG_KEY = "zendeskRetentionPeriodDays";
-const TICKET_TAGS_TO_INCLUDE_CONFIG_KEY = "zendeskTicketTagsToInclude";
-const TICKET_TAGS_TO_EXCLUDE_CONFIG_KEY = "zendeskTicketTagsToExclude";
-const ORGANIZATION_TAGS_TO_INCLUDE_CONFIG_KEY =
-  "zendeskOrganizationTagsToInclude";
-const ORGANIZATION_TAGS_TO_EXCLUDE_CONFIG_KEY =
-  "zendeskOrganizationTagsToExclude";
-const CUSTOM_FIELDS_CONFIG_KEY = "zendeskCustomFieldsConfig";
+export const ZENDESK_CONFIG_KEYS = {
+  TICKET_TAGS_TO_INCLUDE: "zendeskTicketTagsToInclude",
+  TICKET_TAGS_TO_EXCLUDE: "zendeskTicketTagsToExclude",
+  ORGANIZATION_TAGS_TO_INCLUDE: "zendeskOrganizationTagsToInclude",
+  ORGANIZATION_TAGS_TO_EXCLUDE: "zendeskOrganizationTagsToExclude",
+  CUSTOM_FIELDS_CONFIG: "zendeskCustomFieldsConfig",
+  SYNC_UNRESOLVED_TICKETS: "zendeskSyncUnresolvedTicketsEnabled",
+  HIDE_CUSTOMER_DETAILS: "zendeskHideCustomerDetails",
+  RETENTION_PERIOD: "zendeskRetentionPeriodDays",
+} as const;
+
 const MAX_RETENTION_DAYS = 365;
 const DEFAULT_RETENTION_DAYS = 180;
 
@@ -564,7 +564,7 @@ export class ZendeskConnectorManager extends BaseConnectorManager<null> {
     }
 
     switch (configKey) {
-      case SYNC_UNRESOLVED_TICKETS_CONFIG_KEY: {
+      case ZENDESK_CONFIG_KEYS.SYNC_UNRESOLVED_TICKETS: {
         await zendeskConfiguration.update({
           syncUnresolvedTickets: configValue === "true",
         });
@@ -576,7 +576,7 @@ export class ZendeskConnectorManager extends BaseConnectorManager<null> {
         }
         return new Ok(undefined);
       }
-      case HIDE_CUSTOMER_DETAILS_CONFIG_KEY: {
+      case ZENDESK_CONFIG_KEYS.HIDE_CUSTOMER_DETAILS: {
         await zendeskConfiguration.update({
           hideCustomerDetails: configValue === "true",
         });
@@ -587,7 +587,7 @@ export class ZendeskConnectorManager extends BaseConnectorManager<null> {
         }
         return new Ok(undefined);
       }
-      case RETENTION_PERIOD_CONFIG_KEY: {
+      case ZENDESK_CONFIG_KEYS.RETENTION_PERIOD: {
         const retentionDays = parseInt(configValue.trim(), 10);
         if (
           configValue.trim() !== "" &&
@@ -645,7 +645,7 @@ export class ZendeskConnectorManager extends BaseConnectorManager<null> {
         }
         return new Ok(undefined);
       }
-      case TICKET_TAGS_TO_INCLUDE_CONFIG_KEY: {
+      case ZENDESK_CONFIG_KEYS.TICKET_TAGS_TO_INCLUDE: {
         const tags = configValue.trim() === "" ? null : JSON.parse(configValue);
         if (tags !== null && !Array.isArray(tags)) {
           return new Err(
@@ -657,7 +657,7 @@ export class ZendeskConnectorManager extends BaseConnectorManager<null> {
         });
         return new Ok(undefined);
       }
-      case TICKET_TAGS_TO_EXCLUDE_CONFIG_KEY: {
+      case ZENDESK_CONFIG_KEYS.TICKET_TAGS_TO_EXCLUDE: {
         const tags = configValue.trim() === "" ? null : JSON.parse(configValue);
         if (tags !== null && !Array.isArray(tags)) {
           return new Err(
@@ -669,7 +669,7 @@ export class ZendeskConnectorManager extends BaseConnectorManager<null> {
         });
         return new Ok(undefined);
       }
-      case ORGANIZATION_TAGS_TO_INCLUDE_CONFIG_KEY: {
+      case ZENDESK_CONFIG_KEYS.ORGANIZATION_TAGS_TO_INCLUDE: {
         const tags = configValue.trim() === "" ? null : JSON.parse(configValue);
         if (tags !== null && !Array.isArray(tags)) {
           return new Err(
@@ -681,7 +681,7 @@ export class ZendeskConnectorManager extends BaseConnectorManager<null> {
         });
         return new Ok(undefined);
       }
-      case ORGANIZATION_TAGS_TO_EXCLUDE_CONFIG_KEY: {
+      case ZENDESK_CONFIG_KEYS.ORGANIZATION_TAGS_TO_EXCLUDE: {
         const tags = configValue.trim() === "" ? null : JSON.parse(configValue);
         if (tags !== null && !Array.isArray(tags)) {
           return new Err(
@@ -694,7 +694,7 @@ export class ZendeskConnectorManager extends BaseConnectorManager<null> {
 
         return new Ok(undefined);
       }
-      case CUSTOM_FIELDS_CONFIG_KEY: {
+      case ZENDESK_CONFIG_KEYS.CUSTOM_FIELDS_CONFIG: {
         const fieldNames =
           configValue.trim() === "" ? null : JSON.parse(configValue);
 
@@ -774,44 +774,44 @@ export class ZendeskConnectorManager extends BaseConnectorManager<null> {
     }
 
     switch (configKey) {
-      case SYNC_UNRESOLVED_TICKETS_CONFIG_KEY: {
+      case ZENDESK_CONFIG_KEYS.SYNC_UNRESOLVED_TICKETS: {
         return new Ok(zendeskConfiguration.syncUnresolvedTickets.toString());
       }
-      case HIDE_CUSTOMER_DETAILS_CONFIG_KEY: {
+      case ZENDESK_CONFIG_KEYS.HIDE_CUSTOMER_DETAILS: {
         return new Ok(zendeskConfiguration.hideCustomerDetails.toString());
       }
-      case RETENTION_PERIOD_CONFIG_KEY: {
+      case ZENDESK_CONFIG_KEYS.RETENTION_PERIOD: {
         return new Ok(zendeskConfiguration.retentionPeriodDays.toString());
       }
-      case TICKET_TAGS_TO_INCLUDE_CONFIG_KEY: {
+      case ZENDESK_CONFIG_KEYS.TICKET_TAGS_TO_INCLUDE: {
         return new Ok(
           zendeskConfiguration.ticketTagsToInclude
             ? JSON.stringify(zendeskConfiguration.ticketTagsToInclude)
             : ""
         );
       }
-      case TICKET_TAGS_TO_EXCLUDE_CONFIG_KEY: {
+      case ZENDESK_CONFIG_KEYS.TICKET_TAGS_TO_EXCLUDE: {
         return new Ok(
           zendeskConfiguration.ticketTagsToExclude
             ? JSON.stringify(zendeskConfiguration.ticketTagsToExclude)
             : ""
         );
       }
-      case ORGANIZATION_TAGS_TO_INCLUDE_CONFIG_KEY: {
+      case ZENDESK_CONFIG_KEYS.ORGANIZATION_TAGS_TO_INCLUDE: {
         return new Ok(
           zendeskConfiguration.organizationTagsToInclude
             ? JSON.stringify(zendeskConfiguration.organizationTagsToInclude)
             : ""
         );
       }
-      case ORGANIZATION_TAGS_TO_EXCLUDE_CONFIG_KEY: {
+      case ZENDESK_CONFIG_KEYS.ORGANIZATION_TAGS_TO_EXCLUDE: {
         return new Ok(
           zendeskConfiguration.organizationTagsToExclude
             ? JSON.stringify(zendeskConfiguration.organizationTagsToExclude)
             : ""
         );
       }
-      case CUSTOM_FIELDS_CONFIG_KEY: {
+      case ZENDESK_CONFIG_KEYS.CUSTOM_FIELDS_CONFIG: {
         return new Ok(
           zendeskConfiguration.customFieldsConfig
             ? JSON.stringify(zendeskConfiguration.customFieldsConfig)

--- a/connectors/src/connectors/zendesk/index.ts
+++ b/connectors/src/connectors/zendesk/index.ts
@@ -107,6 +107,7 @@ export class ZendeskConnectorManager extends BaseConnectorManager<null> {
         organizationTagsToExclude: null,
         ticketTagsToInclude: null,
         ticketTagsToExclude: null,
+        customFieldsConfig: [],
       }
     );
     const loggerArgs = {

--- a/connectors/src/connectors/zendesk/lib/cli.ts
+++ b/connectors/src/connectors/zendesk/lib/cli.ts
@@ -1,7 +1,7 @@
 import type { Logger } from "pino";
 
 import {
-  RETENTION_PERIOD_CONFIG_KEY,
+  ZENDESK_CONFIG_KEYS,
   ZendeskConnectorManager,
 } from "@connectors/connectors/zendesk";
 import {
@@ -480,7 +480,7 @@ export const zendesk = async ({
       }
       const manager = new ZendeskConnectorManager(connectorId);
       await manager.setConfigurationKey({
-        configKey: RETENTION_PERIOD_CONFIG_KEY,
+        configKey: ZENDESK_CONFIG_KEYS.RETENTION_PERIOD,
         configValue: retentionPeriodDays.toString(),
       });
       return { success: true };

--- a/connectors/src/connectors/zendesk/lib/types.ts
+++ b/connectors/src/connectors/zendesk/lib/types.ts
@@ -1,3 +1,4 @@
+// TODO(2025-08-06 aubin): add some validation to confirm we actually get these types.
 export interface ZendeskFetchedBrand {
   url: string;
   id: number;

--- a/connectors/src/connectors/zendesk/lib/types.ts
+++ b/connectors/src/connectors/zendesk/lib/types.ts
@@ -198,35 +198,7 @@ export interface ZendeskFetchedOrganization {
 
 export interface ZendeskFetchedTicketField {
   id: number;
-  url: string;
-  type: string;
   title: string;
-  raw_title: string;
-  description: string;
-  raw_description: string;
-  position: number;
-  active: boolean;
-  required: boolean;
-  collapsed_for_agents: boolean;
-  regexp_for_validation: string | null;
-  title_in_portal: string;
-  raw_title_in_portal: string;
-  visible_in_portal: boolean;
-  editable_in_portal: boolean;
-  required_in_portal: boolean;
-  tag: string;
   created_at: string;
   updated_at: string;
-  removable: boolean;
-  agent_description: string | null;
-  system_field_options: Record<string, unknown> | null;
-  custom_field_options: Array<{
-    id: number;
-    name: string;
-    raw_name: string;
-    value: string;
-    default: boolean;
-  }> | null;
-  sub_type_id: number | null;
-  follower_ids: number[] | null;
 }

--- a/connectors/src/connectors/zendesk/lib/types.ts
+++ b/connectors/src/connectors/zendesk/lib/types.ts
@@ -200,6 +200,7 @@ export interface ZendeskFetchedOrganization {
 export interface ZendeskFetchedTicketField {
   id: number;
   title: string;
+  active: boolean;
   created_at: string;
   updated_at: string;
 }

--- a/connectors/src/connectors/zendesk/lib/types.ts
+++ b/connectors/src/connectors/zendesk/lib/types.ts
@@ -195,3 +195,38 @@ export interface ZendeskFetchedOrganization {
   organization_fields: Record<string, string | number | boolean>;
   shared_brand_assets: boolean;
 }
+
+export interface ZendeskFetchedTicketField {
+  id: number;
+  url: string;
+  type: string;
+  title: string;
+  raw_title: string;
+  description: string;
+  raw_description: string;
+  position: number;
+  active: boolean;
+  required: boolean;
+  collapsed_for_agents: boolean;
+  regexp_for_validation: string | null;
+  title_in_portal: string;
+  raw_title_in_portal: string;
+  visible_in_portal: boolean;
+  editable_in_portal: boolean;
+  required_in_portal: boolean;
+  tag: string;
+  created_at: string;
+  updated_at: string;
+  removable: boolean;
+  agent_description: string | null;
+  system_field_options: Record<string, unknown> | null;
+  custom_field_options: Array<{
+    id: number;
+    name: string;
+    raw_name: string;
+    value: string;
+    default: boolean;
+  }> | null;
+  sub_type_id: number | null;
+  follower_ids: number[] | null;
+}

--- a/connectors/src/connectors/zendesk/lib/zendesk_api.ts
+++ b/connectors/src/connectors/zendesk/lib/zendesk_api.ts
@@ -720,6 +720,30 @@ export async function getOrganizationTagMapForTickets(
 }
 
 /**
+ * Fetches a single ticket field by ID from the Zendesk API.
+ */
+export async function getZendeskTicketFieldById({
+  accessToken,
+  subdomain,
+  fieldId,
+}: {
+  accessToken: string;
+  subdomain: string;
+  fieldId: number;
+}): Promise<ZendeskFetchedTicketField | null> {
+  const url = `https://${subdomain}.zendesk.com/api/v2/ticket_fields/${fieldId}`;
+  try {
+    const response = await fetchFromZendeskWithRetries({ url, accessToken });
+    return response?.ticket_field ?? null;
+  } catch (e) {
+    if (isZendeskNotFoundError(e)) {
+      return null;
+    }
+    throw e;
+  }
+}
+
+/**
  * Fetches all ticket fields from the Zendesk API.
  */
 export async function listZendeskTicketFields({

--- a/connectors/src/lib/models/zendesk.ts
+++ b/connectors/src/lib/models/zendesk.ts
@@ -56,6 +56,11 @@ export class ZendeskConfigurationModel extends ConnectorBaseModel<ZendeskConfigu
 
   declare ticketTagsToInclude: string[] | null;
   declare ticketTagsToExclude: string[] | null;
+
+  declare customFieldsConfig: {
+    id: number;
+    name: string;
+  }[];
 }
 
 ZendeskConfigurationModel.init(
@@ -104,6 +109,11 @@ ZendeskConfigurationModel.init(
     ticketTagsToExclude: {
       type: DataTypes.ARRAY(DataTypes.STRING),
       allowNull: true,
+    },
+    customFieldsConfig: {
+      type: DataTypes.JSONB,
+      allowNull: false,
+      defaultValue: [],
     },
   },
   {

--- a/connectors/src/resources/zendesk_resources.ts
+++ b/connectors/src/resources/zendesk_resources.ts
@@ -106,6 +106,7 @@ export class ZendeskConfigurationResource extends BaseResource<ZendeskConfigurat
       organizationTagsToExclude: this.organizationTagsToExclude,
       ticketTagsToInclude: this.ticketTagsToInclude,
       ticketTagsToExclude: this.ticketTagsToExclude,
+      customFieldsConfig: this.customFieldsConfig,
 
       connectorId: this.connectorId,
     };

--- a/front/components/data_source/ZendeskConfigView.tsx
+++ b/front/components/data_source/ZendeskConfigView.tsx
@@ -13,6 +13,7 @@ import { ZendeskOrganizationTagFilters } from "@app/components/data_source/Zende
 import { ZendeskTicketTagFilters } from "@app/components/data_source/ZendeskTicketTagFilters";
 import { useTheme } from "@app/components/sparkle/ThemeContext";
 import { useSendNotification } from "@app/hooks/useNotification";
+import { ZENDESK_CONFIG_KEYS } from "@app/lib/constants/zendesk";
 import { useConnectorConfig } from "@app/lib/swr/connectors";
 import type { DataSourceType, WorkspaceType } from "@app/types";
 
@@ -29,17 +30,13 @@ export function ZendeskConfigView({
 }) {
   const { isDark } = useTheme();
 
-  const unresolvedTicketsConfigKey = "zendeskSyncUnresolvedTicketsEnabled";
-  const hideCustomerDetailsConfigKey = "zendeskHideCustomerDetails";
-  const retentionPeriodConfigKey = "zendeskRetentionPeriodDays";
-
   const {
     configValue: syncUnresolvedTicketsConfigValue,
     mutateConfig: mutateSyncUnresolvedTicketsConfig,
   } = useConnectorConfig({
     owner,
     dataSource,
-    configKey: unresolvedTicketsConfigKey,
+    configKey: ZENDESK_CONFIG_KEYS.SYNC_UNRESOLVED_TICKETS,
   });
   const {
     configValue: hideCustomerDetailsConfigValue,
@@ -47,7 +44,7 @@ export function ZendeskConfigView({
   } = useConnectorConfig({
     owner,
     dataSource,
-    configKey: hideCustomerDetailsConfigKey,
+    configKey: ZENDESK_CONFIG_KEYS.HIDE_CUSTOMER_DETAILS,
   });
   const {
     configValue: retentionPeriodDays,
@@ -55,7 +52,7 @@ export function ZendeskConfigView({
   } = useConnectorConfig({
     owner,
     dataSource,
-    configKey: retentionPeriodConfigKey,
+    configKey: ZENDESK_CONFIG_KEYS.RETENTION_PERIOD,
   });
 
   const syncUnresolvedTicketsEnabled =
@@ -88,7 +85,7 @@ export function ZendeskConfigView({
       setLoading(false);
 
       // Show a notif only for the retention period (the others are toggles).
-      if (configKey === retentionPeriodConfigKey) {
+      if (configKey === ZENDESK_CONFIG_KEYS.RETENTION_PERIOD) {
         sendNotification({
           type: "success",
           title: "Retention period updated",
@@ -122,7 +119,7 @@ export function ZendeskConfigView({
         });
         return;
       }
-      await handleSetNewConfig(retentionPeriodConfigKey, numValue);
+      await handleSetNewConfig(ZENDESK_CONFIG_KEYS.RETENTION_PERIOD, numValue);
     }
   };
 
@@ -141,7 +138,7 @@ export function ZendeskConfigView({
               size="xs"
               onClick={async () => {
                 await handleSetNewConfig(
-                  unresolvedTicketsConfigKey,
+                  ZENDESK_CONFIG_KEYS.SYNC_UNRESOLVED_TICKETS,
                   !syncUnresolvedTicketsEnabled
                 );
               }}
@@ -171,7 +168,7 @@ export function ZendeskConfigView({
               size="xs"
               onClick={async () => {
                 await handleSetNewConfig(
-                  hideCustomerDetailsConfigKey,
+                  ZENDESK_CONFIG_KEYS.HIDE_CUSTOMER_DETAILS,
                   !hideCustomerDetailsEnabled
                 );
               }}

--- a/front/components/data_source/ZendeskConfigView.tsx
+++ b/front/components/data_source/ZendeskConfigView.tsx
@@ -8,6 +8,7 @@ import {
 } from "@dust-tt/sparkle";
 import { useState } from "react";
 
+import { ZendeskCustomFieldFilters } from "@app/components/data_source/ZendeskCustomTagFilters";
 import { ZendeskOrganizationTagFilters } from "@app/components/data_source/ZendeskOrganizationTagFilters";
 import { ZendeskTicketTagFilters } from "@app/components/data_source/ZendeskTicketTagFilters";
 import { useTheme } from "@app/components/sparkle/ThemeContext";
@@ -236,6 +237,12 @@ export function ZendeskConfigView({
         dataSource={dataSource}
       />
       <ZendeskOrganizationTagFilters
+        owner={owner}
+        readOnly={readOnly}
+        isAdmin={isAdmin}
+        dataSource={dataSource}
+      />
+      <ZendeskCustomFieldFilters
         owner={owner}
         readOnly={readOnly}
         isAdmin={isAdmin}

--- a/front/components/data_source/ZendeskCustomTagFilters.tsx
+++ b/front/components/data_source/ZendeskCustomTagFilters.tsx
@@ -251,7 +251,7 @@ export function ZendeskCustomFieldFilters({
                   trigger={
                     <Chip
                       label={field.name}
-                      color="blue"
+                      color="highlight"
                       size="sm"
                       onRemove={
                         !readOnly && isAdmin

--- a/front/components/data_source/ZendeskCustomTagFilters.tsx
+++ b/front/components/data_source/ZendeskCustomTagFilters.tsx
@@ -1,5 +1,6 @@
 import {
   Button,
+  Chip,
   ContextItem,
   Input,
   ZendeskLogo,
@@ -221,28 +222,19 @@ export function ZendeskCustomFieldFilters({
 
         <div>
           {customFields.length > 0 ? (
-            <div className="space-y-2">
+            <div className="flex flex-wrap gap-2">
               {customFields.map((field: CustomField) => (
-                <div
+                <Chip
                   key={field.id}
-                  className="flex items-center justify-between rounded-md border bg-gray-50 p-3 dark:bg-gray-800"
-                >
-                  <div className="flex items-center gap-2">
-                    <span className="inline-flex items-center rounded-full bg-blue-100 px-2 py-1 text-xs text-blue-800 dark:bg-blue-900 dark:text-blue-200">
-                      {field.name}
-                    </span>
-                  </div>
-                  {!readOnly && isAdmin && (
-                    <Button
-                      size="sm"
-                      variant="ghost"
-                      onClick={() => handleRemoveField(field.id)}
-                      disabled={loading}
-                      label="Remove"
-                      className="text-red-600 hover:text-red-700 dark:text-red-400 dark:hover:text-red-300"
-                    />
-                  )}
-                </div>
+                  label={field.name}
+                  color="blue"
+                  size="sm"
+                  onRemove={
+                    !readOnly && isAdmin
+                      ? () => handleRemoveField(field.id)
+                      : undefined
+                  }
+                />
               ))}
             </div>
           ) : (

--- a/front/components/data_source/ZendeskCustomTagFilters.tsx
+++ b/front/components/data_source/ZendeskCustomTagFilters.tsx
@@ -34,7 +34,6 @@ export function ZendeskCustomFieldFilters({
   const { isDark } = useTheme();
   const sendNotification = useSendNotification();
   const [inputValue, setInputValue] = useState("");
-  const [isEditing, setIsEditing] = useState(false);
 
   const {
     configValue: customFieldsConfigValue,
@@ -168,20 +167,10 @@ export function ZendeskCustomFieldFilters({
 
     await addCustomFieldByName(inputValue.trim());
     setInputValue("");
-    setIsEditing(false);
   };
 
   const handleRemoveField = async (fieldId: number) => {
     await removeCustomField(fieldId);
-  };
-
-  const handleEdit = () => {
-    setIsEditing(true);
-  };
-
-  const handleCancel = () => {
-    setInputValue("");
-    setIsEditing(false);
   };
 
   const handleKeyDown = (e: React.KeyboardEvent) => {
@@ -221,38 +210,20 @@ export function ZendeskCustomFieldFilters({
       }
       action={
         <div className="flex items-center gap-2">
-          {isEditing ? (
-            <>
-              <Input
-                value={inputValue}
-                onChange={(e) => setInputValue(e.target.value)}
-                onKeyDown={handleKeyDown}
-                placeholder="Enter custom field name"
-                disabled={readOnly || !isAdmin || loading}
-                className="w-80"
-              />
-              <Button
-                size="sm"
-                onClick={handleSave}
-                disabled={readOnly || !isAdmin || loading || !inputValue.trim()}
-                label="Add"
-              />
-              <Button
-                size="sm"
-                variant="ghost-secondary"
-                onClick={handleCancel}
-                disabled={readOnly || !isAdmin || loading}
-                label="Cancel"
-              />
-            </>
-          ) : (
-            <Button
-              size="sm"
-              onClick={handleEdit}
-              disabled={readOnly || !isAdmin || loading}
-              label="Add Custom Field"
-            />
-          )}
+          <Input
+            value={inputValue}
+            onChange={(e) => setInputValue(e.target.value)}
+            onKeyDown={handleKeyDown}
+            placeholder="Enter custom field name"
+            disabled={readOnly || !isAdmin || loading}
+            className="w-80"
+          />
+          <Button
+            size="sm"
+            onClick={handleSave}
+            disabled={readOnly || !isAdmin || loading || !inputValue.trim()}
+            label="Add"
+          />
         </div>
       }
     >

--- a/front/components/data_source/ZendeskCustomTagFilters.tsx
+++ b/front/components/data_source/ZendeskCustomTagFilters.tsx
@@ -231,9 +231,7 @@ export function ZendeskCustomFieldFilters({
         <div className="text-muted-foreground dark:text-muted-foreground-night">
           <p className="mb-4">
             Configure custom ticket field that should be included as labels on
-            synced tickets. Custom field values will be added as tags in the
-            format "fieldName:value", making them searchable and filterable in
-            Dust.
+            synced tickets.
           </p>
 
           {customFields.length > 0 ? (

--- a/front/components/data_source/ZendeskCustomTagFilters.tsx
+++ b/front/components/data_source/ZendeskCustomTagFilters.tsx
@@ -2,7 +2,6 @@ import {
   Button,
   ContextItem,
   Input,
-  XMarkIcon,
   ZendeskLogo,
   ZendeskWhiteLogo,
 } from "@dust-tt/sparkle";
@@ -180,74 +179,82 @@ export function ZendeskCustomFieldFilters({
     }
   };
 
-  const renderCustomFields = () => (
-    <div className="flex flex-wrap gap-2">
-      {customFields.map((field: CustomField) => (
-        <span
-          key={field.id}
-          className="inline-flex items-center gap-1 rounded-md bg-blue-100 px-3 py-1 text-sm font-medium text-blue-800 dark:bg-blue-900 dark:text-blue-200"
-        >
-          {field.name}
-          {!readOnly && isAdmin && (
-            <button
-              onClick={() => handleRemoveField(field.id)}
-              disabled={loading}
-              className="ml-1 hover:opacity-70 disabled:opacity-50"
-            >
-              <XMarkIcon className="h-3 w-3" />
-            </button>
-          )}
-        </span>
-      ))}
-    </div>
-  );
-
   return (
     <ContextItem
       title="Custom Field Tags"
       visual={
         <ContextItem.Visual visual={isDark ? ZendeskWhiteLogo : ZendeskLogo} />
       }
-      action={
-        <div className="flex items-center gap-2">
-          <Input
-            value={inputValue}
-            onChange={(e) => setInputValue(e.target.value)}
-            onKeyDown={handleKeyDown}
-            placeholder="Enter custom field name"
-            disabled={readOnly || !isAdmin || loading}
-            className="w-80"
-          />
-          <Button
-            size="sm"
-            onClick={handleSave}
-            disabled={readOnly || !isAdmin || loading || !inputValue.trim()}
-            label="Add"
-          />
-        </div>
-      }
     >
-      <ContextItem.Description>
+      <div className="space-y-4">
         <div className="text-muted-foreground dark:text-muted-foreground-night">
-          <p className="mb-4">
-            Configure custom ticket field that should be included as labels on
-            synced tickets.
+          <p className="text-sm">
+            Configure custom ticket field names that should be included as tags
+            when syncing tickets. Custom field values will be added as tags in
+            the format "fieldName:value".
           </p>
+        </div>
 
+        {!readOnly && isAdmin && (
+          <div className="space-y-3">
+            <div className="flex gap-2">
+              <Input
+                value={inputValue}
+                onChange={(e) => setInputValue(e.target.value)}
+                onKeyDown={handleKeyDown}
+                placeholder="Enter custom field name"
+                disabled={loading}
+              />
+              <Button
+                size="sm"
+                onClick={handleSave}
+                disabled={loading || !inputValue.trim()}
+                label="Add Field"
+              />
+            </div>
+            <p className="text-xs text-muted-foreground dark:text-muted-foreground-night">
+              Enter the exact name of the custom field as it appears in Zendesk.
+              The field will be validated when added.
+            </p>
+          </div>
+        )}
+
+        <div>
           {customFields.length > 0 ? (
-            <div className="mb-4">
-              <p className="mb-2 text-sm font-medium">
-                Configured Custom Fields:
-              </p>
-              {renderCustomFields()}
+            <div className="space-y-2">
+              {customFields.map((field: CustomField) => (
+                <div
+                  key={field.id}
+                  className="flex items-center justify-between rounded-md border bg-gray-50 p-3 dark:bg-gray-800"
+                >
+                  <div className="flex items-center gap-2">
+                    <span className="inline-flex items-center rounded-full bg-blue-100 px-2 py-1 text-xs text-blue-800 dark:bg-blue-900 dark:text-blue-200">
+                      {field.name}
+                    </span>
+                  </div>
+                  {!readOnly && isAdmin && (
+                    <Button
+                      size="sm"
+                      variant="ghost"
+                      onClick={() => handleRemoveField(field.id)}
+                      disabled={loading}
+                      label="Remove"
+                      className="text-red-600 hover:text-red-700 dark:text-red-400 dark:hover:text-red-300"
+                    />
+                  )}
+                </div>
+              ))}
             </div>
           ) : (
-            <p className="mb-4 text-sm text-muted-foreground dark:text-muted-foreground-night">
-              No custom fields configured.
-            </p>
+            <div className="rounded-md border border-dashed bg-gray-50 p-4 dark:bg-gray-800">
+              <p className="text-center text-sm text-muted-foreground">
+                No custom fields configured yet. Add your first custom field
+                below.
+              </p>
+            </div>
           )}
         </div>
-      </ContextItem.Description>
+      </div>
     </ContextItem>
   );
 }

--- a/front/components/data_source/ZendeskCustomTagFilters.tsx
+++ b/front/components/data_source/ZendeskCustomTagFilters.tsx
@@ -13,6 +13,7 @@ import { useSendNotification } from "@app/hooks/useNotification";
 import { ZENDESK_CONFIG_KEYS } from "@app/lib/constants/zendesk";
 import { useConnectorConfig } from "@app/lib/swr/connectors";
 import type { DataSourceType, WorkspaceType } from "@app/types";
+import { safeParseJSON } from "@app/types";
 
 interface CustomField {
   id: number;
@@ -53,7 +54,7 @@ export function ZendeskCustomFieldFilters({
     if (parsingResult.isErr()) {
       return [];
     }
-    return parsingResult.value;
+    return (parsingResult.value || []) as CustomField[];
   }, [customFieldsConfigValue]);
 
   const addCustomFieldByName = useCallback(
@@ -258,10 +259,10 @@ export function ZendeskCustomFieldFilters({
       <ContextItem.Description>
         <div className="text-muted-foreground dark:text-muted-foreground-night">
           <p className="mb-4">
-            Configure custom ticket field names that should be included as tags
-            when syncing tickets. Custom field values will be added as tags in
-            the format "fieldName:value", making them searchable and filterable
-            in Dust.
+            Configure custom ticket field that should be included as labels on
+            synced tickets. Custom field values will be added as tags in the
+            format "fieldName:value", making them searchable and filterable in
+            Dust.
           </p>
 
           {customFields.length > 0 ? (
@@ -272,18 +273,10 @@ export function ZendeskCustomFieldFilters({
               {renderCustomFields()}
             </div>
           ) : (
-            <p className="mb-4 text-sm text-muted-foreground">
-              No custom fields configured. Custom field values will not be added
-              as tags.
+            <p className="mb-4 text-sm text-muted-foreground dark:text-muted-foreground-night">
+              No custom fields configured.
             </p>
           )}
-
-          <p className="mt-2 text-xs text-muted-foreground">
-            Enter the exact name of the custom field as it appears in Zendesk.
-            The field will be validated against available fields when added.
-            Field values will be formatted as "fieldName:value" tags during
-            sync.
-          </p>
         </div>
       </ContextItem.Description>
     </ContextItem>

--- a/front/components/data_source/ZendeskCustomTagFilters.tsx
+++ b/front/components/data_source/ZendeskCustomTagFilters.tsx
@@ -238,12 +238,9 @@ export function ZendeskCustomFieldFilters({
               ))}
             </div>
           ) : (
-            <div className="rounded-md border border-dashed bg-gray-50 p-4 dark:bg-gray-800">
-              <p className="text-center text-sm text-muted-foreground">
-                No custom fields configured yet. Add your first custom field
-                below.
-              </p>
-            </div>
+            <p className="mb-4 text-sm text-muted-foreground dark:text-muted-foreground-night">
+              No tag filters configured.
+            </p>
           )}
         </div>
       </div>

--- a/front/components/data_source/ZendeskCustomTagFilters.tsx
+++ b/front/components/data_source/ZendeskCustomTagFilters.tsx
@@ -1,0 +1,291 @@
+import {
+  Button,
+  ContextItem,
+  Input,
+  XMarkIcon,
+  ZendeskLogo,
+  ZendeskWhiteLogo,
+} from "@dust-tt/sparkle";
+import { useCallback, useMemo, useState } from "react";
+
+import { useTheme } from "@app/components/sparkle/ThemeContext";
+import { useSendNotification } from "@app/hooks/useNotification";
+import { ZENDESK_CONFIG_KEYS } from "@app/lib/constants/zendesk";
+import { useConnectorConfig } from "@app/lib/swr/connectors";
+import type { DataSourceType, WorkspaceType } from "@app/types";
+
+interface CustomField {
+  id: number;
+  name: string;
+}
+
+export function ZendeskCustomFieldFilters({
+  owner,
+  readOnly,
+  isAdmin,
+  dataSource,
+}: {
+  owner: WorkspaceType;
+  readOnly: boolean;
+  isAdmin: boolean;
+  dataSource: DataSourceType;
+}) {
+  const { isDark } = useTheme();
+  const sendNotification = useSendNotification();
+  const [inputValue, setInputValue] = useState("");
+  const [isEditing, setIsEditing] = useState(false);
+
+  const {
+    configValue: customFieldsConfigValue,
+    mutateConfig: mutateCustomFieldsConfig,
+    isResourcesLoading: loading,
+  } = useConnectorConfig({
+    configKey: ZENDESK_CONFIG_KEYS.CUSTOM_FIELDS_CONFIG,
+    dataSource,
+    owner,
+  });
+
+  const customFields: CustomField[] = useMemo(() => {
+    if (!customFieldsConfigValue) {
+      return [];
+    }
+    const parsingResult = safeParseJSON(customFieldsConfigValue);
+    if (parsingResult.isErr()) {
+      return [];
+    }
+    return parsingResult.value;
+  }, [customFieldsConfigValue]);
+
+  const addCustomFieldByName = useCallback(
+    async (fieldName: string) => {
+      const trimmedFieldName = fieldName.trim();
+      if (!trimmedFieldName) {
+        sendNotification({
+          type: "info",
+          title: "Invalid field name",
+          description: "Field name cannot be empty.",
+        });
+        return;
+      }
+
+      // Get current field names and add the new one.
+      const currentFieldNames = customFields.map((field) => field.name);
+      const updatedFieldNames = [...currentFieldNames, trimmedFieldName];
+
+      const res = await fetch(
+        `/api/w/${owner.sId}/data_sources/${dataSource.sId}/managed/config/${ZENDESK_CONFIG_KEYS.CUSTOM_FIELDS_CONFIG}`,
+        {
+          headers: { "Content-Type": "application/json" },
+          method: "POST",
+          body: JSON.stringify({
+            configValue: JSON.stringify(updatedFieldNames),
+          }),
+        }
+      );
+
+      if (res.ok) {
+        await mutateCustomFieldsConfig();
+        sendNotification({
+          type: "success",
+          title: "Custom field added",
+          description: `Added custom field "${trimmedFieldName}".`,
+        });
+      } else {
+        const err = await res.json();
+        sendNotification({
+          type: "error",
+          title: "Failed to add custom field",
+          description:
+            err.error?.connectors_error?.message || "An unknown error occurred",
+        });
+      }
+    },
+    [
+      owner.sId,
+      dataSource.sId,
+      customFields,
+      mutateCustomFieldsConfig,
+      sendNotification,
+    ]
+  );
+
+  const removeCustomField = useCallback(
+    async (fieldId: number) => {
+      const fieldToRemove = customFields.find((field) => field.id === fieldId);
+      if (!fieldToRemove) {
+        sendNotification({
+          type: "info",
+          title: "Field not found",
+          description: "The field is not configured.",
+        });
+        return;
+      }
+
+      const newFields = customFields
+        .filter((field) => field.id !== fieldId)
+        .map((field) => field.name);
+
+      const res = await fetch(
+        `/api/w/${owner.sId}/data_sources/${dataSource.sId}/managed/config/${ZENDESK_CONFIG_KEYS.CUSTOM_FIELDS_CONFIG}`,
+        {
+          headers: { "Content-Type": "application/json" },
+          method: "POST",
+          body: JSON.stringify({ configValue: JSON.stringify(newFields) }),
+        }
+      );
+
+      if (res.ok) {
+        await mutateCustomFieldsConfig();
+        sendNotification({
+          type: "success",
+          title: "Custom field removed",
+          description: `Removed custom field "${fieldToRemove.name}".`,
+        });
+      } else {
+        const err = await res.json();
+        sendNotification({
+          type: "error",
+          title: "Failed to remove custom field",
+          description:
+            err.error?.connectors_error?.message || "An unknown error occurred",
+        });
+      }
+    },
+    [
+      owner.sId,
+      dataSource.sId,
+      customFields,
+      mutateCustomFieldsConfig,
+      sendNotification,
+    ]
+  );
+
+  const handleSave = async () => {
+    if (!inputValue.trim()) {
+      return;
+    }
+
+    await addCustomFieldByName(inputValue.trim());
+    setInputValue("");
+    setIsEditing(false);
+  };
+
+  const handleRemoveField = async (fieldId: number) => {
+    await removeCustomField(fieldId);
+  };
+
+  const handleEdit = () => {
+    setIsEditing(true);
+  };
+
+  const handleCancel = () => {
+    setInputValue("");
+    setIsEditing(false);
+  };
+
+  const handleKeyDown = (e: React.KeyboardEvent) => {
+    if (e.key === "Enter") {
+      e.preventDefault();
+      void handleSave();
+    }
+  };
+
+  const renderCustomFields = () => (
+    <div className="flex flex-wrap gap-2">
+      {customFields.map((field: CustomField) => (
+        <span
+          key={field.id}
+          className="inline-flex items-center gap-1 rounded-md bg-blue-100 px-3 py-1 text-sm font-medium text-blue-800 dark:bg-blue-900 dark:text-blue-200"
+        >
+          {field.name}
+          {!readOnly && isAdmin && (
+            <button
+              onClick={() => handleRemoveField(field.id)}
+              disabled={loading}
+              className="ml-1 hover:opacity-70 disabled:opacity-50"
+            >
+              <XMarkIcon className="h-3 w-3" />
+            </button>
+          )}
+        </span>
+      ))}
+    </div>
+  );
+
+  return (
+    <ContextItem
+      title="Custom Field Tags"
+      visual={
+        <ContextItem.Visual visual={isDark ? ZendeskWhiteLogo : ZendeskLogo} />
+      }
+      action={
+        <div className="flex items-center gap-2">
+          {isEditing ? (
+            <>
+              <Input
+                value={inputValue}
+                onChange={(e) => setInputValue(e.target.value)}
+                onKeyDown={handleKeyDown}
+                placeholder="Enter custom field name"
+                disabled={readOnly || !isAdmin || loading}
+                className="w-80"
+              />
+              <Button
+                size="sm"
+                onClick={handleSave}
+                disabled={readOnly || !isAdmin || loading || !inputValue.trim()}
+                label="Add"
+              />
+              <Button
+                size="sm"
+                variant="ghost-secondary"
+                onClick={handleCancel}
+                disabled={readOnly || !isAdmin || loading}
+                label="Cancel"
+              />
+            </>
+          ) : (
+            <Button
+              size="sm"
+              onClick={handleEdit}
+              disabled={readOnly || !isAdmin || loading}
+              label="Add Custom Field"
+            />
+          )}
+        </div>
+      }
+    >
+      <ContextItem.Description>
+        <div className="text-muted-foreground dark:text-muted-foreground-night">
+          <p className="mb-4">
+            Configure custom ticket field names that should be included as tags
+            when syncing tickets. Custom field values will be added as tags in
+            the format "fieldName:value", making them searchable and filterable
+            in Dust.
+          </p>
+
+          {customFields.length > 0 ? (
+            <div className="mb-4">
+              <p className="mb-2 text-sm font-medium">
+                Configured Custom Fields:
+              </p>
+              {renderCustomFields()}
+            </div>
+          ) : (
+            <p className="mb-4 text-sm text-muted-foreground">
+              No custom fields configured. Custom field values will not be added
+              as tags.
+            </p>
+          )}
+
+          <p className="mt-2 text-xs text-muted-foreground">
+            Enter the exact name of the custom field as it appears in Zendesk.
+            The field will be validated against available fields when added.
+            Field values will be formatted as "fieldName:value" tags during
+            sync.
+          </p>
+        </div>
+      </ContextItem.Description>
+    </ContextItem>
+  );
+}

--- a/front/components/data_source/ZendeskTagFilters.tsx
+++ b/front/components/data_source/ZendeskTagFilters.tsx
@@ -204,7 +204,7 @@ export function ZendeskTagFilters({
           )}
 
           {!hasTags && (
-            <p className="mb-4 text-sm text-muted-foreground">
+            <p className="mb-4 text-sm text-muted-foreground dark:text-muted-foreground-night">
               No tag filters configured.
             </p>
           )}

--- a/front/components/data_source/ZendeskTicketTagFilters.tsx
+++ b/front/components/data_source/ZendeskTicketTagFilters.tsx
@@ -22,7 +22,7 @@ export function ZendeskTicketTagFilters({
       isAdmin={isAdmin}
       title="Ticket Tag Filters"
       description={
-        "Include or exclude tickets from the sync based on their tags." +
+        "Include or exclude tickets from the sync based on their tags. " +
         "These filters only apply to future syncing and will not retroactively remove " +
         "already-synced tickets."
       }

--- a/front/components/data_source/ZendeskTicketTagFilters.tsx
+++ b/front/components/data_source/ZendeskTicketTagFilters.tsx
@@ -22,7 +22,7 @@ export function ZendeskTicketTagFilters({
       isAdmin={isAdmin}
       title="Ticket Tag Filters"
       description={
-        "Include or exclude tickets from the sync based on their tags. " +
+        "Include or exclude tickets from the sync based on their tags." +
         "These filters only apply to future syncing and will not retroactively remove " +
         "already-synced tickets."
       }

--- a/front/hooks/useZendeskOrganizationTagFilters.ts
+++ b/front/hooks/useZendeskOrganizationTagFilters.ts
@@ -1,8 +1,8 @@
 import { useCallback } from "react";
 
 import { useSendNotification } from "@app/hooks/useNotification";
-import { useConnectorConfig } from "@app/lib/swr/connectors";
 import { ZENDESK_CONFIG_KEYS } from "@app/lib/constants/zendesk";
+import { useConnectorConfig } from "@app/lib/swr/connectors";
 import type { DataSourceType, WorkspaceType } from "@app/types";
 
 export function useZendeskOrganizationTagFilters({

--- a/front/lib/constants/zendesk.ts
+++ b/front/lib/constants/zendesk.ts
@@ -3,4 +3,5 @@ export const ZENDESK_CONFIG_KEYS = {
   TICKET_TAGS_TO_EXCLUDE: "zendeskTicketTagsToExclude",
   ORGANIZATION_TAGS_TO_INCLUDE: "zendeskOrganizationTagsToInclude",
   ORGANIZATION_TAGS_TO_EXCLUDE: "zendeskOrganizationTagsToExclude",
+  CUSTOM_FIELDS_CONFIG: "zendeskCustomFieldsConfig",
 } as const;

--- a/front/lib/constants/zendesk.ts
+++ b/front/lib/constants/zendesk.ts
@@ -4,4 +4,7 @@ export const ZENDESK_CONFIG_KEYS = {
   ORGANIZATION_TAGS_TO_INCLUDE: "zendeskOrganizationTagsToInclude",
   ORGANIZATION_TAGS_TO_EXCLUDE: "zendeskOrganizationTagsToExclude",
   CUSTOM_FIELDS_CONFIG: "zendeskCustomFieldsConfig",
+  SYNC_UNRESOLVED_TICKETS: "zendeskSyncUnresolvedTicketsEnabled",
+  HIDE_CUSTOMER_DETAILS: "zendeskHideCustomerDetails",
+  RETENTION_PERIOD: "zendeskRetentionPeriodDays",
 } as const;

--- a/front/pages/api/w/[wId]/data_sources/[dsId]/managed/config/[key]/index.ts
+++ b/front/pages/api/w/[wId]/data_sources/[dsId]/managed/config/[key]/index.ts
@@ -89,6 +89,7 @@ async function handler(
       "zendeskTicketTagsToExclude",
       "zendeskOrganizationTagsToInclude",
       "zendeskOrganizationTagsToExclude",
+      "zendeskCustomFieldsConfig",
       "gongRetentionPeriodDays",
       "gongTrackersEnabled",
       "privateIntegrationCredentialId",


### PR DESCRIPTION
## Description

- Closes https://github.com/dust-tt/tasks/issues/3557.
- Custom fields are a feature of Zendesk, they act like tags that can be added to tickets with a certain value.
- This PR allows configuring a set of custom fields that should be added as tags (labels) on tickets.
- The current UX requires inputting the IDs of the fields, which are exposed in Zendesk on the main custom field configuration page.

## Tests

- Tested locally.

## Risk

- Low, mostly additive.

## Deploy Plan

- Run migration.
- Deploy connectors.
- Deploy front.
