### PR TITLE
Fix: mcp server deletion

### DIFF
--- a/front/lib/models/assistant/actions/mcp_server_view_helper.ts
+++ b/front/lib/models/assistant/actions/mcp_server_view_helper.ts
@@ -2,6 +2,7 @@ import type { Transaction } from "sequelize";
 import { Op } from "sequelize";
 
 import type { Authenticator } from "@app/lib/auth";
+import { ConversationMCPServerViewModel } from "@app/lib/models/assistant/actions/conversation_mcp_server_view";
 import { AgentDataSourceConfiguration } from "@app/lib/models/assistant/actions/data_sources";
 import {
   AgentChildAgentConfiguration,
@@ -63,6 +64,14 @@ export const destroyMCPServerViewDependencies = async (
   });
 
   await AgentMCPServerConfiguration.destroy({
+    where: {
+      workspaceId: auth.getNonNullableWorkspace().id,
+      mcpServerViewId: mcpServerViewId,
+    },
+    transaction,
+  });
+
+  await ConversationMCPServerViewModel.destroy({
     where: {
       workspaceId: auth.getNonNullableWorkspace().id,
       mcpServerViewId: mcpServerViewId,

--- a/front/lib/resources/internal_mcp_server_in_memory_resource.ts
+++ b/front/lib/resources/internal_mcp_server_in_memory_resource.ts
@@ -28,6 +28,7 @@ import { DustError } from "@app/lib/error";
 import { MCPServerConnection } from "@app/lib/models/assistant/actions/mcp_server_connection";
 import { MCPServerViewModel } from "@app/lib/models/assistant/actions/mcp_server_view";
 import { destroyMCPServerViewDependencies } from "@app/lib/models/assistant/actions/mcp_server_view_helper";
+import { RemoteMCPServerToolMetadataModel } from "@app/lib/models/assistant/actions/remote_mcp_server_tool_metadata";
 import { SpaceResource } from "@app/lib/resources/space_resource";
 import { concurrentExecutor } from "@app/lib/utils/async_utils";
 import { cacheWithRedis } from "@app/lib/utils/cache";
@@ -251,6 +252,13 @@ export class InternalMCPServerInMemoryResource {
     });
 
     await MCPServerConnection.destroy({
+      where: {
+        workspaceId: auth.getNonNullableWorkspace().id,
+        internalMCPServerId: this.id,
+      },
+    });
+
+    await RemoteMCPServerToolMetadataModel.destroy({
       where: {
         workspaceId: auth.getNonNullableWorkspace().id,
         internalMCPServerId: this.id,


### PR DESCRIPTION
## Description

Correctly clean up remote_mcp_server_metadata (badly named since now it also works for internals servers)
Correctly clean up the conversation mcp server views.

## Tests

Local

## Risk

Low

## Deploy Plan

deploy front