### PR TITLE
Fix: Glitchy used-by button when opening modal

### DIFF
--- a/front/components/spaces/UsedByButton.tsx
+++ b/front/components/spaces/UsedByButton.tsx
@@ -26,7 +26,8 @@ export const UsedByButton = ({
       disabled
     />
   ) : (
-    <DropdownMenu>
+    // 1. modal={false} to make the dropdown menu non-modal and avoid a timing issue when we open the Agent side-panel modal.
+    <DropdownMenu modal={false}>
       <DropdownMenuTrigger asChild>
         <Button
           icon={RobotIcon}
@@ -34,6 +35,10 @@ export const UsedByButton = ({
           isSelect={true}
           size="xs"
           label={`${usage.count}`}
+          onClick={(e: React.MouseEvent<HTMLButtonElement>) => {
+            // 2. Avoid propagating the click to the parent element.
+            e.stopPropagation();
+          }}
         />
       </DropdownMenuTrigger>
       <DropdownMenuContent className="max-w-48">


### PR DESCRIPTION
## Description

Fix an issue where the page would be non-interactable if you open an agent details panel from the used-by drop down in Spaces > Tools.

I'm 99% sure that I have seen the same issue elsewhere. **I'd rather have a more global fix in sparkle**.

See this conversation that helped me debug: https://dust.tt/w/0ec9852c2f/assistant/lgsj0rnJ0H

## Tests

Locally

## Risk

Low

## Deploy Plan

deploy front