### PR TITLE
[sparkle] feat(ContextItem): add hoverAction prop to enable hover effects

### DIFF
--- a/sparkle/src/components/ContextItem.tsx
+++ b/sparkle/src/components/ContextItem.tsx
@@ -13,6 +13,7 @@ type ContextItemProps = {
   subElement?: ReactNode;
   title: ReactNode;
   visual: ReactNode;
+  hoverAction?: boolean;
   onClick?: () => void;
 };
 
@@ -25,6 +26,7 @@ export function ContextItem({
   subElement,
   title,
   visual,
+  hoverAction,
   onClick,
 }: ContextItemProps) {
   return (
@@ -63,7 +65,15 @@ export function ContextItem({
           </div>
           {children && <div>{children}</div>}
         </div>
-        <div>{action}</div>
+        <div
+          className={classNames(
+            hoverAction
+              ? "s-opacity-0 s-transition-opacity s-duration-200 group-hover/context-item:s-opacity-100"
+              : ""
+          )}
+        >
+          {action}
+        </div>
       </div>
     </div>
   );

--- a/sparkle/src/components/ContextItem.tsx
+++ b/sparkle/src/components/ContextItem.tsx
@@ -32,7 +32,7 @@ export function ContextItem({
   return (
     <div
       className={cn(
-        "s-flex s-w-full s-flex-col",
+        "s-group/context-item s-flex s-w-full s-flex-col",
         className,
         hasSeparator && "s-border-b s-border-border dark:s-border-border-night",
         !hasSeparatorIfLast && "last:s-border-none"
@@ -66,10 +66,9 @@ export function ContextItem({
           {children && <div>{children}</div>}
         </div>
         <div
-          className={classNames(
-            hoverAction
-              ? "s-opacity-0 s-transition-opacity s-duration-200 group-hover/context-item:s-opacity-100"
-              : ""
+          className={cn(
+            hoverAction &&
+              "s-opacity-0 s-transition-opacity s-duration-200 group-hover/context-item:s-opacity-100"
           )}
         >
           {action}

--- a/sparkle/src/stories/ContextItem.stories.tsx
+++ b/sparkle/src/stories/ContextItem.stories.tsx
@@ -77,6 +77,7 @@ export const ListItemExample = () => (
       <ContextItem
         title="Slack"
         visual={<ContextItem.Visual visual={SlackLogo} />}
+        hoverAction
         action={
           <div className="s-flex s-gap-1">
             <Button icon={TrashIcon} variant="warning" label="Remove" />


### PR DESCRIPTION
## Description
Add a `hoverAction` prop to the ContextItem component to enable conditional visibility of action buttons on hover. This enhances the user interface by showing action buttons only when the user interacts with the item, reducing visual noise.

https://github.com/user-attachments/assets/1f565a76-a368-4f82-a9dd-c3acfdd5e0f4

## Test
- Locally, sparkle stories

## Risk
Low - This change is additive and backward compatible.

## Deploy plan
- Bump and publish sparkle
