### PR TITLE
[front] dust-deep: use available tools

### DIFF
--- a/front/components/actions/mcp/details/MCPActionDetails.tsx
+++ b/front/components/actions/mcp/details/MCPActionDetails.tsx
@@ -19,6 +19,7 @@ import {
 import { MCPDataWarehousesBrowseDetails } from "@app/components/actions/mcp/details/MCPDataWarehousesBrowseDetails";
 import { MCPExtractActionDetails } from "@app/components/actions/mcp/details/MCPExtractActionDetails";
 import { MCPGetDatabaseSchemaActionDetails } from "@app/components/actions/mcp/details/MCPGetDatabaseSchemaActionDetails";
+import { MCPListToolsActionDetails } from "@app/components/actions/mcp/details/MCPListToolsActionDetails";
 import { MCPReasoningActionDetails } from "@app/components/actions/mcp/details/MCPReasoningActionDetails";
 import { MCPRunAgentActionDetails } from "@app/components/actions/mcp/details/MCPRunAgentActionDetails";
 import { MCPTablesQueryActionDetails } from "@app/components/actions/mcp/details/MCPTablesQueryActionDetails";
@@ -190,6 +191,10 @@ export function MCPActionDetails(props: MCPActionDetailsProps) {
 
   if (internalMCPServerName === "run_agent") {
     return <MCPRunAgentActionDetails {...props} />;
+  }
+
+  if (internalMCPServerName === "toolsets") {
+    return <MCPListToolsActionDetails {...props} />;
   }
 
   if (internalMCPServerName === "agent_management") {

--- a/front/components/actions/mcp/details/MCPListToolsActionDetails.tsx
+++ b/front/components/actions/mcp/details/MCPListToolsActionDetails.tsx
@@ -1,0 +1,58 @@
+import { BoltIcon, Chip } from "@dust-tt/sparkle";
+
+import { ActionDetailsWrapper } from "@app/components/actions/ActionDetailsWrapper";
+import type { MCPActionDetailsProps } from "@app/components/actions/mcp/details/MCPActionDetails";
+import { getMcpServerViewDisplayName } from "@app/lib/actions/mcp_helper";
+import { getIcon } from "@app/lib/actions/mcp_icons";
+import { isToolsetsResultResourceType } from "@app/lib/actions/mcp_internal_actions/output_schemas";
+import { useMCPServerViews } from "@app/lib/swr/mcp_servers";
+import { useSpaces } from "@app/lib/swr/spaces";
+
+export function MCPListToolsActionDetails({
+  owner,
+  action,
+  viewType,
+}: MCPActionDetailsProps) {
+  const { spaces } = useSpaces({
+    workspaceId: owner.sId,
+  });
+  const { serverViews: mcpServerViews } = useMCPServerViews({
+    owner,
+    space: spaces.find((s) => s.kind === "global"),
+    availability: "all",
+  });
+  const results =
+    action.output
+      ?.filter(isToolsetsResultResourceType)
+      .map((o) => o.resource) ?? [];
+
+  return (
+    <ActionDetailsWrapper
+      viewType={viewType}
+      actionName={viewType === "conversation" ? `Listing tools` : `List tools`}
+      visual={BoltIcon}
+    >
+      {viewType !== "conversation" && (
+        <div className="pl-6 pt-4 text-sm font-normal text-muted-foreground dark:text-muted-foreground-night">
+          <div className="flex flex-wrap gap-1">
+            {results.map((result) => {
+              const mcpServerView = mcpServerViews.find(
+                (v) => v.sId === result.id
+              );
+              if (!mcpServerView) {
+                return null;
+              }
+              return (
+                <Chip
+                  key={result.id}
+                  label={getMcpServerViewDisplayName(mcpServerView)}
+                  icon={getIcon(mcpServerView.server.icon)}
+                />
+              );
+            })}
+          </div>
+        </div>
+      )}
+    </ActionDetailsWrapper>
+  );
+}

--- a/front/components/actions/mcp/details/MCPListToolsActionDetails.tsx
+++ b/front/components/actions/mcp/details/MCPListToolsActionDetails.tsx
@@ -40,6 +40,7 @@ export function MCPListToolsActionDetails({
                 (v) => v.sId === result.id
               );
               if (!mcpServerView) {
+                console.log("mcpServerView not found", result);
                 return null;
               }
               return (

--- a/front/components/actions/mcp/details/MCPRunAgentActionDetails.tsx
+++ b/front/components/actions/mcp/details/MCPRunAgentActionDetails.tsx
@@ -64,6 +64,7 @@ export function MCPRunAgentActionDetails({
   const { serverViews: mcpServerViews } = useMCPServerViews({
     owner,
     space: spaces.find((s) => s.kind === "global"),
+    availability: "all",
     disabled: addedMCPServerViewIds.length === 0,
   });
 

--- a/front/lib/actions/mcp_internal_actions/output_schemas.ts
+++ b/front/lib/actions/mcp_internal_actions/output_schemas.ts
@@ -500,6 +500,32 @@ export const isRunAgentQueryResourceType = (
   );
 };
 
+// Toolsets results.
+
+export const ToolsetsResultResourceSchema = z.object({
+  mimeType: z.literal(INTERNAL_MIME_TYPES.TOOL_OUTPUT.TOOLSET_LIST_RESULT),
+  text: z.string(),
+  uri: z.literal(""),
+  id: z.string(),
+  description: z.string(),
+});
+
+export type ToolsetsResultResourceType = z.infer<
+  typeof ToolsetsResultResourceSchema
+>;
+
+export const isToolsetsResultResourceType = (
+  outputBlock: CallToolResult["content"][number]
+): outputBlock is {
+  type: "resource";
+  resource: ToolsetsResultResourceType;
+} => {
+  return (
+    outputBlock.type === "resource" &&
+    ToolsetsResultResourceSchema.safeParse(outputBlock.resource).success
+  );
+};
+
 // Agent creation results.
 
 export const AgentCreationResultResourceSchema = z.object({

--- a/front/lib/api/assistant/global_agents/configurations/dust-deep.ts
+++ b/front/lib/api/assistant/global_agents/configurations/dust-deep.ts
@@ -65,7 +65,7 @@ If the request requires some internal company data, use the semantic search tool
 
 If the request requires general information that is likely more recent than your knowledge cutoff, use the web tools (search and browse) to answer the request.
 
-Do not use sub-agents for simple requests.
+Do not use sub-agents for simple requests, unless you need to use a tool that is only available for sub agents.
 </simple_request_guidelines>
 
 <complex_request_guidelines>
@@ -80,8 +80,6 @@ It can also have access to any tool that you may find useful for the task, using
 Tasks that you give to sub-agents must be small and granular. Bias towards breaking down a large task into several smaller tasks.
 
 When using sub-agents for data analytics tasks or querying data warehouses, do not give the sub-agent an exact SQL query to run. Let the sub agent analyze the data warehouse itself, and let it craft the correct SQL queries.
-
-Always call the toolsets tool prior to calling the sub-agent to get the list of available tools.
 </sub_agent_guidelines>
 `;
 
@@ -108,6 +106,10 @@ You can use the Data Warehouses tools to:
 
 In order to properly use the data warehouses, it is useful to also search through company data in case there is some documentation available about the tables, some additional semantic layer, or some code that may define how the tables are built in the first place.
 </data_warehouses_guidelines>
+
+<additional_tools>
+If you need a capability that is not available in the tools you have access to, you can call the toolsets tool to get the list of all available tools of the platform, and then call a sub-agent with the tool you need.
+</additional_tools>
 `;
 
 const outputPrompt = `<output_guidelines>

--- a/front/lib/api/assistant/global_agents/configurations/dust-deep.ts
+++ b/front/lib/api/assistant/global_agents/configurations/dust-deep.ts
@@ -431,14 +431,12 @@ export function _getDustTaskGlobalAgent(
     webSearchBrowseMCPServerView,
     dataSourcesFileSystemMCPServerView,
     dataWarehousesMCPServerView,
-    toolsetsMCPServerView,
   }: {
     settings: GlobalAgentSettings | null;
     preFetchedDataSources: PrefetchedDataSourcesType | null;
     webSearchBrowseMCPServerView: MCPServerViewResource | null;
     dataSourcesFileSystemMCPServerView: MCPServerViewResource | null;
     dataWarehousesMCPServerView: MCPServerViewResource | null;
-    toolsetsMCPServerView: MCPServerViewResource | null;
   }
 ): AgentConfigurationType | null {
   const owner = auth.getNonNullableWorkspace();
@@ -508,10 +506,6 @@ export function _getDustTaskGlobalAgent(
     ..._getDefaultWebActionsForGlobalAgent({
       agentId: GLOBAL_AGENTS_SID.DUST_TASK,
       webSearchBrowseMCPServerView,
-    }),
-    ..._getToolsetsToolsConfiguration({
-      agentId: GLOBAL_AGENTS_SID.DUST_TASK,
-      toolsetsMcpServerView: toolsetsMCPServerView,
     })
   );
 

--- a/front/lib/api/assistant/global_agents/global_agents.ts
+++ b/front/lib/api/assistant/global_agents/global_agents.ts
@@ -299,7 +299,6 @@ function getGlobalAgent({
         webSearchBrowseMCPServerView,
         dataSourcesFileSystemMCPServerView,
         dataWarehousesMCPServerView,
-        toolsetsMCPServerView,
       });
       break;
     default:

--- a/front/lib/api/assistant/global_agents/global_agents.ts
+++ b/front/lib/api/assistant/global_agents/global_agents.ts
@@ -70,6 +70,7 @@ function getGlobalAgent({
   dataSourcesFileSystemMCPServerView,
   interactiveContentMCPServerView,
   runAgentMCPServerView,
+  toolsetsMCPServerView,
   dataWarehousesMCPServerView,
 }: {
   auth: Authenticator;
@@ -83,6 +84,7 @@ function getGlobalAgent({
   dataSourcesFileSystemMCPServerView: MCPServerViewResource | null;
   interactiveContentMCPServerView: MCPServerViewResource | null;
   runAgentMCPServerView: MCPServerViewResource | null;
+  toolsetsMCPServerView: MCPServerViewResource | null;
   dataWarehousesMCPServerView: MCPServerViewResource | null;
 }): AgentConfigurationType | null {
   const settings =
@@ -287,6 +289,7 @@ function getGlobalAgent({
         interactiveContentMCPServerView,
         runAgentMCPServerView,
         dataWarehousesMCPServerView,
+        toolsetsMCPServerView,
       });
       break;
     case GLOBAL_AGENTS_SID.DUST_TASK:
@@ -296,6 +299,7 @@ function getGlobalAgent({
         webSearchBrowseMCPServerView,
         dataSourcesFileSystemMCPServerView,
         dataWarehousesMCPServerView,
+        toolsetsMCPServerView,
       });
       break;
     default:
@@ -357,6 +361,7 @@ export async function getGlobalAgents(
     dataSourcesFileSystemMCPServerView,
     interactiveContentMCPServerView,
     runAgentMCPServerView,
+    toolsetsMCPServerView,
     dataWarehousesMCPServerView,
   ] = await Promise.all([
     variant === "full"
@@ -400,6 +405,12 @@ export async function getGlobalAgents(
       ? MCPServerViewResource.getMCPServerViewForAutoInternalTool(
           auth,
           "run_agent"
+        )
+      : null,
+    variant === "full"
+      ? MCPServerViewResource.getMCPServerViewForAutoInternalTool(
+          auth,
+          "toolsets"
         )
       : null,
     variant === "full"
@@ -461,6 +472,7 @@ export async function getGlobalAgents(
       dataSourcesFileSystemMCPServerView,
       interactiveContentMCPServerView,
       runAgentMCPServerView,
+      toolsetsMCPServerView,
       dataWarehousesMCPServerView,
     })
   );

--- a/front/lib/api/assistant/global_agents/tools.ts
+++ b/front/lib/api/assistant/global_agents/tools.ts
@@ -69,6 +69,39 @@ export function _getDefaultWebActionsForGlobalAgent({
   ];
 }
 
+export function _getToolsetsToolsConfiguration({
+  agentId,
+  toolsetsMcpServerView,
+}: {
+  agentId: GLOBAL_AGENTS_SID;
+  toolsetsMcpServerView: MCPServerViewResource | null;
+}): ServerSideMCPServerConfigurationType[] {
+  if (!toolsetsMcpServerView) {
+    return [];
+  }
+
+  return [
+    {
+      id: -1,
+      sId: agentId + "-toolsets",
+      type: "mcp_server_configuration",
+      name: "toolsets",
+      description:
+        "List the available tools with their names and descriptions.",
+      mcpServerViewId: toolsetsMcpServerView.sId,
+      internalMCPServerId: toolsetsMcpServerView.internalMCPServerId,
+      dataSources: null,
+      tables: null,
+      childAgentId: null,
+      reasoningModel: null,
+      additionalConfiguration: {},
+      timeFrame: null,
+      dustAppConfiguration: null,
+      jsonSchema: null,
+    },
+  ];
+}
+
 export function _getAgentRouterToolsConfiguration(
   agentId: GLOBAL_AGENTS_SID,
   mcpServerView: MCPServerViewResource | null,

--- a/front/lib/swr/mcp_servers.ts
+++ b/front/lib/swr/mcp_servers.ts
@@ -878,21 +878,31 @@ export function useCreatePersonalConnection(owner: LightWorkspaceType) {
   return { createPersonalConnection };
 }
 
-function getMCPServerViewsKey(owner: LightWorkspaceType, space?: SpaceType) {
-  return space ? `/api/w/${owner.sId}/spaces/${space.sId}/mcp_views` : null;
+function getMCPServerViewsKey(
+  owner: LightWorkspaceType,
+  space?: SpaceType,
+  availability?: MCPServerAvailability | "all"
+) {
+  return space
+    ? `/api/w/${owner.sId}/spaces/${space.sId}/mcp_views${
+        availability ? `?availability=${availability}` : ""
+      }`
+    : null;
 }
 
 export function useMCPServerViews({
   owner,
   space,
+  availability,
   disabled,
 }: {
   owner: LightWorkspaceType;
   space?: SpaceType;
+  availability?: MCPServerAvailability | "all";
   disabled?: boolean;
 }) {
   const configFetcher: Fetcher<GetMCPServerViewsResponseBody> = fetcher;
-  const url = getMCPServerViewsKey(owner, space);
+  const url = getMCPServerViewsKey(owner, space, availability);
   const { data, error, mutate } = useSWRWithDefaults(url, configFetcher, {
     disabled,
   });

--- a/front/pages/api/w/[wId]/spaces/[spaceId]/mcp_views/index.ts
+++ b/front/pages/api/w/[wId]/spaces/[spaceId]/mcp_views/index.ts
@@ -21,6 +21,16 @@ export type PostMCPServerViewResponseBody = {
   serverView: MCPServerViewType;
 };
 
+const GetQueryParamsSchema = t.type({
+  availability: t.union([
+    t.undefined,
+    t.literal("manual"),
+    t.literal("auto"),
+    t.literal("auto_hidden_builder"),
+    t.literal("all"),
+  ]),
+});
+
 const PostQueryParamsSchema = t.type({
   mcpServerId: t.string,
 });
@@ -41,7 +51,20 @@ async function handler(
 
   switch (method) {
     case "GET": {
-      const { availability = "manual" } = req.query;
+      const r = GetQueryParamsSchema.decode(req.query);
+
+      if (isLeft(r)) {
+        return apiError(req, res, {
+          status_code: 400,
+          api_error: {
+            type: "invalid_request_error",
+            message: "Invalid query parameters.",
+          },
+        });
+      }
+
+      const { availability = "manual" } = r.right;
+
       const mcpServerViews = await MCPServerViewResource.listBySpace(
         auth,
         space

--- a/front/pages/api/w/[wId]/spaces/[spaceId]/mcp_views/index.ts
+++ b/front/pages/api/w/[wId]/spaces/[spaceId]/mcp_views/index.ts
@@ -41,6 +41,7 @@ async function handler(
 
   switch (method) {
     case "GET": {
+      const { availability = "manual" } = req.query;
       const mcpServerViews = await MCPServerViewResource.listBySpace(
         auth,
         space
@@ -49,7 +50,10 @@ async function handler(
         success: true,
         serverViews: mcpServerViews
           .map((mcpServerView) => mcpServerView.toJSON())
-          .filter((s) => s.server.availability === "manual"),
+          .filter(
+            (s) =>
+              availability === "all" || s.server.availability === availability
+          ),
       });
     }
     case "POST": {


### PR DESCRIPTION
## Description

Adds the toolsets tool to dust-deep. Adapt prompt to call toolsets list when needed.
Add UI for details and fixed run sub agent UI

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

low, behind ff
## Deploy Plan

deploy front
