### PR TITLE
[front] fix: render side panel when only actions

### DIFF
--- a/front/components/assistant/conversation/actions/AgentActionsPanel.tsx
+++ b/front/components/assistant/conversation/actions/AgentActionsPanel.tsx
@@ -159,7 +159,16 @@ function AgentActionsPanelContent({
         className="flex-1 overflow-y-auto p-4 pb-12"
         onScroll={handleScroll}
       >
-        <div className="flex flex-col gap-4">
+        <div className="flex h-full flex-col gap-4">
+          {!shouldStream &&
+            agentMessageToRender.actions.length === 0 &&
+            !agentMessageToRender.chainOfThought && (
+              <div className="flex h-full items-center justify-center">
+                <span className="text-sm text-muted-foreground">
+                  There's no step to display for this message.
+                </span>
+              </div>
+            )}
           {/* Render all parsed steps in order */}
           {Object.entries(steps || {})
             .sort(([a], [b]) => parseInt(a, 10) - parseInt(b, 10))

--- a/front/components/assistant/conversation/actions/AgentMessageActions.tsx
+++ b/front/components/assistant/conversation/actions/AgentMessageActions.tsx
@@ -42,9 +42,6 @@ export function AgentMessageActions({
   const lastAction = isAgentMessageWithActions
     ? agentMessage.actions[agentMessage.actions.length - 1]
     : null;
-  const hasSidePanelContent =
-    (isAgentMessageWithActions && agentMessage.actions.length > 0) ||
-    agentMessage.chainOfThought;
 
   const chainOfThought = agentMessage.chainOfThought || "";
 

--- a/front/components/assistant/conversation/actions/AgentMessageActions.tsx
+++ b/front/components/assistant/conversation/actions/AgentMessageActions.tsx
@@ -55,10 +55,6 @@ export function AgentMessageActions({
     });
   };
 
-  if (lastAgentStateClassification === "done" && !hasSidePanelContent) {
-    return null;
-  }
-
   const lastNotification = lastAction
     ? actionProgress.get(lastAction.id)?.progress ?? null
     : null;


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

actions is always [] in AgentMessageActions. Because of that, we don't display the Message Breakdown Chip if we don't have a CoT, even if we have actions.

Fix : We render the Chip whatsoever and add an empty state. 

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

By hand

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

Low

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->

Deploy front