### PR TITLE
[Client MCP Servers] Fix missing clientSideMCPServerIds in user message context

### DIFF
--- a/front/lib/api/assistant/messages.ts
+++ b/front/lib/api/assistant/messages.ts
@@ -183,6 +183,7 @@ async function batchRenderUserMessages(
         email: userMessage.userContextEmail,
         profilePictureUrl: userMessage.userContextProfilePictureUrl,
         origin: userMessage.userContextOrigin,
+        clientSideMCPServerIds: userMessage.clientSideMCPServerIds,
       },
     } satisfies UserMessageType;
     return { m, rank: message.rank, version: message.version };


### PR DESCRIPTION
## Description

Fixes https://github.com/dust-tt/dust/issues/15280

The `clientSideMCPServerIds` field was not being included when retrieving user messages from the database. This caused  client MCP servers(e.g. CLI file system tools fs_cli__read_file, fs_cli__search_files, etc.) to not be available to agents, even though they were properly registered, since ~a week 

The fix adds the missing field to the user message context in `getUserMessage()` function.

The issue was surfaced when we moved to async loop. When we implemented client side server mcp, we didn't think of rendering it when rendering usermessages in getConversation when fetching from DB. Until recently this wasn't a problem because the current userMessage, that triggered the agent run, was in memory during the sync loop. But the issue became problematic when we moved to async loop and started fetching data from database using `getConversation` during the agent loop.

## Risks

Blast radius: User message retrieval for conversations using client-side MCP servers
Risk: low

## Tests

Manual testing:
- CLI with file system tools now properly exposes tools to agents
- Verified that `clientSideMCPServerIds` is correctly passed through the message context

## Deploy Plan
front