### PR TITLE
Add: sub menu on create agent button

### DIFF
--- a/front/components/assistant/AssistantBrowser.tsx
+++ b/front/components/assistant/AssistantBrowser.tsx
@@ -12,7 +12,6 @@ import {
   DropdownMenuTrigger,
   MoreIcon,
   PencilSquareIcon,
-  PlusIcon,
   RobotIcon,
   ScrollArea,
   ScrollBar,
@@ -26,6 +25,7 @@ import {
 import { useRouter } from "next/router";
 import React, { useCallback, useMemo, useState } from "react";
 
+import { CreateAgentButton } from "@app/components/assistant/CreateAgentButton";
 import { useWelcomeTourGuide } from "@app/components/assistant/WelcomeTourGuideProvider";
 import { useTheme } from "@app/components/sparkle/ThemeContext";
 import { useHashParam } from "@app/hooks/useHashParams";
@@ -296,16 +296,7 @@ export function AssistantBrowser({
           <div className="flex gap-2">
             {!isRestrictedFromAgentCreation && (
               <div ref={createAgentButtonRef}>
-                <Button
-                  tooltip="Create your own agent"
-                  href={`/w/${owner.sId}/builder/assistants/create?flow=personal_assistants`}
-                  variant="primary"
-                  icon={PlusIcon}
-                  label="Create"
-                  data-gtm-label="assistantCreationButton"
-                  data-gtm-location="homepage"
-                  size="sm"
-                />
+                <CreateAgentButton owner={owner} dataGtmLocation="homepage" />
               </div>
             )}
 

--- a/front/components/assistant/AssistantPicker.tsx
+++ b/front/components/assistant/AssistantPicker.tsx
@@ -7,11 +7,11 @@ import {
   DropdownMenuSearchbar,
   DropdownMenuSeparator,
   DropdownMenuTrigger,
-  PlusIcon,
   RobotIcon,
 } from "@dust-tt/sparkle";
 import { useState } from "react";
 
+import { CreateAgentButton } from "@app/components/assistant/CreateAgentButton";
 import { filterAndSortAgents } from "@app/lib/utils";
 import type { LightAgentConfigurationType, WorkspaceType } from "@app/types";
 
@@ -86,11 +86,7 @@ export function AssistantPicker({
               }}
               button={
                 showFooterButtons && (
-                  <Button
-                    label="Create"
-                    icon={PlusIcon}
-                    href={`/w/${owner.sId}/builder/assistants/create?flow=personal_assistants`}
-                  />
+                  <CreateAgentButton owner={owner} dataGtmLocation="homepage" />
                 )
               }
             />

--- a/front/components/assistant/CreateAgentButton.tsx
+++ b/front/components/assistant/CreateAgentButton.tsx
@@ -1,0 +1,67 @@
+import {
+  Button,
+  DocumentIcon,
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+  MagicIcon,
+  PlusIcon,
+} from "@dust-tt/sparkle";
+import { useRouter } from "next/router";
+import { useState } from "react";
+
+import type { LightWorkspaceType } from "@app/types";
+
+interface CreateAgentButtonProps {
+  owner: LightWorkspaceType;
+  dataGtmLocation: string;
+}
+
+export const CreateAgentButton = ({
+  owner,
+  dataGtmLocation,
+}: CreateAgentButtonProps) => {
+  const router = useRouter();
+  const [isLoading, setIsLoading] = useState(false);
+
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>
+        <Button
+          variant="primary"
+          icon={PlusIcon}
+          label="Create"
+          data-gtm-label="assistantCreationButton"
+          data-gtm-location={dataGtmLocation}
+          size="sm"
+          isSelect
+          isLoading={isLoading}
+          isDisabled={isLoading}
+        />
+      </DropdownMenuTrigger>
+      <DropdownMenuContent>
+        <DropdownMenuItem
+          label="agent from scratch"
+          icon={DocumentIcon}
+          onClick={() => {
+            setIsLoading(true);
+            void router.push(
+              `/w/${owner.sId}/builder/assistants/new?flow=personal_assistants`
+            );
+          }}
+        />
+        <DropdownMenuItem
+          label="agent from template"
+          icon={MagicIcon}
+          onClick={() => {
+            setIsLoading(true);
+            void router.push(
+              `/w/${owner.sId}/builder/assistants/create?flow=personal_assistants`
+            );
+          }}
+        />
+      </DropdownMenuContent>
+    </DropdownMenu>
+  );
+};

--- a/front/components/assistant/conversation/SidebarMenu.tsx
+++ b/front/components/assistant/conversation/SidebarMenu.tsx
@@ -3,6 +3,7 @@ import {
   ChatBubbleBottomCenterTextIcon,
   Checkbox,
   ClockIcon,
+  DocumentIcon,
   DropdownMenu,
   DropdownMenuContent,
   DropdownMenuItem,
@@ -12,11 +13,11 @@ import {
   InformationCircleIcon,
   Label,
   ListCheckIcon,
+  MagicIcon,
   MoreIcon,
   NavigationList,
   NavigationListItem,
   NavigationListLabel,
-  PlusIcon,
   RobotIcon,
   SearchInput,
   TrashIcon,
@@ -257,9 +258,16 @@ export function AssistantSidebarMenu({ owner }: AssistantSidebarMenuProps) {
                       <>
                         <DropdownMenuLabel>Agent</DropdownMenuLabel>
                         <DropdownMenuItem
-                          href={`/w/${owner.sId}/builder/assistants/create`}
-                          icon={PlusIcon}
-                          label="Create new agent"
+                          href={`/w/${owner.sId}/builder/assistants/new?flow=personal_assistants`}
+                          icon={DocumentIcon}
+                          label="New agent from scratch"
+                          data-gtm-label="assistantCreationButton"
+                          data-gtm-location="sidebarMenu"
+                        />
+                        <DropdownMenuItem
+                          href={`/w/${owner.sId}/builder/assistants/create?flow=personal_assistants`}
+                          icon={MagicIcon}
+                          label="New agent from template"
                           data-gtm-label="assistantCreationButton"
                           data-gtm-location="sidebarMenu"
                         />

--- a/front/components/assistant/conversation/input_bar/InputBarContainer.tsx
+++ b/front/components/assistant/conversation/input_bar/InputBarContainer.tsx
@@ -277,14 +277,6 @@ const InputBarContainer = ({
           )}
         />
         <div className="flex items-center pb-3 pt-0">
-          {actions.includes("tools") && (
-            <ToolsPicker
-              owner={owner}
-              selectedMCPServerViewIds={selectedMCPServerViewIds}
-              onSelect={onMCPServerViewSelect}
-              onDeselect={onMCPServerViewDeselect}
-            />
-          )}
           {actions.includes("attachment") && (
             <>
               <input
@@ -310,6 +302,14 @@ const InputBarContainer = ({
                 attachedNodes={attachedNodes}
               />
             </>
+          )}
+          {actions.includes("tools") && (
+            <ToolsPicker
+              owner={owner}
+              selectedMCPServerViewIds={selectedMCPServerViewIds}
+              onSelect={onMCPServerViewSelect}
+              onDeselect={onMCPServerViewDeselect}
+            />
           )}
           {(actions.includes("assistants-list") ||
             actions.includes("assistants-list-with-actions")) && (

--- a/front/hooks/useHashParams.ts
+++ b/front/hooks/useHashParams.ts
@@ -55,9 +55,10 @@ export const useHashParam = (
     val: string | undefined;
     options: SetterOptions;
   }>({
-    val: window
-      ? getHashParam(getUrlFromLocation(window.location), key, defaultValue)
-      : defaultValue,
+    val:
+      typeof window !== "undefined"
+        ? getHashParam(getUrlFromLocation(window.location), key, defaultValue)
+        : defaultValue,
     options: DEFAULT_OPTIONS,
   });
 

--- a/front/pages/w/[wId]/builder/assistants/create.tsx
+++ b/front/pages/w/[wId]/builder/assistants/create.tsx
@@ -1,15 +1,6 @@
-import {
-  Button,
-  DocumentIcon,
-  Icon,
-  MagicIcon,
-  Page,
-  PencilSquareIcon,
-  SearchInput,
-} from "@dust-tt/sparkle";
+import { Button, Icon, MagicIcon, Page, SearchInput } from "@dust-tt/sparkle";
 import _ from "lodash";
 import type { InferGetServerSidePropsType } from "next";
-import Link from "next/link";
 import { useRouter } from "next/router";
 import { useCallback, useEffect, useState } from "react";
 
@@ -187,82 +178,51 @@ export default function CreateAssistant({
     >
       <div id="pageContent">
         <Page variant="modal">
-          <div className="flex flex-col gap-6 pt-9">
-            <div className="flex min-h-[20vh] flex-col justify-end gap-6">
-              <div className="flex flex-row items-center gap-2">
-                <Icon
-                  visual={PencilSquareIcon}
-                  size="lg"
-                  className="text-primary-400 dark:text-primary-500"
-                />
+          <div className="flex flex-row items-center gap-2">
+            <Icon
+              visual={MagicIcon}
+              size="lg"
+              className="text-primary-400 dark:text-primary-500"
+            />
 
-                <h2 className="heading-2xl font-semibold">Start new</h2>
-              </div>
-              <Link
-                href={`/w/${owner.sId}/builder/assistants/new?flow=${flow}`}
-              >
-                <Button
-                  icon={DocumentIcon}
-                  label="New Agent"
-                  data-gtm-label="assistantCreationButton"
-                  data-gtm-location="assistantCreationPage"
-                  size="md"
-                  variant="highlight"
-                />
-              </Link>
-            </div>
-            <Page.Separator />
-
-            <div className="flex flex-row items-center gap-2">
-              <Icon
-                visual={MagicIcon}
-                size="lg"
-                className="text-primary-400 dark:text-primary-500"
-              />
-
-              <h2 className="heading-2xl font-semibold">
-                Start from a template
-              </h2>
-            </div>
-            <div className="flex flex-col gap-6">
-              <SearchInput
-                placeholder="Search templates"
-                name="input"
-                value={templateSearchTerm}
-                onChange={handleSearch}
-              />
-              <div className="flex flex-row flex-wrap gap-2">
-                {filteredTemplates.tags
-                  .sort((a, b) =>
-                    a.toLowerCase().localeCompare(b.toLowerCase())
-                  )
-                  .map((tagName) => (
-                    <Button
-                      label={templateTagsMapping[tagName].label}
-                      variant={
-                        selectedTags.includes(tagName) ? "primary" : "outline"
-                      }
-                      key={tagName}
-                      size="xs"
-                      onClick={() => handleTagClick(tagName)}
-                    />
-                  ))}
-              </div>
-            </div>
-            {filteredTemplates.templates.length > 0 && (
-              <>
-                <Page.Separator />
-                <div className="flex flex-col pb-56">
-                  <TemplateGrid
-                    templates={filteredTemplates.templates}
-                    openTemplateModal={openTemplateModal}
-                    templateTagsMapping={templateTagsMapping}
-                    selectedTags={selectedTags}
-                  />
-                </div>
-              </>
-            )}
+            <h2 className="heading-2xl font-semibold">Start from a template</h2>
           </div>
+          <div className="flex flex-col gap-6">
+            <SearchInput
+              placeholder="Search templates"
+              name="input"
+              value={templateSearchTerm}
+              onChange={handleSearch}
+            />
+            <div className="flex flex-row flex-wrap gap-2">
+              {filteredTemplates.tags
+                .sort((a, b) => a.toLowerCase().localeCompare(b.toLowerCase()))
+                .map((tagName) => (
+                  <Button
+                    label={templateTagsMapping[tagName].label}
+                    variant={
+                      selectedTags.includes(tagName) ? "primary" : "outline"
+                    }
+                    key={tagName}
+                    size="xs"
+                    onClick={() => handleTagClick(tagName)}
+                  />
+                ))}
+            </div>
+          </div>
+          {filteredTemplates.templates.length > 0 && (
+            <>
+              <Page.Separator />
+              <div className="flex flex-col pb-56">
+                <TemplateGrid
+                  templates={filteredTemplates.templates}
+                  openTemplateModal={openTemplateModal}
+                  templateTagsMapping={templateTagsMapping}
+                  selectedTags={selectedTags}
+                />
+              </div>
+            </>
+          )}
         </Page>
         <AssistantTemplateModal
           flow={flow}

--- a/front/pages/w/[wId]/builder/assistants/index.tsx
+++ b/front/pages/w/[wId]/builder/assistants/index.tsx
@@ -22,6 +22,7 @@ import { AgentEditBar } from "@app/components/assistant/AgentEditBar";
 import { AssistantDetails } from "@app/components/assistant/AssistantDetails";
 import { ConversationsNavigationProvider } from "@app/components/assistant/conversation/ConversationsNavigationProvider";
 import { AssistantSidebarMenu } from "@app/components/assistant/conversation/SidebarMenu";
+import { CreateAgentButton } from "@app/components/assistant/CreateAgentButton";
 import { AssistantsTable } from "@app/components/assistant/manager/AssistantsTable";
 import { TagsFilterMenu } from "@app/components/assistant/TagsFilterMenu";
 import { EmptyCallToAction } from "@app/components/EmptyCallToAction";
@@ -339,13 +340,9 @@ export default function WorkspaceAssistants({
                     owner={owner}
                   />
                   {!isRestrictedFromAgentCreation && (
-                    <Button
-                      variant="primary"
-                      icon={PlusIcon}
-                      href={`/w/${owner.sId}/builder/assistants/create?flow=workspace_assistants`}
-                      label="Create an agent"
-                      data-gtm-label="assistantCreationButton"
-                      data-gtm-location="assistantsWorkspace"
+                    <CreateAgentButton
+                      owner={owner}
+                      dataGtmLocation="assistantsWorkspace"
                     />
                   )}
                 </div>

--- a/front/styles/global.css
+++ b/front/styles/global.css
@@ -125,6 +125,22 @@ main {
   }
 }
 
+@keyframes fade-collapse {
+  0% {
+    opacity: 1;
+    max-height: 100%;
+  }
+
+  100% {
+    opacity: 0;
+    max-height: 0;
+  }
+}
+
+.animate-fade-collapse {
+  animation: fade-collapse 500ms ease-out forwards;
+}
+
 .s-blinking-cursor > :not(pre):last-child::after {
   /* ... existing code ... */
 }


### PR DESCRIPTION
## Description

Add a submenu on create agent button to pick between fresh or template in order to avoid unecessary page loading.

<img width="392" height="195" alt="image" src="https://github.com/user-attachments/assets/ea7db6f8-de9f-4f97-8380-c8079eaa0302" />
<img width="307" height="307" alt="image" src="https://github.com/user-attachments/assets/197b7aba-c695-438b-96d2-d1df282abcd3" />


## Tests

Local

## Risk

Low

## Deploy Plan

Deploy front