### PR TITLE
[front] Rename `blocked_pending_validation` -> `blocked_validation_required`

### DIFF
--- a/front/lib/actions/statuses.ts
+++ b/front/lib/actions/statuses.ts
@@ -30,7 +30,7 @@ type ToolExecutionBlockedStatus =
 const TOOL_EXECUTION_TRANSIENT_STATUSES = [
   "ready_allowed_explicitly",
   "ready_allowed_implicitly",
-  "blocked_pending_validation",
+  "blocked_validation_required",
   ...TOOL_EXECUTION_BLOCKED_STATUSES,
   "running",
 ] as const;

--- a/front/lib/actions/utils.ts
+++ b/front/lib/actions/utils.ts
@@ -255,7 +255,7 @@ export function approvalStatusToToolExecutionStatus(
     case "denied":
       return "denied";
     case "pending":
-      return "blocked_pending_validation";
+      return "blocked_validation_required";
     default:
       assertNever(approvalStatus);
   }

--- a/front/migrations/20250821_backfill_agent_mcp_action_status.ts
+++ b/front/migrations/20250821_backfill_agent_mcp_action_status.ts
@@ -11,7 +11,11 @@ const BATCH_SIZE = 2048;
 // succeeded is the default (99.1% of actions), we backfill errored using the `isError` column
 // and denied using the `executionState` column.
 
-type TargetStatus = "errored" | "denied" | "succeeded";
+type TargetStatus =
+  | "errored"
+  | "denied"
+  | "succeeded"
+  | "blocked_validation_required";
 
 function getWhereClause({
   lastId,
@@ -35,6 +39,11 @@ function getWhereClause({
       return {
         id: { [Op.gt]: lastId },
         status: "running",
+      };
+    case "blocked_validation_required":
+      return {
+        id: { [Op.gt]: lastId },
+        status: "blocked_pending_validation",
       };
   }
 }

--- a/front/migrations/20250821_backfill_agent_mcp_action_status.ts
+++ b/front/migrations/20250821_backfill_agent_mcp_action_status.ts
@@ -11,11 +11,14 @@ const BATCH_SIZE = 2048;
 // succeeded is the default (99.1% of actions), we backfill errored using the `isError` column
 // and denied using the `executionState` column.
 
-type TargetStatus =
-  | "errored"
-  | "denied"
-  | "succeeded"
-  | "blocked_validation_required";
+const TARGET_STATUSES = [
+  "errored",
+  "denied",
+  "succeeded",
+  "blocked_validation_required",
+] as const;
+
+type TargetStatus = (typeof TARGET_STATUSES)[number];
 
 function getWhereClause({
   lastId,
@@ -102,7 +105,7 @@ async function backfillActions(
 }
 
 makeScript({}, async ({ execute }, logger) => {
-  for (const targetStatus of ["succeeded", "errored", "denied"] as const) {
+  for (const targetStatus of TARGET_STATUSES) {
     logger.info(`Starting backfill of ${targetStatus} actions`);
     await backfillActions({ targetStatus, execute }, logger);
     logger.info(`Completed backfill of ${targetStatus} actions`);


### PR DESCRIPTION
## Description

- This PR renames the `AgentMCPAction` status `blocked_pending_validation` into `blocked_validation_required`.

## Tests

- Checked locally.

## Risk

- Low, unused for now.

## Deploy Plan

- Deploy front.
- Run backfill after the deploy.
