### PR TITLE
Split data source file system tools

### DIFF
--- a/front/components/agent_builder/MCPServerViewsContext.tsx
+++ b/front/components/agent_builder/MCPServerViewsContext.tsx
@@ -103,10 +103,16 @@ function getGroupedMCPServerViews({
     groupBy(mcpServerViewsWithLabel, (view) => {
       const requirements = getMCPServerRequirements(view);
 
+      // Special handling for canvas server:
+      // The canvas server includes list and cat tools for convenience, but its primary purpose is
+      // not data source operations. We don't want it to be classified as requiring knowledge.
+      const isCanvasServer = view.server.name === "canvas";
+
       const isWithKnowledge =
-        requirements.requiresDataSourceConfiguration ||
-        requirements.requiresDataWarehouseConfiguration ||
-        requirements.requiresTableConfiguration;
+        !isCanvasServer &&
+        (requirements.requiresDataSourceConfiguration ||
+          requirements.requiresDataWarehouseConfiguration ||
+          requirements.requiresTableConfiguration);
 
       return isWithKnowledge
         ? "mcpServerViewsWithKnowledge"

--- a/front/components/assistant_builder/useTools.ts
+++ b/front/components/assistant_builder/useTools.ts
@@ -95,10 +95,16 @@ function getGroupedMCPServerViews({
     groupBy(mcpServerViewsWithLabel, (view) => {
       const requirements = getMCPServerRequirements(view);
 
+      // Special handling for canvas server:
+      // The canvas server includes list and cat tools for convenience, but its primary purpose is
+      // not data source operations. We don't want it to be classified as requiring knowledge.
+      const isCanvasServer = view.server.name === "canvas";
+
       const isWithKnowledge =
-        requirements.requiresDataSourceConfiguration ||
-        requirements.requiresDataWarehouseConfiguration ||
-        requirements.requiresTableConfiguration;
+        !isCanvasServer &&
+        (requirements.requiresDataSourceConfiguration ||
+          requirements.requiresDataWarehouseConfiguration ||
+          requirements.requiresTableConfiguration);
 
       return isWithKnowledge
         ? "mcpServerViewsWithKnowledge"

--- a/front/lib/actions/mcp_internal_actions/servers/canvas/index.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/canvas/index.ts
@@ -9,6 +9,8 @@ import {
   EDIT_CANVAS_FILE_TOOL_NAME,
   RETRIEVE_CANVAS_FILE_TOOL_NAME,
 } from "@app/lib/actions/mcp_internal_actions/servers/canvas/types";
+import { registerCatTool } from "@app/lib/actions/mcp_internal_actions/servers/data_sources_file_system/cat_tool";
+import { registerListTool } from "@app/lib/actions/mcp_internal_actions/servers/data_sources_file_system/list_tool";
 import { makeInternalMCPServer } from "@app/lib/actions/mcp_internal_actions/utils";
 import { withToolLogging } from "@app/lib/actions/mcp_internal_actions/wrappers";
 import type { AgentLoopContextType } from "@app/lib/actions/types";
@@ -281,6 +283,31 @@ const createServer = (
       }
     )
   );
+
+  // Register data source file system tools for canvas server with custom descriptions
+  // tailored for canvas use cases (visual assets and templates).
+  registerListTool(auth, server, agentLoopContext, {
+    toolName: "list_assets",
+    toolDescription:
+      "Browse available visual assets and templates in the connected data sources. " +
+      "Use this to explore folders containing images, icons, slideshow templates, " +
+      "or other resources that can be incorporated into canvas files.\n\n" +
+      "List the direct contents of a node. Can be used to see what is inside a specific folder from " +
+      "the filesystem, like 'ls' in Unix. A good fit is to explore the filesystem structure step " +
+      "by step. This tool can be called repeatedly by passing the 'nodeId' output from a step to " +
+      "the next step's nodeId. If a node output by this tool has children " +
+      "(hasChildren: true), it means that this tool can be used again on it.",
+  });
+
+  registerCatTool(auth, server, agentLoopContext, {
+    toolName: "cat_assets",
+    toolDescription:
+      "Read template files or asset configurations from the connected data sources. " +
+      "Use this to retrieve slideshow templates, HTML/CSS snippets, React component examples, " +
+      "or configuration files that can serve as a starting point or be incorporated into canvas files.\n\n" +
+      "Read the contents of a document, referred to by its nodeId (named after the 'cat' unix tool). " +
+      "The nodeId can be obtained using the 'list_assets' tool.",
+  });
 
   return server;
 };

--- a/front/lib/actions/mcp_internal_actions/servers/data_sources_file_system/cat_tool.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/data_sources_file_system/cat_tool.ts
@@ -1,0 +1,166 @@
+import { INTERNAL_MIME_TYPES } from "@dust-tt/client";
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { z } from "zod";
+
+import { MCPError } from "@app/lib/actions/mcp_errors";
+import { FILESYSTEM_CAT_TOOL_NAME } from "@app/lib/actions/mcp_internal_actions/constants";
+import { ConfigurableToolInputSchemas } from "@app/lib/actions/mcp_internal_actions/input_schemas";
+import { renderNode } from "@app/lib/actions/mcp_internal_actions/rendering";
+import {
+  getAgentDataSourceConfigurations,
+  makeDataSourceViewFilter,
+} from "@app/lib/actions/mcp_internal_actions/servers/utils";
+import { withToolLogging } from "@app/lib/actions/mcp_internal_actions/wrappers";
+import type { AgentLoopContextType } from "@app/lib/actions/types";
+import config from "@app/lib/api/config";
+import type { Authenticator } from "@app/lib/auth";
+import logger from "@app/logger/logger";
+import { CoreAPI, Err, Ok } from "@app/types";
+
+const catToolInputSchema = {
+  dataSources:
+    ConfigurableToolInputSchemas[INTERNAL_MIME_TYPES.TOOL_INPUT.DATA_SOURCE],
+  nodeId: z.string().describe("The ID of the node to read."),
+  offset: z
+    .number()
+    .optional()
+    .describe(
+      "The character position to start reading from (0-based). If not provided, starts from " +
+        "the beginning."
+    ),
+  limit: z
+    .number()
+    .optional()
+    .describe(
+      "The maximum number of characters to read. If not provided, reads all characters."
+    ),
+  grep: z
+    .string()
+    .optional()
+    .describe(
+      "A regular expression to filter lines. Applied after offset/limit slicing. Only lines " +
+        "matching this pattern will be returned."
+    ),
+};
+
+interface CatToolOptions {
+  toolName?: string;
+  toolDescription?: string;
+}
+
+export function registerCatTool(
+  auth: Authenticator,
+  server: McpServer,
+  agentLoopContext?: AgentLoopContextType,
+  options: CatToolOptions = {}
+) {
+  const toolName = options.toolName || FILESYSTEM_CAT_TOOL_NAME;
+  const toolDescription =
+    options.toolDescription ||
+    "Read the contents of a document, referred to by its nodeId (named after the 'cat' unix tool). " +
+      "The nodeId can be obtained using the 'find', 'list' or 'search' tools.";
+
+  server.tool(
+    toolName,
+    toolDescription,
+    catToolInputSchema,
+    withToolLogging(
+      auth,
+      { toolName: FILESYSTEM_CAT_TOOL_NAME, agentLoopContext },
+      async ({ dataSources, nodeId, offset, limit, grep }) => {
+        const coreAPI = new CoreAPI(config.getCoreAPIConfig(), logger);
+
+        // Gather data source configurations.
+        const fetchResult = await getAgentDataSourceConfigurations(
+          auth,
+          dataSources
+        );
+
+        if (fetchResult.isErr()) {
+          return new Err(new MCPError(fetchResult.error.message));
+        }
+        const agentDataSourceConfigurations = fetchResult.value;
+
+        // Search the node using our search api.
+        const searchResult = await coreAPI.searchNodes({
+          filter: {
+            node_ids: [nodeId],
+            data_source_views: makeDataSourceViewFilter(
+              agentDataSourceConfigurations
+            ),
+          },
+        });
+
+        if (searchResult.isErr() || searchResult.value.nodes.length === 0) {
+          return new Err(
+            new MCPError(
+              `Could not find node: ${nodeId} (error: ${
+                searchResult.isErr() ? searchResult.error : "No nodes found"
+              })`,
+              { tracked: false }
+            )
+          );
+        }
+
+        const node = searchResult.value.nodes[0];
+
+        if (node.node_type !== "document") {
+          return new Err(
+            new MCPError(`Node is of type ${node.node_type}, not a document.`, {
+              tracked: false,
+            })
+          );
+        }
+
+        // Get dataSource from the data source configuration.
+        const dataSource = agentDataSourceConfigurations.find(
+          (config) =>
+            config.dataSource.dustAPIDataSourceId === node.data_source_id
+        )?.dataSource;
+
+        if (!dataSource) {
+          return new Err(
+            new MCPError(`Could not find dataSource for node: ${nodeId}`)
+          );
+        }
+
+        const dataSourceIdToConnectorMap = new Map();
+        dataSourceIdToConnectorMap.set(
+          dataSource.dustAPIDataSourceId,
+          dataSource.connectorProvider
+        );
+
+        // Read the node.
+        const readResult = await coreAPI.getDataSourceDocumentText({
+          dataSourceId: node.data_source_id,
+          documentId: node.node_id,
+          projectId: dataSource.dustAPIProjectId,
+          offset: offset,
+          limit: limit,
+          grep: grep,
+        });
+
+        if (readResult.isErr()) {
+          return new Err(
+            new MCPError(
+              `Could not read node: ${nodeId} (error: ${readResult.error})`
+            )
+          );
+        }
+
+        return new Ok([
+          {
+            type: "resource" as const,
+            resource: {
+              mimeType:
+                INTERNAL_MIME_TYPES.TOOL_OUTPUT.DATA_SOURCE_NODE_CONTENT,
+              uri: node.source_url ?? "",
+              text: readResult.value.text,
+              metadata: renderNode(node, dataSourceIdToConnectorMap),
+            },
+          },
+        ]);
+      }
+    )
+  );
+}

--- a/front/lib/actions/mcp_internal_actions/servers/data_sources_file_system/index.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/data_sources_file_system/index.ts
@@ -6,9 +6,7 @@ import { z } from "zod";
 
 import { MCPError } from "@app/lib/actions/mcp_errors";
 import {
-  FILESYSTEM_CAT_TOOL_NAME,
   FILESYSTEM_FIND_TOOL_NAME,
-  FILESYSTEM_LIST_TOOL_NAME,
   FILESYSTEM_LOCATE_IN_TREE_TOOL_NAME,
   FIND_TAGS_TOOL_NAME,
   SEARCH_TOOL_NAME,
@@ -17,13 +15,10 @@ import type { DataSourcesToolConfigurationType } from "@app/lib/actions/mcp_inte
 import { ConfigurableToolInputSchemas } from "@app/lib/actions/mcp_internal_actions/input_schemas";
 import type {
   FilesystemPathType,
-  SearchQueryResourceType,
   SearchResultResourceType,
 } from "@app/lib/actions/mcp_internal_actions/output_schemas";
 import {
   makeQueryResource,
-  renderMimeType,
-  renderNode,
   renderSearchResults,
 } from "@app/lib/actions/mcp_internal_actions/rendering";
 import {
@@ -31,6 +26,15 @@ import {
   makeFindTagsDescription,
   makeFindTagsTool,
 } from "@app/lib/actions/mcp_internal_actions/servers/common/find_tags_tool";
+import { registerCatTool } from "@app/lib/actions/mcp_internal_actions/servers/data_sources_file_system/cat_tool";
+import { registerListTool } from "@app/lib/actions/mcp_internal_actions/servers/data_sources_file_system/list_tool";
+import {
+  DATA_SOURCE_FILE_SYSTEM_OPTION_PARAMETERS,
+  extractDataSourceIdFromNodeId,
+  getSearchNodesSortDirection,
+  isDataSourceNodeId,
+  makeQueryResourceForFind,
+} from "@app/lib/actions/mcp_internal_actions/servers/data_sources_file_system/utils";
 import {
   checkConflictingTags,
   getAgentDataSourceConfigurations,
@@ -43,18 +47,11 @@ import { withToolLogging } from "@app/lib/actions/mcp_internal_actions/wrappers"
 import type { AgentLoopContextType } from "@app/lib/actions/types";
 import { getRefs } from "@app/lib/api/assistant/citations";
 import config from "@app/lib/api/config";
-import { ROOT_PARENT_ID } from "@app/lib/api/data_source_view";
 import type { Authenticator } from "@app/lib/auth";
 import { getDisplayNameForDocument } from "@app/lib/data_sources";
 import { concurrentExecutor } from "@app/lib/utils/async_utils";
 import logger from "@app/logger/logger";
-import type {
-  ContentNodeType,
-  CoreAPIContentNode,
-  CoreAPIError,
-  CoreAPISearchNodesResponse,
-  Result,
-} from "@app/types";
+import type { ContentNodeType, CoreAPIContentNode, Result } from "@app/types";
 import {
   CoreAPI,
   DATA_SOURCE_NODE_ID,
@@ -66,33 +63,6 @@ import {
   stripNullBytes,
   timeFrameFromNow,
 } from "@app/types";
-
-const OPTION_PARAMETERS = {
-  limit: z
-    .number()
-    .optional()
-    .describe(
-      "Maximum number of results to return. Initial searches should use 10-20."
-    ),
-  sortBy: z
-    .enum(["title", "timestamp"])
-    .optional()
-    .describe(
-      "Field to sort the results by. 'title' sorts alphabetically A-Z, 'timestamp' sorts by " +
-        "most recent first. If not specified, results are returned in default order, which is " +
-        "folders first, then both documents and tables and alphabetically by title. " +
-        "The default order should be kept unless there is a specific reason to change it. " +
-        "This parameter is mutually exclusive with the `query` parameter."
-    ),
-  nextPageCursor: z
-    .string()
-    .optional()
-    .describe(
-      "Cursor for fetching the next page of results. This parameter should only be used to fetch " +
-        "the next page of a previous search. The value should be exactly the 'nextPageCursor' from " +
-        "the previous search result."
-    ),
-};
 
 const SearchToolInputSchema = z.object({
   nodeIds: z
@@ -368,136 +338,7 @@ const createServer = (
 ): McpServer => {
   const server = makeInternalMCPServer("data_sources_file_system");
 
-  server.tool(
-    FILESYSTEM_CAT_TOOL_NAME,
-    "Read the contents of a document, referred to by its nodeId (named after the 'cat' unix tool). " +
-      "The nodeId can be obtained using the 'find', 'list' or 'search' tools.",
-    {
-      dataSources:
-        ConfigurableToolInputSchemas[
-          INTERNAL_MIME_TYPES.TOOL_INPUT.DATA_SOURCE
-        ],
-      nodeId: z.string().describe("The ID of the node to read."),
-      offset: z
-        .number()
-        .optional()
-        .describe(
-          "The character position to start reading from (0-based). If not provided, starts from " +
-            "the beginning."
-        ),
-      limit: z
-        .number()
-        .optional()
-        .describe(
-          "The maximum number of characters to read. If not provided, reads all characters."
-        ),
-      grep: z
-        .string()
-        .optional()
-        .describe(
-          "A regular expression to filter lines. Applied after offset/limit slicing. Only lines " +
-            "matching this pattern will be returned."
-        ),
-    },
-    withToolLogging(
-      auth,
-      { toolName: FILESYSTEM_CAT_TOOL_NAME, agentLoopContext },
-      async ({ dataSources, nodeId, offset, limit, grep }) => {
-        const coreAPI = new CoreAPI(config.getCoreAPIConfig(), logger);
-
-        // Gather data source configurations.
-        const fetchResult = await getAgentDataSourceConfigurations(
-          auth,
-          dataSources
-        );
-
-        if (fetchResult.isErr()) {
-          return new Err(new MCPError(fetchResult.error.message));
-        }
-        const agentDataSourceConfigurations = fetchResult.value;
-
-        // Search the node using our search api.
-        const searchResult = await coreAPI.searchNodes({
-          filter: {
-            node_ids: [nodeId],
-            data_source_views: makeDataSourceViewFilter(
-              agentDataSourceConfigurations
-            ),
-          },
-        });
-
-        if (searchResult.isErr() || searchResult.value.nodes.length === 0) {
-          return new Err(
-            new MCPError(
-              `Could not find node: ${nodeId} (error: ${
-                searchResult.isErr() ? searchResult.error : "No nodes found"
-              })`,
-              { tracked: false }
-            )
-          );
-        }
-
-        const node = searchResult.value.nodes[0];
-
-        if (node.node_type !== "document") {
-          return new Err(
-            new MCPError(`Node is of type ${node.node_type}, not a document.`, {
-              tracked: false,
-            })
-          );
-        }
-
-        // Get dataSource from the data source configuration.
-        const dataSource = agentDataSourceConfigurations.find(
-          (config) =>
-            config.dataSource.dustAPIDataSourceId === node.data_source_id
-        )?.dataSource;
-
-        if (!dataSource) {
-          return new Err(
-            new MCPError(`Could not find dataSource for node: ${nodeId}`)
-          );
-        }
-
-        const dataSourceIdToConnectorMap = new Map();
-        dataSourceIdToConnectorMap.set(
-          dataSource.dustAPIDataSourceId,
-          dataSource.connectorProvider
-        );
-
-        // Read the node.
-        const readResult = await coreAPI.getDataSourceDocumentText({
-          dataSourceId: node.data_source_id,
-          documentId: node.node_id,
-          projectId: dataSource.dustAPIProjectId,
-          offset: offset,
-          limit: limit,
-          grep: grep,
-        });
-
-        if (readResult.isErr()) {
-          return new Err(
-            new MCPError(
-              `Could not read node: ${nodeId} (error: ${readResult.error})`
-            )
-          );
-        }
-
-        return new Ok([
-          {
-            type: "resource" as const,
-            resource: {
-              mimeType:
-                INTERNAL_MIME_TYPES.TOOL_OUTPUT.DATA_SOURCE_NODE_CONTENT,
-              uri: node.source_url ?? "",
-              text: readResult.value.text,
-              metadata: renderNode(node, dataSourceIdToConnectorMap),
-            },
-          },
-        ]);
-      }
-    )
-  );
+  registerCatTool(auth, server, agentLoopContext);
 
   server.tool(
     FILESYSTEM_FIND_TOOL_NAME,
@@ -536,7 +377,7 @@ const createServer = (
         ConfigurableToolInputSchemas[
           INTERNAL_MIME_TYPES.TOOL_INPUT.DATA_SOURCE
         ],
-      ...OPTION_PARAMETERS,
+      ...DATA_SOURCE_FILE_SYSTEM_OPTION_PARAMETERS,
     },
     withToolLogging(
       auth,
@@ -597,7 +438,12 @@ const createServer = (
             cursor: nextPageCursor,
             limit,
             sort: sortBy
-              ? [{ field: sortBy, direction: getSortDirection(sortBy) }]
+              ? [
+                  {
+                    field: sortBy,
+                    direction: getSearchNodesSortDirection(sortBy),
+                  },
+                ]
               : undefined,
           },
         });
@@ -632,152 +478,7 @@ const createServer = (
     )
   );
 
-  server.tool(
-    FILESYSTEM_LIST_TOOL_NAME,
-    "List the direct contents of a node. Can be used to see what is inside a specific folder from " +
-      "the filesystem, like 'ls' in Unix. A good fit is to explore the filesystem structure step " +
-      "by step. This tool can be called repeatedly by passing the 'nodeId' output from a step to " +
-      "the next step's nodeId. If a node output by this tool or the find tool has children " +
-      "(hasChildren: true), it means that this tool can be used again on it.",
-    {
-      nodeId: z
-        .string()
-        .nullable()
-        .describe(
-          "The exact ID of the node to list the contents of. " +
-            "This ID can be found from previous search results in the 'nodeId' field. " +
-            "If not provided, the content at the root of the filesystem will be shown."
-        ),
-      mimeTypes: z
-        .array(z.string())
-        .optional()
-        .describe(
-          "The mime types to search for. If provided, only nodes with one of these mime types " +
-            "will be returned. If not provided, no filter will be applied. The mime types passed " +
-            "here must be one of the mime types found in the 'mimeType' field."
-        ),
-      dataSources:
-        ConfigurableToolInputSchemas[
-          INTERNAL_MIME_TYPES.TOOL_INPUT.DATA_SOURCE
-        ],
-      ...OPTION_PARAMETERS,
-    },
-    withToolLogging(
-      auth,
-      { toolName: FILESYSTEM_LIST_TOOL_NAME, agentLoopContext },
-      async ({
-        nodeId,
-        dataSources,
-        limit,
-        mimeTypes,
-        sortBy,
-        nextPageCursor,
-      }) => {
-        const coreAPI = new CoreAPI(config.getCoreAPIConfig(), logger);
-        const fetchResult = await getAgentDataSourceConfigurations(
-          auth,
-          dataSources
-        );
-
-        if (fetchResult.isErr()) {
-          return new Err(new MCPError(fetchResult.error.message));
-        }
-        const agentDataSourceConfigurations = fetchResult.value;
-
-        const options = {
-          cursor: nextPageCursor,
-          limit,
-          sort: sortBy
-            ? [{ field: sortBy, direction: getSortDirection(sortBy) }]
-            : undefined,
-        };
-
-        let searchResult: Result<CoreAPISearchNodesResponse, CoreAPIError>;
-
-        if (!nodeId) {
-          // When nodeId is null, search for data sources only
-          const dataSourceViewFilter = makeDataSourceViewFilter(
-            agentDataSourceConfigurations
-          ).map((view) => ({
-            ...view,
-            search_scope: "data_source_name" as const,
-          }));
-
-          searchResult = await coreAPI.searchNodes({
-            filter: {
-              data_source_views: dataSourceViewFilter,
-              mime_types: mimeTypes ? { in: mimeTypes, not: null } : undefined,
-            },
-            options,
-          });
-        } else if (isDataSourceNodeId(nodeId)) {
-          // If it's a data source node ID, extract the data source ID and list its root contents
-          const dataSourceId = extractDataSourceIdFromNodeId(nodeId);
-          if (!dataSourceId) {
-            return new Err(new MCPError("Invalid data source node ID format"));
-          }
-
-          const dataSourceConfig = agentDataSourceConfigurations.find(
-            ({ dataSource }) => dataSource.dustAPIDataSourceId === dataSourceId
-          );
-
-          if (!dataSourceConfig) {
-            return new Err(
-              new MCPError(`Data source not found for ID: ${dataSourceId}`)
-            );
-          }
-
-          searchResult = await coreAPI.searchNodes({
-            filter: {
-              data_source_views: makeDataSourceViewFilter([dataSourceConfig]),
-              node_ids: dataSourceConfig.filter.parents?.in ?? undefined,
-              parent_id: dataSourceConfig.filter.parents?.in
-                ? undefined
-                : ROOT_PARENT_ID,
-              mime_types: mimeTypes ? { in: mimeTypes, not: null } : undefined,
-            },
-            options,
-          });
-        } else {
-          // Regular node listing
-          const dataSourceViewFilter = makeDataSourceViewFilter(
-            agentDataSourceConfigurations
-          );
-
-          searchResult = await coreAPI.searchNodes({
-            filter: {
-              data_source_views: dataSourceViewFilter,
-              parent_id: nodeId,
-              mime_types: mimeTypes ? { in: mimeTypes, not: null } : undefined,
-            },
-            options,
-          });
-        }
-
-        if (searchResult.isErr()) {
-          return new Err(new MCPError("Failed to list folder contents"));
-        }
-
-        return new Ok([
-          {
-            type: "resource" as const,
-            resource: makeQueryResourceForList(
-              nodeId,
-              mimeTypes,
-              nextPageCursor
-            ),
-          },
-          {
-            type: "resource" as const,
-            resource: renderSearchResults(
-              searchResult.value,
-              agentDataSourceConfigurations
-            ),
-          },
-        ]);
-      }
-    )
-  );
+  registerListTool(auth, server, agentLoopContext);
 
   // Check if tags are dynamic before creating the search tool.
   const areTagsDynamic = agentLoopContext
@@ -1014,73 +715,5 @@ const createServer = (
 
   return server;
 };
-
-function getSortDirection(field: "title" | "timestamp"): "asc" | "desc" {
-  switch (field) {
-    case "title":
-      return "asc"; // Alphabetical A-Z.
-    case "timestamp":
-      return "desc"; // Most recent first.
-  }
-}
-
-/**
- * Check if a node ID represents a data source node.
- * Data source node IDs have the format: "datasource_node_id-{data_source_id}"
- */
-function isDataSourceNodeId(nodeId: string): boolean {
-  return nodeId.startsWith(`${DATA_SOURCE_NODE_ID}-`);
-}
-
-/**
- * Extract the data source ID from a data source node ID.
- * Returns null if the node ID is not a data source node ID.
- */
-function extractDataSourceIdFromNodeId(nodeId: string): string | null {
-  if (!isDataSourceNodeId(nodeId)) {
-    return null;
-  }
-  return nodeId.substring(`${DATA_SOURCE_NODE_ID}-`.length);
-}
-
-export function makeQueryResourceForFind(
-  query?: string,
-  rootNodeId?: string,
-  mimeTypes?: string[],
-  nextPageCursor?: string
-): SearchQueryResourceType {
-  const queryText = query ? ` "${query}"` : " all content";
-  const scope = rootNodeId
-    ? ` under ${rootNodeId}`
-    : " across the entire data sources";
-  const types = mimeTypes?.length
-    ? ` (${mimeTypes.map(renderMimeType).join(", ")} files)`
-    : "";
-  const pagination = nextPageCursor ? " - next page" : "";
-
-  return {
-    mimeType: INTERNAL_MIME_TYPES.TOOL_OUTPUT.DATA_SOURCE_SEARCH_QUERY,
-    text: `Searching for${queryText}${scope}${types}${pagination}.`,
-    uri: "",
-  };
-}
-
-export function makeQueryResourceForList(
-  nodeId: string | null,
-  mimeTypes?: string[],
-  nextPageCursor?: string
-): SearchQueryResourceType {
-  const location = nodeId ? ` within node "${nodeId}"` : " at the root level";
-  const types = mimeTypes?.length
-    ? ` (${mimeTypes.map(renderMimeType).join(", ")} files)`
-    : "";
-  const pagination = nextPageCursor ? " - next page" : "";
-
-  return {
-    mimeType: INTERNAL_MIME_TYPES.TOOL_OUTPUT.DATA_SOURCE_SEARCH_QUERY,
-    text: `Listing content${location}${types}${pagination}.`,
-    uri: "",
-  };
-}
 
 export default createServer;

--- a/front/lib/actions/mcp_internal_actions/servers/data_sources_file_system/list_tool.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/data_sources_file_system/list_tool.ts
@@ -1,0 +1,200 @@
+import { INTERNAL_MIME_TYPES } from "@dust-tt/client";
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { z } from "zod";
+
+import { MCPError } from "@app/lib/actions/mcp_errors";
+import { FILESYSTEM_LIST_TOOL_NAME } from "@app/lib/actions/mcp_internal_actions/constants";
+import { ConfigurableToolInputSchemas } from "@app/lib/actions/mcp_internal_actions/input_schemas";
+import { renderSearchResults } from "@app/lib/actions/mcp_internal_actions/rendering";
+import {
+  DATA_SOURCE_FILE_SYSTEM_OPTION_PARAMETERS,
+  extractDataSourceIdFromNodeId,
+  getSearchNodesSortDirection,
+  isDataSourceNodeId,
+  makeQueryResourceForList,
+} from "@app/lib/actions/mcp_internal_actions/servers/data_sources_file_system/utils";
+import {
+  getAgentDataSourceConfigurations,
+  makeDataSourceViewFilter,
+} from "@app/lib/actions/mcp_internal_actions/servers/utils";
+import { withToolLogging } from "@app/lib/actions/mcp_internal_actions/wrappers";
+import type { AgentLoopContextType } from "@app/lib/actions/types";
+import config from "@app/lib/api/config";
+import { ROOT_PARENT_ID } from "@app/lib/api/data_source_view";
+import type { Authenticator } from "@app/lib/auth";
+import logger from "@app/logger/logger";
+import type {
+  CoreAPIError,
+  CoreAPISearchNodesResponse,
+  Result,
+} from "@app/types";
+import { CoreAPI, Err, Ok } from "@app/types";
+
+const ListToolInputSchema = {
+  nodeId: z
+    .string()
+    .nullable()
+    .describe(
+      "The exact ID of the node to list the contents of. " +
+        "This ID can be found from previous search results in the 'nodeId' field. " +
+        "If not provided, the content at the root of the filesystem will be shown."
+    ),
+  mimeTypes: z
+    .array(z.string())
+    .optional()
+    .describe(
+      "The mime types to search for. If provided, only nodes with one of these mime types " +
+        "will be returned. If not provided, no filter will be applied. The mime types passed " +
+        "here must be one of the mime types found in the 'mimeType' field."
+    ),
+  dataSources:
+    ConfigurableToolInputSchemas[INTERNAL_MIME_TYPES.TOOL_INPUT.DATA_SOURCE],
+  ...DATA_SOURCE_FILE_SYSTEM_OPTION_PARAMETERS,
+};
+
+interface ListToolOptions {
+  toolName?: string;
+  toolDescription?: string;
+}
+
+export function registerListTool(
+  auth: Authenticator,
+  server: McpServer,
+  agentLoopContext?: AgentLoopContextType,
+  options: ListToolOptions = {}
+) {
+  const toolName = options.toolName || FILESYSTEM_LIST_TOOL_NAME;
+  const toolDescription =
+    options.toolDescription ||
+    "List the direct contents of a node. Can be used to see what is inside a specific folder from " +
+      "the filesystem, like 'ls' in Unix. A good fit is to explore the filesystem structure step " +
+      "by step. This tool can be called repeatedly by passing the 'nodeId' output from a step to " +
+      "the next step's nodeId. If a node output by this tool or the find tool has children " +
+      "(hasChildren: true), it means that this tool can be used again on it.";
+
+  server.tool(
+    toolName,
+    toolDescription,
+    ListToolInputSchema,
+    withToolLogging(
+      auth,
+      { toolName: FILESYSTEM_LIST_TOOL_NAME, agentLoopContext },
+      async ({
+        nodeId,
+        dataSources,
+        limit,
+        mimeTypes,
+        sortBy,
+        nextPageCursor,
+      }) => {
+        const coreAPI = new CoreAPI(config.getCoreAPIConfig(), logger);
+        const fetchResult = await getAgentDataSourceConfigurations(
+          auth,
+          dataSources
+        );
+
+        if (fetchResult.isErr()) {
+          return new Err(new MCPError(fetchResult.error.message));
+        }
+        const agentDataSourceConfigurations = fetchResult.value;
+
+        const options = {
+          cursor: nextPageCursor,
+          limit,
+          sort: sortBy
+            ? [
+                {
+                  field: sortBy,
+                  direction: getSearchNodesSortDirection(sortBy),
+                },
+              ]
+            : undefined,
+        };
+
+        let searchResult: Result<CoreAPISearchNodesResponse, CoreAPIError>;
+
+        if (!nodeId) {
+          // When nodeId is null, search for data sources only.
+          const dataSourceViewFilter = makeDataSourceViewFilter(
+            agentDataSourceConfigurations
+          ).map((view) => ({
+            ...view,
+            search_scope: "data_source_name" as const,
+          }));
+
+          searchResult = await coreAPI.searchNodes({
+            filter: {
+              data_source_views: dataSourceViewFilter,
+              mime_types: mimeTypes ? { in: mimeTypes, not: null } : undefined,
+            },
+            options,
+          });
+        } else if (isDataSourceNodeId(nodeId)) {
+          // If it's a data source node ID, extract the data source ID and list its root contents.
+          const dataSourceId = extractDataSourceIdFromNodeId(nodeId);
+          if (!dataSourceId) {
+            return new Err(new MCPError("Invalid data source node ID format"));
+          }
+
+          const dataSourceConfig = agentDataSourceConfigurations.find(
+            ({ dataSource }) => dataSource.dustAPIDataSourceId === dataSourceId
+          );
+
+          if (!dataSourceConfig) {
+            return new Err(
+              new MCPError(`Data source not found for ID: ${dataSourceId}`)
+            );
+          }
+
+          searchResult = await coreAPI.searchNodes({
+            filter: {
+              data_source_views: makeDataSourceViewFilter([dataSourceConfig]),
+              node_ids: dataSourceConfig.filter.parents?.in ?? undefined,
+              parent_id: dataSourceConfig.filter.parents?.in
+                ? undefined
+                : ROOT_PARENT_ID,
+              mime_types: mimeTypes ? { in: mimeTypes, not: null } : undefined,
+            },
+            options,
+          });
+        } else {
+          // Regular node listing.
+          const dataSourceViewFilter = makeDataSourceViewFilter(
+            agentDataSourceConfigurations
+          );
+
+          searchResult = await coreAPI.searchNodes({
+            filter: {
+              data_source_views: dataSourceViewFilter,
+              parent_id: nodeId,
+              mime_types: mimeTypes ? { in: mimeTypes, not: null } : undefined,
+            },
+            options,
+          });
+        }
+
+        if (searchResult.isErr()) {
+          return new Err(new MCPError("Failed to list folder contents"));
+        }
+
+        return new Ok([
+          {
+            type: "resource",
+            resource: makeQueryResourceForList(
+              nodeId,
+              mimeTypes,
+              nextPageCursor
+            ),
+          },
+          {
+            type: "resource",
+            resource: renderSearchResults(
+              searchResult.value,
+              agentDataSourceConfigurations
+            ),
+          },
+        ]);
+      }
+    )
+  );
+}

--- a/front/lib/actions/mcp_internal_actions/servers/data_sources_file_system/utils.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/data_sources_file_system/utils.ts
@@ -1,0 +1,105 @@
+import { INTERNAL_MIME_TYPES } from "@dust-tt/client";
+import { z } from "zod";
+
+import type { SearchQueryResourceType } from "@app/lib/actions/mcp_internal_actions/output_schemas";
+import { renderMimeType } from "@app/lib/actions/mcp_internal_actions/rendering";
+import { DATA_SOURCE_NODE_ID } from "@app/types";
+
+export const DATA_SOURCE_FILE_SYSTEM_OPTION_PARAMETERS = {
+  limit: z
+    .number()
+    .optional()
+    .describe(
+      "Maximum number of results to return. Initial searches should use 10-20."
+    ),
+  sortBy: z
+    .enum(["title", "timestamp"])
+    .optional()
+    .describe(
+      "Field to sort the results by. 'title' sorts alphabetically A-Z, 'timestamp' sorts by " +
+        "most recent first. If not specified, results are returned in default order, which is " +
+        "folders first, then both documents and tables and alphabetically by title. " +
+        "The default order should be kept unless there is a specific reason to change it. " +
+        "This parameter is mutually exclusive with the `query` parameter."
+    ),
+  nextPageCursor: z
+    .string()
+    .optional()
+    .describe(
+      "Cursor for fetching the next page of results. This parameter should only be used to fetch " +
+        "the next page of a previous search. The value should be exactly the 'nextPageCursor' from " +
+        "the previous search result."
+    ),
+};
+
+export function getSearchNodesSortDirection(
+  field: "title" | "timestamp"
+): "asc" | "desc" {
+  switch (field) {
+    case "title":
+      return "asc"; // Alphabetical A-Z.
+
+    case "timestamp":
+      return "desc"; // Most recent first.
+  }
+}
+
+/**
+ * Check if a node ID represents a data source node.
+ * Data source node IDs have the format: "datasource_node_id-{data_source_id}"
+ */
+export function isDataSourceNodeId(nodeId: string): boolean {
+  return nodeId.startsWith(`${DATA_SOURCE_NODE_ID}-`);
+}
+
+/**
+ * Extract the data source ID from a data source node ID.
+ * Returns null if the node ID is not a data source node ID.
+ */
+export function extractDataSourceIdFromNodeId(nodeId: string): string | null {
+  if (!isDataSourceNodeId(nodeId)) {
+    return null;
+  }
+
+  return nodeId.substring(`${DATA_SOURCE_NODE_ID}-`.length);
+}
+
+export function makeQueryResourceForFind(
+  query?: string,
+  rootNodeId?: string,
+  mimeTypes?: string[],
+  nextPageCursor?: string
+): SearchQueryResourceType {
+  const queryText = query ? ` "${query}"` : " all content";
+  const scope = rootNodeId
+    ? ` under ${rootNodeId}`
+    : " across the entire data sources";
+  const types = mimeTypes?.length
+    ? ` (${mimeTypes.map(renderMimeType).join(", ")} files)`
+    : "";
+  const pagination = nextPageCursor ? " - next page" : "";
+
+  return {
+    mimeType: INTERNAL_MIME_TYPES.TOOL_OUTPUT.DATA_SOURCE_SEARCH_QUERY,
+    text: `Searching for${queryText}${scope}${types}${pagination}.`,
+    uri: "",
+  };
+}
+
+export function makeQueryResourceForList(
+  nodeId: string | null,
+  mimeTypes?: string[],
+  nextPageCursor?: string
+): SearchQueryResourceType {
+  const location = nodeId ? ` within node "${nodeId}"` : " at the root level";
+  const types = mimeTypes?.length
+    ? ` (${mimeTypes.map(renderMimeType).join(", ")} files)`
+    : "";
+  const pagination = nextPageCursor ? " - next page" : "";
+
+  return {
+    mimeType: INTERNAL_MIME_TYPES.TOOL_OUTPUT.DATA_SOURCE_SEARCH_QUERY,
+    text: `Listing content${location}${types}${pagination}.`,
+    uri: "",
+  };
+}


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
This PR splits tools from the `data_sources_file_system` server (focusing exclusively on `list` and `cat`) so they can be used in the `canvas` server. This will ensure users can provided assets (think visuals, slideshow template) when adding the server to an agent.

I had to slightly hack my way through the builder so that the `canvas` server does not end up under the "Add knowledge" dropdown. Ongoing discussion are happing here: https://dust4ai.slack.com/archives/C050SM8NSPK/p1756308163623739.

The data source is currently required, but will make it optional once we found a solution with the AB team.

<img width="574" height="1776" alt="image" src="https://github.com/user-attachments/assets/b3e03197-ce08-4b70-818a-b1da34dba7e9" />

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
