### PR TITLE
Slack pod restart

### DIFF
--- a/connectors/src/connectors/slack/temporal/workflows.ts
+++ b/connectors/src/connectors/slack/temporal/workflows.ts
@@ -1,4 +1,6 @@
 import {
+  allHandlersFinished,
+  condition,
   continueAsNew,
   executeChild,
   proxyActivities,
@@ -216,10 +218,13 @@ export async function syncOneThreadDebounced(
     await getSlackActivities().saveSuccessSyncActivity(connectorId);
   }
 
-  // If we hit max iterations, unregister the signal handler first to prevent
-  // it from executing during continueAsNew.
+  // If we hit max iterations, ensure all handlers are finished before continuing as new.
   if (debounceCount >= MAX_DEBOUNCE_COUNT) {
+    // Unregister the signal handler to prevent new signals from being accepted.
     setHandler(newWebhookSignal, undefined);
+    // Wait for any in-progress async handlers to complete.
+    await condition(allHandlersFinished);
+    // Now safe to continue as new without losing signals or corrupting state.
     await continueAsNew(connectorId, channelId, threadTs);
   }
 
@@ -277,10 +282,13 @@ export async function syncOneMessageDebounced(
     await getSlackActivities().saveSuccessSyncActivity(connectorId);
   }
 
-  // If we hit max iterations, unregister the signal handler first to prevent
-  // it from executing during continueAsNew.
+  // If we hit max iterations, ensure all handlers are finished before continuing as new.
   if (debounceCount >= MAX_DEBOUNCE_COUNT) {
+    // Unregister the signal handler to prevent new signals from being accepted.
     setHandler(newWebhookSignal, undefined);
+    // Wait for any in-progress async handlers to complete.
+    await condition(allHandlersFinished);
+    // Now safe to continue as new without losing signals or corrupting state.
     await continueAsNew(connectorId, channelId, threadTs);
   }
 

--- a/connectors/src/connectors/slack/temporal/workflows.ts
+++ b/connectors/src/connectors/slack/temporal/workflows.ts
@@ -216,8 +216,10 @@ export async function syncOneThreadDebounced(
     await getSlackActivities().saveSuccessSyncActivity(connectorId);
   }
 
-  // If we hit max iterations, continue as new
+  // If we hit max iterations, unregister the signal handler first to prevent
+  // it from executing during continueAsNew.
   if (debounceCount >= MAX_DEBOUNCE_COUNT) {
+    setHandler(newWebhookSignal, undefined);
     await continueAsNew(connectorId, channelId, threadTs);
   }
 
@@ -275,8 +277,10 @@ export async function syncOneMessageDebounced(
     await getSlackActivities().saveSuccessSyncActivity(connectorId);
   }
 
-  // If we hit max iterations, continue as new
+  // If we hit max iterations, unregister the signal handler first to prevent
+  // it from executing during continueAsNew.
   if (debounceCount >= MAX_DEBOUNCE_COUNT) {
+    setHandler(newWebhookSignal, undefined);
     await continueAsNew(connectorId, channelId, threadTs);
   }
 


### PR DESCRIPTION
## Description


### Issue

Slack sync workflows are experiencing a LOT of pod restarts. From the discussion opened on Slack yesterday, Flav shared that the culprit is likely the call to continueAsNew. 

After a quick dig, my partial understanding is that signal handlers are still active during the workflow transition, potentially causing race conditions and workflow execution issues.

### Solution

Implemented proper signal handler cleanup before continueAsNew by:
- Unregistering signal handlers - Call setHandler(newWebhookSignal, undefined) to prevent new signals from being accepted
- Waiting for handler completion - Use await condition(allHandlersFinished) to ensure any in-progress async signal handlers complete

This follows Temporal best practices for signal handling during workflow transitions and prevents the race conditions that were causing pod restarts.

From temporal doc: https://docs.temporal.io/develop/typescript/continue-as-new#with-message-handlers
>  "If you use Updates or Signals, don't call Continue-as-New from the handlers. Instead, wait for your handlers to finish in your main Workflow before you run ContinueAsNew."


## Tests

Not tested locally. 

## Risk

Can be rolled back if everything explodes. 

## Deploy Plan

Deploy connectors. 
Hope for the best. 