### PR TITLE
[front] - feat(AB v2): template action presets support

### DIFF
--- a/front/components/agent_builder/AgentBuilder.tsx
+++ b/front/components/agent_builder/AgentBuilder.tsx
@@ -26,19 +26,16 @@ import { useAgentConfigurationActions } from "@app/lib/swr/actions";
 import { useEditors } from "@app/lib/swr/editors";
 import { emptyArray } from "@app/lib/swr/swr";
 import logger from "@app/logger/logger";
-import type { FetchAssistantTemplateResponse } from "@app/pages/api/templates/[tId]";
 import type { LightAgentConfigurationType } from "@app/types";
 
 interface AgentBuilderProps {
   agentConfiguration?: LightAgentConfigurationType;
-  assistantTemplate: FetchAssistantTemplateResponse | null;
 }
 
 export default function AgentBuilder({
   agentConfiguration,
-  assistantTemplate,
 }: AgentBuilderProps) {
-  const { owner, user } = useAgentBuilderContext();
+  const { owner, user, assistantTemplate } = useAgentBuilderContext();
   const { supportedDataSourceViews } = useDataSourceViewsContext();
 
   const router = useRouter();
@@ -176,7 +173,6 @@ export default function AgentBuilder({
             <ConversationSidePanelProvider>
               <AgentBuilderRightPanel
                 agentConfigurationSId={agentConfiguration?.sId}
-                assistantTemplate={assistantTemplate}
               />
             </ConversationSidePanelProvider>
           }

--- a/front/components/agent_builder/AgentBuilderContext.tsx
+++ b/front/components/agent_builder/AgentBuilderContext.tsx
@@ -1,21 +1,28 @@
-import { createContext, useContext, useMemo } from "react";
+import { createContext, useContext, useMemo, useState } from "react";
 
 import { DataSourceViewsProvider } from "@app/components/agent_builder/DataSourceViewsContext";
 import { MCPServerViewsProvider } from "@app/components/agent_builder/MCPServerViewsContext";
 import { PreviewPanelProvider } from "@app/components/agent_builder/PreviewPanelContext";
 import { SpacesProvider } from "@app/components/agent_builder/SpacesContext";
-import type { UserType, WorkspaceType } from "@app/types";
+import type { FetchAssistantTemplateResponse } from "@app/pages/api/templates/[tId]";
+import type { TemplateActionPreset, UserType, WorkspaceType } from "@app/types";
 
 type AgentBuilderContextType = {
   owner: WorkspaceType;
   user: UserType;
+  assistantTemplate: FetchAssistantTemplateResponse | null;
+  presetActionToAdd: TemplateActionPreset | null;
+  setPresetActionToAdd: (preset: TemplateActionPreset | null) => void;
 };
 
 export const AgentBuilderContext = createContext<
   AgentBuilderContextType | undefined
 >(undefined);
 
-interface AgentBuilderContextProps extends AgentBuilderContextType {
+interface AgentBuilderProviderProps {
+  owner: WorkspaceType;
+  user: UserType;
+  assistantTemplate: FetchAssistantTemplateResponse | null;
   children: React.ReactNode;
 }
 
@@ -25,14 +32,21 @@ interface AgentBuilderContextProps extends AgentBuilderContextType {
 export function AgentBuilderProvider({
   owner,
   user,
+  assistantTemplate,
   children,
-}: AgentBuilderContextProps) {
+}: AgentBuilderProviderProps) {
+  const [presetActionToAdd, setPresetActionToAdd] =
+    useState<TemplateActionPreset | null>(null);
+
   const value = useMemo(
     () => ({
       owner,
       user,
+      assistantTemplate,
+      presetActionToAdd,
+      setPresetActionToAdd,
     }),
-    [owner, user]
+    [owner, user, assistantTemplate, presetActionToAdd]
   );
 
   return (

--- a/front/components/agent_builder/AgentBuilderRightPanel.tsx
+++ b/front/components/agent_builder/AgentBuilderRightPanel.tsx
@@ -12,11 +12,11 @@ import {
 } from "@dust-tt/sparkle";
 import React, { useState } from "react";
 
+import { useAgentBuilderContext } from "@app/components/agent_builder/AgentBuilderContext";
 import { AgentBuilderPerformance } from "@app/components/agent_builder/AgentBuilderPerformance";
 import { AgentBuilderPreview } from "@app/components/agent_builder/AgentBuilderPreview";
 import { AgentBuilderTemplate } from "@app/components/agent_builder/AgentBuilderTemplate";
 import { usePreviewPanelContext } from "@app/components/agent_builder/PreviewPanelContext";
-import type { FetchAssistantTemplateResponse } from "@app/pages/api/templates/[tId]";
 
 type AgentBuilderRightPanelTabType = "testing" | "performance" | "template";
 
@@ -127,18 +127,21 @@ function CollapsedTabs({ onTabSelect, hasTemplate }: CollapsedTabsProps) {
 interface ExpandedContentProps {
   selectedTab: AgentBuilderRightPanelTabType;
   agentConfigurationSId?: string;
-  assistantTemplate: FetchAssistantTemplateResponse | null;
 }
 
 function ExpandedContent({
   selectedTab,
   agentConfigurationSId,
-  assistantTemplate,
 }: ExpandedContentProps) {
+  const { assistantTemplate, setPresetActionToAdd } = useAgentBuilderContext();
+
   return (
     <div className="flex min-h-0 flex-1 flex-col">
       {selectedTab === "template" && assistantTemplate && (
-        <AgentBuilderTemplate assistantTemplate={assistantTemplate} />
+        <AgentBuilderTemplate
+          assistantTemplate={assistantTemplate}
+          onAddPresetAction={setPresetActionToAdd}
+        />
       )}
       {selectedTab === "testing" && (
         <div className="min-h-0 flex-1">
@@ -158,15 +161,14 @@ function ExpandedContent({
 
 interface AgentBuilderRightPanelProps {
   agentConfigurationSId?: string;
-  assistantTemplate: FetchAssistantTemplateResponse | null;
 }
 
 export function AgentBuilderRightPanel({
   agentConfigurationSId,
-  assistantTemplate,
 }: AgentBuilderRightPanelProps) {
   const { isPreviewPanelOpen, setIsPreviewPanelOpen } =
     usePreviewPanelContext();
+  const { assistantTemplate } = useAgentBuilderContext();
 
   const hasTemplate = !!assistantTemplate;
 
@@ -200,7 +202,6 @@ export function AgentBuilderRightPanel({
         <ExpandedContent
           selectedTab={selectedTab}
           agentConfigurationSId={agentConfigurationSId}
-          assistantTemplate={assistantTemplate}
         />
       ) : (
         <CollapsedTabs

--- a/front/components/agent_builder/capabilities/AgentBuilderCapabilitiesBlock.tsx
+++ b/front/components/agent_builder/capabilities/AgentBuilderCapabilitiesBlock.tsx
@@ -24,6 +24,7 @@ import { AgentBuilderSectionContainer } from "@app/components/agent_builder/Agen
 import { KnowledgeConfigurationSheet } from "@app/components/agent_builder/capabilities/knowledge/KnowledgeConfigurationSheet";
 import type { DialogMode } from "@app/components/agent_builder/capabilities/mcp/MCPServerViewsDialog";
 import { MCPServerViewsDialog } from "@app/components/agent_builder/capabilities/mcp/MCPServerViewsDialog";
+import { usePresetActionHandler } from "@app/components/agent_builder/capabilities/usePresetActionHandler";
 import { useMCPServerViewsContext } from "@app/components/agent_builder/MCPServerViewsContext";
 import type { AgentBuilderAction } from "@app/components/agent_builder/types";
 import {
@@ -37,6 +38,7 @@ import {
   MCP_SPECIFICATION,
 } from "@app/lib/actions/utils";
 import type { MCPServerViewType } from "@app/lib/api/mcp";
+import type { TemplateActionPreset } from "@app/types";
 import { asDisplayName } from "@app/types";
 
 const dataVisualizationAction = {
@@ -154,16 +156,23 @@ export function AgentBuilderCapabilitiesBlock({
     useMCPServerViewsContext();
 
   const [dialogMode, setDialogMode] = useState<DialogMode | null>(null);
-
   const [knowledgeAction, setKnowledgeAction] = useState<{
     action: AgentBuilderAction;
     index: number | null;
+    presetData?: TemplateActionPreset;
   } | null>(null);
+
   const dataVisualization = fields.some(
     (field) => field.type === "DATA_VISUALIZATION"
   )
     ? null
     : dataVisualizationAction;
+
+  usePresetActionHandler({
+    fields,
+    append,
+    setKnowledgeAction,
+  });
 
   const handleEditSave = (updatedAction: AgentBuilderAction) => {
     if (dialogMode?.type === "edit") {
@@ -307,6 +316,7 @@ export function AgentBuilderCapabilitiesBlock({
         isEditing={Boolean(knowledgeAction && knowledgeAction.index !== null)}
         mcpServerViews={mcpServerViewsWithKnowledge}
         getAgentInstructions={getAgentInstructions}
+        presetActionData={knowledgeAction?.presetData}
       />
       <MCPServerViewsDialog
         addTools={append}

--- a/front/components/agent_builder/capabilities/usePresetActionHandler.ts
+++ b/front/components/agent_builder/capabilities/usePresetActionHandler.ts
@@ -1,0 +1,135 @@
+import { useEffect, useRef } from "react";
+import type { UseFieldArrayAppend } from "react-hook-form";
+
+import { useAgentBuilderContext } from "@app/components/agent_builder/AgentBuilderContext";
+import type {
+  AgentBuilderAction,
+  AgentBuilderFormData,
+} from "@app/components/agent_builder/AgentBuilderFormContext";
+import { useMCPServerViewsContext } from "@app/components/agent_builder/MCPServerViewsContext";
+import { getDefaultMCPAction } from "@app/components/agent_builder/types";
+import { useSendNotification } from "@app/hooks/useNotification";
+import {
+  getMCPServerNameForTemplateAction,
+  getMcpServerViewDisplayName,
+  isDirectAddTemplateAction,
+  isKnowledgeTemplateAction,
+} from "@app/lib/actions/mcp_helper";
+import { allowsMultipleInstancesOfInternalMCPServerById } from "@app/lib/actions/mcp_internal_actions/constants";
+import type { TemplateActionPreset } from "@app/types";
+
+interface UsePresetActionHandlerProps {
+  fields: AgentBuilderFormData["actions"];
+  append: UseFieldArrayAppend<AgentBuilderFormData, "actions">;
+  setKnowledgeAction: (
+    action: {
+      action: AgentBuilderAction;
+      index: number | null;
+      presetData?: TemplateActionPreset;
+    } | null
+  ) => void;
+}
+
+export function usePresetActionHandler({
+  fields,
+  append,
+  setKnowledgeAction,
+}: UsePresetActionHandlerProps) {
+  const { presetActionToAdd, setPresetActionToAdd } = useAgentBuilderContext();
+  const {
+    mcpServerViews,
+    mcpServerViewsWithKnowledge,
+    isMCPServerViewsLoading,
+  } = useMCPServerViewsContext();
+  const sendNotification = useSendNotification();
+  // Store preset object reference to prevent duplicate processing.
+  const lastProcessedPresetRef = useRef<TemplateActionPreset | null>(null);
+
+  useEffect(() => {
+    if (!presetActionToAdd || isMCPServerViewsLoading) {
+      if (!presetActionToAdd) {
+        lastProcessedPresetRef.current = null;
+      }
+      return;
+    }
+
+    // Skip if same preset instance (handles rapid clicks and re-renders).
+    if (lastProcessedPresetRef.current === presetActionToAdd) {
+      return;
+    }
+
+    lastProcessedPresetRef.current = presetActionToAdd;
+
+    const targetServerName =
+      getMCPServerNameForTemplateAction(presetActionToAdd);
+    const mcpServerViewSource = isKnowledgeTemplateAction(presetActionToAdd)
+      ? mcpServerViewsWithKnowledge
+      : mcpServerViews;
+
+    const mcpServerView = mcpServerViewSource.find(
+      (view) => view.server.name === targetServerName
+    );
+
+    if (!mcpServerView) {
+      setPresetActionToAdd(null);
+      return;
+    }
+
+    // Check for duplicates only for tools that don't allow multiple instances.
+    if (isDirectAddTemplateAction(presetActionToAdd)) {
+      const allowsMultiple = allowsMultipleInstancesOfInternalMCPServerById(
+        mcpServerView.server.sId
+      );
+
+      if (!allowsMultiple) {
+        const toolAlreadyAdded = fields.some(
+          (field) =>
+            field.type === "MCP" &&
+            field.configuration?.mcpServerViewId === mcpServerView.sId
+        );
+
+        if (toolAlreadyAdded) {
+          sendNotification({
+            title: "Tool already added",
+            description: `${getMcpServerViewDisplayName(mcpServerView)} is already in your agent`,
+            type: "info",
+          });
+          setPresetActionToAdd(null);
+          return;
+        }
+      }
+    }
+
+    const action = getDefaultMCPAction(mcpServerView);
+    action.name = presetActionToAdd.name;
+    action.description = presetActionToAdd.description;
+
+    if (isKnowledgeTemplateAction(presetActionToAdd)) {
+      setKnowledgeAction({
+        action: { ...action, noConfigurationRequired: false },
+        index: null,
+        presetData: presetActionToAdd,
+      });
+    } else {
+      append(action);
+
+      sendNotification({
+        title: "Tool added",
+        description: `${action.name} has been added to your agent`,
+        type: "success",
+      });
+    }
+
+    setPresetActionToAdd(null);
+  }, [
+    presetActionToAdd,
+    setPresetActionToAdd,
+    mcpServerViews,
+    mcpServerViewsWithKnowledge,
+    isMCPServerViewsLoading,
+    append,
+    sendNotification,
+    fields,
+    setKnowledgeAction,
+  ]);
+}

--- a/front/lib/actions/mcp_helper.ts
+++ b/front/lib/actions/mcp_helper.ts
@@ -19,7 +19,11 @@ import {
   LEGACY_REGION_BIT,
   makeSId,
 } from "@app/lib/resources/string_ids";
-import type { ModelId } from "@app/types";
+import type {
+  ModelId,
+  MultiActionPreset,
+  TemplateActionPreset,
+} from "@app/types";
 import { asDisplayName } from "@app/types";
 
 export const getServerTypeAndIdFromSId = (
@@ -161,4 +165,37 @@ export function getMcpServerDisplayName(
     }
   }
   return displayName;
+}
+
+// Only includes action types that are actually used in templates.
+const TEMPLATE_ACTION_TO_MCP_SERVER: Record<
+  MultiActionPreset,
+  InternalMCPServerNameType
+> = {
+  RETRIEVAL_SEARCH: "search",
+  TABLES_QUERY: "query_tables",
+  PROCESS: "extract_data",
+  WEB_NAVIGATION: "web_search_&_browse",
+};
+
+export function getMCPServerNameForTemplateAction(
+  presetAction: TemplateActionPreset
+): InternalMCPServerNameType | null {
+  return TEMPLATE_ACTION_TO_MCP_SERVER[presetAction.type] ?? null;
+}
+
+export function isKnowledgeTemplateAction(
+  presetAction: TemplateActionPreset
+): boolean {
+  return (
+    presetAction.type === "RETRIEVAL_SEARCH" ||
+    presetAction.type === "TABLES_QUERY" ||
+    presetAction.type === "PROCESS"
+  );
+}
+
+export function isDirectAddTemplateAction(
+  presetAction: TemplateActionPreset
+): boolean {
+  return presetAction.type === "WEB_NAVIGATION";
 }

--- a/front/pages/w/[wId]/builder/agents/[aId]/index.tsx
+++ b/front/pages/w/[wId]/builder/agents/[aId]/index.tsx
@@ -88,11 +88,8 @@ export default function EditAgent({
   }
 
   return (
-    <AgentBuilderProvider owner={owner} user={user}>
-      <AgentBuilder
-        agentConfiguration={agentConfiguration}
-        assistantTemplate={null}
-      />
+    <AgentBuilderProvider owner={owner} user={user} assistantTemplate={null}>
+      <AgentBuilder agentConfiguration={agentConfiguration} />
     </AgentBuilderProvider>
   );
 }

--- a/front/pages/w/[wId]/builder/agents/new.tsx
+++ b/front/pages/w/[wId]/builder/agents/new.tsx
@@ -128,14 +128,17 @@ export default function CreateAgent({
   }
 
   return (
-    <AgentBuilderProvider owner={owner} user={user}>
+    <AgentBuilderProvider
+      owner={owner}
+      user={user}
+      assistantTemplate={assistantTemplate}
+    >
       <AgentBuilder
         agentConfiguration={
           agentConfiguration && "sId" in agentConfiguration
             ? agentConfiguration
             : undefined
         }
-        assistantTemplate={assistantTemplate}
       />
     </AgentBuilderProvider>
   );


### PR DESCRIPTION
## Description

This PR adds support for template action presets in Agent Builder v2.

Supports only knowledge and tools currently part of the public templates as preset tools
Users can click on buttons in the Template tab to pre-fill the add knowledge form or insert directly a tool (web search)
Buttons conditionally show different labels/icons

Rebased from https://github.com/dust-tt/dust/pull/15098

<img width="2492" height="1578" alt="image" src="https://github.com/user-attachments/assets/5ca674c3-42b0-441d-a4cc-407ffc7e0a8d" />

## Tests

Locally

## Risk

Low, behind FF

## Deploy Plan

Deploy front
