### PR TITLE
add: enable/disable internal MCP server tools

### DIFF
--- a/front/components/actions/mcp/ToolsList.tsx
+++ b/front/components/actions/mcp/ToolsList.tsx
@@ -136,20 +136,17 @@ export function ToolsList({
                     }`}
                   >
                     <div className="flex items-center gap-2">
-                      {/* We only show the checkbox for remote servers because it's the only one that supports it, for now. */}
-                      {serverType === "remote" && (
-                        <Checkbox
-                          checked={toolEnabled}
-                          disabled={!mayUpdate}
-                          onClick={() =>
-                            handleClick(
-                              tool.name,
-                              getToolPermission(tool.name),
-                              !toolEnabled
-                            )
-                          }
-                        />
-                      )}
+                      <Checkbox
+                        checked={toolEnabled}
+                        disabled={!mayUpdate}
+                        onClick={() =>
+                          handleClick(
+                            tool.name,
+                            getToolPermission(tool.name),
+                            !toolEnabled
+                          )
+                        }
+                      />
                       <h4 className="heading-base flex-grow text-foreground dark:text-foreground-night">
                         {asDisplayName(tool.name)}
                       </h4>
@@ -159,45 +156,44 @@ export function ToolsList({
                         {tool.description}
                       </p>
                     )}
+                    {/* We only show the tool stake for remote servers */}
                     {serverType === "remote" && toolEnabled && (
-                      <>
-                        <Card variant="primary" className="flex-col">
-                          <div className="heading-sm text-muted-foreground dark:text-muted-foreground-night">
-                            Tool stake setting
-                          </div>
-                          <div className="flex justify-end">
-                            <DropdownMenu>
-                              <DropdownMenuTrigger
-                                asChild
-                                disabled={!mayUpdate || !toolEnabled}
-                              >
-                                <Button
-                                  variant="outline"
-                                  label={toolPermissionLabel[toolPermission]}
-                                />
-                              </DropdownMenuTrigger>
-                              <DropdownMenuContent>
-                                {getAvailableStakeLevelsForTool(tool.name).map(
-                                  (permission) => (
-                                    <DropdownMenuItem
-                                      key={permission}
-                                      onClick={() => {
-                                        handleClick(
-                                          tool.name,
-                                          permission,
-                                          getToolEnabled(tool.name)
-                                        );
-                                      }}
-                                      label={toolPermissionLabel[permission]}
-                                      disabled={!toolEnabled}
-                                    />
-                                  )
-                                )}
-                              </DropdownMenuContent>
-                            </DropdownMenu>
-                          </div>
-                        </Card>
-                      </>
+                      <Card variant="primary" className="flex-col">
+                        <div className="heading-sm text-muted-foreground dark:text-muted-foreground-night">
+                          Tool stake setting
+                        </div>
+                        <div className="flex justify-end">
+                          <DropdownMenu>
+                            <DropdownMenuTrigger
+                              asChild
+                              disabled={!mayUpdate || !toolEnabled}
+                            >
+                              <Button
+                                variant="outline"
+                                label={toolPermissionLabel[toolPermission]}
+                              />
+                            </DropdownMenuTrigger>
+                            <DropdownMenuContent>
+                              {getAvailableStakeLevelsForTool(tool.name).map(
+                                (permission) => (
+                                  <DropdownMenuItem
+                                    key={permission}
+                                    onClick={() => {
+                                      handleClick(
+                                        tool.name,
+                                        permission,
+                                        getToolEnabled(tool.name)
+                                      );
+                                    }}
+                                    label={toolPermissionLabel[permission]}
+                                    disabled={!toolEnabled}
+                                  />
+                                )
+                              )}
+                            </DropdownMenuContent>
+                          </DropdownMenu>
+                        </div>
+                      </Card>
                     )}
                   </div>
                 );

--- a/front/lib/actions/mcp_actions.test.ts
+++ b/front/lib/actions/mcp_actions.test.ts
@@ -6,6 +6,7 @@ import {
   makeToolsWithStakesAndTimeout,
   TOOL_NAME_SEPARATOR,
 } from "@app/lib/actions/mcp_actions";
+import { internalMCPServerNameToSId } from "@app/lib/actions/mcp_helper";
 import type { RemoteMCPServerToolMetadataResource } from "@app/lib/resources/remote_mcp_server_tool_metadata_resource";
 
 describe("getPrefixedToolName", () => {
@@ -102,7 +103,12 @@ describe("makeToolsWithStakesAndTimeout", () => {
       },
     ];
 
-    const result = makeToolsWithStakesAndTimeout("ims_XME0qbHbOz7", metadata);
+    const sid = internalMCPServerNameToSId({
+      name: "google_calendar",
+      workspaceId: 1,
+      prefix: 0,
+    });
+    const result = makeToolsWithStakesAndTimeout(sid, metadata);
     assert(result.isOk());
     expect(result.value).toEqual({
       toolsEnabled: {

--- a/front/lib/actions/mcp_actions.test.ts
+++ b/front/lib/actions/mcp_actions.test.ts
@@ -3,11 +3,180 @@ import { assert, describe, expect, it } from "vitest";
 import type { ServerSideMCPServerConfigurationType } from "@app/lib/actions/mcp";
 import {
   getPrefixedToolName,
+  listToolsForServerSideMCPServer,
   makeToolsWithStakesAndTimeout,
   TOOL_NAME_SEPARATOR,
 } from "@app/lib/actions/mcp_actions";
 import { internalMCPServerNameToSId } from "@app/lib/actions/mcp_helper";
-import type { RemoteMCPServerToolMetadataResource } from "@app/lib/resources/remote_mcp_server_tool_metadata_resource";
+import type { MCPConnectionParams } from "@app/lib/actions/mcp_metadata";
+import { connectToMCPServer } from "@app/lib/actions/mcp_metadata";
+import { Authenticator } from "@app/lib/auth";
+import { InternalMCPServerInMemoryResource } from "@app/lib/resources/internal_mcp_server_in_memory_resource";
+import { RemoteMCPServerToolMetadataResource } from "@app/lib/resources/remote_mcp_server_tool_metadata_resource";
+import { SpaceResource } from "@app/lib/resources/space_resource";
+import { generateRandomModelSId } from "@app/lib/resources/string_ids";
+import { GroupFactory } from "@app/tests/utils/GroupFactory";
+import { MembershipFactory } from "@app/tests/utils/MembershipFactory";
+import { UserFactory } from "@app/tests/utils/UserFactory";
+import { WorkspaceFactory } from "@app/tests/utils/WorkspaceFactory";
+
+// Sets up test environment with workspace, auth, MCP server, client connection, and configuration.
+async function setupTest() {
+  const user = await UserFactory.basic();
+  const workspace = await WorkspaceFactory.basic();
+  // Membership need to be set before auth.
+  await MembershipFactory.associate(workspace, user, {
+    role: "admin",
+  });
+  const { globalGroup, systemGroup } = await GroupFactory.defaults(workspace);
+  const auth = await Authenticator.fromUserIdAndWorkspaceId(
+    user.sId,
+    workspace.sId
+  );
+  // Auth user need to have admin role to create space.
+  await SpaceResource.makeDefaultsForWorkspace(auth, {
+    globalGroup,
+    systemGroup,
+  });
+  const internalMCPServer = await InternalMCPServerInMemoryResource.makeNew(
+    auth,
+    {
+      name: "google_calendar",
+      useCase: null,
+    }
+  );
+
+  // Set up MCP connection and configuration.
+  const connectionParams: MCPConnectionParams = {
+    type: "mcpServerId",
+    mcpServerId: internalMCPServer.id,
+    oAuthUseCase: null,
+  };
+
+  const r = await connectToMCPServer(auth, {
+    params: connectionParams,
+  });
+  assert(r.isOk());
+  const mcpClient = r.value;
+
+  const config: ServerSideMCPServerConfigurationType = {
+    id: -1,
+    sId: generateRandomModelSId(),
+    type: "mcp_server_configuration",
+    name: "dummy_name",
+    description: "dummy_description",
+    dataSources: null,
+    tables: null,
+    childAgentId: null,
+    reasoningModel: null,
+    timeFrame: null,
+    jsonSchema: null,
+    additionalConfiguration: {},
+    mcpServerViewId: "mcpServerId",
+    dustAppConfiguration: null,
+    internalMCPServerId: internalMCPServer.id,
+  };
+
+  return {
+    auth,
+    user,
+    workspace,
+    mcpServerId: internalMCPServer.id,
+    connectionParams,
+    mcpClient,
+    config,
+  };
+}
+
+describe("MCP Actions", () => {
+  it("should filter disabled tools and store metadata settings", async () => {
+    const { auth, mcpServerId, connectionParams, mcpClient, config } =
+      await setupTest();
+    // Test initial tool listing - should include all tools with default permissions.
+    const toolsResBefore = await listToolsForServerSideMCPServer(
+      auth,
+      connectionParams,
+      mcpClient,
+      config
+    );
+    assert(toolsResBefore.isOk());
+    expect(toolsResBefore.value).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          availability: "manual",
+          name: "list_calendars",
+          permission: "never_ask", // Default permission from MCP server.
+        }),
+        expect.objectContaining({
+          availability: "manual",
+          name: "list_events",
+          permission: "never_ask", // Default permission from MCP server.
+        }),
+      ])
+    );
+
+    // Update tool metadata settings - disable list_calendars and change permissions.
+    await RemoteMCPServerToolMetadataResource.updateOrCreateSettings(auth, {
+      serverSId: mcpServerId,
+      toolName: "list_calendars",
+      permission: "high",
+      enabled: false, // This will cause the tool to be filtered out.
+    });
+    await RemoteMCPServerToolMetadataResource.updateOrCreateSettings(auth, {
+      serverSId: mcpServerId,
+      toolName: "list_events",
+      permission: "high", // Permission metadata is stored but NOT applied to tool configs.
+      enabled: true, // Explicitly enable (though it's enabled by default).
+    });
+
+    // Verify metadata is stored correctly.
+    const metadata = await RemoteMCPServerToolMetadataResource.fetchByServerId(
+      auth,
+      connectionParams.mcpServerId
+    );
+    expect(metadata).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          enabled: false,
+          toolName: "list_calendars",
+          permission: "high",
+        }),
+        expect.objectContaining({
+          enabled: true,
+          toolName: "list_events",
+          permission: "high",
+        }),
+      ])
+    );
+
+    // Test tool listing after metadata changes.
+    const toolsResAfter = await listToolsForServerSideMCPServer(
+      auth,
+      connectionParams,
+      mcpClient,
+      config
+    );
+    assert(toolsResAfter.isOk());
+    expect(toolsResAfter.value).toEqual(
+      expect.arrayContaining([
+        // Note: list_calendars is filtered out because enabled=false.
+        expect.objectContaining({
+          availability: "manual",
+          name: "list_events",
+          permission: "never_ask", // Permission metadata is stored but NOT applied to tool configs.
+        }),
+      ])
+    );
+    // Verify list_calendars is NOT in the results (filtered out due to enabled=false).
+    expect(toolsResAfter.value).not.toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          name: "list_calendars",
+        }),
+      ])
+    );
+  });
+});
 
 describe("getPrefixedToolName", () => {
   const mockConfig: ServerSideMCPServerConfigurationType = {

--- a/front/lib/actions/mcp_actions.ts
+++ b/front/lib/actions/mcp_actions.ts
@@ -841,7 +841,7 @@ async function listToolsForServerSideMCPServer(
   );
 
   const toolsWithStakesAndTimeout = allToolsRaw
-    .filter(({ name }) => toolsEnabled[name])
+    .filter(({ name }) => !(toolsEnabled[name] === false)) // Include tools that are enabled (true) or not explicitly disabled (undefined).
     .map((tool) => ({
       ...tool,
       stakeLevel:

--- a/front/lib/actions/mcp_actions.ts
+++ b/front/lib/actions/mcp_actions.ts
@@ -834,23 +834,25 @@ async function listToolsForServerSideMCPServer(
   if (r.isErr()) {
     return r;
   }
-  const { toolsStakes, serverTimeoutMs } = r.value;
+  const { toolsEnabled, toolsStakes, serverTimeoutMs } = r.value;
 
   const availability = getAvailabilityOfInternalMCPServerById(
     connectionParams.mcpServerId
   );
 
-  const toolsWithStakesAndTimeout = allToolsRaw.map((tool) => ({
-    ...tool,
-    stakeLevel:
-      toolsStakes[tool.name] ||
-      (availability === "manual"
-        ? FALLBACK_MCP_TOOL_STAKE_LEVEL
-        : FALLBACK_INTERNAL_AUTO_SERVERS_TOOL_STAKE_LEVEL),
-    availability,
-    toolServerId: connectionParams.mcpServerId,
-    ...(serverTimeoutMs && { timeoutMs: serverTimeoutMs }),
-  }));
+  const toolsWithStakesAndTimeout = allToolsRaw
+    .filter(({ name }) => toolsEnabled[name])
+    .map((tool) => ({
+      ...tool,
+      stakeLevel:
+        toolsStakes[tool.name] ||
+        (availability === "manual"
+          ? FALLBACK_MCP_TOOL_STAKE_LEVEL
+          : FALLBACK_INTERNAL_AUTO_SERVERS_TOOL_STAKE_LEVEL),
+      availability,
+      toolServerId: connectionParams.mcpServerId,
+      ...(serverTimeoutMs && { timeoutMs: serverTimeoutMs }),
+    }));
 
   const serverSideToolConfigs = makeServerSideMCPToolConfigurations(
     config,

--- a/front/lib/actions/mcp_actions.ts
+++ b/front/lib/actions/mcp_actions.ts
@@ -133,12 +133,8 @@ export function makeToolsWithStakesAndTimeout(
     toolsStakes = INTERNAL_MCP_SERVERS[serverName].tools_stakes || {};
     serverTimeoutMs = INTERNAL_MCP_SERVERS[serverName]?.timeoutMs;
   } else {
-    toolsStakes = metadata.reduce<Record<string, MCPToolStakeLevelType>>(
-      (acc, metadata) => {
-        acc[metadata.toolName] = metadata.permission;
-        return acc;
-      },
-      {}
+    metadata.forEach(
+      ({ toolName, permission }) => (toolsStakes[toolName] = permission)
     );
   }
 
@@ -838,11 +834,7 @@ async function listToolsForServerSideMCPServer(
   if (r.isErr()) {
     return r;
   }
-  const { toolsEnabled, toolsStakes, serverTimeoutMs } = r.value;
-
-  allToolsRaw = allToolsRaw.filter((tool) => {
-    return !toolsEnabled[tool.name] || toolsEnabled[tool.name];
-  });
+  const { toolsStakes, serverTimeoutMs } = r.value;
 
   const availability = getAvailabilityOfInternalMCPServerById(
     connectionParams.mcpServerId

--- a/front/lib/actions/mcp_actions.ts
+++ b/front/lib/actions/mcp_actions.ts
@@ -42,7 +42,6 @@ import { findMatchingSubSchemas } from "@app/lib/actions/mcp_internal_actions/in
 import type { MCPProgressNotificationType } from "@app/lib/actions/mcp_internal_actions/output_schemas";
 import { isMCPProgressNotificationType } from "@app/lib/actions/mcp_internal_actions/output_schemas";
 import type {
-  ConnectViaMCPServerId,
   MCPConnectionParams,
   ServerSideMCPConnectionParams,
 } from "@app/lib/actions/mcp_metadata";
@@ -113,9 +112,13 @@ export interface ServerToolsAndInstructions {
   tools: MCPToolConfigurationType[];
 }
 
-function makeToolsWithStakesAndTimeout(
+export function makeToolsWithStakesAndTimeout(
   mcpServerId: string,
-  metadata: RemoteMCPServerToolMetadataResource[]
+  metadata: {
+    toolName: string;
+    permission: "high" | "low" | "never_ask";
+    enabled: boolean;
+  }[]
 ) {
   let toolsStakes: Record<string, MCPToolStakeLevelType> = {};
   let serverTimeoutMs: number | undefined;

--- a/front/lib/actions/mcp_actions.ts
+++ b/front/lib/actions/mcp_actions.ts
@@ -785,7 +785,7 @@ async function listToolsForClientSideMCPServer(
   return new Ok(clientSideToolConfigs);
 }
 
-async function listToolsForServerSideMCPServer(
+export async function listToolsForServerSideMCPServer(
   auth: Authenticator,
   connectionParams: ServerSideMCPConnectionParams,
   mcpClient: Client,

--- a/front/lib/actions/mcp_actions.ts
+++ b/front/lib/actions/mcp_actions.ts
@@ -806,7 +806,11 @@ async function listToolsForServerSideMCPServer(
 
     case "remote": {
       const metadata =
-        await RemoteMCPServerToolMetadataResource.fetchByServerId(auth, id);
+        await RemoteMCPServerToolMetadataResource.fetchByServerId(
+          auth,
+          id,
+          serverType
+        );
       toolsStakes = metadata.reduce<Record<string, MCPToolStakeLevelType>>(
         (acc, metadata) => {
           acc[metadata.toolName] = metadata.permission;

--- a/front/lib/actions/mcp_metadata.ts
+++ b/front/lib/actions/mcp_metadata.ts
@@ -83,7 +83,7 @@ export function isInternalMCPServerDefinition(
   );
 }
 
-export interface ConnectViaMCPServerId {
+interface ConnectViaMCPServerId {
   type: "mcpServerId";
   mcpServerId: string;
   oAuthUseCase: MCPOAuthUseCase | null;

--- a/front/lib/actions/mcp_metadata.ts
+++ b/front/lib/actions/mcp_metadata.ts
@@ -83,7 +83,7 @@ export function isInternalMCPServerDefinition(
   );
 }
 
-interface ConnectViaMCPServerId {
+export interface ConnectViaMCPServerId {
   type: "mcpServerId";
   mcpServerId: string;
   oAuthUseCase: MCPOAuthUseCase | null;

--- a/front/lib/models/assistant/actions/remote_mcp_server_tool_metadata.ts
+++ b/front/lib/models/assistant/actions/remote_mcp_server_tool_metadata.ts
@@ -11,7 +11,7 @@ export class RemoteMCPServerToolMetadataModel extends WorkspaceAwareModel<Remote
   declare updatedAt: CreationOptional<Date>;
 
   declare remoteMCPServerId?: ForeignKey<RemoteMCPServerModel["id"]>;
-  declare internalMCPServerId?: number;
+  declare internalMCPServerId?: string;
   declare toolName: string;
   declare permission: MCPToolStakeLevelType;
   declare enabled: boolean;
@@ -38,7 +38,7 @@ RemoteMCPServerToolMetadataModel.init(
       },
     },
     internalMCPServerId: {
-      type: DataTypes.INTEGER,
+      type: DataTypes.STRING,
       allowNull: true,
     },
     toolName: {

--- a/front/lib/models/assistant/actions/remote_mcp_server_tool_metadata.ts
+++ b/front/lib/models/assistant/actions/remote_mcp_server_tool_metadata.ts
@@ -10,7 +10,8 @@ export class RemoteMCPServerToolMetadataModel extends WorkspaceAwareModel<Remote
   declare createdAt: CreationOptional<Date>;
   declare updatedAt: CreationOptional<Date>;
 
-  declare remoteMCPServerId: ForeignKey<RemoteMCPServerModel["id"]>;
+  declare remoteMCPServerId?: ForeignKey<RemoteMCPServerModel["id"]>;
+  declare internalMCPServerId?: number;
   declare toolName: string;
   declare permission: MCPToolStakeLevelType;
   declare enabled: boolean;
@@ -30,11 +31,15 @@ RemoteMCPServerToolMetadataModel.init(
     },
     remoteMCPServerId: {
       type: DataTypes.INTEGER,
-      allowNull: false,
+      allowNull: true,
       references: {
         model: RemoteMCPServerModel,
         key: "id",
       },
+    },
+    internalMCPServerId: {
+      type: DataTypes.INTEGER,
+      allowNull: true,
     },
     toolName: {
       type: DataTypes.STRING,
@@ -57,7 +62,12 @@ RemoteMCPServerToolMetadataModel.init(
       {
         unique: true,
         fields: ["workspaceId", "remoteMCPServerId", "toolName"],
-        name: "remote_mcp_server_tool_metadata_wid_serverid_tool_name",
+        name: "remote_mcp_server_tool_metadata_wid_remoteserverid_serverid_tool_name",
+      },
+      {
+        unique: true,
+        fields: ["workspaceId", "internalMCPServerId", "toolName"],
+        name: "remote_mcp_server_tool_metadata_wid_internalserverid_tool_name",
       },
     ],
   }

--- a/front/lib/models/assistant/actions/remote_mcp_server_tool_metadata.ts
+++ b/front/lib/models/assistant/actions/remote_mcp_server_tool_metadata.ts
@@ -11,7 +11,7 @@ export class RemoteMCPServerToolMetadataModel extends WorkspaceAwareModel<Remote
   declare updatedAt: CreationOptional<Date>;
 
   declare remoteMCPServerId?: ForeignKey<RemoteMCPServerModel["id"]>;
-  declare internalMCPServerId?: string;
+  declare internalMCPServerSId?: string;
   declare toolName: string;
   declare permission: MCPToolStakeLevelType;
   declare enabled: boolean;
@@ -37,7 +37,7 @@ RemoteMCPServerToolMetadataModel.init(
         key: "id",
       },
     },
-    internalMCPServerId: {
+    internalMCPServerSId: {
       type: DataTypes.STRING,
       allowNull: true,
     },
@@ -66,8 +66,8 @@ RemoteMCPServerToolMetadataModel.init(
       },
       {
         unique: true,
-        fields: ["workspaceId", "internalMCPServerId", "toolName"],
-        name: "remote_mcp_server_tool_metadata_wid_internalserverid_tool_name",
+        fields: ["workspaceId", "internalMCPServerSId", "toolName"],
+        name: "remote_mcp_server_tool_metadata_wid_internalserversid_tool_name",
       },
     ],
   }

--- a/front/lib/models/assistant/actions/remote_mcp_server_tool_metadata.ts
+++ b/front/lib/models/assistant/actions/remote_mcp_server_tool_metadata.ts
@@ -62,7 +62,7 @@ RemoteMCPServerToolMetadataModel.init(
       {
         unique: true,
         fields: ["workspaceId", "remoteMCPServerId", "toolName"],
-        name: "remote_mcp_server_tool_metadata_wid_remoteserverid_serverid_tool_name",
+        name: "remote_mcp_server_tool_metadata_wid_serverid_tool_name",
       },
       {
         unique: true,

--- a/front/lib/models/assistant/actions/remote_mcp_server_tool_metadata.ts
+++ b/front/lib/models/assistant/actions/remote_mcp_server_tool_metadata.ts
@@ -11,7 +11,7 @@ export class RemoteMCPServerToolMetadataModel extends WorkspaceAwareModel<Remote
   declare updatedAt: CreationOptional<Date>;
 
   declare remoteMCPServerId?: ForeignKey<RemoteMCPServerModel["id"]>;
-  declare internalMCPServerSId?: string;
+  declare internalMCPServerId?: string;
   declare toolName: string;
   declare permission: MCPToolStakeLevelType;
   declare enabled: boolean;
@@ -37,7 +37,7 @@ RemoteMCPServerToolMetadataModel.init(
         key: "id",
       },
     },
-    internalMCPServerSId: {
+    internalMCPServerId: {
       type: DataTypes.STRING,
       allowNull: true,
     },
@@ -66,7 +66,7 @@ RemoteMCPServerToolMetadataModel.init(
       },
       {
         unique: true,
-        fields: ["workspaceId", "internalMCPServerSId", "toolName"],
+        fields: ["workspaceId", "internalMCPServerId", "toolName"],
         name: "remote_mcp_server_tool_metadata_wid_internalserversid_tool_name",
       },
     ],

--- a/front/lib/resources/remote_mcp_server_tool_metadata_resource.ts
+++ b/front/lib/resources/remote_mcp_server_tool_metadata_resource.ts
@@ -94,7 +94,7 @@ export class RemoteMCPServerToolMetadataResource extends BaseResource<RemoteMCPS
       where:
         serverType === "remote"
           ? { remoteMCPServerId: serverId }
-          : { internalMCPServerId: serverSId },
+          : { internalMCPServerSId: serverSId },
     });
   }
 
@@ -154,7 +154,7 @@ export class RemoteMCPServerToolMetadataResource extends BaseResource<RemoteMCPS
     const [toolMetadata] = await this.model.upsert({
       ...(serverType === "remote"
         ? { remoteMCPServerId: serverId }
-        : { internalMCPServerId: serverSId }),
+        : { internalMCPServerSId: serverSId }),
       toolName,
       permission,
       enabled,
@@ -206,7 +206,7 @@ export class RemoteMCPServerToolMetadataResource extends BaseResource<RemoteMCPS
   } {
     return {
       remoteMCPServerId: this.remoteMCPServerId,
-      internalMCPServerId: this.internalMCPServerId,
+      internalMCPServerId: this.internalMCPServerSId,
       toolName: this.toolName,
       permission: this.permission,
       enabled: this.enabled,

--- a/front/lib/resources/remote_mcp_server_tool_metadata_resource.ts
+++ b/front/lib/resources/remote_mcp_server_tool_metadata_resource.ts
@@ -85,12 +85,15 @@ export class RemoteMCPServerToolMetadataResource extends BaseResource<RemoteMCPS
   static async fetchByServerId(
     auth: Authenticator,
     serverId: number,
+    serverType: "internal" | "remote",
     options?: ResourceFindOptions<RemoteMCPServerToolMetadataModel>
   ): Promise<RemoteMCPServerToolMetadataResource[]> {
     return this.baseFetch(auth, {
       ...options,
       where: {
-        remoteMCPServerId: serverId,
+        ...(serverType === "remote"
+          ? { remoteMCPServerId: serverId }
+          : { internalMCPServerId: serverId }),
       },
     });
   }
@@ -127,11 +130,13 @@ export class RemoteMCPServerToolMetadataResource extends BaseResource<RemoteMCPS
     auth: Authenticator,
     {
       serverId,
+      serverType,
       toolName,
       permission,
       enabled,
     }: {
       serverId: number;
+      serverType: "internal" | "remote";
       toolName: string;
       permission: MCPToolStakeLevelType;
       enabled: boolean;
@@ -148,7 +153,9 @@ export class RemoteMCPServerToolMetadataResource extends BaseResource<RemoteMCPS
     }
 
     const [toolMetadata] = await this.model.upsert({
-      remoteMCPServerId: serverId,
+      ...(serverType === "remote"
+        ? { remoteMCPServerId: serverId }
+        : { internalMCPServerId: serverId }),
       toolName,
       permission,
       enabled,
@@ -192,13 +199,15 @@ export class RemoteMCPServerToolMetadataResource extends BaseResource<RemoteMCPS
   // toJSON
 
   toJSON(): {
-    remoteMCPServerId: number;
+    remoteMCPServerId?: number;
+    internalMCPServerId?: number;
     toolName: string;
     permission: MCPToolStakeLevelType;
     enabled: boolean;
   } {
     return {
       remoteMCPServerId: this.remoteMCPServerId,
+      internalMCPServerId: this.internalMCPServerId,
       toolName: this.toolName,
       permission: this.permission,
       enabled: this.enabled,

--- a/front/lib/resources/remote_mcp_server_tool_metadata_resource.ts
+++ b/front/lib/resources/remote_mcp_server_tool_metadata_resource.ts
@@ -94,7 +94,7 @@ export class RemoteMCPServerToolMetadataResource extends BaseResource<RemoteMCPS
       where:
         serverType === "remote"
           ? { remoteMCPServerId: serverId }
-          : { internalMCPServerSId: serverSId },
+          : { internalMCPServerId: serverSId },
     });
   }
 
@@ -154,7 +154,7 @@ export class RemoteMCPServerToolMetadataResource extends BaseResource<RemoteMCPS
     const [toolMetadata] = await this.model.upsert({
       ...(serverType === "remote"
         ? { remoteMCPServerId: serverId }
-        : { internalMCPServerSId: serverSId }),
+        : { internalMCPServerId: serverSId }),
       toolName,
       permission,
       enabled,
@@ -199,14 +199,14 @@ export class RemoteMCPServerToolMetadataResource extends BaseResource<RemoteMCPS
 
   toJSON(): {
     remoteMCPServerId?: number;
-    internalMCPServerSId?: string;
+    internalMCPServerId?: string;
     toolName: string;
     permission: MCPToolStakeLevelType;
     enabled: boolean;
   } {
     return {
       remoteMCPServerId: this.remoteMCPServerId,
-      internalMCPServerSId: this.internalMCPServerSId,
+      internalMCPServerId: this.internalMCPServerId,
       toolName: this.toolName,
       permission: this.permission,
       enabled: this.enabled,

--- a/front/lib/resources/remote_mcp_server_tool_metadata_resource.ts
+++ b/front/lib/resources/remote_mcp_server_tool_metadata_resource.ts
@@ -199,14 +199,14 @@ export class RemoteMCPServerToolMetadataResource extends BaseResource<RemoteMCPS
 
   toJSON(): {
     remoteMCPServerId?: number;
-    internalMCPServerId?: string;
+    internalMCPServerSId?: string;
     toolName: string;
     permission: MCPToolStakeLevelType;
     enabled: boolean;
   } {
     return {
       remoteMCPServerId: this.remoteMCPServerId,
-      internalMCPServerId: this.internalMCPServerSId,
+      internalMCPServerSId: this.internalMCPServerSId,
       toolName: this.toolName,
       permission: this.permission,
       enabled: this.enabled,

--- a/front/migrations/db/migration_334.sql
+++ b/front/migrations/db/migration_334.sql
@@ -1,0 +1,8 @@
+-- Migration created on Aug 13, 2025
+ALTER TABLE "public"."remote_mcp_server_tool_metadata" ADD COLUMN "internalMCPServerId" VARCHAR(255);
+ALTER TABLE "public"."remote_mcp_server_tool_metadata" ALTER COLUMN "remoteMCPServerId" DROP NOT NULL;
+ALTER TABLE "remote_mcp_server_tool_metadata" ADD CONSTRAINT "check_mcp_server_id_not_both_null" CHECK (
+    ("internalMCPServerId" IS NOT NULL AND "remoteMCPServerId" IS NULL) OR
+    ("internalMCPServerId" IS NULL AND "remoteMCPServerId" IS NOT NULL)
+);
+CREATE UNIQUE INDEX IF NOT EXISTS "remote_mcp_server_tool_metadata_wid_internalserversid_tool_name" ON "remote_mcp_server_tool_metadata" USING btree ("workspaceId", "internalMCPServerId", "toolName");

--- a/front/pages/api/w/[wId]/mcp/[serverId]/tools/[toolName]/index.ts
+++ b/front/pages/api/w/[wId]/mcp/[serverId]/tools/[toolName]/index.ts
@@ -121,8 +121,7 @@ async function handler(
       }
 
       await RemoteMCPServerToolMetadataResource.updateOrCreateSettings(auth, {
-        serverId: id,
-        serverType,
+        serverSId: serverId,
         toolName,
         permission: permission ?? "high",
         enabled: enabled ?? true,

--- a/front/pages/api/w/[wId]/mcp/[serverId]/tools/[toolName]/index.ts
+++ b/front/pages/api/w/[wId]/mcp/[serverId]/tools/[toolName]/index.ts
@@ -14,7 +14,6 @@ import { RemoteMCPServerToolMetadataResource } from "@app/lib/resources/remote_m
 import { RemoteMCPServerResource } from "@app/lib/resources/remote_mcp_servers_resource";
 import { apiError } from "@app/logger/withlogging";
 import type { WithAPIErrorResponse } from "@app/types";
-import { assertNever } from "@app/types";
 
 export type PatchMCPServerToolsPermissionsResponseBody = {
   success: boolean;
@@ -78,78 +77,57 @@ async function handler(
           },
         });
       }
+      const r = UpdateMCPToolSettingsBodySchema.safeParse(req.body);
+      if (r.error) {
+        return apiError(req, res, {
+          api_error: {
+            type: "invalid_request_error",
+            message: fromError(r.error).toString(),
+          },
+          status_code: 400,
+        });
+      }
 
-      switch (serverType) {
-        case "internal":
-          return apiError(req, res, {
-            status_code: 400,
-            api_error: {
-              type: "invalid_request_error",
-              message:
-                "Internal MCP server does not support editing tool permissions.",
-            },
-          });
-        case "remote": {
-          const r = UpdateMCPToolSettingsBodySchema.safeParse(req.body);
-          if (r.error) {
+      const { permission, enabled } = r.data;
+
+      if (serverType === "remote" && permission !== undefined) {
+        if (!CUSTOM_REMOTE_MCP_TOOL_STAKE_LEVELS.includes(permission as any)) {
+          const remoteMCPServer = await RemoteMCPServerResource.findByPk(
+            auth,
+            id
+          );
+          if (!remoteMCPServer) {
             return apiError(req, res, {
+              status_code: 404,
               api_error: {
-                type: "invalid_request_error",
-                message: fromError(r.error).toString(),
+                type: "data_source_not_found",
+                message: "Remote MCP server not found.",
               },
-              status_code: 400,
             });
           }
-
-          const { permission, enabled } = r.data;
-
-          if (permission !== undefined) {
-            if (
-              !CUSTOM_REMOTE_MCP_TOOL_STAKE_LEVELS.includes(permission as any)
-            ) {
-              const remoteMCPServer = await RemoteMCPServerResource.findByPk(
-                auth,
-                id
-              );
-              if (!remoteMCPServer) {
-                return apiError(req, res, {
-                  status_code: 404,
-                  api_error: {
-                    type: "data_source_not_found",
-                    message: "Remote MCP server not found.",
-                  },
-                });
-              }
-              const defaultServerConfig = getDefaultRemoteMCPServerByURL(
-                remoteMCPServer.url
-              );
-              if (defaultServerConfig?.toolStakes?.[toolName] !== permission) {
-                return apiError(req, res, {
-                  status_code: 400,
-                  api_error: {
-                    type: "invalid_request_error",
-                    message: `The '${permission}' permission is only allowed for tools pre-configured with this setting in default servers.`,
-                  },
-                });
-              }
-            }
-          }
-
-          await RemoteMCPServerToolMetadataResource.updateOrCreateSettings(
-            auth,
-            {
-              serverId: id,
-              toolName,
-              permission: permission ?? "high",
-              enabled: enabled ?? true,
-            }
+          const defaultServerConfig = getDefaultRemoteMCPServerByURL(
+            remoteMCPServer.url
           );
-          return res.status(200).json({ success: true });
+          if (defaultServerConfig?.toolStakes?.[toolName] !== permission) {
+            return apiError(req, res, {
+              status_code: 400,
+              api_error: {
+                type: "invalid_request_error",
+                message: `The '${permission}' permission is only allowed for tools pre-configured with this setting in default servers.`,
+              },
+            });
+          }
         }
-        default:
-          assertNever(serverType);
       }
-      break;
+
+      await RemoteMCPServerToolMetadataResource.updateOrCreateSettings(auth, {
+        serverId: id,
+        serverType,
+        toolName,
+        permission: permission ?? "high",
+        enabled: enabled ?? true,
+      });
+      return res.status(200).json({ success: true });
     }
     default:
       return apiError(req, res, {

--- a/front/pages/api/w/[wId]/mcp/[serverId]/tools/index.ts
+++ b/front/pages/api/w/[wId]/mcp/[serverId]/tools/index.ts
@@ -1,7 +1,6 @@
 import type { NextApiRequest, NextApiResponse } from "next";
 
 import type { MCPToolStakeLevelType } from "@app/lib/actions/constants";
-import { getServerTypeAndIdFromSId } from "@app/lib/actions/mcp_helper";
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
 import type { Authenticator } from "@app/lib/auth";
 import { RemoteMCPServerToolMetadataResource } from "@app/lib/resources/remote_mcp_server_tool_metadata_resource";
@@ -49,13 +48,10 @@ async function handler(
 
   switch (req.method) {
     case "GET": {
-      const { serverType, id } = getServerTypeAndIdFromSId(serverId);
-
       const resources =
         await RemoteMCPServerToolMetadataResource.fetchByServerId(
           auth,
-          id,
-          serverType
+          serverId
         );
 
       const toolsSettings = resources.reduce(


### PR DESCRIPTION
## Description

Fix https://github.com/dust-tt/tasks/issues/3330

This PR is better read commit by commit.

Adds the ability to enable/disable internal MCP server tools. The implementation includes:
- UI components in `ToolsList.tsx` for managing tool states
- API endpoints for enabling/disabling tools at `/api/w/[wId]/mcp/[serverId]/tools/[toolName]` and `/api/w/[wId]/mcp/[serverId]/tools`
- Database model updates to track tool enablement state
- Refactoring to use string IDs for better consistency
- Database migration (migration_332.sql) to support the new schema

## Tests

Manual testing of the enable/disable functionality through the UI and API endpoints.

## Risk

Low risk changes as this is additive functionality:
- New database migration adds columns without breaking existing data
- API changes are backward compatible
- UI changes are isolated to the MCP tools management interface
- String ID refactoring improves consistency without changing core functionality

## Deploy Plan

1. Deploy the database migration (migration_332.sql) first
2. Deploy the application code changes
3. Verify MCP tool enable/disable functionality works as expected in the UI
4. Monitor for any issues with the new API endpoints