### PR TITLE
[sparkle] - feat: implement `NotificationButton` component

### DIFF
--- a/sparkle/src/components/NotificationButton.tsx
+++ b/sparkle/src/components/NotificationButton.tsx
@@ -1,0 +1,28 @@
+import React from "react";
+
+import { Button } from "@sparkle/components/Button";
+import { Counter } from "@sparkle/components/Counter";
+import { cn } from "@sparkle/lib/utils";
+
+interface NotificationButtonProps {
+  buttonProps: React.ComponentProps<typeof Button>;
+  counterProps: React.ComponentProps<typeof Counter>;
+  className?: string;
+}
+
+const NotificationButton = ({
+  className,
+  buttonProps,
+  counterProps,
+}: NotificationButtonProps) => {
+  return (
+    <div className={cn("s-relative", className)}>
+      <Button {...buttonProps} />
+      {counterProps.value > 0 && (
+        <Counter {...counterProps} className="s-absolute -s-right-2 -s-top-2" />
+      )}
+    </div>
+  );
+};
+
+export { NotificationButton };

--- a/sparkle/src/components/index.ts
+++ b/sparkle/src/components/index.ts
@@ -130,6 +130,7 @@ export {
 export * from "./NavigationList";
 export type { NotificationType } from "./Notification";
 export { Notification, useSendNotification } from "./Notification";
+export { NotificationButton } from "./NotificationButton";
 export { Page } from "./Page";
 export { PaginatedCitationsGrid } from "./PaginatedCitationsGrid";
 export { Pagination } from "./Pagination";

--- a/sparkle/src/stories/NotificationButton.stories.tsx
+++ b/sparkle/src/stories/NotificationButton.stories.tsx
@@ -1,0 +1,43 @@
+import type { Meta } from "@storybook/react";
+import React from "react";
+
+import { NotificationButton } from "@sparkle/components";
+import { InformationCircleIcon } from "@sparkle/icons";
+
+const meta = {
+  title: "Components/NotificationButton",
+} satisfies Meta<typeof NotificationButton>;
+
+export default meta;
+
+export const Example = () => {
+  return (
+    <div className="s-flex s-gap-4">
+      <NotificationButton
+        buttonProps={{
+          variant: "outline",
+          size: "md",
+          icon: InformationCircleIcon,
+          label: "InformationCircleIcon",
+        }}
+        counterProps={{
+          value: 1,
+          variant: "highlight",
+          size: "sm",
+        }}
+      />
+      <NotificationButton
+        buttonProps={{
+          icon: InformationCircleIcon,
+          size: "sm",
+          variant: "ghost",
+        }}
+        counterProps={{
+          value: 99,
+          variant: "warning",
+          size: "xs",
+        }}
+      />
+    </div>
+  );
+};


### PR DESCRIPTION
## Description

This PR adds a new `NotificationButton` component to display a button with a notification counter.

<img width="267" height="58" alt="Screenshot 2025-08-19 at 23 31 28" src="https://github.com/user-attachments/assets/46bf7de5-05e2-4517-b89e-e36cbdd51c61" />

## Deploy Plan

Publish sparkle