### PR TITLE
[front] - fix(AB v2): navigation lock

### DIFF
--- a/front/components/agent_builder/AgentBuilder.tsx
+++ b/front/components/agent_builder/AgentBuilder.tsx
@@ -122,7 +122,7 @@ export default function AgentBuilder({
       agentSettings: {
         ...baseValues.agentSettings,
         slackProvider,
-        editors: editors ?? [],
+        editors: editors ?? emptyArray(),
       },
     };
   }, [

--- a/front/components/agent_builder/AgentBuilderLeftPanel.tsx
+++ b/front/components/agent_builder/AgentBuilderLeftPanel.tsx
@@ -61,7 +61,12 @@ export function AgentBuilderLeftPanel({
         variant="default"
         className="mx-4 justify-between"
         leftActions={
-          <Button variant="outline" label="Close" onClick={handleCancel} />
+          <Button
+            variant="outline"
+            label="Close"
+            onClick={handleCancel}
+            type="button"
+          />
         }
         rightActions={
           <BarFooter.ButtonBar

--- a/front/components/agent_builder/AgentBuilderLeftPanel.tsx
+++ b/front/components/agent_builder/AgentBuilderLeftPanel.tsx
@@ -6,7 +6,6 @@ import { AgentBuilderCapabilitiesBlock } from "@app/components/agent_builder/cap
 import { AgentBuilderInstructionsBlock } from "@app/components/agent_builder/instructions/AgentBuilderInstructionsBlock";
 import { AgentAccessPublicationDialog } from "@app/components/agent_builder/settings/AgentAccessPublicationDialog";
 import { AgentBuilderSettingsBlock } from "@app/components/agent_builder/settings/AgentBuilderSettingsBlock";
-import { ConfirmContext } from "@app/components/Confirm";
 
 interface AgentBuilderLeftPanelProps {
   title: string;
@@ -23,20 +22,8 @@ export function AgentBuilderLeftPanel({
   saveButtonProps,
   isActionsLoading,
 }: AgentBuilderLeftPanelProps) {
-  const confirm = React.useContext(ConfirmContext);
-
   const handleCancel = async () => {
-    const confirmed = await confirm({
-      title: "Confirm Exit",
-      message:
-        "Are you sure you want to exit? Any unsaved changes will be lost.",
-      validateLabel: "Yes",
-      validateVariant: "warning",
-    });
-
-    if (confirmed) {
-      onCancel();
-    }
+    onCancel();
   };
   return (
     <div className="flex h-full flex-col">

--- a/front/components/agent_builder/transformAgentConfiguration.ts
+++ b/front/components/agent_builder/transformAgentConfiguration.ts
@@ -7,6 +7,8 @@ import { CLAUDE_4_SONNET_DEFAULT_MODEL_CONFIG } from "@app/types";
 
 /**
  * Transforms a light agent configuration (server-side) into agent builder form data (client-side).
+ * Dynamic values (editors, slackProvider, actions) are intentionally set to empty defaults
+ * as they will be populated reactively in the component.
  */
 export function transformAgentConfigurationToFormData(
   agentConfiguration: LightAgentConfigurationType
@@ -20,9 +22,9 @@ export function transformAgentConfigurationToFormData(
         agentConfiguration.scope === "global"
           ? "visible"
           : agentConfiguration.scope,
-      editors: [], // Fallback - editors will be updated reactively
-      slackProvider: null, // TODO: determine from agent configuration
-      slackChannels: [], // TODO: determine from agent configuration
+      editors: [], // Will be populated reactively from useEditors hook
+      slackProvider: null, // Will be populated reactively from supportedDataSourceViews
+      slackChannels: [], // Will be populated reactively if needed
       tags: agentConfiguration.tags,
     },
     instructions: agentConfiguration.instructions || "",
@@ -35,7 +37,7 @@ export function transformAgentConfigurationToFormData(
       reasoningEffort: agentConfiguration.model.reasoningEffort || "none",
       responseFormat: agentConfiguration.model.responseFormat,
     },
-    actions: [], // Actions are always loaded client-side via SWR
+    actions: [], // Will be populated reactively from useAgentConfigurationActions hook
     maxStepsPerRun: agentConfiguration.maxStepsPerRun || 8,
   };
 }


### PR DESCRIPTION
## Description

This PR aims at fixing a wrong initialization state which always causes the `formState` to be dirty. This was then causing the navigation lock to always be triggered.

On top of that I removed the confirm dialog when clicking on the "Cancel" button as it is now handled by the navigation lock, see https://github.com/dust-tt/dust/pull/15144#issuecomment-3200415438

## Tests

Locally

## Risk

Low

## Deploy Plan

Deploy front