### PR TITLE
[workOS] increase the limit for org list 

### DIFF
--- a/front/lib/api/workos/organization_membership.ts
+++ b/front/lib/api/workos/organization_membership.ts
@@ -7,25 +7,13 @@ const MAX_CONCURRENT_WORKOS_FETCH = 10;
 // Cache TTL for WorkOS organization memnbership data (1 hour)
 const WORKOS_ORG_CACHE_TTL_MS = 60 * 60 * 1000;
 
-export async function fetchWorkOSOrganizationMembershipsForUserIdAndOrgId(
-  userId: string,
-  organizationId: string
-) {
-  const response = await getWorkOS().userManagement.listOrganizationMemberships(
-    {
-      userId,
-      organizationId,
-    }
-  );
-
-  return response.data;
-}
 
 async function findWorkOSOrganizationsForUserIdUncached(userId: string) {
   const response = await getWorkOS().userManagement.listOrganizationMemberships(
     {
       userId,
       statuses: ["active"],
+      limit: 50, // by default it returns 10 so we need to increase the limit 
     }
   );
 

--- a/front/lib/api/workos/organization_membership.ts
+++ b/front/lib/api/workos/organization_membership.ts
@@ -13,7 +13,7 @@ async function findWorkOSOrganizationsForUserIdUncached(userId: string) {
     {
       userId,
       statuses: ["active"],
-      limit: 50, // by default it returns 10 so we need to increase the limit 
+      limit: 50, // By default it returns 10 so we need to increase the limit.
     }
   );
 

--- a/front/lib/api/workos/organization_membership.ts
+++ b/front/lib/api/workos/organization_membership.ts
@@ -7,7 +7,6 @@ const MAX_CONCURRENT_WORKOS_FETCH = 10;
 // Cache TTL for WorkOS organization memnbership data (1 hour)
 const WORKOS_ORG_CACHE_TTL_MS = 60 * 60 * 1000;
 
-
 async function findWorkOSOrganizationsForUserIdUncached(userId: string) {
   const response = await getWorkOS().userManagement.listOrganizationMemberships(
     {


### PR DESCRIPTION
## Description
This PR is to fix [this issue](https://github.com/dust-tt/tasks/issues/3912), by default workOS /organizations endpoint returns 10 organizations max, so we need to bump to show more in case you have many workspaces like Alban :D  

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
