### PR TITLE
[sparkle] fix: Nicer background overlay color in dark mode

### DIFF
--- a/sparkle/src/components/Dialog.tsx
+++ b/sparkle/src/components/Dialog.tsx
@@ -24,7 +24,7 @@ const DialogOverlay = React.forwardRef<
   <DialogPrimitive.Overlay
     className={cn(
       "s-fixed s-inset-0 s-z-50 data-[state=open]:s-animate-in data-[state=closed]:s-animate-out data-[state=closed]:s-fade-out-0 data-[state=open]:s-fade-in-0",
-      "s-bg-muted-foreground/75 dark:s-bg-muted-foreground-night/75",
+      "s-bg-muted-foreground/75 dark:s-bg-muted-background-night/75",
       className
     )}
     {...props}

--- a/sparkle/src/components/Sheet.tsx
+++ b/sparkle/src/components/Sheet.tsx
@@ -22,7 +22,7 @@ const SheetOverlay = React.forwardRef<
   <SheetPrimitive.Overlay
     className={cn(
       "s-fixed s-inset-0 s-z-50",
-      "s-bg-muted-foreground/75 dark:s-bg-muted-foreground-night/75",
+      "s-bg-muted-foreground/75 dark:s-bg-muted-background-night/75",
       "data-[state=open]:s-animate-in data-[state=closed]:s-animate-out",
       "data-[state=closed]:s-fade-out-0 data-[state=open]:s-fade-in-0",
       className


### PR DESCRIPTION
 ## Description
- Better background color for the overlay of Sheet and Dialog in dark mode

#### Before
<img width="1866" height="923" alt="Capture d’écran 2025-08-27 à 16 02 56" src="https://github.com/user-attachments/assets/88af99b9-92f1-4997-b988-39a19ec78d56" />

#### After
<img width="1582" height="966" alt="Capture d’écran 2025-08-27 à 16 10 33" src="https://github.com/user-attachments/assets/48fc04f9-e048-4db0-8799-98109369cbb6" />


## Tests
- Published sparkle alpha, tested locally

## Risk
- Low

## Deploy Plan
- Publish sparkle
