### PR TITLE
[front] Improve typing around personal auth errors

### DIFF
--- a/front/components/assistant/conversation/AgentMessage.tsx
+++ b/front/components/assistant/conversation/AgentMessage.tsx
@@ -57,14 +57,13 @@ import type {
   UserType,
   WorkspaceType,
 } from "@app/types";
+import { isPersonalAuthenticationRequiredErrorContent } from "@app/types";
 import { isString } from "@app/types";
 import {
   assertNever,
   GLOBAL_AGENTS_SID,
   isInteractiveFileContentType,
-  isOAuthProvider,
   isSupportedImageContentType,
-  isValidScope,
 } from "@app/types";
 
 interface AgentMessageProps {
@@ -451,14 +450,7 @@ export function AgentMessage({
   }) {
     if (agentMessage.status === "failed") {
       const { error } = agentMessage;
-      if (
-        error &&
-        error.code === "mcp_server_personal_authentication_required" &&
-        isString(error.metadata?.mcp_server_id) &&
-        error.metadata?.mcp_server_id.length > 0 &&
-        isOAuthProvider(error.metadata?.provider) &&
-        isValidScope(error.metadata?.scope)
-      ) {
+      if (isPersonalAuthenticationRequiredErrorContent(error)) {
         return (
           <MCPServerPersonalAuthenticationRequired
             owner={owner}

--- a/front/components/assistant/conversation/ErrorMessage.tsx
+++ b/front/components/assistant/conversation/ErrorMessage.tsx
@@ -9,11 +9,11 @@ import {
 } from "@dust-tt/sparkle";
 
 import { useSubmitFunction } from "@app/lib/client/utils";
-import type { ErrorContent } from "@app/types";
+import type { GenericErrorContent } from "@app/types";
 import { isAgentErrorCategory } from "@app/types";
 
 interface ErrorMessageProps {
-  error: ErrorContent;
+  error: GenericErrorContent;
   retryHandler: () => void;
 }
 

--- a/front/lib/actions/mcp.ts
+++ b/front/lib/actions/mcp.ts
@@ -63,8 +63,10 @@ import type {
   LightWorkspaceType,
   ModelConfigurationType,
   ModelId,
+  PersonalAuthenticationRequiredErrorContent,
   ReasoningModelConfigurationType,
   TimeFrame,
+  ToolErrorEvent,
 } from "@app/types";
 import { isPersonalAuthenticationRequiredErrorContent } from "@app/types";
 import { assertNever, removeNulls } from "@app/types";
@@ -754,7 +756,9 @@ export function isMCPApproveExecutionEvent(
 
 function isToolPersonalAuthRequiredEvent(
   event: unknown
-): event is ToolPersonalAuthRequiredEvent {
+): event is ToolErrorEvent & {
+  error: PersonalAuthenticationRequiredErrorContent;
+} {
   return (
     typeof event === "object" &&
     event !== null &&

--- a/front/lib/actions/mcp.ts
+++ b/front/lib/actions/mcp.ts
@@ -66,6 +66,7 @@ import type {
   ReasoningModelConfigurationType,
   TimeFrame,
 } from "@app/types";
+import { isPersonalAuthenticationRequiredErrorContent } from "@app/types";
 import { assertNever, removeNulls } from "@app/types";
 
 export type BaseMCPServerConfigurationType = {
@@ -760,10 +761,7 @@ function isToolPersonalAuthRequiredEvent(
     "type" in event &&
     event.type === "tool_error" &&
     "error" in event &&
-    typeof event.error === "object" &&
-    event.error !== null &&
-    "code" in event.error &&
-    event.error.code === "mcp_server_personal_authentication_required"
+    isPersonalAuthenticationRequiredErrorContent(event.error)
   );
 }
 

--- a/front/lib/actions/mcp_internal_actions/events.ts
+++ b/front/lib/actions/mcp_internal_actions/events.ts
@@ -1,28 +1,3 @@
-export type MCPServerPersonalAuthenticationRequiredMetadata = {
-  mcp_server_id: string;
-  provider: string;
-  scope?: string;
-  conversationId: string;
-  messageId: string;
-};
-
-export function isMCPServerPersonalAuthenticationRequiredMetadata(
-  metadata: unknown
-): metadata is MCPServerPersonalAuthenticationRequiredMetadata {
-  return (
-    typeof metadata === "object" &&
-    metadata !== null &&
-    "mcp_server_id" in metadata &&
-    typeof metadata.mcp_server_id === "string" &&
-    "provider" in metadata &&
-    typeof metadata.provider === "string" &&
-    "conversationId" in metadata &&
-    typeof metadata.conversationId === "string" &&
-    "messageId" in metadata &&
-    typeof metadata.messageId === "string"
-  );
-}
-
 type ToolPersonalAuthError = {
   mcpServerId: string;
   provider: string;

--- a/front/lib/actions/mcp_internal_actions/events.ts
+++ b/front/lib/actions/mcp_internal_actions/events.ts
@@ -6,6 +6,23 @@ export type MCPServerPersonalAuthenticationRequiredMetadata = {
   messageId: string;
 };
 
+export function isMCPServerPersonalAuthenticationRequiredMetadata(
+  metadata: unknown
+): metadata is MCPServerPersonalAuthenticationRequiredMetadata {
+  return (
+    typeof metadata === "object" &&
+    metadata !== null &&
+    "mcp_server_id" in metadata &&
+    typeof metadata.mcp_server_id === "string" &&
+    "provider" in metadata &&
+    typeof metadata.provider === "string" &&
+    "conversationId" in metadata &&
+    typeof metadata.conversationId === "string" &&
+    "messageId" in metadata &&
+    typeof metadata.messageId === "string"
+  );
+}
+
 type ToolPersonalAuthError = {
   mcpServerId: string;
   provider: string;

--- a/front/lib/actions/mcp_internal_actions/events.ts
+++ b/front/lib/actions/mcp_internal_actions/events.ts
@@ -1,3 +1,11 @@
+export type ToolPersonalAuthRequiredMetadata = {
+  mcpServerId: string;
+  provider: string;
+  scope?: string;
+  toolName: string;
+  message: string;
+};
+
 /**
  * Personal authentication required event type from MCP actions.
  * This needs to be defined here to avoid circular dependencies.
@@ -8,11 +16,5 @@ export type ToolPersonalAuthRequiredEvent = {
   configurationId: string;
   messageId: string;
   conversationId: string;
-  authError: {
-    mcpServerId: string;
-    provider: string;
-    scope?: string;
-    toolName: string;
-    message: string;
-  };
+  authError: ToolPersonalAuthRequiredMetadata;
 };

--- a/front/lib/actions/mcp_internal_actions/events.ts
+++ b/front/lib/actions/mcp_internal_actions/events.ts
@@ -1,4 +1,12 @@
-export type ToolPersonalAuthRequiredMetadata = {
+export type MCPServerPersonalAuthenticationRequiredMetadata = {
+  mcp_server_id: string;
+  provider: string;
+  scope?: string;
+  conversationId: string;
+  messageId: string;
+};
+
+type ToolPersonalAuthError = {
   mcpServerId: string;
   provider: string;
   scope?: string;
@@ -16,5 +24,5 @@ export type ToolPersonalAuthRequiredEvent = {
   configurationId: string;
   messageId: string;
   conversationId: string;
-  authError: ToolPersonalAuthRequiredMetadata;
+  authError: ToolPersonalAuthError;
 };

--- a/front/lib/api/assistant/conversation/retry_blocked_actions.ts
+++ b/front/lib/api/assistant/conversation/retry_blocked_actions.ts
@@ -71,7 +71,6 @@ async function findUserMessageForRetry(
   await getRedisHybridManager().removeEvent((event) => {
     const payload = JSON.parse(event.message["payload"]);
 
-    console.log(payload);
     return isBlockedActionEvent(payload);
   }, getMessageChannelId(messageId));
 

--- a/front/lib/api/assistant/conversation/retry_blocked_actions.ts
+++ b/front/lib/api/assistant/conversation/retry_blocked_actions.ts
@@ -71,6 +71,7 @@ async function findUserMessageForRetry(
   await getRedisHybridManager().removeEvent((event) => {
     const payload = JSON.parse(event.message["payload"]);
 
+    console.log(payload);
     return isBlockedActionEvent(payload);
   }, getMessageChannelId(messageId));
 

--- a/front/types/assistant/agent.ts
+++ b/front/types/assistant/agent.ts
@@ -3,8 +3,7 @@ import type {
   MCPServerConfigurationType,
   MCPToolConfigurationType,
 } from "@app/lib/actions/mcp";
-import type { MCPServerPersonalAuthenticationRequiredMetadata } from "@app/lib/actions/mcp_internal_actions/events";
-import { isMCPServerPersonalAuthenticationRequiredMetadata } from "@app/lib/actions/mcp_internal_actions/events";
+import type { OAuthProvider } from "@app/types";
 import type {
   ReasoningContentType,
   TextContentType,
@@ -15,6 +14,7 @@ import type {
   ModelProviderIdType,
 } from "@app/types/assistant/assistant";
 import type { AgentMessageType } from "@app/types/assistant/conversation";
+import { isOAuthProvider, isValidScope } from "@app/types/oauth/lib";
 import type { ModelId } from "@app/types/shared/model_id";
 import type { TagType } from "@app/types/tag";
 import type { UserType } from "@app/types/user";
@@ -226,6 +226,32 @@ export type GenericErrorContent = {
   message: string;
   metadata: Record<string, string | number | boolean> | null;
 };
+
+export type MCPServerPersonalAuthenticationRequiredMetadata = {
+  mcp_server_id: string;
+  provider: OAuthProvider;
+  scope?: string;
+  conversationId: string;
+  messageId: string;
+};
+
+export function isMCPServerPersonalAuthenticationRequiredMetadata(
+  metadata: unknown
+): metadata is MCPServerPersonalAuthenticationRequiredMetadata {
+  return (
+    typeof metadata === "object" &&
+    metadata !== null &&
+    "mcp_server_id" in metadata &&
+    typeof metadata.mcp_server_id === "string" &&
+    "provider" in metadata &&
+    isOAuthProvider(metadata?.provider) &&
+    (!("scope" in metadata) || isValidScope(metadata.scope)) &&
+    "conversationId" in metadata &&
+    typeof metadata.conversationId === "string" &&
+    "messageId" in metadata &&
+    typeof metadata.messageId === "string"
+  );
+}
 
 export type PersonalAuthenticationRequiredErrorContent = {
   code: "mcp_server_personal_authentication_required";

--- a/front/types/assistant/agent.ts
+++ b/front/types/assistant/agent.ts
@@ -3,6 +3,7 @@ import type {
   MCPServerConfigurationType,
   MCPToolConfigurationType,
 } from "@app/lib/actions/mcp";
+import type { ToolPersonalAuthRequiredMetadata } from "@app/lib/actions/mcp_internal_actions/events";
 import type {
   ReasoningContentType,
   TextContentType,
@@ -222,7 +223,10 @@ export type AgentMessageErrorEvent = {
 export type ErrorContent = {
   code: string;
   message: string;
-  metadata: Record<string, string | number | boolean> | null;
+  metadata:
+    | Record<string, string | number | boolean>
+    | ToolPersonalAuthRequiredMetadata
+    | null;
 };
 
 // Generic event sent when an error occurred during the model call.

--- a/front/types/assistant/agent.ts
+++ b/front/types/assistant/agent.ts
@@ -3,7 +3,7 @@ import type {
   MCPServerConfigurationType,
   MCPToolConfigurationType,
 } from "@app/lib/actions/mcp";
-import type { ToolPersonalAuthRequiredMetadata } from "@app/lib/actions/mcp_internal_actions/events";
+import type { MCPServerPersonalAuthenticationRequiredMetadata } from "@app/lib/actions/mcp_internal_actions/events";
 import type {
   ReasoningContentType,
   TextContentType,
@@ -220,14 +220,17 @@ export type AgentMessageErrorEvent = {
 };
 
 // Generic type for the content of an agent / tool error.
-export type ErrorContent = {
-  code: string;
-  message: string;
-  metadata:
-    | Record<string, string | number | boolean>
-    | ToolPersonalAuthRequiredMetadata
-    | null;
-};
+export type ErrorContent =
+  | {
+      code: string;
+      message: string;
+      metadata: Record<string, string | number | boolean> | null;
+    }
+  | {
+      code: "mcp_server_personal_authentication_required";
+      message: string;
+      metadata: MCPServerPersonalAuthenticationRequiredMetadata;
+    };
 
 // Generic event sent when an error occurred during the model call.
 export type AgentErrorEvent = {

--- a/front/types/assistant/agent.ts
+++ b/front/types/assistant/agent.ts
@@ -4,6 +4,7 @@ import type {
   MCPToolConfigurationType,
 } from "@app/lib/actions/mcp";
 import type { MCPServerPersonalAuthenticationRequiredMetadata } from "@app/lib/actions/mcp_internal_actions/events";
+import { isMCPServerPersonalAuthenticationRequiredMetadata } from "@app/lib/actions/mcp_internal_actions/events";
 import type {
   ReasoningContentType,
   TextContentType,
@@ -231,6 +232,19 @@ export type PersonalAuthenticationRequiredErrorContent = {
   message: string;
   metadata: MCPServerPersonalAuthenticationRequiredMetadata;
 };
+
+export function isPersonalAuthenticationRequiredErrorContent(
+  error: unknown
+): error is PersonalAuthenticationRequiredErrorContent {
+  return (
+    typeof error === "object" &&
+    error !== null &&
+    "code" in error &&
+    error.code === "mcp_server_personal_authentication_required" &&
+    "metadata" in error &&
+    isMCPServerPersonalAuthenticationRequiredMetadata(error.metadata)
+  );
+}
 
 // Generic event sent when an error occurred during the model call.
 export type AgentErrorEvent = {

--- a/front/types/assistant/agent.ts
+++ b/front/types/assistant/agent.ts
@@ -220,17 +220,17 @@ export type AgentMessageErrorEvent = {
 };
 
 // Generic type for the content of an agent / tool error.
-export type ErrorContent =
-  | {
-      code: string;
-      message: string;
-      metadata: Record<string, string | number | boolean> | null;
-    }
-  | {
-      code: "mcp_server_personal_authentication_required";
-      message: string;
-      metadata: MCPServerPersonalAuthenticationRequiredMetadata;
-    };
+export type GenericErrorContent = {
+  code: string;
+  message: string;
+  metadata: Record<string, string | number | boolean> | null;
+};
+
+export type PersonalAuthenticationRequiredErrorContent = {
+  code: "mcp_server_personal_authentication_required";
+  message: string;
+  metadata: MCPServerPersonalAuthenticationRequiredMetadata;
+};
 
 // Generic event sent when an error occurred during the model call.
 export type AgentErrorEvent = {
@@ -238,7 +238,7 @@ export type AgentErrorEvent = {
   created: number;
   configurationId: string;
   messageId: string;
-  error: ErrorContent;
+  error: GenericErrorContent;
 };
 
 // Event sent when an error occurred during the tool call.
@@ -248,7 +248,7 @@ export type ToolErrorEvent = {
   configurationId: string;
   messageId: string;
   conversationId: string;
-  error: ErrorContent;
+  error: GenericErrorContent | PersonalAuthenticationRequiredErrorContent;
   isLastBlockingEventForStep: boolean;
   // TODO(DURABLE-AGENTS 2025-08-25): Move to a deferred event base interface.
   metadata?: {

--- a/front/types/assistant/conversation.ts
+++ b/front/types/assistant/conversation.ts
@@ -9,7 +9,7 @@ import type { ModelId } from "../shared/model_id";
 import type { UserType, WorkspaceType } from "../user";
 import type {
   AgentConfigurationStatus,
-  ErrorContent,
+  GenericErrorContent,
   LightAgentConfigurationType,
 } from "./agent";
 import type { AgentContentItemType } from "./agent_message_content";
@@ -148,7 +148,7 @@ export type BaseAgentMessageType = {
   status: AgentMessageStatus;
   content: string | null;
   chainOfThought: string | null;
-  error: ErrorContent | null;
+  error: GenericErrorContent | null;
 };
 
 export type ParsedContentItem =


### PR DESCRIPTION
## Description

- This PR defines in one place the type of personal auth errors and adds typeguards.
- One thing I have a hard time wrapping my mind around is the conversation from `tool_personal_auth_required` to `mcp_server_personal_authentication_required`, which changes camelCase fields from snake case ones. This will be addressed in a follow up PR.

## Tests

- Rested the sub agent flow.

## Risk

- Low, mostly around typing.

## Deploy Plan

- Deploy front.
