### PR TITLE
[front] fix(ab/knowledge): Fix nested form

### DIFF
--- a/front/components/agent_builder/capabilities/knowledge/KnowledgeConfigurationSheet.tsx
+++ b/front/components/agent_builder/capabilities/knowledge/KnowledgeConfigurationSheet.tsx
@@ -7,7 +7,7 @@ import {
 import { zodResolver } from "@hookform/resolvers/zod";
 import uniqueId from "lodash/uniqueId";
 import { useEffect, useMemo, useState } from "react";
-import { useForm, useWatch } from "react-hook-form";
+import { FormProvider, useForm, useWatch } from "react-hook-form";
 
 import { useAgentBuilderContext } from "@app/components/agent_builder/AgentBuilderContext";
 import { useAgentBuilderFormActions } from "@app/components/agent_builder/AgentBuilderFormContext";
@@ -44,7 +44,6 @@ import {
   DataSourceBuilderProvider,
   useDataSourceBuilderContext,
 } from "@app/components/data_source_view/context/DataSourceBuilderContext";
-import { FormProvider } from "@app/components/sparkle/FormProvider";
 import { getMCPServerNameForTemplateAction } from "@app/lib/actions/mcp_helper";
 import { getMCPServerRequirements } from "@app/lib/actions/mcp_internal_actions/input_configuration";
 import type { MCPServerViewType } from "@app/lib/api/mcp";
@@ -208,7 +207,7 @@ export function KnowledgeConfigurationSheet({
 
   return (
     <MultiPageSheet open={open} onOpenChange={handleOpenChange}>
-      <FormProvider form={form}>
+      <FormProvider {...form}>
         {debouncedOpen && (
           <DataSourceBuilderProvider
             spaces={spaces}

--- a/front/components/agent_builder/capabilities/knowledge/transformations.ts
+++ b/front/components/agent_builder/capabilities/knowledge/transformations.ts
@@ -101,7 +101,7 @@ export function transformTreeToSelectionConfigurations(
         selectedResources: [],
         excludedResources: [],
         isSelectAll: false,
-        tagsFilter: item.tagsFilter,
+        tagsFilter: null,
       };
     }
 
@@ -193,7 +193,7 @@ export function transformSelectionConfigurationsToTree(
             name: node.title,
             type: "node",
             node,
-            tagsFilter: config.tagsFilter,
+            tagsFilter: null,
           });
         } else {
           const pathParts = [baseParts, node.internalId];
@@ -202,7 +202,7 @@ export function transformSelectionConfigurationsToTree(
             name: node.title,
             type: "data_source",
             dataSourceView: node.dataSourceView,
-            tagsFilter: config.tagsFilter,
+            tagsFilter: null,
           });
         }
       }


### PR DESCRIPTION
## Description
Fix nested form issue in Knowledge Configuration Sheet by using react-hook-form's FormProvider instead of Sparkle's FormProvider. This prevents form nesting issues and ensures proper form submission behavior.

## Test
Locally

## Risk
Low - This is a UI-only change affecting form handling.

## Deploy plan
Deploy front