### PR TITLE
[front] Read from `AgentMCPAction.status` instead of `isError`/`executionState`

### DIFF
--- a/front/lib/poke/conversations.ts
+++ b/front/lib/poke/conversations.ts
@@ -47,7 +47,7 @@ export async function getPokeConversation(
                   params: a.params,
                   output: a.output,
                   generatedFiles: a.generatedFiles,
-                  isError: a.isError,
+                  isError: a.status === "errored",
                 };
               }
             }

--- a/front/lib/resources/agent_mcp_action_resource.ts
+++ b/front/lib/resources/agent_mcp_action_resource.ts
@@ -105,7 +105,7 @@ export class AgentMCPActionResource extends BaseResource<AgentMCPAction> {
       ],
       where: {
         workspaceId: owner.id,
-        executionState: "pending",
+        status: "blocked_pending_validation",
       },
       order: [["createdAt", "ASC"]],
     });

--- a/front/lib/resources/agent_step_content_resource.ts
+++ b/front/lib/resources/agent_step_content_resource.ts
@@ -544,8 +544,7 @@ export class AgentStepContentResource extends BaseResource<AgentStepContentModel
           createdAt: action.createdAt.toISOString(),
           functionCallName: stepContent.value.value.name,
           params: JSON.parse(stepContent.value.value.arguments),
-          executionState: action.executionState,
-          isError: action.isError,
+          status: action.status,
           conversationId: stepContent.agentMessage.message.conversation.sId,
           messageId: stepContent.agentMessage.message.sId,
         };

--- a/front/pages/api/w/[wId]/labs/mcp_actions/[agentId]/index.ts
+++ b/front/pages/api/w/[wId]/labs/mcp_actions/[agentId]/index.ts
@@ -4,6 +4,7 @@ import * as reporter from "io-ts-reporters";
 import { NumberFromString, withFallback } from "io-ts-types";
 import type { NextApiRequest, NextApiResponse } from "next";
 
+import type { ToolExecutionStatus } from "@app/lib/actions/statuses";
 import { getAgentConfiguration } from "@app/lib/api/assistant/configuration/agent";
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
 import type { Authenticator } from "@app/lib/auth";
@@ -18,8 +19,7 @@ export type GetMCPActionsResult = {
     createdAt: string;
     functionCallName: string | null;
     params: Record<string, unknown>;
-    executionState: string;
-    isError: boolean;
+    status: ToolExecutionStatus;
     conversationId: string;
     messageId: string;
   }[];

--- a/front/pages/w/[wId]/labs/mcp_actions/[agentId]/index.tsx
+++ b/front/pages/w/[wId]/labs/mcp_actions/[agentId]/index.tsx
@@ -18,6 +18,7 @@ import { ConversationsNavigationProvider } from "@app/components/assistant/conve
 import { AssistantSidebarMenu } from "@app/components/assistant/conversation/SidebarMenu";
 import { AppCenteredLayout } from "@app/components/sparkle/AppCenteredLayout";
 import AppRootLayout from "@app/components/sparkle/AppRootLayout";
+import type { ToolExecutionStatus } from "@app/lib/actions/statuses";
 import { getAgentConfiguration } from "@app/lib/api/assistant/configuration/agent";
 import { getFeatureFlags } from "@app/lib/auth";
 import { withDefaultUserAuthRequirements } from "@app/lib/iam/session";
@@ -126,17 +127,16 @@ export default function AgentMCPActions({
     }
   };
 
-  const getExecutionStateColor = (state: string) => {
+  const getExecutionStateColor = (state: ToolExecutionStatus) => {
     switch (state) {
-      case "allowed_explicitly":
-      case "allowed_implicitly":
+      case "succeeded":
         return "success";
       case "denied":
+      case "errored":
         return "warning";
-      case "pending":
+      case "blocked_authentication_required":
+      case "blocked_pending_validation":
         return "info";
-      case "timeout":
-        return "warning";
       default:
         return "primary";
     }
@@ -227,17 +227,15 @@ export default function AgentMCPActions({
                             <div className="flex items-center gap-2">
                               <Chip
                                 color={
-                                  action.isError
+                                  action.status === "errored"
                                     ? "warning"
-                                    : getExecutionStateColor(
-                                        action.executionState
-                                      )
+                                    : getExecutionStateColor(action.status)
                                 }
                                 size="xs"
                               >
-                                {action.isError
+                                {action.status === "errored"
                                   ? "Error"
-                                  : action.executionState.replace("_", " ")}
+                                  : action.status.replace("_", " ")}
                               </Chip>
                               {action.conversationId && (
                                 <Button

--- a/front/pages/w/[wId]/labs/mcp_actions/[agentId]/index.tsx
+++ b/front/pages/w/[wId]/labs/mcp_actions/[agentId]/index.tsx
@@ -135,7 +135,7 @@ export default function AgentMCPActions({
       case "errored":
         return "warning";
       case "blocked_authentication_required":
-      case "blocked_pending_validation":
+      case "blocked_validation_required":
         return "info";
       default:
         return "primary";

--- a/front/temporal/agent_loop/activities/run_model_and_create_actions_wrapper.ts
+++ b/front/temporal/agent_loop/activities/run_model_and_create_actions_wrapper.ts
@@ -172,7 +172,7 @@ async function getExistingActionsAndBlobs(
       if (!isToolExecutionStatusFinal(mcpAction.status)) {
         actionBlobs.push({
           actionId: mcpAction.id,
-          needsApproval: mcpAction.executionState === "pending",
+          needsApproval: mcpAction.status === "blocked_pending_validation",
         });
       }
     }

--- a/front/temporal/agent_loop/activities/run_model_and_create_actions_wrapper.ts
+++ b/front/temporal/agent_loop/activities/run_model_and_create_actions_wrapper.ts
@@ -172,7 +172,7 @@ async function getExistingActionsAndBlobs(
       if (!isToolExecutionStatusFinal(mcpAction.status)) {
         actionBlobs.push({
           actionId: mcpAction.id,
-          needsApproval: mcpAction.status === "blocked_pending_validation",
+          needsApproval: mcpAction.status === "blocked_validation_required",
         });
       }
     }


### PR DESCRIPTION
## Description

- Follow up on https://github.com/dust-tt/dust/pull/15195.
- This PR deprecates the `isError` and `executionState` column by replacing read locations with `status`.
- We still write into these two columns, they will be removed entirely in a follow up PR.

## Tests

- Checked that the column is correctly backfilled using
```sql
SELECT status, COUNT(*) FROM agent_mcp_actions GROUP BY "status";
SELECT status FROM agent_mcp_actions WHERE "executionState" = 'denied' GROUP BY "status";
SELECT status FROM agent_mcp_actions WHERE "isError" = true GROUP BY "status";
```
- local + front-edge

## Risk

- Medium, column correctly backfilled but many code paths affected.

## Deploy Plan

- Deploy front.
