### PR TITLE
[front] add search for slack channel search in assistant builder

### DIFF
--- a/front/components/assistant_builder/SlackIntegration.tsx
+++ b/front/components/assistant_builder/SlackIntegration.tsx
@@ -91,6 +91,7 @@ export function SlackIntegration({
   return (
     <ContentNodeTree
       // not limited to those synced with Dust.
+      isTitleFilterEnabled={true}
       selectedNodes={selectedNodes}
       setSelectedNodes={(updater) => {
         const newModel = updater(selectedNodes);
@@ -174,7 +175,7 @@ export function SlackAssistantDefaultManager({
               Set this agent as the default agent on one or several of your
               Slack channels. It will answer by default when the{" "}
               <span className="font-bold">{assistantHandle}</span> Slack bot is
-              mentionned in these channels.
+              mentioned in these channels.
             </div>
 
             {!isAdmin(owner) && (


### PR DESCRIPTION
## Description
This PR is to add search functionality for slack channel selection in Assistant Builder (v2 already has it):

<img width="462" height="528" alt="Screenshot 2025-08-28 at 09 44 20" src="https://github.com/user-attachments/assets/67211dd2-8ced-47cb-b06a-e805c13d4c13" />


<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
