### PR TITLE
[front] Fix mcpServerId fetching with archived configurations

### DIFF
--- a/front/lib/api/assistant/configuration/agent.ts
+++ b/front/lib/api/assistant/configuration/agent.ts
@@ -228,8 +228,6 @@ export async function getAgentConfigurations<V extends AgentFetchVariant>(
         order: [["version", "DESC"]],
       });
 
-      console.log("workspaceAgentConfigurations", workspaceAgentConfigurations);
-
       workspaceAgents = await enrichAgentConfigurations(
         auth,
         workspaceAgentConfigurations,

--- a/front/lib/api/assistant/configuration/agent.ts
+++ b/front/lib/api/assistant/configuration/agent.ts
@@ -227,6 +227,9 @@ export async function getAgentConfigurations<V extends AgentFetchVariant>(
         },
         order: [["version", "DESC"]],
       });
+
+      console.log("workspaceAgentConfigurations", workspaceAgentConfigurations);
+
       workspaceAgents = await enrichAgentConfigurations(
         auth,
         workspaceAgentConfigurations,

--- a/front/lib/api/assistant/configuration/agent.ts
+++ b/front/lib/api/assistant/configuration/agent.ts
@@ -163,15 +163,27 @@ export async function getAgentConfigurations<V extends AgentFetchVariant>(
   auth: Authenticator,
   {
     agentIds,
+    agentIdsWithVersions,
     variant,
-  }: {
-    agentIds: string[];
-    variant: V;
-  }
+  }:
+    | {
+        agentIds?: never;
+        agentIdsWithVersions: { sId: string; version: number }[];
+        variant: V;
+      }
+    | {
+        agentIds: string[];
+        agentIdsWithVersions?: never;
+        variant: V;
+      }
 ): Promise<
   V extends "full" ? AgentConfigurationType[] : LightAgentConfigurationType[]
 > {
   return tracer.trace("getAgentConfigurations", async () => {
+    const agentIdsToFetch = agentIdsWithVersions
+      ? agentIdsWithVersions.map(({ sId }) => sId)
+      : agentIds;
+
     const owner = auth.workspace();
     if (!owner) {
       throw new Error("Unexpected `auth` without `workspace`.");
@@ -180,37 +192,38 @@ export async function getAgentConfigurations<V extends AgentFetchVariant>(
       throw new Error("Unexpected `auth` without `user`.");
     }
 
-    const globalAgentIds = agentIds.filter(isGlobalAgentId);
+    const globalAgentIds = agentIdsToFetch.filter(isGlobalAgentId);
 
     let globalAgents: AgentConfigurationType[] = [];
     if (globalAgentIds.length > 0) {
       globalAgents = await getGlobalAgents(auth, globalAgentIds, variant);
     }
 
-    const workspaceAgentIds = agentIds.filter((id) => !isGlobalAgentId(id));
+    const workspaceAgentIds = agentIdsToFetch.filter(
+      (id) => !isGlobalAgentId(id)
+    );
 
     let workspaceAgents: AgentConfigurationType[] = [];
     if (workspaceAgentIds.length > 0) {
-      const latestVersions = (await AgentConfiguration.findAll({
-        attributes: [
-          "sId",
-          [Sequelize.fn("MAX", Sequelize.col("version")), "max_version"],
-        ],
-        where: {
-          workspaceId: owner.id,
-          sId: workspaceAgentIds,
-        },
-        group: ["sId"],
-        raw: true,
-      })) as unknown as { sId: string; max_version: number }[];
+      const agentIdsWithVersionsToFetch = agentIdsWithVersions
+        ? agentIdsWithVersions
+        : ((await AgentConfiguration.findAll({
+            attributes: [
+              "sId",
+              [Sequelize.fn("MAX", Sequelize.col("version")), "version"],
+            ],
+            where: {
+              workspaceId: owner.id,
+              sId: workspaceAgentIds,
+            },
+            group: ["sId"],
+            raw: true,
+          })) as unknown as { sId: string; version: number }[]);
 
       const workspaceAgentConfigurations = await AgentConfiguration.findAll({
         where: {
           workspaceId: owner.id,
-          [Op.or]: latestVersions.map((v) => ({
-            sId: v.sId,
-            version: v.max_version,
-          })),
+          [Op.or]: agentIdsWithVersionsToFetch,
         },
         order: [["version", "DESC"]],
       });

--- a/front/lib/api/assistant/messages.ts
+++ b/front/lib/api/assistant/messages.ts
@@ -195,21 +195,25 @@ async function batchRenderAgentMessages<V extends RenderMessageVariant>(
         if (viewType === "full") {
           const agents = await getAgentConfigurations(auth, {
             agentIdsWithVersions: [...agentConfigurationIds],
-            agentIds: undefined,
             variant: "full",
           });
+          const lightAgents = await getAgentConfigurations(auth, {
+            agentIds: [...agentConfigurationIds].map(({ sId }) => sId),
+            variant: "extra_light",
+          });
+
           return {
             agentConfigurations: agents,
-            lightAgentConfigurations: agents,
+            lightAgentConfigurations: lightAgents,
           };
         } else {
-          const agents = await getAgentConfigurations(auth, {
-            agentIdsWithVersions: [...agentConfigurationIds],
+          const lightAgents = await getAgentConfigurations(auth, {
+            agentIds: [...agentConfigurationIds].map(({ sId }) => sId),
             variant: "extra_light",
           });
           return {
             agentConfigurations: null,
-            lightAgentConfigurations: agents,
+            lightAgentConfigurations: lightAgents,
           };
         }
       })(),

--- a/front/lib/api/assistant/messages.ts
+++ b/front/lib/api/assistant/messages.ts
@@ -174,19 +174,28 @@ async function batchRenderAgentMessages<V extends RenderMessageVariant>(
   const [{ agentConfigurations, lightAgentConfigurations }, agentMCPActions] =
     await Promise.all([
       (async () => {
-        const agentConfigurationIds: Set<string> = agentMessages.reduce(
-          (acc: Set<string>, m) => {
-            const agentId = m.agentMessage?.agentConfigurationId;
-            if (agentId) {
-              acc.add(agentId);
+        const agentConfigurationIds: Set<{
+          sId: string;
+          version: number;
+        }> = agentMessages.reduce(
+          (acc: Set<{ sId: string; version: number }>, m) => {
+            if (m.agentMessage) {
+              const sId = m.agentMessage.agentConfigurationId;
+              const version = m.agentMessage.agentConfigurationVersion;
+
+              acc.add({ sId, version });
             }
             return acc;
           },
-          new Set<string>()
+          new Set<{
+            sId: string;
+            version: number;
+          }>()
         );
         if (viewType === "full") {
           const agents = await getAgentConfigurations(auth, {
-            agentIds: [...agentConfigurationIds],
+            agentIdsWithVersions: [...agentConfigurationIds],
+            agentIds: undefined,
             variant: "full",
           });
           return {
@@ -195,7 +204,7 @@ async function batchRenderAgentMessages<V extends RenderMessageVariant>(
           };
         } else {
           const agents = await getAgentConfigurations(auth, {
-            agentIds: [...agentConfigurationIds],
+            agentIdsWithVersions: [...agentConfigurationIds],
             variant: "extra_light",
           });
           return {

--- a/front/lib/api/assistant/messages.ts
+++ b/front/lib/api/assistant/messages.ts
@@ -1,7 +1,6 @@
 import type { WhereOptions } from "sequelize";
 import { Op, Sequelize } from "sequelize";
 
-import { MCPActionType } from "@app/lib/actions/mcp";
 import {
   AgentMessageContentParser,
   getDelimitersConfiguration,
@@ -10,7 +9,6 @@ import { getLightAgentMessageFromAgentMessage } from "@app/lib/api/assistant/cit
 import { getAgentConfigurations } from "@app/lib/api/assistant/configuration/agent";
 import type { PaginationParams } from "@app/lib/api/pagination";
 import { Authenticator } from "@app/lib/auth";
-import { AgentMCPAction } from "@app/lib/models/assistant/actions/mcp";
 import { AgentStepContentModel } from "@app/lib/models/assistant/agent_step_content";
 import {
   AgentMessage,

--- a/front/lib/api/assistant/messages.ts
+++ b/front/lib/api/assistant/messages.ts
@@ -176,6 +176,7 @@ async function batchRenderAgentMessages<V extends RenderMessageVariant>(
     agentMCPActions,
   ] = await Promise.all([
     (async () => {
+      // Get all unique pairs id-version for the agent configurations
       const agentConfigurationIdsWithVersions = agentMessages.reduce(
         (acc, m) => {
           if (m.agentMessage) {
@@ -187,9 +188,13 @@ async function batchRenderAgentMessages<V extends RenderMessageVariant>(
         },
         new Set<string>()
       );
-      const agentConfigurationIds = new Set(
-        [...agentConfigurationIdsWithVersions].map((id) => id.split("-")[0])
+      // Split back the ids into id and version
+      const splittedIds = [...agentConfigurationIdsWithVersions].map((id) =>
+        id.split("-")
       );
+      // Get all unique ids
+      const agentConfigurationIds = new Set(splittedIds.map((id) => id[0]));
+
       const lightAgentConfigurations = await getAgentConfigurations(auth, {
         agentIds: [...agentConfigurationIds],
         variant: "extra_light",
@@ -198,12 +203,10 @@ async function batchRenderAgentMessages<V extends RenderMessageVariant>(
       const versionedAgentConfigurations =
         viewType === "full"
           ? await getAgentConfigurations(auth, {
-              agentIdsWithVersions: [...agentConfigurationIdsWithVersions].map(
-                (id) => ({
-                  sId: id.split("-")[0],
-                  version: parseInt(id.split("-")[1]),
-                })
-              ),
+              agentIdsWithVersions: splittedIds.map((id) => ({
+                sId: id[0],
+                version: parseInt(id[1]),
+              })),
               variant: "full",
             })
           : null;

--- a/front/lib/resources/agent_step_content_resource.ts
+++ b/front/lib/resources/agent_step_content_resource.ts
@@ -358,7 +358,7 @@ export class AgentStepContentResource extends BaseResource<AgentStepContentModel
               ),
               functionCallId: value.value.id,
               functionCallName: value.value.name,
-              mcpServerId: null,
+              mcpServerId: action.toolConfiguration?.toolServerId,
               agentMessageId: action.agentMessageId,
               step: this.step,
               mcpServerConfigurationId: action.mcpServerConfigurationId,

--- a/front/lib/resources/agent_step_content_resource.ts
+++ b/front/lib/resources/agent_step_content_resource.ts
@@ -358,7 +358,7 @@ export class AgentStepContentResource extends BaseResource<AgentStepContentModel
               ),
               functionCallId: value.value.id,
               functionCallName: value.value.name,
-              mcpServerId: action.toolConfiguration?.toolServerId,
+              mcpServerId: action.toolConfiguration?.toolServerId || null,
               agentMessageId: action.agentMessageId,
               step: this.step,
               mcpServerConfigurationId: action.mcpServerConfigurationId,

--- a/front/temporal/agent_loop/activities/run_tool.ts
+++ b/front/temporal/agent_loop/activities/run_tool.ts
@@ -1,7 +1,6 @@
 import assert from "assert";
 
 import { MCPActionType, runToolWithStreaming } from "@app/lib/actions/mcp";
-import { isServerSideMCPServerConfiguration } from "@app/lib/actions/types/guards";
 import type { AuthenticatorType } from "@app/lib/auth";
 import { Authenticator } from "@app/lib/auth";
 import { AgentMCPAction } from "@app/lib/models/assistant/actions/mcp";
@@ -55,14 +54,7 @@ export async function runToolActivity(
   const action = await AgentMCPAction.findByPk(actionId);
   assert(action, "Action not found");
 
-  const mcpServerConfiguration = agentConfiguration.actions.find(
-    (ac) => `${ac.id}` === `${action.mcpServerConfigurationId}`
-  );
-  const mcpServerId = mcpServerConfiguration
-    ? isServerSideMCPServerConfiguration(mcpServerConfiguration)
-      ? mcpServerConfiguration.internalMCPServerId
-      : mcpServerConfiguration.clientSideMcpServerId
-    : null;
+  const mcpServerId = action.toolConfiguration.toolServerId;
 
   const actionBaseParams = await buildActionBaseParams({
     agentMessageId: action.agentMessageId,


### PR DESCRIPTION
## Description

In order to get the mcpServerId associated to an agent message, we need to get the version of the agent configuration which matches the message. Ritgh now we're only fetching the latest agent configuration, which do not contain the executed action configurations anymore.

## Tests

test on front edge

## Risk

performance impact when getting full messages, as we get twice the configurations

## Deploy Plan

deploy front
