### PR TITLE
[front] - chore(AB v2): rendering `MCPServerViewsFooter`

### DIFF
--- a/front/components/agent_builder/capabilities/mcp/MCPServerViewsFooter.tsx
+++ b/front/components/agent_builder/capabilities/mcp/MCPServerViewsFooter.tsx
@@ -2,6 +2,10 @@ import { Chip } from "@dust-tt/sparkle";
 import React from "react";
 
 import type { SelectedTool } from "@app/components/agent_builder/capabilities/mcp/MCPServerViewsDialog";
+import {
+  getSelectedToolIcon,
+  getSelectedToolLabel,
+} from "@app/components/agent_builder/capabilities/mcp/utils/toolDisplayUtils";
 import type { ActionSpecification } from "@app/components/agent_builder/types";
 
 interface MCPServerViewsFooterProps {
@@ -24,13 +28,8 @@ export function MCPServerViewsFooter({
             {selectedToolsInDialog.map((tool, index) => (
               <Chip
                 key={index}
-                label={
-                  tool.type === "DATA_VISUALIZATION"
-                    ? dataVisualization?.label || ""
-                    : tool.type === "MCP"
-                      ? tool.view.name || tool.view.server.name
-                      : ""
-                }
+                icon={getSelectedToolIcon(tool)}
+                label={getSelectedToolLabel(tool, dataVisualization)}
                 onRemove={
                   onRemoveSelectedTool
                     ? () => onRemoveSelectedTool(tool)

--- a/front/components/agent_builder/capabilities/mcp/utils/toolDisplayUtils.ts
+++ b/front/components/agent_builder/capabilities/mcp/utils/toolDisplayUtils.ts
@@ -1,0 +1,31 @@
+import { ActionIcons, BookOpenIcon } from "@dust-tt/sparkle";
+
+import type { SelectedTool } from "@app/components/agent_builder/capabilities/mcp/MCPServerViewsDialog";
+import type { ActionSpecification } from "@app/components/agent_builder/types";
+import { getMcpServerViewDisplayName } from "@app/lib/actions/mcp_helper";
+import {
+  InternalActionIcons,
+  isCustomServerIconType,
+} from "@app/lib/actions/mcp_icons";
+import { DATA_VISUALIZATION_SPECIFICATION } from "@app/lib/actions/utils";
+
+export function getSelectedToolIcon(tool: SelectedTool): React.ComponentType {
+  if (tool.type === "DATA_VISUALIZATION") {
+    return DATA_VISUALIZATION_SPECIFICATION.dropDownIcon;
+  }
+
+  return isCustomServerIconType(tool.view.server.icon)
+    ? ActionIcons[tool.view.server.icon]
+    : InternalActionIcons[tool.view.server.icon] || BookOpenIcon;
+}
+
+export function getSelectedToolLabel(
+  tool: SelectedTool,
+  dataVisualization?: ActionSpecification | null
+): string {
+  if (tool.type === "DATA_VISUALIZATION") {
+    return dataVisualization?.label || "";
+  }
+
+  return getMcpServerViewDisplayName(tool.view);
+}


### PR DESCRIPTION
## Description

This PR  reuses the logic for getting tool labels and icons from utility functions.

<img width="870" height="664" alt="Screenshot 2025-08-13 at 17 34 32" src="https://github.com/user-attachments/assets/1c68ba87-bc5d-4e97-ada3-00ab467d0439" />

## Tests

Locally

## Risk

Low

## Deploy Plan

Deploy front