### PR TITLE
[front] Add `useFullChainOfThought` flag to control handling between side panel and message

### DIFF
--- a/front/components/assistant/conversation/AgentMessage.tsx
+++ b/front/components/assistant/conversation/AgentMessage.tsx
@@ -144,6 +144,7 @@ export function AgentMessage({
       [showBlockedActionsDialog, enqueueBlockedAction, message]
     ),
     streamId: `message-${message.sId}`,
+    useFullChainOfThought: false,
   });
 
   const agentMessageToRender = getAgentMessageToRender({

--- a/front/components/assistant/conversation/actions/AgentActionsPanel.tsx
+++ b/front/components/assistant/conversation/actions/AgentActionsPanel.tsx
@@ -56,6 +56,7 @@ function AgentActionsPanelContent({
         [currentStreamingStep]
       ),
       streamId: `actions-panel-${messageId}`,
+      useFullChainOfThought: true,
     });
 
   useEffect(() => {

--- a/front/components/assistant/conversation/actions/AgentMessageActions.tsx
+++ b/front/components/assistant/conversation/actions/AgentMessageActions.tsx
@@ -46,10 +46,7 @@ export function AgentMessageActions({
     (isAgentMessageWithActions && agentMessage.actions.length > 0) ||
     agentMessage.chainOfThought;
 
-  const fullChainOfThought = agentMessage.chainOfThought || "";
-  const paragraphs = fullChainOfThought.split("\n\n");
-  const chainOfThought =
-    paragraphs.slice(paragraphs.length - 2).join("\n\n") || "";
+  const chainOfThought = agentMessage.chainOfThought || "";
 
   const onClick = () => {
     openPanel({

--- a/front/lib/assistant/state/messageReducer.ts
+++ b/front/lib/assistant/state/messageReducer.ts
@@ -29,6 +29,7 @@ export interface MessageTemporaryState {
   isRetrying: boolean;
   lastUpdated: Date;
   actionProgress: ActionProgressState;
+  useFullChainOfThought: boolean;
 }
 
 export type AgentMessageStateEvent = (
@@ -174,8 +175,13 @@ export function messageReducer(
           newState.agentState = "writing";
           break;
         case "chain_of_thought":
-          newState.message.chainOfThought =
-            (newState.message.chainOfThought || "") + event.text;
+          // If we're not using the full chain of thought, reset at paragraph boundaries.
+          if (!state.useFullChainOfThought && event.text === "\n\n") {
+            newState.message.chainOfThought = "";
+          } else {
+            newState.message.chainOfThought =
+              (newState.message.chainOfThought || "") + event.text;
+          }
           newState.agentState = "thinking";
           break;
         default:


### PR DESCRIPTION
## Description

- Further improvement on https://github.com/dust-tt/dust/pull/15507.
- This PR improves the way CoT are streamed between the side panel and the message, specifically for GPT5.
- The paragraph delimitation is handled a bit more cleanly (relies on the injected `"\n\n"` block).

https://github.com/user-attachments/assets/b41145eb-d1d3-48f6-b308-f05d40fb099a

## Tests

- Tested locally.

## Risk

- Low.

## Deploy Plan

- Deploy front.
