### PR TITLE
New triggerId column in conversation

### DIFF
--- a/front/components/assistant/conversation/SidebarMenu.tsx
+++ b/front/components/assistant/conversation/SidebarMenu.tsx
@@ -492,7 +492,7 @@ const RenderConversation = ({
           icon={
             conversation.actionRequired
               ? ActionRequiredIcon
-              : conversation.visibility === "triggered"
+              : conversation.triggerId
                 ? ClockIcon
                 : undefined
           }

--- a/front/lib/api/assistant/conversation.ts
+++ b/front/lib/api/assistant/conversation.ts
@@ -115,10 +115,12 @@ export async function createConversation(
     title,
     visibility,
     depth = 0,
+    triggerId,
   }: {
     title: string | null;
     visibility: ConversationVisibility;
     depth?: number;
+    triggerId?: ModelId | null;
   }
 ): Promise<ConversationType> {
   const owner = auth.getNonNullableWorkspace();
@@ -128,6 +130,7 @@ export async function createConversation(
     title,
     visibility,
     depth,
+    triggerId: triggerId || null,
     requestedGroupIds: [],
   });
 
@@ -139,6 +142,7 @@ export async function createConversation(
     title: conversation.title,
     visibility: conversation.visibility,
     depth: conversation.depth,
+    triggerId: conversation.triggerId,
     content: [],
     requestedGroupIds:
       conversation.getConversationRequestedGroupIdsFromModel(auth),

--- a/front/lib/api/assistant/conversation.ts
+++ b/front/lib/api/assistant/conversation.ts
@@ -130,7 +130,7 @@ export async function createConversation(
     title,
     visibility,
     depth,
-    triggerId: triggerId || null,
+    triggerId,
     requestedGroupIds: [],
   });
 

--- a/front/lib/api/assistant/conversation/fetch.ts
+++ b/front/lib/api/assistant/conversation/fetch.ts
@@ -126,6 +126,7 @@ export async function getConversation(
     title: conversation.title,
     visibility: conversation.visibility,
     depth: conversation.depth,
+    triggerId: conversation.triggerId,
     content,
     requestedGroupIds:
       conversation.getConversationRequestedGroupIdsFromModel(auth),

--- a/front/lib/models/assistant/conversation.ts
+++ b/front/lib/models/assistant/conversation.ts
@@ -3,6 +3,7 @@ import { DataTypes } from "sequelize";
 
 import type { AgentMessageFeedbackDirection } from "@app/lib/api/assistant/conversation/feedbacks";
 import type { AgentStepContentModel } from "@app/lib/models/assistant/agent_step_content";
+import type { TriggerModel } from "@app/lib/models/assistant/triggers";
 import { frontSequelize } from "@app/lib/resources/storage";
 import { ContentFragmentModel } from "@app/lib/resources/storage/models/content_fragment";
 import { UserModel } from "@app/lib/resources/storage/models/user";
@@ -23,6 +24,7 @@ export class ConversationModel extends WorkspaceAwareModel<ConversationModel> {
   declare title: string | null;
   declare visibility: CreationOptional<ConversationVisibility>;
   declare depth: CreationOptional<number>;
+  declare triggerId: ForeignKey<TriggerModel["id"]> | null;
 
   declare requestedGroupIds: number[][];
 }
@@ -61,6 +63,11 @@ ConversationModel.init(
       type: DataTypes.ARRAY(DataTypes.ARRAY(DataTypes.BIGINT)),
       allowNull: false,
       defaultValue: [],
+    },
+    triggerId: {
+      type: DataTypes.BIGINT,
+      allowNull: true,
+      defaultValue: null,
     },
   },
   {

--- a/front/lib/resources/conversation_resource.ts
+++ b/front/lib/resources/conversation_resource.ts
@@ -342,6 +342,7 @@ export class ConversationResource extends BaseResource<ConversationModel> {
       title: conversation.title,
       visibility: conversation.visibility,
       depth: conversation.depth,
+      triggerId: conversation.triggerId,
       requestedGroupIds:
         conversation.getConversationRequestedGroupIdsFromModel(auth),
     });
@@ -371,7 +372,6 @@ export class ConversationResource extends BaseResource<ConversationModel> {
 
     const includedConversationVisibilities: ConversationVisibility[] = [
       "unlisted",
-      "triggered",
     ];
 
     if (options?.includeDeleted) {
@@ -421,6 +421,7 @@ export class ConversationResource extends BaseResource<ConversationModel> {
           title: c.title,
           visibility: c.visibility,
           depth: c.depth,
+          triggerId: c.triggerId,
           requestedGroupIds: new this(
             this.model,
             c.get()

--- a/front/migrations/db/migration_349.sql
+++ b/front/migrations/db/migration_349.sql
@@ -1,0 +1,14 @@
+-- Migration created on Aug 27, 2025
+
+-- Add triggerId column to conversations table as an optional foreign key to triggers table
+ALTER TABLE conversations 
+ADD COLUMN "triggerId" bigint DEFAULT NULL 
+REFERENCES "triggers" ("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- Add index for triggerId lookups
+CREATE INDEX "conversations_trigger_id" ON "conversations" ("triggerId");
+
+-- Migrate existing conversations with visibility 'triggered' to 'unlisted'. We only used 'triggered' briefly
+UPDATE conversations
+SET visibility='unlisted'
+WHERE visibility='triggered';

--- a/front/temporal/agent_schedule/activities.ts
+++ b/front/temporal/agent_schedule/activities.ts
@@ -31,7 +31,8 @@ export async function runScheduledAgentsActivity(
 
   const newConversation = await createConversation(auth, {
     title: `@${agentConfiguration.name} scheduled call - ${new Date().toLocaleDateString()}`,
-    visibility: "triggered",
+    visibility: "unlisted",
+    triggerId: trigger.id,
   });
 
   const baseContext = {

--- a/front/types/api/internal/assistant.ts
+++ b/front/types/api/internal/assistant.ts
@@ -183,7 +183,6 @@ export const InternalPostConversationsRequestBodySchema = t.type({
   title: t.union([t.string, t.null]),
   visibility: t.union([
     t.literal("unlisted"),
-    t.literal("triggered"),
     t.literal("deleted"),
     t.literal("test"),
   ]),

--- a/front/types/assistant/conversation.ts
+++ b/front/types/assistant/conversation.ts
@@ -206,7 +206,6 @@ export function isAgentMessageType(arg: MessageType): arg is AgentMessageType {
  */
 export type ConversationVisibility =
   | "unlisted"
-  | "triggered"
   | "deleted"
   | "test";
 
@@ -224,6 +223,7 @@ export type ConversationWithoutContentType = {
   title: string | null;
   visibility: ConversationVisibility;
   depth: number;
+  triggerId: ModelId | null;
   requestedGroupIds: string[][];
 };
 

--- a/front/types/assistant/conversation.ts
+++ b/front/types/assistant/conversation.ts
@@ -204,10 +204,7 @@ export function isAgentMessageType(arg: MessageType): arg is AgentMessageType {
  * when a user 'tests' an agent not in their list using the "test" button:
  * those conversations do not show in users' histories.
  */
-export type ConversationVisibility =
-  | "unlisted"
-  | "deleted"
-  | "test";
+export type ConversationVisibility = "unlisted" | "deleted" | "test";
 
 /**
  * A lighter version of Conversation without the content (for menu display).

--- a/sdks/js/src/types.ts
+++ b/sdks/js/src/types.ts
@@ -926,7 +926,7 @@ const AgentMessageFeedbackSchema = z.object({
 });
 
 const ConversationVisibilitySchema = FlexibleEnumSchema<
-  "unlisted" | "triggered" | "workspace" | "deleted" | "test"
+  "unlisted" | "workspace" | "deleted" | "test"
 >();
 
 export type ConversationVisibility = z.infer<


### PR DESCRIPTION
## Description

Add a triggerId column to the conversations table. It’s a FK into the triggers table. But note that it’s optional, as not every conversation is created from a trigger.

Also, get rid of the "triggered" value from ConversationVisibility, since we’ll now be able to tell based on the new triggerId column. Instead, triggered conversation should just have the normal "unlisted" value.

Note that at this time, we won’t yet be using the actual value of triggerId. This will come later.

Note that existing triggered conversations will lose their clock icon, since they don't have a triggerId. We can live with this, as it's still under a flag with low usage.

## Tests

Manual

## Risk

Low

## Deploy Plan

Need to run migration first, then deploy