### PR TITLE
Add Execution Mode On Public API

### DIFF
--- a/front/lib/actions/mcp_internal_actions/servers/run_agent.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/run_agent.ts
@@ -227,6 +227,10 @@ export default async function createServer(
         },
         skipToolsValidation:
           agentLoopContext.runContext.agentMessage.skipToolsValidation ?? false,
+        params: {
+          // TODO(DURABLE_AGENT 2025-08-20): Remove this if we decided to always use async mode.
+          execution: "async",
+        },
       });
 
       if (convRes.isErr()) {

--- a/front/lib/api/assistant/streaming/blocking.ts
+++ b/front/lib/api/assistant/streaming/blocking.ts
@@ -15,6 +15,7 @@ import type {
   UserMessageType,
 } from "@app/types";
 import { Ok } from "@app/types";
+import type { ExecutionMode } from "@app/types/assistant/agent_run";
 
 // We wait for 60 seconds for agent messages to complete.
 const WAIT_FOR_AGENT_COMPLETION_TIMEOUT_MS = 60000 * 3; // 3 minutes.
@@ -129,16 +130,18 @@ async function waitForAgentCompletion(
 export async function postUserMessageAndWaitForCompletion(
   auth: Authenticator,
   {
-    conversation,
     content,
-    mentions,
     context,
+    conversation,
+    executionMode,
+    mentions,
     skipToolsValidation,
   }: {
-    conversation: ConversationType;
     content: string;
-    mentions: MentionType[];
     context: UserMessageContext;
+    conversation: ConversationType;
+    executionMode?: ExecutionMode;
+    mentions: MentionType[];
     skipToolsValidation: boolean;
   }
 ): Promise<
@@ -151,10 +154,11 @@ export async function postUserMessageAndWaitForCompletion(
   >
 > {
   const postResult = await postUserMessage(auth, {
-    conversation,
     content,
-    mentions,
     context,
+    conversation,
+    executionMode,
+    mentions,
     skipToolsValidation,
   });
 

--- a/front/pages/api/v1/w/[wId]/assistant/conversations/[cId]/messages/index.ts
+++ b/front/pages/api/v1/w/[wId]/assistant/conversations/[cId]/messages/index.ts
@@ -18,6 +18,7 @@ import { concurrentExecutor } from "@app/lib/utils/async_utils";
 import { apiError } from "@app/logger/withlogging";
 import type { UserMessageContext, WithAPIErrorResponse } from "@app/types";
 import { isEmptyString } from "@app/types";
+import { ExecutionModeSchema } from "@app/types/assistant/agent_run";
 
 /**
  * @swagger
@@ -102,6 +103,13 @@ async function handler(
         });
       }
 
+      const executionModeParseResult = ExecutionModeSchema.safeParse(
+        req.query.execution
+      );
+      const executionMode = executionModeParseResult.success
+        ? executionModeParseResult.data
+        : undefined;
+
       const hasReachedLimits = await hasReachedPublicAPILimits(auth);
       if (hasReachedLimits) {
         return apiError(req, res, {
@@ -178,6 +186,7 @@ async function handler(
               content,
               context: ctx,
               conversation,
+              executionMode,
               mentions,
               skipToolsValidation: skipToolsValidation ?? false,
             })
@@ -185,6 +194,7 @@ async function handler(
               content,
               context: ctx,
               conversation,
+              executionMode,
               mentions,
               skipToolsValidation: skipToolsValidation ?? false,
             });

--- a/front/pages/api/v1/w/[wId]/assistant/conversations/index.ts
+++ b/front/pages/api/v1/w/[wId]/assistant/conversations/index.ts
@@ -39,6 +39,7 @@ import {
   isContentFragmentInputWithInlinedContent,
   isEmptyString,
 } from "@app/types";
+import { ExecutionModeSchema } from "@app/types/assistant/agent_run";
 
 const MAX_CONVERSATION_DEPTH = 4;
 
@@ -137,6 +138,13 @@ async function handler(
         skipToolsValidation,
         blocking,
       } = r.data;
+
+      const executionModeParseResult = ExecutionModeSchema.safeParse(
+        req.query.execution
+      );
+      const executionMode = executionModeParseResult.success
+        ? executionModeParseResult.data
+        : undefined;
 
       const hasReachedLimits = await hasReachedPublicAPILimits(auth);
       if (hasReachedLimits) {
@@ -358,6 +366,7 @@ async function handler(
                 content: message.content,
                 context: ctx,
                 conversation,
+                executionMode,
                 mentions: message.mentions,
                 skipToolsValidation: skipToolsValidation ?? false,
               })
@@ -365,6 +374,7 @@ async function handler(
                 content: message.content,
                 context: ctx,
                 conversation,
+                executionMode,
                 mentions: message.mentions,
                 skipToolsValidation: skipToolsValidation ?? false,
               });

--- a/sdks/js/src/index.ts
+++ b/sdks/js/src/index.ts
@@ -694,12 +694,16 @@ export class DustAPI {
     contentFragments,
     blocking = false,
     skipToolsValidation = false,
-  }: PublicPostConversationsRequestBody): Promise<
-    Result<CreateConversationResponseType, APIError>
-  > {
+    params,
+  }: PublicPostConversationsRequestBody & {
+    params?: Record<string, string>;
+  }): Promise<Result<CreateConversationResponseType, APIError>> {
+    const queryParams = new URLSearchParams(params);
+
     const res = await this.request({
       method: "POST",
       path: "assistant/conversations",
+      query: queryParams.toString() ? queryParams : undefined,
       body: {
         title,
         visibility,


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
The remaining agent loop executions being killed ([graph](https://app.datadoghq.eu/s/f4685392-d200-11ed-bb09-da7ad0900005/s57-p9m-a7x)) are mainly using the run agent tool. In https://github.com/dust-tt/dust/pull/15186 we ensure that the main loop would run in async mode, this PR ensures that the run agent creates the conversation with async execution mode. This will bring more robustness to deployment and potential disruptions.

We don't want to expose/document this settings in the SDK so we use a generic passthrough type.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
