### PR TITLE
[core] Track prompt cached tokens + add prompt caching on dust-deep

### DIFF
--- a/core/src/blocks/chat.rs
+++ b/core/src/blocks/chat.rs
@@ -322,6 +322,9 @@ impl Block for Chat {
                 if let Some(Value::Object(s)) = v.get("anthropic_thinking") {
                     extras["anthropic_thinking"] = json!(s.clone());
                 }
+                if let Some(Value::Bool(s)) = v.get("prompt_caching") {
+                    extras["prompt_caching"] = json!(s.clone());
+                }
                 if let Some(Value::Array(a)) = v.get("anthropic_beta_flags") {
                     extras["anthropic_beta_flags"] = json!(a
                         .iter()

--- a/core/src/blocks/llm.rs
+++ b/core/src/blocks/llm.rs
@@ -409,6 +409,9 @@ impl Block for LLM {
                 if let Some(Value::String(s)) = v.get("reasoning_effort") {
                     extras["reasoning_effort"] = json!(s.clone());
                 }
+                if let Some(Value::Bool(s)) = v.get("prompt_caching") {
+                    extras["prompt_caching"] = json!(s.clone());
+                }
 
                 match extras.as_object().unwrap().keys().len() {
                     0 => None,

--- a/core/src/providers/anthropic/anthropic.rs
+++ b/core/src/providers/anthropic/anthropic.rs
@@ -106,7 +106,7 @@ impl AnthropicLLM {
 
         if system.is_some() {
             if prompt_caching {
-                body["system"] = json!([{"type": "text", "text": system.unwrap(), "cache_control": {"type": "ephemeral"}}]);
+                body["system"] = json!([{"type": "text", "text": system, "cache_control": {"type": "ephemeral"}}]);
             } else {
                 body["system"] = json!(system);
             }

--- a/core/src/providers/anthropic/anthropic.rs
+++ b/core/src/providers/anthropic/anthropic.rs
@@ -530,6 +530,7 @@ impl LLM for AnthropicLLM {
             usage: Some(LLMTokenUsage {
                 prompt_tokens: c.usage.input_tokens,
                 completion_tokens: c.usage.output_tokens,
+                cached_tokens: c.usage.cache_read_input_tokens,
                 // Note: the model can actually use less than that, but best we can do is report
                 // the full budget.
                 reasoning_tokens: thinking_budget,

--- a/core/src/providers/anthropic/anthropic.rs
+++ b/core/src/providers/anthropic/anthropic.rs
@@ -81,6 +81,7 @@ impl AnthropicLLM {
         stream: bool,
         thinking: Option<(String, u64)>,
         beta_flags: &Vec<&str>,
+        prompt_caching: bool,
     ) -> Value {
         let mut body = json!({
             "messages": messages,
@@ -104,7 +105,11 @@ impl AnthropicLLM {
         }
 
         if system.is_some() {
-            body["system"] = json!(system);
+            if prompt_caching {
+                body["system"] = json!([{"type": "text", "text": system.unwrap(), "cache_control": {"type": "ephemeral"}}]);
+            } else {
+                body["system"] = json!(system);
+            }
         }
 
         if let Some((thinking_type, thinking_budget_tokens)) = thinking {
@@ -154,6 +159,7 @@ impl AnthropicLLM {
         stop_sequences: &Vec<String>,
         max_tokens: i32,
         beta_flags: &Vec<&str>,
+        prompt_caching: bool,
     ) -> Result<(ChatResponse, Option<String>)> {
         assert!(self.api_key.is_some());
 
@@ -169,6 +175,7 @@ impl AnthropicLLM {
             false,
             None,
             beta_flags,
+            prompt_caching,
         );
 
         let body = self.backend.build_request_body(base_body, &self.id);
@@ -234,6 +241,7 @@ impl AnthropicLLM {
         beta_flags: &Vec<&str>,
         event_sender: UnboundedSender<Value>,
         thinking: Option<(String, u64)>,
+        prompt_caching: bool,
     ) -> Result<(ChatResponse, Option<String>)> {
         let base_body = self.build_base_request_body(
             messages,
@@ -247,6 +255,7 @@ impl AnthropicLLM {
             true,
             thinking,
             beta_flags,
+            prompt_caching,
         );
 
         let body = self.backend.build_request_body(base_body, &self.id);
@@ -423,6 +432,14 @@ impl LLM for AnthropicLLM {
             },
         };
 
+        let prompt_caching = match &extras {
+            None => false,
+            Some(v) => match v.get("prompt_caching") {
+                Some(Value::Bool(b)) => *b,
+                _ => false,
+            },
+        };
+
         let is_claude_4 = self.id.starts_with("claude-4-");
 
         let is_auto_tool = match tool_choice {
@@ -498,6 +515,7 @@ impl LLM for AnthropicLLM {
                     &beta_flags,
                     es,
                     thinking,
+                    prompt_caching,
                 )
                 .await?
             }
@@ -518,6 +536,7 @@ impl LLM for AnthropicLLM {
                         None => get_max_tokens(self.id.as_str()) as i32,
                     },
                     &beta_flags,
+                    prompt_caching,
                 )
                 .await?
             }
@@ -528,7 +547,9 @@ impl LLM for AnthropicLLM {
             provider: ProviderID::Anthropic.to_string(),
             model: self.id.clone(),
             usage: Some(LLMTokenUsage {
-                prompt_tokens: c.usage.input_tokens,
+                prompt_tokens: c.usage.input_tokens
+                    + c.usage.cache_read_input_tokens.unwrap_or(0)
+                    + c.usage.cache_creation_input_tokens.unwrap_or(0),
                 completion_tokens: c.usage.output_tokens,
                 cached_tokens: c.usage.cache_read_input_tokens,
                 // Note: the model can actually use less than that, but best we can do is report

--- a/core/src/providers/anthropic/types.rs
+++ b/core/src/providers/anthropic/types.rs
@@ -67,6 +67,7 @@ pub enum StopReason {
 pub struct Usage {
     pub input_tokens: u64,
     pub output_tokens: u64,
+    pub cache_read_input_tokens: Option<u64>,
 }
 
 // Anthropic content enum (a response is really an array of contents)

--- a/core/src/providers/anthropic/types.rs
+++ b/core/src/providers/anthropic/types.rs
@@ -68,6 +68,7 @@ pub struct Usage {
     pub input_tokens: u64,
     pub output_tokens: u64,
     pub cache_read_input_tokens: Option<u64>,
+    pub cache_creation_input_tokens: Option<u64>,
 }
 
 // Anthropic content enum (a response is really an array of contents)

--- a/core/src/providers/azure_openai.rs
+++ b/core/src/providers/azure_openai.rs
@@ -427,6 +427,9 @@ impl LLM for AzureOpenAILLM {
             usage: c.usage.map(|usage| LLMTokenUsage {
                 prompt_tokens: usage.prompt_tokens,
                 completion_tokens: usage.completion_tokens.unwrap_or(0),
+                cached_tokens: usage
+                    .prompt_tokens_details
+                    .and_then(|details| details.cached_tokens),
                 reasoning_tokens: None,
             }),
             provider_request_id: request_id,

--- a/core/src/providers/llm.rs
+++ b/core/src/providers/llm.rs
@@ -85,6 +85,8 @@ pub struct LLMTokenUsage {
     pub prompt_tokens: u64,
     pub completion_tokens: u64,
     #[serde(skip_serializing_if = "Option::is_none")]
+    pub cached_tokens: Option<u64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub reasoning_tokens: Option<u64>,
 }
 

--- a/core/src/providers/mistral.rs
+++ b/core/src/providers/mistral.rs
@@ -1064,6 +1064,7 @@ impl LLM for MistralAILLM {
             usage: c.usage.map(|u| LLMTokenUsage {
                 completion_tokens: u.completion_tokens.unwrap_or(0),
                 prompt_tokens: u.prompt_tokens,
+                cached_tokens: None,
                 reasoning_tokens: None,
             }),
             provider_request_id: request_id,

--- a/core/src/providers/openai.rs
+++ b/core/src/providers/openai.rs
@@ -53,10 +53,18 @@ lazy_static! {
 static RESPONSES_API_ENABLED: bool = true;
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
+pub struct UsageDetails {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub cached_tokens: Option<u64>,
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct Usage {
     pub prompt_tokens: u64,
     pub completion_tokens: Option<u64>,
     pub total_tokens: u64,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub prompt_tokens_details: Option<UsageDetails>,
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
@@ -1003,6 +1011,9 @@ impl LLM for OpenAILLM {
             usage: c.usage.map(|usage| LLMTokenUsage {
                 prompt_tokens: usage.prompt_tokens,
                 completion_tokens: usage.completion_tokens.unwrap_or(0),
+                cached_tokens: usage
+                    .prompt_tokens_details
+                    .and_then(|details| details.cached_tokens),
                 reasoning_tokens: None,
             }),
             provider_request_id: request_id,

--- a/core/src/providers/openai_compatible_helpers.rs
+++ b/core/src/providers/openai_compatible_helpers.rs
@@ -100,10 +100,18 @@ type ResponseFormat = serde_json::Map<String, serde_json::Value>;
 // Outputs types.
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
+pub struct UsageDetails {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub cached_tokens: Option<u64>,
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct Usage {
     pub prompt_tokens: u64,
     pub completion_tokens: Option<u64>,
     pub total_tokens: u64,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub prompt_tokens_details: Option<UsageDetails>,
 }
 
 #[derive(Debug, Serialize, Deserialize, PartialEq, Clone)]
@@ -749,6 +757,9 @@ pub async fn openai_compatible_chat_completion(
         usage: c.usage.map(|usage| LLMTokenUsage {
             prompt_tokens: usage.prompt_tokens,
             completion_tokens: usage.completion_tokens.unwrap_or(0),
+            cached_tokens: usage
+                .prompt_tokens_details
+                .and_then(|details| details.cached_tokens),
             reasoning_tokens: None,
         }),
         provider_request_id: request_id,

--- a/core/src/providers/openai_responses_api_helpers.rs
+++ b/core/src/providers/openai_responses_api_helpers.rs
@@ -560,6 +560,9 @@ pub async fn openai_responses_api_completion(
         usage: response.usage.map(|usage| LLMTokenUsage {
             prompt_tokens: usage.input_tokens,
             completion_tokens: usage.output_tokens,
+            cached_tokens: usage
+                .input_tokens_details
+                .and_then(|details| details.cached_tokens),
             reasoning_tokens: usage
                 .output_tokens_details
                 .and_then(|details| details.reasoning_tokens),

--- a/front/components/app/blocks/Output.tsx
+++ b/front/components/app/blocks/Output.tsx
@@ -282,6 +282,7 @@ export function InnerLogs({ trace }: { trace: TraceType }) {
           token_usage?: {
             prompt_tokens: number;
             completion_tokens: number;
+            cached_tokens?: number;
             reasoning_tokens?: number;
           };
         }
@@ -435,6 +436,7 @@ export default function Output({
                   token_usage?: {
                     completion_tokens: number;
                     prompt_tokens: number;
+                    cached_tokens?: number;
                     reasoning_tokens?: number;
                   };
                 }
@@ -484,6 +486,7 @@ export default function Output({
                               token_usage?: {
                                 completion_tokens: number;
                                 prompt_tokens: number;
+                                cached_tokens?: number;
                                 reasoning_tokens?: number;
                               };
                             }

--- a/front/lib/api/assistant/global_agents/configurations/dust-deep.ts
+++ b/front/lib/api/assistant/global_agents/configurations/dust-deep.ts
@@ -339,6 +339,7 @@ export function _getDustDeepGlobalAgent(
     modelId: modelConfig.modelConfiguration.modelId,
     temperature: 1.0,
     reasoningEffort: modelConfig.reasoningEffort,
+    promptCaching: true,
   };
 
   deepAgent.model = model;

--- a/front/lib/resources/run_resource.ts
+++ b/front/lib/resources/run_resource.ts
@@ -277,6 +277,7 @@ export class RunResource extends BaseResource<RunModel> {
       modelId: usage.modelId as ModelIdType,
       promptTokens: usage.promptTokens,
       providerId: usage.providerId as ModelProviderIdType,
+      cachedTokens: usage.cachedTokens,
     }));
   }
 }
@@ -295,4 +296,5 @@ export interface RunUsageType {
   modelId: ModelIdType;
   promptTokens: number;
   providerId: ModelProviderIdType;
+  cachedTokens: number | null;
 }

--- a/front/lib/resources/storage/models/runs.ts
+++ b/front/lib/resources/storage/models/runs.ts
@@ -65,6 +65,7 @@ export class RunUsageModel extends WorkspaceAwareModel<RunUsageModel> {
 
   declare promptTokens: number;
   declare completionTokens: number;
+  declare cachedTokens: number | null;
 }
 
 RunUsageModel.init(
@@ -84,6 +85,11 @@ RunUsageModel.init(
     completionTokens: {
       type: DataTypes.INTEGER,
       allowNull: false,
+    },
+    cachedTokens: {
+      type: DataTypes.INTEGER,
+      defaultValue: null,
+      allowNull: true,
     },
   },
   {

--- a/front/migrations/db/migration_351.sql
+++ b/front/migrations/db/migration_351.sql
@@ -1,0 +1,2 @@
+-- Migration created on Sep 02, 2025
+ALTER TABLE "public"."run_usages" ADD COLUMN "cachedTokens" INTEGER DEFAULT NULL;

--- a/front/pages/api/v1/w/[wId]/spaces/[spaceId]/apps/[aId]/runs/index.ts
+++ b/front/pages/api/v1/w/[wId]/spaces/[spaceId]/apps/[aId]/runs/index.ts
@@ -63,17 +63,21 @@ function extractUsageFromExecutions(
           token_usage: {
             prompt_tokens: number;
             completion_tokens: number;
+            cached_tokens?: number;
             reasoning_tokens?: number;
           };
         };
         if (token_usage) {
           const promptTokens = token_usage.prompt_tokens;
           const completionTokens = token_usage.completion_tokens;
+          const cachedTokens = token_usage.cached_tokens;
+
           usages.push({
             providerId: block.provider_id,
             modelId: block.model_id,
             promptTokens,
             completionTokens,
+            cachedTokens: cachedTokens ?? null,
           });
         }
       }

--- a/front/temporal/agent_loop/lib/run_model.ts
+++ b/front/temporal/agent_loop/lib/run_model.ts
@@ -359,7 +359,7 @@ export async function runModelActivity(
     runConfig.MODEL.anthropic_beta_flags = anthropicBetaFlags;
   }
 
-  // Set prompt_caching from agent configuration, default to true if not specified
+  // Set prompt_caching from agent configuration
   if (agentConfiguration.model.promptCaching) {
     runConfig.MODEL.prompt_caching = agentConfiguration.model.promptCaching;
   }

--- a/front/temporal/agent_loop/lib/run_model.ts
+++ b/front/temporal/agent_loop/lib/run_model.ts
@@ -359,6 +359,11 @@ export async function runModelActivity(
     runConfig.MODEL.anthropic_beta_flags = anthropicBetaFlags;
   }
 
+  // Set prompt_caching from agent configuration, default to true if not specified
+  if (agentConfiguration.model.promptCaching) {
+    runConfig.MODEL.prompt_caching = agentConfiguration.model.promptCaching;
+  }
+
   const res = await runActionStreamed(
     auth,
     "assistant-v2-multi-actions-agent",

--- a/front/temporal/agent_loop/lib/run_model.ts
+++ b/front/temporal/agent_loop/lib/run_model.ts
@@ -591,6 +591,7 @@ export async function runModelActivity(
             prompt_tokens: number;
             completion_tokens: number;
             reasoning_tokens?: number;
+            cached_tokens?: number;
           };
         } | null;
         const reasoningTokens = meta?.token_usage?.reasoning_tokens || 0;

--- a/front/types/assistant/agent.ts
+++ b/front/types/assistant/agent.ts
@@ -99,6 +99,7 @@ export type AgentModelConfigurationType = {
   temperature: number;
   reasoningEffort?: AgentReasoningEffort;
   responseFormat?: string;
+  promptCaching?: boolean;
 };
 
 export type AgentFetchVariant = "light" | "full" | "extra_light";


### PR DESCRIPTION
## Description

https://github.com/dust-tt/tasks/issues/3768

Get the count of cached tokens by prompt caching, and store them in db to monitor and track.
For anthropic models the cache needs to be explicitly enabled - adding an option here into model config to enable it. The entire message need to be identical to be used in cache - which is an issue right now with the "context" part, containing user name, date  and conversation id - it works only when iterating the same conversation.
OpenAI can cache prompts if they share the same prefix, they don't need any specific configuration option.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

low

## Deploy Plan

deploy core
deploy front