### PR TITLE
[agent_builder] - refactor: streamline setting of editors in agent co…

### DIFF
--- a/front/components/agent_builder/AgentBuilder.tsx
+++ b/front/components/agent_builder/AgentBuilder.tsx
@@ -170,11 +170,9 @@ export default function AgentBuilder({
       agentSettings: {
         ...baseValues.agentSettings,
         slackProvider,
-        editors: duplicateAgentId
-          ? baseValues.agentSettings.editors
-          : editors.length > 0
-            ? editors
-            : [user],
+        editors: agentConfiguration
+          ? editors
+          : baseValues.agentSettings.editors,
         slackChannels: agentSlackChannels,
       },
     };

--- a/front/components/agent_builder/AgentBuilder.tsx
+++ b/front/components/agent_builder/AgentBuilder.tsx
@@ -170,9 +170,7 @@ export default function AgentBuilder({
       agentSettings: {
         ...baseValues.agentSettings,
         slackProvider,
-        editors: agentConfiguration
-          ? editors
-          : baseValues.agentSettings.editors,
+        editors: agentConfiguration && editors.length > 0 ? editors : [user],
         slackChannels: agentSlackChannels,
       },
     };

--- a/front/components/agent_builder/submitAgentBuilderForm.ts
+++ b/front/components/agent_builder/submitAgentBuilderForm.ts
@@ -216,11 +216,9 @@ export async function submitAgentBuilderForm({
     const { slackChannels, slackProvider } = formData.agentSettings;
     // If the user selected channels that were already routed to a different agent, the current behavior is to
     // unlink them from the previous agent and link them to this one.
-    if (slackProvider) {
+    if (slackProvider && slackChannels.length > 0) {
       const autoRespondWithoutMention =
-        slackChannels.length > 0
-          ? slackChannels[0].autoRespondWithoutMention
-          : undefined;
+        slackChannels[0].autoRespondWithoutMention;
       const slackLinkRes = await fetch(
         `/api/w/${owner.sId}/assistant/agent_configurations/${agentConfiguration.sId}/linked_slack_channels`,
         {

--- a/front/components/me/ProfileTriggersTab.tsx
+++ b/front/components/me/ProfileTriggersTab.tsx
@@ -13,11 +13,7 @@ import type { ColumnDef } from "@tanstack/react-table";
 import cronstrue from "cronstrue";
 import { useCallback, useMemo, useState } from "react";
 
-import {
-  useRemoveTriggerSubscriber,
-  useUserTriggers,
-} from "@app/lib/swr/agent_triggers";
-import { useFeatureFlags } from "@app/lib/swr/workspaces";
+import { useRemoveTriggerSubscriber, useUserTriggers } from "@app/lib/swr/agent_triggers";
 import { classNames } from "@app/lib/utils";
 import { getAgentBuilderRoute } from "@app/lib/utils/router";
 import type { WorkspaceType } from "@app/types";
@@ -27,9 +23,6 @@ interface ProfileTriggersTabProps {
 }
 
 export function ProfileTriggersTab({ owner }: ProfileTriggersTabProps) {
-  const { featureFlags } = useFeatureFlags({
-    workspaceId: owner.sId,
-  });
 
   const { triggers, isTriggersLoading } = useUserTriggers({
     workspaceId: owner.sId,
@@ -46,7 +39,7 @@ export function ProfileTriggersTab({ owner }: ProfileTriggersTabProps) {
     (agentConfigurationId: string) => {
       return getAgentBuilderRoute(owner.sId, agentConfigurationId);
     },
-    [owner.sId, featureFlags]
+    [owner.sId]
   );
 
   const filteredTriggers = useMemo(() => {

--- a/front/components/me/ProfileTriggersTab.tsx
+++ b/front/components/me/ProfileTriggersTab.tsx
@@ -13,7 +13,10 @@ import type { ColumnDef } from "@tanstack/react-table";
 import cronstrue from "cronstrue";
 import { useCallback, useMemo, useState } from "react";
 
-import { useRemoveTriggerSubscriber, useUserTriggers } from "@app/lib/swr/agent_triggers";
+import {
+  useRemoveTriggerSubscriber,
+  useUserTriggers,
+} from "@app/lib/swr/agent_triggers";
 import { classNames } from "@app/lib/utils";
 import { getAgentBuilderRoute } from "@app/lib/utils/router";
 import type { WorkspaceType } from "@app/types";
@@ -23,7 +26,6 @@ interface ProfileTriggersTabProps {
 }
 
 export function ProfileTriggersTab({ owner }: ProfileTriggersTabProps) {
-
   const { triggers, isTriggersLoading } = useUserTriggers({
     workspaceId: owner.sId,
   });


### PR DESCRIPTION
## Description

This PR aims at cleaning up the way we set editors to agent configuration and cleans up a useless hook dependency.

## Tests

Locally

## Risk

Breaking the Agent Builder creation if the condition is wrong

## Deploy Plan

Deploy front
