### PR TITLE
Add: support for multiple internal tools

### DIFF
--- a/front/lib/actions/mcp_helper.ts
+++ b/front/lib/actions/mcp_helper.ts
@@ -47,17 +47,19 @@ export const getServerTypeAndIdFromSId = (
   }
 };
 
-export const internalMCPServerNameToFirstId = ({
+export const internalMCPServerNameToSId = ({
   name,
   workspaceId,
+  prefix,
 }: {
   name: InternalMCPServerNameType;
   workspaceId: ModelId;
+  prefix: number;
 }): string => {
   return dangerouslyMakeSIdWithCustomFirstPrefix("internal_mcp_server", {
     id: INTERNAL_MCP_SERVERS[name].id,
     workspaceId,
-    firstPrefix: LEGACY_REGION_BIT,
+    firstPrefix: prefix,
   });
 };
 

--- a/front/lib/actions/mcp_internal_actions/constants.ts
+++ b/front/lib/actions/mcp_internal_actions/constants.ts
@@ -642,7 +642,13 @@ export const getAvailabilityOfInternalMCPServerById = (
   return getAvailabilityOfInternalMCPServerByName(r.value.name);
 };
 
-export const getAllowMultipleInstancesOfInternalMCPServerById = (
+export const allowsMultipleInstancesOfInternalMCPServerByName = (
+  name: InternalMCPServerNameType
+): boolean => {
+  return !!INTERNAL_MCP_SERVERS[name].allowMultipleInstances;
+};
+
+export const allowsMultipleInstancesOfInternalMCPServerById = (
   sId: string
 ): boolean => {
   const r = getInternalMCPServerNameAndWorkspaceId(sId);

--- a/front/lib/resources/internal_mcp_server_in_memory_resource.ts
+++ b/front/lib/resources/internal_mcp_server_in_memory_resource.ts
@@ -1,16 +1,21 @@
-import type { Transaction } from "sequelize";
 import { Op } from "sequelize";
 
-import { internalMCPServerNameToFirstId } from "@app/lib/actions/mcp_helper";
+import {
+  autoInternalMCPServerNameToSId,
+  internalMCPServerNameToSId,
+} from "@app/lib/actions/mcp_helper";
 import { isEnabledForWorkspace } from "@app/lib/actions/mcp_internal_actions";
 import type { InternalMCPServerNameType } from "@app/lib/actions/mcp_internal_actions/constants";
 import {
+  allowsMultipleInstancesOfInternalMCPServerById,
+  allowsMultipleInstancesOfInternalMCPServerByName,
   AVAILABLE_INTERNAL_MCP_SERVER_NAMES,
-  getAllowMultipleInstancesOfInternalMCPServerById,
   getAvailabilityOfInternalMCPServerById,
   getAvailabilityOfInternalMCPServerByName,
   getInternalMCPServerNameAndWorkspaceId,
+  isAutoInternalMCPServerName,
   isInternalMCPServerName,
+  isInternalMCPServerOfName,
 } from "@app/lib/actions/mcp_internal_actions/constants";
 import {
   connectToMCPServer,
@@ -119,8 +124,7 @@ export class InternalMCPServerInMemoryResource {
     }: {
       name: InternalMCPServerNameType;
       useCase: MCPOAuthUseCase | null;
-    },
-    transaction?: Transaction
+    }
   ) {
     const canAdministrate =
       await SpaceResource.canAdministrateSystemSpace(auth);
@@ -131,14 +135,60 @@ export class InternalMCPServerInMemoryResource {
         "The user is not authorized to create an internal MCP server"
       );
     }
+    const systemSpace = await SpaceResource.fetchWorkspaceSystemSpace(auth);
 
-    const server = await InternalMCPServerInMemoryResource.init(
-      auth,
-      internalMCPServerNameToFirstId({
+    let sid: string | null = null;
+
+    if (isAutoInternalMCPServerName(name)) {
+      sid = autoInternalMCPServerNameToSId({
         name,
         workspaceId: auth.getNonNullableWorkspace().id,
-      })
-    );
+      });
+    } else {
+      const alreadyUsedIds = await MCPServerViewModel.findAll({
+        where: {
+          serverType: "internal",
+          workspaceId: auth.getNonNullableWorkspace().id,
+          vaultId: systemSpace.id,
+        },
+      });
+
+      if (!allowsMultipleInstancesOfInternalMCPServerByName(name)) {
+        const alreadyExistsForSameName = alreadyUsedIds.some((r) => {
+          return isInternalMCPServerOfName(r.internalMCPServerId, name);
+        });
+
+        if (alreadyExistsForSameName) {
+          throw new DustError(
+            "internal_error",
+            "The internal MCP server already exists for this name."
+          );
+        }
+      }
+
+      // 100 tries to avoid an infinite loop.
+      for (let i = 1; i < 100; i++) {
+        const prefix = Math.floor(Math.random() * 1000000);
+        const tempSid = internalMCPServerNameToSId({
+          name,
+          workspaceId: auth.getNonNullableWorkspace().id,
+          prefix,
+        });
+        if (!alreadyUsedIds.some((r) => r.internalMCPServerId === tempSid)) {
+          sid = tempSid;
+          break;
+        }
+      }
+    }
+
+    if (!sid) {
+      throw new DustError(
+        "internal_error",
+        "Could not find an available id for the internal MCP server."
+      );
+    }
+
+    const server = await InternalMCPServerInMemoryResource.init(auth, sid);
 
     if (!server) {
       throw new DustError(
@@ -147,20 +197,15 @@ export class InternalMCPServerInMemoryResource {
       );
     }
 
-    const systemSpace = await SpaceResource.fetchWorkspaceSystemSpace(auth);
-
-    await MCPServerViewModel.create(
-      {
-        workspaceId: auth.getNonNullableWorkspace().id,
-        serverType: "internal",
-        internalMCPServerId: server.id,
-        vaultId: systemSpace.id,
-        editedAt: new Date(),
-        editedByUserId: auth.user()?.id,
-        oAuthUseCase: useCase ?? null,
-      },
-      { transaction }
-    );
+    await MCPServerViewModel.create({
+      workspaceId: auth.getNonNullableWorkspace().id,
+      serverType: "internal",
+      internalMCPServerId: server.id,
+      vaultId: systemSpace.id,
+      editedAt: new Date(),
+      editedByUserId: auth.user()?.id,
+      oAuthUseCase: useCase ?? null,
+    });
 
     return server;
   }
@@ -252,9 +297,10 @@ export class InternalMCPServerInMemoryResource {
     }
 
     const ids = names.map((name) =>
-      internalMCPServerNameToFirstId({
+      internalMCPServerNameToSId({
         name,
         workspaceId: auth.getNonNullableWorkspace().id,
+        prefix: 1, // We could use any value here.
       })
     );
 
@@ -304,7 +350,7 @@ export class InternalMCPServerInMemoryResource {
       sId: this.id,
       ...this.metadata,
       availability: getAvailabilityOfInternalMCPServerById(this.id),
-      allowMultipleInstances: getAllowMultipleInstancesOfInternalMCPServerById(
+      allowMultipleInstances: allowsMultipleInstancesOfInternalMCPServerById(
         this.id
       ),
     };

--- a/front/lib/resources/mcp_server_view_resource.ts
+++ b/front/lib/resources/mcp_server_view_resource.ts
@@ -163,11 +163,9 @@ export class MCPServerViewResource extends ResourceWithSpace<MCPServerViewModel>
     {
       systemView,
       space,
-      transaction,
     }: {
       systemView: MCPServerViewResource;
       space: SpaceResource;
-      transaction?: Transaction;
     }
   ) {
     if (systemView.space.kind !== "system") {
@@ -201,8 +199,7 @@ export class MCPServerViewResource extends ResourceWithSpace<MCPServerViewModel>
         description: systemView.description,
       },
       space,
-      auth.user() ?? undefined,
-      transaction
+      auth.user() ?? undefined
     );
   }
 
@@ -333,6 +330,15 @@ export class MCPServerViewResource extends ResourceWithSpace<MCPServerViewModel>
     options?: ResourceFindOptions<MCPServerViewModel>
   ): Promise<MCPServerViewResource[]> {
     return this.listBySpaces(auth, [space], options);
+  }
+
+  static async listForSystemSpace(
+    auth: Authenticator,
+    options?: ResourceFindOptions<MCPServerViewModel>
+  ) {
+    const systemSpace = await SpaceResource.fetchWorkspaceSystemSpace(auth);
+
+    return this.listBySpace(auth, systemSpace, options);
   }
 
   static async countBySpace(

--- a/front/pages/api/w/[wId]/mcp/index.test.ts
+++ b/front/pages/api/w/[wId]/mcp/index.test.ts
@@ -1,6 +1,13 @@
 import type { RequestMethod } from "node-mocks-http";
 import { describe, expect, it, vi } from "vitest";
 
+import type { InternalMCPServerNameType } from "@app/lib/actions/mcp_internal_actions/constants";
+import {
+  allowsMultipleInstancesOfInternalMCPServerByName,
+  INTERNAL_MCP_SERVERS,
+} from "@app/lib/actions/mcp_internal_actions/constants";
+import { InternalMCPServerInMemoryResource } from "@app/lib/resources/internal_mcp_server_in_memory_resource";
+import { MCPServerViewResource } from "@app/lib/resources/mcp_server_view_resource";
 import { createPrivateApiMockRequest } from "@app/tests/utils/generic_private_api_tests";
 import { RemoteMCPServerFactory } from "@app/tests/utils/RemoteMCPServerFactory";
 import { SpaceFactory } from "@app/tests/utils/SpaceFactory";
@@ -30,18 +37,19 @@ async function setupTest(
   role: "builder" | "user" | "admin" = "admin",
   method: RequestMethod = "GET"
 ) {
-  const { req, res, workspace } = await createPrivateApiMockRequest({
-    role,
-    method,
-  });
+  const { req, res, workspace, authenticator } =
+    await createPrivateApiMockRequest({
+      role,
+      method,
+    });
 
   // Create a system space to hold the Remote MCP servers
-  await SpaceFactory.system(workspace);
+  await SpaceFactory.defaults(authenticator);
 
   // Set up common query parameters
   req.query.wId = workspace.sId;
 
-  return { req, res, workspace };
+  return { req, res, workspace, authenticator };
 }
 
 vi.mock(import("@app/lib/actions/mcp_actions"), async (importOriginal) => {
@@ -126,6 +134,131 @@ describe("POST /api/w/[wId]/mcp/", () => {
         type: "invalid_request_error",
         message: "Invalid request body",
       },
+    });
+  });
+});
+
+describe("POST /api/w/[wId]/mcp/", () => {
+  it("should create an internal MCP server", async () => {
+    const { req, res, authenticator } = await setupTest("admin", "POST");
+
+    req.body = {
+      name: "agent_memory" as InternalMCPServerNameType,
+      serverType: "internal",
+      includeGlobal: true,
+    };
+
+    await handler(req, res);
+
+    expect(res._getStatusCode()).toBe(201);
+    expect(res._getJSONData()).toEqual({
+      success: true,
+      server: expect.objectContaining({
+        name: "agent_memory",
+      }),
+    });
+
+    expect(
+      await MCPServerViewResource.listForSystemSpace(authenticator)
+    ).toHaveLength(1);
+  });
+
+  it("should fail to create an internal MCP server if it already exists", async () => {
+    const { req, res, authenticator } = await setupTest("admin", "POST");
+
+    // Make sure we can only create one instance of this internal MCP server.
+    expect(
+      allowsMultipleInstancesOfInternalMCPServerByName("agent_memory")
+    ).toBe(false);
+
+    // Create the first instance.
+    const internalServer = await InternalMCPServerInMemoryResource.makeNew(
+      authenticator,
+      {
+        name: "agent_memory",
+        useCase: null,
+      }
+    );
+
+    expect(internalServer).toBeDefined();
+
+    expect(
+      await MCPServerViewResource.listForSystemSpace(authenticator)
+    ).toHaveLength(1);
+
+    req.body = {
+      name: "agent_memory" as InternalMCPServerNameType,
+      serverType: "internal",
+      includeGlobal: true,
+    };
+
+    await handler(req, res);
+
+    expect(res._getStatusCode()).toBe(400);
+    expect(res._getJSONData()).toEqual({
+      error: {
+        type: "invalid_request_error",
+        message:
+          "This internal tool has already been added and only one instance is allowed.",
+      },
+    });
+  });
+
+  it("should  create an internal MCP server if it already exists but multiple instances are allowed", async () => {
+    const { req, res, authenticator } = await setupTest("admin", "POST");
+
+    const originalConfig = INTERNAL_MCP_SERVERS["agent_memory"];
+    Object.defineProperty(INTERNAL_MCP_SERVERS, "agent_memory", {
+      value: {
+        ...originalConfig,
+        availability: "manual",
+        allowMultipleInstances: true,
+      },
+      writable: true,
+      configurable: true,
+    });
+
+    // Make sure we can only create one instance of this internal MCP server.
+    expect(
+      allowsMultipleInstancesOfInternalMCPServerByName("agent_memory")
+    ).toBe(true);
+
+    // Create the first instance.
+    const internalServer = await InternalMCPServerInMemoryResource.makeNew(
+      authenticator,
+      {
+        name: "agent_memory",
+        useCase: null,
+      }
+    );
+
+    expect(internalServer).toBeDefined();
+
+    expect(
+      await MCPServerViewResource.listForSystemSpace(authenticator)
+    ).toHaveLength(1);
+
+    req.body = {
+      name: "agent_memory" as InternalMCPServerNameType,
+      serverType: "internal",
+      includeGlobal: true,
+    };
+
+    await handler(req, res);
+
+    expect(res._getStatusCode()).toBe(201);
+    expect(res._getJSONData()).toEqual({
+      success: true,
+      server: expect.objectContaining({
+        name: "agent_memory",
+      }),
+    });
+    expect(res._getJSONData().server.id).not.toBe(internalServer.id);
+
+    Object.defineProperty(INTERNAL_MCP_SERVERS, "agent_memory", {
+      value: originalConfig,
+      writable: true,
+      configurable: true,
     });
   });
 });

--- a/front/pages/api/w/[wId]/mcp/index.ts
+++ b/front/pages/api/w/[wId]/mcp/index.ts
@@ -2,14 +2,14 @@ import { isLeft } from "fp-ts/lib/Either";
 import * as t from "io-ts";
 import type { NextApiRequest, NextApiResponse } from "next";
 
-import { internalMCPServerNameToFirstId } from "@app/lib/actions/mcp_helper";
 import {
   DEFAULT_MCP_SERVER_ICON,
   isCustomServerIconType,
 } from "@app/lib/actions/mcp_icons";
 import {
-  getAllowMultipleInstancesOfInternalMCPServerById,
+  allowsMultipleInstancesOfInternalMCPServerByName,
   isInternalMCPServerName,
+  isInternalMCPServerOfName,
 } from "@app/lib/actions/mcp_internal_actions/constants";
 import { DEFAULT_REMOTE_MCP_SERVERS } from "@app/lib/actions/mcp_internal_actions/remote_servers";
 import type { AuthorizationInfo } from "@app/lib/actions/mcp_metadata";
@@ -274,29 +274,28 @@ async function handler(
           });
         }
 
-        const internalMCPServerId = internalMCPServerNameToFirstId({
-          name,
-          workspaceId: auth.getNonNullableWorkspace().id,
-        });
+        if (!allowsMultipleInstancesOfInternalMCPServerByName(name)) {
+          const installedMCPServers =
+            await MCPServerViewResource.listForSystemSpace(auth, {
+              where: {
+                serverType: "internal",
+              },
+            });
 
-        const existingServer =
-          await InternalMCPServerInMemoryResource.fetchById(
-            auth,
-            internalMCPServerId
+          const alreadyUsed = installedMCPServers.some((mcpServer) =>
+            isInternalMCPServerOfName(mcpServer.internalMCPServerId, name)
           );
 
-        if (
-          existingServer &&
-          !getAllowMultipleInstancesOfInternalMCPServerById(internalMCPServerId)
-        ) {
-          return apiError(req, res, {
-            status_code: 400,
-            api_error: {
-              type: "invalid_request_error",
-              message:
-                "This internal tool has already been added and only one instance is allowed.",
-            },
-          });
+          if (alreadyUsed) {
+            return apiError(req, res, {
+              status_code: 400,
+              api_error: {
+                type: "invalid_request_error",
+                message:
+                  "This internal tool has already been added and only one instance is allowed.",
+              },
+            });
+          }
         }
 
         const newInternalMCPServer =

--- a/front/tests/utils/MCPServerViewFactory.ts
+++ b/front/tests/utils/MCPServerViewFactory.ts
@@ -1,5 +1,3 @@
-import type { Transaction } from "sequelize";
-
 import { Authenticator } from "@app/lib/auth";
 import { MCPServerViewResource } from "@app/lib/resources/mcp_server_view_resource";
 import type { SpaceResource } from "@app/lib/resources/space_resource";
@@ -9,8 +7,7 @@ export class MCPServerViewFactory {
   static async create(
     workspace: LightWorkspaceType,
     mcpServerId: string,
-    space: SpaceResource,
-    transaction?: Transaction
+    space: SpaceResource
   ): Promise<MCPServerViewResource> {
     const auth = await Authenticator.internalAdminForWorkspace(workspace.sId);
     const systemView =
@@ -28,7 +25,6 @@ export class MCPServerViewFactory {
     const serverView = await MCPServerViewResource.create(auth, {
       systemView,
       space,
-      transaction,
     });
 
     return serverView;


### PR DESCRIPTION
## Description

Support adding multiple internal tools (if allowed for a tool).

### How

In the `InternalMCPServerInMemoryResource.makeNew()`, for non auto servers, we try to pick a random id check if it's not used, we use it in the sid generation.

## Tests

Local + added some unit tests.

## Risk

Medium, the sid generation for non-auto servers has changed.

## Deploy Plan

Deploy `front`