### PR TITLE
[front] Fix message typing with streamed actions

### DIFF
--- a/front/components/actions/mcp/details/MCPActionDetails.tsx
+++ b/front/components/actions/mcp/details/MCPActionDetails.tsx
@@ -58,9 +58,10 @@ import {
   isSupportedImageContentType,
   parseTimeFrame,
 } from "@app/types";
+import type { AgentMCPActionWithOutputType } from "@app/types/actions";
 
 export interface MCPActionDetailsProps {
-  action: MCPActionType;
+  action: MCPActionType | AgentMCPActionWithOutputType;
   owner: LightWorkspaceType;
   lastNotification: ProgressNotificationContentType | null;
   messageStatus?: "created" | "succeeded" | "failed" | "cancelled";

--- a/front/components/actions/mcp/details/MCPExtractActionDetails.tsx
+++ b/front/components/actions/mcp/details/MCPExtractActionDetails.tsx
@@ -17,10 +17,11 @@ import {
   isExtractQueryResourceType,
   isExtractResultResourceType,
 } from "@app/lib/actions/mcp_internal_actions/output_schemas";
+import type { AgentMCPActionWithOutputType } from "@app/types/actions";
 import { isTimeFrame } from "@app/types/shared/utils/time_frame";
 
 interface MCPExtractActionQueryProps {
-  action: MCPActionType;
+  action: MCPActionType | AgentMCPActionWithOutputType;
   queryResource?: {
     text: string;
     mimeType: string;

--- a/front/components/assistant/conversation/actions/AgentMessageActions.tsx
+++ b/front/components/assistant/conversation/actions/AgentMessageActions.tsx
@@ -11,24 +11,22 @@ import {
 
 import { MCPActionDetails } from "@app/components/actions/mcp/details/MCPActionDetails";
 import { useConversationSidePanelContext } from "@app/components/assistant/conversation/ConversationSidePanelContext";
-import type { MCPActionType } from "@app/lib/actions/mcp";
 import type {
   ActionProgressState,
   AgentStateClassification,
 } from "@app/lib/assistant/state/messageReducer";
-import type { LightAgentMessageType, LightWorkspaceType } from "@app/types";
+import type {
+  LightAgentMessageType,
+  LightAgentMessageWithActionsType,
+  LightWorkspaceType,
+} from "@app/types";
+import { isLightAgentMessageWithActionsType } from "@app/types";
 
 interface AgentMessageActionsProps {
-  agentMessage: LightAgentMessageType;
+  agentMessage: LightAgentMessageType | LightAgentMessageWithActionsType;
   lastAgentStateClassification: AgentStateClassification;
   actionProgress: ActionProgressState;
   owner: LightWorkspaceType;
-}
-
-export function isMCPActionType(
-  action: { type: "tool_action"; id: number } | undefined
-): action is MCPActionType {
-  return action !== undefined && "functionCallName" in action;
 }
 
 export function AgentMessageActions({
@@ -39,9 +37,15 @@ export function AgentMessageActions({
 }: AgentMessageActionsProps) {
   const { openPanel } = useConversationSidePanelContext();
 
-  const lastAction = agentMessage.actions[agentMessage.actions.length - 1];
+  const isAgentMessageWithActions =
+    isLightAgentMessageWithActionsType(agentMessage);
+  const lastAction = isAgentMessageWithActions
+    ? agentMessage.actions[agentMessage.actions.length - 1]
+    : null;
   const hasSidePanelContent =
-    agentMessage.actions.length > 0 || agentMessage.chainOfThought;
+    (isAgentMessageWithActions && agentMessage.actions.length > 0) ||
+    agentMessage.chainOfThought;
+
   const chainOfThought = agentMessage.chainOfThought || "";
   const onClick = () => {
     openPanel({
@@ -54,7 +58,9 @@ export function AgentMessageActions({
     return null;
   }
 
-  const lastNotification = actionProgress.get(lastAction?.id)?.progress ?? null;
+  const lastNotification = lastAction
+    ? actionProgress.get(lastAction.id)?.progress ?? null
+    : null;
 
   return lastAgentStateClassification !== "done" ? (
     <div
@@ -64,8 +70,7 @@ export function AgentMessageActions({
         lastAction ? "cursor-pointer" : ""
       )}
     >
-      {isMCPActionType(lastAction) &&
-      lastAgentStateClassification === "acting" ? (
+      {lastAction && lastAgentStateClassification === "acting" ? (
         <Card variant="secondary" size="sm">
           <MCPActionDetails
             viewType="conversation"

--- a/front/components/assistant/conversation/actions/PanelAgentStep.tsx
+++ b/front/components/assistant/conversation/actions/PanelAgentStep.tsx
@@ -2,13 +2,14 @@ import { ContentMessage, Markdown, Separator } from "@dust-tt/sparkle";
 
 import { MCPActionDetails } from "@app/components/actions/mcp/details/MCPActionDetails";
 import type { LightWorkspaceType, ParsedContentItem } from "@app/types";
+import type { AgentMCPActionWithOutputType } from "@app/types/actions";
 
 interface AgentStepProps {
   stepNumber: number;
   entries?: ParsedContentItem[];
   reasoningContent?: string;
   isStreaming?: boolean;
-  streamingActions?: Array<{ type: "tool_action"; id: number }>;
+  streamingActions?: AgentMCPActionWithOutputType[];
   streamActionProgress: Map<number, any>;
   owner: LightWorkspaceType;
   messageStatus: "created" | "succeeded" | "failed" | "cancelled";

--- a/front/components/assistant/conversation/actions/PanelAgentStep.tsx
+++ b/front/components/assistant/conversation/actions/PanelAgentStep.tsx
@@ -1,7 +1,6 @@
 import { ContentMessage, Markdown, Separator } from "@dust-tt/sparkle";
 
 import { MCPActionDetails } from "@app/components/actions/mcp/details/MCPActionDetails";
-import { isMCPActionType } from "@app/components/assistant/conversation/actions/AgentMessageActions";
 import type { LightWorkspaceType, ParsedContentItem } from "@app/types";
 
 interface AgentStepProps {
@@ -94,10 +93,6 @@ export function PanelAgentStep({
       {streamingActions.length > 0 && (
         <div className="mt-4">
           {streamingActions.map((action) => {
-            if (!isMCPActionType(action)) {
-              return null;
-            }
-
             const streamProgress = streamActionProgress.get(
               action.id
             )?.progress;

--- a/front/hooks/useAgentMessageStream.ts
+++ b/front/hooks/useAgentMessageStream.ts
@@ -9,7 +9,12 @@ import {
   CLEAR_CONTENT_EVENT,
   messageReducer,
 } from "@app/lib/assistant/state/messageReducer";
-import type { LightAgentMessageType, LightWorkspaceType } from "@app/types";
+import type {
+  LightAgentMessageType,
+  LightAgentMessageWithActionsType,
+  LightWorkspaceType,
+} from "@app/types";
+import { isLightAgentMessageWithActionsType } from "@app/types";
 import { assertNever } from "@app/types";
 
 type AgentMessageStateWithControlEvent =
@@ -17,19 +22,24 @@ type AgentMessageStateWithControlEvent =
   | { type: "end-of-stream" };
 
 function makeInitialMessageStreamState(
-  message: LightAgentMessageType
+  message: LightAgentMessageType | LightAgentMessageWithActionsType
 ): MessageTemporaryState {
   return {
     actionProgress: new Map(),
     agentState: message.status === "created" ? "thinking" : "done",
     isRetrying: false,
     lastUpdated: new Date(),
-    message,
+    message: {
+      ...message,
+      actions: isLightAgentMessageWithActionsType(message)
+        ? message.actions
+        : [],
+    },
   };
 }
 
 interface UseAgentMessageStreamParams {
-  message: LightAgentMessageType;
+  message: LightAgentMessageType | LightAgentMessageWithActionsType;
   conversationId: string | null;
   owner: LightWorkspaceType;
   mutateMessage?: () => void;

--- a/front/lib/actions/mcp.ts
+++ b/front/lib/actions/mcp.ts
@@ -72,7 +72,7 @@ import {
   isPersonalAuthenticationRequiredErrorContent,
   removeNulls,
 } from "@app/types";
-import type { AgentMCPActionType } from "@app/types/actions";
+import type { AgentMCPActionWithOutputType } from "@app/types/actions";
 
 export type BaseMCPServerConfigurationType = {
   id: ModelId;
@@ -219,7 +219,10 @@ type MCPParamsEvent = {
   configurationId: string;
   messageId: string;
   // TODO: cleanup this type from the public API users.
-  action: AgentMCPActionType & { type: "tool_action"; output: null };
+  action: AgentMCPActionWithOutputType & {
+    output: null;
+    generatedFiles: never[];
+  };
 };
 
 type MCPSuccessEvent = {

--- a/front/lib/api/assistant/citations.ts
+++ b/front/lib/api/assistant/citations.ts
@@ -120,10 +120,6 @@ export const getLightAgentMessageFromAgentMessage = (
     chainOfThought: agentMessage.chainOfThought,
     error: agentMessage.error,
     status: agentMessage.status,
-    actions: agentMessage.actions.map((a) => ({
-      type: a.type,
-      id: a.id,
-    })),
     configuration: {
       sId: agentMessage.configuration.sId,
       name: agentMessage.configuration.name,

--- a/front/lib/assistant/state/messageReducer.ts
+++ b/front/lib/assistant/state/messageReducer.ts
@@ -5,10 +5,9 @@ import type {
 import type { ProgressNotificationContentType } from "@app/lib/actions/mcp_internal_actions/output_schemas";
 import { getLightAgentMessageFromAgentMessage } from "@app/lib/api/assistant/citations";
 import type { AgentMessageEvents } from "@app/lib/api/assistant/streaming/types";
-import type { ModelId } from "@app/types";
+import type { LightAgentMessageWithActionsType, ModelId } from "@app/types";
 import { assertNever } from "@app/types";
 import type { AgentMCPActionType } from "@app/types/actions";
-import type { LightAgentMessageType } from "@app/types/assistant/conversation";
 
 export type AgentStateClassification =
   | "thinking"
@@ -25,7 +24,7 @@ export type ActionProgressState = Map<
 >;
 
 export interface MessageTemporaryState {
-  message: LightAgentMessageType;
+  message: LightAgentMessageWithActionsType;
   agentState: AgentStateClassification;
   isRetrying: boolean;
   lastUpdated: Date;
@@ -43,9 +42,9 @@ type AgentMessageStateEventWithoutToolApproveExecution = Exclude<
 >;
 
 function updateMessageWithAction(
-  m: LightAgentMessageType,
-  action: MCPActionType | (AgentMCPActionType & { type: "tool_action" })
-): LightAgentMessageType {
+  m: LightAgentMessageWithActionsType,
+  action: AgentMCPActionType
+): LightAgentMessageWithActionsType {
   return {
     ...m,
     chainOfThought: "",
@@ -158,7 +157,10 @@ export function messageReducer(
     case "agent_message_success":
       return {
         ...state,
-        message: getLightAgentMessageFromAgentMessage(event.message),
+        message: {
+          ...getLightAgentMessageFromAgentMessage(event.message),
+          actions: state.message.actions,
+        },
         agentState: "done",
       };
 

--- a/front/lib/assistant/state/messageReducer.ts
+++ b/front/lib/assistant/state/messageReducer.ts
@@ -7,7 +7,7 @@ import { getLightAgentMessageFromAgentMessage } from "@app/lib/api/assistant/cit
 import type { AgentMessageEvents } from "@app/lib/api/assistant/streaming/types";
 import type { LightAgentMessageWithActionsType, ModelId } from "@app/types";
 import { assertNever } from "@app/types";
-import type { AgentMCPActionType } from "@app/types/actions";
+import type { AgentMCPActionWithOutputType } from "@app/types/actions";
 
 export type AgentStateClassification =
   | "thinking"
@@ -43,7 +43,7 @@ type AgentMessageStateEventWithoutToolApproveExecution = Exclude<
 
 function updateMessageWithAction(
   m: LightAgentMessageWithActionsType,
-  action: AgentMCPActionType
+  action: AgentMCPActionWithOutputType
 ): LightAgentMessageWithActionsType {
   return {
     ...m,

--- a/front/temporal/agent_loop/lib/create_tool_actions.ts
+++ b/front/temporal/agent_loop/lib/create_tool_actions.ts
@@ -198,7 +198,7 @@ async function createActionForTool(
       messageId: agentMessage.sId,
       // TODO: cleanup the type field from the public API users and remove everywhere.
       // TODO: move the output field to a separate field.
-      action: { ...action.toJSON(), type: "tool_action", output: null },
+      action: { ...action.toJSON(), output: null, generatedFiles: [] },
     },
     agentMessageRow,
     {

--- a/front/types/actions.ts
+++ b/front/types/actions.ts
@@ -1,15 +1,23 @@
+import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
+
 import type { InternalMCPServerNameType } from "@app/lib/actions/mcp_internal_actions/constants";
 import type { ToolExecutionStatus } from "@app/lib/actions/statuses";
+import type { ActionGeneratedFileType } from "@app/lib/actions/types";
 import type { ModelId } from "@app/types/shared/model_id";
 
 export type AgentMCPActionType = {
   agentMessageId: ModelId;
-  // TODO(durable-agents): prevent exposing the function call name
+  // TODO(MCPActionDetails): prevent exposing the function call name
   //  currently used in the extension to guess the tool name but quite brittle.
-  functionCallName: string;
+  functionCallName: string | null;
   id: ModelId;
   internalMCPServerName: InternalMCPServerNameType | null;
   mcpServerId: string | null;
   params: Record<string, unknown>;
   status: ToolExecutionStatus;
+};
+
+export type AgentMCPActionWithOutputType = AgentMCPActionType & {
+  generatedFiles: ActionGeneratedFileType[];
+  output: CallToolResult["content"] | null;
 };

--- a/front/types/assistant/conversation.ts
+++ b/front/types/assistant/conversation.ts
@@ -3,6 +3,7 @@ import type {
   MCPApproveExecutionEvent,
 } from "@app/lib/actions/mcp";
 import type { ActionGeneratedFileType } from "@app/lib/actions/types";
+import type { AgentMCPActionType } from "@app/types/actions";
 
 import type { ContentFragmentType } from "../content_fragment";
 import type { ModelId } from "../shared/model_id";
@@ -180,14 +181,21 @@ export type LightAgentMessageType = BaseAgentMessageType & {
     canRead: boolean;
     requestedGroupIds: string[][];
   };
-  actions: {
-    // TODO(2025-07-24 aubin): remove the type here.
-    type: "tool_action";
-    id: ModelId;
-  }[];
   citations: Record<string, CitationType>;
   generatedFiles: Omit<ActionGeneratedFileType, "snippet">[];
 };
+
+// This type represents the agent message we can reconstruct by accumulating streaming events
+// in a conversation.
+export type LightAgentMessageWithActionsType = LightAgentMessageType & {
+  actions: AgentMCPActionType[];
+};
+
+export function isLightAgentMessageWithActionsType(
+  message: LightAgentMessageType | LightAgentMessageWithActionsType
+): message is LightAgentMessageWithActionsType {
+  return "actions" in message;
+}
 
 export type AgentMessageWithRankType = WithRank<AgentMessageType>;
 

--- a/front/types/assistant/conversation.ts
+++ b/front/types/assistant/conversation.ts
@@ -3,7 +3,7 @@ import type {
   MCPApproveExecutionEvent,
 } from "@app/lib/actions/mcp";
 import type { ActionGeneratedFileType } from "@app/lib/actions/types";
-import type { AgentMCPActionType } from "@app/types/actions";
+import type { AgentMCPActionWithOutputType } from "@app/types/actions";
 
 import type { ContentFragmentType } from "../content_fragment";
 import type { ModelId } from "../shared/model_id";
@@ -188,12 +188,14 @@ export type LightAgentMessageType = BaseAgentMessageType & {
 // This type represents the agent message we can reconstruct by accumulating streaming events
 // in a conversation.
 export type LightAgentMessageWithActionsType = LightAgentMessageType & {
-  actions: AgentMCPActionType[];
+  actions: AgentMCPActionWithOutputType[];
 };
 
 export function isLightAgentMessageWithActionsType(
   message: LightAgentMessageType | LightAgentMessageWithActionsType
 ): message is LightAgentMessageWithActionsType {
+  // This check relies on the fact that `message` is already either a LightAgentMessageType or a
+  // LightAgentMessageWithActionsType; message.actions can therefore only be a AgentMCPActionType[].
   return "actions" in message;
 }
 

--- a/sdks/js/src/types.ts
+++ b/sdks/js/src/types.ts
@@ -693,7 +693,6 @@ const MCPActionTypeSchema = z.object({
   status: z.string(),
   params: z.record(z.any()),
   output: CallToolResultSchema.shape.content.nullable(),
-  type: z.literal("tool_action"),
 });
 
 const GlobalAgentStatusSchema = FlexibleEnumSchema<
@@ -1733,7 +1732,9 @@ export type PostUserMessageResponseType = z.infer<
 export const RetryMessageResponseSchema = z.object({
   message: AgentMessageTypeSchema,
 });
-export type RetryMessageResponseType = z.infer<typeof RetryMessageResponseSchema>;
+export type RetryMessageResponseType = z.infer<
+  typeof RetryMessageResponseSchema
+>;
 
 export const GetConversationResponseSchema = z.object({
   conversation: ConversationSchema,


### PR DESCRIPTION
## Description

- The typing for agent messages does not currently represent the fact that in a streaming context we have an agent message that is not a `LightAgentMessageType`, as it contains entire actions.
- We already rely on this albeit the type being incorrect, notably via this https://github.com/dust-tt/dust/blob/5b97021889bf5155b0708eb58f9dae694eb45475/front/components/assistant/conversation/actions/AgentMessageActions.tsx#L28
- This PR introduces a new type that represents best a `LightAgentMessageType` but with actions that are accumulated during the streaming.
- It also removes the field `type` for serialized actions. This field was not used in the extension nor the Slack bot.

## Tests

- Tested locally and on front-edge, with agents that return files, agents that call sub agents that return files.

## Risk

- Medium, well tested.

## Deploy Plan

- Deploy front.
