### PR TITLE
[front,extension] - deps: update @dust-tt/sparkle to version 0.2.577

### DIFF
--- a/extension/package-lock.json
+++ b/extension/package-lock.json
@@ -12,7 +12,7 @@
         "@auth0/auth0-spa-js": "^2.1.3",
         "@datadog/browser-logs": "^6.13.0",
         "@dust-tt/client": "^1.1.6",
-        "@dust-tt/sparkle": "^0.2.576",
+        "@dust-tt/sparkle": "^0.2.577",
         "@frontapp/plugin-sdk": "^1.8.1",
         "@modelcontextprotocol/sdk": "^1.9.0",
         "@tailwindcss/forms": "^0.5.9",
@@ -1293,9 +1293,9 @@
       }
     },
     "node_modules/@dust-tt/sparkle": {
-      "version": "0.2.576",
-      "resolved": "https://registry.npmjs.org/@dust-tt/sparkle/-/sparkle-0.2.576.tgz",
-      "integrity": "sha512-UoaQC6/k8Otvj3CnrbY9kfa7cP0zPi3sR4p+poOGc2OoIQKO1wiBpzQ6SddtdDCx/LEVOeZCyc7Poe6owers9w==",
+      "version": "0.2.577",
+      "resolved": "https://registry.npmjs.org/@dust-tt/sparkle/-/sparkle-0.2.577.tgz",
+      "integrity": "sha512-R00M6wyVzMaLU0Ueaawv8gkKsnXzrfXXjiHh7Pa97etsRA8SxKYv+5VahaDsNQcfGzZ0zdbtMyJP5NgECof2/Q==",
       "dependencies": {
         "@emoji-mart/data": "^1.1.2",
         "@emoji-mart/react": "^1.1.1",

--- a/extension/package.json
+++ b/extension/package.json
@@ -59,7 +59,7 @@
     "@auth0/auth0-spa-js": "^2.1.3",
     "@datadog/browser-logs": "^6.13.0",
     "@dust-tt/client": "^1.1.6",
-    "@dust-tt/sparkle": "^0.2.576",
+    "@dust-tt/sparkle": "^0.2.577",
     "@frontapp/plugin-sdk": "^1.8.1",
     "@modelcontextprotocol/sdk": "^1.9.0",
     "@tailwindcss/forms": "^0.5.9",

--- a/front/components/assistant/conversation/input_bar/editor/MentionDropdown.tsx
+++ b/front/components/assistant/conversation/input_bar/editor/MentionDropdown.tsx
@@ -75,7 +75,6 @@ export const MentionDropdown = ({
         side="bottom"
         sideOffset={4}
         onCloseAutoFocus={(e) => e.preventDefault()}
-        onOpenAutoFocus={(e) => e.preventDefault()}
       >
         {isLoading ? (
           <div className="flex h-12 w-full items-center justify-center">

--- a/front/package-lock.json
+++ b/front/package-lock.json
@@ -7,7 +7,7 @@
       "dependencies": {
         "@datadog/browser-logs": "^6.13.0",
         "@dust-tt/client": "file:../sdks/js",
-        "@dust-tt/sparkle": "^0.2.576",
+        "@dust-tt/sparkle": "^0.2.577",
         "@google-cloud/bigquery": "^7.9.1",
         "@google-cloud/storage-transfer": "^3.6.0",
         "@heroicons/react": "^2.0.11",
@@ -200,7 +200,7 @@
     },
     "../sdks/js": {
       "name": "@dust-tt/client",
-      "version": "1.1.5",
+      "version": "1.1.6",
       "bundleDependencies": [
         "@modelcontextprotocol/sdk"
       ],
@@ -1112,9 +1112,9 @@
       "link": true
     },
     "node_modules/@dust-tt/sparkle": {
-      "version": "0.2.576",
-      "resolved": "https://registry.npmjs.org/@dust-tt/sparkle/-/sparkle-0.2.576.tgz",
-      "integrity": "sha512-UoaQC6/k8Otvj3CnrbY9kfa7cP0zPi3sR4p+poOGc2OoIQKO1wiBpzQ6SddtdDCx/LEVOeZCyc7Poe6owers9w==",
+      "version": "0.2.577",
+      "resolved": "https://registry.npmjs.org/@dust-tt/sparkle/-/sparkle-0.2.577.tgz",
+      "integrity": "sha512-R00M6wyVzMaLU0Ueaawv8gkKsnXzrfXXjiHh7Pa97etsRA8SxKYv+5VahaDsNQcfGzZ0zdbtMyJP5NgECof2/Q==",
       "dependencies": {
         "@emoji-mart/data": "^1.1.2",
         "@emoji-mart/react": "^1.1.1",

--- a/front/package.json
+++ b/front/package.json
@@ -24,7 +24,7 @@
   "dependencies": {
     "@datadog/browser-logs": "^6.13.0",
     "@dust-tt/client": "file:../sdks/js",
-    "@dust-tt/sparkle": "^0.2.576",
+    "@dust-tt/sparkle": "^0.2.577",
     "@google-cloud/bigquery": "^7.9.1",
     "@google-cloud/storage-transfer": "^3.6.0",
     "@heroicons/react": "^2.0.11",


### PR DESCRIPTION
## Description

This PR  updates `@dust-tt/sparkle` to version 0.2.577 in `front` and `extension`.