### PR TITLE
[sparkle] - chore: multi components tweaks (for AB v2)

### DIFF
--- a/sparkle/src/components/Button.tsx
+++ b/sparkle/src/components/Button.tsx
@@ -36,7 +36,7 @@ export type ButtonSizeType = (typeof BUTTON_SIZES)[number];
 // Define button styling with cva
 const buttonVariants = cva(
   cn(
-    "s-inline-flex s-items-center s-justify-center s-whitespace-nowrap s-ring-offset-background s-transition-colors s-ring-inset",
+    "s-inline-flex s-items-center s-justify-center s-whitespace-nowrap s-ring-offset-background s-transition-colors s-ring-inset s-select-none",
     "focus-visible:s-outline-none focus-visible:s-ring-2 focus-visible:s-ring-ring focus-visible:s-ring-offset-0",
     "dark:focus-visible:s-ring-0 dark:focus-visible:s-ring-offset-1"
   ),

--- a/sparkle/src/components/MultiPageDialog.tsx
+++ b/sparkle/src/components/MultiPageDialog.tsx
@@ -3,6 +3,7 @@ import * as React from "react";
 import { useState } from "react";
 
 import { Button, Icon, ScrollArea } from "@sparkle/components";
+import { Separator } from "@sparkle/components";
 import {
   Dialog,
   DialogClose,
@@ -33,6 +34,7 @@ const MultiPageDialogClose = DialogClose;
 
 interface MultiPageDialogFooterProps
   extends React.HTMLAttributes<HTMLDivElement> {
+  addTopSeparator: boolean;
   leftButton?: React.ComponentProps<typeof Button>;
   centerButton?: React.ComponentProps<typeof Button>;
   rightButton?: React.ComponentProps<typeof Button>;
@@ -40,13 +42,14 @@ interface MultiPageDialogFooterProps
 
 const MultiPageDialogFooter = ({
   className,
+  addTopSeparator,
   children,
   leftButton,
   centerButton,
   rightButton,
   ...props
 }: MultiPageDialogFooterProps) => {
-  return (
+  const content = (
     <div
       className={cn("s-flex s-flex-none s-flex-col s-gap-3 s-p-4", className)}
       {...props}
@@ -60,6 +63,15 @@ const MultiPageDialogFooter = ({
         </div>
       </div>
     </div>
+  );
+
+  return addTopSeparator ? (
+    <>
+      <Separator />
+      {content}
+    </>
+  ) : (
+    <>{content}</>
   );
 };
 
@@ -81,6 +93,7 @@ interface MultiPageDialogProps {
   centerButton?: React.ComponentProps<typeof Button>;
   rightButton?: React.ComponentProps<typeof Button>;
   footerContent?: React.ReactNode;
+  addFooterSeparator?: boolean;
 }
 
 interface MultiPageDialogContentProps extends MultiPageDialogProps {
@@ -104,6 +117,7 @@ const MultiPageDialogContent = React.forwardRef<
       showHeaderNavigation = true,
       className,
       disableNext = false,
+      addFooterSeparator = false,
       leftButton,
       centerButton,
       rightButton,
@@ -262,6 +276,7 @@ const MultiPageDialogContent = React.forwardRef<
             leftButton={leftButton}
             centerButton={centerButton}
             rightButton={rightButton}
+            addTopSeparator={addFooterSeparator}
           >
             {footerContent}
           </MultiPageDialogFooter>

--- a/sparkle/src/components/MultiPageDialog.tsx
+++ b/sparkle/src/components/MultiPageDialog.tsx
@@ -48,20 +48,17 @@ const MultiPageDialogFooter = ({
 }: MultiPageDialogFooterProps) => {
   return (
     <div
-      className={cn(
-        "s-flex s-flex-none s-flex-row s-justify-between s-gap-3 s-px-5 s-py-4",
-        className
-      )}
+      className={cn("s-flex s-flex-none s-flex-col s-gap-3 s-p-4", className)}
       {...props}
     >
-      <div className="s-flex s-gap-2">
-        {leftButton && <Button {...leftButton} />}
-      </div>
-      <div className="s-flex s-gap-2">
-        {centerButton && <Button {...centerButton} />}
-        {rightButton && <Button {...rightButton} />}
-      </div>
       {children}
+      <div className="s-flex s-flex-row s-justify-between">
+        <div>{leftButton && <Button {...leftButton} />}</div>
+        <div className="s-flex s-gap-2">
+          {centerButton && <Button {...centerButton} />}
+          {rightButton && <Button {...rightButton} />}
+        </div>
+      </div>
     </div>
   );
 };

--- a/sparkle/src/components/Resizable.tsx
+++ b/sparkle/src/components/Resizable.tsx
@@ -1,8 +1,6 @@
 import * as React from "react";
 import * as ResizablePrimitive from "react-resizable-panels";
 
-import { Icon } from "@sparkle/components/";
-import { GrabIcon } from "@sparkle/icons/app";
 import { cn } from "@sparkle/lib/utils";
 
 const ResizablePanelGroup = ({
@@ -41,7 +39,7 @@ const ResizableHandle = ({
       "data-[panel-group-direction=vertical]:after:s--translate-y-1/2",
       "data-[panel-group-direction=vertical]:after:s-translate-x-0",
       "[&[data-panel-group-direction=vertical]>div]:s-rotate-90",
-      "s-bg-border dark:s-bg-border-night",
+      "s-bg-white dark:s-bg-border-night",
       className
     )}
     {...props}
@@ -49,11 +47,11 @@ const ResizableHandle = ({
     {withHandle && (
       <div
         className={cn(
-          "s-z-10 s-flex s-h-4 s-w-3 s-items-center s-justify-center s-rounded-sm s-border",
-          "s-bg-border dark:s-bg-border-night"
+          "s-absolute s-flex s-h-4 s-w-2 s-items-center s-justify-center s-rounded-sm",
+          "dark:s-bg-structure-50 s-border-structure-200 s-border s-bg-white"
         )}
       >
-        <Icon visual={GrabIcon} size="xs" />
+        <div className="s-w-px" />
       </div>
     )}
   </ResizablePrimitive.PanelResizeHandle>

--- a/sparkle/src/stories/MultiPageDialog.stories.tsx
+++ b/sparkle/src/stories/MultiPageDialog.stories.tsx
@@ -1,6 +1,7 @@
 import type { Meta, StoryObj } from "@storybook/react";
 import React, { useState } from "react";
 
+import { Separator } from "@sparkle/components";
 import { Button } from "@sparkle/components/Button";
 import {
   MultiPageDialog,
@@ -685,17 +686,20 @@ export const WithConditionalNavigation: Story = {
             onClick: isLastPage ? handleSave : handleNext,
           }}
           footerContent={
-            <div className="s-rounded s-bg-blue-50 s-px-3 s-py-2">
-              <p className="s-text-xs s-text-blue-700">
-                {selectedItems.length > 0 && (
-                  <>
-                    {selectedItems.length} data source
-                    {selectedItems.length !== 1 ? "s" : ""} selected •{" "}
-                  </>
-                )}
-                Step {isFirstPage ? "1" : "2"} of 2
-              </p>
-            </div>
+            <>
+              <Separator />
+              <div className="s-rounded s-bg-blue-50">
+                <p className="s-text-xs s-text-blue-700">
+                  {selectedItems.length > 0 && (
+                    <>
+                      {selectedItems.length} data source
+                      {selectedItems.length !== 1 ? "s" : ""} selected •{" "}
+                    </>
+                  )}
+                  Step {isFirstPage ? "1" : "2"} of 2
+                </p>
+              </div>
+            </>
           }
         />
       </MultiPageDialog>

--- a/sparkle/src/stories/MultiPageDialog.stories.tsx
+++ b/sparkle/src/stories/MultiPageDialog.stories.tsx
@@ -1,7 +1,6 @@
 import type { Meta, StoryObj } from "@storybook/react";
 import React, { useState } from "react";
 
-import { Separator } from "@sparkle/components";
 import { Button } from "@sparkle/components/Button";
 import {
   MultiPageDialog,
@@ -665,6 +664,7 @@ export const WithConditionalNavigation: Story = {
           currentPageId={currentPageId}
           onPageChange={setCurrentPageId}
           size="lg"
+          height="md"
           leftButton={{
             label: "Cancel",
             variant: "outline",
@@ -685,21 +685,19 @@ export const WithConditionalNavigation: Story = {
             disabled: isFirstPage ? !canProceedFromFirst : !canSave,
             onClick: isLastPage ? handleSave : handleNext,
           }}
+          addFooterSeparator
           footerContent={
-            <>
-              <Separator />
-              <div className="s-rounded s-bg-blue-50">
-                <p className="s-text-xs s-text-blue-700">
-                  {selectedItems.length > 0 && (
-                    <>
-                      {selectedItems.length} data source
-                      {selectedItems.length !== 1 ? "s" : ""} selected •{" "}
-                    </>
-                  )}
-                  Step {isFirstPage ? "1" : "2"} of 2
-                </p>
-              </div>
-            </>
+            <div className="s-rounded s-bg-blue-50">
+              <p className="s-text-xs s-text-blue-700">
+                {selectedItems.length > 0 && (
+                  <>
+                    {selectedItems.length} data source
+                    {selectedItems.length !== 1 ? "s" : ""} selected •{" "}
+                  </>
+                )}
+                Step {isFirstPage ? "1" : "2"} of 2
+              </p>
+            </div>
           }
         />
       </MultiPageDialog>


### PR DESCRIPTION
## Description

This PR tweaks a few sparkle component to align them with the Agent Builder v2 design decisions. It includes:
- change the `Resizable` handle
- fix the `MultiPageDialog` footer component

It also adds a `select-none` class to the `Button` component, to prevent from selecting text.

## Tests

Locally

## Risk

Low

## Deploy Plan

Publish sparkle
