### PR TITLE
[front] feat(ab): Add data selection to footer + block space & category selection

### DIFF
--- a/front/components/agent_builder/capabilities/knowledge/KnowledgeConfigurationSheet.tsx
+++ b/front/components/agent_builder/capabilities/knowledge/KnowledgeConfigurationSheet.tsx
@@ -185,10 +185,7 @@ export function KnowledgeConfigurationSheet({
   return (
     <MultiPageSheet open={open} onOpenChange={handleOpenChange}>
       <FormProvider {...formMethods}>
-        <DataSourceBuilderProvider
-          control={formMethods.control}
-          spaces={spaces}
-        >
+        <DataSourceBuilderProvider spaces={spaces}>
           <KnowledgeConfigurationSheetContent
             config={config}
             setConfig={setConfig}
@@ -386,7 +383,7 @@ function KnowledgeConfigurationSheetContent({
       })}
       size="xl"
       showNavigation
-      footerContent={<KnowledgeFooter control={control} />}
+      footerContent={<KnowledgeFooter />}
     />
   );
 }

--- a/front/components/agent_builder/capabilities/knowledge/KnowledgeConfigurationSheet.tsx
+++ b/front/components/agent_builder/capabilities/knowledge/KnowledgeConfigurationSheet.tsx
@@ -176,8 +176,8 @@ export function KnowledgeConfigurationSheet({
 
   if (isSpacesLoading) {
     return (
-      <div>
-        <Spinner />
+      <div className="flex justify-center py-8">
+        <Spinner variant="dark" size="md" />
       </div>
     );
   }

--- a/front/components/agent_builder/capabilities/knowledge/KnowledgeFooter.tsx
+++ b/front/components/agent_builder/capabilities/knowledge/KnowledgeFooter.tsx
@@ -7,22 +7,20 @@ import {
   GithubLogo,
 } from "@dust-tt/sparkle";
 import { useState } from "react";
-import type { Control } from "react-hook-form";
 
-import type { CapabilityFormData } from "@app/components/agent_builder/types";
 import { useSourcesFormController } from "@app/components/agent_builder/utils";
 import { useDataSourceBuilderContext } from "@app/components/data_source_view/context/DataSourceBuilderContext";
 import { pluralize } from "@app/types";
 
-export function KnowledgeFooter({
-  control,
-}: {
-  control: Control<CapabilityFormData>;
-}) {
+export function KnowledgeFooter() {
   const [isOpen, setOpen] = useState(false);
   const { removeNode } = useDataSourceBuilderContext();
 
-  const { field } = useSourcesFormController({ control });
+  const { field } = useSourcesFormController();
+
+  if (!field.value.in) {
+    return <></>;
+  }
 
   return (
     <div className="px-4 py-5">

--- a/front/components/agent_builder/capabilities/knowledge/KnowledgeFooter.tsx
+++ b/front/components/agent_builder/capabilities/knowledge/KnowledgeFooter.tsx
@@ -1,0 +1,58 @@
+import {
+  Checkbox,
+  Collapsible,
+  CollapsibleContent,
+  CollapsibleTrigger,
+  ContextItem,
+  GithubLogo,
+} from "@dust-tt/sparkle";
+import { useState } from "react";
+import type { Control } from "react-hook-form";
+
+import type { CapabilityFormData } from "@app/components/agent_builder/types";
+import { useSourcesFormController } from "@app/components/agent_builder/utils";
+import { useDataSourceBuilderContext } from "@app/components/data_source_view/context/DataSourceBuilderContext";
+import { pluralize } from "@app/types";
+
+export function KnowledgeFooter({
+  control,
+}: {
+  control: Control<CapabilityFormData>;
+}) {
+  const [isOpen, setOpen] = useState(false);
+  const { removeNode } = useDataSourceBuilderContext();
+
+  const { field } = useSourcesFormController({ control });
+
+  return (
+    <div className="px-4 py-5">
+      <Collapsible open={isOpen} onOpenChange={setOpen}>
+        <CollapsibleTrigger isOpen={isOpen}>
+          <span className="heading-sm text-muted-foreground">
+            Selection ({field.value.in.length} item
+            {pluralize(field.value.in.length)})
+          </span>
+        </CollapsibleTrigger>
+        <CollapsibleContent>
+          <ContextItem.List className="rounded-xl bg-muted px-1.5 py-2 dark:bg-muted-night">
+            {field.value.in.map((path) => (
+              <ContextItem
+                key={path}
+                title={path}
+                visual={<ContextItem.Visual visual={GithubLogo} />}
+                action={
+                  <Checkbox
+                    checked
+                    onCheckedChange={() => removeNode(path.split(".")[-1])}
+                  />
+                }
+              >
+                <span className="text-xs">{path}</span>
+              </ContextItem>
+            ))}
+          </ContextItem.List>
+        </CollapsibleContent>
+      </Collapsible>
+    </div>
+  );
+}

--- a/front/components/agent_builder/capabilities/knowledge/KnowledgeFooter.tsx
+++ b/front/components/agent_builder/capabilities/knowledge/KnowledgeFooter.tsx
@@ -87,7 +87,7 @@ export function KnowledgeFooter() {
         </CollapsibleTrigger>
         <CollapsibleContent>
           <div className="rounded-xl bg-muted dark:bg-muted-night">
-            <ContextItem.List className="max-h-[183px] overflow-x-scroll">
+            <ContextItem.List className="max-h-40 overflow-x-scroll">
               {field.value.in.map((item) => (
                 <KnowledgeFooterItem key={item.path} item={item} />
               ))}

--- a/front/components/agent_builder/capabilities/knowledge/KnowledgeFooter.tsx
+++ b/front/components/agent_builder/capabilities/knowledge/KnowledgeFooter.tsx
@@ -4,7 +4,6 @@ import {
   CollapsibleContent,
   CollapsibleTrigger,
   ContextItem,
-  GithubLogo,
 } from "@dust-tt/sparkle";
 import { useState } from "react";
 
@@ -12,6 +11,7 @@ import { useAgentBuilderContext } from "@app/components/agent_builder/AgentBuild
 import { useSourcesFormController } from "@app/components/agent_builder/utils";
 import { useDataSourceBuilderContext } from "@app/components/data_source_view/context/DataSourceBuilderContext";
 import type { DataSourceBuilderTreeItemType } from "@app/components/data_source_view/context/types";
+import { getVisualForTreeItem } from "@app/components/data_source_view/context/utils";
 import { useNodePath } from "@app/hooks/useNodePath";
 import type { DataSourceViewContentNode } from "@app/types";
 import { pluralize } from "@app/types";
@@ -50,12 +50,13 @@ function KnowledgeFooterItem({
   item: DataSourceBuilderTreeItemType;
 }) {
   const { removeNodeWithPath } = useDataSourceBuilderContext();
+  const VisualComponent = getVisualForTreeItem(item);
 
   return (
     <ContextItem
       key={item.path}
       title={item.name}
-      visual={<ContextItem.Visual visual={GithubLogo} />}
+      visual={<ContextItem.Visual visual={VisualComponent} />}
       action={
         <Checkbox checked onCheckedChange={() => removeNodeWithPath(item)} />
       }

--- a/front/components/agent_builder/capabilities/knowledge/KnowledgeFooter.tsx
+++ b/front/components/agent_builder/capabilities/knowledge/KnowledgeFooter.tsx
@@ -45,7 +45,7 @@ function KnowledgeFooterItemReadablePath({
 }
 
 function KnowledgeFooterItem({
-  item: { path, name, node },
+  item,
 }: {
   item: DataSourceBuilderTreeItemType;
 }) {
@@ -53,17 +53,16 @@ function KnowledgeFooterItem({
 
   return (
     <ContextItem
-      key={path}
-      title={name}
+      key={item.path}
+      title={item.name}
       visual={<ContextItem.Visual visual={GithubLogo} />}
       action={
-        <Checkbox
-          checked
-          onCheckedChange={() => removeNodeWithPath(path, name)}
-        />
+        <Checkbox checked onCheckedChange={() => removeNodeWithPath(item)} />
       }
     >
-      {node != null && <KnowledgeFooterItemReadablePath node={node} />}
+      {item.type === "node" && (
+        <KnowledgeFooterItemReadablePath node={item.node} />
+      )}
     </ContextItem>
   );
 }

--- a/front/components/agent_builder/capabilities/knowledge/KnowledgeFooter.tsx
+++ b/front/components/agent_builder/capabilities/knowledge/KnowledgeFooter.tsx
@@ -37,12 +37,9 @@ function KnowledgeFooterItemReadablePath({
     <span className="text-xs">
       {isLoading
         ? "loading..."
-        : fullPath
-            .flatMap((node) => [
-              node.dataSourceView.dataSource.name,
-              node.title,
-            ])
-            .join("/")}
+        : [node.parentInternalId, ...fullPath.map((node) => node.title)].join(
+            "/"
+          )}
     </span>
   );
 }

--- a/front/components/agent_builder/capabilities/knowledge/KnowledgeFooter.tsx
+++ b/front/components/agent_builder/capabilities/knowledge/KnowledgeFooter.tsx
@@ -13,12 +13,12 @@ import { useDataSourceBuilderContext } from "@app/components/data_source_view/co
 import { pluralize } from "@app/types";
 
 export function KnowledgeFooter() {
-  const [isOpen, setOpen] = useState(false);
-  const { removeNode } = useDataSourceBuilderContext();
+  const [isOpen, setOpen] = useState(true);
+  const { removeNodeWithPath } = useDataSourceBuilderContext();
 
   const { field } = useSourcesFormController();
 
-  if (!field.value.in) {
+  if (field.value.in.length <= 0) {
     return <></>;
   }
 
@@ -32,23 +32,25 @@ export function KnowledgeFooter() {
           </span>
         </CollapsibleTrigger>
         <CollapsibleContent>
-          <ContextItem.List className="rounded-xl bg-muted px-1.5 py-2 dark:bg-muted-night">
-            {field.value.in.map((path) => (
-              <ContextItem
-                key={path}
-                title={path}
-                visual={<ContextItem.Visual visual={GithubLogo} />}
-                action={
-                  <Checkbox
-                    checked
-                    onCheckedChange={() => removeNode(path.split(".")[-1])}
-                  />
-                }
-              >
-                <span className="text-xs">{path}</span>
-              </ContextItem>
-            ))}
-          </ContextItem.List>
+          <div className="rounded-xl bg-muted dark:bg-muted-night">
+            <ContextItem.List className="max-h-[183px] overflow-x-scroll">
+              {field.value.in.map((path) => (
+                <ContextItem
+                  key={path}
+                  title={path}
+                  visual={<ContextItem.Visual visual={GithubLogo} />}
+                  action={
+                    <Checkbox
+                      checked
+                      onCheckedChange={() => removeNodeWithPath(path)}
+                    />
+                  }
+                >
+                  <span className="text-xs">{path}</span>
+                </ContextItem>
+              ))}
+            </ContextItem.List>
+          </div>
         </CollapsibleContent>
       </Collapsible>
     </div>

--- a/front/components/agent_builder/capabilities/knowledge/KnowledgeFooter.tsx
+++ b/front/components/agent_builder/capabilities/knowledge/KnowledgeFooter.tsx
@@ -34,19 +34,19 @@ export function KnowledgeFooter() {
         <CollapsibleContent>
           <div className="rounded-xl bg-muted dark:bg-muted-night">
             <ContextItem.List className="max-h-[183px] overflow-x-scroll">
-              {field.value.in.map((path) => (
+              {field.value.in.map(({ path, name, readablePath }) => (
                 <ContextItem
                   key={path}
-                  title={path}
+                  title={name}
                   visual={<ContextItem.Visual visual={GithubLogo} />}
                   action={
                     <Checkbox
                       checked
-                      onCheckedChange={() => removeNodeWithPath(path)}
+                      onCheckedChange={() => removeNodeWithPath(path, name)}
                     />
                   }
                 >
-                  <span className="text-xs">{path}</span>
+                  <span className="text-xs">{readablePath}</span>
                 </ContextItem>
               ))}
             </ContextItem.List>

--- a/front/components/agent_builder/capabilities/knowledge/transformations.ts
+++ b/front/components/agent_builder/capabilities/knowledge/transformations.ts
@@ -32,6 +32,8 @@ export function transformTreeToSelectionConfigurations(
 
   // Parse the tree paths to extract data source configurations
   for (const item of tree.in) {
+    // We can skip for item that aren't data_source or node. As we only allow those
+    // to be selected, it safe to skip, and make our life easier type wise after that checks
     if (item.type !== "node" && item.type !== "data_source") {
       continue;
     }

--- a/front/components/agent_builder/capabilities/knowledge/transformations.ts
+++ b/front/components/agent_builder/capabilities/knowledge/transformations.ts
@@ -168,8 +168,7 @@ export function transformSelectionConfigurationsToTree(
 
           inPaths.push({
             path: pathParts.join("."),
-            name: node.title,
-            readablePath: "",
+            name: parentId ?? node.title,
           });
         }
       }
@@ -222,6 +221,5 @@ function buildDataSourcePath(
   return {
     path: parts.join("."),
     name: dataSourceView.dataSource.name,
-    readablePath: "",
   };
 }

--- a/front/components/agent_builder/capabilities/knowledge/transformations.ts
+++ b/front/components/agent_builder/capabilities/knowledge/transformations.ts
@@ -86,7 +86,6 @@ export function transformTreeToSelectionConfigurations(
 export function transformSelectionConfigurationsToTree(
   configurations: DataSourceViewSelectionConfigurations
 ): DataSourceBuilderTreeType {
-  console.log({ configurations });
   const inPaths: DataSourceBuilderTreeItemType[] = [];
   const notInPaths: DataSourceBuilderTreeItemType[] = [];
 

--- a/front/components/agent_builder/utils.ts
+++ b/front/components/agent_builder/utils.ts
@@ -1,4 +1,3 @@
-import type { Control } from "react-hook-form";
 import { useController } from "react-hook-form";
 
 import type { CapabilityFormData } from "@app/components/agent_builder/types";
@@ -40,10 +39,6 @@ export function validateDataSourceConfiguration(
   }
 }
 
-export function useSourcesFormController({
-  control,
-}: {
-  control: Control<CapabilityFormData>;
-}) {
-  return useController({ control, name: "sources" });
+export function useSourcesFormController() {
+  return useController<CapabilityFormData, "sources">({ name: "sources" });
 }

--- a/front/components/agent_builder/utils.ts
+++ b/front/components/agent_builder/utils.ts
@@ -1,3 +1,7 @@
+import type { Control } from "react-hook-form";
+import { useController } from "react-hook-form";
+
+import type { CapabilityFormData } from "@app/components/agent_builder/types";
 import { dataSourceConfigurationSchema } from "@app/components/agent_builder/types";
 import type { DataSourceConfiguration } from "@app/lib/api/assistant/configuration/types";
 import type { AssistantTemplateListType } from "@app/pages/api/templates";
@@ -34,4 +38,12 @@ export function validateDataSourceConfiguration(
   } catch (error) {
     return new Err(normalizeError(error));
   }
+}
+
+export function useSourcesFormController({
+  control,
+}: {
+  control: Control<CapabilityFormData>;
+}) {
+  return useController({ control, name: "sources" });
 }

--- a/front/components/agent_builder/utils.ts
+++ b/front/components/agent_builder/utils.ts
@@ -39,6 +39,10 @@ export function validateDataSourceConfiguration(
   }
 }
 
+/**
+ * Helper hook to access the `sources`.
+ * As a single `useController` can be use to access a given attribute.
+ */
 export function useSourcesFormController() {
   return useController<CapabilityFormData, "sources">({ name: "sources" });
 }

--- a/front/components/data_source_view/DataSourceBuilderSelector.tsx
+++ b/front/components/data_source_view/DataSourceBuilderSelector.tsx
@@ -1,7 +1,6 @@
 import type { BreadcrumbItem } from "@dust-tt/sparkle";
 import { Breadcrumbs, SearchInput } from "@dust-tt/sparkle";
 import { useMemo, useState } from "react";
-import { useWatch } from "react-hook-form";
 
 import { useSpacesContext } from "@app/components/agent_builder/SpacesContext";
 import { useDataSourceBuilderContext } from "@app/components/data_source_view/context/DataSourceBuilderContext";
@@ -37,7 +36,6 @@ export const DataSourceBuilderSelector = ({
     findDataSourceViewFromNavigationHistory(navigationHistory);
 
   const [searchQuery, setSearchQuery] = useState("");
-  const sources = useWatch({ name: "sources" });
 
   const breadcrumbItems: BreadcrumbItem[] = useMemo(
     () =>
@@ -88,8 +86,6 @@ export const DataSourceBuilderSelector = ({
         selectedDataSourceView !== null && (
           <DataSourceNodeTable viewType={viewType} />
         )}
-
-      <pre>{JSON.stringify(sources, undefined, 2)}</pre>
     </div>
   );
 };

--- a/front/components/data_source_view/DataSourceBuilderSelector.tsx
+++ b/front/components/data_source_view/DataSourceBuilderSelector.tsx
@@ -1,14 +1,9 @@
 import type { BreadcrumbItem } from "@dust-tt/sparkle";
-import { Breadcrumbs, SearchInput, Spinner } from "@dust-tt/sparkle";
+import { Breadcrumbs, SearchInput } from "@dust-tt/sparkle";
 import { useMemo, useState } from "react";
-import type { Control } from "react-hook-form";
 
 import { useSpacesContext } from "@app/components/agent_builder/SpacesContext";
-import type { CapabilityFormData } from "@app/components/agent_builder/types";
-import {
-  DataSourceBuilderProvider,
-  useDataSourceBuilderContext,
-} from "@app/components/data_source_view/context/DataSourceBuilderContext";
+import { useDataSourceBuilderContext } from "@app/components/data_source_view/context/DataSourceBuilderContext";
 import type { NavigationHistoryEntryType } from "@app/components/data_source_view/context/types";
 import {
   findCategoryFromNavigationHistory,
@@ -24,42 +19,21 @@ import type {
   ContentNodesViewType,
   DataSourceViewType,
   LightWorkspaceType,
-  SpaceType,
 } from "@app/types";
 
 type DataSourceBuilderSelectorProps = {
-  allowedSpaces?: SpaceType[];
   owner: LightWorkspaceType;
   dataSourceViews: DataSourceViewType[];
   viewType: ContentNodesViewType;
-  control: Control<CapabilityFormData>;
 };
 
 export const DataSourceBuilderSelector = ({
-  control,
-  ...props
-}: DataSourceBuilderSelectorProps) => {
-  const { spaces, isSpacesLoading } = useSpacesContext();
-
-  if (isSpacesLoading) {
-    return <Spinner />;
-  }
-
-  return (
-    <DataSourceBuilderProvider control={control} spaces={spaces}>
-      <DataSourceBuilderSelectorContent {...props} />
-    </DataSourceBuilderProvider>
-  );
-};
-
-export const DataSourceBuilderSelectorContent = ({
-  allowedSpaces,
   dataSourceViews,
   owner,
   viewType,
-}: Omit<DataSourceBuilderSelectorProps, "control">) => {
+}: DataSourceBuilderSelectorProps) => {
+  const { spaces } = useSpacesContext();
   const {
-    spaces,
     navigationHistory,
     navigateTo,
     setSpaceEntry,
@@ -114,7 +88,7 @@ export const DataSourceBuilderSelectorContent = ({
       {currentNavigationEntry.type === "root" ? (
         <DataSourceSpaceSelector
           spaces={filteredSpaces}
-          allowedSpaces={allowedSpaces}
+          allowedSpaces={spaces}
           onSelectSpace={setSpaceEntry}
         />
       ) : (

--- a/front/components/data_source_view/DataSourceCategoryBrowser.tsx
+++ b/front/components/data_source_view/DataSourceCategoryBrowser.tsx
@@ -28,7 +28,7 @@ import {
 } from "@app/types";
 
 interface CategoryRowData {
-  id: string;
+  id: DataSourceViewCategoryWithoutApps;
   title: string;
   onClick: () => void;
   icon: React.JSX.Element;
@@ -109,14 +109,14 @@ export function DataSourceCategoryBrowser({
               onClick={(event) => event.stopPropagation()}
               onCheckedChange={(state) => {
                 if (state === "indeterminate") {
-                  removeNode(row.original.id);
+                  removeNode(row.original.id, row.original.title);
                   return;
                 }
 
                 if (state) {
-                  selectNode(row.original.id);
+                  selectNode({ type: "category", category: row.original.id });
                 } else {
-                  removeNode(row.original.id);
+                  removeNode(row.original.id, row.original.title);
                 }
               }}
             />

--- a/front/components/data_source_view/DataSourceNodeTable.tsx
+++ b/front/components/data_source_view/DataSourceNodeTable.tsx
@@ -214,7 +214,6 @@ export function DataSourceNodeTable({ viewType }: DataSourceNodeTableProps) {
           <ScrollableDataTable
             data={nodeRows}
             columns={columns}
-            maxHeight="max-h-[600px]"
             getRowId={(row) => row.id}
             onLoadMore={handleLoadMore}
           />

--- a/front/components/data_source_view/DataSourceNodeTable.tsx
+++ b/front/components/data_source_view/DataSourceNodeTable.tsx
@@ -36,7 +36,7 @@ interface DataSourceNodeTableProps {
   isCategoryLoading?: boolean;
 }
 
-interface NodeRowData {
+interface NodeRowData extends DataSourceViewContentNode {
   id: string;
   title: string;
   onClick?: () => void;
@@ -132,28 +132,30 @@ export function DataSourceNodeTable({
             isDark,
           });
 
+          const contentNode: DataSourceViewContentNode = {
+            internalId: dsv.sId,
+            title: getDataSourceNameFromView(dsv),
+            dataSourceView: dsv,
+            expandable: true,
+            parentInternalIds: null,
+            type: "folder",
+            mimeType: "application/vnd.dust.folder",
+            parentTitle: null,
+            lastUpdatedAt: null,
+            parentInternalId: null,
+            permission: "read",
+            sourceUrl: null,
+            providerVisibility: null,
+          };
+
           return {
+            ...contentNode,
             id: dsv.sId,
             internalId: dsv.sId,
             title: dsv.dataSource.name,
             icon: <Icon visual={logo} />,
             parentTitle: null,
             onClick: () => {
-              const contentNode: DataSourceViewContentNode = {
-                internalId: dsv.sId,
-                title: getDataSourceNameFromView(dsv),
-                dataSourceView: dsv,
-                expandable: true,
-                parentInternalIds: null,
-                type: "folder",
-                mimeType: "application/vnd.dust.folder",
-                parentTitle: null,
-                lastUpdatedAt: null,
-                parentInternalId: null,
-                permission: "read",
-                sourceUrl: null,
-                providerVisibility: null,
-              };
               onNavigate(contentNode);
             },
           };
@@ -203,12 +205,7 @@ export function DataSourceNodeTable({
               onClick={(event) => event.stopPropagation()}
               onCheckedChange={(state) => {
                 // When clicking a partial checkbox, select all
-                if (selectionState === "partial") {
-                  selectCurrentNavigationEntry();
-                  return;
-                }
-
-                if (state) {
+                if (selectionState === "partial" || state) {
                   selectCurrentNavigationEntry();
                 } else {
                   removeCurrentNavigationEntry();
@@ -230,15 +227,10 @@ export function DataSourceNodeTable({
                 onClick={(event) => event.stopPropagation()}
                 onCheckedChange={(state) => {
                   // When clicking a partial checkbox, select all
-                  if (selectionState === "partial") {
-                    selectNode(row.original.id);
-                    return;
-                  }
-
-                  if (state) {
-                    selectNode(row.original.id);
+                  if (selectionState === "partial" || state) {
+                    selectNode({ type: "node", node: row.original });
                   } else {
-                    removeNode(row.original.id);
+                    removeNode(row.original.id, row.original.title);
                   }
                 }}
               />
@@ -308,6 +300,7 @@ function getTableRows(
 ): NodeRowData[] {
   return nodes.map((node) => {
     return {
+      ...node,
       id: node.internalId,
       title: node.title,
       icon: (

--- a/front/components/data_source_view/DataSourceNodeTable.tsx
+++ b/front/components/data_source_view/DataSourceNodeTable.tsx
@@ -76,8 +76,17 @@ export function DataSourceNodeTable({ viewType }: DataSourceNodeTableProps) {
     }
   }, [hasNextPage, isNodesLoading, loadMore]);
 
-  const nodeRows = useMemo(
-    () => getTableRows(childNodes, (node) => addNodeEntry(node)),
+  const nodeRows: NodeRowData[] = useMemo(
+    () =>
+      childNodes.map((node) => {
+        return {
+          id: node.internalId,
+          title: node.title,
+          icon: getVisualForDataSourceViewContentNode(node),
+          onClick: node.expandable ? () => addNodeEntry(node) : undefined,
+          rawNodeData: node,
+        };
+      }),
     [childNodes, addNodeEntry]
   );
 
@@ -172,30 +181,13 @@ export function DataSourceNodeTable({ viewType }: DataSourceNodeTableProps) {
           <Spinner size="md" />
         </div>
       ) : (
-        <>
-          <ScrollableDataTable
-            data={nodeRows}
-            columns={columns}
-            getRowId={(row) => row.id}
-            onLoadMore={handleLoadMore}
-          />
-        </>
+        <ScrollableDataTable
+          data={nodeRows}
+          columns={columns}
+          getRowId={(row) => row.id}
+          onLoadMore={handleLoadMore}
+        />
       )}
     </div>
   );
-}
-
-function getTableRows(
-  nodes: DataSourceViewContentNode[],
-  onNodeClick: (node: DataSourceViewContentNode) => void
-): NodeRowData[] {
-  return nodes.map((node) => {
-    return {
-      id: node.internalId,
-      title: node.title,
-      icon: getVisualForDataSourceViewContentNode(node),
-      onClick: node.expandable ? () => onNodeClick(node) : undefined,
-      rawNodeData: node,
-    };
-  });
 }

--- a/front/components/data_source_view/DataSourceSpaceSelector.tsx
+++ b/front/components/data_source_view/DataSourceSpaceSelector.tsx
@@ -6,11 +6,11 @@ import { useDataSourceBuilderContext } from "@app/components/data_source_view/co
 import { getSpaceIcon } from "@app/lib/spaces";
 import type { SpaceType } from "@app/types";
 
-type SpaceRowData = {
+type SpaceRowData = SpaceType & {
   id: string;
   icon: React.ComponentType;
   onClick: () => void;
-} & Pick<SpaceType, "name" | "kind">;
+};
 
 export interface DataSourceSpaceSelectorProps {
   spaces: SpaceType[];
@@ -27,6 +27,7 @@ export function DataSourceSpaceSelector({
     useDataSourceBuilderContext();
 
   const spaceRows: SpaceRowData[] = spaces.map((space) => ({
+    ...space,
     id: space.sId,
     name: space.name,
     kind: space.kind,
@@ -53,14 +54,14 @@ export function DataSourceSpaceSelector({
               onClick={(event) => event.stopPropagation()}
               onCheckedChange={(state) => {
                 if (state === "indeterminate") {
-                  removeNode(row.original.id);
+                  removeNode(row.original.id, row.original.name);
                   return;
                 }
 
                 if (state) {
-                  selectNode(row.original.id);
+                  selectNode({ type: "space", space: row.original });
                 } else {
-                  removeNode(row.original.id);
+                  removeNode(row.original.id, row.original.name);
                 }
               }}
             />

--- a/front/components/data_source_view/DataSourceViewTable.tsx
+++ b/front/components/data_source_view/DataSourceViewTable.tsx
@@ -146,9 +146,17 @@ export function DataSourceViewTable() {
         CATEGORY_DETAILS[dsv.category].icon
       : FolderIcon;
 
+    let title = dsv.dataSource.name;
+    if (
+      connectorProvider != null &&
+      connectorProvider.connectorProvider !== "webcrawler"
+    ) {
+      title = connectorProvider.name;
+    }
+
     return {
       id: dsv.sId,
-      title: connectorProvider?.name ?? dsv.dataSource.name,
+      title,
       onClick: () => setDataSourceViewEntry(dsv),
       dataSourceView: dsv,
       icon,

--- a/front/components/data_source_view/DataSourceViewTable.tsx
+++ b/front/components/data_source_view/DataSourceViewTable.tsx
@@ -151,7 +151,6 @@ export function DataSourceViewTable() {
     <ScrollableDataTable
       data={rows}
       columns={columns}
-      maxHeight="max-h-[600px]"
       getRowId={(row) => row.id}
     />
   );

--- a/front/components/data_source_view/DataSourceViewTable.tsx
+++ b/front/components/data_source_view/DataSourceViewTable.tsx
@@ -17,7 +17,7 @@ import {
   findSpaceFromNavigationHistory,
 } from "@app/components/data_source_view/context/utils";
 import { useTheme } from "@app/components/sparkle/ThemeContext";
-import { getConnectorProviderLogoWithFallback } from "@app/lib/connector_providers";
+import { CONNECTOR_CONFIGURATIONS } from "@app/lib/connector_providers";
 import { CATEGORY_DETAILS } from "@app/lib/spaces";
 import { useSpaceDataSourceViews } from "@app/lib/swr/spaces";
 import type { DataSourceViewType } from "@app/types";
@@ -136,19 +136,24 @@ export function DataSourceViewTable() {
     ]
   );
 
-  const rows: RowData[] = spaceDataSourceViews.map((dsv) => ({
-    id: dsv.sId,
-    title: dsv.dataSource.name,
-    onClick: () => setDataSourceViewEntry(dsv),
-    dataSourceView: dsv,
-    icon: dsv.dataSource.connectorProvider
-      ? getConnectorProviderLogoWithFallback({
-          provider: dsv.dataSource.connectorProvider,
-          isDark,
-          fallback: CATEGORY_DETAILS[dsv.category].icon,
-        })
-      : FolderIcon,
-  }));
+  const rows: RowData[] = spaceDataSourceViews.map((dsv) => {
+    const connectorProvider = dsv.dataSource.connectorProvider
+      ? CONNECTOR_CONFIGURATIONS[dsv.dataSource.connectorProvider]
+      : null;
+
+    const icon = dsv.dataSource.connectorProvider
+      ? connectorProvider?.getLogoComponent(isDark) ??
+        CATEGORY_DETAILS[dsv.category].icon
+      : FolderIcon;
+
+    return {
+      id: dsv.sId,
+      title: connectorProvider?.name ?? dsv.dataSource.name,
+      onClick: () => setDataSourceViewEntry(dsv),
+      dataSourceView: dsv,
+      icon,
+    };
+  });
 
   if (isSpaceDataSourceViewsLoading) {
     return (

--- a/front/components/data_source_view/DataSourceViewTable.tsx
+++ b/front/components/data_source_view/DataSourceViewTable.tsx
@@ -1,0 +1,160 @@
+import {
+  Checkbox,
+  DataTable,
+  Hoverable,
+  ScrollableDataTable,
+  Spinner,
+} from "@dust-tt/sparkle";
+import type { ColumnDef } from "@tanstack/react-table";
+import { useMemo } from "react";
+
+import { useAgentBuilderContext } from "@app/components/agent_builder/AgentBuilderContext";
+import { useDataSourceBuilderContext } from "@app/components/data_source_view/context/DataSourceBuilderContext";
+import type { NavigationHistoryEntryType } from "@app/components/data_source_view/context/types";
+import {
+  findCategoryFromNavigationHistory,
+  findSpaceFromNavigationHistory,
+} from "@app/components/data_source_view/context/utils";
+import { useSpaceDataSourceViews } from "@app/lib/swr/spaces";
+import type { DataSourceViewType } from "@app/types";
+
+type RowData = {
+  id: string;
+  title: string;
+  onClick?: () => void;
+  icon?: React.ComponentType;
+  dataSourceView: DataSourceViewType;
+};
+
+export function DataSourceViewTable() {
+  const { owner } = useAgentBuilderContext();
+  const {
+    navigationHistory,
+    isCurrentNavigationEntrySelected,
+    selectCurrentNavigationEntry,
+    removeCurrentNavigationEntry,
+    isRowSelected,
+    isRowSelectable,
+    selectNode,
+    removeNode,
+    setDataSourceViewEntry,
+  } = useDataSourceBuilderContext();
+  const space = findSpaceFromNavigationHistory(navigationHistory);
+
+  const selectedCategory = findCategoryFromNavigationHistory(navigationHistory);
+  const { spaceDataSourceViews, isSpaceDataSourceViewsLoading } =
+    useSpaceDataSourceViews({
+      category: selectedCategory ?? undefined,
+      workspaceId: owner.sId,
+      spaceId: space?.sId ?? "",
+    });
+
+  const columns: ColumnDef<RowData>[] = useMemo(
+    () => [
+      {
+        id: "select",
+        enableSorting: false,
+        enableHiding: false,
+        header: () => {
+          const selectionState = isCurrentNavigationEntrySelected();
+          return (
+            <Checkbox
+              key={`header-${selectionState}`}
+              size="xs"
+              checked={selectionState}
+              disabled={!isRowSelectable()}
+              onClick={(event) => event.stopPropagation()}
+              onCheckedChange={(state) => {
+                // When clicking a partial checkbox, select all
+                if (selectionState === "partial" || state) {
+                  selectCurrentNavigationEntry();
+                } else {
+                  removeCurrentNavigationEntry();
+                }
+              }}
+            />
+          );
+        },
+        cell: ({ row }) => {
+          const selectionState = isRowSelected(row.original.id);
+
+          return (
+            <div className="flex h-full w-full items-center">
+              <Checkbox
+                key={`${row.original.id}-${selectionState}`}
+                size="xs"
+                checked={selectionState}
+                disabled={!isRowSelectable(row.original.id)}
+                onClick={(event) => event.stopPropagation()}
+                onCheckedChange={(state) => {
+                  // When clicking a partial checkbox, select all
+                  const item: NavigationHistoryEntryType = {
+                    type: "data_source",
+                    dataSourceView: row.original.dataSourceView,
+                  };
+                  if (selectionState === "partial" || state) {
+                    selectNode(item);
+                  } else {
+                    removeNode(item);
+                  }
+                }}
+              />
+            </div>
+          );
+        },
+        meta: {
+          sizeRatio: 5,
+        },
+      },
+      {
+        accessorKey: "title",
+        id: "name",
+        header: "Name",
+        cell: ({ row }) => (
+          <DataTable.CellContent icon={row.original.icon}>
+            <Hoverable>
+              {row.original.title} - {row.original.id}
+            </Hoverable>
+          </DataTable.CellContent>
+        ),
+        meta: {
+          sizeRatio: 70,
+        },
+      },
+    ],
+    [
+      isCurrentNavigationEntrySelected,
+      isRowSelectable,
+      isRowSelected,
+      removeCurrentNavigationEntry,
+      removeNode,
+      selectCurrentNavigationEntry,
+      selectNode,
+    ]
+  );
+
+  const rows: RowData[] = spaceDataSourceViews.map((dsv) => ({
+    id: dsv.dataSource.sId,
+    title: dsv.dataSource.name,
+    onClick: () => setDataSourceViewEntry(dsv),
+    dataSourceView: dsv,
+    // TODO: Put icon
+  }));
+
+  if (isSpaceDataSourceViewsLoading) {
+    return (
+      <div className="flex justify-center p-4">
+        <Spinner size="md" />
+      </div>
+    );
+  }
+
+  return (
+    <ScrollableDataTable
+      data={rows}
+      columns={columns}
+      maxHeight="max-h-[600px]"
+      getRowId={(row) => row.id}
+    />
+  );
+}

--- a/front/components/data_source_view/DataSourceViewTable.tsx
+++ b/front/components/data_source_view/DataSourceViewTable.tsx
@@ -112,9 +112,7 @@ export function DataSourceViewTable() {
         header: "Name",
         cell: ({ row }) => (
           <DataTable.CellContent icon={row.original.icon}>
-            <Hoverable>
-              {row.original.title} - {row.original.id}
-            </Hoverable>
+            <Hoverable>{row.original.title}</Hoverable>
           </DataTable.CellContent>
         ),
         meta: {
@@ -134,7 +132,7 @@ export function DataSourceViewTable() {
   );
 
   const rows: RowData[] = spaceDataSourceViews.map((dsv) => ({
-    id: dsv.dataSource.sId,
+    id: dsv.sId,
     title: dsv.dataSource.name,
     onClick: () => setDataSourceViewEntry(dsv),
     dataSourceView: dsv,

--- a/front/components/data_source_view/DataSourceViewTable.tsx
+++ b/front/components/data_source_view/DataSourceViewTable.tsx
@@ -1,6 +1,7 @@
 import {
   Checkbox,
   DataTable,
+  FolderIcon,
   Hoverable,
   ScrollableDataTable,
   Spinner,
@@ -15,6 +16,7 @@ import {
   findCategoryFromNavigationHistory,
   findSpaceFromNavigationHistory,
 } from "@app/components/data_source_view/context/utils";
+import { CATEGORY_DETAILS } from "@app/lib/spaces";
 import { useSpaceDataSourceViews } from "@app/lib/swr/spaces";
 import type { DataSourceViewType } from "@app/types";
 
@@ -136,7 +138,9 @@ export function DataSourceViewTable() {
     title: dsv.dataSource.name,
     onClick: () => setDataSourceViewEntry(dsv),
     dataSourceView: dsv,
-    // TODO: Put icon
+    icon: dsv.dataSource.connectorProvider
+      ? CATEGORY_DETAILS[dsv.category].icon
+      : FolderIcon,
   }));
 
   if (isSpaceDataSourceViewsLoading) {

--- a/front/components/data_source_view/DataSourceViewTable.tsx
+++ b/front/components/data_source_view/DataSourceViewTable.tsx
@@ -16,6 +16,8 @@ import {
   findCategoryFromNavigationHistory,
   findSpaceFromNavigationHistory,
 } from "@app/components/data_source_view/context/utils";
+import { useTheme } from "@app/components/sparkle/ThemeContext";
+import { getConnectorProviderLogoWithFallback } from "@app/lib/connector_providers";
 import { CATEGORY_DETAILS } from "@app/lib/spaces";
 import { useSpaceDataSourceViews } from "@app/lib/swr/spaces";
 import type { DataSourceViewType } from "@app/types";
@@ -42,6 +44,7 @@ export function DataSourceViewTable() {
     setDataSourceViewEntry,
   } = useDataSourceBuilderContext();
   const space = findSpaceFromNavigationHistory(navigationHistory);
+  const { isDark } = useTheme();
 
   const selectedCategory = findCategoryFromNavigationHistory(navigationHistory);
   const { spaceDataSourceViews, isSpaceDataSourceViewsLoading } =
@@ -139,7 +142,11 @@ export function DataSourceViewTable() {
     onClick: () => setDataSourceViewEntry(dsv),
     dataSourceView: dsv,
     icon: dsv.dataSource.connectorProvider
-      ? CATEGORY_DETAILS[dsv.category].icon
+      ? getConnectorProviderLogoWithFallback({
+          provider: dsv.dataSource.connectorProvider,
+          isDark,
+          fallback: CATEGORY_DETAILS[dsv.category].icon,
+        })
       : FolderIcon,
   }));
 

--- a/front/components/data_source_view/context/DataSourceBuilderContext.tsx
+++ b/front/components/data_source_view/context/DataSourceBuilderContext.tsx
@@ -47,7 +47,6 @@ import type {
 import {
   addNodeToTree,
   computeNavigationPath,
-  computeNavigationReadablePath,
   getLastNavigationHistoryEntryId,
   isNodeSelected,
   navigationHistoryEntryTitle,
@@ -233,7 +232,7 @@ export function DataSourceBuilderProvider({
         addNodeToTree(field.value, {
           path: nodePath,
           name: navigationHistoryEntryTitle(entry),
-          readablePath: computeNavigationReadablePath(state.navigationHistory),
+          node: entry.type === "node" ? entry.node : undefined,
         })
       );
     },
@@ -243,9 +242,9 @@ export function DataSourceBuilderProvider({
   const selectCurrentNavigationEntry: DataSourceBuilderState["selectCurrentNavigationEntry"] =
     useCallback(() => {
       const nodePath = computeNavigationPath(state.navigationHistory);
-      const lastEntryId =
+      const lastEntry =
         state.navigationHistory[state.navigationHistory.length - 1];
-      const lastEntry = navigationHistoryEntryTitle(lastEntryId);
+      const lastEntryTitle = navigationHistoryEntryTitle(lastEntry);
 
       const isFirstNode =
         state.navigationHistory[state.navigationHistory.length - 2].type !==
@@ -254,10 +253,11 @@ export function DataSourceBuilderProvider({
       field.onChange(
         addNodeToTree(field.value, {
           path: nodePath,
-          name: lastEntry,
-          readablePath: computeNavigationReadablePath(
-            state.navigationHistory.slice(0, isFirstNode ? -2 : -1)
-          ),
+          name: lastEntryTitle,
+          node:
+            !isFirstNode && lastEntry.type === "node"
+              ? lastEntry.node
+              : undefined,
         })
       );
     }, [field, state.navigationHistory]);
@@ -272,7 +272,6 @@ export function DataSourceBuilderProvider({
         removeNodeFromTree(field.value, {
           path: nodePath,
           name,
-          readablePath: computeNavigationReadablePath(state.navigationHistory),
         })
       );
     },
@@ -286,13 +285,10 @@ export function DataSourceBuilderProvider({
           removeNodeFromTree(field.value, {
             path: path.split("."),
             name,
-            readablePath: computeNavigationReadablePath(
-              state.navigationHistory
-            ),
           })
         );
       },
-      [field, state.navigationHistory]
+      [field]
     );
 
   const removeCurrentNavigationEntry: DataSourceBuilderState["removeCurrentNavigationEntry"] =
@@ -305,7 +301,6 @@ export function DataSourceBuilderProvider({
         removeNodeFromTree(field.value, {
           path: nodePath,
           name: lastEntry,
-          readablePath: computeNavigationReadablePath(state.navigationHistory),
         })
       );
     }, [field, state.navigationHistory]);

--- a/front/components/data_source_view/context/DataSourceBuilderContext.tsx
+++ b/front/components/data_source_view/context/DataSourceBuilderContext.tsx
@@ -308,9 +308,9 @@ export function DataSourceBuilderProvider({
 
   const isRowSelected: DataSourceBuilderState["isRowSelected"] = useCallback(
     (rowId) => {
-      const nodePath = computeNavigationPath(state.navigationHistory);
-      nodePath.push(rowId);
-      console.log({ value: field.value, nodePath });
+      const nodePath = computeNavigationPath(state.navigationHistory).concat(
+        rowId
+      );
       return isNodeSelected(field.value, nodePath);
     },
     [field.value, state.navigationHistory]

--- a/front/components/data_source_view/context/DataSourceBuilderContext.tsx
+++ b/front/components/data_source_view/context/DataSourceBuilderContext.tsx
@@ -38,9 +38,9 @@ import {
   useReducer,
 } from "react";
 import type { Control } from "react-hook-form";
-import { useController } from "react-hook-form";
 
 import type { CapabilityFormData } from "@app/components/agent_builder/types";
+import { useSourcesFormController } from "@app/components/agent_builder/utils";
 import type {
   DataSourceBuilderTreeType,
   NavigationHistoryEntryType,
@@ -60,7 +60,6 @@ import type {
 import { assertNever } from "@app/types";
 
 type StateType = {
-  spaces: SpaceType[];
   sources: DataSourceBuilderTreeType;
   /**
    * Shape is `[root, space, category, ...node]`
@@ -210,9 +209,8 @@ export function DataSourceBuilderProvider({
   children: React.ReactNode;
   control: Control<CapabilityFormData>;
 }) {
-  const { field } = useController({ control, name: "sources" });
+  const { field } = useSourcesFormController({ control });
   const [state, dispatch] = useReducer(dataSourceBuilderReducer, {
-    spaces,
     sources: {
       in: [],
       notIn: [],
@@ -266,7 +264,7 @@ export function DataSourceBuilderProvider({
 
   const nonCompanySpacesSelected = useMemo(() => {
     return new Set(
-      state.spaces
+      spaces
         .filter(
           (space) =>
             space.kind !== "global" &&
@@ -274,7 +272,7 @@ export function DataSourceBuilderProvider({
         )
         .map((s) => s.sId)
     );
-  }, [state.spaces, state.sources]);
+  }, [spaces, state.sources]);
 
   const isRowSelectable: DataSourceBuilderState["isRowSelectable"] =
     useCallback(

--- a/front/components/data_source_view/context/DataSourceBuilderContext.tsx
+++ b/front/components/data_source_view/context/DataSourceBuilderContext.tsx
@@ -88,6 +88,11 @@ type DataSourceBuilderState = StateType & {
   removeNode: (rowId: string) => void;
 
   /**
+   * Remove a specific row, but need to include its full path.
+   */
+  removeNodeWithPath: (path: string) => void;
+
+  /**
    * Remove the current navigationHistory entry
    * Used for the select all of the current page in the table
    */
@@ -243,6 +248,14 @@ export function DataSourceBuilderProvider({
     [field, state.navigationHistory]
   );
 
+  const removeNodeWithPath: DataSourceBuilderState["removeNodeWithPath"] =
+    useCallback(
+      (path) => {
+        field.onChange(removeNodeFromTree(field.value, path.split(".")));
+      },
+      [field]
+    );
+
   const removeCurrentNavigationEntry: DataSourceBuilderState["removeCurrentNavigationEntry"] =
     useCallback(() => {
       const nodePath = computeNavigationPath(state.navigationHistory);
@@ -331,6 +344,7 @@ export function DataSourceBuilderProvider({
       selectNode,
       selectCurrentNavigationEntry,
       removeNode,
+      removeNodeWithPath,
       removeCurrentNavigationEntry,
       isRowSelected,
       isRowSelectable,
@@ -349,6 +363,7 @@ export function DataSourceBuilderProvider({
       navigateTo,
       removeCurrentNavigationEntry,
       removeNode,
+      removeNodeWithPath,
       selectCurrentNavigationEntry,
       selectNode,
       setCategoryEntry,

--- a/front/components/data_source_view/context/DataSourceBuilderContext.tsx
+++ b/front/components/data_source_view/context/DataSourceBuilderContext.tsx
@@ -40,7 +40,6 @@ import {
 
 import { useSourcesFormController } from "@app/components/agent_builder/utils";
 import type {
-  DataSourceBuilderTreeType,
   NavigationHistoryEntryType,
   NodeSelectionState,
 } from "@app/components/data_source_view/context/types";
@@ -60,7 +59,6 @@ import type {
 import { assertNever } from "@app/types";
 
 type StateType = {
-  sources: DataSourceBuilderTreeType;
   /**
    * Shape is `[root, space, category, ...node]`
    * so in this case we can use index to update specific values
@@ -214,10 +212,6 @@ export function DataSourceBuilderProvider({
 }) {
   const { field } = useSourcesFormController();
   const [state, dispatch] = useReducer(dataSourceBuilderReducer, {
-    sources: {
-      in: [],
-      notIn: [],
-    },
     navigationHistory: [{ type: "root" }],
   });
 
@@ -320,11 +314,11 @@ export function DataSourceBuilderProvider({
         .filter(
           (space) =>
             space.kind !== "global" &&
-            isNodeSelected(state.sources, ["root", space.sId])
+            isNodeSelected(field.value, ["root", space.sId])
         )
         .map((s) => s.sId)
     );
-  }, [spaces, state.sources]);
+  }, [field.value, spaces]);
 
   const isRowSelectable: DataSourceBuilderState["isRowSelectable"] =
     useCallback(

--- a/front/components/data_source_view/context/DataSourceBuilderContext.tsx
+++ b/front/components/data_source_view/context/DataSourceBuilderContext.tsx
@@ -37,9 +37,7 @@ import {
   useMemo,
   useReducer,
 } from "react";
-import type { Control } from "react-hook-form";
 
-import type { CapabilityFormData } from "@app/components/agent_builder/types";
 import { useSourcesFormController } from "@app/components/agent_builder/utils";
 import type {
   DataSourceBuilderTreeType,
@@ -203,13 +201,11 @@ function dataSourceBuilderReducer(
 export function DataSourceBuilderProvider({
   spaces,
   children,
-  control,
 }: {
   spaces: SpaceType[];
   children: React.ReactNode;
-  control: Control<CapabilityFormData>;
 }) {
-  const { field } = useSourcesFormController({ control });
+  const { field } = useSourcesFormController();
   const [state, dispatch] = useReducer(dataSourceBuilderReducer, {
     sources: {
       in: [],

--- a/front/components/data_source_view/context/types.ts
+++ b/front/components/data_source_view/context/types.ts
@@ -3,14 +3,33 @@ import { z } from "zod";
 import type {
   DataSourceViewCategoryWithoutApps,
   DataSourceViewContentNode,
+  DataSourceViewType,
   SpaceType,
 } from "@app/types";
 
-const dataSourceBuilderTreeItemType = z.object({
-  name: z.string(),
-  path: z.string(),
-  node: z.custom<DataSourceViewContentNode>().optional(),
-});
+const navigationHistoryEntry = z.discriminatedUnion("type", [
+  z.object({ type: z.literal("root") }),
+  z.object({ type: z.literal("space"), space: z.custom<SpaceType>() }),
+  z.object({
+    type: z.literal("category"),
+    category: z.custom<DataSourceViewCategoryWithoutApps>(),
+  }),
+  z.object({
+    type: z.literal("data_source"),
+    dataSourceView: z.custom<DataSourceViewType>(),
+  }),
+  z.object({
+    type: z.literal("node"),
+    node: z.custom<DataSourceViewContentNode>(),
+  }),
+]);
+
+const dataSourceBuilderTreeItemType = z
+  .object({
+    name: z.string(),
+    path: z.string(),
+  })
+  .and(navigationHistoryEntry);
 export type DataSourceBuilderTreeItemType = z.infer<
   typeof dataSourceBuilderTreeItemType
 >;
@@ -23,10 +42,11 @@ export type DataSourceBuilderTreeType = z.infer<
   typeof dataSourceBuilderTreeType
 >;
 
-export type NavigationHistoryEntryType =
-  | { type: "root" }
-  | { type: "space"; space: SpaceType }
-  | { type: "category"; category: DataSourceViewCategoryWithoutApps }
-  | { type: "node"; node: DataSourceViewContentNode };
+export type NavigationHistoryEntryType = z.infer<typeof navigationHistoryEntry>;
+// | { type: "root" }
+// | { type: "space"; space: SpaceType }
+// | { type: "category"; category: DataSourceViewCategoryWithoutApps }
+// | { type: "data_source"; dataSourceView: DataSourceViewType }
+// | { type: "node"; node: DataSourceViewContentNode };
 
 export type NodeSelectionState = boolean | "partial";

--- a/front/components/data_source_view/context/types.ts
+++ b/front/components/data_source_view/context/types.ts
@@ -6,9 +6,18 @@ import type {
   SpaceType,
 } from "@app/types";
 
+const dataSourceBuilderTreeItemType = z.object({
+  name: z.string(),
+  path: z.string(),
+  readablePath: z.string(),
+});
+export type DataSourceBuilderTreeItemType = z.infer<
+  typeof dataSourceBuilderTreeItemType
+>;
+
 export const dataSourceBuilderTreeType = z.object({
-  in: z.string().array(),
-  notIn: z.string().array(),
+  in: dataSourceBuilderTreeItemType.array(),
+  notIn: dataSourceBuilderTreeItemType.array(),
 });
 export type DataSourceBuilderTreeType = z.infer<
   typeof dataSourceBuilderTreeType

--- a/front/components/data_source_view/context/types.ts
+++ b/front/components/data_source_view/context/types.ts
@@ -43,10 +43,5 @@ export type DataSourceBuilderTreeType = z.infer<
 >;
 
 export type NavigationHistoryEntryType = z.infer<typeof navigationHistoryEntry>;
-// | { type: "root" }
-// | { type: "space"; space: SpaceType }
-// | { type: "category"; category: DataSourceViewCategoryWithoutApps }
-// | { type: "data_source"; dataSourceView: DataSourceViewType }
-// | { type: "node"; node: DataSourceViewContentNode };
 
 export type NodeSelectionState = boolean | "partial";

--- a/front/components/data_source_view/context/types.ts
+++ b/front/components/data_source_view/context/types.ts
@@ -9,7 +9,7 @@ import type {
 const dataSourceBuilderTreeItemType = z.object({
   name: z.string(),
   path: z.string(),
-  readablePath: z.string(),
+  node: z.custom<DataSourceViewContentNode>().optional(),
 });
 export type DataSourceBuilderTreeItemType = z.infer<
   typeof dataSourceBuilderTreeItemType

--- a/front/components/data_source_view/context/utils.test.ts
+++ b/front/components/data_source_view/context/utils.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 
+import type { DataSourceBuilderTreeItemType } from "@app/components/data_source_view/context/types";
 import {
   addNodeToTree,
   isNodeSelected,
@@ -7,9 +8,13 @@ import {
 } from "@app/components/data_source_view/context/utils";
 
 // Helper function to create tree items
-const createTreeItem = (path: string, name?: string) => ({
+const createTreeItem = (
+  path: string,
+  name?: string
+): DataSourceBuilderTreeItemType => ({
   path,
   name: name || path.split("/").pop() || path,
+  type: "root",
 });
 
 describe("DataSourceBuilder utilities", () => {
@@ -17,10 +22,10 @@ describe("DataSourceBuilder utilities", () => {
     it("should add a node to an empty tree", () => {
       const result = addNodeToTree(
         { in: [], notIn: [] },
-        { path: ["root", "a"], name: "a" }
+        { path: "root/a", name: "a", type: "root" }
       );
       expect(result).toEqual({
-        in: [{ path: "root/a", name: "a" }],
+        in: [{ path: "root/a", name: "a", type: "root" }],
         notIn: [],
       });
     });
@@ -31,8 +36,9 @@ describe("DataSourceBuilder utilities", () => {
         notIn: [createTreeItem("root/a")],
       };
       const result = addNodeToTree(tree, {
-        path: ["root", "a"],
+        path: "root/a",
         name: "a",
+        type: "root",
       });
       expect(result).toEqual({
         in: [],
@@ -46,8 +52,9 @@ describe("DataSourceBuilder utilities", () => {
         notIn: [],
       };
       const result = addNodeToTree(tree, {
-        path: ["root", "a"],
+        path: "root/a",
         name: "a",
+        type: "root",
       });
       expect(result).toEqual({
         in: [createTreeItem("root/a")],
@@ -61,8 +68,9 @@ describe("DataSourceBuilder utilities", () => {
         notIn: [],
       };
       const result = addNodeToTree(tree, {
-        path: ["root", "a", "b"],
+        path: "root/a/b",
         name: "b",
+        type: "root",
       });
       expect(result).toEqual({
         in: [createTreeItem("root")],
@@ -77,8 +85,9 @@ describe("DataSourceBuilder utilities", () => {
       };
 
       const result = addNodeToTree(tree, {
-        path: ["a", "b", "c"],
+        path: "a/b/c",
         name: "c",
+        type: "root",
       });
       expect(result).toEqual({
         in: [createTreeItem("a/b/c", "c")],
@@ -93,8 +102,9 @@ describe("DataSourceBuilder utilities", () => {
       };
 
       const result = addNodeToTree(tree, {
-        path: ["root", "a", "b", "c"],
+        path: "root/a/b/c",
         name: "c",
+        type: "root",
       });
       expect(result).toEqual({
         in: [createTreeItem("root/a")],
@@ -108,8 +118,9 @@ describe("DataSourceBuilder utilities", () => {
         notIn: [],
       };
       const result = addNodeToTree(tree, {
-        path: ["root", "a", "b", "c", "d"],
+        path: "root/a/b/c/d",
         name: "d",
+        type: "root",
       });
       expect(result).toEqual({
         in: [createTreeItem("root")],
@@ -123,8 +134,9 @@ describe("DataSourceBuilder utilities", () => {
         notIn: [],
       };
       const result = addNodeToTree(tree, {
-        path: ["root", "b"],
+        path: "root/b",
         name: "b",
+        type: "root",
       });
       expect(result).toEqual({
         in: [createTreeItem("root/a"), createTreeItem("root/b", "b")],
@@ -138,8 +150,9 @@ describe("DataSourceBuilder utilities", () => {
         notIn: [createTreeItem("other")],
       };
       const result = addNodeToTree(tree, {
-        path: ["root"],
+        path: "root",
         name: "root",
+        type: "root",
       });
       expect(result).toEqual({
         in: [createTreeItem("root", "root")],
@@ -157,8 +170,9 @@ describe("DataSourceBuilder utilities", () => {
         ],
       };
       const result = addNodeToTree(tree, {
-        path: ["root", "a"],
+        path: "root/a",
         name: "a",
+        type: "root",
       });
       expect(result).toEqual({
         in: [createTreeItem("root/a", "a")],
@@ -172,8 +186,9 @@ describe("DataSourceBuilder utilities", () => {
         notIn: [createTreeItem("root/a"), createTreeItem("root/a/x")],
       };
       const result = addNodeToTree(tree, {
-        path: ["root", "a", "y"],
+        path: "root/a/y",
         name: "y",
+        type: "root",
       });
       expect(result).toEqual({
         in: [createTreeItem("root/b"), createTreeItem("root/a/y", "y")],
@@ -187,8 +202,9 @@ describe("DataSourceBuilder utilities", () => {
         notIn: [createTreeItem("root/b"), createTreeItem("root/d/x")],
       };
       const result = addNodeToTree(tree, {
-        path: ["root", "d"],
+        path: "root/d",
         name: "d",
+        type: "root",
       });
       expect(result).toEqual({
         in: [
@@ -206,8 +222,9 @@ describe("DataSourceBuilder utilities", () => {
         notIn: [createTreeItem("a")],
       };
       const result = addNodeToTree(tree, {
-        path: ["a"],
+        path: "a",
         name: "a",
+        type: "root",
       });
       expect(result).toEqual({
         in: [],
@@ -221,8 +238,9 @@ describe("DataSourceBuilder utilities", () => {
         notIn: [createTreeItem("temp/cache"), createTreeItem("logs/old")],
       };
       const result = addNodeToTree(tree, {
-        path: ["src", "main"],
+        path: "src/main",
         name: "main",
+        type: "root",
       });
       expect(result).toEqual({
         in: [createTreeItem("docs"), createTreeItem("src/main", "main")],
@@ -238,8 +256,9 @@ describe("DataSourceBuilder utilities", () => {
         notIn: [],
       };
       const result = removeNodeFromTree(tree, {
-        path: ["root", "a"],
+        path: "root/a",
         name: "a",
+        type: "root",
       });
       expect(result).toEqual({
         in: [],
@@ -253,8 +272,9 @@ describe("DataSourceBuilder utilities", () => {
         notIn: [],
       };
       const result = removeNodeFromTree(tree, {
-        path: ["root", "a"],
+        path: "root/a",
         name: "a",
+        type: "root",
       });
       expect(result).toEqual({
         in: [],
@@ -268,8 +288,9 @@ describe("DataSourceBuilder utilities", () => {
         notIn: [createTreeItem("root/a")],
       };
       const result = removeNodeFromTree(tree, {
-        path: ["root", "a"],
+        path: "root/a",
         name: "a",
+        type: "root",
       });
       expect(result).toEqual({
         in: [],
@@ -283,8 +304,9 @@ describe("DataSourceBuilder utilities", () => {
         notIn: [],
       };
       const result = removeNodeFromTree(tree, {
-        path: ["root", "a", "b", "c"],
+        path: "root/a/b/c",
         name: "c",
+        type: "root",
       });
       expect(result).toEqual({
         in: [createTreeItem("root/a/b")],
@@ -302,8 +324,9 @@ describe("DataSourceBuilder utilities", () => {
         notIn: [],
       };
       const result = removeNodeFromTree(tree, {
-        path: ["root", "a"],
+        path: "root/a",
         name: "a",
+        type: "root",
       });
       expect(result).toEqual({
         in: [createTreeItem("root/b")],
@@ -321,8 +344,9 @@ describe("DataSourceBuilder utilities", () => {
         notIn: [],
       };
       const result = removeNodeFromTree(tree, {
-        path: ["root", "a"],
+        path: "root/a",
         name: "a",
+        type: "root",
       });
       expect(result).toEqual({
         in: [
@@ -341,8 +365,9 @@ describe("DataSourceBuilder utilities", () => {
       };
 
       const result = removeNodeFromTree(tree, {
-        path: ["root", "b"],
+        path: "root/b",
         name: "b",
+        type: "root",
       });
       expect(result).toEqual({
         in: [createTreeItem("root/a")],
@@ -356,8 +381,9 @@ describe("DataSourceBuilder utilities", () => {
         notIn: [],
       };
       const result = removeNodeFromTree(tree, {
-        path: ["root", "a", "b"],
+        path: "root/a/b",
         name: "b",
+        type: "root",
       });
       expect(result).toEqual({
         in: [],
@@ -376,8 +402,9 @@ describe("DataSourceBuilder utilities", () => {
         notIn: [],
       };
       const result = removeNodeFromTree(tree, {
-        path: ["root", "a"],
+        path: "root/a",
         name: "a",
+        type: "root",
       });
       expect(result).toEqual({
         in: [createTreeItem("root/b")],
@@ -395,8 +422,9 @@ describe("DataSourceBuilder utilities", () => {
         ],
       };
       const result = removeNodeFromTree(tree, {
-        path: ["root", "a"],
+        path: "root/a",
         name: "a",
+        type: "root",
       });
       expect(result).toEqual({
         in: [createTreeItem("root")],
@@ -414,8 +442,9 @@ describe("DataSourceBuilder utilities", () => {
         notIn: [createTreeItem("root/excluded")],
       };
       const result = removeNodeFromTree(tree, {
-        path: ["root"],
+        path: "root",
         name: "root",
+        type: "root",
       });
       expect(result).toEqual({
         in: [createTreeItem("other/x")],
@@ -435,8 +464,9 @@ describe("DataSourceBuilder utilities", () => {
         ],
       };
       const result = removeNodeFromTree(tree, {
-        path: ["root", "a"],
+        path: "root/a",
         name: "a",
+        type: "root",
       });
       expect(result).toEqual({
         in: [],
@@ -454,8 +484,9 @@ describe("DataSourceBuilder utilities", () => {
         ],
       };
       const result = removeNodeFromTree(tree, {
-        path: ["other", "branch"],
+        path: "other/branch",
         name: "branch",
+        type: "root",
       });
       expect(result).toEqual({
         in: [createTreeItem("root")],
@@ -478,8 +509,9 @@ describe("DataSourceBuilder utilities", () => {
         ],
       };
       const result = removeNodeFromTree(tree, {
-        path: ["root", "a", "x"],
+        path: "root/a/x",
         name: "x",
+        type: "root",
       });
       expect(result).toEqual({
         in: [createTreeItem("root")],
@@ -497,8 +529,9 @@ describe("DataSourceBuilder utilities", () => {
         notIn: [createTreeItem("root/a")],
       };
       const result = removeNodeFromTree(tree, {
-        path: ["root", "a", "b"],
+        path: "root/a/b",
         name: "b",
+        type: "root",
       });
       expect(result).toEqual({
         in: [createTreeItem("root")],

--- a/front/components/data_source_view/context/utils.test.ts
+++ b/front/components/data_source_view/context/utils.test.ts
@@ -9,7 +9,7 @@ import {
 // Helper function to create tree items
 const createTreeItem = (path: string, name?: string) => ({
   path,
-  name: name || path.split(".").pop() || path,
+  name: name || path.split("/").pop() || path,
 });
 
 describe("DataSourceBuilder utilities", () => {
@@ -20,7 +20,7 @@ describe("DataSourceBuilder utilities", () => {
         { path: ["root", "a"], name: "a" }
       );
       expect(result).toEqual({
-        in: [{ path: "root.a", name: "a" }],
+        in: [{ path: "root/a", name: "a" }],
         notIn: [],
       });
     });
@@ -28,7 +28,7 @@ describe("DataSourceBuilder utilities", () => {
     it("should remove node from notIn when adding it", () => {
       const tree = {
         in: [],
-        notIn: [createTreeItem("root.a")],
+        notIn: [createTreeItem("root/a")],
       };
       const result = addNodeToTree(tree, {
         path: ["root", "a"],
@@ -42,7 +42,7 @@ describe("DataSourceBuilder utilities", () => {
 
     it("should not duplicate paths in in array", () => {
       const tree = {
-        in: [createTreeItem("root.a")],
+        in: [createTreeItem("root/a")],
         notIn: [],
       };
       const result = addNodeToTree(tree, {
@@ -50,7 +50,7 @@ describe("DataSourceBuilder utilities", () => {
         name: "a",
       });
       expect(result).toEqual({
-        in: [createTreeItem("root.a")],
+        in: [createTreeItem("root/a")],
         notIn: [],
       });
     });
@@ -81,15 +81,15 @@ describe("DataSourceBuilder utilities", () => {
         name: "c",
       });
       expect(result).toEqual({
-        in: [createTreeItem("a.b.c", "c")],
+        in: [createTreeItem("a/b/c", "c")],
         notIn: [createTreeItem("a")],
       });
     });
 
     it("should add a nested path that is notIn, when its parent is in", () => {
       const tree = {
-        in: [createTreeItem("root.a")],
-        notIn: [createTreeItem("root.a.b.c")],
+        in: [createTreeItem("root/a")],
+        notIn: [createTreeItem("root/a/b/c")],
       };
 
       const result = addNodeToTree(tree, {
@@ -97,7 +97,7 @@ describe("DataSourceBuilder utilities", () => {
         name: "c",
       });
       expect(result).toEqual({
-        in: [createTreeItem("root.a")],
+        in: [createTreeItem("root/a")],
         notIn: [],
       });
     });
@@ -119,7 +119,7 @@ describe("DataSourceBuilder utilities", () => {
 
     it("should add sibling paths independently", () => {
       const tree = {
-        in: [createTreeItem("root.a")],
+        in: [createTreeItem("root/a")],
         notIn: [],
       };
       const result = addNodeToTree(tree, {
@@ -127,7 +127,7 @@ describe("DataSourceBuilder utilities", () => {
         name: "b",
       });
       expect(result).toEqual({
-        in: [createTreeItem("root.a"), createTreeItem("root.b", "b")],
+        in: [createTreeItem("root/a"), createTreeItem("root/b", "b")],
         notIn: [],
       });
     });
@@ -151,9 +151,9 @@ describe("DataSourceBuilder utilities", () => {
       const tree = {
         in: [],
         notIn: [
-          createTreeItem("root.a.b"),
-          createTreeItem("root.a.c"),
-          createTreeItem("root.a.d"),
+          createTreeItem("root/a/b"),
+          createTreeItem("root/a/c"),
+          createTreeItem("root/a/d"),
         ],
       };
       const result = addNodeToTree(tree, {
@@ -161,30 +161,30 @@ describe("DataSourceBuilder utilities", () => {
         name: "a",
       });
       expect(result).toEqual({
-        in: [createTreeItem("root.a", "a")],
+        in: [createTreeItem("root/a", "a")],
         notIn: [],
       });
     });
 
     it("should handle adding when parent is in notIn but has excluded children", () => {
       const tree = {
-        in: [createTreeItem("root.b")],
-        notIn: [createTreeItem("root.a"), createTreeItem("root.a.x")],
+        in: [createTreeItem("root/b")],
+        notIn: [createTreeItem("root/a"), createTreeItem("root/a/x")],
       };
       const result = addNodeToTree(tree, {
         path: ["root", "a", "y"],
         name: "y",
       });
       expect(result).toEqual({
-        in: [createTreeItem("root.b"), createTreeItem("root.a.y", "y")],
-        notIn: [createTreeItem("root.a"), createTreeItem("root.a.x")],
+        in: [createTreeItem("root/b"), createTreeItem("root/a/y", "y")],
+        notIn: [createTreeItem("root/a"), createTreeItem("root/a/x")],
       });
     });
 
     it("should handle complex mixed scenario with multiple branches", () => {
       const tree = {
-        in: [createTreeItem("root.a"), createTreeItem("root.c")],
-        notIn: [createTreeItem("root.b"), createTreeItem("root.d.x")],
+        in: [createTreeItem("root/a"), createTreeItem("root/c")],
+        notIn: [createTreeItem("root/b"), createTreeItem("root/d/x")],
       };
       const result = addNodeToTree(tree, {
         path: ["root", "d"],
@@ -192,11 +192,11 @@ describe("DataSourceBuilder utilities", () => {
       });
       expect(result).toEqual({
         in: [
-          createTreeItem("root.a"),
-          createTreeItem("root.c"),
-          createTreeItem("root.d", "d"),
+          createTreeItem("root/a"),
+          createTreeItem("root/c"),
+          createTreeItem("root/d", "d"),
         ],
-        notIn: [createTreeItem("root.b")],
+        notIn: [createTreeItem("root/b")],
       });
     });
 
@@ -218,15 +218,15 @@ describe("DataSourceBuilder utilities", () => {
     it("should preserve unrelated exclusions when adding", () => {
       const tree = {
         in: [createTreeItem("docs")],
-        notIn: [createTreeItem("temp.cache"), createTreeItem("logs.old")],
+        notIn: [createTreeItem("temp/cache"), createTreeItem("logs/old")],
       };
       const result = addNodeToTree(tree, {
         path: ["src", "main"],
         name: "main",
       });
       expect(result).toEqual({
-        in: [createTreeItem("docs"), createTreeItem("src.main", "main")],
-        notIn: [createTreeItem("temp.cache"), createTreeItem("logs.old")],
+        in: [createTreeItem("docs"), createTreeItem("src/main", "main")],
+        notIn: [createTreeItem("temp/cache"), createTreeItem("logs/old")],
       });
     });
   });
@@ -249,7 +249,7 @@ describe("DataSourceBuilder utilities", () => {
 
     it("should remove node from in when excluding it", () => {
       const tree = {
-        in: [createTreeItem("root.a")],
+        in: [createTreeItem("root/a")],
         notIn: [],
       };
       const result = removeNodeFromTree(tree, {
@@ -265,7 +265,7 @@ describe("DataSourceBuilder utilities", () => {
     it("should not duplicate paths in notIn array", () => {
       const tree = {
         in: [],
-        notIn: [createTreeItem("root.a")],
+        notIn: [createTreeItem("root/a")],
       };
       const result = removeNodeFromTree(tree, {
         path: ["root", "a"],
@@ -273,13 +273,13 @@ describe("DataSourceBuilder utilities", () => {
       });
       expect(result).toEqual({
         in: [],
-        notIn: [createTreeItem("root.a")],
+        notIn: [createTreeItem("root/a")],
       });
     });
 
     it("should handle removing nested paths", () => {
       const tree = {
-        in: [createTreeItem("root.a.b")],
+        in: [createTreeItem("root/a/b")],
         notIn: [],
       };
       const result = removeNodeFromTree(tree, {
@@ -287,17 +287,17 @@ describe("DataSourceBuilder utilities", () => {
         name: "c",
       });
       expect(result).toEqual({
-        in: [createTreeItem("root.a.b")],
-        notIn: [createTreeItem("root.a.b.c", "c")],
+        in: [createTreeItem("root/a/b")],
+        notIn: [createTreeItem("root/a/b/c", "c")],
       });
     });
 
     it("should remove child paths when removing parent", () => {
       const tree = {
         in: [
-          createTreeItem("root.a.b"),
-          createTreeItem("root.a.c"),
-          createTreeItem("root.b"),
+          createTreeItem("root/a/b"),
+          createTreeItem("root/a/c"),
+          createTreeItem("root/b"),
         ],
         notIn: [],
       };
@@ -306,7 +306,7 @@ describe("DataSourceBuilder utilities", () => {
         name: "a",
       });
       expect(result).toEqual({
-        in: [createTreeItem("root.b")],
+        in: [createTreeItem("root/b")],
         notIn: [],
       });
     });
@@ -315,8 +315,8 @@ describe("DataSourceBuilder utilities", () => {
       const tree = {
         in: [
           createTreeItem("root"),
-          createTreeItem("other.a.b"),
-          createTreeItem("root.x.y"),
+          createTreeItem("other/a/b"),
+          createTreeItem("root/x/y"),
         ],
         notIn: [],
       };
@@ -327,17 +327,17 @@ describe("DataSourceBuilder utilities", () => {
       expect(result).toEqual({
         in: [
           createTreeItem("root"),
-          createTreeItem("other.a.b"),
-          createTreeItem("root.x.y"),
+          createTreeItem("other/a/b"),
+          createTreeItem("root/x/y"),
         ],
-        notIn: [createTreeItem("root.a", "a")],
+        notIn: [createTreeItem("root/a", "a")],
       });
     });
 
     it("should remove child notIn", () => {
       const tree = {
-        in: [createTreeItem("root.a")],
-        notIn: [createTreeItem("root.b.c")],
+        in: [createTreeItem("root/a")],
+        notIn: [createTreeItem("root/b/c")],
       };
 
       const result = removeNodeFromTree(tree, {
@@ -345,14 +345,14 @@ describe("DataSourceBuilder utilities", () => {
         name: "b",
       });
       expect(result).toEqual({
-        in: [createTreeItem("root.a")],
-        notIn: [createTreeItem("root.b", "b")],
+        in: [createTreeItem("root/a")],
+        notIn: [createTreeItem("root/b", "b")],
       });
     });
 
     it("should handle removing deeply nested paths with multiple levels", () => {
       const tree = {
-        in: [createTreeItem("root.a.b.c.d.e")],
+        in: [createTreeItem("root/a/b/c/d/e")],
         notIn: [],
       };
       const result = removeNodeFromTree(tree, {
@@ -368,10 +368,10 @@ describe("DataSourceBuilder utilities", () => {
     it("should remove multiple siblings when removing their parent", () => {
       const tree = {
         in: [
-          createTreeItem("root.a.x"),
-          createTreeItem("root.a.y"),
-          createTreeItem("root.a.z"),
-          createTreeItem("root.b"),
+          createTreeItem("root/a/x"),
+          createTreeItem("root/a/y"),
+          createTreeItem("root/a/z"),
+          createTreeItem("root/b"),
         ],
         notIn: [],
       };
@@ -380,7 +380,7 @@ describe("DataSourceBuilder utilities", () => {
         name: "a",
       });
       expect(result).toEqual({
-        in: [createTreeItem("root.b")],
+        in: [createTreeItem("root/b")],
         notIn: [],
       });
     });
@@ -389,9 +389,9 @@ describe("DataSourceBuilder utilities", () => {
       const tree = {
         in: [createTreeItem("root")],
         notIn: [
-          createTreeItem("root.a.x"),
-          createTreeItem("root.b.y"),
-          createTreeItem("root.c"),
+          createTreeItem("root/a/x"),
+          createTreeItem("root/b/y"),
+          createTreeItem("root/c"),
         ],
       };
       const result = removeNodeFromTree(tree, {
@@ -401,24 +401,24 @@ describe("DataSourceBuilder utilities", () => {
       expect(result).toEqual({
         in: [createTreeItem("root")],
         notIn: [
-          createTreeItem("root.b.y"),
-          createTreeItem("root.c"),
-          createTreeItem("root.a", "a"),
+          createTreeItem("root/b/y"),
+          createTreeItem("root/c"),
+          createTreeItem("root/a", "a"),
         ],
       });
     });
 
     it("should handle removing root path with many children", () => {
       const tree = {
-        in: [createTreeItem("root"), createTreeItem("other.x")],
-        notIn: [createTreeItem("root.excluded")],
+        in: [createTreeItem("root"), createTreeItem("other/x")],
+        notIn: [createTreeItem("root/excluded")],
       };
       const result = removeNodeFromTree(tree, {
         path: ["root"],
         name: "root",
       });
       expect(result).toEqual({
-        in: [createTreeItem("other.x")],
+        in: [createTreeItem("other/x")],
         notIn: [],
       });
     });
@@ -426,12 +426,12 @@ describe("DataSourceBuilder utilities", () => {
     it("should handle removing when path has both included and excluded children", () => {
       const tree = {
         in: [
-          createTreeItem("root.a.included1"),
-          createTreeItem("root.a.included2"),
+          createTreeItem("root/a/included1"),
+          createTreeItem("root/a/included2"),
         ],
         notIn: [
-          createTreeItem("root.a.excluded1"),
-          createTreeItem("root.a.excluded2"),
+          createTreeItem("root/a/excluded1"),
+          createTreeItem("root/a/excluded2"),
         ],
       };
       const result = removeNodeFromTree(tree, {
@@ -440,17 +440,17 @@ describe("DataSourceBuilder utilities", () => {
       });
       expect(result).toEqual({
         in: [],
-        notIn: [createTreeItem("root.a", "a")],
+        notIn: [createTreeItem("root/a", "a")],
       });
     });
 
     it("should preserve complex exclusion hierarchy when removing unrelated path", () => {
       const tree = {
-        in: [createTreeItem("root"), createTreeItem("other.branch")],
+        in: [createTreeItem("root"), createTreeItem("other/branch")],
         notIn: [
-          createTreeItem("root.a.b.c"),
-          createTreeItem("root.x.y"),
-          createTreeItem("root.z"),
+          createTreeItem("root/a/b/c"),
+          createTreeItem("root/x/y"),
+          createTreeItem("root/z"),
         ],
       };
       const result = removeNodeFromTree(tree, {
@@ -460,9 +460,9 @@ describe("DataSourceBuilder utilities", () => {
       expect(result).toEqual({
         in: [createTreeItem("root")],
         notIn: [
-          createTreeItem("root.a.b.c"),
-          createTreeItem("root.x.y"),
-          createTreeItem("root.z"),
+          createTreeItem("root/a/b/c"),
+          createTreeItem("root/x/y"),
+          createTreeItem("root/z"),
         ],
       });
     });
@@ -471,10 +471,10 @@ describe("DataSourceBuilder utilities", () => {
       const tree = {
         in: [createTreeItem("root")],
         notIn: [
-          createTreeItem("root.a.x.1"),
-          createTreeItem("root.a.x.2"),
-          createTreeItem("root.a.y.1"),
-          createTreeItem("root.a.y.2"),
+          createTreeItem("root/a/x/1"),
+          createTreeItem("root/a/x/2"),
+          createTreeItem("root/a/y/1"),
+          createTreeItem("root/a/y/2"),
         ],
       };
       const result = removeNodeFromTree(tree, {
@@ -484,9 +484,9 @@ describe("DataSourceBuilder utilities", () => {
       expect(result).toEqual({
         in: [createTreeItem("root")],
         notIn: [
-          createTreeItem("root.a.y.1"),
-          createTreeItem("root.a.y.2"),
-          createTreeItem("root.a.x", "x"),
+          createTreeItem("root/a/y/1"),
+          createTreeItem("root/a/y/2"),
+          createTreeItem("root/a/x", "x"),
         ],
       });
     });
@@ -494,7 +494,7 @@ describe("DataSourceBuilder utilities", () => {
     it("should handle removing path that would create redundant exclusion", () => {
       const tree = {
         in: [createTreeItem("root")],
-        notIn: [createTreeItem("root.a")],
+        notIn: [createTreeItem("root/a")],
       };
       const result = removeNodeFromTree(tree, {
         path: ["root", "a", "b"],
@@ -502,7 +502,7 @@ describe("DataSourceBuilder utilities", () => {
       });
       expect(result).toEqual({
         in: [createTreeItem("root")],
-        notIn: [createTreeItem("root.a")],
+        notIn: [createTreeItem("root/a")],
       });
     });
   });
@@ -510,7 +510,7 @@ describe("DataSourceBuilder utilities", () => {
   describe("isNodeSelected", () => {
     it("should return true for explicitly included node", () => {
       const tree = {
-        in: [createTreeItem("root.a")],
+        in: [createTreeItem("root/a")],
         notIn: [],
       };
       expect(isNodeSelected(tree, ["root", "a"])).toBe(true);
@@ -519,7 +519,7 @@ describe("DataSourceBuilder utilities", () => {
     it("should return false for excluded node", () => {
       const tree = {
         in: [],
-        notIn: [createTreeItem("root.a")],
+        notIn: [createTreeItem("root/a")],
       };
       expect(isNodeSelected(tree, ["root", "a"])).toBe(false);
     });
@@ -543,7 +543,7 @@ describe("DataSourceBuilder utilities", () => {
 
     it("should handle partial path matches", () => {
       const tree = {
-        in: [createTreeItem("root.a")],
+        in: [createTreeItem("root/a")],
         notIn: [],
       };
       expect(isNodeSelected(tree, ["root", "a", "b"])).toBe(true);
@@ -553,7 +553,7 @@ describe("DataSourceBuilder utilities", () => {
     it("should prioritize notIn over in for exact matches", () => {
       const tree = {
         in: [createTreeItem("root")],
-        notIn: [createTreeItem("root.a")],
+        notIn: [createTreeItem("root/a")],
       };
       expect(isNodeSelected(tree, ["root", "a"])).toBe(false);
       expect(isNodeSelected(tree, ["root", "b"])).toBe(true);
@@ -561,7 +561,7 @@ describe("DataSourceBuilder utilities", () => {
 
     it("should handle deeply nested paths", () => {
       const tree = {
-        in: [createTreeItem("a.b.c")],
+        in: [createTreeItem("a/b/c")],
         notIn: [],
       };
       expect(isNodeSelected(tree, ["a", "b", "c"])).toBe(true);
@@ -571,7 +571,7 @@ describe("DataSourceBuilder utilities", () => {
     it("should handle complex inclusion/exclusion scenarios", () => {
       const tree = {
         in: [createTreeItem("root")],
-        notIn: [createTreeItem("root.a"), createTreeItem("root.b.c")],
+        notIn: [createTreeItem("root/a"), createTreeItem("root/b/c")],
       };
       expect(isNodeSelected(tree, ["root"])).toBe("partial");
       expect(isNodeSelected(tree, ["root", "a"])).toBe(false);
@@ -582,8 +582,8 @@ describe("DataSourceBuilder utilities", () => {
 
     it("should return 'partial' when parent has mixed children", () => {
       const tree = {
-        in: [createTreeItem("root.a"), createTreeItem("root.c")],
-        notIn: [createTreeItem("root.b")],
+        in: [createTreeItem("root/a"), createTreeItem("root/c")],
+        notIn: [createTreeItem("root/b")],
       };
       expect(isNodeSelected(tree, ["root"])).toBe("partial");
       expect(isNodeSelected(tree, ["root", "a"])).toBe(true);
@@ -594,7 +594,7 @@ describe("DataSourceBuilder utilities", () => {
     it("should return 'partial' when included parent has excluded children", () => {
       const tree = {
         in: [createTreeItem("root")],
-        notIn: [createTreeItem("root.a")],
+        notIn: [createTreeItem("root/a")],
       };
       expect(isNodeSelected(tree, ["root"])).toBe("partial");
       expect(isNodeSelected(tree, ["root", "a"])).toBe(false);
@@ -613,7 +613,7 @@ describe("DataSourceBuilder utilities", () => {
 
     it("should return 'partial' for parent with some included children", () => {
       const tree = {
-        in: [createTreeItem("root.a.b")],
+        in: [createTreeItem("root/a/b")],
         notIn: [],
       };
       expect(isNodeSelected(tree, ["root"])).toBe("partial");
@@ -624,7 +624,7 @@ describe("DataSourceBuilder utilities", () => {
 
     it("should return false for paths not matching any included pattern", () => {
       const tree = {
-        in: [createTreeItem("root.a")],
+        in: [createTreeItem("root/a")],
         notIn: [],
       };
       expect(isNodeSelected(tree, ["other"])).toBe(false);
@@ -643,7 +643,7 @@ describe("DataSourceBuilder utilities", () => {
     it("should handle tree with only exclusions", () => {
       const tree = {
         in: [],
-        notIn: [createTreeItem("root.a"), createTreeItem("docs.temp")],
+        notIn: [createTreeItem("root/a"), createTreeItem("docs/temp")],
       };
       expect(isNodeSelected(tree, ["root"])).toBe(false);
       expect(isNodeSelected(tree, ["root", "a"])).toBe(false);
@@ -669,7 +669,7 @@ describe("DataSourceBuilder utilities", () => {
     it("should handle deeply nested exclusions", () => {
       const tree = {
         in: [createTreeItem("root")],
-        notIn: [createTreeItem("root.a.b.c.d.e")],
+        notIn: [createTreeItem("root/a/b/c/d/e")],
       };
       expect(isNodeSelected(tree, ["root"])).toBe("partial");
       expect(isNodeSelected(tree, ["root", "a"])).toBe("partial");
@@ -688,8 +688,8 @@ describe("DataSourceBuilder utilities", () => {
 
     it("should handle multiple siblings with mixed states", () => {
       const tree = {
-        in: [createTreeItem("root.a"), createTreeItem("root.c")],
-        notIn: [createTreeItem("root.b"), createTreeItem("root.d")],
+        in: [createTreeItem("root/a"), createTreeItem("root/c")],
+        notIn: [createTreeItem("root/b"), createTreeItem("root/d")],
       };
       expect(isNodeSelected(tree, ["root"])).toBe("partial");
       expect(isNodeSelected(tree, ["root", "a"])).toBe(true);
@@ -701,8 +701,8 @@ describe("DataSourceBuilder utilities", () => {
 
     it("should handle cross-branch scenarios", () => {
       const tree = {
-        in: [createTreeItem("docs.api"), createTreeItem("src.components")],
-        notIn: [createTreeItem("docs.temp"), createTreeItem("src.tests")],
+        in: [createTreeItem("docs/api"), createTreeItem("src/components")],
+        notIn: [createTreeItem("docs/temp"), createTreeItem("src/tests")],
       };
       expect(isNodeSelected(tree, ["docs"])).toBe("partial");
       expect(isNodeSelected(tree, ["docs", "api"])).toBe(true);
@@ -717,7 +717,7 @@ describe("DataSourceBuilder utilities", () => {
     it("should handle single character path segments", () => {
       const tree = {
         in: [createTreeItem("a")],
-        notIn: [createTreeItem("b.c")],
+        notIn: [createTreeItem("b/c")],
       };
       expect(isNodeSelected(tree, ["a"])).toBe(true);
       expect(isNodeSelected(tree, ["a", "x"])).toBe(true);
@@ -729,11 +729,11 @@ describe("DataSourceBuilder utilities", () => {
 
     it("should handle complex nested inclusion with partial exclusions", () => {
       const tree = {
-        in: [createTreeItem("root"), createTreeItem("other.branch")],
+        in: [createTreeItem("root"), createTreeItem("other/branch")],
         notIn: [
-          createTreeItem("root.excluded.deeply.nested"),
-          createTreeItem("root.temp"),
-          createTreeItem("other.branch.cache"),
+          createTreeItem("root/excluded/deeply/nested"),
+          createTreeItem("root/temp"),
+          createTreeItem("other/branch/cache"),
         ],
       };
       expect(isNodeSelected(tree, ["root"])).toBe("partial");
@@ -755,8 +755,8 @@ describe("DataSourceBuilder utilities", () => {
 
     it("should handle edge case with parent and child both in arrays", () => {
       const tree = {
-        in: [createTreeItem("root"), createTreeItem("root.a")],
-        notIn: [createTreeItem("root.b")],
+        in: [createTreeItem("root"), createTreeItem("root/a")],
+        notIn: [createTreeItem("root/b")],
       };
       expect(isNodeSelected(tree, ["root"])).toBe("partial");
       expect(isNodeSelected(tree, ["root", "a"])).toBe(true);
@@ -766,8 +766,8 @@ describe("DataSourceBuilder utilities", () => {
 
     it("should handle conflicting parent-child relationships", () => {
       const tree = {
-        in: [createTreeItem("root.a.b")],
-        notIn: [createTreeItem("root.a")],
+        in: [createTreeItem("root/a/b")],
+        notIn: [createTreeItem("root/a")],
       };
       expect(isNodeSelected(tree, ["root"])).toBe("partial");
       expect(isNodeSelected(tree, ["root", "a"])).toBe(false);
@@ -777,7 +777,7 @@ describe("DataSourceBuilder utilities", () => {
 
     it("should handle multiple levels of partial selection", () => {
       const tree = {
-        in: [createTreeItem("a.b.c.d"), createTreeItem("a.x.y.z")],
+        in: [createTreeItem("a/b/c/d"), createTreeItem("a/x/y/z")],
         notIn: [],
       };
       expect(isNodeSelected(tree, ["a"])).toBe("partial");
@@ -793,12 +793,12 @@ describe("DataSourceBuilder utilities", () => {
 
     it("should handle large tree with many branches", () => {
       const tree = {
-        in: [createTreeItem("app"), createTreeItem("docs.guides")],
+        in: [createTreeItem("app"), createTreeItem("docs/guides")],
         notIn: [
-          createTreeItem("app.cache"),
-          createTreeItem("app.temp.logs"),
-          createTreeItem("docs.temp"),
-          createTreeItem("config.secrets"),
+          createTreeItem("app/cache"),
+          createTreeItem("app/temp/logs"),
+          createTreeItem("docs/temp"),
+          createTreeItem("config/secrets"),
         ],
       };
       expect(isNodeSelected(tree, ["app"])).toBe("partial");

--- a/front/components/data_source_view/context/utils.test.ts
+++ b/front/components/data_source_view/context/utils.test.ts
@@ -6,12 +6,26 @@ import {
   removeNodeFromTree,
 } from "@app/components/data_source_view/context/utils";
 
+// Helper function to create tree items
+const createTreeItem = (
+  path: string,
+  name?: string,
+  readablePath?: string
+) => ({
+  path,
+  name: name || path.split(".").pop() || path,
+  readablePath: readablePath || path.replace(/\./g, "/"),
+});
+
 describe("DataSourceBuilder utilities", () => {
   describe("addNodeToTree", () => {
     it("should add a node to an empty tree", () => {
-      const result = addNodeToTree({ in: [], notIn: [] }, ["root", "a"]);
+      const result = addNodeToTree(
+        { in: [], notIn: [] },
+        { path: ["root", "a"], name: "a", readablePath: "root/a" }
+      );
       expect(result).toEqual({
-        in: ["root.a"],
+        in: [{ path: "root.a", name: "a", readablePath: "root/a" }],
         notIn: [],
       });
     });
@@ -19,9 +33,13 @@ describe("DataSourceBuilder utilities", () => {
     it("should remove node from notIn when adding it", () => {
       const tree = {
         in: [],
-        notIn: ["root.a"],
+        notIn: [createTreeItem("root.a")],
       };
-      const result = addNodeToTree(tree, ["root", "a"]);
+      const result = addNodeToTree(tree, {
+        path: ["root", "a"],
+        name: "a",
+        readablePath: "root/a",
+      });
       expect(result).toEqual({
         in: [],
         notIn: [],
@@ -30,74 +48,98 @@ describe("DataSourceBuilder utilities", () => {
 
     it("should not duplicate paths in in array", () => {
       const tree = {
-        in: ["root.a"],
+        in: [createTreeItem("root.a")],
         notIn: [],
       };
-      const result = addNodeToTree(tree, ["root", "a"]);
+      const result = addNodeToTree(tree, {
+        path: ["root", "a"],
+        name: "a",
+        readablePath: "root/a",
+      });
       expect(result).toEqual({
-        in: ["root.a"],
+        in: [createTreeItem("root.a")],
         notIn: [],
       });
     });
 
     it("should block partial path additions when parent is already selected", () => {
       const tree = {
-        in: ["root"],
+        in: [createTreeItem("root")],
         notIn: [],
       };
-      const result = addNodeToTree(tree, ["root", "a", "b"]);
+      const result = addNodeToTree(tree, {
+        path: ["root", "a", "b"],
+        name: "b",
+        readablePath: "root/a/b",
+      });
       expect(result).toEqual({
-        in: ["root"],
+        in: [createTreeItem("root")],
         notIn: [],
       });
     });
 
-    it("should add a nested path without removing the exluded parent", () => {
+    it("should add a nested path without removing the excluded parent", () => {
       const tree = {
         in: [],
-        notIn: ["a"],
+        notIn: [createTreeItem("a")],
       };
 
-      const result = addNodeToTree(tree, ["a", "b", "c"]);
+      const result = addNodeToTree(tree, {
+        path: ["a", "b", "c"],
+        name: "c",
+        readablePath: "a/b/c",
+      });
       expect(result).toEqual({
-        in: ["a.b.c"],
-        notIn: ["a"],
+        in: [createTreeItem("a.b.c", "c", "a/b/c")],
+        notIn: [createTreeItem("a")],
       });
     });
 
     it("should add a nested path that is notIn, when its parent is in", () => {
       const tree = {
-        in: ["root.a"],
-        notIn: ["root.a.b.c"],
+        in: [createTreeItem("root.a")],
+        notIn: [createTreeItem("root.a.b.c")],
       };
 
-      const result = addNodeToTree(tree, ["root", "a", "b", "c"]);
+      const result = addNodeToTree(tree, {
+        path: ["root", "a", "b", "c"],
+        name: "c",
+        readablePath: "root/a/b/c",
+      });
       expect(result).toEqual({
-        in: ["root.a"],
+        in: [createTreeItem("root.a")],
         notIn: [],
       });
     });
 
     it("should handle adding multiple levels deep when grandparent is included", () => {
       const tree = {
-        in: ["root"],
+        in: [createTreeItem("root")],
         notIn: [],
       };
-      const result = addNodeToTree(tree, ["root", "a", "b", "c", "d"]);
+      const result = addNodeToTree(tree, {
+        path: ["root", "a", "b", "c", "d"],
+        name: "d",
+        readablePath: "root/a/b/c/d",
+      });
       expect(result).toEqual({
-        in: ["root"],
+        in: [createTreeItem("root")],
         notIn: [],
       });
     });
 
     it("should add sibling paths independently", () => {
       const tree = {
-        in: ["root.a"],
+        in: [createTreeItem("root.a")],
         notIn: [],
       };
-      const result = addNodeToTree(tree, ["root", "b"]);
+      const result = addNodeToTree(tree, {
+        path: ["root", "b"],
+        name: "b",
+        readablePath: "root/b",
+      });
       expect(result).toEqual({
-        in: ["root.a", "root.b"],
+        in: [createTreeItem("root.a"), createTreeItem("root.b", "b", "root/b")],
         notIn: [],
       });
     });
@@ -105,57 +147,88 @@ describe("DataSourceBuilder utilities", () => {
     it("should handle adding root level paths", () => {
       const tree = {
         in: [],
-        notIn: ["other"],
+        notIn: [createTreeItem("other")],
       };
-      const result = addNodeToTree(tree, ["root"]);
+      const result = addNodeToTree(tree, {
+        path: ["root"],
+        name: "root",
+        readablePath: "root",
+      });
       expect(result).toEqual({
-        in: ["root"],
-        notIn: ["other"],
+        in: [createTreeItem("root", "root", "root")],
+        notIn: [createTreeItem("other")],
       });
     });
 
     it("should remove multiple child exclusions when adding parent", () => {
       const tree = {
         in: [],
-        notIn: ["root.a.b", "root.a.c", "root.a.d"],
+        notIn: [
+          createTreeItem("root.a.b"),
+          createTreeItem("root.a.c"),
+          createTreeItem("root.a.d"),
+        ],
       };
-      const result = addNodeToTree(tree, ["root", "a"]);
+      const result = addNodeToTree(tree, {
+        path: ["root", "a"],
+        name: "a",
+        readablePath: "root/a",
+      });
       expect(result).toEqual({
-        in: ["root.a"],
+        in: [createTreeItem("root.a", "a", "root/a")],
         notIn: [],
       });
     });
 
     it("should handle adding when parent is in notIn but has excluded children", () => {
       const tree = {
-        in: ["root.b"],
-        notIn: ["root.a", "root.a.x"],
+        in: [createTreeItem("root.b")],
+        notIn: [createTreeItem("root.a"), createTreeItem("root.a.x")],
       };
-      const result = addNodeToTree(tree, ["root", "a", "y"]);
+      const result = addNodeToTree(tree, {
+        path: ["root", "a", "y"],
+        name: "y",
+        readablePath: "root/a/y",
+      });
       expect(result).toEqual({
-        in: ["root.b", "root.a.y"],
-        notIn: ["root.a", "root.a.x"],
+        in: [
+          createTreeItem("root.b"),
+          createTreeItem("root.a.y", "y", "root/a/y"),
+        ],
+        notIn: [createTreeItem("root.a"), createTreeItem("root.a.x")],
       });
     });
 
     it("should handle complex mixed scenario with multiple branches", () => {
       const tree = {
-        in: ["root.a", "root.c"],
-        notIn: ["root.b", "root.d.x"],
+        in: [createTreeItem("root.a"), createTreeItem("root.c")],
+        notIn: [createTreeItem("root.b"), createTreeItem("root.d.x")],
       };
-      const result = addNodeToTree(tree, ["root", "d"]);
+      const result = addNodeToTree(tree, {
+        path: ["root", "d"],
+        name: "d",
+        readablePath: "root/d",
+      });
       expect(result).toEqual({
-        in: ["root.a", "root.c", "root.d"],
-        notIn: ["root.b"],
+        in: [
+          createTreeItem("root.a"),
+          createTreeItem("root.c"),
+          createTreeItem("root.d", "d", "root/d"),
+        ],
+        notIn: [createTreeItem("root.b")],
       });
     });
 
     it("should handle single character paths", () => {
       const tree = {
         in: [],
-        notIn: ["a"],
+        notIn: [createTreeItem("a")],
       };
-      const result = addNodeToTree(tree, ["a"]);
+      const result = addNodeToTree(tree, {
+        path: ["a"],
+        name: "a",
+        readablePath: "a",
+      });
       expect(result).toEqual({
         in: [],
         notIn: [],
@@ -164,13 +237,20 @@ describe("DataSourceBuilder utilities", () => {
 
     it("should preserve unrelated exclusions when adding", () => {
       const tree = {
-        in: ["docs"],
-        notIn: ["temp.cache", "logs.old"],
+        in: [createTreeItem("docs")],
+        notIn: [createTreeItem("temp.cache"), createTreeItem("logs.old")],
       };
-      const result = addNodeToTree(tree, ["src", "main"]);
+      const result = addNodeToTree(tree, {
+        path: ["src", "main"],
+        name: "main",
+        readablePath: "src/main",
+      });
       expect(result).toEqual({
-        in: ["docs", "src.main"],
-        notIn: ["temp.cache", "logs.old"],
+        in: [
+          createTreeItem("docs"),
+          createTreeItem("src.main", "main", "src/main"),
+        ],
+        notIn: [createTreeItem("temp.cache"), createTreeItem("logs.old")],
       });
     });
   });
@@ -181,7 +261,11 @@ describe("DataSourceBuilder utilities", () => {
         in: [],
         notIn: [],
       };
-      const result = removeNodeFromTree(tree, ["root", "a"]);
+      const result = removeNodeFromTree(tree, {
+        path: ["root", "a"],
+        name: "a",
+        readablePath: "root/a",
+      });
       expect(result).toEqual({
         in: [],
         notIn: [],
@@ -190,10 +274,14 @@ describe("DataSourceBuilder utilities", () => {
 
     it("should remove node from in when excluding it", () => {
       const tree = {
-        in: ["root.a"],
+        in: [createTreeItem("root.a")],
         notIn: [],
       };
-      const result = removeNodeFromTree(tree, ["root", "a"]);
+      const result = removeNodeFromTree(tree, {
+        path: ["root", "a"],
+        name: "a",
+        readablePath: "root/a",
+      });
       expect(result).toEqual({
         in: [],
         notIn: [],
@@ -203,70 +291,106 @@ describe("DataSourceBuilder utilities", () => {
     it("should not duplicate paths in notIn array", () => {
       const tree = {
         in: [],
-        notIn: ["root.a"],
+        notIn: [createTreeItem("root.a")],
       };
-      const result = removeNodeFromTree(tree, ["root", "a"]);
+      const result = removeNodeFromTree(tree, {
+        path: ["root", "a"],
+        name: "a",
+        readablePath: "root/a",
+      });
       expect(result).toEqual({
         in: [],
-        notIn: ["root.a"],
+        notIn: [createTreeItem("root.a")],
       });
     });
 
     it("should handle removing nested paths", () => {
       const tree = {
-        in: ["root.a.b"],
+        in: [createTreeItem("root.a.b")],
         notIn: [],
       };
-      const result = removeNodeFromTree(tree, ["root", "a", "b", "c"]);
+      const result = removeNodeFromTree(tree, {
+        path: ["root", "a", "b", "c"],
+        name: "c",
+        readablePath: "root/a/b/c",
+      });
       expect(result).toEqual({
-        in: ["root.a.b"],
-        notIn: ["root.a.b.c"],
+        in: [createTreeItem("root.a.b")],
+        notIn: [createTreeItem("root.a.b.c", "c", "root/a/b/c")],
       });
     });
 
     it("should remove child paths when removing parent", () => {
       const tree = {
-        in: ["root.a.b", "root.a.c", "root.b"],
+        in: [
+          createTreeItem("root.a.b"),
+          createTreeItem("root.a.c"),
+          createTreeItem("root.b"),
+        ],
         notIn: [],
       };
-      const result = removeNodeFromTree(tree, ["root", "a"]);
+      const result = removeNodeFromTree(tree, {
+        path: ["root", "a"],
+        name: "a",
+        readablePath: "root/a",
+      });
       expect(result).toEqual({
-        in: ["root.b"],
+        in: [createTreeItem("root.b")],
         notIn: [],
       });
     });
 
     it("should not affect unrelated paths", () => {
       const tree = {
-        in: ["root", "other.a.b", "root.x.y"],
+        in: [
+          createTreeItem("root"),
+          createTreeItem("other.a.b"),
+          createTreeItem("root.x.y"),
+        ],
         notIn: [],
       };
-      const result = removeNodeFromTree(tree, ["root", "a"]);
+      const result = removeNodeFromTree(tree, {
+        path: ["root", "a"],
+        name: "a",
+        readablePath: "root/a",
+      });
       expect(result).toEqual({
-        in: ["root", "other.a.b", "root.x.y"],
-        notIn: ["root.a"],
+        in: [
+          createTreeItem("root"),
+          createTreeItem("other.a.b"),
+          createTreeItem("root.x.y"),
+        ],
+        notIn: [createTreeItem("root.a", "a", "root/a")],
       });
     });
 
     it("should remove child notIn", () => {
       const tree = {
-        in: ["root.a"],
-        notIn: ["root.b.c"],
+        in: [createTreeItem("root.a")],
+        notIn: [createTreeItem("root.b.c")],
       };
 
-      const result = removeNodeFromTree(tree, ["root", "b"]);
+      const result = removeNodeFromTree(tree, {
+        path: ["root", "b"],
+        name: "b",
+        readablePath: "root/b",
+      });
       expect(result).toEqual({
-        in: ["root.a"],
-        notIn: ["root.b"],
+        in: [createTreeItem("root.a")],
+        notIn: [createTreeItem("root.b", "b", "root/b")],
       });
     });
 
     it("should handle removing deeply nested paths with multiple levels", () => {
       const tree = {
-        in: ["root.a.b.c.d.e"],
+        in: [createTreeItem("root.a.b.c.d.e")],
         notIn: [],
       };
-      const result = removeNodeFromTree(tree, ["root", "a", "b"]);
+      const result = removeNodeFromTree(tree, {
+        path: ["root", "a", "b"],
+        name: "b",
+        readablePath: "root/a/b",
+      });
       expect(result).toEqual({
         in: [],
         notIn: [],
@@ -275,85 +399,149 @@ describe("DataSourceBuilder utilities", () => {
 
     it("should remove multiple siblings when removing their parent", () => {
       const tree = {
-        in: ["root.a.x", "root.a.y", "root.a.z", "root.b"],
+        in: [
+          createTreeItem("root.a.x"),
+          createTreeItem("root.a.y"),
+          createTreeItem("root.a.z"),
+          createTreeItem("root.b"),
+        ],
         notIn: [],
       };
-      const result = removeNodeFromTree(tree, ["root", "a"]);
+      const result = removeNodeFromTree(tree, {
+        path: ["root", "a"],
+        name: "a",
+        readablePath: "root/a",
+      });
       expect(result).toEqual({
-        in: ["root.b"],
+        in: [createTreeItem("root.b")],
         notIn: [],
       });
     });
 
     it("should handle removing when there are multiple exclusions at different levels", () => {
       const tree = {
-        in: ["root"],
-        notIn: ["root.a.x", "root.b.y", "root.c"],
+        in: [createTreeItem("root")],
+        notIn: [
+          createTreeItem("root.a.x"),
+          createTreeItem("root.b.y"),
+          createTreeItem("root.c"),
+        ],
       };
-      const result = removeNodeFromTree(tree, ["root", "a"]);
+      const result = removeNodeFromTree(tree, {
+        path: ["root", "a"],
+        name: "a",
+        readablePath: "root/a",
+      });
       expect(result).toEqual({
-        in: ["root"],
-        notIn: ["root.b.y", "root.c", "root.a"],
+        in: [createTreeItem("root")],
+        notIn: [
+          createTreeItem("root.b.y"),
+          createTreeItem("root.c"),
+          createTreeItem("root.a", "a", "root/a"),
+        ],
       });
     });
 
     it("should handle removing root path with many children", () => {
       const tree = {
-        in: ["root", "other.x"],
-        notIn: ["root.excluded"],
+        in: [createTreeItem("root"), createTreeItem("other.x")],
+        notIn: [createTreeItem("root.excluded")],
       };
-      const result = removeNodeFromTree(tree, ["root"]);
+      const result = removeNodeFromTree(tree, {
+        path: ["root"],
+        name: "root",
+        readablePath: "root",
+      });
       expect(result).toEqual({
-        in: ["other.x"],
+        in: [createTreeItem("other.x")],
         notIn: [],
       });
     });
 
     it("should handle removing when path has both included and excluded children", () => {
       const tree = {
-        in: ["root.a.included1", "root.a.included2"],
-        notIn: ["root.a.excluded1", "root.a.excluded2"],
+        in: [
+          createTreeItem("root.a.included1"),
+          createTreeItem("root.a.included2"),
+        ],
+        notIn: [
+          createTreeItem("root.a.excluded1"),
+          createTreeItem("root.a.excluded2"),
+        ],
       };
-      const result = removeNodeFromTree(tree, ["root", "a"]);
+      const result = removeNodeFromTree(tree, {
+        path: ["root", "a"],
+        name: "a",
+        readablePath: "root/a",
+      });
       expect(result).toEqual({
         in: [],
-        notIn: ["root.a"],
+        notIn: [createTreeItem("root.a", "a", "root/a")],
       });
     });
 
     it("should preserve complex exclusion hierarchy when removing unrelated path", () => {
       const tree = {
-        in: ["root", "other.branch"],
-        notIn: ["root.a.b.c", "root.x.y", "root.z"],
+        in: [createTreeItem("root"), createTreeItem("other.branch")],
+        notIn: [
+          createTreeItem("root.a.b.c"),
+          createTreeItem("root.x.y"),
+          createTreeItem("root.z"),
+        ],
       };
-      const result = removeNodeFromTree(tree, ["other", "branch"]);
+      const result = removeNodeFromTree(tree, {
+        path: ["other", "branch"],
+        name: "branch",
+        readablePath: "other/branch",
+      });
       expect(result).toEqual({
-        in: ["root"],
-        notIn: ["root.a.b.c", "root.x.y", "root.z"],
+        in: [createTreeItem("root")],
+        notIn: [
+          createTreeItem("root.a.b.c"),
+          createTreeItem("root.x.y"),
+          createTreeItem("root.z"),
+        ],
       });
     });
 
     it("should consolidate exclusions when removing parent of multiple excluded children", () => {
       const tree = {
-        in: ["root"],
-        notIn: ["root.a.x.1", "root.a.x.2", "root.a.y.1", "root.a.y.2"],
+        in: [createTreeItem("root")],
+        notIn: [
+          createTreeItem("root.a.x.1"),
+          createTreeItem("root.a.x.2"),
+          createTreeItem("root.a.y.1"),
+          createTreeItem("root.a.y.2"),
+        ],
       };
-      const result = removeNodeFromTree(tree, ["root", "a", "x"]);
+      const result = removeNodeFromTree(tree, {
+        path: ["root", "a", "x"],
+        name: "x",
+        readablePath: "root/a/x",
+      });
       expect(result).toEqual({
-        in: ["root"],
-        notIn: ["root.a.y.1", "root.a.y.2", "root.a.x"],
+        in: [createTreeItem("root")],
+        notIn: [
+          createTreeItem("root.a.y.1"),
+          createTreeItem("root.a.y.2"),
+          createTreeItem("root.a.x", "x", "root/a/x"),
+        ],
       });
     });
 
     it("should handle removing path that would create redundant exclusion", () => {
       const tree = {
-        in: ["root"],
-        notIn: ["root.a"],
+        in: [createTreeItem("root")],
+        notIn: [createTreeItem("root.a")],
       };
-      const result = removeNodeFromTree(tree, ["root", "a", "b"]);
+      const result = removeNodeFromTree(tree, {
+        path: ["root", "a", "b"],
+        name: "b",
+        readablePath: "root/a/b",
+      });
       expect(result).toEqual({
-        in: ["root"],
-        notIn: ["root.a"],
+        in: [createTreeItem("root")],
+        notIn: [createTreeItem("root.a")],
       });
     });
   });
@@ -361,7 +549,7 @@ describe("DataSourceBuilder utilities", () => {
   describe("isNodeSelected", () => {
     it("should return true for explicitly included node", () => {
       const tree = {
-        in: ["root.a"],
+        in: [createTreeItem("root.a")],
         notIn: [],
       };
       expect(isNodeSelected(tree, ["root", "a"])).toBe(true);
@@ -370,14 +558,14 @@ describe("DataSourceBuilder utilities", () => {
     it("should return false for excluded node", () => {
       const tree = {
         in: [],
-        notIn: ["root.a"],
+        notIn: [createTreeItem("root.a")],
       };
       expect(isNodeSelected(tree, ["root", "a"])).toBe(false);
     });
 
     it("should return true for child of included parent", () => {
       const tree = {
-        in: ["root"],
+        in: [createTreeItem("root")],
         notIn: [],
       };
       expect(isNodeSelected(tree, ["root", "a"])).toBe(true);
@@ -387,14 +575,14 @@ describe("DataSourceBuilder utilities", () => {
     it("should return false for child of excluded parent", () => {
       const tree = {
         in: [],
-        notIn: ["root"],
+        notIn: [createTreeItem("root")],
       };
       expect(isNodeSelected(tree, ["root", "a"])).toBe(false);
     });
 
     it("should handle partial path matches", () => {
       const tree = {
-        in: ["root.a"],
+        in: [createTreeItem("root.a")],
         notIn: [],
       };
       expect(isNodeSelected(tree, ["root", "a", "b"])).toBe(true);
@@ -403,8 +591,8 @@ describe("DataSourceBuilder utilities", () => {
 
     it("should prioritize notIn over in for exact matches", () => {
       const tree = {
-        in: ["root"],
-        notIn: ["root.a"],
+        in: [createTreeItem("root")],
+        notIn: [createTreeItem("root.a")],
       };
       expect(isNodeSelected(tree, ["root", "a"])).toBe(false);
       expect(isNodeSelected(tree, ["root", "b"])).toBe(true);
@@ -412,7 +600,7 @@ describe("DataSourceBuilder utilities", () => {
 
     it("should handle deeply nested paths", () => {
       const tree = {
-        in: ["a.b.c"],
+        in: [createTreeItem("a.b.c")],
         notIn: [],
       };
       expect(isNodeSelected(tree, ["a", "b", "c"])).toBe(true);
@@ -421,8 +609,8 @@ describe("DataSourceBuilder utilities", () => {
 
     it("should handle complex inclusion/exclusion scenarios", () => {
       const tree = {
-        in: ["root"],
-        notIn: ["root.a", "root.b.c"],
+        in: [createTreeItem("root")],
+        notIn: [createTreeItem("root.a"), createTreeItem("root.b.c")],
       };
       expect(isNodeSelected(tree, ["root"])).toBe("partial");
       expect(isNodeSelected(tree, ["root", "a"])).toBe(false);
@@ -433,8 +621,8 @@ describe("DataSourceBuilder utilities", () => {
 
     it("should return 'partial' when parent has mixed children", () => {
       const tree = {
-        in: ["root.a", "root.c"],
-        notIn: ["root.b"],
+        in: [createTreeItem("root.a"), createTreeItem("root.c")],
+        notIn: [createTreeItem("root.b")],
       };
       expect(isNodeSelected(tree, ["root"])).toBe("partial");
       expect(isNodeSelected(tree, ["root", "a"])).toBe(true);
@@ -444,8 +632,8 @@ describe("DataSourceBuilder utilities", () => {
 
     it("should return 'partial' when included parent has excluded children", () => {
       const tree = {
-        in: ["root"],
-        notIn: ["root.a"],
+        in: [createTreeItem("root")],
+        notIn: [createTreeItem("root.a")],
       };
       expect(isNodeSelected(tree, ["root"])).toBe("partial");
       expect(isNodeSelected(tree, ["root", "a"])).toBe(false);
@@ -454,7 +642,7 @@ describe("DataSourceBuilder utilities", () => {
 
     it("should return true when all children are included", () => {
       const tree = {
-        in: ["root"],
+        in: [createTreeItem("root")],
         notIn: [],
       };
       expect(isNodeSelected(tree, ["root"])).toBe(true);
@@ -464,7 +652,7 @@ describe("DataSourceBuilder utilities", () => {
 
     it("should return 'partial' for parent with some included children", () => {
       const tree = {
-        in: ["root.a.b"],
+        in: [createTreeItem("root.a.b")],
         notIn: [],
       };
       expect(isNodeSelected(tree, ["root"])).toBe("partial");
@@ -475,7 +663,7 @@ describe("DataSourceBuilder utilities", () => {
 
     it("should return false for paths not matching any included pattern", () => {
       const tree = {
-        in: ["root.a"],
+        in: [createTreeItem("root.a")],
         notIn: [],
       };
       expect(isNodeSelected(tree, ["other"])).toBe(false);
@@ -494,7 +682,7 @@ describe("DataSourceBuilder utilities", () => {
     it("should handle tree with only exclusions", () => {
       const tree = {
         in: [],
-        notIn: ["root.a", "docs.temp"],
+        notIn: [createTreeItem("root.a"), createTreeItem("docs.temp")],
       };
       expect(isNodeSelected(tree, ["root"])).toBe(false);
       expect(isNodeSelected(tree, ["root", "a"])).toBe(false);
@@ -504,7 +692,11 @@ describe("DataSourceBuilder utilities", () => {
 
     it("should handle multiple root level paths", () => {
       const tree = {
-        in: ["root", "docs", "src"],
+        in: [
+          createTreeItem("root"),
+          createTreeItem("docs"),
+          createTreeItem("src"),
+        ],
         notIn: [],
       };
       expect(isNodeSelected(tree, ["root"])).toBe(true);
@@ -515,8 +707,8 @@ describe("DataSourceBuilder utilities", () => {
 
     it("should handle deeply nested exclusions", () => {
       const tree = {
-        in: ["root"],
-        notIn: ["root.a.b.c.d.e"],
+        in: [createTreeItem("root")],
+        notIn: [createTreeItem("root.a.b.c.d.e")],
       };
       expect(isNodeSelected(tree, ["root"])).toBe("partial");
       expect(isNodeSelected(tree, ["root", "a"])).toBe("partial");
@@ -535,8 +727,8 @@ describe("DataSourceBuilder utilities", () => {
 
     it("should handle multiple siblings with mixed states", () => {
       const tree = {
-        in: ["root.a", "root.c"],
-        notIn: ["root.b", "root.d"],
+        in: [createTreeItem("root.a"), createTreeItem("root.c")],
+        notIn: [createTreeItem("root.b"), createTreeItem("root.d")],
       };
       expect(isNodeSelected(tree, ["root"])).toBe("partial");
       expect(isNodeSelected(tree, ["root", "a"])).toBe(true);
@@ -548,8 +740,8 @@ describe("DataSourceBuilder utilities", () => {
 
     it("should handle cross-branch scenarios", () => {
       const tree = {
-        in: ["docs.api", "src.components"],
-        notIn: ["docs.temp", "src.tests"],
+        in: [createTreeItem("docs.api"), createTreeItem("src.components")],
+        notIn: [createTreeItem("docs.temp"), createTreeItem("src.tests")],
       };
       expect(isNodeSelected(tree, ["docs"])).toBe("partial");
       expect(isNodeSelected(tree, ["docs", "api"])).toBe(true);
@@ -561,13 +753,26 @@ describe("DataSourceBuilder utilities", () => {
       expect(isNodeSelected(tree, ["src", "utils"])).toBe(false);
     });
 
+    it("should handle single character path segments", () => {
+      const tree = {
+        in: [createTreeItem("a")],
+        notIn: [createTreeItem("b.c")],
+      };
+      expect(isNodeSelected(tree, ["a"])).toBe(true);
+      expect(isNodeSelected(tree, ["a", "x"])).toBe(true);
+      expect(isNodeSelected(tree, ["b"])).toBe(false);
+      expect(isNodeSelected(tree, ["b", "c"])).toBe(false);
+      expect(isNodeSelected(tree, ["b", "d"])).toBe(false);
+      expect(isNodeSelected(tree, ["c"])).toBe(false);
+    });
+
     it("should handle complex nested inclusion with partial exclusions", () => {
       const tree = {
-        in: ["root", "other.branch"],
+        in: [createTreeItem("root"), createTreeItem("other.branch")],
         notIn: [
-          "root.excluded.deeply.nested",
-          "root.temp",
-          "other.branch.cache",
+          createTreeItem("root.excluded.deeply.nested"),
+          createTreeItem("root.temp"),
+          createTreeItem("other.branch.cache"),
         ],
       };
       expect(isNodeSelected(tree, ["root"])).toBe("partial");
@@ -589,8 +794,8 @@ describe("DataSourceBuilder utilities", () => {
 
     it("should handle edge case with parent and child both in arrays", () => {
       const tree = {
-        in: ["root", "root.a"],
-        notIn: ["root.b"],
+        in: [createTreeItem("root"), createTreeItem("root.a")],
+        notIn: [createTreeItem("root.b")],
       };
       expect(isNodeSelected(tree, ["root"])).toBe("partial");
       expect(isNodeSelected(tree, ["root", "a"])).toBe(true);
@@ -600,8 +805,8 @@ describe("DataSourceBuilder utilities", () => {
 
     it("should handle conflicting parent-child relationships", () => {
       const tree = {
-        in: ["root.a.b"],
-        notIn: ["root.a"],
+        in: [createTreeItem("root.a.b")],
+        notIn: [createTreeItem("root.a")],
       };
       expect(isNodeSelected(tree, ["root"])).toBe("partial");
       expect(isNodeSelected(tree, ["root", "a"])).toBe(false);
@@ -611,7 +816,7 @@ describe("DataSourceBuilder utilities", () => {
 
     it("should handle multiple levels of partial selection", () => {
       const tree = {
-        in: ["a.b.c.d", "a.x.y.z"],
+        in: [createTreeItem("a.b.c.d"), createTreeItem("a.x.y.z")],
         notIn: [],
       };
       expect(isNodeSelected(tree, ["a"])).toBe("partial");
@@ -623,6 +828,30 @@ describe("DataSourceBuilder utilities", () => {
       expect(isNodeSelected(tree, ["a", "x", "y"])).toBe("partial");
       expect(isNodeSelected(tree, ["a", "x", "y", "z"])).toBe(true);
       expect(isNodeSelected(tree, ["a", "m"])).toBe(false);
+    });
+
+    it("should handle large tree with many branches", () => {
+      const tree = {
+        in: [createTreeItem("app"), createTreeItem("docs.guides")],
+        notIn: [
+          createTreeItem("app.cache"),
+          createTreeItem("app.temp.logs"),
+          createTreeItem("docs.temp"),
+          createTreeItem("config.secrets"),
+        ],
+      };
+      expect(isNodeSelected(tree, ["app"])).toBe("partial");
+      expect(isNodeSelected(tree, ["app", "src"])).toBe(true);
+      expect(isNodeSelected(tree, ["app", "cache"])).toBe(false);
+      expect(isNodeSelected(tree, ["app", "temp"])).toBe("partial");
+      expect(isNodeSelected(tree, ["app", "temp", "logs"])).toBe(false);
+      expect(isNodeSelected(tree, ["app", "temp", "other"])).toBe(true);
+      expect(isNodeSelected(tree, ["docs"])).toBe("partial");
+      expect(isNodeSelected(tree, ["docs", "guides"])).toBe(true);
+      expect(isNodeSelected(tree, ["docs", "temp"])).toBe(false);
+      expect(isNodeSelected(tree, ["config"])).toBe(false);
+      expect(isNodeSelected(tree, ["config", "secrets"])).toBe(false);
+      expect(isNodeSelected(tree, ["config", "app"])).toBe(false);
     });
   });
 });

--- a/front/components/data_source_view/context/utils.test.ts
+++ b/front/components/data_source_view/context/utils.test.ts
@@ -7,14 +7,9 @@ import {
 } from "@app/components/data_source_view/context/utils";
 
 // Helper function to create tree items
-const createTreeItem = (
-  path: string,
-  name?: string,
-  readablePath?: string
-) => ({
+const createTreeItem = (path: string, name?: string) => ({
   path,
   name: name || path.split(".").pop() || path,
-  readablePath: readablePath || path.replace(/\./g, "/"),
 });
 
 describe("DataSourceBuilder utilities", () => {
@@ -22,10 +17,10 @@ describe("DataSourceBuilder utilities", () => {
     it("should add a node to an empty tree", () => {
       const result = addNodeToTree(
         { in: [], notIn: [] },
-        { path: ["root", "a"], name: "a", readablePath: "root/a" }
+        { path: ["root", "a"], name: "a" }
       );
       expect(result).toEqual({
-        in: [{ path: "root.a", name: "a", readablePath: "root/a" }],
+        in: [{ path: "root.a", name: "a" }],
         notIn: [],
       });
     });
@@ -38,7 +33,6 @@ describe("DataSourceBuilder utilities", () => {
       const result = addNodeToTree(tree, {
         path: ["root", "a"],
         name: "a",
-        readablePath: "root/a",
       });
       expect(result).toEqual({
         in: [],
@@ -54,7 +48,6 @@ describe("DataSourceBuilder utilities", () => {
       const result = addNodeToTree(tree, {
         path: ["root", "a"],
         name: "a",
-        readablePath: "root/a",
       });
       expect(result).toEqual({
         in: [createTreeItem("root.a")],
@@ -70,7 +63,6 @@ describe("DataSourceBuilder utilities", () => {
       const result = addNodeToTree(tree, {
         path: ["root", "a", "b"],
         name: "b",
-        readablePath: "root/a/b",
       });
       expect(result).toEqual({
         in: [createTreeItem("root")],
@@ -87,10 +79,9 @@ describe("DataSourceBuilder utilities", () => {
       const result = addNodeToTree(tree, {
         path: ["a", "b", "c"],
         name: "c",
-        readablePath: "a/b/c",
       });
       expect(result).toEqual({
-        in: [createTreeItem("a.b.c", "c", "a/b/c")],
+        in: [createTreeItem("a.b.c", "c")],
         notIn: [createTreeItem("a")],
       });
     });
@@ -104,7 +95,6 @@ describe("DataSourceBuilder utilities", () => {
       const result = addNodeToTree(tree, {
         path: ["root", "a", "b", "c"],
         name: "c",
-        readablePath: "root/a/b/c",
       });
       expect(result).toEqual({
         in: [createTreeItem("root.a")],
@@ -120,7 +110,6 @@ describe("DataSourceBuilder utilities", () => {
       const result = addNodeToTree(tree, {
         path: ["root", "a", "b", "c", "d"],
         name: "d",
-        readablePath: "root/a/b/c/d",
       });
       expect(result).toEqual({
         in: [createTreeItem("root")],
@@ -136,10 +125,9 @@ describe("DataSourceBuilder utilities", () => {
       const result = addNodeToTree(tree, {
         path: ["root", "b"],
         name: "b",
-        readablePath: "root/b",
       });
       expect(result).toEqual({
-        in: [createTreeItem("root.a"), createTreeItem("root.b", "b", "root/b")],
+        in: [createTreeItem("root.a"), createTreeItem("root.b", "b")],
         notIn: [],
       });
     });
@@ -152,10 +140,9 @@ describe("DataSourceBuilder utilities", () => {
       const result = addNodeToTree(tree, {
         path: ["root"],
         name: "root",
-        readablePath: "root",
       });
       expect(result).toEqual({
-        in: [createTreeItem("root", "root", "root")],
+        in: [createTreeItem("root", "root")],
         notIn: [createTreeItem("other")],
       });
     });
@@ -172,10 +159,9 @@ describe("DataSourceBuilder utilities", () => {
       const result = addNodeToTree(tree, {
         path: ["root", "a"],
         name: "a",
-        readablePath: "root/a",
       });
       expect(result).toEqual({
-        in: [createTreeItem("root.a", "a", "root/a")],
+        in: [createTreeItem("root.a", "a")],
         notIn: [],
       });
     });
@@ -188,13 +174,9 @@ describe("DataSourceBuilder utilities", () => {
       const result = addNodeToTree(tree, {
         path: ["root", "a", "y"],
         name: "y",
-        readablePath: "root/a/y",
       });
       expect(result).toEqual({
-        in: [
-          createTreeItem("root.b"),
-          createTreeItem("root.a.y", "y", "root/a/y"),
-        ],
+        in: [createTreeItem("root.b"), createTreeItem("root.a.y", "y")],
         notIn: [createTreeItem("root.a"), createTreeItem("root.a.x")],
       });
     });
@@ -207,13 +189,12 @@ describe("DataSourceBuilder utilities", () => {
       const result = addNodeToTree(tree, {
         path: ["root", "d"],
         name: "d",
-        readablePath: "root/d",
       });
       expect(result).toEqual({
         in: [
           createTreeItem("root.a"),
           createTreeItem("root.c"),
-          createTreeItem("root.d", "d", "root/d"),
+          createTreeItem("root.d", "d"),
         ],
         notIn: [createTreeItem("root.b")],
       });
@@ -227,7 +208,6 @@ describe("DataSourceBuilder utilities", () => {
       const result = addNodeToTree(tree, {
         path: ["a"],
         name: "a",
-        readablePath: "a",
       });
       expect(result).toEqual({
         in: [],
@@ -243,13 +223,9 @@ describe("DataSourceBuilder utilities", () => {
       const result = addNodeToTree(tree, {
         path: ["src", "main"],
         name: "main",
-        readablePath: "src/main",
       });
       expect(result).toEqual({
-        in: [
-          createTreeItem("docs"),
-          createTreeItem("src.main", "main", "src/main"),
-        ],
+        in: [createTreeItem("docs"), createTreeItem("src.main", "main")],
         notIn: [createTreeItem("temp.cache"), createTreeItem("logs.old")],
       });
     });
@@ -264,7 +240,6 @@ describe("DataSourceBuilder utilities", () => {
       const result = removeNodeFromTree(tree, {
         path: ["root", "a"],
         name: "a",
-        readablePath: "root/a",
       });
       expect(result).toEqual({
         in: [],
@@ -280,7 +255,6 @@ describe("DataSourceBuilder utilities", () => {
       const result = removeNodeFromTree(tree, {
         path: ["root", "a"],
         name: "a",
-        readablePath: "root/a",
       });
       expect(result).toEqual({
         in: [],
@@ -296,7 +270,6 @@ describe("DataSourceBuilder utilities", () => {
       const result = removeNodeFromTree(tree, {
         path: ["root", "a"],
         name: "a",
-        readablePath: "root/a",
       });
       expect(result).toEqual({
         in: [],
@@ -312,11 +285,10 @@ describe("DataSourceBuilder utilities", () => {
       const result = removeNodeFromTree(tree, {
         path: ["root", "a", "b", "c"],
         name: "c",
-        readablePath: "root/a/b/c",
       });
       expect(result).toEqual({
         in: [createTreeItem("root.a.b")],
-        notIn: [createTreeItem("root.a.b.c", "c", "root/a/b/c")],
+        notIn: [createTreeItem("root.a.b.c", "c")],
       });
     });
 
@@ -332,7 +304,6 @@ describe("DataSourceBuilder utilities", () => {
       const result = removeNodeFromTree(tree, {
         path: ["root", "a"],
         name: "a",
-        readablePath: "root/a",
       });
       expect(result).toEqual({
         in: [createTreeItem("root.b")],
@@ -352,7 +323,6 @@ describe("DataSourceBuilder utilities", () => {
       const result = removeNodeFromTree(tree, {
         path: ["root", "a"],
         name: "a",
-        readablePath: "root/a",
       });
       expect(result).toEqual({
         in: [
@@ -360,7 +330,7 @@ describe("DataSourceBuilder utilities", () => {
           createTreeItem("other.a.b"),
           createTreeItem("root.x.y"),
         ],
-        notIn: [createTreeItem("root.a", "a", "root/a")],
+        notIn: [createTreeItem("root.a", "a")],
       });
     });
 
@@ -373,11 +343,10 @@ describe("DataSourceBuilder utilities", () => {
       const result = removeNodeFromTree(tree, {
         path: ["root", "b"],
         name: "b",
-        readablePath: "root/b",
       });
       expect(result).toEqual({
         in: [createTreeItem("root.a")],
-        notIn: [createTreeItem("root.b", "b", "root/b")],
+        notIn: [createTreeItem("root.b", "b")],
       });
     });
 
@@ -389,7 +358,6 @@ describe("DataSourceBuilder utilities", () => {
       const result = removeNodeFromTree(tree, {
         path: ["root", "a", "b"],
         name: "b",
-        readablePath: "root/a/b",
       });
       expect(result).toEqual({
         in: [],
@@ -410,7 +378,6 @@ describe("DataSourceBuilder utilities", () => {
       const result = removeNodeFromTree(tree, {
         path: ["root", "a"],
         name: "a",
-        readablePath: "root/a",
       });
       expect(result).toEqual({
         in: [createTreeItem("root.b")],
@@ -430,14 +397,13 @@ describe("DataSourceBuilder utilities", () => {
       const result = removeNodeFromTree(tree, {
         path: ["root", "a"],
         name: "a",
-        readablePath: "root/a",
       });
       expect(result).toEqual({
         in: [createTreeItem("root")],
         notIn: [
           createTreeItem("root.b.y"),
           createTreeItem("root.c"),
-          createTreeItem("root.a", "a", "root/a"),
+          createTreeItem("root.a", "a"),
         ],
       });
     });
@@ -450,7 +416,6 @@ describe("DataSourceBuilder utilities", () => {
       const result = removeNodeFromTree(tree, {
         path: ["root"],
         name: "root",
-        readablePath: "root",
       });
       expect(result).toEqual({
         in: [createTreeItem("other.x")],
@@ -472,11 +437,10 @@ describe("DataSourceBuilder utilities", () => {
       const result = removeNodeFromTree(tree, {
         path: ["root", "a"],
         name: "a",
-        readablePath: "root/a",
       });
       expect(result).toEqual({
         in: [],
-        notIn: [createTreeItem("root.a", "a", "root/a")],
+        notIn: [createTreeItem("root.a", "a")],
       });
     });
 
@@ -492,7 +456,6 @@ describe("DataSourceBuilder utilities", () => {
       const result = removeNodeFromTree(tree, {
         path: ["other", "branch"],
         name: "branch",
-        readablePath: "other/branch",
       });
       expect(result).toEqual({
         in: [createTreeItem("root")],
@@ -517,14 +480,13 @@ describe("DataSourceBuilder utilities", () => {
       const result = removeNodeFromTree(tree, {
         path: ["root", "a", "x"],
         name: "x",
-        readablePath: "root/a/x",
       });
       expect(result).toEqual({
         in: [createTreeItem("root")],
         notIn: [
           createTreeItem("root.a.y.1"),
           createTreeItem("root.a.y.2"),
-          createTreeItem("root.a.x", "x", "root/a/x"),
+          createTreeItem("root.a.x", "x"),
         ],
       });
     });
@@ -537,7 +499,6 @@ describe("DataSourceBuilder utilities", () => {
       const result = removeNodeFromTree(tree, {
         path: ["root", "a", "b"],
         name: "b",
-        readablePath: "root/a/b",
       });
       expect(result).toEqual({
         in: [createTreeItem("root")],

--- a/front/components/data_source_view/context/utils.ts
+++ b/front/components/data_source_view/context/utils.ts
@@ -245,7 +245,7 @@ export function navigationHistoryEntryTitle(
 export function findSpaceFromNavigationHistory(
   navigationHistory: NavigationHistoryEntryType[]
 ): SpaceType | null {
-  const entry = navigationHistory[1];
+  const entry = navigationHistory[1]; // Index 1 is where we store the space
   if (entry != null && entry.type === "space") {
     return entry.space;
   }
@@ -256,7 +256,7 @@ export function findSpaceFromNavigationHistory(
 export function findCategoryFromNavigationHistory(
   navigationHistory: NavigationHistoryEntryType[]
 ): DataSourceViewCategoryWithoutApps | null {
-  const entry = navigationHistory[2];
+  const entry = navigationHistory[2]; // Index 2 is where we store the category
   if (entry != null && entry.type === "category") {
     return entry.category;
   }
@@ -267,7 +267,7 @@ export function findCategoryFromNavigationHistory(
 export function findDataSourceViewFromNavigationHistory(
   navigationHistory: NavigationHistoryEntryType[]
 ): DataSourceViewType | null {
-  const entry = navigationHistory[3];
+  const entry = navigationHistory[3]; // Index 3 is where we store the data source
   if (entry != null && entry.type === "data_source") {
     return entry.dataSourceView;
   }

--- a/front/components/data_source_view/context/utils.ts
+++ b/front/components/data_source_view/context/utils.ts
@@ -40,8 +40,6 @@ export function addNodeToTree(
   const { path } = item;
   const pathPrefix = getPathPrefix(path);
 
-  console.log({ item });
-
   const hasParentInclusion = tree.in.some(({ path: inPath }) =>
     isParentOrSamePath(inPath, path)
   );

--- a/front/components/data_source_view/context/utils.ts
+++ b/front/components/data_source_view/context/utils.ts
@@ -11,6 +11,7 @@ import type {
   DataSourceViewType,
   SpaceType,
 } from "@app/types";
+import { assertNever } from "@app/types";
 
 export function pathToString(path: string[]): string {
   return path.join("/");
@@ -213,6 +214,8 @@ export function getLastNavigationHistoryEntryId(
       return entry.dataSourceView.sId;
     case "node":
       return entry.node.internalId;
+    default:
+      assertNever(entry);
   }
 }
 
@@ -236,6 +239,8 @@ export function navigationHistoryEntryTitle(
       return entry.dataSourceView.dataSource.name;
     case "node":
       return entry.node.title;
+    default:
+      assertNever(entry);
   }
 }
 

--- a/front/components/data_source_view/context/utils.ts
+++ b/front/components/data_source_view/context/utils.ts
@@ -1,10 +1,13 @@
+import { FolderIcon, ServerIcon } from "@dust-tt/sparkle";
+
 import type {
   DataSourceBuilderTreeItemType,
   DataSourceBuilderTreeType,
   NavigationHistoryEntryType,
   NodeSelectionState,
 } from "@app/components/data_source_view/context/types";
-import { CATEGORY_DETAILS } from "@app/lib/spaces";
+import { getVisualForDataSourceViewContentNode } from "@app/lib/content_nodes";
+import { CATEGORY_DETAILS, getSpaceIcon } from "@app/lib/spaces";
 import type {
   DataSourceViewCategoryWithoutApps,
   DataSourceViewContentNode,
@@ -285,4 +288,34 @@ export function getLatestNodeFromNavigationHistory(
   }
 
   return null;
+}
+
+export function getVisualForTreeItem(item: DataSourceBuilderTreeItemType) {
+  switch (item.type) {
+    case "root":
+      // Root doesn't have a specific visual, use a default folder icon
+      return FolderIcon;
+
+    case "space":
+      return getSpaceIcon(item.space);
+
+    case "category":
+      return CATEGORY_DETAILS[item.category].icon;
+
+    case "data_source":
+      // For data sources, we can use the connector provider logo or fall back to a generic icon
+      if (item.dataSourceView.dataSource.connectorProvider) {
+        // We could import getConnectorProviderLogoWithFallback but for simplicity,
+        // let's use category-based icons as fallback
+        const category = item.dataSourceView.category;
+        return CATEGORY_DETAILS[category].icon;
+      }
+      return ServerIcon;
+
+    case "node":
+      return getVisualForDataSourceViewContentNode(item.node);
+
+    default:
+      return FolderIcon;
+  }
 }

--- a/front/components/data_source_view/context/utils.ts
+++ b/front/components/data_source_view/context/utils.ts
@@ -12,11 +12,11 @@ import type {
 } from "@app/types";
 
 function pathToString(path: string[]): string {
-  return path.join(".");
+  return path.join("/");
 }
 
 function getPathPrefix(pathStr: string): string {
-  return pathStr + ".";
+  return pathStr + "/";
 }
 
 function isParentOrSamePath(parentPath: string, childPath: string): boolean {

--- a/front/components/data_source_view/context/utils.ts
+++ b/front/components/data_source_view/context/utils.ts
@@ -1,4 +1,4 @@
-import { FolderIcon, ServerIcon } from "@dust-tt/sparkle";
+import { FolderIcon } from "@dust-tt/sparkle";
 
 import type {
   DataSourceBuilderTreeItemType,
@@ -310,7 +310,7 @@ export function getVisualForTreeItem(item: DataSourceBuilderTreeItemType) {
         const category = item.dataSourceView.category;
         return CATEGORY_DETAILS[category].icon;
       }
-      return ServerIcon;
+      return FolderIcon;
 
     case "node":
       return getVisualForDataSourceViewContentNode(item.node);

--- a/front/components/data_source_view/context/utils.ts
+++ b/front/components/data_source_view/context/utils.ts
@@ -36,7 +36,7 @@ export function addNodeToTree(
   item: {
     path: string[];
     name: string;
-    readablePath: string;
+    node?: DataSourceViewContentNode;
   }
 ): DataSourceBuilderTreeType {
   const pathStr = pathToString(item.path);
@@ -74,7 +74,11 @@ export function addNodeToTree(
 
   const newIn = [
     ...tree.in,
-    { path: pathStr, name: item.name, readablePath: item.readablePath },
+    {
+      path: pathStr,
+      name: item.name,
+      node: item.node,
+    },
   ];
 
   return {
@@ -95,7 +99,6 @@ export function removeNodeFromTree(
   item: {
     path: string[];
     name: string;
-    readablePath: string;
   }
 ): DataSourceBuilderTreeType {
   const pathStr = pathToString(item.path);
@@ -149,7 +152,6 @@ export function removeNodeFromTree(
     newNotIn.push({
       path: pathStr,
       name: item.name,
-      readablePath: item.readablePath,
     });
   }
 
@@ -230,24 +232,6 @@ export function computeNavigationPath(
   return navigationHistory.map((entry) =>
     getLastNavigationHistoryEntryId(entry)
   );
-}
-
-/**
- * Compute the human readable path only for node.
- * e.g: Projects/Work/John
- */
-export function computeNavigationReadablePath(
-  navigationHistory: NavigationHistoryEntryType[]
-): string {
-  return navigationHistory
-    .reduce((acc, entry) => {
-      if (entry.type === "node") {
-        acc.push(entry.node.title);
-      }
-
-      return acc;
-    }, [] as string[])
-    .join("/");
 }
 
 export function navigationHistoryEntryTitle(

--- a/front/components/data_source_view/hooks/useDataSourceColumns.tsx
+++ b/front/components/data_source_view/hooks/useDataSourceColumns.tsx
@@ -1,0 +1,106 @@
+import { Checkbox, DataTable, Hoverable } from "@dust-tt/sparkle";
+import type { ColumnDef } from "@tanstack/react-table";
+import { useMemo } from "react";
+
+import { useDataSourceBuilderContext } from "@app/components/data_source_view/context/DataSourceBuilderContext";
+import type { NavigationHistoryEntryType } from "@app/components/data_source_view/context/types";
+
+export type DataSourceRowData = {
+  id: string;
+  title: string;
+  onClick?: () => void;
+  icon?: React.ComponentType;
+  entry: NavigationHistoryEntryType;
+};
+
+export const useDataSourceColumns = () => {
+  const {
+    selectNode,
+    selectCurrentNavigationEntry,
+    removeNode,
+    removeCurrentNavigationEntry,
+    isRowSelected,
+    isRowSelectable,
+    isCurrentNavigationEntrySelected,
+  } = useDataSourceBuilderContext();
+
+  const columns: ColumnDef<DataSourceRowData>[] = useMemo(
+    () => [
+      {
+        id: "select",
+        enableSorting: false,
+        enableHiding: false,
+        header: () => {
+          const selectionState = isCurrentNavigationEntrySelected();
+          return (
+            <Checkbox
+              key={`header-${selectionState}`}
+              size="xs"
+              checked={selectionState}
+              disabled={!isRowSelectable()}
+              onClick={(event) => event.stopPropagation()}
+              onCheckedChange={(state) => {
+                // When clicking a partial checkbox, select all
+                if (selectionState === "partial" || state) {
+                  selectCurrentNavigationEntry();
+                } else {
+                  removeCurrentNavigationEntry();
+                }
+              }}
+            />
+          );
+        },
+        cell: ({ row }) => {
+          const selectionState = isRowSelected(row.original.id);
+
+          return (
+            <div className="flex h-full w-full items-center">
+              <Checkbox
+                key={`${row.original.id}-${selectionState}`}
+                size="xs"
+                checked={selectionState}
+                disabled={!isRowSelectable(row.original.id)}
+                onClick={(event) => event.stopPropagation()}
+                onCheckedChange={(state) => {
+                  // When clicking a partial checkbox, select all
+                  if (selectionState === "partial" || state) {
+                    selectNode(row.original.entry);
+                  } else {
+                    removeNode(row.original.entry);
+                  }
+                }}
+              />
+            </div>
+          );
+        },
+        meta: {
+          sizeRatio: 5,
+        },
+      },
+      {
+        accessorKey: "title",
+        id: "name",
+        header: "Name",
+        cell: ({ row }) => (
+          <DataTable.CellContent icon={row.original.icon}>
+            <Hoverable>{row.original.title}</Hoverable>
+          </DataTable.CellContent>
+        ),
+        meta: {
+          sizeRatio: 70,
+        },
+      },
+    ],
+    [
+      isCurrentNavigationEntrySelected,
+      isRowSelectable,
+      isRowSelected,
+      removeCurrentNavigationEntry,
+      removeNode,
+      selectCurrentNavigationEntry,
+      selectNode,
+    ]
+  );
+
+  return columns;
+};

--- a/front/hooks/useDebounce.ts
+++ b/front/hooks/useDebounce.ts
@@ -1,4 +1,4 @@
-import { debounce } from "lodash";
+import debounce from "lodash/debounce";
 import { useCallback, useEffect, useRef, useState } from "react";
 
 interface UseDebounceOptions {

--- a/front/lib/swr/data_source_views.ts
+++ b/front/lib/swr/data_source_views.ts
@@ -309,13 +309,6 @@ export function useInfinitDataSourceViewContentNodes({
   sorting,
   swrOptions,
 }: FetchDataSourceViewContentNodesOptions) {
-  const body: GetContentNodesOrChildrenRequestBodyType = {
-    internalIds,
-    parentId,
-    viewType: viewType ?? "all",
-    sorting,
-  };
-
   const { data, error, isLoading, size, setSize, mutate, isValidating } =
     useSWRInfiniteWithDefaults<
       [string, GetContentNodesOrChildrenRequestBodyType] | null,
@@ -339,6 +332,13 @@ export function useInfinitDataSourceViewContentNodes({
           params.append("limit", pagination.limit.toString());
         }
 
+        const body: GetContentNodesOrChildrenRequestBodyType = {
+          internalIds,
+          parentId,
+          viewType: viewType ?? "all",
+          sorting,
+        };
+
         return [
           makeURLDataSourceViewContentNodes({ owner, dataSourceView }, params),
           body,
@@ -356,16 +356,18 @@ export function useInfinitDataSourceViewContentNodes({
     lastPage?.nextPageCursor !== null && lastPage?.nextPageCursor !== undefined;
 
   return {
-    isNodesLoading: isLoading,
+    isNodesLoading: isLoading && !data,
     isNodesValidating: isValidating,
     nodesError: error,
     nodes,
     nextPageCursor: lastPage?.nextPageCursor || null,
     hasNextPage,
-    loadMore: () => setSize(size + 1),
+    loadMore: () => setSize((s) => s + 1),
     mutate,
     totalNodesCount: lastPage?.total || 0,
     totalNodesCountIsAccurate: lastPage?.totalIsAccurate || true,
+    isLoadingMore:
+      isLoading || (size > 0 && data && typeof data[size - 1] === "undefined"),
   };
 }
 

--- a/front/pages/api/w/[wId]/spaces/[spaceId]/data_source_views/[dsvId]/content-nodes.ts
+++ b/front/pages/api/w/[wId]/spaces/[spaceId]/data_source_views/[dsvId]/content-nodes.ts
@@ -25,6 +25,9 @@ const GetContentNodesOrChildrenRequestBody = t.type({
   viewType: ContentNodesViewTypeCodec,
   sorting: t.union([SortingParamsCodec, t.undefined]),
 });
+export type GetContentNodesOrChildrenRequestBodyType = t.TypeOf<
+  typeof GetContentNodesOrChildrenRequestBody
+>;
 
 export type GetDataSourceViewContentNodes = {
   nodes: DataSourceViewContentNode[];


### PR DESCRIPTION
## Description
- https://github.com/dust-tt/tasks/issues/3037

### Selected documents/folders footer
<img width="767" height="241" alt="Capture d’écran 2025-08-07 à 18 22 30" src="https://github.com/user-attachments/assets/38206d8b-a3df-4c18-b350-b07d0c365f5c" />
Show selected documents in the footer of the side panel
- Show title and path to the document/folders
- Only shows selected documents/folders and not exceptions

### Disallow selection of whole space and category.
https://github.com/user-attachments/assets/aedc3837-cc67-437c-be2e-2dda0cebfce6
- Disable by default the space and category row
- If something is selected inside one of those, allow the users to unselect it all. Make it clearer using a tooltip, and help keeping the user safe by showing a confirm step before unselecting everything. 

### Known issues
- There is an ordering issue for selected managed sources. e.g: In front-edge when selecting some documents in google drive, the path was ok, but when saving and then re-opening the knowledge panel the path was reversed and missing edges.
- Currently those config <> tree serialization/deserialization doesn't supper `notIn` elements.

## Tests
- Locally
- Updated tests with new tree item type

## Risk
- Low, behind a FF and the current backend verify the accuracy of the selected data sources.

## Deploy Plan
- Deploy front
