### PR TITLE
fix(husky): use git rev-parse to get the current branch

### DIFF
--- a/.husky/post-merge
+++ b/.husky/post-merge
@@ -6,7 +6,7 @@ then
   exit 0
 fi
 
-current_branch=$(git symbolic-ref --short HEAD)
+current_branch=$(git rev-parse --abbrev-ref HEAD)
 if [ "$current_branch" = "main" ]
 then
     ./front/admin/copy_apps.sh

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,7 +1,7 @@
 #!/bin/sh
 
 # Check if the current branch is 'main'
-current_branch=$(git symbolic-ref --short HEAD)
+current_branch=$(git rev-parse --abbrev-ref HEAD)
 if [ "$current_branch" = "main" ]; then
     # Check if the flag is set
     if [ -z "$ALLOW_MAIN_COMMIT" ]; then

--- a/.husky/pre-rebase
+++ b/.husky/pre-rebase
@@ -6,7 +6,7 @@ then
   exit 0
 fi
 
-current_branch=$(git symbolic-ref --short HEAD)
+current_branch=$(git rev-parse --abbrev-ref HEAD)
 if [ "$current_branch" = "main" ]
 then
     ./front/admin/copy_apps.sh


### PR DESCRIPTION
## Description

In a detached head state `symbolic-ref` fails, when `rev-parse` works. 

You can be in a detached head state when using stacking tools, like [git-spice](https://abhinav.github.io/git-spice/guide/), that I use

## Tests

Locally, I can now use git spice, and have pre-commit hooks working

Before
```
➜ gs bc -am "refactor(extension): extract function" -vvvvv
DBG Detaching HEAD  commit=chore-extension-update-dependecy
DBG git checkout: HEAD is now at 8783eb58e chore(extension): update dependecy version of the sdk to 1.1.11
fatal: ref HEAD is not a symbolic ref
husky - pre-commit script failed (code 128)
DBG Checking out branch  name=chore-extension-update-dependecy
DBG git checkout: Switched to branch 'chore-extension-update-dependecy'
FTL gs: commit: commit: exit status 1
```

Now
```
➜ gs bc -m "refactor(extension): extract function" -vvvvv 
DBG Detaching HEAD  commit=chore-extension-update-dependecy
DBG git checkout: HEAD is now at 8783eb58e chore(extension): update dependecy version of the sdk to 1.1.11
You can enable secret check by setting ENABLE_GGSHIELD_ON_COMMIT and installing ggshield
[detached HEAD 743a0d2b9] refactor(extension): extract function
 1 file changed, 26 insertions(+), 18 deletions(-)
DBG Branch name generated from commit  name=refactor-extension-extract commit=743a0d2
DBG Creating branch  name=refactor-extension-extract head=743a0d2b91b5e0098abd86888eb5c7217e37e649
DBG Checking out branch  name=refactor-extension-extract
DBG git checkout: Switched to branch 'refactor-extension-extract'
```

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
