### PR TITLE
[front] Hide close button in validation dialog

### DIFF
--- a/front/components/assistant/conversation/ActionValidationProvider.tsx
+++ b/front/components/assistant/conversation/ActionValidationProvider.tsx
@@ -270,16 +270,9 @@ export function ActionValidationProvider({
     >
       {children}
 
-      <Dialog
-        open={isDialogOpen}
-        onOpenChange={(open) => {
-          if (!open && !isProcessing && currentValidation) {
-            void handleSubmit("rejected");
-          }
-        }}
-      >
+      <Dialog open={isDialogOpen}>
         <DialogContent isAlertDialog onAnimationEnd={onDialogAnimationEnd}>
-          <DialogHeader>
+          <DialogHeader hideButton>
             <DialogTitle
               visual={
                 currentValidation?.metadata.icon ? (


### PR DESCRIPTION
## Description

- This PR removes the close button in the upper-right corner of the validation dialog.
- The idea is that we encourage users to always take an action right away.

<img width="384" height="268" alt="Screenshot 2025-08-25 at 3 32 15 PM" src="https://github.com/user-attachments/assets/168e7a9e-ed92-487a-97b4-9624ba3c0db1" />

- The next step to finalize the design is to display the number of actions to validation at the same location. Will tackle in a follow up PR as this requires some more changes (moving to a multi-page dialog notably).

## Tests

- Checked locally.

## Risk

- Low, purely at the UI level.

## Deploy Plan

- Deploy front.
