### PR TITLE
[front] fix resizable panel handle mount

### DIFF
--- a/front/components/assistant/conversation/ConversationSidePanelContainer.tsx
+++ b/front/components/assistant/conversation/ConversationSidePanelContainer.tsx
@@ -47,8 +47,7 @@ export default function ConversationSidePanelContainer({
       {/* Panel Container - either Canvas or Actions */}
       <ResizablePanel
         ref={panelRef}
-        minSize={currentPanel ? 20 : 0}
-        maxSize={currentPanel ? 100 : 0}
+        minSize={20}
         defaultSize={0}
         onTransitionEnd={() => {
           if (panelRef.current?.isCollapsed()) {

--- a/front/components/assistant/conversation/ConversationSidePanelContainer.tsx
+++ b/front/components/assistant/conversation/ConversationSidePanelContainer.tsx
@@ -37,18 +37,18 @@ export default function ConversationSidePanelContainer({
   return (
     <>
       {/* Resizable Handle for Panels */}
-      {currentPanel && (
-        <ResizableHandle
-          className={cn(
-            "hidden transition-all duration-300 ease-out md:block",
-            !currentPanel && "translate-x-full opacity-0"
-          )}
-        />
-      )}
+      <ResizableHandle
+        className={cn(
+          "hidden transition-all duration-300 ease-out md:block",
+          !currentPanel && "translate-x-full opacity-0"
+        )}
+        disabled={!currentPanel}
+      />
       {/* Panel Container - either Canvas or Actions */}
       <ResizablePanel
         ref={panelRef}
-        minSize={20}
+        minSize={currentPanel ? 20 : 0}
+        maxSize={currentPanel ? 100 : 0}
         defaultSize={0}
         onTransitionEnd={() => {
           if (panelRef.current?.isCollapsed()) {


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

react-resizable-panel needs to have ResizableHandle mounted at all time.
We were dismounting the handle when there was no currentPanel. We should put it to disabled.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->

Deploy front
