### PR TITLE
[front] Refactor `ActionValidationContext`

### DIFF
--- a/front/components/assistant/conversation/ActionValidationProvider.tsx
+++ b/front/components/assistant/conversation/ActionValidationProvider.tsx
@@ -112,7 +112,7 @@ function useValidationQueue({
     [validationQueue]
   );
 
-  const clearCurrentItem = () => {
+  const clearCurrentValidation = () => {
     setCurrentValidation(null);
   };
 
@@ -126,9 +126,7 @@ function useValidationQueue({
 }
 
 type ActionValidationContextType = {
-  enqueueValidation: (
-    validationRequest?: MCPActionValidationRequest
-  ) => void;
+  enqueueValidation: (validationRequest: MCPActionValidationRequest) => void;
   showValidationDialog: () => void;
   hasPendingValidations: boolean;
   totalPendingValidations: number;
@@ -189,7 +187,7 @@ export function ActionValidationProvider({
   useNavigationLock(isDialogOpen);
 
   const submitValidation = async (status: MCPValidationOutputType) => {
-    if (!currentItem) {
+    if (!currentValidation) {
       return;
     }
 
@@ -252,9 +250,9 @@ export function ActionValidationProvider({
   }, [isDialogOpen]);
 
   const hasPendingValidations =
-    currentItem !== null || validationQueueLength > 0;
-  const totalPendingValidations = (currentItem ? 1 : 0) + validationQueueLength;
-
+    currentValidation !== null || validationQueueLength > 0;
+  const totalPendingValidations =
+    (currentValidation ? 1 : 0) + validationQueueLength;
 
   return (
     <ActionValidationContext.Provider
@@ -285,8 +283,11 @@ export function ActionValidationProvider({
           <DialogContainer>
             <div className="flex flex-col gap-4">
               <div>
-                Allow <b>@{currentValidation?.metadata.agentName}</b> to use the
-                tool{" "}
+                Allow{" "}
+                <span className="font-semibold">
+                  @{currentValidation?.metadata.agentName}
+                </span>{" "}
+                to use the tool{" "}
                 <b>{asDisplayName(currentValidation?.metadata.toolName)}</b>{" "}
                 from{" "}
                 <b>

--- a/front/components/assistant/conversation/ActionValidationProvider.tsx
+++ b/front/components/assistant/conversation/ActionValidationProvider.tsx
@@ -288,11 +288,13 @@ export function ActionValidationProvider({
                   @{currentValidation?.metadata.agentName}
                 </span>{" "}
                 to use the tool{" "}
-                <b>{asDisplayName(currentValidation?.metadata.toolName)}</b>{" "}
+                <span className="font-semibold">
+                  {asDisplayName(currentValidation?.metadata.toolName)}
+                </span>{" "}
                 from{" "}
-                <b>
+                <span className="font-semibold">
                   {asDisplayName(currentValidation?.metadata.mcpServerName)}
-                </b>
+                </span>
                 ?
               </div>
               {currentValidation?.inputs &&

--- a/front/components/assistant/conversation/ActionValidationProvider.tsx
+++ b/front/components/assistant/conversation/ActionValidationProvider.tsx
@@ -48,13 +48,13 @@ function useValidationQueue({
     Record<string, MCPActionValidationRequest>
   >({});
 
-  const [currentItem, setCurrentItem] =
+  const [currentValidation, setCurrentValidation] =
     useState<MCPActionValidationRequest | null>(null);
 
   useEffect(() => {
     const nextValidation = pendingValidations[0];
     if (nextValidation) {
-      setCurrentItem(nextValidation);
+      setCurrentValidation(nextValidation);
     }
     if (pendingValidations.length > 1) {
       setValidationQueue(
@@ -69,7 +69,7 @@ function useValidationQueue({
 
   const enqueueValidation = useCallback(
     (validationRequest: MCPActionValidationRequest) => {
-      setCurrentItem((current) => {
+      setCurrentValidation((current) => {
         if (
           current === null ||
           current.actionId === validationRequest.actionId
@@ -100,7 +100,7 @@ function useValidationQueue({
         delete newRecord[nextValidationActionId];
         return newRecord;
       });
-      setCurrentItem(nextValidation);
+      setCurrentValidation(nextValidation);
       return nextValidation;
     }
 
@@ -112,12 +112,16 @@ function useValidationQueue({
     [validationQueue]
   );
 
+  const clearCurrentItem = () => {
+    setCurrentValidation(null);
+  };
+
   return {
     validationQueueLength,
     currentValidation,
     enqueueValidation,
     shiftValidationQueue,
-    setCurrentValidation,
+    clearCurrentValidation,
   };
 }
 
@@ -171,7 +175,7 @@ export function ActionValidationProvider({
   const {
     validationQueueLength,
     currentValidation,
-    setCurrentItem,
+    clearCurrentValidation,
     enqueueValidation,
     shiftValidationQueue,
   } = useValidationQueue({ pendingValidations });
@@ -235,7 +239,7 @@ export function ActionValidationProvider({
   const onDialogAnimationEnd = () => {
     // This is safe to check because the dialog closing animation is triggered after isDialogOpen is set to false.
     if (!isDialogOpen) {
-      setCurrentItem(null);
+      clearCurrentValidation();
       setErrorMessage(null);
     }
   };

--- a/front/components/assistant/conversation/AgentMessage.tsx
+++ b/front/components/assistant/conversation/AgentMessage.tsx
@@ -102,7 +102,8 @@ export function AgentMessage({
     message.configuration.sId as GLOBAL_AGENTS_SID
   );
 
-  const { showValidationDialog } = useActionValidationContext();
+  const { showValidationDialog, enqueueValidation } =
+    useActionValidationContext();
 
   const { mutateMessage } = useConversationMessage({
     conversationId,
@@ -121,7 +122,8 @@ export function AgentMessage({
       const eventType = eventPayload.data.type;
 
       if (eventType === "tool_approve_execution") {
-        showValidationDialog({
+        showValidationDialog();
+        enqueueValidation({
           messageId: eventPayload.data.messageId,
           conversationId: eventPayload.data.conversationId,
           actionId: eventPayload.data.actionId,


### PR DESCRIPTION
## Description

This PR refactors the action validation context, mostly via renaming.
- It now exposes two callbacks: `showValidationDialog` and `enqueueValidation` instead of having `showValidationDialog` enqueue an item.
- It refactors a bit the responsibilities between `useValidationQueue` and the context provider.

## Tests

- Tested locally.

## Risk

- Low.

## Deploy Plan

- Deploy front.
