### PR TITLE
[front] - deps: update @dust-tt/sparkle package to version 0.2.593

### DIFF
--- a/extension/package-lock.json
+++ b/extension/package-lock.json
@@ -12,7 +12,7 @@
         "@auth0/auth0-spa-js": "^2.1.3",
         "@datadog/browser-logs": "^6.13.0",
         "@dust-tt/client": "^1.1.6",
-        "@dust-tt/sparkle": "^0.2.592",
+        "@dust-tt/sparkle": "^0.2.593",
         "@frontapp/plugin-sdk": "^1.8.1",
         "@modelcontextprotocol/sdk": "^1.9.0",
         "@tailwindcss/forms": "^0.5.9",
@@ -1293,10 +1293,9 @@
       }
     },
     "node_modules/@dust-tt/sparkle": {
-      "version": "0.2.592",
-      "resolved": "https://registry.npmjs.org/@dust-tt/sparkle/-/sparkle-0.2.592.tgz",
-      "integrity": "sha512-VNZg3YfEm0SINJ0Cn5Yr1wwsMBp/4AWXnmYKkZwa9zvk9IAIp7X5geADWvFwXEhSyCouoD010WjhH4NagQqR8w==",
-      "license": "ISC",
+      "version": "0.2.593",
+      "resolved": "https://registry.npmjs.org/@dust-tt/sparkle/-/sparkle-0.2.593.tgz",
+      "integrity": "sha512-YEzfbImvaiL+KCKgfGSZnK58B3cp77x2mvD0kXYBM2/bPOMh+2yGj74MqChg907JIaAUdsqTpQsJcTjBlbB3dw==",
       "dependencies": {
         "@emoji-mart/data": "^1.1.2",
         "@emoji-mart/react": "^1.1.1",

--- a/extension/package.json
+++ b/extension/package.json
@@ -59,7 +59,7 @@
     "@auth0/auth0-spa-js": "^2.1.3",
     "@datadog/browser-logs": "^6.13.0",
     "@dust-tt/client": "^1.1.6",
-    "@dust-tt/sparkle": "^0.2.592",
+    "@dust-tt/sparkle": "^0.2.593",
     "@frontapp/plugin-sdk": "^1.8.1",
     "@modelcontextprotocol/sdk": "^1.9.0",
     "@tailwindcss/forms": "^0.5.9",

--- a/front/package-lock.json
+++ b/front/package-lock.json
@@ -7,7 +7,7 @@
       "dependencies": {
         "@datadog/browser-logs": "^6.13.0",
         "@dust-tt/client": "file:../sdks/js",
-        "@dust-tt/sparkle": "^0.2.592",
+        "@dust-tt/sparkle": "^0.2.593",
         "@google-cloud/bigquery": "^7.9.1",
         "@google-cloud/storage-transfer": "^3.6.0",
         "@heroicons/react": "^2.0.11",
@@ -1122,10 +1122,9 @@
       "link": true
     },
     "node_modules/@dust-tt/sparkle": {
-      "version": "0.2.592",
-      "resolved": "https://registry.npmjs.org/@dust-tt/sparkle/-/sparkle-0.2.592.tgz",
-      "integrity": "sha512-VNZg3YfEm0SINJ0Cn5Yr1wwsMBp/4AWXnmYKkZwa9zvk9IAIp7X5geADWvFwXEhSyCouoD010WjhH4NagQqR8w==",
-      "license": "ISC",
+      "version": "0.2.593",
+      "resolved": "https://registry.npmjs.org/@dust-tt/sparkle/-/sparkle-0.2.593.tgz",
+      "integrity": "sha512-YEzfbImvaiL+KCKgfGSZnK58B3cp77x2mvD0kXYBM2/bPOMh+2yGj74MqChg907JIaAUdsqTpQsJcTjBlbB3dw==",
       "dependencies": {
         "@emoji-mart/data": "^1.1.2",
         "@emoji-mart/react": "^1.1.1",

--- a/front/package.json
+++ b/front/package.json
@@ -26,7 +26,7 @@
   "dependencies": {
     "@datadog/browser-logs": "^6.13.0",
     "@dust-tt/client": "file:../sdks/js",
-    "@dust-tt/sparkle": "^0.2.592",
+    "@dust-tt/sparkle": "^0.2.593",
     "@google-cloud/bigquery": "^7.9.1",
     "@google-cloud/storage-transfer": "^3.6.0",
     "@heroicons/react": "^2.0.11",


### PR DESCRIPTION
## Description

This PR ships the changes from https://github.com/dust-tt/dust/pull/15377

## Tests

Locally

## Risk

Low

## Deploy Plan

Deploy front