### PR TITLE
[connectors] Try to catch snowflake suspended account error

### DIFF
--- a/connectors/src/connectors/snowflake/temporal/cast_known_errors.ts
+++ b/connectors/src/connectors/snowflake/temporal/cast_known_errors.ts
@@ -109,6 +109,7 @@ function isSnowflakeSuspendedError(
   return (
     "name" in maybeSuspendedError &&
     maybeSuspendedError.name === "OperationFailedError" &&
+    "message" in maybeSuspendedError &&
     maybeSuspendedError.message.includes("suspended")
   );
 }

--- a/connectors/src/connectors/snowflake/temporal/cast_known_errors.ts
+++ b/connectors/src/connectors/snowflake/temporal/cast_known_errors.ts
@@ -95,6 +95,24 @@ function isSnowflakeRoleNotFoundError(
   );
 }
 
+interface SnowflakeSuspendedError extends Error {
+  name: "OperationFailedError";
+}
+
+function isSnowflakeSuspendedError(
+  err: unknown
+): err is SnowflakeSuspendedError {
+  const maybeSuspendedError = err as {
+    name: "OperationFailedError";
+    message: string;
+  };
+  return (
+    "name" in maybeSuspendedError &&
+    maybeSuspendedError.name === "OperationFailedError" &&
+    maybeSuspendedError.message.includes("suspended")
+  );
+}
+
 export class SnowflakeCastKnownErrorsInterceptor
   implements ActivityInboundCallsInterceptor
 {
@@ -111,7 +129,8 @@ export class SnowflakeCastKnownErrorsInterceptor
         // we add it here to make the user aware that getting locked out of his account blocks the connection
         isSnowflakeAccountLockedError(err) ||
         isSnowflakeIncorrectCredentialsError(err) ||
-        isSnowflakeRoleNotFoundError(err)
+        isSnowflakeRoleNotFoundError(err) ||
+        isSnowflakeSuspendedError(err)
       ) {
         throw new ExternalOAuthTokenError(err);
       }


### PR DESCRIPTION
## Description

Catch error : OperationFailedError: Your free trial has ended and all of your virtual warehouses have been suspended. Add billing information in the Snowflake web UI to continue using the full set of Snowflake features.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

low

## Deploy Plan

deploy connectors
