### PR TITLE
Add auto responding without mention behind FF

### DIFF
--- a/connectors/migrations/db/migration_92.sql
+++ b/connectors/migrations/db/migration_92.sql
@@ -1,0 +1,2 @@
+-- Migration created on Aug 26, 2025
+ALTER TABLE slack_channels ADD COLUMN "autoRespondWithoutMention" BOOLEAN NOT NULL DEFAULT false;

--- a/connectors/src/api/slack_channels_linked_with_agent.ts
+++ b/connectors/src/api/slack_channels_linked_with_agent.ts
@@ -19,6 +19,7 @@ const PatchSlackChannelsLinkedWithAgentReqBodySchema = t.type({
   agent_configuration_id: t.string,
   slack_channel_internal_ids: t.array(t.string),
   connector_id: t.string,
+  auto_respond_without_mention: t.union([t.boolean, t.undefined]),
 });
 
 type PatchSlackChannelsLinkedWithAgentReqBody = t.TypeOf<
@@ -56,6 +57,7 @@ const _patchSlackChannelsLinkedWithAgentHandler = async (
     connector_id: connectorId,
     agent_configuration_id: agentConfigurationId,
     slack_channel_internal_ids: slackChannelInternalIds,
+    auto_respond_without_mention: autoRespondWithoutMention,
   } = bodyValidation.right;
 
   const slackChannelIds = slackChannelInternalIds.map((s) =>
@@ -110,6 +112,7 @@ const _patchSlackChannelsLinkedWithAgentHandler = async (
               agentConfigurationId,
               permission: "write",
               private: remoteChannel.private,
+              autoRespondWithoutMention: autoRespondWithoutMention ?? false,
             },
             {
               transaction: t,
@@ -132,7 +135,10 @@ const _patchSlackChannelsLinkedWithAgentHandler = async (
     await Promise.all(
       slackChannelIds.map((slackChannelId) =>
         SlackChannel.update(
-          { agentConfigurationId },
+          {
+            agentConfigurationId,
+            autoRespondWithoutMention: autoRespondWithoutMention ?? false,
+          },
           { where: { connectorId, slackChannelId }, transaction: t }
         )
       )
@@ -174,6 +180,7 @@ type GetSlackChannelsLinkedWithAgentResBody = WithConnectorsAPIErrorReponse<{
     slackChannelId: string;
     slackChannelName: string;
     agentConfigurationId: string;
+    autoRespondWithoutMention: boolean;
   }[];
 }>;
 
@@ -209,6 +216,7 @@ const _getSlackChannelsLinkedWithAgentHandler = async (
       // We know that agentConfigurationId is not null because of the where clause above
       // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
       agentConfigurationId: c.agentConfigurationId!,
+      autoRespondWithoutMention: c.autoRespondWithoutMention,
     })),
   });
 };

--- a/connectors/src/lib/models/slack.ts
+++ b/connectors/src/lib/models/slack.ts
@@ -131,6 +131,7 @@ export class SlackChannel extends ConnectorBaseModel<SlackChannel> {
 
   declare permission: ConnectorPermission;
   declare agentConfigurationId: CreationOptional<string | null>;
+  declare autoRespondWithoutMention: CreationOptional<boolean>;
 }
 SlackChannel.init(
   {
@@ -168,6 +169,11 @@ SlackChannel.init(
     agentConfigurationId: {
       type: DataTypes.STRING,
       allowNull: true,
+    },
+    autoRespondWithoutMention: {
+      type: DataTypes.BOOLEAN,
+      allowNull: false,
+      defaultValue: false,
     },
   },
   {

--- a/connectors/src/resources/slack_configuration_resource.ts
+++ b/connectors/src/resources/slack_configuration_resource.ts
@@ -114,6 +114,19 @@ export class SlackConfigurationResource extends BaseResource<SlackConfigurationM
     );
   }
 
+  static async findChannelWithAutoRespond(
+    connectorId: ModelId,
+    slackChannelId: string
+  ): Promise<SlackChannel | null> {
+    return SlackChannel.findOne({
+      where: {
+        connectorId,
+        slackChannelId,
+        autoRespondWithoutMention: true,
+      },
+    });
+  }
+
   static async fetchByActiveBot(slackTeamId: string) {
     const blob = await this.model.findOne({
       where: {

--- a/front/components/agent_builder/AgentBuilder.tsx
+++ b/front/components/agent_builder/AgentBuilder.tsx
@@ -145,6 +145,7 @@ export default function AgentBuilder({
       .map((channel) => ({
         slackChannelId: channel.slackChannelId,
         slackChannelName: channel.slackChannelName,
+        autoRespondWithoutMention: channel.autoRespondWithoutMention,
       }));
   }, [agentConfiguration, slackChannelsLinkedWithAgent]);
 

--- a/front/components/agent_builder/AgentBuilderFormContext.tsx
+++ b/front/components/agent_builder/AgentBuilderFormContext.tsx
@@ -177,6 +177,7 @@ const agentSettingsSchema = z.object({
     z.object({
       slackChannelId: z.string(),
       slackChannelName: z.string(),
+      autoRespondWithoutMention: z.boolean().optional(),
     })
   ),
   tags: z.array(tagSchema),

--- a/front/components/agent_builder/settings/SlackSettingsSheet.tsx
+++ b/front/components/agent_builder/settings/SlackSettingsSheet.tsx
@@ -196,7 +196,6 @@ export function SlackSettingsSheet({
   slackDataSource,
 }: SlackSettingsSheetProps) {
   const { owner } = useAgentBuilderContext();
-  const { supportedDataSourceViews } = useDataSourceViewsContext();
   const { hasFeature } = useFeatureFlags({ workspaceId: owner.sId });
   const [localSlackChannels, setLocalSlackChannels] = useState<SlackChannel[]>(
     []
@@ -264,7 +263,7 @@ export function SlackSettingsSheet({
     }
 
     const channelSelectionChanged = Array.from(currentChannelIds).some(
-      (id) => !localChannelIds.has(id)
+      (id) => !localChannelIds.has(id as string)
     );
 
     const currentAutoRespondWithoutMention =
@@ -274,30 +273,6 @@ export function SlackSettingsSheet({
 
     return channelSelectionChanged || autoRespondWithoutMentionChanged;
   }, [slackChannels, localSlackChannels, autoRespondWithoutMentionEnabled]);
-
-  if (!slackProvider) {
-    return (
-      <div className="space-y-4">
-        <p className="text-sm text-muted-foreground dark:text-muted-foreground-night">
-          No Slack integration configured for this workspace.
-        </p>
-      </div>
-    );
-  }
-
-  const slackDataSource = supportedDataSourceViews.find(
-    (dsv) => dsv.dataSource.connectorProvider === slackProvider
-  )?.dataSource;
-
-  if (!slackDataSource) {
-    return (
-      <div className="space-y-4">
-        <p className="text-sm text-muted-foreground dark:text-muted-foreground-night">
-          Slack data source not found.
-        </p>
-      </div>
-    );
-  }
 
   return (
     <Sheet open={isOpen} onOpenChange={handleClose}>
@@ -327,7 +302,7 @@ export function SlackSettingsSheet({
               owner={owner}
               slackDataSource={slackDataSource}
             />
-            {hasFeature("enhanced_default_agent") && (
+            {hasFeature("slack_enhanced_default_agent") && (
               <div className="flex flex-col gap-2 border-t pt-4">
                 <div className="flex items-start justify-between gap-4">
                   <div className="flex min-w-0 flex-1 flex-col gap-1">

--- a/front/components/agent_builder/submitAgentBuilderForm.ts
+++ b/front/components/agent_builder/submitAgentBuilderForm.ts
@@ -217,6 +217,10 @@ export async function submitAgentBuilderForm({
     // If the user selected channels that were already routed to a different agent, the current behavior is to
     // unlink them from the previous agent and link them to this one.
     if (slackProvider) {
+      const autoRespondWithoutMention =
+        slackChannels.length > 0
+          ? slackChannels[0].autoRespondWithoutMention
+          : undefined;
       const slackLinkRes = await fetch(
         `/api/w/${owner.sId}/assistant/agent_configurations/${agentConfiguration.sId}/linked_slack_channels`,
         {
@@ -229,6 +233,7 @@ export async function submitAgentBuilderForm({
             slack_channel_internal_ids: slackChannels.map(
               ({ slackChannelId }) => slackChannelId
             ),
+            auto_respond_without_mention: autoRespondWithoutMention,
           }),
         }
       );

--- a/front/components/assistant_builder/SlackIntegration.tsx
+++ b/front/components/assistant_builder/SlackIntegration.tsx
@@ -223,7 +223,7 @@ export function SlackAssistantDefaultManager({
               />
             )}
 
-            {hasFeature("enhanced_default_agent") &&
+            {hasFeature("slack_enhanced_default_agent") &&
               selectedChannels.length > 0 && (
                 <div className="flex flex-col gap-2 border-t pt-4">
                   <div className="flex items-start justify-between gap-4">

--- a/front/components/assistant_builder/SlackIntegration.tsx
+++ b/front/components/assistant_builder/SlackIntegration.tsx
@@ -8,16 +8,22 @@ import {
   SheetFooter,
   SheetHeader,
   SheetTitle,
+  SliderToggle,
 } from "@dust-tt/sparkle";
 import { useCallback, useEffect, useState } from "react";
 
 import type { ContentNodeTreeItemStatus } from "@app/components/ContentNodeTree";
 import { ContentNodeTree } from "@app/components/ContentNodeTree";
 import { useConnectorPermissions } from "@app/lib/swr/connectors";
+import { useFeatureFlags } from "@app/lib/swr/workspaces";
 import type { ContentNode, DataSourceType, WorkspaceType } from "@app/types";
 import { isAdmin } from "@app/types";
 
-export type SlackChannel = { slackChannelId: string; slackChannelName: string };
+export type SlackChannel = {
+  slackChannelId: string;
+  slackChannelName: string;
+  autoRespondWithoutMention?: boolean;
+};
 
 // The "write" permission filter is applied to retrieve all available channels on Slack,
 const getUseResourceHook =
@@ -144,9 +150,22 @@ export function SlackAssistantDefaultManager({
   show,
   slackDataSource,
 }: SlackAssistantDefaultManagerProps) {
+  const { hasFeature } = useFeatureFlags({ workspaceId: owner.sId });
   const [selectedChannels, setSelectedChannels] =
     useState<SlackChannel[]>(existingSelection);
+  const [
+    autoRespondWithoutMentionEnabled,
+    setAutoRespondWithoutMentionEnabled,
+  ] = useState(false);
   const [hasChanged, setHasChanged] = useState(false);
+
+  useEffect(() => {
+    const currentAutoRespondWithoutMention =
+      existingSelection.length > 0
+        ? existingSelection[0].autoRespondWithoutMention || false
+        : false;
+    setAutoRespondWithoutMentionEnabled(currentAutoRespondWithoutMention);
+  }, [existingSelection]);
 
   const handleSelectionChange = (newSelection: SlackChannel[]) => {
     setSelectedChannels(newSelection);
@@ -154,7 +173,11 @@ export function SlackAssistantDefaultManager({
   };
 
   const saveChanges = () => {
-    onSave(selectedChannels);
+    const channelsWithEnhancedDefault = selectedChannels.map((channel) => ({
+      ...channel,
+      autoRespondWithoutMention: autoRespondWithoutMentionEnabled,
+    }));
+    onSave(channelsWithEnhancedDefault);
     setHasChanged(false);
     onClose();
   };
@@ -174,7 +197,7 @@ export function SlackAssistantDefaultManager({
               Set this agent as the default agent on one or several of your
               Slack channels. It will answer by default when the{" "}
               <span className="font-bold">{assistantHandle}</span> Slack bot is
-              mentionned in these channels.
+              mentioned in these channels.
             </div>
 
             {!isAdmin(owner) && (
@@ -199,6 +222,34 @@ export function SlackAssistantDefaultManager({
                 slackDataSource={slackDataSource}
               />
             )}
+
+            {hasFeature("enhanced_default_agent") &&
+              selectedChannels.length > 0 && (
+                <div className="flex flex-col gap-2 border-t pt-4">
+                  <div className="flex items-start justify-between gap-4">
+                    <div className="flex min-w-0 flex-1 flex-col gap-1">
+                      <span className="text-sm font-medium text-foreground dark:text-foreground-night">
+                        Enhanced Default Agent
+                      </span>
+                      <span className="text-xs text-muted-foreground dark:text-muted-foreground-night">
+                        Agent will automatically respond to all messages and
+                        thread replies in selected channels (not just @mentions)
+                      </span>
+                    </div>
+                    <div className="flex-shrink-0">
+                      <SliderToggle
+                        selected={autoRespondWithoutMentionEnabled}
+                        onClick={() => {
+                          setAutoRespondWithoutMentionEnabled(
+                            !autoRespondWithoutMentionEnabled
+                          );
+                          setHasChanged(true);
+                        }}
+                      />
+                    </div>
+                  </div>
+                </div>
+              )}
           </div>
         </SheetContainer>
         <SheetFooter

--- a/front/components/assistant_builder/submitAssistantBuilderForm.ts
+++ b/front/components/assistant_builder/submitAssistantBuilderForm.ts
@@ -238,6 +238,10 @@ export async function submitAssistantBuilderForm({
           slack_channel_internal_ids: selectedSlackChannels.map(
             ({ slackChannelId }) => slackChannelId
           ),
+          auto_respond_without_mention:
+            selectedSlackChannels.length > 0
+              ? selectedSlackChannels[0].autoRespondWithoutMention
+              : undefined,
         }),
       }
     );

--- a/front/components/assistant_builder/useSlackChannels.tsx
+++ b/front/components/assistant_builder/useSlackChannels.tsx
@@ -53,6 +53,7 @@ export function useSlackChannel({
           .map((channel) => ({
             slackChannelId: channel.slackChannelId,
             slackChannelName: channel.slackChannelName,
+            autoRespondWithoutMention: channel.autoRespondWithoutMention,
           }))
       );
       setSlackChannelsInitialized(true);

--- a/front/lib/api/assistant/conversation/attachments.ts
+++ b/front/lib/api/assistant/conversation/attachments.ts
@@ -114,7 +114,7 @@ export function getAttachmentFromContentNodeContentFragment(
     contentType: cf.contentType,
     snippet: null,
     contentFragmentVersion: cf.contentFragmentVersion,
-    // Backward compatibility: we fallback to the fileId if no generated tables are mentionned
+    // Backward compatibility: we fallback to the fileId if no generated tables are mentioned
     // but the file is queryable.
     generatedTables: isQueryable ? [cf.nodeId] : [],
     isIncludable,
@@ -158,7 +158,7 @@ export function getAttachmentFromFileContentFragment(
     contentType: cf.contentType,
     snippet: cf.snippet,
     contentFragmentVersion: cf.contentFragmentVersion,
-    // Backward compatibility: we fallback to the fileId if no generated tables are mentionned
+    // Backward compatibility: we fallback to the fileId if no generated tables are mentioned
     // but the file is queryable.
     generatedTables:
       cf.generatedTables.length > 0

--- a/front/pages/api/w/[wId]/assistant/agent_configurations/[aId]/linked_slack_channels.ts
+++ b/front/pages/api/w/[wId]/assistant/agent_configurations/[aId]/linked_slack_channels.ts
@@ -51,7 +51,7 @@ async function handler(
   ) {
     const owner = auth.getNonNullableWorkspace();
     const featureFlags = await getFeatureFlags(owner);
-    if (!featureFlags.includes("enhanced_default_agent")) {
+    if (!featureFlags.includes("slack_enhanced_default_agent")) {
       return apiError(req, res, {
         status_code: 403,
         api_error: {

--- a/front/pages/api/w/[wId]/assistant/agent_configurations/[aId]/linked_slack_channels.ts
+++ b/front/pages/api/w/[wId]/assistant/agent_configurations/[aId]/linked_slack_channels.ts
@@ -7,6 +7,7 @@ import { getAgentConfiguration } from "@app/lib/api/assistant/configuration/agen
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
 import config from "@app/lib/api/config";
 import type { Authenticator } from "@app/lib/auth";
+import { getFeatureFlags } from "@app/lib/auth";
 import { DataSourceResource } from "@app/lib/resources/data_source_resource";
 import logger from "@app/logger/logger";
 import { apiError } from "@app/logger/withlogging";
@@ -20,6 +21,7 @@ export type PatchLinkedSlackChannelsResponseBody = {
 export const PatchLinkedSlackChannelsRequestBodySchema = t.type({
   slack_channel_internal_ids: t.array(t.string),
   provider: t.union([t.literal("slack"), t.literal("slack_bot")]),
+  auto_respond_without_mention: t.union([t.boolean, t.undefined]),
 });
 
 async function handler(
@@ -38,6 +40,27 @@ async function handler(
           "Only the users that are `builders` for the current workspace can access an agent.",
       },
     });
+  }
+
+  const bodyValidationResult = PatchLinkedSlackChannelsRequestBodySchema.decode(
+    req.body
+  );
+  if (
+    bodyValidationResult._tag === "Right" &&
+    bodyValidationResult.right.auto_respond_without_mention
+  ) {
+    const owner = auth.getNonNullableWorkspace();
+    const featureFlags = await getFeatureFlags(owner);
+    if (!featureFlags.includes("enhanced_default_agent")) {
+      return apiError(req, res, {
+        status_code: 403,
+        api_error: {
+          type: "feature_flag_not_found",
+          message:
+            "The auto respond without mention feature is not enabled for this workspace.",
+        },
+      });
+    }
   }
 
   if (req.method !== "PATCH") {
@@ -121,6 +144,8 @@ async function handler(
     connectorId: connectorId.toString(),
     agentConfigurationId: agentConfiguration.sId,
     slackChannelInternalIds: bodyValidation.right.slack_channel_internal_ids,
+    autoRespondWithoutMention:
+      bodyValidation.right.auto_respond_without_mention,
   });
 
   if (connectorsApiRes.isErr()) {

--- a/front/pages/api/w/[wId]/assistant/builder/slack/channels_linked_with_agent.ts
+++ b/front/pages/api/w/[wId]/assistant/builder/slack/channels_linked_with_agent.ts
@@ -19,6 +19,7 @@ export type GetSlackChannelsLinkedWithAgentResponseBody = {
     slackChannelId: string;
     slackChannelName: string;
     agentConfigurationId: string;
+    autoRespondWithoutMention: boolean;
   }[];
   slackDataSource?: DataSourceType;
 };

--- a/front/types/connectors/connectors_api.ts
+++ b/front/types/connectors/connectors_api.ts
@@ -517,10 +517,12 @@ export class ConnectorsAPI {
     connectorId,
     slackChannelInternalIds,
     agentConfigurationId,
+    autoRespondWithoutMention,
   }: {
     connectorId: string;
     slackChannelInternalIds: string[];
     agentConfigurationId: string;
+    autoRespondWithoutMention?: boolean;
   }): Promise<ConnectorsAPIResponse<{ success: true }>> {
     const res = await this._fetchWithError(
       `${this._url}/slack/channels/linked_with_agent`,
@@ -531,6 +533,7 @@ export class ConnectorsAPI {
           connector_id: connectorId,
           agent_configuration_id: agentConfigurationId,
           slack_channel_internal_ids: slackChannelInternalIds,
+          auto_respond_without_mention: autoRespondWithoutMention,
         }),
       }
     );
@@ -548,6 +551,7 @@ export class ConnectorsAPI {
         slackChannelId: string;
         slackChannelName: string;
         agentConfigurationId: string;
+        autoRespondWithoutMention: boolean;
       }[];
     }>
   > {

--- a/front/types/shared/feature_flags.ts
+++ b/front/types/shared/feature_flags.ts
@@ -164,6 +164,11 @@ export const WHITELISTABLE_FEATURES_CONFIG = {
     description: "Toolsets MCP tool",
     stage: "dust_only",
   },
+  enhanced_default_agent: {
+    description:
+      "Enhanced default agent feature for Slack channels - auto-respond to all messages in channel",
+    stage: "dust_only",
+  },
 } as const satisfies Record<string, FeatureFlag>;
 
 export type FeatureFlagStage = "dust_only" | "rolling_out" | "on_demand";

--- a/front/types/shared/feature_flags.ts
+++ b/front/types/shared/feature_flags.ts
@@ -164,7 +164,7 @@ export const WHITELISTABLE_FEATURES_CONFIG = {
     description: "Toolsets MCP tool",
     stage: "dust_only",
   },
-  enhanced_default_agent: {
+  slack_enhanced_default_agent: {
     description:
       "Enhanced default agent feature for Slack channels - auto-respond to all messages in channel",
     stage: "dust_only",

--- a/sdks/js/src/types.ts
+++ b/sdks/js/src/types.ts
@@ -622,6 +622,7 @@ const WhitelistableFeaturesSchema = FlexibleEnumSchema<
   | "salesforce_tool"
   | "show_debug_tools"
   | "slack_semantic_search"
+  | "enhanced_default_agent"
   | "toolsets_tool"
   | "usage_data_api"
   | "xai_feature"

--- a/sdks/js/src/types.ts
+++ b/sdks/js/src/types.ts
@@ -622,7 +622,7 @@ const WhitelistableFeaturesSchema = FlexibleEnumSchema<
   | "salesforce_tool"
   | "show_debug_tools"
   | "slack_semantic_search"
-  | "enhanced_default_agent"
+  | "slack_enhanced_default_agent"
   | "toolsets_tool"
   | "usage_data_api"
   | "xai_feature"


### PR DESCRIPTION
## Description

* Adding ability behind FF to auto respond to a Slack channel without being mentioned. This is to unblock a specific customer use case.

## Tests

* Validated in test slack workspace

## Risk

* Minimal - intended to behind FF

## Deploy Plan

(Wait for event subscription to be added)

1. Run migration
2. deploy connectors
3. Deploy front