### PR TITLE
Improve Slideshow instructions and remove custom content type

### DIFF
--- a/front/components/assistant/conversation/ConversationFilesPopover.tsx
+++ b/front/components/assistant/conversation/ConversationFilesPopover.tsx
@@ -21,7 +21,7 @@ import type {
   AllSupportedFileContentType,
   LightWorkspaceType,
 } from "@app/types";
-import { clientExecutableContentType, slideshowContentType } from "@app/types";
+import { clientExecutableContentType } from "@app/types";
 
 interface FileGroup {
   contentType: AllSupportedFileContentType | "other";
@@ -33,7 +33,6 @@ interface FileGroup {
 // Configuration for content types that get their own groups.
 const GROUPED_CONTENT_TYPES = {
   [clientExecutableContentType]: "Canvas",
-  [slideshowContentType]: "Slideshow",
   "application/json": "JSON",
   "text/csv": "Tables",
   "text/plain": "Text",

--- a/front/components/assistant/conversation/canvas/CanvasContainer.tsx
+++ b/front/components/assistant/conversation/canvas/CanvasContainer.tsx
@@ -10,7 +10,7 @@ import type {
   ConversationWithoutContentType,
   LightWorkspaceType,
 } from "@app/types";
-import { clientExecutableContentType, slideshowContentType } from "@app/types";
+import { clientExecutableContentType } from "@app/types";
 
 interface CanvasContainerProps {
   conversation: ConversationWithoutContentType | null;
@@ -70,7 +70,6 @@ export function CanvasContainer({ conversation, owner }: CanvasContainerProps) {
     // Render appropriate content based on content type.
     switch (fileMetadata.contentType) {
       case clientExecutableContentType:
-      case slideshowContentType:
         return (
           <ClientExecutableRenderer
             conversation={conversation}

--- a/front/components/assistant/conversation/canvas/PublicCanvasContainer.tsx
+++ b/front/components/assistant/conversation/canvas/PublicCanvasContainer.tsx
@@ -5,7 +5,7 @@ import { PublicClientExecutableRenderer } from "@app/components/assistant/conver
 import { UnsupportedContentRenderer } from "@app/components/assistant/conversation/canvas/UnsupportedContentRenderer";
 import { usePublicFile } from "@app/lib/swr/files";
 import Custom404 from "@app/pages/404";
-import { clientExecutableContentType, slideshowContentType } from "@app/types";
+import { clientExecutableContentType } from "@app/types";
 
 interface PublicCanvasContainerProps {
   shareToken: string;
@@ -38,7 +38,6 @@ export function PublicCanvasContainer({
 
     switch (fileMetadata.contentType) {
       case clientExecutableContentType:
-      case slideshowContentType:
         return (
           <PublicClientExecutableRenderer
             fileId={fileMetadata.sId}

--- a/front/lib/actions/mcp_internal_actions/servers/canvas/index.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/canvas/index.ts
@@ -22,12 +22,7 @@ import {
 } from "@app/lib/api/files/client_executable";
 import type { Authenticator } from "@app/lib/auth";
 import type { CanvasFileContentType } from "@app/types";
-import {
-  clientExecutableContentType,
-  Err,
-  Ok,
-  slideshowContentType,
-} from "@app/types";
+import { clientExecutableContentType, Err, Ok } from "@app/types";
 import { CANVAS_FILE_FORMATS } from "@app/types";
 
 const MAX_FILE_SIZE_BYTES = 1 * 1024 * 1024; // 1MB
@@ -60,8 +55,7 @@ const createServer = (
         .enum(Object.keys(CANVAS_FILE_FORMATS) as [CanvasFileContentType])
         .describe(
           "The MIME type for the canvas. Currently supports " +
-            `'${clientExecutableContentType}' for client-side executable files and ` +
-            `'${slideshowContentType}' for slideshows.`
+            `'${clientExecutableContentType}' for client-side executable files.`
         ),
       content: z
         .string()

--- a/front/lib/actions/mcp_internal_actions/servers/canvas/instructions/index.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/canvas/instructions/index.ts
@@ -4,7 +4,7 @@ import {
   EDIT_CANVAS_FILE_TOOL_NAME,
   RETRIEVE_CANVAS_FILE_TOOL_NAME,
 } from "@app/lib/actions/mcp_internal_actions/servers/canvas/types";
-import { clientExecutableContentType, slideshowContentType } from "@app/types";
+import { clientExecutableContentType } from "@app/types";
 
 export const CANVAS_INSTRUCTIONS = `\
 ## CREATING VISUALIZATIONS WITH CANVAS
@@ -13,8 +13,7 @@ You have access to a Canvas system that allows you to create and update executab
 
 ### File Management Guidelines:
 - Use the \`${CREATE_CANVAS_FILE_TOOL_NAME}\` tool to create JavaScript/TypeScript files
-- Use  MIME type \`${slideshowContentType}\` for: presentations, slide decks, step-by-step content
-- Use  MIME type \`${clientExecutableContentType}\` for: data visualizations, dashboards, interactive tools and all other cases
+- Use MIME type \`${clientExecutableContentType}\`
 - Supported file extensions: .js, .jsx, .ts, .tsx
 - Files are automatically made available to the user for execution
 

--- a/front/lib/actions/mcp_internal_actions/servers/canvas/instructions/slideshow.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/canvas/instructions/slideshow.ts
@@ -1,54 +1,69 @@
 export const SLIDESHOW_INSTRUCTIONS = `
-### Slideshow Guidelines:
-- For presentations, slide decks, or step-by-step content, use the slideshow components
-- Import slideshow primitives: \`import { Slideshow } from "@dust/slideshow/v1"\`
-- Wrap content in \`<Slideshow>\` with multiple \`<Slideshow.Slide>\` children
-- Each slide can contain any React content: charts, text, images, interactive components
+### Using Slideshow Components in Canvas Files
 
-**Typography Components** - Use these for professional, consistent text formatting:
-- \`<Slideshow.Title>\` - Large title text (7xl, for main slide titles)
-- \`<Slideshow.Heading>\` - Section headings (5xl, for slide sections) 
-- \`<Slideshow.Text>\` - Body text (sm, for regular content)
+REQUIRED FIRST STEP - ASSET DISCOVERY:
+BEFORE creating canvas files with slideshow content, you MUST:
+1. Use list_assets to explore available templates and brand assets
+2. Use cat_assets to examine logos, color schemes, and existing templates
+3. Incorporate the customer's branding elements in your slideshow
+WARNING: Creating generic content without checking for customer brand assets first is not acceptable.
 
-**Customization** - These components accept \`className\` prop for flexible styling:
-- \`<Slideshow>\` - Main container (background, spacing, etc.)
-- \`<Slideshow.Slide>\` - Individual slides (background, layout, padding, etc.)
-- \`<Slideshow.Title>\`, \`<Slideshow.Heading>\`, \`<Slideshow.Text>\` - Typography (colors, alignment, spacing, etc.)
+### When to Use Slideshow Components:
+Use the Slideshow component in canvas files for: presentations, tutorials, step-by-step analysis, comparisons, reports
 
-**Navigation is handled automatically** - the slideshow environment provides:
-- Carousel navigation (arrow keys, prev/next buttons)
-- Slide preview thumbnails
-- Professional transitions and styling
-- Full-screen presentation mode
-- Slide counter and progress indicators
+CONTENT PRINCIPLES:
+- Start with your key insight, not background context
+- One main point per slide - don't overcrowd
+- Prioritize data visualizations over text walls
+- End with clear takeaways or next steps
+- Tell a story: Problem → Analysis → Insights → Action
 
-**Focus on content, not controls** - don't implement your own navigation, buttons, or slide management.
-The slideshow container handles all user interactions and presentation flow.
+COMMON SLIDESHOW STRUCTURES:
+- **Analysis**: Problem → Data → Key Insights → Recommendations
+- **Report**: Executive Summary → Key Metrics → Trends → Next Steps
+- **Tutorial**: Learning Goal → Step-by-Step → Examples → Practice
+- **Comparison**: Options → Criteria → Analysis → Decision
 
-Example slideshow structure:
+### Technical Implementation:
+- Import: \`import { Slideshow } from "@dust/slideshow/v1"\`
+- Structure: \`<Slideshow><Slideshow.Slide>content</Slideshow.Slide></Slideshow>\`
+
+**Typography Components:**
+- \`<Slideshow.Title>\` - Main slide titles (large, impactful)
+- \`<Slideshow.Heading>\` - Section headings
+- \`<Slideshow.Text>\` - Body content
+
+**Customization** - All components accept \`className\` for styling:
+- \`<Slideshow.Slide className="bg-blue-50">\` - Slide backgrounds
+- \`<Slideshow.Title className="text-center text-blue-900">\` - Title styling
+- Use brand colors from discovered assets
+
+DESIGN PRINCIPLES:
+- Use consistent colors and fonts from brand assets
+- Create visual hierarchy: Title → Visual → Supporting text
+- White space is your friend - don't fill every pixel
+- Keep text large enough to read in thumbnails
+
+**Navigation is automatic** - arrow keys, thumbnails, prev/next buttons provided.
+Focus on content quality, not navigation controls.
+
+Example with branding:
 \`\`\`tsx
-import { Slideshow } from "@dust/slideshow/v1";
-import { LineChart } from "recharts";
-
-export default function Presentation() {
-  return (
-    <Slideshow>
-      <Slideshow.Slide>
-        <Slideshow.Title>Welcome to Our Presentation</Slideshow.Title>
-        <Slideshow.Text>Overview of key findings and insights</Slideshow.Text>
-      </Slideshow.Slide>
-      <Slideshow.Slide className="bg-blue-50">
-        <Slideshow.Heading className="text-blue-900">Sales Performance</Slideshow.Heading>
-        <LineChart data={analysisData} />
-        <Slideshow.Text className="text-green-600 font-medium">
-          Revenue increased 25% year-over-year
-        </Slideshow.Text>
-      </Slideshow.Slide>
-    </Slideshow>
-  );
-}
+<Slideshow>
+  <Slideshow.Slide>
+    <Slideshow.Title>Q4 Revenue Analysis</Slideshow.Title>
+    <Slideshow.Text>Key findings from our performance data</Slideshow.Text>
+  </Slideshow.Slide>
+  <Slideshow.Slide className="bg-blue-50">
+    <Slideshow.Heading className="text-blue-900">Growth Metrics</Slideshow.Heading>
+    <LineChart data={revenueData} />
+    <Slideshow.Text className="text-green-600 font-medium">
+      Revenue increased 25% year-over-year
+    </Slideshow.Text>
+  </Slideshow.Slide>
+</Slideshow>
 \`\`\`
 
-- When to use slideshows: presentations, tutorials, step-by-step analysis, before/after comparisons
-- When to use regular Canvas: single visualizations, dashboards, interactive tools
+AVOID: Long paragraphs, technical jargon, navigation controls, generic design
+FOCUS: Clear insights, visual data, brand consistency, story flow
 `;

--- a/front/types/files.ts
+++ b/front/types/files.ts
@@ -317,8 +317,6 @@ export type SupportedFileContentType = keyof typeof FILE_FORMATS;
 export const clientExecutableContentType =
   "application/vnd.dust.client-executable";
 
-export const slideshowContentType = "application/vnd.dust.slideshow";
-
 // Canvas MIME types for specialized use cases (not exposed via APIs).
 export const CANVAS_FILE_FORMATS = {
   // Custom for client-executable code files managed by canvas MCP server.
@@ -327,11 +325,6 @@ export const CANVAS_FILE_FORMATS = {
   [clientExecutableContentType]: {
     cat: "code",
     exts: [".js", ".jsx", ".ts", ".tsx"],
-    isSafeToDisplay: true,
-  },
-  [slideshowContentType]: {
-    cat: "code",
-    exts: [".tsx"],
     isSafeToDisplay: true,
   },
 } as const satisfies Record<string, FileFormat>;


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
Follow up of https://github.com/dust-tt/dust/pull/15494.

This PR removes the specific content type that was added originally as the model was getting confused between Canvas and Slideshow considering them as distinct types. We noticed CoT like: `• The file is a slideshow, not a canvas file, so I can't edit it directly. Let me create a new professional version of the slideshow.`

This content type was originally added to help nudge the model, but it was probably not required.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
