### PR TITLE
[front] enh: Allow system prompt split to use prompt caching

### DIFF
--- a/core/src/providers/anthropic/anthropic.rs
+++ b/core/src/providers/anthropic/anthropic.rs
@@ -50,7 +50,7 @@ fn split_system_prompt(system: &str) -> Vec<Value> {
     let mut current_section = String::new();
 
     for line in system.lines() {
-        if line.eq("---") {
+        if line.eq("\x00\x00\x00") {
             // Save previous section if it exists
             if !current_section.trim().is_empty() {
                 sections.push(json!({
@@ -60,7 +60,7 @@ fn split_system_prompt(system: &str) -> Vec<Value> {
                 }));
             }
             // Start new section
-            current_section = line.to_string() + "\n";
+            current_section = "".to_string();
         } else {
             current_section.push_str(line);
             current_section.push('\n');
@@ -140,8 +140,8 @@ impl AnthropicLLM {
 
         if system.is_some() {
             if prompt_caching {
-                // For prompt caching, we split the system prompt into sections based on the --- separator.
-                // In order to be cached each section must be entirely identical, so we let the caller place the --- separator to isolate dynamic sections.
+                // For prompt caching, we split the system prompt into sections based on the \x00\x00\x00 separator.
+                // In order to be cached each section must be entirely identical, so we let the caller place the separator to isolate dynamic sections.
                 let system_str = system.as_ref().unwrap();
                 let sections = split_system_prompt(system_str);
                 body["system"] = json!(sections);

--- a/core/src/providers/anthropic/anthropic.rs
+++ b/core/src/providers/anthropic/anthropic.rs
@@ -45,6 +45,40 @@ fn get_max_tokens(model_id: &str) -> u64 {
     }
 }
 
+fn split_system_prompt(system: &str) -> Vec<Value> {
+    let mut sections = Vec::new();
+    let mut current_section = String::new();
+
+    for line in system.lines() {
+        if line.eq("---") {
+            // Save previous section if it exists
+            if !current_section.trim().is_empty() {
+                sections.push(json!({
+                    "type": "text",
+                    "text": current_section.trim(),
+                    "cache_control": {"type": "ephemeral"}
+                }));
+            }
+            // Start new section
+            current_section = line.to_string() + "\n";
+        } else {
+            current_section.push_str(line);
+            current_section.push('\n');
+        }
+    }
+
+    // Add the last section
+    if !current_section.trim().is_empty() {
+        sections.push(json!({
+            "type": "text",
+            "text": current_section.trim(),
+            "cache_control": {"type": "ephemeral"}
+        }));
+    }
+
+    sections
+}
+
 impl AnthropicLLM {
     pub fn new(id: String) -> Self {
         Self {
@@ -106,7 +140,11 @@ impl AnthropicLLM {
 
         if system.is_some() {
             if prompt_caching {
-                body["system"] = json!([{"type": "text", "text": system, "cache_control": {"type": "ephemeral"}}]);
+                // For prompt caching, we split the system prompt into sections based on the --- separator.
+                // In order to be cached each section must be entirely identical, so we let the caller place the --- separator to isolate dynamic sections.
+                let system_str = system.as_ref().unwrap();
+                let sections = split_system_prompt(system_str);
+                body["system"] = json!(sections);
             } else {
                 body["system"] = json!(system);
             }

--- a/front/lib/api/assistant/generation.ts
+++ b/front/lib/api/assistant/generation.ts
@@ -26,6 +26,8 @@ import type {
 } from "@app/types";
 import { CHAIN_OF_THOUGHT_META_PROMPT } from "@app/types/assistant/chain_of_thought_meta_prompt";
 
+const SYSTEM_PROMPT_SEPARATOR = "\n---\n\n";
+
 /**
  * Generation of the prompt for agents with multiple actions.
  *
@@ -216,6 +218,9 @@ export async function constructPromptMultiActions(
     userMessage.context.fullName || "Unknown user"
   );
 
+  // Escape the system prompt separator so that it can't be used in the agent instructions.
+  instructions = instructions.replaceAll(SYSTEM_PROMPT_SEPARATOR, "\n----\n\n");
+
   // Replacement if instructions includes "{ASSISTANTS_LIST}"
   if (instructions.includes("{ASSISTANTS_LIST}") && agentsList) {
     instructions = instructions.replaceAll(
@@ -231,7 +236,6 @@ export async function constructPromptMultiActions(
     );
   }
 
-  const prompt = `${context}\n${toolsSection}\n${attachmentsSection}\n${guidelinesSection}\n${instructions}`;
-
+  const prompt = `${context}${SYSTEM_PROMPT_SEPARATOR}${toolsSection}\n${attachmentsSection}\n${guidelinesSection}\n${instructions}`;
   return prompt;
 }

--- a/front/lib/api/assistant/generation.ts
+++ b/front/lib/api/assistant/generation.ts
@@ -26,7 +26,7 @@ import type {
 } from "@app/types";
 import { CHAIN_OF_THOUGHT_META_PROMPT } from "@app/types/assistant/chain_of_thought_meta_prompt";
 
-const SYSTEM_PROMPT_SEPARATOR = "\n---\n\n";
+const SYSTEM_PROMPT_SEPARATOR = "\x00\x00\x00\n";
 
 /**
  * Generation of the prompt for agents with multiple actions.
@@ -235,7 +235,10 @@ export async function constructPromptMultiActions(
         .join("\n")
     );
   }
-
-  const prompt = `${context}${SYSTEM_PROMPT_SEPARATOR}${toolsSection}\n${attachmentsSection}\n${guidelinesSection}\n${instructions}`;
+  const separator = agentConfiguration.model.promptCaching
+    ? SYSTEM_PROMPT_SEPARATOR
+    : "";
+  const prompt = `${context}\n${separator}${toolsSection}\n${attachmentsSection}\n${guidelinesSection}\n${instructions}`;
+  console.log("prompt", prompt);
   return prompt;
 }


### PR DESCRIPTION
## Description

This adds a separator in prompt between the "Context" part, which is dynamic, and the rest, more static. This is interpreted by `anthropic.rs` to split the system prompt in multiple parts, enabling the possibility to cache the second one.
Separator is composed of \x00 chars and is only added when promptCaching is enabled (dust-deep), and is removed when we split. (  \x00 are anyway not interpreted by tokenizers, so would not not have any impact if still there )

## Tests

Locally, with multiple models

## Risk

Enabled only on dust-deep

## Deploy Plan

deploy core+front
