### PR TITLE
Add responsive typography system and new slides layout

### DIFF
--- a/viz/app/styles/globals.css
+++ b/viz/app/styles/globals.css
@@ -114,29 +114,29 @@
 
 @layer base {
   :root {
-    /* Responsive typography and spacing - defined once for all themes */
-    --responsive-text-xs: clamp(0.75rem, 1.8vw, 1rem);
-    --responsive-text-sm: clamp(0.875rem, 2vw, 1.125rem);
-    --responsive-text-base: clamp(1rem, 2.2vw, 1.25rem);
-    --responsive-text-lg: clamp(1.125rem, 2.4vw, 1.5rem);
-    --responsive-text-xl: clamp(1.25rem, 2.8vw, 1.75rem);
-    --responsive-text-2xl: clamp(1.5rem, 3.2vw, 2rem);
-    --responsive-text-3xl: clamp(1.875rem, 3.6vw, 2.5rem);
-    --responsive-text-4xl: clamp(2.25rem, 4.2vw, 3rem);
-    --responsive-text-5xl: clamp(2.5rem, 5vw, 3.5rem);
-    --responsive-text-6xl: clamp(3rem, 6vw, 4.5rem);
-    --responsive-text-7xl: clamp(3.5rem, 7vw, 5.5rem);
+    /* Responsive typography and spacing - aggressive mobile scaling */
+    --responsive-text-xs: clamp(0.5rem, 1.8vw, 1rem);
+    --responsive-text-sm: clamp(0.625rem, 2vw, 1.125rem);
+    --responsive-text-base: clamp(0.75rem, 2.2vw, 1.25rem);
+    --responsive-text-lg: clamp(0.875rem, 2.4vw, 1.5rem);
+    --responsive-text-xl: clamp(1rem, 2.8vw, 1.75rem);
+    --responsive-text-2xl: clamp(1.125rem, 3.2vw, 2rem);
+    --responsive-text-3xl: clamp(1.25rem, 3.6vw, 2.5rem);
+    --responsive-text-4xl: clamp(1.5rem, 4.2vw, 3rem);
+    --responsive-text-5xl: clamp(1.75rem, 5vw, 3.5rem);
+    --responsive-text-6xl: clamp(2rem, 6vw, 4.5rem);
+    --responsive-text-7xl: clamp(2.5rem, 7vw, 5.5rem);
 
-    --responsive-space-1: clamp(0.125rem, 0.25vw, 0.25rem);
-    --responsive-space-2: clamp(0.25rem, 0.5vw, 0.5rem);
-    --responsive-space-3: clamp(0.375rem, 0.75vw, 0.75rem);
-    --responsive-space-4: clamp(0.5rem, 1vw, 1rem);
-    --responsive-space-6: clamp(0.75rem, 1.5vw, 1.5rem);
-    --responsive-space-8: clamp(1rem, 2vw, 2rem);
-    --responsive-space-12: clamp(1.5rem, 3vw, 3rem);
-    --responsive-space-16: clamp(2rem, 4vw, 4rem);
-    --responsive-space-20: clamp(2.5rem, 5vw, 5rem);
-    --responsive-space-24: clamp(3rem, 6vw, 6rem);
+    --responsive-space-1: clamp(0.075rem, 0.25vw, 0.25rem);
+    --responsive-space-2: clamp(0.125rem, 0.5vw, 0.5rem);
+    --responsive-space-3: clamp(0.25rem, 0.75vw, 0.75rem);
+    --responsive-space-4: clamp(0.375rem, 1vw, 1rem);
+    --responsive-space-6: clamp(0.5rem, 1.5vw, 1.5rem);
+    --responsive-space-8: clamp(0.75rem, 2vw, 2rem);
+    --responsive-space-12: clamp(1rem, 3vw, 3rem);
+    --responsive-space-16: clamp(1.5rem, 4vw, 4rem);
+    --responsive-space-20: clamp(2rem, 5vw, 5rem);
+    --responsive-space-24: clamp(2.5rem, 6vw, 6rem);
   }
 
   * {

--- a/viz/app/styles/globals.css
+++ b/viz/app/styles/globals.css
@@ -113,10 +113,204 @@
 }
 
 @layer base {
+  :root {
+    /* Responsive typography and spacing - defined once for all themes */
+    --responsive-text-xs: clamp(0.75rem, 1.8vw, 1rem);
+    --responsive-text-sm: clamp(0.875rem, 2vw, 1.125rem);
+    --responsive-text-base: clamp(1rem, 2.2vw, 1.25rem);
+    --responsive-text-lg: clamp(1.125rem, 2.4vw, 1.5rem);
+    --responsive-text-xl: clamp(1.25rem, 2.8vw, 1.75rem);
+    --responsive-text-2xl: clamp(1.5rem, 3.2vw, 2rem);
+    --responsive-text-3xl: clamp(1.875rem, 3.6vw, 2.5rem);
+    --responsive-text-4xl: clamp(2.25rem, 4.2vw, 3rem);
+    --responsive-text-5xl: clamp(2.5rem, 5vw, 3.5rem);
+    --responsive-text-6xl: clamp(3rem, 6vw, 4.5rem);
+    --responsive-text-7xl: clamp(3.5rem, 7vw, 5.5rem);
+
+    --responsive-space-1: clamp(0.125rem, 0.25vw, 0.25rem);
+    --responsive-space-2: clamp(0.25rem, 0.5vw, 0.5rem);
+    --responsive-space-3: clamp(0.375rem, 0.75vw, 0.75rem);
+    --responsive-space-4: clamp(0.5rem, 1vw, 1rem);
+    --responsive-space-6: clamp(0.75rem, 1.5vw, 1.5rem);
+    --responsive-space-8: clamp(1rem, 2vw, 2rem);
+    --responsive-space-12: clamp(1.5rem, 3vw, 3rem);
+    --responsive-space-16: clamp(2rem, 4vw, 4rem);
+    --responsive-space-20: clamp(2.5rem, 5vw, 5rem);
+    --responsive-space-24: clamp(3rem, 6vw, 6rem);
+  }
+
   * {
     @apply border-border;
   }
   body {
     @apply bg-background text-foreground;
+  }
+}
+
+@layer components {
+  /* Responsive typography and spacing utilities - opt-in for any component */
+  .responsive-text .text-xs {
+    font-size: var(--responsive-text-xs);
+  }
+  .responsive-text .text-sm {
+    font-size: var(--responsive-text-sm);
+  }
+  .responsive-text .text-base {
+    font-size: var(--responsive-text-base);
+  }
+  .responsive-text .text-lg {
+    font-size: var(--responsive-text-lg);
+  }
+  .responsive-text .text-xl {
+    font-size: var(--responsive-text-xl);
+  }
+  .responsive-text .text-2xl {
+    font-size: var(--responsive-text-2xl);
+  }
+  .responsive-text .text-3xl {
+    font-size: var(--responsive-text-3xl);
+  }
+  .responsive-text .text-4xl {
+    font-size: var(--responsive-text-4xl);
+  }
+  .responsive-text .text-5xl {
+    font-size: var(--responsive-text-5xl);
+  }
+  .responsive-text .text-6xl {
+    font-size: var(--responsive-text-6xl);
+  }
+  .responsive-text .text-7xl {
+    font-size: var(--responsive-text-7xl);
+  }
+
+  .responsive-text .gap-1 {
+    gap: var(--responsive-space-1);
+  }
+  .responsive-text .gap-2 {
+    gap: var(--responsive-space-2);
+  }
+  .responsive-text .gap-3 {
+    gap: var(--responsive-space-3);
+  }
+  .responsive-text .gap-4 {
+    gap: var(--responsive-space-4);
+  }
+  .responsive-text .gap-6 {
+    gap: var(--responsive-space-6);
+  }
+  .responsive-text .gap-8 {
+    gap: var(--responsive-space-8);
+  }
+  .responsive-text .gap-12 {
+    gap: var(--responsive-space-12);
+  }
+  .responsive-text .gap-16 {
+    gap: var(--responsive-space-16);
+  }
+
+  .responsive-text .space-y-1 > * + * {
+    margin-top: var(--responsive-space-1);
+  }
+  .responsive-text .space-y-2 > * + * {
+    margin-top: var(--responsive-space-2);
+  }
+  .responsive-text .space-y-3 > * + * {
+    margin-top: var(--responsive-space-3);
+  }
+  .responsive-text .space-y-4 > * + * {
+    margin-top: var(--responsive-space-4);
+  }
+  .responsive-text .space-y-6 > * + * {
+    margin-top: var(--responsive-space-6);
+  }
+  .responsive-text .space-y-8 > * + * {
+    margin-top: var(--responsive-space-8);
+  }
+  .responsive-text .space-y-12 > * + * {
+    margin-top: var(--responsive-space-12);
+  }
+
+  .responsive-text .mt-1 {
+    margin-top: var(--responsive-space-1);
+  }
+  .responsive-text .mt-2 {
+    margin-top: var(--responsive-space-2);
+  }
+  .responsive-text .mt-3 {
+    margin-top: var(--responsive-space-3);
+  }
+  .responsive-text .mt-4 {
+    margin-top: var(--responsive-space-4);
+  }
+  .responsive-text .mt-6 {
+    margin-top: var(--responsive-space-6);
+  }
+  .responsive-text .mt-8 {
+    margin-top: var(--responsive-space-8);
+  }
+  .responsive-text .mt-12 {
+    margin-top: var(--responsive-space-12);
+  }
+  .responsive-text .mt-16 {
+    margin-top: var(--responsive-space-16);
+  }
+
+  .responsive-text .mb-1 {
+    margin-bottom: var(--responsive-space-1);
+  }
+  .responsive-text .mb-2 {
+    margin-bottom: var(--responsive-space-2);
+  }
+  .responsive-text .mb-3 {
+    margin-bottom: var(--responsive-space-3);
+  }
+  .responsive-text .mb-4 {
+    margin-bottom: var(--responsive-space-4);
+  }
+  .responsive-text .mb-6 {
+    margin-bottom: var(--responsive-space-6);
+  }
+  .responsive-text .mb-8 {
+    margin-bottom: var(--responsive-space-8);
+  }
+  .responsive-text .mb-12 {
+    margin-bottom: var(--responsive-space-12);
+  }
+
+  .responsive-text .p-1 {
+    padding: var(--responsive-space-1);
+  }
+  .responsive-text .p-2 {
+    padding: var(--responsive-space-2);
+  }
+  .responsive-text .p-3 {
+    padding: var(--responsive-space-3);
+  }
+  .responsive-text .p-4 {
+    padding: var(--responsive-space-4);
+  }
+  .responsive-text .p-6 {
+    padding: var(--responsive-space-6);
+  }
+  .responsive-text .p-8 {
+    padding: var(--responsive-space-8);
+  }
+  .responsive-text .p-12 {
+    padding: var(--responsive-space-12);
+  }
+
+  /* Slide variant padding */
+  .slide-top-padding {
+    padding: var(--responsive-space-8);
+    padding-top: var(--responsive-space-24);
+  }
+  .slide-centered-padding {
+    padding: var(--responsive-space-8);
+  }
+
+  /* Slide content container */
+  .slide-content-container {
+    max-height: calc(100vh - var(--responsive-space-24) - var(--responsive-space-8));
+    overflow: auto;
   }
 }

--- a/viz/app/styles/globals.css
+++ b/viz/app/styles/globals.css
@@ -114,7 +114,7 @@
 
 @layer base {
   :root {
-    /* Responsive typography and spacing - aggressive mobile scaling */
+    /* Responsive typography and spacing */
     --responsive-text-xs: clamp(0.5rem, 1.8vw, 1rem);
     --responsive-text-sm: clamp(0.625rem, 2vw, 1.125rem);
     --responsive-text-base: clamp(0.75rem, 2.2vw, 1.25rem);
@@ -306,11 +306,5 @@
   }
   .slide-centered-padding {
     padding: var(--responsive-space-8);
-  }
-
-  /* Slide content container */
-  .slide-content-container {
-    max-height: calc(100vh - var(--responsive-space-24) - var(--responsive-space-8));
-    overflow: auto;
   }
 }

--- a/viz/components/dust/slideshow/v1/index.tsx
+++ b/viz/components/dust/slideshow/v1/index.tsx
@@ -208,10 +208,7 @@ type SlideshowProps = PropsWithChildren<{
 }>;
 
 function SlideshowRoot({ children, className }: SlideshowProps) {
-  const slides = React.useMemo(
-    () => validateSlideChildren(children),
-    [children]
-  );
+  const slides = validateSlideChildren(children);
 
   const [activeIndex, setActiveIndex] = React.useState(0);
   const [isNavigationVisible, setIsNavigationVisible] = React.useState(true);

--- a/viz/components/dust/slideshow/v1/index.tsx
+++ b/viz/components/dust/slideshow/v1/index.tsx
@@ -155,9 +155,12 @@ export function Slide({
 
 const NAVIGATION_HIDE_DELAY = 3000; // Milliseconds before navigation auto-hides
 
-function hasDisplayName(component: any): component is { displayName: string } {
+function hasDisplayName(
+  component: unknown
+): component is { displayName: string } {
   return (
-    typeof component === "function" && typeof component.displayName === "string"
+    typeof component === "function" &&
+    typeof (component as { displayName?: string }).displayName === "string"
   );
 }
 

--- a/viz/components/dust/slideshow/v1/index.tsx
+++ b/viz/components/dust/slideshow/v1/index.tsx
@@ -307,10 +307,7 @@ export const Title = ({
   className,
 }: PropsWithChildren<{ className?: string }>) => (
   <h1
-    className={cn(
-      "font-semibold text-3xl sm:text-4xl md:text-5xl lg:text-6xl xl:text-7xl leading-tight m-0 mb-3 sm:mb-4 md:mb-5 lg:mb-6",
-      className
-    )}
+    className={cn("font-semibold text-7xl leading-tight m-0 mb-6", className)}
     style={{ fontFamily: "var(--font-geist-mono)" }}
   >
     {children}
@@ -322,10 +319,7 @@ export const Heading = ({
   className,
 }: PropsWithChildren<{ className?: string }>) => (
   <h2
-    className={cn(
-      "font-semibold text-2xl sm:text-3xl md:text-4xl lg:text-5xl leading-tight m-0 mb-2 sm:mb-3 md:mb-4",
-      className
-    )}
+    className={cn("font-semibold text-5xl leading-tight m-0 mb-4", className)}
     style={{ fontFamily: "var(--font-geist-mono)" }}
   >
     {children}
@@ -337,10 +331,7 @@ export const Text = ({
   className,
 }: PropsWithChildren<{ className?: string }>) => (
   <p
-    className={cn(
-      "font-normal text-xs sm:text-sm md:text-base lg:text-lg m-0",
-      className
-    )}
+    className={cn("font-normal text-lg m-0", className)}
     style={{ fontFamily: "var(--font-geist)" }}
   >
     {children}
@@ -367,29 +358,10 @@ export const Cover = ({
   titleClassName,
 }: CoverProps) => (
   <Slide variant="centered" className={className} isPreview={isPreview}>
-    <div
-      className={cn(
-        "h-full flex flex-col items-center justify-center text-center space-y-2 sm:space-y-3",
-        "md:space-y-4"
-      )}
-    >
-      <Title
-        className={cn(
-          "text-2xl sm:text-3xl md:text-4xl lg:text-5xl xl:text-6xl",
-          titleClassName
-        )}
-      >
-        {title}
-      </Title>
+    <div className="h-full flex flex-col items-center justify-center text-center space-y-4">
+      <Title className={titleClassName}>{title}</Title>
       {subtitle && (
-        <Text
-          className={cn(
-            "text-sm sm:text-base md:text-lg lg:text-xl opacity-80",
-            subtitleClassName
-          )}
-        >
-          {subtitle}
-        </Text>
+        <Text className={cn("opacity-80", subtitleClassName)}>{subtitle}</Text>
       )}
     </div>
   </Slide>
@@ -412,17 +384,13 @@ export const Bullets = ({
   isPreview = false,
 }: BulletsProps) => (
   <Slide variant="top" className={className} isPreview={isPreview}>
-    <div className="h-full flex flex-col space-y-3 sm:space-y-4 md:space-y-5 lg:space-y-6">
+    <div className="h-full flex flex-col space-y-6">
       <Heading className={titleClassName}>{title}</Heading>
-      <ul className="space-y-2 sm:space-y-3 md:space-y-4">
+      <ul className="space-y-4">
         {items.map((item, index) => (
           <li key={index} className="flex items-start">
-            <span className="text-lg sm:text-xl md:text-2xl mr-2 sm:mr-3 md:mr-4 mt-1 opacity-60">
-              •
-            </span>
-            <Text className="text-sm sm:text-base md:text-lg flex-1">
-              {item}
-            </Text>
+            <span className="text-2xl mr-4 mt-1 opacity-60">•</span>
+            <Text className="flex-1">{item}</Text>
           </li>
         ))}
       </ul>
@@ -445,7 +413,7 @@ export const Split = ({
   isPreview = false,
 }: SplitProps) => (
   <Slide variant="top" className={className} isPreview={isPreview}>
-    <div className="h-full grid grid-cols-1 md:grid-cols-2 gap-4 sm:gap-6 md:gap-8 items-center">
+    <div className="h-full grid grid-cols-1 md:grid-cols-2 gap-8 items-center">
       <div>{children[0]}</div>
       <div>{children[1]}</div>
     </div>
@@ -460,9 +428,7 @@ type FullProps = PropsWithChildren<{
 
 export const Full = ({ children, className, isPreview = false }: FullProps) => (
   <Slide variant="top" className={className} isPreview={isPreview}>
-    <div className="h-full flex flex-col space-y-3 sm:space-y-4 md:space-y-5 lg:space-y-6">
-      {children}
-    </div>
+    <div className="h-full flex flex-col space-y-6">{children}</div>
   </Slide>
 );
 Full.displayName = "Slideshow.Slide.Full";
@@ -482,14 +448,7 @@ export const TitleCentered = ({
 }: TitleCenteredProps) => (
   <Slide variant="centered" className={className} isPreview={isPreview}>
     <div className="h-full flex flex-col items-center justify-center text-center">
-      <Title
-        className={cn(
-          "text-3xl sm:text-4xl md:text-5xl lg:text-6xl",
-          titleClassName
-        )}
-      >
-        {title}
-      </Title>
+      <Title className={titleClassName}>{title}</Title>
     </div>
   </Slide>
 );
@@ -511,15 +470,8 @@ export const TitleTop = ({
 }: TitleTopProps) => (
   <Slide variant="top" className={className} isPreview={isPreview}>
     <div className="h-full flex flex-col">
-      <div className="text-center pb-4 sm:pb-6 md:pb-8">
-        <Title
-          className={cn(
-            "text-2xl sm:text-3xl md:text-4xl lg:text-5xl",
-            titleClassName
-          )}
-        >
-          {title}
-        </Title>
+      <div className="text-center pb-8">
+        <Title className={titleClassName}>{title}</Title>
       </div>
       <div className="flex-1 flex flex-col justify-center">{children}</div>
     </div>
@@ -540,15 +492,11 @@ export const BulletsOnly = ({
 }: BulletsOnlyProps) => (
   <Slide variant="top" className={className} isPreview={isPreview}>
     <div className="h-full flex flex-col">
-      <ul className="space-y-3 sm:space-y-4 md:space-y-5 lg:space-y-6">
+      <ul className="space-y-6">
         {items.map((item, index) => (
           <li key={index} className="flex items-start">
-            <span className="text-xl sm:text-2xl md:text-3xl mr-3 sm:mr-4 md:mr-5 lg:mr-6 mt-1 opacity-60">
-              •
-            </span>
-            <Text className="text-base sm:text-lg md:text-xl flex-1">
-              {item}
-            </Text>
+            <span className="text-3xl mr-6 mt-1 opacity-60">•</span>
+            <Text className="flex-1">{item}</Text>
           </li>
         ))}
       </ul>
@@ -575,21 +523,16 @@ export const Quote = ({
   quoteClassName,
 }: QuoteProps) => (
   <Slide variant="centered" className={className} isPreview={isPreview}>
-    <div className="h-full flex flex-col items-center justify-center text-center space-y-4 sm:space-y-6 md:space-y-8">
+    <div className="h-full flex flex-col items-center justify-center text-center space-y-8">
       <blockquote
         className={cn(
-          "text-lg sm:text-xl md:text-2xl lg:text-3xl font-light italic leading-relaxed max-w-4xl",
+          "text-3xl font-light italic leading-relaxed max-w-4xl",
           quoteClassName
         )}
       >
         &quot;{quote}&quot;
       </blockquote>
-      <cite
-        className={cn(
-          "text-sm sm:text-base md:text-lg lg:text-xl opacity-80 not-italic",
-          authorClassName
-        )}
-      >
+      <cite className={cn("text-xl opacity-80 not-italic", authorClassName)}>
         — {author}
       </cite>
     </div>

--- a/viz/components/dust/slideshow/v1/index.tsx
+++ b/viz/components/dust/slideshow/v1/index.tsx
@@ -114,57 +114,105 @@ export function SlideshowPreviewSidebar({
 type SlideProps = PropsWithChildren<{
   className?: string;
   isPreview?: boolean;
+  variant?: "centered" | "top";
 }>;
 
-export function Slide({ children, className, isPreview = false }: SlideProps) {
+export function Slide({
+  children,
+  className,
+  isPreview = false,
+  variant = "top",
+}: SlideProps) {
   const ref = React.useRef<HTMLDivElement>(null);
 
   return (
     <div
       ref={ref}
       className={cn(
-        "w-full h-full flex items-start justify-center overflow-hidden",
+        "w-full h-full flex overflow-hidden responsive-text justify-center",
+        variant === "centered" ? "items-center" : "items-start",
         className
       )}
       style={{ fontFamily: "var(--font-geist)" }}
     >
       {isPreview ? (
-        <div className="p-2 w-full h-full">{children}</div>
+        <div className="p-2 w-full h-full" style={{ fontSize: "0.4em" }}>
+          {children}
+        </div>
       ) : (
-        <div className="p-8 w-full">{children}</div>
+        <div
+          className={cn(
+            "w-full",
+            variant === "top" ? "slide-top-padding" : "slide-centered-padding"
+          )}
+        >
+          {children}
+        </div>
       )}
     </div>
   );
+}
+
+const NAVIGATION_HIDE_DELAY = 3000; // Milliseconds before navigation auto-hides
+
+function hasDisplayName(component: any): component is { displayName: string } {
+  return (
+    typeof component === "function" && typeof component.displayName === "string"
+  );
+}
+
+function validateSlideChildren(
+  children: React.ReactNode
+): React.ReactElement[] {
+  const childArray = React.Children.toArray(children) as React.ReactElement[];
+
+  const validSlideDisplayNames = new Set([
+    "Slideshow.Slide.Base",
+    "Slideshow.Slide.Cover",
+    "Slideshow.Slide.Bullets",
+    "Slideshow.Slide.Split",
+    "Slideshow.Slide.Full",
+    "Slideshow.Slide.TitleCentered",
+    "Slideshow.Slide.TitleTop",
+    "Slideshow.Slide.BulletsOnly",
+    "Slideshow.Slide.Quote",
+  ]);
+
+  const invalidChildren = childArray.filter((child) => {
+    if (!React.isValidElement(child)) {
+      return true;
+    }
+
+    if (!hasDisplayName(child.type)) {
+      return true;
+    }
+
+    return !validSlideDisplayNames.has(child.type.displayName);
+  });
+
+  if (invalidChildren.length > 0) {
+    throw new Error(
+      "Slideshow: All children must be Slideshow.Slide components. " +
+        `Found ${invalidChildren.length} invalid child(ren).`
+    );
+  }
+
+  return childArray;
 }
 
 type SlideshowProps = PropsWithChildren<{
   className?: string;
 }>;
 
-const NAVIGATION_HIDE_DELAY = 3000; // Milliseconds before navigation auto-hides
-
-export function Slideshow({ children, className }: SlideshowProps) {
-  const slides = React.useMemo(() => {
-    const childArray = React.Children.toArray(children) as React.ReactElement[];
-
-    // Validate that all children are Slide components.
-    const invalidChildren = childArray.filter((child) => {
-      return !React.isValidElement(child) || child.type !== Slide;
-    });
-
-    if (invalidChildren.length > 0) {
-      throw new Error(
-        "Slideshow: All children must be Slideshow.Slide components. " +
-          `Found ${invalidChildren.length} invalid child(ren).`
-      );
-    }
-
-    return childArray;
-  }, [children]);
+function SlideshowRoot({ children, className }: SlideshowProps) {
+  const slides = React.useMemo(
+    () => validateSlideChildren(children),
+    [children]
+  );
 
   const [activeIndex, setActiveIndex] = React.useState(0);
   const [isNavigationVisible, setIsNavigationVisible] = React.useState(true);
-  const hideTimeoutRef = React.useRef<NodeJS.Timeout>();
+  const hideTimeoutRef = React.useRef<ReturnType<typeof setTimeout>>();
 
   const resetHideTimer = React.useCallback(() => {
     if (hideTimeoutRef.current) {
@@ -259,7 +307,10 @@ export const Title = ({
   className,
 }: PropsWithChildren<{ className?: string }>) => (
   <h1
-    className={cn("font-semibold text-7xl leading-tight m-0 mb-6", className)}
+    className={cn(
+      "font-semibold text-3xl sm:text-4xl md:text-5xl lg:text-6xl xl:text-7xl leading-tight m-0 mb-3 sm:mb-4 md:mb-5 lg:mb-6",
+      className
+    )}
     style={{ fontFamily: "var(--font-geist-mono)" }}
   >
     {children}
@@ -271,7 +322,10 @@ export const Heading = ({
   className,
 }: PropsWithChildren<{ className?: string }>) => (
   <h2
-    className={cn("font-semibold text-5xl leading-tight m-0 mb-4", className)}
+    className={cn(
+      "font-semibold text-2xl sm:text-3xl md:text-4xl lg:text-5xl leading-tight m-0 mb-2 sm:mb-3 md:mb-4",
+      className
+    )}
     style={{ fontFamily: "var(--font-geist-mono)" }}
   >
     {children}
@@ -283,14 +337,283 @@ export const Text = ({
   className,
 }: PropsWithChildren<{ className?: string }>) => (
   <p
-    className={cn("font-normal text-sm m-0", className)}
+    className={cn(
+      "font-normal text-xs sm:text-sm md:text-base lg:text-lg m-0",
+      className
+    )}
     style={{ fontFamily: "var(--font-geist)" }}
   >
     {children}
   </p>
 );
 
-Slideshow.Slide = Slide;
-Slideshow.Title = Title;
-Slideshow.Heading = Heading;
-Slideshow.Text = Text;
+// Slide-level layout components.
+
+interface CoverProps {
+  className?: string;
+  isPreview?: boolean;
+  subtitle?: string;
+  subtitleClassName?: string;
+  title: string;
+  titleClassName?: string;
+}
+
+export const Cover = ({
+  className,
+  isPreview = false,
+  subtitle,
+  subtitleClassName,
+  title,
+  titleClassName,
+}: CoverProps) => (
+  <Slide variant="centered" className={className} isPreview={isPreview}>
+    <div
+      className={cn(
+        "h-full flex flex-col items-center justify-center text-center space-y-2 sm:space-y-3",
+        "md:space-y-4"
+      )}
+    >
+      <Title
+        className={cn(
+          "text-2xl sm:text-3xl md:text-4xl lg:text-5xl xl:text-6xl",
+          titleClassName
+        )}
+      >
+        {title}
+      </Title>
+      {subtitle && (
+        <Text
+          className={cn(
+            "text-sm sm:text-base md:text-lg lg:text-xl opacity-80",
+            subtitleClassName
+          )}
+        >
+          {subtitle}
+        </Text>
+      )}
+    </div>
+  </Slide>
+);
+Cover.displayName = "Slideshow.Slide.Cover";
+
+interface BulletsProps {
+  className?: string;
+  isPreview?: boolean;
+  items: string[];
+  title: string;
+  titleClassName?: string;
+}
+
+export const Bullets = ({
+  title,
+  items,
+  className,
+  titleClassName,
+  isPreview = false,
+}: BulletsProps) => (
+  <Slide variant="top" className={className} isPreview={isPreview}>
+    <div className="h-full flex flex-col space-y-3 sm:space-y-4 md:space-y-5 lg:space-y-6">
+      <Heading className={titleClassName}>{title}</Heading>
+      <ul className="space-y-2 sm:space-y-3 md:space-y-4">
+        {items.map((item, index) => (
+          <li key={index} className="flex items-start">
+            <span className="text-lg sm:text-xl md:text-2xl mr-2 sm:mr-3 md:mr-4 mt-1 opacity-60">
+              •
+            </span>
+            <Text className="text-sm sm:text-base md:text-lg flex-1">
+              {item}
+            </Text>
+          </li>
+        ))}
+      </ul>
+    </div>
+  </Slide>
+);
+Bullets.displayName = "Slideshow.Slide.Bullets";
+
+type TwoChildren = [React.ReactNode, React.ReactNode];
+
+interface SplitProps {
+  children: TwoChildren;
+  className?: string;
+  isPreview?: boolean;
+}
+
+export const Split = ({
+  children,
+  className,
+  isPreview = false,
+}: SplitProps) => (
+  <Slide variant="top" className={className} isPreview={isPreview}>
+    <div className="h-full grid grid-cols-1 md:grid-cols-2 gap-4 sm:gap-6 md:gap-8 items-center">
+      <div>{children[0]}</div>
+      <div>{children[1]}</div>
+    </div>
+  </Slide>
+);
+Split.displayName = "Slideshow.Slide.Split";
+
+type FullProps = PropsWithChildren<{
+  className?: string;
+  isPreview?: boolean;
+}>;
+
+export const Full = ({ children, className, isPreview = false }: FullProps) => (
+  <Slide variant="top" className={className} isPreview={isPreview}>
+    <div className="h-full flex flex-col space-y-3 sm:space-y-4 md:space-y-5 lg:space-y-6">
+      {children}
+    </div>
+  </Slide>
+);
+Full.displayName = "Slideshow.Slide.Full";
+
+interface TitleCenteredProps {
+  className?: string;
+  isPreview?: boolean;
+  title: string;
+  titleClassName?: string;
+}
+
+export const TitleCentered = ({
+  className,
+  isPreview = false,
+  title,
+  titleClassName,
+}: TitleCenteredProps) => (
+  <Slide variant="centered" className={className} isPreview={isPreview}>
+    <div className="h-full flex flex-col items-center justify-center text-center">
+      <Title
+        className={cn(
+          "text-3xl sm:text-4xl md:text-5xl lg:text-6xl",
+          titleClassName
+        )}
+      >
+        {title}
+      </Title>
+    </div>
+  </Slide>
+);
+TitleCentered.displayName = "Slideshow.Slide.TitleCentered";
+
+type TitleTopProps = PropsWithChildren<{
+  className?: string;
+  isPreview?: boolean;
+  title: string;
+  titleClassName?: string;
+}>;
+
+export const TitleTop = ({
+  title,
+  children,
+  className,
+  titleClassName,
+  isPreview = false,
+}: TitleTopProps) => (
+  <Slide variant="top" className={className} isPreview={isPreview}>
+    <div className="h-full flex flex-col">
+      <div className="text-center pb-4 sm:pb-6 md:pb-8">
+        <Title
+          className={cn(
+            "text-2xl sm:text-3xl md:text-4xl lg:text-5xl",
+            titleClassName
+          )}
+        >
+          {title}
+        </Title>
+      </div>
+      <div className="flex-1 flex flex-col justify-center">{children}</div>
+    </div>
+  </Slide>
+);
+TitleTop.displayName = "Slideshow.Slide.TitleTop";
+
+interface BulletsOnlyProps {
+  className?: string;
+  isPreview?: boolean;
+  items: string[];
+}
+
+export const BulletsOnly = ({
+  className,
+  isPreview = false,
+  items,
+}: BulletsOnlyProps) => (
+  <Slide variant="top" className={className} isPreview={isPreview}>
+    <div className="h-full flex flex-col">
+      <ul className="space-y-3 sm:space-y-4 md:space-y-5 lg:space-y-6">
+        {items.map((item, index) => (
+          <li key={index} className="flex items-start">
+            <span className="text-xl sm:text-2xl md:text-3xl mr-3 sm:mr-4 md:mr-5 lg:mr-6 mt-1 opacity-60">
+              •
+            </span>
+            <Text className="text-base sm:text-lg md:text-xl flex-1">
+              {item}
+            </Text>
+          </li>
+        ))}
+      </ul>
+    </div>
+  </Slide>
+);
+BulletsOnly.displayName = "Slideshow.Slide.BulletsOnly";
+
+interface QuoteProps {
+  author: string;
+  authorClassName?: string;
+  className?: string;
+  isPreview?: boolean;
+  quote: string;
+  quoteClassName?: string;
+}
+
+export const Quote = ({
+  author,
+  authorClassName,
+  className,
+  isPreview = false,
+  quote,
+  quoteClassName,
+}: QuoteProps) => (
+  <Slide variant="centered" className={className} isPreview={isPreview}>
+    <div className="h-full flex flex-col items-center justify-center text-center space-y-4 sm:space-y-6 md:space-y-8">
+      <blockquote
+        className={cn(
+          "text-lg sm:text-xl md:text-2xl lg:text-3xl font-light italic leading-relaxed max-w-4xl",
+          quoteClassName
+        )}
+      >
+        &quot;{quote}&quot;
+      </blockquote>
+      <cite
+        className={cn(
+          "text-sm sm:text-base md:text-lg lg:text-xl opacity-80 not-italic",
+          authorClassName
+        )}
+      >
+        — {author}
+      </cite>
+    </div>
+  </Slide>
+);
+Quote.displayName = "Slideshow.Slide.Quote";
+
+Slide.displayName = "Slideshow.Slide.Base";
+
+// Namespace export.
+export const Slideshow = {
+  Heading,
+  Root: SlideshowRoot,
+  Slide: {
+    Base: Slide,
+    Bullets,
+    BulletsOnly,
+    Cover,
+    Full,
+    Quote,
+    Split,
+    TitleCentered,
+    TitleTop,
+  },
+  Text,
+  Title,
+};


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
This PR adds:
- a few more Slides layout (highly inspired by what exist in the Keynote app). We want them dead simple so LLMs can use them very easily without too much abstraction. The goal here is to ensure that all slides will look nice. A second pass oriented on the design will follow up shortly. 
- a typography system that relies on CSS [clamp](https://developer.mozilla.org/en-US/docs/Web/CSS/clamp) to ensure we can better accommodate the rendering of Slides on many different container size.  We CSS clamp() functions to smoothly scale fonts and spacing based on viewport width rather jarring jumps at specific breakpoints. 

![Sep-02-2025 11-42-52](https://github.com/user-attachments/assets/cd780ff8-027a-4c51-8fae-72fa548fbb71)

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
