### PR TITLE
Fix: glitch with last message

### DIFF
--- a/front/components/assistant/conversation/ConversationViewer.tsx
+++ b/front/components/assistant/conversation/ConversationViewer.tsx
@@ -294,9 +294,13 @@ const ConversationViewer = React.forwardRef<
             void mutateConversations(); // to refresh the list of convos in the sidebar (title)
             break;
           case "agent_message_done":
-            // Mark as read and do not mutate the list of convos in the sidebar to avoid any network request.
+            // Mark as read and do not mutate the list of convos in the sidebar to avoid useless network request.
             // Debounce the call as we might receive multiple events for the same conversation (as we replay the events).
             void debouncedMarkAsRead(event.conversationId, false);
+
+            // Mutate the messages to be sure that the swr cache is updated.
+            // Fixes an issue where the last message of a conversation is "thinking" and not "done" the first time you switch back and forth to a conversation.
+            void mutateMessages();
             break;
           default:
             ((t: never) => {


### PR DESCRIPTION
## Description

Repro:
- Create a convo A
- Ask for a poem, wait for completion
- Switch to an old convo
- Go back to convo A
**Notice that the last message is showing "thinking".**
- Go back to the old convo
- Go back to convo A
**Now it's correct**

**TLDR:**
This is because the client message state is a mix of the message's events and what is fetched fetched via `useConversationMessages()`.

**Long version:**
`useConversationMessages()` will be revalidated from the backend when getting focus or manually via `mutateMessages()` calls.

The `AgentMessage` component work on `MessageTemporaryState` returned by `useAgentMessageStream()`.

The initial `MessageTemporaryState` for an agent message is built from the known state of `useConversationMessages()`.

When a agent message is created, it's added to the state of `useConversationMessages()`, then updated via it's events so `MessageTemporaryState` is kept in sync.

**Nothing particular is done regarding the "messages" state when an agent message is done.**

When we switch to a conversation, we DO trigger a revalidation of the messages states from the backend but we DO NOT wait for it to display the messages list. So it initially uses the previous known state from the backend (when the message was "created") to compute the initial `messageStreamState`, it also connect to the event endpoint and start replaying the events of this already completed message (if they are still available).

Relatively quickly, the messages list is updated from the revalidation, triggering a re-render of the messages, closing the stream and replacing with the content from the backend but keeping the "thinking" state as it is supposed to be updated by the events.

Depending how fast the updated list of messages is fetched and how long since the events were sent (we have a 10 minutes TTL), we can see various glitchy visual state for the last message.

The fix is to mutate the list of messages once we receive the `agent_message_done` event so we make sure the state of the messages is up-to-date.

## Tests

Locally

## Risk

Looking at the data, this will create ~7k more network requests per hour to the messages endpoint at peak time : +20% requests to this particular endpoint, +2% overall (excluding the conversations /events endpoint).

## Deploy Plan

Deploy front