### PR TITLE
[front] fix: conversation side panel animations

### DIFF
--- a/front/components/assistant/conversation/ConversationSidePanelContainer.tsx
+++ b/front/components/assistant/conversation/ConversationSidePanelContainer.tsx
@@ -18,37 +18,45 @@ export default function ConversationSidePanelContainer({
   conversation,
   owner,
 }: ConversationSidePanelContainerProps) {
-  const { currentPanel } = useConversationSidePanelContext();
+  const { currentPanel, setPanelRef, onPanelClosed } =
+    useConversationSidePanelContext();
   const panelRef = useRef<ImperativePanelHandle | null>(null);
 
   useEffect(() => {
-    if (!panelRef.current) {
+    setPanelRef(panelRef.current);
+  }, [setPanelRef]);
+
+  useEffect(() => {
+    if (!currentPanel || !panelRef.current) {
       return;
     }
-    if (currentPanel) {
-      panelRef.current.expand(20);
-    } else {
-      panelRef.current.collapse();
-    }
+
+    panelRef.current?.expand(40);
   }, [currentPanel]);
 
   return (
     <>
       {/* Resizable Handle for Panels */}
-      <ResizableHandle
-        className={cn(
-          "hidden transition-all duration-300 ease-out md:block",
-          !currentPanel && "translate-x-full opacity-0"
-        )}
-      />
-
+      {currentPanel && (
+        <ResizableHandle
+          className={cn(
+            "hidden transition-all duration-300 ease-out md:block",
+            !currentPanel && "translate-x-full opacity-0"
+          )}
+        />
+      )}
       {/* Panel Container - either Interactive Content or Actions */}
       <ResizablePanel
         ref={panelRef}
+        minSize={20}
+        defaultSize={0}
+        onTransitionEnd={() => {
+          if (panelRef.current?.isCollapsed()) {
+            onPanelClosed();
+          }
+        }}
         collapsible
         collapsedSize={0}
-        minSize={currentPanel ? 20 : 0}
-        defaultSize={70}
         className={cn(
           // Smooth transition animation similar to sidebar
           "flex-0 overflow-hidden transition-all duration-300 ease-out",

--- a/front/components/assistant/conversation/ConversationSidePanelContext.tsx
+++ b/front/components/assistant/conversation/ConversationSidePanelContext.tsx
@@ -1,5 +1,6 @@
 import { assertNever } from "@dust-tt/client";
 import React, { useEffect, useState } from "react";
+import type { ImperativePanelHandle } from "react-resizable-panels";
 
 import { useHashParam } from "@app/hooks/useHashParams";
 import type { ActionProgressState } from "@app/lib/assistant/state/messageReducer";
@@ -39,6 +40,8 @@ interface ConversationSidePanelContextType {
   currentPanel: ConversationSidePanelType;
   openPanel: (params: OpenPanelParams) => void;
   closePanel: () => void;
+  onPanelClosed: () => void;
+  setPanelRef: (ref: ImperativePanelHandle | null) => void;
   data: string | undefined;
   metadata: SidePanelMetadata;
 }
@@ -71,6 +74,12 @@ export function ConversationSidePanelProvider({
   );
   const [metadata, setMetadata] = useState<SidePanelMetadata>(undefined);
 
+  const panelRef = React.useRef<ImperativePanelHandle | null>(null);
+
+  const setPanelRef = (ref: ImperativePanelHandle | null) => {
+    panelRef.current = ref;
+  };
+
   const openPanel = (params: OpenPanelParams) => {
     setCurrentPanel(params.type);
 
@@ -99,6 +108,12 @@ export function ConversationSidePanelProvider({
   };
 
   const closePanel = () => {
+    if (panelRef && panelRef.current) {
+      panelRef.current.collapse();
+    }
+  };
+
+  const onPanelClosed = () => {
     setData(undefined);
     setMetadata(undefined);
     setCurrentPanel(undefined);
@@ -116,7 +131,7 @@ export function ConversationSidePanelProvider({
         });
       }
     } else if (!data) {
-      setCurrentPanel(undefined);
+      closePanel();
     }
   }, [data, currentPanel, setCurrentPanel, metadata]);
 
@@ -128,6 +143,8 @@ export function ConversationSidePanelProvider({
           : undefined,
         openPanel,
         closePanel,
+        onPanelClosed,
+        setPanelRef,
         data,
         metadata,
       }}


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

Since my last PR on the panel animation, there was some visual bugs regarding the conversation layout :
- The panel handle was grabbable when it was empty, and you could open the panel with an empty state
- When landing in a conversation, there was a glitchy closing panel animation.

This PR solves that by :
- Saving the ref inside the context.
- Handling the closing via the ref inside the context.
- Removing the data from the context only on the transition end state.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

Tested by hand

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

Low risks

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->

Deploy front.