### PR TITLE
[connectors] Add command to fix parents, fix heartbeat outside of temporal context

### DIFF
--- a/connectors/src/connectors/microsoft/lib/cli.ts
+++ b/connectors/src/connectors/microsoft/lib/cli.ts
@@ -277,7 +277,7 @@ export const microsoft = async ({
               parentInternalId
             );
 
-            if (parentNode) {
+            if (!parentNode) {
               logger.info(
                 { internalId: node.internalId, parentInternalId },
                 "Parent does not exist, skipping"

--- a/connectors/src/connectors/microsoft/lib/cli.ts
+++ b/connectors/src/connectors/microsoft/lib/cli.ts
@@ -195,7 +195,7 @@ export const microsoft = async ({
       return { status: 200, content: { totalCount }, type: typeof totalCount };
     }
 
-    case "update-parents": {
+    case "update-parent-in-node-table": {
       const connector = await getConnector(args);
       const { internalId, idsFile } = args;
 

--- a/connectors/src/connectors/microsoft/lib/cli.ts
+++ b/connectors/src/connectors/microsoft/lib/cli.ts
@@ -252,7 +252,7 @@ export const microsoft = async ({
           client,
           typeAndPathFromInternalId(internalId).itemAPIPath
         );
-        //get parent reference from driveItem
+        // Get parent reference from driveItem.
         if (driveItem && !driveItem.root && driveItem.parentReference) {
           const parentInternalId = getParentReferenceInternalId(
             driveItem.parentReference

--- a/connectors/src/connectors/microsoft/lib/cli.ts
+++ b/connectors/src/connectors/microsoft/lib/cli.ts
@@ -202,7 +202,7 @@ export const microsoft = async ({
       let internalIds: string[];
 
       if (idsFile) {
-        // Read permissions from JSON file
+        // Read ids from JSON file
         if (!fs.existsSync(idsFile)) {
           throw new Error(`Ids file not found: ${idsFile}`);
         }

--- a/connectors/src/connectors/microsoft/lib/cli.ts
+++ b/connectors/src/connectors/microsoft/lib/cli.ts
@@ -1,3 +1,8 @@
+import { isLeft } from "fp-ts/lib/Either";
+import fs from "fs";
+import * as t from "io-ts";
+import * as reporter from "io-ts-reporters";
+
 import { getConnectorManager } from "@connectors/connectors";
 import { getClient } from "@connectors/connectors/microsoft";
 import {
@@ -188,6 +193,104 @@ export const microsoft = async ({
       }
 
       return { status: 200, content: { totalCount }, type: typeof totalCount };
+    }
+
+    case "update-parents": {
+      const connector = await getConnector(args);
+      const { internalId, idsFile } = args;
+
+      let internalIds: string[];
+
+      if (idsFile) {
+        // Read permissions from JSON file
+        if (!fs.existsSync(idsFile)) {
+          throw new Error(`Ids file not found: ${idsFile}`);
+        }
+
+        try {
+          const fileContent = fs.readFileSync(idsFile, "utf8");
+          const parsedIds = JSON.parse(fileContent);
+
+          // Validate using io-ts schema
+          const validation = t.array(t.string).decode(parsedIds);
+
+          if (isLeft(validation)) {
+            const pathError = reporter.formatValidationErrors(validation.left);
+            throw new Error(`Invalid permissions file format: ${pathError}`);
+          }
+
+          internalIds = validation.right;
+        } catch (error) {
+          if (error instanceof SyntaxError) {
+            throw new Error(
+              `Invalid JSON in permissions file: ${error.message}`
+            );
+          }
+          throw error;
+        }
+      } else {
+        if (!internalId) {
+          throw new Error("Missing --internalId argument");
+        }
+        internalIds = [internalId];
+      }
+
+      //get node grom ms graph api
+      const client = await getClient(connector.connectionId);
+
+      for (const internalId of internalIds) {
+        const node = await MicrosoftNodeResource.fetchByInternalId(
+          connector.id,
+          internalId
+        );
+
+        if (!node) {
+          throw new Error(`Could not find node for internalId ${internalId}`);
+        }
+        const driveItem: DriveItem = await getItem(
+          logger,
+          client,
+          typeAndPathFromInternalId(internalId).itemAPIPath
+        );
+        //get parent reference from driveItem
+        if (driveItem && !driveItem.root && driveItem.parentReference) {
+          const parentInternalId = getParentReferenceInternalId(
+            driveItem.parentReference
+          );
+
+          if (parentInternalId === node.parentInternalId) {
+            logger.info(
+              { internalId: node.internalId, parentInternalId },
+              "Parent internalId is the same as the node's parentInternalId, nothing to update"
+            );
+          } else {
+            logger.info(
+              {
+                internalId: node.internalId,
+                previousValue: node.parentInternalId,
+                parentInternalId,
+              },
+              "Updating parentInternalId"
+            );
+            const parentNode = await MicrosoftNodeResource.fetchByInternalId(
+              connector.id,
+              parentInternalId
+            );
+
+            if (parentNode) {
+              logger.info(
+                { internalId: node.internalId, parentInternalId },
+                "Parent does not exist, skipping"
+              );
+            } else {
+              await node.update({ parentInternalId });
+            }
+          }
+        } else {
+          logger.info({ driveItem }, "Node not found, nothing to update");
+        }
+      }
+      return { success: true };
     }
 
     case "start-incremental-sync": {

--- a/connectors/src/connectors/microsoft/lib/cli.ts
+++ b/connectors/src/connectors/microsoft/lib/cli.ts
@@ -235,7 +235,7 @@ export const microsoft = async ({
         internalIds = [internalId];
       }
 
-      //get node grom ms graph api
+      // Get node from MS Graph API.
       const client = await getClient(connector.connectionId);
 
       for (const internalId of internalIds) {

--- a/connectors/src/lib/temporal.ts
+++ b/connectors/src/lib/temporal.ts
@@ -168,6 +168,14 @@ export async function terminateAllWorkflowsForConnectorId(
 // This function allows to heartbeat back to the temporal workflow, but also
 // awaits a temporal sleep(0), which allows to throw an exception if the activity should be cancelled.
 export async function heartbeat() {
+  try {
+    Context.current();
+  } catch (error) {
+    // If we're not in a temporal context, Context.current() will throw
+    // In this case, we just return without doing anything
+    // This allows the function to be called safely outside of temporal activities
+    return;
+  }
   Context.current().heartbeat();
   await Context.current().sleep(0);
 }

--- a/connectors/src/types/admin/cli.ts
+++ b/connectors/src/types/admin/cli.ts
@@ -366,7 +366,7 @@ export const MicrosoftCommandSchema = t.type({
     t.literal("skip-file"),
     t.literal("sync-node"),
     t.literal("get-parents"),
-    t.literal("update-parents"),
+    t.literal("update-parent-in-node-table"),
   ]),
   args: t.record(
     t.string,

--- a/connectors/src/types/admin/cli.ts
+++ b/connectors/src/types/admin/cli.ts
@@ -366,6 +366,7 @@ export const MicrosoftCommandSchema = t.type({
     t.literal("skip-file"),
     t.literal("sync-node"),
     t.literal("get-parents"),
+    t.literal("update-parents"),
   ]),
   args: t.record(
     t.string,

--- a/front/types/connectors/admin/cli.ts
+++ b/front/types/connectors/admin/cli.ts
@@ -366,7 +366,7 @@ export const MicrosoftCommandSchema = t.type({
     t.literal("skip-file"),
     t.literal("sync-node"),
     t.literal("get-parents"),
-    t.literal("update-parents"),
+    t.literal("update-parent-in-node-table"),
   ]),
   args: t.record(
     t.string,

--- a/front/types/connectors/admin/cli.ts
+++ b/front/types/connectors/admin/cli.ts
@@ -366,6 +366,7 @@ export const MicrosoftCommandSchema = t.type({
     t.literal("skip-file"),
     t.literal("sync-node"),
     t.literal("get-parents"),
+    t.literal("update-parents"),
   ]),
   args: t.record(
     t.string,


### PR DESCRIPTION

## Description

Following issues with parents being reset to null, we still need to restore manually parents on some nodes.
This commands checks the node in ms, get the parent, and update parentInternalId if parent is indeed available in existing nodes.
Also  fix heartbeat so that it's ignored outside of temporal context , when called in cli context ( it's called syncNodes for example)

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
