### PR TITLE
[front] Improve typing of agent messages

### DIFF
--- a/front/components/assistant/conversation/AgentMessage.tsx
+++ b/front/components/assistant/conversation/AgentMessage.tsx
@@ -622,6 +622,9 @@ export function AgentMessage({
   }
 }
 
+/**
+ * Reconstructs the agent message to render based on the message fetched and the data streamed.
+ */
 function getAgentMessageToRender({
   message,
   messageStreamState,

--- a/front/components/assistant/conversation/AgentMessage.tsx
+++ b/front/components/assistant/conversation/AgentMessage.tsx
@@ -624,6 +624,7 @@ export function AgentMessage({
 
 /**
  * Reconstructs the agent message to render based on the message fetched and the data streamed.
+ * The message does not contain actions, we may only have some if we received through the stream.
  */
 function getAgentMessageToRender({
   message,


### PR DESCRIPTION
## Description

- This PR improves the typing of messages very marginally, by correctly exposing `agentMessageToRender` as a `LightAgentMessageType | LightAgentMessageWithActionsType` rather than a `LightAgentMessageType`.

## Tests

- Tested locally.

## Risk

- Low, only at the typing level.

## Deploy Plan

- Deploy front.
