### PR TITLE
[front] feat(abv2): Revamp knowledge

### DIFF
--- a/front/components/agent_builder/capabilities/shared/DescriptionSection.tsx
+++ b/front/components/agent_builder/capabilities/shared/DescriptionSection.tsx
@@ -30,7 +30,9 @@ export function DescriptionSection({
     <div className="space-y-4">
       <div>
         <h3 className="mb-2 text-lg font-semibold">{title}</h3>
-        <p className="text-sm text-muted-foreground">{description}</p>
+        <p className="text-sm text-muted-foreground dark:text-muted-foreground-night">
+          {description}
+        </p>
       </div>
 
       <div className="space-y-2">
@@ -43,7 +45,9 @@ export function DescriptionSection({
           error={fieldState.error?.message}
         />
         {helpText && (
-          <p className="text-xs text-muted-foreground">{helpText}</p>
+          <p className="text-xs text-muted-foreground dark:text-muted-foreground-night">
+            {helpText}
+          </p>
         )}
       </div>
     </div>

--- a/front/components/agent_builder/capabilities/shared/NameSection.tsx
+++ b/front/components/agent_builder/capabilities/shared/NameSection.tsx
@@ -29,7 +29,9 @@ export function NameSection({
     <div className="space-y-4">
       <div>
         <h3 className="mb-2 text-lg font-semibold">{title}</h3>
-        <p className="text-sm text-muted-foreground">{description}</p>
+        <p className="text-sm text-muted-foreground dark:text-muted-foreground-night">
+          {description}
+        </p>
       </div>
 
       <div className="space-y-2">
@@ -41,7 +43,9 @@ export function NameSection({
           messageStatus={fieldState.error ? "error" : "default"}
         />
         {helpText && (
-          <p className="text-xs text-muted-foreground">{helpText}</p>
+          <p className="text-xs text-muted-foreground dark:text-muted-foreground-night">
+            {helpText}
+          </p>
         )}
       </div>
     </div>

--- a/front/components/agent_builder/capabilities/shared/ProcessingMethodSection.tsx
+++ b/front/components/agent_builder/capabilities/shared/ProcessingMethodSection.tsx
@@ -112,7 +112,7 @@ export function ProcessingMethodSection() {
             />
           </DropdownMenuTrigger>
 
-          <DropdownMenuContent>
+          <DropdownMenuContent align="start">
             {mcpServerViewsWithKnowledge
               .filter((view) =>
                 hasOnlyTablesSelected

--- a/front/components/agent_builder/capabilities/shared/ProcessingMethodSection.tsx
+++ b/front/components/agent_builder/capabilities/shared/ProcessingMethodSection.tsx
@@ -20,9 +20,12 @@ import {
   isInternalAllowedIcon,
 } from "@app/lib/actions/mcp_icons";
 import {
-  QUERY_TABLES_TOOL_NAME,
-  SEARCH_TOOL_NAME,
+  SEARCH_SERVER_NAME,
+  TABLE_QUERY_SERVER_NAME,
+  TABLE_QUERY_V2_SERVER_NAME,
 } from "@app/lib/actions/mcp_internal_actions/constants";
+
+const tablesServer = [TABLE_QUERY_SERVER_NAME, TABLE_QUERY_V2_SERVER_NAME];
 
 export function ProcessingMethodSection() {
   const { mcpServerViewsWithKnowledge, isMCPServerViewsLoading } =
@@ -64,7 +67,7 @@ export function ProcessingMethodSection() {
       const tableServer = mcpServerViewsWithKnowledge.find(
         (serverView) =>
           serverView.serverType === "internal" &&
-          serverView.server.name === QUERY_TABLES_TOOL_NAME
+          tablesServer.includes(serverView.server.name)
       );
       if (tableServer) {
         onChange(tableServer);
@@ -73,7 +76,7 @@ export function ProcessingMethodSection() {
       const searchServer = mcpServerViewsWithKnowledge.find(
         (serverView) =>
           serverView.serverType === "internal" &&
-          serverView.server.name === SEARCH_TOOL_NAME
+          serverView.server.name === SEARCH_SERVER_NAME
       );
       if (searchServer) {
         onChange(searchServer);
@@ -84,7 +87,9 @@ export function ProcessingMethodSection() {
   return (
     <div className="space-y-4">
       <div>
-        <h3 className="mb-2 text-lg font-semibold">Processing method</h3>
+        <h3 className="mb-2 text-lg font-semibold">
+          Processing method {hasOnlyTablesSelected ? "yes" : "no"}
+        </h3>
       </div>
 
       <div className="space-y-2">
@@ -111,8 +116,8 @@ export function ProcessingMethodSection() {
             {mcpServerViewsWithKnowledge
               .filter((view) =>
                 hasOnlyTablesSelected
-                  ? view.server.name === QUERY_TABLES_TOOL_NAME
-                  : view.server.name !== QUERY_TABLES_TOOL_NAME
+                  ? tablesServer.includes(view.server.name)
+                  : !tablesServer.includes(view.server.name)
               )
               .map((view) => (
                 <DropdownMenuItem

--- a/front/components/agent_builder/capabilities/shared/ProcessingMethodSection.tsx
+++ b/front/components/agent_builder/capabilities/shared/ProcessingMethodSection.tsx
@@ -1,0 +1,101 @@
+import {
+  Button,
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "@dust-tt/sparkle";
+import { useEffect, useMemo } from "react";
+import { useController, useWatch } from "react-hook-form";
+
+import { useMCPServerViewsContext } from "@app/components/agent_builder/MCPServerViewsContext";
+import type { CapabilityFormData } from "@app/components/agent_builder/types";
+import {
+  getMcpServerViewDescription,
+  getMcpServerViewDisplayName,
+} from "@app/lib/actions/mcp_helper";
+import {
+  getAvatar,
+  InternalActionIcons,
+  isInternalAllowedIcon,
+} from "@app/lib/actions/mcp_icons";
+
+export function ProcessingMethodSection() {
+  const { mcpServerViewsWithKnowledge, isMCPServerViewsLoading } =
+    useMCPServerViewsContext();
+  const {
+    field: { value: mcpServerView, onChange },
+  } = useController<CapabilityFormData, "mcpServerView">({
+    name: "mcpServerView",
+  });
+  const sources = useWatch<CapabilityFormData, "sources">({ name: "sources" });
+
+  const hasOnlyTablesSelected = useMemo(() => {
+    if (!sources?.in?.length) {
+      return false;
+    }
+
+    return sources.in.every((item) => {
+      // Check if the item is a node and has table type
+      if (item.type === "node" && item.node) {
+        return item.node.type === "table";
+      }
+      return false;
+    });
+  }, [sources]);
+
+  useEffect(() => {
+    if (hasOnlyTablesSelected) {
+      const tableServer = mcpServerViewsWithKnowledge.find(
+        (serverView) =>
+          serverView.serverType === "internal" &&
+          serverView.server.name === "query_tables"
+      );
+      if (tableServer) {
+        onChange(tableServer);
+      }
+    }
+  }, [hasOnlyTablesSelected, mcpServerViewsWithKnowledge, onChange]);
+
+  return (
+    <div className="space-y-4">
+      <div>
+        <h3 className="mb-2 text-lg font-semibold">Processing method</h3>
+      </div>
+
+      <div className="space-y-2">
+        <DropdownMenu>
+          <DropdownMenuTrigger asChild>
+            <Button
+              isLoading={isMCPServerViewsLoading}
+              label={
+                mcpServerView
+                  ? getMcpServerViewDisplayName(mcpServerView)
+                  : "loading..."
+              }
+              icon={
+                mcpServerView != null &&
+                isInternalAllowedIcon(mcpServerView.server.icon)
+                  ? InternalActionIcons[mcpServerView.server.icon]
+                  : undefined
+              }
+              variant="outline"
+            />
+          </DropdownMenuTrigger>
+
+          <DropdownMenuContent>
+            {mcpServerViewsWithKnowledge.map((view) => (
+              <DropdownMenuItem
+                key={view.id}
+                label={getMcpServerViewDisplayName(view)}
+                icon={getAvatar(view.server)}
+                onClick={() => onChange(view)}
+                description={getMcpServerViewDescription(view)}
+              />
+            ))}
+          </DropdownMenuContent>
+        </DropdownMenu>
+      </div>
+    </div>
+  );
+}

--- a/front/components/agent_builder/capabilities/shared/ProcessingMethodSection.tsx
+++ b/front/components/agent_builder/capabilities/shared/ProcessingMethodSection.tsx
@@ -19,6 +19,10 @@ import {
   InternalActionIcons,
   isInternalAllowedIcon,
 } from "@app/lib/actions/mcp_icons";
+import {
+  QUERY_TABLES_TOOL_NAME,
+  SEARCH_TOOL_NAME,
+} from "@app/lib/actions/mcp_internal_actions/constants";
 
 export function ProcessingMethodSection() {
   const { mcpServerViewsWithKnowledge, isMCPServerViewsLoading } =
@@ -60,7 +64,7 @@ export function ProcessingMethodSection() {
       const tableServer = mcpServerViewsWithKnowledge.find(
         (serverView) =>
           serverView.serverType === "internal" &&
-          serverView.server.name === "query_tables"
+          serverView.server.name === QUERY_TABLES_TOOL_NAME
       );
       if (tableServer) {
         onChange(tableServer);
@@ -69,7 +73,7 @@ export function ProcessingMethodSection() {
       const searchServer = mcpServerViewsWithKnowledge.find(
         (serverView) =>
           serverView.serverType === "internal" &&
-          serverView.server.name === "search"
+          serverView.server.name === SEARCH_TOOL_NAME
       );
       if (searchServer) {
         onChange(searchServer);
@@ -107,8 +111,8 @@ export function ProcessingMethodSection() {
             {mcpServerViewsWithKnowledge
               .filter((view) =>
                 hasOnlyTablesSelected
-                  ? view.server.name === "query_tables"
-                  : view.server.name !== "query_tables"
+                  ? view.server.name === QUERY_TABLES_TOOL_NAME
+                  : view.server.name !== QUERY_TABLES_TOOL_NAME
               )
               .map((view) => (
                 <DropdownMenuItem

--- a/front/components/agent_builder/types.ts
+++ b/front/components/agent_builder/types.ts
@@ -52,7 +52,6 @@ export const DESCRIPTION_MAX_LENGTH = 800;
 export type CapabilityFormData = z.infer<typeof capabilityFormSchema>;
 
 export const CONFIGURATION_SHEET_PAGE_IDS = {
-  MCP_SERVER_SELECTION: "mcp-server-selection",
   DATA_SOURCE_SELECTION: "data-source-selection",
   CONFIGURATION: "configuration",
 } as const;

--- a/front/components/me/UserToolsTable.tsx
+++ b/front/components/me/UserToolsTable.tsx
@@ -27,7 +27,7 @@ interface UserTableRow {
   description: string;
   serverView: MCPServerViewType;
   connection: MCPServerConnectionType | undefined;
-  visual: React.ReactNode;
+  visual: React.JSX.Element;
   onClick?: () => void;
   moreMenuItems?: any[];
 }

--- a/front/lib/actions/mcp_icons.tsx
+++ b/front/lib/actions/mcp_icons.tsx
@@ -92,14 +92,14 @@ export const isInternalAllowedIcon = (
 export const getAvatar = (
   mcpServer: MCPServerType,
   size: ComponentProps<typeof Avatar>["size"] = "sm"
-): React.ReactNode => {
+) => {
   return getAvatarFromIcon(mcpServer.icon, size);
 };
 
 export const getAvatarFromIcon = (
   icon: InternalAllowedIconType | CustomServerIconType,
   size: ComponentProps<typeof Avatar>["size"] = "sm"
-): React.ReactNode => {
+) => {
   if (isCustomServerIconType(icon)) {
     return <Avatar icon={ActionIcons[icon]} size={size} />;
   }

--- a/front/lib/actions/mcp_internal_actions/constants.ts
+++ b/front/lib/actions/mcp_internal_actions/constants.ts
@@ -26,6 +26,10 @@ export const FILESYSTEM_FIND_TOOL_NAME = "find";
 export const FILESYSTEM_LOCATE_IN_TREE_TOOL_NAME = "locate_in_tree";
 export const FILESYSTEM_LIST_TOOL_NAME = "list";
 
+export const SEARCH_SERVER_NAME = "search";
+export const TABLE_QUERY_SERVER_NAME = "query_tables";
+export const TABLE_QUERY_V2_SERVER_NAME = "query_tables_v2";
+
 export const AVAILABLE_INTERNAL_MCP_SERVER_NAMES = [
   // Note:
   // Names should reflect the purpose of the server but not directly the tools it contains.
@@ -51,13 +55,13 @@ export const AVAILABLE_INTERNAL_MCP_SERVER_NAMES = [
   "notion",
   "outlook",
   "primitive_types_debugger",
-  "query_tables",
-  "query_tables_v2",
+  TABLE_QUERY_SERVER_NAME,
+  TABLE_QUERY_V2_SERVER_NAME,
   "reasoning",
   "run_agent",
   "run_dust_app",
   "salesforce",
-  "search",
+  SEARCH_SERVER_NAME,
   "think",
   "web_search_&_browse",
   "google_calendar",

--- a/front/lib/actions/mcp_internal_actions/servers/search.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/search.ts
@@ -7,6 +7,7 @@ import { z } from "zod";
 import { MCPError } from "@app/lib/actions/mcp_errors";
 import {
   FIND_TAGS_TOOL_NAME,
+  SEARCH_SERVER_NAME,
   SEARCH_TOOL_NAME,
 } from "@app/lib/actions/mcp_internal_actions/constants";
 import type { DataSourcesToolConfigurationType } from "@app/lib/actions/mcp_internal_actions/input_schemas";
@@ -45,7 +46,7 @@ import {
 } from "@app/types";
 
 const serverInfo: InternalMCPServerDefinitionType = {
-  name: "search",
+  name: SEARCH_SERVER_NAME,
   version: "1.0.0",
   description: "Search through selected Data sources",
   icon: "ActionMagnifyingGlassIcon",

--- a/front/lib/actions/mcp_internal_actions/servers/tables_query/server.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/tables_query/server.ts
@@ -43,7 +43,7 @@ const RENDERED_CONVERSATION_MIN_TOKEN = 4_000;
 export const TABLES_QUERY_SECTION_FILE_MIN_COLUMN_LENGTH = 500;
 
 const serverInfo: InternalMCPServerDefinitionType = {
-  name: "query_tables",
+  name: QUERY_TABLES_TOOL_NAME,
   version: "1.0.0",
   description: "Tables, Spreadsheets, Notion DBs (quantitative).",
   icon: "ActionTableIcon",

--- a/front/lib/actions/mcp_internal_actions/servers/tables_query/server.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/tables_query/server.ts
@@ -6,7 +6,10 @@ import {
   generateSectionFile,
   uploadFileToConversationDataSource,
 } from "@app/lib/actions/action_file_helpers";
-import { QUERY_TABLES_TOOL_NAME } from "@app/lib/actions/mcp_internal_actions/constants";
+import {
+  QUERY_TABLES_TOOL_NAME,
+  TABLE_QUERY_SERVER_NAME,
+} from "@app/lib/actions/mcp_internal_actions/constants";
 import { ConfigurableToolInputSchemas } from "@app/lib/actions/mcp_internal_actions/input_schemas";
 import type {
   ExecuteTablesQueryErrorResourceType,
@@ -43,7 +46,7 @@ const RENDERED_CONVERSATION_MIN_TOKEN = 4_000;
 export const TABLES_QUERY_SECTION_FILE_MIN_COLUMN_LENGTH = 500;
 
 const serverInfo: InternalMCPServerDefinitionType = {
-  name: QUERY_TABLES_TOOL_NAME,
+  name: TABLE_QUERY_SERVER_NAME,
   version: "1.0.0",
   description: "Tables, Spreadsheets, Notion DBs (quantitative).",
   icon: "ActionTableIcon",

--- a/front/lib/actions/mcp_internal_actions/servers/tables_query/server.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/tables_query/server.ts
@@ -37,7 +37,7 @@ type TablesQueryOutputResources =
   | ExecuteTablesQueryErrorResourceType
   | ToolGeneratedFileType;
 
-export // We need a model with at least 54k tokens to run tables_query.
+// We need a model with at least 54k tokens to run tables_query.
 const TABLES_QUERY_MIN_TOKEN = 50_000;
 const RENDERED_CONVERSATION_MIN_TOKEN = 4_000;
 export const TABLES_QUERY_SECTION_FILE_MIN_COLUMN_LENGTH = 500;


### PR DESCRIPTION
## Description
- https://github.com/dust-tt/tasks/issues/3839
- Move the processing method selection after selecting the knowledge
- Infer the tool based on the data selected
  - If there only documents ➡️ `search`
  - if there is only tables ➡️ `query_tables`
  - if there is a mix of both ➡️ `search` + show a message saying tables will be ignored
- Only show Knowledge footer when selecting knowledge

## Tests
- Locally
<img width="898" height="595" alt="Capture d’écran 2025-08-21 à 10 59 34" src="https://github.com/user-attachments/assets/92bd4ccc-d4f8-4a9a-b866-91d6dd9617d2" />


## Risk
- Low, just moved stuff around behind a FF

## Deploy Plan
- Deploy front
