### PR TITLE
[front] Update name only when unset or provisioned

### DIFF
--- a/front/lib/iam/users.ts
+++ b/front/lib/iam/users.ts
@@ -62,9 +62,11 @@ export async function maybeUpdateFromExternalUser(
 export async function createOrUpdateUser({
   user,
   externalUser,
+  forceNameUpdate = false,
 }: {
   user: UserResource | null;
   externalUser: ExternalUser;
+  forceNameUpdate?: boolean;
 }): Promise<{ user: UserResource; created: boolean }> {
   if (user) {
     const updateArgs: { [key: string]: string } = {};
@@ -77,15 +79,17 @@ export async function createOrUpdateUser({
     // Update the user object from the updated session information.
     updateArgs.username = externalUser.nickname;
 
-    if (externalUser.given_name && externalUser.family_name) {
-      updateArgs.firstName = softHtmlEscape(externalUser.given_name);
-      updateArgs.lastName = softHtmlEscape(externalUser.family_name);
-    } else {
-      const { firstName, lastName } = guessFirstAndLastNameFromFullName(
-        externalUser.name
-      );
-      updateArgs.firstName = softHtmlEscape(firstName);
-      updateArgs.lastName = softHtmlEscape(lastName || "");
+    if ((!user.firstName && !user.lastName) || forceNameUpdate) {
+      if (externalUser.given_name && externalUser.family_name) {
+        updateArgs.firstName = softHtmlEscape(externalUser.given_name);
+        updateArgs.lastName = softHtmlEscape(externalUser.family_name);
+      } else {
+        const { firstName, lastName } = guessFirstAndLastNameFromFullName(
+          externalUser.name
+        );
+        updateArgs.firstName = softHtmlEscape(firstName);
+        updateArgs.lastName = softHtmlEscape(lastName || "");
+      }
     }
 
     if (

--- a/front/temporal/workos_events_queue/activities.ts
+++ b/front/temporal/workos_events_queue/activities.ts
@@ -609,6 +609,7 @@ async function handleCreateOrUpdateWorkOSUser(
   const { user: createdOrUpdatedUser } = await createOrUpdateUser({
     user,
     externalUser,
+    forceNameUpdate: !!(workOSUser.firstName && workOSUser.lastName),
   });
 
   const membership =


### PR DESCRIPTION
## Description

- Do not update firstname/last name unless unset or forced.
- Provisioning can update first name / last name if it's set in directory

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

deploy front
