### PR TITLE
[Slack workflows] Fix file attachment handling for workflow-invoked agents

### DIFF
--- a/connectors/src/api/webhooks/slack/utils.ts
+++ b/connectors/src/api/webhooks/slack/utils.ts
@@ -67,6 +67,15 @@ export interface SlackWebhookEvent<T = string> {
   message?: {
     bot_id?: string;
   };
+  files?: Array<{
+    id?: string;
+    name?: string;
+    title?: string;
+    mimetype?: string;
+    size?: number;
+    url_private?: string;
+    url_private_download?: string;
+  }>;
 }
 
 export type SlackWebhookReqBody = {
@@ -121,6 +130,7 @@ export async function handleChatBot(
   const slackBotId = event.bot_id || null;
   const slackMessageTs = event.ts;
   const slackThreadTs = event.thread_ts || null;
+  const slackFiles = event.files || [];
 
   logger.info(
     {
@@ -170,7 +180,7 @@ export async function handleChatBot(
     slackMessageTs,
     slackThreadTs,
   };
-  const botRes = await botAnswerMessage(slackMessage, params);
+  const botRes = await botAnswerMessage(slackMessage, params, slackFiles);
   if (botRes.isErr()) {
     logger.error(
       {


### PR DESCRIPTION
## Description
Fixes https://github.com/dust-tt/tasks/issues/3878

When a Slack workflow invokes an agent with file attachments, the files were not being passed through to the agent. The webhook handler was only extracting the text message and ignoring the files array from the Slack event.

Changes:
- Added files array to SlackWebhookEvent interface to capture files from Slack events
- Modified handleChatBot to extract and pass files from the event
- Updated botAnswerMessage and answerMessage to accept files parameter
- Modified makeContentFragments to combine event files with thread files
- Files from workflows are now processed alongside thread history files

## Risks
Blast radius: Slack bot file handling in workflows and direct messages
Risk: low

## Tests
- Test that agents can access files when invoked directly by users (existing behavior)
- Test that agents can access files when invoked through Slack workflows (fixed behavior)
- Verify no regression in regular message handling without files

## Deploy Plan
- Deploy connectors service