### PR TITLE
dev: add mprocs file to ease local dev

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@ CLAUDE.md
 yalc.lock
 front/public/sitemap.xml
 front/public/robots.txt
+mprocs.log

--- a/tools/mprocs.yaml
+++ b/tools/mprocs.yaml
@@ -1,0 +1,42 @@
+# Configuration for mprocs to run the dev environment locally.
+# Requirements: mprocs (`brew install mprocs`)
+# ⚠️ you need to restart front-workers after sdks-js is loaded: select front-workers in the mprocs window and press r
+procs:
+  core:
+    cwd: "<CONFIG_DIR>/../core"
+    shell: "./admin/dev.sh"
+  sqlite-workers:
+    cwd: "<CONFIG_DIR>/../core"
+    env:
+      CORE_API: "http://localhost:3001"
+      IS_LOCAL_DEV: "1"
+      DATABASES_STORE_DATABASE_URI: "postgresql://dev:dev@localhost:5432/dust_databases_store"
+      CORE_API_KEY: "soupinou"
+    shell: "cargo run --bin sqlite-worker"
+  oauth:
+    cwd: "<CONFIG_DIR>/../core"
+    shell: "./admin/dev_oauth.sh"
+  front:
+    cwd: "<CONFIG_DIR>/../front"
+    shell: "./admin/dev.sh"
+  front-workers:
+    cwd: "<CONFIG_DIR>/../front"
+    shell: "./admin/dev_worker.sh"
+  sdks-js:
+    cwd: "<CONFIG_DIR>/../sdks/js"
+    shell: "./admin/dev.sh"
+  connectors:
+    cwd: "<CONFIG_DIR>/../connectors"
+    shell: "./admin/dev.sh"
+  sparkle:
+    cwd: "<CONFIG_DIR>/../sparkle"
+    shell: "npm run storybook"
+    autostart: false
+  docs:
+    cwd: "<CONFIG_DIR>/../docs"
+    shell: "npm run start"
+    autostart: false
+  extension:
+    cwd: "<CONFIG_DIR>/../extension"
+    shell: "npm run dev:chrome"
+    autostart: false


### PR DESCRIPTION
## Description

It's complex to start the whole (or part of) the stack. This PR adds a `mprocs` file that ease this. 

We can now "just" `cd tools && mprocs` to start all that is needed for local development.

⚠️ I couldn't manage in 5 minutes to tell `front-workers` to start only when `sdks-js` is built.

Note: this is 99% of a `mprocs` file that was shared internally

## Tests


https://github.com/user-attachments/assets/23199d17-8c86-43dd-96d1-ff4824c26992



## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
