### PR TITLE
[Dev Worker] Add lib/api/mcp to hot reload watch paths

### DIFF
--- a/front/admin/dev_worker.sh
+++ b/front/admin/dev_worker.sh
@@ -12,6 +12,7 @@ NODE_ENV=development npx concurrently \
     --watch 'temporal/agent_loop' \
     --watch 'lib/api/assistant' \
     --watch 'lib/actions' \
+    --watch 'lib/api/mcp' \
     --ext 'ts,js' \
     --signal 'SIGTERM' \
     --delay 5" # 5 seconds delay to avoid restarting the agent loop worker too often.


### PR DESCRIPTION
## Description
Add `lib/api/mcp` directory to nodemon watch paths in the dev worker script to ensure hot reloading when MCP-related files change during development.

## Risks
Blast radius: Development workflow only - affects hot reloading in dev environment
Risk: none

## Deploy Plan
No deployment needed - development script only