### PR TITLE
[connectors] fix(microsoft): Handle 413 HTTP error when upserting

### DIFF
--- a/connectors/src/connectors/microsoft/temporal/file.ts
+++ b/connectors/src/connectors/microsoft/temporal/file.ts
@@ -416,7 +416,6 @@ export async function syncOneFile({
               "Document too large for upsert, marking as skipped"
             );
 
-            // Save the skipReason to the database
             resourceBlob.skipReason = "payload_too_large";
 
             if (fileResource) {

--- a/connectors/src/connectors/microsoft/temporal/file.ts
+++ b/connectors/src/connectors/microsoft/temporal/file.ts
@@ -382,26 +382,55 @@ export async function syncOneFile({
           })),
         ];
 
-        await upsertDataSourceDocument({
-          dataSourceConfig,
-          documentId,
-          documentContent: content,
-          documentUrl: file.webUrl ?? undefined,
-          timestampMs: upsertTimestampMs,
-          tags,
-          parents,
-          parentId: parents[1] || null,
-          upsertContext: {
-            sync_type: isBatchSync ? "batch" : "incremental",
-          },
-          title: file.name ?? "",
-          mimeType: file.file.mimeType ?? "application/octet-stream",
-          async: true,
-        });
+        try {
+          await upsertDataSourceDocument({
+            dataSourceConfig,
+            documentId,
+            documentContent: content,
+            documentUrl: file.webUrl ?? undefined,
+            timestampMs: upsertTimestampMs,
+            tags,
+            parents,
+            parentId: parents[1] || null,
+            upsertContext: {
+              sync_type: isBatchSync ? "batch" : "incremental",
+            },
+            title: file.name ?? "",
+            mimeType: file.file.mimeType ?? "application/octet-stream",
+            async: true,
+          });
 
-        resourceBlob.lastUpsertedTs = upsertTimestampMs
-          ? new Date(upsertTimestampMs)
-          : null;
+          resourceBlob.lastUpsertedTs = upsertTimestampMs
+            ? new Date(upsertTimestampMs)
+            : null;
+        } catch (error) {
+          if (axios.isAxiosError(error) && error.response?.status === 413) {
+            localLogger.info(
+              {
+                status: 413,
+                fileName: file.name,
+                internalId: documentId,
+                webUrl: file.webUrl,
+                documentLen: documentLength,
+              },
+              "Document too large for upsert, marking as skipped"
+            );
+
+            // Save the skipReason to the database
+            resourceBlob.skipReason = "payload_too_large";
+
+            if (fileResource) {
+              await fileResource.update(resourceBlob);
+            } else {
+              await MicrosoftNodeResource.makeNew(resourceBlob);
+            }
+
+            return false;
+          }
+
+          // Re-throw other errors
+          throw error;
+        }
       } else {
         localLogger.info(
           {


### PR DESCRIPTION
## Description
Some file appear to have content that are in the correct range ([logs](https://app.datadoghq.eu/logs?query=%40activityName%3AsyncFiles&agg_m=count&agg_m_source=base&agg_t=count&clustering_pattern_field_path=message&cols=host%2Cservice&fromUser=true&messageDisplay=inline&refresh_mode=sliding&storage=hot&stream_sort=desc&viz=stream&from_ts=1755446718799&to_ts=1755447618799&live=true)). But the content + other metadata are over the Core API limits. Making the Core API return 413 error during the upsert, stucking the connectors.
- Adding a try/catch when `upsertDataSourceDocument`, and handle only HTTP 413, re-throw any other error.

## Tests
- Couldn't test locally, don't have a Microsoft Connection.

## Risk
- Low, only adding a try/catch and some logs. 

## Deploy Plan
- Deploy connectors.
