### PR TITLE
fix: confluence space can be undefined

### DIFF
--- a/connectors/src/connectors/confluence/temporal/workflows.ts
+++ b/connectors/src/connectors/confluence/temporal/workflows.ts
@@ -188,7 +188,7 @@ export async function confluenceSpaceSyncWorkflow(
     confluenceCloudId: confluenceConfig?.cloudId,
   });
   // If the space does not exist, launch a workflow to remove the space.
-  if (space === null) {
+  if (!space) {
     return startConfluenceRemoveSpaceWorkflow(wInfo, connectorId, spaceId);
   }
 


### PR DESCRIPTION
## Description

We're getting `undefined` space in `confluenceUpsertSpaceFolderActivity`, which is causing errors in prod.

This is really a quick fix that doesn't attempt to fix the root issue, which isn't understood for now.
Reading the code, it appears impossible that that `space` could be undefined, yet it is.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
