### PR TITLE
[GitHub] Align file size limits across connector operations

### DIFF
--- a/connectors/src/connectors/github/lib/code/file_operations.ts
+++ b/connectors/src/connectors/github/lib/code/file_operations.ts
@@ -2,6 +2,7 @@ import assert from "assert";
 import { hash as blake3 } from "blake3";
 
 import { GCSRepositoryManager } from "@connectors/connectors/github/lib/code/gcs_repository";
+import { MAX_FILE_SIZE_BYTES } from "@connectors/connectors/github/lib/code/tar_extraction";
 import {
   getRepoUrl,
   inferParentsFromGcsPath,
@@ -18,8 +19,9 @@ import { ConnectorResource } from "@connectors/resources/connector_resource";
 import type { DataSourceConfig, ModelId } from "@connectors/types";
 import { INTERNAL_MIME_TYPES } from "@connectors/types";
 
-// Only allow documents up to 2mb to be processed.
-const MAX_DOCUMENT_TXT_LEN = 2 * 1000 * 1000; // 5MB
+// Use for max text length the file size bytes we allow to be
+// downloaded.
+const MAX_DOCUMENT_TXT_LEN = MAX_FILE_SIZE_BYTES;
 
 export async function formatCodeContentForUpsert(
   dataSourceConfig: DataSourceConfig,

--- a/connectors/src/connectors/github/lib/code/tar_extraction.ts
+++ b/connectors/src/connectors/github/lib/code/tar_extraction.ts
@@ -21,7 +21,7 @@ import {
 import { ExternalOAuthTokenError } from "@connectors/lib/error";
 import type { Logger } from "@connectors/logger/logger";
 
-const MAX_FILE_SIZE_BYTES = 3 * 1024 * 1024; // 3MB
+export const MAX_FILE_SIZE_BYTES = 3 * 1024 * 1024;
 const MAX_CONCURRENT_GCS_UPLOADS = 200;
 
 interface TarExtractionOptions {


### PR DESCRIPTION
## Description
Fixes https://github.com/dust-tt/tasks/issues/3835

Aligned the file size limits between tar extraction and file operations in the GitHub connector by exporting `MAX_FILE_SIZE_BYTES` from `tar_extraction.ts` and using it in `file_operations.ts`.

## Risk
Blast radius: GitHub connector file processing
Risk: low

## Deploy Plan
- Deploy connectors service