### PR TITLE
[connectors] Fix DD metric `zendesk_api.requests.count` by normalizing endpoint tag

### DIFF
--- a/connectors/src/connectors/zendesk/lib/zendesk_api.ts
+++ b/connectors/src/connectors/zendesk/lib/zendesk_api.ts
@@ -27,16 +27,18 @@ const ZENDESK_RATE_LIMIT_TIMEOUT_SECONDS = 60;
 const ZENDESK_TICKET_PAGE_SIZE = 300;
 const ZENDESK_COMMENT_PAGE_SIZE = 100;
 
+const ZENDESK_URL_REGEX = /^https?:\/\/(.*)\.zendesk\.com([^?]*).*/;
+const ZENDESK_ENDPOINT_REGEX = /\/([a-zA-Z_]+)\/(\d+)/g;
+
 function extractMetadataFromZendeskUrl(url: string): {
   subdomain: string;
   endpoint: string;
 } {
-  const regex = /^https?:\/\/(.*)\.zendesk\.com([^?]*).*/;
-  const rawEndpoint = url.replace(regex, "$2");
+  const rawEndpoint = url.replace(ZENDESK_URL_REGEX, "$2");
 
   // Replace numeric IDs with placeholders using the first letter of the previous word.
   const normalizedEndpoint = rawEndpoint.replace(
-    /\/([a-zA-Z_]+)\/(\d+)/g,
+    ZENDESK_ENDPOINT_REGEX,
     (_, word) => {
       const firstLetter = word.charAt(0).toLowerCase();
       return `/${word}/{${firstLetter}Id}`;
@@ -44,7 +46,7 @@ function extractMetadataFromZendeskUrl(url: string): {
   );
 
   return {
-    subdomain: url.replace(regex, "$1"),
+    subdomain: url.replace(ZENDESK_URL_REGEX, "$1"),
     endpoint: normalizedEndpoint,
   };
 }

--- a/connectors/src/connectors/zendesk/lib/zendesk_api.ts
+++ b/connectors/src/connectors/zendesk/lib/zendesk_api.ts
@@ -32,9 +32,14 @@ function extractMetadataFromZendeskUrl(url: string): {
   endpoint: string;
 } {
   const regex = /^https?:\/\/(.*)\.zendesk\.com([^?]*).*/;
+  const rawEndpoint = url.replace(regex, "$2");
+
+  // Replace numeric IDs with placeholders to normalize endpoints.
+  const normalizedEndpoint = rawEndpoint.replace(/\/\d+/g, "/{id}");
+
   return {
     subdomain: url.replace(regex, "$1"),
-    endpoint: url.replace(regex, "$2"),
+    endpoint: normalizedEndpoint,
   };
 }
 

--- a/connectors/src/connectors/zendesk/lib/zendesk_api.ts
+++ b/connectors/src/connectors/zendesk/lib/zendesk_api.ts
@@ -34,8 +34,14 @@ function extractMetadataFromZendeskUrl(url: string): {
   const regex = /^https?:\/\/(.*)\.zendesk\.com([^?]*).*/;
   const rawEndpoint = url.replace(regex, "$2");
 
-  // Replace numeric IDs with placeholders to normalize endpoints.
-  const normalizedEndpoint = rawEndpoint.replace(/\/\d+/g, "/{id}");
+  // Replace numeric IDs with placeholders using the first letter of the previous word.
+  const normalizedEndpoint = rawEndpoint.replace(
+    /\/([a-zA-Z_]+)\/(\d+)/g,
+    (_, word) => {
+      const firstLetter = word.charAt(0).toLowerCase();
+      return `/${word}/{${firstLetter}Id}`;
+    }
+  );
 
   return {
     subdomain: url.replace(regex, "$1"),


### PR DESCRIPTION
## Description

- This PR reduces the cardinality of the [`zendesk_api.requests.count`](https://app.datadoghq.eu/metric/summary?filter=zendesk_api.requests.count&from-usage=true) by normalizing the value of the `endpoint` tag, replacing IDs (all IDs are numeric in Zendesk) with placeholders: `/api/v2/tickets/123` → `/api/v2/tickets/{tId}`.

## Tests

- Checked the behavior of `extractMetadataFromZendeskUrl` locally.

## Risk

- Low.

## Deploy Plan

- Deploy connectors.
