### PR TITLE
Always add the All Channels option

### DIFF
--- a/front/lib/actions/mcp_internal_actions/servers/slack.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/slack.ts
@@ -390,7 +390,7 @@ const createServer = async (
     }
   }
 
-  // We all ways add the "all channels" option, even if we failed to list channels.
+  // We always add the "all channels" option, even if we failed to list channels.
   // This prevents the UI from being completely broken in that case.
   channels.unshift({
     id: "*",

--- a/front/lib/actions/mcp_internal_actions/servers/slack.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/slack.ts
@@ -385,15 +385,18 @@ const createServer = async (
         mcpServerId,
         slackClient,
       });
-
-      channels.unshift({
-        id: "*",
-        name: "All public channels",
-      });
     } catch (error) {
       logger.warn({ error, mcpServerId }, "Error listing Slack channels");
     }
   }
+
+  // We all ways add the "all channels" option, even if we failed to list channels.
+  // This prevents the UI from being completely broken in that case.
+  channels.unshift({
+    id: "*",
+    name: "All public channels",
+  });
+
   const channelOptions = channels.map((c) =>
     z.object({
       value: z.literal(c.id),


### PR DESCRIPTION
## Description

This is a mitigation for the case where the token is revoked and we can't get channels. By adding the All option, we at least allow the UI to work and the user can select All.

## Tests

Manual.

## Risk

Low.

## Deploy Plan

Front.