### PR TITLE
Add: List choice support for MCP tools

### DIFF
--- a/front/components/agent_builder/AgentBuilderFormContext.tsx
+++ b/front/components/agent_builder/AgentBuilderFormContext.tsx
@@ -3,6 +3,7 @@ import { createContext, useContext } from "react";
 import type { UseFormReturn } from "react-hook-form";
 import { z } from "zod";
 
+import type { AdditionalConfigurationType } from "@app/lib/models/assistant/actions/mcp";
 import type { DataSourceViewContentNode, DataSourceViewType } from "@app/types";
 import {
   MODEL_IDS,
@@ -31,7 +32,8 @@ export const mcpServerViewIdSchema = z.string();
 export const childAgentIdSchema = z.string().nullable();
 
 export const additionalConfigurationSchema = z.record(
-  z.union([z.boolean(), z.number(), z.string()])
+  z.string(),
+  z.union([z.boolean(), z.number(), z.string(), z.array(z.string())])
 );
 
 export const dustAppConfigurationSchema = z
@@ -200,7 +202,7 @@ export interface MCPFormData {
       duration: number;
       unit: "hour" | "day" | "week" | "month" | "year";
     } | null;
-    additionalConfiguration: Record<string, boolean | number | string>;
+    additionalConfiguration: AdditionalConfigurationType;
     dustAppConfiguration: any;
     jsonSchema: any;
     _jsonSchemaString: string | null;

--- a/front/components/agent_builder/capabilities/mcp/MCPServerViewsDialog.tsx
+++ b/front/components/agent_builder/capabilities/mcp/MCPServerViewsDialog.tsx
@@ -577,7 +577,6 @@ export function MCPServerViewsDialog({
   };
 
   const handleConfigurationSave = async (formData: MCPFormData) => {
-    console.log("formData", formData);
     if (!configurationTool || !form || !mcpServerView) {
       return;
     }

--- a/front/components/agent_builder/capabilities/mcp/MCPServerViewsDialog.tsx
+++ b/front/components/agent_builder/capabilities/mcp/MCPServerViewsDialog.tsx
@@ -28,6 +28,7 @@ import {
   getMCPConfigurationFormSchema,
   validateMCPActionConfiguration,
 } from "@app/components/agent_builder/capabilities/mcp/utils/formValidation";
+import { AdditionalConfigurationSection } from "@app/components/agent_builder/capabilities/shared/AdditionalConfigurationSection";
 import { ChildAgentSection } from "@app/components/agent_builder/capabilities/shared/ChildAgentSection";
 import { DustAppSection } from "@app/components/agent_builder/capabilities/shared/DustAppSection";
 import { JsonSchemaSection } from "@app/components/agent_builder/capabilities/shared/JsonSchemaSection";
@@ -49,6 +50,7 @@ import {
   DEFAULT_DATA_VISUALIZATION_DESCRIPTION,
   DEFAULT_DATA_VISUALIZATION_NAME,
 } from "@app/lib/actions/constants";
+import { getMcpServerViewDisplayName } from "@app/lib/actions/mcp_helper";
 import { getAvatarFromIcon } from "@app/lib/actions/mcp_icons";
 import { getMCPServerRequirements } from "@app/lib/actions/mcp_internal_actions/input_configuration";
 import type { MCPServerViewType } from "@app/lib/api/mcp";
@@ -521,6 +523,14 @@ export function MCPServerViewsDialog({
                     getAgentInstructions={getAgentInstructions}
                   />
                 )}
+
+                <AdditionalConfigurationSection
+                  requiredStrings={requirements.requiredStrings}
+                  requiredNumbers={requirements.requiredNumbers}
+                  requiredBooleans={requirements.requiredBooleans}
+                  requiredEnums={requirements.requiredEnums}
+                  requiredLists={requirements.requiredLists}
+                />
               </div>
             </div>
           </FormProvider>
@@ -567,6 +577,7 @@ export function MCPServerViewsDialog({
   };
 
   const handleConfigurationSave = async (formData: MCPFormData) => {
+    console.log("formData", formData);
     if (!configurationTool || !form || !mcpServerView) {
       return;
     }
@@ -604,7 +615,7 @@ export function MCPServerViewsDialog({
 
         sendNotification({
           title: "Tool updated successfully",
-          description: `${mcpServerView.server.name} configuration has been updated.`,
+          description: `${getMcpServerViewDisplayName(mcpServerView)} configuration has been updated.`,
           type: "success",
         });
       } else {

--- a/front/components/agent_builder/capabilities/mcp/utils/formDefaults.ts
+++ b/front/components/agent_builder/capabilities/mcp/utils/formDefaults.ts
@@ -31,7 +31,8 @@ export function getDefaultConfiguration(
     return defaults;
   }
 
-  const additionalConfig: Record<string, boolean | number | string> = {};
+  const additionalConfig: Record<string, boolean | number | string | string[]> =
+    {};
 
   // Set default values only for boolean and enums
   // Strings and numbers should be left empty to trigger validation
@@ -43,6 +44,10 @@ export function getDefaultConfiguration(
     if (enumValues.length > 0) {
       additionalConfig[key] = enumValues[0];
     }
+  }
+
+  for (const [key] of Object.entries(requirements.requiredLists)) {
+    additionalConfig[key] = [];
   }
 
   defaults.additionalConfiguration = additionalConfig;

--- a/front/components/agent_builder/capabilities/mcp/utils/validationMessages.ts
+++ b/front/components/agent_builder/capabilities/mcp/utils/validationMessages.ts
@@ -21,6 +21,8 @@ export const VALIDATION_MESSAGES = {
     booleanRequired: (key: string) => `${key} must be selected`,
     enumRequired: (key: string) =>
       `${key} must be selected from available options`,
+    listRequired: (key: string) =>
+      `${key} must be selected from available options`,
     genericRequired: "All required configuration fields must be filled",
   },
   name: {

--- a/front/components/agent_builder/capabilities/mcp/validation/schemaBuilders.ts
+++ b/front/components/agent_builder/capabilities/mcp/validation/schemaBuilders.ts
@@ -1,4 +1,3 @@
-import { isArray } from "lodash";
 import { z } from "zod";
 
 import {
@@ -151,7 +150,7 @@ function createAdditionalConfigurationSchema(
       // Validate required lists
       for (const [key] of Object.entries(requirements.requiredLists)) {
         const value = additionalConfig[key];
-        if (!value || !isArray(value) || value.length === 0) {
+        if (!value || !Array.isArray(value) || value.length === 0) {
           ctx.addIssue({
             code: z.ZodIssueCode.custom,
             message: VALIDATION_MESSAGES.additionalConfig.listRequired(key),

--- a/front/components/agent_builder/capabilities/mcp/validation/schemaBuilders.ts
+++ b/front/components/agent_builder/capabilities/mcp/validation/schemaBuilders.ts
@@ -1,3 +1,4 @@
+import { isArray } from "lodash";
 import { z } from "zod";
 
 import {
@@ -85,7 +86,8 @@ function createAdditionalConfigurationSchema(
     requirements.requiredStrings.length > 0 ||
     requirements.requiredNumbers.length > 0 ||
     requirements.requiredBooleans.length > 0 ||
-    Object.keys(requirements.requiredEnums).length > 0;
+    Object.keys(requirements.requiredEnums).length > 0 ||
+    Object.keys(requirements.requiredLists).length > 0;
 
   if (!hasRequiredFields) {
     return additionalConfigurationSchema.default({});
@@ -141,6 +143,18 @@ function createAdditionalConfigurationSchema(
           ctx.addIssue({
             code: z.ZodIssueCode.custom,
             message: VALIDATION_MESSAGES.additionalConfig.enumRequired(key),
+            path: [key],
+          });
+        }
+      }
+
+      // Validate required lists
+      for (const [key] of Object.entries(requirements.requiredLists)) {
+        const value = additionalConfig[key];
+        if (!value || !isArray(value) || value.length === 0) {
+          ctx.addIssue({
+            code: z.ZodIssueCode.custom,
+            message: VALIDATION_MESSAGES.additionalConfig.listRequired(key),
             path: [key],
           });
         }

--- a/front/components/assistant_builder/actions/MCPAction.tsx
+++ b/front/components/assistant_builder/actions/MCPAction.tsx
@@ -441,6 +441,11 @@ export function hasErrorActionMCP(
         missingFields.push(key);
       }
     }
+    for (const key in requirements.requiredLists) {
+      if (!(key in action.configuration.additionalConfiguration)) {
+        missingFields.push(key);
+      }
+    }
     if (missingFields.length > 0) {
       return `Some fields are missing: ${missingFields.map(asDisplayName).join(", ")}.`;
     }

--- a/front/components/assistant_builder/actions/configuration/AdditionalConfigurationSection.tsx
+++ b/front/components/assistant_builder/actions/configuration/AdditionalConfigurationSection.tsx
@@ -2,6 +2,7 @@ import {
   Button,
   Checkbox,
   DropdownMenu,
+  DropdownMenuCheckboxItem,
   DropdownMenuContent,
   DropdownMenuItem,
   DropdownMenuTrigger,
@@ -10,6 +11,7 @@ import {
 } from "@dust-tt/sparkle";
 import React, { useMemo } from "react";
 
+import type { AdditionalConfigurationType } from "@app/lib/models/assistant/actions/mcp";
 import { asDisplayName } from "@app/types";
 
 function formatKeyForDisplay(key: string): string {
@@ -38,7 +40,7 @@ function groupKeysByPrefix(keys: string[]): Record<string, string[]> {
 
 interface BooleanConfigurationSectionProps {
   requiredBooleans: string[];
-  additionalConfiguration: Record<string, string | number | boolean>;
+  additionalConfiguration: AdditionalConfigurationType;
   onConfigUpdate: (key: string, value: boolean) => void;
 }
 
@@ -74,7 +76,7 @@ function BooleanConfigurationSection({
 
 interface NumberConfigurationSectionProps {
   requiredNumbers: string[];
-  additionalConfiguration: Record<string, string | number | boolean>;
+  additionalConfiguration: AdditionalConfigurationType;
   onConfigUpdate: (key: string, value: number) => void;
 }
 
@@ -113,7 +115,7 @@ function NumberConfigurationSection({
 
 interface StringConfigurationSectionProps {
   requiredStrings: string[];
-  additionalConfiguration: Record<string, string | number | boolean>;
+  additionalConfiguration: AdditionalConfigurationType;
   onConfigUpdate: (key: string, value: string) => void;
 }
 
@@ -147,7 +149,7 @@ function StringConfigurationSection({
 
 interface EnumConfigurationSectionProps {
   requiredEnums: Record<string, string[]>;
-  additionalConfiguration: Record<string, string | number | boolean>;
+  additionalConfiguration: AdditionalConfigurationType;
   onConfigUpdate: (key: string, value: string) => void;
 }
 
@@ -192,14 +194,84 @@ function EnumConfigurationSection({
   });
 }
 
+interface ListConfigurationSectionProps {
+  requiredLists: Record<string, Record<string, string>>;
+  additionalConfiguration: AdditionalConfigurationType;
+  onConfigUpdate: (key: string, value: string[]) => void;
+}
+
+function ListConfigurationSection({
+  requiredLists,
+  additionalConfiguration,
+  onConfigUpdate,
+}: ListConfigurationSectionProps) {
+  if (Object.keys(requiredLists).length === 0) {
+    return null;
+  }
+
+  return Object.entries(requiredLists).map(([key, listValues]) => {
+    const displayLabel = `Select ${formatKeyForDisplay(key)}`;
+    const rawValue = additionalConfiguration[key];
+    const currentValue: string[] = Array.isArray(rawValue) ? rawValue : [];
+
+    return (
+      <div key={key} className="mb-2 flex items-center gap-1">
+        <Label className="w-1/5 text-sm font-medium">
+          {formatKeyForDisplay(key)}
+        </Label>
+        <DropdownMenu>
+          <DropdownMenuTrigger asChild>
+            <Button
+              isSelect
+              label={
+                currentValue.length > 0
+                  ? currentValue.map((v) => listValues[v]).join(", ")
+                  : displayLabel
+              }
+              size="sm"
+              tooltip={displayLabel}
+              variant="outline"
+            />
+          </DropdownMenuTrigger>
+          <DropdownMenuContent align="start">
+            {Object.entries(listValues).map(([value, label]) => (
+              <DropdownMenuCheckboxItem
+                key={value}
+                label={label}
+                checked={
+                  Array.isArray(currentValue) && currentValue.includes(value)
+                }
+                onCheckedChange={(checked) => {
+                  const currentValue = additionalConfiguration[key] ?? [];
+                  if (Array.isArray(currentValue)) {
+                    const newValues = checked
+                      ? [...currentValue, value]
+                      : currentValue.filter((v) => v !== value);
+
+                    onConfigUpdate(key, newValues);
+                  }
+                }}
+              />
+            ))}
+          </DropdownMenuContent>
+        </DropdownMenu>
+      </div>
+    );
+  });
+}
+
 interface GroupedConfigurationSectionProps {
   prefix: string;
   requiredStrings: string[];
   requiredNumbers: string[];
   requiredBooleans: string[];
   requiredEnums: Record<string, string[]>;
-  additionalConfiguration: Record<string, string | number | boolean>;
-  onConfigUpdate: (key: string, value: string | number | boolean) => void;
+  requiredLists: Record<string, Record<string, string>>;
+  additionalConfiguration: AdditionalConfigurationType;
+  onConfigUpdate: (
+    key: string,
+    value: string | string[] | number | boolean
+  ) => void;
 }
 
 function GroupedConfigurationSection({
@@ -208,6 +280,7 @@ function GroupedConfigurationSection({
   requiredNumbers,
   requiredBooleans,
   requiredEnums,
+  requiredLists,
   additionalConfiguration,
   onConfigUpdate,
 }: GroupedConfigurationSectionProps) {
@@ -248,6 +321,11 @@ function GroupedConfigurationSection({
           additionalConfiguration={additionalConfiguration}
           onConfigUpdate={onConfigUpdate}
         />
+        <ListConfigurationSection
+          requiredLists={requiredLists}
+          additionalConfiguration={additionalConfiguration}
+          onConfigUpdate={onConfigUpdate}
+        />
       </div>
     </div>
   );
@@ -258,8 +336,12 @@ interface AdditionalConfigurationSectionProps {
   requiredNumbers: string[];
   requiredBooleans: string[];
   requiredEnums: Record<string, string[]>;
-  additionalConfiguration: Record<string, string | number | boolean>;
-  onConfigUpdate: (key: string, value: string | number | boolean) => void;
+  requiredLists: Record<string, Record<string, string>>;
+  additionalConfiguration: AdditionalConfigurationType;
+  onConfigUpdate: (
+    key: string,
+    value: string | string[] | number | boolean
+  ) => void;
 }
 
 export const AdditionalConfigurationSection: React.FC<
@@ -269,6 +351,7 @@ export const AdditionalConfigurationSection: React.FC<
   requiredNumbers,
   requiredBooleans,
   requiredEnums,
+  requiredLists,
   additionalConfiguration,
   onConfigUpdate,
 }) => {
@@ -297,6 +380,18 @@ export const AdditionalConfigurationSection: React.FC<
     return groups;
   }, [requiredEnums]);
 
+  const groupedLists = useMemo(() => {
+    const groups: Record<string, Record<string, Record<string, string>>> = {};
+    Object.entries(requiredLists).forEach(([key, values]) => {
+      const prefix = getKeyPrefix(key);
+      if (!groups[prefix]) {
+        groups[prefix] = {};
+      }
+      groups[prefix][key] = values;
+    });
+    return groups;
+  }, [requiredLists]);
+
   // Get all unique prefixes
   const allPrefixes = useMemo(() => {
     const prefixSet = new Set<string>();
@@ -305,15 +400,23 @@ export const AdditionalConfigurationSection: React.FC<
     Object.keys(groupedNumbers).forEach((prefix) => prefixSet.add(prefix));
     Object.keys(groupedBooleans).forEach((prefix) => prefixSet.add(prefix));
     Object.keys(groupedEnums).forEach((prefix) => prefixSet.add(prefix));
+    Object.keys(groupedLists).forEach((prefix) => prefixSet.add(prefix));
 
     return Array.from(prefixSet).sort();
-  }, [groupedStrings, groupedNumbers, groupedBooleans, groupedEnums]);
+  }, [
+    groupedStrings,
+    groupedNumbers,
+    groupedBooleans,
+    groupedEnums,
+    groupedLists,
+  ]);
 
   const hasConfiguration =
     Object.keys(requiredStrings).length > 0 ||
     Object.keys(requiredNumbers).length > 0 ||
     Object.keys(requiredBooleans).length > 0 ||
-    Object.keys(requiredEnums).length > 0;
+    Object.keys(requiredEnums).length > 0 ||
+    Object.keys(requiredLists).length > 0;
 
   if (!hasConfiguration) {
     return null;
@@ -339,6 +442,7 @@ export const AdditionalConfigurationSection: React.FC<
           requiredNumbers={groupedNumbers[prefix] || []}
           requiredBooleans={groupedBooleans[prefix] || []}
           requiredEnums={groupedEnums[prefix] || {}}
+          requiredLists={groupedLists[prefix] || {}}
           additionalConfiguration={additionalConfiguration}
           onConfigUpdate={onConfigUpdate}
         />

--- a/front/components/assistant_builder/types.ts
+++ b/front/components/assistant_builder/types.ts
@@ -13,6 +13,7 @@ import {
 import { getMcpServerViewDescription } from "@app/lib/actions/mcp_helper";
 import { getMCPServerRequirements } from "@app/lib/actions/mcp_internal_actions/input_configuration";
 import type { MCPServerViewType } from "@app/lib/api/mcp";
+import type { AdditionalConfigurationType } from "@app/lib/models/assistant/actions/mcp";
 import type { FetchAssistantTemplateResponse } from "@app/pages/api/templates/[tId]";
 import type {
   AgentConfigurationScope,
@@ -65,7 +66,7 @@ export type AssistantBuilderMCPServerConfiguration = {
   childAgentId: string | null;
   reasoningModel: ReasoningModelConfigurationType | null;
   timeFrame: TimeFrame | null;
-  additionalConfiguration: Record<string, boolean | number | string>;
+  additionalConfiguration: AdditionalConfigurationType;
   dustAppConfiguration: DustAppRunConfigurationType | null;
   jsonSchema: JSONSchema | null;
   _jsonSchemaString: string | null;

--- a/front/lib/actions/mcp.ts
+++ b/front/lib/actions/mcp.ts
@@ -39,6 +39,7 @@ import type {
   TableDataSourceConfiguration,
 } from "@app/lib/api/assistant/configuration/types";
 import type { Authenticator } from "@app/lib/auth";
+import type { AdditionalConfigurationType } from "@app/lib/models/assistant/actions/mcp";
 import {
   AgentMCPAction,
   AgentMCPActionOutputItem,
@@ -83,7 +84,7 @@ export type ServerSideMCPServerConfigurationType =
     reasoningModel: ReasoningModelConfigurationType | null;
     timeFrame: TimeFrame | null;
     jsonSchema: JSONSchema | null;
-    additionalConfiguration: Record<string, boolean | number | string>;
+    additionalConfiguration: AdditionalConfigurationType;
     mcpServerViewId: string;
     dustAppConfiguration: DustAppRunConfigurationType | null;
     // Out of convenience, we hold the sId of the internal server if it is an internal server.

--- a/front/lib/actions/mcp_internal_actions/input_configuration.ts
+++ b/front/lib/actions/mcp_internal_actions/input_configuration.ts
@@ -3,6 +3,7 @@ import { INTERNAL_MIME_TYPES } from "@dust-tt/client";
 import { Ajv } from "ajv";
 import assert from "assert";
 import type { JSONSchema7 as JSONSchema } from "json-schema";
+import { zip } from "lodash";
 
 import type { MCPToolConfigurationType } from "@app/lib/actions/mcp";
 import type { ConfigurableToolInputType } from "@app/lib/actions/mcp_internal_actions/input_schemas";
@@ -178,6 +179,16 @@ function generateConfiguredInput({
         );
       }
       return { value, mimeType };
+    }
+
+    case INTERNAL_MIME_TYPES.TOOL_INPUT.LIST: {
+      const value = actionConfiguration.additionalConfiguration[keyPath];
+      if (!Array.isArray(value) || value.some((v) => typeof v !== "string")) {
+        throw new Error(
+          `Expected array of string values for key ${keyPath}, got ${typeof value} for mime type ${mimeType}`
+        );
+      }
+      return { values: value, labels: value, mimeType };
     }
 
     case INTERNAL_MIME_TYPES.TOOL_INPUT.DUST_APP: {
@@ -380,6 +391,7 @@ export interface MCPServerRequirements {
   requiredNumbers: string[];
   requiredBooleans: string[];
   requiredEnums: Record<string, string[]>;
+  requiredLists: Record<string, Record<string, string>>;
   requiresDustAppConfiguration: boolean;
   noRequirement: boolean;
 }
@@ -400,6 +412,7 @@ export function getMCPServerRequirements(
       requiredNumbers: [],
       requiredBooleans: [],
       requiredEnums: {},
+      requiredLists: {},
       requiresDustAppConfiguration: false,
       noRequirement: false,
     };
@@ -494,6 +507,47 @@ export function getMCPServerRequirements(
     })
   );
 
+  const requiredLists = Object.fromEntries(
+    Object.entries(
+      findPathsToConfiguration({
+        mcpServer: server,
+        mimeType: INTERNAL_MIME_TYPES.TOOL_INPUT.LIST,
+      })
+    ).map(([key, schema]) => {
+      const valueProperty = schema.properties?.values;
+      const labelProperty = schema.properties?.labels;
+
+      if (
+        !valueProperty ||
+        !labelProperty ||
+        !isJSONSchemaObject(valueProperty) ||
+        !isJSONSchemaObject(labelProperty)
+      ) {
+        return [key, []];
+      }
+
+      const values =
+        valueProperty.enum?.filter((v): v is string => typeof v === "string") ??
+        [];
+      const labels =
+        labelProperty.enum?.filter((v): v is string => typeof v === "string") ??
+        [];
+
+      if (values.length !== labels.length) {
+        throw new Error(
+          `Expected the same number of values and labels for key ${key}, got ${values.length} values and ${labels.length} labels`
+        );
+      }
+
+      // Create a record of values to labels
+      const valueToLabel: Record<string, string> = Object.fromEntries(
+        zip(labels, values).map(([label, value]) => [value, label])
+      );
+
+      return [key, valueToLabel];
+    })
+  );
+
   const requiredDustAppConfiguration =
     Object.keys(
       findPathsToConfiguration({
@@ -514,6 +568,7 @@ export function getMCPServerRequirements(
     requiredNumbers,
     requiredBooleans,
     requiredEnums,
+    requiredLists,
     requiresDustAppConfiguration: requiredDustAppConfiguration,
     noRequirement:
       !requiresDataSourceConfiguration &&
@@ -526,7 +581,8 @@ export function getMCPServerRequirements(
       requiredStrings.length === 0 &&
       requiredNumbers.length === 0 &&
       requiredBooleans.length === 0 &&
-      Object.keys(requiredEnums).length === 0,
+      Object.keys(requiredEnums).length === 0 &&
+      Object.keys(requiredLists).length === 0,
   };
 }
 
@@ -537,23 +593,41 @@ function isSchemaConfigurable(
   schema: JSONSchema,
   mimeType: InternalToolInputMimeType
 ): boolean {
+  if (mimeType === INTERNAL_MIME_TYPES.TOOL_INPUT.ENUM) {
+    // We only check that the schema has a `value` property and a `mimeType` property with the correct value.
+    const mimeTypeProperty = schema.properties?.mimeType;
+    if (
+      schema.properties?.value &&
+      mimeTypeProperty &&
+      isJSONSchemaObject(mimeTypeProperty)
+    ) {
+      return (
+        mimeTypeProperty.type === "string" &&
+        mimeTypeProperty.const === mimeType
+      );
+    }
+    return false;
+  }
+
+  if (mimeType === INTERNAL_MIME_TYPES.TOOL_INPUT.LIST) {
+    // We only check that the schema has a `values` property and a `mimeType` property with the correct value.
+    const mimeTypeProperty = schema.properties?.mimeType;
+    if (
+      schema.properties?.values &&
+      schema.properties?.labels &&
+      mimeTypeProperty &&
+      isJSONSchemaObject(mimeTypeProperty)
+    ) {
+      return (
+        mimeTypeProperty.type === "string" &&
+        mimeTypeProperty.const === mimeType
+      );
+    }
+    return false;
+  }
+
   // If the mime type has a static configuration schema, we check that the schema matches it.
-  if (mimeType !== INTERNAL_MIME_TYPES.TOOL_INPUT.ENUM) {
-    return areSchemasEqual(schema, ConfigurableToolInputJSONSchemas[mimeType]);
-  }
-  // If the mime type does not have a static configuration schema, it supports flexible schemas.
-  // We only check that the schema has a `value` property and a `mimeType` property with the correct value.
-  const mimeTypeProperty = schema.properties?.mimeType;
-  if (
-    schema.properties?.value &&
-    mimeTypeProperty &&
-    isJSONSchemaObject(mimeTypeProperty)
-  ) {
-    return (
-      mimeTypeProperty.type === "string" && mimeTypeProperty.const === mimeType
-    );
-  }
-  return false;
+  return areSchemasEqual(schema, ConfigurableToolInputJSONSchemas[mimeType]);
 }
 
 /**

--- a/front/lib/actions/mcp_internal_actions/input_schemas.ts
+++ b/front/lib/actions/mcp_internal_actions/input_schemas.ts
@@ -159,7 +159,8 @@ export const ConfigurableToolInputSchemas = {
   // for instance the ENUM mime type is flexible and the exact content of the enum is dynamic.
 } as const satisfies Omit<
   Record<InternalToolInputMimeType, z.ZodType>,
-  typeof INTERNAL_MIME_TYPES.TOOL_INPUT.ENUM
+  | typeof INTERNAL_MIME_TYPES.TOOL_INPUT.ENUM
+  | typeof INTERNAL_MIME_TYPES.TOOL_INPUT.LIST
 >;
 
 // Type for the tool inputs that have a flexible schema, which are schemas that can vary between tools.
@@ -167,6 +168,11 @@ type FlexibleConfigurableToolInput = {
   [INTERNAL_MIME_TYPES.TOOL_INPUT.ENUM]: {
     value: string;
     mimeType: typeof INTERNAL_MIME_TYPES.TOOL_INPUT.ENUM;
+  };
+  [INTERNAL_MIME_TYPES.TOOL_INPUT.LIST]: {
+    values: string[];
+    labels: string[];
+    mimeType: typeof INTERNAL_MIME_TYPES.TOOL_INPUT.LIST;
   };
 };
 

--- a/front/lib/actions/mcp_internal_actions/servers/primitive_types_debugger.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/primitive_types_debugger.ts
@@ -41,6 +41,11 @@ function createServer(): McpServer {
         value: z.enum(["A", "B", "C"]),
         mimeType: z.literal(INTERNAL_MIME_TYPES.TOOL_INPUT.ENUM),
       }),
+      choices: z.object({
+        values: z.enum(["A", "B", "C"]),
+        labels: z.enum(["label A", "label B", "label C"]),
+        mimeType: z.literal(INTERNAL_MIME_TYPES.TOOL_INPUT.LIST),
+      }),
     },
     async (params) => {
       return {

--- a/front/lib/models/assistant/actions/mcp.ts
+++ b/front/lib/models/assistant/actions/mcp.ts
@@ -16,6 +16,11 @@ import { validateJsonSchema } from "@app/lib/utils/json_schemas";
 import type { TimeFrame } from "@app/types";
 import { isTimeFrame } from "@app/types";
 
+export type AdditionalConfigurationType = Record<
+  string,
+  boolean | number | string | string[]
+>;
+
 export class AgentMCPServerConfiguration extends WorkspaceAwareModel<AgentMCPServerConfiguration> {
   declare createdAt: CreationOptional<Date>;
   declare updatedAt: CreationOptional<Date>;
@@ -25,7 +30,7 @@ export class AgentMCPServerConfiguration extends WorkspaceAwareModel<AgentMCPSer
   declare sId: string;
 
   declare timeFrame: TimeFrame | null;
-  declare additionalConfiguration: Record<string, boolean | number | string>;
+  declare additionalConfiguration: AdditionalConfigurationType;
   declare jsonSchema: JSONSchema | null;
 
   declare appId: string | null;

--- a/front/types/api/internal/agent_configuration.ts
+++ b/front/types/api/internal/agent_configuration.ts
@@ -143,7 +143,7 @@ const MCPServerActionConfigurationSchema = t.type({
   jsonSchema: t.union([JsonSchemaCodec, t.null]),
   additionalConfiguration: t.record(
     t.string,
-    t.union([t.boolean, t.number, t.string, t.null])
+    t.union([t.boolean, t.number, t.string, t.array(t.string), t.null])
   ),
   dustAppConfiguration: t.union([DustAppRunActionConfigurationSchema, t.null]),
 });

--- a/sdks/js/src/internal_mime_types.ts
+++ b/sdks/js/src/internal_mime_types.ts
@@ -232,6 +232,7 @@ const TOOL_MIME_TYPES = {
       "NUMBER",
       "BOOLEAN",
       "ENUM",
+      "LIST",
       "REASONING_MODEL",
       "DUST_APP",
       "NULLABLE_TIME_FRAME",


### PR DESCRIPTION
## Description

Add support for multiples choices in a toolset configuration.
Will be used to allow users to pick slack channels to use.

Note:
- "AdditionalConfiguration" was completely missing from agent builder v2 so I added it. (still needs to show the errors)
- I'll update the UI in another PR

## Tests

<img width="1428" height="1093" alt="image" src="https://github.com/user-attachments/assets/19a98e1e-293b-4270-9c46-6af52f4e09b9" />

<img width="1460" height="657" alt="image" src="https://github.com/user-attachments/assets/7c5cf399-d5df-45ae-83f2-9f505eb19e2b" />


## Risk

Low

## Deploy Plan

Deploy front and then enjoy