### PR TITLE
Add Slack bot MCP server

### DIFF
--- a/front/lib/actions/mcp_internal_actions/constants.ts
+++ b/front/lib/actions/mcp_internal_actions/constants.ts
@@ -1002,6 +1002,7 @@ The directive should be used to display a clickable version of the agent name in
       read_channel_history: "never_ask" as const,
       read_thread_messages: "never_ask" as const,
     },
+    tools_retry_policies: undefined,
     timeoutMs: undefined,
     serverInfo: {
       name: "slack_bot",

--- a/front/lib/actions/mcp_internal_actions/constants.ts
+++ b/front/lib/actions/mcp_internal_actions/constants.ts
@@ -1007,7 +1007,7 @@ The directive should be used to display a clickable version of the agent name in
       name: "slack_bot",
       version: "1.0.0",
       description:
-        "Slack tools using workspace bot credentials. Messages and actions will appear as coming from the Dust Slack bot rather than your personal account. The Slack bot must be added to channels before it is able to post messages. Direct messages are not supported. For message search and private channel access, use the user credentials Slack tool instead.",
+        "Slack tools using workspace bot credentials. Messages and actions will appear as coming from the Dust Slack bot rather than your personal account.",
       authorization: {
         provider: "slack" as const,
         supported_use_cases: ["platform_actions"] as const,

--- a/front/lib/actions/mcp_internal_actions/constants.ts
+++ b/front/lib/actions/mcp_internal_actions/constants.ts
@@ -94,6 +94,7 @@ export const AVAILABLE_INTERNAL_MCP_SERVER_NAMES = [
   "run_dust_app",
   "salesforce",
   "slack",
+  "slack_bot",
   "think",
   "toolsets",
   "web_search_&_browse",
@@ -983,6 +984,40 @@ The directive should be used to display a clickable version of the agent name in
       authorization: null,
       documentationUrl: null,
       instructions: null,
+    },
+  },
+  slack_bot: {
+    id: 31,
+    availability: "manual" as const,
+    allowMultipleInstances: true,
+    isRestricted: ({ featureFlags }) => {
+      return !featureFlags.includes("slack_bot_mcp");
+    },
+    isPreview: true,
+    tools_stakes: {
+      list_public_channels: "never_ask" as const,
+      list_users: "never_ask" as const,
+      get_user: "never_ask" as const,
+      post_message: "low" as const,
+      read_channel_history: "never_ask" as const,
+      read_thread_messages: "never_ask" as const,
+    },
+    timeoutMs: undefined,
+    serverInfo: {
+      name: "slack_bot",
+      version: "1.0.0",
+      description:
+        "Slack tools using workspace bot credentials. Messages and actions will appear as coming from the Dust Slack bot rather than your personal account. The Slack bot must be added to channels before it is able to post messages. Direct messages are not supported. For message search and private channel access, use the user credentials Slack tool instead.",
+      authorization: {
+        provider: "slack" as const,
+        supported_use_cases: ["platform_actions"] as const,
+      },
+      icon: "SlackLogo",
+      documentationUrl: null,
+      instructions:
+        "When posting a message on Slack, you MUST use Slack-flavored Markdown to format the message." +
+        "IMPORTANT: if you want to mention a user, you must use <@USER_ID> where USER_ID is the id of the user you want to mention.\n" +
+        "If you want to reference a channel, you must use #CHANNEL where CHANNEL is the channel name, or <#CHANNEL_ID> where CHANNEL_ID is the channel ID.",
     },
   },
   [SEARCH_SERVER_NAME]: {

--- a/front/lib/actions/mcp_internal_actions/servers/index.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/index.ts
@@ -36,8 +36,8 @@ import { default as dustAppServer } from "@app/lib/actions/mcp_internal_actions/
 import { default as salesforceServer } from "@app/lib/actions/mcp_internal_actions/servers/salesforce";
 import { default as searchServer } from "@app/lib/actions/mcp_internal_actions/servers/search";
 import { default as slackServer } from "@app/lib/actions/mcp_internal_actions/servers/slack";
-import { default as slideshowServer } from "@app/lib/actions/mcp_internal_actions/servers/slideshow";
 import { default as slackBotServer } from "@app/lib/actions/mcp_internal_actions/servers/slack/slack_bot";
+import { default as slideshowServer } from "@app/lib/actions/mcp_internal_actions/servers/slideshow";
 import { default as tablesQueryServer } from "@app/lib/actions/mcp_internal_actions/servers/tables_query/server";
 import { default as tablesQueryServerV2 } from "@app/lib/actions/mcp_internal_actions/servers/tables_query/server_v2";
 import { default as thinkServer } from "@app/lib/actions/mcp_internal_actions/servers/think";

--- a/front/lib/actions/mcp_internal_actions/servers/index.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/index.ts
@@ -37,6 +37,7 @@ import { default as salesforceServer } from "@app/lib/actions/mcp_internal_actio
 import { default as searchServer } from "@app/lib/actions/mcp_internal_actions/servers/search";
 import { default as slackServer } from "@app/lib/actions/mcp_internal_actions/servers/slack";
 import { default as slideshowServer } from "@app/lib/actions/mcp_internal_actions/servers/slideshow";
+import { default as slackBotServer } from "@app/lib/actions/mcp_internal_actions/servers/slack/slack_bot";
 import { default as tablesQueryServer } from "@app/lib/actions/mcp_internal_actions/servers/tables_query/server";
 import { default as tablesQueryServerV2 } from "@app/lib/actions/mcp_internal_actions/servers/tables_query/server_v2";
 import { default as thinkServer } from "@app/lib/actions/mcp_internal_actions/servers/think";
@@ -156,6 +157,8 @@ export async function getInternalMCPServer(
       return mondayServer();
     case "slack":
       return slackServer(auth, mcpServerId, agentLoopContext);
+    case "slack_bot":
+      return slackBotServer(auth, mcpServerId, agentLoopContext);
     case "agent_memory":
       return agentMemoryServer(auth, agentLoopContext);
     case "outlook":

--- a/front/lib/actions/mcp_internal_actions/servers/slack.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/slack.ts
@@ -1,10 +1,6 @@
 import { INTERNAL_MIME_TYPES } from "@dust-tt/client";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
-import { WebClient } from "@slack/web-api";
-import type { Channel } from "@slack/web-api/dist/response/ConversationsListResponse";
-import type { Member } from "@slack/web-api/dist/response/UsersListResponse";
 import uniqBy from "lodash/uniqBy";
-import slackifyMarkdown from "slackify-markdown";
 import { z } from "zod";
 
 import { getConnectionForMCPServer } from "@app/lib/actions/mcp_authentication";
@@ -14,17 +10,21 @@ import type {
 } from "@app/lib/actions/mcp_internal_actions/output_schemas";
 import { renderRelativeTimeFrameForToolOutput } from "@app/lib/actions/mcp_internal_actions/rendering";
 import {
+  executeGetUser,
+  executeListPublicChannels,
+  executeListUsers,
+  executePostMessage,
+  getSlackClient,
+} from "@app/lib/actions/mcp_internal_actions/servers/slack/slack_api_helper";
+import {
   makeInternalMCPServer,
-  makeMCPToolJSONSuccess,
   makeMCPToolTextError,
   makePersonalAuthenticationError,
 } from "@app/lib/actions/mcp_internal_actions/utils";
 import type { AgentLoopContextType } from "@app/lib/actions/types";
 import { SLACK_SEARCH_ACTION_NUM_RESULTS } from "@app/lib/actions/utils";
 import { getRefs } from "@app/lib/api/assistant/citations";
-import config from "@app/lib/api/config";
 import type { Authenticator } from "@app/lib/auth";
-import { removeDiacritics } from "@app/lib/utils";
 import { concurrentExecutor } from "@app/lib/utils/async_utils";
 import { cacheWithRedis } from "@app/lib/utils/cache";
 import logger from "@app/logger/logger";
@@ -90,76 +90,6 @@ export const slackSearch = async (
 
   return matches;
 };
-
-const getSlackClient = async (accessToken?: string) => {
-  if (!accessToken) {
-    throw new Error("No access token provided");
-  }
-
-  return new WebClient(accessToken, {
-    timeout: 10000,
-    rejectRateLimitedCalls: false,
-    retryConfig: {
-      retries: 1,
-      factor: 1,
-    },
-  });
-};
-
-type GetPublicChannelsArgs = {
-  mcpServerId: string;
-  slackClient: WebClient;
-};
-
-type ChannelWithIdAndName = Omit<Channel, "id" | "name"> & {
-  id: string;
-  name: string;
-};
-
-const _getPublicChannels = async ({
-  slackClient,
-}: GetPublicChannelsArgs): Promise<ChannelWithIdAndName[]> => {
-  const channels: Channel[] = [];
-
-  let cursor: string | undefined = undefined;
-  do {
-    const response = await slackClient.conversations.list({
-      cursor,
-      limit: 100,
-      exclude_archived: true,
-      types: "public_channel",
-    });
-    if (!response.ok) {
-      throw new Error(response.error);
-    }
-    channels.push(...(response.channels ?? []));
-    cursor = response.response_metadata?.next_cursor;
-
-    // We can't handle a huge list of channels, and even if we could, it would be unusable
-    // in the UI. So we arbitrarily cap it to 500 channels.
-    if (channels.length >= 500) {
-      logger.warn("Channel list truncated after reaching over 500 channels.");
-      break;
-    }
-  } while (cursor);
-
-  return channels
-    .filter((c) => !!c.id && !!c.name)
-    .map((c) => ({
-      ...c,
-      id: c.id!,
-      name: c.name!,
-    }))
-    .sort((a, b) => a.name.localeCompare(b.name));
-};
-
-const getCachedPublicChannels = cacheWithRedis(
-  _getPublicChannels,
-  ({ mcpServerId }: GetPublicChannelsArgs) => mcpServerId,
-  {
-    ttlMs: 60 * 10 * 1000, // 10 minutes
-  }
-);
 
 function makeQueryResource(
   keywords: string[],
@@ -808,35 +738,23 @@ const createServer = async (
     },
     async ({ to, message, threadTs }, { authInfo }) => {
       const accessToken = authInfo?.token;
-      const slackClient = await getSlackClient(accessToken);
-
-      const originalMessage = message;
+      if (!accessToken) {
+        throw new Error("Access token not found");
+      }
 
       if (!agentLoopContext?.runContext) {
         throw new Error("Unreachable: missing agentLoopRunContext.");
       }
 
       try {
-        const agentUrl = `${config.getClientFacingUrl()}/w/${auth.getNonNullableWorkspace().sId}/assistant/new?assistantDetails=${agentLoopContext.runContext.agentConfiguration.sId}`;
-        message = `${slackifyMarkdown(originalMessage)}\n_Sent via <${agentUrl}|${agentLoopContext.runContext.agentConfiguration.name} Agent> on Dust_`;
-
-        const response = await slackClient.chat.postMessage({
-          channel: to,
-          text: message,
-          mrkdwn: true,
-          thread_ts: threadTs,
-        });
-
-        if (!response.ok) {
-          return makeMCPToolTextError(
-            `Error posting message: ${response.error}`
-          );
-        }
-
-        return makeMCPToolJSONSuccess({
-          message: `Message posted to ${to}`,
-          result: response,
-        });
+        return await executePostMessage(
+          to,
+          message,
+          threadTs,
+          accessToken,
+          agentLoopContext,
+          auth
+        );
       } catch (error) {
         if (isSlackTokenRevoked(error)) {
           return makePersonalAuthenticationError("slack");
@@ -857,62 +775,12 @@ const createServer = async (
     },
     async ({ nameFilter }, { authInfo }) => {
       const accessToken = authInfo?.token;
-      const slackClient = await getSlackClient(accessToken);
+      if (!accessToken) {
+        throw new Error("Access token not found");
+      }
 
       try {
-        const users: Member[] = [];
-
-        let cursor: string | undefined = undefined;
-        do {
-          const response = await slackClient.users.list({
-            cursor,
-            limit: 100,
-          });
-          if (!response.ok) {
-            return makeMCPToolTextError(
-              `Error listing users: ${response.error}`
-            );
-          }
-          users.push(
-            ...(response.members ?? []).filter((member) => !member.is_bot)
-          );
-          cursor = response.response_metadata?.next_cursor;
-
-          if (nameFilter) {
-            const normalizedNameFilter = removeDiacritics(
-              nameFilter.toLowerCase()
-            );
-            const filteredUsers = users.filter(
-              (user) =>
-                removeDiacritics(user.name?.toLowerCase() ?? "").includes(
-                  normalizedNameFilter
-                ) ||
-                removeDiacritics(user.real_name?.toLowerCase() ?? "").includes(
-                  normalizedNameFilter
-                )
-            );
-
-            // Early return if we found a user
-            if (filteredUsers.length > 0) {
-              return makeMCPToolJSONSuccess({
-                message: `The workspace has ${filteredUsers.length} users containing "${nameFilter}"`,
-                result: filteredUsers,
-              });
-            }
-          }
-        } while (cursor);
-
-        if (nameFilter) {
-          return makeMCPToolJSONSuccess({
-            message: `The workspace has ${users.length} users but none containing "${nameFilter}"`,
-            result: users,
-          });
-        }
-
-        return makeMCPToolJSONSuccess({
-          message: `The workspace has ${users.length} users`,
-          result: users,
-        });
+        return await executeListUsers(nameFilter, accessToken);
       } catch (error) {
         if (isSlackTokenRevoked(error)) {
           return makePersonalAuthenticationError("slack");
@@ -932,21 +800,12 @@ const createServer = async (
     },
     async ({ userId }, { authInfo }) => {
       const accessToken = authInfo?.token;
-      const slackClient = await getSlackClient(accessToken);
+      if (!accessToken) {
+        throw new Error("Access token not found");
+      }
 
       try {
-        const response = await slackClient.users.info({ user: userId });
-
-        if (!response.ok || !response.user) {
-          return makeMCPToolTextError(
-            `Error retrieving user info: ${response.error ?? "Unknown error"}`
-          );
-        }
-
-        return makeMCPToolJSONSuccess({
-          message: `Retrieved user information for ${userId}`,
-          result: response.user,
-        });
+        return await executeGetUser(userId, accessToken);
       } catch (error) {
         if (isSlackTokenRevoked(error)) {
           return makePersonalAuthenticationError("slack");
@@ -967,47 +826,16 @@ const createServer = async (
     },
     async ({ nameFilter }, { authInfo }) => {
       const accessToken = authInfo?.token;
-      const slackClient = await getSlackClient(accessToken);
+      if (!accessToken) {
+        throw new Error("Access token not found");
+      }
 
       try {
-        const channels = await getCachedPublicChannels({
-          mcpServerId,
-          slackClient,
-        });
-
-        if (nameFilter) {
-          const normalizedNameFilter = removeDiacritics(
-            nameFilter.toLowerCase()
-          );
-          const filteredChannels = channels.filter(
-            (channel) =>
-              removeDiacritics(channel.name?.toLowerCase() ?? "").includes(
-                normalizedNameFilter
-              ) ||
-              removeDiacritics(
-                channel.topic?.value?.toLowerCase() ?? ""
-              ).includes(normalizedNameFilter)
-          );
-
-          // Early return if we found a channel
-          if (filteredChannels.length > 0) {
-            return makeMCPToolJSONSuccess({
-              message: `The workspace has ${filteredChannels.length} channels containing "${nameFilter}"`,
-              result: filteredChannels,
-            });
-          }
-        }
-        if (nameFilter) {
-          return makeMCPToolJSONSuccess({
-            message: `The workspace has ${channels.length} channels but none containing "${nameFilter}"`,
-            result: channels,
-          });
-        }
-
-        return makeMCPToolJSONSuccess({
-          message: `The workspace has ${channels.length} channels`,
-          result: channels,
-        });
+        return await executeListPublicChannels(
+          nameFilter,
+          accessToken,
+          mcpServerId
+        );
       } catch (error) {
         if (isSlackTokenRevoked(error)) {
           return makePersonalAuthenticationError("slack");

--- a/front/lib/actions/mcp_internal_actions/servers/slack/slack_api_helper.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/slack/slack_api_helper.ts
@@ -1,0 +1,226 @@
+import { WebClient } from "@slack/web-api";
+import type { Channel } from "@slack/web-api/dist/response/ConversationsListResponse";
+import type { Member } from "@slack/web-api/dist/response/UsersListResponse";
+import slackifyMarkdown from "slackify-markdown";
+
+import { makeMCPToolJSONSuccess } from "@app/lib/actions/mcp_internal_actions/utils";
+import type { AgentLoopContextType } from "@app/lib/actions/types";
+import config from "@app/lib/api/config";
+import type { Authenticator } from "@app/lib/auth";
+import { removeDiacritics } from "@app/lib/utils";
+import { cacheWithRedis } from "@app/lib/utils/cache";
+import logger from "@app/logger/logger";
+
+export const getSlackClient = async (accessToken?: string) => {
+  if (!accessToken) {
+    throw new Error("No access token provided");
+  }
+
+  return new WebClient(accessToken, {
+    timeout: 10000,
+    rejectRateLimitedCalls: false,
+    retryConfig: {
+      retries: 1,
+      factor: 1,
+    },
+  });
+};
+
+type GetPublicChannelsArgs = {
+  mcpServerId: string;
+  slackClient: WebClient;
+};
+
+type ChannelWithIdAndName = Omit<Channel, "id" | "name"> & {
+  id: string;
+  name: string;
+};
+
+const _getPublicChannels = async ({
+  slackClient,
+}: GetPublicChannelsArgs): Promise<ChannelWithIdAndName[]> => {
+  const channels: Channel[] = [];
+
+  let cursor: string | undefined = undefined;
+  do {
+    const response = await slackClient.conversations.list({
+      cursor,
+      limit: 100,
+      exclude_archived: true,
+      types: "public_channel",
+    });
+    if (!response.ok) {
+      throw new Error(response.error);
+    }
+    channels.push(...(response.channels ?? []));
+    cursor = response.response_metadata?.next_cursor;
+
+    // We can't handle a huge list of channels, and even if we could, it would be unusable
+    // in the UI. So we arbitrarily cap it to 500 channels.
+    if (channels.length >= 500) {
+      logger.warn("Channel list truncated after reaching over 500 channels.");
+      break;
+    }
+  } while (cursor);
+
+  return channels
+    .filter((c) => !!c.id && !!c.name)
+    .map((c) => ({
+      ...c,
+      id: c.id!,
+      name: c.name!,
+    }))
+    .sort((a, b) => a.name.localeCompare(b.name));
+};
+
+export const getCachedPublicChannels = cacheWithRedis(
+  _getPublicChannels,
+  ({ mcpServerId }: GetPublicChannelsArgs) => mcpServerId,
+  {
+    ttlMs: 60 * 10 * 1000, // 10 minutes
+  }
+);
+
+// Post message function
+export async function executePostMessage(
+  to: string,
+  message: string,
+  threadTs: string | undefined,
+  accessToken: string,
+  agentLoopContext: AgentLoopContextType,
+  auth: Authenticator
+) {
+  const slackClient = await getSlackClient(accessToken);
+  const originalMessage = message;
+
+  const agentUrl = `${config.getClientFacingUrl()}/w/${auth.getNonNullableWorkspace().sId}/assistant/new?assistantDetails=${agentLoopContext.runContext?.agentConfiguration.sId}`;
+  message = `${slackifyMarkdown(originalMessage)}\n_Sent via <${agentUrl}|${agentLoopContext.runContext?.agentConfiguration.name} Agent> on Dust_`;
+
+  const response = await slackClient.chat.postMessage({
+    channel: to,
+    text: message,
+    mrkdwn: true,
+    thread_ts: threadTs,
+  });
+
+  if (!response.ok) {
+    throw new Error(response.error);
+  }
+
+  return makeMCPToolJSONSuccess({
+    message: `Message posted to ${to}`,
+    result: response,
+  });
+}
+
+export async function executeListUsers(
+  nameFilter: string | undefined,
+  accessToken: string
+) {
+  const slackClient = await getSlackClient(accessToken);
+  const users: Member[] = [];
+
+  let cursor: string | undefined = undefined;
+  do {
+    const response = await slackClient.users.list({
+      cursor,
+      limit: 100,
+    });
+    if (!response.ok) {
+      throw new Error(response.error);
+    }
+    users.push(...(response.members ?? []).filter((member) => !member.is_bot));
+    cursor = response.response_metadata?.next_cursor;
+
+    if (nameFilter) {
+      const normalizedNameFilter = removeDiacritics(nameFilter.toLowerCase());
+      const filteredUsers = users.filter(
+        (user) =>
+          removeDiacritics(user.name?.toLowerCase() ?? "").includes(
+            normalizedNameFilter
+          ) ||
+          removeDiacritics(user.real_name?.toLowerCase() ?? "").includes(
+            normalizedNameFilter
+          )
+      );
+
+      // Early return if we found a user
+      if (filteredUsers.length > 0) {
+        return makeMCPToolJSONSuccess({
+          message: `The workspace has ${filteredUsers.length} users containing "${nameFilter}"`,
+          result: filteredUsers,
+        });
+      }
+    }
+  } while (cursor);
+
+  if (nameFilter) {
+    return makeMCPToolJSONSuccess({
+      message: `The workspace has ${users.length} users but none containing "${nameFilter}"`,
+      result: users,
+    });
+  }
+
+  return makeMCPToolJSONSuccess({
+    message: `The workspace has ${users.length} users`,
+    result: users,
+  });
+}
+
+export async function executeGetUser(userId: string, accessToken: string) {
+  const slackClient = await getSlackClient(accessToken);
+  const response = await slackClient.users.info({ user: userId });
+
+  if (!response.ok || !response.user) {
+    throw new Error(response.error ?? "Unknown error");
+  }
+
+  return makeMCPToolJSONSuccess({
+    message: `Retrieved user information for ${userId}`,
+    result: response.user,
+  });
+}
+
+export async function executeListPublicChannels(
+  nameFilter: string | undefined,
+  accessToken: string,
+  mcpServerId: string
+) {
+  const slackClient = await getSlackClient(accessToken);
+  const channels = await getCachedPublicChannels({
+    mcpServerId,
+    slackClient,
+  });
+
+  if (nameFilter) {
+    const normalizedNameFilter = removeDiacritics(nameFilter.toLowerCase());
+    const filteredChannels = channels.filter(
+      (channel) =>
+        removeDiacritics(channel.name?.toLowerCase() ?? "").includes(
+          normalizedNameFilter
+        ) ||
+        removeDiacritics(channel.topic?.value?.toLowerCase() ?? "").includes(
+          normalizedNameFilter
+        )
+    );
+
+    // Early return if we found a channel
+    if (filteredChannels.length > 0) {
+      return makeMCPToolJSONSuccess({
+        message: `The workspace has ${filteredChannels.length} channels containing "${nameFilter}"`,
+        result: filteredChannels,
+      });
+    }
+  }
+  if (nameFilter) {
+    return makeMCPToolJSONSuccess({
+      message: `The workspace has ${channels.length} channels but none containing "${nameFilter}"`,
+      result: channels,
+    });
+  }
+
+  return makeMCPToolJSONSuccess({
+    message: `The workspace has ${channels.length} channels`,
+    result: channels,
+  });
+}

--- a/front/lib/actions/mcp_internal_actions/servers/slack/slack_bot.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/slack/slack_bot.ts
@@ -15,6 +15,7 @@ import {
 } from "@app/lib/actions/mcp_internal_actions/utils";
 import type { AgentLoopContextType } from "@app/lib/actions/types";
 import type { Authenticator } from "@app/lib/auth";
+import { normalizeError } from "@app/types";
 
 const createServer = async (
   auth: Authenticator,
@@ -64,7 +65,7 @@ const createServer = async (
           auth
         );
       } catch (error) {
-        return makeMCPToolTextError(`Error posting message: ${error}`);
+        return makeMCPToolTextError(`Error posting message: ${normalizeError(error)}`);
       }
     }
   );
@@ -87,7 +88,7 @@ const createServer = async (
       try {
         return await executeListUsers(nameFilter, accessToken);
       } catch (error) {
-        return makeMCPToolTextError(`Error listing users: ${error}`);
+        return makeMCPToolTextError(`Error listing users: ${normalizeError(error)}`);
       }
     }
   );
@@ -109,7 +110,7 @@ const createServer = async (
       try {
         return await executeGetUser(userId, accessToken);
       } catch (error) {
-        return makeMCPToolTextError(`Error retrieving user info: ${error}`);
+        return makeMCPToolTextError(`Error retrieving user info: ${normalizeError(error)}`);
       }
     }
   );
@@ -136,7 +137,7 @@ const createServer = async (
           mcpServerId
         );
       } catch (error) {
-        return makeMCPToolTextError(`Error listing channels: ${error}`);
+        return makeMCPToolTextError(`Error listing channels: ${normalizeError(error)}`);
       }
     }
   );
@@ -198,7 +199,7 @@ const createServer = async (
           },
         });
       } catch (error) {
-        return makeMCPToolTextError(`Error reading channel history: ${error}`);
+        return makeMCPToolTextError(`Error reading channel history: ${normalizeError(error)}`);
       }
     }
   );
@@ -275,7 +276,7 @@ const createServer = async (
           },
         });
       } catch (error) {
-        return makeMCPToolTextError(`Error reading thread messages: ${error}`);
+        return makeMCPToolTextError(`Error reading thread messages: ${normalizeError(error)}`);
       }
     }
   );

--- a/front/lib/actions/mcp_internal_actions/servers/slack/slack_bot.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/slack/slack_bot.ts
@@ -200,7 +200,7 @@ const createServer = async (
             has_more: hasMore,
             next_cursor: nextCursor,
             pagination_info: {
-              current_page_size: response.messages?.length || 0,
+              current_page_size: response.messages?.length ?? 0,
               has_more_pages: hasMore,
               next_cursor_for_pagination: nextCursor,
             },
@@ -267,18 +267,18 @@ const createServer = async (
 
         // First message is always the parent message
         const parentMessage = response.messages?.[0];
-        const threadReplies = response.messages?.slice(1) || [];
+        const threadReplies = response.messages?.slice(1) ?? [];
 
         return makeMCPToolJSONSuccess({
           message: `Retrieved thread with ${response.messages?.length} total messages (1 parent + ${threadReplies.length} replies)${hasMore ? ". More replies available." : ""}`,
           result: {
             parent_message: parentMessage,
             thread_replies: threadReplies,
-            total_messages: response.messages?.length || 0,
+            total_messages: response.messages?.length ?? 0,
             has_more: hasMore,
             next_cursor: nextCursor,
             pagination_info: {
-              current_page_size: response.messages?.length || 0,
+              current_page_size: response.messages?.length ?? 0,
               replies_in_this_page: threadReplies.length,
               has_more_pages: hasMore,
               next_cursor_for_pagination: nextCursor,

--- a/front/lib/actions/mcp_internal_actions/servers/slack/slack_bot.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/slack/slack_bot.ts
@@ -65,7 +65,9 @@ const createServer = async (
           auth
         );
       } catch (error) {
-        return makeMCPToolTextError(`Error posting message: ${normalizeError(error)}`);
+        return makeMCPToolTextError(
+          `Error posting message: ${normalizeError(error)}`
+        );
       }
     }
   );
@@ -88,7 +90,9 @@ const createServer = async (
       try {
         return await executeListUsers(nameFilter, accessToken);
       } catch (error) {
-        return makeMCPToolTextError(`Error listing users: ${normalizeError(error)}`);
+        return makeMCPToolTextError(
+          `Error listing users: ${normalizeError(error)}`
+        );
       }
     }
   );
@@ -110,7 +114,9 @@ const createServer = async (
       try {
         return await executeGetUser(userId, accessToken);
       } catch (error) {
-        return makeMCPToolTextError(`Error retrieving user info: ${normalizeError(error)}`);
+        return makeMCPToolTextError(
+          `Error retrieving user info: ${normalizeError(error)}`
+        );
       }
     }
   );
@@ -137,7 +143,9 @@ const createServer = async (
           mcpServerId
         );
       } catch (error) {
-        return makeMCPToolTextError(`Error listing channels: ${normalizeError(error)}`);
+        return makeMCPToolTextError(
+          `Error listing channels: ${normalizeError(error)}`
+        );
       }
     }
   );
@@ -199,7 +207,9 @@ const createServer = async (
           },
         });
       } catch (error) {
-        return makeMCPToolTextError(`Error reading channel history: ${normalizeError(error)}`);
+        return makeMCPToolTextError(
+          `Error reading channel history: ${normalizeError(error)}`
+        );
       }
     }
   );
@@ -276,7 +286,9 @@ const createServer = async (
           },
         });
       } catch (error) {
-        return makeMCPToolTextError(`Error reading thread messages: ${normalizeError(error)}`);
+        return makeMCPToolTextError(
+          `Error reading thread messages: ${normalizeError(error)}`
+        );
       }
     }
   );

--- a/front/lib/actions/mcp_internal_actions/servers/slack/slack_bot.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/slack/slack_bot.ts
@@ -1,0 +1,286 @@
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { z } from "zod";
+
+import {
+  executeGetUser,
+  executeListPublicChannels,
+  executeListUsers,
+  executePostMessage,
+  getSlackClient,
+} from "@app/lib/actions/mcp_internal_actions/servers/slack/slack_api_helper";
+import {
+  makeInternalMCPServer,
+  makeMCPToolJSONSuccess,
+  makeMCPToolTextError,
+} from "@app/lib/actions/mcp_internal_actions/utils";
+import type { AgentLoopContextType } from "@app/lib/actions/types";
+import type { Authenticator } from "@app/lib/auth";
+
+const createServer = async (
+  auth: Authenticator,
+  mcpServerId: string,
+  agentLoopContext?: AgentLoopContextType
+): Promise<McpServer> => {
+  const server = makeInternalMCPServer("slack_bot");
+
+  server.tool(
+    "post_message",
+    "Post a message to a Slack channel. The slack bot must be added to the channel before it can post messages. Direct messages are not supported.",
+    {
+      to: z
+        .string()
+        .describe(
+          "The channel to post the message to. Accepted values are the channel name or the channel id."
+        ),
+      message: z
+        .string()
+        .describe(
+          "The message to post, must follow the Slack message formatting rules."
+        ),
+      threadTs: z
+        .string()
+        .optional()
+        .describe(
+          "The thread ts of the message to reply to. If you don't provide a thread ts, the message will be posted as a top-level message."
+        ),
+    },
+    async ({ to, message, threadTs }, { authInfo }) => {
+      const accessToken = authInfo?.token;
+      if (!accessToken) {
+        throw new Error("Access token not found");
+      }
+
+      if (!agentLoopContext?.runContext) {
+        throw new Error("Issue with agent context");
+      }
+
+      try {
+        return await executePostMessage(
+          to,
+          message,
+          threadTs,
+          accessToken,
+          agentLoopContext,
+          auth
+        );
+      } catch (error) {
+        return makeMCPToolTextError(`Error posting message: ${error}`);
+      }
+    }
+  );
+
+  server.tool(
+    "list_users",
+    "List all users in the workspace",
+    {
+      nameFilter: z
+        .string()
+        .optional()
+        .describe("The name of the user to filter by (optional)"),
+    },
+    async ({ nameFilter }, { authInfo }) => {
+      const accessToken = authInfo?.token;
+      if (!accessToken) {
+        throw new Error("Access token not found");
+      }
+
+      try {
+        return await executeListUsers(nameFilter, accessToken);
+      } catch (error) {
+        return makeMCPToolTextError(`Error listing users: ${error}`);
+      }
+    }
+  );
+
+  server.tool(
+    "get_user",
+    "Get user information given a Slack user ID. Use this to retrieve details about a user when you have their user ID.",
+    {
+      userId: z
+        .string()
+        .describe("The Slack user ID to look up (for example: U0123456789)."),
+    },
+    async ({ userId }, { authInfo }) => {
+      const accessToken = authInfo?.token;
+      if (!accessToken) {
+        throw new Error("Access token not found");
+      }
+
+      try {
+        return await executeGetUser(userId, accessToken);
+      } catch (error) {
+        return makeMCPToolTextError(`Error retrieving user info: ${error}`);
+      }
+    }
+  );
+
+  server.tool(
+    "list_public_channels",
+    "List all public channels in the workspace",
+    {
+      nameFilter: z
+        .string()
+        .optional()
+        .describe("The name of the channel to filter by (optional)"),
+    },
+    async ({ nameFilter }, { authInfo }) => {
+      const accessToken = authInfo?.token;
+      if (!accessToken) {
+        throw new Error("Access token not found");
+      }
+
+      try {
+        return await executeListPublicChannels(
+          nameFilter,
+          accessToken,
+          mcpServerId
+        );
+      } catch (error) {
+        return makeMCPToolTextError(`Error listing channels: ${error}`);
+      }
+    }
+  );
+
+  server.tool(
+    "read_channel_history",
+    "Read messages from a specific channel with pagination support. The slack bot must be added to the channel before it can read messages.",
+    {
+      channel: z.string().describe("Channel name or ID"),
+      limit: z
+        .number()
+        .optional()
+        .describe("Number of messages to retrieve (default: 20, max: 200)"),
+      cursor: z
+        .string()
+        .optional()
+        .describe(
+          "Pagination cursor from previous call to get next page of messages"
+        ),
+      oldest: z
+        .string()
+        .optional()
+        .describe("Only messages after this timestamp (Unix timestamp)"),
+      latest: z
+        .string()
+        .optional()
+        .describe("Only messages before this timestamp (Unix timestamp)"),
+    },
+    async ({ channel, limit = 20, cursor, oldest, latest }, { authInfo }) => {
+      const accessToken = authInfo?.token;
+      if (!accessToken) {
+        throw new Error("Access token not found");
+      }
+
+      const slackClient = await getSlackClient(accessToken);
+
+      try {
+        const response = await slackClient.conversations.history({
+          channel: channel,
+          limit: Math.min(limit, 200),
+          cursor: cursor,
+          oldest: oldest,
+          latest: latest,
+        });
+
+        const hasMore = !!response.has_more;
+        const nextCursor = response.response_metadata?.next_cursor;
+
+        return makeMCPToolJSONSuccess({
+          result: {
+            messages: response.messages,
+            has_more: hasMore,
+            next_cursor: nextCursor,
+            pagination_info: {
+              current_page_size: response.messages?.length || 0,
+              has_more_pages: hasMore,
+              next_cursor_for_pagination: nextCursor,
+            },
+          },
+        });
+      } catch (error) {
+        return makeMCPToolTextError(`Error reading channel history: ${error}`);
+      }
+    }
+  );
+
+  server.tool(
+    "read_thread_messages",
+    "Read all messages in a specific thread with pagination support",
+    {
+      channel: z.string().describe("Channel name or ID"),
+      threadTs: z
+        .string()
+        .describe("Thread timestamp (ts of the parent message)"),
+      limit: z
+        .number()
+        .optional()
+        .describe("Number of messages to retrieve (default: 20, max: 200)"),
+      cursor: z
+        .string()
+        .optional()
+        .describe(
+          "Pagination cursor from previous call to get next page of thread messages"
+        ),
+      oldest: z
+        .string()
+        .optional()
+        .describe("Only messages after this timestamp (Unix timestamp)"),
+      latest: z
+        .string()
+        .optional()
+        .describe("Only messages before this timestamp (Unix timestamp)"),
+    },
+    async (
+      { channel, threadTs, limit = 20, cursor, oldest, latest },
+      { authInfo }
+    ) => {
+      const accessToken = authInfo?.token;
+      if (!accessToken) {
+        throw new Error("Access token not found");
+      }
+
+      const slackClient = await getSlackClient(accessToken);
+
+      try {
+        const response = await slackClient.conversations.replies({
+          channel: channel,
+          ts: threadTs,
+          limit: Math.min(limit, 200), // Slack API max is 200
+          cursor: cursor,
+          oldest: oldest,
+          latest: latest,
+        });
+
+        const hasMore = !!response.has_more;
+        const nextCursor = response.response_metadata?.next_cursor;
+
+        // First message is always the parent message
+        const parentMessage = response.messages?.[0];
+        const threadReplies = response.messages?.slice(1) || [];
+
+        return makeMCPToolJSONSuccess({
+          message: `Retrieved thread with ${response.messages?.length} total messages (1 parent + ${threadReplies.length} replies)${hasMore ? ". More replies available." : ""}`,
+          result: {
+            parent_message: parentMessage,
+            thread_replies: threadReplies,
+            total_messages: response.messages?.length || 0,
+            has_more: hasMore,
+            next_cursor: nextCursor,
+            pagination_info: {
+              current_page_size: response.messages?.length || 0,
+              replies_in_this_page: threadReplies.length,
+              has_more_pages: hasMore,
+              next_cursor_for_pagination: nextCursor,
+            },
+          },
+        });
+      } catch (error) {
+        return makeMCPToolTextError(`Error reading thread messages: ${error}`);
+      }
+    }
+  );
+
+  return server;
+};
+
+export default createServer;

--- a/front/lib/api/oauth/providers/slack.ts
+++ b/front/lib/api/oauth/providers/slack.ts
@@ -27,7 +27,6 @@ export class SlackOAuthProvider implements BaseOAuthStrategyProvider {
     const { user_scopes, bot_scopes } = (() => {
       switch (useCase) {
         case "personal_actions":
-        case "platform_actions":
           return {
             user_scopes: [
               "channels:read",
@@ -66,7 +65,8 @@ export class SlackOAuthProvider implements BaseOAuthStrategyProvider {
             ],
           };
         }
-        case "bot": {
+        case "bot":
+        case "platform_actions":
           return {
             user_scopes: [],
             bot_scopes: [
@@ -87,7 +87,6 @@ export class SlackOAuthProvider implements BaseOAuthStrategyProvider {
               "users:read.email",
             ],
           };
-        }
         case "labs_transcripts":
           assert(
             "Unreachable provider `labs_transcripts` in SlackOAuthProvider"
@@ -104,14 +103,13 @@ export class SlackOAuthProvider implements BaseOAuthStrategyProvider {
     const clientId = (() => {
       switch (useCase) {
         case "personal_actions":
-        case "platform_actions":
           return config.getOAuthSlackToolsClientId();
         case "connection": {
           return config.getOAuthSlackClientId();
         }
-        case "bot": {
+        case "bot":
+        case "platform_actions":
           return config.getOAuthSlackBotClientId();
-        }
         case "labs_transcripts":
           assert(
             "Unreachable provider `labs_transcripts` in SlackOAuthProvider"

--- a/front/types/shared/feature_flags.ts
+++ b/front/types/shared/feature_flags.ts
@@ -188,7 +188,7 @@ export const WHITELISTABLE_FEATURES_CONFIG = {
   },
   slack_bot_mcp: {
     description: "Slack bot MCP server for workspace-level Slack integration",
-    stage: "rolling_out",
+    stage: "on_demand",
   },
 } as const satisfies Record<string, FeatureFlag>;
 

--- a/front/types/shared/feature_flags.ts
+++ b/front/types/shared/feature_flags.ts
@@ -186,6 +186,10 @@ export const WHITELISTABLE_FEATURES_CONFIG = {
     description: "Use OpenAI EU API key instead of the default OpenAI API key",
     stage: "on_demand",
   },
+  slack_bot_mcp: {
+    description: "Slack bot MCP server for workspace-level Slack integration",
+    stage: "rolling_out",
+  },
 } as const satisfies Record<string, FeatureFlag>;
 
 export type FeatureFlagStage = "dust_only" | "rolling_out" | "on_demand";

--- a/sdks/js/src/types.ts
+++ b/sdks/js/src/types.ts
@@ -663,6 +663,7 @@ const WhitelistableFeaturesSchema = FlexibleEnumSchema<
   | "salesforce_tool"
   | "show_debug_tools"
   | "slack_semantic_search"
+  | "slack_bot_mcp"
   | "slack_enhanced_default_agent"
   | "slack_message_splitting"
   | "slideshow"


### PR DESCRIPTION
## Description

* Adding MCP tool that uses the Slack bot credentials as opposed to the Slack user credentials. This does not give access to all APIs, so I thought it would be best to create a separate MCP server to avoid confusion as opposed to using the personal vs workspace connection dropdown. Curious on the reviewer's thoughts as I can also see this being potentially confusing for users picking between the "slack" and "slack bot" tools. Keeping this behind FF for this reason until we define ideal UX.
* Our PlatformActions use case did not use the bot credentials previously, it actually used user credentials. Changed that logic to be consistent with other mcp tools, but this does have a consequence that the current slack tool will use bot credentials upon initial admin connection. I think this is preferable to remain consistent.
* No intended logic changes to the existing slack bot, but consolidated code in shared file.

## Tests

Testing on dev Slack workspace:

<img width="909" height="202" alt="Screenshot 2025-09-05 at 3 14 49 PM" src="https://github.com/user-attachments/assets/a9ce6ca9-a9a3-4706-8ba3-5b6d7b01b489" />

## Risk

* Unintended changes to the current Slack tool

## Deploy Plan

1. Deploy oauth
2.  Deploy front