### PR TITLE
feat(front): add a transcription service using gpt-4o-transcribe

### DIFF
--- a/front/lib/utils/transcribe_service.ts
+++ b/front/lib/utils/transcribe_service.ts
@@ -1,0 +1,116 @@
+// Transcribe service using OpenAI Whisper.
+// This module exposes two methods:
+// 1) transcribeFile: Takes an audio file/blob/buffer/stream and returns the full transcript.
+// 2) transcribeStream: Takes a Node.js FsReadStream and returns a readable stream of transcript events from OpenAI.
+//
+// Notes:
+// - This implementation targets Node.js environment where we can pass Readable streams to the
+//   OpenAI SDK.
+// - Streaming transcription uses the OpenAI SDK native streaming (no manual chunking) for models
+//   that support server-side streaming (e.g., gpt-4o-transcribe). We do not implement client-side
+//   chunking.
+
+import type formidable from "formidable";
+import fs from "fs";
+import OpenAI from "openai";
+import type { FileLike } from "openai/uploads";
+import { toFile } from "openai/uploads";
+
+import logger from "@app/logger/logger";
+import type { Result } from "@app/types";
+import { dustManagedCredentials, Err, Ok } from "@app/types";
+import { normalizeError } from "@app/types/shared/utils/error_utils";
+
+// Lazy import to avoid hard dependency until used.
+async function getOpenAI() {
+  const credentials = dustManagedCredentials();
+  return new OpenAI({ apiKey: credentials.OPENAI_API_KEY });
+}
+
+const _TRANSCRIBE_MODEL = "gpt-4o-transcribe";
+
+async function toFileLike(
+  input: formidable.File,
+  fallbackName = "audio.wav"
+): Promise<FileLike> {
+  const stream = fs.createReadStream(input.filepath);
+  const name = input.originalFilename || fallbackName;
+  return toFile(stream, name);
+}
+
+export async function transcribeFile(
+  input: formidable.File
+): Promise<Result<string, Error>> {
+  try {
+    const openai = await getOpenAI();
+    const file = await toFileLike(input);
+
+    const text = await openai.audio.transcriptions.create({
+      file,
+      model: _TRANSCRIBE_MODEL,
+      response_format: "text",
+    });
+    return new Ok(text);
+  } catch (err) {
+    const e = normalizeError(err);
+    logger.error(
+      { err: e },
+      `Failed to transcribe file with ${_TRANSCRIBE_MODEL}`
+    );
+    return new Err(e);
+  }
+}
+
+export type TranscriptionDeltaEvent = {
+  delta: string;
+  type: "delta";
+};
+
+export type TranscriptionFullTranscriptEvent = {
+  fullTranscript: string;
+  type: "fullTranscript";
+};
+
+export type TranscriptionStreamEvent =
+  | TranscriptionDeltaEvent
+  | TranscriptionFullTranscriptEvent;
+
+export async function transcribeStream(
+  input: formidable.File
+): Promise<AsyncIterable<TranscriptionStreamEvent>> {
+  const openai = await getOpenAI();
+  const file = await toFileLike(input);
+  try {
+    const evtStream = await openai.audio.transcriptions.create({
+      file,
+      model: _TRANSCRIBE_MODEL,
+      // When true, OpenAI returns a Stream<TranscriptionStreamEvent> (SSE over HTTP).
+      stream: true,
+      // For streaming with gpt-4o-transcribe, response_format must be json (SDK default).
+    });
+
+    // Map OpenAI events to a simple async iterable of text deltas.
+    return (async function* () {
+      for await (const ev of evtStream) {
+        // Two possible event types: transcript.text.delta and transcript.text.done
+        switch (ev.type) {
+          case "transcript.text.delta":
+            yield { delta: ev.delta } as TranscriptionDeltaEvent;
+            break;
+          case "transcript.text.done":
+            yield {
+              fullTranscript: ev.text,
+            } as TranscriptionFullTranscriptEvent;
+            return;
+        }
+      }
+    })();
+  } catch (err) {
+    const e = normalizeError(err);
+    logger.error(
+      { err: e },
+      `Failed to start streaming transcription with ${_TRANSCRIBE_MODEL}`
+    );
+    throw e;
+  }
+}

--- a/front/scripts/dev/transcribe_audio_file.ts
+++ b/front/scripts/dev/transcribe_audio_file.ts
@@ -1,0 +1,127 @@
+import { readFile } from "node:fs/promises";
+import { basename } from "node:path";
+
+import type formidable from "formidable";
+
+import {
+  transcribeFile,
+  transcribeStream,
+} from "@app/lib/utils/transcribe_service";
+import type { Logger } from "@app/logger/logger";
+import { makeScript } from "@app/scripts/helpers";
+import { assertNever, isDevelopment } from "@app/types";
+import { normalizeError } from "@app/types/shared/utils/error_utils";
+
+async function transcribeAudioFile(
+  {
+    file,
+    stream,
+  }: {
+    file: string;
+    stream?: boolean;
+  },
+  execute: boolean,
+  logger: Logger
+) {
+  if (!isDevelopment()) {
+    throw new Error("This script can only be run in development.");
+  }
+
+  if (!execute) {
+    logger.info({ file, stream }, "Would transcribe audio file.");
+    return;
+  }
+
+  logger.info({ file }, "Reading audio file for transcription.");
+
+  const data = await readFile(file);
+  const filename = basename(file);
+
+  logger.info(
+    { file: filename, size: data.length },
+    "Transcribing audio file."
+  );
+
+  const formidableFile = {
+    filepath: file,
+    originalFilename: filename,
+  } as unknown as formidable.File;
+
+  if (stream) {
+    // Streaming path: we read via a file stream and yield partial transcripts as they are ready.
+    logger.info({ file }, "Streaming transcription started.");
+    let totalLength = 0;
+    try {
+      for await (const event of await transcribeStream(formidableFile)) {
+        switch (event.type) {
+          case "delta":
+            totalLength += event.delta.length;
+            logger.info(
+              { chunkLength: event.delta.length },
+              "Transcription chunk."
+            );
+            // Emit chunk content as a separate log line to keep logs structured.
+            logger.info({ transcriptChunk: event.delta });
+            break;
+
+          case "fullTranscript":
+            break;
+
+          default:
+            assertNever(event);
+        }
+      }
+      logger.info({ file, totalLength }, "Streaming transcription completed.");
+    } catch (err) {
+      const e = normalizeError(err);
+      logger.error({ err: e, file }, "Failed during streaming transcription.");
+      throw e;
+    }
+    return;
+  }
+
+  // Non-streaming path
+  const transcribeResult = await transcribeFile(formidableFile);
+  if (transcribeResult.isErr()) {
+    logger.error(
+      { err: transcribeResult.error, file },
+      "Failed to transcribe audio file."
+    );
+    throw transcribeResult.error;
+  }
+
+  const text = transcribeResult.value;
+  if (text && text.trim().length > 0) {
+    // Log the transcript. Keep as info so it is captured by the app logger (GEN8).
+    logger.info(
+      { file: filename, length: text.length },
+      "Transcription completed."
+    );
+    // Emit transcript as a separate log entry to keep logs structured.
+    logger.info({ transcript: text });
+  } else {
+    logger.warn(
+      { file: filename },
+      "Transcription completed but returned empty text."
+    );
+  }
+}
+
+makeScript(
+  {
+    file: {
+      type: "string",
+      demandOption: true,
+      description: "The file to transcribe",
+    },
+    stream: {
+      type: "boolean",
+      default: false,
+      description:
+        "Use streaming transcription (transcribeStream) and log chunks as they arrive.",
+    },
+  },
+  async ({ file, execute, stream }, logger) => {
+    await transcribeAudioFile({ file, stream }, execute, logger);
+  }
+);


### PR DESCRIPTION
## Description

_Code mostly generated by Junie_

This PR adds a service to transcribe an audio file using OpenAI gpt-4o-transcribe
This allows two ways of transcribing:
1. whole file
2. streaming

## Tests

Added a script to be able to test it:
```
npx tsx scripts/dev/transcribe_audio_file.ts --file ~/Downloads/my_audio_file.mp3 --execute
[...]
{"level":"info","time":1757077798815,"pid":68739,"hostname":"Remy-Christophes-MacBook-Pro.local","execute":true,"transcript":"Bonjour, Soupinou is a really great cat et c'est l'enfant de Daphné et même qu'il a fait pipi dans In the Box of Soupinou.\n"}
```

```
➜ NODE_ENV=development npx tsx scripts/dev/transcribe_audio_file.ts --file ~/Downloads/my_audio_file.mp3 --execute --stream
[...]
[12:58:51.277] INFO (36122): Transcription chunk. {"execute":true,"chunkLength":7}
[12:58:51.277] INFO (36122): {"execute":true,"transcriptChunk":"Bonjour"}
[12:58:51.278] INFO (36122): Transcription chunk. {"execute":true,"chunkLength":1}
[12:58:51.278] INFO (36122): {"execute":true,"transcriptChunk":"à"}
[12:58:51.284] INFO (36122): Transcription chunk. {"execute":true,"chunkLength":4}
[12:58:51.285] INFO (36122): {"execute":true,"transcriptChunk":"tous"}
[12:58:51.293] INFO (36122): Transcription chunk. {"execute":true,"chunkLength":1}
[12:58:51.293] INFO (36122): {"execute":true,"transcriptChunk":","}
[12:58:51.301] INFO (36122): Transcription chunk. {"execute":true,"chunkLength":4}
[12:58:51.301] INFO (36122): {"execute":true,"transcriptChunk":"nous"}
etc.
```

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
