### PR TITLE
[connectors] slack: Add retries in autojoin

### DIFF
--- a/connectors/src/connectors/slack/auto_read_channel.ts
+++ b/connectors/src/connectors/slack/auto_read_channel.ts
@@ -18,7 +18,7 @@ import { SlackChannel } from "@connectors/lib/models/slack";
 import type { Logger } from "@connectors/logger/logger";
 import { ConnectorResource } from "@connectors/resources/connector_resource";
 import { SlackConfigurationResource } from "@connectors/resources/slack_configuration_resource";
-import type { SlackAutoReadPattern } from "@connectors/types";
+import type { ModelId, SlackAutoReadPattern } from "@connectors/types";
 import { INTERNAL_MIME_TYPES, withRetries } from "@connectors/types";
 
 export function findMatchingChannelPatterns(

--- a/connectors/src/connectors/slack/auto_read_channel.ts
+++ b/connectors/src/connectors/slack/auto_read_channel.ts
@@ -186,11 +186,7 @@ export async function autoReadChannel(
 
           const [dataSourceView] = searchRes.value;
 
-          if (
-            !dataSourceView ||
-            dataSourceView.spaceId !== p.spaceId ||
-            dataSourceView.dataSource.sId !== connector.dataSourceId
-          ) {
+          if (!dataSourceView) {
             logger.error({
               connectorId,
               channelId: slackChannelId,

--- a/connectors/src/connectors/slack/auto_read_channel.ts
+++ b/connectors/src/connectors/slack/auto_read_channel.ts
@@ -1,7 +1,10 @@
 import type { ConnectorProvider, Result } from "@dust-tt/client";
 import { DustAPI, Err, Ok } from "@dust-tt/client";
 
-import { joinChannel } from "@connectors/connectors/slack/lib/channels";
+import {
+  joinChannel,
+  joinChannelWithRetries,
+} from "@connectors/connectors/slack/lib/channels";
 import {
   getSlackClient,
   reportSlackUsage,
@@ -95,7 +98,10 @@ export async function autoReadChannel(
       const joinChannelRes = await withRetries(
         logger,
         async (connectorId: ModelId, slackChannelId: string) => {
-          const result = await joinChannel(connectorId, slackChannelId);
+          const result = await joinChannelWithRetries(
+            connectorId,
+            slackChannelId
+          );
           if (result.isErr()) {
             // Retry on any error, not just rate limit errors
             throw result.error; // This will trigger a retry

--- a/connectors/src/connectors/slack/auto_read_channel.ts
+++ b/connectors/src/connectors/slack/auto_read_channel.ts
@@ -181,11 +181,16 @@ export async function autoReadChannel(
               error: searchRes.error.message,
             });
 
-            return new Err(new Error("Failed to join Slack channel in Dust."));
+            throw new Error("Failed to join Slack channel in Dust.");
           }
 
           const [dataSourceView] = searchRes.value;
-          if (!dataSourceView) {
+
+          if (
+            !dataSourceView ||
+            dataSourceView.spaceId !== p.spaceId ||
+            dataSourceView.dataSource.sId !== connector.dataSourceId
+          ) {
             logger.error({
               connectorId,
               channelId: slackChannelId,
@@ -193,9 +198,7 @@ export async function autoReadChannel(
                 "Failed to join Slack channel, there was an issue retrieving dataSourceViews",
             });
 
-            return new Err(
-              new Error("There was an issue retrieving dataSourceViews")
-            );
+            throw new Error("There was an issue retrieving dataSourceViews");
           }
 
           const updateDataSourceViewRes = await dustAPI.patchDataSourceView(
@@ -216,10 +219,8 @@ export async function autoReadChannel(
               channelId: slackChannelId,
               error: updateDataSourceViewRes.error.message,
             });
-            return new Err(
-              new Error(
-                `Failed to update Slack data source view for space ${p.spaceId}.`
-              )
+            throw new Error(
+              `Failed to update Slack data source view for space ${p.spaceId}.`
             );
           }
 

--- a/connectors/src/connectors/slack/auto_read_channel.ts
+++ b/connectors/src/connectors/slack/auto_read_channel.ts
@@ -239,6 +239,7 @@ export async function autoReadChannel(
         } catch (e) {
           return new Err(normalizeError(e));
         }
+
         return new Ok(true);
       },
       { concurrency: 5 }

--- a/connectors/src/connectors/slack/index.ts
+++ b/connectors/src/connectors/slack/index.ts
@@ -20,6 +20,7 @@ import { getBotEnabled } from "@connectors/connectors/slack/bot";
 import {
   getChannels,
   joinChannel,
+  joinChannelWithRetries,
 } from "@connectors/connectors/slack/lib/channels";
 import { slackConfig } from "@connectors/connectors/slack/lib/config";
 import { retrievePermissions } from "@connectors/connectors/slack/lib/retrieve_permissions";
@@ -370,7 +371,10 @@ export class SlackConnectorManager extends BaseConnectorManager<SlackConfigurati
         const slackChannelId = slackChannelIdFromInternalId(internalId);
         let channel = channels[slackChannelId];
         if (!channel) {
-          const joinRes = await joinChannel(this.connectorId, slackChannelId);
+          const joinRes = await joinChannelWithRetries(
+            this.connectorId,
+            slackChannelId
+          );
           if (joinRes.isErr()) {
             return new Err(joinRes.error);
           }
@@ -411,7 +415,7 @@ export class SlackConnectorManager extends BaseConnectorManager<SlackConfigurati
             ) {
               // handle read permission enabled
               slackChannelsToSync.push(channel.slackChannelId);
-              const joinChannelRes = await joinChannel(
+              const joinChannelRes = await joinChannelWithRetries(
                 this.connectorId,
                 channel.slackChannelId
               );

--- a/connectors/src/connectors/slack/index.ts
+++ b/connectors/src/connectors/slack/index.ts
@@ -19,7 +19,6 @@ import {
 import { getBotEnabled } from "@connectors/connectors/slack/bot";
 import {
   getChannels,
-  joinChannel,
   joinChannelWithRetries,
 } from "@connectors/connectors/slack/lib/channels";
 import { slackConfig } from "@connectors/connectors/slack/lib/config";

--- a/connectors/src/connectors/slack/lib/channels.ts
+++ b/connectors/src/connectors/slack/lib/channels.ts
@@ -497,24 +497,10 @@ export async function migrateChannelsFromLegacyBotToNewBot(
     const { id: channelId } = channel;
 
     // Join the new bot to the channel. Wrap with retries to handle rate limits.
-    const joinRes = await withRetries(
-      childLogger,
-      async (slackBotConnectorId: ModelId, channelId: string) => {
-        const joinRes = await joinChannelWithRetries(
-          slackBotConnectorId,
-          channelId
-        );
-        if (joinRes.isErr()) {
-          throw joinRes.error;
-        }
-
-        return joinRes;
-      },
-      {
-        retries: 10,
-        delayBetweenRetriesMs: 10000,
-      }
-    )(slackBotConnector.id, channelId);
+    const joinRes = await joinChannelWithRetries(
+      slackBotConnector.id,
+      channelId
+    );
 
     if (joinRes.isErr()) {
       childLogger.error(

--- a/connectors/src/connectors/slack/lib/channels.ts
+++ b/connectors/src/connectors/slack/lib/channels.ts
@@ -17,8 +17,7 @@ import { SlackChannel } from "@connectors/lib/models/slack";
 import logger from "@connectors/logger/logger";
 import { ConnectorResource } from "@connectors/resources/connector_resource";
 import { SlackConfigurationResource } from "@connectors/resources/slack_configuration_resource";
-import type { ConnectorPermission } from "@connectors/types";
-import type { ModelId } from "@connectors/types";
+import type { ConnectorPermission, ModelId } from "@connectors/types";
 import {
   cacheWithRedis,
   INTERNAL_MIME_TYPES,

--- a/connectors/src/connectors/slack/lib/cli.ts
+++ b/connectors/src/connectors/slack/lib/cli.ts
@@ -390,14 +390,14 @@ export const slack = async ({
           continue;
         }
 
-        logger.info({ channel }, "Processing channel");
+        logger.info({ channelName: channel.name }, "Processing channel");
 
         const matchingPatterns = findMatchingChannelPatterns(
           channel.name,
           autoReadChannelPatterns
         );
         if (matchingPatterns.length === 0) {
-          logger.info({ channel }, "No match, skipping");
+          logger.info({ channelName: channel.name }, "No match, skipping");
           continue;
         }
 

--- a/front/lib/resources/data_source_view_resource.ts
+++ b/front/lib/resources/data_source_view_resource.ts
@@ -467,10 +467,12 @@ export class DataSourceViewResource extends ResourceWithSpace<DataSourceViewMode
         switch (key) {
           case "dataSourceId":
           case "vaultId":
-            const vaultModelId = getResourceIdFromSId(value);
+            const resourceModelId = getResourceIdFromSId(value);
 
-            if (vaultModelId) {
-              whereClause[key] = vaultModelId;
+            if (resourceModelId) {
+              whereClause[key] = resourceModelId;
+            } else {
+              return [];
             }
             break;
 


### PR DESCRIPTION
## Description

- Add retry around joinChannel for rate limit
- Add retry around joining datsSourceView to wait for dataSource node to be indexed

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

deploy connectors
