### PR TITLE
[front] fix: Fix knowledge re-render

### DIFF
--- a/front/components/agent_builder/AgentBuilder.tsx
+++ b/front/components/agent_builder/AgentBuilder.tsx
@@ -174,6 +174,7 @@ export default function AgentBuilder({
 
       if (!agentConfiguration && createdAgent.sId) {
         const newUrl = `/w/${owner.sId}/builder/agents/${createdAgent.sId}`;
+        // willingly using window to not trigger next navigation events
         window.history.replaceState(null, "", newUrl);
       }
     } catch (error) {

--- a/front/components/agent_builder/MCPServerViewsContext.tsx
+++ b/front/components/agent_builder/MCPServerViewsContext.tsx
@@ -153,12 +153,14 @@ export const MCPServerViewsProvider = ({
 }: MCPServerViewsProviderProps) => {
   const { spaces, isSpacesLoading } = useSpacesContext();
 
-  // TODO: we should only fetch it on mount.
   const {
     serverViews: mcpServerViews,
     isLoading,
     isError: isMCPServerViewsError,
-  } = useMCPServerViewsFromSpaces(owner, spaces);
+  } = useMCPServerViewsFromSpaces(owner, spaces, {
+    revalidateIfStale: false,
+    revalidateOnFocus: false,
+  });
 
   const sortedMCPServerViews = useMemo(
     () => mcpServerViews.sort(mcpServerViewSortingFn),

--- a/front/components/agent_builder/capabilities/shared/ProcessingMethodSection.tsx
+++ b/front/components/agent_builder/capabilities/shared/ProcessingMethodSection.tsx
@@ -1,5 +1,6 @@
 import {
   Button,
+  Chip,
   DropdownMenu,
   DropdownMenuContent,
   DropdownMenuItem,
@@ -87,9 +88,7 @@ export function ProcessingMethodSection() {
   return (
     <div className="space-y-4">
       <div>
-        <h3 className="mb-2 text-lg font-semibold">
-          Processing method {hasOnlyTablesSelected ? "yes" : "no"}
-        </h3>
+        <h3 className="mb-2 text-lg font-semibold">Processing method</h3>
       </div>
 
       <div className="space-y-2">
@@ -132,9 +131,7 @@ export function ProcessingMethodSection() {
         </DropdownMenu>
 
         {!hasOnlyTablesSelected && hasSomeTablesSelected && (
-          <div className="text-xs text-muted-foreground dark:text-muted-foreground-night">
-            Your tables will be ignored
-          </div>
+          <Chip color="info" size="sm" label=" Your tables will be ignored " />
         )}
       </div>
     </div>

--- a/front/lib/swr/mcp_servers.ts
+++ b/front/lib/swr/mcp_servers.ts
@@ -1,5 +1,5 @@
 import { useCallback, useMemo } from "react";
-import type { Fetcher } from "swr";
+import type { Fetcher, SWRConfiguration } from "swr";
 
 import { useSendNotification } from "@app/hooks/useNotification";
 import type { MCPToolStakeLevelType } from "@app/lib/actions/constants";
@@ -1116,7 +1116,8 @@ export function useRemoveMCPServerViewFromSpace(owner: LightWorkspaceType) {
 function useMCPServerViewsFromSpacesBase(
   owner: LightWorkspaceType,
   spaces: SpaceType[],
-  availabilities: MCPServerAvailability[]
+  availabilities: MCPServerAvailability[],
+  swrOptions?: SWRConfiguration
 ) {
   const configFetcher: Fetcher<GetMCPServerViewsListResponseBody> = fetcher;
 
@@ -1126,6 +1127,7 @@ function useMCPServerViewsFromSpacesBase(
   const url = `/api/w/${owner.sId}/mcp/views?spaceIds=${spaceIds}&availabilities=${availabilitiesParam}`;
   const { data, error, mutate } = useSWRWithDefaults(url, configFetcher, {
     disabled: !spaces.length,
+    ...swrOptions,
   });
 
   return {
@@ -1138,23 +1140,31 @@ function useMCPServerViewsFromSpacesBase(
 
 export function useMCPServerViewsFromSpaces(
   owner: LightWorkspaceType,
-  spaces: SpaceType[]
+  spaces: SpaceType[],
+  swrOptions?: SWRConfiguration
 ) {
-  return useMCPServerViewsFromSpacesBase(owner, spaces, ["manual", "auto"]);
+  return useMCPServerViewsFromSpacesBase(
+    owner,
+    spaces,
+    ["manual", "auto"],
+    swrOptions
+  );
 }
 
 // Note from seb: the name is misleading as manual will return both internal and remote servers. (all remote are manual, some internals are manual too).
 export function useRemoteMCPServerViewsFromSpaces(
   owner: LightWorkspaceType,
-  spaces: SpaceType[]
+  spaces: SpaceType[],
+  swrOptions?: SWRConfiguration
 ) {
-  return useMCPServerViewsFromSpacesBase(owner, spaces, ["manual"]);
+  return useMCPServerViewsFromSpacesBase(owner, spaces, ["manual"], swrOptions);
 }
 
 // Note from seb: on the flip side, auto will return only internal servers but not all of them so the name is also misleading.
 export function useInternalMCPServerViewsFromSpaces(
   owner: LightWorkspaceType,
-  spaces: SpaceType[]
+  spaces: SpaceType[],
+  swrOptions?: SWRConfiguration
 ) {
-  return useMCPServerViewsFromSpacesBase(owner, spaces, ["auto"]);
+  return useMCPServerViewsFromSpacesBase(owner, spaces, ["auto"], swrOptions);
 }


### PR DESCRIPTION
## Description
This PR fixes a knowledge re-rendering issue by:
1. Moving the data source tree state management into the form to maintain a single source of truth
2. Adding SWR configuration options to prevent unnecessary re-fetches of MCP server views
3. Simplifying the form handling by consolidating save logic and removing unused imports

## Test
Locally

## Risk
Low - Changes are focused on UI rendering optimizations with no backend impact.

## Deploy plan
Deploy front