### PR TITLE
[sparkle] - fix(SearchDropdownMenu): prevent dropdown menu auto-focus on open

### DIFF
--- a/sparkle/src/components/SearchDropdownMenu.tsx
+++ b/sparkle/src/components/SearchDropdownMenu.tsx
@@ -82,6 +82,9 @@ export function SearchDropdownMenu({
         side="bottom"
         align="start"
         className="s-w-[--radix-popper-anchor-width]"
+        onOpenAutoFocus={(e) => {
+          e.preventDefault();
+        }}
         onFocusOutside={(e) => {
           // Prevent closing when search input is focused
           if (e.target === searchInputRef.current) {


### PR DESCRIPTION
## Description

Maintain focus on the search input when interacting with the dropdown to prevent unexpected behavior

## Risk

Low

## Deploy Plan

- Publish sparkle
- Deploy front