### PR TITLE
[Slack] Move channel joining to Temporal workflow for join-only use case

### DIFF
--- a/connectors/src/connectors/slack/temporal/client.ts
+++ b/connectors/src/connectors/slack/temporal/client.ts
@@ -13,7 +13,10 @@ import { normalizeError } from "@connectors/types";
 import { getWeekStart } from "../lib/utils";
 import { QUEUE_NAME } from "./config";
 import { newWebhookSignal, syncChannelSignal } from "./signals";
+import type { JOIN_CHANNEL_USE_CASES } from "./workflows";
 import {
+  joinChannelWorkflow,
+  joinChannelWorkflowId,
   migrateChannelsFromLegacyBotToNewBotWorkflow,
   migrateChannelsFromLegacyBotToNewBotWorkflowId,
   slackGarbageCollectorWorkflow,
@@ -326,6 +329,51 @@ export async function launchSlackMigrateChannelsFromLegacyBotToNewBotWorkflow(
         error: e,
       },
       "Failed starting migrateChannelsFromLegacyBotToNewBot workflow."
+    );
+    return new Err(normalizeError(e));
+  }
+}
+
+export async function launchJoinChannelWorkflow(
+  connectorId: ModelId,
+  channelId: string,
+  useCase: JOIN_CHANNEL_USE_CASES
+) {
+  const client = await getTemporalClient();
+
+  const workflowId = joinChannelWorkflowId(connectorId, channelId, useCase);
+
+  try {
+    await client.workflow.start(joinChannelWorkflow, {
+      args: [connectorId, channelId, useCase],
+      taskQueue: QUEUE_NAME,
+      workflowId: workflowId,
+      searchAttributes: {
+        connectorId: [connectorId],
+      },
+      memo: {
+        connectorId: connectorId,
+      },
+    });
+
+    logger.info(
+      {
+        workflowId,
+        channelId,
+        useCase,
+      },
+      "Started joinChannel workflow."
+    );
+    return new Ok(workflowId);
+  } catch (e) {
+    logger.error(
+      {
+        workflowId,
+        channelId,
+        useCase,
+        error: e,
+      },
+      "Failed starting joinChannel workflow."
     );
     return new Err(normalizeError(e));
   }

--- a/connectors/src/connectors/slack/temporal/client.ts
+++ b/connectors/src/connectors/slack/temporal/client.ts
@@ -13,7 +13,7 @@ import { normalizeError } from "@connectors/types";
 import { getWeekStart } from "../lib/utils";
 import { QUEUE_NAME } from "./config";
 import { newWebhookSignal, syncChannelSignal } from "./signals";
-import type { JOIN_CHANNEL_USE_CASES } from "./workflows";
+import type { JoinChannelUseCaseType } from "./workflows";
 import {
   joinChannelWorkflow,
   joinChannelWorkflowId,
@@ -337,7 +337,7 @@ export async function launchSlackMigrateChannelsFromLegacyBotToNewBotWorkflow(
 export async function launchJoinChannelWorkflow(
   connectorId: ModelId,
   channelId: string,
-  useCase: JOIN_CHANNEL_USE_CASES
+  useCase: JoinChannelUseCaseType
 ) {
   const client = await getTemporalClient();
 

--- a/connectors/src/connectors/slack/temporal/workflows.ts
+++ b/connectors/src/connectors/slack/temporal/workflows.ts
@@ -13,10 +13,12 @@ import type { ModelId } from "@connectors/types";
 import { getWeekEnd, getWeekStart } from "../lib/utils";
 import { newWebhookSignal, syncChannelSignal } from "./signals";
 
-export type JOIN_CHANNEL_USE_CASES =
-  | "join-only"
-  | "auto-read"
-  | "set-permission";
+const JOIN_CHANNEL_USE_CASES = [
+  "join-only",
+  "auto-read",
+  "set-permission",
+] as const;
+export type JoinChannelUseCaseType = (typeof JOIN_CHANNEL_USE_CASES)[number];
 
 // Dynamic activity creation with fresh routing evaluation (enables retry queue switching).
 function getSlackActivities() {
@@ -375,7 +377,7 @@ export function slackGarbageCollectorWorkflowId(connectorId: ModelId) {
 export async function joinChannelWorkflow(
   connectorId: ModelId,
   channelId: string,
-  useCase: JOIN_CHANNEL_USE_CASES
+  useCase: JoinChannelUseCaseType
 ): Promise<{ success: boolean; error?: string }> {
   if (useCase === "auto-read") {
     throw new Error("auto-read use case not implemented");
@@ -402,7 +404,7 @@ export async function joinChannelWorkflow(
 export function joinChannelWorkflowId(
   connectorId: ModelId,
   channelId: string,
-  useCase: JOIN_CHANNEL_USE_CASES
+  useCase: JoinChannelUseCaseType
 ) {
   return `slack-joinChannel-${useCase}-${connectorId}-${channelId}`;
 }

--- a/connectors/src/connectors/slack/temporal/workflows.ts
+++ b/connectors/src/connectors/slack/temporal/workflows.ts
@@ -13,6 +13,11 @@ import type { ModelId } from "@connectors/types";
 import { getWeekEnd, getWeekStart } from "../lib/utils";
 import { newWebhookSignal, syncChannelSignal } from "./signals";
 
+export type JOIN_CHANNEL_USE_CASES =
+  | "join-only"
+  | "auto-read"
+  | "set-permission";
+
 // Dynamic activity creation with fresh routing evaluation (enables retry queue switching).
 function getSlackActivities() {
   const {
@@ -22,10 +27,19 @@ function getSlackActivities() {
     syncChannelMetadata,
     reportInitialSyncProgressActivity,
     getChannelsToGarbageCollect,
-    attemptChannelJoinActivity,
     deleteChannelsFromConnectorDb,
   } = proxyActivities<typeof activities>({
     startToCloseTimeout: "10 minutes",
+  });
+
+  const { attemptChannelJoinActivity } = proxyActivities<typeof activities>({
+    startToCloseTimeout: "10 minutes",
+    retry: {
+      initialInterval: "3s",
+      maximumInterval: "12s",
+      backoffCoefficient: 1.5,
+      maximumAttempts: 25,
+    },
   });
 
   const { deleteChannel, syncThread, syncChannel } = proxyActivities<
@@ -356,4 +370,39 @@ export function syncOneMessageDebouncedWorkflowId(
 
 export function slackGarbageCollectorWorkflowId(connectorId: ModelId) {
   return `slack-GarbageCollector-${connectorId}`;
+}
+
+export async function joinChannelWorkflow(
+  connectorId: ModelId,
+  channelId: string,
+  useCase: JOIN_CHANNEL_USE_CASES
+): Promise<{ success: boolean; error?: string }> {
+  if (useCase === "auto-read") {
+    throw new Error("auto-read use case not implemented");
+  }
+  if (useCase === "set-permission") {
+    throw new Error("set-permission use case not implemented");
+  }
+
+  // Handle join-only use case
+  try {
+    const success = await getSlackActivities().attemptChannelJoinActivity(
+      connectorId,
+      channelId
+    );
+    return { success };
+  } catch (error) {
+    return {
+      success: false,
+      error: error instanceof Error ? error.message : "Unknown error occurred",
+    };
+  }
+}
+
+export function joinChannelWorkflowId(
+  connectorId: ModelId,
+  channelId: string,
+  useCase: JOIN_CHANNEL_USE_CASES
+) {
+  return `slack-joinChannel-${useCase}-${connectorId}-${channelId}`;
 }


### PR DESCRIPTION
## Description
Context: [Slack thread](https://dust4ai.slack.com/archives/C050SM8NSPK/p1757002316693069)

Move the synchronous channel joining operation into an async Temporal workflow to prevent blocking and timeouts when joining multiple Slack channels. This PR implements the "join-only" use case, which is used when linking agents to channels. Follow-up PRs will handle "auto-read" and "set-permissions"

The current implementation joins channels sequentially and synchronously, which can take up to a minute per channel under rate limiting, causing API timeouts and poor user experience.

## Risks
Blast radius: Slack agent channel linking functionality
Risk: low

## Deploy Plan
- Deploy connectors service to apply the new workflow