### PR TITLE
[front] smaller send button in the input bar

### DIFF
--- a/front/components/assistant/conversation/input_bar/InputBarContainer.tsx
+++ b/front/components/assistant/conversation/input_bar/InputBarContainer.tsx
@@ -334,7 +334,7 @@ const InputBarContainer = ({
           )}
         </div>
         <Button
-          size="sm"
+          size="xs"
           isLoading={disableSendButton}
           icon={ArrowUpIcon}
           variant="highlight"


### PR DESCRIPTION
## Description
We should reduce the height of the input bar, and as a quick win we can already shrink the button from sm to xs and it feels so much nicer?? 

<img width="1512" height="858" alt="Screenshot 2025-08-08 at 07 18 39" src="https://github.com/user-attachments/assets/dbc8c42c-1b81-4e00-bae2-4fc7a1f09846" />

<img width="1509" height="854" alt="Screenshot 2025-08-08 at 07 18 47" src="https://github.com/user-attachments/assets/2fe28099-df85-4818-96f0-c16b61180dd5" />


<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
