### PR TITLE
[Slack] Fix bulk channel joining with Temporal workflows

### DIFF
--- a/connectors/src/connectors/slack/auto_read_channel.ts
+++ b/connectors/src/connectors/slack/auto_read_channel.ts
@@ -9,11 +9,11 @@ import {
   getSlackClient,
   reportSlackUsage,
 } from "@connectors/connectors/slack/lib/slack_client";
-import { launchSlackJoinChannelsWorkflowAndWait } from "@connectors/connectors/slack/temporal/client";
 import {
   getSlackChannelSourceUrl,
   slackChannelInternalIdFromSlackChannelId,
 } from "@connectors/connectors/slack/lib/utils";
+import { launchSlackJoinChannelsWorkflowAndWait } from "@connectors/connectors/slack/temporal/client";
 import { apiConfig } from "@connectors/lib/api/config";
 import { dataSourceConfigFromConnector } from "@connectors/lib/api/data_source_config";
 import { concurrentExecutor } from "@connectors/lib/async_utils";
@@ -301,11 +301,11 @@ export async function autoReadChannelsBulk(
       method: "conversations.info",
       channelId: slackChannelId,
     });
-    
+
     const remoteChannel = await slackClient.conversations.info({
       channel: slackChannelId,
     });
-    
+
     const remoteChannelName = remoteChannel.channel?.name;
     if (!remoteChannel.ok || !remoteChannelName) {
       logger.error({
@@ -325,7 +325,7 @@ export async function autoReadChannelsBulk(
       if (!remoteChannel.channel?.is_member) {
         channelsToJoin.push(slackChannelId);
       }
-      
+
       channelsToProcess.push({
         channelId: slackChannelId,
         channelName: remoteChannelName,
@@ -358,7 +358,7 @@ export async function autoReadChannelsBulk(
         connectorId,
       },
     });
-    
+
     if (!channel) {
       channel = await SlackChannel.create({
         connectorId,
@@ -440,7 +440,9 @@ export async function autoReadChannelsBulk(
                 dataSourceView,
                 {
                   parentsToAdd: [
-                    slackChannelInternalIdFromSlackChannelId(channel.slackChannelId),
+                    slackChannelInternalIdFromSlackChannelId(
+                      channel.slackChannelId
+                    ),
                   ],
                   parentsToRemove: undefined,
                 }

--- a/connectors/src/connectors/slack/index.ts
+++ b/connectors/src/connectors/slack/index.ts
@@ -12,7 +12,6 @@ import {
   ConnectorManagerError,
 } from "@connectors/connectors/interface";
 import {
-  autoReadChannel,
   autoReadChannelsBulk,
   findMatchingChannelPatterns,
 } from "@connectors/connectors/slack/auto_read_channel";

--- a/connectors/src/connectors/slack/temporal/client.ts
+++ b/connectors/src/connectors/slack/temporal/client.ts
@@ -336,7 +336,7 @@ export async function launchSlackMigrateChannelsFromLegacyBotToNewBotWorkflow(
 /**
  * Launch workflow(s) to join Slack channels.
  * Returns workflow handles that the caller can await.
- * 
+ *
  * @param connectorId - The connector ID
  * @param channelIds - Array of channel IDs to join
  * @param allowUnlimitedChannels - If true, allows processing more than 250 channels
@@ -349,17 +349,20 @@ export async function launchSlackJoinChannelsWorkflow(
   allowUnlimitedChannels: boolean = false
 ) {
   const MAX_CHANNELS_PER_WORKFLOW = 250;
-  
+
   if (channelIds.length === 0) {
     return new Ok([]);
   }
 
   // Check if we exceed the limit without permission
-  if (!allowUnlimitedChannels && channelIds.length > MAX_CHANNELS_PER_WORKFLOW) {
+  if (
+    !allowUnlimitedChannels &&
+    channelIds.length > MAX_CHANNELS_PER_WORKFLOW
+  ) {
     return new Err(
       new Error(
         `Cannot join more than ${MAX_CHANNELS_PER_WORKFLOW} channels without allowUnlimitedChannels flag. ` +
-        `Received ${channelIds.length} channels.`
+          `Received ${channelIds.length} channels.`
       )
     );
   }
@@ -378,7 +381,7 @@ export async function launchSlackJoinChannelsWorkflow(
       totalChannels: channelIds.length,
       batchCount: batches.length,
     },
-    batches.length > 1 
+    batches.length > 1
       ? "Starting multiple channel join workflows for bulk operation."
       : "Starting channel join workflow."
   );
@@ -399,7 +402,7 @@ export async function launchSlackJoinChannelsWorkflow(
             connectorId: connectorId,
           },
         });
-        
+
         logger.info(
           {
             workflowId,
@@ -407,7 +410,7 @@ export async function launchSlackJoinChannelsWorkflow(
           },
           "Started joinChannels workflow."
         );
-        
+
         return handle;
       })
     );

--- a/connectors/src/connectors/slack/temporal/client.ts
+++ b/connectors/src/connectors/slack/temporal/client.ts
@@ -389,8 +389,8 @@ export async function launchSlackJoinChannelsWorkflow(
   try {
     // Launch all workflows and return handles
     const handles = await Promise.all(
-      batches.map(async (batch, index) => {
-        const workflowId = joinChannelsWorkflowId(connectorId, index);
+      batches.map(async (batch) => {
+        const workflowId = joinChannelsWorkflowId(connectorId, batch);
         const handle = await client.workflow.start(joinChannelsWorkflow, {
           args: [connectorId, batch],
           taskQueue: QUEUE_NAME,

--- a/connectors/src/connectors/slack/temporal/client.ts
+++ b/connectors/src/connectors/slack/temporal/client.ts
@@ -14,6 +14,8 @@ import { getWeekStart } from "../lib/utils";
 import { QUEUE_NAME } from "./config";
 import { newWebhookSignal, syncChannelSignal } from "./signals";
 import {
+  joinChannelsWorkflow,
+  joinChannelsWorkflowId,
   migrateChannelsFromLegacyBotToNewBotWorkflow,
   migrateChannelsFromLegacyBotToNewBotWorkflowId,
   slackGarbageCollectorWorkflow,
@@ -326,6 +328,144 @@ export async function launchSlackMigrateChannelsFromLegacyBotToNewBotWorkflow(
         error: e,
       },
       "Failed starting migrateChannelsFromLegacyBotToNewBot workflow."
+    );
+    return new Err(normalizeError(e));
+  }
+}
+
+/**
+ * Launch workflow(s) to join Slack channels.
+ * Returns workflow handles that the caller can await.
+ * 
+ * @param connectorId - The connector ID
+ * @param channelIds - Array of channel IDs to join
+ * @param allowUnlimitedChannels - If true, allows processing more than 250 channels
+ *                                  by splitting them into multiple workflows.
+ *                                  If false (default), returns an error if more than 250 channels are provided.
+ */
+export async function launchSlackJoinChannelsWorkflow(
+  connectorId: ModelId,
+  channelIds: string[],
+  allowUnlimitedChannels: boolean = false
+) {
+  const MAX_CHANNELS_PER_WORKFLOW = 250;
+  
+  if (channelIds.length === 0) {
+    return new Ok([]);
+  }
+
+  // Check if we exceed the limit without permission
+  if (!allowUnlimitedChannels && channelIds.length > MAX_CHANNELS_PER_WORKFLOW) {
+    return new Err(
+      new Error(
+        `Cannot join more than ${MAX_CHANNELS_PER_WORKFLOW} channels without allowUnlimitedChannels flag. ` +
+        `Received ${channelIds.length} channels.`
+      )
+    );
+  }
+
+  const client = await getTemporalClient();
+
+  // Split into batches if needed
+  const batches: string[][] = [];
+  for (let i = 0; i < channelIds.length; i += MAX_CHANNELS_PER_WORKFLOW) {
+    batches.push(channelIds.slice(i, i + MAX_CHANNELS_PER_WORKFLOW));
+  }
+
+  logger.info(
+    {
+      connectorId,
+      totalChannels: channelIds.length,
+      batchCount: batches.length,
+    },
+    batches.length > 1 
+      ? "Starting multiple channel join workflows for bulk operation."
+      : "Starting channel join workflow."
+  );
+
+  try {
+    // Launch all workflows and return handles
+    const handles = await Promise.all(
+      batches.map(async (batch, index) => {
+        const workflowId = joinChannelsWorkflowId(connectorId, index);
+        const handle = await client.workflow.start(joinChannelsWorkflow, {
+          args: [connectorId, batch],
+          taskQueue: QUEUE_NAME,
+          workflowId: workflowId,
+          searchAttributes: {
+            connectorId: [connectorId],
+          },
+          memo: {
+            connectorId: connectorId,
+          },
+        });
+        
+        logger.info(
+          {
+            workflowId,
+            channelCount: batch.length,
+          },
+          "Started joinChannels workflow."
+        );
+        
+        return handle;
+      })
+    );
+
+    return new Ok(handles);
+  } catch (e) {
+    logger.error(
+      {
+        connectorId,
+        error: e,
+      },
+      "Failed starting channel join workflows."
+    );
+    return new Err(normalizeError(e));
+  }
+}
+
+/**
+ * Launch workflow(s) to join Slack channels and wait for completion.
+ * This is a convenience wrapper that launches and waits for the workflows.
+ */
+export async function launchSlackJoinChannelsWorkflowAndWait(
+  connectorId: ModelId,
+  channelIds: string[],
+  allowUnlimitedChannels: boolean = false
+) {
+  const launchResult = await launchSlackJoinChannelsWorkflow(
+    connectorId,
+    channelIds,
+    allowUnlimitedChannels
+  );
+
+  if (launchResult.isErr()) {
+    return launchResult;
+  }
+
+  const handles = launchResult.value;
+
+  try {
+    // Wait for all workflows to complete
+    await Promise.all(handles.map((handle) => handle.result()));
+
+    logger.info(
+      {
+        connectorId,
+        workflowCount: handles.length,
+      },
+      "All channel join workflows completed successfully."
+    );
+
+    return new Ok(undefined);
+  } catch (e) {
+    logger.error(
+      {
+        connectorId,
+        error: e,
+      },
+      "Failed executing channel join workflows."
     );
     return new Err(normalizeError(e));
   }

--- a/connectors/src/connectors/slack/temporal/workflows.ts
+++ b/connectors/src/connectors/slack/temporal/workflows.ts
@@ -362,7 +362,7 @@ const { attemptChannelJoinActivity: attemptChannelJoinWithRetries } =
     startToCloseTimeout: "10 minutes",
     retry: {
       maximumAttempts: 25,
-      initialInterval: "2s",
+      initialInterval: "5s",
       maximumInterval: "15s",
       backoffCoefficient: 1.5,
     },

--- a/connectors/src/connectors/slack/temporal/workflows.ts
+++ b/connectors/src/connectors/slack/temporal/workflows.ts
@@ -6,7 +6,6 @@ import {
   sleep,
   workflowInfo,
 } from "@temporalio/workflow";
-import crypto from "crypto";
 
 import type * as activities from "@connectors/connectors/slack/temporal/activities";
 import type { ModelId } from "@connectors/types";
@@ -395,17 +394,4 @@ export async function joinChannelsWorkflow(
     },
     { concurrency: CONCURRENCY }
   );
-}
-
-export function joinChannelsWorkflowId(
-  connectorId: ModelId,
-  channelIds: string[]
-) {
-  // Create a hash of the channel IDs to ensure unique workflow ID for each set
-  const channelsHash = crypto
-    .createHash("sha256")
-    .update(channelIds.sort().join(","))
-    .digest("hex")
-    .substring(0, 8); // Use first 8 chars of hash for readability
-  return `slack-joinChannels-${connectorId}-${channelsHash}`;
 }

--- a/connectors/src/connectors/slack/temporal/workflows.ts
+++ b/connectors/src/connectors/slack/temporal/workflows.ts
@@ -6,6 +6,7 @@ import {
   sleep,
   workflowInfo,
 } from "@temporalio/workflow";
+import crypto from "crypto";
 
 import type * as activities from "@connectors/connectors/slack/temporal/activities";
 import type { ModelId } from "@connectors/types";
@@ -398,7 +399,13 @@ export async function joinChannelsWorkflow(
 
 export function joinChannelsWorkflowId(
   connectorId: ModelId,
-  batchIndex: number = 0
+  channelIds: string[]
 ) {
-  return `slack-joinChannels-${connectorId}-batch-${batchIndex}`;
+  // Create a hash of the channel IDs to ensure unique workflow ID for each set
+  const channelsHash = crypto
+    .createHash("sha256")
+    .update(channelIds.sort().join(","))
+    .digest("hex")
+    .substring(0, 8); // Use first 8 chars of hash for readability
+  return `slack-joinChannels-${connectorId}-${channelsHash}`;
 }

--- a/connectors/src/connectors/slack/temporal/workflows.ts
+++ b/connectors/src/connectors/slack/temporal/workflows.ts
@@ -8,8 +8,8 @@ import {
 } from "@temporalio/workflow";
 
 import type * as activities from "@connectors/connectors/slack/temporal/activities";
-import type { ModelId } from "@connectors/types";
-import { concurrentExecutor } from "@connectors/types";
+import type { ModelId } from "../../../types";
+import { concurrentExecutor } from "../../../types/shared/utils/async_utils";
 
 import { getWeekEnd, getWeekStart } from "../lib/utils";
 import { newWebhookSignal, syncChannelSignal } from "./signals";

--- a/connectors/src/connectors/slack/temporal/workflows.ts
+++ b/connectors/src/connectors/slack/temporal/workflows.ts
@@ -358,11 +358,11 @@ export function slackGarbageCollectorWorkflowId(connectorId: ModelId) {
 // Configure attemptChannelJoinActivity with aggressive retries for joinChannels workflow
 const { attemptChannelJoinActivity: attemptChannelJoinWithRetries } =
   proxyActivities<typeof activities>({
-    startToCloseTimeout: "5 minutes",
+    startToCloseTimeout: "10 minutes",
     retry: {
       maximumAttempts: 25,
-      initialInterval: "1s",
-      maximumInterval: "10s",
+      initialInterval: "2s",
+      maximumInterval: "15s",
       backoffCoefficient: 1.5,
     },
   });


### PR DESCRIPTION
## Description
Fixes [issue-3899](https://github.com/dust-tt/tasks/issues/3899)

Key changes:
- Created `joinChannelsWorkflow` to handle bulk channel joins with proper Temporal-based retries (25 attempts, max 10s backoff)
- Replaced individual `joinChannelWithRetries` calls with the new workflow for better reliability
- Added `autoReadChannelsBulk` function to process multiple channels at once instead of one-by-one
- Workflow enforces 250 channel limit per execution, with optional batching for larger operations

## Risks
Blast radius: Slack channel joining and auto-read pattern application
Risk: low

## Deploy Plan
- Deploy connectors service