### PR TITLE
[front] - chore(AB v2): disable sorting removal child agent

### DIFF
--- a/extension/package-lock.json
+++ b/extension/package-lock.json
@@ -12,7 +12,7 @@
         "@auth0/auth0-spa-js": "^2.1.3",
         "@datadog/browser-logs": "^6.13.0",
         "@dust-tt/client": "^1.1.6",
-        "@dust-tt/sparkle": "^0.2.595",
+        "@dust-tt/sparkle": "^0.2.596",
         "@frontapp/plugin-sdk": "^1.8.1",
         "@modelcontextprotocol/sdk": "^1.9.0",
         "@tailwindcss/forms": "^0.5.9",
@@ -1293,9 +1293,9 @@
       }
     },
     "node_modules/@dust-tt/sparkle": {
-      "version": "0.2.595",
-      "resolved": "https://registry.npmjs.org/@dust-tt/sparkle/-/sparkle-0.2.595.tgz",
-      "integrity": "sha512-3Y9QVZMXjZktKLKs9hsa5TbG4C3BQ6PskLaPJoTarhHGEByOF0CT60Qu9/vpXHhBFCScnLpLEdiyByP66W/7qA==",
+      "version": "0.2.596",
+      "resolved": "https://registry.npmjs.org/@dust-tt/sparkle/-/sparkle-0.2.596.tgz",
+      "integrity": "sha512-5FKzJ1s6RnbwVIt7jDBIYFjjKe7Vlfr9gmSPPCIBb7UQ9/fIyG9QTOxLMHFs/97P9ESQfbqJZC5wl2i+PIgkLw==",
       "dependencies": {
         "@emoji-mart/data": "^1.1.2",
         "@emoji-mart/react": "^1.1.1",

--- a/extension/package.json
+++ b/extension/package.json
@@ -59,7 +59,7 @@
     "@auth0/auth0-spa-js": "^2.1.3",
     "@datadog/browser-logs": "^6.13.0",
     "@dust-tt/client": "^1.1.6",
-    "@dust-tt/sparkle": "^0.2.595",
+    "@dust-tt/sparkle": "^0.2.596",
     "@frontapp/plugin-sdk": "^1.8.1",
     "@modelcontextprotocol/sdk": "^1.9.0",
     "@tailwindcss/forms": "^0.5.9",

--- a/front/components/agent_builder/capabilities/shared/ChildAgentSection.tsx
+++ b/front/components/agent_builder/capabilities/shared/ChildAgentSection.tsx
@@ -49,6 +49,8 @@ function AgentSelectionTable({
         columns={columns}
         filter={searchQuery}
         filterColumn="name"
+        sorting={[{ id: "name", desc: false }]}
+        enableSortingRemoval={false}
       />
     </>
   );
@@ -120,6 +122,7 @@ export function ChildAgentSection() {
             </div>
           </DataTable.CellContent>
         ),
+        enableSortingRemoval: false,
         meta: {
           sizeRatio: 100,
         },

--- a/front/package-lock.json
+++ b/front/package-lock.json
@@ -7,7 +7,7 @@
       "dependencies": {
         "@datadog/browser-logs": "^6.13.0",
         "@dust-tt/client": "file:../sdks/js",
-        "@dust-tt/sparkle": "^0.2.595",
+        "@dust-tt/sparkle": "^0.2.596",
         "@google-cloud/bigquery": "^7.9.1",
         "@google-cloud/storage-transfer": "^3.6.0",
         "@heroicons/react": "^2.0.11",
@@ -1122,9 +1122,9 @@
       "link": true
     },
     "node_modules/@dust-tt/sparkle": {
-      "version": "0.2.595",
-      "resolved": "https://registry.npmjs.org/@dust-tt/sparkle/-/sparkle-0.2.595.tgz",
-      "integrity": "sha512-3Y9QVZMXjZktKLKs9hsa5TbG4C3BQ6PskLaPJoTarhHGEByOF0CT60Qu9/vpXHhBFCScnLpLEdiyByP66W/7qA==",
+      "version": "0.2.596",
+      "resolved": "https://registry.npmjs.org/@dust-tt/sparkle/-/sparkle-0.2.596.tgz",
+      "integrity": "sha512-5FKzJ1s6RnbwVIt7jDBIYFjjKe7Vlfr9gmSPPCIBb7UQ9/fIyG9QTOxLMHFs/97P9ESQfbqJZC5wl2i+PIgkLw==",
       "dependencies": {
         "@emoji-mart/data": "^1.1.2",
         "@emoji-mart/react": "^1.1.1",

--- a/front/package.json
+++ b/front/package.json
@@ -26,7 +26,7 @@
   "dependencies": {
     "@datadog/browser-logs": "^6.13.0",
     "@dust-tt/client": "file:../sdks/js",
-    "@dust-tt/sparkle": "^0.2.595",
+    "@dust-tt/sparkle": "^0.2.596",
     "@google-cloud/bigquery": "^7.9.1",
     "@google-cloud/storage-transfer": "^3.6.0",
     "@heroicons/react": "^2.0.11",


### PR DESCRIPTION
## Description

This PR adds default sorting by name in ascending order for the `AgentSelectionTable`. It also disables the removal of sorting for `AgentSelectionTable` to maintain consistent data view.

## Tests

Locally

## Risk

Low

## Deploy Plan

Deploy front
