### PR TITLE
[front] - chore(AB v2): various UI tweaks

### DIFF
--- a/extension/package-lock.json
+++ b/extension/package-lock.json
@@ -12,7 +12,7 @@
         "@auth0/auth0-spa-js": "^2.1.3",
         "@datadog/browser-logs": "^6.13.0",
         "@dust-tt/client": "1.1.4",
-        "@dust-tt/sparkle": "^0.2.566",
+        "@dust-tt/sparkle": "^0.2.569",
         "@frontapp/plugin-sdk": "^1.8.1",
         "@modelcontextprotocol/sdk": "^1.9.0",
         "@tailwindcss/forms": "^0.5.9",
@@ -1254,9 +1254,9 @@
       }
     },
     "node_modules/@dust-tt/sparkle": {
-      "version": "0.2.566",
-      "resolved": "https://registry.npmjs.org/@dust-tt/sparkle/-/sparkle-0.2.566.tgz",
-      "integrity": "sha512-XeXMu7tQUXox/08xyfhkuuMGSVqg8eW+JUExGdatpBKAFCnXHG3O+ssVdiqsEt1+buQglxUOuNVSakqrNGRx8A==",
+      "version": "0.2.569",
+      "resolved": "https://registry.npmjs.org/@dust-tt/sparkle/-/sparkle-0.2.569.tgz",
+      "integrity": "sha512-UvPp8gcC7Y5/gSjRNAPJ10+i1aLhd6DmnNLJjIGyiDc1mzcV01QtRcYzKHLd85mpc/cf1buKfDlhLpd7uRgSXg==",
       "dependencies": {
         "@emoji-mart/data": "^1.1.2",
         "@emoji-mart/react": "^1.1.1",

--- a/extension/package.json
+++ b/extension/package.json
@@ -59,7 +59,7 @@
     "@auth0/auth0-spa-js": "^2.1.3",
     "@datadog/browser-logs": "^6.13.0",
     "@dust-tt/client": "1.1.4",
-    "@dust-tt/sparkle": "^0.2.566",
+    "@dust-tt/sparkle": "^0.2.569",
     "@frontapp/plugin-sdk": "^1.8.1",
     "@modelcontextprotocol/sdk": "^1.9.0",
     "@tailwindcss/forms": "^0.5.9",

--- a/front/components/agent_builder/capabilities/AgentBuilderCapabilitiesBlock.tsx
+++ b/front/components/agent_builder/capabilities/AgentBuilderCapabilitiesBlock.tsx
@@ -221,12 +221,14 @@ export function AgentBuilderCapabilitiesBlock({
   const headerActions = fields.length > 0 && (
     <div className="flex items-center gap-2">
       <Button
-        variant="primary"
-        label="Add knowledge"
+        type="button"
         onClick={onClickKnowledge}
+        label="Add knowledge"
         icon={BookOpenIcon}
+        variant="primary"
       />
       <Button
+        type="button"
         onClick={() => setDialogMode({ type: "add" })}
         label="Add tools"
         icon={ListAddIcon}
@@ -264,12 +266,14 @@ export function AgentBuilderCapabilitiesBlock({
             action={
               <div className="flex items-center gap-2">
                 <Button
-                  variant="primary"
-                  label="Add knowledge"
+                  type="button"
                   onClick={onClickKnowledge}
+                  label="Add knowledge"
                   icon={BookOpenIcon}
+                  variant="primary"
                 />
                 <Button
+                  type="button"
                   onClick={() => setDialogMode({ type: "add" })}
                   label="Add tools"
                   icon={ListAddIcon}

--- a/front/components/agent_builder/capabilities/mcp/MCPServerSelectionPage.tsx
+++ b/front/components/agent_builder/capabilities/mcp/MCPServerSelectionPage.tsx
@@ -3,6 +3,7 @@ import { ActionIcons } from "@dust-tt/sparkle";
 import { Button } from "@dust-tt/sparkle";
 import { PlusIcon } from "@dust-tt/sparkle";
 import { SearchInput } from "@dust-tt/sparkle";
+import { cn } from "@dust-tt/sparkle";
 import React, { useMemo } from "react";
 
 import type { SelectedTool } from "@app/components/agent_builder/capabilities/mcp/MCPServerViewsDialog";
@@ -14,6 +15,8 @@ import { InternalActionIcons } from "@app/lib/actions/mcp_icons";
 import { getMCPServerRequirements } from "@app/lib/actions/mcp_internal_actions/input_configuration";
 import { DATA_VISUALIZATION_SPECIFICATION } from "@app/lib/actions/utils";
 import type { MCPServerViewType } from "@app/lib/api/mcp";
+
+const FADE_TRANSITION_CLASSES = "transition-opacity duration-300 ease-in-out";
 
 interface DataVisualizationCardProps {
   dataVisualization: ActionSpecification;
@@ -40,12 +43,24 @@ function DataVisualizationCard({
             size="sm"
           />
           <span className="text-sm font-medium">{dataVisualization.label}</span>
-          {isSelected && <Chip size="xs" color="green" label="ADDED" />}
+          <div
+            className={cn(
+              FADE_TRANSITION_CLASSES,
+              isSelected ? "opacity-100" : "opacity-0"
+            )}
+          >
+            {isSelected && <Chip size="xs" color="green" label="ADDED" />}
+          </div>
         </div>
         <div className="line-clamp-2 w-full text-xs text-gray-600">
           {dataVisualization.description}
         </div>
-        <div>
+        <div
+          className={cn(
+            FADE_TRANSITION_CLASSES,
+            !isSelected ? "opacity-100" : "opacity-0"
+          )}
+        >
           {!isSelected && (
             <Button size="xs" variant="outline" icon={PlusIcon} label="Add" />
           )}
@@ -85,13 +100,25 @@ function MCPServerCard({ view, onItemClick, isSelected }: MCPServerCardProps) {
               size="sm"
             />
             <span className="text-sm font-medium">{view.label}</span>
-            {isSelected && <Chip size="xs" color="green" label="ADDED" />}
+            <div
+              className={cn(
+                FADE_TRANSITION_CLASSES,
+                isSelected ? "opacity-100" : "opacity-0"
+              )}
+            >
+              {isSelected && <Chip size="xs" color="green" label="ADDED" />}
+            </div>
           </div>
           <div className="line-clamp-2 w-full text-xs text-gray-600">
             {getMcpServerViewDescription(view)}
           </div>
         </div>
-        <div>
+        <div
+          className={cn(
+            FADE_TRANSITION_CLASSES,
+            canAdd ? "opacity-100" : "opacity-0"
+          )}
+        >
           {canAdd && (
             <Button size="xs" variant="outline" icon={PlusIcon} label="Add" />
           )}

--- a/front/components/agent_builder/capabilities/mcp/MCPServerSelectionPage.tsx
+++ b/front/components/agent_builder/capabilities/mcp/MCPServerSelectionPage.tsx
@@ -107,7 +107,6 @@ interface MCPServerSelectionPageProps {
   dataVisualization?: ActionSpecification | null;
   onDataVisualizationClick?: () => void;
   selectedToolsInDialog?: SelectedTool[];
-  onRemoveSelectedTool?: (tool: SelectedTool) => void;
 }
 
 export function MCPServerSelectionPage({
@@ -116,7 +115,6 @@ export function MCPServerSelectionPage({
   dataVisualization,
   onDataVisualizationClick,
   selectedToolsInDialog = [],
-  onRemoveSelectedTool,
 }: MCPServerSelectionPageProps) {
   const [filteredServerViews, setFilteredServerViews] =
     React.useState<MCPServerViewTypeWithLabel[]>(mcpServerViews);
@@ -200,32 +198,6 @@ export function MCPServerSelectionPage({
               isSelected={selectedMCPIds.has(view.sId)}
             />
           ))}
-        </div>
-      )}
-
-      {selectedToolsInDialog.length > 0 && (
-        <div className="space-y-3">
-          <h2 className="text-lg font-semibold">Selected tools</h2>
-          <div className="flex flex-wrap gap-2">
-            {selectedToolsInDialog.map((tool, index) => (
-              <Chip
-                key={index}
-                label={
-                  tool.type === "DATA_VISUALIZATION"
-                    ? dataVisualization?.label || ""
-                    : tool.type === "MCP"
-                      ? tool.view.name || tool.view.server.name
-                      : ""
-                }
-                onRemove={
-                  onRemoveSelectedTool
-                    ? () => onRemoveSelectedTool(tool)
-                    : undefined
-                }
-                size="sm"
-              />
-            ))}
-          </div>
         </div>
       )}
     </div>

--- a/front/components/agent_builder/capabilities/mcp/MCPServerViewsDialog.tsx
+++ b/front/components/agent_builder/capabilities/mcp/MCPServerViewsDialog.tsx
@@ -19,6 +19,7 @@ import type {
 import type { MCPServerConfigurationType } from "@app/components/agent_builder/AgentBuilderFormContext";
 import { MCPActionHeader } from "@app/components/agent_builder/capabilities/mcp/MCPActionHeader";
 import { MCPServerSelectionPage } from "@app/components/agent_builder/capabilities/mcp/MCPServerSelectionPage";
+import { MCPServerViewsFooter } from "@app/components/agent_builder/capabilities/mcp/MCPServerViewsFooter";
 import { generateUniqueActionName } from "@app/components/agent_builder/capabilities/mcp/utils/actionNameUtils";
 import { getDefaultFormValues } from "@app/components/agent_builder/capabilities/mcp/utils/formDefaults";
 import { createFormResetHandler } from "@app/components/agent_builder/capabilities/mcp/utils/formStateUtils";
@@ -53,7 +54,6 @@ import type { MCPServerViewType } from "@app/lib/api/mcp";
 import { useModels } from "@app/lib/swr/models";
 import { useSpaces } from "@app/lib/swr/spaces";
 import { O4_MINI_MODEL_ID } from "@app/types";
-import { MCPServerViewsFooter } from "@app/components/agent_builder/capabilities/mcp/MCPServerViewsFooter";
 
 export type SelectedTool =
   | {

--- a/front/components/agent_builder/capabilities/mcp/MCPServerViewsDialog.tsx
+++ b/front/components/agent_builder/capabilities/mcp/MCPServerViewsDialog.tsx
@@ -53,6 +53,7 @@ import type { MCPServerViewType } from "@app/lib/api/mcp";
 import { useModels } from "@app/lib/swr/models";
 import { useSpaces } from "@app/lib/swr/spaces";
 import { O4_MINI_MODEL_ID } from "@app/types";
+import { MCPServerViewsFooter } from "@app/components/agent_builder/capabilities/mcp/MCPServerViewsFooter";
 
 export type SelectedTool =
   | {
@@ -429,7 +430,6 @@ export function MCPServerViewsDialog({
           dataVisualization={dataVisualization}
           onDataVisualizationClick={onClickDataVisualization}
           selectedToolsInDialog={selectedToolsInDialog}
-          onRemoveSelectedTool={toggleToolSelection}
         />
       ),
     },
@@ -718,6 +718,13 @@ export function MCPServerViewsDialog({
         }}
         leftButton={leftButton}
         rightButton={rightButton}
+        footerContent={
+          <MCPServerViewsFooter
+            selectedToolsInDialog={selectedToolsInDialog}
+            dataVisualization={dataVisualization}
+            onRemoveSelectedTool={toggleToolSelection}
+          />
+        }
       />
     </MultiPageDialog>
   );

--- a/front/components/agent_builder/capabilities/mcp/MCPServerViewsDialog.tsx
+++ b/front/components/agent_builder/capabilities/mcp/MCPServerViewsDialog.tsx
@@ -718,6 +718,7 @@ export function MCPServerViewsDialog({
         }}
         leftButton={leftButton}
         rightButton={rightButton}
+        addFooterSeparator
         footerContent={
           <MCPServerViewsFooter
             selectedToolsInDialog={selectedToolsInDialog}

--- a/front/components/agent_builder/capabilities/mcp/MCPServerViewsFooter.tsx
+++ b/front/components/agent_builder/capabilities/mcp/MCPServerViewsFooter.tsx
@@ -1,0 +1,47 @@
+import { Chip } from "@dust-tt/sparkle";
+import React from "react";
+
+import type { SelectedTool } from "@app/components/agent_builder/capabilities/mcp/MCPServerViewsDialog";
+import type { ActionSpecification } from "@app/components/agent_builder/types";
+
+interface MCPServerViewsFooterProps {
+  selectedToolsInDialog: SelectedTool[];
+  dataVisualization?: ActionSpecification | null;
+  onRemoveSelectedTool?: (tool: SelectedTool) => void;
+}
+
+export function MCPServerViewsFooter({
+  selectedToolsInDialog,
+  dataVisualization,
+  onRemoveSelectedTool,
+}: MCPServerViewsFooterProps) {
+  return (
+    <>
+      {selectedToolsInDialog.length > 0 && (
+        <div className="space-y-3">
+          <h2 className="text-lg font-semibold">Selected tools</h2>
+          <div className="flex flex-wrap gap-2">
+            {selectedToolsInDialog.map((tool, index) => (
+              <Chip
+                key={index}
+                label={
+                  tool.type === "DATA_VISUALIZATION"
+                    ? dataVisualization?.label || ""
+                    : tool.type === "MCP"
+                      ? tool.view.name || tool.view.server.name
+                      : ""
+                }
+                onRemove={
+                  onRemoveSelectedTool
+                    ? () => onRemoveSelectedTool(tool)
+                    : undefined
+                }
+                size="sm"
+              />
+            ))}
+          </div>
+        </div>
+      )}
+    </>
+  );
+}

--- a/front/package-lock.json
+++ b/front/package-lock.json
@@ -7,7 +7,7 @@
       "dependencies": {
         "@datadog/browser-logs": "^6.13.0",
         "@dust-tt/client": "file:../sdks/js",
-        "@dust-tt/sparkle": "^0.2.566",
+        "@dust-tt/sparkle": "^0.2.569",
         "@google-cloud/bigquery": "^7.9.1",
         "@google-cloud/storage-transfer": "^3.6.0",
         "@heroicons/react": "^2.0.11",
@@ -1111,9 +1111,9 @@
       "link": true
     },
     "node_modules/@dust-tt/sparkle": {
-      "version": "0.2.566",
-      "resolved": "https://registry.npmjs.org/@dust-tt/sparkle/-/sparkle-0.2.566.tgz",
-      "integrity": "sha512-XeXMu7tQUXox/08xyfhkuuMGSVqg8eW+JUExGdatpBKAFCnXHG3O+ssVdiqsEt1+buQglxUOuNVSakqrNGRx8A==",
+      "version": "0.2.569",
+      "resolved": "https://registry.npmjs.org/@dust-tt/sparkle/-/sparkle-0.2.569.tgz",
+      "integrity": "sha512-UvPp8gcC7Y5/gSjRNAPJ10+i1aLhd6DmnNLJjIGyiDc1mzcV01QtRcYzKHLd85mpc/cf1buKfDlhLpd7uRgSXg==",
       "dependencies": {
         "@emoji-mart/data": "^1.1.2",
         "@emoji-mart/react": "^1.1.1",

--- a/front/package.json
+++ b/front/package.json
@@ -24,7 +24,7 @@
   "dependencies": {
     "@datadog/browser-logs": "^6.13.0",
     "@dust-tt/client": "file:../sdks/js",
-    "@dust-tt/sparkle": "^0.2.566",
+    "@dust-tt/sparkle": "^0.2.569",
     "@google-cloud/bigquery": "^7.9.1",
     "@google-cloud/storage-transfer": "^3.6.0",
     "@heroicons/react": "^2.0.11",


### PR DESCRIPTION
## Description

This PR improves the UI of the agent builder's tool configuration dialog with several refinements:
- Moves selected tools display to a dedicated footer component with fade transitions
- Adds a footer separator in the dialog for better visual hierarchy
- Improves visibility of "ADDED" status with fade transitions

## Tests

Locally

## Risk

Low

## Deploy Plan

Deploy front