### PR TITLE
[front] fix(ab/knowledge): update how to figure out the processing method

### DIFF
--- a/front/components/agent_builder/DataSourceViewsContext.tsx
+++ b/front/components/agent_builder/DataSourceViewsContext.tsx
@@ -2,7 +2,10 @@ import type { ReactNode } from "react";
 import React, { createContext, useContext, useEffect, useMemo } from "react";
 
 import { useSendNotification } from "@app/hooks/useNotification";
-import { supportsDocumentsData } from "@app/lib/data_sources";
+import {
+  supportsDocumentsData,
+  supportsStructuredData,
+} from "@app/lib/data_sources";
 import { useDataSourceViews } from "@app/lib/swr/data_source_views";
 import { useFeatureFlags } from "@app/lib/swr/workspaces";
 import type { DataSourceViewType, LightWorkspaceType } from "@app/types";
@@ -53,10 +56,11 @@ export const DataSourceViewsProvider = ({
     }
   }, [isDataSourceViewsError, sendNotification]);
 
-  // Filter data sources for document search (excluding table-only sources)
   const supportedDataSourceViews = useMemo(() => {
-    return dataSourceViews.filter((dsv) =>
-      supportsDocumentsData(dsv.dataSource, featureFlags)
+    return dataSourceViews.filter(
+      (dsv) =>
+        supportsDocumentsData(dsv.dataSource, featureFlags) ||
+        supportsStructuredData(dsv.dataSource)
     );
   }, [dataSourceViews, featureFlags]);
 

--- a/front/components/agent_builder/capabilities/knowledge/KnowledgeConfigurationSheet.tsx
+++ b/front/components/agent_builder/capabilities/knowledge/KnowledgeConfigurationSheet.tsx
@@ -99,7 +99,6 @@ function getKnowledgeDefaultValues({
     );
   })();
 
-  console.log("SELECTED MCP", selectedMCPServerView);
   const storedName =
     action?.name ??
     presetActionData?.name ??

--- a/front/components/agent_builder/capabilities/knowledge/utils.ts
+++ b/front/components/agent_builder/capabilities/knowledge/utils.ts
@@ -6,6 +6,11 @@ import {
 } from "@dust-tt/sparkle";
 
 import { DESCRIPTION_MAX_LENGTH } from "@app/components/agent_builder/types";
+import {
+  DATA_WAREHOUSE_SERVER_NAME,
+  TABLE_QUERY_SERVER_NAME,
+  TABLE_QUERY_V2_SERVER_NAME,
+} from "@app/lib/actions/mcp_internal_actions/constants";
 
 export interface CapabilityConfig {
   icon: React.ComponentType;
@@ -56,9 +61,31 @@ export const CAPABILITY_CONFIGS: Record<string, CapabilityConfig> = {
       maxLength: DESCRIPTION_MAX_LENGTH,
     },
   },
-  query_tables: {
+  [TABLE_QUERY_SERVER_NAME]: {
     icon: TableIcon,
     configPageTitle: "Configure Query Tables",
+    configPageDescription: "Describe how you want to query the selected tables",
+    descriptionConfig: {
+      title: "Query Description",
+      description:
+        "Describe what kind of queries you want to run against your selected tables. The agent will use this context to generate appropriate SQL queries.",
+      placeholder: "Describe what you want to query from your tables...",
+    },
+  },
+  [TABLE_QUERY_V2_SERVER_NAME]: {
+    icon: TableIcon,
+    configPageTitle: "Configure Query Tables v2",
+    configPageDescription: "Describe how you want to query the selected tables",
+    descriptionConfig: {
+      title: "Query Description",
+      description:
+        "Describe what kind of queries you want to run against your selected tables. The agent will use this context to generate appropriate SQL queries.",
+      placeholder: "Describe what you want to query from your tables...",
+    },
+  },
+  [DATA_WAREHOUSE_SERVER_NAME]: {
+    icon: TableIcon,
+    configPageTitle: "Configure Data Warehouse",
     configPageDescription: "Describe how you want to query the selected tables",
     descriptionConfig: {
       title: "Query Description",

--- a/front/components/agent_builder/capabilities/shared/ProcessingMethodSection.tsx
+++ b/front/components/agent_builder/capabilities/shared/ProcessingMethodSection.tsx
@@ -13,6 +13,7 @@ import { useController, useWatch } from "react-hook-form";
 import type { MCPServerViewTypeWithLabel } from "@app/components/agent_builder/MCPServerViewsContext";
 import { useMCPServerViewsContext } from "@app/components/agent_builder/MCPServerViewsContext";
 import type { CapabilityFormData } from "@app/components/agent_builder/types";
+import type { DataSourceBuilderTreeItemType } from "@app/components/data_source_view/context/types";
 import {
   getMcpServerViewDescription,
   getMcpServerViewDisplayName,
@@ -30,6 +31,15 @@ import {
 import { isRemoteDatabase } from "@app/lib/data_sources";
 
 const tablesServer = [TABLE_QUERY_SERVER_NAME, TABLE_QUERY_V2_SERVER_NAME];
+
+function isRemoteDatabaseItem(item: DataSourceBuilderTreeItemType): boolean {
+  return (
+    (item.type === "data_source" &&
+      isRemoteDatabase(item.dataSourceView.dataSource)) ||
+    (item.type === "node" &&
+      isRemoteDatabase(item.node.dataSourceView.dataSource))
+  );
+}
 
 export function ProcessingMethodSection() {
   const { mcpServerViewsWithKnowledge, isMCPServerViewsLoading } =
@@ -69,13 +79,7 @@ export function ProcessingMethodSection() {
       return [null, false];
     }
 
-    const onlyRemote = sources.in.every(
-      (item) =>
-        (item.type === "data_source" &&
-          isRemoteDatabase(item.dataSourceView.dataSource)) ||
-        (item.type === "node" &&
-          isRemoteDatabase(item.node.dataSourceView.dataSource))
-    );
+    const onlyRemote = sources.in.every(isRemoteDatabaseItem);
     if (onlyRemote) {
       if (dataWarehouseServer) {
         return [[dataWarehouseServer, ...tablesQueryServers], false];
@@ -84,7 +88,9 @@ export function ProcessingMethodSection() {
     }
 
     const onlyTableQueries = sources.in.every(
-      (item) => item.type === "node" && item.node.type === "table"
+      (item) =>
+        (item.type === "node" && item.node.type === "table") ||
+        isRemoteDatabaseItem(item)
     );
     if (onlyTableQueries) {
       return [tablesQueryServers, false];

--- a/front/components/agent_builder/capabilities/shared/ProcessingMethodSection.tsx
+++ b/front/components/agent_builder/capabilities/shared/ProcessingMethodSection.tsx
@@ -10,6 +10,7 @@ import {
 import { useEffect, useMemo } from "react";
 import { useController, useWatch } from "react-hook-form";
 
+import type { MCPServerViewTypeWithLabel } from "@app/components/agent_builder/MCPServerViewsContext";
 import { useMCPServerViewsContext } from "@app/components/agent_builder/MCPServerViewsContext";
 import type { CapabilityFormData } from "@app/components/agent_builder/types";
 import {
@@ -22,10 +23,11 @@ import {
   isInternalAllowedIcon,
 } from "@app/lib/actions/mcp_icons";
 import {
-  SEARCH_SERVER_NAME,
+  DATA_WAREHOUSE_SERVER_NAME,
   TABLE_QUERY_SERVER_NAME,
   TABLE_QUERY_V2_SERVER_NAME,
 } from "@app/lib/actions/mcp_internal_actions/constants";
+import { isRemoteDatabase } from "@app/lib/data_sources";
 
 const tablesServer = [TABLE_QUERY_SERVER_NAME, TABLE_QUERY_V2_SERVER_NAME];
 
@@ -39,66 +41,86 @@ export function ProcessingMethodSection() {
   });
   const sources = useWatch<CapabilityFormData, "sources">({ name: "sources" });
 
-  const { hasOnlyTablesSelected, hasSomeTablesSelected } = useMemo(() => {
-    if (!sources?.in?.length) {
-      return { hasOnlyTablesSelected: false, hasSomeTablesSelected: false };
-    }
+  const dataWarehouseServer = useMemo(
+    () =>
+      mcpServerViewsWithKnowledge.find(
+        (serverView) =>
+          serverView.serverType === "internal" &&
+          serverView.server.name === DATA_WAREHOUSE_SERVER_NAME
+      ),
+    [mcpServerViewsWithKnowledge]
+  );
 
-    let tableCount = 0;
-    let totalCount = 0;
-
-    for (const item of sources.in) {
-      // Count all selectable items (nodes)
-      if (item.type === "node") {
-        totalCount++;
-        // Check if this node is a table
-        if (item.node?.type === "table") {
-          tableCount++;
-        }
-      }
-    }
-
-    return {
-      hasOnlyTablesSelected: totalCount > 0 && tableCount === totalCount,
-      hasSomeTablesSelected: tableCount > 0,
-    };
-  }, [sources]);
-
-  useEffect(() => {
-    const needsUpdate =
-      !mcpServerView ||
-      (hasOnlyTablesSelected &&
-        !tablesServer.includes(mcpServerView.server.name));
-
-    if (!needsUpdate) {
-      return;
-    }
-
-    if (hasOnlyTablesSelected) {
-      const tableServer = mcpServerViewsWithKnowledge.find(
+  const tablesQueryServers = useMemo(
+    () =>
+      mcpServerViewsWithKnowledge.filter(
         (serverView) =>
           serverView.serverType === "internal" &&
           tablesServer.includes(serverView.server.name)
-      );
-      if (tableServer) {
-        onChange(tableServer);
+      ),
+    [mcpServerViewsWithKnowledge]
+  );
+
+  const [serversToDisplay, displayWarningTableQuery] = useMemo((): [
+    MCPServerViewTypeWithLabel[] | null,
+    boolean,
+  ] => {
+    if (sources.in.length <= 0) {
+      return [null, false];
+    }
+
+    const onlyRemote = sources.in.every(
+      (item) =>
+        (item.type === "data_source" &&
+          isRemoteDatabase(item.dataSourceView.dataSource)) ||
+        (item.type === "node" &&
+          item.node.type === "folder" &&
+          isRemoteDatabase(item.node.dataSourceView.dataSource))
+    );
+    if (onlyRemote) {
+      if (dataWarehouseServer) {
+        return [[dataWarehouseServer], false];
       }
-    } else {
-      const searchServer = mcpServerViewsWithKnowledge.find(
+      return [tablesQueryServers, false];
+    }
+
+    const onlyTableQueries = sources.in.every(
+      (item) => item.type === "node" && item.node.type === "table"
+    );
+    if (onlyTableQueries) {
+      return [tablesQueryServers, false];
+    }
+
+    return [
+      mcpServerViewsWithKnowledge.filter(
         (serverView) =>
-          serverView.serverType === "internal" &&
-          serverView.server.name === SEARCH_SERVER_NAME
-      );
-      if (searchServer) {
-        onChange(searchServer);
+          serverView.server.name !== DATA_WAREHOUSE_SERVER_NAME &&
+          !tablesServer.includes(serverView.server.name)
+      ),
+      sources.in.some(
+        (item) =>
+          (item.type === "data_source" &&
+            isRemoteDatabase(item.dataSourceView.dataSource)) ||
+          (item.type === "node" &&
+            isRemoteDatabase(item.node.dataSourceView.dataSource)) ||
+          (item.type === "node" && item.node.type === "table")
+      ),
+    ];
+  }, [
+    dataWarehouseServer,
+    mcpServerViewsWithKnowledge,
+    sources.in,
+    tablesQueryServers,
+  ]);
+
+  useEffect(() => {
+    if (serversToDisplay) {
+      const [defaultServer] = serversToDisplay;
+      if (defaultServer) {
+        onChange(defaultServer);
       }
     }
-  }, [
-    hasOnlyTablesSelected,
-    mcpServerViewsWithKnowledge,
-    mcpServerView,
-    onChange,
-  ]);
+  }, [serversToDisplay, onChange]);
 
   return (
     <div className="space-y-4">
@@ -138,13 +160,8 @@ export function ProcessingMethodSection() {
         </DropdownMenuTrigger>
 
         <DropdownMenuContent align="start" className="max-w-100">
-          {mcpServerViewsWithKnowledge
-            .filter((view) =>
-              hasOnlyTablesSelected
-                ? tablesServer.includes(view.server.name)
-                : !tablesServer.includes(view.server.name)
-            )
-            .map((view) => (
+          {serversToDisplay &&
+            serversToDisplay.map((view) => (
               <DropdownMenuItem
                 key={view.id}
                 label={getMcpServerViewDisplayName(view)}
@@ -155,8 +172,11 @@ export function ProcessingMethodSection() {
             ))}
         </DropdownMenuContent>
       </DropdownMenu>
-      {!hasOnlyTablesSelected && hasSomeTablesSelected && (
-        <Chip color="info" size="sm" label=" Your tables will be ignored " />
+
+      {displayWarningTableQuery && (
+        <div>
+          <Chip color="info" size="sm" label=" Your tables will be ignored " />
+        </div>
       )}
     </div>
   );

--- a/front/components/agent_builder/capabilities/shared/ProcessingMethodSection.tsx
+++ b/front/components/agent_builder/capabilities/shared/ProcessingMethodSection.tsx
@@ -74,12 +74,11 @@ export function ProcessingMethodSection() {
         (item.type === "data_source" &&
           isRemoteDatabase(item.dataSourceView.dataSource)) ||
         (item.type === "node" &&
-          item.node.type === "folder" &&
           isRemoteDatabase(item.node.dataSourceView.dataSource))
     );
     if (onlyRemote) {
       if (dataWarehouseServer) {
-        return [[dataWarehouseServer], false];
+        return [[dataWarehouseServer, ...tablesQueryServers], false];
       }
       return [tablesQueryServers, false];
     }

--- a/front/components/agent_builder/capabilities/shared/ProcessingMethodSection.tsx
+++ b/front/components/agent_builder/capabilities/shared/ProcessingMethodSection.tsx
@@ -7,7 +7,7 @@ import {
   DropdownMenuTrigger,
   Hoverable,
 } from "@dust-tt/sparkle";
-import { useEffect, useMemo, useRef } from "react";
+import { useEffect, useMemo } from "react";
 import { useController, useFormContext, useWatch } from "react-hook-form";
 
 import type { MCPServerViewTypeWithLabel } from "@app/components/agent_builder/MCPServerViewsContext";
@@ -51,11 +51,6 @@ export function ProcessingMethodSection() {
   });
   const { setValue } = useFormContext<CapabilityFormData>();
   const sources = useWatch<CapabilityFormData, "sources">({ name: "sources" });
-
-  // Track previous sources.in to detect changes
-  const previousSourcesRef = useRef<DataSourceBuilderTreeItemType[]>(
-    sources.in
-  );
 
   const dataWarehouseServer = useMemo(
     () =>
@@ -125,9 +120,6 @@ export function ProcessingMethodSection() {
   ]);
 
   useEffect(() => {
-    // Check if sources.in has changed from previous render
-    const sourcesChanged = previousSourcesRef.current !== sources.in;
-
     // Check if current mcpServerView is not in the serversToDisplay list
     const currentServerNotInList =
       mcpServerView && serversToDisplay
@@ -136,11 +128,10 @@ export function ProcessingMethodSection() {
 
     // Update mcpServerView only in specific cases:
     // 1. mcpServerView is null
-    // 2. sources.in has changed from previous render
-    // 3. list of serversToDisplay doesn't include the current mcpServerView
+    // 2. list of serversToDisplay doesn't include the current mcpServerView
+    // Note: sources.in changes are automatically handled by the effect dependency array
     const shouldUpdate =
-      serversToDisplay &&
-      (mcpServerView === null || sourcesChanged || currentServerNotInList);
+      serversToDisplay && (mcpServerView === null || currentServerNotInList);
 
     if (shouldUpdate) {
       const [defaultServer] = serversToDisplay;
@@ -148,9 +139,6 @@ export function ProcessingMethodSection() {
         setValue("mcpServerView", defaultServer, { shouldDirty: false });
       }
     }
-
-    // Update the ref to track current sources.in for next render
-    previousSourcesRef.current = sources.in;
   }, [serversToDisplay, setValue, mcpServerView, sources.in]);
 
   return (

--- a/front/lib/actions/mcp_internal_actions/constants.ts
+++ b/front/lib/actions/mcp_internal_actions/constants.ts
@@ -46,6 +46,7 @@ export const DATA_WAREHOUSES_QUERY_TOOL_NAME = "query";
 export const SEARCH_SERVER_NAME = "search";
 export const TABLE_QUERY_SERVER_NAME = "query_tables";
 export const TABLE_QUERY_V2_SERVER_NAME = "query_tables_v2";
+export const DATA_WAREHOUSE_SERVER_NAME = "data_warehouses";
 
 export const AVAILABLE_INTERNAL_MCP_SERVER_NAMES = [
   // Note:
@@ -57,7 +58,7 @@ export const AVAILABLE_INTERNAL_MCP_SERVER_NAMES = [
   "agent_router",
   "conversation_files",
   "data_sources_file_system",
-  "data_warehouses",
+  DATA_WAREHOUSE_SERVER_NAME,
   "extract_data",
   "file_generation",
   "freshservice",
@@ -991,7 +992,7 @@ The directive should be used to display a clickable version of the agent name in
       instructions: null,
     },
   },
-  data_warehouses: {
+  [DATA_WAREHOUSE_SERVER_NAME]: {
     id: 1012,
     availability: "auto",
     allowMultipleInstances: false,
@@ -1002,7 +1003,7 @@ The directive should be used to display a clickable version of the agent name in
     tools_stakes: undefined,
     timeoutMs: undefined,
     serverInfo: {
-      name: "data_warehouses",
+      name: DATA_WAREHOUSE_SERVER_NAME,
       version: "1.0.0",
       description:
         "Comprehensive tables navigation toolkit for browsing data warehouses and tables. Provides Unix-like " +


### PR DESCRIPTION
## Description
- Put back the `useMemo` from this PR https://github.com/dust-tt/dust/pull/15384
- Update the logic on why we should update the selected tools.
- Split `KnowledgeConfigurationSheet` form into `KnowledgeConfigurationSheetForm` to make sure we unmount the form when closing the MultiPageSheet, it clean the reset of the form, and clean a processing method glitch when closing the sheet.
- Fix saving data_warehouse and query_tables_v2 tools
- Fix missing description for data_warehouse and query_tables_v2.

## Tests
- Locally
- Front-edge

## Risk
- Low, but can be reverted and behind a FF

## Deploy Plan
- Deploy front
