### PR TITLE
Fix: do not replay old conversation events & debounce markAsRead

### DIFF
--- a/front/lib/api/assistant/streaming/events.ts
+++ b/front/lib/api/assistant/streaming/events.ts
@@ -17,7 +17,7 @@ import type {
 } from "@app/types";
 import { assertNever } from "@app/types";
 
-async function publishConversationEvent(
+export async function publishConversationEvent(
   event: ConversationEvents,
   {
     conversationId,
@@ -32,7 +32,10 @@ async function publishConversationEvent(
   await redisHybridManager.publish(
     conversationChannel,
     JSON.stringify(event),
-    "user_message_events"
+    "user_message_events",
+    // Conversation & message initial states are setup before starting to listen to events so we really care about getting new events.
+    // We are setting a low value to accomodate for reconnections to the event stream.
+    5
   );
 }
 
@@ -96,6 +99,7 @@ function isMessageEventParams(
     case "user_message_new":
     case "agent_message_new":
     case "agent_message_done":
+    case "conversation_title":
       return false;
     default:
       assertNever(eventType);

--- a/front/lib/api/assistant/streaming/types.ts
+++ b/front/lib/api/assistant/streaming/types.ts
@@ -6,6 +6,7 @@ import type {
   AgentMessageDoneEvent,
   AgentMessageNewEvent,
   AgentMessageSuccessEvent,
+  ConversationTitleEvent,
   GenerationTokensEvent,
   ToolErrorEvent,
   UserMessageNewEvent,
@@ -21,6 +22,7 @@ export type AgentMessageEvents =
   | ToolErrorEvent;
 
 export type ConversationEvents =
+  | ConversationTitleEvent
   | AgentMessageNewEvent
   | UserMessageNewEvent
   | AgentMessageDoneEvent;

--- a/front/lib/api/redis-hybrid-manager.ts
+++ b/front/lib/api/redis-hybrid-manager.ts
@@ -187,7 +187,8 @@ class RedisHybridManager {
   public async publish(
     channelName: string,
     data: string,
-    origin: RedisUsageTagsType
+    origin: RedisUsageTagsType,
+    ttl: number = 60 * 10 // 10 minutes
   ): Promise<string> {
     const streamAndPublishClient = await this.getStreamAndPublishClient();
     const streamName = this.getStreamName(channelName);
@@ -202,7 +203,7 @@ class RedisHybridManager {
       });
 
       // Set expiration on the stream
-      await streamAndPublishClient.expire(streamName, 60 * 10); // 10 minutes
+      await streamAndPublishClient.expire(streamName, ttl);
 
       const eventPayload: EventPayload = {
         id: eventId,

--- a/front/package-lock.json
+++ b/front/package-lock.json
@@ -204,7 +204,7 @@
     },
     "../sdks/js": {
       "name": "@dust-tt/client",
-      "version": "1.1.10",
+      "version": "1.1.12",
       "bundleDependencies": [
         "@modelcontextprotocol/sdk"
       ],

--- a/front/types/assistant/agent.ts
+++ b/front/types/assistant/agent.ts
@@ -286,6 +286,7 @@ export type AgentErrorEvent = {
 export type AgentMessageDoneEvent = {
   type: "agent_message_done";
   created: number;
+  conversationId: string;
   configurationId: string;
   messageId: string;
 };


### PR DESCRIPTION
## Description

We noticed that we were hitting the /messages and mark as read endpoint quite often when going back to a conversation.

Easy to repro:
- open network console
- go to a conversation, send a few messages
- go to another and back to the first one
- notice the many conversations/[cId]/messages network calls. 

After investigation, the root cause is that we always replayed the last X minutes of conversation events, regardless of the fetched state of conversations & messages in the client even if we are already waiting for a initial loading of both before starting to listen to events.

This PR fixes it by lowering the TTL of conversations (not messages) events from 10 minutes to 5 seconds as we don't really care about past conversations events to persist. 5 seconds is to accomodate the reconnection time just in case some event coming from the outside happens in between (ie: another user message).

Also, refactored a bit the way the "agent_message_done" is sent and debounced the mark as read call with a delay of 2 seconds.

## Tests

Locally, with multiple browers on the same convo.

## Risk

Medium (events stuff) but confident.

## Deploy Plan

Deploy front