### PR TITLE
[front] - fix(AB v2): actions editing

### DIFF
--- a/front/components/agent_builder/AgentBuilder.tsx
+++ b/front/components/agent_builder/AgentBuilder.tsx
@@ -155,6 +155,7 @@ export default function AgentBuilder({
               disabled: isSaveDisabled,
             }}
             agentConfigurationId={agentConfiguration?.sId || null}
+            isActionsLoading={isActionsLoading}
           />
         }
         rightPanel={

--- a/front/components/agent_builder/AgentBuilderLeftPanel.tsx
+++ b/front/components/agent_builder/AgentBuilderLeftPanel.tsx
@@ -18,6 +18,7 @@ interface AgentBuilderLeftPanelProps {
   onCancel: () => void;
   agentConfigurationId: string | null;
   saveButtonProps?: ButtonProps;
+  isActionsLoading: boolean;
 }
 
 export function AgentBuilderLeftPanel({
@@ -25,6 +26,7 @@ export function AgentBuilderLeftPanel({
   onCancel,
   agentConfigurationId,
   saveButtonProps,
+  isActionsLoading,
 }: AgentBuilderLeftPanelProps) {
   const confirm = React.useContext(ConfirmContext);
 
@@ -62,7 +64,7 @@ export function AgentBuilderLeftPanel({
             agentConfigurationId={agentConfigurationId}
           />
           <Separator />
-          <AgentBuilderCapabilitiesBlock />
+          <AgentBuilderCapabilitiesBlock isActionsLoading={isActionsLoading} />
           <Separator />
           <AgentBuilderSettingsBlock
             isSettingBlocksOpen={!agentConfigurationId}

--- a/front/components/agent_builder/capabilities/AgentBuilderCapabilitiesBlock.tsx
+++ b/front/components/agent_builder/capabilities/AgentBuilderCapabilitiesBlock.tsx
@@ -86,7 +86,6 @@ interface ActionCardProps {
   onEdit?: () => void;
 }
 
-// TODO: Merge this with ActionCard.
 function ActionCard({ action, onRemove, onEdit }: ActionCardProps) {
   const { mcpServerViews, isMCPServerViewsLoading } =
     useMCPServerViewsContext();
@@ -130,7 +129,13 @@ function ActionCard({ action, onRemove, onEdit }: ActionCardProps) {
   );
 }
 
-export function AgentBuilderCapabilitiesBlock() {
+interface AgentBuilderCapabilitiesBlockProps {
+  isActionsLoading: boolean;
+}
+
+export function AgentBuilderCapabilitiesBlock({
+  isActionsLoading,
+}: AgentBuilderCapabilitiesBlockProps) {
   const { getValues } = useFormContext<AgentBuilderFormData>();
   const { fields, remove, append, update } = useFieldArray<
     AgentBuilderFormData,
@@ -247,7 +252,7 @@ export function AgentBuilderCapabilitiesBlock() {
         </div>
       </div>
       <div className="flex-1">
-        {isMCPServerViewsLoading ? (
+        {isMCPServerViewsLoading || isActionsLoading ? (
           <div className="flex h-40 w-full items-center justify-center">
             <Spinner />
           </div>

--- a/front/components/agent_builder/capabilities/AgentBuilderCapabilitiesBlock.tsx
+++ b/front/components/agent_builder/capabilities/AgentBuilderCapabilitiesBlock.tsx
@@ -8,6 +8,7 @@ import {
   XMarkIcon,
 } from "@dust-tt/sparkle";
 import { Spinner } from "@dust-tt/sparkle";
+import { isEmpty } from "lodash";
 import React, { useState } from "react";
 import { useFieldArray, useFormContext } from "react-hook-form";
 
@@ -169,8 +170,8 @@ export function AgentBuilderCapabilitiesBlock() {
     const isDataSourceSelectionRequired =
       action.type === "MCP" &&
       Boolean(
-        action.configuration.dataSourceConfigurations ||
-          action.configuration.tablesConfigurations
+        !isEmpty(action.configuration.dataSourceConfigurations) ||
+          !isEmpty(action.configuration.tablesConfigurations)
       );
 
     if (isDataSourceSelectionRequired) {


### PR DESCRIPTION
## Description

The `actions` endpoint returns an empty object for `dataSourceConfigurations` and `tablesConfigurations` instead of the expected `null` value. This was breaking our check to display a sheet or dialog.

## Tests

Locally

## Risk

Low

## Deploy Plan

Deplloy front
