### PR TITLE
[front] - feat(AB v2): templates work in new agents builder

### DIFF
--- a/front/components/agent_builder/AgentBuilder.tsx
+++ b/front/components/agent_builder/AgentBuilder.tsx
@@ -29,7 +29,7 @@ import type { LightAgentConfigurationType } from "@app/types";
 
 interface AgentBuilderProps {
   agentConfiguration?: LightAgentConfigurationType;
-  assistantTemplate?: FetchAssistantTemplateResponse | null;
+  assistantTemplate: FetchAssistantTemplateResponse | null;
 }
 
 export default function AgentBuilder({

--- a/front/components/agent_builder/AgentBuilder.tsx
+++ b/front/components/agent_builder/AgentBuilder.tsx
@@ -14,8 +14,8 @@ import { submitAgentBuilderForm } from "@app/components/agent_builder/submitAgen
 import {
   getDefaultAgentFormData,
   transformAgentConfigurationToFormData,
+  transformTemplateToFormData,
 } from "@app/components/agent_builder/transformAgentConfiguration";
-import { AGENT_CREATIVITY_LEVEL_TEMPERATURES } from "@app/components/agent_builder/types";
 import { ConversationSidePanelProvider } from "@app/components/assistant/conversation/ConversationSidePanelContext";
 import { appLayoutBack } from "@app/components/sparkle/AppContentLayout";
 import { FormProvider } from "@app/components/sparkle/FormProvider";
@@ -57,42 +57,8 @@ export default function AgentBuilder({
       return transformAgentConfigurationToFormData(agentConfiguration);
     }
     
-    // If we have a template but no agent configuration, apply template data
     if (assistantTemplate) {
-      const defaultFormData = getDefaultAgentFormData(user);
-      const templateFormData = {
-        ...defaultFormData,
-        instructions:
-          assistantTemplate.presetInstructions ?? defaultFormData.instructions,
-        agentSettings: {
-          ...defaultFormData.agentSettings,
-          name: assistantTemplate.handle ?? defaultFormData.agentSettings.name,
-          description:
-            assistantTemplate.description ??
-            defaultFormData.agentSettings.description,
-          pictureUrl:
-            assistantTemplate.pictureUrl ??
-            defaultFormData.agentSettings.pictureUrl,
-        },
-        generationSettings: {
-          ...defaultFormData.generationSettings,
-          modelSettings: {
-            ...defaultFormData.generationSettings.modelSettings,
-            providerId:
-              assistantTemplate.presetProviderId ??
-              defaultFormData.generationSettings.modelSettings.providerId,
-            modelId:
-              assistantTemplate.presetModelId ??
-              defaultFormData.generationSettings.modelSettings.modelId,
-          },
-          temperature: assistantTemplate.presetTemperature
-            ? AGENT_CREATIVITY_LEVEL_TEMPERATURES[
-                assistantTemplate.presetTemperature
-              ]
-            : defaultFormData.generationSettings.temperature,
-        },
-      };
-      return templateFormData;
+      return transformTemplateToFormData(assistantTemplate, user);
     }
     
     return getDefaultAgentFormData(user);

--- a/front/components/agent_builder/AgentBuilder.tsx
+++ b/front/components/agent_builder/AgentBuilder.tsx
@@ -56,11 +56,11 @@ export default function AgentBuilder({
     if (agentConfiguration) {
       return transformAgentConfigurationToFormData(agentConfiguration);
     }
-    
+
     if (assistantTemplate) {
       return transformTemplateToFormData(assistantTemplate, user);
     }
-    
+
     return getDefaultAgentFormData(user);
   }, [agentConfiguration, assistantTemplate, user]);
 

--- a/front/components/agent_builder/AgentBuilder.tsx
+++ b/front/components/agent_builder/AgentBuilder.tsx
@@ -15,6 +15,7 @@ import {
   getDefaultAgentFormData,
   transformAgentConfigurationToFormData,
 } from "@app/components/agent_builder/transformAgentConfiguration";
+import { AGENT_CREATIVITY_LEVEL_TEMPERATURES } from "@app/components/agent_builder/types";
 import { ConversationSidePanelProvider } from "@app/components/assistant/conversation/ConversationSidePanelContext";
 import { appLayoutBack } from "@app/components/sparkle/AppContentLayout";
 import { FormProvider } from "@app/components/sparkle/FormProvider";
@@ -61,21 +62,34 @@ export default function AgentBuilder({
       const defaultFormData = getDefaultAgentFormData(user);
       const templateFormData = {
         ...defaultFormData,
-        instructions: assistantTemplate.presetInstructions ?? defaultFormData.instructions,
+        instructions:
+          assistantTemplate.presetInstructions ?? defaultFormData.instructions,
         agentSettings: {
           ...defaultFormData.agentSettings,
           name: assistantTemplate.handle ?? defaultFormData.agentSettings.name,
-          description: assistantTemplate.description ?? defaultFormData.agentSettings.description,
-          pictureUrl: assistantTemplate.pictureUrl ?? defaultFormData.agentSettings.pictureUrl,
+          description:
+            assistantTemplate.description ??
+            defaultFormData.agentSettings.description,
+          pictureUrl:
+            assistantTemplate.pictureUrl ??
+            defaultFormData.agentSettings.pictureUrl,
         },
         generationSettings: {
           ...defaultFormData.generationSettings,
           modelSettings: {
             ...defaultFormData.generationSettings.modelSettings,
-            providerId: assistantTemplate.presetProviderId ?? defaultFormData.generationSettings.modelSettings.providerId,
-            modelId: assistantTemplate.presetModelId ?? defaultFormData.generationSettings.modelSettings.modelId,
+            providerId:
+              assistantTemplate.presetProviderId ??
+              defaultFormData.generationSettings.modelSettings.providerId,
+            modelId:
+              assistantTemplate.presetModelId ??
+              defaultFormData.generationSettings.modelSettings.modelId,
           },
-          temperature: assistantTemplate.presetTemperature ?? defaultFormData.generationSettings.temperature,
+          temperature: assistantTemplate.presetTemperature
+            ? AGENT_CREATIVITY_LEVEL_TEMPERATURES[
+                assistantTemplate.presetTemperature
+              ]
+            : defaultFormData.generationSettings.temperature,
         },
       };
       return templateFormData;

--- a/front/components/agent_builder/AgentBuilderRightPanel.tsx
+++ b/front/components/agent_builder/AgentBuilderRightPanel.tsx
@@ -127,7 +127,7 @@ function CollapsedTabs({ onTabSelect, hasTemplate }: CollapsedTabsProps) {
 interface ExpandedContentProps {
   selectedTab: AgentBuilderRightPanelTabType;
   agentConfigurationSId?: string;
-  assistantTemplate?: FetchAssistantTemplateResponse | null;
+  assistantTemplate: FetchAssistantTemplateResponse | null;
 }
 
 function ExpandedContent({
@@ -158,7 +158,7 @@ function ExpandedContent({
 
 interface AgentBuilderRightPanelProps {
   agentConfigurationSId?: string;
-  assistantTemplate?: FetchAssistantTemplateResponse | null;
+  assistantTemplate: FetchAssistantTemplateResponse | null;
 }
 
 export function AgentBuilderRightPanel({

--- a/front/components/agent_builder/AgentBuilderRightPanel.tsx
+++ b/front/components/agent_builder/AgentBuilderRightPanel.tsx
@@ -167,13 +167,12 @@ export function AgentBuilderRightPanel({
 }: AgentBuilderRightPanelProps) {
   const { isPreviewPanelOpen, setIsPreviewPanelOpen } =
     usePreviewPanelContext();
-  
+
   const hasTemplate = !!assistantTemplate;
-  
-  const [selectedTab, setSelectedTab] =
-    useState<AgentBuilderRightPanelTabType>(
-      hasTemplate ? "template" : "testing"
-    );
+
+  const [selectedTab, setSelectedTab] = useState<AgentBuilderRightPanelTabType>(
+    hasTemplate ? "template" : "testing"
+  );
 
   const handleTogglePanel = () => {
     setIsPreviewPanelOpen(!isPreviewPanelOpen);
@@ -204,8 +203,8 @@ export function AgentBuilderRightPanel({
           assistantTemplate={assistantTemplate}
         />
       ) : (
-        <CollapsedTabs 
-          onTabSelect={handleTabSelect} 
+        <CollapsedTabs
+          onTabSelect={handleTabSelect}
           hasTemplate={hasTemplate}
         />
       )}

--- a/front/components/agent_builder/AgentBuilderRightPanel.tsx
+++ b/front/components/agent_builder/AgentBuilderRightPanel.tsx
@@ -50,14 +50,6 @@ function PanelHeader({
                   onClick={onTogglePanel}
                   className="ml-4"
                 />
-                {hasTemplate && (
-                  <TabsTrigger
-                    value="template"
-                    label="Template"
-                    icon={MagicIcon}
-                    onClick={() => onTabChange("template")}
-                  />
-                )}
                 <TabsTrigger
                   value="testing"
                   label="Testing"
@@ -70,6 +62,14 @@ function PanelHeader({
                   icon={BarChartIcon}
                   onClick={() => onTabChange("performance")}
                 />
+                {hasTemplate && (
+                  <TabsTrigger
+                    value="template"
+                    label="Template"
+                    icon={MagicIcon}
+                    onClick={() => onTabChange("template")}
+                  />
+                )}
               </TabsList>
             </Tabs>
           </ScrollArea>
@@ -97,15 +97,6 @@ interface CollapsedTabsProps {
 function CollapsedTabs({ onTabSelect, hasTemplate }: CollapsedTabsProps) {
   return (
     <div className="flex flex-1 flex-col items-center justify-center gap-4">
-      {hasTemplate && (
-        <Button
-          icon={MagicIcon}
-          variant="ghost"
-          size="sm"
-          tooltip="Template"
-          onClick={() => onTabSelect("template")}
-        />
-      )}
       <Button
         icon={TestTubeIcon}
         variant="ghost"
@@ -120,6 +111,15 @@ function CollapsedTabs({ onTabSelect, hasTemplate }: CollapsedTabsProps) {
         tooltip="Performance"
         onClick={() => onTabSelect("performance")}
       />
+      {hasTemplate && (
+        <Button
+          icon={MagicIcon}
+          variant="ghost"
+          size="sm"
+          tooltip="Template"
+          onClick={() => onTabSelect("template")}
+        />
+      )}
     </div>
   );
 }

--- a/front/components/agent_builder/AgentBuilderRightPanel.tsx
+++ b/front/components/agent_builder/AgentBuilderRightPanel.tsx
@@ -186,14 +186,7 @@ function TemplateButtons({
   assistantTemplate,
 }: TemplateButtonsProps) {
   const confirm = useContext(ConfirmContext);
-  const { setValue, watch } = useFormContext<AgentBuilderFormData>();
-  
-  // Watch current form values
-  const currentInstructions = watch("instructions");
-  const currentActions = watch("actions");
-  
-  const instructionsChanged = currentInstructions !== assistantTemplate.presetInstructions;
-  const hasActions = currentActions && currentActions.length > 0;
+  const { setValue } = useFormContext<AgentBuilderFormData>();
   
   const handleResetInstructions = async () => {
     const confirmed = await confirm({
@@ -223,28 +216,23 @@ function TemplateButtons({
   
   return (
     <div className="flex items-center justify-end gap-2">
-      {instructionsChanged && (
-        <Button
-          label="Reset instructions"
-          onClick={handleResetInstructions}
-          icon={ArrowPathIcon}
-          size="sm"
-          variant="outline"
-        />
-      )}
-      {hasActions && (
-        <Button
-          label="Reset tools"
-          onClick={handleResetActions}
-          icon={ArrowPathIcon}
-          size="sm"
-          variant="outline"
-        />
-      )}
+      <Button
+        label="Reset instructions"
+        onClick={handleResetInstructions}
+        icon={ArrowPathIcon}
+        size="sm"
+        variant="outline"
+      />
+      <Button
+        label="Reset tools"
+        onClick={handleResetActions}
+        icon={ArrowPathIcon}
+        size="sm"
+        variant="outline"
+      />
     </div>
   );
 }
-
 
 interface AgentBuilderRightPanelProps {
   agentConfigurationSId?: string;

--- a/front/components/agent_builder/AgentBuilderRightPanel.tsx
+++ b/front/components/agent_builder/AgentBuilderRightPanel.tsx
@@ -1,10 +1,7 @@
 import {
-  ArrowPathIcon,
   BarChartIcon,
   Button,
   MagicIcon,
-  Markdown,
-  Page,
   ScrollArea,
   SidebarRightCloseIcon,
   SidebarRightOpenIcon,
@@ -13,14 +10,12 @@ import {
   TabsTrigger,
   TestTubeIcon,
 } from "@dust-tt/sparkle";
-import React, { useContext, useState } from "react";
-import { useFormContext } from "react-hook-form";
+import React, { useState } from "react";
 
-import type { AgentBuilderFormData } from "@app/components/agent_builder/AgentBuilderFormContext";
 import { AgentBuilderPerformance } from "@app/components/agent_builder/AgentBuilderPerformance";
 import { AgentBuilderPreview } from "@app/components/agent_builder/AgentBuilderPreview";
+import { AgentBuilderTemplate } from "@app/components/agent_builder/AgentBuilderTemplate";
 import { usePreviewPanelContext } from "@app/components/agent_builder/PreviewPanelContext";
-import { ConfirmContext } from "@app/components/Confirm";
 import type { FetchAssistantTemplateResponse } from "@app/pages/api/templates/[tId]";
 
 type AgentBuilderRightPanelTabType = "testing" | "performance" | "template";
@@ -143,24 +138,7 @@ function ExpandedContent({
   return (
     <div className="flex min-h-0 flex-1 flex-col">
       {selectedTab === "template" && assistantTemplate && (
-        <div className="flex-1 overflow-y-auto p-4">
-          <div className="flex flex-col gap-4">
-            <TemplateButtons
-              assistantTemplate={assistantTemplate}
-            />
-            {assistantTemplate.helpInstructions && (
-              <>
-                <Markdown content={assistantTemplate.helpInstructions} />
-                {assistantTemplate.helpActions && (
-                  <div className="h-px bg-border" />
-                )}
-              </>
-            )}
-            {assistantTemplate.helpActions && (
-              <Markdown content={assistantTemplate.helpActions} />
-            )}
-          </div>
-        </div>
+        <AgentBuilderTemplate assistantTemplate={assistantTemplate} />
       )}
       {selectedTab === "testing" && (
         <div className="min-h-0 flex-1">
@@ -174,62 +152,6 @@ function ExpandedContent({
           />
         </div>
       )}
-    </div>
-  );
-}
-
-interface TemplateButtonsProps {
-  assistantTemplate: FetchAssistantTemplateResponse;
-}
-
-function TemplateButtons({
-  assistantTemplate,
-}: TemplateButtonsProps) {
-  const confirm = useContext(ConfirmContext);
-  const { setValue } = useFormContext<AgentBuilderFormData>();
-  
-  const handleResetInstructions = async () => {
-    const confirmed = await confirm({
-      title: "Are you sure?",
-      message:
-        "You will lose the changes you have made to the agent's instructions and go back to the template's default settings.",
-      validateVariant: "warning",
-    });
-    
-    if (confirmed && assistantTemplate.presetInstructions) {
-      setValue("instructions", assistantTemplate.presetInstructions);
-    }
-  };
-  
-  const handleResetActions = async () => {
-    const confirmed = await confirm({
-      title: "Are you sure?",
-      message:
-        "You will lose the changes you have made to the agent's tools.",
-      validateVariant: "warning",
-    });
-    
-    if (confirmed) {
-      setValue("actions", []);
-    }
-  };
-  
-  return (
-    <div className="flex items-center justify-end gap-2">
-      <Button
-        label="Reset instructions"
-        onClick={handleResetInstructions}
-        icon={ArrowPathIcon}
-        size="sm"
-        variant="outline"
-      />
-      <Button
-        label="Reset tools"
-        onClick={handleResetActions}
-        icon={ArrowPathIcon}
-        size="sm"
-        variant="outline"
-      />
     </div>
   );
 }

--- a/front/components/agent_builder/AgentBuilderTemplate.tsx
+++ b/front/components/agent_builder/AgentBuilderTemplate.tsx
@@ -1,7 +1,12 @@
 import {
-  ArrowPathIcon,
   Button,
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+  ListAddIcon,
   Markdown,
+  PencilSquareIcon,
 } from "@dust-tt/sparkle";
 import React, { useContext } from "react";
 import { useFormContext } from "react-hook-form";
@@ -41,12 +46,10 @@ interface TemplateButtonsProps {
   assistantTemplate: FetchAssistantTemplateResponse;
 }
 
-function TemplateButtons({
-  assistantTemplate,
-}: TemplateButtonsProps) {
+function TemplateButtons({ assistantTemplate }: TemplateButtonsProps) {
   const confirm = useContext(ConfirmContext);
   const { setValue } = useFormContext<AgentBuilderFormData>();
-  
+
   const handleResetInstructions = async () => {
     const confirmed = await confirm({
       title: "Are you sure?",
@@ -54,41 +57,46 @@ function TemplateButtons({
         "You will lose the changes you have made to the agent's instructions and go back to the template's default settings.",
       validateVariant: "warning",
     });
-    
+
     if (confirmed && assistantTemplate.presetInstructions) {
       setValue("instructions", assistantTemplate.presetInstructions);
     }
   };
-  
+
   const handleResetActions = async () => {
     const confirmed = await confirm({
       title: "Are you sure?",
-      message:
-        "You will lose the changes you have made to the agent's tools.",
+      message: "You will lose the changes you have made to the agent's tools.",
       validateVariant: "warning",
     });
-    
+
     if (confirmed) {
       setValue("actions", []);
     }
   };
-  
+
   return (
-    <div className="flex items-center justify-end gap-2">
-      <Button
-        label="Reset instructions"
-        onClick={handleResetInstructions}
-        icon={ArrowPathIcon}
-        size="sm"
-        variant="outline"
-      />
-      <Button
-        label="Reset tools"
-        onClick={handleResetActions}
-        icon={ArrowPathIcon}
-        size="sm"
-        variant="outline"
-      />
+    <div className="flex items-center justify-end">
+      <DropdownMenu>
+        <DropdownMenuTrigger asChild>
+          <Button label="Reset" size="sm" variant="outline" />
+        </DropdownMenuTrigger>
+        <DropdownMenuContent align="end">
+          <DropdownMenuItem
+            label="Reset instructions"
+            description="Set instructions back to template's default"
+            icon={PencilSquareIcon}
+            onClick={handleResetInstructions}
+            disabled={!assistantTemplate.presetInstructions}
+          />
+          <DropdownMenuItem
+            label="Reset tools"
+            description="Remove all tools"
+            icon={ListAddIcon}
+            onClick={handleResetActions}
+          />
+        </DropdownMenuContent>
+      </DropdownMenu>
     </div>
   );
 }

--- a/front/components/agent_builder/AgentBuilderTemplate.tsx
+++ b/front/components/agent_builder/AgentBuilderTemplate.tsx
@@ -50,29 +50,34 @@ function TemplateButtons({ assistantTemplate }: TemplateButtonsProps) {
   const confirm = useContext(ConfirmContext);
   const { setValue } = useFormContext<AgentBuilderFormData>();
 
-  const handleResetInstructions = async () => {
-    const confirmed = await confirm({
-      title: "Are you sure?",
-      message:
-        "You will lose the changes you have made to the agent's instructions and go back to the template's default settings.",
-      validateVariant: "warning",
-    });
+  const handleResetInstructions = () => {
+    setTimeout(async () => {
+      const confirmed = await confirm({
+        title: "Are you sure?",
+        message:
+          "You will lose the changes you have made to the agent's instructions and go back to the template's default settings.",
+        validateVariant: "warning",
+      });
 
-    if (confirmed && assistantTemplate.presetInstructions) {
-      setValue("instructions", assistantTemplate.presetInstructions);
-    }
+      if (confirmed && assistantTemplate.presetInstructions) {
+        setValue("instructions", assistantTemplate.presetInstructions);
+      }
+    }, 0);
   };
 
-  const handleResetActions = async () => {
-    const confirmed = await confirm({
-      title: "Are you sure?",
-      message: "You will lose the changes you have made to the agent's tools.",
-      validateVariant: "warning",
-    });
+  const handleResetActions = () => {
+    setTimeout(async () => {
+      const confirmed = await confirm({
+        title: "Are you sure?",
+        message:
+          "You will lose the changes you have made to the agent's tools.",
+        validateVariant: "warning",
+      });
 
-    if (confirmed) {
-      setValue("actions", []);
-    }
+      if (confirmed) {
+        setValue("actions", []);
+      }
+    }, 0);
   };
 
   return (

--- a/front/components/agent_builder/AgentBuilderTemplate.tsx
+++ b/front/components/agent_builder/AgentBuilderTemplate.tsx
@@ -1,0 +1,94 @@
+import {
+  ArrowPathIcon,
+  Button,
+  Markdown,
+} from "@dust-tt/sparkle";
+import React, { useContext } from "react";
+import { useFormContext } from "react-hook-form";
+
+import type { AgentBuilderFormData } from "@app/components/agent_builder/AgentBuilderFormContext";
+import { ConfirmContext } from "@app/components/Confirm";
+import type { FetchAssistantTemplateResponse } from "@app/pages/api/templates/[tId]";
+
+interface AgentBuilderTemplateProps {
+  assistantTemplate: FetchAssistantTemplateResponse;
+}
+
+export function AgentBuilderTemplate({
+  assistantTemplate,
+}: AgentBuilderTemplateProps) {
+  return (
+    <div className="flex-1 overflow-y-auto p-4">
+      <div className="flex flex-col gap-4">
+        <TemplateButtons assistantTemplate={assistantTemplate} />
+        {assistantTemplate.helpInstructions && (
+          <>
+            <Markdown content={assistantTemplate.helpInstructions} />
+            {assistantTemplate.helpActions && (
+              <div className="h-px bg-border" />
+            )}
+          </>
+        )}
+        {assistantTemplate.helpActions && (
+          <Markdown content={assistantTemplate.helpActions} />
+        )}
+      </div>
+    </div>
+  );
+}
+
+interface TemplateButtonsProps {
+  assistantTemplate: FetchAssistantTemplateResponse;
+}
+
+function TemplateButtons({
+  assistantTemplate,
+}: TemplateButtonsProps) {
+  const confirm = useContext(ConfirmContext);
+  const { setValue } = useFormContext<AgentBuilderFormData>();
+  
+  const handleResetInstructions = async () => {
+    const confirmed = await confirm({
+      title: "Are you sure?",
+      message:
+        "You will lose the changes you have made to the agent's instructions and go back to the template's default settings.",
+      validateVariant: "warning",
+    });
+    
+    if (confirmed && assistantTemplate.presetInstructions) {
+      setValue("instructions", assistantTemplate.presetInstructions);
+    }
+  };
+  
+  const handleResetActions = async () => {
+    const confirmed = await confirm({
+      title: "Are you sure?",
+      message:
+        "You will lose the changes you have made to the agent's tools.",
+      validateVariant: "warning",
+    });
+    
+    if (confirmed) {
+      setValue("actions", []);
+    }
+  };
+  
+  return (
+    <div className="flex items-center justify-end gap-2">
+      <Button
+        label="Reset instructions"
+        onClick={handleResetInstructions}
+        icon={ArrowPathIcon}
+        size="sm"
+        variant="outline"
+      />
+      <Button
+        label="Reset tools"
+        onClick={handleResetActions}
+        icon={ArrowPathIcon}
+        size="sm"
+        variant="outline"
+      />
+    </div>
+  );
+}

--- a/front/components/agent_builder/AgentBuilderTemplate.tsx
+++ b/front/components/agent_builder/AgentBuilderTemplate.tsx
@@ -84,7 +84,7 @@ function TemplateButtons({ assistantTemplate }: TemplateButtonsProps) {
     <div className="flex items-center justify-end">
       <DropdownMenu>
         <DropdownMenuTrigger asChild>
-          <Button label="Reset" size="sm" variant="outline" />
+          <Button label="Reset" size="sm" variant="outline" isSelect />
         </DropdownMenuTrigger>
         <DropdownMenuContent align="end">
           <DropdownMenuItem

--- a/front/components/agent_builder/AgentTemplateModal.tsx
+++ b/front/components/agent_builder/AgentTemplateModal.tsx
@@ -60,7 +60,7 @@ export function AgentTemplateModal({
                     @{assistantTemplate.handle}
                   </span>
                   <Link
-                    href={`/w/${owner.sId}/builder/assistants/new?flow=${flow}&templateId=${assistantTemplate.sId}`}
+                    href={`/w/${owner.sId}/builder/agents/new?flow=${flow}&templateId=${assistantTemplate.sId}`}
                   >
                     <Button
                       label="Use this template"

--- a/front/components/agent_builder/transformAgentConfiguration.ts
+++ b/front/components/agent_builder/transformAgentConfiguration.ts
@@ -1,4 +1,6 @@
 import type { AgentBuilderFormData } from "@app/components/agent_builder/AgentBuilderFormContext";
+import { AGENT_CREATIVITY_LEVEL_TEMPERATURES } from "@app/components/agent_builder/types";
+import type { FetchAssistantTemplateResponse } from "@app/pages/api/templates/[tId]";
 import type { UserType } from "@app/types";
 import type { LightAgentConfigurationType } from "@app/types";
 import { CLAUDE_4_SONNET_DEFAULT_MODEL_CONFIG } from "@app/types";
@@ -63,5 +65,39 @@ export function getDefaultAgentFormData(user: UserType): AgentBuilderFormData {
     },
     actions: [],
     maxStepsPerRun: 8,
+  };
+}
+
+/**
+ * Transforms an assistant template into agent builder form data with defaults.
+ * Merges template presets with default form data to create a complete configuration.
+ */
+export function transformTemplateToFormData(
+  template: FetchAssistantTemplateResponse,
+  user: UserType
+): AgentBuilderFormData {
+  const defaultFormData = getDefaultAgentFormData(user);
+  
+  return {
+    ...defaultFormData,
+    instructions: template.presetInstructions ?? defaultFormData.instructions,
+    agentSettings: {
+      ...defaultFormData.agentSettings,
+      name: template.handle ?? defaultFormData.agentSettings.name,
+      description: template.description ?? defaultFormData.agentSettings.description,
+      pictureUrl: template.pictureUrl ?? defaultFormData.agentSettings.pictureUrl,
+    },
+    generationSettings: {
+      ...defaultFormData.generationSettings,
+      modelSettings: {
+        providerId: template.presetProviderId ?? defaultFormData.generationSettings.modelSettings.providerId,
+        modelId: template.presetModelId ?? defaultFormData.generationSettings.modelSettings.modelId,
+      },
+      temperature: template.presetTemperature
+        ? AGENT_CREATIVITY_LEVEL_TEMPERATURES[template.presetTemperature]
+        : defaultFormData.generationSettings.temperature,
+    },
+    // TODO: Transform presetActions when template action support is implemented
+    actions: [],
   };
 }

--- a/front/components/agent_builder/transformAgentConfiguration.ts
+++ b/front/components/agent_builder/transformAgentConfiguration.ts
@@ -77,21 +77,27 @@ export function transformTemplateToFormData(
   user: UserType
 ): AgentBuilderFormData {
   const defaultFormData = getDefaultAgentFormData(user);
-  
+
   return {
     ...defaultFormData,
     instructions: template.presetInstructions ?? defaultFormData.instructions,
     agentSettings: {
       ...defaultFormData.agentSettings,
       name: template.handle ?? defaultFormData.agentSettings.name,
-      description: template.description ?? defaultFormData.agentSettings.description,
-      pictureUrl: template.pictureUrl ?? defaultFormData.agentSettings.pictureUrl,
+      description:
+        template.description ?? defaultFormData.agentSettings.description,
+      pictureUrl:
+        template.pictureUrl ?? defaultFormData.agentSettings.pictureUrl,
     },
     generationSettings: {
       ...defaultFormData.generationSettings,
       modelSettings: {
-        providerId: template.presetProviderId ?? defaultFormData.generationSettings.modelSettings.providerId,
-        modelId: template.presetModelId ?? defaultFormData.generationSettings.modelSettings.modelId,
+        providerId:
+          template.presetProviderId ??
+          defaultFormData.generationSettings.modelSettings.providerId,
+        modelId:
+          template.presetModelId ??
+          defaultFormData.generationSettings.modelSettings.modelId,
       },
       temperature: template.presetTemperature
         ? AGENT_CREATIVITY_LEVEL_TEMPERATURES[template.presetTemperature]

--- a/front/components/agent_builder/transformAgentConfiguration.ts
+++ b/front/components/agent_builder/transformAgentConfiguration.ts
@@ -97,7 +97,6 @@ export function transformTemplateToFormData(
         ? AGENT_CREATIVITY_LEVEL_TEMPERATURES[template.presetTemperature]
         : defaultFormData.generationSettings.temperature,
     },
-    // TODO: Transform presetActions when template action support is implemented
     actions: [],
   };
 }

--- a/front/lib/api/assistant/templates.ts
+++ b/front/lib/api/assistant/templates.ts
@@ -18,7 +18,7 @@ export async function generateMockAgentConfigurationFromTemplate(
 
   return new Ok({
     actions: [],
-    description: "",
+    description: template.description ?? "",
     instructions: template.presetInstructions ?? "",
     model: {
       providerId: template.presetProviderId,

--- a/front/pages/w/[wId]/builder/agents/[aId]/index.tsx
+++ b/front/pages/w/[wId]/builder/agents/[aId]/index.tsx
@@ -89,7 +89,10 @@ export default function EditAgent({
 
   return (
     <AgentBuilderProvider owner={owner} user={user}>
-      <AgentBuilder agentConfiguration={agentConfiguration} />
+      <AgentBuilder
+        agentConfiguration={agentConfiguration}
+        assistantTemplate={null}
+      />
     </AgentBuilderProvider>
   );
 }

--- a/front/pages/w/[wId]/builder/agents/new.tsx
+++ b/front/pages/w/[wId]/builder/agents/new.tsx
@@ -8,7 +8,6 @@ import { BUILDER_FLOWS } from "@app/components/assistant_builder/types";
 import AppRootLayout from "@app/components/sparkle/AppRootLayout";
 import { throwIfInvalidAgentConfiguration } from "@app/lib/actions/types/guards";
 import { getAgentConfiguration } from "@app/lib/api/assistant/configuration/agent";
-import { generateMockAgentConfigurationFromTemplate } from "@app/lib/api/assistant/templates";
 import config from "@app/lib/api/config";
 import { getFeatureFlags, isRestrictedFromAgentCreation } from "@app/lib/auth";
 import { withDefaultUserAuthRequirements } from "@app/lib/iam/session";
@@ -94,19 +93,6 @@ export const getServerSideProps = withDefaultUserAuthRequirements<{
     // We reset the scope according to the current flow. This ensures that cloning a workspace
     // agent with flow `personal_assistants` will initialize the agent as private.
     configuration.scope = flow === "personal_assistants" ? "hidden" : "visible";
-  } else if (templateId) {
-    const agentConfigRes = await generateMockAgentConfigurationFromTemplate(
-      templateId,
-      flow
-    );
-
-    if (agentConfigRes.isErr()) {
-      return {
-        notFound: true,
-      };
-    }
-
-    configuration = agentConfigRes.value;
   }
 
   const user = auth.getNonNullableUser().toJSON();
@@ -133,7 +119,6 @@ export default function CreateAgent({
 }: InferGetServerSidePropsType<typeof getServerSideProps>) {
   const { assistantTemplate } = useAssistantTemplate({ templateId });
 
-
   if (agentConfiguration) {
     throwIfInvalidAgentConfiguration(agentConfiguration);
   }
@@ -144,8 +129,8 @@ export default function CreateAgent({
 
   return (
     <AgentBuilderProvider owner={owner} user={user}>
-      <AgentBuilder 
-        agentConfiguration={agentConfiguration} 
+      <AgentBuilder
+        agentConfiguration={agentConfiguration}
         assistantTemplate={assistantTemplate}
       />
     </AgentBuilderProvider>

--- a/front/pages/w/[wId]/builder/agents/new.tsx
+++ b/front/pages/w/[wId]/builder/agents/new.tsx
@@ -133,6 +133,7 @@ export default function CreateAgent({
 }: InferGetServerSidePropsType<typeof getServerSideProps>) {
   const { assistantTemplate } = useAssistantTemplate({ templateId });
 
+
   if (agentConfiguration) {
     throwIfInvalidAgentConfiguration(agentConfiguration);
   }
@@ -143,7 +144,10 @@ export default function CreateAgent({
 
   return (
     <AgentBuilderProvider owner={owner} user={user}>
-      <AgentBuilder />
+      <AgentBuilder 
+        agentConfiguration={agentConfiguration} 
+        assistantTemplate={assistantTemplate}
+      />
     </AgentBuilderProvider>
   );
 }

--- a/front/pages/w/[wId]/builder/agents/new.tsx
+++ b/front/pages/w/[wId]/builder/agents/new.tsx
@@ -130,7 +130,11 @@ export default function CreateAgent({
   return (
     <AgentBuilderProvider owner={owner} user={user}>
       <AgentBuilder
-        agentConfiguration={agentConfiguration}
+        agentConfiguration={
+          agentConfiguration && "sId" in agentConfiguration
+            ? agentConfiguration
+            : undefined
+        }
         assistantTemplate={assistantTemplate}
       />
     </AgentBuilderProvider>


### PR DESCRIPTION
## Description

This PR reintroduces agent creation from a template in the new agent builder.
- Applying a template is now client-side with React Hook Form.
- Updated design for Reset instructions and Reset tools.
- Removed the button to Close template.

Out of scope for this PR: Templates have actions for inserting tools that should be displayed in the Template tab.

## Tests

Locally

## Risk

Low, Behind FF

## Deploy Plan

Deploy front
