### PR TITLE
[front] - chore(AB v2): new tags block

### DIFF
--- a/front/components/agent_builder/AgentBuilderLeftPanel.tsx
+++ b/front/components/agent_builder/AgentBuilderLeftPanel.tsx
@@ -1,11 +1,5 @@
 import type { ButtonProps } from "@dust-tt/sparkle";
-import {
-  BarFooter,
-  BarHeader,
-  Button,
-  ScrollArea,
-  Separator,
-} from "@dust-tt/sparkle";
+import { BarFooter, BarHeader, Button, ScrollArea } from "@dust-tt/sparkle";
 import React from "react";
 
 import { AgentBuilderCapabilitiesBlock } from "@app/components/agent_builder/capabilities/AgentBuilderCapabilitiesBlock";
@@ -48,16 +42,16 @@ export function AgentBuilderLeftPanel({
     <div className="flex h-full flex-col">
       <BarHeader
         variant="default"
+        className="mx-4"
         title={title}
         rightActions={<AgentAccessPublicationDialog />}
       />
       <ScrollArea className="flex-1">
-        <div className="space-y-4 p-4">
+        <div className="space-y-10 p-4">
           <AgentBuilderInstructionsBlock
             agentConfigurationId={agentConfigurationId}
           />
           <AgentBuilderCapabilitiesBlock isActionsLoading={isActionsLoading} />
-          <Separator />
           <AgentBuilderSettingsBlock
             isSettingBlocksOpen={!agentConfigurationId}
           />
@@ -65,6 +59,7 @@ export function AgentBuilderLeftPanel({
       </ScrollArea>
       <BarFooter
         variant="default"
+        className="mx-4"
         leftActions={
           <Button variant="outline" label="Close" onClick={handleCancel} />
         }

--- a/front/components/agent_builder/AgentBuilderRightPanel.tsx
+++ b/front/components/agent_builder/AgentBuilderRightPanel.tsx
@@ -154,7 +154,7 @@ export function AgentBuilderRightPanel({
   };
 
   return (
-    <div className="flex h-full flex-col">
+    <div className="mx-4 flex h-full flex-col">
       <PanelHeader
         isPreviewPanelOpen={isPreviewPanelOpen}
         selectedTab={selectedTab}

--- a/front/components/agent_builder/capabilities/AgentBuilderCapabilitiesBlock.tsx
+++ b/front/components/agent_builder/capabilities/AgentBuilderCapabilitiesBlock.tsx
@@ -102,7 +102,7 @@ function ActionCard({ action, onRemove, onEdit }: ActionCardProps) {
   return (
     <Card
       variant="primary"
-      className="h-32"
+      className="h-28"
       onClick={onEdit}
       action={
         <CardActionButton

--- a/front/components/agent_builder/capabilities/knowledge/KnowledgeConfigurationSheet.tsx
+++ b/front/components/agent_builder/capabilities/knowledge/KnowledgeConfigurationSheet.tsx
@@ -143,7 +143,7 @@ export function KnowledgeConfigurationSheet({
     <MultiPageSheet open={open} onOpenChange={handleOpenChange}>
       <MultiPageSheetTrigger asChild>
         <Button
-          variant="outline"
+          variant="primary"
           label="Add knowledge"
           onClick={onClickKnowledge}
           icon={BookOpenIcon}

--- a/front/components/agent_builder/capabilities/mcp/MCPServerViewsDialog.tsx
+++ b/front/components/agent_builder/capabilities/mcp/MCPServerViewsDialog.tsx
@@ -710,12 +710,14 @@ export function MCPServerViewsDialog({
           onClick={() => onModeChange({ type: "add" })}
           label="Add tools"
           icon={ListAddIcon}
+          variant="outline"
         />
       </MultiPageDialogTrigger>
       <MultiPageDialogContent
         showNavigation={false}
         isAlertDialog
-        size="xl"
+        size="2xl"
+        height="xl"
         pages={pages}
         currentPageId={currentPageId}
         onPageChange={(pageId) => {

--- a/front/components/agent_builder/settings/TagsSection.tsx
+++ b/front/components/agent_builder/settings/TagsSection.tsx
@@ -1,14 +1,5 @@
-import {
-  Button,
-  Chip,
-  PopoverContent,
-  PopoverTrigger,
-  SparklesIcon,
-  Spinner,
-} from "@dust-tt/sparkle";
-import { PopoverRoot } from "@dust-tt/sparkle";
 import { useMemo, useState } from "react";
-import { useController, useFormContext } from "react-hook-form";
+import { useFieldArray, useFormContext } from "react-hook-form";
 
 import { useAgentBuilderContext } from "@app/components/agent_builder/AgentBuilderContext";
 import type { AgentBuilderFormData } from "@app/components/agent_builder/AgentBuilderFormContext";
@@ -60,55 +51,58 @@ export function TagsSection() {
   const { owner } = useAgentBuilderContext();
   const { getValues } = useFormContext<AgentBuilderFormData>();
   const { tags: allTags } = useTags({ owner });
-  const { field } = useController<AgentBuilderFormData, "agentSettings.tags">({
+  const {
+    fields: selectedTags,
+    append,
+    remove,
+  } = useFieldArray<AgentBuilderFormData, "agentSettings.tags">({
     name: "agentSettings.tags",
   });
   const sendNotification = useSendNotification();
 
-  const selectedTags = field.value;
-
-  const [filteredTagsSuggestions, setFilteredTagsSuggestions] = useState<
-    TagType[]
-  >([]);
-  const [isTagsSuggestionLoading, setTagsSuggestionsLoading] = useState(false);
+  const [isSuggestLoading, setIsSuggestLoading] = useState(false);
 
   const instructions = getValues("instructions");
 
+  const availableTagsCount = useMemo(() => {
+    const currentTagIds = new Set(selectedTags.map((field) => field.sId));
+    return allTags.filter((t) => !currentTagIds.has(t.sId)).length;
+  }, [allTags, selectedTags]);
+
   const isButtonDisabled = useMemo(() => {
     return (
+      isSuggestLoading ||
       !instructions ||
       instructions.length < MIN_INSTRUCTIONS_LENGTH_FOR_DROPDOWN_SUGGESTIONS ||
-      allTags.length === 0
+      availableTagsCount === 0
     );
-  }, [instructions, allTags.length]);
+  }, [isSuggestLoading, instructions, availableTagsCount]);
 
   const buttonTooltip = useMemo(() => {
+    if (isSuggestLoading) {
+      return "Generating suggestions...";
+    }
     if (
       !instructions ||
       instructions.length < MIN_INSTRUCTIONS_LENGTH_FOR_DROPDOWN_SUGGESTIONS
     ) {
       return `Add at least ${MIN_INSTRUCTIONS_LENGTH_FOR_DROPDOWN_SUGGESTIONS} characters to instructions to get suggestions`;
     }
-    if (allTags.length === 0) {
-      return "Create tags to start using suggestions";
+    if (availableTagsCount === 0) {
+      return allTags.length === 0
+        ? "Create tags to start using suggestions"
+        : "All available tags are already selected";
     }
-    return undefined;
-  }, [instructions, allTags.length]);
+    return "Generate tag suggestions";
+  }, [isSuggestLoading, instructions, availableTagsCount, allTags.length]);
 
-  const updateTagsSuggestions = async () => {
-    if (isTagsSuggestionLoading) {
-      return;
-    }
-
+  const getSuggestedTags = async (): Promise<TagType[]> => {
     if (
       !instructions ||
       instructions.length < MIN_INSTRUCTIONS_LENGTH_FOR_DROPDOWN_SUGGESTIONS
     ) {
-      return;
+      return [];
     }
-
-    setTagsSuggestionsLoading(true);
-    setFilteredTagsSuggestions([]);
 
     try {
       const description = getValues("agentSettings.description");
@@ -123,11 +117,9 @@ export function TagsSection() {
       if (tagsSuggestionsResult.isOk()) {
         const tagsSuggestions = tagsSuggestionsResult.value;
 
-        let filtered: TagType[] = [];
         if (tagsSuggestions.status === "ok") {
-          const currentTagIds = new Set(selectedTags.map((t) => t.sId));
-          // We make sure we don't suggest tags that already exists.
-          filtered = allTags
+          const currentTagIds = new Set(selectedTags.map((field) => field.sId));
+          return allTags
             .filter((t) => !currentTagIds.has(t.sId))
             .filter((t) => isBuilder(owner) || t.kind !== "protected")
             .filter(
@@ -138,27 +130,59 @@ export function TagsSection() {
             )
             .slice(0, 3);
         }
-
-        setFilteredTagsSuggestions(filtered);
-
-        if (tagsSuggestions.status === "ok" && filtered.length === 0) {
-          sendNotification({
-            title: "No tag suggestions available",
-            type: "info",
-            description:
-              "We couldn't find any relevant tags to suggest for this agent.",
-          });
-        }
       }
     } catch (err) {
       sendNotification({
-        title: "Could not populate any tag suggestions.",
+        title: "Could not get tag suggestions.",
         type: "error",
         description:
           "An error occurred while generating tag suggestions. Please contact us if the error persists.",
       });
+    }
+
+    return [];
+  };
+
+  const handleSuggestTags = async () => {
+    if (isSuggestLoading) {
+      return;
+    }
+
+    setIsSuggestLoading(true);
+
+    try {
+      const suggestedTags = await getSuggestedTags();
+
+      if (suggestedTags.length === 0) {
+        sendNotification({
+          title: "No tag suggestions available",
+          type: "info",
+          description:
+            "We couldn't find any relevant tags to suggest for this agent.",
+        });
+        return;
+      }
+
+      suggestedTags.forEach((tag) => append(tag));
+
+      sendNotification({
+        title: `Added ${suggestedTags.length} suggested tag${suggestedTags.length > 1 ? "s" : ""}`,
+        type: "success",
+        description: `Added: ${suggestedTags.map((t) => t.name).join(", ")}`,
+      });
     } finally {
-      setTagsSuggestionsLoading(false);
+      setIsSuggestLoading(false);
+    }
+  };
+
+  const handleAddTag = (tag: TagType) => {
+    append(tag);
+  };
+
+  const handleRemoveTag = (tagId: string) => {
+    const index = selectedTags.findIndex((field) => field.sId === tagId);
+    if (index !== -1) {
+      remove(index);
     }
   };
 
@@ -167,55 +191,12 @@ export function TagsSection() {
       <TagsSelector
         owner={owner}
         tags={selectedTags}
-        onTagsChange={field.onChange}
-        suggestionButton={
-          <PopoverRoot onOpenChange={(open) => open && updateTagsSuggestions()}>
-            <PopoverTrigger asChild>
-              <Button
-                label="Suggest"
-                icon={SparklesIcon}
-                variant="outline"
-                isSelect
-                disabled={isButtonDisabled}
-                tooltip={buttonTooltip}
-              />
-            </PopoverTrigger>
-            <PopoverContent className="w-64 p-3" side="top" align="start">
-              {isTagsSuggestionLoading ? (
-                <div className="flex items-center justify-center p-4">
-                  <Spinner size="sm" />
-                </div>
-              ) : filteredTagsSuggestions.length > 0 ? (
-                <div className="space-y-2">
-                  <div className="text-xs font-semibold text-muted-foreground dark:text-muted-foreground-night">
-                    Suggestions:
-                  </div>
-                  <div className="flex flex-wrap gap-2">
-                    {filteredTagsSuggestions.map((tag) => (
-                      <Chip
-                        key={`tag-suggestion-chip-${tag.sId}`}
-                        label={tag.name}
-                        size="xs"
-                        color="golden"
-                        onClick={() => {
-                          field.onChange([...selectedTags, tag]);
-                          setFilteredTagsSuggestions((prev) =>
-                            prev.filter((t) => t.sId !== tag.sId)
-                          );
-                        }}
-                        className="cursor-pointer hover:opacity-80"
-                      />
-                    ))}
-                  </div>
-                </div>
-              ) : (
-                <div className="flex items-center justify-center p-4 text-sm text-muted-foreground">
-                  No suggestions available
-                </div>
-              )}
-            </PopoverContent>
-          </PopoverRoot>
-        }
+        onAddTag={handleAddTag}
+        onRemoveTag={handleRemoveTag}
+        onSuggestTags={handleSuggestTags}
+        isSuggestLoading={isSuggestLoading}
+        isSuggestDisabled={isButtonDisabled}
+        suggestTooltip={buttonTooltip}
       />
     </SettingSectionContainer>
   );


### PR DESCRIPTION
## Description

This PR refactors the tags section in Agent Builder v2 by removing the `Popover` component and integrating tag suggestions directly into the `TagsSelector`. 

The changes streamline the code by:
- Replacing `useController` with `useFieldArray` for more direct tag array handling
- Moving suggestion button into `TagsSelector` with loading state
- Optimizing tag filtering logic by centralizing it in `TagsSection`

<img width="343" height="452" alt="Screenshot 2025-08-11 at 14 36 26" src="https://github.com/user-attachments/assets/db950f7d-8e00-41e9-a2e7-8a7ebfaa929c" />

## Tests

Locally

## Risk

Low, behind FF

## Deploy Plan

Deploy front