### PR TITLE
Allow natural description for schedule input

### DIFF
--- a/front/components/agent_builder/AgentBuilderFormContext.tsx
+++ b/front/components/agent_builder/AgentBuilderFormContext.tsx
@@ -212,7 +212,7 @@ export const scheduleFormSchema = z.object({
     .string()
     .min(1, "Cron expression is required")
     .regex(
-      /^(\*|([0-5]?\d)) (\*|([01]?\d|2[0-3])) (\*|([01]?\d|2[0-9]|3[01])) (\*|(1[0-2]|0?[1-9])) (\*|([0-6]))$/,
+      /^((((\d+,)+\d+|(\d+(\/|-|#)\d+)|\d+L?|\*(\/\d+)?|L(-\d+)?|\?|[A-Z]{3}(-[A-Z]{3})?) ?){5,7})|(@(annually|yearly|monthly|weekly|daily|hourly|reboot))|(@every (\d+(ns|us|µs|ms|s|m|h))+)$/,
       "Invalid cron expression (expected 5 fields: min hour day month weekday)"
     ),
   timezone: z.string().min(1, "Timezone is required"),

--- a/front/components/agent_builder/AgentBuilderFormContext.tsx
+++ b/front/components/agent_builder/AgentBuilderFormContext.tsx
@@ -208,13 +208,7 @@ export const agentBuilderFormSchema = z.object({
 
 export const scheduleFormSchema = z.object({
   name: z.string().min(1, "Name is required").max(255, "Name is too long"),
-  cron: z
-    .string()
-    .min(1, "Cron expression is required")
-    .regex(
-      /^((((\d+,)+\d+|(\d+(\/|-|#)\d+)|\d+L?|\*(\/\d+)?|L(-\d+)?|\?|[A-Z]{3}(-[A-Z]{3})?) ?){5,7})|(@(annually|yearly|monthly|weekly|daily|hourly|reboot))|(@every (\d+(ns|us|µs|ms|s|m|h))+)$/,
-      "Invalid cron expression (expected 5 fields: min hour day month weekday)"
-    ),
+  cron: z.string().min(9, "Cron expression is required"),
   timezone: z.string().min(1, "Timezone is required"),
 });
 export type ScheduleFormData = z.infer<typeof scheduleFormSchema>;

--- a/front/components/agent_builder/AgentBuilderLeftPanel.tsx
+++ b/front/components/agent_builder/AgentBuilderLeftPanel.tsx
@@ -48,7 +48,10 @@ export function AgentBuilderLeftPanel({
           />
           <AgentBuilderCapabilitiesBlock isActionsLoading={isActionsLoading} />
           {hasFeature("hootl") && (
-            <AgentBuilderTriggersBlock isTriggersLoading={isTriggersLoading} />
+            <AgentBuilderTriggersBlock
+              owner={owner}
+              isTriggersLoading={isTriggersLoading}
+            />
           )}
           <AgentBuilderSettingsBlock
             isSettingBlocksOpen={!agentConfigurationId}

--- a/front/components/agent_builder/triggers/AgentBuilderTriggersBlock.tsx
+++ b/front/components/agent_builder/triggers/AgentBuilderTriggersBlock.tsx
@@ -19,6 +19,7 @@ import type {
 import { AgentBuilderSectionContainer } from "@app/components/agent_builder/AgentBuilderSectionContainer";
 import { ScheduleEditionModal } from "@app/components/agent_builder/triggers/ScheduleEditionModal";
 import { useSendNotification } from "@app/hooks/useNotification";
+import type { LightWorkspaceType } from "@app/types";
 import type { TriggerKind } from "@app/types/assistant/triggers";
 
 function getIcon(kind: TriggerKind) {
@@ -76,10 +77,12 @@ type DialogMode =
     };
 
 interface AgentBuilderTriggersBlockProps {
+  owner: LightWorkspaceType;
   isTriggersLoading?: boolean;
 }
 
 export function AgentBuilderTriggersBlock({
+  owner,
   isTriggersLoading,
 }: AgentBuilderTriggersBlockProps) {
   const {
@@ -181,6 +184,7 @@ export function AgentBuilderTriggersBlock({
 
       {/* Create/Edit Schedule Modal */}
       <ScheduleEditionModal
+        owner={owner}
         trigger={dialogMode?.type === "edit" ? dialogMode.trigger : undefined}
         isOpen={dialogMode !== null}
         onClose={handleCloseModal}

--- a/front/components/agent_builder/triggers/ScheduleEditionModal.tsx
+++ b/front/components/agent_builder/triggers/ScheduleEditionModal.tsx
@@ -92,7 +92,7 @@ export function ScheduleEditionModal({
         return "Unable to generate a schedule (note: it can't be more frequent than hourly).";
       case "idle":
         if (!cron) {
-          return `Please describe below... (minimum ${MIN_DESCRIPTION_LENGTH} characters)`;
+          return `Please describe above... (minimum ${MIN_DESCRIPTION_LENGTH} characters)`;
         }
         try {
           return `Agent will run ${cronstrue.toString(cron)}.`;

--- a/front/components/agent_builder/triggers/ScheduleEditionModal.tsx
+++ b/front/components/agent_builder/triggers/ScheduleEditionModal.tsx
@@ -1,4 +1,6 @@
 import {
+  Chip,
+  ClockIcon,
   Input,
   Label,
   Sheet,
@@ -7,11 +9,13 @@ import {
   SheetFooter,
   SheetHeader,
   SheetTitle,
+  TextArea,
 } from "@dust-tt/sparkle";
 import { zodResolver } from "@hookform/resolvers/zod";
+import cronstrue from "cronstrue";
 import uniqueId from "lodash/uniqueId";
-import React, { useEffect } from "react";
-import { useForm } from "react-hook-form";
+import React, { useEffect, useMemo, useRef, useState } from "react";
+import { useForm, useWatch } from "react-hook-form";
 
 import type {
   AgentBuilderTriggerType,
@@ -19,8 +23,15 @@ import type {
 } from "@app/components/agent_builder/AgentBuilderFormContext";
 import { scheduleFormSchema } from "@app/components/agent_builder/AgentBuilderFormContext";
 import { FormProvider } from "@app/components/sparkle/FormProvider";
+import { useTextAsCronRule } from "@app/lib/swr/agent_triggers";
+import { debounce } from "@app/lib/utils/debounce";
+import type { LightWorkspaceType } from "@app/types";
+import { assertNever } from "@app/types";
+
+const MIN_DESCRIPTION_LENGTH = 10;
 
 interface ScheduleEditionModalProps {
+  owner: LightWorkspaceType;
   trigger?: AgentBuilderTriggerType;
   isOpen: boolean;
   onClose: () => void;
@@ -28,6 +39,7 @@ interface ScheduleEditionModalProps {
 }
 
 export function ScheduleEditionModal({
+  owner,
   trigger,
   isOpen,
   onClose,
@@ -42,6 +54,15 @@ export function ScheduleEditionModal({
   const form = useForm<ScheduleFormData>({
     resolver: zodResolver(scheduleFormSchema),
     defaultValues,
+  });
+  const [naturalDescription, setNaturalDescription] = useState("");
+  const [
+    naturalDescriptionToCronRuleStatus,
+    setNaturalDescriptionToCronRuleStatus,
+  ] = useState<"idle" | "loading" | "error">("idle");
+  const debounceHandle = useRef<NodeJS.Timeout | undefined>(undefined);
+  const textAsCronRule = useTextAsCronRule({
+    workspace: owner,
   });
 
   const { reset } = form;
@@ -58,6 +79,31 @@ export function ScheduleEditionModal({
     defaultValues.timezone,
     trigger,
   ]);
+
+  const cron = useWatch({
+    control: form.control,
+    name: "cron",
+  });
+  const cronDescription = useMemo(() => {
+    switch (naturalDescriptionToCronRuleStatus) {
+      case "loading":
+        return "Generating schedule...";
+      case "error":
+        return "Unable to generate a schedule (note: it can't be more frequent than hourly).";
+      case "idle":
+        if (!cron) {
+          return `Please describe below... (minimum ${MIN_DESCRIPTION_LENGTH} characters)`;
+        }
+        try {
+          return `Agent will run ${cronstrue.toString(cron)}.`;
+        } catch (error) {
+          setNaturalDescriptionToCronRuleStatus("error");
+        }
+        break;
+      default:
+        assertNever(naturalDescriptionToCronRuleStatus);
+    }
+  }, [naturalDescriptionToCronRuleStatus, cron]);
 
   const handleCancel = () => {
     onClose();
@@ -104,19 +150,61 @@ export function ScheduleEditionModal({
               </div>
 
               <div>
-                <Label htmlFor="trigger-cron">Cron Expression</Label>
-                <Input
-                  id="trigger-cron"
-                  {...form.register("cron")}
-                  placeholder="e.g., 0 9 * * 1-5 (weekdays at 9 AM)"
-                  isError={!!form.formState.errors.cron}
-                  message={form.formState.errors.cron?.message}
-                  messageStatus="error"
+                <Label htmlFor="trigger-description">Frequency</Label>
+
+                <TextArea
+                  id="schedule-description"
+                  placeholder='Describe when you want the agent to run in natural language. e.g. "run every day at 9 AM", or "Late afternoon on business days"...'
+                  rows={3}
+                  value={naturalDescription}
+                  onChange={async (e) => {
+                    const txt = e.target.value;
+                    setNaturalDescription(txt);
+                    setNaturalDescriptionToCronRuleStatus(
+                      txt ? "loading" : "idle"
+                    );
+                    if (txt.length >= MIN_DESCRIPTION_LENGTH) {
+                      debounce(
+                        debounceHandle,
+                        async () => {
+                          form.setValue("cron", "");
+                          try {
+                            const cronRule = await textAsCronRule(txt);
+                            form.setValue("cron", cronRule);
+                            setNaturalDescriptionToCronRuleStatus("idle");
+                          } catch (error) {
+                            setNaturalDescriptionToCronRuleStatus("error");
+                          }
+                        },
+                        500
+                      );
+                    } else {
+                      if (debounceHandle.current) {
+                        clearTimeout(debounceHandle.current);
+                        debounceHandle.current = undefined;
+                      }
+                    }
+                  }}
                 />
-                <p className="mt-1 text-xs text-muted-foreground dark:text-muted-foreground-night">
-                  Use cron format: minute hour day month weekday
-                </p>
+                <div className="my-2">
+                  <Chip
+                    color={"primary"}
+                    isBusy={naturalDescriptionToCronRuleStatus === "loading"}
+                    label={cronDescription}
+                    icon={ClockIcon}
+                  />
+                </div>
               </div>
+
+              <Input
+                id="trigger-cron"
+                {...form.register("cron")}
+                placeholder="e.g., 0 9 * * 1-5 (weekdays at 9 AM)"
+                isError={!!form.formState.errors.cron}
+                message={form.formState.errors.cron?.message}
+                messageStatus="error"
+                className="hidden" // Field is hidden, but we need to keep it for form validation
+              />
 
               <div>
                 <Label htmlFor="trigger-timezone">Timezone</Label>

--- a/front/components/assistant/conversation/ActionValidationProvider.tsx
+++ b/front/components/assistant/conversation/ActionValidationProvider.tsx
@@ -173,7 +173,6 @@ export function ActionValidationProvider({
     handleValidationRequest,
     takeNextFromQueue,
   } = useValidationQueue({ pendingValidations });
-  console.log({ validationQueueLength, currentValidation, pendingValidations });
 
   const [isDialogOpen, setIsDialogOpen] = useState(false);
   const [isProcessing, setIsProcessing] = useState(false);

--- a/front/components/assistant_builder/SettingsScreen.tsx
+++ b/front/components/assistant_builder/SettingsScreen.tsx
@@ -56,6 +56,7 @@ import type {
   BuilderEmojiSuggestionsType,
   BuilderSuggestionsType,
   DataSourceType,
+  LightWorkspaceType,
   Result,
   UserType,
   WorkspaceType,
@@ -534,7 +535,10 @@ export default function SettingsScreen({
         <TagsSection owner={owner} />
 
         {hasFeature("hootl") && (
-          <TriggersSection isTriggersLoading={isTriggersLoading} />
+          <TriggersSection
+            owner={owner}
+            isTriggersLoading={isTriggersLoading}
+          />
         )}
         <div className="flex flex-row gap-4">
           <div className="flex flex-[1_0_0] flex-col gap-2">
@@ -878,8 +882,10 @@ function TriggerCard({ trigger, onRemove, onEdit }: any) {
 }
 
 function TriggersSection({
+  owner,
   isTriggersLoading,
 }: {
+  owner: LightWorkspaceType;
   isTriggersLoading: boolean;
 }) {
   const { builderState, setBuilderState, setEdited } =
@@ -989,6 +995,7 @@ function TriggersSection({
 
       {/* Create/Edit Schedule Modal */}
       <ScheduleEditionModal
+        owner={owner}
         trigger={editedTrigger?.trigger}
         isOpen={editedTrigger !== null || isOpen}
         onClose={handleCloseModal}

--- a/front/lib/api/assistant/configuration/triggers.ts
+++ b/front/lib/api/assistant/configuration/triggers.ts
@@ -74,7 +74,10 @@ export async function generateCronRule(
   if (
     !cronRule ||
     cronRule.split(" ").length !== 5 ||
-    !cronRule.split(" ")[0].match(/^\d+$/)
+    !cronRule.split(" ")[0].match(/^\d+$/) ||
+    !cronRule.match(
+      /^((((\d+,)+\d+|(\d+(\/|-|#)\d+)|\d+L?|\*(\/\d+)?|L(-\d+)?|\?|[A-Z]{3}(-[A-Z]{3})?) ?){5,7})|(@(annually|yearly|monthly|weekly|daily|hourly|reboot))|(@every (\d+(ns|us|µs|ms|s|m|h))+)$/
+    )
   ) {
     return new Err(new Error("Error generating cron rule: malformed output"));
   }

--- a/front/lib/api/assistant/configuration/triggers.ts
+++ b/front/lib/api/assistant/configuration/triggers.ts
@@ -1,0 +1,83 @@
+import { runActionStreamed } from "@app/lib/actions/server";
+import type { Authenticator } from "@app/lib/auth";
+import { getDustProdAction } from "@app/lib/registry";
+import { cloneBaseConfig } from "@app/lib/registry";
+import type { Result } from "@app/types";
+import { Err, getSmallWhitelistedModel, Ok } from "@app/types";
+
+export async function generateCronRule(
+  auth: Authenticator,
+  {
+    naturalDescription,
+  }: {
+    naturalDescription: string;
+  }
+): Promise<Result<string, Error>> {
+  const owner = auth.getNonNullableWorkspace();
+
+  const model = getSmallWhitelistedModel(owner);
+  if (!model) {
+    return new Err(
+      new Error("Failed to find a whitelisted model to generate cron rule")
+    );
+  }
+
+  const config = cloneBaseConfig(
+    getDustProdAction("assistant-builder-cron-rule-generator").config
+  );
+  config.CREATE_CRON.provider_id = model.providerId;
+  config.CREATE_CRON.model_id = model.modelId;
+
+  const res = await runActionStreamed(
+    auth,
+    "assistant-builder-cron-rule-generator",
+    config,
+    [
+      {
+        naturalDescription,
+      },
+    ],
+    {
+      workspaceId: auth.getNonNullableWorkspace().sId,
+    }
+  );
+
+  if (res.isErr()) {
+    return new Err(new Error(`Error generating cron rule: ${res.error}`));
+  }
+
+  const { eventStream } = res.value;
+  let cronRule: string | null = null;
+
+  for await (const event of eventStream) {
+    if (event.type === "error") {
+      return new Err(
+        new Error(`Error generating cron rule: ${event.content.message}`)
+      );
+    }
+
+    if (event.type === "block_execution") {
+      const e = event.content.execution[0][0];
+      if (e.error) {
+        return new Err(new Error(`Error generating cron rule: ${e.error}`));
+      }
+
+      if (event.content.block_name === "OUTPUT" && e.value) {
+        const v = e.value as any;
+        if (v.cron) {
+          cronRule = v.cron;
+        }
+      }
+    }
+  }
+
+  if (
+    !cronRule ||
+    cronRule.split(" ").length !== 5 ||
+    !cronRule.split(" ")[0].match(/^\d+$/)
+  ) {
+    return new Err(new Error("Error generating cron rule: malformed output"));
+  }
+
+  return new Ok(cronRule);
+}

--- a/front/lib/registry.ts
+++ b/front/lib/registry.ts
@@ -332,6 +332,21 @@ export const BaseDustProdActionRegistry = {
       },
     },
   },
+
+  "assistant-builder-cron-rule-generator": {
+    app: {
+      appId: "I0f9t05qlZ",
+      appHash:
+        "589b73fa1ce8c6af9782bb9ece92f3cd421b1e8d94711b1cfbcb4c043206379c",
+    },
+    config: {
+      CREATE_CRON: {
+        function_call: "set_schedule",
+        use_cache: false,
+        use_stream: true,
+      },
+    },
+  },
 };
 
 export type DustRegistryActionName = keyof typeof BaseDustProdActionRegistry;

--- a/front/lib/swr/agent_triggers.ts
+++ b/front/lib/swr/agent_triggers.ts
@@ -1,7 +1,13 @@
+import type { LightWorkspaceType } from "@dust-tt/client";
+import { useCallback } from "react";
 import type { Fetcher } from "swr";
 
 import { emptyArray, fetcher, useSWRWithDefaults } from "@app/lib/swr/swr";
 import type { GetTriggersResponseBody } from "@app/pages/api/w/[wId]/assistant/agent_configurations/[aId]/triggers";
+import type {
+  PostTextAsCronRuleRequestBody,
+  PostTextAsCronRuleResponseBody,
+} from "@app/pages/api/w/[wId]/assistant/agent_configurations/text_as_cron_rule";
 
 export function useAgentTriggers({
   workspaceId,
@@ -29,4 +35,29 @@ export function useAgentTriggers({
     isTriggersValidating: isValidating,
     mutateTriggers: mutate,
   };
+}
+
+export function useTextAsCronRule({
+  workspace,
+}: {
+  workspace: LightWorkspaceType;
+}) {
+  const textAsCronRule = useCallback(
+    async (naturalDescription: string) => {
+      const r: PostTextAsCronRuleResponseBody = await fetcher(
+        `/api/w/${workspace.sId}/assistant/agent_configurations/text_as_cron_rule`,
+        {
+          method: "POST",
+          body: JSON.stringify({
+            naturalDescription,
+          } as PostTextAsCronRuleRequestBody),
+        }
+      );
+
+      return r.cronRule;
+    },
+    [workspace]
+  );
+
+  return textAsCronRule;
 }

--- a/front/package-lock.json
+++ b/front/package-lock.json
@@ -55,6 +55,7 @@
         "cmdk": "^1.0.0",
         "convertapi": "^1.15.0",
         "cron-parser": "^4.9.0",
+        "cronstrue": "^3.2.0",
         "csv-parse": "^5.5.2",
         "csv-stringify": "^6.4.5",
         "date-fns": "^3.6.0",
@@ -12047,6 +12048,15 @@
       },
       "engines": {
         "node": ">=12.0.0"
+      }
+    },
+    "node_modules/cronstrue": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/cronstrue/-/cronstrue-3.2.0.tgz",
+      "integrity": "sha512-CqpqV5bCei+jmKyIw2Wihz+npXDuSkeExWCItEn5hlpD8+QFMXUU2YW5W3Vh/hFxWwzWhguoGXm5gl1os+L2Hw==",
+      "license": "MIT",
+      "bin": {
+        "cronstrue": "bin/cli.js"
       }
     },
     "node_modules/cross-spawn": {

--- a/front/package.json
+++ b/front/package.json
@@ -72,6 +72,7 @@
     "cmdk": "^1.0.0",
     "convertapi": "^1.15.0",
     "cron-parser": "^4.9.0",
+    "cronstrue": "^3.2.0",
     "csv-parse": "^5.5.2",
     "csv-stringify": "^6.4.5",
     "date-fns": "^3.6.0",

--- a/front/pages/api/w/[wId]/assistant/agent_configurations/text_as_cron_rule.ts
+++ b/front/pages/api/w/[wId]/assistant/agent_configurations/text_as_cron_rule.ts
@@ -1,0 +1,75 @@
+import type { NextApiRequest, NextApiResponse } from "next";
+import { z } from "zod";
+
+import { generateCronRule } from "@app/lib/api/assistant/configuration/triggers";
+import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
+import type { Authenticator } from "@app/lib/auth";
+import { apiError, withLogging } from "@app/logger/withlogging";
+import type { WithAPIErrorResponse } from "@app/types";
+
+export type PostTextAsCronRuleResponseBody = {
+  cronRule: string;
+};
+
+const PostTextAsCronRuleRequestBodySchema = z.object({
+  naturalDescription: z.string(),
+});
+
+export type PostTextAsCronRuleRequestBody = z.infer<
+  typeof PostTextAsCronRuleRequestBodySchema
+>;
+
+async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse<WithAPIErrorResponse<PostTextAsCronRuleResponseBody>>,
+  auth: Authenticator
+): Promise<void> {
+  switch (req.method) {
+    case "POST": {
+      const bodyValidation = PostTextAsCronRuleRequestBodySchema.safeParse(
+        JSON.parse(req.body)
+      );
+
+      if (!bodyValidation.success) {
+        return apiError(req, res, {
+          status_code: 400,
+          api_error: {
+            type: "invalid_request_error",
+            message: `Invalid request body: ${bodyValidation.error.message}`,
+          },
+        });
+      }
+
+      const { naturalDescription } = bodyValidation.data;
+
+      const r = await generateCronRule(auth, {
+        naturalDescription,
+      });
+
+      if (r.isErr()) {
+        return apiError(req, res, {
+          status_code: 500,
+          api_error: {
+            type: "internal_server_error",
+            message: "Failed to generate cron rule.",
+          },
+        });
+      }
+
+      return res.status(200).json({
+        cronRule: r.value,
+      });
+    }
+
+    default:
+      return apiError(req, res, {
+        status_code: 405,
+        api_error: {
+          type: "method_not_supported_error",
+          message: "The method passed is not supported, POST is expected.",
+        },
+      });
+  }
+}
+
+export default withLogging(withSessionAuthenticationForWorkspace(handler));


### PR DESCRIPTION
## Description

Added the ability to use natural language description to generate the cron schedule.

- New dust-app (still no endpoint on core api to do a simple llm call..) [Already in prod]
- New api endpoint to generate a cron schedule
- New package to transform the cron schedule into a human readable description

## Tests

Local

<img width="571" height="399" alt="image" src="https://github.com/user-attachments/assets/2848af6b-dd50-40d1-8feb-1d2edda5d91c" />

## Risk

Low, still behind a FF.

## Deploy Plan

Deploy front