### PR TITLE
[front] - AB v2: Remove automatic conversion of XML tags

### DIFF
--- a/front/components/agent_builder/instructions/extensions/InstructionBlockExtension.tsx
+++ b/front/components/agent_builder/instructions/extensions/InstructionBlockExtension.tsx
@@ -540,12 +540,7 @@ export const InstructionBlockExtension =
               }
               return parts.join("");
             },
-            // Paste handler removed - no automatic conversion on paste
-            // This prevents HTML/XML from being unexpectedly converted to instruction blocks
-            // Users can still create instruction blocks by typing <tagname> or <>
           },
-          // Removed appendTransaction and handlePaste - no automatic conversion of XML tags
-          // Users must explicitly trigger conversion by typing an opening tag (handled by InputRule)
         }),
       ];
     },

--- a/front/components/agent_builder/instructions/extensions/InstructionBlockExtension.tsx
+++ b/front/components/agent_builder/instructions/extensions/InstructionBlockExtension.tsx
@@ -218,8 +218,6 @@ export const InstructionBlockExtension =
         new InputRule({
           find: OPENING_TAG_REGEX,
           handler: ({ range, match, commands }) => {
-            // Use the tag name if provided, otherwise default to empty string
-            // The user can edit it after creation
             const type = match[1] ? match[1].toLowerCase() : "";
 
             if (this.editor.isActive(this.name)) {
@@ -230,7 +228,7 @@ export const InstructionBlockExtension =
               { from: range.from, to: range.to },
               {
                 type: this.name,
-                attrs: { type: type || "instructions" }, // Default to "instructions" if empty
+                attrs: { type: type || "instructions" },
                 content: [{ type: "paragraph" }],
               }
             );

--- a/front/components/agent_builder/instructions/extensions/InstructionBlockExtension.tsx
+++ b/front/components/agent_builder/instructions/extensions/InstructionBlockExtension.tsx
@@ -14,13 +14,7 @@ import {
 } from "@tiptap/react";
 import React, { useEffect, useRef, useState } from "react";
 
-import {
-  createProseMirrorInstructionBlock,
-  INSTRUCTION_BLOCK_REGEX,
-  OPENING_TAG_REGEX,
-  parseInstructionBlockMatches,
-  splitTextAroundBlocks,
-} from "@app/lib/client/agent_builder/instructionBlockUtils";
+import { OPENING_TAG_REGEX } from "@app/lib/client/agent_builder/instructionBlockUtils";
 
 export interface InstructionBlockAttributes {
   type: string;
@@ -227,7 +221,9 @@ export const InstructionBlockExtension =
         new InputRule({
           find: OPENING_TAG_REGEX,
           handler: ({ range, match, commands }) => {
-            const type = match[1].toLowerCase();
+            // Use the tag name if provided, otherwise default to empty string
+            // The user can edit it after creation
+            const type = match[1] ? match[1].toLowerCase() : "";
 
             if (this.editor.isActive(this.name)) {
               return;
@@ -237,7 +233,7 @@ export const InstructionBlockExtension =
               { from: range.from, to: range.to },
               {
                 type: this.name,
-                attrs: { type },
+                attrs: { type: type || "info" }, // Default to "info" if empty
                 content: [{ type: "paragraph" }],
               }
             );
@@ -547,102 +543,12 @@ export const InstructionBlockExtension =
               }
               return parts.join("");
             },
-            handlePaste: (
-              view: EditorView,
-              event: ClipboardEvent,
-              slice: Slice
-            ) => {
-              const { state } = view;
-              const { schema, tr } = state;
-
-              // Get the text content from the slice
-              const textContent = slice.content.textBetween(
-                0,
-                slice.content.size,
-                "\n",
-                "\n"
-              );
-
-              // Check if there are any XML tags
-              if (!INSTRUCTION_BLOCK_REGEX.test(textContent)) {
-                return false; // Let default paste behavior handle it
-              }
-
-              // Parse the content and create nodes
-              const nodes: ProseMirrorNode[] = [];
-              const segments = splitTextAroundBlocks(textContent);
-
-              segments.forEach((segment) => {
-                if (segment.type === "text") {
-                  // Add text as paragraphs
-                  const lines = segment.content
-                    .split("\n")
-                    .filter((line) => line.trim());
-                  lines.forEach((line) => {
-                    nodes.push(
-                      schema.nodes.paragraph.create({}, [schema.text(line)])
-                    );
-                  });
-                } else if (segment.type === "block" && segment.blockType) {
-                  // Add instruction block
-                  const instructionBlock = createProseMirrorInstructionBlock(
-                    segment.blockType,
-                    segment.content,
-                    this.type,
-                    schema
-                  );
-                  nodes.push(instructionBlock);
-                }
-              });
-
-              // Insert all nodes at once to preserve order
-              const { from } = state.selection;
-              const fragment = Fragment.fromArray(nodes);
-              tr.insert(from, fragment);
-
-              view.dispatch(tr);
-              return true; // We handled the paste
-            },
+            // Paste handler removed - no automatic conversion on paste
+            // This prevents HTML/XML from being unexpectedly converted to instruction blocks
+            // Users can still create instruction blocks by typing <tagname> or <>
           },
-          appendTransaction: (transactions, oldState, newState) => {
-            if (!transactions.some((tr) => tr.docChanged)) {
-              return null;
-            }
-
-            const { doc, tr, schema } = newState;
-            let modified = false;
-
-            doc.descendants((node, pos) => {
-              if (node.type.name !== "text" || !node.text) {
-                return;
-              }
-
-              const matches = parseInstructionBlockMatches(node.text);
-
-              matches.forEach((match) => {
-                const matchStart = pos + match.start;
-                const matchEnd = pos + match.end;
-
-                const instructionBlock = createProseMirrorInstructionBlock(
-                  match.type,
-                  match.content,
-                  this.type,
-                  schema
-                );
-
-                tr.replaceWith(matchStart, matchEnd, instructionBlock);
-
-                // Position cursor in the block
-                const blockPos = matchStart + 1;
-                const paragraphPos = blockPos + 1;
-                tr.setSelection(TextSelection.create(tr.doc, paragraphPos));
-
-                modified = true;
-              });
-            });
-
-            return modified ? tr : null;
-          },
+          // Removed appendTransaction and handlePaste - no automatic conversion of XML tags
+          // Users must explicitly trigger conversion by typing an opening tag (handled by InputRule)
         }),
       ];
     },

--- a/front/components/agent_builder/instructions/extensions/InstructionBlockExtension.tsx
+++ b/front/components/agent_builder/instructions/extensions/InstructionBlockExtension.tsx
@@ -163,9 +163,9 @@ export const InstructionBlockExtension =
     addAttributes() {
       return {
         type: {
-          default: "info",
+          default: "instructions",
           parseHTML: (element) =>
-            element.getAttribute("data-instruction-type") || "info",
+            element.getAttribute("data-instruction-type") || "instructions",
           renderHTML: (attributes) => ({
             "data-instruction-type": attributes.type,
           }),
@@ -230,7 +230,7 @@ export const InstructionBlockExtension =
               { from: range.from, to: range.to },
               {
                 type: this.name,
-                attrs: { type: type || "info" }, // Default to "info" if empty
+                attrs: { type: type || "instructions" }, // Default to "instructions" if empty
                 content: [{ type: "paragraph" }],
               }
             );

--- a/front/components/agent_builder/instructions/extensions/InstructionBlockExtension.tsx
+++ b/front/components/agent_builder/instructions/extensions/InstructionBlockExtension.tsx
@@ -1,11 +1,8 @@
 import { Chip, cn, IconButton, XMarkIcon } from "@dust-tt/sparkle";
 import { InputRule, mergeAttributes, Node } from "@tiptap/core";
-import type { Node as ProseMirrorNode } from "@tiptap/pm/model";
 import type { Slice } from "@tiptap/pm/model";
-import { Fragment } from "@tiptap/pm/model";
 import { Plugin, PluginKey } from "@tiptap/pm/state";
 import { TextSelection } from "@tiptap/pm/state";
-import type { EditorView } from "@tiptap/pm/view";
 import type { NodeViewProps } from "@tiptap/react";
 import {
   NodeViewContent,

--- a/front/lib/client/agent_builder/instructionBlockUtils.ts
+++ b/front/lib/client/agent_builder/instructionBlockUtils.ts
@@ -8,9 +8,9 @@ import type { JSONContent } from "@tiptap/react";
 export const INSTRUCTION_BLOCK_REGEX = /<(\w+)>([\s\S]*?)<\/\1>/g;
 
 /**
- * Regex pattern for matching opening XML tags
+ * Regex pattern for matching opening XML tags (including empty <>)
  */
-export const OPENING_TAG_REGEX = /<(\w+)>$/;
+export const OPENING_TAG_REGEX = /<(\w*)>$/;
 
 /**
  * Interface for parsed instruction block match


### PR DESCRIPTION
## Description

This PR removes the automatic conversion of XML tags on paste via `appendTransaction` and `handlePaste`.
This caused wrong formatting when pasting HTML or XML with nested tags and in general edge cases that we want to avoid.  

Also we now allow creating an XML block when typing `<>` that is converted automatically to `<instructions>`.
Planned is to allow inserting an XML block from an autocomplete menu in a following PR.

## Tests

Locally

## Risk

Low, behind FF

## Deploy Plan

Deploy front
