### PR TITLE
[front] - refactor(assistant): nullable description

### DIFF
--- a/front/components/agent_builder/AgentBuilder.tsx
+++ b/front/components/agent_builder/AgentBuilder.tsx
@@ -50,18 +50,16 @@ function processActionsFromStorage(
   actions: AssistantBuilderMCPConfigurationWithId[]
 ): AgentBuilderAction[] {
   return actions.map((action) => {
-    if (action.type === "MCP") {
-      return {
-        ...action,
-        configuration: {
-          ...action.configuration,
-          additionalConfiguration: processAdditionalConfigurationFromStorage(
-            action.configuration.additionalConfiguration
-          ),
-        },
-      };
-    }
-    return action;
+    return {
+      ...action,
+      configuration: {
+        ...action.configuration,
+        description: action.description,
+        additionalConfiguration: processAdditionalConfigurationFromStorage(
+          action.configuration.additionalConfiguration
+        ),
+      },
+    };
   });
 }
 

--- a/front/components/agent_builder/AgentBuilderFormContext.tsx
+++ b/front/components/agent_builder/AgentBuilderFormContext.tsx
@@ -123,8 +123,9 @@ export const reasoningModelSchema = z
   })
   .nullable();
 
-export const mcpServerConfigurationSchema = z.object({
+const baseMcpServerConfigurationSchema = z.object({
   mcpServerViewId: mcpServerViewIdSchema,
+  description: z.string().nullable(),
   dataSourceConfigurations: dataSourceConfigurationSchema,
   tablesConfigurations: dataSourceConfigurationSchema,
   childAgentId: childAgentIdSchema,
@@ -136,8 +137,20 @@ export const mcpServerConfigurationSchema = z.object({
   _jsonSchemaString: jsonSchemaStringSchema,
 });
 
+export const mcpServerConfigurationSchema =
+  baseMcpServerConfigurationSchema.refine(
+    (data) =>
+      data.dataSourceConfigurations !== null ||
+      data.tablesConfigurations !== null ||
+      data.description !== null,
+    {
+      message: "Description required when both configurations are null",
+      path: ["description"],
+    }
+  );
+
 export type MCPServerConfigurationType = z.infer<
-  typeof mcpServerConfigurationSchema
+  typeof baseMcpServerConfigurationSchema
 >;
 
 const mcpActionSchema = baseActionSchema.extend({

--- a/front/components/agent_builder/AgentBuilderFormContext.tsx
+++ b/front/components/agent_builder/AgentBuilderFormContext.tsx
@@ -97,7 +97,7 @@ export const mcpTimeFrameSchema = timeFrameSchema;
 const baseActionSchema = z.object({
   id: z.string(),
   name: z.string(),
-  description: z.string(),
+  description: z.string().nullable(),
   noConfigurationRequired: z.boolean().optional(),
 });
 

--- a/front/components/agent_builder/capabilities/mcp/MCPServerViewsSheet.tsx
+++ b/front/components/agent_builder/capabilities/mcp/MCPServerViewsSheet.tsx
@@ -645,7 +645,10 @@ export function MCPServerViewsSheet({
         ...configurationTool,
         name: newActionName,
         description: formData.description,
-        configuration: formData.configuration,
+        configuration: {
+          ...formData.configuration,
+          description: formData.description,
+        },
       };
 
       handleConfigurationSaveUtil({

--- a/front/components/agent_builder/capabilities/mcp/utils/formDefaults.ts
+++ b/front/components/agent_builder/capabilities/mcp/utils/formDefaults.ts
@@ -21,6 +21,7 @@ export function getDefaultConfiguration(
 
   const defaults: MCPServerConfigurationType = {
     mcpServerViewId: mcpServerView?.sId ?? "not-a-valid-sId",
+    description: null,
     dataSourceConfigurations: null,
     tablesConfigurations: null,
     childAgentId: null,

--- a/front/components/agent_builder/get_spaceid_to_actions_map.test.ts
+++ b/front/components/agent_builder/get_spaceid_to_actions_map.test.ts
@@ -32,6 +32,7 @@ const createMockMCPAction = (
   description: `Description for ${name}`,
   configuration: {
     mcpServerViewId: mcpServerViewId || "",
+    description: `Description for ${name}`,
     dataSourceConfigurations: dataSourceConfigurations || null,
     tablesConfigurations: tablesConfigurations || null,
     childAgentId: null,

--- a/front/components/agent_builder/transformAgentConfiguration.ts
+++ b/front/components/agent_builder/transformAgentConfiguration.ts
@@ -128,7 +128,10 @@ export function convertActionsForFormData(
     name: action.name,
     description: action.description,
     type: "MCP",
-    configuration: action.configuration,
+    configuration: {
+      ...action.configuration,
+      description: action.description,
+    },
   }));
 }
 

--- a/front/components/agent_builder/types.ts
+++ b/front/components/agent_builder/types.ts
@@ -183,10 +183,10 @@ export function getDefaultMCPAction(
       requirements.requiresDataSourceConfiguration ||
       requirements.requiresDataWarehouseConfiguration ||
       requirements.requiresTableConfiguration
-        ? ""
+        ? null
         : mcpServerView
           ? getMcpServerViewDescription(mcpServerView)
-          : "",
+          : null,
     noConfigurationRequired: requirements.noRequirement,
   };
 }

--- a/front/components/agent_builder/types.ts
+++ b/front/components/agent_builder/types.ts
@@ -112,7 +112,6 @@ export const capabilityFormSchema = z
       .default(""),
     description: z
       .string()
-      .min(1, "Description is required")
       .max(
         DESCRIPTION_MAX_LENGTH,
         "Description should be less than 800 characters."

--- a/front/components/assistant_builder/ActionsScreen.tsx
+++ b/front/components/assistant_builder/ActionsScreen.tsx
@@ -173,11 +173,13 @@ export default function ActionsScreen({
       actionName,
       newActionName,
       newActionDescription,
+      actionDescription,
       getNewActionConfig,
     }: {
       actionName: string;
       newActionName?: string;
       newActionDescription?: string;
+      actionDescription?: string | null;
       getNewActionConfig: (
         old: AssistantBuilderMCPOrVizState["configuration"]
       ) => AssistantBuilderMCPOrVizState["configuration"];
@@ -190,7 +192,8 @@ export default function ActionsScreen({
             return {
               ...action,
               name: newActionName ?? action.name,
-              description: newActionDescription ?? action.description,
+              description:
+                actionDescription ?? newActionDescription ?? action.description,
               // This is quite unsatisfying, but using `as any` here and repeating every
               // other key in the object instead of spreading is actually the safest we can do.
               // There is no way (that I could find) to make typescript understand that
@@ -265,7 +268,7 @@ export default function ActionsScreen({
             updateAction({
               actionName: pendingAction.previousActionName,
               newActionName: newActionName,
-              newActionDescription: newAction.description,
+              newActionDescription: newAction.description ?? undefined,
               getNewActionConfig: () => newAction.configuration,
             });
           } else {
@@ -489,7 +492,8 @@ function NewActionModal({
         !hasActionError(newActionConfig, mcpServerViews)
       ) {
         newActionConfig.name = newActionConfig.name.trim();
-        newActionConfig.description = newActionConfig.description.trim();
+        newActionConfig.description =
+          newActionConfig.description?.trim() ?? null;
         onSave(newActionConfig);
         onCloseLocal();
       } else {
@@ -523,7 +527,7 @@ function NewActionModal({
       getNewActionConfig,
     }: {
       actionName: string;
-      actionDescription: string;
+      actionDescription: string | null;
       getNewActionConfig: (
         old: AssistantBuilderMCPConfiguration["configuration"]
       ) => AssistantBuilderMCPConfiguration["configuration"];
@@ -686,7 +690,7 @@ interface ActionConfigEditorProps {
   isEditing: boolean;
   updateAction: (args: {
     actionName: string;
-    actionDescription: string;
+    actionDescription: string | null;
     getNewActionConfig: (
       old: AssistantBuilderMCPConfigurationWithId["configuration"]
     ) => AssistantBuilderMCPConfigurationWithId["configuration"];
@@ -739,7 +743,7 @@ interface ActionEditorProps {
   setShowInvalidActionDescError: (error: string | null) => void;
   updateAction: (args: {
     actionName: string;
-    actionDescription: string;
+    actionDescription: string | null;
     getNewActionConfig: (
       old: AssistantBuilderMCPConfiguration["configuration"]
     ) => AssistantBuilderMCPConfiguration["configuration"];

--- a/front/components/assistant_builder/actions/DataDescription.tsx
+++ b/front/components/assistant_builder/actions/DataDescription.tsx
@@ -9,7 +9,7 @@ import type {
 interface DataDescriptionProps {
   updateAction: (args: {
     actionName: string;
-    actionDescription: string;
+    actionDescription: string | null;
     getNewActionConfig: (
       old: AssistantBuilderMCPConfiguration["configuration"]
     ) => AssistantBuilderMCPConfiguration["configuration"];
@@ -34,7 +34,7 @@ export const DataDescription = ({
     >
       <TextArea
         placeholder={"This data contains…"}
-        value={action.description}
+        value={action.description || ""}
         onChange={(e) => {
           if (e.target.value.length < 800) {
             updateAction({

--- a/front/components/assistant_builder/actions/MCPAction.tsx
+++ b/front/components/assistant_builder/actions/MCPAction.tsx
@@ -84,7 +84,7 @@ interface MCPActionProps {
   isEditing: boolean;
   updateAction: (args: {
     actionName: string;
-    actionDescription: string;
+    actionDescription: string | null;
     getNewActionConfig: (
       old: AssistantBuilderMCPConfiguration["configuration"]
     ) => AssistantBuilderMCPConfiguration["configuration"];

--- a/front/components/assistant_builder/actions/configuration/JsonSchemaConfigurationSection.tsx
+++ b/front/components/assistant_builder/actions/configuration/JsonSchemaConfigurationSection.tsx
@@ -11,8 +11,8 @@ import type { Result } from "@app/types";
 interface JsonSchemaConfigurationSectionProps {
   // The agent's instructions and tool description, needed to generate the
   // schema automatically if requested by the user.
-  instructions: string;
-  description: string;
+  instructions: string | null;
+  description: string | null;
   // A string that explains this schema configuration section, displayed to the
   // user.
   sectionConfigurationDescription: string;

--- a/front/components/assistant_builder/types.ts
+++ b/front/components/assistant_builder/types.ts
@@ -90,7 +90,7 @@ export type AssistantBuilderMCPConfiguration = {
   type: "MCP";
   configuration: AssistantBuilderMCPServerConfiguration;
   name: string;
-  description: string;
+  description: string | null;
   noConfigurationRequired?: boolean;
 };
 
@@ -103,7 +103,7 @@ export interface AssistantBuilderDataVisualizationConfiguration {
   type: "DATA_VISUALIZATION";
   configuration: Record<string, never>;
   name: string;
-  description: string;
+  description: string | null;
   noConfigurationRequired: true;
 }
 

--- a/front/lib/agent_yaml_converter/converter.ts
+++ b/front/lib/agent_yaml_converter/converter.ts
@@ -124,7 +124,7 @@ export class AgentYAMLConverter {
       for (const action of actions) {
         const baseAction = {
           name: action.name,
-          description: action.description,
+          description: action.description ?? "",
         };
 
         if (action.type === "DATA_VISUALIZATION") {

--- a/front/pages/api/w/[wId]/assistant/agent_configurations/index.ts
+++ b/front/pages/api/w/[wId]/assistant/agent_configurations/index.ts
@@ -270,7 +270,9 @@ export async function createOrUpgradeAgentConfiguration({
       }
       actionNames.add(action.name);
     }
-    const actionsWithoutDesc = actions.filter((action) => !action.description);
+
+    // We allow knowledge tools to not have any description
+    const actionsWithoutDesc = actions.filter((action) => !action.description && !action.dataSources && !action.tables);
     if (actionsWithoutDesc.length) {
       return new Err(
         Error(

--- a/front/pages/api/w/[wId]/assistant/agent_configurations/index.ts
+++ b/front/pages/api/w/[wId]/assistant/agent_configurations/index.ts
@@ -272,7 +272,9 @@ export async function createOrUpgradeAgentConfiguration({
     }
 
     // We allow knowledge tools to not have any description
-    const actionsWithoutDesc = actions.filter((action) => !action.description && !action.dataSources && !action.tables);
+    const actionsWithoutDesc = actions.filter(
+      (action) => !action.description && !action.dataSources && !action.tables
+    );
     if (actionsWithoutDesc.length) {
       return new Err(
         Error(


### PR DESCRIPTION
## Description


Makes action descriptions nullable in the agent builder and excludes knowledge tools (data sources and tables) from requiring a description.

## Tests

- [x] Locally
- [ ] front-edge

## Risk

Breaking agent

## Deploy Plan

Deploy front