### PR TITLE
[front] - fix(AB v2): reset configuration state in tool selection

### DIFF
--- a/front/components/agent_builder/capabilities/mcp/MCPServerViewsDialog.tsx
+++ b/front/components/agent_builder/capabilities/mcp/MCPServerViewsDialog.tsx
@@ -26,7 +26,6 @@ import {
   getFooterButtons,
   getInitialConfigurationTool,
   getInitialPageId,
-  getModeState,
   handleConfigurationSave as handleConfigurationSaveUtil,
   shouldGenerateUniqueName,
 } from "@app/components/agent_builder/capabilities/mcp/utils/dialogUtils";
@@ -132,9 +131,6 @@ export function MCPServerViewsDialog({
     isMCPServerViewsLoading,
   } = useMCPServerViewsContext();
 
-  const modeState = getModeState(mode);
-  const { isEditMode, isInfoMode, isConfigureMode, isAddMode } = modeState;
-
   const [selectedToolsInDialog, setSelectedToolsInDialog] = useState<
     SelectedTool[]
   >([]);
@@ -233,7 +229,7 @@ export function MCPServerViewsDialog({
   }, [searchTerm, dataVisualization]);
 
   useEffect(() => {
-    if (isEditMode && mode?.type === "edit") {
+    if (mode?.type === "edit") {
       setCurrentPageId(CONFIGURATION_DIALOG_PAGE_IDS.CONFIGURATION);
       setConfigurationTool(mode.action);
       setSelectedToolsInDialog([]);
@@ -250,11 +246,11 @@ export function MCPServerViewsDialog({
           setConfigurationMCPServerView(mcpServerView);
         }
       }
-    } else if (isConfigureMode && mode?.type === "configure") {
+    } else if (mode?.type === "configure") {
       setCurrentPageId(CONFIGURATION_DIALOG_PAGE_IDS.CONFIGURATION);
       setConfigurationTool(mode.action);
       setConfigurationMCPServerView(mode.mcpServerView);
-    } else if (isInfoMode && mode?.type === "info") {
+    } else if (mode?.type === "info") {
       setCurrentPageId(CONFIGURATION_DIALOG_PAGE_IDS.INFO);
       setSelectedToolsInDialog([]);
 
@@ -278,7 +274,7 @@ export function MCPServerViewsDialog({
       setSearchTerm("");
     }
     setIsOpen(!!mode);
-  }, [mode, allMcpServerViews, isEditMode, isConfigureMode, isInfoMode]);
+  }, [mode, allMcpServerViews]);
 
   const toggleToolSelection = useCallback((tool: SelectedTool) => {
     setSelectedToolsInDialog((prev) => {
@@ -582,10 +578,12 @@ export function MCPServerViewsDialog({
     },
   ];
 
+  const currentMode = mode?.type ?? "add";
+
   const handleCancel = () => {
     setIsOpen(false);
     onModeChange(null);
-    if (isAddMode) {
+    if (currentMode) {
       resetDialog();
     }
   };
@@ -651,7 +649,7 @@ export function MCPServerViewsDialog({
 
   const { leftButton, rightButton } = getFooterButtons({
     currentPageId,
-    modeState,
+    modeType: currentMode,
     selectedToolsInDialog,
     form,
     onCancel: handleCancel,
@@ -671,7 +669,7 @@ export function MCPServerViewsDialog({
       onOpenChange={(open) => {
         setIsOpen(open);
 
-        if (!open && isAddMode) {
+        if (!open && currentMode === "add") {
           resetDialog();
         }
 
@@ -699,7 +697,7 @@ export function MCPServerViewsDialog({
         rightButton={rightButton}
         addFooterSeparator
         footerContent={
-          !isConfigureMode ? (
+          currentMode !== "configure" ? (
             <MCPServerViewsFooter
               selectedToolsInDialog={selectedToolsInDialog}
               dataVisualization={dataVisualization}

--- a/front/components/agent_builder/capabilities/mcp/MCPServerViewsDialog.tsx
+++ b/front/components/agent_builder/capabilities/mcp/MCPServerViewsDialog.tsx
@@ -22,6 +22,14 @@ import { MCPActionHeader } from "@app/components/agent_builder/capabilities/mcp/
 import { MCPServerSelectionPage } from "@app/components/agent_builder/capabilities/mcp/MCPServerSelectionPage";
 import { MCPServerViewsFooter } from "@app/components/agent_builder/capabilities/mcp/MCPServerViewsFooter";
 import { generateUniqueActionName } from "@app/components/agent_builder/capabilities/mcp/utils/actionNameUtils";
+import {
+  getFooterButtons,
+  getInitialConfigurationTool,
+  getInitialPageId,
+  getModeState,
+  handleConfigurationSave as handleConfigurationSaveUtil,
+  shouldGenerateUniqueName,
+} from "@app/components/agent_builder/capabilities/mcp/utils/dialogUtils";
 import { getDefaultFormValues } from "@app/components/agent_builder/capabilities/mcp/utils/formDefaults";
 import { createFormResetHandler } from "@app/components/agent_builder/capabilities/mcp/utils/formStateUtils";
 import {
@@ -50,7 +58,6 @@ import {
   DEFAULT_DATA_VISUALIZATION_DESCRIPTION,
   DEFAULT_DATA_VISUALIZATION_NAME,
 } from "@app/lib/actions/constants";
-import { getMcpServerViewDisplayName } from "@app/lib/actions/mcp_helper";
 import { getAvatarFromIcon } from "@app/lib/actions/mcp_icons";
 import { getMCPServerRequirements } from "@app/lib/actions/mcp_internal_actions/input_configuration";
 import type { MCPServerViewType } from "@app/lib/api/mcp";
@@ -70,6 +77,11 @@ const DEFAULT_REASONING_MODEL_ID = O4_MINI_MODEL_ID;
 
 export type DialogMode =
   | { type: "add" }
+  | {
+      type: "configure";
+      action: AgentBuilderAction;
+      mcpServerView: MCPServerViewType;
+    }
   | { type: "edit"; action: AgentBuilderAction; index: number }
   | { type: "info"; action: AgentBuilderAction };
 
@@ -120,9 +132,8 @@ export function MCPServerViewsDialog({
     isMCPServerViewsLoading,
   } = useMCPServerViewsContext();
 
-  const isEditMode = !!mode && mode.type === "edit";
-  const isInfoMode = !!mode && mode.type === "info";
-  const isAddMode = !mode || mode.type === "add";
+  const modeState = getModeState(mode);
+  const { isEditMode, isInfoMode, isConfigureMode, isAddMode } = modeState;
 
   const [selectedToolsInDialog, setSelectedToolsInDialog] = useState<
     SelectedTool[]
@@ -131,14 +142,10 @@ export function MCPServerViewsDialog({
 
   const [isOpen, setIsOpen] = useState(!!mode);
   const [currentPageId, setCurrentPageId] = useState<ConfigurationPagePageId>(
-    isEditMode
-      ? CONFIGURATION_DIALOG_PAGE_IDS.CONFIGURATION
-      : isInfoMode
-        ? CONFIGURATION_DIALOG_PAGE_IDS.INFO
-        : CONFIGURATION_DIALOG_PAGE_IDS.TOOL_SELECTION
+    getInitialPageId(mode)
   );
   const [configurationTool, setConfigurationTool] =
-    useState<AgentBuilderAction | null>(isEditMode ? mode.action : null);
+    useState<AgentBuilderAction | null>(getInitialConfigurationTool(mode));
 
   const [configurationMCPServerView, setConfigurationMCPServerView] =
     useState<MCPServerViewType | null>(null);
@@ -226,7 +233,7 @@ export function MCPServerViewsDialog({
   }, [searchTerm, dataVisualization]);
 
   useEffect(() => {
-    if (isEditMode) {
+    if (isEditMode && mode?.type === "edit") {
       setCurrentPageId(CONFIGURATION_DIALOG_PAGE_IDS.CONFIGURATION);
       setConfigurationTool(mode.action);
       setSelectedToolsInDialog([]);
@@ -243,7 +250,11 @@ export function MCPServerViewsDialog({
           setConfigurationMCPServerView(mcpServerView);
         }
       }
-    } else if (isInfoMode) {
+    } else if (isConfigureMode && mode?.type === "configure") {
+      setCurrentPageId(CONFIGURATION_DIALOG_PAGE_IDS.CONFIGURATION);
+      setConfigurationTool(mode.action);
+      setConfigurationMCPServerView(mode.mcpServerView);
+    } else if (isInfoMode && mode?.type === "info") {
       setCurrentPageId(CONFIGURATION_DIALOG_PAGE_IDS.INFO);
       setSelectedToolsInDialog([]);
 
@@ -267,7 +278,7 @@ export function MCPServerViewsDialog({
       setSearchTerm("");
     }
     setIsOpen(!!mode);
-  }, [mode, allMcpServerViews, isEditMode, isInfoMode]);
+  }, [mode, allMcpServerViews, isEditMode, isConfigureMode, isInfoMode]);
 
   const toggleToolSelection = useCallback((tool: SelectedTool) => {
     setSelectedToolsInDialog((prev) => {
@@ -320,6 +331,7 @@ export function MCPServerViewsDialog({
       const action = getDefaultMCPAction(mcpServerView);
       const isReasoning = requirement.requiresReasoningConfiguration;
 
+      let configuredAction = action;
       if (action.type === "MCP" && isReasoning) {
         if (reasoningModels.length === 0) {
           sendNotification({
@@ -336,7 +348,7 @@ export function MCPServerViewsDialog({
             (model) => model.modelId === DEFAULT_REASONING_MODEL_ID
           ) ?? reasoningModels[0];
 
-        setConfigurationTool({
+        configuredAction = {
           ...action,
           configuration: {
             ...action.configuration,
@@ -347,13 +359,15 @@ export function MCPServerViewsDialog({
               reasoningEffort: null,
             },
           },
-        });
-      } else {
-        setConfigurationTool(action);
+        };
       }
 
-      setConfigurationMCPServerView(mcpServerView);
-      setCurrentPageId(CONFIGURATION_DIALOG_PAGE_IDS.CONFIGURATION);
+      // Switch to configure mode instead of directly setting states
+      onModeChange({
+        type: "configure",
+        action: configuredAction,
+        mcpServerView,
+      });
       return;
     }
 
@@ -587,9 +601,11 @@ export function MCPServerViewsDialog({
         throw new Error("Expected MCP action for configuration save");
       }
 
-      const isNewActionOrNameChanged =
-        mode?.type === "add" ||
-        (mode?.type === "edit" && defaultFormValues.name !== formData.name);
+      const isNewActionOrNameChanged = shouldGenerateUniqueName(
+        mode,
+        defaultFormValues,
+        formData
+      );
 
       const newActionName = isNewActionOrNameChanged
         ? generateUniqueActionName({
@@ -606,50 +622,19 @@ export function MCPServerViewsDialog({
         configuration: formData.configuration,
       };
 
-      if (mode?.type === "edit" && onActionUpdate) {
-        // Edit mode: save the updated action and close dialog
-        onActionUpdate(configuredAction, mode.index);
-        setIsOpen(false);
-        onModeChange(null);
+      handleConfigurationSaveUtil({
+        mode,
+        configuredAction,
+        mcpServerView,
+        onActionUpdate,
+        onModeChange,
+        setSelectedToolsInDialog,
+        setIsOpen,
+        sendNotification,
+      });
 
-        sendNotification({
-          title: "Tool updated successfully",
-          description: `${getMcpServerViewDisplayName(mcpServerView)} configuration has been updated.`,
-          type: "success",
-        });
-      } else {
-        // You can add one tool multiple times if it's configurable, but you cannot have the same name,
-        // so we should check its name and not its id
-        setSelectedToolsInDialog((prev) => {
-          const existingToolIndex = prev.findIndex(
-            (tool) =>
-              tool.type === "MCP" &&
-              tool.configuredAction?.name === newActionName
-          );
-
-          if (existingToolIndex >= 0) {
-            // Update existing tool with configuration
-            const updated = [...prev];
-            updated[existingToolIndex] = {
-              type: "MCP",
-              view: mcpServerView,
-              configuredAction,
-            };
-            return updated;
-          } else {
-            // Add new configured tool
-            return [
-              ...prev,
-              {
-                type: "MCP",
-                view: mcpServerView,
-                configuredAction,
-              },
-            ];
-          }
-        });
-
-        // Navigate back to tool selection page
+      // Handle legacy navigation for non-configure modes
+      if (mode?.type !== "edit" && mode?.type !== "configure") {
         setCurrentPageId(CONFIGURATION_DIALOG_PAGE_IDS.TOOL_SELECTION);
         setConfigurationTool(null);
         setConfigurationMCPServerView(null);
@@ -664,81 +649,21 @@ export function MCPServerViewsDialog({
     }
   };
 
-  const getFooterButtons = () => {
-    const isToolSelectionPage =
-      currentPageId === CONFIGURATION_DIALOG_PAGE_IDS.TOOL_SELECTION;
-    const isConfigurationPage =
-      currentPageId === CONFIGURATION_DIALOG_PAGE_IDS.CONFIGURATION;
-    const isInfoPage = currentPageId === CONFIGURATION_DIALOG_PAGE_IDS.INFO;
-
-    if (isToolSelectionPage) {
-      return {
-        leftButton: {
-          label: "Cancel",
-          variant: "outline" as const,
-          onClick: handleCancel,
-        },
-        rightButton: {
-          label:
-            selectedToolsInDialog.length > 0
-              ? `Add ${selectedToolsInDialog.length} tool${selectedToolsInDialog.length > 1 ? "s" : ""}`
-              : "Add tools",
-          variant: "primary",
-          disabled: selectedToolsInDialog.length === 0,
-          onClick: () => {
-            handleAddSelectedTools();
-            setIsOpen(false);
-            onModeChange(null);
-          },
-        },
-      };
-    }
-
-    if (isConfigurationPage) {
-      if (isEditMode) {
-        // Edit mode: only Cancel and Save buttons
-        return {
-          leftButton: {
-            label: "Cancel",
-            variant: "outline",
-            onClick: handleCancel,
-          },
-          rightButton: {
-            label: "Save Changes",
-            variant: "primary",
-            onClick: form.handleSubmit(handleConfigurationSave),
-          },
-        };
-      } else {
-        return {
-          leftButton: {
-            label: "Back",
-            variant: "outline",
-            onClick: resetToSelection,
-          },
-          rightButton: {
-            label: "Save Configuration",
-            variant: "primary",
-            onClick: form.handleSubmit(handleConfigurationSave),
-          },
-        };
-      }
-    }
-
-    if (isInfoPage) {
-      return {
-        rightButton: {
-          label: "Close",
-          variant: "primary",
-          onClick: handleCancel,
-        },
-      };
-    }
-
-    return {};
-  };
-
-  const { leftButton, rightButton } = getFooterButtons();
+  const { leftButton, rightButton } = getFooterButtons({
+    currentPageId,
+    modeState,
+    selectedToolsInDialog,
+    form,
+    onCancel: handleCancel,
+    onModeChange,
+    onAddSelectedTools: () => {
+      handleAddSelectedTools();
+      setIsOpen(false);
+      onModeChange(null);
+    },
+    onConfigurationSave: handleConfigurationSave,
+    resetToSelection,
+  });
 
   return (
     <MultiPageDialog
@@ -774,11 +699,13 @@ export function MCPServerViewsDialog({
         rightButton={rightButton}
         addFooterSeparator
         footerContent={
-          <MCPServerViewsFooter
-            selectedToolsInDialog={selectedToolsInDialog}
-            dataVisualization={dataVisualization}
-            onRemoveSelectedTool={toggleToolSelection}
-          />
+          !isConfigureMode ? (
+            <MCPServerViewsFooter
+              selectedToolsInDialog={selectedToolsInDialog}
+              dataVisualization={dataVisualization}
+              onRemoveSelectedTool={toggleToolSelection}
+            />
+          ) : undefined
         }
       />
     </MultiPageDialog>

--- a/front/components/agent_builder/capabilities/mcp/utils/dialogUtils.ts
+++ b/front/components/agent_builder/capabilities/mcp/utils/dialogUtils.ts
@@ -2,14 +2,17 @@ import type { UseFormReturn } from "react-hook-form";
 
 import type { MCPFormData } from "@app/components/agent_builder/AgentBuilderFormContext";
 import type {
+  DialogMode,
+  SelectedTool,
+} from "@app/components/agent_builder/capabilities/mcp/MCPServerViewsDialog";
+import type {
   AgentBuilderAction,
   ConfigurationPagePageId,
 } from "@app/components/agent_builder/types";
 import { CONFIGURATION_DIALOG_PAGE_IDS } from "@app/components/agent_builder/types";
 import { getMcpServerViewDisplayName } from "@app/lib/actions/mcp_helper";
 import type { MCPServerViewType } from "@app/lib/api/mcp";
-
-import type { DialogMode, SelectedTool } from "../MCPServerViewsDialog";
+import { pluralize } from "@app/types";
 
 export interface ModeState {
   isEditMode: boolean;
@@ -96,7 +99,7 @@ export function getFooterButtons({
       rightButton: {
         label:
           selectedToolsInDialog.length > 0
-            ? `Add ${selectedToolsInDialog.length} tool${selectedToolsInDialog.length > 1 ? "s" : ""}`
+            ? `Add ${selectedToolsInDialog.length} tool${pluralize(selectedToolsInDialog.length)}`
             : "Add tools",
         variant: "primary",
         disabled: selectedToolsInDialog.length === 0,

--- a/front/components/agent_builder/capabilities/mcp/utils/dialogUtils.ts
+++ b/front/components/agent_builder/capabilities/mcp/utils/dialogUtils.ts
@@ -204,43 +204,6 @@ export function handleConfigurationSave({
     return;
   }
 
-  if (mode?.type === "configure") {
-    // Configure mode: add the configured tool to selected tools and go back to selection
-    setSelectedToolsInDialog((prev) => {
-      const existingToolIndex = prev.findIndex(
-        (tool) =>
-          tool.type === "MCP" &&
-          tool.configuredAction?.name === configuredAction.name
-      );
-
-      if (existingToolIndex >= 0) {
-        // Update existing tool with configuration
-        const updated = [...prev];
-        updated[existingToolIndex] = {
-          type: "MCP",
-          view: mcpServerView,
-          configuredAction,
-        };
-        return updated;
-      } else {
-        // Add new configured tool
-        return [
-          ...prev,
-          {
-            type: "MCP",
-            view: mcpServerView,
-            configuredAction,
-          },
-        ];
-      }
-    });
-
-    // Go back to add mode and tool selection
-    onModeChange({ type: "add" });
-    return;
-  }
-
-  // Default case (add mode or other): add to selected tools and navigate back
   setSelectedToolsInDialog((prev) => {
     const existingToolIndex = prev.findIndex(
       (tool) =>
@@ -269,6 +232,12 @@ export function handleConfigurationSave({
       ];
     }
   });
+
+  if (mode?.type === "configure") {
+    // Go back to add mode and tool selection
+    onModeChange({ type: "add" });
+    return;
+  }
 }
 
 export function shouldGenerateUniqueName(

--- a/front/components/agent_builder/capabilities/mcp/utils/dialogUtils.ts
+++ b/front/components/agent_builder/capabilities/mcp/utils/dialogUtils.ts
@@ -1,0 +1,284 @@
+import type { UseFormReturn } from "react-hook-form";
+
+import type { MCPFormData } from "@app/components/agent_builder/AgentBuilderFormContext";
+import type {
+  AgentBuilderAction,
+  ConfigurationPagePageId,
+} from "@app/components/agent_builder/types";
+import { CONFIGURATION_DIALOG_PAGE_IDS } from "@app/components/agent_builder/types";
+import { getMcpServerViewDisplayName } from "@app/lib/actions/mcp_helper";
+import type { MCPServerViewType } from "@app/lib/api/mcp";
+
+import type { DialogMode, SelectedTool } from "../MCPServerViewsDialog";
+
+export interface ModeState {
+  isEditMode: boolean;
+  isInfoMode: boolean;
+  isConfigureMode: boolean;
+  isAddMode: boolean;
+}
+
+export function getModeState(mode: DialogMode | null): ModeState {
+  const isEditMode = !!mode && mode.type === "edit";
+  const isInfoMode = !!mode && mode.type === "info";
+  const isConfigureMode = !!mode && mode.type === "configure";
+  const isAddMode = !mode || mode.type === "add";
+
+  return { isEditMode, isInfoMode, isConfigureMode, isAddMode };
+}
+
+export function getInitialPageId(
+  mode: DialogMode | null
+): ConfigurationPagePageId {
+  const { isEditMode, isConfigureMode, isInfoMode } = getModeState(mode);
+
+  if (isEditMode || isConfigureMode) {
+    return CONFIGURATION_DIALOG_PAGE_IDS.CONFIGURATION;
+  }
+  if (isInfoMode) {
+    return CONFIGURATION_DIALOG_PAGE_IDS.INFO;
+  }
+  return CONFIGURATION_DIALOG_PAGE_IDS.TOOL_SELECTION;
+}
+
+export function getInitialConfigurationTool(
+  mode: DialogMode | null
+): AgentBuilderAction | null {
+  if (!mode) {
+    return null;
+  }
+
+  if (mode.type === "edit" || mode.type === "configure") {
+    return mode.action;
+  }
+
+  return null;
+}
+
+export interface FooterButtonOptions {
+  currentPageId: ConfigurationPagePageId;
+  modeState: ModeState;
+  selectedToolsInDialog: SelectedTool[];
+  form: UseFormReturn<MCPFormData>;
+  onCancel: () => void;
+  onModeChange: (mode: DialogMode | null) => void;
+  onAddSelectedTools: () => void;
+  onConfigurationSave: (data: MCPFormData) => void;
+  resetToSelection: () => void;
+}
+
+export function getFooterButtons({
+  currentPageId,
+  modeState,
+  selectedToolsInDialog,
+  form,
+  onCancel,
+  onModeChange,
+  onAddSelectedTools,
+  onConfigurationSave,
+  resetToSelection,
+}: FooterButtonOptions) {
+  const { isEditMode, isConfigureMode } = modeState;
+
+  const isToolSelectionPage =
+    currentPageId === CONFIGURATION_DIALOG_PAGE_IDS.TOOL_SELECTION;
+  const isConfigurationPage =
+    currentPageId === CONFIGURATION_DIALOG_PAGE_IDS.CONFIGURATION;
+  const isInfoPage = currentPageId === CONFIGURATION_DIALOG_PAGE_IDS.INFO;
+
+  if (isToolSelectionPage) {
+    return {
+      leftButton: {
+        label: "Cancel",
+        variant: "outline",
+        onClick: onCancel,
+      },
+      rightButton: {
+        label:
+          selectedToolsInDialog.length > 0
+            ? `Add ${selectedToolsInDialog.length} tool${selectedToolsInDialog.length > 1 ? "s" : ""}`
+            : "Add tools",
+        variant: "primary",
+        disabled: selectedToolsInDialog.length === 0,
+        onClick: onAddSelectedTools,
+      },
+    };
+  }
+
+  if (isConfigurationPage) {
+    if (isEditMode) {
+      return {
+        leftButton: {
+          label: "Cancel",
+          variant: "outline",
+          onClick: onCancel,
+        },
+        rightButton: {
+          label: "Save Changes",
+          variant: "primary",
+          onClick: form.handleSubmit(onConfigurationSave),
+        },
+      };
+    }
+
+    if (isConfigureMode) {
+      return {
+        leftButton: {
+          label: "Back",
+          variant: "outline",
+          onClick: () => onModeChange({ type: "add" }),
+        },
+        rightButton: {
+          label: "Save Configuration",
+          variant: "primary",
+          onClick: form.handleSubmit(onConfigurationSave),
+        },
+      };
+    }
+
+    return {
+      leftButton: {
+        label: "Back",
+        variant: "outline",
+        onClick: resetToSelection,
+      },
+      rightButton: {
+        label: "Save Configuration",
+        variant: "primary",
+        onClick: form.handleSubmit(onConfigurationSave),
+      },
+    };
+  }
+
+  if (isInfoPage) {
+    return {
+      rightButton: {
+        label: "Close",
+        variant: "primary",
+        onClick: onCancel,
+      },
+    };
+  }
+
+  return {};
+}
+
+export interface SaveConfigurationOptions {
+  mode: DialogMode | null;
+  configuredAction: AgentBuilderAction;
+  mcpServerView: MCPServerViewType;
+  onActionUpdate?: (action: AgentBuilderAction, index: number) => void;
+  onModeChange: (mode: DialogMode | null) => void;
+  setSelectedToolsInDialog: React.Dispatch<
+    React.SetStateAction<SelectedTool[]>
+  >;
+  setIsOpen: (open: boolean) => void;
+  sendNotification: (notification: {
+    title: string;
+    description: string;
+    type: "success" | "error";
+  }) => void;
+}
+
+export function handleConfigurationSave({
+  mode,
+  configuredAction,
+  mcpServerView,
+  onActionUpdate,
+  onModeChange,
+  setSelectedToolsInDialog,
+  setIsOpen,
+  sendNotification,
+}: SaveConfigurationOptions): void {
+  if (mode?.type === "edit" && onActionUpdate) {
+    // Edit mode: save the updated action and close dialog
+    onActionUpdate(configuredAction, mode.index);
+    setIsOpen(false);
+    onModeChange(null);
+
+    sendNotification({
+      title: "Tool updated successfully",
+      description: `${getMcpServerViewDisplayName(mcpServerView)} configuration has been updated.`,
+      type: "success",
+    });
+    return;
+  }
+
+  if (mode?.type === "configure") {
+    // Configure mode: add the configured tool to selected tools and go back to selection
+    setSelectedToolsInDialog((prev) => {
+      const existingToolIndex = prev.findIndex(
+        (tool) =>
+          tool.type === "MCP" &&
+          tool.configuredAction?.name === configuredAction.name
+      );
+
+      if (existingToolIndex >= 0) {
+        // Update existing tool with configuration
+        const updated = [...prev];
+        updated[existingToolIndex] = {
+          type: "MCP",
+          view: mcpServerView,
+          configuredAction,
+        };
+        return updated;
+      } else {
+        // Add new configured tool
+        return [
+          ...prev,
+          {
+            type: "MCP",
+            view: mcpServerView,
+            configuredAction,
+          },
+        ];
+      }
+    });
+
+    // Go back to add mode and tool selection
+    onModeChange({ type: "add" });
+    return;
+  }
+
+  // Default case (add mode or other): add to selected tools and navigate back
+  setSelectedToolsInDialog((prev) => {
+    const existingToolIndex = prev.findIndex(
+      (tool) =>
+        tool.type === "MCP" &&
+        tool.configuredAction?.name === configuredAction.name
+    );
+
+    if (existingToolIndex >= 0) {
+      // Update existing tool with configuration
+      const updated = [...prev];
+      updated[existingToolIndex] = {
+        type: "MCP",
+        view: mcpServerView,
+        configuredAction,
+      };
+      return updated;
+    } else {
+      // Add new configured tool
+      return [
+        ...prev,
+        {
+          type: "MCP",
+          view: mcpServerView,
+          configuredAction,
+        },
+      ];
+    }
+  });
+}
+
+export function shouldGenerateUniqueName(
+  mode: DialogMode | null,
+  defaultFormValues: MCPFormData,
+  formData: MCPFormData
+): boolean {
+  return (
+    mode?.type === "add" ||
+    mode?.type === "configure" ||
+    (mode?.type === "edit" && defaultFormValues.name !== formData.name)
+  );
+}

--- a/front/components/agent_builder/capabilities/mcp/utils/dialogUtils.ts
+++ b/front/components/agent_builder/capabilities/mcp/utils/dialogUtils.ts
@@ -14,31 +14,15 @@ import { getMcpServerViewDisplayName } from "@app/lib/actions/mcp_helper";
 import type { MCPServerViewType } from "@app/lib/api/mcp";
 import { pluralize } from "@app/types";
 
-export interface ModeState {
-  isEditMode: boolean;
-  isInfoMode: boolean;
-  isConfigureMode: boolean;
-  isAddMode: boolean;
-}
-
-export function getModeState(mode: DialogMode | null): ModeState {
-  const isEditMode = !!mode && mode.type === "edit";
-  const isInfoMode = !!mode && mode.type === "info";
-  const isConfigureMode = !!mode && mode.type === "configure";
-  const isAddMode = !mode || mode.type === "add";
-
-  return { isEditMode, isInfoMode, isConfigureMode, isAddMode };
-}
-
 export function getInitialPageId(
   mode: DialogMode | null
 ): ConfigurationPagePageId {
-  const { isEditMode, isConfigureMode, isInfoMode } = getModeState(mode);
+  const currentMode = mode?.type ?? "add";
 
-  if (isEditMode || isConfigureMode) {
+  if (currentMode === "edit" || currentMode === "configure") {
     return CONFIGURATION_DIALOG_PAGE_IDS.CONFIGURATION;
   }
-  if (isInfoMode) {
+  if (currentMode === "info") {
     return CONFIGURATION_DIALOG_PAGE_IDS.INFO;
   }
   return CONFIGURATION_DIALOG_PAGE_IDS.TOOL_SELECTION;
@@ -60,7 +44,7 @@ export function getInitialConfigurationTool(
 
 export interface FooterButtonOptions {
   currentPageId: ConfigurationPagePageId;
-  modeState: ModeState;
+  modeType: DialogMode["type"];
   selectedToolsInDialog: SelectedTool[];
   form: UseFormReturn<MCPFormData>;
   onCancel: () => void;
@@ -72,7 +56,7 @@ export interface FooterButtonOptions {
 
 export function getFooterButtons({
   currentPageId,
-  modeState,
+  modeType,
   selectedToolsInDialog,
   form,
   onCancel,
@@ -81,8 +65,6 @@ export function getFooterButtons({
   onConfigurationSave,
   resetToSelection,
 }: FooterButtonOptions) {
-  const { isEditMode, isConfigureMode } = modeState;
-
   const isToolSelectionPage =
     currentPageId === CONFIGURATION_DIALOG_PAGE_IDS.TOOL_SELECTION;
   const isConfigurationPage =
@@ -109,7 +91,7 @@ export function getFooterButtons({
   }
 
   if (isConfigurationPage) {
-    if (isEditMode) {
+    if (modeType === "edit") {
       return {
         leftButton: {
           label: "Cancel",
@@ -124,7 +106,7 @@ export function getFooterButtons({
       };
     }
 
-    if (isConfigureMode) {
+    if (modeType === "configure") {
       return {
         leftButton: {
           label: "Back",


### PR DESCRIPTION
## Description

Fix state reset bug in MCP Server Views Dialog when switching browser tabs and improve code maintainability.

  **Problem:** When users were configuring MCP tools in the new agent builder and switched browser tabs, returning to the original tab would reset them back to the tool selection page, losing their configuration progress. The dialog was combining "add mode" (selecting tools) with configuration state. When the `useEffect` re-ran due to tab switching, it would reset `currentPageId` to `TOOL_SELECTION` even when users were in the middle of configuring a tool.

  **Solution:**
  - Added a new `"configure"` mode to `DialogMode` type to distinguish between tool selection and tool configuration
  - Extracted complex dialog logic into reusable utility functions in `dialogUtils.ts` for better maintainability
  - Fixed state preservation issues where previously selected tools were lost when entering configure mode
  - Improved UX by hiding the footer during configuration to avoid confusion

  ## Tests

  Tested locally

  ## Risk

  **Low risk** - This is primarily a bug fix with improved code organization