### PR TITLE
DRY Agent Loop activities payload - Wave 1

### DIFF
--- a/front/temporal/agent_loop/activities/create_tool_actions.ts
+++ b/front/temporal/agent_loop/activities/create_tool_actions.ts
@@ -1,7 +1,4 @@
-import assert from "assert";
-
 import type {
-  ActionBaseParams,
   MCPActionType,
   MCPToolConfigurationType,
 } from "@app/lib/actions/mcp";
@@ -13,15 +10,14 @@ import type { AuthenticatorType } from "@app/lib/auth";
 import { Authenticator } from "@app/lib/auth";
 import type { AgentMCPAction } from "@app/lib/models/assistant/actions/mcp";
 import type { AgentMessage } from "@app/lib/models/assistant/conversation";
-import { AgentStepContentResource } from "@app/lib/resources/agent_step_content_resource";
 import { updateResourceAndPublishEvent } from "@app/temporal/agent_loop/activities/common";
+import { buildActionBaseParams } from "@app/temporal/agent_loop/lib/action_utils";
 import type {
   AgentActionsEvent,
   AgentConfigurationType,
   AgentMessageType,
   ModelId,
 } from "@app/types";
-import { isFunctionCallContent } from "@app/types/assistant/agent_message_content";
 import type { RunAgentArgs } from "@app/types/assistant/agent_run";
 import { getRunAgentData } from "@app/types/assistant/agent_run";
 
@@ -114,35 +110,15 @@ async function createActionForTool(
     step: number;
   }
 ): Promise<ActionBlob | void> {
-  // Fetch step content to derive inputs, functionCallId, and step.
-  const stepContent =
-    await AgentStepContentResource.fetchByModelId(stepContentId);
-  assert(
-    stepContent,
-    `Step content not found for stepContentId: ${stepContentId}`
-  );
-
-  if (!isFunctionCallContent(stepContent.value)) {
-    throw new Error(
-      `Expected step content to be a function call, got: ${stepContent.value.type}`
-    );
-  }
-
-  const rawInputs = JSON.parse(stepContent.value.value.arguments);
-  const { id: functionCallId } = stepContent.value.value;
-
-  const actionBaseParams: ActionBaseParams = {
+  const actionBaseParams = await buildActionBaseParams({
     agentMessageId: agentMessage.agentMessageId,
     citationsAllocated: stepContext.citationsCount,
-    functionCallId,
-    functionCallName: actionConfiguration.name,
-    generatedFiles: [],
     mcpServerConfigurationId: actionConfiguration.id.toString(),
-    params: rawInputs,
     step,
-  };
+    stepContentId,
+  });
 
-  const validateToolInputsResult = validateToolInputs(rawInputs);
+  const validateToolInputsResult = validateToolInputs(actionBaseParams.params);
   if (validateToolInputsResult.isErr()) {
     return updateResourceAndPublishEvent(
       {

--- a/front/temporal/agent_loop/activities/create_tool_actions.ts
+++ b/front/temporal/agent_loop/activities/create_tool_actions.ts
@@ -27,7 +27,6 @@ import { getRunAgentData } from "@app/types/assistant/agent_run";
 
 interface ActionBlob {
   action: AgentMCPAction;
-  actionBaseParams: ActionBaseParams;
   actionConfiguration: MCPToolConfigurationType;
   mcpAction: MCPActionType;
   needsApproval: boolean;
@@ -231,7 +230,6 @@ async function createActionForTool(
 
   return {
     action: agentMCPAction,
-    actionBaseParams,
     actionConfiguration,
     mcpAction,
     needsApproval: status === "pending",

--- a/front/temporal/agent_loop/activities/run_tool.ts
+++ b/front/temporal/agent_loop/activities/run_tool.ts
@@ -12,6 +12,7 @@ import { Authenticator } from "@app/lib/auth";
 import { AgentMCPAction } from "@app/lib/models/assistant/actions/mcp";
 import { updateResourceAndPublishEvent } from "@app/temporal/agent_loop/activities/common";
 import { sliceConversationForAgentMessage } from "@app/temporal/agent_loop/lib/loop_utils";
+import type { ModelId } from "@app/types";
 import { assertNever } from "@app/types";
 import type { RunAgentArgs } from "@app/types/assistant/agent_run";
 import { getRunAgentData } from "@app/types/assistant/agent_run";
@@ -19,7 +20,7 @@ import { getRunAgentData } from "@app/types/assistant/agent_run";
 export async function runToolActivity(
   authType: AuthenticatorType,
   {
-    rawAction,
+    actionId,
     actionBaseParams,
     actionConfiguration,
     rawMcpAction,
@@ -27,7 +28,7 @@ export async function runToolActivity(
     step,
     stepContext,
   }: {
-    rawAction: AgentMCPAction;
+    actionId: ModelId;
     actionBaseParams: ActionBaseParams;
     actionConfiguration: MCPToolConfigurationType;
     rawMcpAction: MCPActionType;
@@ -65,7 +66,7 @@ export async function runToolActivity(
 
   // Temporal activity arguments are serialized as JSON, so we need to deserialize them.
   const mcpAction = new MCPActionType(rawMcpAction);
-  const action = await AgentMCPAction.findByPk(rawAction.id);
+  const action = await AgentMCPAction.findByPk(actionId);
   assert(action, "Action not found");
 
   const eventStream = runToolWithStreaming(auth, actionConfiguration, {

--- a/front/temporal/agent_loop/lib/action_utils.ts
+++ b/front/temporal/agent_loop/lib/action_utils.ts
@@ -1,0 +1,54 @@
+import assert from "assert";
+
+import type { ActionBaseParams } from "@app/lib/actions/mcp";
+import { AgentStepContentResource } from "@app/lib/resources/agent_step_content_resource";
+import type { ModelId } from "@app/types";
+import { isFunctionCallContent } from "@app/types/assistant/agent_message_content";
+
+// TODO(DURABLE-AGENTS 2025-08-08): Clean up once we have full DRY the activities.
+
+/**
+ * Builds ActionBaseParams from stepContentId and action data.
+ */
+export async function buildActionBaseParams({
+  agentMessageId,
+  citationsAllocated,
+  mcpServerConfigurationId,
+  step,
+  stepContentId,
+}: {
+  agentMessageId: number;
+  citationsAllocated: number;
+  mcpServerConfigurationId: string;
+  step: number;
+  stepContentId: ModelId;
+}): Promise<ActionBaseParams> {
+  // Fetch and validate step content.
+  const stepContent =
+    await AgentStepContentResource.fetchByModelId(stepContentId);
+  assert(
+    stepContent,
+    `Step content not found for stepContentId: ${stepContentId}`
+  );
+
+  if (!isFunctionCallContent(stepContent.value)) {
+    throw new Error(
+      `Expected step content to be a function call, got: ${stepContent.value.type}`
+    );
+  }
+
+  const rawInputs = JSON.parse(stepContent.value.value.arguments);
+  const { id: functionCallId, name: functionCallName } =
+    stepContent.value.value;
+
+  return {
+    agentMessageId,
+    citationsAllocated,
+    functionCallId,
+    functionCallName,
+    generatedFiles: [],
+    mcpServerConfigurationId,
+    params: rawInputs,
+    step,
+  };
+}

--- a/front/temporal/agent_loop/lib/agent_loop_executor.ts
+++ b/front/temporal/agent_loop/lib/agent_loop_executor.ts
@@ -68,8 +68,8 @@ export async function executeAgentLoop(
       actionBlobs.map(
         ({ action, actionBaseParams, actionConfiguration, mcpAction }, index) =>
           activities.runToolActivity(authType, {
+            actionId: action.id,
             runAgentArgs,
-            rawAction: action,
             actionBaseParams,
             actionConfiguration,
             rawMcpAction: mcpAction,

--- a/front/temporal/agent_loop/lib/agent_loop_executor.ts
+++ b/front/temporal/agent_loop/lib/agent_loop_executor.ts
@@ -65,17 +65,15 @@ export async function executeAgentLoop(
 
     // Execute tools.
     await Promise.all(
-      actionBlobs.map(
-        ({ action, actionBaseParams, actionConfiguration, mcpAction }, index) =>
-          activities.runToolActivity(authType, {
-            actionId: action.id,
-            runAgentArgs,
-            actionBaseParams,
-            actionConfiguration,
-            rawMcpAction: mcpAction,
-            step: i,
-            stepContext: stepContexts[index],
-          })
+      actionBlobs.map(({ action, actionConfiguration, mcpAction }, index) =>
+        activities.runToolActivity(authType, {
+          actionId: action.id,
+          runAgentArgs,
+          actionConfiguration,
+          rawMcpAction: mcpAction,
+          step: i,
+          stepContext: stepContexts[index],
+        })
       )
     );
   }


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
Paving the way towards breaking the agentic loop when at least one action requires a tool validation. This PR dries the activities payload that needs to be passed to ensure that we can safely break and resume the step. It's currently unachievable since we rely extensively on big payload that exclusively lives in memory.

This first PR focuses around avoiding to pass the whole `agentMcpAction` and remove the `actionBaseParams`. Those two objects will be retrieved from the DB. It adds extra DB calls, but pretty negligible as those query rows on primary key. Will still keep an eye around latency.

⚠️ This is not the end state but a temporary step to bring us in a better shape! 

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
