### PR TITLE
Move buttons at the bottom

### DIFF
--- a/front/components/assistant/conversation/input_bar/InputBarContainer.tsx
+++ b/front/components/assistant/conversation/input_bar/InputBarContainer.tsx
@@ -258,7 +258,7 @@ const InputBarContainer = ({
   return (
     <div
       id="InputBarContainer"
-      className="relative flex flex-1 cursor-text flex-col sm:flex-row sm:pt-0"
+      className="relative flex flex-1 cursor-text flex-col sm:pt-0"
     >
       <EditorContent
         editor={editor}
@@ -272,8 +272,8 @@ const InputBarContainer = ({
         )}
       />
 
-      <div className="flex flex-row items-end justify-between gap-2 self-stretch pb-3 pr-3 sm:flex-col sm:border-0">
-        <div className="flex items-center py-0 sm:py-3.5">
+      <div className="flex flex-row items-end justify-end gap-2 self-stretch pb-3 pr-3 sm:border-0">
+        <div className="flex items-center py-0">
           {actions.includes("tools") && featureFlags.includes("jit_tools") && (
             <ToolsPicker
               owner={owner}


### PR DESCRIPTION
## Description

Move the button at the bottom of the inputbar.
Note that it was already the case on mobile so I just had to remove the non-mobile classes and change to justify-end + a top padding that messed up with alignement.

## Tests

<img width="787" height="288" alt="image" src="https://github.com/user-attachments/assets/369b6604-cd51-4e4d-8e67-a4b054ed8923" />

<img width="345" height="354" alt="image" src="https://github.com/user-attachments/assets/2572ed48-e5d8-4846-b22c-f51aa47a581f" />

## Risk

Low

## Deploy Plan

Deploy front