### PR TITLE
[front] - AB v2: clear conversation button in builder preview 

### DIFF
--- a/front/components/agent_builder/AgentBuilderPreview.tsx
+++ b/front/components/agent_builder/AgentBuilderPreview.tsx
@@ -96,10 +96,7 @@ function PreviewContent({
   isSavingDraftAgent,
 }: PreviewContentProps) {
   const generationContext = useContext(GenerationContext);
-  const isGenerating =
-    generationContext?.generatingMessages.some(
-      (m) => m.conversationId === conversation?.sId
-    ) ?? false;
+  const isGenerating = !!generationContext?.generatingMessages.length;
 
   return (
     <>

--- a/front/components/agent_builder/AgentBuilderPreview.tsx
+++ b/front/components/agent_builder/AgentBuilderPreview.tsx
@@ -68,7 +68,7 @@ function LoadingState({ message }: LoadingStateProps) {
 
 interface PreviewContentProps {
   conversation: ConversationWithoutContentType | null;
-  user: UserType;
+  user: UserType | null;
   owner: WorkspaceType;
   currentPanel: ConversationSidePanelType;
   resetConversation: () => void;
@@ -105,7 +105,7 @@ function PreviewContent({
     <>
       <div className={currentPanel ? "hidden" : "flex h-full flex-col"}>
         <div className="flex-1 overflow-y-auto px-4">
-          {conversation && (
+          {conversation && user && (
             <ConversationViewer
               owner={owner}
               user={user}
@@ -206,7 +206,7 @@ export function AgentBuilderPreview() {
     return (
       <PreviewContent
         conversation={conversation}
-        user={user!}
+        user={user}
         owner={owner}
         currentPanel={currentPanel}
         resetConversation={resetConversation}

--- a/front/components/agent_builder/AgentBuilderPreview.tsx
+++ b/front/components/agent_builder/AgentBuilderPreview.tsx
@@ -1,4 +1,4 @@
-import { ArrowPathIcon, Button, Spinner } from "@dust-tt/sparkle";
+import { Button, Spinner } from "@dust-tt/sparkle";
 import React from "react";
 import { useFormContext } from "react-hook-form";
 
@@ -50,6 +50,7 @@ function LoadingState({ message }: LoadingStateProps) {
     </div>
   );
 }
+
 
 export function AgentBuilderPreview() {
   const { owner } = useAgentBuilderContext();
@@ -108,17 +109,6 @@ export function AgentBuilderPreview() {
     return (
       <>
         <div className={currentPanel ? "hidden" : "flex h-full flex-col"}>
-          {conversation && (
-            <div className="flex items-center justify-end px-6 py-3">
-              <Button
-                variant="outline"
-                size="sm"
-                icon={ArrowPathIcon}
-                onClick={resetConversation}
-                label="Reset conversation"
-              />
-            </div>
-          )}
           <div className="flex-1 overflow-y-auto px-4">
             {conversation && user && (
               <div className={currentPanel ? "hidden" : "block"}>
@@ -133,6 +123,15 @@ export function AgentBuilderPreview() {
               </div>
             )}
           </div>
+          {conversation && (
+            <div className="flex justify-center px-4">
+              <Button
+                variant="outline"
+                onClick={resetConversation}
+                label="Clear conversation"
+              />
+            </div>
+          )}
           <div className="flex-shrink-0 p-4">
             <AssistantInputBar
               disable={isSavingDraftAgent}

--- a/front/components/agent_builder/AgentBuilderPreview.tsx
+++ b/front/components/agent_builder/AgentBuilderPreview.tsx
@@ -1,4 +1,4 @@
-import { Button, Spinner } from "@dust-tt/sparkle";
+import { ArrowPathIcon, Button, Spinner } from "@dust-tt/sparkle";
 import { useContext } from "react";
 import { useFormContext } from "react-hook-form";
 
@@ -104,7 +104,7 @@ function PreviewContent({
   return (
     <>
       <div className={currentPanel ? "hidden" : "flex h-full flex-col"}>
-        <div className="flex-1 overflow-y-auto px-4">
+        <div className="flex-1 overflow-y-auto">
           {conversation && user && (
             <ConversationViewer
               owner={owner}
@@ -120,12 +120,13 @@ function PreviewContent({
           <div className="flex justify-center px-4">
             <Button
               variant="outline"
+              icon={ArrowPathIcon}
               onClick={resetConversation}
               label="Clear conversation"
             />
           </div>
         )}
-        <div className="flex-shrink-0 p-4">
+        <div className="flex-shrink-0 py-4">
           <AssistantInputBar
             disable={isSavingDraftAgent}
             owner={owner}

--- a/front/components/agent_builder/AgentBuilderPreview.tsx
+++ b/front/components/agent_builder/AgentBuilderPreview.tsx
@@ -109,10 +109,7 @@ export function AgentBuilderPreview() {
       <>
         <div className={currentPanel ? "hidden" : "flex h-full flex-col"}>
           {conversation && (
-            <div className="flex items-center justify-between px-6 py-3">
-              <h2 className="font-semibold text-foreground dark:text-foreground-night">
-                {conversation.title}
-              </h2>
+            <div className="flex items-center justify-end px-6 py-3">
               <Button
                 variant="outline"
                 size="sm"


### PR DESCRIPTION
## Description

This PR removes the title in the builder preview, removes the Reset conversations from the top right corner and moves it above the input bar. Clear conversation button is displayed conditionally above the input when the agent is not generating.

<img width="1503" height="698" alt="image" src="https://github.com/user-attachments/assets/123893b9-c9e5-4954-9eb2-cbde041c5400" />

## Tests

Locally

## Risk

Low, behind FF

## Deploy Plan

Deploy front
