### PR TITLE
Add: toolsets server to explore toolsets

### DIFF
--- a/front/lib/actions/mcp_internal_actions/constants.test.ts
+++ b/front/lib/actions/mcp_internal_actions/constants.test.ts
@@ -42,6 +42,7 @@ describe("INTERNAL_MCP_SERVERS", () => {
       { name: "data_sources_file_system", id: 1010 },
       { name: "agent_management", id: 1011 },
       { name: "data_warehouses", id: 1012 },
+      { name: "toolsets", id: 1013 },
     ];
     expect(
       autoInternalTools,

--- a/front/lib/actions/mcp_internal_actions/constants.ts
+++ b/front/lib/actions/mcp_internal_actions/constants.ts
@@ -18,7 +18,6 @@ export const QUERY_TABLES_TOOL_NAME = "query_tables";
 export const GET_DATABASE_SCHEMA_TOOL_NAME = "get_database_schema";
 export const EXECUTE_DATABASE_QUERY_TOOL_NAME = "execute_database_query";
 export const PROCESS_TOOL_NAME = "extract_information_from_documents";
-export const RUN_AGENT_TOOL_NAME = "run_agent";
 export const CREATE_AGENT_TOOL_NAME = "create_agent";
 export const FIND_TAGS_TOOL_NAME = "find_tags";
 export const FILESYSTEM_CAT_TOOL_NAME = "cat";
@@ -40,39 +39,40 @@ export const AVAILABLE_INTERNAL_MCP_SERVER_NAMES = [
   // We'll prefix all tools with the server name to avoid conflicts.
   // It's okay to change the name of the server as we don't refer to it directly.
   "agent_management",
+  "agent_memory",
   "agent_router",
   "conversation_files",
   "data_sources_file_system",
+  "data_warehouses",
   "extract_data",
   "file_generation",
   "freshservice",
-  "interactive_content",
   "github",
   "gmail",
+  "google_calendar",
   "google_sheets",
   "hubspot",
   "image_generation",
   "include_data",
+  "interactive_content",
   "jira",
   "missing_action_catcher",
   "monday",
   "notion",
+  "outlook_calendar",
   "outlook",
   "primitive_types_debugger",
-  TABLE_QUERY_SERVER_NAME,
-  TABLE_QUERY_V2_SERVER_NAME,
   "reasoning",
   "run_agent",
   "run_dust_app",
   "salesforce",
-  SEARCH_SERVER_NAME,
-  "think",
-  "web_search_&_browse",
-  "google_calendar",
-  "outlook_calendar",
   "slack",
-  "agent_memory",
-  "data_warehouses",
+  "think",
+  "toolsets",
+  "web_search_&_browse",
+  SEARCH_SERVER_NAME,
+  TABLE_QUERY_SERVER_NAME,
+  TABLE_QUERY_V2_SERVER_NAME,
 ] as const;
 
 // Whether the server is available by default in the global space.
@@ -620,6 +620,17 @@ export const INTERNAL_MCP_SERVERS = {
     isPreview: true,
     isRestricted: ({ featureFlags }) => {
       return !featureFlags.includes("data_warehouses_tool");
+    },
+    tools_stakes: undefined,
+    timeoutMs: undefined,
+  },
+  toolsets: {
+    id: 1013,
+    availability: "auto",
+    allowMultipleInstances: false,
+    isPreview: false,
+    isRestricted: ({ featureFlags }) => {
+      return !featureFlags.includes("toolsets_tool");
     },
     tools_stakes: undefined,
     timeoutMs: undefined,

--- a/front/lib/actions/mcp_internal_actions/servers/index.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/index.ts
@@ -35,6 +35,7 @@ import { default as slackServer } from "@app/lib/actions/mcp_internal_actions/se
 import { default as tablesQueryServer } from "@app/lib/actions/mcp_internal_actions/servers/tables_query/server";
 import { default as tablesQueryServerV2 } from "@app/lib/actions/mcp_internal_actions/servers/tables_query/server_v2";
 import { default as thinkServer } from "@app/lib/actions/mcp_internal_actions/servers/think";
+import { default as toolsetsServer } from "@app/lib/actions/mcp_internal_actions/servers/toolsets";
 import { default as webtoolsServer } from "@app/lib/actions/mcp_internal_actions/servers/webtools";
 import type { AgentLoopContextType } from "@app/lib/actions/types";
 import {
@@ -150,6 +151,8 @@ export async function getInternalMCPServer(
       return freshserviceServer();
     case "data_warehouses":
       return dataWarehousesServer(auth, agentLoopContext);
+    case "toolsets":
+      return toolsetsServer(auth, agentLoopContext);
     default:
       assertNever(internalMCPServerName);
   }

--- a/front/lib/actions/mcp_internal_actions/servers/toolsets.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/toolsets.ts
@@ -1,0 +1,103 @@
+import { DustAPI, INTERNAL_MIME_TYPES } from "@dust-tt/client";
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+
+import {
+  getMcpServerViewDescription,
+  getMcpServerViewDisplayName,
+} from "@app/lib/actions/mcp_helper";
+import { getMCPServerRequirements } from "@app/lib/actions/mcp_internal_actions/input_configuration";
+import { makeInternalMCPServer } from "@app/lib/actions/mcp_internal_actions/utils";
+import { withToolLogging } from "@app/lib/actions/mcp_internal_actions/wrappers";
+import type { AgentLoopContextType } from "@app/lib/actions/types";
+import { isServerSideMCPServerConfiguration } from "@app/lib/actions/types/guards";
+import apiConfig from "@app/lib/api/config";
+import type { InternalMCPServerDefinitionType } from "@app/lib/api/mcp";
+import type { Authenticator } from "@app/lib/auth";
+import { prodAPICredentialsForOwner } from "@app/lib/auth";
+import { SpaceResource } from "@app/lib/resources/space_resource";
+import logger from "@app/logger/logger";
+import { getHeaderFromGroupIds, getHeaderFromRole, Ok } from "@app/types";
+
+export const TOOLSETS_FILESYSTEM_SERVER_NAME = "toolsets";
+
+const serverInfo: InternalMCPServerDefinitionType = {
+  name: TOOLSETS_FILESYSTEM_SERVER_NAME,
+  version: "1.0.0",
+  description:
+    "Comprehensive navigation toolkit for browsing Toolsets available. Toolsets provides functions for the agent to use.",
+  authorization: null,
+  icon: "ActionLightbulbIcon",
+  documentationUrl: null,
+};
+
+const createServer = (
+  auth: Authenticator,
+  agentLoopContext?: AgentLoopContextType
+): McpServer => {
+  const server = makeInternalMCPServer(serverInfo);
+
+  server.tool(
+    "list",
+    "List the available toolsets with their names and descriptions. This is like using 'ls' in Unix.",
+    {},
+    withToolLogging(auth, { toolName: "list", agentLoopContext }, async () => {
+      const mcpServerViewIdsFromAgentConfiguration =
+        agentLoopContext?.runContext?.agentConfiguration.actions
+          .filter(isServerSideMCPServerConfiguration)
+          .map((action) => action.mcpServerViewId) ?? [];
+
+      const owner = auth.getNonNullableWorkspace();
+      const requestedGroupIds = auth.groups().map((g) => g.sId);
+      const prodCredentials = await prodAPICredentialsForOwner(owner);
+      const config = apiConfig.getDustAPIConfig();
+      const api = new DustAPI(
+        config,
+        {
+          ...prodCredentials,
+          extraHeaders: {
+            ...getHeaderFromGroupIds(requestedGroupIds),
+            ...getHeaderFromRole(auth.role()),
+          },
+        },
+        logger,
+        config.nodeEnv === "development" ? "http://localhost:3000" : null
+      );
+      const globalSpace = await SpaceResource.fetchWorkspaceGlobalSpace(auth);
+      const r = await api.getMCPServerViews(globalSpace.sId, true);
+      if (r.isErr()) {
+        throw new Error(r.error.message);
+      }
+
+      const mcpServerViews = r.value
+        .filter(
+          (mcpServerView) =>
+            !mcpServerViewIdsFromAgentConfiguration.includes(mcpServerView.sId)
+        )
+        .filter(
+          (mcpServerView) =>
+            getMCPServerRequirements(mcpServerView).noRequirement
+        )
+        .filter(
+          (mcpServerView) =>
+            mcpServerView.server.availability !== "auto_hidden_builder"
+        );
+
+      return new Ok(
+        mcpServerViews.map((mcpServerView) => ({
+          type: "resource" as const,
+          resource: {
+            mimeType: INTERNAL_MIME_TYPES.TOOL_OUTPUT.TOOLSET_LIST_RESULT,
+            uri: "",
+            id: mcpServerView.sId,
+            text: getMcpServerViewDisplayName(mcpServerView),
+            description: getMcpServerViewDescription(mcpServerView),
+          },
+        }))
+      );
+    })
+  );
+
+  return server;
+};
+
+export default createServer;

--- a/front/lib/api/mcp.ts
+++ b/front/lib/api/mcp.ts
@@ -15,7 +15,7 @@ import type { EditedByUser, MCPOAuthUseCase, ModelId } from "@app/types";
 export type MCPToolType = {
   name: string;
   description: string;
-  inputSchema: JSONSchema | undefined;
+  inputSchema?: JSONSchema;
 };
 
 export type MCPToolWithAvailabilityType = MCPToolType & {

--- a/front/pages/api/v1/w/[wId]/spaces/[spaceId]/mcp_server_views/index.test.ts
+++ b/front/pages/api/v1/w/[wId]/spaces/[spaceId]/mcp_server_views/index.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it } from "vitest";
+
+import { Authenticator } from "@app/lib/auth";
+import { MCPServerViewResource } from "@app/lib/resources/mcp_server_view_resource";
+import {
+  createPublicApiAuthenticationTests,
+  createPublicApiMockRequest,
+} from "@app/tests/utils/generic_public_api_tests";
+import { MCPServerViewFactory } from "@app/tests/utils/MCPServerViewFactory";
+import { RemoteMCPServerFactory } from "@app/tests/utils/RemoteMCPServerFactory";
+import { SpaceFactory } from "@app/tests/utils/SpaceFactory";
+
+import handler from "./index";
+
+describe(
+  "public api authentication tests",
+  createPublicApiAuthenticationTests(handler)
+);
+
+describe("GET /api/w/[wId]/spaces/[spaceId]/mcp_views", () => {
+  it("returns MCP servers views", async () => {
+    const { req, res, workspace } = await createPublicApiMockRequest();
+
+    const auth = await Authenticator.internalAdminForWorkspace(workspace.sId);
+
+    // Create spaces
+    const { globalSpace } = await SpaceFactory.defaults(auth);
+    const otherSpace = await SpaceFactory.regular(workspace);
+    req.query.spaceId = globalSpace.sId;
+
+    const server = await RemoteMCPServerFactory.create(workspace);
+    const server2 = await RemoteMCPServerFactory.create(workspace);
+    const server3 = await RemoteMCPServerFactory.create(workspace);
+
+    // Create system view
+    await MCPServerViewResource.getMCPServerViewForSystemSpace(
+      auth,
+      server.sId
+    );
+
+    // Create additional views in global space for the same server
+    const view1 = await MCPServerViewFactory.create(
+      workspace,
+      server.sId,
+      globalSpace
+    );
+    const view2 = await MCPServerViewFactory.create(
+      workspace,
+      server2.sId,
+      globalSpace
+    );
+
+    // An in another space to make sure they are not returned
+    await MCPServerViewFactory.create(workspace, server.sId, otherSpace);
+    await MCPServerViewFactory.create(workspace, server3.sId, otherSpace);
+
+    await handler(req, res);
+
+    expect(res._getStatusCode()).toBe(200);
+    expect(res._getJSONData()).toEqual({
+      success: true,
+      serverViews: expect.any(Array),
+    });
+    expect(res._getJSONData().serverViews).toEqual([
+      view1.toJSON(),
+      view2.toJSON(),
+    ]);
+  });
+});

--- a/front/pages/api/v1/w/[wId]/spaces/[spaceId]/mcp_server_views/index.ts
+++ b/front/pages/api/v1/w/[wId]/spaces/[spaceId]/mcp_server_views/index.ts
@@ -1,0 +1,92 @@
+import type { GetMCPServerViewsResponseType } from "@dust-tt/client";
+import { GetMCPServerViewsQuerySchema } from "@dust-tt/client";
+import type { NextApiRequest, NextApiResponse } from "next";
+
+import { withPublicAPIAuthentication } from "@app/lib/api/auth_wrappers";
+import { withResourceFetchingFromRoute } from "@app/lib/api/resource_wrappers";
+import type { Authenticator } from "@app/lib/auth";
+import { MCPServerViewResource } from "@app/lib/resources/mcp_server_view_resource";
+import type { SpaceResource } from "@app/lib/resources/space_resource";
+import type { WithAPIErrorResponse } from "@app/types";
+
+/**
+ * @swagger
+ * /api/v1/w/{wId}/spaces/{spaceId}/mcp_server_views:
+ *   get:
+ *     summary: List available MCP server views.
+ *     description: Retrieves a list of enabled MCP server views (aka tools) for a specific space of the authenticated workspace.
+ *     tags:
+ *       - Tools
+ *     security:
+ *       - BearerAuth: []
+ *     parameters:
+ *       - in: path
+ *         name: wId
+ *         required: true
+ *         description: Unique string identifier for the workspace
+ *         schema:
+ *           type: string
+ *       - in: path
+ *         name: spaceId
+ *         required: true
+ *         description: ID of the space
+ *         schema:
+ *           type: string
+ *     responses:
+ *       200:
+ *         description: MCP server views of the space
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 spaces:
+ *                   type: array
+ *                   items:
+ *                     $ref: '#/components/schemas/MCPServerView'
+ *       400:
+ *         description: Bad Request. Missing or invalid parameters.
+ *       401:
+ *         description: Unauthorized. Invalid or missing authentication token.
+ *       404:
+ *         description: Workspace not found.
+ *       405:
+ *         description: Method not supported.
+ *       500:
+ *         description: Internal Server Error.
+ */
+async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse<WithAPIErrorResponse<GetMCPServerViewsResponseType>>,
+  auth: Authenticator,
+  { space }: { space: SpaceResource }
+): Promise<void> {
+  const { method } = req;
+
+  switch (method) {
+    case "GET": {
+      const { includeAuto } = GetMCPServerViewsQuerySchema.parse(req.query);
+
+      const mcpServerViews = await MCPServerViewResource.listBySpace(
+        auth,
+        space
+      );
+      return res.status(200).json({
+        success: true,
+        serverViews: mcpServerViews
+          .map((mcpServerView) => mcpServerView.toJSON())
+          .filter(
+            (s) =>
+              s.server.availability === "manual" ||
+              (includeAuto && s.server.availability === "auto")
+          ),
+      });
+    }
+  }
+}
+
+export default withPublicAPIAuthentication(
+  withResourceFetchingFromRoute(handler, {
+    space: { requireCanReadOrAdministrate: true },
+  })
+);

--- a/front/pages/api/w/[wId]/mcp/views/index.ts
+++ b/front/pages/api/w/[wId]/mcp/views/index.ts
@@ -1,6 +1,5 @@
-import type { MCPViewsRequestAvailabilityType } from "@dust-tt/client";
-import { GetMCPViewsRequestSchema } from "@dust-tt/client";
 import type { NextApiRequest, NextApiResponse } from "next";
+import { z } from "zod";
 import { fromError } from "zod-validation-error";
 
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
@@ -12,6 +11,16 @@ import { concurrentExecutor } from "@app/lib/utils/async_utils";
 import { apiError } from "@app/logger/withlogging";
 import type { WithAPIErrorResponse } from "@app/types";
 import { isString } from "@app/types";
+
+const MCPViewsRequestAvailabilitySchema = z.enum(["manual", "auto"]);
+type MCPViewsRequestAvailabilityType = z.infer<
+  typeof MCPViewsRequestAvailabilitySchema
+>;
+
+const GetMCPViewsRequestSchema = z.object({
+  spaceIds: z.array(z.string()),
+  availabilities: z.array(MCPViewsRequestAvailabilitySchema),
+});
 
 export type GetMCPServerViewsListResponseBody = {
   success: boolean;

--- a/front/types/assistant/conversation.ts
+++ b/front/types/assistant/conversation.ts
@@ -94,6 +94,7 @@ export type UserMessageContext = {
   profilePictureUrl: string | null;
   origin?: UserMessageOrigin | null;
   clientSideMCPServerIds?: string[];
+  selectedMCPServerViewIds?: string[];
 };
 
 export type UserMessageType = {

--- a/front/types/shared/feature_flags.ts
+++ b/front/types/shared/feature_flags.ts
@@ -160,6 +160,10 @@ export const WHITELISTABLE_FEATURES_CONFIG = {
     description: "Human Out Of The Loop (aka Triggers)",
     stage: "dust_only",
   },
+  toolsets_tool: {
+    description: "Toolsets MCP tool",
+    stage: "dust_only",
+  },
 } as const satisfies Record<string, FeatureFlag>;
 
 export type FeatureFlagStage = "dust_only" | "rolling_out" | "on_demand";

--- a/sdks/js/src/index.ts
+++ b/sdks/js/src/index.ts
@@ -28,6 +28,7 @@ import {
   DustAppRunTokensEvent,
   FileUploadUrlRequestType,
   GenerationTokensEvent,
+  GetMCPServerViewsResponseSchema,
   HeartbeatMCPResponseType,
   LoggerInterface,
   PatchDataSourceViewRequestType,
@@ -1327,6 +1328,24 @@ export class DustAPI {
       return r;
     }
     return new Ok(r.value.spaces);
+  }
+
+  async getMCPServerViews(spaceId: string, includeAuto = false) {
+    const res = await this.request({
+      method: "GET",
+      path: `spaces/${spaceId}/mcp_server_views`,
+      query: new URLSearchParams({ includeAuto: includeAuto.toString() }),
+    });
+
+    const r = await this._resultFromResponse(
+      GetMCPServerViewsResponseSchema,
+      res
+    );
+
+    if (r.isErr()) {
+      return r;
+    }
+    return new Ok(r.value.serverViews);
   }
 
   async searchNodes(searchParams: SearchRequestBodyType) {

--- a/sdks/js/src/internal_mime_types.ts
+++ b/sdks/js/src/internal_mime_types.ts
@@ -272,6 +272,8 @@ const TOOL_MIME_TYPES = {
       "RUN_AGENT_QUERY",
       "WARNING",
       "AGENT_CREATION_RESULT",
+      "TOOLSET_LIST_RESULT",
+      "TOOLSET_DESCRIBE_RESULT",
       // Legacy, kept for backwards compatibility.
       "GET_DATABASE_SCHEMA_MARKER",
       "EXECUTE_TABLES_QUERY_MARKER",

--- a/sdks/js/src/types.ts
+++ b/sdks/js/src/types.ts
@@ -589,16 +589,19 @@ const WhitelistableFeaturesSchema = FlexibleEnumSchema<
   | "advanced_search"
   | "agent_builder_instructions_autocomplete"
   | "agent_builder_v2"
+  | "agent_management_tool"
   | "agent_to_yaml"
   | "anthropic_vertex_fallback"
   | "claude_4_opus_feature"
   | "co_edition"
+  | "data_warehouses_tool"
   | "deepseek_feature"
   | "deepseek_r1_global_agent_feature"
   | "dev_mcp_actions"
   | "disable_run_logs"
   | "disallow_agent_creation_to_users"
   | "exploded_tables_query"
+  | "freshservice_tool"
   | "google_ai_studio_experimental_models_feature"
   | "google_sheets_tool"
   | "hootl"
@@ -614,15 +617,14 @@ const WhitelistableFeaturesSchema = FlexibleEnumSchema<
   | "openai_o1_feature"
   | "openai_o1_high_reasoning_custom_assistants_feature"
   | "openai_o1_high_reasoning_feature"
-  | "freshservice_tool"
   | "research_agent"
   | "salesforce_synced_queries"
   | "salesforce_tool"
   | "show_debug_tools"
+  | "slack_semantic_search"
+  | "toolsets_tool"
   | "usage_data_api"
   | "xai_feature"
-  | "agent_management_tool"
-  | "data_warehouses_tool"
 >();
 
 export type WhitelistableFeature = z.infer<typeof WhitelistableFeaturesSchema>;
@@ -2537,6 +2539,261 @@ export const GetSpacesResponseSchema = z.object({
 
 export type GetSpacesResponseType = z.infer<typeof GetSpacesResponseSchema>;
 
+const OAuthProviderSchema = FlexibleEnumSchema<
+  | "confluence"
+  | "freshservice"
+  | "github"
+  | "google_drive"
+  | "gmail"
+  | "intercom"
+  | "jira"
+  | "monday"
+  | "notion"
+  | "slack"
+  | "gong"
+  | "microsoft"
+  | "microsoft_tools"
+  | "zendesk"
+  | "salesforce"
+  | "hubspot"
+  | "mcp"
+  | "mcp_static"
+>();
+
+const InternalAllowedIconSchema = FlexibleEnumSchema<
+  | "ActionBrainIcon"
+  | "ActionCloudArrowLeftRightIcon"
+  | "ActionDocumentTextIcon"
+  | "ActionEmotionLaughIcon"
+  | "ActionGitBranchIcon"
+  | "ActionGlobeAltIcon"
+  | "ActionImageIcon"
+  | "ActionLightbulbIcon"
+  | "ActionLockIcon"
+  | "ActionMagnifyingGlassIcon"
+  | "ActionRobotIcon"
+  | "ActionScanIcon"
+  | "ActionTableIcon"
+  | "ActionTimeIcon"
+  | "CommandLineIcon"
+  | "GcalLogo"
+  | "GithubLogo"
+  | "GmailLogo"
+  | "GoogleSpreadsheetLogo"
+  | "FreshserviceLogo"
+  | "HubspotLogo"
+  | "OutlookLogo"
+  | "JiraLogo"
+  | "LinearLogo"
+  | "MondayLogo"
+  | "NotionLogo"
+  | "SalesforceLogo"
+  | "SlackLogo"
+  | "StripeLogo"
+>();
+
+const CustomServerIconSchema = FlexibleEnumSchema<
+  | "ActionArmchairIcon"
+  | "ActionArrowDownOnSquareIcon"
+  | "ActionArrowUpOnSquareIcon"
+  | "ActionAttachmentIcon"
+  | "ActionBankIcon"
+  | "ActionBarcodeIcon"
+  | "ActionBeerIcon"
+  | "ActionBookOpenIcon"
+  | "ActionBracesIcon"
+  | "ActionBrainIcon"
+  | "ActionBriefcaseIcon"
+  | "ActionBuildingIcon"
+  | "ActionCalculatorIcon"
+  | "ActionCalendarIcon"
+  | "ActionCalendarCheckIcon"
+  | "ActionCameraIcon"
+  | "ActionCarIcon"
+  | "ActionCardIcon"
+  | "ActionCheckCircleIcon"
+  | "ActionClipboardIcon"
+  | "ActionCloudArrowDownIcon"
+  | "ActionCloudArrowLeftRightIcon"
+  | "ActionCloudArrowUpIcon"
+  | "ActionCodeBlockIcon"
+  | "ActionCodeBoxIcon"
+  | "ActionCommandIcon"
+  | "ActionCommand1Icon"
+  | "ActionCommunityIcon"
+  | "ActionCompanyIcon"
+  | "ActionCubeIcon"
+  | "ActionCupIcon"
+  | "ActionCustomerServiceIcon"
+  | "ActionDashboardIcon"
+  | "ActionDatabaseIcon"
+  | "ActionDocumentIcon"
+  | "ActionDocumentPileIcon"
+  | "ActionDocumentPlusIcon"
+  | "ActionDocumentTextIcon"
+  | "ActionDoubleQuotesIcon"
+  | "ActionEmotionLaughIcon"
+  | "ActionExternalLinkIcon"
+  | "ActionEyeIcon"
+  | "ActionEyeSlashIcon"
+  | "ActionFilmIcon"
+  | "ActionFilterIcon"
+  | "ActionFingerprintIcon"
+  | "ActionFireIcon"
+  | "ActionFlagIcon"
+  | "ActionFlightLandIcon"
+  | "ActionFlightTakeoffIcon"
+  | "ActionFolderIcon"
+  | "ActionFolderAddIcon"
+  | "ActionFolderOpenIcon"
+  | "ActionFullscreenIcon"
+  | "ActionFullscreenExitIcon"
+  | "ActionGamepadIcon"
+  | "ActionGitBranchIcon"
+  | "ActionGitForkIcon"
+  | "ActionGlobeIcon"
+  | "ActionGlobeAltIcon"
+  | "ActionGraduationCapIcon"
+  | "ActionHandHeartIcon"
+  | "ActionHandThumbDownIcon"
+  | "ActionHandThumbUpIcon"
+  | "ActionHeartIcon"
+  | "ActionHomeIcon"
+  | "ActionHospitalIcon"
+  | "ActionImageIcon"
+  | "ActionInboxIcon"
+  | "ActionIncludeIcon"
+  | "ActionLayoutIcon"
+  | "ActionLightbulbIcon"
+  | "ActionListIcon"
+  | "ActionListCheckIcon"
+  | "ActionLockIcon"
+  | "ActionLogoutIcon"
+  | "ActionMagicIcon"
+  | "ActionMagnifyingGlassIcon"
+  | "ActionMailIcon"
+  | "ActionMailAiIcon"
+  | "ActionMailCloseIcon"
+  | "ActionMapIcon"
+  | "ActionMapPinIcon"
+  | "ActionMarkPenIcon"
+  | "ActionMedalIcon"
+  | "ActionMegaphoneIcon"
+  | "ActionMenuIcon"
+  | "ActionMicIcon"
+  | "ActionMoonIcon"
+  | "ActionMovieIcon"
+  | "ActionNumbersIcon"
+  | "ActionPaintIcon"
+  | "ActionPencilSquareIcon"
+  | "ActionPieChartIcon"
+  | "ActionPinDistanceIcon"
+  | "ActionPingPongIcon"
+  | "ActionPlanetIcon"
+  | "ActionPlusIcon"
+  | "ActionPlusCircleIcon"
+  | "ActionPrinterIcon"
+  | "ActionPushpinIcon"
+  | "ActionRainbowIcon"
+  | "ActionRobotIcon"
+  | "ActionRocketIcon"
+  | "ActionSafeIcon"
+  | "ActionSaveIcon"
+  | "ActionScalesIcon"
+  | "ActionScanIcon"
+  | "ActionSeedlingIcon"
+  | "ActionServerIcon"
+  | "ActionShakeHandsIcon"
+  | "ActionShipIcon"
+  | "ActionShirtIcon"
+  | "ActionShoppingBasketIcon"
+  | "ActionSlideshowIcon"
+  | "ActionSparklesIcon"
+  | "ActionSquare3Stack3DIcon"
+  | "ActionStopSignIcon"
+  | "ActionStoreIcon"
+  | "ActionSunIcon"
+  | "ActionSwordIcon"
+  | "ActionTableIcon"
+  | "ActionTagIcon"
+  | "ActionTestTubeIcon"
+  | "ActionTimeIcon"
+  | "ActionTrainIcon"
+  | "ActionTranslateIcon"
+  | "ActionTrashIcon"
+  | "ActionTrophyIcon"
+  | "ActionTShirtIcon"
+  | "ActionUmbrellaIcon"
+  | "ActionUserIcon"
+  | "ActionUserGroupIcon"
+  | "ActionVidiconIcon"
+  | "ActionVolumeUpIcon"
+  | "ActionXCircleIcon"
+>();
+
+const MCPServerTypeSchema = z.object({
+  sId: z.string(),
+  name: z.string(),
+  version: z.string(),
+  description: z.string(),
+  icon: z.union([InternalAllowedIconSchema, CustomServerIconSchema]),
+  authorization: z
+    .object({
+      provider: OAuthProviderSchema,
+      supported_use_cases: z.array(
+        z.enum(["personal_actions", "platform_actions"])
+      ),
+      scope: z.string().optional(),
+    })
+    .nullable(),
+  tools: z.array(
+    z.object({
+      name: z.string(),
+      description: z.string(),
+      inputSchema: z.any().optional(),
+    })
+  ),
+  availability: z.enum(["manual", "auto", "auto_hidden_builder"]),
+  allowMultipleInstances: z.boolean(),
+  documentationUrl: z.string().nullable(),
+});
+
+const MCPServerViewTypeSchema = z.object({
+  id: z.number(),
+  sId: z.string(),
+  name: z.string().nullable(),
+  description: z.string().nullable(),
+  createdAt: z.number(),
+  updatedAt: z.number(),
+  spaceId: z.string(),
+  serverType: z.enum(["remote", "internal"]),
+  server: MCPServerTypeSchema,
+  oAuthUseCase: z.enum(["personal_actions", "platform_actions"]).nullable(),
+  editedByUser: EditedByUserSchema.nullable(),
+});
+
+export type MCPServerViewType = z.infer<typeof MCPServerViewTypeSchema>;
+
+export const GetMCPServerViewsResponseSchema = z.object({
+  success: z.literal(true),
+  serverViews: z.array(MCPServerViewTypeSchema),
+});
+
+export type GetMCPServerViewsResponseType = z.infer<
+  typeof GetMCPServerViewsResponseSchema
+>;
+
+export const GetMCPServerViewsQuerySchema = z.object({
+  includeAuto: z
+    .enum(["true", "false"])
+    .transform((val) => val === "true")
+    .optional(),
+});
+
+export type GetMCPServerViewsQueryType = z.infer<
+  typeof GetMCPServerViewsQuerySchema
+>;
+
 export const BaseSearchBodySchema = z.object({
   viewType: ContentNodesViewTypeSchema,
   spaceIds: z.array(z.string()),
@@ -2732,6 +2989,7 @@ const MCP_VALIDATION_OUTPUTS = [
   "rejected",
   "always_approved",
 ] as const;
+
 export type MCPValidationOutputPublicType =
   (typeof MCP_VALIDATION_OUTPUTS)[number];
 


### PR DESCRIPTION
## Description

Add MCP servers to discover toolsets, behind a FF.
Add public endpoint to list toolsets.

Went for only listing names & descriptions, seems to work fine.

Will definitely need some prompting to explain how and when to use it.

## Tests

Local + added

<img width="1186" height="1169" alt="image" src="https://github.com/user-attachments/assets/08588cd1-9ef8-4ad9-bc8f-d74df37671f0" />

<img width="1249" height="1337" alt="image" src="https://github.com/user-attachments/assets/f0941e18-828a-4695-9358-9aad98544a89" />


## Risk

Low

## Deploy Plan

Deploy front
