### PR TITLE
[front] Optimize Tools inspection drawer performances

### DIFF
--- a/front/components/assistant/conversation/ConversationSidePanelContext.tsx
+++ b/front/components/assistant/conversation/ConversationSidePanelContext.tsx
@@ -84,6 +84,7 @@ export function ConversationSidePanelProvider({
           closePanel();
           return;
         }
+        // TODO
         setData(params.messageId);
         setMetadata(params.metadata);
         break;

--- a/front/components/assistant/conversation/ConversationSidePanelContext.tsx
+++ b/front/components/assistant/conversation/ConversationSidePanelContext.tsx
@@ -84,7 +84,6 @@ export function ConversationSidePanelProvider({
           closePanel();
           return;
         }
-        // TODO
         setData(params.messageId);
         setMetadata(params.metadata);
         break;

--- a/sparkle/src/components/markdown/PrettyJsonViewer.tsx
+++ b/sparkle/src/components/markdown/PrettyJsonViewer.tsx
@@ -14,7 +14,7 @@ const INDENT_CLASSES =
 // Performance limits to prevent browser crashes.
 // These limits are meant to be very conservative.
 const MAX_OBJECT_DEPTH = 8;
-const MAX_ARRAY_ITEMS = 100;
+const MAX_ARRAY_ITEMS = 128;
 const MAX_OBJECT_KEYS = 64;
 const MAX_STRING_LENGTH = 1024;
 

--- a/sparkle/src/components/markdown/PrettyJsonViewer.tsx
+++ b/sparkle/src/components/markdown/PrettyJsonViewer.tsx
@@ -129,7 +129,9 @@ function JsonValue({
   currentPath?: string;
 }) {
   const handleToggleExpanded = (path: string) => {
-    if (!setExpandedPaths) return;
+    if (!setExpandedPaths) {
+      return;
+    }
 
     setExpandedPaths((prev) => {
       const newSet = new Set(prev);


### PR DESCRIPTION
## Description

- Closes https://github.com/dust-tt/tasks/issues/3755.
- This PR aims at adding sane limits to the number of items rendered by the `PrettyJsonViewer` component.
- We technically have very loose limits in what may be rendered into these via tool outputs: we could have very large or very nested objects.

## Tests

- Checked locally.

## Risk

- Low.

## Deploy Plan

- Deploy sparkle.
