### PR TITLE
Google Drive MCP tool

### DIFF
--- a/front/lib/actions/mcp_icons.tsx
+++ b/front/lib/actions/mcp_icons.tsx
@@ -17,6 +17,7 @@ import {
   ActionTimeIcon,
   Avatar,
   CommandLineIcon,
+  DriveLogo,
   FreshserviceLogo,
   GcalLogo,
   GithubLogo,
@@ -71,6 +72,7 @@ export const InternalActionIcons = {
   SalesforceLogo,
   SlackLogo,
   StripeLogo,
+  DriveLogo,
 };
 
 export const INTERNAL_ALLOWED_ICONS = Object.keys(InternalActionIcons);

--- a/front/lib/actions/mcp_internal_actions/constants.ts
+++ b/front/lib/actions/mcp_internal_actions/constants.ts
@@ -66,6 +66,7 @@ export const AVAILABLE_INTERNAL_MCP_SERVER_NAMES = [
   "github",
   "gmail",
   "google_calendar",
+  "google_drive",
   "google_sheets",
   "hubspot",
   "image_generation",
@@ -847,6 +848,35 @@ The directive should be used to display a clickable version of the agent name in
       },
       documentationUrl: null,
       instructions: FRESHSERVICE_SERVER_INSTRUCTIONS,
+    },
+  },
+  google_drive: {
+    id: 27,
+    availability: "manual",
+    allowMultipleInstances: true,
+    isRestricted: ({ featureFlags }) => {
+      return !featureFlags.includes("google_drive_tool");
+    },
+    isPreview: true,
+    tools_stakes: {
+      list_drives: "never_ask",
+      search_files: "never_ask",
+      get_file_content: "never_ask",
+    },
+    timeoutMs: undefined,
+    serverInfo: {
+      name: "google_drive",
+      version: "1.0.0",
+      description:
+        "Tools for searching and reading content from Google Drive files (Docs, Sheets, Presentations, text files).",
+      authorization: {
+        provider: "google_drive" as const,
+        supported_use_cases: ["personal_actions"] as const,
+        scope: "https://www.googleapis.com/auth/drive.readonly" as const,
+      },
+      icon: "DriveLogo",
+      documentationUrl: "https://docs.dust.tt/docs/google-drive",
+      instructions: null,
     },
   },
   [SEARCH_SERVER_NAME]: {

--- a/front/lib/actions/mcp_internal_actions/servers/google_drive.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/google_drive.ts
@@ -124,7 +124,17 @@ const createServer = (): McpServer => {
           ? `(${mimetypeQuery}) and (${query})`
           : `(${mimetypeQuery})`;
 
-        const requestParams: any = {
+        const requestParams: {
+          q: string;
+          pageToken?: string;
+          pageSize?: number;
+          fields: string;
+          orderBy?: string;
+          driveId?: string;
+          includeItemsFromAllDrives?: boolean;
+          supportsAllDrives?: boolean;
+          corpora?: string;
+        } = {
           q: searchQuery,
           pageToken,
           pageSize: pageSize ? Math.min(pageSize, 1000) : undefined,

--- a/front/lib/actions/mcp_internal_actions/servers/google_drive.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/google_drive.ts
@@ -16,7 +16,7 @@ const SUPPORTED_MIMETYPES = [
   "application/vnd.google-apps.spreadsheet",
   "text/plain",
   "text/markdown",
-] as const;
+];
 
 const MAX_CONTENT_SIZE = 50000; // Max characters to return for file content
 
@@ -202,10 +202,7 @@ const createServer = (): McpServer => {
         });
 
         const file = fileMetadata.data;
-        if (
-          !file.mimeType ||
-          !SUPPORTED_MIMETYPES.includes(file.mimeType as any)
-        ) {
+        if (!file.mimeType || !SUPPORTED_MIMETYPES.includes(file.mimeType)) {
           return makeMCPToolTextError(
             `Unsupported file type: ${file.mimeType}. Supported types: ${SUPPORTED_MIMETYPES.join(", ")}`
           );
@@ -224,8 +221,12 @@ const createServer = (): McpServer => {
             fileId,
             mimeType: "text/plain",
           });
-
-          content = exportResponse.data as string;
+          if (typeof exportResponse.data !== "string") {
+            return makeMCPToolTextError(
+              "Failed to export file content as text/plain"
+            );
+          }
+          content = exportResponse.data;
         } else if (
           file.mimeType === "text/plain" ||
           file.mimeType === "text/markdown"
@@ -236,7 +237,12 @@ const createServer = (): McpServer => {
             alt: "media",
           });
 
-          content = downloadResponse.data as string;
+          if (typeof downloadResponse.data !== "string") {
+            return makeMCPToolTextError(
+              "Failed to download file content as text"
+            );
+          }
+          content = downloadResponse.data;
         } else {
           return makeMCPToolTextError(
             `Unsupported file type: ${file.mimeType}`

--- a/front/lib/actions/mcp_internal_actions/servers/google_drive.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/google_drive.ts
@@ -1,0 +1,269 @@
+import type { AuthInfo } from "@modelcontextprotocol/sdk/server/auth/types.js";
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { google } from "googleapis";
+import { z } from "zod";
+
+import {
+  makeInternalMCPServer,
+  makeMCPToolJSONSuccess,
+  makeMCPToolTextError,
+} from "@app/lib/actions/mcp_internal_actions/utils";
+import { normalizeError } from "@app/types/shared/utils/error_utils";
+
+const SUPPORTED_MIMETYPES = [
+  "application/vnd.google-apps.document",
+  "application/vnd.google-apps.presentation",
+  "application/vnd.google-apps.spreadsheet",
+  "text/plain",
+  "text/markdown",
+] as const;
+
+const MAX_CONTENT_SIZE = 50000; // Max characters to return for file content
+
+const createServer = (): McpServer => {
+  const server = makeInternalMCPServer("google_drive");
+
+  async function getDriveClient(authInfo?: AuthInfo) {
+    const accessToken = authInfo?.token;
+    if (!accessToken) {
+      return null;
+    }
+
+    const oauth2Client = new google.auth.OAuth2();
+    oauth2Client.setCredentials({ access_token: accessToken });
+    return google.drive({
+      version: "v3",
+      auth: oauth2Client,
+    });
+  }
+
+  server.tool(
+    "list_drives",
+    "List all Google drives (shared drives) accessible by the user.",
+    {
+      pageToken: z.string().optional().describe("Page token for pagination."),
+      pageSize: z
+        .number()
+        .optional()
+        .describe("Maximum number of drives to return (max 100)."),
+    },
+    async ({ pageToken, pageSize }, { authInfo }) => {
+      const drive = await getDriveClient(authInfo);
+      if (!drive) {
+        return makeMCPToolTextError("Failed to authenticate with Google Drive");
+      }
+
+      try {
+        const res = await drive.drives.list({
+          pageToken,
+          pageSize: pageSize ? Math.min(pageSize, 100) : undefined,
+          fields: "nextPageToken, drives(id, name, createdTime)",
+        });
+
+        return makeMCPToolJSONSuccess({
+          result: res.data,
+        });
+      } catch (err) {
+        return makeMCPToolTextError(
+          normalizeError(err).message || "Failed to list drives"
+        );
+      }
+    }
+  );
+
+  server.tool(
+    "search_files",
+    "Search for files in Google Drive. Can search in personal drive, all shared drives, or a specific drive.",
+    {
+      query: z
+        .string()
+        .optional()
+        .describe(
+          "Search query to filter files. Uses Google Drive's search syntax. Leave empty to list all supported files."
+        ),
+      pageToken: z.string().optional().describe("Page token for pagination."),
+      pageSize: z
+        .number()
+        .optional()
+        .describe("Maximum number of files to return (max 1000)."),
+      driveId: z
+        .string()
+        .optional()
+        .describe(
+          "ID of a specific shared drive to search in. If set, only searches that drive."
+        ),
+      includeSharedDrives: z
+        .boolean()
+        .default(true)
+        .describe(
+          "Whether to include files from shared drives. Only valid if driveId is not set."
+        ),
+      orderBy: z
+        .string()
+        .optional()
+        .describe(
+          "How to order the results. Examples: 'modifiedTime desc', 'name', 'createdTime desc'"
+        ),
+    },
+    async (
+      { query, pageToken, pageSize, driveId, includeSharedDrives, orderBy },
+      { authInfo }
+    ) => {
+      const drive = await getDriveClient(authInfo);
+      if (!drive) {
+        return makeMCPToolTextError("Failed to authenticate with Google Drive");
+      }
+
+      try {
+        // Build query to filter by supported mimetypes
+        const mimetypeQuery = SUPPORTED_MIMETYPES.map(
+          (mimetype) => `mimeType='${mimetype}'`
+        ).join(" or ");
+
+        const searchQuery = query
+          ? `(${mimetypeQuery}) and (${query})`
+          : `(${mimetypeQuery})`;
+
+        const requestParams: any = {
+          q: searchQuery,
+          pageToken,
+          pageSize: pageSize ? Math.min(pageSize, 1000) : undefined,
+          fields:
+            "nextPageToken, files(id, name, mimeType, size, createdTime, modifiedTime, owners, parents, webViewLink, shared)",
+          orderBy,
+        };
+
+        if (driveId) {
+          // Search in a specific shared drive
+          requestParams.driveId = driveId;
+          requestParams.includeItemsFromAllDrives = true;
+          requestParams.supportsAllDrives = true;
+          requestParams.corpora = "drive";
+        } else if (includeSharedDrives) {
+          // Search across all drives (personal + shared)
+          requestParams.includeItemsFromAllDrives = true;
+          requestParams.supportsAllDrives = true;
+          requestParams.corpora = "allDrives";
+        }
+        // If neither driveId nor includeSharedDrives, search only personal drive (default behavior)
+
+        const res = await drive.files.list(requestParams);
+
+        return makeMCPToolJSONSuccess({
+          result: res.data,
+        });
+      } catch (err) {
+        return makeMCPToolTextError(
+          normalizeError(err).message || "Failed to search files"
+        );
+      }
+    }
+  );
+
+  server.tool(
+    "get_file_content",
+    "Get the content of a Google Drive file. Supports Google Docs, Presentations, Sheets, and text files with offset-based pagination.",
+    {
+      fileId: z
+        .string()
+        .describe("The ID of the file to retrieve content from."),
+      offset: z
+        .number()
+        .default(0)
+        .describe("Character offset to start reading from (for pagination)."),
+      limit: z
+        .number()
+        .default(MAX_CONTENT_SIZE)
+        .describe(
+          `Maximum number of characters to return, defaults to ${MAX_CONTENT_SIZE}.`
+        ),
+    },
+    async ({ fileId, offset, limit }, { authInfo }) => {
+      const drive = await getDriveClient(authInfo);
+      if (!drive) {
+        return makeMCPToolTextError("Failed to authenticate with Google Drive");
+      }
+
+      try {
+        // First, get file metadata to determine the mimetype
+        const fileMetadata = await drive.files.get({
+          fileId,
+          fields: "id, name, mimeType, size",
+        });
+
+        const file = fileMetadata.data;
+        if (
+          !file.mimeType ||
+          !SUPPORTED_MIMETYPES.includes(file.mimeType as any)
+        ) {
+          return makeMCPToolTextError(
+            `Unsupported file type: ${file.mimeType}. Supported types: ${SUPPORTED_MIMETYPES.join(", ")}`
+          );
+        }
+
+        let content: string;
+
+        // Handle different file types
+        if (
+          file.mimeType === "application/vnd.google-apps.document" ||
+          file.mimeType === "application/vnd.google-apps.presentation" ||
+          file.mimeType === "application/vnd.google-apps.spreadsheet"
+        ) {
+          // Export Google Docs and Presentations as plain text
+          const exportResponse = await drive.files.export({
+            fileId,
+            mimeType: "text/plain",
+          });
+
+          content = exportResponse.data as string;
+        } else if (
+          file.mimeType === "text/plain" ||
+          file.mimeType === "text/markdown"
+        ) {
+          // Download regular text files
+          const downloadResponse = await drive.files.get({
+            fileId,
+            alt: "media",
+          });
+
+          content = downloadResponse.data as string;
+        } else {
+          return makeMCPToolTextError(
+            `Unsupported file type: ${file.mimeType}`
+          );
+        }
+
+        // Apply offset and limit
+        const totalContentLength = content.length;
+        const startIndex = Math.max(0, offset);
+        const endIndex = Math.min(content.length, startIndex + limit);
+        const truncatedContent = content.slice(startIndex, endIndex);
+
+        const hasMore = endIndex < content.length;
+        const nextOffset = hasMore ? endIndex : undefined;
+
+        return makeMCPToolJSONSuccess({
+          result: {
+            fileId,
+            fileName: file.name,
+            mimeType: file.mimeType,
+            content: truncatedContent,
+            returnedContentLength: truncatedContent.length,
+            totalContentLength,
+            offset: startIndex,
+            nextOffset,
+            hasMore,
+          },
+        });
+      } catch (err) {
+        return makeMCPToolTextError(
+          normalizeError(err).message || "Failed to get file content"
+        );
+      }
+    }
+  );
+
+  return server;
+};
+
+export default createServer;

--- a/front/lib/actions/mcp_internal_actions/servers/index.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/index.ts
@@ -14,6 +14,7 @@ import { default as freshserviceServer } from "@app/lib/actions/mcp_internal_act
 import { default as githubServer } from "@app/lib/actions/mcp_internal_actions/servers/github";
 import { default as gmailServer } from "@app/lib/actions/mcp_internal_actions/servers/gmail";
 import { default as calendarServer } from "@app/lib/actions/mcp_internal_actions/servers/google_calendar";
+import { default as driveServer } from "@app/lib/actions/mcp_internal_actions/servers/google_drive";
 import { default as sheetsServer } from "@app/lib/actions/mcp_internal_actions/servers/google_sheets";
 import { default as hubspotServer } from "@app/lib/actions/mcp_internal_actions/servers/hubspot/server";
 import { default as imageGenerationDallEServer } from "@app/lib/actions/mcp_internal_actions/servers/image_generation";
@@ -127,6 +128,8 @@ export async function getInternalMCPServer(
       return gmailServer();
     case "google_calendar":
       return calendarServer();
+    case "google_drive":
+      return driveServer();
     case "google_sheets":
       return sheetsServer();
     case "data_sources_file_system":

--- a/front/types/shared/feature_flags.ts
+++ b/front/types/shared/feature_flags.ts
@@ -76,6 +76,10 @@ export const WHITELISTABLE_FEATURES_CONFIG = {
     description: "Google Sheets MCP tool",
     stage: "rolling_out",
   },
+  google_drive_tool: {
+    description: "Google Drive MCP tool",
+    stage: "rolling_out",
+  },
   index_private_slack_channel: {
     description: "Allow indexing of private Slack channels",
     stage: "on_demand",

--- a/sdks/js/src/mcp_icon_types.ts
+++ b/sdks/js/src/mcp_icon_types.ts
@@ -30,6 +30,7 @@ export const MCPInternalActionIconSchema = z.enum([
   "SalesforceLogo",
   "SlackLogo",
   "StripeLogo",
+  "DriveLogo",
 ]);
 
 export const MCPExternalActionIconSchema = z.enum([

--- a/sdks/js/src/mcp_icon_types.ts
+++ b/sdks/js/src/mcp_icon_types.ts
@@ -16,6 +16,7 @@ export const MCPInternalActionIconSchema = z.enum([
   "ActionTableIcon",
   "ActionTimeIcon",
   "CommandLineIcon",
+  "DriveLogo",
   "GcalLogo",
   "GmailLogo",
   "GithubLogo",
@@ -30,7 +31,6 @@ export const MCPInternalActionIconSchema = z.enum([
   "SalesforceLogo",
   "SlackLogo",
   "StripeLogo",
-  "DriveLogo",
 ]);
 
 export const MCPExternalActionIconSchema = z.enum([

--- a/sdks/js/src/types.ts
+++ b/sdks/js/src/types.ts
@@ -603,6 +603,7 @@ const WhitelistableFeaturesSchema = FlexibleEnumSchema<
   | "exploded_tables_query"
   | "freshservice_tool"
   | "google_ai_studio_experimental_models_feature"
+  | "google_drive_tool"
   | "google_sheets_tool"
   | "hootl"
   | "index_private_slack_channel"

--- a/sdks/js/src/types.ts
+++ b/sdks/js/src/types.ts
@@ -2611,6 +2611,7 @@ const InternalAllowedIconSchema = FlexibleEnumSchema<
   | "ActionTableIcon"
   | "ActionTimeIcon"
   | "CommandLineIcon"
+  | "DriveLogo"
   | "GcalLogo"
   | "GithubLogo"
   | "GmailLogo"


### PR DESCRIPTION
## Description

MCP server to access google drive (search) + get (docs, presentation, csv, text).
Note: sheet access should be handled through the google sheets server.

## Tests

Tested locally:

BAD:
- [x] (Fixed) Some file retrieval are not working as expected (file exists, fileId provided is good but file does not get downloaded)
- [x] Drive listing only return 10 results should be set to more for sure (at least 100)
- [x] Need to document query parameter more even if models do know the google drive API syntax

GOOD:
- Authentication is good we already have the right scopes
- It does kinda work for some stuff and with minimal prompting claude does a good use of the tools

## Risk

N/A

## Deploy Plan

- deploy `front`