### PR TITLE
[front] Add metadata to response of `actions/blocked`

### DIFF
--- a/front/lib/actions/mcp.ts
+++ b/front/lib/actions/mcp.ts
@@ -173,6 +173,7 @@ export type ToolExecutionMetadata = {
   stake?: MCPToolStakeLevelType;
 
   mcpServerId?: string;
+  mcpServerDisplayName?: string;
   metadata: MCPValidationMetadataType;
 };
 

--- a/front/lib/actions/mcp.ts
+++ b/front/lib/actions/mcp.ts
@@ -172,9 +172,10 @@ export type ToolExecutionMetadata = {
   inputs: Record<string, unknown>;
   stake?: MCPToolStakeLevelType;
 
-  mcpServerId?: string;
-  mcpServerDisplayName?: string;
-  metadata: MCPValidationMetadataType;
+  metadata: MCPValidationMetadataType & {
+    mcpServerId?: string;
+    mcpServerDisplayName?: string;
+  };
 };
 
 export type BlockedActionExecution = ToolExecutionMetadata & {

--- a/front/lib/actions/mcp.ts
+++ b/front/lib/actions/mcp.ts
@@ -164,7 +164,7 @@ export type LightMCPToolConfigurationType =
   | LightServerSideMCPToolConfigurationType
   | LightClientSideMCPToolConfigurationType;
 
-export type ToolExecutionMetadata = {
+export type ToolExecution = {
   conversationId: string;
   messageId: string;
   actionId: string;
@@ -178,13 +178,13 @@ export type ToolExecutionMetadata = {
   };
 };
 
-export type BlockedActionExecution = ToolExecutionMetadata & {
+export type BlockedToolExecution = ToolExecution & {
   status: ToolExecutionBlockedStatus;
   authorizationInfo: AuthorizationInfo | null;
 };
 
 // TODO(durable-agents): cleanup the types of the events.
-export type MCPApproveExecutionEvent = ToolExecutionMetadata & {
+export type MCPApproveExecutionEvent = ToolExecution & {
   type: "tool_approve_execution";
   created: number;
   configurationId: string;

--- a/front/lib/actions/mcp.ts
+++ b/front/lib/actions/mcp.ts
@@ -165,15 +165,18 @@ export type LightMCPToolConfigurationType =
   | LightClientSideMCPToolConfigurationType;
 
 export type ToolExecutionMetadata = {
+  conversationId: string;
+  messageId: string;
   actionId: string;
+
   inputs: Record<string, unknown>;
   stake?: MCPToolStakeLevelType;
+
+  mcpServerId?: string;
   metadata: MCPValidationMetadataType;
 };
 
 export type BlockedActionExecution = ToolExecutionMetadata & {
-  messageId: string;
-  conversationId: string;
   status: ToolExecutionBlockedStatus;
   authorizationInfo: AuthorizationInfo | null;
 };
@@ -183,8 +186,6 @@ export type MCPApproveExecutionEvent = ToolExecutionMetadata & {
   type: "tool_approve_execution";
   created: number;
   configurationId: string;
-  messageId: string;
-  conversationId: string;
   isLastBlockingEventForStep?: boolean;
 };
 

--- a/front/lib/resources/agent_mcp_action_resource.ts
+++ b/front/lib/resources/agent_mcp_action_resource.ts
@@ -257,6 +257,11 @@ export class AgentMCPActionResource extends BaseResource<AgentMCPActionModel> {
         isToolExecutionStatusBlocked(action.status),
         "Action is not blocked."
       );
+      const mcpServerView = isLightServerSideMCPToolConfiguration(
+        action.toolConfiguration
+      )
+        ? mcpServerViewMap.get(action.toolConfiguration.mcpServerViewId)
+        : null;
 
       blockedActionsList.push({
         messageId: agentMessage.message.sId,
@@ -273,14 +278,9 @@ export class AgentMCPActionResource extends BaseResource<AgentMCPActionModel> {
           agentName: agentConfiguration.name,
           icon: action.toolConfiguration.icon,
         },
+        mcpServerId: mcpServerView?.mcpServerId,
         status: action.status,
-        authorizationInfo: isLightServerSideMCPToolConfiguration(
-          action.toolConfiguration
-        )
-          ? mcpServerViewMap
-              .get(action.toolConfiguration.mcpServerViewId)
-              ?.toJSON().server.authorization ?? null
-          : null,
+        authorizationInfo: mcpServerView?.toJSON().server.authorization ?? null,
       });
     }
 

--- a/front/lib/resources/agent_mcp_action_resource.ts
+++ b/front/lib/resources/agent_mcp_action_resource.ts
@@ -8,6 +8,7 @@ import type {
 import { Op } from "sequelize";
 
 import type { BlockedActionExecution } from "@app/lib/actions/mcp";
+import { getMcpServerViewDisplayName } from "@app/lib/actions/mcp_helper";
 import type { ToolExecutionStatus } from "@app/lib/actions/statuses";
 import {
   isToolExecutionStatusBlocked,
@@ -279,6 +280,9 @@ export class AgentMCPActionResource extends BaseResource<AgentMCPActionModel> {
           icon: action.toolConfiguration.icon,
         },
         mcpServerId: mcpServerView?.mcpServerId,
+        mcpServerDisplayName: mcpServerView
+          ? getMcpServerViewDisplayName(mcpServerView.toJSON())
+          : undefined,
         status: action.status,
         authorizationInfo: mcpServerView?.toJSON().server.authorization ?? null,
       });

--- a/front/lib/resources/agent_mcp_action_resource.ts
+++ b/front/lib/resources/agent_mcp_action_resource.ts
@@ -7,7 +7,7 @@ import type {
 } from "sequelize";
 import { Op } from "sequelize";
 
-import type { BlockedActionExecution } from "@app/lib/actions/mcp";
+import type { BlockedToolExecution } from "@app/lib/actions/mcp";
 import { getMcpServerViewDisplayName } from "@app/lib/actions/mcp_helper";
 import type { ToolExecutionStatus } from "@app/lib/actions/statuses";
 import {
@@ -171,7 +171,7 @@ export class AgentMCPActionResource extends BaseResource<AgentMCPActionModel> {
   static async listBlockedActionsForConversation(
     auth: Authenticator,
     conversationId: string
-  ): Promise<BlockedActionExecution[]> {
+  ): Promise<BlockedToolExecution[]> {
     const owner = auth.getNonNullableWorkspace();
 
     const conversation = await ConversationResource.fetchById(
@@ -209,7 +209,7 @@ export class AgentMCPActionResource extends BaseResource<AgentMCPActionModel> {
       order: [["createdAt", "ASC"]],
     });
 
-    const blockedActionsList: BlockedActionExecution[] = [];
+    const blockedActionsList: BlockedToolExecution[] = [];
 
     // We get the latest version here, it may show a different name than the one used when the
     // action was created, taking this shortcut for the sake of simplicity.

--- a/front/lib/resources/agent_mcp_action_resource.ts
+++ b/front/lib/resources/agent_mcp_action_resource.ts
@@ -278,11 +278,11 @@ export class AgentMCPActionResource extends BaseResource<AgentMCPActionModel> {
           mcpServerName: action.toolConfiguration.mcpServerName,
           agentName: agentConfiguration.name,
           icon: action.toolConfiguration.icon,
+          mcpServerId: mcpServerView?.mcpServerId,
+          mcpServerDisplayName: mcpServerView
+            ? getMcpServerViewDisplayName(mcpServerView.toJSON())
+            : undefined,
         },
-        mcpServerId: mcpServerView?.mcpServerId,
-        mcpServerDisplayName: mcpServerView
-          ? getMcpServerViewDisplayName(mcpServerView.toJSON())
-          : undefined,
         status: action.status,
         authorizationInfo: mcpServerView?.toJSON().server.authorization ?? null,
       });

--- a/front/pages/api/w/[wId]/assistant/conversations/[cId]/actions/blocked.ts
+++ b/front/pages/api/w/[wId]/assistant/conversations/[cId]/actions/blocked.ts
@@ -1,6 +1,6 @@
 import type { NextApiRequest, NextApiResponse } from "next";
 
-import type { BlockedActionExecution } from "@app/lib/actions/mcp";
+import type { BlockedToolExecution } from "@app/lib/actions/mcp";
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
 import type { Authenticator } from "@app/lib/auth";
 import { AgentMCPActionResource } from "@app/lib/resources/agent_mcp_action_resource";
@@ -9,7 +9,7 @@ import type { WithAPIErrorResponse } from "@app/types";
 import { isString } from "@app/types";
 
 export type GetBlockedActionsResponseType = {
-  blockedActions: BlockedActionExecution[];
+  blockedActions: BlockedToolExecution[];
 };
 
 async function handler(


### PR DESCRIPTION
## Description

- Part of https://github.com/dust-tt/tasks/issues/3881.
- This PR adds the MCP server ID and name, which are necessary to implement the personal authentication from the db state.
- Currently a no-op, goes hand in hand with https://github.com/dust-tt/dust/pull/15379.
- Will see if I do a cleaner type once we consolidate with the type of the event.

## Tests

- Checked locally.

## Risk

- Low.

## Deploy Plan

- Deploy front.
