### PR TITLE
When searching for an agent, if dust or dust-deep are in the list of the 7 best matches, we display them first. 

### DIFF
--- a/extension/ui/components/input_bar/editor/suggestion.ts
+++ b/extension/ui/components/input_bar/editor/suggestion.ts
@@ -1,3 +1,4 @@
+import { GLOBAL_AGENTS_SID } from "@app/shared/lib/global_agents";
 import { compareForFuzzySort, subFilter } from "@app/shared/lib/utils";
 
 export interface EditorSuggestion {
@@ -15,6 +16,11 @@ export interface EditorSuggestions {
 
 const SUGGESTION_DISPLAY_LIMIT = 7;
 
+const SUGGESTION_PRIORITY: Record<string, number> = {
+  [GLOBAL_AGENTS_SID.DUST]: 1,
+  [GLOBAL_AGENTS_SID.DUST_DEEP]: 2,
+};
+
 function filterAndSortSuggestions(
   lowerCaseQuery: string,
   suggestions: EditorSuggestion[]
@@ -27,7 +33,13 @@ function filterAndSortSuggestions(
         a.label.toLocaleLowerCase(),
         b.label.toLocaleLowerCase()
       )
-    );
+    )
+    .sort((a, b) => {
+      // If within SUGGESTION_DISPLAY_LIMIT there's one from AGENT_PRIORITY, we move it to the top.
+      const aPriority = SUGGESTION_PRIORITY[a.id] ?? Number.MAX_SAFE_INTEGER;
+      const bPriority = SUGGESTION_PRIORITY[b.id] ?? Number.MAX_SAFE_INTEGER;
+      return aPriority - bPriority;
+    });
 }
 export function filterSuggestions(
   query: string,

--- a/front/components/assistant/conversation/input_bar/editor/suggestion.ts
+++ b/front/components/assistant/conversation/input_bar/editor/suggestion.ts
@@ -1,4 +1,5 @@
 import { compareForFuzzySort, subFilter } from "@app/lib/utils";
+import { GLOBAL_AGENTS_SID } from "@app/types";
 
 export interface EditorSuggestion {
   id: string;
@@ -15,6 +16,11 @@ export interface EditorSuggestions {
 
 const SUGGESTION_DISPLAY_LIMIT = 7;
 
+const SUGGESTION_PRIORITY: Record<string, number> = {
+  [GLOBAL_AGENTS_SID.DUST]: 1,
+  [GLOBAL_AGENTS_SID.DUST_DEEP]: 2,
+};
+
 function filterAndSortSuggestions(
   lowerCaseQuery: string,
   suggestions: EditorSuggestion[]
@@ -27,7 +33,13 @@ function filterAndSortSuggestions(
         a.label.toLocaleLowerCase(),
         b.label.toLocaleLowerCase()
       )
-    );
+    )
+    .sort((a, b) => {
+      // If within SUGGESTION_DISPLAY_LIMIT there's one from SUGGESTION_PRIORITY, we move it to the top.
+      const aPriority = SUGGESTION_PRIORITY[a.id] ?? Number.MAX_SAFE_INTEGER;
+      const bPriority = SUGGESTION_PRIORITY[b.id] ?? Number.MAX_SAFE_INTEGER;
+      return aPriority - bPriority;
+    });
 }
 
 export function filterSuggestions(


### PR DESCRIPTION
## Description

Asking review to @spolu and @Duncid to validate they are okay with this change. 

The goal of this PR is to make dust & dust-deep more visible on the mention agent suggestion list: if within the 7 results from the fuzzy search there is dust or dust-deep, we put them first. 

Because dust-deep has a hyphen it had low chances to be displayed first. Example here of the behavior on our workspace before this PR: 

<kbd>
<img width="361" height="374" alt="Screenshot 2025-09-04 at 16 21 01" src="https://github.com/user-attachments/assets/c618a69b-2066-423f-8d05-73cb5a59cca2" />
</kbd>
<kbd>
<img width="371" height="470" alt="Screenshot 2025-09-04 at 16 21 32" src="https://github.com/user-attachments/assets/e985b47c-d4e6-489a-81a7-3c275e6ebbe3" />
</kbd>

If we merge this PR, dust and dust-deep will be the two first results (and this only if they were selected in the best 7 matches)

## Tests

Locally. 

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

Deploy front. 