### PR TITLE
[front] - fix(AB v2): performance conditional rendering

### DIFF
--- a/front/components/agent_builder/AgentBuilderPerformance.tsx
+++ b/front/components/agent_builder/AgentBuilderPerformance.tsx
@@ -48,7 +48,7 @@ function NoAgentState() {
 }
 
 interface AgentBuilderPerformanceProps {
-  agentConfigurationSId: string;
+  agentConfigurationSId?: string;
 }
 
 export function AgentBuilderPerformance({

--- a/front/components/agent_builder/AgentBuilderRightPanel.tsx
+++ b/front/components/agent_builder/AgentBuilderRightPanel.tsx
@@ -117,7 +117,7 @@ function ExpandedContent({
           <AgentBuilderPreview />
         </div>
       )}
-      {selectedTab === "performance" && agentConfigurationSId && (
+      {selectedTab === "performance" && (
         <div className="flex-1 overflow-y-auto p-4">
           <AgentBuilderPerformance
             agentConfigurationSId={agentConfigurationSId}


### PR DESCRIPTION
## Description

This PR fixes the condition to render the `AgentBuilderPerformance` component, in the "Performance" tab. The empty CTA is handled by the component itself but since the component was not rendered on agent creation we just rendered a blank page.

## Tests

Locally

## Risk

Low

## Deploy Plan

Deploy front
