### PR TITLE
[front] fix(ab/knowledge): update how to figure out the processing method

### DIFF
--- a/front/components/agent_builder/capabilities/shared/ProcessingMethodSection.tsx
+++ b/front/components/agent_builder/capabilities/shared/ProcessingMethodSection.tsx
@@ -73,12 +73,11 @@ export function ProcessingMethodSection() {
         (item.type === "data_source" &&
           isRemoteDatabase(item.dataSourceView.dataSource)) ||
         (item.type === "node" &&
-          item.node.type === "folder" &&
           isRemoteDatabase(item.node.dataSourceView.dataSource))
     );
     if (onlyRemote) {
       if (dataWarehouseServer) {
-        return [[dataWarehouseServer], false];
+        return [[dataWarehouseServer, ...tablesQueryServers], false];
       }
       return [tablesQueryServers, false];
     }

--- a/front/components/agent_builder/capabilities/shared/ProcessingMethodSection.tsx
+++ b/front/components/agent_builder/capabilities/shared/ProcessingMethodSection.tsx
@@ -12,6 +12,7 @@ import { useController, useWatch } from "react-hook-form";
 import type { MCPServerViewTypeWithLabel } from "@app/components/agent_builder/MCPServerViewsContext";
 import { useMCPServerViewsContext } from "@app/components/agent_builder/MCPServerViewsContext";
 import type { CapabilityFormData } from "@app/components/agent_builder/types";
+import type { DataSourceBuilderTreeItemType } from "@app/components/data_source_view/context/types";
 import {
   getMcpServerViewDescription,
   getMcpServerViewDisplayName,
@@ -29,6 +30,15 @@ import {
 import { isRemoteDatabase } from "@app/lib/data_sources";
 
 const tablesServer = [TABLE_QUERY_SERVER_NAME, TABLE_QUERY_V2_SERVER_NAME];
+
+function isRemoteDatabaseItem(item: DataSourceBuilderTreeItemType): boolean {
+  return (
+    (item.type === "data_source" &&
+      isRemoteDatabase(item.dataSourceView.dataSource)) ||
+    (item.type === "node" &&
+      isRemoteDatabase(item.node.dataSourceView.dataSource))
+  );
+}
 
 export function ProcessingMethodSection() {
   const { mcpServerViewsWithKnowledge, isMCPServerViewsLoading } =
@@ -68,13 +78,7 @@ export function ProcessingMethodSection() {
       return [null, false];
     }
 
-    const onlyRemote = sources.in.every(
-      (item) =>
-        (item.type === "data_source" &&
-          isRemoteDatabase(item.dataSourceView.dataSource)) ||
-        (item.type === "node" &&
-          isRemoteDatabase(item.node.dataSourceView.dataSource))
-    );
+    const onlyRemote = sources.in.every(isRemoteDatabaseItem);
     if (onlyRemote) {
       if (dataWarehouseServer) {
         return [[dataWarehouseServer, ...tablesQueryServers], false];
@@ -83,7 +87,9 @@ export function ProcessingMethodSection() {
     }
 
     const onlyTableQueries = sources.in.every(
-      (item) => item.type === "node" && item.node.type === "table"
+      (item) =>
+        (item.type === "node" && item.node.type === "table") ||
+        isRemoteDatabaseItem(item)
     );
     if (onlyTableQueries) {
       return [tablesQueryServers, false];

--- a/front/components/agent_builder/capabilities/shared/ProcessingMethodSection.tsx
+++ b/front/components/agent_builder/capabilities/shared/ProcessingMethodSection.tsx
@@ -50,24 +50,16 @@ export function ProcessingMethodSection() {
   });
   const sources = useWatch<CapabilityFormData, "sources">({ name: "sources" });
 
-  const dataWarehouseServer = useMemo(
-    () =>
-      mcpServerViewsWithKnowledge.find(
-        (serverView) =>
-          serverView.serverType === "internal" &&
-          serverView.server.name === DATA_WAREHOUSE_SERVER_NAME
-      ),
-    [mcpServerViewsWithKnowledge]
+  const dataWarehouseServer = mcpServerViewsWithKnowledge.find(
+    (serverView) =>
+      serverView.serverType === "internal" &&
+      serverView.server.name === DATA_WAREHOUSE_SERVER_NAME
   );
 
-  const tablesQueryServers = useMemo(
-    () =>
-      mcpServerViewsWithKnowledge.filter(
-        (serverView) =>
-          serverView.serverType === "internal" &&
-          tablesServer.includes(serverView.server.name)
-      ),
-    [mcpServerViewsWithKnowledge]
+  const tablesQueryServers = mcpServerViewsWithKnowledge.filter(
+    (serverView) =>
+      serverView.serverType === "internal" &&
+      tablesServer.includes(serverView.server.name)
   );
 
   const [serversToDisplay, displayWarningTableQuery] = useMemo((): [

--- a/front/lib/actions/mcp_internal_actions/constants.ts
+++ b/front/lib/actions/mcp_internal_actions/constants.ts
@@ -46,6 +46,7 @@ export const DATA_WAREHOUSES_QUERY_TOOL_NAME = "query";
 export const SEARCH_SERVER_NAME = "search";
 export const TABLE_QUERY_SERVER_NAME = "query_tables";
 export const TABLE_QUERY_V2_SERVER_NAME = "query_tables_v2";
+export const DATA_WAREHOUSE_SERVER_NAME = "data_warehouses";
 
 export const AVAILABLE_INTERNAL_MCP_SERVER_NAMES = [
   // Note:
@@ -57,7 +58,7 @@ export const AVAILABLE_INTERNAL_MCP_SERVER_NAMES = [
   "agent_router",
   "conversation_files",
   "data_sources_file_system",
-  "data_warehouses",
+  DATA_WAREHOUSE_SERVER_NAME,
   "extract_data",
   "file_generation",
   "freshservice",
@@ -991,7 +992,7 @@ The directive should be used to display a clickable version of the agent name in
       instructions: null,
     },
   },
-  data_warehouses: {
+  [DATA_WAREHOUSE_SERVER_NAME]: {
     id: 1012,
     availability: "auto",
     allowMultipleInstances: false,
@@ -1002,7 +1003,7 @@ The directive should be used to display a clickable version of the agent name in
     tools_stakes: undefined,
     timeoutMs: undefined,
     serverInfo: {
-      name: "data_warehouses",
+      name: DATA_WAREHOUSE_SERVER_NAME,
       version: "1.0.0",
       description:
         "Comprehensive tables navigation toolkit for browsing data warehouses and tables. Provides Unix-like " +


### PR DESCRIPTION
## Description
There were some issues and we weren't handling the new `data_warehouse` MCP server. So moved to a `useMemo` to figure out which servers to display. Not the most optimized, but easy to read and maintain.

## Tests
- Locally with tables and documents
- Front-edge
  - [x] remote db: data warehouse, table query
  - [x] remote db + tables: table query
  - [x] remote db + tables + document: search, include, extract + warning
  - [x] documents: search, include, extract

## Risk
Low, easy to fix, behind a FF

## Deploy Plan
Deploy front
