### PR TITLE
[front] - fix(AB): multiple draft creations

### DIFF
--- a/front/components/agent_builder/AgentBuilderPreview.tsx
+++ b/front/components/agent_builder/AgentBuilderPreview.tsx
@@ -1,6 +1,6 @@
 import { ArrowPathIcon, Button, Spinner } from "@dust-tt/sparkle";
 import { useContext, useEffect, useMemo, useRef } from "react";
-import { useFormContext, useWatch } from "react-hook-form";
+import { useWatch } from "react-hook-form";
 
 import { useAgentBuilderContext } from "@app/components/agent_builder/AgentBuilderContext";
 import {
@@ -31,8 +31,6 @@ import type {
   WorkspaceType,
 } from "@app/types";
 import type { ConversationSidePanelType } from "@app/types/conversation_side_panel";
-
-import type { AgentBuilderFormData } from "./AgentBuilderFormContext";
 
 interface EmptyStateProps {
   message: string;
@@ -151,14 +149,12 @@ function PreviewContent({
 export function AgentBuilderPreview() {
   const { owner } = useAgentBuilderContext();
   const { user } = useUser();
-  const { control } = useFormContext<AgentBuilderFormData>();
   const { isMCPServerViewsLoading } = useMCPServerViewsContext();
   const { isPreviewPanelOpen } = usePreviewPanelContext();
 
   const { currentPanel } = useConversationSidePanelContext();
 
   const watchedFields = useWatch({
-    control,
     name: ["instructions", "actions", "agentSettings.name"],
   });
 

--- a/front/components/agent_builder/AgentBuilderPreview.tsx
+++ b/front/components/agent_builder/AgentBuilderPreview.tsx
@@ -189,13 +189,10 @@ export function AgentBuilderPreview() {
   const isUpdatingDraftRef = useRef(false);
 
   useEffect(() => {
-    let isCancelled = false;
-
     const handleDraftUpdate = async () => {
       if (
         !isPreviewPanelOpen ||
         isMCPServerViewsLoading ||
-        isCancelled ||
         isUpdatingDraftRef.current
       ) {
         return;
@@ -205,7 +202,7 @@ export function AgentBuilderPreview() {
       if (!draftAgent && hasContent) {
         isUpdatingDraftRef.current = true;
         const newDraft = await createDraftAgent();
-        if (newDraft && !isCancelled) {
+        if (newDraft) {
           setDraftAgent(newDraft);
         }
         isUpdatingDraftRef.current = false;
@@ -223,15 +220,13 @@ export function AgentBuilderPreview() {
         }
 
         debounceTimerRef.current = setTimeout(async () => {
-          if (!isCancelled) {
-            isUpdatingDraftRef.current = true;
-            const newDraft = await createDraftAgent();
-            if (newDraft && !isCancelled) {
-              setDraftAgent(newDraft);
-              setStickyMentions([{ configurationId: newDraft.sId }]);
-            }
-            isUpdatingDraftRef.current = false;
+          isUpdatingDraftRef.current = true;
+          const newDraft = await createDraftAgent();
+          if (newDraft) {
+            setDraftAgent(newDraft);
+            setStickyMentions([{ configurationId: newDraft.sId }]);
           }
+          isUpdatingDraftRef.current = false;
         }, 500);
       }
     };
@@ -239,7 +234,6 @@ export function AgentBuilderPreview() {
     void handleDraftUpdate();
 
     return () => {
-      isCancelled = true;
       if (debounceTimerRef.current) {
         clearTimeout(debounceTimerRef.current);
       }

--- a/front/components/agent_builder/AgentBuilderPreview.tsx
+++ b/front/components/agent_builder/AgentBuilderPreview.tsx
@@ -1,5 +1,5 @@
 import { ArrowPathIcon, Button, Spinner } from "@dust-tt/sparkle";
-import { useContext } from "react";
+import { useContext, useEffect } from "react";
 import { useFormContext } from "react-hook-form";
 
 import { useAgentBuilderContext } from "@app/components/agent_builder/AgentBuilderContext";
@@ -8,6 +8,7 @@ import {
   useDraftConversation,
 } from "@app/components/agent_builder/hooks/useAgentPreview";
 import { useMCPServerViewsContext } from "@app/components/agent_builder/MCPServerViewsContext";
+import { usePreviewPanelContext } from "@app/components/agent_builder/PreviewPanelContext";
 import { BlockedActionsProvider } from "@app/components/assistant/conversation/BlockedActionsProvider";
 import ConversationSidePanelContent from "@app/components/assistant/conversation/ConversationSidePanelContent";
 import { useConversationSidePanelContext } from "@app/components/assistant/conversation/ConversationSidePanelContext";
@@ -152,6 +153,7 @@ export function AgentBuilderPreview() {
   const { user } = useUser();
   const { getValues } = useFormContext<AgentBuilderFormData>();
   const { isMCPServerViewsLoading } = useMCPServerViewsContext();
+  const { isPreviewPanelOpen } = usePreviewPanelContext();
 
   const { currentPanel } = useConversationSidePanelContext();
 
@@ -160,6 +162,8 @@ export function AgentBuilderPreview() {
 
   const {
     draftAgent,
+    setDraftAgent,
+    createDraftAgent,
     getDraftAgent,
     isSavingDraftAgent,
     draftCreationFailed,
@@ -172,6 +176,32 @@ export function AgentBuilderPreview() {
       draftAgent,
       getDraftAgent,
     });
+
+  // Create draft only when preview panel opens and has content
+  useEffect(() => {
+    const createDraft = async () => {
+      if (
+        isPreviewPanelOpen &&
+        !draftAgent &&
+        hasContent &&
+        !isMCPServerViewsLoading
+      ) {
+        const newDraft = await createDraftAgent();
+        if (newDraft) {
+          setDraftAgent(newDraft);
+        }
+      }
+    };
+
+    void createDraft();
+  }, [
+    isPreviewPanelOpen,
+    draftAgent,
+    hasContent,
+    isMCPServerViewsLoading,
+    createDraftAgent,
+    setDraftAgent,
+  ]);
 
   // Show loading spinner only when the first time we create a draft agent. After that the spinner is shown
   // inside the button in the input bar. This way we don't have to unmount the conversation viewer every time.

--- a/front/components/agent_builder/hooks/useAgentPreview.ts
+++ b/front/components/agent_builder/hooks/useAgentPreview.ts
@@ -83,7 +83,7 @@ export function useDraftAgent() {
       setStickyMentions([{ configurationId: newDraft.sId }]);
       setIsSavingDraftAgent(false);
       return newDraft;
-    }, [owner, sendNotification, getValues]);
+    }, [owner, sendNotification, getValues]); // ✅ Include getValues
 
   const getDraftAgent =
     useCallback(async (): Promise<LightAgentConfigurationType | null> => {
@@ -98,7 +98,7 @@ export function useDraftAgent() {
         return draftAgent;
       }
       return createDraftAgent();
-    }, [draftAgent, createDraftAgent, getValues]);
+    }, [getValues, draftAgent, createDraftAgent]); // ✅ Include getValues
 
   return {
     draftAgent,

--- a/front/components/agent_builder/hooks/useAgentPreview.ts
+++ b/front/components/agent_builder/hooks/useAgentPreview.ts
@@ -83,13 +83,12 @@ export function useDraftAgent() {
       setStickyMentions([{ configurationId: newDraft.sId }]);
       setIsSavingDraftAgent(false);
       return newDraft;
-    }, [owner, sendNotification, getValues]); // ✅ Include getValues
+    }, [owner, sendNotification, getValues]);
 
   const getDraftAgent =
     useCallback(async (): Promise<LightAgentConfigurationType | null> => {
       const formData = getValues();
 
-      // Check if we need to create a new draft (data changed)
       if (
         lastFormDataRef.current &&
         isEqual(lastFormDataRef.current, formData) &&
@@ -98,7 +97,7 @@ export function useDraftAgent() {
         return draftAgent;
       }
       return createDraftAgent();
-    }, [getValues, draftAgent, createDraftAgent]); // ✅ Include getValues
+    }, [getValues, draftAgent, createDraftAgent]);
 
   return {
     draftAgent,
@@ -125,15 +124,13 @@ export function useDraftConversation({
 
   const [conversationId, setConversationId] = useState<string | null>(null);
 
-  const { conversation: swrConversation } = useConversation({
+  const { conversation } = useConversation({
     conversationId: conversationId || "",
     workspaceId: owner.sId,
     options: {
       disabled: !conversationId,
     },
   });
-
-  const conversation = swrConversation || null;
 
   const handleSubmit = async (
     input: string,


### PR DESCRIPTION
## Description

This PR aims at eliminating multiple POST requests in agent builder preview.

**Problem:** The agent builder was sending 4+ POST requests to create draft agents when users interacted with the form, causing performance issues and API spam.

**Root Causes:** Reactive `useWatch` hooks were triggering on every keystroke, unstable `useCallback` dependencies were causing function recreations, cascading updates occurred when draft agents were created.

**Solution:** Implemented a single `useWatch` call for all form fields (instructions, actions, agentSettings.name) and moved to explicit draft creation only when the preview panel opens or agent name changes with 500ms debouncing. Added cascade prevention with `isUpdatingDraftRef` flag to prevent update loops and replaced the complex useDebounce hook with manual debouncing.

## Tests

- [ ] Locally
- [ ] Front edge

## Risk

Low

## Deploy Plan

Deploy front
