### PR TITLE
[front] Fix clipped Poke enum list

### DIFF
--- a/front/components/poke/plugins/EnumSelect.tsx
+++ b/front/components/poke/plugins/EnumSelect.tsx
@@ -53,11 +53,7 @@ export function EnumSelect({
           </PokeButton>
         </PokeFormControl>
       </PopoverTrigger>
-      <PopoverContent
-        className="w-[400px] p-0"
-        mountPortal={false}
-        align="start"
-      >
+      <PopoverContent className="w-[400px] p-0" align="start">
         <PokeCommand className="gap-2 py-3">
           <PokeCommandInput placeholder={label} className="h-9 p-2" />
           <PokeCommandList>


### PR DESCRIPTION
## Description

- Forgot to push a commit on https://github.com/dust-tt/dust/pull/15091.
- This PR allows the Popover to overflow the outside container, otherwise it'll be clipped and we can't see the entire dropdown.

## Tests

- Checked locally.

## Risk

- Low.

## Deploy Plan

- Deploy front.
