### PR TITLE
[front] - fix: update @dust-tt/sparkle dependency to v0.2.579

### DIFF
--- a/extension/package-lock.json
+++ b/extension/package-lock.json
@@ -12,7 +12,7 @@
         "@auth0/auth0-spa-js": "^2.1.3",
         "@datadog/browser-logs": "^6.13.0",
         "@dust-tt/client": "^1.1.6",
-        "@dust-tt/sparkle": "^0.2.578",
+        "@dust-tt/sparkle": "^0.2.579",
         "@frontapp/plugin-sdk": "^1.8.1",
         "@modelcontextprotocol/sdk": "^1.9.0",
         "@tailwindcss/forms": "^0.5.9",
@@ -1293,9 +1293,9 @@
       }
     },
     "node_modules/@dust-tt/sparkle": {
-      "version": "0.2.578",
-      "resolved": "https://registry.npmjs.org/@dust-tt/sparkle/-/sparkle-0.2.578.tgz",
-      "integrity": "sha512-eMj01TD6K73UQaTs2mt+k12lOUKT/x25msfA0AGh6Aq24c8WW58zO911fnB9Cav7Ud/kgifS4ZUIj4ezQiN9cg==",
+      "version": "0.2.579",
+      "resolved": "https://registry.npmjs.org/@dust-tt/sparkle/-/sparkle-0.2.579.tgz",
+      "integrity": "sha512-acEKAOlB4K4sJuzMn8iWg0B/ROnHnLLm5psRzv6De2Tagkaqt3BWXRKFU1xjWRGarAcLMvB6GvHuCK/slMAC5A==",
       "dependencies": {
         "@emoji-mart/data": "^1.1.2",
         "@emoji-mart/react": "^1.1.1",

--- a/extension/package.json
+++ b/extension/package.json
@@ -59,7 +59,7 @@
     "@auth0/auth0-spa-js": "^2.1.3",
     "@datadog/browser-logs": "^6.13.0",
     "@dust-tt/client": "^1.1.6",
-    "@dust-tt/sparkle": "^0.2.578",
+    "@dust-tt/sparkle": "^0.2.579",
     "@frontapp/plugin-sdk": "^1.8.1",
     "@modelcontextprotocol/sdk": "^1.9.0",
     "@tailwindcss/forms": "^0.5.9",

--- a/front/package-lock.json
+++ b/front/package-lock.json
@@ -7,7 +7,7 @@
       "dependencies": {
         "@datadog/browser-logs": "^6.13.0",
         "@dust-tt/client": "file:../sdks/js",
-        "@dust-tt/sparkle": "^0.2.578",
+        "@dust-tt/sparkle": "^0.2.579",
         "@google-cloud/bigquery": "^7.9.1",
         "@google-cloud/storage-transfer": "^3.6.0",
         "@heroicons/react": "^2.0.11",
@@ -1112,9 +1112,9 @@
       "link": true
     },
     "node_modules/@dust-tt/sparkle": {
-      "version": "0.2.578",
-      "resolved": "https://registry.npmjs.org/@dust-tt/sparkle/-/sparkle-0.2.578.tgz",
-      "integrity": "sha512-eMj01TD6K73UQaTs2mt+k12lOUKT/x25msfA0AGh6Aq24c8WW58zO911fnB9Cav7Ud/kgifS4ZUIj4ezQiN9cg==",
+      "version": "0.2.579",
+      "resolved": "https://registry.npmjs.org/@dust-tt/sparkle/-/sparkle-0.2.579.tgz",
+      "integrity": "sha512-acEKAOlB4K4sJuzMn8iWg0B/ROnHnLLm5psRzv6De2Tagkaqt3BWXRKFU1xjWRGarAcLMvB6GvHuCK/slMAC5A==",
       "dependencies": {
         "@emoji-mart/data": "^1.1.2",
         "@emoji-mart/react": "^1.1.1",

--- a/front/package.json
+++ b/front/package.json
@@ -24,7 +24,7 @@
   "dependencies": {
     "@datadog/browser-logs": "^6.13.0",
     "@dust-tt/client": "file:../sdks/js",
-    "@dust-tt/sparkle": "^0.2.578",
+    "@dust-tt/sparkle": "^0.2.579",
     "@google-cloud/bigquery": "^7.9.1",
     "@google-cloud/storage-transfer": "^3.6.0",
     "@heroicons/react": "^2.0.11",


### PR DESCRIPTION
## Description

This PR bumps the sparkle version to ship the changes from https://github.com/dust-tt/dust/pull/15128

## Tests

Locally

## Risk

Low

## Deploy Plan

Deploy front