### PR TITLE
[front] Redirect to signIn  page if user already exist

### DIFF
--- a/front/lib/signup.ts
+++ b/front/lib/signup.ts
@@ -1,11 +1,16 @@
-export function getSignUpUrl({
+export function getSignInUrl({
   signupCallbackUrl,
   invitationEmail,
+  userExists,
 }: {
   signupCallbackUrl: string;
   invitationEmail?: string;
+  userExists: boolean;
 }) {
-  let signUpUrl = `/api/workos/login?returnTo=${signupCallbackUrl}&screenHint=sign-up`;
+  let signUpUrl = `/api/workos/login?returnTo=${signupCallbackUrl}`;
+  if (!userExists) {
+    signUpUrl += "&screenHint=sign-up";
+  }
   if (invitationEmail) {
     signUpUrl += `&loginHint=${encodeURIComponent(invitationEmail)}`;
   }

--- a/front/pages/api/login.ts
+++ b/front/pages/api/login.ts
@@ -11,7 +11,7 @@ import type { SessionWithUser } from "@app/lib/iam/provider";
 import { getUserFromSession } from "@app/lib/iam/session";
 import { createOrUpdateUser, fetchUserFromSession } from "@app/lib/iam/users";
 import { MembershipInvitationResource } from "@app/lib/resources/membership_invitation_resource";
-import { getSignUpUrl } from "@app/lib/signup";
+import { getSignInUrl } from "@app/lib/signup";
 import { ServerSideTracking } from "@app/lib/tracking/server";
 import logger from "@app/logger/logger";
 import { apiError, withLogging } from "@app/logger/withlogging";
@@ -116,9 +116,10 @@ async function handler(
       const pendingInvitation =
         await MembershipInvitationResource.getPendingForEmail(user.email);
       if (pendingInvitation) {
-        const signUpUrl = getSignUpUrl({
+        const signUpUrl = await getSignInUrl({
           signupCallbackUrl: `/api/login?inviteToken=${getMembershipInvitationToken(pendingInvitation.id)}`,
           invitationEmail: pendingInvitation.inviteEmail,
+          userExists: true,
         });
         res.redirect(signUpUrl);
         return;

--- a/front/pages/w/[wId]/join.tsx
+++ b/front/pages/w/[wId]/join.tsx
@@ -9,11 +9,12 @@ import type { InferGetServerSidePropsType } from "next";
 
 import OnboardingLayout from "@app/components/sparkle/OnboardingLayout";
 import config from "@app/lib/api/config";
+import { fetchUsersFromWorkOSWithEmails } from "@app/lib/api/workos/user";
 import { getWorkspaceInfos } from "@app/lib/api/workspace";
 import { getWorkspaceVerifiedDomains } from "@app/lib/api/workspace_domains";
 import { makeGetServerSidePropsRequirementsWrapper } from "@app/lib/iam/session";
 import { MembershipInvitationResource } from "@app/lib/resources/membership_invitation_resource";
-import { getSignUpUrl } from "@app/lib/signup";
+import { getSignInUrl } from "@app/lib/signup";
 import type { LightWorkspaceType } from "@app/types";
 
 /**
@@ -44,9 +45,9 @@ export const getServerSideProps = makeGetServerSidePropsRequirementsWrapper({
   requireUserPrivilege: "none",
 })<{
   baseUrl: string;
-  invitationEmail: string | null;
   onboardingType: OnboardingType;
-  signUpCallbackUrl: string;
+  signInUrl: string;
+  userExists: boolean;
   workspace: LightWorkspaceType;
 }>(async (context) => {
   const wId = context.query.wId as string;
@@ -124,28 +125,32 @@ export const getServerSideProps = makeGetServerSidePropsRequirementsWrapper({
       };
   }
 
+  const users = await fetchUsersFromWorkOSWithEmails([invitationEmail ?? ""]);
+  const userExists = users.length > 0;
+
+  const signInUrl = getSignInUrl({
+    signupCallbackUrl: signUpCallbackUrl,
+    invitationEmail: invitationEmail ?? undefined,
+    userExists,
+  });
+
   return {
     props: {
       baseUrl: config.getClientFacingUrl(),
-      invitationEmail,
+      signInUrl,
+      userExists,
       onboardingType,
-      signUpCallbackUrl,
       workspace,
     },
   };
 });
 
 export default function Join({
-  invitationEmail,
   onboardingType,
-  signUpCallbackUrl,
+  signInUrl,
+  userExists,
   workspace,
 }: InferGetServerSidePropsType<typeof getServerSideProps>) {
-  const signUpUrl = getSignUpUrl({
-    signupCallbackUrl: signUpCallbackUrl,
-    invitationEmail: invitationEmail ?? undefined,
-  });
-
   return (
     <OnboardingLayout
       owner={workspace}
@@ -154,9 +159,9 @@ export default function Join({
         <Button
           variant="ghost"
           size="sm"
-          label="Sign up"
+          label={userExists ? "Sign in" : "Sign up"}
           icon={LoginIcon}
-          onClick={() => (window.location.href = signUpUrl)}
+          onClick={() => (window.location.href = signInUrl)}
         />
       }
     >
@@ -200,9 +205,9 @@ export default function Join({
           <Button
             variant="primary"
             size="sm"
-            label="Sign up"
+            label={userExists ? "Sign in" : "Sign up"}
             icon={LoginIcon}
-            onClick={() => (window.location.href = signUpUrl)}
+            onClick={() => (window.location.href = signInUrl)}
           />
         </div>
         <div className="flex flex-col gap-3 pb-20">


### PR DESCRIPTION
## Description

When a user recieve an invitation, they're always redirect to sign up page even if the account already exist. Check in workos and redirect to sign in page to avoid confusions

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

deploy front
