### PR TITLE
Lower sync to async timeout from 120 seconds to 70 seconds

### DIFF
--- a/front/lib/api/assistant/agent.ts
+++ b/front/lib/api/assistant/agent.ts
@@ -24,8 +24,8 @@ import type {
   RunAgentArgsInput,
 } from "@app/types/assistant/agent_run";
 
-// 80 seconds timeout before switching from sync to async execution.
-const SYNC_TO_ASYNC_TIMEOUT_MS = 80 * 1000;
+// 70 seconds timeout before switching from sync to async execution.
+const SYNC_TO_ASYNC_TIMEOUT_MS = 70 * 1000;
 
 /**
  * Helper to launch async workflow from sync data.

--- a/front/lib/api/assistant/agent.ts
+++ b/front/lib/api/assistant/agent.ts
@@ -24,8 +24,8 @@ import type {
   RunAgentArgsInput,
 } from "@app/types/assistant/agent_run";
 
-// 2 minutes timeout before switching from sync to async execution.
-const SYNC_TO_ASYNC_TIMEOUT_MS = 2 * 60 * 1000;
+// 80 seconds timeout before switching from sync to async execution.
+const SYNC_TO_ASYNC_TIMEOUT_MS = 80 * 1000;
 
 /**
  * Helper to launch async workflow from sync data.


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
This PR lowers the sync to async timeout from 120 seconds to 70 seconds. We've observed that despite having a timeout set to 120 seconds, most of the time we switch way later ([graph](https://app.datadoghq.eu/dashboard/t8g-c26-8w9?fromUser=true&fullscreen_end_ts=1755618687106&fullscreen_paused=false&fullscreen_refresh_mode=sliding&fullscreen_section=overview&fullscreen_start_ts=1755615087106&fullscreen_widget=8127903026177953&refresh_mode=sliding&from_ts=1755612190890&to_ts=1755615790890&live=true)).

Looking at the [graph](https://app.datadoghq.eu/dashboard/t8g-c26-8w9?fromUser=true&fullscreen_end_ts=1755619164132&fullscreen_paused=false&fullscreen_refresh_mode=sliding&fullscreen_section=overview&fullscreen_start_ts=1755615564132&fullscreen_widget=4540239976054739&refresh_mode=sliding&from_ts=1755612190890&to_ts=1755615790890&live=true) of agent loop execution duration, 90 % completes before 70 seconds. Once this PR goes out, 10 % of the whole agent loop executions will be defer to async at some point.
 
## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
