### PR TITLE
Fix Slack bulk channel selection for workspaces with >1000 channels

### DIFF
--- a/front/components/data_source_view/DataSourceViewSelector.tsx
+++ b/front/components/data_source_view/DataSourceViewSelector.tsx
@@ -750,7 +750,7 @@ export function DataSourceViewSelector({
     owner,
     dataSourceView,
     viewType,
-    pagination: { limit: MAX_ROOT_NODES_LIMIT },
+    pagination: { limit: MAX_ROOT_NODES_LIMIT, cursor: null },
   });
 
   const hasActiveSelection =

--- a/front/components/data_source_view/DataSourceViewSelector.tsx
+++ b/front/components/data_source_view/DataSourceViewSelector.tsx
@@ -65,6 +65,7 @@ import {
 
 const ONLY_ONE_SPACE_PER_SELECTION = true;
 const ITEMS_PER_PAGE = 50;
+const MAX_ROOT_NODES_LIMIT = 10000; // Upper limit for fetching all root nodes at once
 
 const getUseResourceHook =
   (
@@ -749,6 +750,7 @@ export function DataSourceViewSelector({
     owner,
     dataSourceView,
     viewType,
+    pagination: { limit: MAX_ROOT_NODES_LIMIT },
   });
 
   const hasActiveSelection =

--- a/front/components/data_source_view/DataSourceViewSelector.tsx
+++ b/front/components/data_source_view/DataSourceViewSelector.tsx
@@ -753,12 +753,6 @@ export function DataSourceViewSelector({
     pagination: { limit: MAX_ROOT_NODES_LIMIT, cursor: null },
   });
 
-  if (totalNodesCount > MAX_ROOT_NODES_LIMIT) {
-    return (
-      <div>Total nodes count is too high. Please contact support@dust.tt.</div>
-    );
-  }
-
   const hasActiveSelection =
     selectionConfiguration.selectedResources.length > 0 ||
     selectionConfiguration.isSelectAll;
@@ -906,6 +900,12 @@ export function DataSourceViewSelector({
         : undefined,
     [searchResult, isExpanded]
   );
+
+  if (totalNodesCount > MAX_ROOT_NODES_LIMIT) {
+    return (
+      <div>Total nodes count is too high. Please contact support@dust.tt.</div>
+    );
+  }
 
   return (
     <div id={`dataSourceViewsSelector-${dataSourceView.dataSource.sId}`}>

--- a/front/components/data_source_view/DataSourceViewSelector.tsx
+++ b/front/components/data_source_view/DataSourceViewSelector.tsx
@@ -65,7 +65,7 @@ import {
 
 const ONLY_ONE_SPACE_PER_SELECTION = true;
 const ITEMS_PER_PAGE = 50;
-const MAX_ROOT_NODES_LIMIT = 10000; // Upper limit for fetching all root nodes at once
+const MAX_ROOT_NODES_LIMIT = 2000;
 
 const getUseResourceHook =
   (
@@ -746,12 +746,18 @@ export function DataSourceViewSelector({
     [dataSourceView]
   );
 
-  const { nodes: rootNodes } = useContentNodes({
+  const { nodes: rootNodes, totalNodesCount } = useContentNodes({
     owner,
     dataSourceView,
     viewType,
     pagination: { limit: MAX_ROOT_NODES_LIMIT, cursor: null },
   });
+
+  if (totalNodesCount > MAX_ROOT_NODES_LIMIT) {
+    return (
+      <div>Total nodes count is too high. Please contact support@dust.tt.</div>
+    );
+  }
 
   const hasActiveSelection =
     selectionConfiguration.selectedResources.length > 0 ||

--- a/front/lib/api/data_source_view.ts
+++ b/front/lib/api/data_source_view.ts
@@ -23,6 +23,7 @@ import type {
 import { assertNever, CoreAPI, Err, Ok } from "@app/types";
 
 const DEFAULT_PAGINATION_LIMIT = 1000;
+const CORE_MAX_PAGE_SIZE = 1000;
 
 // If `internalIds` is not provided, it means that the request is for all the content nodes in the view.
 interface GetContentNodesForDataSourceViewParams {

--- a/front/lib/api/data_source_view.ts
+++ b/front/lib/api/data_source_view.ts
@@ -202,7 +202,7 @@ export async function getContentNodesForDataSourceView(
       options: {
         // We limit the results to the remaining number of nodes
         // we still need to make sure we get a correct nextPageCursor at the end of this loop.
-        limit: limit - resultNodes.length,
+        limit: Math.min(limit - resultNodes.length, CORE_MAX_PAGE_SIZE),
         cursor: nextPageCursor ?? undefined,
         sort: coreAPISorting,
       },

--- a/front/lib/api/pagination.ts
+++ b/front/lib/api/pagination.ts
@@ -35,7 +35,7 @@ function getOrderColumnCodec(supportedOrderColumns: string[]): t.Mixed {
   ]);
 }
 
-const LimitCodec = createRangeCodec(0, 500);
+const LimitCodec = createRangeCodec(0, 10000);
 
 const PaginationParamsCodec = (supportedOrderColumns: string[]) =>
   t.type({

--- a/front/lib/api/pagination.ts
+++ b/front/lib/api/pagination.ts
@@ -35,7 +35,7 @@ function getOrderColumnCodec(supportedOrderColumns: string[]): t.Mixed {
   ]);
 }
 
-const LimitCodec = createRangeCodec(0, 10000);
+const LimitCodec = createRangeCodec(0, 2000);
 
 const PaginationParamsCodec = (supportedOrderColumns: string[]) =>
   t.type({


### PR DESCRIPTION
## Description
Fixes https://github.com/dust-tt/tasks/issues/3842

Context: [Slack thread](https://dust4ai.slack.com/archives/C05A4RWJQKC/p1755681714234859)

When using "Select All" for Slack channels, workspaces with more than 1000 channels were only loading the first 1000, making bulk selection incomplete, without an easy way to find out. We've only have one occurence so far, so likely bumping is a good 80/20 here

### Solution
- Increase the pagination limit when fetching root nodes from the default 1000 to 2000 
- Add a check to display an error message if a workspace has more than 2000 channels, directing users to contact support
- Fix a potential issue in the pagination loop to respect the Core API's maximum page size

## Risks
Blast radius: Slack channel selection in workspace management
Risk: low - Simple increase of pagination limit with proper error handling

## Deploy Plan
- Deploy front service