### PR TITLE
[front] ABv2 - Fix markdown in code and extra new lines

### DIFF
--- a/front/components/agent_builder/instructions/extensions/InstructionBlockExtension.tsx
+++ b/front/components/agent_builder/instructions/extensions/InstructionBlockExtension.tsx
@@ -221,7 +221,7 @@ const InstructionBlockComponent: React.FC<NodeViewProps> = ({
               </Chip>
             </div>
           ) : (
-            <div className="mt-0.5">
+            <div className="mt-0.5 w-full">
               <NodeViewContent
                 className={instructionBlockContentStyles}
                 as="div"

--- a/front/lib/client/agent_builder/instructionBlockUtils.ts
+++ b/front/lib/client/agent_builder/instructionBlockUtils.ts
@@ -70,27 +70,95 @@ export function textToParagraphNodes(content: string): JSONContent[] {
 }
 
 /**
- * Convert text content to block nodes (paragraphs and headings)
+ * Convert text content to block nodes (paragraphs, headings, and code blocks)
  */
 export function textToBlockNodes(content: string): JSONContent[] {
-  const nodes: JSONContent[] = [];
-  const lines = content.split("\n");
+  // First, handle code blocks using regex to preserve them
+  const codeBlockRegex = /```(\w*)\n([\s\S]*?)```/g;
+  const segments: Array<{ type: 'code' | 'text'; content: string; language?: string }> = [];
+  let lastIndex = 0;
+  let match;
 
-  for (const line of lines) {
-    const headingMatch = line.match(/^(#{1,6})\s+(.*)$/);
-    if (headingMatch) {
-      const level = headingMatch[1].length;
-      const headingContent = headingMatch[2].trim();
+  // Find all code blocks
+  while ((match = codeBlockRegex.exec(content)) !== null) {
+    // Add text before the code block
+    if (match.index > lastIndex) {
+      segments.push({
+        type: 'text',
+        content: content.slice(lastIndex, match.index)
+      });
+    }
+    
+    // Add the code block, removing trailing newline to prevent accumulation
+    let codeContent = match[2];
+    if (codeContent && codeContent.endsWith('\n')) {
+      codeContent = codeContent.slice(0, -1);
+    }
+    segments.push({
+      type: 'code',
+      content: codeContent,
+      language: match[1] || ""
+    });
+    
+    lastIndex = match.index + match[0].length;
+  }
+  
+  // Add remaining text after last code block
+  if (lastIndex < content.length) {
+    segments.push({
+      type: 'text',
+      content: content.slice(lastIndex)
+    });
+  }
+
+  // Now process each segment
+  const nodes: JSONContent[] = [];
+  
+  for (const segment of segments) {
+    if (segment.type === 'code') {
+      // Create code block node
       nodes.push({
-        type: "heading",
-        attrs: { level },
-        content: headingContent ? [{ type: "text", text: headingContent }] : [],
+        type: "codeBlock",
+        attrs: { language: segment.language },
+        content: segment.content ? [{ type: "text", text: segment.content }] : [],
       });
     } else {
-      nodes.push({
-        type: "paragraph",
-        content: line.trim() ? [{ type: "text", text: line.trim() }] : [],
-      });
+      // Process text segment for headings and paragraphs
+      const lines = segment.content.split("\n");
+      for (let i = 0; i < lines.length; i++) {
+        const line = lines[i];
+        if (!line.trim()) {
+          // Only add empty paragraph if it's between content (not leading/trailing)
+          // and not consecutive empty lines
+          const isNotFirst = i > 0;
+          const isNotLast = i < lines.length - 1;
+          const prevLineHasContent = i > 0 && lines[i - 1].trim();
+          const nextLineHasContent = i < lines.length - 1 && lines[i + 1].trim();
+          
+          if (isNotFirst && isNotLast && (prevLineHasContent || nextLineHasContent)) {
+            nodes.push({
+              type: "paragraph",
+              content: [],
+            });
+          }
+        } else {
+          const headingMatch = line.match(/^(#{1,6})\s+(.*)$/);
+          if (headingMatch) {
+            const level = headingMatch[1].length;
+            const headingContent = headingMatch[2].trim();
+            nodes.push({
+              type: "heading",
+              attrs: { level },
+              content: headingContent ? [{ type: "text", text: headingContent }] : [],
+            });
+          } else {
+            nodes.push({
+              type: "paragraph",
+              content: [{ type: "text", text: line.trim() }],
+            });
+          }
+        }
+      }
     }
   }
 
@@ -115,34 +183,101 @@ export function textToProseMirrorParagraphs(
 }
 
 /**
- * Convert text content to ProseMirror block nodes (paragraphs and headings)
+ * Convert text content to ProseMirror block nodes (paragraphs, headings, and code blocks)
  */
 export function textToProseMirrorBlocks(
   content: string,
   schema: Schema
 ): ProseMirrorNode[] {
-  const nodes: ProseMirrorNode[] = [];
-  const lines = content.split("\n");
+  // First, handle code blocks using regex to preserve them
+  const codeBlockRegex = /```(\w*)\n([\s\S]*?)```/g;
+  const segments: Array<{ type: 'code' | 'text'; content: string; language?: string }> = [];
+  let lastIndex = 0;
+  let match;
 
-  for (const line of lines) {
-    const headingMatch = line.match(/^(#{1,6})\s+(.*)$/);
-    if (headingMatch && schema.nodes.heading) {
-      const level = headingMatch[1].length;
-      const headingContent = headingMatch[2].trim();
-      nodes.push(
-        schema.nodes.heading.create(
-          { level },
-          headingContent ? [schema.text(headingContent)] : []
-        )
-      );
+  // Find all code blocks
+  while ((match = codeBlockRegex.exec(content)) !== null) {
+    // Add text before the code block
+    if (match.index > lastIndex) {
+      segments.push({
+        type: 'text',
+        content: content.slice(lastIndex, match.index)
+      });
+    }
+    
+    // Add the code block, removing trailing newline to prevent accumulation
+    let codeContent = match[2];
+    if (codeContent && codeContent.endsWith('\n')) {
+      codeContent = codeContent.slice(0, -1);
+    }
+    segments.push({
+      type: 'code',
+      content: codeContent,
+      language: match[1] || ""
+    });
+    
+    lastIndex = match.index + match[0].length;
+  }
+  
+  // Add remaining text after last code block
+  if (lastIndex < content.length) {
+    segments.push({
+      type: 'text',
+      content: content.slice(lastIndex)
+    });
+  }
+
+  // Now process each segment
+  const nodes: ProseMirrorNode[] = [];
+  
+  for (const segment of segments) {
+    if (segment.type === 'code') {
+      // Create code block node if schema supports it
+      if (schema.nodes.codeBlock) {
+        nodes.push(
+          schema.nodes.codeBlock.create(
+            { language: segment.language },
+            segment.content ? [schema.text(segment.content)] : []
+          )
+        );
+      }
     } else {
-      const trimmedLine = line.trim();
-      nodes.push(
-        schema.nodes.paragraph.create(
-          {},
-          trimmedLine ? [schema.text(trimmedLine)] : []
-        )
-      );
+      // Process text segment for headings and paragraphs
+      const lines = segment.content.split("\n");
+      for (let i = 0; i < lines.length; i++) {
+        const line = lines[i];
+        if (!line.trim()) {
+          // Only add empty paragraph if it's between content (not leading/trailing)
+          // and not consecutive empty lines
+          const isNotFirst = i > 0;
+          const isNotLast = i < lines.length - 1;
+          const prevLineHasContent = i > 0 && lines[i - 1].trim();
+          const nextLineHasContent = i < lines.length - 1 && lines[i + 1].trim();
+          
+          if (isNotFirst && isNotLast && (prevLineHasContent || nextLineHasContent)) {
+            nodes.push(schema.nodes.paragraph.create());
+          }
+        } else {
+          const headingMatch = line.match(/^(#{1,6})\s+(.*)$/);
+          if (headingMatch && schema.nodes.heading) {
+            const level = headingMatch[1].length;
+            const headingContent = headingMatch[2].trim();
+            nodes.push(
+              schema.nodes.heading.create(
+                { level },
+                headingContent ? [schema.text(headingContent)] : []
+              )
+            );
+          } else {
+            nodes.push(
+              schema.nodes.paragraph.create(
+                {},
+                [schema.text(line.trim())]
+              )
+            );
+          }
+        }
+      }
     }
   }
 

--- a/front/lib/client/agent_builder/instructionBlockUtils.ts
+++ b/front/lib/client/agent_builder/instructionBlockUtils.ts
@@ -77,7 +77,7 @@ export function textToBlockNodes(content: string): JSONContent[] {
 
   for (const segment of splitContentByCodeFences(content)) {
     if (segment.type === "code") {
-      const language = (segment.info || "").trim().split(/\s+/)[0] || "";
+      const language = extractLanguageFromInfo(segment.info);
       nodes.push({
         type: "codeBlock",
         attrs: { language },
@@ -164,7 +164,7 @@ export function textToProseMirrorBlocks(
   for (const segment of splitContentByCodeFences(content)) {
     if (segment.type === "code") {
       if (schema.nodes.codeBlock) {
-        const language = (segment.info || "").trim().split(/\s+/)[0] || "";
+        const language = extractLanguageFromInfo(segment.info);
         nodes.push(
           schema.nodes.codeBlock.create(
             { language },
@@ -282,6 +282,19 @@ export function splitContentByCodeFences(
   }
 
   return segments;
+}
+
+/** Extract first token (language) from a fenced code info string. */
+function extractLanguageFromInfo(info?: string): string {
+  if (typeof info !== "string") {
+    return "";
+  }
+  const trimmed = info.trim();
+  if (!trimmed) {
+    return "";
+  }
+  const [language] = trimmed.split(/\s+/);
+  return language || "";
 }
 
 /**

--- a/front/lib/client/agent_builder/instructionBlockUtils.ts
+++ b/front/lib/client/agent_builder/instructionBlockUtils.ts
@@ -76,12 +76,14 @@ export function textToBlockNodes(content: string): JSONContent[] {
   const nodes: JSONContent[] = [];
 
   for (const segment of splitContentByCodeFences(content)) {
-    if (segment.type === 'code') {
+    if (segment.type === "code") {
       const language = (segment.info || "").trim().split(/\s+/)[0] || "";
       nodes.push({
         type: "codeBlock",
         attrs: { language },
-        content: segment.content ? [{ type: "text", text: segment.content }] : [],
+        content: segment.content
+          ? [{ type: "text", text: segment.content }]
+          : [],
       });
       continue;
     }
@@ -117,7 +119,9 @@ export function textToBlockNodes(content: string): JSONContent[] {
         nodes.push({
           type: "heading",
           attrs: { level },
-          content: headingContent ? [{ type: "text", text: headingContent }] : [],
+          content: headingContent
+            ? [{ type: "text", text: headingContent }]
+            : [],
         });
       } else {
         nodes.push({
@@ -158,7 +162,7 @@ export function textToProseMirrorBlocks(
   const nodes: ProseMirrorNode[] = [];
 
   for (const segment of splitContentByCodeFences(content)) {
-    if (segment.type === 'code') {
+    if (segment.type === "code") {
       if (schema.nodes.codeBlock) {
         const language = (segment.info || "").trim().split(/\s+/)[0] || "";
         nodes.push(
@@ -248,26 +252,33 @@ export function createInstructionBlockNode(
  */
 export function splitContentByCodeFences(
   content: string
-): Array<{ type: 'code' | 'text'; content: string; info?: string }> {
+): Array<{ type: "code" | "text"; content: string; info?: string }> {
   const codeBlockRegex = /```([^\n]*)\n([\s\S]*?)```/g;
-  const segments: Array<{ type: 'code' | 'text'; content: string; info?: string }> = [];
+  const segments: Array<{
+    type: "code" | "text";
+    content: string;
+    info?: string;
+  }> = [];
   let lastIndex = 0;
   let match: RegExpExecArray | null;
 
   while ((match = codeBlockRegex.exec(content)) !== null) {
     if (match.index > lastIndex) {
-      segments.push({ type: 'text', content: content.slice(lastIndex, match.index) });
+      segments.push({
+        type: "text",
+        content: content.slice(lastIndex, match.index),
+      });
     }
     let codeContent = match[2];
-    if (codeContent && codeContent.endsWith('\n')) {
+    if (codeContent && codeContent.endsWith("\n")) {
       codeContent = codeContent.slice(0, -1);
     }
-    segments.push({ type: 'code', info: match[1] || '', content: codeContent });
+    segments.push({ type: "code", info: match[1] || "", content: codeContent });
     lastIndex = match.index + match[0].length;
   }
 
   if (lastIndex < content.length) {
-    segments.push({ type: 'text', content: content.slice(lastIndex) });
+    segments.push({ type: "text", content: content.slice(lastIndex) });
   }
 
   return segments;

--- a/front/lib/client/agent_builder/instructions.ts
+++ b/front/lib/client/agent_builder/instructions.ts
@@ -3,14 +3,10 @@ import type { JSONContent } from "@tiptap/react";
 import {
   createInstructionBlockNode,
   splitTextAroundBlocks,
+  textToBlockNodes,
 } from "@app/lib/client/agent_builder/instructionBlockUtils";
 
 function serializeNodeToText(node: JSONContent): string {
-  if (node.type === "instructionBlock") {
-    const content = node.content?.map(serializeNodeToText).join("") || "";
-    return content;
-  }
-
   if (node.type === "heading") {
     // Preserve the original heading level in markdown (support H1–H6)
     const level = node.attrs?.level || 1;
@@ -21,16 +17,8 @@ function serializeNodeToText(node: JSONContent): string {
   }
 
   if (node.type === "paragraph") {
-    if (!node.content || !node.content.length) {
-      return "\n";
-    }
-
-    if (node.content.length === 1 && node.content[0].type === "text") {
-      return `${node.content[0].text}\n`;
-    }
-
-    const text = node.content.map(serializeNodeToText).join("");
-    return text ? `${text}\n` : "\n";
+    const text = node.content?.map(serializeNodeToText).join("") || "";
+    return `${text}\n`;
   }
 
   if (node.type === "text") {
@@ -66,41 +54,8 @@ function parseInstructionBlocks(text: string): JSONContent[] {
 
   segments.forEach((segment) => {
     if (segment.type === "text") {
-      // Parse code blocks from the text
-      const codeBlockRegex = /```(\w*)\n([\s\S]*?)```/g;
-      let lastIndex = 0;
-      let match;
-
-      while ((match = codeBlockRegex.exec(segment.content)) !== null) {
-        if (match.index > lastIndex) {
-          const textBefore = segment.content.slice(lastIndex, match.index).trim();
-          if (textBefore) {
-            const nodes = parseTextWithHeadings(textBefore);
-            content.push(...nodes);
-          }
-        }
-        const language = match[1] || "";
-        // Remove trailing newline from code content if present
-        let code = match[2];
-        if (code && code.endsWith("\n")) {
-          code = code.slice(0, -1);
-        }
-        content.push({
-          type: "codeBlock",
-          attrs: { language },
-          content: code ? [{ type: "text", text: code }] : [],
-        });
-
-        lastIndex = match.index + match[0].length;
-      }
-
-      if (lastIndex < segment.content.length) {
-        const remainingText = segment.content.slice(lastIndex).trim();
-        if (remainingText) {
-          const nodes = parseTextWithHeadings(remainingText);
-          content.push(...nodes);
-        }
-      }
+      const nodes = textToBlockNodes(segment.content);
+      content.push(...nodes);
     } else if (segment.type === "block" && segment.blockType) {
       const blockNode = createInstructionBlockNode(
         segment.blockType,
@@ -111,43 +66,6 @@ function parseInstructionBlocks(text: string): JSONContent[] {
   });
 
   return content;
-}
-
-function parseTextWithHeadings(text: string): JSONContent[] {
-  const nodes: JSONContent[] = [];
-  const lines = text.split("\n");
-
-  for (let i = 0; i < lines.length; i++) {
-    const line = lines[i];
-    const headingMatch = line.match(/^(#{1,6})\s+(.*)$/);
-    if (headingMatch) {
-      const level = headingMatch[1].length; // Preserve original level (1–6)
-      const content = headingMatch[2].trim();
-      nodes.push({
-        type: "heading",
-        attrs: { level }, // Keep the original heading level
-        content: content ? [{ type: "text", text: content }] : [],
-      });
-    } else if (line.trim()) {
-      // Only add non-empty paragraphs
-      nodes.push({
-        type: "paragraph",
-        content: [{ type: "text", text: line.trim() }],
-      });
-    } else if (i > 0 && i < lines.length - 1) {
-      // Only add empty paragraphs if they're between content (not leading/trailing)
-      const prevLine = lines[i - 1].trim();
-      const nextLine = lines[i + 1].trim();
-      if (prevLine || nextLine) {
-        nodes.push({
-          type: "paragraph",
-          content: [],
-        });
-      }
-    }
-  }
-
-  return nodes;
 }
 
 export function tipTapContentFromPlainText(text: string): JSONContent {


### PR DESCRIPTION
## Description

**Problems Fixed**

- Markdown in code: Headings inside code inside instruction block showed as headings; now they stay as code.
- Extra newlines: Saving added blank lines around/inside code; now spacing is stable.
- Ensure full width for NodeViewContent in InstructionBlockExtension

**Refactoring & Improvements**

- Central parsing: Added `splitContentByCodeFences` to handle code fences once.
- Shared logic: `textToBlockNodes` and `textToProseMirrorBlocks` use the same parser; `instructions.ts` reuses it.
- Leaner instructions: Removed duplicate heading parsing; simpler paragraph output.
- Consistent code blocks: Trim one trailing newline; ensure one before closing ``` 
- Less duplication: Fewer branches and edge-case bugs.

## Tests

Locally

## Risk

Low, behind FF

## Deploy Plan

Deploy front
