### PR TITLE
Implement timeout-based sync-to-async switching for agent execution

### DIFF
--- a/front/lib/api/assistant/agent.ts
+++ b/front/lib/api/assistant/agent.ts
@@ -6,19 +6,46 @@ import { wakeLock } from "@app/lib/wake_lock";
 import { runModelAndCreateActionsActivity } from "@app/temporal/agent_loop/activities/run_model_and_create_actions_wrapper";
 import { runToolActivity } from "@app/temporal/agent_loop/activities/run_tool";
 import { launchAgentLoopWorkflow } from "@app/temporal/agent_loop/client";
-import { executeAgentLoop } from "@app/temporal/agent_loop/lib/agent_loop_executor";
+import {
+  executeAgentLoop,
+  SyncTimeoutError,
+} from "@app/temporal/agent_loop/lib/agent_loop_executor";
 import { launchUpdateUsageWorkflow } from "@app/temporal/usage_queue/client";
 import type {
   RunAgentArgs,
   RunAgentSynchronousArgs,
 } from "@app/types/assistant/agent_run";
 
+/**
+ * Helper to launch async workflow from sync data.
+ */
+async function launchAsyncWorkflowFromSyncData(
+  authType: AuthenticatorType,
+  runAgentSynchronousArgs: RunAgentSynchronousArgs,
+  { startStep }: { startStep: number }
+): Promise<void> {
+  const { agentMessage, conversation, userMessage } = runAgentSynchronousArgs;
+
+  await launchAgentLoopWorkflow({
+    authType,
+    runAsynchronousAgentArgs: {
+      agentMessageId: agentMessage.sId,
+      agentMessageVersion: agentMessage.version,
+      conversationId: conversation.sId,
+      conversationTitle: conversation.title,
+      userMessageId: userMessage.sId,
+      userMessageVersion: userMessage.version,
+    },
+    startStep,
+  });
+}
+
 // This interface is used to execute an agent. It is not in charge of creating the AgentMessage,
 // but it now handles updating it based on the execution results.
 async function runAgentSynchronousWithStreaming(
   authType: AuthenticatorType,
   runAgentSynchronousArgs: RunAgentSynchronousArgs,
-  startStep: number
+  { startStep }: { startStep: number }
 ): Promise<void> {
   const runAgentArgs: RunAgentArgs = {
     sync: true,
@@ -27,17 +54,40 @@ async function runAgentSynchronousWithStreaming(
 
   const titlePromise = ensureConversationTitle(authType, runAgentArgs);
 
-  await wakeLock(async () => {
-    await executeAgentLoop(
-      authType,
-      runAgentArgs,
-      {
-        runModelAndCreateActionsActivity,
-        runToolActivity,
-      },
-      startStep
-    );
-  });
+  const syncStartTime = Date.now();
+
+  // NOTE: This is an exception to our usual Result<> pattern. Since executeAgentLoop is shared
+  // between Temporal workflows (which have serialization constraints) and direct execution,
+  // we use throwing as the common mechanism that works in both contexts. The SyncTimeoutError
+  // is only thrown in sync mode and never reaches Temporal workflows.
+  try {
+    await wakeLock(async () => {
+      await executeAgentLoop(
+        authType,
+        runAgentArgs,
+        {
+          runModelAndCreateActionsActivity,
+          runToolActivity,
+        },
+        {
+          startStep,
+          syncStartTime,
+        }
+      );
+    });
+  } catch (error) {
+    if (error instanceof SyncTimeoutError) {
+      await launchAsyncWorkflowFromSyncData(authType, runAgentSynchronousArgs, {
+        startStep: error.currentStep,
+      });
+
+      // Don't continue with sync execution after switching to async.
+      return;
+    }
+
+    // Re-throw other errors.
+    throw error;
+  }
 
   await titlePromise;
 
@@ -68,22 +118,10 @@ export async function runAgentLoop(
     await runAgentSynchronousWithStreaming(
       authType,
       runAgentArgs.inMemoryData,
-      startStep
+      { startStep }
     );
   } else if (runAgentArgs.sync) {
-    const { agentMessage, conversation, userMessage } =
-      runAgentArgs.inMemoryData;
-
-    await launchAgentLoopWorkflow({
-      authType,
-      runAsynchronousAgentArgs: {
-        agentMessageId: agentMessage.sId,
-        agentMessageVersion: agentMessage.version,
-        conversationId: conversation.sId,
-        conversationTitle: conversation.title,
-        userMessageId: userMessage.sId,
-        userMessageVersion: userMessage.version,
-      },
+    await launchAsyncWorkflowFromSyncData(authType, runAgentArgs.inMemoryData, {
       startStep,
     });
   } else {

--- a/front/lib/api/assistant/agent.ts
+++ b/front/lib/api/assistant/agent.ts
@@ -86,6 +86,7 @@ async function runAgentSynchronousWithStreaming(
       logger.info(
         {
           agentMessageId: runAgentExecutionData.agentMessage.sId,
+          conversationId: runAgentExecutionData.conversation.sId,
           currentStep: error.currentStep,
           elapsedMs: error.elapsedMs,
           workspaceId: authType.workspaceId,

--- a/front/lib/api/assistant/agent.ts
+++ b/front/lib/api/assistant/agent.ts
@@ -18,7 +18,7 @@ import type {
 } from "@app/types/assistant/agent_run";
 
 // 2 minutes timeout before switching from sync to async execution.
-const SYNC_TO_ASYNC_TIMEOUT_MS = 2 * 15 * 1000;
+const SYNC_TO_ASYNC_TIMEOUT_MS = 2 * 60 * 1000;
 
 /**
  * Helper to launch async workflow from sync data.

--- a/front/temporal/agent_loop/activities/create_tool_actions.ts
+++ b/front/temporal/agent_loop/activities/create_tool_actions.ts
@@ -15,7 +15,7 @@ import type {
   AgentMessageType,
   ModelId,
 } from "@app/types";
-import type { RunAgentSynchronousArgs } from "@app/types/assistant/agent_run";
+import type { RunAgentExecutionData } from "@app/types/assistant/agent_run";
 
 interface ActionBlob {
   action: AgentMCPAction;
@@ -35,7 +35,7 @@ export async function createToolActionsActivity(
     functionCallStepContentIds,
     step,
   }: {
-    runAgentData: RunAgentSynchronousArgs;
+    runAgentData: RunAgentExecutionData;
     actions: AgentActionsEvent["actions"];
     stepContexts: StepContext[];
     functionCallStepContentIds: Record<string, ModelId>;

--- a/front/temporal/agent_loop/activities/run_model.ts
+++ b/front/temporal/agent_loop/activities/run_model.ts
@@ -46,7 +46,7 @@ import type {
   ReasoningContentType,
   TextContentType,
 } from "@app/types/assistant/agent_message_content";
-import type { RunAgentSynchronousArgs } from "@app/types/assistant/agent_run";
+import type { RunAgentExecutionData } from "@app/types/assistant/agent_run";
 
 const CANCELLATION_CHECK_INTERVAL = 500;
 const MAX_AUTO_RETRY = 3;
@@ -66,7 +66,7 @@ export async function runModelActivity(
     functionCallStepContentIds,
     autoRetryCount = 0,
   }: {
-    runAgentData: RunAgentSynchronousArgs;
+    runAgentData: RunAgentExecutionData;
     runIds: string[];
     step: number;
     functionCallStepContentIds: Record<string, ModelId>;

--- a/front/temporal/agent_loop/activities/run_model_and_create_actions_wrapper.ts
+++ b/front/temporal/agent_loop/activities/run_model_and_create_actions_wrapper.ts
@@ -13,7 +13,7 @@ import { MAX_ACTIONS_PER_STEP } from "@app/types/assistant/agent";
 import { isFunctionCallContent } from "@app/types/assistant/agent_message_content";
 import type {
   RunAgentArgs,
-  RunAgentSynchronousArgs,
+  RunAgentExecutionData,
 } from "@app/types/assistant/agent_run";
 import { getRunAgentData } from "@app/types/assistant/agent_run";
 
@@ -124,7 +124,7 @@ export async function runModelAndCreateActionsActivity({
  */
 async function getExistingActionsAndBlobs(
   auth: Authenticator,
-  runAgentArgs: RunAgentSynchronousArgs,
+  runAgentArgs: RunAgentExecutionData,
   step: number
 ): Promise<{
   actionBlobs: ActionBlob[];

--- a/front/temporal/agent_loop/workflows.ts
+++ b/front/temporal/agent_loop/workflows.ts
@@ -99,7 +99,10 @@ export async function agentLoopWorkflow({
     }
   }
 
-  await executeAgentLoop(authType, runAgentArgs, activities, startStep);
+  // In Temporal workflows, we don't pass syncStartTime since async execution doesn't need timeout.
+  await executeAgentLoop(authType, runAgentArgs, activities, {
+    startStep,
+  });
 
   if (childWorkflowHandle) {
     await childWorkflowHandle.result();

--- a/front/types/assistant/agent_run.ts
+++ b/front/types/assistant/agent_run.ts
@@ -31,7 +31,7 @@ export type RunAgentAsynchronousArgs = {
   userMessageVersion: number;
 };
 
-export type RunAgentSynchronousArgs = {
+export type RunAgentExecutionData = {
   agentConfiguration: AgentConfigurationType;
   agentMessage: AgentMessageType;
   agentMessageRow: AgentMessage;
@@ -42,7 +42,8 @@ export type RunAgentSynchronousArgs = {
 export type RunAgentArgs =
   | {
       sync: true;
-      inMemoryData: RunAgentSynchronousArgs;
+      inMemoryData: RunAgentExecutionData;
+      syncToAsyncTimeoutMs?: number;
     }
   | {
       sync: false;
@@ -52,7 +53,7 @@ export type RunAgentArgs =
 export async function getRunAgentData(
   authType: AuthenticatorType,
   runAgentArgs: RunAgentArgs
-): Promise<Result<RunAgentSynchronousArgs & { auth: Authenticator }, Error>> {
+): Promise<Result<RunAgentExecutionData & { auth: Authenticator }, Error>> {
   const auth = await Authenticator.fromJSON(authType);
 
   if (runAgentArgs.sync) {
@@ -149,11 +150,11 @@ export async function getRunAgentData(
   }
 
   return new Ok({
-    auth,
+    agentConfiguration,
     agentMessage,
     agentMessageRow: agentMessageRow.agentMessage,
+    auth,
     conversation,
     userMessage,
-    agentConfiguration,
   });
 }


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
_Inspired by https://github.com/dust-tt/dust/pull/14860._

This PR adds automatic switching from synchronous to asynchronous execution for agent loops that run longer than 3
minutes.

**Why we're using exceptions instead of `Result<>`**

The timeout mechanism uses a throwing approach rather than our typical `Result<>` pattern. This is because `executeAgentLoop` is shared between Temporal workflows (which have serialization constraints) and direct Node.js execution. Throwing provides a common mechanism that works in both contexts without serialization issues, while `Result<>` objects don't serialize properly in Temporal workflows.

**Using timeout as natural segmentation instead of feature flags**

Rather than implementing a feature flag, we're using the 2-minute timeout as a natural way to target only the subset of
conversations that actually need this optimization. Most agent conversations complete well under 2 minutes and will
continue running synchronously as before, while only the longer-running conversations (which are the ones that actually
cause blocking issues) will automatically switch to async execution. This approach is safer and more targeted than a
blanket feature flag.

**Implementation notes**

The switch happens at safe transition points (only on a new step) to ensure no work is lost and execution continues from exactly where it left off in the synchronous workflow.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
