### PR TITLE
Drop migrated_to_csv column and tables_rows table

### DIFF
--- a/core/src/stores/migrations/20250811_drop_csv_migration_field.sql
+++ b/core/src/stores/migrations/20250811_drop_csv_migration_field.sql
@@ -1,0 +1,2 @@
+ALTER TABLE tables
+DROP COLUMN migrated_to_csv;

--- a/core/src/stores/migrations/20250811_drop_table_tables_rows.sql
+++ b/core/src/stores/migrations/20250811_drop_table_tables_rows.sql
@@ -1,0 +1,2 @@
+-- Note that this migration needs to be run on $DATABASES_STORE_DATABASE_URI, not $CORE_DATABASE_URI
+DROP TABLE tables_rows;


### PR DESCRIPTION
## Description

The migrated_to_csv column of the tables table and tables_rows table are no longer needed now that we migrated to GCS for table storage.

Fixes https://github.com/dust-tt/tasks/issues/3669 and https://github.com/dust-tt/tasks/issues/3636

Later, we can delete the dust_databases_store altogether, since it only has this one table.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

Run the two migration scripts. No need to lock anything since the dropped objects are no longer used.