### PR TITLE
Simplify usage of yalc for Sparkle local dev

### DIFF
--- a/front/admin/sparkle_dev.sh
+++ b/front/admin/sparkle_dev.sh
@@ -1,0 +1,119 @@
+#!/bin/bash
+
+# Sparkle Development Helper Script
+# 
+# This script automates the process of building and publishing the Sparkle
+# design system package for local development using yalc.
+# 
+# Usage:
+#   ./sparkle_dev.sh           # Build and publish
+#   ./sparkle_dev.sh --restore # Restore npm version of Sparkle
+
+set -e
+
+# Colors
+GREEN='\033[32m'
+YELLOW='\033[33m'
+BLUE='\033[34m'
+RED='\033[31m'
+DIM='\033[2m'
+RESET='\033[0m'
+
+# Paths
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SPARKLE_DIR="$(cd "$SCRIPT_DIR/../../sparkle" && pwd)"
+FRONT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+ROLLUP_CONFIG="$SPARKLE_DIR/rollup.config.mjs"
+
+log() {
+    local message="$1"
+    local color="${2:-$RESET}"
+    echo -e "${color}${message}${RESET}"
+}
+
+# No longer needed - using environment variable instead
+
+build_sparkle() {
+    log "🔨 Building Sparkle (without terser)..." "$BLUE"
+    
+    # Build in sparkle directory with terser disabled
+    cd "$SPARKLE_DIR"
+    
+    if DISABLE_TERSER=1 npm run build > /dev/null 2>&1; then
+        log "✅ Sparkle built successfully" "$GREEN"
+    else
+        log "❌ Sparkle build failed" "$RED"
+        exit 1
+    fi
+}
+
+publish_to_yalc() {
+    log "📦 Publishing to yalc..." "$BLUE"
+    
+    cd "$SPARKLE_DIR"
+    
+    # Publish to yalc store
+    if "$FRONT_DIR/node_modules/.bin/yalc" publish > /dev/null 2>&1; then
+        log "✅ Published to yalc store" "$GREEN"
+        
+        # Add/update link in front
+        cd "$FRONT_DIR"
+        if "$FRONT_DIR/node_modules/.bin/yalc" add @dust-tt/sparkle > /dev/null 2>&1; then
+            log "✅ Updated front with yalc link" "$GREEN"
+        else
+            log "❌ Failed to update front with yalc link" "$RED"
+            exit 1
+        fi
+    else
+        log "❌ Yalc publish failed" "$RED"
+        exit 1
+    fi
+}
+
+build_and_publish() {
+    build_sparkle
+    publish_to_yalc
+    log "🎉 Sparkle development build complete!" "$GREEN"
+}
+
+restore_npm_sparkle() {
+    log "🔄 Restoring npm version of Sparkle..." "$BLUE"
+    
+    cd "$FRONT_DIR"
+    
+    # Remove yalc link and restore npm version
+    if "$FRONT_DIR/node_modules/.bin/yalc" remove @dust-tt/sparkle > /dev/null 2>&1; then
+        log "✅ Removed yalc link" "$GREEN"
+        
+        # Reinstall npm version
+        if npm install @dust-tt/sparkle > /dev/null 2>&1; then
+            log "✅ Restored npm version of @dust-tt/sparkle" "$GREEN"
+            log "🎉 Sparkle restored to npm version!" "$GREEN"
+        else
+            log "❌ Failed to reinstall npm version" "$RED"
+            exit 1
+        fi
+    else
+        log "❌ Failed to remove yalc link" "$RED"
+        exit 1
+    fi
+}
+
+main() {
+    # Parse arguments
+    if [[ "$1" == "--restore" ]] || [[ "$1" == "-r" ]]; then
+        restore_npm_sparkle
+        exit 0
+    fi
+    
+    # Check if we're in the right directory structure
+    if [[ ! -d "$SPARKLE_DIR" ]] || [[ ! -f "$ROLLUP_CONFIG" ]]; then
+        log "❌ Cannot find Sparkle directory or rollup config" "$RED"
+        log "   Expected: $SPARKLE_DIR" "$DIM"
+        exit 1
+    fi
+    
+    build_and_publish
+}
+
+main "$@"

--- a/front/package-lock.json
+++ b/front/package-lock.json
@@ -187,7 +187,8 @@
         "typescript": "5.4.5",
         "vite-tsconfig-paths": "^5.1.4",
         "vitest": "^3.0.8",
-        "vitest-canvas-mock": "^0.3.3"
+        "vitest-canvas-mock": "^0.3.3",
+        "yalc": "^1.0.0-pre.53"
       },
       "peerDependencies": {
         "typescript": "5.4.5"
@@ -13179,6 +13180,15 @@
         "node": ">=6"
       }
     },
+    "node_modules/detect-indent": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/detect-indent/-/detect-indent-6.1.0.tgz",
+      "integrity": "sha512-reYkTUJAZb9gUuZ2RvVCNhVHdg62RHnJ7WJl8ftMi4diZ6NWlciOzQN88pUhSELEwflJht4oQDv0F0BMlwaYtA==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/detect-libc": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.0.3.tgz",
@@ -17529,6 +17539,15 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/ignore-walk": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/ignore-walk/-/ignore-walk-3.0.4.tgz",
+      "integrity": "sha512-PY6Ii8o1jMRA1z4F2hRkH/xN59ox43DavKvD3oDpfurRlOJyAHpifIwpbdv1n4jt4ov0jSpw3kQ4GhJnpBL6WQ==",
+      "dev": true,
+      "dependencies": {
+        "minimatch": "^3.0.4"
+      }
+    },
     "node_modules/immediate": {
       "version": "3.0.6",
       "resolved": "https://registry.npmjs.org/immediate/-/immediate-3.0.6.tgz",
@@ -21254,6 +21273,39 @@
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/npm-bundled": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/npm-bundled/-/npm-bundled-1.1.2.tgz",
+      "integrity": "sha512-x5DHup0SuyQcmL3s7Rx/YQ8sbw/Hzg0rj48eN0dV7hf5cmQq5PXIeioroH3raV1QC1yh3uTYuMThvEQF3iKgGQ==",
+      "dev": true,
+      "dependencies": {
+        "npm-normalize-package-bin": "^1.0.1"
+      }
+    },
+    "node_modules/npm-normalize-package-bin": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/npm-normalize-package-bin/-/npm-normalize-package-bin-1.0.1.tgz",
+      "integrity": "sha512-EPfafl6JL5/rU+ot6P3gRSCpPDW5VmIzX959Ob1+ySFUuuYHWHekXpwdUZcKP5C+DS4GEtdJluwBjnsNDl+fSA==",
+      "dev": true
+    },
+    "node_modules/npm-packlist": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/npm-packlist/-/npm-packlist-2.2.2.tgz",
+      "integrity": "sha512-Jt01acDvJRhJGthnUJVF/w6gumWOZxO7IkpY/lsX9//zqQgnF7OJaxgQXcerd4uQOLu7W5bkb4mChL9mdfm+Zg==",
+      "dev": true,
+      "dependencies": {
+        "glob": "^7.1.6",
+        "ignore-walk": "^3.0.3",
+        "npm-bundled": "^1.1.1",
+        "npm-normalize-package-bin": "^1.0.1"
+      },
+      "bin": {
+        "npm-packlist": "bin/index.js"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/npmlog": {
@@ -28490,6 +28542,104 @@
       "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
       "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
       "license": "ISC",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/yalc": {
+      "version": "1.0.0-pre.53",
+      "resolved": "https://registry.npmjs.org/yalc/-/yalc-1.0.0-pre.53.tgz",
+      "integrity": "sha512-tpNqBCpTXplnduzw5XC+FF8zNJ9L/UXmvQyyQj7NKrDNavbJtHvzmZplL5ES/RCnjX7JR7W9wz5GVDXVP3dHUQ==",
+      "dev": true,
+      "dependencies": {
+        "chalk": "^4.1.0",
+        "detect-indent": "^6.0.0",
+        "fs-extra": "^8.0.1",
+        "glob": "^7.1.4",
+        "ignore": "^5.0.4",
+        "ini": "^2.0.0",
+        "npm-packlist": "^2.1.5",
+        "yargs": "^16.1.1"
+      },
+      "bin": {
+        "yalc": "src/yalc.js"
+      }
+    },
+    "node_modules/yalc/node_modules/cliui": {
+      "version": "7.0.4",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-7.0.4.tgz",
+      "integrity": "sha512-OcRE68cOsVMXp1Yvonl/fzkQOyjLSu/8bhPDfQt0e0/Eb283TKP20Fs2MqoPsr9SwA595rRCA+QMzYc9nBP+JQ==",
+      "dev": true,
+      "dependencies": {
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.0",
+        "wrap-ansi": "^7.0.0"
+      }
+    },
+    "node_modules/yalc/node_modules/fs-extra": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-8.1.0.tgz",
+      "integrity": "sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==",
+      "dev": true,
+      "dependencies": {
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^4.0.0",
+        "universalify": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=6 <7 || >=8"
+      }
+    },
+    "node_modules/yalc/node_modules/ini": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ini/-/ini-2.0.0.tgz",
+      "integrity": "sha512-7PnF4oN3CvZF23ADhA5wRaYEQpJ8qygSkbtTXWBeXWXmEVRXK+1ITciHWwHhsjv1TmW0MgacIv6hEi5pX5NQdA==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/yalc/node_modules/jsonfile": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
+      "integrity": "sha512-m6F1R3z8jjlf2imQHS2Qez5sjKWQzbuuhuJ/FKYFRZvPE3PuHcSMVZzfsLhGVOkfd20obL5SWEBew5ShlquNxg==",
+      "dev": true,
+      "optionalDependencies": {
+        "graceful-fs": "^4.1.6"
+      }
+    },
+    "node_modules/yalc/node_modules/universalify": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
+      "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
+      "dev": true,
+      "engines": {
+        "node": ">= 4.0.0"
+      }
+    },
+    "node_modules/yalc/node_modules/yargs": {
+      "version": "16.2.0",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-16.2.0.tgz",
+      "integrity": "sha512-D1mvvtDG0L5ft/jGWkLpG1+m0eQxOfaBvTNELraWj22wSVUMWxZUvYgJYcKh6jGGIkJFhH4IZPQhR4TKpc8mBw==",
+      "dev": true,
+      "dependencies": {
+        "cliui": "^7.0.2",
+        "escalade": "^3.1.1",
+        "get-caller-file": "^2.0.5",
+        "require-directory": "^2.1.1",
+        "string-width": "^4.2.0",
+        "y18n": "^5.0.5",
+        "yargs-parser": "^20.2.2"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/yalc/node_modules/yargs-parser": {
+      "version": "20.2.9",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.9.tgz",
+      "integrity": "sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w==",
+      "dev": true,
       "engines": {
         "node": ">=10"
       }

--- a/front/package.json
+++ b/front/package.json
@@ -21,7 +21,8 @@
     "create-db-migration": "./create_db_migration_file.sh",
     "prepare": "cd .. && husky .husky",
     "debug:profiler": "tsx ./scripts/debug/run_profiler.ts",
-    "sitemap": "next-sitemap"
+    "sitemap": "next-sitemap",
+    "sparkle:dev": "./admin/sparkle_dev.sh"
   },
   "dependencies": {
     "@datadog/browser-logs": "^6.13.0",
@@ -206,7 +207,8 @@
     "typescript": "5.4.5",
     "vite-tsconfig-paths": "^5.1.4",
     "vitest": "^3.0.8",
-    "vitest-canvas-mock": "^0.3.3"
+    "vitest-canvas-mock": "^0.3.3",
+    "yalc": "^1.0.0-pre.53"
   },
   "peerDependencies": {
     "typescript": "5.4.5"

--- a/sparkle/rollup.config.mjs
+++ b/sparkle/rollup.config.mjs
@@ -5,7 +5,6 @@ import resolve from "@rollup/plugin-node-resolve";
 import autoprefixer from "autoprefixer";
 import fs from "fs";
 import path from "path";
-import { rollup } from "rollup";
 import external from "rollup-plugin-peer-deps-external";
 import postcss from "rollup-plugin-postcss";
 import tailwindcss from "tailwindcss";
@@ -56,21 +55,25 @@ const config = {
       extract: false,
     }),
     json(),
-    terser({
-      compress: {
-        passes: 2,
-        drop_console: true,
-        keep_fnames: false,
-      },
-      format: {
-        comments: false,
-        preserve_annotations: false,
-      },
-      mangle: {
-        properties: false,
-      },
-      sourceMap: false,
-    }),
+    // Conditionally include terser based on environment variable
+    // Set DISABLE_TERSER=1 to disable minification (fixes webpack exports issue in dev)
+    ...(process.env.DISABLE_TERSER ? [] : [
+      terser({
+        compress: {
+          passes: 2,
+          drop_console: true,
+          keep_fnames: false,
+        },
+        format: {
+          comments: false,
+          preserve_annotations: false,
+        },
+        mangle: {
+          properties: false,
+        },
+        sourceMap: false,
+      })
+    ]),
   ],
 };
 


### PR DESCRIPTION
## Description

This PR adds a development helper script (`front/admin/sparkle_dev.sh`) that automates the process of building and publishing the Sparkle design system package for local development using yalc. The script simplifies the workflow for developers working on Sparkle components by providing a streamlined way to test changes locally without npm publishing.

Key changes include:
- Added `sparkle_dev.sh` script to handle local Sparkle development workflow
- Updated Sparkle's Rollup configuration to support disabling terser via environment variable for faster builds
- Added yalc as a development dependency in the front package

## Tests

Tested manually by running the script to build and link Sparkle locally. The script successfully builds Sparkle without terser optimization and publishes it via yalc for local consumption.

## Risk

Low risk - changes are limited to development tooling and do not affect production code. The Rollup configuration change only applies when the `DISABLE_TERSER` environment variable is explicitly set, maintaining existing behavior by default.

## Deploy Plan

No special deployment steps required. This is a development-only tool that does not impact production deployments.
