### PR TITLE
Move Canvas instructions to MCP instructions rather than system prompt

### DIFF
--- a/front/lib/actions/mcp_internal_actions/constants.ts
+++ b/front/lib/actions/mcp_internal_actions/constants.ts
@@ -12,6 +12,7 @@ import {
   JIRA_SERVER_INSTRUCTIONS,
   SALESFORCE_SERVER_INSTRUCTIONS,
 } from "@app/lib/actions/mcp_internal_actions/instructions";
+import { CANVAS_INSTRUCTIONS } from "@app/lib/actions/mcp_internal_actions/servers/canvas/instructions";
 import type { InternalMCPServerDefinitionType } from "@app/lib/api/mcp";
 import { getResourceNameAndIdFromSId } from "@app/lib/resources/string_ids";
 import type {
@@ -732,7 +733,7 @@ The directive should be used to display a clickable version of the agent name in
       authorization: null,
       icon: "ActionDocumentTextIcon",
       documentationUrl: null,
-      instructions: null,
+      instructions: CANVAS_INSTRUCTIONS,
     },
   },
   outlook: {

--- a/front/lib/actions/mcp_internal_actions/servers/canvas/index.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/canvas/index.ts
@@ -4,6 +4,11 @@ import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod";
 
 import { MCPError } from "@app/lib/actions/mcp_errors";
+import {
+  CREATE_CANVAS_FILE_TOOL_NAME,
+  EDIT_CANVAS_FILE_TOOL_NAME,
+  RETRIEVE_CANVAS_FILE_TOOL_NAME,
+} from "@app/lib/actions/mcp_internal_actions/servers/canvas/types";
 import { makeInternalMCPServer } from "@app/lib/actions/mcp_internal_actions/utils";
 import { withToolLogging } from "@app/lib/actions/mcp_internal_actions/wrappers";
 import type { AgentLoopContextType } from "@app/lib/actions/types";
@@ -18,10 +23,6 @@ import { Err, Ok } from "@app/types";
 import { CANVAS_FILE_FORMATS } from "@app/types";
 
 const MAX_FILE_SIZE_BYTES = 1 * 1024 * 1024; // 1MB
-
-export const CREATE_CANVAS_FILE_TOOL_NAME = "create_canvas_file";
-export const EDIT_CANVAS_FILE_TOOL_NAME = "edit_canvas_file";
-export const RETRIEVE_CANVAS_FILE_TOOL_NAME = "retrieve_canvas_file";
 
 /**
  * Canvas Server - Allows the model to create and update canvas files.

--- a/front/lib/actions/mcp_internal_actions/servers/canvas/instructions.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/canvas/instructions.ts
@@ -2,10 +2,10 @@ import {
   CREATE_CANVAS_FILE_TOOL_NAME,
   EDIT_CANVAS_FILE_TOOL_NAME,
   RETRIEVE_CANVAS_FILE_TOOL_NAME,
-} from "@app/lib/actions/mcp_internal_actions/servers/canvas";
+} from "@app/lib/actions/mcp_internal_actions/servers/canvas/types";
 import { clientExecutableContentType } from "@app/types";
 
-export const visualizationWithCanvasSystemPrompt = () => `\
+export const CANVAS_INSTRUCTIONS = `\
 ## CREATING VISUALIZATIONS WITH CANVAS
 
 You have access to a canvas system that allows you to create and update executable files. When creating visualizations, you should create files instead of using the :::visualization directive.

--- a/front/lib/actions/mcp_internal_actions/servers/canvas/types.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/canvas/types.ts
@@ -1,0 +1,3 @@
+export const CREATE_CANVAS_FILE_TOOL_NAME = "create_canvas_file";
+export const EDIT_CANVAS_FILE_TOOL_NAME = "edit_canvas_file";
+export const RETRIEVE_CANVAS_FILE_TOOL_NAME = "retrieve_canvas_file";

--- a/front/lib/api/assistant/generation.ts
+++ b/front/lib/api/assistant/generation.ts
@@ -185,7 +185,7 @@ export async function constructPromptMultiActions(
     );
 
   // Only inject the visualization system prompt if the canvas server is not enabled.
-  if (!hasCanvasServer) {
+  if (agentConfiguration.visualizationEnabled && !hasCanvasServer) {
     guidelinesSection += `\n${visualizationSystemPrompt()}\n`;
   }
 

--- a/front/lib/api/assistant/generation.ts
+++ b/front/lib/api/assistant/generation.ts
@@ -16,7 +16,6 @@ import {
 } from "@app/lib/actions/types/guards";
 import { citationMetaPrompt } from "@app/lib/api/assistant/citations";
 import { visualizationSystemPrompt } from "@app/lib/api/assistant/visualization";
-import { visualizationWithCanvasSystemPrompt } from "@app/lib/api/assistant/visualization_with_canvas";
 import type { Authenticator } from "@app/lib/auth";
 import { getFeatureFlags } from "@app/lib/auth";
 import type {
@@ -185,11 +184,8 @@ export async function constructPromptMultiActions(
       isMCPConfigurationForInternalCanvas(action)
     );
 
-  // If canvas server is enabled, use the canvas system prompt over the
-  // visualization system prompt.
-  if (hasCanvasServer) {
-    guidelinesSection += `\n${visualizationWithCanvasSystemPrompt()}\n`;
-  } else if (agentConfiguration.visualizationEnabled) {
+  // Only inject the visualization system prompt if the canvas server is not enabled.
+  if (!hasCanvasServer) {
     guidelinesSection += `\n${visualizationSystemPrompt()}\n`;
   }
 


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
Fixes https://github.com/dust-tt/tasks/issues/3936.

This PR moves the Canvas system prompt to the server instructions to consolidate everything in one place.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
