### PR TITLE
[connectors] Add retry logic on action validation in Slack bot

### DIFF
--- a/connectors/package-lock.json
+++ b/connectors/package-lock.json
@@ -95,7 +95,7 @@
     },
     "../sdks/js": {
       "name": "@dust-tt/client",
-      "version": "1.1.6",
+      "version": "1.1.9",
       "bundleDependencies": [
         "@modelcontextprotocol/sdk"
       ],


### PR DESCRIPTION
## Description

- When validating actions coming from a sub agent, we need to retry the main agent's conversation to relaunch the workflow.
- This behavior was not replicating in the Slack bot, which is fixed by this PR.

## Tests

## Risk

## Deploy Plan

- Deploy connectors.
