### PR TITLE
[front] Replace `MCPActionType` with resource in `tool_success` events

### DIFF
--- a/front/lib/actions/mcp.ts
+++ b/front/lib/actions/mcp.ts
@@ -245,6 +245,7 @@ type MCPSuccessEvent = {
   messageId: string;
   action: AgentMCPActionType & {
     output: CallToolResult["content"];
+    generatedFiles: ActionGeneratedFileType[];
   };
 };
 
@@ -590,7 +591,7 @@ export async function* runToolWithStreaming(
     return;
   }
 
-  const { outputItems } = await processToolResults(auth, {
+  const { outputItems, generatedFiles } = await processToolResults(auth, {
     action,
     conversation,
     localLogger,
@@ -610,6 +611,7 @@ export async function* runToolWithStreaming(
     action: {
       ...action.toJSON(),
       output: removeNulls(outputItems.map(hideFileFromActionOutput)),
+      generatedFiles,
     },
   };
 }
@@ -693,6 +695,7 @@ export async function handleMCPActionError(
     action: {
       ...action.toJSON(),
       output: [outputContent],
+      generatedFiles: [],
     },
   };
 }

--- a/front/lib/actions/mcp.ts
+++ b/front/lib/actions/mcp.ts
@@ -244,8 +244,8 @@ type MCPSuccessEvent = {
   configurationId: string;
   messageId: string;
   action: AgentMCPActionType & {
-    generatedFiles: ActionGeneratedFileType[];
     output: CallToolResult["content"];
+    generatedFiles: ActionGeneratedFileType[];
   };
 };
 

--- a/front/lib/actions/mcp.ts
+++ b/front/lib/actions/mcp.ts
@@ -244,8 +244,8 @@ type MCPSuccessEvent = {
   configurationId: string;
   messageId: string;
   action: AgentMCPActionType & {
-    output: CallToolResult["content"];
     generatedFiles: ActionGeneratedFileType[];
+    output: CallToolResult["content"];
   };
 };
 

--- a/front/lib/actions/mcp.ts
+++ b/front/lib/actions/mcp.ts
@@ -69,10 +69,7 @@ import {
   isPersonalAuthenticationRequiredErrorContent,
   removeNulls,
 } from "@app/types";
-import type {
-  AgentMCPActionType,
-  AgentMCPActionWithOutputType,
-} from "@app/types/actions";
+import type { AgentMCPActionWithOutputType } from "@app/types/actions";
 
 export type BaseMCPServerConfigurationType = {
   id: ModelId;
@@ -231,11 +228,7 @@ type MCPParamsEvent = {
   created: number;
   configurationId: string;
   messageId: string;
-  // TODO: cleanup this type from the public API users.
-  action: AgentMCPActionWithOutputType & {
-    output: null;
-    generatedFiles: never[];
-  };
+  action: AgentMCPActionWithOutputType;
 };
 
 type MCPSuccessEvent = {
@@ -243,10 +236,7 @@ type MCPSuccessEvent = {
   created: number;
   configurationId: string;
   messageId: string;
-  action: AgentMCPActionType & {
-    output: CallToolResult["content"];
-    generatedFiles: ActionGeneratedFileType[];
-  };
+  action: AgentMCPActionWithOutputType;
 };
 
 type MCPErrorEvent = {

--- a/front/types/assistant/agent.ts
+++ b/front/types/assistant/agent.ts
@@ -1,9 +1,11 @@
+import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
+
 import type {
-  MCPActionType,
   MCPServerConfigurationType,
   MCPToolConfigurationType,
 } from "@app/lib/actions/mcp";
 import type { OAuthProvider } from "@app/types";
+import type { AgentMCPActionType } from "@app/types/actions";
 import type {
   ReasoningContentType,
   TextContentType,
@@ -312,7 +314,10 @@ export type AgentActionSuccessEvent = {
   created: number;
   configurationId: string;
   messageId: string;
-  action: MCPActionType;
+  action: AgentMCPActionType & {
+    type: "tool_action";
+    output: CallToolResult["content"];
+  };
 };
 
 // Event sent to stop the generation.

--- a/front/types/assistant/agent.ts
+++ b/front/types/assistant/agent.ts
@@ -315,7 +315,6 @@ export type AgentActionSuccessEvent = {
   configurationId: string;
   messageId: string;
   action: AgentMCPActionType & {
-    type: "tool_action";
     output: CallToolResult["content"];
   };
 };

--- a/front/types/assistant/agent.ts
+++ b/front/types/assistant/agent.ts
@@ -316,8 +316,8 @@ export type AgentActionSuccessEvent = {
   configurationId: string;
   messageId: string;
   action: AgentMCPActionType & {
-    generatedFiles: ActionGeneratedFileType[];
     output: CallToolResult["content"];
+    generatedFiles: ActionGeneratedFileType[];
   };
 };
 

--- a/front/types/assistant/agent.ts
+++ b/front/types/assistant/agent.ts
@@ -1,17 +1,14 @@
-import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
-
 import type {
   MCPServerConfigurationType,
   MCPToolConfigurationType,
 } from "@app/lib/actions/mcp";
-import type { ActionGeneratedFileType } from "@app/lib/actions/types";
 import type { OAuthProvider } from "@app/types";
-import type { AgentMCPActionType } from "@app/types/actions";
+import type { AgentMCPActionWithOutputType } from "@app/types/actions";
 import type {
+  FunctionCallContentType,
   ReasoningContentType,
   TextContentType,
 } from "@app/types/assistant/agent_message_content";
-import type { FunctionCallContentType } from "@app/types/assistant/agent_message_content";
 import type {
   ModelIdType,
   ModelProviderIdType,
@@ -315,10 +312,7 @@ export type AgentActionSuccessEvent = {
   created: number;
   configurationId: string;
   messageId: string;
-  action: AgentMCPActionType & {
-    output: CallToolResult["content"];
-    generatedFiles: ActionGeneratedFileType[];
-  };
+  action: AgentMCPActionWithOutputType;
 };
 
 // Event sent to stop the generation.

--- a/front/types/assistant/agent.ts
+++ b/front/types/assistant/agent.ts
@@ -4,6 +4,7 @@ import type {
   MCPServerConfigurationType,
   MCPToolConfigurationType,
 } from "@app/lib/actions/mcp";
+import type { ActionGeneratedFileType } from "@app/lib/actions/types";
 import type { OAuthProvider } from "@app/types";
 import type { AgentMCPActionType } from "@app/types/actions";
 import type {
@@ -315,6 +316,7 @@ export type AgentActionSuccessEvent = {
   configurationId: string;
   messageId: string;
   action: AgentMCPActionType & {
+    generatedFiles: ActionGeneratedFileType[];
     output: CallToolResult["content"];
   };
 };

--- a/front/types/assistant/conversation.ts
+++ b/front/types/assistant/conversation.ts
@@ -1,5 +1,3 @@
-import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
-
 import type {
   MCPActionType,
   MCPApproveExecutionEvent,
@@ -165,10 +163,7 @@ export type AgentMessageType = BaseAgentMessageType & {
   visibility: MessageVisibility;
   configuration: LightAgentConfigurationType;
   skipToolsValidation: boolean;
-  actions: (AgentMCPActionType & {
-    type: "tool_action";
-    output: CallToolResult["content"];
-  })[];
+  actions: MCPActionType[];
   rawContents: Array<{
     step: number;
     content: string;

--- a/front/types/assistant/conversation.ts
+++ b/front/types/assistant/conversation.ts
@@ -3,7 +3,7 @@ import type {
   MCPApproveExecutionEvent,
 } from "@app/lib/actions/mcp";
 import type { ActionGeneratedFileType } from "@app/lib/actions/types";
-import type { AgentMCPActionType, AgentMCPActionWithOutputType } from "@app/types/actions";
+import type { AgentMCPActionWithOutputType } from "@app/types/actions";
 
 import type { ContentFragmentType } from "../content_fragment";
 import type { ModelId } from "../shared/model_id";

--- a/front/types/assistant/conversation.ts
+++ b/front/types/assistant/conversation.ts
@@ -1,9 +1,11 @@
+import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
+
 import type {
   MCPActionType,
   MCPApproveExecutionEvent,
 } from "@app/lib/actions/mcp";
 import type { ActionGeneratedFileType } from "@app/lib/actions/types";
-import type { AgentMCPActionWithOutputType } from "@app/types/actions";
+import type { AgentMCPActionType, AgentMCPActionWithOutputType } from "@app/types/actions";
 
 import type { ContentFragmentType } from "../content_fragment";
 import type { ModelId } from "../shared/model_id";
@@ -163,7 +165,10 @@ export type AgentMessageType = BaseAgentMessageType & {
   visibility: MessageVisibility;
   configuration: LightAgentConfigurationType;
   skipToolsValidation: boolean;
-  actions: MCPActionType[];
+  actions: (AgentMCPActionType & {
+    type: "tool_action";
+    output: CallToolResult["content"];
+  })[];
   rawContents: Array<{
     step: number;
     content: string;


### PR DESCRIPTION
## Description

- Part of https://github.com/dust-tt/tasks/issues/3586.
- This PR replaces the `new MCPActionType` to rely on the resource when creating `tool_success` events.
- The type `AgentMCPActionType` is compatible with the public type (done in https://github.com/dust-tt/dust/pull/15412).

## Tests

- Tested locally via the chrome extension.

## Risk

- Low.

## Deploy Plan

- Deploy front.
