### PR TITLE
400 not 500 when action not blocked

### DIFF
--- a/front/components/agent_builder/capabilities/shared/ProcessingMethodSection.tsx
+++ b/front/components/agent_builder/capabilities/shared/ProcessingMethodSection.tsx
@@ -147,7 +147,7 @@ export function ProcessingMethodSection() {
         }
       }
     }
-  }, [mcpServerView, serversToDisplay, setValue, sources.in]);
+  }, [mcpServerView, serversToDisplay, setValue, sources.in, hasFeature]);
 
   return (
     <div className="mt-2 flex flex-col space-y-4">

--- a/front/hooks/useValidateAction.ts
+++ b/front/hooks/useValidateAction.ts
@@ -50,6 +50,18 @@ export function useValidateAction({
         );
 
         if (!response.ok) {
+          try {
+            const errData = await response.json();
+            if (errData?.error.type === "action_not_blocked") {
+              // If the action is not blocked anymore, we consider the validation already
+              // successful.  This can happen if multiple clients validate the same action. We
+              // direct return a success in that case.
+              return { success: true };
+            }
+          } catch {
+            // ignore JSON parsing errors and fall through to generic error
+          }
+
           onError("Failed to assess action approval. Please try again.");
           return { success: false };
         }

--- a/front/lib/api/assistant/conversation/validate_actions.ts
+++ b/front/lib/api/assistant/conversation/validate_actions.ts
@@ -11,6 +11,7 @@ import { runAgentLoop } from "@app/lib/api/assistant/agent";
 import { getMessageChannelId } from "@app/lib/api/assistant/streaming/helpers";
 import { getRedisHybridManager } from "@app/lib/api/redis-hybrid-manager";
 import type { Authenticator } from "@app/lib/auth";
+import { DustError } from "@app/lib/error";
 import { Message } from "@app/lib/models/assistant/conversation";
 import { AgentMCPActionResource } from "@app/lib/resources/agent_mcp_action_resource";
 import { AgentStepContentResource } from "@app/lib/resources/agent_step_content_resource";
@@ -18,7 +19,6 @@ import logger from "@app/logger/logger";
 import { buildActionBaseParams } from "@app/temporal/agent_loop/lib/action_utils";
 import type { ConversationType, Result } from "@app/types";
 import { getRunAgentData } from "@app/types/assistant/agent_run";
-import { DustError } from "@app/lib/error";
 
 async function getUserMessageIdFromMessageId(
   auth: Authenticator,

--- a/front/lib/error.ts
+++ b/front/lib/error.ts
@@ -35,6 +35,8 @@ export type DustErrorCode =
   | "remote_server_not_found"
   | "internal_server_not_found"
   | "mcp_server_view_not_found"
+  | "action_not_found"
+  | "action_not_blocked"
   // Space errors
   | "space_already_exists";
 

--- a/front/pages/api/v1/w/[wId]/assistant/conversations/[cId]/messages/[mId]/validate-action.ts
+++ b/front/pages/api/v1/w/[wId]/assistant/conversations/[cId]/messages/[mId]/validate-action.ts
@@ -127,18 +127,32 @@ async function handler(
   });
 
   if (result.isErr()) {
-    return apiError(
-      req,
-      res,
-      {
-        status_code: 500,
-        api_error: {
-          type: "internal_server_error",
-          message: "Failed to validate action",
-        },
-      },
-      result.error
-    );
+    switch (result.error.code) {
+      case "action_not_blocked":
+        // The action is already unblocked, so we return a success instead.
+        return res.status(200).json({ success: true });
+      case "action_not_found":
+        return apiError(req, res, {
+          status_code: 404,
+          api_error: {
+            type: "action_not_found",
+            message: "Action not found.",
+          },
+        });
+      default:
+        return apiError(
+          req,
+          res,
+          {
+            status_code: 500,
+            api_error: {
+              type: "internal_server_error",
+              message: "Failed to validate action",
+            },
+          },
+          result.error
+        );
+    }
   }
 
   res.status(200).json({ success: true });

--- a/front/pages/api/v1/w/[wId]/assistant/conversations/[cId]/messages/[mId]/validate-action.ts
+++ b/front/pages/api/v1/w/[wId]/assistant/conversations/[cId]/messages/[mId]/validate-action.ts
@@ -129,8 +129,13 @@ async function handler(
   if (result.isErr()) {
     switch (result.error.code) {
       case "action_not_blocked":
-        // The action is already unblocked, so we return a success instead.
-        return res.status(200).json({ success: true });
+        return apiError(req, res, {
+          status_code: 404,
+          api_error: {
+            type: "action_not_blocked",
+            message: "Action not blocked.",
+          },
+        });
       case "action_not_found":
         return apiError(req, res, {
           status_code: 404,

--- a/front/pages/api/v1/w/[wId]/assistant/conversations/[cId]/messages/[mId]/validate-action.ts
+++ b/front/pages/api/v1/w/[wId]/assistant/conversations/[cId]/messages/[mId]/validate-action.ts
@@ -130,7 +130,7 @@ async function handler(
     switch (result.error.code) {
       case "action_not_blocked":
         return apiError(req, res, {
-          status_code: 404,
+          status_code: 400,
           api_error: {
             type: "action_not_blocked",
             message: "Action not blocked.",

--- a/front/pages/api/w/[wId]/assistant/conversations/[cId]/messages/[mId]/validate-action.ts
+++ b/front/pages/api/w/[wId]/assistant/conversations/[cId]/messages/[mId]/validate-action.ts
@@ -75,8 +75,13 @@ async function handler(
   if (result.isErr()) {
     switch (result.error.code) {
       case "action_not_blocked":
-        // The action is already unblocked, so we return a success instead.
-        return res.status(200).json({ success: true });
+        return apiError(req, res, {
+          status_code: 404,
+          api_error: {
+            type: "action_not_blocked",
+            message: "Action not blocked.",
+          },
+        });
       case "action_not_found":
         return apiError(req, res, {
           status_code: 404,

--- a/front/pages/api/w/[wId]/assistant/conversations/[cId]/messages/[mId]/validate-action.ts
+++ b/front/pages/api/w/[wId]/assistant/conversations/[cId]/messages/[mId]/validate-action.ts
@@ -76,7 +76,7 @@ async function handler(
     switch (result.error.code) {
       case "action_not_blocked":
         return apiError(req, res, {
-          status_code: 404,
+          status_code: 400,
           api_error: {
             type: "action_not_blocked",
             message: "Action not blocked.",

--- a/front/pages/api/w/[wId]/assistant/conversations/[cId]/messages/[mId]/validate-action.ts
+++ b/front/pages/api/w/[wId]/assistant/conversations/[cId]/messages/[mId]/validate-action.ts
@@ -74,20 +74,15 @@ async function handler(
 
   if (result.isErr()) {
     switch (result.error.code) {
+      case "action_not_blocked":
+        // The action is already unblocked, so we return a success instead.
+        return res.status(200).json({ success: true });
       case "action_not_found":
         return apiError(req, res, {
           status_code: 404,
           api_error: {
             type: "action_not_found",
             message: "Action not found.",
-          },
-        });
-      case "action_not_blocked":
-        return apiError(req, res, {
-          status_code: 400,
-          api_error: {
-            type: "action_not_blocked",
-            message: "Action is not blocked, cannot validate.",
           },
         });
       default:

--- a/front/pages/api/w/[wId]/assistant/conversations/[cId]/messages/[mId]/validate-action.ts
+++ b/front/pages/api/w/[wId]/assistant/conversations/[cId]/messages/[mId]/validate-action.ts
@@ -73,18 +73,37 @@ async function handler(
   });
 
   if (result.isErr()) {
-    return apiError(
-      req,
-      res,
-      {
-        status_code: 500,
-        api_error: {
-          type: "internal_server_error",
-          message: "Failed to validate action",
-        },
-      },
-      result.error
-    );
+    switch (result.error.code) {
+      case "action_not_found":
+        return apiError(req, res, {
+          status_code: 404,
+          api_error: {
+            type: "action_not_found",
+            message: "Action not found.",
+          },
+        });
+      case "action_not_blocked":
+        return apiError(req, res, {
+          status_code: 400,
+          api_error: {
+            type: "action_not_blocked",
+            message: "Action is not blocked, cannot validate.",
+          },
+        });
+      default:
+        return apiError(
+          req,
+          res,
+          {
+            status_code: 500,
+            api_error: {
+              type: "internal_server_error",
+              message: "Failed to validate action",
+            },
+          },
+          result.error
+        );
+    }
   }
 
   res.status(200).json({ success: true });

--- a/front/types/error.ts
+++ b/front/types/error.ts
@@ -115,6 +115,8 @@ const API_ERROR_TYPES = [
   // MCP Server Connections:
   "mcp_server_connection_not_found",
   "mcp_server_view_not_found",
+  "action_not_found",
+  "action_not_blocked",
   // Conversation:
   ...CONVERSATION_ERROR_TYPES,
   // MCP:

--- a/front/types/error.ts
+++ b/front/types/error.ts
@@ -116,7 +116,6 @@ const API_ERROR_TYPES = [
   "mcp_server_connection_not_found",
   "mcp_server_view_not_found",
   "action_not_found",
-  "action_not_blocked",
   // Conversation:
   ...CONVERSATION_ERROR_TYPES,
   // MCP:

--- a/front/types/error.ts
+++ b/front/types/error.ts
@@ -116,6 +116,7 @@ const API_ERROR_TYPES = [
   "mcp_server_connection_not_found",
   "mcp_server_view_not_found",
   "action_not_found",
+  "action_not_blocked",
   // Conversation:
   ...CONVERSATION_ERROR_TYPES,
   // MCP:


### PR DESCRIPTION
## Description

Context: https://github.com/dust-tt/tasks/issues/4003
This won't fix the error seen in the eng runner ticket but will prevent a whole lot of 500s here:
https://app.datadoghq.eu/logs?query=service%3Afront%20%40url%3A%2Fapi%2Fw%2F%2A%2Fvalidate-action%20%40statusCode%3A500&agg_m=count&agg_m_source=base&agg_t=count&clustering_pattern_field_path=message&cols=host%2Cservice&event=AwAAAZkVSovHWkGEYQAAABhBWmtWU3BWSkFBQmhLVmFPV0RqUk93QXEAAAAkZjE5OTE1NGEtYWVhZS00ZWJjLWFmNjktYzA1YzA0NjcwNjA5AAA05w&messageDisplay=inline&refresh_mode=sliding&storage=hot&stream_sort=desc&viz=stream&from_ts=1756397514721&to_ts=1757002314721&live=true

Add DustError return to validateAction helper method to be able to return granular status code in the validate-action endpoint. Handle error code for `action_not_blocked` client-side

## Tests

Tested locally

## Risk

Low

## Deploy Plan

- deploy `front`