### PR TITLE
[CLI] Handle agent_generation_cancelled event

### DIFF
--- a/cli/package-lock.json
+++ b/cli/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.3.0",
       "license": "MIT",
       "dependencies": {
-        "@dust-tt/client": "^1.1.2",
+        "@dust-tt/client": "^1.1.9",
         "@modelcontextprotocol/sdk": "^1.9.0",
         "clipboardy": "^4.0.0",
         "execa": "^9.6.0",
@@ -85,14 +85,14 @@
       }
     },
     "node_modules/@dust-tt/client": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@dust-tt/client/-/client-1.1.2.tgz",
-      "integrity": "sha512-tyg/o9qHpnGZ046AOgzASMRweXcJGyGICGX655ArestfAdiMXvLt2kJRqIkWC4CESm5EKxCphUf+Kj8sJs+gMQ==",
+      "version": "1.1.9",
+      "resolved": "https://registry.npmjs.org/@dust-tt/client/-/client-1.1.9.tgz",
+      "integrity": "sha512-kalO0cnMnaWrtQ2RfJZ7s8p4B6kOQ0G7Zi/7ldxJDf5UJi0LFYXEynt+SvT2Q/JlwUgFL1K/f+g324UtoIEh3g==",
       "bundleDependencies": [
         "@modelcontextprotocol/sdk"
       ],
       "dependencies": {
-        "@modelcontextprotocol/sdk": "git://github.com/dust-tt/typescript-sdk.git#bca26e405d6db2cf71fd7211234a72ecc46d0215",
+        "@modelcontextprotocol/sdk": "git://github.com/dust-tt/typescript-sdk.git#628ebe48388549faae7e35504611af9ac2c6f5e4",
         "@types/json-schema": "^7.0.15",
         "event-source-polyfill": "^1.0.31",
         "eventsource-parser": "^1.1.1",
@@ -104,7 +104,7 @@
       }
     },
     "node_modules/@dust-tt/client/node_modules/@modelcontextprotocol/sdk": {
-      "version": "1.12.1",
+      "version": "1.17.1",
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -113,6 +113,7 @@
         "cors": "^2.8.5",
         "cross-spawn": "^7.0.5",
         "eventsource": "^3.0.2",
+        "eventsource-parser": "^3.0.0",
         "express": "^5.0.1",
         "express-rate-limit": "^7.5.0",
         "pkce-challenge": "^5.0.0",
@@ -122,6 +123,14 @@
       },
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/@dust-tt/client/node_modules/@modelcontextprotocol/sdk/node_modules/eventsource-parser": {
+      "version": "3.0.3",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.0.0"
       }
     },
     "node_modules/@dust-tt/client/node_modules/accepts": {

--- a/cli/package.json
+++ b/cli/package.json
@@ -27,7 +27,7 @@
   "author": "Dust",
   "license": "MIT",
   "dependencies": {
-    "@dust-tt/client": "^1.1.2",
+    "@dust-tt/client": "^1.1.9",
     "@modelcontextprotocol/sdk": "^1.9.0",
     "clipboardy": "^4.0.0",
     "execa": "^9.6.0",

--- a/cli/src/ui/commands/Chat.tsx
+++ b/cli/src/ui/commands/Chat.tsx
@@ -703,6 +703,18 @@ const CliChat: FC<CliChatProps> = ({
             throw new Error(`Agent error: ${event.error.message}`);
           } else if (event.type === "user_message_error") {
             throw new Error(`User message error: ${event.error.message}`);
+          } else if (event.type === "agent_generation_cancelled") {
+            // Handle generation cancellation
+            if (updateIntervalRef.current) {
+              clearInterval(updateIntervalRef.current);
+            }
+            setError(null);
+            pushFullLinesToConversationItems(false);
+            chainOfThoughtRef.current = "";
+            contentRef.current = contentRef.current || "[Cancelled]";
+            pushFullLinesToConversationItems(false);
+            contentRef.current = "";
+            break;
           } else if (event.type === "agent_message_success") {
             if (updateIntervalRef.current) {
               clearInterval(updateIntervalRef.current);

--- a/cli/src/ui/commands/chat/nonInteractive.ts
+++ b/cli/src/ui/commands/chat/nonInteractive.ts
@@ -28,6 +28,7 @@ interface NonInteractiveOutput {
   messageId: string;
   events?: EventDetail[];
   agentMessage?: unknown;
+  cancelled?: boolean;
 }
 
 export async function sendNonInteractiveMessage(
@@ -191,6 +192,23 @@ export async function sendNonInteractiveMessage(
           return;
         }
         process.exit(1);
+      } else if (event.type === "agent_generation_cancelled") {
+        // Handle generation cancellation
+        const output: NonInteractiveOutput = {
+          agentId: selectedAgent.sId,
+          agentAnswer: fullResponse.trim() || "[Message generation was cancelled]",
+          conversationId: conversation.sId,
+          messageId: event.messageId,
+          cancelled: true,
+        };
+
+        // Add detailed event history if requested
+        if (showDetails) {
+          output.events = eventDetails;
+        }
+
+        // Exit with special code to indicate cancellation
+        process.exit(2);
       } else if (event.type === "agent_message_success") {
         // Success - output the result
         const output: NonInteractiveOutput = {


### PR DESCRIPTION
## Description
Part 2 of fix for https://github.com/dust-tt/tasks/issues/3896
Context: https://dust4ai.slack.com/archives/C05F84CFP0E/p1756116822064819?thread_ts=1756116822.064819&cid=C05F84CFP0E

Updates CLI to properly handle the `agent_generation_cancelled` event after SDK support is added.

**Depends on PR #15387 (SDK + Connectors changes) - merge and publish SDK v1.1.9 first**

### Changes:
**CLI** (`cli/src/ui/commands/`):
- Interactive mode: Shows "[Cancelled]" and properly cleans up state  
- Non-interactive mode: Exits with code 2 and includes `cancelled` flag in output
- Update SDK dependency to v1.1.9

## Risks
Blast radius: CLI tool only
Risk: low

## Tests
- CLI will build successfully once SDK v1.1.9 is published

## Deploy Plan
1. Merge and deploy PR #15387 (SDK + Connectors)
2. Publish SDK v1.1.9 to npm
3. Then merge 

Note: not publishing changes yet--not major, and other CLI PRs will come