### PR TITLE
[Durable Agents] Add AuthorizationInfo to BlockedActionExecution

### DIFF
--- a/front/lib/actions/mcp.ts
+++ b/front/lib/actions/mcp.ts
@@ -25,6 +25,7 @@ import type { ToolPersonalAuthRequiredEvent } from "@app/lib/actions/mcp_interna
 import { hideInternalConfiguration } from "@app/lib/actions/mcp_internal_actions/input_configuration";
 import type { ProgressNotificationContentType } from "@app/lib/actions/mcp_internal_actions/output_schemas";
 import { isTextContent } from "@app/lib/actions/mcp_internal_actions/output_schemas";
+import type { AuthorizationInfo } from "@app/lib/actions/mcp_metadata";
 import {
   hideFileFromActionOutput,
   rewriteContentForModel,
@@ -173,6 +174,7 @@ export type BlockedActionExecution = ToolExecutionMetadata & {
   messageId: string;
   conversationId: string;
   status: ToolExecutionBlockedStatus;
+  authorizationInfo: AuthorizationInfo | null;
 };
 
 // TODO(durable-agents): cleanup the types of the events.

--- a/front/lib/resources/agent_mcp_action_resource.ts
+++ b/front/lib/resources/agent_mcp_action_resource.ts
@@ -234,10 +234,9 @@ export class AgentMCPActionResource extends BaseResource<AgentMCPActionModel> {
       ...new Set(
         removeNulls(
           blockedActions.map(({ toolConfiguration }) => {
-            if (isLightServerSideMCPToolConfiguration(toolConfiguration)) {
-              return toolConfiguration.mcpServerViewId;
-            }
-            return null;
+            return isLightServerSideMCPToolConfiguration(toolConfiguration)
+              ? toolConfiguration.mcpServerViewId
+              : null;
           })
         )
       ),

--- a/front/lib/resources/agent_mcp_action_resource.ts
+++ b/front/lib/resources/agent_mcp_action_resource.ts
@@ -8,12 +8,6 @@ import type {
 import { Op } from "sequelize";
 
 import type { BlockedActionExecution } from "@app/lib/actions/mcp";
-import { getServerTypeAndIdFromSId } from "@app/lib/actions/mcp_helper";
-import {
-  INTERNAL_MCP_SERVERS,
-  isInternalMCPServerName,
-} from "@app/lib/actions/mcp_internal_actions/constants";
-import type { AuthorizationInfo } from "@app/lib/actions/mcp_metadata";
 import type { ToolExecutionStatus } from "@app/lib/actions/statuses";
 import {
   isToolExecutionStatusBlocked,
@@ -23,8 +17,6 @@ import { isLightServerSideMCPToolConfiguration } from "@app/lib/actions/types/gu
 import { getAgentConfigurations } from "@app/lib/api/assistant/configuration/agent";
 import type { Authenticator } from "@app/lib/auth";
 import { AgentMCPActionModel } from "@app/lib/models/assistant/actions/mcp";
-import { MCPServerViewModel } from "@app/lib/models/assistant/actions/mcp_server_view";
-import { RemoteMCPServerModel } from "@app/lib/models/assistant/actions/remote_mcp_server";
 import { AgentStepContentModel } from "@app/lib/models/assistant/agent_step_content";
 import { AgentMessage, Message } from "@app/lib/models/assistant/conversation";
 import { BaseResource } from "@app/lib/resources/base_resource";


### PR DESCRIPTION
## Description
Fixes the need to include authorization information when listing blocked MCP actions for a conversation.

Adds the `AuthorizationInfo` object to the `BlockedActionExecution` type and updates the `listBlockedActionsForConversation` function to fetch and include this information for both internal and remote MCP servers.

## Risks
Blast radius: MCP action blocking functionality  
Risk: low

## Deploy Plan
- Deploy front service