### PR TITLE
[connectors] Fix support for non-organization users in webhooks

### DIFF
--- a/connectors/src/api/webhooks/webhook_github.ts
+++ b/connectors/src/api/webhooks/webhook_github.ts
@@ -255,7 +255,7 @@ const _webhookGithubAPIHandler = async (
         const login =
           "organization" in jsonBody
             ? jsonBody.organization.login
-            : jsonBody.user.login;
+            : jsonBody.sender.login;
         if (jsonBody.action === "opened" || jsonBody.action === "edited") {
           return syncIssue(
             enabledConnectors,

--- a/connectors/src/connectors/github/lib/github_webhooks.ts
+++ b/connectors/src/connectors/github/lib/github_webhooks.ts
@@ -132,7 +132,7 @@ const PullRequestPayloadSchema = t.intersection([
       organization: OrganizationSchema,
     }),
     t.type({
-      user: UserSchema,
+      sender: UserSchema,
     }),
   ]),
 ]);


### PR DESCRIPTION
## Description

- Closes https://github.com/dust-tt/tasks/issues/3775.
- The schema used to validate the payload of GitHub `pull_request` webhook had a small delta with [what we observed live](https://app.datadoghq.eu/logs?query=%22Could%20not%20process%20webhook%22%20%40provider%3Agithub%20%40jsonBody.pull_request.diff_url%3Ahttps%5C%3A%2F%2Fgithub.com%2FbenjaminW78%2A&agg_m=count&agg_m_source=base&agg_t=count&clustering_pattern_field_path=message&cols=host%2Cservice&event=AwAAAZiF1G_nmLym2QAAABhBWmlGMUhaWEFBQ3A1WHcxUUhQMExRQWwAAAAkMDE5ODg1ZTctODc3Yi00ZTI4LWEzN2EtN2U3ZmFhZTA5NGE1AAAyoA&messageDisplay=inline&refresh_mode=sliding&storage=hot&stream_sort=desc&viz=stream&from_ts=1754431482636&to_ts=1754690682636&live=true) and what's in the [official documentation](https://docs.github.com/en/webhooks/webhook-events-and-payloads?actionType=closed#pull_request).
- This change only affects non-organization users and `pull_request` events.

## Tests

## Risk

- Low.

## Deploy Plan

- Deploy connectors.
