### PR TITLE
[slack] Fix infinite loops, removed pqueue usage

### DIFF
--- a/connectors/src/connectors/slack/temporal/workflows.ts
+++ b/connectors/src/connectors/slack/temporal/workflows.ts
@@ -184,25 +184,8 @@ export async function syncOneThreadDebounced(
 ) {
   let signaled = false;
   let debounceCount = 0;
-  let receivedSignalsCount = 0;
 
   setHandler(newWebhookSignal, async () => {
-    receivedSignalsCount++;
-
-    if (receivedSignalsCount >= MAX_SIGNAL_RECEIVED_COUNT) {
-      log.info(
-        `Continuing as Workflow as new due to too many signals received for syncOneThreadDebounced: ${receivedSignalsCount}`,
-        {
-          connectorId,
-          channelId,
-          threadTs,
-          debounceCount,
-          receivedSignalsCount,
-        }
-      );
-      await continueAsNew(connectorId, channelId, threadTs);
-      return;
-    }
     signaled = true;
   });
 
@@ -252,25 +235,8 @@ export async function syncOneMessageDebounced(
 ) {
   let signaled = false;
   let debounceCount = 0;
-  let receivedSignalsCount = 0;
 
   setHandler(newWebhookSignal, async () => {
-    receivedSignalsCount++;
-
-    if (receivedSignalsCount >= MAX_SIGNAL_RECEIVED_COUNT) {
-      log.info(
-        `Continuing as Workflow as new due to too many signals received for syncOneMessageDebounced: ${receivedSignalsCount}`,
-        {
-          connectorId,
-          channelId,
-          threadTs,
-          debounceCount,
-          receivedSignalsCount,
-        }
-      );
-      await continueAsNew(connectorId, channelId, threadTs);
-      return;
-    }
     signaled = true;
   });
 

--- a/connectors/src/connectors/slack/temporal/workflows.ts
+++ b/connectors/src/connectors/slack/temporal/workflows.ts
@@ -1,7 +1,6 @@
 import {
   continueAsNew,
   executeChild,
-  log,
   proxyActivities,
   setHandler,
   sleep,
@@ -58,10 +57,6 @@ function getSlackActivities() {
     syncThread,
   };
 }
-
-// we have a maximum of 990 signal received before we continue as new
-// this is to avoid "Failed to signalWithStart Workflow: 3 INVALID_ARGUMENT: exceeded workflow execution limit for signal events"
-const MAX_SIGNAL_RECEIVED_COUNT = 990;
 
 // Max debounce
 const MAX_DEBOUNCE_COUNT = 100;


### PR DESCRIPTION
## Description

This aims at fixing the async hooks corruption crashing slack pods.

According to temporal , we should ( https://github.com/temporalio/sdk-typescript/issues/939 ) :
- Avoid infinite loops in workflow code
- Always await async operations (sleep(), activities, child workflows)
- Check condition() predicates don't immediately evaluate to true

One main issue is the debounce loops which keeps while we get signals, and async operations in signal handlers which creates nested async contexts. This limit the number of iteration and continueAsNew workflow once reached.

Also replaced the pqueue by a simple loop to handle the signals sequentially without relying on pqueue and async hooks.


## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

can be rolled back

## Deploy Plan

deploy connectors
