### PR TITLE
[front] ABv2 - Instruction block supports other blocks

### DIFF
--- a/front/components/agent_builder/instructions/extensions/InstructionBlockExtension.tsx
+++ b/front/components/agent_builder/instructions/extensions/InstructionBlockExtension.tsx
@@ -1,7 +1,7 @@
 import { ChevronDownIcon, ChevronRightIcon, Chip, cn } from "@dust-tt/sparkle";
 import type { Editor } from "@tiptap/core";
 import { InputRule, mergeAttributes, Node } from "@tiptap/core";
-import type { Slice } from "@tiptap/pm/model";
+import type { Node as ProseMirrorNode, Slice } from "@tiptap/pm/model";
 import { Plugin, PluginKey } from "@tiptap/pm/state";
 import { TextSelection } from "@tiptap/pm/state";
 import type { NodeViewProps } from "@tiptap/react";
@@ -553,9 +553,9 @@ export const InstructionBlockExtension =
 
     addProseMirrorPlugins() {
       // Helper function to find first and last paragraph nodes in a block
-      const findFirstLastParagraphs = (blockNode: any) => {
-        let firstPara = null;
-        let lastPara = null;
+      const findFirstLastParagraphs = (blockNode: ProseMirrorNode) => {
+        let firstPara: ProseMirrorNode | null = null;
+        let lastPara: ProseMirrorNode | null = null;
         let firstParaIndex = -1;
         let lastParaIndex = -1;
 
@@ -575,7 +575,10 @@ export const InstructionBlockExtension =
       };
 
       // Helper function to check if a paragraph contains a valid XML tag
-      const getTagFromParagraph = (para: any, isClosing: boolean) => {
+      const getTagFromParagraph = (
+        para: ProseMirrorNode | null,
+        isClosing: boolean
+      ) => {
         if (!para) return null;
         const text = para.textContent.trim();
         // Allow empty tag name for typing (<>) and a wider set when non-empty

--- a/front/components/agent_builder/instructions/extensions/InstructionBlockExtension.tsx
+++ b/front/components/agent_builder/instructions/extensions/InstructionBlockExtension.tsx
@@ -112,6 +112,8 @@ function focusInsideCurrentInstructionBlock(editor: Editor): void {
 function queueFocusInsideCurrentInstructionBlock(editor: Editor): void {
   if (editor.isDestroyed || !editor.view) return;
   requestAnimationFrame(() => {
+    // Double-check lifecycle at callback time to avoid acting on a destroyed editor
+    if (editor.isDestroyed || !editor.view) return;
     focusInsideCurrentInstructionBlock(editor);
   });
 }

--- a/front/components/agent_builder/instructions/extensions/InstructionBlockExtension.tsx
+++ b/front/components/agent_builder/instructions/extensions/InstructionBlockExtension.tsx
@@ -65,6 +65,8 @@ function positionCursorInMiddleParagraph(
 // Define consistent heading styles to match the main editor
 const instructionBlockContentStyles = cn(
   "prose prose-sm mt-2",
+  // Add left padding to align with the chip (chevron button width + gap)
+  "ml-6",
   // Override for all headings to match the editor's heading style
   "[&_h1,&_h2,&_h3,&_h4,&_h5,&_h6]:text-xl",
   "[&_h1,&_h2,&_h3,&_h4,&_h5,&_h6]:font-semibold",
@@ -124,10 +126,10 @@ const InstructionBlockComponent: React.FC<NodeViewProps> = ({
     }
   };
 
-  const containerClasses = `rounded-lg border bg-gray-100 p-2 dark:bg-gray-800 transition-all ${
+  const containerClasses = `rounded-lg p-2 transition-all ${
     selected && isCollapsed
-      ? "ring-2 ring-highlight-300 dark:ring-highlight-300-night border-highlight-300 dark:border-highlight-300-night"
-      : "border-border"
+      ? "ring-2 ring-highlight-300 dark:ring-highlight-300-night"
+      : ""
   }`;
 
   return (
@@ -144,7 +146,9 @@ const InstructionBlockComponent: React.FC<NodeViewProps> = ({
           >
             <ChevronIcon className="h-4 w-4" />
           </button>
-          <Chip size="mini">{displayType.toUpperCase() || " "}</Chip>
+          <Chip size="mini" className="bg-gray-100 dark:bg-gray-800">
+            {displayType.toUpperCase() || " "}
+          </Chip>
         </div>
         {!isCollapsed && (
           <NodeViewContent className={instructionBlockContentStyles} as="div" />
@@ -461,7 +465,9 @@ export const InstructionBlockExtension =
           const isAtEndOfClosingTag =
             paragraphNode &&
             paragraphNode.type.name === "paragraph" &&
-            paragraphNode.textContent.match(/^<\/([A-Za-z_][A-Za-z0-9._:-]*)?>$/) &&
+            paragraphNode.textContent.match(
+              /^<\/([A-Za-z_][A-Za-z0-9._:-]*)?>$/
+            ) &&
             $from.parentOffset === paragraphNode.content.size;
 
           if (!isParagraphEmpty && !isAtEndOfClosingTag) {

--- a/front/components/agent_builder/instructions/extensions/InstructionBlockExtension.tsx
+++ b/front/components/agent_builder/instructions/extensions/InstructionBlockExtension.tsx
@@ -2,8 +2,7 @@ import { ChevronDownIcon, ChevronRightIcon, Chip, cn } from "@dust-tt/sparkle";
 import type { Editor } from "@tiptap/core";
 import { InputRule, mergeAttributes, Node } from "@tiptap/core";
 import type { Node as ProseMirrorNode, Slice } from "@tiptap/pm/model";
-import { Plugin, PluginKey } from "@tiptap/pm/state";
-import { TextSelection } from "@tiptap/pm/state";
+import { Plugin, PluginKey, TextSelection } from "@tiptap/pm/state";
 import type { NodeViewProps } from "@tiptap/react";
 import {
   NodeViewContent,
@@ -13,8 +12,8 @@ import {
 import React, { useState } from "react";
 
 import {
-  OPENING_TAG_REGEX,
   CLOSING_TAG_REGEX,
+  OPENING_TAG_REGEX,
 } from "@app/lib/client/agent_builder/instructionBlockUtils";
 
 export interface InstructionBlockAttributes {
@@ -101,7 +100,9 @@ function positionCursorInMiddleParagraph(
  * Focus cursor inside the current instruction block
  */
 function focusInsideCurrentInstructionBlock(editor: Editor): void {
-  if (editor.isDestroyed) return;
+  if (editor.isDestroyed) {
+    return;
+  }
 
   const blockPos = getCurrentInstructionBlockPos(editor);
   if (blockPos > -1) {
@@ -113,10 +114,14 @@ function focusInsideCurrentInstructionBlock(editor: Editor): void {
  * Queue a caret move inside the current instruction block (post-render)
  */
 function queueFocusInsideCurrentInstructionBlock(editor: Editor): void {
-  if (editor.isDestroyed || !editor.view) return;
+  if (editor.isDestroyed || !editor.view) {
+    return;
+  }
   requestAnimationFrame(() => {
     // Double-check lifecycle at callback time to avoid acting on a destroyed editor
-    if (editor.isDestroyed || !editor.view) return;
+    if (editor.isDestroyed || !editor.view) {
+      return;
+    }
     focusInsideCurrentInstructionBlock(editor);
   });
 }
@@ -277,7 +282,7 @@ export const InstructionBlockExtension =
 
         insertInstructionBlock:
           (type) =>
-          ({ commands, editor, state, chain }) => {
+          ({ state, chain }) => {
             const { selection } = state;
             const { $from } = selection;
 
@@ -582,7 +587,9 @@ export const InstructionBlockExtension =
         para: ProseMirrorNode | null,
         isClosing: boolean
       ) => {
-        if (!para) return null;
+        if (!para) {
+          return null;
+        }
         const text = para.textContent.trim();
         const regex = isClosing ? CLOSING_TAG_REGEX : OPENING_TAG_REGEX;
         const match = text.match(regex);
@@ -687,7 +694,7 @@ export const InstructionBlockExtension =
             }
 
             // Create transaction to sync the tags
-            let tr = newState.tr;
+            const tr = newState.tr;
             tr.setMeta("instructionBlockTagSync", true);
             tr.setMeta("addToHistory", false); // Don't add to undo history
 

--- a/front/components/agent_builder/instructions/extensions/InstructionBlockExtension.tsx
+++ b/front/components/agent_builder/instructions/extensions/InstructionBlockExtension.tsx
@@ -12,7 +12,10 @@ import {
 } from "@tiptap/react";
 import React, { useState } from "react";
 
-import { OPENING_TAG_REGEX } from "@app/lib/client/agent_builder/instructionBlockUtils";
+import {
+  OPENING_TAG_REGEX,
+  CLOSING_TAG_REGEX,
+} from "@app/lib/client/agent_builder/instructionBlockUtils";
 
 export interface InstructionBlockAttributes {
   type: string;
@@ -146,7 +149,7 @@ const InstructionBlockComponent: React.FC<NodeViewProps> = ({
     const firstChild = node.child(0);
     if (firstChild.type.name === "paragraph") {
       const text = firstChild.textContent.trim();
-      const match = text.match(/^<([A-Za-z_][A-Za-z0-9._:-]*)?>$/);
+      const match = text.match(OPENING_TAG_REGEX);
       if (match) {
         displayType = match[1] || ""; // Empty string for <>
       }
@@ -524,9 +527,7 @@ export const InstructionBlockExtension =
           const isAtEndOfClosingTag =
             paragraphNode &&
             paragraphNode.type.name === "paragraph" &&
-            paragraphNode.textContent.match(
-              /^<\/([A-Za-z_][A-Za-z0-9._:-]*)?>$/
-            ) &&
+            paragraphNode.textContent.match(CLOSING_TAG_REGEX) &&
             $from.parentOffset === paragraphNode.content.size;
 
           if (!isParagraphEmpty && !isAtEndOfClosingTag) {
@@ -583,10 +584,7 @@ export const InstructionBlockExtension =
       ) => {
         if (!para) return null;
         const text = para.textContent.trim();
-        // Allow empty tag name for typing (<>) and a wider set when non-empty
-        const regex = isClosing
-          ? /^<\/([A-Za-z_][A-Za-z0-9._:-]*)?>$/
-          : /^<([A-Za-z_][A-Za-z0-9._:-]*)?>$/;
+        const regex = isClosing ? CLOSING_TAG_REGEX : OPENING_TAG_REGEX;
         const match = text.match(regex);
         return match ? match[1] || "" : null;
       };

--- a/front/components/agent_builder/instructions/extensions/InstructionBlockExtension.tsx
+++ b/front/components/agent_builder/instructions/extensions/InstructionBlockExtension.tsx
@@ -190,7 +190,7 @@ const InstructionBlockComponent: React.FC<NodeViewProps> = ({
     }
   };
 
-  const containerClasses = `rounded-lg p-2 transition-all ${
+  const containerClasses = `rounded-lg py-2 px-1 transition-all ${
     selected && isCollapsed
       ? "ring-2 ring-highlight-300 dark:ring-highlight-300-night"
       : ""

--- a/front/components/agent_builder/instructions/useBlockInsertDropdown.tsx
+++ b/front/components/agent_builder/instructions/useBlockInsertDropdown.tsx
@@ -14,7 +14,9 @@ import { useCallback, useMemo, useRef, useState } from "react";
 
 type CompatibleEditor = CoreEditor | ReactEditor;
 
-function isSelectionInInstructionBlock(editor: ReactEditor | CoreEditor | null) {
+function isSelectionInInstructionBlock(
+  editor: ReactEditor | CoreEditor | null
+) {
   if (!editor || ("isDestroyed" in editor && editor.isDestroyed)) {
     return false;
   }

--- a/front/components/agent_builder/instructions/useBlockInsertDropdown.tsx
+++ b/front/components/agent_builder/instructions/useBlockInsertDropdown.tsx
@@ -14,6 +14,19 @@ import { useCallback, useMemo, useRef, useState } from "react";
 
 type CompatibleEditor = CoreEditor | ReactEditor;
 
+function isSelectionInInstructionBlock(editor: ReactEditor | CoreEditor | null) {
+  if (!editor || ("isDestroyed" in editor && editor.isDestroyed)) {
+    return false;
+  }
+  const $from = (editor as ReactEditor).state.selection.$from;
+  for (let d = $from.depth; d >= 0; d--) {
+    if ($from.node(d).type.name === "instructionBlock") {
+      return true;
+    }
+  }
+  return false;
+}
+
 export interface BlockSuggestion {
   id: string;
   label: string;
@@ -181,20 +194,9 @@ export const useBlockInsertDropdown = (
         );
       },
       items: ({ query }: { query: string }) => {
-        // We'll detect if we're in an instruction block using the editor reference
-        const editor = editorRef.current;
-        let isInInstructionBlock = false;
-
-        if (editor && !editor.isDestroyed) {
-          const $from = editor.state.selection.$from;
-          for (let d = $from.depth; d >= 0; d--) {
-            if ($from.node(d).type.name === "instructionBlock") {
-              isInInstructionBlock = true;
-              break;
-            }
-          }
-        }
-
+        const isInInstructionBlock = isSelectionInInstructionBlock(
+          editorRef.current
+        );
         return filterSuggestions(query, isInInstructionBlock);
       },
       render: () => {
@@ -211,20 +213,10 @@ export const useBlockInsertDropdown = (
               return;
             }
 
-            const editor = editorRef.current;
-            let isInInstructionBlock = false;
-
-            if (editor && !editor.isDestroyed) {
-              const $from = editor.state.selection.$from;
-              for (let d = $from.depth; d >= 0; d--) {
-                if ($from.node(d).type.name === "instructionBlock") {
-                  isInInstructionBlock = true;
-                  break;
-                }
-              }
-            }
-
-            updateQuery(props.query || "", isInInstructionBlock);
+            updateQuery(
+              props.query || "",
+              isSelectionInInstructionBlock(editorRef.current)
+            );
             setState((prev) => ({
               ...prev,
               isOpen: true,
@@ -240,20 +232,10 @@ export const useBlockInsertDropdown = (
 
             const rect = props.clientRect();
             if (rect) {
-              const editor = editorRef.current;
-              let isInInstructionBlock = false;
-
-              if (editor && !editor.isDestroyed) {
-                const $from = editor.state.selection.$from;
-                for (let d = $from.depth; d >= 0; d--) {
-                  if ($from.node(d).type.name === "instructionBlock") {
-                    isInInstructionBlock = true;
-                    break;
-                  }
-                }
-              }
-
-              updateQuery(props.query || "", isInInstructionBlock);
+              updateQuery(
+                props.query || "",
+                isSelectionInInstructionBlock(editorRef.current)
+              );
               setState((prev) => ({
                 ...prev,
                 triggerRect: rect,

--- a/front/lib/client/agent_builder/instructionBlockUtils.ts
+++ b/front/lib/client/agent_builder/instructionBlockUtils.ts
@@ -5,12 +5,17 @@ import type { JSONContent } from "@tiptap/react";
 /**
  * Regex pattern for matching XML-style instruction blocks
  */
-export const INSTRUCTION_BLOCK_REGEX = /<(\w+)>([\s\S]*?)<\/\1>/g;
+// Support tag names with letters, digits, underscore, dash, dot, and colon.
+// Allow standard XML-like Name production (simplified): start with letter/_ then [A-Za-z0-9._:-]*
+export const INSTRUCTION_BLOCK_REGEX =
+  /<([A-Za-z_][A-Za-z0-9._:-]*)>([\s\S]*?)<\/\1>/g;
 
 /**
- * Regex pattern for matching opening XML tags (including empty <>)
+ * Regex pattern for matching opening XML tags (including empty <>).
  */
-export const OPENING_TAG_REGEX = /<(\w*)>$/;
+// Allow empty tag name while typing: <>
+// When non-empty, support letters, digits, underscore, dash, dot, and colon.
+export const OPENING_TAG_REGEX = /<([A-Za-z_][A-Za-z0-9._:-]*)?>$/;
 
 /**
  * Interface for parsed instruction block match
@@ -61,6 +66,34 @@ export function textToParagraphNodes(content: string): JSONContent[] {
 }
 
 /**
+ * Convert text content to block nodes (paragraphs and headings)
+ */
+export function textToBlockNodes(content: string): JSONContent[] {
+  const nodes: JSONContent[] = [];
+  const lines = content.split("\n");
+
+  for (const line of lines) {
+    const headingMatch = line.match(/^(#{1,6})\s+(.*)$/);
+    if (headingMatch) {
+      const level = headingMatch[1].length;
+      const headingContent = headingMatch[2].trim();
+      nodes.push({
+        type: "heading",
+        attrs: { level },
+        content: headingContent ? [{ type: "text", text: headingContent }] : [],
+      });
+    } else {
+      nodes.push({
+        type: "paragraph",
+        content: line.trim() ? [{ type: "text", text: line.trim() }] : [],
+      });
+    }
+  }
+
+  return nodes;
+}
+
+/**
  * Convert text content to ProseMirror paragraph nodes
  */
 export function textToProseMirrorParagraphs(
@@ -78,13 +111,48 @@ export function textToProseMirrorParagraphs(
 }
 
 /**
+ * Convert text content to ProseMirror block nodes (paragraphs and headings)
+ */
+export function textToProseMirrorBlocks(
+  content: string,
+  schema: Schema
+): ProseMirrorNode[] {
+  const nodes: ProseMirrorNode[] = [];
+  const lines = content.split("\n");
+
+  for (const line of lines) {
+    const headingMatch = line.match(/^(#{1,6})\s+(.*)$/);
+    if (headingMatch && schema.nodes.heading) {
+      const level = headingMatch[1].length;
+      const headingContent = headingMatch[2].trim();
+      nodes.push(
+        schema.nodes.heading.create(
+          { level },
+          headingContent ? [schema.text(headingContent)] : []
+        )
+      );
+    } else {
+      const trimmedLine = line.trim();
+      nodes.push(
+        schema.nodes.paragraph.create(
+          {},
+          trimmedLine ? [schema.text(trimmedLine)] : []
+        )
+      );
+    }
+  }
+
+  return nodes;
+}
+
+/**
  * Create instruction block JSONContent
  */
 export function createInstructionBlockNode(
   type: string,
   content: string
 ): JSONContent {
-  const paragraphs = textToParagraphNodes(content);
+  const blocks = textToBlockNodes(content);
 
   // Add opening and closing tags as paragraphs
   const blockContent: JSONContent[] = [
@@ -92,9 +160,7 @@ export function createInstructionBlockNode(
       type: "paragraph",
       content: [{ type: "text", text: `<${type}>` }],
     },
-    ...(paragraphs.length > 0
-      ? paragraphs
-      : [{ type: "paragraph", content: [] }]),
+    ...(blocks.length > 0 ? blocks : [{ type: "paragraph", content: [] }]),
     {
       type: "paragraph",
       content: [{ type: "text", text: `</${type}>` }],
@@ -117,12 +183,12 @@ export function createProseMirrorInstructionBlock(
   nodeType: NodeType,
   schema: Schema
 ): ProseMirrorNode {
-  const paragraphs = textToProseMirrorParagraphs(content, schema);
+  const blocks = textToProseMirrorBlocks(content, schema);
 
   // Add opening and closing tags as paragraphs
   const blockContent = [
     schema.nodes.paragraph.create({}, [schema.text(`<${type}>`)]),
-    ...(paragraphs.length > 0 ? paragraphs : [schema.nodes.paragraph.create()]),
+    ...(blocks.length > 0 ? blocks : [schema.nodes.paragraph.create()]),
     schema.nodes.paragraph.create({}, [schema.text(`</${type}>`)]),
   ];
 

--- a/front/lib/client/agent_builder/instructionBlockUtils.ts
+++ b/front/lib/client/agent_builder/instructionBlockUtils.ts
@@ -3,19 +3,23 @@ import type { NodeType } from "@tiptap/pm/model";
 import type { JSONContent } from "@tiptap/react";
 
 /**
- * Regex pattern for matching XML-style instruction blocks
+ * Tag name pattern (XML-like, simplified): start with letter/_ then [A-Za-z0-9._:-]*
  */
-// Support tag names with letters, digits, underscore, dash, dot, and colon.
-// Allow standard XML-like Name production (simplified): start with letter/_ then [A-Za-z0-9._:-]*
-export const INSTRUCTION_BLOCK_REGEX =
-  /<([A-Za-z_][A-Za-z0-9._:-]*)>([\s\S]*?)<\/\1>/g;
+export const TAG_NAME_PATTERN = "[A-Za-z_][A-Za-z0-9._:-]*";
 
 /**
- * Regex pattern for matching opening XML tags (including empty <>).
+ * Regex pattern for matching XML-style instruction blocks
  */
-// Allow empty tag name while typing: <>
-// When non-empty, support letters, digits, underscore, dash, dot, and colon.
-export const OPENING_TAG_REGEX = /<([A-Za-z_][A-Za-z0-9._:-]*)?>$/;
+export const INSTRUCTION_BLOCK_REGEX = new RegExp(
+  `<(${TAG_NAME_PATTERN})>([\\s\\S]*?)<\\/\\1>`,
+  "g"
+);
+
+/**
+ * Regex pattern for matching opening/closing XML tags (including empty <> when typing).
+ */
+export const OPENING_TAG_REGEX = new RegExp(`<(${TAG_NAME_PATTERN})?>$`);
+export const CLOSING_TAG_REGEX = new RegExp(`^</(${TAG_NAME_PATTERN})?>$`);
 
 /**
  * Interface for parsed instruction block match


### PR DESCRIPTION
## Description

This PR introduces support for headings and code blocks inside the instruction XML block
- Headings support in instruction block
- Code block support in instruction block
- Cleaner style of the instruction block
- Suggestion menu conditionally hides options in the instruction block
- Creating an instruction block does not create a new empty block if current block is empty
- Refactored the instruction block utils to reuse them more

## Tests

Locally

## Risk

Low, behind FF

## Deploy Plan

Deploy front