### PR TITLE
enh(gpt-5-global): keep search depth low by default

### DIFF
--- a/front/lib/api/assistant/global_agents/configurations/openai.ts
+++ b/front/lib/api/assistant/global_agents/configurations/openai.ts
@@ -160,7 +160,10 @@ export function _getGPT5GlobalAgent({
     versionAuthorId: null,
     name: metadata.name,
     description: metadata.description,
-    instructions: `${globalAgentGuidelines}\n${globalAgentWebSearchGuidelines}`,
+    instructions:
+      `${globalAgentGuidelines}\n${globalAgentWebSearchGuidelines}\n` +
+      "Unless the user explictly requests deeper research, keep the search depth low and" +
+      " aim to provide an answer quickly, with a maximum of 3 steps of tool use.",
     pictureUrl: metadata.pictureUrl,
     status,
     scope: "global",

--- a/front/lib/api/assistant/global_agents/configurations/openai.ts
+++ b/front/lib/api/assistant/global_agents/configurations/openai.ts
@@ -162,7 +162,7 @@ export function _getGPT5GlobalAgent({
     description: metadata.description,
     instructions:
       `${globalAgentGuidelines}\n${globalAgentWebSearchGuidelines}\n` +
-      "Unless the user explictly requests deeper research, keep the search depth low and" +
+      "Unless the user explicitly requests deeper research, keep the search depth low and" +
       " aim to provide an answer quickly, with a maximum of 3 steps of tool use.",
     pictureUrl: metadata.pictureUrl,
     status,


### PR DESCRIPTION
## Description

By default gpt5 medium does a lot of browsing, causing very slow answers

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
