### PR TITLE
fix: case-insensitive email in usage metrics

### DIFF
--- a/front/lib/workspace_usage.ts
+++ b/front/lib/workspace_usage.ts
@@ -127,7 +127,7 @@ export async function unsafeGetUsageData(
           WHEN cf."id" IS NOT NULL THEN 'content_fragment'
         END AS "messageType",
         um."userContextFullName" AS "userFullName",
-        um."userContextEmail" AS "userEmail",
+        LOWER(um."userContextEmail") AS "userEmail",
         COALESCE(ac."sId", am."agentConfigurationId") AS "assistantId",
         COALESCE(ac."name", am."agentConfigurationId") AS "assistantName",
         msv."internalMCPServerId" AS "actionType",
@@ -223,7 +223,7 @@ export async function getMessageUsageData(
         m."parentId" AS "parent_message_id",
         um."id" AS "user_message_id",
         um."userId" AS "user_id",
-        um."userContextEmail" AS "user_email",
+        LOWER(um."userContextEmail") AS "user_email",
         um."userContextOrigin" AS "source"
       FROM
         "agent_messages" am
@@ -342,7 +342,7 @@ export async function getUserUsageData(
         attributes: [
           "userMessage.userId",
           "userMessage.userContextFullName",
-          "userMessage.userContextEmail",
+          "LOWER(userMessage.userContextEmail)",
           "userMessage.userContextOrigin",
           [Sequelize.fn("COUNT", Sequelize.col("userMessage.id")), "count"],
           [
@@ -395,7 +395,7 @@ export async function getUserUsageData(
         group: [
           "userMessage.userId",
           "userMessage.userContextFullName",
-          "userMessage.userContextEmail",
+          "LOWER(userMessage.userContextEmail)",
           "userMessage.userContextOrigin",
         ],
         order: [["count", "DESC"]],

--- a/front/pages/api/v1/w/[wId]/assistant/conversations/[cId]/messages/index.ts
+++ b/front/pages/api/v1/w/[wId]/assistant/conversations/[cId]/messages/index.ts
@@ -164,7 +164,7 @@ async function handler(
 
       const ctx: UserMessageContext = {
         clientSideMCPServerIds: context.clientSideMCPServerIds ?? [],
-        email: context.email ?? null,
+        email: context.email?.toLowerCase() ?? null,
         fullName: context.fullName ?? null,
         origin: context.origin ?? "api",
         profilePictureUrl: context.profilePictureUrl ?? null,

--- a/front/pages/api/v1/w/[wId]/assistant/conversations/index.ts
+++ b/front/pages/api/v1/w/[wId]/assistant/conversations/index.ts
@@ -297,7 +297,7 @@ async function handler(
             {
               username: context?.username ?? null,
               fullName: context?.fullName ?? null,
-              email: context?.email ?? null,
+              email: context?.email?.toLowerCase() ?? null,
               profilePictureUrl: context?.profilePictureUrl ?? null,
             }
           );
@@ -340,7 +340,7 @@ async function handler(
       if (message) {
         const ctx: UserMessageContext = {
           clientSideMCPServerIds: message.context.clientSideMCPServerIds ?? [],
-          email: message.context.email ?? null,
+          email: message.context.email?.toLowerCase() ?? null,
           fullName: message.context.fullName ?? null,
           origin: message.context.origin ?? "api",
           profilePictureUrl: message.context.profilePictureUrl ?? null,


### PR DESCRIPTION
## Description

We sometimes fails to match emails together in usage metrics if messages have a "userContextEmail" that uses different case.

See example here: https://dust4ai.slack.com/archives/C06J575TVN1/p1755124584936069

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
