### PR TITLE
[front,extension] Bump sparkle version

### DIFF
--- a/extension/package-lock.json
+++ b/extension/package-lock.json
@@ -12,7 +12,7 @@
         "@auth0/auth0-spa-js": "^2.1.3",
         "@datadog/browser-logs": "^6.13.0",
         "@dust-tt/client": "1.1.4",
-        "@dust-tt/sparkle": "^0.2.571",
+        "@dust-tt/sparkle": "^0.2.574",
         "@frontapp/plugin-sdk": "^1.8.1",
         "@modelcontextprotocol/sdk": "^1.9.0",
         "@tailwindcss/forms": "^0.5.9",
@@ -1254,9 +1254,9 @@
       }
     },
     "node_modules/@dust-tt/sparkle": {
-      "version": "0.2.571",
-      "resolved": "https://registry.npmjs.org/@dust-tt/sparkle/-/sparkle-0.2.571.tgz",
-      "integrity": "sha512-5J8U0geVfGIiUKhAt+f8/tagxheLK15w9ZDS9CgH5udHxEtOPZrVKRb1WiV9HrjyNXBxJYSFRhJ1vp0BxECu6w==",
+      "version": "0.2.575",
+      "resolved": "https://registry.npmjs.org/@dust-tt/sparkle/-/sparkle-0.2.575.tgz",
+      "integrity": "sha512-qwPKYZCc9Kc9XFXFaoiEe9rc6YWLSULZcZv1uhAKrt34bjN0/fpJla9gleeS08vjEwQ9Bsk8PfDh8PQjdubclQ==",
       "license": "ISC",
       "dependencies": {
         "@emoji-mart/data": "^1.1.2",

--- a/extension/package.json
+++ b/extension/package.json
@@ -59,7 +59,7 @@
     "@auth0/auth0-spa-js": "^2.1.3",
     "@datadog/browser-logs": "^6.13.0",
     "@dust-tt/client": "1.1.4",
-    "@dust-tt/sparkle": "^0.2.571",
+    "@dust-tt/sparkle": "^0.2.574",
     "@frontapp/plugin-sdk": "^1.8.1",
     "@modelcontextprotocol/sdk": "^1.9.0",
     "@tailwindcss/forms": "^0.5.9",

--- a/front/package-lock.json
+++ b/front/package-lock.json
@@ -7,7 +7,7 @@
       "dependencies": {
         "@datadog/browser-logs": "^6.13.0",
         "@dust-tt/client": "file:../sdks/js",
-        "@dust-tt/sparkle": "^0.2.571",
+        "@dust-tt/sparkle": "^0.2.574",
         "@google-cloud/bigquery": "^7.9.1",
         "@google-cloud/storage-transfer": "^3.6.0",
         "@heroicons/react": "^2.0.11",
@@ -1111,9 +1111,9 @@
       "link": true
     },
     "node_modules/@dust-tt/sparkle": {
-      "version": "0.2.571",
-      "resolved": "https://registry.npmjs.org/@dust-tt/sparkle/-/sparkle-0.2.571.tgz",
-      "integrity": "sha512-5J8U0geVfGIiUKhAt+f8/tagxheLK15w9ZDS9CgH5udHxEtOPZrVKRb1WiV9HrjyNXBxJYSFRhJ1vp0BxECu6w==",
+      "version": "0.2.574",
+      "resolved": "https://registry.npmjs.org/@dust-tt/sparkle/-/sparkle-0.2.574.tgz",
+      "integrity": "sha512-lhPYZaHcZPubldQ1vRj0o+2LXlS8ZI6Ek0peeQgWf5xZzZAJzCsk3Y7HC4lDJ6Bia34qQ0RWsbB1MZ5fdyK9yQ==",
       "license": "ISC",
       "dependencies": {
         "@emoji-mart/data": "^1.1.2",

--- a/front/package.json
+++ b/front/package.json
@@ -24,7 +24,7 @@
   "dependencies": {
     "@datadog/browser-logs": "^6.13.0",
     "@dust-tt/client": "file:../sdks/js",
-    "@dust-tt/sparkle": "^0.2.571",
+    "@dust-tt/sparkle": "^0.2.574",
     "@google-cloud/bigquery": "^7.9.1",
     "@google-cloud/storage-transfer": "^3.6.0",
     "@heroicons/react": "^2.0.11",


### PR DESCRIPTION
## Description

- This PR bumps the version of sparkle to get the changes from https://github.com/dust-tt/dust/pull/15040, which introduced a new component `ContentMessageInline`.

## Tests

## Risk

- Not sure what's in versions `0.2.572` and `0.2.573`.

## Deploy Plan

- Deploy front.
