### PR TITLE
[front] Skip legacy file content fragments when listing attachments

### DIFF
--- a/front/lib/api/assistant/conversation/attachments.ts
+++ b/front/lib/api/assistant/conversation/attachments.ts
@@ -1,5 +1,4 @@
 import { assertNever, CONTENT_NODE_MIME_TYPES } from "@dust-tt/client";
-import assert from "assert";
 
 import {
   isConversationIncludableFileContentType,

--- a/front/lib/api/assistant/conversation/attachments.ts
+++ b/front/lib/api/assistant/conversation/attachments.ts
@@ -6,6 +6,7 @@ import {
   isQueryableContentType,
   isSearchableContentType,
 } from "@app/lib/api/assistant/conversation/content_types";
+import logger from "@app/logger/logger";
 import type {
   ContentFragmentInputWithContentNode,
   ContentFragmentType,
@@ -81,7 +82,7 @@ export function conversationAttachmentId(
 
 export function getAttachmentFromContentFragment(
   cf: ContentFragmentType
-): ConversationAttachmentType {
+): ConversationAttachmentType | null {
   if (isContentNodeContentFragment(cf)) {
     return getAttachmentFromContentNodeContentFragment(cf);
   }
@@ -133,9 +134,18 @@ export function getAttachmentFromContentNodeContentFragment(
 
 export function getAttachmentFromFileContentFragment(
   cf: FileContentFragmentType
-): FileAttachmentType {
+): FileAttachmentType | null {
   const fileId = cf.fileId;
-  assert(fileId, `File attachment must have a fileId (sId: ${cf.sId})`);
+  if (!fileId) {
+    logger.warn(
+      {
+        contentFragmentId: cf.sId,
+        contentFragmentCreatedAt: new Date(cf.created),
+      },
+      "File attachment without a fileId (unsupported legacy)."
+    );
+    return null;
+  }
 
   // Here, snippet not null is actually to detect file attachments that are prior to the JIT
   // actions, and differentiate them from the newer file attachments that do have a snippet.

--- a/front/lib/api/assistant/jit_utils.ts
+++ b/front/lib/api/assistant/jit_utils.ts
@@ -34,7 +34,10 @@ export function listAttachments(
         continue;
       }
 
-      attachments.push(getAttachmentFromContentFragment(m));
+      const attachment = getAttachmentFromContentFragment(m);
+      if (attachment) {
+        attachments.push(attachment);
+      }
     } else if (isAgentMessageType(m)) {
       const generatedFiles = m.actions.flatMap((a) => a.getGeneratedFiles());
 

--- a/front/lib/api/assistant/preprocessing.ts
+++ b/front/lib/api/assistant/preprocessing.ts
@@ -188,11 +188,18 @@ export async function renderConversationForModel(
         ],
       });
     } else if (isContentFragmentType(m)) {
-      messages.push(
-        await renderLightContentFragmentForModel(auth, m, conversation, model, {
+      const renderedContentFragment = await renderLightContentFragmentForModel(
+        auth,
+        m,
+        conversation,
+        model,
+        {
           excludeImages: Boolean(excludeImages),
-        })
+        }
       );
+      if (renderedContentFragment) {
+        messages.push(renderedContentFragment);
+      }
     } else {
       assertNever(m);
     }

--- a/front/lib/resources/content_fragment_resource.ts
+++ b/front/lib/resources/content_fragment_resource.ts
@@ -630,7 +630,7 @@ export async function renderLightContentFragmentForModel(
   }: {
     excludeImages: boolean;
   }
-): Promise<ContentFragmentMessageTypeModel> {
+): Promise<ContentFragmentMessageTypeModel | null> {
   const { contentType, sId } = message;
 
   const contentFragment = await ContentFragmentResource.fromMessageId(
@@ -655,6 +655,9 @@ export async function renderLightContentFragmentForModel(
   }
 
   const attachment = getAttachmentFromContentFragment(message);
+  if (!attachment) {
+    return null;
+  }
 
   const { fileId: fileModelId } = contentFragment;
 

--- a/front/lib/resources/content_fragment_resource.ts
+++ b/front/lib/resources/content_fragment_resource.ts
@@ -618,7 +618,7 @@ export async function getContentFragmentFromAttachmentFile(
   }
 }
 
-// Render only a tag to specifiy that a content fragment was injected at a given position except for
+// Render only a tag to specify that a content fragment was injected at a given position except for
 // images when the model support them.
 export async function renderLightContentFragmentForModel(
   auth: Authenticator,


### PR DESCRIPTION
## Description

- We have a conversation looping over and over again [here](https://cloud.temporal.io/namespaces/dust-agent-prod.gmnlm/workflows/agent-loop-workflow-45be539d72-433c737b71-lMgxxxJi8M/0198e3db-3801-7716-bb3f-3d91e22045b7/pending-activities).
- The issue was reproduced on [a conversation](https://dust.tt/w/0ec9852c2f/assistant/697c48efab) on our workspace.
- The conversation is failing on a legacy content fragment type that is of type file but has no `fileId`.
- This PR skips these attachments, which are all older than July 2024.

## Tests

## Risk

- Low.

## Deploy Plan

- Deploy front.
