### PR TITLE
[connectors] Fix Zendesk duplicate cleanup script

### DIFF
--- a/connectors/migrations/20250710_cleanup_duplicate_zendesk_tickets.ts
+++ b/connectors/migrations/20250710_cleanup_duplicate_zendesk_tickets.ts
@@ -88,17 +88,10 @@ async function cleanupConnector(
     ticketIdsToSee.forEach((id) => ticketIdsSeen.add(id));
 
     const ticketsByTicketId = _.groupBy(tickets, (t) => t.ticketId);
-    const duplicateTickets = Object.values(ticketsByTicketId).filter(
-      (t) => t.length > 1
-    );
 
     await concurrentExecutor(
-      duplicateTickets,
+      Object.values(ticketsByTicketId),
       async (ticketBatch) => {
-        // Skip if there is only one ticket, we can safely assume it's the correct one.
-        if (ticketBatch.length === 1) {
-          return;
-        }
         // Fetch the first ticket from Zendesk to get the brand ID (they all have the same one).
         const brandIdFromZendesk = await getTicketBrandId(ticketBatch[0]!, {
           accessToken,


### PR DESCRIPTION
## Description

- This PR fixes the script used to cleanup duplicate Zendesk tickets by removing a filtering on groups of tickets with the same ID on their size being equal to 1.
- There are indeed such groups with only 1 element that is incorrect, for instance if not all brands are selected the ticket from an unselected brand will appear on other ones.

## Tests

- N/A.

## Risk

- N/A.

## Deploy Plan

- Deploy connectors (no code change but having the up-to-date script on the pods is practical).
