### PR TITLE
[connectors] chore(logs): Remove outbound log interceptor

### DIFF
--- a/connectors/src/connectors/bigquery/temporal/worker.ts
+++ b/connectors/src/connectors/bigquery/temporal/worker.ts
@@ -10,10 +10,7 @@ import {
   getTemporalWorkerConnection,
   TEMPORAL_MAXED_CACHED_WORKFLOWS,
 } from "@connectors/lib/temporal";
-import {
-  ActivityInboundLogInterceptor,
-  ActivityOutboundLogInterceptor,
-} from "@connectors/lib/temporal_monitoring";
+import { ActivityInboundLogInterceptor } from "@connectors/lib/temporal_monitoring";
 import logger from "@connectors/logger/logger";
 
 export async function runBigQueryWorker() {
@@ -31,7 +28,6 @@ export async function runBigQueryWorker() {
       activity: [
         (ctx: Context) => ({
           inbound: new ActivityInboundLogInterceptor(ctx, logger, "bigquery"),
-          outbound: new ActivityOutboundLogInterceptor("bigquery"),
         }),
         () => ({
           inbound: new BigQueryCastKnownErrorsInterceptor(),

--- a/connectors/src/connectors/confluence/temporal/worker.ts
+++ b/connectors/src/connectors/confluence/temporal/worker.ts
@@ -10,10 +10,7 @@ import {
   getTemporalWorkerConnection,
   TEMPORAL_MAXED_CACHED_WORKFLOWS,
 } from "@connectors/lib/temporal";
-import {
-  ActivityInboundLogInterceptor,
-  ActivityOutboundLogInterceptor,
-} from "@connectors/lib/temporal_monitoring";
+import { ActivityInboundLogInterceptor } from "@connectors/lib/temporal_monitoring";
 import logger from "@connectors/logger/logger";
 
 export async function runConfluenceWorker() {
@@ -31,7 +28,6 @@ export async function runConfluenceWorker() {
       activity: [
         (ctx: Context) => ({
           inbound: new ActivityInboundLogInterceptor(ctx, logger, "confluence"),
-          outbound: new ActivityOutboundLogInterceptor("confluence"),
         }),
         () => ({
           inbound: new ConfluenceCastKnownErrorsInterceptor(),

--- a/connectors/src/connectors/github/temporal/worker.ts
+++ b/connectors/src/connectors/github/temporal/worker.ts
@@ -9,10 +9,7 @@ import {
   getTemporalWorkerConnection,
   TEMPORAL_MAXED_CACHED_WORKFLOWS,
 } from "@connectors/lib/temporal";
-import {
-  ActivityInboundLogInterceptor,
-  ActivityOutboundLogInterceptor,
-} from "@connectors/lib/temporal_monitoring";
+import { ActivityInboundLogInterceptor } from "@connectors/lib/temporal_monitoring";
 import logger from "@connectors/logger/logger";
 
 export async function runGithubWorker() {
@@ -33,7 +30,6 @@ export async function runGithubWorker() {
       activity: [
         (ctx: Context) => ({
           inbound: new ActivityInboundLogInterceptor(ctx, logger, "github"),
-          outbound: new ActivityOutboundLogInterceptor("github"),
         }),
         () => ({
           inbound: new GithubCastKnownErrorsInterceptor(),

--- a/connectors/src/connectors/gong/temporal/worker.ts
+++ b/connectors/src/connectors/gong/temporal/worker.ts
@@ -9,10 +9,7 @@ import {
   getTemporalWorkerConnection,
   TEMPORAL_MAXED_CACHED_WORKFLOWS,
 } from "@connectors/lib/temporal";
-import {
-  ActivityInboundLogInterceptor,
-  ActivityOutboundLogInterceptor,
-} from "@connectors/lib/temporal_monitoring";
+import { ActivityInboundLogInterceptor } from "@connectors/lib/temporal_monitoring";
 import logger from "@connectors/logger/logger";
 
 export async function runGongWorker() {
@@ -30,7 +27,6 @@ export async function runGongWorker() {
       activity: [
         (ctx: Context) => ({
           inbound: new ActivityInboundLogInterceptor(ctx, logger, "gong"),
-          outbound: new ActivityOutboundLogInterceptor("gong"),
         }),
         () => ({
           inbound: new GongCastKnownErrorsInterceptor(),

--- a/connectors/src/connectors/google_drive/temporal/worker.ts
+++ b/connectors/src/connectors/google_drive/temporal/worker.ts
@@ -6,10 +6,7 @@ import * as activities from "@connectors/connectors/google_drive/temporal/activi
 import { GoogleDriveCastKnownErrorsInterceptor } from "@connectors/connectors/google_drive/temporal/cast_known_errors";
 import * as sync_status from "@connectors/lib/sync_status";
 import { getTemporalWorkerConnection } from "@connectors/lib/temporal";
-import {
-  ActivityInboundLogInterceptor,
-  ActivityOutboundLogInterceptor,
-} from "@connectors/lib/temporal_monitoring";
+import { ActivityInboundLogInterceptor } from "@connectors/lib/temporal_monitoring";
 import logger from "@connectors/logger/logger";
 
 import {
@@ -36,7 +33,6 @@ export async function runGoogleWorkers() {
             logger,
             "google_drive"
           ),
-          outbound: new ActivityOutboundLogInterceptor("google_drive"),
         }),
         () => ({
           inbound: new GoogleDriveCastKnownErrorsInterceptor(),
@@ -70,7 +66,6 @@ export async function runGoogleWorkers() {
             logger,
             "google_drive"
           ),
-          outbound: new ActivityOutboundLogInterceptor("google_drive"),
         }),
         () => ({
           inbound: new GoogleDriveCastKnownErrorsInterceptor(),

--- a/connectors/src/connectors/intercom/temporal/worker.ts
+++ b/connectors/src/connectors/intercom/temporal/worker.ts
@@ -7,10 +7,7 @@ import {
   getTemporalWorkerConnection,
   TEMPORAL_MAXED_CACHED_WORKFLOWS,
 } from "@connectors/lib/temporal";
-import {
-  ActivityInboundLogInterceptor,
-  ActivityOutboundLogInterceptor,
-} from "@connectors/lib/temporal_monitoring";
+import { ActivityInboundLogInterceptor } from "@connectors/lib/temporal_monitoring";
 import logger from "@connectors/logger/logger";
 
 export async function runIntercomWorker() {
@@ -28,7 +25,6 @@ export async function runIntercomWorker() {
       activity: [
         (ctx: Context) => ({
           inbound: new ActivityInboundLogInterceptor(ctx, logger, "intercom"),
-          outbound: new ActivityOutboundLogInterceptor("intercom"),
         }),
       ],
     },

--- a/connectors/src/connectors/microsoft/temporal/worker.ts
+++ b/connectors/src/connectors/microsoft/temporal/worker.ts
@@ -8,10 +8,7 @@ import {
   getTemporalWorkerConnection,
   TEMPORAL_MAXED_CACHED_WORKFLOWS,
 } from "@connectors/lib/temporal";
-import {
-  ActivityInboundLogInterceptor,
-  ActivityOutboundLogInterceptor,
-} from "@connectors/lib/temporal_monitoring";
+import { ActivityInboundLogInterceptor } from "@connectors/lib/temporal_monitoring";
 import logger from "@connectors/logger/logger";
 
 import * as activities from "./activities";
@@ -32,7 +29,6 @@ export async function runMicrosoftWorker() {
       activity: [
         (ctx: Context) => ({
           inbound: new ActivityInboundLogInterceptor(ctx, logger, "microsoft"),
-          outbound: new ActivityOutboundLogInterceptor("microsoft"),
         }),
         () => ({
           inbound: new MicrosoftCastKnownErrorsInterceptor(),

--- a/connectors/src/connectors/notion/temporal/worker.ts
+++ b/connectors/src/connectors/notion/temporal/worker.ts
@@ -9,10 +9,7 @@ import {
   QUEUE_NAME,
 } from "@connectors/connectors/notion/temporal/config";
 import { getTemporalWorkerConnection } from "@connectors/lib/temporal";
-import {
-  ActivityInboundLogInterceptor,
-  ActivityOutboundLogInterceptor,
-} from "@connectors/lib/temporal_monitoring";
+import { ActivityInboundLogInterceptor } from "@connectors/lib/temporal_monitoring";
 import logger from "@connectors/logger/logger";
 
 export async function runNotionWorker() {
@@ -30,7 +27,6 @@ export async function runNotionWorker() {
       activity: [
         (ctx: Context) => ({
           inbound: new ActivityInboundLogInterceptor(ctx, logger, "notion"),
-          outbound: new ActivityOutboundLogInterceptor("notion"),
         }),
         () => ({
           inbound: new NotionCastKnownErrorsInterceptor(),
@@ -66,7 +62,6 @@ export async function runNotionGarbageCollectWorker() {
       activity: [
         (ctx: Context) => ({
           inbound: new ActivityInboundLogInterceptor(ctx, logger, "notion"),
-          outbound: new ActivityOutboundLogInterceptor("notion"),
         }),
         () => ({
           inbound: new NotionCastKnownErrorsInterceptor(),

--- a/connectors/src/connectors/salesforce/temporal/worker.ts
+++ b/connectors/src/connectors/salesforce/temporal/worker.ts
@@ -10,10 +10,7 @@ import {
   getTemporalWorkerConnection,
   TEMPORAL_MAXED_CACHED_WORKFLOWS,
 } from "@connectors/lib/temporal";
-import {
-  ActivityInboundLogInterceptor,
-  ActivityOutboundLogInterceptor,
-} from "@connectors/lib/temporal_monitoring";
+import { ActivityInboundLogInterceptor } from "@connectors/lib/temporal_monitoring";
 import logger from "@connectors/logger/logger";
 
 export async function runSalesforceWorker() {
@@ -31,7 +28,6 @@ export async function runSalesforceWorker() {
       activity: [
         (ctx: Context) => ({
           inbound: new ActivityInboundLogInterceptor(ctx, logger, "salesforce"),
-          outbound: new ActivityOutboundLogInterceptor("salesforce"),
         }),
         () => ({
           inbound: new SalesforceCastKnownErrorsInterceptor(),

--- a/connectors/src/connectors/slack/temporal/worker.ts
+++ b/connectors/src/connectors/slack/temporal/worker.ts
@@ -7,10 +7,7 @@ import {
   getTemporalWorkerConnection,
   TEMPORAL_MAXED_CACHED_WORKFLOWS,
 } from "@connectors/lib/temporal";
-import {
-  ActivityInboundLogInterceptor,
-  ActivityOutboundLogInterceptor,
-} from "@connectors/lib/temporal_monitoring";
+import { ActivityInboundLogInterceptor } from "@connectors/lib/temporal_monitoring";
 import logger from "@connectors/logger/logger";
 
 import { QUEUE_NAME } from "./config";
@@ -30,7 +27,6 @@ export async function runSlackWorker() {
       activity: [
         (ctx: Context) => ({
           inbound: new ActivityInboundLogInterceptor(ctx, logger, "slack"),
-          outbound: new ActivityOutboundLogInterceptor("slack"),
         }),
         () => ({
           inbound: new SlackCastKnownErrorsInterceptor(),

--- a/connectors/src/connectors/snowflake/temporal/worker.ts
+++ b/connectors/src/connectors/snowflake/temporal/worker.ts
@@ -10,10 +10,7 @@ import {
   getTemporalWorkerConnection,
   TEMPORAL_MAXED_CACHED_WORKFLOWS,
 } from "@connectors/lib/temporal";
-import {
-  ActivityInboundLogInterceptor,
-  ActivityOutboundLogInterceptor,
-} from "@connectors/lib/temporal_monitoring";
+import { ActivityInboundLogInterceptor } from "@connectors/lib/temporal_monitoring";
 import logger from "@connectors/logger/logger";
 
 export async function runSnowflakeWorker() {
@@ -31,7 +28,6 @@ export async function runSnowflakeWorker() {
       activity: [
         (ctx: Context) => ({
           inbound: new ActivityInboundLogInterceptor(ctx, logger, "snowflake"),
-          outbound: new ActivityOutboundLogInterceptor("snowflake"),
         }),
         () => ({
           inbound: new SnowflakeCastKnownErrorsInterceptor(),

--- a/connectors/src/connectors/webcrawler/temporal/worker.ts
+++ b/connectors/src/connectors/webcrawler/temporal/worker.ts
@@ -6,10 +6,7 @@ import {
   getTemporalWorkerConnection,
   TEMPORAL_MAXED_CACHED_WORKFLOWS,
 } from "@connectors/lib/temporal";
-import {
-  ActivityInboundLogInterceptor,
-  ActivityOutboundLogInterceptor,
-} from "@connectors/lib/temporal_monitoring";
+import { ActivityInboundLogInterceptor } from "@connectors/lib/temporal_monitoring";
 import logger from "@connectors/logger/logger";
 
 import { WebCrawlerQueueNames } from "./config";
@@ -34,7 +31,6 @@ export async function runWebCrawlerWorker() {
               logger,
               "webcrawler"
             ),
-            outbound: new ActivityOutboundLogInterceptor("webcrawler"),
           }),
         ],
       },
@@ -56,7 +52,6 @@ export async function runWebCrawlerWorker() {
               logger,
               "webcrawler"
             ),
-            outbound: new ActivityOutboundLogInterceptor("webcrawler"),
           }),
         ],
       },
@@ -78,7 +73,6 @@ export async function runWebCrawlerWorker() {
               logger,
               "webcrawler"
             ),
-            outbound: new ActivityOutboundLogInterceptor("webcrawler"),
           }),
         ],
       },

--- a/connectors/src/connectors/zendesk/temporal/worker.ts
+++ b/connectors/src/connectors/zendesk/temporal/worker.ts
@@ -4,10 +4,7 @@ import TsconfigPathsPlugin from "tsconfig-paths-webpack-plugin";
 
 import { ZendeskCastKnownErrorsInterceptor } from "@connectors/connectors/zendesk/temporal/cast_known_errors";
 import { getTemporalWorkerConnection } from "@connectors/lib/temporal";
-import {
-  ActivityInboundLogInterceptor,
-  ActivityOutboundLogInterceptor,
-} from "@connectors/lib/temporal_monitoring";
+import { ActivityInboundLogInterceptor } from "@connectors/lib/temporal_monitoring";
 import logger from "@connectors/logger/logger";
 
 import * as activities from "./activities";
@@ -29,7 +26,6 @@ export async function runZendeskWorkers() {
       activity: [
         (ctx: Context) => ({
           inbound: new ActivityInboundLogInterceptor(ctx, logger, "zendesk"),
-          outbound: new ActivityOutboundLogInterceptor("zendesk"),
         }),
         () => ({
           inbound: new ZendeskCastKnownErrorsInterceptor(),

--- a/connectors/src/lib/temporal_monitoring.ts
+++ b/connectors/src/lib/temporal_monitoring.ts
@@ -2,12 +2,9 @@ import type { ConnectorProvider } from "@dust-tt/client";
 import { assertNever } from "@dust-tt/client";
 import type { Context } from "@temporalio/activity";
 import { ApplicationFailure } from "@temporalio/activity";
-import type { MetricTags } from "@temporalio/common";
 import type {
   ActivityExecuteInput,
   ActivityInboundCallsInterceptor,
-  ActivityOutboundCallsInterceptor,
-  GetLogAttributesInput,
   Next,
 } from "@temporalio/worker";
 import tracer from "dd-trace";
@@ -253,35 +250,5 @@ export class ActivityInboundLogInterceptor
         statsDClient.increment("activities_success.count", 1, tags);
       }
     }
-  }
-}
-
-export class ActivityOutboundLogInterceptor
-  implements ActivityOutboundCallsInterceptor
-{
-  private readonly provider: ConnectorProvider;
-
-  constructor(provider: ConnectorProvider) {
-    this.provider = provider;
-  }
-
-  getLogAttributes(
-    input: GetLogAttributesInput,
-    next: Next<ActivityOutboundCallsInterceptor, "getLogAttributes">
-  ): Record<string, unknown> {
-    return next({
-      ...input,
-      provider: this.provider,
-    });
-  }
-
-  getMetricTags(
-    input: MetricTags,
-    next: Next<ActivityOutboundCallsInterceptor, "getMetricTags">
-  ): MetricTags {
-    return next({
-      ...input,
-      provider: this.provider,
-    });
   }
 }


### PR DESCRIPTION
## Description
- Follow up of https://github.com/dust-tt/dust/pull/15085
It didn't add tags like we expected, and it doubled the logs in datadog, creating a bit too much noise (see [logs](https://app.datadoghq.eu/logs?query=%28%22Activity%20failed%22%20OR%20%22Unhandled%20activity%20error%22%29%20%40attempt%3A%3E19%20%40dd.service%3Aconnectors-worker%20region%3Aus-central1&agg_m=count&agg_m_source=base&agg_t=count&clustering_pattern_field_path=message&cols=host%2Cservice&messageDisplay=inline&panel=%7B%22queryString%22%3A%22%22%2C%22queryId%22%3A%22a%22%2C%22timeRange%22%3A%7B%22from%22%3A1755180000000%2C%22to%22%3A1755187200000%2C%22live%22%3Afalse%7D%7D&refresh_mode=sliding&storage=hot&stream_sort=desc&viz=timeseries&from_ts=1754986631681&to_ts=1755591431681&live=true)). So removing the `ActivityOutboundLogInterceptor`

## Tests
- Locally

## Risk
- Very low, removing a piece of code that wasn't there a week ago.

## Deploy Plan
- Deploy connectors
