### PR TITLE
feat: add tool to export large number of logs from DD

### DIFF
--- a/tools/datadog-log-exporter/.gitignore
+++ b/tools/datadog-log-exporter/.gitignore
@@ -1,0 +1,20 @@
+# Dependencies
+node_modules/
+
+# Build output
+dist/
+
+# Local env/config
+.env
+.env.*
+
+# Runtime artifacts
+*.log
+*.csv
+*.state.json
+
+# OS/editor noise
+.DS_Store
+*.swp
+*.swo
+

--- a/tools/datadog-log-exporter/README.md
+++ b/tools/datadog-log-exporter/README.md
@@ -1,0 +1,37 @@
+# Datadog Log Exporter
+
+Export large ranges of Datadog logs to CSV. Paginates by timestamp (newest → oldest), handles rate limits, and can resume after interruption.
+
+Requirements
+
+- Node 18+
+- Env vars: `DATADOG_API_KEY`, `DATADOG_APP_KEY` (optional `DATADOG_SITE`, default `datadoghq.com`)
+
+Quick Start
+
+- `cd tools/datadog-log-exporter`
+- `./run.sh --query '@connectorId:145 @action:skip_deletion' --columns 'timestamp,id,connectorId,action,message,service,host' --out logs.csv`
+
+Columns
+
+- Use Datadog attribute names without the leading `@` (e.g., `@http.status_code` → `http.status_code`).
+- Special columns: `id`, `timestamp`.
+
+Options
+
+- `--query <q>`: Datadog log query (required)
+- `--columns <c1,c2,...>`: CSV columns (required)
+- `--out <path>`: Output CSV (default `datadog-logs.csv`)
+- `--from <ISO>` / `--to <ISO>`: Time range (default last 14 days)
+- `--page-limit <n≤1000>`: Page size (default 1000)
+- `--target-per-window <n>`: Target logs per window (default 2000)
+- `--initial-window|--max-window|--min-window <dur>`: Defaults 15m / 6h / 1m
+- `--resume <true|false>`: Resume from state (default true)
+
+Resume
+
+- Uses `<out>.state.json`. Re-run the same command (same `--out`) to continue where it left off.
+
+Fresh Run
+
+- Delete the CSV and its state file to start over.

--- a/tools/datadog-log-exporter/package-lock.json
+++ b/tools/datadog-log-exporter/package-lock.json
@@ -1,0 +1,593 @@
+{
+  "name": "datadog-log-exporter",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "datadog-log-exporter",
+      "version": "0.1.0",
+      "devDependencies": {
+        "@types/node": "^20.11.30",
+        "tsx": "^4.19.0",
+        "typescript": "^5.5.4"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.25.9",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.25.9.tgz",
+      "integrity": "sha512-OaGtL73Jck6pBKjNIe24BnFE6agGl+6KxDtTfHhy1HmhthfKouEcOhqpSL64K4/0WCtbKFLOdzD/44cJ4k9opA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.25.9",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.25.9.tgz",
+      "integrity": "sha512-5WNI1DaMtxQ7t7B6xa572XMXpHAaI/9Hnhk8lcxF4zVN4xstUgTlvuGDorBguKEnZO70qwEcLpfifMLoxiPqHQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.25.9",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.25.9.tgz",
+      "integrity": "sha512-IDrddSmpSv51ftWslJMvl3Q2ZT98fUSL2/rlUXuVqRXHCs5EUF1/f+jbjF5+NG9UffUDMCiTyh8iec7u8RlTLg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.25.9",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.25.9.tgz",
+      "integrity": "sha512-I853iMZ1hWZdNllhVZKm34f4wErd4lMyeV7BLzEExGEIZYsOzqDWDf+y082izYUE8gtJnYHdeDpN/6tUdwvfiw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.25.9",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.25.9.tgz",
+      "integrity": "sha512-XIpIDMAjOELi/9PB30vEbVMs3GV1v2zkkPnuyRRURbhqjyzIINwj+nbQATh4H9GxUgH1kFsEyQMxwiLFKUS6Rg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.25.9",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.25.9.tgz",
+      "integrity": "sha512-jhHfBzjYTA1IQu8VyrjCX4ApJDnH+ez+IYVEoJHeqJm9VhG9Dh2BYaJritkYK3vMaXrf7Ogr/0MQ8/MeIefsPQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.25.9",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.25.9.tgz",
+      "integrity": "sha512-z93DmbnY6fX9+KdD4Ue/H6sYs+bhFQJNCPZsi4XWJoYblUqT06MQUdBCpcSfuiN72AbqeBFu5LVQTjfXDE2A6Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.25.9",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.25.9.tgz",
+      "integrity": "sha512-mrKX6H/vOyo5v71YfXWJxLVxgy1kyt1MQaD8wZJgJfG4gq4DpQGpgTB74e5yBeQdyMTbgxp0YtNj7NuHN0PoZg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.25.9",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.25.9.tgz",
+      "integrity": "sha512-HBU2Xv78SMgaydBmdor38lg8YDnFKSARg1Q6AT0/y2ezUAKiZvc211RDFHlEZRFNRVhcMamiToo7bDx3VEOYQw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.25.9",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.25.9.tgz",
+      "integrity": "sha512-BlB7bIcLT3G26urh5Dmse7fiLmLXnRlopw4s8DalgZ8ef79Jj4aUcYbk90g8iCa2467HX8SAIidbL7gsqXHdRw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.25.9",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.25.9.tgz",
+      "integrity": "sha512-e7S3MOJPZGp2QW6AK6+Ly81rC7oOSerQ+P8L0ta4FhVi+/j/v2yZzx5CqqDaWjtPFfYz21Vi1S0auHrap3Ma3A==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.25.9",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.25.9.tgz",
+      "integrity": "sha512-Sbe10Bnn0oUAB2AalYztvGcK+o6YFFA/9829PhOCUS9vkJElXGdphz0A3DbMdP8gmKkqPmPcMJmJOrI3VYB1JQ==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.25.9",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.25.9.tgz",
+      "integrity": "sha512-YcM5br0mVyZw2jcQeLIkhWtKPeVfAerES5PvOzaDxVtIyZ2NUBZKNLjC5z3/fUlDgT6w89VsxP2qzNipOaaDyA==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.25.9",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.25.9.tgz",
+      "integrity": "sha512-++0HQvasdo20JytyDpFvQtNrEsAgNG2CY1CLMwGXfFTKGBGQT3bOeLSYE2l1fYdvML5KUuwn9Z8L1EWe2tzs1w==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.25.9",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.25.9.tgz",
+      "integrity": "sha512-uNIBa279Y3fkjV+2cUjx36xkx7eSjb8IvnL01eXUKXez/CBHNRw5ekCGMPM0BcmqBxBcdgUWuUXmVWwm4CH9kg==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.25.9",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.25.9.tgz",
+      "integrity": "sha512-Mfiphvp3MjC/lctb+7D287Xw1DGzqJPb/J2aHHcHxflUo+8tmN/6d4k6I2yFR7BVo5/g7x2Monq4+Yew0EHRIA==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.25.9",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.25.9.tgz",
+      "integrity": "sha512-iSwByxzRe48YVkmpbgoxVzn76BXjlYFXC7NvLYq+b+kDjyyk30J0JY47DIn8z1MO3K0oSl9fZoRmZPQI4Hklzg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.25.9",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.25.9.tgz",
+      "integrity": "sha512-9jNJl6FqaUG+COdQMjSCGW4QiMHH88xWbvZ+kRVblZsWrkXlABuGdFJ1E9L7HK+T0Yqd4akKNa/lO0+jDxQD4Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.25.9",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.25.9.tgz",
+      "integrity": "sha512-RLLdkflmqRG8KanPGOU7Rpg829ZHu8nFy5Pqdi9U01VYtG9Y0zOG6Vr2z4/S+/3zIyOxiK6cCeYNWOFR9QP87g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.25.9",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.25.9.tgz",
+      "integrity": "sha512-YaFBlPGeDasft5IIM+CQAhJAqS3St3nJzDEgsgFixcfZeyGPCd6eJBWzke5piZuZ7CtL656eOSYKk4Ls2C0FRQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.25.9",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.25.9.tgz",
+      "integrity": "sha512-1MkgTCuvMGWuqVtAvkpkXFmtL8XhWy+j4jaSO2wxfJtilVCi0ZE37b8uOdMItIHz4I6z1bWWtEX4CJwcKYLcuA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.25.9",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.25.9.tgz",
+      "integrity": "sha512-4Xd0xNiMVXKh6Fa7HEJQbrpP3m3DDn43jKxMjxLLRjWnRsfxjORYJlXPO4JNcXtOyfajXorRKY9NkOpTHptErg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.25.9",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.25.9.tgz",
+      "integrity": "sha512-WjH4s6hzo00nNezhp3wFIAfmGZ8U7KtrJNlFMRKxiI9mxEK1scOMAaa9i4crUtu+tBr+0IN6JCuAcSBJZfnphw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.25.9",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.25.9.tgz",
+      "integrity": "sha512-mGFrVJHmZiRqmP8xFOc6b84/7xa5y5YvR1x8djzXpJBSv/UsNK6aqec+6JDjConTgvvQefdGhFDAs2DLAds6gQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.25.9",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.25.9.tgz",
+      "integrity": "sha512-b33gLVU2k11nVx1OhX3C8QQP6UHQK4ZtN56oFWvVXvz2VkDoe6fbG8TOgHFxEvqeqohmRnIHe5A1+HADk4OQww==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.25.9",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.25.9.tgz",
+      "integrity": "sha512-PPOl1mi6lpLNQxnGoyAfschAodRFYXJ+9fs6WHXz7CSWKbOqiMZsubC+BQsVKuul+3vKLuwTHsS2c2y9EoKwxQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@types/node": {
+      "version": "20.19.11",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.11.tgz",
+      "integrity": "sha512-uug3FEEGv0r+jrecvUUpbY8lLisvIjg6AAic6a2bSP5OEOLeJsDSnvhCDov7ipFFMXS3orMpzlmi0ZcuGkBbow==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/esbuild": {
+      "version": "0.25.9",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.25.9.tgz",
+      "integrity": "sha512-CRbODhYyQx3qp7ZEwzxOk4JBqmD/seJrzPa/cGjY1VtIn5E09Oi9/dB4JwctnfZ8Q8iT7rioVv5k/FNT/uf54g==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.25.9",
+        "@esbuild/android-arm": "0.25.9",
+        "@esbuild/android-arm64": "0.25.9",
+        "@esbuild/android-x64": "0.25.9",
+        "@esbuild/darwin-arm64": "0.25.9",
+        "@esbuild/darwin-x64": "0.25.9",
+        "@esbuild/freebsd-arm64": "0.25.9",
+        "@esbuild/freebsd-x64": "0.25.9",
+        "@esbuild/linux-arm": "0.25.9",
+        "@esbuild/linux-arm64": "0.25.9",
+        "@esbuild/linux-ia32": "0.25.9",
+        "@esbuild/linux-loong64": "0.25.9",
+        "@esbuild/linux-mips64el": "0.25.9",
+        "@esbuild/linux-ppc64": "0.25.9",
+        "@esbuild/linux-riscv64": "0.25.9",
+        "@esbuild/linux-s390x": "0.25.9",
+        "@esbuild/linux-x64": "0.25.9",
+        "@esbuild/netbsd-arm64": "0.25.9",
+        "@esbuild/netbsd-x64": "0.25.9",
+        "@esbuild/openbsd-arm64": "0.25.9",
+        "@esbuild/openbsd-x64": "0.25.9",
+        "@esbuild/openharmony-arm64": "0.25.9",
+        "@esbuild/sunos-x64": "0.25.9",
+        "@esbuild/win32-arm64": "0.25.9",
+        "@esbuild/win32-ia32": "0.25.9",
+        "@esbuild/win32-x64": "0.25.9"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/get-tsconfig": {
+      "version": "4.10.1",
+      "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.10.1.tgz",
+      "integrity": "sha512-auHyJ4AgMz7vgS8Hp3N6HXSmlMdUyhSUrfBF16w153rxtLIEOE+HGqaBppczZvnHLqQJfiHotCYpNhl0lUROFQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "resolve-pkg-maps": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/privatenumber/get-tsconfig?sponsor=1"
+      }
+    },
+    "node_modules/resolve-pkg-maps": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-pkg-maps/-/resolve-pkg-maps-1.0.0.tgz",
+      "integrity": "sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
+      }
+    },
+    "node_modules/tsx": {
+      "version": "4.20.4",
+      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.20.4.tgz",
+      "integrity": "sha512-yyxBKfORQ7LuRt/BQKBXrpcq59ZvSW0XxwfjAt3w2/8PmdxaFzijtMhTawprSHhpzeM5BgU2hXHG3lklIERZXg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "~0.25.0",
+        "get-tsconfig": "^4.7.5"
+      },
+      "bin": {
+        "tsx": "dist/cli.mjs"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.2.tgz",
+      "integrity": "sha512-CWBzXQrc/qOkhidw1OzBTQuYRbfyxDXJMVJ1XNwUHGROVmuaeiEm3OslpZ1RV96d7SKKjZKrSJu3+t/xlw3R9A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "dev": true,
+      "license": "MIT"
+    }
+  }
+}

--- a/tools/datadog-log-exporter/package.json
+++ b/tools/datadog-log-exporter/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "datadog-log-exporter",
+  "private": true,
+  "version": "0.1.0",
+  "type": "module",
+  "engines": {
+    "node": ">=18"
+  },
+  "scripts": {
+    "build": "tsc -p tsconfig.json",
+    "start": "node dist/index.js",
+    "dev": "tsx src/index.ts"
+  },
+  "dependencies": {
+  },
+  "devDependencies": {
+    "@types/node": "^20.11.30",
+    "tsx": "^4.19.0",
+    "typescript": "^5.5.4"
+  }
+}
+

--- a/tools/datadog-log-exporter/run.sh
+++ b/tools/datadog-log-exporter/run.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Simple runner for the Datadog Log Exporter TS CLI.
+# - Ensures the CLI is built (runs npm install/build if needed)
+# - Verifies required env vars
+# - Forwards all arguments to the CLI
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+cd "$SCRIPT_DIR"
+
+if [[ ! -f "dist/index.js" ]]; then
+  echo "[datadog-log-exporter] Building TypeScript CLI..."
+  npm install >/dev/null 2>&1
+  npm run build
+fi
+
+if [[ -z "${DATADOG_API_KEY:-}" ]]; then
+  echo "Error: DATADOG_API_KEY is not set" >&2
+  exit 1
+fi
+
+if [[ -z "${DATADOG_APP_KEY:-}" ]]; then
+  echo "Error: DATADOG_APP_KEY is not set" >&2
+  exit 1
+fi
+
+exec node dist/index.js "$@"
+

--- a/tools/datadog-log-exporter/src/index.ts
+++ b/tools/datadog-log-exporter/src/index.ts
@@ -1,0 +1,346 @@
+#!/usr/bin/env node
+import { setTimeout as sleep } from "node:timers/promises";
+import { promises as fsp } from "node:fs";
+import fs from "node:fs";
+import path from "node:path";
+import { Args, LogEvent, LogsResponse, StateFile } from "./types.js";
+
+function parseDuration(str: string): number {
+  const m = String(str).match(/^(\d+)([smhd])$/i);
+  if (!m) throw new Error(`Invalid duration: ${str} (use e.g. 30s, 15m, 2h, 1d)`);
+  const n = parseInt(m[1], 10);
+  const unit = m[2].toLowerCase();
+  switch (unit) {
+    case "s":
+      return n * 1000;
+    case "m":
+      return n * 60 * 1000;
+    case "h":
+      return n * 60 * 60 * 1000;
+    case "d":
+      return n * 24 * 60 * 60 * 1000;
+  }
+  throw new Error("unreachable");
+}
+
+function toISO(t: number): string {
+  return new Date(t).toISOString();
+}
+
+function fromMaybeISO(v: string | undefined, fallbackMs: number): number {
+  if (!v) return fallbackMs;
+  const t = Date.parse(v);
+  if (Number.isNaN(t)) throw new Error(`Invalid ISO date: ${v}`);
+  return t;
+}
+
+function parseArgv(argv: string[]): Record<string, string | boolean> {
+  const args: Record<string, string | boolean> = {};
+  for (let i = 2; i < argv.length; i++) {
+    const a = argv[i];
+    const next = argv[i + 1];
+    if (a.startsWith("--")) {
+      const key = a.slice(2);
+      if (typeof next === "string" && !next.startsWith("--")) {
+        args[key] = next;
+        i++;
+      } else {
+        args[key] = true;
+      }
+    }
+  }
+  return args;
+}
+
+function csvEscape(val: unknown): string {
+  if (val == null) return "";
+  const s = String(val);
+  if (s.includes("\"") || s.includes(",") || s.includes("\n") || s.includes("\r")) {
+    return '"' + s.replace(/"/g, '""') + '"';
+  }
+  return s;
+}
+
+function get(obj: unknown, pathStr: string): unknown {
+  if (obj == null) return undefined;
+  const parts = pathStr.split(".");
+  let cur: any = obj as any; // eslint-disable-line @typescript-eslint/no-explicit-any
+  for (const p of parts) {
+    if (cur == null) return undefined;
+    cur = cur[p];
+  }
+  return cur;
+}
+
+async function fileExists(p: string): Promise<boolean> {
+  try {
+    await fsp.access(p, fs.constants.F_OK);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function jittered(baseMs: number, factor = 0.2): number {
+  const delta = baseMs * factor;
+  return Math.round(baseMs - delta + Math.random() * (2 * delta));
+}
+
+async function writeCsvHeader(outPath: string, columns: string[]): Promise<void> {
+  const header = columns.join(",") + "\n";
+  try {
+    await fsp.writeFile(outPath, header, { flag: "wx" });
+  } catch (e: any) {
+    if (e && e.code === "EEXIST") return;
+    throw e;
+  }
+}
+
+function resolveColumn(e: LogEvent, col: string): unknown {
+  if (col === "id") return e.id;
+  if (col === "timestamp") return e.attributes?.timestamp;
+  const attrs = e.attributes || {};
+  const nested = (attrs as any).attributes || {}; // eslint-disable-line @typescript-eslint/no-explicit-any
+  let v = get(nested, col);
+  if (v === undefined) v = get(attrs, col);
+  return v;
+}
+
+async function appendCsvRows(outPath: string, columns: string[], events: LogEvent[]): Promise<void> {
+  const lines = events.map((e) => columns.map((c) => csvEscape(resolveColumn(e, c))).join(","));
+  if (lines.length > 0) {
+    await fsp.appendFile(outPath, lines.join("\n") + "\n");
+  }
+}
+
+async function readState(statePath: string): Promise<StateFile | null> {
+  if (!(await fileExists(statePath))) return null;
+  const raw = await fsp.readFile(statePath, "utf8");
+  return JSON.parse(raw) as StateFile;
+}
+
+async function writeState(statePath: string, state: StateFile): Promise<void> {
+  await fsp.writeFile(statePath, JSON.stringify(state, null, 2));
+}
+
+function pickRateLimitWait(headers: Headers): number {
+  const retryAfter = headers.get("retry-after");
+  if (retryAfter && !Number.isNaN(parseInt(retryAfter, 10))) {
+    return parseInt(retryAfter, 10) * 1000;
+  }
+  const reset = headers.get("x-rate-limit-reset") || headers.get("x-ratelimit-reset");
+  if (reset && !Number.isNaN(parseInt(reset, 10))) {
+    const resetSec = parseInt(reset, 10);
+    return Math.max(0, (resetSec * 1000) - Date.now());
+  }
+  return 2000;
+}
+
+async function fetchWithBackoff(url: string, init: RequestInit, maxRetries = 6): Promise<Response> {
+  let attempt = 0;
+  while (true) {
+    const res = await fetch(url, init);
+    if (res.status === 429) {
+      const wait = pickRateLimitWait(res.headers);
+      const backoff = jittered(Math.min(60000, wait || 2000));
+      console.warn(`429 Too Many Requests. Waiting ~${backoff}ms before retry...`);
+      await sleep(backoff);
+      attempt++;
+      if (attempt > maxRetries) throw new Error(`Rate limited too many times.`);
+      continue;
+    }
+    if (res.status >= 500) {
+      const backoff = jittered(Math.min(60000, 1000 * Math.pow(2, attempt)));
+      console.warn(`${res.status} Server error. Retrying in ~${backoff}ms...`);
+      await sleep(backoff);
+      attempt++;
+      if (attempt > maxRetries) throw new Error(`Server error ${res.status} too many times.`);
+      continue;
+    }
+    if (!res.ok) {
+      const txt = await res.text();
+      throw new Error(`HTTP ${res.status}: ${txt}`);
+    }
+    return res;
+  }
+}
+
+async function queryLogs(params: {
+  site: string;
+  apiKey: string;
+  appKey: string;
+  query: string;
+  fromISO: string;
+  toISO: string;
+  pageLimit: number;
+  cursor?: string;
+}): Promise<{ events: LogEvent[]; nextCursor?: string | null; rateRemaining?: number }> {
+  const { site, apiKey, appKey, query, fromISO, toISO, pageLimit, cursor } = params;
+  const url = `https://api.${site}/api/v2/logs/events/search`;
+  const body: Record<string, unknown> = {
+    filter: { query, from: fromISO, to: toISO },
+    options: { timeOffset: 0, timezone: "UTC" },
+    page: { limit: Math.min(1000, pageLimit) },
+    sort: "desc",
+  };
+  if (cursor) (body.page as any).cursor = cursor; // eslint-disable-line @typescript-eslint/no-explicit-any
+
+  const res = await fetchWithBackoff(url, {
+    method: "POST",
+    headers: {
+      "content-type": "application/json",
+      "dd-api-key": apiKey,
+      "dd-application-key": appKey,
+    },
+    body: JSON.stringify(body),
+  });
+  const json = (await res.json()) as LogsResponse;
+  const events = json?.data ?? [];
+  let nextCursor = json?.meta?.page?.after ?? null;
+  if (!nextCursor && json?.links?.next) {
+    try {
+      const u = new URL(json.links.next);
+      const c = u.searchParams.get("page[cursor]");
+      if (c) nextCursor = c;
+    } catch {
+      // ignore
+    }
+  }
+  const rateRemainingStr = res.headers.get("x-rate-limit-remaining") || res.headers.get("x-ratelimit-remaining") || "";
+  const rateRemaining = rateRemainingStr ? parseInt(rateRemainingStr, 10) : undefined;
+  return { events, nextCursor, rateRemaining };
+}
+
+function adjustWindowSize(currentMs: number, lastCount: number, target: number, minMs: number, maxMs: number): number {
+  if (lastCount === 0) return Math.min(maxMs, Math.round(currentMs * 2));
+  const ratio = lastCount / target;
+  if (ratio > 1.5) return Math.max(minMs, Math.round(currentMs / 2));
+  if (ratio < 0.5) return Math.min(maxMs, Math.round(currentMs * 1.5));
+  return currentMs;
+}
+
+async function main(): Promise<void> {
+  const argv = parseArgv(process.argv);
+  if (argv.help || argv.h) {
+    console.log(`Usage: node dist/index.js --query <QUERY> --columns <col1,col2,...> [options]\n\nOptions:\n  --from <ISO>                Start time (older). Default: 14 days ago\n  --to <ISO>                  End time (newer). Default: now\n  --out <path>                Output CSV file. Default: datadog-logs.csv\n  --page-limit <n>            Page size (<=1000). Default: 1000\n  --target-per-window <n>     Target logs per window. Default: 2000\n  --initial-window <dur>      Initial window (e.g. 15m). Default: 15m\n  --max-window <dur>          Max window size. Default: 6h\n  --min-window <dur>          Min window size. Default: 1m\n  --resume [true|false]       Resume from state. Default: true\n`);
+    return;
+  }
+
+  const query = (argv.query as string) || "";
+  const columns = String(argv.columns || "")
+    .split(",")
+    .map((s) => s.trim())
+    .filter(Boolean);
+  const outPath = (argv.out as string) || "datadog-logs.csv";
+  const pageLimit = Math.min(1000, parseInt((argv["page-limit"] as string) || "1000", 10));
+  const resume = argv.resume !== "false"; // default true
+  const targetPerWindow = parseInt((argv["target-per-window"] as string) || "2000", 10);
+
+  if (!query) throw new Error("--query is required");
+  if (columns.length === 0) throw new Error("--columns is required (comma separated)");
+
+  const now = Date.now();
+  const defaultFrom = now - 14 * 24 * 60 * 60 * 1000;
+  const fromMs = fromMaybeISO(argv.from as string | undefined, defaultFrom);
+  const toMs = fromMaybeISO(argv.to as string | undefined, now);
+  if (fromMs >= toMs) throw new Error("--from must be earlier than --to");
+
+  const initialWindow = parseDuration((argv["initial-window"] as string) || "15m");
+  const maxWindow = parseDuration((argv["max-window"] as string) || "6h");
+  const minWindow = parseDuration((argv["min-window"] as string) || "1m");
+
+  const site = process.env.DATADOG_SITE || "datadoghq.com";
+  const apiKey = process.env.DATADOG_API_KEY;
+  const appKey = process.env.DATADOG_APP_KEY;
+  if (!apiKey || !appKey) throw new Error("Please set DATADOG_API_KEY and DATADOG_APP_KEY environment variables.");
+
+  const statePath = outPath + ".state.json";
+  let state: StateFile | null = null;
+  if (resume) state = await readState(statePath);
+
+  let currentTo = state?.currentTo ?? toMs; // newest boundary moving older
+  let windowMs = state?.windowMs ?? initialWindow;
+  let totalCount = state?.totalCount ?? 0;
+
+  if (!(await fileExists(outPath))) {
+    await writeCsvHeader(outPath, columns);
+  }
+
+  console.log(`Starting export`);
+  console.log(`Query: ${query}`);
+  console.log(`Range: ${toISO(fromMs)} -> ${toISO(toMs)} (desc)`);
+  console.log(`Output: ${outPath}`);
+
+  while (currentTo > fromMs) {
+    const currentFrom = Math.max(fromMs, currentTo - windowMs);
+    const fromISO = toISO(currentFrom);
+    const toISOstr = toISO(currentTo);
+    console.log(`Window: [${fromISO} .. ${toISOstr}]`);
+
+    let cursor = state?.cursor || undefined;
+    let windowCount = state?.windowCount || 0;
+    let lastPageIds = state?.lastPageIds && Array.isArray(state.lastPageIds) ? state.lastPageIds : [];
+    state = null; // clear carry-over state
+
+    while (true) {
+      const { events, nextCursor, rateRemaining } = await queryLogs({
+        site,
+        apiKey,
+        appKey,
+        query,
+        fromISO,
+        toISO: toISOstr,
+        pageLimit,
+        cursor,
+      });
+
+      let pageEvents = events;
+      if (lastPageIds.length && pageEvents.length) {
+        const idSet = new Set(lastPageIds);
+        const before = pageEvents.length;
+        pageEvents = pageEvents.filter((e) => !idSet.has(e.id));
+        if (before !== pageEvents.length) {
+          console.warn(`Filtered ${before - pageEvents.length} duplicate events on resume.`);
+        }
+      }
+
+      if (rateRemaining !== undefined && !Number.isNaN(rateRemaining) && rateRemaining <= 1) {
+        await sleep(1000);
+      }
+
+      if (pageEvents.length > 0) {
+        await appendCsvRows(outPath, columns, pageEvents);
+        totalCount += pageEvents.length;
+        windowCount += pageEvents.length;
+      }
+
+      await writeState(statePath, {
+        currentTo,
+        windowMs,
+        cursor: nextCursor || null,
+        windowCount,
+        totalCount,
+        lastPageIds: (events || []).map((e) => e.id),
+      });
+
+      if (!nextCursor) break;
+      cursor = nextCursor;
+      lastPageIds = (events || []).map((e) => e.id);
+    }
+
+    console.log(`Window complete: ${windowCount} events`);
+    windowMs = adjustWindowSize(windowMs, windowCount, targetPerWindow, minWindow, maxWindow);
+    currentTo = currentFrom - 1; // avoid boundary duplicates
+
+    await writeState(statePath, { currentTo, windowMs, cursor: null, windowCount: 0, totalCount });
+  }
+
+  console.log(`Done. Exported ${totalCount} events to ${outPath}`);
+}
+
+// Execute
+main().catch((err) => {
+  console.error(err?.stack || String(err));
+  process.exit(1);
+});
+

--- a/tools/datadog-log-exporter/src/types.ts
+++ b/tools/datadog-log-exporter/src/types.ts
@@ -1,0 +1,44 @@
+export interface LogEvent {
+  id: string;
+  attributes?: Record<string, unknown> & {
+    timestamp?: string;
+    attributes?: Record<string, unknown>;
+  };
+}
+
+export interface LogsResponseMeta {
+  page?: { after?: string | null };
+}
+
+export interface LogsResponse {
+  data?: LogEvent[];
+  meta?: LogsResponseMeta;
+  links?: { next?: string };
+}
+
+export interface Args {
+  query: string;
+  columns: string[];
+  outPath: string;
+  pageLimit: number;
+  resume: boolean;
+  targetPerWindow: number;
+  fromMs: number;
+  toMs: number;
+  initialWindow: number;
+  maxWindow: number;
+  minWindow: number;
+  site: string;
+  apiKey: string;
+  appKey: string;
+}
+
+export interface StateFile {
+  currentTo: number;
+  windowMs: number;
+  cursor: string | null;
+  windowCount: number;
+  totalCount: number;
+  lastPageIds?: string[];
+}
+

--- a/tools/datadog-log-exporter/tsconfig.json
+++ b/tools/datadog-log-exporter/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ES2022",
+    "moduleResolution": "Bundler",
+    "outDir": "dist",
+    "rootDir": "src",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true
+  },
+  "include": ["src"]
+}
+


### PR DESCRIPTION
## Description

DD's website only allows to pull 100k logs, sometimes there are more than 100k and it's a huge pain to do in batches on datadog's website (need to mess with timestamps and merge file)

## Tests

Full local run

## Risk

None (entirely separate)

## Deploy Plan

None