### PR TITLE
[front] - fix(AB v2): add duplicate agent modal title support

### DIFF
--- a/front/components/agent_builder/AgentBuilder.tsx
+++ b/front/components/agent_builder/AgentBuilder.tsx
@@ -280,7 +280,9 @@ export default function AgentBuilder({
   const saveLabel = isSubmitting ? "Saving..." : "Save";
 
   const title = agentConfiguration
-    ? `Edit agent @${agentConfiguration.name}`
+    ? duplicateAgentId
+      ? `Duplicate @${agentConfiguration.name}`
+      : `Edit agent @${agentConfiguration.name}`
     : "Create new agent";
 
   return (

--- a/front/components/assistant_builder/AssistantBuilder.tsx
+++ b/front/components/assistant_builder/AssistantBuilder.tsx
@@ -369,9 +369,11 @@ export default function AssistantBuilder({
     Boolean(template !== null && initialBuilderState?.instructions)
   );
 
-  const modalTitle = agentConfiguration
-    ? `Edit @${builderState.handle}`
-    : "New Agent";
+  const modalTitle = duplicateAgentId
+    ? `Duplicate @${builderState.handle}`
+    : agentConfiguration
+      ? `Edit @${builderState.handle}`
+      : "New Agent";
 
   return (
     <>


### PR DESCRIPTION
## Description

This PR update the  modal title to reflect duplication when the `duplicateAgentId` is present

## Tests

Locally

## Risk

Low

## Deploy Plan

Deploy front
