### PR TITLE
[front] Pass conversation files to sub agents

### DIFF
--- a/front/lib/actions/mcp_internal_actions/servers/run_agent/conversation.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/run_agent/conversation.ts
@@ -27,7 +27,7 @@ export async function getOrCreateConversation(
     mainConversation,
     query,
     toolsetsToAdd,
-    filesToAdd,
+    fileOrContentFragmentIds,
   }: {
     childAgentBlob: ChildAgentBlob;
     childAgentId: string;
@@ -35,7 +35,7 @@ export async function getOrCreateConversation(
     mainConversation: ConversationType;
     query: string;
     toolsetsToAdd: string[] | null;
-    filesToAdd: string[] | null;
+    fileOrContentFragmentIds: string[] | null;
   }
 ): Promise<
   Result<
@@ -68,13 +68,13 @@ export async function getOrCreateConversation(
 
   const contentFragments: PublicPostContentFragmentRequestBody[] = [];
 
-  if (filesToAdd) {
+  if (fileOrContentFragmentIds) {
     // Get all files from the current conversation and filter which one to pass to the sub agent
     const attachments = listAttachments(mainConversation);
     for (const attachment of attachments) {
       if (
         isFileAttachmentType(attachment) &&
-        filesToAdd?.includes(attachment.fileId)
+        fileOrContentFragmentIds?.includes(attachment.fileId)
       ) {
         // Convert file attachment to content fragment
         contentFragments.push({
@@ -85,7 +85,7 @@ export async function getOrCreateConversation(
         });
       } else if (
         isContentNodeAttachmentType(attachment) &&
-        filesToAdd?.includes(attachment.contentFragmentId)
+        fileOrContentFragmentIds?.includes(attachment.contentFragmentId)
       ) {
         // Convert content node attachment to content fragment
         contentFragments.push({

--- a/front/lib/actions/mcp_internal_actions/servers/run_agent/index.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/run_agent/index.ts
@@ -184,11 +184,18 @@ export default async function createServer(
         )
         .optional()
         .nullable(),
+      filesToAdd: z
+        .array(z.string().regex(new RegExp(`^[_\\w]+$`)))
+        .describe(
+          "The filesId of the files to pass to the agent conversation. If the file is a content node, use the contentFragmentId instead."
+        )
+        .optional()
+        .nullable(),
       childAgent:
         ConfigurableToolInputSchemas[INTERNAL_MIME_TYPES.TOOL_INPUT.AGENT],
     },
     async (
-      { query, childAgent: { uri }, toolsetsToAdd },
+      { query, childAgent: { uri }, toolsetsToAdd, filesToAdd },
       { sendNotification, _meta }
     ) => {
       assert(
@@ -233,6 +240,7 @@ export default async function createServer(
           mainConversation,
           query,
           toolsetsToAdd: toolsetsToAdd ?? null,
+          filesToAdd: filesToAdd ?? null,
         }
       );
 

--- a/front/lib/actions/mcp_internal_actions/servers/run_agent/index.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/run_agent/index.ts
@@ -184,7 +184,7 @@ export default async function createServer(
         )
         .optional()
         .nullable(),
-      filesToAdd: z
+      fileOrContentFragmentIds: z
         .array(z.string().regex(new RegExp(`^[_\\w]+$`)))
         .describe(
           "The filesId of the files to pass to the agent conversation. If the file is a content node, use the contentFragmentId instead."
@@ -195,7 +195,7 @@ export default async function createServer(
         ConfigurableToolInputSchemas[INTERNAL_MIME_TYPES.TOOL_INPUT.AGENT],
     },
     async (
-      { query, childAgent: { uri }, toolsetsToAdd, filesToAdd },
+      { query, childAgent: { uri }, toolsetsToAdd, fileOrContentFragmentIds },
       { sendNotification, _meta }
     ) => {
       assert(
@@ -240,7 +240,7 @@ export default async function createServer(
           mainConversation,
           query,
           toolsetsToAdd: toolsetsToAdd ?? null,
-          filesToAdd: filesToAdd ?? null,
+          fileOrContentFragmentIds: fileOrContentFragmentIds ?? null,
         }
       );
 


### PR DESCRIPTION
fixes: https://github.com/dust-tt/tasks/issues/3773

## Description

Add all existing files to the conversation of subagent

## Tests

Locally, with uploaded and generated files.
Tested query table in sub agents on files in main convo

## Risk

none

## Deploy Plan

deploy front
