### PR TITLE
[front] - fix(AB v2): automatic emoji suggestion for agent 

### DIFF
--- a/front/components/agent_builder/settings/AgentBuilderSettingsBlock.tsx
+++ b/front/components/agent_builder/settings/AgentBuilderSettingsBlock.tsx
@@ -10,7 +10,7 @@ import {
   SparklesIcon,
   Spinner,
 } from "@dust-tt/sparkle";
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { useController, useWatch } from "react-hook-form";
 
 import { useAgentBuilderContext } from "@app/components/agent_builder/AgentBuilderContext";
@@ -282,6 +282,7 @@ function AgentDescriptionInput() {
 function AgentPictureInput() {
   const { owner } = useAgentBuilderContext();
   const [isAvatarModalOpen, setIsAvatarModalOpen] = useState(false);
+  const hasSuggestedRef = useRef(false);
   const instructions = useWatch<AgentBuilderFormData, "instructions">({
     name: "instructions",
   });
@@ -326,10 +327,20 @@ function AgentPictureInput() {
   useEffect(() => {
     if (
       !field.value &&
+      !hasSuggestedRef.current &&
       instructions &&
       instructions.length >= MIN_INSTRUCTIONS_LENGTH_SUGGESTIONS
     ) {
+      hasSuggestedRef.current = true;
       void updateEmojiFromSuggestions();
+    }
+
+    // Reset the flag if instructions become too short again
+    if (
+      instructions &&
+      instructions.length < MIN_INSTRUCTIONS_LENGTH_SUGGESTIONS
+    ) {
+      hasSuggestedRef.current = false;
     }
   }, [field.value, instructions, updateEmojiFromSuggestions]);
 


### PR DESCRIPTION
## Description

This PR introduces a `useRef` hook to track if emoji suggestions have been made for the agent picture input. We were having a glitch when a suggestions was triggered, and another one triggered on top when a user was typing before the emoji was set.

## Tests

Locally

## Risk

Low

## Deploy Plan

Deploy front