### PR TITLE
[front] fix: useHashParam don't reset on route change

### DIFF
--- a/front/hooks/useHashParams.ts
+++ b/front/hooks/useHashParams.ts
@@ -59,7 +59,6 @@ export const useHashParam = (
   // Listen to hash change events and update the internal value if the hash is removed.
   useEffect(() => {
     const onEventComplete = (url: string) => {
-      console.log(url);
       const hash = getHashFromUrl(url);
       // If there's no hash after route change, clear the content.
       if (!hash && innerValue) {

--- a/front/hooks/useHashParams.ts
+++ b/front/hooks/useHashParams.ts
@@ -58,7 +58,8 @@ export const useHashParam = (
 
   // Listen to hash change events and update the internal value if the hash is removed.
   useEffect(() => {
-    const routeChangeComplete = (url: string) => {
+    const onEventComplete = (url: string) => {
+      console.log(url);
       const hash = getHashFromUrl(url);
       // If there's no hash after route change, clear the content.
       if (!hash && innerValue) {
@@ -66,8 +67,12 @@ export const useHashParam = (
       }
     };
 
-    router.events.on("routeChangeComplete", routeChangeComplete);
-    return () => router.events.off("routeChangeComplete", routeChangeComplete);
+    router.events.on("hashChangeComplete", onEventComplete);
+    router.events.on("routeChangeComplete", onEventComplete);
+    return () => {
+      router.events.off("hashChangeComplete", onEventComplete);
+      router.events.off("routeChangeComplete", onEventComplete);
+    };
   }, [router.events, innerValue, setInnerValue]);
 
   // Listen to innerValue changes and update the hash in the router if there is a mismatch.

--- a/front/hooks/useHashParams.ts
+++ b/front/hooks/useHashParams.ts
@@ -58,7 +58,7 @@ export const useHashParam = (
 
   // Listen to hash change events and update the internal value if the hash is removed.
   useEffect(() => {
-    const handleHashComplete = (url: string) => {
+    const routeChangeComplete = (url: string) => {
       const hash = getHashFromUrl(url);
       // If there's no hash after route change, clear the content.
       if (!hash && innerValue) {
@@ -66,8 +66,8 @@ export const useHashParam = (
       }
     };
 
-    router.events.on("hashChangeComplete", handleHashComplete);
-    return () => router.events.off("hashChangeComplete", handleHashComplete);
+    router.events.on("routeChangeComplete", routeChangeComplete);
+    return () => router.events.off("routeChangeComplete", routeChangeComplete);
   }, [router.events, innerValue, setInnerValue]);
 
   // Listen to innerValue changes and update the hash in the router if there is a mismatch.


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

This PR https://github.com/dust-tt/dust/commit/04e6d29b59c16acf82eeca97c4180afd713182a7 introduced a bug where usehashparam don't reset how they should on route change. Fixing this.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

Tested by hand

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

Low

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->

Deploy front