### PR TITLE
[front] Avoid content flickering on navigation dialog exit

### DIFF
--- a/front/components/Confirm.tsx
+++ b/front/components/Confirm.tsx
@@ -7,23 +7,22 @@ import {
   DialogHeader,
   DialogTitle,
 } from "@dust-tt/sparkle";
-import React from "react";
+import type { ReactNode } from "react";
+import { createContext, useEffect, useRef, useState } from "react";
 
 export type ConfirmDataType = {
   title: string;
-  message: string | React.ReactNode;
+  message: string | ReactNode;
   validateLabel?: string;
   validateVariant?: "primary" | "warning";
 };
 
-export const ConfirmContext = React.createContext<
+export const ConfirmContext = createContext<
   (n: ConfirmDataType) => Promise<boolean>
 >((n) => new Promise((resolve) => resolve(!!n))); // dummy function
 
-export function ConfirmPopupArea({ children }: { children: React.ReactNode }) {
-  const [confirmData, setConfirmData] = React.useState<ConfirmDataType | null>(
-    null
-  );
+export function ConfirmPopupArea({ children }: { children: ReactNode }) {
+  const [confirmData, setConfirmData] = useState<ConfirmDataType | null>(null);
 
   const resolveConfirmRef = useRef<(result: boolean) => void>(() => undefined);
 

--- a/front/components/Confirm.tsx
+++ b/front/components/Confirm.tsx
@@ -42,14 +42,14 @@ export function ConfirmPopupArea({ children }: { children: React.ReactNode }) {
       <ConfirmDialog
         confirmData={confirmData}
         resolveConfirm={resolveConfirmRef.current}
-        closeDialogFn={() => setConfirmData(null)}
+        clearConfirmData={() => setConfirmData(null)}
       />
     </ConfirmContext.Provider>
   );
 }
 
 interface ConfirmDialogProps {
-  closeDialogFn: () => void;
+  clearConfirmData: () => void;
   confirmData: ConfirmDataType | null;
   resolveConfirm: (result: boolean) => void;
 }
@@ -57,13 +57,13 @@ interface ConfirmDialogProps {
 export function ConfirmDialog({
   confirmData,
   resolveConfirm,
-  closeDialogFn,
+  clearConfirmData,
 }: ConfirmDialogProps) {
   // To avoid content flickering, we clear out the current validation when closing animation ends
   // instead of right after clicking on one of the buttons.
   const onDialogAnimationEnd = () => {
     if (!open) {
-      closeDialogFn();
+      clearConfirmData();
     }
   };
 
@@ -73,7 +73,7 @@ export function ConfirmDialog({
       onOpenChange={(open) => {
         if (!open) {
           resolveConfirm(false);
-          closeDialogFn();
+          clearConfirmData();
         }
       }}
     >

--- a/front/components/Confirm.tsx
+++ b/front/components/Confirm.tsx
@@ -59,6 +59,14 @@ export function ConfirmDialog({
   resolveConfirm,
   closeDialogFn,
 }: ConfirmDialogProps) {
+  // To avoid content flickering, we clear out the current validation when closing animation ends
+  // instead of right after clicking on one of the buttons.
+  const onDialogAnimationEnd = () => {
+    if (!open) {
+      closeDialogFn();
+    }
+  };
+
   return (
     <Dialog
       open={confirmData != null}
@@ -69,7 +77,7 @@ export function ConfirmDialog({
         }
       }}
     >
-      <DialogContent size="md">
+      <DialogContent size="md" onAnimationEnd={onDialogAnimationEnd}>
         <DialogHeader hideButton>
           <DialogTitle>{confirmData?.title ?? ""}</DialogTitle>
         </DialogHeader>
@@ -82,18 +90,12 @@ export function ConfirmDialog({
           leftButtonProps={{
             label: "Cancel",
             variant: "outline",
-            onClick: () => {
-              resolveConfirm(false);
-              closeDialogFn();
-            },
+            onClick: () => resolveConfirm(false),
           }}
           rightButtonProps={{
             label: confirmData?.validateLabel ?? "OK",
             variant: confirmData?.validateVariant ?? "warning",
-            onClick: async () => {
-              resolveConfirm(true);
-              closeDialogFn();
-            },
+            onClick: () => resolveConfirm(true),
           }}
         />
       </DialogContent>

--- a/front/components/Confirm.tsx
+++ b/front/components/Confirm.tsx
@@ -25,9 +25,7 @@ export function ConfirmPopupArea({ children }: { children: React.ReactNode }) {
     null
   );
 
-  const resolveConfirmRef = React.useRef<(result: boolean) => void>(
-    () => undefined
-  );
+  const resolveConfirmRef = useRef<(result: boolean) => void>(() => undefined);
 
   const confirm = (confirm: ConfirmDataType) => {
     setConfirmData(confirm);
@@ -59,22 +57,28 @@ export function ConfirmDialog({
   resolveConfirm,
   clearConfirmData,
 }: ConfirmDialogProps) {
+  const [isDialogOpen, setIsDialogOpen] = useState(false);
+
+  useEffect(() => {
+    setIsDialogOpen(confirmData != null);
+  }, [confirmData]);
+
   // To avoid content flickering, we clear out the current validation when closing animation ends
   // instead of right after clicking on one of the buttons.
   const onDialogAnimationEnd = () => {
-    if (!open) {
+    if (!isDialogOpen) {
       clearConfirmData();
     }
   };
 
   return (
     <Dialog
-      open={confirmData != null}
+      open={isDialogOpen}
       onOpenChange={(open) => {
         if (!open) {
           resolveConfirm(false);
-          clearConfirmData();
         }
+        setIsDialogOpen(open);
       }}
     >
       <DialogContent size="md" onAnimationEnd={onDialogAnimationEnd}>


### PR DESCRIPTION
## Description

- This PR prevents flickering on the content of the confirmation dialog that appear when going back from a location where `useNavigationLock` was used.
- This behavior can be observed in the agent/assistant builder for instance.

Before
https://github.com/user-attachments/assets/59817881-9149-412d-a58d-2cdadc968601

After
https://github.com/user-attachments/assets/3bfc0419-2ba9-4ea7-ac21-deccd07f82a7

## Tests

- Tested locally.

## Risk

- Low.

## Deploy Plan

- Deploy front.
