### PR TITLE
[front] Hide `View full conversation` button during run agent execution

### DIFF
--- a/front/components/actions/mcp/details/MCPRunAgentActionDetails.tsx
+++ b/front/components/actions/mcp/details/MCPRunAgentActionDetails.tsx
@@ -149,12 +149,8 @@ export function MCPRunAgentActionDetails({
     if (resultResource) {
       return resultResource.resource.uri;
     }
-    const output = lastNotification?.data.output;
-    if (isRunAgentProgressOutput(output)) {
-      return `/w/${owner.sId}/assistant/${output.conversationId}`;
-    }
     return null;
-  }, [resultResource, lastNotification, owner.sId]);
+  }, [resultResource]);
 
   const references = useMemo(() => {
     if (!resultResource?.resource.refs) {


### PR DESCRIPTION
## Description

- Part of https://github.com/dust-tt/tasks/issues/3830.
- Currently, sub agents send a notification to expose the ID of the sub agent's conversation, which is used to display the button `View full conversation`.
- We need to remove this button to prevent users from going into the sub agent's conversation and validating tool executions/authenticating personal tools from there, since we won't be able to capture this from the main conversation.

## Tests

- Checked locally.

## Risk

- Low, only UI.
- Non negligible product impact.

## Deploy Plan

- Deploy front.
