### PR TITLE
[sparkle] - fix(Dialog): fixed content

### DIFF
--- a/sparkle/src/components/Dialog.tsx
+++ b/sparkle/src/components/Dialog.tsx
@@ -3,7 +3,12 @@ import { FocusScope } from "@radix-ui/react-focus-scope";
 import { cva } from "class-variance-authority";
 import * as React from "react";
 
-import { Button, ButtonProps, ScrollArea } from "@sparkle/components";
+import {
+  Button,
+  ButtonProps,
+  ScrollArea,
+  Separator,
+} from "@sparkle/components";
 import { XMarkIcon } from "@sparkle/icons/app";
 import { cn } from "@sparkle/lib/utils";
 
@@ -141,20 +146,40 @@ const DialogHeader = ({
 );
 DialogHeader.displayName = "DialogHeader";
 
-const DialogContainer = ({
-  children,
-}: React.HTMLAttributes<HTMLDivElement>) => (
-  <ScrollArea className="s-w-full s-flex-grow">
-    <div
-      className={cn(
-        "s-copy-base s-relative s-flex s-flex-col s-gap-2 s-px-5 s-py-4 s-text-left",
-        "s-text-foreground dark:s-text-foreground-night"
-      )}
-    >
-      {children}
-    </div>
-  </ScrollArea>
-);
+interface DialogContainerProps extends React.HTMLAttributes<HTMLDivElement> {
+  fixedContent?: React.ReactNode;
+}
+
+const DialogContainer = ({ children, fixedContent }: DialogContainerProps) => {
+  const contentStyles = cn(
+    "s-copy-base s-px-5 s-py-4 s-text-foreground dark:s-text-foreground-night"
+  );
+
+  const scrollableContent = (
+    <ScrollArea className="s-w-full s-flex-grow">
+      <div
+        className={cn(
+          contentStyles,
+          "s-relative s-flex s-flex-col s-gap-2 s-text-left"
+        )}
+      >
+        {children}
+      </div>
+    </ScrollArea>
+  );
+
+  if (fixedContent) {
+    return (
+      <div className="s-flex s-flex-grow s-flex-col s-overflow-hidden">
+        <div className={cn(contentStyles, "s-flex-none")}>{fixedContent}</div>
+        <Separator />
+        {scrollableContent}
+      </div>
+    );
+  }
+
+  return scrollableContent;
+};
 DialogContainer.displayName = "DialogContainer";
 
 interface DialogFooterProps extends React.HTMLAttributes<HTMLDivElement> {

--- a/sparkle/src/components/MessageCard.tsx
+++ b/sparkle/src/components/MessageCard.tsx
@@ -15,10 +15,7 @@ export interface MessageCardProps {
   dismissible?: boolean;
 }
 
-export const MessageCard = React.forwardRef<
-  HTMLDivElement,
-  MessageCardProps
->(
+export const MessageCard = React.forwardRef<HTMLDivElement, MessageCardProps>(
   (
     {
       className,

--- a/sparkle/src/components/MultiPageDialog.tsx
+++ b/sparkle/src/components/MultiPageDialog.tsx
@@ -2,8 +2,7 @@ import { cva } from "class-variance-authority";
 import * as React from "react";
 import { useState } from "react";
 
-import { Button, Icon, ScrollArea } from "@sparkle/components";
-import { Separator } from "@sparkle/components";
+import { Button, Icon, ScrollArea, Separator } from "@sparkle/components";
 import {
   Dialog,
   DialogClose,
@@ -26,6 +25,7 @@ interface MultiPageDialogPage {
   description?: string;
   icon?: React.ComponentType;
   content: React.ReactNode;
+  fixedContent?: React.ReactNode;
 }
 
 const MultiPageDialogRoot = Dialog;
@@ -256,7 +256,7 @@ const MultiPageDialogContent = React.forwardRef<
           </DialogHeader>
 
           <div className="s-min-h-0 s-flex-1 s-overflow-hidden">
-            <ScrollArea
+            <div
               className={cn(
                 "s-h-full s-transition-all s-duration-200 s-ease-out",
                 {
@@ -266,13 +266,26 @@ const MultiPageDialogContent = React.forwardRef<
                   "s--translate-x-2":
                     isTransitioning && transitionDirection === "prev",
                   "s-translate-x-0 s-opacity-100": !isTransitioning,
-                }
+                },
+                currentPage.fixedContent ? "s-flex s-flex-col" : ""
               )}
             >
-              <div className="s-flex s-flex-col s-gap-2 s-px-5 s-py-4">
-                {currentPage.content}
-              </div>
-            </ScrollArea>
+              {currentPage.fixedContent && (
+                <>
+                  <div className="s-flex-none s-px-5 s-py-4">
+                    {currentPage.fixedContent}
+                  </div>
+                  <Separator />
+                </>
+              )}
+              <ScrollArea
+                className={currentPage.fixedContent ? "s-flex-1" : "s-h-full"}
+              >
+                <div className="s-flex s-flex-col s-gap-2 s-px-5 s-py-4">
+                  {currentPage.content}
+                </div>
+              </ScrollArea>
+            </div>
           </div>
 
           <MultiPageDialogFooter

--- a/sparkle/src/components/MultiPageDialog.tsx
+++ b/sparkle/src/components/MultiPageDialog.tsx
@@ -183,7 +183,10 @@ const MultiPageDialogContent = React.forwardRef<
         {...props}
       >
         <div className={cn(multiPageDialogLayoutVariants())}>
-          <DialogHeader hideButton={true} className="s-flex-none">
+          <DialogHeader
+            hideButton={showHeaderNavigation}
+            className="s-flex-none"
+          >
             <div className="s-flex s-items-center s-justify-between s-pr-8">
               <div className="s-flex s-items-center s-gap-3">
                 {showNavigation && showHeaderNavigation && (

--- a/sparkle/src/components/Resizable.tsx
+++ b/sparkle/src/components/Resizable.tsx
@@ -48,7 +48,7 @@ const ResizableHandle = ({
       <div
         className={cn(
           "s-absolute s-flex s-h-6 s-w-2 s-items-center s-justify-center s-rounded-2xl",
-          "s-border-gray-100 s-border s-bg-white"
+          "s-border s-border-gray-100 s-bg-white"
         )}
       >
         <div className="s-w-px" />

--- a/sparkle/src/stories/Dialog.stories.tsx
+++ b/sparkle/src/stories/Dialog.stories.tsx
@@ -1,7 +1,7 @@
 import type { Meta, StoryObj } from "@storybook/react";
 import React from "react";
 
-import { Avatar, Button, Input } from "@sparkle/components";
+import { Avatar, Button, Input, SearchInput } from "@sparkle/components";
 
 import {
   Dialog,
@@ -168,7 +168,16 @@ export const LargeContent: Story = {
         <DialogHeader>
           <DialogTitle>Terms of Service</DialogTitle>
         </DialogHeader>
-        <DialogContainer>
+        <DialogContainer
+          fixedContent={
+            <SearchInput
+              value=""
+              onChange={() => {}}
+              name="search-terms"
+              placeholder="Search terms..."
+            />
+          }
+        >
           <div className="s-space-y-4">
             <h3 className="s-font-semibold">1. Introduction</h3>
             <p className="s-text-sm s-text-muted-foreground">
@@ -202,6 +211,13 @@ export const LargeContent: Story = {
               Lorem ipsum dolor sit amet consectetur adipisicing elit. Deserunt
               architecto dolorem corrupti accusamus optio neque officia
               perferendis molestiae.
+            </p>
+            <h3 className="s-font-semibold">6. Additional Terms</h3>
+            <p className="s-text-sm s-text-muted-foreground">
+              More content to make the dialog scrollable and test the fixed
+              search input functionality. Lorem ipsum dolor sit amet consectetur
+              adipisicing elit. Quod possimus sit modi reprehenderit sed dolorem
+              nisi nostrum.
             </p>
           </div>
         </DialogContainer>

--- a/sparkle/src/stories/MultiPageDialog.stories.tsx
+++ b/sparkle/src/stories/MultiPageDialog.stories.tsx
@@ -274,6 +274,7 @@ export const SimpleToolDialog: Story = {
         </MultiPageDialogTrigger>
         <MultiPageDialogContent
           pages={toolPages}
+          showHeaderNavigation={false}
           currentPageId="tool-selection"
           onPageChange={() => {}}
           size="xl"

--- a/sparkle/src/stories/MultiPageDialog.stories.tsx
+++ b/sparkle/src/stories/MultiPageDialog.stories.tsx
@@ -1,8 +1,8 @@
 import type { Meta, StoryObj } from "@storybook/react";
 import React, { useState } from "react";
 
-import { Button } from "@sparkle/components/Button";
 import { SearchInput } from "@sparkle/components";
+import { Button } from "@sparkle/components/Button";
 import {
   MultiPageDialog,
   MultiPageDialogContent,

--- a/sparkle/src/stories/MultiPageDialog.stories.tsx
+++ b/sparkle/src/stories/MultiPageDialog.stories.tsx
@@ -2,6 +2,7 @@ import type { Meta, StoryObj } from "@storybook/react";
 import React, { useState } from "react";
 
 import { Button } from "@sparkle/components/Button";
+import { SearchInput } from "@sparkle/components";
 import {
   MultiPageDialog,
   MultiPageDialogContent,
@@ -710,6 +711,7 @@ export const ScrollableContent: Story = {
   render: () => {
     const [currentPageId, setCurrentPageId] = useState("long-form");
     const [isOpen, setIsOpen] = useState(false);
+    const [searchTerm, setSearchTerm] = useState("");
 
     const handleSave = () => {
       alert("Long form submitted!");
@@ -739,8 +741,17 @@ export const ScrollableContent: Story = {
       {
         id: "long-form",
         title: "Long Form Content",
-        description: "This page demonstrates scrollable content",
+        description:
+          "This page demonstrates scrollable content with fixed search",
         icon: DocumentTextIcon,
+        fixedContent: (
+          <SearchInput
+            value={searchTerm}
+            onChange={setSearchTerm}
+            name="search-content"
+            placeholder="Search through content..."
+          />
+        ),
         content: (
           <div className="s-space-y-6">
             <div>
@@ -749,9 +760,16 @@ export const ScrollableContent: Story = {
               </h3>
               <p className="s-text-sm s-text-muted-foreground">
                 This page contains a lot of content to demonstrate scrolling
-                functionality. The content should be scrollable within the
-                dialog area.
+                functionality with a fixed search input. The search input stays
+                visible while scrolling through the content below.
               </p>
+              {searchTerm && (
+                <div className="s-rounded-md s-border s-bg-yellow-50 s-p-3">
+                  <p className="s-text-sm s-text-yellow-800">
+                    🔍 Searching for: <strong>{searchTerm}</strong>
+                  </p>
+                </div>
+              )}
             </div>
 
             {Array.from({ length: 15 }, (_, i) => (
@@ -794,12 +812,13 @@ export const ScrollableContent: Story = {
 
             <div className="s-rounded-md s-border s-bg-blue-50 s-p-4">
               <h4 className="s-mb-2 s-text-sm s-font-semibold s-text-blue-900">
-                Scroll Test Complete
+                Fixed Content Test Complete
               </h4>
               <p className="s-text-xs s-text-blue-700">
-                If you can see this message, the scrolling functionality is
-                working correctly! The dialog maintains its fixed height while
-                allowing the content to scroll.
+                If you can see this message, the fixed content functionality is
+                working correctly! The search input remains fixed at the top
+                while this content scrolls. Try scrolling back up - the search
+                input should always be visible.
               </p>
             </div>
           </div>
@@ -837,13 +856,14 @@ export const ScrollableContent: Story = {
     return (
       <MultiPageDialog open={isOpen} onOpenChange={setIsOpen}>
         <MultiPageDialogTrigger asChild>
-          <Button label="Open Scrollable Content Dialog" />
+          <Button label="Open Fixed Content Test Dialog" />
         </MultiPageDialogTrigger>
         <MultiPageDialogContent
           pages={scrollablePages}
           currentPageId={currentPageId}
           onPageChange={setCurrentPageId}
-          size="lg"
+          size="xl"
+          height="xl"
           leftButton={{
             label: "Cancel",
             variant: "outline",


### PR DESCRIPTION
## Description

This PR enhances the `Dialog` components to support fixed content sections that remain visible while the rest of the dialog content scrolls. The PR introduces a new `fixedContent` prop to both `DialogContainer` and `MultiPageDialog` components, allowing for elements like search bars to remain anchored at the top.

<img width="861" height="392" alt="Screenshot 2025-08-15 at 11 16 54" src="https://github.com/user-attachments/assets/80ae70f3-ff2f-47ed-8796-8d205a1d601e" />
<img width="694" height="678" alt="Screenshot 2025-08-15 at 11 17 18" src="https://github.com/user-attachments/assets/4bd2b28e-dd88-463c-8078-dd3989c4a596" />

## Tests

Locally

## Risk

Low, this shouldn't introduce any breaking change.

## Deploy Plan

Publish sparkle
