### PR TITLE
Fix: tests and split job

### DIFF
--- a/.github/workflows/build-and-lint-front.yml
+++ b/.github/workflows/build-and-lint-front.yml
@@ -62,7 +62,7 @@ jobs:
           flaky_summary: true
           group_suite: true
           check_name: Tests Report
-  tsc-lint:
+  tsc:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
@@ -82,4 +82,25 @@ jobs:
         run: npm ci
       - name: Typecheck and Lint
         working-directory: front
-        run: npx tsc --version && npm run tsc && npm run lint && npm run format:check && npm run docs:check
+        run: npx tsc --version && npm run tsc
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 20.13.0
+          cache: "npm"
+          cache-dependency-path: |
+            ./front/package-lock.json
+            ./types/package-lock.json
+            ./sdks/js/package-lock.json
+      - name: Install SDK/JS
+        working-directory: sdks/js
+        run: npm install
+      - name: Install Front
+        working-directory: front
+        run: npm install
+      - name: Typecheck and Lint
+        working-directory: front
+        run: npm run lint && npm run format:check && npm run docs:check

--- a/.github/workflows/build-and-lint-front.yml
+++ b/.github/workflows/build-and-lint-front.yml
@@ -80,7 +80,7 @@ jobs:
       - name: Build Front
         working-directory: front
         run: npm ci
-      - name: Typecheck and Lint
+      - name: Typecheck
         working-directory: front
         run: npx tsc --version && npm run tsc
   lint:
@@ -101,6 +101,6 @@ jobs:
       - name: Install Front
         working-directory: front
         run: npm install
-      - name: Typecheck and Lint
+      - name: Lint
         working-directory: front
         run: npm run lint && npm run format:check && npm run docs:check

--- a/front/lib/resources/trigger_resource.test.ts
+++ b/front/lib/resources/trigger_resource.test.ts
@@ -8,7 +8,7 @@ import { AgentConfigurationFactory } from "@app/tests/utils/AgentConfigurationFa
 import { createResourceTest } from "@app/tests/utils/generic_resource_tests";
 import { UserFactory } from "@app/tests/utils/UserFactory";
 
-describe.skip("TriggerResource", () => {
+describe("TriggerResource", () => {
   describe("addToSubscribers", () => {
     it("should successfully add user to subscribers", async () => {
       const {

--- a/front/vite.setup.ts
+++ b/front/vite.setup.ts
@@ -33,6 +33,16 @@ beforeEach(async (c) => {
       ),
   }));
 
+  // Mock Temporal
+  vi.mock("@app/lib/temporal", () => ({
+    getTemporalClientForAgentNamespace: vi.fn().mockResolvedValue({
+      schedule: {
+        getHandle: vi.fn().mockReturnValue({
+          update: vi.fn(),
+        }),
+      },
+    }),
+  }));
   const namespace = cls.createNamespace("test-namespace");
 
   // We use CLS to create a namespace and a transaction to isolate each test.


### PR DESCRIPTION
## Description

Fix tests that i had to skip because of temporal not available.
Also, split lint & tsc in 2 parallels jobs + tests job that was already // yesterday (almost halved time compared to 2 days go)

## Tests

Green

## Risk

Low

## Deploy Plan

Deploy front