### PR TITLE
[front] - fix(AB v2): throw editors edition error

### DIFF
--- a/front/lib/api/assistant/configuration/agent.ts
+++ b/front/lib/api/assistant/configuration/agent.ts
@@ -505,7 +505,19 @@ export async function createAgentConfiguration(
             );
             throw result.error;
           }
-          await group.setMembers(auth, editors, { transaction: t });
+          const setMembersRes = await group.setMembers(auth, editors, {
+            transaction: t,
+          });
+          if (setMembersRes.isErr()) {
+            logger.error(
+              {
+                workspaceId: owner.sId,
+                agentConfigurationId: existingAgent.sId,
+              },
+              `Error setting members to agent ${existingAgent.sId}: ${setMembersRes.error}`
+            );
+            throw setMembersRes.error;
+          }
         }
       }
 


### PR DESCRIPTION
## Description

This PR  adds proper error handling for setting group members when creating agent configurations by logging an error and throwing if setting members fails during the transaction

## Tests

Locally

## Risk

Low

## Deploy Plan

Deploy front
