### PR TITLE
[front] - fix(AB v2): ensure user is set as default editor

### DIFF
--- a/front/components/agent_builder/AgentBuilder.tsx
+++ b/front/components/agent_builder/AgentBuilder.tsx
@@ -172,7 +172,9 @@ export default function AgentBuilder({
         slackProvider,
         editors: duplicateAgentId
           ? baseValues.agentSettings.editors
-          : editors ?? emptyArray(),
+          : editors.length > 0
+            ? editors
+            : [user],
         slackChannels: agentSlackChannels,
       },
     };


### PR DESCRIPTION
## Description

This PR default the editors list to include the current user when no editors are provided during agent creation

## Tests

Locally

## Risk

Low

## Deploy Plan

Deploy front
