### PR TITLE
[Durable Agents] Fix validation blocking conversation navigation

### DIFF
--- a/front/components/assistant/conversation/BlockedActionsProvider.tsx
+++ b/front/components/assistant/conversation/BlockedActionsProvider.tsx
@@ -256,6 +256,8 @@ function useBlockedActionsQueue({
           }));
         return [...prevQueue, ...newItems];
       });
+    } else {
+      setBlockedActionsQueue([]);
     }
   }, [blockedActions]);
 

--- a/front/components/assistant/conversation/BlockedActionsProvider.tsx
+++ b/front/components/assistant/conversation/BlockedActionsProvider.tsx
@@ -45,6 +45,8 @@ type AuthenticationRequiredBlockedAction = Extract<
   { status: "blocked_authentication_required" }
 >;
 
+const EMPTY_BLOCKED_ACTIONS_QUEUE: BlockedActionQueueItem[] = [];
+
 interface AuthenticationDialogPageProps {
   authActions: AuthenticationRequiredBlockedAction[];
   connectionStates: Record<string, "connecting" | "connected" | "idle">;
@@ -257,7 +259,7 @@ function useBlockedActionsQueue({
         return [...prevQueue, ...newItems];
       });
     } else {
-      setBlockedActionsQueue([]);
+      setBlockedActionsQueue(EMPTY_BLOCKED_ACTIONS_QUEUE);
     }
   }, [blockedActions]);
 


### PR DESCRIPTION
Description
---
Fixes this [incident](https://dust4ai.slack.com/archives/C05B529FHV1/p1756885131710779)

Hooks were not resetting the blocked action queue state when blocked actions became empty.

Risks
---
na

Deploy
---
front