### PR TITLE
[front] - fix(AB v2): tool knowledge edition

### DIFF
--- a/front/components/agent_builder/capabilities/knowledge/transformations.ts
+++ b/front/components/agent_builder/capabilities/knowledge/transformations.ts
@@ -164,13 +164,25 @@ export function transformSelectionConfigurationsToTree(
           });
         } else {
           const pathParts = [baseParts, node.internalId];
-          inPaths.push({
-            path: pathParts.join("/"),
-            name: node.title,
-            type: "data_source",
-            dataSourceView: node.dataSourceView,
-            tagsFilter: config.tagsFilter,
-          });
+          // For table nodes without parents, we should still create a "node" type
+          // so that ProcessingMethodSection can properly detect them
+          if (node.type === "table") {
+            inPaths.push({
+              path: pathParts.join("/"),
+              name: node.title,
+              type: "node",
+              node,
+              tagsFilter: config.tagsFilter,
+            });
+          } else {
+            inPaths.push({
+              path: pathParts.join("/"),
+              name: node.title,
+              type: "data_source",
+              dataSourceView: node.dataSourceView,
+              tagsFilter: config.tagsFilter,
+            });
+          }
         }
       }
     }

--- a/front/components/agent_builder/capabilities/mcp/MCPServerViewsSheet.tsx
+++ b/front/components/agent_builder/capabilities/mcp/MCPServerViewsSheet.tsx
@@ -21,7 +21,10 @@ import { MCPActionHeader } from "@app/components/agent_builder/capabilities/mcp/
 import { MCPServerInfoPage } from "@app/components/agent_builder/capabilities/mcp/MCPServerInfoPage";
 import { MCPServerSelectionPage } from "@app/components/agent_builder/capabilities/mcp/MCPServerSelectionPage";
 import { MCPServerViewsFooter } from "@app/components/agent_builder/capabilities/mcp/MCPServerViewsFooter";
-import { generateUniqueActionName } from "@app/components/agent_builder/capabilities/mcp/utils/actionNameUtils";
+import {
+  generateUniqueActionName,
+  nameToStorageFormat,
+} from "@app/components/agent_builder/capabilities/mcp/utils/actionNameUtils";
 import { getDefaultFormValues } from "@app/components/agent_builder/capabilities/mcp/utils/formDefaults";
 import { createFormResetHandler } from "@app/components/agent_builder/capabilities/mcp/utils/formStateUtils";
 import {
@@ -630,11 +633,13 @@ export function MCPServerViewsSheet({
 
       const newActionName = isNewActionOrNameChanged
         ? generateUniqueActionName({
-            baseName: formData.name,
+            baseName: nameToStorageFormat(formData.name),
             existingActions: actions,
             selectedToolsInSheet,
           })
-        : formData.name;
+        : mode?.type === "edit"
+          ? configurationTool.name
+          : formData.name;
 
       const configuredAction: AgentBuilderAction = {
         ...configurationTool,

--- a/front/components/agent_builder/capabilities/mcp/utils/actionNameUtils.ts
+++ b/front/components/agent_builder/capabilities/mcp/utils/actionNameUtils.ts
@@ -7,6 +7,22 @@ interface GenerateUniqueActionNameParams {
   selectedToolsInSheet?: SelectedTool[];
 }
 
+// Convert stored name back to user-friendly format for display
+export function nameToDisplayFormat(name: string): string {
+  return name
+    .split("_")
+    .map((word) => word.charAt(0).toUpperCase() + word.slice(1))
+    .join(" ");
+}
+
+// Convert display format name back to storage format
+export function nameToStorageFormat(displayName: string): string {
+  return displayName
+    .toLowerCase()
+    .replace(/\s+/g, "_")
+    .replace(/[^a-z0-9_]/g, ""); // Remove any non-alphanumeric characters except underscores
+}
+
 // TODO: refactor an make it reusable for mcp tools with data source selection.
 export function generateUniqueActionName({
   baseName,

--- a/front/components/agent_builder/capabilities/mcp/utils/sheetUtils.ts
+++ b/front/components/agent_builder/capabilities/mcp/utils/sheetUtils.ts
@@ -235,9 +235,14 @@ export function shouldGenerateUniqueName(
   defaultFormValues: MCPFormData,
   formData: MCPFormData
 ): boolean {
-  return (
-    mode?.type === "add" ||
-    mode?.type === "configure" ||
-    (mode?.type === "edit" && defaultFormValues.name !== formData.name)
-  );
+  if (mode?.type === "add" || mode?.type === "configure") {
+    return true; // Always generate unique names for new actions
+  }
+
+  if (mode?.type === "edit") {
+    // For editing, only generate a unique name if the user actually changed it
+    return defaultFormValues.name !== formData.name;
+  }
+
+  return false;
 }

--- a/front/components/agent_builder/capabilities/shared/ProcessingMethodSection.tsx
+++ b/front/components/agent_builder/capabilities/shared/ProcessingMethodSection.tsx
@@ -64,6 +64,15 @@ export function ProcessingMethodSection() {
   }, [sources]);
 
   useEffect(() => {
+    const needsUpdate =
+      !mcpServerView ||
+      (hasOnlyTablesSelected &&
+        !tablesServer.includes(mcpServerView.server.name));
+
+    if (!needsUpdate) {
+      return;
+    }
+
     if (hasOnlyTablesSelected) {
       const tableServer = mcpServerViewsWithKnowledge.find(
         (serverView) =>
@@ -83,7 +92,12 @@ export function ProcessingMethodSection() {
         onChange(searchServer);
       }
     }
-  }, [hasOnlyTablesSelected, mcpServerViewsWithKnowledge, onChange]);
+  }, [
+    hasOnlyTablesSelected,
+    mcpServerViewsWithKnowledge,
+    mcpServerView,
+    onChange,
+  ]);
 
   return (
     <div className="space-y-4">

--- a/front/components/agent_builder/capabilities/shared/SelectDataSourcesFilters.tsx
+++ b/front/components/agent_builder/capabilities/shared/SelectDataSourcesFilters.tsx
@@ -74,6 +74,7 @@ function DataSourceFilterContextItem({
 export function SelectDataSourcesFilters() {
   const { setSheetPageId } = useDataSourceBuilderContext();
   const sources = useWatch<CapabilityFormData, "sources">({ name: "sources" });
+
   const dataSourceViews = sources.in.reduce(
     (acc, source) => {
       if (source.type === "data_source") {


### PR DESCRIPTION
## Description

This PR fixes the following issues:
- When editing existing table query tools in the new agent builder, the form wasn't loading the selected data and wasn't showing the correct processing method
- Smart naming logic was incorrectly applying suffix generation (e.g., "_2") to existing tools during editing instead of only to new tools

Solution:
  - Table detection fix: Fixed transformSelectionConfigurationsToTree to properly set table nodes as type: "node" instead of "data_source" so ProcessingMethodSection can detect them correctly
  - Form data loading: Updated Knowledge sheet to check both dataSourceConfigurations and tablesConfigurations when loading existing actions
  - Processing method preservation: Modified ProcessingMethodSection to only auto-switch processing methods when necessary, preserving existing selections during editing
  - Smart naming: Fixed naming logic to preserve original names when editing, only generating unique names for new actions or when the user actually changes the name

## Tests

- [x] locally
- [x] front-edge

## Risk

Moderated, behind FF

## Deploy Plan

Deploy front
