### PR TITLE
feat(sdk): Add the new AgentMessageDoneEvent event

### DIFF
--- a/connectors/src/connectors/slack/chat/stream_conversation_handler.ts
+++ b/connectors/src/connectors/slack/chat/stream_conversation_handler.ts
@@ -442,6 +442,10 @@ async function streamAgentAnswerToSlack(
         return new Ok(undefined);
       }
 
+      case "agent_message_done":
+        // No-op, we handle completion in "agent_message_success"
+        break;
+
       default:
         assertNever(event);
     }

--- a/sdks/js/package-lock.json
+++ b/sdks/js/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@dust-tt/client",
-  "version": "1.1.12",
+  "version": "1.1.13",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@dust-tt/client",
-      "version": "1.1.12",
+      "version": "1.1.13",
       "bundleDependencies": [
         "@modelcontextprotocol/sdk"
       ],

--- a/sdks/js/package.json
+++ b/sdks/js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dust-tt/client",
-  "version": "1.1.12",
+  "version": "1.1.13",
   "description": "Client for Dust API",
   "repository": {
     "type": "git",

--- a/sdks/js/src/types.ts
+++ b/sdks/js/src/types.ts
@@ -1194,6 +1194,15 @@ export type AgentMessageSuccessEvent = z.infer<
   typeof AgentMessageSuccessEventSchema
 >;
 
+const AgentMessageDoneEventSchema = z.object({
+  type: z.literal("agent_message_done"),
+  created: z.number(),
+  conversationId: z.string(),
+  configurationId: z.string(),
+  messageId: z.string(),
+});
+export type AgentMessageDoneEvent = z.infer<typeof AgentMessageDoneEventSchema>;
+
 const AgentGenerationCancelledEventSchema = z.object({
   type: z.literal("agent_generation_cancelled"),
   created: z.number(),


### PR DESCRIPTION
## Description

* We missed the `AgentMessageDoneEvent` in the SDK so we can use in the chrome extension
* Push version to 1.1.13 so I can publish the SDK right away

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
