### PR TITLE
Dust-deep can be disabled by the admin

### DIFF
--- a/front/components/assistant/manager/GlobalAgentAction.tsx
+++ b/front/components/assistant/manager/GlobalAgentAction.tsx
@@ -37,7 +37,6 @@ export function GlobalAgentAction({
   const isConfigurable = agent.sId === GLOBAL_AGENTS_SID.DUST;
   const canBeDisabled =
     agent.sId !== GLOBAL_AGENTS_SID.DUST &&
-    agent.sId !== GLOBAL_AGENTS_SID.DUST_DEEP &&
     agent.sId !== GLOBAL_AGENTS_SID.HELPER;
 
   if (isConfigurable) {


### PR DESCRIPTION
## Description

Only helper cannot be disabled at all. 
Dust can be disable but on its own config page. 
Since we removed the config page for Dust-deep, it needs to be added back here so that there's a slide to deactivated. 

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

Deploy front. 