### PR TITLE
Lower Agent Loop Sync To Async Timeout

### DIFF
--- a/front/lib/api/assistant/agent.ts
+++ b/front/lib/api/assistant/agent.ts
@@ -24,8 +24,8 @@ import type {
   RunAgentArgsInput,
 } from "@app/types/assistant/agent_run";
 
-// 70 seconds timeout before switching from sync to async execution.
-const SYNC_TO_ASYNC_TIMEOUT_MS = 70 * 1000;
+// 40 seconds timeout before switching from sync to async execution.
+const SYNC_TO_ASYNC_TIMEOUT_MS = 40 * 1000;
 
 /**
  * Helper to launch async workflow from sync data.


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
This PR lowers the agent loop sync to async timeout from 70 seconds to 40 seconds. Infra has been scaled up in https://github.com/dust-tt/dust-infra/pull/420. 

By using 40 seconds it means that ~ 25 % of the agent loops would be running async at some point. 

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->
Dashboard to monitor is here: https://app.datadoghq.eu/dashboard/t8g-c26-8w9?fromUser=false&refresh_mode=sliding&from_ts=1755666664579&to_ts=1755667564579&live=true.,

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
