### PR TITLE
[front] Fix "User message not found" in `ensureConversationTitleActivity`

### DIFF
--- a/front/lib/api/assistant/agent.ts
+++ b/front/lib/api/assistant/agent.ts
@@ -83,6 +83,12 @@ async function runAgentSynchronousWithStreaming(
     });
   } catch (error) {
     if (error instanceof SyncTimeoutError) {
+      // Ensure title is computed and update in-memory conversation before launching async workflow.
+      const generatedTitle = await titlePromise;
+      if (generatedTitle) {
+        runAgentExecutionData.conversation.title = generatedTitle;
+      }
+
       await launchAsyncWorkflowFromSyncData(authType, runAgentExecutionData, {
         startStep: error.currentStep,
       });

--- a/front/lib/api/assistant/conversation/title.ts
+++ b/front/lib/api/assistant/conversation/title.ts
@@ -18,7 +18,7 @@ const MIN_GENERATION_TOKENS = 1024;
 export async function ensureConversationTitle(
   authType: AuthenticatorType,
   runAgentArgs: RunAgentArgs
-): Promise<void> {
+): Promise<string | null> {
   const runAgentDataRes = await getRunAgentData(authType, runAgentArgs);
   if (runAgentDataRes.isErr()) {
     throw runAgentDataRes.error;
@@ -28,7 +28,7 @@ export async function ensureConversationTitle(
 
   // If the conversation has a title, return early.
   if (conversation.title) {
-    return;
+    return conversation.title;
   }
   const auth = await Authenticator.fromJSON(authType);
 
@@ -46,7 +46,7 @@ export async function ensureConversationTitle(
       },
       "Conversation title generation error"
     );
-    return;
+    return null;
   }
 
   const title = titleRes.value;
@@ -64,6 +64,8 @@ export async function ensureConversationTitle(
     }),
     "user_message_events"
   );
+
+  return title;
 }
 
 async function generateConversationTitle(

--- a/front/types/assistant/agent_run.ts
+++ b/front/types/assistant/agent_run.ts
@@ -100,8 +100,8 @@ export async function getRunAgentData(
   }
 
   // Find the user message group by searching in reverse order.
-  const userMessageGroup = conversation.content.findLast(
-    (messageGroup) => messageGroup[0]?.sId === userMessageId
+  const userMessageGroup = conversation.content.findLast((messageGroup) =>
+    messageGroup.some((m) => m.sId === userMessageId)
   );
 
   // We assume that the message group is ordered by version ASC. Message version starts from 0.


### PR DESCRIPTION
## Description

- Error logs [here](https://app.datadoghq.eu/logs?query=%28%22Activity%20failed%22%20OR%20%22Unhandled%20activity%20error%22%29%20%40attempt%3A%3E14%20%40dd.service%3Afront-worker%20region%3Aus-central1&agg_m=count&agg_m_source=base&agg_t=count&clustering_pattern_field_path=message&cols=host%2Cservice&event=AwAAAZi71j_Nrp-wVwAAABhBWmk3MWxEeUFBQUZTeTlybG5RZnFnQUMAAAAkZjE5OGJiZDYtNjVkMS00ZjkxLWE5ZWMtYTM3YmEwNzU1NWU4AAA5xQ&link_source=monitor_notif&messageDisplay=inline&refresh_mode=sliding&storage=hot&stream_sort=desc&viz=stream&from_ts=1755411684518&to_ts=1755498084518&live=true) (btw we have logs in double now for some reason).
- The error stems from two main reasons:
  - We don't have the updated `conversationTitle` here https://github.com/dust-tt/dust/blob/main/front/temporal/agent_loop/workflows.ts#L81, it's passed from the in-memory object conversation, which is not updated in `ensureConversationTitle` and is therefore always null (whereas after 2 min it's always already set).
  - We have multiple versions of the user message (query [here](https://metabase.dust.tt/question#eyJkYXRhc2V0X3F1ZXJ5Ijp7ImRhdGFiYXNlIjo0LCJ0eXBlIjoibmF0aXZlIiwibmF0aXZlIjp7InRlbXBsYXRlLXRhZ3MiOnt9LCJxdWVyeSI6IlNFTEVDVCBtLiogRlJPTSBtZXNzYWdlcyBtXG5KT0lOIGNvbnZlcnNhdGlvbnMgY1xuT04gbS5cImNvbnZlcnNhdGlvbklkXCIgPSBjLmlkXG5XSEVSRSBjLlwic0lkXCIgPSAnTjFvbGRPbkxDZyc7XG4ifX0sImRpc3BsYXkiOiJ0YWJsZSIsInBhcmFtZXRlcnMiOltdLCJ2aXN1YWxpemF0aW9uX3NldHRpbmdzIjp7fSwidHlwZSI6InF1ZXN0aW9uIn0=)) and we don't find those correctly.
- This PR fixes the issue through the first and second points to not launch a `agentLoopConversationTitleWorkflow` incorrectly (ensure that the title is there when switching) and get the correct user message.
- This change will unlock the workflows currently stuck.

## Tests

## Risk

- Low.

## Deploy Plan

- Deploy front.
