### PR TITLE
Optimize to_csv_record to take invariant out of loop

### DIFF
--- a/core/src/databases/table.rs
+++ b/core/src/databases/table.rs
@@ -990,6 +990,7 @@ impl Row {
 
     pub fn to_csv_record(&self, headers: &Vec<String>) -> Result<Vec<String>> {
         let mut record = Vec::new();
+        let row_val = self.value();
         for header in headers {
             // We need to set the row_id in a __dust_id field
             if header == "__dust_id" {
@@ -997,7 +998,7 @@ impl Row {
                 continue;
             }
 
-            match self.value().get(header) {
+            match row_val.get(header) {
                 Some(Value::Bool(b)) => record.push(b.to_string()),
                 Some(Value::Number(x)) => {
                     if x.is_i64() {


### PR DESCRIPTION
## Description

The call to self.value() on each iteration was building the entire json object for the row. Just taking this invariant out of the loop.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
