### PR TITLE
fix(conversations): correct delete notifications

### DIFF
--- a/front/components/assistant/conversation/SidebarMenu.tsx
+++ b/front/components/assistant/conversation/SidebarMenu.tsx
@@ -122,19 +122,13 @@ export function AssistantSidebarMenu({ owner }: AssistantSidebarMenuProps) {
       sendNotification({
         type: "success",
         title: "Conversations successfully deleted",
-        description:
-          total > 1
-            ? `${total} conversations have been deleted.`
-            : `${total} conversation has been deleted.`,
+        description: `${total} conversation${total > 1 ? "s" : ""} have been deleted.`,
       });
     } else if (successCount === 0) {
       sendNotification({
         type: "error",
         title: "Failed to delete conversations",
-        description:
-          total > 1
-            ? "Could not delete the selected conversations."
-            : "Could not delete the selected conversation.",
+        description: `Could not delete the selected ${total > 1 ? "conversations" : "conversation"}.`,
       });
     } else {
       sendNotification({
@@ -162,10 +156,7 @@ export function AssistantSidebarMenu({ owner }: AssistantSidebarMenuProps) {
       sendNotification({
         type: "success",
         title: "Conversations successfully deleted",
-        description:
-          total > 1
-            ? `${total} conversations have been deleted.`
-            : `${total} conversation has been deleted.`,
+        description: `${total} conversation${total > 1 ? "s" : ""} have been deleted.`,
       });
     } else if (successCount === 0) {
       sendNotification({

--- a/front/components/assistant/conversation/SidebarMenu.tsx
+++ b/front/components/assistant/conversation/SidebarMenu.tsx
@@ -102,37 +102,84 @@ export function AssistantSidebarMenu({ owner }: AssistantSidebarMenuProps) {
 
   const deleteSelection = useCallback(async () => {
     setIsDeleting(true);
-    if (selectedConversations.length > 0) {
+    const total = selectedConversations.length;
+    let successCount = 0;
+    if (total > 0) {
       for (const conversation of selectedConversations) {
-        await doDelete(conversation);
+        const ok = await doDelete(conversation);
+        if (ok) {
+          successCount += 1;
+        }
       }
       toggleMultiSelect();
     }
     setIsDeleting(false);
     setShowDeleteDialog(null);
-    sendNotification({
-      type: "success",
-      title: "Conversations successfully deleted",
-      description:
-        selectedConversations.length > 1
-          ? `${selectedConversations.length} conversations have been deleted.`
-          : `${selectedConversations.length} conversation has been deleted.`,
-    });
+    if (!total) {
+      return;
+    }
+    if (successCount === total) {
+      sendNotification({
+        type: "success",
+        title: "Conversations successfully deleted",
+        description:
+          total > 1
+            ? `${total} conversations have been deleted.`
+            : `${total} conversation has been deleted.`,
+      });
+    } else if (successCount === 0) {
+      sendNotification({
+        type: "error",
+        title: "Failed to delete conversations",
+        description:
+          total > 1
+            ? "Could not delete the selected conversations."
+            : "Could not delete the selected conversation.",
+      });
+    } else {
+      sendNotification({
+        type: "error",
+        title: "Some conversations couldn’t be deleted",
+        description: `Deleted ${successCount} of ${total} conversations.`,
+      });
+    }
   }, [doDelete, selectedConversations, sendNotification, toggleMultiSelect]);
 
   const deleteAll = useCallback(async () => {
     setIsDeleting(true);
+    const total = conversations.length;
+    let successCount = 0;
     for (const conversation of conversations) {
-      await doDelete(conversation);
+      const ok = await doDelete(conversation);
+      if (ok) {
+        successCount += 1;
+      }
     }
-    sendNotification({
-      type: "success",
-      title: "Conversations successfully deleted",
-      description:
-        conversations.length > 1
-          ? `${conversations.length} conversations have been deleted.`
-          : `${conversations.length} conversation has been deleted.`,
-    });
+    if (!total) {
+      return;
+    }
+    if (successCount === total) {
+      sendNotification({
+        type: "success",
+        title: "Conversations successfully deleted",
+        description:
+          total > 1
+            ? `${total} conversations have been deleted.`
+            : `${total} conversation has been deleted.`,
+      });
+    } else if (successCount === 0) {
+      sendNotification({
+        type: "error",
+        title: "Failed to delete conversations",
+        description: "Could not delete conversation history.",
+      });
+    } else {
+      sendNotification({
+        type: "error",
+        title: "Some conversations couldn’t be deleted",
+        description: `Deleted ${successCount} of ${total} conversations.`,
+      });
+    }
     setIsDeleting(false);
     setShowDeleteDialog(null);
   }, [conversations, doDelete, sendNotification]);


### PR DESCRIPTION
## Description

- Show success only when all selected deletes succeed
- Show error when all fail; error for partial deletes

This prevents misleading success toasts on 403 responses during deletion.

https://github.com/dust-tt/tasks/issues/3820

## Tests


## Risk

low

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
