### PR TITLE
enh: reduce claude high reasoning budget

### DIFF
--- a/core/src/providers/anthropic/anthropic.rs
+++ b/core/src/providers/anthropic/anthropic.rs
@@ -449,7 +449,7 @@ impl LLM for AnthropicLLM {
         let thinking = match (reasoning_effort, is_claude_4, is_auto_tool) {
             (Some(effort), true, true) => match effort.as_str() {
                 "medium" => Some(("enabled".to_string(), 1024)),
-                "high" => Some(("enabled".to_string(), 16_384)),
+                "high" => Some(("enabled".to_string(), 4096)),
                 _ => None,
             },
             _ => None,


### PR DESCRIPTION
## Description

16k is not usable because we count the whole budget each time, as AFAIK anthropic doesn't not provide the number of reasoning tokens generated.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
