### PR TITLE
[front] Multipage action validation 

### DIFF
--- a/front/components/assistant/conversation/ActionValidationProvider.tsx
+++ b/front/components/assistant/conversation/ActionValidationProvider.tsx
@@ -130,7 +130,7 @@ export function ActionValidationProvider({
   conversation,
   children,
 }: ActionValidationProviderProps) {
-  const { blockedActions, mutate: mutateBlockedActions } = useBlockedActions({
+  const { blockedActions } = useBlockedActions({
     conversationId: conversation?.sId || null,
     workspaceId: owner.sId,
   });
@@ -176,10 +176,6 @@ export function ActionValidationProvider({
 
     const currentValidation = validationQueue[0];
 
-    if (!currentValidation) {
-      return;
-    }
-
     const { validationRequest, message } = currentValidation;
     const result = await validateAction({
       validationRequest,
@@ -191,8 +187,6 @@ export function ActionValidationProvider({
     if (!result.success) {
       return;
     }
-
-    await mutateBlockedActions();
 
     setNeverAskAgain(false);
     setErrorMessage(null);

--- a/front/components/assistant/conversation/ActionValidationProvider.tsx
+++ b/front/components/assistant/conversation/ActionValidationProvider.tsx
@@ -310,6 +310,7 @@ export function ActionValidationProvider({
             pages={pages}
             currentPageId={validatedActions.toString()}
             onPageChange={() => {}}
+            hideCloseButton
             size="lg"
             isAlertDialog
             showNavigation={true}

--- a/front/components/assistant/conversation/ActionValidationProvider.tsx
+++ b/front/components/assistant/conversation/ActionValidationProvider.tsx
@@ -210,10 +210,11 @@ export function ActionValidationProvider({
   };
 
   const showValidationDialog = useCallback(() => {
-    if (!isDialogOpen) {
+    if (!isDialogOpen && validationQueue.length > 0) {
+      setInitialQueueLength(validationQueue.length);
       setIsDialogOpen(true);
     }
-  }, [isDialogOpen]);
+  }, [isDialogOpen, validationQueue.length]);
 
   const hasPendingValidations = validationQueue.length > 0;
   const totalPendingValidations = validationQueue.length;

--- a/front/components/assistant/conversation/ActionValidationProvider.tsx
+++ b/front/components/assistant/conversation/ActionValidationProvider.tsx
@@ -68,7 +68,6 @@ function useValidationQueue({
       validationRequest: MCPActionValidationRequest;
     }) => {
       setValidationQueue((prevQueue) => {
-        // Check if validation already exists in queue
         const exists = prevQueue.some(
           (v) => v.validationRequest.actionId === validationRequest.actionId
         );
@@ -160,6 +159,7 @@ export function ActionValidationProvider({
 
   useNavigationLock(isDialogOpen);
 
+  // Open the dialog when there are pending validations and the dialog is not open.
   useEffect(() => {
     if (validationQueue.length > 0 && !isDialogOpen) {
       setValidatedActions(0);

--- a/front/components/assistant/conversation/ActionValidationProvider.tsx
+++ b/front/components/assistant/conversation/ActionValidationProvider.tsx
@@ -228,7 +228,6 @@ export function ActionValidationProvider({
     return Array.from({ length: totalCount }, (_, index) => ({
       id: index.toString(),
       title: "Tool Validation Required",
-      description: "Review and approve the tool usage request",
       icon: validationRequest.metadata.icon
         ? getIcon(validationRequest.metadata.icon)
         : ActionPieChartIcon,

--- a/front/components/assistant/conversation/ActionValidationProvider.tsx
+++ b/front/components/assistant/conversation/ActionValidationProvider.tsx
@@ -4,15 +4,9 @@ import {
   Checkbox,
   CodeBlock,
   CollapsibleComponent,
-  Dialog,
-  DialogContainer,
-  DialogContent,
-  DialogFooter,
-  DialogHeader,
-  DialogTitle,
-  Icon,
   Label,
-  Spinner,
+  MultiPageDialog,
+  MultiPageDialogContent,
 } from "@dust-tt/sparkle";
 import type { ReactNode } from "react";
 import {
@@ -27,7 +21,7 @@ import {
 import { useNavigationLock } from "@app/components/assistant_builder/useNavigationLock";
 import { useValidateAction } from "@app/hooks/useValidateAction";
 import type { MCPValidationOutputType } from "@app/lib/actions/constants";
-import { getAvatarFromIcon } from "@app/lib/actions/mcp_icons";
+import { getIcon } from "@app/lib/actions/mcp_icons";
 import { useBlockedActions } from "@app/lib/swr/blocked_actions";
 import type {
   ConversationWithoutContentType,
@@ -35,39 +29,33 @@ import type {
   LightWorkspaceType,
   MCPActionValidationRequest,
 } from "@app/types";
-import { asDisplayName, pluralize } from "@app/types";
+import { asDisplayName } from "@app/types";
+
+type ValidationQueueItem = {
+  message?: LightAgentMessageType;
+  validationRequest: MCPActionValidationRequest;
+};
 
 function useValidationQueue({
   pendingValidations,
 }: {
   pendingValidations: MCPActionValidationRequest[];
 }) {
-  // We store two states: the current validation and a queue.
-  // The current validation is the one displayed in the dialog that can be validated.
-  // The queue does not store the current validation.
-  const [validationQueue, setValidationQueue] = useState<
-    // Store validations by `actionId` to prevent duplicate entries.
-    Record<string, MCPActionValidationRequest>
-  >({});
-
-  const [currentItem, setCurrentItem] = useState<{
-    message?: LightAgentMessageType;
-    validationRequest: MCPActionValidationRequest;
-  } | null>(null);
+  const [validationQueue, setValidationQueue] = useState<ValidationQueueItem[]>(
+    []
+  );
 
   useEffect(() => {
-    const nextValidation = pendingValidations[0];
-    if (nextValidation) {
-      setCurrentItem({ validationRequest: nextValidation });
-    }
-    if (pendingValidations.length > 1) {
-      setValidationQueue(
-        Object.fromEntries(
-          pendingValidations
-            .slice(1)
-            .map((validation) => [validation.actionId, validation])
-        )
-      );
+    if (pendingValidations.length > 0) {
+      setValidationQueue((prevQueue) => {
+        const existingIds = new Set(
+          prevQueue.map((v) => v.validationRequest.actionId)
+        );
+        const newItems = pendingValidations
+          .filter((v) => !existingIds.has(v.actionId))
+          .map((validationRequest) => ({ validationRequest }));
+        return [...prevQueue, ...newItems];
+      });
     }
   }, [pendingValidations]);
 
@@ -79,59 +67,30 @@ function useValidationQueue({
       message: LightAgentMessageType;
       validationRequest: MCPActionValidationRequest;
     }) => {
-      setCurrentItem((current) => {
-        if (
-          current === null ||
-          current.validationRequest.actionId === validationRequest.actionId
-        ) {
-          return { message, validationRequest };
+      setValidationQueue((prevQueue) => {
+        // Check if validation already exists in queue
+        const exists = prevQueue.some(
+          (v) => v.validationRequest.actionId === validationRequest.actionId
+        );
+
+        if (!exists) {
+          return [...prevQueue, { validationRequest, message }];
         }
 
-        setValidationQueue((prevRecord) => ({
-          ...prevRecord,
-          [validationRequest.actionId]: validationRequest,
-        }));
-        return current;
+        return prevQueue;
       });
     },
     []
   );
 
-  // We don't update the current validation here to avoid content flickering.
   const shiftValidationQueue = useCallback(() => {
-    const enqueuedActionIds = Object.keys(validationQueue);
-
-    if (enqueuedActionIds.length > 0) {
-      const nextValidationActionId = enqueuedActionIds[0];
-      const nextValidation = validationQueue[nextValidationActionId];
-
-      setValidationQueue((prevRecord) => {
-        const newRecord = { ...prevRecord };
-        delete newRecord[nextValidationActionId];
-        return newRecord;
-      });
-      setCurrentItem({ validationRequest: nextValidation });
-      return nextValidation;
-    }
-
-    return null;
-  }, [validationQueue]);
-
-  const validationQueueLength = useMemo(
-    () => Object.keys(validationQueue).length,
-    [validationQueue]
-  );
-
-  const clearCurrentValidation = () => {
-    setCurrentItem(null);
-  };
+    setValidationQueue((prevQueue) => prevQueue.slice(1));
+  }, []);
 
   return {
-    validationQueueLength,
-    currentItem,
+    validationQueue,
     enqueueValidation,
     shiftValidationQueue,
-    clearCurrentValidation,
   };
 }
 
@@ -156,6 +115,7 @@ export function useActionValidationContext() {
       "useActionValidationContext must be used within an ActionValidationContext"
     );
   }
+
   return context;
 }
 
@@ -170,7 +130,7 @@ export function ActionValidationProvider({
   conversation,
   children,
 }: ActionValidationProviderProps) {
-  const { blockedActions } = useBlockedActions({
+  const { blockedActions, mutate: mutateBlockedActions } = useBlockedActions({
     conversationId: conversation?.sId || null,
     workspaceId: owner.sId,
   });
@@ -183,17 +143,14 @@ export function ActionValidationProvider({
     );
   }, [blockedActions]);
 
-  const {
-    validationQueueLength,
-    currentItem,
-    clearCurrentValidation,
-    enqueueValidation,
-    shiftValidationQueue,
-  } = useValidationQueue({ pendingValidations });
+  const { validationQueue, enqueueValidation, shiftValidationQueue } =
+    useValidationQueue({ pendingValidations });
 
   const [isDialogOpen, setIsDialogOpen] = useState(false);
-  const [neverAskAgain, setNeverAskAgain] = useState(false);
+  const [initialQueueLength, setInitialQueueLength] = useState(0);
+
   const [errorMessage, setErrorMessage] = useState<string | null>(null);
+  const [neverAskAgain, setNeverAskAgain] = useState(false);
 
   const { validateAction, isValidating } = useValidateAction({
     owner,
@@ -203,13 +160,25 @@ export function ActionValidationProvider({
 
   useNavigationLock(isDialogOpen);
 
+  useEffect(() => {
+    if (validationQueue.length > 0 && !isDialogOpen) {
+      setInitialQueueLength(validationQueue.length);
+      setIsDialogOpen(true);
+    }
+  }, [validationQueue.length, isDialogOpen]);
+
   const submitValidation = async (status: MCPValidationOutputType) => {
-    if (!currentItem) {
+    if (!validationQueue.length) {
       return;
     }
 
-    const { validationRequest, message } = currentItem;
+    const currentValidation = validationQueue[0];
 
+    if (!currentValidation) {
+      return;
+    }
+
+    const { validationRequest, message } = currentValidation;
     const result = await validateAction({
       validationRequest,
       message,
@@ -217,42 +186,115 @@ export function ActionValidationProvider({
         status === "approved" && neverAskAgain ? "always_approved" : status,
     });
 
-    if (result.success) {
-      setNeverAskAgain(false);
-      setErrorMessage(null);
+    if (!result.success) {
+      return;
+    }
+
+    await mutateBlockedActions();
+
+    setNeverAskAgain(false);
+    setErrorMessage(null);
+
+    const remainingAfterShift = validationQueue.length - 1;
+
+    shiftValidationQueue();
+
+    if (remainingAfterShift === 0) {
+      setIsDialogOpen(false);
+      setInitialQueueLength(0);
     }
   };
 
   const handleSubmit = (approved: MCPValidationOutputType) => {
     void submitValidation(approved);
-
-    const nextValidationRequest = shiftValidationQueue();
-    // We will clear out the current validation in onDialogAnimationEnd to avoid content flickering.
-    if (!nextValidationRequest) {
-      setIsDialogOpen(false);
-    }
   };
 
-  // To avoid content flickering, we will clear out the current validation when closing animation ends.
-  const onDialogAnimationEnd = () => {
-    // This is safe to check because the dialog closing animation is triggered after isDialogOpen is set to false.
-    if (!isDialogOpen) {
-      clearCurrentValidation();
-      setErrorMessage(null);
-    }
-  };
-
-  // We need the useCallback because this will be used as a dependency of the hook down the line.
   const showValidationDialog = useCallback(() => {
     if (!isDialogOpen) {
       setIsDialogOpen(true);
     }
   }, [isDialogOpen]);
 
-  const hasPendingValidations =
-    currentItem !== null || validationQueueLength > 0;
-  const totalPendingValidations = (currentItem ? 1 : 0) + validationQueueLength;
-  const validationRequest = currentItem?.validationRequest;
+  const hasPendingValidations = validationQueue.length > 0;
+  const totalPendingValidations = validationQueue.length;
+
+  const pages = useMemo(() => {
+    if (!validationQueue.length || initialQueueLength === 0) {
+      return [];
+    }
+
+    const { validationRequest } = validationQueue[0];
+    const hasDetails =
+      validationRequest?.inputs &&
+      Object.keys(validationRequest.inputs).length > 0;
+
+    return Array.from({ length: initialQueueLength }, (_, index) => ({
+      id: index.toString(),
+      title: "Tool Validation Required",
+      description: "Review and approve the tool usage request",
+      icon: validationRequest.metadata.icon
+        ? getIcon(validationRequest.metadata.icon)
+        : ActionPieChartIcon,
+      content: (
+        <div className="flex flex-col gap-4">
+          <div>
+            Allow{" "}
+            <span className="font-semibold">
+              @{validationRequest.metadata.agentName}
+            </span>{" "}
+            to use the tool{" "}
+            <span className="font-semibold">
+              {asDisplayName(validationRequest.metadata.toolName)}
+            </span>{" "}
+            from{" "}
+            <span className="font-semibold">
+              {asDisplayName(validationRequest.metadata.mcpServerName)}
+            </span>
+            ?
+          </div>
+          {hasDetails && (
+            <CollapsibleComponent
+              triggerChildren={
+                <span className="font-medium text-muted-foreground dark:text-muted-foreground-night">
+                  Details
+                </span>
+              }
+              contentChildren={
+                <div>
+                  <div className="max-h-80 overflow-auto rounded-lg bg-muted dark:bg-muted-night">
+                    <CodeBlock
+                      wrapLongLines
+                      className="language-json overflow-y-auto"
+                    >
+                      {JSON.stringify(validationRequest.inputs, null, 2)}
+                    </CodeBlock>
+                  </div>
+                </div>
+              }
+            />
+          )}
+          {errorMessage && (
+            <div className="mt-2 text-sm font-medium text-warning-800 dark:text-warning-800-night">
+              {errorMessage}
+            </div>
+          )}
+          {validationRequest.stake === "low" && (
+            <div className="mt-5">
+              <Label className="copy-sm flex w-fit cursor-pointer flex-row items-center gap-2 py-2 pr-2 font-normal">
+                <Checkbox
+                  checked={neverAskAgain}
+                  onCheckedChange={(check) => {
+                    setNeverAskAgain(!!check);
+                  }}
+                />
+                <span>Always allow this tool</span>
+              </Label>
+            </div>
+          )}
+        </div>
+      ),
+    }));
+  }, [validationQueue, errorMessage, neverAskAgain, initialQueueLength]);
 
   return (
     <ActionValidationContext.Provider
@@ -265,118 +307,43 @@ export function ActionValidationProvider({
     >
       {children}
 
-      <Dialog open={isDialogOpen}>
-        <DialogContent isAlertDialog onAnimationEnd={onDialogAnimationEnd}>
-          <DialogHeader hideButton>
-            <DialogTitle
-              visual={
-                validationRequest?.metadata.icon ? (
-                  getAvatarFromIcon(validationRequest?.metadata.icon)
-                ) : (
-                  <Icon visual={ActionPieChartIcon} size="sm" />
-                )
-              }
-            >
-              Tool Validation Required
-            </DialogTitle>
-          </DialogHeader>
-          <DialogContainer>
-            <div className="flex flex-col gap-4">
-              <div>
-                Allow{" "}
-                <span className="font-semibold">
-                  @{validationRequest?.metadata.agentName}
-                </span>{" "}
-                to use the tool{" "}
-                <span className="font-semibold">
-                  {asDisplayName(validationRequest?.metadata.toolName)}
-                </span>{" "}
-                from{" "}
-                <span className="font-semibold">
-                  {asDisplayName(validationRequest?.metadata.mcpServerName)}
-                </span>
-                ?
+      <MultiPageDialog open={isDialogOpen} onOpenChange={setIsDialogOpen}>
+        {pages.length > 0 && (
+          <MultiPageDialogContent
+            pages={pages}
+            currentPageId={Math.max(
+              0,
+              initialQueueLength - validationQueue.length
+            ).toString()}
+            onPageChange={() => {}}
+            size="lg"
+            isAlertDialog
+            showNavigation={true}
+            showHeaderNavigation={false}
+            footerContent={
+              <div className="flex flex-row justify-end gap-2">
+                <Button
+                  variant="outline"
+                  label="Decline"
+                  onClick={() => handleSubmit("rejected")}
+                  disabled={isValidating}
+                >
+                  Decline
+                </Button>
+                <Button
+                  variant="highlight"
+                  label="Allow"
+                  autoFocus
+                  onClick={() => handleSubmit("approved")}
+                  disabled={isValidating}
+                >
+                  Allow
+                </Button>
               </div>
-              {validationRequest?.inputs &&
-                Object.keys(validationRequest?.inputs).length > 0 && (
-                  <CollapsibleComponent
-                    triggerChildren={
-                      <span className="font-medium text-muted-foreground dark:text-muted-foreground-night">
-                        Details
-                      </span>
-                    }
-                    contentChildren={
-                      <div>
-                        <div className="max-h-80 overflow-auto rounded-lg bg-muted dark:bg-muted-night">
-                          <CodeBlock
-                            wrapLongLines
-                            className="language-json overflow-y-auto"
-                          >
-                            {JSON.stringify(validationRequest?.inputs, null, 2)}
-                          </CodeBlock>
-                        </div>
-                      </div>
-                    }
-                  />
-                )}
-
-              {validationQueueLength > 0 && (
-                <div className="mt-2 text-sm font-medium text-info-900 dark:text-info-900-night">
-                  {validationQueueLength} more request
-                  {pluralize(validationQueueLength)} in the queue
-                </div>
-              )}
-
-              {errorMessage && (
-                <div className="mt-2 text-sm font-medium text-warning-800 dark:text-warning-800-night">
-                  {errorMessage}
-                </div>
-              )}
-            </div>
-            {validationRequest?.stake === "low" && (
-              <div className="mt-5">
-                <Label className="copy-sm flex w-fit cursor-pointer flex-row items-center gap-2 py-2 pr-2 font-normal">
-                  <Checkbox
-                    checked={neverAskAgain}
-                    onCheckedChange={(check) => {
-                      setNeverAskAgain(!!check);
-                    }}
-                  />
-                  <span>Always allow this tool</span>
-                </Label>
-              </div>
-            )}
-          </DialogContainer>
-          <DialogFooter>
-            <Button
-              label="Decline"
-              variant="outline"
-              onClick={() => handleSubmit("rejected")}
-              disabled={isValidating}
-            >
-              {isValidating && (
-                <div className="flex items-center">
-                  <span className="mr-2">Declining</span>
-                  <Spinner size="xs" variant="dark" />
-                </div>
-              )}
-            </Button>
-            <Button
-              label="Allow"
-              variant="highlight"
-              onClick={() => handleSubmit("approved")}
-              disabled={isValidating}
-            >
-              {isValidating && (
-                <div className="flex items-center">
-                  <span className="mr-2">Approving</span>
-                  <Spinner size="xs" variant="light" />
-                </div>
-              )}
-            </Button>
-          </DialogFooter>
-        </DialogContent>
-      </Dialog>
+            }
+          />
+        )}
+      </MultiPageDialog>
     </ActionValidationContext.Provider>
   );
 }

--- a/front/components/assistant/conversation/ActionValidationProvider.tsx
+++ b/front/components/assistant/conversation/ActionValidationProvider.tsx
@@ -30,17 +30,21 @@ import type {
   MCPActionValidationRequest,
 } from "@app/types";
 import { asDisplayName } from "@app/types";
+<<<<<<< HEAD
 
 type ValidationQueueItem = {
   message?: LightAgentMessageType;
   validationRequest: MCPActionValidationRequest;
 };
+=======
+>>>>>>> 83961b732 (working multipage)
 
 function useValidationQueue({
   pendingValidations,
 }: {
   pendingValidations: MCPActionValidationRequest[];
 }) {
+<<<<<<< HEAD
   const [validationQueue, setValidationQueue] = useState<ValidationQueueItem[]>(
     []
   );
@@ -56,12 +60,20 @@ function useValidationQueue({
           .map((validationRequest) => ({ validationRequest }));
         return [...prevQueue, ...newItems];
       });
+=======
+  const [validationQueue, setValidationQueue] = useState<
+    MCPActionValidationRequest[]
+  >([]);
+
+  useEffect(() => {
+    if (pendingValidations.length > 0) {
+      setValidationQueue(pendingValidations);
+>>>>>>> 83961b732 (working multipage)
     }
   }, [pendingValidations]);
 
   const enqueueValidation = useCallback(
     ({
-      message,
       validationRequest,
     }: {
       message: LightAgentMessageType;
@@ -70,11 +82,19 @@ function useValidationQueue({
       setValidationQueue((prevQueue) => {
         // Check if validation already exists in queue
         const exists = prevQueue.some(
+<<<<<<< HEAD
           (v) => v.validationRequest.actionId === validationRequest.actionId
         );
 
         if (!exists) {
           return [...prevQueue, { validationRequest, message }];
+=======
+          (v) => v.actionId === validationRequest.actionId
+        );
+
+        if (!exists) {
+          return [...prevQueue, validationRequest];
+>>>>>>> 83961b732 (working multipage)
         }
 
         return prevQueue;
@@ -83,8 +103,15 @@ function useValidationQueue({
     []
   );
 
+<<<<<<< HEAD
   const shiftValidationQueue = useCallback(() => {
     setValidationQueue((prevQueue) => prevQueue.slice(1));
+=======
+  const shiftValidationQueue = useCallback((actionId: string) => {
+    setValidationQueue((prevQueue) =>
+      prevQueue.filter((v) => v.actionId !== actionId)
+    );
+>>>>>>> 83961b732 (working multipage)
   }, []);
 
   return {
@@ -147,8 +174,13 @@ export function ActionValidationProvider({
     useValidationQueue({ pendingValidations });
 
   const [isDialogOpen, setIsDialogOpen] = useState(false);
+<<<<<<< HEAD
   const [initialQueueLength, setInitialQueueLength] = useState(0);
 
+=======
+  const [currentPageIndex, setCurrentPageIndex] = useState(0);
+  const [isProcessing, setIsProcessing] = useState(false);
+>>>>>>> 83961b732 (working multipage)
   const [errorMessage, setErrorMessage] = useState<string | null>(null);
   const [neverAskAgain, setNeverAskAgain] = useState(false);
 
@@ -172,7 +204,15 @@ export function ActionValidationProvider({
       return;
     }
 
+<<<<<<< HEAD
     const currentValidation = validationQueue[0];
+=======
+    const currentValidation = validationQueue[currentPageIndex];
+
+    if (!currentValidation) {
+      return;
+    }
+>>>>>>> 83961b732 (working multipage)
 
     if (!currentValidation) {
       return;
@@ -180,13 +220,42 @@ export function ActionValidationProvider({
 
     const { validationRequest, message } = currentValidation;
     const result = await validateAction({
-      validationRequest,
-      message,
+      validationRequest: currentValidation,
       approved:
         status === "approved" && neverAskAgain ? "always_approved" : status,
     });
 
+<<<<<<< HEAD
     if (!result.success) {
+=======
+    if (result.success) {
+      setNeverAskAgain(false);
+      setErrorMessage(null);
+    }
+
+    setErrorMessage(null);
+    setIsProcessing(true);
+
+    const response = await fetch(
+      `/api/w/${owner.sId}/assistant/conversations/${currentValidation.conversationId}/messages/${currentValidation.messageId}/validate-action`,
+      {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({
+          actionId: currentValidation.actionId,
+          approved:
+            status === "approved" && neverAskAgain ? "always_approved" : status,
+        }),
+      }
+    );
+
+    setIsProcessing(false);
+
+    if (!response.ok) {
+      setErrorMessage("Failed to assess action approval. Please try again.");
+>>>>>>> 83961b732 (working multipage)
       return;
     }
 
@@ -197,11 +266,30 @@ export function ActionValidationProvider({
 
     const remainingAfterShift = validationQueue.length - 1;
 
+<<<<<<< HEAD
     shiftValidationQueue();
 
     if (remainingAfterShift === 0) {
       setIsDialogOpen(false);
       setInitialQueueLength(0);
+=======
+    const isLastValidation = validationQueue.length === 1;
+
+    shiftValidationQueue(currentValidation.actionId);
+
+    if (isLastValidation) {
+      // No more validations, close the dialog
+      setIsDialogOpen(false);
+    } else {
+      // Move to the next page if available
+      const nextPageIndex = currentPageIndex + 1;
+      if (nextPageIndex < validationQueue.length - 1) {
+        setCurrentPageIndex(nextPageIndex);
+      } else {
+        // If we're at the last page, go to the first page
+        setCurrentPageIndex(0);
+      }
+>>>>>>> 83961b732 (working multipage)
     }
   };
 
@@ -212,6 +300,10 @@ export function ActionValidationProvider({
   const showValidationDialog = useCallback(() => {
     if (!isDialogOpen) {
       setIsDialogOpen(true);
+<<<<<<< HEAD
+=======
+      setCurrentPageIndex(0);
+>>>>>>> 83961b732 (working multipage)
     }
   }, [isDialogOpen]);
 
@@ -219,6 +311,7 @@ export function ActionValidationProvider({
   const totalPendingValidations = validationQueue.length;
 
   const pages = useMemo(() => {
+<<<<<<< HEAD
     if (!validationQueue.length || initialQueueLength === 0) {
       return [];
     }
@@ -295,6 +388,83 @@ export function ActionValidationProvider({
       ),
     }));
   }, [validationQueue, errorMessage, neverAskAgain, initialQueueLength]);
+=======
+    const basePages = validationQueue.map((validationRequest, index) => {
+      const hasDetails =
+        validationRequest?.inputs &&
+        Object.keys(validationRequest.inputs).length > 0;
+
+      return {
+        id: index.toString(),
+        title: `Tool Validation Required (${index + 1})`,
+        description: "Review and approve the tool usage request",
+        icon: validationRequest.metadata.icon
+          ? getIcon(validationRequest.metadata.icon)
+          : ActionPieChartIcon,
+        content: (
+          <div className="flex flex-col gap-4">
+            <div>
+              Allow{" "}
+              <span className="font-semibold">
+                @{validationRequest.metadata.agentName}
+              </span>{" "}
+              to use the tool{" "}
+              <span className="font-semibold">
+                {asDisplayName(validationRequest.metadata.toolName)}
+              </span>{" "}
+              from{" "}
+              <span className="font-semibold">
+                {asDisplayName(validationRequest.metadata.mcpServerName)}
+              </span>
+              ?
+            </div>
+            {hasDetails && (
+              <CollapsibleComponent
+                triggerChildren={
+                  <span className="font-medium text-muted-foreground dark:text-muted-foreground-night">
+                    Details
+                  </span>
+                }
+                contentChildren={
+                  <div>
+                    <div className="max-h-80 overflow-auto rounded-lg bg-muted dark:bg-muted-night">
+                      <CodeBlock
+                        wrapLongLines
+                        className="language-json overflow-y-auto"
+                      >
+                        {JSON.stringify(validationRequest.inputs, null, 2)}
+                      </CodeBlock>
+                    </div>
+                  </div>
+                }
+              />
+            )}
+            {errorMessage && (
+              <div className="mt-2 text-sm font-medium text-warning-800 dark:text-warning-800-night">
+                {errorMessage}
+              </div>
+            )}
+            {validationRequest.stake === "low" && (
+              <div className="mt-5">
+                <Label className="copy-sm flex w-fit cursor-pointer flex-row items-center gap-2 py-2 pr-2 font-normal">
+                  <Checkbox
+                    checked={neverAskAgain}
+                    onCheckedChange={(check) => {
+                      setNeverAskAgain(!!check);
+                    }}
+                  />
+                  <span>Always allow this tool</span>
+                </Label>
+              </div>
+            )}
+          </div>
+        ),
+      };
+    });
+
+    return basePages;
+  }, [validationQueue, errorMessage, neverAskAgain]);
+>>>>>>> 83961b732 (working multipage)
 
   return (
     <ActionValidationContext.Provider
@@ -308,6 +478,7 @@ export function ActionValidationProvider({
       {children}
 
       <MultiPageDialog open={isDialogOpen} onOpenChange={setIsDialogOpen}>
+<<<<<<< HEAD
         {pages.length > 0 && (
           <MultiPageDialogContent
             pages={pages}
@@ -343,6 +514,37 @@ export function ActionValidationProvider({
             }
           />
         )}
+=======
+        <MultiPageDialogContent
+          pages={pages}
+          currentPageId={currentPageIndex.toString()}
+          onPageChange={(pageId) => setCurrentPageIndex(parseInt(pageId))}
+          size="lg"
+          isAlertDialog
+          showNavigation={validationQueue.length > 1}
+          footerContent={
+            <div className="flex flex-row justify-end gap-2">
+              <Button
+                variant="outline"
+                label="Decline"
+                onClick={() => handleSubmit("rejected")}
+                disabled={isProcessing || isValidating}
+              >
+                Decline
+              </Button>
+              <Button
+                variant="highlight"
+                label="Allow"
+                autoFocus
+                onClick={() => handleSubmit("approved")}
+                disabled={isProcessing || isValidating}
+              >
+                Allow
+              </Button>
+            </div>
+          }
+        />
+>>>>>>> 83961b732 (working multipage)
       </MultiPageDialog>
     </ActionValidationContext.Provider>
   );

--- a/front/components/assistant/conversation/ActionValidationProvider.tsx
+++ b/front/components/assistant/conversation/ActionValidationProvider.tsx
@@ -30,21 +30,17 @@ import type {
   MCPActionValidationRequest,
 } from "@app/types";
 import { asDisplayName } from "@app/types";
-<<<<<<< HEAD
 
 type ValidationQueueItem = {
   message?: LightAgentMessageType;
   validationRequest: MCPActionValidationRequest;
 };
-=======
->>>>>>> 83961b732 (working multipage)
 
 function useValidationQueue({
   pendingValidations,
 }: {
   pendingValidations: MCPActionValidationRequest[];
 }) {
-<<<<<<< HEAD
   const [validationQueue, setValidationQueue] = useState<ValidationQueueItem[]>(
     []
   );
@@ -60,20 +56,12 @@ function useValidationQueue({
           .map((validationRequest) => ({ validationRequest }));
         return [...prevQueue, ...newItems];
       });
-=======
-  const [validationQueue, setValidationQueue] = useState<
-    MCPActionValidationRequest[]
-  >([]);
-
-  useEffect(() => {
-    if (pendingValidations.length > 0) {
-      setValidationQueue(pendingValidations);
->>>>>>> 83961b732 (working multipage)
     }
   }, [pendingValidations]);
 
   const enqueueValidation = useCallback(
     ({
+      message,
       validationRequest,
     }: {
       message: LightAgentMessageType;
@@ -82,19 +70,11 @@ function useValidationQueue({
       setValidationQueue((prevQueue) => {
         // Check if validation already exists in queue
         const exists = prevQueue.some(
-<<<<<<< HEAD
           (v) => v.validationRequest.actionId === validationRequest.actionId
         );
 
         if (!exists) {
           return [...prevQueue, { validationRequest, message }];
-=======
-          (v) => v.actionId === validationRequest.actionId
-        );
-
-        if (!exists) {
-          return [...prevQueue, validationRequest];
->>>>>>> 83961b732 (working multipage)
         }
 
         return prevQueue;
@@ -103,15 +83,8 @@ function useValidationQueue({
     []
   );
 
-<<<<<<< HEAD
   const shiftValidationQueue = useCallback(() => {
     setValidationQueue((prevQueue) => prevQueue.slice(1));
-=======
-  const shiftValidationQueue = useCallback((actionId: string) => {
-    setValidationQueue((prevQueue) =>
-      prevQueue.filter((v) => v.actionId !== actionId)
-    );
->>>>>>> 83961b732 (working multipage)
   }, []);
 
   return {
@@ -174,13 +147,8 @@ export function ActionValidationProvider({
     useValidationQueue({ pendingValidations });
 
   const [isDialogOpen, setIsDialogOpen] = useState(false);
-<<<<<<< HEAD
   const [initialQueueLength, setInitialQueueLength] = useState(0);
 
-=======
-  const [currentPageIndex, setCurrentPageIndex] = useState(0);
-  const [isProcessing, setIsProcessing] = useState(false);
->>>>>>> 83961b732 (working multipage)
   const [errorMessage, setErrorMessage] = useState<string | null>(null);
   const [neverAskAgain, setNeverAskAgain] = useState(false);
 
@@ -204,15 +172,7 @@ export function ActionValidationProvider({
       return;
     }
 
-<<<<<<< HEAD
     const currentValidation = validationQueue[0];
-=======
-    const currentValidation = validationQueue[currentPageIndex];
-
-    if (!currentValidation) {
-      return;
-    }
->>>>>>> 83961b732 (working multipage)
 
     if (!currentValidation) {
       return;
@@ -220,42 +180,13 @@ export function ActionValidationProvider({
 
     const { validationRequest, message } = currentValidation;
     const result = await validateAction({
-      validationRequest: currentValidation,
+      validationRequest,
+      message,
       approved:
         status === "approved" && neverAskAgain ? "always_approved" : status,
     });
 
-<<<<<<< HEAD
     if (!result.success) {
-=======
-    if (result.success) {
-      setNeverAskAgain(false);
-      setErrorMessage(null);
-    }
-
-    setErrorMessage(null);
-    setIsProcessing(true);
-
-    const response = await fetch(
-      `/api/w/${owner.sId}/assistant/conversations/${currentValidation.conversationId}/messages/${currentValidation.messageId}/validate-action`,
-      {
-        method: "POST",
-        headers: {
-          "Content-Type": "application/json",
-        },
-        body: JSON.stringify({
-          actionId: currentValidation.actionId,
-          approved:
-            status === "approved" && neverAskAgain ? "always_approved" : status,
-        }),
-      }
-    );
-
-    setIsProcessing(false);
-
-    if (!response.ok) {
-      setErrorMessage("Failed to assess action approval. Please try again.");
->>>>>>> 83961b732 (working multipage)
       return;
     }
 
@@ -266,30 +197,11 @@ export function ActionValidationProvider({
 
     const remainingAfterShift = validationQueue.length - 1;
 
-<<<<<<< HEAD
     shiftValidationQueue();
 
     if (remainingAfterShift === 0) {
       setIsDialogOpen(false);
       setInitialQueueLength(0);
-=======
-    const isLastValidation = validationQueue.length === 1;
-
-    shiftValidationQueue(currentValidation.actionId);
-
-    if (isLastValidation) {
-      // No more validations, close the dialog
-      setIsDialogOpen(false);
-    } else {
-      // Move to the next page if available
-      const nextPageIndex = currentPageIndex + 1;
-      if (nextPageIndex < validationQueue.length - 1) {
-        setCurrentPageIndex(nextPageIndex);
-      } else {
-        // If we're at the last page, go to the first page
-        setCurrentPageIndex(0);
-      }
->>>>>>> 83961b732 (working multipage)
     }
   };
 
@@ -300,10 +212,6 @@ export function ActionValidationProvider({
   const showValidationDialog = useCallback(() => {
     if (!isDialogOpen) {
       setIsDialogOpen(true);
-<<<<<<< HEAD
-=======
-      setCurrentPageIndex(0);
->>>>>>> 83961b732 (working multipage)
     }
   }, [isDialogOpen]);
 
@@ -311,7 +219,6 @@ export function ActionValidationProvider({
   const totalPendingValidations = validationQueue.length;
 
   const pages = useMemo(() => {
-<<<<<<< HEAD
     if (!validationQueue.length || initialQueueLength === 0) {
       return [];
     }
@@ -388,83 +295,6 @@ export function ActionValidationProvider({
       ),
     }));
   }, [validationQueue, errorMessage, neverAskAgain, initialQueueLength]);
-=======
-    const basePages = validationQueue.map((validationRequest, index) => {
-      const hasDetails =
-        validationRequest?.inputs &&
-        Object.keys(validationRequest.inputs).length > 0;
-
-      return {
-        id: index.toString(),
-        title: `Tool Validation Required (${index + 1})`,
-        description: "Review and approve the tool usage request",
-        icon: validationRequest.metadata.icon
-          ? getIcon(validationRequest.metadata.icon)
-          : ActionPieChartIcon,
-        content: (
-          <div className="flex flex-col gap-4">
-            <div>
-              Allow{" "}
-              <span className="font-semibold">
-                @{validationRequest.metadata.agentName}
-              </span>{" "}
-              to use the tool{" "}
-              <span className="font-semibold">
-                {asDisplayName(validationRequest.metadata.toolName)}
-              </span>{" "}
-              from{" "}
-              <span className="font-semibold">
-                {asDisplayName(validationRequest.metadata.mcpServerName)}
-              </span>
-              ?
-            </div>
-            {hasDetails && (
-              <CollapsibleComponent
-                triggerChildren={
-                  <span className="font-medium text-muted-foreground dark:text-muted-foreground-night">
-                    Details
-                  </span>
-                }
-                contentChildren={
-                  <div>
-                    <div className="max-h-80 overflow-auto rounded-lg bg-muted dark:bg-muted-night">
-                      <CodeBlock
-                        wrapLongLines
-                        className="language-json overflow-y-auto"
-                      >
-                        {JSON.stringify(validationRequest.inputs, null, 2)}
-                      </CodeBlock>
-                    </div>
-                  </div>
-                }
-              />
-            )}
-            {errorMessage && (
-              <div className="mt-2 text-sm font-medium text-warning-800 dark:text-warning-800-night">
-                {errorMessage}
-              </div>
-            )}
-            {validationRequest.stake === "low" && (
-              <div className="mt-5">
-                <Label className="copy-sm flex w-fit cursor-pointer flex-row items-center gap-2 py-2 pr-2 font-normal">
-                  <Checkbox
-                    checked={neverAskAgain}
-                    onCheckedChange={(check) => {
-                      setNeverAskAgain(!!check);
-                    }}
-                  />
-                  <span>Always allow this tool</span>
-                </Label>
-              </div>
-            )}
-          </div>
-        ),
-      };
-    });
-
-    return basePages;
-  }, [validationQueue, errorMessage, neverAskAgain]);
->>>>>>> 83961b732 (working multipage)
 
   return (
     <ActionValidationContext.Provider
@@ -478,7 +308,6 @@ export function ActionValidationProvider({
       {children}
 
       <MultiPageDialog open={isDialogOpen} onOpenChange={setIsDialogOpen}>
-<<<<<<< HEAD
         {pages.length > 0 && (
           <MultiPageDialogContent
             pages={pages}
@@ -514,37 +343,6 @@ export function ActionValidationProvider({
             }
           />
         )}
-=======
-        <MultiPageDialogContent
-          pages={pages}
-          currentPageId={currentPageIndex.toString()}
-          onPageChange={(pageId) => setCurrentPageIndex(parseInt(pageId))}
-          size="lg"
-          isAlertDialog
-          showNavigation={validationQueue.length > 1}
-          footerContent={
-            <div className="flex flex-row justify-end gap-2">
-              <Button
-                variant="outline"
-                label="Decline"
-                onClick={() => handleSubmit("rejected")}
-                disabled={isProcessing || isValidating}
-              >
-                Decline
-              </Button>
-              <Button
-                variant="highlight"
-                label="Allow"
-                autoFocus
-                onClick={() => handleSubmit("approved")}
-                disabled={isProcessing || isValidating}
-              >
-                Allow
-              </Button>
-            </div>
-          }
-        />
->>>>>>> 83961b732 (working multipage)
       </MultiPageDialog>
     </ActionValidationContext.Provider>
   );


### PR DESCRIPTION
## Description

- Remove currentValidation in favor of only using `validationQueue`
- `validationQueue` becomes an array
- If we have several action waiting to be validated we show a multipage dialog. Otherwise behavior is the same

## Excepted behavior:

- Should not change

## Tests

- Tested behavior with 1 and multiple actions awaiting

Uploading Screen Recording 2025-08-26 at 15.50.39.mov…

## Risk

Low. Only impact `ActionValidationProvider`

## Deploy Plan

Deploy front
