### PR TITLE
Move export to main app

### DIFF
--- a/front/components/assistant/conversation/content/ClientExecutableRenderer.tsx
+++ b/front/components/assistant/conversation/content/ClientExecutableRenderer.tsx
@@ -22,6 +22,48 @@ import { useConversationSidePanelContext } from "../ConversationSidePanelContext
 import { ShareInteractiveFilePopover } from "../ShareInteractiveFilePopover";
 import { InteractiveContentHeader } from "./InteractiveContentHeader";
 
+interface ExportContentDropdownProps {
+  iframeRef: React.RefObject<HTMLIFrameElement>;
+}
+
+function ExportContentDropdown({ iframeRef }: ExportContentDropdownProps) {
+  const exportVisualization = React.useCallback(
+    (format: "png" | "svg") => {
+      if (iframeRef.current?.contentWindow) {
+        iframeRef.current.contentWindow.postMessage(
+          { type: `EXPORT_${format.toUpperCase()}` },
+          "*"
+        );
+      } else {
+        console.log("No iframe content window found");
+      }
+    },
+    [iframeRef]
+  );
+
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>
+        <Button
+          icon={ArrowDownOnSquareIcon}
+          isSelect
+          size="xs"
+          tooltip="Export content"
+          variant="ghost"
+        />
+      </DropdownMenuTrigger>
+      <DropdownMenuContent>
+        <DropdownMenuItem onClick={() => exportVisualization("png")}>
+          Export as PNG
+        </DropdownMenuItem>
+        <DropdownMenuItem onClick={() => exportVisualization("svg")}>
+          Export as SVG
+        </DropdownMenuItem>
+      </DropdownMenuContent>
+    </DropdownMenu>
+  );
+}
+
 interface ClientExecutableRendererProps {
   conversation: ConversationType;
   fileId: string;
@@ -49,17 +91,6 @@ export function ClientExecutableRenderer({
   );
 
   const [showCode, setShowCode] = React.useState(false);
-
-  const exportVisualization = React.useCallback((format: "png" | "svg") => {
-    if (iframeRef.current?.contentWindow) {
-      iframeRef.current.contentWindow.postMessage(
-        { type: `EXPORT_${format.toUpperCase()}` },
-        "*"
-      );
-    } else {
-      console.log("No iframe content window found");
-    }
-  }, []);
 
   if (isFileContentLoading) {
     return (
@@ -92,25 +123,7 @@ export function ClientExecutableRenderer({
           tooltip={showCode ? "Switch to Rendering" : "Switch to Code"}
           variant="ghost"
         />
-        <DropdownMenu>
-          <DropdownMenuTrigger asChild>
-            <Button
-              icon={ArrowDownOnSquareIcon}
-              isSelect
-              size="xs"
-              tooltip="Export content"
-              variant="ghost"
-            />
-          </DropdownMenuTrigger>
-          <DropdownMenuContent>
-            <DropdownMenuItem onClick={() => exportVisualization("png")}>
-              Export as PNG
-            </DropdownMenuItem>
-            <DropdownMenuItem onClick={() => exportVisualization("svg")}>
-              Export as SVG
-            </DropdownMenuItem>
-          </DropdownMenuContent>
-        </DropdownMenu>
+        <ExportContentDropdown iframeRef={iframeRef} />
         <ShareInteractiveFilePopover
           fileId={fileId}
           owner={owner}

--- a/front/components/assistant/conversation/content/ClientExecutableRenderer.tsx
+++ b/front/components/assistant/conversation/content/ClientExecutableRenderer.tsx
@@ -36,10 +36,13 @@ export function ClientExecutableRenderer({
   owner,
 }: ClientExecutableRendererProps) {
   const { closePanel } = useConversationSidePanelContext();
+  const iframeRef = React.useRef<HTMLIFrameElement>(null);
+
   const { fileContent, isFileContentLoading, error } = useFileContent({
     fileId,
     owner,
   });
+
   const isUsingConversationFiles = React.useMemo(
     () => (fileContent ? isFileUsingConversationFiles(fileContent) : false),
     [fileContent]
@@ -47,22 +50,16 @@ export function ClientExecutableRenderer({
 
   const [showCode, setShowCode] = React.useState(false);
 
-  const exportVisualization = React.useCallback(
-    (format: "png" | "svg") => {
-      const iframe = document.querySelector(
-        `iframe[src*="identifier=viz-${fileId}"]`
-      ) as HTMLIFrameElement;
-      if (iframe?.contentWindow) {
-        iframe.contentWindow.postMessage(
-          { type: `EXPORT_${format.toUpperCase()}` },
-          "*"
-        );
-      } else {
-        console.log("No iframe content window found");
-      }
-    },
-    [fileId]
-  );
+  const exportVisualization = React.useCallback((format: "png" | "svg") => {
+    if (iframeRef.current?.contentWindow) {
+      iframeRef.current.contentWindow.postMessage(
+        { type: `EXPORT_${format.toUpperCase()}` },
+        "*"
+      );
+    } else {
+      console.log("No iframe content window found");
+    }
+  }, []);
 
   if (isFileContentLoading) {
     return (
@@ -147,6 +144,7 @@ export function ClientExecutableRenderer({
               key={`viz-${fileId}`}
               conversationId={conversation.sId}
               isInDrawer={true}
+              ref={iframeRef}
             />
           </div>
         )}

--- a/front/components/assistant/conversation/content/ClientExecutableRenderer.tsx
+++ b/front/components/assistant/conversation/content/ClientExecutableRenderer.tsx
@@ -1,7 +1,12 @@
 import {
+  ArrowDownOnSquareIcon,
   Button,
   CodeBlock,
   CommandLineIcon,
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
   SparklesIcon,
   Spinner,
 } from "@dust-tt/sparkle";
@@ -42,6 +47,23 @@ export function ClientExecutableRenderer({
 
   const [showCode, setShowCode] = React.useState(false);
 
+  const exportVisualization = React.useCallback(
+    (format: "png" | "svg") => {
+      const iframe = document.querySelector(
+        `iframe[src*="identifier=viz-${fileId}"]`
+      ) as HTMLIFrameElement;
+      if (iframe?.contentWindow) {
+        iframe.contentWindow.postMessage(
+          { type: `EXPORT_${format.toUpperCase()}` },
+          "*"
+        );
+      } else {
+        console.log("No iframe content window found");
+      }
+    },
+    [fileId]
+  );
+
   if (isFileContentLoading) {
     return (
       <CenteredState>
@@ -73,6 +95,25 @@ export function ClientExecutableRenderer({
           tooltip={showCode ? "Switch to Rendering" : "Switch to Code"}
           variant="ghost"
         />
+        <DropdownMenu>
+          <DropdownMenuTrigger asChild>
+            <Button
+              icon={ArrowDownOnSquareIcon}
+              isSelect
+              size="xs"
+              tooltip="Export content"
+              variant="ghost"
+            />
+          </DropdownMenuTrigger>
+          <DropdownMenuContent>
+            <DropdownMenuItem onClick={() => exportVisualization("png")}>
+              Export as PNG
+            </DropdownMenuItem>
+            <DropdownMenuItem onClick={() => exportVisualization("svg")}>
+              Export as SVG
+            </DropdownMenuItem>
+          </DropdownMenuContent>
+        </DropdownMenu>
         <ShareInteractiveFilePopover
           fileId={fileId}
           owner={owner}

--- a/front/next.config.js
+++ b/front/next.config.js
@@ -20,7 +20,6 @@ const CONTENT_SECURITY_POLICIES = [
   `frame-ancestors 'self';`,
   `manifest-src 'self';`,
   `worker-src 'self' blob:;`,
-  `prefetch-src 'self' dust.tt *.dust.tt https://dust.tt https://*.dust.tt;`,
   `upgrade-insecure-requests;`,
 ].join(" ");
 

--- a/viz/app/components/VisualizationWrapper.tsx
+++ b/viz/app/components/VisualizationWrapper.tsx
@@ -153,7 +153,7 @@ export function useVisualizationAPI(
           return;
         }
 
-        // Validate message structure using io-ts
+        // Validate message structure using zod.
         const validatedMessage = validateMessage(event.data);
         if (!validatedMessage) {
           console.log("Invalid message format received:", event.data);

--- a/viz/app/components/VisualizationWrapper.tsx
+++ b/viz/app/components/VisualizationWrapper.tsx
@@ -5,6 +5,12 @@ import type {
   VisualizationRPCCommand,
   VisualizationRPCRequestMap,
 } from "@viz/app/types";
+import type {
+  SupportedMessage,
+  SupportedEventType,
+} from "@viz/app/types/messages";
+
+import { validateMessage } from "@viz/app/types/messages";
 import { Spinner } from "@viz/app/components/Components";
 import { ErrorBoundary } from "@viz/app/components/ErrorBoundary";
 import { toBlob, toSvg } from "html-to-image";
@@ -61,7 +67,8 @@ function validateTailwindCode(code: string): void {
 }
 
 export function useVisualizationAPI(
-  sendCrossDocumentMessage: ReturnType<typeof makeSendCrossDocumentMessage>
+  sendCrossDocumentMessage: ReturnType<typeof makeSendCrossDocumentMessage>,
+  { allowedVisualizationOrigin }: { allowedVisualizationOrigin?: string }
 ) {
   const [error, setError] = useState<Error | null>(null);
 
@@ -130,13 +137,51 @@ export function useVisualizationAPI(
     await sendCrossDocumentMessage("displayCode", null);
   }, [sendCrossDocumentMessage]);
 
+  const addEventListener = useCallback(
+    (
+      eventType: SupportedEventType,
+      handler: (data: SupportedMessage) => void
+    ): (() => void) => {
+      const messageHandler = (event: MessageEvent) => {
+        if (
+          allowedVisualizationOrigin &&
+          event.origin !== allowedVisualizationOrigin
+        ) {
+          console.log(
+            `Ignored message from unauthorized origin: ${event.origin}, expected: ${allowedVisualizationOrigin}`
+          );
+          return;
+        }
+
+        // Validate message structure using io-ts
+        const validatedMessage = validateMessage(event.data);
+        if (!validatedMessage) {
+          console.log("Invalid message format received:", event.data);
+          return;
+        }
+
+        // Check if this is the event type we're listening for
+        if (validatedMessage.type === eventType) {
+          handler(validatedMessage);
+        }
+      };
+
+      window.addEventListener("message", messageHandler);
+
+      // Return cleanup function
+      return () => window.removeEventListener("message", messageHandler);
+    },
+    [allowedVisualizationOrigin]
+  );
+
   return {
+    addEventListener,
+    displayCode,
+    downloadFile,
     error,
     fetchCode,
     fetchFile,
     sendHeightToParent,
-    downloadFile,
-    displayCode,
   };
 }
 
@@ -204,7 +249,9 @@ export function VisualizationWrapperWithErrorBoundary({
       }),
     [identifier, allowedVisualizationOrigin]
   );
-  const api = useVisualizationAPI(sendCrossDocumentMessage);
+  const api = useVisualizationAPI(sendCrossDocumentMessage, {
+    allowedVisualizationOrigin,
+  });
 
   return (
     <ErrorBoundary
@@ -245,6 +292,7 @@ export function VisualizationWrapper({
     sendHeightToParent,
     downloadFile,
     displayCode,
+    addEventListener,
   } = api;
 
   const memoizedDownloadFile = useDownloadFileCallback(downloadFile);
@@ -346,6 +394,25 @@ export function VisualizationWrapper({
     }
   }, [error]);
 
+  // Add message listeners for export requests.
+  useEffect(() => {
+    const cleanups: (() => void)[] = [];
+
+    cleanups.push(
+      addEventListener("EXPORT_PNG", async () => {
+        await handleScreenshotDownload();
+      })
+    );
+
+    cleanups.push(
+      addEventListener("EXPORT_SVG", async () => {
+        await handleSVGDownload();
+      })
+    );
+
+    return () => cleanups.forEach((cleanup) => cleanup());
+  }, [addEventListener, handleScreenshotDownload, handleSVGDownload]);
+
   if (errored) {
     // Throw the error to the ErrorBoundary.
     throw errored;
@@ -361,22 +428,22 @@ export function VisualizationWrapper({
         isFullHeight ? "h-screen" : ""
       }`}
     >
-      <div className="flex flex-row gap-2 absolute top-2 right-2 rounded transition opacity-0 group-hover/viz:opacity-100 z-50">
-        <button
-          onClick={handleScreenshotDownload}
-          title="Download screenshot"
-          className="h-7 px-2.5 rounded-lg label-xs inline-flex items-center justify-center border border-border text-primary bg-white"
-        >
-          Png
-        </button>
-        <button
-          onClick={handleSVGDownload}
-          title="Download SVG"
-          className="h-7 px-2.5 rounded-lg label-xs inline-flex items-center justify-center border border-border text-primary bg-white"
-        >
-          Svg
-        </button>
-        {!isFullHeight && (
+      {!isFullHeight && (
+        <div className="flex flex-row gap-2 absolute top-2 right-2 rounded transition opacity-0 group-hover/viz:opacity-100 z-50">
+          <button
+            onClick={handleScreenshotDownload}
+            title="Download screenshot"
+            className="h-7 px-2.5 rounded-lg label-xs inline-flex items-center justify-center border border-border text-primary bg-white"
+          >
+            Png
+          </button>
+          <button
+            onClick={handleSVGDownload}
+            title="Download SVG"
+            className="h-7 px-2.5 rounded-lg label-xs inline-flex items-center justify-center border border-border text-primary bg-white"
+          >
+            Svg
+          </button>
           <button
             title="Show code"
             onClick={handleDisplayCode}
@@ -384,8 +451,8 @@ export function VisualizationWrapper({
           >
             Code
           </button>
-        )}
-      </div>
+        </div>
+      )}
       <div ref={ref}>
         <Runner
           code={runnerParams.code}

--- a/viz/app/types/messages.ts
+++ b/viz/app/types/messages.ts
@@ -1,0 +1,41 @@
+import * as t from "io-ts";
+
+// Define the base message event structure.
+export const MessageEventCodec = t.type({
+  type: t.string,
+  data: t.unknown, // Will be refined by specific message codecs.
+});
+
+// Export request message codecs
+export const ExportPngMessageCodec = t.type({
+  type: t.literal("EXPORT_PNG"),
+});
+
+export const ExportSvgMessageCodec = t.type({
+  type: t.literal("EXPORT_SVG"),
+});
+
+// Union of all supported message types coming from the parent window.
+export const SupportedMessageCodec = t.union([
+  ExportPngMessageCodec,
+  ExportSvgMessageCodec,
+]);
+
+// Type definitions derived from codecs.
+export type MessageEvent = t.TypeOf<typeof MessageEventCodec>;
+export type ExportPngMessage = t.TypeOf<typeof ExportPngMessageCodec>;
+export type ExportSvgMessage = t.TypeOf<typeof ExportSvgMessageCodec>;
+export type SupportedMessage = t.TypeOf<typeof SupportedMessageCodec>;
+
+// Extract valid event types from our supported messages.
+export type SupportedEventType = SupportedMessage["type"];
+
+// Validation helper functions
+export const isValidMessage = (data: unknown): data is SupportedMessage => {
+  return SupportedMessageCodec.is(data);
+};
+
+export const validateMessage = (data: unknown): SupportedMessage | null => {
+  const result = SupportedMessageCodec.decode(data);
+  return result._tag === "Right" ? result.right : null;
+};

--- a/viz/app/types/messages.ts
+++ b/viz/app/types/messages.ts
@@ -1,41 +1,35 @@
-import * as t from "io-ts";
+import { z } from "zod";
 
 // Define the base message event structure.
-export const MessageEventCodec = t.type({
-  type: t.string,
-  data: t.unknown, // Will be refined by specific message codecs.
+export const MessageEventSchema = z.object({
+  type: z.string(),
+  data: z.unknown().optional(), // Will be refined by specific message schemas.
 });
 
-// Export request message codecs
-export const ExportPngMessageCodec = t.type({
-  type: t.literal("EXPORT_PNG"),
+// Export request message schemas
+export const ExportPngMessageSchema = z.object({
+  type: z.literal("EXPORT_PNG"),
 });
 
-export const ExportSvgMessageCodec = t.type({
-  type: t.literal("EXPORT_SVG"),
+export const ExportSvgMessageSchema = z.object({
+  type: z.literal("EXPORT_SVG"),
 });
 
 // Union of all supported message types coming from the parent window.
-export const SupportedMessageCodec = t.union([
-  ExportPngMessageCodec,
-  ExportSvgMessageCodec,
+export const SupportedMessageSchema = z.union([
+  ExportPngMessageSchema,
+  ExportSvgMessageSchema,
 ]);
 
-// Type definitions derived from codecs.
-export type MessageEvent = t.TypeOf<typeof MessageEventCodec>;
-export type ExportPngMessage = t.TypeOf<typeof ExportPngMessageCodec>;
-export type ExportSvgMessage = t.TypeOf<typeof ExportSvgMessageCodec>;
-export type SupportedMessage = t.TypeOf<typeof SupportedMessageCodec>;
+// Type definitions derived from schemas.
+export type MessageEvent = z.infer<typeof MessageEventSchema>;
+export type SupportedMessage = z.infer<typeof SupportedMessageSchema>;
 
 // Extract valid event types from our supported messages.
 export type SupportedEventType = SupportedMessage["type"];
 
-// Validation helper functions
-export const isValidMessage = (data: unknown): data is SupportedMessage => {
-  return SupportedMessageCodec.is(data);
-};
-
 export const validateMessage = (data: unknown): SupportedMessage | null => {
-  const result = SupportedMessageCodec.decode(data);
-  return result._tag === "Right" ? result.right : null;
+  const result = SupportedMessageSchema.safeParse(data);
+
+  return result.success ? result.data : null;
 };

--- a/viz/package-lock.json
+++ b/viz/package-lock.json
@@ -43,7 +43,6 @@
         "embla-carousel-react": "^8.6.0",
         "html-to-image": "^1.11.11",
         "input-otp": "^1.4.2",
-        "io-ts": "^2.2.22",
         "lucide-react": "^0.483.0",
         "next": "^14.2.25",
         "next-themes": "^0.4.6",
@@ -61,7 +60,7 @@
         "tailwindcss-animate": "^1.0.7",
         "tw-animate-css": "^1.3.6",
         "vaul": "^1.1.2",
-        "zod": "^4.0.15"
+        "zod": "^4.0.17"
       },
       "devDependencies": {
         "@types/node": "^20",
@@ -4364,13 +4363,6 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
-    "node_modules/fp-ts": {
-      "version": "2.16.10",
-      "resolved": "https://registry.npmjs.org/fp-ts/-/fp-ts-2.16.10.tgz",
-      "integrity": "sha512-vuROzbNVfCmUkZSUbnWSltR1sbheyQbTzug7LB/46fEa1c0EucLeBaCEUE0gF3ZGUGBt9lVUiziGOhhj6K1ORA==",
-      "license": "MIT",
-      "peer": true
-    },
     "node_modules/fs.realpath": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
@@ -4810,15 +4802,6 @@
       "integrity": "sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg==",
       "engines": {
         "node": ">=12"
-      }
-    },
-    "node_modules/io-ts": {
-      "version": "2.2.22",
-      "resolved": "https://registry.npmjs.org/io-ts/-/io-ts-2.2.22.tgz",
-      "integrity": "sha512-FHCCztTkHoV9mdBsHpocLpdTAfh956ZQcIkWQxxS0U5HT53vtrcuYdQneEJKH6xILaLNzXVl2Cvwtoy8XNN0AA==",
-      "license": "MIT",
-      "peerDependencies": {
-        "fp-ts": "^2.5.0"
       }
     },
     "node_modules/is-arguments": {
@@ -7682,9 +7665,9 @@
       }
     },
     "node_modules/zod": {
-      "version": "4.0.15",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-4.0.15.tgz",
-      "integrity": "sha512-2IVHb9h4Mt6+UXkyMs0XbfICUh1eUrlJJAOupBHUhLRnKkruawyDddYRCs0Eizt900ntIMk9/4RksYl+FgSpcQ==",
+      "version": "4.0.17",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.0.17.tgz",
+      "integrity": "sha512-1PHjlYRevNxxdy2JZ8JcNAw7rX8V9P1AKkP+x/xZfxB0K5FYfuV+Ug6P/6NVSR2jHQ+FzDDoDHS04nYUsOIyLQ==",
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"

--- a/viz/package-lock.json
+++ b/viz/package-lock.json
@@ -43,6 +43,7 @@
         "embla-carousel-react": "^8.6.0",
         "html-to-image": "^1.11.11",
         "input-otp": "^1.4.2",
+        "io-ts": "^2.2.22",
         "lucide-react": "^0.483.0",
         "next": "^14.2.25",
         "next-themes": "^0.4.6",
@@ -4363,6 +4364,13 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/fp-ts": {
+      "version": "2.16.10",
+      "resolved": "https://registry.npmjs.org/fp-ts/-/fp-ts-2.16.10.tgz",
+      "integrity": "sha512-vuROzbNVfCmUkZSUbnWSltR1sbheyQbTzug7LB/46fEa1c0EucLeBaCEUE0gF3ZGUGBt9lVUiziGOhhj6K1ORA==",
+      "license": "MIT",
+      "peer": true
+    },
     "node_modules/fs.realpath": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
@@ -4802,6 +4810,15 @@
       "integrity": "sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg==",
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/io-ts": {
+      "version": "2.2.22",
+      "resolved": "https://registry.npmjs.org/io-ts/-/io-ts-2.2.22.tgz",
+      "integrity": "sha512-FHCCztTkHoV9mdBsHpocLpdTAfh956ZQcIkWQxxS0U5HT53vtrcuYdQneEJKH6xILaLNzXVl2Cvwtoy8XNN0AA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "fp-ts": "^2.5.0"
       }
     },
     "node_modules/is-arguments": {

--- a/viz/package.json
+++ b/viz/package.json
@@ -44,6 +44,7 @@
     "embla-carousel-react": "^8.6.0",
     "html-to-image": "^1.11.11",
     "input-otp": "^1.4.2",
+    "io-ts": "^2.2.22",
     "lucide-react": "^0.483.0",
     "next": "^14.2.25",
     "next-themes": "^0.4.6",

--- a/viz/package.json
+++ b/viz/package.json
@@ -44,7 +44,6 @@
     "embla-carousel-react": "^8.6.0",
     "html-to-image": "^1.11.11",
     "input-otp": "^1.4.2",
-    "io-ts": "^2.2.22",
     "lucide-react": "^0.483.0",
     "next": "^14.2.25",
     "next-themes": "^0.4.6",
@@ -62,7 +61,7 @@
     "tailwindcss-animate": "^1.0.7",
     "tw-animate-css": "^1.3.6",
     "vaul": "^1.1.2",
-    "zod": "^4.0.15"
+    "zod": "^4.0.17"
   },
   "devDependencies": {
     "@types/node": "^20",


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
This PR moves the export content of Viz to a the parent window. So far, RPC messages were only sent from the iframe to parent, this we now need to do parent to viz. I used zod as I'm planning to clean up the types/typeguards in a follow up PR to only use zod schema validation.

<img width="1114" height="340" alt="image (1)" src="https://github.com/user-attachments/assets/63949086-ca03-4fa8-9610-59164b59ebc3" />

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
