### PR TITLE
Add Slack semantic search, under a flag

### DIFF
--- a/front/lib/actions/mcp_internal_actions/constants.ts
+++ b/front/lib/actions/mcp_internal_actions/constants.ts
@@ -341,6 +341,7 @@ export const INTERNAL_MCP_SERVERS = {
     isPreview: false,
     tools_stakes: {
       search_messages: "never_ask",
+      semantic_search_messages: "never_ask",
       list_users: "never_ask",
       list_public_channels: "never_ask",
       list_threads: "never_ask",

--- a/front/lib/actions/mcp_internal_actions/servers/slack.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/slack.ts
@@ -439,7 +439,6 @@ const createServer = async (
             searchQuery = `${searchQuery} ${usersMentioned.map((user) => `${user}`).join(" ")}`;
           }
 
-          console.log(`Searching Slack with query: ${searchQuery}`);
           const messages = await slackClient.search.messages({
             query: searchQuery,
             sort: "score",

--- a/front/lib/actions/mcp_internal_actions/servers/slack.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/slack.ts
@@ -23,6 +23,7 @@ import { getRefs } from "@app/lib/api/assistant/citations";
 import config from "@app/lib/api/config";
 import type { InternalMCPServerDefinitionType } from "@app/lib/api/mcp";
 import type { Authenticator } from "@app/lib/auth";
+import { getFeatureFlags } from "@app/lib/auth";
 import { removeDiacritics } from "@app/lib/utils";
 import { concurrentExecutor } from "@app/lib/utils/async_utils";
 import type { TimeFrame } from "@app/types";
@@ -98,10 +99,10 @@ function isSlackTokenRevoked(error: unknown): boolean {
   );
 }
 
-const createServer = (
+const createServer = async (
   auth: Authenticator,
   agentLoopContext?: AgentLoopContextType
-): McpServer => {
+): Promise<McpServer> => {
   const server = new McpServer(serverInfo, {
     instructions:
       "When posting a message on slack, you MUST use slack-flavored markdown to format the message." +
@@ -110,427 +111,440 @@ const createServer = (
       "NEVER use the channel name or the user name directly in a message as it will not be parsed correctly and appear as plain text.",
   });
 
-  server.tool(
-    "search_messages",
-    "Search messages accross all channels and dms for the current user",
-    {
-      keywords: z
-        .string()
-        .array()
-        .min(1)
-        .describe(
-          "Between 1 and 3 keywords to retrieve relevant messages " +
-            "based on the user request and conversation context."
-        ),
-      channels: z
-        .string()
-        .array()
-        .optional()
-        .describe("Narrow the search to a specific channels names (optional)"),
-      usersFrom: z
-        .string()
-        .array()
-        .optional()
-        .describe(
-          "Narrow the search to messages wrote by specific users ids (optional)"
-        ),
-      usersTo: z
-        .string()
-        .array()
-        .optional()
-        .describe(
-          "Narrow the search to direct messages sent to specific users ids (optional)"
-        ),
-      usersMentioned: z
-        .string()
-        .array()
-        .optional()
-        .describe(
-          "Narrow the search to messages mentioning specific users ids (optional)"
-        ),
-      relativeTimeFrame: z
-        .string()
-        .regex(/^(all|\d+[hdwmy])$/)
-        .describe(
-          "The time frame (relative to LOCAL_TIME) to restrict the search based" +
-            " on the user request and past conversation context." +
-            " Possible values are: `all`, `{k}h`, `{k}d`, `{k}w`, `{k}m`, `{k}y`" +
-            " where {k} is a number. Be strict, do not invent invalid values."
-        ),
-    },
-    async (
+  if (
+    !(await getFeatureFlags(auth.getNonNullableWorkspace())).includes(
+      "slack_semantic_search"
+    )
+  ) {
+    server.tool(
+      "search_messages",
+      "Search messages accross all channels and dms for the current user",
       {
-        keywords,
-        usersFrom,
-        usersTo,
-        usersMentioned,
-        relativeTimeFrame,
-        channels,
+        keywords: z
+          .string()
+          .array()
+          .min(1)
+          .describe(
+            "Between 1 and 3 keywords to retrieve relevant messages " +
+              "based on the user request and conversation context."
+          ),
+        channels: z
+          .string()
+          .array()
+          .optional()
+          .describe(
+            "Narrow the search to a specific channels names (optional)"
+          ),
+        usersFrom: z
+          .string()
+          .array()
+          .optional()
+          .describe(
+            "Narrow the search to messages wrote by specific users ids (optional)"
+          ),
+        usersTo: z
+          .string()
+          .array()
+          .optional()
+          .describe(
+            "Narrow the search to direct messages sent to specific users ids (optional)"
+          ),
+        usersMentioned: z
+          .string()
+          .array()
+          .optional()
+          .describe(
+            "Narrow the search to messages mentioning specific users ids (optional)"
+          ),
+        relativeTimeFrame: z
+          .string()
+          .regex(/^(all|\d+[hdwmy])$/)
+          .describe(
+            "The time frame (relative to LOCAL_TIME) to restrict the search based" +
+              " on the user request and past conversation context." +
+              " Possible values are: `all`, `{k}h`, `{k}d`, `{k}w`, `{k}m`, `{k}y`" +
+              " where {k} is a number. Be strict, do not invent invalid values."
+          ),
       },
-      { authInfo }
-    ) => {
-      if (!agentLoopContext?.runContext) {
-        throw new Error("Unreachable: missing agentLoopRunContext.");
-      }
-
-      if (keywords.length > 5) {
-        return makeMCPToolTextError(
-          "The search query is too broad. Please reduce the number of keywords to 5 or less."
-        );
-      }
-
-      const accessToken = authInfo?.token;
-      const slackClient = await getSlackClient(accessToken);
-
-      const timeFrame = parseTimeFrame(relativeTimeFrame);
-
-      try {
-        // Search in slack only support AND queries which can easily return 0 hits.
-        // To avoid this, we'll simulate an OR query by searching for each keyword separately.
-        // Then we will aggregate the results.
-        const results: Match[][] = await concurrentExecutor(
+      async (
+        {
           keywords,
-          async (keyword) => {
-            let query = keyword;
+          usersFrom,
+          usersTo,
+          usersMentioned,
+          relativeTimeFrame,
+          channels,
+        },
+        { authInfo }
+      ) => {
+        if (!agentLoopContext?.runContext) {
+          throw new Error("Unreachable: missing agentLoopRunContext.");
+        }
 
-            if (timeFrame) {
-              const timestampInMs = timeFrameFromNow(timeFrame);
-              const date = new Date(timestampInMs);
-              query = `${query} after:${date.getFullYear()}-${date.getMonth() + 1}-${date.getDate()}`;
-            }
+        if (keywords.length > 5) {
+          return makeMCPToolTextError(
+            "The search query is too broad. Please reduce the number of keywords to 5 or less."
+          );
+        }
 
-            if (channels && channels.length > 0) {
-              query = `${query} ${channels
-                .map((channel) =>
-                  channel.charAt(0) === "#" ? `in:${channel}` : `in:#${channel}`
-                )
-                .join(" ")}`;
-            }
+        const accessToken = authInfo?.token;
+        const slackClient = await getSlackClient(accessToken);
 
-            if (usersFrom && usersFrom.length > 0) {
-              query = `${query} ${usersFrom.map((user) => `from:${user}`).join(" ")}`;
-            }
+        const timeFrame = parseTimeFrame(relativeTimeFrame);
 
-            if (usersTo && usersTo.length > 0) {
-              query = `${query} ${usersTo.map((user) => `to:${user}`).join(" ")}`;
-            }
+        try {
+          // Search in slack only support AND queries which can easily return 0 hits.
+          // To avoid this, we'll simulate an OR query by searching for each keyword separately.
+          // Then we will aggregate the results.
+          const results: Match[][] = await concurrentExecutor(
+            keywords,
+            async (keyword) => {
+              let query = keyword;
 
-            if (usersMentioned && usersMentioned.length > 0) {
-              query = `${query} ${usersMentioned.map((user) => `${user}`).join(" ")}`;
-            }
+              if (timeFrame) {
+                const timestampInMs = timeFrameFromNow(timeFrame);
+                const date = new Date(timestampInMs);
+                query = `${query} after:${date.getFullYear()}-${date.getMonth() + 1}-${date.getDate()}`;
+              }
 
-            const messages = await slackClient.search.messages({
-              query,
-              sort: "score",
-              sort_dir: "desc",
-              highlight: false,
-              count: SLACK_SEARCH_ACTION_NUM_RESULTS,
-              page: 1,
-            });
+              if (channels && channels.length > 0) {
+                query = `${query} ${channels
+                  .map((channel) =>
+                    channel.charAt(0) === "#"
+                      ? `in:${channel}`
+                      : `in:#${channel}`
+                  )
+                  .join(" ")}`;
+              }
 
-            if (!messages.ok) {
-              throw new Error(messages.error);
-            }
+              if (usersFrom && usersFrom.length > 0) {
+                query = `${query} ${usersFrom.map((user) => `from:${user}`).join(" ")}`;
+              }
 
-            return messages.messages?.matches ?? [];
-          },
-          { concurrency: 3 }
-        );
+              if (usersTo && usersTo.length > 0) {
+                query = `${query} ${usersTo.map((user) => `to:${user}`).join(" ")}`;
+              }
 
-        // Flatten the results, order by score descending.
-        const rawMatches = results
-          .flat()
-          .sort((a, b) => (b.score ?? 0) - (a.score ?? 0));
+              if (usersMentioned && usersMentioned.length > 0) {
+                query = `${query} ${usersMentioned.map((user) => `${user}`).join(" ")}`;
+              }
 
-        // Filter out matches that don't have a text.
-        const matchesWithText = rawMatches.filter((match) => !!match.text);
+              const messages = await slackClient.search.messages({
+                query,
+                sort: "score",
+                sort_dir: "desc",
+                highlight: false,
+                count: SLACK_SEARCH_ACTION_NUM_RESULTS,
+                page: 1,
+              });
 
-        // Deduplicate matches by their iid.
-        const deduplicatedMatches = uniqBy(matchesWithText, "iid");
+              if (!messages.ok) {
+                throw new Error(messages.error);
+              }
 
-        // Keep only the top SLACK_SEARCH_ACTION_NUM_RESULTS matches.
-        const matches = deduplicatedMatches.slice(
-          0,
-          SLACK_SEARCH_ACTION_NUM_RESULTS
-        );
-
-        if (matches.length === 0) {
-          return {
-            isError: false,
-            content: [
-              {
-                type: "text" as const,
-                text: `No messages found.`,
-              },
-              {
-                type: "resource" as const,
-                resource: makeQueryResource(
-                  keywords,
-                  timeFrame,
-                  channels,
-                  usersFrom,
-                  usersTo,
-                  usersMentioned
-                ),
-              },
-            ],
-          };
-        } else {
-          const { citationsOffset } = agentLoopContext.runContext.stepContext;
-
-          const refs = getRefs().slice(
-            citationsOffset,
-            citationsOffset + SLACK_SEARCH_ACTION_NUM_RESULTS
+              return messages.messages?.matches ?? [];
+            },
+            { concurrency: 3 }
           );
 
-          const results: SearchResultResourceType[] = matches.map(
-            (match): SearchResultResourceType => {
-              return {
-                mimeType:
-                  INTERNAL_MIME_TYPES.TOOL_OUTPUT.DATA_SOURCE_SEARCH_RESULT,
-                uri: match.permalink ?? "",
-                text: `#${match.channel?.name ?? "Unknown"}, ${match.text ?? ""}`,
+          // Flatten the results, order by score descending.
+          const rawMatches = results
+            .flat()
+            .sort((a, b) => (b.score ?? 0) - (a.score ?? 0));
 
-                id: match.ts ?? "",
-                source: {
-                  provider: "slack",
+          // Filter out matches that don't have a text.
+          const matchesWithText = rawMatches.filter((match) => !!match.text);
+
+          // Deduplicate matches by their iid.
+          const deduplicatedMatches = uniqBy(matchesWithText, "iid");
+
+          // Keep only the top SLACK_SEARCH_ACTION_NUM_RESULTS matches.
+          const matches = deduplicatedMatches.slice(
+            0,
+            SLACK_SEARCH_ACTION_NUM_RESULTS
+          );
+
+          if (matches.length === 0) {
+            return {
+              isError: false,
+              content: [
+                {
+                  type: "text" as const,
+                  text: `No messages found.`,
                 },
-                tags: [],
-                ref: refs.shift() as string,
-                chunks: [stripNullBytes(match.text ?? "")],
-              };
-            }
-          );
+                {
+                  type: "resource" as const,
+                  resource: makeQueryResource(
+                    keywords,
+                    timeFrame,
+                    channels,
+                    usersFrom,
+                    usersTo,
+                    usersMentioned
+                  ),
+                },
+              ],
+            };
+          } else {
+            const { citationsOffset } = agentLoopContext.runContext.stepContext;
 
-          return {
-            isError: false,
-            content: [
-              ...results.map((result) => ({
-                type: "resource" as const,
-                resource: result,
-              })),
-              {
-                type: "resource" as const,
-                resource: makeQueryResource(
-                  keywords,
-                  timeFrame,
-                  channels,
-                  usersFrom,
-                  usersTo,
-                  usersMentioned
-                ),
-              },
-            ],
-          };
+            const refs = getRefs().slice(
+              citationsOffset,
+              citationsOffset + SLACK_SEARCH_ACTION_NUM_RESULTS
+            );
+
+            const results: SearchResultResourceType[] = matches.map(
+              (match): SearchResultResourceType => {
+                return {
+                  mimeType:
+                    INTERNAL_MIME_TYPES.TOOL_OUTPUT.DATA_SOURCE_SEARCH_RESULT,
+                  uri: match.permalink ?? "",
+                  text: `#${match.channel?.name ?? "Unknown"}, ${match.text ?? ""}`,
+
+                  id: match.ts ?? "",
+                  source: {
+                    provider: "slack",
+                  },
+                  tags: [],
+                  ref: refs.shift() as string,
+                  chunks: [stripNullBytes(match.text ?? "")],
+                };
+              }
+            );
+
+            return {
+              isError: false,
+              content: [
+                ...results.map((result) => ({
+                  type: "resource" as const,
+                  resource: result,
+                })),
+                {
+                  type: "resource" as const,
+                  resource: makeQueryResource(
+                    keywords,
+                    timeFrame,
+                    channels,
+                    usersFrom,
+                    usersTo,
+                    usersMentioned
+                  ),
+                },
+              ],
+            };
+          }
+        } catch (error) {
+          if (isSlackTokenRevoked(error)) {
+            return makePersonalAuthenticationError({ serverInfo });
+          }
+          return makeMCPToolTextError(`Error searching messages: ${error}`);
         }
-      } catch (error) {
-        if (isSlackTokenRevoked(error)) {
-          return makePersonalAuthenticationError({ serverInfo });
-        }
-        return makeMCPToolTextError(`Error searching messages: ${error}`);
       }
-    }
-  );
-
-  server.tool(
-    "semantic_search_messages",
-    "Use semantic search to find messages across all channels and DMs for the current user",
-    {
-      query: z
-        .string()
-        .describe(
-          "A query to retrieve relevant messages based on the user request and conversation context. For it to be treated as semantic search, make sure it begins with a question word such as what, where, how, etc, and ends with a question mark. If the user asks to limit to certain channels, don't make them part of this query. Instead, use the `channels` parameter to limit the search to specific channels. But only do this if the user explicitly asks for it, otherwise, the search will be more effective if you don't limit it to specific channels."
-        ),
-      channels: z
-        .string()
-        .array()
-        .optional()
-        .describe("Narrow the search to a specific channels names (optional)"),
-      usersFrom: z
-        .string()
-        .array()
-        .optional()
-        .describe(
-          "Narrow the search to messages wrote by specific users ids (optional)"
-        ),
-      usersTo: z
-        .string()
-        .array()
-        .optional()
-        .describe(
-          "Narrow the search to direct messages sent to specific user IDs (optional)"
-        ),
-      usersMentioned: z
-        .string()
-        .array()
-        .optional()
-        .describe(
-          "Narrow the search to messages mentioning specific users ids (optional)"
-        ),
-      relativeTimeFrame: z
-        .string()
-        .regex(/^(all|\d+[hdwmy])$/)
-        .describe(
-          "The time frame (relative to LOCAL_TIME) to restrict the search based" +
-            " on the user request and past conversation context." +
-            " Possible values are: `all`, `{k}h`, `{k}d`, `{k}w`, `{k}m`, `{k}y`" +
-            " where {k} is a number. Be strict, do not invent invalid values."
-        ),
-    },
-    async (
+    );
+  } else {
+    server.tool(
+      "semantic_search_messages",
+      "Use semantic search to find messages across all channels and DMs for the current user",
       {
-        query,
-        usersFrom,
-        usersTo,
-        usersMentioned,
-        relativeTimeFrame,
-        channels,
+        query: z
+          .string()
+          .describe(
+            "A query to retrieve relevant messages based on the user request and conversation context. For it to be treated as semantic search, make sure it begins with a question word such as what, where, how, etc, and ends with a question mark. If the user asks to limit to certain channels, don't make them part of this query. Instead, use the `channels` parameter to limit the search to specific channels. But only do this if the user explicitly asks for it, otherwise, the search will be more effective if you don't limit it to specific channels."
+          ),
+        channels: z
+          .string()
+          .array()
+          .optional()
+          .describe(
+            "Narrow the search to a specific channels names (optional)"
+          ),
+        usersFrom: z
+          .string()
+          .array()
+          .optional()
+          .describe(
+            "Narrow the search to messages wrote by specific users ids (optional)"
+          ),
+        usersTo: z
+          .string()
+          .array()
+          .optional()
+          .describe(
+            "Narrow the search to direct messages sent to specific user IDs (optional)"
+          ),
+        usersMentioned: z
+          .string()
+          .array()
+          .optional()
+          .describe(
+            "Narrow the search to messages mentioning specific users ids (optional)"
+          ),
+        relativeTimeFrame: z
+          .string()
+          .regex(/^(all|\d+[hdwmy])$/)
+          .describe(
+            "The time frame (relative to LOCAL_TIME) to restrict the search based" +
+              " on the user request and past conversation context." +
+              " Possible values are: `all`, `{k}h`, `{k}d`, `{k}w`, `{k}m`, `{k}y`" +
+              " where {k} is a number. Be strict, do not invent invalid values." +
+              " Also, do not pass this unless the user explicitly asks for some timeframe."
+          ),
       },
-      { authInfo }
-    ) => {
-      if (!agentLoopContext?.runContext) {
-        throw new Error("Unreachable: missing agentLoopRunContext.");
-      }
-
-      const accessToken = authInfo?.token;
-      const slackClient = await getSlackClient(accessToken);
-
-      const timeFrame = parseTimeFrame(relativeTimeFrame);
-
-      try {
-        let searchQuery = query;
-
-        if (timeFrame) {
-          const timestampInMs = timeFrameFromNow(timeFrame);
-          const date = new Date(timestampInMs);
-          searchQuery = `${searchQuery} after:${date.getFullYear()}-${date.getMonth() + 1}-${date.getDate()}`;
+      async (
+        {
+          query,
+          usersFrom,
+          usersTo,
+          usersMentioned,
+          relativeTimeFrame,
+          channels,
+        },
+        { authInfo }
+      ) => {
+        if (!agentLoopContext?.runContext) {
+          throw new Error("Unreachable: missing agentLoopRunContext.");
         }
 
-        if (channels && channels.length > 0) {
-          searchQuery = `${searchQuery} ${channels
-            .map((channel) =>
-              channel.charAt(0) === "#" ? `in:${channel}` : `in:#${channel}`
-            )
-            .join(" ")}`;
-        }
+        const accessToken = authInfo?.token;
+        const slackClient = await getSlackClient(accessToken);
 
-        if (usersFrom && usersFrom.length > 0) {
-          searchQuery = `${searchQuery} ${usersFrom.map((user) => `from:${user}`).join(" ")}`;
-        }
+        const timeFrame = parseTimeFrame(relativeTimeFrame);
 
-        if (usersTo && usersTo.length > 0) {
-          searchQuery = `${searchQuery} ${usersTo.map((user) => `to:${user}`).join(" ")}`;
-        }
+        try {
+          let searchQuery = query;
 
-        if (usersMentioned && usersMentioned.length > 0) {
-          searchQuery = `${searchQuery} ${usersMentioned.map((user) => `${user}`).join(" ")}`;
-        }
+          if (timeFrame) {
+            const timestampInMs = timeFrameFromNow(timeFrame);
+            const date = new Date(timestampInMs);
+            searchQuery = `${searchQuery} after:${date.getFullYear()}-${date.getMonth() + 1}-${date.getDate()}`;
+          }
 
-        console.log(`Searching Slack with query: ${searchQuery}`);
-        const messages = await slackClient.search.messages({
-          query: searchQuery,
-          sort: "score",
-          sort_dir: "desc",
-          highlight: false,
-          count: SLACK_SEARCH_ACTION_NUM_RESULTS,
-          page: 1,
-        });
+          if (channels && channels.length > 0) {
+            searchQuery = `${searchQuery} ${channels
+              .map((channel) =>
+                channel.charAt(0) === "#" ? `in:${channel}` : `in:#${channel}`
+              )
+              .join(" ")}`;
+          }
 
-        if (!messages.ok) {
-          throw new Error(messages.error);
-        }
+          if (usersFrom && usersFrom.length > 0) {
+            searchQuery = `${searchQuery} ${usersFrom.map((user) => `from:${user}`).join(" ")}`;
+          }
 
-        const rawMatches = messages.messages?.matches ?? [];
+          if (usersTo && usersTo.length > 0) {
+            searchQuery = `${searchQuery} ${usersTo.map((user) => `to:${user}`).join(" ")}`;
+          }
 
-        // Filter out matches that don't have a text.
-        const matchesWithText = rawMatches.filter((match) => !!match.text);
+          if (usersMentioned && usersMentioned.length > 0) {
+            searchQuery = `${searchQuery} ${usersMentioned.map((user) => `${user}`).join(" ")}`;
+          }
 
-        // Deduplicate matches by their iid.
-        const deduplicatedMatches = uniqBy(matchesWithText, "iid");
+          console.log(`Searching Slack with query: ${searchQuery}`);
+          const messages = await slackClient.search.messages({
+            query: searchQuery,
+            sort: "score",
+            sort_dir: "desc",
+            highlight: false,
+            count: SLACK_SEARCH_ACTION_NUM_RESULTS,
+            page: 1,
+          });
 
-        // Keep only the top SLACK_SEARCH_ACTION_NUM_RESULTS matches.
-        const matches = deduplicatedMatches.slice(
-          0,
-          SLACK_SEARCH_ACTION_NUM_RESULTS
-        );
+          if (!messages.ok) {
+            throw new Error(messages.error);
+          }
 
-        if (matches.length === 0) {
-          return {
-            isError: false,
-            content: [
-              {
-                type: "text" as const,
-                text: `No messages found.`,
-              },
-              {
-                type: "resource" as const,
-                resource: makeQueryResource(
-                  [query],
-                  timeFrame,
-                  channels,
-                  usersFrom,
-                  usersTo,
-                  usersMentioned
-                ),
-              },
-            ],
-          };
-        } else {
-          const { citationsOffset } = agentLoopContext.runContext.stepContext;
+          const rawMatches = messages.messages?.matches ?? [];
 
-          const refs = getRefs().slice(
-            citationsOffset,
-            citationsOffset + SLACK_SEARCH_ACTION_NUM_RESULTS
+          // Filter out matches that don't have a text.
+          const matchesWithText = rawMatches.filter((match) => !!match.text);
+
+          // Deduplicate matches by their iid.
+          const deduplicatedMatches = uniqBy(matchesWithText, "iid");
+
+          // Keep only the top SLACK_SEARCH_ACTION_NUM_RESULTS matches.
+          const matches = deduplicatedMatches.slice(
+            0,
+            SLACK_SEARCH_ACTION_NUM_RESULTS
           );
 
-          const results: SearchResultResourceType[] = matches.map(
-            (match): SearchResultResourceType => {
-              return {
-                mimeType:
-                  INTERNAL_MIME_TYPES.TOOL_OUTPUT.DATA_SOURCE_SEARCH_RESULT,
-                uri: match.permalink ?? "",
-                text: `#${match.channel?.name ?? "Unknown"}, ${match.text ?? ""}`,
-
-                id: match.ts ?? "",
-                source: {
-                  provider: "slack",
+          if (matches.length === 0) {
+            return {
+              isError: false,
+              content: [
+                {
+                  type: "text" as const,
+                  text: `No messages found.`,
                 },
-                tags: [],
-                ref: refs.shift() as string,
-                chunks: [stripNullBytes(match.text ?? "")],
-              };
-            }
-          );
+                {
+                  type: "resource" as const,
+                  resource: makeQueryResource(
+                    [query],
+                    timeFrame,
+                    channels,
+                    usersFrom,
+                    usersTo,
+                    usersMentioned
+                  ),
+                },
+              ],
+            };
+          } else {
+            const { citationsOffset } = agentLoopContext.runContext.stepContext;
 
-          return {
-            isError: false,
-            content: [
-              ...results.map((result) => ({
-                type: "resource" as const,
-                resource: result,
-              })),
-              {
-                type: "resource" as const,
-                resource: makeQueryResource(
-                  [query],
-                  timeFrame,
-                  channels,
-                  usersFrom,
-                  usersTo,
-                  usersMentioned
-                ),
-              },
-            ],
-          };
+            const refs = getRefs().slice(
+              citationsOffset,
+              citationsOffset + SLACK_SEARCH_ACTION_NUM_RESULTS
+            );
+
+            const results: SearchResultResourceType[] = matches.map(
+              (match): SearchResultResourceType => {
+                return {
+                  mimeType:
+                    INTERNAL_MIME_TYPES.TOOL_OUTPUT.DATA_SOURCE_SEARCH_RESULT,
+                  uri: match.permalink ?? "",
+                  text: `#${match.channel?.name ?? "Unknown"}, ${match.text ?? ""}`,
+
+                  id: match.ts ?? "",
+                  source: {
+                    provider: "slack",
+                  },
+                  tags: [],
+                  ref: refs.shift() as string,
+                  chunks: [stripNullBytes(match.text ?? "")],
+                };
+              }
+            );
+
+            return {
+              isError: false,
+              content: [
+                ...results.map((result) => ({
+                  type: "resource" as const,
+                  resource: result,
+                })),
+                {
+                  type: "resource" as const,
+                  resource: makeQueryResource(
+                    [query],
+                    timeFrame,
+                    channels,
+                    usersFrom,
+                    usersTo,
+                    usersMentioned
+                  ),
+                },
+              ],
+            };
+          }
+        } catch (error) {
+          if (isSlackTokenRevoked(error)) {
+            return makePersonalAuthenticationError({ serverInfo });
+          }
+          return makeMCPToolTextError(`Error searching messages: ${error}`);
         }
-      } catch (error) {
-        if (isSlackTokenRevoked(error)) {
-          return makePersonalAuthenticationError({ serverInfo });
-        }
-        return makeMCPToolTextError(`Error searching messages: ${error}`);
       }
-    }
-  );
+    );
+  }
 
   server.tool(
     "list_threads",

--- a/front/types/shared/feature_flags.ts
+++ b/front/types/shared/feature_flags.ts
@@ -121,6 +121,10 @@ export const WHITELISTABLE_FEATURES_CONFIG = {
     description: "Display debug tools in the interface",
     stage: "dust_only",
   },
+  slack_semantic_search: {
+    description: "Enable semantic search in Slack",
+    stage: "on_demand",
+  },
   usage_data_api: {
     description:
       "API for accessing usage data (Means that any builder with an API key can access usage data of the workspace from API)",

--- a/sdks/js/src/types.ts
+++ b/sdks/js/src/types.ts
@@ -618,6 +618,7 @@ const WhitelistableFeaturesSchema = FlexibleEnumSchema<
   | "salesforce_synced_queries"
   | "salesforce_tool"
   | "show_debug_tools"
+  | "slack_semantic_search"
   | "usage_data_api"
   | "xai_feature"
   | "agent_management_tool"


### PR DESCRIPTION
## Description

The support is under a slack_semantic_search flag. When enabled, it replaces the existing search_messages (which is keywords based) by a semantic_search_messages, which formulates queries in a format that triggers semantic search.

Make sure to ignore spaces when reviewing to avoid a large diff.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
