### PR TITLE
Fix: useHashParams, handle reload and current hash correctly + various little fixes

### DIFF
--- a/front/components/assistant/AssistantBrowser.tsx
+++ b/front/components/assistant/AssistantBrowser.tsx
@@ -373,12 +373,6 @@ export function AssistantBrowser({
         </ScrollArea>
       </div>
 
-      {isLoading && (
-        <div className="flex justify-center py-8">
-          <Spinner size="lg" />
-        </div>
-      )}
-
       {viewTab === "all" ? (
         <>
           <div className="mb-2 flex flex-wrap gap-2">
@@ -447,6 +441,11 @@ export function AssistantBrowser({
             handleMoreClick={handleMoreClick}
           />
         )
+      )}
+      {isLoading && (
+        <div className="flex justify-center py-8">
+          <Spinner size="lg" />
+        </div>
       )}
     </>
   );

--- a/front/components/assistant/conversation/input_bar/InputBarContainer.tsx
+++ b/front/components/assistant/conversation/input_bar/InputBarContainer.tsx
@@ -250,7 +250,7 @@ const InputBarContainer = ({
     "inline-block w-full",
     "border-0 px-2 outline-none ring-0 focus:border-0 focus:outline-none focus:ring-0",
     "whitespace-pre-wrap font-normal",
-    "pb-6 pt-4 sm:py-3.5" // Increased padding on mobile
+    "py-3.5"
   );
 
   return (
@@ -273,7 +273,7 @@ const InputBarContainer = ({
             "overflow-y-auto",
             isExpanded
               ? "h-[60vh] max-h-[60vh] lg:h-[80vh] lg:max-h-[80vh]"
-              : "max-h-64 min-h-10"
+              : "max-h-64 min-h-24 sm:min-h-14"
           )}
         />
         <div className="flex items-center pb-3 pt-0">

--- a/front/hooks/useHashParams.ts
+++ b/front/hooks/useHashParams.ts
@@ -54,7 +54,12 @@ export const useHashParam = (
   const [innerValue, setInnerValue] = useState<{
     val: string | undefined;
     options: SetterOptions;
-  }>({ val: defaultValue, options: DEFAULT_OPTIONS });
+  }>({
+    val: window
+      ? getHashParam(getUrlFromLocation(window.location), key, defaultValue)
+      : defaultValue,
+    options: DEFAULT_OPTIONS,
+  });
 
   // Listen to hash change events and update the internal value if the hash is removed.
   useEffect(() => {
@@ -77,11 +82,10 @@ export const useHashParam = (
   // Listen to innerValue changes and update the hash in the router if there is a mismatch.
   useEffect(() => {
     if (typeof window !== "undefined" && router.isReady) {
-      // get current hash from window.location.
+      // get current hash from window.location, DO NOT DEFAULT TO DEFAULT VALUE.
       const currentHash = getHashParam(
         getUrlFromLocation(window.location),
-        key,
-        defaultValue
+        key
       );
       if (currentHash !== innerValue.val) {
         const { pathname, search } = window.location;


### PR DESCRIPTION
## Description

Fix reloading of page reverting to default value and fix infinite useEffect because getting current hash was always giving the default value.

## Tests

Local

## Risk

Low

## Deploy Plan

Deploy front