### PR TITLE
feat(extension): add unread icon on the list of conversations

### DIFF
--- a/extension/package-lock.json
+++ b/extension/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "@auth0/auth0-spa-js": "^2.1.3",
         "@datadog/browser-logs": "^6.13.0",
-        "@dust-tt/client": "^1.1.10",
+        "@dust-tt/client": "^1.1.12",
         "@dust-tt/sparkle": "^0.2.611",
         "@frontapp/plugin-sdk": "^1.8.1",
         "@modelcontextprotocol/sdk": "^1.9.0",
@@ -271,12 +271,13 @@
       }
     },
     "node_modules/@dust-tt/client": {
-      "version": "1.1.10",
-      "resolved": "https://registry.npmjs.org/@dust-tt/client/-/client-1.1.10.tgz",
-      "integrity": "sha512-jwE0gFI2FfQYRLL6EeTEm4N3XYEajKetPtZ0Ne+oy6oAJT+3Rl60nMST8RGTWIXB2VCB43aDiv3dqfvUA2UpZw==",
+      "version": "1.1.12",
+      "resolved": "https://registry.npmjs.org/@dust-tt/client/-/client-1.1.12.tgz",
+      "integrity": "sha512-/ovlQBiYhwFXodfpmd+TVEGJnHyzuxD1N/M1WoC/it7KFSJwPgTsH3v4pr7IZ/Ux9z/kIe3uxr0R1ajKObW0jQ==",
       "bundleDependencies": [
         "@modelcontextprotocol/sdk"
       ],
+      "license": "ISC",
       "dependencies": {
         "@modelcontextprotocol/sdk": "git://github.com/dust-tt/typescript-sdk.git#628ebe48388549faae7e35504611af9ac2c6f5e4",
         "@types/json-schema": "^7.0.15",

--- a/extension/package.json
+++ b/extension/package.json
@@ -58,7 +58,7 @@
   "dependencies": {
     "@auth0/auth0-spa-js": "^2.1.3",
     "@datadog/browser-logs": "^6.13.0",
-    "@dust-tt/client": "^1.1.10",
+    "@dust-tt/client": "^1.1.12",
     "@dust-tt/sparkle": "^0.2.611",
     "@frontapp/plugin-sdk": "^1.8.1",
     "@modelcontextprotocol/sdk": "^1.9.0",

--- a/extension/ui/components/conversation/ConversationsListButton.tsx
+++ b/extension/ui/components/conversation/ConversationsListButton.tsx
@@ -15,9 +15,8 @@ import {
   Spinner,
 } from "@dust-tt/sparkle";
 import moment from "moment";
-import React from "react";
-import { useState } from "react";
-import { useNavigate, useParams } from "react-router-dom";
+import React, { useState } from "react";
+import { NavigateFunction, useNavigate, useParams } from "react-router-dom";
 
 type GroupLabel =
   | "Today"
@@ -26,6 +25,28 @@ type GroupLabel =
   | "Last Month"
   | "Last 12 Months"
   | "Older";
+
+function getDropdownMenuItem(
+  conversation: ConversationWithoutContentPublicType,
+  conversationId: string | undefined,
+  navigate: NavigateFunction
+) {
+  return (
+    <DropdownMenuItem
+      key={conversation.sId}
+      label={conversation.title || "Untitled Conversation"}
+      className={classNames(
+        "text-sm text-muted-foreground dark:text-muted-foreground-night font-normal",
+        conversationId === conversation.sId
+          ? "bg-primary-50 dark:bg-primary-50-night"
+          : ""
+      )}
+      onClick={() => {
+        navigate(`/conversations/${conversation.sId}`);
+      }}
+    />
+  );
+}
 
 const Content = () => {
   const { conversations, isConversationsLoading } = useConversations();
@@ -119,21 +140,8 @@ const Content = () => {
                 />
               )}
               {conversationsByDate[dateLabel as GroupLabel].map(
-                (conversation) => (
-                  <DropdownMenuItem
-                    key={conversation.sId}
-                    label={conversation.title || "Untitled Conversation"}
-                    className={classNames(
-                      "text-sm text-muted-foreground dark:text-muted-foreground-night font-normal",
-                      conversationId === conversation.sId
-                        ? "bg-primary-50 dark:bg-primary-50-night"
-                        : ""
-                    )}
-                    onClick={() => {
-                      navigate(`/conversations/${conversation.sId}`);
-                    }}
-                  />
-                )
+                (conversation) =>
+                  getDropdownMenuItem(conversation, conversationId, navigate)
               )}
             </React.Fragment>
           ))}

--- a/extension/ui/components/conversation/ConversationsListButton.tsx
+++ b/extension/ui/components/conversation/ConversationsListButton.tsx
@@ -16,7 +16,8 @@ import {
 } from "@dust-tt/sparkle";
 import moment from "moment";
 import React, { useState } from "react";
-import { NavigateFunction, useNavigate, useParams } from "react-router-dom";
+import type { NavigateFunction } from "react-router-dom";
+import { useNavigate, useParams } from "react-router-dom";
 
 type GroupLabel =
   | "Today"
@@ -31,10 +32,12 @@ function getDropdownMenuItem(
   conversationId: string | undefined,
   navigate: NavigateFunction
 ) {
+  const unreadIcon = conversation.unread ? "🔵 " : "";
+  const conversationLabel = conversation.title || "Untitled Conversation";
   return (
     <DropdownMenuItem
       key={conversation.sId}
-      label={conversation.title || "Untitled Conversation"}
+      label={unreadIcon + conversationLabel}
       className={classNames(
         "text-sm text-muted-foreground dark:text-muted-foreground-night font-normal",
         conversationId === conversation.sId


### PR DESCRIPTION
## Description

Add a small blue dot next to the conversation list when it's unread, in the extension.

It's less delightful than in the web, but as the `label` of the `DropdownMenuItem` is a `string` refactoring this to allow a ReactNode is probably not worth it for now

## Tests

Locally

<img width="377" height="448" alt="Screenshot 2025-09-04 at 16 00 54" src="https://github.com/user-attachments/assets/4c7df68d-b263-472b-927b-355ab5c05d48" />

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
