### PR TITLE
enh: implement light native reasoning for gpt5

### DIFF
--- a/core/src/providers/openai_responses_api_helpers.rs
+++ b/core/src/providers/openai_responses_api_helpers.rs
@@ -404,7 +404,13 @@ pub async fn openai_responses_api_completion(
                 _ => None,
             },
             match v.get("reasoning_effort") {
-                Some(Value::String(r)) => Some(r.to_string()),
+                Some(Value::String(r)) => {
+                    if r == "light" {
+                        Some("low".to_string())
+                    } else {
+                        Some(r.to_string())
+                    }
+                }
                 _ => {
                     if model_id.starts_with("gpt-5") {
                         Some("minimal".to_string())

--- a/front/lib/actions/mcp_internal_actions/servers/reasoning.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/reasoning.ts
@@ -239,7 +239,11 @@ async function* runReasoning(
 
   const reasoningEffort =
     reasoningModel.reasoningEffort ?? supportedModel.defaultReasoningEffort;
-  if (reasoningEffort !== "none" && reasoningEffort !== "light") {
+
+  if (
+    reasoningEffort !== "none" &&
+    (reasoningEffort !== "light" || supportedModel.useNativeLightReasoning)
+  ) {
     config.MODEL.reasoning_effort = reasoningEffort;
   }
 

--- a/front/lib/api/assistant/generation.ts
+++ b/front/lib/api/assistant/generation.ts
@@ -98,8 +98,7 @@ export async function constructPromptMultiActions(
   if (
     hasAvailableActions &&
     agentConfiguration.model.reasoningEffort === "light" &&
-    // TODO(gpt5): improve config to clean this up.
-    agentConfiguration.model.providerId !== "openai"
+    !model.useNativeLightReasoning
   ) {
     toolUseDirectives += `${CHAIN_OF_THOUGHT_META_PROMPT}\n`;
   } else if (

--- a/front/temporal/agent_loop/activities/run_model.ts
+++ b/front/temporal/agent_loop/activities/run_model.ts
@@ -349,7 +349,10 @@ export async function runModelActivity({
   const reasoningEffort =
     agentConfiguration.model.reasoningEffort ?? model.defaultReasoningEffort;
 
-  if (reasoningEffort !== "none" && reasoningEffort !== "light") {
+  if (
+    reasoningEffort !== "none" &&
+    (reasoningEffort !== "light" || model.useNativeLightReasoning)
+  ) {
     runConfig.MODEL.reasoning_effort = reasoningEffort;
   }
 

--- a/front/types/assistant/assistant.ts
+++ b/front/types/assistant/assistant.ts
@@ -325,6 +325,10 @@ export type ModelConfigurationType = {
   maximumReasoningEffort: AgentReasoningEffort;
   defaultReasoningEffort: AgentReasoningEffort;
 
+  // If set to true, we'll pass the "light" reasoning effort to `core`. Otherwise, we'll
+  // use chain of thought prompting.
+  useNativeLightReasoning?: boolean;
+
   // Denotes model is able to take a response format request parameter
   supportsResponseFormat?: boolean;
 
@@ -500,6 +504,7 @@ export const GPT_5_MODEL_CONFIG: ModelConfigurationType = {
   minimumReasoningEffort: "none",
   maximumReasoningEffort: "high",
   defaultReasoningEffort: "medium",
+  useNativeLightReasoning: true,
   supportsResponseFormat: true,
   formattingMetaPrompt: OPENAI_FORMATTING_META_PROMPT,
 };


### PR DESCRIPTION
## Description

Use native "low" reasoning when "light" is selected.

## Tests

Locally

## Risk

Low

## Deploy Plan

Deploy core then front