### PR TITLE
Directly use async loop if agent uses long running tools

### DIFF
--- a/front/lib/api/assistant/agent.ts
+++ b/front/lib/api/assistant/agent.ts
@@ -7,8 +7,11 @@ import {
 } from "@app/lib/actions/mcp_internal_actions/constants";
 import { ensureConversationTitle } from "@app/lib/api/assistant/conversation/title";
 import type { Authenticator, AuthenticatorType } from "@app/lib/auth";
+import {
+  LONG_RUNNING_TOOL_THRESHOLD_MS,
+  SYNC_TO_ASYNC_TIMEOUT_MS,
+} from "@app/lib/constants/timeouts";
 import { wakeLock } from "@app/lib/wake_lock";
-import { PRESTOP_GRACE_PERIOD_MS } from "@app/pages/api/[preStopSecret]/prestop";
 import {
   logAgentLoopPhaseCompletionActivity,
   logAgentLoopPhaseStartActivity,
@@ -30,12 +33,6 @@ import type {
   RunAgentArgs,
   RunAgentArgsInput,
 } from "@app/types/assistant/agent_run";
-
-// 40 seconds timeout before switching from sync to async execution.
-const SYNC_TO_ASYNC_TIMEOUT_MS = 40 * 1000;
-
-// 10 seconds before prestop grace period.
-const LONG_RUNNING_TOOL_THRESHOLD_MS = PRESTOP_GRACE_PERIOD_MS - 10_000;
 
 /**
  * TODO(DURABLE_AGENT 2025-08-20): This is a temporary solution to handle long-running tools. To be

--- a/front/lib/constants/timeouts.ts
+++ b/front/lib/constants/timeouts.ts
@@ -1,0 +1,17 @@
+/**
+ * Shared timeout constants used across the application.
+ *
+ * These constants are defined centrally to avoid duplication and ensure consistency
+ * between different parts of the system (API routes, agent loops, etc.).
+ */
+
+// This is defined as terminationGracePeriodSeconds in the deployment specification.
+// DO NOT CHANGE THIS VALUE unless you update the deployment specification.
+export const PRESTOP_GRACE_PERIOD_MS = 130 * 1_000; // 130 seconds grace period.
+
+// Threshold for determining if tools should trigger async mode (2 minutes).
+// This is 10 seconds before the prestop grace period to ensure sufficient buffer time.
+export const LONG_RUNNING_TOOL_THRESHOLD_MS = PRESTOP_GRACE_PERIOD_MS - 10_000;
+
+// Standard sync-to-async timeout for agent execution (40 seconds).
+export const SYNC_TO_ASYNC_TIMEOUT_MS = 40 * 1_000;

--- a/front/pages/api/[preStopSecret]/prestop.ts
+++ b/front/pages/api/[preStopSecret]/prestop.ts
@@ -9,7 +9,7 @@ import { withLogging } from "@app/logger/withlogging";
 
 // This is defined as terminationGracePeriodSeconds in the deployment specification.
 // DO NOT CHANGE THIS VALUE unless you update the deployment specification.
-const PRESTOP_GRACE_PERIOD_MS = 130 * 1000; // 130 seconds grace period.
+export const PRESTOP_GRACE_PERIOD_MS = 130 * 1000; // 130 seconds grace period.
 
 const PRESTOP_MAX_WAIT_MS = 120 * 1000; // 120 seconds max wait.
 const PRESTOP_LOG_INTERVAL_MS = 1000; // 1 second log interval.

--- a/front/pages/api/[preStopSecret]/prestop.ts
+++ b/front/pages/api/[preStopSecret]/prestop.ts
@@ -1,15 +1,12 @@
 import type { NextApiRequest, NextApiResponse } from "next";
 
+import { PRESTOP_GRACE_PERIOD_MS } from "@app/lib/constants/timeouts";
 import { setTimeoutAsync } from "@app/lib/utils/async_utils";
 import type { WakeLockEntry } from "@app/lib/wake_lock";
 import { getWakeLockDetails, wakeLockIsFree } from "@app/lib/wake_lock";
 import logger from "@app/logger/logger";
 import { statsDClient } from "@app/logger/statsDClient";
 import { withLogging } from "@app/logger/withlogging";
-
-// This is defined as terminationGracePeriodSeconds in the deployment specification.
-// DO NOT CHANGE THIS VALUE unless you update the deployment specification.
-export const PRESTOP_GRACE_PERIOD_MS = 130 * 1000; // 130 seconds grace period.
 
 const PRESTOP_MAX_WAIT_MS = 120 * 1000; // 120 seconds max wait.
 const PRESTOP_LOG_INTERVAL_MS = 1000; // 1 second log interval.


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
We noticed that tools running above 2 minutes are often being cut when deploying. This PR makes an assumption that tools with a timeout above the grace period (modulo a small buffer) should be directly run in asynchronous mode.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
