### PR TITLE
[front] Fix `dev_worker` admin script

### DIFF
--- a/front/admin/dev_worker.sh
+++ b/front/admin/dev_worker.sh
@@ -2,7 +2,7 @@
 set -euo pipefail
 
 # Compute the list from the registry.
-WORKERS="$(tsx ./admin/print_workers_except_agent_loop.ts)"
+WORKERS="$(npx tsx ./admin/print_workers_except_agent_loop.ts)"
 
 NODE_ENV=development npx concurrently \
   --names "workers,agent-loop" \


### PR DESCRIPTION
## Description

- This PR fixes the admin script `dev_worker.sh`.

## Tests

- Tested locally.

## Risk

- None, only used for development.

## Deploy Plan

- No deploy.
