### PR TITLE
[front] Display entire CoT in side panel

### DIFF
--- a/front/components/assistant/conversation/actions/AgentActionsPanel.tsx
+++ b/front/components/assistant/conversation/actions/AgentActionsPanel.tsx
@@ -119,7 +119,7 @@ function AgentActionsPanelContent({
     /**
      * 1000px threshold is used to determine if the user is at the bottom of the panel.
      * If the user is within 1000px of the bottom, we consider them to be at the bottom.
-     * This is to prevent loosing auto-scroll when we receive a visually BIG chunk.
+     * This is to prevent losing auto-scroll when we receive a visually BIG chunk.
      */
     const threshold = 1000;
     isUserAtBottomRef.current =
@@ -286,7 +286,7 @@ export function AgentActionsPanel({
     );
   }
 
-  // Use key to force remount when message changes for proper state reset
+  // Use key to force remount when the message changes for proper state reset.
   return (
     <AgentActionsPanelContent
       key={fullAgentMessage.sId}

--- a/front/components/assistant/conversation/actions/AgentActionsPanel.tsx
+++ b/front/components/assistant/conversation/actions/AgentActionsPanel.tsx
@@ -161,7 +161,7 @@ function AgentActionsPanelContent({
         <div className="flex flex-col gap-4">
           {/* Render all parsed steps in order */}
           {Object.entries(steps || {})
-            .sort(([a], [b]) => parseInt(a) - parseInt(b))
+            .sort(([a], [b]) => parseInt(a, 10) - parseInt(b, 10))
             .map(([step, entries]) => {
               if (!entries || !Array.isArray(entries) || entries.length === 0) {
                 return null;
@@ -170,7 +170,7 @@ function AgentActionsPanelContent({
               return (
                 <PanelAgentStep
                   key={step}
-                  stepNumber={parseInt(step)}
+                  stepNumber={parseInt(step, 10)}
                   entries={entries}
                   streamActionProgress={streamActionProgress}
                   owner={owner}

--- a/front/components/assistant/conversation/actions/AgentMessageActions.tsx
+++ b/front/components/assistant/conversation/actions/AgentMessageActions.tsx
@@ -46,7 +46,9 @@ export function AgentMessageActions({
     (isAgentMessageWithActions && agentMessage.actions.length > 0) ||
     agentMessage.chainOfThought;
 
-  const chainOfThought = agentMessage.chainOfThought || "";
+  const fullChainOfThought = agentMessage.chainOfThought || "";
+  const chainOfThought = fullChainOfThought.split("\n\n").pop() || "";
+
   const onClick = () => {
     openPanel({
       type: "actions",

--- a/front/components/assistant/conversation/actions/AgentMessageActions.tsx
+++ b/front/components/assistant/conversation/actions/AgentMessageActions.tsx
@@ -47,7 +47,9 @@ export function AgentMessageActions({
     agentMessage.chainOfThought;
 
   const fullChainOfThought = agentMessage.chainOfThought || "";
-  const chainOfThought = fullChainOfThought.split("\n\n").pop() || "";
+  const paragraphs = fullChainOfThought.split("\n\n");
+  const chainOfThought =
+    paragraphs.slice(paragraphs.length - 2).join("\n\n") || "";
 
   const onClick = () => {
     openPanel({

--- a/front/lib/assistant/state/messageReducer.ts
+++ b/front/lib/assistant/state/messageReducer.ts
@@ -174,12 +174,8 @@ export function messageReducer(
           newState.agentState = "writing";
           break;
         case "chain_of_thought":
-          if (event.text === "\n\n") {
-            newState.message.chainOfThought = "";
-          } else {
-            newState.message.chainOfThought =
-              (newState.message.chainOfThought || "") + event.text;
-          }
+          newState.message.chainOfThought =
+            (newState.message.chainOfThought || "") + event.text;
           newState.agentState = "thinking";
           break;
         default:


### PR DESCRIPTION
## Description

- Certain models (GPT5 mostly) have multi-paragraph chain of thoughts.
- We currently only render the last one in both the side panel and the `AgentMessageActions`, which not only hides some of the content during streaming but also creates a blinking effect when the entire CoT gets displayed all at once.
- This PR changes this behavior to render all paragraphs in the side panel whilst keeping the current behavior for the in-conversation view.
- We actually show 2 paragraphs for a rolling effect, what was convenient when streaming is that gpt5 marks the delimitation between paragraphs by sending one block equal to `"\n\n"`, whereas the actual text can contain double line breaks but that wouldn't come in a single block. Therefore, separating paragraphs gets a lot harder outside of the streaming context. The current approach is a balance between an overfit on gpt5 and this limitation, could definitely be improved (possibly by storing two CoT, the full one and the one that should be displayed in the conversation).

https://github.com/user-attachments/assets/a2352e27-2fbe-40ed-95f2-f3e9dddb092f

- Currently not ideal since we sometimes lose the paragraph title when the next one comes.
- Would be great to prevent the blinking in the side panel after the streaming ends.

## Tests

- Tested locally.

## Risk

- Low, mostly UI. At worst render the entire CoT, which is not great but not the end of the world.

## Deploy Plan

- Deploy front.
