### PR TITLE
make resize handler fully visible in conversation

### DIFF
--- a/front/components/assistant/conversation/ConversationSidePanelContainer.tsx
+++ b/front/components/assistant/conversation/ConversationSidePanelContainer.tsx
@@ -37,7 +37,11 @@ export default function ConversationSidePanelContainer({
   return (
     <>
       {/* Resizable Handle for Panels */}
-      <ResizableHandle withHandle disabled={!currentPanel} />
+      <ResizableHandle
+        withHandle
+        disabled={!currentPanel}
+        className="relative z-50"
+      />
       {/* Panel Container - either Content Creation or Actions */}
       <ResizablePanel
         ref={panelRef}

--- a/front/components/assistant/conversation/ConversationSidePanelContainer.tsx
+++ b/front/components/assistant/conversation/ConversationSidePanelContainer.tsx
@@ -37,11 +37,7 @@ export default function ConversationSidePanelContainer({
   return (
     <>
       {/* Resizable Handle for Panels */}
-      <ResizableHandle
-        withHandle
-        disabled={!currentPanel}
-        className="relative z-50"
-      />
+      <ResizableHandle withHandle disabled={!currentPanel} className="z-50" />
       {/* Panel Container - either Content Creation or Actions */}
       <ResizablePanel
         ref={panelRef}


### PR DESCRIPTION
## Description

- https://github.com/dust-tt/tasks/issues/4002
- Make resize handler fully visible in conversation

**Before**:

<img width="1106" height="682" alt="image" src="https://github.com/user-attachments/assets/4ded124a-aa6f-450f-8397-5cc0a6ac40ea" />

**After**:

<img width="209" height="182" alt="Screenshot 2025-09-04 at 10 16 00" src="https://github.com/user-attachments/assets/63ff3026-38c2-4eb5-bdcf-18c2f43846ca" />

## Tests

Handle still works as excepted

## Risk

Low

## Deploy Plan

Deploy front
