### PR TITLE
[front] Allow access to provisioned groups for system/admin key

### DIFF
--- a/front/lib/auth.ts
+++ b/front/lib/auth.ts
@@ -810,6 +810,11 @@ export class Authenticator {
     resourcePermission: ResourcePermission,
     permission: PermissionType
   ): boolean {
+    console.log(
+      "============================xcxx?? ",
+      resourcePermission,
+      permission
+    );
     // First path: Role-based permission check.
     if (hasRolePermissions(resourcePermission)) {
       const workspace = this.getNonNullableWorkspace();
@@ -826,6 +831,9 @@ export class Authenticator {
       const hasRolePermission = resourcePermission.roles.some(
         (r) => this.role() === r.role && r.permissions.includes(permission)
       );
+      console.log("resourcePermission", resourcePermission.roles);
+      console.log("role", this.role());
+      console.log("hasRolePermission", hasRolePermission, this.role());
 
       if (
         hasRolePermission &&
@@ -835,6 +843,7 @@ export class Authenticator {
       }
     }
 
+    console.log("groups", this.groups());
     // Second path: Group-based permission check.
     return this.groups().some((userGroup) =>
       resourcePermission.groups.some(

--- a/front/lib/auth.ts
+++ b/front/lib/auth.ts
@@ -810,11 +810,6 @@ export class Authenticator {
     resourcePermission: ResourcePermission,
     permission: PermissionType
   ): boolean {
-    console.log(
-      "============================xcxx?? ",
-      resourcePermission,
-      permission
-    );
     // First path: Role-based permission check.
     if (hasRolePermissions(resourcePermission)) {
       const workspace = this.getNonNullableWorkspace();
@@ -831,9 +826,6 @@ export class Authenticator {
       const hasRolePermission = resourcePermission.roles.some(
         (r) => this.role() === r.role && r.permissions.includes(permission)
       );
-      console.log("resourcePermission", resourcePermission.roles);
-      console.log("role", this.role());
-      console.log("hasRolePermission", hasRolePermission, this.role());
 
       if (
         hasRolePermission &&
@@ -843,7 +835,6 @@ export class Authenticator {
       }
     }
 
-    console.log("groups", this.groups());
     // Second path: Group-based permission check.
     return this.groups().some((userGroup) =>
       resourcePermission.groups.some(

--- a/front/lib/resources/group_resource.ts
+++ b/front/lib/resources/group_resource.ts
@@ -370,7 +370,7 @@ export class GroupResource extends BaseResource<GroupModel> {
   // Use with care as this gives access to all groups in the workspace.
   static async internalFetchAllWorkspaceGroups({
     workspaceId,
-    groupKinds = ["global", "regular", "system"],
+    groupKinds = ["global", "regular", "system", "provisioned"],
     transaction,
   }: {
     workspaceId: ModelId;
@@ -392,7 +392,7 @@ export class GroupResource extends BaseResource<GroupModel> {
 
   static async listWorkspaceGroupsFromKey(
     key: KeyResource,
-    groupKinds: GroupKind[] = ["global", "regular", "system"]
+    groupKinds: GroupKind[] = ["global", "regular", "system", "provisioned"]
   ): Promise<GroupResource[]> {
     let groups: GroupModel[] = [];
 


### PR DESCRIPTION
## Description

System key should have access to provisioned groups. Vault in "groups" management mode are only tied to provisioned groups, so system keys can't do any operation of them if they're not in all groups.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
