### PR TITLE
[connectors] get rid of pqueue for slack conn

### DIFF
--- a/connectors/src/connectors/slack/index.ts
+++ b/connectors/src/connectors/slack/index.ts
@@ -368,7 +368,7 @@ export class SlackConnectorManager extends BaseConnectorManager<SlackConfigurati
       // First, ensure all channels exist (sequential to avoid race conditions)
       for (const [internalId] of permissionEntries) {
         const slackChannelId = slackChannelIdFromInternalId(internalId);
-        let channel = channels[slackChannelId];
+        const channel = channels[slackChannelId];
         if (!channel) {
           const joinRes = await joinChannelWithRetries(
             this.connectorId,

--- a/connectors/src/connectors/slack/index.ts
+++ b/connectors/src/connectors/slack/index.ts
@@ -1,7 +1,6 @@
 import type { ConnectorProvider, Result } from "@dust-tt/client";
 import { Err, Ok } from "@dust-tt/client";
 import { WebClient } from "@slack/web-api";
-import PQueue from "p-queue";
 
 import type {
   CreateConnectorErrorCode,
@@ -360,13 +359,14 @@ export class SlackConnectorManager extends BaseConnectorManager<SlackConfigurati
       }
     );
 
-    const q = new PQueue({ concurrency: 10 });
-    const promises: Promise<void>[] = [];
-
     const slackChannelsToSync: string[] = [];
 
     try {
-      for (const [internalId, permission] of Object.entries(permissions)) {
+      // Prepare permission entries for concurrent processing
+      const permissionEntries = Object.entries(permissions);
+
+      // First, ensure all channels exist (sequential to avoid race conditions)
+      for (const [internalId] of permissionEntries) {
         const slackChannelId = slackChannelIdFromInternalId(internalId);
         let channel = channels[slackChannelId];
         if (!channel) {
@@ -392,51 +392,55 @@ export class SlackConnectorManager extends BaseConnectorManager<SlackConfigurati
             private: !!channelInfo.is_private,
           });
           channels[slackChannelId] = slackChannel;
-          channel = slackChannel;
         }
-
-        promises.push(
-          q.add(async () => {
-            if (!channel) {
-              return;
-            }
-            const oldPermission = channel.permission;
-            if (oldPermission === permission) {
-              return;
-            }
-            await channel.update({
-              permission: permission,
-            });
-
-            if (
-              !["read", "read_write"].includes(oldPermission) &&
-              ["read", "read_write"].includes(permission)
-            ) {
-              // handle read permission enabled
-              slackChannelsToSync.push(channel.slackChannelId);
-              const joinChannelRes = await joinChannelWithRetries(
-                this.connectorId,
-                channel.slackChannelId
-              );
-              if (joinChannelRes.isErr()) {
-                logger.error(
-                  {
-                    connectorId: this.connectorId,
-                    channelId: channel.slackChannelId,
-                    error: joinChannelRes.error,
-                  },
-                  "Could not join the Slack channel"
-                );
-                throw new Error(
-                  `Our Slack bot (@Dust) was not able to join the Slack channel #${channel.slackChannelName}. Please re-authorize Slack or invite @Dust from #${channel.slackChannelName} on Slack.`
-                );
-              }
-            }
-          })
-        );
       }
 
-      await Promise.all(promises);
+      await concurrentExecutor(
+        permissionEntries,
+        async ([internalId, permission]) => {
+          const slackChannelId = slackChannelIdFromInternalId(internalId);
+          const channel = channels[slackChannelId];
+
+          if (!channel) {
+            return;
+          }
+
+          const oldPermission = channel.permission;
+          if (oldPermission === permission) {
+            return;
+          }
+
+          await channel.update({
+            permission: permission,
+          });
+
+          if (
+            !["read", "read_write"].includes(oldPermission) &&
+            ["read", "read_write"].includes(permission)
+          ) {
+            // handle read permission enabled
+            slackChannelsToSync.push(channel.slackChannelId);
+            const joinChannelRes = await joinChannelWithRetries(
+              this.connectorId,
+              channel.slackChannelId
+            );
+            if (joinChannelRes.isErr()) {
+              logger.error(
+                {
+                  connectorId: this.connectorId,
+                  channelId: channel.slackChannelId,
+                  error: joinChannelRes.error,
+                },
+                "Could not join the Slack channel"
+              );
+              throw new Error(
+                `Our Slack bot (@Dust) was not able to join the Slack channel #${channel.slackChannelName}. Please re-authorize Slack or invite @Dust from #${channel.slackChannelName} on Slack.`
+              );
+            }
+          }
+        },
+        { concurrency: 10 }
+      );
       const workflowRes = await launchSlackSyncWorkflow(
         this.connectorId,
         null,


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

https://app.datadoghq.eu/monitors/22026957

Slack worker are restarting in loop. 

```
Error: async hook stack has become corrupted (actual: 1111657, expected: 4)
----- Native stack trace -----

 1: 0xc3833d node::AsyncHooks::FailWithCorruptedAsyncStack(double) [/usr/local/bin/node]
 2: 0xc39660 node::AsyncHooks::pop_async_context(double) [/usr/local/bin/node]
 3: 0xbd2d0a node::InternalCallbackScope::Close() [/usr/local/bin/node]
 4: 0xbd312b node::InternalMakeCallback(node::Environment*, v8::Local<v8::Object>, v8::Local<v8::Object>, v8::Local<v8::Function>, int, v8::Local<v8::Value>*, node::async_context) [/usr/local/bin/node]
 5: 0xbea18f node::AsyncWrap::MakeCallback(v8::Local<v8::Function>, int, v8::Local<v8::Value>*) [/usr/local/bin/node]
 6: 0xd2131a node::worker::MessagePort::OnMessage(node::worker::MessagePort::MessageProcessingMode) [/usr/local/bin/node]
 7: 0x18c5813  [/usr/local/bin/node]
 8: 0x18da28b  [/usr/local/bin/node]
 9: 0x18c6537 uv_run [/usr/local/bin/node]
10: 0xbd3be6 node::SpinEventLoopInternal(node::Environment*) [/usr/local/bin/node]
11: 0xdca1d6 node::worker::Worker::Run() [/usr/local/bin/node]
12: 0xdca619  [/usr/local/bin/node]
13: 0x7f04a197c1f5  [/lib/x86_64-linux-gnu/libc.so.6]
14: 0x7f04a19fbb00 __clone [/lib/x86_64-linux-gnu/libc.so.6]
```

This PR gets rid of pqueue and just uses a concurrentExecutor instead.
I'm not really sure of if it will solve the issue, but behaviour should be the same.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

Safe to rollback, only logic.

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->

Deploy conn