### PR TITLE
Add: unread support for conversation

### DIFF
--- a/front/components/assistant/conversation/ConversationViewer.tsx
+++ b/front/components/assistant/conversation/ConversationViewer.tsx
@@ -20,6 +20,7 @@ import {
 import {
   useConversation,
   useConversationFeedbacks,
+  useConversationMarkAsRead,
   useConversationMessages,
   useConversationParticipants,
   useConversations,
@@ -28,6 +29,7 @@ import { classNames } from "@app/lib/utils";
 import type {
   AgentGenerationCancelledEvent,
   AgentMention,
+  AgentMessageDoneEvent,
   AgentMessageNewEvent,
   ContentFragmentType,
   ConversationTitleEvent,
@@ -72,6 +74,11 @@ const ConversationViewer = React.forwardRef<
     mutateConversation,
   } = useConversation({
     conversationId,
+    workspaceId: owner.sId,
+  });
+
+  useConversationMarkAsRead({
+    conversation,
     workspaceId: owner.sId,
   });
 
@@ -243,6 +250,7 @@ const ConversationViewer = React.forwardRef<
     [conversationId, owner.sId]
   );
 
+  // Only conversation related events are handled here.
   const onEventCallback = useCallback(
     (eventStr: string) => {
       const eventPayload: {
@@ -250,6 +258,7 @@ const ConversationViewer = React.forwardRef<
         data:
           | UserMessageNewEvent
           | AgentMessageNewEvent
+          | AgentMessageDoneEvent
           | AgentGenerationCancelledEvent
           | ConversationTitleEvent;
       } = JSON.parse(eventStr);
@@ -275,11 +284,11 @@ const ConversationViewer = React.forwardRef<
             void mutateMessages();
             break;
 
-          case "conversation_title": {
+          case "conversation_title":
+          case "agent_message_done":
             void mutateConversation();
-            void mutateConversations(); // to refresh the list of convos in the sidebar
+            void mutateConversations(); // to refresh the list of convos in the sidebar (title, unread & actionRequired)
             break;
-          }
           default:
             ((t: never) => {
               console.error("Unknown event type", t);

--- a/front/components/assistant/conversation/SidebarMenu.tsx
+++ b/front/components/assistant/conversation/SidebarMenu.tsx
@@ -2,16 +2,16 @@ import {
   Button,
   ChatBubbleBottomCenterTextIcon,
   Checkbox,
-  ClockIcon,
   DocumentIcon,
+  DotIcon,
   DropdownMenu,
   DropdownMenuContent,
   DropdownMenuItem,
   DropdownMenuLabel,
   DropdownMenuTrigger,
+  ExclamationCircleIcon,
   FolderOpenIcon,
   Icon,
-  InformationCircleIcon,
   Label,
   ListCheckIcon,
   MagicIcon,
@@ -450,8 +450,8 @@ const RenderConversation = ({
       ? "New Conversation"
       : `Conversation from ${new Date(conversation.created).toLocaleDateString()}`);
 
-  const ActionRequiredIcon = () => (
-    <Icon visual={InformationCircleIcon} className="text-golden-700" />
+  const UnreadIcon = () => (
+    <Icon visual={DotIcon} className="-ml-1 -mr-2 text-highlight" />
   );
 
   return (
@@ -476,12 +476,13 @@ const RenderConversation = ({
           selected={router.query.cId === conversation.sId}
           icon={
             conversation.actionRequired
-              ? ActionRequiredIcon
-              : conversation.triggerId
-                ? ClockIcon
+              ? ExclamationCircleIcon
+              : conversation.unread
+                ? UnreadIcon
                 : undefined
           }
           label={conversationLabel}
+          className={conversation.unread ? "font-medium" : undefined}
           href={`/w/${owner.sId}/assistant/${conversation.sId}`}
           shallow
         />

--- a/front/lib/api/assistant/conversation.ts
+++ b/front/lib/api/assistant/conversation.ts
@@ -144,6 +144,8 @@ export async function createConversation(
     depth: conversation.depth,
     triggerId: conversation.triggerSId(),
     content: [],
+    unread: false,
+    actionRequired: false,
     requestedGroupIds:
       conversation.getConversationRequestedGroupIdsFromModel(auth),
   };
@@ -599,6 +601,12 @@ export async function postUserMessage(
         rank: m.rank,
       };
 
+      // Mark the conversation as unread for all participants except the user.
+      await ConversationResource.markAsUnreadForOtherParticipants(auth, {
+        conversation,
+        excludedUser: user?.toJSON(),
+      });
+
       const results: ({ row: AgentMessage; m: AgentMessageType } | null)[] =
         await Promise.all(
           mentions.filter(isAgentMention).map((mention) => {
@@ -1038,6 +1046,12 @@ export async function editUserMessage(
         context: message.context,
         rank: m.rank,
       };
+
+      // Mark the conversation as unread for all participants except the user.
+      await ConversationResource.markAsUnreadForOtherParticipants(auth, {
+        conversation,
+        excludedUser: user?.toJSON(),
+      });
 
       // For now agent messages are appended at the end of conversation
       // it is fine since for now editing with new mentions is only supported

--- a/front/lib/api/assistant/conversation/fetch.ts
+++ b/front/lib/api/assistant/conversation/fetch.ts
@@ -118,6 +118,12 @@ export async function getConversation(
     (content[m.rank] as any).push(m);
   }
 
+  const { actionRequired, unread } =
+    await ConversationResource.getActionRequiredAndUnreadForUser(
+      auth,
+      conversation.id
+    );
+
   return new Ok({
     id: conversation.id,
     created: conversation.createdAt.getTime(),
@@ -128,6 +134,8 @@ export async function getConversation(
     depth: conversation.depth,
     triggerId: conversation.triggerSId(),
     content,
+    actionRequired,
+    unread,
     requestedGroupIds:
       conversation.getConversationRequestedGroupIdsFromModel(auth),
   });

--- a/front/lib/api/assistant/streaming/events.ts
+++ b/front/lib/api/assistant/streaming/events.ts
@@ -95,6 +95,7 @@ function isMessageEventParams(
       return true;
     case "user_message_new":
     case "agent_message_new":
+    case "agent_message_done":
       return false;
     default:
       assertNever(eventType);

--- a/front/lib/api/assistant/streaming/types.ts
+++ b/front/lib/api/assistant/streaming/types.ts
@@ -3,6 +3,7 @@ import type {
   AgentActionSuccessEvent,
   AgentErrorEvent,
   AgentGenerationCancelledEvent,
+  AgentMessageDoneEvent,
   AgentMessageNewEvent,
   AgentMessageSuccessEvent,
   GenerationTokensEvent,
@@ -19,4 +20,7 @@ export type AgentMessageEvents =
   | GenerationTokensEvent
   | ToolErrorEvent;
 
-export type ConversationEvents = AgentMessageNewEvent | UserMessageNewEvent;
+export type ConversationEvents =
+  | AgentMessageNewEvent
+  | UserMessageNewEvent
+  | AgentMessageDoneEvent;

--- a/front/pages/api/v1/w/[wId]/assistant/conversations/[cId]/index.test.ts
+++ b/front/pages/api/v1/w/[wId]/assistant/conversations/[cId]/index.test.ts
@@ -1,0 +1,10 @@
+import { describe } from "vitest";
+
+import { createPublicApiAuthenticationTests } from "@app/tests/utils/generic_public_api_tests";
+
+import handler from "./index";
+
+describe(
+  "public api authentication tests",
+  createPublicApiAuthenticationTests(handler)
+);

--- a/front/pages/api/w/[wId]/assistant/conversations/[cId]/index.ts
+++ b/front/pages/api/w/[wId]/assistant/conversations/[cId]/index.ts
@@ -7,6 +7,7 @@ import {
   deleteOrLeaveConversation,
   updateConversationTitle,
 } from "@app/lib/api/assistant/conversation";
+import { getConversation } from "@app/lib/api/assistant/conversation/fetch";
 import { apiErrorForConversation } from "@app/lib/api/assistant/conversation/helper";
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
 import type { Authenticator } from "@app/lib/auth";
@@ -18,9 +19,18 @@ import type {
 } from "@app/types";
 import { isString } from "@app/types";
 
-export const PatchConversationsRequestBodySchema = t.type({
-  title: t.string,
-});
+const PatchConversationsRequestBodySchema = t.union([
+  t.type({
+    title: t.string,
+  }),
+  t.type({
+    read: t.literal(true),
+  }),
+]);
+
+export type PatchConversationsRequestBody = t.TypeOf<
+  typeof PatchConversationsRequestBodySchema
+>;
 
 export type GetConversationsResponseBody = {
   conversation: ConversationWithoutContentType;
@@ -70,45 +80,64 @@ async function handler(
       return;
     }
 
-    case "PATCH": {
-      const conversationRes =
-        await ConversationResource.fetchConversationWithoutContent(auth, cId);
+    case "PATCH":
+      {
+        const conversationRes =
+          await ConversationResource.fetchConversationWithoutContent(auth, cId);
 
-      if (conversationRes.isErr()) {
-        return apiErrorForConversation(req, res, conversationRes.error);
+        if (conversationRes.isErr()) {
+          return apiErrorForConversation(req, res, conversationRes.error);
+        }
+
+        const conversation = conversationRes.value;
+        const bodyValidation = PatchConversationsRequestBodySchema.decode(
+          req.body
+        );
+
+        if (isLeft(bodyValidation)) {
+          const pathError = reporter.formatValidationErrors(
+            bodyValidation.left
+          );
+
+          return apiError(req, res, {
+            status_code: 400,
+            api_error: {
+              type: "invalid_request_error",
+              message: `Invalid request body: ${pathError}`,
+            },
+          });
+        }
+
+        if ("title" in bodyValidation.right) {
+          const result = await updateConversationTitle(auth, {
+            conversationId: conversation.sId,
+            title: bodyValidation.right.title,
+          });
+
+          if (result.isErr()) {
+            return apiErrorForConversation(req, res, result.error);
+          }
+          return res.status(200).json({ conversation: result.value });
+        } else if ("read" in bodyValidation.right) {
+          await ConversationResource.markAsRead(auth, {
+            conversation,
+          });
+          const result = await getConversation(auth, cId);
+          if (result.isErr()) {
+            return apiErrorForConversation(req, res, result.error);
+          }
+          return res.status(200).json({ conversation: result.value });
+        } else {
+          return apiError(req, res, {
+            status_code: 400,
+            api_error: {
+              type: "invalid_request_error",
+              message: "Invalid request body",
+            },
+          });
+        }
       }
-
-      const conversation = conversationRes.value;
-      const bodyValidation = PatchConversationsRequestBodySchema.decode(
-        req.body
-      );
-
-      if (isLeft(bodyValidation)) {
-        const pathError = reporter.formatValidationErrors(bodyValidation.left);
-
-        return apiError(req, res, {
-          status_code: 400,
-          api_error: {
-            type: "invalid_request_error",
-            message: `Invalid request body: ${pathError}`,
-          },
-        });
-      }
-
-      const { title } = bodyValidation.right;
-
-      const result = await updateConversationTitle(auth, {
-        conversationId: conversation.sId,
-        title,
-      });
-
-      if (result.isErr()) {
-        return apiErrorForConversation(req, res, result.error);
-      }
-
-      res.status(200).json({ conversation: result.value });
-      return;
-    }
+      break;
 
     default:
       return apiError(req, res, {

--- a/front/pages/api/w/[wId]/assistant/conversations/[cId]/index.ts
+++ b/front/pages/api/w/[wId]/assistant/conversations/[cId]/index.ts
@@ -7,7 +7,6 @@ import {
   deleteOrLeaveConversation,
   updateConversationTitle,
 } from "@app/lib/api/assistant/conversation";
-import { getConversation } from "@app/lib/api/assistant/conversation/fetch";
 import { apiErrorForConversation } from "@app/lib/api/assistant/conversation/helper";
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
 import type { Authenticator } from "@app/lib/auth";
@@ -122,7 +121,11 @@ async function handler(
           await ConversationResource.markAsRead(auth, {
             conversation,
           });
-          const result = await getConversation(auth, cId);
+          const result =
+            await ConversationResource.fetchConversationWithoutContent(
+              auth,
+              cId
+            );
           if (result.isErr()) {
             return apiErrorForConversation(req, res, result.error);
           }

--- a/front/temporal/agent_loop/activities/common.ts
+++ b/front/temporal/agent_loop/activities/common.ts
@@ -1,7 +1,11 @@
 import { publishConversationRelatedEvent } from "@app/lib/api/assistant/streaming/events";
 import type { AgentMessageEvents } from "@app/lib/api/assistant/streaming/types";
+import type { Authenticator } from "@app/lib/auth";
 import type { AgentMessage } from "@app/lib/models/assistant/conversation";
 import { AgentStepContentResource } from "@app/lib/resources/agent_step_content_resource";
+import { ConversationResource } from "@app/lib/resources/conversation_resource";
+import type { ConversationWithoutContentType } from "@app/types";
+import { assertNever } from "@app/types";
 
 // Process database operations for agent events before publishing to Redis.
 async function processEventForDatabase(
@@ -65,18 +69,51 @@ async function processEventForDatabase(
 }
 
 export async function updateResourceAndPublishEvent(
-  event: AgentMessageEvents,
-  agentMessageRow: AgentMessage,
+  auth: Authenticator,
   {
-    conversationId,
+    event,
+    agentMessageRow,
+    conversation,
     step,
   }: {
-    conversationId: string;
+    event: AgentMessageEvents;
+    agentMessageRow: AgentMessage;
+    conversation: ConversationWithoutContentType;
     step: number;
   }
 ): Promise<void> {
   // Process database operations BEFORE publishing to Redis.
   await processEventForDatabase(event, agentMessageRow, step);
 
-  await publishConversationRelatedEvent({ conversationId, event, step });
+  // If the agent message is not in a created status, we want to mark the conversation as unread for all participants.
+  switch (agentMessageRow.status) {
+    case "created":
+      // Do nothing.
+      break;
+    case "succeeded":
+    case "failed":
+    case "cancelled":
+      // No excluded user because the message is created by the agent.
+      await ConversationResource.markAsUnreadForOtherParticipants(auth, {
+        conversation,
+      });
+      await publishConversationRelatedEvent({
+        conversationId: conversation.sId,
+        event: {
+          type: "agent_message_done",
+          created: Date.now(),
+          configurationId: event.configurationId,
+          messageId: event.messageId,
+        },
+      });
+      break;
+    default:
+      assertNever(agentMessageRow.status);
+  }
+
+  await publishConversationRelatedEvent({
+    conversationId: conversation.sId,
+    event,
+    step,
+  });
 }

--- a/front/temporal/agent_loop/activities/run_tool.ts
+++ b/front/temporal/agent_loop/activities/run_tool.ts
@@ -84,8 +84,8 @@ export async function runToolActivity(
     switch (event.type) {
       case "tool_error":
         // For tool errors, send immediately.
-        await updateResourceAndPublishEvent(
-          {
+        await updateResourceAndPublishEvent(auth, {
+          event: {
             type: "tool_error",
             created: event.created,
             configurationId: agentConfiguration.sId,
@@ -99,11 +99,9 @@ export async function runToolActivity(
             isLastBlockingEventForStep: true,
           },
           agentMessageRow,
-          {
-            conversationId: conversation.sId,
-            step,
-          }
-        );
+          conversation,
+          step,
+        });
 
         return { deferredEvents };
 
@@ -128,8 +126,8 @@ export async function runToolActivity(
         return { deferredEvents };
 
       case "tool_success":
-        await updateResourceAndPublishEvent(
-          {
+        await updateResourceAndPublishEvent(auth, {
+          event: {
             type: "agent_action_success",
             created: event.created,
             configurationId: agentConfiguration.sId,
@@ -137,16 +135,16 @@ export async function runToolActivity(
             action: event.action,
           },
           agentMessageRow,
-          {
-            conversationId: conversation.sId,
-            step,
-          }
-        );
+          conversation,
+          step,
+        });
         break;
       case "tool_params":
       case "tool_notification":
-        await updateResourceAndPublishEvent(event, agentMessageRow, {
-          conversationId: conversation.sId,
+        await updateResourceAndPublishEvent(auth, {
+          event,
+          agentMessageRow,
+          conversation,
           step,
         });
         break;

--- a/front/types/assistant/agent.ts
+++ b/front/types/assistant/agent.ts
@@ -282,6 +282,14 @@ export type AgentErrorEvent = {
   error: GenericErrorContent;
 };
 
+// Generic event sent when an agent message is done (could be successful, failed, or cancelled).
+export type AgentMessageDoneEvent = {
+  type: "agent_message_done";
+  created: number;
+  configurationId: string;
+  messageId: string;
+};
+
 // Event sent when an error occurred during the tool call.
 export type ToolErrorEvent = {
   type: "tool_error";

--- a/front/types/assistant/conversation.ts
+++ b/front/types/assistant/conversation.ts
@@ -223,8 +223,8 @@ export type ConversationWithoutContentType = {
   id: ModelId;
   created: number;
   updated?: number;
-  unread?: boolean;
-  actionRequired?: boolean;
+  unread: boolean;
+  actionRequired: boolean;
   owner: WorkspaceType;
   sId: string;
   title: string | null;

--- a/sdks/js/src/types.ts
+++ b/sdks/js/src/types.ts
@@ -1745,6 +1745,14 @@ export type GetConversationResponseType = z.infer<
   typeof GetConversationResponseSchema
 >;
 
+export const PatchConversationRequestSchema = z.object({
+  read: z.literal(true),
+});
+
+export type PatchConversationRequestType = z.infer<
+  typeof PatchConversationRequestSchema
+>;
+
 export const TokenizeResponseSchema = z.object({
   tokens: CoreAPITokenTypeSchema.array(),
 });


### PR DESCRIPTION
## Description

Add support for unread status on conversations.
Made unread and actionRequired mandatory in the `ConversationWithoutContentType` so I had to get them in a few places.
Created a new event to let the client know when a agent message is done so it would refresh the conversation(s) and reflect the various state.
Added a hook that will auto mark as read after a small delay if needed.

## Tests

Local

## Risk

Medium as it adds a bit more http requests (2 when an agent message is done) and db requests (to fetch the states for the user).

## Deploy Plan

Deploy front