### PR TITLE
[front] Lower max number of steps from 128 to 64

### DIFF
--- a/front/migrations/db/migration_336.sql
+++ b/front/migrations/db/migration_336.sql
@@ -1,0 +1,4 @@
+-- Migration created on Aug 18, 2025
+UPDATE "agent_configurations"
+SET "maxStepsPerRun" = 64
+WHERE status = 'active';

--- a/front/types/assistant/agent.ts
+++ b/front/types/assistant/agent.ts
@@ -183,8 +183,7 @@ export function isTemplateAgentConfiguration(
   );
 }
 
-export const DEFAULT_MAX_STEPS_USE_PER_RUN = 8;
-export const MAX_STEPS_USE_PER_RUN_LIMIT = 128;
+export const MAX_STEPS_USE_PER_RUN_LIMIT = 64;
 export const MAX_ACTIONS_PER_STEP = 16;
 
 /**


### PR DESCRIPTION
## Description

- [Here](https://dust4ai.slack.com/archives/C050SM8NSPK/p1755527996377959).
- This PR lowers `MAX_STEPS_USE_PER_RUN_LIMIT` from 128 to 64.

## Tests

## Risk

## Deploy Plan

- Deploy front.
