### PR TITLE
Save step context on agent action

### DIFF
--- a/front/lib/actions/mcp.ts
+++ b/front/lib/actions/mcp.ts
@@ -635,14 +635,14 @@ export async function createMCPAction(
   const action = await AgentMCPAction.create({
     agentMessageId: actionBaseParams.agentMessageId,
     augmentedInputs,
-    toolConfiguration,
     citationsAllocated: stepContext.citationsCount,
     executionState: "pending",
     isError: false,
     mcpServerConfigurationId: actionBaseParams.mcpServerConfigurationId,
     stepContentId,
-    version: 0,
     stepContext,
+    toolConfiguration,
+    version: 0,
     workspaceId: auth.getNonNullableWorkspace().id,
   });
 

--- a/front/lib/actions/mcp.ts
+++ b/front/lib/actions/mcp.ts
@@ -642,6 +642,7 @@ export async function createMCPAction(
     mcpServerConfigurationId: actionBaseParams.mcpServerConfigurationId,
     stepContentId,
     version: 0,
+    stepContext,
     workspaceId: auth.getNonNullableWorkspace().id,
   });
 

--- a/front/lib/models/assistant/actions/mcp.ts
+++ b/front/lib/models/assistant/actions/mcp.ts
@@ -4,6 +4,7 @@ import type { CreationOptional, ForeignKey, NonAttribute } from "sequelize";
 import { DataTypes } from "sequelize";
 
 import type { LightMCPToolConfigurationType } from "@app/lib/actions/mcp";
+import type { StepContext } from "@app/lib/actions/types";
 import { MCPServerViewModel } from "@app/lib/models/assistant/actions/mcp_server_view";
 import { AgentConfiguration } from "@app/lib/models/assistant/agent";
 import { AgentStepContentModel } from "@app/lib/models/assistant/agent_step_content";
@@ -199,6 +200,7 @@ export class AgentMCPAction extends WorkspaceAwareModel<AgentMCPAction> {
   declare citationsAllocated: number;
   declare augmentedInputs: Record<string, unknown>;
   declare toolConfiguration: LightMCPToolConfigurationType;
+  declare stepContext: StepContext;
 
   declare outputItems: NonAttribute<AgentMCPActionOutputItem[]>;
   declare agentMessage?: NonAttribute<AgentMessage>;
@@ -256,6 +258,11 @@ AgentMCPAction.init(
       defaultValue: {},
     },
     toolConfiguration: {
+      type: DataTypes.JSONB,
+      allowNull: false,
+      defaultValue: {},
+    },
+    stepContext: {
       type: DataTypes.JSONB,
       allowNull: false,
       defaultValue: {},

--- a/front/migrations/db/migration_333.sql
+++ b/front/migrations/db/migration_333.sql
@@ -1,0 +1,2 @@
+-- Migration created on Aug 11, 2025
+ALTER TABLE "public"."agent_mcp_actions" ADD COLUMN "stepContext" JSONB NOT NULL DEFAULT '{}';

--- a/front/temporal/agent_loop/activities/run_tool.ts
+++ b/front/temporal/agent_loop/activities/run_tool.ts
@@ -2,7 +2,6 @@ import assert from "assert";
 
 import { MCPActionType } from "@app/lib/actions/mcp";
 import { runToolWithStreaming } from "@app/lib/actions/mcp";
-import type { StepContext } from "@app/lib/actions/types";
 import type { AuthenticatorType } from "@app/lib/auth";
 import { Authenticator } from "@app/lib/auth";
 import { AgentMCPAction } from "@app/lib/models/assistant/actions/mcp";
@@ -20,12 +19,10 @@ export async function runToolActivity(
     actionId,
     runAgentArgs,
     step,
-    stepContext,
   }: {
     actionId: ModelId;
     runAgentArgs: RunAgentArgs;
     step: number;
-    stepContext: StepContext;
   }
 ): Promise<void> {
   const auth = await Authenticator.fromJSON(authType);
@@ -82,7 +79,7 @@ export async function runToolActivity(
     agentMessage,
     conversation,
     mcpAction,
-    stepContext,
+    stepContext: action.stepContext,
   });
 
   for await (const event of eventStream) {

--- a/front/temporal/agent_loop/lib/agent_loop_executor.ts
+++ b/front/temporal/agent_loop/lib/agent_loop_executor.ts
@@ -70,7 +70,6 @@ export async function executeAgentLoop(
           actionId: action.id,
           runAgentArgs,
           step: i,
-          stepContext: stepContexts[index],
         })
       )
     );


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
This PR is the last step towards saving all required information to resume the agent loop in DB. It kinds of overlaps with the existing `citationsAllocated` field. I'll drop this field later on. We don't expect the `stepContext` to stay around for a long time, we will clean things up afterward.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

- [x] Apply SQL migration
- [ ] Deploy front
