### PR TITLE
[front] abv2: tiptap fixes

### DIFF
--- a/front/components/agent_builder/instructions/InstructionBlockExtension.tsx
+++ b/front/components/agent_builder/instructions/InstructionBlockExtension.tsx
@@ -20,6 +20,7 @@ import {
   parseInstructionBlockMatches,
   splitTextAroundBlocks,
 } from "@app/lib/client/agent_builder/instructionBlockUtils";
+import { Button, Icon, IconButton, XMarkIcon } from "@dust-tt/sparkle";
 
 export interface InstructionBlockAttributes {
   type: string;
@@ -41,7 +42,7 @@ const InstructionBlockComponent: React.FC<NodeViewProps> = ({ node }) => {
 
   return (
     <NodeViewWrapper className="my-4">
-      <div className="rounded-lg border border-border bg-muted-background p-4">
+      <div className="rounded-lg border border-border bg-gray-100 p-4">
         <span
           className="text-sm font-semibold text-muted-foreground"
           contentEditable={false}
@@ -60,8 +61,10 @@ export const InstructionBlockExtension =
   Node.create<InstructionBlockAttributes>({
     name: "instructionBlock",
     group: "block",
-    content: "block+",
+    priority: 1000,
+    content: "paragraph+",
     defining: true,
+    isolating: true,
 
     addAttributes() {
       return {
@@ -134,6 +137,131 @@ export const InstructionBlockExtension =
           },
         }),
       ];
+    },
+
+    addKeyboardShortcuts() {
+      return {
+        "Shift-Enter": () => {
+          if (!this.editor.isActive(this.name)) {
+            return false;
+          }
+          return this.editor.commands.splitBlock();
+        },
+        ArrowDown: () => {
+          if (!this.editor.isActive(this.name)) {
+            return false;
+          }
+
+          const { state } = this.editor;
+          const { doc, selection } = state;
+          const $from = selection.$from;
+
+          // Find the depth of the surrounding instruction block
+          let blockDepth: number | null = null;
+          for (let d = $from.depth; d >= 0; d -= 1) {
+            if ($from.node(d).type.name === this.name) {
+              blockDepth = d;
+              break;
+            }
+          }
+
+          if (blockDepth === null) {
+            return false;
+          }
+
+          const blockNode = $from.node(blockDepth);
+
+          // Only trigger when at the end of the last child of the block
+          const isAtEndOfTextBlock =
+            selection.empty && $from.parentOffset === $from.parent.content.size;
+          const isInLastChildOfBlock =
+            $from.index(blockDepth) === blockNode.childCount - 1;
+
+          if (!isAtEndOfTextBlock || !isInLastChildOfBlock) {
+            return false;
+          }
+
+          const posBeforeBlock = $from.before(blockDepth);
+          const posAfterBlock = posBeforeBlock + blockNode.nodeSize;
+          const $after = doc.resolve(posAfterBlock);
+          const nextNode = $after.nodeAfter;
+
+          if (!nextNode || nextNode.type.name !== "paragraph") {
+            // Create a paragraph after the block if none exists
+            this.editor.commands.insertContentAt(posAfterBlock, {
+              type: "paragraph",
+            });
+          }
+
+          // Place the cursor at the start of the paragraph after the block
+          this.editor.commands.setTextSelection(posAfterBlock + 1);
+          this.editor.commands.focus();
+          return true;
+        },
+        ArrowUp: () => {
+          if (!this.editor.isActive(this.name)) {
+            return false;
+          }
+
+          const { state } = this.editor;
+          const { doc, selection } = state;
+          const $from = selection.$from;
+
+          // Find the depth of the surrounding instruction block
+          let blockDepth: number | null = null;
+          for (let d = $from.depth; d >= 0; d -= 1) {
+            if ($from.node(d).type.name === this.name) {
+              blockDepth = d;
+              break;
+            }
+          }
+
+          if (blockDepth === null) {
+            return false;
+          }
+
+          const blockNode = $from.node(blockDepth);
+
+          // Only trigger when at the start of the first child of the block
+          const isAtStartOfTextBlock =
+            selection.empty && $from.parentOffset === 0;
+          const isInFirstChildOfBlock = $from.index(blockDepth) === 0;
+
+          if (!isAtStartOfTextBlock || !isInFirstChildOfBlock) {
+            return false;
+          }
+
+          const posBeforeBlock = $from.before(blockDepth);
+          const $before = doc.resolve(posBeforeBlock);
+          const prevNode = $before.nodeBefore;
+
+          if (!prevNode || prevNode.type.name !== "paragraph") {
+            // Create a paragraph before the block if none exists
+            this.editor.commands.insertContentAt(posBeforeBlock, {
+              type: "paragraph",
+            });
+          }
+
+          // Place the cursor at the end of the paragraph before the block
+          // Find the new position after possible insertion
+          const $beforeAfterInsert = doc.resolve(posBeforeBlock);
+          const prevNodeAfterInsert = $beforeAfterInsert.nodeBefore;
+          let cursorPos;
+          if (
+            prevNodeAfterInsert &&
+            prevNodeAfterInsert.type.name === "paragraph"
+          ) {
+            // Place cursor at end of previous paragraph
+            cursorPos = posBeforeBlock - 1;
+          } else {
+            // Fallback: place at start of doc
+            cursorPos = 1;
+          }
+          this.editor.commands.setTextSelection(cursorPos);
+          this.editor.commands.focus();
+          return true;
+        },
+      };
     },
 
     addProseMirrorPlugins() {

--- a/front/components/agent_builder/instructions/InstructionBlockExtension.tsx
+++ b/front/components/agent_builder/instructions/InstructionBlockExtension.tsx
@@ -20,7 +20,6 @@ import {
   parseInstructionBlockMatches,
   splitTextAroundBlocks,
 } from "@app/lib/client/agent_builder/instructionBlockUtils";
-import { Button, Icon, IconButton, XMarkIcon } from "@dust-tt/sparkle";
 
 export interface InstructionBlockAttributes {
   type: string;
@@ -219,8 +218,6 @@ export const InstructionBlockExtension =
           if (blockDepth === null) {
             return false;
           }
-
-          const blockNode = $from.node(blockDepth);
 
           // Only trigger when at the start of the first child of the block
           const isAtStartOfTextBlock =


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

Parts of https://github.com/dust-tt/tasks/issues/3779

Users are now able to use arrow up/down to leave a block by the top or the bottom
Shift + enter now adds an extra line within the block.
+ background of blocks is now gray-100 as per figma.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

Tested by hand

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

Low risks

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->

Deploy front