### PR TITLE
[front] fix(nav): Force mount nav menu for SEO purpose

### DIFF
--- a/front/components/home/menu/MainNavigation.tsx
+++ b/front/components/home/menu/MainNavigation.tsx
@@ -1,6 +1,7 @@
 import { ChevronRightIcon, Icon } from "@dust-tt/sparkle";
 import Link from "next/link";
 import * as React from "react";
+import { useState } from "react";
 
 import { H4, Strong } from "@app/components/home/ContentComponents";
 import { menuConfig } from "@app/components/home/menu/config";
@@ -17,56 +18,59 @@ import { classNames } from "@app/lib/utils";
 import { appendUTMParams } from "@app/lib/utils/utm";
 
 export function MainNavigation() {
+  const [nav, setNav] = useState("");
   return (
-    <NavigationMenu className="mr-4 hidden xl:flex">
+    <NavigationMenu className="mr-4 hidden xl:flex" onValueChange={setNav}>
       <NavigationMenuList>
-        {menuConfig.mainNav.map((item, index) => {
-          return (
-            <NavigationMenuItem key={index}>
-              {item.href ? (
-                <Link
-                  href={
-                    item.isExternal ? item.href : appendUTMParams(item.href)
-                  }
-                  target={item.isExternal ? "_blank" : undefined}
-                  legacyBehavior
-                  passHref
+        {menuConfig.mainNav.map((item, index) => (
+          <NavigationMenuItem value={item.title} key={index}>
+            {item.href ? (
+              <Link
+                href={item.isExternal ? item.href : appendUTMParams(item.href)}
+                target={item.isExternal ? "_blank" : undefined}
+                legacyBehavior
+                passHref
+              >
+                <NavigationMenuLink className={navigationMenuTriggerStyle()}>
+                  {item.title}
+                </NavigationMenuLink>
+              </Link>
+            ) : (
+              <React.Fragment key={`${index}-nav-fragment`}>
+                <NavigationMenuTrigger>{item.title}</NavigationMenuTrigger>
+                <NavigationMenuContent
+                  forceMount
+                  className={classNames(
+                    `opacity-0 data-[state=closed]:hidden`,
+                    nav === item.title && "block opacity-100"
+                  )}
                 >
-                  <NavigationMenuLink className={navigationMenuTriggerStyle()}>
-                    {item.title}
-                  </NavigationMenuLink>
-                </Link>
-              ) : (
-                <React.Fragment key={index}>
-                  <NavigationMenuTrigger>{item.title}</NavigationMenuTrigger>
-                  <NavigationMenuContent>
-                    <div className="flex flex-col gap-4 p-6 pb-8">
-                      <H4 className="text-muted-foreground" mono>
-                        {item.label}
-                      </H4>
-                      <ul
-                        className={classNames(
-                          "grid-rows-" + item.rows,
-                          "grid w-full grid-flow-col gap-x-8 gap-y-4"
-                        )}
-                      >
-                        {item.items &&
-                          item.items.map((item) => (
-                            <ListItem
-                              key={item.title}
-                              title={item.title}
-                              href={item.href}
-                              isExternal={item.isExternal}
-                            />
-                          ))}
-                      </ul>
-                    </div>
-                  </NavigationMenuContent>
-                </React.Fragment>
-              )}
-            </NavigationMenuItem>
-          );
-        })}
+                  <div className="flex flex-col gap-4 p-6 pb-8">
+                    <H4 className="text-muted-foreground" mono>
+                      {item.label}
+                    </H4>
+                    <ul
+                      className={classNames(
+                        "grid-rows-" + item.rows,
+                        "grid w-full grid-flow-col gap-x-8 gap-y-4"
+                      )}
+                    >
+                      {item.items &&
+                        item.items.map((item) => (
+                          <ListItem
+                            key={item.title}
+                            title={item.title}
+                            href={item.href}
+                            isExternal={item.isExternal}
+                          />
+                        ))}
+                    </ul>
+                  </div>
+                </NavigationMenuContent>
+              </React.Fragment>
+            )}
+          </NavigationMenuItem>
+        ))}
       </NavigationMenuList>
     </NavigationMenu>
   );


### PR DESCRIPTION
## Description
We use [radix navigation-menu](https://www.radix-ui.com/primitives/docs/components/navigation-menu) for the menu of the public website. It currently hide the links inside `NavigationContent`, which makes it doesn't help our SEO and search provider finding the links. It's a know issue at radix https://github.com/radix-ui/primitives/issues/1273 or https://github.com/radix-ui/primitives/issues/1155

Based on comments, found a hacky way to make those links appear. We `forceMount` the content, and use basic `hidden` and `opacity` switch to display/hide the displayed item.

## Tests
- Locally, no flashing at mount, didn't notice a change

## Risk
- Low, just menu display, easy to revert.

## Deploy Plan
- Deploy front
