### PR TITLE
[extension] Force refresh or logout when we have an expired_oauth_token_error

### DIFF
--- a/extension/platforms/chrome/services/auth.ts
+++ b/extension/platforms/chrome/services/auth.ts
@@ -140,15 +140,23 @@ export class ChromeAuthService extends AuthService {
     }
   }
 
-  async getAccessToken(): Promise<string | null> {
+  async getAccessToken(forceRefresh?: boolean): Promise<string | null> {
     let tokens = await this.getStoredTokens();
-    if (!tokens || !tokens.accessToken || tokens.expiresAt < Date.now()) {
+    if (
+      !tokens ||
+      !tokens.accessToken ||
+      tokens.expiresAt < Date.now() ||
+      forceRefresh
+    ) {
       const refreshRes = await this.refreshToken(tokens);
       if (refreshRes.isOk()) {
         tokens = refreshRes.value;
       }
     }
-
+    // We wanted a refreshed token, don't return the one we have which is invalid.
+    if (forceRefresh) {
+      return null;
+    }
     return tokens?.accessToken ?? null;
   }
 

--- a/extension/platforms/front/services/auth.ts
+++ b/extension/platforms/front/services/auth.ts
@@ -245,13 +245,22 @@ export class FrontAuthService extends AuthService {
     return true;
   }
 
-  async getAccessToken(): Promise<string | null> {
+  async getAccessToken(forceRefresh?: boolean): Promise<string | null> {
     let tokens = await this.getStoredTokens();
-    if (!tokens || !tokens.accessToken || tokens.expiresAt < Date.now()) {
+    if (
+      !tokens ||
+      !tokens.accessToken ||
+      tokens.expiresAt < Date.now() ||
+      forceRefresh
+    ) {
       const refreshRes = await this.refreshToken();
       if (refreshRes.isOk()) {
         tokens = refreshRes.value;
       }
+    }
+    // We wanted a refreshed token, don't return the one we have which is invalid.
+    if (forceRefresh) {
+      return null;
     }
     return tokens?.accessToken ?? null;
   }

--- a/extension/shared/services/auth.ts
+++ b/extension/shared/services/auth.ts
@@ -71,7 +71,6 @@ export abstract class AuthService {
 
   // Shared methods with implementation
   async saveTokens(rawTokens: OAuthAuthorizeResponse) {
-    console.log("======================", rawTokens);
     const tokens: StoredTokens = {
       accessToken: rawTokens.accessToken,
       refreshToken: rawTokens.refreshToken,

--- a/extension/shared/services/auth.ts
+++ b/extension/shared/services/auth.ts
@@ -71,6 +71,7 @@ export abstract class AuthService {
 
   // Shared methods with implementation
   async saveTokens(rawTokens: OAuthAuthorizeResponse) {
+    console.log("======================", rawTokens);
     const tokens: StoredTokens = {
       accessToken: rawTokens.accessToken,
       refreshToken: rawTokens.refreshToken,
@@ -117,7 +118,7 @@ export abstract class AuthService {
 
   abstract logout(): Promise<boolean>;
 
-  abstract getAccessToken(): Promise<string | null>;
+  abstract getAccessToken(forceRefresh?: boolean): Promise<string | null>;
 
   abstract refreshToken(
     tokens: StoredTokens | null

--- a/extension/ui/components/auth/useAuth.ts
+++ b/extension/ui/components/auth/useAuth.ts
@@ -55,7 +55,7 @@ export const useAuthHook = () => {
 
   const handleRefreshToken = useCallback(async () => {
     // Call getAccessToken, it will refresh the token if needed.
-    const newAccessToken = await platform.auth.getAccessToken();
+    const newAccessToken = await platform.auth.getAccessToken(true);
     if (!newAccessToken) {
       setAuthError(
         new AuthError("not_authenticated", "No access token received.")

--- a/extension/ui/hooks/useAuthErrorCheck.ts
+++ b/extension/ui/hooks/useAuthErrorCheck.ts
@@ -27,7 +27,7 @@ export const useAuthErrorCheck = (error: any, mutate: () => any) => {
 
           case "expired_oauth_token_error":
             // Attempt to get the access token, it will refresh the token if needed.
-            const accesToken = await platform.auth.getAccessToken();
+            const accesToken = await platform.auth.getAccessToken(true);
             if (!accesToken) {
               // If we still don't have an access token, we need to logout.
               setAuthError(error);


### PR DESCRIPTION
## Description

We have high peaks of expired_oauth_token_error in front due to an infinite retryal of same requests by the extension. When extension receive expired_oauth_token_error, it calls again getAccessToken() that should refresh the token - but if it only checks if the token is expired based on its own data, and doesnt refresh if it if it does not see as "expired" return then the same token and retry infinitely.
The forceRefresh is used to tell we know that the current token is invalid and that we need a new one. Returns null if we can't refresh (this redirects to logout)

## Tests

Tested locally

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

publish