### PR TITLE
Remove hardcoded mcp provider for remote mcp server

### DIFF
--- a/front/lib/actions/mcp_authentication.ts
+++ b/front/lib/actions/mcp_authentication.ts
@@ -47,7 +47,7 @@ export async function getConnectionForMCPServer(
       );
     }
   } else {
-    logger.warn(
+    logger.info(
       {
         workspaceId: auth.getNonNullableWorkspace().sId,
         mcpServerId,

--- a/front/lib/actions/mcp_metadata.ts
+++ b/front/lib/actions/mcp_metadata.ts
@@ -300,7 +300,7 @@ export const connectToMCPServer = async (
                 return new Err(
                   new MCPServerPersonalAuthenticationRequiredError(
                     params.mcpServerId,
-                    "mcp"
+                    remoteMCPServer.authorization.provider
                   )
                 );
               } else {

--- a/front/pages/api/w/[wId]/mcp/index.ts
+++ b/front/pages/api/w/[wId]/mcp/index.ts
@@ -145,7 +145,7 @@ async function handler(
           if (token.isOk()) {
             bearerToken = token.value.access_token;
             authorization = {
-              provider: "mcp",
+              provider: token.value.connection.provider,
               supported_use_cases: ["platform_actions", "personal_actions"],
             };
           } else {


### PR DESCRIPTION
## Description

Now we can have mcp or mcp_static and it's required to be correct otherwise we cannot retrieve the metadata from the admin.

## Tests

Locally

## Risk

Low

## Deploy Plan

Deploy front