### PR TITLE
Decrease amount of default information for freshservice ticket

### DIFF
--- a/front/lib/actions/mcp_internal_actions/constants.ts
+++ b/front/lib/actions/mcp_internal_actions/constants.ts
@@ -510,6 +510,7 @@ export const INTERNAL_MCP_SERVERS = {
       // Read operations - never ask
       list_tickets: "never_ask",
       get_ticket: "never_ask",
+      get_ticket_read_fields: "never_ask",
       list_departments: "never_ask",
       list_products: "never_ask",
       list_oncall_schedules: "never_ask",

--- a/front/lib/actions/mcp_internal_actions/servers/freshservice/freshservice_api_helper.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/freshservice/freshservice_api_helper.ts
@@ -1,23 +1,61 @@
-export interface FreshserviceTicket {
-  id: number;
-  subject: string;
-  description_text?: string;
-  priority: number;
-  status: number;
-  source: number;
-  requester_id: number;
-  responder_id?: number;
-  department_id?: number;
-  group_id?: number;
-  type?: string;
-  tags?: string[];
-  created_at: string;
-  updated_at: string;
-  due_by?: string;
-  fr_due_by?: string;
-  is_escalated: boolean;
-  custom_fields?: Record<string, any>;
-}
+import { z } from "zod";
+
+export const FreshserviceTicketSchema = z.object({
+  id: z.number(),
+  subject: z.string(),
+  description_text: z.string().optional(),
+  description: z.string().optional(),
+  priority: z.number(),
+  status: z.number(),
+  source: z.number(),
+  requester_id: z.number(),
+  requested_for_id: z.number().optional(),
+  responder_id: z.number().optional(),
+  department_id: z.number().optional(),
+  group_id: z.number().optional(),
+  type: z.string().optional(),
+  tags: z.array(z.string()).optional(),
+  created_at: z.string(),
+  updated_at: z.string(),
+  due_by: z.string().optional(),
+  fr_due_by: z.string().optional(),
+  is_escalated: z.boolean(),
+  custom_fields: z.record(z.any()).optional(),
+  cc_emails: z.array(z.string()).optional(),
+  fwd_emails: z.array(z.string()).optional(),
+  reply_cc_emails: z.array(z.string()).optional(),
+  fr_escalated: z.boolean().optional(),
+  spam: z.boolean().optional(),
+  email_config_id: z.number().nullable().optional(),
+  to_emails: z.string().nullable().optional(),
+  sla_policy_id: z.number().optional(),
+  urgency: z.number().optional(),
+  impact: z.number().optional(),
+  category: z.string().nullable().optional(),
+  sub_category: z.string().nullable().optional(),
+  item_category: z.string().nullable().optional(),
+  deleted: z.boolean().optional(),
+  resolution_notes: z.string().nullable().optional(),
+  resolution_notes_html: z.string().nullable().optional(),
+  attachments: z
+    .array(
+      z.object({
+        content_type: z.string(),
+        size: z.number(),
+        name: z.string(),
+        attachment_url: z.string(),
+        created_at: z.string(),
+        updated_at: z.string(),
+      })
+    )
+    .optional(),
+  workspace_id: z.number().optional(),
+  created_within_business_hours: z.boolean().optional(),
+  approval_status: z.number().optional(),
+  approval_status_name: z.string().optional(),
+});
+
+export type FreshserviceTicket = z.infer<typeof FreshserviceTicketSchema>;
 
 export interface FreshserviceRequester {
   id: number;


### PR DESCRIPTION
## Description
* Avoiding freshservice context window issues while iterating through tickets by decrease the number of default fields. Exposing fields param to allow llm to acquire additional details.

## Tests

```
Freshservice Get Ticket
Inputs
{
  "ticket_id": 43
}

Output
Ticket retrieved successfully
{
  "id": 43,
  "subject": "MacBook shutting down randomly and battery swelling",
  "description_text": "Frank Aloia's MacBook is shutting down randomly during video calls, and the battery is swelling. Serial Number: 1. This is a safety issue and requires immediate attention.",
  "priority": 4,
  "status": 2,
  "requester_id": 34001122375,
  "responder_id": null,
  "department_id": 34000246686,
  "group_id": null,
  "type": "Incident",
  "created_at": "2025-06-06T17:00:13Z",
  "updated_at": "2025-08-13T13:54:09Z",
  "due_by": "2025-06-06T21:00:13Z"
}
```

## Risk

* Minimal - fixing existing context window issues

## Deploy Plan

* Deploy front