### PR TITLE
[front] Replace `MCPActionType` with the resource in action creation

### DIFF
--- a/front/lib/actions/mcp.ts
+++ b/front/lib/actions/mcp.ts
@@ -218,7 +218,8 @@ type MCPParamsEvent = {
   created: number;
   configurationId: string;
   messageId: string;
-  action: AgentMCPActionType;
+  // TODO: cleanup this type from the public API users.
+  action: AgentMCPActionType & { type: "tool_action" };
 };
 
 type MCPSuccessEvent = {

--- a/front/lib/actions/mcp.ts
+++ b/front/lib/actions/mcp.ts
@@ -219,7 +219,7 @@ type MCPParamsEvent = {
   configurationId: string;
   messageId: string;
   // TODO: cleanup this type from the public API users.
-  action: AgentMCPActionType & { type: "tool_action" };
+  action: AgentMCPActionType & { type: "tool_action"; output: null };
 };
 
 type MCPSuccessEvent = {

--- a/front/lib/actions/mcp.ts
+++ b/front/lib/actions/mcp.ts
@@ -67,8 +67,12 @@ import type {
   TimeFrame,
   ToolErrorEvent,
 } from "@app/types";
-import { isPersonalAuthenticationRequiredErrorContent } from "@app/types";
-import { assertNever, removeNulls } from "@app/types";
+import {
+  assertNever,
+  isPersonalAuthenticationRequiredErrorContent,
+  removeNulls,
+} from "@app/types";
+import type { AgentMCPActionType } from "@app/types/actions";
 
 export type BaseMCPServerConfigurationType = {
   id: ModelId;
@@ -214,7 +218,7 @@ type MCPParamsEvent = {
   created: number;
   configurationId: string;
   messageId: string;
-  action: MCPActionType;
+  action: AgentMCPActionType;
 };
 
 type MCPSuccessEvent = {
@@ -612,13 +616,13 @@ export async function createMCPAction(
     stepContentId: ModelId;
     stepContext: StepContext;
   }
-): Promise<{ action: AgentMCPActionResource; mcpAction: MCPActionType }> {
+): Promise<AgentMCPActionResource> {
   const toolConfiguration = omit(
     actionConfiguration,
     MCP_TOOL_CONFIGURATION_FIELDS_TO_OMIT
   ) as LightMCPToolConfigurationType;
 
-  const action = await AgentMCPActionResource.makeNew(auth, {
+  return AgentMCPActionResource.makeNew(auth, {
     agentMessageId: actionBaseParams.agentMessageId,
     augmentedInputs,
     citationsAllocated: stepContext.citationsCount,
@@ -629,15 +633,6 @@ export async function createMCPAction(
     toolConfiguration,
     version: 0,
   });
-
-  const mcpAction = new MCPActionType({
-    ...actionBaseParams,
-    id: action.id,
-    output: null,
-    type: "tool_action",
-  });
-
-  return { action, mcpAction };
 }
 
 type BaseErrorParams = {

--- a/front/lib/assistant/state/messageReducer.ts
+++ b/front/lib/assistant/state/messageReducer.ts
@@ -7,6 +7,7 @@ import { getLightAgentMessageFromAgentMessage } from "@app/lib/api/assistant/cit
 import type { AgentMessageEvents } from "@app/lib/api/assistant/streaming/types";
 import type { ModelId } from "@app/types";
 import { assertNever } from "@app/types";
+import type { AgentMCPActionType } from "@app/types/actions";
 import type { LightAgentMessageType } from "@app/types/assistant/conversation";
 
 export type AgentStateClassification =
@@ -43,7 +44,7 @@ type AgentMessageStateEventWithoutToolApproveExecution = Exclude<
 
 function updateMessageWithAction(
   m: LightAgentMessageType,
-  action: MCPActionType
+  action: MCPActionType | (AgentMCPActionType & { type: "tool_action" })
 ): LightAgentMessageType {
   return {
     ...m,

--- a/front/lib/resources/agent_mcp_action_resource.ts
+++ b/front/lib/resources/agent_mcp_action_resource.ts
@@ -53,6 +53,7 @@ export class AgentMCPActionResource extends BaseResource<AgentMCPActionModel> {
     readonly stepContent: NonAttribute<AgentStepContentModel>,
     readonly metadata: {
       internalMCPServerName: InternalMCPServerNameType | null;
+      mcpServerId: string;
     }
   ) {
     super(model, blob);
@@ -97,6 +98,7 @@ export class AgentMCPActionResource extends BaseResource<AgentMCPActionModel> {
 
       return new this(this.model, a.get(), stepContent, {
         internalMCPServerName,
+        mcpServerId: a.toolConfiguration.toolServerId,
       });
     });
   }
@@ -130,6 +132,7 @@ export class AgentMCPActionResource extends BaseResource<AgentMCPActionModel> {
 
     return new this(this.model, action.get(), stepContent, {
       internalMCPServerName,
+      mcpServerId: blob.toolConfiguration.toolServerId,
     });
   }
 
@@ -335,6 +338,7 @@ export class AgentMCPActionResource extends BaseResource<AgentMCPActionModel> {
       id: this.id,
       internalMCPServerName: this.metadata.internalMCPServerName,
       mcpServerConfigurationId: this.mcpServerConfigurationId,
+      mcpServerId: this.metadata.mcpServerId,
       params: this.augmentedInputs,
       status: this.status,
       stepContentId: this.stepContentId,

--- a/front/lib/resources/agent_mcp_action_resource.ts
+++ b/front/lib/resources/agent_mcp_action_resource.ts
@@ -332,20 +332,12 @@ export class AgentMCPActionResource extends BaseResource<AgentMCPActionModel> {
 
     return {
       agentMessageId: this.agentMessageId,
-      citationsAllocated: this.citationsAllocated,
-      functionCallId: this.stepContent.value.value.id,
       functionCallName: this.stepContent.value.value.name,
       id: this.id,
       internalMCPServerName: this.metadata.internalMCPServerName,
-      mcpServerConfigurationId: this.mcpServerConfigurationId,
       mcpServerId: this.metadata.mcpServerId,
       params: this.augmentedInputs,
       status: this.status,
-      stepContentId: this.stepContentId,
-      stepContext: this.stepContext,
-      toolConfiguration: this.toolConfiguration,
-      version: this.version,
-      workspaceId: this.workspaceId,
     };
   }
 

--- a/front/temporal/agent_loop/lib/create_tool_actions.ts
+++ b/front/temporal/agent_loop/lib/create_tool_actions.ts
@@ -197,7 +197,8 @@ async function createActionForTool(
       configurationId: agentConfiguration.sId,
       messageId: agentMessage.sId,
       // TODO: cleanup the type field from the public API users and remove everywhere.
-      action: { ...action.toJSON(), type: "tool_action" },
+      // TODO: move the output field to a separate field.
+      action: { ...action.toJSON(), type: "tool_action", output: null },
     },
     agentMessageRow,
     {

--- a/front/temporal/agent_loop/lib/create_tool_actions.ts
+++ b/front/temporal/agent_loop/lib/create_tool_actions.ts
@@ -196,7 +196,8 @@ async function createActionForTool(
       created: Date.now(),
       configurationId: agentConfiguration.sId,
       messageId: agentMessage.sId,
-      action: action.toJSON(),
+      // TODO: cleanup the type field from the public API users and remove everywhere.
+      action: { ...action.toJSON(), type: "tool_action" },
     },
     agentMessageRow,
     {

--- a/front/temporal/agent_loop/lib/create_tool_actions.ts
+++ b/front/temporal/agent_loop/lib/create_tool_actions.ts
@@ -181,7 +181,7 @@ async function createActionForTool(
   // Create the action object in the database and yield an event for the generation of the params.
   // We store the action here as the params have been generated, if an error occurs later on,
   // the error will be stored on the parent agent message.
-  const { action: agentMCPAction, mcpAction } = await createMCPAction(auth, {
+  const action = await createMCPAction(auth, {
     actionBaseParams,
     actionConfiguration,
     augmentedInputs,
@@ -196,7 +196,7 @@ async function createActionForTool(
       created: Date.now(),
       configurationId: agentConfiguration.sId,
       messageId: agentMessage.sId,
-      action: mcpAction,
+      action: action.toJSON(),
     },
     agentMessageRow,
     {
@@ -207,7 +207,7 @@ async function createActionForTool(
 
   return {
     actionBlob: {
-      actionId: agentMCPAction.id,
+      actionId: action.id,
       actionStatus: status,
       needsApproval: status === "blocked_validation_required",
     },
@@ -219,8 +219,8 @@ async function createActionForTool(
             configurationId: agentConfiguration.sId,
             messageId: agentMessage.sId,
             conversationId,
-            actionId: agentMCPAction.sId,
-            inputs: mcpAction.params,
+            actionId: action.sId,
+            inputs: action.augmentedInputs,
             stake: actionConfiguration.permission,
             metadata: {
               toolName: actionConfiguration.originalName,

--- a/front/types/actions.ts
+++ b/front/types/actions.ts
@@ -1,23 +1,15 @@
-import type { LightMCPToolConfigurationType } from "@app/lib/actions/mcp";
 import type { InternalMCPServerNameType } from "@app/lib/actions/mcp_internal_actions/constants";
 import type { ToolExecutionStatus } from "@app/lib/actions/statuses";
-import type { StepContext } from "@app/lib/actions/types";
 import type { ModelId } from "@app/types/shared/model_id";
 
 export type AgentMCPActionType = {
   agentMessageId: ModelId;
-  citationsAllocated: number;
-  functionCallId: string;
+  // TODO(durable-agents): prevent exposing the function call name
+  //  currently used in the extension to guess the tool name but quite brittle.
   functionCallName: string;
   id: ModelId;
   internalMCPServerName: InternalMCPServerNameType | null;
-  mcpServerConfigurationId: string;
   mcpServerId: string | null;
   params: Record<string, unknown>;
   status: ToolExecutionStatus;
-  stepContentId: ModelId;
-  stepContext: StepContext;
-  toolConfiguration: LightMCPToolConfigurationType;
-  version: number;
-  workspaceId: ModelId;
 };

--- a/front/types/actions.ts
+++ b/front/types/actions.ts
@@ -12,6 +12,7 @@ export type AgentMCPActionType = {
   id: ModelId;
   internalMCPServerName: InternalMCPServerNameType | null;
   mcpServerConfigurationId: string;
+  mcpServerId: string | null;
   params: Record<string, unknown>;
   status: ToolExecutionStatus;
   stepContentId: ModelId;

--- a/sdks/js/src/types.ts
+++ b/sdks/js/src/types.ts
@@ -690,6 +690,7 @@ const MCPActionTypeSchema = z.object({
   internalMCPServerName: z.string().nullable(),
   agentMessageId: ModelIdSchema,
   functionCallName: z.string().nullable(),
+  status: z.string(),
   params: z.record(z.any()),
   output: CallToolResultSchema.shape.content.nullable(),
   type: z.literal("tool_action"),


### PR DESCRIPTION
## Description

- Part of https://github.com/dust-tt/tasks/issues/3586.
- This PR replaces one call site of `new MCPActionType` to rely on the resource.
- The type `AgentMCPActionType` is compatible with the public type (done in https://github.com/dust-tt/dust/pull/15412).
- Will have to cleanup the extension and the Slack bot to remove the `type` field, which is always equal to "tool_action" (since the field is named action in the first place).

## Tests

- Tested locally.

## Risk

- Medium, but well tested.

## Deploy Plan

- Deploy front.
