### PR TITLE
[front] Improve UI for Zendesk tag filters

### DIFF
--- a/front/components/data_source/ZendeskConfigView.tsx
+++ b/front/components/data_source/ZendeskConfigView.tsx
@@ -206,7 +206,9 @@ export function ZendeskConfigView({
               placeholder={retentionPeriodDays ?? undefined}
               className="w-20"
             />
-            <span className="text-sm text-muted-foreground">days</span>
+            <span className="text-sm text-muted-foreground dark:text-muted-foreground-night">
+              days
+            </span>
             <Button
               size="sm"
               onClick={handleRetentionPeriodSave}

--- a/front/components/data_source/ZendeskConfigView.tsx
+++ b/front/components/data_source/ZendeskConfigView.tsx
@@ -196,37 +196,36 @@ export function ZendeskConfigView({
             visual={isDark ? ZendeskWhiteLogo : ZendeskLogo}
           />
         }
-        action={
-          <div className="flex items-center gap-2">
-            <Input
-              value={retentionInput}
-              type="number"
-              onChange={(e) => setRetentionInput(e.target.value)}
-              disabled={readOnly || !isAdmin || loading}
-              placeholder={retentionPeriodDays ?? undefined}
-              className="w-20"
-            />
-            <span className="text-sm text-muted-foreground dark:text-muted-foreground-night">
-              days
-            </span>
-            <Button
-              size="sm"
-              onClick={handleRetentionPeriodSave}
-              disabled={
-                readOnly ||
-                !isAdmin ||
-                loading ||
-                retentionInput === retentionPeriodDays?.toString()
-              }
-              label="Save"
-            />
-          </div>
-        }
       >
         <ContextItem.Description>
-          <div className="text-muted-foreground dark:text-muted-foreground-night">
-            Set the retention period, outdated tickets will be cleaned on a
-            daily basis.
+          <div className="mb-4 flex items-start justify-between gap-4 text-muted-foreground dark:text-muted-foreground-night">
+            <span>
+              Set the retention period, outdated tickets will be cleaned on a daily basis.
+            </span>
+            <div className="flex items-center gap-2">
+              <Input
+                value={retentionInput}
+                type="number"
+                onChange={(e) => setRetentionInput(e.target.value)}
+                disabled={readOnly || !isAdmin || loading}
+                placeholder={retentionPeriodDays ?? undefined}
+                className="w-20"
+              />
+              <span className="text-sm text-muted-foreground dark:text-muted-foreground-night">
+                days
+              </span>
+              <Button
+                size="sm"
+                onClick={handleRetentionPeriodSave}
+                disabled={
+                  readOnly ||
+                  !isAdmin ||
+                  loading ||
+                  retentionInput === retentionPeriodDays?.toString()
+                }
+                label="Save"
+              />
+            </div>
           </div>
         </ContextItem.Description>
       </ContextItem>

--- a/front/components/data_source/ZendeskConfigView.tsx
+++ b/front/components/data_source/ZendeskConfigView.tsx
@@ -199,9 +199,8 @@ export function ZendeskConfigView({
       >
         <ContextItem.Description>
           <div className="mb-4 flex items-start justify-between gap-4 text-muted-foreground dark:text-muted-foreground-night">
-            <span>
-              Set the retention period, outdated tickets will be cleaned on a daily basis.
-            </span>
+            Set the retention period (in days), tickets older than the retention
+            period will not be synced with Dust.
             <div className="flex items-center gap-2">
               <Input
                 value={retentionInput}

--- a/front/components/data_source/ZendeskConfigView.tsx
+++ b/front/components/data_source/ZendeskConfigView.tsx
@@ -208,12 +208,13 @@ export function ZendeskConfigView({
                 type="number"
                 onChange={(e) => setRetentionInput(e.target.value)}
                 disabled={readOnly || !isAdmin || loading}
-                placeholder={retentionPeriodDays ?? undefined}
-                className="w-20"
+                placeholder={
+                  retentionPeriodDays
+                    ? `${retentionPeriodDays} days`
+                    : undefined
+                }
+                className="w-24"
               />
-              <span className="text-sm text-muted-foreground dark:text-muted-foreground-night">
-                days
-              </span>
               <Button
                 size="sm"
                 onClick={handleRetentionPeriodSave}

--- a/front/components/data_source/ZendeskTagFilters.tsx
+++ b/front/components/data_source/ZendeskTagFilters.tsx
@@ -116,7 +116,7 @@ export function ZendeskTagFilters({
         <ContextItem.Visual visual={isDark ? ZendeskWhiteLogo : ZendeskLogo} />
       }
       action={
-        <div className="flex items-center gap-2">
+        <div className="flex flex-col gap-2">
           {isEditing ? (
             <>
               <div className="flex flex-col gap-2">
@@ -137,32 +137,33 @@ export function ZendeskTagFilters({
                   onKeyDown={handleKeyDown}
                   placeholder={placeholder}
                   disabled={readOnly || !isAdmin || loading}
-                  className="w-80"
                 />
               </div>
-              <Button
-                size="sm"
-                onClick={handleSave}
-                disabled={readOnly || !isAdmin || loading || !inputValue.trim()}
-                label="Add"
-              />
-              <Button
-                size="sm"
-                variant="ghost-secondary"
-                onClick={handleCancel}
-                disabled={readOnly || !isAdmin || loading}
-                label="Cancel"
-              />
+              <div className="flex items-center justify-end gap-2">
+                <Button
+                  size="sm"
+                  onClick={handleSave}
+                  disabled={
+                    readOnly || !isAdmin || loading || !inputValue.trim()
+                  }
+                  label="Add"
+                />
+                <Button
+                  size="sm"
+                  variant="outline"
+                  onClick={handleCancel}
+                  disabled={readOnly || !isAdmin || loading}
+                  label="Cancel"
+                />
+              </div>
             </>
           ) : (
-            <>
-              <Button
-                size="sm"
-                onClick={handleEdit}
-                disabled={readOnly || !isAdmin || loading}
-                label="Add Tags"
-              />
-            </>
+            <Button
+              size="sm"
+              onClick={handleEdit}
+              disabled={readOnly || !isAdmin || loading}
+              label="Add Tags"
+            />
           )}
         </div>
       }

--- a/front/components/data_source/ZendeskTagFilters.tsx
+++ b/front/components/data_source/ZendeskTagFilters.tsx
@@ -117,7 +117,7 @@ export function ZendeskTagFilters({
       }
       action={
         <div className="flex flex-col gap-2">
-          {isEditing ? (
+          {isEditing && (
             <>
               <div className="flex flex-col gap-2">
                 <Tabs
@@ -157,20 +157,23 @@ export function ZendeskTagFilters({
                 />
               </div>
             </>
-          ) : (
-            <Button
-              size="sm"
-              onClick={handleEdit}
-              disabled={readOnly || !isAdmin || loading}
-              label="Add Tags"
-            />
           )}
         </div>
       }
     >
       <ContextItem.Description>
         <div className="text-muted-foreground dark:text-muted-foreground-night">
-          <p className="mb-4">{description}</p>
+          <div className="mb-4 flex items-start justify-between gap-4">
+            <p>{description}</p>
+            {!isEditing && (
+              <Button
+                size="sm"
+                onClick={handleEdit}
+                disabled={readOnly || !isAdmin || loading}
+                label="Add Tags"
+              />
+            )}
+          </div>
 
           {hasIncludedTags && (
             <div className="mb-4">


### PR DESCRIPTION
## Description

- This PR aims at improving the UI for configuring tags for a Zendesk connector.
- Having an overly large component for inputting tags causes the description to wrap heavily. This PR comes hand in hand with https://github.com/dust-tt/dust/pull/14855 for shorter descriptions.
- The component with the Tabs and the two Buttons is made smaller.

Before:
<img width="570" height="570" alt="Screenshot 2025-08-06 at 11 30 00 PM" src="https://github.com/user-attachments/assets/2903ef3b-7de1-4e87-8238-3662db2cec0c" />

After:
<img width="570" height="589" alt="Screenshot 2025-08-07 at 12 00 30 AM" src="https://github.com/user-attachments/assets/dbb4c678-271c-4ca4-be05-e819a156e95a" />

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
