### PR TITLE
[front] redirect to the homepage when there is no opener

### DIFF
--- a/front/pages/oauth/[provider]/finalize.tsx
+++ b/front/pages/oauth/[provider]/finalize.tsx
@@ -1,5 +1,5 @@
 import type { InferGetServerSidePropsType } from "next";
-import { useEffect, useState } from "react";
+import { useEffect } from "react";
 
 import { makeGetServerSidePropsRequirementsWrapper } from "@app/lib/iam/session";
 import { useFinalize } from "@app/lib/swr/oauth";

--- a/front/pages/oauth/[provider]/finalize.tsx
+++ b/front/pages/oauth/[provider]/finalize.tsx
@@ -33,16 +33,15 @@ export default function Finalize({
   queryParams,
   provider,
 }: InferGetServerSidePropsType<typeof getServerSideProps>) {
-  const [error, setError] = useState<string | null>(null);
   const doFinalize = useFinalize();
   // Finalize the connection on component mount.
   useEffect(() => {
     async function finalizeOAuth() {
+      // You can end up here when you directly edit the configuration
+      // (e.g. go to GitHub and configure repositories from Dust App in Settings, hence no opener).
+      // We cannot really do anything here, so we simply redirect to Dust homepage.
       if (!window.opener) {
-        setError(
-          "This URL was unexpectedly visited outside of the Dust Connections setup flow. " +
-            "Please close this window and try again from Dust."
-        );
+        window.location.href = window.location.origin;
       } else {
         const res = await doFinalize(provider, queryParams);
         // Send a message `connection_finalized` to the window that opened
@@ -69,5 +68,5 @@ export default function Finalize({
     void finalizeOAuth();
   }, [queryParams, provider, doFinalize]);
 
-  return error ? <p>{error}</p> : null; // Render nothing.
+  return null; // Render nothing.
 }


### PR DESCRIPTION
## Description
This PR is to fix [this task](https://github.com/dust-tt/tasks/issues/3823). We currently show an error message when there is no opener but you can go to the configuration page directly from GitHub (and not via Dust). In this case there will be no query params and no opener, and we show an error message even though it's successful. 

Since we cannot tell if it's a success or failure, and how a user landed in the page, we simply redirect to `window.location.origin` which will be `dust.tt`.  

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
