### PR TITLE
[front] fix: panel can't close in AB

### DIFF
--- a/front/components/assistant/conversation/actions/AgentActionsPanel.tsx
+++ b/front/components/assistant/conversation/actions/AgentActionsPanel.tsx
@@ -20,7 +20,7 @@ export function AgentActionsPanel({
   owner,
 }: AgentActionsPanelProps) {
   const {
-    closePanel,
+    onPanelClosed,
     data: messageId,
     metadata: messageMetadata,
   } = useConversationSidePanelContext();
@@ -49,6 +49,7 @@ export function AgentActionsPanel({
     !fullAgentMessage ||
     fullAgentMessage.type !== "agent_message"
   ) {
+    onPanelClosed();
     return null;
   }
 
@@ -60,7 +61,7 @@ export function AgentActionsPanel({
     <div className="flex h-full flex-col">
       <AgentActionsPanelHeader
         title="Breakdown of the tools used"
-        onClose={closePanel}
+        onClose={onPanelClosed}
       />
       <div
         ref={scrollContainerRef}


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

Following modifications to the Tools breakdown animation, users can't close the panel when it's opened.

This PR fixes that + fixes a bug of empty panel on refresh in AB. 

Note : this makes the animation a tiny little bit less smooth in the main conversation, because content disappears before closing ends, in the main conversation. This is only when clicking on the cross to close.
I'll find a better fix on monday, this is to unblock users.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

Tested by hand.

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

Low

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->

Deploy front