### PR TITLE
Handle tools approval with wildcard

### DIFF
--- a/front/lib/actions/utils.test.ts
+++ b/front/lib/actions/utils.test.ts
@@ -1,0 +1,604 @@
+import { beforeEach, describe, expect, it } from "vitest";
+
+import type { UserResource } from "@app/lib/resources/user_resource";
+import { UserFactory } from "@app/tests/utils/UserFactory";
+
+import { hasUserAlwaysApprovedTool, setUserAlwaysApprovedTool } from "./utils";
+
+describe("Tool validation utilities", () => {
+  let user: UserResource;
+
+  beforeEach(async () => {
+    user = await UserFactory.basic();
+  });
+
+  describe("setUserAlwaysApprovedTool", () => {
+    it("should store tool approval in user metadata", async () => {
+      const mcpServerId = "test-server";
+      const toolName = "test-tool";
+
+      await setUserAlwaysApprovedTool({
+        user,
+        mcpServerId,
+        toolName,
+      });
+
+      // Verify the metadata was stored correctly
+      const metadata = await user.getMetadata(
+        `toolsValidations:${mcpServerId}`
+      );
+      expect(metadata).toBeTruthy();
+      expect(metadata!.value).toBe(toolName);
+    });
+
+    it("should handle multiple tool approvals for same server", async () => {
+      const mcpServerId = "multi-tool-server";
+      const tool1 = "tool-1";
+      const tool2 = "tool-2";
+
+      await setUserAlwaysApprovedTool({
+        user,
+        mcpServerId,
+        toolName: tool1,
+      });
+
+      await setUserAlwaysApprovedTool({
+        user,
+        mcpServerId,
+        toolName: tool2,
+      });
+
+      const tools = await user.getMetadataAsArray(
+        `toolsValidations:${mcpServerId}`
+      );
+      expect(tools).toContain(tool1);
+      expect(tools).toContain(tool2);
+      expect(tools).toHaveLength(2);
+    });
+
+    it("should not duplicate tool approvals", async () => {
+      const mcpServerId = "duplicate-server";
+      const toolName = "duplicate-tool";
+
+      await setUserAlwaysApprovedTool({
+        user,
+        mcpServerId,
+        toolName,
+      });
+
+      await setUserAlwaysApprovedTool({
+        user,
+        mcpServerId,
+        toolName,
+      });
+
+      const tools = await user.getMetadataAsArray(
+        `toolsValidations:${mcpServerId}`
+      );
+      expect(tools).toEqual([toolName]);
+    });
+
+    it("should handle special characters in server ID and tool name", async () => {
+      const mcpServerId = "server-with@special#chars";
+      const toolName = "tool-with@special#chars";
+
+      await setUserAlwaysApprovedTool({
+        user,
+        mcpServerId,
+        toolName,
+      });
+
+      const metadata = await user.getMetadata(
+        `toolsValidations:${mcpServerId}`
+      );
+      expect(metadata).toBeTruthy();
+      expect(metadata!.value).toBe(toolName);
+    });
+
+    it("should throw error if mcpServerId is empty", async () => {
+      const mcpServerId = "";
+      const toolName = "test-tool";
+
+      await expect(
+        setUserAlwaysApprovedTool({
+          user,
+          mcpServerId,
+          toolName,
+        })
+      ).rejects.toThrow("mcpServerId is required");
+    });
+
+    it("should throw error if toolName is empty", async () => {
+      const mcpServerId = "test-server";
+      const toolName = "";
+
+      await expect(
+        setUserAlwaysApprovedTool({
+          user,
+          mcpServerId,
+          toolName,
+        })
+      ).rejects.toThrow("toolName is required");
+    });
+  });
+
+  describe("hasUserAlwaysApprovedTool", () => {
+    it("should return true when tool name is found in metadata", async () => {
+      const mcpServerId = "test-server";
+      const toolName = "test-tool";
+
+      // First add some tools to metadata
+      await setUserAlwaysApprovedTool({
+        user,
+        mcpServerId,
+        toolName: "other-tool",
+      });
+      await setUserAlwaysApprovedTool({
+        user,
+        mcpServerId,
+        toolName,
+      });
+      await setUserAlwaysApprovedTool({
+        user,
+        mcpServerId,
+        toolName: "another-tool",
+      });
+
+      const result = await hasUserAlwaysApprovedTool({
+        user,
+        mcpServerId,
+        toolName,
+      });
+
+      expect(result).toBe(true);
+    });
+
+    it("should return true when wildcard is found in metadata", async () => {
+      const mcpServerId = "test-server";
+      const toolName = "test-tool";
+
+      // Add wildcard approval
+      await setUserAlwaysApprovedTool({
+        user,
+        mcpServerId,
+        toolName: "*",
+      });
+
+      const result = await hasUserAlwaysApprovedTool({
+        user,
+        mcpServerId,
+        toolName,
+      });
+
+      expect(result).toBe(true);
+    });
+
+    it("should return false when tool name is not found and no wildcard", async () => {
+      const mcpServerId = "test-server";
+      const toolName = "test-tool";
+
+      // Add some other tools but not the one we're looking for
+      await setUserAlwaysApprovedTool({
+        user,
+        mcpServerId,
+        toolName: "other-tool",
+      });
+      await setUserAlwaysApprovedTool({
+        user,
+        mcpServerId,
+        toolName: "another-tool",
+      });
+
+      const result = await hasUserAlwaysApprovedTool({
+        user,
+        mcpServerId,
+        toolName,
+      });
+
+      expect(result).toBe(false);
+    });
+
+    it("should return false when metadata is empty", async () => {
+      const mcpServerId = "test-server";
+      const toolName = "test-tool";
+
+      const result = await hasUserAlwaysApprovedTool({
+        user,
+        mcpServerId,
+        toolName,
+      });
+
+      expect(result).toBe(false);
+    });
+
+    it("should handle exact tool name match among similar names", async () => {
+      const mcpServerId = "test-server";
+      const toolName = "tool";
+
+      // Add similar tool names
+      await setUserAlwaysApprovedTool({
+        user,
+        mcpServerId,
+        toolName: "tool-prefix",
+      });
+      await setUserAlwaysApprovedTool({
+        user,
+        mcpServerId,
+        toolName: "prefix-tool",
+      });
+      await setUserAlwaysApprovedTool({
+        user,
+        mcpServerId,
+        toolName: "tool", // Exact match
+      });
+      await setUserAlwaysApprovedTool({
+        user,
+        mcpServerId,
+        toolName: "tool-suffix",
+      });
+
+      const result = await hasUserAlwaysApprovedTool({
+        user,
+        mcpServerId,
+        toolName,
+      });
+
+      expect(result).toBe(true);
+    });
+
+    it("should return false for partial matches without exact match", async () => {
+      const mcpServerId = "test-server";
+      const toolName = "tool";
+
+      // Add similar tool names but no exact match
+      await setUserAlwaysApprovedTool({
+        user,
+        mcpServerId,
+        toolName: "tool-prefix",
+      });
+      await setUserAlwaysApprovedTool({
+        user,
+        mcpServerId,
+        toolName: "prefix-tool",
+      });
+      await setUserAlwaysApprovedTool({
+        user,
+        mcpServerId,
+        toolName: "my-tool-name",
+      });
+
+      const result = await hasUserAlwaysApprovedTool({
+        user,
+        mcpServerId,
+        toolName,
+      });
+
+      expect(result).toBe(false);
+    });
+
+    it("should handle special characters in tool name lookup", async () => {
+      const mcpServerId = "test-server";
+      const toolName = "tool@with#special$chars";
+
+      await setUserAlwaysApprovedTool({
+        user,
+        mcpServerId,
+        toolName: "regular-tool",
+      });
+      await setUserAlwaysApprovedTool({
+        user,
+        mcpServerId,
+        toolName,
+      });
+      await setUserAlwaysApprovedTool({
+        user,
+        mcpServerId,
+        toolName: "another-tool",
+      });
+
+      const result = await hasUserAlwaysApprovedTool({
+        user,
+        mcpServerId,
+        toolName,
+      });
+
+      expect(result).toBe(true);
+    });
+
+    it("should work with different server IDs independently", async () => {
+      const server1 = "server-1";
+      const server2 = "server-2";
+      const toolName = "shared-tool";
+
+      // Approve tool for server1 only
+      await setUserAlwaysApprovedTool({
+        user,
+        mcpServerId: server1,
+        toolName,
+      });
+
+      const result1 = await hasUserAlwaysApprovedTool({
+        user,
+        mcpServerId: server1,
+        toolName,
+      });
+
+      const result2 = await hasUserAlwaysApprovedTool({
+        user,
+        mcpServerId: server2,
+        toolName,
+      });
+
+      expect(result1).toBe(true);
+      expect(result2).toBe(false);
+    });
+
+    it("should prioritize wildcard over specific tool names", async () => {
+      const mcpServerId = "test-server";
+      const toolName = "specific-tool";
+
+      // Add both wildcard and specific tool
+      await setUserAlwaysApprovedTool({
+        user,
+        mcpServerId,
+        toolName: "other-tool",
+      });
+      await setUserAlwaysApprovedTool({
+        user,
+        mcpServerId,
+        toolName: "*",
+      });
+      await setUserAlwaysApprovedTool({
+        user,
+        mcpServerId,
+        toolName,
+      });
+
+      const result = await hasUserAlwaysApprovedTool({
+        user,
+        mcpServerId,
+        toolName,
+      });
+
+      expect(result).toBe(true);
+    });
+
+    it("should handle case sensitivity correctly", async () => {
+      const mcpServerId = "test-server";
+      const toolName = "MyTool";
+
+      await setUserAlwaysApprovedTool({
+        user,
+        mcpServerId,
+        toolName: "mytool",
+      });
+      await setUserAlwaysApprovedTool({
+        user,
+        mcpServerId,
+        toolName: "MYTOOL",
+      });
+      await setUserAlwaysApprovedTool({
+        user,
+        mcpServerId,
+        toolName: "MyTool", // Exact case match
+      });
+
+      const result = await hasUserAlwaysApprovedTool({
+        user,
+        mcpServerId,
+        toolName,
+      });
+
+      expect(result).toBe(true);
+    });
+
+    it("should return false for case mismatch when exact match not found", async () => {
+      const mcpServerId = "test-server";
+      const toolName = "MyTool";
+
+      await setUserAlwaysApprovedTool({
+        user,
+        mcpServerId,
+        toolName: "mytool",
+      });
+      await setUserAlwaysApprovedTool({
+        user,
+        mcpServerId,
+        toolName: "MYTOOL",
+      });
+      await setUserAlwaysApprovedTool({
+        user,
+        mcpServerId,
+        toolName: "myTool",
+      });
+
+      const result = await hasUserAlwaysApprovedTool({
+        user,
+        mcpServerId,
+        toolName,
+      });
+
+      expect(result).toBe(false);
+    });
+  });
+
+  describe("integration scenarios", () => {
+    it("should work correctly when setting and then checking approval", async () => {
+      const mcpServerId = "integration-server";
+      const toolName = "integration-tool";
+
+      // First, set the tool as approved
+      await setUserAlwaysApprovedTool({
+        user,
+        mcpServerId,
+        toolName,
+      });
+
+      // Then check if it's approved
+      const result = await hasUserAlwaysApprovedTool({
+        user,
+        mcpServerId,
+        toolName,
+      });
+
+      expect(result).toBe(true);
+    });
+
+    it("should handle multiple tools for the same server", async () => {
+      const mcpServerId = "multi-tool-server";
+      const tool1 = "tool-1";
+      const tool2 = "tool-2";
+      const tool3 = "tool-3";
+
+      // Set multiple tools as approved
+      await setUserAlwaysApprovedTool({
+        user,
+        mcpServerId,
+        toolName: tool1,
+      });
+      await setUserAlwaysApprovedTool({
+        user,
+        mcpServerId,
+        toolName: tool2,
+      });
+
+      // Check each tool
+      const result1 = await hasUserAlwaysApprovedTool({
+        user,
+        mcpServerId,
+        toolName: tool1,
+      });
+      const result2 = await hasUserAlwaysApprovedTool({
+        user,
+        mcpServerId,
+        toolName: tool2,
+      });
+      const result3 = await hasUserAlwaysApprovedTool({
+        user,
+        mcpServerId,
+        toolName: tool3,
+      });
+
+      expect(result1).toBe(true);
+      expect(result2).toBe(true);
+      expect(result3).toBe(false);
+    });
+
+    it("should handle complex workflow with multiple servers and tools", async () => {
+      const server1 = "server-alpha";
+      const server2 = "server-beta";
+      const tools = ["read-file", "write-file", "execute-command"];
+
+      // Approve all tools for server1
+      for (const tool of tools) {
+        await setUserAlwaysApprovedTool({
+          user,
+          mcpServerId: server1,
+          toolName: tool,
+        });
+      }
+
+      // Approve only first tool for server2
+      await setUserAlwaysApprovedTool({
+        user,
+        mcpServerId: server2,
+        toolName: tools[0],
+      });
+
+      // Add wildcard for server2
+      await setUserAlwaysApprovedTool({
+        user,
+        mcpServerId: server2,
+        toolName: "*",
+      });
+
+      // Test server1 - all tools should be approved individually
+      for (const tool of tools) {
+        const result = await hasUserAlwaysApprovedTool({
+          user,
+          mcpServerId: server1,
+          toolName: tool,
+        });
+        expect(result).toBe(true);
+      }
+
+      // Test server2 - all tools should be approved due to wildcard
+      for (const tool of tools) {
+        const result = await hasUserAlwaysApprovedTool({
+          user,
+          mcpServerId: server2,
+          toolName: tool,
+        });
+        expect(result).toBe(true);
+      }
+
+      // Test unknown tool on server2 - should be approved due to wildcard
+      const unknownResult = await hasUserAlwaysApprovedTool({
+        user,
+        mcpServerId: server2,
+        toolName: "unknown-tool",
+      });
+      expect(unknownResult).toBe(true);
+
+      // Test unknown server - should be false
+      const unknownServerResult = await hasUserAlwaysApprovedTool({
+        user,
+        mcpServerId: "unknown-server",
+        toolName: tools[0],
+      });
+      expect(unknownServerResult).toBe(false);
+    });
+
+    it("should maintain data integrity across multiple operations", async () => {
+      const mcpServerId = "integrity-test-server";
+      const tools = ["tool-a", "tool-b", "tool-c"];
+
+      // Add tools one by one and verify each addition
+      for (let i = 0; i < tools.length; i++) {
+        await setUserAlwaysApprovedTool({
+          user,
+          mcpServerId,
+          toolName: tools[i],
+        });
+
+        // Verify all previously added tools are still there
+        for (let j = 0; j <= i; j++) {
+          const result = await hasUserAlwaysApprovedTool({
+            user,
+            mcpServerId,
+            toolName: tools[j],
+          });
+          expect(result).toBe(true);
+        }
+
+        // Verify tools not yet added are not there
+        for (let k = i + 1; k < tools.length; k++) {
+          const result = await hasUserAlwaysApprovedTool({
+            user,
+            mcpServerId,
+            toolName: tools[k],
+          });
+          expect(result).toBe(false);
+        }
+      }
+
+      // Try to add duplicates and verify no changes
+      for (const tool of tools) {
+        await setUserAlwaysApprovedTool({
+          user,
+          mcpServerId,
+          toolName: tool,
+        });
+      }
+
+      // All tools should still be approved exactly once
+      const allTools = await user.getMetadataAsArray(
+        `toolsValidations:${mcpServerId}`
+      );
+      expect(allTools).toHaveLength(tools.length);
+      for (const tool of tools) {
+        expect(allTools.filter((t) => t === tool)).toHaveLength(1);
+      }
+    });
+  });
+});

--- a/front/lib/api/assistant/conversation/validate_actions.ts
+++ b/front/lib/api/assistant/conversation/validate_actions.ts
@@ -8,6 +8,7 @@ import {
   isMCPApproveExecutionEvent,
   updateMCPApprovalState,
 } from "@app/lib/actions/mcp";
+import { setUserAlwaysApprovedTool } from "@app/lib/actions/utils";
 import { runAgentLoop } from "@app/lib/api/assistant/agent";
 import { getMessageChannelId } from "@app/lib/api/assistant/streaming/helpers";
 import { getRedisHybridManager } from "@app/lib/api/redis-hybrid-manager";
@@ -133,10 +134,13 @@ export async function validateAction(
       });
       const toolName = actionBaseParams.functionCallName;
 
-      await user.appendToMetadata(
-        `toolsValidations:${toolServerId}`,
-        `${toolName}`
-      );
+      if (toolName) {
+        await setUserAlwaysApprovedTool({
+          user,
+          mcpServerId: toolServerId,
+          toolName,
+        });
+      }
     }
   }
 

--- a/front/lib/resources/user_resource.test.ts
+++ b/front/lib/resources/user_resource.test.ts
@@ -1,0 +1,229 @@
+import { beforeEach, describe, expect, it } from "vitest";
+
+import type { UserResource } from "@app/lib/resources/user_resource";
+import { UserFactory } from "@app/tests/utils/UserFactory";
+
+describe("UserResource", () => {
+  let user: UserResource;
+
+  beforeEach(async () => {
+    user = await UserFactory.basic();
+  });
+
+  describe("getMetadataAsArray", () => {
+    it("should return empty array when metadata does not exist", async () => {
+      const result = await user.getMetadataAsArray("nonexistent-key");
+      expect(result).toEqual([]);
+    });
+
+    it("should return array with single value when metadata contains one item", async () => {
+      const key = "test-key";
+      const value = "single-value";
+
+      await user.setMetadata(key, value);
+
+      const result = await user.getMetadataAsArray(key);
+      expect(result).toEqual([value]);
+    });
+
+    it("should return array with multiple values when metadata contains comma-separated items", async () => {
+      const key = "test-key";
+      const values = ["value1", "value2", "value3"];
+      const commaSeparatedValue = values.join(",");
+
+      await user.setMetadata(key, commaSeparatedValue);
+
+      const result = await user.getMetadataAsArray(key);
+      expect(result).toEqual(values);
+    });
+
+    it("should handle empty string values in array", async () => {
+      const key = "test-key";
+      const values = ["value1", "", "value3"];
+      const commaSeparatedValue = values.join(",");
+
+      await user.setMetadata(key, commaSeparatedValue);
+
+      const result = await user.getMetadataAsArray(key);
+      expect(result).toEqual(values);
+    });
+
+    it("should handle values with spaces", async () => {
+      const key = "test-key";
+      const values = ["value with spaces", "another value", "third"];
+      const commaSeparatedValue = values.join(",");
+
+      await user.setMetadata(key, commaSeparatedValue);
+
+      const result = await user.getMetadataAsArray(key);
+      expect(result).toEqual(values);
+    });
+
+    it("should handle single empty string", async () => {
+      const key = "test-key";
+      const value = "";
+
+      await user.setMetadata(key, value);
+
+      const result = await user.getMetadataAsArray(key);
+      expect(result).toEqual([""]);
+    });
+  });
+
+  describe("upsertMetadataArray", () => {
+    it("should create new metadata when key does not exist", async () => {
+      const key = "new-key";
+      const value = "first-value";
+
+      await user.upsertMetadataArray(key, value);
+
+      const metadata = await user.getMetadata(key);
+      expect(metadata).toBeTruthy();
+      expect(metadata!.value).toBe(value);
+      expect(metadata!.key).toBe(key);
+      expect(metadata!.userId).toBe(user.id);
+    });
+
+    it("should add value to existing metadata array", async () => {
+      const key = "existing-key";
+      const initialValue = "initial-value";
+      const newValue = "new-value";
+
+      // Create initial metadata
+      await user.setMetadata(key, initialValue);
+
+      // Add new value
+      await user.upsertMetadataArray(key, newValue);
+
+      const result = await user.getMetadataAsArray(key);
+      expect(result).toEqual([initialValue, newValue]);
+    });
+
+    it("should not add duplicate values", async () => {
+      const key = "duplicate-key";
+      const value = "duplicate-value";
+
+      // Add value twice
+      await user.upsertMetadataArray(key, value);
+      await user.upsertMetadataArray(key, value);
+
+      const result = await user.getMetadataAsArray(key);
+      expect(result).toEqual([value]);
+    });
+
+    it("should handle adding to existing comma-separated values", async () => {
+      const key = "multi-key";
+      const initialValues = ["value1", "value2"];
+      const newValue = "value3";
+
+      // Set initial comma-separated values
+      await user.setMetadata(key, initialValues.join(","));
+
+      // Add new value
+      await user.upsertMetadataArray(key, newValue);
+
+      const result = await user.getMetadataAsArray(key);
+      expect(result).toEqual([...initialValues, newValue]);
+    });
+
+    it("should not add duplicate to existing comma-separated values", async () => {
+      const key = "multi-duplicate-key";
+      const initialValues = ["value1", "value2", "value3"];
+      const duplicateValue = "value2";
+
+      // Set initial comma-separated values
+      await user.setMetadata(key, initialValues.join(","));
+
+      // Try to add duplicate value
+      await user.upsertMetadataArray(key, duplicateValue);
+
+      const result = await user.getMetadataAsArray(key);
+      expect(result).toEqual(initialValues);
+    });
+
+    it("should handle empty string values", async () => {
+      const key = "empty-key";
+      const emptyValue = "";
+
+      await user.upsertMetadataArray(key, emptyValue);
+
+      const result = await user.getMetadataAsArray(key);
+      expect(result).toEqual([emptyValue]);
+    });
+
+    it("should handle values with commas by preserving them", async () => {
+      const key = "comma-key";
+      const valueWithComma = "value,with,commas";
+
+      await user.upsertMetadataArray(key, valueWithComma);
+
+      const result = await user.getMetadataAsArray(key);
+      expect(result).toEqual([valueWithComma]);
+    });
+
+    it("should handle adding empty string to existing values", async () => {
+      const key = "mixed-key";
+      const initialValue = "initial";
+      const emptyValue = "";
+
+      await user.setMetadata(key, initialValue);
+      await user.upsertMetadataArray(key, emptyValue);
+
+      const result = await user.getMetadataAsArray(key);
+      expect(result).toEqual([initialValue, emptyValue]);
+    });
+  });
+
+  describe("integration tests", () => {
+    it("should work correctly with multiple operations on same key", async () => {
+      const key = "integration-key";
+      const values = ["first", "second", "third"];
+
+      // Add values one by one
+      for (const value of values) {
+        await user.upsertMetadataArray(key, value);
+      }
+
+      // Verify all values are present
+      const result = await user.getMetadataAsArray(key);
+      expect(result).toEqual(values);
+
+      // Try adding duplicate
+      await user.upsertMetadataArray(key, values[1]);
+
+      // Should still have same values (no duplicate)
+      const resultAfterDuplicate = await user.getMetadataAsArray(key);
+      expect(resultAfterDuplicate).toEqual(values);
+
+      // Add new value
+      const newValue = "fourth";
+      await user.upsertMetadataArray(key, newValue);
+
+      const finalResult = await user.getMetadataAsArray(key);
+      expect(finalResult).toEqual([...values, newValue]);
+    });
+
+    it("should handle multiple different keys independently", async () => {
+      const key1 = "key1";
+      const key2 = "key2";
+      const values1 = ["a", "b"];
+      const values2 = ["x", "y", "z"];
+
+      // Add values to different keys
+      for (const value of values1) {
+        await user.upsertMetadataArray(key1, value);
+      }
+
+      for (const value of values2) {
+        await user.upsertMetadataArray(key2, value);
+      }
+
+      // Verify keys are independent
+      const result1 = await user.getMetadataAsArray(key1);
+      const result2 = await user.getMetadataAsArray(key2);
+
+      expect(result1).toEqual(values1);
+      expect(result2).toEqual(values2);
+    });
+  });
+});


### PR DESCRIPTION
## Description

Refactored the "always approve" metadata code to handle wildcard.

## Tests

Added

## Risk

Medium but worse case, tools are no longer auto-approved.

## Deploy Plan

Deploy front