### PR TITLE
[blocked action validaton] always use latest pending validation

### DIFF
--- a/front/components/assistant/conversation/BlockedActionsProvider.tsx
+++ b/front/components/assistant/conversation/BlockedActionsProvider.tsx
@@ -244,19 +244,9 @@ function useBlockedActionsQueue({
   >(blockedActions.map((action) => ({ blockedAction: action })));
 
   useEffect(() => {
-    if (blockedActions.length > 0) {
-      setBlockedActionsQueue((prevQueue) => {
-        const existingIds = new Set(
-          prevQueue.map((v) => v.blockedAction.actionId)
-        );
-        const newItems = blockedActions
-          .filter((v) => !existingIds.has(v.actionId))
-          .map((blockedAction) => ({
-            blockedAction,
-          }));
-        return [...prevQueue, ...newItems];
-      });
-    }
+    setBlockedActionsQueue(
+      blockedActions.map((action) => ({ blockedAction: action }))
+    );
   }, [blockedActions]);
 
   const enqueueBlockedAction = ({
@@ -274,7 +264,7 @@ function useBlockedActionsQueue({
       // If the action is not in the queue, add it.
       // If the action is in the queue, replace it with the new one.
       return existingIndex === -1
-        ? [...blockedActionsQueue, { blockedAction, message }]
+        ? [...prevQueue, { blockedAction, message }]
         : prevQueue.map((item, index) =>
             index === existingIndex ? { blockedAction, message } : item
           );
@@ -572,7 +562,7 @@ export function BlockedActionsProvider({
     if (hasPendingAuthentications && validatedActions === 0) {
       return "auth";
     }
-    const nextValidation = pendingValidations[validatedActions];
+    const nextValidation = pendingValidations[0];
     return nextValidation
       ? `validation-${nextValidation.blockedAction.actionId}`
       : pages[0].id;


### PR DESCRIPTION
## Description

- Once a user has validated an blocked action it's removed from the queue. Thus we should always render the first item from the blocked action queue.
- When we have to validated several actions at once we should always use the latest pending action
- Follow up on https://github.com/dust-tt/dust/pull/15517

## Tests

Tested locally

https://github.com/user-attachments/assets/5c7674a6-f2f4-41e1-8a7a-36ad66dfd431

## Risk

Low risk. Simplify code.

## Deploy Plan

- Deploy front
