### PR TITLE
[connectors] fix(microsoft): Better error handling when retrying

### DIFF
--- a/connectors/src/connectors/microsoft/temporal/file.ts
+++ b/connectors/src/connectors/microsoft/temporal/file.ts
@@ -52,6 +52,7 @@ import {
   cacheWithRedis,
   concurrentExecutor,
   INTERNAL_MIME_TYPES,
+  WithRetriesError,
 } from "@connectors/types";
 
 const PARENT_SYNC_CACHE_TTL_MS = 30 * 60 * 1000;
@@ -404,7 +405,13 @@ export async function syncOneFile({
             ? new Date(upsertTimestampMs)
             : null;
         } catch (error) {
-          if (axios.isAxiosError(error) && error.response?.status === 413) {
+          if (
+            error instanceof WithRetriesError &&
+            error.errors.every(
+              ({ error }) =>
+                axios.isAxiosError(error) && error.response?.status === 413
+            )
+          ) {
             localLogger.info(
               {
                 status: 413,


### PR DESCRIPTION
## Description
- Follow up of https://github.com/dust-tt/dust/pull/15101
- The error is actually a `WithRetriesError` which can contains Axios error. So the previous error wasn't catching properly the 413 error.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk
- Low

## Deploy Plan
- Deploy connectors
