### PR TITLE
Don't use `AgentMCPActionResource` inside `front/lib`

### DIFF
--- a/front/lib/actions/mcp.ts
+++ b/front/lib/actions/mcp.ts
@@ -1,6 +1,5 @@
 import type { ActionApprovalStateType } from "@dust-tt/client";
 import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
-import { McpError } from "@modelcontextprotocol/sdk/types.js";
 import type { JSONSchema7 as JSONSchema } from "json-schema";
 import omit from "lodash/omit";
 
@@ -8,11 +7,6 @@ import type {
   MCPToolStakeLevelType,
   MCPValidationMetadataType,
 } from "@app/lib/actions/constants";
-import { MCPServerPersonalAuthenticationRequiredError } from "@app/lib/actions/mcp_authentication";
-import {
-  executeMCPTool,
-  processToolResults,
-} from "@app/lib/actions/mcp_execution";
 import type {
   CustomServerIconType,
   InternalAllowedIconType,
@@ -25,17 +19,12 @@ import type { ToolPersonalAuthRequiredEvent } from "@app/lib/actions/mcp_interna
 import { hideInternalConfiguration } from "@app/lib/actions/mcp_internal_actions/input_configuration";
 import type { ProgressNotificationContentType } from "@app/lib/actions/mcp_internal_actions/output_schemas";
 import { isTextContent } from "@app/lib/actions/mcp_internal_actions/output_schemas";
-import { ToolBlockedAwaitingInputError } from "@app/lib/actions/mcp_internal_actions/servers/run_agent/types";
 import type { AuthorizationInfo } from "@app/lib/actions/mcp_metadata";
-import {
-  hideFileFromActionOutput,
-  rewriteContentForModel,
-} from "@app/lib/actions/mcp_utils";
+import { rewriteContentForModel } from "@app/lib/actions/mcp_utils";
 import type { ToolExecutionStatus } from "@app/lib/actions/statuses";
 import { isToolExecutionStatusFinal } from "@app/lib/actions/statuses";
 import type {
   ActionGeneratedFileType,
-  AgentLoopRunContextType,
   StepContext,
 } from "@app/lib/actions/types";
 import type { AgentActionSpecification } from "@app/lib/actions/types/agent";
@@ -47,13 +36,9 @@ import type { Authenticator } from "@app/lib/auth";
 import type { AdditionalConfigurationType } from "@app/lib/models/assistant/actions/mcp";
 import { AgentMCPActionOutputItem } from "@app/lib/models/assistant/actions/mcp";
 import { AgentMCPActionResource } from "@app/lib/resources/agent_mcp_action_resource";
-import { getResourceIdFromSId } from "@app/lib/resources/string_ids";
-import logger from "@app/logger/logger";
-import { statsDClient } from "@app/logger/statsDClient";
 import type {
   AgentConfigurationType,
   AgentMessageType,
-  ConversationType,
   DustAppRunConfigurationType,
   FunctionCallType,
   FunctionMessageTypeModel,
@@ -223,7 +208,7 @@ export function getMCPApprovalStateFromUserApprovalState(
   }
 }
 
-type MCPParamsEvent = {
+export type MCPParamsEvent = {
   type: "tool_params";
   created: number;
   configurationId: string;
@@ -231,7 +216,7 @@ type MCPParamsEvent = {
   action: AgentMCPActionWithOutputType;
 };
 
-type MCPSuccessEvent = {
+export type MCPSuccessEvent = {
   type: "tool_success";
   created: number;
   configurationId: string;
@@ -239,7 +224,7 @@ type MCPSuccessEvent = {
   action: AgentMCPActionWithOutputType;
 };
 
-type MCPErrorEvent = {
+export type MCPErrorEvent = {
   type: "tool_error";
   created: number;
   configurationId: string;
@@ -427,179 +412,6 @@ export function buildToolSpecification(
 }
 
 /**
- * Runs a tool with streaming for the given MCP action configuration.
- *
- * All errors within this function must be handled through `handleMCPActionError`
- * to ensure consistent error reporting and proper conversation flow control.
- * TODO(DURABLE_AGENTS 2025-08-05): This function is going to be used only to execute the tool.
- */
-export async function* runToolWithStreaming(
-  auth: Authenticator,
-  {
-    action,
-    actionBaseParams,
-    agentConfiguration,
-    agentMessage,
-    conversation,
-  }: {
-    action: AgentMCPActionResource;
-    actionBaseParams: ActionBaseParams;
-    agentConfiguration: AgentConfigurationType;
-    agentMessage: AgentMessageType;
-    conversation: ConversationType;
-  }
-): AsyncGenerator<
-  | MCPApproveExecutionEvent
-  | MCPErrorEvent
-  | MCPParamsEvent
-  | MCPSuccessEvent
-  | ToolNotificationEvent
-  | ToolPersonalAuthRequiredEvent,
-  void
-> {
-  const owner = auth.getNonNullableWorkspace();
-
-  const { toolConfiguration, status, augmentedInputs: inputs } = action;
-
-  const localLogger = logger.child({
-    actionConfigurationId: toolConfiguration.sId,
-    conversationId: conversation.sId,
-    messageId: agentMessage.sId,
-    workspaceId: conversation.owner.sId,
-  });
-
-  const tags = [
-    `action:${toolConfiguration.name}`,
-    `mcp_server:${toolConfiguration.mcpServerName}`,
-    `workspace:${owner.sId}`,
-    `workspace_name:${owner.name}`,
-  ];
-
-  const agentLoopRunContext: AgentLoopRunContextType = {
-    agentConfiguration,
-    agentMessage,
-    conversation,
-    stepContext: action.stepContext,
-    toolConfiguration,
-  };
-
-  const toolCallResult = yield* executeMCPTool({
-    auth,
-    inputs,
-    agentLoopRunContext,
-    action,
-    agentConfiguration,
-    conversation,
-    agentMessage,
-  });
-
-  if (!toolCallResult || toolCallResult.isErr()) {
-    statsDClient.increment("mcp_actions_error.count", 1, tags);
-    localLogger.error(
-      {
-        error: toolCallResult
-          ? toolCallResult.error.message
-          : "No tool call result",
-      },
-      "Error calling MCP tool on run."
-    );
-
-    const { error: toolErr } = toolCallResult ?? {};
-
-    // If we got a personal authentication error, we emit a specific event that will be
-    // deferred until after all tools complete, then converted to a tool_error.
-    if (MCPServerPersonalAuthenticationRequiredError.is(toolErr)) {
-      const authErrorMessage =
-        `The tool ${actionBaseParams.functionCallName} requires personal ` +
-        `authentication, please authenticate to use it.`;
-
-      // Update the action to mark it as blocked because of a personal authentication error.
-      await action.updateStatus("blocked_authentication_required");
-
-      yield {
-        type: "tool_personal_auth_required",
-        created: Date.now(),
-        configurationId: agentConfiguration.sId,
-        messageId: agentMessage.sId,
-        conversationId: conversation.sId,
-        authError: {
-          mcpServerId: toolErr.mcpServerId,
-          provider: toolErr.provider,
-          toolName: actionBaseParams.functionCallName ?? "unknown",
-          message: authErrorMessage,
-          ...(toolErr.scope && {
-            scope: toolErr.scope,
-          }),
-        },
-      };
-
-      return;
-    } else if (toolErr instanceof ToolBlockedAwaitingInputError) {
-      // Update the action status to blocked_child_action_input_required to break the agent loop.
-      await action.updateStatus("blocked_child_action_input_required");
-
-      // Update the step context to save the resume state.
-      await action.updateStepContext({
-        ...action.stepContext,
-        resumeState: toolErr.resumeState,
-      });
-
-      // Yield the blocking events.
-      for (const event of toolErr.blockingEvents) {
-        yield event;
-      }
-
-      return;
-    }
-
-    let errorMessage: string;
-
-    // We don't want to expose the MCP full error message to the user.
-    if (toolErr && toolErr instanceof McpError && toolErr.code === -32001) {
-      // MCP Error -32001: Request timed out.
-      errorMessage = `The tool ${actionBaseParams.functionCallName} timed out. `;
-    } else {
-      errorMessage = `The tool ${actionBaseParams.functionCallName} returned an error. `;
-    }
-    errorMessage +=
-      "An error occurred while executing the tool. You can inform the user of this issue.";
-
-    yield await handleMCPActionError({
-      action,
-      agentConfiguration,
-      agentMessage,
-      status,
-      errorMessage,
-    });
-    return;
-  }
-
-  const { outputItems, generatedFiles } = await processToolResults(auth, {
-    action,
-    conversation,
-    localLogger,
-    toolCallResult: toolCallResult.value,
-    toolConfiguration,
-  });
-
-  statsDClient.increment("mcp_actions_success.count", 1, tags);
-
-  await action.updateStatus("succeeded");
-
-  yield {
-    type: "tool_success",
-    created: Date.now(),
-    configurationId: agentConfiguration.sId,
-    messageId: agentMessage.sId,
-    action: {
-      ...action.toJSON(),
-      output: removeNulls(outputItems.map(hideFileFromActionOutput)),
-      generatedFiles,
-    },
-  };
-}
-
-/**
  * Creates an MCP action in the database and returns both the DB record and the type object.
  */
 export async function createMCPAction(
@@ -719,30 +531,4 @@ export function isBlockedActionEvent(
     (isMCPApproveExecutionEvent(event) ||
       isToolPersonalAuthRequiredEvent(event))
   );
-}
-
-// TODO(DURABLE_AGENTS 2025-08-12): Create a proper resource for the agent mcp action.
-export async function getMCPAction(
-  auth: Authenticator,
-  actionId: string
-): Promise<AgentMCPActionResource | null> {
-  const id = getResourceIdFromSId(actionId);
-  if (!id) {
-    throw new Error(`Invalid action ID: ${actionId}`);
-  }
-  return AgentMCPActionResource.fetchByModelIdWithAuth(auth, id);
-}
-
-// TODO(DURABLE_AGENTS 2025-08-12): Create a proper resource for the agent mcp action.
-export async function updateMCPApprovalState(
-  action: AgentMCPActionResource,
-  approvalState: "denied" | "ready_allowed_explicitly"
-): Promise<boolean> {
-  if (action.status === approvalState) {
-    return false;
-  }
-
-  await action.updateStatus(approvalState);
-
-  return true;
 }

--- a/front/lib/api/assistant/conversation/validate_actions.ts
+++ b/front/lib/api/assistant/conversation/validate_actions.ts
@@ -3,10 +3,8 @@ import { Err, Ok } from "@dust-tt/client";
 import assert from "assert";
 
 import {
-  getMCPAction,
   getMCPApprovalStateFromUserApprovalState,
   isMCPApproveExecutionEvent,
-  updateMCPApprovalState,
 } from "@app/lib/actions/mcp";
 import { setUserAlwaysApprovedTool } from "@app/lib/actions/utils";
 import { runAgentLoop } from "@app/lib/api/assistant/agent";
@@ -14,6 +12,7 @@ import { getMessageChannelId } from "@app/lib/api/assistant/streaming/helpers";
 import { getRedisHybridManager } from "@app/lib/api/redis-hybrid-manager";
 import type { Authenticator } from "@app/lib/auth";
 import { Message } from "@app/lib/models/assistant/conversation";
+import { AgentMCPActionResource } from "@app/lib/resources/agent_mcp_action_resource";
 import { AgentStepContentResource } from "@app/lib/resources/agent_step_content_resource";
 import logger from "@app/logger/logger";
 import { buildActionBaseParams } from "@app/temporal/agent_loop/lib/action_utils";
@@ -96,7 +95,7 @@ export async function validateAction(
     messageId,
   });
 
-  const action = await getMCPAction(auth, actionId);
+  const action = await AgentMCPActionResource.fetchById(auth, actionId);
   if (!action) {
     return new Err(new Error(`Action not found: ${actionId}`));
   }
@@ -114,8 +113,7 @@ export async function validateAction(
     return new Err(new Error(`Action is not blocked: ${action.status}`));
   }
 
-  const actionUpdated = await updateMCPApprovalState(
-    action,
+  const [updatedCount] = await action.updateStatus(
     getMCPApprovalStateFromUserApprovalState(approvalState)
   );
 
@@ -144,7 +142,7 @@ export async function validateAction(
     }
   }
 
-  if (!actionUpdated) {
+  if (updatedCount === 0) {
     logger.info(
       {
         actionId,

--- a/front/lib/api/mcp/create_mcp.ts
+++ b/front/lib/api/mcp/create_mcp.ts
@@ -1,0 +1,49 @@
+import omit from "lodash/omit";
+
+import type {
+  ActionBaseParams,
+  LightMCPToolConfigurationType,
+  MCPToolConfigurationType,
+} from "@app/lib/actions/mcp";
+import { MCP_TOOL_CONFIGURATION_FIELDS_TO_OMIT } from "@app/lib/actions/mcp";
+import type { StepContext } from "@app/lib/actions/types";
+import type { Authenticator } from "@app/lib/auth";
+import { AgentMCPActionResource } from "@app/lib/resources/agent_mcp_action_resource";
+import type { ModelId } from "@app/types/shared/model_id";
+
+/**
+ * Creates an MCP action in the database and returns both the DB record and the type object.
+ */
+export async function createMCPAction(
+  auth: Authenticator,
+  {
+    actionBaseParams,
+    actionConfiguration,
+    augmentedInputs,
+    stepContentId,
+    stepContext,
+  }: {
+    actionBaseParams: ActionBaseParams;
+    actionConfiguration: MCPToolConfigurationType;
+    augmentedInputs: Record<string, unknown>;
+    stepContentId: ModelId;
+    stepContext: StepContext;
+  }
+): Promise<AgentMCPActionResource> {
+  const toolConfiguration = omit(
+    actionConfiguration,
+    MCP_TOOL_CONFIGURATION_FIELDS_TO_OMIT
+  ) as LightMCPToolConfigurationType;
+
+  return AgentMCPActionResource.makeNew(auth, {
+    agentMessageId: actionBaseParams.agentMessageId,
+    augmentedInputs,
+    citationsAllocated: stepContext.citationsCount,
+    mcpServerConfigurationId: actionBaseParams.mcpServerConfigurationId,
+    status: actionBaseParams.status,
+    stepContentId,
+    stepContext,
+    toolConfiguration,
+    version: 0,
+  });
+}

--- a/front/lib/api/mcp/error.ts
+++ b/front/lib/api/mcp/error.ts
@@ -1,0 +1,56 @@
+import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
+
+import type { MCPErrorEvent, MCPSuccessEvent } from "@app/lib/actions/mcp";
+import type { ToolExecutionStatus } from "@app/lib/actions/statuses";
+import { isToolExecutionStatusFinal } from "@app/lib/actions/statuses";
+import { AgentMCPActionOutputItem } from "@app/lib/models/assistant/actions/mcp";
+import type { AgentMCPActionResource } from "@app/lib/resources/agent_mcp_action_resource";
+import type { AgentConfigurationType } from "@app/types/assistant/agent";
+import type { AgentMessageType } from "@app/types/assistant/conversation";
+
+type HandleErrorParams = {
+  action: AgentMCPActionResource;
+  agentConfiguration: AgentConfigurationType;
+  agentMessage: AgentMessageType;
+  errorMessage: string;
+  status: ToolExecutionStatus;
+};
+
+/**
+ * Handles MCP action errors with type-safe discriminated union based on error severity.
+ */
+export async function handleMCPActionError(
+  params: HandleErrorParams
+): Promise<MCPErrorEvent | MCPSuccessEvent> {
+  const { action, agentConfiguration, agentMessage, errorMessage, status } =
+    params;
+
+  const outputContent: CallToolResult["content"][number] = {
+    type: "text",
+    text: errorMessage,
+  };
+
+  await AgentMCPActionOutputItem.create({
+    workspaceId: action.workspaceId,
+    agentMCPActionId: action.id,
+    content: outputContent,
+  });
+
+  // If the tool is not already in a final state, we set it to errored (could be denied).
+  if (!isToolExecutionStatusFinal(status)) {
+    await action.updateStatus("errored");
+  }
+
+  // Yields tool_success to continue the conversation.
+  return {
+    type: "tool_success",
+    created: Date.now(),
+    configurationId: agentConfiguration.sId,
+    messageId: agentMessage.sId,
+    action: {
+      ...action.toJSON(),
+      output: [outputContent],
+      generatedFiles: [],
+    },
+  };
+}

--- a/front/lib/api/mcp/run_tool.ts
+++ b/front/lib/api/mcp/run_tool.ts
@@ -8,7 +8,6 @@ import type {
   MCPSuccessEvent,
   ToolNotificationEvent,
 } from "@app/lib/actions/mcp";
-import { handleMCPActionError } from "@app/lib/actions/mcp";
 import { MCPServerPersonalAuthenticationRequiredError } from "@app/lib/actions/mcp_authentication";
 import {
   executeMCPTool,
@@ -18,6 +17,7 @@ import type { ToolPersonalAuthRequiredEvent } from "@app/lib/actions/mcp_interna
 import { ToolBlockedAwaitingInputError } from "@app/lib/actions/mcp_internal_actions/servers/run_agent/types";
 import { hideFileFromActionOutput } from "@app/lib/actions/mcp_utils";
 import type { AgentLoopRunContextType } from "@app/lib/actions/types";
+import { handleMCPActionError } from "@app/lib/api/mcp/error";
 import type { Authenticator } from "@app/lib/auth";
 import type { AgentMCPActionResource } from "@app/lib/resources/agent_mcp_action_resource";
 import logger from "@app/logger/logger";

--- a/front/lib/api/tools/run_tools.ts
+++ b/front/lib/api/tools/run_tools.ts
@@ -1,0 +1,203 @@
+import { McpError } from "@modelcontextprotocol/sdk/types.js";
+
+import type {
+  ActionBaseParams,
+  MCPApproveExecutionEvent,
+  MCPErrorEvent,
+  MCPParamsEvent,
+  MCPSuccessEvent,
+  ToolNotificationEvent,
+} from "@app/lib/actions/mcp";
+import { handleMCPActionError } from "@app/lib/actions/mcp";
+import { MCPServerPersonalAuthenticationRequiredError } from "@app/lib/actions/mcp_authentication";
+import {
+  executeMCPTool,
+  processToolResults,
+} from "@app/lib/actions/mcp_execution";
+import type { ToolPersonalAuthRequiredEvent } from "@app/lib/actions/mcp_internal_actions/events";
+import { ToolBlockedAwaitingInputError } from "@app/lib/actions/mcp_internal_actions/servers/run_agent/types";
+import { hideFileFromActionOutput } from "@app/lib/actions/mcp_utils";
+import type { AgentLoopRunContextType } from "@app/lib/actions/types";
+import type { Authenticator } from "@app/lib/auth";
+import type { AgentMCPActionResource } from "@app/lib/resources/agent_mcp_action_resource";
+import logger from "@app/logger/logger";
+import { statsDClient } from "@app/logger/statsDClient";
+import type {
+  AgentConfigurationType,
+  AgentMessageType,
+  ConversationType,
+} from "@app/types";
+import { removeNulls } from "@app/types";
+
+/**
+ * Runs a tool with streaming for the given MCP action configuration.
+ *
+ * All errors within this function must be handled through `handleMCPActionError`
+ * to ensure consistent error reporting and proper conversation flow control.
+ * TODO(DURABLE_AGENTS 2025-08-05): This function is going to be used only to execute the tool.
+ */
+export async function* runToolWithStreaming(
+  auth: Authenticator,
+  {
+    action,
+    actionBaseParams,
+    agentConfiguration,
+    agentMessage,
+    conversation,
+  }: {
+    action: AgentMCPActionResource;
+    actionBaseParams: ActionBaseParams;
+    agentConfiguration: AgentConfigurationType;
+    agentMessage: AgentMessageType;
+    conversation: ConversationType;
+  }
+): AsyncGenerator<
+  | MCPApproveExecutionEvent
+  | MCPErrorEvent
+  | MCPParamsEvent
+  | MCPSuccessEvent
+  | ToolNotificationEvent
+  | ToolPersonalAuthRequiredEvent,
+  void
+> {
+  const owner = auth.getNonNullableWorkspace();
+
+  const { toolConfiguration, status, augmentedInputs: inputs } = action;
+
+  const localLogger = logger.child({
+    actionConfigurationId: toolConfiguration.sId,
+    conversationId: conversation.sId,
+    messageId: agentMessage.sId,
+    workspaceId: conversation.owner.sId,
+  });
+
+  const tags = [
+    `action:${toolConfiguration.name}`,
+    `mcp_server:${toolConfiguration.mcpServerName}`,
+    `workspace:${owner.sId}`,
+    `workspace_name:${owner.name}`,
+  ];
+
+  const agentLoopRunContext: AgentLoopRunContextType = {
+    agentConfiguration,
+    agentMessage,
+    conversation,
+    stepContext: action.stepContext,
+    toolConfiguration,
+  };
+
+  const toolCallResult = yield* executeMCPTool({
+    auth,
+    inputs,
+    agentLoopRunContext,
+    action,
+    agentConfiguration,
+    conversation,
+    agentMessage,
+  });
+
+  if (!toolCallResult || toolCallResult.isErr()) {
+    statsDClient.increment("mcp_actions_error.count", 1, tags);
+    localLogger.error(
+      {
+        error: toolCallResult
+          ? toolCallResult.error.message
+          : "No tool call result",
+      },
+      "Error calling MCP tool on run."
+    );
+
+    const { error: toolErr } = toolCallResult ?? {};
+
+    // If we got a personal authentication error, we emit a specific event that will be
+    // deferred until after all tools complete, then converted to a tool_error.
+    if (MCPServerPersonalAuthenticationRequiredError.is(toolErr)) {
+      const authErrorMessage =
+        `The tool ${actionBaseParams.functionCallName} requires personal ` +
+        `authentication, please authenticate to use it.`;
+
+      // Update the action to mark it as blocked because of a personal authentication error.
+      await action.updateStatus("blocked_authentication_required");
+
+      yield {
+        type: "tool_personal_auth_required",
+        created: Date.now(),
+        configurationId: agentConfiguration.sId,
+        messageId: agentMessage.sId,
+        conversationId: conversation.sId,
+        authError: {
+          mcpServerId: toolErr.mcpServerId,
+          provider: toolErr.provider,
+          toolName: actionBaseParams.functionCallName ?? "unknown",
+          message: authErrorMessage,
+          ...(toolErr.scope && {
+            scope: toolErr.scope,
+          }),
+        },
+      };
+
+      return;
+    } else if (toolErr instanceof ToolBlockedAwaitingInputError) {
+      // Update the action status to blocked_child_action_input_required to break the agent loop.
+      await action.updateStatus("blocked_child_action_input_required");
+
+      // Update the step context to save the resume state.
+      await action.updateStepContext({
+        ...action.stepContext,
+        resumeState: toolErr.resumeState,
+      });
+
+      // Yield the blocking events.
+      for (const event of toolErr.blockingEvents) {
+        yield event;
+      }
+
+      return;
+    }
+
+    let errorMessage: string;
+
+    // We don't want to expose the MCP full error message to the user.
+    if (toolErr && toolErr instanceof McpError && toolErr.code === -32001) {
+      // MCP Error -32001: Request timed out.
+      errorMessage = `The tool ${actionBaseParams.functionCallName} timed out. `;
+    } else {
+      errorMessage = `The tool ${actionBaseParams.functionCallName} returned an error. `;
+    }
+    errorMessage +=
+      "An error occurred while executing the tool. You can inform the user of this issue.";
+
+    yield await handleMCPActionError({
+      action,
+      agentConfiguration,
+      agentMessage,
+      status,
+      errorMessage,
+    });
+    return;
+  }
+
+  const { outputItems, generatedFiles } = await processToolResults(auth, {
+    action,
+    conversation,
+    localLogger,
+    toolCallResult: toolCallResult.value,
+    toolConfiguration,
+  });
+
+  statsDClient.increment("mcp_actions_success.count", 1, tags);
+
+  await action.updateStatus("succeeded");
+
+  yield {
+    type: "tool_success",
+    created: Date.now(),
+    configurationId: agentConfiguration.sId,
+    messageId: agentMessage.sId,
+    action: {
+      ...action.toJSON(),
+      output: removeNulls(outputItems.map(hideFileFromActionOutput)),
+      generatedFiles,
+    },
+  };
+}

--- a/front/lib/resources/agent_mcp_action_resource.ts
+++ b/front/lib/resources/agent_mcp_action_resource.ts
@@ -28,7 +28,7 @@ import { ConversationResource } from "@app/lib/resources/conversation_resource";
 import { MCPServerViewResource } from "@app/lib/resources/mcp_server_view_resource";
 import type { ReadonlyAttributesType } from "@app/lib/resources/storage/types";
 import type { ModelStaticWorkspaceAware } from "@app/lib/resources/storage/wrappers/workspace_models";
-import { makeSId } from "@app/lib/resources/string_ids";
+import { getResourceIdFromSId, makeSId } from "@app/lib/resources/string_ids";
 import type { ResourceFindOptions } from "@app/lib/resources/types";
 import logger from "@app/logger/logger";
 import type { ModelId, Result } from "@app/types";
@@ -149,6 +149,22 @@ export class AgentMCPActionResource extends BaseResource<AgentMCPActionModel> {
       },
       transaction
     );
+    return action;
+  }
+
+  static async fetchById(
+    auth: Authenticator,
+    sId: string
+  ): Promise<AgentMCPActionResource | null> {
+    const modelId = getResourceIdFromSId(sId);
+    if (!modelId) {
+      return null;
+    }
+
+    const [action] = await AgentMCPActionResource.fetchByModelIds(auth, [
+      modelId,
+    ]);
+
     return action;
   }
 

--- a/front/temporal/agent_loop/activities/run_tool.ts
+++ b/front/temporal/agent_loop/activities/run_tool.ts
@@ -1,6 +1,6 @@
 import assert from "assert";
 
-import { runToolWithStreaming } from "@app/lib/actions/mcp";
+import { runToolWithStreaming } from "@app/lib/api/mcp/run_tool";
 import type { AuthenticatorType } from "@app/lib/auth";
 import { Authenticator } from "@app/lib/auth";
 import { AgentMCPActionResource } from "@app/lib/resources/agent_mcp_action_resource";

--- a/front/temporal/agent_loop/lib/create_tool_actions.ts
+++ b/front/temporal/agent_loop/lib/create_tool_actions.ts
@@ -2,12 +2,12 @@ import type {
   MCPApproveExecutionEvent,
   MCPToolConfigurationType,
 } from "@app/lib/actions/mcp";
-import { createMCPAction } from "@app/lib/actions/mcp";
 import { getAugmentedInputs } from "@app/lib/actions/mcp_execution";
 import { validateToolInputs } from "@app/lib/actions/mcp_utils";
 import type { ToolExecutionStatus } from "@app/lib/actions/statuses";
 import type { StepContext } from "@app/lib/actions/types";
 import { getExecutionStatusFromConfig } from "@app/lib/actions/utils";
+import { createMCPAction } from "@app/lib/api/mcp/create_mcp";
 import type { Authenticator } from "@app/lib/auth";
 import type { AgentMessage } from "@app/lib/models/assistant/conversation";
 import { updateResourceAndPublishEvent } from "@app/temporal/agent_loop/activities/common";


### PR DESCRIPTION
## Description

- Follow up on https://github.com/dust-tt/dust/pull/15537
- Don't import `AgentMCPActionResource` inside `front/lib`
- Favor using AgentMCPActionResource functions instead of wrapper functions

## Tests

Tested locally. No regressions.

## Risk

Low. Need to make sure we don't import frontend module in backend code. 

## Deploy Plan

Deploy front
