### PR TITLE
[front] - fix(AB v2): restore instructions

### DIFF
--- a/front/components/agent_builder/instructions/AgentBuilderInstructionsBlock.tsx
+++ b/front/components/agent_builder/instructions/AgentBuilderInstructionsBlock.tsx
@@ -44,7 +44,7 @@ export function AgentBuilderInstructionsBlock({
       return;
     }
 
-    setValue("instructions", text, { shouldDirty: true });
+    setValue("instructions", text, { shouldDirty: true, shouldValidate: true });
     setCompareVersion(null);
     setIsInstructionDiffMode(false);
   };

--- a/front/components/agent_builder/instructions/AgentBuilderInstructionsEditor.tsx
+++ b/front/components/agent_builder/instructions/AgentBuilderInstructionsEditor.tsx
@@ -129,7 +129,10 @@ export function AgentBuilderInstructionsEditor({
 
     const currentContent = plainTextFromTipTapContent(editor.getJSON());
     if (currentContent !== field.value) {
-      editor.commands.setContent(tipTapContentFromPlainText(field.value));
+      // Use setTimeout to ensure this runs after any diff mode changes
+      setTimeout(() => {
+        editor.commands.setContent(tipTapContentFromPlainText(field.value));
+      }, 0);
     }
   }, [editor, field.value]);
 


### PR DESCRIPTION
## Description

The fix uses `setTimeout(() => {}, 0)` to defer the content update to the next tick of the event loop, ensuring it runs after any synchronous effects from the diff mode changes. This resolves both the timing issue and the `flushSync` warning since the content update happens outside of React's render cycle.

The issue was that when the restore button was clicked:
- `setValue` updated the form value
- `setIsInstructionDiffMode(false)` immediately triggered diff mode cleanup
- The sync effect tried to update content during React's render cycle, causing conflicts

By deferring the content update, we allow the diff mode cleanup to complete first, then update the editor content in the next tick.

## Tests

Locally

## Risk

Low

## Deploy Plan

Deploy front