### PR TITLE
feat(extension): handle marking as read conversations

### DIFF
--- a/extension/package-lock.json
+++ b/extension/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "@auth0/auth0-spa-js": "^2.1.3",
         "@datadog/browser-logs": "^6.13.0",
-        "@dust-tt/client": "^1.1.12",
+        "@dust-tt/client": "^1.1.13",
         "@dust-tt/sparkle": "^0.2.612",
         "@frontapp/plugin-sdk": "^1.8.1",
         "@modelcontextprotocol/sdk": "^1.9.0",
@@ -271,9 +271,9 @@
       }
     },
     "node_modules/@dust-tt/client": {
-      "version": "1.1.12",
-      "resolved": "https://registry.npmjs.org/@dust-tt/client/-/client-1.1.12.tgz",
-      "integrity": "sha512-/ovlQBiYhwFXodfpmd+TVEGJnHyzuxD1N/M1WoC/it7KFSJwPgTsH3v4pr7IZ/Ux9z/kIe3uxr0R1ajKObW0jQ==",
+      "version": "1.1.13",
+      "resolved": "https://registry.npmjs.org/@dust-tt/client/-/client-1.1.13.tgz",
+      "integrity": "sha512-YJaXgn/nH7ZNFJUTjjS30m+FEujraw1S1aR6vsT/p4Yaxz8s7pwEViWLYXivPRlwiQBaK08fn2+ruG9qPfah7A==",
       "bundleDependencies": [
         "@modelcontextprotocol/sdk"
       ],

--- a/extension/package.json
+++ b/extension/package.json
@@ -58,7 +58,7 @@
   "dependencies": {
     "@auth0/auth0-spa-js": "^2.1.3",
     "@datadog/browser-logs": "^6.13.0",
-    "@dust-tt/client": "^1.1.12",
+    "@dust-tt/client": "^1.1.13",
     "@dust-tt/sparkle": "^0.2.612",
     "@frontapp/plugin-sdk": "^1.8.1",
     "@modelcontextprotocol/sdk": "^1.9.0",

--- a/extension/ui/components/conversation/useConversationMarkAsRead.ts
+++ b/extension/ui/components/conversation/useConversationMarkAsRead.ts
@@ -1,0 +1,60 @@
+import { useDustAPI } from "@app/shared/lib/dust_api";
+import { useConversations } from "@app/ui/components/conversation/useConversations";
+import { datadogLogs } from "@datadog/browser-logs";
+import type { ConversationPublicType } from "@dust-tt/client";
+import { useCallback, useEffect } from "react";
+
+const DELAY_BEFORE_MARKING_AS_READ = 2000;
+
+/**
+ * This hook can be used to automatically mark a conversation as read after a delay.
+ * It can also be used to manually mark a conversation as read.
+ */
+export function useConversationMarkAsRead({
+  conversation,
+}: {
+  conversation: ConversationPublicType | null;
+}) {
+  const { mutateConversations } = useConversations();
+  const dustAPI = useDustAPI();
+
+  const markAsRead = useCallback(
+    async (conversationId: string, mutateList: boolean): Promise<void> => {
+      const response = await dustAPI.markAsRead({
+        conversationId,
+      });
+
+      if (response.isErr()) {
+        datadogLogs.logger.error(
+          "Error marking conversation as read:",
+          response.error
+        );
+        throw new Error("Failed to mark conversation as read");
+      }
+      if (mutateList) {
+        void mutateConversations();
+      }
+    },
+    [mutateConversations]
+  );
+
+  useEffect(() => {
+    let timeout: NodeJS.Timeout | null = null;
+    if (conversation?.sId && conversation.unread) {
+      timeout = setTimeout(
+        () => markAsRead(conversation.sId, true),
+        DELAY_BEFORE_MARKING_AS_READ
+      );
+    }
+
+    return () => {
+      if (timeout) {
+        clearTimeout(timeout);
+      }
+    };
+  }, [conversation?.sId, conversation?.unread, markAsRead]);
+
+  return {
+    markAsRead,
+  };
+}


### PR DESCRIPTION
## Description

Implement "mark as read" on the chrome extension, so it behaves like the main dust app

## Tests



https://github.com/user-attachments/assets/78cebe44-a944-402c-bdfa-e4c7cddb8899



## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
