### PR TITLE
Add pokefy page to poke

### DIFF
--- a/front/components/poke/PokeNavbar.tsx
+++ b/front/components/poke/PokeNavbar.tsx
@@ -36,6 +36,7 @@ function PokeNavbar({ currentRegion, regionUrls }: PokeNavbarProps) {
           <Button href="/poke/templates" variant="ghost" label="Templates" />
           <Button href="/poke/plugins" variant="ghost" label="Plugins" />
           <Button href="/poke/kill" variant="ghost" label="Kill Switches" />
+          <Button href="/poke/pokefy" variant="ghost" label="Pokefy URL" />
         </div>
       </div>
       <div className="items-right flex gap-6">

--- a/front/lib/utils/url-to-poke.ts
+++ b/front/lib/utils/url-to-poke.ts
@@ -1,0 +1,218 @@
+/**
+ * Converts Dust webapp URLs to their poke equivalents
+ * Returns null if no poke equivalent exists
+ */
+
+interface RouteMapping {
+  pattern: RegExp;
+  pokePath: string | null;
+}
+
+const ROUTE_MAPPINGS: RouteMapping[] = [
+  // Conversations
+  {
+    pattern: /^\/w\/([^/]+)\/assistant\/([^/]+)$/,
+    pokePath: "/poke/$1/conversations/$2"
+  },
+  
+  // Assistants
+  {
+    pattern: /^\/w\/([^/]+)\/builder\/assistants\/([^/]+)$/,
+    pokePath: "/poke/$1/assistants/$2"
+  },
+  
+  // Spaces
+  {
+    pattern: /^\/w\/([^/]+)\/spaces\/([^/]+)$/,
+    pokePath: "/poke/$1/spaces/$2"
+  },
+  
+  // Apps
+  {
+    pattern: /^\/w\/([^/]+)\/spaces\/([^/]+)\/apps\/([^/]+)$/,
+    pokePath: "/poke/$1/spaces/$2/apps/$3"
+  },
+  
+  // App runs
+  {
+    pattern: /^\/w\/([^/]+)\/spaces\/([^/]+)\/apps\/([^/]+)\/runs$/,
+    pokePath: "/poke/$1/spaces/$2/apps/$3"
+  },
+  
+  // Specific app run
+  {
+    pattern: /^\/w\/([^/]+)\/spaces\/([^/]+)\/apps\/([^/]+)\/runs\/([^/]+)$/,
+    pokePath: "/poke/$1/spaces/$2/apps/$3"
+  },
+  
+  // Data source views in spaces/categories
+  {
+    pattern: /^\/w\/([^/]+)\/spaces\/([^/]+)\/categories\/[^/]+\/data_source_views\/([^/]+)$/,
+    pokePath: "/poke/$1/spaces/$2/data_source_views/$3"
+  },
+  
+  // MCP server views
+  {
+    pattern: /^\/w\/([^/]+)\/spaces\/([^/]+)\/mcp_server_views\/([^/]+)$/,
+    pokePath: "/poke/$1/spaces/$2/mcp_server_views/$3"
+  },
+  
+  // Workspace root
+  {
+    pattern: /^\/w\/([^/]+)$/,
+    pokePath: "/poke/$1"
+  },
+  
+  // Workspace/memberships
+  {
+    pattern: /^\/w\/([^/]+)\/workspace$/,
+    pokePath: "/poke/$1"
+  },
+  
+  // Members
+  {
+    pattern: /^\/w\/([^/]+)\/members$/,
+    pokePath: "/poke/$1/memberships"
+  },
+  
+  // Trackers (labs)
+  {
+    pattern: /^\/w\/([^/]+)\/labs\/trackers\/([^/]+)$/,
+    pokePath: "/poke/$1/trackers/$2"
+  },
+  
+  // Data sources (legacy)
+  {
+    pattern: /^\/w\/([^/]+)\/data_sources\/([^/]+)$/,
+    pokePath: "/poke/$1/data_sources/$2"
+  },
+  
+  // Routes without poke equivalents
+  {
+    pattern: /^\/w\/([^/]+)\/join$/,
+    pokePath: null
+  },
+  {
+    pattern: /^\/w\/([^/]+)\/subscription$/,
+    pokePath: null
+  },
+  {
+    pattern: /^\/w\/([^/]+)\/oauth\//,
+    pokePath: null
+  },
+  {
+    pattern: /^\/w\/([^/]+)\/builder\/data_sources/,
+    pokePath: null
+  },
+  {
+    pattern: /^\/w\/([^/]+)\/spaces\/([^/]+)\/categories\//,
+    pokePath: null
+  },
+  {
+    pattern: /^\/w\/([^/]+)\/spaces\/([^/]+)\/apps\/([^/]+)\/(settings|specification|datasets)/,
+    pokePath: null
+  },
+  {
+    pattern: /^\/w\/([^/]+)\/labs\/(transcripts|mcp_actions)/,
+    pokePath: null
+  }
+];
+
+export function convertUrlToPoke(url: string): string | null {
+  try {
+    const urlObj = new URL(url);
+    
+    // Check if it's a Dust domain (dust.tt or any subdomain like eu.dust.tt)
+    // Must be exactly dust.tt or *.dust.tt (not *dust.tt which would match notdust.tt)
+    if (urlObj.hostname !== 'dust.tt' && !urlObj.hostname.endsWith('.dust.tt')) {
+      return null;
+    }
+    
+    const pathname = urlObj.pathname;
+    
+    // Find matching route
+    for (const mapping of ROUTE_MAPPINGS) {
+      const match = pathname.match(mapping.pattern);
+      if (match) {
+        if (mapping.pokePath === null) {
+          return null;
+        }
+        
+        // Replace placeholders with captured groups
+        let pokePath = mapping.pokePath;
+        for (let i = 1; i < match.length; i++) {
+          pokePath = pokePath.replace(`$${i}`, match[i]);
+        }
+        
+        // Construct new URL with poke path
+        const pokeUrl = new URL(urlObj);
+        pokeUrl.pathname = pokePath;
+        
+        // Remove query params that might not be relevant in poke
+        pokeUrl.search = '';
+        
+        return pokeUrl.toString();
+      }
+    }
+    
+    // No match found
+    return null;
+  } catch (error) {
+    // Invalid URL
+    return null;
+  }
+}
+
+export function convertPokeToUrl(pokeUrl: string): string | null {
+  try {
+    const urlObj = new URL(pokeUrl);
+    
+    // Check if it's a Dust domain (dust.tt or any subdomain like eu.dust.tt)
+    // Must be exactly dust.tt or *.dust.tt (not *dust.tt which would match notdust.tt)
+    if (urlObj.hostname !== 'dust.tt' && !urlObj.hostname.endsWith('.dust.tt')) {
+      return null;
+    }
+    
+    const pathname = urlObj.pathname;
+    
+    // Check if it's a poke URL
+    if (!pathname.startsWith('/poke/')) {
+      return null;
+    }
+    
+    // Remove /poke/ prefix
+    const pokePath = pathname.slice(6);
+    
+    // Define reverse mappings
+    const reverseMappings: Array<[RegExp, string]> = [
+      [/^([^/]+)\/conversations\/([^/]+)$/, '/w/$1/assistant/$2'],
+      [/^([^/]+)\/assistants\/([^/]+)$/, '/w/$1/builder/assistants/$2'],
+      [/^([^/]+)\/spaces\/([^/]+)\/apps\/([^/]+)$/, '/w/$1/spaces/$2/apps/$3'],
+      [/^([^/]+)\/spaces\/([^/]+)\/data_source_views\/([^/]+)$/, '/w/$1/spaces/$2/categories/data/data_source_views/$3'],
+      [/^([^/]+)\/spaces\/([^/]+)\/mcp_server_views\/([^/]+)$/, '/w/$1/spaces/$2/mcp_server_views/$3'],
+      [/^([^/]+)\/spaces\/([^/]+)$/, '/w/$1/spaces/$2'],
+      [/^([^/]+)\/memberships$/, '/w/$1/members'],
+      [/^([^/]+)\/trackers\/([^/]+)$/, '/w/$1/labs/trackers/$2'],
+      [/^([^/]+)\/data_sources\/([^/]+)$/, '/w/$1/data_sources/$2'],
+      [/^([^/]+)$/, '/w/$1']
+    ];
+    
+    for (const [pattern, replacement] of reverseMappings) {
+      const match = pokePath.match(pattern);
+      if (match) {
+        let webPath = replacement;
+        for (let i = 1; i < match.length; i++) {
+          webPath = webPath.replace(`$${i}`, match[i]);
+        }
+        
+        const webUrl = new URL(urlObj);
+        webUrl.pathname = webPath;
+        return webUrl.toString();
+      }
+    }
+    
+    return null;
+  } catch (error) {
+    return null;
+  }
+}

--- a/front/lib/utils/url-to-poke.ts
+++ b/front/lib/utils/url-to-poke.ts
@@ -12,124 +12,129 @@ const ROUTE_MAPPINGS: RouteMapping[] = [
   // Conversations
   {
     pattern: /^\/w\/([^/]+)\/assistant\/([^/]+)$/,
-    pokePath: "/poke/$1/conversations/$2"
+    pokePath: "/poke/$1/conversations/$2",
   },
-  
+
   // Assistants
   {
     pattern: /^\/w\/([^/]+)\/builder\/assistants\/([^/]+)$/,
-    pokePath: "/poke/$1/assistants/$2"
+    pokePath: "/poke/$1/assistants/$2",
   },
-  
+
   // Spaces
   {
     pattern: /^\/w\/([^/]+)\/spaces\/([^/]+)$/,
-    pokePath: "/poke/$1/spaces/$2"
+    pokePath: "/poke/$1/spaces/$2",
   },
-  
+
   // Apps
   {
     pattern: /^\/w\/([^/]+)\/spaces\/([^/]+)\/apps\/([^/]+)$/,
-    pokePath: "/poke/$1/spaces/$2/apps/$3"
+    pokePath: "/poke/$1/spaces/$2/apps/$3",
   },
-  
+
   // App runs
   {
     pattern: /^\/w\/([^/]+)\/spaces\/([^/]+)\/apps\/([^/]+)\/runs$/,
-    pokePath: "/poke/$1/spaces/$2/apps/$3"
+    pokePath: "/poke/$1/spaces/$2/apps/$3",
   },
-  
+
   // Specific app run
   {
     pattern: /^\/w\/([^/]+)\/spaces\/([^/]+)\/apps\/([^/]+)\/runs\/([^/]+)$/,
-    pokePath: "/poke/$1/spaces/$2/apps/$3"
+    pokePath: "/poke/$1/spaces/$2/apps/$3",
   },
-  
+
   // Data source views in spaces/categories
   {
-    pattern: /^\/w\/([^/]+)\/spaces\/([^/]+)\/categories\/[^/]+\/data_source_views\/([^/]+)$/,
-    pokePath: "/poke/$1/spaces/$2/data_source_views/$3"
+    pattern:
+      /^\/w\/([^/]+)\/spaces\/([^/]+)\/categories\/[^/]+\/data_source_views\/([^/]+)$/,
+    pokePath: "/poke/$1/spaces/$2/data_source_views/$3",
   },
-  
+
   // MCP server views
   {
     pattern: /^\/w\/([^/]+)\/spaces\/([^/]+)\/mcp_server_views\/([^/]+)$/,
-    pokePath: "/poke/$1/spaces/$2/mcp_server_views/$3"
+    pokePath: "/poke/$1/spaces/$2/mcp_server_views/$3",
   },
-  
+
   // Workspace root
   {
     pattern: /^\/w\/([^/]+)$/,
-    pokePath: "/poke/$1"
+    pokePath: "/poke/$1",
   },
-  
+
   // Workspace/memberships
   {
     pattern: /^\/w\/([^/]+)\/workspace$/,
-    pokePath: "/poke/$1"
+    pokePath: "/poke/$1",
   },
-  
+
   // Members
   {
     pattern: /^\/w\/([^/]+)\/members$/,
-    pokePath: "/poke/$1/memberships"
+    pokePath: "/poke/$1/memberships",
   },
-  
+
   // Trackers (labs)
   {
     pattern: /^\/w\/([^/]+)\/labs\/trackers\/([^/]+)$/,
-    pokePath: "/poke/$1/trackers/$2"
+    pokePath: "/poke/$1/trackers/$2",
   },
-  
+
   // Data sources (legacy)
   {
     pattern: /^\/w\/([^/]+)\/data_sources\/([^/]+)$/,
-    pokePath: "/poke/$1/data_sources/$2"
+    pokePath: "/poke/$1/data_sources/$2",
   },
-  
+
   // Routes without poke equivalents
   {
     pattern: /^\/w\/([^/]+)\/join$/,
-    pokePath: null
+    pokePath: null,
   },
   {
     pattern: /^\/w\/([^/]+)\/subscription$/,
-    pokePath: null
+    pokePath: null,
   },
   {
     pattern: /^\/w\/([^/]+)\/oauth\//,
-    pokePath: null
+    pokePath: null,
   },
   {
     pattern: /^\/w\/([^/]+)\/builder\/data_sources/,
-    pokePath: null
+    pokePath: null,
   },
   {
     pattern: /^\/w\/([^/]+)\/spaces\/([^/]+)\/categories\//,
-    pokePath: null
+    pokePath: null,
   },
   {
-    pattern: /^\/w\/([^/]+)\/spaces\/([^/]+)\/apps\/([^/]+)\/(settings|specification|datasets)/,
-    pokePath: null
+    pattern:
+      /^\/w\/([^/]+)\/spaces\/([^/]+)\/apps\/([^/]+)\/(settings|specification|datasets)/,
+    pokePath: null,
   },
   {
     pattern: /^\/w\/([^/]+)\/labs\/(transcripts|mcp_actions)/,
-    pokePath: null
-  }
+    pokePath: null,
+  },
 ];
 
 export function convertUrlToPoke(url: string): string | null {
   try {
     const urlObj = new URL(url);
-    
+
     // Check if it's a Dust domain (dust.tt or any subdomain like eu.dust.tt)
     // Must be exactly dust.tt or *.dust.tt (not *dust.tt which would match notdust.tt)
-    if (urlObj.hostname !== 'dust.tt' && !urlObj.hostname.endsWith('.dust.tt')) {
+    if (
+      urlObj.hostname !== "dust.tt" &&
+      !urlObj.hostname.endsWith(".dust.tt")
+    ) {
       return null;
     }
-    
+
     const pathname = urlObj.pathname;
-    
+
     // Find matching route
     for (const mapping of ROUTE_MAPPINGS) {
       const match = pathname.match(mapping.pattern);
@@ -137,24 +142,24 @@ export function convertUrlToPoke(url: string): string | null {
         if (mapping.pokePath === null) {
           return null;
         }
-        
+
         // Replace placeholders with captured groups
         let pokePath = mapping.pokePath;
         for (let i = 1; i < match.length; i++) {
           pokePath = pokePath.replace(`$${i}`, match[i]);
         }
-        
+
         // Construct new URL with poke path
         const pokeUrl = new URL(urlObj);
         pokeUrl.pathname = pokePath;
-        
+
         // Remove query params that might not be relevant in poke
-        pokeUrl.search = '';
-        
+        pokeUrl.search = "";
+
         return pokeUrl.toString();
       }
     }
-    
+
     // No match found
     return null;
   } catch (error) {
@@ -166,37 +171,46 @@ export function convertUrlToPoke(url: string): string | null {
 export function convertPokeToUrl(pokeUrl: string): string | null {
   try {
     const urlObj = new URL(pokeUrl);
-    
+
     // Check if it's a Dust domain (dust.tt or any subdomain like eu.dust.tt)
     // Must be exactly dust.tt or *.dust.tt (not *dust.tt which would match notdust.tt)
-    if (urlObj.hostname !== 'dust.tt' && !urlObj.hostname.endsWith('.dust.tt')) {
+    if (
+      urlObj.hostname !== "dust.tt" &&
+      !urlObj.hostname.endsWith(".dust.tt")
+    ) {
       return null;
     }
-    
+
     const pathname = urlObj.pathname;
-    
+
     // Check if it's a poke URL
-    if (!pathname.startsWith('/poke/')) {
+    if (!pathname.startsWith("/poke/")) {
       return null;
     }
-    
+
     // Remove /poke/ prefix
     const pokePath = pathname.slice(6);
-    
+
     // Define reverse mappings
     const reverseMappings: Array<[RegExp, string]> = [
-      [/^([^/]+)\/conversations\/([^/]+)$/, '/w/$1/assistant/$2'],
-      [/^([^/]+)\/assistants\/([^/]+)$/, '/w/$1/builder/assistants/$2'],
-      [/^([^/]+)\/spaces\/([^/]+)\/apps\/([^/]+)$/, '/w/$1/spaces/$2/apps/$3'],
-      [/^([^/]+)\/spaces\/([^/]+)\/data_source_views\/([^/]+)$/, '/w/$1/spaces/$2/categories/data/data_source_views/$3'],
-      [/^([^/]+)\/spaces\/([^/]+)\/mcp_server_views\/([^/]+)$/, '/w/$1/spaces/$2/mcp_server_views/$3'],
-      [/^([^/]+)\/spaces\/([^/]+)$/, '/w/$1/spaces/$2'],
-      [/^([^/]+)\/memberships$/, '/w/$1/members'],
-      [/^([^/]+)\/trackers\/([^/]+)$/, '/w/$1/labs/trackers/$2'],
-      [/^([^/]+)\/data_sources\/([^/]+)$/, '/w/$1/data_sources/$2'],
-      [/^([^/]+)$/, '/w/$1']
+      [/^([^/]+)\/conversations\/([^/]+)$/, "/w/$1/assistant/$2"],
+      [/^([^/]+)\/assistants\/([^/]+)$/, "/w/$1/builder/assistants/$2"],
+      [/^([^/]+)\/spaces\/([^/]+)\/apps\/([^/]+)$/, "/w/$1/spaces/$2/apps/$3"],
+      [
+        /^([^/]+)\/spaces\/([^/]+)\/data_source_views\/([^/]+)$/,
+        "/w/$1/spaces/$2/categories/data/data_source_views/$3",
+      ],
+      [
+        /^([^/]+)\/spaces\/([^/]+)\/mcp_server_views\/([^/]+)$/,
+        "/w/$1/spaces/$2/mcp_server_views/$3",
+      ],
+      [/^([^/]+)\/spaces\/([^/]+)$/, "/w/$1/spaces/$2"],
+      [/^([^/]+)\/memberships$/, "/w/$1/members"],
+      [/^([^/]+)\/trackers\/([^/]+)$/, "/w/$1/labs/trackers/$2"],
+      [/^([^/]+)\/data_sources\/([^/]+)$/, "/w/$1/data_sources/$2"],
+      [/^([^/]+)$/, "/w/$1"],
     ];
-    
+
     for (const [pattern, replacement] of reverseMappings) {
       const match = pokePath.match(pattern);
       if (match) {
@@ -204,13 +218,13 @@ export function convertPokeToUrl(pokeUrl: string): string | null {
         for (let i = 1; i < match.length; i++) {
           webPath = webPath.replace(`$${i}`, match[i]);
         }
-        
+
         const webUrl = new URL(urlObj);
         webUrl.pathname = webPath;
         return webUrl.toString();
       }
     }
-    
+
     return null;
   } catch (error) {
     return null;

--- a/front/pages/poke/pokefy.tsx
+++ b/front/pages/poke/pokefy.tsx
@@ -1,0 +1,203 @@
+import type { ReactElement } from "react";
+import { useState } from "react";
+
+import PokeLayout from "@app/components/poke/PokeLayout";
+import { withSuperUserAuthRequirements } from "@app/lib/iam/session";
+import { convertUrlToPoke } from "@app/lib/utils/url-to-poke";
+
+export const getServerSideProps = withSuperUserAuthRequirements<{
+  initialUrl?: string;
+  initialPokeUrl?: string;
+  initialError?: string;
+}>(async (context) => {
+  const { url } = context.query;
+
+  // If URL is provided as query parameter, try to convert it
+  if (url && typeof url === "string") {
+    let fullUrl = url;
+
+    // Add protocol if missing
+    if (!fullUrl.startsWith("http://") && !fullUrl.startsWith("https://")) {
+      if (fullUrl.startsWith("dust.tt/") || fullUrl.startsWith("eu.dust.tt/")) {
+        fullUrl = "https://" + fullUrl;
+      } else if (fullUrl.startsWith("w/")) {
+        const host = context.req.headers.host || "dust.tt";
+        fullUrl = `https://${host}/${fullUrl}`;
+      } else {
+        fullUrl = "https://" + fullUrl;
+      }
+    }
+
+    try {
+      const pokeUrl = convertUrlToPoke(fullUrl);
+
+      if (pokeUrl) {
+        const pokeUrlObj = new URL(pokeUrl);
+        return {
+          props: {
+            initialUrl: fullUrl,
+            initialPokeUrl: pokeUrlObj.pathname + pokeUrlObj.search,
+          },
+        };
+      } else {
+        return {
+          props: {
+            initialUrl: fullUrl,
+            initialError: "No poke page available for this URL",
+          },
+        };
+      }
+    } catch (error) {
+      return {
+        props: {
+          initialUrl: fullUrl,
+          initialError: "Invalid URL format",
+        },
+      };
+    }
+  }
+
+  return { props: {} };
+});
+
+interface PokefyPageProps {
+  initialUrl?: string;
+  initialPokeUrl?: string;
+  initialError?: string;
+}
+
+function PokefyPage({
+  initialUrl,
+  initialPokeUrl,
+  initialError,
+}: PokefyPageProps) {
+  const [url, setUrl] = useState(initialUrl || "");
+  const [error, setError] = useState(initialError || "");
+  const [result, setResult] = useState<string | null>(initialPokeUrl || null);
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    setError("");
+    setResult(null);
+
+    if (!url) {
+      setError("Please enter a URL");
+      return;
+    }
+
+    let fullUrl = url.trim();
+
+    // Add protocol if missing
+    if (!fullUrl.startsWith("http://") && !fullUrl.startsWith("https://")) {
+      if (fullUrl.startsWith("dust.tt/") || fullUrl.startsWith("eu.dust.tt/")) {
+        fullUrl = "https://" + fullUrl;
+      } else if (fullUrl.startsWith("w/")) {
+        fullUrl = `https://${window.location.hostname}/${fullUrl}`;
+      } else {
+        fullUrl = "https://" + fullUrl;
+      }
+    }
+
+    try {
+      const pokeUrl = convertUrlToPoke(fullUrl);
+
+      if (pokeUrl) {
+        const pokeUrlObj = new URL(pokeUrl);
+        // Show the poke URL instead of redirecting
+        setResult(pokeUrlObj.pathname);
+      } else {
+        setError("No poke page available for this URL");
+      }
+    } catch (err) {
+      setError("Invalid URL format");
+    }
+  };
+
+  return (
+    <div className="mx-auto max-w-4xl">
+      <h1 className="mb-4 text-2xl font-bold">Convert webapp URLs to Poke</h1>
+
+      <form onSubmit={handleSubmit} className="mt-6">
+        <div>
+          <label htmlFor="url" className="mb-2 block text-sm font-medium">
+            Enter URL to convert:
+          </label>
+          <input
+            id="url"
+            type="text"
+            value={url}
+            onChange={(e) => setUrl(e.target.value)}
+            placeholder="https://dust.tt/w/workspace/assistant/conversation"
+            className="w-full rounded-md border border-gray-300 px-3 py-2 font-mono text-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
+          />
+        </div>
+
+        <button
+          type="submit"
+          className="mt-4 rounded-md bg-blue-600 px-4 py-2 text-white transition-colors hover:bg-blue-700"
+        >
+          Convert to Poke URL
+        </button>
+      </form>
+
+      {error && (
+        <div className="mt-4 rounded-md border border-red-200 bg-red-50 p-4 text-red-700">
+          ❌ {error}
+        </div>
+      )}
+
+      {result && (
+        <div className="mt-4 rounded-md border border-green-200 bg-green-50 p-4">
+          <p className="mb-2 text-green-700">
+            ✅ <strong>Poke URL available:</strong>
+          </p>
+          <p className="text-lg">
+            <a
+              href={result}
+              className="font-bold text-blue-600 hover:text-blue-800"
+            >
+              {result}
+            </a>
+          </p>
+        </div>
+      )}
+
+      <div className="mt-10 rounded-md bg-gray-50 p-4 text-sm text-gray-600">
+        <h3 className="mb-2 font-semibold">Usage examples:</h3>
+        <ul className="space-y-1">
+          <li>
+            Enter full URL:{" "}
+            <code className="rounded bg-gray-200 px-1">
+              https://dust.tt/w/workspace/assistant/conv123
+            </code>
+          </li>
+          <li>
+            Protocol optional:{" "}
+            <code className="rounded bg-gray-200 px-1">
+              dust.tt/w/workspace/assistant/conv123
+            </code>
+          </li>
+          <li>
+            EU subdomain:{" "}
+            <code className="rounded bg-gray-200 px-1">
+              eu.dust.tt/w/workspace/assistant/conv123
+            </code>
+          </li>
+          <li>
+            Just the path:{" "}
+            <code className="rounded bg-gray-200 px-1">
+              w/workspace/assistant/conv123
+            </code>{" "}
+            (uses current domain)
+          </li>
+        </ul>
+      </div>
+    </div>
+  );
+}
+
+PokefyPage.getLayout = (page: ReactElement) => {
+  return <PokeLayout title="Pokefy">{page}</PokeLayout>;
+};
+
+export default PokefyPage;

--- a/front/pages/poke/pokefy.tsx
+++ b/front/pages/poke/pokefy.tsx
@@ -7,7 +7,6 @@ import { convertUrlToPoke } from "@app/lib/utils/url-to-poke";
 
 export const getServerSideProps = withSuperUserAuthRequirements<{
   initialUrl?: string;
-  initialPokeUrl?: string;
   initialError?: string;
 }>(async (context) => {
   const { url } = context.query;
@@ -33,10 +32,11 @@ export const getServerSideProps = withSuperUserAuthRequirements<{
 
       if (pokeUrl) {
         const pokeUrlObj = new URL(pokeUrl);
+        // Redirect directly to the poke URL when provided via query parameter
         return {
-          props: {
-            initialUrl: fullUrl,
-            initialPokeUrl: pokeUrlObj.pathname + pokeUrlObj.search,
+          redirect: {
+            destination: pokeUrlObj.pathname + pokeUrlObj.search,
+            permanent: false,
           },
         };
       } else {
@@ -62,23 +62,19 @@ export const getServerSideProps = withSuperUserAuthRequirements<{
 
 interface PokefyPageProps {
   initialUrl?: string;
-  initialPokeUrl?: string;
   initialError?: string;
 }
 
 function PokefyPage({
   initialUrl,
-  initialPokeUrl,
   initialError,
 }: PokefyPageProps) {
   const [url, setUrl] = useState(initialUrl || "");
   const [error, setError] = useState(initialError || "");
-  const [result, setResult] = useState<string | null>(initialPokeUrl || null);
 
   const handleSubmit = (e: React.FormEvent) => {
     e.preventDefault();
     setError("");
-    setResult(null);
 
     if (!url) {
       setError("Please enter a URL");
@@ -103,8 +99,8 @@ function PokefyPage({
 
       if (pokeUrl) {
         const pokeUrlObj = new URL(pokeUrl);
-        // Show the poke URL instead of redirecting
-        setResult(pokeUrlObj.pathname);
+        // Redirect directly to the poke URL
+        window.location.href = pokeUrlObj.pathname;
       } else {
         setError("No poke page available for this URL");
       }
@@ -116,6 +112,7 @@ function PokefyPage({
   return (
     <div className="mx-auto max-w-4xl">
       <h1 className="mb-4 text-2xl font-bold">Convert webapp URLs to Poke</h1>
+      <p className="text-sm text-gray-600 mb-4">Enter a Dust URL below and you'll be redirected to the poke equivalent page.</p>
 
       <form onSubmit={handleSubmit} className="mt-6">
         <div>
@@ -143,22 +140,6 @@ function PokefyPage({
       {error && (
         <div className="mt-4 rounded-md border border-red-200 bg-red-50 p-4 text-red-700">
           ❌ {error}
-        </div>
-      )}
-
-      {result && (
-        <div className="mt-4 rounded-md border border-green-200 bg-green-50 p-4">
-          <p className="mb-2 text-green-700">
-            ✅ <strong>Poke URL available:</strong>
-          </p>
-          <p className="text-lg">
-            <a
-              href={result}
-              className="font-bold text-blue-600 hover:text-blue-800"
-            >
-              {result}
-            </a>
-          </p>
         </div>
       )}
 

--- a/front/pages/poke/pokefy.tsx
+++ b/front/pages/poke/pokefy.tsx
@@ -65,10 +65,7 @@ interface PokefyPageProps {
   initialError?: string;
 }
 
-function PokefyPage({
-  initialUrl,
-  initialError,
-}: PokefyPageProps) {
+function PokefyPage({ initialUrl, initialError }: PokefyPageProps) {
   const [url, setUrl] = useState(initialUrl || "");
   const [error, setError] = useState(initialError || "");
 
@@ -112,7 +109,10 @@ function PokefyPage({
   return (
     <div className="mx-auto max-w-4xl">
       <h1 className="mb-4 text-2xl font-bold">Convert webapp URLs to Poke</h1>
-      <p className="text-sm text-gray-600 mb-4">Enter a Dust URL below and you'll be redirected to the poke equivalent page.</p>
+      <p className="mb-4 text-sm text-gray-600">
+        Enter a Dust URL below and you'll be redirected to the poke equivalent
+        page.
+      </p>
 
       <form onSubmit={handleSubmit} className="mt-6">
         <div>


### PR DESCRIPTION
## Description

We need to convert urls to poke ones - the chrome extension works great, but in front it doesn't - and not greatly discoverable (not sure wendy uses it because she always posts regular URLs, and engineers complain because they have to look at how to convert to poke). 

<img width="668" height="513" alt="Screenshot 2025-09-05 at 17 40 31" src="https://github.com/user-attachments/assets/429c2117-e3cd-4363-acf1-f8861da3cc03" />


## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
