### PR TITLE
fix(oauth): accept McpStatic as valid credential provider

### DIFF
--- a/core/src/oauth/providers/mcp.rs
+++ b/core/src/oauth/providers/mcp.rs
@@ -43,9 +43,9 @@ impl MCPConnectionProvider {
         let provider = credentials.provider();
 
         // Fetch credential
-        if provider != CredentialProvider::Mcp {
+        if provider != CredentialProvider::Mcp && provider != CredentialProvider::McpStatic {
             return Err(anyhow!(
-                "Invalid credential provider: {:?}, expected MCP",
+                "Invalid credential provider: {:?}, expected MCP or McpStatic",
                 provider
             ));
         }


### PR DESCRIPTION
## Description

Prior to this change, when using a static MCP server, this error would occur:
```
23.397021042s ERROR Failed to finalize connection error=Internal error: Invalid credential provider: McpStatic, expected MCP. provider=McpStatic on tokio-runtime-worker at src/oauth/connection.rs:728
23.397053500s ERROR API error error_code="internal_error" error_message="Failed to finalize connection." error=None on tokio-runtime-worker at src/utils.rs:133
```
This error bubbles up to the front:
<img width="546" height="636" alt="Screenshot 2025-08-21 at 12 50 32" src="https://github.com/user-attachments/assets/d5523516-9d43-4c4b-a462-07e477fa9b03" />

This PR fixes this error by:
- allowing both Mcp and McpStatic as valid credential providers
- updating error message to reflect accepted providers

## Tests

Local

## Risk

Low

## Deploy Plan

Deploy oauth
