### PR TITLE
Add support for MCP servers with static oauth credentials

### DIFF
--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -149,6 +149,7 @@ pub mod oauth {
         pub mod intercom;
         pub mod jira;
         pub mod mcp;
+        pub mod mcp_static;
         pub mod microsoft;
         pub mod microsoft_tools;
         pub mod mock;

--- a/core/src/oauth/connection.rs
+++ b/core/src/oauth/connection.rs
@@ -6,10 +6,11 @@ use crate::oauth::{
         gong::GongConnectionProvider, google_drive::GoogleDriveConnectionProvider,
         hubspot::HubspotConnectionProvider, intercom::IntercomConnectionProvider,
         jira::JiraConnectionProvider, mcp::MCPConnectionProvider,
-        microsoft::MicrosoftConnectionProvider, microsoft_tools::MicrosoftToolsConnectionProvider,
-        mock::MockConnectionProvider, monday::MondayConnectionProvider,
-        notion::NotionConnectionProvider, salesforce::SalesforceConnectionProvider,
-        slack::SlackConnectionProvider, zendesk::ZendeskConnectionProvider,
+        mcp_static::MCPStaticConnectionProvider, microsoft::MicrosoftConnectionProvider,
+        microsoft_tools::MicrosoftToolsConnectionProvider, mock::MockConnectionProvider,
+        monday::MondayConnectionProvider, notion::NotionConnectionProvider,
+        salesforce::SalesforceConnectionProvider, slack::SlackConnectionProvider,
+        zendesk::ZendeskConnectionProvider,
     },
     store::OAuthStore,
 };
@@ -108,6 +109,7 @@ pub enum ConnectionProvider {
     Salesforce,
     Hubspot,
     Mcp,
+    McpStatic,
 }
 
 impl FromStr for ConnectionProvider {
@@ -248,6 +250,8 @@ pub fn provider(t: ConnectionProvider) -> Box<dyn Provider + Sync + Send> {
         ConnectionProvider::Salesforce => Box::new(SalesforceConnectionProvider::new()),
         ConnectionProvider::Hubspot => Box::new(HubspotConnectionProvider::new()),
         ConnectionProvider::Mcp => Box::new(MCPConnectionProvider::new()),
+        // MCP Static is the same as MCP but does not require the discovery process on the front end.
+        ConnectionProvider::McpStatic => Box::new(MCPStaticConnectionProvider::new()),
     }
 }
 

--- a/core/src/oauth/credential.rs
+++ b/core/src/oauth/credential.rs
@@ -27,6 +27,7 @@ pub enum CredentialProvider {
     Jira,
     Monday,
     Mcp,
+    McpStatic,
     Notion,
     Freshservice,
 }
@@ -40,6 +41,7 @@ impl From<ConnectionProvider> for CredentialProvider {
             ConnectionProvider::Gmail => CredentialProvider::Gmail,
             ConnectionProvider::Jira => CredentialProvider::Jira,
             ConnectionProvider::Mcp => CredentialProvider::Mcp,
+            ConnectionProvider::McpStatic => CredentialProvider::McpStatic,
             ConnectionProvider::Freshservice => CredentialProvider::Freshservice,
             _ => panic!("Unsupported provider: {:?}", provider),
         }
@@ -221,6 +223,9 @@ impl Credential {
                 vec!["client_id", "client_secret"]
             }
             CredentialProvider::Mcp => {
+                vec!["client_id"]
+            }
+            CredentialProvider::McpStatic => {
                 vec!["client_id"]
             }
             CredentialProvider::Notion => {

--- a/core/src/oauth/providers/mcp_static.rs
+++ b/core/src/oauth/providers/mcp_static.rs
@@ -1,0 +1,61 @@
+use crate::oauth::{
+    connection::{ConnectionProvider, Provider},
+    providers::mcp::MCPConnectionProvider,
+};
+use async_trait::async_trait;
+
+pub struct MCPStaticConnectionProvider {
+    inner: MCPConnectionProvider,
+}
+
+impl MCPStaticConnectionProvider {
+    pub fn new() -> Self {
+        MCPStaticConnectionProvider {
+            inner: MCPConnectionProvider::new(),
+        }
+    }
+}
+
+#[async_trait]
+impl Provider for MCPStaticConnectionProvider {
+    fn id(&self) -> ConnectionProvider {
+        ConnectionProvider::McpStatic
+    }
+
+    fn reqwest_client(&self) -> reqwest::Client {
+        self.inner.reqwest_client()
+    }
+
+    async fn finalize(
+        &self,
+        connection: &crate::oauth::connection::Connection,
+        related_credentials: Option<crate::oauth::credential::Credential>,
+        code: &str,
+        redirect_uri: &str,
+    ) -> Result<crate::oauth::connection::FinalizeResult, crate::oauth::connection::ProviderError>
+    {
+        self.inner
+            .finalize(connection, related_credentials, code, redirect_uri)
+            .await
+    }
+
+    async fn refresh(
+        &self,
+        connection: &crate::oauth::connection::Connection,
+        related_credentials: Option<crate::oauth::credential::Credential>,
+    ) -> Result<crate::oauth::connection::RefreshResult, crate::oauth::connection::ProviderError>
+    {
+        self.inner.refresh(connection, related_credentials).await
+    }
+
+    fn scrubbed_raw_json(&self, raw_json: &serde_json::Value) -> anyhow::Result<serde_json::Value> {
+        self.inner.scrubbed_raw_json(raw_json)
+    }
+
+    fn handle_provider_request_error(
+        &self,
+        error: crate::oauth::providers::utils::ProviderHttpRequestError,
+    ) -> crate::oauth::connection::ProviderError {
+        self.inner.handle_provider_request_error(error)
+    }
+}

--- a/front/components/actions/mcp/MCPServerOAuthConnexion.tsx
+++ b/front/components/actions/mcp/MCPServerOAuthConnexion.tsx
@@ -91,14 +91,18 @@ export function MCPServerOAuthConnexion({
           // Can't happen but to make typescript happy.
           continue;
         }
-        if (!value) {
-          isFormValid = false;
-          break;
-        }
+
         const input = inputs[key];
-        if (input && input.validator && !input.validator(value)) {
-          isFormValid = false;
-          break;
+        if (input && input.validator) {
+          if (!input.validator(value)) {
+            isFormValid = false;
+            break;
+          }
+        } else {
+          if (!value) {
+            isFormValid = false;
+            break;
+          }
         }
       }
 

--- a/front/lib/actions/mcp_internal_actions/remote_servers.ts
+++ b/front/lib/actions/mcp_internal_actions/remote_servers.ts
@@ -10,7 +10,7 @@ export type DefaultRemoteMCPServerConfig = {
   icon: InternalAllowedIconType;
   documentationUrl?: string;
   connectionInstructions?: string;
-  authMethod: "bearer" | "oauth" | null;
+  authMethod: "bearer" | "oauth-dynamic" | null;
   supportedOAuthUseCases?: MCPOAuthUseCase[];
   toolStakes?: Record<string, "high" | "low" | "never_ask">;
 };
@@ -60,7 +60,7 @@ export const DEFAULT_REMOTE_MCP_SERVERS: DefaultRemoteMCPServerConfig[] = [
     url: "https://mcp.linear.app/sse",
     icon: "LinearLogo",
     documentationUrl: "https://linear.app/docs",
-    authMethod: "oauth",
+    authMethod: "oauth-dynamic",
     toolStakes: {
       search_documentation: "never_ask",
       list_comments: "never_ask",

--- a/front/lib/api/oauth.ts
+++ b/front/lib/api/oauth.ts
@@ -15,6 +15,7 @@ import { HubspotOAuthProvider } from "@app/lib/api/oauth/providers/hubspot";
 import { IntercomOAuthProvider } from "@app/lib/api/oauth/providers/intercom";
 import { JiraOAuthProvider } from "@app/lib/api/oauth/providers/jira";
 import { MCPOAuthProvider } from "@app/lib/api/oauth/providers/mcp";
+import { MCPOAuthStaticOAuthProvider } from "@app/lib/api/oauth/providers/mcp_static";
 import { MicrosoftOAuthProvider } from "@app/lib/api/oauth/providers/microsoft";
 import { MicrosoftToolsOAuthProvider } from "@app/lib/api/oauth/providers/microsoft_tools";
 import { MondayOAuthProvider } from "@app/lib/api/oauth/providers/monday";
@@ -56,6 +57,7 @@ const _PROVIDER_STRATEGIES: Record<OAuthProvider, BaseOAuthStrategyProvider> = {
   intercom: new IntercomOAuthProvider(),
   jira: new JiraOAuthProvider(),
   mcp: new MCPOAuthProvider(),
+  mcp_static: new MCPOAuthStaticOAuthProvider(),
   microsoft: new MicrosoftOAuthProvider(),
   microsoft_tools: new MicrosoftToolsOAuthProvider(),
   monday: new MondayOAuthProvider(),

--- a/front/lib/api/oauth/providers/mcp.ts
+++ b/front/lib/api/oauth/providers/mcp.ts
@@ -16,7 +16,11 @@ import { getPKCEConfig } from "@app/lib/utils/pkce";
 import logger from "@app/logger/logger";
 import type { ExtraConfigType } from "@app/pages/w/[wId]/oauth/[provider]/setup";
 import { OAuthAPI } from "@app/types";
-import type { OAuthConnectionType, OAuthUseCase } from "@app/types/oauth/lib";
+import type {
+  OAuthConnectionType,
+  OAuthProvider,
+  OAuthUseCase,
+} from "@app/types/oauth/lib";
 
 export const MCP_OAUTH_RESPONSE_TYPE = "code";
 export const MCP_OAUTH_CODE_CHALLENGE_METHOD = "S256";
@@ -43,6 +47,8 @@ export type MCPOAuthConnectionMetadataType = z.infer<
 type MCPMetadataType = z.infer<typeof MCPMetadataSchema>;
 
 export class MCPOAuthProvider implements BaseOAuthStrategyProvider {
+  provider: OAuthProvider = "mcp";
+
   setupUri({
     connection,
   }: {
@@ -72,7 +78,10 @@ export class MCPOAuthProvider implements BaseOAuthStrategyProvider {
       "code_challenge_method",
       MCP_OAUTH_CODE_CHALLENGE_METHOD
     );
-    authUrl.searchParams.set("redirect_uri", finalizeUriForProvider("mcp"));
+    authUrl.searchParams.set(
+      "redirect_uri",
+      finalizeUriForProvider(this.provider)
+    );
     authUrl.searchParams.set("state", connection.connection_id);
 
     return authUrl.toString();

--- a/front/lib/api/oauth/providers/mcp_static.ts
+++ b/front/lib/api/oauth/providers/mcp_static.ts
@@ -1,0 +1,8 @@
+import { MCPOAuthProvider } from "@app/lib/api/oauth/providers/mcp";
+import type { OAuthProvider } from "@app/types";
+
+// This provider is used to authenticate with MCP servers that require static OAuth credentials.
+// It behaves exactly like the MCP provider but does requires the user to provide the various oauth credentials instead of using the discovery process.
+export class MCPOAuthStaticOAuthProvider extends MCPOAuthProvider {
+  provider: OAuthProvider = "mcp_static";
+}

--- a/front/lib/resources/default_remote_mcp_server_in_memory_resource.ts
+++ b/front/lib/resources/default_remote_mcp_server_in_memory_resource.ts
@@ -60,7 +60,7 @@ export class DefaultRemoteMCPServerInMemoryResource {
       description: this.config.description,
       icon: this.config.icon,
       authorization:
-        this.config.authMethod === "oauth"
+        this.config.authMethod === "oauth-dynamic"
           ? {
               provider: "mcp",
               supported_use_cases: this.config.supportedOAuthUseCases || [],


### PR DESCRIPTION
## Description

Add support for pre-entering MCP server oauth credentials (as opposed to dynamic client discovery).

Implemented as a different oauth provider so I could re-use the `getProviderRequiredOAuthCredentialInputs()` method and avoid re-inventing the wheel or adding an hack.

On the front end and backend, the "mcp_static" provider is implemented by reusing the code from the "mcp" provider, except for the provider name.

The UI isn't amazing but I'd like to test with a customer asap.

<img width="590" height="350" alt="image" src="https://github.com/user-attachments/assets/cc0cb856-6114-41da-8def-aa34a4d208d0" />

<img width="598" height="890" alt="image" src="https://github.com/user-attachments/assets/ca54c3b0-954c-46f6-b51f-644fbed4fcef" />

## Tests

Local

## Risk

Medium, could break setup for tools connection, tested with internal & remote servers.

## Deploy Plan

Deploy oauth and deploy front