### PR TITLE
[front] Remove ability to create `sId`s from `MCPActionType`

### DIFF
--- a/front/lib/actions/mcp.ts
+++ b/front/lib/actions/mcp.ts
@@ -390,25 +390,7 @@ export class MCPActionType {
     };
   }
 
-  getSId(owner: LightWorkspaceType): string {
-    return MCPActionType.modelIdToSId({
-      id: this.id,
-      workspaceId: owner.id,
-    });
-  }
 
-  static modelIdToSId({
-    id,
-    workspaceId,
-  }: {
-    id: ModelId;
-    workspaceId: ModelId;
-  }): string {
-    return makeSId("mcp_action", {
-      id,
-      workspaceId,
-    });
-  }
 }
 
 const MAX_DESCRIPTION_LENGTH = 1024;

--- a/front/lib/actions/mcp.ts
+++ b/front/lib/actions/mcp.ts
@@ -50,7 +50,7 @@ import type { Authenticator } from "@app/lib/auth";
 import type { AdditionalConfigurationType } from "@app/lib/models/assistant/actions/mcp";
 import { AgentMCPActionOutputItem } from "@app/lib/models/assistant/actions/mcp";
 import { AgentMCPActionResource } from "@app/lib/resources/agent_mcp_action_resource";
-import { getResourceIdFromSId, makeSId } from "@app/lib/resources/string_ids";
+import { getResourceIdFromSId } from "@app/lib/resources/string_ids";
 import logger from "@app/logger/logger";
 import { statsDClient } from "@app/logger/statsDClient";
 import type {
@@ -60,7 +60,6 @@ import type {
   DustAppRunConfigurationType,
   FunctionCallType,
   FunctionMessageTypeModel,
-  LightWorkspaceType,
   ModelConfigurationType,
   ModelId,
   PersonalAuthenticationRequiredErrorContent,
@@ -389,8 +388,6 @@ export class MCPActionType {
       content: output,
     };
   }
-
-
 }
 
 const MAX_DESCRIPTION_LENGTH = 1024;

--- a/front/lib/resources/agent_mcp_action_resource.ts
+++ b/front/lib/resources/agent_mcp_action_resource.ts
@@ -405,7 +405,7 @@ export class AgentMCPActionResource extends BaseResource<AgentMCPActionModel> {
     });
   }
 
-  private static modelIdToSId({
+  static modelIdToSId({
     id,
     workspaceId,
   }: {

--- a/front/lib/resources/agent_step_content_resource.ts
+++ b/front/lib/resources/agent_step_content_resource.ts
@@ -25,6 +25,7 @@ import {
   ConversationModel,
   Message,
 } from "@app/lib/models/assistant/conversation";
+import { AgentMCPActionResource } from "@app/lib/resources/agent_mcp_action_resource";
 import { BaseResource } from "@app/lib/resources/base_resource";
 import { FileResource } from "@app/lib/resources/file_resource";
 import { FileModel } from "@app/lib/resources/storage/models/files";
@@ -549,7 +550,7 @@ export class AgentStepContentResource extends BaseResource<AgentStepContentModel
         );
 
         return {
-          sId: MCPActionType.modelIdToSId({
+          sId: AgentMCPActionResource.modelIdToSId({
             id: action.id,
             workspaceId: action.workspaceId,
           }),

--- a/front/temporal/agent_loop/lib/create_tool_actions.ts
+++ b/front/temporal/agent_loop/lib/create_tool_actions.ts
@@ -216,7 +216,7 @@ async function createActionForTool(
             configurationId: agentConfiguration.sId,
             messageId: agentMessage.sId,
             conversationId,
-            actionId: mcpAction.getSId(auth.getNonNullableWorkspace()),
+            actionId: agentMCPAction.sId,
             inputs: mcpAction.params,
             stake: actionConfiguration.permission,
             metadata: {


### PR DESCRIPTION
## Description

- Part of https://github.com/dust-tt/tasks/issues/3586, more specifically part of an effort to remove `MCPActionType` and replace with the resource.
- This PR removes the methods relative to `sId`s from `MCPActionType`, using the resources instead.

## Tests

- Tested locally a simple run that uses tools.

## Risk

- Low.

## Deploy Plan

- Deploy front.
