### PR TITLE
[front] Fix layout of Poke agent page

### DIFF
--- a/front/components/poke/plugins/PluginList.tsx
+++ b/front/components/poke/plugins/PluginList.tsx
@@ -72,7 +72,7 @@ export function PluginList({ pluginResourceTarget }: PluginListProps) {
 
   return (
     <div className="border-material-200 flex min-h-48 flex-col rounded-lg border bg-muted-background dark:bg-muted-background-night">
-      <div className="flex justify-between gap-3 rounded-t-lg bg-primary-300 p-4 dark:bg-primary-300-night">
+      <div className="flex items-center justify-between gap-3 rounded-t-lg bg-primary-300 p-4 dark:bg-primary-300-night">
         <h2 className="text-md font-bold">Plugins</h2>
         <div className="max-w-xs flex-1">
           <Input

--- a/front/pages/poke/[wId]/assistants/[aId]/index.tsx
+++ b/front/pages/poke/[wId]/assistants/[aId]/index.tsx
@@ -65,40 +65,40 @@ const AssistantDetailsPage = ({
   const { isDark } = useTheme();
   return (
     <div>
-      <div className="flex flex-row justify-between gap-4">
-        <h3 className="text-xl font-bold">
-          Agent from workspace{" "}
-          <a href={`/poke/${workspace.sId}`} className="text-highlight-500">
-            {workspace.name}
-          </a>
-        </h3>
-        <div className="flex flex-row gap-4">
-          <DropdownMenu>
-            <DropdownMenuTrigger asChild>
-              <Button
-                icon={UserGroupIcon}
-                onClick={(e: React.MouseEvent<HTMLButtonElement>) => {
-                  e.currentTarget.focus();
-                }}
-                label={`Editors`}
-              />
-            </DropdownMenuTrigger>
-            <DropdownMenuContent
-              onCloseAutoFocus={(event) => {
-                event.preventDefault();
+      <h3 className="text-xl font-bold">
+        Agent from workspace{" "}
+        <a href={`/poke/${workspace.sId}`} className="text-highlight-500">
+          {workspace.name}
+        </a>
+      </h3>
+      <div className="mt-4 flex flex-row gap-4">
+        <DropdownMenu>
+          <DropdownMenuTrigger asChild>
+            <Button
+              icon={UserGroupIcon}
+              onClick={(e: React.MouseEvent<HTMLButtonElement>) => {
+                e.currentTarget.focus();
               }}
-            >
-              {lastVersionEditors.length === 0 && (
-                <DropdownMenuItem label="No editors found!" />
-              )}
-              {lastVersionEditors.map((editor) => (
-                <DropdownMenuItem
-                  key={editor.id}
-                  label={`${editor.fullName} (${editor.email})`}
-                />
-              ))}
-            </DropdownMenuContent>
-          </DropdownMenu>
+              label={`Editors`}
+            />
+          </DropdownMenuTrigger>
+          <DropdownMenuContent
+            onCloseAutoFocus={(event) => {
+              event.preventDefault();
+            }}
+          >
+            {lastVersionEditors.length === 0 && (
+              <DropdownMenuItem label="No editors found!" />
+            )}
+            {lastVersionEditors.map((editor) => (
+              <DropdownMenuItem
+                key={editor.id}
+                label={`${editor.fullName} (${editor.email})`}
+              />
+            ))}
+          </DropdownMenuContent>
+        </DropdownMenu>
+        <div className="flex-1">
           <PluginList
             pluginResourceTarget={{
               resourceId: agentConfigurations[0].sId,

--- a/front/pages/poke/[wId]/assistants/[aId]/index.tsx
+++ b/front/pages/poke/[wId]/assistants/[aId]/index.tsx
@@ -65,13 +65,13 @@ const AssistantDetailsPage = ({
   const { isDark } = useTheme();
   return (
     <div>
-      <h3 className="text-xl font-bold">
-        Agent from workspace{" "}
-        <a href={`/poke/${workspace.sId}`} className="text-highlight-500">
-          {workspace.name}
-        </a>
-      </h3>
-      <div className="mt-4 flex flex-row gap-4">
+      <div className="flex flex-row items-center gap-4">
+        <h3 className="text-xl font-bold">
+          Agent from workspace{" "}
+          <a href={`/poke/${workspace.sId}`} className="text-highlight-500">
+            {workspace.name}
+          </a>
+        </h3>
         <DropdownMenu>
           <DropdownMenuTrigger asChild>
             <Button
@@ -98,15 +98,15 @@ const AssistantDetailsPage = ({
             ))}
           </DropdownMenuContent>
         </DropdownMenu>
-        <div className="flex-1">
-          <PluginList
-            pluginResourceTarget={{
-              resourceId: agentConfigurations[0].sId,
-              resourceType: "agents",
-              workspace: workspace,
-            }}
-          />
-        </div>
+      </div>
+      <div className="mt-4">
+        <PluginList
+          pluginResourceTarget={{
+            resourceId: agentConfigurations[0].sId,
+            resourceType: "agents",
+            workspace: workspace,
+          }}
+        />
       </div>
 
       <Page.Vertical align="stretch">


### PR DESCRIPTION
## Description

- The layout is broken, with the Editors dropdown and the plugin list at the very right of the page.
- This PR fixes that.
- It's quite subtle but in the `PluginList` the title "Plugins" was also not correctly aligned vertically.

<img width="1880" height="417" alt="Screenshot 2025-08-21 at 4 58 39 PM" src="https://github.com/user-attachments/assets/3e8ffc47-3397-4ad4-9cd3-e6db7957bf93" />

<img width="1880" height="417" alt="Screenshot 2025-08-21 at 4 58 16 PM" src="https://github.com/user-attachments/assets/93e7a172-374d-4022-8326-6e79c5111796" />

## Tests

- Checked locally.

## Risk

- Low, only UI and only Poke.

## Deploy Plan

- Deploy front.
