### PR TITLE
[front] Implement UI for actions blocked on personal authentication in Dialog

### DIFF
--- a/front/components/actions/mcp/ConnectMCPServerDialog.tsx
+++ b/front/components/actions/mcp/ConnectMCPServerDialog.tsx
@@ -11,6 +11,7 @@ import { useCallback, useEffect, useMemo, useState } from "react";
 import { MCPServerOAuthConnexion } from "@app/components/actions/mcp/MCPServerOAuthConnexion";
 import { useSendNotification } from "@app/hooks/useNotification";
 import {
+  getMcpServerDisplayName,
   getMcpServerViewDisplayName,
   getServerTypeAndIdFromSId,
   isRemoteMCPServerType,
@@ -169,7 +170,8 @@ export function ConnectMCPServerDialog({
     // Then associate connection.
     await createMCPServerConnection({
       connectionId: cRes.value.connection_id,
-      mcpServer: mcpServerView.server,
+      mcpServerId: mcpServerView.server.sId,
+      mcpServerDisplayName: getMcpServerDisplayName(mcpServerView.server),
       provider: authorization.provider,
     });
 

--- a/front/components/agent_builder/PersonalConnectionRequiredDialog.tsx
+++ b/front/components/agent_builder/PersonalConnectionRequiredDialog.tsx
@@ -175,7 +175,9 @@ export function PersonalConnectionRequiredDialog({
                             }
                             setIsConnecting(true);
                             await createPersonalConnection({
-                              mcpServer: mcpServerView.server,
+                              mcpServerId: mcpServerView.server.sId,
+                              mcpServerDisplayName:
+                                getMcpServerViewDisplayName(mcpServerView),
                               provider:
                                 mcpServerView.server.authorization.provider,
                               useCase: "personal_actions",

--- a/front/components/assistant/conversation/ActionValidationProvider.tsx
+++ b/front/components/assistant/conversation/ActionValidationProvider.tsx
@@ -610,7 +610,10 @@ export function ActionValidationProvider({
               <Button
                 label="Done"
                 variant="highlight"
-                onClick={() => retryBlockedActions()}
+                onClick={() => {
+                  void retryBlockedActions();
+                  setIsDialogOpen(false);
+                }}
                 disabled={isProcessing}
               >
                 {isProcessing && (

--- a/front/components/assistant/conversation/ActionValidationProvider.tsx
+++ b/front/components/assistant/conversation/ActionValidationProvider.tsx
@@ -30,6 +30,7 @@ import { useNavigationLock } from "@app/components/assistant_builder/useNavigati
 import { useValidateAction } from "@app/hooks/useValidateAction";
 import type { MCPValidationOutputType } from "@app/lib/actions/constants";
 import type { BlockedActionExecution } from "@app/lib/actions/mcp";
+import { getMcpServerDisplayName } from "@app/lib/actions/mcp_helper";
 import { getAvatarFromIcon } from "@app/lib/actions/mcp_icons";
 import type { AuthorizationInfo } from "@app/lib/actions/mcp_metadata";
 import { useSubmitFunction } from "@app/lib/client/utils";
@@ -70,7 +71,7 @@ function PersonalAuthenticationRequiredInline({
 
   const { createPersonalConnection } = useCreatePersonalConnection(owner);
   const { submit: retry } = useSubmitFunction(async () => retryHandler());
-
+  getMcpServerDisplayName;
   const handleConnect = async () => {
     if (!mcpServer) {
       return;
@@ -99,8 +100,8 @@ function PersonalAuthenticationRequiredInline({
         ) : (
           <Icon visual={ActionPieChartIcon} size="sm" />
         )}
-        <span className="font-medium capitalize">
-          {blockedAction.metadata.mcpServerName}
+        <span className="font-medium">
+          {asDisplayName(blockedAction.metadata.mcpServerName)}
         </span>
       </div>
       {mcpServer &&

--- a/front/components/assistant/conversation/ActionValidationProvider.tsx
+++ b/front/components/assistant/conversation/ActionValidationProvider.tsx
@@ -2,6 +2,7 @@ import {
   ActionPieChartIcon,
   Button,
   Checkbox,
+  Chip,
   CloudArrowLeftRightIcon,
   CodeBlock,
   CollapsibleComponent,
@@ -102,16 +103,23 @@ function PersonalAuthenticationRequiredInline({
           {blockedAction.metadata.mcpServerName}
         </span>
       </div>
-      {!isConnected && mcpServer && (
-        <Button
-          label={isConnected ? "Connected" : "Connect"}
-          variant={isConnected ? "success" : "outline"}
-          size="sm"
-          icon={isConnected ? undefined : CloudArrowLeftRightIcon}
-          disabled={isConnecting || isConnected}
-          onClick={() => handleConnect()}
-        />
-      )}
+      {mcpServer &&
+        (isConnected ? (
+          <Chip color="success" size="xs">
+            Connected
+          </Chip>
+        ) : isConnecting ? (
+          <Spinner size="sm" />
+        ) : (
+          <Button
+            label={"Connect"}
+            variant={"outline"}
+            size="sm"
+            icon={CloudArrowLeftRightIcon}
+            disabled={isConnecting || isConnected}
+            onClick={() => handleConnect()}
+          />
+        ))}
     </div>
   );
 }

--- a/front/components/assistant/conversation/ActionValidationProvider.tsx
+++ b/front/components/assistant/conversation/ActionValidationProvider.tsx
@@ -77,12 +77,12 @@ function PersonalAuthenticationRequiredInline({
       return;
     }
     setIsConnecting(true);
-    const success = await createPersonalConnection(
+    const success = await createPersonalConnection({
       mcpServer,
-      blockedAction.authorizationInfo.provider,
-      "personal_actions",
-      blockedAction.authorizationInfo.scope
-    );
+      provider: blockedAction.authorizationInfo.provider,
+      useCase: "personal_actions",
+      scope: blockedAction.authorizationInfo.scope,
+    });
     setIsConnecting(false);
     if (!success) {
       setIsConnected(false);

--- a/front/components/assistant/conversation/ActionValidationProvider.tsx
+++ b/front/components/assistant/conversation/ActionValidationProvider.tsx
@@ -24,6 +24,7 @@ import {
   useState,
 } from "react";
 
+import { MCPServerPersonalAuthenticationRequired } from "@app/components/assistant/conversation/MCPServerPersonalAuthenticationRequired";
 import { useNavigationLock } from "@app/components/assistant_builder/useNavigationLock";
 import { useValidateAction } from "@app/hooks/useValidateAction";
 import type { MCPValidationOutputType } from "@app/lib/actions/constants";
@@ -319,9 +320,17 @@ export function ActionValidationProvider({
                 ))
               }
             >
-              {isAuthenticationRequired
-                ? "Personal Authentication Required"
-                : "Tool Validation Required"}
+              {isAuthenticationRequired ? (
+                <div className="flex flex-col">
+                  <span>Personal Authentication Required</span>
+                  <span className="text-sm font-normal text-muted-foreground dark:text-muted-foreground-night">
+                    The agent took an action that requires personal
+                    authentication
+                  </span>
+                </div>
+              ) : (
+                "Tool Validation Required"
+              )}
             </DialogTitle>
           </DialogHeader>
           <DialogContainer>
@@ -409,18 +418,22 @@ export function ActionValidationProvider({
             )}</>)
             {/* TODO: move this to an actual component, TBD on work on triggers.. */}
             {isAuthenticationRequired ? (
-              <div className="flex flex-col gap-4">
-                <span>
-                  The agent took an action that requires personal authentication
-                </span>
-                {actionsBlockedOnAuthentication.map((action) => (
-                  // TODO
-                  <div key={action.actionId}>
-                    <b>@{action.metadata.agentName}</b> is trying to use the
-                    tool <b>{asDisplayName(action.metadata.toolName)}</b> from{" "}
-                    <b>{asDisplayName(action.metadata.mcpServerName)}</b>
-                  </div>
-                ))}
+              <div className="flex flex-col gap-2">
+                {actionsBlockedOnAuthentication.map(
+                  (action) =>
+                    action.mcpServerId &&
+                    action.authorizationInfo && (
+                      <MCPServerPersonalAuthenticationRequired
+                        key={`personal-auth-required-${action.actionId}`}
+                        owner={owner}
+                        mcpServerId={action.mcpServerId}
+                        provider={action.authorizationInfo.provider}
+                        scope={action.authorizationInfo.scope}
+                        // We only retry when clicking on Done.
+                        retryHandler={() => {}}
+                      />
+                    )
+                )}
               </div>
             ) : (
               <>

--- a/front/components/assistant/conversation/ActionValidationProvider.tsx
+++ b/front/components/assistant/conversation/ActionValidationProvider.tsx
@@ -507,50 +507,50 @@ export function ActionValidationProvider({
               </div>
           </DialogContainer>
           <DialogFooter>
-            isAuthenticationRequired ?
-            <Button
-              label="Done"
-              variant="highlight"
-              onClick={() => retryBlockedActions()}
-              disabled={isProcessing}
-            >
-              {isProcessing && (
-                <div className="flex items-center">
-                  <span className="mr-2">Resuming</span>
-                  <Spinner size="xs" variant="dark" />
-                </div>
-              )}
-            </Button>
-            :(
-            <>
+            {isAuthenticationRequired ? (
               <Button
-                label="Decline"
-                variant="outline"
-                onClick={() => handleSubmit("rejected")}
-                disabled={isValidating}
+                label="Done"
+                variant="highlight"
+                onClick={() => retryBlockedActions()}
+                disabled={isProcessing}
               >
-                {isValidating && (
+                {isProcessing && (
                   <div className="flex items-center">
-                    <span className="mr-2">Declining</span>
+                    <span className="mr-2">Resuming</span>
                     <Spinner size="xs" variant="dark" />
                   </div>
                 )}
               </Button>
-              <Button
-                label="Allow"
-                variant="highlight"
-                onClick={() => handleSubmit("approved")}
-                disabled={isValidating}
-              >
-                {isValidating && (
-                  <div className="flex items-center">
-                    <span className="mr-2">Approving</span>
-                    <Spinner size="xs" variant="light" />
-                  </div>
-                )}
-              </Button>
-            </>
-            )
+            ) : (
+              <>
+                <Button
+                  label="Decline"
+                  variant="outline"
+                  onClick={() => handleSubmit("rejected")}
+                  disabled={isValidating}
+                >
+                  {isValidating && (
+                    <div className="flex items-center">
+                      <span className="mr-2">Declining</span>
+                      <Spinner size="xs" variant="dark" />
+                    </div>
+                  )}
+                </Button>
+                <Button
+                  label="Allow"
+                  variant="highlight"
+                  onClick={() => handleSubmit("approved")}
+                  disabled={isValidating}
+                >
+                  {isValidating && (
+                    <div className="flex items-center">
+                      <span className="mr-2">Approving</span>
+                      <Spinner size="xs" variant="light" />
+                    </div>
+                  )}
+                </Button>
+              </>
+            )}
           </DialogFooter>
         </DialogContent>
       </Dialog>

--- a/front/components/assistant/conversation/ActionValidationProvider.tsx
+++ b/front/components/assistant/conversation/ActionValidationProvider.tsx
@@ -64,6 +64,7 @@ function PersonalAuthenticationRequiredInline({
   const [isConnected, setIsConnected] = useState(false);
   const [isConnecting, setIsConnecting] = useState(false);
 
+  // TODO: get rid of this
   const { server: mcpServer } = useMCPServer({
     owner,
     serverId: blockedAction.mcpServerId,
@@ -71,7 +72,7 @@ function PersonalAuthenticationRequiredInline({
 
   const { createPersonalConnection } = useCreatePersonalConnection(owner);
   const { submit: retry } = useSubmitFunction(async () => retryHandler());
-  getMcpServerDisplayName;
+
   const handleConnect = async () => {
     if (!mcpServer) {
       return;
@@ -262,6 +263,8 @@ export function ActionValidationProvider({
     conversationId: conversation?.sId || null,
     workspaceId: owner.sId,
   });
+
+  const { createPersonalConnection } = useCreatePersonalConnection(owner);
 
   const [actionsBlockedOnAuthentication, setActionsBlockedOnAuthentication] =
     useState<BlockedActionExecution[]>([]);

--- a/front/components/assistant/conversation/ConversationContainer.tsx
+++ b/front/components/assistant/conversation/ConversationContainer.tsx
@@ -64,7 +64,7 @@ export function ConversationContainer({
     useContext(InputBarContext);
 
   const {
-    hasPendingValidations,
+    userActionIsRequired,
     totalPendingValidations,
     showValidationDialog,
   } = useActionValidationContext();
@@ -365,7 +365,7 @@ export function ConversationContainer({
         </div>
       )}
 
-      {activeConversationId && hasPendingValidations && (
+      {activeConversationId && userActionIsRequired && (
         <ContentMessageInline
           icon={InformationCircleIcon}
           variant="primary"
@@ -392,7 +392,7 @@ export function ConversationContainer({
         }
         stickyMentions={stickyMentions}
         conversationId={activeConversationId}
-        disable={activeConversationId !== null && hasPendingValidations}
+        disable={activeConversationId !== null && userActionIsRequired}
       />
 
       {!activeConversationId && (

--- a/front/components/assistant/conversation/MCPServerPersonalAuthenticationRequired.tsx
+++ b/front/components/assistant/conversation/MCPServerPersonalAuthenticationRequired.tsx
@@ -6,6 +6,7 @@ import {
 } from "@dust-tt/sparkle";
 import { useState } from "react";
 
+import { getMcpServerDisplayName } from "@app/lib/actions/mcp_helper";
 import { useSubmitFunction } from "@app/lib/client/utils";
 import {
   useCreatePersonalConnection,
@@ -66,7 +67,8 @@ export function MCPServerPersonalAuthenticationRequired({
             onClick={async () => {
               setIsConnecting(true);
               const success = await createPersonalConnection({
-                mcpServer,
+                mcpServerId: mcpServer.sId,
+                mcpServerDisplayName: getMcpServerDisplayName(mcpServer),
                 provider,
                 useCase: "personal_actions",
                 scope,

--- a/front/lib/actions/mcp.ts
+++ b/front/lib/actions/mcp.ts
@@ -168,6 +168,7 @@ export type ToolExecutionMetadata = {
   actionId: string;
   inputs: Record<string, unknown>;
   stake?: MCPToolStakeLevelType;
+  mcpServerId?: string;
   metadata: MCPValidationMetadataType;
 };
 

--- a/front/lib/actions/mcp.ts
+++ b/front/lib/actions/mcp.ts
@@ -165,16 +165,18 @@ export type LightMCPToolConfigurationType =
   | LightClientSideMCPToolConfigurationType;
 
 export type ToolExecutionMetadata = {
+  conversationId: string;
+  messageId: string;
   actionId: string;
+
   inputs: Record<string, unknown>;
   stake?: MCPToolStakeLevelType;
+
   mcpServerId?: string;
   metadata: MCPValidationMetadataType;
 };
 
 export type BlockedActionExecution = ToolExecutionMetadata & {
-  messageId: string;
-  conversationId: string;
   status: ToolExecutionBlockedStatus;
   authorizationInfo: AuthorizationInfo | null;
 };
@@ -184,8 +186,6 @@ export type MCPApproveExecutionEvent = ToolExecutionMetadata & {
   type: "tool_approve_execution";
   created: number;
   configurationId: string;
-  messageId: string;
-  conversationId: string;
   isLastBlockingEventForStep?: boolean;
 };
 

--- a/front/lib/resources/agent_mcp_action_resource.ts
+++ b/front/lib/resources/agent_mcp_action_resource.ts
@@ -257,6 +257,11 @@ export class AgentMCPActionResource extends BaseResource<AgentMCPActionModel> {
         isToolExecutionStatusBlocked(action.status),
         "Action is not blocked."
       );
+      const mcpServerView = isLightServerSideMCPToolConfiguration(
+        action.toolConfiguration
+      )
+        ? mcpServerViewMap.get(action.toolConfiguration.mcpServerViewId)
+        : null;
 
       blockedActionsList.push({
         messageId: agentMessage.message.sId,
@@ -273,14 +278,9 @@ export class AgentMCPActionResource extends BaseResource<AgentMCPActionModel> {
           agentName: agentConfiguration.name,
           icon: action.toolConfiguration.icon,
         },
+        mcpServerId: mcpServerView?.mcpServerId,
         status: action.status,
-        authorizationInfo: isLightServerSideMCPToolConfiguration(
-          action.toolConfiguration
-        )
-          ? mcpServerViewMap
-              .get(action.toolConfiguration.mcpServerViewId)
-              ?.toJSON().server.authorization ?? null
-          : null,
+        authorizationInfo: mcpServerView?.toJSON().server.authorization ?? null,
       });
     }
 

--- a/front/lib/swr/mcp_servers.ts
+++ b/front/lib/swr/mcp_servers.ts
@@ -617,11 +617,13 @@ export function useCreateMCPServerConnection({
   const sendNotification = useSendNotification();
   const createMCPServerConnection = async ({
     connectionId,
-    mcpServer,
+    mcpServerId,
+    mcpServerDisplayName,
     provider,
   }: {
     connectionId: string;
-    mcpServer: MCPServerType;
+    mcpServerId: string;
+    mcpServerDisplayName: string;
     provider: OAuthProvider;
   }): Promise<PostConnectionResponseBody | null> => {
     const response = await fetch(
@@ -633,7 +635,7 @@ export function useCreateMCPServerConnection({
         },
         body: JSON.stringify({
           connectionId,
-          mcpServerId: mcpServer.sId,
+          mcpServerId,
           provider,
         }),
       }
@@ -641,8 +643,8 @@ export function useCreateMCPServerConnection({
     if (response.ok) {
       sendNotification({
         type: "success",
-        title: `${getMcpServerDisplayName(mcpServer)} connected`,
-        description: `Successfully connected to ${getMcpServerDisplayName(mcpServer)}.`,
+        title: `${mcpServerDisplayName} connected`,
+        description: `Successfully connected to ${mcpServerDisplayName}.`,
       });
       void mutateConnections();
       if (connectionType === "workspace") {
@@ -652,8 +654,8 @@ export function useCreateMCPServerConnection({
     } else {
       sendNotification({
         type: "error",
-        title: `Failed to connect ${getMcpServerDisplayName(mcpServer)}`,
-        description: `Could not connect to ${getMcpServerDisplayName(mcpServer)}. Please try again.`,
+        title: `Failed to connect ${mcpServerDisplayName}`,
+        description: `Could not connect to ${mcpServerDisplayName}. Please try again.`,
       });
       return null;
     }
@@ -826,19 +828,21 @@ export function useCreatePersonalConnection(owner: LightWorkspaceType) {
   const sendNotification = useSendNotification();
 
   const createPersonalConnection = async ({
-    mcpServer,
+    mcpServerId,
+    mcpServerDisplayName,
     provider,
     useCase,
     scope,
   }: {
-    mcpServer: MCPServerType;
+    mcpServerId: string;
+    mcpServerDisplayName: string;
     provider: OAuthProvider;
     useCase: OAuthUseCase;
     scope?: string;
   }): Promise<boolean> => {
     try {
       const extraConfig: Record<string, string> = {
-        mcp_server_id: mcpServer.sId,
+        mcp_server_id: mcpServerId,
       };
 
       if (scope) {
@@ -864,7 +868,8 @@ export function useCreatePersonalConnection(owner: LightWorkspaceType) {
 
       const result = await createMCPServerConnection({
         connectionId: cRes.value.connection_id,
-        mcpServer,
+        mcpServerId: mcpServerId,
+        mcpServerDisplayName: mcpServerDisplayName,
         provider,
       });
 


### PR DESCRIPTION
## Description

- Part of https://github.com/dust-tt/tasks/issues/3881.
- This PR implements a quick and dirty version of the personal authentication dialog, in an effort to bring everything into the Dialog handle all blocked actions similarly.

<img width="643" height="347" alt="Screenshot 2025-08-26 at 2 24 57 AM" src="https://github.com/user-attachments/assets/7cd6bc15-c68c-4318-8ed6-6e3af6a64fde" />

## Tests

- Tested locally.

## Risk

## Deploy Plan

- Deploy front.
