### PR TITLE
Fix sparkle dropdown hit area

### DIFF
--- a/sparkle/src/components/Dropdown.tsx
+++ b/sparkle/src/components/Dropdown.tsx
@@ -370,25 +370,25 @@ const DropdownMenuItem = React.forwardRef<
     ref
   ) => {
     return (
-      <DropdownMenuPrimitive.Item
-        ref={ref}
-        className={cn(
-          menuStyleClasses.item({ variant }),
-          inset ? menuStyleClasses.inset : "",
-          className
-        )}
-        {...props}
-        asChild={asChild}
+      <LinkWrapper
+        href={href}
+        target={target}
+        rel={rel}
+        replace={replace}
+        shallow={shallow}
+        prefetch={prefetch}
       >
-        <div className="s-h-full s-w-full">
-          <LinkWrapper
-            href={href}
-            target={target}
-            rel={rel}
-            replace={replace}
-            shallow={shallow}
-            prefetch={prefetch}
-          >
+        <DropdownMenuPrimitive.Item
+          ref={ref}
+          className={cn(
+            menuStyleClasses.item({ variant }),
+            inset ? menuStyleClasses.inset : "",
+            className
+          )}
+          {...props}
+          asChild={asChild}
+        >
+          <div className="s-h-full s-w-full">
             <ItemWithLabelIconAndDescription
               label={label}
               icon={icon}
@@ -398,9 +398,9 @@ const DropdownMenuItem = React.forwardRef<
             >
               {children}
             </ItemWithLabelIconAndDescription>
-          </LinkWrapper>
-        </div>
-      </DropdownMenuPrimitive.Item>
+          </div>
+        </DropdownMenuPrimitive.Item>
+      </LinkWrapper>
     );
   }
 );


### PR DESCRIPTION
## Description

Move the linkwrapper around the item so everything is clickable


## Tests

tested with alpha deploy

## Risk

Low

## Deploy Plan

Deploy front