### PR TITLE
[front] feat(nav): Better handling of nav for SEO

### DIFF
--- a/front/components/home/menu/MainNavigation.tsx
+++ b/front/components/home/menu/MainNavigation.tsx
@@ -17,12 +17,14 @@ import { classNames } from "@app/lib/utils";
 import { appendUTMParams } from "@app/lib/utils/utm";
 
 export function MainNavigation() {
+  const [nav, setNav] = React.useState("");
+
   return (
-    <NavigationMenu className="mr-4 hidden xl:flex">
+    <NavigationMenu className="mr-4 hidden xl:flex" onValueChange={setNav}>
       <NavigationMenuList>
         {menuConfig.mainNav.map((item, index) => {
           return (
-            <NavigationMenuItem key={index}>
+            <NavigationMenuItem key={index} value={item.title}>
               {item.href ? (
                 <Link
                   href={
@@ -39,7 +41,14 @@ export function MainNavigation() {
               ) : (
                 <React.Fragment key={index}>
                   <NavigationMenuTrigger>{item.title}</NavigationMenuTrigger>
-                  <NavigationMenuContent>
+                  <NavigationMenuContent
+                    forceMount
+                    className={classNames(
+                      nav === item.title
+                        ? "block h-auto opacity-100"
+                        : "hidden h-0 opacity-0"
+                    )}
+                  >
                     <div className="flex flex-col gap-4 p-6 pb-8">
                       <H4 className="text-muted-foreground" mono>
                         {item.label}


### PR DESCRIPTION
## Description
- Follow up of https://github.com/dust-tt/dust/pull/15213
- Properly handle the forceMount and display/hide of the nav. From the previous PR it was still "displaying" the components above the other nav menu.

## Tests
- Locally

## Risk
- Low, easy to revert

## Deploy Plan
- Deploy front
