### PR TITLE
[front] fix(abv2): Divers fixes

### DIFF
--- a/connectors/package-lock.json
+++ b/connectors/package-lock.json
@@ -95,13 +95,13 @@
     },
     "../sdks/js": {
       "name": "@dust-tt/client",
-      "version": "1.1.3",
+      "version": "1.1.4",
       "bundleDependencies": [
         "@modelcontextprotocol/sdk"
       ],
       "license": "ISC",
       "dependencies": {
-        "@modelcontextprotocol/sdk": "git://github.com:dust-tt/typescript-sdk.git#bca26e405d6db2cf71fd7211234a72ecc46d0215",
+        "@modelcontextprotocol/sdk": "git://github.com:dust-tt/typescript-sdk.git#628ebe48388549faae7e35504611af9ac2c6f5e4",
         "@types/json-schema": "^7.0.15",
         "event-source-polyfill": "^1.0.31",
         "eventsource-parser": "^1.1.1",

--- a/front/components/agent_builder/capabilities/knowledge/KnowledgeFooter.tsx
+++ b/front/components/agent_builder/capabilities/knowledge/KnowledgeFooter.tsx
@@ -14,6 +14,7 @@ import { useDataSourceBuilderContext } from "@app/components/data_source_view/co
 import type { DataSourceBuilderTreeItemType } from "@app/components/data_source_view/context/types";
 import { getVisualForTreeItem } from "@app/components/data_source_view/context/utils";
 import { useNodePath } from "@app/hooks/useNodePath";
+import { getDataSourceNameFromView } from "@app/lib/data_sources";
 import type { DataSourceViewContentNode } from "@app/types";
 import { pluralize } from "@app/types";
 
@@ -36,7 +37,9 @@ function KnowledgeFooterItemReadablePath({
         <span className="text-xs">
           {fullPath
             .map((node, index) =>
-              index === 0 ? node.dataSourceView.dataSource.name : node.title
+              index === 0
+                ? getDataSourceNameFromView(node.dataSourceView)
+                : node.title
             )
             .join("/")}
         </span>

--- a/front/components/agent_builder/capabilities/knowledge/KnowledgeFooter.tsx
+++ b/front/components/agent_builder/capabilities/knowledge/KnowledgeFooter.tsx
@@ -13,6 +13,7 @@ import { useSourcesFormController } from "@app/components/agent_builder/utils";
 import { useDataSourceBuilderContext } from "@app/components/data_source_view/context/DataSourceBuilderContext";
 import type { DataSourceBuilderTreeItemType } from "@app/components/data_source_view/context/types";
 import { getVisualForTreeItem } from "@app/components/data_source_view/context/utils";
+import { useTheme } from "@app/components/sparkle/ThemeContext";
 import { useNodePath } from "@app/hooks/useNodePath";
 import { getDataSourceNameFromView } from "@app/lib/data_sources";
 import type { DataSourceViewContentNode } from "@app/types";
@@ -53,8 +54,9 @@ function KnowledgeFooterItem({
 }: {
   item: DataSourceBuilderTreeItemType;
 }) {
+  const { isDark } = useTheme();
   const { removeNodeWithPath } = useDataSourceBuilderContext();
-  const VisualComponent = getVisualForTreeItem(item);
+  const VisualComponent = getVisualForTreeItem(item, isDark);
 
   return (
     <ContextItem

--- a/front/components/agent_builder/capabilities/knowledge/KnowledgeFooter.tsx
+++ b/front/components/agent_builder/capabilities/knowledge/KnowledgeFooter.tsx
@@ -16,7 +16,7 @@ import { getVisualForTreeItem } from "@app/components/data_source_view/context/u
 import { useNodePath } from "@app/hooks/useNodePath";
 import { getDataSourceNameFromView } from "@app/lib/data_sources";
 import type { DataSourceViewContentNode } from "@app/types";
-import { pluralize } from "@app/types";
+import { pluralize, removeNulls } from "@app/types";
 
 function KnowledgeFooterItemReadablePath({
   node,
@@ -35,13 +35,13 @@ function KnowledgeFooterItemReadablePath({
         <LoadingBlock className="h-4 w-[250px]" />
       ) : (
         <span className="text-xs">
-          {fullPath
-            .map((node, index) =>
+          {removeNulls(
+            fullPath.map((node, index) =>
               index === 0
                 ? getDataSourceNameFromView(node.dataSourceView)
-                : node.title
+                : node.parentTitle
             )
-            .join("/")}
+          ).join("/")}
         </span>
       )}
     </div>

--- a/front/components/data_source_view/DataSourceBuilderSelector.tsx
+++ b/front/components/data_source_view/DataSourceBuilderSelector.tsx
@@ -10,6 +10,7 @@ import { DataSourceCategoryBrowser } from "@app/components/data_source_view/Data
 import { DataSourceNodeTable } from "@app/components/data_source_view/DataSourceNodeTable";
 import { DataSourceSpaceSelector } from "@app/components/data_source_view/DataSourceSpaceSelector";
 import { DataSourceViewTable } from "@app/components/data_source_view/DataSourceViewTable";
+import { getDataSourceNameFromView } from "@app/lib/data_sources";
 import { CATEGORY_DETAILS } from "@app/lib/spaces";
 import type {
   ContentNodesViewType,
@@ -108,7 +109,7 @@ function getBreadcrumbConfig(
       };
     case "data_source":
       return {
-        label: entry.dataSourceView.dataSource.name,
+        label: getDataSourceNameFromView(entry.dataSourceView),
       };
     case "node":
       return {

--- a/front/components/data_source_view/DataSourceNodeTable.tsx
+++ b/front/components/data_source_view/DataSourceNodeTable.tsx
@@ -43,7 +43,6 @@ export function DataSourceNodeTable({ viewType }: DataSourceNodeTableProps) {
         : undefined,
     viewType,
     pagination: { limit: PAGE_SIZE, cursor: null },
-    sorting: [{ field: "title", direction: "asc" }],
   });
 
   const handleLoadMore = async () => {

--- a/front/components/data_source_view/DataSourceNodeTable.tsx
+++ b/front/components/data_source_view/DataSourceNodeTable.tsx
@@ -43,6 +43,7 @@ export function DataSourceNodeTable({ viewType }: DataSourceNodeTableProps) {
         : undefined,
     viewType,
     pagination: { limit: PAGE_SIZE, cursor: null },
+    sorting: [{ field: "title", direction: "asc" }],
   });
 
   const handleLoadMore = async () => {

--- a/front/components/data_source_view/DataSourceSpaceSelector.tsx
+++ b/front/components/data_source_view/DataSourceSpaceSelector.tsx
@@ -12,6 +12,7 @@ import { useDataSourceBuilderContext } from "@app/components/data_source_view/co
 import type { NavigationHistoryEntryType } from "@app/components/data_source_view/context/types";
 import { getSpaceIcon } from "@app/lib/spaces";
 import type { SpaceType } from "@app/types";
+import { SPACE_KINDS } from "@app/types";
 
 type SpaceRowData = SpaceType & {
   id: string;
@@ -32,15 +33,30 @@ export function DataSourceSpaceSelector({
     useDataSourceBuilderContext();
 
   const confirm = useContext(ConfirmContext);
-  const spaceRows: SpaceRowData[] = spaces.map((space) => ({
-    ...space,
-    id: space.sId,
-    name: space.name,
-    kind: space.kind,
-    icon: getSpaceIcon(space),
-    onClick: () => setSpaceEntry(space),
-    disabled: allowedSpaces.find((s) => s.sId === space.sId) == null,
-  }));
+
+  const spaceRows: SpaceRowData[] = spaces
+    .map((space) => ({
+      ...space,
+      id: space.sId,
+      name: space.name,
+      kind: space.kind,
+      icon: getSpaceIcon(space),
+      onClick: () => setSpaceEntry(space),
+      disabled: allowedSpaces.find((s) => s.sId === space.sId) == null,
+    }))
+    .toSorted((a, b) => {
+      // First, sort by kind according to the specified order
+      const aKindIndex = SPACE_KINDS.indexOf(a.kind);
+      const bKindIndex = SPACE_KINDS.indexOf(b.kind);
+
+      // If kinds are different, sort by kind order
+      if (aKindIndex !== bKindIndex) {
+        return aKindIndex - bKindIndex;
+      }
+
+      // If kinds are the same, sort by name alphabetically
+      return a.name.localeCompare(b.name);
+    });
 
   const columns: ColumnDef<SpaceRowData>[] = useMemo(
     () => [

--- a/front/components/data_source_view/DataSourceViewTable.tsx
+++ b/front/components/data_source_view/DataSourceViewTable.tsx
@@ -53,8 +53,9 @@ export function DataSourceViewTable() {
           type: "data_source",
           dataSourceView: dsv,
         },
-      };
-    });
+      } satisfies DataSourceRowData;
+    })
+    .toSorted((a, b) => a.title.localeCompare(b.title));
 
   if (isSpaceDataSourceViewsLoading) {
     return (

--- a/front/components/data_source_view/context/utils.ts
+++ b/front/components/data_source_view/context/utils.ts
@@ -6,6 +6,7 @@ import type {
   NavigationHistoryEntryType,
   NodeSelectionState,
 } from "@app/components/data_source_view/context/types";
+import { CONNECTOR_CONFIGURATIONS } from "@app/lib/connector_providers";
 import { getVisualForDataSourceViewContentNode } from "@app/lib/content_nodes";
 import { CATEGORY_DETAILS, getSpaceIcon } from "@app/lib/spaces";
 import type {
@@ -290,7 +291,10 @@ export function getLatestNodeFromNavigationHistory(
   return null;
 }
 
-export function getVisualForTreeItem(item: DataSourceBuilderTreeItemType) {
+export function getVisualForTreeItem(
+  item: DataSourceBuilderTreeItemType,
+  isDark = false
+) {
   switch (item.type) {
     case "root":
       // Root doesn't have a specific visual, use a default folder icon
@@ -305,10 +309,12 @@ export function getVisualForTreeItem(item: DataSourceBuilderTreeItemType) {
     case "data_source":
       // For data sources, we can use the connector provider logo or fall back to a generic icon
       if (item.dataSourceView.dataSource.connectorProvider) {
-        // We could import getConnectorProviderLogoWithFallback but for simplicity,
-        // let's use category-based icons as fallback
-        const category = item.dataSourceView.category;
-        return CATEGORY_DETAILS[category].icon;
+        const connectorProvider =
+          CONNECTOR_CONFIGURATIONS[
+            item.dataSourceView.dataSource.connectorProvider
+          ];
+
+        return connectorProvider.getLogoComponent(isDark);
       }
       return FolderIcon;
 

--- a/front/components/data_source_view/context/utils.ts
+++ b/front/components/data_source_view/context/utils.ts
@@ -8,6 +8,7 @@ import type {
 } from "@app/components/data_source_view/context/types";
 import { CONNECTOR_CONFIGURATIONS } from "@app/lib/connector_providers";
 import { getVisualForDataSourceViewContentNode } from "@app/lib/content_nodes";
+import { getDataSourceNameFromView } from "@app/lib/data_sources";
 import { CATEGORY_DETAILS, getSpaceIcon } from "@app/lib/spaces";
 import type {
   DataSourceViewCategoryWithoutApps,
@@ -238,7 +239,7 @@ export function navigationHistoryEntryTitle(
     case "category":
       return CATEGORY_DETAILS[entry.category].label;
     case "data_source":
-      return entry.dataSourceView.dataSource.name;
+      return getDataSourceNameFromView(entry.dataSourceView);
     case "node":
       return entry.node.title;
     default:

--- a/front/types/space.ts
+++ b/front/types/space.ts
@@ -4,7 +4,11 @@ export const UNIQUE_SPACE_KINDS = [
   "conversations",
 ] as const;
 
-const SPACE_KINDS = [...UNIQUE_SPACE_KINDS, "public", "regular"] as const;
+export const SPACE_KINDS = [
+  ...UNIQUE_SPACE_KINDS,
+  "public",
+  "regular",
+] as const;
 
 export type SpaceKind = (typeof SPACE_KINDS)[number];
 


### PR DESCRIPTION
## Description
- Related to this [comment](https://github.com/dust-tt/tasks/issues/3037#issuecomment-3182557788) for that issue https://github.com/dust-tt/tasks/issues/3037
- Show correct connectors name in breadcrumbs and footer
- Order websites and folders alphabetically
- Fix missing some path elements for manage connectors.

Cannot order content nodes alphabetically, it must use the API to do so and there is currently an issue with text sorting (https://github.com/dust-tt/tasks/issues/3797)

## Tests
- Locally
- Front-edge for managed connections

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan
- Deploy front
