### PR TITLE
[front] - chore: update @dust-tt/sparkle library to version 0.2.588

### DIFF
--- a/extension/package-lock.json
+++ b/extension/package-lock.json
@@ -12,7 +12,7 @@
         "@auth0/auth0-spa-js": "^2.1.3",
         "@datadog/browser-logs": "^6.13.0",
         "@dust-tt/client": "^1.1.6",
-        "@dust-tt/sparkle": "^0.2.587",
+        "@dust-tt/sparkle": "^0.2.588",
         "@frontapp/plugin-sdk": "^1.8.1",
         "@modelcontextprotocol/sdk": "^1.9.0",
         "@tailwindcss/forms": "^0.5.9",
@@ -1293,9 +1293,9 @@
       }
     },
     "node_modules/@dust-tt/sparkle": {
-      "version": "0.2.587",
-      "resolved": "https://registry.npmjs.org/@dust-tt/sparkle/-/sparkle-0.2.587.tgz",
-      "integrity": "sha512-+jKtrugk3kxQCtmaSdpLL6ZbBPIerr2VcbKhcXvq7M1uRmoscYdfAaHjpwsvUYAZaEfKjH3aye4LxG+qqmWnCQ==",
+      "version": "0.2.588",
+      "resolved": "https://registry.npmjs.org/@dust-tt/sparkle/-/sparkle-0.2.588.tgz",
+      "integrity": "sha512-A2z0AmAFrzPbvGeXjzhLj0Fl+qseO3rH6LeAa7hkJDGHQ31NRtsY5xcffcSzY7DoMcLSr1Fpfb/wzc1BqEq5gg==",
       "dependencies": {
         "@emoji-mart/data": "^1.1.2",
         "@emoji-mart/react": "^1.1.1",

--- a/extension/package.json
+++ b/extension/package.json
@@ -59,7 +59,7 @@
     "@auth0/auth0-spa-js": "^2.1.3",
     "@datadog/browser-logs": "^6.13.0",
     "@dust-tt/client": "^1.1.6",
-    "@dust-tt/sparkle": "^0.2.587",
+    "@dust-tt/sparkle": "^0.2.588",
     "@frontapp/plugin-sdk": "^1.8.1",
     "@modelcontextprotocol/sdk": "^1.9.0",
     "@tailwindcss/forms": "^0.5.9",

--- a/front/components/agent_builder/capabilities/mcp/MCPServerSelectionPage.tsx
+++ b/front/components/agent_builder/capabilities/mcp/MCPServerSelectionPage.tsx
@@ -1,13 +1,4 @@
-import {
-  ActionIcons,
-  BookOpenIcon,
-  Button,
-  Card,
-  Chip,
-  cn,
-  Icon,
-  PlusIcon,
-} from "@dust-tt/sparkle";
+import { ActionIcons, BookOpenIcon, ToolCard } from "@dust-tt/sparkle";
 import React, { useMemo } from "react";
 
 import { useAgentBuilderFormActions } from "@app/components/agent_builder/AgentBuilderFormContext";
@@ -30,75 +21,6 @@ import { getMCPServerRequirements } from "@app/lib/actions/mcp_internal_actions/
 import type { MCPServerViewType } from "@app/lib/api/mcp";
 import { removeNulls } from "@app/types";
 
-const FADE_TRANSITION_CLASSES = "transition-opacity duration-300 ease-in-out";
-
-interface BaseToolCardProps {
-  icon: React.ComponentType;
-  label: string;
-  description: string;
-  isSelected: boolean;
-  canAdd: boolean;
-  cantAddReason?: string;
-  onClick: () => void;
-}
-
-function BaseToolCard({
-  icon,
-  label,
-  description,
-  isSelected,
-  canAdd,
-  cantAddReason,
-  onClick,
-}: BaseToolCardProps) {
-  return (
-    <Card
-      variant={isSelected ? "secondary" : "primary"}
-      onClick={canAdd ? onClick : undefined}
-      disabled={!canAdd}
-      className="h-24 p-3"
-    >
-      <div className="flex h-full w-full items-center justify-between gap-3">
-        <div className="flex-1">
-          <div className="mb-2 flex items-center gap-2">
-            <Icon visual={icon} size="sm" />
-            <span className="text-sm font-medium">{label}</span>
-            {isSelected && (
-              <Chip
-                size="xs"
-                color="green"
-                label="ADDED"
-                className={cn(FADE_TRANSITION_CLASSES, "opacity-100")}
-              />
-            )}
-          </div>
-          <div className="line-clamp-2 text-xs text-gray-600">
-            {description}
-          </div>
-        </div>
-
-        <div className="flex-shrink-0">
-          {canAdd ? (
-            <Button
-              size="xs"
-              variant="outline"
-              icon={PlusIcon}
-              label="Add"
-              className={cn(FADE_TRANSITION_CLASSES, "opacity-100")}
-            />
-          ) : (
-            cantAddReason && (
-              <div className="text-xs italic text-gray-600">
-                {cantAddReason}
-              </div>
-            )
-          )}
-        </div>
-      </div>
-    </Card>
-  );
-}
-
 interface DataVisualizationCardProps {
   specification: ActionSpecification;
   isSelected: boolean;
@@ -111,7 +33,7 @@ function DataVisualizationCard({
   onClick,
 }: DataVisualizationCardProps) {
   return (
-    <BaseToolCard
+    <ToolCard
       icon={specification.dropDownIcon}
       label={specification.label}
       description={specification.description}
@@ -144,7 +66,7 @@ function MCPServerCard({
     : InternalActionIcons[view.server.icon] || BookOpenIcon;
 
   return (
-    <BaseToolCard
+    <ToolCard
       icon={icon}
       label={view.label}
       description={getMcpServerViewDescription(view)}

--- a/front/components/agent_builder/instructions/InstructionsTipsPopover.tsx
+++ b/front/components/agent_builder/instructions/InstructionsTipsPopover.tsx
@@ -134,7 +134,7 @@ export function InstructionTipsPopover({ owner }: InstructionTipsPopoverProps) {
           size="sm"
           icon={LightbulbIcon}
           aria-label="View instruction tips"
-          pulseOnce={shouldPulse}
+          briefPulse={shouldPulse}
         />
       </PopoverTrigger>
       <PopoverContent className="w-80 p-4" side="bottom" align="start">

--- a/front/package-lock.json
+++ b/front/package-lock.json
@@ -7,7 +7,7 @@
       "dependencies": {
         "@datadog/browser-logs": "^6.13.0",
         "@dust-tt/client": "file:../sdks/js",
-        "@dust-tt/sparkle": "^0.2.587",
+        "@dust-tt/sparkle": "^0.2.588",
         "@google-cloud/bigquery": "^7.9.1",
         "@google-cloud/storage-transfer": "^3.6.0",
         "@heroicons/react": "^2.0.11",
@@ -1113,9 +1113,9 @@
       "link": true
     },
     "node_modules/@dust-tt/sparkle": {
-      "version": "0.2.587",
-      "resolved": "https://registry.npmjs.org/@dust-tt/sparkle/-/sparkle-0.2.587.tgz",
-      "integrity": "sha512-+jKtrugk3kxQCtmaSdpLL6ZbBPIerr2VcbKhcXvq7M1uRmoscYdfAaHjpwsvUYAZaEfKjH3aye4LxG+qqmWnCQ==",
+      "version": "0.2.588",
+      "resolved": "https://registry.npmjs.org/@dust-tt/sparkle/-/sparkle-0.2.588.tgz",
+      "integrity": "sha512-A2z0AmAFrzPbvGeXjzhLj0Fl+qseO3rH6LeAa7hkJDGHQ31NRtsY5xcffcSzY7DoMcLSr1Fpfb/wzc1BqEq5gg==",
       "dependencies": {
         "@emoji-mart/data": "^1.1.2",
         "@emoji-mart/react": "^1.1.1",

--- a/front/package.json
+++ b/front/package.json
@@ -24,7 +24,7 @@
   "dependencies": {
     "@datadog/browser-logs": "^6.13.0",
     "@dust-tt/client": "file:../sdks/js",
-    "@dust-tt/sparkle": "^0.2.587",
+    "@dust-tt/sparkle": "^0.2.588",
     "@google-cloud/bigquery": "^7.9.1",
     "@google-cloud/storage-transfer": "^3.6.0",
     "@heroicons/react": "^2.0.11",


### PR DESCRIPTION
## Description

This PR:
 - Introduce the new `ToolCard` component in MCP server selection to replace the `BaseCard`
 - Adjust `InstructionTipsPopover` to use `briefPulse` instead of `pulseOnce` for the icon property

## Tests

Locally

## Risk

Low

## Deploy Plan

Deploy front