### PR TITLE
[SDK] Add `retryMessage` method in SDK

### DIFF
--- a/sdks/js/package-lock.json
+++ b/sdks/js/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@dust-tt/client",
-  "version": "1.1.8",
+  "version": "1.1.9",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@dust-tt/client",
-      "version": "1.1.8",
+      "version": "1.1.9",
       "bundleDependencies": [
         "@modelcontextprotocol/sdk"
       ],

--- a/sdks/js/package.json
+++ b/sdks/js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dust-tt/client",
-  "version": "1.1.8",
+  "version": "1.1.9",
   "description": "Client for Dust API",
   "repository": {
     "type": "git",

--- a/sdks/js/src/index.ts
+++ b/sdks/js/src/index.ts
@@ -78,6 +78,7 @@ import {
   PostUserMessageResponseSchema,
   PostWorkspaceSearchResponseBodySchema,
   RegisterMCPResponseSchema,
+  RetryMessageResponseSchema,
   Result,
   RunAppResponseSchema,
   SearchDataSourceViewsResponseSchema,
@@ -1365,6 +1366,35 @@ export class DustAPI {
       return r;
     }
     return new Ok(r.value.nodes);
+  }
+
+  async retryMessage({
+    conversationId,
+    messageId,
+    blockedOnly = false,
+  }: {
+    conversationId: string;
+    messageId: string;
+    blockedOnly?: boolean;
+  }) {
+    const query = blockedOnly 
+      ? new URLSearchParams({ blocked_only: "true" })
+      : undefined;
+
+    const res = await this.request({
+      method: "POST",
+      path: `assistant/conversations/${conversationId}/messages/${messageId}/retry`,
+      query,
+    });
+
+    const r = await this._resultFromResponse(
+      RetryMessageResponseSchema,
+      res
+    );
+    if (r.isErr()) {
+      return r;
+    }
+    return new Ok(r.value.message);
   }
 
   private async _fetchWithError(

--- a/sdks/js/src/types.ts
+++ b/sdks/js/src/types.ts
@@ -1729,6 +1729,11 @@ export type PostUserMessageResponseType = z.infer<
   typeof PostUserMessageResponseSchema
 >;
 
+export const RetryMessageResponseSchema = z.object({
+  message: AgentMessageTypeSchema,
+});
+export type RetryMessageResponseType = z.infer<typeof RetryMessageResponseSchema>;
+
 export const GetConversationResponseSchema = z.object({
   conversation: ConversationSchema,
 });


### PR DESCRIPTION
## Description

- This PR adds a method to retry a message on the `DustAPI` class.
- This will be useful for both the extension and the Slack bot.

## Tests

## Risk

- Low.

## Deploy Plan

- Publish SDK.
