### PR TITLE
[extension] Fix citations and clipboard

### DIFF
--- a/extension/ui/components/conversation/UserMessage.tsx
+++ b/extension/ui/components/conversation/UserMessage.tsx
@@ -49,7 +49,7 @@ export function UserMessage({
 
   return (
     <div className="flex flex-grow flex-col">
-      <div className="self-end max-w-[85%]">
+      <div className="self-end max-w-[85%] min-w-60">
         <ConversationMessage
           pictureUrl={message.user?.image || message.context.profilePictureUrl}
           name={message.context.fullName ?? undefined}

--- a/extension/ui/components/markdown/CiteBlock.tsx
+++ b/extension/ui/components/markdown/CiteBlock.tsx
@@ -100,7 +100,9 @@ export function getCiteDirective() {
           const references = node.children[0]?.value
             .split(",")
             .map((s: string) => s.trim())
-            .filter((s: string) => s.length == 2)
+            // Citations used to be 2 characters long, but are now 3 characters long.
+            // We support both for backward compatibility.
+            .filter((s: string) => s.length === 2 || s.length === 3)
             .map((ref: string) => ({
               counter: counter(ref),
               ref,


### PR DESCRIPTION
## Description

- Citations with 3 chars refs were not supported in extension, allow support for them
- Clipboard copy now shows "copied" icon and parses citations (code `handleCopyToClipboard` copied from front)
- Fixing user message min width

## Tests

locally

## Risk


none

## Deploy Plan

publish 