### PR TITLE
improve heartbeat

### DIFF
--- a/core/bin/sqlite_worker.rs
+++ b/core/bin/sqlite_worker.rs
@@ -63,7 +63,7 @@ const DEFAULT_QUERY_TIMEOUT_MS: u64 = 10_000;
 // Cleanup databases every 30 seconds instead of every loop iteration.
 const DATABASE_CLEANUP_INTERVAL: Duration = Duration::from_secs(30);
 
-const CORE_API_TIMEOUT: Duration = Duration::from_secs(5);
+const CORE_API_TIMEOUT: Duration = Duration::from_secs(2);
 
 struct DatabaseEntry {
     database: Arc<Mutex<SqliteDatabase>>,

--- a/core/bin/sqlite_worker.rs
+++ b/core/bin/sqlite_worker.rs
@@ -63,6 +63,8 @@ const DEFAULT_QUERY_TIMEOUT_MS: u64 = 10_000;
 // Cleanup databases every 30 seconds instead of every loop iteration.
 const DATABASE_CLEANUP_INTERVAL: Duration = Duration::from_secs(30);
 
+const CORE_API_TIMEOUT: Duration = Duration::from_secs(5);
+
 struct DatabaseEntry {
     database: Arc<Mutex<SqliteDatabase>>,
     last_accessed: Instant,
@@ -164,7 +166,9 @@ impl WorkerState {
     }
 
     async fn _core_request(&self, method: &str) -> Result<()> {
-        let res = reqwest::Client::new()
+        let res = reqwest::Client::builder()
+            .timeout(CORE_API_TIMEOUT)
+            .build()?
             .request(
                 Method::from_bytes(method.as_bytes())?,
                 format!("{}/sqlite_workers", *CORE_API),
@@ -198,13 +202,13 @@ async fn index(State(state): State<Arc<WorkerState>>) -> Result<&'static str, St
 
     let elapsed = now - last_heartbeat;
 
-    if elapsed < HEARTBEAT_INTERVAL_MS * 2 {
+    if elapsed < HEARTBEAT_INTERVAL_MS * 10 {
         Ok("sqlite_worker server ready")
     } else {
         error!(
             "Health check failed: last heartbeat was {} ms ago (threshold: {} ms)",
             elapsed,
-            HEARTBEAT_INTERVAL_MS * 2
+            HEARTBEAT_INTERVAL_MS * 10
         );
         Err(StatusCode::SERVICE_UNAVAILABLE)
     }


### PR DESCRIPTION
## Description

sqlite workers keep restarting because of failing heart checks. From the logs, we can see that health check fails because of non successful heartbeat sent to core - however we almost never  see "Failed to send heartbeat" - which makes me think the call to core is blocked and not replying, blocking the loop.
Trying to fix by adding a timeout on http call, so that we unblock heartbeat call and see proper log if it can't be sent. Also increase threshold so that we can have the time to try multiple times sending heartbeat before sending "Health check failed"

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
