### PR TITLE
Handle blocking events from child agents in run_agent tool

### DIFF
--- a/front/components/assistant/conversation/ActionValidationProvider.tsx
+++ b/front/components/assistant/conversation/ActionValidationProvider.tsx
@@ -30,6 +30,7 @@ import { getAvatarFromIcon } from "@app/lib/actions/mcp_icons";
 import { useBlockedActions } from "@app/lib/swr/blocked_actions";
 import type {
   ConversationWithoutContentType,
+  LightAgentMessageType,
   LightWorkspaceType,
   MCPActionValidationRequest,
 } from "@app/types";
@@ -48,13 +49,15 @@ function useValidationQueue({
     Record<string, MCPActionValidationRequest>
   >({});
 
-  const [currentValidation, setCurrentValidation] =
-    useState<MCPActionValidationRequest | null>(null);
+  const [currentValidation, setCurrentValidation] = useState<{
+    message?: LightAgentMessageType;
+    validationRequest: MCPActionValidationRequest;
+  } | null>(null);
 
   useEffect(() => {
     const nextValidation = pendingValidations[0];
     if (nextValidation) {
-      setCurrentValidation(nextValidation);
+      setCurrentValidation({ validationRequest: nextValidation });
     }
     if (pendingValidations.length > 1) {
       setValidationQueue(
@@ -72,9 +75,9 @@ function useValidationQueue({
       setCurrentValidation((current) => {
         if (
           current === null ||
-          current.actionId === validationRequest.actionId
+          current.validationRequest.actionId === validationRequest.actionId
         ) {
-          return validationRequest;
+          return { validationRequest };
         }
 
         setValidationQueue((prevRecord) => ({
@@ -121,9 +124,10 @@ function useValidationQueue({
 }
 
 type ActionValidationContextType = {
-  showValidationDialog: (
-    validationRequest?: MCPActionValidationRequest
-  ) => void;
+  showValidationDialog: (params?: {
+    message: LightAgentMessageType;
+    validationRequest: MCPActionValidationRequest;
+  }) => void;
   hasPendingValidations: boolean;
   totalPendingValidations: number;
 };
@@ -195,19 +199,38 @@ export function ActionValidationProvider({
     setErrorMessage(null);
     setIsProcessing(true);
 
+    const { validationRequest, message } = currentValidation;
+
     const response = await fetch(
-      `/api/w/${owner.sId}/assistant/conversations/${currentValidation.conversationId}/messages/${currentValidation.messageId}/validate-action`,
+      `/api/w/${owner.sId}/assistant/conversations/${validationRequest.conversationId}/messages/${validationRequest.messageId}/validate-action`,
       {
         method: "POST",
         headers: {
           "Content-Type": "application/json",
         },
         body: JSON.stringify({
-          actionId: currentValidation.actionId,
+          actionId: validationRequest.actionId,
           approved,
         }),
       }
     );
+
+    // Retry on blocked tools on the main conversation if there is one that is != from the event's.
+    if (
+      conversation?.sId &&
+      message &&
+      conversation.sId !== validationRequest.conversationId
+    ) {
+      await fetch(
+        `/api/w/${owner.sId}/assistant/conversations/${conversation.sId}/messages/${message.sId}/retry?blocked_only=true`,
+        {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+          },
+        }
+      );
+    }
 
     setIsProcessing(false);
 
@@ -224,7 +247,7 @@ export function ActionValidationProvider({
 
     const foundItem = takeNextFromQueue();
     if (foundItem) {
-      setCurrentValidation(foundItem);
+      setCurrentValidation({ validationRequest: foundItem });
     } else {
       // To avoid content flickering, we will clear out the current validation in onDialogAnimationEnd.
       setIsDialogOpen(false);
@@ -242,14 +265,17 @@ export function ActionValidationProvider({
 
   // This will be used as a dependency of the hook down the line so we need to use useCallback.
   const showValidationDialog = useCallback(
-    (validationRequest?: MCPActionValidationRequest) => {
+    (params?: {
+      message: LightAgentMessageType;
+      validationRequest: MCPActionValidationRequest;
+    }) => {
       if (!isDialogOpen) {
         setIsDialogOpen(true);
       }
 
       // If we have a new validation request, queue it.
-      if (validationRequest) {
-        handleValidationRequest(validationRequest);
+      if (params?.validationRequest) {
+        handleValidationRequest(params?.validationRequest);
       }
     },
     [handleValidationRequest, isDialogOpen]
@@ -275,8 +301,10 @@ export function ActionValidationProvider({
           <DialogHeader hideButton>
             <DialogTitle
               visual={
-                currentValidation?.metadata.icon ? (
-                  getAvatarFromIcon(currentValidation.metadata.icon)
+                currentValidation?.validationRequest.metadata.icon ? (
+                  getAvatarFromIcon(
+                    currentValidation.validationRequest.metadata.icon
+                  )
                 ) : (
                   <Icon visual={ActionPieChartIcon} size="sm" />
                 )
@@ -288,17 +316,27 @@ export function ActionValidationProvider({
           <DialogContainer>
             <div className="flex flex-col gap-4">
               <div>
-                Allow <b>@{currentValidation?.metadata.agentName}</b> to use the
-                tool{" "}
-                <b>{asDisplayName(currentValidation?.metadata.toolName)}</b>{" "}
+                Allow{" "}
+                <b>
+                  @{currentValidation?.validationRequest.metadata.agentName}
+                </b>{" "}
+                to use the tool{" "}
+                <b>
+                  {asDisplayName(
+                    currentValidation?.validationRequest.metadata.toolName
+                  )}
+                </b>{" "}
                 from{" "}
                 <b>
-                  {asDisplayName(currentValidation?.metadata.mcpServerName)}
+                  {asDisplayName(
+                    currentValidation?.validationRequest.metadata.mcpServerName
+                  )}
                 </b>
                 ?
               </div>
-              {currentValidation?.inputs &&
-                Object.keys(currentValidation.inputs).length > 0 && (
+              {currentValidation?.validationRequest.inputs &&
+                Object.keys(currentValidation.validationRequest.inputs).length >
+                  0 && (
                   <CollapsibleComponent
                     triggerChildren={
                       <span className="font-medium text-muted-foreground dark:text-muted-foreground-night">
@@ -312,7 +350,11 @@ export function ActionValidationProvider({
                             wrapLongLines
                             className="language-json overflow-y-auto"
                           >
-                            {JSON.stringify(currentValidation?.inputs, null, 2)}
+                            {JSON.stringify(
+                              currentValidation?.validationRequest.inputs,
+                              null,
+                              2
+                            )}
                           </CodeBlock>
                         </div>
                       </div>
@@ -333,7 +375,7 @@ export function ActionValidationProvider({
                 </div>
               )}
             </div>
-            {currentValidation?.stake === "low" && (
+            {currentValidation?.validationRequest.stake === "low" && (
               <div className="mt-5">
                 <Label className="copy-sm flex w-fit cursor-pointer flex-row items-center gap-2 py-2 pr-2 font-normal">
                   <Checkbox

--- a/front/components/assistant/conversation/ActionValidationProvider.tsx
+++ b/front/components/assistant/conversation/ActionValidationProvider.tsx
@@ -71,13 +71,19 @@ function useValidationQueue({
   }, [pendingValidations]);
 
   const handleValidationRequest = useCallback(
-    (validationRequest: MCPActionValidationRequest) => {
+    ({
+      message,
+      validationRequest,
+    }: {
+      message: LightAgentMessageType;
+      validationRequest: MCPActionValidationRequest;
+    }) => {
       setCurrentValidation((current) => {
         if (
           current === null ||
           current.validationRequest.actionId === validationRequest.actionId
         ) {
-          return { validationRequest };
+          return { message, validationRequest };
         }
 
         setValidationQueue((prevRecord) => ({
@@ -274,8 +280,8 @@ export function ActionValidationProvider({
       }
 
       // If we have a new validation request, queue it.
-      if (params?.validationRequest) {
-        handleValidationRequest(params?.validationRequest);
+      if (params) {
+        handleValidationRequest(params);
       }
     },
     [handleValidationRequest, isDialogOpen]

--- a/front/components/assistant/conversation/AgentMessage.tsx
+++ b/front/components/assistant/conversation/AgentMessage.tsx
@@ -122,12 +122,15 @@ export function AgentMessage({
 
       if (eventType === "tool_approve_execution") {
         showValidationDialog({
-          messageId: eventPayload.data.messageId,
-          conversationId: eventPayload.data.conversationId,
-          actionId: eventPayload.data.actionId,
-          inputs: eventPayload.data.inputs,
-          stake: eventPayload.data.stake,
-          metadata: eventPayload.data.metadata,
+          message,
+          validationRequest: {
+            messageId: eventPayload.data.messageId,
+            conversationId: eventPayload.data.conversationId,
+            actionId: eventPayload.data.actionId,
+            inputs: eventPayload.data.inputs,
+            stake: eventPayload.data.stake,
+            metadata: eventPayload.data.metadata,
+          },
         });
       }
     },

--- a/front/components/assistant/conversation/AgentMessage.tsx
+++ b/front/components/assistant/conversation/AgentMessage.tsx
@@ -57,6 +57,7 @@ import type {
   UserType,
   WorkspaceType,
 } from "@app/types";
+import { isString } from "@app/types";
 import {
   assertNever,
   GLOBAL_AGENTS_SID,
@@ -331,7 +332,10 @@ export function AgentMessage({
             variant="outline"
             size="xs"
             onClick={() => {
-              void retryHandler(agentMessageToRender);
+              void retryHandler({
+                conversationId,
+                messageId: agentMessageToRender.sId,
+              });
             }}
             icon={ArrowPathIcon}
             className="text-muted-foreground"
@@ -440,25 +444,43 @@ export function AgentMessage({
     lastTokenClassification: null | "tokens" | "chain_of_thought";
   }) {
     if (agentMessage.status === "failed") {
+      const { error } = agentMessage;
       if (
-        agentMessage.error &&
-        agentMessage.error.code ===
-          "mcp_server_personal_authentication_required" &&
-        typeof agentMessage.error.metadata?.mcp_server_id === "string" &&
-        agentMessage.error.metadata?.mcp_server_id.length > 0 &&
-        isOAuthProvider(agentMessage.error.metadata?.provider) &&
-        isValidScope(agentMessage.error.metadata?.scope)
+        error &&
+        error.code === "mcp_server_personal_authentication_required" &&
+        isString(error.metadata?.mcp_server_id) &&
+        error.metadata?.mcp_server_id.length > 0 &&
+        isOAuthProvider(error.metadata?.provider) &&
+        isValidScope(error.metadata?.scope)
       ) {
         return (
           <MCPServerPersonalAuthenticationRequired
             owner={owner}
-            mcpServerId={agentMessage.error.metadata.mcp_server_id}
-            provider={agentMessage.error.metadata.provider}
-            scope={agentMessage.error.metadata.scope}
+            mcpServerId={error.metadata.mcp_server_id}
+            provider={error.metadata.provider}
+            scope={error.metadata.scope}
             retryHandler={async () => {
               // Dispatch retry event to reset failed state and re-enable streaming.
               dispatch(RETRY_BLOCKED_ACTIONS_STARTED_EVENT);
-              return retryHandler(agentMessage, { blockedOnly: true });
+              // Retry on the event's conversationId, which may be coming from a subagent.
+              if (
+                error.metadata &&
+                isString(error.metadata.messageId) &&
+                isString(error.metadata.conversationId) &&
+                error.metadata.conversationId !== conversationId
+              ) {
+                await retryHandler({
+                  conversationId: error.metadata.conversationId,
+                  messageId: error.metadata.messageId,
+                  blockedOnly: true,
+                });
+              }
+              // Retry on the main conversation.
+              await retryHandler({
+                conversationId,
+                messageId: agentMessage.sId,
+                blockedOnly: true,
+              });
             }}
           />
         );
@@ -472,7 +494,9 @@ export function AgentMessage({
               metadata: {},
             }
           }
-          retryHandler={async () => retryHandler(agentMessage)}
+          retryHandler={async () =>
+            retryHandler({ conversationId, messageId: agentMessage.sId })
+          }
         />
       );
     }
@@ -583,13 +607,18 @@ export function AgentMessage({
     );
   }
 
-  async function retryHandler(
-    agentMessage: LightAgentMessageType,
-    { blockedOnly }: { blockedOnly: boolean } = { blockedOnly: false }
-  ) {
+  async function retryHandler({
+    conversationId,
+    messageId,
+    blockedOnly = false,
+  }: {
+    conversationId: string;
+    messageId: string;
+    blockedOnly?: boolean;
+  }) {
     setIsRetryHandlerProcessing(true);
     await fetch(
-      `/api/w/${owner.sId}/assistant/conversations/${conversationId}/messages/${agentMessage.sId}/retry?blocked_only=${blockedOnly}`,
+      `/api/w/${owner.sId}/assistant/conversations/${conversationId}/messages/${messageId}/retry?blocked_only=${blockedOnly}`,
       {
         method: "POST",
         headers: {

--- a/front/lib/actions/mcp.ts
+++ b/front/lib/actions/mcp.ts
@@ -25,7 +25,7 @@ import type { ToolPersonalAuthRequiredEvent } from "@app/lib/actions/mcp_interna
 import { hideInternalConfiguration } from "@app/lib/actions/mcp_internal_actions/input_configuration";
 import type { ProgressNotificationContentType } from "@app/lib/actions/mcp_internal_actions/output_schemas";
 import { isTextContent } from "@app/lib/actions/mcp_internal_actions/output_schemas";
-import { BlockedAwaitingInputError } from "@app/lib/actions/mcp_internal_actions/servers/run_agent/types";
+import { ToolBlockedAwaitingInputError } from "@app/lib/actions/mcp_internal_actions/servers/run_agent/types";
 import {
   hideFileFromActionOutput,
   rewriteContentForModel,
@@ -540,8 +540,8 @@ export async function* runToolWithStreaming(
       };
 
       return;
-    } else if (toolErr instanceof BlockedAwaitingInputError) {
-      // Update the step context to keep the restart state.
+    } else if (toolErr instanceof ToolBlockedAwaitingInputError) {
+      // Update the step context to save the resume state.
       await action.updateStepContext({
         ...action.stepContext,
         resumeState: toolErr.resumeState,

--- a/front/lib/actions/mcp.ts
+++ b/front/lib/actions/mcp.ts
@@ -739,9 +739,42 @@ export async function handleMCPActionError(
 }
 
 export function isMCPApproveExecutionEvent(
-  event: AgentActionRunningEvents
+  event: unknown
 ): event is MCPApproveExecutionEvent {
-  return event.type === "tool_approve_execution";
+  return (
+    typeof event === "object" &&
+    event !== null &&
+    "type" in event &&
+    event.type === "tool_approve_execution"
+  );
+}
+
+function isToolPersonalAuthRequiredEvent(
+  event: unknown
+): event is ToolPersonalAuthRequiredEvent {
+  return (
+    typeof event === "object" &&
+    event !== null &&
+    "type" in event &&
+    event.type === "tool_error" &&
+    "error" in event &&
+    typeof event.error === "object" &&
+    event.error !== null &&
+    "code" in event.error &&
+    event.error.code === "mcp_server_personal_authentication_required"
+  );
+}
+
+export function isBlockedActionEvent(
+  event: unknown
+): event is MCPApproveExecutionEvent | ToolPersonalAuthRequiredEvent {
+  return (
+    typeof event === "object" &&
+    event !== null &&
+    "type" in event &&
+    (isMCPApproveExecutionEvent(event) ||
+      isToolPersonalAuthRequiredEvent(event))
+  );
 }
 
 // TODO(DURABLE_AGENTS 2025-08-12): Create a proper resource for the agent mcp action.

--- a/front/lib/actions/mcp.ts
+++ b/front/lib/actions/mcp.ts
@@ -527,6 +527,7 @@ export async function* runToolWithStreaming(
         created: Date.now(),
         configurationId: agentConfiguration.sId,
         messageId: agentMessage.sId,
+        conversationId: conversation.sId,
         authError: {
           mcpServerId: toolErr.mcpServerId,
           provider: toolErr.provider,

--- a/front/lib/actions/mcp.ts
+++ b/front/lib/actions/mcp.ts
@@ -544,7 +544,7 @@ export async function* runToolWithStreaming(
       // Update the step context to keep the restart state.
       await action.updateStepContext({
         ...action.stepContext,
-        restartState: toolErr.restartState,
+        resumeState: toolErr.resumeState,
       });
 
       // Yield the blocking events.

--- a/front/lib/actions/mcp_execution.ts
+++ b/front/lib/actions/mcp_execution.ts
@@ -26,9 +26,9 @@ import {
   isBlobResource,
   isMCPProgressNotificationType,
   isResourceWithName,
-  isToolApproveBubbleUpNotificationType,
   isToolGeneratedFile,
 } from "@app/lib/actions/mcp_internal_actions/output_schemas";
+import type { BlockedAwaitingInputError } from "@app/lib/actions/mcp_internal_actions/servers/run_agent/types";
 import { handleBase64Upload } from "@app/lib/actions/mcp_utils";
 import type {
   ActionGeneratedFileType,
@@ -83,7 +83,10 @@ export async function* executeMCPTool({
   ToolNotificationEvent | MCPApproveExecutionEvent,
   Result<
     CallToolResult["content"],
-    Error | McpError | MCPServerPersonalAuthenticationRequiredError
+    | Error
+    | McpError
+    | MCPServerPersonalAuthenticationRequiredError
+    | BlockedAwaitingInputError
   > | null,
   unknown
 > {
@@ -102,48 +105,16 @@ export async function* executeMCPTool({
     } else if (event.type === "notification") {
       const { notification } = event;
       if (isMCPProgressNotificationType(notification)) {
-        const { output: notificationOutput } = notification.params.data;
-        // Tool approval notifications have a specific handling:
-        // they are not yielded as regular notifications but are bubbled up as
-        // `tool_approval_bubble_up` events instead. We attach the messageId from the
-        // main conversation as `pubsubMessageId` to route the event to the main conversation channel.
-        if (isToolApproveBubbleUpNotificationType(notificationOutput)) {
-          const {
-            conversationId,
-            messageId,
-            configurationId,
-            actionId,
-            inputs,
-            stake,
-            metadata,
-          } = notificationOutput;
-
-          yield {
-            created: Date.now(),
-            type: "tool_approve_execution",
-            configurationId,
-            conversationId,
-            messageId,
-            actionId,
-            inputs,
-            stake,
-            metadata: {
-              ...metadata,
-              pubsubMessageId: agentMessage.sId,
-            },
-          };
-        } else {
-          // Regular notifications, we yield them as is with the type "tool_notification".
-          yield {
-            type: "tool_notification",
-            created: Date.now(),
-            configurationId: agentConfiguration.sId,
-            conversationId: conversation.sId,
-            messageId: agentMessage.sId,
-            action: mcpAction,
-            notification: notification.params,
-          };
-        }
+        // Regular notifications, we yield them as is with the type "tool_notification".
+        yield {
+          type: "tool_notification",
+          created: Date.now(),
+          configurationId: agentConfiguration.sId,
+          conversationId: conversation.sId,
+          messageId: agentMessage.sId,
+          action: mcpAction,
+          notification: notification.params,
+        };
       }
     }
   }

--- a/front/lib/actions/mcp_execution.ts
+++ b/front/lib/actions/mcp_execution.ts
@@ -28,7 +28,7 @@ import {
   isResourceWithName,
   isToolGeneratedFile,
 } from "@app/lib/actions/mcp_internal_actions/output_schemas";
-import type { BlockedAwaitingInputError } from "@app/lib/actions/mcp_internal_actions/servers/run_agent/types";
+import type { ToolBlockedAwaitingInputError } from "@app/lib/actions/mcp_internal_actions/servers/run_agent/types";
 import { handleBase64Upload } from "@app/lib/actions/mcp_utils";
 import type {
   ActionGeneratedFileType,
@@ -86,7 +86,7 @@ export async function* executeMCPTool({
     | Error
     | McpError
     | MCPServerPersonalAuthenticationRequiredError
-    | BlockedAwaitingInputError
+    | ToolBlockedAwaitingInputError
   > | null,
   unknown
 > {

--- a/front/lib/actions/mcp_internal_actions/events.ts
+++ b/front/lib/actions/mcp_internal_actions/events.ts
@@ -7,6 +7,7 @@ export type ToolPersonalAuthRequiredEvent = {
   created: number;
   configurationId: string;
   messageId: string;
+  conversationId: string;
   authError: {
     mcpServerId: string;
     provider: string;

--- a/front/lib/actions/mcp_internal_actions/output_schemas.ts
+++ b/front/lib/actions/mcp_internal_actions/output_schemas.ts
@@ -843,18 +843,6 @@ const NotificationToolApproveBubbleUpContentSchema = z.object({
   }),
 });
 
-type NotificationToolApproveBubbleUpContentType = z.infer<
-  typeof NotificationToolApproveBubbleUpContentSchema
->;
-
-export function isToolApproveBubbleUpNotificationType(
-  notificationOutput: ProgressNotificationOutput
-): notificationOutput is NotificationToolApproveBubbleUpContentType {
-  return NotificationToolApproveBubbleUpContentSchema.safeParse(
-    notificationOutput
-  ).success;
-}
-
 const NotificationTextContentSchema = z.object({
   type: z.literal("text"),
   text: z.string(),

--- a/front/lib/actions/mcp_internal_actions/servers/run_agent/conversation.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/run_agent/conversation.ts
@@ -2,7 +2,7 @@ import type { ConversationPublicType, DustAPI, Result } from "@dust-tt/client";
 import { Err, Ok } from "@dust-tt/client";
 
 import type { ChildAgentBlob } from "@app/lib/actions/mcp_internal_actions/servers/run_agent/types";
-import { isRunAgentRestartState } from "@app/lib/actions/mcp_internal_actions/servers/run_agent/types";
+import { isRunAgentResumeState } from "@app/lib/actions/mcp_internal_actions/servers/run_agent/types";
 import type { AgentLoopRunContextType } from "@app/lib/actions/types";
 import logger from "@app/logger/logger";
 import type { AgentConfigurationType, ConversationType } from "@app/types";
@@ -37,10 +37,10 @@ export async function getOrCreateConversation(
 > {
   const { agentMessage, stepContext } = agentLoopContext;
 
-  const { restartState } = stepContext;
-  if (restartState && isRunAgentRestartState(restartState)) {
+  const { resumeState } = stepContext;
+  if (resumeState && isRunAgentResumeState(resumeState)) {
     const convRes = await api.getConversation({
-      conversationId: restartState.conversationId,
+      conversationId: resumeState.conversationId,
     });
 
     if (convRes.isErr()) {
@@ -50,7 +50,7 @@ export async function getOrCreateConversation(
     return new Ok({
       conversation: convRes.value,
       isNewConversation: false,
-      userMessageId: restartState.userMessageId,
+      userMessageId: resumeState.userMessageId,
     });
   }
 

--- a/front/lib/actions/mcp_internal_actions/servers/run_agent/conversation.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/run_agent/conversation.ts
@@ -1,0 +1,105 @@
+import type { ConversationPublicType, DustAPI, Result } from "@dust-tt/client";
+import { Err, Ok } from "@dust-tt/client";
+
+import type { ChildAgentBlob } from "@app/lib/actions/mcp_internal_actions/servers/run_agent/types";
+import { isRunAgentRestartState } from "@app/lib/actions/mcp_internal_actions/servers/run_agent/types";
+import type { AgentLoopRunContextType } from "@app/lib/actions/types";
+import logger from "@app/logger/logger";
+import type { AgentConfigurationType, ConversationType } from "@app/types";
+
+export async function getOrCreateConversation(
+  api: DustAPI,
+  agentLoopContext: AgentLoopRunContextType,
+  {
+    childAgentBlob,
+    childAgentId,
+    mainAgent,
+    mainConversation,
+    query,
+    toolsetsToAdd,
+  }: {
+    childAgentBlob: ChildAgentBlob;
+    childAgentId: string;
+    mainAgent: AgentConfigurationType;
+    mainConversation: ConversationType;
+    query: string;
+    toolsetsToAdd: string[] | null;
+  }
+): Promise<
+  Result<
+    {
+      conversation: ConversationPublicType;
+      isNewConversation: boolean;
+      userMessageId: string;
+    },
+    Error
+  >
+> {
+  const { agentMessage, stepContext } = agentLoopContext;
+
+  const { restartState } = stepContext;
+  if (restartState && isRunAgentRestartState(restartState)) {
+    const convRes = await api.getConversation({
+      conversationId: restartState.conversationId,
+    });
+
+    if (convRes.isErr()) {
+      return new Err(new Error("Failed to get conversation"));
+    }
+
+    return new Ok({
+      conversation: convRes.value,
+      isNewConversation: false,
+      userMessageId: restartState.userMessageId,
+    });
+  }
+
+  const convRes = await api.createConversation({
+    title: `run_agent ${mainAgent.name} > ${childAgentBlob.name}`,
+    visibility: "unlisted",
+    depth: mainConversation.depth + 1,
+    message: {
+      content: query,
+      mentions: [{ configurationId: childAgentId }],
+      context: {
+        timezone: Intl.DateTimeFormat().resolvedOptions().timeZone,
+        username: mainAgent.name,
+        fullName: `@${mainAgent.name}`,
+        email: null,
+        profilePictureUrl: mainAgent.pictureUrl,
+        // `run_agent` origin will skip adding the conversation to the user history.
+        origin: "run_agent",
+        selectedMCPServerViewIds: toolsetsToAdd,
+      },
+    },
+    skipToolsValidation: agentMessage.skipToolsValidation ?? false,
+    params: {
+      // TODO(DURABLE_AGENT 2025-08-20): Remove this if we decided to always use async mode.
+      execution: "async",
+    },
+  });
+
+  if (convRes.isErr()) {
+    logger.error(
+      {
+        error: convRes.error,
+        stepContext,
+      },
+      "Failed to create conversation"
+    );
+
+    return new Err(new Error("Failed to create conversation"));
+  }
+
+  const { conversation, message: createdUserMessage } = convRes.value;
+
+  if (!createdUserMessage) {
+    return new Err(new Error("Failed to retrieve the created message."));
+  }
+
+  return new Ok({
+    conversation,
+    isNewConversation: true,
+    userMessageId: createdUserMessage.sId,
+  });
+}

--- a/front/lib/actions/mcp_internal_actions/servers/run_agent/index.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/run_agent/index.ts
@@ -14,10 +14,7 @@ import type {
   ChildAgentBlob,
   RunAgentBlockingEvent,
 } from "@app/lib/actions/mcp_internal_actions/servers/run_agent/types";
-import {
-  BlockedAwaitingInputError,
-  makeBlockedAwaitingInputResponse,
-} from "@app/lib/actions/mcp_internal_actions/servers/run_agent/types";
+import { makeToolBlockedAwaitingInputResponse } from "@app/lib/actions/mcp_internal_actions/servers/run_agent/types";
 import {
   makeInternalMCPServer,
   makeMCPToolTextError,
@@ -372,20 +369,13 @@ export default async function createServer(
             // If this is the last blocking event for the step, throw an error to break the agent
             // loop until the user approves the execution.
             if (event.isLastBlockingEventForStep) {
-              const err = new BlockedAwaitingInputError(
+              return makeToolBlockedAwaitingInputResponse(
                 collectedBlockingEvents,
                 {
                   conversationId: conversation.sId,
                   userMessageId,
                 }
               );
-
-              console.log(">>>> err", err.toString());
-
-              return makeBlockedAwaitingInputResponse(collectedBlockingEvents, {
-                conversationId: conversation.sId,
-                userMessageId,
-              });
             }
           } else if (event.type === "tool_error") {
             // Handle personal authentication required errors.
@@ -410,17 +400,7 @@ export default async function createServer(
               });
 
               if (event.isLastBlockingEventForStep) {
-                const err = new BlockedAwaitingInputError(
-                  collectedBlockingEvents,
-                  {
-                    conversationId: conversation.sId,
-                    userMessageId,
-                  }
-                );
-
-                console.log(">>>> err", err);
-
-                return makeBlockedAwaitingInputResponse(
+                return makeToolBlockedAwaitingInputResponse(
                   collectedBlockingEvents,
                   {
                     conversationId: conversation.sId,

--- a/front/lib/actions/mcp_internal_actions/servers/run_agent/index.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/run_agent/index.ts
@@ -405,6 +405,7 @@ export default async function createServer(
                   provider: metadata.provider,
                   toolName: metadata.toolName,
                   message: metadata.message,
+                  scope: metadata.scope,
                 },
               });
 

--- a/front/lib/actions/mcp_internal_actions/servers/run_agent/index.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/run_agent/index.ts
@@ -399,6 +399,7 @@ export default async function createServer(
                 created: event.created,
                 configurationId: event.configurationId,
                 messageId: event.messageId,
+                conversationId: conversation.sId,
                 authError: {
                   mcpServerId: metadata.mcp_server_id,
                   provider: metadata.provider,

--- a/front/lib/actions/mcp_internal_actions/servers/run_agent/index.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/run_agent/index.ts
@@ -9,6 +9,15 @@ import {
   ConfigurableToolInputSchemas,
 } from "@app/lib/actions/mcp_internal_actions/input_schemas";
 import type { MCPProgressNotificationType } from "@app/lib/actions/mcp_internal_actions/output_schemas";
+import { getOrCreateConversation } from "@app/lib/actions/mcp_internal_actions/servers/run_agent/conversation";
+import type {
+  ChildAgentBlob,
+  RunAgentBlockingEvent,
+} from "@app/lib/actions/mcp_internal_actions/servers/run_agent/types";
+import {
+  BlockedAwaitingInputError,
+  makeBlockedAwaitingInputResponse,
+} from "@app/lib/actions/mcp_internal_actions/servers/run_agent/types";
 import {
   makeInternalMCPServer,
   makeMCPToolTextError,
@@ -126,11 +135,7 @@ export default async function createServer(
     childAgentId = agentLoopContext.runContext.toolConfiguration.childAgentId;
   }
 
-  let childAgentBlob: {
-    name: string;
-    description: string;
-  } | null = null;
-
+  let childAgentBlob: ChildAgentBlob | null = null;
   if (childAgentId) {
     childAgentBlob = await leakyGetAgentNameAndDescriptionForChildAgent(
       auth,
@@ -214,46 +219,28 @@ export default async function createServer(
         logger
       );
 
-      const convRes = await api.createConversation({
-        title: `run_agent ${mainAgent.name} > ${childAgentBlob.name}`,
-        visibility: "unlisted",
-        depth: mainConversation.depth + 1,
-        message: {
-          content: query,
-          mentions: [{ configurationId: childAgentId }],
-          context: {
-            timezone: Intl.DateTimeFormat().resolvedOptions().timeZone,
-            username: mainAgent.name,
-            fullName: `@${mainAgent.name}`,
-            email: null,
-            profilePictureUrl: mainAgent.pictureUrl,
-            // `run_agent` origin will skip adding the conversation to the user history.
-            origin: "run_agent",
-            selectedMCPServerViewIds: toolsetsToAdd,
-          },
-        },
-        skipToolsValidation:
-          agentLoopContext.runContext.agentMessage.skipToolsValidation ?? false,
-        params: {
-          // TODO(DURABLE_AGENT 2025-08-20): Remove this if we decided to always use async mode.
-          execution: "async",
-        },
-      });
+      const convRes = await getOrCreateConversation(
+        api,
+        agentLoopContext.runContext,
+        {
+          childAgentBlob,
+          childAgentId,
+          mainAgent,
+          mainConversation,
+          query,
+          toolsetsToAdd: toolsetsToAdd ?? null,
+        }
+      );
 
       if (convRes.isErr()) {
-        const errorMessage = `Failed to create conversation: ${convRes.error.message}`;
-        return makeMCPToolTextError(errorMessage);
+        return makeMCPToolTextError(convRes.error.message);
       }
 
-      const { conversation, message: createdUserMessage } = convRes.value;
+      const { conversation, isNewConversation, userMessageId } = convRes.value;
 
-      if (!createdUserMessage) {
-        const errorMessage = "Failed to retrieve the created message.";
-        return makeMCPToolTextError(errorMessage);
-      }
-
-      // Send notification indicating that a run_agent started and a new conversation was created.
-      if (_meta?.progressToken && sendNotification) {
+      // Send notification indicating that a run_agent started and a new conversation was created if
+      // it is the first time the conversation is created.
+      if (_meta?.progressToken && sendNotification && isNewConversation) {
         const notification: MCPProgressNotificationType = {
           method: "notifications/progress",
           params: {
@@ -276,7 +263,7 @@ export default async function createServer(
 
       const streamRes = await api.streamAgentAnswerEvents({
         conversation: conversation,
-        userMessageId: createdUserMessage.sId,
+        userMessageId,
       });
 
       if (streamRes.isErr()) {
@@ -284,13 +271,17 @@ export default async function createServer(
         return makeMCPToolTextError(errorMessage);
       }
 
+      const collectedBlockingEvents: RunAgentBlockingEvent[] = [];
+
+      // TODO(DURABLE_AGENT 2025-08-25): We should make this more robust and use the existing
+      // conversation content if present.
       let finalContent = "";
       let chainOfThought = "";
       let refs: Record<string, CitationType> = {};
       try {
         for await (const event of streamRes.value.eventStream) {
           if (event.type === "generation_tokens") {
-            // Separate content based on classification
+            // Separate content based on classification.
             if (event.classification === "chain_of_thought") {
               chainOfThought += event.text;
               const notification: MCPProgressNotificationType = {
@@ -340,7 +331,7 @@ export default async function createServer(
               event.delimiterClassification === "chain_of_thought" &&
               chainOfThought.length > 0
             ) {
-              // For closing chain of thought delimiters, add a newline
+              // For closing chain of thought delimiters, add a newline.
               chainOfThought += "\n";
               const notification: MCPProgressNotificationType = {
                 method: "notifications/progress",
@@ -375,34 +366,67 @@ export default async function createServer(
             }
             break;
           } else if (event.type === "tool_approve_execution") {
-            // We catch tool approval events and bubble them up as progress notifications to the
-            // parent tool execution.
-            // In the MCP server runner, we translate them into a tool_approve_execution event
-            // that can be ultimately shown to the end user.
-            // This part only passes along the event data without modifying them.
-            const notification: MCPProgressNotificationType = {
-              method: "notifications/progress",
-              params: {
-                progress: 0,
-                total: 1,
-                progressToken: 0,
-                data: {
-                  label: "Waiting for tool approval...",
-                  output: {
-                    type: "tool_approval_bubble_up",
-                    configurationId: event.configurationId,
-                    conversationId: event.conversationId,
-                    messageId: event.messageId,
-                    actionId: event.actionId,
-                    metadata: event.metadata,
-                    stake: event.stake,
-                    inputs: event.inputs,
-                  },
-                },
-              },
-            };
+            // Collect this blocking event.
+            collectedBlockingEvents.push(event);
 
-            await sendNotification(notification);
+            // If this is the last blocking event for the step, throw an error to break the agent
+            // loop until the user approves the execution.
+            if (event.isLastBlockingEventForStep) {
+              const err = new BlockedAwaitingInputError(
+                collectedBlockingEvents,
+                {
+                  conversationId: conversation.sId,
+                  userMessageId,
+                }
+              );
+
+              console.log(">>>> err", err.toString());
+
+              return makeBlockedAwaitingInputResponse(collectedBlockingEvents, {
+                conversationId: conversation.sId,
+                userMessageId,
+              });
+            }
+          } else if (event.type === "tool_error") {
+            // Handle personal authentication required errors.
+            if (
+              event.error.code === "mcp_server_personal_authentication_required"
+            ) {
+              const metadata = event.error.metadata ?? {};
+
+              collectedBlockingEvents.push({
+                type: "tool_personal_auth_required",
+                created: event.created,
+                configurationId: event.configurationId,
+                messageId: event.messageId,
+                authError: {
+                  mcpServerId: metadata.mcp_server_id,
+                  provider: metadata.provider,
+                  toolName: metadata.toolName,
+                  message: metadata.message,
+                },
+              });
+
+              if (event.isLastBlockingEventForStep) {
+                const err = new BlockedAwaitingInputError(
+                  collectedBlockingEvents,
+                  {
+                    conversationId: conversation.sId,
+                    userMessageId,
+                  }
+                );
+
+                console.log(">>>> err", err);
+
+                return makeBlockedAwaitingInputResponse(
+                  collectedBlockingEvents,
+                  {
+                    conversationId: conversation.sId,
+                    userMessageId,
+                  }
+                );
+              }
+            }
           }
         }
       } catch (streamError) {

--- a/front/lib/actions/mcp_internal_actions/servers/run_agent/types.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/run_agent/types.ts
@@ -8,16 +8,16 @@ export interface ChildAgentBlob {
   description: string;
 }
 
-// Restart state for run_agent.
+// Resume state for run_agent.
 
-export type RunAgentRestartState = Record<string, unknown> & {
+export type RunAgentResumeState = Record<string, unknown> & {
   conversationId: string;
   userMessageId: string;
 };
 
-export function isRunAgentRestartState(
+export function isRunAgentResumeState(
   state: unknown
-): state is RunAgentRestartState {
+): state is RunAgentResumeState {
   return (
     typeof state === "object" &&
     state !== null &&
@@ -28,16 +28,16 @@ export function isRunAgentRestartState(
   );
 }
 
-// Restart required error for run_agent.
+// Resume required error for run_agent.
 
 export const BlockedAwaitingInputErrorName = "BlockedAwaitingInputError";
 
 export class BlockedAwaitingInputError extends Error {
   constructor(
     public readonly blockingEvents: RunAgentBlockingEvent[],
-    public readonly restartState: Record<string, unknown>
+    public readonly resumeState: Record<string, unknown>
   ) {
-    super("Tool requires restart after blocking events");
+    super("Tool requires resume after blocking events");
     this.name = BlockedAwaitingInputErrorName;
   }
 }
@@ -52,7 +52,7 @@ export type RunAgentBlockingEvent =
  */
 export function makeBlockedAwaitingInputResponse(
   blockingEvents: RunAgentBlockingEvent[],
-  state: RunAgentRestartState
+  state: RunAgentResumeState
 ): CallToolResult {
   return {
     isError: true,

--- a/front/lib/actions/mcp_internal_actions/servers/run_agent/types.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/run_agent/types.ts
@@ -40,19 +40,6 @@ export class BlockedAwaitingInputError extends Error {
     super("Tool requires restart after blocking events");
     this.name = BlockedAwaitingInputErrorName;
   }
-
-  // This method is used to check if an error resulting from a Temporal activity is a
-  // BlockedAwaitingInputError.
-  static isBlockedAwaitingInputError(
-    error: unknown
-  ): error is BlockedAwaitingInputError {
-    return (
-      error instanceof Error &&
-      error.name === BlockedAwaitingInputErrorName &&
-      "blockingEvents" in error &&
-      "restartState" in error
-    );
-  }
 }
 
 export type RunAgentBlockingEvent =

--- a/front/lib/actions/mcp_internal_actions/servers/run_agent/types.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/run_agent/types.ts
@@ -1,0 +1,84 @@
+import type { MCPApproveExecutionEvent } from "@dust-tt/client";
+import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
+
+import type { ToolPersonalAuthRequiredEvent } from "@app/lib/actions/mcp_internal_actions/events";
+
+export interface ChildAgentBlob {
+  name: string;
+  description: string;
+}
+
+// Restart state for run_agent.
+
+export type RunAgentRestartState = Record<string, unknown> & {
+  conversationId: string;
+  userMessageId: string;
+};
+
+export function isRunAgentRestartState(
+  state: unknown
+): state is RunAgentRestartState {
+  return (
+    typeof state === "object" &&
+    state !== null &&
+    "conversationId" in state &&
+    typeof state.conversationId === "string" &&
+    "userMessageId" in state &&
+    typeof state.userMessageId === "string"
+  );
+}
+
+// Restart required error for run_agent.
+
+export const BlockedAwaitingInputErrorName = "BlockedAwaitingInputError";
+
+export class BlockedAwaitingInputError extends Error {
+  constructor(
+    public readonly blockingEvents: RunAgentBlockingEvent[],
+    public readonly restartState: Record<string, unknown>
+  ) {
+    super("Tool requires restart after blocking events");
+    this.name = BlockedAwaitingInputErrorName;
+  }
+
+  // This method is used to check if an error resulting from a Temporal activity is a
+  // BlockedAwaitingInputError.
+  static isBlockedAwaitingInputError(
+    error: unknown
+  ): error is BlockedAwaitingInputError {
+    return (
+      error instanceof Error &&
+      error.name === BlockedAwaitingInputErrorName &&
+      "blockingEvents" in error &&
+      "restartState" in error
+    );
+  }
+}
+
+export type RunAgentBlockingEvent =
+  | MCPApproveExecutionEvent
+  | ToolPersonalAuthRequiredEvent;
+
+/**
+ * Serializes a BlockedAwaitingInputError for MCP transport.
+ * MCP protocol strips custom error properties, so we encode them in the response content.
+ */
+export function makeBlockedAwaitingInputResponse(
+  blockingEvents: RunAgentBlockingEvent[],
+  state: RunAgentRestartState
+): CallToolResult {
+  return {
+    isError: true,
+    content: [
+      {
+        type: "text",
+        text: JSON.stringify({
+          __dust_blocked_awaiting_input: {
+            blockingEvents,
+            state,
+          },
+        }),
+      },
+    ],
+  };
+}

--- a/front/lib/actions/statuses.ts
+++ b/front/lib/actions/statuses.ts
@@ -9,6 +9,7 @@ type ToolExecutionFinalStatus = (typeof TOOL_EXECUTION_FINAL_STATUSES)[number];
 export const TOOL_EXECUTION_BLOCKED_STATUSES = [
   "blocked_authentication_required",
   "blocked_validation_required",
+  "blocked_child_action_required",
 ] as const;
 
 export type ToolExecutionBlockedStatus =

--- a/front/lib/actions/statuses.ts
+++ b/front/lib/actions/statuses.ts
@@ -9,7 +9,7 @@ type ToolExecutionFinalStatus = (typeof TOOL_EXECUTION_FINAL_STATUSES)[number];
 export const TOOL_EXECUTION_BLOCKED_STATUSES = [
   "blocked_authentication_required",
   "blocked_validation_required",
-  "blocked_child_action_required",
+  "blocked_child_action_input_required",
 ] as const;
 
 export type ToolExecutionBlockedStatus =

--- a/front/lib/actions/types/index.ts
+++ b/front/lib/actions/types/index.ts
@@ -11,9 +11,10 @@ import type {
 } from "@app/types";
 
 export type StepContext = {
-  retrievalTopK: number;
-  citationsOffset: number;
   citationsCount: number;
+  citationsOffset: number;
+  restartState: Record<string, unknown> | null;
+  retrievalTopK: number;
   websearchResultCount: number;
 };
 

--- a/front/lib/actions/types/index.ts
+++ b/front/lib/actions/types/index.ts
@@ -13,7 +13,7 @@ import type {
 export type StepContext = {
   citationsCount: number;
   citationsOffset: number;
-  restartState: Record<string, unknown> | null;
+  resumeState: Record<string, unknown> | null;
   retrievalTopK: number;
   websearchResultCount: number;
 };

--- a/front/lib/actions/utils.ts
+++ b/front/lib/actions/utils.ts
@@ -214,9 +214,10 @@ export function computeStepContexts({
     });
 
     stepContexts.push({
-      retrievalTopK,
-      citationsOffset: currentOffset,
       citationsCount,
+      citationsOffset: currentOffset,
+      restartState: null,
+      retrievalTopK,
       websearchResultCount: websearchResults,
     });
 

--- a/front/lib/actions/utils.ts
+++ b/front/lib/actions/utils.ts
@@ -216,7 +216,7 @@ export function computeStepContexts({
     stepContexts.push({
       citationsCount,
       citationsOffset: currentOffset,
-      restartState: null,
+      resumeState: null,
       retrievalTopK,
       websearchResultCount: websearchResults,
     });

--- a/front/lib/api/assistant/conversation/retry_blocked_actions.ts
+++ b/front/lib/api/assistant/conversation/retry_blocked_actions.ts
@@ -1,4 +1,10 @@
+import {
+  isBlockedActionEvent,
+  isMCPApproveExecutionEvent,
+} from "@app/lib/actions/mcp";
 import { runAgentLoop } from "@app/lib/api/assistant/agent";
+import { getMessageChannelId } from "@app/lib/api/assistant/streaming/helpers";
+import { getRedisHybridManager } from "@app/lib/api/redis-hybrid-manager";
 import type { Authenticator } from "@app/lib/auth";
 import { Message } from "@app/lib/models/assistant/conversation";
 import { AgentMCPActionResource } from "@app/lib/resources/agent_mcp_action_resource";
@@ -61,6 +67,15 @@ async function findUserMessageForRetry(
   if (blockedActions.length === 0) {
     return new Err(new Error("No blocked actions found"));
   }
+
+  // Purge blocked actions event message from the stream:
+  // - remove tool_approve_execution events (watch out as those events are not republished).
+  // - remove tool_personal_auth_required events.
+  await getRedisHybridManager().removeEvent((event) => {
+    const payload = JSON.parse(event.message["payload"]);
+
+    return isBlockedActionEvent(payload);
+  }, getMessageChannelId(messageId));
 
   return new Ok({
     agentMessageId: agentMessage.sId,

--- a/front/lib/api/assistant/conversation/retry_blocked_actions.ts
+++ b/front/lib/api/assistant/conversation/retry_blocked_actions.ts
@@ -1,7 +1,4 @@
-import {
-  isBlockedActionEvent,
-  isMCPApproveExecutionEvent,
-} from "@app/lib/actions/mcp";
+import { isBlockedActionEvent } from "@app/lib/actions/mcp";
 import { runAgentLoop } from "@app/lib/api/assistant/agent";
 import { getMessageChannelId } from "@app/lib/api/assistant/streaming/helpers";
 import { getRedisHybridManager } from "@app/lib/api/redis-hybrid-manager";

--- a/front/lib/api/assistant/streaming/events.ts
+++ b/front/lib/api/assistant/streaming/events.ts
@@ -105,7 +105,9 @@ export async function publishConversationRelatedEvent(
   a: ConversationRelatedEventParams
 ) {
   if (isMessageEventParams(a, a.event.type)) {
-    return publishMessageEvent(a.event, { step: a.step });
+    return publishMessageEvent(a.event, {
+      step: a.step,
+    });
   } else {
     return publishConversationEvent(a.event, {
       conversationId: a.conversationId,

--- a/front/lib/api/assistant/streaming/helpers.ts
+++ b/front/lib/api/assistant/streaming/helpers.ts
@@ -40,9 +40,9 @@ export function getConversationChannelId({
 export function getEventMessageChannelId(event: AgentMessageEvents) {
   // Tool approve execution can come from a sub agent, and in that case we want to send an event
   // to the main conversation.
-  if (event.type === "tool_approve_execution") {
+  if (event.type === "tool_approve_execution" || event.type === "tool_error") {
     return getMessageChannelId(
-      event.metadata.pubsubMessageId ?? event.messageId
+      event.metadata?.pubsubMessageId ?? event.messageId
     );
   }
   return getMessageChannelId(event.messageId);

--- a/front/lib/resources/agent_mcp_action_resource.ts
+++ b/front/lib/resources/agent_mcp_action_resource.ts
@@ -13,6 +13,7 @@ import {
   isToolExecutionStatusBlocked,
   TOOL_EXECUTION_BLOCKED_STATUSES,
 } from "@app/lib/actions/statuses";
+import type { StepContext } from "@app/lib/actions/types";
 import { getAgentConfigurations } from "@app/lib/api/assistant/configuration/agent";
 import type { Authenticator } from "@app/lib/auth";
 import { AgentMCPActionModel } from "@app/lib/models/assistant/actions/mcp";
@@ -313,6 +314,14 @@ export class AgentMCPActionResource extends BaseResource<AgentMCPActionModel> {
   ): Promise<[affectedCount: number]> {
     return this.update({
       status,
+    });
+  }
+
+  async updateStepContext(
+    stepContext: StepContext
+  ): Promise<[affectedCount: number]> {
+    return this.update({
+      stepContext,
     });
   }
 

--- a/front/temporal/agent_loop/activities/publish_deferred_events.ts
+++ b/front/temporal/agent_loop/activities/publish_deferred_events.ts
@@ -54,8 +54,19 @@ export async function publishDeferredEventsActivity(
         };
         break;
 
+      case "tool_approve_execution":
+        eventToPublish = {
+          ...event,
+          metadata: {
+            ...event.metadata,
+            // Override the message id to root the event to the right channel.
+            pubsubMessageId: deferredEvent.context.agentMessageId,
+          },
+        };
+        break;
+
       default:
-        assertNever(event.type);
+        assertNever(event);
     }
 
     await publishConversationRelatedEvent({

--- a/front/temporal/agent_loop/activities/publish_deferred_events.ts
+++ b/front/temporal/agent_loop/activities/publish_deferred_events.ts
@@ -50,6 +50,9 @@ export async function publishDeferredEventsActivity(
               }),
             },
           },
+          metadata: {
+            pubsubMessageId: deferredEvent.context.agentMessageId,
+          },
           isLastBlockingEventForStep: isLastEvent,
         };
         break;

--- a/front/temporal/agent_loop/activities/publish_deferred_events.ts
+++ b/front/temporal/agent_loop/activities/publish_deferred_events.ts
@@ -39,6 +39,7 @@ export async function publishDeferredEventsActivity(
           created: event.created,
           configurationId: event.configurationId,
           messageId: event.messageId,
+          conversationId: event.conversationId,
           error: {
             code: "mcp_server_personal_authentication_required",
             message: event.authError.message,

--- a/front/temporal/agent_loop/activities/publish_deferred_events.ts
+++ b/front/temporal/agent_loop/activities/publish_deferred_events.ts
@@ -48,6 +48,8 @@ export async function publishDeferredEventsActivity(
               ...(event.authError.scope && {
                 scope: event.authError.scope,
               }),
+              // TODO(DURABLE-AGENTS 2025-08-25): Find a proper place to pass conversationId.
+              conversationId: context.conversationId,
             },
           },
           metadata: {

--- a/front/temporal/agent_loop/activities/publish_deferred_events.ts
+++ b/front/temporal/agent_loop/activities/publish_deferred_events.ts
@@ -50,7 +50,8 @@ export async function publishDeferredEventsActivity(
                 scope: event.authError.scope,
               }),
               // TODO(DURABLE-AGENTS 2025-08-25): Find a proper place to pass conversationId.
-              conversationId: context.conversationId,
+              conversationId: event.conversationId,
+              messageId: event.messageId,
             },
           },
           metadata: {

--- a/front/temporal/agent_loop/activities/run_tool.ts
+++ b/front/temporal/agent_loop/activities/run_tool.ts
@@ -97,6 +97,7 @@ export async function runToolActivity(
             created: event.created,
             configurationId: agentConfiguration.sId,
             messageId: agentMessage.sId,
+            conversationId: conversation.sId,
             error: {
               code: event.error.code,
               message: event.error.message,

--- a/front/temporal/agent_loop/activities/run_tool.ts
+++ b/front/temporal/agent_loop/activities/run_tool.ts
@@ -116,8 +116,8 @@ export async function runToolActivity(
 
       case "tool_personal_auth_required":
       case "tool_approve_execution":
-        // Update the action status to blocked_child_action_required to break the agent loop.
-        await action.updateStatus("blocked_child_action_required");
+        // Update the action status to blocked_child_action_input_required to break the agent loop.
+        await action.updateStatus("blocked_child_action_input_required");
 
         // Defer personal auth events to be sent after all tools complete.
         deferredEvents.push({

--- a/front/temporal/agent_loop/lib/create_tool_actions.ts
+++ b/front/temporal/agent_loop/lib/create_tool_actions.ts
@@ -152,6 +152,7 @@ async function createActionForTool(
         created: Date.now(),
         configurationId: agentConfiguration.sId,
         messageId: agentMessage.sId,
+        conversationId,
         error: {
           code: "tool_error",
           message: validateToolInputsResult.error.message,

--- a/front/temporal/agent_loop/lib/deferred_events.ts
+++ b/front/temporal/agent_loop/lib/deferred_events.ts
@@ -1,3 +1,4 @@
+import type { MCPApproveExecutionEvent } from "@app/lib/actions/mcp";
 import type { ToolPersonalAuthRequiredEvent } from "@app/lib/actions/mcp_internal_actions/events";
 
 /**
@@ -5,13 +6,14 @@ import type { ToolPersonalAuthRequiredEvent } from "@app/lib/actions/mcp_interna
  * These are events that might need to be sent after all tools in a step complete,
  * rather than immediately when they occur.
  */
-type DeferrableEvent = ToolPersonalAuthRequiredEvent;
+type DeferrableEvent = MCPApproveExecutionEvent | ToolPersonalAuthRequiredEvent;
 
 /**
  * Context information needed to send a deferred event.
  * This captures the temporal workflow context at the time the event was deferred.
  */
 type DeferredEventContext = {
+  agentMessageId: string;
   agentMessageRowId: number;
   conversationId: string;
   step: number;

--- a/front/types/assistant/agent.ts
+++ b/front/types/assistant/agent.ts
@@ -242,6 +242,10 @@ export type ToolErrorEvent = {
   messageId: string;
   error: ErrorContent;
   isLastBlockingEventForStep: boolean;
+  // TODO(DURABLE-AGENTS 2025-08-25): Move to a deferred event base interface.
+  metadata?: {
+    pubsubMessageId?: string;
+  };
 };
 
 export type AgentDisabledErrorEvent = {

--- a/front/types/assistant/agent.ts
+++ b/front/types/assistant/agent.ts
@@ -240,6 +240,7 @@ export type ToolErrorEvent = {
   created: number;
   configurationId: string;
   messageId: string;
+  conversationId: string;
   error: ErrorContent;
   isLastBlockingEventForStep: boolean;
   // TODO(DURABLE-AGENTS 2025-08-25): Move to a deferred event base interface.

--- a/sdks/js/src/types.ts
+++ b/sdks/js/src/types.ts
@@ -1085,7 +1085,7 @@ export type MCPValidationMetadataPublicType = z.infer<
 const ToolExecutionBlockedStatusSchema = z.enum([
   "blocked_authentication_required",
   "blocked_validation_required",
-  "blocked_child_action_required",
+  "blocked_child_action_input_required",
 ]);
 
 export type ToolExecutionBlockedStatusType = z.infer<

--- a/sdks/js/src/types.ts
+++ b/sdks/js/src/types.ts
@@ -1110,16 +1110,22 @@ export type BlockedActionExecutionType = z.infer<
 
 const MCPApproveExecutionEventSchema = ToolExecutionMetadataSchema.extend({
   type: z.literal("tool_approve_execution"),
-  created: z.number(),
   configurationId: z.string(),
-  messageId: z.string(),
   conversationId: z.string(),
+  created: z.number(),
+  isLastBlockingEventForStep: z.boolean().optional(),
+  messageId: z.string(),
 });
+
+export type MCPApproveExecutionEvent = z.infer<
+  typeof MCPApproveExecutionEventSchema
+>;
 
 const ToolErrorEventSchema = z.object({
   type: z.literal("tool_error"),
   created: z.number(),
   configurationId: z.string(),
+  isLastBlockingEventForStep: z.boolean().optional(),
   messageId: z.string(),
   error: z.object({
     code: z.string(),

--- a/sdks/js/src/types.ts
+++ b/sdks/js/src/types.ts
@@ -1085,6 +1085,7 @@ export type MCPValidationMetadataPublicType = z.infer<
 const ToolExecutionBlockedStatusSchema = z.enum([
   "blocked_authentication_required",
   "blocked_validation_required",
+  "blocked_child_action_required",
 ]);
 
 export type ToolExecutionBlockedStatusType = z.infer<


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
This PR enables the `run_agent` tool to properly handle blocking events (tool approval and authentication) from child conversations.

### The Problem

When a parent agent uses `run_agent` to invoke a child agent, and that child needs user approval or authentication, the events were not propagating to the parent loop. Instead we were relying on MCP notification to bubble those up from the `run_agent` to the parent loop. This prevented the parent loop from breaking if `run_agent` needed validation, creating long running activities that could eventually get killed after some time. Also we could not validate/auth after more than 15 minutes, since those events are ephemerals (a bit more work is needed to save this on the parent action.
  
### The Solution

We now collect blocking events from child conversations and bubble them up to the parent. When a child agent encounters a blocking event (like needing Gmail auth or tool approval), we serialize these events through the MCP transport layer and properly surface them in the parent conversation's event stream.

The tricky part is that MCP tools can't directly yield events like regular actions. They return results through the MCP protocol which strips custom error properties. So we created a special serialization pattern that preserves the blocking events and the child conversation state needed to resume execution after the user provides input (inspired by the existing  `__dust_auth_required`).

### How does it work?

The `run_agent` tool creates a conversation on the first run and listened to the streamed events, if any event requires a user's input happens, all events associated are collected until we get the last before breaking the tool activity. This error is then handled in the `runToolWithStreaming` function to leverage the existing `deferredEvents` pattern used for the personal auth event. 

Both the current state of the tool (which will be used to resume) and the status are updated on the parent's conversation action. The status is set to `blocked_child_action_required` so they can get picked up in:
 https://github.com/dust-tt/dust/blob/f658135d83e16186f8e96b49d602554c909f0370/front/temporal/agent_loop/activities/run_model_and_create_actions_wrapper.ts#L172-L176

This means agents can now seamlessly delegate work to other agents, even when those child agents need user permissions. The user experience remains smooth, they get prompted for approval in the parent conversation and everything continues (both workflows restart) once they approve.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->
Tested locally. Safe to rollback.

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
