### PR TITLE
[front] Add Tailwind arbitrary value validation in Canvas server

### DIFF
--- a/front/lib/actions/mcp_internal_actions/servers/canvas/index.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/canvas/index.ts
@@ -9,6 +9,7 @@ import {
   EDIT_CANVAS_FILE_TOOL_NAME,
   RETRIEVE_CANVAS_FILE_TOOL_NAME,
 } from "@app/lib/actions/mcp_internal_actions/servers/canvas/types";
+import { validateTailwindCode } from "@app/lib/actions/mcp_internal_actions/servers/canvas/validation";
 import { registerCatTool } from "@app/lib/actions/mcp_internal_actions/servers/data_sources_file_system/cat_tool";
 import { registerListTool } from "@app/lib/actions/mcp_internal_actions/servers/data_sources_file_system/list_tool";
 import { makeInternalMCPServer } from "@app/lib/actions/mcp_internal_actions/utils";
@@ -79,6 +80,11 @@ const createServer = (
         { file_name, mime_type, content, description },
         { sendNotification, _meta }
       ) => {
+        const validationResult = validateTailwindCode(content);
+        if (validationResult.isErr()) {
+          return new Err(new MCPError(validationResult.error.message));
+        }
+
         const { conversation } = agentLoopContext?.runContext ?? {};
         if (!conversation) {
           return new Err(

--- a/front/lib/actions/mcp_internal_actions/servers/canvas/validation.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/canvas/validation.ts
@@ -1,0 +1,49 @@
+import type { Result } from "@app/types";
+import { Err } from "@app/types";
+import { Ok } from "@app/types";
+
+// Regular expression to capture the value inside a className attribute. This pattern assumes
+// double quotes for simplicity.
+const classNameRegex = /className\s*=\s*"([^"]*)"/g;
+
+// Regular expression to capture Tailwind arbitrary values:
+// Matches a word boundary, then one or more lowercase letters or hyphens,
+// followed by a dash, an opening bracket, one or more non-']' characters, and a closing bracket.
+const arbitraryRegex = /\b[a-z-]+-\[[^\]]+\]/g;
+
+/**
+ * Validates that the generated code doesn't contain Tailwind arbitrary values.
+ *
+ * Arbitrary values like h-[600px], w-[800px], bg-[#ff0000] cause visualization failures
+ * because they're not included in our pre-built CSS. This validation fails fast with
+ * a clear error message that gets exposed to the user, allowing them to retry which
+ * provides the error details to the model for correction.
+ */
+export function validateTailwindCode(code: string): Result<undefined, Error> {
+  const matches: string[] = [];
+  let classMatch: RegExpExecArray | null = null;
+
+  // Iterate through all occurrences of the className attribute in the code.
+  while ((classMatch = classNameRegex.exec(code)) !== null) {
+    const classContent = classMatch[1];
+    if (classContent) {
+      // Find all matching arbitrary values within the class attribute's value.
+      const arbitraryMatches = classContent.match(arbitraryRegex) || [];
+      matches.push(...arbitraryMatches);
+    }
+  }
+
+  // If we found any, remove duplicates and throw an error with up to three examples.
+  if (matches.length > 0) {
+    const uniqueMatches = Array.from(new Set(matches));
+    const examples = uniqueMatches.slice(0, 3).join(", ");
+    return new Err(
+      new Error(
+        `Forbidden Tailwind arbitrary values detected: ${examples}. ` +
+          `Arbitrary values like h-[600px], w-[800px], bg-[#ff0000] are not allowed. ` +
+          `Use predefined classes like h-96, w-full, bg-red-500 instead, or use the style prop for specific values.`
+      )
+    );
+  }
+  return new Ok(undefined);
+}


### PR DESCRIPTION
## Description

- Closes https://github.com/dust-tt/tasks/issues/3934.
- This PR ports the arbitrary value detection we have in `viz` to the `Canvas` server to expose an error to the model. The expectation is that the model will reformulate it using the examples.

## Tests

## Risk

- Low.

## Deploy Plan

- Deploy front.
