### PR TITLE
[front] - chore(AB v2): add handle to resizable conversation panel

### DIFF
--- a/front/components/assistant/conversation/ConversationSidePanelContainer.tsx
+++ b/front/components/assistant/conversation/ConversationSidePanelContainer.tsx
@@ -37,13 +37,7 @@ export default function ConversationSidePanelContainer({
   return (
     <>
       {/* Resizable Handle for Panels */}
-      <ResizableHandle
-        className={cn(
-          "hidden transition-all duration-300 ease-out md:block",
-          !currentPanel && "translate-x-full opacity-0"
-        )}
-        disabled={!currentPanel}
-      />
+      <ResizableHandle withHandle disabled={!currentPanel} />
       {/* Panel Container - either Content Creation or Actions */}
       <ResizablePanel
         ref={panelRef}


### PR DESCRIPTION
## Description

This PR adds a handle to the `ConversationSidePanelContainer` for consistency with the new agent builder.

<img width="2556" height="1355" alt="Screenshot 2025-09-02 at 12 08 37" src="https://github.com/user-attachments/assets/af8e5038-d828-4dd6-ade4-68a6be2e3acd" />

## Tests

Locally

## Risk

Low

## Deploy Plan

Deploy front