### PR TITLE
[front] Add poke plugin to apply group roles

### DIFF
--- a/front/lib/api/poke/plugins/workspaces/apply_group_roles.ts
+++ b/front/lib/api/poke/plugins/workspaces/apply_group_roles.ts
@@ -39,7 +39,7 @@ export const applyGroupRoles = createPlugin({
     const errors: string[] = [];
 
     for (const membership of memberships) {
-      const user = await UserResource.fetchById(membership.userId.toString());
+      const user = await UserResource.fetchByModelId(membership.userId);
       if (!user) {
         errors.push(`User not found: ${membership.userId}`);
         continue;

--- a/front/lib/api/poke/plugins/workspaces/apply_group_roles.ts
+++ b/front/lib/api/poke/plugins/workspaces/apply_group_roles.ts
@@ -1,0 +1,90 @@
+import { createPlugin } from "@app/lib/api/poke/types";
+import { determineUserRoleFromGroups } from "@app/lib/api/user";
+import { GroupResource } from "@app/lib/resources/group_resource";
+import { MembershipResource } from "@app/lib/resources/membership_resource";
+import { UserResource } from "@app/lib/resources/user_resource";
+import { Err, Ok } from "@app/types";
+
+export const applyGroupRoles = createPlugin({
+  manifest: {
+    id: "apply-roles-from-groups",
+    name: "Apply roles defined by the dust-admins and dust-builders groups",
+    description:
+      "Force resync roles using dust-admins and dust-builders groups",
+    resourceTypes: ["workspaces"],
+    warning:
+      "This action will override the existing membership roles based on the dust-admins and dust-builders groups. " +
+      "Make sure the user is aware of this and does not want to keep the roles assigned manually.",
+    args: {},
+  },
+  execute: async (auth) => {
+    const workspace = auth.getNonNullableWorkspace();
+
+    const provisioningGroups =
+      await GroupResource.listRoleProvisioningGroupsForWorkspace(auth);
+
+    if (provisioningGroups.length === 0) {
+      return new Ok({
+        display: "text",
+        value:
+          "dust-admins or dust-builders group both not found in workspace.",
+      });
+    }
+
+    const { memberships } = await MembershipResource.getActiveMemberships({
+      workspace,
+    });
+
+    let updatedCount = 0;
+    const errors: string[] = [];
+
+    for (const membership of memberships) {
+      const user = await UserResource.fetchById(membership.userId.toString());
+      if (!user) {
+        errors.push(`User not found: ${membership.userId}`);
+        continue;
+      }
+
+      const currentRole = membership.role;
+      const expectedRole = await determineUserRoleFromGroups(workspace, user);
+
+      if (currentRole !== expectedRole) {
+        const updateResult = await MembershipResource.updateMembershipRole({
+          user,
+          workspace,
+          newRole: expectedRole,
+        });
+
+        if (updateResult.isErr()) {
+          errors.push(
+            `Failed to update role for user ${user.sId}: ${updateResult.error.type}`
+          );
+        } else {
+          updatedCount++;
+        }
+      }
+    }
+
+    const groupSummary = provisioningGroups
+      .map((g) => `${g.name} (${g.sId})`)
+      .join(", ");
+
+    if (errors.length > 0) {
+      return new Err(
+        new Error(
+          `Role sync completed with errors. Updated ${updatedCount} memberships. Groups: ${groupSummary}. Errors: ${errors.join("; ")}`
+        )
+      );
+    }
+
+    return new Ok({
+      display: "json",
+      value: {
+        status: "success",
+        message: `Successfully synced membership roles for workspace "${workspace.name}".`,
+        updatedCount,
+        groupSummary,
+      },
+    });
+  },
+});

--- a/front/lib/api/poke/plugins/workspaces/apply_group_roles.ts
+++ b/front/lib/api/poke/plugins/workspaces/apply_group_roles.ts
@@ -8,7 +8,7 @@ import { Err, Ok } from "@app/types";
 export const applyGroupRoles = createPlugin({
   manifest: {
     id: "apply-roles-from-groups",
-    name: "Apply roles defined by the dust-admins and dust-builders groups",
+    name: "Apply group roles",
     description:
       "Force resync roles using dust-admins and dust-builders groups",
     resourceTypes: ["workspaces"],

--- a/front/lib/api/poke/plugins/workspaces/index.ts
+++ b/front/lib/api/poke/plugins/workspaces/index.ts
@@ -1,4 +1,5 @@
 export * from "./add_user_to_workos_organization";
+export * from "./apply_group_roles";
 export * from "./check_seat_count";
 export * from "./clean_outdated_directory_sync_groups";
 export * from "./compute_statistics";

--- a/front/lib/api/user.ts
+++ b/front/lib/api/user.ts
@@ -1,10 +1,17 @@
 import type { Authenticator } from "@app/lib/auth";
 import { ExtensionConfigurationResource } from "@app/lib/resources/extension";
+import {
+  ADMIN_GROUP_NAME,
+  BUILDER_GROUP_NAME,
+  GroupResource,
+} from "@app/lib/resources/group_resource";
 import { UserResource } from "@app/lib/resources/user_resource";
 import { WorkspaceResource } from "@app/lib/resources/workspace_resource";
 import { renderLightWorkspaceType } from "@app/lib/workspace";
 import logger from "@app/logger/logger";
 import type {
+  LightWorkspaceType,
+  MembershipRoleType,
   Result,
   UserTypeWithExtensionWorkspaces,
   UserTypeWithWorkspaces,
@@ -122,4 +129,33 @@ export async function getUserWithWorkspaces<T extends boolean>(
       };
     }),
   };
+}
+
+export async function determineUserRoleFromGroups(
+  workspace: LightWorkspaceType,
+  user: UserResource
+): Promise<MembershipRoleType> {
+  // Get all groups the user is a member of.
+  const userGroups = await GroupResource.listUserGroupsInWorkspace({
+    user,
+    workspace,
+  });
+
+  let atLeastBuilder = false;
+
+  for (const group of userGroups) {
+    if (group.name === ADMIN_GROUP_NAME) {
+      return "admin";
+    }
+    if (group.name === BUILDER_GROUP_NAME) {
+      atLeastBuilder = true;
+    }
+  }
+  // If we're here, the user is not in the admin group.
+  if (atLeastBuilder) {
+    return "builder";
+  }
+
+  // Did not find any group granting a role, so the user should be a regular user.
+  return "user";
 }


### PR DESCRIPTION
## Description

- This PR adds a Poke plugin that force applies the roles defined by the `dust-admins` and `dust-members` groups.
- The poke plugin is not very optimized, we'll see if we need to speed it up.

## Tests

- Tested locally.

## Risk

- Low, only an admin action.

## Deploy Plan

- Deploy front.
