### PR TITLE
[front] Uniformize interface for tool execution detail components

### DIFF
--- a/front/components/actions/mcp/details/MCPActionDetails.tsx
+++ b/front/components/actions/mcp/details/MCPActionDetails.tsx
@@ -24,7 +24,6 @@ import { MCPReasoningActionDetails } from "@app/components/actions/mcp/details/M
 import { MCPRunAgentActionDetails } from "@app/components/actions/mcp/details/MCPRunAgentActionDetails";
 import { MCPTablesQueryActionDetails } from "@app/components/actions/mcp/details/MCPTablesQueryActionDetails";
 import { SearchResultDetails } from "@app/components/actions/mcp/details/MCPToolOutputDetails";
-import type { MCPActionType } from "@app/lib/actions/mcp";
 import {
   DATA_WAREHOUSES_DESCRIBE_TABLES_TOOL_NAME,
   DATA_WAREHOUSES_FIND_TOOL_NAME,
@@ -61,7 +60,7 @@ import {
 import type { AgentMCPActionWithOutputType } from "@app/types/actions";
 
 export interface MCPActionDetailsProps {
-  action: MCPActionType | AgentMCPActionWithOutputType;
+  action: AgentMCPActionWithOutputType;
   owner: LightWorkspaceType;
   lastNotification: ProgressNotificationContentType | null;
   messageStatus?: "created" | "succeeded" | "failed" | "cancelled";

--- a/front/components/actions/mcp/details/MCPActionDetails.tsx
+++ b/front/components/actions/mcp/details/MCPActionDetails.tsx
@@ -25,7 +25,7 @@ import { MCPReasoningActionDetails } from "@app/components/actions/mcp/details/M
 import { MCPRunAgentActionDetails } from "@app/components/actions/mcp/details/MCPRunAgentActionDetails";
 import { MCPTablesQueryActionDetails } from "@app/components/actions/mcp/details/MCPTablesQueryActionDetails";
 import { SearchResultDetails } from "@app/components/actions/mcp/details/MCPToolOutputDetails";
-import type { ToolOutputDetailsProps } from "@app/components/actions/mcp/details/types";
+import type { ToolExecutionDetailsProps } from "@app/components/actions/mcp/details/types";
 import {
   DATA_WAREHOUSES_DESCRIBE_TABLES_TOOL_NAME,
   DATA_WAREHOUSES_FIND_TOOL_NAME,
@@ -81,7 +81,7 @@ export function MCPActionDetails({
   const parts = functionCallName ? functionCallName.split("__") : [];
   const toolName = parts[parts.length - 1];
 
-  const toolOutputDetailsProps: ToolOutputDetailsProps = {
+  const toolOutputDetailsProps: ToolExecutionDetailsProps = {
     lastNotification,
     messageStatus,
     owner,

--- a/front/components/actions/mcp/details/MCPActionDetails.tsx
+++ b/front/components/actions/mcp/details/MCPActionDetails.tsx
@@ -25,6 +25,7 @@ import { MCPReasoningActionDetails } from "@app/components/actions/mcp/details/M
 import { MCPRunAgentActionDetails } from "@app/components/actions/mcp/details/MCPRunAgentActionDetails";
 import { MCPTablesQueryActionDetails } from "@app/components/actions/mcp/details/MCPTablesQueryActionDetails";
 import { SearchResultDetails } from "@app/components/actions/mcp/details/MCPToolOutputDetails";
+import type { ToolOutputDetailsProps } from "@app/components/actions/mcp/details/types";
 import {
   DATA_WAREHOUSES_DESCRIBE_TABLES_TOOL_NAME,
   DATA_WAREHOUSES_FIND_TOOL_NAME,
@@ -105,6 +106,15 @@ export function MCPActionDetails({
   const parts = functionCallName ? functionCallName.split("__") : [];
   const toolName = parts[parts.length - 1];
 
+  const toolOutputDetailsProps: ToolOutputDetailsProps = {
+    lastNotification,
+    messageStatus,
+    owner,
+    toolOutput: output,
+    toolParams: params,
+    viewType,
+  };
+
   if (
     internalMCPServerName === "search" ||
     internalMCPServerName === "data_sources_file_system"
@@ -151,27 +161,11 @@ export function MCPActionDetails({
     }
 
     if (toolName === FILESYSTEM_CAT_TOOL_NAME) {
-      return (
-        <DataSourceNodeContentDetails
-          owner={owner}
-          lastNotification={lastNotification}
-          messageStatus={messageStatus}
-          viewType={viewType}
-          action={{ ...action, output }}
-        />
-      );
+      return <DataSourceNodeContentDetails {...toolOutputDetailsProps} />;
     }
 
     if (toolName === FILESYSTEM_LOCATE_IN_TREE_TOOL_NAME) {
-      return (
-        <FilesystemPathDetails
-          owner={owner}
-          lastNotification={lastNotification}
-          messageStatus={messageStatus}
-          viewType={viewType}
-          action={{ ...action, output }}
-        />
-      );
+      return <FilesystemPathDetails {...toolOutputDetailsProps} />;
     }
   }
 
@@ -205,117 +199,45 @@ export function MCPActionDetails({
       );
     }
     if (toolName === WEBBROWSER_TOOL_NAME) {
-      return (
-        <MCPBrowseActionDetails
-          owner={owner}
-          lastNotification={lastNotification}
-          messageStatus={messageStatus}
-          viewType={viewType}
-          action={{ ...action, output }}
-        />
-      );
+      return <MCPBrowseActionDetails {...toolOutputDetailsProps} />;
     }
   }
 
   if (internalMCPServerName === "query_tables") {
     if (toolName === QUERY_TABLES_TOOL_NAME) {
-      return (
-        <MCPTablesQueryActionDetails
-          owner={owner}
-          lastNotification={lastNotification}
-          messageStatus={messageStatus}
-          viewType={viewType}
-          action={{ ...action, output }}
-        />
-      );
+      return <MCPTablesQueryActionDetails {...toolOutputDetailsProps} />;
     }
   }
 
   if (internalMCPServerName === "query_tables_v2") {
     if (toolName === GET_DATABASE_SCHEMA_TOOL_NAME) {
-      return (
-        <MCPGetDatabaseSchemaActionDetails
-          owner={owner}
-          lastNotification={lastNotification}
-          messageStatus={messageStatus}
-          viewType={viewType}
-          action={{ ...action, output }}
-        />
-      );
+      return <MCPGetDatabaseSchemaActionDetails {...toolOutputDetailsProps} />;
     }
     if (toolName === EXECUTE_DATABASE_QUERY_TOOL_NAME) {
-      return (
-        <MCPTablesQueryActionDetails
-          owner={owner}
-          lastNotification={lastNotification}
-          messageStatus={messageStatus}
-          viewType={viewType}
-          action={{ ...action, output }}
-        />
-      );
+      return <MCPTablesQueryActionDetails {...toolOutputDetailsProps} />;
     }
   }
 
   if (internalMCPServerName === "reasoning") {
-    return (
-      <MCPReasoningActionDetails
-        owner={owner}
-        lastNotification={lastNotification}
-        messageStatus={messageStatus}
-        viewType={viewType}
-        action={{ ...action, output }}
-      />
-    );
+    return <MCPReasoningActionDetails {...toolOutputDetailsProps} />;
   }
 
   if (internalMCPServerName === "extract_data") {
     if (toolName === PROCESS_TOOL_NAME) {
-      return (
-        <MCPExtractActionDetails
-          owner={owner}
-          lastNotification={lastNotification}
-          messageStatus={messageStatus}
-          viewType={viewType}
-          action={{ ...action, output }}
-        />
-      );
+      return <MCPExtractActionDetails {...toolOutputDetailsProps} />;
     }
   }
 
   if (internalMCPServerName === "run_agent") {
-    return (
-      <MCPRunAgentActionDetails
-        owner={owner}
-        lastNotification={lastNotification}
-        messageStatus={messageStatus}
-        viewType={viewType}
-        action={{ ...action, output }}
-      />
-    );
+    return <MCPRunAgentActionDetails {...toolOutputDetailsProps} />;
   }
 
   if (internalMCPServerName === "toolsets") {
-    return (
-      <MCPListToolsActionDetails
-        owner={owner}
-        lastNotification={lastNotification}
-        messageStatus={messageStatus}
-        viewType={viewType}
-        action={{ ...action, output }}
-      />
-    );
+    return <MCPListToolsActionDetails {...toolOutputDetailsProps} />;
   }
 
   if (internalMCPServerName === "agent_management") {
-    return (
-      <MCPAgentManagementActionDetails
-        owner={owner}
-        lastNotification={lastNotification}
-        messageStatus={messageStatus}
-        viewType={viewType}
-        action={{ ...action, output }}
-      />
-    );
+    return <MCPAgentManagementActionDetails {...toolOutputDetailsProps} />;
   }
 
   if (internalMCPServerName === "data_warehouses") {
@@ -324,37 +246,13 @@ export function MCPActionDetails({
         toolName
       )
     ) {
-      return (
-        <MCPDataWarehousesBrowseDetails
-          owner={owner}
-          lastNotification={lastNotification}
-          messageStatus={messageStatus}
-          viewType={viewType}
-          action={{ ...action, output }}
-        />
-      );
+      return <MCPDataWarehousesBrowseDetails {...toolOutputDetailsProps} />;
     }
     if (toolName === DATA_WAREHOUSES_DESCRIBE_TABLES_TOOL_NAME) {
-      return (
-        <MCPGetDatabaseSchemaActionDetails
-          owner={owner}
-          lastNotification={lastNotification}
-          messageStatus={messageStatus}
-          viewType={viewType}
-          action={{ ...action, output }}
-        />
-      );
+      return <MCPGetDatabaseSchemaActionDetails {...toolOutputDetailsProps} />;
     }
     if (toolName === DATA_WAREHOUSES_QUERY_TOOL_NAME) {
-      return (
-        <MCPTablesQueryActionDetails
-          owner={owner}
-          lastNotification={lastNotification}
-          messageStatus={messageStatus}
-          viewType={viewType}
-          action={{ ...action, output }}
-        />
-      );
+      return <MCPTablesQueryActionDetails {...toolOutputDetailsProps} />;
     }
   }
 

--- a/front/components/actions/mcp/details/MCPActionDetails.tsx
+++ b/front/components/actions/mcp/details/MCPActionDetails.tsx
@@ -8,6 +8,7 @@ import {
   MagnifyingGlassIcon,
   Markdown,
 } from "@dust-tt/sparkle";
+import { useEffect, useState } from "react";
 
 import { ActionDetailsWrapper } from "@app/components/actions/ActionDetailsWrapper";
 import { MCPAgentManagementActionDetails } from "@app/components/actions/mcp/details/MCPAgentManagementActionDetails";
@@ -67,11 +68,39 @@ export interface MCPActionDetailsProps {
   viewType: "conversation" | "sidebar";
 }
 
-export function MCPActionDetails(props: MCPActionDetailsProps) {
+export function MCPActionDetails({
+  action,
+  viewType,
+  owner,
+  lastNotification,
+  messageStatus,
+}: MCPActionDetailsProps) {
   const {
-    action: { output, functionCallName, internalMCPServerName, params },
-    viewType,
-  } = props;
+    functionCallName,
+    internalMCPServerName,
+    params,
+    status,
+    output: baseOutput,
+  } = action;
+
+  const [output, setOutput] = useState(baseOutput);
+
+  useEffect(() => {
+    if (status === "denied") {
+      const deniedMessage = {
+        type: "text" as const,
+        text: "Tool execution rejected by the user.",
+      };
+
+      if (baseOutput === null) {
+        setOutput([deniedMessage]);
+      } else {
+        setOutput([...baseOutput, deniedMessage]);
+      }
+    } else {
+      setOutput(baseOutput);
+    }
+  }, [status, baseOutput]);
 
   const parts = functionCallName ? functionCallName.split("__") : [];
   const toolName = parts[parts.length - 1];
@@ -122,11 +151,27 @@ export function MCPActionDetails(props: MCPActionDetailsProps) {
     }
 
     if (toolName === FILESYSTEM_CAT_TOOL_NAME) {
-      return <DataSourceNodeContentDetails {...props} />;
+      return (
+        <DataSourceNodeContentDetails
+          owner={owner}
+          lastNotification={lastNotification}
+          messageStatus={messageStatus}
+          viewType={viewType}
+          action={{ ...action, output }}
+        />
+      );
     }
 
     if (toolName === FILESYSTEM_LOCATE_IN_TREE_TOOL_NAME) {
-      return <FilesystemPathDetails {...props} />;
+      return (
+        <FilesystemPathDetails
+          owner={owner}
+          lastNotification={lastNotification}
+          messageStatus={messageStatus}
+          viewType={viewType}
+          action={{ ...action, output }}
+        />
+      );
     }
   }
 
@@ -160,45 +205,117 @@ export function MCPActionDetails(props: MCPActionDetailsProps) {
       );
     }
     if (toolName === WEBBROWSER_TOOL_NAME) {
-      return <MCPBrowseActionDetails {...props} />;
+      return (
+        <MCPBrowseActionDetails
+          owner={owner}
+          lastNotification={lastNotification}
+          messageStatus={messageStatus}
+          viewType={viewType}
+          action={{ ...action, output }}
+        />
+      );
     }
   }
 
   if (internalMCPServerName === "query_tables") {
     if (toolName === QUERY_TABLES_TOOL_NAME) {
-      return <MCPTablesQueryActionDetails {...props} />;
+      return (
+        <MCPTablesQueryActionDetails
+          owner={owner}
+          lastNotification={lastNotification}
+          messageStatus={messageStatus}
+          viewType={viewType}
+          action={{ ...action, output }}
+        />
+      );
     }
   }
 
   if (internalMCPServerName === "query_tables_v2") {
     if (toolName === GET_DATABASE_SCHEMA_TOOL_NAME) {
-      return <MCPGetDatabaseSchemaActionDetails {...props} />;
+      return (
+        <MCPGetDatabaseSchemaActionDetails
+          owner={owner}
+          lastNotification={lastNotification}
+          messageStatus={messageStatus}
+          viewType={viewType}
+          action={{ ...action, output }}
+        />
+      );
     }
     if (toolName === EXECUTE_DATABASE_QUERY_TOOL_NAME) {
-      return <MCPTablesQueryActionDetails {...props} />;
+      return (
+        <MCPTablesQueryActionDetails
+          owner={owner}
+          lastNotification={lastNotification}
+          messageStatus={messageStatus}
+          viewType={viewType}
+          action={{ ...action, output }}
+        />
+      );
     }
   }
 
   if (internalMCPServerName === "reasoning") {
-    return <MCPReasoningActionDetails {...props} />;
+    return (
+      <MCPReasoningActionDetails
+        owner={owner}
+        lastNotification={lastNotification}
+        messageStatus={messageStatus}
+        viewType={viewType}
+        action={{ ...action, output }}
+      />
+    );
   }
 
   if (internalMCPServerName === "extract_data") {
     if (toolName === PROCESS_TOOL_NAME) {
-      return <MCPExtractActionDetails {...props} />;
+      return (
+        <MCPExtractActionDetails
+          owner={owner}
+          lastNotification={lastNotification}
+          messageStatus={messageStatus}
+          viewType={viewType}
+          action={{ ...action, output }}
+        />
+      );
     }
   }
 
   if (internalMCPServerName === "run_agent") {
-    return <MCPRunAgentActionDetails {...props} />;
+    return (
+      <MCPRunAgentActionDetails
+        owner={owner}
+        lastNotification={lastNotification}
+        messageStatus={messageStatus}
+        viewType={viewType}
+        action={{ ...action, output }}
+      />
+    );
   }
 
   if (internalMCPServerName === "toolsets") {
-    return <MCPListToolsActionDetails {...props} />;
+    return (
+      <MCPListToolsActionDetails
+        owner={owner}
+        lastNotification={lastNotification}
+        messageStatus={messageStatus}
+        viewType={viewType}
+        action={{ ...action, output }}
+      />
+    );
   }
 
   if (internalMCPServerName === "agent_management") {
-    return <MCPAgentManagementActionDetails {...props} />;
+    return (
+      <MCPAgentManagementActionDetails
+        owner={owner}
+        lastNotification={lastNotification}
+        messageStatus={messageStatus}
+        viewType={viewType}
+        action={{ ...action, output }}
+      />
+    );
   }
 
   if (internalMCPServerName === "data_warehouses") {
@@ -207,17 +324,49 @@ export function MCPActionDetails(props: MCPActionDetailsProps) {
         toolName
       )
     ) {
-      return <MCPDataWarehousesBrowseDetails {...props} />;
+      return (
+        <MCPDataWarehousesBrowseDetails
+          owner={owner}
+          lastNotification={lastNotification}
+          messageStatus={messageStatus}
+          viewType={viewType}
+          action={{ ...action, output }}
+        />
+      );
     }
     if (toolName === DATA_WAREHOUSES_DESCRIBE_TABLES_TOOL_NAME) {
-      return <MCPGetDatabaseSchemaActionDetails {...props} />;
+      return (
+        <MCPGetDatabaseSchemaActionDetails
+          owner={owner}
+          lastNotification={lastNotification}
+          messageStatus={messageStatus}
+          viewType={viewType}
+          action={{ ...action, output }}
+        />
+      );
     }
     if (toolName === DATA_WAREHOUSES_QUERY_TOOL_NAME) {
-      return <MCPTablesQueryActionDetails {...props} />;
+      return (
+        <MCPTablesQueryActionDetails
+          owner={owner}
+          lastNotification={lastNotification}
+          messageStatus={messageStatus}
+          viewType={viewType}
+          action={{ ...action, output }}
+        />
+      );
     }
   }
 
-  return <GenericActionDetails {...props} />;
+  return (
+    <GenericActionDetails
+      owner={owner}
+      lastNotification={lastNotification}
+      messageStatus={messageStatus}
+      viewType={viewType}
+      action={{ ...action, output }}
+    />
+  );
 }
 
 export function GenericActionDetails({

--- a/front/components/actions/mcp/details/MCPActionDetails.tsx
+++ b/front/components/actions/mcp/details/MCPActionDetails.tsx
@@ -8,7 +8,6 @@ import {
   MagnifyingGlassIcon,
   Markdown,
 } from "@dust-tt/sparkle";
-import { useEffect, useState } from "react";
 
 import { ActionDetailsWrapper } from "@app/components/actions/ActionDetailsWrapper";
 import { MCPAgentManagementActionDetails } from "@app/components/actions/mcp/details/MCPAgentManagementActionDetails";

--- a/front/components/actions/mcp/details/MCPActionDetails.tsx
+++ b/front/components/actions/mcp/details/MCPActionDetails.tsx
@@ -76,32 +76,7 @@ export function MCPActionDetails({
   lastNotification,
   messageStatus,
 }: MCPActionDetailsProps) {
-  const {
-    functionCallName,
-    internalMCPServerName,
-    params,
-    status,
-    output: baseOutput,
-  } = action;
-
-  const [output, setOutput] = useState(baseOutput);
-
-  useEffect(() => {
-    if (status === "denied") {
-      const deniedMessage = {
-        type: "text" as const,
-        text: "Tool execution rejected by the user.",
-      };
-
-      if (baseOutput === null) {
-        setOutput([deniedMessage]);
-      } else {
-        setOutput([...baseOutput, deniedMessage]);
-      }
-    } else {
-      setOutput(baseOutput);
-    }
-  }, [status, baseOutput]);
+  const { functionCallName, internalMCPServerName, params, output } = action;
 
   const parts = functionCallName ? functionCallName.split("__") : [];
   const toolName = parts[parts.length - 1];

--- a/front/components/actions/mcp/details/MCPAgentManagementActionDetails.tsx
+++ b/front/components/actions/mcp/details/MCPAgentManagementActionDetails.tsx
@@ -11,16 +11,17 @@ import { useEffect, useRef } from "react";
 import { useSWRConfig } from "swr";
 
 import { ActionDetailsWrapper } from "@app/components/actions/ActionDetailsWrapper";
-import type { MCPActionDetailsProps } from "@app/components/actions/mcp/details/MCPActionDetails";
+import type { ToolOutputDetailsProps } from "@app/components/actions/mcp/details/types";
 import { isAgentCreationResultResourceType } from "@app/lib/actions/mcp_internal_actions/output_schemas";
 
 export function MCPAgentManagementActionDetails({
-  action,
+  toolOutput,
+  toolParams,
   viewType,
   owner,
   messageStatus,
-}: MCPActionDetailsProps) {
-  const creationResult = action.output?.find(isAgentCreationResultResourceType);
+}: ToolOutputDetailsProps) {
+  const creationResult = toolOutput?.find(isAgentCreationResultResourceType);
   const { mutate } = useSWRConfig();
   const hasRefreshed = useRef(false);
 
@@ -62,7 +63,7 @@ export function MCPAgentManagementActionDetails({
           <ContentMessage variant="primary" size="lg">
             <Markdown
               content={
-                action.output
+                toolOutput
                   ?.map((o) => (o.type === "text" ? o.text : ""))
                   .join("\n") || "Agent creation completed."
               }
@@ -108,7 +109,7 @@ export function MCPAgentManagementActionDetails({
             </ul>
           </div>
 
-          {typeof action.params.instructions === "string" ? (
+          {typeof toolParams.instructions === "string" ? (
             <CollapsibleComponent
               triggerChildren={
                 <span className="text-sm font-medium text-foreground dark:text-foreground-night">
@@ -118,7 +119,7 @@ export function MCPAgentManagementActionDetails({
               contentChildren={
                 <div className="mt-2">
                   <ContentMessage variant="primary" size="sm">
-                    <Markdown content={action.params.instructions} />
+                    <Markdown content={toolParams.instructions} />
                   </ContentMessage>
                 </div>
               }
@@ -164,7 +165,7 @@ export function MCPAgentManagementActionDetails({
                 </p>
               </div>
 
-              {typeof action.params.sub_agent_instructions === "string" ? (
+              {typeof toolParams.sub_agent_instructions === "string" ? (
                 <CollapsibleComponent
                   triggerChildren={
                     <span className="text-sm font-medium text-foreground dark:text-foreground-night">
@@ -174,9 +175,7 @@ export function MCPAgentManagementActionDetails({
                   contentChildren={
                     <div className="mt-2">
                       <ContentMessage variant="primary" size="sm">
-                        <Markdown
-                          content={action.params.sub_agent_instructions}
-                        />
+                        <Markdown content={toolParams.sub_agent_instructions} />
                       </ContentMessage>
                     </div>
                   }

--- a/front/components/actions/mcp/details/MCPAgentManagementActionDetails.tsx
+++ b/front/components/actions/mcp/details/MCPAgentManagementActionDetails.tsx
@@ -11,7 +11,7 @@ import { useEffect, useRef } from "react";
 import { useSWRConfig } from "swr";
 
 import { ActionDetailsWrapper } from "@app/components/actions/ActionDetailsWrapper";
-import type { ToolOutputDetailsProps } from "@app/components/actions/mcp/details/types";
+import type { ToolExecutionDetailsProps } from "@app/components/actions/mcp/details/types";
 import { isAgentCreationResultResourceType } from "@app/lib/actions/mcp_internal_actions/output_schemas";
 
 export function MCPAgentManagementActionDetails({
@@ -20,7 +20,7 @@ export function MCPAgentManagementActionDetails({
   viewType,
   owner,
   messageStatus,
-}: ToolOutputDetailsProps) {
+}: ToolExecutionDetailsProps) {
   const creationResult = toolOutput?.find(isAgentCreationResultResourceType);
   const { mutate } = useSWRConfig();
   const hasRefreshed = useRef(false);

--- a/front/components/actions/mcp/details/MCPBrowseActionDetails.tsx
+++ b/front/components/actions/mcp/details/MCPBrowseActionDetails.tsx
@@ -1,14 +1,14 @@
 import { Button, GlobeAltIcon } from "@dust-tt/sparkle";
 
 import { ActionDetailsWrapper } from "@app/components/actions/ActionDetailsWrapper";
-import type { ToolOutputDetailsProps } from "@app/components/actions/mcp/details/types";
+import type { ToolExecutionDetailsProps } from "@app/components/actions/mcp/details/types";
 import { isBrowseResultResourceType } from "@app/lib/actions/mcp_internal_actions/output_schemas";
 
 export function MCPBrowseActionDetails({
   toolOutput,
   toolParams,
   viewType,
-}: ToolOutputDetailsProps) {
+}: ToolExecutionDetailsProps) {
   const urls = toolParams.urls as string[];
   const browseResults =
     toolOutput?.filter(isBrowseResultResourceType).map((o) => o.resource) ?? [];

--- a/front/components/actions/mcp/details/MCPBrowseActionDetails.tsx
+++ b/front/components/actions/mcp/details/MCPBrowseActionDetails.tsx
@@ -1,17 +1,17 @@
 import { Button, GlobeAltIcon } from "@dust-tt/sparkle";
 
 import { ActionDetailsWrapper } from "@app/components/actions/ActionDetailsWrapper";
-import type { MCPActionDetailsProps } from "@app/components/actions/mcp/details/MCPActionDetails";
+import type { ToolOutputDetailsProps } from "@app/components/actions/mcp/details/types";
 import { isBrowseResultResourceType } from "@app/lib/actions/mcp_internal_actions/output_schemas";
 
 export function MCPBrowseActionDetails({
-  action,
+  toolOutput,
+  toolParams,
   viewType,
-}: MCPActionDetailsProps) {
-  const urls = action.params.urls as string[];
+}: ToolOutputDetailsProps) {
+  const urls = toolParams.urls as string[];
   const browseResults =
-    action.output?.filter(isBrowseResultResourceType).map((o) => o.resource) ??
-    [];
+    toolOutput?.filter(isBrowseResultResourceType).map((o) => o.resource) ?? [];
 
   return (
     <ActionDetailsWrapper

--- a/front/components/actions/mcp/details/MCPDataSourcesFileSystemActionDetails.tsx
+++ b/front/components/actions/mcp/details/MCPDataSourcesFileSystemActionDetails.tsx
@@ -11,7 +11,7 @@ import {
 } from "@dust-tt/sparkle";
 
 import { ActionDetailsWrapper } from "@app/components/actions/ActionDetailsWrapper";
-import type { ToolOutputDetailsProps } from "@app/components/actions/mcp/details/types";
+import type { ToolExecutionDetailsProps } from "@app/components/actions/mcp/details/types";
 import {
   isDataSourceNodeContentType,
   isFilesystemPathType,
@@ -25,7 +25,7 @@ import { formatDataSourceDisplayName } from "@app/types";
 export function DataSourceNodeContentDetails({
   toolOutput,
   viewType,
-}: ToolOutputDetailsProps) {
+}: ToolExecutionDetailsProps) {
   const dataSourceNodeContent = toolOutput
     ?.filter(isDataSourceNodeContentType)
     .map((o) => o.resource)?.[0];
@@ -76,7 +76,7 @@ export function DataSourceNodeContentDetails({
 export function FilesystemPathDetails({
   toolOutput,
   viewType,
-}: ToolOutputDetailsProps) {
+}: ToolExecutionDetailsProps) {
   const filesystemPath = toolOutput
     ?.filter(isFilesystemPathType)
     .map((o) => o.resource)?.[0];

--- a/front/components/actions/mcp/details/MCPDataSourcesFileSystemActionDetails.tsx
+++ b/front/components/actions/mcp/details/MCPDataSourcesFileSystemActionDetails.tsx
@@ -1,27 +1,32 @@
 import type { BreadcrumbItem } from "@dust-tt/sparkle";
-import { ActionPinDistanceIcon } from "@dust-tt/sparkle";
 import {
+  ActionPinDistanceIcon,
+  Breadcrumbs,
   Citation,
   CitationIcons,
   CitationTitle,
+  DocumentIcon,
   Icon,
   Markdown,
 } from "@dust-tt/sparkle";
-import { Breadcrumbs, DocumentIcon } from "@dust-tt/sparkle";
 
 import { ActionDetailsWrapper } from "@app/components/actions/ActionDetailsWrapper";
-import type { MCPActionDetailsProps } from "@app/components/actions/mcp/details/MCPActionDetails";
-import { isDataSourceNodeContentType } from "@app/lib/actions/mcp_internal_actions/output_schemas";
-import { isFilesystemPathType } from "@app/lib/actions/mcp_internal_actions/output_schemas";
-import { getDocumentIcon } from "@app/lib/content_nodes";
-import { getVisualForContentNodeType } from "@app/lib/content_nodes";
+import type { ToolOutputDetailsProps } from "@app/components/actions/mcp/details/types";
+import {
+  isDataSourceNodeContentType,
+  isFilesystemPathType,
+} from "@app/lib/actions/mcp_internal_actions/output_schemas";
+import {
+  getDocumentIcon,
+  getVisualForContentNodeType,
+} from "@app/lib/content_nodes";
 import { formatDataSourceDisplayName } from "@app/types";
 
 export function DataSourceNodeContentDetails({
-  action,
+  toolOutput,
   viewType,
-}: MCPActionDetailsProps) {
-  const dataSourceNodeContent = action.output
+}: ToolOutputDetailsProps) {
+  const dataSourceNodeContent = toolOutput
     ?.filter(isDataSourceNodeContentType)
     .map((o) => o.resource)?.[0];
 
@@ -69,10 +74,10 @@ export function DataSourceNodeContentDetails({
 }
 
 export function FilesystemPathDetails({
-  action,
+  toolOutput,
   viewType,
-}: MCPActionDetailsProps) {
-  const filesystemPath = action.output
+}: ToolOutputDetailsProps) {
+  const filesystemPath = toolOutput
     ?.filter(isFilesystemPathType)
     .map((o) => o.resource)?.[0];
 

--- a/front/components/actions/mcp/details/MCPDataWarehousesBrowseDetails.tsx
+++ b/front/components/actions/mcp/details/MCPDataWarehousesBrowseDetails.tsx
@@ -7,14 +7,14 @@ import {
 } from "@dust-tt/sparkle";
 
 import { ActionDetailsWrapper } from "@app/components/actions/ActionDetailsWrapper";
-import type { ToolOutputDetailsProps } from "@app/components/actions/mcp/details/types";
+import type { ToolExecutionDetailsProps } from "@app/components/actions/mcp/details/types";
 import { isWarehousesBrowseType } from "@app/lib/actions/mcp_internal_actions/output_schemas";
 import { getDocumentIcon } from "@app/lib/content_nodes";
 
 export function MCPDataWarehousesBrowseDetails({
   toolOutput,
   viewType,
-}: ToolOutputDetailsProps) {
+}: ToolExecutionDetailsProps) {
   const browseResult = toolOutput
     ?.filter(isWarehousesBrowseType)
     .map((o) => o.resource)?.[0];

--- a/front/components/actions/mcp/details/MCPDataWarehousesBrowseDetails.tsx
+++ b/front/components/actions/mcp/details/MCPDataWarehousesBrowseDetails.tsx
@@ -7,15 +7,15 @@ import {
 } from "@dust-tt/sparkle";
 
 import { ActionDetailsWrapper } from "@app/components/actions/ActionDetailsWrapper";
-import type { MCPActionDetailsProps } from "@app/components/actions/mcp/details/MCPActionDetails";
+import type { ToolOutputDetailsProps } from "@app/components/actions/mcp/details/types";
 import { isWarehousesBrowseType } from "@app/lib/actions/mcp_internal_actions/output_schemas";
 import { getDocumentIcon } from "@app/lib/content_nodes";
 
 export function MCPDataWarehousesBrowseDetails({
-  action,
+  toolOutput,
   viewType,
-}: MCPActionDetailsProps) {
-  const browseResult = action.output
+}: ToolOutputDetailsProps) {
+  const browseResult = toolOutput
     ?.filter(isWarehousesBrowseType)
     .map((o) => o.resource)?.[0];
 

--- a/front/components/actions/mcp/details/MCPExtractActionDetails.tsx
+++ b/front/components/actions/mcp/details/MCPExtractActionDetails.tsx
@@ -12,7 +12,6 @@ import { useState } from "react";
 
 import { ActionDetailsWrapper } from "@app/components/actions/ActionDetailsWrapper";
 import type { MCPActionDetailsProps } from "@app/components/actions/mcp/details/MCPActionDetails";
-import type { MCPActionType } from "@app/lib/actions/mcp";
 import {
   isExtractQueryResourceType,
   isExtractResultResourceType,
@@ -21,7 +20,7 @@ import type { AgentMCPActionWithOutputType } from "@app/types/actions";
 import { isTimeFrame } from "@app/types/shared/utils/time_frame";
 
 interface MCPExtractActionQueryProps {
-  action: MCPActionType | AgentMCPActionWithOutputType;
+  action: AgentMCPActionWithOutputType;
   queryResource?: {
     text: string;
     mimeType: string;

--- a/front/components/actions/mcp/details/MCPExtractActionDetails.tsx
+++ b/front/components/actions/mcp/details/MCPExtractActionDetails.tsx
@@ -11,16 +11,15 @@ import type { JSONSchema7 as JSONSchema } from "json-schema";
 import { useState } from "react";
 
 import { ActionDetailsWrapper } from "@app/components/actions/ActionDetailsWrapper";
-import type { MCPActionDetailsProps } from "@app/components/actions/mcp/details/MCPActionDetails";
+import type { ToolOutputDetailsProps } from "@app/components/actions/mcp/details/types";
 import {
   isExtractQueryResourceType,
   isExtractResultResourceType,
 } from "@app/lib/actions/mcp_internal_actions/output_schemas";
-import type { AgentMCPActionWithOutputType } from "@app/types/actions";
 import { isTimeFrame } from "@app/types/shared/utils/time_frame";
 
 interface MCPExtractActionQueryProps {
-  action: AgentMCPActionWithOutputType;
+  toolParams: Record<string, unknown>;
   queryResource?: {
     text: string;
     mimeType: string;
@@ -41,18 +40,19 @@ interface MCPExtractActionResultsProps {
 }
 
 export function MCPExtractActionDetails({
-  action,
+  toolParams,
+  toolOutput,
   viewType,
-}: MCPActionDetailsProps) {
-  const queryResource = action.output
+}: ToolOutputDetailsProps) {
+  const queryResource = toolOutput
     ?.filter(isExtractQueryResourceType)
     .map((o) => o.resource)?.[0];
 
-  const resultResource = action.output
+  const resultResource = toolOutput
     ?.filter(isExtractResultResourceType)
     .map((o) => o.resource)?.[0];
 
-  const jsonSchema = action.params?.jsonSchema as JSONSchema | undefined;
+  const jsonSchema = toolParams?.jsonSchema as JSONSchema | undefined;
 
   return (
     <ActionDetailsWrapper
@@ -68,7 +68,7 @@ export function MCPExtractActionDetails({
             Query
           </span>
           <MCPExtractActionQuery
-            action={action}
+            toolParams={toolParams}
             queryResource={queryResource}
           />
         </div>
@@ -117,10 +117,10 @@ export function MCPExtractActionDetails({
 }
 
 function MCPExtractActionQuery({
-  action,
+  toolParams,
   queryResource,
 }: MCPExtractActionQueryProps) {
-  const timeFrameParam = action.params?.timeFrame;
+  const timeFrameParam = toolParams?.timeFrame;
 
   if (queryResource) {
     return (

--- a/front/components/actions/mcp/details/MCPExtractActionDetails.tsx
+++ b/front/components/actions/mcp/details/MCPExtractActionDetails.tsx
@@ -11,7 +11,7 @@ import type { JSONSchema7 as JSONSchema } from "json-schema";
 import { useState } from "react";
 
 import { ActionDetailsWrapper } from "@app/components/actions/ActionDetailsWrapper";
-import type { ToolOutputDetailsProps } from "@app/components/actions/mcp/details/types";
+import type { ToolExecutionDetailsProps } from "@app/components/actions/mcp/details/types";
 import {
   isExtractQueryResourceType,
   isExtractResultResourceType,
@@ -43,7 +43,7 @@ export function MCPExtractActionDetails({
   toolParams,
   toolOutput,
   viewType,
-}: ToolOutputDetailsProps) {
+}: ToolExecutionDetailsProps) {
   const queryResource = toolOutput
     ?.filter(isExtractQueryResourceType)
     .map((o) => o.resource)?.[0];

--- a/front/components/actions/mcp/details/MCPGetDatabaseSchemaActionDetails.tsx
+++ b/front/components/actions/mcp/details/MCPGetDatabaseSchemaActionDetails.tsx
@@ -1,7 +1,7 @@
 import { CodeBlock, CollapsibleComponent, TableIcon } from "@dust-tt/sparkle";
 
 import { ActionDetailsWrapper } from "@app/components/actions/ActionDetailsWrapper";
-import type { ToolOutputDetailsProps } from "@app/components/actions/mcp/details/types";
+import type { ToolExecutionDetailsProps } from "@app/components/actions/mcp/details/types";
 import type {
   DatabaseSchemaResourceType,
   ExampleRowsResourceType,
@@ -14,7 +14,7 @@ import {
 export function MCPGetDatabaseSchemaActionDetails({
   toolOutput,
   viewType,
-}: ToolOutputDetailsProps) {
+}: ToolExecutionDetailsProps) {
   // Extract different types of outputs
   const schemaBlocks =
     toolOutput?.filter(isDatabaseSchemaResourceType).map((o) => o.resource) ??

--- a/front/components/actions/mcp/details/MCPGetDatabaseSchemaActionDetails.tsx
+++ b/front/components/actions/mcp/details/MCPGetDatabaseSchemaActionDetails.tsx
@@ -1,7 +1,7 @@
 import { CodeBlock, CollapsibleComponent, TableIcon } from "@dust-tt/sparkle";
 
 import { ActionDetailsWrapper } from "@app/components/actions/ActionDetailsWrapper";
-import type { MCPActionDetailsProps } from "@app/components/actions/mcp/details/MCPActionDetails";
+import type { ToolOutputDetailsProps } from "@app/components/actions/mcp/details/types";
 import type {
   DatabaseSchemaResourceType,
   ExampleRowsResourceType,
@@ -12,16 +12,15 @@ import {
 } from "@app/lib/actions/mcp_internal_actions/output_schemas";
 
 export function MCPGetDatabaseSchemaActionDetails({
-  action,
+  toolOutput,
   viewType,
-}: MCPActionDetailsProps) {
-  const { output } = action;
-
+}: ToolOutputDetailsProps) {
   // Extract different types of outputs
   const schemaBlocks =
-    output?.filter(isDatabaseSchemaResourceType).map((o) => o.resource) ?? [];
+    toolOutput?.filter(isDatabaseSchemaResourceType).map((o) => o.resource) ??
+    [];
   const exampleRowsBlocks =
-    output?.filter(isExampleRowsResourceType).map((o) => o.resource) ?? [];
+    toolOutput?.filter(isExampleRowsResourceType).map((o) => o.resource) ?? [];
 
   return (
     <ActionDetailsWrapper

--- a/front/components/actions/mcp/details/MCPListToolsActionDetails.tsx
+++ b/front/components/actions/mcp/details/MCPListToolsActionDetails.tsx
@@ -1,7 +1,7 @@
 import { BoltIcon, Chip } from "@dust-tt/sparkle";
 
 import { ActionDetailsWrapper } from "@app/components/actions/ActionDetailsWrapper";
-import type { MCPActionDetailsProps } from "@app/components/actions/mcp/details/MCPActionDetails";
+import type { ToolOutputDetailsProps } from "@app/components/actions/mcp/details/types";
 import { getMcpServerViewDisplayName } from "@app/lib/actions/mcp_helper";
 import { getIcon } from "@app/lib/actions/mcp_icons";
 import { isToolsetsResultResourceType } from "@app/lib/actions/mcp_internal_actions/output_schemas";
@@ -10,9 +10,9 @@ import { useSpaces } from "@app/lib/swr/spaces";
 
 export function MCPListToolsActionDetails({
   owner,
-  action,
+  toolOutput,
   viewType,
-}: MCPActionDetailsProps) {
+}: ToolOutputDetailsProps) {
   const { spaces } = useSpaces({
     workspaceId: owner.sId,
   });
@@ -22,9 +22,8 @@ export function MCPListToolsActionDetails({
     availability: "all",
   });
   const results =
-    action.output
-      ?.filter(isToolsetsResultResourceType)
-      .map((o) => o.resource) ?? [];
+    toolOutput?.filter(isToolsetsResultResourceType).map((o) => o.resource) ??
+    [];
 
   return (
     <ActionDetailsWrapper

--- a/front/components/actions/mcp/details/MCPListToolsActionDetails.tsx
+++ b/front/components/actions/mcp/details/MCPListToolsActionDetails.tsx
@@ -1,7 +1,7 @@
 import { BoltIcon, Chip } from "@dust-tt/sparkle";
 
 import { ActionDetailsWrapper } from "@app/components/actions/ActionDetailsWrapper";
-import type { ToolOutputDetailsProps } from "@app/components/actions/mcp/details/types";
+import type { ToolExecutionDetailsProps } from "@app/components/actions/mcp/details/types";
 import { getMcpServerViewDisplayName } from "@app/lib/actions/mcp_helper";
 import { getIcon } from "@app/lib/actions/mcp_icons";
 import { isToolsetsResultResourceType } from "@app/lib/actions/mcp_internal_actions/output_schemas";
@@ -12,7 +12,7 @@ export function MCPListToolsActionDetails({
   owner,
   toolOutput,
   viewType,
-}: ToolOutputDetailsProps) {
+}: ToolExecutionDetailsProps) {
   const { spaces } = useSpaces({
     workspaceId: owner.sId,
   });

--- a/front/components/actions/mcp/details/MCPReasoningActionDetails.tsx
+++ b/front/components/actions/mcp/details/MCPReasoningActionDetails.tsx
@@ -1,27 +1,25 @@
 import { ChatBubbleThoughtIcon } from "@dust-tt/sparkle";
 
 import { ActionDetailsWrapper } from "@app/components/actions/ActionDetailsWrapper";
-import type { MCPActionDetailsProps } from "@app/components/actions/mcp/details/MCPActionDetails";
 import {
   ReasoningSuccessBlock,
   ThinkingBlock,
 } from "@app/components/actions/mcp/details/MCPToolOutputDetails";
+import type { ToolOutputDetailsProps } from "@app/components/actions/mcp/details/types";
 import {
   isReasoningSuccessOutput,
   isThinkingOutput,
 } from "@app/lib/actions/mcp_internal_actions/output_schemas";
 
 export function MCPReasoningActionDetails({
-  action,
+  toolOutput,
   viewType,
-}: MCPActionDetailsProps) {
-  const { output } = action;
-
+}: ToolOutputDetailsProps) {
   const thinkingBlocks =
-    output?.filter(isThinkingOutput).map((o) => o.resource) ?? [];
+    toolOutput?.filter(isThinkingOutput).map((o) => o.resource) ?? [];
 
   const reasoningSuccessBlocks =
-    output?.filter(isReasoningSuccessOutput).map((o) => o.resource) ?? [];
+    toolOutput?.filter(isReasoningSuccessOutput).map((o) => o.resource) ?? [];
 
   return (
     <ActionDetailsWrapper

--- a/front/components/actions/mcp/details/MCPReasoningActionDetails.tsx
+++ b/front/components/actions/mcp/details/MCPReasoningActionDetails.tsx
@@ -5,7 +5,7 @@ import {
   ReasoningSuccessBlock,
   ThinkingBlock,
 } from "@app/components/actions/mcp/details/MCPToolOutputDetails";
-import type { ToolOutputDetailsProps } from "@app/components/actions/mcp/details/types";
+import type { ToolExecutionDetailsProps } from "@app/components/actions/mcp/details/types";
 import {
   isReasoningSuccessOutput,
   isThinkingOutput,
@@ -14,7 +14,7 @@ import {
 export function MCPReasoningActionDetails({
   toolOutput,
   viewType,
-}: ToolOutputDetailsProps) {
+}: ToolExecutionDetailsProps) {
   const thinkingBlocks =
     toolOutput?.filter(isThinkingOutput).map((o) => o.resource) ?? [];
 

--- a/front/components/actions/mcp/details/MCPRunAgentActionDetails.tsx
+++ b/front/components/actions/mcp/details/MCPRunAgentActionDetails.tsx
@@ -20,7 +20,7 @@ import type { PluggableList } from "react-markdown/lib/react-markdown";
 
 import { ActionDetailsWrapper } from "@app/components/actions/ActionDetailsWrapper";
 import { ToolGeneratedFileDetails } from "@app/components/actions/mcp/details/MCPToolOutputDetails";
-import type { ToolOutputDetailsProps } from "@app/components/actions/mcp/details/types";
+import type { ToolExecutionDetailsProps } from "@app/components/actions/mcp/details/types";
 import {
   CitationsContext,
   CiteBlock,
@@ -51,7 +51,7 @@ export function MCPRunAgentActionDetails({
   toolOutput,
   toolParams,
   viewType,
-}: ToolOutputDetailsProps) {
+}: ToolExecutionDetailsProps) {
   const { isDark } = useTheme();
 
   const addedMCPServerViewIds: string[] = useMemo(() => {

--- a/front/components/actions/mcp/details/MCPRunAgentActionDetails.tsx
+++ b/front/components/actions/mcp/details/MCPRunAgentActionDetails.tsx
@@ -10,17 +10,17 @@ import {
   CollapsibleComponent,
   ContentMessage,
   DocumentIcon,
+  ExternalLinkIcon,
   Markdown,
   RobotIcon,
 } from "@dust-tt/sparkle";
-import { ExternalLinkIcon } from "@dust-tt/sparkle";
 import { useEffect, useMemo, useState } from "react";
 import type { Components } from "react-markdown";
 import type { PluggableList } from "react-markdown/lib/react-markdown";
 
 import { ActionDetailsWrapper } from "@app/components/actions/ActionDetailsWrapper";
-import type { MCPActionDetailsProps } from "@app/components/actions/mcp/details/MCPActionDetails";
 import { ToolGeneratedFileDetails } from "@app/components/actions/mcp/details/MCPToolOutputDetails";
+import type { ToolOutputDetailsProps } from "@app/components/actions/mcp/details/types";
 import {
   CitationsContext,
   CiteBlock,
@@ -46,19 +46,20 @@ import { useSpaces } from "@app/lib/swr/spaces";
 import { emptyArray } from "@app/lib/swr/swr";
 
 export function MCPRunAgentActionDetails({
-  owner,
-  action,
   lastNotification,
+  owner,
+  toolOutput,
+  toolParams,
   viewType,
-}: MCPActionDetailsProps) {
+}: ToolOutputDetailsProps) {
   const { isDark } = useTheme();
 
   const addedMCPServerViewIds: string[] = useMemo(() => {
-    if (!action.params["toolsetsToAdd"]) {
+    if (!toolParams["toolsetsToAdd"]) {
       return emptyArray();
     }
-    return action.params["toolsetsToAdd"] as string[];
-  }, [action.params]);
+    return toolParams["toolsetsToAdd"] as string[];
+  }, [toolParams]);
 
   const { spaces } = useSpaces({
     workspaceId: owner.sId,
@@ -71,14 +72,12 @@ export function MCPRunAgentActionDetails({
     disabled: addedMCPServerViewIds.length === 0,
   });
 
-  const queryResource =
-    action.output?.find(isRunAgentQueryResourceType) || null;
+  const queryResource = toolOutput?.find(isRunAgentQueryResourceType) || null;
 
-  const resultResource =
-    action.output?.find(isRunAgentResultResourceType) || null;
+  const resultResource = toolOutput?.find(isRunAgentResultResourceType) || null;
 
   const generatedFiles =
-    action.output?.filter(isToolGeneratedFile).map((o) => o.resource) ?? [];
+    toolOutput?.filter(isToolGeneratedFile).map((o) => o.resource) ?? [];
 
   const childAgentId = useMemo(() => {
     if (queryResource) {

--- a/front/components/actions/mcp/details/MCPTablesQueryActionDetails.tsx
+++ b/front/components/actions/mcp/details/MCPTablesQueryActionDetails.tsx
@@ -7,7 +7,7 @@ import {
   ThinkingBlock,
   ToolGeneratedFileDetails,
 } from "@app/components/actions/mcp/details/MCPToolOutputDetails";
-import type { ToolOutputDetailsProps } from "@app/components/actions/mcp/details/types";
+import type { ToolExecutionDetailsProps } from "@app/components/actions/mcp/details/types";
 import {
   isExecuteTablesQueryErrorResourceType,
   isSqlQueryOutput,
@@ -20,7 +20,7 @@ export function MCPTablesQueryActionDetails({
   toolParams,
   viewType,
   owner,
-}: ToolOutputDetailsProps) {
+}: ToolExecutionDetailsProps) {
   const thinkingBlocks =
     toolOutput?.filter(isThinkingOutput).map((o) => o.resource) ?? [];
   const sqlQueryBlocks =

--- a/front/components/actions/mcp/details/MCPTablesQueryActionDetails.tsx
+++ b/front/components/actions/mcp/details/MCPTablesQueryActionDetails.tsx
@@ -2,12 +2,12 @@ import { INTERNAL_MIME_TYPES } from "@dust-tt/client";
 import { CodeBlock, TableIcon } from "@dust-tt/sparkle";
 
 import { ActionDetailsWrapper } from "@app/components/actions/ActionDetailsWrapper";
-import type { MCPActionDetailsProps } from "@app/components/actions/mcp/details/MCPActionDetails";
 import {
   SqlQueryBlock,
   ThinkingBlock,
   ToolGeneratedFileDetails,
 } from "@app/components/actions/mcp/details/MCPToolOutputDetails";
+import type { ToolOutputDetailsProps } from "@app/components/actions/mcp/details/types";
 import {
   isExecuteTablesQueryErrorResourceType,
   isSqlQueryOutput,
@@ -16,23 +16,24 @@ import {
 } from "@app/lib/actions/mcp_internal_actions/output_schemas";
 
 export function MCPTablesQueryActionDetails({
-  action,
+  toolOutput,
+  toolParams,
   viewType,
   owner,
-}: MCPActionDetailsProps) {
+}: ToolOutputDetailsProps) {
   const thinkingBlocks =
-    action.output?.filter(isThinkingOutput).map((o) => o.resource) ?? [];
+    toolOutput?.filter(isThinkingOutput).map((o) => o.resource) ?? [];
   const sqlQueryBlocks =
-    action.output?.filter(isSqlQueryOutput).map((o) => o.resource) ?? [];
+    toolOutput?.filter(isSqlQueryOutput).map((o) => o.resource) ?? [];
   const generatedFiles =
-    action.output?.filter(isToolGeneratedFile).map((o) => o.resource) ?? [];
+    toolOutput?.filter(isToolGeneratedFile).map((o) => o.resource) ?? [];
   const errorBlocks =
-    action.output
+    toolOutput
       ?.filter(isExecuteTablesQueryErrorResourceType)
       .map((o) => o.resource) ?? [];
 
   // For v2 server, get query from params if no SQL query blocks in output.
-  const queryFromParams = action.params?.query as string | undefined;
+  const queryFromParams = toolParams?.query as string | undefined;
   const hasQueryToDisplay = sqlQueryBlocks.length > 0 || queryFromParams;
 
   return (
@@ -44,15 +45,13 @@ export function MCPTablesQueryActionDetails({
       visual={TableIcon}
     >
       {viewType === "conversation" ? (
-        <>
-          {thinkingBlocks.length > 0 && (
-            <div className="flex flex-col gap-4 pl-6 pt-4">
-              {thinkingBlocks.map((block) => (
-                <div key={block.text}>{block.text}</div>
-              ))}
-            </div>
-          )}
-        </>
+        thinkingBlocks.length > 0 && (
+          <div className="flex flex-col gap-4 pl-6 pt-4">
+            {thinkingBlocks.map((block) => (
+              <div key={block.text}>{block.text}</div>
+            ))}
+          </div>
+        )
       ) : (
         <div className="flex flex-col gap-4 pl-6 pt-4">
           {thinkingBlocks.length > 0 && (
@@ -110,7 +109,7 @@ export function MCPTablesQueryActionDetails({
               </span>
               {errorBlocks.map((block, index) => (
                 <CodeBlock
-                  key={`execute-tables-query-error-${action.id}-${index}`}
+                  key={`execute-tables-query-error-${index}`}
                   wrapLongLines
                 >
                   {block.text}

--- a/front/components/actions/mcp/details/types.ts
+++ b/front/components/actions/mcp/details/types.ts
@@ -1,0 +1,14 @@
+import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
+
+import type { ProgressNotificationContentType } from "@app/lib/actions/mcp_internal_actions/output_schemas";
+import type { LightWorkspaceType } from "@app/types";
+
+// Generic interface for every component that displays details for a certain type of tool output.
+export interface ToolOutputDetailsProps {
+  lastNotification: ProgressNotificationContentType | null;
+  messageStatus?: "created" | "succeeded" | "failed" | "cancelled";
+  owner: LightWorkspaceType;
+  toolOutput: CallToolResult["content"] | null;
+  toolParams: Record<string, unknown>;
+  viewType: "conversation" | "sidebar";
+}

--- a/front/components/actions/mcp/details/types.ts
+++ b/front/components/actions/mcp/details/types.ts
@@ -4,7 +4,7 @@ import type { ProgressNotificationContentType } from "@app/lib/actions/mcp_inter
 import type { LightWorkspaceType } from "@app/types";
 
 // Generic interface for every component that displays details for a certain type of tool output.
-export interface ToolOutputDetailsProps {
+export interface ToolExecutionDetailsProps {
   lastNotification: ProgressNotificationContentType | null;
   messageStatus?: "created" | "succeeded" | "failed" | "cancelled";
   owner: LightWorkspaceType;


### PR DESCRIPTION
## Description

- This PR adds a uniformized interface `ToolExecutionDetailsProps` for the props passed down to components that details the execution of a tool.
- This change is necessary if we want to override the output content based on the status of the action, in a follow up PR I'll fix the rendering for denied actions, which are not stored in db anymore.

## Tests

- Tested locally.

## Risk

- Low.

## Deploy Plan

- Deploy front.
