### PR TITLE
[front] Fix issue with action validation on empty conversation

### DIFF
--- a/front/components/assistant/conversation/ConversationContainer.tsx
+++ b/front/components/assistant/conversation/ConversationContainer.tsx
@@ -26,7 +26,6 @@ import { useSendNotification } from "@app/hooks/useNotification";
 import { updateMessagePagesWithOptimisticData } from "@app/lib/client/conversation/event_handlers";
 import { getRandomGreetingForName } from "@app/lib/client/greetings";
 import type { DustError } from "@app/lib/error";
-import { useBlockedActions } from "@app/lib/swr/blocked_actions";
 import {
   useConversationMessages,
   useConversations,

--- a/front/components/assistant/conversation/ConversationContainer.tsx
+++ b/front/components/assistant/conversation/ConversationContainer.tsx
@@ -348,7 +348,7 @@ export function ConversationContainer({
         </div>
       )}
 
-      {hasPendingValidations && (
+      {activeConversationId && hasPendingValidations && (
         <ContentMessageInline
           icon={InformationCircleIcon}
           variant="primary"

--- a/front/components/assistant/conversation/ConversationContainer.tsx
+++ b/front/components/assistant/conversation/ConversationContainer.tsx
@@ -26,6 +26,7 @@ import { useSendNotification } from "@app/hooks/useNotification";
 import { updateMessagePagesWithOptimisticData } from "@app/lib/client/conversation/event_handlers";
 import { getRandomGreetingForName } from "@app/lib/client/greetings";
 import type { DustError } from "@app/lib/error";
+import { useBlockedActions } from "@app/lib/swr/blocked_actions";
 import {
   useConversationMessages,
   useConversations,
@@ -375,7 +376,7 @@ export function ConversationContainer({
         }
         stickyMentions={stickyMentions}
         conversationId={activeConversationId}
-        disable={hasPendingValidations}
+        disable={activeConversationId !== null && hasPendingValidations}
       />
 
       {!activeConversationId && (


### PR DESCRIPTION
## Description

- This PR fixes a bug where the `ContentMessage` "1 action requires manual approval" would appear on an empty conversation.
- Steps to reproduce: start a conversation, get to a point where a validation is required. Refresh and hit `CMD + /`.
<img width="637" height="249" alt="Screenshot 2025-08-24 at 4 31 42 PM" src="https://github.com/user-attachments/assets/46371b14-947a-4091-9641-80e71c9c1da6" />

- This is a very temporary fix, as per IRL there is also a mutate missing: we want to mutate the pending validations when changing conversation. Will tackle in a follow up PR.

## Tests

- Checked locally.

## Risk

- Low.

## Deploy Plan

- Deploy front.
