### PR TITLE
Release Confluence folder

### DIFF
--- a/connectors/src/connectors/confluence/lib/confluence_api.ts
+++ b/connectors/src/connectors/confluence/lib/confluence_api.ts
@@ -18,8 +18,6 @@ import { getOAuthConnectionAccessToken } from "@connectors/types";
 
 const PAGE_FETCH_LIMIT = 100;
 
-const CONNECTOR_IDS_WITH_FOLDER_SUPPORT: ModelId[] = [1126, 27089];
-
 export async function getConfluenceCloudInformation(accessToken: string) {
   const client = new ConfluenceClient(accessToken);
 
@@ -175,12 +173,10 @@ function getConfluenceContentRef(
 export async function getActiveChildContentRefs(
   client: ConfluenceClient,
   {
-    connectorId,
     pageCursor,
     parentContentId,
     spaceKey,
   }: {
-    connectorId: ModelId;
     pageCursor: string | null;
     parentContentId: string;
     spaceKey: string;
@@ -189,7 +185,6 @@ export async function getActiveChildContentRefs(
   // Fetch the child content of the parent page.
   const { content: childContent, nextPageCursor } =
     await client.getChildContent({
-      includeFolders: CONNECTOR_IDS_WITH_FOLDER_SUPPORT.includes(connectorId),
       limit: PAGE_FETCH_LIMIT,
       pageCursor,
       parentContentId,

--- a/connectors/src/connectors/confluence/lib/confluence_client.ts
+++ b/connectors/src/connectors/confluence/lib/confluence_client.ts
@@ -858,7 +858,10 @@ export class ConfluenceClient {
     } catch (err) {
       // If the folder scope is not yet granted, throw an ExternalOAuthTokenError so users can
       // re-authorize to pick up the new scope.
-      if (err instanceof ConfluenceClientError && err.status === 401) {
+      if (
+        err instanceof ConfluenceClientError &&
+        (err.status === 401 || err.status === 403)
+      ) {
         logger.error(
           {
             err,

--- a/connectors/src/connectors/confluence/lib/confluence_client.ts
+++ b/connectors/src/connectors/confluence/lib/confluence_client.ts
@@ -679,20 +679,18 @@ export class ConfluenceClient {
   }
 
   async getChildContent({
-    includeFolders = false,
     limit,
     pageCursor,
     parentContentId,
     spaceKey,
   }: {
-    includeFolders?: boolean;
     limit: number;
     pageCursor: string | null;
     parentContentId: string;
     spaceKey: string;
   }) {
     // Build CQL query to get pages with specific IDs.
-    const cqlQuery = `type IN (${includeFolders ? "page, folder" : "page"}) AND space="${spaceKey}" AND parent=${parentContentId}`;
+    const cqlQuery = `type IN (page, folder) AND space="${spaceKey}" AND parent=${parentContentId}`;
 
     const params = new URLSearchParams({
       cql: cqlQuery,
@@ -852,10 +850,26 @@ export class ConfluenceClient {
   }
 
   async getFolderById(folderId: string) {
-    return this.request(
-      `${this.restApiBaseUrl}/folders/${folderId}`,
-      ConfluenceFolderCodec
-    );
+    try {
+      return await this.request(
+        `${this.restApiBaseUrl}/folders/${folderId}`,
+        ConfluenceFolderCodec
+      );
+    } catch (err) {
+      // If the folder scope is not yet granted, throw an ExternalOAuthTokenError so users can
+      // re-authorize to pick up the new scope.
+      if (err instanceof ConfluenceClientError && err.status === 401) {
+        logger.error(
+          {
+            err,
+          },
+          "Missing folder scope, re-authorizing is required"
+        );
+        throw new ExternalOAuthTokenError();
+      }
+
+      throw err;
+    }
   }
 
   async getPageReadRestrictions(pageId: string) {

--- a/connectors/src/connectors/confluence/temporal/activities.ts
+++ b/connectors/src/connectors/confluence/temporal/activities.ts
@@ -299,7 +299,6 @@ export async function confluenceGetActiveChildContentRefsActivity({
   localLogger.info("Fetching Confluence child pages in space.");
 
   return getActiveChildContentRefs(client, {
-    connectorId,
     pageCursor,
     parentContentId,
     spaceKey,
@@ -426,7 +425,6 @@ export async function confluenceGetTopLevelContentIdsActivity({
   const { childContentRefs, nextPageCursor } = await getActiveChildContentRefs(
     client,
     {
-      connectorId,
       pageCursor,
       parentContentId: rootContentId,
       spaceKey,


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
This PR releases the support for Confluence folders to everyone. As it requires to go through the re-auth flow to pick up the new scope required to get the folder. I wrapped the folder API cal with a try/catch to throw an `ExternalTokenError` which will pause the connectors and ask admin to re-auth. This approach ensures that only customers with actual folders will need to re-auth.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
