### PR TITLE
[connectors] Improve handling of personal authentication errors in Slack bot

### DIFF
--- a/connectors/src/connectors/slack/chat/stream_conversation_handler.ts
+++ b/connectors/src/connectors/slack/chat/stream_conversation_handler.ts
@@ -6,7 +6,13 @@ import type {
   Result,
   UserMessageType,
 } from "@dust-tt/client";
-import { assertNever, Err, Ok, TOOL_RUNNING_LABEL } from "@dust-tt/client";
+import {
+  assertNever,
+  Err,
+  isMCPServerPersonalAuthRequiredError,
+  Ok,
+  TOOL_RUNNING_LABEL,
+} from "@dust-tt/client";
 import type { ChatPostMessageResponse, WebClient } from "@slack/web-api";
 import * as t from "io-ts";
 import slackifyMarkdown from "slackify-markdown";
@@ -192,7 +198,30 @@ async function streamAgentAnswerToSlack(
           )
         );
       }
-      case "tool_error":
+      case "tool_error": {
+        if (isMCPServerPersonalAuthRequiredError(event.error)) {
+          const conversationUrl = makeConversationUrl(
+            connector.workspaceId,
+            conversation.sId
+          );
+          await postSlackMessageUpdate({
+            messageUpdate: {
+              text:
+                "The agent took an action that requires personal authentication. " +
+                `Please go to <${conversationUrl}|the conversation> to authenticate.`,
+              assistantName,
+              agentConfigurations,
+            },
+            ...conversationData,
+          });
+          return new Ok(undefined);
+        }
+        return new Err(
+          new Error(
+            `Tool message error: code: ${event.error.code} message: ${event.error.message}`
+          )
+        );
+      }
       case "agent_error": {
         return new Err(
           new Error(

--- a/sdks/js/src/types.ts
+++ b/sdks/js/src/types.ts
@@ -1101,6 +1101,16 @@ const ToolErrorEventSchema = z.object({
 });
 export type ToolErrorEvent = z.infer<typeof ToolErrorEventSchema>;
 
+export function isMCPServerPersonalAuthRequiredError(
+  error: ToolErrorEvent["error"]
+) {
+  return (
+    error.code === "mcp_server_personal_authentication_required" &&
+    error.metadata &&
+    "mcpServerId" in error.metadata
+  );
+}
+
 const AgentErrorEventSchema = z.object({
   type: z.literal("agent_error"),
   created: z.number(),


### PR DESCRIPTION
## Description

- Closes https://github.com/dust-tt/tasks/issues/3753.
- Errors due to a tool requiring personal authentication are not currently shown nicely when invoked from Slack (logs [here](https://app.datadoghq.eu/logs?query=%22Unexpected%20exception%20answering%20to%20Slack%20Chat%20Bot%20message%22%20region%3Aeurope-west1&agg_m=count&agg_m_source=base&agg_t=count&cols=host%2Cservice&event=AwAAAZh7X5aJvWrGHgAAABhBWmg3WDV1b0FBQWxyVVBSb2loZndBQU0AAAAkZjE5ODdiNjMtOTdmOS00OTZhLTk0NTctYTFlZGM4YmE4NWVmAAAi8g&fromUser=true&link_source=monitor_notif&messageDisplay=inline&refresh_mode=sliding&storage=hot&stream_sort=desc&viz=stream&from_ts=1754415973000&to_ts=1754416573000&live=false)).
- This PR improves this case by showing a pre-made custom message, inviting the user to visit the web app.

## Tests

- Tested locally, after an incredible painful setup.

## Risk

- Low

## Deploy Plan

- Deploy connectors.
