### PR TITLE
[extension] Fix return of getAccessToken

### DIFF
--- a/extension/platforms/chrome/manifests/manifest.base.json
+++ b/extension/platforms/chrome/manifests/manifest.base.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "Dust",
-  "version": "0.0.25",
+  "version": "0.0.26",
   "description": "Get more done, faster, with the power of your agents at your fingertips.",
   "icons": {
     "16": "images/dust16.png",

--- a/extension/platforms/front/services/auth.ts
+++ b/extension/platforms/front/services/auth.ts
@@ -256,12 +256,11 @@ export class FrontAuthService extends AuthService {
       const refreshRes = await this.refreshToken();
       if (refreshRes.isOk()) {
         tokens = refreshRes.value;
+      } else {
+        tokens = null;
       }
     }
-    // We wanted a refreshed token, don't return the one we have which is invalid.
-    if (forceRefresh) {
-      return null;
-    }
+
     return tokens?.accessToken ?? null;
   }
 


### PR DESCRIPTION
## Description

getAccessToken inconditionnaly return null if froceRefresh is set - which is not the correct behaviour. If refresh fails, reset the token to avoid returning an invalid token.
Also adding datadogs logs when we fail to refresh tokens.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan
publish extension
