### PR TITLE
[front] - chore(AB v2): knowledge configuration page

### DIFF
--- a/front/components/agent_builder/capabilities/knowledge/KnowledgeConfigurationSheet.tsx
+++ b/front/components/agent_builder/capabilities/knowledge/KnowledgeConfigurationSheet.tsx
@@ -50,6 +50,14 @@ import { getMCPServerRequirements } from "@app/lib/actions/mcp_internal_actions/
 import type { MCPServerViewType } from "@app/lib/api/mcp";
 import type { TemplateActionPreset } from "@app/types";
 
+// Convert stored name back to user-friendly format for display
+function nameToDisplayFormat(name: string): string {
+  return name
+    .split("_")
+    .map((word) => word.charAt(0).toUpperCase() + word.slice(1))
+    .join(" ");
+}
+
 interface KnowledgeConfigurationSheetProps {
   onSave: (action: AgentBuilderAction) => void;
   onClose: () => void;
@@ -161,12 +169,15 @@ export function KnowledgeConfigurationSheet({
       return mcpServerViews.find((view) => view.server.name === "search");
     })();
 
-    const defaultName =
+    const storedName =
       action?.name ??
       presetActionData?.name ??
       selectedMCPServerView?.name ??
       selectedMCPServerView?.server.name ??
       "";
+
+    // Convert stored name to user-friendly format for display
+    const defaultName = storedName ? nameToDisplayFormat(storedName) : "";
 
     const defaultDescription =
       action?.description ?? presetActionData?.description ?? "";
@@ -342,13 +353,7 @@ function KnowledgeConfigurationSheetContent({
         <div className="space-y-6">
           <SelectDataSourcesFilters />
 
-          <NameSection
-            title="Tool Name"
-            description="Customize the name of this knowledge tool to reference it in your instructions."
-            label="Name"
-            placeholder="search_gdrive"
-            helpText="Use lowercase letters, numbers, and underscores only. No spaces allowed."
-          />
+          <NameSection title="Name" placeholder="Search Google Drive" />
 
           <ProcessingMethodSection />
 

--- a/front/components/agent_builder/capabilities/knowledge/utils.ts
+++ b/front/components/agent_builder/capabilities/knowledge/utils.ts
@@ -15,7 +15,6 @@ export interface CapabilityConfig {
     title: string;
     description: string;
     placeholder: string;
-    helpText?: string;
     maxLength?: number;
   };
 }
@@ -30,8 +29,6 @@ export const CAPABILITY_CONFIGS: Record<string, CapabilityConfig> = {
       description:
         "Provide a brief description of the data content and context to help the agent determine when to utilize it effectively.",
       placeholder: "This data contains…",
-      helpText:
-        "This description helps the agent understand what to search for.",
     },
   },
   include_data: {
@@ -44,8 +41,6 @@ export const CAPABILITY_CONFIGS: Record<string, CapabilityConfig> = {
         "Describe what type of data you want to include from your selected data sources to provide context to the agent.",
       placeholder:
         "Describe what data you want to include from your selected data sources...",
-      helpText:
-        "This description helps the agent understand what type of data to include as context.",
     },
   },
   extract_data: {
@@ -70,8 +65,6 @@ export const CAPABILITY_CONFIGS: Record<string, CapabilityConfig> = {
       description:
         "Describe what kind of queries you want to run against your selected tables. The agent will use this context to generate appropriate SQL queries.",
       placeholder: "Describe what you want to query from your tables...",
-      helpText:
-        "This description helps the agent understand what kind of SQL queries to generate based on your conversation context.",
     },
   },
 };

--- a/front/components/agent_builder/capabilities/shared/DescriptionSection.tsx
+++ b/front/components/agent_builder/capabilities/shared/DescriptionSection.tsx
@@ -8,7 +8,6 @@ interface DescriptionSectionProps {
   description: string;
   label?: string;
   placeholder: string;
-  helpText?: string;
   maxLength?: number;
 }
 
@@ -19,7 +18,6 @@ export function DescriptionSection({
   description,
   label,
   placeholder,
-  helpText,
 }: DescriptionSectionProps) {
   const { register } = useFormContext();
   const { fieldState } = useController<CapabilityFormData, typeof FIELD_NAME>({
@@ -44,11 +42,6 @@ export function DescriptionSection({
           showErrorLabel={true}
           error={fieldState.error?.message}
         />
-        {helpText && (
-          <p className="text-xs text-muted-foreground dark:text-muted-foreground-night">
-            {helpText}
-          </p>
-        )}
       </div>
     </div>
   );

--- a/front/components/agent_builder/capabilities/shared/NameSection.tsx
+++ b/front/components/agent_builder/capabilities/shared/NameSection.tsx
@@ -5,7 +5,7 @@ import type { CapabilityFormData } from "@app/components/agent_builder/types";
 
 interface NameSectionProps {
   title: string;
-  description: string;
+  description?: string;
   label?: string;
   placeholder: string;
   helpText?: string;
@@ -29,9 +29,11 @@ export function NameSection({
     <div className="space-y-4">
       <div>
         <h3 className="mb-2 text-lg font-semibold">{title}</h3>
-        <p className="text-sm text-muted-foreground dark:text-muted-foreground-night">
-          {description}
-        </p>
+        {description && (
+          <p className="text-sm text-muted-foreground dark:text-muted-foreground-night">
+            {description}
+          </p>
+        )}
       </div>
 
       <div className="space-y-2">

--- a/front/components/agent_builder/capabilities/shared/ProcessingMethodSection.tsx
+++ b/front/components/agent_builder/capabilities/shared/ProcessingMethodSection.tsx
@@ -89,47 +89,49 @@ export function ProcessingMethodSection() {
     <div className="space-y-4">
       <div>
         <h3 className="mb-2 text-lg font-semibold">Processing method</h3>
+        <span className="text-sm text-muted-foreground dark:text-muted-foreground-night">
+          Sets the approach for finding and retrieving information from your
+          data sources. Need help? Check our guide.
+        </span>
       </div>
 
-      <div className="space-y-2">
-        <DropdownMenu>
-          <DropdownMenuTrigger asChild>
-            <Button
-              isLoading={isMCPServerViewsLoading}
-              label={
-                mcpServerView
-                  ? getMcpServerViewDisplayName(mcpServerView)
-                  : "loading..."
-              }
-              icon={
-                mcpServerView != null &&
-                isInternalAllowedIcon(mcpServerView.server.icon)
-                  ? InternalActionIcons[mcpServerView.server.icon]
-                  : undefined
-              }
-              variant="outline"
-            />
-          </DropdownMenuTrigger>
+      <DropdownMenu>
+        <DropdownMenuTrigger asChild>
+          <Button
+            isLoading={isMCPServerViewsLoading}
+            label={
+              mcpServerView
+                ? getMcpServerViewDisplayName(mcpServerView)
+                : "loading..."
+            }
+            icon={
+              mcpServerView != null &&
+              isInternalAllowedIcon(mcpServerView.server.icon)
+                ? InternalActionIcons[mcpServerView.server.icon]
+                : undefined
+            }
+            variant="outline"
+          />
+        </DropdownMenuTrigger>
 
-          <DropdownMenuContent align="start" className="max-w-100">
-            {mcpServerViewsWithKnowledge
-              .filter((view) =>
-                hasOnlyTablesSelected
-                  ? tablesServer.includes(view.server.name)
-                  : !tablesServer.includes(view.server.name)
-              )
-              .map((view) => (
-                <DropdownMenuItem
-                  key={view.id}
-                  label={getMcpServerViewDisplayName(view)}
-                  icon={getAvatar(view.server)}
-                  onClick={() => onChange(view)}
-                  description={getMcpServerViewDescription(view)}
-                />
-              ))}
-          </DropdownMenuContent>
-        </DropdownMenu>
-      </div>
+        <DropdownMenuContent align="start" className="max-w-100">
+          {mcpServerViewsWithKnowledge
+            .filter((view) =>
+              hasOnlyTablesSelected
+                ? tablesServer.includes(view.server.name)
+                : !tablesServer.includes(view.server.name)
+            )
+            .map((view) => (
+              <DropdownMenuItem
+                key={view.id}
+                label={getMcpServerViewDisplayName(view)}
+                icon={getAvatar(view.server)}
+                onClick={() => onChange(view)}
+                description={getMcpServerViewDescription(view)}
+              />
+            ))}
+        </DropdownMenuContent>
+      </DropdownMenu>
       {!hasOnlyTablesSelected && hasSomeTablesSelected && (
         <Chip color="info" size="sm" label=" Your tables will be ignored " />
       )}

--- a/front/components/agent_builder/types.ts
+++ b/front/components/agent_builder/types.ts
@@ -97,10 +97,18 @@ export const capabilityFormSchema = z
     name: z
       .string()
       .min(1, "The name cannot be empty.")
-      .regex(
-        /^[a-z0-9_]+$/,
-        "The name can only contain lowercase letters, numbers, and underscores (no spaces)."
-      )
+      .transform((val) => {
+        // Convert to lowercase and replace spaces and special chars with underscores
+        return (
+          val
+            .toLowerCase()
+            .replace(/[^a-z0-9_]/g, "_")
+            // Remove consecutive underscores
+            .replace(/_+/g, "_")
+            // Remove leading/trailing underscores
+            .replace(/^_+|_+$/g, "")
+        );
+      })
       .default(""),
     description: z
       .string()

--- a/front/lib/actions/mcp_internal_actions/constants.ts
+++ b/front/lib/actions/mcp_internal_actions/constants.ts
@@ -316,7 +316,8 @@ The directive should be used to display a clickable version of the agent name in
     serverInfo: {
       name: "include_data",
       version: "1.0.0",
-      description: "Include data exhaustively",
+      description:
+        "Always includes specific documents in full for every conversation with this agent.",
       icon: "ActionTimeIcon",
       authorization: null,
       documentationUrl: null,
@@ -394,7 +395,8 @@ The directive should be used to display a clickable version of the agent name in
     serverInfo: {
       name: "extract_data",
       version: "1.0.0",
-      description: "Structured extraction",
+      description:
+        "Extracts structured information from unstructured data using your defined schema.",
       icon: "ActionScanIcon",
       authorization: null,
       documentationUrl: null,
@@ -854,7 +856,8 @@ The directive should be used to display a clickable version of the agent name in
     serverInfo: {
       name: SEARCH_SERVER_NAME,
       version: "1.0.0",
-      description: "Search through selected Data sources",
+      description:
+        "Searches through selected data sources to surface the best content for answering user queries.",
       icon: "ActionMagnifyingGlassIcon",
       authorization: null,
       documentationUrl: null,
@@ -934,7 +937,7 @@ The directive should be used to display a clickable version of the agent name in
       name: "query_tables_v2",
       version: "1.0.0",
       description:
-        "Tables, Spreadsheets, Notion DBs (quantitative) (mcp, exploded).",
+        "Transforms your questions into SQL queries for analyzing data. (quantitative) (mcp, exploded).",
       icon: "ActionTableIcon",
       authorization: null,
       documentationUrl: null,


### PR DESCRIPTION
## Description

This PR improves the knowledge configuration UI in Agent Builder v2, following the Figma [here](https://www.figma.com/design/QOxHwppG64GtPocpDhS6Y7/Product---Core?node-id=17678-32863&m=dev), by:
- Sanitizing capability names to use lowercase with underscores
- Streamlining server action descriptions for better clarity
- Removing redundant help text from capability configurations
- Adding user-friendly name display formatting in the Knowledge Configuration Sheet

## Tests

Locally

## Risk

Low

## Deploy Plan

Deploy front