### PR TITLE
Add: handle subscribers for triggers

### DIFF
--- a/front/lib/api/assistant/conversation.ts
+++ b/front/lib/api/assistant/conversation.ts
@@ -473,7 +473,10 @@ export async function postUserMessage(
         return;
       }
 
-      return ConversationResource.upsertParticipation(auth, conversation);
+      return ConversationResource.upsertParticipation(auth, {
+        conversation,
+        action: "posted",
+      });
     })(),
   ]);
 
@@ -892,7 +895,10 @@ export async function editUserMessage(
         })
       )
     ),
-    ConversationResource.upsertParticipation(auth, conversation),
+    ConversationResource.upsertParticipation(auth, {
+      conversation,
+      action: "posted",
+    }),
   ]);
 
   const agentConfigurations = removeNulls(results[0]);

--- a/front/lib/client/conversation/event_handlers.ts
+++ b/front/lib/client/conversation/event_handlers.ts
@@ -98,9 +98,11 @@ export function getUpdatedParticipantsFromEvent(
       return participants;
     } else {
       participants.participants.users.push({
+        sId: user.sId,
         username: user.username,
         fullName: user.fullName,
         pictureUrl: user.image,
+        action: "posted",
       });
     }
   } else if (isAgentMessageType(message)) {

--- a/front/lib/resources/conversation_resource.ts
+++ b/front/lib/resources/conversation_resource.ts
@@ -25,6 +25,7 @@ import type {
   ConversationVisibility,
   ConversationWithoutContentType,
   LightAgentConfigurationType,
+  ParticipantActionType,
   Result,
 } from "@app/types";
 import { ConversationError, Err, normalizeError, Ok } from "@app/types";
@@ -392,7 +393,6 @@ export class ConversationResource extends BaseResource<ConversationModel> {
       where: {
         userId: user.id,
         workspaceId: owner.id,
-        action: "posted",
       },
       include: [
         {
@@ -434,7 +434,13 @@ export class ConversationResource extends BaseResource<ConversationModel> {
 
   static async upsertParticipation(
     auth: Authenticator,
-    conversation: ConversationType
+    {
+      conversation,
+      action,
+    }: {
+      conversation: ConversationType;
+      action: ParticipantActionType;
+    }
   ) {
     const user = auth.user();
     if (!user) {
@@ -455,7 +461,7 @@ export class ConversationResource extends BaseResource<ConversationModel> {
         participant.changed("updatedAt", true);
         await participant.update(
           {
-            action: "posted",
+            action,
             updatedAt: new Date(),
           },
           { transaction: t }
@@ -464,7 +470,7 @@ export class ConversationResource extends BaseResource<ConversationModel> {
         await ConversationParticipantModel.create(
           {
             conversationId: conversation.id,
-            action: "posted",
+            action,
             userId: user.id,
             workspaceId: conversation.owner.id,
             unread: false,

--- a/front/lib/resources/trigger_resource.ts
+++ b/front/lib/resources/trigger_resource.ts
@@ -193,8 +193,8 @@ export class TriggerResource extends BaseResource<TriggerModel> {
     switch (this.kind) {
       case "schedule":
         return createOrUpdateAgentScheduleWorkflow({
-          authType: auth.toJSON(),
-          trigger: this.toJSON(),
+          auth,
+          trigger: this,
         });
       default:
         assertNever(this.kind);

--- a/front/pages/api/w/[wId]/assistant/agent_configurations/[aId]/triggers/[tId]/subscribers.ts
+++ b/front/pages/api/w/[wId]/assistant/agent_configurations/[aId]/triggers/[tId]/subscribers.ts
@@ -133,16 +133,6 @@ async function handler(
     }
 
     case "DELETE": {
-      if (!agentConfiguration.canEdit && !auth.isAdmin()) {
-        return apiError(req, res, {
-          status_code: 403,
-          api_error: {
-            type: "app_auth_error",
-            message: "Only editors can manage subscribers for this trigger.",
-          },
-        });
-      }
-
       const removeResult = await trigger.removeFromSubscribers(auth);
       if (removeResult.isErr()) {
         return apiError(req, res, {

--- a/front/scripts/clear_temporal_schedules.ts
+++ b/front/scripts/clear_temporal_schedules.ts
@@ -1,0 +1,123 @@
+import { getTemporalClientForAgentNamespace } from "@app/lib/temporal";
+import logger from "@app/logger/logger";
+
+import { makeScript } from "./helpers";
+
+makeScript(
+  {
+    namespace: {
+      alias: "n",
+      describe: "Temporal namespace to clear schedules from",
+      type: "string" as const,
+      choices: ["agent", "front", "connectors"] as const,
+      default: "agent",
+    },
+  },
+  async ({ execute, namespace }, scriptLogger) => {
+    scriptLogger.info(
+      { namespace, execute },
+      `Starting to clear all schedules in Temporal namespace: ${namespace}`
+    );
+
+    if (!execute) {
+      scriptLogger.warn(
+        "This is a dry run. Use --execute to actually clear the schedules."
+      );
+    }
+
+    // Get the appropriate Temporal client based on namespace
+    let client;
+    switch (namespace) {
+      case "agent":
+        const { getTemporalClientForAgentNamespace } = await import(
+          "@app/lib/temporal"
+        );
+        client = await getTemporalClientForAgentNamespace();
+        break;
+      case "front":
+        const { getTemporalClientForFrontNamespace } = await import(
+          "@app/lib/temporal"
+        );
+        client = await getTemporalClientForFrontNamespace();
+        break;
+      case "connectors":
+        const { getTemporalClientForConnectorsNamespace } = await import(
+          "@app/lib/temporal"
+        );
+        client = await getTemporalClientForConnectorsNamespace();
+        break;
+      default:
+        throw new Error(`Unsupported namespace: ${namespace}`);
+    }
+
+    try {
+      // List all schedules
+      scriptLogger.info("Fetching all schedules...");
+      const schedulesIterable = client.schedule.list();
+
+      // Convert AsyncIterable to array
+      const schedules = [];
+      for await (const schedule of schedulesIterable) {
+        schedules.push(schedule);
+      }
+
+      if (schedules.length === 0) {
+        scriptLogger.info("No schedules found to clear.");
+        return;
+      }
+
+      scriptLogger.info(`Found ${schedules.length} schedules to clear.`);
+
+      let deletedCount = 0;
+      let errorCount = 0;
+
+      // Iterate through and delete each schedule
+      for (const schedule of schedules) {
+        const scheduleId = schedule.scheduleId;
+
+        try {
+          scriptLogger.info(
+            { scheduleId },
+            `Processing schedule: ${scheduleId}`
+          );
+
+          if (execute) {
+            const handle = client.schedule.getHandle(scheduleId);
+            await handle.delete();
+            scriptLogger.info(
+              { scheduleId },
+              `✅ Deleted schedule: ${scheduleId}`
+            );
+            deletedCount++;
+          } else {
+            scriptLogger.info(
+              { scheduleId },
+              `🔍 Would delete schedule: ${scheduleId} (dry run)`
+            );
+          }
+        } catch (error) {
+          scriptLogger.error(
+            { scheduleId, error },
+            `❌ Failed to delete schedule: ${scheduleId}`
+          );
+          errorCount++;
+        }
+      }
+
+      if (execute) {
+        scriptLogger.info(
+          { deletedCount, errorCount, totalSchedules: schedules.length },
+          `Completed clearing schedules. Deleted: ${deletedCount}, Errors: ${errorCount}`
+        );
+      } else {
+        scriptLogger.info(
+          { totalSchedules: schedules.length },
+          `Dry run completed. Found ${schedules.length} schedules that would be deleted.`
+        );
+      }
+    } catch (error) {
+      scriptLogger.error({ error }, "Failed to list or clear schedules");
+      throw error;
+    }
+  }
+);

--- a/front/scripts/clear_temporal_schedules.ts
+++ b/front/scripts/clear_temporal_schedules.ts
@@ -1,6 +1,3 @@
-import { getTemporalClientForAgentNamespace } from "@app/lib/temporal";
-import logger from "@app/logger/logger";
-
 import { makeScript } from "./helpers";
 
 makeScript(
@@ -8,8 +5,8 @@ makeScript(
     namespace: {
       alias: "n",
       describe: "Temporal namespace to clear schedules from",
-      type: "string" as const,
-      choices: ["agent", "front", "connectors"] as const,
+      type: "string",
+      choices: ["agent", "front", "connectors"],
       default: "agent",
     },
   },

--- a/front/temporal/agent_schedule/activities.ts
+++ b/front/temporal/agent_schedule/activities.ts
@@ -1,3 +1,7 @@
+import {
+  isMCPConfigurationForRunAgent,
+  isServerSideMCPServerConfiguration,
+} from "@app/lib/actions/types/guards";
 import { getAgentConfiguration } from "@app/lib/api/assistant/configuration/agent";
 import {
   createConversation,
@@ -5,30 +9,70 @@ import {
 } from "@app/lib/api/assistant/conversation";
 import type { AuthenticatorType } from "@app/lib/auth";
 import { Authenticator } from "@app/lib/auth";
+import { ConversationResource } from "@app/lib/resources/conversation_resource";
+import { MCPServerViewResource } from "@app/lib/resources/mcp_server_view_resource";
+import { TriggerResource } from "@app/lib/resources/trigger_resource";
 import logger from "@app/logger/logger";
+import type { AgentConfigurationType } from "@app/types";
 import type { TriggerType } from "@app/types/assistant/triggers";
 
-export async function runScheduledAgentsActivity(
-  authType: AuthenticatorType,
+/**
+ * We want to create individual conversations if the agent outcome will vary from user to user.
+ */
+async function shouldCreateIndividualConversations(
+  auth: Authenticator,
+  agentConfiguration: AgentConfigurationType,
+  checkedAgentConfigurationIds: string[] = []
+): Promise<boolean> {
+  // Check if one of the actions is using a personal actions or a run agent action
+  const mcpServerViews = await MCPServerViewResource.listByWorkspace(auth);
+  const mcpServerViewsMap = new Map(
+    mcpServerViews.map((mcpServerView) => [mcpServerView.sId, mcpServerView])
+  );
+  for (const action of agentConfiguration.actions) {
+    if (isServerSideMCPServerConfiguration(action)) {
+      const mcpServerView = mcpServerViewsMap.get(action.mcpServerViewId);
+      if (!mcpServerView) {
+        throw new Error(
+          `MCP server view with ID ${action.mcpServerViewId} not found.`
+        );
+      }
+      if (mcpServerView.oAuthUseCase === "personal_actions") {
+        return true;
+      }
+      // Check the chain of agents
+      if (
+        isMCPConfigurationForRunAgent(action) &&
+        action.childAgentId &&
+        // Avoid infinite loop
+        !checkedAgentConfigurationIds.includes(action.childAgentId)
+      ) {
+        const subAgentConfiguration = await getAgentConfiguration(auth, {
+          agentId: action.childAgentId,
+          variant: "full",
+        });
+        if (subAgentConfiguration) {
+          const subCheck = await shouldCreateIndividualConversations(
+            auth,
+            subAgentConfiguration,
+            [...checkedAgentConfigurationIds, agentConfiguration.sId]
+          );
+          if (subCheck) {
+            return true;
+          }
+        }
+      }
+    }
+  }
+
+  return false;
+}
+
+const createConversationForAgentConfiguration = async (
+  auth: Authenticator,
+  agentConfiguration: AgentConfigurationType,
   trigger: TriggerType
-) {
-  const auth = await Authenticator.fromJSON(authType);
-
-  if (!auth.workspace() || !auth.user()) {
-    throw new Error("Invalid authentication. Missing workspaceId or userId.");
-  }
-
-  const agentConfiguration = await getAgentConfiguration(auth, {
-    agentId: trigger.agentConfigurationId,
-    variant: "light",
-  });
-
-  if (!agentConfiguration) {
-    throw new Error(
-      `Agent configuration with ID ${trigger.agentConfigurationId} not found in workspace ${auth.getNonNullableWorkspace().id}.`
-    );
-  }
-
+) => {
   const newConversation = await createConversation(auth, {
     title: `@${agentConfiguration.name} scheduled call - ${new Date().toLocaleDateString()}`,
     visibility: "triggered",
@@ -64,5 +108,91 @@ export async function runScheduledAgentsActivity(
       "scheduledAgentCallActivity: Error sending message."
     );
     return;
+  }
+
+  return newConversation;
+};
+
+export async function runScheduledAgentsActivity(
+  authType: AuthenticatorType,
+  trigger: TriggerType
+) {
+  const auth = await Authenticator.fromJSON(authType);
+
+  if (!auth.workspace() || !auth.user()) {
+    throw new Error("Invalid authentication. Missing workspaceId or userId.");
+  }
+
+  const agentConfiguration = await getAgentConfiguration(auth, {
+    agentId: trigger.agentConfigurationId,
+    variant: "full",
+  });
+
+  if (!agentConfiguration) {
+    throw new Error(
+      `Agent configuration with ID ${trigger.agentConfigurationId} not found in workspace ${auth.getNonNullableWorkspace().id}.`
+    );
+  }
+
+  const useIndividualConversations = await shouldCreateIndividualConversations(
+    auth,
+    agentConfiguration
+  );
+  const triggerResource = await TriggerResource.fetchById(auth, trigger.sId);
+  if (!triggerResource) {
+    throw new Error(`Trigger with ID ${trigger.sId} not found.`);
+  }
+  const subscribers = await triggerResource.getSubscribers(auth);
+  if (subscribers.isErr()) {
+    throw new Error("Error getting trigger subscribers.");
+  }
+  const subscribersAuths = await Promise.all(
+    subscribers.value.map((s) =>
+      Authenticator.fromUserIdAndWorkspaceId(
+        s.sId,
+        auth.getNonNullableWorkspace().sId
+      )
+    )
+  );
+  if (useIndividualConversations) {
+    // Create conversations for the editor and all the subscribers
+    for (const tempAuth of [auth, ...subscribersAuths]) {
+      try {
+        await createConversationForAgentConfiguration(
+          tempAuth,
+          agentConfiguration,
+          trigger
+        );
+      } catch (error) {
+        // Might happen if a subscriber do not have the right permissions to use the agent
+        logger.error(
+          {
+            error,
+            agentConfigurationId: trigger.agentConfigurationId,
+            userId: tempAuth.getNonNullableUser().sId,
+            workspaceId: tempAuth.getNonNullableWorkspace().sId,
+          },
+          "Error creating conversation for agent configuration."
+        );
+      }
+    }
+  } else {
+    // Create a single conversation for the editor
+    const conversation = await createConversationForAgentConfiguration(
+      auth,
+      agentConfiguration,
+      trigger
+    );
+    if (!conversation) {
+      throw new Error("Error creating conversation.");
+    }
+
+    // Upsert all the subscribers as participants
+    for (const tempAuth of subscribersAuths) {
+      await ConversationResource.upsertParticipation(tempAuth, {
+        conversation,
+        action: "subscribed",
+      });
+    }
   }
 }

--- a/front/temporal/agent_schedule/workflows.ts
+++ b/front/temporal/agent_schedule/workflows.ts
@@ -5,7 +5,7 @@ import type * as activities from "@app/temporal/agent_schedule/activities";
 import type { TriggerType } from "@app/types/assistant/triggers";
 
 const { runScheduledAgentsActivity } = proxyActivities<typeof activities>({
-  startToCloseTimeout: "2 minutes",
+  startToCloseTimeout: "5 minutes",
 });
 
 export async function agentScheduleWorkflow(

--- a/front/types/assistant/conversation.ts
+++ b/front/types/assistant/conversation.ts
@@ -248,9 +248,11 @@ export interface AgentParticipantType {
 }
 
 export interface UserParticipantType {
+  sId: string;
   fullName: string | null;
   pictureUrl: string | null;
   username: string;
+  action: ParticipantActionType;
 }
 
 export interface ConversationParticipantsType {


### PR DESCRIPTION
## Description

Handle triggers subscribers by making so we create separate conversations or just subscribe to a single one depending on the agent configuration.

- Updated the way we list users participants to use the `conversation_participants` table.
- Removed hardcoded "posted" action and use the appriopriate "subscribed" action.
- Added more informations in the `UserParticipantType`

## Tests

Tested different scenarios (will add tests later as I'm fixing an issue with tests).
- Agent without personal actions
- Agent with personal actions
- Agent with subagent without personal actions
- Agent with subagent with personal actions

(examples)
<img width="529" height="134" alt="image" src="https://github.com/user-attachments/assets/dfa9cd7d-f595-40ae-b087-97783bd1ab91" />


## Risk

Low

## Deploy Plan

Deploy front