### PR TITLE
[front] - fix(AB v2): prevent default behavior on enter in `TagsSelector`

### DIFF
--- a/front/components/agent_builder/settings/TagsSelector.tsx
+++ b/front/components/agent_builder/settings/TagsSelector.tsx
@@ -119,6 +119,9 @@ export const TagsSelector = ({
 
   const onKeyDown = async (e: KeyboardEvent<HTMLInputElement>) => {
     if (e.key === "Enter") {
+      e.preventDefault();
+      e.stopPropagation();
+
       if (showCreateOption) {
         await handleCreateTag(searchText.trim());
       } else {


### PR DESCRIPTION
## Description

This PR prevents a race condition when pressing "Enter" to create new tags in the agent builder.

## Tests

Locally

## Risk

Low

## Deploy Plan

Deploy front
