### PR TITLE
[front] - feat(AB v2): implement agent duplication 

### DIFF
--- a/front/components/agent_builder/AgentBuilder.tsx
+++ b/front/components/agent_builder/AgentBuilder.tsx
@@ -270,10 +270,11 @@ export default function AgentBuilder({
   const { isDirty, isSubmitting } = form.formState;
 
   // Disable navigation lock during save process for new agents
-  useNavigationLock(isDirty && !isSaving);
+  useNavigationLock((isDirty || !!duplicateAgentId) && !isSaving);
 
-  const isSaveDisabled =
-    !isDirty || isSubmitting || isActionsLoading || isTriggersLoading;
+  const isSaveDisabled = duplicateAgentId
+    ? false
+    : !isDirty || isSubmitting || isActionsLoading || isTriggersLoading;
 
   const saveLabel = isSubmitting ? "Saving..." : "Save";
 

--- a/front/components/agent_builder/AgentBuilder.tsx
+++ b/front/components/agent_builder/AgentBuilder.tsx
@@ -26,6 +26,7 @@ import { submitAgentBuilderForm } from "@app/components/agent_builder/submitAgen
 import {
   getDefaultAgentFormData,
   transformAgentConfigurationToFormData,
+  transformDuplicateAgentToFormData,
   transformTemplateToFormData,
 } from "@app/components/agent_builder/transformAgentConfiguration";
 import type { AgentBuilderAction } from "@app/components/agent_builder/types";
@@ -78,10 +79,12 @@ function processAdditionalConfigurationFromStorage(
 
 interface AgentBuilderProps {
   agentConfiguration?: LightAgentConfigurationType;
+  duplicateAgentId?: string | null;
 }
 
 export default function AgentBuilder({
   agentConfiguration,
+  duplicateAgentId,
 }: AgentBuilderProps) {
   const { owner, user, assistantTemplate } = useAgentBuilderContext();
   const { supportedDataSourceViews } = useDataSourceViewsContext();
@@ -93,7 +96,7 @@ export default function AgentBuilder({
 
   const { actions, isActionsLoading } = useAgentConfigurationActions(
     owner.sId,
-    agentConfiguration?.sId ?? null
+    duplicateAgentId ?? agentConfiguration?.sId ?? null
   );
 
   const { triggers, isTriggersLoading } = useAgentTriggers({
@@ -148,7 +151,10 @@ export default function AgentBuilder({
   const formValues = useMemo((): AgentBuilderFormData => {
     let baseValues: AgentBuilderFormData;
 
-    if (agentConfiguration) {
+    if (duplicateAgentId && agentConfiguration) {
+      // Handle agent duplication case
+      baseValues = transformDuplicateAgentToFormData(agentConfiguration, user);
+    } else if (agentConfiguration) {
       baseValues = transformAgentConfigurationToFormData(agentConfiguration);
     } else if (assistantTemplate) {
       baseValues = transformTemplateToFormData(assistantTemplate, user);
@@ -171,6 +177,7 @@ export default function AgentBuilder({
     agentConfiguration,
     assistantTemplate,
     user,
+    duplicateAgentId,
     processedActions,
     slackProvider,
     editors,

--- a/front/components/agent_builder/transformAgentConfiguration.ts
+++ b/front/components/agent_builder/transformAgentConfiguration.ts
@@ -131,3 +131,29 @@ export function convertActionsForFormData(
     configuration: action.configuration,
   }));
 }
+
+/**
+ * Transforms an agent configuration for duplication into agent builder form data.
+ * Similar to transformAgentConfigurationToFormData but adds "_Copy" suffix to name,
+ * resets editors to current user, and defaults to private scope.
+ */
+export function transformDuplicateAgentToFormData(
+  agentConfiguration: LightAgentConfigurationType,
+  user: UserType
+): AgentBuilderFormData {
+  const baseFormData =
+    transformAgentConfigurationToFormData(agentConfiguration);
+
+  return {
+    ...baseFormData,
+    agentSettings: {
+      ...baseFormData.agentSettings,
+      name: `${agentConfiguration.name}${
+        "isTemplate" in agentConfiguration ? "" : "_Copy"
+      }`,
+      scope: "hidden", // Default duplicated agents to private scope
+      editors: [user], // Reset editors to current user for duplicated agent
+      tags: agentConfiguration.tags.filter((tag) => tag.kind !== "protected"),
+    },
+  };
+}

--- a/front/pages/w/[wId]/builder/agents/new.tsx
+++ b/front/pages/w/[wId]/builder/agents/new.tsx
@@ -43,6 +43,7 @@ export const getServerSideProps = withDefaultUserAuthRequirements<{
   flow: BuilderFlow;
   baseUrl: string;
   templateId: string | null;
+  duplicateAgentId: string | null;
 }>(async (context, auth) => {
   const owner = auth.workspace();
   const plan = auth.plan();
@@ -106,6 +107,7 @@ export const getServerSideProps = withDefaultUserAuthRequirements<{
       plan,
       subscription,
       templateId,
+      duplicateAgentId: duplicate,
       user,
     },
   };
@@ -116,6 +118,7 @@ export default function CreateAgent({
   owner,
   user,
   templateId,
+  duplicateAgentId,
 }: InferGetServerSidePropsType<typeof getServerSideProps>) {
   const { assistantTemplate } = useAssistantTemplate({ templateId });
 
@@ -139,6 +142,7 @@ export default function CreateAgent({
             ? agentConfiguration
             : undefined
         }
+        duplicateAgentId={duplicateAgentId}
       />
     </AgentBuilderProvider>
   );


### PR DESCRIPTION
## Description

This PR adds the missing duplicate functionality to the new agent builder. When duplicating an agent, the copy gets a "_Copy" suffix, defaults to private scope, and resets editors to the current user while filtering out protected tags. The existing UI components already route duplicates correctly based on the `agent_builder_v2` feature flag, so no additional UI changes were needed.

## Tests

Locally

## Risk

Low

## Deploy Plan

Deploy front
