### PR TITLE
[front] show navigation loader

### DIFF
--- a/front/components/app/RootLayout.tsx
+++ b/front/components/app/RootLayout.tsx
@@ -7,6 +7,7 @@ import { SWRConfig } from "swr";
 import type { UrlObject } from "url";
 
 import { ConfirmPopupArea } from "@app/components/Confirm";
+import { NavigationLoadingProvider } from "@app/components/sparkle/NavigationLoadingContext";
 import { SidebarProvider } from "@app/components/sparkle/SidebarContext";
 import { isAPIErrorResponse } from "@app/types";
 
@@ -87,9 +88,11 @@ export default function RootLayout({
         }}
       >
         <SidebarProvider>
-          <ConfirmPopupArea>
-            <Notification.Area>{children}</Notification.Area>
-          </ConfirmPopupArea>
+          <NavigationLoadingProvider>
+            <ConfirmPopupArea>
+              <Notification.Area>{children}</Notification.Area>
+            </ConfirmPopupArea>
+          </NavigationLoadingProvider>
         </SidebarProvider>
       </SWRConfig>
     </SparkleContext.Provider>

--- a/front/components/navigation/NavigationSidebar.tsx
+++ b/front/components/navigation/NavigationSidebar.tsx
@@ -18,6 +18,7 @@ import { useWelcomeTourGuide } from "@app/components/assistant/WelcomeTourGuideP
 import type { SidebarNavigation } from "@app/components/navigation/config";
 import { getTopNavigationTabs } from "@app/components/navigation/config";
 import { HelpDropdown } from "@app/components/navigation/HelpDropdown";
+import { useNavigationLoading } from "@app/components/sparkle/NavigationLoadingContext";
 import { UserMenu } from "@app/components/UserMenu";
 import { isFreePlan } from "@app/lib/plans/plan_codes";
 import { useAppStatus } from "@app/lib/swr/useAppStatus";
@@ -64,6 +65,13 @@ export const NavigationSidebar = React.forwardRef<
   });
 
   const { spaceMenuButtonRef } = useWelcomeTourGuide();
+  const { showNavigationLoader } = useNavigationLoading();
+
+  const handleTabClick = (href?: string) => {
+    if (href && href !== router.asPath) {
+      showNavigationLoader();
+    }
+  };
 
   // TODO(2024-06-19 flav): Fix issue with AppLayout changing between pagesg
   const navs = useMemo(
@@ -105,6 +113,7 @@ export const NavigationSidebar = React.forwardRef<
                     tooltip={tab.hideLabel ? tab.label : undefined}
                     icon={tab.icon}
                     href={tab.href}
+                    onClick={() => handleTabClick(tab.href)}
                   />
                 </div>
               ))}
@@ -136,6 +145,7 @@ export const NavigationSidebar = React.forwardRef<
                                   icon={menu.icon}
                                   href={menu.href}
                                   target={menu.target}
+                                  onClick={() => handleTabClick(menu.href)}
                                 />
                                 {menu.subMenuLabel && (
                                   <div
@@ -157,6 +167,7 @@ export const NavigationSidebar = React.forwardRef<
                                         icon={nav.icon}
                                         className="grow pl-14 pr-4"
                                         href={nav.href ? nav.href : undefined}
+                                        onClick={() => handleTabClick(nav.href)}
                                       />
                                     ))}
                                   </div>

--- a/front/components/sparkle/AppContentLayout.tsx
+++ b/front/components/sparkle/AppContentLayout.tsx
@@ -6,6 +6,7 @@ import React from "react";
 import type { SidebarNavigation } from "@app/components/navigation/config";
 import { Navigation } from "@app/components/navigation/Navigation";
 import { AppLayoutTitle } from "@app/components/sparkle/AppLayoutTitle";
+import { NavigationLoadingOverlay } from "@app/components/sparkle/NavigationLoadingOverlay";
 import { useAppKeyboardShortcuts } from "@app/hooks/useAppKeyboardShortcuts";
 import type { SubscriptionType, WorkspaceType } from "@app/types";
 
@@ -95,6 +96,7 @@ export default function AppContentLayout({
           "dark:bg-background-night dark:text-foreground-night"
         )}
       >
+        <NavigationLoadingOverlay />
         {/* Temporary measure to preserve title existence on smaller screens.
          * Page has no title, prepend empty AppLayoutTitle. */}
         {loaded && !hasTitle && (

--- a/front/components/sparkle/NavigationLoadingContext.tsx
+++ b/front/components/sparkle/NavigationLoadingContext.tsx
@@ -1,0 +1,71 @@
+import { useRouter } from "next/router";
+import React, { useCallback, useContext, useEffect, useState } from "react";
+
+interface NavigationLoadingContextType {
+  isNavigating: boolean;
+  showNavigationLoader: () => void;
+}
+
+interface NavigationLoadingProviderProps {
+  children: React.ReactNode;
+}
+
+const NavigationLoadingContext = React.createContext<
+  NavigationLoadingContextType | undefined
+>(undefined);
+
+// In our app, it sometimes takes a very long time to navigate to another page (e.g. go to the spaces tab).
+// Users often don't know if they fail to click or we are loading the page. To avoid confusion,
+// you can show a loading spinner when navigation takes longer with this context. The loading spinner has an opacity animation,
+// it starts with opacity: 0 and then after 0.5s we set opacity: 1, so we can show the spinner only when the
+// navigation takes a long time.
+export function NavigationLoadingProvider({
+  children,
+}: NavigationLoadingProviderProps) {
+  const [isNavigating, setIsNavigating] = useState(false);
+  const router = useRouter();
+
+  const showNavigationLoader = useCallback(() => {
+    setIsNavigating(true);
+  }, []);
+
+  // Clear loading state when route change is complete
+  useEffect(() => {
+    const handleRouteChangeComplete = () => {
+      setIsNavigating(false);
+    };
+
+    const handleRouteChangeError = () => {
+      setIsNavigating(false);
+    };
+
+    router.events.on("routeChangeComplete", handleRouteChangeComplete);
+    router.events.on("routeChangeError", handleRouteChangeError);
+
+    return () => {
+      router.events.off("routeChangeComplete", handleRouteChangeComplete);
+      router.events.off("routeChangeError", handleRouteChangeError);
+    };
+  }, [router.events]);
+
+  return (
+    <NavigationLoadingContext.Provider
+      value={{
+        isNavigating,
+        showNavigationLoader,
+      }}
+    >
+      {children}
+    </NavigationLoadingContext.Provider>
+  );
+}
+
+export function useNavigationLoading() {
+  const context = useContext(NavigationLoadingContext);
+  if (!context) {
+    throw new Error(
+      "useNavigationLoading must be used within a NavigationLoadingProvider"
+    );
+  }
+  return context;
+}

--- a/front/components/sparkle/NavigationLoadingContext.tsx
+++ b/front/components/sparkle/NavigationLoadingContext.tsx
@@ -29,24 +29,20 @@ export function NavigationLoadingProvider({
     setIsNavigating(true);
   }, []);
 
+  const endNavigationLoader = useCallback(() => {
+    setIsNavigating(false);
+  }, []);
+
   // Clear loading state when route change is complete
   useEffect(() => {
-    const handleRouteChangeComplete = () => {
-      setIsNavigating(false);
-    };
-
-    const handleRouteChangeError = () => {
-      setIsNavigating(false);
-    };
-
-    router.events.on("routeChangeComplete", handleRouteChangeComplete);
-    router.events.on("routeChangeError", handleRouteChangeError);
+    router.events.on("routeChangeComplete", endNavigationLoader);
+    router.events.on("routeChangeError", endNavigationLoader);
 
     return () => {
-      router.events.off("routeChangeComplete", handleRouteChangeComplete);
-      router.events.off("routeChangeError", handleRouteChangeError);
+      router.events.off("routeChangeComplete", endNavigationLoader);
+      router.events.off("routeChangeError", endNavigationLoader);
     };
-  }, [router.events]);
+  }, [router.events, endNavigationLoader]);
 
   return (
     <NavigationLoadingContext.Provider

--- a/front/components/sparkle/NavigationLoadingOverlay.tsx
+++ b/front/components/sparkle/NavigationLoadingOverlay.tsx
@@ -1,0 +1,26 @@
+import { cn, Spinner } from "@dust-tt/sparkle";
+import React from "react";
+
+import { useNavigationLoading } from "@app/components/sparkle/NavigationLoadingContext";
+
+export function NavigationLoadingOverlay() {
+  const { isNavigating } = useNavigationLoading();
+
+  if (!isNavigating) {
+    return null;
+  }
+
+  return (
+    <div
+      className={cn(
+        "absolute inset-0 z-50",
+        "bg-background/80 backdrop-blur-sm",
+        "dark:bg-background-night/80",
+        "flex items-center justify-center",
+        "animate-navigation-loader opacity-0"
+      )}
+    >
+      <Spinner size="lg" />
+    </div>
+  );
+}

--- a/front/tailwind.config.js
+++ b/front/tailwind.config.js
@@ -547,7 +547,8 @@ module.exports = {
         reload: "reload 1000ms ease-out",
         fadeout: "fadeout 500ms ease-out",
         marquee: "marquee 25s linear infinite",
-        "navigation-loader": "navigation-fade-in 0.2s ease-in-out 0.5s forwards",
+        "navigation-loader":
+          "navigation-fade-in 0.2s ease-in-out 0.5s forwards",
       },
       colors: {
         // Creates night shades for all colors

--- a/front/tailwind.config.js
+++ b/front/tailwind.config.js
@@ -532,6 +532,11 @@ module.exports = {
           "0%": { transform: "translate3d(0, 0, 0)" },
           "100%": { transform: "translate3d(-50%, 0, 0)" },
         },
+        "navigation-fade-in": {
+          to: {
+            opacity: "1",
+          },
+        },
       },
       animation: {
         "move-square": "move-square 4s ease-out infinite",
@@ -542,6 +547,7 @@ module.exports = {
         reload: "reload 1000ms ease-out",
         fadeout: "fadeout 500ms ease-out",
         marquee: "marquee 25s linear infinite",
+        "navigation-loader": "navigation-fade-in 0.2s ease-in-out 0.5s forwards",
       },
       colors: {
         // Creates night shades for all colors


### PR DESCRIPTION
## Description
This PR is based on Alban's PR [here](https://github.com/dust-tt/dust/pull/14874). We show a navigation loader only when you switch between chat/spaces for now. There is a discussion with @pinotalexandre if we want to show a loader in entire page vs only in button (which is how it's implemented in Create Agent button now). Alex will investigate how other products show a loading spinner, and we will see how we want to do it in other places in the app. 

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
