### PR TITLE
[front] - refact(AB v2): UI tweaks

### DIFF
--- a/front/components/agent_builder/AgentBuilder.tsx
+++ b/front/components/agent_builder/AgentBuilder.tsx
@@ -137,7 +137,7 @@ export default function AgentBuilder({
   const saveLabel = isSubmitting ? "Saving..." : "Save";
 
   const title = agentConfiguration
-    ? `Edit agent ${agentConfiguration.name}`
+    ? `Edit @${agentConfiguration.name}`
     : "Create new agent";
 
   return (

--- a/front/components/agent_builder/capabilities/AgentBuilderCapabilitiesBlock.tsx
+++ b/front/components/agent_builder/capabilities/AgentBuilderCapabilitiesBlock.tsx
@@ -101,7 +101,7 @@ function ActionCard({ action, onRemove, onEdit }: ActionCardProps) {
   return (
     <Card
       variant="primary"
-      className="max-h-40"
+      className="h-32"
       onClick={onEdit}
       action={
         <CardActionButton
@@ -239,11 +239,11 @@ export function AgentBuilderCapabilitiesBlock({
 
   return (
     <div className="flex h-full flex-col gap-4">
-      <Page.H>Tools & Capabilities</Page.H>
+      <Page.H>Knowledge & Tools</Page.H>
       <div className="flex flex-col items-center justify-between sm:flex-row">
         <Page.P>
           <span className="text-sm text-muted-foreground dark:text-muted-foreground-night">
-            Add tools and capabilities to enhance your agent's abilities.
+            Add tools and knowledge to enhance your agent's abilities.
           </span>
         </Page.P>
         <div className="flex w-full flex-col gap-2 sm:w-auto">

--- a/front/components/agent_builder/capabilities/mcp/MCPServerViewsDialog.tsx
+++ b/front/components/agent_builder/capabilities/mcp/MCPServerViewsDialog.tsx
@@ -1,7 +1,7 @@
 import type { MultiPageDialogPage } from "@dust-tt/sparkle";
 import {
   Button,
-  LightbulbIcon,
+  ListAddIcon,
   MultiPageDialog,
   MultiPageDialogContent,
   MultiPageDialogTrigger,
@@ -702,7 +702,7 @@ export function MCPServerViewsDialog({
       }}
     >
       <MultiPageDialogTrigger asChild>
-        <Button label="Add tools" icon={LightbulbIcon} />
+        <Button label="Add tools" icon={ListAddIcon} />
       </MultiPageDialogTrigger>
       <MultiPageDialogContent
         showNavigation={false}

--- a/front/components/agent_builder/settings/AgentBuilderSettingsBlock.tsx
+++ b/front/components/agent_builder/settings/AgentBuilderSettingsBlock.tsx
@@ -137,12 +137,12 @@ function AgentNameInput() {
   };
 
   return (
-    <div className="space-y-2">
+    <div className="space-y-1">
       <label className="text-sm font-semibold text-foreground dark:text-foreground-night">
         Name
       </label>
-      <div className="relative">
-        <Input placeholder="Enter agent name" {...field} className="pr-10" />
+      <div className="relative max-w-100">
+        <Input placeholder="Enter agent name" {...field} />
         <DropdownMenu
           onOpenChange={(open) => open && handleGenerateNameSuggestions()}
         >
@@ -256,16 +256,12 @@ function AgentDescriptionInput() {
   };
 
   return (
-    <div className="space-y-2">
+    <div className="space-y-1">
       <label className="text-sm font-semibold text-foreground dark:text-foreground-night">
         Description
       </label>
       <div className="relative">
-        <Input
-          placeholder="Enter agent description"
-          {...field}
-          className="pr-10"
-        />
+        <Input placeholder="Enter agent description" {...field} />
         <Button
           icon={isGenerating ? () => <Spinner size="xs" /> : SparklesIcon}
           variant="outline"
@@ -415,13 +411,13 @@ export function AgentBuilderSettingsBlock({
               </span>
             </Page.P>
             <div className="space-y-4">
-              <div className="flex items-start gap-8">
-                <div className="flex-grow">
+              <div className="flex items-center gap-8">
+                <div className="flex w-full flex-col gap-2">
                   <AgentNameInput />
+                  <AgentDescriptionInput />
                 </div>
                 <AgentPictureInput />
               </div>
-              <AgentDescriptionInput />
               <TagsSection />
               <AgentAccessAndPublication />
             </div>


### PR DESCRIPTION
## Description

This PR tackles a bunch of UI tweaks:
 - Prefix agent name with "@" in edit page title for clarity
 - Standardize height of action cards for consistency
 - Rename "Tools & Capabilities" to "Knowledge & Tools" to reflect broader functionality
 - Replace lightbulb icon with list-add icon for adding tools button for better representation
 - Reduce vertical spacing for agent name and description inputs for a more compact layout
 - Adjust maximum width of the agent name input for consistency
 - Reorganize inputs and picture upload on settings page for a cleaner layout

## Tests

Locally

## Risk

Low

## Deploy Plan

Deploy front