### PR TITLE
[front] infinite load root level data source nodes 

### DIFF
--- a/front/components/agent_builder/capabilities/knowledge/DataSourceNodeTable.tsx
+++ b/front/components/agent_builder/capabilities/knowledge/DataSourceNodeTable.tsx
@@ -10,7 +10,7 @@ import {
 import type { DataSourceRowData } from "@app/components/data_source_view/hooks/useDataSourceColumns";
 import { useDataSourceColumns } from "@app/components/data_source_view/hooks/useDataSourceColumns";
 import { getVisualForDataSourceViewContentNode } from "@app/lib/content_nodes";
-import { useInfinitDataSourceViewContentNodes } from "@app/lib/swr/data_source_views";
+import { useInfiniteDataSourceViewContentNodes } from "@app/lib/swr/data_source_views";
 import type { ContentNodesViewType } from "@app/types";
 
 const PAGE_SIZE = 25;
@@ -33,7 +33,7 @@ export function DataSourceNodeTable({ viewType }: DataSourceNodeTableProps) {
     hasNextPage,
     loadMore,
     isLoadingMore,
-  } = useInfinitDataSourceViewContentNodes({
+  } = useInfiniteDataSourceViewContentNodes({
     owner,
     dataSourceView:
       traversedNode?.dataSourceView ?? dataSourceView ?? undefined,

--- a/front/components/data_source_view/DataSourceViewSelector.tsx
+++ b/front/components/data_source_view/DataSourceViewSelector.tsx
@@ -953,7 +953,7 @@ export function DataSourceViewSelector({
             <Button
               variant="ghost"
               size="xs"
-              disabled={rootNodes.length === 0}
+              disabled={rootNodes.length === 0 || isLoadingMore}
               className="mr-4 text-xs"
               label={hasActiveSelection ? "Unselect All" : "Select All"}
               icon={ListCheckIcon}

--- a/front/components/data_source_view/DataSourceViewSelector.tsx
+++ b/front/components/data_source_view/DataSourceViewSelector.tsx
@@ -68,7 +68,7 @@ import {
 
 const ONLY_ONE_SPACE_PER_SELECTION = true;
 const ITEMS_PER_PAGE = 50;
-const PAGE_SIZE = 2000;
+const PAGE_SIZE = 10;
 
 const getUseResourceHook =
   (

--- a/front/components/data_source_view/DataSourceViewSelector.tsx
+++ b/front/components/data_source_view/DataSourceViewSelector.tsx
@@ -43,7 +43,10 @@ import {
   isRemoteDatabase,
   isWebsite,
 } from "@app/lib/data_sources";
-import { useDataSourceViewContentNodes } from "@app/lib/swr/data_source_views";
+import {
+  useDataSourceViewContentNodes,
+  useInfiniteDataSourceViewContentNodes,
+} from "@app/lib/swr/data_source_views";
 import { useSpacesSearch } from "@app/lib/swr/spaces";
 import type {
   ContentNode,
@@ -65,7 +68,7 @@ import {
 
 const ONLY_ONE_SPACE_PER_SELECTION = true;
 const ITEMS_PER_PAGE = 50;
-const MAX_ROOT_NODES_LIMIT = 2000;
+const PAGE_SIZE = 2000;
 
 const getUseResourceHook =
   (
@@ -700,6 +703,11 @@ interface DataSourceViewSelectorProps {
   selectionMode?: "checkbox" | "radio";
 }
 
+// When `isRootSelectable` is false, you cannot select the entire data source and automatically sync new nodes
+// added to the data source. You can however select all the available nodes at that moment and we show the button to
+// select all in UI. We need to send all the available node ids to the backend, so we need to fetch
+// all the available nodes separately (= different from the paginated nodes a user is seeing in the UI).
+// We use useInfiniteDataSourceViewContentNodes hook and we keep fetching data until hasNextPage is false inside the useEffect.
 export function DataSourceViewSelector({
   owner,
   readonly = false,
@@ -746,11 +754,16 @@ export function DataSourceViewSelector({
     [dataSourceView]
   );
 
-  const { nodes: rootNodes, totalNodesCount } = useContentNodes({
+  const {
+    nodes: rootNodes,
+    hasNextPage,
+    isLoadingMore,
+    loadMore,
+  } = useInfiniteDataSourceViewContentNodes({
     owner,
     dataSourceView,
     viewType,
-    pagination: { limit: MAX_ROOT_NODES_LIMIT, cursor: null },
+    pagination: { limit: PAGE_SIZE, cursor: null },
   });
 
   const hasActiveSelection =
@@ -901,11 +914,15 @@ export function DataSourceViewSelector({
     [searchResult, isExpanded]
   );
 
-  if (totalNodesCount > MAX_ROOT_NODES_LIMIT) {
-    return (
-      <div>Total nodes count is too high. Please contact support@dust.tt.</div>
-    );
-  }
+  useEffect(() => {
+    const handleLoadMore = async () => {
+      await loadMore();
+    };
+
+    if (hasNextPage && !isLoadingMore) {
+      void handleLoadMore();
+    }
+  }, [hasNextPage, isLoadingMore, loadMore]);
 
   return (
     <div id={`dataSourceViewsSelector-${dataSourceView.dataSource.sId}`}>

--- a/front/components/data_source_view/DataSourceViewSelector.tsx
+++ b/front/components/data_source_view/DataSourceViewSelector.tsx
@@ -68,7 +68,7 @@ import {
 
 const ONLY_ONE_SPACE_PER_SELECTION = true;
 const ITEMS_PER_PAGE = 50;
-const PAGE_SIZE = 10;
+const PAGE_SIZE = 2000;
 
 const getUseResourceHook =
   (

--- a/front/components/data_source_view/DataSourceViewSelector.tsx
+++ b/front/components/data_source_view/DataSourceViewSelector.tsx
@@ -68,7 +68,7 @@ import {
 
 const ONLY_ONE_SPACE_PER_SELECTION = true;
 const ITEMS_PER_PAGE = 50;
-const PAGE_SIZE = 2000;
+const PAGE_SIZE = 1000;
 
 const getUseResourceHook =
   (

--- a/front/lib/swr/data_source_views.ts
+++ b/front/lib/swr/data_source_views.ts
@@ -355,7 +355,7 @@ export function useInfiniteDataSourceViewContentNodes({
   const hasNextPage =
     lastPage?.nextPageCursor !== null && lastPage?.nextPageCursor !== undefined;
 
-  const loadMore = useCallback(() =>  setSize((s) => s + 1), [setSize]);
+  const loadMore = useCallback(() => setSize((s) => s + 1), [setSize]);
 
   return {
     isNodesLoading: isLoading && !data,

--- a/front/lib/swr/data_source_views.ts
+++ b/front/lib/swr/data_source_views.ts
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 import type { Fetcher, KeyedMutator, SWRConfiguration } from "swr";
 
 import type {
@@ -355,6 +355,10 @@ export function useInfiniteDataSourceViewContentNodes({
   const hasNextPage =
     lastPage?.nextPageCursor !== null && lastPage?.nextPageCursor !== undefined;
 
+  const loadMore = useCallback(() => {
+    () => setSize((s) => s + 1);
+  }, [setSize]);
+
   return {
     isNodesLoading: isLoading && !data,
     isNodesValidating: isValidating,
@@ -362,7 +366,7 @@ export function useInfiniteDataSourceViewContentNodes({
     nodes,
     nextPageCursor: lastPage?.nextPageCursor || null,
     hasNextPage,
-    loadMore: () => setSize((s) => s + 1),
+    loadMore,
     mutate,
     totalNodesCount: lastPage?.total || 0,
     totalNodesCountIsAccurate: lastPage?.totalIsAccurate || true,

--- a/front/lib/swr/data_source_views.ts
+++ b/front/lib/swr/data_source_views.ts
@@ -299,7 +299,7 @@ export function useDataSourceViewContentNodes({
   };
 }
 
-export function useInfinitDataSourceViewContentNodes({
+export function useInfiniteDataSourceViewContentNodes({
   owner,
   dataSourceView,
   pagination,

--- a/front/lib/swr/data_source_views.ts
+++ b/front/lib/swr/data_source_views.ts
@@ -355,9 +355,7 @@ export function useInfiniteDataSourceViewContentNodes({
   const hasNextPage =
     lastPage?.nextPageCursor !== null && lastPage?.nextPageCursor !== undefined;
 
-  const loadMore = useCallback(() => {
-    () => setSize((s) => s + 1);
-  }, [setSize]);
+  const loadMore = useCallback(() =>  setSize((s) => s + 1), [setSize]);
 
   return {
     isNodesLoading: isLoading && !data,


### PR DESCRIPTION
## Description
This PR is to fix https://github.com/dust-tt/tasks/issues/3921. To select all the root nodes, we need to separately fetch ids and send them to backend when a user selects "Select All" option. 



<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

## Tests
I tested it locally + on front edge with page_size 10 and checked if it fetched all the pages. 
<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk
The risk should be low if I understand it correctly:
- We always fetch 2000 nodes first, so nothing should change if you have less than 2000
- I wonder if it can slow down the app if there are waaay too many nodes but I don't think it will be like more than 10K, so it should be okay?
<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
