### PR TITLE
[front] Remove intermediate statuses `pending`, `allowed_implicitly`, ...

### DIFF
--- a/front/lib/actions/mcp.ts
+++ b/front/lib/actions/mcp.ts
@@ -40,7 +40,6 @@ import type {
 } from "@app/lib/actions/types";
 import type { StepContext } from "@app/lib/actions/types";
 import type { AgentActionSpecification } from "@app/lib/actions/types/agent";
-import { approvalStatusToToolExecutionStatus } from "@app/lib/actions/utils";
 import type {
   DataSourceConfiguration,
   TableDataSourceConfiguration,
@@ -191,7 +190,7 @@ export function getMCPApprovalStateFromUserApprovalState(
   switch (userApprovalState) {
     case "always_approved":
     case "approved":
-      return "allowed_explicitly";
+      return "ready_allowed_explicitly";
 
     case "rejected":
       return "denied";
@@ -606,14 +605,12 @@ export async function createMCPAction(
     augmentedInputs,
     stepContentId,
     stepContext,
-    approvalStatus,
   }: {
     actionBaseParams: ActionBaseParams;
     actionConfiguration: MCPToolConfigurationType;
     augmentedInputs: Record<string, unknown>;
     stepContentId: ModelId;
     stepContext: StepContext;
-    approvalStatus: "allowed_implicitly" | "pending";
   }
 ): Promise<{ action: AgentMCPActionResource; mcpAction: MCPActionType }> {
   const toolConfiguration = omit(
@@ -626,7 +623,7 @@ export async function createMCPAction(
     augmentedInputs,
     citationsAllocated: stepContext.citationsCount,
     mcpServerConfigurationId: actionBaseParams.mcpServerConfigurationId,
-    status: approvalStatusToToolExecutionStatus(approvalStatus),
+    status: actionBaseParams.status,
     stepContentId,
     stepContext,
     toolConfiguration,
@@ -749,14 +746,13 @@ export async function getMCPAction(
 // TODO(DURABLE_AGENTS 2025-08-12): Create a proper resource for the agent mcp action.
 export async function updateMCPApprovalState(
   action: AgentMCPActionResource,
-  executionState: "denied" | "allowed_explicitly"
+  approvalState: "denied" | "ready_allowed_explicitly"
 ): Promise<boolean> {
-  const status = approvalStatusToToolExecutionStatus(executionState);
-  if (action.status === status) {
+  if (action.status === approvalState) {
     return false;
   }
 
-  await action.updateStatus(status);
+  await action.updateStatus(approvalState);
 
   return true;
 }

--- a/front/lib/actions/statuses.ts
+++ b/front/lib/actions/statuses.ts
@@ -1,10 +1,3 @@
-// TODO(2025-08-20 aubin): remove this (consolidated into a single column).
-export type MCPExecutionState =
-  | "allowed_explicitly"
-  | "allowed_implicitly"
-  | "denied"
-  | "pending";
-
 const TOOL_EXECUTION_FINAL_STATUSES = [
   "succeeded",
   "errored",

--- a/front/lib/actions/utils.ts
+++ b/front/lib/actions/utils.ts
@@ -9,10 +9,6 @@ import {
 import type { ActionSpecification } from "@app/components/assistant_builder/types";
 import type { MCPToolStakeLevelType } from "@app/lib/actions/constants";
 import type { MCPToolConfigurationType } from "@app/lib/actions/mcp";
-import type {
-  MCPExecutionState,
-  ToolExecutionStatus,
-} from "@app/lib/actions/statuses";
 import type { StepContext } from "@app/lib/actions/types";
 import {
   isMCPInternalDataSourceFileSystem,
@@ -242,39 +238,20 @@ export function getMCPApprovalKey({
   return `conversation:${conversationId}:message:${messageId}:action:${actionId}`;
 }
 
-// TODO(durable-agents): remove this translation once status is backfilled, have
-//  getExecutionStatusFromConfig return a ToolExecutionStatus directly.
-export function approvalStatusToToolExecutionStatus(
-  approvalStatus: MCPExecutionState
-): ToolExecutionStatus {
-  switch (approvalStatus) {
-    case "allowed_explicitly":
-      return "ready_allowed_explicitly";
-    case "allowed_implicitly":
-      return "ready_allowed_implicitly";
-    case "denied":
-      return "denied";
-    case "pending":
-      return "blocked_validation_required";
-    default:
-      assertNever(approvalStatus);
-  }
-}
-
 export async function getExecutionStatusFromConfig(
   auth: Authenticator,
   actionConfiguration: MCPToolConfigurationType,
   agentMessage: AgentMessageType
 ): Promise<{
   stake?: MCPToolStakeLevelType;
-  status: "allowed_implicitly" | "pending";
+  status: "ready_allowed_implicitly" | "blocked_validation_required";
   serverId?: string;
 }> {
   // If the agent message is marked as "skipToolsValidation" we skip all tools validation
   // irrespective of the `actionConfiguration.permission`. This is set when the agent message was
   // created by an API call where the caller explicitly set `skipToolsValidation` to true.
   if (agentMessage.skipToolsValidation) {
-    return { status: "allowed_implicitly" };
+    return { status: "ready_allowed_implicitly" };
   }
 
   // Permissions:
@@ -284,7 +261,7 @@ export async function getExecutionStatusFromConfig(
   // - undefined: Use default permission ("never_ask" for default tools, "high" for other tools)
   switch (actionConfiguration.permission) {
     case "never_ask":
-      return { status: "allowed_implicitly" };
+      return { status: "ready_allowed_implicitly" };
     case "low": {
       // The user may not be populated, notably when using the public API.
       const user = auth.user();
@@ -296,12 +273,12 @@ export async function getExecutionStatusFromConfig(
         neverAskSetting &&
         neverAskSetting.value.includes(`${actionConfiguration.name}`)
       ) {
-        return { status: "allowed_implicitly" };
+        return { status: "ready_allowed_implicitly" };
       }
-      return { status: "pending" };
+      return { status: "blocked_validation_required" };
     }
     case "high":
-      return { status: "pending" };
+      return { status: "blocked_validation_required" };
     default:
       assertNever(actionConfiguration.permission);
   }


### PR DESCRIPTION
## Description

- Part of https://github.com/dust-tt/tasks/issues/3880.
- `MCPExecutionState` (`approved_implicitly`, `pending`, `approved_explicitly`, `denied`) is an intermediate type that we convert into one of the new statuses (`allowed_implicitly`, `blocked_pending_validation`, ...).
- This translation is purely a change in wording, that was kept because the column `executionState` still relied on the old wording.
- Now that this column has been dropped, we can remove this translation and directly use the new statuses.
- The SDK nor the extensions don't rely on these statuses.

## Tests

- Tested locally.

## Risk

- Low.

## Deploy Plan

- Deploy front.
