### PR TITLE
Handle: actionRequired

### DIFF
--- a/front/lib/api/assistant/agent.ts
+++ b/front/lib/api/assistant/agent.ts
@@ -11,6 +11,7 @@ import {
   LONG_RUNNING_TOOL_THRESHOLD_MS,
   SYNC_TO_ASYNC_TIMEOUT_MS,
 } from "@app/lib/constants/timeouts";
+import { ConversationResource } from "@app/lib/resources/conversation_resource";
 import { wakeLock } from "@app/lib/wake_lock";
 import {
   logAgentLoopPhaseCompletionActivity,
@@ -238,6 +239,9 @@ export async function runAgentLoop(
     executionMode: runAgentArgs.sync ? "sync" : "async",
     startStep,
   });
+
+  // Clear action required in conversation - the loop will put them back if needed.
+  await ConversationResource.clearActionRequired(auth, conversationId);
 
   // Thread initial start time through execution
   const runAgentArgsWithTiming = {

--- a/front/lib/resources/agent_mcp_action_resource.ts
+++ b/front/lib/resources/agent_mcp_action_resource.ts
@@ -195,6 +195,11 @@ export class AgentMCPActionResource extends BaseResource<AgentMCPActionModel> {
       return [];
     }
 
+    const latestAgentMessages =
+      await ConversationResource.getLatestAgentMessageIdByRank(auth, {
+        conversation,
+      });
+
     const blockedActions = await AgentMCPActionModel.findAll({
       include: [
         {
@@ -261,6 +266,14 @@ export class AgentMCPActionResource extends BaseResource<AgentMCPActionModel> {
     for (const action of blockedActions) {
       const agentMessage = action.agentMessage;
       assert(agentMessage?.message, "No message for agent message.");
+
+      // Ignore actions that are not the latest version of the agent message.
+      if (
+        !latestAgentMessages.some((m) => m.agentMessageId === agentMessage.id)
+      ) {
+        continue;
+      }
+
       const agentConfiguration = agentConfigurations.find(
         (a) => a.sId === agentMessage.agentConfigurationId
       );

--- a/front/lib/resources/agent_mcp_action_resource.ts
+++ b/front/lib/resources/agent_mcp_action_resource.ts
@@ -196,9 +196,7 @@ export class AgentMCPActionResource extends BaseResource<AgentMCPActionModel> {
     }
 
     const latestAgentMessages =
-      await ConversationResource.getLatestAgentMessageIdByRank(auth, {
-        conversation,
-      });
+      await conversation.getLatestAgentMessageIdByRank(auth);
 
     const blockedActions = await AgentMCPActionModel.findAll({
       include: [

--- a/front/lib/resources/conversation_resource.ts
+++ b/front/lib/resources/conversation_resource.ts
@@ -3,7 +3,7 @@ import type {
   InferAttributes,
   Transaction,
 } from "sequelize";
-import { col, fn, literal, Op, Sequelize, where } from "sequelize";
+import { col, fn, literal, Op, QueryTypes, Sequelize, where } from "sequelize";
 
 import { Authenticator } from "@app/lib/auth";
 import { ConversationMCPServerViewModel } from "@app/lib/models/assistant/actions/conversation_mcp_server_view";
@@ -17,6 +17,7 @@ import {
 } from "@app/lib/models/assistant/conversation";
 import { BaseResource } from "@app/lib/resources/base_resource";
 import type { MCPServerViewResource } from "@app/lib/resources/mcp_server_view_resource";
+import { frontSequelize } from "@app/lib/resources/storage";
 import type { ReadonlyAttributesType } from "@app/lib/resources/storage/types";
 import { getResourceIdFromSId } from "@app/lib/resources/string_ids";
 import { TriggerResource } from "@app/lib/resources/trigger_resource";
@@ -484,13 +485,64 @@ export class ConversationResource extends BaseResource<ConversationModel> {
     }));
   }
 
+  static async markAsActionRequired(conversationId: string) {
+    const conversation = await ConversationModel.findOne({
+      where: {
+        sId: conversationId,
+      },
+    });
+    if (conversation === null) {
+      return new Err(new ConversationError("conversation_not_found"));
+    }
+
+    // Update the conversation participant to set actionRequired to true
+    const updated = await ConversationParticipantModel.update(
+      { actionRequired: true },
+      {
+        // We do not have a workspaceId here because we do not have an Authenticator in the caller.
+        // It's fine because we are only updating the actionRequired flag.
+        where: {
+          conversationId: conversation.id,
+        },
+      }
+    );
+
+    return new Ok(updated);
+  }
+
+  static async clearActionRequired(
+    auth: Authenticator,
+    conversationId: string
+  ) {
+    const conversation = await ConversationModel.findOne({
+      where: {
+        sId: conversationId,
+      },
+    });
+    if (conversation === null) {
+      return new Err(new ConversationError("conversation_not_found"));
+    }
+
+    const updated = await ConversationParticipantModel.update(
+      { actionRequired: false },
+      {
+        where: {
+          conversationId: conversation.id,
+          workspaceId: auth.getNonNullableWorkspace().id,
+        },
+      }
+    );
+
+    return new Ok(updated);
+  }
+
   static async upsertParticipation(
     auth: Authenticator,
     {
       conversation,
       action,
     }: {
-      conversation: ConversationType;
+      conversation: ConversationWithoutContentType;
       action: ParticipantActionType;
     }
   ) {
@@ -532,6 +584,60 @@ export class ConversationResource extends BaseResource<ConversationModel> {
         );
       }
     });
+  }
+
+  /**
+   * Get the latest agent message id by rank for a given conversation.
+   * @param conversationId - The conversation id.
+   * @returns The latest agent message id, version and rank.
+   */
+  static async getLatestAgentMessageIdByRank(
+    auth: Authenticator,
+    { conversation }: { conversation: ConversationResource }
+  ): Promise<
+    {
+      rank: number;
+      agentMessageId: number;
+      version: number;
+    }[]
+  > {
+    const query = `
+        SELECT 
+        rank,
+        "agentMessageId",
+        version
+      FROM (
+        SELECT 
+          rank,
+          "agentMessageId",
+          version,
+          ROW_NUMBER() OVER (
+            PARTITION BY rank 
+            ORDER BY version DESC
+          ) as rn
+        FROM messages
+        WHERE 
+          "workspaceId" = :workspaceId
+          AND "conversationId" = :conversationId
+          AND "agentMessageId" IS NOT NULL
+      ) ranked_messages
+      WHERE rn = 1
+  `;
+
+    // eslint-disable-next-line dust/no-raw-sql
+    const results = await frontSequelize.query<{
+      rank: number;
+      agentMessageId: number;
+      version: number;
+    }>(query, {
+      type: QueryTypes.SELECT,
+      replacements: {
+        workspaceId: auth.getNonNullableWorkspace().id,
+        conversationId: conversation.id,
+      },
+    });
+
+    return results;
   }
 
   static async updateRequestedGroupIds(

--- a/front/temporal/agent_loop/activities/publish_deferred_events.ts
+++ b/front/temporal/agent_loop/activities/publish_deferred_events.ts
@@ -1,7 +1,6 @@
 import { publishConversationRelatedEvent } from "@app/lib/api/assistant/streaming/events";
 import type { AgentMessageEvents } from "@app/lib/api/assistant/streaming/types";
 import { AgentMessage } from "@app/lib/models/assistant/conversation";
-import { ConversationResource } from "@app/lib/resources/conversation_resource";
 import type { DeferredEvent } from "@app/temporal/agent_loop/lib/deferred_events";
 import { assertNever } from "@app/types";
 
@@ -85,7 +84,6 @@ export async function publishDeferredEventsActivity(
 
     // Check if this event should pause the workflow.
     if (deferredEvent.shouldPauseAgentLoop) {
-      await ConversationResource.markAsActionRequired(context.conversationId);
       shouldPauseWorkflow = true;
     }
   }

--- a/front/temporal/agent_loop/activities/publish_deferred_events.ts
+++ b/front/temporal/agent_loop/activities/publish_deferred_events.ts
@@ -1,6 +1,7 @@
 import { publishConversationRelatedEvent } from "@app/lib/api/assistant/streaming/events";
 import type { AgentMessageEvents } from "@app/lib/api/assistant/streaming/types";
 import { AgentMessage } from "@app/lib/models/assistant/conversation";
+import { ConversationResource } from "@app/lib/resources/conversation_resource";
 import type { DeferredEvent } from "@app/temporal/agent_loop/lib/deferred_events";
 import { assertNever } from "@app/types";
 
@@ -84,6 +85,7 @@ export async function publishDeferredEventsActivity(
 
     // Check if this event should pause the workflow.
     if (deferredEvent.shouldPauseAgentLoop) {
+      await ConversationResource.markAsActionRequired(context.conversationId);
       shouldPauseWorkflow = true;
     }
   }

--- a/front/temporal/agent_loop/activities/run_tool.ts
+++ b/front/temporal/agent_loop/activities/run_tool.ts
@@ -4,6 +4,7 @@ import { runToolWithStreaming } from "@app/lib/api/mcp/run_tool";
 import type { AuthenticatorType } from "@app/lib/auth";
 import { Authenticator } from "@app/lib/auth";
 import { AgentMCPActionResource } from "@app/lib/resources/agent_mcp_action_resource";
+import { ConversationResource } from "@app/lib/resources/conversation_resource";
 import { updateResourceAndPublishEvent } from "@app/temporal/agent_loop/activities/common";
 import { buildActionBaseParams } from "@app/temporal/agent_loop/lib/action_utils";
 import type { ToolExecutionResult } from "@app/temporal/agent_loop/lib/deferred_events";
@@ -118,6 +119,10 @@ export async function runToolActivity(
             step,
           },
           shouldPauseAgentLoop: true,
+        });
+
+        await ConversationResource.markAsActionRequired(auth, {
+          conversation,
         });
 
         return { deferredEvents };


### PR DESCRIPTION
## Description

Handle setting and clearing the action required flag.
Set when evaluating deferred actions.
Clear before agent loop start.

Also fixed a bug where blocked actions on previous versions of agent messages would be accounted for.

## Tests

Local

## Risk

Medium as it touches the agent loop.

## Deploy Plan

Deploy front