### PR TITLE
[front] Use correct id to delete group

### DIFF
--- a/front/temporal/workos_events_queue/activities.ts
+++ b/front/temporal/workos_events_queue/activities.ts
@@ -636,10 +636,7 @@ async function handleGroupDelete(
   event: DirectoryGroup
 ) {
   const auth = await Authenticator.internalAdminForWorkspace(workspace.sId);
-  const group = await GroupResource.fetchByWorkOSGroupId(
-    auth,
-    event.directoryId
-  );
+  const group = await GroupResource.fetchByWorkOSGroupId(auth, event.id);
 
   if (!group) {
     // Group already deleted, log and return success to avoid blocking the workflow


### PR DESCRIPTION
## Description

We were looking the group from the direvctory id, not the group id (leading to  "Group to delete not found, likely already deleted" )

related to https://github.com/dust-tt/tasks/issues/3848

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

deploy front
