### PR TITLE
[connectors,extension] Add missing event type

### DIFF
--- a/connectors/src/connectors/slack/chat/stream_conversation_handler.ts
+++ b/connectors/src/connectors/slack/chat/stream_conversation_handler.ts
@@ -192,6 +192,7 @@ async function streamAgentAnswerToSlack(
           )
         );
       }
+      case "tool_error":
       case "agent_error": {
         return new Err(
           new Error(

--- a/extension/ui/components/assistants/state/messageReducer.ts
+++ b/extension/ui/components/assistants/state/messageReducer.ts
@@ -7,6 +7,7 @@ import type {
   AgentMessagePublicType,
   AgentMessageSuccessEvent,
   GenerationTokensEvent,
+  ToolErrorEvent,
   ToolNotificationEvent,
   ToolNotificationProgress,
 } from "@dust-tt/client";
@@ -35,6 +36,7 @@ export type AgentMessageStateEvent =
   | AgentGenerationCancelledEvent
   | AgentMessageSuccessEvent
   | GenerationTokensEvent
+  | ToolErrorEvent
   | ToolNotificationEvent;
 
 type AgentMessageStateEventWithoutToolApproveExecution = Exclude<
@@ -99,6 +101,7 @@ export function messageReducer(
       return updateProgress(state, event);
     }
 
+    case "tool_error":
     case "agent_error":
       return {
         ...state,

--- a/front/lib/actions/mcp.ts
+++ b/front/lib/actions/mcp.ts
@@ -178,7 +178,6 @@ type MCPSuccessEvent = {
   action: MCPActionType;
 };
 
-// TODO(MCP 2025-05-06): Add action to the error event.
 type MCPErrorEvent = {
   type: "tool_error";
   created: number;

--- a/front/lib/actions/mcp.ts
+++ b/front/lib/actions/mcp.ts
@@ -187,7 +187,6 @@ type MCPErrorEvent = {
   error: {
     code: string;
     message: string;
-    // TODO(2025-07-22 aubin): make this non nullable (we can always pass an empty object).
     metadata: Record<string, string | number | boolean> | null;
   };
 };

--- a/sdks/js/src/index.ts
+++ b/sdks/js/src/index.ts
@@ -1,7 +1,7 @@
 import { createParser } from "eventsource-parser";
 import { z } from "zod";
 
-import type {
+import {
   AgentActionSpecificEvent,
   AgentActionSuccessEvent,
   AgentConfigurationViewType,
@@ -41,6 +41,7 @@ import type {
   PublicRegisterMCPRequestBody,
   RegisterMCPResponseType,
   SearchRequestBodyType,
+  ToolErrorEvent,
   UserMessageErrorEvent,
   ValidateActionRequestBodyType,
   ValidateActionResponseType,
@@ -99,12 +100,13 @@ const DEFAULT_MAX_RECONNECT_ATTEMPTS = 10;
 const DEFAULT_RECONNECT_DELAY = 5000;
 
 type AgentEvent =
-  | UserMessageErrorEvent
-  | AgentErrorEvent
+  | AgentActionSpecificEvent
   | AgentActionSuccessEvent
-  | GenerationTokensEvent
+  | AgentErrorEvent
   | AgentMessageSuccessEvent
-  | AgentActionSpecificEvent;
+  | GenerationTokensEvent
+  | UserMessageErrorEvent
+  | ToolErrorEvent;
 
 const textFromResponse = async (response: DustResponse): Promise<string> => {
   if (typeof response.body === "string") {

--- a/sdks/js/src/types.ts
+++ b/sdks/js/src/types.ts
@@ -1088,6 +1088,19 @@ const MCPApproveExecutionEventSchema = z.object({
   metadata: MCPValidationMetadataSchema,
 });
 
+const ToolErrorEventSchema = z.object({
+  type: z.literal("tool_error"),
+  created: z.number(),
+  configurationId: z.string(),
+  messageId: z.string(),
+  error: z.object({
+    code: z.string(),
+    message: z.string(),
+    metadata: z.record(z.any()).nullable(),
+  }),
+});
+export type ToolErrorEvent = z.infer<typeof ToolErrorEventSchema>;
+
 const AgentErrorEventSchema = z.object({
   type: z.literal("agent_error"),
   created: z.number(),


### PR DESCRIPTION
## Description

- The `tool_error` event type was added in front but not to the SDK, therefore not to the Slack bot nor the extension implemenetations.
- This PR adds the missing type, currently handling as `agent_errors`.

## Tests

- tsc

## Risk

- Low.

## Deploy Plan

- Deploy connectors.
- Publish new version of the extension.
