### PR TITLE
[connectors] Fix sub agent tool validation in Slack bot answers

### DIFF
--- a/connectors/src/connectors/slack/chat/stream_conversation_handler.ts
+++ b/connectors/src/connectors/slack/chat/stream_conversation_handler.ts
@@ -210,6 +210,7 @@ async function streamAgentAnswerToSlack(
           {
             connectorId: connector.id,
             conversationId: conversation.sId,
+            eventConversationId: event.conversationId,
             messageId: event.messageId,
             actionId: event.actionId,
             toolName: event.metadata.toolName,
@@ -220,7 +221,7 @@ async function streamAgentAnswerToSlack(
 
         const blockId = SlackBlockIdToolValidationSchema.encode({
           workspaceId: connector.workspaceId,
-          conversationId: conversation.sId,
+          conversationId: event.conversationId,
           messageId: event.messageId,
           actionId: event.actionId,
           slackThreadTs: mainMessage.message?.thread_ts,


### PR DESCRIPTION
## Description

- Currently, validating a tool execution from a sub agent in Slack validates on the main agent's conversation instead of the sub agent's.
- This PR fixes that by taking the conversation from the event, similarly to what we do in the webapp's front-end in `useValidateAction`.

## Tests

## Risk

## Deploy Plan

- Deploy connectors.
