### PR TITLE
[connectors] github: ignore undici termination error

### DIFF
--- a/connectors/src/connectors/github/temporal/worker.ts
+++ b/connectors/src/connectors/github/temporal/worker.ts
@@ -14,6 +14,18 @@ import logger from "@connectors/logger/logger";
 
 export async function runGithubWorker() {
   const { connection, namespace } = await getTemporalWorkerConnection();
+
+  process.on("unhandledRejection", (reason) => {
+    if (
+      reason instanceof Error &&
+      reason.message.includes("other side closed")
+    ) {
+      logger.info({ error: reason }, "Undici connection cleanup (ignored)");
+      return;
+    }
+    throw reason;
+  });
+
   const worker = await Worker.create({
     workflowsPath: require.resolve("./workflows"),
     activities: {

--- a/connectors/src/connectors/github/temporal/worker.ts
+++ b/connectors/src/connectors/github/temporal/worker.ts
@@ -15,15 +15,16 @@ import logger from "@connectors/logger/logger";
 export async function runGithubWorker() {
   const { connection, namespace } = await getTemporalWorkerConnection();
 
-  process.on("unhandledRejection", (reason) => {
+  process.on("uncaughtException", (error) => {
     if (
-      reason instanceof Error &&
-      reason.message.includes("other side closed")
+      error instanceof Error &&
+      error.message.includes("terminated: other side closed")
     ) {
-      logger.info({ error: reason }, "Undici connection cleanup (ignored)");
+      logger.warn({ error }, "Undici connection cleanup error (ignored)");
       return;
     }
-    throw reason;
+
+    throw error;
   });
 
   const worker = await Worker.create({


### PR DESCRIPTION
## Description

Unhanlded exception with "other side closed" can happen in github worker as octokit is using connection pool with undici  - connections are closed outside of temporal context and can throw exception here.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

none, mainly removes a panic log

## Deploy Plan

deploy connector
