### PR TITLE
Deprecate Slack connector bot

### DIFF
--- a/connectors/src/api/webhooks/slack/deprecated_bot.ts
+++ b/connectors/src/api/webhooks/slack/deprecated_bot.ts
@@ -43,7 +43,6 @@ export async function handleDeprecatedChatBot(
   res: Response,
   logger: Logger
 ) {
-  console.log("handleDeprecatedChatBot", req.body);
   const { event, team_id: slackTeamId } = req.body;
   const { channel: slackChannel, ts: slackMessageTs } = event;
 
@@ -71,11 +70,11 @@ export async function handleDeprecatedChatBot(
     )
   );
 
-  const deprecatedSlackConnector = connectors.find((c) => c?.type === "slack");
+  const deprecatedSlackConnector = connectors.find((c) => c.type === "slack");
   const deprecatedSlackConfiguration = slackConfigurations.find(
     (c) => c.connectorId === deprecatedSlackConnector?.id
   );
-  const slackBotConnector = connectors.find((c) => c?.type === "slack_bot");
+  const slackBotConnector = connectors.find((c) => c.type === "slack_bot");
   const slackBotConfiguration = slackConfigurations.find(
     (c) => c.connectorId === slackBotConnector?.id
   );

--- a/connectors/src/api/webhooks/slack/deprecated_bot.ts
+++ b/connectors/src/api/webhooks/slack/deprecated_bot.ts
@@ -1,0 +1,143 @@
+import type { WebClient } from "@slack/web-api";
+import type { Request, Response } from "express";
+import type { Logger } from "pino";
+
+import { makeMarkdownBlock } from "@connectors/connectors/slack/chat/blocks";
+import { getSlackClient } from "@connectors/connectors/slack/lib/slack_client";
+import { ConnectorResource } from "@connectors/resources/connector_resource";
+import { SlackConfigurationResource } from "@connectors/resources/slack_configuration_resource";
+import { removeNulls } from "@connectors/types/shared/utils/general";
+
+async function sendSlackMessage(
+  slackClient: WebClient,
+  {
+    channel,
+    threadTs,
+    message,
+  }: {
+    channel: string;
+    threadTs: string;
+    message: string;
+  },
+  logger: Logger
+) {
+  try {
+    await slackClient.chat.postMessage({
+      channel,
+      blocks: makeMarkdownBlock(message),
+      thread_ts: threadTs,
+    });
+  } catch (error) {
+    logger.error({ error }, "Error sending Slack message");
+  }
+}
+
+const SLACK_DEPRECATED_BOT_ERROR_MESSAGE =
+  "Oops! That's the deprecated version of Dust. Mention @dust instead!";
+
+const REQUIRE_SLACK_BOT_INSTALLATION_MESSAGE =
+  "Hi there! This version of Dust is deprecated. You can ask a Slack admin to install the new version of Dust on your Slack workspace!";
+
+export async function handleDeprecatedChatBot(
+  req: Request,
+  res: Response,
+  logger: Logger
+) {
+  console.log("handleDeprecatedChatBot", req.body);
+  const { event, team_id: slackTeamId } = req.body;
+  const { channel: slackChannel, ts: slackMessageTs } = event;
+
+  const localLogger = logger.child({
+    action: "handleDeprecatedChatBot",
+    slackChannel,
+    slackMessageTs,
+    slackTeamId,
+  });
+
+  const slackConfigurations =
+    await SlackConfigurationResource.listForTeamId(slackTeamId);
+  // If there are no slack configurations, return 200.
+  if (slackConfigurations.length === 0) {
+    localLogger.info("No deprecated Slack configurations found.", slackTeamId);
+
+    return res.status(200).send();
+  }
+
+  const connectors = removeNulls(
+    await Promise.all(
+      slackConfigurations.map((config) =>
+        ConnectorResource.fetchById(config.connectorId)
+      )
+    )
+  );
+
+  const deprecatedSlackConnector = connectors.find((c) => c?.type === "slack");
+  const deprecatedSlackConfiguration = slackConfigurations.find(
+    (c) => c.connectorId === deprecatedSlackConnector?.id
+  );
+  const slackBotConnector = connectors.find((c) => c?.type === "slack_bot");
+  const slackBotConfiguration = slackConfigurations.find(
+    (c) => c.connectorId === slackBotConnector?.id
+  );
+
+  // We need to answer 200 quickly to Slack, otherwise they will retry the HTTP request.
+  res.status(200).send();
+
+  if (!deprecatedSlackConnector) {
+    localLogger.info("No deprecated Slack connector found.");
+    return;
+  }
+
+  const deprecatedSlackClient = await getSlackClient(
+    deprecatedSlackConnector?.id
+  );
+
+  // Case 1: Slack bot connector is not installed.
+  if (!slackBotConnector) {
+    localLogger.info("Slack bot connector is not installed.");
+    return sendSlackMessage(
+      deprecatedSlackClient,
+      {
+        channel: slackChannel,
+        threadTs: slackMessageTs,
+        message: REQUIRE_SLACK_BOT_INSTALLATION_MESSAGE,
+      },
+      localLogger
+    );
+  }
+
+  const isDeprecatedBotEnabled = deprecatedSlackConfiguration?.botEnabled;
+  const isSlackBotEnabled = slackBotConfiguration?.botEnabled;
+
+  // Case 2: Both Slack connectors are installed but deprecated bot is still enabled.
+  if (slackBotConnector && isDeprecatedBotEnabled && !isSlackBotEnabled) {
+    localLogger.info("Deprecated bot is enabled but Slack bot is not.");
+
+    return sendSlackMessage(
+      deprecatedSlackClient,
+      {
+        channel: slackChannel,
+        threadTs: slackMessageTs,
+        message: REQUIRE_SLACK_BOT_INSTALLATION_MESSAGE,
+      },
+      localLogger
+    );
+  }
+
+  // Case 3: New bot is enabled but they are using the deprecated bot mention.
+  if (slackBotConnector && isSlackBotEnabled) {
+    localLogger.info(
+      "New bot is enabled but they are using the deprecated bot mention."
+    );
+
+    return sendSlackMessage(
+      deprecatedSlackClient,
+      {
+        channel: slackChannel,
+        threadTs: slackMessageTs,
+        message: SLACK_DEPRECATED_BOT_ERROR_MESSAGE,
+      },
+      localLogger
+    );
+  }
+}

--- a/connectors/src/api/webhooks/webhook_slack.ts
+++ b/connectors/src/api/webhooks/webhook_slack.ts
@@ -11,10 +11,7 @@ import type {
   SlackWebhookReqBody,
   SlackWebhookResBody,
 } from "@connectors/api/webhooks/slack/utils";
-import {
-  isSlackWebhookEventReqBody,
-  withTrace,
-} from "@connectors/api/webhooks/slack/utils";
+import { isSlackWebhookEventReqBody } from "@connectors/api/webhooks/slack/utils";
 import { getBotUserIdMemoized } from "@connectors/connectors/slack/lib/bot_user_helpers";
 import { updateSlackChannelInConnectorsDb } from "@connectors/connectors/slack/lib/channels";
 import {

--- a/connectors/src/api/webhooks/webhook_slack.ts
+++ b/connectors/src/api/webhooks/webhook_slack.ts
@@ -6,12 +6,12 @@ import {
   isChannelCreatedEvent,
   onChannelCreation,
 } from "@connectors/api/webhooks/slack/created_channel";
+import { handleDeprecatedChatBot } from "@connectors/api/webhooks/slack/deprecated_bot";
 import type {
   SlackWebhookReqBody,
   SlackWebhookResBody,
 } from "@connectors/api/webhooks/slack/utils";
 import {
-  handleChatBot,
   isSlackWebhookEventReqBody,
   withTrace,
 } from "@connectors/api/webhooks/slack/utils";
@@ -109,10 +109,7 @@ const _webhookSlackAPIHandler = async (
     try {
       switch (event.type) {
         case "app_mention": {
-          await withTrace({
-            "slack.team_id": teamId,
-            "slack.app": "slack",
-          })(handleChatBot)(req, res, logger);
+          await handleDeprecatedChatBot(req, res, logger);
           break;
         }
         /**
@@ -163,10 +160,7 @@ const _webhookSlackAPIHandler = async (
               return res.status(200).send();
             }
             // Message from an actual user (a human)
-            await withTrace({
-              "slack.team_id": teamId,
-              "slack.app": "slack",
-            })(handleChatBot)(req, res, logger);
+            await handleDeprecatedChatBot(req, res, logger);
             break;
           } else if (event.channel_type === "channel") {
             if (!event.channel) {


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
This PR fully deprecates the Slack data source connector that could be summon from Slack. All interactions must now go through the new slack bot connector. 

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
