### PR TITLE
[front] - fix(AB): improve mcpServerView suggestion

### DIFF
--- a/front/components/agent_builder/capabilities/shared/ProcessingMethodSection.tsx
+++ b/front/components/agent_builder/capabilities/shared/ProcessingMethodSection.tsx
@@ -118,14 +118,29 @@ export function ProcessingMethodSection() {
   }, [mcpServerViewsWithKnowledge, sources.in, mcpServerView]);
 
   useEffect(() => {
-    // Update mcpServerView only if it's null and we have servers to display
-    if (serversToDisplay && mcpServerView === null) {
-      const [defaultServer] = serversToDisplay;
-      if (defaultServer) {
-        setValue("mcpServerView", defaultServer, { shouldDirty: false });
+    if (serversToDisplay) {
+      let suggestedServer = serversToDisplay[0];
+      // If all selected sources are tables or remote databases, suggest
+      // table query method
+      if (
+        sources.in.length > 0 &&
+        sources.in.every(isRemoteDatabaseOrTableItem)
+      ) {
+        const tableQueryServer = serversToDisplay.find(
+          (server) =>
+            tablesServer.includes(server.server.name) ||
+            server.server.name === DATA_WAREHOUSE_SERVER_NAME
+        );
+        if (tableQueryServer) {
+          suggestedServer = tableQueryServer;
+        }
+      }
+
+      if (suggestedServer) {
+        setValue("mcpServerView", suggestedServer, { shouldDirty: true });
       }
     }
-  }, [serversToDisplay, setValue, mcpServerView]);
+  }, [serversToDisplay, setValue, mcpServerView, sources.in]);
 
   return (
     <div className="mt-2 flex flex-col space-y-4">


### PR DESCRIPTION
## Description

Improves the processing method suggestion logic in the agent builder by automatically suggesting table query servers when all selected sources are tables or remote databases. The change prioritizes table query methods (including data warehouse servers) over other processing methods when the user selects only structured data sources, and marks the suggestion as dirty to indicate a change was made.

## Tests

Locally

## Risk

Low

## Deploy Plan

Deploy front