### PR TITLE
[connectors] notion: Don't retry infintely on 503

### DIFF
--- a/connectors/src/connectors/notion/temporal/activities.ts
+++ b/connectors/src/connectors/notion/temporal/activities.ts
@@ -158,7 +158,7 @@ export async function fetchDatabaseChildPages({
       cursor,
     });
   } catch (e) {
-    // Sometimes a cursor will consistently fail with 500.
+    // Sometimes a cursor will consistently fail with 500 or 503.
     // In this case, there is not much we can do, so we just give up and move on.
     // Notion workspaces are resynced daily so nothing is lost forever.
     const potentialNotionError = e as {
@@ -167,8 +167,10 @@ export async function fetchDatabaseChildPages({
       status: number;
     };
     if (
-      potentialNotionError.code === "internal_server_error" &&
-      potentialNotionError.status === 500
+      (potentialNotionError.code === "internal_server_error" &&
+        potentialNotionError.status === 500) ||
+      (potentialNotionError.code === "service_unavailable" &&
+        potentialNotionError.status === 503)
     ) {
       if (Context.current().info.attempt > 20) {
         localLogger.error(


### PR DESCRIPTION
## Description

503 can be thrown if database cna't be read. Skipping if it fails after 20 tries

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

deploy connectors
