### PR TITLE
[front] Add error boundary to conversation layout

### DIFF
--- a/front/components/assistant/conversation/ConversationError.tsx
+++ b/front/components/assistant/conversation/ConversationError.tsx
@@ -70,7 +70,7 @@ interface ErrorDisplayProps {
   title: string;
 }
 
-function ErrorDisplay({ icon, message, title }: ErrorDisplayProps) {
+export function ErrorDisplay({ icon, message, title }: ErrorDisplayProps) {
   return (
     <div className="flex h-screen flex-col items-center justify-center gap-1">
       {icon && (

--- a/front/components/assistant/conversation/ConversationLayout.tsx
+++ b/front/components/assistant/conversation/ConversationLayout.tsx
@@ -5,7 +5,10 @@ import React, { useMemo } from "react";
 import { BlockedActionsProvider } from "@app/components/assistant/conversation/BlockedActionsProvider";
 import { CoEditionProvider } from "@app/components/assistant/conversation/co_edition/CoEditionProvider";
 import { CONVERSATION_VIEW_SCROLL_LAYOUT } from "@app/components/assistant/conversation/constant";
-import { ConversationErrorDisplay } from "@app/components/assistant/conversation/ConversationError";
+import {
+  ConversationErrorDisplay,
+  ErrorDisplay,
+} from "@app/components/assistant/conversation/ConversationError";
 import ConversationSidePanelContainer from "@app/components/assistant/conversation/ConversationSidePanelContainer";
 import { ConversationSidePanelProvider } from "@app/components/assistant/conversation/ConversationSidePanelContext";
 import { useConversationSidePanelContext } from "@app/components/assistant/conversation/ConversationSidePanelContext";
@@ -33,6 +36,7 @@ import type {
   UserType,
   WorkspaceType,
 } from "@app/types";
+import { ErrorBoundary } from "@app/components/error_boundary/ErrorBoundary";
 
 export interface ConversationLayoutProps {
   baseUrl: string;
@@ -189,6 +193,18 @@ interface ConversationInnerLayoutProps {
   activeConversationId: string | null;
 }
 
+function UncaughtConversationErrorFallback() {
+  return (
+    <ErrorDisplay
+      title="Something unexpected happened"
+      message={[
+        "Try refreshing the page to continue your conversation.",
+        "Still having trouble? Reach out at support@dust.tt",
+      ]}
+    />
+  );
+}
+
 function ConversationInnerLayout({
   children,
   conversation,
@@ -200,42 +216,44 @@ function ConversationInnerLayout({
   const { currentPanel } = useConversationSidePanelContext();
 
   return (
-    <div className="flex h-full w-full flex-col">
-      <ResizablePanelGroup
-        direction="horizontal"
-        className="flex h-full w-full flex-1"
-      >
-        <ResizablePanel defaultSize={100}>
-          <div className="flex h-full flex-col">
-            {activeConversationId && (
-              <ConversationTitle owner={owner} baseUrl={baseUrl} />
-            )}
-            {conversationError ? (
-              <ConversationErrorDisplay error={conversationError} />
-            ) : (
-              <FileDropProvider>
-                <GenerationContextProvider>
-                  <div
-                    id={CONVERSATION_VIEW_SCROLL_LAYOUT}
-                    className={cn(
-                      "dd-privacy-mask h-full overflow-y-auto scroll-smooth px-4",
-                      // Hide conversation on mobile when any panel is opened.
-                      currentPanel && "hidden md:block"
-                    )}
-                  >
-                    {children}
-                  </div>
-                </GenerationContextProvider>
-              </FileDropProvider>
-            )}
-          </div>
-        </ResizablePanel>
+    <ErrorBoundary fallback={<UncaughtConversationErrorFallback />}>
+      <div className="flex h-full w-full flex-col">
+        <ResizablePanelGroup
+          direction="horizontal"
+          className="flex h-full w-full flex-1"
+        >
+          <ResizablePanel defaultSize={100}>
+            <div className="flex h-full flex-col">
+              {activeConversationId && (
+                <ConversationTitle owner={owner} baseUrl={baseUrl} />
+              )}
+              {conversationError ? (
+                <ConversationErrorDisplay error={conversationError} />
+              ) : (
+                <FileDropProvider>
+                  <GenerationContextProvider>
+                    <div
+                      id={CONVERSATION_VIEW_SCROLL_LAYOUT}
+                      className={cn(
+                        "dd-privacy-mask h-full overflow-y-auto scroll-smooth px-4",
+                        // Hide conversation on mobile when any panel is opened.
+                        currentPanel && "hidden md:block"
+                      )}
+                    >
+                      {children}
+                    </div>
+                  </GenerationContextProvider>
+                </FileDropProvider>
+              )}
+            </div>
+          </ResizablePanel>
 
-        <ConversationSidePanelContainer
-          owner={owner}
-          conversation={conversation}
-        />
-      </ResizablePanelGroup>
-    </div>
+          <ConversationSidePanelContainer
+            owner={owner}
+            conversation={conversation}
+          />
+        </ResizablePanelGroup>
+      </div>
+    </ErrorBoundary>
   );
 }

--- a/front/components/assistant/conversation/ConversationLayout.tsx
+++ b/front/components/assistant/conversation/ConversationLayout.tsx
@@ -24,6 +24,7 @@ import { AssistantSidebarMenu } from "@app/components/assistant/conversation/Sid
 import { AssistantDetails } from "@app/components/assistant/details/AssistantDetails";
 import { WelcomeTourGuide } from "@app/components/assistant/WelcomeTourGuide";
 import { useWelcomeTourGuide } from "@app/components/assistant/WelcomeTourGuideProvider";
+import { ErrorBoundary } from "@app/components/error_boundary/ErrorBoundary";
 import AppContentLayout from "@app/components/sparkle/AppContentLayout";
 import { useURLSheet } from "@app/hooks/useURLSheet";
 import { useConversation } from "@app/lib/swr/conversations";
@@ -36,7 +37,6 @@ import type {
   UserType,
   WorkspaceType,
 } from "@app/types";
-import { ErrorBoundary } from "@app/components/error_boundary/ErrorBoundary";
 
 export interface ConversationLayoutProps {
   baseUrl: string;

--- a/front/components/error_boundary/ErrorBoundary.tsx
+++ b/front/components/error_boundary/ErrorBoundary.tsx
@@ -1,0 +1,46 @@
+import { datadogLogs } from "@datadog/browser-logs";
+import * as React from "react";
+
+interface ErrorBoundaryProps {
+  children: React.ReactNode;
+  fallback: React.ReactNode;
+}
+
+interface ErrorBoundaryState {
+  hasError: boolean;
+}
+
+export class ErrorBoundary extends React.Component<
+  ErrorBoundaryProps,
+  ErrorBoundaryState
+> {
+  constructor(props: ErrorBoundaryProps) {
+    super(props);
+    this.state = { hasError: false };
+  }
+
+  static getDerivedStateFromError(): ErrorBoundaryState {
+    return { hasError: true };
+  }
+
+  componentDidCatch(error: Error, info: React.ErrorInfo) {
+    datadogLogs.logger.error("Uncaught client side error", {
+      error: {
+        message: error.message,
+        stack: error.stack,
+        name: error.name,
+      },
+      errorInfo: {
+        componentStack: info.componentStack,
+      },
+    });
+  }
+
+  render() {
+    if (this.state.hasError) {
+      return this.props.fallback;
+    }
+
+    return this.props.children;
+  }
+}


### PR DESCRIPTION
## Description
This PR is to add an error boundary to conversation layout, so that if there is an uncaught error in client side inside the conversation UI tree, the app won't crush and we show an error message.

based on https://react.dev/reference/react/Component#catching-rendering-errors-with-an-error-boundary & https://nextjs.org/docs/14/pages/building-your-application/configuring/error-handling

I will add the error boundary for other places in the app in a separate PR 

<img width="1297" height="927" alt="Screenshot 2025-08-29 at 10 27 27" src="https://github.com/user-attachments/assets/52cbfd04-2465-4d9c-9693-66c45cf458a5" />

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->
- I manually throw an error, and check if the error is displayed or not.
- In dev mode you see uncaught error overlay but if you close it you should see the actual UI

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
