### PR TITLE
[front] Support sub agent setup in action validation handling

### DIFF
--- a/front/components/assistant/conversation/ActionValidationProvider.tsx
+++ b/front/components/assistant/conversation/ActionValidationProvider.tsx
@@ -127,7 +127,7 @@ function useValidationQueue({
 
   return {
     validationQueueLength,
-    currentValidation: currentItem,
+    currentItem,
     enqueueValidation,
     shiftValidationQueue,
     clearCurrentValidation,
@@ -184,7 +184,7 @@ export function ActionValidationProvider({
 
   const {
     validationQueueLength,
-    currentValidation,
+    currentItem,
     clearCurrentValidation,
     enqueueValidation,
     shiftValidationQueue,
@@ -199,7 +199,7 @@ export function ActionValidationProvider({
   useNavigationLock(isDialogOpen);
 
   const submitValidation = async (status: MCPValidationOutputType) => {
-    if (!currentValidation) {
+    if (!currentItem) {
       return;
     }
 
@@ -211,7 +211,7 @@ export function ActionValidationProvider({
     setErrorMessage(null);
     setIsProcessing(true);
 
-    const { validationRequest, message } = currentValidation;
+    const { validationRequest, message } = currentItem;
 
     const response = await fetch(
       `/api/w/${owner.sId}/assistant/conversations/${validationRequest.conversationId}/messages/${validationRequest.messageId}/validate-action`,
@@ -281,9 +281,9 @@ export function ActionValidationProvider({
   }, [isDialogOpen]);
 
   const hasPendingValidations =
-    currentValidation !== null || validationQueueLength > 0;
-  const totalPendingValidations =
-    (currentValidation ? 1 : 0) + validationQueueLength;
+    currentItem !== null || validationQueueLength > 0;
+  const totalPendingValidations = (currentItem ? 1 : 0) + validationQueueLength;
+  const validationRequest = currentItem?.validationRequest;
 
   return (
     <ActionValidationContext.Provider
@@ -301,10 +301,8 @@ export function ActionValidationProvider({
           <DialogHeader hideButton>
             <DialogTitle
               visual={
-                currentValidation?.validationRequest.metadata.icon ? (
-                  getAvatarFromIcon(
-                    currentValidation.validationRequest.metadata.icon
-                  )
+                validationRequest?.metadata.icon ? (
+                  getAvatarFromIcon(validationRequest?.metadata.icon)
                 ) : (
                   <Icon visual={ActionPieChartIcon} size="sm" />
                 )
@@ -318,25 +316,20 @@ export function ActionValidationProvider({
               <div>
                 Allow{" "}
                 <span className="font-semibold">
-                  @{currentValidation?.validationRequest.metadata.agentName}
+                  @{validationRequest?.metadata.agentName}
                 </span>{" "}
                 to use the tool{" "}
                 <span className="font-semibold">
-                  {asDisplayName(
-                    currentValidation?.validationRequest.metadata.toolName
-                  )}
+                  {asDisplayName(validationRequest?.metadata.toolName)}
                 </span>{" "}
                 from{" "}
                 <span className="font-semibold">
-                  {asDisplayName(
-                    currentValidation?.validationRequest.metadata.mcpServerName
-                  )}
+                  {asDisplayName(validationRequest?.metadata.mcpServerName)}
                 </span>
                 ?
               </div>
-              {currentValidation?.validationRequest.inputs &&
-                Object.keys(currentValidation.validationRequest.inputs).length >
-                  0 && (
+              {validationRequest?.inputs &&
+                Object.keys(validationRequest?.inputs).length > 0 && (
                   <CollapsibleComponent
                     triggerChildren={
                       <span className="font-medium text-muted-foreground dark:text-muted-foreground-night">
@@ -350,11 +343,7 @@ export function ActionValidationProvider({
                             wrapLongLines
                             className="language-json overflow-y-auto"
                           >
-                            {JSON.stringify(
-                              currentValidation?.validationRequest.inputs,
-                              null,
-                              2
-                            )}
+                            {JSON.stringify(validationRequest?.inputs, null, 2)}
                           </CodeBlock>
                         </div>
                       </div>
@@ -375,7 +364,7 @@ export function ActionValidationProvider({
                 </div>
               )}
             </div>
-            {currentValidation?.validationRequest.stake === "low" && (
+            {validationRequest?.stake === "low" && (
               <div className="mt-5">
                 <Label className="copy-sm flex w-fit cursor-pointer flex-row items-center gap-2 py-2 pr-2 font-normal">
                   <Checkbox

--- a/front/components/assistant/conversation/ActionValidationProvider.tsx
+++ b/front/components/assistant/conversation/ActionValidationProvider.tsx
@@ -49,7 +49,7 @@ function useValidationQueue({
     Record<string, MCPActionValidationRequest>
   >({});
 
-  const [currentValidation, setCurrentValidation] = useState<{
+  const [currentItem, setCurrentItem] = useState<{
     message?: LightAgentMessageType;
     validationRequest: MCPActionValidationRequest;
   } | null>(null);
@@ -57,7 +57,7 @@ function useValidationQueue({
   useEffect(() => {
     const nextValidation = pendingValidations[0];
     if (nextValidation) {
-      setCurrentValidation({ validationRequest: nextValidation });
+      setCurrentItem({ validationRequest: nextValidation });
     }
     if (pendingValidations.length > 1) {
       setValidationQueue(
@@ -78,7 +78,7 @@ function useValidationQueue({
       message: LightAgentMessageType;
       validationRequest: MCPActionValidationRequest;
     }) => {
-      setCurrentValidation((current) => {
+      setCurrentItem((current) => {
         if (
           current === null ||
           current.validationRequest.actionId === validationRequest.actionId
@@ -109,7 +109,7 @@ function useValidationQueue({
         delete newRecord[nextValidationActionId];
         return newRecord;
       });
-      setCurrentValidation(nextValidation);
+      setCurrentItem({ validationRequest: nextValidation });
       return nextValidation;
     }
 
@@ -122,12 +122,12 @@ function useValidationQueue({
   );
 
   const clearCurrentValidation = () => {
-    setCurrentValidation(null);
+    setCurrentItem(null);
   };
 
   return {
     validationQueueLength,
-    currentValidation,
+    currentValidation: currentItem,
     enqueueValidation,
     shiftValidationQueue,
     clearCurrentValidation,
@@ -135,7 +135,7 @@ function useValidationQueue({
 }
 
 type ActionValidationContextType = {
-  enqueueValidation: (params?: {
+  enqueueValidation: (params: {
     message: LightAgentMessageType;
     validationRequest: MCPActionValidationRequest;
   }) => void;
@@ -322,7 +322,9 @@ export function ActionValidationProvider({
                 </span>{" "}
                 to use the tool{" "}
                 <span className="font-semibold">
-                  {asDisplayName(currentValidation?.validationRequest.metadata.toolName)}
+                  {asDisplayName(
+                    currentValidation?.validationRequest.metadata.toolName
+                  )}
                 </span>{" "}
                 from{" "}
                 <span className="font-semibold">

--- a/front/components/assistant/conversation/AgentMessage.tsx
+++ b/front/components/assistant/conversation/AgentMessage.tsx
@@ -124,12 +124,15 @@ export function AgentMessage({
       if (eventType === "tool_approve_execution") {
         showValidationDialog();
         enqueueValidation({
-          messageId: eventPayload.data.messageId,
-          conversationId: eventPayload.data.conversationId,
-          actionId: eventPayload.data.actionId,
-          inputs: eventPayload.data.inputs,
-          stake: eventPayload.data.stake,
-          metadata: eventPayload.data.metadata,
+          message,
+          validationRequest: {
+            messageId: eventPayload.data.messageId,
+            conversationId: eventPayload.data.conversationId,
+            actionId: eventPayload.data.actionId,
+            inputs: eventPayload.data.inputs,
+            stake: eventPayload.data.stake,
+            metadata: eventPayload.data.metadata,
+          },
         });
       }
     },

--- a/front/hooks/useValidateAction.ts
+++ b/front/hooks/useValidateAction.ts
@@ -1,0 +1,92 @@
+import { useCallback, useState } from "react";
+
+import type { MCPValidationOutputType } from "@app/lib/actions/constants";
+import type {
+  ConversationWithoutContentType,
+  LightAgentMessageType,
+  LightWorkspaceType,
+  MCPActionValidationRequest,
+} from "@app/types";
+
+interface UseValidateActionParams {
+  owner: LightWorkspaceType;
+  conversation: ConversationWithoutContentType | null;
+  onError?: (errorMessage: string) => void;
+}
+
+export function useValidateAction({
+  owner,
+  conversation,
+  onError,
+}: UseValidateActionParams) {
+  const [isValidating, setIsValidating] = useState(false);
+
+  const validateAction = useCallback(
+    async ({
+      validationRequest,
+      message,
+      approved,
+    }: {
+      validationRequest: MCPActionValidationRequest;
+      message?: LightAgentMessageType;
+      approved: MCPValidationOutputType;
+    }) => {
+      setIsValidating(true);
+
+      try {
+        // Validate the action.
+        const response = await fetch(
+          `/api/w/${owner.sId}/assistant/conversations/${validationRequest.conversationId}/messages/${validationRequest.messageId}/validate-action`,
+          {
+            method: "POST",
+            headers: {
+              "Content-Type": "application/json",
+            },
+            body: JSON.stringify({
+              actionId: validationRequest.actionId,
+              approved,
+            }),
+          }
+        );
+
+        if (!response.ok && onError) {
+          onError("Failed to assess action approval. Please try again.");
+          return { success: false };
+        }
+
+        // Retry on blocked tools on the main conversation if there is one that is != from the event's.
+        if (
+          conversation?.sId &&
+          message &&
+          conversation.sId !== validationRequest.conversationId
+        ) {
+          const response = await fetch(
+            `/api/w/${owner.sId}/assistant/conversations/${conversation.sId}/messages/${message.sId}/retry?blocked_only=true`,
+            {
+              method: "POST",
+              headers: {
+                "Content-Type": "application/json",
+              },
+            }
+          );
+
+          if (!response.ok && onError) {
+            onError("Failed to resume conversation. Please try again.");
+            return { success: false };
+          }
+        }
+        return { success: true };
+      } catch (error) {
+        if (onError) {
+          onError("Failed to assess action approval. Please try again.");
+        }
+        return { success: false };
+      } finally {
+        setIsValidating(false);
+      }
+    },
+    [owner.sId, conversation?.sId, onError]
+  );
+
+  return { validateAction, isValidating };
+}

--- a/front/hooks/useValidateAction.ts
+++ b/front/hooks/useValidateAction.ts
@@ -11,7 +11,7 @@ import type {
 interface UseValidateActionParams {
   owner: LightWorkspaceType;
   conversation: ConversationWithoutContentType | null;
-  onError?: (errorMessage: string) => void;
+  onError: (errorMessage: string) => void;
 }
 
 export function useValidateAction({
@@ -50,9 +50,7 @@ export function useValidateAction({
         );
 
         if (!response.ok) {
-          if (onError) {
-            onError("Failed to assess action approval. Please try again.");
-          }
+          onError("Failed to assess action approval. Please try again.");
           return { success: false };
         }
 
@@ -73,17 +71,13 @@ export function useValidateAction({
           );
 
           if (!response.ok) {
-            if (onError) {
-              onError("Failed to resume conversation. Please try again.");
-            }
+            onError("Failed to resume conversation. Please try again.");
             return { success: false };
           }
         }
         return { success: true };
       } catch (error) {
-        if (onError) {
-          onError("Failed to assess action approval. Please try again.");
-        }
+        onError("Failed to assess action approval. Please try again.");
         return { success: false };
       } finally {
         setIsValidating(false);

--- a/front/hooks/useValidateAction.ts
+++ b/front/hooks/useValidateAction.ts
@@ -49,8 +49,10 @@ export function useValidateAction({
           }
         );
 
-        if (!response.ok && onError) {
-          onError("Failed to assess action approval. Please try again.");
+        if (!response.ok) {
+          if (onError) {
+            onError("Failed to assess action approval. Please try again.");
+          }
           return { success: false };
         }
 
@@ -70,8 +72,10 @@ export function useValidateAction({
             }
           );
 
-          if (!response.ok && onError) {
-            onError("Failed to resume conversation. Please try again.");
+          if (!response.ok) {
+            if (onError) {
+              onError("Failed to resume conversation. Please try again.");
+            }
             return { success: false };
           }
         }


### PR DESCRIPTION
## Description

- This PR adds an optional message to the action validation context, allowing to identify a pending validation coming from a sub agent and triggering the correct validation flow (`validate-action` on the sub agent's action + `retry?blocked_only=true` on the parent).

## Tests

- Tested locally.

## Risk

- Low.

## Deploy Plan

- Deploy front.
