### PR TITLE
[SDK][Connectors] Add support for agent_generation_cancelled event

### DIFF
--- a/connectors/src/connectors/slack/chat/stream_conversation_handler.ts
+++ b/connectors/src/connectors/slack/chat/stream_conversation_handler.ts
@@ -375,6 +375,34 @@ async function streamAgentAnswerToSlack(
         return new Ok(undefined);
       }
 
+      case "agent_generation_cancelled": {
+        // Handle generation cancellation by showing a cancelled message
+        const cancelledMessage = "_Message generation was cancelled._";
+        const { formattedContent, footnotes } = annotateCitations(
+          answer || cancelledMessage,
+          actions
+        );
+        const slackContent = slackifyMarkdown(
+          normalizeContentForSlack(formattedContent)
+        );
+
+        await postSlackMessageUpdate(
+          {
+            messageUpdate: {
+              text: slackContent,
+              assistantName,
+              agentConfigurations,
+              footnotes,
+            },
+            ...conversationData,
+            updateState,
+          },
+          { adhereToRateLimit: false }
+        );
+
+        return new Ok(undefined);
+      }
+
       default:
         assertNever(event);
     }

--- a/sdks/js/package-lock.json
+++ b/sdks/js/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@dust-tt/client",
-  "version": "1.1.8",
+  "version": "1.1.9",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@dust-tt/client",
-      "version": "1.1.8",
+      "version": "1.1.9",
       "bundleDependencies": [
         "@modelcontextprotocol/sdk"
       ],

--- a/sdks/js/package.json
+++ b/sdks/js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dust-tt/client",
-  "version": "1.1.8",
+  "version": "1.1.9",
   "description": "Client for Dust API",
   "repository": {
     "type": "git",

--- a/sdks/js/src/index.ts
+++ b/sdks/js/src/index.ts
@@ -6,6 +6,7 @@ import {
   AgentActionSuccessEvent,
   AgentConfigurationViewType,
   AgentErrorEvent,
+  AgentGenerationCancelledEvent,
   AgentMessagePublicType,
   AgentMessageSuccessEvent,
   APIError,
@@ -106,6 +107,7 @@ type AgentEvent =
   | AgentActionSpecificEvent
   | AgentActionSuccessEvent
   | AgentErrorEvent
+  | AgentGenerationCancelledEvent
   | AgentMessageSuccessEvent
   | GenerationTokensEvent
   | UserMessageErrorEvent
@@ -829,6 +831,7 @@ export class DustAPI {
     const terminalEventTypes: AgentEvent["type"][] = [
       "agent_message_success",
       "agent_error",
+      "agent_generation_cancelled",
       "user_message_error",
     ];
 


### PR DESCRIPTION
## Description
Part 1 of fix for https://github.com/dust-tt/tasks/issues/3896
Context: https://dust4ai.slack.com/archives/C05F84CFP0E/p1756116822064819?thread_ts=1756116822.064819&cid=C05F84CFP0E

The `agent_generation_cancelled` event was yielded by the backend but not included in the SDK client's `AgentEvent` union type. This PR adds support for this event type in the SDK and updates the Slack connector to handle it.

### Changes:
1. **SDK** (`sdks/js`):
   - Add AgentGenerationCancelledEvent to AgentEvent union type
   - Add to terminal events list to properly end the stream
   - Bump version to 1.1.9

2. **Slack Connector** (`connectors`):
   - Add case to handle agent_generation_cancelled event
   - Shows "_Message generation was cancelled._" message to users

## Risks
Blast radius: SDK consumers and Slack integration
Risk: low

## Tests
- SDK builds successfully with no TypeScript errors
- Connectors build successfully with no TypeScript errors

## Deploy Plan
- Deploy SDK and connectors together (connectors uses local SDK reference)
- Follow-up PR #15375 will update CLI after SDK v1.1.9 is published