### PR TITLE
[front] feat(abv2): enforce content tools

### DIFF
--- a/front/components/data_source_view/DataSourceNavigationView.tsx
+++ b/front/components/data_source_view/DataSourceNavigationView.tsx
@@ -25,7 +25,9 @@ export function DataSourceNavigationView({
         <DataSourceCategoryBrowser space={currentNavigationEntry.space} />
       )}
 
-      {currentNavigationEntry.type === "category" && <DataSourceViewTable />}
+      {currentNavigationEntry.type === "category" && (
+        <DataSourceViewTable viewType={viewType} />
+      )}
 
       {(currentNavigationEntry.type === "node" ||
         currentNavigationEntry.type === "data_source") &&

--- a/front/components/data_source_view/DataSourceNodeTable.tsx
+++ b/front/components/data_source_view/DataSourceNodeTable.tsx
@@ -43,6 +43,7 @@ export function DataSourceNodeTable({ viewType }: DataSourceNodeTableProps) {
         : undefined,
     viewType,
     pagination: { limit: PAGE_SIZE, cursor: null },
+    sorting: [{ field: "title", direction: "asc" }],
   });
 
   const handleLoadMore = async () => {

--- a/front/components/data_source_view/DataSourceSpaceSelector.tsx
+++ b/front/components/data_source_view/DataSourceSpaceSelector.tsx
@@ -54,7 +54,12 @@ export function DataSourceSpaceSelector({
         return aKindIndex - bKindIndex;
       }
 
-      // If kinds are the same, sort by name alphabetically
+      // If kinds are the same, sort by isRestricted (non-restricted first)
+      if (a.isRestricted !== b.isRestricted) {
+        return a.isRestricted ? 1 : -1;
+      }
+
+      // If kinds and isRestricted are the same, sort by name alphabetically
       return a.name.localeCompare(b.name);
     });
 

--- a/front/components/data_source_view/DataSourceViewTable.tsx
+++ b/front/components/data_source_view/DataSourceViewTable.tsx
@@ -10,11 +10,19 @@ import type { DataSourceRowData } from "@app/components/data_source_view/hooks/u
 import { useDataSourceColumns } from "@app/components/data_source_view/hooks/useDataSourceColumns";
 import { useTheme } from "@app/components/sparkle/ThemeContext";
 import { CONNECTOR_CONFIGURATIONS } from "@app/lib/connector_providers";
-import { getDataSourceNameFromView } from "@app/lib/data_sources";
+import {
+  getDataSourceNameFromView,
+  isRemoteDatabase,
+} from "@app/lib/data_sources";
 import { CATEGORY_DETAILS } from "@app/lib/spaces";
 import { useSpaceDataSourceViews } from "@app/lib/swr/spaces";
+import type { ContentNodesViewType } from "@app/types";
 
-export function DataSourceViewTable() {
+export function DataSourceViewTable({
+  viewType,
+}: {
+  viewType: ContentNodesViewType;
+}) {
   const { owner } = useAgentBuilderContext();
   const { navigationHistory, setDataSourceViewEntry } =
     useDataSourceBuilderContext();
@@ -31,7 +39,15 @@ export function DataSourceViewTable() {
 
   const columns = useDataSourceColumns();
   const rows: DataSourceRowData[] = spaceDataSourceViews
-    .filter((dsv) => dsv.dataSource.connectorProvider !== "slack_bot")
+    .filter((dsv) => {
+      if (viewType === "data_warehouse") {
+        return isRemoteDatabase(dsv.dataSource);
+      } else if (viewType === "table") {
+        return !isRemoteDatabase(dsv.dataSource);
+      }
+
+      return dsv.dataSource.connectorProvider !== "slack_bot";
+    })
     .map((dsv) => {
       const provider = dsv.dataSource.connectorProvider;
 

--- a/front/components/data_source_view/DataSourceViewTable.tsx
+++ b/front/components/data_source_view/DataSourceViewTable.tsx
@@ -40,13 +40,18 @@ export function DataSourceViewTable({
   const columns = useDataSourceColumns();
   const rows: DataSourceRowData[] = spaceDataSourceViews
     .filter((dsv) => {
-      if (viewType === "data_warehouse") {
-        return isRemoteDatabase(dsv.dataSource);
-      } else if (viewType === "table") {
-        return !isRemoteDatabase(dsv.dataSource);
+      if (dsv.dataSource.connectorProvider === "slack_bot") {
+        return false;
       }
 
-      return dsv.dataSource.connectorProvider !== "slack_bot";
+      switch (viewType) {
+        case "data_warehouse":
+          return isRemoteDatabase(dsv.dataSource);
+        case "table":
+          return !isRemoteDatabase(dsv.dataSource);
+        default:
+          return true;
+      }
     })
     .map((dsv) => {
       const provider = dsv.dataSource.connectorProvider;


### PR DESCRIPTION
## Description
- https://github.com/dust-tt/tasks/issues/3784
- Filtering on the content nodes level was already done
- Added a very basic DataSource filtering depending on the `viewType`. Mainly removing or adding data wharehouse if type is not related to that.
Not sure about that approach. I was checking the current implementation that seems to correctly filter the type of data it can access, but needs to do a bunch of calls to figure it out. We could probably do something similar with the new abv2 setup, but it would require more changes. Happy to discuss

## Tests
- [ ] front-edge

## Risk
- Low

## Deploy Plan
- Deploy front
