### PR TITLE
[Github] Increase file size limit from 2MB to 3MB for code sync

### DIFF
--- a/connectors/src/connectors/github/lib/code/tar_extraction.ts
+++ b/connectors/src/connectors/github/lib/code/tar_extraction.ts
@@ -21,7 +21,7 @@ import {
 import { ExternalOAuthTokenError } from "@connectors/lib/error";
 import type { Logger } from "@connectors/logger/logger";
 
-const MAX_FILE_SIZE_BYTES = 2 * 1024 * 1024; // 2MB
+const MAX_FILE_SIZE_BYTES = 3 * 1024 * 1024; // 3MB
 const MAX_CONCURRENT_GCS_UPLOADS = 200;
 
 interface TarExtractionOptions {

--- a/connectors/src/connectors/github/lib/github_code.ts
+++ b/connectors/src/connectors/github/lib/github_code.ts
@@ -50,7 +50,7 @@ export async function getRepoInfo(
 
 export function isRepoTooLarge(repoInfo: RepositoryInfo): boolean {
   // `data.size` is the whole repo size in KB, we use it to filter repos > 10GB download size. There
-  // is further filtering by file type + for "extracted size" per file to 1MB.
+  // is further filtering by file type + for "extracted size" per file to 3MB.
   if (repoInfo.size > REPO_SIZE_LIMIT) {
     // For now we throw a panic log, so we are able to report the issue to the
     // user, and continue with the rest of the sync. See runbook for future


### PR DESCRIPTION
## Description
Increases the maximum file size limit for GitHub code sync from 2MB to 3MB, allowing larger source files to be synced to Dust.

We communicated 3Mb to clients, e.g. [here](https://github.com/dust-tt/tasks/issues/3835)

## Risk
Blast radius: GitHub code sync functionality
Risk: low

## Test
- Updated the `MAX_FILE_SIZE_BYTES` constant in tar_extraction.ts
- Updated the comment in github_code.ts to reflect the new limit

## Deploy Plan
- Deploy connectors service