### PR TITLE
Fix file_system tool was deactivated

### DIFF
--- a/front/lib/actions/mcp_internal_actions/constants.ts
+++ b/front/lib/actions/mcp_internal_actions/constants.ts
@@ -563,11 +563,11 @@ export const INTERNAL_MCP_SERVERS = {
   },
   data_sources_file_system: {
     id: 1010,
-    availability: "auto",
-    allowMultipleInstances: false,
     // This server is hidden for everyone, it is only available through the search tool
     // when the advanced_search mode is enabled.
-    isRestricted: () => true,
+    availability: "auto_hidden_builder",
+    allowMultipleInstances: false,
+    isRestricted: undefined,
     isPreview: false,
     tools_stakes: undefined,
     timeoutMs: undefined,


### PR DESCRIPTION
## Description

Reactivate the file_system_tool, and set the valid config to have it hidden on the builder (since added using the search tool). 

## Tests

Locally. 

## Risk

Can be rolled back. 

## Deploy Plan

Deploy front. 