### PR TITLE
[sparkle] - feat(Dialog): allow Dialog to mount on a specified container

### DIFF
--- a/sparkle/src/components/Dialog.tsx
+++ b/sparkle/src/components/Dialog.tsx
@@ -79,6 +79,7 @@ interface DialogContentProps
   trapFocusScope?: boolean;
   isAlertDialog?: boolean;
   preventAutoFocusOnClose?: boolean;
+  mountPortalContainer?: HTMLElement;
 }
 
 const DialogContent = React.forwardRef<
@@ -95,6 +96,7 @@ const DialogContent = React.forwardRef<
       isAlertDialog,
       preventAutoFocusOnClose = true,
       onCloseAutoFocus,
+      mountPortalContainer,
       ...props
     },
     ref
@@ -110,7 +112,7 @@ const DialogContent = React.forwardRef<
     );
 
     return (
-      <DialogPortal>
+      <DialogPortal container={mountPortalContainer}>
         <DialogOverlay />
         <FocusScope trapped={trapFocusScope} asChild>
           <DialogPrimitive.Content


### PR DESCRIPTION
## Description

This PR modified the `Dialog` component such that it can now be mounted on a provided DOM element allowing more flexibility in the DOM hierarchy.

This is a similar to what we did for `DropdownMenu`

## Risk

Low

## Deploy Plan

Publish sparkle