### PR TITLE
[front] - fix(AB): data viz server

### DIFF
--- a/front/components/agent_builder/AgentBuilder.tsx
+++ b/front/components/agent_builder/AgentBuilder.tsx
@@ -32,6 +32,7 @@ import {
 import type { AgentBuilderAction } from "@app/components/agent_builder/types";
 import { ConversationSidePanelProvider } from "@app/components/assistant/conversation/ConversationSidePanelContext";
 import type { AssistantBuilderMCPConfigurationWithId } from "@app/components/assistant_builder/types";
+import { getDataVisualizationActionConfiguration } from "@app/components/assistant_builder/types";
 import { useNavigationLock } from "@app/components/assistant_builder/useNavigationLock";
 import { appLayoutBack } from "@app/components/sparkle/AppContentLayout";
 import { FormProvider } from "@app/components/sparkle/FormProvider";
@@ -47,22 +48,29 @@ import type { LightAgentConfigurationType } from "@app/types";
 import { isBuilder, removeNulls } from "@app/types";
 
 function processActionsFromStorage(
-  actions: AssistantBuilderMCPConfigurationWithId[]
+  actions: AssistantBuilderMCPConfigurationWithId[],
+  visualizationEnabled: boolean
 ): AgentBuilderAction[] {
-  return actions.map((action) => {
-    if (action.type === "MCP") {
-      return {
-        ...action,
-        configuration: {
-          ...action.configuration,
-          additionalConfiguration: processAdditionalConfigurationFromStorage(
-            action.configuration.additionalConfiguration
-          ),
-        },
-      };
-    }
-    return action;
-  });
+  const visualizationAction = visualizationEnabled
+    ? [getDataVisualizationActionConfiguration()]
+    : [];
+  return [
+    ...visualizationAction,
+    ...actions.map((action) => {
+      if (action.type === "MCP") {
+        return {
+          ...action,
+          configuration: {
+            ...action.configuration,
+            additionalConfiguration: processAdditionalConfigurationFromStorage(
+              action.configuration.additionalConfiguration
+            ),
+          },
+        };
+      }
+      return action;
+    }),
+  ];
 }
 
 function processAdditionalConfigurationFromStorage(
@@ -130,8 +138,11 @@ export default function AgentBuilder({
   }, [supportedDataSourceViews]);
 
   const processedActions = useMemo(() => {
-    return processActionsFromStorage(actions ?? emptyArray());
-  }, [actions]);
+    return processActionsFromStorage(
+      actions ?? emptyArray(),
+      agentConfiguration?.visualizationEnabled ?? false
+    );
+  }, [actions, agentConfiguration?.visualizationEnabled]);
 
   const agentSlackChannels = useMemo(() => {
     if (!agentConfiguration || !slackChannelsLinkedWithAgent.length) {

--- a/front/components/agent_builder/get_spaceid_to_actions_map.test.ts
+++ b/front/components/agent_builder/get_spaceid_to_actions_map.test.ts
@@ -13,7 +13,7 @@ const createMockAction = (
 ): AssistantBuilderMCPOrVizState => ({
   id,
   type: "DATA_VISUALIZATION",
-  configuration: {},
+  configuration: null,
   name,
   description: `Description for ${name}`,
   noConfigurationRequired: true,

--- a/front/components/assistant_builder/AssistantBuilder.tsx
+++ b/front/components/assistant_builder/AssistantBuilder.tsx
@@ -1,5 +1,6 @@
 import "react-image-crop/dist/ReactCrop.css";
 
+import { removeNulls } from "@dust-tt/client";
 import {
   Button,
   SidebarRightCloseIcon,
@@ -304,8 +305,8 @@ export default function AssistantBuilder({
 
   const { showDialog, ...dialogProps } = useAwaitableDialog({
     owner,
-    mcpServerViewToCheckIds: builderState.actions.map(
-      (a) => a.configuration.mcpServerViewId
+    mcpServerViewToCheckIds: removeNulls(
+      builderState.actions.map((a) => a.configuration?.mcpServerViewId)
     ),
     mcpServerViews,
   });

--- a/front/components/assistant_builder/types.ts
+++ b/front/components/assistant_builder/types.ts
@@ -101,7 +101,7 @@ export type AssistantBuilderMCPConfigurationWithId =
 
 export interface AssistantBuilderDataVisualizationConfiguration {
   type: "DATA_VISUALIZATION";
-  configuration: Record<string, never>;
+  configuration: null;
   name: string;
   description: string;
   noConfigurationRequired: true;
@@ -243,7 +243,7 @@ export const ASSISTANT_BUILDER_DUST_APP_RUN_ACTION_CONFIGURATION_DEFAULT_DESCRIP
 export function getDataVisualizationConfiguration(): AssistantBuilderDataVisualizationConfiguration {
   return {
     type: "DATA_VISUALIZATION",
-    configuration: {},
+    configuration: null,
     name: DEFAULT_DATA_VISUALIZATION_NAME,
     description: DEFAULT_DATA_VISUALIZATION_DESCRIPTION,
     noConfigurationRequired: true,


### PR DESCRIPTION
## Description

This PR fixes the handling of data visualization actions in the agent builder by conditionally adding them based on agent configuration and properly handling nullable `mcpServerViewId` values. The changes modify `processActionsFromStorage` to accept a `visualizationEnabled` parameter and prepend a data visualization action when enabled. Additionally, it updates the data visualization configuration type to use null instead of an empty object for the configuration property and adds proper null handling in the assistant builder.

## Tests

Locally

## Risk

Low

## Deploy Plan

Deploy front