### PR TITLE
[front] Move server information to `constants`

### DIFF
--- a/front/lib/actions/mcp_internal_actions/constants.ts
+++ b/front/lib/actions/mcp_internal_actions/constants.ts
@@ -117,7 +117,7 @@ export const INTERNAL_MCP_SERVERS = {
       get_issue: "never_ask",
     },
     timeoutMs: undefined,
-    serverMetadata: {
+    serverInfo: {
       name: "github",
       version: "1.0.0",
       description: "GitHub tools to manage issues and pull requests.",
@@ -138,7 +138,7 @@ export const INTERNAL_MCP_SERVERS = {
     isPreview: false,
     tools_stakes: undefined,
     timeoutMs: undefined,
-    serverMetadata: {
+    serverInfo: {
       name: "image_generation",
       version: "1.0.0",
       description: "Agent can generate images (GPT Image 1).",
@@ -156,7 +156,7 @@ export const INTERNAL_MCP_SERVERS = {
     isPreview: false,
     tools_stakes: undefined,
     timeoutMs: undefined,
-    serverMetadata: {
+    serverInfo: {
       name: "file_generation",
       version: "1.0.0",
       description: "Agent can generate and convert files.",
@@ -174,7 +174,7 @@ export const INTERNAL_MCP_SERVERS = {
     isPreview: false,
     tools_stakes: undefined,
     timeoutMs: undefined,
-    serverMetadata: {
+    serverInfo: {
       name: TABLE_QUERY_SERVER_NAME,
       version: "1.0.0",
       description: "Tables, Spreadsheets, Notion DBs (quantitative).",
@@ -192,7 +192,7 @@ export const INTERNAL_MCP_SERVERS = {
     isPreview: false,
     tools_stakes: undefined,
     timeoutMs: undefined,
-    serverMetadata: {
+    serverInfo: {
       name: DEFAULT_WEBSEARCH_ACTION_NAME,
       version: "1.0.0",
       description: DEFAULT_WEBSEARCH_ACTION_DESCRIPTION,
@@ -212,7 +212,7 @@ export const INTERNAL_MCP_SERVERS = {
     isPreview: true,
     tools_stakes: undefined,
     timeoutMs: undefined,
-    serverMetadata: {
+    serverInfo: {
       name: "think",
       version: "1.0.0",
       description: "Expand thinking and reasoning capabilities.",
@@ -269,7 +269,7 @@ export const INTERNAL_MCP_SERVERS = {
       remove_association: "high",
     },
     timeoutMs: undefined,
-    serverMetadata: {
+    serverInfo: {
       name: "hubspot",
       version: "1.0.0",
       description:
@@ -293,7 +293,7 @@ export const INTERNAL_MCP_SERVERS = {
     isPreview: false,
     tools_stakes: undefined,
     timeoutMs: undefined,
-    serverMetadata: {
+    serverInfo: {
       name: DEFAULT_AGENT_ROUTER_ACTION_NAME,
       version: "1.0.0",
       description: DEFAULT_AGENT_ROUTER_ACTION_DESCRIPTION,
@@ -313,7 +313,7 @@ The directive should be used to display a clickable version of the agent name in
     isPreview: false,
     tools_stakes: undefined,
     timeoutMs: undefined,
-    serverMetadata: {
+    serverInfo: {
       name: "include_data",
       version: "1.0.0",
       description: "Include data exhaustively",
@@ -331,7 +331,7 @@ The directive should be used to display a clickable version of the agent name in
     isPreview: false,
     tools_stakes: undefined,
     timeoutMs: undefined,
-    serverMetadata: {
+    serverInfo: {
       name: "run_dust_app",
       version: "1.0.0",
       description: "Run Dust Apps with specified parameters",
@@ -370,7 +370,7 @@ The directive should be used to display a clickable version of the agent name in
       update_schema_database: "low",
     },
     timeoutMs: undefined,
-    serverMetadata: {
+    serverInfo: {
       name: "notion",
       version: "1.0.0",
       description: "Notion tools to manage pages and databases.",
@@ -391,7 +391,7 @@ The directive should be used to display a clickable version of the agent name in
     isPreview: false,
     tools_stakes: undefined,
     timeoutMs: undefined,
-    serverMetadata: {
+    serverInfo: {
       name: "extract_data",
       version: "1.0.0",
       description: "Structured extraction",
@@ -409,7 +409,7 @@ The directive should be used to display a clickable version of the agent name in
     isPreview: false,
     tools_stakes: undefined,
     timeoutMs: undefined,
-    serverMetadata: {
+    serverInfo: {
       name: "missing_action_catcher",
       version: "1.0.0",
       description: "To be used to catch errors and avoid erroring.",
@@ -436,7 +436,7 @@ The directive should be used to display a clickable version of the agent name in
       describe_object: "never_ask",
     },
     timeoutMs: undefined,
-    serverMetadata: {
+    serverInfo: {
       name: "salesforce",
       version: "1.0.0",
       description: "Salesforce tools.",
@@ -462,7 +462,7 @@ The directive should be used to display a clickable version of the agent name in
       create_reply_draft: "low",
     },
     timeoutMs: undefined,
-    serverMetadata: {
+    serverInfo: {
       name: "gmail",
       version: "1.0.0",
       description: "Gmail tools for reading emails and managing email drafts.",
@@ -493,7 +493,7 @@ The directive should be used to display a clickable version of the agent name in
       check_availability: "never_ask",
     },
     timeoutMs: undefined,
-    serverMetadata: {
+    serverInfo: {
       name: "google_calendar",
       version: "1.0.0",
       description: "Tools for managing Google calendars and events.",
@@ -516,7 +516,7 @@ The directive should be used to display a clickable version of the agent name in
     isPreview: false,
     tools_stakes: undefined,
     timeoutMs: undefined,
-    serverMetadata: {
+    serverInfo: {
       name: "conversation_files",
       version: "1.0.0",
       description: "Include files from conversation attachments",
@@ -542,7 +542,7 @@ The directive should be used to display a clickable version of the agent name in
       get_user: "never_ask",
     },
     timeoutMs: undefined,
-    serverMetadata: {
+    serverInfo: {
       name: "slack",
       version: "1.0.0",
       description: "Slack tools for searching and posting messages.",
@@ -579,7 +579,7 @@ The directive should be used to display a clickable version of the agent name in
       format_cells: "low",
     },
     timeoutMs: undefined,
-    serverMetadata: {
+    serverInfo: {
       name: "google_sheets",
       version: "1.0.0",
       description: "Tools for managing Google Sheets spreadsheets and data.",
@@ -633,7 +633,7 @@ The directive should be used to display a clickable version of the agent name in
       delete_group: "high",
     },
     timeoutMs: undefined,
-    serverMetadata: {
+    serverInfo: {
       name: "monday",
       version: "1.0.0",
       description:
@@ -656,7 +656,7 @@ The directive should be used to display a clickable version of the agent name in
     isPreview: false,
     tools_stakes: undefined,
     timeoutMs: undefined,
-    serverMetadata: {
+    serverInfo: {
       name: "agent_memory",
       version: "1.0.0",
       description: "User-scoped long-term memory tools for agents.",
@@ -697,7 +697,7 @@ The directive should be used to display a clickable version of the agent name in
       delete_issue_link: "low",
     },
     timeoutMs: undefined,
-    serverMetadata: {
+    serverInfo: {
       name: "jira",
       version: "1.0.0",
       description:
@@ -721,7 +721,7 @@ The directive should be used to display a clickable version of the agent name in
     isPreview: true,
     tools_stakes: undefined,
     timeoutMs: undefined,
-    serverMetadata: {
+    serverInfo: {
       name: "interactive_content",
       version: "1.0.0",
       description:
@@ -749,7 +749,7 @@ The directive should be used to display a clickable version of the agent name in
       update_contact: "high",
     },
     timeoutMs: undefined,
-    serverMetadata: {
+    serverInfo: {
       name: "outlook",
       version: "1.0.0",
       description:
@@ -781,7 +781,7 @@ The directive should be used to display a clickable version of the agent name in
       check_availability: "never_ask",
     },
     timeoutMs: undefined,
-    serverMetadata: {
+    serverInfo: {
       name: "outlook_calendar",
       version: "1.0.0",
       description: "Tools for managing Outlook calendars and events.",
@@ -827,7 +827,7 @@ The directive should be used to display a clickable version of the agent name in
       create_solution_article: "high",
     },
     timeoutMs: undefined,
-    serverMetadata: {
+    serverInfo: {
       name: "freshservice",
       icon: "FreshserviceLogo",
       version: "1.0.0",
@@ -851,7 +851,7 @@ The directive should be used to display a clickable version of the agent name in
     isPreview: false,
     tools_stakes: undefined,
     timeoutMs: undefined,
-    serverMetadata: {
+    serverInfo: {
       name: SEARCH_SERVER_NAME,
       version: "1.0.0",
       description: "Search through selected Data sources",
@@ -869,7 +869,7 @@ The directive should be used to display a clickable version of the agent name in
     isPreview: false,
     tools_stakes: undefined,
     timeoutMs: 10 * 60 * 1000, // 10 minutes
-    serverMetadata: {
+    serverInfo: {
       name: "run_agent",
       version: "1.0.0",
       description: "Run a child agent (agent as tool).",
@@ -889,7 +889,7 @@ The directive should be used to display a clickable version of the agent name in
     },
     tools_stakes: undefined,
     timeoutMs: undefined,
-    serverMetadata: {
+    serverInfo: {
       name: "primitive_types_debugger",
       version: "1.0.0",
       description:
@@ -908,7 +908,7 @@ The directive should be used to display a clickable version of the agent name in
     isPreview: false,
     tools_stakes: undefined,
     timeoutMs: undefined,
-    serverMetadata: {
+    serverInfo: {
       name: "reasoning",
       version: "1.0.0",
       description:
@@ -930,7 +930,7 @@ The directive should be used to display a clickable version of the agent name in
     isPreview: true,
     tools_stakes: undefined,
     timeoutMs: undefined,
-    serverMetadata: {
+    serverInfo: {
       name: "query_tables_v2",
       version: "1.0.0",
       description:
@@ -951,7 +951,7 @@ The directive should be used to display a clickable version of the agent name in
     isPreview: false,
     tools_stakes: undefined,
     timeoutMs: undefined,
-    serverMetadata: {
+    serverInfo: {
       name: "data_sources_file_system",
       version: "1.0.0",
       description:
@@ -978,7 +978,7 @@ The directive should be used to display a clickable version of the agent name in
       create_agent: "high",
     },
     timeoutMs: undefined,
-    serverMetadata: {
+    serverInfo: {
       name: "agent_management",
       version: "1.0.0",
       description: "Tools for managing agent configurations",
@@ -998,7 +998,7 @@ The directive should be used to display a clickable version of the agent name in
     },
     tools_stakes: undefined,
     timeoutMs: undefined,
-    serverMetadata: {
+    serverInfo: {
       name: "data_warehouses",
       version: "1.0.0",
       description:
@@ -1021,7 +1021,7 @@ The directive should be used to display a clickable version of the agent name in
     },
     tools_stakes: undefined,
     timeoutMs: undefined,
-    serverMetadata: {
+    serverInfo: {
       name: "toolsets",
       version: "1.0.0",
       description:
@@ -1049,7 +1049,7 @@ The directive should be used to display a clickable version of the agent name in
     isPreview: boolean;
     tools_stakes: Record<string, MCPToolStakeLevelType> | undefined;
     timeoutMs: number | undefined;
-    serverMetadata: InternalMCPServerDefinitionType;
+    serverInfo: InternalMCPServerDefinitionType;
   }
 >;
 

--- a/front/lib/actions/mcp_internal_actions/constants.ts
+++ b/front/lib/actions/mcp_internal_actions/constants.ts
@@ -1,4 +1,18 @@
 import type { MCPToolStakeLevelType } from "@app/lib/actions/constants";
+import {
+  DEFAULT_AGENT_ROUTER_ACTION_DESCRIPTION,
+  DEFAULT_AGENT_ROUTER_ACTION_NAME,
+} from "@app/lib/actions/constants";
+import {
+  DEFAULT_WEBSEARCH_ACTION_DESCRIPTION,
+  DEFAULT_WEBSEARCH_ACTION_NAME,
+} from "@app/lib/actions/constants";
+import {
+  FRESHSERVICE_SERVER_INSTRUCTIONS,
+  JIRA_SERVER_INSTRUCTIONS,
+  SALESFORCE_SERVER_INSTRUCTIONS,
+} from "@app/lib/actions/mcp_internal_actions/instructions";
+import type { InternalMCPServerDefinitionType } from "@app/lib/api/mcp";
 import { getResourceNameAndIdFromSId } from "@app/lib/resources/string_ids";
 import type {
   ModelId,
@@ -111,6 +125,17 @@ export const INTERNAL_MCP_SERVERS = {
       get_issue: "never_ask",
     },
     timeoutMs: undefined,
+    serverMetadata: {
+      name: "github",
+      version: "1.0.0",
+      description: "GitHub tools to manage issues and pull requests.",
+      authorization: {
+        provider: "github" as const,
+        supported_use_cases: ["platform_actions"] as const,
+      },
+      icon: "GithubLogo",
+      documentationUrl: null,
+    },
   },
   image_generation: {
     id: 2,
@@ -120,6 +145,14 @@ export const INTERNAL_MCP_SERVERS = {
     isPreview: false,
     tools_stakes: undefined,
     timeoutMs: undefined,
+    serverMetadata: {
+      name: "image_generation",
+      version: "1.0.0",
+      description: "Agent can generate images (GPT Image 1).",
+      icon: "ActionImageIcon",
+      authorization: null,
+      documentationUrl: null,
+    },
   },
   file_generation: {
     id: 3,
@@ -129,8 +162,16 @@ export const INTERNAL_MCP_SERVERS = {
     isPreview: false,
     tools_stakes: undefined,
     timeoutMs: undefined,
+    serverMetadata: {
+      name: "file_generation",
+      version: "1.0.0",
+      description: "Agent can generate and convert files.",
+      authorization: null,
+      icon: "ActionDocumentTextIcon",
+      documentationUrl: null,
+    },
   },
-  query_tables: {
+  [TABLE_QUERY_SERVER_NAME]: {
     id: 4,
     availability: "auto",
     allowMultipleInstances: false,
@@ -138,8 +179,16 @@ export const INTERNAL_MCP_SERVERS = {
     isPreview: false,
     tools_stakes: undefined,
     timeoutMs: undefined,
+    serverMetadata: {
+      name: TABLE_QUERY_SERVER_NAME,
+      version: "1.0.0",
+      description: "Tables, Spreadsheets, Notion DBs (quantitative).",
+      icon: "ActionTableIcon",
+      authorization: null,
+      documentationUrl: null,
+    },
   },
-  "web_search_&_browse": {
+  [DEFAULT_WEBSEARCH_ACTION_NAME]: {
     id: 5,
     availability: "auto",
     allowMultipleInstances: false,
@@ -147,6 +196,14 @@ export const INTERNAL_MCP_SERVERS = {
     isPreview: false,
     tools_stakes: undefined,
     timeoutMs: undefined,
+    serverMetadata: {
+      name: DEFAULT_WEBSEARCH_ACTION_NAME,
+      version: "1.0.0",
+      description: DEFAULT_WEBSEARCH_ACTION_DESCRIPTION,
+      icon: "ActionGlobeAltIcon",
+      authorization: null,
+      documentationUrl: null,
+    },
   },
   think: {
     id: 6,
@@ -158,6 +215,14 @@ export const INTERNAL_MCP_SERVERS = {
     isPreview: true,
     tools_stakes: undefined,
     timeoutMs: undefined,
+    serverMetadata: {
+      name: "think",
+      version: "1.0.0",
+      description: "Expand thinking and reasoning capabilities.",
+      icon: "ActionBrainIcon",
+      authorization: null,
+      documentationUrl: null,
+    },
   },
   hubspot: {
     id: 7,
@@ -206,8 +271,22 @@ export const INTERNAL_MCP_SERVERS = {
       remove_association: "high",
     },
     timeoutMs: undefined,
+    serverMetadata: {
+      name: "hubspot",
+      version: "1.0.0",
+      description:
+        "Comprehensive HubSpot CRM integration supporting all object types (contacts, companies, deals) and ALL engagement types (tasks, notes, meetings, calls, emails). " +
+        "Features advanced user activity tracking, owner search and listing, association management, and enhanced search capabilities with owner filtering. " +
+        "Perfect for CRM data management and user activity analysis.",
+      authorization: {
+        provider: "hubspot" as const,
+        supported_use_cases: ["platform_actions", "personal_actions"] as const,
+      },
+      icon: "HubspotLogo",
+      documentationUrl: null,
+    },
   },
-  agent_router: {
+  [DEFAULT_AGENT_ROUTER_ACTION_NAME]: {
     id: 8,
     availability: "auto_hidden_builder",
     allowMultipleInstances: false,
@@ -215,6 +294,17 @@ export const INTERNAL_MCP_SERVERS = {
     isPreview: false,
     tools_stakes: undefined,
     timeoutMs: undefined,
+    serverMetadata: {
+      name: DEFAULT_AGENT_ROUTER_ACTION_NAME,
+      version: "1.0.0",
+      description: DEFAULT_AGENT_ROUTER_ACTION_DESCRIPTION,
+      icon: "ActionRobotIcon",
+      authorization: null,
+      documentationUrl: null,
+      instructions: `These tools provide discoverability to published agents available in the workspace.
+The tools return agents with their "mention" markdown directive.
+The directive should be used to display a clickable version of the agent name in the response.`,
+    },
   },
   include_data: {
     id: 9,
@@ -224,6 +314,14 @@ export const INTERNAL_MCP_SERVERS = {
     isPreview: false,
     tools_stakes: undefined,
     timeoutMs: undefined,
+    serverMetadata: {
+      name: "include_data",
+      version: "1.0.0",
+      description: "Include data exhaustively",
+      icon: "ActionTimeIcon",
+      authorization: null,
+      documentationUrl: null,
+    },
   },
   run_dust_app: {
     id: 10,
@@ -233,6 +331,14 @@ export const INTERNAL_MCP_SERVERS = {
     isPreview: false,
     tools_stakes: undefined,
     timeoutMs: undefined,
+    serverMetadata: {
+      name: "run_dust_app",
+      version: "1.0.0",
+      description: "Run Dust Apps with specified parameters",
+      icon: "CommandLineIcon",
+      authorization: null,
+      documentationUrl: null,
+    },
   },
   notion: {
     id: 11,
@@ -263,6 +369,17 @@ export const INTERNAL_MCP_SERVERS = {
       update_schema_database: "low",
     },
     timeoutMs: undefined,
+    serverMetadata: {
+      name: "notion",
+      version: "1.0.0",
+      description: "Notion tools to manage pages and databases.",
+      authorization: {
+        provider: "notion" as const,
+        supported_use_cases: ["platform_actions", "personal_actions"] as const,
+      },
+      icon: "NotionLogo",
+      documentationUrl: null,
+    },
   },
   extract_data: {
     id: 12,
@@ -272,6 +389,14 @@ export const INTERNAL_MCP_SERVERS = {
     isPreview: false,
     tools_stakes: undefined,
     timeoutMs: undefined,
+    serverMetadata: {
+      name: "extract_data",
+      version: "1.0.0",
+      description: "Structured extraction",
+      icon: "ActionScanIcon",
+      authorization: null,
+      documentationUrl: null,
+    },
   },
   missing_action_catcher: {
     id: 13,
@@ -281,6 +406,14 @@ export const INTERNAL_MCP_SERVERS = {
     isPreview: false,
     tools_stakes: undefined,
     timeoutMs: undefined,
+    serverMetadata: {
+      name: "missing_action_catcher",
+      version: "1.0.0",
+      description: "To be used to catch errors and avoid erroring.",
+      authorization: null,
+      icon: "ActionDocumentTextIcon",
+      documentationUrl: null,
+    },
   },
   salesforce: {
     id: 14,
@@ -299,6 +432,18 @@ export const INTERNAL_MCP_SERVERS = {
       describe_object: "never_ask",
     },
     timeoutMs: undefined,
+    serverMetadata: {
+      name: "salesforce",
+      version: "1.0.0",
+      description: "Salesforce tools.",
+      authorization: {
+        provider: "salesforce" as const,
+        supported_use_cases: ["personal_actions", "platform_actions"] as const,
+      },
+      icon: "SalesforceLogo",
+      documentationUrl: "https://docs.dust.tt/docs/salesforce",
+      instructions: SALESFORCE_SERVER_INSTRUCTIONS,
+    },
   },
   gmail: {
     id: 15,
@@ -313,6 +458,19 @@ export const INTERNAL_MCP_SERVERS = {
       create_reply_draft: "low",
     },
     timeoutMs: undefined,
+    serverMetadata: {
+      name: "gmail",
+      version: "1.0.0",
+      description: "Gmail tools for reading emails and managing email drafts.",
+      authorization: {
+        provider: "google_drive" as const,
+        supported_use_cases: ["personal_actions"] as const,
+        scope:
+          "https://www.googleapis.com/auth/gmail.readonly https://www.googleapis.com/auth/gmail.compose" as const,
+      },
+      icon: "GmailLogo",
+      documentationUrl: "https://docs.dust.tt/docs/gmail-tool-setup",
+    },
   },
   google_calendar: {
     id: 16,
@@ -330,6 +488,19 @@ export const INTERNAL_MCP_SERVERS = {
       check_availability: "never_ask",
     },
     timeoutMs: undefined,
+    serverMetadata: {
+      name: "google_calendar",
+      version: "1.0.0",
+      description: "Tools for managing Google calendars and events.",
+      authorization: {
+        provider: "google_drive",
+        supported_use_cases: ["personal_actions"] as const,
+        scope:
+          "https://www.googleapis.com/auth/calendar https://www.googleapis.com/auth/calendar.events" as const,
+      },
+      icon: "GcalLogo",
+      documentationUrl: "https://docs.dust.tt/docs/google-calendar",
+    },
   },
   conversation_files: {
     id: 17,
@@ -339,6 +510,14 @@ export const INTERNAL_MCP_SERVERS = {
     isPreview: false,
     tools_stakes: undefined,
     timeoutMs: undefined,
+    serverMetadata: {
+      name: "conversation_files",
+      version: "1.0.0",
+      description: "Include files from conversation attachments",
+      icon: "ActionDocumentTextIcon",
+      authorization: null,
+      documentationUrl: null,
+    },
   },
   slack: {
     id: 18,
@@ -356,6 +535,21 @@ export const INTERNAL_MCP_SERVERS = {
       get_user: "never_ask",
     },
     timeoutMs: undefined,
+    serverMetadata: {
+      name: "slack",
+      version: "1.0.0",
+      description: "Slack tools for searching and posting messages.",
+      authorization: {
+        provider: "slack" as const,
+        supported_use_cases: ["personal_actions"] as const,
+      },
+      icon: "SlackLogo",
+      documentationUrl: "https://docs.dust.tt/docs/slack-mcp",
+      instructions:
+        "When posting a message on Slack, you MUST use Slack-flavored Markdown to format the message." +
+        "IMPORTANT: if you want to mention a user, you must use <@USER_ID> where USER_ID is the id of the user you want to mention.\n" +
+        "If you want to reference a channel, you must use #CHANNEL where CHANNEL is the channel name, or <#CHANNEL_ID> where CHANNEL_ID is the channel ID.",
+    },
   },
   google_sheets: {
     id: 19,
@@ -378,6 +572,19 @@ export const INTERNAL_MCP_SERVERS = {
       format_cells: "low",
     },
     timeoutMs: undefined,
+    serverMetadata: {
+      name: "google_sheets",
+      version: "1.0.0",
+      description: "Tools for managing Google Sheets spreadsheets and data.",
+      authorization: {
+        provider: "gmail",
+        supported_use_cases: ["personal_actions"] as const,
+        scope:
+          "https://www.googleapis.com/auth/spreadsheets https://www.googleapis.com/auth/drive.readonly" as const,
+      },
+      icon: "GoogleSpreadsheetLogo",
+      documentationUrl: "https://docs.dust.tt/docs/google-sheets",
+    },
   },
   monday: {
     id: 20,
@@ -418,6 +625,19 @@ export const INTERNAL_MCP_SERVERS = {
       delete_group: "high",
     },
     timeoutMs: undefined,
+    serverMetadata: {
+      name: "monday",
+      version: "1.0.0",
+      description:
+        "Monday.com integration providing CRM-like operations for boards, items, and updates. Enables reading and managing Monday.com boards and items through the GraphQL API.",
+      authorization: {
+        provider: "monday" as const,
+        supported_use_cases: ["personal_actions", "platform_actions"] as const,
+      },
+      icon: "MondayLogo",
+      documentationUrl:
+        "https://developer.monday.com/api-reference/docs/introduction-to-graphql",
+    },
   },
   agent_memory: {
     id: 21,
@@ -427,6 +647,14 @@ export const INTERNAL_MCP_SERVERS = {
     isPreview: false,
     tools_stakes: undefined,
     timeoutMs: undefined,
+    serverMetadata: {
+      name: "agent_memory",
+      version: "1.0.0",
+      description: "User-scoped long-term memory tools for agents.",
+      authorization: null,
+      icon: "ActionLightbulbIcon",
+      documentationUrl: null,
+    },
   },
   jira: {
     id: 22,
@@ -459,6 +687,19 @@ export const INTERNAL_MCP_SERVERS = {
       delete_issue_link: "low",
     },
     timeoutMs: undefined,
+    serverMetadata: {
+      name: "jira",
+      version: "1.0.0",
+      description:
+        "Comprehensive JIRA integration providing full issue management capabilities including create, read, update, comment, workflow transitions, and issue linking operations using the JIRA REST API.",
+      authorization: {
+        provider: "jira" as const,
+        supported_use_cases: ["platform_actions", "personal_actions"] as const,
+      },
+      icon: "JiraLogo",
+      documentationUrl: null,
+      instructions: JIRA_SERVER_INSTRUCTIONS,
+    },
   },
   interactive_content: {
     id: 23,
@@ -470,6 +711,15 @@ export const INTERNAL_MCP_SERVERS = {
     isPreview: true,
     tools_stakes: undefined,
     timeoutMs: undefined,
+    serverMetadata: {
+      name: "interactive_content",
+      version: "1.0.0",
+      description:
+        "Create and update interactive content files that users can execute and interact with. Currently supports client-executable code.",
+      authorization: null,
+      icon: "ActionDocumentTextIcon",
+      documentationUrl: null,
+    },
   },
   outlook: {
     id: 24,
@@ -488,6 +738,20 @@ export const INTERNAL_MCP_SERVERS = {
       update_contact: "high",
     },
     timeoutMs: undefined,
+    serverMetadata: {
+      name: "outlook",
+      version: "1.0.0",
+      description:
+        "Outlook tools for reading emails, managing email drafts, and managing contacts.",
+      authorization: {
+        provider: "microsoft_tools" as const,
+        supported_use_cases: ["personal_actions"] as const,
+        scope:
+          "Mail.ReadWrite Mail.ReadWrite.Shared Contacts.ReadWrite Contacts.ReadWrite.Shared User.Read offline_access" as const,
+      },
+      icon: "OutlookLogo",
+      documentationUrl: "https://docs.dust.tt/docs/outlook-tool-setup",
+    },
   },
   outlook_calendar: {
     id: 25,
@@ -505,6 +769,19 @@ export const INTERNAL_MCP_SERVERS = {
       check_availability: "never_ask",
     },
     timeoutMs: undefined,
+    serverMetadata: {
+      name: "outlook_calendar",
+      version: "1.0.0",
+      description: "Tools for managing Outlook calendars and events.",
+      authorization: {
+        provider: "microsoft_tools" as const,
+        supported_use_cases: ["personal_actions"] as const,
+        scope:
+          "Calendars.ReadWrite Calendars.ReadWrite.Shared User.Read offline_access" as const,
+      },
+      icon: "OutlookLogo",
+      documentationUrl: "https://docs.dust.tt/docs/outlook-calendar-tool-setup",
+    },
   },
   freshservice: {
     id: 26,
@@ -537,8 +814,23 @@ export const INTERNAL_MCP_SERVERS = {
       create_solution_article: "high",
     },
     timeoutMs: undefined,
+    serverMetadata: {
+      name: "freshservice",
+      icon: "FreshserviceLogo",
+      version: "1.0.0",
+      description:
+        "Freshservice integration supporting ticket management, service catalog, solutions, departments, " +
+        "on-call schedules, and more. Provides comprehensive access to Freshservice resources with " +
+        "OAuth authentication and secure API access.",
+      authorization: {
+        provider: "freshservice" as const,
+        supported_use_cases: ["platform_actions", "personal_actions"] as const,
+      },
+      documentationUrl: null,
+      instructions: FRESHSERVICE_SERVER_INSTRUCTIONS,
+    },
   },
-  search: {
+  [SEARCH_SERVER_NAME]: {
     id: 1006,
     availability: "auto",
     allowMultipleInstances: false,
@@ -546,6 +838,14 @@ export const INTERNAL_MCP_SERVERS = {
     isPreview: false,
     tools_stakes: undefined,
     timeoutMs: undefined,
+    serverMetadata: {
+      name: SEARCH_SERVER_NAME,
+      version: "1.0.0",
+      description: "Search through selected Data sources",
+      icon: "ActionMagnifyingGlassIcon",
+      authorization: null,
+      documentationUrl: null,
+    },
   },
   run_agent: {
     id: 1008,
@@ -555,6 +855,14 @@ export const INTERNAL_MCP_SERVERS = {
     isPreview: false,
     tools_stakes: undefined,
     timeoutMs: 10 * 60 * 1000, // 10 minutes
+    serverMetadata: {
+      name: "run_agent",
+      version: "1.0.0",
+      description: "Run a child agent (agent as tool).",
+      icon: "ActionRobotIcon",
+      authorization: null,
+      documentationUrl: null,
+    },
   },
   primitive_types_debugger: {
     id: 1004,
@@ -566,6 +874,15 @@ export const INTERNAL_MCP_SERVERS = {
     },
     tools_stakes: undefined,
     timeoutMs: undefined,
+    serverMetadata: {
+      name: "primitive_types_debugger",
+      version: "1.0.0",
+      description:
+        "Demo server showing a basic interaction with various configurable blocks.",
+      icon: "ActionEmotionLaughIcon",
+      authorization: null,
+      documentationUrl: null,
+    },
   },
   reasoning: {
     id: 1007,
@@ -575,6 +892,15 @@ export const INTERNAL_MCP_SERVERS = {
     isPreview: false,
     tools_stakes: undefined,
     timeoutMs: undefined,
+    serverMetadata: {
+      name: "reasoning",
+      version: "1.0.0",
+      description:
+        "Agent can decide to trigger a reasoning model for complex tasks.",
+      icon: "ActionLightbulbIcon",
+      authorization: null,
+      documentationUrl: null,
+    },
   },
   query_tables_v2: {
     id: 1009,
@@ -587,6 +913,15 @@ export const INTERNAL_MCP_SERVERS = {
     isPreview: true,
     tools_stakes: undefined,
     timeoutMs: undefined,
+    serverMetadata: {
+      name: "query_tables_v2",
+      version: "1.0.0",
+      description:
+        "Tables, Spreadsheets, Notion DBs (quantitative) (mcp, exploded).",
+      icon: "ActionTableIcon",
+      authorization: null,
+      documentationUrl: null,
+    },
   },
   data_sources_file_system: {
     id: 1010,
@@ -598,6 +933,19 @@ export const INTERNAL_MCP_SERVERS = {
     isPreview: false,
     tools_stakes: undefined,
     timeoutMs: undefined,
+    serverMetadata: {
+      name: "data_sources_file_system",
+      version: "1.0.0",
+      description:
+        "Comprehensive content navigation toolkit for browsing user data sources. Provides Unix-like " +
+        "browsing (ls, find) and smart search tools to help agents efficiently explore and discover " +
+        "content from manually uploaded files or data synced from SaaS products (Notion, Slack, Github" +
+        ", etc.) organized in a filesystem-like hierarchy. Each item in this tree-like hierarchy is " +
+        "called a node, nodes are referenced by a nodeId.",
+      authorization: null,
+      icon: "ActionDocumentTextIcon",
+      documentationUrl: null,
+    },
   },
   agent_management: {
     id: 1011,
@@ -611,6 +959,14 @@ export const INTERNAL_MCP_SERVERS = {
       create_agent: "high",
     },
     timeoutMs: undefined,
+    serverMetadata: {
+      name: "agent_management",
+      version: "1.0.0",
+      description: "Tools for managing agent configurations",
+      authorization: null,
+      icon: "ActionRobotIcon",
+      documentationUrl: null,
+    },
   },
   data_warehouses: {
     id: 1012,
@@ -622,6 +978,17 @@ export const INTERNAL_MCP_SERVERS = {
     },
     tools_stakes: undefined,
     timeoutMs: undefined,
+    serverMetadata: {
+      name: "data_warehouses",
+      version: "1.0.0",
+      description:
+        "Comprehensive tables navigation toolkit for browsing data warehouses and tables. Provides Unix-like " +
+        "browsing (ls, find) to help agents efficiently explore and discover tables organized in a " +
+        "warehouse-centric hierarchy. Each warehouse contains schemas/databases which contain tables.",
+      authorization: null,
+      icon: "ActionTableIcon",
+      documentationUrl: null,
+    },
   },
   toolsets: {
     id: 1013,
@@ -633,6 +1000,16 @@ export const INTERNAL_MCP_SERVERS = {
     },
     tools_stakes: undefined,
     timeoutMs: undefined,
+    serverMetadata: {
+      name: "toolsets",
+      version: "1.0.0",
+      description:
+        "Comprehensive navigation toolkit for browsing available toolsets. " +
+        "Toolsets provide functions for the agent to use.",
+      authorization: null,
+      icon: "ActionLightbulbIcon",
+      documentationUrl: null,
+    },
   },
   // Using satisfies here instead of : type to avoid typescript widening the type and breaking the type inference for AutoInternalMCPServerNameType.
 } satisfies Record<
@@ -650,6 +1027,7 @@ export const INTERNAL_MCP_SERVERS = {
     isPreview: boolean;
     tools_stakes: Record<string, MCPToolStakeLevelType> | undefined;
     timeoutMs: number | undefined;
+    serverMetadata: InternalMCPServerDefinitionType;
   }
 >;
 
@@ -694,7 +1072,7 @@ export const getAvailabilityOfInternalMCPServerById = (
 export const allowsMultipleInstancesOfInternalMCPServerByName = (
   name: InternalMCPServerNameType
 ): boolean => {
-  return !!INTERNAL_MCP_SERVERS[name].allowMultipleInstances;
+  return INTERNAL_MCP_SERVERS[name].allowMultipleInstances;
 };
 
 export const allowsMultipleInstancesOfInternalMCPServerById = (

--- a/front/lib/actions/mcp_internal_actions/constants.ts
+++ b/front/lib/actions/mcp_internal_actions/constants.ts
@@ -1034,9 +1034,8 @@ The directive should be used to display a clickable version of the agent name in
     },
   },
   // Using satisfies here instead of : type to avoid typescript widening the type and breaking the type inference for AutoInternalMCPServerNameType.
-} satisfies Record<
-  InternalMCPServerNameType,
-  {
+} satisfies {
+  [K in InternalMCPServerNameType]: {
     id: number;
     availability: MCPServerAvailability;
     allowMultipleInstances: boolean;
@@ -1049,9 +1048,9 @@ The directive should be used to display a clickable version of the agent name in
     isPreview: boolean;
     tools_stakes: Record<string, MCPToolStakeLevelType> | undefined;
     timeoutMs: number | undefined;
-    serverInfo: InternalMCPServerDefinitionType;
-  }
->;
+    serverInfo: InternalMCPServerDefinitionType & { name: K };
+  };
+};
 
 export type InternalMCPServerNameType =
   (typeof AVAILABLE_INTERNAL_MCP_SERVER_NAMES)[number];

--- a/front/lib/actions/mcp_internal_actions/constants.ts
+++ b/front/lib/actions/mcp_internal_actions/constants.ts
@@ -98,14 +98,6 @@ const MCP_SERVER_AVAILABILITY = [
 ] as const;
 export type MCPServerAvailability = (typeof MCP_SERVER_AVAILABILITY)[number];
 
-export const isMCPServerAvailability = (
-  availability: string
-): availability is MCPServerAvailability => {
-  return MCP_SERVER_AVAILABILITY.includes(
-    availability as MCPServerAvailability
-  );
-};
-
 export const INTERNAL_MCP_SERVERS = {
   // Note:
   // ids should be stable, do not change them when moving internal servers to production as it would break existing agents.
@@ -135,6 +127,7 @@ export const INTERNAL_MCP_SERVERS = {
       },
       icon: "GithubLogo",
       documentationUrl: null,
+      instructions: null,
     },
   },
   image_generation: {
@@ -152,6 +145,7 @@ export const INTERNAL_MCP_SERVERS = {
       icon: "ActionImageIcon",
       authorization: null,
       documentationUrl: null,
+      instructions: null,
     },
   },
   file_generation: {
@@ -169,6 +163,7 @@ export const INTERNAL_MCP_SERVERS = {
       authorization: null,
       icon: "ActionDocumentTextIcon",
       documentationUrl: null,
+      instructions: null,
     },
   },
   [TABLE_QUERY_SERVER_NAME]: {
@@ -186,6 +181,7 @@ export const INTERNAL_MCP_SERVERS = {
       icon: "ActionTableIcon",
       authorization: null,
       documentationUrl: null,
+      instructions: null,
     },
   },
   [DEFAULT_WEBSEARCH_ACTION_NAME]: {
@@ -203,6 +199,7 @@ export const INTERNAL_MCP_SERVERS = {
       icon: "ActionGlobeAltIcon",
       authorization: null,
       documentationUrl: null,
+      instructions: null,
     },
   },
   think: {
@@ -222,6 +219,7 @@ export const INTERNAL_MCP_SERVERS = {
       icon: "ActionBrainIcon",
       authorization: null,
       documentationUrl: null,
+      instructions: null,
     },
   },
   hubspot: {
@@ -284,6 +282,7 @@ export const INTERNAL_MCP_SERVERS = {
       },
       icon: "HubspotLogo",
       documentationUrl: null,
+      instructions: null,
     },
   },
   [DEFAULT_AGENT_ROUTER_ACTION_NAME]: {
@@ -321,6 +320,7 @@ The directive should be used to display a clickable version of the agent name in
       icon: "ActionTimeIcon",
       authorization: null,
       documentationUrl: null,
+      instructions: null,
     },
   },
   run_dust_app: {
@@ -338,6 +338,7 @@ The directive should be used to display a clickable version of the agent name in
       icon: "CommandLineIcon",
       authorization: null,
       documentationUrl: null,
+      instructions: null,
     },
   },
   notion: {
@@ -379,6 +380,7 @@ The directive should be used to display a clickable version of the agent name in
       },
       icon: "NotionLogo",
       documentationUrl: null,
+      instructions: null,
     },
   },
   extract_data: {
@@ -396,6 +398,7 @@ The directive should be used to display a clickable version of the agent name in
       icon: "ActionScanIcon",
       authorization: null,
       documentationUrl: null,
+      instructions: null,
     },
   },
   missing_action_catcher: {
@@ -413,6 +416,7 @@ The directive should be used to display a clickable version of the agent name in
       authorization: null,
       icon: "ActionDocumentTextIcon",
       documentationUrl: null,
+      instructions: null,
     },
   },
   salesforce: {
@@ -470,6 +474,7 @@ The directive should be used to display a clickable version of the agent name in
       },
       icon: "GmailLogo",
       documentationUrl: "https://docs.dust.tt/docs/gmail-tool-setup",
+      instructions: null,
     },
   },
   google_calendar: {
@@ -500,6 +505,7 @@ The directive should be used to display a clickable version of the agent name in
       },
       icon: "GcalLogo",
       documentationUrl: "https://docs.dust.tt/docs/google-calendar",
+      instructions: null,
     },
   },
   conversation_files: {
@@ -517,6 +523,7 @@ The directive should be used to display a clickable version of the agent name in
       icon: "ActionDocumentTextIcon",
       authorization: null,
       documentationUrl: null,
+      instructions: null,
     },
   },
   slack: {
@@ -584,6 +591,7 @@ The directive should be used to display a clickable version of the agent name in
       },
       icon: "GoogleSpreadsheetLogo",
       documentationUrl: "https://docs.dust.tt/docs/google-sheets",
+      instructions: null,
     },
   },
   monday: {
@@ -637,6 +645,7 @@ The directive should be used to display a clickable version of the agent name in
       icon: "MondayLogo",
       documentationUrl:
         "https://developer.monday.com/api-reference/docs/introduction-to-graphql",
+      instructions: null,
     },
   },
   agent_memory: {
@@ -654,6 +663,7 @@ The directive should be used to display a clickable version of the agent name in
       authorization: null,
       icon: "ActionLightbulbIcon",
       documentationUrl: null,
+      instructions: null,
     },
   },
   jira: {
@@ -719,6 +729,7 @@ The directive should be used to display a clickable version of the agent name in
       authorization: null,
       icon: "ActionDocumentTextIcon",
       documentationUrl: null,
+      instructions: null,
     },
   },
   outlook: {
@@ -751,6 +762,7 @@ The directive should be used to display a clickable version of the agent name in
       },
       icon: "OutlookLogo",
       documentationUrl: "https://docs.dust.tt/docs/outlook-tool-setup",
+      instructions: null,
     },
   },
   outlook_calendar: {
@@ -781,6 +793,7 @@ The directive should be used to display a clickable version of the agent name in
       },
       icon: "OutlookLogo",
       documentationUrl: "https://docs.dust.tt/docs/outlook-calendar-tool-setup",
+      instructions: null,
     },
   },
   freshservice: {
@@ -845,6 +858,7 @@ The directive should be used to display a clickable version of the agent name in
       icon: "ActionMagnifyingGlassIcon",
       authorization: null,
       documentationUrl: null,
+      instructions: null,
     },
   },
   run_agent: {
@@ -862,6 +876,7 @@ The directive should be used to display a clickable version of the agent name in
       icon: "ActionRobotIcon",
       authorization: null,
       documentationUrl: null,
+      instructions: null,
     },
   },
   primitive_types_debugger: {
@@ -882,6 +897,7 @@ The directive should be used to display a clickable version of the agent name in
       icon: "ActionEmotionLaughIcon",
       authorization: null,
       documentationUrl: null,
+      instructions: null,
     },
   },
   reasoning: {
@@ -900,6 +916,7 @@ The directive should be used to display a clickable version of the agent name in
       icon: "ActionLightbulbIcon",
       authorization: null,
       documentationUrl: null,
+      instructions: null,
     },
   },
   query_tables_v2: {
@@ -921,6 +938,7 @@ The directive should be used to display a clickable version of the agent name in
       icon: "ActionTableIcon",
       authorization: null,
       documentationUrl: null,
+      instructions: null,
     },
   },
   data_sources_file_system: {
@@ -945,6 +963,7 @@ The directive should be used to display a clickable version of the agent name in
       authorization: null,
       icon: "ActionDocumentTextIcon",
       documentationUrl: null,
+      instructions: null,
     },
   },
   agent_management: {
@@ -966,6 +985,7 @@ The directive should be used to display a clickable version of the agent name in
       authorization: null,
       icon: "ActionRobotIcon",
       documentationUrl: null,
+      instructions: null,
     },
   },
   data_warehouses: {
@@ -988,6 +1008,7 @@ The directive should be used to display a clickable version of the agent name in
       authorization: null,
       icon: "ActionTableIcon",
       documentationUrl: null,
+      instructions: null,
     },
   },
   toolsets: {
@@ -1009,6 +1030,7 @@ The directive should be used to display a clickable version of the agent name in
       authorization: null,
       icon: "ActionLightbulbIcon",
       documentationUrl: null,
+      instructions: null,
     },
   },
   // Using satisfies here instead of : type to avoid typescript widening the type and breaking the type inference for AutoInternalMCPServerNameType.

--- a/front/lib/actions/mcp_internal_actions/instructions.ts
+++ b/front/lib/actions/mcp_internal_actions/instructions.ts
@@ -1,0 +1,78 @@
+export const SALESFORCE_SERVER_INSTRUCTIONS = `You have access to the following tools: execute_read_query, list_objects, and describe_object.
+
+# General Workflow for Salesforce Data:
+1.  **List Objects (Optional):** If you don't know the exact name of an object, use \`list_objects\` to find it.
+2.  **Describe Object:** Use \`describe_object\` with the specific object name (e.g., \`Account\`, \`MyCustomObject__c\`) to get its detailed metadata. This will show you all available fields, their exact names, data types, and information about relationships (child relationships are particularly important for subqueries).
+3.  **Execute Read Query:** Use \`execute_read_query\` to retrieve data using SOQL. Construct your SOQL queries based on the information obtained from \`describe_object\` to ensure you are using correct field and relationship names.
+
+# execute_read_query
+You can use it to execute SOQL read queries on Salesforce. Queries can be used to retrieve or discover data, never to write data.
+
+**Best Practices for Querying:**
+1.  **Discover Object Structure First:** ALWAYS use \`describe_object(objectName='YourObjectName')\` to understand an object's fields and relationships before writing complex queries. Alternatively, for a quick field list directly in a query, use \`FIELDS()\` (e.g., \`SELECT FIELDS(ALL) FROM Account LIMIT 1\`). This helps prevent errors from misspelled or non-existent field/relationship names. The \`FIELDS()\` function requires a \`LIMIT\` clause, with a maximum of 200.
+2.  **Verify Field and Relationship Names:** If you encounter "No such column" or "Didn't understand relationship" errors, use \`describe_object\` for the relevant object(s) to confirm the exact names and their availability. For example, child relationship names used in subqueries (e.g., \`(SELECT Name FROM Contacts)\` or \`(SELECT Name FROM MyCustomChildren__r)\`) can be found in the output of \`describe_object\`.
+
+**Custom Objects, Fields, and Relationships:**
+-   **Custom Objects & Fields:** When referencing custom objects or fields, append \`__c\` to their names (e.g., \`MyCustomField__c\`, \`MyCustomObject__c\`). Confirm these names using \`describe_object\`.
+-   **Custom Relationships:** When referencing custom relationships (typically in parent-to-child subqueries), append \`__r\` to the relationship name (e.g., \`(SELECT Name FROM MyCustomRelatedObjects__r)\`). \`describe_object\` will list these child relationship names.
+
+**FIELDS() Keyword Details (Alternative to describe_object for quick field listing in query):**
+Use \`FIELDS(ALL)\`, \`FIELDS(CUSTOM)\`, or \`FIELDS(STANDARD)\` in your \`SELECT\` statement to retrieve groups of fields.
+-   \`FIELDS(ALL)\`: Selects all fields.
+-   \`FIELDS(CUSTOM)\`: Selects all custom fields.
+-   \`FIELDS(STANDARD)\`: Selects all standard fields.
+Remember to include \`LIMIT\` (max 200) when using \`FIELDS()\`.
+
+**Relationships in Queries (Confirm names with describe_object):**
+-   **Child-to-Parent:** Use dot notation. E.g., \`SELECT Account.Name, LastName FROM Contact\`.
+-   **Parent-to-Child (Subqueries):** Use a subquery. Confirm relationship name (e.g., \`Contacts\` or \`MyCustomChildren__r\`) via \`describe_object\`.
+    -   Standard Relationship: \`SELECT Name, (SELECT FirstName, LastName FROM Contacts) FROM Account\`
+    -   Custom Relationship: \`SELECT Name, (SELECT Name FROM MyCustomChildren__r) FROM Account\`
+
+If errors persist after using \`describe_object\` and following these guidelines, the field, object, or relationship might genuinely not exist, or you may lack permissions.
+
+# list_objects
+You can use it to list the objects in Salesforce: standard and custom objects. Useful for finding object names if you're unsure.
+
+# describe_object
+Use this tool to get detailed metadata about a specific Salesforce object. Provide the object's API name (e.g., \`Account\`, \`Lead\`, \`MyCustomObject__c\`).
+The output includes:
+-   A list of all fields with their names, labels, types, and other properties.
+-   Details about child relationships (useful for parent-to-child subqueries in SOQL), including the relationship name.
+-   Information about record types.
+-   Other object-level properties.
+This is the most reliable way to discover the correct names for fields and relationships before writing an \`execute_read_query\`.
+`;
+
+export const JIRA_SERVER_INSTRUCTIONS = `
+      You have access to the following tools: get_issue, get_projects, get_project, get_transitions, create_comment, get_issues, get_issue_types, get_issue_create_fields, get_connection_info, transition_issue, create_issue, update_issue, create_issue_link, delete_issue_link, get_issue_link_types, get_users, get_issue_read_fields.
+
+      # General Workflow for JIRA Data:
+      1.  **Authenticate:** Use \`get_connection_info\` to authenticate with JIRA if you are not authenticated ("No access token found").
+      2.  **For Create/Update Operations:** Always use \`get_issue_types\` and \`get_issue_create_fields\` with the specific issue typename to get its create/update-time metadata (fields available on the Create/Update screens).
+      3.  **Execute Read Query:** Use \`get_issues\` to retrieve data using JQL. Construct your JQL queries based on the information obtained from \`get_issue_types\` to ensure you are using correct field and relationship names.
+
+      **Best Practices for Querying:**
+      1.  **Discover Object Structure First:** Use \`get_issue_create_fields\` to understand fields available for create/update in a given project and issue type. Alternatively, for a quick field list directly in a query, use \`get_issues\`.
+      2.  **Verify Field and Relationship Names:** If you encounter JIRA 400 errors suggesting that the field or relationship does not exist, use \`get_issue_types\` for the relevant object(s) to confirm the exact names and their availability.
+
+      **Field Selection for get_issue (Optional Performance Optimization):**
+      - By default, \`get_issue\` returns essential fields: summary, issuetype, priority, assignee, reporter, labels, duedate, parent, project, status
+      - Only use \`get_issue_read_fields\` if you need additional custom fields or want to optimize performance by requesting specific fields
+      - For built-in fields use the \`key\` (e.g., "summary", "issuetype", "status"). For custom fields use the \`id\` (e.g., "customfield_10020").
+
+      **User Lookup (get_users):**
+      - Provide emailAddress for exact match on email. Example: { "emailAddress": "jane.doe@acme.com" }
+      - Or provide name for case-insensitive contains on display name. Example: { "name": "Jane" }
+      - If neither emailAddress nor name is provided, the tool lists the first maxResults users.
+      - For pagination, pass startAt using the previous result's nextStartAt. Example: { "name": "Jane", "startAt": 100 }
+    `;
+
+export const FRESHSERVICE_SERVER_INSTRUCTIONS = `
+     **Best Practices:**
+      - Use specific filters when listing tickets to narrow down results
+      - By default, \`list_tickets\` returns minimal fields (id, subject, status) for performance
+      - By default, \`get_ticket\` returns essential fields for detailed information
+      - Use \`get_ticket_read_fields\` only if you need additional custom fields
+      - Use \`include\` parameter with \`get_ticket\` to get related data like conversations, requester info, etc.
+    `;

--- a/front/lib/actions/mcp_internal_actions/personal_authentication.ts
+++ b/front/lib/actions/mcp_internal_actions/personal_authentication.ts
@@ -1,13 +1,17 @@
-import type { AuthorizationInfo } from "@app/lib/actions/mcp_metadata";
+import assert from "assert";
+
 import type { InternalMCPServerDefinitionType } from "@app/lib/api/mcp";
 
 export function makePersonalAuthenticationError({
-  serverInfo,
+  serverMetadata,
 }: {
-  serverInfo: InternalMCPServerDefinitionType & {
-    authorization: AuthorizationInfo;
-  };
+  serverMetadata: InternalMCPServerDefinitionType;
 }) {
+  assert(
+    serverMetadata.authorization?.provider,
+    "MCP server does not require a personal authentication."
+  );
+
   return {
     isError: true,
     content: [
@@ -15,7 +19,7 @@ export function makePersonalAuthenticationError({
         type: "text" as const,
         text: JSON.stringify({
           __dust_auth_required: {
-            provider: serverInfo.authorization.provider,
+            provider: serverMetadata.authorization.provider,
           },
         }),
       },

--- a/front/lib/actions/mcp_internal_actions/personal_authentication.ts
+++ b/front/lib/actions/mcp_internal_actions/personal_authentication.ts
@@ -3,12 +3,12 @@ import assert from "assert";
 import type { InternalMCPServerDefinitionType } from "@app/lib/api/mcp";
 
 export function makePersonalAuthenticationError({
-  serverMetadata,
+  serverInfo,
 }: {
-  serverMetadata: InternalMCPServerDefinitionType;
+  serverInfo: InternalMCPServerDefinitionType;
 }) {
   assert(
-    serverMetadata.authorization?.provider,
+    serverInfo.authorization?.provider,
     "MCP server does not require a personal authentication."
   );
 
@@ -19,7 +19,7 @@ export function makePersonalAuthenticationError({
         type: "text" as const,
         text: JSON.stringify({
           __dust_auth_required: {
-            provider: serverMetadata.authorization.provider,
+            provider: serverInfo.authorization.provider,
           },
         }),
       },

--- a/front/lib/actions/mcp_internal_actions/personal_authentication.ts
+++ b/front/lib/actions/mcp_internal_actions/personal_authentication.ts
@@ -1,17 +1,16 @@
-import assert from "assert";
+import type { InternalMCPServerNameType } from "@app/lib/actions/mcp_internal_actions/constants";
+import { INTERNAL_MCP_SERVERS } from "@app/lib/actions/mcp_internal_actions/constants";
 
-import type { InternalMCPServerDefinitionType } from "@app/lib/api/mcp";
+// Type that extracts server names where authorization is not null.
+type ServersWithAuthorization = {
+  [K in InternalMCPServerNameType]: (typeof INTERNAL_MCP_SERVERS)[K]["serverInfo"]["authorization"] extends null
+    ? never
+    : K;
+}[InternalMCPServerNameType];
 
-export function makePersonalAuthenticationError({
-  serverInfo,
-}: {
-  serverInfo: InternalMCPServerDefinitionType;
-}) {
-  assert(
-    serverInfo.authorization?.provider,
-    "MCP server does not require a personal authentication."
-  );
-
+export function makePersonalAuthenticationError(
+  serverName: ServersWithAuthorization
+) {
   return {
     isError: true,
     content: [
@@ -19,7 +18,9 @@ export function makePersonalAuthenticationError({
         type: "text" as const,
         text: JSON.stringify({
           __dust_auth_required: {
-            provider: serverInfo.authorization.provider,
+            provider:
+              INTERNAL_MCP_SERVERS[serverName].serverInfo.authorization
+                .provider,
           },
         }),
       },

--- a/front/lib/actions/mcp_internal_actions/servers/agent_management.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/agent_management.ts
@@ -10,19 +10,9 @@ import {
 } from "@app/lib/actions/mcp_internal_actions/utils";
 import type { AgentLoopContextType } from "@app/lib/actions/types";
 import apiConfig from "@app/lib/api/config";
-import type { InternalMCPServerDefinitionType } from "@app/lib/api/mcp";
 import type { Authenticator } from "@app/lib/auth";
 import { prodAPICredentialsForOwner } from "@app/lib/auth";
 import logger from "@app/logger/logger";
-
-const serverInfo: InternalMCPServerDefinitionType = {
-  name: "agent_management",
-  version: "1.0.0",
-  description: "Tools for managing agent configurations",
-  authorization: null,
-  icon: "ActionRobotIcon",
-  documentationUrl: null,
-};
 
 const createServer = (
   auth: Authenticator,
@@ -30,7 +20,7 @@ const createServer = (
 ): McpServer => {
   void agentLoopContext;
 
-  const server = makeInternalMCPServer(serverInfo);
+  const server = makeInternalMCPServer("agent_management");
 
   server.tool(
     "create_agent",

--- a/front/lib/actions/mcp_internal_actions/servers/agent_memory.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/agent_memory.ts
@@ -4,24 +4,14 @@ import { z } from "zod";
 
 import { makeInternalMCPServer } from "@app/lib/actions/mcp_internal_actions/utils";
 import type { AgentLoopContextType } from "@app/lib/actions/types";
-import type { InternalMCPServerDefinitionType } from "@app/lib/api/mcp";
 import type { Authenticator } from "@app/lib/auth";
 import { AgentMemoryResource } from "@app/lib/resources/agent_memory_resource";
-
-const serverInfo: InternalMCPServerDefinitionType = {
-  name: "agent_memory",
-  version: "1.0.0",
-  description: "User-scoped long-term memory tools for agents.",
-  authorization: null,
-  icon: "ActionLightbulbIcon",
-  documentationUrl: null,
-};
 
 const createServer = (
   auth: Authenticator,
   agentLoopContext?: AgentLoopContextType
 ): McpServer => {
-  const server = makeInternalMCPServer(serverInfo);
+  const server = makeInternalMCPServer("agent_memory");
 
   const isUserScopedMemory = true;
 

--- a/front/lib/actions/mcp_internal_actions/servers/agent_router.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/agent_router.ts
@@ -2,41 +2,25 @@ import { DustAPI } from "@dust-tt/client";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod";
 
-import {
-  DEFAULT_AGENT_ROUTER_ACTION_DESCRIPTION,
-  DEFAULT_AGENT_ROUTER_ACTION_NAME,
-} from "@app/lib/actions/constants";
+import { DEFAULT_AGENT_ROUTER_ACTION_NAME } from "@app/lib/actions/constants";
 import {
   makeInternalMCPServer,
   makeMCPToolTextError,
 } from "@app/lib/actions/mcp_internal_actions/utils";
 import { getSuggestedAgentsForContent } from "@app/lib/api/assistant/agent_suggestion";
 import apiConfig from "@app/lib/api/config";
-import type { InternalMCPServerDefinitionType } from "@app/lib/api/mcp";
 import type { Authenticator } from "@app/lib/auth";
 import { prodAPICredentialsForOwner } from "@app/lib/auth";
 import logger from "@app/logger/logger";
 import type { LightAgentConfigurationType } from "@app/types";
 import { getHeaderFromGroupIds, getHeaderFromRole } from "@app/types/groups";
 
-const serverInfo: InternalMCPServerDefinitionType = {
-  name: DEFAULT_AGENT_ROUTER_ACTION_NAME,
-  version: "1.0.0",
-  description: DEFAULT_AGENT_ROUTER_ACTION_DESCRIPTION,
-  icon: "ActionRobotIcon",
-  authorization: null,
-  documentationUrl: null,
-  instructions: `These tools provide discoverability to published agents available in the workspace.
-The tools return agents with their "mention" markdown directive.
-The directive should be used to display a clickable version of the agent name in the response.`,
-};
-
 const MAX_INSTRUCTIONS_LENGTH = 1000;
 const LIST_ALL_AGENTS_TOOL_NAME = "list_all_published_agents";
 export const SUGGEST_AGENTS_TOOL_NAME = "suggest_agents_for_content";
 
 const createServer = (auth: Authenticator): McpServer => {
-  const server = makeInternalMCPServer(serverInfo);
+  const server = makeInternalMCPServer(DEFAULT_AGENT_ROUTER_ACTION_NAME);
 
   server.tool(
     LIST_ALL_AGENTS_TOOL_NAME,

--- a/front/lib/actions/mcp_internal_actions/servers/conversation_files.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/conversation_files.ts
@@ -16,7 +16,6 @@ import {
   renderAttachmentXml,
 } from "@app/lib/api/assistant/conversation/attachments";
 import { listAttachments } from "@app/lib/api/assistant/jit_utils";
-import type { InternalMCPServerDefinitionType } from "@app/lib/api/mcp";
 import { getSupportedModelConfig } from "@app/lib/assistant";
 import type { Authenticator } from "@app/lib/auth";
 import {
@@ -44,20 +43,12 @@ const MAX_FILE_SIZE_FOR_INCLUDE = 1024 * 1024; // 1MB.
  * the legacy action system, but this server provides the MCP implementation
  * for future migration.
  */
-const serverInfo: InternalMCPServerDefinitionType = {
-  name: "conversation_files",
-  version: "1.0.0",
-  description: "Include files from conversation attachments",
-  icon: "ActionDocumentTextIcon",
-  authorization: null,
-  documentationUrl: null,
-};
 
 function createServer(
   auth: Authenticator,
   agentLoopContext?: AgentLoopContextType
 ): McpServer {
-  const server = makeInternalMCPServer(serverInfo);
+  const server = makeInternalMCPServer("conversation_files");
 
   server.tool(
     DEFAULT_CONVERSATION_INCLUDE_FILE_ACTION_NAME,

--- a/front/lib/actions/mcp_internal_actions/servers/data_sources_file_system.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/data_sources_file_system.ts
@@ -44,7 +44,6 @@ import type { AgentLoopContextType } from "@app/lib/actions/types";
 import { getRefs } from "@app/lib/api/assistant/citations";
 import config from "@app/lib/api/config";
 import { ROOT_PARENT_ID } from "@app/lib/api/data_source_view";
-import type { InternalMCPServerDefinitionType } from "@app/lib/api/mcp";
 import type { Authenticator } from "@app/lib/auth";
 import { getDisplayNameForDocument } from "@app/lib/data_sources";
 import { concurrentExecutor } from "@app/lib/utils/async_utils";
@@ -67,22 +66,6 @@ import {
   stripNullBytes,
   timeFrameFromNow,
 } from "@app/types";
-
-export const FILESYSTEM_SERVER_NAME = "data_sources_file_system";
-
-const serverInfo: InternalMCPServerDefinitionType = {
-  name: FILESYSTEM_SERVER_NAME,
-  version: "1.0.0",
-  description:
-    "Comprehensive content navigation toolkit for browsing user data sources. Provides Unix-like " +
-    "browsing (ls, find) and smart search tools to help agents efficiently explore and discover " +
-    "content from manually uploaded files or data synced from SaaS products (Notion, Slack, Github" +
-    ", etc.) organized in a filesystem-like hierarchy. Each item in this tree-like hierarchy is " +
-    "called a node, nodes are referenced by a nodeId.",
-  authorization: null,
-  icon: "ActionDocumentTextIcon",
-  documentationUrl: null,
-};
 
 const OPTION_PARAMETERS = {
   limit: z
@@ -383,7 +366,7 @@ const createServer = (
   auth: Authenticator,
   agentLoopContext?: AgentLoopContextType
 ): McpServer => {
-  const server = makeInternalMCPServer(serverInfo);
+  const server = makeInternalMCPServer("data_sources_file_system");
 
   server.tool(
     FILESYSTEM_CAT_TOOL_NAME,

--- a/front/lib/actions/mcp_internal_actions/servers/data_warehouses/server.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/data_warehouses/server.ts
@@ -1,5 +1,5 @@
 import { INTERNAL_MIME_TYPES } from "@dust-tt/client";
-import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod";
 
 import { MCPError } from "@app/lib/actions/mcp_errors";
@@ -23,10 +23,10 @@ import {
 } from "@app/lib/actions/mcp_internal_actions/servers/tables_query/schema";
 import { executeQuery } from "@app/lib/actions/mcp_internal_actions/servers/tables_query/server_v2";
 import { getAgentDataSourceConfigurations } from "@app/lib/actions/mcp_internal_actions/servers/utils";
+import { makeInternalMCPServer } from "@app/lib/actions/mcp_internal_actions/utils";
 import { withToolLogging } from "@app/lib/actions/mcp_internal_actions/wrappers";
 import type { AgentLoopContextType } from "@app/lib/actions/types";
 import config from "@app/lib/api/config";
-import type { InternalMCPServerDefinitionType } from "@app/lib/api/mcp";
 import type { Authenticator } from "@app/lib/auth";
 import { DataSourceResource } from "@app/lib/resources/data_source_resource";
 import logger from "@app/logger/logger";
@@ -37,23 +37,11 @@ const TABLES_FILESYSTEM_TOOL_NAME = "tables_filesystem_navigation";
 const DEFAULT_LIMIT = 50;
 const MAX_LIMIT = 100;
 
-const serverInfo: InternalMCPServerDefinitionType = {
-  name: "data_warehouses",
-  version: "1.0.0",
-  description:
-    "Comprehensive tables navigation toolkit for browsing data warehouses and tables. Provides Unix-like " +
-    "browsing (ls, find) to help agents efficiently explore and discover tables organized in a " +
-    "warehouse-centric hierarchy. Each warehouse contains schemas/databases which contain tables.",
-  authorization: null,
-  icon: "ActionTableIcon",
-  documentationUrl: null,
-};
-
 const createServer = (
   auth: Authenticator,
   agentLoopContext?: AgentLoopContextType
 ): McpServer => {
-  const server = new McpServer(serverInfo);
+  const server = makeInternalMCPServer("data_warehouses");
 
   server.tool(
     DATA_WAREHOUSES_LIST_TOOL_NAME,

--- a/front/lib/actions/mcp_internal_actions/servers/file_generation.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/file_generation.ts
@@ -11,22 +11,12 @@ import {
   makeInternalMCPServer,
   makeMCPToolTextError,
 } from "@app/lib/actions/mcp_internal_actions/utils";
-import type { InternalMCPServerDefinitionType } from "@app/lib/api/mcp";
 import type { Authenticator } from "@app/lib/auth";
 import { FileResource } from "@app/lib/resources/file_resource";
 import { getResourceNameAndIdFromSId } from "@app/lib/resources/string_ids";
 import { cacheWithRedis } from "@app/lib/utils/cache";
 import type { SupportedFileContentType } from "@app/types";
 import { assertNever, normalizeError, validateUrl } from "@app/types";
-
-const serverInfo: InternalMCPServerDefinitionType = {
-  name: "file_generation",
-  version: "1.0.0",
-  description: "Agent can generate and convert files.",
-  authorization: null,
-  icon: "ActionDocumentTextIcon",
-  documentationUrl: null,
-};
 
 const OUTPUT_FORMATS = [
   "csv",
@@ -104,7 +94,7 @@ function getContentTypeFromOutputFormat(
 }
 
 const createServer = (auth: Authenticator): McpServer => {
-  const server = makeInternalMCPServer(serverInfo);
+  const server = makeInternalMCPServer("file_generation");
   server.tool(
     "get_supported_source_formats_for_output_format",
     "Get a list of source formats supported for a target output format.",

--- a/front/lib/actions/mcp_internal_actions/servers/freshservice/server.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/freshservice/server.ts
@@ -1,41 +1,17 @@
-import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod";
 
 import {
+  makeInternalMCPServer,
   makeMCPToolJSONSuccess,
   makeMCPToolTextError,
 } from "@app/lib/actions/mcp_internal_actions/utils";
-import type { InternalMCPServerDefinitionType } from "@app/lib/api/mcp";
 
 import type { FreshserviceTicket } from "./freshservice_api_helper";
 import { FreshserviceTicketSchema } from "./freshservice_api_helper";
 
-const serverInfo: InternalMCPServerDefinitionType = {
-  name: "freshservice",
-  icon: "FreshserviceLogo",
-  version: "1.0.0",
-  description:
-    "Freshservice integration supporting ticket management, service catalog, solutions, departments, " +
-    "on-call schedules, and more. Provides comprehensive access to Freshservice resources with " +
-    "OAuth authentication and secure API access.",
-  authorization: {
-    provider: "freshservice" as const,
-    supported_use_cases: ["platform_actions", "personal_actions"] as const,
-  },
-  documentationUrl: null,
-};
-
 const createServer = (): McpServer => {
-  const server = new McpServer(serverInfo, {
-    instructions: `
-     **Best Practices:**
-      - Use specific filters when listing tickets to narrow down results
-      - By default, \`list_tickets\` returns minimal fields (id, subject, status) for performance
-      - By default, \`get_ticket\` returns essential fields for detailed information
-      - Use \`get_ticket_read_fields\` only if you need additional custom fields
-      - Use \`include\` parameter with \`get_ticket\` to get related data like conversations, requester info, etc.
-    `,
-  });
+  const server = makeInternalMCPServer("freshservice");
 
   // Helper function to make authenticated API calls
   const withAuth = async <T>({
@@ -923,4 +899,3 @@ const createServer = (): McpServer => {
 };
 
 export default createServer;
-export { serverInfo };

--- a/front/lib/actions/mcp_internal_actions/servers/github.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/github.ts
@@ -12,7 +12,6 @@ import {
   makeMCPToolTextError,
   makeMCPToolTextSuccess,
 } from "@app/lib/actions/mcp_internal_actions/utils";
-import type { InternalMCPServerDefinitionType } from "@app/lib/api/mcp";
 import type { Authenticator } from "@app/lib/auth";
 import { isWorkspaceUsingStaticIP } from "@app/lib/misc";
 import { EnvironmentConfig, normalizeError } from "@app/types";
@@ -48,20 +47,8 @@ const createOctokit = async (
   });
 };
 
-const serverInfo: InternalMCPServerDefinitionType = {
-  name: "github",
-  version: "1.0.0",
-  description: "GitHub tools to manage issues and pull requests.",
-  authorization: {
-    provider: "github" as const,
-    supported_use_cases: ["platform_actions"] as const,
-  },
-  icon: "GithubLogo",
-  documentationUrl: null,
-};
-
 const createServer = (auth: Authenticator): McpServer => {
-  const server = makeInternalMCPServer(serverInfo);
+  const server = makeInternalMCPServer("github");
 
   server.tool(
     "create_issue",

--- a/front/lib/actions/mcp_internal_actions/servers/gmail.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/gmail.ts
@@ -56,22 +56,8 @@ interface MessageDetail {
   error?: string;
 }
 
-const serverInfo: InternalMCPServerDefinitionType = {
-  name: "gmail",
-  version: "1.0.0",
-  description: "Gmail tools for reading emails and managing email drafts.",
-  authorization: {
-    provider: "google_drive" as const,
-    supported_use_cases: ["personal_actions"] as const,
-    scope:
-      "https://www.googleapis.com/auth/gmail.readonly https://www.googleapis.com/auth/gmail.compose" as const,
-  },
-  icon: "GmailLogo",
-  documentationUrl: "https://docs.dust.tt/docs/gmail-tool-setup",
-};
-
 const createServer = (): McpServer => {
-  const server = makeInternalMCPServer(serverInfo);
+  const server = makeInternalMCPServer("gmail");
 
   server.tool(
     "get_drafts",

--- a/front/lib/actions/mcp_internal_actions/servers/gmail.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/gmail.ts
@@ -7,7 +7,6 @@ import {
   makeMCPToolJSONSuccess,
   makeMCPToolTextError,
 } from "@app/lib/actions/mcp_internal_actions/utils";
-import type { InternalMCPServerDefinitionType } from "@app/lib/api/mcp";
 import { concurrentExecutor } from "@app/lib/utils/async_utils";
 
 interface GmailHeader {

--- a/front/lib/actions/mcp_internal_actions/servers/google_calendar.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/google_calendar.ts
@@ -9,25 +9,10 @@ import {
   makeMCPToolJSONSuccess,
   makeMCPToolTextError,
 } from "@app/lib/actions/mcp_internal_actions/utils";
-import type { InternalMCPServerDefinitionType } from "@app/lib/api/mcp";
 import { normalizeError } from "@app/types/shared/utils/error_utils";
 
-const serverInfo: InternalMCPServerDefinitionType = {
-  name: "google_calendar",
-  version: "1.0.0",
-  description: "Tools for managing Google calendars and events.",
-  authorization: {
-    provider: "google_drive",
-    supported_use_cases: ["personal_actions"] as const,
-    scope:
-      "https://www.googleapis.com/auth/calendar https://www.googleapis.com/auth/calendar.events" as const,
-  },
-  icon: "GcalLogo",
-  documentationUrl: "https://docs.dust.tt/docs/google-calendar",
-};
-
 const createServer = (): McpServer => {
-  const server = makeInternalMCPServer(serverInfo);
+  const server = makeInternalMCPServer("google_calendar");
 
   async function getCalendarClient(authInfo?: AuthInfo) {
     const accessToken = authInfo?.token;

--- a/front/lib/actions/mcp_internal_actions/servers/google_sheets.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/google_sheets.ts
@@ -8,25 +8,10 @@ import {
   makeMCPToolJSONSuccess,
   makeMCPToolTextError,
 } from "@app/lib/actions/mcp_internal_actions/utils";
-import type { InternalMCPServerDefinitionType } from "@app/lib/api/mcp";
 import { normalizeError } from "@app/types/shared/utils/error_utils";
 
-const serverInfo: InternalMCPServerDefinitionType = {
-  name: "google_sheets",
-  version: "1.0.0",
-  description: "Tools for managing Google Sheets spreadsheets and data.",
-  authorization: {
-    provider: "gmail",
-    supported_use_cases: ["personal_actions"] as const,
-    scope:
-      "https://www.googleapis.com/auth/spreadsheets https://www.googleapis.com/auth/drive.readonly" as const,
-  },
-  icon: "GoogleSpreadsheetLogo",
-  documentationUrl: "https://docs.dust.tt/docs/google-sheets",
-};
-
 const createServer = (): McpServer => {
-  const server = makeInternalMCPServer(serverInfo);
+  const server = makeInternalMCPServer("google_sheets");
 
   async function getSheetsClient(authInfo?: AuthInfo) {
     const accessToken = authInfo?.token;

--- a/front/lib/actions/mcp_internal_actions/servers/hubspot/server.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/hubspot/server.ts
@@ -1,5 +1,5 @@
 import { FilterOperatorEnum } from "@hubspot/api-client/lib/codegen/crm/contacts";
-import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod";
 
 import {
@@ -54,29 +54,14 @@ import {
   withAuth,
 } from "@app/lib/actions/mcp_internal_actions/servers/hubspot/hubspot_utils";
 import {
+  makeInternalMCPServer,
   makeMCPToolJSONSuccess,
   makeMCPToolTextError,
   makeMCPToolTextSuccess,
 } from "@app/lib/actions/mcp_internal_actions/utils";
-import type { InternalMCPServerDefinitionType } from "@app/lib/api/mcp";
-
-const serverInfo: InternalMCPServerDefinitionType = {
-  name: "hubspot",
-  version: "1.0.0",
-  description:
-    "Comprehensive HubSpot CRM integration supporting all object types (contacts, companies, deals) and ALL engagement types (tasks, notes, meetings, calls, emails). " +
-    "Features advanced user activity tracking, owner search and listing, association management, and enhanced search capabilities with owner filtering. " +
-    "Perfect for CRM data management and user activity analysis.",
-  authorization: {
-    provider: "hubspot" as const,
-    supported_use_cases: ["platform_actions", "personal_actions"] as const,
-  },
-  icon: "HubspotLogo",
-  documentationUrl: null,
-};
 
 const createServer = (): McpServer => {
-  const server = new McpServer(serverInfo);
+  const server = makeInternalMCPServer("hubspot");
 
   server.tool(
     "get_object_properties",
@@ -1259,4 +1244,3 @@ const createServer = (): McpServer => {
 };
 
 export default createServer;
-export { serverInfo };

--- a/front/lib/actions/mcp_internal_actions/servers/image_generation.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/image_generation.ts
@@ -7,7 +7,6 @@ import {
   makeInternalMCPServer,
   makeMCPToolTextError,
 } from "@app/lib/actions/mcp_internal_actions/utils";
-import type { InternalMCPServerDefinitionType } from "@app/lib/api/mcp";
 import type { Authenticator } from "@app/lib/auth";
 import { rateLimiter } from "@app/lib/utils/rate_limiter";
 import { getStatsDClient } from "@app/lib/utils/statsd";
@@ -21,17 +20,8 @@ const IMAGE_GENERATION_RATE_LIMITER_TIMEFRAME_SECONDS = 60 * 60 * 24 * 7; // 1 w
 const DEFAULT_IMAGE_OUTPUT_FORMAT = "png";
 const DEFAULT_IMAGE_MIME_TYPE = "image/png";
 
-const serverInfo: InternalMCPServerDefinitionType = {
-  name: "image_generation",
-  version: "1.0.0",
-  description: "Agent can generate images (GPT Image 1).",
-  icon: "ActionImageIcon",
-  authorization: null,
-  documentationUrl: null,
-};
-
 const createServer = (auth: Authenticator): McpServer => {
-  const server = makeInternalMCPServer(serverInfo);
+  const server = makeInternalMCPServer("image_generation");
 
   server.tool(
     "generate_image",

--- a/front/lib/actions/mcp_internal_actions/servers/include.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/include.ts
@@ -32,7 +32,6 @@ import { withToolLogging } from "@app/lib/actions/mcp_internal_actions/wrappers"
 import type { AgentLoopContextType } from "@app/lib/actions/types";
 import { getRefs } from "@app/lib/api/assistant/citations";
 import config from "@app/lib/api/config";
-import type { InternalMCPServerDefinitionType } from "@app/lib/api/mcp";
 import type { Authenticator } from "@app/lib/auth";
 import {
   getDataSourceNameFromView,
@@ -50,20 +49,11 @@ import {
   timeFrameFromNow,
 } from "@app/types";
 
-const serverInfo: InternalMCPServerDefinitionType = {
-  name: "include_data",
-  version: "1.0.0",
-  description: "Include data exhaustively",
-  icon: "ActionTimeIcon",
-  authorization: null,
-  documentationUrl: null,
-};
-
 function createServer(
   auth: Authenticator,
   agentLoopContext?: AgentLoopContextType
 ): McpServer {
-  const server = makeInternalMCPServer(serverInfo);
+  const server = makeInternalMCPServer("include_data");
 
   const commonInputsSchema = {
     timeFrame:

--- a/front/lib/actions/mcp_internal_actions/servers/interactive_content.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/interactive_content.ts
@@ -12,21 +12,10 @@ import {
   editClientExecutableFile,
   getClientExecutableFileContent,
 } from "@app/lib/api/files/client_executable";
-import type { InternalMCPServerDefinitionType } from "@app/lib/api/mcp";
 import type { Authenticator } from "@app/lib/auth";
 import type { InteractiveFileContentType } from "@app/types";
 import { Err, Ok } from "@app/types";
 import { INTERACTIVE_FILE_FORMATS } from "@app/types";
-
-const serverInfo: InternalMCPServerDefinitionType = {
-  name: "interactive_content",
-  version: "1.0.0",
-  description:
-    "Create and update interactive content files that users can execute and interact with. Currently supports client-executable code.",
-  authorization: null,
-  icon: "ActionDocumentTextIcon",
-  documentationUrl: null,
-};
 
 const MAX_FILE_SIZE_BYTES = 1 * 1024 * 1024; // 1MB
 
@@ -45,7 +34,7 @@ const createServer = (
   auth: Authenticator,
   agentLoopContext?: AgentLoopContextType
 ): McpServer => {
-  const server = makeInternalMCPServer(serverInfo);
+  const server = makeInternalMCPServer("interactive_content");
 
   server.tool(
     CREATE_INTERACTIVE_FILE_TOOL_NAME,

--- a/front/lib/actions/mcp_internal_actions/servers/jira/server.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/jira/server.ts
@@ -1,4 +1,4 @@
-import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod";
 
 import {
@@ -31,50 +31,13 @@ import {
   SEARCH_USERS_MAX_RESULTS,
 } from "@app/lib/actions/mcp_internal_actions/servers/jira/types";
 import {
+  makeInternalMCPServer,
   makeMCPToolJSONSuccess,
   makeMCPToolTextError,
 } from "@app/lib/actions/mcp_internal_actions/utils";
-import type { InternalMCPServerDefinitionType } from "@app/lib/api/mcp";
-
-const serverInfo: InternalMCPServerDefinitionType = {
-  name: "jira",
-  version: "1.0.0",
-  description:
-    "Comprehensive JIRA integration providing full issue management capabilities including create, read, update, comment, workflow transitions, and issue linking operations using the JIRA REST API.",
-  authorization: {
-    provider: "jira" as const,
-    supported_use_cases: ["platform_actions", "personal_actions"] as const,
-  },
-  icon: "JiraLogo",
-  documentationUrl: null,
-};
 
 const createServer = (): McpServer => {
-  const server = new McpServer(serverInfo, {
-    instructions: `
-      You have access to the following tools: get_issue, get_projects, get_project, get_transitions, create_comment, get_issues, get_issue_types, get_issue_create_fields, get_connection_info, transition_issue, create_issue, update_issue, create_issue_link, delete_issue_link, get_issue_link_types, get_users, get_issue_read_fields.
-
-      # General Workflow for JIRA Data:
-      1.  **Authenticate:** Use \`get_connection_info\` to authenticate with JIRA if you are not authenticated ("No access token found").
-      2.  **For Create/Update Operations:** Always use \`get_issue_types\` and \`get_issue_create_fields\` with the specific issue typename to get its create/update-time metadata (fields available on the Create/Update screens).
-      3.  **Execute Read Query:** Use \`get_issues\` to retrieve data using JQL. Construct your JQL queries based on the information obtained from \`get_issue_types\` to ensure you are using correct field and relationship names.
-
-      **Best Practices for Querying:**
-      1.  **Discover Object Structure First:** Use \`get_issue_create_fields\` to understand fields available for create/update in a given project and issue type. Alternatively, for a quick field list directly in a query, use \`get_issues\`.
-      2.  **Verify Field and Relationship Names:** If you encounter JIRA 400 errors suggesting that the field or relationship does not exist, use \`get_issue_types\` for the relevant object(s) to confirm the exact names and their availability.
-
-      **Field Selection for get_issue (Optional Performance Optimization):**
-      - By default, \`get_issue\` returns essential fields: summary, issuetype, priority, assignee, reporter, labels, duedate, parent, project, status
-      - Only use \`get_issue_read_fields\` if you need additional custom fields or want to optimize performance by requesting specific fields
-      - For built-in fields use the \`key\` (e.g., "summary", "issuetype", "status"). For custom fields use the \`id\` (e.g., "customfield_10020").
-
-      **User Lookup (get_users):**
-      - Provide emailAddress for exact match on email. Example: { "emailAddress": "jane.doe@acme.com" }
-      - Or provide name for case-insensitive contains on display name. Example: { "name": "Jane" }
-      - If neither emailAddress nor name is provided, the tool lists the first maxResults users.
-      - For pagination, pass startAt using the previous result's nextStartAt. Example: { "name": "Jane", "startAt": 100 }
-    `,
-  });
+  const server = makeInternalMCPServer("jira");
 
   server.tool(
     "get_issue_read_fields",
@@ -724,4 +687,3 @@ const createServer = (): McpServer => {
 };
 
 export default createServer;
-export { serverInfo };

--- a/front/lib/actions/mcp_internal_actions/servers/missing_action_catcher.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/missing_action_catcher.ts
@@ -5,23 +5,13 @@ import {
   makeMCPToolTextError,
 } from "@app/lib/actions/mcp_internal_actions/utils";
 import type { AgentLoopContextType } from "@app/lib/actions/types";
-import type { InternalMCPServerDefinitionType } from "@app/lib/api/mcp";
 import type { Authenticator } from "@app/lib/auth";
-
-const serverInfo: InternalMCPServerDefinitionType = {
-  name: "missing_action_catcher",
-  version: "1.0.0",
-  description: "To be used to catch errors and avoid erroring.",
-  authorization: null,
-  icon: "ActionDocumentTextIcon",
-  documentationUrl: null,
-};
 
 const createServer = (
   auth: Authenticator,
   agentLoopContext?: AgentLoopContextType
 ): McpServer => {
-  const server = makeInternalMCPServer(serverInfo);
+  const server = makeInternalMCPServer("missing_action_catcher");
   if (agentLoopContext) {
     const actionName = agentLoopContext.runContext
       ? agentLoopContext.runContext.toolConfiguration.name

--- a/front/lib/actions/mcp_internal_actions/servers/monday/server.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/monday/server.ts
@@ -1,4 +1,4 @@
-import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod";
 
 import type { SearchItemsFilters } from "@app/lib/actions/mcp_internal_actions/servers/monday/monday_api_helper";
@@ -34,27 +34,13 @@ import {
   uploadFileToColumn,
 } from "@app/lib/actions/mcp_internal_actions/servers/monday/monday_api_helper";
 import {
+  makeInternalMCPServer,
   makeMCPToolJSONSuccess,
   makeMCPToolTextError,
 } from "@app/lib/actions/mcp_internal_actions/utils";
-import type { InternalMCPServerDefinitionType } from "@app/lib/api/mcp";
-
-const serverInfo: InternalMCPServerDefinitionType = {
-  name: "monday",
-  version: "1.0.0",
-  description:
-    "Monday.com integration providing CRM-like operations for boards, items, and updates. Enables reading and managing Monday.com boards and items through the GraphQL API.",
-  authorization: {
-    provider: "monday" as const,
-    supported_use_cases: ["personal_actions", "platform_actions"] as const,
-  },
-  icon: "MondayLogo",
-  documentationUrl:
-    "https://developer.monday.com/api-reference/docs/introduction-to-graphql",
-};
 
 const createServer = (): McpServer => {
-  const server = new McpServer(serverInfo);
+  const server = makeInternalMCPServer("monday");
 
   server.tool(
     "get_boards",
@@ -929,4 +915,3 @@ const createServer = (): McpServer => {
 };
 
 export default createServer;
-export { serverInfo };

--- a/front/lib/actions/mcp_internal_actions/servers/notion.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/notion.ts
@@ -12,7 +12,6 @@ import type {
 import { parseISO } from "date-fns";
 import { z } from "zod";
 
-import { INTERNAL_MCP_SERVERS } from "@app/lib/actions/mcp_internal_actions/constants";
 import type {
   SearchQueryResourceType,
   SearchResultResourceType,

--- a/front/lib/actions/mcp_internal_actions/servers/notion.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/notion.ts
@@ -264,7 +264,7 @@ async function withNotionClient<T>(
   try {
     const accessToken = authInfo?.token;
     if (!accessToken) {
-      return makePersonalAuthenticationError(INTERNAL_MCP_SERVERS["notion"]);
+      return makePersonalAuthenticationError("notion");
     }
     const notion = new Client({ auth: accessToken });
 
@@ -309,7 +309,7 @@ const createServer = (
 
       const accessToken = authInfo?.token;
       if (!accessToken) {
-        return makePersonalAuthenticationError(INTERNAL_MCP_SERVERS["notion"]);
+        return makePersonalAuthenticationError("notion");
       }
       const notion = new Client({ auth: accessToken });
 

--- a/front/lib/actions/mcp_internal_actions/servers/notion.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/notion.ts
@@ -12,6 +12,7 @@ import type {
 import { parseISO } from "date-fns";
 import { z } from "zod";
 
+import { INTERNAL_MCP_SERVERS } from "@app/lib/actions/mcp_internal_actions/constants";
 import type {
   SearchQueryResourceType,
   SearchResultResourceType,
@@ -26,22 +27,9 @@ import {
 import type { AgentLoopContextType } from "@app/lib/actions/types";
 import { NOTION_SEARCH_ACTION_NUM_RESULTS } from "@app/lib/actions/utils";
 import { getRefs } from "@app/lib/api/assistant/citations";
-import type { InternalMCPServerDefinitionType } from "@app/lib/api/mcp";
 import type { Authenticator } from "@app/lib/auth";
 import type { TimeFrame } from "@app/types";
 import { normalizeError, parseTimeFrame, timeFrameFromNow } from "@app/types";
-
-const serverInfo = {
-  name: "notion",
-  version: "1.0.0",
-  description: "Notion tools to manage pages and databases.",
-  authorization: {
-    provider: "notion" as const,
-    supported_use_cases: ["platform_actions", "personal_actions"] as const,
-  },
-  icon: "NotionLogo",
-  documentationUrl: null,
-} satisfies InternalMCPServerDefinitionType;
 
 const uuidRegex =
   /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
@@ -276,7 +264,7 @@ async function withNotionClient<T>(
   try {
     const accessToken = authInfo?.token;
     if (!accessToken) {
-      return makePersonalAuthenticationError({ serverInfo });
+      return makePersonalAuthenticationError(INTERNAL_MCP_SERVERS["notion"]);
     }
     const notion = new Client({ auth: accessToken });
 
@@ -294,7 +282,7 @@ const createServer = (
   auth: Authenticator,
   agentLoopContext?: AgentLoopContextType
 ): McpServer => {
-  const server = makeInternalMCPServer(serverInfo);
+  const server = makeInternalMCPServer("notion");
 
   server.tool(
     "search",
@@ -321,7 +309,7 @@ const createServer = (
 
       const accessToken = authInfo?.token;
       if (!accessToken) {
-        return makePersonalAuthenticationError({ serverInfo });
+        return makePersonalAuthenticationError(INTERNAL_MCP_SERVERS["notion"]);
       }
       const notion = new Client({ auth: accessToken });
 

--- a/front/lib/actions/mcp_internal_actions/servers/outlook/calendar_server.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/outlook/calendar_server.ts
@@ -1,29 +1,15 @@
-import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod";
 
 import * as OutlookApi from "@app/lib/actions/mcp_internal_actions/servers/outlook/outlook_api_helper";
 import {
+  makeInternalMCPServer,
   makeMCPToolJSONSuccess,
   makeMCPToolTextError,
 } from "@app/lib/actions/mcp_internal_actions/utils";
-import type { InternalMCPServerDefinitionType } from "@app/lib/api/mcp";
-
-const serverInfo: InternalMCPServerDefinitionType = {
-  name: "outlook_calendar",
-  version: "1.0.0",
-  description: "Tools for managing Outlook calendars and events.",
-  authorization: {
-    provider: "microsoft_tools" as const,
-    supported_use_cases: ["personal_actions"] as const,
-    scope:
-      "Calendars.ReadWrite Calendars.ReadWrite.Shared User.Read offline_access" as const,
-  },
-  icon: "OutlookLogo",
-  documentationUrl: "https://docs.dust.tt/docs/outlook-calendar-tool-setup",
-};
 
 const createServer = (): McpServer => {
-  const server = new McpServer(serverInfo);
+  const server = makeInternalMCPServer("outlook_calendar");
 
   server.tool(
     "list_calendars",

--- a/front/lib/actions/mcp_internal_actions/servers/outlook/server.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/outlook/server.ts
@@ -1,11 +1,11 @@
-import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod";
 
 import {
+  makeInternalMCPServer,
   makeMCPToolJSONSuccess,
   makeMCPToolTextError,
 } from "@app/lib/actions/mcp_internal_actions/utils";
-import type { InternalMCPServerDefinitionType } from "@app/lib/api/mcp";
 import { concurrentExecutor } from "@app/lib/utils/async_utils";
 
 const OutlookEmailAddressSchema = z.object({
@@ -68,23 +68,8 @@ const OutlookContactSchema = z.object({
 type OutlookMessage = z.infer<typeof OutlookMessageSchema>;
 type OutlookContact = z.infer<typeof OutlookContactSchema>;
 
-const serverInfo: InternalMCPServerDefinitionType = {
-  name: "outlook",
-  version: "1.0.0",
-  description:
-    "Outlook tools for reading emails, managing email drafts, and managing contacts.",
-  authorization: {
-    provider: "microsoft_tools" as const,
-    supported_use_cases: ["personal_actions"] as const,
-    scope:
-      "Mail.ReadWrite Mail.ReadWrite.Shared Contacts.ReadWrite Contacts.ReadWrite.Shared User.Read offline_access" as const,
-  },
-  icon: "OutlookLogo",
-  documentationUrl: "https://docs.dust.tt/docs/outlook-tool-setup",
-};
-
 const createServer = (): McpServer => {
-  const server = new McpServer(serverInfo);
+  const server = makeInternalMCPServer("outlook");
 
   server.tool(
     "get_messages",

--- a/front/lib/actions/mcp_internal_actions/servers/primitive_types_debugger.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/primitive_types_debugger.ts
@@ -4,20 +4,9 @@ import { z } from "zod";
 
 import { ConfigurableToolInputSchemas } from "@app/lib/actions/mcp_internal_actions/input_schemas";
 import { makeInternalMCPServer } from "@app/lib/actions/mcp_internal_actions/utils";
-import type { InternalMCPServerDefinitionType } from "@app/lib/api/mcp";
-
-const serverInfo: InternalMCPServerDefinitionType = {
-  name: "primitive_types_debugger",
-  version: "1.0.0",
-  description:
-    "Demo server showing a basic interaction with various configurable blocks.",
-  icon: "ActionEmotionLaughIcon",
-  authorization: null,
-  documentationUrl: null,
-};
 
 function createServer(): McpServer {
-  const server = makeInternalMCPServer(serverInfo);
+  const server = makeInternalMCPServer("primitive_types_debugger");
 
   server.tool(
     "pass_through",

--- a/front/lib/actions/mcp_internal_actions/servers/process/index.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/process/index.ts
@@ -1,5 +1,5 @@
 import { INTERNAL_MIME_TYPES, removeNulls } from "@dust-tt/client";
-import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import assert from "assert";
 import type { JSONSchema7 as JSONSchema } from "json-schema";
 import _ from "lodash";
@@ -29,6 +29,7 @@ import {
   getDataSourceConfiguration,
   shouldAutoGenerateTags,
 } from "@app/lib/actions/mcp_internal_actions/servers/utils";
+import { makeInternalMCPServer } from "@app/lib/actions/mcp_internal_actions/utils";
 import { withToolLogging } from "@app/lib/actions/mcp_internal_actions/wrappers";
 import { runActionStreamed } from "@app/lib/actions/server";
 import type {
@@ -40,7 +41,6 @@ import {
   isServerSideMCPServerConfiguration,
 } from "@app/lib/actions/types/guards";
 import { constructPromptMultiActions } from "@app/lib/api/assistant/generation";
-import type { InternalMCPServerDefinitionType } from "@app/lib/api/mcp";
 import { getSupportedModelConfig } from "@app/lib/assistant";
 import type { Authenticator } from "@app/lib/auth";
 import { cloneBaseConfig, getDustProdAction } from "@app/lib/registry";
@@ -62,15 +62,6 @@ import { applyDataSourceFilters, getExtractFileTitle } from "./utils";
 type ProcessActionOutputsType = {
   data: unknown[];
   total_documents?: number;
-};
-
-const serverInfo: InternalMCPServerDefinitionType = {
-  name: "extract_data",
-  version: "1.0.0",
-  description: "Structured extraction",
-  icon: "ActionScanIcon",
-  authorization: null,
-  documentationUrl: null,
 };
 
 const EXTRACT_TOOL_JSON_SCHEMA_ARGUMENT_DESCRIPTION =
@@ -233,7 +224,7 @@ function createServer(
   auth: Authenticator,
   agentLoopContext?: AgentLoopContextType
 ): McpServer {
-  const server = new McpServer(serverInfo);
+  const server = makeInternalMCPServer("extract_data");
 
   const isJsonSchemaConfigured =
     (agentLoopContext?.listToolsContext &&

--- a/front/lib/actions/mcp_internal_actions/servers/reasoning.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/reasoning.ts
@@ -14,7 +14,6 @@ import {
   getDelimitersConfiguration,
 } from "@app/lib/api/assistant/agent_message_content_parser";
 import { renderConversationForModel } from "@app/lib/api/assistant/preprocessing";
-import type { InternalMCPServerDefinitionType } from "@app/lib/api/mcp";
 import { getRedisClient } from "@app/lib/api/redis";
 import { getSupportedModelConfig } from "@app/lib/assistant";
 import type { Authenticator } from "@app/lib/auth";
@@ -39,21 +38,11 @@ const CANCELLATION_CHECK_INTERVAL = 500;
 
 const REASONING_GENERATION_TOKENS = 20480;
 
-const serverInfo: InternalMCPServerDefinitionType = {
-  name: "reasoning",
-  version: "1.0.0",
-  description:
-    "Agent can decide to trigger a reasoning model for complex tasks.",
-  icon: "ActionLightbulbIcon",
-  authorization: null,
-  documentationUrl: null,
-};
-
 function createServer(
   auth: Authenticator,
   agentLoopContext?: AgentLoopContextType
 ): McpServer {
-  const server = makeInternalMCPServer(serverInfo);
+  const server = makeInternalMCPServer("reasoning");
 
   server.tool(
     "advanced_reasoning",

--- a/front/lib/actions/mcp_internal_actions/servers/run_agent.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/run_agent.ts
@@ -22,7 +22,6 @@ import {
 import { getCitationsFromActions } from "@app/lib/api/assistant/citations";
 import { getGlobalAgentMetadata } from "@app/lib/api/assistant/global_agents/global_agent_metadata";
 import config from "@app/lib/api/config";
-import type { InternalMCPServerDefinitionType } from "@app/lib/api/mcp";
 import type { Authenticator } from "@app/lib/auth";
 import { prodAPICredentialsForOwner } from "@app/lib/auth";
 import { AgentConfiguration } from "@app/lib/models/assistant/agent";
@@ -31,15 +30,6 @@ import logger from "@app/logger/logger";
 import type { CitationType, Result } from "@app/types";
 import { isGlobalAgentId } from "@app/types";
 import { Err, getHeaderFromUserEmail, normalizeError, Ok } from "@app/types";
-
-const serverInfo: InternalMCPServerDefinitionType = {
-  name: "run_agent",
-  version: "1.0.0",
-  description: "Run a child agent (agent as tool).",
-  icon: "ActionRobotIcon",
-  authorization: null,
-  documentationUrl: null,
-};
 
 function parseAgentConfigurationUri(uri: string): Result<string, Error> {
   const match = uri.match(AGENT_CONFIGURATION_URI_PATTERN);
@@ -108,7 +98,7 @@ export default async function createServer(
   auth: Authenticator,
   agentLoopContext?: AgentLoopContextType
 ): Promise<McpServer> {
-  const server = makeInternalMCPServer(serverInfo);
+  const server = makeInternalMCPServer("run_agent");
   const owner = auth.getNonNullableWorkspace();
 
   let childAgentId: string | null = null;

--- a/front/lib/actions/mcp_internal_actions/servers/run_dust_app.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/run_dust_app.ts
@@ -27,7 +27,6 @@ import { isMCPInternalDustAppRun } from "@app/lib/actions/types/guards";
 import { renderConversationForModel } from "@app/lib/api/assistant/preprocessing";
 import config from "@app/lib/api/config";
 import { getDatasetSchema } from "@app/lib/api/datasets";
-import type { InternalMCPServerDefinitionType } from "@app/lib/api/mcp";
 import type { Authenticator } from "@app/lib/auth";
 import { prodAPICredentialsForOwner } from "@app/lib/auth";
 import { extractConfig } from "@app/lib/config";
@@ -53,15 +52,6 @@ import {
 import { ConfigurableToolInputSchemas } from "../input_schemas";
 
 const MIN_GENERATION_TOKENS = 2048;
-
-const serverInfo: InternalMCPServerDefinitionType = {
-  name: "run_dust_app",
-  version: "1.0.0",
-  description: "Run Dust Apps with specified parameters",
-  icon: "CommandLineIcon",
-  authorization: null,
-  documentationUrl: null,
-};
 
 interface DustFileOutput {
   __dust_file?: {
@@ -346,7 +336,7 @@ export default async function createServer(
   auth: Authenticator,
   agentLoopContext?: AgentLoopContextType
 ): Promise<McpServer> {
-  const server = makeInternalMCPServer(serverInfo);
+  const server = makeInternalMCPServer("run_dust_app");
   const owner = auth.getNonNullableWorkspace();
 
   if (agentLoopContext && agentLoopContext.listToolsContext) {

--- a/front/lib/actions/mcp_internal_actions/servers/salesforce.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/salesforce.ts
@@ -7,69 +7,11 @@ import {
   makeMCPToolJSONSuccess,
   makeMCPToolTextSuccess,
 } from "@app/lib/actions/mcp_internal_actions/utils";
-import type { InternalMCPServerDefinitionType } from "@app/lib/api/mcp";
-
-const serverInfo: InternalMCPServerDefinitionType = {
-  name: "salesforce",
-  version: "1.0.0",
-  description: "Salesforce tools.",
-  authorization: {
-    provider: "salesforce" as const,
-    supported_use_cases: ["personal_actions", "platform_actions"] as const,
-  },
-  icon: "SalesforceLogo",
-  documentationUrl: "https://docs.dust.tt/docs/salesforce",
-  instructions: `You have access to the following tools: execute_read_query, list_objects, and describe_object.
-
-# General Workflow for Salesforce Data:
-1.  **List Objects (Optional):** If you don't know the exact name of an object, use \`list_objects\` to find it.
-2.  **Describe Object:** Use \`describe_object\` with the specific object name (e.g., \`Account\`, \`MyCustomObject__c\`) to get its detailed metadata. This will show you all available fields, their exact names, data types, and information about relationships (child relationships are particularly important for subqueries).
-3.  **Execute Read Query:** Use \`execute_read_query\` to retrieve data using SOQL. Construct your SOQL queries based on the information obtained from \`describe_object\` to ensure you are using correct field and relationship names.
-
-# execute_read_query
-You can use it to execute SOQL read queries on Salesforce. Queries can be used to retrieve or discover data, never to write data.
-
-**Best Practices for Querying:**
-1.  **Discover Object Structure First:** ALWAYS use \`describe_object(objectName='YourObjectName')\` to understand an object's fields and relationships before writing complex queries. Alternatively, for a quick field list directly in a query, use \`FIELDS()\` (e.g., \`SELECT FIELDS(ALL) FROM Account LIMIT 1\`). This helps prevent errors from misspelled or non-existent field/relationship names. The \`FIELDS()\` function requires a \`LIMIT\` clause, with a maximum of 200.
-2.  **Verify Field and Relationship Names:** If you encounter "No such column" or "Didn't understand relationship" errors, use \`describe_object\` for the relevant object(s) to confirm the exact names and their availability. For example, child relationship names used in subqueries (e.g., \`(SELECT Name FROM Contacts)\` or \`(SELECT Name FROM MyCustomChildren__r)\`) can be found in the output of \`describe_object\`.
-
-**Custom Objects, Fields, and Relationships:**
--   **Custom Objects & Fields:** When referencing custom objects or fields, append \`__c\` to their names (e.g., \`MyCustomField__c\`, \`MyCustomObject__c\`). Confirm these names using \`describe_object\`.
--   **Custom Relationships:** When referencing custom relationships (typically in parent-to-child subqueries), append \`__r\` to the relationship name (e.g., \`(SELECT Name FROM MyCustomRelatedObjects__r)\`). \`describe_object\` will list these child relationship names.
-
-**FIELDS() Keyword Details (Alternative to describe_object for quick field listing in query):**
-Use \`FIELDS(ALL)\`, \`FIELDS(CUSTOM)\`, or \`FIELDS(STANDARD)\` in your \`SELECT\` statement to retrieve groups of fields.
--   \`FIELDS(ALL)\`: Selects all fields.
--   \`FIELDS(CUSTOM)\`: Selects all custom fields.
--   \`FIELDS(STANDARD)\`: Selects all standard fields.
-Remember to include \`LIMIT\` (max 200) when using \`FIELDS()\`.
-
-**Relationships in Queries (Confirm names with describe_object):**
--   **Child-to-Parent:** Use dot notation. E.g., \`SELECT Account.Name, LastName FROM Contact\`.
--   **Parent-to-Child (Subqueries):** Use a subquery. Confirm relationship name (e.g., \`Contacts\` or \`MyCustomChildren__r\`) via \`describe_object\`.
-    -   Standard Relationship: \`SELECT Name, (SELECT FirstName, LastName FROM Contacts) FROM Account\`
-    -   Custom Relationship: \`SELECT Name, (SELECT Name FROM MyCustomChildren__r) FROM Account\`
-
-If errors persist after using \`describe_object\` and following these guidelines, the field, object, or relationship might genuinely not exist, or you may lack permissions.
-
-# list_objects
-You can use it to list the objects in Salesforce: standard and custom objects. Useful for finding object names if you're unsure.
-
-# describe_object
-Use this tool to get detailed metadata about a specific Salesforce object. Provide the object's API name (e.g., \`Account\`, \`Lead\`, \`MyCustomObject__c\`).
-The output includes:
--   A list of all fields with their names, labels, types, and other properties.
--   Details about child relationships (useful for parent-to-child subqueries in SOQL), including the relationship name.
--   Information about record types.
--   Other object-level properties.
-This is the most reliable way to discover the correct names for fields and relationships before writing an \`execute_read_query\`.
-`,
-};
 
 const SF_API_VERSION = "57.0";
 
 const createServer = (): McpServer => {
-  const server = makeInternalMCPServer(serverInfo);
+  const server = makeInternalMCPServer("salesforce");
 
   server.tool(
     "execute_read_query",

--- a/front/lib/actions/mcp_internal_actions/servers/search.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/search.ts
@@ -29,7 +29,6 @@ import { withToolLogging } from "@app/lib/actions/mcp_internal_actions/wrappers"
 import type { AgentLoopContextType } from "@app/lib/actions/types";
 import { getRefs } from "@app/lib/api/assistant/citations";
 import config from "@app/lib/api/config";
-import type { InternalMCPServerDefinitionType } from "@app/lib/api/mcp";
 import type { Authenticator } from "@app/lib/auth";
 import { getDisplayNameForDocument } from "@app/lib/data_sources";
 import { concurrentExecutor } from "@app/lib/utils/async_utils";
@@ -44,15 +43,6 @@ import {
   stripNullBytes,
   timeFrameFromNow,
 } from "@app/types";
-
-const serverInfo: InternalMCPServerDefinitionType = {
-  name: SEARCH_SERVER_NAME,
-  version: "1.0.0",
-  description: "Search through selected Data sources",
-  icon: "ActionMagnifyingGlassIcon",
-  authorization: null,
-  documentationUrl: null,
-};
 
 export async function searchFunction({
   query,
@@ -225,7 +215,7 @@ function createServer(
   auth: Authenticator,
   agentLoopContext?: AgentLoopContextType
 ): McpServer {
-  const server = makeInternalMCPServer(serverInfo);
+  const server = makeInternalMCPServer(SEARCH_SERVER_NAME);
 
   const commonInputsSchema = {
     query: z

--- a/front/lib/actions/mcp_internal_actions/servers/slack.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/slack.ts
@@ -537,9 +537,7 @@ const createServer = async (
           }
         } catch (error) {
           if (isSlackTokenRevoked(error)) {
-            return makePersonalAuthenticationError(
-              INTERNAL_MCP_SERVERS["slack"]
-            );
+            return makePersonalAuthenticationError("slack");
           }
           return makeMCPToolTextError(`Error searching messages: ${error}`);
         }
@@ -676,9 +674,7 @@ const createServer = async (
           }
         } catch (error) {
           if (isSlackTokenRevoked(error)) {
-            return makePersonalAuthenticationError(
-              INTERNAL_MCP_SERVERS["slack"]
-            );
+            return makePersonalAuthenticationError("slack");
           }
           return makeMCPToolTextError(`Error searching messages: ${error}`);
         }
@@ -809,7 +805,7 @@ const createServer = async (
         }
       } catch (error) {
         if (isSlackTokenRevoked(error)) {
-          return makePersonalAuthenticationError(INTERNAL_MCP_SERVERS["slack"]);
+          return makePersonalAuthenticationError("slack");
         }
         return makeMCPToolTextError(`Error listing threads: ${error}`);
       }
@@ -871,7 +867,7 @@ const createServer = async (
         });
       } catch (error) {
         if (isSlackTokenRevoked(error)) {
-          return makePersonalAuthenticationError(INTERNAL_MCP_SERVERS["slack"]);
+          return makePersonalAuthenticationError("slack");
         }
         return makeMCPToolTextError(`Error posting message: ${error}`);
       }
@@ -947,7 +943,7 @@ const createServer = async (
         });
       } catch (error) {
         if (isSlackTokenRevoked(error)) {
-          return makePersonalAuthenticationError(INTERNAL_MCP_SERVERS["slack"]);
+          return makePersonalAuthenticationError("slack");
         }
         return makeMCPToolTextError(`Error listing users: ${error}`);
       }
@@ -981,7 +977,7 @@ const createServer = async (
         });
       } catch (error) {
         if (isSlackTokenRevoked(error)) {
-          return makePersonalAuthenticationError(INTERNAL_MCP_SERVERS["slack"]);
+          return makePersonalAuthenticationError("slack");
         }
         return makeMCPToolTextError(`Error retrieving user info: ${error}`);
       }
@@ -1042,7 +1038,7 @@ const createServer = async (
         });
       } catch (error) {
         if (isSlackTokenRevoked(error)) {
-          return makePersonalAuthenticationError(INTERNAL_MCP_SERVERS["slack"]);
+          return makePersonalAuthenticationError("slack");
         }
         return makeMCPToolTextError(`Error listing channels: ${error}`);
       }

--- a/front/lib/actions/mcp_internal_actions/servers/slack.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/slack.ts
@@ -8,7 +8,6 @@ import slackifyMarkdown from "slackify-markdown";
 import { z } from "zod";
 
 import { getConnectionForMCPServer } from "@app/lib/actions/mcp_authentication";
-import { INTERNAL_MCP_SERVERS } from "@app/lib/actions/mcp_internal_actions/constants";
 import type {
   SearchQueryResourceType,
   SearchResultResourceType,

--- a/front/lib/actions/mcp_internal_actions/servers/slack.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/slack.ts
@@ -8,6 +8,7 @@ import slackifyMarkdown from "slackify-markdown";
 import { z } from "zod";
 
 import { getConnectionForMCPServer } from "@app/lib/actions/mcp_authentication";
+import { INTERNAL_MCP_SERVERS } from "@app/lib/actions/mcp_internal_actions/constants";
 import type {
   SearchQueryResourceType,
   SearchResultResourceType,
@@ -19,12 +20,10 @@ import {
   makeMCPToolJSONSuccess,
   makeMCPToolTextError,
 } from "@app/lib/actions/mcp_internal_actions/utils";
-import type { AuthorizationInfo } from "@app/lib/actions/mcp_metadata";
 import type { AgentLoopContextType } from "@app/lib/actions/types";
 import { SLACK_SEARCH_ACTION_NUM_RESULTS } from "@app/lib/actions/utils";
 import { getRefs } from "@app/lib/api/assistant/citations";
 import config from "@app/lib/api/config";
-import type { InternalMCPServerDefinitionType } from "@app/lib/api/mcp";
 import type { Authenticator } from "@app/lib/auth";
 import { removeDiacritics } from "@app/lib/utils";
 import { concurrentExecutor } from "@app/lib/utils/async_utils";
@@ -90,24 +89,6 @@ export const slackSearch = async (
   const matches = matchesWithText.slice(0, SLACK_SEARCH_ACTION_NUM_RESULTS);
 
   return matches;
-};
-
-const serverInfo: InternalMCPServerDefinitionType & {
-  authorization: AuthorizationInfo;
-} = {
-  name: "slack",
-  version: "1.0.0",
-  description: "Slack tools for searching and posting messages.",
-  authorization: {
-    provider: "slack" as const,
-    supported_use_cases: ["personal_actions"] as const,
-  },
-  icon: "SlackLogo",
-  documentationUrl: "https://docs.dust.tt/docs/slack-mcp",
-  instructions:
-    "When posting a message on slack, you MUST use slack-flavored markdown to format the message." +
-    "IMPORTANT: if you want to mention a user, you must use <@USER_ID> where USER_ID is the id of the user you want to mention.\n" +
-    "If you want to reference a channel, you must use #CHANNEL where CHANNEL is the channel name, or <#CHANNEL_ID> where CHANNEL_ID is the channel ID.",
 };
 
 const getSlackClient = async (accessToken?: string) => {
@@ -370,7 +351,7 @@ const createServer = async (
   mcpServerId: string,
   agentLoopContext?: AgentLoopContextType
 ): Promise<McpServer> => {
-  const server = makeInternalMCPServer(serverInfo);
+  const server = makeInternalMCPServer("slack");
 
   const c = await getConnectionForMCPServer(auth, {
     mcpServerId,
@@ -556,7 +537,9 @@ const createServer = async (
           }
         } catch (error) {
           if (isSlackTokenRevoked(error)) {
-            return makePersonalAuthenticationError({ serverInfo });
+            return makePersonalAuthenticationError(
+              INTERNAL_MCP_SERVERS["slack"]
+            );
           }
           return makeMCPToolTextError(`Error searching messages: ${error}`);
         }
@@ -693,7 +676,9 @@ const createServer = async (
           }
         } catch (error) {
           if (isSlackTokenRevoked(error)) {
-            return makePersonalAuthenticationError({ serverInfo });
+            return makePersonalAuthenticationError(
+              INTERNAL_MCP_SERVERS["slack"]
+            );
           }
           return makeMCPToolTextError(`Error searching messages: ${error}`);
         }
@@ -824,7 +809,7 @@ const createServer = async (
         }
       } catch (error) {
         if (isSlackTokenRevoked(error)) {
-          return makePersonalAuthenticationError({ serverInfo });
+          return makePersonalAuthenticationError(INTERNAL_MCP_SERVERS["slack"]);
         }
         return makeMCPToolTextError(`Error listing threads: ${error}`);
       }
@@ -886,7 +871,7 @@ const createServer = async (
         });
       } catch (error) {
         if (isSlackTokenRevoked(error)) {
-          return makePersonalAuthenticationError({ serverInfo });
+          return makePersonalAuthenticationError(INTERNAL_MCP_SERVERS["slack"]);
         }
         return makeMCPToolTextError(`Error posting message: ${error}`);
       }
@@ -962,7 +947,7 @@ const createServer = async (
         });
       } catch (error) {
         if (isSlackTokenRevoked(error)) {
-          return makePersonalAuthenticationError({ serverInfo });
+          return makePersonalAuthenticationError(INTERNAL_MCP_SERVERS["slack"]);
         }
         return makeMCPToolTextError(`Error listing users: ${error}`);
       }
@@ -996,7 +981,7 @@ const createServer = async (
         });
       } catch (error) {
         if (isSlackTokenRevoked(error)) {
-          return makePersonalAuthenticationError({ serverInfo });
+          return makePersonalAuthenticationError(INTERNAL_MCP_SERVERS["slack"]);
         }
         return makeMCPToolTextError(`Error retrieving user info: ${error}`);
       }
@@ -1057,7 +1042,7 @@ const createServer = async (
         });
       } catch (error) {
         if (isSlackTokenRevoked(error)) {
-          return makePersonalAuthenticationError({ serverInfo });
+          return makePersonalAuthenticationError(INTERNAL_MCP_SERVERS["slack"]);
         }
         return makeMCPToolTextError(`Error listing channels: ${error}`);
       }

--- a/front/lib/actions/mcp_internal_actions/servers/tables_query/server.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/tables_query/server.ts
@@ -1,5 +1,5 @@
 import { INTERNAL_MIME_TYPES } from "@dust-tt/client";
-import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 
 import {
   generateCSVFileAndSnippet,
@@ -18,12 +18,14 @@ import type {
   ToolGeneratedFileType,
 } from "@app/lib/actions/mcp_internal_actions/output_schemas";
 import { fetchTableDataSourceConfigurations } from "@app/lib/actions/mcp_internal_actions/servers/utils";
-import { makeMCPToolTextError } from "@app/lib/actions/mcp_internal_actions/utils";
+import {
+  makeInternalMCPServer,
+  makeMCPToolTextError,
+} from "@app/lib/actions/mcp_internal_actions/utils";
 import { runActionStreamed } from "@app/lib/actions/server";
 import type { AgentLoopContextType } from "@app/lib/actions/types";
 import { renderConversationForModel } from "@app/lib/api/assistant/preprocessing";
 import type { CSVRecord } from "@app/lib/api/csv";
-import type { InternalMCPServerDefinitionType } from "@app/lib/api/mcp";
 import { getSupportedModelConfig } from "@app/lib/assistant";
 import type { Authenticator } from "@app/lib/auth";
 import { cloneBaseConfig, getDustProdAction } from "@app/lib/registry";
@@ -45,20 +47,11 @@ const TABLES_QUERY_MIN_TOKEN = 50_000;
 const RENDERED_CONVERSATION_MIN_TOKEN = 4_000;
 export const TABLES_QUERY_SECTION_FILE_MIN_COLUMN_LENGTH = 500;
 
-const serverInfo: InternalMCPServerDefinitionType = {
-  name: TABLE_QUERY_SERVER_NAME,
-  version: "1.0.0",
-  description: "Tables, Spreadsheets, Notion DBs (quantitative).",
-  icon: "ActionTableIcon",
-  authorization: null,
-  documentationUrl: null,
-};
-
 function createServer(
   auth: Authenticator,
   agentLoopContext?: AgentLoopContextType
 ): McpServer {
-  const server = new McpServer(serverInfo);
+  const server = makeInternalMCPServer(TABLE_QUERY_SERVER_NAME);
 
   server.tool(
     QUERY_TABLES_TOOL_NAME,

--- a/front/lib/actions/mcp_internal_actions/servers/tables_query/server_v2.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/tables_query/server_v2.ts
@@ -1,5 +1,5 @@
 import { INTERNAL_MIME_TYPES } from "@dust-tt/client";
-import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod";
 
 import {
@@ -33,12 +33,14 @@ import {
   TABLES_QUERY_SECTION_FILE_MIN_COLUMN_LENGTH,
 } from "@app/lib/actions/mcp_internal_actions/servers/tables_query/server";
 import { fetchTableDataSourceConfigurations } from "@app/lib/actions/mcp_internal_actions/servers/utils";
-import { makeMCPToolTextError } from "@app/lib/actions/mcp_internal_actions/utils";
+import {
+  makeInternalMCPServer,
+  makeMCPToolTextError,
+} from "@app/lib/actions/mcp_internal_actions/utils";
 import { withToolLogging } from "@app/lib/actions/mcp_internal_actions/wrappers";
 import type { AgentLoopContextType } from "@app/lib/actions/types";
 import config from "@app/lib/api/config";
 import type { CSVRecord } from "@app/lib/api/csv";
-import type { InternalMCPServerDefinitionType } from "@app/lib/api/mcp";
 import type { Authenticator } from "@app/lib/auth";
 import { DataSourceViewResource } from "@app/lib/resources/data_source_view_resource";
 import logger from "@app/logger/logger";
@@ -53,21 +55,11 @@ type TablesQueryOutputResources =
   | ToolGeneratedFileType
   | ToolMarkerResourceType;
 
-const serverInfo: InternalMCPServerDefinitionType = {
-  name: "query_tables_v2",
-  version: "1.0.0",
-  description:
-    "Tables, Spreadsheets, Notion DBs (quantitative) (mcp, exploded).",
-  icon: "ActionTableIcon",
-  authorization: null,
-  documentationUrl: null,
-};
-
 function createServer(
   auth: Authenticator,
   agentLoopContext?: AgentLoopContextType
 ): McpServer {
-  const server = new McpServer(serverInfo);
+  const server = makeInternalMCPServer("query_tables_v2");
 
   server.tool(
     GET_DATABASE_SCHEMA_TOOL_NAME,

--- a/front/lib/actions/mcp_internal_actions/servers/think.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/think.ts
@@ -2,19 +2,9 @@ import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod";
 
 import { makeInternalMCPServer } from "@app/lib/actions/mcp_internal_actions/utils";
-import type { InternalMCPServerDefinitionType } from "@app/lib/api/mcp";
-
-const serverInfo: InternalMCPServerDefinitionType = {
-  name: "think",
-  version: "1.0.0",
-  description: "Expand thinking and reasoning capabilities.",
-  icon: "ActionBrainIcon",
-  authorization: null,
-  documentationUrl: null,
-};
 
 const createServer = (): McpServer => {
-  const server = makeInternalMCPServer(serverInfo);
+  const server = makeInternalMCPServer("think");
 
   const describePlanToolPrompt = `Use this tool when you need to outline a detailed plan for solving a complex problem. It will not obtain new information or make any changes to the repository, but will log your plan for reference throughout the conversation.
 

--- a/front/lib/actions/mcp_internal_actions/servers/toolsets.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/toolsets.ts
@@ -11,30 +11,17 @@ import { withToolLogging } from "@app/lib/actions/mcp_internal_actions/wrappers"
 import type { AgentLoopContextType } from "@app/lib/actions/types";
 import { isServerSideMCPServerConfiguration } from "@app/lib/actions/types/guards";
 import apiConfig from "@app/lib/api/config";
-import type { InternalMCPServerDefinitionType } from "@app/lib/api/mcp";
 import type { Authenticator } from "@app/lib/auth";
 import { prodAPICredentialsForOwner } from "@app/lib/auth";
 import { SpaceResource } from "@app/lib/resources/space_resource";
 import logger from "@app/logger/logger";
 import { getHeaderFromGroupIds, getHeaderFromRole, Ok } from "@app/types";
 
-export const TOOLSETS_FILESYSTEM_SERVER_NAME = "toolsets";
-
-const serverInfo: InternalMCPServerDefinitionType = {
-  name: TOOLSETS_FILESYSTEM_SERVER_NAME,
-  version: "1.0.0",
-  description:
-    "Comprehensive navigation toolkit for browsing Toolsets available. Toolsets provides functions for the agent to use.",
-  authorization: null,
-  icon: "ActionLightbulbIcon",
-  documentationUrl: null,
-};
-
 const createServer = (
   auth: Authenticator,
   agentLoopContext?: AgentLoopContextType
 ): McpServer => {
-  const server = makeInternalMCPServer(serverInfo);
+  const server = makeInternalMCPServer("toolsets");
 
   server.tool(
     "list",

--- a/front/lib/actions/mcp_internal_actions/servers/webtools.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/webtools.ts
@@ -1,12 +1,9 @@
 import { INTERNAL_MIME_TYPES } from "@dust-tt/client";
-import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
 import { z } from "zod";
 
-import {
-  DEFAULT_WEBSEARCH_ACTION_DESCRIPTION,
-  DEFAULT_WEBSEARCH_ACTION_NAME,
-} from "@app/lib/actions/constants";
+import { DEFAULT_WEBSEARCH_ACTION_NAME } from "@app/lib/actions/constants";
 import {
   WEBBROWSER_TOOL_NAME,
   WEBSEARCH_TOOL_NAME,
@@ -15,10 +12,12 @@ import type {
   BrowseResultResourceType,
   WebsearchResultResourceType,
 } from "@app/lib/actions/mcp_internal_actions/output_schemas";
-import { makeMCPToolTextError } from "@app/lib/actions/mcp_internal_actions/utils";
+import {
+  makeInternalMCPServer,
+  makeMCPToolTextError,
+} from "@app/lib/actions/mcp_internal_actions/utils";
 import type { AgentLoopContextType } from "@app/lib/actions/types";
 import { getRefs } from "@app/lib/api/assistant/citations";
-import type { InternalMCPServerDefinitionType } from "@app/lib/api/mcp";
 import { tokenCountForTexts } from "@app/lib/tokenization";
 import {
   browseUrls,
@@ -26,19 +25,10 @@ import {
 } from "@app/lib/utils/webbrowse";
 import { webSearch } from "@app/lib/utils/websearch";
 
-export const serverInfo: InternalMCPServerDefinitionType = {
-  name: DEFAULT_WEBSEARCH_ACTION_NAME,
-  version: "1.0.0",
-  description: DEFAULT_WEBSEARCH_ACTION_DESCRIPTION,
-  icon: "ActionGlobeAltIcon",
-  authorization: null,
-  documentationUrl: null,
-};
-
 const BROWSE_MAX_TOKENS_LIMIT = 32_000;
 
 const createServer = (agentLoopContext?: AgentLoopContextType): McpServer => {
-  const server = new McpServer(serverInfo);
+  const server = makeInternalMCPServer(DEFAULT_WEBSEARCH_ACTION_NAME);
 
   server.tool(
     WEBSEARCH_TOOL_NAME,

--- a/front/lib/actions/mcp_internal_actions/utils.ts
+++ b/front/lib/actions/mcp_internal_actions/utils.ts
@@ -10,9 +10,9 @@ import { INTERNAL_MCP_SERVERS } from "@app/lib/actions/mcp_internal_actions/cons
 export function makeInternalMCPServer(
   serverName: InternalMCPServerNameType
 ): McpServer {
-  const { serverMetadata } = INTERNAL_MCP_SERVERS[serverName];
-  return new McpServer(serverMetadata, {
-    instructions: serverMetadata.instructions ?? undefined,
+  const { serverInfo } = INTERNAL_MCP_SERVERS[serverName];
+  return new McpServer(serverInfo, {
+    instructions: serverInfo.instructions ?? undefined,
   });
 }
 

--- a/front/lib/actions/mcp_internal_actions/utils.ts
+++ b/front/lib/actions/mcp_internal_actions/utils.ts
@@ -4,13 +4,15 @@ import type {
   TextContent,
 } from "@modelcontextprotocol/sdk/types.js";
 
-import type { InternalMCPServerDefinitionType } from "@app/lib/api/mcp";
+import type { InternalMCPServerNameType } from "@app/lib/actions/mcp_internal_actions/constants";
+import { INTERNAL_MCP_SERVERS } from "@app/lib/actions/mcp_internal_actions/constants";
 
 export function makeInternalMCPServer(
-  serverInfo: InternalMCPServerDefinitionType
+  serverName: InternalMCPServerNameType
 ): McpServer {
-  return new McpServer(serverInfo, {
-    instructions: serverInfo.instructions,
+  const { serverMetadata } = INTERNAL_MCP_SERVERS[serverName];
+  return new McpServer(serverMetadata, {
+    instructions: serverMetadata.instructions,
   });
 }
 

--- a/front/lib/actions/mcp_internal_actions/utils.ts
+++ b/front/lib/actions/mcp_internal_actions/utils.ts
@@ -12,7 +12,7 @@ export function makeInternalMCPServer(
 ): McpServer {
   const { serverMetadata } = INTERNAL_MCP_SERVERS[serverName];
   return new McpServer(serverMetadata, {
-    instructions: serverMetadata.instructions,
+    instructions: serverMetadata.instructions ?? undefined,
   });
 }
 

--- a/front/lib/api/mcp.ts
+++ b/front/lib/api/mcp.ts
@@ -88,8 +88,8 @@ type InternalMCPServerType = MCPServerType & {
   name: InternalMCPServerNameType;
   // We enforce that we pass an icon here.
   icon: InternalAllowedIconType;
-  // Instructions that are appended to the overall prompt
-  instructions?: string;
+  // Instructions that are appended to the overall prompt.
+  instructions: string | null;
 };
 
 export type InternalMCPServerDefinitionType = Omit<


### PR DESCRIPTION
## Description

- Part of https://github.com/dust-tt/tasks/issues/3881.
- This PR moves the server information used to initialize the `McpServer` into `INTERNAL_MCP_SERVERS`.
- This doesn't change anything when creating MCP servers, but this allows retrieving the server information only using its name, which was not possible up until now (the only way to get it was to do a `listTools`).
- The only meaningful changes are around `makePersonalAuthenticationError` (`personal_authentication.ts`) and `makeInternalMCPServer` (`utils.ts`).

## Tests

- Checked locally (create an agent, use tools).

## Risk

- Low, only refactoring.

## Deploy Plan

- Deploy front.
