### PR TITLE
[front] Replace `MCPActionType` with resource in `tool_notification` events

### DIFF
--- a/front/lib/actions/mcp.ts
+++ b/front/lib/actions/mcp.ts
@@ -259,6 +259,7 @@ export type ToolNotificationEvent = {
   messageId: string;
   action: AgentMCPActionType & {
     type: "tool_action";
+    output: null;
   };
   notification: ProgressNotificationContentType;
 };

--- a/front/lib/actions/mcp.ts
+++ b/front/lib/actions/mcp.ts
@@ -69,7 +69,10 @@ import {
   isPersonalAuthenticationRequiredErrorContent,
   removeNulls,
 } from "@app/types";
-import type { AgentMCPActionWithOutputType } from "@app/types/actions";
+import type {
+  AgentMCPActionType,
+  AgentMCPActionWithOutputType,
+} from "@app/types/actions";
 
 export type BaseMCPServerConfigurationType = {
   id: ModelId;
@@ -258,7 +261,6 @@ export type ToolNotificationEvent = {
   conversationId: string;
   messageId: string;
   action: AgentMCPActionType & {
-    type: "tool_action";
     output: null;
   };
   notification: ProgressNotificationContentType;

--- a/front/lib/actions/mcp.ts
+++ b/front/lib/actions/mcp.ts
@@ -69,10 +69,7 @@ import {
   isPersonalAuthenticationRequiredErrorContent,
   removeNulls,
 } from "@app/types";
-import type {
-  AgentMCPActionType,
-  AgentMCPActionWithOutputType,
-} from "@app/types/actions";
+import type { AgentMCPActionWithOutputType } from "@app/types/actions";
 
 export type BaseMCPServerConfigurationType = {
   id: ModelId;

--- a/front/lib/actions/mcp.ts
+++ b/front/lib/actions/mcp.ts
@@ -260,7 +260,8 @@ export type ToolNotificationEvent = {
   configurationId: string;
   conversationId: string;
   messageId: string;
-  action: AgentMCPActionType;
+  // TODO(2025-08-29 aubin): replace with AgentMCPActionType as soon as the SDK type is updated.
+  action: AgentMCPActionWithOutputType;
   notification: ProgressNotificationContentType;
 };
 

--- a/front/lib/actions/mcp.ts
+++ b/front/lib/actions/mcp.ts
@@ -260,9 +260,7 @@ export type ToolNotificationEvent = {
   configurationId: string;
   conversationId: string;
   messageId: string;
-  action: AgentMCPActionType & {
-    output: null;
-  };
+  action: AgentMCPActionType;
   notification: ProgressNotificationContentType;
 };
 

--- a/front/lib/actions/mcp_execution.ts
+++ b/front/lib/actions/mcp_execution.ts
@@ -109,7 +109,12 @@ export async function* executeMCPTool({
           configurationId: agentConfiguration.sId,
           conversationId: conversation.sId,
           messageId: agentMessage.sId,
-          action: action.toJSON(),
+          action: {
+            ...action.toJSON(),
+            // TODO(2025-08-29 aubin): cleanup as soon as the SDK type is updated.
+            output: null,
+            generatedFiles: [],
+          },
           notification: notification.params,
         };
       }

--- a/front/lib/actions/mcp_execution.ts
+++ b/front/lib/actions/mcp_execution.ts
@@ -14,7 +14,6 @@ import {
 } from "@app/lib/actions/action_output_limits";
 import type {
   LightMCPToolConfigurationType,
-  MCPActionType,
   MCPApproveExecutionEvent,
   MCPToolConfigurationType,
   ToolNotificationEvent,

--- a/front/lib/actions/mcp_execution.ts
+++ b/front/lib/actions/mcp_execution.ts
@@ -109,10 +109,7 @@ export async function* executeMCPTool({
           configurationId: agentConfiguration.sId,
           conversationId: conversation.sId,
           messageId: agentMessage.sId,
-          action: {
-            ...action.toJSON(),
-            output: null,
-          },
+          action: action.toJSON(),
           notification: notification.params,
         };
       }

--- a/front/lib/actions/mcp_execution.ts
+++ b/front/lib/actions/mcp_execution.ts
@@ -69,7 +69,6 @@ export async function* executeMCPTool({
   agentConfiguration,
   conversation,
   agentMessage,
-  mcpAction,
 }: {
   auth: Authenticator;
   inputs: Record<string, unknown>;
@@ -78,7 +77,6 @@ export async function* executeMCPTool({
   agentConfiguration: AgentConfigurationType;
   conversation: ConversationType;
   agentMessage: AgentMessageType;
-  mcpAction: MCPActionType;
 }): AsyncGenerator<
   ToolNotificationEvent | MCPApproveExecutionEvent,
   Result<
@@ -112,7 +110,10 @@ export async function* executeMCPTool({
           configurationId: agentConfiguration.sId,
           conversationId: conversation.sId,
           messageId: agentMessage.sId,
-          action: mcpAction,
+          action: {
+            ...action.toJSON(),
+            type: "tool_action",
+          },
           notification: notification.params,
         };
       }

--- a/front/lib/actions/mcp_execution.ts
+++ b/front/lib/actions/mcp_execution.ts
@@ -111,7 +111,6 @@ export async function* executeMCPTool({
           messageId: agentMessage.sId,
           action: {
             ...action.toJSON(),
-            type: "tool_action",
             output: null,
           },
           notification: notification.params,

--- a/front/lib/actions/mcp_execution.ts
+++ b/front/lib/actions/mcp_execution.ts
@@ -113,6 +113,7 @@ export async function* executeMCPTool({
           action: {
             ...action.toJSON(),
             type: "tool_action",
+            output: null,
           },
           notification: notification.params,
         };

--- a/front/lib/assistant/state/messageReducer.ts
+++ b/front/lib/assistant/state/messageReducer.ts
@@ -1,13 +1,13 @@
-import type {
-  MCPActionType,
-  ToolNotificationEvent,
-} from "@app/lib/actions/mcp";
+import type { ToolNotificationEvent } from "@app/lib/actions/mcp";
 import type { ProgressNotificationContentType } from "@app/lib/actions/mcp_internal_actions/output_schemas";
 import { getLightAgentMessageFromAgentMessage } from "@app/lib/api/assistant/citations";
 import type { AgentMessageEvents } from "@app/lib/api/assistant/streaming/types";
 import type { LightAgentMessageWithActionsType, ModelId } from "@app/types";
 import { assertNever } from "@app/types";
-import type { AgentMCPActionWithOutputType } from "@app/types/actions";
+import type {
+  AgentMCPActionType,
+  AgentMCPActionWithOutputType,
+} from "@app/types/actions";
 
 export type AgentStateClassification =
   | "thinking"
@@ -18,7 +18,7 @@ export type AgentStateClassification =
 export type ActionProgressState = Map<
   ModelId,
   {
-    action: AgentMCPActionType & { type: "tool_action" };
+    action: AgentMCPActionType;
     progress?: ProgressNotificationContentType;
   }
 >;

--- a/front/lib/assistant/state/messageReducer.ts
+++ b/front/lib/assistant/state/messageReducer.ts
@@ -18,7 +18,7 @@ export type AgentStateClassification =
 export type ActionProgressState = Map<
   ModelId,
   {
-    action: MCPActionType;
+    action: AgentMCPActionType & { type: "tool_action" };
     progress?: ProgressNotificationContentType;
   }
 >;
@@ -59,7 +59,7 @@ function updateProgress(
   const actionId = event.action.id;
   const currentProgress = state.actionProgress.get(actionId);
 
-  const newState = {
+  return {
     ...state,
     actionProgress: new Map(state.actionProgress).set(actionId, {
       action: event.action,
@@ -73,8 +73,6 @@ function updateProgress(
       },
     }),
   };
-
-  return newState;
 }
 
 export const CLEAR_CONTENT_EVENT = { type: "clear_content" as const };

--- a/front/temporal/agent_loop/activities/run_tool.ts
+++ b/front/temporal/agent_loop/activities/run_tool.ts
@@ -1,6 +1,6 @@
 import assert from "assert";
 
-import { MCPActionType, runToolWithStreaming } from "@app/lib/actions/mcp";
+import { runToolWithStreaming } from "@app/lib/actions/mcp";
 import type { AuthenticatorType } from "@app/lib/auth";
 import { Authenticator } from "@app/lib/auth";
 import { AgentMCPActionResource } from "@app/lib/resources/agent_mcp_action_resource";
@@ -71,20 +71,12 @@ export async function runToolActivity(
     status: action.status,
   });
 
-  const mcpAction = new MCPActionType({
-    ...actionBaseParams,
-    id: action.id,
-    type: "tool_action",
-    output: null,
-  });
-
   const eventStream = runToolWithStreaming(auth, {
     action,
     actionBaseParams,
     agentConfiguration,
     agentMessage,
     conversation,
-    mcpAction,
   });
 
   for await (const event of eventStream) {


### PR DESCRIPTION
## Description

- Part of https://github.com/dust-tt/tasks/issues/3586.
- This PR replaces the `new MCPActionType` to rely on the resource when creating `tool_notification` events.
- The type `AgentMCPActionType` is compatible with the public type (done in https://github.com/dust-tt/dust/pull/15412).

## Tests

- Tested locally.

## Risk

- Low.

## Deploy Plan

- Deploy front.
