### PR TITLE
[front] Add workspace ID to `uploadFileToConversationDataSource` logs

### DIFF
--- a/front/lib/actions/action_file_helpers.ts
+++ b/front/lib/actions/action_file_helpers.ts
@@ -210,6 +210,7 @@ export async function uploadFileToConversationDataSource({
   if (jitDataSource.isErr()) {
     logger.error(
       {
+        workspaceId: auth.workspace()?.sId,
         code: jitDataSource.error.code,
         message: jitDataSource.error.message,
       },
@@ -222,6 +223,7 @@ export async function uploadFileToConversationDataSource({
     if (r.isErr()) {
       logger.error(
         {
+          workspaceId: auth.workspace()?.sId,
           code: r.error.code,
           message: r.error.message,
         },


### PR DESCRIPTION
## Description

- This PR adds the workspace ID to the logs output by `uploadFileToConversationDataSource`.

## Tests

## Risk

## Deploy Plan

- Deploy front.
