### PR TITLE
[front] Transform citations from subagent

### DIFF
--- a/front/lib/actions/mcp_internal_actions/servers/run_agent/index.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/run_agent/index.ts
@@ -456,7 +456,9 @@ export default async function createServer(
           finalContent = finalContent.replace(citationRegex, `$1${newRef}$2`);
           newRefs[newRef] = refsFromAgent[refKeyFromAgent];
         } else {
-          // Remove the citation reference and clean up formatting
+          // We run out of available refs, meaning we have more refs in output than
+          // RUN_AGENT_ACTION_NUM_RESULTS, so we remove the remaining citation reference and
+          // clean up formatting.
           const citationRegex = new RegExp(
             `(:cite\\[[^\\]]*\\b)${refKeyFromAgent}\\b(?:,([^\\]]*\\])|([^\\]]*\\]))`,
             "g"

--- a/front/lib/actions/types/guards.ts
+++ b/front/lib/actions/types/guards.ts
@@ -169,6 +169,15 @@ export function isMCPInternalWebsearch(
   );
 }
 
+export function isMCPInternalRunAgent(
+  arg: MCPToolConfigurationType
+): arg is ServerSideMCPToolConfigurationType {
+  return (
+    isServerSideMCPToolConfiguration(arg) &&
+    isInternalMCPServerOfName(arg.internalMCPServerId, "run_agent")
+  );
+}
+
 export function isMCPInternalSlack(
   arg: MCPToolConfigurationType
 ): arg is ServerSideMCPToolConfigurationType {

--- a/front/lib/actions/utils.ts
+++ b/front/lib/actions/utils.ts
@@ -27,7 +27,7 @@ import { assertNever } from "@app/types";
 export const WEBSEARCH_ACTION_NUM_RESULTS = 16;
 export const SLACK_SEARCH_ACTION_NUM_RESULTS = 24;
 export const NOTION_SEARCH_ACTION_NUM_RESULTS = 16;
-export const RUN_AGENT_ACTION_NUM_RESULTS = 32;
+export const RUN_AGENT_ACTION_NUM_RESULTS = 64;
 
 export const MCP_SPECIFICATION: ActionSpecification = {
   label: "More...",

--- a/front/lib/actions/utils.ts
+++ b/front/lib/actions/utils.ts
@@ -14,6 +14,7 @@ import {
   isMCPInternalDataSourceFileSystem,
   isMCPInternalInclude,
   isMCPInternalNotion,
+  isMCPInternalRunAgent,
   isMCPInternalSearch,
   isMCPInternalSlack,
   isMCPInternalWebsearch,
@@ -26,6 +27,7 @@ import { assertNever } from "@app/types";
 export const WEBSEARCH_ACTION_NUM_RESULTS = 16;
 export const SLACK_SEARCH_ACTION_NUM_RESULTS = 24;
 export const NOTION_SEARCH_ACTION_NUM_RESULTS = 16;
+export const RUN_AGENT_ACTION_NUM_RESULTS = 32;
 
 export const MCP_SPECIFICATION: ActionSpecification = {
   label: "More...",
@@ -177,6 +179,10 @@ export function getCitationsCount({
 
   if (isMCPInternalNotion(action)) {
     return NOTION_SEARCH_ACTION_NUM_RESULTS;
+  }
+
+  if (isMCPInternalRunAgent(action)) {
+    return RUN_AGENT_ACTION_NUM_RESULTS;
   }
 
   return getRetrievalTopK({


### PR DESCRIPTION
## Description

This transform the citations that are received from a sub agent execution by new citations ref available for this action. `run_agent` can have up to 32 citations, if the result contains more, they will be removed.

## Tests

locally

## Risk

limited, only on sub agents citations

## Deploy Plan

deploy front
