### PR TITLE
[front] - fix: capitalize labels in 'Create Agent' dropdown menu

### DIFF
--- a/front/components/assistant/CreateAgentButton.tsx
+++ b/front/components/assistant/CreateAgentButton.tsx
@@ -42,7 +42,7 @@ export const CreateAgentButton = ({
       </DropdownMenuTrigger>
       <DropdownMenuContent>
         <DropdownMenuItem
-          label="agent from scratch"
+          label="Agent from scratch"
           icon={DocumentIcon}
           onClick={() => {
             setIsLoading(true);
@@ -52,7 +52,7 @@ export const CreateAgentButton = ({
           }}
         />
         <DropdownMenuItem
-          label="agent from template"
+          label="Agent from template"
           icon={MagicIcon}
           onClick={() => {
             setIsLoading(true);


### PR DESCRIPTION
## Description

This PR capitalizes items in the "Create Agent" dropdown menu

<img width="271" height="159" alt="Screenshot 2025-08-13 at 08 19 43" src="https://github.com/user-attachments/assets/9da199fa-addb-4e4c-abc9-34933727d48e" />

## Tests

Locally

## Risk

None

## Deploy Plan

Deploy front
