### PR TITLE
Delete the user's memories when we delete the workspace or the  user

### DIFF
--- a/front/poke/temporal/activities.ts
+++ b/front/poke/temporal/activities.ts
@@ -26,6 +26,7 @@ import { DustAppSecret } from "@app/lib/models/dust_app_secret";
 import { FeatureFlag } from "@app/lib/models/feature_flag";
 import { MembershipInvitationModel } from "@app/lib/models/membership_invitation";
 import { Subscription } from "@app/lib/models/plan";
+import { AgentMemoryResource } from "@app/lib/resources/agent_memory_resource";
 import { AppResource } from "@app/lib/resources/app_resource";
 import { DataSourceResource } from "@app/lib/resources/data_source_resource";
 import { DataSourceViewResource } from "@app/lib/resources/data_source_view_resource";
@@ -603,11 +604,7 @@ export async function deleteWorkspaceActivity({
       workspaceId: workspace.id,
     },
   });
-  await AgentMemoryModel.destroy({
-    where: {
-      workspaceId: workspace.id,
-    },
-  });
+  await AgentMemoryResource.deleteAllForWorkspace(auth);
 
   hardDeleteLogger.info({ workspaceId }, "Deleting Workspace");
 

--- a/front/poke/temporal/activities.ts
+++ b/front/poke/temporal/activities.ts
@@ -462,6 +462,13 @@ export async function deleteMembersActivity({
         await FileResource.deleteAllForUser(auth, user.toJSON());
         await membership.delete(auth, {});
 
+        // Delete the user's agent memories.
+        await AgentMemoryModel.destroy({
+          where: {
+            userId: user.id,
+          },
+        });
+
         await user.delete(auth, {});
       }
     } else {
@@ -592,6 +599,11 @@ export async function deleteWorkspaceActivity({
     },
   });
   await FeatureFlag.destroy({
+    where: {
+      workspaceId: workspace.id,
+    },
+  });
+  await AgentMemoryModel.destroy({
     where: {
       workspaceId: workspace.id,
     },


### PR DESCRIPTION
## Description

_Jamais 2 sans 3_ 🙈 

We have one `poke-xxx-delete-workspace` stuck with a `ForeignKeyConstraintError: update or delete on table "workspaces" violates foreign key constraint "agent_memories_workspaceId_fkey" on table "agent_memories"
`


I initially did a PR (two PRs) to make sure we delete the agent memories when we delete the agents. https://github.com/dust-tt/dust/pull/15606 https://github.com/dust-tt/dust/pull/15607

But this was not enough to unstuck the workflow as the agent configurations are already deleted on this workflow (it's not a relationship between agent <> memory, we store the `sId`. Meaning dangling memories are still dangling and workflow is still stuck. 

To fix this, I added another piece of code to remove the remaining memories when we delete the workspace or the user. 

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

Deploy front. 