### PR TITLE
[front] abv2: fix copy raw content of instructions

### DIFF
--- a/front/components/agent_builder/instructions/InstructionBlockExtension.tsx
+++ b/front/components/agent_builder/instructions/InstructionBlockExtension.tsx
@@ -141,6 +141,11 @@ export const InstructionBlockExtension =
           key: new PluginKey("instructionBlockAutoConvert"),
           props: {
             clipboardTextSerializer: (slice: Slice) => {
+              /**
+               * Serializes the content of the text slice into a string format.
+               * This is needed to handle copying the raw content of the XML
+               * instruction blocks and paragraphs correctly.
+               */
               const parts: string[] = [];
               for (let i = 0; i < slice.content.childCount; i++) {
                 const child = slice.content.child(i);

--- a/front/components/agent_builder/instructions/InstructionBlockExtension.tsx
+++ b/front/components/agent_builder/instructions/InstructionBlockExtension.tsx
@@ -140,6 +140,25 @@ export const InstructionBlockExtension =
         new Plugin({
           key: new PluginKey("instructionBlockAutoConvert"),
           props: {
+            clipboardTextSerializer: (slice: Slice) => {
+              const parts: string[] = [];
+              for (let i = 0; i < slice.content.childCount; i++) {
+                const child = slice.content.child(i);
+                if (child.type.name === this.name) {
+                  const type = (child.attrs as InstructionBlockAttributes).type;
+                  const inner = child.textBetween(0, child.content.size, "\n");
+                  parts.push(`<${type}>\n${inner}\n</${type}>`);
+                } else if (child.type.name === "paragraph") {
+                  parts.push(child.textContent);
+                } else if (child.isText) {
+                  parts.push(child.text || "");
+                } else {
+                  parts.push(child.textBetween(0, child.content.size, "\n"));
+                }
+                if (i < slice.content.childCount - 1) parts.push("\n");
+              }
+              return parts.join("");
+            },
             handlePaste: (
               view: EditorView,
               event: ClipboardEvent,

--- a/front/components/agent_builder/instructions/InstructionBlockExtension.tsx
+++ b/front/components/agent_builder/instructions/InstructionBlockExtension.tsx
@@ -160,7 +160,9 @@ export const InstructionBlockExtension =
                 } else {
                   parts.push(child.textBetween(0, child.content.size, "\n"));
                 }
-                if (i < slice.content.childCount - 1) parts.push("\n");
+                if (i < slice.content.childCount - 1) {
+                  parts.push("\n");
+                }
               }
               return parts.join("");
             },


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

When copying instructions that have XML tags, we don't copy the raw instrucitons but rather the cotnent of the tags. This PR aims at fixing that and allowing to copy the whole raw instrucitons.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

Tested by hand.

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

Low

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->

Deploy front