### PR TITLE
[front] Fix incorrect prop name in `CreateAgentButton`

### DIFF
--- a/front/components/assistant/CreateAgentButton.tsx
+++ b/front/components/assistant/CreateAgentButton.tsx
@@ -37,7 +37,7 @@ export const CreateAgentButton = ({
           size="sm"
           isSelect
           isLoading={isLoading}
-          isDisabled={isLoading}
+          disabled={isLoading}
         />
       </DropdownMenuTrigger>
       <DropdownMenuContent>


### PR DESCRIPTION
## Description

- This PR fixes an incorrect prop name passed to the `CreateAgentButton` component, leading to the disabled state not correctly set when `isLoading`.
- Stumbled upon this thanks to a console warning `React does not recognize the isDisabled prop on a DOM element.`.

## Tests

- Tested locally.

## Risk

- N/A.

## Deploy Plan

- Deploy front.
