### PR TITLE
[front] - chore(AB v2): redirect to new agent builder

### DIFF
--- a/front/components/assistant/AssistantBrowser.tsx
+++ b/front/components/assistant/AssistantBrowser.tsx
@@ -36,7 +36,7 @@ import {
   subFilter,
   tagsSorter,
 } from "@app/lib/utils";
-import { setQueryParam } from "@app/lib/utils/router";
+import { getAgentBuilderRoute, setQueryParam } from "@app/lib/utils/router";
 import type { LightAgentConfigurationType, WorkspaceType } from "@app/types";
 import { isBuilder } from "@app/types";
 
@@ -302,7 +302,11 @@ export function AssistantBrowser({
 
             <Button
               tooltip="Manage agents"
-              href={`/w/${owner.sId}/builder/assistants/`}
+              href={getAgentBuilderRoute(
+                owner.sId,
+                "manage",
+                featureFlags.includes("agent_builder_v2")
+              )}
               variant="primary"
               icon={RobotIcon}
               label="Manage"

--- a/front/components/assistant/AssistantDetails.tsx
+++ b/front/components/assistant/AssistantDetails.tsx
@@ -39,6 +39,8 @@ import { MembersList } from "@app/components/members/MembersList";
 import { isMCPConfigurationForAgentMemory } from "@app/lib/actions/types/guards";
 import { useAgentConfiguration } from "@app/lib/swr/assistants";
 import { useEditors, useUpdateEditors } from "@app/lib/swr/editors";
+import { useFeatureFlags } from "@app/lib/swr/workspaces";
+import { getAgentBuilderRoute } from "@app/lib/utils/router";
 import type {
   AgentConfigurationScope,
   AgentConfigurationType,
@@ -93,8 +95,12 @@ function AssistantDetailsInfo({
   agentConfiguration: AgentConfigurationType;
   owner: WorkspaceType;
 }) {
-  const isConfigurable = agentConfiguration.sId === GLOBAL_AGENTS_SID.DUST;
+  const { featureFlags } = useFeatureFlags({
+    workspaceId: owner.sId,
+  });
+  const hasAgentBuilderV2 = featureFlags.includes("agent_builder_v2");
 
+  const isConfigurable = agentConfiguration.sId === GLOBAL_AGENTS_SID.DUST;
   return (
     <>
       {agentConfiguration.tags.length > 0 && (
@@ -117,7 +123,11 @@ function AssistantDetailsInfo({
             <Button
               label={`Manage ${agentConfiguration.name} configuration`}
               icon={Cog6ToothIcon}
-              href={`/w/${owner.sId}/builder/assistants/${agentConfiguration.sId}`}
+              href={getAgentBuilderRoute(
+                owner.sId,
+                agentConfiguration.sId,
+                hasAgentBuilderV2
+              )}
             />
           ) : (
             <Chip

--- a/front/components/assistant/AssistantDetailsButtonBar.tsx
+++ b/front/components/assistant/AssistantDetailsButtonBar.tsx
@@ -24,6 +24,7 @@ import { useURLSheet } from "@app/hooks/useURLSheet";
 import { useUpdateUserFavorite } from "@app/lib/swr/assistants";
 import { useUser } from "@app/lib/swr/user";
 import { useFeatureFlags } from "@app/lib/swr/workspaces";
+import { getAgentBuilderRoute } from "@app/lib/utils/router";
 import logger from "@app/logger/logger";
 import type { LightAgentConfigurationType, WorkspaceType } from "@app/types";
 import { isAdmin, isBuilder, normalizeError } from "@app/types";
@@ -54,6 +55,7 @@ export function AssistantDetailsButtonBar({
     workspaceId: owner.sId,
   });
 
+  const hasAgentBuilderV2 = featureFlags.includes("agent_builder_v2");
   const isRestrictedFromAgentCreation =
     featureFlags.includes("disallow_agent_creation_to_users") &&
     !isBuilder(owner);
@@ -173,7 +175,12 @@ export function AssistantDetailsButtonBar({
                   icon={ClipboardIcon}
                   onClick={async (e) => {
                     await router.push(
-                      `/w/${owner.sId}/builder/assistants/new?flow=personal_assistants&duplicate=${agentConfiguration.sId}`
+                      getAgentBuilderRoute(
+                        owner.sId,
+                        "new",
+                        hasAgentBuilderV2,
+                        `flow=personal_assistants&duplicate=${agentConfiguration.sId}`
+                      )
                     );
                     e.stopPropagation();
                   }}
@@ -240,7 +247,12 @@ export function AssistantDetailsButtonBar({
             size="sm"
             href={
               canEditAssistant
-                ? `/w/${owner.sId}/builder/assistants/${agentConfiguration.sId}?flow=workspace_assistants`
+                ? getAgentBuilderRoute(
+                    owner.sId,
+                    agentConfiguration.sId,
+                    hasAgentBuilderV2,
+                    "flow=workspace_assistants"
+                  )
                 : undefined
             }
             disabled={!canEditAssistant}

--- a/front/components/assistant/CreateAgentButton.tsx
+++ b/front/components/assistant/CreateAgentButton.tsx
@@ -15,6 +15,7 @@ import { useState } from "react";
 
 import { useYAMLUpload } from "@app/hooks/useYAMLUpload";
 import { useFeatureFlags } from "@app/lib/swr/workspaces";
+import { getAgentBuilderRoute } from "@app/lib/utils/router";
 import type { LightWorkspaceType } from "@app/types";
 
 interface CreateAgentButtonProps {
@@ -33,6 +34,12 @@ export const CreateAgentButton = ({
   });
 
   const { hasFeature } = useFeatureFlags({ workspaceId: owner.sId });
+
+  const { featureFlags } = useFeatureFlags({
+    workspaceId: owner.sId,
+  });
+
+  const hasAgentBuilderV2 = featureFlags.includes("agent_builder_v2");
 
   return (
     <DropdownMenu>
@@ -56,7 +63,12 @@ export const CreateAgentButton = ({
           onClick={() => {
             setIsLoading(true);
             void router.push(
-              `/w/${owner.sId}/builder/assistants/new?flow=personal_assistants`
+              getAgentBuilderRoute(
+                owner.sId,
+                "new",
+                hasAgentBuilderV2,
+                "flow=personal_assistants"
+              )
             );
           }}
         />
@@ -66,7 +78,12 @@ export const CreateAgentButton = ({
           onClick={() => {
             setIsLoading(true);
             void router.push(
-              `/w/${owner.sId}/builder/assistants/create?flow=personal_assistants`
+              getAgentBuilderRoute(
+                owner.sId,
+                "create",
+                hasAgentBuilderV2,
+                "flow=personal_assistants"
+              )
             );
           }}
         />

--- a/front/components/assistant/conversation/SidebarMenu.tsx
+++ b/front/components/assistant/conversation/SidebarMenu.tsx
@@ -43,6 +43,7 @@ import {
 } from "@app/lib/swr/conversations";
 import { useFeatureFlags } from "@app/lib/swr/workspaces";
 import { removeDiacritics, subFilter } from "@app/lib/utils";
+import { getAgentBuilderRoute } from "@app/lib/utils/router";
 import type { ConversationWithoutContentType, WorkspaceType } from "@app/types";
 import { isBuilder } from "@app/types";
 
@@ -76,6 +77,7 @@ export function AssistantSidebarMenu({ owner }: AssistantSidebarMenuProps) {
     workspaceId: owner.sId,
   });
 
+  const hasAgentBuilderV2 = featureFlags.includes("agent_builder_v2");
   const isRestrictedFromAgentCreation =
     featureFlags.includes("disallow_agent_creation_to_users") &&
     !isBuilder(owner);
@@ -302,14 +304,24 @@ export function AssistantSidebarMenu({ owner }: AssistantSidebarMenuProps) {
                       <>
                         <DropdownMenuLabel>Agent</DropdownMenuLabel>
                         <DropdownMenuItem
-                          href={`/w/${owner.sId}/builder/assistants/new?flow=personal_assistants`}
+                          href={getAgentBuilderRoute(
+                            owner.sId,
+                            "new",
+                            hasAgentBuilderV2,
+                            "flow=personal_assistants"
+                          )}
                           icon={DocumentIcon}
                           label="New agent from scratch"
                           data-gtm-label="assistantCreationButton"
                           data-gtm-location="sidebarMenu"
                         />
                         <DropdownMenuItem
-                          href={`/w/${owner.sId}/builder/assistants/create?flow=personal_assistants`}
+                          href={getAgentBuilderRoute(
+                            owner.sId,
+                            "create",
+                            hasAgentBuilderV2,
+                            "flow=personal_assistants"
+                          )}
                           icon={MagicIcon}
                           label="New agent from template"
                           data-gtm-label="assistantCreationButton"
@@ -339,7 +351,11 @@ export function AssistantSidebarMenu({ owner }: AssistantSidebarMenuProps) {
                     )}
                     {isBuilder(owner) && (
                       <DropdownMenuItem
-                        href={`/w/${owner.sId}/builder/assistants`}
+                        href={getAgentBuilderRoute(
+                          owner.sId,
+                          "manage",
+                          hasAgentBuilderV2
+                        )}
                         icon={RobotIcon}
                         label="Manage agents"
                         data-gtm-label="assistantManagementButton"

--- a/front/components/assistant/manager/AssistantsTable.tsx
+++ b/front/components/assistant/manager/AssistantsTable.tsx
@@ -20,11 +20,13 @@ import { GlobalAgentAction } from "@app/components/assistant/manager/GlobalAgent
 import { TableTagSelector } from "@app/components/assistant/manager/TableTagSelector";
 import { assistantUsageMessage } from "@app/components/assistant/Usage";
 import { useTags } from "@app/lib/swr/tags";
+import { useFeatureFlags } from "@app/lib/swr/workspaces";
 import {
   classNames,
   formatTimestampToFriendlyDate,
   tagsSorter,
 } from "@app/lib/utils";
+import { getAgentBuilderRoute } from "@app/lib/utils/router";
 import type {
   AgentConfigurationScope,
   AgentUsageType,
@@ -278,6 +280,12 @@ export function AssistantsTable({
     agentConfiguration: undefined,
   });
   const router = useRouter();
+
+  const { featureFlags } = useFeatureFlags({
+    workspaceId: owner.sId,
+  });
+  const hasAgentBuilderV2 = featureFlags.includes("agent_builder_v2");
+
   const rows: RowData[] = useMemo(
     () =>
       agents.map((agentConfiguration) => {
@@ -345,13 +353,16 @@ export function AssistantsTable({
                     onClick: (e: React.MouseEvent) => {
                       e.stopPropagation();
                       void router.push(
-                        `/w/${owner.sId}/builder/assistants/${
-                          agentConfiguration.sId
-                        }?flow=${
-                          agentConfiguration.scope
-                            ? "workspace_assistants"
-                            : "personal_assistants"
-                        }`
+                        getAgentBuilderRoute(
+                          owner.sId,
+                          agentConfiguration.sId,
+                          hasAgentBuilderV2,
+                          `flow=${
+                            agentConfiguration.scope
+                              ? "workspace_assistants"
+                              : "personal_assistants"
+                          }`
+                        )
                       );
                     },
                     kind: "item" as const,
@@ -388,7 +399,12 @@ export function AssistantsTable({
                     onClick: (e: React.MouseEvent) => {
                       e.stopPropagation();
                       void router.push(
-                        `/w/${owner.sId}/builder/assistants/new?flow=personal_assistants&duplicate=${agentConfiguration.sId}`
+                        getAgentBuilderRoute(
+                          owner.sId,
+                          "new",
+                          hasAgentBuilderV2,
+                          `flow=personal_assistants&duplicate=${agentConfiguration.sId}`
+                        )
                       );
                     },
                     kind: "item" as const,
@@ -413,6 +429,7 @@ export function AssistantsTable({
     [
       agents,
       handleToggleAgentStatus,
+      hasAgentBuilderV2,
       owner,
       router,
       setShowDetails,

--- a/front/components/assistant/manager/GlobalAgentAction.tsx
+++ b/front/components/assistant/manager/GlobalAgentAction.tsx
@@ -11,6 +11,8 @@ import {
 } from "@dust-tt/sparkle";
 import { useRouter } from "next/router";
 
+import { useFeatureFlags } from "@app/lib/swr/workspaces";
+import { getAgentBuilderRoute } from "@app/lib/utils/router";
 import type { LightAgentConfigurationType, WorkspaceType } from "@app/types";
 import { GLOBAL_AGENTS_SID, isBuilder } from "@app/types";
 
@@ -32,6 +34,12 @@ export function GlobalAgentAction({
   setShowDisabledFreeWorkspacePopup,
 }: GlobalAgentActionProps) {
   const router = useRouter();
+
+  const { featureFlags } = useFeatureFlags({
+    workspaceId: owner.sId,
+  });
+  const hasAgentBuilderV2 = featureFlags.includes("agent_builder_v2");
+
   if (agent.sId === "helper") {
     return null;
   }
@@ -49,7 +57,9 @@ export function GlobalAgentAction({
         disabled={!isBuilder(owner)}
         onClick={(e: Event) => {
           e.stopPropagation();
-          void router.push(`/w/${owner.sId}/builder/assistants/${agent.sId}`);
+          void router.push(
+            getAgentBuilderRoute(owner.sId, agent.sId, hasAgentBuilderV2)
+          );
         }}
       />
     );

--- a/front/components/assistant_builder/AssistantTemplateModal.tsx
+++ b/front/components/assistant_builder/AssistantTemplateModal.tsx
@@ -15,6 +15,8 @@ import Link from "next/link";
 
 import type { BuilderFlow } from "@app/components/assistant_builder/types";
 import { useAssistantTemplate } from "@app/lib/swr/assistants";
+import { useFeatureFlags } from "@app/lib/swr/workspaces";
+import { getAgentBuilderRoute } from "@app/lib/utils/router";
 import type { WorkspaceType } from "@app/types";
 
 interface AssistantTemplateModalProps {
@@ -32,6 +34,11 @@ export function AssistantTemplateModal({
 }: AssistantTemplateModalProps) {
   const { assistantTemplate, isAssistantTemplateLoading } =
     useAssistantTemplate({ templateId });
+
+  const { featureFlags } = useFeatureFlags({
+    workspaceId: owner.sId,
+  });
+  const hasAgentBuilderV2 = featureFlags.includes("agent_builder_v2");
 
   return (
     <Sheet
@@ -61,7 +68,12 @@ export function AssistantTemplateModal({
                       @{assistantTemplate.handle}
                     </span>
                     <Link
-                      href={`/w/${owner.sId}/builder/assistants/new?flow=${flow}&templateId=${assistantTemplate.sId}`}
+                      href={getAgentBuilderRoute(
+                        owner.sId,
+                        "new",
+                        hasAgentBuilderV2,
+                        `flow=${flow}&templateId=${assistantTemplate.sId}`
+                      )}
                     >
                       <Button
                         label="Use this template"

--- a/front/components/assistant_builder/InstructionScreen.tsx
+++ b/front/components/assistant_builder/InstructionScreen.tsx
@@ -37,6 +37,7 @@ import { useUserMetadata } from "@app/lib/swr/user";
 import { useFeatureFlags } from "@app/lib/swr/workspaces";
 import { setUserMetadataFromClient } from "@app/lib/user";
 import { classNames } from "@app/lib/utils";
+import { getAgentBuilderRoute } from "@app/lib/utils/router";
 import type {
   LightAgentConfigurationType,
   ModelConfigurationType,
@@ -106,6 +107,7 @@ export function InstructionScreen({
   const { featureFlags } = useFeatureFlags({
     workspaceId: owner.sId,
   });
+  const hasAgentBuilderV2 = featureFlags.includes("agent_builder_v2");
 
   const extensions = useMemo(() => {
     return getAgentBuilderInstructionsExtensionsForWorkspace(
@@ -335,7 +337,12 @@ export function InstructionScreen({
                 size="xs"
                 onClick={() => {
                   void router.push(
-                    `/w/${owner.sId}/builder/assistants/create?flow=personal_assistants`
+                    getAgentBuilderRoute(
+                      owner.sId,
+                      "create",
+                      hasAgentBuilderV2,
+                      "flow=personal_assistants"
+                    )
                   );
                 }}
                 label="Browse templates"
@@ -364,7 +371,11 @@ export function InstructionScreen({
                   You can also use one of our{" "}
                   <Hoverable
                     variant="highlight"
-                    href={`/w/${owner.sId}/builder/assistants/create`}
+                    href={getAgentBuilderRoute(
+                      owner.sId,
+                      "create",
+                      hasAgentBuilderV2
+                    )}
                     target="_blank"
                   >
                     templates

--- a/front/lib/utils/router.ts
+++ b/front/lib/utils/router.ts
@@ -31,3 +31,14 @@ export const parseQueryString = (url: string) => {
 
   return params;
 };
+
+export const getAgentBuilderRoute = (
+  workspaceId: string,
+  route: string,
+  hasAgentBuilderV2: boolean,
+  queryParams?: string
+): string => {
+  const basePath = hasAgentBuilderV2 ? "agents" : "assistants";
+  const fullPath = `/w/${workspaceId}/builder/${basePath}${route === "manage" ? "" : `/${route}`}`;
+  return queryParams ? `${fullPath}?${queryParams}` : fullPath;
+};


### PR DESCRIPTION
## Description

This PR aims at redirecting to the new agent builder instead of the assistant builder based on whether the agent `agent_builder_v2` flag is activated.

## Tests

Locally

## Risk

Low

## Deploy Plan

Deploy front
