### PR TITLE
[sparkle] - fix(MultiPageSheet): footer API

### DIFF
--- a/sparkle/src/components/MultiPageSheet.tsx
+++ b/sparkle/src/components/MultiPageSheet.tsx
@@ -21,6 +21,7 @@ interface MultiPageSheetPage {
   icon?: React.ComponentType;
   content: React.ReactNode;
   fixedContent?: React.ReactNode;
+  footerContent?: React.ReactNode;
 }
 
 interface MultiPageSheetProps {
@@ -32,7 +33,6 @@ interface MultiPageSheetProps {
   trapFocusScope?: boolean;
   showNavigation?: boolean;
   showHeaderNavigation?: boolean;
-  footerContent?: React.ReactNode;
   onSave?: (e: React.MouseEvent<HTMLButtonElement, MouseEvent>) => void;
   className?: string;
   disableNext?: boolean;
@@ -69,8 +69,12 @@ const MultiPageSheetFooter = ({
       className={cn("s-flex s-flex-none s-flex-col s-gap-3 s-p-4", className)}
       {...props}
     >
-      {children}
-      <Separator />
+      {children && (
+        <>
+          {children}
+          <Separator />
+        </>
+      )}
       <div className="s-flex s-flex-row s-justify-between">
         <div>{leftButton && <Button {...leftButton} />}</div>
         <div className="s-flex s-gap-2">
@@ -111,7 +115,6 @@ const MultiPageSheetContent = React.forwardRef<
       trapFocusScope,
       showNavigation = true,
       showHeaderNavigation = true,
-      footerContent,
       className,
       disableNext = false,
       addFooterSeparator = false,
@@ -240,7 +243,7 @@ const MultiPageSheetContent = React.forwardRef<
           rightButton={rightButton}
           addTopSeparator={addFooterSeparator}
         >
-          {footerContent}
+          {currentPage.footerContent}
         </MultiPageSheetFooter>
       </SheetContent>
     );

--- a/sparkle/src/components/Sheet.tsx
+++ b/sparkle/src/components/Sheet.tsx
@@ -170,11 +170,11 @@ const SheetContainer = ({ children }: React.HTMLAttributes<HTMLDivElement>) => {
   return (
     <ScrollArea
       className={cn(
-        "s-w-full s-flex-grow",
+        "s-h-full s-w-full s-flex-grow",
         "s-border-t s-border-border/60 s-transition-all s-duration-300 dark:s-border-border-night/60"
       )}
     >
-      <div className="s-relative s-flex s-flex-col s-gap-5 s-p-5 s-text-left s-text-sm s-text-foreground dark:s-text-foreground-night">
+      <div className="s-relative s-flex s-h-full s-flex-col s-gap-5 s-p-5 s-text-left s-text-sm s-text-foreground dark:s-text-foreground-night">
         {children}
       </div>
     </ScrollArea>

--- a/sparkle/src/stories/MultiPageSheet.stories.tsx
+++ b/sparkle/src/stories/MultiPageSheet.stories.tsx
@@ -437,6 +437,11 @@ export const WithConditionalNavigation: Story = {
             </div>
           </div>
         ),
+        footerContent: (
+          <div className="s-w-full s-border s-border-border-dark">
+            This is a footer content
+          </div>
+        ),
       },
     ];
 
@@ -456,11 +461,6 @@ export const WithConditionalNavigation: Story = {
             currentPageId === "data-selection" && selectedItems.length === 0
           }
           disableSave={!description.trim()}
-          footerContent={
-            <div className="s-w-full s-border s-border-border-dark">
-              This is a footer content
-            </div>
-          }
         />
       </MultiPageSheet>
     );


### PR DESCRIPTION
## Description

This PR changes the `MultiPageSheet` API to define a footer per page instead of a global footer.

## Tests

Locally for the AB v2 specific use case

## Risk

Low, but touches some height related stuff on the `Sheet` component which is widely used.

## Deploy Plan

Publish sparkle
