### PR TITLE
get deal owner by default in Hubspot

### DIFF
--- a/front/lib/actions/mcp_internal_actions/servers/hubspot/hubspot_api_helper.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/hubspot/hubspot_api_helper.ts
@@ -1003,7 +1003,17 @@ export const getDeal = async (
 ): Promise<SimplePublicObject | null> => {
   const hubspotClient = new Client({ accessToken });
   try {
-    const deal = await hubspotClient.crm.deals.basicApi.getById(dealId);
+    const deal = await hubspotClient.crm.deals.basicApi.getById(dealId, [
+      "amount",
+      "hubspot_owner_id",
+      "closedate",
+      "createdate",
+      "dealname",
+      "dealstage",
+      "hs_lastmodifieddate",
+      "hs_object_id",
+      "pipeline",
+    ]);
     return deal;
   } catch (error: any) {
     if (error.code === 404) {


### PR DESCRIPTION
## Description

Add the deal owner property (default HubSpot prop) when getting a HubSpot deal by using the MCP tool.


Needed to override the default because of this 
```Optionalproperties: string[]
A comma separated list of the properties to be returned in the response. If any of the specified properties are not present on the requested object(s), they will be ignored.
```

https://github.hubspot.com/hubspot-api-nodejs/classes/crm_deals.BasicApi.html#getById
