### PR TITLE
[front] Various UI improvements to Poke

### DIFF
--- a/front/components/poke/apps/view.tsx
+++ b/front/components/poke/apps/view.tsx
@@ -21,7 +21,7 @@ export function ViewAppTable({
       <div className="flex justify-between gap-3">
         <div className="border-material-200 my-4 flex flex-grow flex-col rounded-lg border p-4">
           <div className="flex items-center justify-between gap-3">
-            <h2 className="text-md flex-grow pb-4 font-bold">Overview:</h2>
+            <h2 className="text-md flex-grow pb-4 font-bold">Overview</h2>
           </div>
           <PokeTable>
             <PokeTableBody>

--- a/front/components/poke/data_source_views/view.tsx
+++ b/front/components/poke/data_source_views/view.tsx
@@ -25,7 +25,7 @@ export function ViewDataSourceViewTable({
       <div className="flex justify-between gap-3">
         <div className="border-material-200 my-4 flex flex-grow flex-col rounded-lg border p-4">
           <div className="flex items-center justify-between gap-3">
-            <h2 className="text-md flex-grow pb-4 font-bold">Overview:</h2>
+            <h2 className="text-md flex-grow pb-4 font-bold">Overview</h2>
           </div>
           <PokeTable>
             <PokeTableBody>

--- a/front/components/poke/data_sources/view.tsx
+++ b/front/components/poke/data_sources/view.tsx
@@ -64,7 +64,7 @@ export function ViewDataSourceTable({
         <div className="flex justify-between gap-3">
           <div className="border-material-200 my-4 flex flex-grow flex-col rounded-lg border p-4">
             <div className="flex items-center justify-between gap-3">
-              <h2 className="text-md flex-grow pb-4 font-bold">Overview:</h2>
+              <h2 className="text-md flex-grow pb-4 font-bold">Overview</h2>
               <Button
                 aria-label="View raw objects"
                 variant="outline"

--- a/front/components/poke/mcp_server_views/view.tsx
+++ b/front/components/poke/mcp_server_views/view.tsx
@@ -28,7 +28,7 @@ export function ViewMCPServerViewTable({
       <div className="flex justify-between gap-3">
         <div className="border-material-200 my-4 flex flex-grow flex-col rounded-lg border p-4">
           <div className="flex items-center justify-between gap-3">
-            <h2 className="text-md flex-grow pb-4 font-bold">Overview:</h2>
+            <h2 className="text-md flex-grow pb-4 font-bold">Overview</h2>
           </div>
           <PokeTable>
             <PokeTableBody>

--- a/front/components/poke/plugins/EnumSelect.tsx
+++ b/front/components/poke/plugins/EnumSelect.tsx
@@ -35,7 +35,7 @@ export function EnumSelect({
   value,
 }: EnumSelectProps) {
   return (
-    <PopoverRoot modal={false}>
+    <PopoverRoot modal={true}>
       <PopoverTrigger asChild>
         <PokeFormControl>
           <PokeButton

--- a/front/components/poke/plugins/EnumSelect.tsx
+++ b/front/components/poke/plugins/EnumSelect.tsx
@@ -6,6 +6,7 @@ import {
   PopoverTrigger,
 } from "@dust-tt/sparkle";
 import { Check, CheckCircle, Circle } from "lucide-react";
+import React from "react";
 
 import { PokeButton } from "@app/components/poke/shadcn/ui/button";
 import {
@@ -18,7 +19,6 @@ import {
 } from "@app/components/poke/shadcn/ui/command";
 import { PokeFormControl } from "@app/components/poke/shadcn/ui/form";
 import type { AsyncEnumValues, EnumValues } from "@app/types/poke/plugins";
-import React, { useState } from "react";
 
 interface EnumSelectProps {
   label?: string;
@@ -35,7 +35,7 @@ export function EnumSelect({
   placeholder = "Select value",
   value,
 }: EnumSelectProps) {
-  const [open, setOpen] = useState(false);
+  const [open, setOpen] = React.useState(false);
 
   return (
     <PopoverRoot modal={true} open={open} onOpenChange={setOpen}>

--- a/front/components/poke/plugins/EnumSelect.tsx
+++ b/front/components/poke/plugins/EnumSelect.tsx
@@ -18,6 +18,7 @@ import {
 } from "@app/components/poke/shadcn/ui/command";
 import { PokeFormControl } from "@app/components/poke/shadcn/ui/form";
 import type { AsyncEnumValues, EnumValues } from "@app/types/poke/plugins";
+import React, { useState } from "react";
 
 interface EnumSelectProps {
   label?: string;
@@ -34,8 +35,10 @@ export function EnumSelect({
   placeholder = "Select value",
   value,
 }: EnumSelectProps) {
+  const [open, setOpen] = useState(false);
+
   return (
-    <PopoverRoot modal={true}>
+    <PopoverRoot modal={true} open={open} onOpenChange={setOpen}>
       <PopoverTrigger asChild>
         <PokeFormControl>
           <PokeButton
@@ -65,6 +68,7 @@ export function EnumSelect({
                   key={option.value}
                   onSelect={() => {
                     onValueChange(option.value);
+                    setOpen(false);
                   }}
                 >
                   <div className="flex w-full items-center gap-2">

--- a/front/components/poke/plugins/PluginList.tsx
+++ b/front/components/poke/plugins/PluginList.tsx
@@ -20,7 +20,7 @@ interface PluginCardProps {
 function PluginCard({ onClick, plugin }: PluginCardProps) {
   return (
     <PokeCard
-      className="flex h-20 w-44 cursor-pointer hover:bg-gray-100"
+      className="flex h-20 w-44 cursor-pointer hover:bg-gray-100 dark:hover:bg-gray-800"
       onClick={onClick}
     >
       <PokeCardHeader className="flex space-y-1.5 overflow-hidden p-2 text-left">

--- a/front/components/poke/plugins/PluginList.tsx
+++ b/front/components/poke/plugins/PluginList.tsx
@@ -84,7 +84,7 @@ export function PluginList({ pluginResourceTarget }: PluginListProps) {
         </div>
       </div>
 
-      <div>
+      <div className="h-full">
         {filteredPlugins.length === 0 ? (
           <div className="flex h-full items-center justify-center text-gray-500">
             {searchQuery.trim() ? (

--- a/front/components/poke/plugins/PluginList.tsx
+++ b/front/components/poke/plugins/PluginList.tsx
@@ -20,7 +20,7 @@ interface PluginCardProps {
 function PluginCard({ onClick, plugin }: PluginCardProps) {
   return (
     <PokeCard
-      className="flex h-20 w-44 cursor-pointer hover:bg-gray-100 dark:hover:bg-gray-800"
+      className="flex h-20 w-44 cursor-pointer hover:bg-gray-100 dark:hover:bg-muted/10"
       onClick={onClick}
     >
       <PokeCardHeader className="flex space-y-1.5 overflow-hidden p-2 text-left">

--- a/front/components/poke/plugins/PluginList.tsx
+++ b/front/components/poke/plugins/PluginList.tsx
@@ -73,7 +73,7 @@ export function PluginList({ pluginResourceTarget }: PluginListProps) {
   return (
     <div className="border-material-200 flex min-h-48 flex-col rounded-lg border bg-muted-background dark:bg-muted-background-night">
       <div className="flex justify-between gap-3 rounded-t-lg bg-primary-300 p-4 dark:bg-primary-300-night">
-        <h2 className="text-md font-bold">Plugins :</h2>
+        <h2 className="text-md font-bold">Plugins</h2>
         <div className="max-w-xs flex-1">
           <Input
             placeholder="Search plugins..."

--- a/front/components/poke/shadcn/ui/card.tsx
+++ b/front/components/poke/shadcn/ui/card.tsx
@@ -9,7 +9,7 @@ const Card = React.forwardRef<
   <div
     ref={ref}
     className={cn(
-      "bg-card text-card-foreground rounded-lg border shadow-sm",
+      "bg-card text-card-foreground dark:text-card-foreground-night rounded-lg border shadow-sm",
       className
     )}
     {...props}
@@ -47,7 +47,10 @@ const CardDescription = React.forwardRef<
 >(({ className, ...props }, ref) => (
   <p
     ref={ref}
-    className={cn("copy-sm text-muted-foreground", className)}
+    className={cn(
+      "copy-sm text-muted-foreground dark:text-muted-foreground-night",
+      className
+    )}
     {...props}
   />
 ));

--- a/front/components/poke/shadcn/ui/command.tsx
+++ b/front/components/poke/shadcn/ui/command.tsx
@@ -138,11 +138,13 @@ const CommandInput = React.forwardRef<
   React.ComponentPropsWithoutRef<typeof CommandPrimitive.Input>
 >(({ className, ...props }, ref) => (
   <div className="flex items-center border-b px-3" cmdk-input-wrapper="">
-    <MagnifyingGlassIcon className="mr-2 h-4 w-4 shrink-0 opacity-50" />
+    <MagnifyingGlassIcon className="mb-3 mr-2 h-4 w-4 shrink-0 opacity-50" />
     <CommandPrimitive.Input
       ref={ref}
       className={cn(
-        "flex h-10 w-full rounded-md bg-transparent py-3 text-sm outline-none placeholder:text-muted-foreground disabled:cursor-not-allowed disabled:opacity-50",
+        "mb-3 flex h-10 w-full rounded-md bg-transparent py-3 text-sm outline-none",
+        "placeholder:text-muted-foreground disabled:cursor-not-allowed disabled:opacity-50",
+        "dark:placeholder:text-muted-foreground-night",
         className
       )}
       {...props}

--- a/front/components/poke/shadcn/ui/command.tsx
+++ b/front/components/poke/shadcn/ui/command.tsx
@@ -119,7 +119,9 @@ const CommandDialog = ({
             shouldFilter={shouldFilter}
             className={cn(
               "text-muted-foreground dark:text-muted-foreground-night",
-              "[&_[cmdk-group-heading]]:px-2 [&_[cmdk-group-heading]]:font-medium [&_[cmdk-group-heading]]:text-muted-foreground",
+              "[&_[cmdk-group-heading]]:px-2 [&_[cmdk-group-heading]]:font-medium",
+              "[&_[cmdk-group-heading]]:text-muted-foreground",
+              "dark:[&_[cmdk-group-heading]]:text-muted-foreground-night",
               "[&_[cmdk-group]:not([hidden])_~[cmdk-group]]:pt-0 [&_[cmdk-group]]:px-2",
               "[&_[cmdk-input-wrapper]_svg]:h-5 [&_[cmdk-input-wrapper]_svg]:w-5 [&_[cmdk-input]]:h-12",
               "[&_[cmdk-item]]:px-2 [&_[cmdk-item]]:py-3 [&_[cmdk-item]_svg]:h-5 [&_[cmdk-item]_svg]:w-5"
@@ -187,7 +189,11 @@ const CommandGroup = React.forwardRef<
   <CommandPrimitive.Group
     ref={ref}
     className={cn(
-      "overflow-hidden p-1 text-foreground [&_[cmdk-group-heading]]:px-2 [&_[cmdk-group-heading]]:py-1.5 [&_[cmdk-group-heading]]:text-xs [&_[cmdk-group-heading]]:font-medium [&_[cmdk-group-heading]]:text-muted-foreground",
+      "overflow-hidden p-1 text-foreground dark:text-foreground-night",
+      "[&_[cmdk-group-heading]]:px-2 [&_[cmdk-group-heading]]:py-1.5",
+      "[&_[cmdk-group-heading]]:text-xs [&_[cmdk-group-heading]]:font-medium",
+      "[&_[cmdk-group-heading]]:text-muted-foreground",
+      "dark:[&_[cmdk-group-heading]]:text-muted-foreground-night",
       className
     )}
     {...props}
@@ -262,6 +268,7 @@ const CommandShortcut = ({
     <span
       className={cn(
         "ml-auto text-xs tracking-widest text-muted-foreground",
+        "dark:text-muted-foreground-night",
         className
       )}
       {...props}

--- a/front/components/poke/shadcn/ui/table.tsx
+++ b/front/components/poke/shadcn/ui/table.tsx
@@ -70,6 +70,7 @@ const TableRow = React.forwardRef<
     ref={ref}
     className={cn(
       "border-b transition-colors hover:bg-muted/50 data-[state=selected]:bg-muted",
+      "dark:hover:bg-muted/10 dark:data-[state=selected]:bg-muted-night",
       className
     )}
     {...props}
@@ -84,7 +85,9 @@ const TableHead = React.forwardRef<
   <th
     ref={ref}
     className={cn(
-      "h-10 px-2 text-left align-middle font-medium text-muted-foreground [&:has([role=checkbox])]:pr-0 [&>[role=checkbox]]:translate-y-[2px]",
+      "h-10 px-2 text-left align-middle font-medium text-muted-foreground",
+      "dark:text-muted-foreground-night [&:has([role=checkbox])]:pr-0",
+      "[&>[role=checkbox]]:translate-y-[2px]",
       className
     )}
     {...props}
@@ -113,7 +116,10 @@ const TableCaption = React.forwardRef<
 >(({ className, ...props }, ref) => (
   <caption
     ref={ref}
-    className={cn("mt-4 text-sm text-muted-foreground", className)}
+    className={cn(
+      "mt-4 text-sm text-muted-foreground dark:text-muted-foreground-night",
+      className
+    )}
     {...props}
   />
 ));

--- a/front/components/poke/spaces/view.tsx
+++ b/front/components/poke/spaces/view.tsx
@@ -19,7 +19,7 @@ export function ViewSpaceViewTable({ space }: ViewSpaceTableProps) {
       <div className="flex justify-between gap-3">
         <div className="border-material-200 my-4 flex flex-grow flex-col rounded-lg border p-4">
           <div className="flex items-center justify-between gap-3">
-            <h2 className="text-md flex-grow pb-4 font-bold">Overview:</h2>
+            <h2 className="text-md flex-grow pb-4 font-bold">Overview</h2>
           </div>
           <PokeTable>
             <PokeTableBody>

--- a/front/components/poke/subscriptions/table.tsx
+++ b/front/components/poke/subscriptions/table.tsx
@@ -100,7 +100,7 @@ export function ActiveSubscriptionTable({
           <div className="border-material-200 flex flex-grow flex-col rounded-lg border p-4">
             <div className="flex items-center justify-between gap-3">
               <h2 className="text-md flex-grow pb-4 font-bold">
-                Active Subscription:
+                Active Subscription
               </h2>
               <SubscriptionsHistoryModal
                 owner={owner}
@@ -167,7 +167,7 @@ export function ActiveSubscriptionTable({
             </PokeTable>
           </div>
           <div className="border-material-200 flex flex-grow flex-col rounded-lg border p-4">
-            <h2 className="text-md pb-4 font-bold">Plan limitations:</h2>
+            <h2 className="text-md pb-4 font-bold">Plan limitations</h2>
             <PokeTable>
               <PokeTableBody>
                 <PokeTableRow>

--- a/front/components/poke/workspace/table.tsx
+++ b/front/components/poke/workspace/table.tsx
@@ -67,7 +67,7 @@ export function WorkspaceInfoTable({
     <div className="flex justify-between gap-3">
       <div className="border-material-200 flex flex-grow flex-col rounded-lg border p-4">
         <div className="flex items-center justify-between gap-3">
-          <h2 className="text-md flex-grow pb-4 font-bold">Workspace info:</h2>
+          <h2 className="text-md flex-grow pb-4 font-bold">Workspace info</h2>
         </div>
         <PokeTable>
           <PokeTableBody>

--- a/front/components/poke/workspace/table.tsx
+++ b/front/components/poke/workspace/table.tsx
@@ -131,6 +131,9 @@ export function WorkspaceInfoTable({
                     ? "⚠️"
                     : "❌"}
               </PokeTableCell>
+            </PokeTableRow>
+            <PokeTableRow>
+              <PokeTableCell>Verified Domains</PokeTableCell>
               <PokeTableCell>
                 {workspaceVerifiedDomains.map((d) => d.domain).join(", ")}
               </PokeTableCell>

--- a/front/pages/poke/[wId]/assistants/[aId]/index.tsx
+++ b/front/pages/poke/[wId]/assistants/[aId]/index.tsx
@@ -67,7 +67,7 @@ const AssistantDetailsPage = ({
     <div>
       <div className="flex flex-row justify-between gap-4">
         <h3 className="text-xl font-bold">
-          Agent of workspace:{" "}
+          Agent from workspace{" "}
           <a href={`/poke/${workspace.sId}`} className="text-highlight-500">
             {workspace.name}
           </a>

--- a/front/pages/poke/[wId]/assistants/[aId]/index.tsx
+++ b/front/pages/poke/[wId]/assistants/[aId]/index.tsx
@@ -77,7 +77,7 @@ const AssistantDetailsPage = ({
             <DropdownMenuTrigger asChild>
               <Button
                 icon={UserGroupIcon}
-                onClick={(e: any) => {
+                onClick={(e: React.MouseEvent<HTMLButtonElement>) => {
                   e.currentTarget.focus();
                 }}
                 label={`Editors`}

--- a/front/pages/poke/[wId]/conversations/[cId]/index.tsx
+++ b/front/pages/poke/[wId]/conversations/[cId]/index.tsx
@@ -291,7 +291,7 @@ const ConversationPage = ({
       {conversation && (
         <div className="max-w-4xl">
           <h3 className="text-xl font-bold">
-            Conversation of workspace:{" "}
+            Conversation in workspace{" "}
             <a href={`/poke/${workspaceId}`} className="text-highlight-500">
               {workspace.name}
             </a>

--- a/front/pages/poke/[wId]/data_sources/[dsId]/index.tsx
+++ b/front/pages/poke/[wId]/data_sources/[dsId]/index.tsx
@@ -556,7 +556,7 @@ const DataSourcePage = ({
   return (
     <>
       <h3 className="text-xl font-bold">
-        Data Source: {dataSource.name} of workspace:{" "}
+        Data Source {dataSource.name} in workspace{" "}
         <a href={`/poke/${owner.sId}`} className="text-highlight-500">
           {owner.name}
         </a>

--- a/front/pages/poke/[wId]/data_sources/[dsId]/index.tsx
+++ b/front/pages/poke/[wId]/data_sources/[dsId]/index.tsx
@@ -562,7 +562,7 @@ const DataSourcePage = ({
         </a>
       </h3>
       <p>
-        The content source of truth is <b>connectors</b>.
+        The data displayed here is fetched from <b>connectors</b>.
       </p>
 
       <div className="flex flex-row gap-x-6">

--- a/front/pages/poke/[wId]/groups/[groupId]/index.tsx
+++ b/front/pages/poke/[wId]/groups/[groupId]/index.tsx
@@ -74,7 +74,7 @@ export default function GroupPage({
   return (
     <>
       <h3 className="text-xl font-bold">
-        Group: {group.name} ({group.kind}) of workspace:{" "}
+        Group {group.name} ({group.kind}) within workspace{" "}
         <a href={`/poke/${owner.sId}`} className="text-highlight-500">
           {owner.name}
         </a>

--- a/front/pages/poke/[wId]/memberships.tsx
+++ b/front/pages/poke/[wId]/memberships.tsx
@@ -56,7 +56,7 @@ const MembershipsPage = ({
   return (
     <>
       <h3 className="text-xl font-bold">
-        Members of workspace:{" "}
+        Members of workspace{" "}
         <a href={`/poke/${owner.sId}`} className="text-highlight-500">
           {owner.name}
         </a>

--- a/front/pages/poke/[wId]/spaces/[spaceId]/data_source_views/[dsvId]/index.tsx
+++ b/front/pages/poke/[wId]/spaces/[spaceId]/data_source_views/[dsvId]/index.tsx
@@ -56,14 +56,14 @@ export default function DataSourceViewPage({
   return (
     <>
       <h3 className="text-xl font-bold">
-        {dataSourceView.name} in space:{" "}
+        {dataSourceView.name} in space{" "}
         <a
           href={`/poke/${owner.sId}/spaces/${dataSourceView.space.sId}`}
           className="text-highlight-500"
         >
           {dataSourceView.space.name}
         </a>{" "}
-        of workspace:{" "}
+        within workspace{" "}
         <a href={`/poke/${owner.sId}`} className="text-highlight-500">
           {owner.name}
         </a>

--- a/front/pages/poke/[wId]/spaces/[spaceId]/data_source_views/[dsvId]/index.tsx
+++ b/front/pages/poke/[wId]/spaces/[spaceId]/data_source_views/[dsvId]/index.tsx
@@ -69,7 +69,8 @@ export default function DataSourceViewPage({
         </a>
       </h3>
       <p>
-        The content source of truth is <b>core</b>.
+        The data displayed here is fetched from <b>core</b> (
+        <i>elasticsearch index</i>).
       </p>
       <div className="flex flex-row gap-x-6">
         <ViewDataSourceViewTable

--- a/front/pages/poke/[wId]/spaces/[spaceId]/index.tsx
+++ b/front/pages/poke/[wId]/spaces/[spaceId]/index.tsx
@@ -79,7 +79,7 @@ export default function SpacePage({
   return (
     <>
       <h3 className="text-xl font-bold">
-        Space: {space.name} ({space.kind}) of workspace:{" "}
+        Space {space.name} ({space.kind}) within workspace{" "}
         <a href={`/poke/${owner.sId}`} className="text-highlight-500">
           {owner.name}
         </a>

--- a/front/pages/poke/[wId]/spaces/[spaceId]/mcp_server_views/[svId]/index.tsx
+++ b/front/pages/poke/[wId]/spaces/[spaceId]/mcp_server_views/[svId]/index.tsx
@@ -47,14 +47,14 @@ export default function MCPServerViewPage({
   return (
     <>
       <h3 className="text-xl font-bold">
-        MCP Server View: {getMcpServerViewDisplayName(mcpServerView)} in space:{" "}
+        MCP Server View {getMcpServerViewDisplayName(mcpServerView)} in space{" "}
         <a
           href={`/poke/${owner.sId}/spaces/${mcpServerView.spaceId}`}
           className="text-highlight-500"
         >
           {mcpServerView.space?.name || mcpServerView.spaceId}
         </a>{" "}
-        of workspace:{" "}
+        within workspace{" "}
         <a href={`/poke/${owner.sId}`} className="text-highlight-500">
           {owner.name}
         </a>


### PR DESCRIPTION
## Description

- Improve text/hover colors in dark mode.
- Move verified domains to their own row in WorkspaceInfo to prevent having 3 column and making the hover only apply to the first 2 columns.
- Improve copy.
- Add margin underneath the Command input.
- Align `No plugins available` vertically.
- Close the enum list when clicking on an item.

Added margin

<img width="493" height="380" alt="Screenshot 2025-08-15 at 8 30 39 PM" src="https://github.com/user-attachments/assets/5d76c60e-85e6-41e3-85e0-86413140bf96" />

<img width="493" height="380" alt="Screenshot 2025-08-15 at 9 18 12 AM" src="https://github.com/user-attachments/assets/91bcac14-8ca8-469a-8ea3-cbfc7d14a5ca" />

No plugins available alignment

<img width="1650" height="177" alt="Screenshot 2025-08-15 at 8 31 34 PM" src="https://github.com/user-attachments/assets/a5dbdd1e-dc05-434c-97fd-c81295b5631b" />

<img width="1650" height="177" alt="Screenshot 2025-08-15 at 8 31 56 PM" src="https://github.com/user-attachments/assets/98a91940-013c-4ffa-98d2-34b13d2f6cec" />

## Tests

- Checked locally.

## Risk

- Low.

## Deploy Plan

- Deploy front.
