### PR TITLE
[front] Correctly set action status to "succeeded"

### DIFF
--- a/front/lib/actions/mcp.ts
+++ b/front/lib/actions/mcp.ts
@@ -638,6 +638,10 @@ export async function* runToolWithStreaming(
 
   statsDClient.increment("mcp_actions_success.count", 1, tags);
 
+  await action.update({
+    status: "succeeded",
+  });
+
   yield {
     type: "tool_success",
     created: Date.now(),


### PR DESCRIPTION
## Description

- This PR correctly sets the status of an `AgentMCPAction` to `succeeded` on successful executions.

## Tests

- Checked locally.

## Risk

- Low, field unused for now.

## Deploy Plan

- Deploy front.
