### PR TITLE
[connectors] enh(Slack): show rate-limit specific message on SDK-handled rate limits hits

### DIFF
--- a/connectors/src/connectors/slack/bot.ts
+++ b/connectors/src/connectors/slack/bot.ts
@@ -33,6 +33,7 @@ import {
 } from "@connectors/connectors/slack/lib/bot_user_helpers";
 import {
   isSlackWebAPIPlatformError,
+  isWebAPIRateLimitedError,
   SlackExternalUserError,
   SlackMessageError,
 } from "@connectors/connectors/slack/lib/errors";
@@ -150,7 +151,7 @@ export async function botAnswerMessage(
         channelId: slackChannel,
         useCase: "bot",
       });
-      if (e instanceof ProviderRateLimitError) {
+      if (e instanceof ProviderRateLimitError || isWebAPIRateLimitedError(e)) {
         await slackClient.chat.postMessage({
           channel: slackChannel,
           blocks: makeMarkdownBlock(SLACK_RATE_LIMIT_ERROR_MESSAGE),

--- a/connectors/src/connectors/slack/lib/errors.ts
+++ b/connectors/src/connectors/slack/lib/errors.ts
@@ -1,11 +1,18 @@
 import type {
   ChatPostMessageResponse,
+  CodedError,
+  WebAPIHTTPError,
   WebAPIPlatformError,
+  WebAPIRateLimitedError,
 } from "@slack/web-api";
 import { ErrorCode } from "@slack/web-api";
 import type { Attributes } from "sequelize";
 
 import type { SlackChatBotMessage } from "@connectors/lib/models/slack";
+
+function isCodedError(error: unknown): error is CodedError {
+  return error != null && typeof error === "object" && "code" in error;
+}
 
 export class SlackExternalUserError extends Error {}
 
@@ -34,4 +41,40 @@ export function isSlackWebAPIPlatformErrorBotNotFound(
   err: unknown
 ): err is WebAPIPlatformError {
   return isSlackWebAPIPlatformError(err) && err.data.error === "bot_not_found";
+}
+
+// Type guards for Slack errors
+// See https://github.com/slackapi/node-slack-sdk/blob/main/packages/web-api/src/errors.ts.
+export function isWebAPIRateLimitedError(
+  error: unknown
+): error is WebAPIRateLimitedError {
+  return (
+    isCodedError(error) &&
+    error.code === ErrorCode.RateLimitedError &&
+    "retryAfter" in error &&
+    typeof error.retryAfter === "number"
+  );
+}
+
+export function isWebAPIHTTPError(error: unknown): error is WebAPIHTTPError {
+  return (
+    isCodedError(error) &&
+    error.code === ErrorCode.HTTPError &&
+    "statusCode" in error &&
+    typeof error.statusCode === "number"
+  );
+}
+
+export function isWebAPIPlatformError(
+  error: unknown
+): error is WebAPIPlatformError {
+  return (
+    isCodedError(error) &&
+    error.code === ErrorCode.PlatformError &&
+    "data" in error &&
+    error.data != null &&
+    typeof error.data === "object" &&
+    "error" in error.data &&
+    typeof error.data.error === "string"
+  );
 }


### PR DESCRIPTION
## Description

- Closes https://github.com/dust-tt/tasks/issues/3777.
- This PR fixes the specific rate limit message not being triggered on rate limits handled by the Slack SDK.
- Logs [here](https://app.datadoghq.eu/logs?query=%22Unexpected%20exception%20answering%20to%20Slack%20Chat%20Bot%20message%22%20%40connectorId%3A27576&agg_m=count&agg_m_source=base&agg_t=count&clustering_pattern_field_path=message&cols=host%2Cservice&event=AwAAAZiLIC6ZmiMqaQAAABhBWmlMSUQ1bkFBRGo1bTQ1aV9fU01BQUoAAAAkZjE5ODhiMjctYzQyNi00NDkyLThjOTMtY2ZlYTAzYWY5NWQ5AAAQLg&link_source=monitor_notif&messageDisplay=inline&refresh_mode=sliding&storage=hot&stream_sort=desc&viz=stream&from_ts=1754671773357&to_ts=1754686173357&live=false).

## Tests

- Could not trigger locally.

## Risk

- Low.

## Deploy Plan

- Deploy connectors.
