### PR TITLE
[front] Fix group-based role assignment logic

### DIFF
--- a/front/temporal/workos_events_queue/activities.ts
+++ b/front/temporal/workos_events_queue/activities.ts
@@ -98,15 +98,7 @@ async function handleRoleAssignmentForGroup({
   group: GroupResource;
   action: "add" | "remove";
 }) {
-  let targetRole: MembershipRoleType | null = null;
-
-  if (group.name === ADMIN_GROUP_NAME) {
-    targetRole = "admin";
-  } else if (group.name === BUILDER_GROUP_NAME) {
-    targetRole = "builder";
-  }
-
-  if (!targetRole) {
+  if (group.name !== ADMIN_GROUP_NAME && group.name !== BUILDER_GROUP_NAME) {
     // Not a special group, no role assignment needed.
     return;
   }
@@ -125,25 +117,22 @@ async function handleRoleAssignmentForGroup({
   }
 
   if (action === "add") {
-    // Assign the target role if user doesn't already have it or a higher role.
-    const shouldAssignRole =
-      (targetRole === "admin" && currentMembership.role !== "admin") ||
-      (targetRole === "builder" && currentMembership.role === "user");
+    const newRole = await getRoleFromGroupMemberships(workspace, user);
 
-    if (shouldAssignRole) {
+    if (newRole !== currentMembership.role) {
       const updateResult = await MembershipResource.updateMembershipRole({
         user,
         workspace,
-        newRole: targetRole,
+        newRole,
       });
 
       if (updateResult.isErr()) {
         logger.error(
-          { error: updateResult.error, userId: user.sId, role: targetRole },
-          `Failed to assign ${targetRole} role to user`
+          { error: updateResult.error, userId: user.sId, role: newRole },
+          `Failed to assign ${newRole} role to user`
         );
         throw new Error(
-          `Failed to assign ${targetRole} role to user ${user.sId}: ${updateResult.error.type}`
+          `Failed to assign ${newRole} role to user ${user.sId}: ${updateResult.error.type}`
         );
       }
 
@@ -151,31 +140,23 @@ async function handleRoleAssignmentForGroup({
         {
           userId: user.sId,
           oldRole: currentMembership.role,
-          newRole: targetRole,
+          newRole,
           groupName: group.name,
         },
-        `Assigned ${targetRole} role to user based on group membership`
+        `Assigned ${newRole} role to user based on group membership`
       );
 
       void ServerSideTracking.trackUpdateMembershipRole({
         user: user.toJSON(),
         workspace,
         previousRole: currentMembership.role,
-        role: targetRole,
+        role: newRole,
       });
     }
   } else if (action === "remove") {
-    // Check if the user should lose their role when removed from the group.
-    // We need to check if they're still in other groups that grant the same or higher role.
-    const shouldDowngradeRole = await shouldDowngradeUserRole(
-      workspace,
-      user,
-      targetRole
-    );
+    const newRole = await getRoleFromGroupMemberships(workspace, user);
 
-    if (shouldDowngradeRole) {
-      const newRole = targetRole === "admin" ? "builder" : "user";
-
+    if (newRole !== currentMembership.role) {
       const updateResult = await MembershipResource.updateMembershipRole({
         user,
         workspace,
@@ -215,31 +196,33 @@ async function handleRoleAssignmentForGroup({
 /**
  * Check if the user should be downgraded when removed from a role-granting group.
  */
-async function shouldDowngradeUserRole(
+async function getRoleFromGroupMemberships(
   workspace: LightWorkspaceType,
-  user: UserResource,
-  roleBeingRemoved: MembershipRoleType
-): Promise<boolean> {
+  user: UserResource
+): Promise<MembershipRoleType> {
   // Get all groups the user is a member of.
   const userGroups = await GroupResource.listUserGroupsInWorkspace({
     user,
     workspace,
   });
 
-  // Check if user is still in any groups that grant the same or higher role.
+  let atLeastBuilder = false;
+
   for (const group of userGroups) {
-    if (
-      (group.name === ADMIN_GROUP_NAME &&
-        (roleBeingRemoved === "admin" || roleBeingRemoved === "builder")) ||
-      (group.name === BUILDER_GROUP_NAME && roleBeingRemoved === "builder")
-    ) {
-      // User is still in a group that grants this role or higher.
-      return false;
+    if (group.name === ADMIN_GROUP_NAME) {
+      return "admin";
+    }
+    if (group.name === BUILDER_GROUP_NAME) {
+      atLeastBuilder = true;
     }
   }
+  // If we're here, the user is not in the admin group.
+  if (atLeastBuilder) {
+    return "builder";
+  }
 
-  // User is not in any other groups that grant this role.
-  return true;
+  // Did not find any group granting a role, so the user should be a regular user.
+  return "user";
 }
 
 // WorkOS webhooks do not guarantee event ordering. Events can arrive out of sequence.


### PR DESCRIPTION
## Description

- This PR fixes an issue in the `dust-builders` and `dust-admins` group assignment: when removing a user from `dust-admins` we used to always set it to `builder`, instead the user should be `builder` if they are still in `dust-builders` and `user` otherwise.
- This PR refactors the way the assignment is done by directly checking what the target role is based on the groups (in `handleRoleAssignmentForGroup` the user was already added or removed from the group).

## Tests

- Tested locally using our Okta (made a runbook [here](https://www.notion.so/dust-tt/Runbook-Test-WorkOS-Directory-Sync-Locally-Okta-ngrok-25628599d94180a49e52d07975b2b881))

## Risk

- Medium, affects the role assignment but only changes something on addition/removal from group.

## Deploy Plan

- Deploy front.
