### PR TITLE
[front] - fix(AB v2): first few fixes

### DIFF
--- a/front/components/agent_builder/AgentBuilder.tsx
+++ b/front/components/agent_builder/AgentBuilder.tsx
@@ -139,6 +139,7 @@ export default function AgentBuilder({
           type: "error",
         });
       } else {
+        const createdAgent = result.value;
         sendNotification({
           title: agentConfiguration ? "Agent saved" : "Agent created",
           description: agentConfiguration
@@ -146,6 +147,12 @@ export default function AgentBuilder({
             : "Your agent has been successfully created",
           type: "success",
         });
+
+        // If this was a new agent creation, update URL without re-rendering
+        if (!agentConfiguration && createdAgent.sId) {
+          const newUrl = `/w/${owner.sId}/builder/agents/${createdAgent.sId}`;
+          window.history.replaceState(null, "", newUrl);
+        }
       }
     } catch (error) {
       logger.error("Unexpected error:", error);

--- a/front/components/agent_builder/capabilities/mcp/MCPServerViewsDialog.tsx
+++ b/front/components/agent_builder/capabilities/mcp/MCPServerViewsDialog.tsx
@@ -648,12 +648,8 @@ export function MCPServerViewsDialog({
         <Button label="Add tools" icon={LightbulbIcon} />
       </MultiPageDialogTrigger>
       <MultiPageDialogContent
+        showNavigation={false}
         isAlertDialog
-        showNavigation={
-          !isEditMode &&
-          !isInfoMode &&
-          currentPageId === CONFIGURATION_DIALOG_PAGE_IDS.CONFIGURATION
-        }
         size="xl"
         pages={pages}
         currentPageId={currentPageId}

--- a/front/components/agent_builder/capabilities/mcp/MCPServerViewsDialog.tsx
+++ b/front/components/agent_builder/capabilities/mcp/MCPServerViewsDialog.tsx
@@ -653,6 +653,7 @@ export function MCPServerViewsDialog({
         <Button label="Add tools" icon={LightbulbIcon} />
       </MultiPageDialogTrigger>
       <MultiPageDialogContent
+        isAlertDialog
         showNavigation={
           !isEditMode &&
           !isInfoMode &&

--- a/front/components/agent_builder/capabilities/mcp/MCPServerViewsDialog.tsx
+++ b/front/components/agent_builder/capabilities/mcp/MCPServerViewsDialog.tsx
@@ -607,11 +607,6 @@ export function MCPServerViewsDialog({
             variant: "outline",
             onClick: handleBackToSelection,
           },
-          centerButton: {
-            label: "Cancel",
-            variant: "outline",
-            onClick: handleCancel,
-          },
           rightButton: {
             label: "Save Configuration",
             variant: "primary",
@@ -634,7 +629,7 @@ export function MCPServerViewsDialog({
     return {};
   };
 
-  const { leftButton, centerButton, rightButton } = getFooterButtons();
+  const { leftButton, rightButton } = getFooterButtons();
 
   return (
     <MultiPageDialog
@@ -670,7 +665,6 @@ export function MCPServerViewsDialog({
           }
         }}
         leftButton={leftButton}
-        centerButton={centerButton}
         rightButton={rightButton}
       />
     </MultiPageDialog>

--- a/front/components/agent_builder/instructions/AgentBuilderInstructionsEditor.tsx
+++ b/front/components/agent_builder/instructions/AgentBuilderInstructionsEditor.tsx
@@ -46,7 +46,7 @@ function createBuilderStateFromWatchedFields(
 
 const editorVariants = cva(
   [
-    "overflow-auto border rounded-xl p-2 resize-y min-h-60",
+    "overflow-auto border rounded-xl p-2 resize-y min-h-60 h-125",
     "transition-all duration-200",
     "bg-muted-background dark:bg-muted-background-night",
   ],

--- a/front/components/agent_builder/settings/AgentBuilderSettingsBlock.tsx
+++ b/front/components/agent_builder/settings/AgentBuilderSettingsBlock.tsx
@@ -23,10 +23,7 @@ import { AgentBuilderEditors } from "@app/components/agent_builder/settings/Agen
 import { AgentBuilderScopeSelector } from "@app/components/agent_builder/settings/AgentBuilderScopeSelector";
 import { AgentBuilderSlackSelector } from "@app/components/agent_builder/settings/AgentBuilderSlackSelector";
 import { AvatarPicker } from "@app/components/agent_builder/settings/avatar_picker/AgentBuilderAvatarPicker";
-import {
-  DROID_AVATAR_URLS,
-  SPIRIT_AVATAR_URLS,
-} from "@app/components/agent_builder/settings/avatar_picker/types";
+import { DROID_AVATAR_URLS, SPIRIT_AVATAR_URLS } from "@app/components/agent_builder/settings/avatar_picker/types";
 import { TagsSection } from "@app/components/agent_builder/settings/TagsSection";
 import {
   fetchWithErr,
@@ -38,12 +35,7 @@ import {
   makeUrlForEmojiAndBackground,
 } from "@app/components/assistant_builder/avatar_picker/utils";
 import { useSendNotification } from "@app/hooks/useNotification";
-import type {
-  APIError,
-  BuilderEmojiSuggestionsType,
-  Result,
-  WorkspaceType,
-} from "@app/types";
+import type { APIError, BuilderEmojiSuggestionsType, Result, WorkspaceType } from "@app/types";
 
 const MIN_INSTRUCTIONS_LENGTH_SUGGESTIONS = 20;
 
@@ -408,7 +400,7 @@ export function AgentBuilderSettingsBlock({
           <Page.H>Settings</Page.H>
         </CollapsibleTrigger>
         <CollapsibleContent>
-          <div className="flex flex-col gap-4 pt-4">
+          <div className="flex flex-col gap-4 pt-4 px-1">
             <Page.P>
               <span className="text-sm text-muted-foreground dark:text-muted-foreground-night">
                 Configure tags and access settings for your agent.

--- a/front/components/agent_builder/settings/AgentBuilderSettingsBlock.tsx
+++ b/front/components/agent_builder/settings/AgentBuilderSettingsBlock.tsx
@@ -23,7 +23,10 @@ import { AgentBuilderEditors } from "@app/components/agent_builder/settings/Agen
 import { AgentBuilderScopeSelector } from "@app/components/agent_builder/settings/AgentBuilderScopeSelector";
 import { AgentBuilderSlackSelector } from "@app/components/agent_builder/settings/AgentBuilderSlackSelector";
 import { AvatarPicker } from "@app/components/agent_builder/settings/avatar_picker/AgentBuilderAvatarPicker";
-import { DROID_AVATAR_URLS, SPIRIT_AVATAR_URLS } from "@app/components/agent_builder/settings/avatar_picker/types";
+import {
+  DROID_AVATAR_URLS,
+  SPIRIT_AVATAR_URLS,
+} from "@app/components/agent_builder/settings/avatar_picker/types";
 import { TagsSection } from "@app/components/agent_builder/settings/TagsSection";
 import {
   fetchWithErr,
@@ -35,7 +38,12 @@ import {
   makeUrlForEmojiAndBackground,
 } from "@app/components/assistant_builder/avatar_picker/utils";
 import { useSendNotification } from "@app/hooks/useNotification";
-import type { APIError, BuilderEmojiSuggestionsType, Result, WorkspaceType } from "@app/types";
+import type {
+  APIError,
+  BuilderEmojiSuggestionsType,
+  Result,
+  WorkspaceType,
+} from "@app/types";
 
 const MIN_INSTRUCTIONS_LENGTH_SUGGESTIONS = 20;
 
@@ -400,7 +408,7 @@ export function AgentBuilderSettingsBlock({
           <Page.H>Settings</Page.H>
         </CollapsibleTrigger>
         <CollapsibleContent>
-          <div className="flex flex-col gap-4 pt-4 px-1">
+          <div className="flex flex-col gap-4 px-1 pt-4">
             <Page.P>
               <span className="text-sm text-muted-foreground dark:text-muted-foreground-night">
                 Configure tags and access settings for your agent.

--- a/front/components/agent_builder/settings/TagsSection.tsx
+++ b/front/components/agent_builder/settings/TagsSection.tsx
@@ -182,7 +182,7 @@ export function TagsSection() {
                 tooltip={buttonTooltip}
               />
             </PopoverTrigger>
-            <PopoverContent className="w-64 p-3">
+            <PopoverContent className="w-64 p-3" side="top" align="start">
               {isTagsSuggestionLoading ? (
                 <div className="flex items-center justify-center p-4">
                   <Spinner size="sm" />

--- a/front/components/agent_builder/settings/TagsSelector.tsx
+++ b/front/components/agent_builder/settings/TagsSelector.tsx
@@ -96,6 +96,8 @@ export const TagsSelector = ({
             </DropdownMenuTrigger>
             <DropdownMenuContent
               className="h-96 w-96"
+              side="top"
+              align="start"
               dropdownHeaders={
                 <>
                   <DropdownMenuSearchbar


### PR DESCRIPTION
## Description

This PR changes the MCP server views dialog to make it more intuitive by:
- Removing the redundant "Cancel" center button to simplify navigation
- Adding left padding to the agent name input field to improve alignment
- Set a height to the instructions block
- Avoid tags popovers collision

## Tests

Locally

## Risk

Low, UX only and behind FF

## Deploy Plan

Deploy front