### PR TITLE
[Front] Fix viewType parameter flickering in data source view URLs

### DIFF
--- a/front/components/spaces/SpaceDataSourceViewContentList.tsx
+++ b/front/components/spaces/SpaceDataSourceViewContentList.tsx
@@ -447,9 +447,9 @@ export const SpaceDataSourceViewContentList = ({
     if (!isTablesValidating && !isDocumentsValidating) {
       // If the view only has content in one of the two views, we switch to that view.
       // if both views have content, or neither view has content, we default to documents.
-      if (hasTables && !hasDocuments) {
+      if (hasTables && !hasDocuments && viewType !== "table") {
         handleViewTypeChange("table");
-      } else if (!hasTables && hasDocuments) {
+      } else if (!hasTables && hasDocuments && viewType !== "document") {
         handleViewTypeChange("document");
       } else if (!viewType) {
         handleViewTypeChange(DEFAULT_VIEW_TYPE);


### PR DESCRIPTION
## Description
Fixes URL flickering issue where the `viewType=document` parameter was rapidly alternating in data source view pages at URLs like: `https://dust.tt/w/0ec9852c2f/spaces/vlt_ZqMdUAzI0OTf/categories/folder/data_source_views/dsv_Q8Ac4ujCfEha#?viewType=document`

The issue was caused by a `useEffect` hook that was unnecessarily re-setting the viewType even when it was already correctly set. The hook would automatically switch between "document" and "table" view types based on content availability, but wasn't checking if the current viewType was already correct before attempting to change it.

The fix adds checks to prevent redundant viewType updates: it now only changes the viewType when it's actually different from the current value.

## Risks
Blast radius: Data source view pages navigation behavior
Risk: low

## Tests
Formatting check passed

## Deploy Plan
- Deploy front service