### PR TITLE
[front] Replace error log with info

### DIFF
--- a/front/temporal/agent_loop/activities/run_model.ts
+++ b/front/temporal/agent_loop/activities/run_model.ts
@@ -734,7 +734,7 @@ export async function runModelActivity({
         step,
       }
     );
-    localLogger.error("Agent message generation succeeded");
+    localLogger.info("Agent message generation succeeded");
 
     return null;
   }


### PR DESCRIPTION
## Description

- The `Agent message generation succeeded` log was incorrectly logged as an error rather than an info.
- This PR fixes that.

## Tests

## Risk

## Deploy Plan

- Deploy front.
