### PR TITLE
[front] fix(ab/knowledge): Hide remote db checkbox

### DIFF
--- a/front/components/data_source_view/hooks/useDataSourceColumns.tsx
+++ b/front/components/data_source_view/hooks/useDataSourceColumns.tsx
@@ -59,6 +59,11 @@ export const useDataSourceColumns = () => {
               disabled={!isRowSelectable()}
               onClick={(event) => event.stopPropagation()}
               onCheckedChange={(state) => {
+                if (shouldHideSelectColumn && selectionState === "partial") {
+                  removeCurrentNavigationEntry();
+                  return;
+                }
+
                 // When clicking a partial checkbox, select all
                 if (selectionState === "partial" || state) {
                   selectCurrentNavigationEntry();
@@ -92,6 +97,11 @@ export const useDataSourceColumns = () => {
                 disabled={!isRowSelectable(row.original.id)}
                 onClick={(event) => event.stopPropagation()}
                 onCheckedChange={(state) => {
+                  if (shouldHideSelect && selectionState === "partial") {
+                    removeNode(row.original.entry);
+                    return;
+                  }
+
                   // When clicking a partial checkbox, select all
                   if (selectionState === "partial" || state) {
                     selectNode(row.original.entry);

--- a/front/components/data_source_view/hooks/useDataSourceColumns.tsx
+++ b/front/components/data_source_view/hooks/useDataSourceColumns.tsx
@@ -59,8 +59,8 @@ export const useDataSourceColumns = () => {
   } = useDataSourceBuilderContext();
   const confirm = useContext(ConfirmContext);
 
-  const columns: ColumnDef<DataSourceRowData>[] = useMemo(() => {
-    return [
+  const columns: ColumnDef<DataSourceRowData>[] = useMemo(
+    () => [
       {
         id: "select",
         enableSorting: false,
@@ -168,18 +168,19 @@ export const useDataSourceColumns = () => {
           sizeRatio: 70,
         },
       },
-    ];
-  }, [
-    confirm,
-    isCurrentNavigationEntrySelected,
-    isRowSelectable,
-    isRowSelected,
-    navigationHistory,
-    removeCurrentNavigationEntry,
-    removeNode,
-    selectCurrentNavigationEntry,
-    selectNode,
-  ]);
+    ],
+    [
+      confirm,
+      isCurrentNavigationEntrySelected,
+      isRowSelectable,
+      isRowSelected,
+      navigationHistory,
+      removeCurrentNavigationEntry,
+      removeNode,
+      selectCurrentNavigationEntry,
+      selectNode,
+    ]
+  );
 
   return columns;
 };


### PR DESCRIPTION
## Description
Because we cannot technically select a whole remote db (snowflake or bigquery) or their folder, hide the checkbox for those.
- Make all node, folder, data source unselecting when the checkbox state is partial. 

<img width="763" height="375" alt="Capture d’écran 2025-08-28 à 09 40 14" src="https://github.com/user-attachments/assets/46433470-c306-4fca-b17a-a4182fa54c78" />
<img width="764" height="369" alt="Capture d’écran 2025-08-28 à 09 40 10" src="https://github.com/user-attachments/assets/7b605335-a8ae-4fbe-8f9f-b5a96f0884e1" />
<img width="769" height="487" alt="Capture d’écran 2025-08-28 à 09 40 06" src="https://github.com/user-attachments/assets/82dc2045-9df0-4dc3-a196-f6fe894de73f" />

## Tests
- Locally

## Risk
- Low

## Deploy Plan
- Deploy front
