### PR TITLE
[front] Add more metadata to serialized action

### DIFF
--- a/front/lib/resources/agent_mcp_action_resource.ts
+++ b/front/lib/resources/agent_mcp_action_resource.ts
@@ -324,7 +324,7 @@ export class AgentMCPActionResource extends BaseResource<AgentMCPActionModel> {
     return {
       id: this.id,
       agentMessageId: this.agentMessageId,
-      augmentedInputs: this.augmentedInputs,
+      params: this.augmentedInputs,
       citationsAllocated: this.citationsAllocated,
       internalMCPServerName: this.internalMCPServerName,
       mcpServerConfigurationId: this.mcpServerConfigurationId,

--- a/front/lib/resources/agent_mcp_action_resource.ts
+++ b/front/lib/resources/agent_mcp_action_resource.ts
@@ -321,9 +321,16 @@ export class AgentMCPActionResource extends BaseResource<AgentMCPActionModel> {
   }
 
   toJSON(): AgentMCPActionType {
+    assert(
+      this.stepContent.value.type === "function_call",
+      "Action linked to a non-function call step content."
+    );
+
     return {
       agentMessageId: this.agentMessageId,
       citationsAllocated: this.citationsAllocated,
+      functionCallId: this.stepContent.value.value.id,
+      functionCallName: this.stepContent.value.value.name,
       id: this.id,
       internalMCPServerName: this.internalMCPServerName,
       mcpServerConfigurationId: this.mcpServerConfigurationId,

--- a/front/lib/resources/agent_mcp_action_resource.ts
+++ b/front/lib/resources/agent_mcp_action_resource.ts
@@ -322,6 +322,7 @@ export class AgentMCPActionResource extends BaseResource<AgentMCPActionModel> {
 
   toJSON(): AgentMCPActionType {
     return {
+      id: this.id,
       agentMessageId: this.agentMessageId,
       augmentedInputs: this.augmentedInputs,
       citationsAllocated: this.citationsAllocated,

--- a/front/lib/resources/agent_mcp_action_resource.ts
+++ b/front/lib/resources/agent_mcp_action_resource.ts
@@ -51,7 +51,9 @@ export class AgentMCPActionResource extends BaseResource<AgentMCPActionModel> {
     blob: Attributes<AgentMCPActionModel>,
     // TODO(DURABLE-AGENTS, 2025-08-21): consider using the resource instead of the model.
     readonly stepContent: NonAttribute<AgentStepContentModel>,
-    readonly internalMCPServerName: InternalMCPServerNameType | null
+    readonly metadata: {
+      internalMCPServerName: InternalMCPServerNameType | null;
+    }
   ) {
     super(model, blob);
   }
@@ -93,7 +95,9 @@ export class AgentMCPActionResource extends BaseResource<AgentMCPActionModel> {
         a.toolConfiguration.toolServerId
       );
 
-      return new this(this.model, a.get(), stepContent, internalMCPServerName);
+      return new this(this.model, a.get(), stepContent, {
+        internalMCPServerName,
+      });
     });
   }
 
@@ -124,12 +128,9 @@ export class AgentMCPActionResource extends BaseResource<AgentMCPActionModel> {
     });
     assert(stepContent, "Step content not found.");
 
-    return new this(
-      this.model,
-      action.get(),
-      stepContent,
-      internalMCPServerName
-    );
+    return new this(this.model, action.get(), stepContent, {
+      internalMCPServerName,
+    });
   }
 
   static async fetchByModelIdWithAuth(
@@ -332,7 +333,7 @@ export class AgentMCPActionResource extends BaseResource<AgentMCPActionModel> {
       functionCallId: this.stepContent.value.value.id,
       functionCallName: this.stepContent.value.value.name,
       id: this.id,
-      internalMCPServerName: this.internalMCPServerName,
+      internalMCPServerName: this.metadata.internalMCPServerName,
       mcpServerConfigurationId: this.mcpServerConfigurationId,
       params: this.augmentedInputs,
       status: this.status,

--- a/front/lib/resources/agent_mcp_action_resource.ts
+++ b/front/lib/resources/agent_mcp_action_resource.ts
@@ -322,12 +322,12 @@ export class AgentMCPActionResource extends BaseResource<AgentMCPActionModel> {
 
   toJSON(): AgentMCPActionType {
     return {
-      id: this.id,
       agentMessageId: this.agentMessageId,
-      params: this.augmentedInputs,
       citationsAllocated: this.citationsAllocated,
+      id: this.id,
       internalMCPServerName: this.internalMCPServerName,
       mcpServerConfigurationId: this.mcpServerConfigurationId,
+      params: this.augmentedInputs,
       status: this.status,
       stepContentId: this.stepContentId,
       stepContext: this.stepContext,

--- a/front/lib/resources/agent_mcp_action_resource.ts
+++ b/front/lib/resources/agent_mcp_action_resource.ts
@@ -137,40 +137,14 @@ export class AgentMCPActionResource extends BaseResource<AgentMCPActionModel> {
     id: ModelId,
     transaction?: Transaction
   ): Promise<AgentMCPActionResource | null> {
-    const workspaceId = auth.getNonNullableWorkspace().id;
-
-    const [action] = await this.baseFetch(auth, {
-      where: { id, workspaceId },
-    });
-
-    const stepContent = await AgentStepContentModel.findOne({
-      where: {
-        id: action.stepContentId,
-        workspaceId,
-      },
-      transaction,
-    });
-    assert(stepContent, "Step content not found.");
-
-    return new this(
-      this.model,
+    const [action] = await this.baseFetch(
+      auth,
       {
-        id: action.id,
-        workspaceId: action.workspaceId,
-        agentMessageId: action.agentMessageId,
-        augmentedInputs: action.augmentedInputs,
-        citationsAllocated: action.citationsAllocated,
-        mcpServerConfigurationId: action.mcpServerConfigurationId,
-        status: action.status,
-        stepContentId: action.stepContentId,
-        stepContext: action.stepContext,
-        toolConfiguration: action.toolConfiguration,
-        version: action.version,
-        createdAt: action.createdAt,
-        updatedAt: action.updatedAt,
+        where: { id },
       },
-      stepContent
+      transaction
     );
+    return action;
   }
 
   static async fetchByModelIds(

--- a/front/types/actions.ts
+++ b/front/types/actions.ts
@@ -1,4 +1,5 @@
 import type { LightMCPToolConfigurationType } from "@app/lib/actions/mcp";
+import type { InternalMCPServerNameType } from "@app/lib/actions/mcp_internal_actions/constants";
 import type { ToolExecutionStatus } from "@app/lib/actions/statuses";
 import type { StepContext } from "@app/lib/actions/types";
 import type { ModelId } from "@app/types/shared/model_id";
@@ -8,6 +9,7 @@ export type AgentMCPActionType = {
   augmentedInputs: Record<string, unknown>;
   citationsAllocated: number;
   mcpServerConfigurationId: string;
+  internalMCPServerName: InternalMCPServerNameType | null;
   status: ToolExecutionStatus;
   stepContentId: ModelId;
   stepContext: StepContext;

--- a/front/types/actions.ts
+++ b/front/types/actions.ts
@@ -5,6 +5,7 @@ import type { StepContext } from "@app/lib/actions/types";
 import type { ModelId } from "@app/types/shared/model_id";
 
 export type AgentMCPActionType = {
+  id: ModelId;
   agentMessageId: ModelId;
   augmentedInputs: Record<string, unknown>;
   citationsAllocated: number;

--- a/front/types/actions.ts
+++ b/front/types/actions.ts
@@ -5,12 +5,14 @@ import type { StepContext } from "@app/lib/actions/types";
 import type { ModelId } from "@app/types/shared/model_id";
 
 export type AgentMCPActionType = {
-  id: ModelId;
   agentMessageId: ModelId;
-  params: Record<string, unknown>;
   citationsAllocated: number;
-  mcpServerConfigurationId: string;
+  functionCallId: string;
+  functionCallName: string;
+  id: ModelId;
   internalMCPServerName: InternalMCPServerNameType | null;
+  mcpServerConfigurationId: string;
+  params: Record<string, unknown>;
   status: ToolExecutionStatus;
   stepContentId: ModelId;
   stepContext: StepContext;

--- a/front/types/actions.ts
+++ b/front/types/actions.ts
@@ -7,7 +7,7 @@ import type { ModelId } from "@app/types/shared/model_id";
 export type AgentMCPActionType = {
   id: ModelId;
   agentMessageId: ModelId;
-  augmentedInputs: Record<string, unknown>;
+  params: Record<string, unknown>;
   citationsAllocated: number;
   mcpServerConfigurationId: string;
   internalMCPServerName: InternalMCPServerNameType | null;


### PR DESCRIPTION
## Description

- This PR adds more metadata to the serialized actions, in order to align it with `MCPActionType`, which is the current one being used when serialized through the network.
- `AgentMCPActionType` now contains all fields from `MCPActionTypeSchema` except for `type` and `output`.

## Tests

## Risk

- None.

## Deploy Plan

- Deploy front.
