### PR TITLE
Check column count early in /rows API

### DIFF
--- a/core/src/databases/csv.rs
+++ b/core/src/databases/csv.rs
@@ -19,7 +19,7 @@ pub struct GoogleCloudStorageCSVContent {
     pub bucket_csv_path: String,
 }
 
-const MAX_TABLE_COLUMNS: usize = 512;
+pub const MAX_TABLE_COLUMNS: usize = 512;
 const MAX_COLUMN_NAME_LENGTH: usize = 1024;
 const MAX_TABLE_ROWS: usize = 500_000;
 

--- a/core/src/databases/table.rs
+++ b/core/src/databases/table.rs
@@ -13,6 +13,7 @@ use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use tracing::{info, warn};
 
+use crate::databases::csv::MAX_TABLE_COLUMNS;
 use crate::databases::table_upserts_background_worker::{
     TableUpsertActivityData, REDIS_CLIENT, REDIS_LOCK_TTL_SECONDS, REDIS_TABLE_UPSERT_HASH_NAME,
     REDIS_URI,
@@ -385,6 +386,15 @@ impl LocalTable {
             let rows = rows.clone();
             tokio::task::spawn_blocking(move || {
                 for (row_index, row) in rows.iter().enumerate() {
+                    if row.headers.len() > MAX_TABLE_COLUMNS {
+                        Err(anyhow!(
+                            "Row {} has more than {} values ({})",
+                            row_index,
+                            MAX_TABLE_COLUMNS,
+                            row.headers.len()
+                        ))?;
+                    }
+
                     match row.value().keys().find(|key| match key.chars().next() {
                         Some(c) => c.is_ascii_uppercase(),
                         None => false,


### PR DESCRIPTION
## Description

With the rows API, we were ending up in situations where the background thread was asked to process rows with too many values, and kept retrying forever.

With this change, we stop this right when the initial API call is made, so it gets blocked early.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

Deploy Core