### PR TITLE
[connectors] Fix slack configuration fetch

### DIFF
--- a/connectors/src/connectors/slack/auto_read_channel.ts
+++ b/connectors/src/connectors/slack/auto_read_channel.ts
@@ -37,19 +37,32 @@ export async function autoReadChannel(
   slackChannelId: string,
   provider: Extract<ConnectorProvider, "slack_bot" | "slack"> = "slack"
 ): Promise<Result<boolean, Error>> {
-  const slackConfiguration =
-    await SlackConfigurationResource.fetchByTeamId(teamId);
+  const slackConfigurations =
+    await SlackConfigurationResource.listForTeamId(teamId);
+  const connectorIds = slackConfigurations.map((c) => c.connectorId);
+  const connectors = await ConnectorResource.fetchByIds(provider, connectorIds);
+  const connector = connectors.find((c) => c.type === provider);
+
+  if (!connector) {
+    return new Err(
+      new Error(
+        `Connector not found for teamId ${teamId} and provider ${provider}`
+      )
+    );
+  }
+
+  const slackConfiguration = slackConfigurations.find(
+    (c) => c.connectorId === connector.id
+  );
+
   if (!slackConfiguration) {
     return new Err(
       new Error(`Slack configuration not found for teamId ${teamId}`)
     );
   }
+
   const { connectorId } = slackConfiguration;
 
-  const connector = await ConnectorResource.fetchById(connectorId);
-  if (!connector) {
-    return new Err(new Error(`Connector ${connectorId} not found`));
-  }
   const slackClient = await getSlackClient(connectorId);
 
   reportSlackUsage({

--- a/connectors/src/resources/slack_configuration_resource.ts
+++ b/connectors/src/resources/slack_configuration_resource.ts
@@ -114,19 +114,6 @@ export class SlackConfigurationResource extends BaseResource<SlackConfigurationM
     );
   }
 
-  static async fetchByTeamId(slackTeamId: string) {
-    const blob = await this.model.findOne({
-      where: {
-        slackTeamId,
-      },
-    });
-    if (!blob) {
-      return null;
-    }
-
-    return new this(this.model, blob.get());
-  }
-
   static async fetchByActiveBot(slackTeamId: string) {
     const blob = await this.model.findOne({
       where: {


### PR DESCRIPTION
## Description

Fetch the slack configuration that matches the specified provider.
Otherwise, we were randomly fetching one configuration matching the team id (could be slack or slack bot)

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

deploy connectors
