### PR TITLE
Fix mark as read

### DIFF
--- a/front/components/agent_builder/capabilities/shared/ProcessingMethodSection.tsx
+++ b/front/components/agent_builder/capabilities/shared/ProcessingMethodSection.tsx
@@ -147,7 +147,7 @@ export function ProcessingMethodSection() {
         }
       }
     }
-  }, [mcpServerView, serversToDisplay, setValue, sources.in]);
+  }, [mcpServerView, serversToDisplay, setValue, sources.in, hasFeature]);
 
   return (
     <div className="mt-2 flex flex-col space-y-4">

--- a/front/components/assistant/conversation/ConversationViewer.tsx
+++ b/front/components/assistant/conversation/ConversationViewer.tsx
@@ -77,7 +77,7 @@ const ConversationViewer = React.forwardRef<
     workspaceId: owner.sId,
   });
 
-  useConversationMarkAsRead({
+  const { markAsRead } = useConversationMarkAsRead({
     conversation,
     workspaceId: owner.sId,
   });
@@ -285,9 +285,12 @@ const ConversationViewer = React.forwardRef<
             break;
 
           case "conversation_title":
-          case "agent_message_done":
             void mutateConversation();
-            void mutateConversations(); // to refresh the list of convos in the sidebar (title, unread & actionRequired)
+            void mutateConversations(); // to refresh the list of convos in the sidebar (title)
+            break;
+          case "agent_message_done":
+            // Immediate mark as read and do not mutate the list of convos in the sidebar to avoid any network request.
+            void markAsRead(conversationId, false);
             break;
           default:
             ((t: never) => {
@@ -301,6 +304,8 @@ const ConversationViewer = React.forwardRef<
       mutateConversations,
       mutateMessages,
       mutateConversationParticipants,
+      markAsRead,
+      conversationId,
     ]
   );
 

--- a/front/lib/api/assistant/conversation.ts
+++ b/front/lib/api/assistant/conversation.ts
@@ -9,7 +9,6 @@ import {
   getAgentConfigurations,
 } from "@app/lib/api/assistant/configuration/agent";
 import { getContentFragmentBlob } from "@app/lib/api/assistant/conversation/content_fragment";
-import { getConversation } from "@app/lib/api/assistant/conversation/fetch";
 import { canReadMessage } from "@app/lib/api/assistant/messages";
 import { getContentFragmentGroupIds } from "@app/lib/api/assistant/permissions";
 import {
@@ -160,7 +159,7 @@ export async function updateConversationTitle(
     conversationId: string;
     title: string;
   }
-): Promise<Result<ConversationType, ConversationError>> {
+): Promise<Result<undefined, ConversationError>> {
   const conversation = await ConversationResource.fetchById(
     auth,
     conversationId
@@ -172,7 +171,7 @@ export async function updateConversationTitle(
 
   await conversation.updateTitle(title);
 
-  return getConversation(auth, conversationId);
+  return new Ok(undefined);
 }
 
 /**

--- a/front/lib/swr/conversations.ts
+++ b/front/lib/swr/conversations.ts
@@ -508,7 +508,6 @@ export function useConversationMarkAsRead({
       return;
     }
     try {
-      console.log("Marking conversation as read");
       const response = await fetch(
         `/api/w/${workspaceId}/assistant/conversations/${conversation.sId}`,
         {
@@ -540,10 +539,8 @@ export function useConversationMarkAsRead({
   }, [conversation, workspaceId, mutateConversation, mutateConversations]);
 
   useEffect(() => {
-    console.log("useEffect", conversation);
     let timeout: NodeJS.Timeout | null = null;
     if (conversation?.sId && conversation.unread) {
-      console.log("Marking conversation as read with delay");
       timeout = setTimeout(markAsRead, DELAY_BEFORE_MARKING_AS_READ);
     }
 

--- a/front/pages/api/w/[wId]/assistant/conversations/[cId]/index.ts
+++ b/front/pages/api/w/[wId]/assistant/conversations/[cId]/index.ts
@@ -35,10 +35,16 @@ export type GetConversationsResponseBody = {
   conversation: ConversationWithoutContentType;
 };
 
+export type PatchConversationsResponseBody = {
+  success: boolean;
+};
+
 async function handler(
   req: NextApiRequest,
   res: NextApiResponse<
-    WithAPIErrorResponse<GetConversationsResponseBody | void>
+    WithAPIErrorResponse<
+      GetConversationsResponseBody | PatchConversationsResponseBody | void
+    >
   >,
   auth: Authenticator
 ): Promise<void> {
@@ -116,20 +122,13 @@ async function handler(
           if (result.isErr()) {
             return apiErrorForConversation(req, res, result.error);
           }
-          return res.status(200).json({ conversation: result.value });
+          return res.status(200).json({ success: true });
         } else if ("read" in bodyValidation.right) {
           await ConversationResource.markAsRead(auth, {
             conversation,
           });
-          const result =
-            await ConversationResource.fetchConversationWithoutContent(
-              auth,
-              cId
-            );
-          if (result.isErr()) {
-            return apiErrorForConversation(req, res, result.error);
-          }
-          return res.status(200).json({ conversation: result.value });
+
+          return res.status(200).json({ success: true });
         } else {
           return apiError(req, res, {
             status_code: 400,

--- a/sdks/js/src/types.ts
+++ b/sdks/js/src/types.ts
@@ -1753,6 +1753,14 @@ export type PatchConversationRequestType = z.infer<
   typeof PatchConversationRequestSchema
 >;
 
+export const PatchConversationsResponseSchema = z.object({
+  success: z.boolean(),
+});
+
+export type PatchConversationsResponseType = z.infer<
+  typeof PatchConversationsResponseSchema
+>;
+
 export const TokenizeResponseSchema = z.object({
   tokens: CoreAPITokenTypeSchema.array(),
 });


### PR DESCRIPTION
## Description

It was broken with multiple messages in a row when staying on the conversation page.
It was triggering more network requests as we were mutating the conversation(s) after marking read.

Reworked the approach so the hook will still automatically mark after a delay when looking at an unread conversation but instead of relying on mutating conversation(s) when a new message is coming to trigger a mark as read : if we are on the conversation we immediately mark as read and that's it.

## Tests

Local

## Risk

Low as we are back to even less load than before.

## Deploy Plan

Deploy front