### PR TITLE
[connectors] - fix(Intercom): wrong data type

### DIFF
--- a/connectors/migrations/db/migration_91.sql
+++ b/connectors/migrations/db/migration_91.sql
@@ -1,0 +1,2 @@
+-- Migration created on Aug 11, 2025
+ALTER TABLE "intercom_collections" ALTER COLUMN "description" TYPE TEXT;

--- a/connectors/src/lib/models/intercom.ts
+++ b/connectors/src/lib/models/intercom.ts
@@ -195,7 +195,7 @@ IntercomCollectionModel.init(
       allowNull: false,
     },
     description: {
-      type: DataTypes.STRING,
+      type: DataTypes.TEXT,
       allowNull: true,
     },
     url: {


### PR DESCRIPTION
## Description

This PR aims at changing the data types from the `intercom_collections.description` column from "STRING" to "TEXT.

This is to fix the following error we are seeing in production:
```
DatabaseError: value too long for type character varying(255)
```

**References:**
- [Datadog errors](https://app.datadoghq.eu/logs?query=%28%22Activity%20failed%22%20OR%20%22Unhandled%20activity%20error%22%29%20%40attempt%3A%3E19%20%40workflowId%3Aintercom-sync-26583-help-center-7457&agg_m=count&agg_m_source=base&agg_t=count&clustering_pattern_field_path=message&cols=host%2Cservice&fromUser=true&messageDisplay=inline&refresh_mode=sliding&storage=hot&stream_sort=desc&viz=stream&from_ts=1754923934111&to_ts=1754924834111&live=true)

## Risk

Low

## Deploy Plan

- Apply migration
- Deploy connectors