### PR TITLE
[front] fix(ab/knowledge): Fix scroll for ScrollableDataTable

### DIFF
--- a/extension/package-lock.json
+++ b/extension/package-lock.json
@@ -12,7 +12,7 @@
         "@auth0/auth0-spa-js": "^2.1.3",
         "@datadog/browser-logs": "^6.13.0",
         "@dust-tt/client": "^1.1.6",
-        "@dust-tt/sparkle": "^0.2.591",
+        "@dust-tt/sparkle": "^0.2.592",
         "@frontapp/plugin-sdk": "^1.8.1",
         "@modelcontextprotocol/sdk": "^1.9.0",
         "@tailwindcss/forms": "^0.5.9",
@@ -1293,9 +1293,9 @@
       }
     },
     "node_modules/@dust-tt/sparkle": {
-      "version": "0.2.591",
-      "resolved": "https://registry.npmjs.org/@dust-tt/sparkle/-/sparkle-0.2.591.tgz",
-      "integrity": "sha512-2Q2+xv2aJUl6yJueNGvV9Ui+KwLdPju1zNEL/9mnWu1YJ7rEqGB9LVnH3no2Pqcj/BSlUIlhcZd2TOYy1wiqcw==",
+      "version": "0.2.592",
+      "resolved": "https://registry.npmjs.org/@dust-tt/sparkle/-/sparkle-0.2.592.tgz",
+      "integrity": "sha512-VNZg3YfEm0SINJ0Cn5Yr1wwsMBp/4AWXnmYKkZwa9zvk9IAIp7X5geADWvFwXEhSyCouoD010WjhH4NagQqR8w==",
       "license": "ISC",
       "dependencies": {
         "@emoji-mart/data": "^1.1.2",

--- a/extension/package.json
+++ b/extension/package.json
@@ -59,7 +59,7 @@
     "@auth0/auth0-spa-js": "^2.1.3",
     "@datadog/browser-logs": "^6.13.0",
     "@dust-tt/client": "^1.1.6",
-    "@dust-tt/sparkle": "^0.2.591",
+    "@dust-tt/sparkle": "^0.2.592",
     "@frontapp/plugin-sdk": "^1.8.1",
     "@modelcontextprotocol/sdk": "^1.9.0",
     "@tailwindcss/forms": "^0.5.9",

--- a/front/components/agent_builder/capabilities/knowledge/DataSourceBuilderSelector.tsx
+++ b/front/components/agent_builder/capabilities/knowledge/DataSourceBuilderSelector.tsx
@@ -152,17 +152,12 @@ export const DataSourceBuilderSelector = ({
             value={searchTerm}
             onChange={setSearchTerm}
           />
-          {isSearching && currentSpace && (
-            <div className="text-sm text-muted-foreground dark:text-muted-foreground-night">
-              Searching in{" "}
-              <span className="font-medium">{currentSpace.name}</span>
-            </div>
-          )}
         </div>
       )}
 
       {showSearch ? (
         <DataSourceSearchResults
+          currentSpace={currentSpace}
           searchResultNodes={searchResultNodes}
           isLoading={isLoading}
           onClearSearch={() => setSearchTerm("")}

--- a/front/components/agent_builder/capabilities/knowledge/DataSourceBuilderSelector.tsx
+++ b/front/components/agent_builder/capabilities/knowledge/DataSourceBuilderSelector.tsx
@@ -1,5 +1,5 @@
 import type { BreadcrumbItem } from "@dust-tt/sparkle";
-import { Breadcrumbs, cn, SearchInput } from "@dust-tt/sparkle";
+import { Breadcrumbs, SearchInput } from "@dust-tt/sparkle";
 import { useEffect, useMemo, useState } from "react";
 
 import { DataSourceNavigationView } from "@app/components/agent_builder/capabilities/knowledge/DataSourceNavigationView";
@@ -93,16 +93,13 @@ export const DataSourceBuilderSelector = ({
   const hasError = isSearchError;
 
   const shouldShowSearch = isSearching && currentSpace;
-  const [isChanging, setIsChanging] = useState(false);
   const [showSearch, setShowSearch] = useState(shouldShowSearch);
 
   // Handle transition when search state changes
   useEffect(() => {
     if (shouldShowSearch !== showSearch) {
-      setIsChanging(true);
       const timer = setTimeout(() => {
         setShowSearch(shouldShowSearch);
-        setTimeout(() => setIsChanging(false), 50);
       }, 150);
 
       return () => clearTimeout(timer);
@@ -139,7 +136,7 @@ export const DataSourceBuilderSelector = ({
   }
 
   return (
-    <div className="flex flex-col gap-4">
+    <div className="relative flex h-full flex-1 flex-col gap-4">
       {breadcrumbItems.length > 0 && <Breadcrumbs items={breadcrumbItems} />}
 
       {currentNavigationEntry.type === "root" ? (
@@ -156,7 +153,7 @@ export const DataSourceBuilderSelector = ({
             onChange={setSearchTerm}
           />
           {isSearching && currentSpace && (
-            <div className="text-sm text-muted-foreground">
+            <div className="text-sm text-muted-foreground dark:text-muted-foreground-night">
               Searching in{" "}
               <span className="font-medium">{currentSpace.name}</span>
             </div>
@@ -164,23 +161,16 @@ export const DataSourceBuilderSelector = ({
         </div>
       )}
 
-      <div
-        className={cn(
-          "transition-opacity duration-150",
-          isChanging && "opacity-0"
-        )}
-      >
-        {showSearch ? (
-          <DataSourceSearchResults
-            searchResultNodes={searchResultNodes}
-            isLoading={isLoading}
-            onClearSearch={() => setSearchTerm("")}
-            error={hasError ? new Error("Search failed") : null}
-          />
-        ) : (
-          <DataSourceNavigationView viewType={viewType} />
-        )}
-      </div>
+      {showSearch ? (
+        <DataSourceSearchResults
+          searchResultNodes={searchResultNodes}
+          isLoading={isLoading}
+          onClearSearch={() => setSearchTerm("")}
+          error={hasError ? new Error("Search failed") : null}
+        />
+      ) : (
+        <DataSourceNavigationView viewType={viewType} />
+      )}
     </div>
   );
 };

--- a/front/components/agent_builder/capabilities/knowledge/DataSourceCategoryBrowser.tsx
+++ b/front/components/agent_builder/capabilities/knowledge/DataSourceCategoryBrowser.tsx
@@ -134,6 +134,7 @@ export function DataSourceCategoryBrowser({
       data={categoryRows}
       columns={columns}
       getRowId={(originalRow) => originalRow.id}
+      maxHeight
     />
   );
 }

--- a/front/components/agent_builder/capabilities/knowledge/DataSourceNodeTable.tsx
+++ b/front/components/agent_builder/capabilities/knowledge/DataSourceNodeTable.tsx
@@ -86,6 +86,7 @@ export function DataSourceNodeTable({ viewType }: DataSourceNodeTableProps) {
       getRowId={(row) => row.id}
       onLoadMore={handleLoadMore}
       isLoading={isLoadingMore}
+      maxHeight
     />
   );
 }

--- a/front/components/agent_builder/capabilities/knowledge/DataSourceSearchResults.tsx
+++ b/front/components/agent_builder/capabilities/knowledge/DataSourceSearchResults.tsx
@@ -26,10 +26,11 @@ import {
   getVisualForDataSourceViewContentNode,
 } from "@app/lib/content_nodes";
 import { formatTimestampToFriendlyDate } from "@app/lib/utils";
-import type { DataSourceViewContentNode } from "@app/types";
+import type { DataSourceViewContentNode, SpaceType } from "@app/types";
 import { isDataSourceViewCategoryWithoutApps } from "@app/types";
 
 interface DataSourceSearchResultsProps {
+  currentSpace: SpaceType | null;
   searchResultNodes: DataSourceContentNode[];
   isLoading: boolean;
   onClearSearch: () => void;
@@ -145,6 +146,7 @@ function makeSearchResultColumnsWithSelection(
 }
 
 export function DataSourceSearchResults({
+  currentSpace,
   searchResultNodes,
   isLoading,
   onClearSearch,
@@ -369,17 +371,27 @@ export function DataSourceSearchResults({
   }
 
   return (
-    <div className="flex w-full flex-col gap-2">
+    <>
       {error ? (
         <div className="text-end text-sm text-muted-foreground">
           Error searching results.
         </div>
       ) : (
         <>
-          <div className="text-end text-sm text-muted-foreground">
-            {isLoading
-              ? "Searching..."
-              : `${searchResults.length} results found`}
+          <div className="flex flex-row items-center justify-between text-end text-sm text-muted-foreground dark:text-muted-foreground-night">
+            <div>
+              {currentSpace !== null && (
+                <>
+                  Searching in{" "}
+                  <span className="font-medium">{currentSpace.name}</span>
+                </>
+              )}
+            </div>
+            <div>
+              {isLoading
+                ? "Searching..."
+                : `${searchResults.length} results found`}
+            </div>
           </div>
           <ScrollableDataTable
             data={searchTableRows}
@@ -389,10 +401,10 @@ export function DataSourceSearchResults({
               isLoading && "pointer-events-none opacity-50"
             )}
             totalRowCount={searchResults.length}
-            maxHeight="h-[600px]"
+            maxHeight
           />
         </>
       )}
-    </div>
+    </>
   );
 }

--- a/front/components/agent_builder/capabilities/knowledge/DataSourceSpaceSelector.tsx
+++ b/front/components/agent_builder/capabilities/knowledge/DataSourceSpaceSelector.tsx
@@ -149,6 +149,7 @@ export function DataSourceSpaceSelector({
       data={spaceRows}
       columns={columns}
       getRowId={(originalRow) => originalRow.id}
+      maxHeight
     />
   );
 }

--- a/front/components/agent_builder/capabilities/knowledge/DataSourceViewTable.tsx
+++ b/front/components/agent_builder/capabilities/knowledge/DataSourceViewTable.tsx
@@ -92,6 +92,7 @@ export function DataSourceViewTable({
       data={rows}
       columns={columns}
       getRowId={(row) => row.id}
+      maxHeight
     />
   );
 }

--- a/front/components/agent_builder/capabilities/knowledge/KnowledgeConfigurationSheet.tsx
+++ b/front/components/agent_builder/capabilities/knowledge/KnowledgeConfigurationSheet.tsx
@@ -323,15 +323,14 @@ function KnowledgeConfigurationSheetContent({
         ? "Choose the tables to query for your processing method"
         : "Choose the data sources to include in your knowledge base",
       icon: undefined,
+      noScroll: true,
       content: (
-        <div className="h-full">
-          <DataSourceBuilderSelector
-            dataSourceViews={supportedDataSourceViews}
-            owner={owner}
-            viewType="all"
-            allowedSpaces={allowedSpaces}
-          />
-        </div>
+        <DataSourceBuilderSelector
+          dataSourceViews={supportedDataSourceViews}
+          owner={owner}
+          viewType="all"
+          allowedSpaces={allowedSpaces}
+        />
       ),
       footerContent: hasSourceSelection ? <KnowledgeFooter /> : undefined,
     },

--- a/front/package-lock.json
+++ b/front/package-lock.json
@@ -7,7 +7,7 @@
       "dependencies": {
         "@datadog/browser-logs": "^6.13.0",
         "@dust-tt/client": "file:../sdks/js",
-        "@dust-tt/sparkle": "^0.2.591",
+        "@dust-tt/sparkle": "^0.2.592",
         "@google-cloud/bigquery": "^7.9.1",
         "@google-cloud/storage-transfer": "^3.6.0",
         "@heroicons/react": "^2.0.11",
@@ -1114,9 +1114,9 @@
       "link": true
     },
     "node_modules/@dust-tt/sparkle": {
-      "version": "0.2.591",
-      "resolved": "https://registry.npmjs.org/@dust-tt/sparkle/-/sparkle-0.2.591.tgz",
-      "integrity": "sha512-2Q2+xv2aJUl6yJueNGvV9Ui+KwLdPju1zNEL/9mnWu1YJ7rEqGB9LVnH3no2Pqcj/BSlUIlhcZd2TOYy1wiqcw==",
+      "version": "0.2.592",
+      "resolved": "https://registry.npmjs.org/@dust-tt/sparkle/-/sparkle-0.2.592.tgz",
+      "integrity": "sha512-VNZg3YfEm0SINJ0Cn5Yr1wwsMBp/4AWXnmYKkZwa9zvk9IAIp7X5geADWvFwXEhSyCouoD010WjhH4NagQqR8w==",
       "license": "ISC",
       "dependencies": {
         "@emoji-mart/data": "^1.1.2",

--- a/front/package.json
+++ b/front/package.json
@@ -25,7 +25,7 @@
   "dependencies": {
     "@datadog/browser-logs": "^6.13.0",
     "@dust-tt/client": "file:../sdks/js",
-    "@dust-tt/sparkle": "^0.2.591",
+    "@dust-tt/sparkle": "^0.2.592",
     "@google-cloud/bigquery": "^7.9.1",
     "@google-cloud/storage-transfer": "^3.6.0",
     "@heroicons/react": "^2.0.11",


### PR DESCRIPTION
## Description
- Bump `@dust-tt/sparkle`
- Use new `maxHeight: boolean` feature and use it in all `ScrollableDataTable` in ABv2 knowledge
- Remove the animation between search and datatable inside knowledge, it was breaking the infinite scroll due to the extra div
- Move the `Search in [space]` to make it on the same line as the result number.

## Tests
- Locally

## Risk
- Low, most `ScrollableDataTable` are being a FF

## Deploy Plan
- Deploy front
