### PR TITLE
[sparkle] feat(ScrollableDataTable): Support full height

### DIFF
--- a/front/components/agent_builder/capabilities/knowledge/KnowledgeConfigurationSheet.tsx
+++ b/front/components/agent_builder/capabilities/knowledge/KnowledgeConfigurationSheet.tsx
@@ -1,9 +1,5 @@
 import type { MultiPageSheetPage } from "@dust-tt/sparkle";
-import {
-  MultiPageSheet,
-  MultiPageSheetContent,
-  ScrollArea,
-} from "@dust-tt/sparkle";
+import { MultiPageSheet, MultiPageSheetContent } from "@dust-tt/sparkle";
 import { zodResolver } from "@hookform/resolvers/zod";
 import uniqueId from "lodash/uniqueId";
 import { useEffect, useMemo, useState } from "react";
@@ -328,15 +324,13 @@ function KnowledgeConfigurationSheetContent({
         : "Choose the data sources to include in your knowledge base",
       icon: undefined,
       content: (
-        <div className="space-y-4">
-          <ScrollArea>
-            <DataSourceBuilderSelector
-              dataSourceViews={supportedDataSourceViews}
-              owner={owner}
-              viewType="all"
-              allowedSpaces={allowedSpaces}
-            />
-          </ScrollArea>
+        <div className="h-full">
+          <DataSourceBuilderSelector
+            dataSourceViews={supportedDataSourceViews}
+            owner={owner}
+            viewType="all"
+            allowedSpaces={allowedSpaces}
+          />
         </div>
       ),
       footerContent: hasSourceSelection ? <KnowledgeFooter /> : undefined,

--- a/sparkle/src/components/DataTable.tsx
+++ b/sparkle/src/components/DataTable.tsx
@@ -327,7 +327,7 @@ export function DataTable<TData extends TBaseData>({
 
 export interface ScrollableDataTableProps<TData extends TBaseData>
   extends DataTableProps<TData> {
-  maxHeight?: string;
+  maxHeight?: string | boolean;
   onLoadMore?: () => void;
   isLoading?: boolean;
 }
@@ -343,7 +343,7 @@ export function ScrollableDataTable<TData extends TBaseData>({
   className,
   widthClassName = "s-w-full",
   columnsBreakpoints = {},
-  maxHeight = "s-h-100",
+  maxHeight,
   onLoadMore,
   isLoading = false,
   rowSelection,
@@ -480,24 +480,95 @@ export function ScrollableDataTable<TData extends TBaseData>({
   }, [onLoadMore, isLoading]);
 
   return (
-    <div className={cn("s-flex s-flex-col s-gap-2", className, widthClassName)}>
-      <div
-        className={cn(
-          "s-relative s-overflow-y-auto s-overflow-x-hidden",
-          maxHeight
-        )}
-        ref={tableContainerRef}
-      >
-        <div className="s-relative">
-          <DataTable.Root className="s-w-full s-table-fixed">
-            <DataTable.Header className="s-sticky s-top-0 s-z-20 s-bg-white s-shadow-sm dark:s-bg-background-night">
-              {table.getHeaderGroups().map((headerGroup) => (
+    <div
+      className={cn(
+        "s-relative s-overflow-y-auto s-overflow-x-hidden",
+        className,
+        widthClassName,
+        maxHeight === true
+          ? "s-flex-1"
+          : typeof maxHeight === "string"
+            ? maxHeight
+            : "s-max-h-100"
+      )}
+      ref={tableContainerRef}
+    >
+      <div className="s-relative">
+        <DataTable.Root className="s-w-full s-table-fixed">
+          <DataTable.Header className="s-sticky s-top-0 s-z-20 s-bg-white s-shadow-sm dark:s-bg-background-night">
+            {table.getHeaderGroups().map((headerGroup) => (
+              <DataTable.Row
+                key={headerGroup.id}
+                widthClassName={widthClassName}
+              >
+                {headerGroup.headers.map((header) => {
+                  const breakpoint = columnsBreakpoints[header.id];
+                  if (
+                    !windowSize.width ||
+                    !shouldRenderColumn(windowSize.width, breakpoint)
+                  ) {
+                    return null;
+                  }
+
+                  return (
+                    <DataTable.Head
+                      column={header.column}
+                      key={header.id}
+                      className="s-max-w-0"
+                      style={{
+                        width: columnSizing[header.id],
+                        minWidth: columnSizing[header.id],
+                      }}
+                    >
+                      <div className="s-flex s-w-full s-items-center s-space-x-1">
+                        <span className="s-truncate">
+                          {flexRender(
+                            header.column.columnDef.header,
+                            header.getContext()
+                          )}
+                        </span>
+                      </div>
+                    </DataTable.Head>
+                  );
+                })}
+              </DataTable.Row>
+            ))}
+          </DataTable.Header>
+          <DataTable.Body
+            className="s-relative s-w-full"
+            style={{
+              height: `${rowVirtualizer.getTotalSize()}px`,
+            }}
+          >
+            {rowVirtualizer.getVirtualItems().map((virtualRow) => {
+              const row = rows[virtualRow.index];
+              const handleRowClick = () => {
+                if (enableRowSelection && row.getCanSelect()) {
+                  row.toggleSelected(
+                    !enableMultiRowSelection ? true : undefined
+                  );
+                }
+                row.original.onClick?.();
+              };
+
+              return (
                 <DataTable.Row
-                  key={headerGroup.id}
+                  key={row.id}
+                  id={row.id}
                   widthClassName={widthClassName}
+                  onClick={
+                    enableRowSelection ? handleRowClick : row.original.onClick
+                  }
+                  className="s-absolute s-w-full"
+                  {...(enableRowSelection && {
+                    "data-selected": row.getIsSelected(),
+                  })}
+                  style={{
+                    transform: `translateY(${virtualRow.start}px)`,
+                  }}
                 >
-                  {headerGroup.headers.map((header) => {
-                    const breakpoint = columnsBreakpoints[header.id];
+                  {row.getVisibleCells().map((cell) => {
+                    const breakpoint = columnsBreakpoints[cell.column.id];
                     if (
                       !windowSize.width ||
                       !shouldRenderColumn(windowSize.width, breakpoint)
@@ -506,114 +577,47 @@ export function ScrollableDataTable<TData extends TBaseData>({
                     }
 
                     return (
-                      <DataTable.Head
-                        column={header.column}
-                        key={header.id}
+                      <DataTable.Cell
+                        column={cell.column}
+                        key={cell.id}
+                        id={cell.id}
                         className="s-max-w-0"
                         style={{
-                          width: columnSizing[header.id],
-                          minWidth: columnSizing[header.id],
+                          width: columnSizing[cell.column.id],
+                          minWidth: columnSizing[cell.column.id],
                         }}
                       >
-                        <div className="s-flex s-w-full s-items-center s-space-x-1">
+                        <div className="s-flex s-items-center s-space-x-1">
                           <span className="s-truncate">
                             {flexRender(
-                              header.column.columnDef.header,
-                              header.getContext()
+                              cell.column.columnDef.cell,
+                              cell.getContext()
                             )}
                           </span>
                         </div>
-                      </DataTable.Head>
+                      </DataTable.Cell>
                     );
                   })}
                 </DataTable.Row>
-              ))}
-            </DataTable.Header>
-            <DataTable.Body
-              className="s-relative s-w-full"
-              style={{
-                height: `${rowVirtualizer.getTotalSize()}px`,
-              }}
-            >
-              {rowVirtualizer.getVirtualItems().map((virtualRow) => {
-                const row = rows[virtualRow.index];
-                const handleRowClick = () => {
-                  if (enableRowSelection && row.getCanSelect()) {
-                    row.toggleSelected(
-                      !enableMultiRowSelection ? true : undefined
-                    );
-                  }
-                  row.original.onClick?.();
-                };
-
-                return (
-                  <DataTable.Row
-                    key={row.id}
-                    id={row.id}
-                    widthClassName={widthClassName}
-                    onClick={
-                      enableRowSelection ? handleRowClick : row.original.onClick
-                    }
-                    className="s-absolute s-w-full"
-                    {...(enableRowSelection && {
-                      "data-selected": row.getIsSelected(),
-                    })}
-                    style={{
-                      transform: `translateY(${virtualRow.start}px)`,
-                    }}
-                  >
-                    {row.getVisibleCells().map((cell) => {
-                      const breakpoint = columnsBreakpoints[cell.column.id];
-                      if (
-                        !windowSize.width ||
-                        !shouldRenderColumn(windowSize.width, breakpoint)
-                      ) {
-                        return null;
-                      }
-
-                      return (
-                        <DataTable.Cell
-                          column={cell.column}
-                          key={cell.id}
-                          id={cell.id}
-                          className="s-max-w-0"
-                          style={{
-                            width: columnSizing[cell.column.id],
-                            minWidth: columnSizing[cell.column.id],
-                          }}
-                        >
-                          <div className="s-flex s-items-center s-space-x-1">
-                            <span className="s-truncate">
-                              {flexRender(
-                                cell.column.columnDef.cell,
-                                cell.getContext()
-                              )}
-                            </span>
-                          </div>
-                        </DataTable.Cell>
-                      );
-                    })}
-                  </DataTable.Row>
-                );
-              })}
-            </DataTable.Body>
-          </DataTable.Root>
-          {/*sentinel div used for the intersection observer*/}
-          <div
-            ref={loadMoreRef}
-            className="s-absolute s-bottom-0 s-h-1 s-w-full"
-          />
-        </div>
-
-        {isLoading && (
-          <div className="s-sticky s-bottom-0 s-left-0 s-right-0 s-flex s-justify-center s-bg-white/80 s-py-2 s-backdrop-blur-sm dark:s-bg-background-night/80">
-            <div className="s-flex s-items-center s-gap-2 s-text-sm s-text-muted-foreground">
-              <Spinner size="xs" />
-              <span>Loading more data...</span>
-            </div>
-          </div>
-        )}
+              );
+            })}
+          </DataTable.Body>
+        </DataTable.Root>
+        {/*sentinel div used for the intersection observer*/}
+        <div
+          ref={loadMoreRef}
+          className="s-absolute s-bottom-0 s-h-1 s-w-full"
+        />
       </div>
+
+      {isLoading && (
+        <div className="s-sticky s-bottom-0 s-left-0 s-right-0 s-flex s-justify-center s-bg-white/80 s-py-2 s-backdrop-blur-sm dark:s-bg-background-night/80">
+          <div className="s-flex s-items-center s-gap-2 s-text-sm s-text-muted-foreground">
+            <Spinner size="xs" />
+            <span>Loading more data...</span>
+          </div>
+        </div>
+      )}
     </div>
   );
 }

--- a/sparkle/src/components/MultiPageSheet.tsx
+++ b/sparkle/src/components/MultiPageSheet.tsx
@@ -22,6 +22,11 @@ interface MultiPageSheetPage {
   content: React.ReactNode;
   fixedContent?: React.ReactNode;
   footerContent?: React.ReactNode;
+  /**
+   * Remove the default ScrollArea in the SheetContainer.
+   * To be used if you want to manage the scroll yourself
+   */
+  noScroll?: boolean;
 }
 
 interface MultiPageSheetProps {
@@ -231,6 +236,7 @@ const MultiPageSheetContent = React.forwardRef<
             )}
             <SheetContainer
               className={currentPage.fixedContent ? "s-flex-1" : undefined}
+              noScroll={currentPage.noScroll}
             >
               {currentPage.content}
             </SheetContainer>

--- a/sparkle/src/components/Sheet.tsx
+++ b/sparkle/src/components/Sheet.tsx
@@ -180,18 +180,25 @@ const SheetHeader = ({
 );
 SheetHeader.displayName = "SheetHeader";
 
-const SheetContainer = ({ children }: React.HTMLAttributes<HTMLDivElement>) => {
+interface SheetContainerProps extends React.HTMLAttributes<HTMLDivElement> {
+  noScroll?: boolean;
+}
+
+const SheetContainer = ({ children, noScroll }: SheetContainerProps) => {
+  const ScrollContainer = noScroll ? React.Fragment : ScrollArea;
   return (
-    <ScrollArea
-      className={cn(
-        "s-h-full s-w-full s-flex-grow",
-        "s-border-t s-border-border/60 s-transition-all s-duration-300 dark:s-border-border-night/60"
-      )}
-    >
-      <div className="s-relative s-flex s-h-full s-flex-col s-gap-5 s-p-5 s-text-left s-text-sm s-text-foreground dark:s-text-foreground-night">
-        {children}
+    <ScrollContainer>
+      <div
+        className={cn(
+          "s-h-full s-w-full s-flex-grow",
+          "s-border-t s-border-border/60 s-transition-all s-duration-300 dark:s-border-border-night/60"
+        )}
+      >
+        <div className="s-relative s-flex s-h-full s-flex-col s-gap-5 s-p-5 s-text-left s-text-sm s-text-foreground dark:s-text-foreground-night">
+          {children}
+        </div>
       </div>
-    </ScrollArea>
+    </ScrollContainer>
   );
 };
 SheetContainer.displayName = "SheetContainer";

--- a/sparkle/src/stories/DataTable.stories.tsx
+++ b/sparkle/src/stories/DataTable.stories.tsx
@@ -607,6 +607,67 @@ export const ScrollableDataTableExample = () => {
   );
 };
 
+export const ScrollableDataTableFullHeightExample = () => {
+  const [filter, setFilter] = useState("");
+  const [rowSelection, setRowSelection] = useState<RowSelectionState>({});
+  const [data, setData] = useState(() => createData(0, 50));
+  const [isLoading, setIsLoading] = useState(false);
+
+  // Load more data when user scrolls to bottom
+  const loadMore = useCallback(() => {
+    setIsLoading(true);
+
+    // Simulate API call delay
+    setTimeout(() => {
+      setData((prevData) => [...prevData, ...createData(prevData.length, 50)]);
+      setIsLoading(false);
+    }, 1000);
+  }, []);
+
+  const columnsWithSize = columns.map((column, index) => {
+    return { ...column, meta: { sizeRatio: index % 2 === 0 ? 15 : 10 } };
+  });
+
+  const columnsWithSelection: ColumnDef<Data>[] = useMemo(
+    () => [createSelectionColumn<Data>(), ...columnsWithSize],
+    []
+  );
+  return (
+    <div className="s-flex s-w-full s-max-w-4xl s-flex-col s-gap-6">
+      <h3 className="s-text-lg s-font-medium">
+        Virtualized ScrollableDataTable with Infinite Scrolling based on parent
+        height
+      </h3>
+
+      <div className="s-flex s-h-[400px] s-flex-col s-gap-4">
+        <Input
+          name="filter"
+          placeholder="Filter"
+          value={filter}
+          onChange={(e) => setFilter(e.target.value)}
+        />
+
+        <ScrollableDataTable
+          data={data}
+          filter={filter}
+          filterColumn="name"
+          columns={columnsWithSelection}
+          onLoadMore={loadMore}
+          isLoading={isLoading}
+          maxHeight
+          rowSelection={rowSelection}
+          setRowSelection={setRowSelection}
+          enableRowSelection={true}
+        />
+
+        <div className="s-text-sm s-text-muted-foreground">
+          Loaded {data.length} rows. Scroll to the bottom to load more.
+        </div>
+      </div>
+    </div>
+  );
+};
+
 export const DataTableWithRowSelectionExample = () => {
   const [rowSelection, setRowSelection] = useState<RowSelectionState>({});
   const [data] = useState<Data[]>(() => createData(0, 10));

--- a/sparkle/src/stories/MultiPageSheet.stories.tsx
+++ b/sparkle/src/stories/MultiPageSheet.stories.tsx
@@ -633,6 +633,7 @@ export const WithScrollableDataTable: Story = {
         title: "User Management",
         description: "Manage users with infinite scroll",
         icon: UserIcon,
+        noScroll: true,
         content: (
           <div className="s-flex s-h-full s-flex-col s-space-y-4">
             <div className="s-flex-shrink-0">

--- a/sparkle/src/stories/MultiPageSheet.stories.tsx
+++ b/sparkle/src/stories/MultiPageSheet.stories.tsx
@@ -1,7 +1,9 @@
 import type { Meta, StoryObj } from "@storybook/react";
-import React, { useState } from "react";
+import type { ColumnDef } from "@tanstack/react-table";
+import React, { useCallback, useState } from "react";
 
 import { Button } from "@sparkle/components/Button";
+import { ScrollableDataTable } from "@sparkle/components/DataTable";
 import {
   MultiPageSheet,
   MultiPageSheetContent,
@@ -461,6 +463,216 @@ export const WithConditionalNavigation: Story = {
             currentPageId === "data-selection" && selectedItems.length === 0
           }
           disableSave={!description.trim()}
+        />
+      </MultiPageSheet>
+    );
+  },
+};
+
+// Sample data types for the ScrollableDataTable
+interface UserData {
+  id: string;
+  name: string;
+  email: string;
+  role: string;
+  status: string;
+  lastActive: string;
+  onClick?: () => void;
+}
+
+// Generate random user data
+const generateRandomUsers = (
+  count: number,
+  startId: number = 0
+): UserData[] => {
+  const roles = ["Admin", "User", "Manager", "Developer", "Designer"];
+  const statuses = ["Active", "Inactive", "Pending"];
+  const firstNames = [
+    "John",
+    "Jane",
+    "Mike",
+    "Sarah",
+    "David",
+    "Lisa",
+    "Tom",
+    "Anna",
+    "Chris",
+    "Emma",
+  ];
+  const lastNames = [
+    "Smith",
+    "Johnson",
+    "Williams",
+    "Brown",
+    "Jones",
+    "Garcia",
+    "Miller",
+    "Davis",
+    "Rodriguez",
+    "Martinez",
+  ];
+
+  return Array.from({ length: count }, (_, index) => {
+    const firstName = firstNames[Math.floor(Math.random() * firstNames.length)];
+    const lastName = lastNames[Math.floor(Math.random() * lastNames.length)];
+    const id = (startId + index + 1).toString();
+
+    return {
+      id,
+      name: `${firstName} ${lastName}`,
+      email: `${firstName.toLowerCase()}.${lastName.toLowerCase()}@example.com`,
+      role: roles[Math.floor(Math.random() * roles.length)],
+      status: statuses[Math.floor(Math.random() * statuses.length)],
+      lastActive: new Date(
+        Date.now() - Math.floor(Math.random() * 30) * 24 * 60 * 60 * 1000
+      ).toLocaleDateString(),
+      onClick: () => alert(`Clicked on user: ${firstName} ${lastName}`),
+    };
+  });
+};
+
+export const WithScrollableDataTable: Story = {
+  render() {
+    const [currentPageId, setCurrentPageId] = useState("users");
+    const [users, setUsers] = useState<UserData[]>(() =>
+      generateRandomUsers(50)
+    );
+    const [isLoading, setIsLoading] = useState(false);
+    const [hasMore, setHasMore] = useState(true);
+
+    // Define columns for the data table
+    const columns: ColumnDef<UserData>[] = [
+      {
+        accessorKey: "name",
+        header: "Name",
+        cell: ({ row }) => (
+          <div className="s-font-medium">{row.getValue("name")}</div>
+        ),
+        meta: { sizeRatio: 25 },
+      },
+      {
+        accessorKey: "email",
+        header: "Email",
+        cell: ({ row }) => (
+          <div className="s-text-muted-foreground">{row.getValue("email")}</div>
+        ),
+        meta: { sizeRatio: 30 },
+      },
+      {
+        accessorKey: "role",
+        header: "Role",
+        cell: ({ row }) => (
+          <div className="s-inline-flex s-rounded-full s-bg-blue-100 s-px-2 s-py-1 s-text-xs s-font-semibold s-text-blue-800">
+            {row.getValue("role")}
+          </div>
+        ),
+        meta: { sizeRatio: 15 },
+      },
+      {
+        accessorKey: "status",
+        header: "Status",
+        cell: ({ row }) => {
+          const status = row.getValue("status") as string;
+          const colorClass =
+            status === "Active"
+              ? "s-bg-green-100 s-text-green-800"
+              : status === "Inactive"
+                ? "s-bg-red-100 s-text-red-800"
+                : "s-bg-yellow-100 s-text-yellow-800";
+
+          return (
+            <div
+              className={`s-inline-flex s-rounded-full s-px-2 s-py-1 s-text-xs s-font-semibold ${colorClass}`}
+            >
+              {status}
+            </div>
+          );
+        },
+        meta: { sizeRatio: 15 },
+      },
+      {
+        accessorKey: "lastActive",
+        header: "Last Active",
+        cell: ({ row }) => (
+          <div className="s-text-sm s-text-muted-foreground">
+            {row.getValue("lastActive")}
+          </div>
+        ),
+        meta: { sizeRatio: 15 },
+      },
+    ];
+
+    // Handle infinite loading
+    const handleLoadMore = useCallback(() => {
+      if (isLoading || !hasMore) {
+        return;
+      }
+
+      setIsLoading(true);
+
+      // Simulate API call delay
+      setTimeout(() => {
+        const newUsers = generateRandomUsers(25, users.length);
+        setUsers((prev) => [...prev, ...newUsers]);
+        setIsLoading(false);
+
+        // Stop loading more after reaching 200 items for demo purposes
+        if (users.length >= 175) {
+          setHasMore(false);
+        }
+      }, 1000);
+    }, [isLoading, hasMore, users.length]);
+
+    const handleSave = () => {
+      alert("User data saved!");
+    };
+
+    const scrollableDataTablePages: MultiPageSheetPage[] = [
+      {
+        id: "users",
+        title: "User Management",
+        description: "Manage users with infinite scroll",
+        icon: UserIcon,
+        content: (
+          <div className="s-flex s-h-full s-flex-col s-space-y-4">
+            <div className="s-flex-shrink-0">
+              <h3 className="s-mb-2 s-text-lg s-font-semibold">
+                Users Database
+              </h3>
+              <p className="s-text-sm s-text-muted-foreground">
+                Browse through all users with infinite scrolling. Click on any
+                row to view details.
+              </p>
+            </div>
+            <ScrollableDataTable
+              className="s-min-h-0"
+              data={users}
+              columns={columns}
+              maxHeight={true}
+              onLoadMore={hasMore ? handleLoadMore : undefined}
+              isLoading={isLoading}
+              enableRowSelection={false}
+            />
+            <div className="s-flex-shrink-0 s-text-xs s-text-muted-foreground">
+              Showing {users.length} users{" "}
+              {hasMore ? "(loading more available)" : "(all users loaded)"}
+            </div>
+          </div>
+        ),
+      },
+    ];
+
+    return (
+      <MultiPageSheet>
+        <MultiPageSheetTrigger asChild>
+          <Button label="Open User Management" />
+        </MultiPageSheetTrigger>
+        <MultiPageSheetContent
+          pages={scrollableDataTablePages}
+          currentPageId={currentPageId}
+          onPageChange={setCurrentPageId}
+          size="xl"
+          onSave={handleSave}
         />
       </MultiPageSheet>
     );


### PR DESCRIPTION
## Description
This diff appear big, but it just merge the `<div>` around the `overflow` div the div itself.
- Make the `maxHeight` a boolean so that the `<ScrollableDataTable />` can take the full height of its relative parent.
- Add a `noScroll` option to the MultiSheetPage page props, it remove the default `ScrollArea` that mess up with the ScrollableDataTable

## Tests
- [x] Storybook
- [x] Locally

## Risk
- Low, could break `<ScrollableDataTable />`, but we don't use them a lot, and ok to revert.

## Deploy Plan
- Publish sparkle
