### PR TITLE
Make name optional, and default to cronstrue when displaying

### DIFF
--- a/front/components/agent_builder/AgentBuilderFormContext.tsx
+++ b/front/components/agent_builder/AgentBuilderFormContext.tsx
@@ -210,7 +210,7 @@ export const agentBuilderFormSchema = z.object({
 });
 
 export const scheduleFormSchema = z.object({
-  name: z.string().min(1, "Name is required").max(255, "Name is too long"),
+  name: z.string().max(255, "Name is too long"),
   cron: z.string().min(9, "Cron expression is required"),
   timezone: z.string().min(1, "Timezone is required"),
   customPrompt: z.string(),

--- a/front/components/agent_builder/triggers/ScheduleEditionModal.tsx
+++ b/front/components/agent_builder/triggers/ScheduleEditionModal.tsx
@@ -51,7 +51,7 @@ export function ScheduleEditionModal({
   const isEditor = !trigger?.editor || trigger?.editor === user?.id;
 
   const defaultValues: ScheduleFormData = {
-    name: "Schedule",
+    name: "",
     cron: "",
     timezone: Intl.DateTimeFormat().resolvedOptions().timeZone,
     customPrompt: "",
@@ -153,7 +153,7 @@ export function ScheduleEditionModal({
           <FormProvider form={form} onSubmit={onSubmit}>
             <div className="space-y-4">
               <div>
-                <Label htmlFor="trigger-name">Trigger Name</Label>
+                <Label htmlFor="trigger-name">Trigger Name (optional)</Label>
                 <Input
                   id="trigger-name"
                   {...form.register("name")}

--- a/front/components/agent_builder/triggers/TriggerCard.tsx
+++ b/front/components/agent_builder/triggers/TriggerCard.tsx
@@ -40,6 +40,15 @@ export const TriggerCard = ({
     return "";
   }, [trigger.configuration?.cron]);
 
+  let triggerName = trigger.name;
+  let triggerDescription = cronDescription;
+
+  // If we don't have a name, use the cron description as the name, and skip the description to avoid duplication.
+  if (trigger.name?.trim() === "" && trigger.configuration) {
+    triggerName = cronstrue.toString(trigger.configuration.cron);
+    triggerDescription = "";
+  }
+
   return (
     <Card
       variant="primary"
@@ -61,10 +70,10 @@ export const TriggerCard = ({
       <div className="flex w-full flex-col gap-2 text-sm">
         <div className="flex w-full items-center gap-2 font-medium text-foreground dark:text-foreground-night">
           {getIcon(trigger.kind)}
-          <span className="truncate">{trigger.name}</span>
+          <span className="truncate">{triggerName}</span>
         </div>
         <span className="text-muted-foreground dark:text-muted-foreground-night">
-          {trigger.kind === "schedule" && <span>{cronDescription}</span>}
+          {trigger.kind === "schedule" && <span>{triggerDescription}</span>}
         </span>
       </div>
     </Card>

--- a/front/components/assistant/details/tabs/AgentTriggersTab.tsx
+++ b/front/components/assistant/details/tabs/AgentTriggersTab.tsx
@@ -8,6 +8,7 @@ import {
 } from "@dust-tt/sparkle";
 import { Button } from "@dust-tt/sparkle";
 import { Spinner } from "@dust-tt/sparkle";
+import cronstrue from "cronstrue";
 import { useState } from "react";
 
 import {
@@ -94,7 +95,10 @@ export function AgentTriggersTab({
                 <Icon
                   visual={trigger.kind === "schedule" ? ClockIcon : BellIcon}
                 />
-                <div className="font-medium">{trigger.name}</div>
+                <div className="font-medium">
+                  {trigger.name?.trim() ||
+                    cronstrue.toString(trigger.configuration.cron)}
+                </div>
               </div>
               <div className="self-end">
                 {trigger.isEditor ? (

--- a/front/components/assistant/details/tabs/AgentTriggersTab.tsx
+++ b/front/components/assistant/details/tabs/AgentTriggersTab.tsx
@@ -96,8 +96,9 @@ export function AgentTriggersTab({
                   visual={trigger.kind === "schedule" ? ClockIcon : BellIcon}
                 />
                 <div className="font-medium">
-                  {trigger.name?.trim() ||
-                    cronstrue.toString(trigger.configuration.cron)}
+                  {trigger.name?.trim() === ""
+                    ? cronstrue.toString(trigger.configuration.cron)
+                    : trigger.name}
                 </div>
               </div>
               <div className="self-end">


### PR DESCRIPTION
## Description

This does a few things discussed in https://github.com/dust-tt/tasks/issues/3920:

Trigger name is now optional:
<img width="500" height="475" alt="image" src="https://github.com/user-attachments/assets/a1e8a5ff-8913-4e79-8495-3b695bd7bdfc" />

In the cards, we fall back to cronstrue as the name, and omit the descr which would be identical"
<img width="874" height="183" alt="image" src="https://github.com/user-attachments/assets/d68086a0-b416-44e3-9618-3c12802e0bc3" />

In Triggers side panel, we fall back to construe:
<img width="507" height="376" alt="image" src="https://github.com/user-attachments/assets/ac94be5a-07bd-400f-84ad-6f027b6d1352" />

Note that we do not **set** the name, but only fall back to other fields in the UI.


## Tests

Manuel

## Risk

UI tweaks

## Deploy Plan

Front