### PR TITLE
[front] ABv2 - Improved instruction block

### DIFF
--- a/front/components/agent_builder/instructions/extensions/InstructionBlockExtension.tsx
+++ b/front/components/agent_builder/instructions/extensions/InstructionBlockExtension.tsx
@@ -155,7 +155,7 @@ const InstructionBlockComponent: React.FC<NodeViewProps> = ({
       const text = firstChild.textContent.trim();
       const match = text.match(OPENING_TAG_REGEX);
       if (match) {
-        displayType = match[1] || ""; // Empty string for <>
+        displayType = match[0] || ""; // Full match including < and >
       }
     }
   }
@@ -210,7 +210,7 @@ const InstructionBlockComponent: React.FC<NodeViewProps> = ({
           {isCollapsed ? (
             <div contentEditable={false}>
               <Chip size="mini" className="bg-gray-100 dark:bg-gray-800">
-                {displayType.toUpperCase() || " "}
+                {displayType ? displayType.toUpperCase() : " "}
               </Chip>
             </div>
           ) : (
@@ -618,7 +618,7 @@ export const InstructionBlockExtension =
                         const marginClass = isOpeningTag ? "mb-2" : isClosingTag ? "mt-2" : "";
                         decorations.push(
                           Decoration.node(childPos, childPos + child.nodeSize, {
-                            class: `inline-block px-2 py-1 rounded bg-gray-100 dark:bg-gray-800 text-xs font-medium uppercase ${marginClass}`,
+                            class: `inline-block px-1.5 py-1 rounded bg-gray-100 dark:bg-gray-800 text-xs font-medium uppercase ${marginClass}`,
                           })
                         );
                       }

--- a/front/components/agent_builder/instructions/extensions/InstructionBlockExtension.tsx
+++ b/front/components/agent_builder/instructions/extensions/InstructionBlockExtension.tsx
@@ -208,8 +208,12 @@ const InstructionBlockComponent: React.FC<NodeViewProps> = ({
             <ChevronIcon className="h-4 w-4" />
           </button>
           {isCollapsed ? (
-            <div contentEditable={false}>
-              <Chip size="mini" className="bg-gray-100 dark:bg-gray-800">
+            <div 
+              contentEditable={false} 
+              className="cursor-pointer mt-[0.5px]"
+              onClick={handleToggle}
+            >
+              <Chip size="mini" className="bg-gray-100 dark:bg-gray-800 hover:bg-gray-200 dark:hover:bg-gray-700 transition-colors">
                 {displayType ? displayType.toUpperCase() : " "}
               </Chip>
             </div>

--- a/front/components/agent_builder/instructions/extensions/InstructionBlockExtension.tsx
+++ b/front/components/agent_builder/instructions/extensions/InstructionBlockExtension.tsx
@@ -620,7 +620,7 @@ export const InstructionBlockExtension =
                         const marginClass = isOpeningTag ? "mb-2" : isClosingTag ? "mt-2" : "";
                         decorations.push(
                           Decoration.node(childPos, childPos + child.nodeSize, {
-                            class: `block w-fit px-1.5 py-1 rounded bg-gray-100 dark:bg-gray-800 text-xs font-medium uppercase ${marginClass}`,
+                            class: `block w-fit px-1.5 py-1 rounded-md bg-gray-100 dark:bg-gray-800 text-xs font-medium uppercase ${marginClass}`,
                           })
                         );
                       }

--- a/front/components/agent_builder/instructions/extensions/InstructionBlockExtension.tsx
+++ b/front/components/agent_builder/instructions/extensions/InstructionBlockExtension.tsx
@@ -208,18 +208,24 @@ const InstructionBlockComponent: React.FC<NodeViewProps> = ({
             <ChevronIcon className="h-4 w-4" />
           </button>
           {isCollapsed ? (
-            <div 
-              contentEditable={false} 
-              className="cursor-pointer mt-[0.5px]"
+            <div
+              contentEditable={false}
+              className="mt-[0.5px] cursor-pointer"
               onClick={handleToggle}
             >
-              <Chip size="mini" className="bg-gray-100 dark:bg-gray-800 hover:bg-gray-200 dark:hover:bg-gray-700 transition-colors">
+              <Chip
+                size="mini"
+                className="bg-gray-100 transition-colors hover:bg-gray-200 dark:bg-gray-800 dark:hover:bg-gray-700"
+              >
                 {displayType ? displayType.toUpperCase() : " "}
               </Chip>
             </div>
           ) : (
             <div className="mt-0.5">
-              <NodeViewContent className={instructionBlockContentStyles} as="div" />
+              <NodeViewContent
+                className={instructionBlockContentStyles}
+                as="div"
+              />
             </div>
           )}
         </div>
@@ -609,19 +615,23 @@ export const InstructionBlockExtension =
           props: {
             decorations(state) {
               const decorations: Decoration[] = [];
-              
+
               state.doc.descendants((node, pos) => {
                 if (node.type.name === "instructionBlock") {
                   let childPos = pos + 1;
-                  
+
                   node.forEach((child) => {
                     if (child.type.name === "paragraph") {
                       const text = child.textContent.trim();
                       const isOpeningTag = text.match(OPENING_TAG_REGEX);
                       const isClosingTag = text.match(CLOSING_TAG_REGEX);
-                      
+
                       if (isOpeningTag || isClosingTag) {
-                        const marginClass = isOpeningTag ? "mb-2" : isClosingTag ? "mt-2" : "";
+                        const marginClass = isOpeningTag
+                          ? "mb-2"
+                          : isClosingTag
+                            ? "mt-2"
+                            : "";
                         decorations.push(
                           Decoration.node(childPos, childPos + child.nodeSize, {
                             class: `block w-fit px-1.5 py-1 rounded-md bg-gray-100 dark:bg-gray-800 text-xs font-medium uppercase ${marginClass}`,
@@ -633,7 +643,7 @@ export const InstructionBlockExtension =
                   });
                 }
               });
-              
+
               return DecorationSet.create(state.doc, decorations);
             },
           },

--- a/front/components/agent_builder/instructions/extensions/InstructionBlockExtension.tsx
+++ b/front/components/agent_builder/instructions/extensions/InstructionBlockExtension.tsx
@@ -214,7 +214,9 @@ const InstructionBlockComponent: React.FC<NodeViewProps> = ({
               </Chip>
             </div>
           ) : (
-            <NodeViewContent className={instructionBlockContentStyles} as="div" />
+            <div className="mt-0.5">
+              <NodeViewContent className={instructionBlockContentStyles} as="div" />
+            </div>
           )}
         </div>
       </div>
@@ -618,7 +620,7 @@ export const InstructionBlockExtension =
                         const marginClass = isOpeningTag ? "mb-2" : isClosingTag ? "mt-2" : "";
                         decorations.push(
                           Decoration.node(childPos, childPos + child.nodeSize, {
-                            class: `inline-block px-1.5 py-1 rounded bg-gray-100 dark:bg-gray-800 text-xs font-medium uppercase ${marginClass}`,
+                            class: `block w-fit px-1.5 py-1 rounded bg-gray-100 dark:bg-gray-800 text-xs font-medium uppercase ${marginClass}`,
                           })
                         );
                       }

--- a/front/components/agent_builder/instructions/extensions/InstructionBlockExtension.tsx
+++ b/front/components/agent_builder/instructions/extensions/InstructionBlockExtension.tsx
@@ -128,9 +128,7 @@ function queueFocusInsideCurrentInstructionBlock(editor: Editor): void {
 
 // Define consistent heading styles to match the main editor
 const instructionBlockContentStyles = cn(
-  "prose prose-sm mt-2",
-  // Add left padding to align with the chip (chevron button width + gap)
-  "ml-6",
+  "prose prose-sm",
   // Override for all headings to match the editor's heading style
   "[&_h1,&_h2,&_h3,&_h4,&_h5,&_h6]:text-xl",
   "[&_h1,&_h2,&_h3,&_h4,&_h5,&_h6]:font-semibold",
@@ -199,24 +197,25 @@ const InstructionBlockComponent: React.FC<NodeViewProps> = ({
   return (
     <NodeViewWrapper className="my-2">
       <div className={containerClasses} onClick={handleBlockClick}>
-        <div
-          className="flex select-none items-center gap-1"
-          contentEditable={false}
-        >
+        <div className="flex items-start gap-1">
           <button
             onClick={handleToggle}
-            className="rounded p-0.5 transition-colors hover:bg-gray-200 dark:hover:bg-gray-700"
+            className="mt-[3px] rounded p-0.5 transition-colors hover:bg-gray-200 dark:hover:bg-gray-700"
             type="button"
+            contentEditable={false}
           >
             <ChevronIcon className="h-4 w-4" />
           </button>
-          <Chip size="mini" className="bg-gray-100 dark:bg-gray-800">
-            {displayType.toUpperCase() || " "}
-          </Chip>
+          {isCollapsed ? (
+            <div contentEditable={false}>
+              <Chip size="mini" className="bg-gray-100 dark:bg-gray-800">
+                {displayType.toUpperCase() || " "}
+              </Chip>
+            </div>
+          ) : (
+            <NodeViewContent className={instructionBlockContentStyles} as="div" />
+          )}
         </div>
-        {!isCollapsed && (
-          <NodeViewContent className={instructionBlockContentStyles} as="div" />
-        )}
       </div>
     </NodeViewWrapper>
   );


### PR DESCRIPTION
## Description

This PR improves the instuction XML block in the agent builder v2.
- When collapsed the chip is clickable
- When expanded the XML tags are displayed but the chip is not
- Opening and closing tags are styled to look like the chip
- Hover states of the chip

## Tests

Locally

## Risk

Low, behind FF

## Deploy Plan

Deploy front
