### PR TITLE
[front] - refactor(AB v2): tools configuration

### DIFF
--- a/front/components/agent_builder/capabilities/AgentBuilderCapabilitiesBlock.tsx
+++ b/front/components/agent_builder/capabilities/AgentBuilderCapabilitiesBlock.tsx
@@ -1,10 +1,13 @@
 import {
   Avatar,
+  BookOpenIcon,
+  Button,
   Card,
   CardActionButton,
   CardGrid,
   EmptyCTA,
   Hoverable,
+  ListAddIcon,
   XMarkIcon,
 } from "@dust-tt/sparkle";
 import { Spinner } from "@dust-tt/sparkle";
@@ -215,30 +218,22 @@ export function AgentBuilderCapabilitiesBlock({
 
   const getAgentInstructions = () => getValues("instructions");
 
-  const dropdownButtons = (
-    <>
-      <KnowledgeConfigurationSheet
-        onClose={handleCloseSheet}
-        onClickKnowledge={onClickKnowledge}
-        onSave={handleEditSave}
-        action={knowledgeAction?.action ?? null}
-        isEditing={Boolean(knowledgeAction && knowledgeAction.index !== null)}
-        mcpServerViews={mcpServerViewsWithKnowledge}
-        getAgentInstructions={getAgentInstructions}
+  const headerActions = fields.length > 0 && (
+    <div className="flex items-center gap-2">
+      <Button
+        variant="primary"
+        label="Add knowledge"
+        onClick={onClickKnowledge}
+        icon={BookOpenIcon}
       />
-      <MCPServerViewsDialog
-        addTools={append}
-        dataVisualization={dataVisualization}
-        mode={dialogMode}
-        onModeChange={setDialogMode}
-        onActionUpdate={handleMcpActionUpdate}
-        actions={fields}
-        getAgentInstructions={getAgentInstructions}
+      <Button
+        onClick={() => setDialogMode({ type: "add" })}
+        label="Add tools"
+        icon={ListAddIcon}
+        variant="outline"
       />
-    </>
+    </div>
   );
-
-  const headerActions = fields.length > 0 && dropdownButtons;
 
   return (
     <AgentBuilderSectionContainer
@@ -267,7 +262,20 @@ export function AgentBuilderCapabilitiesBlock({
         ) : fields.length === 0 ? (
           <EmptyCTA
             action={
-              <div className="flex items-center gap-2">{dropdownButtons}</div>
+              <div className="flex items-center gap-2">
+                <Button
+                  variant="primary"
+                  label="Add knowledge"
+                  onClick={onClickKnowledge}
+                  icon={BookOpenIcon}
+                />
+                <Button
+                  onClick={() => setDialogMode({ type: "add" })}
+                  label="Add tools"
+                  icon={ListAddIcon}
+                  variant="outline"
+                />
+              </div>
             }
             className="pb-5"
             style={BACKGROUND_IMAGE_STYLE_PROPS}
@@ -285,6 +293,23 @@ export function AgentBuilderCapabilitiesBlock({
           </CardGrid>
         )}
       </div>
+      <KnowledgeConfigurationSheet
+        onClose={handleCloseSheet}
+        onSave={handleEditSave}
+        action={knowledgeAction?.action ?? null}
+        isEditing={Boolean(knowledgeAction && knowledgeAction.index !== null)}
+        mcpServerViews={mcpServerViewsWithKnowledge}
+        getAgentInstructions={getAgentInstructions}
+      />
+      <MCPServerViewsDialog
+        addTools={append}
+        dataVisualization={dataVisualization}
+        mode={dialogMode}
+        onModeChange={setDialogMode}
+        onActionUpdate={handleMcpActionUpdate}
+        actions={fields}
+        getAgentInstructions={getAgentInstructions}
+      />
     </AgentBuilderSectionContainer>
   );
 }

--- a/front/components/agent_builder/capabilities/knowledge/KnowledgeConfigurationSheet.tsx
+++ b/front/components/agent_builder/capabilities/knowledge/KnowledgeConfigurationSheet.tsx
@@ -3,11 +3,9 @@ import {
   ContextItem,
   MultiPageSheet,
   MultiPageSheetContent,
-  MultiPageSheetTrigger,
   ScrollArea,
   Spinner,
 } from "@dust-tt/sparkle";
-import { Button } from "@dust-tt/sparkle";
 import { BookOpenIcon } from "@dust-tt/sparkle";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { uniqueId } from "lodash";
@@ -55,7 +53,6 @@ import type { DataSourceViewSelectionConfigurations } from "@app/types";
 interface KnowledgeConfigurationSheetProps {
   onSave: (action: AgentBuilderAction) => void;
   onClose: () => void;
-  onClickKnowledge: () => void;
   action: AgentBuilderAction | null;
   isEditing: boolean;
   mcpServerViews: MCPServerViewType[];
@@ -65,7 +62,6 @@ interface KnowledgeConfigurationSheetProps {
 export function KnowledgeConfigurationSheet({
   onSave,
   onClose,
-  onClickKnowledge,
   action,
   isEditing,
   mcpServerViews,
@@ -147,14 +143,6 @@ export function KnowledgeConfigurationSheet({
 
   return (
     <MultiPageSheet open={open} onOpenChange={handleOpenChange}>
-      <MultiPageSheetTrigger asChild>
-        <Button
-          variant="primary"
-          label="Add knowledge"
-          onClick={onClickKnowledge}
-          icon={BookOpenIcon}
-        />
-      </MultiPageSheetTrigger>
       <FormProvider {...formMethods}>
         <KnowledgeConfigurationSheetContent
           onSave={handleSave}

--- a/front/components/agent_builder/capabilities/mcp/MCPServerViewsDialog.tsx
+++ b/front/components/agent_builder/capabilities/mcp/MCPServerViewsDialog.tsx
@@ -1,10 +1,7 @@
 import type { MultiPageDialogPage } from "@dust-tt/sparkle";
 import {
-  Button,
-  ListAddIcon,
   MultiPageDialog,
   MultiPageDialogContent,
-  MultiPageDialogTrigger,
   Spinner,
 } from "@dust-tt/sparkle";
 import { zodResolver } from "@hookform/resolvers/zod";
@@ -705,14 +702,6 @@ export function MCPServerViewsDialog({
         }
       }}
     >
-      <MultiPageDialogTrigger asChild>
-        <Button
-          onClick={() => onModeChange({ type: "add" })}
-          label="Add tools"
-          icon={ListAddIcon}
-          variant="outline"
-        />
-      </MultiPageDialogTrigger>
       <MultiPageDialogContent
         showNavigation={false}
         isAlertDialog


### PR DESCRIPTION
## Description

This PR ensures that the `KnowledgeConfigurationSheet` and `MCPServerViewsDialog` are always mounted. With the previous implementation we were mounting/unmounting them when adding a first tool. This was causing the closing animation to break.

## Tests

Locally

## Risk

Low

## Deploy Plan

Deploy front