### PR TITLE
enh: add unicode metaprompt for latest OpenAI reasoning models

### DIFF
--- a/core/src/providers/openai_responses_api_helpers.rs
+++ b/core/src/providers/openai_responses_api_helpers.rs
@@ -396,8 +396,10 @@ pub async fn openai_responses_api_completion(
     transform_system_messages: TransformSystemMessages,
     provider_name: String,
 ) -> Result<LLMChatGeneration> {
-    let is_reasoning_model =
-        model_id.starts_with("o3") || model_id.starts_with("o1") || model_id.starts_with("o4");
+    let is_reasoning_model = model_id.starts_with("o3")
+        || model_id.starts_with("o1")
+        || model_id.starts_with("o4")
+        || model_id.starts_with("gpt-5");
 
     let (openai_org_id, instructions, reasoning_effort, store) = match &extras {
         None => (None, None, None, true),

--- a/front/lib/actions/mcp_internal_actions/servers/webtools.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/webtools.ts
@@ -49,7 +49,7 @@ const createServer = (agentLoopContext?: AgentLoopContextType): McpServer => {
         .describe(
           "The query used to perform the Google search. If requested by the " +
             "user, use the Google syntax `site:` to restrict the search " +
-            "to a particular website or domain. Should not contain unicode sequences."
+            "to a particular website or domain."
         ),
       page: z
         .number()

--- a/front/lib/api/assistant/generation.ts
+++ b/front/lib/api/assistant/generation.ts
@@ -95,6 +95,9 @@ export async function constructPromptMultiActions(
   let toolsSection = "# TOOLS\n";
 
   let toolUseDirectives = "\n## TOOL USE DIRECTIVES\n";
+  if (hasAvailableActions && model.toolUseMetaPrompt) {
+    toolUseDirectives += `${model.toolUseMetaPrompt}\\n`;
+  }
   if (
     hasAvailableActions &&
     agentConfiguration.model.reasoningEffort === "light" &&

--- a/front/types/assistant/assistant.ts
+++ b/front/types/assistant/assistant.ts
@@ -312,6 +312,9 @@ export type ModelConfigurationType = {
   // This meta-prompt is always injected into the agent's system instructions.
   formattingMetaPrompt?: string;
 
+  // This meta-prompt is injected if the agent has tools available.
+  toolUseMetaPrompt?: string;
+
   // Adjust the token count estimation by a ratio. Only needed for anthropic models, where the token count is higher than our estimate
   tokenCountAdjustment?: number;
 
@@ -487,6 +490,22 @@ NEVER:
 - Return a response that is just a list of bullet points.
 - Omit headings in multi-paragraph answers.`;
 
+const OPENAI_TOOL_USE_META_PROMPT =
+  `CRITICAL: When calling functions or tools, ` +
+  `you MUST be extremely careful with accented characters. ` +
+  `Always use the actual accented character in the JSON, ` +
+  `never use Unicode escape sequences like \\u00XX.
+CORRECT examples (what you SHOULD do):
+- Use: {"query": "Žižek philosophy"}
+- Use: {"query": "café français"}  
+- Use: {"query": "naïveté übermensch"}
+- Use: {"query": "Søren Kierkegaard"}
+INCORRECT examples (what you must NEVER do):
+- Never: {"query": "\\u017di\\u017eek philosophy"}
+- Never: {"query": "caf\\u00e9 fran\\u00e7ais"}
+- Never: {"query": "na\\u00efvet\\u00e9"}
+The tools expect properly formed JSON with actual UTF-8 characters, not escape sequences.`;
+
 export const GPT_5_MODEL_CONFIG: ModelConfigurationType = {
   providerId: "openai",
   modelId: GPT_5_MODEL_ID,
@@ -507,6 +526,7 @@ export const GPT_5_MODEL_CONFIG: ModelConfigurationType = {
   useNativeLightReasoning: true,
   supportsResponseFormat: true,
   formattingMetaPrompt: OPENAI_FORMATTING_META_PROMPT,
+  toolUseMetaPrompt: OPENAI_TOOL_USE_META_PROMPT,
 };
 export const O1_MODEL_CONFIG: ModelConfigurationType = {
   providerId: "openai",
@@ -573,6 +593,7 @@ export const O3_MODEL_CONFIG: ModelConfigurationType = {
   defaultReasoningEffort: "medium",
   supportsResponseFormat: true,
   formattingMetaPrompt: OPENAI_FORMATTING_META_PROMPT,
+  toolUseMetaPrompt: OPENAI_TOOL_USE_META_PROMPT,
 };
 
 export const O3_MINI_MODEL_CONFIG: ModelConfigurationType = {
@@ -594,6 +615,8 @@ export const O3_MINI_MODEL_CONFIG: ModelConfigurationType = {
   maximumReasoningEffort: "high",
   defaultReasoningEffort: "medium",
   supportsResponseFormat: true,
+  formattingMetaPrompt: OPENAI_FORMATTING_META_PROMPT,
+  toolUseMetaPrompt: OPENAI_TOOL_USE_META_PROMPT,
 };
 
 export const O4_MINI_MODEL_CONFIG: ModelConfigurationType = {
@@ -614,6 +637,8 @@ export const O4_MINI_MODEL_CONFIG: ModelConfigurationType = {
   maximumReasoningEffort: "high",
   defaultReasoningEffort: "medium",
   supportsResponseFormat: true,
+  formattingMetaPrompt: OPENAI_FORMATTING_META_PROMPT,
+  toolUseMetaPrompt: OPENAI_TOOL_USE_META_PROMPT,
 };
 
 export const DEFAULT_TOKEN_COUNT_ADJUSTMENT = 1.15;


### PR DESCRIPTION
## Description

Meta prompt to avoid the invalid unicode sequences in tool calls from GPT5 (and other recent openai models)

## Tests

Local

## Risk

Low

## Deploy Plan

Deploy front