### PR TITLE
Add github personal mcp tool

### DIFF
--- a/front/components/agent_builder/settings/SlackSettingsSheet.tsx
+++ b/front/components/agent_builder/settings/SlackSettingsSheet.tsx
@@ -302,6 +302,31 @@ export function SlackSettingsSheet({
               owner={owner}
               slackDataSource={slackDataSource}
             />
+            {hasFeature("slack_enhanced_default_agent") && (
+              <div className="flex flex-col gap-2 border-t pt-4">
+                <div className="flex items-start justify-between gap-4">
+                  <div className="flex min-w-0 flex-1 flex-col gap-1">
+                    <span className="text-sm font-medium text-foreground dark:text-foreground-night">
+                      Enhanced Default Agent
+                    </span>
+                    <span className="text-xs text-muted-foreground dark:text-muted-foreground-night">
+                      Agent will automatically respond to all new threads (not
+                      just @mentions).
+                    </span>
+                  </div>
+                  <div className="flex-shrink-0">
+                    <SliderToggle
+                      selected={autoRespondWithoutMentionEnabled}
+                      onClick={() =>
+                        setAutoRespondWithoutMentionEnabled(
+                          !autoRespondWithoutMentionEnabled
+                        )
+                      }
+                    />
+                  </div>
+                </div>
+              </div>
+            )}
           </div>
         </SheetContainer>
         <SheetFooter

--- a/front/lib/actions/mcp_internal_actions/constants.ts
+++ b/front/lib/actions/mcp_internal_actions/constants.ts
@@ -132,7 +132,7 @@ export const INTERNAL_MCP_SERVERS = {
       description: "GitHub tools to manage issues and pull requests.",
       authorization: {
         provider: "github" as const,
-        supported_use_cases: ["platform_actions"] as const,
+        supported_use_cases: ["platform_actions", "personal_actions"] as const,
       },
       icon: "GithubLogo",
       documentationUrl: null,

--- a/front/lib/api/config.ts
+++ b/front/lib/api/config.ts
@@ -144,6 +144,11 @@ const config = {
       "OAUTH_GITHUB_APP_PLATFORM_ACTIONS"
     );
   },
+  getOAuthGithubAppPersonalActions: (): string => {
+    return EnvironmentConfig.getEnvVariable(
+      "OAUTH_GITHUB_APP_PLATFORM_ACTIONS_CLIENT_ID"
+    );
+  },
   getOAuthNotionClientId: (): string => {
     return EnvironmentConfig.getEnvVariable("OAUTH_NOTION_CLIENT_ID");
   },

--- a/front/lib/api/oauth/providers/github.ts
+++ b/front/lib/api/oauth/providers/github.ts
@@ -2,7 +2,10 @@ import type { ParsedUrlQuery } from "querystring";
 
 import config from "@app/lib/api/config";
 import type { BaseOAuthStrategyProvider } from "@app/lib/api/oauth/providers/base_oauth_stragegy_provider";
-import { getStringFromQuery } from "@app/lib/api/oauth/utils";
+import {
+  finalizeUriForProvider,
+  getStringFromQuery,
+} from "@app/lib/api/oauth/utils";
 import type { ExtraConfigType } from "@app/pages/w/[wId]/oauth/[provider]/setup";
 import type { OAuthConnectionType, OAuthUseCase } from "@app/types/oauth/lib";
 
@@ -14,6 +17,17 @@ export class GithubOAuthProvider implements BaseOAuthStrategyProvider {
     connection: OAuthConnectionType;
     useCase: OAuthUseCase;
   }) {
+    if (useCase === "personal_actions") {
+      // OAuth flow for personal connections (user access tokens)
+      return (
+        `https://github.com/login/oauth/authorize?` +
+        `client_id=${config.getOAuthGithubAppPersonalActions()}` +
+        `&state=${connection.connection_id}` +
+        `&redirect_uri=${encodeURIComponent(finalizeUriForProvider("github"))}` +
+        `&scope=repo`
+      );
+    }
+
     const app =
       useCase === "platform_actions"
         ? config.getOAuthGithubAppPlatformActions()
@@ -24,21 +38,26 @@ export class GithubOAuthProvider implements BaseOAuthStrategyProvider {
       `?state=${connection.connection_id}`
     );
   }
-  // {
-  //   installation_id: '52689080',
-  //   setup_action: 'update',
-  //   state: 'con_...-...',
-  //   provider: 'github'
-  // }
+
   codeFromQuery(query: ParsedUrlQuery) {
-    return getStringFromQuery(query, "installation_id");
+    // OAuth flow returns "code", GitHub App installation returns "installation_id"
+    // Both serve as authorization credentials for their respective flows
+    return (
+      getStringFromQuery(query, "installation_id") ||
+      getStringFromQuery(query, "code")
+    );
   }
 
   connectionIdFromQuery(query: ParsedUrlQuery) {
     return getStringFromQuery(query, "state");
   }
 
-  isExtraConfigValid(extraConfig: ExtraConfigType) {
+  isExtraConfigValid(extraConfig: ExtraConfigType, useCase: OAuthUseCase) {
+    if (useCase === "personal_actions") {
+      return (
+        Object.keys(extraConfig).length === 1 && "mcp_server_id" in extraConfig
+      );
+    }
     return Object.keys(extraConfig).length === 0;
   }
 }

--- a/front/types/shared/feature_flags.ts
+++ b/front/types/shared/feature_flags.ts
@@ -167,7 +167,7 @@ export const WHITELISTABLE_FEATURES_CONFIG = {
   slack_enhanced_default_agent: {
     description:
       "Enhanced default agent feature for Slack channels - auto-respond to all messages in channel",
-    stage: "dust_only",
+    stage: "on_demand",
   },
   simple_audio_transcription: {
     description: "Simple Audio transcription feature",


### PR DESCRIPTION
## Description

* Implement personal connections for Github using user tokens - https://docs.github.com/en/apps/creating-github-apps/authenticating-with-a-github-app/generating-a-user-access-token-for-a-github-app
## Tests

Created the following issue:

<img width="912" height="566" alt="Screenshot 2025-09-03 at 6 56 31 PM" src="https://github.com/user-attachments/assets/bc7e4eac-9aa8-4d72-aa04-20993e1d2c74" />

## Risk

* Unintentional logic changes to workspace level connection

## Deploy Plan

1. Enable client secrets on slack app
2. Add OAUTH_GITHUB_APP_PLATFORM_ACTIONS_CLIENT_SECRET variable to oauth
3. Add OAUTH_GITHUB_APP_PLATFORM_ACTIONS_CLIENT_ID to front
4. Merge
5. Deploy core
6. Deploy front