### PR TITLE
[front] Fix conversation rendering within tools

### DIFF
--- a/front/lib/actions/mcp_internal_actions/servers/reasoning.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/reasoning.ts
@@ -215,7 +215,7 @@ async function* runReasoning(
     tools: "",
     allowedTokenCount: supportedModel.contextSize - REASONING_GENERATION_TOKENS,
     excludeImages: true,
-    checkMissingActions: false,
+    onMissingAction: "skip",
   });
   if (renderedConversationRes.isErr()) {
     yield {

--- a/front/lib/actions/mcp_internal_actions/servers/run_dust_app.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/run_dust_app.ts
@@ -326,7 +326,7 @@ async function prepareParamsWithHistory(
         tools: "",
         allowedTokenCount,
         excludeImages: true,
-        checkMissingActions: false,
+        onMissingAction: "skip",
       });
 
       if (convoRes.isOk()) {

--- a/front/lib/actions/mcp_internal_actions/servers/tables_query/server.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/tables_query/server.ts
@@ -97,7 +97,7 @@ function createServer(
         tools: "",
         allowedTokenCount,
         excludeImages: true,
-        checkMissingActions: false,
+        onMissingAction: "skip",
       });
       if (renderedConversationRes.isErr()) {
         return makeMCPToolTextError(

--- a/front/lib/api/assistant/preprocessing.ts
+++ b/front/lib/api/assistant/preprocessing.ts
@@ -408,11 +408,9 @@ async function getSteps(
         }
 
         const actions = step.actions;
-        const functionResultByCallId: Record<string, FunctionMessageTypeModel> =
-          {};
-        for (const action of actions) {
-          functionResultByCallId[action.call.id] = action.result;
-        }
+        const functionResultByCallId = Object.fromEntries(
+          step.actions.map((action) => [action.call.id, action.result])
+        );
         for (const content of step.contents) {
           if (content.type === "function_call") {
             const functionCall = content.value;
@@ -444,6 +442,7 @@ async function getSteps(
         if (onMissingAction !== "skip") {
           return true;
         }
+
         const functionResultByCallId = Object.fromEntries(
           step.actions.map((action) => [action.call.id, action.result])
         );


### PR DESCRIPTION
## Description

- Certain tools such as tables query v1 rely on the rendered conversation.
- We have observed some failed executions on them due to having a weird conversation state when running the tool: the `agent_mcp_actions` have been created but without any output at time of tool run (this was changed recently).
- Example run [here](https://dust.tt/w/78bda07b39/spaces/vlt_rICtlrSEpWqX/apps/b4f205e453/runs/efaeca266e3ee78af003c33622621f93b023eb3ea812e892c7446d44d6c1f95a).
- This PR aims at making sure `renderConversationForModel` always return a valid state that can be given to a model.

## Tests

- Tested locally.

## Risk

- Critical code path but no-op 99% of the time.

## Deploy Plan

- Deploy front.
