### PR TITLE
[front] Improve design of `ContentMessageInline`

### DIFF
--- a/extension/package-lock.json
+++ b/extension/package-lock.json
@@ -12,7 +12,7 @@
         "@auth0/auth0-spa-js": "^2.1.3",
         "@datadog/browser-logs": "^6.13.0",
         "@dust-tt/client": "^1.1.6",
-        "@dust-tt/sparkle": "^0.2.579",
+        "@dust-tt/sparkle": "^0.2.580",
         "@frontapp/plugin-sdk": "^1.8.1",
         "@modelcontextprotocol/sdk": "^1.9.0",
         "@tailwindcss/forms": "^0.5.9",
@@ -1293,9 +1293,10 @@
       }
     },
     "node_modules/@dust-tt/sparkle": {
-      "version": "0.2.579",
-      "resolved": "https://registry.npmjs.org/@dust-tt/sparkle/-/sparkle-0.2.579.tgz",
-      "integrity": "sha512-acEKAOlB4K4sJuzMn8iWg0B/ROnHnLLm5psRzv6De2Tagkaqt3BWXRKFU1xjWRGarAcLMvB6GvHuCK/slMAC5A==",
+      "version": "0.2.581",
+      "resolved": "https://registry.npmjs.org/@dust-tt/sparkle/-/sparkle-0.2.581.tgz",
+      "integrity": "sha512-4hcKKy5zv5ZbSlk+S3D85u2uRQ+x/9c12J4Kwbu+OsCKPBLDYwLoUKbXfCxgz7lRhksKvblHrpIvCHQNokGhKQ==",
+      "license": "ISC",
       "dependencies": {
         "@emoji-mart/data": "^1.1.2",
         "@emoji-mart/react": "^1.1.1",

--- a/extension/package.json
+++ b/extension/package.json
@@ -59,7 +59,7 @@
     "@auth0/auth0-spa-js": "^2.1.3",
     "@datadog/browser-logs": "^6.13.0",
     "@dust-tt/client": "^1.1.6",
-    "@dust-tt/sparkle": "^0.2.579",
+    "@dust-tt/sparkle": "^0.2.580",
     "@frontapp/plugin-sdk": "^1.8.1",
     "@modelcontextprotocol/sdk": "^1.9.0",
     "@tailwindcss/forms": "^0.5.9",

--- a/front/components/assistant/conversation/ConversationContainer.tsx
+++ b/front/components/assistant/conversation/ConversationContainer.tsx
@@ -352,7 +352,7 @@ export function ConversationContainer({
         <ContentMessageInline
           icon={InformationCircleIcon}
           variant="primary"
-          className="mb-5 flex max-h-screen w-full pb-2 sm:w-full sm:max-w-3xl sm:pb-4"
+          className="mb-5 flex max-h-screen w-full sm:w-full sm:max-w-3xl"
         >
           <span className="font-bold">
             {totalPendingValidations} action

--- a/front/components/assistant/conversation/input_bar/InputBar.tsx
+++ b/front/components/assistant/conversation/input_bar/InputBar.tsx
@@ -356,7 +356,6 @@ export function AssistantInputBar({
       ) && (
         <div className="flex justify-center px-4 pb-4">
           <Button
-            className="mt-4"
             variant="outline"
             label={isStopping ? "Stopping generation..." : "Stop generation"}
             icon={StopIcon}

--- a/front/package-lock.json
+++ b/front/package-lock.json
@@ -7,7 +7,7 @@
       "dependencies": {
         "@datadog/browser-logs": "^6.13.0",
         "@dust-tt/client": "file:../sdks/js",
-        "@dust-tt/sparkle": "^0.2.579",
+        "@dust-tt/sparkle": "^0.2.580",
         "@google-cloud/bigquery": "^7.9.1",
         "@google-cloud/storage-transfer": "^3.6.0",
         "@heroicons/react": "^2.0.11",
@@ -1112,9 +1112,10 @@
       "link": true
     },
     "node_modules/@dust-tt/sparkle": {
-      "version": "0.2.579",
-      "resolved": "https://registry.npmjs.org/@dust-tt/sparkle/-/sparkle-0.2.579.tgz",
-      "integrity": "sha512-acEKAOlB4K4sJuzMn8iWg0B/ROnHnLLm5psRzv6De2Tagkaqt3BWXRKFU1xjWRGarAcLMvB6GvHuCK/slMAC5A==",
+      "version": "0.2.580",
+      "resolved": "https://registry.npmjs.org/@dust-tt/sparkle/-/sparkle-0.2.580.tgz",
+      "integrity": "sha512-5kgqWYyCJbkFRuTwAigveh+55gx6WozpyAJkG3umU5/wIKRTtW3Y+gJRLy9+OK3mQhkBVVPIsA11CBr5UFaSIQ==",
+      "license": "ISC",
       "dependencies": {
         "@emoji-mart/data": "^1.1.2",
         "@emoji-mart/react": "^1.1.1",

--- a/front/package.json
+++ b/front/package.json
@@ -24,7 +24,7 @@
   "dependencies": {
     "@datadog/browser-logs": "^6.13.0",
     "@dust-tt/client": "file:../sdks/js",
-    "@dust-tt/sparkle": "^0.2.579",
+    "@dust-tt/sparkle": "^0.2.580",
     "@google-cloud/bigquery": "^7.9.1",
     "@google-cloud/storage-transfer": "^3.6.0",
     "@heroicons/react": "^2.0.11",


### PR DESCRIPTION
## Description

- Fix a weird padding issue in the "Review actions" `ContentMessageInline`.
- Remove the top margin above the "Stop generation" button.
- Take https://github.com/dust-tt/dust/pull/15151.

Before
<img width="1004" height="342" alt="Screenshot 2025-08-19 at 2 08 03 PM" src="https://github.com/user-attachments/assets/d14c5840-6958-40bf-b6f1-1831f40d5b1b" />

After
<img width="1004" height="342" alt="Screenshot 2025-08-19 at 2 03 26 PM" src="https://github.com/user-attachments/assets/22a1ed35-e44c-4516-b236-6ebbd6e8aa1d" />

## Tests

- Checked locally.

## Risk

- Low, only UI.

## Deploy Plan

- Deploy front.
