### PR TITLE
Opt: do not fetch tools until we load the tools panel

### DIFF
--- a/front/components/assistant/ToolsPicker.tsx
+++ b/front/components/assistant/ToolsPicker.tsx
@@ -9,6 +9,7 @@ import {
   DropdownMenuSeparator,
   DropdownMenuTrigger,
   Icon,
+  Spinner,
 } from "@dust-tt/sparkle";
 import { useMemo, useState } from "react";
 
@@ -52,13 +53,19 @@ export function ToolsPicker({
     () => spaces.filter((s) => s.kind === "global"),
     [spaces]
   );
-  const { serverViews: autoServerViews } = useInternalMCPServerViewsFromSpaces(
+  const { serverViews: autoServerViews, isLoading: isAutoServerViewsLoading } =
+    useInternalMCPServerViewsFromSpaces(
+      owner,
+      globalSpaces,
+      { disabled: !isOpen } // We don't want to fetch the server views when the picker is closed.
+    );
+  const {
+    serverViews: manualServerViews,
+    isLoading: isManualServerViewsLoading,
+  } = useRemoteMCPServerViewsFromSpaces(
     owner,
-    globalSpaces
-  );
-  const { serverViews: manualServerViews } = useRemoteMCPServerViewsFromSpaces(
-    owner,
-    globalSpaces
+    globalSpaces,
+    { disabled: !isOpen } // We don't want to fetch the server views when the picker is closed.
   );
 
   const {
@@ -205,7 +212,11 @@ export function ToolsPicker({
           </>
         ) : (
           <div className="flex items-center justify-center py-4 text-sm text-muted-foreground">
-            No results found
+            {isAutoServerViewsLoading || isManualServerViewsLoading ? (
+              <Spinner size="sm" />
+            ) : (
+              "No results found"
+            )}
           </div>
         )}
       </DropdownMenuContent>

--- a/front/lib/swr/mcp_servers.ts
+++ b/front/lib/swr/mcp_servers.ts
@@ -1162,7 +1162,7 @@ function useMCPServerViewsFromSpacesBase(
 export function useMCPServerViewsFromSpaces(
   owner: LightWorkspaceType,
   spaces: SpaceType[],
-  swrOptions?: SWRConfiguration
+  swrOptions?: SWRConfiguration & { disabled?: boolean }
 ) {
   return useMCPServerViewsFromSpacesBase(
     owner,
@@ -1176,7 +1176,7 @@ export function useMCPServerViewsFromSpaces(
 export function useRemoteMCPServerViewsFromSpaces(
   owner: LightWorkspaceType,
   spaces: SpaceType[],
-  swrOptions?: SWRConfiguration
+  swrOptions?: SWRConfiguration & { disabled?: boolean }
 ) {
   return useMCPServerViewsFromSpacesBase(owner, spaces, ["manual"], swrOptions);
 }
@@ -1185,7 +1185,7 @@ export function useRemoteMCPServerViewsFromSpaces(
 export function useInternalMCPServerViewsFromSpaces(
   owner: LightWorkspaceType,
   spaces: SpaceType[],
-  swrOptions?: SWRConfiguration
+  swrOptions?: SWRConfiguration & { disabled?: boolean }
 ) {
   return useMCPServerViewsFromSpacesBase(owner, spaces, ["auto"], swrOptions);
 }


### PR DESCRIPTION
## Description

No need to load the list of available tools for JIT until the button is clicked.

## Tests

Local

## Risk

Low

## Deploy Plan

Deploy front