### PR TITLE
Fix Slack bulk channel selection for workspaces with >1000 channels

### DIFF
--- a/front/components/data_source_view/DataSourceNodeTable.tsx
+++ b/front/components/data_source_view/DataSourceNodeTable.tsx
@@ -10,7 +10,7 @@ import {
 import type { DataSourceRowData } from "@app/components/data_source_view/hooks/useDataSourceColumns";
 import { useDataSourceColumns } from "@app/components/data_source_view/hooks/useDataSourceColumns";
 import { getVisualForDataSourceViewContentNode } from "@app/lib/content_nodes";
-import { useInfinitDataSourceViewContentNodes } from "@app/lib/swr/data_source_views";
+import { useInfiniteDataSourceViewContentNodes } from "@app/lib/swr/data_source_views";
 import type { ContentNodesViewType } from "@app/types";
 
 const PAGE_SIZE = 25;
@@ -33,7 +33,7 @@ export function DataSourceNodeTable({ viewType }: DataSourceNodeTableProps) {
     hasNextPage,
     loadMore,
     isLoadingMore,
-  } = useInfinitDataSourceViewContentNodes({
+  } = useInfiniteDataSourceViewContentNodes({
     owner,
     dataSourceView:
       traversedNode?.dataSourceView ?? dataSourceView ?? undefined,

--- a/front/components/data_source_view/DataSourceViewSelector.tsx
+++ b/front/components/data_source_view/DataSourceViewSelector.tsx
@@ -753,7 +753,7 @@ export function DataSourceViewSelector({
     nodes: rootNodes,
     hasNextPage,
     loadMore,
-    isNodesLoading,
+    isLoadingMore,
   } = useInfiniteDataSourceViewContentNodes({
     owner,
     dataSourceView,
@@ -762,10 +762,10 @@ export function DataSourceViewSelector({
 
   // Load all pages of root nodes
   useEffect(() => {
-    if (hasNextPage && !isNodesLoading) {
+    if (hasNextPage && !isLoadingMore) {
       void loadMore();
     }
-  }, [hasNextPage, loadMore, isNodesLoading]);
+  }, [hasNextPage, loadMore, isLoadingMore]);
 
   const hasActiveSelection =
     selectionConfiguration.selectedResources.length > 0 ||

--- a/front/components/data_source_view/DataSourceViewSelector.tsx
+++ b/front/components/data_source_view/DataSourceViewSelector.tsx
@@ -43,7 +43,10 @@ import {
   isRemoteDatabase,
   isWebsite,
 } from "@app/lib/data_sources";
-import { useDataSourceViewContentNodes } from "@app/lib/swr/data_source_views";
+import {
+  useDataSourceViewContentNodes,
+  useInfiniteDataSourceViewContentNodes,
+} from "@app/lib/swr/data_source_views";
 import { useSpacesSearch } from "@app/lib/swr/spaces";
 import type {
   ContentNode,
@@ -745,11 +748,24 @@ export function DataSourceViewSelector({
     [dataSourceView]
   );
 
-  const { nodes: rootNodes } = useContentNodes({
+  // Use infinite scroll to fetch all root nodes for Select All functionality
+  const {
+    nodes: rootNodes,
+    hasNextPage,
+    loadMore,
+    isNodesLoading,
+  } = useInfiniteDataSourceViewContentNodes({
     owner,
     dataSourceView,
     viewType,
   });
+
+  // Load all pages of root nodes
+  useEffect(() => {
+    if (hasNextPage && !isNodesLoading) {
+      void loadMore();
+    }
+  }, [hasNextPage, loadMore, isNodesLoading]);
 
   const hasActiveSelection =
     selectionConfiguration.selectedResources.length > 0 ||

--- a/front/lib/swr/data_source_views.ts
+++ b/front/lib/swr/data_source_views.ts
@@ -299,7 +299,7 @@ export function useDataSourceViewContentNodes({
   };
 }
 
-export function useInfinitDataSourceViewContentNodes({
+export function useInfiniteDataSourceViewContentNodes({
   owner,
   dataSourceView,
   pagination,


### PR DESCRIPTION
## Description
Fixes https://github.com/dust-tt/tasks/issues/3842

Context: [Slack thread](https://dust4ai.slack.com/archives/C05A4RWJQKC/p1755681714234859)

When using "Select All" for Slack channels, workspaces with more than 1000 channels were only loading the first 1000, making bulk selection incomplete.

The issue was in `DataSourceViewSelector` where we fetch root nodes without pagination, defaulting to the API limit of 1000 items.

### Solution
Use the existing `useInfinitDataSourceViewContentNodes` hook to automatically fetch all pages of root nodes. This ensures all channels are loaded for bulk selection operations.

## Risks
Blast radius: Slack channel selection in workspace management
Risk: low - Using existing pagination mechanism, minimal code changes

## Deploy Plan
- Deploy front service