### PR TITLE
[front] Fix user name escaping

### DIFF
--- a/front/lib/api/invitation.ts
+++ b/front/lib/api/invitation.ts
@@ -28,6 +28,7 @@ import type {
   WorkspaceType,
 } from "@app/types";
 import { Err, Ok, sanitizeString } from "@app/types";
+import { escape } from "html-escaper";
 
 // Make token expires after 7 days
 const INVITATION_EXPIRATION_TIME_SEC = 60 * 60 * 24 * 7;
@@ -185,7 +186,8 @@ export async function sendWorkspaceInvitationEmail(
     templateId: config.getInvitationEmailTemplate(),
     dynamic_template_data: {
       inviteLink: getMembershipInvitationUrl(owner, invitation.id),
-      inviterName: user.fullName,
+      // Escape the name to prevent XSS attacks via injected script elements.
+      inviterName: escape(user.fullName),
       workspaceName: owner.name,
     },
   };

--- a/front/lib/api/invitation.ts
+++ b/front/lib/api/invitation.ts
@@ -1,4 +1,5 @@
 import sgMail from "@sendgrid/mail";
+import { escape } from "html-escaper";
 import { sign } from "jsonwebtoken";
 import type { Transaction } from "sequelize";
 import { Op } from "sequelize";
@@ -28,7 +29,6 @@ import type {
   WorkspaceType,
 } from "@app/types";
 import { Err, Ok, sanitizeString } from "@app/types";
-import { escape } from "html-escaper";
 
 // Make token expires after 7 days
 const INVITATION_EXPIRATION_TIME_SEC = 60 * 60 * 24 * 7;

--- a/front/lib/iam/users.ts
+++ b/front/lib/iam/users.ts
@@ -1,5 +1,3 @@
-import { escape } from "html-escaper";
-
 import { revokeAndTrackMembership } from "@app/lib/api/membership";
 import type { Authenticator } from "@app/lib/auth";
 import type { ExternalUser, SessionWithUser } from "@app/lib/iam/provider";
@@ -129,11 +127,8 @@ export async function createOrUpdateUser({
       externalUser.name
     );
 
-    firstName = escape(externalUser.given_name || firstName);
+    firstName = externalUser.given_name || firstName;
     lastName = externalUser.family_name || lastName;
-    if (lastName) {
-      lastName = escape(lastName);
-    }
 
     // If worksOSUserId is already taken, we don't want to take it - only one user can have the same workOSUserId.
     const existingWorkOSUser = externalUser.workOSUserId

--- a/front/lib/iam/users.ts
+++ b/front/lib/iam/users.ts
@@ -69,17 +69,15 @@ export async function createOrUpdateUser({
     // Update the user object from the updated session information.
     updateArgs.username = externalUser.nickname;
 
-    if (!user.firstName && !user.lastName) {
-      if (externalUser.given_name && externalUser.family_name) {
-        updateArgs.firstName = externalUser.given_name;
-        updateArgs.lastName = externalUser.family_name;
-      } else {
-        const { firstName, lastName } = guessFirstAndLastNameFromFullName(
-          externalUser.name
-        );
-        updateArgs.firstName = firstName;
-        updateArgs.lastName = lastName || "";
-      }
+    if (externalUser.given_name && externalUser.family_name) {
+      updateArgs.firstName = externalUser.given_name;
+      updateArgs.lastName = externalUser.family_name;
+    } else {
+      const { firstName, lastName } = guessFirstAndLastNameFromFullName(
+        externalUser.name
+      );
+      updateArgs.firstName = firstName;
+      updateArgs.lastName = lastName || "";
     }
 
     if (

--- a/front/lib/iam/users.ts
+++ b/front/lib/iam/users.ts
@@ -24,8 +24,8 @@ import type { Result } from "@app/types";
 import { Err, Ok, sanitizeString } from "@app/types";
 
 /**
- * Soft HTML escaping that prevents HTML tag injection while preserving apostrophes and other common characters
- * Only escapes < and > which are the minimal characters needed to prevent HTML tag injection
+ * Soft HTML escaping that prevents HTML tag injection while preserving apostrophes and other common characters.
+ * Only escapes < and > which are the minimal characters needed to prevent HTML tag injection.
  */
 function softHtmlEscape(str: string): string {
   return str.replace(/</g, "&lt;").replace(/>/g, "&gt;");


### PR DESCRIPTION
## Description

- Fixes https://github.com/dust-tt/tasks/issues/3756.
- Currently names are escaped using `html-escaper`, which also escapes common characters such as apostrophes, causing names to not appear correctly.
- This behavior was introduced to prevent XSS injections as detailed in https://github.com/dust-tt/dust/issues/12145.
- This PR moves the escaping to the email generation and introduces a softer escaping method specific to HTML elements.
- `createOrUpdateUser` also now always update the user name to make this retroactive on the next sync.

## Tests

## Risk

## Deploy Plan

- Deploy front.
