### PR TITLE
[front] Improve Poke plugin dialog display

### DIFF
--- a/front/components/poke/plugins/RunPluginDialog.tsx
+++ b/front/components/poke/plugins/RunPluginDialog.tsx
@@ -87,7 +87,7 @@ export function RunPluginDialog({
     <Dialog open={true} onOpenChange={handleClose}>
       <DialogContent
         className={cn(
-          "w-auto overflow-visible",
+          "w-auto",
           "bg-muted-background dark:bg-muted-background-night",
           "sm:min-w-[600px] sm:max-w-[1000px]"
         )}


### PR DESCRIPTION
## Description

- This PR improves the visual appearance of the `RunPluginDialog` component by clipping the Dialog on the outer container, which has rounded borders.

Before

<img width="493" height="244" alt="Screenshot 2025-08-14 at 5 45 45 PM" src="https://github.com/user-attachments/assets/bb5ea2dc-bb47-49d1-a896-23d6946a41c7" />

After (see the top border)

<img width="493" height="244" alt="Screenshot 2025-08-14 at 5 45 35 PM" src="https://github.com/user-attachments/assets/e205ff78-a90a-41fa-a13e-a6790410b33c" />


## Tests

- Checked locally.

## Risk

- Very low.

## Deploy Plan

- Deploy front.
