### PR TITLE
add: spacesUsedInActions

### DIFF
--- a/front/components/agent_builder/capabilities/knowledge/KnowledgeConfigurationSheet.tsx
+++ b/front/components/agent_builder/capabilities/knowledge/KnowledgeConfigurationSheet.tsx
@@ -12,6 +12,7 @@ import { uniqueId } from "lodash";
 import { useEffect, useMemo, useState } from "react";
 import {
   FormProvider,
+  useFieldArray,
   useForm,
   useFormContext,
   useWatch,
@@ -114,6 +115,22 @@ export function KnowledgeConfigurationSheet({
     onClose();
   };
 
+  const { fields } = useFieldArray<AgentBuilderFormData, "actions">({
+    name: "actions",
+  });
+  const spacesUsedInActions: Set<string> = new Set();
+  for (const field of fields) {
+    if (field.configuration && field.configuration.dataSourceConfigurations) {
+      for (const dsConfig of Object.values(
+        field.configuration.dataSourceConfigurations
+      )) {
+        if (dsConfig) {
+          spacesUsedInActions.add(dsConfig.dataSourceView.spaceId);
+        }
+      }
+    }
+  }
+
   // Custom open hook to only have debounce when we close.
   // We use this value to unmount the Sheet Content, and we need
   // debounce when closing to avoid messing up the closing animation.
@@ -195,6 +212,7 @@ export function KnowledgeConfigurationSheet({
         {debouncedOpen && (
           <DataSourceBuilderProvider spaces={spaces}>
             <KnowledgeConfigurationSheetContent
+              spacesUsedInActions={spacesUsedInActions}
               onSave={handleSave}
               open={open}
               getAgentInstructions={getAgentInstructions}
@@ -208,6 +226,7 @@ export function KnowledgeConfigurationSheet({
 }
 
 interface KnowledgeConfigurationSheetContentProps {
+  spacesUsedInActions={spacesUsedInActions}
   onSave: (
     formData: CapabilityFormData,
     dataSourceConfigurations: DataSourceViewSelectionConfigurations
@@ -218,6 +237,8 @@ interface KnowledgeConfigurationSheetContentProps {
 }
 
 function KnowledgeConfigurationSheetContent({
+  spacesUsedInActions,
+
   onSave,
   open,
   getAgentInstructions,
@@ -350,6 +371,7 @@ function KnowledgeConfigurationSheetContent({
           <ScrollArea>
             <DataSourceBuilderSelector
               dataSourceViews={supportedDataSourceViews}
+              spacesUsedInActions={spacesUsedInActions}
               owner={owner}
               viewType={viewType}
             />

--- a/front/components/data_source_view/DataSourceBuilderSelector.tsx
+++ b/front/components/data_source_view/DataSourceBuilderSelector.tsx
@@ -20,11 +20,13 @@ import type {
 type DataSourceBuilderSelectorProps = {
   owner: LightWorkspaceType;
   dataSourceViews: DataSourceViewType[];
+  spacesUsedInActions: Set<string>;
   viewType: ContentNodesViewType;
 };
 
 export const DataSourceBuilderSelector = ({
   dataSourceViews,
+  spacesUsedInActions,
   viewType,
 }: DataSourceBuilderSelectorProps) => {
   const { spaces } = useSpacesContext();
@@ -64,7 +66,7 @@ export const DataSourceBuilderSelector = ({
       {currentNavigationEntry.type === "root" ? (
         <DataSourceSpaceSelector
           spaces={filteredSpaces}
-          allowedSpaces={spaces}
+          allowedSpaceSIds={spacesUsedInActions}
         />
       ) : (
         <SearchInput

--- a/front/components/data_source_view/DataSourceSpaceSelector.tsx
+++ b/front/components/data_source_view/DataSourceSpaceSelector.tsx
@@ -15,18 +15,19 @@ import type { SpaceType } from "@app/types";
 
 type SpaceRowData = SpaceType & {
   id: string;
+  disabled: boolean;
   icon: React.ComponentType;
   onClick: () => void;
 };
 
 export interface DataSourceSpaceSelectorProps {
   spaces: SpaceType[];
-  allowedSpaces?: SpaceType[];
+  allowedSpaceSIds?: Set<string>;
 }
 
 export function DataSourceSpaceSelector({
   spaces,
-  allowedSpaces = [],
+  allowedSpaceSIds,
 }: DataSourceSpaceSelectorProps) {
   const { removeNode, isRowSelected, setSpaceEntry } =
     useDataSourceBuilderContext();
@@ -39,7 +40,7 @@ export function DataSourceSpaceSelector({
     kind: space.kind,
     icon: getSpaceIcon(space),
     onClick: () => setSpaceEntry(space),
-    disabled: allowedSpaces.find((s) => s.sId === space.sId) == null,
+    disabled: !!allowedSpaceSIds && allowedSpaceSIds.has(space.sId),
   }));
 
   const columns: ColumnDef<SpaceRowData>[] = useMemo(


### PR DESCRIPTION
## Description

Add tracking of spaces used in actions to prevent duplicate space selection in the knowledge configuration sheet. The system now collects spaces that are already used in action configurations and disables them in the data source space selector to avoid conflicts.

Changes include:
- Collect spaces used in existing actions using `useFieldArray`
- Pass `spacesUsedInActions` through the component hierarchy
- Disable already-used spaces in the `DataSourceSpaceSelector`

## Tests

Manual testing in the knowledge configuration UI to verify that spaces already used in actions are properly disabled in the space selector.

## Risk

Low risk - this is an additive feature that improves UX by preventing duplicate space configurations. The changes are isolated to the knowledge configuration flow and maintain backward compatibility.

## Deploy Plan

Standard deployment - no special considerations required. The changes are self-contained within the frontend knowledge configuration components.