### PR TITLE
[connectors] chore(temporal): Add customs tags to activity logs

### DIFF
--- a/connectors/src/connectors/bigquery/temporal/worker.ts
+++ b/connectors/src/connectors/bigquery/temporal/worker.ts
@@ -10,7 +10,10 @@ import {
   getTemporalWorkerConnection,
   TEMPORAL_MAXED_CACHED_WORKFLOWS,
 } from "@connectors/lib/temporal";
-import { ActivityInboundLogInterceptor } from "@connectors/lib/temporal_monitoring";
+import {
+  ActivityInboundLogInterceptor,
+  ActivityOutboundLogInterceptor,
+} from "@connectors/lib/temporal_monitoring";
 import logger from "@connectors/logger/logger";
 
 export async function runBigQueryWorker() {
@@ -25,11 +28,14 @@ export async function runBigQueryWorker() {
     reuseV8Context: true,
     namespace,
     interceptors: {
-      activityInbound: [
-        (ctx: Context) => {
-          return new ActivityInboundLogInterceptor(ctx, logger, "bigquery");
-        },
-        () => new BigQueryCastKnownErrorsInterceptor(),
+      activity: [
+        (ctx: Context) => ({
+          inbound: new ActivityInboundLogInterceptor(ctx, logger, "bigquery"),
+          outbound: new ActivityOutboundLogInterceptor("bigquery"),
+        }),
+        () => ({
+          inbound: new BigQueryCastKnownErrorsInterceptor(),
+        }),
       ],
     },
     bundlerOptions: {

--- a/connectors/src/connectors/confluence/temporal/worker.ts
+++ b/connectors/src/connectors/confluence/temporal/worker.ts
@@ -10,7 +10,10 @@ import {
   getTemporalWorkerConnection,
   TEMPORAL_MAXED_CACHED_WORKFLOWS,
 } from "@connectors/lib/temporal";
-import { ActivityInboundLogInterceptor } from "@connectors/lib/temporal_monitoring";
+import {
+  ActivityInboundLogInterceptor,
+  ActivityOutboundLogInterceptor,
+} from "@connectors/lib/temporal_monitoring";
 import logger from "@connectors/logger/logger";
 
 export async function runConfluenceWorker() {
@@ -25,11 +28,14 @@ export async function runConfluenceWorker() {
     reuseV8Context: true,
     namespace,
     interceptors: {
-      activityInbound: [
-        (ctx: Context) => {
-          return new ActivityInboundLogInterceptor(ctx, logger, "confluence");
-        },
-        () => new ConfluenceCastKnownErrorsInterceptor(),
+      activity: [
+        (ctx: Context) => ({
+          inbound: new ActivityInboundLogInterceptor(ctx, logger, "confluence"),
+          outbound: new ActivityOutboundLogInterceptor("confluence"),
+        }),
+        () => ({
+          inbound: new ConfluenceCastKnownErrorsInterceptor(),
+        }),
       ],
     },
     bundlerOptions: {

--- a/connectors/src/connectors/github/temporal/worker.ts
+++ b/connectors/src/connectors/github/temporal/worker.ts
@@ -9,7 +9,10 @@ import {
   getTemporalWorkerConnection,
   TEMPORAL_MAXED_CACHED_WORKFLOWS,
 } from "@connectors/lib/temporal";
-import { ActivityInboundLogInterceptor } from "@connectors/lib/temporal_monitoring";
+import {
+  ActivityInboundLogInterceptor,
+  ActivityOutboundLogInterceptor,
+} from "@connectors/lib/temporal_monitoring";
 import logger from "@connectors/logger/logger";
 
 export async function runGithubWorker() {
@@ -27,11 +30,14 @@ export async function runGithubWorker() {
     reuseV8Context: true,
     namespace,
     interceptors: {
-      activityInbound: [
-        (ctx: Context) => {
-          return new ActivityInboundLogInterceptor(ctx, logger, "github");
-        },
-        () => new GithubCastKnownErrorsInterceptor(),
+      activity: [
+        (ctx: Context) => ({
+          inbound: new ActivityInboundLogInterceptor(ctx, logger, "github"),
+          outbound: new ActivityOutboundLogInterceptor("github"),
+        }),
+        () => ({
+          inbound: new GithubCastKnownErrorsInterceptor(),
+        }),
       ],
     },
   });

--- a/connectors/src/connectors/gong/temporal/worker.ts
+++ b/connectors/src/connectors/gong/temporal/worker.ts
@@ -9,7 +9,10 @@ import {
   getTemporalWorkerConnection,
   TEMPORAL_MAXED_CACHED_WORKFLOWS,
 } from "@connectors/lib/temporal";
-import { ActivityInboundLogInterceptor } from "@connectors/lib/temporal_monitoring";
+import {
+  ActivityInboundLogInterceptor,
+  ActivityOutboundLogInterceptor,
+} from "@connectors/lib/temporal_monitoring";
 import logger from "@connectors/logger/logger";
 
 export async function runGongWorker() {
@@ -24,11 +27,14 @@ export async function runGongWorker() {
     reuseV8Context: true,
     namespace,
     interceptors: {
-      activityInbound: [
-        (ctx: Context) => {
-          return new ActivityInboundLogInterceptor(ctx, logger, "gong");
-        },
-        () => new GongCastKnownErrorsInterceptor(),
+      activity: [
+        (ctx: Context) => ({
+          inbound: new ActivityInboundLogInterceptor(ctx, logger, "gong"),
+          outbound: new ActivityOutboundLogInterceptor("gong"),
+        }),
+        () => ({
+          inbound: new GongCastKnownErrorsInterceptor(),
+        }),
       ],
     },
     bundlerOptions: {

--- a/connectors/src/connectors/google_drive/temporal/worker.ts
+++ b/connectors/src/connectors/google_drive/temporal/worker.ts
@@ -6,7 +6,10 @@ import * as activities from "@connectors/connectors/google_drive/temporal/activi
 import { GoogleDriveCastKnownErrorsInterceptor } from "@connectors/connectors/google_drive/temporal/cast_known_errors";
 import * as sync_status from "@connectors/lib/sync_status";
 import { getTemporalWorkerConnection } from "@connectors/lib/temporal";
-import { ActivityInboundLogInterceptor } from "@connectors/lib/temporal_monitoring";
+import {
+  ActivityInboundLogInterceptor,
+  ActivityOutboundLogInterceptor,
+} from "@connectors/lib/temporal_monitoring";
 import logger from "@connectors/logger/logger";
 
 import {
@@ -26,11 +29,18 @@ export async function runGoogleWorkers() {
     reuseV8Context: true,
     namespace,
     interceptors: {
-      activityInbound: [
-        (ctx: Context) => {
-          return new ActivityInboundLogInterceptor(ctx, logger, "google_drive");
-        },
-        () => new GoogleDriveCastKnownErrorsInterceptor(),
+      activity: [
+        (ctx: Context) => ({
+          inbound: new ActivityInboundLogInterceptor(
+            ctx,
+            logger,
+            "google_drive"
+          ),
+          outbound: new ActivityOutboundLogInterceptor("google_drive"),
+        }),
+        () => ({
+          inbound: new GoogleDriveCastKnownErrorsInterceptor(),
+        }),
       ],
     },
     bundlerOptions: {
@@ -53,11 +63,18 @@ export async function runGoogleWorkers() {
     reuseV8Context: true,
     namespace,
     interceptors: {
-      activityInbound: [
-        (ctx: Context) => {
-          return new ActivityInboundLogInterceptor(ctx, logger, "google_drive");
-        },
-        () => new GoogleDriveCastKnownErrorsInterceptor(),
+      activity: [
+        (ctx: Context) => ({
+          inbound: new ActivityInboundLogInterceptor(
+            ctx,
+            logger,
+            "google_drive"
+          ),
+          outbound: new ActivityOutboundLogInterceptor("google_drive"),
+        }),
+        () => ({
+          inbound: new GoogleDriveCastKnownErrorsInterceptor(),
+        }),
       ],
     },
   });

--- a/connectors/src/connectors/intercom/temporal/worker.ts
+++ b/connectors/src/connectors/intercom/temporal/worker.ts
@@ -7,7 +7,10 @@ import {
   getTemporalWorkerConnection,
   TEMPORAL_MAXED_CACHED_WORKFLOWS,
 } from "@connectors/lib/temporal";
-import { ActivityInboundLogInterceptor } from "@connectors/lib/temporal_monitoring";
+import {
+  ActivityInboundLogInterceptor,
+  ActivityOutboundLogInterceptor,
+} from "@connectors/lib/temporal_monitoring";
 import logger from "@connectors/logger/logger";
 
 export async function runIntercomWorker() {
@@ -22,10 +25,11 @@ export async function runIntercomWorker() {
     reuseV8Context: true,
     namespace,
     interceptors: {
-      activityInbound: [
-        (ctx: Context) => {
-          return new ActivityInboundLogInterceptor(ctx, logger, "intercom");
-        },
+      activity: [
+        (ctx: Context) => ({
+          inbound: new ActivityInboundLogInterceptor(ctx, logger, "intercom"),
+          outbound: new ActivityOutboundLogInterceptor("intercom"),
+        }),
       ],
     },
   });

--- a/connectors/src/connectors/microsoft/temporal/worker.ts
+++ b/connectors/src/connectors/microsoft/temporal/worker.ts
@@ -8,7 +8,10 @@ import {
   getTemporalWorkerConnection,
   TEMPORAL_MAXED_CACHED_WORKFLOWS,
 } from "@connectors/lib/temporal";
-import { ActivityInboundLogInterceptor } from "@connectors/lib/temporal_monitoring";
+import {
+  ActivityInboundLogInterceptor,
+  ActivityOutboundLogInterceptor,
+} from "@connectors/lib/temporal_monitoring";
 import logger from "@connectors/logger/logger";
 
 import * as activities from "./activities";
@@ -26,11 +29,14 @@ export async function runMicrosoftWorker() {
     reuseV8Context: true,
     namespace,
     interceptors: {
-      activityInbound: [
-        (ctx: Context) => {
-          return new ActivityInboundLogInterceptor(ctx, logger, "microsoft");
-        },
-        () => new MicrosoftCastKnownErrorsInterceptor(),
+      activity: [
+        (ctx: Context) => ({
+          inbound: new ActivityInboundLogInterceptor(ctx, logger, "microsoft"),
+          outbound: new ActivityOutboundLogInterceptor("microsoft"),
+        }),
+        () => ({
+          inbound: new MicrosoftCastKnownErrorsInterceptor(),
+        }),
       ],
     },
     bundlerOptions: {

--- a/connectors/src/connectors/notion/temporal/worker.ts
+++ b/connectors/src/connectors/notion/temporal/worker.ts
@@ -9,7 +9,10 @@ import {
   QUEUE_NAME,
 } from "@connectors/connectors/notion/temporal/config";
 import { getTemporalWorkerConnection } from "@connectors/lib/temporal";
-import { ActivityInboundLogInterceptor } from "@connectors/lib/temporal_monitoring";
+import {
+  ActivityInboundLogInterceptor,
+  ActivityOutboundLogInterceptor,
+} from "@connectors/lib/temporal_monitoring";
 import logger from "@connectors/logger/logger";
 
 export async function runNotionWorker() {
@@ -24,11 +27,14 @@ export async function runNotionWorker() {
     maxConcurrentActivityTaskExecutions: 24,
     maxCachedWorkflows: 200,
     interceptors: {
-      activityInbound: [
-        (ctx: Context) => {
-          return new ActivityInboundLogInterceptor(ctx, logger, "notion");
-        },
-        () => new NotionCastKnownErrorsInterceptor(),
+      activity: [
+        (ctx: Context) => ({
+          inbound: new ActivityInboundLogInterceptor(ctx, logger, "notion"),
+          outbound: new ActivityOutboundLogInterceptor("notion"),
+        }),
+        () => ({
+          inbound: new NotionCastKnownErrorsInterceptor(),
+        }),
       ],
     },
     bundlerOptions: {
@@ -57,11 +63,14 @@ export async function runNotionGarbageCollectWorker() {
     maxConcurrentActivityTaskExecutions: 24,
     maxCachedWorkflows: 200,
     interceptors: {
-      activityInbound: [
-        (ctx: Context) => {
-          return new ActivityInboundLogInterceptor(ctx, logger, "notion");
-        },
-        () => new NotionCastKnownErrorsInterceptor(),
+      activity: [
+        (ctx: Context) => ({
+          inbound: new ActivityInboundLogInterceptor(ctx, logger, "notion"),
+          outbound: new ActivityOutboundLogInterceptor("notion"),
+        }),
+        () => ({
+          inbound: new NotionCastKnownErrorsInterceptor(),
+        }),
       ],
     },
     bundlerOptions: {

--- a/connectors/src/connectors/salesforce/temporal/worker.ts
+++ b/connectors/src/connectors/salesforce/temporal/worker.ts
@@ -10,7 +10,10 @@ import {
   getTemporalWorkerConnection,
   TEMPORAL_MAXED_CACHED_WORKFLOWS,
 } from "@connectors/lib/temporal";
-import { ActivityInboundLogInterceptor } from "@connectors/lib/temporal_monitoring";
+import {
+  ActivityInboundLogInterceptor,
+  ActivityOutboundLogInterceptor,
+} from "@connectors/lib/temporal_monitoring";
 import logger from "@connectors/logger/logger";
 
 export async function runSalesforceWorker() {
@@ -25,11 +28,14 @@ export async function runSalesforceWorker() {
     reuseV8Context: true,
     namespace,
     interceptors: {
-      activityInbound: [
-        (ctx: Context) => {
-          return new ActivityInboundLogInterceptor(ctx, logger, "salesforce");
-        },
-        () => new SalesforceCastKnownErrorsInterceptor(),
+      activity: [
+        (ctx: Context) => ({
+          inbound: new ActivityInboundLogInterceptor(ctx, logger, "salesforce"),
+          outbound: new ActivityOutboundLogInterceptor("salesforce"),
+        }),
+        () => ({
+          inbound: new SalesforceCastKnownErrorsInterceptor(),
+        }),
       ],
     },
     bundlerOptions: {

--- a/connectors/src/connectors/slack/temporal/worker.ts
+++ b/connectors/src/connectors/slack/temporal/worker.ts
@@ -7,7 +7,10 @@ import {
   getTemporalWorkerConnection,
   TEMPORAL_MAXED_CACHED_WORKFLOWS,
 } from "@connectors/lib/temporal";
-import { ActivityInboundLogInterceptor } from "@connectors/lib/temporal_monitoring";
+import {
+  ActivityInboundLogInterceptor,
+  ActivityOutboundLogInterceptor,
+} from "@connectors/lib/temporal_monitoring";
 import logger from "@connectors/logger/logger";
 
 import { QUEUE_NAME } from "./config";
@@ -24,11 +27,14 @@ export async function runSlackWorker() {
     maxConcurrentActivityTaskExecutions: 16,
     maxCachedWorkflows: TEMPORAL_MAXED_CACHED_WORKFLOWS,
     interceptors: {
-      activityInbound: [
-        (ctx: Context) => {
-          return new ActivityInboundLogInterceptor(ctx, logger, "slack");
-        },
-        () => new SlackCastKnownErrorsInterceptor(),
+      activity: [
+        (ctx: Context) => ({
+          inbound: new ActivityInboundLogInterceptor(ctx, logger, "slack"),
+          outbound: new ActivityOutboundLogInterceptor("slack"),
+        }),
+        () => ({
+          inbound: new SlackCastKnownErrorsInterceptor(),
+        }),
       ],
     },
   });

--- a/connectors/src/connectors/snowflake/temporal/worker.ts
+++ b/connectors/src/connectors/snowflake/temporal/worker.ts
@@ -10,7 +10,10 @@ import {
   getTemporalWorkerConnection,
   TEMPORAL_MAXED_CACHED_WORKFLOWS,
 } from "@connectors/lib/temporal";
-import { ActivityInboundLogInterceptor } from "@connectors/lib/temporal_monitoring";
+import {
+  ActivityInboundLogInterceptor,
+  ActivityOutboundLogInterceptor,
+} from "@connectors/lib/temporal_monitoring";
 import logger from "@connectors/logger/logger";
 
 export async function runSnowflakeWorker() {
@@ -25,11 +28,14 @@ export async function runSnowflakeWorker() {
     reuseV8Context: true,
     namespace,
     interceptors: {
-      activityInbound: [
-        (ctx: Context) => {
-          return new ActivityInboundLogInterceptor(ctx, logger, "snowflake");
-        },
-        () => new SnowflakeCastKnownErrorsInterceptor(),
+      activity: [
+        (ctx: Context) => ({
+          inbound: new ActivityInboundLogInterceptor(ctx, logger, "snowflake"),
+          outbound: new ActivityOutboundLogInterceptor("snowflake"),
+        }),
+        () => ({
+          inbound: new SnowflakeCastKnownErrorsInterceptor(),
+        }),
       ],
     },
     bundlerOptions: {

--- a/connectors/src/connectors/webcrawler/temporal/worker.ts
+++ b/connectors/src/connectors/webcrawler/temporal/worker.ts
@@ -6,7 +6,10 @@ import {
   getTemporalWorkerConnection,
   TEMPORAL_MAXED_CACHED_WORKFLOWS,
 } from "@connectors/lib/temporal";
-import { ActivityInboundLogInterceptor } from "@connectors/lib/temporal_monitoring";
+import {
+  ActivityInboundLogInterceptor,
+  ActivityOutboundLogInterceptor,
+} from "@connectors/lib/temporal_monitoring";
 import logger from "@connectors/logger/logger";
 
 import { WebCrawlerQueueNames } from "./config";
@@ -24,10 +27,15 @@ export async function runWebCrawlerWorker() {
       maxConcurrentActivityTaskExecutions: 6,
       maxCachedWorkflows: TEMPORAL_MAXED_CACHED_WORKFLOWS,
       interceptors: {
-        activityInbound: [
-          (ctx: Context) => {
-            return new ActivityInboundLogInterceptor(ctx, logger, "webcrawler");
-          },
+        activity: [
+          (ctx: Context) => ({
+            inbound: new ActivityInboundLogInterceptor(
+              ctx,
+              logger,
+              "webcrawler"
+            ),
+            outbound: new ActivityOutboundLogInterceptor("webcrawler"),
+          }),
         ],
       },
     }),
@@ -41,9 +49,15 @@ export async function runWebCrawlerWorker() {
       maxConcurrentActivityTaskExecutions: 3,
       maxCachedWorkflows: TEMPORAL_MAXED_CACHED_WORKFLOWS,
       interceptors: {
-        activityInbound: [
-          (ctx: Context) =>
-            new ActivityInboundLogInterceptor(ctx, logger, "webcrawler"),
+        activity: [
+          (ctx: Context) => ({
+            inbound: new ActivityInboundLogInterceptor(
+              ctx,
+              logger,
+              "webcrawler"
+            ),
+            outbound: new ActivityOutboundLogInterceptor("webcrawler"),
+          }),
         ],
       },
     }),
@@ -57,9 +71,15 @@ export async function runWebCrawlerWorker() {
       maxConcurrentActivityTaskExecutions: 16,
       maxCachedWorkflows: TEMPORAL_MAXED_CACHED_WORKFLOWS,
       interceptors: {
-        activityInbound: [
-          (ctx: Context) =>
-            new ActivityInboundLogInterceptor(ctx, logger, "webcrawler"),
+        activity: [
+          (ctx: Context) => ({
+            inbound: new ActivityInboundLogInterceptor(
+              ctx,
+              logger,
+              "webcrawler"
+            ),
+            outbound: new ActivityOutboundLogInterceptor("webcrawler"),
+          }),
         ],
       },
     }),


### PR DESCRIPTION
## Description
- Follow up of https://github.com/dust-tt/dust/pull/15030 that didn't work as expected, we didn't see new tags being added to temporal in datadog
- Per jsdoc `activityInbound` is deprecated, so replace it by `activity` for each workers interceptors.

Per jsdoc of `metricMeter`:
```
Get the metric meter for this activity with activity-specific tags.
To add custom tags, register a {@link ActivityOutboundCallsInterceptor} that
intercepts the `getMetricTags()` method.
```
Added a new `ActivityOutboundLogInterceptor` to add a custom tags to `getLogAttributes` and `getMetricTags` see if it add back tags to Datadog

## Tests
- Locally

## Risk
- Should be low, should have no change to current interceptor, and the new one just add a simple tag.

## Deploy Plan
- Deploy connectors
