### PR TITLE
[front] - chore(AB v2): slack settings sheet

### DIFF
--- a/front/components/agent_builder/instructions/AdvancedSettings.tsx
+++ b/front/components/agent_builder/instructions/AdvancedSettings.tsx
@@ -87,7 +87,7 @@ export function AdvancedSettings() {
         <DropdownMenuTrigger asChild>
           <Button label="Advanced" variant="outline" size="sm" isSelect />
         </DropdownMenuTrigger>
-        <DropdownMenuContent align="end">
+        <DropdownMenuContent align="start">
           <ModelSelectionSubmenu models={models} />
 
           <CreativityLevelSubmenu />

--- a/front/components/agent_builder/instructions/AgentBuilderInstructionsEditor.tsx
+++ b/front/components/agent_builder/instructions/AgentBuilderInstructionsEditor.tsx
@@ -26,7 +26,7 @@ export const INSTRUCTIONS_MAXIMUM_CHARACTER_COUNT = 120_000;
 
 const editorVariants = cva(
   [
-    "overflow-auto border rounded-xl p-2 resize-y min-h-60 h-100",
+    "overflow-auto border rounded-xl p-2 resize-y min-h-60 max-h-[1024px]",
     "transition-all duration-200",
     "bg-muted-background dark:bg-muted-background-night",
   ],

--- a/front/components/agent_builder/settings/SlackSettingsSheet.tsx
+++ b/front/components/agent_builder/settings/SlackSettingsSheet.tsx
@@ -1,5 +1,9 @@
 import {
+  Button,
+  Checkbox,
+  ExternalLinkIcon,
   Icon,
+  SearchInput,
   Sheet,
   SheetContainer,
   SheetContent,
@@ -8,6 +12,7 @@ import {
   SheetHeader,
   SheetTitle,
   SlackLogo,
+  Spinner,
 } from "@dust-tt/sparkle";
 import React, { useCallback, useEffect, useMemo, useState } from "react";
 import { useController } from "react-hook-form";
@@ -15,114 +20,165 @@ import { useController } from "react-hook-form";
 import { useAgentBuilderContext } from "@app/components/agent_builder/AgentBuilderContext";
 import type { AgentBuilderFormData } from "@app/components/agent_builder/AgentBuilderFormContext";
 import { useDataSourceViewsContext } from "@app/components/agent_builder/DataSourceViewsContext";
-import type { ContentNodeTreeItemStatus } from "@app/components/ContentNodeTree";
-import { ContentNodeTree } from "@app/components/ContentNodeTree";
 import { useConnectorPermissions } from "@app/lib/swr/connectors";
-import type { ContentNode, DataSourceType, WorkspaceType } from "@app/types";
+import type { DataSourceType, WorkspaceType } from "@app/types";
 
-export type SlackChannel = { slackChannelId: string; slackChannelName: string };
+const SLACK_CHANNEL_INTERNAL_ID_PREFIX = "slack-channel-";
 
-const getUseResourceHook =
-  (owner: WorkspaceType, slackDataSource: DataSourceType) =>
-  (parentId: string | null) =>
-    useConnectorPermissions({
-      dataSource: slackDataSource,
-      filterPermission: "write",
-      owner,
-      parentId,
-      viewType: "all",
-    });
+export type SlackChannel = {
+  slackChannelId: string;
+  slackChannelName: string;
+  sourceUrl?: string | null;
+};
 
-interface SlackIntegrationProps {
+interface SlackChannelsListProps {
   existingSelection: SlackChannel[];
   onSelectionChange: (channels: SlackChannel[]) => void;
   owner: WorkspaceType;
   slackDataSource: DataSourceType;
 }
 
-function SlackIntegration({
+function SlackChannelsList({
   existingSelection,
   onSelectionChange,
   owner,
   slackDataSource,
-}: SlackIntegrationProps) {
-  const [newSelection, setNewSelection] = useState<SlackChannel[]>([]);
-  useEffect(() => {
-    if (existingSelection.length > 0) {
-      setNewSelection(existingSelection);
-    }
-  }, [existingSelection]);
+}: SlackChannelsListProps) {
+  const [searchQuery, setSearchQuery] = useState("");
 
-  const customIsNodeChecked = useCallback(
-    (node: ContentNode) => {
-      const channelId = node.internalId.substring("slack-channel-".length);
-      return newSelection?.some((c) => c.slackChannelId === channelId) || false;
+  const { resources, isResourcesLoading, isResourcesError } =
+    useConnectorPermissions({
+      dataSource: slackDataSource,
+      filterPermission: "write",
+      owner,
+      parentId: null,
+      viewType: "all",
+    });
+
+  const filteredChannels = useMemo(() => {
+    if (!resources) {
+      return [];
+    }
+
+    return resources
+      .filter((resource) =>
+        resource.internalId.startsWith(SLACK_CHANNEL_INTERNAL_ID_PREFIX)
+      )
+      .map((resource) => ({
+        slackChannelId: resource.internalId.substring(
+          SLACK_CHANNEL_INTERNAL_ID_PREFIX.length
+        ),
+        slackChannelName: resource.title,
+        sourceUrl: resource.sourceUrl,
+      }))
+      .filter(
+        (channel) =>
+          searchQuery.trim() === "" ||
+          channel.slackChannelName
+            .toLowerCase()
+            .includes(searchQuery.toLowerCase())
+      );
+  }, [resources, searchQuery]);
+
+  const handleChannelToggle = useCallback(
+    (channel: SlackChannel, isChecked?: boolean) => {
+      const currentlySelected = existingSelection.some(
+        (c) => c.slackChannelId === channel.slackChannelId
+      );
+      const shouldSelect = isChecked ?? !currentlySelected;
+
+      if (shouldSelect) {
+        const channelForSelection: SlackChannel = {
+          slackChannelId: channel.slackChannelId,
+          slackChannelName: channel.slackChannelName,
+          sourceUrl: channel.sourceUrl,
+        };
+        onSelectionChange([...existingSelection, channelForSelection]);
+      } else {
+        onSelectionChange(
+          existingSelection.filter(
+            (c) => c.slackChannelId !== channel.slackChannelId
+          )
+        );
+      }
     },
-    [newSelection]
+    [existingSelection, onSelectionChange]
   );
 
-  // Notify parent component when newSelection changes.
-  useEffect(() => {
-    if (newSelection !== null) {
-      onSelectionChange(newSelection);
-    }
-  }, [newSelection, onSelectionChange]);
-
-  const useResourcesHook = useCallback(
-    (parentId: string | null) =>
-      getUseResourceHook(owner, slackDataSource)(parentId),
-    [owner, slackDataSource]
+  const isChannelSelected = useCallback(
+    (channel: SlackChannel) =>
+      existingSelection.some(
+        (c) => c.slackChannelId === channel.slackChannelId
+      ),
+    [existingSelection]
   );
 
-  const { resources } = useResourcesHook(null);
-  const selectedNodes = resources.reduce(
-    (acc, c) =>
-      customIsNodeChecked(c)
-        ? {
-            ...acc,
-            [c.internalId]: {
-              node: c,
-              isSelected: true,
-              parents: [],
-            },
-          }
-        : acc,
-    {} as Record<string, ContentNodeTreeItemStatus>
-  );
+  if (isResourcesError) {
+    return (
+      <div className="text-sm text-warning">
+        Failed to retrieve Slack channels. Please check your Slack integration.
+      </div>
+    );
+  }
 
   return (
-    <ContentNodeTree
-      selectedNodes={selectedNodes}
-      setSelectedNodes={(updater) => {
-        const newModel = updater(selectedNodes);
+    <div className="space-y-4">
+      <SearchInput
+        name="slack-channel-search"
+        placeholder="Search channels..."
+        value={searchQuery}
+        onChange={setSearchQuery}
+      />
 
-        setNewSelection((prevSelection) => {
-          const newSelection = [...prevSelection];
-          Object.values(newModel).forEach((item) => {
-            const { isSelected, node } = item;
-            const index = newSelection.findIndex(
-              (c) => `slack-channel-${c.slackChannelId}` === node.internalId
-            );
-
-            if (isSelected && index === -1) {
-              newSelection.push({
-                slackChannelId: node.internalId.substring(
-                  "slack-channel-".length
-                ),
-                slackChannelName: node.title,
-              });
-            }
-
-            if (!isSelected && index !== -1) {
-              newSelection.splice(index, 1);
-            }
-          });
-          return newSelection;
-        });
-      }}
-      showExpand={false}
-      useResourcesHook={useResourcesHook}
-    />
+      {isResourcesLoading ? (
+        <div className="flex justify-center py-8">
+          <Spinner size="sm" />
+        </div>
+      ) : (
+        <div className="overflow-y-auto">
+          {filteredChannels.length === 0 ? (
+            <div className="py-4 text-center text-sm text-muted-foreground dark:text-muted-foreground-night">
+              {searchQuery.trim() === ""
+                ? "No channels available"
+                : `No channels match "${searchQuery}"`}
+            </div>
+          ) : (
+            filteredChannels.map((channel) => (
+              <div
+                key={channel.slackChannelId}
+                className="group flex cursor-pointer items-center justify-between rounded-lg p-2"
+                onClick={() => handleChannelToggle(channel)}
+              >
+                <div className="flex items-center space-x-3">
+                  <Checkbox
+                    checked={isChannelSelected(channel)}
+                    onCheckedChange={(checked) =>
+                      handleChannelToggle(channel, checked === true)
+                    }
+                    onClick={(e: React.MouseEvent) => e.stopPropagation()}
+                    size="xs"
+                  />
+                  <span className="text-sm font-medium text-gray-900 dark:text-gray-100">
+                    {channel.slackChannelName}
+                  </span>
+                </div>
+                {channel.sourceUrl && (
+                  <div className="opacity-0 transition-opacity group-hover:opacity-100">
+                    <Button
+                      href={channel.sourceUrl}
+                      icon={ExternalLinkIcon}
+                      size="xs"
+                      variant="outline"
+                      onClick={(e: React.MouseEvent) => e.stopPropagation()}
+                    />
+                  </div>
+                )}
+              </div>
+            ))
+          )}
+        </div>
+      )}
+    </div>
   );
 }
 
@@ -238,7 +294,7 @@ export function SlackSettingsSheet({
               <span className="font-bold">@Dust</span> Slack bot is mentionned
               in these channels.
             </div>
-            <SlackIntegration
+            <SlackChannelsList
               existingSelection={localSlackChannels}
               onSelectionChange={handleSelectionChange}
               owner={owner}

--- a/front/components/agent_builder/settings/VisibilitySection.tsx
+++ b/front/components/agent_builder/settings/VisibilitySection.tsx
@@ -42,7 +42,7 @@ export function VisibilitySection() {
               type="button"
             />
           </DropdownMenuTrigger>
-          <DropdownMenuContent align="end">
+          <DropdownMenuContent align="start">
             <DropdownMenuItem
               label="Published"
               description="Visible & usable by all members of the workspace."


### PR DESCRIPTION
## Description

This PR aims at implementing a slack channel selection instead of reusing the existing `ContentNodeTree`. It gives more flexibility (to add search for example) and doesn't bring along a lot of useless logic in this simple case.

## Tests

Local

## Risk

Low

## Deploy Plan

Deploy front