### PR TITLE
Add Jira markdown style

### DIFF
--- a/front/lib/actions/mcp_internal_actions/servers/jira/jira_api_helper.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/jira/jira_api_helper.ts
@@ -2,12 +2,12 @@ import type { Result } from "@dust-tt/client";
 import { Err, Ok } from "@dust-tt/client";
 import type { AuthInfo } from "@modelcontextprotocol/sdk/server/auth/types.js";
 import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
+import { markdownToAdf } from "marklassian";
 import { z } from "zod";
 
 import {
   createJQLFromSearchFilters,
   processFieldsForJira,
-  textToADF,
 } from "@app/lib/actions/mcp_internal_actions/servers/jira/jira_utils";
 import type {
   ADFDocument,
@@ -354,7 +354,7 @@ export async function createComment(
   let adfBody: ADFDocument;
 
   if (typeof commentBody === "string") {
-    adfBody = textToADF(commentBody);
+    adfBody = markdownToAdf(commentBody);
   } else if (isADFDocument(commentBody)) {
     adfBody = commentBody;
   } else {
@@ -770,7 +770,7 @@ export async function createIssueLink(
     const commentText = requestBody.comment.body;
     requestBody.comment = {
       ...requestBody.comment,
-      body: textToADF(commentText),
+      body: markdownToAdf(commentText),
     };
   }
 

--- a/front/lib/actions/mcp_internal_actions/servers/jira/jira_utils.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/jira/jira_utils.ts
@@ -1,3 +1,5 @@
+import { markdownToAdf } from "marklassian";
+
 import type {
   SearchFilter,
   SearchFilterField,
@@ -89,40 +91,6 @@ export function createJQLFromSearchFilters(
   return jql;
 }
 
-// Converts plain text to Atlassian Document Format (ADF)
-// Based on: https://developer.atlassian.com/cloud/jira/platform/apis/document/structure/
-
-export function textToADF(text: string): {
-  type: "doc";
-  version: 1;
-  content: Array<{
-    type: "paragraph";
-    content: Array<{
-      type: "text";
-      text: string;
-    }>;
-  }>;
-} {
-  // Split text by newlines to create multiple paragraphs
-  const lines = text.split("\n");
-
-  const content = lines.map((line) => ({
-    type: "paragraph" as const,
-    content: [
-      {
-        type: "text" as const,
-        text: line || "", // Handle empty lines
-      },
-    ],
-  }));
-
-  return {
-    type: "doc",
-    version: 1,
-    content,
-  };
-}
-
 /**
  * Determines if a field should be converted to ADF format.
  *
@@ -185,7 +153,7 @@ export function processFieldsForJira(
     const fieldMetadata = fieldsMetadata?.[fieldKey];
 
     if (shouldConvertToADF(fieldKey, fieldValue, fieldMetadata)) {
-      processedFields[fieldKey] = textToADF(fieldValue as string);
+      processedFields[fieldKey] = markdownToAdf(fieldValue as string);
     }
   }
 

--- a/front/package-lock.json
+++ b/front/package-lock.json
@@ -83,6 +83,7 @@
         "lucide-react": "^0.363.0",
         "luxon": "^3.4.4",
         "marked": "^14.1.3",
+        "marklassian": "^1.0.4",
         "minimist": "^1.2.8",
         "moment-timezone": "^0.5.43",
         "motion": "^12.7.3",
@@ -19270,6 +19271,25 @@
       },
       "engines": {
         "node": ">= 18"
+      }
+    },
+    "node_modules/marklassian": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/marklassian/-/marklassian-1.0.4.tgz",
+      "integrity": "sha512-sRLXdgKzTXFUYuOO0shpVPfrarogFvEb7pWaTm/J1RkCgNLBVvG5vmnCWMndy7Z7ba0dLn4jt/tDW74YfNEbgA==",
+      "dependencies": {
+        "marked": "^15.0.6 || ^16.0.0"
+      }
+    },
+    "node_modules/marklassian/node_modules/marked": {
+      "version": "16.1.2",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-16.1.2.tgz",
+      "integrity": "sha512-rNQt5EvRinalby7zJZu/mB+BvaAY2oz3wCuCjt1RDrWNpS1Pdf9xqMOeC9Hm5adBdcV/3XZPJpG58eT+WBc0XQ==",
+      "bin": {
+        "marked": "bin/marked.js"
+      },
+      "engines": {
+        "node": ">= 20"
       }
     },
     "node_modules/math-intrinsics": {

--- a/front/package.json
+++ b/front/package.json
@@ -100,6 +100,7 @@
     "lucide-react": "^0.363.0",
     "luxon": "^3.4.4",
     "marked": "^14.1.3",
+    "marklassian": "^1.0.4",
     "minimist": "^1.2.8",
     "moment-timezone": "^0.5.43",
     "motion": "^12.7.3",


### PR DESCRIPTION
## Description

* Ask from customer to support Jira-style markdown. Jira has it's own markdown format called Atlassian Document Format.

## Tests

<img width="1033" height="260" alt="Screenshot 2025-08-13 at 2 03 23 PM" src="https://github.com/user-attachments/assets/d99a597c-7b58-4798-b419-d0a133e9663c" />

## Risk

* minimal

## Deploy Plan

* Deploy front