### PR TITLE
[front] Don't create workspace if user already has memberships

### DIFF
--- a/front/lib/api/signup.ts
+++ b/front/lib/api/signup.ts
@@ -317,7 +317,7 @@ export async function handleRegularSignupFlow(
     }
 
     return new Ok({ flow: "joined", workspace: lightWorkspace });
-  } else if (!targetWorkspace) {
+  } else if (!targetWorkspace && activeMemberships.length === 0) {
     const workspace = await createWorkspace(session);
     const lightWorkspace = renderLightWorkspaceType({ workspace });
     await createAndLogMembership({


### PR DESCRIPTION
## Description

If targetWorkspace can't be found be user already has a workspace, just return to default workspace, don't create

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

deploy front
