### PR TITLE
[connectors] fix(Zendesk): add safeguard on brand matches

### DIFF
--- a/connectors/src/connectors/zendesk/lib/sync_ticket.ts
+++ b/connectors/src/connectors/zendesk/lib/sync_ticket.ts
@@ -203,6 +203,7 @@ export async function syncTicket({
       },
       "[Zendesk] Skipping sync. Ticket does not belong to the correct brand."
     );
+    return;
   }
 
   let ticketInDb = await ZendeskTicketResource.fetchByTicketId({

--- a/connectors/src/connectors/zendesk/lib/sync_ticket.ts
+++ b/connectors/src/connectors/zendesk/lib/sync_ticket.ts
@@ -192,6 +192,19 @@ export async function syncTicket({
 }) {
   const connectorId = connector.id;
 
+  if (ticket.brand_id !== brandId) {
+    logger.info(
+      {
+        ...loggerArgs,
+        connectorId,
+        ticketId: ticket.id,
+        ticketBrandId: ticket.brand_id,
+        brandId,
+      },
+      "[Zendesk] Skipping sync. Ticket does not belong to the correct brand."
+    );
+  }
+
   let ticketInDb = await ZendeskTicketResource.fetchByTicketId({
     connectorId,
     brandId,


### PR DESCRIPTION
## Description

- This PR adds a check that should technically be redundant with the check performed in `shouldSyncTicket` but that somehow gets bypassed (we still see duplicate tickets).

## Tests

- N/A.

## Risk

- N/A.

## Deploy Plan

- Deploy connectors.
