### PR TITLE
[connectors] move handler

### DIFF
--- a/connectors/src/connectors/github/temporal/worker.ts
+++ b/connectors/src/connectors/github/temporal/worker.ts
@@ -15,18 +15,6 @@ import logger from "@connectors/logger/logger";
 export async function runGithubWorker() {
   const { connection, namespace } = await getTemporalWorkerConnection();
 
-  process.on("uncaughtException", (error) => {
-    if (
-      error instanceof Error &&
-      error.message.includes("terminated: other side closed")
-    ) {
-      logger.warn({ error }, "Undici connection cleanup error (ignored)");
-      return;
-    }
-
-    throw error;
-  });
-
   const worker = await Worker.create({
     workflowsPath: require.resolve("./workflows"),
     activities: {

--- a/connectors/src/types/shared/utils/global_error_handler.ts
+++ b/connectors/src/types/shared/utils/global_error_handler.ts
@@ -23,6 +23,15 @@ export function setupGlobalErrorHandler(logger: LoggerInterface) {
   });
 
   process.on("uncaughtException", (error) => {
+    if (
+      error instanceof Error &&
+      (error.message.includes("other side closed") ||
+        error.message.includes("ECONNRESET"))
+    ) {
+      logger.warn({ error }, "Undici connection cleanup error (ignored)");
+      return;
+    }
+
     logger.error({ error, panic: true }, "Uncaught Exception");
   });
 }


### PR DESCRIPTION
## Description

Only one uncaughtException handler is allowed , move handling to global_eror_handler to keep panic log and avoid pod crash

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

deploy connectors
