### PR TITLE
enh: add markdown meta prompt on o3 and gpt5

### DIFF
--- a/front/lib/api/assistant/generation.ts
+++ b/front/lib/api/assistant/generation.ts
@@ -80,6 +80,10 @@ export async function constructPromptMultiActions(
     }
   }
 
+  if (model.formattingMetaPrompt) {
+    context += `# RESPONSE FORMAT\n${model.formattingMetaPrompt}\n`;
+  }
+
   if (errorContext) {
     context +=
       "\n\n # INSTRUCTIONS ERROR\n\nNote: There was an error while building instructions:\n" +

--- a/front/types/assistant/assistant.ts
+++ b/front/types/assistant/assistant.ts
@@ -309,6 +309,9 @@ export type ModelConfigurationType = {
   // This meta-prompt is injected into the agent's system instructions if the agent is in a native reasoning context (reasoning effort >= medium).
   nativeReasoningMetaPrompt?: string;
 
+  // This meta-prompt is always injected into the agent's system instructions.
+  formattingMetaPrompt?: string;
+
   // Adjust the token count estimation by a ratio. Only needed for anthropic models, where the token count is higher than our estimate
   tokenCountAdjustment?: number;
 
@@ -466,6 +469,20 @@ export const GPT_4O_MINI_MODEL_CONFIG: ModelConfigurationType = {
   defaultReasoningEffort: "none",
   supportsResponseFormat: false,
 };
+
+const OPENAI_FORMATTING_META_PROMPT = `# Response Formats
+SYSTEM STYLE: Rich Markdown by default
+- Always respond using rich Markdown unless the user explicitly requests another format.
+- Use H1 titles (# Title).
+- Organize content into sections with H2/H3 headings (##, ###). Favor paragraphs and subsections.
+- Use bullet/numbered lists sparingly and never as the sole structure of the response.
+- Include tables when they materially aid clarity; use code blocks for code, configs, or commands.
+- If the user specifies a different format, follow the user’s instructions.
+- When style directives conflict, prefer this Markdown style guide.
+NEVER:
+- Return a response that is just a list of bullet points.
+- Omit headings in multi-paragraph answers.`;
+
 export const GPT_5_MODEL_CONFIG: ModelConfigurationType = {
   providerId: "openai",
   modelId: GPT_5_MODEL_ID,
@@ -484,6 +501,7 @@ export const GPT_5_MODEL_CONFIG: ModelConfigurationType = {
   maximumReasoningEffort: "high",
   defaultReasoningEffort: "medium",
   supportsResponseFormat: true,
+  formattingMetaPrompt: OPENAI_FORMATTING_META_PROMPT,
 };
 export const O1_MODEL_CONFIG: ModelConfigurationType = {
   providerId: "openai",
@@ -549,6 +567,7 @@ export const O3_MODEL_CONFIG: ModelConfigurationType = {
   maximumReasoningEffort: "high",
   defaultReasoningEffort: "medium",
   supportsResponseFormat: true,
+  formattingMetaPrompt: OPENAI_FORMATTING_META_PROMPT,
 };
 
 export const O3_MINI_MODEL_CONFIG: ModelConfigurationType = {


### PR DESCRIPTION
## Description

OpenAI injects a prompt to discourage the model from using markdown when GPT-5 an o3 are used through the API.
This new meta prompt is successful at re-enabling the markdown formatting, without being excessively prescriptive.

Here's a comparison: https://dust.tt/w/0ec9852c2f/assistant/KV9Vbjlhb6
 
## Tests

Tested.

## Risk

Low

## Deploy Plan

Deploy front