### PR TITLE
[front] Create conversation data source when receiving files from sub agent

### DIFF
--- a/front/lib/actions/mcp_execution.ts
+++ b/front/lib/actions/mcp_execution.ts
@@ -56,6 +56,7 @@ import {
   removeNulls,
   stripNullBytes,
 } from "@app/types";
+import { getOrCreateConversationDataSourceFromFile } from "@app/lib/api/data_sources";
 
 /**
  * Handles tool approval process and returns the final execution status.
@@ -328,7 +329,11 @@ export async function processToolResults({
               auth,
               block.resource.fileId
             );
-
+            // We need to create the conversation data source in case the file comes from a subagent
+            // who uploaded it to its own conversation but not the main agent's.
+            if (file) {
+              await getOrCreateConversationDataSourceFromFile(auth, file);
+            }
             return {
               content: {
                 type: block.type,

--- a/front/lib/actions/mcp_execution.ts
+++ b/front/lib/actions/mcp_execution.ts
@@ -32,6 +32,7 @@ import type {
   ActionGeneratedFileType,
   AgentLoopRunContextType,
 } from "@app/lib/actions/types";
+import { getOrCreateConversationDataSourceFromFile } from "@app/lib/api/data_sources";
 import { processAndStoreFromUrl } from "@app/lib/api/files/upload";
 import type { Authenticator } from "@app/lib/auth";
 import type { AgentMCPAction } from "@app/lib/models/assistant/actions/mcp";
@@ -56,7 +57,6 @@ import {
   removeNulls,
   stripNullBytes,
 } from "@app/types";
-import { getOrCreateConversationDataSourceFromFile } from "@app/lib/api/data_sources";
 
 /**
  * Handles tool approval process and returns the final execution status.


### PR DESCRIPTION
## Description

- Context [here](https://dust4ai.slack.com/archives/C05F84CFP0E/p1754658593592129).
- This PR fixes an issue when a sub agent passes a file to the main agent, that then crashes with the error `AssertionError: No conversation datasource view found for table when trying to get JIT actions`.

## Tests

- Ongoing

## Risk

- Low.

## Deploy Plan

- Deploy front.
