### PR TITLE
[front] Handle denied tool rendering in `MCPActionDetails`

### DIFF
--- a/front/components/actions/mcp/details/MCPActionDetails.tsx
+++ b/front/components/actions/mcp/details/MCPActionDetails.tsx
@@ -8,6 +8,7 @@ import {
   MagnifyingGlassIcon,
   Markdown,
 } from "@dust-tt/sparkle";
+import { useEffect, useState } from "react";
 
 import { ActionDetailsWrapper } from "@app/components/actions/ActionDetailsWrapper";
 import { MCPAgentManagementActionDetails } from "@app/components/actions/mcp/details/MCPAgentManagementActionDetails";
@@ -75,7 +76,32 @@ export function MCPActionDetails({
   lastNotification,
   messageStatus,
 }: MCPActionDetailsProps) {
-  const { functionCallName, internalMCPServerName, params, output } = action;
+  const {
+    functionCallName,
+    internalMCPServerName,
+    params,
+    status,
+    output: baseOutput,
+  } = action;
+
+  const [output, setOutput] = useState(baseOutput);
+
+  useEffect(() => {
+    if (status === "denied") {
+      const deniedMessage = {
+        type: "text" as const,
+        text: "Tool execution rejected by the user.",
+      };
+
+      if (baseOutput === null) {
+        setOutput([deniedMessage]);
+      } else {
+        setOutput([...baseOutput, deniedMessage]);
+      }
+    } else {
+      setOutput(baseOutput);
+    }
+  }, [status, baseOutput]);
 
   const parts = functionCallName ? functionCallName.split("__") : [];
   const toolName = parts[parts.length - 1];


### PR DESCRIPTION
## Description

- This PR fixes the rendering of denied tool executions. The issue was that they were not rendered.

## Tests

- Tested locally.

## Risk

- Low.

## Deploy Plan

- Deploy front.
