### PR TITLE
[front] chore(ab/knowledge): Small code fixes

### DIFF
--- a/front/components/agent_builder/capabilities/knowledge/DataSourceBuilderSelector.tsx
+++ b/front/components/agent_builder/capabilities/knowledge/DataSourceBuilderSelector.tsx
@@ -12,6 +12,7 @@ import React from "react";
 import { DataSourceNavigationView } from "@app/components/agent_builder/capabilities/knowledge/DataSourceNavigationView";
 import { DataSourceSearchResults } from "@app/components/agent_builder/capabilities/knowledge/DataSourceSearchResults";
 import { DataSourceSpaceSelector } from "@app/components/agent_builder/capabilities/knowledge/DataSourceSpaceSelector";
+import { useDataSourceViewsContext } from "@app/components/agent_builder/DataSourceViewsContext";
 import { useSpacesContext } from "@app/components/agent_builder/SpacesContext";
 import { useDataSourceBuilderContext } from "@app/components/data_source_view/context/DataSourceBuilderContext";
 import type { NavigationHistoryEntryType } from "@app/components/data_source_view/context/types";
@@ -20,25 +21,21 @@ import { useDebounce } from "@app/hooks/useDebounce";
 import { getDataSourceNameFromView } from "@app/lib/data_sources";
 import { CATEGORY_DETAILS } from "@app/lib/spaces";
 import { useSpacesSearch, useSystemSpace } from "@app/lib/swr/spaces";
-import type {
-  ContentNodesViewType,
-  DataSourceViewType,
-  LightWorkspaceType,
-} from "@app/types";
+import type { ContentNodesViewType, LightWorkspaceType } from "@app/types";
 import { MIN_SEARCH_QUERY_SIZE } from "@app/types";
 
 type DataSourceBuilderSelectorProps = {
   owner: LightWorkspaceType;
-  dataSourceViews: DataSourceViewType[];
   viewType: ContentNodesViewType;
 };
 
 export const DataSourceBuilderSelector = ({
   owner,
-  dataSourceViews,
   viewType,
 }: DataSourceBuilderSelectorProps) => {
   const { spaces } = useSpacesContext();
+  const { supportedDataSourceViews: dataSourceViews } =
+    useDataSourceViewsContext();
   const { navigationHistory, navigateTo } = useDataSourceBuilderContext();
   const router = useRouter();
   const { systemSpace } = useSystemSpace({ workspaceId: owner.sId });

--- a/front/components/agent_builder/capabilities/knowledge/DataSourceBuilderSelector.tsx
+++ b/front/components/agent_builder/capabilities/knowledge/DataSourceBuilderSelector.tsx
@@ -9,6 +9,7 @@ import { useRouter } from "next/router";
 import { useEffect, useMemo, useState } from "react";
 import React from "react";
 
+import { useAgentBuilderContext } from "@app/components/agent_builder/AgentBuilderContext";
 import { DataSourceNavigationView } from "@app/components/agent_builder/capabilities/knowledge/DataSourceNavigationView";
 import { DataSourceSearchResults } from "@app/components/agent_builder/capabilities/knowledge/DataSourceSearchResults";
 import { DataSourceSpaceSelector } from "@app/components/agent_builder/capabilities/knowledge/DataSourceSpaceSelector";
@@ -21,18 +22,17 @@ import { useDebounce } from "@app/hooks/useDebounce";
 import { getDataSourceNameFromView } from "@app/lib/data_sources";
 import { CATEGORY_DETAILS } from "@app/lib/spaces";
 import { useSpacesSearch, useSystemSpace } from "@app/lib/swr/spaces";
-import type { ContentNodesViewType, LightWorkspaceType } from "@app/types";
+import type { ContentNodesViewType } from "@app/types";
 import { MIN_SEARCH_QUERY_SIZE } from "@app/types";
 
 type DataSourceBuilderSelectorProps = {
-  owner: LightWorkspaceType;
   viewType: ContentNodesViewType;
 };
 
 export const DataSourceBuilderSelector = ({
-  owner,
   viewType,
 }: DataSourceBuilderSelectorProps) => {
+  const { owner } = useAgentBuilderContext();
   const { spaces } = useSpacesContext();
   const { supportedDataSourceViews: dataSourceViews } =
     useDataSourceViewsContext();

--- a/front/components/agent_builder/capabilities/knowledge/KnowledgeConfigurationSheet.tsx
+++ b/front/components/agent_builder/capabilities/knowledge/KnowledgeConfigurationSheet.tsx
@@ -311,11 +311,11 @@ function KnowledgeConfigurationSheetContent({
   const mcpServerView = useWatch<CapabilityFormData, "mcpServerView">({
     name: "mcpServerView",
   });
-  const sources = useWatch<CapabilityFormData, "sources">({
-    name: "sources",
+  const hasSourceSelection = useWatch({
+    compute: (formData: CapabilityFormData) => {
+      return formData.sources.in.length > 0;
+    },
   });
-
-  const hasSourceSelection = sources.in.length > 0;
 
   const config = useMemo(() => {
     if (mcpServerView !== null) {

--- a/front/components/agent_builder/capabilities/knowledge/KnowledgeConfigurationSheet.tsx
+++ b/front/components/agent_builder/capabilities/knowledge/KnowledgeConfigurationSheet.tsx
@@ -35,10 +35,11 @@ import {
   CONFIGURATION_SHEET_PAGE_IDS,
 } from "@app/components/agent_builder/types";
 import { ConfirmContext } from "@app/components/Confirm";
+import { DataSourceBuilderProvider } from "@app/components/data_source_view/context/DataSourceBuilderContext";
 import {
-  DataSourceBuilderProvider,
-  useDataSourceBuilderContext,
-} from "@app/components/data_source_view/context/DataSourceBuilderContext";
+  KnowledgePageProvider,
+  useKnowledgePageContext,
+} from "@app/components/data_source_view/context/PageContext";
 import { getMCPServerNameForTemplateAction } from "@app/lib/actions/mcp_helper";
 import { SEARCH_SERVER_NAME } from "@app/lib/actions/mcp_internal_actions/constants";
 import { getMCPServerRequirements } from "@app/lib/actions/mcp_internal_actions/input_configuration";
@@ -277,16 +278,15 @@ function KnowledgeConfigurationSheetForm({
 
   return (
     <FormProvider {...form}>
-      <DataSourceBuilderProvider
-        spaces={spaces}
-        initialPageId={getInitialPageId(isEditing)}
-      >
-        <KnowledgeConfigurationSheetContent
-          onSave={form.handleSubmit(handleSave)}
-          onClose={onClose}
-          getAgentInstructions={getAgentInstructions}
-          isEditing={isEditing}
-        />
+      <DataSourceBuilderProvider spaces={spaces}>
+        <KnowledgePageProvider initialPageId={getInitialPageId(isEditing)}>
+          <KnowledgeConfigurationSheetContent
+            onSave={form.handleSubmit(handleSave)}
+            onClose={onClose}
+            getAgentInstructions={getAgentInstructions}
+            isEditing={isEditing}
+          />
+        </KnowledgePageProvider>
       </DataSourceBuilderProvider>
     </FormProvider>
   );
@@ -305,7 +305,7 @@ function KnowledgeConfigurationSheetContent({
   getAgentInstructions,
   isEditing,
 }: KnowledgeConfigurationSheetContentProps) {
-  const { currentPageId, setSheetPageId } = useDataSourceBuilderContext();
+  const { currentPageId, setSheetPageId } = useKnowledgePageContext();
 
   const mcpServerView = useWatch<CapabilityFormData, "mcpServerView">({
     name: "mcpServerView",

--- a/front/components/agent_builder/capabilities/knowledge/KnowledgeConfigurationSheet.tsx
+++ b/front/components/agent_builder/capabilities/knowledge/KnowledgeConfigurationSheet.tsx
@@ -329,7 +329,6 @@ function KnowledgeConfigurationSheetContent({
   }, [mcpServerView]);
 
   const { owner } = useAgentBuilderContext();
-  const { supportedDataSourceViews } = useDataSourceViewsContext();
 
   const handlePageChange = (pageId: string) => {
     if (isValidPage(pageId, CONFIGURATION_SHEET_PAGE_IDS)) {
@@ -384,13 +383,7 @@ function KnowledgeConfigurationSheetContent({
         : "Choose the data sources to include in your knowledge base",
       icon: undefined,
       noScroll: true,
-      content: (
-        <DataSourceBuilderSelector
-          dataSourceViews={supportedDataSourceViews}
-          owner={owner}
-          viewType="all"
-        />
-      ),
+      content: <DataSourceBuilderSelector owner={owner} viewType="all" />,
       footerContent: hasSourceSelection ? <KnowledgeFooter /> : undefined,
     },
     {

--- a/front/components/agent_builder/capabilities/knowledge/KnowledgeConfigurationSheet.tsx
+++ b/front/components/agent_builder/capabilities/knowledge/KnowledgeConfigurationSheet.tsx
@@ -6,7 +6,6 @@ import uniqueId from "lodash/uniqueId";
 import { useContext, useEffect, useMemo, useState } from "react";
 import { FormProvider, useForm, useWatch } from "react-hook-form";
 
-import { useAgentBuilderContext } from "@app/components/agent_builder/AgentBuilderContext";
 import { DataSourceBuilderSelector } from "@app/components/agent_builder/capabilities/knowledge/DataSourceBuilderSelector";
 import { KnowledgeFooter } from "@app/components/agent_builder/capabilities/knowledge/KnowledgeFooter";
 import {
@@ -328,8 +327,6 @@ function KnowledgeConfigurationSheetContent({
     return getMCPServerRequirements(mcpServerView);
   }, [mcpServerView]);
 
-  const { owner } = useAgentBuilderContext();
-
   const handlePageChange = (pageId: string) => {
     if (isValidPage(pageId, CONFIGURATION_SHEET_PAGE_IDS)) {
       setSheetPageId(pageId);
@@ -383,7 +380,7 @@ function KnowledgeConfigurationSheetContent({
         : "Choose the data sources to include in your knowledge base",
       icon: undefined,
       noScroll: true,
-      content: <DataSourceBuilderSelector owner={owner} viewType="all" />,
+      content: <DataSourceBuilderSelector viewType="all" />,
       footerContent: hasSourceSelection ? <KnowledgeFooter /> : undefined,
     },
     {

--- a/front/components/agent_builder/capabilities/knowledge/KnowledgeFooter.tsx
+++ b/front/components/agent_builder/capabilities/knowledge/KnowledgeFooter.tsx
@@ -103,12 +103,7 @@ function KnowledgeFooterItem({
 
 export function KnowledgeFooter() {
   const [isOpen, setOpen] = useState(true);
-
   const { field } = useSourcesFormController();
-
-  if (field.value.in.length <= 0) {
-    return <></>;
-  }
 
   return (
     <Collapsible open={isOpen} onOpenChange={setOpen}>

--- a/front/components/agent_builder/capabilities/shared/SelectDataSourcesFilters.tsx
+++ b/front/components/agent_builder/capabilities/shared/SelectDataSourcesFilters.tsx
@@ -5,7 +5,7 @@ import { DataSourceViewTagsFilterDropdown } from "@app/components/agent_builder/
 import { useSpacesContext } from "@app/components/agent_builder/SpacesContext";
 import type { CapabilityFormData } from "@app/components/agent_builder/types";
 import { CONFIGURATION_SHEET_PAGE_IDS } from "@app/components/agent_builder/types";
-import { useDataSourceBuilderContext } from "@app/components/data_source_view/context/DataSourceBuilderContext";
+import { useKnowledgePageContext } from "@app/components/data_source_view/context/PageContext";
 import { useTheme } from "@app/components/sparkle/ThemeContext";
 import { getConnectorProviderLogoWithFallback } from "@app/lib/connector_providers";
 import { getDisplayNameForDataSource } from "@app/lib/data_sources";
@@ -45,7 +45,7 @@ function DataSourceFilterContextItem({
 }
 
 export function SelectDataSourcesFilters() {
-  const { setSheetPageId } = useDataSourceBuilderContext();
+  const { setSheetPageId } = useKnowledgePageContext();
   const sources = useWatch<CapabilityFormData, "sources">({ name: "sources" });
 
   const dataSourceViews = sources.in.reduce(

--- a/front/components/data_source_view/context/DataSourceBuilderContext.tsx
+++ b/front/components/data_source_view/context/DataSourceBuilderContext.tsx
@@ -38,7 +38,6 @@ import {
   useReducer,
 } from "react";
 
-import type { ConfigurationPagePageId } from "@app/components/agent_builder/types";
 import { useSourcesFormController } from "@app/components/agent_builder/utils";
 import type {
   DataSourceBuilderTreeItemType,
@@ -70,7 +69,6 @@ type StateType = {
    * so in this case we can use index to update specific values
    */
   navigationHistory: NavigationHistoryEntryType[];
-  currentPageId: ConfigurationPagePageId;
 };
 
 type DataSourceBuilderState = StateType & {
@@ -155,8 +153,6 @@ type DataSourceBuilderState = StateType & {
   updateSourcesTags: (index: number, tagsFilter: TagsFilter) => void;
 
   toggleInConversationFiltering: (mode: TagsFilterMode) => void;
-
-  setSheetPageId: (pageId: ConfigurationPagePageId) => void;
 };
 
 type ActionType =
@@ -179,10 +175,6 @@ type ActionType =
   | {
       type: "NAVIGATION_NAVIGATE_TO";
       payload: { index: number };
-    }
-  | {
-      type: "SET_SHEET_CURRENT_PAGE";
-      payload: { pageId: ConfigurationPagePageId };
     };
 
 const DataSourceBuilderContext = createContext<
@@ -240,12 +232,6 @@ function dataSourceBuilderReducer(
         ],
       };
     }
-    case "SET_SHEET_CURRENT_PAGE": {
-      return {
-        ...state,
-        currentPageId: payload.pageId,
-      };
-    }
     default:
       assertNever(type);
   }
@@ -253,17 +239,14 @@ function dataSourceBuilderReducer(
 
 export function DataSourceBuilderProvider({
   spaces,
-  initialPageId,
   children,
 }: {
   spaces: SpaceType[];
-  initialPageId: ConfigurationPagePageId;
   children: React.ReactNode;
 }) {
   const { field } = useSourcesFormController();
   const [state, dispatch] = useReducer(dataSourceBuilderReducer, {
     navigationHistory: [{ type: "root" }],
-    currentPageId: initialPageId,
   });
 
   const selectNode: DataSourceBuilderState["selectNode"] = useCallback(
@@ -471,13 +454,6 @@ export function DataSourceBuilderProvider({
       [field]
     );
 
-  const setSheetPageId: DataSourceBuilderState["setSheetPageId"] = useCallback(
-    (pageId) => {
-      dispatch({ type: "SET_SHEET_CURRENT_PAGE", payload: { pageId } });
-    },
-    []
-  );
-
   const value = useMemo(
     () => ({
       ...state,
@@ -496,7 +472,6 @@ export function DataSourceBuilderProvider({
       navigateTo,
       updateSourcesTags,
       toggleInConversationFiltering,
-      setSheetPageId,
     }),
     [
       state,
@@ -515,7 +490,6 @@ export function DataSourceBuilderProvider({
       setDataSourceViewEntry,
       updateSourcesTags,
       toggleInConversationFiltering,
-      setSheetPageId,
     ]
   );
 

--- a/front/components/data_source_view/context/PageContext.tsx
+++ b/front/components/data_source_view/context/PageContext.tsx
@@ -1,0 +1,80 @@
+import { createContext, useContext, useMemo, useReducer } from "react";
+
+import type { ConfigurationPagePageId } from "@app/components/agent_builder/types";
+import { assertNever } from "@app/types";
+
+type PageState = {
+  currentPageId: ConfigurationPagePageId;
+};
+
+type KnowledgePageContextType = PageState & {
+  /**
+   * Set the current page ID for the sheet
+   */
+  setSheetPageId: (pageId: ConfigurationPagePageId) => void;
+};
+
+type PageActionType = {
+  type: "SET_SHEET_CURRENT_PAGE";
+  payload: { pageId: ConfigurationPagePageId };
+};
+
+const KnowledgePageContext = createContext<
+  KnowledgePageContextType | undefined
+>(undefined);
+
+function pageReducer(
+  state: PageState,
+  { type, payload }: PageActionType
+): PageState {
+  switch (type) {
+    case "SET_SHEET_CURRENT_PAGE": {
+      return {
+        ...state,
+        currentPageId: payload.pageId,
+      };
+    }
+    default:
+      assertNever(type);
+  }
+}
+
+export function KnowledgePageProvider({
+  initialPageId,
+  children,
+}: {
+  initialPageId: ConfigurationPagePageId;
+  children: React.ReactNode;
+}) {
+  const [state, dispatch] = useReducer(pageReducer, {
+    currentPageId: initialPageId,
+  });
+
+  const setSheetPageId: KnowledgePageContextType["setSheetPageId"] = (
+    pageId
+  ) => {
+    dispatch({ type: "SET_SHEET_CURRENT_PAGE", payload: { pageId } });
+  };
+
+  const value = useMemo(
+    () => ({
+      ...state,
+      setSheetPageId,
+    }),
+    [state]
+  );
+
+  return (
+    <KnowledgePageContext.Provider value={value}>
+      {children}
+    </KnowledgePageContext.Provider>
+  );
+}
+
+export function useKnowledgePageContext() {
+  const context = useContext(KnowledgePageContext);
+  if (!context) {
+    throw new Error(`usePageContext must be used within PageProvider`);
+  }
+  return context;
+}

--- a/front/components/data_source_view/hooks/useDataSourceColumns.tsx
+++ b/front/components/data_source_view/hooks/useDataSourceColumns.tsx
@@ -1,4 +1,4 @@
-import { Checkbox, DataTable, Hoverable } from "@dust-tt/sparkle";
+import { Checkbox, cn, DataTable, Hoverable } from "@dust-tt/sparkle";
 import type { ColumnDef } from "@tanstack/react-table";
 import { useContext, useMemo } from "react";
 
@@ -72,18 +72,17 @@ export const useDataSourceColumns = () => {
             return null;
           }
 
-          const hideColumn = shouldHideColumn(navigationHistory, currentEntry);
-
-          if (hideColumn && selectionState !== "partial") {
-            return undefined;
-          }
+          const hideColumn =
+            shouldHideColumn(navigationHistory, currentEntry) &&
+            selectionState !== "partial";
 
           return (
             <Checkbox
               key={`header-${selectionState}`}
               size="sm"
+              className={cn(hideColumn && "invisible")}
               checked={selectionState}
-              disabled={!isRowSelectable()}
+              disabled={!isRowSelectable() || hideColumn}
               onClick={(event) => event.stopPropagation()}
               onCheckedChange={async (state) => {
                 if (selectionState === "partial") {
@@ -110,14 +109,9 @@ export const useDataSourceColumns = () => {
         },
         cell: ({ row }) => {
           const selectionState = isRowSelected(row.original.id);
-          const hideColumn = shouldHideColumn(
-            navigationHistory,
-            row.original.entry
-          );
-
-          if (hideColumn && selectionState !== "partial") {
-            return undefined;
-          }
+          const hideColumn =
+            shouldHideColumn(navigationHistory, row.original.entry) &&
+            selectionState !== "partial";
 
           return (
             <div className="flex h-full w-full items-center">
@@ -125,7 +119,8 @@ export const useDataSourceColumns = () => {
                 key={`${row.original.id}-${selectionState}`}
                 size="sm"
                 checked={selectionState}
-                disabled={!isRowSelectable(row.original.id)}
+                className={cn(hideColumn && "invisible")}
+                disabled={!isRowSelectable(row.original.id) || hideColumn}
                 onClick={(event) => event.stopPropagation()}
                 onCheckedChange={async (state) => {
                   if (selectionState === "partial") {


### PR DESCRIPTION
## Description
- Clean some code, avoid passing props that can be fetch from provider.
- Fix re-rendering that was caused by having `currentPageId` inside the main `DataSourcesBuilderContext`, which was called inside the `KnowledgeConfigurationSheetContent` and making the whole MultiPageSheet re-render.
- Use `useWatch` compute params instead of name to avoid some other re-rendering.

## Tests
- Locally

## Risk
- Low, UI only

## Deploy Plan
- Deploy front
