### PR TITLE
[front] remove expand button, adjust the size/spacing and increase the clickable area of the input bar

### DIFF
--- a/front/components/assistant/AssistantPicker.tsx
+++ b/front/components/assistant/AssistantPicker.tsx
@@ -70,7 +70,7 @@ export function AssistantPicker({
       </DropdownMenuTrigger>
       <DropdownMenuContent
         className="h-96 w-96"
-        align="end"
+        align="start"
         dropdownHeaders={
           <>
             <DropdownMenuSearchbar

--- a/front/components/assistant/CreateAgentButton.tsx
+++ b/front/components/assistant/CreateAgentButton.tsx
@@ -51,7 +51,7 @@ export const CreateAgentButton = ({
       </DropdownMenuTrigger>
       <DropdownMenuContent align="start">
         <DropdownMenuItem
-          label="Agent from scratch"
+          label="agent from scratch"
           icon={DocumentIcon}
           onClick={() => {
             setIsLoading(true);
@@ -61,7 +61,7 @@ export const CreateAgentButton = ({
           }}
         />
         <DropdownMenuItem
-          label="Agent from template"
+          label="agent from template"
           icon={MagicIcon}
           onClick={() => {
             setIsLoading(true);

--- a/front/components/assistant/CreateAgentButton.tsx
+++ b/front/components/assistant/CreateAgentButton.tsx
@@ -49,9 +49,9 @@ export const CreateAgentButton = ({
           disabled={isLoading}
         />
       </DropdownMenuTrigger>
-      <DropdownMenuContent>
+      <DropdownMenuContent align="start">
         <DropdownMenuItem
-          label="agent from scratch"
+          label="Agent from scratch"
           icon={DocumentIcon}
           onClick={() => {
             setIsLoading(true);
@@ -61,7 +61,7 @@ export const CreateAgentButton = ({
           }}
         />
         <DropdownMenuItem
-          label="agent from template"
+          label="Agent from template"
           icon={MagicIcon}
           onClick={() => {
             setIsLoading(true);

--- a/front/components/assistant/ToolsPicker.tsx
+++ b/front/components/assistant/ToolsPicker.tsx
@@ -119,7 +119,7 @@ export function ToolsPicker({
       </DropdownMenuTrigger>
       <DropdownMenuContent
         className="h-96 w-96"
-        align="end"
+        align="start"
         dropdownHeaders={
           <>
             <DropdownMenuSearchbar

--- a/front/components/assistant/conversation/input_bar/InputBar.tsx
+++ b/front/components/assistant/conversation/input_bar/InputBar.tsx
@@ -374,7 +374,7 @@ export function AssistantInputBar({
         >
           <div
             className={classNames(
-              "relative flex w-full flex-1 flex-col items-stretch gap-0 self-stretch pl-3 sm:flex-row",
+              "relative flex w-full flex-1 flex-col items-stretch gap-0 self-stretch sm:flex-row",
               "rounded-2xl transition-all",
               "bg-muted-background dark:bg-muted-background-night",
               "border",

--- a/front/components/assistant/conversation/input_bar/InputBarAttachments.tsx
+++ b/front/components/assistant/conversation/input_bar/InputBarAttachments.tsx
@@ -102,7 +102,7 @@ export function InputBarAttachments({
   }
 
   return (
-    <CitationGrid className="mr-3 border-b border-separator pb-3 pt-3">
+    <CitationGrid className="border-b border-separator px-3 pb-3 pt-3">
       {allAttachments.map((attachment) => {
         const attachmentCitation = attachmentToAttachmentCitation(attachment);
         return (

--- a/front/components/assistant/conversation/input_bar/InputBarAttachmentsPicker.tsx
+++ b/front/components/assistant/conversation/input_bar/InputBarAttachmentsPicker.tsx
@@ -137,7 +137,7 @@ export const InputBarAttachmentsPicker = ({
       <DropdownMenuContent
         className="h-80 w-80 xs:h-96 xs:w-96"
         collisionPadding={15}
-        align="end"
+        align="start"
         onInteractOutside={() => setIsOpen(false)}
         onEscapeKeyDown={() => setIsOpen(false)}
         dropdownHeaders={

--- a/front/components/assistant/conversation/input_bar/InputBarContainer.tsx
+++ b/front/components/assistant/conversation/input_bar/InputBarContainer.tsx
@@ -92,7 +92,6 @@ const InputBarContainer = ({
   selectedMCPServerViewIds,
 }: InputBarContainerProps) => {
   const suggestions = useAssistantSuggestions(agentConfigurations, owner);
-  const [isExpanded, setIsExpanded] = useState(false);
   const [nodeOrUrlCandidate, setNodeOrUrlCandidate] = useState<
     UrlCandidate | NodeCandidate | null
   >(null);
@@ -122,7 +121,6 @@ const InputBarContainer = ({
   const { editor, editorService } = useCustomEditor({
     suggestions,
     onEnterKeyDown,
-    resetEditorContainerSize,
     disableAutoFocus,
     onUrlDetected: handleUrlDetected,
     suggestionHandler: mentionDropdown.getSuggestionHandler(),
@@ -245,16 +243,6 @@ const InputBarContainer = ({
 
   const fileInputRef = useRef<HTMLInputElement>(null);
 
-  function handleExpansionToggle() {
-    setIsExpanded((currentExpanded) => !currentExpanded);
-    // Focus at the end of the document when toggling expansion.
-    editorService.focusEnd();
-  }
-
-  function resetEditorContainerSize() {
-    setIsExpanded(false);
-  }
-
   const contentEditableClasses = classNames(
     "inline-block w-full",
     "border-0 outline-none ring-0 focus:border-0 focus:outline-none focus:ring-0",
@@ -282,99 +270,82 @@ const InputBarContainer = ({
             "scrollbar-hide",
             "overflow-y-auto",
             disableTextInput && "cursor-not-allowed",
-            isExpanded
-              ? "h-[60vh] max-h-[60vh] lg:h-[80vh] lg:max-h-[80vh]"
-              : "max-h-[40vh] min-h-14 min-h-24 sm:min-h-16"
+            "max-h-[40vh] min-h-14 sm:min-h-16"
           )}
         />
-        <div className="flex items-center px-1 pb-1.5 sm:px-2 sm:pb-3">
-          {actions.includes("attachment") && (
-            <>
-              <input
-                accept={getSupportedFileExtensions().join(",")}
-                onChange={async (e) => {
-                  await fileUploaderService.handleFileChange(e);
-                  if (fileInputRef.current) {
-                    fileInputRef.current.value = "";
-                  }
-                  editorService.focusEnd();
-                }}
-                ref={fileInputRef}
-                style={{ display: "none" }}
-                type="file"
-                multiple={true}
-              />
-              <InputBarAttachmentsPicker
-                fileUploaderService={fileUploaderService}
+        <div className="flex items-center justify-between px-1 pb-1.5 pr-2 pt-1.5 sm:pb-3 sm:pl-2 sm:pr-3">
+          <div className="flex items-center">
+            {actions.includes("attachment") && (
+              <>
+                <input
+                  accept={getSupportedFileExtensions().join(",")}
+                  onChange={async (e) => {
+                    await fileUploaderService.handleFileChange(e);
+                    if (fileInputRef.current) {
+                      fileInputRef.current.value = "";
+                    }
+                    editorService.focusEnd();
+                  }}
+                  ref={fileInputRef}
+                  style={{ display: "none" }}
+                  type="file"
+                  multiple={true}
+                />
+                <InputBarAttachmentsPicker
+                  fileUploaderService={fileUploaderService}
+                  owner={owner}
+                  isLoading={false}
+                  onNodeSelect={onNodeSelect}
+                  onNodeUnselect={onNodeUnselect}
+                  attachedNodes={attachedNodes}
+                  disabled={disableTextInput}
+                />
+              </>
+            )}
+            {actions.includes("tools") && (
+              <ToolsPicker
                 owner={owner}
-                isLoading={false}
-                onNodeSelect={onNodeSelect}
-                onNodeUnselect={onNodeUnselect}
-                attachedNodes={attachedNodes}
+                selectedMCPServerViewIds={selectedMCPServerViewIds}
+                onSelect={onMCPServerViewSelect}
+                onDeselect={onMCPServerViewDeselect}
                 disabled={disableTextInput}
               />
-            </>
-          )}
-          {actions.includes("tools") && (
-            <ToolsPicker
-              owner={owner}
-              selectedMCPServerViewIds={selectedMCPServerViewIds}
-              onSelect={onMCPServerViewSelect}
-              onDeselect={onMCPServerViewDeselect}
-              disabled={disableTextInput}
-            />
-          )}
-          {(actions.includes("assistants-list") ||
-            actions.includes("assistants-list-with-actions")) && (
-            <AssistantPicker
-              owner={owner}
-              size="xs"
-              onItemClick={(c) => {
-                editorService.insertMention({ id: c.sId, label: c.name });
-              }}
-              assistants={allAssistants}
-              showDropdownArrow={false}
-              showFooterButtons={actions.includes(
-                "assistants-list-with-actions"
-              )}
-              disabled={disableTextInput}
-            />
-          )}
-        </div>
-      </div>
-
-      <div className="flex flex-col items-end justify-between gap-2 self-stretch pb-3 pr-3 pt-3 sm:border-0">
-        <div className="flex items-center">
-          {actions.includes("fullscreen") && (
-            <div className="hidden sm:flex">
-              <Button
-                disabled={disableTextInput}
-                variant="ghost-secondary"
-                icon={isExpanded ? FullscreenExitIcon : FullscreenIcon}
+            )}
+            {(actions.includes("assistants-list") ||
+              actions.includes("assistants-list-with-actions")) && (
+              <AssistantPicker
+                owner={owner}
                 size="xs"
-                onClick={handleExpansionToggle}
+                onItemClick={(c) => {
+                  editorService.insertMention({ id: c.sId, label: c.name });
+                }}
+                assistants={allAssistants}
+                showDropdownArrow={false}
+                showFooterButtons={actions.includes(
+                  "assistants-list-with-actions"
+                )}
+                disabled={disableTextInput}
               />
-            </div>
-          )}
+            )}
+          </div>
+          <Button
+            size="xs"
+            isLoading={disableSendButton}
+            icon={ArrowUpIcon}
+            variant="highlight"
+            disabled={editorService.isEmpty() || disableSendButton}
+            onClick={async () => {
+              onEnterKeyDown(
+                editorService.isEmpty(),
+                editorService.getMarkdownAndMentions(),
+                () => {
+                  editorService.clearEditor();
+                },
+                editorService.setLoading
+              );
+            }}
+          />
         </div>
-        <Button
-          size="xs"
-          isLoading={disableSendButton}
-          icon={ArrowUpIcon}
-          variant="highlight"
-          disabled={editorService.isEmpty() || disableSendButton}
-          onClick={async () => {
-            onEnterKeyDown(
-              editorService.isEmpty(),
-              editorService.getMarkdownAndMentions(),
-              () => {
-                editorService.clearEditor();
-                resetEditorContainerSize();
-              },
-              editorService.setLoading
-            );
-          }}
-        />
       </div>
 
       <MentionDropdown mentionDropdownState={mentionDropdown} />

--- a/front/components/assistant/conversation/input_bar/InputBarContainer.tsx
+++ b/front/components/assistant/conversation/input_bar/InputBarContainer.tsx
@@ -257,9 +257,9 @@ const InputBarContainer = ({
 
   const contentEditableClasses = classNames(
     "inline-block w-full",
-    "border-0 px-2 outline-none ring-0 focus:border-0 focus:outline-none focus:ring-0",
+    "border-0 outline-none ring-0 focus:border-0 focus:outline-none focus:ring-0",
     "whitespace-pre-wrap font-normal",
-    "py-3.5"
+    "pr-3 sm:pl-4 pl-3 sm:pt-3.5 pt-3"
   );
 
   return (
@@ -284,10 +284,10 @@ const InputBarContainer = ({
             disableTextInput && "cursor-not-allowed",
             isExpanded
               ? "h-[60vh] max-h-[60vh] lg:h-[80vh] lg:max-h-[80vh]"
-              : "max-h-64 min-h-24 sm:min-h-14"
+              : "max-h-[40vh] min-h-14 min-h-24 sm:min-h-16"
           )}
         />
-        <div className="flex items-center pb-3 pt-0">
+        <div className="flex items-center px-1 pb-1.5 sm:px-2 sm:pb-3">
           {actions.includes("attachment") && (
             <>
               <input

--- a/front/components/assistant/conversation/input_bar/InputBarContainer.tsx
+++ b/front/components/assistant/conversation/input_bar/InputBarContainer.tsx
@@ -1,9 +1,4 @@
-import {
-  ArrowUpIcon,
-  Button,
-  FullscreenExitIcon,
-  FullscreenIcon,
-} from "@dust-tt/sparkle";
+import { ArrowUpIcon, Button } from "@dust-tt/sparkle";
 import type { Editor } from "@tiptap/react";
 import { EditorContent } from "@tiptap/react";
 import React, {

--- a/front/components/assistant/conversation/input_bar/InputBarContainer.tsx
+++ b/front/components/assistant/conversation/input_bar/InputBarContainer.tsx
@@ -242,7 +242,7 @@ const InputBarContainer = ({
     "inline-block w-full",
     "border-0 outline-none ring-0 focus:border-0 focus:outline-none focus:ring-0",
     "whitespace-pre-wrap font-normal",
-    "pr-3 sm:pl-4 pl-3 sm:pt-3.5 pt-3"
+    "px-3 sm:pl-4 sm:pt-3.5 pt-3"
   );
 
   return (
@@ -268,7 +268,7 @@ const InputBarContainer = ({
             "max-h-[40vh] min-h-14 sm:min-h-16"
           )}
         />
-        <div className="flex items-center justify-between px-1 pb-1.5 pr-2 pt-1.5 sm:pb-3 sm:pl-2 sm:pr-3">
+        <div className="flex items-center justify-between px-1 px-2 py-1.5 sm:pb-3 sm:pr-3">
           <div className="flex items-center">
             {actions.includes("attachment") && (
               <>

--- a/front/components/assistant/conversation/input_bar/editor/useCustomEditor.tsx
+++ b/front/components/assistant/conversation/input_bar/editor/useCustomEditor.tsx
@@ -196,7 +196,6 @@ export interface CustomEditorProps {
     setLoading: (loading: boolean) => void
   ) => void;
   suggestions: EditorSuggestions;
-  resetEditorContainerSize: () => void;
   disableAutoFocus: boolean;
   onUrlDetected?: (candidate: UrlCandidate | NodeCandidate | null) => void;
   suggestionHandler: {
@@ -211,7 +210,6 @@ export interface CustomEditorProps {
 
 const useCustomEditor = ({
   onEnterKeyDown,
-  resetEditorContainerSize,
   suggestions,
   disableAutoFocus,
   onUrlDetected,
@@ -300,7 +298,6 @@ const useCustomEditor = ({
 
           const clearEditor = () => {
             editor.commands.clearContent();
-            resetEditorContainerSize();
           };
 
           const setLoading = (loading: boolean) => {


### PR DESCRIPTION
## Description
This PR is to remove the expand button (approved [here](https://dust4ai.slack.com/archives/C050A0S2Z7F/p1756115775582289)) and adjust the size and spacing of the input bar. This also increases the clickable area of the input bar and adjust the sizing on mobile.

before:
<img width="820" height="161" alt="Screenshot 2025-08-25 at 14 22 56" src="https://github.com/user-attachments/assets/8c07f381-2a68-447e-8c3c-a9883518ac6d" />


after:
<img width="800" height="180" alt="Screenshot 2025-08-25 at 14 06 26" src="https://github.com/user-attachments/assets/4f6d620c-be61-44f3-9c8b-6eadb750dfb9" />

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
