### PR TITLE
feat(front): add an endpoint to transcribe an audio file

### DIFF
--- a/front/lib/utils/transcribe_service.ts
+++ b/front/lib/utils/transcribe_service.ts
@@ -1,0 +1,116 @@
+// Transcribe service using OpenAI Whisper.
+// This module exposes two methods:
+// 1) transcribeFile: Takes an audio file/blob/buffer/stream and returns the full transcript.
+// 2) transcribeStream: Takes a Node.js FsReadStream and returns a readable stream of transcript events from OpenAI.
+//
+// Notes:
+// - This implementation targets Node.js environment where we can pass Readable streams to the
+//   OpenAI SDK.
+// - Streaming transcription uses the OpenAI SDK native streaming (no manual chunking) for models
+//   that support server-side streaming (e.g., gpt-4o-transcribe). We do not implement client-side
+//   chunking.
+
+import type formidable from "formidable";
+import fs from "fs";
+import OpenAI from "openai";
+import type { FileLike } from "openai/uploads";
+import { toFile } from "openai/uploads";
+
+import logger from "@app/logger/logger";
+import type { Result } from "@app/types";
+import { dustManagedCredentials, Err, Ok } from "@app/types";
+import { normalizeError } from "@app/types/shared/utils/error_utils";
+
+// Lazy import to avoid hard dependency until used.
+async function getOpenAI() {
+  const credentials = dustManagedCredentials();
+  return new OpenAI({ apiKey: credentials.OPENAI_API_KEY });
+}
+
+const _TRANSCRIBE_MODEL = "gpt-4o-transcribe";
+
+async function toFileLike(
+  input: formidable.File,
+  fallbackName = "audio.wav"
+): Promise<FileLike> {
+  const stream = fs.createReadStream(input.filepath);
+  const name = input.originalFilename || fallbackName;
+  return toFile(stream, name);
+}
+
+export async function transcribeFile(
+  input: formidable.File
+): Promise<Result<string, Error>> {
+  try {
+    const openai = await getOpenAI();
+    const file = await toFileLike(input);
+
+    const text = await openai.audio.transcriptions.create({
+      file,
+      model: _TRANSCRIBE_MODEL,
+      response_format: "text",
+    });
+    return new Ok(text);
+  } catch (err) {
+    const e = normalizeError(err);
+    logger.error(
+      { err: e },
+      `Failed to transcribe file with ${_TRANSCRIBE_MODEL}`
+    );
+    return new Err(e);
+  }
+}
+
+export type TranscriptionDeltaEvent = {
+  delta: string;
+  type: "delta";
+};
+
+export type TranscriptionFullTranscriptEvent = {
+  fullTranscript: string;
+  type: "fullTranscript";
+};
+
+export type TranscriptionStreamEvent =
+  | TranscriptionDeltaEvent
+  | TranscriptionFullTranscriptEvent;
+
+export async function transcribeStream(
+  input: formidable.File
+): Promise<AsyncIterable<TranscriptionStreamEvent>> {
+  const openai = await getOpenAI();
+  const file = await toFileLike(input);
+  try {
+    const evtStream = await openai.audio.transcriptions.create({
+      file,
+      model: _TRANSCRIBE_MODEL,
+      // When true, OpenAI returns a Stream<TranscriptionStreamEvent> (SSE over HTTP).
+      stream: true,
+      // For streaming with gpt-4o-transcribe, response_format must be json (SDK default).
+    });
+
+    // Map OpenAI events to a simple async iterable of text deltas.
+    return (async function* () {
+      for await (const ev of evtStream) {
+        // Two possible event types: transcript.text.delta and transcript.text.done
+        switch (ev.type) {
+          case "transcript.text.delta":
+            yield { delta: ev.delta } as TranscriptionDeltaEvent;
+            break;
+          case "transcript.text.done":
+            yield {
+              fullTranscript: ev.text,
+            } as TranscriptionFullTranscriptEvent;
+            return;
+        }
+      }
+    })();
+  } catch (err) {
+    const e = normalizeError(err);
+    logger.error(
+      { err: e },
+      `Failed to start streaming transcription with ${_TRANSCRIBE_MODEL}`
+    );
+    throw e;
+  }
+}

--- a/front/pages/api/w/[wId]/services/transcribe/index.ts
+++ b/front/pages/api/w/[wId]/services/transcribe/index.ts
@@ -1,0 +1,146 @@
+import formidable from "formidable";
+import type { NextApiRequest, NextApiResponse } from "next";
+
+import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
+import {
+  transcribeFile,
+  transcribeStream,
+} from "@app/lib/utils/transcribe_service";
+import logger from "@app/logger/logger";
+import { apiError } from "@app/logger/withlogging";
+import type { WithAPIErrorResponse } from "@app/types";
+import { assertNever } from "@app/types";
+import { normalizeError } from "@app/types/shared/utils/error_utils";
+
+export const config = {
+  api: {
+    // We need the raw request stream for streaming audio and for formidable to parse multipart.
+    bodyParser: false,
+  },
+};
+
+export type PostTranscribeResponseBody = { text: string };
+
+async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse<WithAPIErrorResponse<PostTranscribeResponseBody | void>>
+) {
+  const { wId } = req.query;
+  if (!wId || typeof wId !== "string") {
+    return apiError(req, res, {
+      status_code: 400,
+      api_error: {
+        type: "invalid_request_error",
+        message:
+          "The request query is invalid, expects { workspaceId: string }.",
+      },
+    });
+  }
+  if (req.method !== "POST") {
+    res.setHeader("Allow", "POST");
+    res.status(405).json({
+      error: {
+        type: "method_not_supported_error",
+        message: "The method passed is not supported, POST is expected.",
+      },
+    });
+    return;
+  }
+
+  const form = formidable({ multiples: false });
+  const [, files] = await form.parse(req);
+  const maybeFiles = files.file;
+
+  if (!maybeFiles || maybeFiles.length !== 1) {
+    return apiError(req, res, {
+      status_code: 400,
+      api_error: {
+        type: "invalid_request_error",
+        message: "No file uploaded",
+      },
+    });
+  }
+  const file = maybeFiles[0];
+  const streamResponse = req.query.stream === "true" || false;
+
+  try {
+    if (!streamResponse) {
+      const r = await transcribeFile(file);
+      if (r.isErr()) {
+        logger.error(
+          { err: r.error, wId },
+          "Transcription failed for uploaded file."
+        );
+        res.status(500).json({
+          error: {
+            type: "internal_server_error",
+            message: "Failed to transcribe file. Please try again later.",
+          },
+        });
+        return;
+      }
+      res.status(200).json({ text: r.value });
+      return;
+    }
+
+    res.writeHead(200, {
+      "Content-Type": "text/event-stream",
+      "Cache-Control": "no-cache",
+      Connection: "keep-alive",
+    });
+    res.flushHeaders();
+
+    // Create an AbortController to handle client disconnection
+    const controller = new AbortController();
+    const { signal } = controller;
+
+    // Handle client disconnection
+    req.on("close", () => {
+      controller.abort();
+    });
+
+    const stream = await transcribeStream(file);
+    for await (const chunk of stream) {
+      let stop = false;
+      switch (chunk.type) {
+        case "delta":
+          res.write(
+            `data: ${JSON.stringify({ type: "delta", delta: chunk.delta })}\n\n`
+          );
+          // @ts-expect-error - We need it for streaming, but it does not exist in the types.
+          res.flush();
+          break;
+
+        case "fullTranscript":
+          res.write(
+            `data: ${JSON.stringify({ type: "fullTranscript", fullTranscript: chunk.fullTranscript })}\n\n`
+          );
+          stop = true;
+          break;
+
+        default:
+          assertNever(chunk);
+      }
+
+      if (signal.aborted || stop) {
+        break;
+      }
+    }
+    res.write("data: done\n\n");
+    // @ts-expect-error - We need it for streaming, but it does not exist in the types.
+    res.flush();
+
+    res.end();
+  } catch (e) {
+    const err = normalizeError(e);
+    logger.error({ err, wId }, "Unexpected error in transcribe endpoint.");
+    res.status(500).json({
+      error: {
+        type: "internal_server_error",
+        message: "Failed to transcribe file. Please try again later.",
+      },
+    });
+  }
+}
+
+export default withSessionAuthenticationForWorkspace(handler);

--- a/front/pages/w/[wId]/labs/index.tsx
+++ b/front/pages/w/[wId]/labs/index.tsx
@@ -1,5 +1,6 @@
 import {
   ActionCodeBoxIcon,
+  BellIcon,
   BookOpenIcon,
   ContextItem,
   EyeIcon,
@@ -52,6 +53,14 @@ const LABS_FEATURES: LabsFeatureItemType[] = [
     description:
       "Monitor and track MCP (Model Context Protocol) actions executed by your agents.",
     onlyAdminCanManage: true,
+  },
+  {
+    id: "transcription",
+    label: "Audio transcription",
+    featureFlag: "simple_audio_transcription",
+    visibleWithoutAccess: false,
+    icon: BellIcon,
+    description: "Transcribe audio files using state-of-the-art models.",
   },
 ];
 

--- a/front/pages/w/[wId]/labs/transcription/index.tsx
+++ b/front/pages/w/[wId]/labs/transcription/index.tsx
@@ -1,0 +1,242 @@
+import { BookOpenIcon, Page } from "@dust-tt/sparkle";
+import type { InferGetServerSidePropsType } from "next";
+import type { FormEvent, ReactElement } from "react";
+import { useRef, useState } from "react";
+
+import { ConversationsNavigationProvider } from "@app/components/assistant/conversation/ConversationsNavigationProvider";
+import { AssistantSidebarMenu } from "@app/components/assistant/conversation/SidebarMenu";
+import { AppCenteredLayout } from "@app/components/sparkle/AppCenteredLayout";
+import AppRootLayout from "@app/components/sparkle/AppRootLayout";
+import { getFeatureFlags } from "@app/lib/auth";
+import { withDefaultUserAuthRequirements } from "@app/lib/iam/session";
+import type {
+  SubscriptionType,
+  WhitelistableFeature,
+  WorkspaceType,
+} from "@app/types";
+
+export const getServerSideProps = withDefaultUserAuthRequirements<{
+  owner: WorkspaceType;
+  subscription: SubscriptionType;
+  featureFlags: WhitelistableFeature[];
+}>(async (_, auth) => {
+  const owner = auth.workspace();
+  const subscription = auth.subscription();
+  const user = auth.user();
+
+  if (!owner || !subscription || !user) {
+    return {
+      notFound: true,
+    };
+  }
+
+  const featureFlags = await getFeatureFlags(owner);
+  if (!featureFlags.includes("simple_audio_transcription")) {
+    return {
+      notFound: true,
+    };
+  }
+
+  return {
+    props: {
+      owner,
+      subscription,
+      featureFlags,
+    },
+  };
+});
+
+export default function LabsTranscriptionIndex({
+  owner,
+  subscription,
+}: InferGetServerSidePropsType<typeof getServerSideProps>) {
+  const wId = owner.sId;
+
+  const [selectedFile, setSelectedFile] = useState<File | null>(null);
+  const [useStreaming, setUseStreaming] = useState<boolean>(true);
+  const [isLoading, setIsLoading] = useState<boolean>(false);
+  const [error, setError] = useState<string | null>(null);
+  const [transcript, setTranscript] = useState<string>("");
+  const [partial, setPartial] = useState<string>("");
+  const abortRef = useRef<AbortController | null>(null);
+
+  const reset = () => {
+    setError(null);
+    setTranscript("");
+    setPartial("");
+  };
+
+  const handleCancel = () => {
+    const a = abortRef.current;
+    if (a) {
+      a.abort();
+    }
+  };
+
+  const handleSubmit = async (e: FormEvent<HTMLFormElement>) => {
+    e.preventDefault();
+    reset();
+    if (!selectedFile) {
+      setError("Please select an audio file.");
+      return;
+    }
+
+    const form = new FormData();
+    form.append("file", selectedFile);
+    const resp = await fetch(
+      `/api/w/${wId}/services/transcribe?stream=${useStreaming}`,
+      {
+        method: "POST",
+        body: form,
+      }
+    );
+
+    try {
+      setIsLoading(true);
+      if (useStreaming) {
+        // Streamed transcription: POST raw audio and parse SSE response.
+        abortRef.current = new AbortController();
+        setPartial("");
+        setTranscript("");
+        if (!resp.ok || !resp.body) {
+          const msg = await resp.text();
+          throw new Error(msg || "Failed to stream transcription.");
+        }
+        const reader = resp.body.getReader();
+        const decoder = new TextDecoder();
+        let buffer = "";
+        // Read until stream ends or aborted.
+        // eslint-disable-next-line no-constant-condition
+        while (true) {
+          const { done, value } = await reader.read();
+          if (done) {
+            break;
+          }
+          buffer += decoder.decode(value, { stream: true });
+          // Parse SSE messages separated by double newlines.
+          const parts = buffer.split("\n\n");
+          buffer = parts.pop() || "";
+          for (const part of parts) {
+            if (!part) {
+              continue;
+            }
+            if (part === "data: done") {
+              break;
+            }
+
+            const payload = JSON.parse(part.replace("data: ", "")) as {
+              type: string;
+              delta?: string;
+              fullTranscript?: string;
+            };
+            if (payload.type === "delta") {
+              setPartial((p) => p + payload.delta);
+            } else if (payload.type === "fullTranscript") {
+              setTranscript(payload.fullTranscript!);
+            }
+          }
+        }
+      } else {
+        const json = (await resp.json()) as { text?: string };
+        setTranscript(json.text || "");
+      }
+    } finally {
+      setIsLoading(false);
+      abortRef.current = null;
+    }
+  };
+
+  return (
+    <ConversationsNavigationProvider>
+      <AppCenteredLayout
+        subscription={subscription}
+        owner={owner}
+        pageTitle="Dust - Transcription tools"
+        navChildren={<AssistantSidebarMenu owner={owner} />}
+      >
+        <Page>
+          <Page.Header title="Transcriptions tools" icon={BookOpenIcon} />
+          <Page.Layout direction="vertical">
+            <form
+              onSubmit={handleSubmit}
+              style={{
+                display: "flex",
+                flexDirection: "column",
+                gap: 12,
+                maxWidth: 640,
+              }}
+            >
+              <label>
+                Audio file
+                <input
+                  type="file"
+                  accept="audio/*"
+                  onChange={(e) => {
+                    const f = e.currentTarget.files?.[0] || null;
+                    setSelectedFile(f);
+                  }}
+                  disabled={isLoading}
+                />
+              </label>
+
+              <label style={{ display: "flex", alignItems: "center", gap: 8 }}>
+                <input
+                  type="checkbox"
+                  checked={useStreaming}
+                  onChange={(e) => setUseStreaming(e.currentTarget.checked)}
+                  disabled={isLoading}
+                />
+                Stream results
+              </label>
+
+              <div style={{ display: "flex", gap: 8 }}>
+                <button type="submit" disabled={isLoading || !selectedFile}>
+                  {isLoading
+                    ? useStreaming
+                      ? "Streaming…"
+                      : "Transcribing…"
+                    : "Transcribe"}
+                </button>
+                {isLoading ? (
+                  <button type="button" onClick={handleCancel}>
+                    Cancel
+                  </button>
+                ) : (
+                  <button
+                    type="button"
+                    onClick={reset}
+                    disabled={!transcript && !partial && !error}
+                  >
+                    Reset
+                  </button>
+                )}
+              </div>
+
+              {error ? (
+                <div style={{ color: "red" }}>Error: {error}</div>
+              ) : null}
+
+              {useStreaming && (partial || isLoading) ? (
+                <div>
+                  <div style={{ fontWeight: 600 }}>Partial transcript</div>
+                  <pre style={{ whiteSpace: "pre-wrap" }}>{partial}</pre>
+                </div>
+              ) : null}
+
+              {transcript ? (
+                <div>
+                  <div style={{ fontWeight: 600 }}>Final transcript</div>
+                  <pre style={{ whiteSpace: "pre-wrap" }}>{transcript}</pre>
+                </div>
+              ) : null}
+            </form>
+          </Page.Layout>
+        </Page>
+      </AppCenteredLayout>
+    </ConversationsNavigationProvider>
+  );
+}
+
+LabsTranscriptionIndex.getLayout = (page: ReactElement) => {
+  return <AppRootLayout>{page}</AppRootLayout>;
+};

--- a/front/scripts/dev/transcribe_audio_file.ts
+++ b/front/scripts/dev/transcribe_audio_file.ts
@@ -1,0 +1,127 @@
+import { readFile } from "node:fs/promises";
+import { basename } from "node:path";
+
+import type formidable from "formidable";
+
+import {
+  transcribeFile,
+  transcribeStream,
+} from "@app/lib/utils/transcribe_service";
+import type { Logger } from "@app/logger/logger";
+import { makeScript } from "@app/scripts/helpers";
+import { assertNever, isDevelopment } from "@app/types";
+import { normalizeError } from "@app/types/shared/utils/error_utils";
+
+async function transcribeAudioFile(
+  {
+    file,
+    stream,
+  }: {
+    file: string;
+    stream?: boolean;
+  },
+  execute: boolean,
+  logger: Logger
+) {
+  if (!isDevelopment()) {
+    throw new Error("This script can only be run in development.");
+  }
+
+  if (!execute) {
+    logger.info({ file, stream }, "Would transcribe audio file.");
+    return;
+  }
+
+  logger.info({ file }, "Reading audio file for transcription.");
+
+  const data = await readFile(file);
+  const filename = basename(file);
+
+  logger.info(
+    { file: filename, size: data.length },
+    "Transcribing audio file."
+  );
+
+  const formidableFile = {
+    filepath: file,
+    originalFilename: filename,
+  } as unknown as formidable.File;
+
+  if (stream) {
+    // Streaming path: we read via a file stream and yield partial transcripts as they are ready.
+    logger.info({ file }, "Streaming transcription started.");
+    let totalLength = 0;
+    try {
+      for await (const event of await transcribeStream(formidableFile)) {
+        switch (event.type) {
+          case "delta":
+            totalLength += event.delta.length;
+            logger.info(
+              { chunkLength: event.delta.length },
+              "Transcription chunk."
+            );
+            // Emit chunk content as a separate log line to keep logs structured.
+            logger.info({ transcriptChunk: event.delta });
+            break;
+
+          case "fullTranscript":
+            break;
+
+          default:
+            assertNever(event);
+        }
+      }
+      logger.info({ file, totalLength }, "Streaming transcription completed.");
+    } catch (err) {
+      const e = normalizeError(err);
+      logger.error({ err: e, file }, "Failed during streaming transcription.");
+      throw e;
+    }
+    return;
+  }
+
+  // Non-streaming path
+  const transcribeResult = await transcribeFile(formidableFile);
+  if (transcribeResult.isErr()) {
+    logger.error(
+      { err: transcribeResult.error, file },
+      "Failed to transcribe audio file."
+    );
+    throw transcribeResult.error;
+  }
+
+  const text = transcribeResult.value;
+  if (text && text.trim().length > 0) {
+    // Log the transcript. Keep as info so it is captured by the app logger (GEN8).
+    logger.info(
+      { file: filename, length: text.length },
+      "Transcription completed."
+    );
+    // Emit transcript as a separate log entry to keep logs structured.
+    logger.info({ transcript: text });
+  } else {
+    logger.warn(
+      { file: filename },
+      "Transcription completed but returned empty text."
+    );
+  }
+}
+
+makeScript(
+  {
+    file: {
+      type: "string",
+      demandOption: true,
+      description: "The file to transcribe",
+    },
+    stream: {
+      type: "boolean",
+      default: false,
+      description:
+        "Use streaming transcription (transcribeStream) and log chunks as they arrive.",
+    },
+  },
+  async ({ file, execute, stream }, logger) => {
+    await transcribeAudioFile({ file, stream }, execute, logger);
+  }
+);

--- a/front/types/labs.ts
+++ b/front/types/labs.ts
@@ -10,7 +10,12 @@ export const labsTranscriptsProviders = [
 export type LabsTranscriptsProviderType =
   (typeof labsTranscriptsProviders)[number];
 
-export const labsFeatures = ["transcripts", "trackers", "mcp_actions"] as const;
+export const labsFeatures = [
+  "transcripts",
+  "trackers",
+  "mcp_actions",
+  "transcription",
+] as const;
 export type LabsFeatureType = (typeof labsFeatures)[number];
 
 // Types

--- a/front/types/shared/feature_flags.ts
+++ b/front/types/shared/feature_flags.ts
@@ -169,6 +169,10 @@ export const WHITELISTABLE_FEATURES_CONFIG = {
       "Enhanced default agent feature for Slack channels - auto-respond to all messages in channel",
     stage: "dust_only",
   },
+  simple_audio_transcription: {
+    description: "Simple Audio transcription feature",
+    stage: "dust_only",
+  },
 } as const satisfies Record<string, FeatureFlag>;
 
 export type FeatureFlagStage = "dust_only" | "rolling_out" | "on_demand";

--- a/sdks/js/src/types.ts
+++ b/sdks/js/src/types.ts
@@ -626,6 +626,7 @@ const WhitelistableFeaturesSchema = FlexibleEnumSchema<
   | "toolsets_tool"
   | "usage_data_api"
   | "xai_feature"
+  | "simple_audio_transcription"
 >();
 
 export type WhitelistableFeature = z.infer<typeof WhitelistableFeaturesSchema>;


### PR DESCRIPTION
## Description

This PR adds an HTTP endpoint that allows to transcribe an audio file. 
It supports 2 outputs:
1. whole transcription
2. stream, with a streaming of transcriptions chunks

I also added a feature flag so we can hide features around voice.


## Tests

The PR also adds a _very_ crude UI, only accessible internally and _not_ to customers, to test the HTTP endpoint

https://github.com/user-attachments/assets/85f0d191-186d-420e-9157-fb61f9d9cdf7


## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
