### PR TITLE
Control execution mode for agent loop API

### DIFF
--- a/front/components/assistant/conversation/ConversationContainer.tsx
+++ b/front/components/assistant/conversation/ConversationContainer.tsx
@@ -62,9 +62,8 @@ export function ConversationContainer({
 
   const router = useRouter();
 
-  // TODO(DURABLE_AGENT 2025-07-22): Remove this once we have a proper way to handle
-  // asynchronous loops.
-  const { async } = router.query;
+  const { execution } = router.query;
+  const executionMode = typeof execution === "string" ? execution : "auto";
 
   const sendNotification = useSendNotification();
 
@@ -134,7 +133,7 @@ export function ConversationContainer({
             user,
             conversationId: activeConversationId,
             messageData,
-            forceAsync: async === "true",
+            executionMode,
           });
 
           // Replace placeholder message with API response.
@@ -226,7 +225,7 @@ export function ConversationContainer({
           clientSideMCPServerIds: removeNulls([serverId]),
           selectedMCPServerViewIds,
         },
-        forceAsync: async === "true",
+        executionMode,
       });
 
       setIsSubmitting(false);
@@ -261,7 +260,7 @@ export function ConversationContainer({
       }
     },
     [
-      async,
+      executionMode,
       isSubmitting,
       mutateConversations,
       owner,

--- a/front/components/assistant/conversation/lib.ts
+++ b/front/components/assistant/conversation/lib.ts
@@ -65,7 +65,7 @@ export async function submitMessage({
   user,
   conversationId,
   messageData,
-  forceAsync = false,
+  executionMode,
 }: {
   owner: WorkspaceType;
   user: UserType;
@@ -76,7 +76,7 @@ export async function submitMessage({
     contentFragments: ContentFragmentsType;
     clientSideMCPServerIds?: string[];
   };
-  forceAsync?: boolean;
+  executionMode?: string;
 }): Promise<Result<{ message: UserMessageWithRankType }, SubmitMessageError>> {
   const { input, mentions, contentFragments, clientSideMCPServerIds } =
     messageData;
@@ -144,7 +144,7 @@ export async function submitMessage({
   }
 
   // Create a new user message.
-  const queryParams = forceAsync ? "?async=true" : "";
+  const queryParams = executionMode ? `?execution=${executionMode}` : "";
   const mRes = await fetch(
     `/api/w/${owner.sId}/assistant/conversations/${conversationId}/messages${queryParams}`,
     {
@@ -221,7 +221,7 @@ export async function createConversationWithMessage({
   messageData,
   visibility = "unlisted",
   title,
-  forceAsync = false,
+  executionMode,
 }: {
   owner: WorkspaceType;
   user: UserType;
@@ -234,7 +234,7 @@ export async function createConversationWithMessage({
   };
   visibility?: ConversationVisibility;
   title?: string;
-  forceAsync?: boolean;
+  executionMode?: string;
 }): Promise<Result<ConversationType, SubmitMessageError>> {
   const {
     input,
@@ -291,7 +291,7 @@ export async function createConversationWithMessage({
   };
 
   // Create new conversation and post the initial message at the same time.
-  const queryParams = forceAsync ? "?async=true" : "";
+  const queryParams = executionMode ? `?execution=${executionMode}` : "";
   const cRes = await fetch(
     `/api/w/${owner.sId}/assistant/conversations${queryParams}`,
     {

--- a/front/lib/api/assistant/conversation.ts
+++ b/front/lib/api/assistant/conversation.ts
@@ -84,6 +84,7 @@ import {
   Ok,
   removeNulls,
 } from "@app/types";
+import type { ExecutionMode } from "@app/types/assistant/agent_run";
 
 // Soft assumption that we will not have more than 10 mentions in the same user message.
 const MAX_CONCURRENT_AGENT_EXECUTIONS_PER_USER_MESSAGE = 10;
@@ -339,14 +340,14 @@ export async function postUserMessage(
     mentions,
     context,
     skipToolsValidation,
-    forceAsynchronousLoop = false,
+    executionMode,
   }: {
     conversation: ConversationType;
     content: string;
     mentions: MentionType[];
     context: UserMessageContext;
     skipToolsValidation: boolean;
-    forceAsynchronousLoop?: boolean;
+    executionMode?: ExecutionMode;
   }
 ): Promise<
   Result<
@@ -699,7 +700,7 @@ export async function postUserMessage(
       void runAgentLoop(
         auth,
         { sync: true, inMemoryData },
-        { forceAsynchronousLoop, startStep: 0 }
+        { executionMode, startStep: 0 }
       );
     },
     { concurrency: MAX_CONCURRENT_AGENT_EXECUTIONS_PER_USER_MESSAGE }
@@ -1148,11 +1149,7 @@ export async function editUserMessage(
         agentMessageRow,
       };
 
-      void runAgentLoop(
-        auth,
-        { sync: true, inMemoryData },
-        { forceAsynchronousLoop: false, startStep: 0 }
-      );
+      void runAgentLoop(auth, { sync: true, inMemoryData }, { startStep: 0 });
     },
     { concurrency: MAX_CONCURRENT_AGENT_EXECUTIONS_PER_USER_MESSAGE }
   );
@@ -1378,11 +1375,7 @@ export async function retryAgentMessage(
     agentMessageRow,
   };
 
-  void runAgentLoop(
-    auth,
-    { sync: true, inMemoryData },
-    { forceAsynchronousLoop: false, startStep: 0 }
-  );
+  void runAgentLoop(auth, { sync: true, inMemoryData }, { startStep: 0 });
 
   // TODO(DURABLE-AGENTS 2025-07-17): Publish message events to all open tabs to maintain
   // conversation state synchronization in multiplex mode. This is a temporary solution -

--- a/front/lib/api/assistant/conversation/validate_actions.ts
+++ b/front/lib/api/assistant/conversation/validate_actions.ts
@@ -12,7 +12,6 @@ import { runAgentLoop } from "@app/lib/api/assistant/agent";
 import { getMessageChannelId } from "@app/lib/api/assistant/streaming/helpers";
 import { getRedisHybridManager } from "@app/lib/api/redis-hybrid-manager";
 import type { Authenticator } from "@app/lib/auth";
-import { getFeatureFlags } from "@app/lib/auth";
 import { Message } from "@app/lib/models/assistant/conversation";
 import { AgentStepContentResource } from "@app/lib/resources/agent_step_content_resource";
 import logger from "@app/logger/logger";
@@ -85,9 +84,6 @@ export async function validateAction(
     },
     "Tool validation request"
   );
-
-  const featureFlags = await getFeatureFlags(auth.getNonNullableWorkspace());
-  const hasAsyncLoopFeature = featureFlags.includes("async_loop");
 
   const {
     agentMessageId,
@@ -167,7 +163,6 @@ export async function validateAction(
       inMemoryData: runAgentDataRes.value,
     },
     {
-      forceAsynchronousLoop: hasAsyncLoopFeature,
       // Resume from the step where the action was created.
       startStep: agentStepContent.step,
     }

--- a/front/types/assistant/agent_run.ts
+++ b/front/types/assistant/agent_run.ts
@@ -1,9 +1,9 @@
 /**
  * Run agent arguments
  */
-
 import type { Result } from "@dust-tt/client";
 import { Err, Ok } from "@dust-tt/client";
+import { z } from "zod";
 
 import { getAgentConfiguration } from "@app/lib/api/assistant/configuration/agent";
 import { getConversation } from "@app/lib/api/assistant/conversation/fetch";
@@ -21,6 +21,9 @@ import {
   isAgentMessageType,
   isUserMessageType,
 } from "@app/types/assistant/conversation";
+
+export const ExecutionModeSchema = z.enum(["sync", "async", "auto"]);
+export type ExecutionMode = z.infer<typeof ExecutionModeSchema>;
 
 export type RunAgentAsynchronousArgs = {
   agentMessageId: string;

--- a/front/types/shared/feature_flags.ts
+++ b/front/types/shared/feature_flags.ts
@@ -142,10 +142,6 @@ export const WHITELISTABLE_FEATURES_CONFIG = {
     description: "Freshservice MCP tool",
     stage: "rolling_out",
   },
-  async_loop: {
-    description: "Asynchronous loop for conversation processing",
-    stage: "dust_only",
-  },
   agent_management_tool: {
     description: "MCP tool for creating and managing agent configurations",
     stage: "dust_only",

--- a/sdks/js/src/types.ts
+++ b/sdks/js/src/types.ts
@@ -590,7 +590,6 @@ const WhitelistableFeaturesSchema = FlexibleEnumSchema<
   | "agent_builder_instructions_autocomplete"
   | "agent_builder_v2"
   | "anthropic_vertex_fallback"
-  | "async_loop"
   | "claude_4_opus_feature"
   | "co_edition"
   | "deepseek_feature"


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
This PR augments the existing query params that let you run async loop to support all three agentic loop mode:
- `auto`: starts sync then switch to async after 2 minutes
- `sync`: start and keep running in sync mode
- `async`: directly start in async mode

One can now control the execution mode when posting a message in a conversation by providing `?execution=<mode>` in the URL.

It removes the FF `async_loop` that we used to control the release at first.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
