### PR TITLE
Fix: conversation layout

### DIFF
--- a/front/components/assistant/AssistantPicker.tsx
+++ b/front/components/assistant/AssistantPicker.tsx
@@ -20,6 +20,7 @@ interface AssistantPickerProps {
   assistants: LightAgentConfigurationType[];
   onItemClick: (assistant: LightAgentConfigurationType) => void;
   pickerButton?: React.ReactNode;
+  showDropdownArrow?: boolean;
   showFooterButtons?: boolean;
   size?: "xs" | "sm" | "md";
   isLoading?: boolean;
@@ -31,6 +32,7 @@ export function AssistantPicker({
   assistants,
   onItemClick,
   pickerButton,
+  showDropdownArrow = true,
   showFooterButtons = true,
   size = "md",
   isLoading = false,
@@ -57,7 +59,7 @@ export function AssistantPicker({
           <Button
             icon={RobotIcon}
             variant="ghost-secondary"
-            isSelect
+            isSelect={showDropdownArrow}
             size={size}
             tooltip="Pick an agent"
             disabled={isLoading}

--- a/front/components/assistant/ToolsPicker.tsx
+++ b/front/components/assistant/ToolsPicker.tsx
@@ -89,7 +89,6 @@ export function ToolsPicker({
           size="xs"
           tooltip="Tools"
           disabled={isLoading}
-          isSelect
         />
       </DropdownMenuTrigger>
       <DropdownMenuContent

--- a/front/components/assistant/conversation/input_bar/InputBarAttachmentsPicker.tsx
+++ b/front/components/assistant/conversation/input_bar/InputBarAttachmentsPicker.tsx
@@ -130,7 +130,6 @@ export const InputBarAttachmentsPicker = ({
           size="xs"
           disabled={isLoading}
           onClick={() => setIsOpen(!isOpen)}
-          isSelect
         />
       </DropdownMenuTrigger>
       <DropdownMenuContent

--- a/front/components/assistant/conversation/input_bar/InputBarContainer.tsx
+++ b/front/components/assistant/conversation/input_bar/InputBarContainer.tsx
@@ -258,22 +258,21 @@ const InputBarContainer = ({
   return (
     <div
       id="InputBarContainer"
-      className="relative flex flex-1 cursor-text flex-col sm:pt-0"
+      className="relative flex flex-1 cursor-text flex-row sm:pt-0"
     >
-      <EditorContent
-        editor={editor}
-        className={classNames(
-          contentEditableClasses,
-          "scrollbar-hide",
-          "overflow-y-auto",
-          isExpanded
-            ? "h-[60vh] max-h-[60vh] lg:h-[80vh] lg:max-h-[80vh]"
-            : "max-h-64"
-        )}
-      />
-
-      <div className="flex flex-row items-end justify-end gap-2 self-stretch pb-3 pr-3 sm:border-0">
-        <div className="flex items-center py-0">
+      <div className="flex flex-grow flex-col">
+        <EditorContent
+          editor={editor}
+          className={classNames(
+            contentEditableClasses,
+            "scrollbar-hide",
+            "overflow-y-auto",
+            isExpanded
+              ? "h-[60vh] max-h-[60vh] lg:h-[80vh] lg:max-h-[80vh]"
+              : "max-h-64 min-h-10"
+          )}
+        />
+        <div className="flex items-center pb-3 pt-0">
           {actions.includes("tools") && featureFlags.includes("jit_tools") && (
             <ToolsPicker
               owner={owner}
@@ -317,11 +316,17 @@ const InputBarContainer = ({
                 editorService.insertMention({ id: c.sId, label: c.name });
               }}
               assistants={allAssistants}
+              showDropdownArrow={false}
               showFooterButtons={actions.includes(
                 "assistants-list-with-actions"
               )}
             />
           )}
+        </div>
+      </div>
+
+      <div className="flex flex-col items-end justify-between gap-2 self-stretch pb-3 pr-3 pt-3 sm:border-0">
+        <div className="flex items-center">
           {actions.includes("fullscreen") && (
             <div className="hidden sm:flex">
               <Button

--- a/front/components/assistant/conversation/input_bar/InputBarContainer.tsx
+++ b/front/components/assistant/conversation/input_bar/InputBarContainer.tsx
@@ -259,6 +259,12 @@ const InputBarContainer = ({
     <div
       id="InputBarContainer"
       className="relative flex flex-1 cursor-text flex-row sm:pt-0"
+      onClick={(e) => {
+        // If e.target is not a child of a div with class "tiptap", then focus on the editor
+        if (!(e.target instanceof HTMLElement && e.target.closest(".tiptap"))) {
+          editorService.focusEnd();
+        }
+      }}
     >
       <div className="flex flex-grow flex-col">
         <EditorContent


### PR DESCRIPTION
## Description

Rework layout to give more space to message area while keeping all buttons.

<img width="828" height="157" alt="image" src="https://github.com/user-attachments/assets/bc7016e3-6e29-49d5-914a-0ffdc74bd63a" />
<img width="797" height="304" alt="image" src="https://github.com/user-attachments/assets/40b34826-6de4-432e-a4d5-95bbb53022d4" />
<img width="294" height="369" alt="image" src="https://github.com/user-attachments/assets/e77947cd-5ad2-4200-a6be-4d7c9ebda4bd" />


## Tests

Local, tested mobile as well.

## Risk

Low

## Deploy Plan

Deploy front