### PR TITLE
Fix: bigquery cross project views

### DIFF
--- a/core/src/databases/remote_databases/bigquery.rs
+++ b/core/src/databases/remote_databases/bigquery.rs
@@ -316,7 +316,7 @@ impl BigQueryRemoteDatabase {
             None => Vec::new(),
         }
         .iter()
-        .map(|t| format!("{}.{}.{}", self.project_id, t.dataset_id, t.table_id))
+        .map(|t| format!("{}.{}.{}", t.project_id, t.dataset_id, t.table_id))
         .collect();
 
         Ok(BigQueryQueryPlan {


### PR DESCRIPTION
## Description

Do not use the service account project when looking at query_plan as a view might use a table referenced from another project.

## Risk

Low

## Deploy Plan

Deploy core