### PR TITLE
[GDrive - Microsoft] Up max file size to download: 128 -> 256 MB

### DIFF
--- a/connectors/src/lib/data_sources.ts
+++ b/connectors/src/lib/data_sources.ts
@@ -47,7 +47,7 @@ export const MAX_DOCUMENT_TXT_LEN = 750000;
 export const MAX_SMALL_DOCUMENT_TXT_LEN = 500000;
 // For some data sources we allow large documents (5mb) to be processed (behind flag).
 export const MAX_LARGE_DOCUMENT_TXT_LEN = 5000000;
-export const MAX_FILE_SIZE_TO_DOWNLOAD = 128 * 1024 * 1024;
+export const MAX_FILE_SIZE_TO_DOWNLOAD = 256 * 1024 * 1024;
 
 const MAX_TITLE_LENGTH = 512;
 const MAX_TAG_LENGTH = 512;


### PR DESCRIPTION
Description
---
Asked multiple times by a high value pilot, and causes some issues for customers https://github.com/dust-tt/tasks/issues/3895

Risk
---
low; potentially mem issues on pods but we likely would have seen some before

Deploy
---
connectors
