### PR TITLE
[front] fix:  worker restart in dev

### DIFF
--- a/front/temporal/agent_loop/worker.ts
+++ b/front/temporal/agent_loop/worker.ts
@@ -58,11 +58,7 @@ export async function runAgentLoopWorker() {
     },
   });
 
-  const shutdown = async () => {
-    worker.shutdown();
-  };
-
-  process.on("SIGTERM", () => shutdown());
+  process.on("SIGTERM", () => worker.shutdown());
 
   try {
     await worker.run(); // this resolves after shutdown completes

--- a/front/temporal/agent_loop/worker.ts
+++ b/front/temporal/agent_loop/worker.ts
@@ -58,5 +58,18 @@ export async function runAgentLoopWorker() {
     },
   });
 
-  await worker.run();
+  const shutdown = async () => {
+    worker.shutdown();
+  };
+
+  process.on("SIGTERM", () => shutdown());
+
+  try {
+    await worker.run(); // this resolves after shutdown completes
+  } catch (error) {
+    console.error("Agent loop worker error:", error);
+  } finally {
+    await connection.close();
+    process.exit(0);
+  }
 }


### PR DESCRIPTION
## Description

in dev, nodemon is calling SIGTERM on the worker when a file is modified - handle the signal by shutting down worker and closing connections.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

dev only
