### PR TITLE
Dry agent loop -  Lightweight Tool Configuration Storage

### DIFF
--- a/front/lib/actions/mcp_execution.ts
+++ b/front/lib/actions/mcp_execution.ts
@@ -10,6 +10,7 @@ import {
   MAXED_OUTPUT_FILE_SNIPPET_LENGTH,
 } from "@app/lib/actions/action_output_limits";
 import type {
+  LightMCPToolConfigurationType,
   MCPActionType,
   MCPApproveExecutionEvent,
   MCPExecutionState,
@@ -74,7 +75,7 @@ export async function handleToolApproval(
     localLogger: Logger;
     mcpAction: MCPActionType;
     owner: LightWorkspaceType;
-    toolConfiguration: MCPToolConfigurationType;
+    toolConfiguration: LightMCPToolConfigurationType;
   }
 ): Promise<MCPExecutionState> {
   let newExecutionState: MCPExecutionState = executionState;
@@ -240,7 +241,7 @@ export async function processToolResults(
     conversation: ConversationType;
     localLogger: Logger;
     toolCallResult: CallToolResult["content"];
-    toolConfiguration: MCPToolConfigurationType;
+    toolConfiguration: LightMCPToolConfigurationType;
   }
 ): Promise<{
   outputItems: AgentMCPActionOutputItem[];

--- a/front/lib/actions/mcp_execution.ts
+++ b/front/lib/actions/mcp_execution.ts
@@ -64,17 +64,17 @@ import {
 export async function handleToolApproval(
   auth: Authenticator,
   {
-    actionConfiguration,
     executionState,
     localLogger,
     mcpAction,
     owner,
+    toolConfiguration,
   }: {
-    actionConfiguration: MCPToolConfigurationType;
     executionState: MCPExecutionState;
     localLogger: Logger;
     mcpAction: MCPActionType;
     owner: LightWorkspaceType;
+    toolConfiguration: MCPToolConfigurationType;
   }
 ): Promise<MCPExecutionState> {
   let newExecutionState: MCPExecutionState = executionState;
@@ -85,13 +85,7 @@ export async function handleToolApproval(
         actionId: mcpAction.getSId(owner),
       });
 
-      localLogger.info(
-        {
-          workspaceId: owner.sId,
-          actionName: actionConfiguration.name,
-        },
-        "Waiting for action validation"
-      );
+      localLogger.info("Waiting for action validation");
 
       // Start listening for action events
       for await (const event of actionEventGenerator) {
@@ -106,8 +100,8 @@ export async function handleToolApproval(
         if (data.type === "always_approved") {
           const user = auth.getNonNullableUser();
           await user.appendToMetadata(
-            `toolsValidations:${actionConfiguration.toolServerId}`,
-            `${actionConfiguration.name}`
+            `toolsValidations:${toolConfiguration.toolServerId}`,
+            `${mcpAction.functionCallName}`
           );
         }
 
@@ -233,21 +227,22 @@ export async function* executeMCPTool({
  * Processes tool results, handles file uploads, and creates output items.
  * Returns the processed content and generated files.
  */
-export async function processToolResults({
-  auth,
-  toolCallResult,
-  conversation,
-  action,
-  actionConfiguration,
-  localLogger,
-}: {
-  auth: Authenticator;
-  toolCallResult: CallToolResult["content"];
-  conversation: ConversationType;
-  action: AgentMCPAction;
-  actionConfiguration: MCPToolConfigurationType;
-  localLogger: Logger;
-}): Promise<{
+export async function processToolResults(
+  auth: Authenticator,
+  {
+    action,
+    conversation,
+    localLogger,
+    toolCallResult,
+    toolConfiguration,
+  }: {
+    action: AgentMCPAction;
+    conversation: ConversationType;
+    localLogger: Logger;
+    toolCallResult: CallToolResult["content"];
+    toolConfiguration: MCPToolConfigurationType;
+  }
+): Promise<{
   outputItems: AgentMCPActionOutputItem[];
   generatedFiles: ActionGeneratedFileType[];
 }> {
@@ -267,9 +262,9 @@ export async function processToolResults({
           // If the text is too large we create a file and return a resource block that references the file.
           if (
             computeTextByteSize(block.text) > MAX_TEXT_CONTENT_SIZE &&
-            actionConfiguration.mcpServerName !== "conversation_files"
+            toolConfiguration.mcpServerName !== "conversation_files"
           ) {
-            const fileName = `${actionConfiguration.mcpServerName}_${Date.now()}.txt`;
+            const fileName = `${toolConfiguration.mcpServerName}_${Date.now()}.txt`;
             const snippet =
               block.text.substring(0, MAXED_OUTPUT_FILE_SNIPPET_LENGTH) +
               "... (truncated)";

--- a/front/lib/actions/mcp_internal_actions/servers/index.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/index.ts
@@ -51,9 +51,9 @@ function isAdvancedSearchMode(agentLoopContext?: AgentLoopContextType) {
   return (
     (agentLoopContext?.runContext &&
       isServerSideMCPToolConfiguration(
-        agentLoopContext.runContext.actionConfiguration
+        agentLoopContext.runContext.toolConfiguration
       ) &&
-      agentLoopContext.runContext.actionConfiguration.additionalConfiguration[
+      agentLoopContext.runContext.toolConfiguration.additionalConfiguration[
         ADVANCED_SEARCH_SWITCH
       ] === true) ||
     (agentLoopContext?.listToolsContext &&

--- a/front/lib/actions/mcp_internal_actions/servers/index.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/index.ts
@@ -37,8 +37,8 @@ import { default as thinkServer } from "@app/lib/actions/mcp_internal_actions/se
 import { default as webtoolsServer } from "@app/lib/actions/mcp_internal_actions/servers/webtools";
 import type { AgentLoopContextType } from "@app/lib/actions/types";
 import {
+  isLightServerSideMCPToolConfiguration,
   isServerSideMCPServerConfiguration,
-  isServerSideMCPToolConfiguration,
 } from "@app/lib/actions/types/guards";
 import type { Authenticator } from "@app/lib/auth";
 import { assertNever } from "@app/types";
@@ -50,7 +50,7 @@ import { assertNever } from "@app/types";
 function isAdvancedSearchMode(agentLoopContext?: AgentLoopContextType) {
   return (
     (agentLoopContext?.runContext &&
-      isServerSideMCPToolConfiguration(
+      isLightServerSideMCPToolConfiguration(
         agentLoopContext.runContext.toolConfiguration
       ) &&
       agentLoopContext.runContext.toolConfiguration.additionalConfiguration[

--- a/front/lib/actions/mcp_internal_actions/servers/missing_action_catcher.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/missing_action_catcher.ts
@@ -21,7 +21,7 @@ const createServer = (
   const server = new McpServer(serverInfo);
   if (agentLoopContext) {
     const actionName = agentLoopContext.runContext
-      ? agentLoopContext.runContext.actionConfiguration.name
+      ? agentLoopContext.runContext.toolConfiguration.name
       : agentLoopContext.listToolsContext?.agentActionConfiguration.name;
 
     if (!actionName) {

--- a/front/lib/actions/mcp_internal_actions/servers/process/index.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/process/index.ts
@@ -242,9 +242,9 @@ function createServer(
         null) ||
     (agentLoopContext?.runContext &&
       isServerSideMCPToolConfiguration(
-        agentLoopContext.runContext.actionConfiguration
+        agentLoopContext.runContext.toolConfiguration
       ) &&
-      agentLoopContext.runContext.actionConfiguration.jsonSchema !== null);
+      agentLoopContext.runContext.toolConfiguration.jsonSchema !== null);
 
   const isTimeFrameConfigured =
     (agentLoopContext?.listToolsContext &&
@@ -255,9 +255,9 @@ function createServer(
         null) ||
     (agentLoopContext?.runContext &&
       isServerSideMCPToolConfiguration(
-        agentLoopContext.runContext.actionConfiguration
+        agentLoopContext.runContext.toolConfiguration
       ) &&
-      agentLoopContext.runContext.actionConfiguration.timeFrame !== null);
+      agentLoopContext.runContext.toolConfiguration.timeFrame !== null);
 
   const areTagsDynamic = agentLoopContext
     ? shouldAutoGenerateTags(agentLoopContext)

--- a/front/lib/actions/mcp_internal_actions/servers/process/index.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/process/index.ts
@@ -32,8 +32,8 @@ import type {
   AgentLoopContextType,
 } from "@app/lib/actions/types";
 import {
+  isLightServerSideMCPToolConfiguration,
   isServerSideMCPServerConfiguration,
-  isServerSideMCPToolConfiguration,
 } from "@app/lib/actions/types/guards";
 import { constructPromptMultiActions } from "@app/lib/api/assistant/generation";
 import type { InternalMCPServerDefinitionType } from "@app/lib/api/mcp";
@@ -241,7 +241,7 @@ function createServer(
       agentLoopContext.listToolsContext.agentActionConfiguration.jsonSchema !==
         null) ||
     (agentLoopContext?.runContext &&
-      isServerSideMCPToolConfiguration(
+      isLightServerSideMCPToolConfiguration(
         agentLoopContext.runContext.toolConfiguration
       ) &&
       agentLoopContext.runContext.toolConfiguration.jsonSchema !== null);
@@ -254,7 +254,7 @@ function createServer(
       agentLoopContext.listToolsContext.agentActionConfiguration.timeFrame !==
         null) ||
     (agentLoopContext?.runContext &&
-      isServerSideMCPToolConfiguration(
+      isLightServerSideMCPToolConfiguration(
         agentLoopContext.runContext.toolConfiguration
       ) &&
       agentLoopContext.runContext.toolConfiguration.timeFrame !== null);

--- a/front/lib/actions/mcp_internal_actions/servers/run_agent.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/run_agent.ts
@@ -18,7 +18,6 @@ import {
   isLightServerSideMCPToolConfiguration,
   isMCPActionArray,
   isServerSideMCPServerConfiguration,
-  isServerSideMCPToolConfiguration,
 } from "@app/lib/actions/types/guards";
 import { getCitationsFromActions } from "@app/lib/api/assistant/citations";
 import { getGlobalAgentMetadata } from "@app/lib/api/assistant/global_agents/global_agent_metadata";

--- a/front/lib/actions/mcp_internal_actions/servers/run_agent.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/run_agent.ts
@@ -128,11 +128,11 @@ export default async function createServer(
     agentLoopContext &&
     agentLoopContext.runContext &&
     isServerSideMCPToolConfiguration(
-      agentLoopContext.runContext.actionConfiguration
+      agentLoopContext.runContext.toolConfiguration
     ) &&
-    agentLoopContext.runContext.actionConfiguration.childAgentId
+    agentLoopContext.runContext.toolConfiguration.childAgentId
   ) {
-    childAgentId = agentLoopContext.runContext.actionConfiguration.childAgentId;
+    childAgentId = agentLoopContext.runContext.toolConfiguration.childAgentId;
   }
 
   let childAgentBlob: {

--- a/front/lib/actions/mcp_internal_actions/servers/run_agent.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/run_agent.ts
@@ -15,6 +15,7 @@ import type {
   AgentLoopContextType,
 } from "@app/lib/actions/types";
 import {
+  isLightServerSideMCPToolConfiguration,
   isMCPActionArray,
   isServerSideMCPServerConfiguration,
   isServerSideMCPToolConfiguration,
@@ -127,7 +128,7 @@ export default async function createServer(
   if (
     agentLoopContext &&
     agentLoopContext.runContext &&
-    isServerSideMCPToolConfiguration(
+    isLightServerSideMCPToolConfiguration(
       agentLoopContext.runContext.toolConfiguration
     ) &&
     agentLoopContext.runContext.toolConfiguration.childAgentId

--- a/front/lib/actions/mcp_internal_actions/servers/run_dust_app.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/run_dust_app.ts
@@ -12,8 +12,8 @@ import {
 } from "@app/lib/actions/action_file_helpers";
 import { DUST_CONVERSATION_HISTORY_MAGIC_INPUT_KEY } from "@app/lib/actions/constants";
 import type {
+  LightServerSideMCPToolConfigurationType,
   ServerSideMCPServerConfigurationType,
-  ServerSideMCPToolConfigurationType,
 } from "@app/lib/actions/mcp";
 import type { ToolGeneratedFileType } from "@app/lib/actions/mcp_internal_actions/output_schemas";
 import { makeMCPToolTextError } from "@app/lib/actions/mcp_internal_actions/utils";
@@ -115,7 +115,7 @@ async function prepareAppContext(
   auth: Authenticator,
   actionConfig:
     | ServerSideMCPServerConfigurationType
-    | ServerSideMCPToolConfigurationType
+    | LightServerSideMCPToolConfigurationType
 ): Promise<{
   app: AppResource;
   schema: DatasetSchema | null;

--- a/front/lib/actions/mcp_internal_actions/servers/run_dust_app.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/run_dust_app.ts
@@ -382,14 +382,14 @@ export default async function createServer(
     );
   } else if (agentLoopContext && agentLoopContext.runContext) {
     if (
-      !isMCPInternalDustAppRun(agentLoopContext.runContext.actionConfiguration)
+      !isMCPInternalDustAppRun(agentLoopContext.runContext.toolConfiguration)
     ) {
       throw new Error("Invalid Dust app run tool configuration");
     }
 
     const { app, schema, appConfig } = await prepareAppContext(
       auth,
-      agentLoopContext.runContext.actionConfiguration
+      agentLoopContext.runContext.toolConfiguration
     );
 
     if (!app.description) {

--- a/front/lib/actions/mcp_internal_actions/servers/utils.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/utils.ts
@@ -523,11 +523,11 @@ export function shouldAutoGenerateTags(
       listToolsContext.agentActionConfiguration.dataSources
     );
   } else if (
-    !!runContext?.actionConfiguration &&
-    isServerSideMCPToolConfiguration(runContext.actionConfiguration) &&
-    !!runContext.actionConfiguration.dataSources
+    !!runContext?.toolConfiguration &&
+    isServerSideMCPToolConfiguration(runContext.toolConfiguration) &&
+    !!runContext.toolConfiguration.dataSources
   ) {
-    return hasTagAutoMode(runContext.actionConfiguration.dataSources);
+    return hasTagAutoMode(runContext.toolConfiguration.dataSources);
   }
 
   return false;

--- a/front/lib/actions/mcp_internal_actions/servers/utils.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/utils.ts
@@ -9,8 +9,8 @@ import {
 } from "@app/lib/actions/mcp_internal_actions/input_schemas";
 import type { AgentLoopContextType } from "@app/lib/actions/types";
 import {
+  isLightServerSideMCPToolConfiguration,
   isServerSideMCPServerConfiguration,
-  isServerSideMCPToolConfiguration,
 } from "@app/lib/actions/types/guards";
 import type {
   DataSourceConfiguration,
@@ -524,7 +524,7 @@ export function shouldAutoGenerateTags(
     );
   } else if (
     !!runContext?.toolConfiguration &&
-    isServerSideMCPToolConfiguration(runContext.toolConfiguration) &&
+    isLightServerSideMCPToolConfiguration(runContext.toolConfiguration) &&
     !!runContext.toolConfiguration.dataSources
   ) {
     return hasTagAutoMode(runContext.toolConfiguration.dataSources);

--- a/front/lib/actions/mcp_internal_actions/wrappers.ts
+++ b/front/lib/actions/mcp_internal_actions/wrappers.ts
@@ -55,13 +55,13 @@ export function withToolLogging<T>(
     if (agentLoopContext?.runContext) {
       const {
         agentConfiguration,
-        actionConfiguration,
+        toolConfiguration,
         conversation,
         agentMessage,
       } = agentLoopContext.runContext;
       loggerArgs = {
         ...loggerArgs,
-        actionConfigurationId: actionConfiguration.sId,
+        actionConfigurationId: toolConfiguration.sId,
         agentConfigurationId: agentConfiguration.sId,
         agentConfigurationVersion: agentConfiguration.version,
         agentMessageId: agentMessage.sId,

--- a/front/lib/actions/types/guards.ts
+++ b/front/lib/actions/types/guards.ts
@@ -1,5 +1,7 @@
 import type {
   ClientSideMCPToolConfigurationType,
+  LightMCPToolConfigurationType,
+  LightServerSideMCPToolConfigurationType,
   MCPActionType,
   MCPServerConfigurationType,
   MCPToolConfigurationType,
@@ -186,10 +188,10 @@ export function isMCPInternalNotion(
 }
 
 export function isMCPInternalDustAppRun(
-  arg: MCPToolConfigurationType
-): arg is ServerSideMCPToolConfigurationType {
+  arg: LightMCPToolConfigurationType
+): arg is LightServerSideMCPToolConfigurationType {
   return (
-    isServerSideMCPToolConfiguration(arg) &&
+    isLightServerSideMCPToolConfiguration(arg) &&
     isInternalMCPServerOfName(arg.internalMCPServerId, "run_dust_app")
   );
 }
@@ -198,6 +200,16 @@ export function isServerSideMCPToolConfiguration(
   arg: MCPToolConfigurationType
 ): arg is ServerSideMCPToolConfigurationType {
   return isMCPToolConfiguration(arg) && "mcpServerViewId" in arg;
+}
+
+export function isLightServerSideMCPToolConfiguration(
+  arg: unknown
+): arg is LightServerSideMCPToolConfigurationType {
+  return (
+    isMCPToolConfiguration(arg) &&
+    "mcpServerViewId" in arg &&
+    !("inputSchema" in arg)
+  );
 }
 
 export function isClientSideMCPToolConfiguration(

--- a/front/lib/actions/types/index.ts
+++ b/front/lib/actions/types/index.ts
@@ -26,11 +26,11 @@ export type ActionGeneratedFileType = {
 
 export type AgentLoopRunContextType = {
   agentConfiguration: AgentConfigurationType;
-  actionConfiguration: MCPToolConfigurationType;
+  agentMessage: AgentMessageType;
   clientSideActionConfigurations?: ClientSideMCPServerConfigurationType[];
   conversation: ConversationType;
-  agentMessage: AgentMessageType;
   stepContext: StepContext;
+  toolConfiguration: MCPToolConfigurationType;
 };
 
 export type AgentLoopListToolsContextType = {

--- a/front/lib/actions/types/index.ts
+++ b/front/lib/actions/types/index.ts
@@ -1,7 +1,7 @@
 import type {
   ClientSideMCPServerConfigurationType,
+  LightMCPToolConfigurationType,
   MCPServerConfigurationType,
-  MCPToolConfigurationType,
 } from "@app/lib/actions/mcp";
 import type {
   AgentConfigurationType,
@@ -30,7 +30,7 @@ export type AgentLoopRunContextType = {
   clientSideActionConfigurations?: ClientSideMCPServerConfigurationType[];
   conversation: ConversationType;
   stepContext: StepContext;
-  toolConfiguration: MCPToolConfigurationType;
+  toolConfiguration: LightMCPToolConfigurationType;
 };
 
 export type AgentLoopListToolsContextType = {

--- a/front/lib/models/assistant/actions/mcp.ts
+++ b/front/lib/models/assistant/actions/mcp.ts
@@ -3,7 +3,7 @@ import type { JSONSchema7 as JSONSchema } from "json-schema";
 import type { CreationOptional, ForeignKey, NonAttribute } from "sequelize";
 import { DataTypes } from "sequelize";
 
-import type { MCPToolConfigurationType } from "@app/lib/actions/mcp";
+import type { LightMCPToolConfigurationType } from "@app/lib/actions/mcp";
 import { MCPServerViewModel } from "@app/lib/models/assistant/actions/mcp_server_view";
 import { AgentConfiguration } from "@app/lib/models/assistant/agent";
 import { AgentStepContentModel } from "@app/lib/models/assistant/agent_step_content";
@@ -198,7 +198,7 @@ export class AgentMCPAction extends WorkspaceAwareModel<AgentMCPAction> {
 
   declare citationsAllocated: number;
   declare augmentedInputs: Record<string, unknown>;
-  declare toolConfiguration: MCPToolConfigurationType;
+  declare toolConfiguration: LightMCPToolConfigurationType;
 
   declare outputItems: NonAttribute<AgentMCPActionOutputItem[]>;
   declare agentMessage?: NonAttribute<AgentMessage>;

--- a/front/lib/models/assistant/actions/mcp.ts
+++ b/front/lib/models/assistant/actions/mcp.ts
@@ -3,6 +3,7 @@ import type { JSONSchema7 as JSONSchema } from "json-schema";
 import type { CreationOptional, ForeignKey, NonAttribute } from "sequelize";
 import { DataTypes } from "sequelize";
 
+import type { MCPToolConfigurationType } from "@app/lib/actions/mcp";
 import { MCPServerViewModel } from "@app/lib/models/assistant/actions/mcp_server_view";
 import { AgentConfiguration } from "@app/lib/models/assistant/agent";
 import { AgentStepContentModel } from "@app/lib/models/assistant/agent_step_content";
@@ -197,6 +198,7 @@ export class AgentMCPAction extends WorkspaceAwareModel<AgentMCPAction> {
 
   declare citationsAllocated: number;
   declare augmentedInputs: Record<string, unknown>;
+  declare toolConfiguration: MCPToolConfigurationType;
 
   declare outputItems: NonAttribute<AgentMCPActionOutputItem[]>;
   declare agentMessage?: NonAttribute<AgentMessage>;
@@ -249,6 +251,11 @@ AgentMCPAction.init(
       defaultValue: 0,
     },
     augmentedInputs: {
+      type: DataTypes.JSONB,
+      allowNull: false,
+      defaultValue: {},
+    },
+    toolConfiguration: {
       type: DataTypes.JSONB,
       allowNull: false,
       defaultValue: {},

--- a/front/migrations/db/migration_332.sql
+++ b/front/migrations/db/migration_332.sql
@@ -1,0 +1,2 @@
+-- Migration created on Aug 08, 2025
+ALTER TABLE "public"."agent_mcp_actions" ADD COLUMN "toolConfiguration" JSONB NOT NULL DEFAULT '{}';

--- a/front/temporal/agent_loop/activities/create_tool_actions.ts
+++ b/front/temporal/agent_loop/activities/create_tool_actions.ts
@@ -21,7 +21,6 @@ import { getRunAgentData } from "@app/types/assistant/agent_run";
 
 interface ActionBlob {
   action: AgentMCPAction;
-  actionConfiguration: MCPToolConfigurationType;
   needsApproval: boolean;
 }
 
@@ -152,6 +151,7 @@ async function createActionForTool(
     augmentedInputs,
     stepContentId,
     stepContext,
+    toolConfiguration: actionConfiguration,
   });
 
   // Publish the tool params event.
@@ -211,7 +211,6 @@ async function createActionForTool(
 
   return {
     action: agentMCPAction,
-    actionConfiguration,
     needsApproval: status === "pending",
   };
 }

--- a/front/temporal/agent_loop/activities/create_tool_actions.ts
+++ b/front/temporal/agent_loop/activities/create_tool_actions.ts
@@ -148,10 +148,10 @@ async function createActionForTool(
   // the error will be stored on the parent agent message.
   const { action: agentMCPAction, mcpAction } = await createMCPAction(auth, {
     actionBaseParams,
+    actionConfiguration,
     augmentedInputs,
     stepContentId,
     stepContext,
-    toolConfiguration: actionConfiguration,
   });
 
   // Publish the tool params event.

--- a/front/temporal/agent_loop/activities/run_tool.ts
+++ b/front/temporal/agent_loop/activities/run_tool.ts
@@ -1,6 +1,5 @@
 import assert from "assert";
 
-import type { MCPToolConfigurationType } from "@app/lib/actions/mcp";
 import { MCPActionType } from "@app/lib/actions/mcp";
 import { runToolWithStreaming } from "@app/lib/actions/mcp";
 import type { StepContext } from "@app/lib/actions/types";
@@ -19,13 +18,11 @@ export async function runToolActivity(
   authType: AuthenticatorType,
   {
     actionId,
-    actionConfiguration,
     runAgentArgs,
     step,
     stepContext,
   }: {
     actionId: ModelId;
-    actionConfiguration: MCPToolConfigurationType;
     runAgentArgs: RunAgentArgs;
     step: number;
     stepContext: StepContext;
@@ -78,7 +75,7 @@ export async function runToolActivity(
     output: null,
   });
 
-  const eventStream = runToolWithStreaming(auth, actionConfiguration, {
+  const eventStream = runToolWithStreaming(auth, {
     action,
     actionBaseParams,
     agentConfiguration,

--- a/front/temporal/agent_loop/lib/agent_loop_executor.ts
+++ b/front/temporal/agent_loop/lib/agent_loop_executor.ts
@@ -65,11 +65,10 @@ export async function executeAgentLoop(
 
     // Execute tools.
     await Promise.all(
-      actionBlobs.map(({ action, actionConfiguration }, index) =>
+      actionBlobs.map(({ action }, index) =>
         activities.runToolActivity(authType, {
           actionId: action.id,
           runAgentArgs,
-          actionConfiguration,
           step: i,
           stepContext: stepContexts[index],
         })

--- a/front/temporal/relocation/lib/sql/insert.ts
+++ b/front/temporal/relocation/lib/sql/insert.ts
@@ -10,7 +10,7 @@ const JSONB_COLUMNS = [
   },
   {
     tableName: "agent_mcp_actions",
-    columns: ["augmentedInputs"],
+    columns: ["augmentedInputs", "toolConfiguration"],
   },
 ];
 


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
Follow up of https://github.com/dust-tt/dust/pull/14908.

This PR implements a pragmatic (but ugly) temporary solution to eliminate the dependency on passing heavyweight `actionConfiguration` objects between agent loop activities.

To support resumable workflows, we now store a lightweight version of the tool configuration directly in the `agent_mcp_actions` table. This approach omits bulky fields like `inputSchema` and `description` that aren't needed during tool execution, reducing storage size while keeping all the essential execution metadata.

This is far from ideal, but removing all dependencies on this one attributes is a several persons jobs. I'll create a few follow up cards for stakeholders.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

- [ ] Run SQL migration
- [ ] Deploy front
