### PR TITLE
[front] Add missing type in `usePendingValidations` hook

### DIFF
--- a/front/lib/swr/pending_validations.ts
+++ b/front/lib/swr/pending_validations.ts
@@ -1,4 +1,7 @@
+import type { Fetcher } from "swr";
+
 import { fetcher, useSWRWithDefaults } from "@app/lib/swr/swr";
+import type { GetPendingValidationsResponseType } from "@app/pages/api/w/[wId]/assistant/conversations/[cId]/pending-validations";
 
 export function usePendingValidations({
   conversationId,
@@ -7,11 +10,14 @@ export function usePendingValidations({
   conversationId: string | null;
   workspaceId: string;
 }) {
+  const pendingValidationsFetcher: Fetcher<GetPendingValidationsResponseType> =
+    fetcher;
+
   const { data, error, mutate } = useSWRWithDefaults(
     conversationId
       ? `/api/w/${workspaceId}/assistant/conversations/${conversationId}/pending-validations`
       : null,
-    fetcher,
+    pendingValidationsFetcher,
     { disabled: conversationId === null }
   );
 


### PR DESCRIPTION
## Description

- The object returned by the `usePendingValidations` hook was missing some typing.
- This PR fixes that.

## Tests

## Risk

- Only typing.

## Deploy Plan

- Deploy front.
