### PR TITLE
[front] render differently triggered convos in side-bar

### DIFF
--- a/front/components/assistant/conversation/SidebarMenu.tsx
+++ b/front/components/assistant/conversation/SidebarMenu.tsx
@@ -476,7 +476,7 @@ const RenderConversation = ({
           icon={
             conversation.actionRequired
               ? ActionRequiredIcon
-              : conversation.unread
+              : conversation.visibility === "triggered"
                 ? ClockIcon
                 : undefined
           }

--- a/front/lib/resources/conversation_resource.ts
+++ b/front/lib/resources/conversation_resource.ts
@@ -371,6 +371,7 @@ export class ConversationResource extends BaseResource<ConversationModel> {
 
     const includedConversationVisibilities: ConversationVisibility[] = [
       "unlisted",
+      "triggered",
     ];
 
     if (options?.includeDeleted) {

--- a/front/temporal/agent_schedule/activities.ts
+++ b/front/temporal/agent_schedule/activities.ts
@@ -31,7 +31,7 @@ export async function runScheduledAgentsActivity(
 
   const newConversation = await createConversation(auth, {
     title: `@${agentConfiguration.name} scheduled call - ${new Date().toLocaleDateString()}`,
-    visibility: "unlisted",
+    visibility: "triggered",
   });
 
   const baseContext = {

--- a/front/types/api/internal/assistant.ts
+++ b/front/types/api/internal/assistant.ts
@@ -183,6 +183,7 @@ export const InternalPostConversationsRequestBodySchema = t.type({
   title: t.union([t.string, t.null]),
   visibility: t.union([
     t.literal("unlisted"),
+    t.literal("triggered"),
     t.literal("deleted"),
     t.literal("test"),
   ]),

--- a/front/types/assistant/conversation.ts
+++ b/front/types/assistant/conversation.ts
@@ -204,7 +204,11 @@ export function isAgentMessageType(arg: MessageType): arg is AgentMessageType {
  * when a user 'tests' an agent not in their list using the "test" button:
  * those conversations do not show in users' histories.
  */
-export type ConversationVisibility = "unlisted" | "deleted" | "test";
+export type ConversationVisibility =
+  | "unlisted"
+  | "triggered"
+  | "deleted"
+  | "test";
 
 /**
  * A lighter version of Conversation without the content (for menu display).

--- a/sdks/js/src/types.ts
+++ b/sdks/js/src/types.ts
@@ -926,7 +926,7 @@ const AgentMessageFeedbackSchema = z.object({
 });
 
 const ConversationVisibilitySchema = FlexibleEnumSchema<
-  "unlisted" | "workspace" | "deleted" | "test"
+  "unlisted" | "triggered" | "workspace" | "deleted" | "test"
 >();
 
 export type ConversationVisibility = z.infer<
@@ -1104,7 +1104,9 @@ const BlockedActionExecutionSchema = ToolExecutionMetadataSchema.extend({
   status: ToolExecutionBlockedStatusSchema,
 });
 
-export type BlockedActionExecutionType = z.infer<typeof BlockedActionExecutionSchema>;
+export type BlockedActionExecutionType = z.infer<
+  typeof BlockedActionExecutionSchema
+>;
 
 const MCPApproveExecutionEventSchema = ToolExecutionMetadataSchema.extend({
   type: z.literal("tool_approve_execution"),


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

We're starting to have conversations originating from a trigger. We want to allow user to differentiate them visually in the sidebar.

This PR adds a new visibility type for conversations, being "triggered", that makes conversations rendered differently in the side-bar, with a ClockIcon.

<img width="3024" height="1890" alt="image" src="https://github.com/user-attachments/assets/acba63dc-ad72-4735-bf7f-7c58bef12b0d" />

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

Tested by hand

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

Low, behind ff

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->

Deploy front.