### PR TITLE
[front] - fix(AB v2): MCPServerSelectionPage tabs

### DIFF
--- a/front/components/agent_builder/capabilities/mcp/MCPServerSelectionPage.tsx
+++ b/front/components/agent_builder/capabilities/mcp/MCPServerSelectionPage.tsx
@@ -28,6 +28,84 @@ const McpServerViewTypeMatch: Record<
   "Other tools": ["remote"],
 };
 
+interface DataVisualizationCardProps {
+  dataVisualization: ActionSpecification;
+  onDataVisualizationClick: () => void;
+  isSelected: boolean;
+}
+
+function DataVisualizationCard({
+  dataVisualization,
+  onDataVisualizationClick,
+  isSelected,
+}: DataVisualizationCardProps) {
+  return (
+    <Card
+      variant="primary"
+      disabled={isSelected}
+      onClick={isSelected ? undefined : onDataVisualizationClick}
+    >
+      <div className="flex w-full flex-col gap-1 text-sm">
+        <div className="mb-2 flex items-center gap-2">
+          <Avatar
+            icon={DATA_VISUALIZATION_SPECIFICATION.dropDownIcon}
+            size="sm"
+          />
+          <span className="text-sm font-medium">{dataVisualization.label}</span>
+          {isSelected && <Chip size="xs" color="green" label="ADDED" />}
+        </div>
+        <div className="line-clamp-2 w-full text-xs text-gray-600">
+          {dataVisualization.description}
+        </div>
+        <div>
+          {!isSelected && (
+            <Button size="xs" variant="outline" icon={PlusIcon} label="Add" />
+          )}
+        </div>
+      </div>
+    </Card>
+  );
+}
+
+interface MCPServerCardProps {
+  view: MCPServerViewTypeWithLabel;
+  onItemClick: (mcpServerView: MCPServerViewType) => void;
+  isSelected: boolean;
+}
+
+function MCPServerCard({ view, onItemClick, isSelected }: MCPServerCardProps) {
+  return (
+    <Card
+      variant={isSelected ? "secondary" : "primary"}
+      onClick={isSelected ? undefined : () => onItemClick(view)}
+      disabled={isSelected}
+    >
+      <div className="flex w-full flex-col gap-1 text-sm">
+        <div className="mb-2 flex items-center gap-2">
+          <Icon
+            visual={
+              isCustomServerIconType(view.server.icon)
+                ? ActionIcons[view.server.icon]
+                : InternalActionIcons[view.server.icon] || BookOpenIcon
+            }
+            size="sm"
+          />
+          <span className="text-sm font-medium">{view.label}</span>
+          {isSelected && <Chip size="xs" color="green" label="ADDED" />}
+        </div>
+        <div className="line-clamp-2 w-full text-xs text-gray-600">
+          {getMcpServerViewDescription(view)}
+        </div>
+        <div>
+          {!isSelected && (
+            <Button size="xs" variant="outline" icon={PlusIcon} label="Add" />
+          )}
+        </div>
+      </div>
+    </Card>
+  );
+}
+
 interface MCPServerSelectionPageProps {
   mcpServerViews: MCPServerViewTypeWithLabel[];
   onItemClick: (mcpServerView: MCPServerViewType) => void;
@@ -87,15 +165,15 @@ export function MCPServerSelectionPage({
 
       setShowDataVisualization(
         dataVisualization?.label.toLowerCase().includes(searchTermLower) ||
-          dataVisualization?.description
+          (dataVisualization?.description
             ?.toLowerCase()
-            .includes(searchTermLower) ||
+            .includes(searchTermLower) &&
+            serverTypeMatch.includes("internal")) ||
           false
       );
     } else {
-      setShowDataVisualization(true);
+      setShowDataVisualization(serverTypeMatch.includes("internal"));
     }
-
     setFilteredServerViews(filtered);
   };
 
@@ -111,6 +189,14 @@ export function MCPServerSelectionPage({
 
   const isDataVisualizationSelected = selectedToolsInDialog.some(
     (tool) => tool.type === "DATA_VISUALIZATION"
+  );
+
+  const internalFilteredServerViews = filteredServerViews.filter(
+    (view) => view.serverType === "internal"
+  );
+
+  const remoteFilteredServerViews = filteredServerViews.filter(
+    (view) => view.serverType === "remote"
   );
 
   return (
@@ -131,92 +217,51 @@ export function MCPServerSelectionPage({
           />
         ))}
       </div>
-      <h2 className="text-lg font-semibold">Capabilities</h2>
-      <div className="grid grid-cols-2 gap-4">
-        {dataVisualization &&
+      {/* Capabilities Section - Internal servers only */}
+      {(internalFilteredServerViews.length > 0 ||
+        (dataVisualization &&
           onDataVisualizationClick &&
-          showDataVisualization && (
-            <Card
-              key="data-visualization"
-              variant="primary"
-              disabled={isDataVisualizationSelected}
-              onClick={
-                isDataVisualizationSelected
-                  ? undefined
-                  : onDataVisualizationClick
-              }
-            >
-              <div className="flex w-full flex-col gap-1 text-sm">
-                <div className="mb-2 flex items-center gap-2">
-                  <Avatar
-                    icon={DATA_VISUALIZATION_SPECIFICATION.dropDownIcon}
-                    size="sm"
-                  />
-                  <span className="text-sm font-medium">
-                    {dataVisualization.label}
-                  </span>
-                  {isDataVisualizationSelected && (
-                    <Chip size="xs" color="green" label="ADDED" />
-                  )}
-                </div>
-                <div className="line-clamp-2 w-full text-xs text-gray-600">
-                  {dataVisualization.description}
-                </div>
-                <div>
-                  {!isDataVisualizationSelected && (
-                    <Button
-                      size="xs"
-                      variant="outline"
-                      icon={PlusIcon}
-                      label="Add"
-                    />
-                  )}
-                </div>
-              </div>
-            </Card>
-          )}
-        {filteredServerViews.map((view) => {
-          const isSelectedInDialog = selectedMCPIds.has(view.sId);
-          return (
-            <Card
-              key={view.id}
-              variant={isSelectedInDialog ? "secondary" : "primary"}
-              onClick={isSelectedInDialog ? undefined : () => onItemClick(view)}
-              disabled={isSelectedInDialog}
-            >
-              <div className="flex w-full flex-col gap-1 text-sm">
-                <div className="mb-2 flex items-center gap-2">
-                  <Icon
-                    visual={
-                      isCustomServerIconType(view.server.icon)
-                        ? ActionIcons[view.server.icon]
-                        : InternalActionIcons[view.server.icon] || BookOpenIcon
-                    }
-                    size="sm"
-                  />
-                  <span className="text-sm font-medium">{view.label}</span>
-                  {isSelectedInDialog && (
-                    <Chip size="xs" color="green" label="ADDED" />
-                  )}
-                </div>
-                <div className="line-clamp-2 w-full text-xs text-gray-600">
-                  {getMcpServerViewDescription(view)}
-                </div>
-                <div>
-                  {!isSelectedInDialog && (
-                    <Button
-                      size="xs"
-                      variant="outline"
-                      icon={PlusIcon}
-                      label="Add"
-                    />
-                  )}
-                </div>
-              </div>
-            </Card>
-          );
-        })}
-      </div>
+          showDataVisualization)) && (
+        <>
+          <h2 className="text-lg font-semibold">Capabilities</h2>
+          <div className="grid grid-cols-2 gap-4">
+            {dataVisualization &&
+              onDataVisualizationClick &&
+              showDataVisualization && (
+                <DataVisualizationCard
+                  dataVisualization={dataVisualization}
+                  onDataVisualizationClick={onDataVisualizationClick}
+                  isSelected={isDataVisualizationSelected}
+                />
+              )}
+            {internalFilteredServerViews.map((view) => (
+              <MCPServerCard
+                key={view.id}
+                view={view}
+                onItemClick={onItemClick}
+                isSelected={selectedMCPIds.has(view.sId)}
+              />
+            ))}
+          </div>
+        </>
+      )}
+
+      {/* Other tools Section - Remote servers only */}
+      {remoteFilteredServerViews.length > 0 && (
+        <>
+          <h2 className="text-lg font-semibold">Other tools</h2>
+          <div className="grid grid-cols-2 gap-4">
+            {remoteFilteredServerViews.map((view) => (
+              <MCPServerCard
+                key={view.id}
+                view={view}
+                onItemClick={onItemClick}
+                isSelected={selectedMCPIds.has(view.sId)}
+              />
+            ))}
+          </div>
+        </>
+      )}
 
       {selectedToolsInDialog.length > 0 && (
         <div className="space-y-3">


### PR DESCRIPTION
## Description

This PR refactors the MCPServerSelectionPage component to better organize server selection cards and filter logic. The changes extract server selection card components for improved maintainability and update the filtering logic to properly separate internal and remote server cards based on search terms and server types.

## Tests

Locally

## Risk

Low

## Deploy Plan

Deploy front