### PR TITLE
Flag last blocking events

### DIFF
--- a/front/lib/actions/mcp.ts
+++ b/front/lib/actions/mcp.ts
@@ -182,6 +182,7 @@ export type MCPApproveExecutionEvent = ToolExecutionMetadata & {
   configurationId: string;
   messageId: string;
   conversationId: string;
+  isLastBlockingEventForStep?: boolean;
 };
 
 export function getMCPApprovalStateFromUserApprovalState(

--- a/front/temporal/agent_loop/activities/publish_deferred_events.ts
+++ b/front/temporal/agent_loop/activities/publish_deferred_events.ts
@@ -17,8 +17,9 @@ export async function publishDeferredEventsActivity(
 ): Promise<boolean> {
   let shouldPauseWorkflow = false;
 
-  for (const deferredEvent of deferredEvents) {
+  for (const [index, deferredEvent] of deferredEvents.entries()) {
     const { event, context } = deferredEvent;
+    const isLastEvent = index === deferredEvents.length - 1;
 
     const agentMessageRow = await AgentMessage.findByPk(
       context.agentMessageRowId
@@ -49,6 +50,7 @@ export async function publishDeferredEventsActivity(
               }),
             },
           },
+          isLastBlockingEventForStep: isLastEvent,
         };
         break;
 

--- a/front/temporal/agent_loop/activities/run_tool.ts
+++ b/front/temporal/agent_loop/activities/run_tool.ts
@@ -103,6 +103,7 @@ export async function runToolActivity(
               message: event.error.message,
               metadata: event.error.metadata,
             },
+            isLastBlockingEventForStep: true,
           },
           agentMessageRow,
           {

--- a/front/temporal/agent_loop/lib/create_tool_actions.ts
+++ b/front/temporal/agent_loop/lib/create_tool_actions.ts
@@ -1,4 +1,7 @@
-import type { MCPToolConfigurationType } from "@app/lib/actions/mcp";
+import type {
+  MCPApproveExecutionEvent,
+  MCPToolConfigurationType,
+} from "@app/lib/actions/mcp";
 import { createMCPAction } from "@app/lib/actions/mcp";
 import { getAugmentedInputs } from "@app/lib/actions/mcp_execution";
 import { validateToolInputs } from "@app/lib/actions/mcp_utils";
@@ -46,6 +49,9 @@ export async function createToolActionsActivity(
   const conversationId = conversation.sId;
 
   const actionBlobs: ActionBlob[] = [];
+  const approvalEvents: Array<
+    Omit<MCPApproveExecutionEvent, "isLastBlockingEventForStep">
+  > = [];
 
   for (const [
     index,
@@ -65,8 +71,28 @@ export async function createToolActionsActivity(
     });
 
     if (result) {
-      actionBlobs.push(result);
+      actionBlobs.push(result.actionBlob);
+      if (result.approvalEventData) {
+        approvalEvents.push(result.approvalEventData);
+      }
     }
+  }
+
+  // Publish all approval events with the isLastBlockingEventForStep flag
+  for (const [idx, eventData] of approvalEvents.entries()) {
+    const isLastApproval = idx === approvalEvents.length - 1;
+
+    await updateResourceAndPublishEvent(
+      {
+        ...eventData,
+        isLastBlockingEventForStep: isLastApproval,
+      },
+      agentMessageRow,
+      {
+        conversationId,
+        step,
+      }
+    );
   }
 
   return {
@@ -95,7 +121,13 @@ async function createActionForTool(
     stepContext: StepContext;
     step: number;
   }
-): Promise<ActionBlob | void> {
+): Promise<{
+  actionBlob: ActionBlob;
+  approvalEventData?: Omit<
+    MCPApproveExecutionEvent,
+    "isLastBlockingEventForStep"
+  >;
+} | void> {
   const { status } = await getExecutionStatusFromConfig(
     auth,
     actionConfiguration,
@@ -167,34 +199,29 @@ async function createActionForTool(
     }
   );
 
-  if (status === "blocked_validation_required") {
-    await updateResourceAndPublishEvent(
-      {
-        type: "tool_approve_execution",
-        created: Date.now(),
-        configurationId: agentConfiguration.sId,
-        messageId: agentMessage.sId,
-        conversationId,
-        actionId: mcpAction.getSId(auth.getNonNullableWorkspace()),
-        inputs: mcpAction.params,
-        stake: actionConfiguration.permission,
-        metadata: {
-          toolName: actionConfiguration.originalName,
-          mcpServerName: actionConfiguration.mcpServerName,
-          agentName: agentConfiguration.name,
-          icon: actionConfiguration.icon,
-        },
-      },
-      agentMessageRow,
-      {
-        conversationId,
-        step,
-      }
-    );
-  }
-
   return {
-    actionId: agentMCPAction.id,
-    needsApproval: status === "blocked_validation_required",
+    actionBlob: {
+      actionId: agentMCPAction.id,
+      needsApproval: status === "blocked_validation_required",
+    },
+    approvalEventData:
+      status === "blocked_validation_required"
+        ? {
+            type: "tool_approve_execution",
+            created: Date.now(),
+            configurationId: agentConfiguration.sId,
+            messageId: agentMessage.sId,
+            conversationId,
+            actionId: mcpAction.getSId(auth.getNonNullableWorkspace()),
+            inputs: mcpAction.params,
+            stake: actionConfiguration.permission,
+            metadata: {
+              toolName: actionConfiguration.originalName,
+              mcpServerName: actionConfiguration.mcpServerName,
+              agentName: agentConfiguration.name,
+              icon: actionConfiguration.icon,
+            },
+          }
+        : undefined,
   };
 }

--- a/front/temporal/agent_loop/lib/create_tool_actions.ts
+++ b/front/temporal/agent_loop/lib/create_tool_actions.ts
@@ -157,6 +157,9 @@ async function createActionForTool(
           message: validateToolInputsResult.error.message,
           metadata: null,
         },
+        // This is not exactly correct, but it's not relevant here as we only care about the
+        // blocking nature of the event, which is not the case here.
+        isLastBlockingEventForStep: false,
       },
       agentMessageRow,
       {

--- a/front/types/assistant/agent.ts
+++ b/front/types/assistant/agent.ts
@@ -241,6 +241,7 @@ export type ToolErrorEvent = {
   configurationId: string;
   messageId: string;
   error: ErrorContent;
+  isLastBlockingEventForStep?: boolean;
 };
 
 export type AgentDisabledErrorEvent = {

--- a/front/types/assistant/agent.ts
+++ b/front/types/assistant/agent.ts
@@ -241,7 +241,7 @@ export type ToolErrorEvent = {
   configurationId: string;
   messageId: string;
   error: ErrorContent;
-  isLastBlockingEventForStep?: boolean;
+  isLastBlockingEventForStep: boolean;
 };
 
 export type AgentDisabledErrorEvent = {


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
Moving towards make the tool run_agent more robust, this PR adds a `isLastBlockingEventForStep` boolean on the two events that can actually pause the agent loop:
- `tool_error`
- `tool_approve_execution`

This is required to be able to exit the tool `run_agent` once we get this last event.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
