### PR TITLE
[front] Shorten description of Zendesk configuration items

### DIFF
--- a/front/components/data_source/ZendeskConfigView.tsx
+++ b/front/components/data_source/ZendeskConfigView.tsx
@@ -152,9 +152,7 @@ export function ZendeskConfigView({
       >
         <ContextItem.Description>
           <div className="text-muted-foreground dark:text-muted-foreground-night">
-            If activated, Dust will also sync the unresolved tickets. This may
-            significantly increase the number of synced tickets, potentially
-            negatively affecting the response quality due to the added noise.
+            If activated, Dust will also sync the unresolved tickets.
           </div>
         </ContextItem.Description>
       </ContextItem>
@@ -225,8 +223,8 @@ export function ZendeskConfigView({
       >
         <ContextItem.Description>
           <div className="text-muted-foreground dark:text-muted-foreground-night">
-            Set the duration of the retention period: tickets older than the
-            retention period will be cleaned on a daily basis.
+            Set the retention period, outdated tickets will be cleaned on a
+            daily basis.
           </div>
         </ContextItem.Description>
       </ContextItem>

--- a/front/components/data_source/ZendeskOrganizationTagFilters.tsx
+++ b/front/components/data_source/ZendeskOrganizationTagFilters.tsx
@@ -26,10 +26,8 @@ export function ZendeskOrganizationTagFilters({
       isAdmin={isAdmin}
       title="Organization Tag Filters"
       description={
-        "Configure organization tags to control which tickets are synced based on their " +
-        "associated organization. Add 'Included' tags to sync only tickets from organizations with " +
-        "those tags, or add 'Excluded' tags to filter out tickets from organizations with specific " +
-        "tags. These filters only apply to future syncing and will not retroactively remove " +
+        "Include or exclude tickets from the sync based on their associated organization. " +
+        "These filters only apply to future syncing and will not retroactively remove " +
         "already-synced tickets."
       }
       tagFilters={organizationTagFilters}

--- a/front/components/data_source/ZendeskTagFilters.tsx
+++ b/front/components/data_source/ZendeskTagFilters.tsx
@@ -201,14 +201,9 @@ export function ZendeskTagFilters({
 
           {!hasTags && (
             <p className="mb-4 text-sm text-muted-foreground">
-              No tag filters configured. All items will be synced.
+              No tag filters configured.
             </p>
           )}
-
-          <p className="mt-2 text-xs text-muted-foreground">
-            Enter one tag at a time. Excluded tags take precedence over included
-            tags.
-          </p>
         </div>
       </ContextItem.Description>
     </ContextItem>

--- a/front/components/data_source/ZendeskTicketTagFilters.tsx
+++ b/front/components/data_source/ZendeskTicketTagFilters.tsx
@@ -22,9 +22,8 @@ export function ZendeskTicketTagFilters({
       isAdmin={isAdmin}
       title="Ticket Tag Filters"
       description={
-        "Configure tags to control which tickets are synced to Dust. Add 'Included' tags to sync " +
-        "only tickets with those tags, or add 'Excluded' tags to filter out tickets with those " +
-        "tags. These filters only apply to future syncing and will not retroactively remove " +
+        "Include or exclude tickets from the sync based on their tags." +
+        "These filters only apply to future syncing and will not retroactively remove " +
         "already-synced tickets."
       }
       tagFilters={ticketTagFilters}

--- a/front/components/data_source/ZendeskTicketTagFilters.tsx
+++ b/front/components/data_source/ZendeskTicketTagFilters.tsx
@@ -22,7 +22,7 @@ export function ZendeskTicketTagFilters({
       isAdmin={isAdmin}
       title="Ticket Tag Filters"
       description={
-        "Include or exclude tickets from the sync based on their tags." +
+        "Include or exclude tickets from the sync based on their tags. " +
         "These filters only apply to future syncing and will not retroactively remove " +
         "already-synced tickets."
       }


### PR DESCRIPTION
## Description

- This PR shortens the descriptions of each item in the connectors permissions modal for Zendesk connectors.

Before:
<img width="570" height="589" alt="Screenshot 2025-08-07 at 9 29 12 AM" src="https://github.com/user-attachments/assets/61029456-649e-42a8-acde-8e946f77c4e6" />

After:
<img width="570" height="595" alt="Screenshot 2025-08-06 at 11 22 02 PM" src="https://github.com/user-attachments/assets/adb6cb2b-45c7-4400-b24b-6f81d5afcbcf" />

Having overly long descriptions gives less room for the actual permissions selection.

## Tests

- Checked locally.

## Risk

- N/A, only UI.

## Deploy Plan

- Deploy front.
