### PR TITLE
[front] handle error when user can't access agent configuration

### DIFF
--- a/front/components/assistant/conversation/ConversationContainer.tsx
+++ b/front/components/assistant/conversation/ConversationContainer.tsx
@@ -86,7 +86,7 @@ export function ConversationContainer({
     },
   });
 
-  const { mutateMessages } = useConversationMessages({
+  const { mutateMessages, isMessagesError } = useConversationMessages({
     conversationId: activeConversationId,
     workspaceId: owner.sId,
     limit: 50,
@@ -323,6 +323,23 @@ export function ConversationContainer({
   );
 
   const { startConversationRef } = useWelcomeTourGuide();
+
+  if (isMessagesError) {
+    return (
+      <div className="flex h-full w-full items-center justify-center">
+        <div className="flex flex-col gap-3 text-center">
+          <div>
+            <span className="text-4xl leading-10 text-foreground dark:text-foreground-night">
+              🚫
+            </span>
+            <p className="copy-sm leading-tight text-muted-foreground dark:text-muted-foreground-night">
+              You don't have access to this conversation.
+            </p>
+          </div>
+        </div>
+      </div>
+    );
+  }
 
   return (
     <DropzoneContainer

--- a/front/lib/api/assistant/messages.ts
+++ b/front/lib/api/assistant/messages.ts
@@ -398,14 +398,24 @@ async function batchRenderAgentMessages<V extends RenderMessageVariant>(
     })
   );
 
-  const errors = renderedMessages.filter((m) => m.isErr());
+  const errors = renderedMessages.filter((m): m is Err<ConversationError> =>
+    m.isErr()
+  );
   if (errors.length > 0) {
-    return new Err(errors[0].error);
+    return errors[0];
   }
 
   return new Ok(
     renderedMessages
-      .filter((m) => m.isOk())
+      .filter(
+        (
+          m
+        ): m is Ok<{
+          m: AgentMessageType;
+          rank: number;
+          version: number;
+        }> => m.isOk()
+      )
       .map((m) => m.value) as V extends "full"
       ? { m: AgentMessageType; rank: number; version: number }[]
       : { m: LightAgentMessageType; rank: number; version: number }[]

--- a/front/lib/api/assistant/messages.ts
+++ b/front/lib/api/assistant/messages.ts
@@ -277,8 +277,8 @@ async function batchRenderAgentMessages<V extends RenderMessageVariant>(
         (a) => a.sId === agentMessage.agentConfigurationId
       );
       if (!agentConfiguration) {
-        throw new Error(
-          "Unreachable: agent configuration must be found for agent message"
+        return new Err(
+          new ConversationError("conversation_with_unavailable_agent")
         );
       }
 
@@ -387,19 +387,26 @@ async function batchRenderAgentMessages<V extends RenderMessageVariant>(
       } satisfies AgentMessageType;
 
       if (viewType === "full") {
-        return { m, rank: message.rank, version: message.version };
+        return new Ok({ m, rank: message.rank, version: message.version });
       } else {
-        return {
+        return new Ok({
           m: getLightAgentMessageFromAgentMessage(m),
           rank: message.rank,
           version: message.version,
-        };
+        });
       }
     })
   );
 
+  const errors = renderedMessages.filter((m) => m.isErr());
+  if (errors.length > 0) {
+    return errors[0];
+  }
+
   return new Ok(
-    renderedMessages as V extends "full"
+    renderedMessages
+      .filter((m) => m.isOk())
+      .map((m) => m.value) as V extends "full"
       ? { m: AgentMessageType; rank: number; version: number }[]
       : { m: LightAgentMessageType; rank: number; version: number }[]
   );

--- a/front/lib/api/assistant/messages.ts
+++ b/front/lib/api/assistant/messages.ts
@@ -400,7 +400,7 @@ async function batchRenderAgentMessages<V extends RenderMessageVariant>(
 
   const errors = renderedMessages.filter((m) => m.isErr());
   if (errors.length > 0) {
-    return errors[0];
+    return new Err(errors[0].error);
   }
 
   return new Ok(


### PR DESCRIPTION
## Description

This happens when a user tries to access a conversation in which there's an agent he does not have access to (anymore). Usually happens when some datasource form private spaces are added - in that case teh agent configuration can't be "read" anymore. 
Bubble up a result and show an error message instead of white screen.

## Tests

Locally

## Risk

low

## Deploy Plan

deploy front