### PR TITLE
Add slack get user info tool

### DIFF
--- a/front/lib/actions/mcp_internal_actions/constants.ts
+++ b/front/lib/actions/mcp_internal_actions/constants.ts
@@ -345,6 +345,7 @@ export const INTERNAL_MCP_SERVERS = {
       list_public_channels: "never_ask",
       list_threads: "never_ask",
       post_message: "low",
+      get_user: "never_ask",
     },
     timeoutMs: undefined,
   },


### PR DESCRIPTION
## Description

* See rate limiting issues when listing all Slack users in instances where agent is trying to work backwards from user ID. Adding a tool for the Slack get user API to retrieve user information for the user ID.

## Tests

```
{
  "id": "U08JBGWL2G2",
  "name": "fealoia88",
  "is_bot": false,
  "updated": 1742325722,
  "is_app_user": false,
  "deleted": false,
  "color": "bb86b7",
  "is_email_confirmed": true,
  "real_name": "Frank Aloia",
  "tz": "America/New_York",
  "tz_label": "Eastern Daylight Time",
  "tz_offset": -14400,
  "is_admin": true,
  "is_owner": true,
  "is_primary_owner": true,
  "is_restricted": false,
  "is_ultra_restricted": false,
  "has_2fa": false,
  "who_can_share_contact_card": "EVERYONE",
  "profile": {
    "real_name": "Frank Aloia",
    "display_name": "",
    "avatar_hash": "4bdccd1e29b0",
    "real_name_normalized": "Frank Aloia",
    "display_name_normalized": "",
    "image_24": "https://avatars.slack-edge.com/2025-03-18/8615144358390_4bdccd1e29b0b83687f5_24.png",
    "image_32": "https://avatars.slack-edge.com/2025-03-18/8615144358390_4bdccd1e29b0b83687f5_32.png",
    "image_48": "https://avatars.slack-edge.com/2025-03-18/8615144358390_4bdccd1e29b0b83687f5_48.png",
    "image_72": "https://avatars.slack-edge.com/2025-03-18/8615144358390_4bdccd1e29b0b83687f5_72.png",
    "image_192": "https://avatars.slack-edge.com/2025-03-18/8615144358390_4bdccd1e29b0b83687f5_192.png",
    "image_512": "https://avatars.slack-edge.com/2025-03-18/8615144358390_4bdccd1e29b0b83687f5_512.png",
    "image_1024": "https://avatars.slack-edge.com/2025-03-18/8615144358390_4bdccd1e29b0b83687f5_1024.png",
    "image_original": "https://avatars.slack-edge.com/2025-03-18/8615144358390_4bdccd1e29b0b83687f5_original.png",
    "is_custom_image": true,
    "first_name": "Frank",
    "last_name": "Aloia",
    "team": "T08JBGWKML2",
    "title": "",
    "phone": "",
    "skype": "",
    "status_text": "",
    "status_text_canonical": "",
    "status_emoji": "",
    "status_emoji_display_info": [],
    "status_expiration": 0
  }
}
```
## Risk

* Minimal

## Deploy Plan

* Deploy front