### PR TITLE
[front & viz] improve content creation UI 

### DIFF
--- a/front/components/assistant/conversation/content_creation/ClientExecutableRenderer.tsx
+++ b/front/components/assistant/conversation/content_creation/ClientExecutableRenderer.tsx
@@ -44,25 +44,13 @@ function ExportContentDropdown({ iframeRef }: ExportContentDropdownProps) {
   );
 
   return (
-    <DropdownMenu>
-      <DropdownMenuTrigger asChild>
-        <Button
-          icon={ArrowDownOnSquareIcon}
-          isSelect
-          size="xs"
-          tooltip="Export content"
-          variant="ghost"
-        />
-      </DropdownMenuTrigger>
-      <DropdownMenuContent>
-        <DropdownMenuItem onClick={() => exportVisualization("png")}>
-          Export as PNG
-        </DropdownMenuItem>
-        <DropdownMenuItem onClick={() => exportVisualization("svg")}>
-          Export as SVG
-        </DropdownMenuItem>
-      </DropdownMenuContent>
-    </DropdownMenu>
+    <Button
+      icon={ArrowDownOnSquareIcon}
+      size="xs"
+      tooltip="Export as PNG"
+      variant="ghost"
+      onClick={() => exportVisualization("png")}
+    />
   );
 }
 

--- a/front/components/assistant/conversation/content_creation/ClientExecutableRenderer.tsx
+++ b/front/components/assistant/conversation/content_creation/ClientExecutableRenderer.tsx
@@ -3,10 +3,6 @@ import {
   Button,
   CodeBlock,
   CommandLineIcon,
-  DropdownMenu,
-  DropdownMenuContent,
-  DropdownMenuItem,
-  DropdownMenuTrigger,
   EyeIcon,
   Spinner,
 } from "@dust-tt/sparkle";

--- a/front/components/assistant/conversation/content_creation/ContentCreationHeader.tsx
+++ b/front/components/assistant/conversation/content_creation/ContentCreationHeader.tsx
@@ -1,4 +1,4 @@
-import { Button, cn, LinkIcon, XMarkIcon } from "@dust-tt/sparkle";
+import { Button, cn, XMarkIcon } from "@dust-tt/sparkle";
 import React from "react";
 
 import { AppLayoutTitle } from "@app/components/sparkle/AppLayoutTitle";
@@ -6,7 +6,6 @@ import { AppLayoutTitle } from "@app/components/sparkle/AppLayoutTitle";
 interface ContentCreationHeaderProps {
   children?: React.ReactNode;
   onClose?: () => void;
-  onShare?: () => void;
   subtitle?: string;
   title: string;
 }
@@ -14,7 +13,6 @@ interface ContentCreationHeaderProps {
 export function ContentCreationHeader({
   children,
   onClose,
-  onShare,
   subtitle,
   title,
 }: ContentCreationHeaderProps) {
@@ -43,20 +41,10 @@ export function ContentCreationHeader({
         {/* Actions - always visible and right-aligned. */}
         <div className="flex shrink-0 items-center gap-2">
           {children}
-          {onShare && (
-            <Button
-              variant="ghost"
-              size="sm"
-              onClick={onShare}
-              icon={LinkIcon}
-              tooltip="Share publicly"
-              className="text-element-600 hover:text-element-900"
-            />
-          )}
           {onClose && (
             <Button
               variant="ghost"
-              size="sm"
+              size="xs"
               onClick={onClose}
               icon={XMarkIcon}
               className="text-element-600 hover:text-element-900"

--- a/front/lib/actions/mcp_internal_actions/constants.ts
+++ b/front/lib/actions/mcp_internal_actions/constants.ts
@@ -732,7 +732,7 @@ The directive should be used to display a clickable version of the agent name in
       name: "content_creation",
       version: "1.0.0",
       description:
-        "Create interactive content including dashboards with data visualizations, presentations, or any custom interactive components.",
+        "Create dashboards, presentations, or any interactive content with charts, KPIs, and data visualizations.",
       authorization: null,
       icon: "ActionDocumentTextIcon",
       documentationUrl: null,

--- a/front/lib/actions/mcp_internal_actions/constants.ts
+++ b/front/lib/actions/mcp_internal_actions/constants.ts
@@ -732,23 +732,23 @@ The directive should be used to display a clickable version of the agent name in
       name: "content_creation",
       version: "1.0.0",
       description:
-        "Create interactive content including dashboards with data visualizations, slide presentations, or any custom interactive components.",
+        "Create interactive content including dashboards with data visualizations, presentations, or any custom interactive components.",
       authorization: null,
       icon: "ActionDocumentTextIcon",
       documentationUrl: null,
       instructions: CONTENT_CREATION_INSTRUCTIONS,
       flavors: [
         {
-          id: "dashboards",
+          id: "dashboard",
           name: "Dashboard",
           description:
             "Create interactive dashboards with charts, KPIs, and data visualizations",
           icon: "ActionPieChartIcon",
         },
         {
-          id: "slides",
-          name: "Slides",
-          description: "Build slide decks and presentations",
+          id: "presentation",
+          name: "Presentation",
+          description: "Create presentations",
           icon: "ActionSlideshowIcon",
         },
         {

--- a/viz/components/dust/slideshow/v1/navigation.tsx
+++ b/viz/components/dust/slideshow/v1/navigation.tsx
@@ -19,9 +19,9 @@ export function SlideshowNavigation({
 }: SlideshowNavigationProps) {
   React.useEffect(() => {
     const handleKeyDown = (e: KeyboardEvent) => {
-      if (e.key === "ArrowLeft") {
+      if (e.key === "ArrowLeft" || e.key === "ArrowUp") {
         prev();
-      } else if (e.key === "ArrowRight") {
+      } else if (e.key === "ArrowRight" || e.key === "ArrowDown") {
         next();
       }
     };


### PR DESCRIPTION
## Description
This PR does the following things:
- allows you to navigate presentation with arrow up & down https://github.com/dust-tt/tasks/issues/3987
- removes download as svg option https://github.com/dust-tt/tasks/issues/3990 
- rename slides to presentation https://github.com/dust-tt/tasks/issues/3992
- align button size to xs

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
