### PR TITLE
[front] deep: display chip when only thoughts

### DIFF
--- a/front/components/assistant/conversation/actions/AgentMessageActions.tsx
+++ b/front/components/assistant/conversation/actions/AgentMessageActions.tsx
@@ -40,7 +40,8 @@ export function AgentMessageActions({
   const { openPanel } = useConversationSidePanelContext();
 
   const lastAction = agentMessage.actions[agentMessage.actions.length - 1];
-  const hasActions = agentMessage.actions.length > 0;
+  const hasSidePanelContent =
+    agentMessage.actions.length > 0 || agentMessage.chainOfThought;
   const chainOfThought = agentMessage.chainOfThought || "";
   const onClick = () => {
     openPanel({
@@ -52,7 +53,7 @@ export function AgentMessageActions({
     });
   };
 
-  if (lastAgentStateClassification === "done" && !hasActions) {
+  if (lastAgentStateClassification === "done" && !hasSidePanelContent) {
     return null;
   }
 
@@ -104,7 +105,7 @@ export function AgentMessageActions({
     <div className="flex flex-col items-start gap-y-4">
       <Button
         size="sm"
-        label="Tools inspection"
+        label="Message Breakdown"
         icon={CommandLineIcon}
         variant="outline"
         onClick={onClick}


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

For now when there's only thinking steps, we don't display the tools inspection chip, so we can't open the side modal, so we can't see the chain of thoughts.

This PR fixes the way we display the chip, and changes the label because of the change of content.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

Tested by hand

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

Low.

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->

Deploy front.