### PR TITLE
[connectors] Moving catch to withRetry

### DIFF
--- a/connectors/src/lib/data_sources.ts
+++ b/connectors/src/lib/data_sources.ts
@@ -190,17 +190,6 @@ async function _upsertDataSourceDocument({
           e.config.data = "[REDACTED]";
         }
 
-        // Handle quota errors specifically
-        if (axios.isAxiosError(e) && e.response?.status === 403) {
-          const errorType = e.response?.data?.error?.type;
-          if (
-            errorType === "workspace_quota_error" ||
-            errorType === "data_source_quota_error"
-          ) {
-            throw new WorkspaceQuotaExceededError(e);
-          }
-        }
-
         statsDClient.increment(
           "data_source_upserts_error.count",
           1,

--- a/connectors/src/lib/data_sources.ts
+++ b/connectors/src/lib/data_sources.ts
@@ -22,11 +22,7 @@ import { toMarkdown } from "mdast-util-to-markdown";
 import { gfm } from "micromark-extension-gfm";
 
 import { apiConfig } from "@connectors/lib/api/config";
-import {
-  DustConnectorWorkflowError,
-  TablesError,
-  WorkspaceQuotaExceededError,
-} from "@connectors/lib/error";
+import { DustConnectorWorkflowError, TablesError } from "@connectors/lib/error";
 import logger from "@connectors/logger/logger";
 import { statsDClient } from "@connectors/logger/withlogging";
 import type { ProviderVisibility } from "@connectors/types";

--- a/connectors/src/types/shared/retries.ts
+++ b/connectors/src/types/shared/retries.ts
@@ -50,7 +50,11 @@ export function withRetries<Args extends unknown[], Return>(
           e.code === "ERR_BAD_REQUEST" &&
           e.status === 403
         ) {
-          if (e.response?.data?.error?.type === "workspace_quota_error") {
+          const errorType = e.response?.data?.error?.type;
+          if (
+            errorType === "workspace_quota_error" ||
+            errorType === "data_source_quota_error"
+          ) {
             throw new WorkspaceQuotaExceededError(e);
           }
         }


### PR DESCRIPTION
## Description

workspace_quota_error was already handled in withRetries, but not data_source_quota_error . Better to handle it here as it won't be retried and wrapped in a WithRetriesError, that is not handled in temporal_monitoring

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

deploy connectors