### PR TITLE
[front] Uniformize blocked actions handling

### DIFF
--- a/front/components/assistant/conversation/ActionValidationProvider.tsx
+++ b/front/components/assistant/conversation/ActionValidationProvider.tsx
@@ -27,7 +27,7 @@ import {
 import { useNavigationLock } from "@app/components/assistant_builder/useNavigationLock";
 import type { MCPValidationOutputType } from "@app/lib/actions/constants";
 import { getAvatarFromIcon } from "@app/lib/actions/mcp_icons";
-import { usePendingValidations } from "@app/lib/swr/pending_validations";
+import { useBlockedActions } from "@app/lib/swr/blocked_actions";
 import type {
   ConversationWithoutContentType,
   LightWorkspaceType,
@@ -150,10 +150,18 @@ export function ActionValidationProvider({
   conversation,
   children,
 }: ActionValidationProviderProps) {
-  const { pendingValidations } = usePendingValidations({
+  const { blockedActions } = useBlockedActions({
     conversationId: conversation?.sId || null,
     workspaceId: owner.sId,
   });
+
+  // Filter blocked actions to only get validation required ones.
+  // TODO(durable-agents): also display blocked_authentication_required.
+  const pendingValidations = useMemo(() => {
+    return blockedActions.filter(
+      (action) => action.status === "blocked_validation_required"
+    );
+  }, [blockedActions]);
 
   const {
     validationQueueLength,

--- a/front/components/assistant/conversation/ActionValidationProvider.tsx
+++ b/front/components/assistant/conversation/ActionValidationProvider.tsx
@@ -70,7 +70,10 @@ function useValidationQueue({
   const handleValidationRequest = useCallback(
     (validationRequest: MCPActionValidationRequest) => {
       setCurrentValidation((current) => {
-        if (current === null) {
+        if (
+          current === null ||
+          current.actionId === validationRequest.actionId
+        ) {
           return validationRequest;
         }
 
@@ -170,6 +173,7 @@ export function ActionValidationProvider({
     handleValidationRequest,
     takeNextFromQueue,
   } = useValidationQueue({ pendingValidations });
+  console.log({ validationQueueLength, currentValidation, pendingValidations });
 
   const [isDialogOpen, setIsDialogOpen] = useState(false);
   const [isProcessing, setIsProcessing] = useState(false);

--- a/front/lib/actions/mcp.ts
+++ b/front/lib/actions/mcp.ts
@@ -32,6 +32,7 @@ import {
 import type {
   MCPExecutionState,
   MCPRunningState,
+  ToolExecutionBlockedStatus,
   ToolExecutionStatus,
 } from "@app/lib/actions/statuses";
 import { isToolExecutionStatusFinal } from "@app/lib/actions/statuses";
@@ -166,16 +167,26 @@ export type LightMCPToolConfigurationType =
   | LightServerSideMCPToolConfigurationType
   | LightClientSideMCPToolConfigurationType;
 
-export type MCPApproveExecutionEvent = {
+export type ToolExecutionMetadata = {
+  actionId: string;
+  inputs: Record<string, unknown>;
+  stake?: MCPToolStakeLevelType;
+  metadata: MCPValidationMetadataType;
+};
+
+export type BlockedActionExecution = ToolExecutionMetadata & {
+  messageId: string;
+  conversationId: string;
+  status: ToolExecutionBlockedStatus;
+};
+
+// TODO(durable-agents): cleanup the types of the events.
+export type MCPApproveExecutionEvent = ToolExecutionMetadata & {
   type: "tool_approve_execution";
   created: number;
   configurationId: string;
   messageId: string;
   conversationId: string;
-  actionId: string;
-  inputs: Record<string, unknown>;
-  stake?: MCPToolStakeLevelType;
-  metadata: MCPValidationMetadataType;
 };
 
 export function getMCPApprovalStateFromUserApprovalState(

--- a/front/lib/actions/statuses.ts
+++ b/front/lib/actions/statuses.ts
@@ -22,15 +22,15 @@ type ToolExecutionFinalStatus = (typeof TOOL_EXECUTION_FINAL_STATUSES)[number];
 
 export const TOOL_EXECUTION_BLOCKED_STATUSES = [
   "blocked_authentication_required",
+  "blocked_validation_required",
 ] as const;
 
-type ToolExecutionBlockedStatus =
+export type ToolExecutionBlockedStatus =
   (typeof TOOL_EXECUTION_BLOCKED_STATUSES)[number];
 
 const TOOL_EXECUTION_TRANSIENT_STATUSES = [
   "ready_allowed_explicitly",
   "ready_allowed_implicitly",
-  "blocked_validation_required",
   ...TOOL_EXECUTION_BLOCKED_STATUSES,
   "running",
 ] as const;

--- a/front/lib/resources/agent_mcp_action_resource.ts
+++ b/front/lib/resources/agent_mcp_action_resource.ts
@@ -18,7 +18,7 @@ import type { ReadonlyAttributesType } from "@app/lib/resources/storage/types";
 import type { ModelStaticWorkspaceAware } from "@app/lib/resources/storage/wrappers/workspace_models";
 import { makeSId } from "@app/lib/resources/string_ids";
 import type { ResourceFindOptions } from "@app/lib/resources/types";
-import type { MCPActionValidationRequest, ModelId, Result } from "@app/types";
+import type { ModelId, Result } from "@app/types";
 import { removeNulls } from "@app/types";
 import { Err, normalizeError, Ok } from "@app/types";
 

--- a/front/lib/resources/agent_mcp_action_resource.ts
+++ b/front/lib/resources/agent_mcp_action_resource.ts
@@ -2,7 +2,11 @@ import assert from "assert";
 import type { Attributes, NonAttribute, Transaction } from "sequelize";
 import { Op } from "sequelize";
 
-import { TOOL_EXECUTION_BLOCKED_STATUSES } from "@app/lib/actions/statuses";
+import type { BlockedActionExecution } from "@app/lib/actions/mcp";
+import {
+  isToolExecutionStatusBlocked,
+  TOOL_EXECUTION_BLOCKED_STATUSES,
+} from "@app/lib/actions/statuses";
 import { getAgentConfigurations } from "@app/lib/api/assistant/configuration/agent";
 import type { Authenticator } from "@app/lib/auth";
 import { AgentMCPAction } from "@app/lib/models/assistant/actions/mcp";
@@ -71,10 +75,10 @@ export class AgentMCPActionResource extends BaseResource<AgentMCPAction> {
     });
   }
 
-  static async listPendingValidationsForConversation(
+  static async listBlockedActionsForConversation(
     auth: Authenticator,
     conversationId: string
-  ): Promise<MCPActionValidationRequest[]> {
+  ): Promise<BlockedActionExecution[]> {
     const owner = auth.getNonNullableWorkspace();
 
     const conversation = await ConversationResource.fetchById(
@@ -85,7 +89,7 @@ export class AgentMCPActionResource extends BaseResource<AgentMCPAction> {
       return [];
     }
 
-    const pendingActions = await AgentMCPAction.findAll({
+    const blockedActions = await AgentMCPAction.findAll({
       include: [
         {
           model: AgentMessage,
@@ -105,12 +109,14 @@ export class AgentMCPActionResource extends BaseResource<AgentMCPAction> {
       ],
       where: {
         workspaceId: owner.id,
-        status: "blocked_pending_validation",
+        status: {
+          [Op.in]: TOOL_EXECUTION_BLOCKED_STATUSES,
+        },
       },
       order: [["createdAt", "ASC"]],
     });
 
-    const pendingValidations: MCPActionValidationRequest[] = [];
+    const blockedActionsList: BlockedActionExecution[] = [];
 
     // We get the latest version here, it may show a different name than the one used when the
     // action was created, taking this shortcut for the sake of simplicity.
@@ -118,14 +124,14 @@ export class AgentMCPActionResource extends BaseResource<AgentMCPAction> {
       agentIds: [
         ...new Set(
           removeNulls(
-            pendingActions.map((a) => a.agentMessage?.agentConfigurationId)
+            blockedActions.map((a) => a.agentMessage?.agentConfigurationId)
           )
         ),
       ],
       variant: "extra_light",
     });
 
-    for (const action of pendingActions) {
+    for (const action of blockedActions) {
       const agentMessage = action.agentMessage;
       assert(agentMessage?.message, "No message for agent message.");
       const agentConfiguration = agentConfigurations.find(
@@ -133,7 +139,13 @@ export class AgentMCPActionResource extends BaseResource<AgentMCPAction> {
       );
       assert(agentConfiguration, "Agent not found.");
 
-      pendingValidations.push({
+      // We just fetched on the status being blocked, we just don't get it typed properly.
+      assert(
+        isToolExecutionStatusBlocked(action.status),
+        "Action is not blocked."
+      );
+
+      blockedActionsList.push({
         messageId: agentMessage.message.sId,
         conversationId,
         actionId: this.modelIdToSId({
@@ -148,10 +160,11 @@ export class AgentMCPActionResource extends BaseResource<AgentMCPAction> {
           agentName: agentConfiguration.name,
           icon: action.toolConfiguration.icon,
         },
+        status: action.status,
       });
     }
 
-    return pendingValidations;
+    return blockedActionsList;
   }
 
   static async listBlockedActionsForAgentMessage(

--- a/front/lib/swr/blocked_actions.ts
+++ b/front/lib/swr/blocked_actions.ts
@@ -1,28 +1,28 @@
 import type { Fetcher } from "swr";
 
 import { fetcher, useSWRWithDefaults } from "@app/lib/swr/swr";
-import type { GetPendingValidationsResponseType } from "@app/pages/api/w/[wId]/assistant/conversations/[cId]/pending-validations";
+import type { GetBlockedActionsResponseType } from "@app/pages/api/w/[wId]/assistant/conversations/[cId]/actions/blocked";
 
-export function usePendingValidations({
+export function useBlockedActions({
   conversationId,
   workspaceId,
 }: {
   conversationId: string | null;
   workspaceId: string;
 }) {
-  const pendingValidationsFetcher: Fetcher<GetPendingValidationsResponseType> =
+  const blockedActionsFetcher: Fetcher<GetBlockedActionsResponseType> =
     fetcher;
 
   const { data, error, mutate } = useSWRWithDefaults(
     conversationId
-      ? `/api/w/${workspaceId}/assistant/conversations/${conversationId}/pending-validations`
+      ? `/api/w/${workspaceId}/assistant/conversations/${conversationId}/actions/blocked`
       : null,
-    pendingValidationsFetcher,
+    blockedActionsFetcher,
     { disabled: conversationId === null }
   );
 
   return {
-    pendingValidations: data?.pendingValidations || [],
+    blockedActions: data?.blockedActions || [],
     isLoading: !error && !data,
     isError: error,
     mutate,

--- a/front/lib/swr/blocked_actions.ts
+++ b/front/lib/swr/blocked_actions.ts
@@ -10,8 +10,7 @@ export function useBlockedActions({
   conversationId: string | null;
   workspaceId: string;
 }) {
-  const blockedActionsFetcher: Fetcher<GetBlockedActionsResponseType> =
-    fetcher;
+  const blockedActionsFetcher: Fetcher<GetBlockedActionsResponseType> = fetcher;
 
   const { data, error, mutate } = useSWRWithDefaults(
     conversationId

--- a/front/pages/api/v1/w/[wId]/assistant/conversations/[cId]/actions/blocked.ts
+++ b/front/pages/api/v1/w/[wId]/assistant/conversations/[cId]/actions/blocked.ts
@@ -1,22 +1,20 @@
+import type { BlockedActionsResponseType } from "@dust-tt/client";
 import type { NextApiRequest, NextApiResponse } from "next";
 
-import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
+import { withPublicAPIAuthentication } from "@app/lib/api/auth_wrappers";
 import type { Authenticator } from "@app/lib/auth";
 import { AgentMCPActionResource } from "@app/lib/resources/agent_mcp_action_resource";
 import { apiError } from "@app/logger/withlogging";
-import type {
-  MCPActionValidationRequest,
-  WithAPIErrorResponse,
-} from "@app/types";
+import type { WithAPIErrorResponse } from "@app/types";
 import { isString } from "@app/types";
 
-export type GetPendingValidationsResponseType = {
-  pendingValidations: MCPActionValidationRequest[];
-};
+/**
+ * @ignoreswagger
+ */
 
 async function handler(
   req: NextApiRequest,
-  res: NextApiResponse<WithAPIErrorResponse<GetPendingValidationsResponseType>>,
+  res: NextApiResponse<WithAPIErrorResponse<BlockedActionsResponseType>>,
   auth: Authenticator
 ): Promise<void> {
   if (req.method !== "GET") {
@@ -41,13 +39,15 @@ async function handler(
     });
   }
 
-  const pendingValidations =
-    await AgentMCPActionResource.listPendingValidationsForConversation(
+  const blockedActions =
+    await AgentMCPActionResource.listBlockedActionsForConversation(
       auth,
       cId
     );
 
-  res.status(200).json({ pendingValidations });
+  res.status(200).json({ blockedActions });
 }
 
-export default withSessionAuthenticationForWorkspace(handler);
+export default withPublicAPIAuthentication(handler, {
+  requiredScopes: { GET: "read:conversation" },
+});

--- a/front/pages/api/v1/w/[wId]/assistant/conversations/[cId]/actions/blocked.ts
+++ b/front/pages/api/v1/w/[wId]/assistant/conversations/[cId]/actions/blocked.ts
@@ -40,10 +40,7 @@ async function handler(
   }
 
   const blockedActions =
-    await AgentMCPActionResource.listBlockedActionsForConversation(
-      auth,
-      cId
-    );
+    await AgentMCPActionResource.listBlockedActionsForConversation(auth, cId);
 
   res.status(200).json({ blockedActions });
 }

--- a/front/pages/api/w/[wId]/assistant/conversations/[cId]/actions/blocked.ts
+++ b/front/pages/api/w/[wId]/assistant/conversations/[cId]/actions/blocked.ts
@@ -1,17 +1,15 @@
 import type { NextApiRequest, NextApiResponse } from "next";
 
+import type { BlockedActionExecution } from "@app/lib/actions/mcp";
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
 import type { Authenticator } from "@app/lib/auth";
 import { AgentMCPActionResource } from "@app/lib/resources/agent_mcp_action_resource";
 import { apiError } from "@app/logger/withlogging";
-import type {
-  MCPActionValidationRequest,
-  WithAPIErrorResponse,
-} from "@app/types";
+import type { WithAPIErrorResponse } from "@app/types";
 import { isString } from "@app/types";
 
 export type GetBlockedActionsResponseType = {
-  blockedActions: MCPActionValidationRequest[];
+  blockedActions: BlockedActionExecution[];
 };
 
 async function handler(

--- a/front/pages/api/w/[wId]/assistant/conversations/[cId]/actions/blocked.ts
+++ b/front/pages/api/w/[wId]/assistant/conversations/[cId]/actions/blocked.ts
@@ -1,20 +1,22 @@
-import type { PendingValidationsResponseType } from "@dust-tt/client";
 import type { NextApiRequest, NextApiResponse } from "next";
 
-import { withPublicAPIAuthentication } from "@app/lib/api/auth_wrappers";
+import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
 import type { Authenticator } from "@app/lib/auth";
 import { AgentMCPActionResource } from "@app/lib/resources/agent_mcp_action_resource";
 import { apiError } from "@app/logger/withlogging";
-import type { WithAPIErrorResponse } from "@app/types";
+import type {
+  MCPActionValidationRequest,
+  WithAPIErrorResponse,
+} from "@app/types";
 import { isString } from "@app/types";
 
-/**
- * @ignoreswagger
- */
+export type GetBlockedActionsResponseType = {
+  blockedActions: MCPActionValidationRequest[];
+};
 
 async function handler(
   req: NextApiRequest,
-  res: NextApiResponse<WithAPIErrorResponse<PendingValidationsResponseType>>,
+  res: NextApiResponse<WithAPIErrorResponse<GetBlockedActionsResponseType>>,
   auth: Authenticator
 ): Promise<void> {
   if (req.method !== "GET") {
@@ -39,15 +41,10 @@ async function handler(
     });
   }
 
-  const pendingValidations =
-    await AgentMCPActionResource.listPendingValidationsForConversation(
-      auth,
-      cId
-    );
+  const blockedActions =
+    await AgentMCPActionResource.listBlockedActionsForConversation(auth, cId);
 
-  res.status(200).json({ pendingValidations });
+  res.status(200).json({ blockedActions });
 }
 
-export default withPublicAPIAuthentication(handler, {
-  requiredScopes: { GET: "read:conversation" },
-});
+export default withSessionAuthenticationForWorkspace(handler);

--- a/sdks/js/package-lock.json
+++ b/sdks/js/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@dust-tt/client",
-  "version": "1.1.7",
+  "version": "1.1.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@dust-tt/client",
-      "version": "1.1.7",
+      "version": "1.1.8",
       "bundleDependencies": [
         "@modelcontextprotocol/sdk"
       ],

--- a/sdks/js/package.json
+++ b/sdks/js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dust-tt/client",
-  "version": "1.1.7",
+  "version": "1.1.8",
   "description": "Client for Dust API",
   "repository": {
     "type": "git",

--- a/sdks/js/src/index.ts
+++ b/sdks/js/src/index.ts
@@ -10,6 +10,7 @@ import {
   AgentMessageSuccessEvent,
   APIError,
   AppsCheckRequestType,
+  BlockedActionsResponseType,
   CancelMessageGenerationRequestType,
   ConversationPublicType,
   CreateConversationResponseType,
@@ -50,6 +51,7 @@ import {
 import {
   APIErrorSchema,
   AppsCheckResponseSchema,
+  BlockedActionsResponseSchema,
   CancelMessageGenerationResponseSchema,
   CreateConversationResponseSchema,
   CreateGenericAgentConfigurationResponseSchema,
@@ -1421,6 +1423,19 @@ export class DustAPI {
   }
 
   // MCP Related.
+
+  async getBlockedActions({
+    conversationId,
+  }: {
+    conversationId: string;
+  }): Promise<Result<BlockedActionsResponseType, APIError>> {
+    const res = await this.request({
+      method: "GET",
+      path: `assistant/conversations/${conversationId}/actions/blocked`,
+    });
+
+    return this._resultFromResponse(BlockedActionsResponseSchema, res);
+  }
 
   async validateAction({
     conversationId,

--- a/sdks/js/src/types.ts
+++ b/sdks/js/src/types.ts
@@ -1082,19 +1082,36 @@ export type MCPValidationMetadataPublicType = z.infer<
   typeof MCPValidationMetadataSchema
 >;
 
-const PendingValidationSchema = z.object({
-  conversationId: z.string(),
-  messageId: z.string(),
+const ToolExecutionBlockedStatusSchema = z.enum([
+  "blocked_authentication_required",
+  "blocked_validation_required",
+]);
+
+export type ToolExecutionBlockedStatusType = z.infer<
+  typeof ToolExecutionBlockedStatusSchema
+>;
+
+const ToolExecutionMetadataSchema = z.object({
   actionId: z.string(),
   inputs: z.record(z.any()),
   stake: MCPStakeLevelSchema,
   metadata: MCPValidationMetadataSchema,
 });
 
-const MCPApproveExecutionEventSchema = PendingValidationSchema.extend({
+const BlockedActionExecutionSchema = ToolExecutionMetadataSchema.extend({
+  messageId: z.string(),
+  conversationId: z.string(),
+  status: ToolExecutionBlockedStatusSchema,
+});
+
+export type BlockedActionExecutionType = z.infer<typeof BlockedActionExecutionSchema>;
+
+const MCPApproveExecutionEventSchema = ToolExecutionMetadataSchema.extend({
   type: z.literal("tool_approve_execution"),
   created: z.number(),
   configurationId: z.string(),
+  messageId: z.string(),
+  conversationId: z.string(),
 });
 
 const ToolErrorEventSchema = z.object({
@@ -2993,12 +3010,12 @@ const MCP_VALIDATION_OUTPUTS = [
 export type MCPValidationOutputPublicType =
   (typeof MCP_VALIDATION_OUTPUTS)[number];
 
-export const PendingValidationsResponseSchema = z.object({
-  pendingValidations: z.array(PendingValidationSchema),
+export const BlockedActionsResponseSchema = z.object({
+  blockedActions: z.array(BlockedActionExecutionSchema),
 });
 
-export type PendingValidationsResponseType = z.infer<
-  typeof PendingValidationsResponseSchema
+export type BlockedActionsResponseType = z.infer<
+  typeof BlockedActionsResponseSchema
 >;
 
 const MCPViewsRequestAvailabilitySchema = z.enum(["manual", "auto"]);


### PR DESCRIPTION
## Description

This PR makes the interface around blocked actions less specific to the pending validations.
- The endpoint `pending-validations` is renamed into `actions/blocked`.
- It now returns all blocked actions, the goal will be to handle them similarly in the front-end. Currently we filter at the application-level for retrocompatibility.

## Tests

- Tested locally.

## Risk

- Still unused in the SDK.

## Deploy Plan

- Deploy front.
- Publish SDK.
