### PR TITLE
[front] Change signature of `createPersonalConnection`

### DIFF
--- a/front/components/actions/mcp/ConnectMCPServerDialog.tsx
+++ b/front/components/actions/mcp/ConnectMCPServerDialog.tsx
@@ -11,6 +11,7 @@ import { useCallback, useEffect, useMemo, useState } from "react";
 import { MCPServerOAuthConnexion } from "@app/components/actions/mcp/MCPServerOAuthConnexion";
 import { useSendNotification } from "@app/hooks/useNotification";
 import {
+  getMcpServerDisplayName,
   getMcpServerViewDisplayName,
   getServerTypeAndIdFromSId,
   isRemoteMCPServerType,
@@ -169,7 +170,8 @@ export function ConnectMCPServerDialog({
     // Then associate connection.
     await createMCPServerConnection({
       connectionId: cRes.value.connection_id,
-      mcpServer: mcpServerView.server,
+      mcpServerId: mcpServerView.server.sId,
+      mcpServerDisplayName: getMcpServerDisplayName(mcpServerView.server),
       provider: authorization.provider,
     });
 

--- a/front/components/agent_builder/PersonalConnectionRequiredDialog.tsx
+++ b/front/components/agent_builder/PersonalConnectionRequiredDialog.tsx
@@ -175,7 +175,9 @@ export function PersonalConnectionRequiredDialog({
                             }
                             setIsConnecting(true);
                             await createPersonalConnection({
-                              mcpServer: mcpServerView.server,
+                              mcpServerId: mcpServerView.server.sId,
+                              mcpServerDisplayName:
+                                getMcpServerViewDisplayName(mcpServerView),
                               provider:
                                 mcpServerView.server.authorization.provider,
                               useCase: "personal_actions",

--- a/front/components/assistant/conversation/MCPServerPersonalAuthenticationRequired.tsx
+++ b/front/components/assistant/conversation/MCPServerPersonalAuthenticationRequired.tsx
@@ -6,6 +6,7 @@ import {
 } from "@dust-tt/sparkle";
 import { useState } from "react";
 
+import { getMcpServerDisplayName } from "@app/lib/actions/mcp_helper";
 import { useSubmitFunction } from "@app/lib/client/utils";
 import {
   useCreatePersonalConnection,
@@ -66,7 +67,8 @@ export function MCPServerPersonalAuthenticationRequired({
             onClick={async () => {
               setIsConnecting(true);
               const success = await createPersonalConnection({
-                mcpServer,
+                mcpServerId: mcpServer.sId,
+                mcpServerDisplayName: getMcpServerDisplayName(mcpServer),
                 provider,
                 useCase: "personal_actions",
                 scope,

--- a/front/lib/swr/mcp_servers.ts
+++ b/front/lib/swr/mcp_servers.ts
@@ -617,11 +617,13 @@ export function useCreateMCPServerConnection({
   const sendNotification = useSendNotification();
   const createMCPServerConnection = async ({
     connectionId,
-    mcpServer,
+    mcpServerId,
+    mcpServerDisplayName,
     provider,
   }: {
     connectionId: string;
-    mcpServer: MCPServerType;
+    mcpServerId: string;
+    mcpServerDisplayName: string;
     provider: OAuthProvider;
   }): Promise<PostConnectionResponseBody | null> => {
     const response = await fetch(
@@ -633,7 +635,7 @@ export function useCreateMCPServerConnection({
         },
         body: JSON.stringify({
           connectionId,
-          mcpServerId: mcpServer.sId,
+          mcpServerId,
           provider,
         }),
       }
@@ -641,8 +643,8 @@ export function useCreateMCPServerConnection({
     if (response.ok) {
       sendNotification({
         type: "success",
-        title: `${getMcpServerDisplayName(mcpServer)} connected`,
-        description: `Successfully connected to ${getMcpServerDisplayName(mcpServer)}.`,
+        title: `${mcpServerDisplayName} connected`,
+        description: `Successfully connected to ${mcpServerDisplayName}.`,
       });
       void mutateConnections();
       if (connectionType === "workspace") {
@@ -652,8 +654,8 @@ export function useCreateMCPServerConnection({
     } else {
       sendNotification({
         type: "error",
-        title: `Failed to connect ${getMcpServerDisplayName(mcpServer)}`,
-        description: `Could not connect to ${getMcpServerDisplayName(mcpServer)}. Please try again.`,
+        title: `Failed to connect ${mcpServerDisplayName}`,
+        description: `Could not connect to ${mcpServerDisplayName}. Please try again.`,
       });
       return null;
     }
@@ -826,19 +828,21 @@ export function useCreatePersonalConnection(owner: LightWorkspaceType) {
   const sendNotification = useSendNotification();
 
   const createPersonalConnection = async ({
-    mcpServer,
+    mcpServerId,
+    mcpServerDisplayName,
     provider,
     useCase,
     scope,
   }: {
-    mcpServer: MCPServerType;
+    mcpServerId: string;
+    mcpServerDisplayName: string;
     provider: OAuthProvider;
     useCase: OAuthUseCase;
     scope?: string;
   }): Promise<boolean> => {
     try {
       const extraConfig: Record<string, string> = {
-        mcp_server_id: mcpServer.sId,
+        mcp_server_id: mcpServerId,
       };
 
       if (scope) {
@@ -864,7 +868,8 @@ export function useCreatePersonalConnection(owner: LightWorkspaceType) {
 
       const result = await createMCPServerConnection({
         connectionId: cRes.value.connection_id,
-        mcpServer,
+        mcpServerId: mcpServerId,
+        mcpServerDisplayName: mcpServerDisplayName,
         provider,
       });
 


### PR DESCRIPTION
## Description

- This PR changes the signature of `createPersonalConnection`.
- This is a necessary step for https://github.com/dust-tt/tasks/issues/3881, we're gonna pull only the two fields from the db.

## Tests

- Checked locally.

## Risk

- Low.

## Deploy Plan

- Deploy front.
