### PR TITLE
[front] Allow adding MCP servers if on the global space

### DIFF
--- a/front/components/assistant_builder/AddToolsDropdown.tsx
+++ b/front/components/assistant_builder/AddToolsDropdown.tsx
@@ -340,7 +340,9 @@ function MCPDropdownMenuItem({
       onClick={() => onClick(view)}
       disabled={
         view.serverType === "remote" &&
-        !allowedSpaces.some((s) => s.sId === view.spaceId)
+        !allowedSpaces.some(
+          (s) => s.sId === view.spaceId || s.kind === "global"
+        )
       }
     />
   );


### PR DESCRIPTION
## Description

- Closes https://github.com/dust-tt/tasks/issues/3739.
- This PR allows adding MCP servers in the Agent Builder if they are in the global space, which can be done via the "Available to all Spaces" toggle in `MCPServerDetailsSharing.tsx`.
- The goal is to match more closely the expectations set by the `MCPServerDetailsSharing.tsx`, which states that the toggle makes a tool available on all spaces.

## Tests

- Checked locally.

## Risk

- Permission logic.

## Deploy Plan

- Deploy front.
