### PR TITLE
feat(snowflake): add support for views

### DIFF
--- a/connectors/src/connectors/snowflake/lib/permissions.ts
+++ b/connectors/src/connectors/snowflake/lib/permissions.ts
@@ -5,6 +5,7 @@ import {
   fetchDatabases,
   fetchSchemas,
   fetchTables,
+  fetchViews,
 } from "@connectors/connectors/snowflake/lib/snowflake_api";
 import {
   RemoteDatabaseModel,
@@ -127,8 +128,19 @@ export const fetchAvailableChildrenInSnowflake = async ({
     if (allTablesRes.isErr()) {
       return new Err(allTablesRes.error);
     }
+
+    const allViewsRes = await fetchViews({
+      credentials,
+      fromSchema: parentInternalId,
+    });
+    if (allViewsRes.isErr()) {
+      return new Err(allViewsRes.error);
+    }
+
+    const allTablesAndViews = [...allTablesRes.value, ...allViewsRes.value];
+
     return new Ok(
-      allTablesRes.value.map((row) => {
+      allTablesAndViews.map((row) => {
         const internalId = buildInternalId({
           databaseName,
           schemaName,


### PR DESCRIPTION
## Description

Adds support for Snowflake views.

The logic is a bit tricky -- the query plan still reports the underlying tables. 
So if it happens that the query plan uses tables that are outside of the explicitly allowed tables, we query `GET_OBJECT_REFERENCES` on each of the allowed tables. For views, this returns the table that is being referenced, so we can add those to the allow list.

## Tests

Tested locally

## Risk

Low. The only risk is that an agent can technically query a table it has not been  explicitly given access to if:
- it is allowed to query a view of that table
- the table itself can be queried via the role

## Deploy Plan

Deploy core and connectors