### PR TITLE
[front] - fix(AB v2): knowledge tool renaming + tweaks

### DIFF
--- a/extension/package-lock.json
+++ b/extension/package-lock.json
@@ -12,7 +12,7 @@
         "@auth0/auth0-spa-js": "^2.1.3",
         "@datadog/browser-logs": "^6.13.0",
         "@dust-tt/client": "1.1.4",
-        "@dust-tt/sparkle": "^0.2.569",
+        "@dust-tt/sparkle": "^0.2.570",
         "@frontapp/plugin-sdk": "^1.8.1",
         "@modelcontextprotocol/sdk": "^1.9.0",
         "@tailwindcss/forms": "^0.5.9",
@@ -1254,9 +1254,9 @@
       }
     },
     "node_modules/@dust-tt/sparkle": {
-      "version": "0.2.569",
-      "resolved": "https://registry.npmjs.org/@dust-tt/sparkle/-/sparkle-0.2.569.tgz",
-      "integrity": "sha512-UvPp8gcC7Y5/gSjRNAPJ10+i1aLhd6DmnNLJjIGyiDc1mzcV01QtRcYzKHLd85mpc/cf1buKfDlhLpd7uRgSXg==",
+      "version": "0.2.570",
+      "resolved": "https://registry.npmjs.org/@dust-tt/sparkle/-/sparkle-0.2.570.tgz",
+      "integrity": "sha512-hEwcEF8TPQ4O7Z5Y7OoCSEldMYWtrLUxKMxLF9BT74BhZXwR8BiRczPK1QO0zNlBdYCm5YWK6oF6VPOOP+tHQQ==",
       "dependencies": {
         "@emoji-mart/data": "^1.1.2",
         "@emoji-mart/react": "^1.1.1",

--- a/extension/package.json
+++ b/extension/package.json
@@ -59,7 +59,7 @@
     "@auth0/auth0-spa-js": "^2.1.3",
     "@datadog/browser-logs": "^6.13.0",
     "@dust-tt/client": "1.1.4",
-    "@dust-tt/sparkle": "^0.2.569",
+    "@dust-tt/sparkle": "^0.2.570",
     "@frontapp/plugin-sdk": "^1.8.1",
     "@modelcontextprotocol/sdk": "^1.9.0",
     "@tailwindcss/forms": "^0.5.9",

--- a/front/components/agent_builder/AgentBuilder.tsx
+++ b/front/components/agent_builder/AgentBuilder.tsx
@@ -150,7 +150,7 @@ export default function AgentBuilder({
             saveButtonProps={{
               size: "sm",
               label: saveLabel,
-              variant: "primary",
+              variant: "highlight",
               onClick: handleSave,
               disabled: isSaveDisabled,
             }}

--- a/front/components/agent_builder/capabilities/AgentBuilderCapabilitiesBlock.tsx
+++ b/front/components/agent_builder/capabilities/AgentBuilderCapabilitiesBlock.tsx
@@ -1,5 +1,6 @@
 import {
   Avatar,
+  BoltIcon,
   BookOpenIcon,
   Button,
   Card,
@@ -8,9 +9,9 @@ import {
   EmptyCTA,
   Hoverable,
   ListAddIcon,
+  Spinner,
   XMarkIcon,
 } from "@dust-tt/sparkle";
-import { Spinner } from "@dust-tt/sparkle";
 import { isEmpty } from "lodash";
 import React, { useState } from "react";
 import { useFieldArray, useFormContext } from "react-hook-form";
@@ -269,7 +270,7 @@ export function AgentBuilderCapabilitiesBlock({
                   type="button"
                   onClick={onClickKnowledge}
                   label="Add knowledge"
-                  icon={BookOpenIcon}
+                  icon={BoltIcon}
                   variant="primary"
                 />
                 <Button

--- a/front/components/agent_builder/capabilities/knowledge/KnowledgeConfigurationSheet.tsx
+++ b/front/components/agent_builder/capabilities/knowledge/KnowledgeConfigurationSheet.tsx
@@ -29,6 +29,7 @@ import { getDefaultConfiguration } from "@app/components/agent_builder/capabilit
 import { isValidPage } from "@app/components/agent_builder/capabilities/mcp/utils/sheetUtils";
 import { DescriptionSection } from "@app/components/agent_builder/capabilities/shared/DescriptionSection";
 import { JsonSchemaSection } from "@app/components/agent_builder/capabilities/shared/JsonSchemaSection";
+import { NameSection } from "@app/components/agent_builder/capabilities/shared/NameSection";
 import { TimeFrameSection } from "@app/components/agent_builder/capabilities/shared/TimeFrameSection";
 import { useDataSourceViewsContext } from "@app/components/agent_builder/DataSourceViewsContext";
 import { useMCPServerViewsContext } from "@app/components/agent_builder/MCPServerViewsContext";
@@ -154,7 +155,11 @@ export function KnowledgeConfigurationSheet({
       configuration:
         action?.configuration ?? getDefaultConfiguration(selectedMCPServerView),
       mcpServerView: selectedMCPServerView ?? null,
-      name: selectedMCPServerView?.server.name,
+      name:
+        action?.name ??
+        selectedMCPServerView?.name ??
+        selectedMCPServerView?.server.name ??
+        "",
     };
   }, [action, mcpServerViews, isEditing]);
 
@@ -218,7 +223,8 @@ function KnowledgeConfigurationSheetContent({
   getAgentInstructions,
   isEditing,
 }: KnowledgeConfigurationSheetContentProps) {
-  const { handleSubmit, setValue } = useFormContext<CapabilityFormData>();
+  const { handleSubmit, setValue, getValues } =
+    useFormContext<CapabilityFormData>();
 
   const mcpServerView = useWatch<CapabilityFormData, "mcpServerView">({
     name: "mcpServerView",
@@ -283,7 +289,12 @@ function KnowledgeConfigurationSheetContent({
 
   const handleMCPServerSelection = (mcpServerView: MCPServerViewType) => {
     setValue("mcpServerView", mcpServerView);
-    setValue("name", mcpServerView.name ?? mcpServerView.server.name ?? "");
+
+    const currentName = getValues("name");
+    if (!currentName || !isEditing) {
+      setValue("name", mcpServerView.name ?? mcpServerView.server.name ?? "");
+    }
+
     setValue("configuration.mcpServerViewId", mcpServerView.sId);
     setCurrentPageId(CONFIGURATION_SHEET_PAGE_IDS.DATA_SOURCE_SELECTION);
   };
@@ -355,6 +366,14 @@ function KnowledgeConfigurationSheetContent({
       icon: config?.icon,
       content: (
         <div className="space-y-6">
+          <NameSection
+            title="Tool Name"
+            description="Customize the name of this knowledge tool to reference it in your instructions."
+            label="Name"
+            placeholder="search_gdrive"
+            helpText="Use lowercase letters, numbers, and underscores only. No spaces allowed."
+          />
+
           {requirements.mayRequireTimeFrameConfiguration && (
             <TimeFrameSection actionType="extract" />
           )}

--- a/front/components/agent_builder/capabilities/shared/NameSection.tsx
+++ b/front/components/agent_builder/capabilities/shared/NameSection.tsx
@@ -1,0 +1,49 @@
+import { Input } from "@dust-tt/sparkle";
+import { useController, useFormContext } from "react-hook-form";
+
+import type { CapabilityFormData } from "@app/components/agent_builder/types";
+
+interface NameSectionProps {
+  title: string;
+  description: string;
+  label?: string;
+  placeholder: string;
+  helpText?: string;
+}
+
+const FIELD_NAME = "name";
+
+export function NameSection({
+  title,
+  description,
+  label,
+  placeholder,
+  helpText,
+}: NameSectionProps) {
+  const { register } = useFormContext();
+  const { fieldState } = useController<CapabilityFormData, typeof FIELD_NAME>({
+    name: FIELD_NAME,
+  });
+
+  return (
+    <div className="space-y-4">
+      <div>
+        <h3 className="mb-2 text-lg font-semibold">{title}</h3>
+        <p className="text-sm text-muted-foreground">{description}</p>
+      </div>
+
+      <div className="space-y-2">
+        <Input
+          placeholder={placeholder}
+          {...register(FIELD_NAME)}
+          label={label}
+          message={fieldState.error?.message}
+          messageStatus={fieldState.error ? "error" : "default"}
+        />
+        {helpText && (
+          <p className="text-xs text-muted-foreground">{helpText}</p>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/front/components/agent_builder/instructions/AdvancedSettings.tsx
+++ b/front/components/agent_builder/instructions/AdvancedSettings.tsx
@@ -35,12 +35,7 @@ export function AdvancedSettings() {
   return (
     <DropdownMenu>
       <DropdownMenuTrigger asChild>
-        <Button
-          label="Advanced settings"
-          variant="outline"
-          size="sm"
-          isSelect
-        />
+        <Button label="Advanced" variant="outline" size="sm" isSelect />
       </DropdownMenuTrigger>
       <DropdownMenuContent align="end">
         <ModelSelectionSubmenu models={models} />

--- a/front/components/agent_builder/instructions/AgentBuilderInstructionsEditor.tsx
+++ b/front/components/agent_builder/instructions/AgentBuilderInstructionsEditor.tsx
@@ -3,6 +3,7 @@ import { CharacterCount } from "@tiptap/extension-character-count";
 import Document from "@tiptap/extension-document";
 import { History } from "@tiptap/extension-history";
 import { ListItem } from "@tiptap/extension-list-item";
+import Placeholder from "@tiptap/extension-placeholder";
 import Text from "@tiptap/extension-text";
 import { EditorContent, useEditor } from "@tiptap/react";
 import { cva } from "class-variance-authority";
@@ -75,6 +76,12 @@ export function AgentBuilderInstructionsEditor({
       History,
       InstructionBlockExtension,
       AgentInstructionDiffExtension,
+      Placeholder.configure({
+        placeholder:
+          "What does this agent do? How should it behave? What should it avoid doing?",
+        emptyNodeClass:
+          "first:before:text-gray-400 first:before:italic first:before:content-[attr(data-placeholder)] first:before:pointer-events-none first:before:absolute",
+      }),
       CharacterCount.configure({
         limit: INSTRUCTIONS_MAXIMUM_CHARACTER_COUNT,
       }),

--- a/front/components/agent_builder/instructions/AgentBuilderInstructionsEditor.tsx
+++ b/front/components/agent_builder/instructions/AgentBuilderInstructionsEditor.tsx
@@ -25,7 +25,7 @@ export const INSTRUCTIONS_MAXIMUM_CHARACTER_COUNT = 120_000;
 
 const editorVariants = cva(
   [
-    "overflow-auto border rounded-xl p-2 resize-y min-h-60 h-125",
+    "overflow-auto border rounded-xl p-2 resize-y min-h-60 h-100",
     "transition-all duration-200",
     "bg-muted-background dark:bg-muted-background-night",
   ],

--- a/front/package-lock.json
+++ b/front/package-lock.json
@@ -7,7 +7,7 @@
       "dependencies": {
         "@datadog/browser-logs": "^6.13.0",
         "@dust-tt/client": "file:../sdks/js",
-        "@dust-tt/sparkle": "^0.2.569",
+        "@dust-tt/sparkle": "^0.2.570",
         "@google-cloud/bigquery": "^7.9.1",
         "@google-cloud/storage-transfer": "^3.6.0",
         "@heroicons/react": "^2.0.11",
@@ -1111,9 +1111,9 @@
       "link": true
     },
     "node_modules/@dust-tt/sparkle": {
-      "version": "0.2.569",
-      "resolved": "https://registry.npmjs.org/@dust-tt/sparkle/-/sparkle-0.2.569.tgz",
-      "integrity": "sha512-UvPp8gcC7Y5/gSjRNAPJ10+i1aLhd6DmnNLJjIGyiDc1mzcV01QtRcYzKHLd85mpc/cf1buKfDlhLpd7uRgSXg==",
+      "version": "0.2.570",
+      "resolved": "https://registry.npmjs.org/@dust-tt/sparkle/-/sparkle-0.2.570.tgz",
+      "integrity": "sha512-hEwcEF8TPQ4O7Z5Y7OoCSEldMYWtrLUxKMxLF9BT74BhZXwR8BiRczPK1QO0zNlBdYCm5YWK6oF6VPOOP+tHQQ==",
       "dependencies": {
         "@emoji-mart/data": "^1.1.2",
         "@emoji-mart/react": "^1.1.1",

--- a/front/package.json
+++ b/front/package.json
@@ -24,7 +24,7 @@
   "dependencies": {
     "@datadog/browser-logs": "^6.13.0",
     "@dust-tt/client": "file:../sdks/js",
-    "@dust-tt/sparkle": "^0.2.569",
+    "@dust-tt/sparkle": "^0.2.570",
     "@google-cloud/bigquery": "^7.9.1",
     "@google-cloud/storage-transfer": "^3.6.0",
     "@heroicons/react": "^2.0.11",

--- a/sparkle/src/components/Resizable.tsx
+++ b/sparkle/src/components/Resizable.tsx
@@ -39,7 +39,7 @@ const ResizableHandle = ({
       "data-[panel-group-direction=vertical]:after:s--translate-y-1/2",
       "data-[panel-group-direction=vertical]:after:s-translate-x-0",
       "[&[data-panel-group-direction=vertical]>div]:s-rotate-90",
-      "s-bg-gray-200 dark:s-bg-border-night",
+      "s-bg-gray-100 dark:s-bg-border-night",
       className
     )}
     {...props}
@@ -48,7 +48,7 @@ const ResizableHandle = ({
       <div
         className={cn(
           "s-absolute s-flex s-h-6 s-w-2 s-items-center s-justify-center s-rounded-2xl",
-          "s-border-structure-200 s-border s-bg-white"
+          "s-border-gray-100 s-border s-bg-white"
         )}
       >
         <div className="s-w-px" />


### PR DESCRIPTION
## Description

This PR enables users to rename "knowledge" tools. To do so we add an additional input field in the configuration page.

It also ships along a few UI tweaks:
- a placeholder in the instructions editor
- button icons/label aligments

## Tests

Locally

## Risk

Low

## Deploy Plan

Deploy front
