### PR TITLE
Fix failed slack workflow no channel found

### DIFF
--- a/connectors/src/connectors/slack/temporal/activities.ts
+++ b/connectors/src/connectors/slack/temporal/activities.ts
@@ -100,8 +100,10 @@ export async function syncChannel(
   const remoteChannel = await withSlackErrorHandling(() =>
     getChannelById(slackClient, connectorId, channelId)
   );
-  if (!remoteChannel.name) {
-    throw new Error(`Could not find channel name for channel ${channelId}`);
+  if (!remoteChannel || !remoteChannel.name) {
+    throw new Error(
+      `Could not find channel or channel name for channel ${channelId}`
+    );
   }
   const dataSourceConfig = dataSourceConfigFromConnector(connector);
 

--- a/connectors/src/connectors/slack/temporal/workflows.ts
+++ b/connectors/src/connectors/slack/temporal/workflows.ts
@@ -196,8 +196,10 @@ export async function syncOneThreadDebounced(
       connectorId,
       channelId
     );
-    if (!channel.name) {
-      throw new Error(`Could not find channel name for channel ${channelId}`);
+    if (!channel || !channel.name) {
+      throw new Error(
+        `Could not find channel or channel name for channel ${channelId}`
+      );
     }
 
     await getSlackActivities().syncChannelMetadata(
@@ -247,8 +249,10 @@ export async function syncOneMessageDebounced(
       connectorId,
       channelId
     );
-    if (!channel.name) {
-      throw new Error(`Could not find channel name for channel ${channelId}`);
+    if (!channel || !channel.name) {
+      throw new Error(
+        `Could not find channel or channel name for channel ${channelId}`
+      );
     }
     const messageTs = parseInt(threadTs, 10) * 1000;
     const startTsMs = getWeekStart(new Date(messageTs)).getTime();


### PR DESCRIPTION
## Description

Attempt to fix all the stuck workflows `slack-syncOneThreadDebounced`.
https://cloud.temporal.io/namespaces/eu-dust-prod.gmnlm/workflows/slack-syncOneThreadDebounced-5-C026PHHMF0X-1756130996.138999/3f044447-b30a-47b5-b44f-7bb9173c6456/history

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

Deploy connector. 
Technically nothing else to do -> if I get some non determinist error I'll bump the queue version and reset the workflows 🙏🏻 