### PR TITLE
[front] - chore(AB v2): move editors to access section

### DIFF
--- a/front/components/agent_builder/AgentBuilderLeftPanel.tsx
+++ b/front/components/agent_builder/AgentBuilderLeftPanel.tsx
@@ -1,12 +1,12 @@
 import type { ButtonProps } from "@dust-tt/sparkle";
 import { BarFooter, BarHeader, Button, ScrollArea } from "@dust-tt/sparkle";
+import { XMarkIcon } from "@dust-tt/sparkle";
 import React from "react";
 
 import { useAgentBuilderContext } from "@app/components/agent_builder/AgentBuilderContext";
 import { AgentBuilderCapabilitiesBlock } from "@app/components/agent_builder/capabilities/AgentBuilderCapabilitiesBlock";
 import { AgentBuilderInstructionsBlock } from "@app/components/agent_builder/instructions/AgentBuilderInstructionsBlock";
 import { AgentBuilderSettingsBlock } from "@app/components/agent_builder/settings/AgentBuilderSettingsBlock";
-import { EditorsSheet } from "@app/components/agent_builder/settings/EditorsSheet";
 import { AgentBuilderTriggersBlock } from "@app/components/agent_builder/triggers/AgentBuilderTriggersBlock";
 import { useFeatureFlags } from "@app/lib/swr/workspaces";
 
@@ -39,7 +39,9 @@ export function AgentBuilderLeftPanel({
         variant="default"
         className="mx-4"
         title={title}
-        rightActions={<EditorsSheet />}
+        rightActions={
+          <Button icon={XMarkIcon} onClick={handleCancel} variant="ghost" />
+        }
       />
       <ScrollArea className="flex-1">
         <div className="mx-auto space-y-10 p-4 2xl:max-w-4xl">
@@ -64,7 +66,7 @@ export function AgentBuilderLeftPanel({
         leftActions={
           <Button
             variant="outline"
-            label="Close"
+            label="Cancel"
             onClick={handleCancel}
             type="button"
           />

--- a/front/components/agent_builder/settings/AccessSection.tsx
+++ b/front/components/agent_builder/settings/AccessSection.tsx
@@ -30,7 +30,7 @@ export function AccessSection() {
   };
 
   return (
-    <SettingSectionContainer title="Editors & Access">
+    <SettingSectionContainer title="Access">
       <div className="mt-2 flex items-center gap-2">
         <EditorsSheet />
         <DropdownMenu>

--- a/front/components/agent_builder/settings/AccessSection.tsx
+++ b/front/components/agent_builder/settings/AccessSection.tsx
@@ -12,9 +12,9 @@ import { useState } from "react";
 import { useController } from "react-hook-form";
 
 import type { AgentBuilderFormData } from "@app/components/agent_builder/AgentBuilderFormContext";
+import { EditorsSheet } from "@app/components/agent_builder/settings/EditorsSheet";
 import { SlackSettingsSheet } from "@app/components/agent_builder/settings/SlackSettingsSheet";
 import { SettingSectionContainer } from "@app/components/agent_builder/shared/SettingSectionContainer";
-import { EditorsSheet } from "@app/components/agent_builder/settings/EditorsSheet";
 
 export function AccessSection() {
   const { field } = useController<AgentBuilderFormData, "agentSettings.scope">({

--- a/front/components/agent_builder/settings/AccessSection.tsx
+++ b/front/components/agent_builder/settings/AccessSection.tsx
@@ -14,8 +14,9 @@ import { useController } from "react-hook-form";
 import type { AgentBuilderFormData } from "@app/components/agent_builder/AgentBuilderFormContext";
 import { SlackSettingsSheet } from "@app/components/agent_builder/settings/SlackSettingsSheet";
 import { SettingSectionContainer } from "@app/components/agent_builder/shared/SettingSectionContainer";
+import { EditorsSheet } from "@app/components/agent_builder/settings/EditorsSheet";
 
-export function VisibilitySection() {
+export function AccessSection() {
   const { field } = useController<AgentBuilderFormData, "agentSettings.scope">({
     name: "agentSettings.scope",
   });
@@ -29,8 +30,9 @@ export function VisibilitySection() {
   };
 
   return (
-    <SettingSectionContainer title="Visibility">
+    <SettingSectionContainer title="Editors & Access">
       <div className="mt-2 flex items-center gap-2">
+        <EditorsSheet />
         <DropdownMenu>
           <DropdownMenuTrigger asChild>
             <Button

--- a/front/components/agent_builder/settings/AgentBuilderSettingsBlock.tsx
+++ b/front/components/agent_builder/settings/AgentBuilderSettingsBlock.tsx
@@ -16,6 +16,7 @@ import { useController, useWatch } from "react-hook-form";
 import { useAgentBuilderContext } from "@app/components/agent_builder/AgentBuilderContext";
 import type { AgentBuilderFormData } from "@app/components/agent_builder/AgentBuilderFormContext";
 import { AgentBuilderSectionContainer } from "@app/components/agent_builder/AgentBuilderSectionContainer";
+import { AccessSection } from "@app/components/agent_builder/settings/AccessSection";
 import { AvatarPicker } from "@app/components/agent_builder/settings/avatar_picker/AgentBuilderAvatarPicker";
 import {
   DROID_AVATAR_URLS,
@@ -27,7 +28,6 @@ import {
   getDescriptionSuggestion,
   getNameSuggestions,
 } from "@app/components/agent_builder/settings/utils";
-import { AccessSection } from "@app/components/agent_builder/settings/AccessSection";
 import { SettingSectionContainer } from "@app/components/agent_builder/shared/SettingSectionContainer";
 import {
   buildSelectedEmojiType,

--- a/front/components/agent_builder/settings/AgentBuilderSettingsBlock.tsx
+++ b/front/components/agent_builder/settings/AgentBuilderSettingsBlock.tsx
@@ -27,7 +27,7 @@ import {
   getDescriptionSuggestion,
   getNameSuggestions,
 } from "@app/components/agent_builder/settings/utils";
-import { VisibilitySection } from "@app/components/agent_builder/settings/VisibilitySection";
+import { AccessSection } from "@app/components/agent_builder/settings/AccessSection";
 import { SettingSectionContainer } from "@app/components/agent_builder/shared/SettingSectionContainer";
 import {
   buildSelectedEmojiType,
@@ -392,7 +392,7 @@ export function AgentBuilderSettingsBlock({
           <AgentPictureInput />
         </div>
         <AgentDescriptionInput />
-        <VisibilitySection />
+        <AccessSection />
         <TagsSection />
       </div>
     </AgentBuilderSectionContainer>


### PR DESCRIPTION
## Description

This PR moves the "Editors" button to the access section and replaces it by a `XMarkIcon` to close the builder.

<img width="1332" height="995" alt="Screenshot 2025-08-26 at 13 39 50" src="https://github.com/user-attachments/assets/ae3a9363-ab4f-4c0b-b0c5-5e6c3333f3bd" />


## Tests

Locally

## Risk

Low

## Deploy Plan

Deploy front