### PR TITLE
Ignore spaces of auto internal tools in agent permissions

### DIFF
--- a/front/lib/actions/mcp_internal_actions/constants.test.ts
+++ b/front/lib/actions/mcp_internal_actions/constants.test.ts
@@ -9,4 +9,43 @@ describe("INTERNAL_MCP_SERVERS", () => {
 
     expect(ids.length).toBe(uniqueIds.size);
   });
+
+  it("manipulating the list of auto internal tools may requires a migration", () => {
+    const autoInternalTools: { name: string; id: number }[] = [];
+
+    for (const [key, value] of Object.entries(INTERNAL_MCP_SERVERS)) {
+      if (
+        value.availability === "auto" ||
+        value.availability === "auto_hidden_builder"
+      ) {
+        autoInternalTools.push({ name: key, id: value.id });
+      }
+    }
+    const HARD_CODED_AUTO_INTERNAL_TOOLS = [
+      { name: "image_generation", id: 2 },
+      { name: "file_generation", id: 3 },
+      { name: "query_tables", id: 4 },
+      { name: "web_search_&_browse", id: 5 },
+      { name: "think", id: 6 },
+      { name: "agent_router", id: 8 },
+      { name: "include_data", id: 9 },
+      { name: "run_dust_app", id: 10 },
+      { name: "extract_data", id: 12 },
+      { name: "missing_action_catcher", id: 13 },
+      { name: "conversation_files", id: 17 },
+      { name: "agent_memory", id: 21 },
+      { name: "interactive_content", id: 23 },
+      { name: "search", id: 1006 },
+      { name: "run_agent", id: 1008 },
+      { name: "reasoning", id: 1007 },
+      { name: "query_tables_v2", id: 1009 },
+      { name: "data_sources_file_system", id: 1010 },
+      { name: "agent_management", id: 1011 },
+      { name: "data_warehouses", id: 1012 },
+    ];
+    expect(
+      autoInternalTools,
+      "Internal tools with availabilty auto or auto_hidden_builder are not up to date.\nIf you are adding or removing a tool, just update the hard coded list.\nHowever, if you are changing the availability from auto(_xxx) to manual, you need to run a migration on existing agents that were configured with that tool to update their requestedGroupIds (see getAgentConfigurationGroupIdsFromActions())."
+    ).toEqual(HARD_CODED_AUTO_INTERNAL_TOOLS);
+  });
 });

--- a/front/lib/api/assistant/permissions.ts
+++ b/front/lib/api/assistant/permissions.ts
@@ -1,6 +1,7 @@
 import { Op } from "sequelize";
 
 import type { ServerSideMCPServerConfigurationType } from "@app/lib/actions/mcp";
+import { getAvailabilityOfInternalMCPServerById } from "@app/lib/actions/mcp_internal_actions/constants";
 import type { UnsavedMCPServerConfigurationType } from "@app/lib/actions/types/agent";
 import { isServerSideMCPServerConfiguration } from "@app/lib/actions/types/guards";
 import type { Authenticator } from "@app/lib/auth";
@@ -15,7 +16,7 @@ import type {
   ContentFragmentInputWithContentNode,
   ModelId,
 } from "@app/types";
-import { removeNulls } from "@app/types";
+import { assertNever, removeNulls } from "@app/types";
 
 export async function listAgentConfigurationsForGroups(
   auth: Authenticator,
@@ -121,6 +122,21 @@ export async function getAgentConfigurationGroupIdsFromActions(
     const { sId: spaceId } = view.space;
     if (ignoreSpaceIds?.has(spaceId)) {
       continue;
+    }
+
+    // We skip the permissions for internal tools as they are automatically available to all users.
+    // This mimic the previous behavior of generic internal tools (search etc..).
+    if (view.serverType === "internal") {
+      const availability = getAvailabilityOfInternalMCPServerById(view.sId);
+      switch (availability) {
+        case "auto":
+        case "auto_hidden_builder":
+          continue;
+        case "manual":
+          break;
+        default:
+          assertNever(availability);
+      }
     }
     if (!spacePermissions.has(spaceId)) {
       spacePermissions.set(spaceId, new Set());


### PR DESCRIPTION
## Description

Ignore spaces for auto internal tools to avoid the need to whitelist them in slack workflows for example.

## Tests

Local

## Risk

Low

## Deploy Plan

Deploy front