### PR TITLE
[front] Remove `agentMessage` mutation in `runToolActivity`

### DIFF
--- a/front/lib/actions/mcp.ts
+++ b/front/lib/actions/mcp.ts
@@ -569,7 +569,6 @@ export async function* runToolWithStreaming(
       actionBaseParams,
       status,
       errorMessage,
-      yieldAsError: false,
     });
     return;
   }
@@ -639,7 +638,7 @@ export async function createMCPAction(
   });
 }
 
-type BaseErrorParams = {
+type HandleErrorParams = {
   action: AgentMCPActionResource;
   actionBaseParams: ActionBaseParams;
   agentConfiguration: AgentConfigurationType;
@@ -647,21 +646,6 @@ type BaseErrorParams = {
   errorMessage: string;
   status: ToolExecutionStatus;
 };
-
-// Yields tool_error (stops conversation) - for auth/validation failures.
-type YieldAsErrorParams = BaseErrorParams & {
-  yieldAsError: true;
-  errorCode?: string;
-  errorMetadata?: Record<string, string | number | boolean> | null;
-};
-
-// Yields tool_success (continues conversation) - for timeouts/denials/execution errors.
-type YieldAsSuccessParams = BaseErrorParams & {
-  yieldAsError: false;
-  actionBaseParams: ActionBaseParams;
-};
-
-type HandleErrorParams = YieldAsErrorParams | YieldAsSuccessParams;
 
 /**
  * Handles MCP action errors with type-safe discriminated union based on error severity.
@@ -683,24 +667,6 @@ export async function handleMCPActionError(
     agentMCPActionId: action.id,
     content: outputContent,
   });
-
-  // Yields tool_error to stop conversation.
-  if (params.yieldAsError) {
-    // Update the action to mark it as having an error.
-    await action.updateStatus("errored");
-
-    return {
-      type: "tool_error",
-      created: Date.now(),
-      configurationId: agentConfiguration.sId,
-      messageId: agentMessage.sId,
-      error: {
-        code: params.errorCode ?? "tool_error",
-        message: errorMessage,
-        metadata: params.errorMetadata ?? null,
-      },
-    };
-  }
 
   // If the tool is not already in a final state, we set it to errored (could be denied).
   if (!isToolExecutionStatusFinal(status)) {

--- a/front/temporal/agent_loop/activities/run_tool.ts
+++ b/front/temporal/agent_loop/activities/run_tool.ts
@@ -145,26 +145,7 @@ export async function runToolActivity(
             step,
           }
         );
-
-        // We stitch the action into the agent message. The conversation is expected to include
-        // the agentMessage object, updating this object will update the conversation as well.
-        // Action might have already added earlier, so we to replace it.
-        // TODO(DURABLE-AGENTS 2025-08-12): This is a hack to avoid duplicates. Consider fetching
-        // at least on every step.
-        const existingActionIndex = agentMessage.actions.findIndex(
-          (existingAction) => existingAction.id === event.action.id
-        );
-
-        if (existingActionIndex >= 0) {
-          // Replace existing action with updated one.
-          agentMessage.actions[existingActionIndex] = event.action;
-        } else {
-          // Add the new action if it doesn't exist.
-          agentMessage.actions.push(event.action);
-        }
-
         break;
-
       case "tool_params":
       case "tool_notification":
         await updateResourceAndPublishEvent(event, agentMessageRow, {


### PR DESCRIPTION
## Description

- This PR removes mutations to the `agentMessage` in `runToolActivity`.
We actually only rely on the `agentMessage` for its `sId` and for passing it to the `agentLoopContext`.
In any case we should never need to mutate the `agentMessage` in the `runToolActivity`, but looking more into how the `agentMessage` is used within `agentLoopContext`, we either use the `sId` for logging purposes or the `skipToolsValidation` property in `run_agent` so we're not breaking any behavior that sneakily relied on this mutation.

- This PR also removes the ability for `handleMCPActionError` to "yield as error"  in `runToolWithStreaming`.
This possibility was introduced to handle personal authentication, but the flow has changed since and does not rely on this.

## Tests

- Tested locally.

## Risk

- Low.

## Deploy Plan

- Deploy front.
