### PR TITLE
Store agumented inputs on AgentMCPAction

### DIFF
--- a/front/lib/actions/mcp.ts
+++ b/front/lib/actions/mcp.ts
@@ -485,12 +485,8 @@ export async function* runToolWithStreaming(
     return;
   }
 
-  // We put back the preconfigured inputs (data sources for instance) from the agent configuration if any.
-  const inputs = getAugmentedInputs({
-    auth,
-    rawInputs: actionBaseParams.params,
-    actionConfiguration,
-  });
+  // Use the augmented inputs that were computed and stored during action creation
+  const inputs = action.augmentedInputs;
 
   const agentLoopRunContext: AgentLoopRunContextType = {
     actionConfiguration,
@@ -615,23 +611,26 @@ export async function createMCPAction(
   auth: Authenticator,
   {
     actionBaseParams,
+    augmentedInputs,
     stepContentId,
     stepContext,
   }: {
     actionBaseParams: ActionBaseParams;
+    augmentedInputs: Record<string, unknown>;
     stepContentId: ModelId;
     stepContext: StepContext;
   }
 ): Promise<{ action: AgentMCPAction; mcpAction: MCPActionType }> {
   const action = await AgentMCPAction.create({
     agentMessageId: actionBaseParams.agentMessageId,
-    mcpServerConfigurationId: actionBaseParams.mcpServerConfigurationId,
-    workspaceId: auth.getNonNullableWorkspace().id,
-    isError: false,
-    executionState: "pending",
-    version: 0,
-    stepContentId,
+    augmentedInputs,
     citationsAllocated: stepContext.citationsCount,
+    executionState: "pending",
+    isError: false,
+    mcpServerConfigurationId: actionBaseParams.mcpServerConfigurationId,
+    stepContentId,
+    version: 0,
+    workspaceId: auth.getNonNullableWorkspace().id,
   });
 
   const mcpAction = new MCPActionType({

--- a/front/lib/actions/mcp.ts
+++ b/front/lib/actions/mcp.ts
@@ -9,7 +9,6 @@ import type {
 import { MCPServerPersonalAuthenticationRequiredError } from "@app/lib/actions/mcp_authentication";
 import {
   executeMCPTool,
-  getAugmentedInputs,
   handleToolApproval,
   processToolResults,
 } from "@app/lib/actions/mcp_execution";

--- a/front/lib/models/assistant/actions/mcp.ts
+++ b/front/lib/models/assistant/actions/mcp.ts
@@ -196,6 +196,7 @@ export class AgentMCPAction extends WorkspaceAwareModel<AgentMCPAction> {
     | "denied";
 
   declare citationsAllocated: number;
+  declare augmentedInputs: Record<string, unknown>;
 
   declare outputItems: NonAttribute<AgentMCPActionOutputItem[]>;
   declare agentMessage?: NonAttribute<AgentMessage>;
@@ -246,6 +247,11 @@ AgentMCPAction.init(
       type: DataTypes.INTEGER,
       allowNull: false,
       defaultValue: 0,
+    },
+    augmentedInputs: {
+      type: DataTypes.JSONB,
+      allowNull: false,
+      defaultValue: {},
     },
   },
   {

--- a/front/migrations/db/migration_331.sql
+++ b/front/migrations/db/migration_331.sql
@@ -1,0 +1,2 @@
+-- Migration created on Aug 08, 2025
+ALTER TABLE "public"."agent_mcp_actions" ADD COLUMN "augmentedInputs" JSONB NOT NULL DEFAULT '{}';

--- a/front/temporal/agent_loop/activities/create_tool_actions.ts
+++ b/front/temporal/agent_loop/activities/create_tool_actions.ts
@@ -1,5 +1,6 @@
 import type { MCPToolConfigurationType } from "@app/lib/actions/mcp";
 import { createMCPAction } from "@app/lib/actions/mcp";
+import { getAugmentedInputs } from "@app/lib/actions/mcp_execution";
 import { validateToolInputs } from "@app/lib/actions/mcp_utils";
 import type { StepContext } from "@app/lib/actions/types";
 import { getExecutionStatusFromConfig } from "@app/lib/actions/utils";
@@ -136,11 +137,19 @@ async function createActionForTool(
     );
   }
 
+  // Compute augmented inputs with preconfigured data sources, etc.
+  const augmentedInputs = getAugmentedInputs({
+    auth,
+    rawInputs: actionBaseParams.params,
+    actionConfiguration,
+  });
+
   // Create the action object in the database and yield an event for the generation of the params.
   // We store the action here as the params have been generated, if an error occurs later on,
   // the error will be stored on the parent agent message.
   const { action: agentMCPAction, mcpAction } = await createMCPAction(auth, {
     actionBaseParams,
+    augmentedInputs,
     stepContentId,
     stepContext,
   });

--- a/front/temporal/relocation/lib/sql/insert.ts
+++ b/front/temporal/relocation/lib/sql/insert.ts
@@ -8,6 +8,10 @@ const JSONB_COLUMNS = [
     tableName: "agent_configurations",
     columns: ["responseFormat"],
   },
+  {
+    tableName: "agent_mcp_actions",
+    columns: ["augmentedInputs"],
+  },
 ];
 
 export function generateParameterizedInsertStatements(


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
To be able to resume the agent loop once actions have been approved we need to DRY parameters that are being passed through all the activities. One of the last item that needs to be removed is `actionConfiguration`. This attributes is primarily used to:
- augment the inputs with our internal mime types (e.g: data sources, ...)
- store the "always approved" answer from a user for this specific tool
- get the connection params (we can use a lighter type here)
- override the tool timeout (we can use a lighter type here)

This PR focuses on the augment inputs needs, we add a new column in the existing `agent_mcp_actions` data model so we can augment the inputs in the `createToolActionsActivity` and retrieve them from the DB in the `runToolWithStreaming`. 

I thought about augmenting directly `agent_step_content` but this one data model is used to render the conversation to the model and we definitely don't want to expose any internal logic out there.

⚠️ There is no plan to backfill the augmented inputs of the already ran actions.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

- [ ] Run the SQL migration
- [ ] Deploy front