### PR TITLE
[front] - fix(AB v2): excluded nodes retrieval

### DIFF
--- a/front/components/agent_builder/capabilities/knowledge/KnowledgeConfigurationSheet.tsx
+++ b/front/components/agent_builder/capabilities/knowledge/KnowledgeConfigurationSheet.tsx
@@ -1,6 +1,7 @@
 import type { MultiPageSheetPage } from "@dust-tt/sparkle";
 import { MultiPageSheet, MultiPageSheetContent } from "@dust-tt/sparkle";
 import { zodResolver } from "@hookform/resolvers/zod";
+import isEmpty from "lodash/isEmpty";
 import uniqueId from "lodash/uniqueId";
 import { useContext, useEffect, useMemo, useState } from "react";
 import { FormProvider, useForm, useWatch } from "react-hook-form";
@@ -44,7 +45,6 @@ import { SEARCH_SERVER_NAME } from "@app/lib/actions/mcp_internal_actions/consta
 import { getMCPServerRequirements } from "@app/lib/actions/mcp_internal_actions/input_configuration";
 import type { MCPServerViewType } from "@app/lib/api/mcp";
 import type { TemplateActionPreset } from "@app/types";
-import isEmpty from "lodash/isEmpty";
 
 interface KnowledgeConfigurationSheetProps {
   onSave: (action: AgentBuilderAction) => void;

--- a/front/components/agent_builder/capabilities/knowledge/KnowledgeConfigurationSheet.tsx
+++ b/front/components/agent_builder/capabilities/knowledge/KnowledgeConfigurationSheet.tsx
@@ -44,6 +44,7 @@ import { SEARCH_SERVER_NAME } from "@app/lib/actions/mcp_internal_actions/consta
 import { getMCPServerRequirements } from "@app/lib/actions/mcp_internal_actions/input_configuration";
 import type { MCPServerViewType } from "@app/lib/api/mcp";
 import type { TemplateActionPreset } from "@app/types";
+import isEmpty from "lodash/isEmpty";
 
 interface KnowledgeConfigurationSheetProps {
   onSave: (action: AgentBuilderAction) => void;
@@ -73,7 +74,11 @@ function getKnowledgeDefaultValues({
   const tablesConfigurations = action?.configuration?.tablesConfigurations;
 
   // Use either data source or tables configurations - they're mutually exclusive
-  const configurationToUse = dataSourceConfigurations || tablesConfigurations;
+  const configurationToUse = isEmpty(dataSourceConfigurations)
+    ? isEmpty(tablesConfigurations)
+      ? {}
+      : tablesConfigurations
+    : dataSourceConfigurations;
 
   const dataSourceTree =
     configurationToUse && action

--- a/front/components/agent_builder/capabilities/knowledge/transformations.ts
+++ b/front/components/agent_builder/capabilities/knowledge/transformations.ts
@@ -133,14 +133,14 @@ export function transformSelectionConfigurationsToTree(
     const baseParts = buildDataSourcePath(dataSourceView);
 
     // If all nodes are selected, just add the data source path
-    inPaths.push({
-      path: baseParts,
-      name: dataSourceView.dataSource.name,
-      type: "data_source",
-      dataSourceView,
-      tagsFilter: config.tagsFilter,
-    });
     if (config.isSelectAll) {
+      inPaths.push({
+        path: baseParts,
+        name: dataSourceView.dataSource.name,
+        type: "data_source",
+        dataSourceView,
+        tagsFilter: config.tagsFilter,
+      });
       continue;
     }
 

--- a/front/components/agent_builder/capabilities/knowledge/transformations.ts
+++ b/front/components/agent_builder/capabilities/knowledge/transformations.ts
@@ -132,15 +132,15 @@ export function transformSelectionConfigurationsToTree(
     const { dataSourceView } = config;
     const baseParts = buildDataSourcePath(dataSourceView);
 
+    // If all nodes are selected, just add the data source path
+    inPaths.push({
+      path: baseParts,
+      name: dataSourceView.dataSource.name,
+      type: "data_source",
+      dataSourceView,
+      tagsFilter: config.tagsFilter,
+    });
     if (config.isSelectAll) {
-      // If all nodes are selected, just add the data source path
-      inPaths.push({
-        path: baseParts,
-        name: dataSourceView.dataSource.name,
-        type: "data_source",
-        dataSourceView,
-        tagsFilter: config.tagsFilter,
-      });
       continue;
     }
 

--- a/front/components/assistant_builder/server_side_props_helpers.ts
+++ b/front/components/assistant_builder/server_side_props_helpers.ts
@@ -244,7 +244,7 @@ async function renderDataSourcesConfigurations(
       if (sr.excludedResources && sr.excludedResources.length > 0) {
         const excludedContentNodes = await getContentNodesForDataSourceView(
           dataSourceView,
-          { internalIds: sr.excludedResources, viewType: "document" }
+          { internalIds: sr.excludedResources, viewType: "all" }
         );
         if (excludedContentNodes.isErr()) {
           localLogger.error(


### PR DESCRIPTION
## Description

Fixes an issue with excluded nodes retrieval in Agent Builder v2 by:
- Using the correct viewType ("all" instead of "document") when fetching excluded resources from data source configurations
- Streamlining the selection configuration logic by handling empty configurations properly

## Tests

- [ ] Locally
- [ ] front-edge

## Risk

Low

## Deploy Plan

Deploy front
