### PR TITLE
Fix slideshow preview

### DIFF
--- a/front/lib/actions/mcp_internal_actions/servers/content_creation/instructions/index.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/content_creation/instructions/index.ts
@@ -74,6 +74,7 @@ You have access to a Content Creation system that allows you to create and updat
       - Label formatters: Use labelFormatter prop with a function returning a string:
         - Example: \`labelFormatter={(label) => \`Date: \${label}\`}\`
       - Always wrap charts in ChartContainer for proper sizing and theming
+      - Use proper margins to prevent label cutoff: \`margin={{ top: 20, right: 30, left: 20, bottom: 20 }}\`
       - In slideshow context, ChartContainer automatically adapts to slide dimensions - no height needed
       - For standalone components, ChartContainer may need explicit height: className="h-[400px]"
   - The papaparse library is available to be imported, e.g. \`import Papa from "papaparse"\` & \`const parsed = Papa.parse(fileContent, {header:true, skipEmptyLines: "greedy"});\`. The \`skipEmptyLines:"greedy"\` configuration should always be used.

--- a/viz/app/styles/globals.css
+++ b/viz/app/styles/globals.css
@@ -376,4 +376,10 @@
   .slide-content {
     color: hsl(var(--slide-content-text));
   }
+
+  /* Chart axis styling for better visibility in slideshows */
+  .responsive-text .recharts-cartesian-axis-tick text {
+    font-size: 14px;
+    font-weight: 600;
+  }
 }

--- a/viz/app/styles/globals.css
+++ b/viz/app/styles/globals.css
@@ -334,7 +334,7 @@
   /* Slide variant padding */
   .slide-top-padding {
     padding: var(--responsive-space-8);
-    padding-top: var(--responsive-space-24);
+    padding-top: var(--responsive-space-12);
   }
   .slide-centered-padding {
     padding: var(--responsive-space-8);

--- a/viz/components/dust/slideshow/v1/index.tsx
+++ b/viz/components/dust/slideshow/v1/index.tsx
@@ -69,7 +69,6 @@ export function SlidePreview({
               isActive && "border-primary"
             )}
           >
-            {/*  ← Pick your real slide width */}
             <SlideMiniature slide={slide} />
 
             <span className="absolute bottom-1 right-1 text-xs opacity-70 bg-background/80 px-1 rounded z-10">

--- a/viz/components/dust/slideshow/v1/index.tsx
+++ b/viz/components/dust/slideshow/v1/index.tsx
@@ -19,6 +19,27 @@ import { SlideshowNavigation } from "@viz/components/dust/slideshow/v1/navigatio
 
 // Preview components.
 
+interface SlideMiniatureProps {
+  slide: React.ReactElement;
+}
+
+export function SlideMiniature({ slide }: SlideMiniatureProps) {
+  return (
+    <div className="absolute inset-0 overflow-hidden">
+      <div
+        className="origin-top-left pointer-events-none"
+        style={{
+          width: "1920px",
+          height: "1080px",
+          transform: "scale(0.11)",
+        }}
+      >
+        {React.cloneElement(slide, { isPreview: false })}
+      </div>
+    </div>
+  );
+}
+
 interface SlidePreviewProps {
   index: number;
   isActive: boolean;
@@ -26,7 +47,12 @@ interface SlidePreviewProps {
   slide: React.ReactElement;
 }
 
-function SlidePreview({ slide, index, isActive, onClick }: SlidePreviewProps) {
+export function SlidePreview({
+  slide,
+  index,
+  isActive,
+  onClick,
+}: SlidePreviewProps) {
   return (
     <SidebarMenuItem>
       <SidebarMenuButton
@@ -38,27 +64,15 @@ function SlidePreview({ slide, index, isActive, onClick }: SlidePreviewProps) {
         <div className="w-full cursor-pointer">
           <div
             className={cn(
-              "relative w-full aspect-video rounded-xl border text-xs overflow-hidden hover:border-muted",
-              isActive ? "border-primary border-2" : "border-border"
+              "relative w-full aspect-video rounded-xl overflow-hidden hover:border-muted",
+              "border-2 border-box",
+              isActive && "border-primary"
             )}
           >
-            {/* Scaled down version of the slide */}
-            <div
-              className="w-full h-full origin-top-left pointer-events-none"
-              style={{
-                transform: "scale(0.15)",
-                width: "667%",
-                height: "667%",
-              }}
-            >
-              {React.cloneElement(slide, { isPreview: true })}
-            </div>
-            {/* Slide number overlay */}
-            <span
-              className={cn(
-                "absolute bottom-1 right-1 text-xs opacity-70 bg-background/80 px-1 rounded z-10"
-              )}
-            >
+            {/*  ← Pick your real slide width */}
+            <SlideMiniature slide={slide} />
+
+            <span className="absolute bottom-1 right-1 text-xs opacity-70 bg-background/80 px-1 rounded z-10">
               {index + 1}
             </span>
           </div>
@@ -260,9 +274,7 @@ export function Slide({
         )}
       >
         {isPreview ? (
-          <div className="p-4 w-full h-full" style={{ fontSize: "0.4em" }}>
-            {children}
-          </div>
+          <div className="p-4 w-full h-full">{children}</div>
         ) : (
           children
         )}


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
This PR improves (best-effort) the slideshow preview broken following the recent move to a grid layout. It's best effort, previews might be slightly different than actual slide rendering. The most robust solution would be to either create image from it or render each preview in an iframe. IMHO, this current solution is enough for now.

<img width="257" height="1776" alt="image" src="https://github.com/user-attachments/assets/077368a5-be2b-4c4b-a8ca-482d4f450734" />

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
