### PR TITLE
[front] - fix(AB v2): reset dirty on save

### DIFF
--- a/front/components/agent_builder/AgentBuilder.tsx
+++ b/front/components/agent_builder/AgentBuilder.tsx
@@ -237,7 +237,7 @@ export default function AgentBuilder({
 
       if (!agentConfiguration && createdAgent.sId) {
         const newUrl = `/w/${owner.sId}/builder/agents/${createdAgent.sId}`;
-        await router.push(newUrl);
+        await router.replace(newUrl, undefined, { shallow: true });
       }
     } catch (error) {
       logger.error("Unexpected error:", error);

--- a/front/components/agent_builder/AgentBuilder.tsx
+++ b/front/components/agent_builder/AgentBuilder.tsx
@@ -230,10 +230,14 @@ export default function AgentBuilder({
         type: "success",
       });
 
+      // Reset form dirty state after successful save
+      form.reset(form.getValues(), {
+        keepValues: true,
+      });
+
       if (!agentConfiguration && createdAgent.sId) {
         const newUrl = `/w/${owner.sId}/builder/agents/${createdAgent.sId}`;
-        // willingly using window to not trigger next navigation events
-        window.history.replaceState(null, "", newUrl);
+        await router.push(newUrl);
       }
     } catch (error) {
       logger.error("Unexpected error:", error);


### PR DESCRIPTION
## Description

This PR resets form dirty state after a successful save to prevent unsaved changes warning. It also replaces direct window.history manipulation with next/router for consistent navigation handling

## Tests

Locally

## Risk

Low

## Deploy Plan

Deploy front