### PR TITLE
[sparkle] Add `inline` version of `ContentMessage`

### DIFF
--- a/sparkle/src/components/ContentMessage.tsx
+++ b/sparkle/src/components/ContentMessage.tsx
@@ -23,39 +23,40 @@ const CONTENT_MESSAGE_SIZES = ["sm", "md", "lg"] as const;
 
 type ContentMessageSizeType = (typeof CONTENT_MESSAGE_SIZES)[number];
 
-const contentMessageVariants = cva(
-  "s-flex s-flex-col s-gap-1 s-rounded-xl s-py-4 s-px-5 s-border",
-  {
-    variants: {
-      variant: {
-        primary:
-          "s-bg-muted-background dark:s-bg-muted-background-night s-border-border dark:s-border-border-night",
-        success:
-          "s-bg-success-100 dark:s-bg-success-100-night s-border-transparent",
-        warning:
-          "s-bg-warning-100 dark:s-bg-warning-100-night s-border-transparent",
-        highlight:
-          "s-bg-highlight-100 dark:s-bg-highlight-100-night s-border-transparent",
-        info: "s-bg-info-100 dark:s-bg-info-100-night s-border-transparent",
-        green: "s-bg-green-100 dark:s-bg-green-100-night s-border-transparent",
-        blue: "s-bg-blue-100 dark:s-bg-blue-100-night s-border-transparent",
-        rose: "s-bg-rose-100 dark:s-bg-rose-100-night s-border-transparent",
-        golden:
-          "s-bg-golden-100 dark:s-bg-golden-100-night s-border-transparent",
-        outline: "s-bg-transparent s-border-border dark:s-border-border-night",
-      },
-      size: {
-        lg: "",
-        md: "s-max-w-[500px]",
-        sm: "s-max-w-[380px]",
-      },
+const contentMessageVariants = cva("s-border", {
+  variants: {
+    variant: {
+      primary:
+        "s-bg-muted-background dark:s-bg-muted-background-night s-border-border dark:s-border-border-night",
+      success:
+        "s-bg-success-100 dark:s-bg-success-100-night s-border-transparent",
+      warning:
+        "s-bg-warning-100 dark:s-bg-warning-100-night s-border-transparent",
+      highlight:
+        "s-bg-highlight-100 dark:s-bg-highlight-100-night s-border-transparent",
+      info: "s-bg-info-100 dark:s-bg-info-100-night s-border-transparent",
+      green: "s-bg-green-100 dark:s-bg-green-100-night s-border-transparent",
+      blue: "s-bg-blue-100 dark:s-bg-blue-100-night s-border-transparent",
+      rose: "s-bg-rose-100 dark:s-bg-rose-100-night s-border-transparent",
+      golden: "s-bg-golden-100 dark:s-bg-golden-100-night s-border-transparent",
+      outline: "s-bg-transparent s-border-border dark:s-border-border-night",
     },
-    defaultVariants: {
-      variant: "info",
-      size: "md",
+    size: {
+      lg: "",
+      md: "s-max-w-[500px]",
+      sm: "s-max-w-[380px]",
     },
-  }
-);
+    inline: {
+      true: "s-flex s-items-center s-gap-3 s-rounded-lg s-py-3 s-px-4",
+      false: "s-flex s-flex-col s-gap-1 s-rounded-xl s-py-4 s-px-5",
+    },
+  },
+  defaultVariants: {
+    variant: "info",
+    size: "md",
+    inline: false,
+  },
+});
 
 const iconVariants = cva("s-shrink-0", {
   variants: {
@@ -115,6 +116,8 @@ export interface ContentMessageProps {
   size?: ContentMessageSizeType;
   variant?: ContentMessageVariantType;
   icon?: ComponentType;
+  inline?: boolean;
+  action?: React.ReactNode;
 }
 
 export function ContentMessage({
@@ -124,11 +127,18 @@ export function ContentMessage({
   size = "md",
   className = "",
   icon,
+  inline = false,
+  action,
 }: ContentMessageProps) {
   return (
-    <div className={cn(contentMessageVariants({ variant, size }), className)}>
-      {(icon || title) && (
-        <div className="s-flex s-items-center s-gap-1.5">
+    <div
+      className={cn(
+        contentMessageVariants({ variant, size, inline }),
+        className
+      )}
+    >
+      {inline ? (
+        <>
           {icon && (
             <Icon
               size="xs"
@@ -136,10 +146,32 @@ export function ContentMessage({
               className={iconVariants({ variant })}
             />
           )}
-          {title && <div className={titleVariants({ variant })}>{title}</div>}
-        </div>
+          <div className={cn("s-flex-1", textVariants({ variant }))}>
+            {children}
+          </div>
+          {action && <div className="s-shrink-0">{action}</div>}
+        </>
+      ) : (
+        <>
+          {(icon || title) && (
+            <div className="s-flex s-items-center s-gap-1.5">
+              {icon && (
+                <Icon
+                  size="xs"
+                  visual={icon}
+                  className={iconVariants({ variant })}
+                />
+              )}
+              {title && (
+                <div className={titleVariants({ variant })}>{title}</div>
+              )}
+            </div>
+          )}
+          {children && (
+            <div className={textVariants({ variant })}>{children}</div>
+          )}
+        </>
       )}
-      {children && <div className={textVariants({ variant })}>{children}</div>}
     </div>
   );
 }

--- a/sparkle/src/components/ContentMessage.tsx
+++ b/sparkle/src/components/ContentMessage.tsx
@@ -24,7 +24,6 @@ const CONTENT_MESSAGE_SIZES = ["sm", "md", "lg"] as const;
 
 type ContentMessageSizeType = (typeof CONTENT_MESSAGE_SIZES)[number];
 
-// Shared variant styles
 const sharedVariantStyles = {
   primary:
     "s-bg-muted-background dark:s-bg-muted-background-night s-border-border dark:s-border-border-night",

--- a/sparkle/src/components/ContentMessage.tsx
+++ b/sparkle/src/components/ContentMessage.tsx
@@ -1,6 +1,7 @@
 import { cva } from "class-variance-authority";
 import React, { ComponentType } from "react";
 
+import { Button, ButtonProps } from "@sparkle/components/Button";
 import { Icon } from "@sparkle/components/Icon";
 import { cn } from "@sparkle/lib/utils";
 
@@ -109,6 +110,16 @@ const textVariants = cva("s-text-sm", {
   },
 });
 
+function ContentMessageAction(props: ButtonProps) {
+  return (
+    <Button
+      size="xs"
+      className={cn("s-shrink-0", props.className)}
+      {...props}
+    />
+  );
+}
+
 export interface ContentMessageProps {
   title?: string;
   children?: React.ReactNode;
@@ -117,10 +128,9 @@ export interface ContentMessageProps {
   variant?: ContentMessageVariantType;
   icon?: ComponentType;
   inline?: boolean;
-  action?: React.ReactNode;
 }
 
-export function ContentMessage({
+function ContentMessage({
   title,
   variant = "info",
   children,
@@ -128,8 +138,19 @@ export function ContentMessage({
   className = "",
   icon,
   inline = false,
-  action,
 }: ContentMessageProps) {
+  const childrenArray = React.Children.toArray(children);
+
+  const actionChild = childrenArray.find(
+    (child) =>
+      React.isValidElement(child) && child.type === ContentMessageAction
+  );
+
+  const contentChildren = childrenArray.filter(
+    (child) =>
+      !React.isValidElement(child) || child.type !== ContentMessageAction
+  );
+
   return (
     <div
       className={cn(
@@ -150,12 +171,12 @@ export function ContentMessage({
             {title && (
               <>
                 <span className={titleVariants({ variant })}>{title}</span>
-                {children && ": "}
+                {contentChildren.length > 0 && ": "}
               </>
             )}
-            {children}
+            {contentChildren}
           </div>
-          {action && <div className="s-shrink-0">{action}</div>}
+          {actionChild}
         </>
       ) : (
         <>
@@ -173,11 +194,13 @@ export function ContentMessage({
               )}
             </div>
           )}
-          {children && (
-            <div className={textVariants({ variant })}>{children}</div>
+          {contentChildren.length > 0 && (
+            <div className={textVariants({ variant })}>{contentChildren}</div>
           )}
         </>
       )}
     </div>
   );
 }
+
+export { ContentMessage, ContentMessageAction };

--- a/sparkle/src/components/ContentMessage.tsx
+++ b/sparkle/src/components/ContentMessage.tsx
@@ -153,7 +153,7 @@ function ContentMessage({
         </div>
       )}
       {children && <div className={textVariants({ variant })}>{children}</div>}
-      // TODO(2025-08-13 aubin): Allow passing a ContentMessageAction here.
+      {/* TODO(2025-08-13 aubin): Allow passing a ContentMessageAction here. */}
     </div>
   );
 }
@@ -202,7 +202,7 @@ function ContentMessageInline({
       <div className={cn("s-flex-1", textVariants({ variant }))}>
         {title && <span className={titleVariants({ variant })}>{title}</span>}
         {title && contentChildren.length > 0 && ": "}
-        {contentChildren.length > 0 && <span>{contentChildren}</span>}
+        {contentChildren}
       </div>
       {actionChild}
     </div>

--- a/sparkle/src/components/ContentMessage.tsx
+++ b/sparkle/src/components/ContentMessage.tsx
@@ -169,11 +169,11 @@ function ContentMessageAction(props: ButtonProps) {
 }
 
 export interface ContentMessageInlineProps {
-  children?: React.ReactNode;
+  title?: string;
   className?: string;
+  children?: React.ReactNode;
   variant?: ContentMessageVariantType;
   icon?: ComponentType;
-  title?: string;
 }
 
 function ContentMessageInline({

--- a/sparkle/src/components/ContentMessage.tsx
+++ b/sparkle/src/components/ContentMessage.tsx
@@ -47,7 +47,7 @@ const contentMessageVariants = cva("s-border", {
       sm: "s-max-w-[380px]",
     },
     inline: {
-      true: "s-flex s-items-center s-gap-3 s-rounded-lg s-py-3 s-px-4",
+      true: "s-flex s-items-center s-gap-3 s-rounded-xl s-py-3 s-px-4",
       false: "s-flex s-flex-col s-gap-1 s-rounded-xl s-py-4 s-px-5",
     },
   },

--- a/sparkle/src/components/ContentMessage.tsx
+++ b/sparkle/src/components/ContentMessage.tsx
@@ -184,13 +184,19 @@ function ContentMessageInline({
 }: ContentMessageInlineProps) {
   const childrenArray = React.Children.toArray(children);
 
-  const actionChild = childrenArray.find(
-    (child) =>
-      React.isValidElement(child) && child.type === ContentMessageAction
-  );
-  const contentChildren = childrenArray.filter(
-    (child) =>
-      !React.isValidElement(child) || child.type !== ContentMessageAction
+  const { actionChilds, contentChildren } = childrenArray.reduce(
+    ({ actionChilds, contentChildren }, child) => {
+      if (React.isValidElement(child) && child.type === ContentMessageAction) {
+        actionChilds.push(child);
+      } else {
+        contentChildren.push(child);
+      }
+      return { actionChilds, contentChildren };
+    },
+    {
+      actionChilds: [] as React.ReactNode[],
+      contentChildren: [] as React.ReactNode[],
+    }
   );
 
   return (
@@ -203,7 +209,7 @@ function ContentMessageInline({
         {title && contentChildren.length > 0 && ": "}
         {contentChildren}
       </div>
-      {actionChild}
+      {actionChilds}
     </div>
   );
 }

--- a/sparkle/src/components/ContentMessage.tsx
+++ b/sparkle/src/components/ContentMessage.tsx
@@ -24,40 +24,51 @@ const CONTENT_MESSAGE_SIZES = ["sm", "md", "lg"] as const;
 
 type ContentMessageSizeType = (typeof CONTENT_MESSAGE_SIZES)[number];
 
-const contentMessageVariants = cva("s-border s-rounded-xl s-flex ", {
-  variants: {
-    variant: {
-      primary:
-        "s-bg-muted-background dark:s-bg-muted-background-night s-border-border dark:s-border-border-night",
-      success:
-        "s-bg-success-100 dark:s-bg-success-100-night s-border-transparent",
-      warning:
-        "s-bg-warning-100 dark:s-bg-warning-100-night s-border-transparent",
-      highlight:
-        "s-bg-highlight-100 dark:s-bg-highlight-100-night s-border-transparent",
-      info: "s-bg-info-100 dark:s-bg-info-100-night s-border-transparent",
-      green: "s-bg-green-100 dark:s-bg-green-100-night s-border-transparent",
-      blue: "s-bg-blue-100 dark:s-bg-blue-100-night s-border-transparent",
-      rose: "s-bg-rose-100 dark:s-bg-rose-100-night s-border-transparent",
-      golden: "s-bg-golden-100 dark:s-bg-golden-100-night s-border-transparent",
-      outline: "s-bg-transparent s-border-border dark:s-border-border-night",
+// Shared variant styles
+const sharedVariantStyles = {
+  primary:
+    "s-bg-muted-background dark:s-bg-muted-background-night s-border-border dark:s-border-border-night",
+  success: "s-bg-success-100 dark:s-bg-success-100-night s-border-transparent",
+  warning: "s-bg-warning-100 dark:s-bg-warning-100-night s-border-transparent",
+  highlight:
+    "s-bg-highlight-100 dark:s-bg-highlight-100-night s-border-transparent",
+  info: "s-bg-info-100 dark:s-bg-info-100-night s-border-transparent",
+  green: "s-bg-green-100 dark:s-bg-green-100-night s-border-transparent",
+  blue: "s-bg-blue-100 dark:s-bg-blue-100-night s-border-transparent",
+  rose: "s-bg-rose-100 dark:s-bg-rose-100-night s-border-transparent",
+  golden: "s-bg-golden-100 dark:s-bg-golden-100-night s-border-transparent",
+  outline: "s-bg-transparent s-border-border dark:s-border-border-night",
+};
+
+const contentMessageVariants = cva(
+  "s-flex s-flex-col s-gap-1 s-rounded-xl s-py-4 s-px-5 s-border",
+  {
+    variants: {
+      variant: sharedVariantStyles,
+      size: {
+        lg: "",
+        md: "s-max-w-[500px]",
+        sm: "s-max-w-[380px]",
+      },
     },
-    size: {
-      lg: "",
-      md: "s-max-w-[500px]",
-      sm: "s-max-w-[380px]",
+    defaultVariants: {
+      variant: "info",
+      size: "md",
     },
-    inline: {
-      true: "s-items-center s-gap-3 s-py-3 s-px-4",
-      false: "s-flex-col s-gap-1  s-py-4 s-px-5",
+  }
+);
+
+const contentMessageInlineVariants = cva(
+  "s-flex s-items-center s-gap-3 s-rounded-lg s-py-3 s-px-4 s-border",
+  {
+    variants: {
+      variant: sharedVariantStyles,
     },
-  },
-  defaultVariants: {
-    variant: "info",
-    size: "md",
-    inline: false,
-  },
-});
+    defaultVariants: {
+      variant: "info",
+    },
+  }
+);
 
 const iconVariants = cva("s-shrink-0", {
   variants: {
@@ -110,6 +121,43 @@ const textVariants = cva("s-text-sm", {
   },
 });
 
+export interface ContentMessageProps {
+  title?: string;
+  children?: React.ReactNode;
+  className?: string;
+  size?: ContentMessageSizeType;
+  variant?: ContentMessageVariantType;
+  icon?: ComponentType;
+}
+
+function ContentMessage({
+  title,
+  variant = "info",
+  children,
+  size = "md",
+  className = "",
+  icon,
+}: ContentMessageProps) {
+  return (
+    <div className={cn(contentMessageVariants({ variant, size }), className)}>
+      {(icon || title) && (
+        <div className="s-flex s-items-center s-gap-1.5">
+          {icon && (
+            <Icon
+              size="xs"
+              visual={icon}
+              className={iconVariants({ variant })}
+            />
+          )}
+          {title && <div className={titleVariants({ variant })}>{title}</div>}
+        </div>
+      )}
+      {children && <div className={textVariants({ variant })}>{children}</div>}
+      // TODO(2025-08-13 aubin): Allow passing a ContentMessageAction here.
+    </div>
+  );
+}
+
 function ContentMessageAction(props: ButtonProps) {
   return (
     <Button
@@ -120,87 +168,45 @@ function ContentMessageAction(props: ButtonProps) {
   );
 }
 
-export interface ContentMessageProps {
-  title?: string;
+export interface ContentMessageInlineProps {
   children?: React.ReactNode;
   className?: string;
-  size?: ContentMessageSizeType;
   variant?: ContentMessageVariantType;
   icon?: ComponentType;
-  inline?: boolean;
+  title?: string;
 }
 
-function ContentMessage({
+function ContentMessageInline({
   title,
   variant = "info",
   children,
-  size = "md",
   className = "",
   icon,
-  inline = false,
-}: ContentMessageProps) {
+}: ContentMessageInlineProps) {
   const childrenArray = React.Children.toArray(children);
 
   const actionChild = childrenArray.find(
     (child) =>
       React.isValidElement(child) && child.type === ContentMessageAction
   );
-
   const contentChildren = childrenArray.filter(
     (child) =>
       !React.isValidElement(child) || child.type !== ContentMessageAction
   );
 
   return (
-    <div
-      className={cn(
-        contentMessageVariants({ variant, size, inline }),
-        className
+    <div className={cn(contentMessageInlineVariants({ variant }), className)}>
+      {icon && (
+        <Icon size="xs" visual={icon} className={iconVariants({ variant })} />
       )}
-    >
-      {inline ? (
-        <>
-          {icon && (
-            <Icon
-              size="xs"
-              visual={icon}
-              className={iconVariants({ variant })}
-            />
-          )}
-          <div className={cn("s-flex-1", textVariants({ variant }))}>
-            {title && (
-              <>
-                <span className={titleVariants({ variant })}>{title}</span>
-                {contentChildren.length > 0 && ": "}
-              </>
-            )}
-            {contentChildren}
-          </div>
-          {actionChild}
-        </>
-      ) : (
-        <>
-          {(icon || title) && (
-            <div className="s-flex s-items-center s-gap-1.5">
-              {icon && (
-                <Icon
-                  size="xs"
-                  visual={icon}
-                  className={iconVariants({ variant })}
-                />
-              )}
-              {title && (
-                <div className={titleVariants({ variant })}>{title}</div>
-              )}
-            </div>
-          )}
-          {contentChildren.length > 0 && (
-            <div className={textVariants({ variant })}>{contentChildren}</div>
-          )}
-        </>
-      )}
+      <div className={cn("s-flex-1", textVariants({ variant }))}>
+        {title && <span className={titleVariants({ variant })}>{title}</span>}
+        {title && contentChildren.length > 0 && ": "}
+        {contentChildren.length > 0 && <span>{contentChildren}</span>}
+      </div>
+      {actionChild}
     </div>
   );
 }
 
-export { ContentMessage, ContentMessageAction };
+export { ContentMessage, ContentMessageAction, ContentMessageInline };

--- a/sparkle/src/components/ContentMessage.tsx
+++ b/sparkle/src/components/ContentMessage.tsx
@@ -23,7 +23,7 @@ const CONTENT_MESSAGE_SIZES = ["sm", "md", "lg"] as const;
 
 type ContentMessageSizeType = (typeof CONTENT_MESSAGE_SIZES)[number];
 
-const contentMessageVariants = cva("s-border", {
+const contentMessageVariants = cva("s-border s-rounded-xl s-flex ", {
   variants: {
     variant: {
       primary:
@@ -47,8 +47,8 @@ const contentMessageVariants = cva("s-border", {
       sm: "s-max-w-[380px]",
     },
     inline: {
-      true: "s-flex s-items-center s-gap-3 s-rounded-xl s-py-3 s-px-4",
-      false: "s-flex s-flex-col s-gap-1 s-rounded-xl s-py-4 s-px-5",
+      true: "s-items-center s-gap-3 s-py-3 s-px-4",
+      false: "s-flex-col s-gap-1  s-py-4 s-px-5",
     },
   },
   defaultVariants: {

--- a/sparkle/src/components/ContentMessage.tsx
+++ b/sparkle/src/components/ContentMessage.tsx
@@ -147,6 +147,12 @@ export function ContentMessage({
             />
           )}
           <div className={cn("s-flex-1", textVariants({ variant }))}>
+            {title && (
+              <>
+                <span className={titleVariants({ variant })}>{title}</span>
+                {children && ": "}
+              </>
+            )}
             {children}
           </div>
           {action && <div className="s-shrink-0">{action}</div>}

--- a/sparkle/src/components/index.ts
+++ b/sparkle/src/components/index.ts
@@ -35,7 +35,11 @@ export {
 } from "./Collapsible";
 export { default as ConfettiBackground } from "./ConfettiBackground";
 export { Container } from "./Container";
-export { ContentMessage } from "./ContentMessage";
+export {
+  ContentMessage,
+  ContentMessageAction,
+  ContentMessageInline,
+} from "./ContentMessage";
 export { ContextItem } from "./ContextItem";
 export {
   ConversationContainer,

--- a/sparkle/src/stories/ContentMessage.stories.tsx
+++ b/sparkle/src/stories/ContentMessage.stories.tsx
@@ -175,6 +175,16 @@ export const InlineWithAction: Story = {
   ),
 };
 
+export const InlineWitTwohAction: Story = {
+  render: () => (
+    <ContentMessageInline icon={InformationCircleIcon} variant="info">
+      This is an inline message. It can be used to display a short message.
+      <ContentMessageAction variant="primary" label="Button" />
+      <ContentMessageAction variant="highlight" label="Button" />
+    </ContentMessageInline>
+  ),
+};
+
 export const InlineWithTitle: Story = {
   render: () => (
     <div className="s-flex s-flex-col s-gap-4">

--- a/sparkle/src/stories/ContentMessage.stories.tsx
+++ b/sparkle/src/stories/ContentMessage.stories.tsx
@@ -2,6 +2,7 @@ import type { Meta, StoryObj } from "@storybook/react";
 import React from "react";
 
 import {
+  Button,
   ChatBubbleBottomCenterTextIcon,
   ContentMessage,
   HeartIcon,
@@ -141,6 +142,62 @@ export const ColorVariants: Story = {
         >
           This is a {variant} variant message. It shows how the component looks
           with this color scheme.
+        </ContentMessage>
+      ))}
+    </div>
+  ),
+};
+
+export const InlineBasic: Story = {
+  render: () => (
+    <ContentMessage icon={InformationCircleIcon} variant="info" inline>
+      3 actions require manual approval
+    </ContentMessage>
+  ),
+};
+
+export const InlineWithAction: Story = {
+  render: () => (
+    <ContentMessage 
+      icon={InformationCircleIcon} 
+      variant="info"
+      inline
+      action={<Button size="xs" variant="primary" label="Review actions" />}
+    >
+      3 actions require manual approval
+    </ContentMessage>
+  ),
+};
+
+export const InlineVariants: Story = {
+  render: () => (
+    <div className="s-flex s-flex-col s-gap-4">
+      {[
+        "primary",
+        "warning",
+        "success",
+        "highlight",
+        "info",
+      ].map((variant) => (
+        <ContentMessage
+          key={variant}
+          icon={InformationCircleIcon}
+          variant={
+            variant as
+              | "primary"
+              | "warning"
+              | "success"
+              | "highlight"
+              | "info"
+              | "green"
+              | "blue"
+              | "rose"
+              | "golden"
+          }
+          inline
+          action={<Button size="xs" variant="primary" label="Action" />}
+        >
+          {variant.charAt(0).toUpperCase() + variant.slice(1)} inline message
         </ContentMessage>
       ))}
     </div>

--- a/sparkle/src/stories/ContentMessage.stories.tsx
+++ b/sparkle/src/stories/ContentMessage.stories.tsx
@@ -151,20 +151,20 @@ export const ColorVariants: Story = {
 export const InlineBasic: Story = {
   render: () => (
     <ContentMessage icon={InformationCircleIcon} variant="info" inline>
-      3 actions require manual approval
+      This is an inline message. It can be used to display a short message.
     </ContentMessage>
   ),
 };
 
 export const InlineWithAction: Story = {
   render: () => (
-    <ContentMessage 
-      icon={InformationCircleIcon} 
+    <ContentMessage
+      icon={InformationCircleIcon}
       variant="info"
       inline
-      action={<Button size="xs" variant="primary" label="Review actions" />}
+      action={<Button size="xs" variant="primary" label="Button" />}
     >
-      3 actions require manual approval
+      This is an inline message. It can be used to display a short message.
     </ContentMessage>
   ),
 };
@@ -172,18 +172,18 @@ export const InlineWithAction: Story = {
 export const InlineWithTitle: Story = {
   render: () => (
     <div className="s-flex s-flex-col s-gap-4">
-      <ContentMessage 
+      <ContentMessage
         title="Status"
-        icon={InformationCircleIcon} 
+        icon={InformationCircleIcon}
         variant="info"
         inline
-        action={<Button size="xs" variant="primary" label="Review actions" />}
+        action={<Button size="xs" variant="primary" label="Button" />}
       >
-        3 actions require manual approval
+        This is an inline message.
       </ContentMessage>
-      <ContentMessage 
+      <ContentMessage
         title="Alert"
-        icon={InformationCircleIcon} 
+        icon={InformationCircleIcon}
         variant="warning"
         inline
       />
@@ -194,13 +194,7 @@ export const InlineWithTitle: Story = {
 export const InlineVariants: Story = {
   render: () => (
     <div className="s-flex s-flex-col s-gap-4">
-      {[
-        "primary",
-        "warning",
-        "success",
-        "highlight",
-        "info",
-      ].map((variant) => (
+      {["primary", "warning", "success", "highlight", "info"].map((variant) => (
         <ContentMessage
           key={variant}
           icon={InformationCircleIcon}

--- a/sparkle/src/stories/ContentMessage.stories.tsx
+++ b/sparkle/src/stories/ContentMessage.stories.tsx
@@ -1,8 +1,9 @@
 import type { Meta, StoryObj } from "@storybook/react";
 import React from "react";
 
+import { ContentMessageAction } from "@sparkle/components/ContentMessage";
+
 import {
-  Button,
   ChatBubbleBottomCenterTextIcon,
   ContentMessage,
   HeartIcon,
@@ -158,13 +159,9 @@ export const InlineBasic: Story = {
 
 export const InlineWithAction: Story = {
   render: () => (
-    <ContentMessage
-      icon={InformationCircleIcon}
-      variant="info"
-      inline
-      action={<Button size="xs" variant="primary" label="Button" />}
-    >
+    <ContentMessage icon={InformationCircleIcon} variant="info" inline>
       This is an inline message. It can be used to display a short message.
+      <ContentMessageAction variant="primary" label="Button" />
     </ContentMessage>
   ),
 };
@@ -177,9 +174,9 @@ export const InlineWithTitle: Story = {
         icon={InformationCircleIcon}
         variant="info"
         inline
-        action={<Button size="xs" variant="primary" label="Button" />}
       >
         This is an inline message.
+        <ContentMessageAction variant="primary" label="Button" />
       </ContentMessage>
       <ContentMessage
         title="Alert"
@@ -211,9 +208,9 @@ export const InlineVariants: Story = {
               | "golden"
           }
           inline
-          action={<Button size="xs" variant="primary" label="Action" />}
         >
           {variant.charAt(0).toUpperCase() + variant.slice(1)} inline message
+          <ContentMessageAction variant="primary" label="Action" />
         </ContentMessage>
       ))}
     </div>

--- a/sparkle/src/stories/ContentMessage.stories.tsx
+++ b/sparkle/src/stories/ContentMessage.stories.tsx
@@ -169,6 +169,28 @@ export const InlineWithAction: Story = {
   ),
 };
 
+export const InlineWithTitle: Story = {
+  render: () => (
+    <div className="s-flex s-flex-col s-gap-4">
+      <ContentMessage 
+        title="Status"
+        icon={InformationCircleIcon} 
+        variant="info"
+        inline
+        action={<Button size="xs" variant="primary" label="Review actions" />}
+      >
+        3 actions require manual approval
+      </ContentMessage>
+      <ContentMessage 
+        title="Alert"
+        icon={InformationCircleIcon} 
+        variant="warning"
+        inline
+      />
+    </div>
+  ),
+};
+
 export const InlineVariants: Story = {
   render: () => (
     <div className="s-flex s-flex-col s-gap-4">

--- a/sparkle/src/stories/ContentMessage.stories.tsx
+++ b/sparkle/src/stories/ContentMessage.stories.tsx
@@ -1,11 +1,11 @@
 import type { Meta, StoryObj } from "@storybook/react";
 import React from "react";
 
-import { ContentMessageAction } from "@sparkle/components/ContentMessage";
-
 import {
   ChatBubbleBottomCenterTextIcon,
   ContentMessage,
+  ContentMessageAction,
+  ContentMessageInline,
   HeartIcon,
   InformationCircleIcon,
 } from "../index_with_tw_base";
@@ -65,6 +65,15 @@ type Story = StoryObj<typeof meta>;
 export const Basic: Story = {
   args: {
     title: "This is a title",
+    children: "This is a message. It can be multiple lines long.",
+    size: "md",
+  },
+};
+
+export const WithIcon: Story = {
+  args: {
+    title: "This is a title",
+    icon: InformationCircleIcon,
     children: "This is a message. It can be multiple lines long.",
     size: "md",
   },
@@ -151,38 +160,36 @@ export const ColorVariants: Story = {
 
 export const InlineBasic: Story = {
   render: () => (
-    <ContentMessage icon={InformationCircleIcon} variant="info" inline>
+    <ContentMessageInline icon={InformationCircleIcon} variant="info">
       This is an inline message. It can be used to display a short message.
-    </ContentMessage>
+    </ContentMessageInline>
   ),
 };
 
 export const InlineWithAction: Story = {
   render: () => (
-    <ContentMessage icon={InformationCircleIcon} variant="info" inline>
+    <ContentMessageInline icon={InformationCircleIcon} variant="info">
       This is an inline message. It can be used to display a short message.
       <ContentMessageAction variant="primary" label="Button" />
-    </ContentMessage>
+    </ContentMessageInline>
   ),
 };
 
 export const InlineWithTitle: Story = {
   render: () => (
     <div className="s-flex s-flex-col s-gap-4">
-      <ContentMessage
+      <ContentMessageInline
         title="Status"
         icon={InformationCircleIcon}
         variant="info"
-        inline
       >
         This is an inline message.
         <ContentMessageAction variant="primary" label="Button" />
-      </ContentMessage>
-      <ContentMessage
+      </ContentMessageInline>
+      <ContentMessageInline
         title="Alert"
         icon={InformationCircleIcon}
         variant="warning"
-        inline
       />
     </div>
   ),
@@ -192,7 +199,7 @@ export const InlineVariants: Story = {
   render: () => (
     <div className="s-flex s-flex-col s-gap-4">
       {["primary", "warning", "success", "highlight", "info"].map((variant) => (
-        <ContentMessage
+        <ContentMessageInline
           key={variant}
           icon={InformationCircleIcon}
           variant={
@@ -207,11 +214,10 @@ export const InlineVariants: Story = {
               | "rose"
               | "golden"
           }
-          inline
         >
           {variant.charAt(0).toUpperCase() + variant.slice(1)} inline message
           <ContentMessageAction variant="primary" label="Action" />
-        </ContentMessage>
+        </ContentMessageInline>
       ))}
     </div>
   ),

--- a/sparkle/src/stories/ContentMessage.stories.tsx
+++ b/sparkle/src/stories/ContentMessage.stories.tsx
@@ -175,7 +175,7 @@ export const InlineWithAction: Story = {
   ),
 };
 
-export const InlineWitTwohAction: Story = {
+export const InlineWithTwoActions: Story = {
   render: () => (
     <ContentMessageInline icon={InformationCircleIcon} variant="info">
       This is an inline message. It can be used to display a short message.


### PR DESCRIPTION
## Description

- This PR adds an inline version of the `ContentMessage` component.
- Figma [here](https://www.figma.com/design/QOxHwppG64GtPocpDhS6Y7/Product---Core?node-id=17320-158718&p=f&t=XDkSqBbvciKTdS4S-0).
- This component will be used very soon to alert the user of pending tool validation approvals in a conversation.

<img width="838" height="984" alt="Screenshot 2025-08-13 at 12 38 00 PM" src="https://github.com/user-attachments/assets/67365fc9-afdb-41c2-9672-db6f1c3d6c9c" />

## Tests

- Checked on storybook.

## Risk

- N/A, doesn't change the component for current uses.

## Deploy Plan

- Unsure
