### PR TITLE
[front] Add log on file not found for conversation data source creation

### DIFF
--- a/front/lib/actions/mcp_execution.ts
+++ b/front/lib/actions/mcp_execution.ts
@@ -331,6 +331,18 @@ export async function processToolResults(
             // who uploaded it to its own conversation but not the main agent's.
             if (file) {
               await uploadFileToConversationDataSource({ auth, file });
+            } else {
+              localLogger.error(
+                { fileId: block.resource.fileId },
+                "Error creating conversation data source for file"
+              );
+              return {
+                content: {
+                  type: "text",
+                  text: "Failed to upload file",
+                },
+                file: null,
+              };
             }
             return {
               content: {


### PR DESCRIPTION
## Description

- Follow up on https://github.com/dust-tt/dust/pull/14966.
- Context in [this thread](https://dust4ai.slack.com/archives/C05B529FHV1/p1754911822733959).
- This PR adds a log on conversation data source failed creations.

## Tests

## Risk

## Deploy Plan

- Deploy front.
