### PR TITLE
[front] chore: eslint lodash

### DIFF
--- a/eslint-plugin-dust/index.js
+++ b/eslint-plugin-dust/index.js
@@ -4,6 +4,7 @@ const noRawSqlRule = require("./rules/no-raw-sql");
 const noUnverifiedWorkspaceBypass = require("./rules/no-unverified-workspace-bypass");
 const tooLongIndexName = require("./rules/too-long-index-name");
 const noDirectSparkleNotification = require("./rules/no-direct-sparkle-notification");
+const noBulkLodash = require("./rules/no-bulk-lodash.js");
 
 module.exports = {
   meta: {
@@ -15,5 +16,6 @@ module.exports = {
     "no-unverified-workspace-bypass": noUnverifiedWorkspaceBypass,
     "too-long-index-name": tooLongIndexName,
     "no-direct-sparkle-notification": noDirectSparkleNotification,
+    "no-bulk-lodash": noBulkLodash,
   },
 };

--- a/eslint-plugin-dust/rules/no-bulk-lodash.js
+++ b/eslint-plugin-dust/rules/no-bulk-lodash.js
@@ -15,8 +15,15 @@ module.exports = {
   create(context) {
     return {
       ImportDeclaration(node) {
-        // Only check files in front/components
-        if (!context.getFilename().includes("front/components/")) {
+        // Only check files in specified paths
+        const pathsToCheck = [
+          "front/components/",
+          "front/lib/client/",
+          "front/lib/swr/",
+        ];
+
+        const filename = context.getFilename();
+        if (!pathsToCheck.some((path) => filename.includes(path))) {
           return;
         }
 
@@ -30,7 +37,7 @@ module.exports = {
           context.report({
             node,
             message:
-              "Bulk lodash imports are not allowed in front/components. Use individual imports instead.",
+              "Bulk lodash imports are not allowed in this file. Use individual imports instead.",
             fix(fixer) {
               const newImports = imports
                 .map((name) => `import ${name} from 'lodash/${name}';`)

--- a/eslint-plugin-dust/rules/no-bulk-lodash.js
+++ b/eslint-plugin-dust/rules/no-bulk-lodash.js
@@ -4,7 +4,8 @@ module.exports = {
   meta: {
     type: "problem",
     docs: {
-      description: "Disallow bulk lodash imports in frontend code to prevent bundle bloat",
+      description:
+        "Disallow bulk lodash imports in frontend code to prevent bundle bloat",
       category: "Best Practices",
       recommended: true,
       url: "https://lodash.com/docs/4.17.15#lodash",
@@ -33,18 +34,6 @@ module.exports = {
   create(context) {
     return {
       ImportDeclaration(node) {
-        // Only check files in specified paths
-        const pathsToCheck = [
-          "front/components/",
-          "front/lib/client/",
-          "front/lib/swr/",
-        ];
-
-        const filename = context.getFilename();
-        if (!pathsToCheck.some((path) => filename.includes(path))) {
-          return;
-        }
-
         if (
           node.source.value === "lodash" &&
           node.specifiers.length > 0 &&
@@ -54,8 +43,7 @@ module.exports = {
 
           context.report({
             node,
-            message:
-              `Bulk lodash imports significantly increase bundle size (~70KB). Use individual imports instead (e.g., 'lodash/debounce') to reduce bundle size by 90%+. Importing: ${imports.join(", ")}`,
+            message: `Bulk lodash imports significantly increase bundle size (~70KB). Use individual imports instead (e.g., 'lodash/debounce') to reduce bundle size by 90%+. Importing: ${imports.join(", ")}`,
             fix(fixer) {
               const newImports = imports
                 .map((name) => `import ${name} from 'lodash/${name}';`)

--- a/eslint-plugin-dust/rules/no-bulk-lodash.js
+++ b/eslint-plugin-dust/rules/no-bulk-lodash.js
@@ -1,0 +1,45 @@
+"use strict";
+
+module.exports = {
+  meta: {
+    type: "problem",
+    docs: {
+      description: "Disallow bulk lodash imports in front/components",
+      category: "Best Practices",
+      recommended: true,
+    },
+    fixable: "code",
+    schema: [],
+  },
+
+  create(context) {
+    return {
+      ImportDeclaration(node) {
+        // Only check files in front/components
+        if (!context.getFilename().includes("front/components/")) {
+          return;
+        }
+
+        if (
+          node.source.value === "lodash" &&
+          node.specifiers.length > 0 &&
+          node.specifiers[0].type === "ImportSpecifier"
+        ) {
+          const imports = node.specifiers.map((spec) => spec.imported.name);
+
+          context.report({
+            node,
+            message:
+              "Bulk lodash imports are not allowed in front/components. Use individual imports instead.",
+            fix(fixer) {
+              const newImports = imports
+                .map((name) => `import ${name} from 'lodash/${name}';`)
+                .join("\n");
+              return fixer.replaceText(node, newImports);
+            },
+          });
+        }
+      },
+    };
+  },
+};

--- a/eslint-plugin-dust/rules/no-bulk-lodash.js
+++ b/eslint-plugin-dust/rules/no-bulk-lodash.js
@@ -4,9 +4,27 @@ module.exports = {
   meta: {
     type: "problem",
     docs: {
-      description: "Disallow bulk lodash imports in front/components",
+      description: "Disallow bulk lodash imports in frontend code to prevent bundle bloat",
       category: "Best Practices",
       recommended: true,
+      url: "https://lodash.com/docs/4.17.15#lodash",
+      explanation: `
+        Bulk lodash imports (e.g., import { debounce, throttle } from 'lodash') are problematic in frontend code because:
+        
+        1. **Bundle Size Impact**: The entire lodash library (~70KB minified) gets included even if you only use 1-2 functions
+        2. **Tree Shaking Issues**: Many bundlers struggle to tree-shake lodash effectively when imported as a whole
+        3. **Performance**: Larger bundle sizes lead to slower page loads and poor user experience
+        4. **Memory Usage**: Unused lodash functions consume unnecessary memory in the browser
+        5. **Network Overhead**: More data to download, especially critical on mobile connections
+        
+        **Solution**: Use individual imports like 'lodash/debounce' which only include the specific function you need.
+        This can reduce your bundle size by 90%+ when using only a few lodash utilities.
+        
+        **Example**:
+        ❌ Bad:  import { debounce, throttle } from 'lodash';
+        ✅ Good: import debounce from 'lodash/debounce';
+                import throttle from 'lodash/throttle';
+      `,
     },
     fixable: "code",
     schema: [],
@@ -37,7 +55,7 @@ module.exports = {
           context.report({
             node,
             message:
-              "Bulk lodash imports are not allowed in this file. Use individual imports instead.",
+              `Bulk lodash imports significantly increase bundle size (~70KB). Use individual imports instead (e.g., 'lodash/debounce') to reduce bundle size by 90%+. Importing: ${imports.join(", ")}`,
             fix(fixer) {
               const newImports = imports
                 .map((name) => `import ${name} from 'lodash/${name}';`)

--- a/front/.eslintrc.js
+++ b/front/.eslintrc.js
@@ -60,6 +60,7 @@ module.exports = {
     "dust/no-unverified-workspace-bypass": "error",
     "dust/too-long-index-name": "error",
     "dust/no-direct-sparkle-notification": "warn",
+    "dust/no-bulk-lodash": "error",
   },
   overrides: [
     {

--- a/front/.prettierignore
+++ b/front/.prettierignore
@@ -1,2 +1,4 @@
 .next
 public/swagger.json
+node_modules
+.yalc

--- a/front/components/agent_builder/AgentBuilder.tsx
+++ b/front/components/agent_builder/AgentBuilder.tsx
@@ -1,5 +1,5 @@
 import { zodResolver } from "@hookform/resolvers/zod";
-import { set } from "lodash";
+import set from "lodash/set";
 import { useRouter } from "next/router";
 import { useMemo } from "react";
 import { useForm } from "react-hook-form";

--- a/front/components/agent_builder/MCPServerViewsContext.tsx
+++ b/front/components/agent_builder/MCPServerViewsContext.tsx
@@ -1,4 +1,4 @@
-import { groupBy } from "lodash";
+import groupBy from "lodash/groupBy";
 import type { ReactNode } from "react";
 import React, { createContext, useContext, useMemo } from "react";
 

--- a/front/components/agent_builder/capabilities/AgentBuilderCapabilitiesBlock.tsx
+++ b/front/components/agent_builder/capabilities/AgentBuilderCapabilitiesBlock.tsx
@@ -12,7 +12,6 @@ import {
   Spinner,
   XMarkIcon,
 } from "@dust-tt/sparkle";
-import { Spinner } from "@dust-tt/sparkle";
 import isEmpty from "lodash/isEmpty";
 import React, { useState } from "react";
 import { useFieldArray, useFormContext } from "react-hook-form";

--- a/front/components/agent_builder/capabilities/AgentBuilderCapabilitiesBlock.tsx
+++ b/front/components/agent_builder/capabilities/AgentBuilderCapabilitiesBlock.tsx
@@ -12,7 +12,8 @@ import {
   Spinner,
   XMarkIcon,
 } from "@dust-tt/sparkle";
-import { isEmpty } from "lodash";
+import { Spinner } from "@dust-tt/sparkle";
+import isEmpty from "lodash/isEmpty";
 import React, { useState } from "react";
 import { useFieldArray, useFormContext } from "react-hook-form";
 

--- a/front/components/agent_builder/capabilities/knowledge/KnowledgeConfigurationSheet.tsx
+++ b/front/components/agent_builder/capabilities/knowledge/KnowledgeConfigurationSheet.tsx
@@ -8,7 +8,7 @@ import {
   Spinner,
 } from "@dust-tt/sparkle";
 import { zodResolver } from "@hookform/resolvers/zod";
-import { uniqueId } from "lodash";
+import uniqueId from "lodash/uniqueId";
 import { useEffect, useMemo, useState } from "react";
 import {
   FormProvider,

--- a/front/components/agent_builder/capabilities/mcp/utils/formDefaults.ts
+++ b/front/components/agent_builder/capabilities/mcp/utils/formDefaults.ts
@@ -1,4 +1,4 @@
-import { set } from "lodash";
+import set from "lodash/set";
 
 import type {
   AdditionalConfigurationInBuilderType,

--- a/front/components/agent_builder/capabilities/shared/ReasoningModelSection.tsx
+++ b/front/components/agent_builder/capabilities/shared/ReasoningModelSection.tsx
@@ -15,7 +15,7 @@ import {
   InformationCircleIcon,
   Spinner,
 } from "@dust-tt/sparkle";
-import { partition } from "lodash";
+import partition from "lodash/partition";
 import { useMemo } from "react";
 import { useController } from "react-hook-form";
 

--- a/front/components/agent_builder/hooks/useAgentPreview.ts
+++ b/front/components/agent_builder/hooks/useAgentPreview.ts
@@ -1,4 +1,4 @@
-import { isEqual } from "lodash";
+import isEqual from "lodash/isEqual";
 import { useCallback, useEffect, useRef, useState } from "react";
 import { useFormContext, useWatch } from "react-hook-form";
 

--- a/front/components/agent_builder/instructions/extensions/AgentBuilderInstructionsAutoCompleteExtension.ts
+++ b/front/components/agent_builder/instructions/extensions/AgentBuilderInstructionsAutoCompleteExtension.ts
@@ -4,7 +4,7 @@ import type { Node } from "@tiptap/pm/model";
 import { Plugin, PluginKey } from "@tiptap/pm/state";
 import type { EditorView } from "@tiptap/pm/view";
 import { Decoration, DecorationSet } from "@tiptap/pm/view";
-import { debounce } from "lodash";
+import debounce from "lodash/debounce";
 
 /**
  * Minimal interface for autocomplete - we only need name, handle, description and actions with name/description.

--- a/front/components/agent_builder/types.ts
+++ b/front/components/agent_builder/types.ts
@@ -1,5 +1,5 @@
 import type { Icon } from "@dust-tt/sparkle";
-import { uniqueId } from "lodash";
+import uniqueId from "lodash/uniqueId";
 import { z } from "zod";
 
 import type { agentBuilderFormSchema } from "@app/components/agent_builder/AgentBuilderFormContext";

--- a/front/components/assistant/conversation/input_bar/editor/extensions/AgentBuilderInstructionsAutoCompleteExtension.ts
+++ b/front/components/assistant/conversation/input_bar/editor/extensions/AgentBuilderInstructionsAutoCompleteExtension.ts
@@ -4,7 +4,7 @@ import type { Node } from "@tiptap/pm/model";
 import { Plugin, PluginKey } from "@tiptap/pm/state";
 import type { EditorView } from "@tiptap/pm/view";
 import { Decoration, DecorationSet } from "@tiptap/pm/view";
-import { debounce } from "lodash";
+import debounce from "lodash/debounce";
 
 import type { AssistantBuilderState } from "@app/components/assistant_builder/types";
 

--- a/front/components/assistant/conversation/input_bar/editor/extensions/MentionWithPasteExtension.tsx
+++ b/front/components/assistant/conversation/input_bar/editor/extensions/MentionWithPasteExtension.tsx
@@ -1,7 +1,7 @@
 import Mention from "@tiptap/extension-mention";
 import type { PasteRuleMatch } from "@tiptap/react";
 import { nodePasteRule } from "@tiptap/react";
-import { escapeRegExp } from "lodash";
+import escapeRegExp from "lodash/escapeRegExp";
 
 import type { EditorSuggestions } from "@app/components/assistant/conversation/input_bar/editor/suggestion";
 

--- a/front/components/assistant_builder/AddToolsDropdown.tsx
+++ b/front/components/assistant_builder/AddToolsDropdown.tsx
@@ -11,7 +11,7 @@ import {
   Spinner,
 } from "@dust-tt/sparkle";
 import assert from "assert";
-import { uniqueId } from "lodash";
+import uniqueId from "lodash/uniqueId";
 import { useState } from "react";
 
 import { useAssistantBuilderContext } from "@app/components/assistant_builder/contexts/AssistantBuilderContexts";

--- a/front/components/assistant_builder/AssistantBuilder.tsx
+++ b/front/components/assistant_builder/AssistantBuilder.tsx
@@ -9,7 +9,7 @@ import {
   TabsTrigger,
 } from "@dust-tt/sparkle";
 import assert from "assert";
-import { uniqueId } from "lodash";
+import uniqueId from "lodash/uniqueId";
 import { useRouter } from "next/router";
 import React, { useCallback, useEffect, useState } from "react";
 

--- a/front/components/assistant_builder/TryAssistant.tsx
+++ b/front/components/assistant_builder/TryAssistant.tsx
@@ -1,4 +1,4 @@
-import { isEqual } from "lodash";
+import isEqual from "lodash/isEqual";
 import { useCallback, useEffect, useRef, useState } from "react";
 
 import {

--- a/front/components/assistant_builder/actions/configuration/DustAppConfigurationSection.tsx
+++ b/front/components/assistant_builder/actions/configuration/DustAppConfigurationSection.tsx
@@ -8,7 +8,7 @@ import {
   Separator,
   Spinner,
 } from "@dust-tt/sparkle";
-import { sortBy } from "lodash";
+import sortBy from "lodash/sortBy";
 import React, { useMemo } from "react";
 
 import { ConfigurationSectionContainer } from "@app/components/assistant_builder/actions/configuration/ConfigurationSectionContainer";

--- a/front/components/assistant_builder/actions/configuration/ReasoningModelConfigurationSection.tsx
+++ b/front/components/assistant_builder/actions/configuration/ReasoningModelConfigurationSection.tsx
@@ -15,7 +15,7 @@ import {
   InformationCircleIcon,
   Spinner,
 } from "@dust-tt/sparkle";
-import { partition } from "lodash";
+import partition from "lodash/partition";
 import { useMemo } from "react";
 
 import { ConfigurationSectionContainer } from "@app/components/assistant_builder/actions/configuration/ConfigurationSectionContainer";

--- a/front/components/assistant_builder/contexts/AssistantBuilderContexts.tsx
+++ b/front/components/assistant_builder/contexts/AssistantBuilderContexts.tsx
@@ -1,4 +1,4 @@
-import { uniqueId } from "lodash";
+import uniqueId from "lodash/uniqueId";
 import type { ReactNode } from "react";
 import React, {
   createContext,

--- a/front/components/assistant_builder/tags/DataSourceViewTagsFilterDropdown.tsx
+++ b/front/components/assistant_builder/tags/DataSourceViewTagsFilterDropdown.tsx
@@ -7,7 +7,7 @@ import {
   PopoverTrigger,
   SliderToggle,
 } from "@dust-tt/sparkle";
-import { cloneDeep } from "lodash";
+import cloneDeep from "lodash/cloneDeep";
 
 import { getActionTags } from "@app/components/assistant_builder/tags/helpers";
 import { TagSearchSection } from "@app/components/assistant_builder/tags/TagSearchSection";

--- a/front/components/assistant_builder/types.ts
+++ b/front/components/assistant_builder/types.ts
@@ -1,7 +1,7 @@
 import type { Icon } from "@dust-tt/sparkle";
 import { CircleIcon, SquareIcon, TriangleIcon } from "@dust-tt/sparkle";
 import type { JSONSchema7 as JSONSchema } from "json-schema";
-import { uniqueId } from "lodash";
+import uniqueId from "lodash/uniqueId";
 import type React from "react";
 import type { SVGProps } from "react";
 

--- a/front/components/assistant_builder/useTools.ts
+++ b/front/components/assistant_builder/useTools.ts
@@ -1,4 +1,4 @@
-import { groupBy } from "lodash";
+import groupBy from "lodash/groupBy";
 import { useMemo } from "react";
 
 import { sortMCPServerViewsByPriority } from "@app/components/agent_builder/MCPServerViewsContext";

--- a/front/components/me/UserToolsTable.tsx
+++ b/front/components/me/UserToolsTable.tsx
@@ -1,6 +1,6 @@
 import { Chip, DataTable, Label, SearchInput, Spinner } from "@dust-tt/sparkle";
 import type { ColumnDef } from "@tanstack/react-table";
-import { keyBy } from "lodash";
+import keyBy from "lodash/keyBy";
 import { useCallback, useMemo, useState } from "react";
 
 import { useSendNotification } from "@app/hooks/useNotification";

--- a/front/components/spaces/ContentActions.tsx
+++ b/front/components/spaces/ContentActions.tsx
@@ -6,7 +6,7 @@ import {
   PencilSquareIcon,
   TrashIcon,
 } from "@dust-tt/sparkle";
-import { capitalize } from "lodash";
+import capitalize from "lodash/capitalize";
 import type { NextRouter } from "next/router";
 import type { MouseEvent as ReactMouseEvent, RefObject } from "react";
 import React, { useCallback, useImperativeHandle, useState } from "react";

--- a/front/components/spaces/SpaceAppsList.tsx
+++ b/front/components/spaces/SpaceAppsList.tsx
@@ -6,7 +6,7 @@ import {
   Spinner,
 } from "@dust-tt/sparkle";
 import type { CellContext, ColumnDef } from "@tanstack/react-table";
-import { sortBy } from "lodash";
+import sortBy from "lodash/sortBy";
 import Link from "next/link";
 import type { ComponentType } from "react";
 import * as React from "react";

--- a/front/components/spaces/SpaceSideBarMenu.tsx
+++ b/front/components/spaces/SpaceSideBarMenu.tsx
@@ -10,7 +10,8 @@ import {
   Tree,
 } from "@dust-tt/sparkle";
 import type { ReturnTypeOf } from "@octokit/core/types";
-import { sortBy, uniqBy } from "lodash";
+import sortBy from "lodash/sortBy";
+import uniqBy from "lodash/uniqBy";
 import { useRouter } from "next/router";
 import type { ComponentType, ReactElement } from "react";
 import { Fragment, useCallback, useEffect, useMemo, useState } from "react";

--- a/front/components/trackers/TrackerBuilder.tsx
+++ b/front/components/trackers/TrackerBuilder.tsx
@@ -12,7 +12,7 @@ import {
   TextArea,
   TrashIcon,
 } from "@dust-tt/sparkle";
-import { capitalize } from "lodash";
+import capitalize from "lodash/capitalize";
 import { LockIcon } from "lucide-react";
 import { useRouter } from "next/router";
 import { useContext, useMemo, useState } from "react";

--- a/front/components/workspace/ProviderManagementModal.tsx
+++ b/front/components/workspace/ProviderManagementModal.tsx
@@ -16,7 +16,8 @@ import {
   SheetTrigger,
   SliderToggle,
 } from "@dust-tt/sparkle";
-import { isEqual, uniqBy } from "lodash";
+import isEqual from "lodash/isEqual";
+import uniqBy from "lodash/uniqBy";
 import { useCallback, useEffect, useMemo, useState } from "react";
 
 import {

--- a/front/lib/actions/mcp.ts
+++ b/front/lib/actions/mcp.ts
@@ -2,7 +2,7 @@ import type { ActionApprovalStateType } from "@dust-tt/client";
 import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
 import { McpError } from "@modelcontextprotocol/sdk/types.js";
 import type { JSONSchema7 as JSONSchema } from "json-schema";
-import { omit } from "lodash";
+import omit from "lodash/omit";
 
 import type {
   MCPToolStakeLevelType,

--- a/front/lib/actions/mcp_internal_actions/input_configuration.ts
+++ b/front/lib/actions/mcp_internal_actions/input_configuration.ts
@@ -3,7 +3,7 @@ import { INTERNAL_MIME_TYPES } from "@dust-tt/client";
 import { Ajv } from "ajv";
 import assert from "assert";
 import type { JSONSchema7 as JSONSchema } from "json-schema";
-import { zip } from "lodash";
+import zip from "lodash/zip";
 
 import type { MCPToolConfigurationType } from "@app/lib/actions/mcp";
 import type { ConfigurableToolInputType } from "@app/lib/actions/mcp_internal_actions/input_schemas";

--- a/front/lib/actions/mcp_internal_actions/servers/common/find_tags_tool.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/common/find_tags_tool.ts
@@ -1,5 +1,5 @@
 import { INTERNAL_MIME_TYPES } from "@dust-tt/client";
-import { trim } from "lodash";
+import trim from "lodash/trim";
 import { z } from "zod";
 
 import { MCPError } from "@app/lib/actions/mcp_errors";

--- a/front/lib/actions/mcp_internal_actions/servers/slack.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/slack.ts
@@ -3,7 +3,7 @@ import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { WebClient } from "@slack/web-api";
 import type { Match } from "@slack/web-api/dist/response/SearchMessagesResponse";
 import type { Member } from "@slack/web-api/dist/response/UsersListResponse";
-import { uniqBy } from "lodash";
+import uniqBy from "lodash/uniqBy";
 import slackifyMarkdown from "slackify-markdown";
 import { z } from "zod";
 

--- a/front/lib/api/agent_data_sources.ts
+++ b/front/lib/api/agent_data_sources.ts
@@ -1,4 +1,5 @@
-import { sortBy, uniqBy } from "lodash";
+import sortBy from "lodash/sortBy";
+import uniqBy from "lodash/uniqBy";
 import type { WhereAttributeHashValue } from "sequelize";
 import { Op, Sequelize } from "sequelize";
 

--- a/front/lib/api/assistant/agent_message_content_parser.ts
+++ b/front/lib/api/assistant/agent_message_content_parser.ts
@@ -1,4 +1,4 @@
-import { escapeRegExp } from "lodash";
+import escapeRegExp from "lodash/escapeRegExp";
 
 import { getSupportedModelConfig } from "@app/lib/assistant";
 import type {

--- a/front/lib/api/assistant/conversation/destroy.ts
+++ b/front/lib/api/assistant/conversation/destroy.ts
@@ -1,4 +1,4 @@
-import { chunk } from "lodash";
+import chunk from "lodash/chunk";
 import { Op } from "sequelize";
 
 import { hardDeleteDataSource } from "@app/lib/api/data_sources";

--- a/front/lib/api/spaces.ts
+++ b/front/lib/api/spaces.ts
@@ -1,5 +1,5 @@
 import assert from "assert";
-import { uniq } from "lodash";
+import uniq from "lodash/uniq";
 
 import { hardDeleteApp } from "@app/lib/api/apps";
 import {

--- a/front/lib/api/workos/organization.ts
+++ b/front/lib/api/workos/organization.ts
@@ -5,7 +5,7 @@ import {
   OrganizationDomainState,
 } from "@workos-inc/node";
 import assert from "assert";
-import { uniqueId } from "lodash";
+import uniqueId from "lodash/uniqueId";
 
 import { config } from "@app/lib/api/regions/config";
 import { getWorkOS } from "@app/lib/api/workos/client";

--- a/front/lib/client/conversation/event_handlers.ts
+++ b/front/lib/client/conversation/event_handlers.ts
@@ -1,4 +1,4 @@
-import { cloneDeep } from "lodash";
+import cloneDeep from "lodash/cloneDeep";
 
 import { getLightAgentMessageFromAgentMessage } from "@app/lib/api/assistant/citations";
 import type { FetchConversationParticipantsResponse } from "@app/pages/api/w/[wId]/assistant/conversations/[cId]/participants";

--- a/front/lib/resources/app_resource.ts
+++ b/front/lib/resources/app_resource.ts
@@ -1,5 +1,5 @@
 import assert from "assert";
-import { sortBy } from "lodash";
+import sortBy from "lodash/sortBy";
 import type { Attributes, CreationAttributes, ModelStatic } from "sequelize";
 import { Op } from "sequelize";
 

--- a/front/lib/resources/data_source_view_resource.ts
+++ b/front/lib/resources/data_source_view_resource.ts
@@ -2,7 +2,7 @@
 // This design will be moved up to BaseResource once we transition away from Sequelize.
 // eslint-disable-next-line @typescript-eslint/no-empty-interface
 import assert from "assert";
-import { keyBy } from "lodash";
+import keyBy from "lodash/keyBy";
 import type {
   Attributes,
   CreationAttributes,

--- a/front/lib/spaces.ts
+++ b/front/lib/spaces.ts
@@ -8,7 +8,7 @@ import {
   PlanetIcon,
   ServerIcon,
 } from "@dust-tt/sparkle";
-import { groupBy } from "lodash";
+import groupBy from "lodash/groupBy";
 import type React from "react";
 
 import { MCP_SPECIFICATION } from "@app/lib/actions/utils";

--- a/front/lib/swr/actions.ts
+++ b/front/lib/swr/actions.ts
@@ -1,4 +1,4 @@
-import { uniqueId } from "lodash";
+import uniqueId from "lodash/uniqueId";
 import { useMemo } from "react";
 import type { Fetcher } from "swr";
 

--- a/front/lib/utils.ts
+++ b/front/lib/utils.ts
@@ -1,4 +1,4 @@
-import { isEqual } from "lodash";
+import isEqual from "lodash/isEqual";
 
 import type { LightAgentConfigurationType } from "@app/types";
 import type { TagType } from "@app/types/tag";

--- a/front/lib/utils/json_schemas.ts
+++ b/front/lib/utils/json_schemas.ts
@@ -3,7 +3,7 @@ import type {
   JSONSchema7 as JSONSchema,
   JSONSchema7Definition as JSONSchemaDefinition,
 } from "json-schema";
-import { isEqual } from "lodash";
+import isEqual from "lodash/isEqual";
 
 import type { ConfigurableToolInputType } from "@app/lib/actions/mcp_internal_actions/input_schemas";
 

--- a/front/pages/api/v1/w/[wId]/spaces/[spaceId]/members/index.ts
+++ b/front/pages/api/v1/w/[wId]/spaces/[spaceId]/members/index.ts
@@ -3,7 +3,7 @@ import type {
   PostSpaceMembersResponseBody,
 } from "@dust-tt/client";
 import { PostSpaceMembersRequestBodySchema } from "@dust-tt/client";
-import { uniqBy } from "lodash";
+import uniqBy from "lodash/uniqBy";
 import type { NextApiRequest, NextApiResponse } from "next";
 
 import { withPublicAPIAuthentication } from "@app/lib/api/auth_wrappers";

--- a/front/pages/api/w/[wId]/spaces/[spaceId]/index.ts
+++ b/front/pages/api/w/[wId]/spaces/[spaceId]/index.ts
@@ -1,6 +1,6 @@
 import { isLeft } from "fp-ts/lib/Either";
 import * as reporter from "io-ts-reporters";
-import { uniqBy } from "lodash";
+import uniqBy from "lodash/uniqBy";
 import type { NextApiRequest, NextApiResponse } from "next";
 
 import { getDataSourceViewsUsageByCategory } from "@app/lib/api/agent_data_sources";

--- a/front/pages/poke/[wId]/index.tsx
+++ b/front/pages/poke/[wId]/index.tsx
@@ -12,7 +12,7 @@ import {
   SheetTrigger,
 } from "@dust-tt/sparkle";
 import { format } from "date-fns/format";
-import { keyBy } from "lodash";
+import keyBy from "lodash/keyBy";
 import type { InferGetServerSidePropsType } from "next";
 import { useRouter } from "next/router";
 import type { ReactElement } from "react";

--- a/front/pages/w/[wId]/labs/trackers/index.tsx
+++ b/front/pages/w/[wId]/labs/trackers/index.tsx
@@ -11,7 +11,7 @@ import {
   Spinner,
 } from "@dust-tt/sparkle";
 import type { CellContext } from "@tanstack/react-table";
-import { capitalize } from "lodash";
+import capitalize from "lodash/capitalize";
 import type { InferGetServerSidePropsType } from "next";
 import { useRouter } from "next/router";
 import React, { useMemo } from "react";


### PR DESCRIPTION
## Description
- Add eslint rule to prevent bulk import of lodash on known frontend code. Because lodash is not tree shakable, it imports all of lodash when doing `import { [function] } from "lodash"`
- Auto-fix all of found occurences
- Added a auto-fix to the rule
```
import { uniqBy } from "lodash"
// becomes
import uniqBy from "lodash/uniqBy"
```
This make sure we only import the function we need.

Only touch the following folders where I knew only client code was present
- `/front/components`
- `/front/lib/swr`
- `/front/lib/client`

### Area of improvements
We could efforce any everywhere just to be safe and avoid any mistake. But some backend parts use `import * as _ from "lodash"`, so it would require more changes that are not game changer right now.

## Tests
- Locally

## Risk
- None, doesn't change other imports
