### PR TITLE
[front] Handle missing `toolServerId` when retrieving MCP server name

### DIFF
--- a/front/lib/resources/agent_mcp_action_resource.ts
+++ b/front/lib/resources/agent_mcp_action_resource.ts
@@ -91,9 +91,9 @@ export class AgentMCPActionResource extends BaseResource<AgentMCPActionModel> {
 
       // Each action must have a step content.
       assert(stepContent, "Step content not found.");
-      const internalMCPServerName = getInternalMCPServerNameFromSId(
-        a.toolConfiguration.toolServerId
-      );
+      const internalMCPServerName = a.toolConfiguration.toolServerId
+        ? getInternalMCPServerNameFromSId(a.toolConfiguration.toolServerId)
+        : null;
 
       return new this(this.model, a.get(), stepContent, {
         internalMCPServerName,


### PR DESCRIPTION
## Description

- Context [here](https://dust4ai.slack.com/archives/C050SM8NSPK/p1756305670386769).

## Tests

## Risk


## Deploy Plan

- Deploy front.
