### PR TITLE
Ensure action is blocked when being validated

### DIFF
--- a/front/lib/api/assistant/conversation/validate_actions.ts
+++ b/front/lib/api/assistant/conversation/validate_actions.ts
@@ -8,7 +8,6 @@ import {
   isMCPApproveExecutionEvent,
   updateMCPApprovalState,
 } from "@app/lib/actions/mcp";
-import { isToolExecutionStatusBlocked } from "@app/lib/actions/statuses";
 import { runAgentLoop } from "@app/lib/api/assistant/agent";
 import { getMessageChannelId } from "@app/lib/api/assistant/streaming/helpers";
 import { getRedisHybridManager } from "@app/lib/api/redis-hybrid-manager";
@@ -110,12 +109,8 @@ export async function validateAction(
     );
   }
 
-  if (!isToolExecutionStatusBlocked(action.status)) {
-    return new Err(
-      new Error(
-        `Action is not blocked: ${action.status} for action ${actionId}`
-      )
-    );
+  if (action.status !== "blocked_validation_required") {
+    return new Err(new Error(`Action is not blocked: ${action.status}`));
   }
 
   const actionUpdated = await updateMCPApprovalState(

--- a/front/lib/api/assistant/conversation/validate_actions.ts
+++ b/front/lib/api/assistant/conversation/validate_actions.ts
@@ -8,6 +8,7 @@ import {
   isMCPApproveExecutionEvent,
   updateMCPApprovalState,
 } from "@app/lib/actions/mcp";
+import { isToolExecutionStatusBlocked } from "@app/lib/actions/statuses";
 import { runAgentLoop } from "@app/lib/api/assistant/agent";
 import { getMessageChannelId } from "@app/lib/api/assistant/streaming/helpers";
 import { getRedisHybridManager } from "@app/lib/api/redis-hybrid-manager";
@@ -106,6 +107,14 @@ export async function validateAction(
   if (!agentStepContent) {
     return new Err(
       new Error(`Agent step content not found: ${action.stepContentId}`)
+    );
+  }
+
+  if (!isToolExecutionStatusBlocked(action.status)) {
+    return new Err(
+      new Error(
+        `Action is not blocked: ${action.status} for action ${actionId}`
+      )
     );
   }
 

--- a/front/temporal/agent_loop/activities/run_model_and_create_actions_wrapper.ts
+++ b/front/temporal/agent_loop/activities/run_model_and_create_actions_wrapper.ts
@@ -172,6 +172,7 @@ async function getExistingActionsAndBlobs(
       if (!isToolExecutionStatusFinal(mcpAction.status)) {
         actionBlobs.push({
           actionId: mcpAction.id,
+          actionStatus: mcpAction.status,
           needsApproval: mcpAction.status === "blocked_validation_required",
         });
       }

--- a/front/temporal/agent_loop/lib/create_tool_actions.ts
+++ b/front/temporal/agent_loop/lib/create_tool_actions.ts
@@ -5,6 +5,7 @@ import type {
 import { createMCPAction } from "@app/lib/actions/mcp";
 import { getAugmentedInputs } from "@app/lib/actions/mcp_execution";
 import { validateToolInputs } from "@app/lib/actions/mcp_utils";
+import type { ToolExecutionStatus } from "@app/lib/actions/statuses";
 import type { StepContext } from "@app/lib/actions/types";
 import { getExecutionStatusFromConfig } from "@app/lib/actions/utils";
 import type { Authenticator } from "@app/lib/auth";
@@ -21,6 +22,7 @@ import type { RunAgentExecutionData } from "@app/types/assistant/agent_run";
 
 export interface ActionBlob {
   actionId: ModelId;
+  actionStatus: ToolExecutionStatus;
   needsApproval: boolean;
 }
 
@@ -206,6 +208,7 @@ async function createActionForTool(
   return {
     actionBlob: {
       actionId: agentMCPAction.id,
+      actionStatus: status,
       needsApproval: status === "blocked_validation_required",
     },
     approvalEventData:


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
See thread: https://dust4ai.slack.com/archives/C092U6ATV2Q/p1756289100974459.

With the recent status changes on the tool execution, the validate endpoint was not updated to ensure the action is actually blocked.

It also adds the status to the action blob so we can easily debug next occurrences of an action running twice. 

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
