### PR TITLE
feat(conversations): add leaveConversation + delete-or-leave semantics

### DIFF
--- a/front/pages/api/w/[wId]/assistant/conversations/[cId]/index.ts
+++ b/front/pages/api/w/[wId]/assistant/conversations/[cId]/index.ts
@@ -2,7 +2,6 @@ import { isLeft } from "fp-ts/lib/Either";
 import * as t from "io-ts";
 import * as reporter from "io-ts-reporters";
 import type { NextApiRequest, NextApiResponse } from "next";
-import { isString } from "@app/types";
 
 import {
   deleteOrLeaveConversation,
@@ -17,6 +16,7 @@ import type {
   ConversationWithoutContentType,
   WithAPIErrorResponse,
 } from "@app/types";
+import { isString } from "@app/types";
 
 export const PatchConversationsRequestBodySchema = t.type({
   title: t.string,

--- a/front/pages/api/w/[wId]/assistant/conversations/[cId]/index.ts
+++ b/front/pages/api/w/[wId]/assistant/conversations/[cId]/index.ts
@@ -66,7 +66,7 @@ async function handler(
         return apiErrorForConversation(req, res, result.error);
       }
 
-      res.status(204).end();
+      res.status(200).end();
       return;
     }
 

--- a/front/pages/api/w/[wId]/assistant/conversations/[cId]/index.ts
+++ b/front/pages/api/w/[wId]/assistant/conversations/[cId]/index.ts
@@ -2,6 +2,7 @@ import { isLeft } from "fp-ts/lib/Either";
 import * as t from "io-ts";
 import * as reporter from "io-ts-reporters";
 import type { NextApiRequest, NextApiResponse } from "next";
+import { isString } from "@app/types";
 
 import {
   deleteOrLeaveConversation,
@@ -32,7 +33,8 @@ async function handler(
   >,
   auth: Authenticator
 ): Promise<void> {
-  if (!(typeof req.query.cId === "string")) {
+  const { cId } = req.query;
+  if (!isString(cId)) {
     return apiError(req, res, {
       status_code: 400,
       api_error: {
@@ -46,10 +48,7 @@ async function handler(
     case "GET":
       {
         const conversationRes =
-          await ConversationResource.fetchConversationWithoutContent(
-            auth,
-            req.query.cId
-          );
+          await ConversationResource.fetchConversationWithoutContent(auth, cId);
 
         if (conversationRes.isErr()) {
           return apiErrorForConversation(req, res, conversationRes.error);
@@ -61,9 +60,7 @@ async function handler(
       }
 
     case "DELETE": {
-      const result = await deleteOrLeaveConversation(auth, {
-        conversationId: req.query.cId,
-      });
+      const result = await deleteOrLeaveConversation(auth, { conversationId: cId });
       if (result.isErr()) {
         return apiErrorForConversation(req, res, result.error);
       }
@@ -73,10 +70,7 @@ async function handler(
     }
 
     case "PATCH": {
-      const conversationRes = await ConversationResource.fetchConversationWithoutContent(
-        auth,
-        req.query.cId
-      );
+      const conversationRes = await ConversationResource.fetchConversationWithoutContent(auth, cId);
 
       if (conversationRes.isErr()) {
         return apiErrorForConversation(req, res, conversationRes.error);

--- a/front/pages/api/w/[wId]/assistant/conversations/[cId]/index.ts
+++ b/front/pages/api/w/[wId]/assistant/conversations/[cId]/index.ts
@@ -42,36 +42,47 @@ async function handler(
     });
   }
 
-  const conversationRes =
-    await ConversationResource.fetchConversationWithoutContent(
-      auth,
-      req.query.cId
-    );
-
-  if (conversationRes.isErr()) {
-    return apiErrorForConversation(req, res, conversationRes.error);
-  }
-
-  const conversation = conversationRes.value;
-
   switch (req.method) {
     case "GET":
+      {
+        const conversationRes =
+          await ConversationResource.fetchConversationWithoutContent(
+            auth,
+            req.query.cId
+          );
+
+        if (conversationRes.isErr()) {
+          return apiErrorForConversation(req, res, conversationRes.error);
+        }
+
+        const conversation = conversationRes.value;
       res.status(200).json({ conversation });
       return;
+      }
 
     case "DELETE": {
       const result = await deleteOrLeaveConversation(auth, {
-        conversationId: conversation.sId,
+        conversationId: req.query.cId,
       });
       if (result.isErr()) {
         return apiErrorForConversation(req, res, result.error);
       }
 
-      res.status(200).end();
+      res.status(204).end();
       return;
     }
 
     case "PATCH": {
+      const conversationRes = await ConversationResource.fetchConversationWithoutContent(
+        auth,
+        req.query.cId
+      );
+
+      if (conversationRes.isErr()) {
+        return apiErrorForConversation(req, res, conversationRes.error);
+      }
+
+      const conversation = conversationRes.value;
       const bodyValidation = PatchConversationsRequestBodySchema.decode(
         req.body
       );

--- a/front/pages/api/w/[wId]/assistant/conversations/[cId]/index.ts
+++ b/front/pages/api/w/[wId]/assistant/conversations/[cId]/index.ts
@@ -45,22 +45,23 @@ async function handler(
   }
 
   switch (req.method) {
-    case "GET":
-      {
-        const conversationRes =
-          await ConversationResource.fetchConversationWithoutContent(auth, cId);
+    case "GET": {
+      const conversationRes =
+        await ConversationResource.fetchConversationWithoutContent(auth, cId);
 
-        if (conversationRes.isErr()) {
-          return apiErrorForConversation(req, res, conversationRes.error);
-        }
-
-        const conversation = conversationRes.value;
-      res.status(200).json({ conversation });
-      return;
+      if (conversationRes.isErr()) {
+        return apiErrorForConversation(req, res, conversationRes.error);
       }
 
+      const conversation = conversationRes.value;
+      res.status(200).json({ conversation });
+      return;
+    }
+
     case "DELETE": {
-      const result = await deleteOrLeaveConversation(auth, { conversationId: cId });
+      const result = await deleteOrLeaveConversation(auth, {
+        conversationId: cId,
+      });
       if (result.isErr()) {
         return apiErrorForConversation(req, res, result.error);
       }
@@ -70,7 +71,8 @@ async function handler(
     }
 
     case "PATCH": {
-      const conversationRes = await ConversationResource.fetchConversationWithoutContent(auth, cId);
+      const conversationRes =
+        await ConversationResource.fetchConversationWithoutContent(auth, cId);
 
       if (conversationRes.isErr()) {
         return apiErrorForConversation(req, res, conversationRes.error);

--- a/front/pages/api/w/[wId]/assistant/conversations/[cId]/index.ts
+++ b/front/pages/api/w/[wId]/assistant/conversations/[cId]/index.ts
@@ -4,7 +4,7 @@ import * as reporter from "io-ts-reporters";
 import type { NextApiRequest, NextApiResponse } from "next";
 
 import {
-  deleteConversation,
+  deleteOrLeaveConversation,
   updateConversationTitle,
 } from "@app/lib/api/assistant/conversation";
 import { apiErrorForConversation } from "@app/lib/api/assistant/conversation/helper";
@@ -60,7 +60,7 @@ async function handler(
       return;
 
     case "DELETE": {
-      const result = await deleteConversation(auth, {
+      const result = await deleteOrLeaveConversation(auth, {
         conversationId: conversation.sId,
       });
       if (result.isErr()) {


### PR DESCRIPTION
## Description

- ConversationResource.leaveConversation(auth): remove caller participation
- deleteOrLeaveConversation(): soft-delete when accessible, leave otherwise (and soft-delete if no members remain)
- Wire DELETE /assistant/conversations/:id to deleteOrLeaveConversation

Next step: special UI when a conversation is 403 (CTA to "Leave" conversation)

## Tests

Manual

## Risk

Medium

## Deploy Plan

Deploy `front`