### PR TITLE
fix: dev_worker.sh use bash

### DIFF
--- a/front/admin/dev_worker.sh
+++ b/front/admin/dev_worker.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 set -euo pipefail
 
 # Compute the list from the registry.


### PR DESCRIPTION
## Description

`-o pipefail` is non-POSIX. `bash` required instead of `sh`.

## Tests

Tested locally

## Risk

None

## Deploy Plan

N/A