### PR TITLE
[front] feat(abv2): Remove being able to unselect nested node

### DIFF
--- a/front/components/agent_builder/AgentBuilderFormContext.tsx
+++ b/front/components/agent_builder/AgentBuilderFormContext.tsx
@@ -73,14 +73,12 @@ const tagsFilterSchema = z
   })
   .nullable();
 
-const dataSourceViewSelectionConfigurationSchema = z
-  .object({
-    dataSourceView: z.custom<DataSourceViewType>(),
-    selectedResources: z.array(z.custom<DataSourceViewContentNode>()),
-    isSelectAll: z.boolean(),
-    tagsFilter: tagsFilterSchema,
-  })
-  .nullable();
+const dataSourceViewSelectionConfigurationSchema = z.object({
+  dataSourceView: z.custom<DataSourceViewType>(),
+  selectedResources: z.array(z.custom<DataSourceViewContentNode>()),
+  isSelectAll: z.boolean(),
+  tagsFilter: tagsFilterSchema,
+});
 
 export const dataSourceConfigurationSchema = z
   .record(z.string(), dataSourceViewSelectionConfigurationSchema)

--- a/front/components/agent_builder/AgentBuilderFormContext.tsx
+++ b/front/components/agent_builder/AgentBuilderFormContext.tsx
@@ -76,6 +76,7 @@ const tagsFilterSchema = z
 const dataSourceViewSelectionConfigurationSchema = z.object({
   dataSourceView: z.custom<DataSourceViewType>(),
   selectedResources: z.array(z.custom<DataSourceViewContentNode>()),
+  excludedResources: z.array(z.custom<DataSourceViewContentNode>()),
   isSelectAll: z.boolean(),
   tagsFilter: tagsFilterSchema,
 });

--- a/front/components/agent_builder/capabilities/knowledge/KnowledgeConfigurationSheet.tsx
+++ b/front/components/agent_builder/capabilities/knowledge/KnowledgeConfigurationSheet.tsx
@@ -149,9 +149,7 @@ export function KnowledgeConfigurationSheet({
 
     const dataSourceTree =
       dataSourceConfigurations && action
-        ? transformSelectionConfigurationsToTree(
-            dataSourceConfigurations as DataSourceViewSelectionConfigurations
-          ) // TODO: fix type
+        ? transformSelectionConfigurationsToTree(dataSourceConfigurations)
         : { in: [], notIn: [] };
 
     const selectedMCPServerView = (() => {

--- a/front/components/agent_builder/capabilities/knowledge/transformations.ts
+++ b/front/components/agent_builder/capabilities/knowledge/transformations.ts
@@ -144,94 +144,61 @@ export function transformSelectionConfigurationsToTree(
     }
 
     if (config.selectedResources.length > 0) {
-      // Group selected resources by parent for efficient processing
-      const resourcesByParent = new Map<
-        string | null,
-        typeof config.selectedResources
-      >();
-
       for (const node of config.selectedResources) {
-        const parentId = node.parentInternalId || null;
-        const nodes = resourcesByParent.get(parentId) || [];
-        nodes.push(node);
-        resourcesByParent.set(parentId, nodes);
-      }
-
-      // Add paths for selected resources
-      for (const [parentId, nodes] of resourcesByParent) {
-        for (const node of nodes) {
-          if (parentId) {
-            const pathParts = [
-              baseParts,
-              ...(
-                node.parentInternalIds?.filter(
-                  (id) => id !== node.internalId
-                ) ?? []
-              ).toReversed(),
-              node.internalId,
-            ];
-            inPaths.push({
-              path: pathParts.join("/"),
-              name: node.title,
-              type: "node",
-              node,
-            });
-          } else {
-            const pathParts = [baseParts, node.internalId];
-            inPaths.push({
-              path: pathParts.join("/"),
-              name: node.title,
-              type: "data_source",
-              dataSourceView: node.dataSourceView,
-            });
-          }
+        if (node.parentInternalId) {
+          const pathParts = [
+            baseParts,
+            ...(
+              node.parentInternalIds?.filter((id) => id !== node.internalId) ??
+              []
+            ).toReversed(),
+            node.internalId,
+          ];
+          inPaths.push({
+            path: pathParts.join("/"),
+            name: node.title,
+            type: "node",
+            node,
+          });
+        } else {
+          const pathParts = [baseParts, node.internalId];
+          inPaths.push({
+            path: pathParts.join("/"),
+            name: node.title,
+            type: "data_source",
+            dataSourceView: node.dataSourceView,
+          });
         }
       }
     }
 
     // Process excluded resources and add them to notInPaths
     if (config.excludedResources.length > 0) {
-      // Group excluded resources by parent for efficient processing
-      const excludedResourcesByParent = new Map<
-        string | null,
-        typeof config.excludedResources
-      >();
-
-      for (const node of config.excludedResources) {
-        const parentId = node.parentInternalId || null;
-        const nodes = excludedResourcesByParent.get(parentId) || [];
-        nodes.push(node);
-        excludedResourcesByParent.set(parentId, nodes);
-      }
-
       // Add paths for excluded resources
-      for (const [parentId, nodes] of excludedResourcesByParent) {
-        for (const node of nodes) {
-          if (parentId) {
-            const pathParts = [
-              baseParts,
-              ...(
-                node.parentInternalIds?.filter(
-                  (id) => id !== node.internalId
-                ) ?? []
-              ).toReversed(),
-              node.internalId,
-            ];
-            notInPaths.push({
-              path: pathParts.join("/"),
-              name: node.title,
-              type: "node",
-              node,
-            });
-          } else {
-            const pathParts = [baseParts, node.internalId];
-            notInPaths.push({
-              path: pathParts.join("/"),
-              name: node.title,
-              type: "data_source",
-              dataSourceView: node.dataSourceView,
-            });
-          }
+      for (const node of config.excludedResources) {
+        if (node.parentInternalId) {
+          const pathParts = [
+            baseParts,
+            ...(
+              node.parentInternalIds?.filter((id) => id !== node.internalId) ??
+              []
+            ).toReversed(),
+            node.internalId,
+          ];
+          notInPaths.push({
+            path: pathParts.join("/"),
+            name: node.title,
+            type: "node",
+            node,
+          });
+        } else {
+          const pathParts = [baseParts, node.internalId];
+          notInPaths.push({
+            path: pathParts.join("/"),
+            name: node.title,
+            type: "data_source",
+            dataSourceView: node.dataSourceView,
+          });
         }
       }
     }

--- a/front/components/agent_builder/capabilities/knowledge/transformations.ts
+++ b/front/components/agent_builder/capabilities/knowledge/transformations.ts
@@ -172,7 +172,7 @@ export function transformSelectionConfigurationsToTree(
             ];
             inPaths.push({
               path: pathParts.join("/"),
-              name: parentId,
+              name: node.title,
               type: "node",
               node,
             });

--- a/front/components/agent_builder/capabilities/knowledge/transformations.ts
+++ b/front/components/agent_builder/capabilities/knowledge/transformations.ts
@@ -161,7 +161,15 @@ export function transformSelectionConfigurationsToTree(
       for (const [parentId, nodes] of resourcesByParent) {
         for (const node of nodes) {
           if (parentId) {
-            const pathParts = [baseParts, parentId, node.internalId];
+            const pathParts = [
+              baseParts,
+              ...(
+                node.parentInternalIds?.filter(
+                  (id) => id !== node.internalId
+                ) ?? []
+              ).toReversed(),
+              node.internalId,
+            ];
             inPaths.push({
               path: pathParts.join("/"),
               name: parentId,
@@ -200,7 +208,15 @@ export function transformSelectionConfigurationsToTree(
       for (const [parentId, nodes] of excludedResourcesByParent) {
         for (const node of nodes) {
           if (parentId) {
-            const pathParts = [baseParts, parentId, node.internalId];
+            const pathParts = [
+              baseParts,
+              ...(
+                node.parentInternalIds?.filter(
+                  (id) => id !== node.internalId
+                ) ?? []
+              ).toReversed(),
+              node.internalId,
+            ];
             notInPaths.push({
               path: pathParts.join("/"),
               name: node.title,
@@ -212,8 +228,8 @@ export function transformSelectionConfigurationsToTree(
             notInPaths.push({
               path: pathParts.join("/"),
               name: node.title,
-              type: "node",
-              node,
+              type: "data_source",
+              dataSourceView: node.dataSourceView,
             });
           }
         }

--- a/front/components/agent_builder/capabilities/knowledge/transformations.ts
+++ b/front/components/agent_builder/capabilities/knowledge/transformations.ts
@@ -242,8 +242,6 @@ export function transformSelectionConfigurationsToTree(
     notIn: deduplicatePaths(notInPaths),
   };
 
-  console.log("RES", res);
-
   return res;
 }
 

--- a/front/components/agent_builder/submitAgentBuilderForm.ts
+++ b/front/components/agent_builder/submitAgentBuilderForm.ts
@@ -29,7 +29,9 @@ function processDataSourceConfigurations(
         ? null
         : {
             in: config.selectedResources.map((resource) => resource.internalId),
-            not: [],
+            not: config.excludedResources.map(
+              (resource) => resource.internalId
+            ),
           },
       tags: config.tagsFilter
         ? {

--- a/front/components/agent_builder/submitAgentBuilderForm.ts
+++ b/front/components/agent_builder/submitAgentBuilderForm.ts
@@ -139,16 +139,14 @@ export async function submitAgentBuilderForm({
               dataSources:
                 action.configuration.dataSourceConfigurations !== null
                   ? processDataSourceConfigurations(
-                      action.configuration
-                        .dataSourceConfigurations as DataSourceViewSelectionConfigurations, // TODO fix type
+                      action.configuration.dataSourceConfigurations,
                       owner
                     )
                   : null,
               tables:
                 action.configuration.tablesConfigurations !== null
                   ? processTableSelection(
-                      action.configuration
-                        .tablesConfigurations as DataSourceViewSelectionConfigurations, // TODO fix type
+                      action.configuration.tablesConfigurations,
                       owner
                     )
                   : null,

--- a/front/components/agent_builder/submitAgentBuilderForm.ts
+++ b/front/components/agent_builder/submitAgentBuilderForm.ts
@@ -7,6 +7,7 @@ import type { TableDataSourceConfiguration } from "@app/lib/api/assistant/config
 import type { AdditionalConfigurationType } from "@app/lib/models/assistant/actions/mcp";
 import type {
   AgentConfigurationType,
+  DataSourcesConfigurationsCodecType,
   DataSourceViewSelectionConfigurations,
   LightAgentConfigurationType,
   PostOrPatchAgentConfigurationRequestBody,
@@ -17,14 +18,9 @@ import { Err, Ok } from "@app/types";
 import { normalizeError } from "@app/types/shared/utils/error_utils";
 
 function processDataSourceConfigurations(
-  dataSourceConfigurations: DataSourceViewSelectionConfigurations | null,
+  dataSourceConfigurations: DataSourceViewSelectionConfigurations,
   owner: WorkspaceType
-) {
-  // TODO: fix type, it should not be null.
-  if (dataSourceConfigurations === null) {
-    return [];
-  }
-
+): DataSourcesConfigurationsCodecType {
   return Object.values(dataSourceConfigurations).map((config) => ({
     dataSourceViewId: config.dataSourceView.sId,
     workspaceId: owner.sId,

--- a/front/components/assistant_builder/server_side_props_helpers.ts
+++ b/front/components/assistant_builder/server_side_props_helpers.ts
@@ -195,6 +195,7 @@ async function renderDataSourcesConfigurations(
         return {
           dataSourceView: serializedDataSourceView,
           selectedResources: [],
+          excludedResources: [],
           isSelectAll: sr.isSelectAll,
           tagsFilter: sr.tagsFilter,
         };
@@ -228,6 +229,7 @@ async function renderDataSourcesConfigurations(
         return {
           dataSourceView: serializedDataSourceView,
           selectedResources: [],
+          excludedResources: [],
           isSelectAll: sr.isSelectAll,
           tagsFilter: sr.tagsFilter,
         };
@@ -236,6 +238,7 @@ async function renderDataSourcesConfigurations(
       return {
         dataSourceView: serializedDataSourceView,
         selectedResources: contentNodesRes.value.nodes,
+        excludedResources: [],
         isSelectAll: sr.isSelectAll,
         tagsFilter: sr.tagsFilter,
       };
@@ -307,6 +310,7 @@ async function renderTableDataSourcesConfigurations(
           return {
             dataSourceView: serializedDataSourceView,
             selectedResources: [],
+            excludedResources: [],
             isSelectAll: sr.isSelectAll,
             tagsFilter: sr.tagsFilter,
           };
@@ -315,6 +319,7 @@ async function renderTableDataSourcesConfigurations(
         return {
           dataSourceView: serializedDataSourceView,
           selectedResources: contentNodesRes.value.nodes,
+          excludedResources: [],
           isSelectAll: sr.isSelectAll,
           tagsFilter: sr.tagsFilter,
         };

--- a/front/components/assistant_builder/server_side_props_helpers.ts
+++ b/front/components/assistant_builder/server_side_props_helpers.ts
@@ -367,6 +367,8 @@ async function renderTableDataSourcesConfigurations(
         acc[sId].selectedResources.push(...config.selectedResources);
       }
 
+      acc[sId].excludedResources = [];
+
       return acc;
     },
     {}

--- a/front/components/assistant_builder/server_side_props_helpers.ts
+++ b/front/components/assistant_builder/server_side_props_helpers.ts
@@ -19,6 +19,7 @@ import { SpaceResource } from "@app/lib/resources/space_resource";
 import logger from "@app/logger/logger";
 import type {
   AgentConfigurationType,
+  DataSourceViewContentNode,
   DataSourceViewSelectionConfiguration,
   DataSourceViewSelectionConfigurations,
   TemplateAgentConfigurationType,
@@ -171,9 +172,17 @@ async function renderDataSourcesConfigurations(
   },
   dataSourceViews: DataSourceViewResource[]
 ): Promise<DataSourceViewSelectionConfigurations> {
+  const localLogger = logger.child({
+    action: {
+      id: action.id,
+      type: action.type,
+    },
+  });
+
   const selectedResources = action.dataSources.map((ds) => ({
     dataSourceViewId: ds.dataSourceViewId,
     resources: ds.filter.parents?.in ?? null,
+    excludedResources: ds.filter.parents?.not ?? null,
     isSelectAll: !ds.filter.parents,
     tagsFilter: ds.filter.tags || null, // todo(TAF) Remove this when we don't need to support optional tags from builder.
   }));
@@ -210,12 +219,8 @@ async function renderDataSourcesConfigurations(
       );
 
       if (contentNodesRes.isErr()) {
-        logger.error(
+        localLogger.error(
           {
-            action: {
-              id: action.id,
-              type: action.type,
-            },
             dataSourceView: dataSourceView.toTraceJSON(),
             error: contentNodesRes.error,
             internalIds: sr.resources,
@@ -235,10 +240,33 @@ async function renderDataSourcesConfigurations(
         };
       }
 
+      let excludedResources: DataSourceViewContentNode[] = [];
+      if (sr.excludedResources && sr.excludedResources.length > 0) {
+        const excludedContentNodes = await getContentNodesForDataSourceView(
+          dataSourceView,
+          { internalIds: sr.excludedResources, viewType: "document" }
+        );
+        if (excludedContentNodes.isErr()) {
+          localLogger.error(
+            {
+              dataSourceView: dataSourceView.toTraceJSON(),
+              error: excludedContentNodes.error,
+              internalIds: sr.excludedResources,
+              workspace: {
+                id: dataSourceView.workspaceId,
+              },
+            },
+            "Agent Builder: Error fetching excluded content nodes for documents."
+          );
+        } else {
+          excludedResources = excludedContentNodes.value.nodes;
+        }
+      }
+
       return {
         dataSourceView: serializedDataSourceView,
         selectedResources: contentNodesRes.value.nodes,
-        excludedResources: [],
+        excludedResources,
         isSelectAll: sr.isSelectAll,
         tagsFilter: sr.tagsFilter,
       };

--- a/front/components/assistant_builder/server_side_props_helpers.ts
+++ b/front/components/assistant_builder/server_side_props_helpers.ts
@@ -347,7 +347,7 @@ async function renderTableDataSourcesConfigurations(
         return {
           dataSourceView: serializedDataSourceView,
           selectedResources: contentNodesRes.value.nodes,
-          excludedResources: [],
+          excludedResources: [], // this will stay empty as TablesQueryConfiguration doesn't support exclusions
           isSelectAll: sr.isSelectAll,
           tagsFilter: sr.tagsFilter,
         };

--- a/front/components/data_source_view/context/DataSourceBuilderContext.tsx
+++ b/front/components/data_source_view/context/DataSourceBuilderContext.tsx
@@ -346,9 +346,20 @@ export function DataSourceBuilderProvider({
           return true;
         }
 
+        // Check if any parent path is already selected
+        // We check all parent paths by iterating from the full path down to the root
+        for (let i = nodePath.length - 1; i > 0; i--) {
+          const parentPath = nodePath.slice(0, i);
+          const selectionState = isNodeSelected(field.value, parentPath);
+          if (selectionState === true) {
+            // A parent is fully selected, so this row cannot be selected
+            return false;
+          }
+        }
+
         return nonCompanySpacesSelected.has(currentSpaceId);
       },
-      [nonCompanySpacesSelected, state.navigationHistory]
+      [nonCompanySpacesSelected, state.navigationHistory, field.value]
     );
 
   const isCurrentNavigationEntrySelected: DataSourceBuilderState["isCurrentNavigationEntrySelected"] =

--- a/front/components/data_source_view/context/DataSourceBuilderContext.tsx
+++ b/front/components/data_source_view/context/DataSourceBuilderContext.tsx
@@ -346,20 +346,9 @@ export function DataSourceBuilderProvider({
           return true;
         }
 
-        // Check if any parent path is already selected
-        // We check all parent paths by iterating from the full path down to the root
-        for (let i = nodePath.length - 1; i > 0; i--) {
-          const parentPath = nodePath.slice(0, i);
-          const selectionState = isNodeSelected(field.value, parentPath);
-          if (selectionState === true) {
-            // A parent is fully selected, so this row cannot be selected
-            return false;
-          }
-        }
-
         return nonCompanySpacesSelected.has(currentSpaceId);
       },
-      [nonCompanySpacesSelected, state.navigationHistory, field.value]
+      [nonCompanySpacesSelected, state.navigationHistory]
     );
 
   const isCurrentNavigationEntrySelected: DataSourceBuilderState["isCurrentNavigationEntrySelected"] =

--- a/front/components/data_source_view/context/utils.test.ts
+++ b/front/components/data_source_view/context/utils.test.ts
@@ -262,6 +262,7 @@ describe("DataSourceBuilder utilities", () => {
 
       expect(result).toEqual({
         in: [createTreeItem("root/a", "a")],
+        notIn: [],
       });
     });
   });

--- a/front/components/data_source_view/context/utils.test.ts
+++ b/front/components/data_source_view/context/utils.test.ts
@@ -247,6 +247,23 @@ describe("DataSourceBuilder utilities", () => {
         notIn: [createTreeItem("temp/cache"), createTreeItem("logs/old")],
       });
     });
+
+    it("should remove child in when adding its parent", () => {
+      const tree = {
+        in: [createTreeItem("root/a/b", "a.b")],
+        notIn: [],
+      };
+
+      const result = addNodeToTree(tree, {
+        path: "root/a",
+        name: "a",
+        type: "root",
+      });
+
+      expect(result).toEqual({
+        in: [createTreeItem("root/a", "a")],
+      });
+    });
   });
 
   describe("removeNodeFromTree", () => {

--- a/front/components/data_source_view/context/utils.ts
+++ b/front/components/data_source_view/context/utils.ts
@@ -35,6 +35,7 @@ function isParentOrSamePath(parentPath: string, childPath: string): boolean {
 /**
  * Adds a path to the tree by adding it to the 'in' array and removing it from 'notIn' if present.
  * If a parent path is already included, don't add child paths to avoid redundancy.
+ * When adding a parent path, removes any child paths from 'in' to avoid redundancy.
  *
  * @returns New tree with the node added
  */
@@ -75,7 +76,11 @@ export function addNodeToTree(
     };
   }
 
-  const newIn = [...tree.in, item];
+  const newIn = tree.in.filter(
+    ({ path: inPath }) => !inPath.startsWith(pathPrefix)
+  );
+
+  newIn.push(item);
 
   return {
     in: newIn,

--- a/front/components/labs/transcripts/StorageConfiguration.tsx
+++ b/front/components/labs/transcripts/StorageConfiguration.tsx
@@ -59,6 +59,7 @@ export function StorageConfiguration({
           [dataSourceView.sId]: {
             dataSourceView,
             selectedResources: [],
+            excludedResources: [],
             isSelectAll: true,
             tagsFilter: null,
           },
@@ -110,6 +111,7 @@ export function StorageConfiguration({
           [dataSourceView.sId]: {
             dataSourceView,
             selectedResources: [],
+            excludedResources: [],
             isSelectAll: true,
             tagsFilter: null,
           },

--- a/front/components/spaces/SpaceManagedDatasourcesViewsModal.tsx
+++ b/front/components/spaces/SpaceManagedDatasourcesViewsModal.tsx
@@ -122,6 +122,7 @@ export default function SpaceManagedDataSourcesViewsModal({
           acc[config.dataSourceView.sId] = {
             dataSourceView: config.dataSourceView,
             selectedResources,
+            excludedResources: [],
             isSelectAll,
             tagsFilter: null, // No tags filters needed to list data source views
           };

--- a/front/pages/w/[wId]/labs/trackers/[tId]/index.tsx
+++ b/front/pages/w/[wId]/labs/trackers/[tId]/index.tsx
@@ -176,6 +176,7 @@ const renderDataSourcesConfigurations = async (
         return {
           dataSourceView: serializedDataSourceView,
           selectedResources: [],
+          excludedResources: [],
           isSelectAll: sr.isSelectAll,
           tagsFilter: sr.tagsFilter,
         };
@@ -206,6 +207,7 @@ const renderDataSourcesConfigurations = async (
         return {
           dataSourceView: serializedDataSourceView,
           selectedResources: [],
+          excludedResources: [],
           isSelectAll: sr.isSelectAll,
           tagsFilter: sr.tagsFilter,
         };
@@ -214,6 +216,7 @@ const renderDataSourcesConfigurations = async (
       return {
         dataSourceView: serializedDataSourceView,
         selectedResources: contentNodesRes.value.nodes,
+        excludedResources: [],
         isSelectAll: sr.isSelectAll,
         tagsFilter: sr.tagsFilter,
       };

--- a/front/types/api/internal/agent_configuration.ts
+++ b/front/types/api/internal/agent_configuration.ts
@@ -77,6 +77,9 @@ const DataSourcesConfigurationsCodec = t.array(
     filter: DataSourceFilterCodec,
   })
 );
+export type DataSourcesConfigurationsCodecType = t.TypeOf<
+  typeof DataSourcesConfigurationsCodec
+>;
 
 // Tables
 

--- a/front/types/data_source_view.ts
+++ b/front/types/data_source_view.ts
@@ -40,6 +40,7 @@ export const isEqualNode = (
 export type DataSourceViewSelectionConfiguration = {
   dataSourceView: DataSourceViewType;
   selectedResources: DataSourceViewContentNode[];
+  excludedResources: DataSourceViewContentNode[];
   isSelectAll: boolean;
   tagsFilter: TagsFilter;
 };
@@ -57,6 +58,7 @@ export function defaultSelectionConfiguration(
     dataSourceView,
     isSelectAll: false,
     selectedResources: [],
+    excludedResources: [],
     tagsFilter: null,
   };
 }


### PR DESCRIPTION
## Description
- https://github.com/dust-tt/tasks/issues/3789
- CoreAPI does seems to support `parents.in` & `parents.not`.
- Added a new `excludedResources` to manipulate those
- Update the render data source configurations to get the excluded resources.

## Tests
- Locally
- Added a new unit tests

## Risk
- Low, behind FF

## Deploy Plan
- Deploy front
