### PR TITLE
[front] fix tool breakdown opening

### DIFF
--- a/front/components/assistant/conversation/actions/AgentActionsPanel.tsx
+++ b/front/components/assistant/conversation/actions/AgentActionsPanel.tsx
@@ -43,13 +43,18 @@ export function AgentActionsPanel({
     }
   }, [fullAgentMessage]);
 
+  useEffect(() => {
+    if (!messageId) {
+      onPanelClosed();
+    }
+  }, [messageId]);
+
   if (
     !messageId ||
     !messageMetadata ||
     !fullAgentMessage ||
     fullAgentMessage.type !== "agent_message"
   ) {
-    onPanelClosed();
     return null;
   }
 


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

See https://dust4ai.slack.com/archives/C050SM8NSPK/p1755584237829739 for full context. 
Since the addition of animation to tools breakdown panel, the panel was setting a state during a re-render outside of an effect. This was causing some weirdness with the React rendering, 

This PR solves the two-clicks opening issue.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

Tested by hand

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

Low

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->

Deploy front