### PR TITLE
[front] Align design of `MCPServerPersonalAuthenticationRequired` on `ErrorMessage`

### DIFF
--- a/front/components/assistant/conversation/MCPServerPersonalAuthenticationRequired.tsx
+++ b/front/components/assistant/conversation/MCPServerPersonalAuthenticationRequired.tsx
@@ -51,7 +51,7 @@ export function MCPServerPersonalAuthenticationRequired({
       <div className="whitespace-normal break-words">
         {isConnected
           ? "You are now connected. Automatically retrying..."
-          : "The agent took an action that requires personal authentication"}
+          : "The agent took an action that requires personal authentication."}
       </div>
       {!isConnected && mcpServer && (
         <div className="flex flex-col gap-2 pt-3 sm:flex-row">

--- a/front/components/assistant/conversation/MCPServerPersonalAuthenticationRequired.tsx
+++ b/front/components/assistant/conversation/MCPServerPersonalAuthenticationRequired.tsx
@@ -1,4 +1,9 @@
-import { Button, Chip, CloudArrowLeftRightIcon } from "@dust-tt/sparkle";
+import {
+  Button,
+  CloudArrowLeftRightIcon,
+  ContentMessage,
+  InformationCircleIcon,
+} from "@dust-tt/sparkle";
 import { useState } from "react";
 
 import { useSubmitFunction } from "@app/lib/client/utils";
@@ -33,51 +38,48 @@ export function MCPServerPersonalAuthenticationRequired({
   const [isConnecting, setIsConnecting] = useState<boolean>(false);
 
   return (
-    <div className="flex flex-col gap-9">
-      {isConnected ? (
-        <div className="flex flex-col gap-1 sm:flex-row">
-          <Chip
-            color="success"
-            label={"You are now connected. Automatically retrying..."}
+    <ContentMessage
+      title={
+        isConnected
+          ? "Connected successfully"
+          : "Personal authentication required"
+      }
+      variant={isConnected ? "success" : "info"}
+      className="flex flex-col gap-3"
+      icon={InformationCircleIcon}
+    >
+      <div className="whitespace-normal break-words">
+        {isConnected
+          ? "You are now connected. Automatically retrying..."
+          : "The agent took an action that requires personal authentication"}
+      </div>
+      {!isConnected && mcpServer && (
+        <div className="flex flex-col gap-2 pt-3 sm:flex-row">
+          <Button
+            label="Connect"
+            variant="outline"
             size="xs"
+            icon={CloudArrowLeftRightIcon}
+            disabled={isConnecting}
+            onClick={async () => {
+              setIsConnecting(true);
+              const success = await createPersonalConnection(
+                mcpServer,
+                provider,
+                "personal_actions",
+                scope
+              );
+              setIsConnecting(false);
+              if (!success) {
+                setIsConnected(false);
+              } else {
+                setIsConnected(true);
+                await retry();
+              }
+            }}
           />
-        </div>
-      ) : (
-        <div className="flex flex-col gap-1 sm:flex-row">
-          <Chip
-            color="info"
-            label={
-              "The agent took an action that requires personal authentication"
-            }
-            size="xs"
-          />
-          {mcpServer && (
-            <Button
-              label={`Connect`}
-              variant="outline"
-              size="xs"
-              icon={CloudArrowLeftRightIcon}
-              disabled={isConnecting}
-              onClick={async () => {
-                setIsConnecting(true);
-                const success = await createPersonalConnection(
-                  mcpServer,
-                  provider,
-                  "personal_actions",
-                  scope
-                );
-                setIsConnecting(false);
-                if (!success) {
-                  setIsConnected(false);
-                } else {
-                  setIsConnected(true);
-                  await retry();
-                }
-              }}
-            />
-          )}
         </div>
       )}
-    </div>
+    </ContentMessage>
   );
 }


### PR DESCRIPTION
## Description

- Closes https://github.com/dust-tt/tasks/issues/3754.
- This PR aligns the design of `MCPServerPersonalAuthenticationRequired` on `ErrorMessage`, using a `ContentMessage` for a larger component.

Before:
<img width="599" height="215" alt="Screenshot 2025-08-07 at 4 14 30 PM" src="https://github.com/user-attachments/assets/f8b9e131-560c-4748-bf35-146bb84812b2" />

After:
<img width="599" height="301" alt="Screenshot 2025-08-07 at 4 11 51 PM" src="https://github.com/user-attachments/assets/5fbd9593-cc19-4559-b9df-4370276ac6ea" />


## Tests

- Checked locally.

## Risk

- Low, mostly UI.

## Deploy Plan

- Deploy front.
