### PR TITLE
[front] - fix(AB v2): knowledge flows

### DIFF
--- a/front/components/agent_builder/capabilities/knowledge/DataSourceBuilderSelector.tsx
+++ b/front/components/agent_builder/capabilities/knowledge/DataSourceBuilderSelector.tsx
@@ -164,7 +164,7 @@ export const DataSourceBuilderSelector = ({
   }
 
   return (
-    <div className="relative flex h-full flex-1 flex-col gap-4">
+    <div className="relative flex h-full flex-1 flex-col gap-4 pt-2">
       {breadcrumbItems.length > 1 && <Breadcrumbs items={breadcrumbItems} />}
 
       {currentNavigationEntry.type === "root" ? (

--- a/front/components/agent_builder/capabilities/knowledge/KnowledgeConfigurationSheet.tsx
+++ b/front/components/agent_builder/capabilities/knowledge/KnowledgeConfigurationSheet.tsx
@@ -109,6 +109,7 @@ export function KnowledgeConfigurationSheet({
         <KnowledgeConfigurationSheetForm
           action={action}
           setIsDirty={setIsDirty}
+          onCancel={handlePageChange}
           {...props}
         />
       )}
@@ -118,6 +119,7 @@ export function KnowledgeConfigurationSheet({
 
 type KnowledgeConfigurationSheetFormProps = KnowledgeConfigurationSheetProps & {
   setIsDirty: (value: boolean) => void;
+  onCancel: () => Promise<void>;
 };
 
 function KnowledgeConfigurationSheetForm({
@@ -129,6 +131,7 @@ function KnowledgeConfigurationSheetForm({
   getAgentInstructions,
   onClose,
   onSave,
+  onCancel,
   setIsDirty,
 }: KnowledgeConfigurationSheetFormProps) {
   const { spaces } = useSpacesContext();
@@ -212,6 +215,7 @@ function KnowledgeConfigurationSheetForm({
           <KnowledgeConfigurationSheetContent
             onSave={form.handleSubmit(handleSave)}
             onClose={onClose}
+            onCancel={onCancel}
             getAgentInstructions={getAgentInstructions}
             isEditing={isEditing}
           />
@@ -224,6 +228,7 @@ function KnowledgeConfigurationSheetForm({
 interface KnowledgeConfigurationSheetContentProps {
   onSave: () => void;
   onClose: () => void;
+  onCancel: () => Promise<void>;
   getAgentInstructions: () => string;
   isEditing: boolean;
 }
@@ -231,6 +236,7 @@ interface KnowledgeConfigurationSheetContentProps {
 function KnowledgeConfigurationSheetContent({
   onSave,
   onClose,
+  onCancel,
   getAgentInstructions,
   isEditing,
 }: KnowledgeConfigurationSheetContentProps) {
@@ -289,21 +295,17 @@ function KnowledgeConfigurationSheetContent({
   const getFooterButtons = () => {
     const isDataSourcePage =
       currentPageId === CONFIGURATION_SHEET_PAGE_IDS.DATA_SOURCE_SELECTION;
-    const isConfigurationPage =
-      currentPageId === CONFIGURATION_SHEET_PAGE_IDS.CONFIGURATION;
+    const isManageSelectionMode = isDataSourcePage && hasSourceSelection;
 
     return {
       leftButton: {
-        label:
-          isDataSourcePage || (isConfigurationPage && isEditing)
-            ? "Cancel"
-            : "Back",
+        label: "Cancel",
         variant: "outline",
-        onClick: () => {
-          if (isDataSourcePage || (isConfigurationPage && isEditing)) {
-            onClose();
+        onClick: async () => {
+          if (isManageSelectionMode) {
+            setSheetPageId(CONFIGURATION_SHEET_PAGE_IDS.CONFIGURATION);
           } else {
-            setSheetPageId(CONFIGURATION_SHEET_PAGE_IDS.DATA_SOURCE_SELECTION);
+            await onCancel();
           }
         },
       },

--- a/front/components/agent_builder/capabilities/knowledge/KnowledgeConfigurationSheet.tsx
+++ b/front/components/agent_builder/capabilities/knowledge/KnowledgeConfigurationSheet.tsx
@@ -214,7 +214,6 @@ function KnowledgeConfigurationSheetForm({
         <KnowledgePageProvider initialPageId={getInitialPageId(isEditing)}>
           <KnowledgeConfigurationSheetContent
             onSave={form.handleSubmit(handleSave)}
-            onClose={onClose}
             onCancel={onCancel}
             getAgentInstructions={getAgentInstructions}
             isEditing={isEditing}
@@ -227,7 +226,6 @@ function KnowledgeConfigurationSheetForm({
 
 interface KnowledgeConfigurationSheetContentProps {
   onSave: () => void;
-  onClose: () => void;
   onCancel: () => Promise<void>;
   getAgentInstructions: () => string;
   isEditing: boolean;
@@ -235,7 +233,6 @@ interface KnowledgeConfigurationSheetContentProps {
 
 function KnowledgeConfigurationSheetContent({
   onSave,
-  onClose,
   onCancel,
   getAgentInstructions,
   isEditing,

--- a/front/components/agent_builder/capabilities/mcp/MCPServerSelectionPage.tsx
+++ b/front/components/agent_builder/capabilities/mcp/MCPServerSelectionPage.tsx
@@ -116,7 +116,7 @@ export function MCPServerSelectionPage({
 
   return (
     <>
-      <div className="flex flex-col gap-4">
+      <div className="flex flex-col gap-4 py-2">
         {((dataVisualization && onDataVisualizationClick) ||
           defaultMcpServerViews) && (
           <span className="text-lg font-semibold">Top tools</span>


### PR DESCRIPTION
## Description

This PR aims at changing the knowledge configuration flow. We want the "Manage selection" flow to be a separate one, which means that when a user gets to the end of the configuration and clicks the "Manage Selection" button, clicking cancel will "close" the selection page and brings back to the configuration page.

## Tests

Locally

## Risk

Low

## Deploy Plan

Deploy front