### PR TITLE
[Dev Worker] Add lib/actions to hot reload watch paths

### DIFF
--- a/front/admin/dev_worker.sh
+++ b/front/admin/dev_worker.sh
@@ -11,6 +11,7 @@ NODE_ENV=development npx concurrently \
   "nodemon --exec 'tsx ./start_worker.ts --workers agent_loop' \
     --watch 'temporal/agent_loop' \
     --watch 'lib/api/assistant' \
+    --watch 'lib/actions' \
     --ext 'ts,js' \
     --signal 'SIGTERM' \
     --delay 5" # 5 seconds delay to avoid restarting the agent loop worker too often.


### PR DESCRIPTION
## Description
Add `lib/actions` directory to nodemon watch paths in the dev worker script to ensure hot reloading when files in that directory change.

(e.g. here changing tool timeout was not picked up)

## Risks
Blast radius: Development workflow only - affects hot reloading in dev environment
Risk: none

## Deploy Plan
No deployment needed - development script only