### PR TITLE
[sparkle] - chore(ToolCard): show tooltip on hover

### DIFF
--- a/sparkle/src/components/ToolCard.tsx
+++ b/sparkle/src/components/ToolCard.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 
 import { Avatar, Button, Card, Chip } from "@sparkle/components/";
+import { TruncatedText } from "@sparkle/components/TruncatedText";
 import { PlusIcon } from "@sparkle/icons/app/";
 import { cn } from "@sparkle/lib/utils";
 
@@ -69,9 +70,9 @@ export const ToolCard = React.forwardRef<HTMLDivElement, ToolCardProps>(
               </div>
             )}
           </div>
-          <div className="s-line-clamp-2 s-h-10 s-overflow-hidden s-text-sm s-text-muted-foreground dark:s-text-muted-foreground-night">
+          <TruncatedText className="s-text-sm s-text-muted-foreground dark:s-text-muted-foreground-night">
             {description}
-          </div>
+          </TruncatedText>
         </div>
       </Card>
     );

--- a/sparkle/src/components/ToolCard.tsx
+++ b/sparkle/src/components/ToolCard.tsx
@@ -11,7 +11,7 @@ const FADE_TRANSITION_CLASSES =
 export interface ToolCardProps {
   icon: React.ComponentType;
   label: string;
-  description: string;
+  description: string | React.ReactNode;
   isSelected: boolean;
   canAdd: boolean;
   cantAddReason?: string;

--- a/sparkle/src/components/TruncatedText.tsx
+++ b/sparkle/src/components/TruncatedText.tsx
@@ -1,0 +1,52 @@
+import React from "react";
+
+import { Tooltip } from "@sparkle/components/Tooltip";
+import { cn } from "@sparkle/lib/utils";
+
+interface TruncatedTextProps extends React.HTMLAttributes<HTMLDivElement> {
+  children: string;
+  lineClamp?: number;
+}
+
+export const TruncatedText: React.FC<TruncatedTextProps> = ({
+  children,
+  className,
+  lineClamp = 2,
+  ...props
+}) => {
+  const [isTruncated, setIsTruncated] = React.useState(false);
+  const textRef = React.useRef<HTMLDivElement>(null);
+
+  React.useLayoutEffect(() => {
+    const element = textRef.current;
+    if (element) {
+      const isOverflowing = element.scrollHeight > element.clientHeight;
+      setIsTruncated(isOverflowing);
+    }
+  });
+
+  const textElement = (
+    <div
+      ref={textRef}
+      className={cn(
+        `s-line-clamp-${lineClamp} s-cursor-pointer s-select-none`,
+        className
+      )}
+      {...props}
+    >
+      {children}
+    </div>
+  );
+
+  if (isTruncated) {
+    return (
+      <Tooltip
+        trigger={textElement}
+        label={children}
+        tooltipTriggerAsChild={true}
+      />
+    );
+  }
+
+  return textElement;
+};

--- a/sparkle/src/components/TruncatedText.tsx
+++ b/sparkle/src/components/TruncatedText.tsx
@@ -4,7 +4,7 @@ import { Tooltip } from "@sparkle/components/Tooltip";
 import { cn } from "@sparkle/lib/utils";
 
 interface TruncatedTextProps extends React.HTMLAttributes<HTMLDivElement> {
-  children: string;
+  children: string | React.ReactNode;
   lineClamp?: number;
 }
 

--- a/sparkle/src/components/TruncatedText.tsx
+++ b/sparkle/src/components/TruncatedText.tsx
@@ -17,6 +17,9 @@ export const TruncatedText: React.FC<TruncatedTextProps> = ({
   const [isTruncated, setIsTruncated] = React.useState(false);
   const textRef = React.useRef<HTMLDivElement>(null);
 
+  // Check if content is actually truncated by comparing scroll height to
+  // client height
+  // This ensures we only show the tooltip when text is cut off by line-clamp-
   React.useLayoutEffect(() => {
     const element = textRef.current;
     if (element) {

--- a/sparkle/src/stories/ToolCard.stories.tsx
+++ b/sparkle/src/stories/ToolCard.stories.tsx
@@ -2,6 +2,7 @@ import type { Meta } from "@storybook/react";
 import React from "react";
 
 import { ToolCard } from "@sparkle/components";
+import { Hoverable } from "@sparkle/components";
 import { BookOpenIcon, CommandLineIcon } from "@sparkle/icons/app";
 
 const meta: Meta<typeof ToolCard> = {
@@ -27,7 +28,24 @@ export const Examples = () => (
     <ToolCard
       icon={CommandLineIcon}
       label="Reasoning"
-      description="Agent can decide to trigger a reasoning model for complex tasks. Agent can decide to trigger a reasoning model for complex tasks. Agent can decide to trigger a reasoning model for complex tasks. Agent can decide to trigger a reasoning model for complex tasks. Agent can decide to trigger a reasoning model for complex tasks. Agent can decide to trigger a reasoning model for complex tasks."
+      description={
+        <>
+          Agent can decide to trigger a reasoning model for complex tasks. Agent
+          can decide to trigger a reasoning model for complex tasks. Agent can
+          decide to trigger a reasoning model for complex tasks. Agent can
+          decide to trigger a reasoning model for complex tasks. Agent can
+          decide to trigger a reasoning model for complex tasks. Agent can
+          decide to trigger a reasoning model for complex tasks.{" "}
+          <Hoverable
+            href="https://example.com/help"
+            target="_blank"
+            rel="noopener noreferrer"
+            variant="primary"
+          >
+            the docs
+          </Hoverable>
+        </>
+      }
       isSelected={true}
       canAdd={false}
     />

--- a/sparkle/src/stories/ToolCard.stories.tsx
+++ b/sparkle/src/stories/ToolCard.stories.tsx
@@ -27,7 +27,7 @@ export const Examples = () => (
     <ToolCard
       icon={CommandLineIcon}
       label="Reasoning"
-      description="Agent can decide to trigger a reasoning model for complex tasks."
+      description="Agent can decide to trigger a reasoning model for complex tasks. Agent can decide to trigger a reasoning model for complex tasks. Agent can decide to trigger a reasoning model for complex tasks. Agent can decide to trigger a reasoning model for complex tasks. Agent can decide to trigger a reasoning model for complex tasks. Agent can decide to trigger a reasoning model for complex tasks."
       isSelected={true}
       canAdd={false}
     />


### PR DESCRIPTION
## Description

Replaces the direct text truncation implementation in `ToolCard` with a new `TruncatedText` component that intelligently displays tooltips only when text is actually truncated. 

The `TruncatedText` component detects overflow by comparing scroll height to client height and shows the full content in a tooltip on hover. Additionally, the `ToolCard` description prop now accepts `React.ReactNode` to support rich content like embedded links.


<img width="427" height="249" alt="Screenshot 2025-09-04 at 10 54 06" src="https://github.com/user-attachments/assets/19f096c0-a127-4844-9c3c-764a56b6e5bc" />

## Tests

Storybook

## Risk

Low

## Deploy Plan

Publish sparkle