### PR TITLE
allow users to get the full agent config by api

### DIFF
--- a/front/pages/api/v1/w/[wId]/assistant/agent_configurations/[sId]/index.ts
+++ b/front/pages/api/v1/w/[wId]/assistant/agent_configurations/[sId]/index.ts
@@ -130,7 +130,7 @@ async function handler(
   }
 
   // Validate variant parameter if provided
-  const configVariant = 
+  const configVariant =
     typeof variant === "string" && (variant === "light" || variant === "full")
       ? variant
       : "light";

--- a/front/pages/api/v1/w/[wId]/assistant/agent_configurations/[sId]/index.ts
+++ b/front/pages/api/v1/w/[wId]/assistant/agent_configurations/[sId]/index.ts
@@ -30,6 +30,14 @@ import type { WithAPIErrorResponse } from "@app/types";
  *         description: ID of the agent configuration
  *         schema:
  *           type: string
+ *       - in: query
+ *         name: variant
+ *         required: false
+ *         description: Configuration variant to retrieve. 'light' returns basic config without actions, 'full' includes complete actions/tools configuration
+ *         schema:
+ *           type: string
+ *           enum: [light, full]
+ *           default: light
  *     security:
  *       - BearerAuth: []
  *     responses:
@@ -109,7 +117,7 @@ async function handler(
   >,
   auth: Authenticator
 ): Promise<void> {
-  const { sId } = req.query;
+  const { sId, variant } = req.query;
 
   if (typeof sId !== "string") {
     return apiError(req, res, {
@@ -121,9 +129,15 @@ async function handler(
     });
   }
 
+  // Validate variant parameter if provided
+  const configVariant = 
+    typeof variant === "string" && (variant === "light" || variant === "full")
+      ? variant
+      : "light";
+
   const agentConfiguration = await getAgentConfiguration(auth, {
     agentId: sId,
-    variant: "light",
+    variant: configVariant,
   });
 
   if (!agentConfiguration) {

--- a/front/public/swagger.json
+++ b/front/public/swagger.json
@@ -136,6 +136,20 @@
             "schema": {
               "type": "string"
             }
+          },
+          {
+            "in": "query",
+            "name": "variant",
+            "required": false,
+            "description": "Configuration variant to retrieve. 'light' returns basic config without actions, 'full' includes complete actions/tools configuration",
+            "schema": {
+              "type": "string",
+              "enum": [
+                "light",
+                "full"
+              ],
+              "default": "light"
+            }
           }
         ],
         "security": [
@@ -4050,6 +4064,75 @@
           },
           "405": {
             "description": "Method not supported"
+          }
+        }
+      }
+    },
+    "/api/v1/w/{wId}/spaces/{spaceId}/mcp_server_views": {
+      "get": {
+        "summary": "List available MCP server views.",
+        "description": "Retrieves a list of enabled MCP server views (aka tools) for a specific space of the authenticated workspace.",
+        "tags": [
+          "Tools"
+        ],
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "in": "path",
+            "name": "wId",
+            "required": true,
+            "description": "Unique string identifier for the workspace",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "path",
+            "name": "spaceId",
+            "required": true,
+            "description": "ID of the space",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "MCP server views of the space",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "spaces": {
+                      "type": "array",
+                      "items": {
+                        "$ref": "#/components/schemas/MCPServerView"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request. Missing or invalid parameters."
+          },
+          "401": {
+            "description": "Unauthorized. Invalid or missing authentication token."
+          },
+          "404": {
+            "description": "Workspace not found."
+          },
+          "405": {
+            "description": "Method not supported."
+          },
+          "500": {
+            "description": "Internal Server Error."
           }
         }
       }

--- a/front/public/swagger.json
+++ b/front/public/swagger.json
@@ -24,9 +24,7 @@
       "get": {
         "summary": "List agents",
         "description": "Get the agent configurations for the workspace identified by {wId}.",
-        "tags": [
-          "Agents"
-        ],
+        "tags": ["Agents"],
         "parameters": [
           {
             "in": "path",
@@ -61,10 +59,7 @@
             "description": "When set to 'true', includes recent authors information for each agent",
             "schema": {
               "type": "string",
-              "enum": [
-                "true",
-                "false"
-              ]
+              "enum": ["true", "false"]
             }
           }
         ],
@@ -115,9 +110,7 @@
       "get": {
         "summary": "Get agent configuration",
         "description": "Retrieve the agent configuration identified by {sId} in the workspace identified by {wId}.",
-        "tags": [
-          "Agents"
-        ],
+        "tags": ["Agents"],
         "parameters": [
           {
             "in": "path",
@@ -144,10 +137,7 @@
             "description": "Configuration variant to retrieve. 'light' returns basic config without actions, 'full' includes complete actions/tools configuration",
             "schema": {
               "type": "string",
-              "enum": [
-                "light",
-                "full"
-              ],
+              "enum": ["light", "full"],
               "default": "light"
             }
           }
@@ -193,9 +183,7 @@
       "patch": {
         "summary": "Update agent configuration",
         "description": "Update the agent configuration identified by {sId} in the workspace identified by {wId}.",
-        "tags": [
-          "Agents"
-        ],
+        "tags": ["Agents"],
         "parameters": [
           {
             "in": "path",
@@ -274,9 +262,7 @@
       "get": {
         "summary": "Search agents by name",
         "description": "Search for agent configurations by name in the workspace identified by {wId}.",
-        "tags": [
-          "Agents"
-        ],
+        "tags": ["Agents"],
         "parameters": [
           {
             "in": "path",
@@ -341,9 +327,7 @@
     },
     "/api/v1/w/{wId}/assistant/conversations/{cId}/cancel": {
       "post": {
-        "tags": [
-          "Conversations"
-        ],
+        "tags": ["Conversations"],
         "summary": "Cancel message generation in a conversation",
         "parameters": [
           {
@@ -376,9 +360,7 @@
             "application/json": {
               "schema": {
                 "type": "object",
-                "required": [
-                  "messageIds"
-                ],
+                "required": ["messageIds"],
                 "properties": {
                   "messageIds": {
                     "type": "array",
@@ -422,9 +404,7 @@
       "post": {
         "summary": "Create a content fragment",
         "description": "Create a new content fragment in the workspace identified by {wId}.",
-        "tags": [
-          "Conversations"
-        ],
+        "tags": ["Conversations"],
         "parameters": [
           {
             "in": "path",
@@ -487,9 +467,7 @@
       "get": {
         "summary": "Get the events for a conversation",
         "description": "Get the events for a conversation in the workspace identified by {wId}.",
-        "tags": [
-          "Conversations"
-        ],
+        "tags": ["Conversations"],
         "parameters": [
           {
             "in": "path",
@@ -550,9 +528,7 @@
       "get": {
         "summary": "Get feedbacks for a conversation",
         "description": "Retrieves all feedback entries for a specific conversation.\nRequires authentication and read:conversation scope.\n",
-        "tags": [
-          "Feedbacks"
-        ],
+        "tags": ["Feedbacks"],
         "parameters": [
           {
             "name": "wId",
@@ -605,10 +581,7 @@
                           },
                           "thumbDirection": {
                             "type": "string",
-                            "enum": [
-                              "up",
-                              "down"
-                            ],
+                            "enum": ["up", "down"],
                             "description": "Direction of the thumb feedback"
                           },
                           "content": {
@@ -662,9 +635,7 @@
       "get": {
         "summary": "Get a conversation",
         "description": "Get a conversation in the workspace identified by {wId}.",
-        "tags": [
-          "Conversations"
-        ],
+        "tags": ["Conversations"],
         "security": [
           {
             "BearerAuth": []
@@ -721,9 +692,7 @@
     },
     "/api/v1/w/{wId}/assistant/conversations/{cId}/messages/{mId}/edit": {
       "post": {
-        "tags": [
-          "Conversations"
-        ],
+        "tags": ["Conversations"],
         "summary": "Edit an existing message in a conversation",
         "parameters": [
           {
@@ -765,10 +734,7 @@
             "application/json": {
               "schema": {
                 "type": "object",
-                "required": [
-                  "content",
-                  "mentions"
-                ],
+                "required": ["content", "mentions"],
                 "properties": {
                   "content": {
                     "type": "string",
@@ -779,9 +745,7 @@
                     "description": "List of agent mentions in the message",
                     "items": {
                       "type": "object",
-                      "required": [
-                        "configurationId"
-                      ],
+                      "required": ["configurationId"],
                       "properties": {
                         "configurationId": {
                           "type": "string",
@@ -829,9 +793,7 @@
       "get": {
         "summary": "Get events for a message",
         "description": "Get events for a message in the workspace identified by {wId}.",
-        "tags": [
-          "Conversations"
-        ],
+        "tags": ["Conversations"],
         "parameters": [
           {
             "in": "path",
@@ -925,9 +887,7 @@
       "post": {
         "summary": "Submit feedback for a specific message in a conversation",
         "description": "Submit user feedback (thumbs up/down) for a specific message in a conversation.\nRequires authentication and update:conversation scope.\n",
-        "tags": [
-          "Feedbacks"
-        ],
+        "tags": ["Feedbacks"],
         "parameters": [
           {
             "name": "wId",
@@ -968,16 +928,11 @@
             "application/json": {
               "schema": {
                 "type": "object",
-                "required": [
-                  "thumbDirection"
-                ],
+                "required": ["thumbDirection"],
                 "properties": {
                   "thumbDirection": {
                     "type": "string",
-                    "enum": [
-                      "up",
-                      "down"
-                    ],
+                    "enum": ["up", "down"],
                     "description": "Direction of the thumb feedback"
                   },
                   "feedbackContent": {
@@ -1023,9 +978,7 @@
       "delete": {
         "summary": "Delete feedback for a specific message",
         "description": "Delete user feedback for a specific message in a conversation.\nRequires authentication and update:conversation scope.\n",
-        "tags": [
-          "Feedbacks"
-        ],
+        "tags": ["Feedbacks"],
         "parameters": [
           {
             "name": "wId",
@@ -1092,9 +1045,7 @@
       "post": {
         "summary": "Validate an action in a conversation message",
         "description": "Approves or rejects an action taken in a specific message in a conversation",
-        "tags": [
-          "Conversations"
-        ],
+        "tags": ["Conversations"],
         "parameters": [
           {
             "in": "path",
@@ -1130,10 +1081,7 @@
             "application/json": {
               "schema": {
                 "type": "object",
-                "required": [
-                  "actionId",
-                  "approved"
-                ],
+                "required": ["actionId", "approved"],
                 "properties": {
                   "actionId": {
                     "type": "string",
@@ -1188,9 +1136,7 @@
       "post": {
         "summary": "Create a message",
         "description": "Create a message in the workspace identified by {wId} in the conversation identified by {cId}.",
-        "tags": [
-          "Conversations"
-        ],
+        "tags": ["Conversations"],
         "parameters": [
           {
             "in": "path",
@@ -1256,9 +1202,7 @@
       "post": {
         "summary": "Create a new conversation",
         "description": "Create a new conversation in the workspace identified by {wId}.",
-        "tags": [
-          "Conversations"
-        ],
+        "tags": ["Conversations"],
         "parameters": [
           {
             "in": "path",
@@ -1281,9 +1225,7 @@
             "application/json": {
               "schema": {
                 "type": "object",
-                "required": [
-                  "message"
-                ],
+                "required": ["message"],
                 "properties": {
                   "message": {
                     "$ref": "#/components/schemas/Message"
@@ -1343,9 +1285,7 @@
     },
     "/api/v1/w/{wId}/files": {
       "post": {
-        "tags": [
-          "Conversations"
-        ],
+        "tags": ["Conversations"],
         "summary": "Create a file upload URL",
         "parameters": [
           {
@@ -1444,9 +1384,7 @@
       "post": {
         "summary": "Update heartbeat for a client-side MCP server",
         "description": "[Documentation](https://docs.dust.tt/docs/client-side-mcp-server)\nUpdate the heartbeat for a previously registered client-side MCP server.\nThis extends the TTL for the server registration.\n",
-        "tags": [
-          "MCP"
-        ],
+        "tags": ["MCP"],
         "security": [
           {
             "BearerAuth": []
@@ -1469,9 +1407,7 @@
             "application/json": {
               "schema": {
                 "type": "object",
-                "required": [
-                  "serverId"
-                ],
+                "required": ["serverId"],
                 "properties": {
                   "serverId": {
                     "type": "string",
@@ -1521,9 +1457,7 @@
       "post": {
         "summary": "Register a client-side MCP server",
         "description": "[Documentation](https://docs.dust.tt/docs/client-side-mcp-server)\nRegister a client-side MCP server to Dust.\nThe registration is scoped to the current user and workspace.\nA serverId identifier is generated and returned in the response.\n",
-        "tags": [
-          "MCP"
-        ],
+        "tags": ["MCP"],
         "security": [
           {
             "BearerAuth": []
@@ -1546,9 +1480,7 @@
             "application/json": {
               "schema": {
                 "type": "object",
-                "required": [
-                  "serverName"
-                ],
+                "required": ["serverName"],
                 "properties": {
                   "serverName": {
                     "type": "string",
@@ -1595,9 +1527,7 @@
       "get": {
         "summary": "Stream MCP tool requests for a workspace",
         "description": "[Documentation](https://docs.dust.tt/docs/client-side-mcp-server)\nServer-Sent Events (SSE) endpoint that streams MCP tool requests for a workspace.\nThis endpoint is used by client-side MCP servers to listen for tool requests in real-time.\nThe connection will remain open and events will be sent as new tool requests are made.\n",
-        "tags": [
-          "MCP"
-        ],
+        "tags": ["MCP"],
         "security": [
           {
             "BearerAuth": []
@@ -1672,9 +1602,7 @@
       "post": {
         "summary": "Submit MCP tool execution results",
         "description": "[Documentation](https://docs.dust.tt/docs/client-side-mcp-server)\nEndpoint for client-side MCP servers to submit the results of tool executions.\nThis endpoint accepts the output from tools that were executed locally.\n",
-        "tags": [
-          "MCP"
-        ],
+        "tags": ["MCP"],
         "security": [
           {
             "BearerAuth": []
@@ -1697,10 +1625,7 @@
             "application/json": {
               "schema": {
                 "type": "object",
-                "required": [
-                  "result",
-                  "serverId"
-                ],
+                "required": ["result", "serverId"],
                 "properties": {
                   "result": {
                     "type": "object",
@@ -1741,9 +1666,7 @@
       "post": {
         "summary": "Search for nodes in the workspace",
         "description": "Search for nodes in the workspace",
-        "tags": [
-          "Search"
-        ],
+        "tags": ["Search"],
         "parameters": [
           {
             "in": "path",
@@ -1766,9 +1689,7 @@
             "application/json": {
               "schema": {
                 "type": "object",
-                "required": [
-                  "query"
-                ],
+                "required": ["query"],
                 "properties": {
                   "query": {
                     "type": "string",
@@ -1828,9 +1749,7 @@
       "get": {
         "summary": "Get an app run",
         "description": "Retrieve a run for an app in the space identified by {spaceId}.",
-        "tags": [
-          "Apps"
-        ],
+        "tags": ["Apps"],
         "security": [
           {
             "BearerAuth": []
@@ -1903,9 +1822,7 @@
       "post": {
         "summary": "Create an app run",
         "description": "Create and execute a run for an app in the space specified by {spaceId}.",
-        "tags": [
-          "Apps"
-        ],
+        "tags": ["Apps"],
         "security": [
           {
             "BearerAuth": []
@@ -1946,11 +1863,7 @@
             "application/json": {
               "schema": {
                 "type": "object",
-                "required": [
-                  "specification_hash",
-                  "config",
-                  "inputs"
-                ],
+                "required": ["specification_hash", "config", "inputs"],
                 "properties": {
                   "specification_hash": {
                     "type": "string",
@@ -2050,9 +1963,7 @@
       "get": {
         "summary": "List apps",
         "description": "Get all apps in the space identified by {spaceId}.",
-        "tags": [
-          "Apps"
-        ],
+        "tags": ["Apps"],
         "security": [
           {
             "BearerAuth": []
@@ -2151,9 +2062,7 @@
     },
     "/api/v1/w/{wId}/spaces/{spaceId}/data_source_views/{dsvId}": {
       "get": {
-        "tags": [
-          "DatasourceViews"
-        ],
+        "tags": ["DatasourceViews"],
         "security": [
           {
             "BearerAuth": []
@@ -2206,9 +2115,7 @@
         }
       },
       "patch": {
-        "tags": [
-          "DatasourceViews"
-        ],
+        "tags": ["DatasourceViews"],
         "security": [
           {
             "BearerAuth": []
@@ -2258,9 +2165,7 @@
                         }
                       }
                     },
-                    "required": [
-                      "parentsIn"
-                    ]
+                    "required": ["parentsIn"]
                   },
                   {
                     "type": "object",
@@ -2313,9 +2218,7 @@
         }
       },
       "delete": {
-        "tags": [
-          "DatasourceViews"
-        ],
+        "tags": ["DatasourceViews"],
         "security": [
           {
             "BearerAuth": []
@@ -2371,9 +2274,7 @@
       "get": {
         "summary": "Search the data source view",
         "description": "Search the data source view identified by {dsvId} in the workspace identified by {wId}.",
-        "tags": [
-          "DatasourceViews"
-        ],
+        "tags": ["DatasourceViews"],
         "security": [
           {
             "BearerAuth": []
@@ -2570,9 +2471,7 @@
       "get": {
         "summary": "List Data Source Views",
         "description": "Retrieves a list of data source views for the specified space",
-        "tags": [
-          "DatasourceViews"
-        ],
+        "tags": ["DatasourceViews"],
         "security": [
           {
             "BearerAuth": []
@@ -2639,9 +2538,7 @@
       "get": {
         "summary": "Retrieve a document from a data source",
         "description": "Retrieve a document from a data source identified by {dsId} in the workspace identified by {wId}.",
-        "tags": [
-          "Datasources"
-        ],
+        "tags": ["Datasources"],
         "parameters": [
           {
             "in": "path",
@@ -2721,9 +2618,7 @@
       "post": {
         "summary": "Upsert a document in a data source",
         "description": "Upsert a document in a data source in the workspace identified by {wId}.",
-        "tags": [
-          "Datasources"
-        ],
+        "tags": ["Datasources"],
         "parameters": [
           {
             "in": "path",
@@ -2866,9 +2761,7 @@
       "delete": {
         "summary": "Delete a document from a data source",
         "description": "Delete a document from a data source in the workspace identified by {wId}.",
-        "tags": [
-          "Datasources"
-        ],
+        "tags": ["Datasources"],
         "parameters": [
           {
             "in": "path",
@@ -2955,9 +2848,7 @@
       "post": {
         "summary": "Update the parents of a document",
         "description": "Update the parents of a document in the data source identified by {dsId} in the workspace identified by {wId}.",
-        "tags": [
-          "Datasources"
-        ],
+        "tags": ["Datasources"],
         "parameters": [
           {
             "in": "path",
@@ -3050,9 +2941,7 @@
       "get": {
         "summary": "Get documents",
         "description": "Get documents in the data source identified by {dsId} in the workspace identified by {wId}.",
-        "tags": [
-          "Datasources"
-        ],
+        "tags": ["Datasources"],
         "security": [
           {
             "BearerAuth": []
@@ -3149,9 +3038,7 @@
       "get": {
         "summary": "Search the data source",
         "description": "Search the data source identified by {dsId} in the workspace identified by {wId}.",
-        "tags": [
-          "Datasources"
-        ],
+        "tags": ["Datasources"],
         "security": [
           {
             "BearerAuth": []
@@ -3348,9 +3235,7 @@
       "get": {
         "summary": "Get a table",
         "description": "Get a table in the data source identified by {dsId} in the workspace identified by {wId}.",
-        "tags": [
-          "Datasources"
-        ],
+        "tags": ["Datasources"],
         "security": [
           {
             "BearerAuth": []
@@ -3416,9 +3301,7 @@
       "delete": {
         "summary": "Delete a table",
         "description": "Delete a table in the data source identified by {dsId} in the workspace identified by {wId}.",
-        "tags": [
-          "Datasources"
-        ],
+        "tags": ["Datasources"],
         "security": [
           {
             "BearerAuth": []
@@ -3479,9 +3362,7 @@
       "get": {
         "summary": "Get a row",
         "description": "Get a row in the table identified by {tId} in the data source identified by {dsId} in the workspace identified by {wId}.",
-        "tags": [
-          "Datasources"
-        ],
+        "tags": ["Datasources"],
         "security": [
           {
             "BearerAuth": []
@@ -3556,9 +3437,7 @@
       "delete": {
         "summary": "Delete a row",
         "description": "Delete a row in the table identified by {tId} in the data source identified by {dsId} in the workspace identified by {wId}.",
-        "tags": [
-          "Datasources"
-        ],
+        "tags": ["Datasources"],
         "security": [
           {
             "BearerAuth": []
@@ -3628,9 +3507,7 @@
       "get": {
         "summary": "List rows",
         "description": "List rows in the table identified by {tId} in the data source identified by {dsId} in the workspace identified by {wId}.",
-        "tags": [
-          "Datasources"
-        ],
+        "tags": ["Datasources"],
         "security": [
           {
             "BearerAuth": []
@@ -3712,9 +3589,7 @@
       "post": {
         "summary": "Upsert rows",
         "description": "Upsert rows in the table identified by {tId} in the data source identified by {dsId} in the workspace identified by {wId}.",
-        "tags": [
-          "Datasources"
-        ],
+        "tags": ["Datasources"],
         "security": [
           {
             "BearerAuth": []
@@ -3792,9 +3667,7 @@
                                 "properties": {
                                   "type": {
                                     "type": "string",
-                                    "enum": [
-                                      "datetime"
-                                    ]
+                                    "enum": ["datetime"]
                                   },
                                   "epoch": {
                                     "type": "number"
@@ -3849,9 +3722,7 @@
       "get": {
         "summary": "Get tables",
         "description": "Get tables in the data source identified by {dsId} in the workspace identified by {wId}.",
-        "tags": [
-          "Datasources"
-        ],
+        "tags": ["Datasources"],
         "security": [
           {
             "BearerAuth": []
@@ -3908,9 +3779,7 @@
       "post": {
         "summary": "Upsert a table",
         "description": "Upsert a table in the data source identified by {dsId} in the workspace identified by {wId}.",
-        "tags": [
-          "Datasources"
-        ],
+        "tags": ["Datasources"],
         "security": [
           {
             "BearerAuth": []
@@ -4012,9 +3881,7 @@
       "get": {
         "summary": "Get data sources",
         "description": "Get data sources in the workspace identified by {wId}.",
-        "tags": [
-          "Datasources"
-        ],
+        "tags": ["Datasources"],
         "parameters": [
           {
             "in": "path",
@@ -4068,82 +3935,11 @@
         }
       }
     },
-    "/api/v1/w/{wId}/spaces/{spaceId}/mcp_server_views": {
-      "get": {
-        "summary": "List available MCP server views.",
-        "description": "Retrieves a list of enabled MCP server views (aka tools) for a specific space of the authenticated workspace.",
-        "tags": [
-          "Tools"
-        ],
-        "security": [
-          {
-            "BearerAuth": []
-          }
-        ],
-        "parameters": [
-          {
-            "in": "path",
-            "name": "wId",
-            "required": true,
-            "description": "Unique string identifier for the workspace",
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "in": "path",
-            "name": "spaceId",
-            "required": true,
-            "description": "ID of the space",
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "MCP server views of the space",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "spaces": {
-                      "type": "array",
-                      "items": {
-                        "$ref": "#/components/schemas/MCPServerView"
-                      }
-                    }
-                  }
-                }
-              }
-            }
-          },
-          "400": {
-            "description": "Bad Request. Missing or invalid parameters."
-          },
-          "401": {
-            "description": "Unauthorized. Invalid or missing authentication token."
-          },
-          "404": {
-            "description": "Workspace not found."
-          },
-          "405": {
-            "description": "Method not supported."
-          },
-          "500": {
-            "description": "Internal Server Error."
-          }
-        }
-      }
-    },
     "/api/v1/w/{wId}/spaces": {
       "get": {
         "summary": "List available spaces.",
         "description": "Retrieves a list of accessible spaces for the authenticated workspace.",
-        "tags": [
-          "Spaces"
-        ],
+        "tags": ["Spaces"],
         "security": [
           {
             "BearerAuth": []
@@ -4201,9 +3997,7 @@
       "get": {
         "summary": "Get workspace usage data",
         "description": "Get usage data for the workspace identified by {wId} in CSV or JSON format.",
-        "tags": [
-          "Workspace"
-        ],
+        "tags": ["Workspace"],
         "security": [
           {
             "BearerAuth": []
@@ -4244,10 +4038,7 @@
             "description": "The mode of date range selection",
             "schema": {
               "type": "string",
-              "enum": [
-                "month",
-                "range"
-              ]
+              "enum": ["month", "range"]
             }
           },
           {
@@ -4257,10 +4048,7 @@
             "description": "The output format of the data (defaults to 'csv')",
             "schema": {
               "type": "string",
-              "enum": [
-                "csv",
-                "json"
-              ]
+              "enum": ["csv", "json"]
             }
           },
           {
@@ -4432,10 +4220,7 @@
               "type": "string",
               "description": "Feature flags enabled for the workspace"
             },
-            "example": [
-              "advanced_analytics",
-              "beta_features"
-            ]
+            "example": ["advanced_analytics", "beta_features"]
           },
           "ssoEnforced": {
             "type": "boolean",
@@ -4447,10 +4232,7 @@
               "type": "string",
               "description": "List of allowed authentication providers"
             },
-            "example": [
-              "google",
-              "github"
-            ]
+            "example": ["google", "github"]
           },
           "defaultEmbeddingProvider": {
             "type": "string",
@@ -4462,10 +4244,7 @@
       },
       "Context": {
         "type": "object",
-        "required": [
-          "username",
-          "timezone"
-        ],
+        "required": ["username", "timezone"],
         "properties": {
           "username": {
             "type": "string",
@@ -4762,10 +4541,7 @@
       },
       "Message": {
         "type": "object",
-        "required": [
-          "content",
-          "mentions"
-        ],
+        "required": ["content", "mentions"],
         "properties": {
           "content": {
             "type": "string",
@@ -4786,9 +4562,7 @@
       },
       "ContentFragment": {
         "type": "object",
-        "required": [
-          "title"
-        ],
+        "required": ["title"],
         "properties": {
           "title": {
             "type": "string",
@@ -4843,12 +4617,7 @@
           },
           "kind": {
             "type": "string",
-            "enum": [
-              "regular",
-              "global",
-              "system",
-              "public"
-            ],
+            "enum": ["regular", "global", "system", "public"],
             "description": "The kind of the space"
           },
           "groupIds": {
@@ -4948,13 +4717,7 @@
                 "value_type": {
                   "type": "string",
                   "description": "Data type of the column",
-                  "enum": [
-                    "text",
-                    "int",
-                    "float",
-                    "bool",
-                    "date"
-                  ],
+                  "enum": ["text", "int", "float", "bool", "date"],
                   "example": "int"
                 },
                 "possible_values": {
@@ -4964,11 +4727,7 @@
                     "type": "string"
                   },
                   "nullable": true,
-                  "example": [
-                    "1",
-                    "2",
-                    "3"
-                  ]
+                  "example": ["1", "2", "3"]
                 }
               }
             }
@@ -4999,9 +4758,7 @@
             "items": {
               "type": "string"
             },
-            "example": [
-              "1234f4567c"
-            ]
+            "example": ["1234f4567c"]
           }
         }
       },
@@ -5010,12 +4767,7 @@
         "properties": {
           "category": {
             "type": "string",
-            "enum": [
-              "managed",
-              "folder",
-              "website",
-              "apps"
-            ],
+            "enum": ["managed", "folder", "website", "apps"],
             "description": "The category of the data source view"
           },
           "createdAt": {
@@ -5045,10 +4797,7 @@
           },
           "kind": {
             "type": "string",
-            "enum": [
-              "default",
-              "custom"
-            ],
+            "enum": ["default", "custom"],
             "description": "The kind of the data source view"
           },
           "parentsIn": {
@@ -5168,10 +4917,7 @@
             "items": {
               "type": "string"
             },
-            "example": [
-              "customer_support",
-              "faq"
-            ]
+            "example": ["customer_support", "faq"]
           },
           "parent_id": {
             "type": "string",
@@ -5186,10 +4932,7 @@
             "items": {
               "type": "string"
             },
-            "example": [
-              "7b9d1f3e5a",
-              "2c4a6e8d0f"
-            ]
+            "example": ["7b9d1f3e5a", "2c4a6e8d0f"]
           },
           "source_url": {
             "type": "string",
@@ -5217,22 +4960,12 @@
               {
                 "chunk_id": "9f1d3b5a7c",
                 "text": "This is the first chunk of the document.",
-                "embedding": [
-                  0.1,
-                  0.2,
-                  0.3,
-                  0.4
-                ]
+                "embedding": [0.1, 0.2, 0.3, 0.4]
               },
               {
                 "chunk_id": "4a2c6e8b0d",
                 "text": "This is the second chunk of the document.",
-                "embedding": [
-                  0.5,
-                  0.6,
-                  0.7,
-                  0.8
-                ]
+                "embedding": [0.5, 0.6, 0.7, 0.8]
               }
             ]
           },


### PR DESCRIPTION
## Description

allow users to get the full config of the agents by API (including sub agents) 

`{{baseUrl}}/api/v1/w/{{wid}}/assistant/agent_configurations/{{agent_sid}}?variant=full`

## Tests

tested locally
