### PR TITLE
[front] - chore(AB v2): first round of feedback

### DIFF
--- a/front/components/agent_builder/capabilities/AgentBuilderCapabilitiesBlock.tsx
+++ b/front/components/agent_builder/capabilities/AgentBuilderCapabilitiesBlock.tsx
@@ -9,7 +9,6 @@ import {
   ContentMessage,
   EmptyCTA,
   Hoverable,
-  ListAddIcon,
   Spinner,
   XMarkIcon,
 } from "@dust-tt/sparkle";
@@ -259,8 +258,8 @@ export function AgentBuilderCapabilitiesBlock({
         type="button"
         onClick={() => setDialogMode({ type: "add" })}
         label="Add tools"
-        icon={ListAddIcon}
-        variant="outline"
+        icon={BoltIcon}
+        variant="primary"
       />
     </div>
   );
@@ -305,7 +304,7 @@ export function AgentBuilderCapabilitiesBlock({
                   onClick={() => setDialogMode({ type: "add" })}
                   label="Add tools"
                   icon={BoltIcon}
-                  variant="outline"
+                  variant="primary"
                 />
               </div>
             }

--- a/front/components/agent_builder/capabilities/AgentBuilderCapabilitiesBlock.tsx
+++ b/front/components/agent_builder/capabilities/AgentBuilderCapabilitiesBlock.tsx
@@ -259,7 +259,7 @@ export function AgentBuilderCapabilitiesBlock({
         onClick={() => setDialogMode({ type: "add" })}
         label="Add tools"
         icon={BoltIcon}
-        variant="primary"
+        variant="outline"
       />
     </div>
   );
@@ -304,7 +304,7 @@ export function AgentBuilderCapabilitiesBlock({
                   onClick={() => setDialogMode({ type: "add" })}
                   label="Add tools"
                   icon={BoltIcon}
-                  variant="primary"
+                  variant="outline"
                 />
               </div>
             }

--- a/front/components/agent_builder/capabilities/knowledge/DataSourceBuilderSelector.tsx
+++ b/front/components/agent_builder/capabilities/knowledge/DataSourceBuilderSelector.tsx
@@ -134,7 +134,7 @@ export const DataSourceBuilderSelector = ({
 
   return (
     <div className="relative flex h-full flex-1 flex-col gap-4">
-      {breadcrumbItems.length > 0 && <Breadcrumbs items={breadcrumbItems} />}
+      {breadcrumbItems.length > 1 && <Breadcrumbs items={breadcrumbItems} />}
 
       {currentNavigationEntry.type === "root" ? (
         <DataSourceSpaceSelector spaces={filteredSpaces} />
@@ -170,7 +170,7 @@ function getBreadcrumbConfig(
   switch (entry.type) {
     case "root":
       return {
-        label: "Knowledge",
+        label: "Spaces",
       };
     case "space":
       return {

--- a/front/components/agent_builder/capabilities/knowledge/KnowledgeConfigurationSheet.tsx
+++ b/front/components/agent_builder/capabilities/knowledge/KnowledgeConfigurationSheet.tsx
@@ -1,5 +1,9 @@
 import type { MultiPageSheetPage } from "@dust-tt/sparkle";
-import { MultiPageSheet, MultiPageSheetContent } from "@dust-tt/sparkle";
+import {
+  Avatar,
+  MultiPageSheet,
+  MultiPageSheetContent,
+} from "@dust-tt/sparkle";
 import { zodResolver } from "@hookform/resolvers/zod";
 import uniqueId from "lodash/uniqueId";
 import { useContext, useEffect, useMemo, useState } from "react";
@@ -346,7 +350,9 @@ function KnowledgeConfigurationSheetContent({
       description:
         config?.configPageDescription ||
         "Select knowledge type and configure settings",
-      icon: config?.icon,
+      icon: config?.icon
+        ? () => <Avatar icon={config.icon} size="md" className="mr-2" />
+        : undefined,
       content: (
         <div className="space-y-6">
           <SelectDataSourcesFilters />

--- a/front/components/agent_builder/capabilities/shared/ProcessingMethodSection.tsx
+++ b/front/components/agent_builder/capabilities/shared/ProcessingMethodSection.tsx
@@ -125,6 +125,7 @@ export function ProcessingMethodSection() {
                 : undefined
             }
             variant="outline"
+            isSelect
           />
         </DropdownMenuTrigger>
 

--- a/front/components/agent_builder/capabilities/shared/ProcessingMethodSection.tsx
+++ b/front/components/agent_builder/capabilities/shared/ProcessingMethodSection.tsx
@@ -5,6 +5,7 @@ import {
   DropdownMenuContent,
   DropdownMenuItem,
   DropdownMenuTrigger,
+  Hoverable,
 } from "@dust-tt/sparkle";
 import { useEffect, useMemo } from "react";
 import { useController, useWatch } from "react-hook-form";
@@ -105,7 +106,14 @@ export function ProcessingMethodSection() {
         <h3 className="mb-2 text-lg font-semibold">Processing method</h3>
         <span className="text-sm text-muted-foreground dark:text-muted-foreground-night">
           Sets the approach for finding and retrieving information from your
-          data sources. Need help? Check our guide.
+          data sources. Need help? Check our{" "}
+          <Hoverable
+            href="https://docs.dust.tt/docs/knowledge"
+            variant="primary"
+          >
+            guide
+          </Hoverable>
+          .
         </span>
       </div>
 

--- a/front/components/agent_builder/capabilities/shared/SelectDataSourcesFilters.tsx
+++ b/front/components/agent_builder/capabilities/shared/SelectDataSourcesFilters.tsx
@@ -9,6 +9,7 @@ import {
 } from "@dust-tt/sparkle";
 import { useWatch } from "react-hook-form";
 
+import { useSpacesContext } from "@app/components/agent_builder/SpacesContext";
 import { DataSourceViewTagsFilterDropdown } from "@app/components/agent_builder/capabilities/shared/DataSourceViewTagsFilterDropdown";
 import type { CapabilityFormData } from "@app/components/agent_builder/types";
 import { CONFIGURATION_SHEET_PAGE_IDS } from "@app/components/agent_builder/types";

--- a/front/components/agent_builder/capabilities/shared/SelectDataSourcesFilters.tsx
+++ b/front/components/agent_builder/capabilities/shared/SelectDataSourcesFilters.tsx
@@ -9,8 +9,8 @@ import {
 } from "@dust-tt/sparkle";
 import { useWatch } from "react-hook-form";
 
-import { useSpacesContext } from "@app/components/agent_builder/SpacesContext";
 import { DataSourceViewTagsFilterDropdown } from "@app/components/agent_builder/capabilities/shared/DataSourceViewTagsFilterDropdown";
+import { useSpacesContext } from "@app/components/agent_builder/SpacesContext";
 import type { CapabilityFormData } from "@app/components/agent_builder/types";
 import { CONFIGURATION_SHEET_PAGE_IDS } from "@app/components/agent_builder/types";
 import { useDataSourceBuilderContext } from "@app/components/data_source_view/context/DataSourceBuilderContext";
@@ -33,6 +33,9 @@ function DataSourceFilterContextItem({
 }: DataSourceFilterContextItemProps) {
   const { isDark } = useTheme();
   const { toggleTagsMode } = useDataSourceBuilderContext();
+  const { spaces } = useSpacesContext();
+
+  const spaceName = spaces.find((s) => s.sId === dataSourceView.spaceId)?.name;
 
   return (
     <ContextItem
@@ -46,6 +49,7 @@ function DataSourceFilterContextItem({
           })}
         />
       }
+      subElement={spaceName && <span className="text-xs">{spaceName}</span>}
       action={
         <PopoverRoot>
           <PopoverTrigger asChild>

--- a/front/components/agent_builder/triggers/AgentBuilderTriggersBlock.tsx
+++ b/front/components/agent_builder/triggers/AgentBuilderTriggersBlock.tsx
@@ -95,7 +95,7 @@ export function AgentBuilderTriggersBlock({
         triggers.length > 0 && (
           <Button
             label="Add Schedule"
-            variant="primary"
+            variant="outline"
             icon={ClockIcon}
             onClick={handleCreateTrigger}
             type="button"
@@ -113,7 +113,7 @@ export function AgentBuilderTriggersBlock({
             action={
               <Button
                 label="Add Schedule"
-                variant="primary"
+                variant="outline"
                 icon={ClockIcon}
                 onClick={handleCreateTrigger}
                 type="button"

--- a/front/components/data_source_view/context/utils.ts
+++ b/front/components/data_source_view/context/utils.ts
@@ -297,6 +297,26 @@ export function getLatestNodeFromNavigationHistory(
   return null;
 }
 
+export function getSpaceNameFromTreeItem(
+  item: DataSourceBuilderTreeItemType,
+  spaces: SpaceType[]
+): string | null {
+  // Direct space access if the item is a space type
+  if (item.type === "space") {
+    return item.space.name;
+  }
+
+  // For other types, extract space ID from path structure
+  const pathParts = item.path.split("/");
+  if (pathParts.length > 1) {
+    const spaceId = pathParts[1];
+    const space = spaces.find((s) => s.sId === spaceId);
+    return space?.name ?? null;
+  }
+
+  return null;
+}
+
 export function getVisualForTreeItem(
   item: DataSourceBuilderTreeItemType,
   isDark = false

--- a/front/hooks/useNodePath.ts
+++ b/front/hooks/useNodePath.ts
@@ -8,20 +8,20 @@ export function useNodePath({
   owner,
   disabled = false,
 }: {
-  node: DataSourceViewContentNode;
+  node?: DataSourceViewContentNode;
   owner: LightWorkspaceType;
   disabled?: boolean;
 }) {
   const { nodes: parentNodes, isNodesLoading } = useDataSourceViewContentNodes({
     owner,
-    dataSourceView: node.dataSourceView,
-    internalIds: node.parentInternalIds ?? [],
+    dataSourceView: node?.dataSourceView,
+    internalIds: node?.parentInternalIds ?? [],
     viewType: "all",
-    disabled: disabled || !node.parentInternalIds?.length,
+    disabled: disabled || !node || !node.parentInternalIds?.length,
   });
 
   const fullPath = useMemo(() => {
-    if (disabled || !node.parentInternalIds?.length) {
+    if (disabled || !node || !node.parentInternalIds?.length) {
       return [];
     }
 
@@ -36,7 +36,7 @@ export function useNodePath({
       .reverse();
 
     return sortedParentNodes;
-  }, [disabled, node.parentInternalIds, isNodesLoading, parentNodes]);
+  }, [disabled, node, isNodesLoading, parentNodes]);
 
   return {
     fullPath,


### PR DESCRIPTION
## Description

This PR implements UI and UX improvements to the Agent Builder V2 knowledge configuration based on feedback. Changes include:
- Using BoltIcon instead of ListAddIcon for tools with primary variant
- Adding space name context in data source filters and footer items for better identification
- Adjusting breadcrumb visibility to only show when there's more than one item
- Changing root breadcrumb label from "Knowledge" to "Spaces"
- Making processing method section more user-friendly with hoverable guide link
- Enhancing icon display in configuration sheets using Avatar component

## Tests

Locally

## Risk

Low

## Deploy Plan

Deploy front
