### PR TITLE
Add `fullScreen` hash parameter when sharing content creation with conversation participants

### DIFF
--- a/front/components/assistant/conversation/content_creation/ClientExecutableRenderer.tsx
+++ b/front/components/assistant/conversation/content_creation/ClientExecutableRenderer.tsx
@@ -25,6 +25,7 @@ import type {
   ConversationWithoutContentType,
   LightWorkspaceType,
 } from "@app/types";
+import { FULL_SCREEN_HASH_PARAM } from "@app/types/conversation_side_panel";
 
 interface ExportContentDropdownProps {
   iframeRef: React.RefObject<HTMLIFrameElement>;
@@ -62,8 +63,6 @@ interface ClientExecutableRendererProps {
   fileName?: string;
   owner: LightWorkspaceType;
 }
-
-const FULL_SCREEN_HASH_PARAM = "fullScreen";
 
 export function ClientExecutableRenderer({
   conversation,

--- a/front/components/assistant/conversation/content_creation/ShareContentCreationFilePopover.tsx
+++ b/front/components/assistant/conversation/content_creation/ShareContentCreationFilePopover.tsx
@@ -24,10 +24,15 @@ import {
 } from "@dust-tt/sparkle";
 import React from "react";
 
-import { setHashParam } from "@app/hooks/useHashParams";
+import { appendHashParam } from "@app/hooks/useHashParams";
 import { useShareContentCreationFile } from "@app/lib/swr/files";
 import type { FileShareScope, LightWorkspaceType } from "@app/types";
-import { FULL_SCREEN_HASH_PARAM } from "@app/types/conversation_side_panel";
+import {
+  CONTENT_CREATION_SIDE_PANEL_TYPE,
+  FULL_SCREEN_HASH_PARAM,
+  SIDE_PANEL_HASH_PARAM,
+  SIDE_PANEL_TYPE_HASH_PARAM,
+} from "@app/types/conversation_side_panel";
 
 interface FileSharingDropdownProps {
   selectedScope: FileShareScope;
@@ -154,17 +159,28 @@ export function ShareContentCreationFilePopover({
     }
   };
 
-  // Create the URL with fullscreen parameter for conversation participants
-  const shareUrlWithFullscreen = React.useMemo(() => {
+  // Create the URL with fullscreen and side panel parameters for conversation participants
+  const shareUrlWithFullscreen = (() => {
     if (
       fileShare?.scope === "conversation_participants" &&
       fileShare?.shareUrl
     ) {
-      return setHashParam(fileShare.shareUrl, FULL_SCREEN_HASH_PARAM, "true");
+      let url = appendHashParam(
+        fileShare.shareUrl,
+        FULL_SCREEN_HASH_PARAM,
+        "true"
+      );
+      url = appendHashParam(url, SIDE_PANEL_HASH_PARAM, fileId);
+      url = appendHashParam(
+        url,
+        SIDE_PANEL_TYPE_HASH_PARAM,
+        CONTENT_CREATION_SIDE_PANEL_TYPE
+      );
+      return url;
     }
 
     return fileShare?.shareUrl ?? "";
-  }, [fileShare?.scope, fileShare?.shareUrl]);
+  })();
 
   const handleCopyLink = async () => {
     await copyToClipboard(shareUrlWithFullscreen);

--- a/front/components/assistant/conversation/content_creation/ShareContentCreationFilePopover.tsx
+++ b/front/components/assistant/conversation/content_creation/ShareContentCreationFilePopover.tsx
@@ -160,30 +160,29 @@ export function ShareContentCreationFilePopover({
   };
 
   // Create the URL with fullscreen and side panel parameters for conversation participants
-  const shareUrlWithFullscreen = (() => {
-    if (
-      fileShare?.scope === "conversation_participants" &&
-      fileShare?.shareUrl
-    ) {
-      let url = appendHashParam(
-        fileShare.shareUrl,
-        FULL_SCREEN_HASH_PARAM,
-        "true"
-      );
-      url = appendHashParam(url, SIDE_PANEL_HASH_PARAM, fileId);
-      url = appendHashParam(
-        url,
-        SIDE_PANEL_TYPE_HASH_PARAM,
-        CONTENT_CREATION_SIDE_PANEL_TYPE
-      );
-      return url;
+  const buildShareURLForConversationParticipants = (url: string) => {
+    url = appendHashParam(url, FULL_SCREEN_HASH_PARAM, "true");
+    url = appendHashParam(url, SIDE_PANEL_HASH_PARAM, fileId);
+    url = appendHashParam(
+      url,
+      SIDE_PANEL_TYPE_HASH_PARAM,
+      CONTENT_CREATION_SIDE_PANEL_TYPE
+    );
+    return url;
+  };
+
+  const getShareURL = (scope: FileShareScope) => {
+    if (scope === "conversation_participants" && fileShare?.shareUrl) {
+      return buildShareURLForConversationParticipants(fileShare.shareUrl);
     }
 
     return fileShare?.shareUrl ?? "";
-  })();
+  };
+
+  const shareURL = getShareURL(selectedScope);
 
   const handleCopyLink = async () => {
-    await copyToClipboard(shareUrlWithFullscreen);
+    await copyToClipboard(shareURL);
   };
 
   return (
@@ -251,7 +250,7 @@ export function ShareContentCreationFilePopover({
                       disabled
                       onClick={(e) => e.currentTarget.select()}
                       readOnly
-                      value={shareUrlWithFullscreen}
+                      value={shareURL}
                     />
                   </div>
                   <IconButton

--- a/front/components/assistant/conversation/content_creation/ShareContentCreationFilePopover.tsx
+++ b/front/components/assistant/conversation/content_creation/ShareContentCreationFilePopover.tsx
@@ -24,15 +24,8 @@ import {
 } from "@dust-tt/sparkle";
 import React from "react";
 
-import { appendHashParam } from "@app/hooks/useHashParams";
 import { useShareContentCreationFile } from "@app/lib/swr/files";
 import type { FileShareScope, LightWorkspaceType } from "@app/types";
-import {
-  CONTENT_CREATION_SIDE_PANEL_TYPE,
-  FULL_SCREEN_HASH_PARAM,
-  SIDE_PANEL_HASH_PARAM,
-  SIDE_PANEL_TYPE_HASH_PARAM,
-} from "@app/types/conversation_side_panel";
 
 interface FileSharingDropdownProps {
   selectedScope: FileShareScope;
@@ -159,28 +152,7 @@ export function ShareContentCreationFilePopover({
     }
   };
 
-  // Create the URL with fullscreen and side panel parameters for conversation participants
-  const buildShareURLForConversationParticipants = (url: string) => {
-    url = appendHashParam(url, FULL_SCREEN_HASH_PARAM, "true");
-    url = appendHashParam(url, SIDE_PANEL_HASH_PARAM, fileId);
-    url = appendHashParam(
-      url,
-      SIDE_PANEL_TYPE_HASH_PARAM,
-      CONTENT_CREATION_SIDE_PANEL_TYPE
-    );
-    return url;
-  };
-
-  const getShareURL = (scope: FileShareScope) => {
-    if (scope === "conversation_participants" && fileShare?.shareUrl) {
-      return buildShareURLForConversationParticipants(fileShare.shareUrl);
-    }
-
-    return fileShare?.shareUrl ?? "";
-  };
-
-  const shareURL = getShareURL(selectedScope);
-
+  const shareURL = fileShare?.shareUrl ?? "";
   const handleCopyLink = async () => {
     await copyToClipboard(shareURL);
   };

--- a/front/components/assistant/conversation/content_creation/ShareContentCreationFilePopover.tsx
+++ b/front/components/assistant/conversation/content_creation/ShareContentCreationFilePopover.tsx
@@ -24,8 +24,10 @@ import {
 } from "@dust-tt/sparkle";
 import React from "react";
 
+import { setHashParam } from "@app/hooks/useHashParams";
 import { useShareContentCreationFile } from "@app/lib/swr/files";
 import type { FileShareScope, LightWorkspaceType } from "@app/types";
+import { FULL_SCREEN_HASH_PARAM } from "@app/types/conversation_side_panel";
 
 interface FileSharingDropdownProps {
   selectedScope: FileShareScope;
@@ -152,8 +154,20 @@ export function ShareContentCreationFilePopover({
     }
   };
 
+  // Create the URL with fullscreen parameter for conversation participants
+  const shareUrlWithFullscreen = React.useMemo(() => {
+    if (
+      fileShare?.scope === "conversation_participants" &&
+      fileShare?.shareUrl
+    ) {
+      return setHashParam(fileShare.shareUrl, FULL_SCREEN_HASH_PARAM, "true");
+    }
+
+    return fileShare?.shareUrl ?? "";
+  }, [fileShare?.scope, fileShare?.shareUrl]);
+
   const handleCopyLink = async () => {
-    await copyToClipboard(fileShare?.shareUrl ?? "");
+    await copyToClipboard(shareUrlWithFullscreen);
   };
 
   return (
@@ -221,7 +235,7 @@ export function ShareContentCreationFilePopover({
                       disabled
                       onClick={(e) => e.currentTarget.select()}
                       readOnly
-                      value={fileShare?.shareUrl ?? ""}
+                      value={shareUrlWithFullscreen}
                     />
                   </div>
                   <IconButton

--- a/front/hooks/useHashParams.ts
+++ b/front/hooks/useHashParams.ts
@@ -147,24 +147,17 @@ export const useHashParam = (
   return [innerValue.val || defaultValue, setValue];
 };
 
-export const setHashParam = (
-  url: string,
-  key: string,
-  value?: string
-): string => {
-  const urlObj = new URL(url, "https://example.com");
-  const hash = urlObj.hash.slice(1);
-  const [prefix, query] = hash.split("?");
-  const searchParams = new URLSearchParams(query);
+export function appendHashParam(url: string, key: string, value: string) {
+  const urlObj = new URL(url);
+  const additionalHash = `${key}=${value}`;
 
-  if (typeof value === "undefined" || value === "") {
-    searchParams.delete(key);
+  if (urlObj.hash) {
+    // Remove the # from existing hash and append
+    const existingHash = urlObj.hash.slice(1);
+    urlObj.hash = `#${existingHash}&${additionalHash}`;
   } else {
-    searchParams.set(key, value);
+    urlObj.hash = `#${additionalHash}`;
   }
 
-  const hashSearch = searchParams.toString();
-  urlObj.hash = hashSearch ? `${prefix}?${hashSearch}` : prefix;
-
   return urlObj.toString();
-};
+}

--- a/front/hooks/useHashParams.ts
+++ b/front/hooks/useHashParams.ts
@@ -149,14 +149,18 @@ export const useHashParam = (
 
 export function appendHashParam(url: string, key: string, value: string) {
   const urlObj = new URL(url);
-  const additionalHash = `${key}=${value}`;
+  const newParam = `${key}=${value}`;
 
-  if (urlObj.hash) {
-    // Remove the # from existing hash and append
-    const existingHash = urlObj.hash.slice(1);
-    urlObj.hash = `#?${existingHash}&${additionalHash}`;
+  // Get existing hash parameters (without the #)
+  const existingHash = urlObj.hash.slice(1);
+
+  if (existingHash) {
+    // If hash already exists, append with appropriate separator
+    const separator = existingHash.startsWith("?") ? "&" : "?";
+    urlObj.hash = `#${existingHash}${separator}${newParam}`;
   } else {
-    urlObj.hash = `#?${additionalHash}`;
+    // If no hash exists, create new one with ? prefix
+    urlObj.hash = `#?${newParam}`;
   }
 
   return urlObj.toString();

--- a/front/hooks/useHashParams.ts
+++ b/front/hooks/useHashParams.ts
@@ -146,3 +146,25 @@ export const useHashParam = (
 
   return [innerValue.val || defaultValue, setValue];
 };
+
+export const setHashParam = (
+  url: string,
+  key: string,
+  value?: string
+): string => {
+  const urlObj = new URL(url, "https://example.com");
+  const hash = urlObj.hash.slice(1);
+  const [prefix, query] = hash.split("?");
+  const searchParams = new URLSearchParams(query);
+
+  if (typeof value === "undefined" || value === "") {
+    searchParams.delete(key);
+  } else {
+    searchParams.set(key, value);
+  }
+
+  const hashSearch = searchParams.toString();
+  urlObj.hash = hashSearch ? `${prefix}?${hashSearch}` : prefix;
+
+  return urlObj.toString();
+};

--- a/front/hooks/useHashParams.ts
+++ b/front/hooks/useHashParams.ts
@@ -146,22 +146,3 @@ export const useHashParam = (
 
   return [innerValue.val || defaultValue, setValue];
 };
-
-export function appendHashParam(url: string, key: string, value: string) {
-  const urlObj = new URL(url);
-  const newParam = `${key}=${value}`;
-
-  // Get existing hash parameters (without the #)
-  const existingHash = urlObj.hash.slice(1);
-
-  if (existingHash) {
-    // If hash already exists, append with appropriate separator
-    const separator = existingHash.startsWith("?") ? "&" : "?";
-    urlObj.hash = `#${existingHash}${separator}${newParam}`;
-  } else {
-    // If no hash exists, create new one with ? prefix
-    urlObj.hash = `#?${newParam}`;
-  }
-
-  return urlObj.toString();
-}

--- a/front/hooks/useHashParams.ts
+++ b/front/hooks/useHashParams.ts
@@ -154,9 +154,9 @@ export function appendHashParam(url: string, key: string, value: string) {
   if (urlObj.hash) {
     // Remove the # from existing hash and append
     const existingHash = urlObj.hash.slice(1);
-    urlObj.hash = `#${existingHash}&${additionalHash}`;
+    urlObj.hash = `#?${existingHash}&${additionalHash}`;
   } else {
-    urlObj.hash = `#${additionalHash}`;
+    urlObj.hash = `#?${additionalHash}`;
   }
 
   return urlObj.toString();

--- a/front/pages/share/file/[token].tsx
+++ b/front/pages/share/file/[token].tsx
@@ -55,11 +55,9 @@ export const getServerSideProps = makeGetServerSidePropsRequirementsWrapper({
 
   // If the file is shared with conversation participants, redirect to the conversation.
   if (shareScope === "conversation_participants") {
-    const destination =
-      `/w/${workspace.sId}/assistant/${file.useCaseMetadata?.conversationId}#?` +
-      `${FULL_SCREEN_HASH_PARAM}=true&` +
-      `${SIDE_PANEL_TYPE_HASH_PARAM}=${CONTENT_CREATION_SIDE_PANEL_TYPE}&` +
-      `${SIDE_PANEL_HASH_PARAM}=${file.sId}`;
+    const pathname = `/w/${workspace.sId}/assistant/${file.useCaseMetadata?.conversationId}`;
+    const hash = `#?${FULL_SCREEN_HASH_PARAM}=true&${SIDE_PANEL_TYPE_HASH_PARAM}=${CONTENT_CREATION_SIDE_PANEL_TYPE}&${SIDE_PANEL_HASH_PARAM}=${file.sId}`;
+    const destination = pathname + hash;
 
     return {
       redirect: {

--- a/front/pages/share/file/[token].tsx
+++ b/front/pages/share/file/[token].tsx
@@ -9,6 +9,7 @@ import { WorkspaceResource } from "@app/lib/resources/workspace_resource";
 import { getFaviconPath } from "@app/lib/utils";
 import {
   CONTENT_CREATION_SIDE_PANEL_TYPE,
+  FULL_SCREEN_HASH_PARAM,
   SIDE_PANEL_HASH_PARAM,
   SIDE_PANEL_TYPE_HASH_PARAM,
 } from "@app/types/conversation_side_panel";
@@ -54,12 +55,15 @@ export const getServerSideProps = makeGetServerSidePropsRequirementsWrapper({
 
   // If the file is shared with conversation participants, redirect to the conversation.
   if (shareScope === "conversation_participants") {
+    const destination =
+      `/w/${workspace.sId}/assistant/${file.useCaseMetadata?.conversationId}#?` +
+      `${FULL_SCREEN_HASH_PARAM}=true&` +
+      `${SIDE_PANEL_TYPE_HASH_PARAM}=${CONTENT_CREATION_SIDE_PANEL_TYPE}&` +
+      `${SIDE_PANEL_HASH_PARAM}=${file.sId}`;
+
     return {
       redirect: {
-        destination:
-          `/w/${workspace.sId}/assistant/${file.useCaseMetadata?.conversationId}#?` +
-          `${SIDE_PANEL_TYPE_HASH_PARAM}=${CONTENT_CREATION_SIDE_PANEL_TYPE}&` +
-          `${SIDE_PANEL_HASH_PARAM}=${file.sId}`,
+        destination,
         permanent: false,
       },
     };

--- a/front/types/conversation_side_panel.ts
+++ b/front/types/conversation_side_panel.ts
@@ -1,5 +1,6 @@
 export const SIDE_PANEL_HASH_PARAM = "spid";
 export const SIDE_PANEL_TYPE_HASH_PARAM = "spt";
+export const FULL_SCREEN_HASH_PARAM = "fullScreen";
 
 export const CONTENT_CREATION_SIDE_PANEL_TYPE = "content_creation";
 export const AGENT_ACTIONS_SIDE_PANEL_TYPE = "actions";


### PR DESCRIPTION
## Description

- Fixes https://github.com/dust-tt/tasks/issues/4041
- Add `fullScreen` hash params when sharing to conversation participants only

## Tests

https://github.com/user-attachments/assets/ead04e37-7a4b-469b-b7dc-593b17954f81

https://github.com/user-attachments/assets/f18fb66d-9053-4606-b733-31a9c09fd288

## Risk

Low.

## Deploy Plan

Deploy front
