### PR TITLE
[front] feat(ab/knowledge): Make in conversation filtering global

### DIFF
--- a/front/components/agent_builder/capabilities/shared/DataSourceViewTagsFilterDropdown.tsx
+++ b/front/components/agent_builder/capabilities/shared/DataSourceViewTagsFilterDropdown.tsx
@@ -4,6 +4,7 @@ import {
   PopoverContent,
   PopoverRoot,
   PopoverTrigger,
+  SliderToggle,
 } from "@dust-tt/sparkle";
 import { useCallback, useMemo } from "react";
 import { useWatch } from "react-hook-form";
@@ -12,11 +13,17 @@ import { useAgentBuilderContext } from "@app/components/agent_builder/AgentBuild
 import type { CapabilityFormData } from "@app/components/agent_builder/types";
 import { TagSearchSection } from "@app/components/assistant_builder/tags/TagSearchSection";
 import { useDataSourceBuilderContext } from "@app/components/data_source_view/context/DataSourceBuilderContext";
-import type { DataSourceTag, DataSourceViewType, TagsFilter } from "@app/types";
+import type {
+  DataSourceTag,
+  DataSourceViewType,
+  TagsFilter,
+  TagsFilterMode,
+} from "@app/types";
 
 export function DataSourceViewTagsFilterDropdown() {
   const { owner } = useAgentBuilderContext();
-  const { updateSourcesTags } = useDataSourceBuilderContext();
+  const { updateSourcesTags, toggleInConversationFiltering } =
+    useDataSourceBuilderContext();
   const sources = useWatch<CapabilityFormData, "sources">({ name: "sources" });
 
   const dataSourceViews = sources.in.reduce((acc, source) => {
@@ -100,9 +107,11 @@ export function DataSourceViewTagsFilterDropdown() {
     [sources.in, updateSourcesTags]
   );
 
-  const { tagsIn, tagsNotIn } = useMemo(() => {
+  const { tagsIn, tagsNotIn, mode } = useMemo(() => {
     return sources.in.reduce(
       ({ tagsIn, tagsNotIn }, source) => {
+        let mode: TagsFilterMode = "custom";
+
         if (source.type === "data_source") {
           if (source.tagsFilter !== null) {
             tagsIn.push(
@@ -124,6 +133,7 @@ export function DataSourceViewTagsFilterDropdown() {
                   source.dataSourceView.dataSource.connectorProvider,
               }))
             );
+            mode = source.tagsFilter.mode;
           }
         } else if (source.type === "node") {
           if (source.tagsFilter !== null) {
@@ -146,17 +156,20 @@ export function DataSourceViewTagsFilterDropdown() {
                   source.node.dataSourceView.dataSource.connectorProvider,
               }))
             );
+            mode = source.tagsFilter.mode;
           }
         }
 
         return {
           tagsIn,
           tagsNotIn,
+          mode,
         };
       },
-      { tagsIn: [], tagsNotIn: [] } as {
+      { tagsIn: [], tagsNotIn: [], mode: "custom" } as {
         tagsIn: DataSourceTag[];
         tagsNotIn: DataSourceTag[];
+        mode: TagsFilterMode;
       }
     );
   }, [sources.in]);
@@ -203,6 +216,28 @@ export function DataSourceViewTagsFilterDropdown() {
             operation="not"
             showChipIcons
           />
+
+          <div className="text-sm">
+            <div className="mb-1 font-semibold">In-conversation filtering</div>
+            <div className="text-xs text-muted-foreground dark:text-muted-foreground-night">
+              Allow agents to determine filters to apply based on conversation
+              context.
+            </div>
+            <div className="mt-2 flex flex-row items-center space-x-4">
+              <SliderToggle
+                selected={mode === "auto"}
+                onClick={() =>
+                  toggleInConversationFiltering(
+                    mode === "custom" ? "auto" : "custom"
+                  )
+                }
+              />
+              <div className="font-medium">
+                {mode === "custom" ? "Enable" : "Disable"} in converation
+                filtering
+              </div>
+            </div>
+          </div>
         </div>
       </PopoverContent>
     </PopoverRoot>

--- a/front/components/agent_builder/capabilities/shared/DataSourceViewTagsFilterDropdown.tsx
+++ b/front/components/agent_builder/capabilities/shared/DataSourceViewTagsFilterDropdown.tsx
@@ -233,7 +233,7 @@ export function DataSourceViewTagsFilterDropdown() {
                 }
               />
               <div className="font-medium">
-                {mode === "custom" ? "Enable" : "Disable"} in converation
+                {mode === "custom" ? "Enable" : "Disable"} in conversation
                 filtering
               </div>
             </div>

--- a/front/components/agent_builder/capabilities/shared/SelectDataSourcesFilters.tsx
+++ b/front/components/agent_builder/capabilities/shared/SelectDataSourcesFilters.tsx
@@ -1,12 +1,4 @@
-import {
-  Button,
-  ContextItem,
-  MoreIcon,
-  PopoverContent,
-  PopoverRoot,
-  PopoverTrigger,
-  SliderToggle,
-} from "@dust-tt/sparkle";
+import { Button, ContextItem } from "@dust-tt/sparkle";
 import { useWatch } from "react-hook-form";
 
 import { DataSourceViewTagsFilterDropdown } from "@app/components/agent_builder/capabilities/shared/DataSourceViewTagsFilterDropdown";
@@ -17,10 +9,9 @@ import { useDataSourceBuilderContext } from "@app/components/data_source_view/co
 import { useTheme } from "@app/components/sparkle/ThemeContext";
 import { getConnectorProviderLogoWithFallback } from "@app/lib/connector_providers";
 import { getDisplayNameForDataSource } from "@app/lib/data_sources";
-import type { DataSourceViewType, TagsFilter } from "@app/types";
+import type { DataSourceViewType } from "@app/types";
 
 type DataSourceFilterItem = {
-  mode: NonNullable<TagsFilter>["mode"];
   dataSourceView: DataSourceViewType;
 };
 
@@ -29,10 +20,9 @@ type DataSourceFilterContextItemProps = {
 };
 
 function DataSourceFilterContextItem({
-  item: { dataSourceView, mode },
+  item: { dataSourceView },
 }: DataSourceFilterContextItemProps) {
   const { isDark } = useTheme();
-  const { toggleTagsMode } = useDataSourceBuilderContext();
   const { spaces } = useSpacesContext();
 
   const spaceName = spaces.find((s) => s.sId === dataSourceView.spaceId)?.name;
@@ -50,28 +40,6 @@ function DataSourceFilterContextItem({
         />
       }
       subElement={spaceName && <span className="text-xs">{spaceName}</span>}
-      action={
-        <PopoverRoot>
-          <PopoverTrigger asChild>
-            <Button icon={MoreIcon} variant="ghost" size="mini" />
-          </PopoverTrigger>
-
-          <PopoverContent align="end" className="w-72 text-sm">
-            <div className="mb-1 font-semibold">In-conversation filtering</div>
-            <div className="text-xs text-muted-foreground dark:text-muted-foreground-night">
-              Allow agents to determine filters to apply based on conversation
-              context.
-            </div>
-            <div className="mt-2 flex flex-row items-center justify-between">
-              <SliderToggle
-                selected={mode === "auto"}
-                onClick={() => toggleTagsMode(dataSourceView)}
-              />
-              <div className="font-medium">Enable in converation filtering</div>
-            </div>
-          </PopoverContent>
-        </PopoverRoot>
-      }
     />
   );
 }
@@ -85,12 +53,10 @@ export function SelectDataSourcesFilters() {
       if (source.type === "data_source") {
         acc[source.dataSourceView.dataSource.dustAPIDataSourceId] = {
           dataSourceView: source.dataSourceView,
-          mode: source.tagsFilter?.mode ?? "custom",
         };
       } else if (source.type === "node") {
         acc[source.node.dataSourceView.dataSource.dustAPIDataSourceId] = {
           dataSourceView: source.node.dataSourceView,
-          mode: source.tagsFilter?.mode ?? "custom",
         };
       }
 

--- a/front/types/data_source_view.ts
+++ b/front/types/data_source_view.ts
@@ -45,10 +45,11 @@ export type DataSourceViewSelectionConfiguration = {
   tagsFilter: TagsFilter;
 };
 
+export type TagsFilterMode = "custom" | "auto";
 export type TagsFilter = {
   in: string[];
   not: string[];
-  mode: "custom" | "auto";
+  mode: TagsFilterMode;
 } | null;
 
 export function defaultSelectionConfiguration(


### PR DESCRIPTION
## Description
Because we "merge" all the `tagsFilter.mode` for all the selected node and data_sources, take the last one into account as source of truth of what is the global selected mode (arbitrary). So for existing `mode` set before the release of ABv2, this is backward compatible as it will take the last data source into account, and setting/unsetting the toggle will update it all.

<img width="766" height="519" alt="Capture d’écran 2025-08-27 à 15 13 56" src="https://github.com/user-attachments/assets/e115c263-14db-477c-9cb8-039609235e2c" />
<img width="760" height="533" alt="Capture d’écran 2025-08-27 à 15 14 02" src="https://github.com/user-attachments/assets/73b6a7ec-c3db-49b2-b063-68e130271347" />

## Tests
- Locally

## Risk
Low, behind FF

## Deploy Plan
- Deploy front
