### PR TITLE
Use the new Slack search API

### DIFF
--- a/front/lib/actions/mcp_internal_actions/servers/slack.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/slack.ts
@@ -536,6 +536,12 @@ const createServer = async (
               // Ideally, there would be a way to disable this behavior in the Slack API.
               content = content.replace(/[\uE000\uE001]/g, "");
 
+              // Replace <@U050CALAKFD|someone> with just @someone
+              content = content.replace(
+                /<@([A-Z0-9]+)\|([^>]+)>/g,
+                (_m, _id, username) => `@${username}`
+              );
+
               return `From ${author} in #${channel}: ${content}`;
             };
 

--- a/front/lib/actions/mcp_internal_actions/servers/slack.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/slack.ts
@@ -462,10 +462,11 @@ const createServer = async (
           }
 
           type SlackSemanticSearchMessage = {
-            permalink?: string;
-            content?: string;
+            author_name?: string;
             channel_name?: string;
             message_ts?: string;
+            content?: string;
+            permalink?: string;
           };
 
           type SlackSemanticSearchResponse = {
@@ -531,7 +532,7 @@ const createServer = async (
                   mimeType:
                     INTERNAL_MIME_TYPES.TOOL_OUTPUT.DATA_SOURCE_SEARCH_RESULT,
                   uri: match.permalink ?? "",
-                  text: `#${match.channel_name ?? "Unknown"}, ${match.content ?? ""}`,
+                  text: `From ${match.author_name ?? "Unknown"} in #${match.channel_name ?? "Unknown"}: ${match.content ?? ""}`,
                   id: match.message_ts ?? "",
                   source: {
                     provider: "slack",

--- a/front/lib/actions/mcp_internal_actions/servers/slack.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/slack.ts
@@ -438,20 +438,22 @@ const createServer = async (
             searchQuery = `${searchQuery} ${usersMentioned.map((user) => `${user}`).join(" ")}`;
           }
 
+          // The slack client library does not support the assistant.search.context endpoint,
+          // so we use the raw fetch API to call it (GET with query params).
+          const params = new URLSearchParams({
+            query: searchQuery,
+            sort: "score",
+            sort_dir: "desc",
+            limit: SLACK_SEARCH_ACTION_NUM_RESULTS.toString(),
+          });
+
           const resp = await fetch(
-            "https://slack.com/api/assistant.search.context",
+            `https://slack.com/api/assistant.search.context?${params.toString()}`,
             {
-              method: "POST",
+              method: "GET",
               headers: {
-                "Content-Type": "application/json; charset=utf-8",
                 Authorization: `Bearer ${accessToken}`,
               },
-              body: JSON.stringify({
-                query: searchQuery,
-                sort: "score",
-                sort_dir: "desc",
-                limit: SLACK_SEARCH_ACTION_NUM_RESULTS,
-              }),
             }
           );
 

--- a/front/lib/actions/mcp_internal_actions/servers/slack.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/slack.ts
@@ -526,13 +526,26 @@ const createServer = async (
               citationsOffset + SLACK_SEARCH_ACTION_NUM_RESULTS
             );
 
+            const getTextFromMatch = (match: SlackSemanticSearchMessage) => {
+              const author = match.author_name || "Unknown";
+              const channel = match.channel_name || "Unknown";
+              let content = match.content || "";
+
+              // assistant.search.context wraps search words in \uE000 and \uE001,
+              // which display as squares in the UI, so we strip them out.
+              // Ideally, there would be a way to disable this behavior in the Slack API.
+              content = content.replace(/[\uE000\uE001]/g, "");
+
+              return `From ${author} in #${channel}: ${content}`;
+            };
+
             const results: SearchResultResourceType[] = matches.map(
               (match): SearchResultResourceType => {
                 return {
                   mimeType:
                     INTERNAL_MIME_TYPES.TOOL_OUTPUT.DATA_SOURCE_SEARCH_RESULT,
                   uri: match.permalink ?? "",
-                  text: `From ${match.author_name ?? "Unknown"} in #${match.channel_name ?? "Unknown"}: ${match.content ?? ""}`,
+                  text: getTextFromMatch(match),
                   id: match.message_ts ?? "",
                   source: {
                     provider: "slack",


### PR DESCRIPTION
## Description

We were already using semantic search with the old API. This change switches to use the new API, which allows searching public channels that the user is not subscribed to, and is generally the API that Slack wants us to use.

## Tests

Manual

## Risk

Minimal, still under a flag

## Deploy Plan

Deploy Front