### PR TITLE
[sparkle] - fix(`SearchInput`): remove flex-grow

### DIFF
--- a/sparkle/src/components/Dropdown.tsx
+++ b/sparkle/src/components/Dropdown.tsx
@@ -660,6 +660,7 @@ const DropdownMenuSearchbar = React.forwardRef<
     return (
       <div className={cn("s-flex s-gap-1.5 s-p-1.5", className)}>
         <SearchInput
+          className="w-full"
           ref={internalRef}
           placeholder={placeholder}
           name={name}

--- a/sparkle/src/components/SearchDropdownMenu.tsx
+++ b/sparkle/src/components/SearchDropdownMenu.tsx
@@ -41,6 +41,7 @@ export function SearchDropdownMenu({
           ref={searchInputRef}
           name="search"
           placeholder="Search"
+          className="w-full"
           value={searchInputValue}
           disabled={disabled}
           onFocus={() => {

--- a/sparkle/src/components/SearchInput.tsx
+++ b/sparkle/src/components/SearchInput.tsx
@@ -52,7 +52,7 @@ export const SearchInput = forwardRef<HTMLInputElement, SearchInputProps>(
     };
 
     return (
-      <div className={cn("s-relative s-flex-grow", className)}>
+      <div className={cn("s-relative", className)}>
         <Input
           type="text"
           name={name}


### PR DESCRIPTION
 ## Description

This PR alters the `SearchInput` container styling to no longer use `flex-grow` for component sizing

## Tests

Storybook 

## Risk

This component is widely used, could break a bunch of components

## Deploy Plan

Publish sparkle