### PR TITLE
Research global agent skeleton

### DIFF
--- a/front/lib/actions/mcp_internal_actions/servers/data_sources_file_system.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/data_sources_file_system.ts
@@ -63,8 +63,14 @@ import {
 
 const FILESYSTEM_TOOL_NAME = "filesystem_navigation";
 
+export const FILESYSTEM_SERVER_NAME = "data_sources_file_system";
+export const FILESYSTEM_CAT_TOOL_NAME = "cat";
+export const FILESYSTEM_FIND_TOOL_NAME = "find";
+export const FILESYSTEM_LOCATE_IN_TREE_TOOL_NAME = "locate_in_tree";
+export const FILESYSTEM_LIST_TOOL_NAME = "list";
+
 const serverInfo: InternalMCPServerDefinitionType = {
-  name: "data_sources_file_system",
+  name: FILESYSTEM_SERVER_NAME,
   version: "1.0.0",
   description:
     "Comprehensive content navigation toolkit for browsing user data sources. Provides Unix-like " +
@@ -379,7 +385,7 @@ const createServer = (
   const server = new McpServer(serverInfo);
 
   server.tool(
-    "cat",
+    FILESYSTEM_CAT_TOOL_NAME,
     "Read the contents of a document, referred to by its nodeId (named after the 'cat' unix tool). " +
       "The nodeId can be obtained using the 'find', 'list' or 'search' tools.",
     {
@@ -510,7 +516,7 @@ const createServer = (
   );
 
   server.tool(
-    "find",
+    FILESYSTEM_FIND_TOOL_NAME,
     "Find content based on their title starting from a specific node. Can be used to find specific " +
       "nodes by searching for their titles. The query title can be omitted to list all nodes " +
       "starting from a specific node. This is like using 'find' in Unix.",
@@ -643,7 +649,7 @@ const createServer = (
   );
 
   server.tool(
-    "list",
+    FILESYSTEM_LIST_TOOL_NAME,
     "List the direct contents of a node. Can be used to see what is inside a specific folder from " +
       "the filesystem, like 'ls' in Unix. A good fit is to explore the filesystem structure step " +
       "by step. This tool can be called repeatedly by passing the 'nodeId' output from a step to " +
@@ -854,7 +860,7 @@ const createServer = (
   }
 
   server.tool(
-    "locate_in_tree",
+    FILESYSTEM_LOCATE_IN_TREE_TOOL_NAME,
     "Show the complete path from a node to the data source root, displaying the hierarchy of parent nodes. " +
       "This is useful for understanding where a specific node is located within the data source structure. " +
       "The path is returned as a list of nodes, with the first node being the data source root and " +

--- a/front/lib/api/assistant/global_agents/configurations/research.ts
+++ b/front/lib/api/assistant/global_agents/configurations/research.ts
@@ -24,12 +24,13 @@ export function _getResearchGlobalAgent(
     preFetchedDataSources,
     webSearchBrowseMCPServerView,
     searchMCPServerView,
+    dataSourcesFileSystemMCPServerView,
   }: {
     settings: GlobalAgentSettings | null;
     preFetchedDataSources: PrefetchedDataSourcesType | null;
-    agentRouterMCPServerView: MCPServerViewResource | null;
     webSearchBrowseMCPServerView: MCPServerViewResource | null;
     searchMCPServerView: MCPServerViewResource | null;
+    dataSourcesFileSystemMCPServerView: MCPServerViewResource | null;
   }
 ): AgentConfigurationType | null {
   const owner = auth.getNonNullableWorkspace();
@@ -219,7 +220,7 @@ Output required:
 \`\`\`
 ### BAD Examples:
 \`\`\`
-Task: "Generate comprehensive business metrics for Dust over the last 30 days:
+Task: "Generate comprehensive business metrics over the last 30 days:
 - User growth metrics (new signups, active users, user retention)
 - Product usage metrics (feature adoption, session metrics, engagement)
 - Revenue metrics (new customers, revenue growth, churn)
@@ -237,7 +238,7 @@ Task: "Analyze business performance with revenue, users, and churn metrics"
 </launch_analytics_task_instructions>
 
 <data_source_file_system_api_instructions>
-You can use the data_sources_file_system_api to explore the internal data of the company "Dust".
+You can use the data_sources_file_system_api to explore the internal data of the company.
 
 <data_source_file_system_hierarchy>
 The data sources are organized in a directed graph.
@@ -297,7 +298,7 @@ You must never output text outside of \`<thinking>\` tags between tool use. Only
       status: "disabled_by_admin",
       actions: [
         ..._getDefaultWebActionsForGlobalAgent({
-          agentId: GLOBAL_AGENTS_SID.DUST,
+          agentId: GLOBAL_AGENTS_SID.RESEARCH,
           webSearchBrowseMCPServerView,
         }),
       ],
@@ -384,6 +385,35 @@ You must never output text outside of \`<thinking>\` tags between tool use. Only
           dustAppConfiguration: null,
           jsonSchema: null,
         });
+        if (dataSourcesFileSystemMCPServerView) {
+          actions.push({
+            id: -1,
+            sId:
+              GLOBAL_AGENTS_SID.RESEARCH +
+              "-datasource-action-" +
+              dsView.dataSource.sId,
+            type: "mcp_server_configuration",
+            name: "hidden_dust_search_file_system_" + dsView.dataSource.name,
+            description: `The user's ${dsView.dataSource.connectorProvider} data source (file system).`,
+            mcpServerViewId: dataSourcesFileSystemMCPServerView.sId,
+            internalMCPServerId:
+              dataSourcesFileSystemMCPServerView.internalMCPServerId,
+            dataSources: [
+              {
+                workspaceId: preFetchedDataSources.workspaceId,
+                dataSourceViewId: dsView.sId,
+                filter: { parents: null, tags: null },
+              },
+            ],
+            tables: null,
+            childAgentId: null,
+            reasoningModel: null,
+            additionalConfiguration: {},
+            timeFrame: null,
+            dustAppConfiguration: null,
+            jsonSchema: null,
+          });
+        }
       }
     });
   }

--- a/front/lib/api/assistant/global_agents/configurations/research.ts
+++ b/front/lib/api/assistant/global_agents/configurations/research.ts
@@ -322,6 +322,31 @@ You must never output text outside of \`<thinking>\` tags between tool use. Only
     (dsView) => dsView.dataSource.assistantDefaultSelected === true
   );
 
+  if (dataSourceViews.length > 0 && dataSourcesFileSystemMCPServerView) {
+    actions.push({
+      id: -1,
+      sId: GLOBAL_AGENTS_SID.RESEARCH + "-file-system-action",
+      type: "mcp_server_configuration",
+      name: "hidden_dust_search_file_system",
+      description: `The user's data sources (file system).`,
+      mcpServerViewId: dataSourcesFileSystemMCPServerView.sId,
+      internalMCPServerId:
+        dataSourcesFileSystemMCPServerView.internalMCPServerId,
+      dataSources: dataSourceViews.map((dsView) => ({
+        dataSourceViewId: dsView.sId,
+        workspaceId: preFetchedDataSources.workspaceId,
+        filter: { parents: null, tags: null },
+      })),
+      tables: null,
+      childAgentId: null,
+      reasoningModel: null,
+      additionalConfiguration: {},
+      timeFrame: null,
+      dustAppConfiguration: null,
+      jsonSchema: null,
+    });
+  }
+
   // Only add the action if there are data sources and the search MCPServer is available.
   if (dataSourceViews.length > 0 && searchMCPServerView) {
     // We push one action with all data sources
@@ -385,35 +410,6 @@ You must never output text outside of \`<thinking>\` tags between tool use. Only
           dustAppConfiguration: null,
           jsonSchema: null,
         });
-        if (dataSourcesFileSystemMCPServerView) {
-          actions.push({
-            id: -1,
-            sId:
-              GLOBAL_AGENTS_SID.RESEARCH +
-              "-datasource-action-" +
-              dsView.dataSource.sId,
-            type: "mcp_server_configuration",
-            name: "hidden_dust_search_file_system_" + dsView.dataSource.name,
-            description: `The user's ${dsView.dataSource.connectorProvider} data source (file system).`,
-            mcpServerViewId: dataSourcesFileSystemMCPServerView.sId,
-            internalMCPServerId:
-              dataSourcesFileSystemMCPServerView.internalMCPServerId,
-            dataSources: [
-              {
-                workspaceId: preFetchedDataSources.workspaceId,
-                dataSourceViewId: dsView.sId,
-                filter: { parents: null, tags: null },
-              },
-            ],
-            tables: null,
-            childAgentId: null,
-            reasoningModel: null,
-            additionalConfiguration: {},
-            timeFrame: null,
-            dustAppConfiguration: null,
-            jsonSchema: null,
-          });
-        }
       }
     });
   }

--- a/front/lib/api/assistant/global_agents/configurations/research.ts
+++ b/front/lib/api/assistant/global_agents/configurations/research.ts
@@ -1,0 +1,409 @@
+import type { MCPServerConfigurationType } from "@app/lib/actions/mcp";
+import { globalAgentGuidelines } from "@app/lib/api/assistant/global_agents/guidelines";
+import type { PrefetchedDataSourcesType } from "@app/lib/api/assistant/global_agents/tools";
+import { _getDefaultWebActionsForGlobalAgent } from "@app/lib/api/assistant/global_agents/tools";
+import { dummyModelConfiguration } from "@app/lib/api/assistant/global_agents/utils";
+import type { Authenticator } from "@app/lib/auth";
+import type { GlobalAgentSettings } from "@app/lib/models/assistant/agent";
+import type { MCPServerViewResource } from "@app/lib/resources/mcp_server_view_resource";
+import type {
+  AgentConfigurationType,
+  AgentModelConfigurationType,
+} from "@app/types";
+import {
+  getLargeWhitelistedModel,
+  getSmallWhitelistedModel,
+  GLOBAL_AGENTS_SID,
+  MAX_STEPS_USE_PER_RUN_LIMIT,
+} from "@app/types";
+
+export function _getResearchGlobalAgent(
+  auth: Authenticator,
+  {
+    settings,
+    preFetchedDataSources,
+    webSearchBrowseMCPServerView,
+    searchMCPServerView,
+  }: {
+    settings: GlobalAgentSettings | null;
+    preFetchedDataSources: PrefetchedDataSourcesType | null;
+    agentRouterMCPServerView: MCPServerViewResource | null;
+    webSearchBrowseMCPServerView: MCPServerViewResource | null;
+    searchMCPServerView: MCPServerViewResource | null;
+  }
+): AgentConfigurationType | null {
+  const owner = auth.getNonNullableWorkspace();
+
+  const name = "research";
+  const description =
+    "An agent built to do deep research with context on your company data and the internet.";
+  const pictureUrl = "https://dust.tt/static/systemavatar/dust_avatar_full.png";
+
+  const modelConfiguration = auth.isUpgraded()
+    ? getLargeWhitelistedModel(owner)
+    : getSmallWhitelistedModel(owner);
+
+  const model: AgentModelConfigurationType = modelConfiguration
+    ? {
+        providerId: modelConfiguration.providerId,
+        modelId: modelConfiguration.modelId,
+        temperature: 0.7,
+        reasoningEffort: modelConfiguration.defaultReasoningEffort,
+      }
+    : dummyModelConfiguration;
+
+  const instructions = `${globalAgentGuidelines}
+  <primary_goal>
+You are a Research Lead. Your primarily role is to conduct deep research tasks.
+As an AI agent, you are limited in context window so you spawn sub-agents to do some of the work for you.
+You are then responsible to produce a final comprehensive and extremely detailed report based on the work of your sub agents.
+</primary_goal>
+
+<launch_browsing_task_instructions>
+You must bias towards starting browsing tasks instead of browsing URLs yourself if the content of the webpage might be large (over 2000 lines).
+
+Launching a task allows to utilize a sub agent to extract relevant content from a web page instead of reading it yourself and risking overloading your own context window.
+
+In order to efficiently launch browsing tasks, you must provide one or several URLs along with a precise, comprehensive and self-contained prompt describing what to extract.
+The browse agent will not have any context about your task or conversation history besides your prompt.
+
+
+### GOOD Examples:
+\`\`\`
+Task: "Extract pricing information from https://example.com/pricing
+Please find and extract:
+- All pricing tiers and their costs (monthly and annual if available)
+- Features included in each tier
+- Any enterprise pricing information
+- Free trial details if mentioned
+- Payment methods accepted
+Format the information in a structured list with clear tier names and associated features."
+\`\`\`
+\`\`\`
+Task: "Analyze the technical documentation at https://docs.example.com/api/v2/authentication
+Extract:
+- Supported authentication methods (OAuth, API keys, etc.)
+- Required headers and parameters for each method
+- Example code snippets for authentication
+- Rate limiting information related to authentication
+- Any security best practices mentioned"
+\`\`\`
+### BAD Examples:
+\`\`\`
+Task: "Check out this website: https://example.com and tell me what you find"
+(Too vague - no specific extraction goals)
+\`\`\`
+\`\`\`
+Task: "Look at pricing" 
+(Missing URL and specific extraction requirements)
+\`\`\`
+\`\`\`
+Task: "Browse https://example.com and also check their blog and documentation"
+(Too broad - should be split into multiple focused tasks)
+\`\`\`
+</launch_browsing_task_instructions>
+
+<launch_find_task_instructions>
+Launching a find task allows to spawn an agent that will be responsible for find the exact location of a file in the content tree, either by approximate name or by content.
+This is the optimal way to find a file for which you either have:
+- The name, or the approximate name (either mentioned by the user directly, or referenced in another document)
+- An approximate hierarchical location in the data sources graph
+- An approximate knowledge of the content
+
+If finding the document will take for than 2 or 3 steps, using a find task should be preferred over doing the search yourself.
+
+The prompt passed yo the finder agent must be precise and self-contained, as the sub agent will not have access to any of your conversation history and will not have additional context on your overall goals.
+</launch_find_task_instructions>
+
+<launch_research_task_instructions>
+Launching a research task allows to spawn a researcher sub agent to find or extract information from the company's internal data sources or the public internet. The sub agent has access to the data source file system API, the web search and the browse tool.
+
+Tasks you delegate to researcher sub agents must be well-scoped and specific.
+When relevant, for tasks that require internal company data, provide the exact content node IDs the research sub agent should start from.
+
+If you have a well-defined sub task to perform within your broader research process, bias towards delegating it to a researcher sub agent to avoid overloading your own context window with a lot of intermediate sub steps that won't contribute to your goal.
+Research tasks you spawn must be as granular as possible.
+
+You can start several researchers simultaneously using parallel tool calling.
+
+When possible, try to gather sufficient context or determine specific research areas before launching a swarm of several researchers.
+
+If the research task includes company data, ALWAYS ask the researcher to provide a list of content node IDs for the resources they used in their research, in order to be able to trace back their claims or launch more research that start from these.
+If the research task includes public internet content, ALWAYS ask the researcher to provide a list of URLs for the resources they used in their research, in order to be able to trace back their claims or research further.
+If a researcher fails to produce an output, you can break down the task further to split it across more researchers.
+### GOOD Examples:
+\`\`\`
+Task: "Find all Q3 2024 product roadmap documents in our internal Notion workspace starting from content node ID: notion_12345. 
+Extract:
+- Planned feature releases with target dates
+- Priority levels for each feature
+- Dependencies mentioned
+- Team assignments
+Please provide the content node IDs for all documents referenced."
+\`\`\`
+\`\`\`
+Task: "Research our competitor Acme Corp's recent product launches (last 6 months) using web search.
+Focus on:
+- New features announced
+- Pricing changes
+- Market positioning statements
+- Customer testimonials or case studies
+Provide URLs for all sources used."
+\`\`\`
+\`\`\`
+Task: "Locate the 'Customer Churn Analysis 2024' document in our internal data sources. 
+Start search from the Analytics folder (if you can find it) or use semantic search with keywords: 'churn', 'retention', 'customer analysis'.
+Once found, extract the top 5 reasons for churn and their percentages.
+Return the content node ID of the document."
+\`\`\`
+### BAD Examples:
+\`\`\`
+Task: "Research everything about our competitors"
+(Too broad - needs specific competitors and aspects to research)
+\`\`\`
+\`\`\`
+Task: "Find some internal documents about sales"
+(Too vague - no specific document names, time periods, or content node IDs)
+\`\`\`
+\`\`\`
+Task: "Analyze our entire product strategy and compare it with the market, then create recommendations"
+(Multiple complex tasks combined - should be split into: 1) Find product strategy docs, 2) Research market trends, 3) Synthesize findings)
+\`\`\`
+</launch_research_task_instructions>
+
+<launch_analytics_task_instructions>
+Launching an analytics task allows to spawn a sub agent that has read access to the company's Snowflake data warehouse, which contains all the data required to compute metrics about our product's usage, our business, our users, our customers etc..
+
+The analytics agent does not have any context about your task or conversation history beyond the prompt you give it. The prompt must be detailed, specific and self contained.
+
+**Important: Each analytics task should compute only one type of metric.** When you need multiple metrics, spawn separate analytics tasks for each one. This enables parallel processing and clearer results.
+Common metrics that should each be their own task:
+- User growth metrics (new signups)
+- Active user metrics (MAU/DAU)  
+- Retention and cohort analysis
+- Revenue and payment metrics
+- Churn and cancellation metrics
+- Feature adoption rates
+- Performance and system metrics
+### GOOD Examples:
+When needing business metrics for a period, spawn separate tasks like these:
+\`\`\`
+Task 1: "Calculate new user signups for the last 30 days (May 7 - June 7, 2025)
+Output required:
+- Total new signups
+- Daily breakdown
+- Comparison to previous 30-day period"
+\`\`\`
+\`\`\`
+Task 2: "Calculate Monthly Active Users (MAU) for May 7 - June 7, 2025
+Definition: Unique users who performed at least one login
+Output required:
+- Total MAU for the period
+- Week-over-week trend
+- Comparison to previous period"
+\`\`\`
+\`\`\`
+Task 3: "Calculate revenue from new customers for May 7 - June 7, 2025
+Output required:
+- Total revenue from new customers
+- Number of new paying customers
+- Average revenue per new customer"
+\`\`\`
+\`\`\`
+Task 4: "Calculate customer churn rate for May 7 - June 7, 2025
+Definition: Customers who cancelled their subscription
+Output required:
+- Number of churned customers
+- Churn rate percentage
+- Comparison to previous period"
+\`\`\`
+### BAD Examples:
+\`\`\`
+Task: "Generate comprehensive business metrics for Dust over the last 30 days:
+- User growth metrics (new signups, active users, user retention)
+- Product usage metrics (feature adoption, session metrics, engagement)
+- Revenue metrics (new customers, revenue growth, churn)
+- Performance metrics (system uptime, response times, error rates)"
+(This combines many different metrics - should be split into separate tasks for each metric type)
+\`\`\`
+\`\`\`
+Task: "Calculate user metrics including MAU, DAU, retention, and growth for last quarter"
+(Each of these metrics should be its own task for clarity and efficiency)
+\`\`\`
+\`\`\`
+Task: "Analyze business performance with revenue, users, and churn metrics"
+(Too broad - revenue, users, and churn are distinct analyses requiring separate tasks)
+\`\`\`
+</launch_analytics_task_instructions>
+
+<data_source_file_system_api_instructions>
+You can use the data_sources_file_system_api to explore the internal data of the company "Dust".
+
+<data_source_file_system_hierarchy>
+The data sources are organized in a directed graph.
+Each root node represents a data source. Each node in the data sources have exactly one parent and optionally some children (\`hasChildren\`).
+
+- You can use \`list\` to list the nodes that are direct children of a given node. This will return the nodeId and title for each node. Note that documents can also have children in some data sources.
+- You can use \`locate_in_tree\` to view the whole path leading to a given node (you will see the whole subtree that contains the node, from the root up to the node)
+</data_source_file_system_hierarchy>
+
+<data_source_file_system_find_a_node>
+- You search for a node by title using the \`find\` tool on a given node (will explore all children of this node recursively)
+- You can search by running a semantic search (recursively) against the content of all children of a node
+</data_source_file_system_find_a_node>
+
+<data_source_file_system_read_content>
+- You can read the actual content in a document node using the \`cat\` tool
+</data_source_file_system_read_content>
+
+</data_source_file_system_api_instructions>
+
+<parallel_tool_calling_instructions>
+You can use parallel tool calling in order to speed-up your work, when applicable. Tasks that can be done in parallel should be done in parallel.
+</parallel_tool_calling_instructions>
+
+<output_guidelines>
+You must never output text outside of \`<thinking>\` tags between tool use. Only start writing in the main response body (in \`<response>\` tags) once you are done using tools and ready to write a final answer.
+</output_guidelines>
+`;
+
+  const researchAgent = {
+    id: -1,
+    sId: GLOBAL_AGENTS_SID.RESEARCH,
+    version: 0,
+    versionCreatedAt: null,
+    versionAuthorId: null,
+    name,
+    description,
+    instructions,
+    pictureUrl,
+    scope: "global" as const,
+    userFavorite: false,
+    model,
+    visualizationEnabled: true,
+    templateId: null,
+    requestedGroupIds: [],
+    tags: [],
+    canRead: true,
+    canEdit: false,
+  };
+
+  if (
+    (settings && settings.status === "disabled_by_admin") ||
+    !modelConfiguration
+  ) {
+    return {
+      ...researchAgent,
+      status: "disabled_by_admin",
+      actions: [
+        ..._getDefaultWebActionsForGlobalAgent({
+          agentId: GLOBAL_AGENTS_SID.DUST,
+          webSearchBrowseMCPServerView,
+        }),
+      ],
+      maxStepsPerRun: 0,
+    };
+  }
+
+  // This only happens when we fetch the list version of the agent.
+  if (!preFetchedDataSources) {
+    return {
+      ...researchAgent,
+      status: "active",
+      actions: [],
+      maxStepsPerRun: MAX_STEPS_USE_PER_RUN_LIMIT,
+    };
+  }
+
+  const actions: MCPServerConfigurationType[] = [];
+
+  const dataSourceViews = preFetchedDataSources.dataSourceViews.filter(
+    (dsView) => dsView.dataSource.assistantDefaultSelected === true
+  );
+
+  // Only add the action if there are data sources and the search MCPServer is available.
+  if (dataSourceViews.length > 0 && searchMCPServerView) {
+    // We push one action with all data sources
+    actions.push({
+      id: -1,
+      sId: GLOBAL_AGENTS_SID.RESEARCH + "-datasource-action",
+      type: "mcp_server_configuration",
+      name: "search_all_data_sources",
+      description: "The user's entire workspace data sources",
+      mcpServerViewId: searchMCPServerView.sId,
+      internalMCPServerId: searchMCPServerView.internalMCPServerId,
+      dataSources: dataSourceViews.map((dsView) => ({
+        dataSourceViewId: dsView.sId,
+        workspaceId: preFetchedDataSources.workspaceId,
+        filter: { parents: null, tags: null },
+      })),
+      tables: null,
+      childAgentId: null,
+      reasoningModel: null,
+      additionalConfiguration: {},
+      timeFrame: null,
+      dustAppConfiguration: null,
+      jsonSchema: null,
+    });
+
+    // Add one action per managed data source to improve search results for queries like
+    // "search in <data_source>".
+    // Only include data sources from the global space to limit actions for the same
+    // data source.
+    // Hack: Prefix action names with "hidden_" to prevent them from appearing in the UI,
+    // avoiding duplicate display of data sources.
+    dataSourceViews.forEach((dsView) => {
+      if (
+        dsView.dataSource.connectorProvider &&
+        dsView.dataSource.connectorProvider !== "webcrawler" &&
+        dsView.isInGlobalSpace
+      ) {
+        actions.push({
+          id: -1,
+          sId:
+            GLOBAL_AGENTS_SID.RESEARCH +
+            "-datasource-action-" +
+            dsView.dataSource.sId,
+          type: "mcp_server_configuration",
+          name: "hidden_dust_search_" + dsView.dataSource.name,
+          description: `The user's ${dsView.dataSource.connectorProvider} data source.`,
+          mcpServerViewId: searchMCPServerView.sId,
+          internalMCPServerId: searchMCPServerView.internalMCPServerId,
+          dataSources: [
+            {
+              workspaceId: preFetchedDataSources.workspaceId,
+              dataSourceViewId: dsView.sId,
+              filter: { parents: null, tags: null },
+            },
+          ],
+          tables: null,
+          childAgentId: null,
+          reasoningModel: null,
+          additionalConfiguration: {},
+          timeFrame: null,
+          dustAppConfiguration: null,
+          jsonSchema: null,
+        });
+      }
+    });
+  }
+
+  actions.push(
+    ..._getDefaultWebActionsForGlobalAgent({
+      agentId: GLOBAL_AGENTS_SID.RESEARCH,
+      webSearchBrowseMCPServerView,
+    })
+  );
+
+  // Fix the action ids.
+  actions.forEach((action, i) => {
+    action.id = -i;
+  });
+
+  return {
+    ...researchAgent,
+    status: "active",
+    actions,
+    maxStepsPerRun: MAX_STEPS_USE_PER_RUN_LIMIT,
+  };
+}

--- a/front/lib/api/assistant/global_agents/configurations/research.ts
+++ b/front/lib/api/assistant/global_agents/configurations/research.ts
@@ -1,4 +1,12 @@
 import type { MCPServerConfigurationType } from "@app/lib/actions/mcp";
+import type { InternalMCPServerNameType } from "@app/lib/actions/mcp_internal_actions/constants";
+import { SEARCH_TOOL_NAME } from "@app/lib/actions/mcp_internal_actions/constants";
+import {
+  FILESYSTEM_FIND_TOOL_NAME,
+  FILESYSTEM_LIST_TOOL_NAME,
+  FILESYSTEM_LOCATE_IN_TREE_TOOL_NAME,
+  FILESYSTEM_SERVER_NAME,
+} from "@app/lib/actions/mcp_internal_actions/servers/data_sources_file_system";
 import { globalAgentGuidelines } from "@app/lib/api/assistant/global_agents/guidelines";
 import type { PrefetchedDataSourcesType } from "@app/lib/api/assistant/global_agents/tools";
 import { _getDefaultWebActionsForGlobalAgent } from "@app/lib/api/assistant/global_agents/tools";
@@ -235,27 +243,27 @@ Task: "Analyze business performance with revenue, users, and churn metrics"
 \`\`\`
 </launch_analytics_task_instructions>
 
-<data_source_file_system_api_instructions>
-You can use the data_sources_file_system_api to explore the internal data of the company.
+<${FILESYSTEM_SERVER_NAME}_tools_instructions>
+You have access to several tools to explore the internal data of the company:
 
-<data_source_file_system_hierarchy>
+<${FILESYSTEM_SERVER_NAME}_hierarchy>
 The data sources are organized in a directed graph.
 Each root node represents a data source. Each node in the data sources have exactly one parent and optionally some children (\`hasChildren\`).
 
-- You can use \`list\` to list the nodes that are direct children of a given node. This will return the nodeId and title for each node. Note that documents can also have children in some data sources.
-- You can use \`locate_in_tree\` to view the whole path leading to a given node (you will see the whole subtree that contains the node, from the root up to the node)
-</data_source_file_system_hierarchy>
+- You can use the \`${FILESYSTEM_LIST_TOOL_NAME}\` tool to list the nodes that are direct children of a given node. Pass \`nodeId: null\` to list all root data sources. This will return the nodeId and title for each node. Note that documents can also have children in some data sources.
+- You can use the \`${FILESYSTEM_LOCATE_IN_TREE_TOOL_NAME}\` tool to view the whole path leading to a given node (you will see the whole path from the root up to the node)
+</${FILESYSTEM_SERVER_NAME}_hierarchy>
 
-<data_source_file_system_find_a_node>
-- You search for a node by title using the \`find\` tool on a given node (will explore all children of this node recursively)
-- You can search by running a semantic search (recursively) against the content of all children of a node
-</data_source_file_system_find_a_node>
+<${FILESYSTEM_SERVER_NAME}_find_a_node>
+- You can use the \`${FILESYSTEM_FIND_TOOL_NAME}\` tool to search for nodes by title starting from a specific node (will explore all children of this node recursively). Omit the rootNodeId to search across all data sources.
+- You can use the \`${SEARCH_TOOL_NAME}\` tool to run a semantic search against the content of documents within specified nodes
+</${FILESYSTEM_SERVER_NAME}_find_a_node>
 
-<data_source_file_system_read_content>
+<${FILESYSTEM_SERVER_NAME}_read_content>
 - You can read the actual content in a document node using the \`cat\` tool
-</data_source_file_system_read_content>
+</${FILESYSTEM_SERVER_NAME}_read_content>
 
-</data_source_file_system_api_instructions>
+</${FILESYSTEM_SERVER_NAME}_tools_instructions>
 
 <parallel_tool_calling_instructions>
 You can use parallel tool calling in order to speed-up your work, when applicable. Tasks that can be done in parallel should be done in parallel.
@@ -325,7 +333,7 @@ You must never output text outside of \`<thinking>\` tags between tool use. Only
       id: -1,
       sId: GLOBAL_AGENTS_SID.RESEARCH + "-file-system-action",
       type: "mcp_server_configuration",
-      name: "search_file_system",
+      name: "data_sources_file_system" satisfies InternalMCPServerNameType,
       description: "Our company's internal data sources",
       mcpServerViewId: dataSourcesFileSystemMCPServerView.sId,
       internalMCPServerId:

--- a/front/lib/api/assistant/global_agents/configurations/research.ts
+++ b/front/lib/api/assistant/global_agents/configurations/research.ts
@@ -23,13 +23,11 @@ export function _getResearchGlobalAgent(
     settings,
     preFetchedDataSources,
     webSearchBrowseMCPServerView,
-    searchMCPServerView,
     dataSourcesFileSystemMCPServerView,
   }: {
     settings: GlobalAgentSettings | null;
     preFetchedDataSources: PrefetchedDataSourcesType | null;
     webSearchBrowseMCPServerView: MCPServerViewResource | null;
-    searchMCPServerView: MCPServerViewResource | null;
     dataSourcesFileSystemMCPServerView: MCPServerViewResource | null;
   }
 ): AgentConfigurationType | null {
@@ -327,8 +325,8 @@ You must never output text outside of \`<thinking>\` tags between tool use. Only
       id: -1,
       sId: GLOBAL_AGENTS_SID.RESEARCH + "-file-system-action",
       type: "mcp_server_configuration",
-      name: "hidden_dust_search_file_system",
-      description: `The user's data sources (file system).`,
+      name: "search_file_system",
+      description: "Our company's internal data sources",
       mcpServerViewId: dataSourcesFileSystemMCPServerView.sId,
       internalMCPServerId:
         dataSourcesFileSystemMCPServerView.internalMCPServerId,
@@ -344,73 +342,6 @@ You must never output text outside of \`<thinking>\` tags between tool use. Only
       timeFrame: null,
       dustAppConfiguration: null,
       jsonSchema: null,
-    });
-  }
-
-  // Only add the action if there are data sources and the search MCPServer is available.
-  if (dataSourceViews.length > 0 && searchMCPServerView) {
-    // We push one action with all data sources
-    actions.push({
-      id: -1,
-      sId: GLOBAL_AGENTS_SID.RESEARCH + "-datasource-action",
-      type: "mcp_server_configuration",
-      name: "search_all_data_sources",
-      description: "The user's entire workspace data sources",
-      mcpServerViewId: searchMCPServerView.sId,
-      internalMCPServerId: searchMCPServerView.internalMCPServerId,
-      dataSources: dataSourceViews.map((dsView) => ({
-        dataSourceViewId: dsView.sId,
-        workspaceId: preFetchedDataSources.workspaceId,
-        filter: { parents: null, tags: null },
-      })),
-      tables: null,
-      childAgentId: null,
-      reasoningModel: null,
-      additionalConfiguration: {},
-      timeFrame: null,
-      dustAppConfiguration: null,
-      jsonSchema: null,
-    });
-
-    // Add one action per managed data source to improve search results for queries like
-    // "search in <data_source>".
-    // Only include data sources from the global space to limit actions for the same
-    // data source.
-    // Hack: Prefix action names with "hidden_" to prevent them from appearing in the UI,
-    // avoiding duplicate display of data sources.
-    dataSourceViews.forEach((dsView) => {
-      if (
-        dsView.dataSource.connectorProvider &&
-        dsView.dataSource.connectorProvider !== "webcrawler" &&
-        dsView.isInGlobalSpace
-      ) {
-        actions.push({
-          id: -1,
-          sId:
-            GLOBAL_AGENTS_SID.RESEARCH +
-            "-datasource-action-" +
-            dsView.dataSource.sId,
-          type: "mcp_server_configuration",
-          name: "hidden_dust_search_" + dsView.dataSource.name,
-          description: `The user's ${dsView.dataSource.connectorProvider} data source.`,
-          mcpServerViewId: searchMCPServerView.sId,
-          internalMCPServerId: searchMCPServerView.internalMCPServerId,
-          dataSources: [
-            {
-              workspaceId: preFetchedDataSources.workspaceId,
-              dataSourceViewId: dsView.sId,
-              filter: { parents: null, tags: null },
-            },
-          ],
-          tables: null,
-          childAgentId: null,
-          reasoningModel: null,
-          additionalConfiguration: {},
-          timeFrame: null,
-          dustAppConfiguration: null,
-          jsonSchema: null,
-        });
-      }
     });
   }
 

--- a/front/lib/api/assistant/global_agents/global_agent_metadata.ts
+++ b/front/lib/api/assistant/global_agents/global_agent_metadata.ts
@@ -236,6 +236,14 @@ export function getGlobalAgentMetadata(sId: GLOBAL_AGENTS_SID): AgentMetadata {
         description: "An agent with context on your company data.",
         pictureUrl: "https://dust.tt/static/systemavatar/dust_avatar_full.png",
       };
+    case GLOBAL_AGENTS_SID.RESEARCH:
+      return {
+        sId: GLOBAL_AGENTS_SID.RESEARCH,
+        name: "research",
+        description: "An agent that can do deep research on your company data.",
+        pictureUrl:
+          "https://dust.tt/static/systemavatar/research_avatar_full.png",
+      };
     default:
       assertNever(sId);
   }

--- a/front/lib/api/assistant/global_agents/global_agents.ts
+++ b/front/lib/api/assistant/global_agents/global_agents.ts
@@ -64,6 +64,7 @@ function getGlobalAgent({
   agentRouterMCPServerView,
   webSearchBrowseMCPServerView,
   searchMCPServerView,
+  dataSourcesFileSystemMCPServerView,
 }: {
   auth: Authenticator;
   sId: string | number;
@@ -73,6 +74,7 @@ function getGlobalAgent({
   agentRouterMCPServerView: MCPServerViewResource | null;
   webSearchBrowseMCPServerView: MCPServerViewResource | null;
   searchMCPServerView: MCPServerViewResource | null;
+  dataSourcesFileSystemMCPServerView: MCPServerViewResource | null;
 }): AgentConfigurationType | null {
   const settings =
     globalAgentSettings.find((settings) => settings.agentId === sId) ?? null;
@@ -257,9 +259,9 @@ function getGlobalAgent({
       agentConfiguration = _getResearchGlobalAgent(auth, {
         settings,
         preFetchedDataSources,
-        agentRouterMCPServerView,
         webSearchBrowseMCPServerView,
         searchMCPServerView,
+        dataSourcesFileSystemMCPServerView,
       });
       break;
     default:
@@ -316,6 +318,7 @@ export async function getGlobalAgents(
     agentRouterMCPServerView,
     webSearchBrowseMCPServerView,
     searchMCPServerView,
+    dataSourcesFileSystemMCPServerView,
   ] = await Promise.all([
     variant === "full"
       ? getDataSourcesAndWorkspaceIdForGlobalAgents(auth)
@@ -340,6 +343,12 @@ export async function getGlobalAgents(
       ? MCPServerViewResource.getMCPServerViewForAutoInternalTool(
           auth,
           "search"
+        )
+      : null,
+    variant === "full"
+      ? MCPServerViewResource.getMCPServerViewForAutoInternalTool(
+          auth,
+          "data_sources_file_system"
         )
       : null,
   ]);
@@ -392,6 +401,7 @@ export async function getGlobalAgents(
       agentRouterMCPServerView,
       webSearchBrowseMCPServerView,
       searchMCPServerView,
+      dataSourcesFileSystemMCPServerView,
     })
   );
 

--- a/front/lib/api/assistant/global_agents/global_agents.ts
+++ b/front/lib/api/assistant/global_agents/global_agents.ts
@@ -260,7 +260,6 @@ function getGlobalAgent({
         settings,
         preFetchedDataSources,
         webSearchBrowseMCPServerView,
-        searchMCPServerView,
         dataSourcesFileSystemMCPServerView,
       });
       break;

--- a/front/lib/api/assistant/global_agents/global_agents.ts
+++ b/front/lib/api/assistant/global_agents/global_agents.ts
@@ -30,6 +30,7 @@ import {
   _getO3GlobalAgent,
   _getO3MiniGlobalAgent,
 } from "@app/lib/api/assistant/global_agents/configurations/openai";
+import { _getResearchGlobalAgent } from "@app/lib/api/assistant/global_agents/configurations/research";
 import {
   _getGithubGlobalAgent,
   _getGoogleDriveGlobalAgent,
@@ -252,6 +253,15 @@ function getGlobalAgent({
         searchMCPServerView,
       });
       break;
+    case GLOBAL_AGENTS_SID.RESEARCH:
+      agentConfiguration = _getResearchGlobalAgent(auth, {
+        settings,
+        preFetchedDataSources,
+        agentRouterMCPServerView,
+        webSearchBrowseMCPServerView,
+        searchMCPServerView,
+      });
+      break;
     default:
       return null;
   }
@@ -361,6 +371,12 @@ export async function getGlobalAgents(
   if (!flags.includes("deepseek_r1_global_agent_feature")) {
     agentsIdsToFetch = agentsIdsToFetch.filter(
       (sId) => sId !== GLOBAL_AGENTS_SID.DEEPSEEK_R1
+    );
+  }
+
+  if (!flags.includes("research_agent")) {
+    agentsIdsToFetch = agentsIdsToFetch.filter(
+      (sId) => sId !== GLOBAL_AGENTS_SID.RESEARCH
     );
   }
 

--- a/front/types/assistant/assistant.ts
+++ b/front/types/assistant/assistant.ts
@@ -1454,6 +1454,7 @@ export type ReasoningModelConfigurationType = {
 export enum GLOBAL_AGENTS_SID {
   HELPER = "helper",
   DUST = "dust",
+  RESEARCH = "research",
   SLACK = "slack",
   GOOGLE_DRIVE = "google_drive",
   NOTION = "notion",


### PR DESCRIPTION
## Description

Adds the `@research` agent - only with FF activated. 
As of now it does exactly the same as Dust does in term of tools, except I added file_system tools. 

## Tests

Locally. 

## Risk

It's behind a FF so should be safe but can be rolled back. 

## Deploy Plan

Deploy front. 