### PR TITLE
[front] Add `status` on `agent_mcp_actions`

### DIFF
--- a/front/lib/actions/mcp.ts
+++ b/front/lib/actions/mcp.ts
@@ -515,6 +515,7 @@ export async function* runToolWithStreaming(
 
   const { executionState } = mcpAction;
 
+  // TODO(2025-08-20 aubin): use the status here: `if (isToolExecutionStatusTerminal(status))`.
   if (executionState === "denied") {
     statsDClient.increment("mcp_actions_denied.count", 1, tags);
     localLogger.info("Action execution rejected by user");

--- a/front/lib/actions/mcp.ts
+++ b/front/lib/actions/mcp.ts
@@ -756,6 +756,7 @@ export async function handleMCPActionError(
     // Update action to mark it as having an error.
     await action.update({
       isError: true,
+      status: "errored",
     });
 
     return {
@@ -769,6 +770,13 @@ export async function handleMCPActionError(
         metadata: params.errorMetadata ?? null,
       },
     };
+  }
+
+  // If the tool is not already in a terminal state
+  if (!isToolExecutionStatusTerminal(executionState)) {
+    await action.update({
+      status: "errored",
+    });
   }
 
   // Yields tool_success to continue conversation.

--- a/front/lib/actions/mcp.ts
+++ b/front/lib/actions/mcp.ts
@@ -318,6 +318,7 @@ export class MCPActionType {
   readonly citationsAllocated: number = 0;
   // TODO(2025-07-24 aubin): remove the type here.
   readonly type = "tool_action" as const;
+  readonly status: ToolExecutionStatus;
 
   readonly runningState: MCPRunningState;
 
@@ -339,6 +340,7 @@ export class MCPActionType {
     this.step = blob.step;
     this.citationsAllocated = blob.citationsAllocated;
     this.runningState = blob.runningState;
+    this.status = blob.status;
   }
 
   getGeneratedFiles(): ActionGeneratedFileType[] {
@@ -658,12 +660,14 @@ export async function createMCPAction(
     augmentedInputs,
     stepContentId,
     stepContext,
+    approvalStatus,
   }: {
     actionBaseParams: ActionBaseParams;
     actionConfiguration: MCPToolConfigurationType;
     augmentedInputs: Record<string, unknown>;
     stepContentId: ModelId;
     stepContext: StepContext;
+    approvalStatus: "allowed_implicitly" | "pending";
   }
 ): Promise<{ action: AgentMCPAction; mcpAction: MCPActionType }> {
   const toolConfiguration = omit(
@@ -679,6 +683,7 @@ export async function createMCPAction(
     isError: false,
     mcpServerConfigurationId: actionBaseParams.mcpServerConfigurationId,
     runningState: "not_started",
+    status: approvalStatus,
     stepContentId,
     stepContext,
     toolConfiguration,

--- a/front/lib/actions/mcp.ts
+++ b/front/lib/actions/mcp.ts
@@ -191,8 +191,7 @@ export type MCPExecutionState =
   | "allowed_explicitly"
   | "allowed_implicitly"
   | "denied"
-  | "pending"
-  | "timeout";
+  | "pending";
 
 // TODO(2025-08-20 aubin): remove this (consolidated into a single column).
 export type MCPRunningState =

--- a/front/lib/actions/mcp.ts
+++ b/front/lib/actions/mcp.ts
@@ -390,6 +390,17 @@ export class MCPActionType {
       };
     }
 
+    // TODO(durable-agents): uncomment the following once the `status` has been filled.
+    // if (this.status === "denied") {
+    //   return {
+    //     role: "function" as const,
+    //     name: this.functionCallName,
+    //     function_call_id: this.functionCallId,
+    //     content:
+    //       "The user rejected this specific action execution. Using this action is hence forbidden for this message.",
+    //   };
+    // }
+
     const outputItems = removeNulls(
       this.output?.map(rewriteContentForModel) ?? []
     );

--- a/front/lib/actions/mcp.ts
+++ b/front/lib/actions/mcp.ts
@@ -201,42 +201,42 @@ export type MCPRunningState =
   | "completed"
   | "errored";
 
-const TOOL_EXECUTION_TERMINAL_STATES = [
+const TOOL_EXECUTION_TERMINAL_STATUS = [
   "succeeded",
   "errored",
   "denied",
 ] as const;
 
-export type ToolExecutionTerminalState =
-  (typeof TOOL_EXECUTION_TERMINAL_STATES)[number];
+export type ToolExecutionTerminalStatus =
+  (typeof TOOL_EXECUTION_TERMINAL_STATUS)[number];
 
-const TOOL_EXECUTION_TRANSITIONARY_STATES = [
+const TOOL_EXECUTION_TRANSITIONARY_STATUS = [
   "allowed_explicitly",
   "allowed_implicitly",
   "pending",
   "running",
 ] as const;
 
-export type ToolExecutionTransitionaryState =
-  (typeof TOOL_EXECUTION_TRANSITIONARY_STATES)[number];
+export type ToolExecutionTransitionaryStatus =
+  (typeof TOOL_EXECUTION_TRANSITIONARY_STATUS)[number];
 
-export type ToolExecutionState =
-  | ToolExecutionTerminalState
-  | ToolExecutionTransitionaryState;
+export type ToolExecutionStatus =
+  | ToolExecutionTerminalStatus
+  | ToolExecutionTransitionaryStatus;
 
-export function isToolExecutionStateTerminal(
-  state: ToolExecutionState
-): state is ToolExecutionTerminalState {
-  return TOOL_EXECUTION_TERMINAL_STATES.includes(
-    state as ToolExecutionTerminalState
+export function isToolExecutionStatusTerminal(
+  state: ToolExecutionStatus
+): state is ToolExecutionTerminalStatus {
+  return TOOL_EXECUTION_TERMINAL_STATUS.includes(
+    state as ToolExecutionTerminalStatus
   );
 }
 
-export function isToolExecutionStateTransitionary(
-  state: ToolExecutionState
-): state is ToolExecutionTransitionaryState {
-  return TOOL_EXECUTION_TRANSITIONARY_STATES.includes(
-    state as ToolExecutionTransitionaryState
+export function isToolExecutionStatusTransitionary(
+  state: ToolExecutionStatus
+): state is ToolExecutionTransitionaryStatus {
+  return TOOL_EXECUTION_TRANSITIONARY_STATUS.includes(
+    state as ToolExecutionTransitionaryStatus
   );
 }
 

--- a/front/lib/actions/mcp.ts
+++ b/front/lib/actions/mcp.ts
@@ -172,7 +172,7 @@ export type MCPApproveExecutionEvent = {
 
 export function getMCPApprovalStateFromUserApprovalState(
   userApprovalState: ActionApprovalStateType
-): MCPExecutionState {
+) {
   switch (userApprovalState) {
     case "always_approved":
     case "approved":
@@ -521,7 +521,7 @@ export async function* runToolWithStreaming(
 
   const { executionState } = mcpAction;
 
-  // TODO(2025-08-20 aubin): use the status here: `if (isToolExecutionStatusFinal(status))`.
+  // TODO(durable-agents): remove this part once `status` has been filled (unreachable code path).
   if (executionState === "denied") {
     statsDClient.increment("mcp_actions_denied.count", 1, tags);
     localLogger.info("Action execution rejected by user");
@@ -826,7 +826,7 @@ export async function getMCPAction(
 // TODO(DURABLE_AGENTS 2025-08-12): Create a proper resource for the agent mcp action.
 export async function updateMCPApprovalState(
   action: AgentMCPAction,
-  executionState: MCPExecutionState
+  executionState: "denied" | "allowed_explicitly"
 ): Promise<boolean> {
   if (action.executionState === executionState) {
     return false;
@@ -834,6 +834,7 @@ export async function updateMCPApprovalState(
 
   await action.update({
     executionState,
+    status: executionState,
   });
 
   return true;

--- a/front/lib/actions/mcp.ts
+++ b/front/lib/actions/mcp.ts
@@ -202,8 +202,7 @@ export type MCPRunningState =
 
 const TOOL_EXECUTION_FINAL_STATUS = ["succeeded", "errored", "denied"] as const;
 
-export type ToolExecutionFinalStatus =
-  (typeof TOOL_EXECUTION_FINAL_STATUS)[number];
+type ToolExecutionFinalStatus = (typeof TOOL_EXECUTION_FINAL_STATUS)[number];
 
 const TOOL_EXECUTION_TRANSIENT_STATUS = [
   "allowed_explicitly",
@@ -212,7 +211,7 @@ const TOOL_EXECUTION_TRANSIENT_STATUS = [
   "running",
 ] as const;
 
-export type ToolExecutionTransientStatus =
+type ToolExecutionTransientStatus =
   (typeof TOOL_EXECUTION_TRANSIENT_STATUS)[number];
 
 export type ToolExecutionStatus =

--- a/front/lib/actions/mcp.ts
+++ b/front/lib/actions/mcp.ts
@@ -186,6 +186,7 @@ export function getMCPApprovalStateFromUserApprovalState(
   }
 }
 
+// TODO(2025-08-20 aubin): remove this (consolidated into a single column).
 export type MCPExecutionState =
   | "allowed_explicitly"
   | "allowed_implicitly"
@@ -193,11 +194,51 @@ export type MCPExecutionState =
   | "pending"
   | "timeout";
 
+// TODO(2025-08-20 aubin): remove this (consolidated into a single column).
 export type MCPRunningState =
   | "not_started"
   | "running"
   | "completed"
   | "errored";
+
+const TOOL_EXECUTION_TERMINAL_STATES = [
+  "succeeded",
+  "errored",
+  "denied",
+] as const;
+
+export type ToolExecutionTerminalState =
+  (typeof TOOL_EXECUTION_TERMINAL_STATES)[number];
+
+const TOOL_EXECUTION_TRANSITIONARY_STATES = [
+  "allowed_explicitly",
+  "allowed_implicitly",
+  "pending",
+  "running",
+] as const;
+
+export type ToolExecutionTransitionaryState =
+  (typeof TOOL_EXECUTION_TRANSITIONARY_STATES)[number];
+
+export type ToolExecutionState =
+  | ToolExecutionTerminalState
+  | ToolExecutionTransitionaryState;
+
+export function isToolExecutionStateTerminal(
+  state: ToolExecutionState
+): state is ToolExecutionTerminalState {
+  return TOOL_EXECUTION_TERMINAL_STATES.includes(
+    state as ToolExecutionTerminalState
+  );
+}
+
+export function isToolExecutionStateTransitionary(
+  state: ToolExecutionState
+): state is ToolExecutionTransitionaryState {
+  return TOOL_EXECUTION_TRANSITIONARY_STATES.includes(
+    state as ToolExecutionTransitionaryState
+  );
+}
 
 type MCPParamsEvent = {
   type: "tool_params";

--- a/front/lib/actions/mcp_execution.ts
+++ b/front/lib/actions/mcp_execution.ts
@@ -87,6 +87,10 @@ export async function* executeMCPTool({
   > | null,
   unknown
 > {
+  await action.update({
+    status: "running",
+  });
+
   let toolCallResult: Result<
     CallToolResult["content"],
     Error | McpError | MCPServerPersonalAuthenticationRequiredError

--- a/front/lib/actions/utils.ts
+++ b/front/lib/actions/utils.ts
@@ -8,7 +8,11 @@ import {
 
 import type { ActionSpecification } from "@app/components/assistant_builder/types";
 import type { MCPToolStakeLevelType } from "@app/lib/actions/constants";
-import type { MCPToolConfigurationType } from "@app/lib/actions/mcp";
+import type {
+  MCPExecutionState,
+  MCPToolConfigurationType,
+  ToolExecutionStatus,
+} from "@app/lib/actions/mcp";
 import type { StepContext } from "@app/lib/actions/types";
 import {
   isMCPInternalDataSourceFileSystem,
@@ -236,6 +240,25 @@ export function getMCPApprovalKey({
   actionId: number;
 }): string {
   return `conversation:${conversationId}:message:${messageId}:action:${actionId}`;
+}
+
+// TODO(durable-agents): remove this translation once status is backfilled, have
+//  getExecutionStatusFromConfig return a ToolExecutionStatus directly.
+export function approvalStatusToToolExecutionStatus(
+  approvalStatus: MCPExecutionState
+): ToolExecutionStatus {
+  switch (approvalStatus) {
+    case "allowed_explicitly":
+      return "ready_allowed_explicitly";
+    case "allowed_implicitly":
+      return "ready_allowed_implicitly";
+    case "denied":
+      return "denied";
+    case "pending":
+      return "blocked_pending_validation";
+    default:
+      assertNever(approvalStatus);
+  }
 }
 
 export async function getExecutionStatusFromConfig(

--- a/front/lib/api/assistant/conversation/validate_actions.ts
+++ b/front/lib/api/assistant/conversation/validate_actions.ts
@@ -125,6 +125,7 @@ export async function validateAction(
         mcpServerId: action.toolConfiguration.toolServerId,
         step: agentStepContent.step,
         stepContentId: action.stepContentId,
+        status: action.status,
       });
       const toolName = actionBaseParams.functionCallName;
 

--- a/front/lib/models/assistant/actions/mcp.ts
+++ b/front/lib/models/assistant/actions/mcp.ts
@@ -311,6 +311,11 @@ AgentMCPAction.init(
         name: "agent_mcp_action_workspace_agent_message_execution_state",
         concurrently: true,
       },
+      {
+        fields: ["workspaceId", "agentMessageId", "status"],
+        name: "agent_mcp_action_workspace_agent_message_status",
+        concurrently: true,
+      },
     ],
   }
 );

--- a/front/lib/models/assistant/actions/mcp.ts
+++ b/front/lib/models/assistant/actions/mcp.ts
@@ -261,6 +261,7 @@ AgentMCPAction.init(
     status: {
       type: DataTypes.STRING,
       allowNull: true,
+      defaultValue: "succeeded",
     },
     isError: {
       type: DataTypes.BOOLEAN,

--- a/front/lib/models/assistant/actions/mcp.ts
+++ b/front/lib/models/assistant/actions/mcp.ts
@@ -6,6 +6,7 @@ import { DataTypes } from "sequelize";
 import type {
   LightMCPToolConfigurationType,
   MCPExecutionState,
+  ToolExecutionStatus,
 } from "@app/lib/actions/mcp";
 import type { MCPRunningState } from "@app/lib/actions/mcp";
 import type { StepContext } from "@app/lib/actions/types";
@@ -191,29 +192,22 @@ AgentMCPServerConfiguration.belongsTo(MCPServerViewModel, {
 
 export class AgentMCPAction extends WorkspaceAwareModel<AgentMCPAction> {
   declare createdAt: CreationOptional<Date>;
-
   declare updatedAt: CreationOptional<Date>;
 
   declare mcpServerConfigurationId: string;
-
   declare version: number;
-
   declare agentMessageId: ForeignKey<AgentMessage["id"]>;
-
   declare stepContentId: ForeignKey<AgentStepContentModel["id"]>;
 
   declare isError: boolean;
-
   declare executionState: MCPExecutionState;
-
   declare runningState: MCPRunningState;
 
+  declare status: ToolExecutionStatus;
+
   declare citationsAllocated: number;
-
   declare augmentedInputs: Record<string, unknown>;
-
   declare toolConfiguration: LightMCPToolConfigurationType;
-
   declare stepContext: StepContext;
 
   declare outputItems: NonAttribute<AgentMCPActionOutputItem[]>;
@@ -263,6 +257,10 @@ AgentMCPAction.init(
       validate: {
         isIn: [["not_started", "running", "completed", "errored"]],
       },
+    },
+    status: {
+      type: DataTypes.STRING,
+      allowNull: true,
     },
     isError: {
       type: DataTypes.BOOLEAN,

--- a/front/lib/resources/agent_step_content_resource.ts
+++ b/front/lib/resources/agent_step_content_resource.ts
@@ -368,6 +368,7 @@ export class AgentStepContentResource extends BaseResource<AgentStepContentModel
             executionState: action.executionState,
             isError: action.isError,
             type: "tool_action",
+            status: action.status,
             citationsAllocated: action.citationsAllocated,
             generatedFiles: removeNulls(
               action.outputItems.map((o) => {

--- a/front/migrations/20250821_backfill_agent_mcp_action_status.ts
+++ b/front/migrations/20250821_backfill_agent_mcp_action_status.ts
@@ -6,6 +6,10 @@ import { makeScript } from "@app/scripts/helpers";
 
 const BATCH_SIZE = 2048;
 
+// There are 3 possible final states: errored, succeeded, denied.
+// succeeded is the default (99.1% of actions), we backfill errored using the `isError` column
+// and denied using the `executionState` column.
+
 async function getNextBatch({
   lastId,
   targetStatus,

--- a/front/migrations/20250821_backfill_agent_mcp_action_status.ts
+++ b/front/migrations/20250821_backfill_agent_mcp_action_status.ts
@@ -1,0 +1,53 @@
+import { Op } from "sequelize";
+
+import { AgentMCPAction } from "@app/lib/models/assistant/actions/mcp";
+import { makeScript } from "@app/scripts/helpers";
+
+const BATCH_SIZE = 2048;
+
+makeScript({}, async ({ execute }, logger) => {
+  logger.info("Starting backfill");
+
+  let lastId = 0;
+  let hasMore = true;
+  do {
+    // Get a batch of actions that are errored.
+    const mcpActions = await AgentMCPAction.findAll({
+      where: {
+        id: {
+          [Op.gt]: lastId,
+        },
+        isError: {
+          [Op.is]: true,
+        },
+      },
+      order: [["id", "ASC"]],
+      limit: BATCH_SIZE,
+    });
+    logger.info(
+      `Processing ${mcpActions.length} actions starting from ${lastId}`
+    );
+
+    // Update the status accordingly.
+    if (execute) {
+      await AgentMCPAction.update(
+        { status: "errored" },
+        {
+          where: {
+            id: {
+              [Op.in]: mcpActions.map((a) => a.id),
+            },
+          },
+        }
+      );
+      logger.info(`Updated ${mcpActions.length} actions`);
+    } else {
+      logger.info(`Would update ${mcpActions.length} actions`);
+    }
+
+    lastId = mcpActions[mcpActions.length - 1].id;
+    hasMore = mcpActions.length === BATCH_SIZE;
+  } while (hasMore);
+
+  logger.info("Completed backfill");
+});

--- a/front/migrations/20250821_backfill_agent_mcp_action_status.ts
+++ b/front/migrations/20250821_backfill_agent_mcp_action_status.ts
@@ -41,7 +41,8 @@ async function backfillActions(
   do {
     const mcpActions = await getNextBatch({ lastId, targetStatus });
     logger.info(
-      `Processing ${mcpActions.length} ${targetStatus} actions starting from ${lastId}`
+      { lastId, targetStatus },
+      `Processing ${mcpActions.length} actions`
     );
 
     if (execute) {
@@ -55,9 +56,15 @@ async function backfillActions(
           },
         }
       );
-      logger.info(`Updated ${mcpActions.length} actions`);
+      logger.info(
+        { lastId, targetStatus },
+        `Updated ${mcpActions.length} actions`
+      );
     } else {
-      logger.info(`Would update ${mcpActions.length} actions`);
+      logger.info(
+        { lastId, targetStatus },
+        `Would update ${mcpActions.length} actions`
+      );
     }
 
     lastId = mcpActions[mcpActions.length - 1].id;

--- a/front/migrations/db/migration_340.sql
+++ b/front/migrations/db/migration_340.sql
@@ -1,0 +1,2 @@
+-- Migration created on Aug 20, 2025
+ALTER TABLE "public"."agent_mcp_actions" ADD COLUMN "status" VARCHAR(255);

--- a/front/migrations/db/migration_340.sql
+++ b/front/migrations/db/migration_340.sql
@@ -1,2 +1,3 @@
 -- Migration created on Aug 20, 2025
 ALTER TABLE "public"."agent_mcp_actions" ADD COLUMN "status" VARCHAR(255);
+CREATE INDEX CONCURRENTLY "agent_mcp_action_workspace_agent_message_status" ON "agent_mcp_actions" ("workspaceId", "agentMessageId", "status");

--- a/front/migrations/db/migration_340.sql
+++ b/front/migrations/db/migration_340.sql
@@ -1,3 +1,3 @@
 -- Migration created on Aug 20, 2025
-ALTER TABLE "public"."agent_mcp_actions" ADD COLUMN "status" VARCHAR(255);
+ALTER TABLE "public"."agent_mcp_actions" ADD COLUMN "status" VARCHAR(255) DEFAULT 'succeeded';
 CREATE INDEX CONCURRENTLY "agent_mcp_action_workspace_agent_message_status" ON "agent_mcp_actions" ("workspaceId", "agentMessageId", "status");

--- a/front/temporal/agent_loop/activities/run_model_and_create_actions_wrapper.ts
+++ b/front/temporal/agent_loop/activities/run_model_and_create_actions_wrapper.ts
@@ -168,13 +168,14 @@ async function getExistingActionsAndBlobs(
         "Unexpected: step content is not a function call"
       );
 
-      // If the tool is not already in a final state we must add it to the list of actions to run.
-      if (!isToolExecutionStatusFinal(mcpAction.executionState)) {
-        actionBlobs.push({
-          actionId: mcpAction.id,
-          needsApproval: mcpAction.executionState === "pending",
-        });
-      }
+      // TODO(durable-agents): uncomment the following once `status` has been filled.
+      // // If the tool is not already in a final state we must add it to the list of actions to run.
+      // if (!isToolExecutionStatusFinal(mcpAction.executionState)) {
+      actionBlobs.push({
+        actionId: mcpAction.id,
+        needsApproval: mcpAction.executionState === "pending",
+      });
+      // }
     }
   }
 

--- a/front/temporal/agent_loop/activities/run_model_and_create_actions_wrapper.ts
+++ b/front/temporal/agent_loop/activities/run_model_and_create_actions_wrapper.ts
@@ -1,6 +1,6 @@
 import assert from "assert";
 
-import { isToolExecutionStatusTerminal } from "@app/lib/actions/mcp";
+import { isToolExecutionStatusFinal } from "@app/lib/actions/mcp";
 import type { AuthenticatorType } from "@app/lib/auth";
 import type { Authenticator } from "@app/lib/auth";
 import { AgentMCPAction as AgentMCPActionModel } from "@app/lib/models/assistant/actions/mcp";

--- a/front/temporal/agent_loop/activities/run_model_and_create_actions_wrapper.ts
+++ b/front/temporal/agent_loop/activities/run_model_and_create_actions_wrapper.ts
@@ -1,5 +1,6 @@
 import assert from "assert";
 
+import { isToolExecutionStatusTerminal } from "@app/lib/actions/mcp";
 import type { AuthenticatorType } from "@app/lib/auth";
 import type { Authenticator } from "@app/lib/auth";
 import { AgentMCPAction as AgentMCPActionModel } from "@app/lib/models/assistant/actions/mcp";
@@ -167,10 +168,13 @@ async function getExistingActionsAndBlobs(
         "Unexpected: step content is not a function call"
       );
 
-      actionBlobs.push({
-        actionId: mcpAction.id,
-        needsApproval: mcpAction.executionState === "pending",
-      });
+      // We want to skip the runModel if there are actions that are not in a terminal state.
+      if (!isToolExecutionStatusTerminal(mcpAction.status)) {
+        actionBlobs.push({
+          actionId: mcpAction.id,
+          needsApproval: mcpAction.executionState === "pending",
+        });
+      }
     }
   }
 

--- a/front/temporal/agent_loop/activities/run_model_and_create_actions_wrapper.ts
+++ b/front/temporal/agent_loop/activities/run_model_and_create_actions_wrapper.ts
@@ -168,10 +168,13 @@ async function getExistingActionsAndBlobs(
         "Unexpected: step content is not a function call"
       );
 
-      actionBlobs.push({
-        actionId: mcpAction.id,
-        needsApproval: mcpAction.executionState === "pending",
-      });
+      // If the tool is not already in a final state we must add it to the list of actions to run.
+      if (!isToolExecutionStatusFinal(mcpAction.executionState)) {
+        actionBlobs.push({
+          actionId: mcpAction.id,
+          needsApproval: mcpAction.executionState === "pending",
+        });
+      }
     }
   }
 

--- a/front/temporal/agent_loop/activities/run_model_and_create_actions_wrapper.ts
+++ b/front/temporal/agent_loop/activities/run_model_and_create_actions_wrapper.ts
@@ -168,13 +168,10 @@ async function getExistingActionsAndBlobs(
         "Unexpected: step content is not a function call"
       );
 
-      // We want to skip the runModel if there are actions that are not in a terminal state.
-      if (!isToolExecutionStatusTerminal(mcpAction.status)) {
-        actionBlobs.push({
-          actionId: mcpAction.id,
-          needsApproval: mcpAction.executionState === "pending",
-        });
-      }
+      actionBlobs.push({
+        actionId: mcpAction.id,
+        needsApproval: mcpAction.executionState === "pending",
+      });
     }
   }
 

--- a/front/temporal/agent_loop/activities/run_tool.ts
+++ b/front/temporal/agent_loop/activities/run_tool.ts
@@ -67,6 +67,7 @@ export async function runToolActivity(
     mcpServerId,
     step,
     stepContentId: action.stepContentId,
+    status: action.status,
   });
 
   const mcpAction = new MCPActionType({

--- a/front/temporal/agent_loop/lib/action_utils.ts
+++ b/front/temporal/agent_loop/lib/action_utils.ts
@@ -1,6 +1,9 @@
 import assert from "assert";
 
-import type { ActionBaseParams } from "@app/lib/actions/mcp";
+import type {
+  ActionBaseParams,
+  ToolExecutionStatus,
+} from "@app/lib/actions/mcp";
 import { getInternalMCPServerNameFromSId } from "@app/lib/actions/mcp_internal_actions/constants";
 import { AgentStepContentResource } from "@app/lib/resources/agent_step_content_resource";
 import type { ModelId } from "@app/types";
@@ -18,6 +21,7 @@ export async function buildActionBaseParams({
   mcpServerId,
   step,
   stepContentId,
+  status,
 }: {
   agentMessageId: number;
   citationsAllocated: number;
@@ -25,6 +29,7 @@ export async function buildActionBaseParams({
   mcpServerId: string | null;
   step: number;
   stepContentId: ModelId;
+  status: ToolExecutionStatus;
 }): Promise<ActionBaseParams> {
   // Fetch and validate step content.
   const stepContent =
@@ -58,5 +63,6 @@ export async function buildActionBaseParams({
     params: rawInputs,
     step,
     runningState: "running",
+    status,
   };
 }

--- a/front/temporal/agent_loop/lib/create_tool_actions.ts
+++ b/front/temporal/agent_loop/lib/create_tool_actions.ts
@@ -96,6 +96,12 @@ async function createActionForTool(
     step: number;
   }
 ): Promise<ActionBlob | void> {
+  const { status } = await getExecutionStatusFromConfig(
+    auth,
+    actionConfiguration,
+    agentMessage
+  );
+
   const actionBaseParams = await buildActionBaseParams({
     agentMessageId: agentMessage.agentMessageId,
     citationsAllocated: stepContext.citationsCount,
@@ -103,6 +109,7 @@ async function createActionForTool(
     mcpServerConfigurationId: actionConfiguration.id.toString(),
     step,
     stepContentId,
+    status,
   });
 
   const validateToolInputsResult = validateToolInputs(actionBaseParams.params);
@@ -142,6 +149,7 @@ async function createActionForTool(
     augmentedInputs,
     stepContentId,
     stepContext,
+    approvalStatus: status,
   });
 
   // Publish the tool params event.
@@ -158,13 +166,6 @@ async function createActionForTool(
       conversationId,
       step,
     }
-  );
-
-  // Handle tool approval.
-  const { status } = await getExecutionStatusFromConfig(
-    auth,
-    actionConfiguration,
-    agentMessage
   );
 
   if (status === "pending") {

--- a/front/temporal/agent_loop/lib/create_tool_actions.ts
+++ b/front/temporal/agent_loop/lib/create_tool_actions.ts
@@ -3,7 +3,10 @@ import { createMCPAction } from "@app/lib/actions/mcp";
 import { getAugmentedInputs } from "@app/lib/actions/mcp_execution";
 import { validateToolInputs } from "@app/lib/actions/mcp_utils";
 import type { StepContext } from "@app/lib/actions/types";
-import { getExecutionStatusFromConfig } from "@app/lib/actions/utils";
+import {
+  approvalStatusToToolExecutionStatus,
+  getExecutionStatusFromConfig,
+} from "@app/lib/actions/utils";
 import type { Authenticator } from "@app/lib/auth";
 import type { AgentMessage } from "@app/lib/models/assistant/conversation";
 import { updateResourceAndPublishEvent } from "@app/temporal/agent_loop/activities/common";
@@ -109,7 +112,7 @@ async function createActionForTool(
     mcpServerConfigurationId: actionConfiguration.id.toString(),
     step,
     stepContentId,
-    status,
+    status: approvalStatusToToolExecutionStatus(status),
   });
 
   const validateToolInputsResult = validateToolInputs(actionBaseParams.params);


### PR DESCRIPTION
## Description

- Part of https://github.com/dust-tt/tasks/issues/3819.

The goal of this PR is to consolidate all the status relative to an action in a single column `status`.
It only adds the `status` column that will be used in the end and starts writing in it + backfills it.

In a follow up PR this `status` will be used to do the following:
- In `getExistingActionsAndBlobs` we won't add to the array of actions to run the ones that are in a final state.
- We render `denied` actions with a custom message instead of saving an action output.
- In the `/pending-validations` endpoint we fetch pending actions (already the case, we just need to read from one column instead of the other).
- We remove `isError`, `executionStatus` and `runningStatus` and instead use `status`.

## Tests

- Tested locally.

```sql
SELECT status FROM agent_mcp_actions WHERE "status" != 'succeeded' GROUP BY "status";
SELECT status FROM agent_mcp_actions WHERE "executionState" = 'denied' GROUP BY "status";
SELECT status FROM agent_mcp_actions WHERE "isError" = true GROUP BY "status";
```

## Risk

## Deploy Plan

- Run migration.
- Deploy front.
- Run backfill.
