### PR TITLE
[front] - fix(conversation): hide panel handler when close

### DIFF
--- a/front/components/assistant/conversation/ConversationSidePanelContainer.tsx
+++ b/front/components/assistant/conversation/ConversationSidePanelContainer.tsx
@@ -38,7 +38,7 @@ export default function ConversationSidePanelContainer({
   return (
     <>
       {/* Resizable Handle for Panels */}
-      <ResizableHandle withHandle disabled={!currentPanel} className="z-50" />
+      {currentPanel && <ResizableHandle withHandle className="z-50" />}
       {/* Panel Container - either Content Creation or Actions */}
       <ResizablePanel
         ref={panelRef}


### PR DESCRIPTION
## Description

This PR ensures that ResizableHandle is only rendered when currentPanel is active, to avoid below situation:

<img width="509" height="950" alt="Screenshot 2025-09-06 at 13 18 17" src="https://github.com/user-attachments/assets/89d4d506-8743-4f68-9f48-fe4d8ecd15f4" />

## Tests

Locally

## Risk

Low

## Deploy Plan

Deploy front
