### PR TITLE
[front] show expire state and resend button for invitation 

### DIFF
--- a/front/components/members/EditInvitationModal.tsx
+++ b/front/components/members/EditInvitationModal.tsx
@@ -16,7 +16,6 @@ import { ConfirmContext } from "@app/components/Confirm";
 import { ROLES_DATA } from "@app/components/members/Roles";
 import { RoleDropDown } from "@app/components/members/RolesDropDown";
 import { useSendNotification } from "@app/hooks/useNotification";
-import { INVITATION_EXPIRATION_TIME_SEC } from "@app/lib/constants/invitation";
 import { sendInvitations, updateInvitation } from "@app/lib/invitations";
 import { useProvisioningStatus } from "@app/lib/swr/workos";
 import type {
@@ -25,11 +24,7 @@ import type {
   WorkspaceType,
 } from "@app/types";
 
-function isInvitationExpired(createdAt: number): boolean {
-  const now = Date.now();
-  const expirationTime = createdAt + INVITATION_EXPIRATION_TIME_SEC * 1000;
-  return now > expirationTime;
-}
+import { isInvitationExpired } from "./utils";
 
 export function EditInvitationModal({
   owner,

--- a/front/components/members/EditInvitationModal.tsx
+++ b/front/components/members/EditInvitationModal.tsx
@@ -16,6 +16,7 @@ import { ConfirmContext } from "@app/components/Confirm";
 import { ROLES_DATA } from "@app/components/members/Roles";
 import { RoleDropDown } from "@app/components/members/RolesDropDown";
 import { useSendNotification } from "@app/hooks/useNotification";
+import { INVITATION_EXPIRATION_TIME_SEC } from "@app/lib/constants/invitation";
 import { sendInvitations, updateInvitation } from "@app/lib/invitations";
 import { useProvisioningStatus } from "@app/lib/swr/workos";
 import type {
@@ -23,6 +24,12 @@ import type {
   MembershipInvitationType,
   WorkspaceType,
 } from "@app/types";
+
+function isInvitationExpired(createdAt: number): boolean {
+  const now = Date.now();
+  const expirationTime = createdAt + INVITATION_EXPIRATION_TIME_SEC * 1000;
+  return now > expirationTime;
+}
 
 export function EditInvitationModal({
   owner,
@@ -91,6 +98,9 @@ export function EditInvitationModal({
                 <div className="text-muted-foreground dark:text-muted-foreground-night">
                   Invitation sent on{" "}
                   {new Date(invitation.createdAt).toLocaleDateString()}
+                  {isInvitationExpired(invitation.createdAt) && (
+                    <span className="ml-2 text-red-500">(expired)</span>
+                  )}
                 </div>
               </div>
 

--- a/front/components/members/InvitationsList.tsx
+++ b/front/components/members/InvitationsList.tsx
@@ -14,21 +14,15 @@ import React, { useMemo, useState } from "react";
 import { EditInvitationModal } from "@app/components/members/EditInvitationModal";
 import { displayRole, ROLES_DATA } from "@app/components/members/Roles";
 import { useSendNotification } from "@app/hooks/useNotification";
-import { INVITATION_EXPIRATION_TIME_SEC } from "@app/lib/constants/invitation";
 import { sendInvitations } from "@app/lib/invitations";
 import { useWorkspaceInvitations } from "@app/lib/swr/memberships";
 import type { MembershipInvitationType, WorkspaceType } from "@app/types";
 
+import { isInvitationExpired } from "./utils";
+
 type RowData = MembershipInvitationType & {
   onClick: () => void;
 };
-
-function isInvitationExpired(createdAt: number): boolean {
-  const now = Date.now();
-  // createdAt is in milliseconds but INVITATION_EXPIRATION_TIME_SEC is in seconds
-  const expirationTime = createdAt + INVITATION_EXPIRATION_TIME_SEC * 1000;
-  return now > expirationTime;
-}
 
 export function InvitationsList({
   owner,

--- a/front/components/members/InvitationsList.tsx
+++ b/front/components/members/InvitationsList.tsx
@@ -80,7 +80,7 @@ export function InvitationsList({
                   <span className="text-red-500">(expired)</span>
                   <Button
                     size="xs"
-                    variant="primary"
+                    variant="outline"
                     icon={MovingMailIcon}
                     label="Resend"
                     onClick={async (e: React.MouseEvent) => {

--- a/front/components/members/utils.ts
+++ b/front/components/members/utils.ts
@@ -1,0 +1,7 @@
+import { INVITATION_EXPIRATION_TIME_SEC } from "@app/lib/constants/invitation";
+
+export function isInvitationExpired(createdAt: number): boolean {
+  const now = Date.now();
+  const expirationTime = createdAt + INVITATION_EXPIRATION_TIME_SEC * 1000;
+  return now > expirationTime;
+}

--- a/front/lib/api/invitation.ts
+++ b/front/lib/api/invitation.ts
@@ -10,6 +10,7 @@ import {
   getWorkspaceAdministrationVersionLock,
 } from "@app/lib/api/workspace";
 import type { Authenticator } from "@app/lib/auth";
+import { INVITATION_EXPIRATION_TIME_SEC } from "@app/lib/constants/invitation";
 import { MAX_UNCONSUMED_INVITATIONS_PER_WORKSPACE_PER_DAY } from "@app/lib/invitations";
 import { MembershipInvitationModel } from "@app/lib/models/membership_invitation";
 import { MembershipResource } from "@app/lib/resources/membership_resource";
@@ -29,9 +30,6 @@ import type {
   WorkspaceType,
 } from "@app/types";
 import { Err, Ok, sanitizeString } from "@app/types";
-
-// Make token expires after 7 days
-const INVITATION_EXPIRATION_TIME_SEC = 60 * 60 * 24 * 7;
 
 function typeFromModel(
   invitation: MembershipInvitationModel

--- a/front/lib/constants/invitation.ts
+++ b/front/lib/constants/invitation.ts
@@ -1,0 +1,3 @@
+
+// Make token expires after 7 days
+export const INVITATION_EXPIRATION_TIME_SEC = 60 * 60 * 24 * 7;

--- a/front/lib/constants/invitation.ts
+++ b/front/lib/constants/invitation.ts
@@ -1,3 +1,2 @@
-
 // Make token expires after 7 days
 export const INVITATION_EXPIRATION_TIME_SEC = 60 * 60 * 24 * 7;


### PR DESCRIPTION
## Description
This PR is to fix [this task](https://github.com/dust-tt/tasks/issues/3923), show an expired text and resend button in the invitation table. Right now we don't show any message even if an invitation is expired. We cannot check invitation `status` since it won't be updated when it's expired, so we manually compute if it's expired or not in frontend. 

<img width="890" height="319" alt="Screenshot 2025-08-27 at 13 14 55" src="https://github.com/user-attachments/assets/07b09b0f-3de4-4df4-afe8-acb10e08fe23" />

<img width="450" height="371" alt="Screenshot 2025-08-27 at 13 15 06" src="https://github.com/user-attachments/assets/744737ec-7edb-433c-af47-72e8565f354b" />

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
