### PR TITLE
Change agent suggestion order: dust then dust-deep

### DIFF
--- a/extension/shared/lib/global_agents.ts
+++ b/extension/shared/lib/global_agents.ts
@@ -1,0 +1,9 @@
+// Not exhaustive list of global agents, we added only the ones that are used in the extension code.
+export const GLOBAL_AGENTS_SID = {
+  HELPER: "helper",
+  DUST: "dust",
+  DUST_DEEP: "dust-deep",
+  CLAUDE_4_SONNET: "claude-4-sonnet",
+  GPT4: "gpt-4",
+  GPT5: "gpt-5",
+};

--- a/extension/shared/lib/utils.ts
+++ b/extension/shared/lib/utils.ts
@@ -200,6 +200,14 @@ export function compareAgentsForSort(
     return 1;
   }
 
+  // Check for 'dust-deep'
+  if (a.sId === "dust-deep") {
+    return -1;
+  }
+  if (b.sId === "dust-deep") {
+    return 1;
+  }
+
   // Check for 'claude-3'
   if (a.sId === "claude-3-sonnet") {
     return -1;

--- a/extension/shared/lib/utils.ts
+++ b/extension/shared/lib/utils.ts
@@ -2,6 +2,7 @@
  * Utils to generate PKCE code verifier and challenge.
  */
 
+import { GLOBAL_AGENTS_SID } from "@app/shared/lib/global_agents";
 import type {
   DataSourceViewContentNodeType,
   LightAgentConfigurationType,
@@ -185,46 +186,49 @@ export function compareAgentsForSort(
   a: LightAgentConfigurationType,
   b: LightAgentConfigurationType
 ) {
-  // Place favorites first
   if (a.userFavorite && !b.userFavorite) {
     return -1;
   }
   if (b.userFavorite && !a.userFavorite) {
     return 1;
   }
-  // Check for 'dust'
-  if (a.sId === "dust") {
+
+  if (a.sId === GLOBAL_AGENTS_SID.DUST) {
     return -1;
   }
-  if (b.sId === "dust") {
+  if (b.sId === GLOBAL_AGENTS_SID.DUST) {
     return 1;
   }
 
-  // Check for 'dust-deep'
-  if (a.sId === "dust-deep") {
+  if (a.sId === GLOBAL_AGENTS_SID.DUST_DEEP) {
     return -1;
   }
-  if (b.sId === "dust-deep") {
+  if (b.sId === GLOBAL_AGENTS_SID.DUST_DEEP) {
     return 1;
   }
 
-  // Check for 'claude-3'
-  if (a.sId === "claude-3-sonnet") {
+  if (a.sId === GLOBAL_AGENTS_SID.CLAUDE_4_SONNET) {
     return -1;
   }
-  if (b.sId === "claude-3-sonnet") {
+  if (b.sId === GLOBAL_AGENTS_SID.CLAUDE_4_SONNET) {
     return 1;
   }
 
-  // Check for 'gpt4'
-  if (a.sId === "gpt-4") {
+  if (a.sId === GLOBAL_AGENTS_SID.GPT5) {
     return -1;
   }
-  if (b.sId === "gpt-4") {
+  if (b.sId === GLOBAL_AGENTS_SID.GPT5) {
     return 1;
   }
 
-  // Check for agents with non-global 'scope'
+  if (a.sId === GLOBAL_AGENTS_SID.GPT4) {
+    return -1;
+  }
+  if (b.sId === GLOBAL_AGENTS_SID.GPT4) {
+    return 1;
+  }
+
+  // Check for agents with non-global 'scope'.
   if (a.scope !== "global" && b.scope === "global") {
     return -1;
   }
@@ -232,7 +236,7 @@ export function compareAgentsForSort(
     return 1;
   }
 
-  // default: sort alphabetically
+  // Default: sort alphabetically.
   return a.name.localeCompare(b.name, "en", { sensitivity: "base" });
 }
 

--- a/extension/ui/components/conversation/AgentSuggestion.tsx
+++ b/extension/ui/components/conversation/AgentSuggestion.tsx
@@ -1,4 +1,5 @@
 import { useDustAPI } from "@app/shared/lib/dust_api";
+import { GLOBAL_AGENTS_SID } from "@app/shared/lib/global_agents";
 import { AssistantPicker } from "@app/ui/components/assistants/AssistantPicker";
 import { usePublicAgentConfigurations } from "@app/ui/components/assistants/usePublicAgentConfigurations";
 import { useSubmitFunction } from "@app/ui/components/utils/useSubmitFunction";
@@ -128,23 +129,22 @@ function sortAgents(
   a: LightAgentConfigurationType,
   b: LightAgentConfigurationType
 ) {
-  // Place favorites first
   if (a.userFavorite && !b.userFavorite) {
     return -1;
   }
   if (b.userFavorite && !a.userFavorite) {
     return 1;
   }
-  // Dust always first
-  if (a.sId === "dust") {
+
+  if (a.sId === GLOBAL_AGENTS_SID.DUST) {
     return -1;
-  } else if (b.sId === "dust") {
+  } else if (b.sId === GLOBAL_AGENTS_SID.DUST) {
     return 1;
   }
-  // Dust-deep always second
-  if (a.sId === "dust-deep") {
+
+  if (a.sId === GLOBAL_AGENTS_SID.DUST_DEEP) {
     return -1;
-  } else if (b.sId === "dust-deep") {
+  } else if (b.sId === GLOBAL_AGENTS_SID.DUST_DEEP) {
     return 1;
   }
   return (b.usage?.messageCount || 0) - (a.usage?.messageCount || 0);

--- a/extension/ui/components/conversation/AgentSuggestion.tsx
+++ b/extension/ui/components/conversation/AgentSuggestion.tsx
@@ -135,9 +135,16 @@ function sortAgents(
   if (b.userFavorite && !a.userFavorite) {
     return 1;
   }
+  // Dust always first
   if (a.sId === "dust") {
     return -1;
   } else if (b.sId === "dust") {
+    return 1;
+  }
+  // Dust-deep always second
+  if (a.sId === "dust-deep") {
+    return -1;
+  } else if (b.sId === "dust-deep") {
     return 1;
   }
   return (b.usage?.messageCount || 0) - (a.usage?.messageCount || 0);

--- a/front/components/assistant/conversation/AgentSuggestion.tsx
+++ b/front/components/assistant/conversation/AgentSuggestion.tsx
@@ -22,6 +22,7 @@ import type {
   UserMessageType,
   WorkspaceType,
 } from "@app/types";
+import { GLOBAL_AGENTS_SID } from "@app/types";
 
 interface AgentSuggestionProps {
   conversationId: string;
@@ -199,15 +200,15 @@ function sortAgents(
     return 1;
   }
   // Dust always first
-  if (a.sId === "dust") {
+  if (a.sId === GLOBAL_AGENTS_SID.DUST) {
     return -1;
-  } else if (b.sId === "dust") {
+  } else if (b.sId === GLOBAL_AGENTS_SID.DUST) {
     return 1;
   }
   // Dust-deep always second
-  if (a.sId === "dust-deep") {
+  if (a.sId === GLOBAL_AGENTS_SID.DUST_DEEP) {
     return -1;
-  } else if (b.sId === "dust-deep") {
+  } else if (b.sId === GLOBAL_AGENTS_SID.DUST_DEEP) {
     return 1;
   }
   return (b.usage?.messageCount || 0) - (a.usage?.messageCount || 0);

--- a/front/components/assistant/conversation/AgentSuggestion.tsx
+++ b/front/components/assistant/conversation/AgentSuggestion.tsx
@@ -198,9 +198,16 @@ function sortAgents(
   if (b.userFavorite && !a.userFavorite) {
     return 1;
   }
+  // Dust always first
   if (a.sId === "dust") {
     return -1;
   } else if (b.sId === "dust") {
+    return 1;
+  }
+  // Dust-deep always second
+  if (a.sId === "dust-deep") {
+    return -1;
+  } else if (b.sId === "dust-deep") {
     return 1;
   }
   return (b.usage?.messageCount || 0) - (a.usage?.messageCount || 0);

--- a/front/lib/api/assistant/global_agents/configurations/dust-deep.ts
+++ b/front/lib/api/assistant/global_agents/configurations/dust-deep.ts
@@ -296,8 +296,7 @@ export function _getDustDeepGlobalAgent(
   const description =
     "Deep research with company data, web search/browse, Content Creation, and data warehouses.";
 
-  const pictureUrl =
-    "https://dust.tt/static/systemavatar/dust-deep_avatar_full.png";
+  const pictureUrl = "https://dust.tt/static/systemavatar/dust_avatar_full.png";
 
   const modelConfig = getModelConfig(owner, "anthropic");
 

--- a/front/types/assistant/assistant.ts
+++ b/front/types/assistant/assistant.ts
@@ -1592,6 +1592,7 @@ export function getGlobalAgentAuthorName(agentId: string): string {
 
 const CUSTOM_ORDER: string[] = [
   GLOBAL_AGENTS_SID.DUST,
+  GLOBAL_AGENTS_SID.DUST_DEEP,
   GLOBAL_AGENTS_SID.CLAUDE_4_SONNET,
   GLOBAL_AGENTS_SID.GPT4,
   GLOBAL_AGENTS_SID.O3_MINI,
@@ -1632,6 +1633,14 @@ export function compareAgentsForSort(
     return -1;
   }
   if (b.sId === GLOBAL_AGENTS_SID.DUST) {
+    return 1;
+  }
+
+  // Check for 'dust-deep'
+  if (a.sId === GLOBAL_AGENTS_SID.DUST_DEEP) {
+    return -1;
+  }
+  if (b.sId === GLOBAL_AGENTS_SID.DUST_DEEP) {
     return 1;
   }
 

--- a/front/types/assistant/assistant.ts
+++ b/front/types/assistant/assistant.ts
@@ -1621,14 +1621,13 @@ export function compareAgentsForSort(
   a: LightAgentConfigurationType,
   b: LightAgentConfigurationType
 ) {
-  // Place favorites first
   if (a.userFavorite && !b.userFavorite) {
     return -1;
   }
   if (b.userFavorite && !a.userFavorite) {
     return 1;
   }
-  // Check for 'dust'
+
   if (a.sId === GLOBAL_AGENTS_SID.DUST) {
     return -1;
   }
@@ -1636,7 +1635,6 @@ export function compareAgentsForSort(
     return 1;
   }
 
-  // Check for 'dust-deep'
   if (a.sId === GLOBAL_AGENTS_SID.DUST_DEEP) {
     return -1;
   }
@@ -1644,7 +1642,6 @@ export function compareAgentsForSort(
     return 1;
   }
 
-  // Check for 'gpt5'
   if (a.sId === GLOBAL_AGENTS_SID.GPT5) {
     return -1;
   }
@@ -1652,7 +1649,6 @@ export function compareAgentsForSort(
     return 1;
   }
 
-  // Check for 'gpt4'
   if (a.sId === GLOBAL_AGENTS_SID.GPT4) {
     return -1;
   }


### PR DESCRIPTION
## Description

- Add `dust-deep` right after `dust` by default. 
- Change the avatar of `dust-deep` to use the same as dust

## Tests

Locally. 

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

Deploy front. 