### PR TITLE
Blocked action provider - Better logic

### DIFF
--- a/front/components/assistant/conversation/BlockedActionsProvider.tsx
+++ b/front/components/assistant/conversation/BlockedActionsProvider.tsx
@@ -153,6 +153,7 @@ export function BlockedActionsProvider({
     );
   }, [blockedActionsQueue]);
 
+  // TODO: support "auth" step
   const [currentStep, setCurrentStep] = useState<"validation">("validation");
 
   const [currentValidationIndex, setCurrentValidationIndex] = useState(0);
@@ -178,6 +179,11 @@ export function BlockedActionsProvider({
     setSubmitStatus(status);
 
     const currentBlockedAction = pendingValidations[currentValidationIndex];
+    if (!currentBlockedAction) {
+      setErrorMessage("No blocked action found. Please try again.");
+      return;
+    }
+
     const { blockedAction, message } = currentBlockedAction;
 
     const result = await validateAction({

--- a/front/components/assistant/conversation/BlockedActionsProvider.tsx
+++ b/front/components/assistant/conversation/BlockedActionsProvider.tsx
@@ -14,7 +14,6 @@ import {
   useState,
 } from "react";
 
-import { AuthenticationDialogPage } from "@app/components/assistant/conversation/blocked_actions/AuthentificationDialogPage";
 import { ToolValidationDialogPage } from "@app/components/assistant/conversation/blocked_actions/ToolValidationDialogPage";
 import { useNavigationLock } from "@app/components/assistant_builder/useNavigationLock";
 import { useValidateAction } from "@app/hooks/useValidateAction";
@@ -22,7 +21,6 @@ import type { MCPValidationOutputType } from "@app/lib/actions/constants";
 import type { BlockedToolExecution } from "@app/lib/actions/mcp";
 import { getIcon } from "@app/lib/actions/mcp_icons";
 import { useBlockedActions } from "@app/lib/swr/blocked_actions";
-import { useCreatePersonalConnection } from "@app/lib/swr/mcp_servers";
 import type {
   ConversationWithoutContentType,
   LightAgentMessageType,
@@ -35,10 +33,6 @@ type BlockedActionQueueItem = {
 };
 
 const EMPTY_BLOCKED_ACTIONS_QUEUE: BlockedActionQueueItem[] = [];
-
-type AuthenticationRequiredBlockedAction = BlockedToolExecution & {
-  status: "blocked_authentication_required";
-};
 
 function useBlockedActionsQueue({
   blockedActions,
@@ -156,16 +150,7 @@ export function BlockedActionsProvider({
     );
   }, [blockedActionsQueue]);
 
-  const pendingAuthorizations = useMemo(() => {
-    return blockedActionsQueue.filter(
-      (action) =>
-        action.blockedAction.status === "blocked_authentication_required"
-    );
-  }, [blockedActionsQueue]);
-
-  const [currentStep, setCurrentStep] = useState<"auth" | "validation">(
-    "validation"
-  );
+  const [currentStep, setCurrentStep] = useState<"validation">("validation");
 
   const [currentValidationIndex, setCurrentValidationIndex] = useState(0);
 
@@ -178,64 +163,13 @@ export function BlockedActionsProvider({
 
   const [isDialogOpen, setIsDialogOpen] = useState(false);
 
-  // Track connection states for authentication actions
-  const [connectionStates, setConnectionStates] = useState<
-    Record<string, "connecting" | "connected" | "idle">
-  >({});
-
   const { validateAction, isValidating } = useValidateAction({
     owner,
     conversation,
     onError: setErrorMessage,
   });
 
-  const { createPersonalConnection } = useCreatePersonalConnection(owner);
-
   useNavigationLock(isDialogOpen);
-
-  const handleRetry = useCallback(async () => {
-    if (!conversationId) {
-      return;
-    }
-
-    const firstMessage =
-      pendingValidations[0]?.message || pendingAuthorizations[0]?.message;
-    if (!firstMessage) {
-      return;
-    }
-
-    try {
-      await fetch(
-        `/api/w/${owner.sId}/assistant/conversations/${conversationId}/messages/${firstMessage.sId}/retry?blocked_only=true`,
-        {
-          method: "POST",
-          headers: {
-            "Content-Type": "application/json",
-          },
-        }
-      );
-
-      pendingValidations.forEach((item) => {
-        removeCompletedAction(item.blockedAction.actionId);
-      });
-
-      pendingAuthorizations.forEach((item) => {
-        removeCompletedAction(item.blockedAction.actionId);
-      });
-
-      setIsDialogOpen(false);
-      setCurrentStep("validation");
-      setCurrentValidationIndex(0);
-    } catch (error) {
-      setErrorMessage("Failed to resume conversation. Please try again.");
-    }
-  }, [
-    conversationId,
-    pendingValidations,
-    pendingAuthorizations,
-    owner.sId,
-    removeCompletedAction,
-  ]);
 
   useEffect(() => {
     // Close the dialog when there are no more blocked actions
@@ -245,34 +179,6 @@ export function BlockedActionsProvider({
       setCurrentValidationIndex(0);
     }
   }, [blockedActionsQueue.length, isDialogOpen, isValidating]);
-
-  useEffect(() => {
-    if (
-      pendingAuthorizations.length > 0 &&
-      Object.values(connectionStates).every((state) => state === "connected")
-    ) {
-      void handleRetry();
-    }
-  }, [connectionStates, pendingAuthorizations.length, handleRetry]);
-
-  useEffect(() => {
-    if (
-      currentStep === "auth" &&
-      pendingAuthorizations.length === 0 &&
-      pendingValidations.length > 0
-    ) {
-      setCurrentStep("validation");
-      setCurrentValidationIndex(0);
-    }
-
-    if (
-      currentStep === "validation" &&
-      pendingValidations.length === 0 &&
-      pendingAuthorizations.length > 0
-    ) {
-      setCurrentStep("auth");
-    }
-  }, [currentStep, pendingAuthorizations.length, pendingValidations.length]);
 
   const submitValidation = async (status: MCPValidationOutputType) => {
     setSubmitStatus(status);
@@ -306,52 +212,32 @@ export function BlockedActionsProvider({
         removeCompletedAction(item.blockedAction.actionId);
       });
 
-      // If there are still pending authorizations, switch to auth step
-      if (pendingAuthorizations.length > 0) {
-        setCurrentStep("auth");
-        setCurrentValidationIndex(0);
-      } else {
-        // Close dialog if no more blocked actions
-        setIsDialogOpen(false);
-        setCurrentStep("validation");
-        setCurrentValidationIndex(0);
-      }
+      // Close dialog if no more blocked actions
+      setIsDialogOpen(false);
+      setCurrentStep("validation");
+      setCurrentValidationIndex(0);
     }
   };
 
-  const showBlockedActionsDialog = useCallback(() => {
-    if (blockedActionsQueue.length > 0) {
-      // Always show validation first if there are pending validations
-      if (pendingAuthorizations.length > 0) {
-        setCurrentStep("auth");
-      } else if (pendingValidations.length > 0) {
-        setCurrentStep("validation");
-      }
-
+  useEffect(() => {
+    if (pendingValidations.length > 0 && !isDialogOpen) {
+      setCurrentStep("validation");
       setCurrentValidationIndex(0);
       setIsDialogOpen(true);
     }
-  }, [
-    blockedActionsQueue.length,
-    pendingValidations.length,
-    pendingAuthorizations.length,
-  ]);
+  }, [pendingValidations.length, isDialogOpen]);
 
-  const handleConnectionStateChange = useCallback(
-    (actionId: string, status: "connecting" | "connected" | "idle") => {
-      setConnectionStates((prev) => ({
-        ...prev,
-        [actionId]: status,
-      }));
-    },
-    []
-  );
+  const showBlockedActionsDialog = useCallback(() => {
+    if (blockedActionsQueue.length > 0 && pendingValidations.length > 0) {
+      setCurrentStep("validation");
+      setCurrentValidationIndex(0);
+      setIsDialogOpen(true);
+    }
+  }, [blockedActionsQueue.length, pendingValidations.length]);
 
   const hasPendingValidations = pendingValidations.length > 0;
-  const hasPendingAuthorizations = pendingAuthorizations.length > 0;
-  const hasBlockedActions = hasPendingValidations || hasPendingAuthorizations;
-  const totalBlockedActions =
-    pendingValidations.length + pendingAuthorizations.length;
+  const hasBlockedActions = hasPendingValidations;
+  const totalBlockedActions = pendingValidations.length;
 
   const pages = useMemo(() => {
     if (currentStep === "validation" && hasPendingValidations) {
@@ -375,40 +261,13 @@ export function BlockedActionsProvider({
       });
     }
 
-    if (currentStep === "auth" && hasPendingAuthorizations) {
-      return [
-        {
-          id: "authorization",
-          title: "Authentication Required",
-          icon: ActionPieChartIcon,
-          content: (
-            <AuthenticationDialogPage
-              authActions={pendingAuthorizations.map(
-                (item) =>
-                  item.blockedAction as AuthenticationRequiredBlockedAction
-              )}
-              connectionStates={connectionStates}
-              onConnectionStateChange={handleConnectionStateChange}
-              createPersonalConnection={createPersonalConnection}
-              errorMessage={errorMessage}
-            />
-          ),
-        },
-      ];
-    }
-
     return [];
   }, [
     currentStep,
     hasPendingValidations,
-    hasPendingAuthorizations,
     pendingValidations,
-    pendingAuthorizations,
     errorMessage,
     neverAskAgain,
-    connectionStates,
-    handleConnectionStateChange,
-    createPersonalConnection,
   ]);
 
   const currentPageId = useMemo(() => {
@@ -421,10 +280,6 @@ export function BlockedActionsProvider({
       pendingValidations[currentValidationIndex]
     ) {
       return `validation-${pendingValidations[currentValidationIndex].blockedAction.actionId}`;
-    }
-
-    if (currentStep === "auth") {
-      return "authorization";
     }
 
     return pages[0]?.id || "";
@@ -447,7 +302,7 @@ export function BlockedActionsProvider({
             pages={pages}
             currentPageId={currentPageId}
             onPageChange={() => {}}
-            hideCloseButton={currentStep === "auth"}
+            hideCloseButton={false}
             size="lg"
             isAlertDialog
             showNavigation={currentStep === "validation" && pages.length > 1}

--- a/front/components/assistant/conversation/BlockedActionsProvider.tsx
+++ b/front/components/assistant/conversation/BlockedActionsProvider.tsx
@@ -174,20 +174,8 @@ export function BlockedActionsProvider({
 
   useNavigationLock(isDialogOpen);
 
-  useEffect(() => {
-    // Close the dialog when there are no more blocked actions
-    if (blockedActionsQueue.length === 0 && isDialogOpen && !isValidating) {
-      setIsDialogOpen(false);
-      setCurrentStep("validation");
-      setCurrentValidationIndex(0);
-    }
-  }, [blockedActionsQueue.length, isDialogOpen, isValidating]);
-
   const submitValidation = async (status: MCPValidationOutputType) => {
     setSubmitStatus(status);
-    if (!pendingValidations.length) {
-      return;
-    }
 
     const currentBlockedAction = pendingValidations[currentValidationIndex];
     const { blockedAction, message } = currentBlockedAction;
@@ -200,6 +188,7 @@ export function BlockedActionsProvider({
     });
 
     if (!result.success) {
+      setErrorMessage("Failed to assess action approval. Please try again.");
       return;
     }
 
@@ -222,6 +211,7 @@ export function BlockedActionsProvider({
     }
   };
 
+  // Opens the dialog when there are new pending validations
   useEffect(() => {
     if (pendingValidations.length > 0 && !isDialogOpen) {
       setCurrentStep("validation");
@@ -229,6 +219,15 @@ export function BlockedActionsProvider({
       setIsDialogOpen(true);
     }
   }, [pendingValidations.length, isDialogOpen]);
+
+  // Close the dialog when there are no more blocked actions
+  useEffect(() => {
+    if (blockedActionsQueue.length === 0 && isDialogOpen && !isValidating) {
+      setIsDialogOpen(false);
+      setCurrentStep("validation");
+      setCurrentValidationIndex(0);
+    }
+  }, [blockedActionsQueue.length, isDialogOpen, isValidating]);
 
   const showBlockedActionsDialog = useCallback(() => {
     if (blockedActionsQueue.length > 0 && pendingValidations.length > 0) {

--- a/front/components/assistant/conversation/BlockedActionsProvider.tsx
+++ b/front/components/assistant/conversation/BlockedActionsProvider.tsx
@@ -301,31 +301,27 @@ export function BlockedActionsProvider({
             showNavigation={pages.length > 1}
             showHeaderNavigation={false}
             footerContent={(() => {
-              if (pages.length > 1) {
-                return (
-                  <div className="flex flex-row justify-end gap-2">
-                    <Button
-                      variant="outline"
-                      label="Decline"
-                      onClick={() => submitValidation("rejected")}
-                      disabled={isValidating}
-                      isLoading={submitStatus === "rejected"}
-                    >
-                      Decline
-                    </Button>
-                    <Button
-                      variant="highlight"
-                      label="Allow"
-                      autoFocus
-                      onClick={() => submitValidation("approved")}
-                      disabled={isValidating}
-                      isLoading={submitStatus === "approved"}
-                    />
-                  </div>
-                );
-              }
-
-              return null;
+              return (
+                <div className="flex flex-row justify-end gap-2">
+                  <Button
+                    variant="outline"
+                    label="Decline"
+                    onClick={() => submitValidation("rejected")}
+                    disabled={isValidating}
+                    isLoading={submitStatus === "rejected"}
+                  >
+                    Decline
+                  </Button>
+                  <Button
+                    variant="highlight"
+                    label="Allow"
+                    autoFocus
+                    onClick={() => submitValidation("approved")}
+                    disabled={isValidating}
+                    isLoading={submitStatus === "approved"}
+                  />
+                </div>
+              );
             })()}
           />
         )}

--- a/front/components/assistant/conversation/BlockedActionsProvider.tsx
+++ b/front/components/assistant/conversation/BlockedActionsProvider.tsx
@@ -55,32 +55,35 @@ function useBlockedActionsQueue({
     }
   }, [conversationId, blockedActions]);
 
-  const enqueueBlockedAction = ({
-    message,
-    blockedAction,
-  }: {
-    message: LightAgentMessageType;
-    blockedAction: BlockedToolExecution;
-  }) => {
-    // Only enqueue actions for the current conversation
-    if (blockedAction.conversationId !== conversationId) {
-      return;
-    }
+  const enqueueBlockedAction = useCallback(
+    ({
+      message,
+      blockedAction,
+    }: {
+      message: LightAgentMessageType;
+      blockedAction: BlockedToolExecution;
+    }) => {
+      // Only enqueue actions for the current conversation
+      if (blockedAction.conversationId !== conversationId) {
+        return;
+      }
 
-    setBlockedActionsQueue((prevQueue) => {
-      const existingIndex = prevQueue.findIndex(
-        (v) => v.blockedAction.actionId === blockedAction.actionId
-      );
+      setBlockedActionsQueue((prevQueue) => {
+        const existingIndex = prevQueue.findIndex(
+          (v) => v.blockedAction.actionId === blockedAction.actionId
+        );
 
-      // If the action is not in the queue, add it.
-      // If the action is in the queue, replace it with the new one.
-      return existingIndex === -1
-        ? [...prevQueue, { blockedAction, message }]
-        : prevQueue.map((item, index) =>
-            index === existingIndex ? { blockedAction, message } : item
-          );
-    });
-  };
+        // If the action is not in the queue, add it.
+        // If the action is in the queue, replace it with the new one.
+        return existingIndex === -1
+          ? [...prevQueue, { blockedAction, message }]
+          : prevQueue.map((item, index) =>
+              index === existingIndex ? { blockedAction, message } : item
+            );
+      });
+    },
+    [conversationId]
+  );
 
   const removeCompletedAction = useCallback((actionId: string) => {
     setBlockedActionsQueue((prevQueue) =>

--- a/front/components/assistant/conversation/BlockedActionsProvider.tsx
+++ b/front/components/assistant/conversation/BlockedActionsProvider.tsx
@@ -1,13 +1,6 @@
 import {
   ActionPieChartIcon,
   Button,
-  Checkbox,
-  CloudArrowLeftRightIcon,
-  cn,
-  CodeBlock,
-  CollapsibleComponent,
-  Icon,
-  Label,
   MultiPageDialog,
   MultiPageDialogContent,
 } from "@dust-tt/sparkle";
@@ -21,276 +14,78 @@ import {
   useState,
 } from "react";
 
+import { ToolValidationDialogPage } from "@app/components/assistant/conversation/blocked_actions/ToolValidationDialogPage";
 import { useNavigationLock } from "@app/components/assistant_builder/useNavigationLock";
 import { useValidateAction } from "@app/hooks/useValidateAction";
 import type { MCPValidationOutputType } from "@app/lib/actions/constants";
 import type { BlockedToolExecution } from "@app/lib/actions/mcp";
 import { getIcon } from "@app/lib/actions/mcp_icons";
 import { useBlockedActions } from "@app/lib/swr/blocked_actions";
-import { useCreatePersonalConnection } from "@app/lib/swr/mcp_servers";
-import logger from "@app/logger/logger";
 import type {
   ConversationWithoutContentType,
   LightAgentMessageType,
   LightWorkspaceType,
-  OAuthProvider,
-  OAuthUseCase,
 } from "@app/types";
-import { asDisplayName } from "@app/types";
-
-type ConnectionState = "connecting" | "connected" | "idle";
-
-type AuthenticationRequiredBlockedAction = Extract<
-  BlockedToolExecution,
-  { status: "blocked_authentication_required" }
->;
-
-const EMPTY_BLOCKED_ACTIONS_QUEUE: BlockedActionQueueItem[] = [];
-
-interface AuthenticationDialogPageProps {
-  authActions: AuthenticationRequiredBlockedAction[];
-  connectionStates: Record<string, "connecting" | "connected" | "idle">;
-  onConnectionStateChange: (
-    actionId: string,
-    status: "connecting" | "connected" | "idle"
-  ) => void;
-  createPersonalConnection: (params: {
-    mcpServerId: string;
-    mcpServerDisplayName: string;
-    provider: OAuthProvider;
-    useCase: OAuthUseCase;
-    scope?: string;
-  }) => Promise<boolean>;
-  errorMessage: string | null;
-}
-
-function AuthenticationDialogPage({
-  authActions,
-  connectionStates,
-  onConnectionStateChange,
-  createPersonalConnection,
-  errorMessage,
-}: AuthenticationDialogPageProps) {
-  const handleConnect = useCallback(
-    async (blockedAction: AuthenticationRequiredBlockedAction) => {
-      onConnectionStateChange(blockedAction.actionId, "connecting");
-      const success = await createPersonalConnection({
-        mcpServerId: blockedAction.metadata.mcpServerId,
-        mcpServerDisplayName: blockedAction.metadata.mcpServerDisplayName,
-        provider: blockedAction.authorizationInfo.provider,
-        useCase: "personal_actions",
-        scope: blockedAction.authorizationInfo.scope,
-      });
-      if (success) {
-        onConnectionStateChange(blockedAction.actionId, "connected");
-      } else {
-        logger.error(
-          {
-            mcpServerId: blockedAction.metadata.mcpServerId,
-            mcpServerDisplayName: blockedAction.metadata.mcpServerDisplayName,
-            provider: blockedAction.authorizationInfo.provider,
-            scope: blockedAction.authorizationInfo.scope,
-          },
-          "Failed to connect to MCP server"
-        );
-        onConnectionStateChange(blockedAction.actionId, "idle");
-      }
-    },
-    [createPersonalConnection, onConnectionStateChange]
-  );
-
-  return (
-    <div className="flex flex-col gap-4">
-      {authActions.map((blockedAction, authIndex) => {
-        return (
-          <div key={authIndex} className="rounded-md">
-            <div className="flex items-center justify-between">
-              <div className="flex items-center">
-                <div className="flex h-8 w-8 items-center justify-center">
-                  {blockedAction.metadata.icon ? (
-                    <Icon visual={getIcon(blockedAction.metadata.icon)} />
-                  ) : null}
-                </div>
-                <div className="font-medium">
-                  {blockedAction.metadata.mcpServerDisplayName}
-                </div>
-              </div>
-              <Button
-                label={
-                  connectionStates[blockedAction.actionId] === "connected"
-                    ? "Connected"
-                    : "Connect"
-                }
-                className={cn(
-                  "text-foreground dark:text-foreground-night",
-                  connectionStates[blockedAction.actionId] === "connected" &&
-                    "bg-green-100 hover:bg-green-100/80 dark:bg-green-100-night dark:hover:bg-green-100-night/80"
-                )}
-                variant="ghost"
-                size="xs"
-                icon={
-                  connectionStates[blockedAction.actionId] === "connected"
-                    ? undefined
-                    : CloudArrowLeftRightIcon
-                }
-                disabled={
-                  connectionStates[blockedAction.actionId] === "connecting" ||
-                  connectionStates[blockedAction.actionId] === "connected"
-                }
-                isLoading={
-                  connectionStates[blockedAction.actionId] === "connecting"
-                }
-                onClick={() => handleConnect(blockedAction)}
-              />
-            </div>
-          </div>
-        );
-      })}
-      {errorMessage && (
-        <div className="mt-2 text-sm font-medium text-warning-800 dark:text-warning-800-night">
-          {errorMessage}
-        </div>
-      )}
-    </div>
-  );
-}
-
-interface ToolValidationDialogPageProps {
-  blockedAction: BlockedToolExecution;
-  errorMessage: string | null;
-  neverAskAgain: boolean;
-  setNeverAskAgain: (value: boolean) => void;
-}
-
-function ToolValidationDialogPage({
-  blockedAction,
-  errorMessage,
-  neverAskAgain,
-  setNeverAskAgain,
-}: ToolValidationDialogPageProps) {
-  const hasDetails =
-    blockedAction?.inputs && Object.keys(blockedAction.inputs).length > 0;
-
-  return (
-    <div className="flex flex-col gap-4">
-      <div>
-        Allow{" "}
-        <span className="font-semibold">
-          @{blockedAction.metadata.agentName}
-        </span>{" "}
-        to use the tool{" "}
-        <span className="font-semibold">
-          {asDisplayName(blockedAction.metadata.toolName)}
-        </span>{" "}
-        from{" "}
-        <span className="font-semibold">
-          {asDisplayName(blockedAction.metadata.mcpServerName)}
-        </span>
-        ?
-      </div>
-      {hasDetails && (
-        <CollapsibleComponent
-          triggerChildren={
-            <span className="font-medium text-muted-foreground dark:text-muted-foreground-night">
-              Details
-            </span>
-          }
-          contentChildren={
-            <div>
-              <div className="max-h-80 overflow-auto rounded-lg bg-muted dark:bg-muted-night">
-                <CodeBlock
-                  wrapLongLines
-                  className="language-json overflow-y-auto"
-                >
-                  {JSON.stringify(blockedAction.inputs, null, 2)}
-                </CodeBlock>
-              </div>
-            </div>
-          }
-        />
-      )}
-      {errorMessage && (
-        <div className="mt-2 text-sm font-medium text-warning-800 dark:text-warning-800-night">
-          {errorMessage}
-        </div>
-      )}
-      {blockedAction.stake === "low" && (
-        <div className="mt-5">
-          <Label className="copy-sm flex w-fit cursor-pointer flex-row items-center gap-2 py-2 pr-2 font-normal">
-            <Checkbox
-              checked={neverAskAgain}
-              onCheckedChange={(check) => {
-                setNeverAskAgain(!!check);
-              }}
-            />
-            <span>Always allow this tool</span>
-          </Label>
-        </div>
-      )}
-    </div>
-  );
-}
 
 type BlockedActionQueueItem = {
   message?: LightAgentMessageType;
   blockedAction: BlockedToolExecution;
 };
 
+const EMPTY_BLOCKED_ACTIONS_QUEUE: BlockedActionQueueItem[] = [];
+
 function useBlockedActionsQueue({
   blockedActions,
+  conversationId,
 }: {
   blockedActions: BlockedToolExecution[];
+  conversationId: string | null;
 }) {
   const [blockedActionsQueue, setBlockedActionsQueue] = useState<
     BlockedActionQueueItem[]
-  >(blockedActions.map((action) => ({ blockedAction: action })));
+  >([]);
 
   useEffect(() => {
-    if (blockedActions.length > 0) {
-      setBlockedActionsQueue((prevQueue) => {
-        const existingIds = new Set(
-          prevQueue.map((v) => v.blockedAction.actionId)
-        );
-        const newItems = blockedActions
-          .filter((v) => !existingIds.has(v.actionId))
-          .map((blockedAction) => ({
-            blockedAction,
-          }));
-        return [...prevQueue, ...newItems];
-      });
+    if (conversationId) {
+      // Filter out blocked_authentication_required actions as requested
+      const validationRequiredActions = blockedActions.filter(
+        (action) => action.status === "blocked_validation_required"
+      );
+
+      setBlockedActionsQueue(
+        validationRequiredActions.map((action) => ({ blockedAction: action }))
+      );
     } else {
       setBlockedActionsQueue(EMPTY_BLOCKED_ACTIONS_QUEUE);
     }
-  }, [blockedActions]);
+  }, [conversationId, blockedActions]);
 
-  const enqueueBlockedAction = useCallback(
-    ({
-      message,
-      blockedAction,
-    }: {
-      message: LightAgentMessageType;
-      blockedAction: BlockedToolExecution;
-    }) => {
-      setBlockedActionsQueue((prevQueue) => {
-        const existingIndex = prevQueue.findIndex(
-          (v) => v.blockedAction.actionId === blockedAction.actionId
-        );
+  const enqueueBlockedAction = ({
+    message,
+    blockedAction,
+  }: {
+    message: LightAgentMessageType;
+    blockedAction: BlockedToolExecution;
+  }) => {
+    // Only enqueue actions for the current conversation
+    if (blockedAction.conversationId !== conversationId) {
+      return;
+    }
 
-        // If the action is not in the queue, add it.
-        // If the action is in the queue, replace it with the new one.
-        return existingIndex === -1
-          ? [...blockedActionsQueue, { blockedAction, message }]
-          : prevQueue.map((item, index) =>
-              index === existingIndex ? { blockedAction, message } : item
-            );
-      });
-    },
-    [blockedActionsQueue]
-  );
+    setBlockedActionsQueue((prevQueue) => {
+      const existingIndex = prevQueue.findIndex(
+        (v) => v.blockedAction.actionId === blockedAction.actionId
+      );
 
-  const shiftBlockedActionQueue = useCallback(() => {
-    setBlockedActionsQueue((prevQueue) => prevQueue.slice(1));
-  }, []);
+      // If the action is not in the queue, add it.
+      // If the action is in the queue, replace it with the new one.
+      return existingIndex === -1
+        ? [...prevQueue, { blockedAction, message }]
+        : prevQueue.map((item, index) =>
+            index === existingIndex ? { blockedAction, message } : item
+          );
+    });
+  };
 
   const removeCompletedAction = useCallback((actionId: string) => {
     setBlockedActionsQueue((prevQueue) =>
@@ -301,7 +96,6 @@ function useBlockedActionsQueue({
   return {
     blockedActionsQueue,
     enqueueBlockedAction,
-    shiftBlockedActionQueue,
     removeCompletedAction,
   };
 }
@@ -342,22 +136,18 @@ export function BlockedActionsProvider({
   conversation,
   children,
 }: BlockedActionsProviderProps) {
-  const { createPersonalConnection } = useCreatePersonalConnection(owner);
+  const conversationId = conversation?.sId || null;
 
   const { blockedActions } = useBlockedActions({
-    conversationId: conversation?.sId || null,
+    conversationId,
     workspaceId: owner.sId,
   });
 
   const { blockedActionsQueue, enqueueBlockedAction, removeCompletedAction } =
     useBlockedActionsQueue({
       blockedActions,
+      conversationId,
     });
-
-  // Track connection states for each authentication item
-  const [connectionStates, setConnectionStates] = useState<
-    Record<string, ConnectionState>
-  >({});
 
   const pendingValidations = useMemo(() => {
     return blockedActionsQueue.filter(
@@ -365,16 +155,11 @@ export function BlockedActionsProvider({
     );
   }, [blockedActionsQueue]);
 
-  const pendingAuthentications = useMemo(() => {
-    return blockedActionsQueue.filter(
-      (action) =>
-        action.blockedAction.status === "blocked_authentication_required"
-    );
-  }, [blockedActionsQueue]);
+  const [currentStep, setCurrentStep] = useState<"auth" | "validation">(
+    "validation"
+  );
 
-  // Count of already validated actions.
-  // used to keep track of the current page in the dialog and the total number of pages.
-  const [validatedActions, setValidatedActions] = useState(0);
+  const [currentValidationIndex, setCurrentValidationIndex] = useState(0);
 
   const [errorMessage, setErrorMessage] = useState<string | null>(null);
   const [neverAskAgain, setNeverAskAgain] = useState(false);
@@ -397,18 +182,20 @@ export function BlockedActionsProvider({
     // Close the dialog when there are no more blocked actions
     if (blockedActionsQueue.length === 0 && isDialogOpen && !isValidating) {
       setIsDialogOpen(false);
+      setCurrentStep("validation");
+      setCurrentValidationIndex(0);
     }
   }, [blockedActionsQueue.length, isDialogOpen, isValidating]);
 
   const submitValidation = async (status: MCPValidationOutputType) => {
     setSubmitStatus(status);
-    if (!blockedActionsQueue.length) {
+    if (!pendingValidations.length) {
       return;
     }
 
-    const currentBlockedAction = blockedActionsQueue[0];
-
+    const currentBlockedAction = pendingValidations[currentValidationIndex];
     const { blockedAction, message } = currentBlockedAction;
+
     const result = await validateAction({
       validationRequest: blockedAction,
       message,
@@ -420,170 +207,84 @@ export function BlockedActionsProvider({
       return;
     }
 
-    removeCompletedAction(blockedAction.actionId);
-
     setSubmitStatus(null);
     setNeverAskAgain(false);
     setErrorMessage(null);
 
-    setValidatedActions((c) => c + 1);
+    // Move to next validation or close dialog if done
+    if (currentValidationIndex + 1 < pendingValidations.length) {
+      setCurrentValidationIndex(currentValidationIndex + 1);
+    } else {
+      pendingValidations.forEach((item) => {
+        removeCompletedAction(item.blockedAction.actionId);
+      });
+
+      // Close dialog
+      setIsDialogOpen(false);
+      setCurrentStep("validation");
+      setCurrentValidationIndex(0);
+    }
   };
 
   const showBlockedActionsDialog = useCallback(() => {
     if (blockedActionsQueue.length > 0) {
-      setValidatedActions(0);
+      if (pendingValidations.length > 0) {
+        setCurrentStep("validation");
+      }
+      setCurrentValidationIndex(0);
       setIsDialogOpen(true);
     }
-  }, [blockedActionsQueue.length]);
-
-  // Remove all completed authentication actions from the queue
-  // We want to wait until all authentication actions are connected to remove them from the queue
-  const handleDone = useCallback(() => {
-    pendingAuthentications.forEach((item) => {
-      removeCompletedAction(item.blockedAction.actionId);
-    });
-    setIsDialogOpen(false);
-  }, [pendingAuthentications, removeCompletedAction]);
+  }, [blockedActionsQueue.length, pendingValidations.length]);
 
   const hasPendingValidations = pendingValidations.length > 0;
-  const hasPendingAuthentications = pendingAuthentications.length > 0;
-  const hasBlockedActions = hasPendingValidations || hasPendingAuthentications;
-  const totalBlockedActions =
-    pendingValidations.length + pendingAuthentications.length;
-
-  // Check if all authentication actions are connected
-  const areAllAuthenticationsConnected = useMemo(() => {
-    if (!hasPendingAuthentications) {
-      return true;
-    }
-    return pendingAuthentications.every(
-      (item) => connectionStates[item.blockedAction.actionId] === "connected"
-    );
-  }, [hasPendingAuthentications, pendingAuthentications, connectionStates]);
+  const hasBlockedActions = hasPendingValidations;
+  const totalBlockedActions = pendingValidations.length;
 
   const pages = useMemo(() => {
-    // Total count is:
-    // number of validated actions
-    // + number of pending validations
-    // +1 if there are pending authentications has it's all in one page.
-    const totalCount =
-      validatedActions +
-      (hasPendingAuthentications ? 1 : 0) +
-      pendingValidations.length;
-
-    if (totalCount === 0) {
-      return [];
-    }
-
-    return Array.from({ length: totalCount }, (_, index) => {
-      if (hasPendingAuthentications && index === 0) {
-        // Create a combined authentication page with all pending authentications
-        const authActions: AuthenticationRequiredBlockedAction[] =
-          pendingAuthentications
-            .map((item) => item.blockedAction)
-            .filter(
-              (item): item is AuthenticationRequiredBlockedAction =>
-                item.status === "blocked_authentication_required"
-            );
-
+    if (currentStep === "validation" && hasPendingValidations) {
+      return pendingValidations.map((item) => {
+        const { blockedAction } = item;
         return {
-          id: "auth",
-          title: "Personal authentication required",
-          description:
-            "The agent took an action that requires personal authentication",
-          icon: undefined,
+          id: `validation-${blockedAction.actionId}`,
+          title: "Tool Validation Required",
+          icon: blockedAction.metadata.icon
+            ? getIcon(blockedAction.metadata.icon)
+            : ActionPieChartIcon,
           content: (
-            <AuthenticationDialogPage
-              authActions={authActions}
-              connectionStates={connectionStates}
-              onConnectionStateChange={(actionId, status) =>
-                setConnectionStates((prev) => ({
-                  ...prev,
-                  [actionId]: status,
-                }))
-              }
-              createPersonalConnection={createPersonalConnection}
+            <ToolValidationDialogPage
+              blockedAction={blockedAction}
               errorMessage={errorMessage}
+              neverAskAgain={neverAskAgain}
+              setNeverAskAgain={setNeverAskAgain}
             />
           ),
         };
-      }
+      });
+    }
 
-      // Index within the validations section (excluding the optional auth page)
-      const validationSectionIndex = hasPendingAuthentications
-        ? index - 1
-        : index;
-
-      if (validationSectionIndex < validatedActions) {
-        return {
-          id: index.toString(),
-          title: "Completed",
-          icon: ActionPieChartIcon,
-          content: (
-            <div className="py-4 text-sm text-muted-foreground">
-              Action already processed
-            </div>
-          ),
-        };
-      }
-
-      const pendingValidationIndex = validationSectionIndex - validatedActions;
-      const currentBlockedAction = pendingValidations[pendingValidationIndex];
-
-      if (!currentBlockedAction) {
-        return {
-          id: index.toString(),
-          title: "Completed",
-          icon: ActionPieChartIcon,
-          content: (
-            <div className="py-4 text-sm text-muted-foreground">
-              Action already processed
-            </div>
-          ),
-        };
-      }
-
-      const { blockedAction } = currentBlockedAction;
-
-      return {
-        id: `validation-${blockedAction.actionId}`,
-        title: "Tool Validation Required",
-        icon: blockedAction.metadata.icon
-          ? getIcon(blockedAction.metadata.icon)
-          : ActionPieChartIcon,
-        content: (
-          <ToolValidationDialogPage
-            blockedAction={blockedAction}
-            errorMessage={errorMessage}
-            neverAskAgain={neverAskAgain}
-            setNeverAskAgain={setNeverAskAgain}
-          />
-        ),
-      };
-    });
+    return [];
   }, [
+    currentStep,
+    hasPendingValidations,
+    pendingValidations,
     errorMessage,
     neverAskAgain,
-    validatedActions,
-    connectionStates,
-    createPersonalConnection,
-    hasPendingAuthentications,
-    pendingValidations,
-    pendingAuthentications,
   ]);
 
   const currentPageId = useMemo(() => {
     if (pages.length === 0) {
       return "";
     }
-    if (hasPendingAuthentications && validatedActions === 0) {
-      return "auth";
+
+    if (
+      currentStep === "validation" &&
+      pendingValidations[currentValidationIndex]
+    ) {
+      return `validation-${pendingValidations[currentValidationIndex].blockedAction.actionId}`;
     }
-    const nextValidation = pendingValidations[validatedActions];
-    return nextValidation
-      ? `validation-${nextValidation.blockedAction.actionId}`
-      : pages[0].id;
-  }, [pages, hasPendingAuthentications, validatedActions, pendingValidations]);
+
+    return pages[0]?.id || "";
+  }, [pages, currentStep, currentValidationIndex, pendingValidations]);
 
   return (
     <ActionValidationContext.Provider
@@ -602,53 +303,37 @@ export function BlockedActionsProvider({
             pages={pages}
             currentPageId={currentPageId}
             onPageChange={() => {}}
-            hideCloseButton={
-              !(hasPendingAuthentications && validatedActions === 0)
-            }
+            hideCloseButton={currentStep === "auth"}
             size="lg"
             isAlertDialog
-            showNavigation={true}
+            showNavigation={currentStep === "validation" && pages.length > 1}
             showHeaderNavigation={false}
             footerContent={(() => {
-              // Check if we're on the authentication page (first page with pending authentications)
-              const isOnAuthenticationDialogPage =
-                hasPendingAuthentications && validatedActions === 0;
-
-              if (isOnAuthenticationDialogPage) {
+              if (currentStep === "validation") {
                 return (
                   <div className="flex flex-row justify-end gap-2">
                     <Button
+                      variant="outline"
+                      label="Decline"
+                      onClick={() => submitValidation("rejected")}
+                      disabled={isValidating}
+                      isLoading={submitStatus === "rejected"}
+                    >
+                      Decline
+                    </Button>
+                    <Button
                       variant="highlight"
-                      label="Done"
-                      onClick={handleDone}
-                      disabled={!areAllAuthenticationsConnected}
+                      label="Allow"
+                      autoFocus
+                      onClick={() => submitValidation("approved")}
+                      disabled={isValidating}
+                      isLoading={submitStatus === "approved"}
                     />
                   </div>
                 );
               }
 
-              // For validation pages, show the usual Allow/Decline buttons
-              return (
-                <div className="flex flex-row justify-end gap-2">
-                  <Button
-                    variant="outline"
-                    label="Decline"
-                    onClick={() => submitValidation("rejected")}
-                    disabled={isValidating}
-                    isLoading={submitStatus === "rejected"}
-                  >
-                    Decline
-                  </Button>
-                  <Button
-                    variant="highlight"
-                    label="Allow"
-                    autoFocus
-                    onClick={() => submitValidation("approved")}
-                    disabled={isValidating}
-                    isLoading={submitStatus === "approved"}
-                  />
-                </div>
-              );
+              return null;
             })()}
           />
         )}

--- a/front/components/assistant/conversation/BlockedActionsProvider.tsx
+++ b/front/components/assistant/conversation/BlockedActionsProvider.tsx
@@ -310,7 +310,7 @@ export function BlockedActionsProvider({
             pages={pages}
             currentPageId={currentPageId}
             onPageChange={() => {}}
-            hideCloseButton={false}
+            hideCloseButton
             size="lg"
             isAlertDialog
             showNavigation={currentStep === "validation" && pages.length > 1}

--- a/front/components/assistant/conversation/blocked_actions/AuthentificationDialogPage.tsx
+++ b/front/components/assistant/conversation/blocked_actions/AuthentificationDialogPage.tsx
@@ -1,0 +1,119 @@
+import { Button, CloudArrowLeftRightIcon, cn, Icon } from "@dust-tt/sparkle";
+import { useCallback } from "react";
+
+import type { BlockedToolExecution } from "@app/lib/actions/mcp";
+import { getIcon } from "@app/lib/actions/mcp_icons";
+import logger from "@app/logger/logger";
+import type { OAuthProvider, OAuthUseCase } from "@app/types";
+
+type AuthenticationRequiredBlockedAction = BlockedToolExecution & {
+  status: "blocked_authentication_required";
+};
+
+interface AuthenticationDialogPageProps {
+  authActions: AuthenticationRequiredBlockedAction[];
+  connectionStates: Record<string, "connecting" | "connected" | "idle">;
+  onConnectionStateChange: (
+    actionId: string,
+    status: "connecting" | "connected" | "idle"
+  ) => void;
+  createPersonalConnection: (params: {
+    mcpServerId: string;
+    mcpServerDisplayName: string;
+    provider: OAuthProvider;
+    useCase: OAuthUseCase;
+    scope?: string;
+  }) => Promise<boolean>;
+  errorMessage: string | null;
+}
+
+export function AuthenticationDialogPage({
+  authActions,
+  connectionStates,
+  onConnectionStateChange,
+  createPersonalConnection,
+  errorMessage,
+}: AuthenticationDialogPageProps) {
+  const handleConnect = useCallback(
+    async (blockedAction: AuthenticationRequiredBlockedAction) => {
+      onConnectionStateChange(blockedAction.actionId, "connecting");
+      const success = await createPersonalConnection({
+        mcpServerId: blockedAction.metadata.mcpServerId,
+        mcpServerDisplayName: blockedAction.metadata.mcpServerDisplayName,
+        provider: blockedAction.authorizationInfo.provider,
+        useCase: "personal_actions",
+        scope: blockedAction.authorizationInfo.scope,
+      });
+      if (success) {
+        onConnectionStateChange(blockedAction.actionId, "connected");
+      } else {
+        logger.error(
+          {
+            mcpServerId: blockedAction.metadata.mcpServerId,
+            mcpServerDisplayName: blockedAction.metadata.mcpServerDisplayName,
+            provider: blockedAction.authorizationInfo.provider,
+            scope: blockedAction.authorizationInfo.scope,
+          },
+          "Failed to connect to MCP server"
+        );
+        onConnectionStateChange(blockedAction.actionId, "idle");
+      }
+    },
+    [createPersonalConnection, onConnectionStateChange]
+  );
+
+  return (
+    <div className="flex flex-col gap-4">
+      {authActions.map((blockedAction, authIndex) => {
+        return (
+          <div key={authIndex} className="rounded-md">
+            <div className="flex items-center justify-between">
+              <div className="flex items-center">
+                <div className="flex h-8 w-8 items-center justify-center">
+                  {blockedAction.metadata.icon ? (
+                    <Icon visual={getIcon(blockedAction.metadata.icon)} />
+                  ) : null}
+                </div>
+                <div className="font-medium">
+                  {blockedAction.metadata.mcpServerDisplayName}
+                </div>
+              </div>
+              <Button
+                label={
+                  connectionStates[blockedAction.actionId] === "connected"
+                    ? "Connected"
+                    : "Connect"
+                }
+                className={cn(
+                  "text-foreground dark:text-foreground-night",
+                  connectionStates[blockedAction.actionId] === "connected" &&
+                    "bg-green-100 hover:bg-green-100/80 dark:bg-green-100-night dark:hover:bg-green-100-night/80"
+                )}
+                variant="ghost"
+                size="xs"
+                icon={
+                  connectionStates[blockedAction.actionId] === "connected"
+                    ? undefined
+                    : CloudArrowLeftRightIcon
+                }
+                disabled={
+                  connectionStates[blockedAction.actionId] === "connecting" ||
+                  connectionStates[blockedAction.actionId] === "connected"
+                }
+                isLoading={
+                  connectionStates[blockedAction.actionId] === "connecting"
+                }
+                onClick={() => handleConnect(blockedAction)}
+              />
+            </div>
+          </div>
+        );
+      })}
+      {errorMessage && (
+        <div className="mt-2 text-sm font-medium text-warning-800 dark:text-warning-800-night">
+          {errorMessage}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/front/components/assistant/conversation/blocked_actions/AuthentificationDialogPage.tsx
+++ b/front/components/assistant/conversation/blocked_actions/AuthentificationDialogPage.tsx
@@ -10,13 +10,12 @@ type AuthenticationRequiredBlockedAction = BlockedToolExecution & {
   status: "blocked_authentication_required";
 };
 
+type ConnectionState = "connecting" | "connected" | "idle";
+
 interface AuthenticationDialogPageProps {
   authActions: AuthenticationRequiredBlockedAction[];
-  connectionStates: Record<string, "connecting" | "connected" | "idle">;
-  onConnectionStateChange: (
-    actionId: string,
-    status: "connecting" | "connected" | "idle"
-  ) => void;
+  connectionStates: Record<string, ConnectionState>;
+  onConnectionStateChange: (actionId: string, status: ConnectionState) => void;
   createPersonalConnection: (params: {
     mcpServerId: string;
     mcpServerDisplayName: string;

--- a/front/components/assistant/conversation/blocked_actions/ToolValidationDialogPage.tsx
+++ b/front/components/assistant/conversation/blocked_actions/ToolValidationDialogPage.tsx
@@ -1,0 +1,83 @@
+import { CollapsibleComponent } from "@dust-tt/sparkle";
+import { CodeBlock } from "@dust-tt/sparkle";
+import { Label } from "@dust-tt/sparkle";
+import { Checkbox } from "@dust-tt/sparkle";
+
+import type { BlockedToolExecution } from "@app/lib/actions/mcp";
+import { asDisplayName } from "@app/types";
+
+interface ToolValidationDialogPageProps {
+  blockedAction: BlockedToolExecution;
+  errorMessage: string | null;
+  neverAskAgain: boolean;
+  setNeverAskAgain: (value: boolean) => void;
+}
+
+export function ToolValidationDialogPage({
+  blockedAction,
+  errorMessage,
+  neverAskAgain,
+  setNeverAskAgain,
+}: ToolValidationDialogPageProps) {
+  const hasDetails =
+    blockedAction?.inputs && Object.keys(blockedAction.inputs).length > 0;
+
+  return (
+    <div className="flex flex-col gap-4">
+      <div>
+        Allow{" "}
+        <span className="font-semibold">
+          @{blockedAction.metadata.agentName}
+        </span>{" "}
+        to use the tool{" "}
+        <span className="font-semibold">
+          {asDisplayName(blockedAction.metadata.toolName)}
+        </span>{" "}
+        from{" "}
+        <span className="font-semibold">
+          {asDisplayName(blockedAction.metadata.mcpServerName)}
+        </span>
+        ?
+      </div>
+      {hasDetails && (
+        <CollapsibleComponent
+          triggerChildren={
+            <span className="font-medium text-muted-foreground dark:text-muted-foreground-night">
+              Details
+            </span>
+          }
+          contentChildren={
+            <div>
+              <div className="max-h-80 overflow-auto rounded-lg bg-muted dark:bg-muted-night">
+                <CodeBlock
+                  wrapLongLines
+                  className="language-json overflow-y-auto"
+                >
+                  {JSON.stringify(blockedAction.inputs, null, 2)}
+                </CodeBlock>
+              </div>
+            </div>
+          }
+        />
+      )}
+      {errorMessage && (
+        <div className="mt-2 text-sm font-medium text-warning-800 dark:text-warning-800-night">
+          {errorMessage}
+        </div>
+      )}
+      {blockedAction.stake === "low" && (
+        <div className="mt-5">
+          <Label className="copy-sm flex w-fit cursor-pointer flex-row items-center gap-2 py-2 pr-2 font-normal">
+            <Checkbox
+              checked={neverAskAgain}
+              onCheckedChange={(check) => {
+                setNeverAskAgain(!!check);
+              }}
+            />
+            <span>Always allow this tool</span>
+          </Label>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/front/components/assistant/conversation/blocked_actions/ToolValidationDialogPage.tsx
+++ b/front/components/assistant/conversation/blocked_actions/ToolValidationDialogPage.tsx
@@ -1,7 +1,9 @@
-import { CollapsibleComponent } from "@dust-tt/sparkle";
-import { CodeBlock } from "@dust-tt/sparkle";
-import { Label } from "@dust-tt/sparkle";
-import { Checkbox } from "@dust-tt/sparkle";
+import {
+  Checkbox,
+  CodeBlock,
+  CollapsibleComponent,
+  Label,
+} from "@dust-tt/sparkle";
 
 import type { BlockedToolExecution } from "@app/lib/actions/mcp";
 import { asDisplayName } from "@app/types";


### PR DESCRIPTION
## Description

- Fixes https://github.com/dust-tt/tasks/issues/4014
- Move the `ToolValidationPage` and `AuthorizationValidationPage` to dedicated files for better readibility
- Better support of validations and navigation between pages
- Make sure blockedActionQueue is well updated when changing conversation
- Simpler page navigation to prevent potential `undefined`s
- Remove support for `blocked_authentication_required` as this flow requires a dedicated PR. `blocked_authentication_required` is still supported by legacy flow

#### Note for reviewer

All changes are happening in the file `BlockedActionsProvider`. The goal here to make the provider safer by simplifying the way we do navigation between blocked actions. For now only `blocked_validation_required` is handled by the provider.
We pass all blocked actions to the multipage provider, then we allow/decline one by one and on the last week we clear the queue and close the modal.

## Tests

Locally. Tested of several cases and previous issues mentionned last week

## Risk

This component is wrapping the whole ConversationLayout and AgentBuilderPreview. Need careful local testing and review.

## Deploy Plan

Front
