### PR TITLE
Sparkle Icon -> Eye Icon / Canvas

### DIFF
--- a/front/components/assistant/conversation/content/ClientExecutableRenderer.tsx
+++ b/front/components/assistant/conversation/content/ClientExecutableRenderer.tsx
@@ -7,7 +7,7 @@ import {
   DropdownMenuContent,
   DropdownMenuItem,
   DropdownMenuTrigger,
-  SparklesIcon,
+  EyeIcon,
   Spinner,
 } from "@dust-tt/sparkle";
 import React from "react";
@@ -120,7 +120,7 @@ export function ClientExecutableRenderer({
         onClose={closePanel}
       >
         <Button
-          icon={showCode ? SparklesIcon : CommandLineIcon}
+          icon={showCode ? EyeIcon : CommandLineIcon}
           onClick={() => setShowCode(!showCode)}
           size="xs"
           tooltip={showCode ? "Switch to Rendering" : "Switch to Code"}

--- a/sparkle/src/components/markdown/CodeBlockWithExtendedSupport.tsx
+++ b/sparkle/src/components/markdown/CodeBlockWithExtendedSupport.tsx
@@ -25,7 +25,7 @@ import {
   JsonValueType,
   PrettyJsonViewer,
 } from "@sparkle/components/markdown/PrettyJsonViewer";
-import { CommandLineIcon, SparklesIcon } from "@sparkle/icons/app";
+import { CommandLineIcon, EyeIcon } from "@sparkle/icons/app";
 import { cn } from "@sparkle/lib/utils";
 
 const PRETTY_JSON_PREFERENCE_KEY = "pretty-json-preference";
@@ -389,7 +389,7 @@ export function CodeBlockWithExtendedSupport({
             size="xs"
             variant={"outline"}
             label={showMermaid ? "Markdown" : "Mermaid"}
-            icon={showMermaid ? CommandLineIcon : SparklesIcon}
+            icon={showMermaid ? CommandLineIcon : EyeIcon}
             onClick={() => setShowMermaid(!showMermaid)}
             tooltip={showMermaid ? "Switch to Markdown" : "Switch to Mermaid"}
           />
@@ -417,7 +417,7 @@ export function CodeBlockWithExtendedSupport({
             size="xs"
             variant={"outline"}
             label={showPrettyJson ? "Raw JSON" : "Pretty JSON"}
-            icon={showPrettyJson ? CommandLineIcon : SparklesIcon}
+            icon={showPrettyJson ? CommandLineIcon : EyeIcon}
             onClick={() => {
               const newValue = !showPrettyJson;
               setShowPrettyJson(newValue);

--- a/sparkle/src/components/markdown/CodeBlockWithExtendedSupport.tsx
+++ b/sparkle/src/components/markdown/CodeBlockWithExtendedSupport.tsx
@@ -25,7 +25,7 @@ import {
   JsonValueType,
   PrettyJsonViewer,
 } from "@sparkle/components/markdown/PrettyJsonViewer";
-import { CommandLineIcon, EyeIcon } from "@sparkle/icons/app";
+import { CommandLineIcon, SparklesIcon } from "@sparkle/icons/app";
 import { cn } from "@sparkle/lib/utils";
 
 const PRETTY_JSON_PREFERENCE_KEY = "pretty-json-preference";
@@ -389,7 +389,7 @@ export function CodeBlockWithExtendedSupport({
             size="xs"
             variant={"outline"}
             label={showMermaid ? "Markdown" : "Mermaid"}
-            icon={showMermaid ? CommandLineIcon : EyeIcon}
+            icon={showMermaid ? CommandLineIcon : SparklesIcon}
             onClick={() => setShowMermaid(!showMermaid)}
             tooltip={showMermaid ? "Switch to Markdown" : "Switch to Mermaid"}
           />
@@ -417,7 +417,7 @@ export function CodeBlockWithExtendedSupport({
             size="xs"
             variant={"outline"}
             label={showPrettyJson ? "Raw JSON" : "Pretty JSON"}
-            icon={showPrettyJson ? CommandLineIcon : EyeIcon}
+            icon={showPrettyJson ? CommandLineIcon : SparklesIcon}
             onClick={() => {
               const newValue = !showPrettyJson;
               setShowPrettyJson(newValue);


### PR DESCRIPTION
## Description

Changing the SparkleIcon to EyeIcon for Canvas

## Tests


## Risk
very low - UI break

## Deploy Plan
Deploy
Merge
