### PR TITLE
Add: ability pick from public channels in slack tool

### DIFF
--- a/front/components/actions/mcp/AddActionMenu.tsx
+++ b/front/components/actions/mcp/AddActionMenu.tsx
@@ -21,7 +21,7 @@ import type { WorkspaceType } from "@app/types";
 
 type AddActionMenuProps = {
   owner: WorkspaceType;
-  enabledMCPServers: { id: string; name: string }[];
+  enabledMCPServers: MCPServerType[];
   buttonVariant?: "primary" | "outline";
   createInternalMCPServer: (mcpServer: MCPServerType) => void;
   createRemoteMCPServer: (
@@ -81,7 +81,10 @@ export const AddActionMenu = ({
           .filter(
             (mcpServer) =>
               mcpServer.allowMultipleInstances ||
-              !enabledMCPServers.some((enabled) => enabled.id === mcpServer.sId)
+              !enabledMCPServers.some(
+                // The comparison by names here is safe because names are shared between multiple instance of the same MCP server (sIds are not).
+                (enabledMCPServer) => enabledMCPServer.name === mcpServer.name
+              )
           )
           .filter((mcpServer) => filterMCPServer(mcpServer, searchText))
           .map((mcpServer) => (

--- a/front/components/actions/mcp/AdminActionsList.tsx
+++ b/front/components/actions/mcp/AdminActionsList.tsx
@@ -140,11 +140,6 @@ export const AdminActionsList = ({
     }
   };
 
-  const enabledMCPServers = mcpServers.map((s) => ({
-    id: s.sId,
-    name: s.name,
-  }));
-
   const rows: RowData[] = useMemo(
     () =>
       mcpServers
@@ -281,7 +276,7 @@ export const AdminActionsList = ({
         portalToHeader(
           <AddActionMenu
             owner={owner}
-            enabledMCPServers={enabledMCPServers}
+            enabledMCPServers={mcpServers}
             setIsLoading={setIsLoading}
             createRemoteMCPServer={onCreateRemoteMCPServer}
             createInternalMCPServer={onCreateInternalMCPServer}
@@ -302,7 +297,7 @@ export const AdminActionsList = ({
               <AddActionMenu
                 buttonVariant="outline"
                 owner={owner}
-                enabledMCPServers={enabledMCPServers}
+                enabledMCPServers={mcpServers}
                 setIsLoading={setIsLoading}
                 createRemoteMCPServer={onCreateRemoteMCPServer}
                 createInternalMCPServer={onCreateInternalMCPServer}

--- a/front/components/agent_builder/capabilities/shared/AdditionalConfigurationSection.tsx
+++ b/front/components/agent_builder/capabilities/shared/AdditionalConfigurationSection.tsx
@@ -229,9 +229,15 @@ function ListConfigurationInput({
     name: `configuration.additionalConfiguration.${configKey}`,
   });
 
-  const displayLabel = `Select ${formatKeyForDisplay(configKey)}`;
   const rawValue = field.value;
   const currentValue: string[] = Array.isArray(rawValue) ? rawValue : [];
+  let displayLabel =
+    currentValue.length > 0
+      ? currentValue.map((v) => listValues[v]).join(", ")
+      : `Select ${formatKeyForDisplay(configKey)}`;
+  if (displayLabel.length > 16) {
+    displayLabel = `${currentValue.length} selected`;
+  }
 
   return (
     <>
@@ -244,11 +250,7 @@ function ListConfigurationInput({
             <DropdownMenuTrigger asChild>
               <Button
                 isSelect
-                label={
-                  currentValue.length > 0
-                    ? currentValue.map((v) => listValues[v]).join(", ")
-                    : displayLabel
-                }
+                label={displayLabel}
                 size="sm"
                 tooltip={displayLabel}
                 variant="outline"

--- a/front/components/assistant_builder/actions/configuration/AdditionalConfigurationSection.tsx
+++ b/front/components/assistant_builder/actions/configuration/AdditionalConfigurationSection.tsx
@@ -210,9 +210,15 @@ function ListConfigurationSection({
   }
 
   return Object.entries(requiredLists).map(([key, listValues]) => {
-    const displayLabel = `Select ${formatKeyForDisplay(key)}`;
     const rawValue = additionalConfiguration[key];
     const currentValue: string[] = Array.isArray(rawValue) ? rawValue : [];
+    let displayLabel =
+      currentValue.length > 0
+        ? currentValue.map((v) => listValues[v]).join(", ")
+        : `Select ${formatKeyForDisplay(key)}`;
+    if (displayLabel.length > 16) {
+      displayLabel = `${currentValue.length} selected`;
+    }
 
     return (
       <div key={key} className="mb-2 flex items-center gap-1">
@@ -223,11 +229,7 @@ function ListConfigurationSection({
           <DropdownMenuTrigger asChild>
             <Button
               isSelect
-              label={
-                currentValue.length > 0
-                  ? currentValue.map((v) => listValues[v]).join(", ")
-                  : displayLabel
-              }
+              label={displayLabel}
               size="sm"
               tooltip={displayLabel}
               variant="outline"
@@ -287,7 +289,9 @@ function GroupedConfigurationSection({
   const hasConfiguration =
     Object.keys(requiredStrings).length > 0 ||
     Object.keys(requiredNumbers).length > 0 ||
-    Object.keys(requiredBooleans).length > 0;
+    Object.keys(requiredBooleans).length > 0 ||
+    Object.keys(requiredEnums).length > 0 ||
+    Object.keys(requiredLists).length > 0;
 
   if (!hasConfiguration) {
     return null;

--- a/front/lib/actions/mcp_internal_actions/index.ts
+++ b/front/lib/actions/mcp_internal_actions/index.ts
@@ -45,6 +45,7 @@ export const connectToInternalMCPServer = async (
     auth,
     {
       internalMCPServerName: res.value.name,
+      mcpServerId,
     },
     agentLoopContext
   );

--- a/front/lib/actions/mcp_internal_actions/input_schemas.ts
+++ b/front/lib/actions/mcp_internal_actions/input_schemas.ts
@@ -170,8 +170,12 @@ type FlexibleConfigurableToolInput = {
     mimeType: typeof INTERNAL_MIME_TYPES.TOOL_INPUT.ENUM;
   };
   [INTERNAL_MIME_TYPES.TOOL_INPUT.LIST]: {
+    // Added "options" here but allow undefined because it's expected in the input schema to build the configuration UI but useless in the MCP tool call.
+    options?: {
+      value: string;
+      label: string;
+    }[];
     values: string[];
-    labels: string[];
     mimeType: typeof INTERNAL_MIME_TYPES.TOOL_INPUT.LIST;
   };
 };

--- a/front/lib/actions/mcp_internal_actions/servers/index.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/index.ts
@@ -70,8 +70,10 @@ export async function getInternalMCPServer(
   auth: Authenticator,
   {
     internalMCPServerName,
+    mcpServerId,
   }: {
     internalMCPServerName: InternalMCPServerNameType;
+    mcpServerId: string;
   },
   agentLoopContext?: AgentLoopContextType
 ): Promise<McpServer> {
@@ -135,7 +137,7 @@ export async function getInternalMCPServer(
     case "monday":
       return mondayServer();
     case "slack":
-      return slackServer(auth, agentLoopContext);
+      return slackServer(auth, mcpServerId, agentLoopContext);
     case "agent_memory":
       return agentMemoryServer(auth, agentLoopContext);
     case "outlook":

--- a/front/lib/actions/mcp_internal_actions/servers/primitive_types_debugger.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/primitive_types_debugger.ts
@@ -42,8 +42,25 @@ function createServer(): McpServer {
         mimeType: z.literal(INTERNAL_MIME_TYPES.TOOL_INPUT.ENUM),
       }),
       choices: z.object({
-        values: z.enum(["A", "B", "C"]),
-        labels: z.enum(["label A", "label B", "label C"]),
+        options: z
+          .union([
+            z.object({
+              value: z.literal("A"),
+              label: z.literal("Label A"),
+            }),
+            z.object({
+              value: z.literal("B"),
+              label: z.literal("Label B"),
+            }),
+            z.object({
+              value: z.literal("C"),
+              label: z.literal("Label C"),
+            }),
+          ])
+          // Options are optionals because we only need them for the UI but they won't be provided when the tool is called.
+          .optional(),
+        // "values" are required because they are used to provide the selected values when the tool is called.
+        values: z.array(z.string()),
         mimeType: z.literal(INTERNAL_MIME_TYPES.TOOL_INPUT.LIST),
       }),
     },

--- a/front/lib/actions/mcp_internal_actions/servers/slack.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/slack.ts
@@ -1,12 +1,14 @@
 import { INTERNAL_MIME_TYPES } from "@dust-tt/client";
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { WebClient } from "@slack/web-api";
+import type { Channel } from "@slack/web-api/dist/response/ConversationsListResponse";
 import type { Match } from "@slack/web-api/dist/response/SearchMessagesResponse";
 import type { Member } from "@slack/web-api/dist/response/UsersListResponse";
 import { uniqBy } from "lodash";
 import slackifyMarkdown from "slackify-markdown";
 import { z } from "zod";
 
+import { getConnectionForMCPServer } from "@app/lib/actions/mcp_authentication";
 import type {
   SearchQueryResourceType,
   SearchResultResourceType,
@@ -26,8 +28,11 @@ import type { Authenticator } from "@app/lib/auth";
 import { getFeatureFlags } from "@app/lib/auth";
 import { removeDiacritics } from "@app/lib/utils";
 import { concurrentExecutor } from "@app/lib/utils/async_utils";
+import { cacheWithRedis } from "@app/lib/utils/cache";
+import logger from "@app/logger/logger";
 import type { TimeFrame } from "@app/types";
 import { parseTimeFrame, stripNullBytes, timeFrameFromNow } from "@app/types";
+import { isDevelopment, isDustWorkspace } from "@app/types/shared/env";
 
 const serverInfo = {
   name: "slack",
@@ -55,6 +60,56 @@ const getSlackClient = async (accessToken?: string) => {
     },
   });
 };
+
+type GetPublicChannelsArgs = {
+  mcpServerId: string;
+  slackClient: WebClient;
+};
+
+type ChannelWithIdAndName = Omit<Channel, "id" | "name"> & {
+  id: string;
+  name: string;
+};
+
+const _getPublicChannels = async ({
+  slackClient,
+}: GetPublicChannelsArgs): Promise<ChannelWithIdAndName[]> => {
+  const channels: Channel[] = [];
+
+  let cursor: string | undefined = undefined;
+  do {
+    const response = await slackClient.conversations.list({
+      cursor,
+      limit: 100,
+      exclude_archived: true,
+      types: "public_channel",
+    });
+    if (!response.ok) {
+      throw new Error(`Error listing channels: ${response.error}`);
+    }
+    channels.push(...(response.channels ?? []));
+    cursor = response.response_metadata?.next_cursor;
+  } while (cursor);
+
+  return channels
+    .filter((c) => !!c.id && !!c.name)
+    .map((c) => ({
+      ...c,
+      id: c.id!,
+      name: c.name!,
+    }))
+    .sort((a, b) => a.name.localeCompare(b.name));
+};
+
+const getCachedPublicChannels = cacheWithRedis(
+  _getPublicChannels,
+  ({ mcpServerId }: GetPublicChannelsArgs) => {
+    return `public-channels-${mcpServerId}`;
+  },
+  {
+    ttlMs: 60 * 10 * 1000, // 10 minutes
+  }
+);
 
 function makeQueryResource(
   keywords: string[],
@@ -101,6 +156,7 @@ function isSlackTokenRevoked(error: unknown): boolean {
 
 const createServer = async (
   auth: Authenticator,
+  mcpServerId: string,
   agentLoopContext?: AgentLoopContextType
 ): Promise<McpServer> => {
   const server = new McpServer(serverInfo, {
@@ -110,6 +166,62 @@ const createServer = async (
       "If you want to reference a channel, you must use #CHANNEL where CHANNEL is the name of the channel you want to reference.\n" +
       "NEVER use the channel name or the user name directly in a message as it will not be parsed correctly and appear as plain text.",
   });
+
+  if (isDustWorkspace(auth.getNonNullableWorkspace()) || isDevelopment()) {
+    const c = await getConnectionForMCPServer(auth, {
+      mcpServerId,
+      connectionType: "workspace", // Always get the admin token.
+    });
+
+    if (!c) {
+      logger.warn("No connection found for slack");
+    }
+    // Note: this is a temporary tool to test the dynamic configuration of channels, but it's meant to be added directly to one of the tools below.
+    else {
+      try {
+        const slackClient = await getSlackClient(c.access_token);
+        const channels = await getCachedPublicChannels({
+          mcpServerId,
+          slackClient,
+        });
+
+        channels.unshift({
+          id: "*",
+          name: "All public channels",
+        });
+
+        const options = channels.map((c) =>
+          z.object({
+            value: z.literal(c.id),
+            label: z.literal(c.id === "*" ? c.name : `#${c.name}`),
+          })
+        );
+
+        server.tool(
+          "list_picked_channels",
+          "List all channels that the user has picked",
+          {
+            channels: z.object({
+              // "options" are optionals because we only need them for the UI but they won't be provided when the tool is called.
+              // Note: I don't know how to make this work without the any.
+              // eslint-disable-next-line @typescript-eslint/no-explicit-any
+              options: z.union(options as any).optional(),
+              values: z.array(z.string()),
+              mimeType: z.literal(INTERNAL_MIME_TYPES.TOOL_INPUT.LIST),
+            }),
+          },
+          async ({ channels }) => {
+            return makeMCPToolJSONSuccess({
+              message: "Channels listed",
+              result: channels.values,
+            });
+          }
+        );
+      } catch (error) {
+        logger.warn("Error listing channels: ", error);
+      }
+    }
+  }
 
   if (
     !(await getFeatureFlags(auth.getNonNullableWorkspace())).includes(
@@ -910,47 +1022,33 @@ const createServer = async (
       const slackClient = await getSlackClient(accessToken);
 
       try {
-        const channels: any[] = [];
+        const channels = await getCachedPublicChannels({
+          mcpServerId,
+          slackClient,
+        });
 
-        let cursor: string | undefined = undefined;
-        do {
-          const response = await slackClient.conversations.list({
-            cursor,
-            limit: 100,
-            types: "public_channel",
-          });
-          if (!response.ok) {
-            return makeMCPToolTextError(
-              `Error listing channels: ${response.error}`
-            );
+        if (nameFilter) {
+          const normalizedNameFilter = removeDiacritics(
+            nameFilter.toLowerCase()
+          );
+          const filteredChannels = channels.filter(
+            (channel) =>
+              removeDiacritics(channel.name?.toLowerCase() ?? "").includes(
+                normalizedNameFilter
+              ) ||
+              removeDiacritics(
+                channel.topic?.value?.toLowerCase() ?? ""
+              ).includes(normalizedNameFilter)
+          );
+
+          // Early return if we found a channel
+          if (filteredChannels.length > 0) {
+            return makeMCPToolJSONSuccess({
+              message: `The workspace has ${filteredChannels.length} channels containing "${nameFilter}"`,
+              result: filteredChannels,
+            });
           }
-          channels.push(...(response.channels ?? []));
-          cursor = response.response_metadata?.next_cursor;
-
-          if (nameFilter) {
-            const normalizedNameFilter = removeDiacritics(
-              nameFilter.toLowerCase()
-            );
-            const filteredChannels = channels.filter(
-              (channel) =>
-                removeDiacritics(channel.name?.toLowerCase() ?? "").includes(
-                  normalizedNameFilter
-                ) ||
-                removeDiacritics(
-                  channel.topic?.value?.toLowerCase() ?? ""
-                ).includes(normalizedNameFilter)
-            );
-
-            // Early return if we found a channel
-            if (filteredChannels.length > 0) {
-              return makeMCPToolJSONSuccess({
-                message: `The workspace has ${filteredChannels.length} channels containing "${nameFilter}"`,
-                result: filteredChannels,
-              });
-            }
-          }
-        } while (cursor);
-
+        }
         if (nameFilter) {
           return makeMCPToolJSONSuccess({
             message: `The workspace has ${channels.length} channels but none containing "${nameFilter}"`,

--- a/front/package-lock.json
+++ b/front/package-lock.json
@@ -4,7 +4,6 @@
   "requires": true,
   "packages": {
     "": {
-      "name": "front",
       "dependencies": {
         "@datadog/browser-logs": "^6.13.0",
         "@dust-tt/client": "file:../sdks/js",

--- a/front/types/shared/env.ts
+++ b/front/types/shared/env.ts
@@ -1,4 +1,4 @@
-import type { WorkspaceType } from "../user";
+import type { LightWorkspaceType } from "../user";
 
 export function isDevelopment() {
   return process.env.NODE_ENV === "development";
@@ -6,6 +6,6 @@ export function isDevelopment() {
 export function isTest() {
   return process.env.NODE_ENV === "test";
 }
-export function isDustWorkspace(w: WorkspaceType) {
+export function isDustWorkspace(w: LightWorkspaceType) {
   return w.sId === process.env.PRODUCTION_DUST_WORKSPACE_ID;
 }


### PR DESCRIPTION
## Description

(only for our workspace or in dev)
Allow to pick a subset of public slack channels when adding the slack tool to an agent.

Notable changes:
- Updated the code for the LIST mimetype to separate options to pick from and values picked.
- Fixed broken check for existing instance of the same tool.
- Cached public channels list.

## Tests

<img width="588" height="1392" alt="image" src="https://github.com/user-attachments/assets/1fc34ab6-1c96-45b0-a91e-7908b60f8e7a" />

<img width="742" height="423" alt="image" src="https://github.com/user-attachments/assets/82c43fab-0000-41f8-b6e8-1797cf1fd9ff" />

## Risk

Low, not used.

## Deploy Plan

Deploy front