### PR TITLE
[front] Align Notion MCP auth errors on Slack implementation

### DIFF
--- a/front/lib/actions/mcp_internal_actions/personal_authentication.ts
+++ b/front/lib/actions/mcp_internal_actions/personal_authentication.ts
@@ -1,9 +1,12 @@
+import type { AuthorizationInfo } from "@app/lib/actions/mcp_metadata";
 import type { InternalMCPServerDefinitionType } from "@app/lib/api/mcp";
 
 export function makePersonalAuthenticationError({
   serverInfo,
 }: {
-  serverInfo: InternalMCPServerDefinitionType;
+  serverInfo: InternalMCPServerDefinitionType & {
+    authorization: AuthorizationInfo;
+  };
 }) {
   return {
     isError: true,
@@ -12,7 +15,7 @@ export function makePersonalAuthenticationError({
         type: "text" as const,
         text: JSON.stringify({
           __dust_auth_required: {
-            provider: serverInfo.authorization?.provider,
+            provider: serverInfo.authorization.provider,
           },
         }),
       },

--- a/front/lib/actions/mcp_internal_actions/personal_authentication.ts
+++ b/front/lib/actions/mcp_internal_actions/personal_authentication.ts
@@ -1,0 +1,21 @@
+import type { InternalMCPServerDefinitionType } from "@app/lib/api/mcp";
+
+export function makePersonalAuthenticationError({
+  serverInfo,
+}: {
+  serverInfo: InternalMCPServerDefinitionType;
+}) {
+  return {
+    isError: true,
+    content: [
+      {
+        type: "text" as const,
+        text: JSON.stringify({
+          __dust_auth_required: {
+            provider: serverInfo.authorization?.provider,
+          },
+        }),
+      },
+    ],
+  };
+}

--- a/front/lib/actions/mcp_internal_actions/servers/notion.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/notion.ts
@@ -30,7 +30,7 @@ import type { Authenticator } from "@app/lib/auth";
 import type { TimeFrame } from "@app/types";
 import { normalizeError, parseTimeFrame, timeFrameFromNow } from "@app/types";
 
-const serverInfo: InternalMCPServerDefinitionType = {
+const serverInfo = {
   name: "notion",
   version: "1.0.0",
   description: "Notion tools to manage pages and databases.",
@@ -40,7 +40,7 @@ const serverInfo: InternalMCPServerDefinitionType = {
   },
   icon: "NotionLogo",
   documentationUrl: null,
-};
+} satisfies InternalMCPServerDefinitionType;
 
 const uuidRegex =
   /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;

--- a/front/lib/actions/mcp_internal_actions/servers/slack.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/slack.ts
@@ -1,6 +1,5 @@
 import { INTERNAL_MIME_TYPES } from "@dust-tt/client";
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
-import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
 import { WebClient } from "@slack/web-api";
 import type { Match } from "@slack/web-api/dist/response/SearchMessagesResponse";
 import type { Member } from "@slack/web-api/dist/response/UsersListResponse";
@@ -12,6 +11,7 @@ import type {
   SearchQueryResourceType,
   SearchResultResourceType,
 } from "@app/lib/actions/mcp_internal_actions/output_schemas";
+import { makePersonalAuthenticationError } from "@app/lib/actions/mcp_internal_actions/personal_authentication";
 import { renderRelativeTimeFrameForToolOutput } from "@app/lib/actions/mcp_internal_actions/rendering";
 import {
   makeMCPToolJSONSuccess,
@@ -96,22 +96,6 @@ function isSlackTokenRevoked(error: unknown): boolean {
     (error as any).message &&
     (error as any).message.toString().includes("token_revoked")
   );
-}
-
-function makeSlackTokenRevokedError(): CallToolResult {
-  return {
-    isError: true,
-    content: [
-      {
-        type: "text" as const,
-        text: JSON.stringify({
-          __dust_auth_required: {
-            provider: serverInfo.authorization?.provider,
-          },
-        }),
-      },
-    ],
-  };
 }
 
 const createServer = (
@@ -341,7 +325,7 @@ const createServer = (
         }
       } catch (error) {
         if (isSlackTokenRevoked(error)) {
-          return makeSlackTokenRevokedError();
+          return makePersonalAuthenticationError({ serverInfo });
         }
         return makeMCPToolTextError(`Error searching messages: ${error}`);
       }
@@ -471,7 +455,7 @@ const createServer = (
         }
       } catch (error) {
         if (isSlackTokenRevoked(error)) {
-          return makeSlackTokenRevokedError();
+          return makePersonalAuthenticationError({ serverInfo });
         }
         return makeMCPToolTextError(`Error listing threads: ${error}`);
       }
@@ -533,7 +517,7 @@ const createServer = (
         });
       } catch (error) {
         if (isSlackTokenRevoked(error)) {
-          return makeSlackTokenRevokedError();
+          return makePersonalAuthenticationError({ serverInfo });
         }
         return makeMCPToolTextError(`Error posting message: ${error}`);
       }
@@ -609,7 +593,7 @@ const createServer = (
         });
       } catch (error) {
         if (isSlackTokenRevoked(error)) {
-          return makeSlackTokenRevokedError();
+          return makePersonalAuthenticationError({ serverInfo });
         }
         return makeMCPToolTextError(`Error listing users: ${error}`);
       }
@@ -684,7 +668,7 @@ const createServer = (
         });
       } catch (error) {
         if (isSlackTokenRevoked(error)) {
-          return makeSlackTokenRevokedError();
+          return makePersonalAuthenticationError({ serverInfo });
         }
         return makeMCPToolTextError(`Error listing channels: ${error}`);
       }

--- a/front/lib/actions/mcp_internal_actions/servers/slack.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/slack.ts
@@ -28,7 +28,7 @@ import { concurrentExecutor } from "@app/lib/utils/async_utils";
 import type { TimeFrame } from "@app/types";
 import { parseTimeFrame, stripNullBytes, timeFrameFromNow } from "@app/types";
 
-const serverInfo: InternalMCPServerDefinitionType = {
+const serverInfo = {
   name: "slack",
   version: "1.0.0",
   description: "Slack tools for searching and posting messages.",
@@ -38,7 +38,7 @@ const serverInfo: InternalMCPServerDefinitionType = {
   },
   icon: "SlackLogo",
   documentationUrl: "https://docs.dust.tt/docs/slack-mcp",
-};
+} satisfies InternalMCPServerDefinitionType;
 
 const getSlackClient = async (accessToken?: string) => {
   if (!accessToken) {


### PR DESCRIPTION
## Description

- Related to https://github.com/dust-tt/tasks/issues/3745.
- This PR unifies the way token errors are thrown in the Notion MCP, aligning with the Slack MCP implementation.
- The current error is not caught as an MCP personal authentication error and does not trigger the auth flow as a result.

## Tests

- Tested locally.

## Risk

- Low.

## Deploy Plan

- Deploy front.
