### PR TITLE
[front] conversation: add read state to convos

### DIFF
--- a/front/components/assistant/conversation/SidebarMenu.tsx
+++ b/front/components/assistant/conversation/SidebarMenu.tsx
@@ -402,9 +402,9 @@ const RenderConversation = ({
         <NavigationListItem
           selected={router.query.cId === conversation.sId}
           icon={
-            conversation.state === "action_required"
+            conversation.actionRequired
               ? ActionRequiredIcon
-              : conversation.state === "unread"
+              : conversation.unread
                 ? ClockIcon
                 : undefined
           }

--- a/front/components/assistant/conversation/SidebarMenu.tsx
+++ b/front/components/assistant/conversation/SidebarMenu.tsx
@@ -2,11 +2,14 @@ import {
   Button,
   ChatBubbleBottomCenterTextIcon,
   Checkbox,
+  ClockIcon,
   DropdownMenu,
   DropdownMenuContent,
   DropdownMenuItem,
   DropdownMenuLabel,
   DropdownMenuTrigger,
+  Icon,
+  InformationCircleIcon,
   Label,
   ListCheckIcon,
   MoreIcon,
@@ -374,6 +377,10 @@ const RenderConversation = ({
       ? "New Conversation"
       : `Conversation from ${new Date(conversation.created).toLocaleDateString()}`);
 
+  const ActionRequiredIcon = () => (
+    <Icon visual={InformationCircleIcon} className="text-golden-700" />
+  );
+
   return (
     <>
       {isMultiSelect ? (
@@ -394,6 +401,13 @@ const RenderConversation = ({
       ) : (
         <NavigationListItem
           selected={router.query.cId === conversation.sId}
+          icon={
+            conversation.state === "action_required"
+              ? ActionRequiredIcon
+              : conversation.state === "unread"
+                ? ClockIcon
+                : undefined
+          }
           label={conversationLabel}
           href={`/w/${owner.sId}/assistant/${conversation.sId}`}
           shallow

--- a/front/lib/models/assistant/conversation.ts
+++ b/front/lib/models/assistant/conversation.ts
@@ -9,6 +9,7 @@ import { UserModel } from "@app/lib/resources/storage/models/user";
 import { WorkspaceAwareModel } from "@app/lib/resources/storage/wrappers/workspace_models";
 import type {
   AgentMessageStatus,
+  ConversationParticipantState,
   ConversationVisibility,
   MessageVisibility,
   ParticipantActionType,
@@ -89,6 +90,7 @@ export class ConversationParticipantModel extends WorkspaceAwareModel<Conversati
   declare updatedAt: CreationOptional<Date>;
 
   declare action: ParticipantActionType;
+  declare state: ConversationParticipantState;
 
   declare conversationId: ForeignKey<ConversationModel["id"]>;
   declare userId: ForeignKey<UserModel["id"]>;
@@ -111,6 +113,11 @@ ConversationParticipantModel.init(
     action: {
       type: DataTypes.STRING,
       allowNull: false,
+    },
+    state: {
+      type: DataTypes.STRING,
+      allowNull: false,
+      defaultValue: "read",
     },
   },
   {

--- a/front/lib/models/assistant/conversation.ts
+++ b/front/lib/models/assistant/conversation.ts
@@ -9,7 +9,6 @@ import { UserModel } from "@app/lib/resources/storage/models/user";
 import { WorkspaceAwareModel } from "@app/lib/resources/storage/wrappers/workspace_models";
 import type {
   AgentMessageStatus,
-  ConversationParticipantState,
   ConversationVisibility,
   MessageVisibility,
   ParticipantActionType,
@@ -90,7 +89,8 @@ export class ConversationParticipantModel extends WorkspaceAwareModel<Conversati
   declare updatedAt: CreationOptional<Date>;
 
   declare action: ParticipantActionType;
-  declare state: ConversationParticipantState;
+  declare unread: boolean;
+  declare actionRequired: boolean;
 
   declare conversationId: ForeignKey<ConversationModel["id"]>;
   declare userId: ForeignKey<UserModel["id"]>;
@@ -114,10 +114,15 @@ ConversationParticipantModel.init(
       type: DataTypes.STRING,
       allowNull: false,
     },
-    state: {
-      type: DataTypes.STRING,
+    unread: {
+      type: DataTypes.BOOLEAN,
       allowNull: false,
-      defaultValue: "read",
+      defaultValue: false,
+    },
+    actionRequired: {
+      type: DataTypes.BOOLEAN,
+      allowNull: false,
+      defaultValue: false,
     },
   },
   {

--- a/front/lib/resources/conversation_resource.ts
+++ b/front/lib/resources/conversation_resource.ts
@@ -381,7 +381,13 @@ export class ConversationResource extends BaseResource<ConversationModel> {
     }
 
     const participations = await ConversationParticipantModel.findAll({
-      attributes: ["userId", "updatedAt", "conversationId", "state"],
+      attributes: [
+        "userId",
+        "updatedAt",
+        "conversationId",
+        "unread",
+        "actionRequired",
+      ],
       where: {
         userId: user.id,
         workspaceId: owner.id,
@@ -407,7 +413,8 @@ export class ConversationResource extends BaseResource<ConversationModel> {
           id: c.id,
           created: c.createdAt.getTime(),
           updated: p.updatedAt.getTime(),
-          state: p.state,
+          unread: p.unread,
+          actionRequired: p.actionRequired,
           sId: c.sId,
           owner,
           title: c.title,
@@ -459,7 +466,8 @@ export class ConversationResource extends BaseResource<ConversationModel> {
             action: "posted",
             userId: user.id,
             workspaceId: conversation.owner.id,
-            state: "read",
+            unread: false,
+            actionRequired: false,
           },
           { transaction: t }
         );

--- a/front/lib/resources/conversation_resource.ts
+++ b/front/lib/resources/conversation_resource.ts
@@ -381,7 +381,7 @@ export class ConversationResource extends BaseResource<ConversationModel> {
     }
 
     const participations = await ConversationParticipantModel.findAll({
-      attributes: ["userId", "updatedAt", "conversationId"],
+      attributes: ["userId", "updatedAt", "conversationId", "state"],
       where: {
         userId: user.id,
         workspaceId: owner.id,
@@ -407,6 +407,7 @@ export class ConversationResource extends BaseResource<ConversationModel> {
           id: c.id,
           created: c.createdAt.getTime(),
           updated: p.updatedAt.getTime(),
+          state: p.state,
           sId: c.sId,
           owner,
           title: c.title,
@@ -458,6 +459,7 @@ export class ConversationResource extends BaseResource<ConversationModel> {
             action: "posted",
             userId: user.id,
             workspaceId: conversation.owner.id,
+            state: "read",
           },
           { transaction: t }
         );

--- a/front/migrations/20250408_missing_conversation_participants.ts
+++ b/front/migrations/20250408_missing_conversation_participants.ts
@@ -127,6 +127,7 @@ async function processConversation(
             createdAt: lastMessageByUserId[userId],
             updatedAt: lastMessageByUserId[userId],
             action: "posted",
+            state: "read",
           },
           {
             silent: true,

--- a/front/migrations/20250408_missing_conversation_participants.ts
+++ b/front/migrations/20250408_missing_conversation_participants.ts
@@ -127,7 +127,8 @@ async function processConversation(
             createdAt: lastMessageByUserId[userId],
             updatedAt: lastMessageByUserId[userId],
             action: "posted",
-            state: "read",
+            unread: false,
+            actionRequired: false,
           },
           {
             silent: true,

--- a/front/migrations/db/migration_330.sql
+++ b/front/migrations/db/migration_330.sql
@@ -1,0 +1,2 @@
+-- Migration created on Aug 06, 2025
+ALTER TABLE "public"."conversation_participants" ADD COLUMN "state" VARCHAR(255) NOT NULL DEFAULT 'read';

--- a/front/migrations/db/migration_330.sql
+++ b/front/migrations/db/migration_330.sql
@@ -1,2 +1,3 @@
 -- Migration created on Aug 06, 2025
-ALTER TABLE "public"."conversation_participants" ADD COLUMN "state" VARCHAR(255) NOT NULL DEFAULT 'read';
+ALTER TABLE "public"."conversation_participants" ADD COLUMN "unread" BOOLEAN NOT NULL DEFAULT false;
+ALTER TABLE "public"."conversation_participants" ADD COLUMN "actionRequired" BOOLEAN NOT NULL DEFAULT FALSE; 

--- a/front/types/assistant/conversation.ts
+++ b/front/types/assistant/conversation.ts
@@ -204,6 +204,7 @@ export type ConversationWithoutContentType = {
   id: ModelId;
   created: number;
   updated?: number;
+  state?: ConversationParticipantState;
   owner: WorkspaceType;
   sId: string;
   title: string | null;
@@ -221,6 +222,10 @@ export type ConversationType = ConversationWithoutContentType & {
 };
 
 export type ParticipantActionType = "posted" | "reacted" | "subscribed";
+export type ConversationParticipantState =
+  | "read"
+  | "unread"
+  | "action_required";
 
 /**
  * Conversation participants.

--- a/front/types/assistant/conversation.ts
+++ b/front/types/assistant/conversation.ts
@@ -204,7 +204,8 @@ export type ConversationWithoutContentType = {
   id: ModelId;
   created: number;
   updated?: number;
-  state?: ConversationParticipantState;
+  unread?: boolean;
+  actionRequired?: boolean;
   owner: WorkspaceType;
   sId: string;
   title: string | null;
@@ -222,10 +223,6 @@ export type ConversationType = ConversationWithoutContentType & {
 };
 
 export type ParticipantActionType = "posted" | "reacted" | "subscribed";
-export type ConversationParticipantState =
-  | "read"
-  | "unread"
-  | "action_required";
 
 /**
  * Conversation participants.


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

Closes https://github.com/dust-tt/tasks/issues/3421
Closes https://github.com/dust-tt/tasks/issues/3689

This PR aims at adding a state to the conversation participant model. We want to track for each participant the actual state of the conversation for them. If they read it or not. 

This work is part of HOOTL initiative, and used also for deep research. This allows user to better track what happens in Dust when they're not here.

<img width="1512" height="945" alt="Capture d’écran 2025-08-06 à 23 39 20" src="https://github.com/user-attachments/assets/945fa25f-3537-47fe-949b-4cb7e84eb7be" />

This PR does not update the unread => read when opening the conversation.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

Tested by hand.

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

Low.

## Deploy Plan

Migrate 330.
Deploy Front.