### PR TITLE
Use 421 error instead of 404

### DIFF
--- a/connectors/src/api/webhooks/webhook_slack_bot.ts
+++ b/connectors/src/api/webhooks/webhook_slack_bot.ts
@@ -70,7 +70,7 @@ const _webhookSlackBotAPIHandler = async (
           type: "connector_configuration_not_found",
           message: `Slack configuration not found for teamId ${teamId}`,
         },
-        status_code: 404,
+        status_code: 421,
       });
     }
 
@@ -116,7 +116,7 @@ const _webhookSlackBotAPIHandler = async (
                   type: "connector_configuration_not_found",
                   message: `Slack configuration not found for teamId ${teamId}. Are you sure the bot is not enabled?`,
                 },
-                status_code: 404,
+                status_code: 421,
               });
             }
             const connector = await ConnectorResource.fetchById(


### PR DESCRIPTION
## Description

This error happens as webhooks are sent to all regions, but only one can handle it. Instead of returning a 404, use 421 (Misdirected Request)

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk
low

## Deploy Plan

deploy connectors