### PR TITLE
feat(data-warehouses): add skeleton

### DIFF
--- a/front/lib/actions/mcp_internal_actions/constants.ts
+++ b/front/lib/actions/mcp_internal_actions/constants.ts
@@ -49,6 +49,7 @@ export const AVAILABLE_INTERNAL_MCP_SERVER_NAMES = [
   "outlook_calendar",
   "slack",
   "agent_memory",
+  "data_warehouses",
 ] as const;
 
 // Whether the server is available by default in the global space.
@@ -583,6 +584,17 @@ export const INTERNAL_MCP_SERVERS = {
     tools_stakes: {
       create_agent: "high",
     },
+    timeoutMs: undefined,
+  },
+  data_warehouses: {
+    id: 1012,
+    availability: "auto",
+    allowMultipleInstances: false,
+    isPreview: true,
+    isRestricted: ({ featureFlags }) => {
+      return !featureFlags.includes("data_warehouses_tool");
+    },
+    tools_stakes: undefined,
     timeoutMs: undefined,
   },
   // Using satisfies here instead of : type to avoid typescript widening the type and breaking the type inference for AutoInternalMCPServerNameType.

--- a/front/lib/actions/mcp_internal_actions/input_configuration.ts
+++ b/front/lib/actions/mcp_internal_actions/input_configuration.ts
@@ -71,6 +71,15 @@ function generateConfiguredInput({
       );
     }
 
+    case INTERNAL_MIME_TYPES.TOOL_INPUT.DATA_WAREHOUSE: {
+      return (
+        actionConfiguration.dataSources?.map((config) => ({
+          uri: getDataSourceURI(config),
+          mimeType,
+        })) || []
+      );
+    }
+
     case INTERNAL_MIME_TYPES.TOOL_INPUT.TABLE: {
       return (
         actionConfiguration.tables?.map((config) => ({

--- a/front/lib/actions/mcp_internal_actions/input_schemas.ts
+++ b/front/lib/actions/mcp_internal_actions/input_schemas.ts
@@ -102,6 +102,12 @@ export const ConfigurableToolInputSchemas = {
       mimeType: z.literal(INTERNAL_MIME_TYPES.TOOL_INPUT.DATA_SOURCE),
     })
   ),
+  [INTERNAL_MIME_TYPES.TOOL_INPUT.DATA_WAREHOUSE]: z.array(
+    z.object({
+      uri: z.string().regex(DATA_SOURCE_CONFIGURATION_URI_PATTERN),
+      mimeType: z.literal(INTERNAL_MIME_TYPES.TOOL_INPUT.DATA_WAREHOUSE),
+    })
+  ),
   [INTERNAL_MIME_TYPES.TOOL_INPUT.TABLE]: z.array(
     z.object({
       uri: z.string().regex(TABLE_CONFIGURATION_URI_PATTERN),

--- a/front/lib/actions/mcp_internal_actions/servers/data_warehouses/server.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/data_warehouses/server.ts
@@ -1,0 +1,199 @@
+import { INTERNAL_MIME_TYPES } from "@dust-tt/client";
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { z } from "zod";
+
+import { ConfigurableToolInputSchemas } from "@app/lib/actions/mcp_internal_actions/input_schemas";
+import { withToolLogging } from "@app/lib/actions/mcp_internal_actions/wrappers";
+import type { AgentLoopContextType } from "@app/lib/actions/types";
+import type { InternalMCPServerDefinitionType } from "@app/lib/api/mcp";
+import type { Authenticator } from "@app/lib/auth";
+
+const TABLES_FILESYSTEM_TOOL_NAME = "tables_filesystem_navigation";
+
+const DEFAULT_LIMIT = 50;
+const MAX_LIMIT = 100;
+
+const serverInfo: InternalMCPServerDefinitionType = {
+  name: "data_warehouses",
+  version: "1.0.0",
+  description:
+    "Comprehensive tables navigation toolkit for browsing data warehouses and tables. Provides Unix-like " +
+    "browsing (ls, find) to help agents efficiently explore and discover tables organized in a " +
+    "warehouse-centric hierarchy. Each warehouse contains schemas/databases which contain tables.",
+  authorization: null,
+  icon: "ActionTableIcon",
+  documentationUrl: null,
+};
+
+const createServer = (
+  auth: Authenticator,
+  agentLoopContext?: AgentLoopContextType
+): McpServer => {
+  const server = new McpServer(serverInfo);
+
+  server.tool(
+    "list",
+    "List the direct contents of a warehouse, database, or schema. Can be used to see what is inside a " +
+      "specific location in the tables hierarchy, like 'ls' in Unix. If no nodeId is provided, lists " +
+      "all available data warehouses at the root level. Hierarchy supports: warehouse → database → schema → " +
+      "nested schemas → tables. Schemas can be arbitrarily nested within other schemas. Results are paginated " +
+      "with a default limit and you can fetch additional pages using the nextPageCursor.",
+    {
+      dataSources:
+        ConfigurableToolInputSchemas[
+          INTERNAL_MIME_TYPES.TOOL_INPUT.DATA_WAREHOUSE
+        ],
+      nodeId: z
+        .string()
+        .nullable()
+        .describe(
+          "The ID of the warehouse, database, or schema to list contents of. " +
+            "If not provided, lists all available data warehouses at the root."
+        ),
+      limit: z
+        .number()
+        .optional()
+        .describe(
+          `Maximum number of results to return. Default is ${DEFAULT_LIMIT}, max is ${MAX_LIMIT}.`
+        ),
+      nextPageCursor: z
+        .string()
+        .optional()
+        .describe(
+          "Cursor for fetching the next page of results. Use the 'nextPageCursor' from " +
+            "the previous list result to fetch additional items."
+        ),
+    },
+    withToolLogging(
+      auth,
+      { toolName: TABLES_FILESYSTEM_TOOL_NAME, agentLoopContext },
+      async (args) => {
+        void args;
+        throw new Error("Not implemented");
+      }
+    )
+  );
+
+  server.tool(
+    "find",
+    "Find tables, schemas and databases based on their name starting from a specific node in the tables hierarchy. " +
+      "Can be used to search for tables by name across warehouses, databases, and schemas. " +
+      "The query supports partial matching - for example, searching for 'sales' will find " +
+      "'sales_2024', 'monthly_sales_report', etc. This is like using 'find' in Unix for tables.",
+    {
+      dataSources:
+        ConfigurableToolInputSchemas[
+          INTERNAL_MIME_TYPES.TOOL_INPUT.DATA_WAREHOUSE
+        ],
+      query: z
+        .string()
+        .optional()
+        .describe(
+          "The table name to search for. This supports partial matching and does not require the " +
+            "exact name. For example, searching for 'revenue' will find 'revenue_2024', " +
+            "'monthly_revenue', 'revenue_by_region', etc. If omitted, lists all tables."
+        ),
+      rootNodeId: z
+        .string()
+        .optional()
+        .describe(
+          "The node ID to start the search from (warehouse, database, or schema ID). " +
+            "If not provided, searches across all available warehouses. This restricts the " +
+            "search to the specified node and all its descendants."
+        ),
+      limit: z
+        .number()
+        .optional()
+        .describe(
+          `Maximum number of results to return. Default is ${DEFAULT_LIMIT}, max is ${MAX_LIMIT}.`
+        ),
+      nextPageCursor: z
+        .string()
+        .optional()
+        .describe(
+          "Cursor for fetching the next page of results. Use the 'nextPageCursor' from " +
+            "the previous find result to fetch additional items."
+        ),
+    },
+    withToolLogging(
+      auth,
+      { toolName: TABLES_FILESYSTEM_TOOL_NAME, agentLoopContext },
+      async (args) => {
+        void args;
+        throw new Error("Not implemented");
+      }
+    )
+  );
+
+  server.tool(
+    "describe_tables",
+    "Get detailed schema information for one or more tables. Provides DBML schema definitions, " +
+      "SQL dialect-specific query guidelines, and example rows. All tables must be from the same " +
+      "warehouse - cross-warehouse schema requests are not supported. Use this to understand table " +
+      "structure before writing queries.",
+    {
+      dataSources:
+        ConfigurableToolInputSchemas[
+          INTERNAL_MIME_TYPES.TOOL_INPUT.DATA_WAREHOUSE
+        ],
+      tableIds: z
+        .array(z.string())
+        .min(1)
+        .describe(
+          "Array of table identifiers in the format 'table-<dataSourceSId>-<nodeId>'. " +
+            "All tables must be from the same warehouse (same dataSourceSId)."
+        ),
+    },
+    withToolLogging(
+      auth,
+      { toolName: TABLES_FILESYSTEM_TOOL_NAME, agentLoopContext },
+      async (args) => {
+        void args;
+        throw new Error("Not implemented");
+      }
+    )
+  );
+
+  server.tool(
+    "query",
+    "Execute SQL queries on tables from the same warehouse. You MUST call describe_tables at least once " +
+      "before attempting to query tables to understand their structure. The query must respect the SQL dialect " +
+      "and guidelines provided by describe_tables. All tables in a single query must be from the same warehouse.",
+    {
+      dataSources: ConfigurableToolInputSchemas[
+        INTERNAL_MIME_TYPES.TOOL_INPUT.DATA_WAREHOUSE
+      ]
+        .optional()
+        .describe(
+          "The data sources configured for this tool. This determines which warehouses and content nodes the tool can access."
+        ),
+      tableIds: z
+        .array(z.string())
+        .min(1)
+        .describe(
+          "Array of table identifiers in the format 'table-<dataSourceSId>-<nodeId>'. " +
+            "All tables must be from the same warehouse (same dataSourceSId)."
+        ),
+      query: z
+        .string()
+        .describe(
+          "The SQL query to execute. Must respect the SQL dialect and guidelines provided by describe_tables."
+        ),
+      fileName: z
+        .string()
+        .describe("The name of the file to save the results to."),
+    },
+    withToolLogging(
+      auth,
+      { toolName: TABLES_FILESYSTEM_TOOL_NAME, agentLoopContext },
+      async (args) => {
+        void args;
+        throw new Error("Not implemented");
+      }
+    )
+  );
+
+  return server;
+};
+
+export default createServer;

--- a/front/lib/actions/mcp_internal_actions/servers/index.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/index.ts
@@ -7,6 +7,7 @@ import { default as agentMemoryServer } from "@app/lib/actions/mcp_internal_acti
 import { default as agentRouterServer } from "@app/lib/actions/mcp_internal_actions/servers/agent_router";
 import { default as conversationFilesServer } from "@app/lib/actions/mcp_internal_actions/servers/conversation_files";
 import { default as dataSourcesFileSystemServer } from "@app/lib/actions/mcp_internal_actions/servers/data_sources_file_system";
+import { default as dataWarehousesServer } from "@app/lib/actions/mcp_internal_actions/servers/data_warehouses/server";
 import { default as generateFileServer } from "@app/lib/actions/mcp_internal_actions/servers/file_generation";
 import { default as freshserviceServer } from "@app/lib/actions/mcp_internal_actions/servers/freshservice/server";
 import { default as githubServer } from "@app/lib/actions/mcp_internal_actions/servers/github";
@@ -145,6 +146,8 @@ export async function getInternalMCPServer(
       return agentManagementServer(auth, agentLoopContext);
     case "freshservice":
       return freshserviceServer();
+    case "data_warehouses":
+      return dataWarehousesServer(auth, agentLoopContext);
     default:
       assertNever(internalMCPServerName);
   }

--- a/front/types/shared/feature_flags.ts
+++ b/front/types/shared/feature_flags.ts
@@ -154,6 +154,11 @@ export const WHITELISTABLE_FEATURES_CONFIG = {
     description: "Activate @research agent.",
     stage: "dust_only",
   },
+  data_warehouses_tool: {
+    description:
+      "Data warehouses file system navigation with hierarchical warehouse structure",
+    stage: "dust_only",
+  },
 } as const satisfies Record<string, FeatureFlag>;
 
 export type FeatureFlagStage = "dust_only" | "rolling_out" | "on_demand";

--- a/sdks/js/src/internal_mime_types.ts
+++ b/sdks/js/src/internal_mime_types.ts
@@ -55,16 +55,22 @@ function generateConnectorRelativeMimeTypes<
 // Mime type that represents a datasource.
 export const DATA_SOURCE_MIME_TYPE = "application/vnd.dust.datasource" as const;
 
+// Mime type that represents a data warehouse, like Snowflake or BigQuery.
+export const DATA_WAREHOUSE_MIME_TYPE =
+  "application/vnd.dust.data-warehouse" as const;
+
 export const DATA_SOURCE_FOLDER_SPREADSHEET_MIME_TYPE =
   "application/vnd.dust.folder.spreadsheet" as const;
 export type DataSourceFolderSpreadsheetMimeType =
   typeof DATA_SOURCE_FOLDER_SPREADSHEET_MIME_TYPE;
 
 type DataSourceMimeType = typeof DATA_SOURCE_MIME_TYPE;
+type DataWarehouseMimeType = typeof DATA_WAREHOUSE_MIME_TYPE;
 
 export const CONTENT_NODE_MIME_TYPES = {
   GENERIC: {
     DATA_SOURCE: DATA_SOURCE_MIME_TYPE,
+    DATA_WAREHOUSE: DATA_WAREHOUSE_MIME_TYPE,
   },
   FOLDER: {
     SPREADSHEET: DATA_SOURCE_FOLDER_SPREADSHEET_MIME_TYPE,
@@ -219,6 +225,7 @@ const TOOL_MIME_TYPES = {
     category: "TOOL_INPUT",
     resourceTypes: [
       "DATA_SOURCE",
+      "DATA_WAREHOUSE",
       "TABLE",
       "AGENT",
       "STRING",
@@ -344,6 +351,7 @@ export type DustMimeType =
   | SalesforceMimeType
   | GongMimeType
   | DataSourceMimeType
+  | DataWarehouseMimeType
   | DataSourceFolderSpreadsheetMimeType;
 
 export function isDustMimeType(mimeType: string): mimeType is DustMimeType {

--- a/sdks/js/src/types.ts
+++ b/sdks/js/src/types.ts
@@ -622,6 +622,7 @@ const WhitelistableFeaturesSchema = FlexibleEnumSchema<
   | "usage_data_api"
   | "xai_feature"
   | "agent_management_tool"
+  | "data_warehouses_tool"
 >();
 
 export type WhitelistableFeature = z.infer<typeof WhitelistableFeaturesSchema>;


### PR DESCRIPTION
## Description

Adds just the skeleton for the data warehouses tool (splitted off the [big branch](https://github.com/dust-tt/dust/pull/14836) )

A functional no-op, only adding feature flag, tool server, input mime type

## Tests

Local

## Risk

None

## Deploy Plan

deploy `front`