### PR TITLE
Limit to 500 Slack channels in the list

### DIFF
--- a/front/lib/actions/mcp_internal_actions/servers/slack.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/slack.ts
@@ -157,6 +157,7 @@ const _getPublicChannels = async ({
     // We can't handle a huge list of channels, and even if we could, it would be unusable
     // in the UI. So we arbitrarily cap it to 500 channels.
     if (channels.length >= 500) {
+      logger.warn("Channel list truncated to 500 channels.");
       break;
     }
   } while (cursor);

--- a/front/lib/actions/mcp_internal_actions/servers/slack.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/slack.ts
@@ -153,6 +153,12 @@ const _getPublicChannels = async ({
     }
     channels.push(...(response.channels ?? []));
     cursor = response.response_metadata?.next_cursor;
+
+    // We can't handle a huge list of channels, and even if we could, it would be unusable
+    // in the UI. So we arbitrarily cap it to 500 channels.
+    if (channels.length >= 500) {
+      break;
+    }
   } while (cursor);
 
   return channels


### PR DESCRIPTION
## Description

We can't handle a huge list of channels, and even if we could, it would be unusable in the UI. So we arbitrarily cap it to 500 channels.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
