### PR TITLE
[front] abv2: fix paste order of xml tags

### DIFF
--- a/front/components/agent_builder/instructions/InstructionBlockExtension.tsx
+++ b/front/components/agent_builder/instructions/InstructionBlockExtension.tsx
@@ -1,6 +1,7 @@
 import { InputRule, mergeAttributes, Node } from "@tiptap/core";
 import type { Node as ProseMirrorNode } from "@tiptap/pm/model";
 import type { Slice } from "@tiptap/pm/model";
+import { Fragment } from "@tiptap/pm/model";
 import { Plugin, PluginKey } from "@tiptap/pm/state";
 import { TextSelection } from "@tiptap/pm/state";
 import type { EditorView } from "@tiptap/pm/view";
@@ -188,12 +189,10 @@ export const InstructionBlockExtension =
                 }
               });
 
-              // Insert the nodes
+              // Insert all nodes at once to preserve order
               const { from } = state.selection;
-              nodes.forEach((node) => {
-                const pos = tr.mapping.map(from);
-                tr.insert(pos, node);
-              });
+              const fragment = Fragment.fromArray(nodes);
+              tr.insert(from, fragment);
 
               view.dispatch(tr);
               return true; // We handled the paste


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

When pasting instructions in the agent builder v2, the xml tags were pasted in the reverse order. We were pasting at the same position, which means that the later inserted was taking precedence.

To fix this, we create one big tip tap fragment from the ordered array and insert it all at once, so we preserve the order.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

Tested by hand.

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

Low risks

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->

Deploy front
