### PR TITLE
[front,sparkle] - chore(AB v2): UI tweaks

### DIFF
--- a/front/components/agent_builder/AgentBuilderLeftPanel.tsx
+++ b/front/components/agent_builder/AgentBuilderLeftPanel.tsx
@@ -59,7 +59,7 @@ export function AgentBuilderLeftPanel({
       </ScrollArea>
       <BarFooter
         variant="default"
-        className="mx-4"
+        className="mx-4 justify-between"
         leftActions={
           <Button variant="outline" label="Close" onClick={handleCancel} />
         }

--- a/front/components/agent_builder/capabilities/mcp/MCPServerSelectionPage.tsx
+++ b/front/components/agent_builder/capabilities/mcp/MCPServerSelectionPage.tsx
@@ -1,4 +1,11 @@
-import { Avatar, BookOpenIcon, Card, Chip, Icon } from "@dust-tt/sparkle";
+import {
+  Avatar,
+  BookOpenIcon,
+  Card,
+  CardGrid,
+  Chip,
+  Icon,
+} from "@dust-tt/sparkle";
 import { ActionIcons } from "@dust-tt/sparkle";
 import { Button } from "@dust-tt/sparkle";
 import { PlusIcon } from "@dust-tt/sparkle";
@@ -182,7 +189,7 @@ export function MCPServerSelectionPage({
         (dataVisualization &&
           onDataVisualizationClick &&
           showDataVisualization)) && (
-        <div className="grid grid-cols-2 gap-4">
+        <CardGrid>
           {dataVisualization &&
             onDataVisualizationClick &&
             showDataVisualization && (
@@ -200,7 +207,7 @@ export function MCPServerSelectionPage({
               isSelected={selectedMCPIds.has(view.sId)}
             />
           ))}
-        </div>
+        </CardGrid>
       )}
 
       {selectedToolsInDialog.length > 0 && (

--- a/sparkle/src/components/Dialog.tsx
+++ b/sparkle/src/components/Dialog.tsx
@@ -126,7 +126,7 @@ const DialogHeader = ({
 }: NewDialogHeaderProps) => (
   <div
     className={cn(
-      "s-z-50 s-flex s-flex-none s-flex-col s-gap-0 s-px-5 s-py-4 s-text-left",
+      "s-sticky s-top-0 s-z-50 s-flex s-flex-none s-flex-col s-gap-0 s-bg-background s-px-5 s-py-4 s-text-left dark:s-bg-background-night",
       className
     )}
     {...props}

--- a/sparkle/src/components/Resizable.tsx
+++ b/sparkle/src/components/Resizable.tsx
@@ -47,7 +47,7 @@ const ResizableHandle = ({
     {withHandle && (
       <div
         className={cn(
-          "s-absolute s-flex s-h-6 s-w-2 s-items-center s-justify-center s-rounded-sm",
+          "s-absolute s-flex s-h-6 s-w-2 s-items-center s-justify-center s-rounded-2xl",
           "s-border-structure-200 s-border s-bg-white"
         )}
       >

--- a/sparkle/src/components/Resizable.tsx
+++ b/sparkle/src/components/Resizable.tsx
@@ -39,7 +39,7 @@ const ResizableHandle = ({
       "data-[panel-group-direction=vertical]:after:s--translate-y-1/2",
       "data-[panel-group-direction=vertical]:after:s-translate-x-0",
       "[&[data-panel-group-direction=vertical]>div]:s-rotate-90",
-      "s-bg-white dark:s-bg-border-night",
+      "s-bg-gray-200 dark:s-bg-border-night",
       className
     )}
     {...props}
@@ -47,8 +47,8 @@ const ResizableHandle = ({
     {withHandle && (
       <div
         className={cn(
-          "s-absolute s-flex s-h-4 s-w-2 s-items-center s-justify-center s-rounded-sm",
-          "dark:s-bg-structure-50 s-border-structure-200 s-border s-bg-white"
+          "s-absolute s-flex s-h-6 s-w-2 s-items-center s-justify-center s-rounded-sm",
+          "s-border-structure-200 s-border s-bg-white"
         )}
       >
         <div className="s-w-px" />

--- a/sparkle/src/stories/Bar.stories.tsx
+++ b/sparkle/src/stories/Bar.stories.tsx
@@ -88,8 +88,6 @@ export const BasicBarHeaderValidate = () => {
 };
 
 export const BasicBarFooterValidate = () => {
-  const [isSaving, setIsSaving] = React.useState(false);
-
   return (
     <div className="s-flex s-h-full s-w-full s-flex-col">
       <div className="s-flex-1 s-overflow-y-auto s-p-4">

--- a/sparkle/src/stories/Bar.stories.tsx
+++ b/sparkle/src/stories/Bar.stories.tsx
@@ -5,6 +5,8 @@ import { ChatBubbleBottomCenterTextIcon } from "@sparkle/icons/app";
 
 import {
   Bar,
+  BarFooter,
+  Button,
   Page,
   ResizableHandle,
   ResizablePanel,
@@ -111,29 +113,24 @@ export const BasicBarFooterValidate = () => {
           />
         </div>
       </div>
-      <Bar
-        position="bottom"
+      <BarFooter
+        variant="default"
+        className="mx-4 s-justify-between"
+        leftActions={
+          <Button
+            variant="outline"
+            label="Close"
+            onClick={() => console.log("Exit")}
+          />
+        }
         rightActions={
-          <Bar.ButtonBar
+          <BarFooter.ButtonBar
             variant="validate"
-            cancelButtonProps={{
-              size: "sm",
-              label: "Cancel",
-              variant: "ghost",
-              onClick: () => alert("Cancelled!"),
-            }}
             saveButtonProps={{
               size: "sm",
-              label: isSaving ? "Saving..." : "Save",
+              label: "Save",
               variant: "primary",
-              onClick: () => {
-                setIsSaving(true);
-                setTimeout(() => {
-                  setIsSaving(false);
-                  alert("Saved!");
-                }, 2000);
-              },
-              disabled: isSaving,
+              disabled: false,
             }}
           />
         }

--- a/sparkle/src/stories/Resizable.stories.tsx
+++ b/sparkle/src/stories/Resizable.stories.tsx
@@ -85,7 +85,7 @@ export function ResizableGrabDemo() {
       className="s-min-h-[200px] s-max-w-md s-rounded-lg s-border s-bg-white md:s-min-w-[450px]"
     >
       <ResizablePanel defaultSize={25}>
-        <div className="s-flex s-h-full s-items-center s-justify-center s-bg-primary-900 s-p-6 s-text-white">
+        <div className="s-flex s-h-full s-items-center s-justify-center">
           <span className="s-font-semibold">Sidebar</span>
         </div>
       </ResizablePanel>


### PR DESCRIPTION
## Description

This PR adds various UI tweaks to improve the Agent Builder v2 experience:
- Changed background color to gray-200 for `ResizableHandle` for better visibility
- Improved `DataTable` row selection by implementing click handler for entire rows
- Added sticky positioning and dark mode support to `DialogHeader`
- Added justification between buttons in the `AgentBuilderLeftPanel` footer

## Tests

Locallly

## Risk

Low

## Deploy Plan

Deploy front
