### PR TITLE
[front] feat(ab/filters): Add tags knowledge tags filtering

### DIFF
--- a/front/components/agent_builder/capabilities/knowledge/DataSourceNodeTable.tsx
+++ b/front/components/agent_builder/capabilities/knowledge/DataSourceNodeTable.tsx
@@ -64,6 +64,7 @@ export function DataSourceNodeTable({ viewType }: DataSourceNodeTableProps) {
           entry: {
             type: "node",
             node,
+            tagsFilter: null,
           },
         };
       }),

--- a/front/components/agent_builder/capabilities/knowledge/DataSourceSearchResults.tsx
+++ b/front/components/agent_builder/capabilities/knowledge/DataSourceSearchResults.tsx
@@ -319,11 +319,13 @@ export function DataSourceSearchResults({
       return {
         type: "data_source",
         dataSourceView: node.dataSourceView,
+        tagsFilter: null,
       };
     } else {
       return {
         type: "node",
         node: node,
+        tagsFilter: null,
       };
     }
   };

--- a/front/components/agent_builder/capabilities/knowledge/DataSourceViewTable.tsx
+++ b/front/components/agent_builder/capabilities/knowledge/DataSourceViewTable.tsx
@@ -73,6 +73,7 @@ export function DataSourceViewTable({
         entry: {
           type: "data_source",
           dataSourceView: dsv,
+          tagsFilter: null,
         },
       } satisfies DataSourceRowData;
     })

--- a/front/components/agent_builder/capabilities/knowledge/KnowledgeConfigurationSheet.tsx
+++ b/front/components/agent_builder/capabilities/knowledge/KnowledgeConfigurationSheet.tsx
@@ -34,16 +34,16 @@ import {
 } from "@app/components/agent_builder/get_allowed_spaces";
 import { useMCPServerViewsContext } from "@app/components/agent_builder/MCPServerViewsContext";
 import { useSpacesContext } from "@app/components/agent_builder/SpacesContext";
-import type {
-  CapabilityFormData,
-  ConfigurationSheetPageId,
-} from "@app/components/agent_builder/types";
+import type { CapabilityFormData } from "@app/components/agent_builder/types";
 import type { AgentBuilderAction } from "@app/components/agent_builder/types";
 import {
   capabilityFormSchema,
   CONFIGURATION_SHEET_PAGE_IDS,
 } from "@app/components/agent_builder/types";
-import { DataSourceBuilderProvider } from "@app/components/data_source_view/context/DataSourceBuilderContext";
+import {
+  DataSourceBuilderProvider,
+  useDataSourceBuilderContext,
+} from "@app/components/data_source_view/context/DataSourceBuilderContext";
 import { FormProvider } from "@app/components/sparkle/FormProvider";
 import { getMCPServerNameForTemplateAction } from "@app/lib/actions/mcp_helper";
 import { getMCPServerRequirements } from "@app/lib/actions/mcp_internal_actions/input_configuration";
@@ -199,18 +199,25 @@ export function KnowledgeConfigurationSheet({
     }
   };
 
+  const getInitialPageId = () => {
+    if (isEditing) {
+      return CONFIGURATION_SHEET_PAGE_IDS.CONFIGURATION;
+    }
+    return CONFIGURATION_SHEET_PAGE_IDS.DATA_SOURCE_SELECTION;
+  };
+
   return (
     <MultiPageSheet open={open} onOpenChange={handleOpenChange}>
       <FormProvider form={form}>
         {debouncedOpen && (
-          <DataSourceBuilderProvider spaces={spaces}>
+          <DataSourceBuilderProvider
+            spaces={spaces}
+            initialPageId={getInitialPageId()}
+          >
             <KnowledgeConfigurationSheetContent
               onSave={form.handleSubmit(handleSave)}
               onClose={onClose}
-              open={open}
               getAgentInstructions={getAgentInstructions}
-              isEditing={isEditing}
-              presetActionData={presetActionData}
             />
           </DataSourceBuilderProvider>
         )}
@@ -222,19 +229,13 @@ export function KnowledgeConfigurationSheet({
 interface KnowledgeConfigurationSheetContentProps {
   onSave: () => void;
   onClose: () => void;
-  open: boolean;
   getAgentInstructions: () => string;
-  isEditing: boolean;
-  presetActionData?: TemplateActionPreset;
 }
 
 function KnowledgeConfigurationSheetContent({
   onSave,
   onClose,
-  open,
   getAgentInstructions,
-  isEditing,
-  presetActionData,
 }: KnowledgeConfigurationSheetContentProps) {
   const { actions } = useAgentBuilderFormActions();
   const { mcpServerViews } = useMCPServerViewsContext();
@@ -244,6 +245,7 @@ function KnowledgeConfigurationSheetContent({
     spaces,
     spaceIdToActions,
   });
+  const { currentPageId, setSheetPageId } = useDataSourceBuilderContext();
 
   const mcpServerView = useWatch<CapabilityFormData, "mcpServerView">({
     name: "mcpServerView",
@@ -268,26 +270,9 @@ function KnowledgeConfigurationSheetContent({
   const { owner } = useAgentBuilderContext();
   const { supportedDataSourceViews } = useDataSourceViewsContext();
 
-  const getInitialPageId = () => {
-    if (isEditing) {
-      return CONFIGURATION_SHEET_PAGE_IDS.CONFIGURATION;
-    }
-    return CONFIGURATION_SHEET_PAGE_IDS.DATA_SOURCE_SELECTION;
-  };
-
-  const [currentPageId, setCurrentPageId] =
-    useState<ConfigurationSheetPageId>(getInitialPageId());
-
-  useEffect(() => {
-    if (open) {
-      setCurrentPageId(getInitialPageId());
-    }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [open, isEditing, presetActionData]);
-
   const handlePageChange = (pageId: string) => {
     if (isValidPage(pageId, CONFIGURATION_SHEET_PAGE_IDS)) {
-      setCurrentPageId(pageId);
+      setSheetPageId(pageId);
     }
   };
 
@@ -303,9 +288,7 @@ function KnowledgeConfigurationSheetContent({
           if (isDataSourcePage) {
             onClose();
           } else {
-            setCurrentPageId(
-              CONFIGURATION_SHEET_PAGE_IDS.DATA_SOURCE_SELECTION
-            );
+            setSheetPageId(CONFIGURATION_SHEET_PAGE_IDS.DATA_SOURCE_SELECTION);
           }
         },
       },
@@ -315,7 +298,7 @@ function KnowledgeConfigurationSheetContent({
         disabled: isDataSourcePage ? !hasSourceSelection : false,
         onClick: () => {
           if (isDataSourcePage) {
-            setCurrentPageId(CONFIGURATION_SHEET_PAGE_IDS.CONFIGURATION);
+            setSheetPageId(CONFIGURATION_SHEET_PAGE_IDS.CONFIGURATION);
           } else {
             onSave();
           }

--- a/front/components/agent_builder/capabilities/knowledge/KnowledgeConfigurationSheet.tsx
+++ b/front/components/agent_builder/capabilities/knowledge/KnowledgeConfigurationSheet.tsx
@@ -25,6 +25,7 @@ import { DescriptionSection } from "@app/components/agent_builder/capabilities/s
 import { JsonSchemaSection } from "@app/components/agent_builder/capabilities/shared/JsonSchemaSection";
 import { NameSection } from "@app/components/agent_builder/capabilities/shared/NameSection";
 import { ProcessingMethodSection } from "@app/components/agent_builder/capabilities/shared/ProcessingMethodSection";
+import { SelectDataSourcesFilters } from "@app/components/agent_builder/capabilities/shared/SelectDataSourcesFilters";
 import { TimeFrameSection } from "@app/components/agent_builder/capabilities/shared/TimeFrameSection";
 import { useDataSourceViewsContext } from "@app/components/agent_builder/DataSourceViewsContext";
 import {
@@ -356,6 +357,8 @@ function KnowledgeConfigurationSheetContent({
       icon: config?.icon,
       content: (
         <div className="space-y-6">
+          <SelectDataSourcesFilters />
+
           <NameSection
             title="Tool Name"
             description="Customize the name of this knowledge tool to reference it in your instructions."

--- a/front/components/agent_builder/capabilities/knowledge/KnowledgeFooter.tsx
+++ b/front/components/agent_builder/capabilities/knowledge/KnowledgeFooter.tsx
@@ -66,9 +66,10 @@ function KnowledgeFooterItem({
       visual={<ContextItem.Visual visual={VisualComponent} />}
       action={
         <Button
+          size="mini"
+          variant="ghost"
           icon={XMarkIcon}
           onClick={() => removeNodeWithPath(item)}
-          variant="ghost"
         />
       }
       subElement={

--- a/front/components/agent_builder/capabilities/knowledge/transformations.ts
+++ b/front/components/agent_builder/capabilities/knowledge/transformations.ts
@@ -62,7 +62,7 @@ export function transformTreeToSelectionConfigurations(
         selectedResources: [],
         excludedResources: [],
         isSelectAll: isFullDataSource,
-        tagsFilter: null,
+        tagsFilter: item.tagsFilter,
       };
     }
 
@@ -101,7 +101,7 @@ export function transformTreeToSelectionConfigurations(
         selectedResources: [],
         excludedResources: [],
         isSelectAll: false,
-        tagsFilter: null,
+        tagsFilter: item.tagsFilter,
       };
     }
 
@@ -139,6 +139,7 @@ export function transformSelectionConfigurationsToTree(
         name: dataSourceView.dataSource.name,
         type: "data_source",
         dataSourceView,
+        tagsFilter: config.tagsFilter,
       });
       continue;
     }
@@ -159,6 +160,7 @@ export function transformSelectionConfigurationsToTree(
             name: node.title,
             type: "node",
             node,
+            tagsFilter: config.tagsFilter,
           });
         } else {
           const pathParts = [baseParts, node.internalId];
@@ -167,6 +169,7 @@ export function transformSelectionConfigurationsToTree(
             name: node.title,
             type: "data_source",
             dataSourceView: node.dataSourceView,
+            tagsFilter: config.tagsFilter,
           });
         }
       }
@@ -190,6 +193,7 @@ export function transformSelectionConfigurationsToTree(
             name: node.title,
             type: "node",
             node,
+            tagsFilter: config.tagsFilter,
           });
         } else {
           const pathParts = [baseParts, node.internalId];
@@ -198,6 +202,7 @@ export function transformSelectionConfigurationsToTree(
             name: node.title,
             type: "data_source",
             dataSourceView: node.dataSourceView,
+            tagsFilter: config.tagsFilter,
           });
         }
       }

--- a/front/components/agent_builder/capabilities/shared/DataSourceViewTagsFilterDropdown.tsx
+++ b/front/components/agent_builder/capabilities/shared/DataSourceViewTagsFilterDropdown.tsx
@@ -49,15 +49,14 @@ export function DataSourceViewTagsFilterDropdown() {
           return acc;
         }, [] as number[]);
 
-        if (sourceIndexes.length < 0) {
-          console.error("No source found");
+        if (sourceIndexes.length <= 0) {
           return;
         }
 
         for (const sourceIdx of sourceIndexes) {
           const source = sources.in[sourceIdx];
           if (source.type !== "data_source" && source.type !== "node") {
-            console.error("Source type does not support tags filter");
+            // Source type does not support tags filter);
             continue;
           }
 
@@ -84,8 +83,6 @@ export function DataSourceViewTagsFilterDropdown() {
               ),
             };
           }
-
-          console.log({ newTagsFilter });
 
           // If all tags are removed and mode is not auto, set tagsFilter to null
           if (

--- a/front/components/agent_builder/capabilities/shared/DataSourceViewTagsFilterDropdown.tsx
+++ b/front/components/agent_builder/capabilities/shared/DataSourceViewTagsFilterDropdown.tsx
@@ -163,7 +163,7 @@ export function DataSourceViewTagsFilterDropdown() {
 
   return (
     <PopoverRoot>
-      <PopoverTrigger>
+      <PopoverTrigger asChild>
         <Button label="Filters" isSelect />
       </PopoverTrigger>
 

--- a/front/components/agent_builder/capabilities/shared/DataSourceViewTagsFilterDropdown.tsx
+++ b/front/components/agent_builder/capabilities/shared/DataSourceViewTagsFilterDropdown.tsx
@@ -1,0 +1,100 @@
+import {
+  Button,
+  Label,
+  Page,
+  PopoverContent,
+  PopoverRoot,
+  PopoverTrigger,
+} from "@dust-tt/sparkle";
+import { useState } from "react";
+import { useWatch } from "react-hook-form";
+
+import { useAgentBuilderContext } from "@app/components/agent_builder/AgentBuilderContext";
+import { useDataSourceViewsContext } from "@app/components/agent_builder/DataSourceViewsContext";
+import type { CapabilityFormData } from "@app/components/agent_builder/types";
+import { TagSearchSection } from "@app/components/assistant_builder/tags/TagSearchSection";
+import type { DataSourceTag } from "@app/types";
+
+import { transformTreeToSelectionConfigurations } from "../knowledge/transformations";
+
+export function DataSourceViewTagsFilterDropdown() {
+  const [tagsIn, setTagsIn] = useState<DataSourceTag[]>([]);
+  const [tagsNotIn, setTagsNotIn] = useState<DataSourceTag[]>([]);
+  const { supportedDataSourceViews } = useDataSourceViewsContext();
+  const { owner } = useAgentBuilderContext();
+  const sources = useWatch<CapabilityFormData, "sources">({ name: "sources" });
+  const dataSourceConfigurations = transformTreeToSelectionConfigurations(
+    sources,
+    supportedDataSourceViews
+  );
+
+  return (
+    <PopoverRoot>
+      <PopoverTrigger>
+        <Button label="Filters" isSelect />
+      </PopoverTrigger>
+
+      <PopoverContent
+        align="end"
+        className="max-h-[var(--radix-popper-available-height)] w-[600px] max-w-[600px] overflow-scroll"
+        collisionPadding={20}
+      >
+        <div className="flex flex-col gap-8 p-2">
+          <div className="flex flex-col gap-2">
+            <Page.SectionHeader
+              title="Filtering"
+              description="Filter to only include content bearing must-have labels, and exclude content with must-not-have labels."
+            />
+          </div>
+
+          <TagSearchSection
+            label="Must-have labels"
+            dataSourceViews={Object.values(dataSourceConfigurations).map(
+              (ds) => ds.dataSourceView
+            )}
+            owner={owner}
+            selectedTagsIn={tagsIn}
+            selectedTagsNot={tagsNotIn}
+            onTagAdd={(tag) => setTagsIn((prev) => [...prev, tag])}
+            onTagRemove={(tag) =>
+              setTagsIn((prev) => prev.filter((t) => t.tag !== tag.tag))
+            }
+            operation="in"
+          />
+
+          <TagSearchSection
+            label="Must-not-have labels"
+            dataSourceViews={Object.values(dataSourceConfigurations).map(
+              (ds) => ds.dataSourceView
+            )}
+            owner={owner}
+            selectedTagsIn={tagsIn}
+            selectedTagsNot={tagsNotIn}
+            onTagAdd={(tag) => setTagsNotIn((prev) => [...prev, tag])}
+            onTagRemove={(tag) =>
+              setTagsNotIn((prev) => prev.filter((t) => t.tag !== tag.tag))
+            }
+            operation="not"
+          />
+
+          <div className="flex flex-col gap-2">
+            <Page.SectionHeader
+              title="In-conversation filtering"
+              description="Allow agents to determine filters to apply based on conversation context."
+            />
+          </div>
+          <div className="flex flex-row items-center gap-2">
+            {/* <SliderToggle */}
+            {/*   selected={tagsFilter?.mode === "auto"} */}
+            {/*   onClick={() => { */}
+            {/*     handleAutoFilter(tagsFilter?.mode !== "auto"); */}
+            {/*   }} */}
+            {/*   size="xs" */}
+            {/* /> */}
+            <Label>Enable in-conversation filtering</Label>
+          </div>
+        </div>
+      </PopoverContent>
+    </PopoverRoot>
+  );
+}

--- a/front/components/agent_builder/capabilities/shared/DataSourceViewTagsFilterDropdown.tsx
+++ b/front/components/agent_builder/capabilities/shared/DataSourceViewTagsFilterDropdown.tsx
@@ -185,6 +185,7 @@ export function DataSourceViewTagsFilterDropdown() {
             onTagAdd={handleTagsOperation("in", "add")}
             onTagRemove={handleTagsOperation("in", "remove")}
             operation="in"
+            showChipIcons
           />
 
           <TagSearchSection
@@ -196,6 +197,7 @@ export function DataSourceViewTagsFilterDropdown() {
             onTagAdd={handleTagsOperation("not", "add")}
             onTagRemove={handleTagsOperation("not", "remove")}
             operation="not"
+            showChipIcons
           />
         </div>
       </PopoverContent>

--- a/front/components/agent_builder/capabilities/shared/DataSourceViewTagsFilterDropdown.tsx
+++ b/front/components/agent_builder/capabilities/shared/DataSourceViewTagsFilterDropdown.tsx
@@ -164,12 +164,12 @@ export function DataSourceViewTagsFilterDropdown() {
   return (
     <PopoverRoot>
       <PopoverTrigger asChild>
-        <Button label="Filters" isSelect />
+        <Button label="Filters" variant="outline" isSelect />
       </PopoverTrigger>
 
       <PopoverContent
         align="end"
-        className="max-h-[var(--radix-popper-available-height)] w-[600px] max-w-[600px] overflow-scroll"
+        className="max-h-[var(--radix-popper-available-height)] w-150 max-w-150 overflow-scroll"
         collisionPadding={20}
       >
         <div className="flex flex-col gap-8 p-2">

--- a/front/components/agent_builder/capabilities/shared/DataSourceViewTagsFilterDropdown.tsx
+++ b/front/components/agent_builder/capabilities/shared/DataSourceViewTagsFilterDropdown.tsx
@@ -1,32 +1,161 @@
 import {
   Button,
-  Label,
   Page,
   PopoverContent,
   PopoverRoot,
   PopoverTrigger,
 } from "@dust-tt/sparkle";
-import { useState } from "react";
-import { useWatch } from "react-hook-form";
+import { useCallback, useMemo } from "react";
+import { useFormContext, useWatch } from "react-hook-form";
 
 import { useAgentBuilderContext } from "@app/components/agent_builder/AgentBuilderContext";
-import { useDataSourceViewsContext } from "@app/components/agent_builder/DataSourceViewsContext";
 import type { CapabilityFormData } from "@app/components/agent_builder/types";
 import { TagSearchSection } from "@app/components/assistant_builder/tags/TagSearchSection";
-import type { DataSourceTag } from "@app/types";
-
-import { transformTreeToSelectionConfigurations } from "../knowledge/transformations";
+import type { DataSourceTag, DataSourceViewType } from "@app/types";
 
 export function DataSourceViewTagsFilterDropdown() {
-  const [tagsIn, setTagsIn] = useState<DataSourceTag[]>([]);
-  const [tagsNotIn, setTagsNotIn] = useState<DataSourceTag[]>([]);
-  const { supportedDataSourceViews } = useDataSourceViewsContext();
   const { owner } = useAgentBuilderContext();
+  const { setValue } = useFormContext<CapabilityFormData>();
   const sources = useWatch<CapabilityFormData, "sources">({ name: "sources" });
-  const dataSourceConfigurations = transformTreeToSelectionConfigurations(
-    sources,
-    supportedDataSourceViews
+
+  const dataSourceViews = sources.in.reduce((acc, source) => {
+    if (source.type === "data_source") {
+      acc.push(source.dataSourceView);
+    } else if (source.type === "node") {
+      acc.push(source.node.dataSourceView);
+    }
+    return acc;
+  }, [] as DataSourceViewType[]);
+
+  const handleTagsOperation = useCallback(
+    (include: "in" | "not", operation: "add" | "remove") => {
+      return (tag: DataSourceTag) => {
+        const dsv = dataSourceViews.find(
+          (dsv) =>
+            dsv.dataSource.dustAPIDataSourceId === tag.dustAPIDataSourceId
+        );
+        if (!dsv) {
+          console.error("No dataSourceView found for the tag");
+          return;
+        }
+
+        const sourceIdx = sources.in.findIndex((source) => {
+          if (
+            source.type === "data_source" &&
+            source.dataSourceView.dataSource.dustAPIDataSourceId ===
+              tag.dustAPIDataSourceId
+          ) {
+            return true;
+          } else if (
+            source.type === "node" &&
+            source.node.dataSourceView.dataSource.dustAPIDataSourceId ===
+              tag.dustAPIDataSourceId
+          ) {
+            return true;
+          }
+          return false;
+        });
+
+        if (sourceIdx < 0) {
+          console.error("No source found");
+          return;
+        }
+
+        const source = sources.in[sourceIdx];
+        if (source.type !== "data_source" && source.type !== "node") {
+          console.error("Source type does not support tags filter");
+          return;
+        }
+
+        const currentSource = sources.in[sourceIdx];
+
+        if (
+          currentSource.type !== "data_source" &&
+          currentSource.type !== "node"
+        ) {
+          console.error("Current source type does not support tags filter");
+          return;
+        }
+
+        const currentTagsFilter = currentSource.tagsFilter;
+
+        let newTagsFilter = currentTagsFilter || {
+          in: [],
+          not: [],
+          mode: "custom" as const,
+        };
+
+        if (operation === "add") {
+          // Add tag to the specified array if not already present
+          if (!newTagsFilter[include].includes(tag.tag)) {
+            newTagsFilter = {
+              ...newTagsFilter,
+              [include]: [...newTagsFilter[include], tag.tag],
+            };
+          }
+        } else if (operation === "remove") {
+          // Remove tag from the specified array
+          newTagsFilter = {
+            ...newTagsFilter,
+            [include]: newTagsFilter[include].filter(
+              (t: string) => t !== tag.tag
+            ),
+          };
+        }
+
+        // If all tags are removed and mode is not auto, set tagsFilter to null
+        if (
+          newTagsFilter.in.length === 0 &&
+          newTagsFilter.not.length === 0 &&
+          newTagsFilter.mode !== "auto"
+        ) {
+          setValue(`sources.in.${sourceIdx}.tagsFilter`, null);
+        } else {
+          setValue(`sources.in.${sourceIdx}.tagsFilter`, newTagsFilter);
+        }
+      };
+    },
+    [dataSourceViews, sources.in, setValue]
   );
+
+  const { tagsIn, tagsNotIn } = useMemo(() => {
+    return sources.in.reduce(
+      ({ tagsIn, tagsNotIn }, source) => {
+        if (source.type === "data_source") {
+          if (source.tagsFilter !== null) {
+            tagsIn.push(
+              ...source.tagsFilter.in.map((tag) => ({
+                tag,
+                dustAPIDataSourceId:
+                  source.dataSourceView.dataSource.dustAPIDataSourceId,
+                connectorProvider:
+                  source.dataSourceView.dataSource.connectorProvider,
+              }))
+            );
+
+            tagsNotIn.push(
+              ...source.tagsFilter.not.map((tag) => ({
+                tag,
+                dustAPIDataSourceId:
+                  source.dataSourceView.dataSource.dustAPIDataSourceId,
+                connectorProvider:
+                  source.dataSourceView.dataSource.connectorProvider,
+              }))
+            );
+          }
+        }
+
+        return {
+          tagsIn,
+          tagsNotIn,
+        };
+      },
+      { tagsIn: [], tagsNotIn: [] } as {
+        tagsIn: DataSourceTag[];
+        tagsNotIn: DataSourceTag[];
+      }
+    );
+  }, [sources.in]);
 
   return (
     <PopoverRoot>
@@ -49,50 +178,25 @@ export function DataSourceViewTagsFilterDropdown() {
 
           <TagSearchSection
             label="Must-have labels"
-            dataSourceViews={Object.values(dataSourceConfigurations).map(
-              (ds) => ds.dataSourceView
-            )}
+            dataSourceViews={dataSourceViews}
             owner={owner}
             selectedTagsIn={tagsIn}
             selectedTagsNot={tagsNotIn}
-            onTagAdd={(tag) => setTagsIn((prev) => [...prev, tag])}
-            onTagRemove={(tag) =>
-              setTagsIn((prev) => prev.filter((t) => t.tag !== tag.tag))
-            }
+            onTagAdd={handleTagsOperation("in", "add")}
+            onTagRemove={handleTagsOperation("in", "remove")}
             operation="in"
           />
 
           <TagSearchSection
             label="Must-not-have labels"
-            dataSourceViews={Object.values(dataSourceConfigurations).map(
-              (ds) => ds.dataSourceView
-            )}
+            dataSourceViews={dataSourceViews}
             owner={owner}
             selectedTagsIn={tagsIn}
             selectedTagsNot={tagsNotIn}
-            onTagAdd={(tag) => setTagsNotIn((prev) => [...prev, tag])}
-            onTagRemove={(tag) =>
-              setTagsNotIn((prev) => prev.filter((t) => t.tag !== tag.tag))
-            }
+            onTagAdd={handleTagsOperation("not", "add")}
+            onTagRemove={handleTagsOperation("not", "remove")}
             operation="not"
           />
-
-          <div className="flex flex-col gap-2">
-            <Page.SectionHeader
-              title="In-conversation filtering"
-              description="Allow agents to determine filters to apply based on conversation context."
-            />
-          </div>
-          <div className="flex flex-row items-center gap-2">
-            {/* <SliderToggle */}
-            {/*   selected={tagsFilter?.mode === "auto"} */}
-            {/*   onClick={() => { */}
-            {/*     handleAutoFilter(tagsFilter?.mode !== "auto"); */}
-            {/*   }} */}
-            {/*   size="xs" */}
-            {/* /> */}
-            <Label>Enable in-conversation filtering</Label>
-          </div>
         </div>
       </PopoverContent>
     </PopoverRoot>

--- a/front/components/agent_builder/capabilities/shared/ProcessingMethodSection.tsx
+++ b/front/components/agent_builder/capabilities/shared/ProcessingMethodSection.tsx
@@ -129,11 +129,10 @@ export function ProcessingMethodSection() {
               ))}
           </DropdownMenuContent>
         </DropdownMenu>
-
-        {!hasOnlyTablesSelected && hasSomeTablesSelected && (
-          <Chip color="info" size="sm" label=" Your tables will be ignored " />
-        )}
       </div>
+      {!hasOnlyTablesSelected && hasSomeTablesSelected && (
+        <Chip color="info" size="sm" label=" Your tables will be ignored " />
+      )}
     </div>
   );
 }

--- a/front/components/agent_builder/capabilities/shared/SelectDataSourcesFilters.tsx
+++ b/front/components/agent_builder/capabilities/shared/SelectDataSourcesFilters.tsx
@@ -5,6 +5,7 @@ import { DataSourceViewTagsFilterDropdown } from "@app/components/agent_builder/
 import type { CapabilityFormData } from "@app/components/agent_builder/types";
 import { useTheme } from "@app/components/sparkle/ThemeContext";
 import { getConnectorProviderLogoWithFallback } from "@app/lib/connector_providers";
+import { getDisplayNameForDataSource } from "@app/lib/data_sources";
 import type { DataSourceViewType } from "@app/types";
 
 export function SelectDataSourcesFilters() {
@@ -39,7 +40,7 @@ export function SelectDataSourcesFilters() {
             {Object.values(dataSourceViews).map((dsv) => (
               <ContextItem
                 key={dsv.id}
-                title={dsv.dataSource.name}
+                title={getDisplayNameForDataSource(dsv.dataSource)}
                 visual={
                   <ContextItem.Visual
                     visual={getConnectorProviderLogoWithFallback({

--- a/front/components/agent_builder/capabilities/shared/SelectDataSourcesFilters.tsx
+++ b/front/components/agent_builder/capabilities/shared/SelectDataSourcesFilters.tsx
@@ -1,29 +1,84 @@
-import { ContextItem } from "@dust-tt/sparkle";
+import { ContextItem, SliderToggle, Tooltip } from "@dust-tt/sparkle";
 import { useWatch } from "react-hook-form";
 
 import { DataSourceViewTagsFilterDropdown } from "@app/components/agent_builder/capabilities/shared/DataSourceViewTagsFilterDropdown";
 import type { CapabilityFormData } from "@app/components/agent_builder/types";
+import { useDataSourceBuilderContext } from "@app/components/data_source_view/context/DataSourceBuilderContext";
 import { useTheme } from "@app/components/sparkle/ThemeContext";
 import { getConnectorProviderLogoWithFallback } from "@app/lib/connector_providers";
 import { getDisplayNameForDataSource } from "@app/lib/data_sources";
-import type { DataSourceViewType } from "@app/types";
+import type { DataSourceViewType, TagsFilter } from "@app/types";
+
+type DataSourceFilterItem = {
+  mode: NonNullable<TagsFilter>["mode"];
+  dataSourceView: DataSourceViewType;
+};
+
+type DataSourceFilterContextItemProps = {
+  item: DataSourceFilterItem;
+};
+
+function DataSourceFilterContextItem({
+  item: { dataSourceView, mode },
+}: DataSourceFilterContextItemProps) {
+  const { isDark } = useTheme();
+  const { toggleTagsMode } = useDataSourceBuilderContext();
+
+  return (
+    <ContextItem
+      key={dataSourceView.id}
+      title={getDisplayNameForDataSource(dataSourceView.dataSource)}
+      visual={
+        <ContextItem.Visual
+          visual={getConnectorProviderLogoWithFallback({
+            provider: dataSourceView.dataSource.connectorProvider,
+            isDark,
+          })}
+        />
+      }
+      action={
+        <Tooltip
+          align="end"
+          trigger={
+            <SliderToggle
+              selected={mode === "auto"}
+              onClick={() => toggleTagsMode(dataSourceView)}
+            />
+          }
+          label={
+            <div>
+              Enable in-conversation filtering
+              <div className="text-muted-foreground dark:text-muted-foreground-night">
+                Allow agents to determine filters to apply based on conversation
+                context.
+              </div>
+            </div>
+          }
+        />
+      }
+    />
+  );
+}
 
 export function SelectDataSourcesFilters() {
-  const { isDark } = useTheme();
   const sources = useWatch<CapabilityFormData, "sources">({ name: "sources" });
   const dataSourceViews = sources.in.reduce(
     (acc, source) => {
       if (source.type === "data_source") {
-        acc[source.dataSourceView.dataSource.dustAPIDataSourceId] =
-          source.dataSourceView;
+        acc[source.dataSourceView.dataSource.dustAPIDataSourceId] = {
+          dataSourceView: source.dataSourceView,
+          mode: source.tagsFilter?.mode ?? "custom",
+        };
       } else if (source.type === "node") {
-        acc[source.node.dataSourceView.dataSource.dustAPIDataSourceId] =
-          source.node.dataSourceView;
+        acc[source.node.dataSourceView.dataSource.dustAPIDataSourceId] = {
+          dataSourceView: source.node.dataSourceView,
+          mode: source.tagsFilter?.mode ?? "custom",
+        };
       }
 
       return acc;
     },
-    {} as Record<string, DataSourceViewType>
+    {} as Record<string, DataSourceFilterItem>
   );
 
   return (
@@ -37,18 +92,10 @@ export function SelectDataSourcesFilters() {
       <div>
         <div className="rounded-xl bg-muted dark:bg-muted-night">
           <ContextItem.List className="max-h-40 overflow-x-scroll">
-            {Object.values(dataSourceViews).map((dsv) => (
-              <ContextItem
-                key={dsv.id}
-                title={getDisplayNameForDataSource(dsv.dataSource)}
-                visual={
-                  <ContextItem.Visual
-                    visual={getConnectorProviderLogoWithFallback({
-                      provider: dsv.dataSource.connectorProvider,
-                      isDark,
-                    })}
-                  />
-                }
+            {Object.values(dataSourceViews).map((item) => (
+              <DataSourceFilterContextItem
+                key={item.dataSourceView.id}
+                item={item}
               />
             ))}
           </ContextItem.List>

--- a/front/components/agent_builder/capabilities/shared/SelectDataSourcesFilters.tsx
+++ b/front/components/agent_builder/capabilities/shared/SelectDataSourcesFilters.tsx
@@ -11,6 +11,7 @@ import { useWatch } from "react-hook-form";
 
 import { DataSourceViewTagsFilterDropdown } from "@app/components/agent_builder/capabilities/shared/DataSourceViewTagsFilterDropdown";
 import type { CapabilityFormData } from "@app/components/agent_builder/types";
+import { CONFIGURATION_SHEET_PAGE_IDS } from "@app/components/agent_builder/types";
 import { useDataSourceBuilderContext } from "@app/components/data_source_view/context/DataSourceBuilderContext";
 import { useTheme } from "@app/components/sparkle/ThemeContext";
 import { getConnectorProviderLogoWithFallback } from "@app/lib/connector_providers";
@@ -71,6 +72,7 @@ function DataSourceFilterContextItem({
 }
 
 export function SelectDataSourcesFilters() {
+  const { setSheetPageId } = useDataSourceBuilderContext();
   const sources = useWatch<CapabilityFormData, "sources">({ name: "sources" });
   const dataSourceViews = sources.in.reduce(
     (acc, source) => {
@@ -96,7 +98,15 @@ export function SelectDataSourcesFilters() {
       <div className="align-center flex flex-row justify-between">
         <h3 className="mb-2 text-lg font-semibold">Selected data source</h3>
 
-        <DataSourceViewTagsFilterDropdown />
+        <div className="flex flex-row items-center space-x-2">
+          <Button
+            label="Manage selection"
+            onClick={() =>
+              setSheetPageId(CONFIGURATION_SHEET_PAGE_IDS.DATA_SOURCE_SELECTION)
+            }
+          />
+          <DataSourceViewTagsFilterDropdown />
+        </div>
       </div>
 
       <div>

--- a/front/components/agent_builder/capabilities/shared/SelectDataSourcesFilters.tsx
+++ b/front/components/agent_builder/capabilities/shared/SelectDataSourcesFilters.tsx
@@ -1,4 +1,12 @@
-import { ContextItem, SliderToggle, Tooltip } from "@dust-tt/sparkle";
+import {
+  Button,
+  ContextItem,
+  MoreIcon,
+  PopoverContent,
+  PopoverRoot,
+  PopoverTrigger,
+  SliderToggle,
+} from "@dust-tt/sparkle";
 import { useWatch } from "react-hook-form";
 
 import { DataSourceViewTagsFilterDropdown } from "@app/components/agent_builder/capabilities/shared/DataSourceViewTagsFilterDropdown";
@@ -37,24 +45,26 @@ function DataSourceFilterContextItem({
         />
       }
       action={
-        <Tooltip
-          align="end"
-          trigger={
-            <SliderToggle
-              selected={mode === "auto"}
-              onClick={() => toggleTagsMode(dataSourceView)}
-            />
-          }
-          label={
-            <div>
-              Enable in-conversation filtering
-              <div className="text-muted-foreground dark:text-muted-foreground-night">
-                Allow agents to determine filters to apply based on conversation
-                context.
-              </div>
+        <PopoverRoot>
+          <PopoverTrigger asChild>
+            <Button icon={MoreIcon} variant="ghost" size="mini" />
+          </PopoverTrigger>
+
+          <PopoverContent align="end" className="w-72 text-sm">
+            <div className="mb-1 font-semibold">In-conversation filtering</div>
+            <div className="text-xs text-muted-foreground dark:text-muted-foreground-night">
+              Allow agents to determine filters to apply based on conversation
+              context.
             </div>
-          }
-        />
+            <div className="mt-2 flex flex-row items-center justify-between">
+              <SliderToggle
+                selected={mode === "auto"}
+                onClick={() => toggleTagsMode(dataSourceView)}
+              />
+              <div className="font-medium">Enable in converation filtering</div>
+            </div>
+          </PopoverContent>
+        </PopoverRoot>
       }
     />
   );

--- a/front/components/agent_builder/capabilities/shared/SelectDataSourcesFilters.tsx
+++ b/front/components/agent_builder/capabilities/shared/SelectDataSourcesFilters.tsx
@@ -1,0 +1,49 @@
+import { ContextItem } from "@dust-tt/sparkle";
+import { useWatch } from "react-hook-form";
+
+import { DataSourceViewTagsFilterDropdown } from "@app/components/agent_builder/capabilities/shared/DataSourceViewTagsFilterDropdown";
+import type { CapabilityFormData } from "@app/components/agent_builder/types";
+import type { DataSourceBuilderTreeItemType } from "@app/components/data_source_view/context/types";
+import { getVisualForTreeItem } from "@app/components/data_source_view/context/utils";
+import { useTheme } from "@app/components/sparkle/ThemeContext";
+
+function KnowledgeFooterItem({
+  item,
+}: {
+  item: DataSourceBuilderTreeItemType;
+}) {
+  const { isDark } = useTheme();
+  const VisualComponent = getVisualForTreeItem(item, isDark);
+
+  return (
+    <ContextItem
+      key={item.path}
+      title={item.name}
+      visual={<ContextItem.Visual visual={VisualComponent} />}
+    />
+  );
+}
+
+export function SelectDataSourcesFilters() {
+  const sources = useWatch<CapabilityFormData, "sources">({ name: "sources" });
+
+  return (
+    <div className="space-y-4">
+      <div className="align-center flex flex-row justify-between">
+        <h3 className="mb-2 text-lg font-semibold">Selected data source</h3>
+
+        <DataSourceViewTagsFilterDropdown />
+      </div>
+
+      <div>
+        <div className="rounded-xl bg-muted dark:bg-muted-night">
+          <ContextItem.List className="max-h-40 overflow-x-scroll">
+            {sources.in.map((item) => (
+              <KnowledgeFooterItem key={item.path} item={item} />
+            ))}
+          </ContextItem.List>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/front/components/assistant_builder/tags/TagSearchInput.tsx
+++ b/front/components/assistant_builder/tags/TagSearchInput.tsx
@@ -59,6 +59,14 @@ export const TagSearchInput = ({
                     onTagAdd(tag);
                     setSearchInputValue("");
                   }}
+                  icon={
+                    showChipIcons
+                      ? getConnectorProviderLogoWithFallback({
+                          provider: tag.connectorProvider,
+                          isDark,
+                        })
+                      : undefined
+                  }
                 />
               </div>
             ))}

--- a/front/components/assistant_builder/tags/TagSearchInput.tsx
+++ b/front/components/assistant_builder/tags/TagSearchInput.tsx
@@ -6,6 +6,8 @@ import {
   Spinner,
 } from "@dust-tt/sparkle";
 
+import { useTheme } from "@app/components/sparkle/ThemeContext";
+import { getConnectorProviderLogoWithFallback } from "@app/lib/connector_providers";
 import type { DataSourceTag } from "@app/types";
 
 export interface TagSearchProps {
@@ -18,6 +20,7 @@ export interface TagSearchProps {
   tagChipColor?: "primary" | "warning";
   isLoading: boolean;
   disabled?: boolean;
+  showChipIcons?: boolean;
 }
 
 export const TagSearchInput = ({
@@ -30,7 +33,9 @@ export const TagSearchInput = ({
   tagChipColor = "primary",
   isLoading,
   disabled = false,
+  showChipIcons = false,
 }: TagSearchProps) => {
+  const { isDark } = useTheme();
   return (
     <div className="flex flex-col gap-3">
       <SearchDropdownMenu
@@ -74,6 +79,14 @@ export const TagSearchInput = ({
             onRemove={() => onTagRemove(tag)}
             color={tagChipColor}
             size="xs"
+            icon={
+              showChipIcons
+                ? getConnectorProviderLogoWithFallback({
+                    provider: tag.connectorProvider,
+                    isDark,
+                  })
+                : undefined
+            }
           />
         ))}
       </div>

--- a/front/components/assistant_builder/tags/TagSearchSection.tsx
+++ b/front/components/assistant_builder/tags/TagSearchSection.tsx
@@ -60,17 +60,23 @@ export function TagSearchSection({
           );
 
         if (!isTagUsed) {
+          // Find the corresponding dataSourceView to get the connectorProvider
+          const dataSourceView = dataSourceViews.find(
+            (dsv) => dsv.dataSource.dustAPIDataSourceId === dataSourceId
+          );
+
           formattedTags.push({
             tag: tag.tag,
             dustAPIDataSourceId: dataSourceId,
-            connectorProvider: null,
+            connectorProvider:
+              dataSourceView?.dataSource.connectorProvider || null,
           });
         }
       }
     }
 
     setAvailableTags(formattedTags);
-  }, [rawTags, selectedTagsIn, selectedTagsNot]);
+  }, [dataSourceViews, rawTags, selectedTagsIn, selectedTagsNot]);
 
   // Debounce the search input.
   useEffect(() => {

--- a/front/components/assistant_builder/tags/TagSearchSection.tsx
+++ b/front/components/assistant_builder/tags/TagSearchSection.tsx
@@ -18,6 +18,7 @@ interface TagSearchSectionProps {
   owner: LightWorkspaceType;
   selectedTagsIn: DataSourceTag[];
   selectedTagsNot: DataSourceTag[];
+  showChipIcons?: boolean;
 }
 
 export function TagSearchSection({
@@ -29,6 +30,7 @@ export function TagSearchSection({
   owner,
   selectedTagsIn,
   selectedTagsNot,
+  showChipIcons,
 }: TagSearchSectionProps) {
   const [searchInputValue, setSearchInputValue] = useState<string>("");
   const [debouncedQuery, setDebouncedQuery] = useState<string>("");
@@ -107,6 +109,7 @@ export function TagSearchSection({
         onTagRemove={onTagRemove}
         tagChipColor={tagChipColor}
         isLoading={isLoading}
+        showChipIcons={showChipIcons}
       />
     </div>
   );

--- a/front/components/data_source_view/context/DataSourceBuilderContext.tsx
+++ b/front/components/data_source_view/context/DataSourceBuilderContext.tsx
@@ -150,6 +150,8 @@ type DataSourceBuilderState = StateType & {
    * Update the `tagsFilter` of the given `sources` index
    */
   updateSourcesTags: (index: number, tagsFilter: TagsFilter) => void;
+
+  toggleTagsMode: (dataSourceView: DataSourceViewType) => void;
 };
 
 type ActionType =
@@ -421,6 +423,46 @@ export function DataSourceBuilderProvider({
       [field]
     );
 
+  const toggleTagsMode: DataSourceBuilderState["toggleTagsMode"] = useCallback(
+    (dataSourceView) => {
+      field.onChange({
+        ...field.value,
+        in: field.value.in.map((source) => {
+          // Check if this source matches the given dataSourceView
+          const isMatchingSource =
+            (source.type === "data_source" &&
+              source.dataSourceView.sId === dataSourceView.sId) ||
+            (source.type === "node" &&
+              source.node.dataSourceView.sId === dataSourceView.sId);
+
+          if (isMatchingSource && "tagsFilter" in source) {
+            // Initialize tagsFilter if null
+            const currentTagsFilter = source.tagsFilter || {
+              in: [],
+              not: [],
+              mode: "custom" as const,
+            };
+
+            // Toggle between "auto" and "custom" modes
+            const newMode =
+              currentTagsFilter.mode === "auto" ? "custom" : "auto";
+
+            return {
+              ...source,
+              tagsFilter: {
+                ...currentTagsFilter,
+                mode: newMode,
+              },
+            };
+          }
+
+          return source;
+        }),
+      });
+    },
+    [field]
+  );
+
   const value = useMemo(
     () => ({
       ...state,
@@ -438,6 +480,7 @@ export function DataSourceBuilderProvider({
       addNodeEntry,
       navigateTo,
       updateSourcesTags,
+      toggleTagsMode,
     }),
     [
       state,
@@ -455,6 +498,7 @@ export function DataSourceBuilderProvider({
       setSpaceEntry,
       setDataSourceViewEntry,
       updateSourcesTags,
+      toggleTagsMode,
     ]
   );
 

--- a/front/components/data_source_view/context/DataSourceBuilderContext.tsx
+++ b/front/components/data_source_view/context/DataSourceBuilderContext.tsx
@@ -200,7 +200,7 @@ function dataSourceBuilderReducer(
         ...state,
         navigationHistory: [
           ...state.navigationHistory,
-          { type: "node", node: payload.node },
+          { type: "node", node: payload.node, tagsFilter: null },
         ],
       };
     }
@@ -215,7 +215,11 @@ function dataSourceBuilderReducer(
         ...state,
         navigationHistory: [
           ...state.navigationHistory.slice(0, 3),
-          { type: "data_source", dataSourceView: payload.dataSourceView },
+          {
+            type: "data_source",
+            dataSourceView: payload.dataSourceView,
+            tagsFilter: null,
+          },
         ],
       };
     }

--- a/front/components/data_source_view/context/DataSourceBuilderContext.tsx
+++ b/front/components/data_source_view/context/DataSourceBuilderContext.tsx
@@ -38,6 +38,7 @@ import {
   useReducer,
 } from "react";
 
+import type { ConfigurationPagePageId } from "@app/components/agent_builder/types";
 import { useSourcesFormController } from "@app/components/agent_builder/utils";
 import type {
   DataSourceBuilderTreeItemType,
@@ -68,6 +69,7 @@ type StateType = {
    * so in this case we can use index to update specific values
    */
   navigationHistory: NavigationHistoryEntryType[];
+  currentPageId: ConfigurationPagePageId;
 };
 
 type DataSourceBuilderState = StateType & {
@@ -152,6 +154,8 @@ type DataSourceBuilderState = StateType & {
   updateSourcesTags: (index: number, tagsFilter: TagsFilter) => void;
 
   toggleTagsMode: (dataSourceView: DataSourceViewType) => void;
+
+  setSheetPageId: (pageId: ConfigurationPagePageId) => void;
 };
 
 type ActionType =
@@ -174,6 +178,10 @@ type ActionType =
   | {
       type: "NAVIGATION_NAVIGATE_TO";
       payload: { index: number };
+    }
+  | {
+      type: "SET_SHEET_CURRENT_PAGE";
+      payload: { pageId: ConfigurationPagePageId };
     };
 
 const DataSourceBuilderContext = createContext<
@@ -231,6 +239,12 @@ function dataSourceBuilderReducer(
         ],
       };
     }
+    case "SET_SHEET_CURRENT_PAGE": {
+      return {
+        ...state,
+        currentPageId: payload.pageId,
+      };
+    }
     default:
       assertNever(type);
   }
@@ -238,14 +252,17 @@ function dataSourceBuilderReducer(
 
 export function DataSourceBuilderProvider({
   spaces,
+  initialPageId,
   children,
 }: {
   spaces: SpaceType[];
+  initialPageId: ConfigurationPagePageId;
   children: React.ReactNode;
 }) {
   const { field } = useSourcesFormController();
   const [state, dispatch] = useReducer(dataSourceBuilderReducer, {
     navigationHistory: [{ type: "root" }],
+    currentPageId: initialPageId,
   });
 
   const selectNode: DataSourceBuilderState["selectNode"] = useCallback(
@@ -463,6 +480,13 @@ export function DataSourceBuilderProvider({
     [field]
   );
 
+  const setSheetPageId: DataSourceBuilderState["setSheetPageId"] = useCallback(
+    (pageId) => {
+      dispatch({ type: "SET_SHEET_CURRENT_PAGE", payload: { pageId } });
+    },
+    []
+  );
+
   const value = useMemo(
     () => ({
       ...state,
@@ -481,6 +505,7 @@ export function DataSourceBuilderProvider({
       navigateTo,
       updateSourcesTags,
       toggleTagsMode,
+      setSheetPageId,
     }),
     [
       state,
@@ -499,6 +524,7 @@ export function DataSourceBuilderProvider({
       setDataSourceViewEntry,
       updateSourcesTags,
       toggleTagsMode,
+      setSheetPageId,
     ]
   );
 

--- a/front/components/data_source_view/context/DataSourceBuilderContext.tsx
+++ b/front/components/data_source_view/context/DataSourceBuilderContext.tsx
@@ -58,6 +58,7 @@ import type {
   DataSourceViewContentNode,
   DataSourceViewType,
   SpaceType,
+  TagsFilter,
 } from "@app/types";
 import { assertNever } from "@app/types";
 
@@ -144,6 +145,11 @@ type DataSourceBuilderState = StateType & {
    * Navigate to a specific node
    */
   navigateTo: (index: number) => void;
+
+  /**
+   * Update the `tagsFilter` of the given `sources` index
+   */
+  updateSourcesTags: (index: number, tagsFilter: TagsFilter) => void;
 };
 
 type ActionType =
@@ -395,6 +401,26 @@ export function DataSourceBuilderProvider({
     []
   );
 
+  const updateSourcesTags: DataSourceBuilderState["updateSourcesTags"] =
+    useCallback(
+      (index, tagsFilter) => {
+        field.onChange({
+          ...field.value,
+          in: field.value.in.map((source, i) => {
+            if (i === index) {
+              return {
+                ...source,
+                tagsFilter,
+              };
+            }
+
+            return source;
+          }),
+        });
+      },
+      [field]
+    );
+
   const value = useMemo(
     () => ({
       ...state,
@@ -411,6 +437,7 @@ export function DataSourceBuilderProvider({
       setDataSourceViewEntry,
       addNodeEntry,
       navigateTo,
+      updateSourcesTags,
     }),
     [
       state,
@@ -427,6 +454,7 @@ export function DataSourceBuilderProvider({
       setCategoryEntry,
       setSpaceEntry,
       setDataSourceViewEntry,
+      updateSourcesTags,
     ]
   );
 

--- a/front/components/data_source_view/context/types.ts
+++ b/front/components/data_source_view/context/types.ts
@@ -7,6 +7,12 @@ import type {
   SpaceType,
 } from "@app/types";
 
+const tagsFilter = z.object({
+  in: z.string().array(),
+  not: z.string().array(),
+  mode: z.union([z.literal("custom"), z.literal("auto")]),
+});
+
 const navigationHistoryEntry = z.discriminatedUnion("type", [
   z.object({ type: z.literal("root") }),
   z.object({ type: z.literal("space"), space: z.custom<SpaceType>() }),
@@ -17,10 +23,12 @@ const navigationHistoryEntry = z.discriminatedUnion("type", [
   z.object({
     type: z.literal("data_source"),
     dataSourceView: z.custom<DataSourceViewType>(),
+    tagsFilter: tagsFilter.nullable(),
   }),
   z.object({
     type: z.literal("node"),
     node: z.custom<DataSourceViewContentNode>(),
+    tagsFilter: tagsFilter.nullable(),
   }),
 ]);
 


### PR DESCRIPTION
## Description
https://github.com/dust-tt/tasks/issues/3885
- Adds tag filtering capabilities to knowledge selection in Agent Builder v2. Users can now filter data sources based on tags, with support for must-have and must-not-have labels. Instead of visually being set per data sources, there is a global tags search, which then set the tag filters to the correct data source.
- For now the `mode = auto` has be removed from the popover as it cannot be set globally.
- Add options to show the icons in the tags search chips
- Add "Manage Selection" button to navigate back

<img width="755" height="265" alt="Capture d’écran 2025-08-25 à 16 31 01" src="https://github.com/user-attachments/assets/e29f457c-db7a-4a64-b174-d964475ee4e0" />
<img width="750" height="415" alt="Capture d’écran 2025-08-25 à 16 31 05" src="https://github.com/user-attachments/assets/32de31bb-6d29-4d1d-a45b-405af310d439" />

## Tests
- Locally

## Risk
- Low, behind FF, just UI/filtering works.

## Deploy Plan
- Deploy front
