### PR TITLE
Add conversation list to poke trigger page

### DIFF
--- a/front/components/poke/conversations/columns.tsx
+++ b/front/components/poke/conversations/columns.tsx
@@ -1,0 +1,59 @@
+import { IconButton, LinkWrapper } from "@dust-tt/sparkle";
+import { ArrowsUpDownIcon } from "@heroicons/react/20/solid";
+import type { ColumnDef } from "@tanstack/react-table";
+
+import { formatTimestampToFriendlyDate } from "@app/lib/utils";
+import type {
+  ConversationWithoutContentType,
+  LightWorkspaceType,
+} from "@app/types";
+
+export function makeColumnsForConversations(
+  owner: LightWorkspaceType
+): ColumnDef<ConversationWithoutContentType>[] {
+  return [
+    {
+      accessorKey: "sId",
+      header: ({ column }) => {
+        return (
+          <div className="flex space-x-2">
+            <p>sId</p>
+            <IconButton
+              variant="outline"
+              icon={ArrowsUpDownIcon}
+              onClick={() =>
+                column.toggleSorting(column.getIsSorted() === "asc")
+              }
+            />
+          </div>
+        );
+      },
+      cell: ({ row }) => {
+        const conversation = row.original;
+
+        return (
+          <LinkWrapper
+            href={`/poke/${owner.sId}/conversations/${conversation.sId}`}
+          >
+            {conversation.sId}
+          </LinkWrapper>
+        );
+      },
+    },
+    {
+      accessorKey: "createdAt",
+      header: "Created At",
+      cell: ({ row }) => {
+        return formatTimestampToFriendlyDate(row.original.created);
+      },
+    },
+    {
+      accessorKey: "title",
+      header: "Title",
+    },
+    {
+      accessorKey: "visibility",
+      header: "Visibility",
+    },
+  ];
+}

--- a/front/components/poke/conversations/table.tsx
+++ b/front/components/poke/conversations/table.tsx
@@ -5,13 +5,15 @@ import type {
   LightWorkspaceType,
 } from "@app/types";
 
+interface ConversationDataTableProps {
+  owner: LightWorkspaceType;
+  conversations: ConversationWithoutContentType[];
+}
+
 export function ConversationDataTable({
   owner,
   conversations,
-}: {
-  owner: LightWorkspaceType;
-  conversations: ConversationWithoutContentType[];
-}) {
+}: ConversationDataTableProps) {
   const columns = makeColumnsForConversations(owner);
 
   return (

--- a/front/components/poke/conversations/table.tsx
+++ b/front/components/poke/conversations/table.tsx
@@ -1,0 +1,23 @@
+import { makeColumnsForConversations } from "@app/components/poke/conversations/columns";
+import { PokeDataTable } from "@app/components/poke/shadcn/ui/data_table";
+import type {
+  ConversationWithoutContentType,
+  LightWorkspaceType,
+} from "@app/types";
+
+export function ConversationDataTable({
+  owner,
+  conversations,
+}: {
+  owner: LightWorkspaceType;
+  conversations: ConversationWithoutContentType[];
+}) {
+  const columns = makeColumnsForConversations(owner);
+
+  return (
+    <PokeDataTable<ConversationWithoutContentType, unknown>
+      columns={columns}
+      data={conversations}
+    />
+  );
+}

--- a/front/lib/resources/conversation_resource.ts
+++ b/front/lib/resources/conversation_resource.ts
@@ -450,7 +450,8 @@ export class ConversationResource extends BaseResource<ConversationModel> {
 
   static async listConversationsForTrigger(
     auth: Authenticator,
-    triggerId: string
+    triggerId: string,
+    options?: FetchConversationOptions
   ): Promise<ConversationWithoutContentType[]> {
     const owner = auth.getNonNullableWorkspace();
 
@@ -459,7 +460,7 @@ export class ConversationResource extends BaseResource<ConversationModel> {
       return [];
     }
 
-    const conversations = await this.model.findAll({
+    const conversations = await this.baseFetch(auth, options, {
       where: {
         workspaceId: owner.id,
         triggerId: triggerModelId,
@@ -478,7 +479,7 @@ export class ConversationResource extends BaseResource<ConversationModel> {
       triggerId: triggerId,
       requestedGroupIds: new this(
         this.model,
-        c.get()
+        c
       ).getConversationRequestedGroupIdsFromModel(auth),
     }));
   }


### PR DESCRIPTION
## Description

And conversations can be clicked to go to convo page.

Fixes https://github.com/dust-tt/tasks/issues/3948

<img width="1064" height="235" alt="image" src="https://github.com/user-attachments/assets/cba44ea2-05f5-4697-b11a-2847eea1d298" />


## Tests

Manual

## Risk

poke only

## Deploy Plan

Front