### PR TITLE
Reduce RUM session sampling rate to 20%

### DIFF
--- a/front/pages/_document.tsx
+++ b/front/pages/_document.tsx
@@ -60,7 +60,7 @@ class MyDocument extends Document {
                  ],
                  traceSampleRate: 5,
                  traceContextInjection: 'sampled',
-                 sessionSampleRate: 100,
+                 sessionSampleRate: 20,
                  sessionReplaySampleRate: 5,
                  defaultPrivacyLevel: 'mask-user-input',
                  beforeSend: function (event) {


### PR DESCRIPTION
## Description

Reduces the Datadog RUM session sampling rate from 100% to 20% in the frontend configuration. This change decreases the amount of session data collected for monitoring while maintaining sufficient coverage for observability.

## Tests

This change only modifies a configuration value and doesn't require additional tests. The impact can be verified by monitoring the volume of session data sent to Datadog after deployment.

## Risk

Low risk change. This is a configuration adjustment that reduces data collection volume. If issues arise, the change can be easily rolled back by reverting the sampling rate back to 100%.

## Deploy Plan

Standard deployment - no special considerations required. The change takes effect immediately after deployment and will reduce the volume of RUM data sent to Datadog.
