### PR TITLE
[front] Capitalize `Canvas` in instructions/descriptions

### DIFF
--- a/front/lib/actions/mcp_internal_actions/servers/canvas/index.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/canvas/index.ts
@@ -47,13 +47,13 @@ const createServer = (
 
   server.tool(
     CREATE_CANVAS_FILE_TOOL_NAME,
-    "Create a new canvas file that users can execute or interact with. Use this for " +
+    "Create a new Canvas file that users can execute or interact with. Use this for " +
       "content that provides functionality beyond static viewing.",
     {
       file_name: z
         .string()
         .describe(
-          "The name of the canvas file to create, including extension (e.g. " +
+          "The name of the Canvas file to create, including extension (e.g. " +
             "DataVisualization.tsx)"
         ),
       mime_type: z
@@ -67,14 +67,14 @@ const createServer = (
         .string()
         .max(MAX_FILE_SIZE_BYTES)
         .describe(
-          "The content for the canvas file. Should be complete and ready for execution or " +
+          "The content for the Canvas file. Should be complete and ready for execution or " +
             "interaction."
         ),
       description: z
         .string()
         .optional()
         .describe(
-          "Optional description of what this canvas does (e.g., " +
+          "Optional description of what this Canvas does (e.g., " +
             "'Interactive data visualization', 'Executable analysis script', " +
             "'Dynamic dashboard')"
         ),
@@ -125,7 +125,7 @@ const createServer = (
               total: 1,
               progressToken: _meta?.progressToken,
               data: {
-                label: "Creating canvas...",
+                label: "Creating Canvas file...",
                 output: {
                   type: "canvas_file",
                   fileId: fileResource.sId,
@@ -161,7 +161,7 @@ const createServer = (
 
   server.tool(
     EDIT_CANVAS_FILE_TOOL_NAME,
-    "Modifies content within an canvas file by substituting specified text segments. " +
+    "Modifies content within a Canvas file by substituting specified text segments. " +
       "Performs single substitution by default, or multiple substitutions when " +
       "`expected_replacements` is defined. This function demands comprehensive contextual " +
       "information surrounding the target modification to ensure accurate targeting. " +
@@ -176,7 +176,7 @@ const createServer = (
     {
       file_id: z
         .string()
-        .describe("The ID of the canvas file to update (e.g., 'fil_abc123')"),
+        .describe("The ID of the Canvas file to update (e.g., 'fil_abc123')"),
       old_string: z
         .string()
         .describe(
@@ -235,7 +235,7 @@ const createServer = (
               total: 1,
               progressToken: _meta?.progressToken,
               data: {
-                label: "Updating canvas...",
+                label: "Updating Canvas file...",
                 output: {
                   type: "canvas_file",
                   fileId: fileResource.sId,
@@ -263,14 +263,14 @@ const createServer = (
 
   server.tool(
     RETRIEVE_CANVAS_FILE_TOOL_NAME,
-    "Retrieve the current content of an existing canvas file by its file ID. " +
-      "Use this to read back the content of canvas files you have previously created or " +
+    "Retrieve the current content of an existing Canvas file by its file ID. " +
+      "Use this to read back the content of Canvas files you have previously created or " +
       `updated. Use this tool before calling ${EDIT_CANVAS_FILE_TOOL_NAME} to ` +
       "understand the current file state and identify the exact text to replace.",
     {
       file_id: z
         .string()
-        .describe("The ID of the canvas file to retrieve (e.g., 'fil_abc123')"),
+        .describe("The ID of the Canvas file to retrieve (e.g., 'fil_abc123')"),
     },
     withToolLogging(
       auth,
@@ -296,14 +296,14 @@ const createServer = (
     )
   );
 
-  // Register data source file system tools for canvas server with custom descriptions
-  // tailored for canvas use cases (visual assets and templates).
+  // Register data source file system tools for the Canvas server with custom
+  // descriptions tailored for Canvas use cases (visual assets and templates).
   registerListTool(auth, server, agentLoopContext, {
     toolName: "list_assets",
     toolDescription:
       "Browse available visual assets and templates in the connected data sources. " +
       "Use this to explore folders containing images, icons, slideshow templates, " +
-      "or other resources that can be incorporated into canvas files.\n\n" +
+      "or other resources that can be incorporated into Canvas files.\n\n" +
       "List the direct contents of a node. Can be used to see what is inside a specific folder from " +
       "the filesystem, like 'ls' in Unix. A good fit is to explore the filesystem structure step " +
       "by step. This tool can be called repeatedly by passing the 'nodeId' output from a step to " +
@@ -316,8 +316,8 @@ const createServer = (
     toolDescription:
       "Read template files or asset configurations from the connected data sources. " +
       "Use this to retrieve slideshow templates, HTML/CSS snippets, React component examples, " +
-      "or configuration files that can serve as a starting point or be incorporated into canvas files.\n\n" +
-      "Read the contents of a document, referred to by its nodeId (named after the 'cat' unix tool). " +
+      "or configuration files that can serve as a starting point or be incorporated into Canvas files.\n\n" +
+      "Read the contents of a document, referred to by its nodeId (named after the 'cat' Unix tool). " +
       "The nodeId can be obtained using the 'list_assets' tool.",
   });
 

--- a/front/lib/actions/mcp_internal_actions/servers/canvas/instructions/index.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/canvas/instructions/index.ts
@@ -9,7 +9,7 @@ import { clientExecutableContentType, slideshowContentType } from "@app/types";
 export const CANVAS_INSTRUCTIONS = `\
 ## CREATING VISUALIZATIONS WITH CANVAS
 
-You have access to a canvas system that allows you to create and update executable files. When creating visualizations, you should create files instead of using the :::visualization directive.
+You have access to a Canvas system that allows you to create and update executable files. When creating visualizations, you should create files instead of using the :::visualization directive.
 
 ### File Management Guidelines:
 - Use the \`${CREATE_CANVAS_FILE_TOOL_NAME}\` tool to create JavaScript/TypeScript files
@@ -19,7 +19,7 @@ You have access to a canvas system that allows you to create and update executab
 - Files are automatically made available to the user for execution
 
 ### Updating Existing Files:
-- To modify existing canvas files, always use \`${RETRIEVE_CANVAS_FILE_TOOL_NAME}\` first to read the current content
+- To modify existing Canvas files, always use \`${RETRIEVE_CANVAS_FILE_TOOL_NAME}\` first to read the current content
 - Then use \`${EDIT_CANVAS_FILE_TOOL_NAME}\` to make targeted changes by replacing specific text
 - The edit tool requires exact text matching - include surrounding context for unique identification
 - Never attempt to edit without first retrieving the current file content

--- a/front/lib/actions/mcp_internal_actions/servers/canvas/instructions/slideshow.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/canvas/instructions/slideshow.ts
@@ -35,5 +35,5 @@ export default function Presentation() {
 \`\`\`
 
 - When to use slideshows: presentations, tutorials, step-by-step analysis, before/after comparisons
-- When to use regular canvas: single visualizations, dashboards, interactive tools
+- When to use regular Canvas: single visualizations, dashboards, interactive tools
 `;


### PR DESCRIPTION
## Description

- This PR capitalizes `Canvas` in instructions and tool descriptions.
- The goal is to prevent confusion with the actual word as much as possible and refer to it as a named entity.

## Tests

## Risk

## Deploy Plan

- Deploy front.
