### PR TITLE
[front] Change the input bar layout

### DIFF
--- a/front/components/assistant/AssistantPicker.tsx
+++ b/front/components/assistant/AssistantPicker.tsx
@@ -66,7 +66,7 @@ export function AssistantPicker({
       </DropdownMenuTrigger>
       <DropdownMenuContent
         className="h-96 w-96"
-        align="end"
+        align="start"
         dropdownHeaders={
           <>
             <DropdownMenuSearchbar

--- a/front/components/assistant/AssistantPicker.tsx
+++ b/front/components/assistant/AssistantPicker.tsx
@@ -57,7 +57,6 @@ export function AssistantPicker({
           <Button
             icon={RobotIcon}
             variant="ghost-secondary"
-            isSelect
             size={size}
             tooltip="Pick an agent"
             disabled={isLoading}

--- a/front/components/assistant/ToolsPicker.tsx
+++ b/front/components/assistant/ToolsPicker.tsx
@@ -94,7 +94,7 @@ export function ToolsPicker({
       </DropdownMenuTrigger>
       <DropdownMenuContent
         className="h-96 w-96"
-        align="end"
+        align="start"
         dropdownHeaders={
           <>
             <DropdownMenuSearchbar

--- a/front/components/assistant/ToolsPicker.tsx
+++ b/front/components/assistant/ToolsPicker.tsx
@@ -89,7 +89,6 @@ export function ToolsPicker({
           size="xs"
           tooltip="Tools"
           disabled={isLoading}
-          isSelect
         />
       </DropdownMenuTrigger>
       <DropdownMenuContent

--- a/front/components/assistant/conversation/input_bar/InputBarAttachmentsPicker.tsx
+++ b/front/components/assistant/conversation/input_bar/InputBarAttachmentsPicker.tsx
@@ -130,7 +130,6 @@ export const InputBarAttachmentsPicker = ({
           size="xs"
           disabled={isLoading}
           onClick={() => setIsOpen(!isOpen)}
-          isSelect
         />
       </DropdownMenuTrigger>
       <DropdownMenuContent

--- a/front/components/assistant/conversation/input_bar/InputBarAttachmentsPicker.tsx
+++ b/front/components/assistant/conversation/input_bar/InputBarAttachmentsPicker.tsx
@@ -136,7 +136,7 @@ export const InputBarAttachmentsPicker = ({
       <DropdownMenuContent
         className="h-80 w-80 xs:h-96 xs:w-96"
         collisionPadding={15}
-        align="end"
+        align="start"
         onInteractOutside={() => setIsOpen(false)}
         onEscapeKeyDown={() => setIsOpen(false)}
         dropdownHeaders={

--- a/front/components/assistant/conversation/input_bar/InputBarContainer.tsx
+++ b/front/components/assistant/conversation/input_bar/InputBarContainer.tsx
@@ -1,9 +1,4 @@
-import {
-  ArrowUpIcon,
-  Button,
-  FullscreenExitIcon,
-  FullscreenIcon,
-} from "@dust-tt/sparkle";
+import { ArrowUpIcon, Button } from "@dust-tt/sparkle";
 import type { Editor } from "@tiptap/react";
 import { EditorContent } from "@tiptap/react";
 import React, {

--- a/front/components/assistant/conversation/input_bar/InputBarContainer.tsx
+++ b/front/components/assistant/conversation/input_bar/InputBarContainer.tsx
@@ -92,7 +92,6 @@ const InputBarContainer = ({
 }: InputBarContainerProps) => {
   const { featureFlags } = useFeatureFlags({ workspaceId: owner.sId });
   const suggestions = useAssistantSuggestions(agentConfigurations, owner);
-  const [isExpanded, setIsExpanded] = useState(false);
   const [nodeOrUrlCandidate, setNodeOrUrlCandidate] = useState<
     UrlCandidate | NodeCandidate | null
   >(null);
@@ -122,7 +121,6 @@ const InputBarContainer = ({
   const { editor, editorService } = useCustomEditor({
     suggestions,
     onEnterKeyDown,
-    resetEditorContainerSize,
     disableAutoFocus,
     onUrlDetected: handleUrlDetected,
     suggestionHandler: mentionDropdown.getSuggestionHandler(),
@@ -238,27 +236,17 @@ const InputBarContainer = ({
 
   const fileInputRef = useRef<HTMLInputElement>(null);
 
-  function handleExpansionToggle() {
-    setIsExpanded((currentExpanded) => !currentExpanded);
-    // Focus at the end of the document when toggling expansion.
-    editorService.focusEnd();
-  }
-
-  function resetEditorContainerSize() {
-    setIsExpanded(false);
-  }
-
   const contentEditableClasses = classNames(
     "inline-block w-full",
     "border-0 px-2 outline-none ring-0 focus:border-0 focus:outline-none focus:ring-0",
     "whitespace-pre-wrap font-normal",
-    "pb-6 pt-4 sm:py-3.5" // Increased padding on mobile
+    "pt-4"
   );
 
   return (
     <div
       id="InputBarContainer"
-      className="relative flex min-h-[100px] flex-1 cursor-text flex-col justify-between sm:pt-0"
+      className="relative flex flex-1 cursor-text flex-col justify-between sm:pt-0"
     >
       <EditorContent
         editor={editor}
@@ -266,13 +254,11 @@ const InputBarContainer = ({
           contentEditableClasses,
           "scrollbar-hide",
           "overflow-y-auto",
-          isExpanded
-            ? "h-[60vh] max-h-[60vh] lg:h-[80vh] lg:max-h-[80vh]"
-            : "max-h-64"
+          "sd:min-h-14 max-h-[40vh] min-h-16"
         )}
       />
 
-      <div className="flex flex-row items-end justify-between gap-2 self-stretch pb-3 pr-3 sm:border-0">
+      <div className="flex flex-row items-end justify-between gap-2 self-stretch pb-3 pr-3 pt-1 sm:border-0">
         <div className="flex items-center py-0">
           {actions.includes("tools") && featureFlags.includes("jit_tools") && (
             <ToolsPicker
@@ -322,16 +308,6 @@ const InputBarContainer = ({
               )}
             />
           )}
-          {/* {actions.includes("fullscreen") && (
-            <div className="hidden sm:flex">
-              <Button
-                variant="ghost-secondary"
-                icon={isExpanded ? FullscreenExitIcon : FullscreenIcon}
-                size="xs"
-                onClick={handleExpansionToggle}
-              />
-            </div>
-          )} */}
         </div>
         <Button
           size="xs"
@@ -345,7 +321,6 @@ const InputBarContainer = ({
               editorService.getMarkdownAndMentions(),
               () => {
                 editorService.clearEditor();
-                resetEditorContainerSize();
               },
               editorService.setLoading
             );

--- a/front/components/assistant/conversation/input_bar/InputBarContainer.tsx
+++ b/front/components/assistant/conversation/input_bar/InputBarContainer.tsx
@@ -258,7 +258,7 @@ const InputBarContainer = ({
   return (
     <div
       id="InputBarContainer"
-      className="relative flex flex-1 cursor-text flex-col sm:pt-0"
+      className="relative flex min-h-[100px] flex-1 cursor-text flex-col justify-between sm:pt-0"
     >
       <EditorContent
         editor={editor}
@@ -272,7 +272,7 @@ const InputBarContainer = ({
         )}
       />
 
-      <div className="flex flex-row items-end justify-end gap-2 self-stretch pb-3 pr-3 sm:border-0">
+      <div className="flex flex-row items-end justify-between gap-2 self-stretch pb-3 pr-3 sm:border-0">
         <div className="flex items-center py-0">
           {actions.includes("tools") && featureFlags.includes("jit_tools") && (
             <ToolsPicker
@@ -322,7 +322,7 @@ const InputBarContainer = ({
               )}
             />
           )}
-          {actions.includes("fullscreen") && (
+          {/* {actions.includes("fullscreen") && (
             <div className="hidden sm:flex">
               <Button
                 variant="ghost-secondary"
@@ -331,7 +331,7 @@ const InputBarContainer = ({
                 onClick={handleExpansionToggle}
               />
             </div>
-          )}
+          )} */}
         </div>
         <Button
           size="xs"

--- a/front/components/assistant/conversation/input_bar/editor/useCustomEditor.tsx
+++ b/front/components/assistant/conversation/input_bar/editor/useCustomEditor.tsx
@@ -196,7 +196,6 @@ export interface CustomEditorProps {
     setLoading: (loading: boolean) => void
   ) => void;
   suggestions: EditorSuggestions;
-  resetEditorContainerSize: () => void;
   disableAutoFocus: boolean;
   onUrlDetected?: (candidate: UrlCandidate | NodeCandidate | null) => void;
   suggestionHandler: {
@@ -211,7 +210,6 @@ export interface CustomEditorProps {
 
 const useCustomEditor = ({
   onEnterKeyDown,
-  resetEditorContainerSize,
   suggestions,
   disableAutoFocus,
   onUrlDetected,
@@ -300,7 +298,6 @@ const useCustomEditor = ({
 
           const clearEditor = () => {
             editor.commands.clearContent();
-            resetEditorContainerSize();
           };
 
           const setLoading = (loading: boolean) => {


### PR DESCRIPTION
## Description
This PR is to change the layout of the input bar 
- Remove expanded button
- Remove arrow down icon from dropdown buttons
- Place the buttons on the left 
- Adjust height and spacing

before:
<img width="861" height="152" alt="Screenshot 2025-08-08 at 17 44 26" src="https://github.com/user-attachments/assets/6ffb5238-a8e4-4e90-9490-84f9ec9d68d9" />


after:
<img width="819" height="184" alt="Screenshot 2025-08-08 at 17 43 18" src="https://github.com/user-attachments/assets/1069ad99-117f-4985-b649-07040064794d" />


<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
