### PR TITLE
Content creation retry

### DIFF
--- a/front/components/assistant/conversation/actions/VisualizationActionIframe.tsx
+++ b/front/components/assistant/conversation/actions/VisualizationActionIframe.tsx
@@ -301,8 +301,6 @@ export const VisualizationActionIframe = forwardRef<
     [codeFullyGenerated, iframeLoaded, isErrored]
   );
 
-  console.log("agentConfigurationId", agentConfigurationId);
-
   const handleVisualizationRetry = useVisualizationRetry({
     workspaceId: workspace?.sId ?? null,
     conversationId,

--- a/front/components/assistant/conversation/actions/VisualizationActionIframe.tsx
+++ b/front/components/assistant/conversation/actions/VisualizationActionIframe.tsx
@@ -5,7 +5,6 @@ import {
   ContentMessage,
   ExclamationCircleIcon,
   Markdown,
-  MarkdownContentContext,
   Sheet,
   SheetContainer,
   SheetContent,
@@ -17,7 +16,6 @@ import type { SetStateAction } from "react";
 import React, {
   forwardRef,
   useCallback,
-  useContext,
   useEffect,
   useMemo,
   useRef,
@@ -285,6 +283,11 @@ export const VisualizationActionIframe = forwardRef<
     visualization,
   } = props;
 
+  console.log("agentConfigurationId", agentConfigurationId);
+  console.log("conversationId", conversationId);
+  console.log("isPublic", isPublic);
+  console.log("workspace", props.workspace);
+
   useVisualizationDataHandler({
     visualization,
     workspaceId: isPublic ? null : props.workspace.sId,
@@ -302,25 +305,25 @@ export const VisualizationActionIframe = forwardRef<
     [codeFullyGenerated, iframeLoaded, isErrored]
   );
 
-  const handleVisualizationRetry = useVisualizationRetry({
+  const { handleVisualizationRetry, canRetry } = useVisualizationRetry({
     workspaceId: isPublic ? null : props.workspace.sId,
     conversationId,
     agentConfigurationId,
+    isPublic,
   });
 
   const handleRetryClick = useCallback(async () => {
     if (retryClicked || !errorMessage) {
       return;
     }
+
     setRetryClicked(true);
+
     const success = await handleVisualizationRetry(errorMessage);
     if (!success) {
       setRetryClicked(false);
     }
   }, [errorMessage, handleVisualizationRetry, retryClicked]);
-
-  const markdownContentContext = useContext(MarkdownContentContext);
-  const canRetry = !isPublic && markdownContentContext?.isLastMessage;
 
   return (
     <div className={cn("relative flex flex-col", isInDrawer && "h-full")}>
@@ -396,7 +399,7 @@ export const VisualizationActionIframe = forwardRef<
                       </div>
                     )}
 
-                    {canRetry && !retryClicked && (
+                    {canRetry && (
                       <div className="flex justify-center">
                         <Button
                           variant="outline"

--- a/front/components/assistant/conversation/actions/VisualizationActionIframe.tsx
+++ b/front/components/assistant/conversation/actions/VisualizationActionIframe.tsx
@@ -223,7 +223,7 @@ interface PublicVisualizationActionIframeProps {
 }
 
 // This interface represents the props for the VisualizationActionIframe component when it is used
-// in a legacy context.
+// in a conversation context.
 interface ConversationVisualizationActionIframeProps {
   agentConfigurationId: string;
   conversationId: string;

--- a/front/components/assistant/conversation/actions/VisualizationActionIframe.tsx
+++ b/front/components/assistant/conversation/actions/VisualizationActionIframe.tsx
@@ -320,8 +320,7 @@ export const VisualizationActionIframe = forwardRef<
   }, [errorMessage, handleVisualizationRetry, retryClicked]);
 
   const markdownContentContext = useContext(MarkdownContentContext);
-  const canRetry =
-    !isPublic || (markdownContentContext?.isLastMessage ?? false);
+  const canRetry = !isPublic && markdownContentContext?.isLastMessage;
 
   return (
     <div className={cn("relative flex flex-col", isInDrawer && "h-full")}>

--- a/front/components/assistant/conversation/actions/VisualizationActionIframe.tsx
+++ b/front/components/assistant/conversation/actions/VisualizationActionIframe.tsx
@@ -299,6 +299,8 @@ export const VisualizationActionIframe = forwardRef<
     [codeFullyGenerated, iframeLoaded, isErrored]
   );
 
+  console.log("agentConfigurationId", agentConfigurationId);
+
   const handleVisualizationRetry = useVisualizationRetry({
     workspaceId: workspace?.sId ?? null,
     conversationId,
@@ -316,7 +318,13 @@ export const VisualizationActionIframe = forwardRef<
     }
   }, [errorMessage, handleVisualizationRetry, retryClicked]);
 
-  const canRetry = useContext(MarkdownContentContext)?.isLastMessage ?? false;
+  const isContentCreationContext = Boolean(
+    conversationId || agentConfigurationId || workspace
+  );
+  const markdownContentContext = useContext(MarkdownContentContext);
+  const canRetry =
+    isContentCreationContext ||
+    (markdownContentContext?.isLastMessage ?? false);
 
   return (
     <div className={cn("relative flex flex-col", isInDrawer && "h-full")}>

--- a/front/components/assistant/conversation/actions/VisualizationActionIframe.tsx
+++ b/front/components/assistant/conversation/actions/VisualizationActionIframe.tsx
@@ -283,11 +283,6 @@ export const VisualizationActionIframe = forwardRef<
     visualization,
   } = props;
 
-  console.log("agentConfigurationId", agentConfigurationId);
-  console.log("conversationId", conversationId);
-  console.log("isPublic", isPublic);
-  console.log("workspace", props.workspace);
-
   useVisualizationDataHandler({
     visualization,
     workspaceId: isPublic ? null : props.workspace.sId,

--- a/front/components/assistant/conversation/actions/VisualizationActionIframe.tsx
+++ b/front/components/assistant/conversation/actions/VisualizationActionIframe.tsx
@@ -2,6 +2,8 @@ import {
   Button,
   cn,
   CodeBlock,
+  ContentMessage,
+  ExclamationCircleIcon,
   Markdown,
   MarkdownContentContext,
   Sheet,
@@ -383,22 +385,34 @@ export const VisualizationActionIframe = forwardRef<
                 </div>
               )}
               {isErrored && (
-                <div className="flex h-full w-full flex-col items-center gap-4 py-8">
-                  <div className="px-4 text-sm text-muted-foreground dark:text-muted-foreground-night">
-                    An error occured while rendering the visualization.
-                    <div className="pt-2 text-xs text-muted-foreground dark:text-muted-foreground-night">
-                      {errorMessage}
+                <div className="flex h-full w-full items-center justify-center p-6">
+                  <ContentMessage
+                    title="Visualization Error"
+                    variant="warning"
+                    icon={ExclamationCircleIcon}
+                    className="max-w-md text-center"
+                  >
+                    <div className="mb-4 text-sm">
+                      An error occurred while rendering the visualization.
                     </div>
-                  </div>
 
-                  {canRetry && !retryClicked && (
-                    <Button
-                      variant="outline"
-                      size="sm"
-                      label="Retry Visualization"
-                      onClick={handleRetryClick}
-                    />
-                  )}
+                    {errorMessage && (
+                      <div className="mb-4 rounded-md bg-warning-50 p-3 text-xs text-warning-900 dark:bg-warning-50-night dark:text-warning-900-night">
+                        {errorMessage}
+                      </div>
+                    )}
+
+                    {canRetry && !retryClicked && (
+                      <div className="flex justify-center">
+                        <Button
+                          variant="outline"
+                          size="sm"
+                          label="Retry Visualization"
+                          onClick={handleRetryClick}
+                        />
+                      </div>
+                    )}
+                  </ContentMessage>
                 </div>
               )}
             </div>

--- a/front/components/assistant/conversation/content_creation/ClientExecutableRenderer.tsx
+++ b/front/components/assistant/conversation/content_creation/ClientExecutableRenderer.tsx
@@ -223,7 +223,7 @@ export function ClientExecutableRenderer({
         ) : (
           <div className="h-full">
             <VisualizationActionIframe
-              agentConfigurationId={fileMetadata?.agentConfigurationId ?? null}
+              agentConfigurationId={fileMetadata?.agentConfigurationId ?? ""}
               workspace={owner}
               visualization={{
                 code: fileContent ?? "",

--- a/front/components/assistant/conversation/content_creation/ClientExecutableRenderer.tsx
+++ b/front/components/assistant/conversation/content_creation/ClientExecutableRenderer.tsx
@@ -223,7 +223,10 @@ export function ClientExecutableRenderer({
         ) : (
           <div className="h-full">
             <VisualizationActionIframe
-              agentConfigurationId={fileMetadata?.agentConfigurationId ?? ""}
+              agentConfigurationId={
+                fileMetadata?.useCaseMetadata
+                  .lastEditedByAgentConfigurationId ?? ""
+              }
               workspace={owner}
               visualization={{
                 code: fileContent ?? "",

--- a/front/components/assistant/conversation/content_creation/ClientExecutableRenderer.tsx
+++ b/front/components/assistant/conversation/content_creation/ClientExecutableRenderer.tsx
@@ -20,6 +20,7 @@ import { useDesktopNavigation } from "@app/components/navigation/DesktopNavigati
 import { useHashParam } from "@app/hooks/useHashParams";
 import { isFileUsingConversationFiles } from "@app/lib/files";
 import { useFileContent } from "@app/lib/swr/files";
+import { useFileMetadata } from "@app/lib/swr/files";
 import type {
   ConversationWithoutContentType,
   LightWorkspaceType,
@@ -89,6 +90,7 @@ export function ClientExecutableRenderer({
     fileId,
     owner,
   });
+  const { fileMetadata } = useFileMetadata({ fileId, owner });
 
   const isUsingConversationFiles = React.useMemo(
     () => (fileContent ? isFileUsingConversationFiles(fileContent) : false),
@@ -221,7 +223,7 @@ export function ClientExecutableRenderer({
         ) : (
           <div className="h-full">
             <VisualizationActionIframe
-              agentConfigurationId={null}
+              agentConfigurationId={fileMetadata?.agentConfigurationId ?? null}
               workspace={owner}
               visualization={{
                 code: fileContent ?? "",

--- a/front/lib/actions/mcp_internal_actions/servers/content_creation/index.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/content_creation/index.ts
@@ -89,7 +89,9 @@ const createServer = (
           );
         }
 
-        const { conversation } = agentLoopContext?.runContext ?? {};
+        const { conversation, agentConfiguration } =
+          agentLoopContext?.runContext ?? {};
+
         if (!conversation) {
           return new Err(
             new MCPError(
@@ -103,6 +105,7 @@ const createServer = (
           conversationId: conversation.sId,
           fileName: file_name,
           mimeType: mime_type,
+          agentConfigurationId: agentConfiguration?.sId,
         });
 
         if (result.isErr()) {

--- a/front/lib/actions/mcp_internal_actions/servers/content_creation/index.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/content_creation/index.ts
@@ -105,7 +105,7 @@ const createServer = (
           conversationId: conversation.sId,
           fileName: file_name,
           mimeType: mime_type,
-          agentConfigurationId: agentConfiguration?.sId,
+          createdByAgentConfigurationId: agentConfiguration?.sId,
         });
 
         if (result.isErr()) {
@@ -217,7 +217,7 @@ const createServer = (
           oldString: old_string,
           newString: new_string,
           expectedReplacements: expected_replacements,
-          agentConfigurationId: agentConfiguration?.sId,
+          editedByAgentConfigurationId: agentConfiguration?.sId,
         });
 
         if (result.isErr()) {

--- a/front/lib/actions/mcp_internal_actions/servers/content_creation/index.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/content_creation/index.ts
@@ -210,11 +210,14 @@ const createServer = (
         { file_id, old_string, new_string, expected_replacements },
         { sendNotification, _meta }
       ) => {
+        const { agentConfiguration } = agentLoopContext?.runContext ?? {};
+
         const result = await editClientExecutableFile(auth, {
           fileId: file_id,
           oldString: old_string,
           newString: new_string,
           expectedReplacements: expected_replacements,
+          agentConfigurationId: agentConfiguration?.sId,
         });
 
         if (result.isErr()) {

--- a/front/lib/api/files/client_executable.ts
+++ b/front/lib/api/files/client_executable.ts
@@ -2,7 +2,11 @@ import { getFileContent } from "@app/lib/api/files/utils";
 import type { Authenticator } from "@app/lib/auth";
 import { FileResource } from "@app/lib/resources/file_resource";
 import logger from "@app/logger/logger";
-import type { ContentCreationFileContentType, Result } from "@app/types";
+import type {
+  ContentCreationFileContentType,
+  FileUseCaseMetadata,
+  Result,
+} from "@app/types";
 import {
   clientExecutableContentType,
   CONTENT_CREATION_FILE_FORMATS,
@@ -69,6 +73,22 @@ export async function createClientExecutableFile(
       );
     }
 
+    const createUseCaseMetadata = (
+      conversationId: string,
+      createdByAgentConfigurationId?: string
+    ): FileUseCaseMetadata => {
+      const metadata: FileUseCaseMetadata = {
+        conversationId,
+      };
+
+      if (createdByAgentConfigurationId) {
+        metadata.lastEditedByAgentConfigurationId =
+          createdByAgentConfigurationId;
+      }
+
+      return metadata;
+    };
+
     // Create the file resource.
     const fileResource = await FileResource.makeNew({
       workspaceId: workspace.id,
@@ -77,12 +97,10 @@ export async function createClientExecutableFile(
       fileSize: 0, // Will be updated in uploadContent.
       // Attach the conversation id so we can use it to control access to the file.
       useCase: "conversation",
-      useCaseMetadata: {
+      useCaseMetadata: createUseCaseMetadata(
         conversationId,
-        ...(createdByAgentConfigurationId
-          ? { lastEditedByAgentConfigurationId: createdByAgentConfigurationId }
-          : {}),
-      },
+        createdByAgentConfigurationId
+      ),
     });
 
     // Upload content directly.

--- a/front/lib/api/files/client_executable.ts
+++ b/front/lib/api/files/client_executable.ts
@@ -18,11 +18,16 @@ export async function createClientExecutableFile(
     conversationId: string;
     fileName: string;
     mimeType: ContentCreationFileContentType;
-    agentConfigurationId?: string;
+    createdByAgentConfigurationId?: string;
   }
 ): Promise<Result<FileResource, Error>> {
-  const { content, conversationId, fileName, mimeType, agentConfigurationId } =
-    params;
+  const {
+    content,
+    conversationId,
+    fileName,
+    mimeType,
+    createdByAgentConfigurationId,
+  } = params;
 
   try {
     const workspace = auth.getNonNullableWorkspace();
@@ -74,7 +79,9 @@ export async function createClientExecutableFile(
       useCase: "conversation",
       useCaseMetadata: {
         conversationId,
-        ...(agentConfigurationId ? { agentConfigurationId } : {}),
+        ...(createdByAgentConfigurationId
+          ? { createdByAgentConfigurationId }
+          : {}),
       },
     });
 
@@ -109,7 +116,7 @@ export async function editClientExecutableFile(
     oldString: string;
     newString: string;
     expectedReplacements?: number;
-    agentConfigurationId?: string;
+    editedByAgentConfigurationId?: string;
   }
 ): Promise<
   Result<{ fileResource: FileResource; replacementCount: number }, Error>
@@ -119,7 +126,7 @@ export async function editClientExecutableFile(
     oldString,
     newString,
     expectedReplacements = 1,
-    agentConfigurationId,
+    editedByAgentConfigurationId,
   } = params;
 
   // Fetch the existing file.
@@ -150,12 +157,13 @@ export async function editClientExecutableFile(
   }
 
   if (
-    agentConfigurationId &&
-    fileResource.useCaseMetadata?.agentConfigurationId !== agentConfigurationId
+    editedByAgentConfigurationId &&
+    fileResource.useCaseMetadata?.agentConfigurationId !==
+      editedByAgentConfigurationId
   ) {
     await fileResource.setUseCaseMetadata({
       ...fileResource.useCaseMetadata,
-      agentConfigurationId,
+      agentConfigurationId: editedByAgentConfigurationId,
     });
   }
 

--- a/front/lib/api/files/client_executable.ts
+++ b/front/lib/api/files/client_executable.ts
@@ -2,11 +2,7 @@ import { getFileContent } from "@app/lib/api/files/utils";
 import type { Authenticator } from "@app/lib/auth";
 import { FileResource } from "@app/lib/resources/file_resource";
 import logger from "@app/logger/logger";
-import type {
-  ContentCreationFileContentType,
-  FileUseCaseMetadata,
-  Result,
-} from "@app/types";
+import type { ContentCreationFileContentType, Result } from "@app/types";
 import {
   clientExecutableContentType,
   CONTENT_CREATION_FILE_FORMATS,
@@ -73,22 +69,6 @@ export async function createClientExecutableFile(
       );
     }
 
-    const createUseCaseMetadata = (
-      conversationId: string,
-      createdByAgentConfigurationId?: string
-    ): FileUseCaseMetadata => {
-      const metadata: FileUseCaseMetadata = {
-        conversationId,
-      };
-
-      if (createdByAgentConfigurationId) {
-        metadata.lastEditedByAgentConfigurationId =
-          createdByAgentConfigurationId;
-      }
-
-      return metadata;
-    };
-
     // Create the file resource.
     const fileResource = await FileResource.makeNew({
       workspaceId: workspace.id,
@@ -97,10 +77,10 @@ export async function createClientExecutableFile(
       fileSize: 0, // Will be updated in uploadContent.
       // Attach the conversation id so we can use it to control access to the file.
       useCase: "conversation",
-      useCaseMetadata: createUseCaseMetadata(
+      useCaseMetadata: {
         conversationId,
-        createdByAgentConfigurationId
-      ),
+        lastEditedByAgentConfigurationId: createdByAgentConfigurationId,
+      },
     });
 
     // Upload content directly.

--- a/front/lib/api/files/client_executable.ts
+++ b/front/lib/api/files/client_executable.ts
@@ -149,7 +149,10 @@ export async function editClientExecutableFile(
     );
   }
 
-  if (agentConfigurationId && fileResource.useCaseMetadata) {
+  if (
+    agentConfigurationId &&
+    fileResource.useCaseMetadata?.agentConfigurationId !== agentConfigurationId
+  ) {
     await fileResource.setUseCaseMetadata({
       ...fileResource.useCaseMetadata,
       agentConfigurationId,

--- a/front/lib/api/files/client_executable.ts
+++ b/front/lib/api/files/client_executable.ts
@@ -18,9 +18,11 @@ export async function createClientExecutableFile(
     conversationId: string;
     fileName: string;
     mimeType: ContentCreationFileContentType;
+    agentConfigurationId?: string;
   }
 ): Promise<Result<FileResource, Error>> {
-  const { content, conversationId, fileName, mimeType } = params;
+  const { content, conversationId, fileName, mimeType, agentConfigurationId } =
+    params;
 
   try {
     const workspace = auth.getNonNullableWorkspace();
@@ -72,6 +74,7 @@ export async function createClientExecutableFile(
       useCase: "conversation",
       useCaseMetadata: {
         conversationId,
+        ...(agentConfigurationId ? { agentConfigurationId } : {}),
       },
     });
 

--- a/front/lib/api/files/client_executable.ts
+++ b/front/lib/api/files/client_executable.ts
@@ -80,7 +80,7 @@ export async function createClientExecutableFile(
       useCaseMetadata: {
         conversationId,
         ...(createdByAgentConfigurationId
-          ? { createdByAgentConfigurationId }
+          ? { lastEditedByAgentConfigurationId: createdByAgentConfigurationId }
           : {}),
       },
     });
@@ -158,12 +158,12 @@ export async function editClientExecutableFile(
 
   if (
     editedByAgentConfigurationId &&
-    fileResource.useCaseMetadata?.agentConfigurationId !==
+    fileResource.useCaseMetadata?.lastEditedByAgentConfigurationId !==
       editedByAgentConfigurationId
   ) {
     await fileResource.setUseCaseMetadata({
       ...fileResource.useCaseMetadata,
-      agentConfigurationId: editedByAgentConfigurationId,
+      lastEditedByAgentConfigurationId: editedByAgentConfigurationId,
     });
   }
 

--- a/front/lib/api/files/client_executable.ts
+++ b/front/lib/api/files/client_executable.ts
@@ -109,11 +109,18 @@ export async function editClientExecutableFile(
     oldString: string;
     newString: string;
     expectedReplacements?: number;
+    agentConfigurationId?: string;
   }
 ): Promise<
   Result<{ fileResource: FileResource; replacementCount: number }, Error>
 > {
-  const { fileId, oldString, newString, expectedReplacements = 1 } = params;
+  const {
+    fileId,
+    oldString,
+    newString,
+    expectedReplacements = 1,
+    agentConfigurationId,
+  } = params;
 
   // Fetch the existing file.
   const fileContentResult = await getClientExecutableFileContent(auth, fileId);
@@ -140,6 +147,13 @@ export async function editClientExecutableFile(
         `Expected ${expectedReplacements} replacements, but found ${occurrences} occurrences`
       )
     );
+  }
+
+  if (agentConfigurationId && fileResource.useCaseMetadata) {
+    await fileResource.setUseCaseMetadata({
+      ...fileResource.useCaseMetadata,
+      agentConfigurationId,
+    });
   }
 
   // Perform the replacement.

--- a/front/lib/resources/file_resource.ts
+++ b/front/lib/resources/file_resource.ts
@@ -568,13 +568,6 @@ export class FileResource extends BaseResource<FileModel> {
   // Serialization logic.
 
   toJSON(auth?: Authenticator): FileType {
-    const extraMetadata = this.useCaseMetadata?.lastEditedByAgentConfigurationId
-      ? {
-          lastEditedByAgentConfigurationId:
-            this.useCaseMetadata.lastEditedByAgentConfigurationId,
-        }
-      : {};
-
     const blob: FileType = {
       // TODO(spolu): move this to ModelId
       id: this.sId,
@@ -584,7 +577,6 @@ export class FileResource extends BaseResource<FileModel> {
       fileSize: this.fileSize,
       status: this.status,
       useCase: this.useCase,
-      ...extraMetadata,
     };
 
     if (auth && this.isReady && !this.isUpsertUseCase()) {

--- a/front/lib/resources/file_resource.ts
+++ b/front/lib/resources/file_resource.ts
@@ -568,6 +568,10 @@ export class FileResource extends BaseResource<FileModel> {
   // Serialization logic.
 
   toJSON(auth?: Authenticator): FileType {
+    const extraMetadata = this.useCaseMetadata?.agentConfigurationId
+      ? { agentConfigurationId: this.useCaseMetadata.agentConfigurationId }
+      : {};
+
     const blob: FileType = {
       // TODO(spolu): move this to ModelId
       id: this.sId,
@@ -577,6 +581,7 @@ export class FileResource extends BaseResource<FileModel> {
       fileSize: this.fileSize,
       status: this.status,
       useCase: this.useCase,
+      ...extraMetadata,
     };
 
     if (auth && this.isReady && !this.isUpsertUseCase()) {

--- a/front/lib/resources/file_resource.ts
+++ b/front/lib/resources/file_resource.ts
@@ -568,8 +568,11 @@ export class FileResource extends BaseResource<FileModel> {
   // Serialization logic.
 
   toJSON(auth?: Authenticator): FileType {
-    const extraMetadata = this.useCaseMetadata?.agentConfigurationId
-      ? { agentConfigurationId: this.useCaseMetadata.agentConfigurationId }
+    const extraMetadata = this.useCaseMetadata?.lastEditedByAgentConfigurationId
+      ? {
+          lastEditedByAgentConfigurationId:
+            this.useCaseMetadata.lastEditedByAgentConfigurationId,
+        }
       : {};
 
     const blob: FileType = {

--- a/front/lib/resources/file_resource.ts
+++ b/front/lib/resources/file_resource.ts
@@ -25,6 +25,7 @@ import { renderLightWorkspaceType } from "@app/lib/workspace";
 import type {
   FileShareScope,
   FileType,
+  FileTypeWithMetadata,
   FileTypeWithUploadUrl,
   FileUseCaseMetadata,
   LightWorkspaceType,
@@ -596,6 +597,15 @@ export class FileResource extends BaseResource<FileModel> {
     return {
       ...blob,
       uploadUrl: this.getPrivateUrl(auth),
+    };
+  }
+
+  toJSONWithMetadata(auth: Authenticator): FileTypeWithMetadata {
+    const blob = this.toJSON(auth);
+
+    return {
+      ...blob,
+      useCaseMetadata: this.useCaseMetadata ?? {},
     };
   }
 

--- a/front/lib/swr/conversations.ts
+++ b/front/lib/swr/conversations.ts
@@ -366,14 +366,18 @@ export function useVisualizationRetry({
   workspaceId,
   conversationId,
   agentConfigurationId,
+  isPublic,
 }: {
   workspaceId: string | null;
   conversationId: string | null;
   agentConfigurationId: string | null;
+  isPublic: boolean;
 }) {
+  const canRetry = !isPublic && agentConfigurationId && conversationId;
+
   const handleVisualizationRetry = useCallback(
-    async (errorMessage: string) => {
-      if (!conversationId || !agentConfigurationId) {
+    async (errorMessage: string): Promise<boolean> => {
+      if (!canRetry) {
         return false;
       }
 
@@ -410,16 +414,13 @@ export function useVisualizationRetry({
         return false;
       }
     },
-    [workspaceId, conversationId, agentConfigurationId]
+    [workspaceId, conversationId, agentConfigurationId, canRetry]
   );
 
-  if (!agentConfigurationId) {
-    return () => {
-      return false;
-    };
-  }
-
-  return handleVisualizationRetry;
+  return {
+    handleVisualizationRetry,
+    canRetry,
+  };
 }
 
 export function useConversationMessage({

--- a/front/lib/swr/files.ts
+++ b/front/lib/swr/files.ts
@@ -1,4 +1,3 @@
-import type { FileType } from "@dust-tt/client";
 import type { Fetcher, SWRConfiguration } from "swr";
 
 import { useSendNotification } from "@app/hooks/useNotification";
@@ -17,6 +16,7 @@ import type { ShareFileResponseBody } from "@app/pages/api/w/[wId]/files/[fileId
 import type {
   DataSourceViewType,
   FileShareScope,
+  FileTypeWithMetadata,
   LightWorkspaceType,
 } from "@app/types";
 
@@ -121,11 +121,6 @@ export function useUpsertFileAsDatasourceEntry(
   return doCreate;
 }
 
-type FileWithMetadataType = FileType & {
-  conversationId?: string;
-  agentConfigurationId?: string;
-};
-
 export function useFileMetadata({
   fileId,
   owner,
@@ -135,7 +130,7 @@ export function useFileMetadata({
   owner: LightWorkspaceType;
   cacheKey?: string | null;
 }) {
-  const fileMetadataFetcher: Fetcher<FileWithMetadataType> = fetcher;
+  const fileMetadataFetcher: Fetcher<FileTypeWithMetadata> = fetcher;
 
   // Include cacheKey in the SWR key if provided to force cache invalidation.
   const swrKey = fileId

--- a/front/lib/swr/files.ts
+++ b/front/lib/swr/files.ts
@@ -121,6 +121,10 @@ export function useUpsertFileAsDatasourceEntry(
   return doCreate;
 }
 
+type InternalFileMetadata = FileType & {
+  agentConfigurationId?: string;
+};
+
 export function useFileMetadata({
   fileId,
   owner,
@@ -130,7 +134,8 @@ export function useFileMetadata({
   owner: LightWorkspaceType;
   cacheKey?: string | null;
 }) {
-  const fileMetadataFetcher: Fetcher<FileType> = fetcher;
+  // Internally, our metadata may include extra fields not present in the public client type.
+  const fileMetadataFetcher: Fetcher<InternalFileMetadata> = fetcher;
 
   // Include cacheKey in the SWR key if provided to force cache invalidation.
   const swrKey = fileId

--- a/front/lib/swr/files.ts
+++ b/front/lib/swr/files.ts
@@ -121,7 +121,7 @@ export function useUpsertFileAsDatasourceEntry(
   return doCreate;
 }
 
-type InternalFileMetadata = FileType & {
+type FileWithMetadataType = FileType & {
   conversationId?: string;
   agentConfigurationId?: string;
 };
@@ -135,7 +135,7 @@ export function useFileMetadata({
   owner: LightWorkspaceType;
   cacheKey?: string | null;
 }) {
-  const fileMetadataFetcher: Fetcher<InternalFileMetadata> = fetcher;
+  const fileMetadataFetcher: Fetcher<FileWithMetadataType> = fetcher;
 
   // Include cacheKey in the SWR key if provided to force cache invalidation.
   const swrKey = fileId

--- a/front/lib/swr/files.ts
+++ b/front/lib/swr/files.ts
@@ -122,6 +122,7 @@ export function useUpsertFileAsDatasourceEntry(
 }
 
 type InternalFileMetadata = FileType & {
+  conversationId?: string;
   agentConfigurationId?: string;
 };
 
@@ -134,7 +135,6 @@ export function useFileMetadata({
   owner: LightWorkspaceType;
   cacheKey?: string | null;
 }) {
-  // Internally, our metadata may include extra fields not present in the public client type.
   const fileMetadataFetcher: Fetcher<InternalFileMetadata> = fetcher;
 
   // Include cacheKey in the SWR key if provided to force cache invalidation.

--- a/front/next.config.js
+++ b/front/next.config.js
@@ -1,10 +1,7 @@
 const path = require("path");
-const { destination } = require("pino");
-
-const showReactScan =
-  process.env.NODE_ENV === "development" && process.env.REACT_SCAN === "true";
 
 const isDev = process.env.NODE_ENV === "development";
+const showReactScan = isDev && process.env.REACT_SCAN === "true";
 
 const CONTENT_SECURITY_POLICIES = [
   "default-src 'none';",
@@ -14,7 +11,7 @@ const CONTENT_SECURITY_POLICIES = [
   `style-src-elem 'self' 'unsafe-inline' *.fontawesome.com *.googleapis.com *.gstatic.com;`,
   `img-src 'self' data: blob: webkit-fake-url: https:;`,
   `connect-src 'self' blob: dust.tt *.dust.tt https://dust.tt https://*.dust.tt browser-intake-datadoghq.eu *.google-analytics.com *.googlesyndication.com *.googleadservices.com cdn.jsdelivr.net *.hsforms.com *.hscollectedforms.net *.hubspot.com *.hubapi.com *.cr-relay.com *.usercentrics.eu *.ads.linkedin.com px.ads.linkedin.com google.com *.google.com *.workos.com translate-pa.googleapis.com;`,
-  `frame-src 'self' *.wistia.net eu.viz.dust.tt viz.dust.tt *.hsforms.net *.googletagmanager.com *.doubleclick.net *.hsforms.com;`,
+  `frame-src 'self' *.wistia.net eu.viz.dust.tt viz.dust.tt *.hsforms.net *.googletagmanager.com *.doubleclick.net *.hsforms.com ${isDev ? "http://localhost:3007" : ""};`,
   `font-src 'self' data: dust.tt *.dust.tt https://dust.tt https://*.dust.tt *.gstatic.com *.wistia.net fonts.cdnfonts.com migaku-public-data.migaku.com;`,
   `media-src 'self' data:;`,
   `object-src 'none';`,

--- a/front/next.config.js
+++ b/front/next.config.js
@@ -11,7 +11,7 @@ const CONTENT_SECURITY_POLICIES = [
   `style-src-elem 'self' 'unsafe-inline' *.fontawesome.com *.googleapis.com *.gstatic.com;`,
   `img-src 'self' data: blob: webkit-fake-url: https:;`,
   `connect-src 'self' blob: dust.tt *.dust.tt https://dust.tt https://*.dust.tt browser-intake-datadoghq.eu *.google-analytics.com *.googlesyndication.com *.googleadservices.com cdn.jsdelivr.net *.hsforms.com *.hscollectedforms.net *.hubspot.com *.hubapi.com *.cr-relay.com *.usercentrics.eu *.ads.linkedin.com px.ads.linkedin.com google.com *.google.com *.workos.com translate-pa.googleapis.com;`,
-  `frame-src 'self' *.wistia.net eu.viz.dust.tt viz.dust.tt *.hsforms.net *.googletagmanager.com *.doubleclick.net *.hsforms.com ${isDev ? "http://localhost:3007" : ""};`,
+  `frame-src 'self' *.wistia.net eu.viz.dust.tt viz.dust.tt *.hsforms.net *.googletagmanager.com *.doubleclick.net *.hsforms.com${isDev ? " http://localhost:3007" : ""};`,
   `font-src 'self' data: dust.tt *.dust.tt https://dust.tt https://*.dust.tt *.gstatic.com *.wistia.net fonts.cdnfonts.com migaku-public-data.migaku.com;`,
   `media-src 'self' data:;`,
   `object-src 'none';`,

--- a/front/pages/api/w/[wId]/files/[fileId]/metadata.ts
+++ b/front/pages/api/w/[wId]/files/[fileId]/metadata.ts
@@ -82,7 +82,7 @@ async function handler(
     }
   }
 
-  return res.status(200).json(fileResource.toJSON(auth));
+  return res.status(200).json(fileResource.toJSONWithMetadata(auth));
 }
 
 export default withSessionAuthenticationForWorkspace(handler);

--- a/front/types/files.ts
+++ b/front/types/files.ts
@@ -55,6 +55,10 @@ export interface FileType {
 
 export type FileTypeWithUploadUrl = FileType & { uploadUrl: string };
 
+export type FileTypeWithMetadata = FileType & {
+  useCaseMetadata: FileUseCaseMetadata;
+};
+
 export type FileFormatCategory = "image" | "data" | "code" | "delimited";
 
 // Define max sizes for each category.

--- a/front/types/files.ts
+++ b/front/types/files.ts
@@ -36,6 +36,7 @@ export const fileShareScopeSchema = z.enum([
   "workspace",
   "public",
 ]);
+
 export type FileShareScope = z.infer<typeof fileShareScopeSchema>;
 
 export interface FileType {

--- a/front/types/files.ts
+++ b/front/types/files.ts
@@ -51,7 +51,6 @@ export interface FileType {
   uploadUrl?: string;
   publicUrl?: string;
   useCase: FileUseCase;
-  lastEditedByAgentConfigurationId?: string;
 }
 
 export type FileTypeWithUploadUrl = FileType & { uploadUrl: string };

--- a/front/types/files.ts
+++ b/front/types/files.ts
@@ -28,6 +28,7 @@ export type FileUseCaseMetadata = {
   conversationId?: string;
   spaceId?: string;
   generatedTables?: string[];
+  agentConfigurationId?: string;
 };
 
 export const fileShareScopeSchema = z.enum([
@@ -49,6 +50,7 @@ export interface FileType {
   uploadUrl?: string;
   publicUrl?: string;
   useCase: FileUseCase;
+  agentConfigurationId?: string;
 }
 
 export type FileTypeWithUploadUrl = FileType & { uploadUrl: string };

--- a/front/types/files.ts
+++ b/front/types/files.ts
@@ -28,7 +28,7 @@ export type FileUseCaseMetadata = {
   conversationId?: string;
   spaceId?: string;
   generatedTables?: string[];
-  agentConfigurationId?: string;
+  lastEditedByAgentConfigurationId?: string;
 };
 
 export const fileShareScopeSchema = z.enum([
@@ -50,7 +50,7 @@ export interface FileType {
   uploadUrl?: string;
   publicUrl?: string;
   useCase: FileUseCase;
-  agentConfigurationId?: string;
+  lastEditedByAgentConfigurationId?: string;
 }
 
 export type FileTypeWithUploadUrl = FileType & { uploadUrl: string };

--- a/viz/app/components/VisualizationWrapper.tsx
+++ b/viz/app/components/VisualizationWrapper.tsx
@@ -450,23 +450,6 @@ export function VisualizationWrapper({
     return <Spinner />;
   }
 
-  // Test error trigger for demonstration
-  const triggerTestError = () => {
-    // Simulate a realistic content generation error that could happen
-    const testError =
-      Math.random() > 0.5
-        ? new Error(
-            "Test error from visualization wrapper: This simulates a content generation error!"
-          )
-        : new Error(
-            "Forbidden Tailwind arbitrary values detected: h-[600px], w-[800px]. Arbitrary values like h-[600px], w-[800px], bg-[#ff0000] are not allowed. Use predefined classes like h-96, w-full, bg-red-500 instead, or use the style prop for specific values."
-          );
-
-    // Communicate the error to parent frame before throwing
-    communicateErrorToParent(testError);
-    throw testError;
-  };
-
   return (
     <div
       className={`relative font-sans group/viz ${
@@ -511,51 +494,6 @@ export function VisualizationWrapper({
             }
           }}
         />
-      </div>
-
-      {/* Test Error Section - Always Visible for Testing */}
-      <div className="mt-6 p-4 bg-gray-50 dark:bg-gray-900 rounded-lg border border-gray-200 dark:border-gray-700">
-        <h3 className="text-sm font-medium text-gray-900 dark:text-gray-100 mb-3">
-          🧪 Test Error Boundary System
-        </h3>
-        <p className="text-xs text-gray-600 dark:text-gray-400 mb-3">
-          Click these buttons to test different error scenarios and see the
-          error boundary in action:
-        </p>
-        <div className="flex flex-wrap gap-2">
-          <button
-            onClick={triggerTestError}
-            className="px-3 py-2 text-xs font-medium rounded-md border border-red-300 text-red-600 bg-red-50 hover:bg-red-100 transition-colors"
-          >
-            🧪 Test Error Boundary
-          </button>
-          <button
-            onClick={() => {
-              // Simulate a content generation error that would be caught by the Runner
-              const error = new Error(
-                "Simulated Runner rendering error: This simulates an error during content generation!"
-              );
-              setErrorMessage(error);
-              communicateErrorToParent(error);
-            }}
-            className="px-3 py-2 text-xs font-medium rounded-md border border-orange-300 text-orange-600 bg-orange-50 hover:bg-orange-100 transition-colors"
-          >
-            🎭 Runner Error
-          </button>
-          <button
-            onClick={() => {
-              // Simulate a realistic Tailwind validation error
-              const error = new Error(
-                "Forbidden Tailwind arbitrary values detected: h-[600px], w-[800px]. Arbitrary values like h-[600px], w-[800px], bg-[#ff0000] are not allowed. Use predefined classes like h-96, w-full, bg-red-500 instead, or use the style prop for specific values."
-              );
-              setErrorMessage(error);
-              communicateErrorToParent(error);
-            }}
-            className="px-3 py-2 text-xs font-medium rounded-md border border-purple-300 text-purple-600 bg-purple-50 hover:bg-purple-100 transition-colors"
-          >
-            🎨 Tailwind Error
-          </button>
-        </div>
       </div>
     </div>
   );

--- a/viz/app/components/VisualizationWrapper.tsx
+++ b/viz/app/components/VisualizationWrapper.tsx
@@ -287,28 +287,6 @@ export function VisualizationWrapper({
 
   const [errored, setErrorMessage] = useState<Error | null>(null);
 
-  // Function to communicate errors to parent frame
-  const communicateErrorToParent = useCallback(
-    (error: Error | string) => {
-      const errorMessage = error instanceof Error ? error.message : error;
-      console.error("Content generation error:", errorMessage);
-
-      // Send error message to parent frame for better error handling
-      window.top?.postMessage(
-        {
-          command: "setErrorMessage",
-          messageUniqueId: Date.now().toString(),
-          identifier: identifier,
-          params: {
-            errorMessage: errorMessage,
-          },
-        },
-        "*"
-      );
-    },
-    [identifier]
-  );
-
   const {
     fetchCode,
     fetchFile,
@@ -420,7 +398,7 @@ export function VisualizationWrapper({
     if (error) {
       setErrorMessage(error);
     }
-  }, [error, communicateErrorToParent]);
+  }, [error]);
 
   // Add message listeners for export requests.
   useEffect(() => {
@@ -488,7 +466,6 @@ export function VisualizationWrapper({
           onRendered={(error) => {
             if (error) {
               setErrorMessage(error);
-              communicateErrorToParent(error);
             }
           }}
         />

--- a/viz/app/components/VisualizationWrapper.tsx
+++ b/viz/app/components/VisualizationWrapper.tsx
@@ -487,8 +487,6 @@ export function VisualizationWrapper({
           scope={runnerParams.scope}
           onRendered={(error) => {
             if (error) {
-              // This catches content generation errors from the Runner component
-              console.error("Content generation error:", error);
               setErrorMessage(error);
               communicateErrorToParent(error);
             }


### PR DESCRIPTION
## Description

- https://github.com/dust-tt/tasks/issues/3967
- Allow users to retry a content generation if it failed to render
- Add `agentConfigurationId` to useCaseMetadata
- Improve style of Error Boundary

## Tests

Locally

https://github.com/user-attachments/assets/26845285-823e-44d9-9cd0-8b9de2b81ef8

## Risk

Potential risks contained to visualisation. Low risk overall.

## Deploy Plan

Deploy front
