### PR TITLE
[front] - chore(AB v2): increase dialog content height for better visibility

### DIFF
--- a/front/components/agent_builder/settings/AgentAccessPublicationDialog.tsx
+++ b/front/components/agent_builder/settings/AgentAccessPublicationDialog.tsx
@@ -40,7 +40,7 @@ export function AgentAccessPublicationDialog() {
           tooltip="Access & Publication Settings"
         />
       </DialogTrigger>
-      <DialogContent size="xl" height="md">
+      <DialogContent size="xl" height="xl">
         <DialogHeader>
           <DialogTitle>Access & Publication Settings</DialogTitle>
         </DialogHeader>


### PR DESCRIPTION
## Description

This PR changes the height property of DialogContent from "md" to "xl" for improved content presentation and user interaction.

<img width="1800" height="1042" alt="Screenshot 2025-08-18 at 10 13 26" src="https://github.com/user-attachments/assets/f6c97411-9bf1-4995-b99a-9b31b65c899c" />

## Tests

Locally

## Risk

None

## Deploy Plan

Deploy front
