### PR TITLE
[front] - fix(AB v2): clamp `ActionCard` content

### DIFF
--- a/front/components/agent_builder/capabilities/AgentBuilderCapabilitiesBlock.tsx
+++ b/front/components/agent_builder/capabilities/AgentBuilderCapabilitiesBlock.tsx
@@ -103,6 +103,9 @@ function ActionCard({ action, onRemove, onEdit }: ActionCardProps) {
         ) ?? null
       : null;
 
+  const displayName = actionDisplayName(action, mcpServerView);
+  const description = action.description ?? "";
+
   return (
     <Card
       variant="primary"
@@ -122,18 +125,16 @@ function ActionCard({ action, onRemove, onEdit }: ActionCardProps) {
       <div className="flex w-full flex-col gap-2 text-sm">
         <div className="flex w-full items-center gap-2 font-medium text-foreground dark:text-foreground-night">
           {actionIcon(action, mcpServerView)}
-          <div className="w-full truncate">
-            {actionDisplayName(action, mcpServerView)}
-          </div>
+          <span className="truncate">{displayName}</span>
         </div>
-        <div className="line-clamp-4 text-muted-foreground dark:text-muted-foreground-night">
-          <p>{action.description}</p>
+
+        <div className="text-muted-foreground dark:text-muted-foreground-night">
+          <span className="line-clamp-2 break-words">{description}</span>
         </div>
       </div>
     </Card>
   );
 }
-
 interface AgentBuilderCapabilitiesBlockProps {
   isActionsLoading: boolean;
 }


### PR DESCRIPTION
## Description

This PR  updates the `ActionCard` description display to use `line-clamp-2` for better text overflow management.

<img width="684" height="176" alt="Screenshot 2025-08-13 at 11 24 11" src="https://github.com/user-attachments/assets/b7035f86-544e-467a-bba4-0c2745713ea4" />

## Tests

Locally

## Risk

Low

## Deploy Plan

Deploy front