### PR TITLE
[MCP] Fix tool timeout handling in agent loop

### DIFF
--- a/front/lib/actions/constants.ts
+++ b/front/lib/actions/constants.ts
@@ -3,6 +3,9 @@ import type {
   InternalAllowedIconType,
 } from "@app/lib/actions/mcp_icons";
 
+export const DEFAULT_MCP_REQUEST_TIMEOUT_MS = 3 * 60 * 1000; // 3 minutes.
+export const MAX_MCP_REQUEST_TIMEOUT_MS = 10 * 60 * 1000; // 10 minutes.
+
 // Stored in a separate file to prevent a circular dependency issue.
 
 // Use top_k of 768 as 512 worked really smoothly during initial tests. Might update to 1024 in the

--- a/front/lib/actions/mcp_actions.ts
+++ b/front/lib/actions/mcp_actions.ts
@@ -37,6 +37,7 @@ import {
   getAvailabilityOfInternalMCPServerById,
   getInternalMCPServerNameAndWorkspaceId,
   INTERNAL_MCP_SERVERS,
+  DEFAULT_MCP_REQUEST_TIMEOUT_MS,
 } from "@app/lib/actions/mcp_internal_actions/constants";
 import { findMatchingSubSchemas } from "@app/lib/actions/mcp_internal_actions/input_configuration";
 import type { MCPProgressNotificationType } from "@app/lib/actions/mcp_internal_actions/output_schemas";
@@ -84,8 +85,6 @@ import type { ModelId, Result } from "@app/types";
 import { Err, normalizeError, Ok, slugify } from "@app/types";
 
 const MAX_OUTPUT_ITEMS = 128;
-
-const DEFAULT_MCP_REQUEST_TIMEOUT_MS = 3 * 60 * 1000; // 3 minutes.
 
 const MCP_NOTIFICATION_EVENT_NAME = "mcp-notification";
 const MCP_TOOL_DONE_EVENT_NAME = "TOOL_DONE" as const;

--- a/front/lib/actions/mcp_actions.ts
+++ b/front/lib/actions/mcp_actions.ts
@@ -20,6 +20,7 @@ import {
 import type { MCPToolStakeLevelType } from "@app/lib/actions/constants";
 import {
   DEFAULT_CLIENT_SIDE_MCP_TOOL_STAKE_LEVEL,
+  DEFAULT_MCP_REQUEST_TIMEOUT_MS,
   FALLBACK_INTERNAL_AUTO_SERVERS_TOOL_STAKE_LEVEL,
   FALLBACK_MCP_TOOL_STAKE_LEVEL,
 } from "@app/lib/actions/constants";
@@ -37,7 +38,6 @@ import {
   getAvailabilityOfInternalMCPServerById,
   getInternalMCPServerNameAndWorkspaceId,
   INTERNAL_MCP_SERVERS,
-  DEFAULT_MCP_REQUEST_TIMEOUT_MS,
 } from "@app/lib/actions/mcp_internal_actions/constants";
 import { findMatchingSubSchemas } from "@app/lib/actions/mcp_internal_actions/input_configuration";
 import type { MCPProgressNotificationType } from "@app/lib/actions/mcp_internal_actions/output_schemas";

--- a/front/lib/actions/mcp_internal_actions/constants.ts
+++ b/front/lib/actions/mcp_internal_actions/constants.ts
@@ -101,6 +101,9 @@ const MCP_SERVER_AVAILABILITY = [
 ] as const;
 export type MCPServerAvailability = (typeof MCP_SERVER_AVAILABILITY)[number];
 
+export const DEFAULT_MCP_REQUEST_TIMEOUT_MS = 3 * 60 * 1000; // 3 minutes.
+export const MAX_MCP_REQUEST_TIMEOUT_MS = 10 * 60 * 1000; // 10 minutes.
+
 export const INTERNAL_MCP_SERVERS = {
   // Note:
   // ids should be stable, do not change them when moving internal servers to production as it would break existing agents.
@@ -905,7 +908,7 @@ The directive should be used to display a clickable version of the agent name in
     isRestricted: undefined,
     isPreview: false,
     tools_stakes: undefined,
-    timeoutMs: 10 * 60 * 1000, // 10 minutes
+    timeoutMs: MAX_MCP_REQUEST_TIMEOUT_MS,
     serverInfo: {
       name: "run_agent",
       version: "1.0.0",

--- a/front/lib/actions/mcp_internal_actions/constants.ts
+++ b/front/lib/actions/mcp_internal_actions/constants.ts
@@ -2,6 +2,7 @@ import type { MCPToolStakeLevelType } from "@app/lib/actions/constants";
 import {
   DEFAULT_AGENT_ROUTER_ACTION_DESCRIPTION,
   DEFAULT_AGENT_ROUTER_ACTION_NAME,
+  MAX_MCP_REQUEST_TIMEOUT_MS,
 } from "@app/lib/actions/constants";
 import {
   DEFAULT_WEBSEARCH_ACTION_DESCRIPTION,
@@ -100,9 +101,6 @@ const MCP_SERVER_AVAILABILITY = [
   "auto_hidden_builder",
 ] as const;
 export type MCPServerAvailability = (typeof MCP_SERVER_AVAILABILITY)[number];
-
-export const DEFAULT_MCP_REQUEST_TIMEOUT_MS = 3 * 60 * 1000; // 3 minutes.
-export const MAX_MCP_REQUEST_TIMEOUT_MS = 10 * 60 * 1000; // 10 minutes.
 
 export const INTERNAL_MCP_SERVERS = {
   // Note:

--- a/front/temporal/agent_loop/workflows.ts
+++ b/front/temporal/agent_loop/workflows.ts
@@ -19,6 +19,7 @@ import type {
   RunAgentArgs,
   RunAgentAsynchronousArgs,
 } from "@app/types/assistant/agent_run";
+import { MAX_MCP_REQUEST_TIMEOUT_MS } from "@app/lib/actions/mcp_internal_actions/constants";
 
 const logMetricsActivities = proxyActivities<
   typeof logAgentLoopMetricsActivities
@@ -33,7 +34,11 @@ const activities: AgentLoopActivities = {
     startToCloseTimeout: "7 minutes",
   }).runModelAndCreateActionsActivity,
   runToolActivity: proxyActivities<typeof runToolActivities>({
-    startToCloseTimeout: "10 minutes",
+    // The activity timeout should be slightly longer than the max timeout of
+    // the tool, to avoid the activity being killed before the tool timeout.
+    startToCloseTimeout: `${
+      MAX_MCP_REQUEST_TIMEOUT_MS / 1000 / 60 + 1
+    } minutes`,
     retry: {
       // Do not retry tool activities. Those are not idempotent.
       maximumAttempts: 1,

--- a/front/temporal/agent_loop/workflows.ts
+++ b/front/temporal/agent_loop/workflows.ts
@@ -19,7 +19,7 @@ import type {
   RunAgentArgs,
   RunAgentAsynchronousArgs,
 } from "@app/types/assistant/agent_run";
-import { MAX_MCP_REQUEST_TIMEOUT_MS } from "@app/lib/actions/mcp_internal_actions/constants";
+import { MAX_MCP_REQUEST_TIMEOUT_MS } from "@app/lib/actions/constants";
 
 const logMetricsActivities = proxyActivities<
   typeof logAgentLoopMetricsActivities


### PR DESCRIPTION
## Description
Fixes https://github.com/dust-tt/tasks/issues/3953

The activity was being failed before the tool times out, which would leave the conversation hanging. This fix ensures the Temporal activity timeout is longer than the MCP request timeout to prevent activities from being killed before tools complete.

Changes:
- Move timeout constants to a shared location in `constants.ts`
- Set activity timeout to be 1 minute longer than the max MCP request timeout (11 minutes vs 10 minutes)

## Risks
Blast radius: MCP tool execution in agent loops
Risk: low

## Deploy Plan
- Deploy front service