### PR TITLE
[front] - fix(AB v2): polish

### DIFF
--- a/front/components/agent_builder/capabilities/knowledge/KnowledgeConfigurationSheet.tsx
+++ b/front/components/agent_builder/capabilities/knowledge/KnowledgeConfigurationSheet.tsx
@@ -7,7 +7,7 @@ import {
 import { zodResolver } from "@hookform/resolvers/zod";
 import isEmpty from "lodash/isEmpty";
 import uniqueId from "lodash/uniqueId";
-import { useContext, useEffect, useMemo, useState } from "react";
+import { useContext, useEffect, useMemo, useRef, useState } from "react";
 import { FormProvider, useForm, useWatch } from "react-hook-form";
 
 import { DataSourceBuilderSelector } from "@app/components/agent_builder/capabilities/knowledge/DataSourceBuilderSelector";
@@ -312,6 +312,7 @@ function KnowledgeConfigurationSheetContent({
   isEditing,
 }: KnowledgeConfigurationSheetContentProps) {
   const { currentPageId, setSheetPageId } = useKnowledgePageContext();
+  const nameSectionRef = useRef<HTMLInputElement>(null);
 
   const mcpServerView = useWatch<CapabilityFormData, "mcpServerView">({
     name: "mcpServerView",
@@ -332,6 +333,13 @@ function KnowledgeConfigurationSheetContent({
   const requirements = useMemo(() => {
     return getMCPServerRequirements(mcpServerView);
   }, [mcpServerView]);
+
+  // Focus NameSection input when navigating to CONFIGURATION page
+  useEffect(() => {
+    if (currentPageId === CONFIGURATION_SHEET_PAGE_IDS.CONFIGURATION) {
+      nameSectionRef.current?.focus();
+    }
+  }, [currentPageId]);
 
   const handlePageChange = (pageId: string) => {
     if (isValidPage(pageId, CONFIGURATION_SHEET_PAGE_IDS)) {
@@ -400,7 +408,11 @@ function KnowledgeConfigurationSheetContent({
         : undefined,
       content: (
         <div className="space-y-6">
-          <NameSection title="Name" placeholder="Search Google Drive" />
+          <NameSection
+            ref={nameSectionRef}
+            title="Name"
+            placeholder="Name ..."
+          />
 
           <ProcessingMethodSection />
 

--- a/front/components/agent_builder/capabilities/knowledge/KnowledgeConfigurationSheet.tsx
+++ b/front/components/agent_builder/capabilities/knowledge/KnowledgeConfigurationSheet.tsx
@@ -1,5 +1,9 @@
 import type { MultiPageSheetPage } from "@dust-tt/sparkle";
-import { MultiPageSheet, MultiPageSheetContent } from "@dust-tt/sparkle";
+import {
+  Avatar,
+  MultiPageSheet,
+  MultiPageSheetContent,
+} from "@dust-tt/sparkle";
 import { zodResolver } from "@hookform/resolvers/zod";
 import isEmpty from "lodash/isEmpty";
 import uniqueId from "lodash/uniqueId";
@@ -391,11 +395,11 @@ function KnowledgeConfigurationSheetContent({
       description:
         config?.configPageDescription ||
         "Select knowledge type and configure settings",
-      icon: config?.icon,
+      icon: config
+        ? () => <Avatar icon={config.icon} size="md" className="mr-2" />
+        : undefined,
       content: (
         <div className="space-y-6">
-          <SelectDataSourcesFilters />
-
           <NameSection title="Name" placeholder="Search Google Drive" />
 
           <ProcessingMethodSection />
@@ -409,6 +413,8 @@ function KnowledgeConfigurationSheetContent({
           )}
 
           {config && <DescriptionSection {...config?.descriptionConfig} />}
+
+          <SelectDataSourcesFilters />
         </div>
       ),
     },

--- a/front/components/agent_builder/capabilities/knowledge/KnowledgeConfigurationSheet.tsx
+++ b/front/components/agent_builder/capabilities/knowledge/KnowledgeConfigurationSheet.tsx
@@ -408,13 +408,13 @@ function KnowledgeConfigurationSheetContent({
         : undefined,
       content: (
         <div className="space-y-6">
+          <ProcessingMethodSection />
+
           <NameSection
             ref={nameSectionRef}
             title="Name"
             placeholder="Name ..."
           />
-
-          <ProcessingMethodSection />
 
           {requirements.mayRequireTimeFrameConfiguration && (
             <TimeFrameSection actionType="extract" />

--- a/front/components/agent_builder/capabilities/knowledge/KnowledgeConfigurationSheet.tsx
+++ b/front/components/agent_builder/capabilities/knowledge/KnowledgeConfigurationSheet.tsx
@@ -235,7 +235,9 @@ function KnowledgeConfigurationSheetForm({
         ? action!.name // Keep original name when editing without changes
         : generateUniqueActionName({
             baseName: nameToStorageFormat(formData.name),
-            existingActions: actions || [],
+            existingActions: isEditing
+              ? (actions || []).filter((a) => a.id !== action?.id)
+              : actions || [],
           });
 
     const newAction: AgentBuilderAction = {

--- a/front/components/agent_builder/capabilities/knowledge/utils.ts
+++ b/front/components/agent_builder/capabilities/knowledge/utils.ts
@@ -28,7 +28,7 @@ export const CAPABILITY_CONFIGS: Record<string, CapabilityConfig> = {
   search: {
     icon: MagnifyingGlassIcon,
     configPageTitle: "Configure Search",
-    configPageDescription: "Describe what you want to search for",
+    configPageDescription: "Describe what you want to search for.",
     descriptionConfig: {
       title: "What’s the data?",
       description:
@@ -39,7 +39,7 @@ export const CAPABILITY_CONFIGS: Record<string, CapabilityConfig> = {
   include_data: {
     icon: ActionIncludeIcon,
     configPageTitle: "Configure Include Data",
-    configPageDescription: "Set time range and describe what data to include",
+    configPageDescription: "Set time range and describe what data to include.",
     descriptionConfig: {
       title: "What’s the data?",
       description:
@@ -52,7 +52,7 @@ export const CAPABILITY_CONFIGS: Record<string, CapabilityConfig> = {
     icon: ActionScanIcon,
     configPageTitle: "Configure Extract Data",
     configPageDescription:
-      "Set extraction parameters and describe what data to extract",
+      "Set extraction parameters and describe what data to extract.",
     descriptionConfig: {
       title: "What’s the data?",
       description:
@@ -64,7 +64,8 @@ export const CAPABILITY_CONFIGS: Record<string, CapabilityConfig> = {
   [TABLE_QUERY_SERVER_NAME]: {
     icon: TableIcon,
     configPageTitle: "Configure Query Tables",
-    configPageDescription: "Describe how you want to query the selected tables",
+    configPageDescription:
+      "Describe how you want to query the selected tables.",
     descriptionConfig: {
       title: "Query Description",
       description:
@@ -75,7 +76,8 @@ export const CAPABILITY_CONFIGS: Record<string, CapabilityConfig> = {
   [TABLE_QUERY_V2_SERVER_NAME]: {
     icon: TableIcon,
     configPageTitle: "Configure Query Tables v2",
-    configPageDescription: "Describe how you want to query the selected tables",
+    configPageDescription:
+      "Describe how you want to query the selected tables.",
     descriptionConfig: {
       title: "Query Description",
       description:
@@ -86,7 +88,8 @@ export const CAPABILITY_CONFIGS: Record<string, CapabilityConfig> = {
   [DATA_WAREHOUSE_SERVER_NAME]: {
     icon: TableIcon,
     configPageTitle: "Configure Data Warehouse",
-    configPageDescription: "Describe how you want to query the selected tables",
+    configPageDescription:
+      "Describe how you want to query the selected tables.",
     descriptionConfig: {
       title: "Query Description",
       description:

--- a/front/components/agent_builder/capabilities/mcp/MCPServerViewsSheet.tsx
+++ b/front/components/agent_builder/capabilities/mcp/MCPServerViewsSheet.tsx
@@ -7,7 +7,13 @@ import {
 } from "@dust-tt/sparkle";
 import { zodResolver } from "@hookform/resolvers/zod";
 import uniqueId from "lodash/uniqueId";
-import React, { useCallback, useEffect, useMemo, useState } from "react";
+import React, {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
 import type { UseFieldArrayAppend } from "react-hook-form";
 import { useForm } from "react-hook-form";
 
@@ -141,6 +147,7 @@ export function MCPServerViewsSheet({
     SelectedTool[]
   >([]);
   const [searchTerm, setSearchTerm] = useState("");
+  const searchInputRef = useRef<HTMLInputElement>(null);
 
   const [isOpen, setIsOpen] = useState(!!mode);
   const [currentPageId, setCurrentPageId] = useState<ConfigurationPagePageId>(
@@ -281,6 +288,16 @@ export function MCPServerViewsSheet({
     }
     setIsOpen(!!mode);
   }, [mode, allMcpServerViews]);
+
+  // Focus SearchInput when opening on TOOL_SELECTION page
+  useEffect(() => {
+    if (isOpen && currentPageId === TOOLS_SHEET_PAGE_IDS.TOOL_SELECTION) {
+      // Small delay to ensure the component is fully rendered
+      setTimeout(() => {
+        searchInputRef.current?.focus();
+      }, 100);
+    }
+  }, [isOpen, currentPageId]);
 
   const toggleToolSelection = useCallback((tool: SelectedTool) => {
     setSelectedToolsInSheet((prev) => {
@@ -495,10 +512,11 @@ export function MCPServerViewsSheet({
         <>
           {!isMCPServerViewsLoading && (
             <SearchInput
+              ref={searchInputRef}
               value={searchTerm}
               onChange={setSearchTerm}
               name="search-mcp-servers"
-              placeholder="Search servers..."
+              placeholder="Search tools..."
             />
           )}
           <MCPServerSelectionPage

--- a/front/components/agent_builder/capabilities/shared/NameSection.tsx
+++ b/front/components/agent_builder/capabilities/shared/NameSection.tsx
@@ -1,4 +1,5 @@
 import { Input } from "@dust-tt/sparkle";
+import { forwardRef } from "react";
 import { useController, useFormContext } from "react-hook-form";
 
 import type { CapabilityFormData } from "@app/components/agent_builder/types";
@@ -13,43 +14,55 @@ interface NameSectionProps {
 
 const FIELD_NAME = "name";
 
-export function NameSection({
-  title,
-  description,
-  label,
-  placeholder,
-  helpText,
-}: NameSectionProps) {
-  const { register } = useFormContext();
-  const { fieldState } = useController<CapabilityFormData, typeof FIELD_NAME>({
-    name: FIELD_NAME,
-  });
+export const NameSection = forwardRef<HTMLInputElement, NameSectionProps>(
+  ({ title, description, label, placeholder, helpText }, ref) => {
+    const { register } = useFormContext();
+    const { fieldState } = useController<CapabilityFormData, typeof FIELD_NAME>(
+      {
+        name: FIELD_NAME,
+      }
+    );
 
-  return (
-    <div className="space-y-4">
-      <div>
-        <h3 className="mb-2 text-lg font-semibold">{title}</h3>
-        {description && (
-          <p className="text-sm text-muted-foreground dark:text-muted-foreground-night">
-            {description}
-          </p>
-        )}
-      </div>
+    const { ref: registerRef, ...registerProps } = register(FIELD_NAME);
 
-      <div className="space-y-2">
-        <Input
-          placeholder={placeholder}
-          {...register(FIELD_NAME)}
-          label={label}
-          message={fieldState.error?.message}
-          messageStatus={fieldState.error ? "error" : "default"}
-        />
-        {helpText && (
-          <p className="text-xs text-muted-foreground dark:text-muted-foreground-night">
-            {helpText}
-          </p>
-        )}
+    return (
+      <div className="space-y-4">
+        <div>
+          <h3 className="mb-2 text-lg font-semibold">{title}</h3>
+          {description && (
+            <p className="text-sm text-muted-foreground dark:text-muted-foreground-night">
+              {description}
+            </p>
+          )}
+        </div>
+
+        <div className="space-y-2">
+          <Input
+            ref={(e) => {
+              registerRef(e);
+              if (ref) {
+                if (typeof ref === "function") {
+                  ref(e);
+                } else {
+                  ref.current = e;
+                }
+              }
+            }}
+            placeholder={placeholder}
+            {...registerProps}
+            label={label}
+            message={fieldState.error?.message}
+            messageStatus={fieldState.error ? "error" : "default"}
+          />
+          {helpText && (
+            <p className="text-xs text-muted-foreground dark:text-muted-foreground-night">
+              {helpText}
+            </p>
+          )}
+        </div>
       </div>
-    </div>
-  );
-}
+    );
+  }
+);
+
+NameSection.displayName = "NameSection";

--- a/front/components/agent_builder/capabilities/shared/ProcessingMethodSection.tsx
+++ b/front/components/agent_builder/capabilities/shared/ProcessingMethodSection.tsx
@@ -173,7 +173,7 @@ export function ProcessingMethodSection() {
                 ? InternalActionIcons[mcpServerView.server.icon]
                 : undefined
             }
-            variant="outline"
+            variant="primary"
             isSelect
           />
         </DropdownMenuTrigger>

--- a/front/components/agent_builder/capabilities/shared/SelectDataSourcesFilters.tsx
+++ b/front/components/agent_builder/capabilities/shared/SelectDataSourcesFilters.tsx
@@ -10,6 +10,7 @@ import { useTheme } from "@app/components/sparkle/ThemeContext";
 import { getConnectorProviderLogoWithFallback } from "@app/lib/connector_providers";
 import { getDisplayNameForDataSource } from "@app/lib/data_sources";
 import type { DataSourceViewType } from "@app/types";
+import { pluralize } from "@app/types";
 
 type DataSourceFilterItem = {
   dataSourceView: DataSourceViewType;
@@ -68,7 +69,9 @@ export function SelectDataSourcesFilters() {
   return (
     <div className="space-y-4">
       <div className="align-center flex flex-row justify-between">
-        <h3 className="mb-2 text-lg font-semibold">Selected data source</h3>
+        <h3 className="mb-2 text-lg font-semibold">
+          Selected data source{pluralize(Object.values(dataSourceViews).length)}
+        </h3>
 
         <div className="flex flex-row items-center space-x-2">
           <Button

--- a/front/components/agent_builder/instructions/ModelSelectionSubmenu.tsx
+++ b/front/components/agent_builder/instructions/ModelSelectionSubmenu.tsx
@@ -138,7 +138,9 @@ export function ModelSelectionSubmenu({ models }: ModelSelectionSubmenuProps) {
                 )}
                 {hasOlderModels && (
                   <>
-                    <DropdownMenuLabel label="Older models" />
+                    <DropdownMenuLabel
+                      label={hasRecentModels ? "Older models" : "All models"}
+                    />
                     <DropdownMenuRadioGroup value={currentModelKey}>
                       {models.older.map((modelConfig) => (
                         <ModelRadioItem

--- a/front/components/agent_builder/settings/EditorsSheet.tsx
+++ b/front/components/agent_builder/settings/EditorsSheet.tsx
@@ -21,8 +21,13 @@ import type {
   ColumnDef,
   PaginationState,
 } from "@tanstack/react-table";
-import React, { useEffect, useMemo, useState } from "react";
-import { useCallback } from "react";
+import React, {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
 import { useController } from "react-hook-form";
 
 import { useAgentBuilderContext } from "@app/components/agent_builder/AgentBuilderContext";
@@ -51,6 +56,7 @@ export function EditorsSheet() {
   const [searchTerm, setSearchTerm] = useState("");
   const [localEditors, setLocalEditors] = useState<UserType[]>([]);
   const [isOpen, setIsOpen] = useState(false);
+  const searchInputRef = useRef<HTMLInputElement>(null);
 
   const {
     field: { onChange, value: editors },
@@ -63,6 +69,15 @@ export function EditorsSheet() {
       setLocalEditors([...(editors || [])]);
     }
   }, [editors, isOpen]);
+
+  useEffect(() => {
+    if (isOpen) {
+      // Small delay to wait for sheet animation to complete
+      setTimeout(() => {
+        searchInputRef.current?.focus();
+      }, 200);
+    }
+  }, [isOpen]);
 
   const { members: workspaceMembers, isLoading: isWorkspaceMembersLoading } =
     useSearchMembers({
@@ -221,6 +236,7 @@ export function EditorsSheet() {
         <SheetContainer>
           <div className="flex flex-col gap-5 text-sm text-foreground dark:text-foreground-night">
             <SearchInput
+              ref={searchInputRef}
               value={searchTerm}
               onChange={setSearchTerm}
               name="search-editors"

--- a/sparkle/src/components/Sheet.tsx
+++ b/sparkle/src/components/Sheet.tsx
@@ -201,7 +201,7 @@ const SheetContainer = ({ children, noScroll }: SheetContainerProps) => {
         "s-border-t s-border-border/60 s-transition-all s-duration-300 dark:s-border-border-night/60"
       )}
     >
-      <div className="s-relative s-flex s-h-full s-flex-col s-gap-5 s-p-5 s-text-left s-text-sm s-text-foreground dark:s-text-foreground-night">
+      <div className="s-relative s-flex s-h-full s-flex-col s-gap-5 s-px-5 s-text-left s-text-sm s-text-foreground dark:s-text-foreground-night">
         {children}
       </div>
     </ScrollContainer>

--- a/sparkle/src/components/ToolCard.tsx
+++ b/sparkle/src/components/ToolCard.tsx
@@ -54,7 +54,7 @@ export const ToolCard = React.forwardRef<HTMLDivElement, ToolCardProps>(
                 />
               )}
             </div>
-            {canAdd && !isSelected && (
+            {canAdd && (
               <Button
                 size="xs"
                 variant="outline"


### PR DESCRIPTION
## Description

This PR implements several UX improvements to the Agent Builder knowledge configuration UI:
- Autofocus input fields at key steps (search input when opening tool selection, name input when configuring)
- Prefill the name field with the processing method display name when selecting a new MCP server view
- Exclude current action when checking for unique names during editing

## Tests

Locally

## Risk

Low

## Deploy Plan

Deploy front
