### PR TITLE
[front] move AC id to sid in trigger

### DIFF
--- a/front/lib/models/assistant/triggers.ts
+++ b/front/lib/models/assistant/triggers.ts
@@ -93,3 +93,8 @@ TriggerModel.init(
 TriggerModel.belongsTo(UserModel, {
   foreignKey: { name: "editor", allowNull: false },
 });
+
+TriggerModel.belongsTo(AgentConfiguration, {
+  foreignKey: { name: "agentConfigurationId", allowNull: false },
+  targetKey: "sId",
+});

--- a/front/lib/models/assistant/triggers.ts
+++ b/front/lib/models/assistant/triggers.ts
@@ -21,7 +21,11 @@ export class TriggerModel extends WorkspaceAwareModel<TriggerModel> {
   declare kind: TriggerKind;
   declare customPrompt: string | null;
 
-  declare agentConfigurationId: ForeignKey<AgentConfiguration["id"]>;
+  /**
+   * We use the sId, because it's static between an agent versions,
+   * whereas the id is dynamic and changes with each new agent version.
+   */
+  declare agentConfigurationId: ForeignKey<AgentConfiguration["sId"]>;
   declare editor: ForeignKey<UserModel["id"]>;
 
   declare configuration: TriggerConfigurationType;
@@ -40,6 +44,10 @@ TriggerModel.init(
       defaultValue: DataTypes.NOW,
     },
     sId: {
+      type: DataTypes.STRING,
+      allowNull: false,
+    },
+    agentConfigurationId: {
       type: DataTypes.STRING,
       allowNull: false,
     },
@@ -82,9 +90,6 @@ TriggerModel.init(
   }
 );
 
-TriggerModel.belongsTo(AgentConfiguration, {
-  foreignKey: { name: "agentConfigurationId", allowNull: false },
-});
 TriggerModel.belongsTo(UserModel, {
   foreignKey: { name: "editor", allowNull: false },
 });

--- a/front/lib/models/assistant/triggers.ts
+++ b/front/lib/models/assistant/triggers.ts
@@ -93,8 +93,3 @@ TriggerModel.init(
 TriggerModel.belongsTo(UserModel, {
   foreignKey: { name: "editor", allowNull: false },
 });
-
-TriggerModel.belongsTo(AgentConfiguration, {
-  foreignKey: { name: "agentConfigurationId", allowNull: false },
-  targetKey: "sId",
-});

--- a/front/lib/models/assistant/triggers.ts
+++ b/front/lib/models/assistant/triggers.ts
@@ -1,7 +1,7 @@
 import type { CreationOptional, ForeignKey } from "sequelize";
 import { DataTypes } from "sequelize";
 
-import { AgentConfiguration } from "@app/lib/models/assistant/agent";
+import type { AgentConfiguration } from "@app/lib/models/assistant/agent";
 import { frontSequelize } from "@app/lib/resources/storage";
 import { UserModel } from "@app/lib/resources/storage/models/user";
 import { WorkspaceAwareModel } from "@app/lib/resources/storage/wrappers/workspace_models";

--- a/front/lib/resources/trigger_resource.ts
+++ b/front/lib/resources/trigger_resource.ts
@@ -163,7 +163,6 @@ export class TriggerResource extends BaseResource<TriggerModel> {
       async (trigger) => {
         const r = await deleteAgentScheduleWorkflow({
           workspaceId: workspace.sId,
-          agentConfigurationId: trigger.agentConfigurationId,
           triggerId: trigger.sId,
         });
         if (r.isErr()) {
@@ -209,7 +208,6 @@ export class TriggerResource extends BaseResource<TriggerModel> {
       case "schedule":
         return deleteAgentScheduleWorkflow({
           workspaceId: auth.getNonNullableWorkspace().sId,
-          agentConfigurationId: this.agentConfigurationId,
           triggerId: this.sId,
         });
       default:

--- a/front/migrations/db/migration_341.sql
+++ b/front/migrations/db/migration_341.sql
@@ -1,0 +1,4 @@
+-- Migration created on Aug 21, 2025
+ALTER TABLE "triggers" ALTER COLUMN "agentConfigurationId" SET NOT NULL;
+ALTER TABLE "triggers" ALTER COLUMN "agentConfigurationId" DROP DEFAULT;
+ALTER TABLE "triggers" ALTER COLUMN "agentConfigurationId" TYPE VARCHAR(255);

--- a/front/migrations/db/migration_341.sql
+++ b/front/migrations/db/migration_341.sql
@@ -1,4 +1,6 @@
 -- Migration created on Aug 21, 2025
+ALTER TABLE "triggers" DROP CONSTRAINT IF EXISTS "triggers_agentConfigurationId_fkey";
+
 ALTER TABLE "triggers" ALTER COLUMN "agentConfigurationId" SET NOT NULL;
 ALTER TABLE "triggers" ALTER COLUMN "agentConfigurationId" DROP DEFAULT;
 ALTER TABLE "triggers" ALTER COLUMN "agentConfigurationId" TYPE VARCHAR(255);

--- a/front/temporal/agent_schedule/client.ts
+++ b/front/temporal/agent_schedule/client.ts
@@ -122,7 +122,6 @@ export async function deleteAgentScheduleWorkflow({
   triggerId,
 }: {
   workspaceId: string;
-  agentConfigurationId: number;
   triggerId: string;
 }): Promise<Result<void, Error>> {
   const client = await getTemporalClientForAgentNamespace();

--- a/front/types/assistant/triggers.ts
+++ b/front/types/assistant/triggers.ts
@@ -16,7 +16,7 @@ export type TriggerType = {
   sId: string;
   name: string;
   description: string;
-  agentConfigurationId: AgentConfigurationType["id"];
+  agentConfigurationId: AgentConfigurationType["sId"];
   editor: UserType["id"];
   customPrompt: string | null;
 } & TriggerConfiguration;


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

We need to move the id to the sId for the agent configuration foreign key.
SID is static between ac versions, not the id.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

Not used

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

Low

## Deploy Plan

Migrate
Deploy front