### PR TITLE
[dockerfiles] Build `check_table` binary in `core` docker image

### DIFF
--- a/dockerfiles/core.Dockerfile
+++ b/dockerfiles/core.Dockerfile
@@ -6,7 +6,7 @@ WORKDIR /app
 
 COPY /core/ .
 
-RUN cargo build --release --bin core-api --bin sqlite-worker
+RUN cargo build --release --bin core-api --bin sqlite-worker --bin check_table
 
 EXPOSE 3001
 


### PR DESCRIPTION
## Description

- This PR adds the build of the `check_table` binary to `core`'s docker image.
- This binary is useful to debug issues with remote databases.

## Tests

## Risk

## Deploy Plan

- Deploy core.
