### PR TITLE
Extend web browsing functionality

### DIFF
--- a/front/lib/actions/mcp_internal_actions/output_schemas.ts
+++ b/front/lib/actions/mcp_internal_actions/output_schemas.ts
@@ -453,7 +453,6 @@ export const BrowseResultResourceSchema = z.object({
   uri: z.string(), // Browsed url, might differ from the requested url
   text: z.string(),
   html: z.string().optional(),
-  extract: z.any().optional(),
   title: z.string().optional(),
   description: z.string().optional(),
   responseCode: z.string(),

--- a/front/lib/actions/mcp_internal_actions/output_schemas.ts
+++ b/front/lib/actions/mcp_internal_actions/output_schemas.ts
@@ -452,6 +452,8 @@ export const BrowseResultResourceSchema = z.object({
   requestedUrl: z.string(),
   uri: z.string(), // Browsed url, might differ from the requested url
   text: z.string(),
+  html: z.string().optional(),
+  extract: z.any().optional(),
   title: z.string().optional(),
   description: z.string().optional(),
   responseCode: z.string(),

--- a/front/lib/utils/webbrowse.ts
+++ b/front/lib/utils/webbrowse.ts
@@ -13,7 +13,11 @@ type BrowserScrapeMetadata = {
 };
 
 export type BrowseScrapeSuccessResponse = BrowserScrapeMetadata & {
-  markdown: string;
+  markdown?: string;
+  html?: string;
+  extract?: unknown;
+  screenshots?: string[];
+  links?: string[];
   title: string | undefined;
   description: string | undefined;
 };
@@ -25,14 +29,20 @@ export type BrowseScrapeErrorResponse = BrowserScrapeMetadata & {
 export function isBrowseScrapeSuccessResponse(
   response: BrowseScrapeSuccessResponse | BrowseScrapeErrorResponse
 ): response is BrowseScrapeSuccessResponse {
-  return "markdown" in response;
+  return "markdown" in response || "html" in response || "extract" in response;
 }
 
 /**
- * Fetches the content of a URL and returns it as markdown using Firecrawl
+ * Fetches the content of a URL and returns it as markdown, HTML, or extracted data using Firecrawl
  */
 export const browseUrl = async (
-  url: string
+  url: string,
+  format: "markdown" | "html" | "extract" = "markdown",
+  extractPrompt?: string,
+  options?: {
+    screenshotMode?: "none" | "viewport" | "fullPage";
+    links?: boolean;
+  }
 ): Promise<BrowseScrapeSuccessResponse | BrowseScrapeErrorResponse> => {
   if (!credentials.FIRECRAWL_API_KEY) {
     throw new Error(
@@ -44,11 +54,71 @@ export const browseUrl = async (
     apiKey: credentials.FIRECRAWL_API_KEY,
   });
 
+  type FirecrawlFormat =
+    | "markdown"
+    | "rawHtml"
+    | "links"
+    | "screenshot"
+    | "screenshot@fullPage"
+    | "extract";
+
+  interface ScrapeOptionsMinimal {
+    formats?: FirecrawlFormat[];
+    extract?: { prompt: string };
+  }
+
+  type ExtendedScrapeResponse = ScrapeResponse & {
+    markdown?: string;
+    rawHtml?: string;
+    extract?: unknown;
+    screenshot?: string;
+    links?: string[];
+    metadata?: { statusCode?: number; title?: string; description?: string };
+    actions?: unknown;
+    error?: string;
+    success?: boolean;
+  };
+
   let scrapeResult: ScrapeResponse;
   try {
-    scrapeResult = (await fc.scrapeUrl(url, {
-      formats: ["markdown"],
-    })) as ScrapeResponse;
+    const scrapeOptions: ScrapeOptionsMinimal = {};
+    const formats: FirecrawlFormat[] = [];
+
+    if (format === "extract") {
+      if (!extractPrompt) {
+        return {
+          error:
+            "When format is 'extract', provide extractPrompt (natural language).",
+          status: 400,
+          url: url,
+        };
+      }
+      formats.push("extract");
+      scrapeOptions.extract = { prompt: extractPrompt };
+    } else {
+      if (format === "html") {
+        formats.push("rawHtml");
+      } else {
+        formats.push("markdown");
+      }
+    }
+
+    if (options?.screenshotMode && options.screenshotMode !== "none") {
+      // Firecrawl requires choosing exactly one screenshot format
+      if (options.screenshotMode === "fullPage") {
+        formats.push("screenshot@fullPage");
+      } else {
+        formats.push("screenshot");
+      }
+    }
+
+    if (options?.links) {
+      formats.push("links");
+    }
+
+    scrapeOptions.formats = formats;
+
+    scrapeResult = (await fc.scrapeUrl(url, scrapeOptions)) as ScrapeResponse;
   } catch (error) {
     logger.error(
       {
@@ -66,6 +136,15 @@ export const browseUrl = async (
 
   if (!scrapeResult.success) {
     const errorMessage = scrapeResult.error || "Unknown error.";
+    logger.error(
+      {
+        url,
+        format,
+        error: errorMessage,
+        metadata: scrapeResult.metadata,
+      },
+      "[Firecrawl] Scrape request failed"
+    );
     return {
       error: errorMessage,
       status: scrapeResult.metadata?.statusCode || 500,
@@ -73,14 +152,114 @@ export const browseUrl = async (
     };
   }
 
-  if (scrapeResult.markdown) {
+  const extended = scrapeResult as ExtendedScrapeResponse;
+  let actionsScreenshots: string[] | undefined = undefined;
+  if (
+    extended.actions &&
+    typeof extended.actions === "object" &&
+    "screenshots" in (extended.actions as Record<string, unknown>)
+  ) {
+    const v = (extended.actions as { screenshots?: unknown }).screenshots;
+    if (Array.isArray(v) && v.every((x) => typeof x === "string")) {
+      actionsScreenshots = v as string[];
+    }
+  }
+
+  if (
+    format === "extract" &&
+    (scrapeResult as ExtendedScrapeResponse).extract
+  ) {
+    const sr = scrapeResult as ExtendedScrapeResponse;
+    const screenshots: string[] = [];
+    if (typeof sr.screenshot === "string") {
+      screenshots.push(sr.screenshot);
+    }
+    if (Array.isArray(actionsScreenshots)) {
+      screenshots.push(...actionsScreenshots);
+    }
     return {
-      markdown: scrapeResult.markdown,
-      title: scrapeResult.metadata?.title,
-      description: scrapeResult.metadata?.description,
-      status: scrapeResult.metadata?.statusCode ?? 200,
+      extract: sr.extract,
+      screenshots: screenshots.length ? screenshots : undefined,
+      links: sr.links,
+      title: sr.metadata?.title,
+      description: sr.metadata?.description,
+      status: sr.metadata?.statusCode ?? 200,
       url: url,
     };
+  } else if (format === "extract" && !scrapeResult.extract) {
+    logger.error(
+      {
+        url,
+        scrapeResult: JSON.stringify(scrapeResult),
+      },
+      "[Firecrawl] Extract format requested but no extract data returned"
+    );
+    return {
+      error:
+        "Extract format requested but no extract data was returned from Firecrawl",
+      status: scrapeResult.metadata?.statusCode ?? 500,
+      url: url,
+    };
+  } else if (
+    format === "html" &&
+    (scrapeResult as ExtendedScrapeResponse).rawHtml
+  ) {
+    const sr = scrapeResult as ExtendedScrapeResponse;
+    const screenshots: string[] = [];
+    if (typeof sr.screenshot === "string") {
+      screenshots.push(sr.screenshot);
+    }
+    if (Array.isArray(actionsScreenshots)) {
+      screenshots.push(...actionsScreenshots);
+    }
+    return {
+      html: sr.rawHtml,
+      screenshots: screenshots.length ? screenshots : undefined,
+      links: sr.links,
+      title: sr.metadata?.title,
+      description: sr.metadata?.description,
+      status: sr.metadata?.statusCode ?? 200,
+      url: url,
+    };
+  } else if (format === "markdown" && scrapeResult.markdown) {
+    const sr = scrapeResult as ExtendedScrapeResponse;
+    const screenshots: string[] = [];
+    if (typeof sr.screenshot === "string") {
+      screenshots.push(sr.screenshot);
+    }
+    if (Array.isArray(actionsScreenshots)) {
+      screenshots.push(...actionsScreenshots);
+    }
+    return {
+      markdown: sr.markdown,
+      screenshots: screenshots.length ? screenshots : undefined,
+      links: sr.links,
+      title: sr.metadata?.title,
+      description: sr.metadata?.description,
+      status: sr.metadata?.statusCode ?? 200,
+      url: url,
+    };
+  }
+
+  // If no primary format matched, but we asked for screenshots, still return them if present
+  if (options?.screenshotMode && options.screenshotMode !== "none") {
+    const sr = scrapeResult as ExtendedScrapeResponse;
+    const screenshots: string[] = [];
+    if (typeof sr.screenshot === "string") {
+      screenshots.push(sr.screenshot);
+    }
+    if (Array.isArray(actionsScreenshots)) {
+      screenshots.push(...actionsScreenshots);
+    }
+    if (screenshots.length) {
+      return {
+        screenshots,
+        title: sr.metadata?.title,
+        description: sr.metadata?.description,
+        status: sr.metadata?.statusCode ?? 200,
+        url,
+      };
+    }
   }
 
   return {
@@ -95,12 +274,18 @@ export const browseUrl = async (
  */
 export const browseUrls = async (
   urls: string[],
-  chunkSize = 8
+  chunkSize = 8,
+  format: "markdown" | "html" | "extract" = "markdown",
+  extractPrompt?: string,
+  options?: {
+    screenshotMode?: "none" | "viewport" | "fullPage";
+    links?: boolean;
+  }
 ): Promise<Array<BrowseScrapeSuccessResponse | BrowseScrapeErrorResponse>> => {
   const results = await concurrentExecutor(
     urls,
     async (url) => {
-      return browseUrl(url);
+      return browseUrl(url, format, extractPrompt, options);
     },
     { concurrency: chunkSize }
   );


### PR DESCRIPTION
## Description

* Extending firecrawler web tool to optionally do the following: gather links on page, take screenshots, return raw html, run agentic "extract" functionality with prompt

## Tests

<img width="713" height="465" alt="Screenshot 2025-08-10 at 10 42 31 PM" src="https://github.com/user-attachments/assets/cfb52283-d2ca-4b03-941d-59c94eedb7d0" />

## Risk

* Minimal - should be extension to web-browsing tool

## Deploy Plan
* Deploy front