### PR TITLE
[Front] Fix viewType parameter flickering in data source view URLs

### DIFF
--- a/front/hooks/useHashParams.ts
+++ b/front/hooks/useHashParams.ts
@@ -118,6 +118,7 @@ export const useHashParam = (
         }
       }
     }
+    // Router object reference changes between renders, excluding it prevents unnecessary updates.
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [defaultValue, innerValue, key, router.isReady]);
 

--- a/front/hooks/useHashParams.ts
+++ b/front/hooks/useHashParams.ts
@@ -118,7 +118,8 @@ export const useHashParam = (
         }
       }
     }
-  }, [defaultValue, innerValue, key, router.isReady, router]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [defaultValue, innerValue, key, router.isReady]);
 
   const setValue = useCallback<Setter>(
     async (

--- a/front/hooks/useHashParams.ts
+++ b/front/hooks/useHashParams.ts
@@ -118,7 +118,8 @@ export const useHashParam = (
         }
       }
     }
-    // Router object reference changes between renders, excluding it prevents unnecessary updates.
+    // Router object reference changes between renders, excluding it prevents unnecessary updates,
+    // some of which cause an infinite rendering loop.
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [defaultValue, innerValue, key, router.isReady]);
 


### PR DESCRIPTION
## Description
Fixes https://github.com/dust-tt/tasks/issues/3836

Fixes the flickering issue where URLs with `viewType=document` parameter rapidly alternate with URLs without the parameter on data source view pages.

## Risks
Blast radius: useHashParam hook usage across the app
Risk: low - the change is minimal and only affects dependency tracking

## Tests
Tested manually - viewType parameter no longer flickers in URLs

## Deploy Plan
- Deploy front service