### PR TITLE
[front] Replace `MCPActionType` with the resource

### DIFF
--- a/front/lib/actions/mcp_internal_actions/servers/run_agent/index.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/run_agent/index.ts
@@ -495,7 +495,10 @@ ${query}`
 
           let refsFromAgent: Record<string, CitationType> = {};
           let files: ActionGeneratedFileType[] = [];
-          if (isMCPActionArray(agentMessage.actions)) {
+          if (
+            Array.isArray(agentMessage.actions) &&
+            agentMessage.actions.every(isAgentMCPActionWithOutputType)
+          ) {
             refsFromAgent = getCitationsFromActions(agentMessage.actions);
             files = agentMessage.actions.flatMap((action: any) =>
               action.generatedFiles.filter((f: any) => !f.hidden)

--- a/front/lib/actions/mcp_internal_actions/servers/run_agent/index.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/run_agent/index.ts
@@ -635,9 +635,9 @@ ${query}`
               return new Err(new MCPError(errorMessage));
             } else if (event.type === "agent_message_success") {
               if (
-              Array.isArray(event.message.actions) &&
-              event.message.actions.every(isAgentMCPActionWithOutputType)
-            ) {
+                Array.isArray(event.message.actions) &&
+                event.message.actions.every(isAgentMCPActionWithOutputType)
+              ) {
                 refsFromAgent = getCitationsFromActions(event.message.actions);
                 files = event.message.actions.flatMap((action) =>
                   action.generatedFiles.filter((f) => !f.hidden)

--- a/front/lib/actions/mcp_internal_actions/servers/run_agent/index.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/run_agent/index.ts
@@ -634,6 +634,8 @@ ${query}`
               const errorMessage = `User message error: ${event.error.message}`;
               return new Err(new MCPError(errorMessage));
             } else if (event.type === "agent_message_success") {
+              // TODO(2025-09-22 aubin): update the SDK type to remove the need for this typeguard
+              //  (event.message.actions should always be an AgentMCPActionWithOutputType[]).
               if (
                 Array.isArray(event.message.actions) &&
                 event.message.actions.every(isAgentMCPActionWithOutputType)

--- a/front/lib/actions/mcp_internal_actions/servers/run_agent/index.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/run_agent/index.ts
@@ -500,8 +500,8 @@ ${query}`
             agentMessage.actions.every(isAgentMCPActionWithOutputType)
           ) {
             refsFromAgent = getCitationsFromActions(agentMessage.actions);
-            files = agentMessage.actions.flatMap((action: any) =>
-              action.generatedFiles.filter((f: any) => !f.hidden)
+            files = agentMessage.actions.flatMap((action) =>
+              action.generatedFiles.filter((f) => !f.hidden)
             );
           }
           return {

--- a/front/lib/actions/mcp_internal_actions/servers/run_agent/index.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/run_agent/index.ts
@@ -31,7 +31,6 @@ import type {
 } from "@app/lib/actions/types";
 import {
   isLightServerSideMCPToolConfiguration,
-  isMCPActionArray,
   isServerSideMCPServerConfiguration,
 } from "@app/lib/actions/types/guards";
 import { RUN_AGENT_ACTION_NUM_RESULTS } from "@app/lib/actions/utils";
@@ -54,6 +53,7 @@ import {
   normalizeError,
   Ok,
 } from "@app/types";
+import { isAgentMCPActionWithOutputType } from "@app/types/actions";
 
 const RUN_AGENT_TOOL_LOG_NAME = "run_agent";
 
@@ -634,7 +634,10 @@ ${query}`
               const errorMessage = `User message error: ${event.error.message}`;
               return new Err(new MCPError(errorMessage));
             } else if (event.type === "agent_message_success") {
-              if (isMCPActionArray(event.message.actions)) {
+              if (
+              Array.isArray(event.message.actions) &&
+              event.message.actions.every(isAgentMCPActionWithOutputType)
+            ) {
                 refsFromAgent = getCitationsFromActions(event.message.actions);
                 files = event.message.actions.flatMap((action) =>
                   action.generatedFiles.filter((f) => !f.hidden)

--- a/front/lib/actions/mcp_internal_actions/utils/file_utils.ts
+++ b/front/lib/actions/mcp_internal_actions/utils/file_utils.ts
@@ -67,7 +67,7 @@ export async function getFileFromConversationAttachment(
         }
       }
     } else if (isAgentMessageType(m)) {
-      const generatedFiles = m.actions.flatMap((a) => a.getGeneratedFiles());
+      const generatedFiles = m.actions.flatMap((a) => a.generatedFiles);
 
       for (const f of generatedFiles) {
         if (isContentCreationFileContentType(f.contentType)) {

--- a/front/lib/actions/types/guards.ts
+++ b/front/lib/actions/types/guards.ts
@@ -302,6 +302,8 @@ function isMCPActionType(action: unknown): action is MCPActionType {
 }
 
 // TODO: replace with a typeguard on AgentMCPActionWithOutputType.
-export function isMCPActionArray(actions: unknown): actions is MCPActionType[] {
+export function isAgentMCPActionArray(
+  actions: unknown
+): actions is MCPActionType[] {
   return Array.isArray(actions) && actions.every(isMCPActionType);
 }

--- a/front/lib/actions/types/guards.ts
+++ b/front/lib/actions/types/guards.ts
@@ -283,27 +283,3 @@ export function throwIfInvalidAgentConfiguration(
     }
   }
 }
-
-// TODO: replace with a typeguard AgentMCPActionWithOutputType.
-function isMCPActionType(action: unknown): action is MCPActionType {
-  return (
-    typeof action === "object" &&
-    action !== null &&
-    "id" in action &&
-    typeof action.id === "number" &&
-    "agentMessageId" in action &&
-    typeof action.agentMessageId === "number" &&
-    "output" in action &&
-    "step" in action &&
-    typeof action.step === "number" &&
-    "citationsAllocated" in action &&
-    typeof action.citationsAllocated === "number"
-  );
-}
-
-// TODO: replace with a typeguard on AgentMCPActionWithOutputType.
-export function isAgentMCPActionArray(
-  actions: unknown
-): actions is MCPActionType[] {
-  return Array.isArray(actions) && actions.every(isMCPActionType);
-}

--- a/front/lib/actions/types/guards.ts
+++ b/front/lib/actions/types/guards.ts
@@ -3,7 +3,6 @@ import type {
   LightClientSideMCPToolConfigurationType,
   LightMCPToolConfigurationType,
   LightServerSideMCPToolConfigurationType,
-  MCPActionType,
   MCPServerConfigurationType,
   MCPToolConfigurationType,
   ServerSideMCPServerConfigurationType,

--- a/front/lib/actions/types/guards.ts
+++ b/front/lib/actions/types/guards.ts
@@ -284,6 +284,7 @@ export function throwIfInvalidAgentConfiguration(
   }
 }
 
+// TODO: replace with a typeguard AgentMCPActionWithOutputType.
 function isMCPActionType(action: unknown): action is MCPActionType {
   return (
     typeof action === "object" &&
@@ -300,6 +301,7 @@ function isMCPActionType(action: unknown): action is MCPActionType {
   );
 }
 
+// TODO: replace with a typeguard on AgentMCPActionWithOutputType.
 export function isMCPActionArray(actions: unknown): actions is MCPActionType[] {
   return Array.isArray(actions) && actions.every(isMCPActionType);
 }

--- a/front/lib/api/assistant/citations.ts
+++ b/front/lib/api/assistant/citations.ts
@@ -1,4 +1,3 @@
-import type { MCPActionType } from "@app/lib/actions/mcp";
 import {
   isRunAgentResultResourceType,
   isSearchResultResourceType,
@@ -11,6 +10,7 @@ import type {
   LightAgentMessageType,
 } from "@app/types";
 import { removeNulls } from "@app/types";
+import type { AgentMCPActionWithOutputType } from "@app/types/actions";
 
 let REFS: string[] | null = null;
 const getRand = rand("chawarma");
@@ -49,7 +49,7 @@ export function citationMetaPrompt(isUsingRunAgent: boolean) {
 }
 
 export const getCitationsFromActions = (
-  actions: MCPActionType[]
+  actions: AgentMCPActionWithOutputType[]
 ): Record<string, CitationType> => {
   const searchResultsWithDocs = removeNulls(
     actions.flatMap((action) =>

--- a/front/lib/api/assistant/citations.ts
+++ b/front/lib/api/assistant/citations.ts
@@ -15,7 +15,7 @@ import type { AgentMCPActionWithOutputType } from "@app/types/actions";
 let REFS: string[] | null = null;
 const getRand = rand("chawarma");
 
-export const getRefs = () => {
+export function getRefs() {
   const alphabet = "abcdefghijklmnopqrstuvwxyz0123456789".split("");
   if (REFS === null) {
     REFS = [];
@@ -30,7 +30,7 @@ export const getRefs = () => {
     REFS.sort(() => (getRand() > 0.5 ? 1 : -1));
   }
   return REFS;
-};
+}
 
 /**
  * Prompt to remind agents how to cite documents or web pages.
@@ -48,9 +48,9 @@ export function citationMetaPrompt(isUsingRunAgent: boolean) {
   );
 }
 
-export const getCitationsFromActions = (
+export function getCitationsFromActions(
   actions: AgentMCPActionWithOutputType[]
-): Record<string, CitationType> => {
+): Record<string, CitationType> {
   const searchResultsWithDocs = removeNulls(
     actions.flatMap((action) =>
       action.output?.filter(isSearchResultResourceType).map((o) => o.resource)
@@ -105,11 +105,11 @@ export const getCitationsFromActions = (
     ...websearchRefs,
     ...runAgentRefs,
   };
-};
+}
 
-export const getLightAgentMessageFromAgentMessage = (
+export function getLightAgentMessageFromAgentMessage(
   agentMessage: AgentMessageType
-): LightAgentMessageType => {
+): LightAgentMessageType {
   return {
     type: "agent_message",
     sId: agentMessage.sId,
@@ -138,4 +138,4 @@ export const getLightAgentMessageFromAgentMessage = (
         ...(f.hidden ? { hidden: true } : {}),
       })),
   };
-};
+}

--- a/front/lib/api/assistant/conversation/files.ts
+++ b/front/lib/api/assistant/conversation/files.ts
@@ -4,15 +4,15 @@ import { isAgentMessageType } from "@app/types";
 
 export function listGeneratedFiles(
   conversation: ConversationType
-): Array<ActionGeneratedFileType> {
-  const files: Array<ActionGeneratedFileType> = [];
+): ActionGeneratedFileType[] {
+  const files: ActionGeneratedFileType[] = [];
 
   for (const versions of conversation.content) {
     const message = versions[versions.length - 1];
 
     if (isAgentMessageType(message)) {
-      const generatedFiles = message.actions.flatMap((action) =>
-        action.getGeneratedFiles()
+      const generatedFiles = message.actions.flatMap(
+        (action) => action.generatedFiles
       );
 
       files.push(

--- a/front/lib/api/assistant/jit_utils.ts
+++ b/front/lib/api/assistant/jit_utils.ts
@@ -41,7 +41,7 @@ export function listAttachments(
         attachments.push(attachment);
       }
     } else if (isAgentMessageType(m)) {
-      const generatedFiles = m.actions.flatMap((a) => a.getGeneratedFiles());
+      const generatedFiles = m.actions.flatMap((a) => a.generatedFiles);
 
       for (const f of generatedFiles) {
         // Content Creation files should not be shown in the JIT.
@@ -58,8 +58,6 @@ export function listAttachments(
           })
         );
       }
-    } else {
-      continue;
     }
   }
 

--- a/front/lib/api/assistant/messages.ts
+++ b/front/lib/api/assistant/messages.ts
@@ -1,7 +1,6 @@
 import type { WhereOptions } from "sequelize";
 import { Op, Sequelize } from "sequelize";
 
-import type { MCPActionType } from "@app/lib/actions/mcp";
 import {
   AgentMessageContentParser,
   getDelimitersConfiguration,
@@ -36,6 +35,7 @@ import type {
 } from "@app/types";
 import type { LightAgentConfigurationType } from "@app/types";
 import { ConversationError, Err, Ok, removeNulls } from "@app/types";
+import type { AgentMCPActionWithOutputType } from "@app/types/actions";
 import type {
   AgentContentItemType,
   ReasoningContentType,
@@ -64,7 +64,7 @@ export function getMaximalVersionAgentStepContent(
 }
 
 export async function generateParsedContents(
-  actions: MCPActionType[],
+  actions: AgentMCPActionWithOutputType[],
   agentConfiguration: LightAgentConfigurationType,
   messageId: string,
   contents: { step: number; content: AgentContentItemType }[]

--- a/front/lib/api/assistant/messages.ts
+++ b/front/lib/api/assistant/messages.ts
@@ -26,6 +26,7 @@ import type {
   ContentFragmentType,
   ConversationWithoutContentType,
   FetchConversationMessagesResponse,
+  LightAgentConfigurationType,
   LightAgentMessageType,
   LightMessageWithRankType,
   MessageWithRankType,
@@ -33,7 +34,6 @@ import type {
   Result,
   UserMessageType,
 } from "@app/types";
-import type { LightAgentConfigurationType } from "@app/types";
 import { ConversationError, Err, Ok, removeNulls } from "@app/types";
 import type { AgentMCPActionWithOutputType } from "@app/types/actions";
 import type {

--- a/front/lib/api/assistant/messages.ts
+++ b/front/lib/api/assistant/messages.ts
@@ -68,8 +68,8 @@ export async function generateParsedContents(
   agentConfiguration: LightAgentConfigurationType,
   messageId: string,
   contents: { step: number; content: AgentContentItemType }[]
-): Promise<Record<number, Array<ParsedContentItem>>> {
-  const parsedContents: Record<number, Array<ParsedContentItem>> = {};
+): Promise<Record<number, ParsedContentItem[]>> {
+  const parsedContents: Record<number, ParsedContentItem[]> = {};
   const actionsByCallId = new Map(actions.map((a) => [a.functionCallId, a]));
 
   for (const c of contents) {
@@ -112,7 +112,6 @@ export async function generateParsedContents(
       if (matchingAction) {
         parsedContents[step].push({ kind: "action", action: matchingAction });
       }
-      continue;
     }
   }
 

--- a/front/lib/api/assistant/messages.ts
+++ b/front/lib/api/assistant/messages.ts
@@ -16,6 +16,7 @@ import {
   Message,
   UserMessage,
 } from "@app/lib/models/assistant/conversation";
+import { AgentMCPActionResource } from "@app/lib/resources/agent_mcp_action_resource";
 import { AgentStepContentResource } from "@app/lib/resources/agent_step_content_resource";
 import { ContentFragmentResource } from "@app/lib/resources/content_fragment_resource";
 import { ConversationResource } from "@app/lib/resources/conversation_resource";
@@ -208,31 +209,26 @@ async function batchRenderAgentMessages<V extends RenderMessageVariant>(
     // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
     agentMessages.map((m) => m.agentMessageId || null)
   );
-  const [agentConfigurations, agentMCPActions] = await Promise.all([
-    (async () => {
-      // Get all unique pairs id-version for the agent configurations
-      const agentConfigurationIds = agentMessages.reduce((acc, m) => {
-        if (m.agentMessage) {
-          acc.add(m.agentMessage.agentConfigurationId);
-        }
-        return acc;
-      }, new Set<string>());
+  // Get all unique pairs id-version for the agent configurations
+  const agentConfigurationIds = agentMessages.reduce((acc, m) => {
+    if (m.agentMessage) {
+      acc.add(m.agentMessage.agentConfigurationId);
+    }
+    return acc;
+  }, new Set<string>());
 
-      return getAgentConfigurations(auth, {
-        agentIds: [...agentConfigurationIds],
-        variant: "extra_light",
-      });
-    })(),
-    (async () => {
-      const agentStepContents =
-        await AgentStepContentResource.fetchByAgentMessages(auth, {
-          agentMessageIds,
-          includeMCPActions: true,
-          latestVersionsOnly: true,
-        });
-      return agentStepContents.map((sc) => sc.toJSON().mcpActions ?? []).flat();
-    })(),
-  ]);
+  const agentConfigurations = await getAgentConfigurations(auth, {
+    agentIds: [...agentConfigurationIds],
+    variant: "extra_light",
+  });
+
+  const stepContents = await AgentStepContentResource.fetchByAgentMessages(
+    auth,
+    {
+      agentMessageIds,
+      latestVersionsOnly: true,
+    }
+  );
 
   if (!agentConfigurations) {
     return new Err(
@@ -240,14 +236,18 @@ async function batchRenderAgentMessages<V extends RenderMessageVariant>(
     );
   }
 
-  const stepContents = await AgentStepContentResource.fetchByAgentMessages(
+  const agentMCPActions = await AgentMCPActionResource.fetchByStepContents(
     auth,
     {
-      agentMessageIds: agentMessageIds,
-      includeMCPActions: false,
+      stepContents,
       latestVersionsOnly: true,
     }
   );
+  const actionsWithOutputs =
+    await AgentMCPActionResource.enrichActionsWithOutputItems(
+      auth,
+      agentMCPActions
+    );
 
   const stepContentsByMessageId: Record<string, AgentStepContentResource[]> =
     stepContents.reduce(
@@ -272,7 +272,7 @@ async function batchRenderAgentMessages<V extends RenderMessageVariant>(
       }
       const agentMessage = message.agentMessage;
 
-      const actions = agentMCPActions
+      const actions = actionsWithOutputs
         .filter((a) => a.agentMessageId === agentMessage.id)
         .sort((a, b) => a.step - b.step);
 

--- a/front/lib/api/assistant/preprocessing.ts
+++ b/front/lib/api/assistant/preprocessing.ts
@@ -387,11 +387,11 @@ export async function renderConversationForModel(
 }
 
 type Step = {
-  contents: Array<Exclude<AgentContentItemType, ErrorContentType>>;
-  actions: Array<{
+  contents: Exclude<AgentContentItemType, ErrorContentType>[];
+  actions: {
     call: FunctionCallType;
     result: FunctionMessageTypeModel;
-  }>;
+  }[];
 };
 
 function renderActionForMultiActionsModel(

--- a/front/lib/api/assistant/preprocessing.ts
+++ b/front/lib/api/assistant/preprocessing.ts
@@ -1,3 +1,5 @@
+import { isTextContent } from "@app/lib/actions/mcp_internal_actions/output_schemas";
+import { rewriteContentForModel } from "@app/lib/actions/mcp_utils";
 import {
   getTextContentFromMessage,
   getTextRepresentationFromMessages,
@@ -29,6 +31,7 @@ import {
   Ok,
   removeNulls,
 } from "@app/types";
+import type { AgentMCPActionWithOutputType } from "@app/types/actions";
 import type {
   AgentContentItemType,
   ErrorContentType,
@@ -391,6 +394,57 @@ type Step = {
   }>;
 };
 
+function renderActionForMultiActionsModel(
+  action: AgentMCPActionWithOutputType,
+  model: ModelConfigurationType
+): FunctionMessageTypeModel {
+  const totalTextLength =
+    action.output?.reduce(
+      (acc, curr) => acc + (curr.type === "text" ? curr.text?.length ?? 0 : 0),
+      0
+    ) ?? 0;
+
+  if (totalTextLength > model.contextSize * 0.9) {
+    return {
+      role: "function" as const,
+      name: action.functionCallName,
+      function_call_id: action.functionCallId,
+      content:
+        "The tool returned too much content. The response cannot be processed.",
+    };
+  }
+
+  if (action.status === "denied") {
+    return {
+      role: "function" as const,
+      name: action.functionCallName,
+      function_call_id: action.functionCallId,
+      content:
+        "The user rejected this specific action execution. Using this action is hence forbidden for this message.",
+    };
+  }
+
+  const outputItems = removeNulls(
+    action.output?.map(rewriteContentForModel) ?? []
+  );
+
+  let output;
+  if (outputItems.length === 0) {
+    output = "Successfully executed action, no output.";
+  } else if (outputItems.every((item) => isTextContent(item))) {
+    output = outputItems.map((item) => item.text).join("\n");
+  } else {
+    output = JSON.stringify(outputItems);
+  }
+
+  return {
+    role: "function" as const,
+    name: action.functionCallName,
+    function_call_id: action.functionCallId,
+    content: output,
+  };
+}
+
 async function getSteps(
   auth: Authenticator,
   {
@@ -426,10 +480,12 @@ async function getSteps(
     // All these calls are not async, so we're not doing a Promise.all for now but might need to
     // be reconsidered in the future.
     stepByStepIndex[stepIndex].actions.push({
-      call: action.renderForFunctionCall(),
-      result: await action.renderForMultiActionsModel(auth, {
-        model,
-      }),
+      call: {
+        id: action.functionCallId,
+        name: action.functionCallName,
+        arguments: JSON.stringify(action.params),
+      },
+      result: renderActionForMultiActionsModel(action, model),
     });
   }
 

--- a/front/lib/resources/agent_mcp_action_resource.ts
+++ b/front/lib/resources/agent_mcp_action_resource.ts
@@ -36,8 +36,6 @@ import {
   Message,
 } from "@app/lib/models/assistant/conversation";
 import { AgentStepContentResource } from "@app/lib/resources/agent_step_content_resource";
-import { AgentMessage, Message } from "@app/lib/models/assistant/conversation";
-import type { AgentStepContentResource } from "@app/lib/resources/agent_step_content_resource";
 import { BaseResource } from "@app/lib/resources/base_resource";
 import { ConversationResource } from "@app/lib/resources/conversation_resource";
 import { FileResource } from "@app/lib/resources/file_resource";

--- a/front/lib/resources/agent_mcp_action_resource.ts
+++ b/front/lib/resources/agent_mcp_action_resource.ts
@@ -642,6 +642,8 @@ export class AgentMCPActionResource extends BaseResource<AgentMCPActionModel> {
     );
 
     const fileById = _.keyBy(
+      // Using the model instead of the resource since we're mutating outputItems.
+      // Not super clean but everything happens in this one function and faster to write.
       await FileModel.findAll({
         where: {
           workspaceId,
@@ -673,10 +675,6 @@ export class AgentMCPActionResource extends BaseResource<AgentMCPActionModel> {
             }
 
             const file = o.file;
-            const fileSid = FileResource.modelIdToSId({
-              id: file.id,
-              workspaceId: action.workspaceId,
-            });
 
             const hidden =
               o.content.type === "resource" &&
@@ -684,7 +682,10 @@ export class AgentMCPActionResource extends BaseResource<AgentMCPActionModel> {
               o.content.resource.hidden === true;
 
             return {
-              fileId: fileSid,
+              fileId: FileResource.modelIdToSId({
+                id: file.id,
+                workspaceId: file.workspaceId,
+              }),
               contentType: file.contentType,
               title: file.fileName,
               snippet: file.snippet,

--- a/front/lib/resources/agent_mcp_action_resource.ts
+++ b/front/lib/resources/agent_mcp_action_resource.ts
@@ -556,6 +556,7 @@ export class AgentMCPActionResource extends BaseResource<AgentMCPActionModel> {
       agentMessageId: this.agentMessageId,
       citationsAllocated: this.citationsAllocated,
       functionCallName: this.functionCallName,
+      functionCallId: this.stepContent.value.value.id,
       id: this.id,
       internalMCPServerName: this.metadata.internalMCPServerName,
       mcpServerId: this.metadata.mcpServerId,

--- a/front/lib/resources/agent_mcp_action_resource.ts
+++ b/front/lib/resources/agent_mcp_action_resource.ts
@@ -554,12 +554,14 @@ export class AgentMCPActionResource extends BaseResource<AgentMCPActionModel> {
 
     return {
       agentMessageId: this.agentMessageId,
+      citationsAllocated: this.citationsAllocated,
       functionCallName: this.functionCallName,
       id: this.id,
       internalMCPServerName: this.metadata.internalMCPServerName,
       mcpServerId: this.metadata.mcpServerId,
       params: this.augmentedInputs,
       status: this.status,
+      step: this.stepContent.step,
     };
   }
 

--- a/front/lib/resources/agent_mcp_action_resource.ts
+++ b/front/lib/resources/agent_mcp_action_resource.ts
@@ -1,4 +1,5 @@
 import assert from "assert";
+import _ from "lodash";
 import type {
   Attributes,
   CreationAttributes,
@@ -13,6 +14,8 @@ import type { BlockedToolExecution } from "@app/lib/actions/mcp";
 import { getMcpServerViewDisplayName } from "@app/lib/actions/mcp_helper";
 import type { InternalMCPServerNameType } from "@app/lib/actions/mcp_internal_actions/constants";
 import { getInternalMCPServerNameFromSId } from "@app/lib/actions/mcp_internal_actions/constants";
+import { isToolGeneratedFile } from "@app/lib/actions/mcp_internal_actions/output_schemas";
+import { hideFileFromActionOutput } from "@app/lib/actions/mcp_utils";
 import type { ToolExecutionStatus } from "@app/lib/actions/statuses";
 import {
   isToolExecutionStatusBlocked,
@@ -22,7 +25,10 @@ import type { StepContext } from "@app/lib/actions/types";
 import { isLightServerSideMCPToolConfiguration } from "@app/lib/actions/types/guards";
 import { getAgentConfigurations } from "@app/lib/api/assistant/configuration/agent";
 import type { Authenticator } from "@app/lib/auth";
-import { AgentMCPActionModel } from "@app/lib/models/assistant/actions/mcp";
+import {
+  AgentMCPActionModel,
+  AgentMCPActionOutputItem,
+} from "@app/lib/models/assistant/actions/mcp";
 import { AgentStepContentModel } from "@app/lib/models/assistant/agent_step_content";
 import {
   AgentMessage,
@@ -30,9 +36,13 @@ import {
   Message,
 } from "@app/lib/models/assistant/conversation";
 import { AgentStepContentResource } from "@app/lib/resources/agent_step_content_resource";
+import { AgentMessage, Message } from "@app/lib/models/assistant/conversation";
+import type { AgentStepContentResource } from "@app/lib/resources/agent_step_content_resource";
 import { BaseResource } from "@app/lib/resources/base_resource";
 import { ConversationResource } from "@app/lib/resources/conversation_resource";
+import { FileResource } from "@app/lib/resources/file_resource";
 import { MCPServerViewResource } from "@app/lib/resources/mcp_server_view_resource";
+import { FileModel } from "@app/lib/resources/storage/models/files";
 import type { ReadonlyAttributesType } from "@app/lib/resources/storage/types";
 import type { ModelStaticWorkspaceAware } from "@app/lib/resources/storage/wrappers/workspace_models";
 import { getResourceIdFromSId, makeSId } from "@app/lib/resources/string_ids";
@@ -41,7 +51,10 @@ import logger from "@app/logger/logger";
 import type { GetMCPActionsResult } from "@app/pages/api/w/[wId]/labs/mcp_actions/[agentId]";
 import type { LightAgentConfigurationType, ModelId, Result } from "@app/types";
 import { Err, isString, normalizeError, Ok, removeNulls } from "@app/types";
-import type { AgentMCPActionType } from "@app/types/actions";
+import type {
+  AgentMCPActionType,
+  AgentMCPActionWithOutputType,
+} from "@app/types/actions";
 import type { FunctionCallContentType } from "@app/types/assistant/agent_message_content";
 
 // Attributes are marked as read-only to reflect the stateless nature of our Resource.
@@ -388,6 +401,66 @@ export class AgentMCPActionResource extends BaseResource<AgentMCPActionModel> {
     return blockedActionsList;
   }
 
+  static async fetchByStepContents(
+    auth: Authenticator,
+    {
+      stepContents,
+      latestVersionsOnly = false,
+    }: {
+      stepContents: AgentStepContentResource[];
+      latestVersionsOnly?: boolean;
+    }
+  ): Promise<AgentMCPActionResource[]> {
+    if (stepContents.length === 0) {
+      return [];
+    }
+
+    const workspaceId = auth.getNonNullableWorkspace().id;
+
+    // Not using the baseFetch because we already have the step contents.
+    let actions = await AgentMCPActionModel.findAll({
+      where: {
+        workspaceId,
+        stepContentId: {
+          [Op.in]: stepContents.map((content) => content.id),
+        },
+      },
+    });
+
+    if (latestVersionsOnly) {
+      const actionsByStepContentId = _.groupBy(actions, (action) =>
+        action.stepContentId.toString()
+      );
+      actions = removeNulls(
+        Object.values(actionsByStepContentId).map(
+          (actionsForContent) => _.maxBy(actionsForContent, "version") ?? null
+        )
+      );
+    }
+
+    const stepContentsMap = new Map(stepContents.map((s) => [s.id, s]));
+
+    return actions.map((a) => {
+      const stepContent = stepContentsMap.get(a.stepContentId);
+
+      // Each action must have a function call step content.
+      assert(stepContent, "Step content not found.");
+      assert(
+        stepContent.isFunctionCallContent(),
+        "Step content is not a function call."
+      );
+
+      const internalMCPServerName = a.toolConfiguration.toolServerId
+        ? getInternalMCPServerNameFromSId(a.toolConfiguration.toolServerId)
+        : null;
+
+      return new this(this.model, a.get(), stepContent, {
+        internalMCPServerName,
+        mcpServerId: a.toolConfiguration.toolServerId,
+      });
+    });
+  }
+
   static async listByAgentMessageIds(
     auth: Authenticator,
     agentMessageIds: ModelId[]
@@ -544,6 +617,85 @@ export class AgentMCPActionResource extends BaseResource<AgentMCPActionModel> {
     );
 
     return actions;
+  }
+
+  static async enrichActionsWithOutputItems(
+    auth: Authenticator,
+    actions: AgentMCPActionResource[]
+  ): Promise<AgentMCPActionWithOutputType[]> {
+    const workspaceId = auth.getNonNullableWorkspace().id;
+
+    const outputItemsByActionId = _.groupBy(
+      await AgentMCPActionOutputItem.findAll({
+        where: {
+          workspaceId,
+          agentMCPActionId: {
+            [Op.in]: actions.map((a) => a.id),
+          },
+        },
+      }),
+      "agentMCPActionId"
+    );
+
+    const fileIds = removeNulls(
+      Object.values(outputItemsByActionId).flatMap((o) =>
+        o.map((o) => o.fileId)
+      )
+    );
+
+    const fileById = _.keyBy(
+      await FileModel.findAll({
+        where: {
+          workspaceId,
+          id: {
+            [Op.in]: fileIds,
+          },
+        },
+      }),
+      "id"
+    );
+
+    for (const outputItems of Object.values(outputItemsByActionId)) {
+      for (const item of outputItems) {
+        if (item.fileId) {
+          item.file = fileById[item.fileId.toString()];
+        }
+      }
+    }
+
+    return actions.map((action) => {
+      const outputItems = outputItemsByActionId[action.id.toString()] ?? [];
+      return {
+        ...action.toJSON(),
+        output: removeNulls(outputItems.map(hideFileFromActionOutput)),
+        generatedFiles: removeNulls(
+          outputItems.map((o) => {
+            if (!o.file) {
+              return null;
+            }
+
+            const file = o.file;
+            const fileSid = FileResource.modelIdToSId({
+              id: file.id,
+              workspaceId: action.workspaceId,
+            });
+
+            const hidden =
+              o.content.type === "resource" &&
+              isToolGeneratedFile(o.content) &&
+              o.content.resource.hidden === true;
+
+            return {
+              fileId: fileSid,
+              contentType: file.contentType,
+              title: file.fileName,
+              snippet: file.snippet,
+              ...(hidden ? { hidden: true } : {}),
+            };
+          })
+        ),
+      };
+    });
   }
 
   toJSON(): AgentMCPActionType {

--- a/front/lib/resources/agent_step_content_resource.ts
+++ b/front/lib/resources/agent_step_content_resource.ts
@@ -28,6 +28,7 @@ import { withTransaction } from "@app/lib/utils/sql_utils";
 import logger from "@app/logger/logger";
 import type { ModelId, Result } from "@app/types";
 import { Err, Ok, removeNulls } from "@app/types";
+import type { AgentMCPActionWithOutputType } from "@app/types/actions";
 import type {
   AgentStepContentType,
   FunctionCallContentType,
@@ -367,6 +368,8 @@ export class AgentStepContentResource extends BaseResource<AgentStepContentModel
           "Unexpected: MCP actions on non-function call step content"
         );
         // MCP actions filtering already happened in fetch methods if latestVersionsOnly was requested
+        // TODO(durable-agents): use AgentMCPActionResource.toJSON(), which may require moving
+        //  its constructor to the AgentStepContentResource instead of the model.
         base.mcpActions = this.agentMCPActions.map(
           (action: AgentMCPActionModel) => {
             const mcpServerId = action.toolConfiguration?.toolServerId || null;
@@ -409,7 +412,7 @@ export class AgentStepContentResource extends BaseResource<AgentStepContentModel
                   };
                 })
               ),
-            };
+            } satisfies AgentMCPActionWithOutputType;
           }
         );
       }

--- a/front/lib/resources/agent_step_content_resource.ts
+++ b/front/lib/resources/agent_step_content_resource.ts
@@ -8,27 +8,18 @@ import type {
 } from "sequelize";
 import { Op } from "sequelize";
 
-import { getInternalMCPServerNameFromSId } from "@app/lib/actions/mcp_internal_actions/constants";
-import { isToolGeneratedFile } from "@app/lib/actions/mcp_internal_actions/output_schemas";
-import { hideFileFromActionOutput } from "@app/lib/actions/mcp_utils";
 import { getAgentConfigurations } from "@app/lib/api/assistant/configuration/agent";
 import type { Authenticator } from "@app/lib/auth";
-import {
-  AgentMCPActionModel,
-  AgentMCPActionOutputItem,
-} from "@app/lib/models/assistant/actions/mcp";
+import { AgentMCPActionModel } from "@app/lib/models/assistant/actions/mcp";
 import { AgentStepContentModel } from "@app/lib/models/assistant/agent_step_content";
 import { AgentMessage } from "@app/lib/models/assistant/conversation";
 import { BaseResource } from "@app/lib/resources/base_resource";
-import { FileResource } from "@app/lib/resources/file_resource";
-import { FileModel } from "@app/lib/resources/storage/models/files";
 import type { ReadonlyAttributesType } from "@app/lib/resources/storage/types";
 import { makeSId } from "@app/lib/resources/string_ids";
 import { withTransaction } from "@app/lib/utils/sql_utils";
 import logger from "@app/logger/logger";
 import type { ModelId, Result } from "@app/types";
-import { Err, Ok, removeNulls } from "@app/types";
-import type { AgentMCPActionWithOutputType } from "@app/types/actions";
+import { Err, Ok } from "@app/types";
 import type {
   AgentStepContentType,
   FunctionCallContentType,
@@ -160,12 +151,10 @@ export class AgentStepContentResource extends BaseResource<AgentStepContentModel
     {
       agentMessageIds,
       transaction,
-      includeMCPActions = false,
       latestVersionsOnly = false,
     }: {
       agentMessageIds: ModelId[];
       transaction?: Transaction;
-      includeMCPActions?: boolean;
       latestVersionsOnly?: boolean;
     }
   ): Promise<AgentStepContentResource[]> {
@@ -192,104 +181,17 @@ export class AgentStepContentResource extends BaseResource<AgentStepContentModel
       transaction,
     });
 
-    if (includeMCPActions) {
-      const contentIds: ModelId[] = contents.map((c) => c.id);
-
-      const mcpActionsByContentId = _.groupBy(
-        await AgentMCPActionModel.findAll({
-          where: {
-            workspaceId: owner.id,
-            stepContentId: {
-              [Op.in]: contentIds,
-            },
-          },
-        }),
-        "stepContentId"
-      );
-
-      const actionIds = Object.values(mcpActionsByContentId).flatMap((a) =>
-        a.map((a) => a.id)
-      );
-
-      const outputItemsByActionId = _.groupBy(
-        await AgentMCPActionOutputItem.findAll({
-          where: {
-            workspaceId: owner.id,
-            agentMCPActionId: {
-              [Op.in]: actionIds,
-            },
-          },
-        }),
-        "agentMCPActionId"
-      );
-
-      const fileIds = removeNulls(
-        Object.values(outputItemsByActionId).flatMap((o) =>
-          o.map((o) => o.fileId)
-        )
-      );
-
-      const fileById = _.keyBy(
-        await FileModel.findAll({
-          where: {
-            workspaceId: owner.id,
-            id: {
-              [Op.in]: fileIds,
-            },
-          },
-        }),
-        "id"
-      );
-
-      for (const outputItems of Object.values(outputItemsByActionId)) {
-        for (const item of outputItems) {
-          if (item.fileId) {
-            item.file = fileById[item.fileId.toString()];
-          }
-        }
-      }
-
-      for (const actions of Object.values(mcpActionsByContentId)) {
-        for (const action of actions) {
-          action.outputItems =
-            outputItemsByActionId[action.id.toString()] ?? [];
-        }
-      }
-
-      for (const content of contents) {
-        content.agentMCPActions =
-          mcpActionsByContentId[content.id.toString()] ?? [];
-      }
-    }
-
     if (latestVersionsOnly) {
       contents = this.filterLatestVersions(contents, [
         "agentMessageId",
         "step",
         "index",
       ]);
-
-      // Also filter MCP actions to latest versions
-      if (includeMCPActions) {
-        contents.forEach((c) => {
-          if (!("agentMCPActions" in c)) {
-            return;
-          }
-          const maxVersionAction = _.maxBy(
-            c.agentMCPActions as AgentMCPActionModel[],
-            "version"
-          );
-          c.agentMCPActions = maxVersionAction ? [maxVersionAction] : [];
-        });
-      }
     }
 
     return contents.map(
       (content) =>
-        new AgentStepContentResource(AgentStepContentModel, {
-          ...content.get(),
-          agentMCPActions: content.agentMCPActions,
-        })
+        new AgentStepContentResource(AgentStepContentModel, content.get())
     );
   }
 
@@ -345,7 +247,7 @@ export class AgentStepContentResource extends BaseResource<AgentStepContentModel
       };
     }
 
-    const base: AgentStepContentType = {
+    return {
       id: this.id,
       sId: this.sId,
       createdAt: this.createdAt.getTime(),
@@ -357,68 +259,6 @@ export class AgentStepContentResource extends BaseResource<AgentStepContentModel
       type: this.type,
       value,
     };
-
-    if ("agentMCPActions" in this && Array.isArray(this.agentMCPActions)) {
-      if (this.agentMCPActions.length === 0) {
-        base.mcpActions = [];
-      } else {
-        const { value } = this;
-        assert(
-          value.type === "function_call",
-          "Unexpected: MCP actions on non-function call step content"
-        );
-        // MCP actions filtering already happened in fetch methods if latestVersionsOnly was requested
-        // TODO(durable-agents): use AgentMCPActionResource.toJSON(), which may require moving
-        //  its constructor to the AgentStepContentResource instead of the model.
-        base.mcpActions = this.agentMCPActions.map(
-          (action: AgentMCPActionModel) => {
-            const mcpServerId = action.toolConfiguration?.toolServerId || null;
-
-            return {
-              id: action.id,
-              agentMessageId: action.agentMessageId,
-              functionCallName: value.value.name,
-              internalMCPServerName:
-                getInternalMCPServerNameFromSId(mcpServerId),
-              mcpServerId,
-              params: JSON.parse(value.value.arguments),
-              status: action.status,
-              output: removeNulls(
-                action.outputItems.map(hideFileFromActionOutput)
-              ),
-              generatedFiles: removeNulls(
-                action.outputItems.map((o) => {
-                  if (!o.file) {
-                    return null;
-                  }
-
-                  const file = o.file;
-                  const fileSid = FileResource.modelIdToSId({
-                    id: file.id,
-                    workspaceId: action.workspaceId,
-                  });
-
-                  const hidden =
-                    o.content.type === "resource" &&
-                    isToolGeneratedFile(o.content) &&
-                    o.content.resource.hidden === true;
-
-                  return {
-                    fileId: fileSid,
-                    contentType: file.contentType,
-                    title: file.fileName,
-                    snippet: file.snippet,
-                    ...(hidden ? { hidden: true } : {}),
-                  };
-                })
-              ),
-            } satisfies AgentMCPActionWithOutputType;
-          }
-        );
-      }
-    }
-
-    return base;
   }
 
   static async createNewVersion({

--- a/front/lib/resources/agent_step_content_resource.ts
+++ b/front/lib/resources/agent_step_content_resource.ts
@@ -10,7 +10,7 @@ import { Op } from "sequelize";
 
 import { getAgentConfigurations } from "@app/lib/api/assistant/configuration/agent";
 import type { Authenticator } from "@app/lib/auth";
-import { AgentMCPActionModel } from "@app/lib/models/assistant/actions/mcp";
+import type { AgentMCPActionModel } from "@app/lib/models/assistant/actions/mcp";
 import { AgentStepContentModel } from "@app/lib/models/assistant/agent_step_content";
 import { AgentMessage } from "@app/lib/models/assistant/conversation";
 import { BaseResource } from "@app/lib/resources/base_resource";

--- a/front/lib/resources/agent_step_content_resource.ts
+++ b/front/lib/resources/agent_step_content_resource.ts
@@ -8,7 +8,6 @@ import type {
 } from "sequelize";
 import { Op } from "sequelize";
 
-import { MCPActionType } from "@app/lib/actions/mcp";
 import { getInternalMCPServerNameFromSId } from "@app/lib/actions/mcp_internal_actions/constants";
 import { isToolGeneratedFile } from "@app/lib/actions/mcp_internal_actions/output_schemas";
 import { hideFileFromActionOutput } from "@app/lib/actions/mcp_utils";
@@ -372,23 +371,18 @@ export class AgentStepContentResource extends BaseResource<AgentStepContentModel
           (action: AgentMCPActionModel) => {
             const mcpServerId = action.toolConfiguration?.toolServerId || null;
 
-            return new MCPActionType({
+            return {
               id: action.id,
+              agentMessageId: action.agentMessageId,
+              functionCallName: value.value.name,
+              internalMCPServerName:
+                getInternalMCPServerNameFromSId(mcpServerId),
+              mcpServerId,
               params: JSON.parse(value.value.arguments),
+              status: action.status,
               output: removeNulls(
                 action.outputItems.map(hideFileFromActionOutput)
               ),
-              functionCallId: value.value.id,
-              functionCallName: value.value.name,
-              mcpServerId,
-              internalMCPServerName:
-                getInternalMCPServerNameFromSId(mcpServerId),
-              agentMessageId: action.agentMessageId,
-              step: this.step,
-              mcpServerConfigurationId: action.mcpServerConfigurationId,
-              type: "tool_action",
-              status: action.status,
-              citationsAllocated: action.citationsAllocated,
               generatedFiles: removeNulls(
                 action.outputItems.map((o) => {
                   if (!o.file) {
@@ -415,7 +409,7 @@ export class AgentStepContentResource extends BaseResource<AgentStepContentModel
                   };
                 })
               ),
-            });
+            };
           }
         );
       }

--- a/front/pages/poke/[wId]/conversations/[cId]/index.tsx
+++ b/front/pages/poke/[wId]/conversations/[cId]/index.tsx
@@ -209,10 +209,7 @@ const AgentMessageView = ({
                 />
               )}
               {a.created && <>{new Date(a.created).toLocaleTimeString()}: </>}
-              step {a.step}: <b className="px-1">{a.functionCallName}()</b>{" "}
-              <i>
-                [{a.type}, {a.functionCallId}]
-              </i>
+              step {a.step}: <b className="px-1">{a.functionCallName}()</b>
               {a.runId && (
                 <>
                   log:{" "}

--- a/front/types/actions.ts
+++ b/front/types/actions.ts
@@ -11,6 +11,7 @@ export type AgentMCPActionType = {
   // TODO(MCPActionDetails): prevent exposing the function call name
   //  currently used in the extension to guess the tool name but quite brittle.
   functionCallName: string | null;
+  functionCallId: string;
   id: ModelId;
   internalMCPServerName: InternalMCPServerNameType | null;
   mcpServerId: string | null;

--- a/front/types/actions.ts
+++ b/front/types/actions.ts
@@ -24,3 +24,48 @@ export type AgentMCPActionWithOutputType = AgentMCPActionType & {
   generatedFiles: ActionGeneratedFileType[];
   output: CallToolResult["content"] | null;
 };
+
+// TODO(2025-09-16 aubin): remove this typeguard, either replace with a zod schema or fix the
+//  public type to remove the reliance on this typeguard.
+function isAgentMCPActionType(action: unknown): action is AgentMCPActionType {
+  return (
+    typeof action === "object" &&
+    action !== null &&
+    "agentMessageId" in action &&
+    typeof action.agentMessageId === "number" &&
+    "citationsAllocated" in action &&
+    typeof action.citationsAllocated === "number" &&
+    "functionCallName" in action &&
+    typeof action.functionCallName === "string" &&
+    "functionCallId" in action &&
+    typeof action.functionCallId === "string" &&
+    "id" in action &&
+    typeof action.id === "number" &&
+    "internalMCPServerName" in action &&
+    (action.internalMCPServerName === null ||
+      typeof action.internalMCPServerName === "string") &&
+    "mcpServerId" in action &&
+    (action.mcpServerId === null || typeof action.mcpServerId === "string") &&
+    "params" in action &&
+    typeof action.params === "object" &&
+    action.params !== null &&
+    "status" in action &&
+    typeof action.status === "string" &&
+    "step" in action &&
+    typeof action.step === "number"
+  );
+}
+
+// TODO(2025-09-16 aubin): remove this typeguard, either replace with a zod schema or fix the
+//  public type to remove the reliance on this typeguard.
+export function isAgentMCPActionWithOutputType(
+  action: unknown
+): action is AgentMCPActionWithOutputType {
+  return (
+    isAgentMCPActionType(action) &&
+    "generatedFiles" in action &&
+    Array.isArray(action.generatedFiles) &&
+    "output" in action &&
+    (action.output === null || Array.isArray(action.output))
+  );
+}

--- a/front/types/actions.ts
+++ b/front/types/actions.ts
@@ -10,7 +10,7 @@ export type AgentMCPActionType = {
   citationsAllocated: number;
   // TODO(MCPActionDetails): prevent exposing the function call name
   //  currently used in the extension to guess the tool name but quite brittle.
-  functionCallName: string | null;
+  functionCallName: string;
   functionCallId: string;
   id: ModelId;
   internalMCPServerName: InternalMCPServerNameType | null;

--- a/front/types/actions.ts
+++ b/front/types/actions.ts
@@ -7,6 +7,7 @@ import type { ModelId } from "@app/types/shared/model_id";
 
 export type AgentMCPActionType = {
   agentMessageId: ModelId;
+  citationsAllocated: number;
   // TODO(MCPActionDetails): prevent exposing the function call name
   //  currently used in the extension to guess the tool name but quite brittle.
   functionCallName: string | null;
@@ -15,6 +16,7 @@ export type AgentMCPActionType = {
   mcpServerId: string | null;
   params: Record<string, unknown>;
   status: ToolExecutionStatus;
+  step: number;
 };
 
 export type AgentMCPActionWithOutputType = AgentMCPActionType & {

--- a/front/types/assistant/agent_message_content.ts
+++ b/front/types/assistant/agent_message_content.ts
@@ -1,4 +1,4 @@
-import type { MCPActionType } from "@app/lib/actions/mcp";
+import type { AgentMCPActionWithOutputType } from "@app/types/actions";
 import type { ModelId } from "@app/types";
 import type { ModelProviderIdType } from "@app/types/assistant/assistant";
 import type { FunctionCallType } from "@app/types/assistant/generation";
@@ -75,5 +75,5 @@ export type AgentStepContentType = {
   type: AgentContentItemType["type"];
   value: AgentContentItemType;
   // Array of MCP actions that reference this step content.
-  mcpActions?: MCPActionType[];
+  mcpActions?: AgentMCPActionWithOutputType[];
 };

--- a/front/types/assistant/agent_message_content.ts
+++ b/front/types/assistant/agent_message_content.ts
@@ -1,4 +1,3 @@
-import type { AgentMCPActionWithOutputType } from "@app/types/actions";
 import type { ModelId } from "@app/types";
 import type { ModelProviderIdType } from "@app/types/assistant/assistant";
 import type { FunctionCallType } from "@app/types/assistant/generation";
@@ -74,6 +73,4 @@ export type AgentStepContentType = {
   version: number;
   type: AgentContentItemType["type"];
   value: AgentContentItemType;
-  // Array of MCP actions that reference this step content.
-  mcpActions?: AgentMCPActionWithOutputType[];
 };

--- a/front/types/assistant/conversation.ts
+++ b/front/types/assistant/conversation.ts
@@ -1,7 +1,4 @@
-import type {
-  MCPActionType,
-  MCPApproveExecutionEvent,
-} from "@app/lib/actions/mcp";
+import type { MCPApproveExecutionEvent } from "@app/lib/actions/mcp";
 import type { ActionGeneratedFileType } from "@app/lib/actions/types";
 import type { AgentMCPActionWithOutputType } from "@app/types/actions";
 
@@ -160,7 +157,7 @@ export type BaseAgentMessageType = {
 
 export type ParsedContentItem =
   | { kind: "reasoning"; content: string }
-  | { kind: "action"; action: MCPActionType };
+  | { kind: "action"; action: AgentMCPActionWithOutputType };
 
 export type AgentMessageType = BaseAgentMessageType & {
   id: ModelId;
@@ -169,7 +166,7 @@ export type AgentMessageType = BaseAgentMessageType & {
   visibility: MessageVisibility;
   configuration: LightAgentConfigurationType;
   skipToolsValidation: boolean;
-  actions: MCPActionType[];
+  actions: AgentMCPActionWithOutputType[];
   rawContents: Array<{
     step: number;
     content: string;

--- a/front/types/poke/index.ts
+++ b/front/types/poke/index.ts
@@ -42,7 +42,7 @@ export type PokeMCPServerViewType = MCPServerViewType &
     space: PokeSpaceType;
   };
 
-type PokeAgentActionType = AgentMessageType["actions"][0] & {
+type PokeAgentActionType = AgentMessageType["actions"][number] & {
   runId?: string | null;
   appWorkspaceId?: string | null;
   appSpaceId?: string | null;

--- a/sdks/js/src/types.ts
+++ b/sdks/js/src/types.ts
@@ -734,7 +734,7 @@ const MCPActionTypeSchema = z.object({
   mcpServerId: z.string().nullable(),
   internalMCPServerName: z.string().nullable(),
   agentMessageId: ModelIdSchema,
-  functionCallName: z.string().nullable(),
+  functionCallName: z.string(),
   status: z.string(),
   params: z.record(z.any()),
   output: CallToolResultSchema.shape.content.nullable(),

--- a/sdks/js/src/types.ts
+++ b/sdks/js/src/types.ts
@@ -734,7 +734,7 @@ const MCPActionTypeSchema = z.object({
   mcpServerId: z.string().nullable(),
   internalMCPServerName: z.string().nullable(),
   agentMessageId: ModelIdSchema,
-  functionCallName: z.string(),
+  functionCallName: z.string().nullable(),
   status: z.string(),
   params: z.record(z.any()),
   output: CallToolResultSchema.shape.content.nullable(),


### PR DESCRIPTION
## Description

- Closes https://github.com/dust-tt/tasks/issues/3586.
- This PR removes `MCPActionType` entirely (the last call site was in `getConversation` for rendering).
- The `AgentStepContentResource` is effectively uncoupled from the `AgentMCPAction`: the step content will only be the step content from now on and never contain references to the actions, which are fetched separately.

## Tests

- Tested locally, on front edge and using a local build of the extension.

## Risk

- Very high blast radius.

## Deploy Plan

- Deploy front.
