### PR TITLE
[front] Cleanup columns related to state from `AgentMCPAction`

### DIFF
--- a/front/lib/actions/mcp.ts
+++ b/front/lib/actions/mcp.ts
@@ -30,7 +30,6 @@ import {
   rewriteContentForModel,
 } from "@app/lib/actions/mcp_utils";
 import type {
-  MCPExecutionState,
   ToolExecutionBlockedStatus,
   ToolExecutionStatus,
 } from "@app/lib/actions/statuses";
@@ -240,10 +239,7 @@ export type ToolNotificationEvent = {
   notification: ProgressNotificationContentType;
 };
 
-export type ActionBaseParams = Omit<
-  MCPActionBlob,
-  "id" | "type" | "executionState" | "output" | "isError"
->;
+export type ActionBaseParams = Omit<MCPActionBlob, "id" | "type" | "output">;
 
 export type AgentActionRunningEvents =
   | MCPParamsEvent
@@ -265,20 +261,19 @@ export class MCPActionType {
   readonly id: ModelId;
   readonly generatedFiles: ActionGeneratedFileType[];
   readonly agentMessageId: ModelId;
-  readonly executionState: MCPExecutionState = "pending";
 
   readonly mcpServerConfigurationId: string;
   readonly mcpServerId: string | null;
   readonly internalMCPServerName: InternalMCPServerNameType | null;
   readonly params: Record<string, unknown>; // Hold the inputs for the action.
   readonly output: CallToolResult["content"] | null;
-  // TODO(durable-agents): drop this column.
+
   readonly functionCallId: string | null;
   readonly functionCallName: string | null;
   readonly step: number = -1;
-  readonly isError: boolean = false;
+
   readonly citationsAllocated: number = 0;
-  // TODO(2025-07-24 aubin): remove the type here.
+
   readonly type = "tool_action" as const;
   readonly status: ToolExecutionStatus;
 
@@ -291,8 +286,6 @@ export class MCPActionType {
     this.mcpServerConfigurationId = blob.mcpServerConfigurationId;
     this.mcpServerId = blob.mcpServerId;
     this.internalMCPServerName = blob.internalMCPServerName;
-    this.executionState = blob.executionState;
-    this.isError = blob.isError;
     this.params = blob.params;
     this.output = blob.output;
     this.functionCallId = blob.functionCallId;
@@ -483,7 +476,7 @@ export async function* runToolWithStreaming(
     `workspace_name:${owner.name}`,
   ];
 
-  const { executionState, status } = mcpAction;
+  const { status } = mcpAction;
 
   // Use the augmented inputs that were computed and stored during action creation
   const inputs = action.augmentedInputs;
@@ -527,7 +520,7 @@ export async function* runToolWithStreaming(
         `The tool ${actionBaseParams.functionCallName} requires personal ` +
         `authentication, please authenticate to use it.`;
 
-      // Update action to mark it as blocked because of personal authentication error.
+      // Update the action to mark it as blocked because of a personal authentication error.
       await action.updateStatus("blocked_authentication_required");
 
       yield {
@@ -567,7 +560,6 @@ export async function* runToolWithStreaming(
       agentConfiguration,
       agentMessage,
       actionBaseParams,
-      executionState,
       status,
       errorMessage,
       yieldAsError: false,
@@ -595,10 +587,8 @@ export async function* runToolWithStreaming(
     action: new MCPActionType({
       ...actionBaseParams,
       generatedFiles,
-      executionState,
       status: "succeeded",
       id: action.id,
-      isError: false,
       output: removeNulls(outputItems.map(hideFileFromActionOutput)),
       type: "tool_action",
     }),
@@ -606,7 +596,7 @@ export async function* runToolWithStreaming(
 }
 
 /**
- * Creates MCP action in database and returns both the DB record and the type object.
+ * Creates an MCP action in the database and returns both the DB record and the type object.
  */
 export async function createMCPAction(
   auth: Authenticator,
@@ -635,8 +625,6 @@ export async function createMCPAction(
     agentMessageId: actionBaseParams.agentMessageId,
     augmentedInputs,
     citationsAllocated: stepContext.citationsCount,
-    executionState: "pending",
-    isError: false,
     mcpServerConfigurationId: actionBaseParams.mcpServerConfigurationId,
     status: approvalStatusToToolExecutionStatus(approvalStatus),
     stepContentId,
@@ -647,9 +635,7 @@ export async function createMCPAction(
 
   const mcpAction = new MCPActionType({
     ...actionBaseParams,
-    executionState: "pending",
     id: action.id,
-    isError: false,
     output: null,
     type: "tool_action",
   });
@@ -663,7 +649,6 @@ type BaseErrorParams = {
   agentConfiguration: AgentConfigurationType;
   agentMessage: AgentMessageType;
   errorMessage: string;
-  executionState: MCPExecutionState;
   status: ToolExecutionStatus;
 };
 
@@ -688,13 +673,7 @@ type HandleErrorParams = YieldAsErrorParams | YieldAsSuccessParams;
 export async function handleMCPActionError(
   params: HandleErrorParams
 ): Promise<MCPErrorEvent | MCPSuccessEvent> {
-  const {
-    agentConfiguration,
-    agentMessage,
-    errorMessage,
-    executionState,
-    status,
-  } = params;
+  const { agentConfiguration, agentMessage, errorMessage, status } = params;
 
   const outputContent: CallToolResult["content"][number] = {
     type: "text",
@@ -711,6 +690,7 @@ export async function handleMCPActionError(
 
   // Yields tool_error to stop conversation.
   if (params.yieldAsError) {
+    // Update the action to mark it as having an error.
     await action.updateStatus("errored");
 
     return {
@@ -731,7 +711,7 @@ export async function handleMCPActionError(
     await action.updateStatus("errored");
   }
 
-  // Yields tool_success to continue conversation.
+  // Yields tool_success to continue the conversation.
   return {
     type: "tool_success",
     created: Date.now(),
@@ -740,10 +720,8 @@ export async function handleMCPActionError(
     action: new MCPActionType({
       ...actionBaseParams,
       generatedFiles: [],
-      executionState,
       status,
       id: action.id,
-      isError: false,
       output: [outputContent],
       type: "tool_action",
     }),
@@ -778,9 +756,7 @@ export async function updateMCPApprovalState(
     return false;
   }
 
-  await action.updateStatus(
-    approvalStatusToToolExecutionStatus(executionState)
-  );
+  await action.updateStatus(status);
 
   return true;
 }

--- a/front/lib/actions/mcp.ts
+++ b/front/lib/actions/mcp.ts
@@ -31,7 +31,6 @@ import {
 } from "@app/lib/actions/mcp_utils";
 import type {
   MCPExecutionState,
-  MCPRunningState,
   ToolExecutionBlockedStatus,
   ToolExecutionStatus,
 } from "@app/lib/actions/statuses";
@@ -283,8 +282,6 @@ export class MCPActionType {
   readonly type = "tool_action" as const;
   readonly status: ToolExecutionStatus;
 
-  readonly runningState: MCPRunningState;
-
   constructor(blob: MCPActionBlob) {
     this.id = blob.id;
     this.type = blob.type;
@@ -302,7 +299,6 @@ export class MCPActionType {
     this.functionCallName = blob.functionCallName;
     this.step = blob.step;
     this.citationsAllocated = blob.citationsAllocated;
-    this.runningState = blob.runningState;
     this.status = blob.status;
   }
 
@@ -605,7 +601,6 @@ export async function* runToolWithStreaming(
       isError: false,
       output: removeNulls(outputItems.map(hideFileFromActionOutput)),
       type: "tool_action",
-      runningState: "completed",
     }),
   };
 }
@@ -643,7 +638,6 @@ export async function createMCPAction(
     executionState: "pending",
     isError: false,
     mcpServerConfigurationId: actionBaseParams.mcpServerConfigurationId,
-    runningState: "not_started",
     status: approvalStatusToToolExecutionStatus(approvalStatus),
     stepContentId,
     stepContext,
@@ -658,7 +652,6 @@ export async function createMCPAction(
     isError: false,
     output: null,
     type: "tool_action",
-    runningState: "not_started",
   });
 
   return { action, mcpAction };
@@ -753,7 +746,6 @@ export async function handleMCPActionError(
       isError: false,
       output: [outputContent],
       type: "tool_action",
-      runningState: "errored",
     }),
   };
 }

--- a/front/lib/actions/mcp.ts
+++ b/front/lib/actions/mcp.ts
@@ -756,7 +756,7 @@ export async function updateMCPApprovalState(
     return false;
   }
 
-  await action.updateStatus(approvalState);
+  await action.updateStatus(status);
 
   return true;
 }

--- a/front/lib/actions/mcp.ts
+++ b/front/lib/actions/mcp.ts
@@ -40,7 +40,6 @@ import type {
 } from "@app/lib/actions/types";
 import type { StepContext } from "@app/lib/actions/types";
 import type { AgentActionSpecification } from "@app/lib/actions/types/agent";
-import { approvalStatusToToolExecutionStatus } from "@app/lib/actions/utils";
 import type {
   DataSourceConfiguration,
   TableDataSourceConfiguration,
@@ -191,7 +190,7 @@ export function getMCPApprovalStateFromUserApprovalState(
   switch (userApprovalState) {
     case "always_approved":
     case "approved":
-      return "allowed_explicitly";
+      return "ready_allowed_explicitly";
 
     case "rejected":
       return "denied";
@@ -606,14 +605,12 @@ export async function createMCPAction(
     augmentedInputs,
     stepContentId,
     stepContext,
-    approvalStatus,
   }: {
     actionBaseParams: ActionBaseParams;
     actionConfiguration: MCPToolConfigurationType;
     augmentedInputs: Record<string, unknown>;
     stepContentId: ModelId;
     stepContext: StepContext;
-    approvalStatus: "allowed_implicitly" | "pending";
   }
 ): Promise<{ action: AgentMCPActionResource; mcpAction: MCPActionType }> {
   const toolConfiguration = omit(
@@ -626,7 +623,7 @@ export async function createMCPAction(
     augmentedInputs,
     citationsAllocated: stepContext.citationsCount,
     mcpServerConfigurationId: actionBaseParams.mcpServerConfigurationId,
-    status: approvalStatusToToolExecutionStatus(approvalStatus),
+    status: actionBaseParams.status,
     stepContentId,
     stepContext,
     toolConfiguration,
@@ -749,14 +746,13 @@ export async function getMCPAction(
 // TODO(DURABLE_AGENTS 2025-08-12): Create a proper resource for the agent mcp action.
 export async function updateMCPApprovalState(
   action: AgentMCPActionResource,
-  executionState: "denied" | "allowed_explicitly"
+  approvalState: "denied" | "ready_allowed_explicitly"
 ): Promise<boolean> {
-  const status = approvalStatusToToolExecutionStatus(executionState);
-  if (action.status === status) {
+  if (action.status === approvalState) {
     return false;
   }
 
-  await action.updateStatus(status);
+  await action.updateStatus(approvalState);
 
   return true;
 }

--- a/front/lib/actions/statuses.ts
+++ b/front/lib/actions/statuses.ts
@@ -1,10 +1,3 @@
-// TODO(2025-08-20 aubin): remove this (consolidated into a single column).
-export type MCPExecutionState =
-  | "allowed_explicitly"
-  | "allowed_implicitly"
-  | "denied"
-  | "pending";
-
 const TOOL_EXECUTION_FINAL_STATUSES = [
   "succeeded",
   "errored",

--- a/front/lib/actions/statuses.ts
+++ b/front/lib/actions/statuses.ts
@@ -1,3 +1,10 @@
+// TODO(2025-08-20 aubin): remove this (consolidated into a single column).
+export type MCPExecutionState =
+  | "allowed_explicitly"
+  | "allowed_implicitly"
+  | "denied"
+  | "pending";
+
 const TOOL_EXECUTION_FINAL_STATUSES = [
   "succeeded",
   "errored",

--- a/front/lib/actions/statuses.ts
+++ b/front/lib/actions/statuses.ts
@@ -5,13 +5,6 @@ export type MCPExecutionState =
   | "denied"
   | "pending";
 
-// TODO(2025-08-20 aubin): remove this (consolidated into a single column).
-export type MCPRunningState =
-  | "not_started"
-  | "running"
-  | "completed"
-  | "errored";
-
 const TOOL_EXECUTION_FINAL_STATUSES = [
   "succeeded",
   "errored",

--- a/front/lib/actions/utils.ts
+++ b/front/lib/actions/utils.ts
@@ -9,10 +9,7 @@ import {
 import type { ActionSpecification } from "@app/components/assistant_builder/types";
 import type { MCPToolStakeLevelType } from "@app/lib/actions/constants";
 import type { MCPToolConfigurationType } from "@app/lib/actions/mcp";
-import type {
-  MCPExecutionState,
-  ToolExecutionStatus,
-} from "@app/lib/actions/statuses";
+import type { ToolExecutionStatus } from "@app/lib/actions/statuses";
 import type { StepContext } from "@app/lib/actions/types";
 import {
   isMCPInternalDataSourceFileSystem,

--- a/front/lib/actions/utils.ts
+++ b/front/lib/actions/utils.ts
@@ -9,7 +9,10 @@ import {
 import type { ActionSpecification } from "@app/components/assistant_builder/types";
 import type { MCPToolStakeLevelType } from "@app/lib/actions/constants";
 import type { MCPToolConfigurationType } from "@app/lib/actions/mcp";
-import type { ToolExecutionStatus } from "@app/lib/actions/statuses";
+import type {
+  MCPExecutionState,
+  ToolExecutionStatus,
+} from "@app/lib/actions/statuses";
 import type { StepContext } from "@app/lib/actions/types";
 import {
   isMCPInternalDataSourceFileSystem,

--- a/front/lib/actions/utils.ts
+++ b/front/lib/actions/utils.ts
@@ -9,10 +9,6 @@ import {
 import type { ActionSpecification } from "@app/components/assistant_builder/types";
 import type { MCPToolStakeLevelType } from "@app/lib/actions/constants";
 import type { MCPToolConfigurationType } from "@app/lib/actions/mcp";
-import type {
-  MCPExecutionState,
-  ToolExecutionStatus,
-} from "@app/lib/actions/statuses";
 import type { StepContext } from "@app/lib/actions/types";
 import {
   isMCPInternalDataSourceFileSystem,
@@ -242,39 +238,20 @@ export function getMCPApprovalKey({
   return `conversation:${conversationId}:message:${messageId}:action:${actionId}`;
 }
 
-// TODO(durable-agents): remove this translation once status is backfilled, have
-//  getExecutionStatusFromConfig return a ToolExecutionStatus directly.
-export function approvalStatusToToolExecutionStatus(
-  approvalStatus: MCPExecutionState
-): ToolExecutionStatus {
-  switch (approvalStatus) {
-    case "allowed_explicitly":
-      return "ready_allowed_explicitly";
-    case "allowed_implicitly":
-      return "ready_allowed_implicitly";
-    case "denied":
-      return "denied";
-    case "pending":
-      return "blocked_validation_required";
-    default:
-      assertNever(approvalStatus);
-  }
-}
-
 export async function getExecutionStatusFromConfig(
   auth: Authenticator,
   actionConfiguration: MCPToolConfigurationType,
   agentMessage: AgentMessageType
 ): Promise<{
   stake?: MCPToolStakeLevelType;
-  status: "allowed_implicitly" | "pending";
+  status: "ready_allowed_implicitly" | "blocked_validation_required";
   serverId?: string;
 }> {
   // If the agent message is marked as "skipToolsValidation" we skip all tools validation
   // irrespective of the `actionConfiguration.permission`. This is set when the agent message was
   // created by an API call where the caller explicitly set `skipToolsValidation` to true.
   if (agentMessage.skipToolsValidation) {
-    return { status: "allowed_implicitly" };
+    return { status: "ready_allowed_implicitly" };
   }
 
   // Permissions:
@@ -284,7 +261,7 @@ export async function getExecutionStatusFromConfig(
   // - undefined: Use default permission ("never_ask" for default tools, "high" for other tools)
   switch (actionConfiguration.permission) {
     case "never_ask":
-      return { status: "allowed_implicitly" };
+      return { status: "ready_allowed_implicitly" };
     case "low": {
       // The user may not be populated, notably when using the public API.
       const user = auth.user();
@@ -296,12 +273,12 @@ export async function getExecutionStatusFromConfig(
         neverAskSetting &&
         neverAskSetting.value.includes(`${actionConfiguration.name}`)
       ) {
-        return { status: "allowed_implicitly" };
+        return { status: "ready_allowed_implicitly" };
       }
-      return { status: "pending" };
+      return { status: "blocked_validation_required" };
     }
     case "high":
-      return { status: "pending" };
+      return { status: "blocked_validation_required" };
     default:
       assertNever(actionConfiguration.permission);
   }

--- a/front/lib/models/assistant/actions/mcp.ts
+++ b/front/lib/models/assistant/actions/mcp.ts
@@ -4,11 +4,7 @@ import type { CreationOptional, ForeignKey, NonAttribute } from "sequelize";
 import { DataTypes } from "sequelize";
 
 import type { LightMCPToolConfigurationType } from "@app/lib/actions/mcp";
-import type {
-  MCPExecutionState,
-  MCPRunningState,
-  ToolExecutionStatus,
-} from "@app/lib/actions/statuses";
+import type { ToolExecutionStatus } from "@app/lib/actions/statuses";
 import type { StepContext } from "@app/lib/actions/types";
 import { MCPServerViewModel } from "@app/lib/models/assistant/actions/mcp_server_view";
 import { AgentConfiguration } from "@app/lib/models/assistant/agent";
@@ -199,10 +195,6 @@ export class AgentMCPAction extends WorkspaceAwareModel<AgentMCPAction> {
   declare agentMessageId: ForeignKey<AgentMessage["id"]>;
   declare stepContentId: ForeignKey<AgentStepContentModel["id"]>;
 
-  declare isError: boolean;
-  declare executionState: MCPExecutionState;
-  declare runningState: MCPRunningState;
-
   declare status: ToolExecutionStatus;
 
   declare citationsAllocated: number;
@@ -236,37 +228,10 @@ AgentMCPAction.init(
       allowNull: false,
       defaultValue: 0,
     },
-    executionState: {
-      type: DataTypes.STRING,
-      allowNull: false,
-      validate: {
-        isIn: [
-          [
-            "pending",
-            "timeout",
-            "allowed_explicitly",
-            "allowed_implicitly",
-            "denied",
-          ],
-        ],
-      },
-    },
-    runningState: {
-      type: DataTypes.STRING,
-      allowNull: false,
-      validate: {
-        isIn: [["not_started", "running", "completed", "errored"]],
-      },
-    },
     status: {
       type: DataTypes.STRING,
       allowNull: true,
       defaultValue: "succeeded",
-    },
-    isError: {
-      type: DataTypes.BOOLEAN,
-      allowNull: false,
-      defaultValue: false,
     },
     citationsAllocated: {
       type: DataTypes.INTEGER,
@@ -305,11 +270,6 @@ AgentMCPAction.init(
         fields: ["workspaceId", "agentMessageId", "stepContentId", "version"],
         name: "agent_mcp_action_workspace_agent_message_step_content_version",
         unique: true,
-        concurrently: true,
-      },
-      {
-        fields: ["workspaceId", "agentMessageId", "executionState"],
-        name: "agent_mcp_action_workspace_agent_message_execution_state",
         concurrently: true,
       },
       {

--- a/front/lib/resources/agent_mcp_action_resource.ts
+++ b/front/lib/resources/agent_mcp_action_resource.ts
@@ -8,10 +8,7 @@ import type {
 import { Op } from "sequelize";
 
 import type { BlockedActionExecution } from "@app/lib/actions/mcp";
-import type {
-  MCPExecutionState,
-  ToolExecutionStatus,
-} from "@app/lib/actions/statuses";
+import type { ToolExecutionStatus } from "@app/lib/actions/statuses";
 import {
   isToolExecutionStatusBlocked,
   TOOL_EXECUTION_BLOCKED_STATUSES,
@@ -131,7 +128,6 @@ export class AgentMCPActionResource extends BaseResource<AgentMCPAction> {
     });
     assert(stepContent, "Step content not found.");
 
-    // Create a new resource instance with the updated stepContent
     return new this(
       this.model,
       {
@@ -140,10 +136,7 @@ export class AgentMCPActionResource extends BaseResource<AgentMCPAction> {
         agentMessageId: action.agentMessageId,
         augmentedInputs: action.augmentedInputs,
         citationsAllocated: action.citationsAllocated,
-        executionState: action.executionState,
-        isError: action.isError,
         mcpServerConfigurationId: action.mcpServerConfigurationId,
-        runningState: action.runningState,
         status: action.status,
         stepContentId: action.stepContentId,
         stepContext: action.stepContext,
@@ -290,10 +283,7 @@ export class AgentMCPActionResource extends BaseResource<AgentMCPAction> {
       agentMessageId: this.agentMessageId,
       augmentedInputs: this.augmentedInputs,
       citationsAllocated: this.citationsAllocated,
-      executionState: this.executionState,
-      isError: this.isError,
       mcpServerConfigurationId: this.mcpServerConfigurationId,
-      runningState: this.runningState,
       status: this.status,
       stepContentId: this.stepContentId,
       stepContext: this.stepContext,
@@ -308,14 +298,7 @@ export class AgentMCPActionResource extends BaseResource<AgentMCPAction> {
   ): Promise<[affectedCount: number]> {
     return this.update({
       status,
-      isError: status === "errored",
     });
-  }
-
-  async updateExecutionState(
-    executionState: MCPExecutionState
-  ): Promise<[affectedCount: number]> {
-    return this.update({ executionState });
   }
 
   static async deleteByAgentMessageId(

--- a/front/lib/resources/agent_step_content_resource.ts
+++ b/front/lib/resources/agent_step_content_resource.ts
@@ -364,8 +364,6 @@ export class AgentStepContentResource extends BaseResource<AgentStepContentModel
             agentMessageId: action.agentMessageId,
             step: this.step,
             mcpServerConfigurationId: action.mcpServerConfigurationId,
-            executionState: action.executionState,
-            isError: action.isError,
             type: "tool_action",
             status: action.status,
             citationsAllocated: action.citationsAllocated,

--- a/front/lib/resources/agent_step_content_resource.ts
+++ b/front/lib/resources/agent_step_content_resource.ts
@@ -357,7 +357,6 @@ export class AgentStepContentResource extends BaseResource<AgentStepContentModel
             output: removeNulls(
               action.outputItems.map(hideFileFromActionOutput)
             ),
-            runningState: action.runningState,
             functionCallId: value.value.id,
             functionCallName: value.value.name,
             mcpServerId,

--- a/front/migrations/20250821_backfill_agent_mcp_action_status.ts
+++ b/front/migrations/20250821_backfill_agent_mcp_action_status.ts
@@ -1,113 +1,113 @@
-import type { Logger } from "pino";
-import type { WhereOptions } from "sequelize";
-import { Op } from "sequelize";
-
-import { AgentMCPAction } from "@app/lib/models/assistant/actions/mcp";
-import { makeScript } from "@app/scripts/helpers";
-
-const BATCH_SIZE = 2048;
-
-// There are 3 possible final states: errored, succeeded, denied.
-// succeeded is the default (99.1% of actions), we backfill errored using the `isError` column
-// and denied using the `executionState` column.
-
-const TARGET_STATUSES = [
-  "errored",
-  "denied",
-  "succeeded",
-  "blocked_validation_required",
-] as const;
-
-type TargetStatus = (typeof TARGET_STATUSES)[number];
-
-function getWhereClause({
-  lastId,
-  targetStatus,
-}: {
-  lastId: number;
-  targetStatus: TargetStatus;
-}): WhereOptions<AgentMCPAction> {
-  switch (targetStatus) {
-    case "errored":
-      return {
-        id: { [Op.gt]: lastId },
-        isError: true,
-      };
-    case "denied":
-      return {
-        id: { [Op.gt]: lastId },
-        executionState: "denied",
-      };
-    case "succeeded":
-      return {
-        id: { [Op.gt]: lastId },
-        status: "running",
-      };
-    case "blocked_validation_required":
-      return {
-        id: { [Op.gt]: lastId },
-        status: "blocked_pending_validation",
-      };
-  }
-}
-async function getNextBatch({
-  lastId,
-  targetStatus,
-}: {
-  lastId: number;
-  targetStatus: TargetStatus;
-}) {
-  return AgentMCPAction.findAll({
-    where: getWhereClause({ lastId, targetStatus }),
-    order: [["id", "ASC"]],
-    limit: BATCH_SIZE,
-  });
-}
-
-async function backfillActions(
-  { targetStatus, execute }: { targetStatus: TargetStatus; execute: boolean },
-  logger: Logger
-) {
-  let lastId = 0;
-  let hasMore = true;
-  do {
-    const mcpActions = await getNextBatch({ lastId, targetStatus });
-    logger.info(
-      { lastId, targetStatus },
-      `Processing ${mcpActions.length} actions`
-    );
-
-    if (execute) {
-      await AgentMCPAction.update(
-        { status: targetStatus },
-        {
-          where: {
-            id: {
-              [Op.in]: mcpActions.map((a) => a.id),
-            },
-          },
-        }
-      );
-      logger.info(
-        { lastId, targetStatus },
-        `Updated ${mcpActions.length} actions`
-      );
-    } else {
-      logger.info(
-        { lastId, targetStatus },
-        `Would update ${mcpActions.length} actions`
-      );
-    }
-
-    lastId = mcpActions[mcpActions.length - 1].id;
-    hasMore = mcpActions.length === BATCH_SIZE;
-  } while (hasMore);
-}
-
-makeScript({}, async ({ execute }, logger) => {
-  for (const targetStatus of TARGET_STATUSES) {
-    logger.info(`Starting backfill of ${targetStatus} actions`);
-    await backfillActions({ targetStatus, execute }, logger);
-    logger.info(`Completed backfill of ${targetStatus} actions`);
-  }
-});
+// import type { Logger } from "pino";
+// import type { WhereOptions } from "sequelize";
+// import { Op } from "sequelize";
+//
+// import { AgentMCPAction } from "@app/lib/models/assistant/actions/mcp";
+// import { makeScript } from "@app/scripts/helpers";
+//
+// const BATCH_SIZE = 2048;
+//
+// // There are 3 possible final states: errored, succeeded, denied.
+// // succeeded is the default (99.1% of actions), we backfill errored using the `isError` column
+// // and denied using the `executionState` column.
+//
+// const TARGET_STATUSES = [
+//   "errored",
+//   "denied",
+//   "succeeded",
+//   "blocked_validation_required",
+// ] as const;
+//
+// type TargetStatus = (typeof TARGET_STATUSES)[number];
+//
+// function getWhereClause({
+//   lastId,
+//   targetStatus,
+// }: {
+//   lastId: number;
+//   targetStatus: TargetStatus;
+// }): WhereOptions<AgentMCPAction> {
+//   switch (targetStatus) {
+//     case "errored":
+//       return {
+//         id: { [Op.gt]: lastId },
+//         isError: true,
+//       };
+//     case "denied":
+//       return {
+//         id: { [Op.gt]: lastId },
+//         executionState: "denied",
+//       };
+//     case "succeeded":
+//       return {
+//         id: { [Op.gt]: lastId },
+//         status: "running",
+//       };
+//     case "blocked_validation_required":
+//       return {
+//         id: { [Op.gt]: lastId },
+//         status: "blocked_pending_validation",
+//       };
+//   }
+// }
+// async function getNextBatch({
+//   lastId,
+//   targetStatus,
+// }: {
+//   lastId: number;
+//   targetStatus: TargetStatus;
+// }) {
+//   return AgentMCPAction.findAll({
+//     where: getWhereClause({ lastId, targetStatus }),
+//     order: [["id", "ASC"]],
+//     limit: BATCH_SIZE,
+//   });
+// }
+//
+// async function backfillActions(
+//   { targetStatus, execute }: { targetStatus: TargetStatus; execute: boolean },
+//   logger: Logger
+// ) {
+//   let lastId = 0;
+//   let hasMore = true;
+//   do {
+//     const mcpActions = await getNextBatch({ lastId, targetStatus });
+//     logger.info(
+//       { lastId, targetStatus },
+//       `Processing ${mcpActions.length} actions`
+//     );
+//
+//     if (execute) {
+//       await AgentMCPAction.update(
+//         { status: targetStatus },
+//         {
+//           where: {
+//             id: {
+//               [Op.in]: mcpActions.map((a) => a.id),
+//             },
+//           },
+//         }
+//       );
+//       logger.info(
+//         { lastId, targetStatus },
+//         `Updated ${mcpActions.length} actions`
+//       );
+//     } else {
+//       logger.info(
+//         { lastId, targetStatus },
+//         `Would update ${mcpActions.length} actions`
+//       );
+//     }
+//
+//     lastId = mcpActions[mcpActions.length - 1].id;
+//     hasMore = mcpActions.length === BATCH_SIZE;
+//   } while (hasMore);
+// }
+//
+// makeScript({}, async ({ execute }, logger) => {
+//   for (const targetStatus of TARGET_STATUSES) {
+//     logger.info(`Starting backfill of ${targetStatus} actions`);
+//     await backfillActions({ targetStatus, execute }, logger);
+//     logger.info(`Completed backfill of ${targetStatus} actions`);
+//   }
+// });

--- a/front/migrations/db/migration_343.sql
+++ b/front/migrations/db/migration_343.sql
@@ -1,0 +1,4 @@
+-- Migration created on Aug 24, 2025
+ALTER TABLE "public"."agent_mcp_actions" DROP COLUMN "executionState";
+ALTER TABLE "public"."agent_mcp_actions" DROP COLUMN "runningState";
+ALTER TABLE "public"."agent_mcp_actions" DROP COLUMN "isError";

--- a/front/temporal/agent_loop/activities/run_tool.ts
+++ b/front/temporal/agent_loop/activities/run_tool.ts
@@ -74,8 +74,6 @@ export async function runToolActivity(
   const mcpAction = new MCPActionType({
     ...actionBaseParams,
     id: action.id,
-    isError: action.isError,
-    executionState: action.executionState,
     type: "tool_action",
     output: null,
   });
@@ -158,7 +156,7 @@ export async function runToolActivity(
           // Replace existing action with updated one.
           agentMessage.actions[existingActionIndex] = event.action;
         } else {
-          // Add new action if it doesn't exist.
+          // Add the new action if it doesn't exist.
           agentMessage.actions.push(event.action);
         }
 

--- a/front/temporal/agent_loop/activities/run_tool.ts
+++ b/front/temporal/agent_loop/activities/run_tool.ts
@@ -59,8 +59,6 @@ export async function runToolActivity(
   );
   assert(action, "Action not found");
 
-  await action.updateStatus("running");
-
   const mcpServerId = action.toolConfiguration.toolServerId;
 
   const actionBaseParams = await buildActionBaseParams({
@@ -95,8 +93,6 @@ export async function runToolActivity(
   for await (const event of eventStream) {
     switch (event.type) {
       case "tool_error":
-        await action.updateStatus("errored");
-
         // For tool errors, send immediately.
         await updateResourceAndPublishEvent(
           {
@@ -134,8 +130,6 @@ export async function runToolActivity(
         return { deferredEvents };
 
       case "tool_success":
-        await action.updateStatus("succeeded");
-
         await updateResourceAndPublishEvent(
           {
             type: "agent_action_success",

--- a/front/temporal/agent_loop/lib/action_utils.ts
+++ b/front/temporal/agent_loop/lib/action_utils.ts
@@ -60,7 +60,6 @@ export async function buildActionBaseParams({
     mcpServerConfigurationId,
     params: rawInputs,
     step,
-    runningState: "running",
     status,
   };
 }

--- a/front/temporal/agent_loop/lib/create_tool_actions.ts
+++ b/front/temporal/agent_loop/lib/create_tool_actions.ts
@@ -197,11 +197,6 @@ async function createActionForTool(
     );
   }
 
-  // Update the action to surface the execution state.
-  await agentMCPAction.updateStatus(
-    approvalStatusToToolExecutionStatus(status)
-  );
-
   return {
     actionId: agentMCPAction.id,
     needsApproval: status === "pending",


### PR DESCRIPTION
## Description

- Closes https://github.com/dust-tt/tasks/issues/3880.
- Follow up on  https://github.com/dust-tt/dust/pull/15246.
- This PR removes the columns `executionState`, `isError` and `runningState` from `AgentMCPAction`, which have all been consolidated into the `status` column.
- We already don't read from these columns anymore.

## Tests

- Tested locally.

## Risk

- Blast radius mostly in the validation flow.
- Hard to revert with perfect accuracy (but not impossible), we have already validated that we only need the new statuses.

## Deploy Plan

- Deploy front.
- Run migration.
