### PR TITLE
[front] - fix(AB v2): correct conditional logic for assigning editors

### DIFF
--- a/front/components/agent_builder/AgentBuilder.tsx
+++ b/front/components/agent_builder/AgentBuilder.tsx
@@ -170,7 +170,7 @@ export default function AgentBuilder({
       agentSettings: {
         ...baseValues.agentSettings,
         slackProvider,
-        editors: agentConfiguration && editors.length > 0 ? editors : [user],
+        editors: agentConfiguration || editors.length > 0 ? editors : [user],
         slackChannels: agentSlackChannels,
       },
     };

--- a/front/lib/api/assistant/configuration/agent.ts
+++ b/front/lib/api/assistant/configuration/agent.ts
@@ -1,9 +1,17 @@
 import assert from "assert";
 import { tracer } from "dd-trace";
 import type { Transaction } from "sequelize";
-import { Op, Sequelize, UniqueConstraintError, ValidationError } from "sequelize";
+import {
+  Op,
+  Sequelize,
+  UniqueConstraintError,
+  ValidationError,
+} from "sequelize";
 
-import { DEFAULT_WEBSEARCH_ACTION_DESCRIPTION, DEFAULT_WEBSEARCH_ACTION_NAME } from "@app/lib/actions/constants";
+import {
+  DEFAULT_WEBSEARCH_ACTION_DESCRIPTION,
+  DEFAULT_WEBSEARCH_ACTION_NAME,
+} from "@app/lib/actions/constants";
 import type { ServerSideMCPServerConfigurationType } from "@app/lib/actions/mcp";
 import { createAgentActionConfiguration } from "@app/lib/api/assistant/configuration/actions";
 import {
@@ -17,7 +25,10 @@ import config from "@app/lib/api/config";
 import { Authenticator } from "@app/lib/auth";
 import { isRemoteDatabase } from "@app/lib/data_sources";
 import type { DustError } from "@app/lib/error";
-import { AgentConfiguration, AgentUserRelation } from "@app/lib/models/assistant/agent";
+import {
+  AgentConfiguration,
+  AgentUserRelation,
+} from "@app/lib/models/assistant/agent";
 import { TagAgentModel } from "@app/lib/models/assistant/tag_agent";
 import { DataSourceViewResource } from "@app/lib/resources/data_source_view_resource";
 import { GroupResource } from "@app/lib/resources/group_resource";
@@ -468,7 +479,7 @@ export async function createAgentConfiguration(
             agentConfigurationInstance,
             { transaction: t }
           );
-          await auth.refresh({ transaction: t})
+          await auth.refresh({ transaction: t });
           await group.setMembers(auth, editors, { transaction: t });
         } else {
           const group = await GroupResource.fetchByAgentConfiguration({

--- a/front/lib/api/assistant/configuration/agent.ts
+++ b/front/lib/api/assistant/configuration/agent.ts
@@ -1,17 +1,9 @@
 import assert from "assert";
 import { tracer } from "dd-trace";
 import type { Transaction } from "sequelize";
-import {
-  Op,
-  Sequelize,
-  UniqueConstraintError,
-  ValidationError,
-} from "sequelize";
+import { Op, Sequelize, UniqueConstraintError, ValidationError } from "sequelize";
 
-import {
-  DEFAULT_WEBSEARCH_ACTION_DESCRIPTION,
-  DEFAULT_WEBSEARCH_ACTION_NAME,
-} from "@app/lib/actions/constants";
+import { DEFAULT_WEBSEARCH_ACTION_DESCRIPTION, DEFAULT_WEBSEARCH_ACTION_NAME } from "@app/lib/actions/constants";
 import type { ServerSideMCPServerConfigurationType } from "@app/lib/actions/mcp";
 import { createAgentActionConfiguration } from "@app/lib/api/assistant/configuration/actions";
 import {
@@ -25,10 +17,7 @@ import config from "@app/lib/api/config";
 import { Authenticator } from "@app/lib/auth";
 import { isRemoteDatabase } from "@app/lib/data_sources";
 import type { DustError } from "@app/lib/error";
-import {
-  AgentConfiguration,
-  AgentUserRelation,
-} from "@app/lib/models/assistant/agent";
+import { AgentConfiguration, AgentUserRelation } from "@app/lib/models/assistant/agent";
 import { TagAgentModel } from "@app/lib/models/assistant/tag_agent";
 import { DataSourceViewResource } from "@app/lib/resources/data_source_view_resource";
 import { GroupResource } from "@app/lib/resources/group_resource";
@@ -479,6 +468,7 @@ export async function createAgentConfiguration(
             agentConfigurationInstance,
             { transaction: t }
           );
+          await auth.refresh({ transaction: t})
           await group.setMembers(auth, editors, { transaction: t });
         } else {
           const group = await GroupResource.fetchByAgentConfiguration({

--- a/front/lib/auth.ts
+++ b/front/lib/auth.ts
@@ -1,7 +1,11 @@
 import assert from "assert";
 import tracer from "dd-trace";
 import memoizer from "lru-memoizer";
-import type { GetServerSidePropsContext, NextApiRequest, NextApiResponse } from "next";
+import type {
+  GetServerSidePropsContext,
+  NextApiRequest,
+  NextApiResponse,
+} from "next";
 import type { Transaction } from "sequelize";
 
 import config from "@app/lib/api/config";
@@ -12,7 +16,10 @@ import { FeatureFlag } from "@app/lib/models/feature_flag";
 import { isUpgraded } from "@app/lib/plans/plan_codes";
 import { GroupResource } from "@app/lib/resources/group_resource";
 import type { KeyAuthType } from "@app/lib/resources/key_resource";
-import { KeyResource, SECRET_KEY_PREFIX } from "@app/lib/resources/key_resource";
+import {
+  KeyResource,
+  SECRET_KEY_PREFIX,
+} from "@app/lib/resources/key_resource";
 import { MembershipResource } from "@app/lib/resources/membership_resource";
 import { getResourceIdFromSId } from "@app/lib/resources/string_ids";
 import { SubscriptionResource } from "@app/lib/resources/subscription_resource";
@@ -207,10 +214,10 @@ export class Authenticator {
       this._groups = await GroupResource.listUserGroupsInWorkspace({
         user: this._user,
         workspace: renderLightWorkspaceType({ workspace: this._workspace }),
-        transaction
-      })
+        transaction,
+      });
     } else {
-      return
+      return;
     }
   }
 

--- a/front/lib/resources/group_resource.ts
+++ b/front/lib/resources/group_resource.ts
@@ -1,16 +1,6 @@
-import type {
-  DirectoryGroup,
-  DirectoryGroup as WorkOSGroup,
-} from "@workos-inc/node";
+import type { DirectoryGroup, DirectoryGroup as WorkOSGroup } from "@workos-inc/node";
 import assert from "assert";
-import type {
-  Attributes,
-  CreationAttributes,
-  Includeable,
-  ModelStatic,
-  Transaction,
-  WhereOptions,
-} from "sequelize";
+import type { Attributes, CreationAttributes, Includeable, ModelStatic, Transaction, WhereOptions } from "sequelize";
 import { Op } from "sequelize";
 
 import type { Authenticator } from "@app/lib/auth";
@@ -41,13 +31,7 @@ import type {
   RolePermission,
   UserType,
 } from "@app/types";
-import {
-  AGENT_GROUP_PREFIX,
-  Err,
-  normalizeError,
-  Ok,
-  removeNulls,
-} from "@app/types";
+import { AGENT_GROUP_PREFIX, Err, normalizeError, Ok, removeNulls } from "@app/types";
 
 export const ADMIN_GROUP_NAME = "dust-admins";
 export const BUILDER_GROUP_NAME = "dust-builders";

--- a/front/lib/resources/group_resource.ts
+++ b/front/lib/resources/group_resource.ts
@@ -1,6 +1,16 @@
-import type { DirectoryGroup, DirectoryGroup as WorkOSGroup } from "@workos-inc/node";
+import type {
+  DirectoryGroup,
+  DirectoryGroup as WorkOSGroup,
+} from "@workos-inc/node";
 import assert from "assert";
-import type { Attributes, CreationAttributes, Includeable, ModelStatic, Transaction, WhereOptions } from "sequelize";
+import type {
+  Attributes,
+  CreationAttributes,
+  Includeable,
+  ModelStatic,
+  Transaction,
+  WhereOptions,
+} from "sequelize";
 import { Op } from "sequelize";
 
 import type { Authenticator } from "@app/lib/auth";
@@ -31,7 +41,13 @@ import type {
   RolePermission,
   UserType,
 } from "@app/types";
-import { AGENT_GROUP_PREFIX, Err, normalizeError, Ok, removeNulls } from "@app/types";
+import {
+  AGENT_GROUP_PREFIX,
+  Err,
+  normalizeError,
+  Ok,
+  removeNulls,
+} from "@app/types";
 
 export const ADMIN_GROUP_NAME = "dust-admins";
 export const BUILDER_GROUP_NAME = "dust-builders";


### PR DESCRIPTION
## Description

Fixes a logical error in the agent builder's editor assignment where the conditional logic was using && instead of ||, preventing proper editor assignment when no existing agent configuration exists but editors are specified. Also adds a refresh mechanism to ensure authentication state is properly updated after creating agent configurations, preventing potential permission issues.

## Tests

Locally

## Risk

Medium, touches permissions

## Deploy Plan

Deploy front
