### PR TITLE
[front] - chore(AB): improve `MCPToolCard` UI

### DIFF
--- a/extension/package-lock.json
+++ b/extension/package-lock.json
@@ -12,7 +12,7 @@
         "@auth0/auth0-spa-js": "^2.1.3",
         "@datadog/browser-logs": "^6.13.0",
         "@dust-tt/client": "^1.1.10",
-        "@dust-tt/sparkle": "^0.2.609",
+        "@dust-tt/sparkle": "^0.2.611-rc-2",
         "@frontapp/plugin-sdk": "^1.8.1",
         "@modelcontextprotocol/sdk": "^1.9.0",
         "@tailwindcss/forms": "^0.5.9",
@@ -1293,9 +1293,9 @@
       }
     },
     "node_modules/@dust-tt/sparkle": {
-      "version": "0.2.609",
-      "resolved": "https://registry.npmjs.org/@dust-tt/sparkle/-/sparkle-0.2.609.tgz",
-      "integrity": "sha512-vlLGs+2NbTgUO6HH5PY9dAT/Mkffo862cTt+PMrDLSa+raeb/lEst3CmtWNNHqOIoEL1GfyjdqRg8B8TzJ0mNw==",
+      "version": "0.2.611-rc-2",
+      "resolved": "https://registry.npmjs.org/@dust-tt/sparkle/-/sparkle-0.2.611-rc-2.tgz",
+      "integrity": "sha512-j7CZCBQ8490iHPyyhgsBLz4YHhvAdEv7RxveLMrFNQMsLWlKv5aXDunneKdzMXt7sjqnPVQuJhScVtMCHic65w==",
       "dependencies": {
         "@emoji-mart/data": "^1.1.2",
         "@emoji-mart/react": "^1.1.1",

--- a/extension/package-lock.json
+++ b/extension/package-lock.json
@@ -12,7 +12,7 @@
         "@auth0/auth0-spa-js": "^2.1.3",
         "@datadog/browser-logs": "^6.13.0",
         "@dust-tt/client": "^1.1.10",
-        "@dust-tt/sparkle": "^0.2.611-rc-2",
+        "@dust-tt/sparkle": "^0.2.611",
         "@frontapp/plugin-sdk": "^1.8.1",
         "@modelcontextprotocol/sdk": "^1.9.0",
         "@tailwindcss/forms": "^0.5.9",
@@ -1293,9 +1293,9 @@
       }
     },
     "node_modules/@dust-tt/sparkle": {
-      "version": "0.2.611-rc-2",
-      "resolved": "https://registry.npmjs.org/@dust-tt/sparkle/-/sparkle-0.2.611-rc-2.tgz",
-      "integrity": "sha512-j7CZCBQ8490iHPyyhgsBLz4YHhvAdEv7RxveLMrFNQMsLWlKv5aXDunneKdzMXt7sjqnPVQuJhScVtMCHic65w==",
+      "version": "0.2.611",
+      "resolved": "https://registry.npmjs.org/@dust-tt/sparkle/-/sparkle-0.2.611.tgz",
+      "integrity": "sha512-0KD9QCgt7GNFI2vD9D6QJaFimOW1ruaXsY1Oc3k6vIbzXo1EjpT4LZkg8SOQK7an3O2jIJsSRFhkqzUqzoJ6iw==",
       "dependencies": {
         "@emoji-mart/data": "^1.1.2",
         "@emoji-mart/react": "^1.1.1",

--- a/extension/package.json
+++ b/extension/package.json
@@ -59,7 +59,7 @@
     "@auth0/auth0-spa-js": "^2.1.3",
     "@datadog/browser-logs": "^6.13.0",
     "@dust-tt/client": "^1.1.10",
-    "@dust-tt/sparkle": "^0.2.609",
+    "@dust-tt/sparkle": "^0.2.611-rc-2",
     "@frontapp/plugin-sdk": "^1.8.1",
     "@modelcontextprotocol/sdk": "^1.9.0",
     "@tailwindcss/forms": "^0.5.9",

--- a/extension/package.json
+++ b/extension/package.json
@@ -59,7 +59,7 @@
     "@auth0/auth0-spa-js": "^2.1.3",
     "@datadog/browser-logs": "^6.13.0",
     "@dust-tt/client": "^1.1.10",
-    "@dust-tt/sparkle": "^0.2.611-rc-2",
+    "@dust-tt/sparkle": "^0.2.611",
     "@frontapp/plugin-sdk": "^1.8.1",
     "@modelcontextprotocol/sdk": "^1.9.0",
     "@tailwindcss/forms": "^0.5.9",

--- a/front/components/agent_builder/capabilities/mcp/MCPActionHeader.tsx
+++ b/front/components/agent_builder/capabilities/mcp/MCPActionHeader.tsx
@@ -45,7 +45,7 @@ export function MCPActionHeader({
           <h2 className="heading-base line-clamp-1 text-foreground dark:text-foreground-night">
             {getMcpServerViewDisplayName(mcpServerView, newAction)}
           </h2>
-          <p className="line-clamp-2 overflow-hidden text-sm text-muted-foreground dark:text-muted-foreground-night">
+          <p className="overflow-hidden text-sm text-muted-foreground dark:text-muted-foreground-night">
             {mcpServerView.server.description}
           </p>
         </div>

--- a/front/components/agent_builder/capabilities/mcp/MCPServerSelectionPage.tsx
+++ b/front/components/agent_builder/capabilities/mcp/MCPServerSelectionPage.tsx
@@ -1,4 +1,9 @@
-import { ActionIcons, BookOpenIcon, ToolCard } from "@dust-tt/sparkle";
+import {
+  ActionIcons,
+  BookOpenIcon,
+  Hoverable,
+  ToolCard,
+} from "@dust-tt/sparkle";
 import React, { useMemo } from "react";
 
 import type { SelectedTool } from "@app/components/agent_builder/capabilities/mcp/MCPServerViewsSheet";
@@ -49,15 +54,43 @@ function MCPServerCard({ view, isSelected, onClick }: MCPServerCardProps) {
     ? ActionIcons[view.server.icon]
     : InternalActionIcons[view.server.icon] || BookOpenIcon;
 
+  // Create a ref to use as portal container for tooltips to prevent click blocking
+  const containerRef = React.useRef<HTMLDivElement>(null);
+
+  let description: React.ReactNode | null;
+  if (view.server.documentationUrl) {
+    description = (
+      <>
+        {getMcpServerViewDescription(view)} Find documentation{" "}
+        <Hoverable
+          href={view.server.documentationUrl}
+          target="_blank"
+          rel="noopener noreferrer"
+          variant="primary"
+          onClick={(e) => e.stopPropagation()}
+        >
+          here
+        </Hoverable>
+        .
+      </>
+    );
+  } else {
+    description = <>{getMcpServerViewDescription(view)}</>;
+  }
+
   return (
-    <ToolCard
-      icon={icon}
-      label={view.label}
-      description={getMcpServerViewDescription(view)}
-      isSelected={isSelected}
-      canAdd={canAdd}
-      onClick={onClick}
-    />
+    <div ref={containerRef}>
+      <ToolCard
+        icon={icon}
+        label={view.label}
+        description={description}
+        isSelected={isSelected}
+        canAdd={canAdd}
+        onClick={onClick}
+        mountPortal
+        mountPortalContainer={containerRef.current || undefined}
+      />
+    </div>
   );
 }
 

--- a/front/package-lock.json
+++ b/front/package-lock.json
@@ -7,7 +7,7 @@
       "dependencies": {
         "@datadog/browser-logs": "^6.13.0",
         "@dust-tt/client": "file:../sdks/js",
-        "@dust-tt/sparkle": "^0.2.609",
+        "@dust-tt/sparkle": "^0.2.611-rc-2",
         "@google-cloud/bigquery": "^7.9.1",
         "@google-cloud/storage-transfer": "^3.6.0",
         "@heroicons/react": "^2.0.11",
@@ -1123,9 +1123,9 @@
       "link": true
     },
     "node_modules/@dust-tt/sparkle": {
-      "version": "0.2.609",
-      "resolved": "https://registry.npmjs.org/@dust-tt/sparkle/-/sparkle-0.2.609.tgz",
-      "integrity": "sha512-vlLGs+2NbTgUO6HH5PY9dAT/Mkffo862cTt+PMrDLSa+raeb/lEst3CmtWNNHqOIoEL1GfyjdqRg8B8TzJ0mNw==",
+      "version": "0.2.611-rc-2",
+      "resolved": "https://registry.npmjs.org/@dust-tt/sparkle/-/sparkle-0.2.611-rc-2.tgz",
+      "integrity": "sha512-j7CZCBQ8490iHPyyhgsBLz4YHhvAdEv7RxveLMrFNQMsLWlKv5aXDunneKdzMXt7sjqnPVQuJhScVtMCHic65w==",
       "dependencies": {
         "@emoji-mart/data": "^1.1.2",
         "@emoji-mart/react": "^1.1.1",

--- a/front/package-lock.json
+++ b/front/package-lock.json
@@ -7,7 +7,7 @@
       "dependencies": {
         "@datadog/browser-logs": "^6.13.0",
         "@dust-tt/client": "file:../sdks/js",
-        "@dust-tt/sparkle": "^0.2.611-rc-2",
+        "@dust-tt/sparkle": "^0.2.611",
         "@google-cloud/bigquery": "^7.9.1",
         "@google-cloud/storage-transfer": "^3.6.0",
         "@heroicons/react": "^2.0.11",
@@ -1123,9 +1123,9 @@
       "link": true
     },
     "node_modules/@dust-tt/sparkle": {
-      "version": "0.2.611-rc-2",
-      "resolved": "https://registry.npmjs.org/@dust-tt/sparkle/-/sparkle-0.2.611-rc-2.tgz",
-      "integrity": "sha512-j7CZCBQ8490iHPyyhgsBLz4YHhvAdEv7RxveLMrFNQMsLWlKv5aXDunneKdzMXt7sjqnPVQuJhScVtMCHic65w==",
+      "version": "0.2.611",
+      "resolved": "https://registry.npmjs.org/@dust-tt/sparkle/-/sparkle-0.2.611.tgz",
+      "integrity": "sha512-0KD9QCgt7GNFI2vD9D6QJaFimOW1ruaXsY1Oc3k6vIbzXo1EjpT4LZkg8SOQK7an3O2jIJsSRFhkqzUqzoJ6iw==",
       "dependencies": {
         "@emoji-mart/data": "^1.1.2",
         "@emoji-mart/react": "^1.1.1",

--- a/front/package.json
+++ b/front/package.json
@@ -27,7 +27,7 @@
   "dependencies": {
     "@datadog/browser-logs": "^6.13.0",
     "@dust-tt/client": "file:../sdks/js",
-    "@dust-tt/sparkle": "^0.2.611-rc-2",
+    "@dust-tt/sparkle": "^0.2.611",
     "@google-cloud/bigquery": "^7.9.1",
     "@google-cloud/storage-transfer": "^3.6.0",
     "@heroicons/react": "^2.0.11",

--- a/front/package.json
+++ b/front/package.json
@@ -27,7 +27,7 @@
   "dependencies": {
     "@datadog/browser-logs": "^6.13.0",
     "@dust-tt/client": "file:../sdks/js",
-    "@dust-tt/sparkle": "^0.2.609",
+    "@dust-tt/sparkle": "^0.2.611-rc-2",
     "@google-cloud/bigquery": "^7.9.1",
     "@google-cloud/storage-transfer": "^3.6.0",
     "@heroicons/react": "^2.0.11",


### PR DESCRIPTION
## Description

This PR aims adds a `Tooltip` to `MCPToolCard` with truncated descriptions. When a `documentationUrl` is attached to a MCPServerView we also display the link within the `Tooltip`.

<img width="706" height="493" alt="Screenshot 2025-09-04 at 14 30 11" src="https://github.com/user-attachments/assets/55073613-eb3f-4f05-b4eb-3d0216e05807" />

## Tests

Locally

## Risk

Low

## Deploy Plan

- Merge https://github.com/dust-tt/dust/pull/15665 and publish sparkle
- Update sparkle version to GR in `front` and `extension`
- Deploy front
