### PR TITLE
[front] Fix dependencies in hooks of blocked actions queue

### DIFF
--- a/front/components/assistant/conversation/BlockedActionsProvider.tsx
+++ b/front/components/assistant/conversation/BlockedActionsProvider.tsx
@@ -254,35 +254,32 @@ function useBlockedActionsQueue({
           .map((blockedAction) => ({
             blockedAction,
           }));
-        return [...blockedActionsQueue, ...newItems];
+        return [...prevQueue, ...newItems];
       });
     }
   }, [blockedActions]);
 
-  const enqueueBlockedAction = useCallback(
-    ({
-      message,
-      blockedAction,
-    }: {
-      message: LightAgentMessageType;
-      blockedAction: BlockedToolExecution;
-    }) => {
-      setBlockedActionsQueue((prevQueue) => {
-        const existingIndex = prevQueue.findIndex(
-          (v) => v.blockedAction.actionId === blockedAction.actionId
-        );
+  const enqueueBlockedAction = ({
+    message,
+    blockedAction,
+  }: {
+    message: LightAgentMessageType;
+    blockedAction: BlockedToolExecution;
+  }) => {
+    setBlockedActionsQueue((prevQueue) => {
+      const existingIndex = prevQueue.findIndex(
+        (v) => v.blockedAction.actionId === blockedAction.actionId
+      );
 
-        // If the action is not in the queue, add it.
-        // If the action is in the queue, replace it with the new one.
-        return existingIndex === -1
-          ? [...blockedActionsQueue, { blockedAction, message }]
-          : prevQueue.map((item, index) =>
-              index === existingIndex ? { blockedAction, message } : item
-            );
-      });
-    },
-    []
-  );
+      // If the action is not in the queue, add it.
+      // If the action is in the queue, replace it with the new one.
+      return existingIndex === -1
+        ? [...blockedActionsQueue, { blockedAction, message }]
+        : prevQueue.map((item, index) =>
+            index === existingIndex ? { blockedAction, message } : item
+          );
+    });
+  };
 
   const shiftBlockedActionQueue = useCallback(() => {
     setBlockedActionsQueue((prevQueue) => prevQueue.slice(1));


### PR DESCRIPTION
## Description

- This PR fixes dependencies in hooks of blocked actions queue, by removing an unnecessary `useCallback` and fixing a `useEffect`.

## Tests

## Risk

- Low.

## Deploy Plan

- Deploy front.
