### PR TITLE
[sparkle] - refacto(Dialog): enhance sizes

### DIFF
--- a/sparkle/src/components/Dialog.tsx
+++ b/sparkle/src/components/Dialog.tsx
@@ -28,14 +28,26 @@ const DialogOverlay = React.forwardRef<
 ));
 DialogOverlay.displayName = DialogPrimitive.Overlay.displayName;
 
-const DIALOG_SIZES = ["md", "lg", "xl", "full"] as const;
+const DIALOG_SIZES = ["md", "lg", "xl", "2xl", "full"] as const;
 type DialogSizeType = (typeof DIALOG_SIZES)[number];
+
+const DIALOG_HEIGHTS = ["md", "lg", "xl", "2xl", "full"] as const;
+type DialogHeightType = (typeof DIALOG_HEIGHTS)[number];
 
 const sizeClasses: Record<DialogSizeType, string> = {
   md: "sm:s-max-w-md",
   lg: "sm:s-max-w-xl",
   xl: "sm:s-max-w-3xl",
+  "2xl": "sm:s-max-w-5xl",
   full: "sm:s-max-w-full sm:s-h-full",
+};
+
+const heightClasses: Record<DialogHeightType, string> = {
+  md: "s-max-h-[90vh] sm:s-h-md",
+  lg: "s-max-h-[90vh] sm:s-h-lg",
+  xl: "s-max-h-[90vh] sm:s-h-xl",
+  "2xl": "s-max-h-[90vh] sm:s-h-2xl",
+  full: "s-h-full",
 };
 
 const dialogVariants = cva(
@@ -48,6 +60,7 @@ const dialogVariants = cva(
   {
     variants: {
       size: sizeClasses,
+      height: heightClasses,
     },
     defaultVariants: {
       size: "md",
@@ -58,6 +71,7 @@ const dialogVariants = cva(
 interface DialogContentProps
   extends React.ComponentPropsWithoutRef<typeof DialogPrimitive.Content> {
   size?: DialogSizeType;
+  height?: DialogHeightType;
   trapFocusScope?: boolean;
   isAlertDialog?: boolean;
 }
@@ -67,7 +81,15 @@ const DialogContent = React.forwardRef<
   DialogContentProps
 >(
   (
-    { className, children, size, trapFocusScope, isAlertDialog, ...props },
+    {
+      className,
+      children,
+      size,
+      height,
+      trapFocusScope,
+      isAlertDialog,
+      ...props
+    },
     ref
   ) => (
     <DialogPortal>
@@ -75,7 +97,7 @@ const DialogContent = React.forwardRef<
       <FocusScope trapped={trapFocusScope} asChild>
         <DialogPrimitive.Content
           ref={ref}
-          className={cn(dialogVariants({ size }), className)}
+          className={cn(dialogVariants({ size, height }), className)}
           onInteractOutside={
             isAlertDialog ? (e) => e.preventDefault() : props.onInteractOutside
           }

--- a/sparkle/src/components/Dialog.tsx
+++ b/sparkle/src/components/Dialog.tsx
@@ -31,7 +31,7 @@ DialogOverlay.displayName = DialogPrimitive.Overlay.displayName;
 const DIALOG_SIZES = ["md", "lg", "xl", "2xl", "full"] as const;
 type DialogSizeType = (typeof DIALOG_SIZES)[number];
 
-const DIALOG_HEIGHTS = ["md", "lg", "xl", "2xl", "full"] as const;
+const DIALOG_HEIGHTS = ["md", "lg", "xl", "2xl"] as const;
 type DialogHeightType = (typeof DIALOG_HEIGHTS)[number];
 
 const sizeClasses: Record<DialogSizeType, string> = {
@@ -47,7 +47,6 @@ const heightClasses: Record<DialogHeightType, string> = {
   lg: "s-max-h-[90vh] sm:s-h-lg",
   xl: "s-max-h-[90vh] sm:s-h-xl",
   "2xl": "s-max-h-[90vh] sm:s-h-2xl",
-  full: "s-h-full",
 };
 
 const dialogVariants = cva(

--- a/sparkle/src/components/MultiPageDialog.tsx
+++ b/sparkle/src/components/MultiPageDialog.tsx
@@ -15,24 +15,6 @@ import {
 import { ChevronLeftIcon, ChevronRightIcon } from "@sparkle/icons/app";
 import { cn } from "@sparkle/lib/utils";
 
-const MULTI_PAGE_DIALOG_SIZES = ["md", "lg", "xl"] as const;
-type MultiPageDialogSizeType = (typeof MULTI_PAGE_DIALOG_SIZES)[number];
-
-const multiPageDialogSizeClasses: Record<MultiPageDialogSizeType, string> = {
-  md: "s-h-100 s-max-h-screen",
-  lg: "s-h-125 s-max-h-screen",
-  xl: "s-h-150 s-max-h-screen",
-};
-
-const multiPageDialogHeightVariants = cva("", {
-  variants: {
-    size: multiPageDialogSizeClasses,
-  },
-  defaultVariants: {
-    size: "md",
-  },
-});
-
 const multiPageDialogLayoutVariants = cva(
   cn("s-flex s-flex-col s-h-full s-overflow-hidden")
 );
@@ -90,7 +72,8 @@ interface MultiPageDialogProps {
   pages: MultiPageDialogPage[];
   currentPageId: string;
   onPageChange: (pageId: string) => void;
-  size?: MultiPageDialogSizeType;
+  size?: React.ComponentProps<typeof DialogContent>["size"];
+  height?: React.ComponentProps<typeof DialogContent>["height"];
   trapFocusScope?: boolean;
   isAlertDialog?: boolean;
   showNavigation?: boolean;
@@ -117,6 +100,7 @@ const MultiPageDialogContent = React.forwardRef<
       currentPageId,
       onPageChange,
       size = "md",
+      height,
       trapFocusScope,
       isAlertDialog,
       showNavigation = true,
@@ -181,9 +165,10 @@ const MultiPageDialogContent = React.forwardRef<
       <DialogContent
         ref={ref}
         size={size}
+        height={height}
         trapFocusScope={trapFocusScope}
         isAlertDialog={isAlertDialog}
-        className={cn(multiPageDialogHeightVariants({ size }), className)}
+        className={className}
         {...props}
       >
         <div className={cn(multiPageDialogLayoutVariants())}>

--- a/sparkle/src/stories/Dialog.stories.tsx
+++ b/sparkle/src/stories/Dialog.stories.tsx
@@ -164,7 +164,7 @@ export const LargeContent: Story = {
       <DialogTrigger asChild>
         <Button label="View Terms" />
       </DialogTrigger>
-      <DialogContent size="xl">
+      <DialogContent size="2xl" height="md">
         <DialogHeader>
           <DialogTitle>Terms of Service</DialogTitle>
         </DialogHeader>
@@ -174,19 +174,34 @@ export const LargeContent: Story = {
             <p className="s-text-sm s-text-muted-foreground">
               Lorem ipsum dolor sit amet consectetur adipisicing elit. Quod
               possimus sit modi reprehenderit sed dolorem nisi nostrum,
-              dignissimos tempora eligendi!
+              dignissimos tempora eligendi! Sed enim sapiente molestias pariatur
+              earum ipsum exercitationem corrupti voluptates?
             </p>
             <h3 className="s-font-semibold">2. Terms of Use</h3>
             <p className="s-text-sm s-text-muted-foreground">
               Lorem ipsum dolor sit amet consectetur adipisicing elit. Quod
               possimus sit modi reprehenderit sed dolorem nisi nostrum,
-              dignissimos tempora eligendi!
+              dignissimos tempora eligendi! Minus voluptatem iste accusantium
+              delectus nesciunt adipisci vitae earum similique.
             </p>
             <h3 className="s-font-semibold">3. Privacy Policy</h3>
             <p className="s-text-sm s-text-muted-foreground">
               Lorem ipsum dolor sit amet consectetur adipisicing elit. Quod
               possimus sit modi reprehenderit sed dolorem nisi nostrum,
-              dignissimos tempora eligendi!
+              dignissimos tempora eligendi! Facere explicabo aliquam corporis
+              error consectetur veniam assumenda.
+            </p>
+            <h3 className="s-font-semibold">4. Data Processing</h3>
+            <p className="s-text-sm s-text-muted-foreground">
+              Lorem ipsum dolor sit amet consectetur adipisicing elit. Dolorem
+              ipsum inventore vel, voluptatem fugiat necessitatibus reiciendis
+              accusantium dignissimos optio error.
+            </p>
+            <h3 className="s-font-semibold">5. User Rights</h3>
+            <p className="s-text-sm s-text-muted-foreground">
+              Lorem ipsum dolor sit amet consectetur adipisicing elit. Deserunt
+              architecto dolorem corrupti accusamus optio neque officia
+              perferendis molestiae.
             </p>
           </div>
         </DialogContainer>

--- a/sparkle/src/stories/MultiPageDialog.stories.tsx
+++ b/sparkle/src/stories/MultiPageDialog.stories.tsx
@@ -277,6 +277,7 @@ export const SimpleToolDialog: Story = {
           currentPageId="tool-selection"
           onPageChange={() => {}}
           size="xl"
+          height="xl"
           leftButton={{
             label: "Cancel",
             variant: "outline",

--- a/sparkle/tailwind.config.js
+++ b/sparkle/tailwind.config.js
@@ -371,6 +371,12 @@ module.exports = {
         100: "400px",
         125: "500px",
         150: "600px",
+        175: "700px",
+        // Semantic height classes matching dialog widths
+        md: "448px",
+        lg: "576px",
+        xl: "768px",
+        "2xl": "1024px",
       },
       minHeight: (theme) => ({
         ...theme("spacing"),


### PR DESCRIPTION
## Description

This PR adds new size option '2xl' to the Dialog component and introduced height control properties to better handle dialog content scaling. This change enhances the flexibility of dialogs by allowing wider sizes and better height management, particularly useful for displaying multiple cards per row in components like MCPServerViewsDialog.

## Tests

Locally on storybook

## Risk

Low

## Deploy Plan

Publish sparkle
