### PR TITLE
[front] Fix typing in `useConversation` hook

### DIFF
--- a/front/components/assistant/conversation/ConversationLayout.tsx
+++ b/front/components/assistant/conversation/ConversationLayout.tsx
@@ -27,7 +27,7 @@ import { useConversation } from "@app/lib/swr/conversations";
 import { useFeatureFlags } from "@app/lib/swr/workspaces";
 import type {
   ConversationError,
-  ConversationType,
+  ConversationWithoutContentType,
   LightWorkspaceType,
   SubscriptionType,
   UserType,
@@ -182,7 +182,7 @@ const ConversationLayoutContent = ({
 
 interface ConversationInnerLayoutProps {
   children: React.ReactNode;
-  conversation: ConversationType | null;
+  conversation: ConversationWithoutContentType | null;
   owner: LightWorkspaceType;
   baseUrl: string;
   conversationError: ConversationError | null;

--- a/front/components/assistant/conversation/ConversationSidePanelContainer.tsx
+++ b/front/components/assistant/conversation/ConversationSidePanelContainer.tsx
@@ -4,10 +4,13 @@ import type { ImperativePanelHandle } from "react-resizable-panels";
 
 import ConversationSidePanelContent from "@app/components/assistant/conversation/ConversationSidePanelContent";
 import { useConversationSidePanelContext } from "@app/components/assistant/conversation/ConversationSidePanelContext";
-import type { ConversationType, LightWorkspaceType } from "@app/types";
+import type {
+  ConversationWithoutContentType,
+  LightWorkspaceType,
+} from "@app/types";
 
 interface ConversationSidePanelContainerProps {
-  conversation: ConversationType | null;
+  conversation: ConversationWithoutContentType | null;
   owner: LightWorkspaceType;
 }
 

--- a/front/components/assistant/conversation/ConversationSidePanelContent.tsx
+++ b/front/components/assistant/conversation/ConversationSidePanelContent.tsx
@@ -1,6 +1,9 @@
 import { AgentActionsPanel } from "@app/components/assistant/conversation/actions/AgentActionsPanel";
 import { InteractiveContentContainer } from "@app/components/assistant/conversation/content/InteractiveContentContainer";
-import type { ConversationType, LightWorkspaceType } from "@app/types";
+import type {
+  ConversationWithoutContentType,
+  LightWorkspaceType,
+} from "@app/types";
 import type { ConversationSidePanelType } from "@app/types/conversation_side_panel";
 import {
   AGENT_ACTIONS_SIDE_PANEL_TYPE,
@@ -8,7 +11,7 @@ import {
 } from "@app/types/conversation_side_panel";
 
 interface ConversationSidePanelContentProps {
-  conversation: ConversationType | null;
+  conversation: ConversationWithoutContentType | null;
   owner: LightWorkspaceType;
   currentPanel: ConversationSidePanelType;
 }

--- a/front/components/assistant/conversation/actions/AgentActionsPanel.tsx
+++ b/front/components/assistant/conversation/actions/AgentActionsPanel.tsx
@@ -5,10 +5,13 @@ import { MCPActionDetails } from "@app/components/actions/mcp/details/MCPActionD
 import { AgentActionsPanelHeader } from "@app/components/assistant/conversation/actions/AgentActionsPanelHeader";
 import { useConversationSidePanelContext } from "@app/components/assistant/conversation/ConversationSidePanelContext";
 import { useConversationMessage } from "@app/lib/swr/conversations";
-import type { ConversationType, LightWorkspaceType } from "@app/types";
+import type {
+  ConversationWithoutContentType,
+  LightWorkspaceType,
+} from "@app/types";
 
 interface AgentActionsPanelProps {
-  conversation: ConversationType | null;
+  conversation: ConversationWithoutContentType | null;
   owner: LightWorkspaceType;
 }
 

--- a/front/components/assistant/conversation/content/ClientExecutableRenderer.tsx
+++ b/front/components/assistant/conversation/content/ClientExecutableRenderer.tsx
@@ -16,7 +16,10 @@ import { VisualizationActionIframe } from "@app/components/assistant/conversatio
 import { CenteredState } from "@app/components/assistant/conversation/content/CenteredState";
 import { isFileUsingConversationFiles } from "@app/lib/files";
 import { useFileContent } from "@app/lib/swr/files";
-import type { ConversationType, LightWorkspaceType } from "@app/types";
+import type {
+  ConversationWithoutContentType,
+  LightWorkspaceType,
+} from "@app/types";
 
 import { useConversationSidePanelContext } from "../ConversationSidePanelContext";
 import { ShareInteractiveFilePopover } from "../ShareInteractiveFilePopover";
@@ -65,7 +68,7 @@ function ExportContentDropdown({ iframeRef }: ExportContentDropdownProps) {
 }
 
 interface ClientExecutableRendererProps {
-  conversation: ConversationType;
+  conversation: ConversationWithoutContentType;
   fileId: string;
   fileName?: string;
   owner: LightWorkspaceType;

--- a/front/components/assistant/conversation/content/InteractiveContentContainer.tsx
+++ b/front/components/assistant/conversation/content/InteractiveContentContainer.tsx
@@ -6,11 +6,14 @@ import { ClientExecutableRenderer } from "@app/components/assistant/conversation
 import { UnsupportedContentRenderer } from "@app/components/assistant/conversation/content/UnsupportedContentRenderer";
 import { useConversationSidePanelContext } from "@app/components/assistant/conversation/ConversationSidePanelContext";
 import { useFileMetadata } from "@app/lib/swr/files";
-import type { ConversationType, LightWorkspaceType } from "@app/types";
+import type {
+  ConversationWithoutContentType,
+  LightWorkspaceType,
+} from "@app/types";
 import { clientExecutableContentType } from "@app/types";
 
 interface InteractiveContentContainerProps {
-  conversation: ConversationType | null;
+  conversation: ConversationWithoutContentType | null;
   owner: LightWorkspaceType;
 }
 

--- a/front/components/assistant_builder/TryAssistant.tsx
+++ b/front/components/assistant_builder/TryAssistant.tsx
@@ -15,6 +15,7 @@ import type {
   AgentMention,
   ContentFragmentsType,
   ConversationType,
+  ConversationWithoutContentType,
   LightAgentConfigurationType,
   MentionType,
   Result,
@@ -163,7 +164,7 @@ export function useTryAssistantCore({
 }: {
   owner: WorkspaceType;
   user: UserType | null;
-  openWithConversation?: ConversationType;
+  openWithConversation?: ConversationWithoutContentType;
   assistant: LightAgentConfigurationType | null;
   createDraftAgent?: () => Promise<LightAgentConfigurationType | null>;
 }) {
@@ -175,15 +176,13 @@ export function useTryAssistantCore({
   );
   const sendNotification = useSendNotification();
 
-  const { conversation: swrConversation } = useConversation({
+  const { conversation } = useConversation({
     conversationId: conversationId || "",
     workspaceId: owner.sId,
     options: {
       disabled: !conversationId,
     },
   });
-
-  const conversation = swrConversation || null;
 
   const handleSubmit = async (
     input: string,

--- a/front/lib/swr/conversations.ts
+++ b/front/lib/swr/conversations.ts
@@ -20,7 +20,6 @@ import type {
 } from "@app/pages/api/w/[wId]/assistant/conversations/[cId]/tools";
 import type {
   ConversationError,
-  ConversationType,
   ConversationWithoutContentType,
   FetchConversationMessagesResponse,
   LightWorkspaceType,
@@ -35,13 +34,14 @@ export function useConversation({
   workspaceId: string;
   options?: { disabled: boolean };
 }): {
-  conversation: ConversationType | null;
+  conversation: ConversationWithoutContentType | null;
   isConversationLoading: boolean;
   conversationError: ConversationError;
   mutateConversation: () => void;
 } {
-  const conversationFetcher: Fetcher<{ conversation: ConversationType }> =
-    fetcher;
+  const conversationFetcher: Fetcher<{
+    conversation: ConversationWithoutContentType;
+  }> = fetcher;
 
   const { data, error, mutate } = useSWRWithDefaults(
     conversationId


### PR DESCRIPTION
## Description

- The type of the conversation returned by the `useConversation` hook was incorrect, the endpoint returns a conversation without content [here](https://github.com/dust-tt/dust/blob/main/front/pages/api/w/%5BwId%5D/assistant/conversations/%5BcId%5D/index.ts#L46).
- This is pretty dangerous because using `conversation.content` in the front end will pass the typecheck but can crash hard since it's undefined.
- This PR fixes that.

## Tests

- tsc.

## Risk

- N/A, no actual code change.

## Deploy Plan

- Deploy front.
