### PR TITLE
[front] Add logs on every return path of `runModelActivity`

### DIFF
--- a/front/temporal/agent_loop/activities/run_model.ts
+++ b/front/temporal/agent_loop/activities/run_model.ts
@@ -118,6 +118,7 @@ export async function runModelActivity({
 
   const isLegacyAgent = isLegacyAgentConfiguration(agentConfiguration);
   if (isLegacyAgent && step !== 0) {
+    localLogger.warn("Legacy agent only supports step 0.");
     // legacy agents stop after one step
     return null;
   }
@@ -521,6 +522,8 @@ export async function runModelActivity({
           step,
         }
       );
+      localLogger.error("Agent generation cancelled");
+
       return null;
     }
 
@@ -731,6 +734,7 @@ export async function runModelActivity({
         step,
       }
     );
+    localLogger.error("Agent message generation succeeded");
 
     return null;
   }


### PR DESCRIPTION
## Description

- Part of https://github.com/dust-tt/tasks/issues/3772.
- TL;DR the agent loop stops after a function call (tools are executed and we have tool outputs in db).
- The main running hypotheses for now are that `tryListMCPTools` stays hanging for some reason.
- This PR adds a log on every return of `runModelActivity` to help debugging.

## Tests

- N/A.

## Risk

- N/A.

## Deploy Plan

- Deploy front.
