### PR TITLE
[front] Fix statuses in personal auth flow

### DIFF
--- a/front/lib/actions/mcp.ts
+++ b/front/lib/actions/mcp.ts
@@ -528,6 +528,9 @@ export async function* runToolWithStreaming(
 
       return;
     } else if (toolErr instanceof ToolBlockedAwaitingInputError) {
+      // Update the action status to blocked_child_action_input_required to break the agent loop.
+      await action.updateStatus("blocked_child_action_input_required");
+
       // Update the step context to save the resume state.
       await action.updateStepContext({
         ...action.stepContext,

--- a/front/temporal/agent_loop/activities/run_tool.ts
+++ b/front/temporal/agent_loop/activities/run_tool.ts
@@ -116,9 +116,6 @@ export async function runToolActivity(
 
       case "tool_personal_auth_required":
       case "tool_approve_execution":
-        // Update the action status to blocked_child_action_input_required to break the agent loop.
-        await action.updateStatus("blocked_child_action_input_required");
-
         // Defer personal auth events to be sent after all tools complete.
         deferredEvents.push({
           event,


### PR DESCRIPTION
## Description

- We don't set the correct status in the personal authentication flow, overfitting on the sub agent setup.
- Not a huge deal as we don't rely on `blocked_authentication_required` being set correct vs `blocked_child_action_input_required` but not great either.

## Tests

- Tested locally with a sub agent setup, `the main agent's action is `blocked_child_action_input_required` and the sub agent's is `blocked_authentication_required`.

## Risk

- Low.

## Deploy Plan

- Deploy front.
