### PR TITLE
[front] ABv2 - Headings in builder editor

### DIFF
--- a/front/components/agent_builder/instructions/AgentBuilderInstructionsEditor.tsx
+++ b/front/components/agent_builder/instructions/AgentBuilderInstructionsEditor.tsx
@@ -79,7 +79,7 @@ export function AgentBuilderInstructionsEditor({
       StarterKit.configure({
         paragraph: false, // We use custom ParagraphExtension
         heading: {
-          levels: [1, 2, 3, 4, 5, 6], // Support H1–H6 but display with the same style
+          levels: [1, 2, 3, 4, 5, 6],
           HTMLAttributes: {
             class: "text-xl font-semibold mt-4 mb-3",
           },

--- a/front/components/agent_builder/instructions/AgentBuilderInstructionsEditor.tsx
+++ b/front/components/agent_builder/instructions/AgentBuilderInstructionsEditor.tsx
@@ -78,7 +78,12 @@ export function AgentBuilderInstructionsEditor({
     return [
       StarterKit.configure({
         paragraph: false, // We use custom ParagraphExtension
-        heading: false,
+        heading: {
+          levels: [1, 2, 3, 4, 5, 6], // Support H1–H6 but display with the same style
+          HTMLAttributes: {
+            class: "text-xl font-semibold mt-4 mb-3",
+          },
+        },
         bulletList: false,
         orderedList: false,
         listItem: false,

--- a/front/components/agent_builder/instructions/useBlockInsertDropdown.tsx
+++ b/front/components/agent_builder/instructions/useBlockInsertDropdown.tsx
@@ -1,4 +1,4 @@
-import { CommandLineIcon, DocumentIcon } from "@dust-tt/sparkle";
+import { CommandLineIcon, DocumentIcon, DocumentTextIcon } from "@dust-tt/sparkle";
 import type { Editor as CoreEditor } from "@tiptap/core";
 import type { Editor as ReactEditor } from "@tiptap/react";
 import type {
@@ -21,6 +21,19 @@ export interface BlockSuggestion {
 }
 
 const BLOCK_SUGGESTIONS: BlockSuggestion[] = [
+  {
+    id: "heading",
+    label: "Heading",
+    icon: DocumentTextIcon,
+    command: (editor, range) => {
+      editor
+        .chain()
+        .focus()
+        .deleteRange(range)
+        .setHeading({ level: 1 })
+        .run();
+    },
+  },
   {
     id: "xml-block",
     label: "XML Tag",

--- a/front/components/agent_builder/instructions/useBlockInsertDropdown.tsx
+++ b/front/components/agent_builder/instructions/useBlockInsertDropdown.tsx
@@ -1,4 +1,8 @@
-import { CommandLineIcon, DocumentIcon, DocumentTextIcon } from "@dust-tt/sparkle";
+import {
+  CommandLineIcon,
+  DocumentIcon,
+  DocumentTextIcon,
+} from "@dust-tt/sparkle";
 import type { Editor as CoreEditor } from "@tiptap/core";
 import type { Editor as ReactEditor } from "@tiptap/react";
 import type {
@@ -26,12 +30,7 @@ const BLOCK_SUGGESTIONS: BlockSuggestion[] = [
     label: "Heading",
     icon: DocumentTextIcon,
     command: (editor, range) => {
-      editor
-        .chain()
-        .focus()
-        .deleteRange(range)
-        .setHeading({ level: 1 })
-        .run();
+      editor.chain().focus().deleteRange(range).setHeading({ level: 1 }).run();
     },
   },
   {

--- a/front/lib/client/agent_builder/instructions.ts
+++ b/front/lib/client/agent_builder/instructions.ts
@@ -109,7 +109,6 @@ function parseTextWithHeadings(text: string): JSONContent[] {
   const lines = text.split("\n");
 
   for (const line of lines) {
-    // Check for markdown headings and preserve their levels (H1–H6)
     const headingMatch = line.match(/^(#{1,6})\s+(.*)$/);
     if (headingMatch) {
       const level = headingMatch[1].length; // Preserve original level (1–6)
@@ -120,7 +119,6 @@ function parseTextWithHeadings(text: string): JSONContent[] {
         content: content ? [{ type: "text", text: content }] : [],
       });
     } else {
-      // Regular paragraph
       nodes.push({
         type: "paragraph",
         content: line.trim() ? [{ type: "text", text: line.trim() }] : [],

--- a/front/lib/client/agent_builder/instructions.ts
+++ b/front/lib/client/agent_builder/instructions.ts
@@ -3,7 +3,6 @@ import type { JSONContent } from "@tiptap/react";
 import {
   createInstructionBlockNode,
   splitTextAroundBlocks,
-  textToParagraphNodes,
 } from "@app/lib/client/agent_builder/instructionBlockUtils";
 
 function serializeNodeToText(node: JSONContent): string {
@@ -108,7 +107,7 @@ function parseInstructionBlocks(text: string): JSONContent[] {
 function parseTextWithHeadings(text: string): JSONContent[] {
   const nodes: JSONContent[] = [];
   const lines = text.split("\n");
-  
+
   for (const line of lines) {
     // Check for markdown headings and preserve their levels (H1–H6)
     const headingMatch = line.match(/^(#{1,6})\s+(.*)$/);


### PR DESCRIPTION
## Description

This PR introduces headings support in the agent builder
- Slash suggestions support adding heading block to the editor
- Markdown commands (#, ##, ### ... + space) create headings
- All headings are displayed as one size (H1) but proper size is stored in the instructions 
- Copy and paste preserves the original markdown/html formatting (tested in Gmail, Gdocs, Notion)

## Tests

Locally

## Risk

Low, behind FF

## Deploy Plan

Deploy front
