### PR TITLE
[front] Disable `InputBar` on pending validations

### DIFF
--- a/front/components/assistant/AssistantPicker.tsx
+++ b/front/components/assistant/AssistantPicker.tsx
@@ -24,6 +24,7 @@ interface AssistantPickerProps {
   showFooterButtons?: boolean;
   size?: "xs" | "sm" | "md";
   isLoading?: boolean;
+  disabled?: boolean;
   mountPortal?: boolean;
 }
 
@@ -36,6 +37,7 @@ export function AssistantPicker({
   showFooterButtons = true,
   size = "md",
   isLoading = false,
+  disabled = false,
 }: AssistantPickerProps) {
   const [searchText, setSearchText] = useState("");
   const [isOpen, setIsOpen] = useState(false);
@@ -62,7 +64,7 @@ export function AssistantPicker({
             isSelect={showDropdownArrow}
             size={size}
             tooltip="Pick an agent"
-            disabled={isLoading}
+            disabled={disabled || isLoading}
           />
         )}
       </DropdownMenuTrigger>

--- a/front/components/assistant/ToolsPicker.tsx
+++ b/front/components/assistant/ToolsPicker.tsx
@@ -33,6 +33,7 @@ interface ToolsPickerProps {
   onSelect: (serverView: MCPServerViewType) => void;
   onDeselect: (serverView: MCPServerViewType) => void;
   isLoading?: boolean;
+  disabled?: boolean;
 }
 
 export function ToolsPicker({
@@ -41,6 +42,7 @@ export function ToolsPicker({
   onSelect,
   onDeselect,
   isLoading = false,
+  disabled = false,
 }: ToolsPickerProps) {
   const [searchText, setSearchText] = useState("");
   const [isOpen, setIsOpen] = useState(false);
@@ -112,7 +114,7 @@ export function ToolsPicker({
           variant="ghost-secondary"
           size="xs"
           tooltip="Tools"
-          disabled={isLoading}
+          disabled={disabled || isLoading}
         />
       </DropdownMenuTrigger>
       <DropdownMenuContent

--- a/front/components/assistant/conversation/input_bar/InputBar.tsx
+++ b/front/components/assistant/conversation/input_bar/InputBar.tsx
@@ -420,7 +420,7 @@ export function AssistantInputBar({
                   fileUploaderService.isProcessingFiles ||
                   disable
                 }
-                preventTyping={disable}
+                disableTextInput={disable}
                 onNodeSelect={handleNodesAttachmentSelect}
                 onNodeUnselect={handleNodesAttachmentRemove}
                 selectedMCPServerViewIds={selectedMCPServerViewIds}

--- a/front/components/assistant/conversation/input_bar/InputBar.tsx
+++ b/front/components/assistant/conversation/input_bar/InputBar.tsx
@@ -414,8 +414,11 @@ export function AssistantInputBar({
                 stickyMentions={stickyMentions}
                 fileUploaderService={fileUploaderService}
                 disableSendButton={
-                  disableSendButton || fileUploaderService.isProcessingFiles
+                  disableSendButton ||
+                  fileUploaderService.isProcessingFiles ||
+                  disable
                 }
+                preventTyping={disable}
                 onNodeSelect={handleNodesAttachmentSelect}
                 onNodeUnselect={handleNodesAttachmentRemove}
                 selectedMCPServerViewIds={selectedMCPServerViewIds}

--- a/front/components/assistant/conversation/input_bar/InputBar.tsx
+++ b/front/components/assistant/conversation/input_bar/InputBar.tsx
@@ -370,7 +370,7 @@ export function AssistantInputBar({
           className="w-full"
           containerClassName="w-full"
           size={isFocused ? "large" : "medium"}
-          disabled={!isFloating || disable}
+          disabled={disable || !isFloating}
         >
           <div
             className={classNames(
@@ -381,18 +381,17 @@ export function AssistantInputBar({
               "border-border-dark dark:border-border-dark-night",
               "sm:border-border-dark/50 sm:focus-within:border-border-dark",
               "dark:focus-within:border-border-dark-night sm:focus-within:border-border-dark",
-              disable && "cursor-not-allowed bg-muted/50 opacity-50",
-              isFloating && !disable
+              disable && "cursor-not-allowed opacity-75",
+              isFloating
                 ? classNames(
                     "focus-within:ring-1 dark:focus-within:ring-1",
                     "dark:focus-within:ring-highlight/30-night focus-within:ring-highlight/30",
                     "sm:focus-within:ring-2 dark:sm:focus-within:ring-2"
                   )
-                : !disable &&
-                    classNames(
-                      "focus-within:border-highlight-300",
-                      "dark:focus-within:border-highlight-300-night"
-                    ),
+                : classNames(
+                    "focus-within:border-highlight-300",
+                    "dark:focus-within:border-highlight-300-night"
+                  ),
               isAnimating ? "duration-600 animate-shake" : "duration-300"
             )}
           >
@@ -416,9 +415,7 @@ export function AssistantInputBar({
                 stickyMentions={stickyMentions}
                 fileUploaderService={fileUploaderService}
                 disableSendButton={
-                  disableSendButton ||
-                  fileUploaderService.isProcessingFiles ||
-                  disable
+                  disableSendButton || fileUploaderService.isProcessingFiles
                 }
                 disableTextInput={disable}
                 onNodeSelect={handleNodesAttachmentSelect}

--- a/front/components/assistant/conversation/input_bar/InputBar.tsx
+++ b/front/components/assistant/conversation/input_bar/InputBar.tsx
@@ -370,7 +370,7 @@ export function AssistantInputBar({
           className="w-full"
           containerClassName="w-full"
           size={isFocused ? "large" : "medium"}
-          disabled={!isFloating}
+          disabled={!isFloating || disable}
         >
           <div
             className={classNames(
@@ -381,16 +381,18 @@ export function AssistantInputBar({
               "border-border-dark dark:border-border-dark-night",
               "sm:border-border-dark/50 sm:focus-within:border-border-dark",
               "dark:focus-within:border-border-dark-night sm:focus-within:border-border-dark",
-              isFloating
+              disable && "cursor-not-allowed bg-muted/50 opacity-50",
+              isFloating && !disable
                 ? classNames(
                     "focus-within:ring-1 dark:focus-within:ring-1",
                     "dark:focus-within:ring-highlight/30-night focus-within:ring-highlight/30",
                     "sm:focus-within:ring-2 dark:sm:focus-within:ring-2"
                   )
-                : classNames(
-                    "focus-within:border-highlight-300",
-                    "dark:focus-within:border-highlight-300-night"
-                  ),
+                : !disable &&
+                    classNames(
+                      "focus-within:border-highlight-300",
+                      "dark:focus-within:border-highlight-300-night"
+                    ),
               isAnimating ? "duration-600 animate-shake" : "duration-300"
             )}
           >

--- a/front/components/assistant/conversation/input_bar/InputBarAttachmentsPicker.tsx
+++ b/front/components/assistant/conversation/input_bar/InputBarAttachmentsPicker.tsx
@@ -39,8 +39,9 @@ interface InputBarAttachmentsPickerProps {
   fileUploaderService: FileUploaderService;
   onNodeSelect: (node: DataSourceViewContentNode) => void;
   onNodeUnselect: (node: DataSourceViewContentNode) => void;
-  isLoading?: boolean;
   attachedNodes: DataSourceViewContentNode[];
+  isLoading?: boolean;
+  disabled?: boolean;
 }
 
 const PAGE_SIZE = 25;
@@ -52,6 +53,7 @@ export const InputBarAttachmentsPicker = ({
   onNodeUnselect,
   attachedNodes,
   isLoading = false,
+  disabled = false,
 }: InputBarAttachmentsPickerProps) => {
   const fileInputRef = useRef<HTMLInputElement>(null);
   const itemsContainerRef = useRef<HTMLDivElement>(null);
@@ -128,7 +130,7 @@ export const InputBarAttachmentsPicker = ({
           variant="ghost-secondary"
           icon={AttachmentIcon}
           size="xs"
-          disabled={isLoading}
+          disabled={disabled || isLoading}
           onClick={() => setIsOpen(!isOpen)}
         />
       </DropdownMenuTrigger>

--- a/front/components/assistant/conversation/input_bar/InputBarContainer.tsx
+++ b/front/components/assistant/conversation/input_bar/InputBarContainer.tsx
@@ -62,7 +62,7 @@ export interface InputBarContainerProps {
   actions: InputBarAction[];
   disableAutoFocus: boolean;
   disableSendButton: boolean;
-  preventTyping: boolean;
+  disableTextInput: boolean;
   fileUploaderService: FileUploaderService;
   onNodeSelect: (node: DataSourceViewContentNode) => void;
   onNodeUnselect: (node: DataSourceViewContentNode) => void;
@@ -82,7 +82,7 @@ const InputBarContainer = ({
   actions,
   disableAutoFocus,
   disableSendButton,
-  preventTyping,
+  disableTextInput,
   fileUploaderService,
   onNodeSelect,
   onNodeUnselect,
@@ -133,12 +133,12 @@ const InputBarContainer = ({
     editorRef.current = editor;
   }, [editor]);
 
-  // Disable the editor when preventTyping is true.
+  // Disable the editor when disableTextInput is true.
   useEffect(() => {
     if (editor) {
-      editor.setEditable(!preventTyping);
+      editor.setEditable(!disableTextInput);
     }
-  }, [editor, preventTyping]);
+  }, [editor, disableTextInput]);
 
   useUrlHandler(editor, selectedNode, nodeOrUrlCandidate, handleUrlReplaced);
 
@@ -275,12 +275,13 @@ const InputBarContainer = ({
     >
       <div className="flex w-0 flex-grow flex-col">
         <EditorContent
+          disabled={disableTextInput}
           editor={editor}
           className={classNames(
             contentEditableClasses,
             "scrollbar-hide",
             "overflow-y-auto",
-            preventTyping && "cursor-not-allowed text-muted-foreground",
+            disableTextInput && "cursor-not-allowed",
             isExpanded
               ? "h-[60vh] max-h-[60vh] lg:h-[80vh] lg:max-h-[80vh]"
               : "max-h-64 min-h-24 sm:min-h-14"
@@ -310,6 +311,7 @@ const InputBarContainer = ({
                 onNodeSelect={onNodeSelect}
                 onNodeUnselect={onNodeUnselect}
                 attachedNodes={attachedNodes}
+                disabled={disableTextInput}
               />
             </>
           )}
@@ -319,6 +321,7 @@ const InputBarContainer = ({
               selectedMCPServerViewIds={selectedMCPServerViewIds}
               onSelect={onMCPServerViewSelect}
               onDeselect={onMCPServerViewDeselect}
+              disabled={disableTextInput}
             />
           )}
           {(actions.includes("assistants-list") ||
@@ -334,6 +337,7 @@ const InputBarContainer = ({
               showFooterButtons={actions.includes(
                 "assistants-list-with-actions"
               )}
+              disabled={disableTextInput}
             />
           )}
         </div>
@@ -344,6 +348,7 @@ const InputBarContainer = ({
           {actions.includes("fullscreen") && (
             <div className="hidden sm:flex">
               <Button
+                disabled={disableTextInput}
                 variant="ghost-secondary"
                 icon={isExpanded ? FullscreenExitIcon : FullscreenIcon}
                 size="xs"

--- a/front/components/assistant/conversation/input_bar/InputBarContainer.tsx
+++ b/front/components/assistant/conversation/input_bar/InputBarContainer.tsx
@@ -280,6 +280,7 @@ const InputBarContainer = ({
             contentEditableClasses,
             "scrollbar-hide",
             "overflow-y-auto",
+            preventTyping && "cursor-not-allowed text-muted-foreground",
             isExpanded
               ? "h-[60vh] max-h-[60vh] lg:h-[80vh] lg:max-h-[80vh]"
               : "max-h-64 min-h-24 sm:min-h-14"

--- a/front/components/assistant/conversation/input_bar/InputBarContainer.tsx
+++ b/front/components/assistant/conversation/input_bar/InputBarContainer.tsx
@@ -62,6 +62,7 @@ export interface InputBarContainerProps {
   actions: InputBarAction[];
   disableAutoFocus: boolean;
   disableSendButton: boolean;
+  preventTyping: boolean;
   fileUploaderService: FileUploaderService;
   onNodeSelect: (node: DataSourceViewContentNode) => void;
   onNodeUnselect: (node: DataSourceViewContentNode) => void;
@@ -81,6 +82,7 @@ const InputBarContainer = ({
   actions,
   disableAutoFocus,
   disableSendButton,
+  preventTyping,
   fileUploaderService,
   onNodeSelect,
   onNodeUnselect,
@@ -126,10 +128,17 @@ const InputBarContainer = ({
     suggestionHandler: mentionDropdown.getSuggestionHandler(),
   });
 
-  // Update the editor ref when the editor is created
+  // Update the editor ref when the editor is created.
   useEffect(() => {
     editorRef.current = editor;
   }, [editor]);
+
+  // Disable the editor when preventTyping is true.
+  useEffect(() => {
+    if (editor) {
+      editor.setEditable(!preventTyping);
+    }
+  }, [editor, preventTyping]);
 
   useUrlHandler(editor, selectedNode, nodeOrUrlCandidate, handleUrlReplaced);
 


### PR DESCRIPTION
## Description

- This PR follows up on https://github.com/dust-tt/dust/pull/15052 to prevent the user from typing when tools are awaiting a validation.
- The buttons (attach, tools, agent, expand) are also disabled.
- As a short term solution, the input bar is set at a lower opacity to give some kind of visual feedback that it's blocked. TBD on final design. (The rainbow effect is also removed to prevent having it glowing behind the input bar).

<img width="635" height="221" alt="Screenshot 2025-08-19 at 7 19 40 PM" src="https://github.com/user-attachments/assets/f18ee87f-254f-4d5d-bcb7-8917b1327773" />

## Tests

- Checked locally.

## Risk

- Mostly UI, behavior-wise the input bar will be disabled when the send button was already disabled.

## Deploy Plan

- Deploy front.
