### PR TITLE
Fix: conversation input width with non-truncable string

### DIFF
--- a/front/components/assistant/conversation/input_bar/InputBarContainer.tsx
+++ b/front/components/assistant/conversation/input_bar/InputBarContainer.tsx
@@ -264,7 +264,7 @@ const InputBarContainer = ({
         }
       }}
     >
-      <div className="flex flex-grow flex-col">
+      <div className="flex w-0 flex-grow flex-col">
         <EditorContent
           editor={editor}
           className={classNames(


### PR DESCRIPTION
## Description

Fix the input bar growing too far because it has no width specified.
width 0 + flex-grow does the trick.

## Tests

Local, firefox & chrome

## Risk

Low

## Deploy Plan

deploy front