### PR TITLE
[Durable Agents] Retry policy for tools

### DIFF
--- a/front/lib/actions/mcp.ts
+++ b/front/lib/actions/mcp.ts
@@ -27,6 +27,7 @@ import type {
   DataSourceConfiguration,
   TableDataSourceConfiguration,
 } from "@app/lib/api/assistant/configuration/types";
+import type { MCPToolRetryPolicyType } from "@app/lib/api/mcp";
 import type { Authenticator } from "@app/lib/auth";
 import type { AdditionalConfigurationType } from "@app/lib/models/assistant/actions/mcp";
 import type {
@@ -46,7 +47,6 @@ import {
   removeNulls,
 } from "@app/types";
 import type { AgentMCPActionWithOutputType } from "@app/types/actions";
-import { MCPToolRetryPolicyType } from "@app/lib/api/mcp";
 
 export type BaseMCPServerConfigurationType = {
   id: ModelId;

--- a/front/lib/actions/mcp.ts
+++ b/front/lib/actions/mcp.ts
@@ -46,17 +46,34 @@ import {
   removeNulls,
 } from "@app/types";
 import type { AgentMCPActionWithOutputType } from "@app/types/actions";
+import {
+  isLightClientSideMCPToolConfiguration,
+  isLightServerSideMCPToolConfiguration,
+  isServerSideMCPToolConfiguration,
+} from "@app/lib/actions/types/guards";
 
 export const MCP_TOOL_RETRY_POLICY_TYPES = [
-  "retryable_on_interrupt",
-  "always_retryable",
-  "never_retryable",
+  "retry_on_interrupt",
+  "always_retry",
+  "never_retry",
 ] as const;
 export type MCPToolRetryPolicyType =
   (typeof MCP_TOOL_RETRY_POLICY_TYPES)[number];
 
 // Default to never_retryable if the retry policy is not defined.
-export const DEFAULT_MCP_TOOL_RETRY_POLICY = "never_retryable";
+export const DEFAULT_MCP_TOOL_RETRY_POLICY =
+  "never_retry" satisfies MCPToolRetryPolicyType;
+
+export function getRetryPolicyFromToolConfiguration(
+  toolConfiguration: MCPToolConfigurationType | LightMCPToolConfigurationType
+): MCPToolRetryPolicyType {
+  return isLightServerSideMCPToolConfiguration(toolConfiguration) ||
+    (!isLightClientSideMCPToolConfiguration(toolConfiguration) &&
+      isServerSideMCPToolConfiguration(toolConfiguration))
+    ? toolConfiguration.retryPolicy
+    : // Client-side MCP tool retry policy is not supported yet.
+      DEFAULT_MCP_TOOL_RETRY_POLICY;
+}
 
 export type BaseMCPServerConfigurationType = {
   id: ModelId;

--- a/front/lib/actions/mcp.ts
+++ b/front/lib/actions/mcp.ts
@@ -23,6 +23,11 @@ import { rewriteContentForModel } from "@app/lib/actions/mcp_utils";
 import type { ToolExecutionStatus } from "@app/lib/actions/statuses";
 import type { ActionGeneratedFileType } from "@app/lib/actions/types";
 import type { AgentActionSpecification } from "@app/lib/actions/types/agent";
+import {
+  isLightClientSideMCPToolConfiguration,
+  isLightServerSideMCPToolConfiguration,
+  isServerSideMCPToolConfiguration,
+} from "@app/lib/actions/types/guards";
 import type {
   DataSourceConfiguration,
   TableDataSourceConfiguration,
@@ -46,11 +51,6 @@ import {
   removeNulls,
 } from "@app/types";
 import type { AgentMCPActionWithOutputType } from "@app/types/actions";
-import {
-  isLightClientSideMCPToolConfiguration,
-  isLightServerSideMCPToolConfiguration,
-  isServerSideMCPToolConfiguration,
-} from "@app/lib/actions/types/guards";
 
 export const MCP_TOOL_RETRY_POLICY_TYPES = ["retry", "no_retry"] as const;
 export type MCPToolRetryPolicyType =

--- a/front/lib/actions/mcp.ts
+++ b/front/lib/actions/mcp.ts
@@ -23,11 +23,6 @@ import { rewriteContentForModel } from "@app/lib/actions/mcp_utils";
 import type { ToolExecutionStatus } from "@app/lib/actions/statuses";
 import type { ActionGeneratedFileType } from "@app/lib/actions/types";
 import type { AgentActionSpecification } from "@app/lib/actions/types/agent";
-import {
-  isLightClientSideMCPToolConfiguration,
-  isLightServerSideMCPToolConfiguration,
-  isServerSideMCPToolConfiguration,
-} from "@app/lib/actions/types/guards";
 import type {
   DataSourceConfiguration,
   TableDataSourceConfiguration,
@@ -51,25 +46,7 @@ import {
   removeNulls,
 } from "@app/types";
 import type { AgentMCPActionWithOutputType } from "@app/types/actions";
-
-export const MCP_TOOL_RETRY_POLICY_TYPES = ["retry", "no_retry"] as const;
-export type MCPToolRetryPolicyType =
-  (typeof MCP_TOOL_RETRY_POLICY_TYPES)[number];
-
-// Default to never_retryable if the retry policy is not defined.
-export const DEFAULT_MCP_TOOL_RETRY_POLICY =
-  "no_retry" satisfies MCPToolRetryPolicyType;
-
-export function getRetryPolicyFromToolConfiguration(
-  toolConfiguration: MCPToolConfigurationType | LightMCPToolConfigurationType
-): MCPToolRetryPolicyType {
-  return isLightServerSideMCPToolConfiguration(toolConfiguration) ||
-    (!isLightClientSideMCPToolConfiguration(toolConfiguration) &&
-      isServerSideMCPToolConfiguration(toolConfiguration))
-    ? toolConfiguration.retryPolicy
-    : // Client-side MCP tool retry policy is not supported yet.
-      DEFAULT_MCP_TOOL_RETRY_POLICY;
-}
+import { MCPToolRetryPolicyType } from "@app/lib/api/mcp";
 
 export type BaseMCPServerConfigurationType = {
   id: ModelId;

--- a/front/lib/actions/mcp.ts
+++ b/front/lib/actions/mcp.ts
@@ -47,6 +47,17 @@ import {
 } from "@app/types";
 import type { AgentMCPActionWithOutputType } from "@app/types/actions";
 
+export const MCP_TOOL_RETRY_POLICY_TYPES = [
+  "retryable_on_interrupt",
+  "always_retryable",
+  "never_retryable",
+] as const;
+export type MCPToolRetryPolicyType =
+  (typeof MCP_TOOL_RETRY_POLICY_TYPES)[number];
+
+// Default to never_retryable if the retry policy is not defined.
+export const DEFAULT_MCP_TOOL_RETRY_POLICY = "never_retryable";
+
 export type BaseMCPServerConfigurationType = {
   id: ModelId;
 
@@ -95,6 +106,7 @@ export type ServerSideMCPToolType = Omit<
   permission: MCPToolStakeLevelType;
   toolServerId: string;
   timeoutMs?: number;
+  retryPolicy: MCPToolRetryPolicyType;
 };
 
 export type ClientSideMCPToolType = Omit<

--- a/front/lib/actions/mcp.ts
+++ b/front/lib/actions/mcp.ts
@@ -52,17 +52,13 @@ import {
   isServerSideMCPToolConfiguration,
 } from "@app/lib/actions/types/guards";
 
-export const MCP_TOOL_RETRY_POLICY_TYPES = [
-  "retry_on_interrupt",
-  "always_retry",
-  "never_retry",
-] as const;
+export const MCP_TOOL_RETRY_POLICY_TYPES = ["retry", "no_retry"] as const;
 export type MCPToolRetryPolicyType =
   (typeof MCP_TOOL_RETRY_POLICY_TYPES)[number];
 
 // Default to never_retryable if the retry policy is not defined.
 export const DEFAULT_MCP_TOOL_RETRY_POLICY =
-  "never_retry" satisfies MCPToolRetryPolicyType;
+  "no_retry" satisfies MCPToolRetryPolicyType;
 
 export function getRetryPolicyFromToolConfiguration(
   toolConfiguration: MCPToolConfigurationType | LightMCPToolConfigurationType

--- a/front/lib/actions/mcp_actions.test.ts
+++ b/front/lib/actions/mcp_actions.test.ts
@@ -3,8 +3,8 @@ import { assert, describe, expect, it } from "vitest";
 import type { ServerSideMCPServerConfigurationType } from "@app/lib/actions/mcp";
 import {
   getPrefixedToolName,
-  listToolsForServerSideMCPServer,
   getToolExtraFields,
+  listToolsForServerSideMCPServer,
   TOOL_NAME_SEPARATOR,
 } from "@app/lib/actions/mcp_actions";
 import { internalMCPServerNameToSId } from "@app/lib/actions/mcp_helper";

--- a/front/lib/actions/mcp_actions.test.ts
+++ b/front/lib/actions/mcp_actions.test.ts
@@ -4,7 +4,7 @@ import type { ServerSideMCPServerConfigurationType } from "@app/lib/actions/mcp"
 import {
   getPrefixedToolName,
   listToolsForServerSideMCPServer,
-  makeToolsWithStakesAndTimeout,
+  getToolExtraFields,
   TOOL_NAME_SEPARATOR,
 } from "@app/lib/actions/mcp_actions";
 import { internalMCPServerNameToSId } from "@app/lib/actions/mcp_helper";
@@ -277,7 +277,7 @@ describe("makeToolsWithStakesAndTimeout", () => {
       workspaceId: 1,
       prefix: 0,
     });
-    const result = makeToolsWithStakesAndTimeout(sid, metadata);
+    const result = getToolExtraFields(sid, metadata);
     assert(result.isOk());
     expect(result.value).toEqual({
       toolsEnabled: {
@@ -319,7 +319,7 @@ describe("makeToolsWithStakesAndTimeout", () => {
       },
     ];
 
-    const result = makeToolsWithStakesAndTimeout("rms_DzP3svIoVg", metadata);
+    const result = getToolExtraFields("rms_DzP3svIoVg", metadata);
     assert(result.isOk());
     expect(result.value).toEqual({
       toolsEnabled: {
@@ -341,7 +341,7 @@ describe("makeToolsWithStakesAndTimeout", () => {
     const metadata: RemoteMCPServerToolMetadataResource[] = [];
 
     expect(() => {
-      makeToolsWithStakesAndTimeout("invalid_server_id", metadata);
+      getToolExtraFields("invalid_server_id", metadata);
     }).toThrow("Invalid MCP server ID: invalid_server_id");
   });
 });

--- a/front/lib/actions/mcp_actions.test.ts
+++ b/front/lib/actions/mcp_actions.test.ts
@@ -332,6 +332,7 @@ describe("makeToolsWithStakesAndTimeout", () => {
         another_tool: "high",
         yet_another_tool: "low",
       },
+      toolsRetryPolicies: undefined,
       serverTimeoutMs: undefined,
     });
   });

--- a/front/lib/actions/mcp_actions.ts
+++ b/front/lib/actions/mcp_actions.ts
@@ -138,8 +138,7 @@ export function getToolExtraFields(
     }
     const serverName = r.value.name;
     toolsStakes = INTERNAL_MCP_SERVERS[serverName].tools_stakes || {};
-    toolsRetryPolicies =
-      INTERNAL_MCP_SERVERS[serverName].tools_retry_policies || {};
+    toolsRetryPolicies = INTERNAL_MCP_SERVERS[serverName].tools_retry_policies;
     serverTimeoutMs = INTERNAL_MCP_SERVERS[serverName]?.timeoutMs;
   } else {
     metadata.forEach(

--- a/front/lib/actions/mcp_actions.ts
+++ b/front/lib/actions/mcp_actions.ts
@@ -32,7 +32,6 @@ import type {
   ServerSideMCPServerConfigurationType,
   ServerSideMCPToolConfigurationType,
 } from "@app/lib/actions/mcp";
-import { DEFAULT_MCP_TOOL_RETRY_POLICY } from "@app/lib/api/mcp";
 import { MCPServerPersonalAuthenticationRequiredError } from "@app/lib/actions/mcp_authentication";
 import { getServerTypeAndIdFromSId } from "@app/lib/actions/mcp_helper";
 import {
@@ -76,6 +75,7 @@ import type {
   MCPToolType,
   ServerSideMCPToolTypeWithStakeAndRetryPolicy,
 } from "@app/lib/api/mcp";
+import { DEFAULT_MCP_TOOL_RETRY_POLICY } from "@app/lib/api/mcp";
 import type { Authenticator } from "@app/lib/auth";
 import { MCPServerViewResource } from "@app/lib/resources/mcp_server_view_resource";
 import { RemoteMCPServerToolMetadataResource } from "@app/lib/resources/remote_mcp_server_tool_metadata_resource";

--- a/front/lib/actions/mcp_actions.ts
+++ b/front/lib/actions/mcp_actions.ts
@@ -24,10 +24,15 @@ import {
   FALLBACK_INTERNAL_AUTO_SERVERS_TOOL_STAKE_LEVEL,
   FALLBACK_MCP_TOOL_STAKE_LEVEL,
 } from "@app/lib/actions/constants";
-import type {ClientSideMCPServerConfigurationType, ClientSideMCPToolConfigurationType, MCPServerConfigurationType, MCPToolConfigurationType, MCPToolRetryPolicyType, ServerSideMCPServerConfigurationType, ServerSideMCPToolConfigurationType} from "@app/lib/actions/mcp";
-import {
-  DEFAULT_MCP_TOOL_RETRY_POLICY
+import type {
+  ClientSideMCPServerConfigurationType,
+  ClientSideMCPToolConfigurationType,
+  MCPServerConfigurationType,
+  MCPToolConfigurationType,
+  ServerSideMCPServerConfigurationType,
+  ServerSideMCPToolConfigurationType,
 } from "@app/lib/actions/mcp";
+import { DEFAULT_MCP_TOOL_RETRY_POLICY } from "@app/lib/api/mcp";
 import { MCPServerPersonalAuthenticationRequiredError } from "@app/lib/actions/mcp_authentication";
 import { getServerTypeAndIdFromSId } from "@app/lib/actions/mcp_helper";
 import {
@@ -67,6 +72,7 @@ import {
 import { getBaseServerId } from "@app/lib/api/actions/mcp/client_side_registry";
 import type {
   ClientSideMCPToolTypeWithStakeLevel,
+  MCPToolRetryPolicyType,
   MCPToolType,
   ServerSideMCPToolTypeWithStakeAndRetryPolicy,
 } from "@app/lib/api/mcp";
@@ -833,15 +839,13 @@ export async function listToolsForServerSideMCPServer(
       stakeLevel: FALLBACK_MCP_TOOL_STAKE_LEVEL,
       availability: "manual" as const,
       toolServerId: "",
+      retryPolicy: DEFAULT_MCP_TOOL_RETRY_POLICY,
     }));
 
     // Create configurations and add required properties.
     const serverSideToolConfigs = makeServerSideMCPToolConfigurations(
       config,
-      rawTools.map((tool) => ({
-        ...tool,
-        retryPolicy: DEFAULT_MCP_TOOL_RETRY_POLICY,
-      }))
+      rawTools
     );
     return new Ok(serverSideToolConfigs);
   }

--- a/front/lib/actions/mcp_actions.ts
+++ b/front/lib/actions/mcp_actions.ts
@@ -881,7 +881,9 @@ export async function listToolsForServerSideMCPServer(
       toolServerId: connectionParams.mcpServerId,
       ...(serverTimeoutMs && { timeoutMs: serverTimeoutMs }),
       retryPolicy:
-        toolsRetryPolicies?.[tool.name] || DEFAULT_MCP_TOOL_RETRY_POLICY,
+        toolsRetryPolicies?.[tool.name] ||
+        toolsRetryPolicies?.["default"] ||
+        DEFAULT_MCP_TOOL_RETRY_POLICY,
     }));
 
   const serverSideToolConfigs = makeServerSideMCPToolConfigurations(

--- a/front/lib/actions/mcp_actions.ts
+++ b/front/lib/actions/mcp_actions.ts
@@ -24,15 +24,9 @@ import {
   FALLBACK_INTERNAL_AUTO_SERVERS_TOOL_STAKE_LEVEL,
   FALLBACK_MCP_TOOL_STAKE_LEVEL,
 } from "@app/lib/actions/constants";
+import type {ClientSideMCPServerConfigurationType, ClientSideMCPToolConfigurationType, MCPServerConfigurationType, MCPToolConfigurationType, MCPToolRetryPolicyType, ServerSideMCPServerConfigurationType, ServerSideMCPToolConfigurationType} from "@app/lib/actions/mcp";
 import {
-  DEFAULT_MCP_TOOL_RETRY_POLICY,
-  type ClientSideMCPServerConfigurationType,
-  type ClientSideMCPToolConfigurationType,
-  type MCPServerConfigurationType,
-  type MCPToolConfigurationType,
-  type MCPToolRetryPolicyType,
-  type ServerSideMCPServerConfigurationType,
-  type ServerSideMCPToolConfigurationType,
+  DEFAULT_MCP_TOOL_RETRY_POLICY
 } from "@app/lib/actions/mcp";
 import { MCPServerPersonalAuthenticationRequiredError } from "@app/lib/actions/mcp_authentication";
 import { getServerTypeAndIdFromSId } from "@app/lib/actions/mcp_helper";

--- a/front/lib/actions/mcp_internal_actions/constants.ts
+++ b/front/lib/actions/mcp_internal_actions/constants.ts
@@ -8,7 +8,7 @@ import {
   DEFAULT_WEBSEARCH_ACTION_DESCRIPTION,
   DEFAULT_WEBSEARCH_ACTION_NAME,
 } from "@app/lib/actions/constants";
-import { MCPToolRetryPolicyType } from "@app/lib/actions/mcp";
+import type { MCPToolRetryPolicyType } from "@app/lib/actions/mcp";
 import {
   FRESHSERVICE_SERVER_INSTRUCTIONS,
   JIRA_SERVER_INSTRUCTIONS,

--- a/front/lib/actions/mcp_internal_actions/constants.ts
+++ b/front/lib/actions/mcp_internal_actions/constants.ts
@@ -936,7 +936,7 @@ The directive should be used to display a clickable version of the agent name in
     isPreview: false,
     tools_stakes: undefined,
     tools_retry_policies: {
-      run_agent: "retry_on_interrupt",
+      default: "retry_on_interrupt",
     },
     timeoutMs: MAX_MCP_REQUEST_TIMEOUT_MS,
     serverInfo: {

--- a/front/lib/actions/mcp_internal_actions/constants.ts
+++ b/front/lib/actions/mcp_internal_actions/constants.ts
@@ -935,9 +935,7 @@ The directive should be used to display a clickable version of the agent name in
     isRestricted: undefined,
     isPreview: false,
     tools_stakes: undefined,
-    tools_retry_policies: {
-      default: "retry_on_interrupt",
-    },
+    tools_retry_policies: { default: "retry" },
     timeoutMs: MAX_MCP_REQUEST_TIMEOUT_MS,
     serverInfo: {
       name: "run_agent",

--- a/front/lib/actions/mcp_internal_actions/constants.ts
+++ b/front/lib/actions/mcp_internal_actions/constants.ts
@@ -184,7 +184,7 @@ export const INTERNAL_MCP_SERVERS = {
     isRestricted: undefined,
     isPreview: false,
     tools_stakes: undefined,
-    tools_retry_policies: { default: "retry" },
+    tools_retry_policies: { default: "retry_on_interrupt" },
     timeoutMs: undefined,
     serverInfo: {
       name: TABLE_QUERY_SERVER_NAME,
@@ -204,7 +204,7 @@ export const INTERNAL_MCP_SERVERS = {
     isRestricted: undefined,
     isPreview: false,
     tools_stakes: undefined,
-    tools_retry_policies: { default: "retry" },
+    tools_retry_policies: { default: "retry_on_interrupt" },
     timeoutMs: undefined,
     serverInfo: {
       name: DEFAULT_WEBSEARCH_ACTION_NAME,
@@ -225,7 +225,7 @@ export const INTERNAL_MCP_SERVERS = {
     },
     isPreview: true,
     tools_stakes: undefined,
-    tools_retry_policies: { default: "retry" },
+    tools_retry_policies: { default: "retry_on_interrupt" },
     timeoutMs: undefined,
     serverInfo: {
       name: "think",
@@ -329,7 +329,7 @@ The directive should be used to display a clickable version of the agent name in
     isRestricted: undefined,
     isPreview: false,
     tools_stakes: undefined,
-    tools_retry_policies: { default: "retry" },
+    tools_retry_policies: { default: "retry_on_interrupt" },
     timeoutMs: undefined,
     serverInfo: {
       name: "include_data",
@@ -411,7 +411,7 @@ The directive should be used to display a clickable version of the agent name in
     isRestricted: undefined,
     isPreview: false,
     tools_stakes: undefined,
-    tools_retry_policies: { default: "retry" },
+    tools_retry_policies: { default: "retry_on_interrupt" },
     timeoutMs: undefined,
     serverInfo: {
       name: "extract_data",
@@ -894,7 +894,7 @@ The directive should be used to display a clickable version of the agent name in
       search_files: "never_ask",
       get_file_content: "never_ask",
     },
-    tools_retry_policies: { default: "retry" },
+    tools_retry_policies: { default: "retry_on_interrupt" },
     timeoutMs: undefined,
     serverInfo: {
       name: "google_drive",
@@ -918,7 +918,7 @@ The directive should be used to display a clickable version of the agent name in
     isRestricted: undefined,
     isPreview: false,
     tools_stakes: undefined,
-    tools_retry_policies: { default: "retry" },
+    tools_retry_policies: { default: "retry_on_interrupt" },
     timeoutMs: undefined,
     serverInfo: {
       name: SEARCH_SERVER_NAME,

--- a/front/lib/actions/mcp_internal_actions/constants.ts
+++ b/front/lib/actions/mcp_internal_actions/constants.ts
@@ -8,6 +8,7 @@ import {
   DEFAULT_WEBSEARCH_ACTION_DESCRIPTION,
   DEFAULT_WEBSEARCH_ACTION_NAME,
 } from "@app/lib/actions/constants";
+import { MCPToolRetryPolicyType } from "@app/lib/actions/mcp";
 import {
   FRESHSERVICE_SERVER_INSTRUCTIONS,
   JIRA_SERVER_INSTRUCTIONS,
@@ -121,6 +122,7 @@ export const INTERNAL_MCP_SERVERS = {
       list_pull_requests: "never_ask",
       get_issue: "never_ask",
     },
+    tools_retry_policies: undefined,
     timeoutMs: undefined,
     serverInfo: {
       name: "github",
@@ -142,6 +144,7 @@ export const INTERNAL_MCP_SERVERS = {
     isRestricted: undefined,
     isPreview: false,
     tools_stakes: undefined,
+    tools_retry_policies: undefined,
     timeoutMs: undefined,
     serverInfo: {
       name: "image_generation",
@@ -160,6 +163,7 @@ export const INTERNAL_MCP_SERVERS = {
     isRestricted: undefined,
     isPreview: false,
     tools_stakes: undefined,
+    tools_retry_policies: undefined,
     timeoutMs: undefined,
     serverInfo: {
       name: "file_generation",
@@ -178,6 +182,7 @@ export const INTERNAL_MCP_SERVERS = {
     isRestricted: undefined,
     isPreview: false,
     tools_stakes: undefined,
+    tools_retry_policies: undefined,
     timeoutMs: undefined,
     serverInfo: {
       name: TABLE_QUERY_SERVER_NAME,
@@ -197,6 +202,7 @@ export const INTERNAL_MCP_SERVERS = {
     isRestricted: undefined,
     isPreview: false,
     tools_stakes: undefined,
+    tools_retry_policies: undefined,
     timeoutMs: undefined,
     serverInfo: {
       name: DEFAULT_WEBSEARCH_ACTION_NAME,
@@ -217,6 +223,7 @@ export const INTERNAL_MCP_SERVERS = {
     },
     isPreview: true,
     tools_stakes: undefined,
+    tools_retry_policies: undefined,
     timeoutMs: undefined,
     serverInfo: {
       name: "think",
@@ -274,6 +281,7 @@ export const INTERNAL_MCP_SERVERS = {
       update_deal: "high",
       remove_association: "high",
     },
+    tools_retry_policies: undefined,
     timeoutMs: undefined,
     serverInfo: {
       name: "hubspot",
@@ -298,6 +306,7 @@ export const INTERNAL_MCP_SERVERS = {
     isRestricted: undefined,
     isPreview: false,
     tools_stakes: undefined,
+    tools_retry_policies: undefined,
     timeoutMs: undefined,
     serverInfo: {
       name: DEFAULT_AGENT_ROUTER_ACTION_NAME,
@@ -318,6 +327,7 @@ The directive should be used to display a clickable version of the agent name in
     isRestricted: undefined,
     isPreview: false,
     tools_stakes: undefined,
+    tools_retry_policies: undefined,
     timeoutMs: undefined,
     serverInfo: {
       name: "include_data",
@@ -337,6 +347,7 @@ The directive should be used to display a clickable version of the agent name in
     isRestricted: undefined,
     isPreview: false,
     tools_stakes: undefined,
+    tools_retry_policies: undefined,
     timeoutMs: undefined,
     serverInfo: {
       name: "run_dust_app",
@@ -376,6 +387,7 @@ The directive should be used to display a clickable version of the agent name in
       update_row_database: "low",
       update_schema_database: "low",
     },
+    tools_retry_policies: undefined,
     timeoutMs: undefined,
     serverInfo: {
       name: "notion",
@@ -397,6 +409,7 @@ The directive should be used to display a clickable version of the agent name in
     isRestricted: undefined,
     isPreview: false,
     tools_stakes: undefined,
+    tools_retry_policies: undefined,
     timeoutMs: undefined,
     serverInfo: {
       name: "extract_data",
@@ -415,6 +428,7 @@ The directive should be used to display a clickable version of the agent name in
     isRestricted: undefined,
     isPreview: false,
     tools_stakes: undefined,
+    tools_retry_policies: undefined,
     timeoutMs: undefined,
     serverInfo: {
       name: "missing_action_catcher",
@@ -442,6 +456,7 @@ The directive should be used to display a clickable version of the agent name in
       list_objects: "never_ask",
       describe_object: "never_ask",
     },
+    tools_retry_policies: undefined,
     timeoutMs: undefined,
     serverInfo: {
       name: "salesforce",
@@ -468,6 +483,7 @@ The directive should be used to display a clickable version of the agent name in
       get_messages: "low",
       create_reply_draft: "low",
     },
+    tools_retry_policies: undefined,
     timeoutMs: undefined,
     serverInfo: {
       name: "gmail",
@@ -499,6 +515,7 @@ The directive should be used to display a clickable version of the agent name in
       delete_event: "low",
       check_availability: "never_ask",
     },
+    tools_retry_policies: undefined,
     timeoutMs: undefined,
     serverInfo: {
       name: "google_calendar",
@@ -522,6 +539,7 @@ The directive should be used to display a clickable version of the agent name in
     isRestricted: undefined,
     isPreview: false,
     tools_stakes: undefined,
+    tools_retry_policies: undefined,
     timeoutMs: undefined,
     serverInfo: {
       name: "conversation_files",
@@ -548,6 +566,7 @@ The directive should be used to display a clickable version of the agent name in
       post_message: "low",
       get_user: "never_ask",
     },
+    tools_retry_policies: undefined,
     timeoutMs: undefined,
     serverInfo: {
       name: "slack",
@@ -585,6 +604,7 @@ The directive should be used to display a clickable version of the agent name in
       delete_worksheet: "low",
       format_cells: "low",
     },
+    tools_retry_policies: undefined,
     timeoutMs: undefined,
     serverInfo: {
       name: "google_sheets",
@@ -639,6 +659,7 @@ The directive should be used to display a clickable version of the agent name in
       delete_item: "high",
       delete_group: "high",
     },
+    tools_retry_policies: undefined,
     timeoutMs: undefined,
     serverInfo: {
       name: "monday",
@@ -662,6 +683,7 @@ The directive should be used to display a clickable version of the agent name in
     isRestricted: undefined,
     isPreview: false,
     tools_stakes: undefined,
+    tools_retry_policies: undefined,
     timeoutMs: undefined,
     serverInfo: {
       name: "agent_memory",
@@ -703,6 +725,7 @@ The directive should be used to display a clickable version of the agent name in
       create_issue_link: "low",
       delete_issue_link: "low",
     },
+    tools_retry_policies: undefined,
     timeoutMs: undefined,
     serverInfo: {
       name: "jira",
@@ -727,6 +750,7 @@ The directive should be used to display a clickable version of the agent name in
     },
     isPreview: true,
     tools_stakes: undefined,
+    tools_retry_policies: undefined,
     timeoutMs: undefined,
     serverInfo: {
       name: "content_creation",
@@ -755,6 +779,7 @@ The directive should be used to display a clickable version of the agent name in
       create_contact: "high",
       update_contact: "high",
     },
+    tools_retry_policies: undefined,
     timeoutMs: undefined,
     serverInfo: {
       name: "outlook",
@@ -787,6 +812,7 @@ The directive should be used to display a clickable version of the agent name in
       delete_event: "low",
       check_availability: "never_ask",
     },
+    tools_retry_policies: undefined,
     timeoutMs: undefined,
     serverInfo: {
       name: "outlook_calendar",
@@ -835,6 +861,7 @@ The directive should be used to display a clickable version of the agent name in
       add_ticket_reply: "low",
       create_solution_article: "high",
     },
+    tools_retry_policies: undefined,
     timeoutMs: undefined,
     serverInfo: {
       name: "freshservice",
@@ -865,6 +892,7 @@ The directive should be used to display a clickable version of the agent name in
       search_files: "never_ask",
       get_file_content: "never_ask",
     },
+    tools_retry_policies: undefined,
     timeoutMs: undefined,
     serverInfo: {
       name: "google_drive",
@@ -888,6 +916,7 @@ The directive should be used to display a clickable version of the agent name in
     isRestricted: undefined,
     isPreview: false,
     tools_stakes: undefined,
+    tools_retry_policies: undefined,
     timeoutMs: undefined,
     serverInfo: {
       name: SEARCH_SERVER_NAME,
@@ -906,6 +935,9 @@ The directive should be used to display a clickable version of the agent name in
     isRestricted: undefined,
     isPreview: false,
     tools_stakes: undefined,
+    tools_retry_policies: {
+      run_agent: "retryable_on_interrupt",
+    },
     timeoutMs: MAX_MCP_REQUEST_TIMEOUT_MS,
     serverInfo: {
       name: "run_agent",
@@ -926,6 +958,7 @@ The directive should be used to display a clickable version of the agent name in
       return !featureFlags.includes("dev_mcp_actions");
     },
     tools_stakes: undefined,
+    tools_retry_policies: undefined,
     timeoutMs: undefined,
     serverInfo: {
       name: "primitive_types_debugger",
@@ -945,6 +978,7 @@ The directive should be used to display a clickable version of the agent name in
     isRestricted: undefined,
     isPreview: false,
     tools_stakes: undefined,
+    tools_retry_policies: undefined,
     timeoutMs: undefined,
     serverInfo: {
       name: "reasoning",
@@ -967,6 +1001,7 @@ The directive should be used to display a clickable version of the agent name in
     },
     isPreview: true,
     tools_stakes: undefined,
+    tools_retry_policies: undefined,
     timeoutMs: undefined,
     serverInfo: {
       name: "query_tables_v2",
@@ -988,6 +1023,7 @@ The directive should be used to display a clickable version of the agent name in
     isRestricted: undefined,
     isPreview: false,
     tools_stakes: undefined,
+    tools_retry_policies: undefined,
     timeoutMs: undefined,
     serverInfo: {
       name: "data_sources_file_system",
@@ -1015,6 +1051,7 @@ The directive should be used to display a clickable version of the agent name in
     tools_stakes: {
       create_agent: "high",
     },
+    tools_retry_policies: undefined,
     timeoutMs: undefined,
     serverInfo: {
       name: "agent_management",
@@ -1035,6 +1072,7 @@ The directive should be used to display a clickable version of the agent name in
       return !featureFlags.includes("data_warehouses_tool");
     },
     tools_stakes: undefined,
+    tools_retry_policies: undefined,
     timeoutMs: undefined,
     serverInfo: {
       name: DATA_WAREHOUSE_SERVER_NAME,
@@ -1058,6 +1096,7 @@ The directive should be used to display a clickable version of the agent name in
       return !featureFlags.includes("toolsets_tool");
     },
     tools_stakes: undefined,
+    tools_retry_policies: undefined,
     timeoutMs: undefined,
     serverInfo: {
       name: "toolsets",
@@ -1085,6 +1124,7 @@ The directive should be used to display a clickable version of the agent name in
       | undefined;
     isPreview: boolean;
     tools_stakes: Record<string, MCPToolStakeLevelType> | undefined;
+    tools_retry_policies: Record<string, MCPToolRetryPolicyType> | undefined;
     timeoutMs: number | undefined;
     serverInfo: InternalMCPServerDefinitionType & { name: K };
   };

--- a/front/lib/actions/mcp_internal_actions/constants.ts
+++ b/front/lib/actions/mcp_internal_actions/constants.ts
@@ -936,7 +936,7 @@ The directive should be used to display a clickable version of the agent name in
     isPreview: false,
     tools_stakes: undefined,
     tools_retry_policies: {
-      run_agent: "retryable_on_interrupt",
+      run_agent: "retry_on_interrupt",
     },
     timeoutMs: MAX_MCP_REQUEST_TIMEOUT_MS,
     serverInfo: {

--- a/front/lib/actions/mcp_internal_actions/constants.ts
+++ b/front/lib/actions/mcp_internal_actions/constants.ts
@@ -182,7 +182,7 @@ export const INTERNAL_MCP_SERVERS = {
     isRestricted: undefined,
     isPreview: false,
     tools_stakes: undefined,
-    tools_retry_policies: undefined,
+    tools_retry_policies: { default: "retry" },
     timeoutMs: undefined,
     serverInfo: {
       name: TABLE_QUERY_SERVER_NAME,
@@ -202,7 +202,7 @@ export const INTERNAL_MCP_SERVERS = {
     isRestricted: undefined,
     isPreview: false,
     tools_stakes: undefined,
-    tools_retry_policies: undefined,
+    tools_retry_policies: { default: "retry" },
     timeoutMs: undefined,
     serverInfo: {
       name: DEFAULT_WEBSEARCH_ACTION_NAME,
@@ -223,7 +223,7 @@ export const INTERNAL_MCP_SERVERS = {
     },
     isPreview: true,
     tools_stakes: undefined,
-    tools_retry_policies: undefined,
+    tools_retry_policies: { default: "retry" },
     timeoutMs: undefined,
     serverInfo: {
       name: "think",
@@ -327,7 +327,7 @@ The directive should be used to display a clickable version of the agent name in
     isRestricted: undefined,
     isPreview: false,
     tools_stakes: undefined,
-    tools_retry_policies: undefined,
+    tools_retry_policies: { default: "retry" },
     timeoutMs: undefined,
     serverInfo: {
       name: "include_data",
@@ -409,7 +409,7 @@ The directive should be used to display a clickable version of the agent name in
     isRestricted: undefined,
     isPreview: false,
     tools_stakes: undefined,
-    tools_retry_policies: undefined,
+    tools_retry_policies: { default: "retry" },
     timeoutMs: undefined,
     serverInfo: {
       name: "extract_data",
@@ -892,7 +892,7 @@ The directive should be used to display a clickable version of the agent name in
       search_files: "never_ask",
       get_file_content: "never_ask",
     },
-    tools_retry_policies: undefined,
+    tools_retry_policies: { default: "retry" },
     timeoutMs: undefined,
     serverInfo: {
       name: "google_drive",
@@ -916,7 +916,7 @@ The directive should be used to display a clickable version of the agent name in
     isRestricted: undefined,
     isPreview: false,
     tools_stakes: undefined,
-    tools_retry_policies: undefined,
+    tools_retry_policies: { default: "retry" },
     timeoutMs: undefined,
     serverInfo: {
       name: SEARCH_SERVER_NAME,
@@ -935,7 +935,7 @@ The directive should be used to display a clickable version of the agent name in
     isRestricted: undefined,
     isPreview: false,
     tools_stakes: undefined,
-    tools_retry_policies: { default: "retry" },
+    tools_retry_policies: undefined,
     timeoutMs: MAX_MCP_REQUEST_TIMEOUT_MS,
     serverInfo: {
       name: "run_agent",

--- a/front/lib/actions/mcp_internal_actions/constants.ts
+++ b/front/lib/actions/mcp_internal_actions/constants.ts
@@ -8,14 +8,16 @@ import {
   DEFAULT_WEBSEARCH_ACTION_DESCRIPTION,
   DEFAULT_WEBSEARCH_ACTION_NAME,
 } from "@app/lib/actions/constants";
-import type { MCPToolRetryPolicyType } from "@app/lib/actions/mcp";
 import {
   FRESHSERVICE_SERVER_INSTRUCTIONS,
   JIRA_SERVER_INSTRUCTIONS,
   SALESFORCE_SERVER_INSTRUCTIONS,
 } from "@app/lib/actions/mcp_internal_actions/instructions";
 import { CONTENT_CREATION_INSTRUCTIONS } from "@app/lib/actions/mcp_internal_actions/servers/content_creation/instructions";
-import type { InternalMCPServerDefinitionType } from "@app/lib/api/mcp";
+import type {
+  InternalMCPServerDefinitionType,
+  MCPToolRetryPolicyType,
+} from "@app/lib/api/mcp";
 import { getResourceNameAndIdFromSId } from "@app/lib/resources/string_ids";
 import type {
   ModelId,

--- a/front/lib/actions/types/guards.ts
+++ b/front/lib/actions/types/guards.ts
@@ -1,5 +1,6 @@
 import type {
   ClientSideMCPToolConfigurationType,
+  LightClientSideMCPToolConfigurationType,
   LightMCPToolConfigurationType,
   LightServerSideMCPToolConfigurationType,
   MCPActionType,
@@ -218,6 +219,25 @@ export function isLightServerSideMCPToolConfiguration(
     isMCPToolConfiguration(arg) &&
     "mcpServerViewId" in arg &&
     !("inputSchema" in arg)
+  );
+}
+
+export function isLightClientSideMCPToolConfiguration(
+  arg: unknown
+): arg is LightClientSideMCPToolConfigurationType {
+  return (
+    isMCPToolConfiguration(arg) &&
+    "clientSideMcpServerId" in arg &&
+    !("inputSchema" in arg)
+  );
+}
+
+export function isLightMCPToolConfiguration(
+  arg: unknown
+): arg is LightMCPToolConfigurationType {
+  return (
+    isLightServerSideMCPToolConfiguration(arg) ||
+    isLightClientSideMCPToolConfiguration(arg)
   );
 }
 

--- a/front/lib/api/assistant/agent.ts
+++ b/front/lib/api/assistant/agent.ts
@@ -154,6 +154,7 @@ async function runAgentSynchronousWithStreaming(
             publishDeferredEventsActivity,
             runModelAndCreateActionsActivity,
             runToolActivity,
+            runRetryableToolActivity: runToolActivity,
           },
           {
             startStep,

--- a/front/lib/api/mcp.ts
+++ b/front/lib/api/mcp.ts
@@ -1,6 +1,7 @@
 import type { JSONSchema7 as JSONSchema } from "json-schema";
 
 import type { MCPToolStakeLevelType } from "@app/lib/actions/constants";
+import type { MCPToolRetryPolicyType } from "@app/lib/actions/mcp";
 import type {
   CustomServerIconType,
   InternalAllowedIconType,
@@ -11,7 +12,6 @@ import type {
 } from "@app/lib/actions/mcp_internal_actions/constants";
 import type { AuthorizationInfo } from "@app/lib/actions/mcp_metadata";
 import type { EditedByUser, MCPOAuthUseCase, ModelId } from "@app/types";
-import { MCPToolRetryPolicyType } from "@app/lib/actions/mcp";
 
 export type MCPToolType = {
   name: string;

--- a/front/lib/api/mcp.ts
+++ b/front/lib/api/mcp.ts
@@ -11,6 +11,7 @@ import type {
 } from "@app/lib/actions/mcp_internal_actions/constants";
 import type { AuthorizationInfo } from "@app/lib/actions/mcp_metadata";
 import type { EditedByUser, MCPOAuthUseCase, ModelId } from "@app/types";
+import { MCPToolRetryPolicyType } from "@app/lib/actions/mcp";
 
 export type MCPToolType = {
   name: string;
@@ -26,17 +27,18 @@ export type WithStakeLevelType<T> = T & {
   stakeLevel: MCPToolStakeLevelType;
 };
 
-export type ServerSideMCPToolTypeWithStakeLevel =
+export type ServerSideMCPToolTypeWithStakeAndRetryPolicy =
   WithStakeLevelType<MCPToolWithAvailabilityType> & {
     toolServerId: string;
     timeoutMs?: number;
+    retryPolicy: MCPToolRetryPolicyType;
   };
 
 export type ClientSideMCPToolTypeWithStakeLevel =
   WithStakeLevelType<MCPToolWithAvailabilityType>;
 
 export type MCPToolWithStakeLevelType =
-  | ServerSideMCPToolTypeWithStakeLevel
+  | ServerSideMCPToolTypeWithStakeAndRetryPolicy
   | ClientSideMCPToolTypeWithStakeLevel;
 
 export type MCPServerType = {

--- a/front/lib/api/mcp.ts
+++ b/front/lib/api/mcp.ts
@@ -21,7 +21,7 @@ import {
 } from "@app/lib/actions/types/guards";
 import type { EditedByUser, MCPOAuthUseCase, ModelId } from "@app/types";
 
-const MCP_TOOL_RETRY_POLICY_TYPES = ["retry", "no_retry"] as const;
+const MCP_TOOL_RETRY_POLICY_TYPES = ["retry_on_interrupt", "no_retry"] as const;
 export type MCPToolRetryPolicyType =
   (typeof MCP_TOOL_RETRY_POLICY_TYPES)[number];
 

--- a/front/lib/api/mcp.ts
+++ b/front/lib/api/mcp.ts
@@ -27,7 +27,7 @@ export type MCPToolRetryPolicyType =
 
 // Default to never_retryable if the retry policy is not defined.
 export const DEFAULT_MCP_TOOL_RETRY_POLICY =
-  "no_retry" satisfies MCPToolRetryPolicyType;
+  "no_retry" as const satisfies MCPToolRetryPolicyType;
 
 export function getRetryPolicyFromToolConfiguration(
   toolConfiguration: MCPToolConfigurationType | LightMCPToolConfigurationType

--- a/front/lib/api/mcp.ts
+++ b/front/lib/api/mcp.ts
@@ -1,7 +1,6 @@
 import type { JSONSchema7 as JSONSchema } from "json-schema";
 
 import type { MCPToolStakeLevelType } from "@app/lib/actions/constants";
-import type { MCPToolRetryPolicyType } from "@app/lib/actions/mcp";
 import type {
   CustomServerIconType,
   InternalAllowedIconType,
@@ -12,6 +11,34 @@ import type {
 } from "@app/lib/actions/mcp_internal_actions/constants";
 import type { AuthorizationInfo } from "@app/lib/actions/mcp_metadata";
 import type { EditedByUser, MCPOAuthUseCase, ModelId } from "@app/types";
+import {
+  MCPToolConfigurationType,
+  LightMCPToolConfigurationType,
+} from "@app/lib/actions/mcp";
+import {
+  isLightServerSideMCPToolConfiguration,
+  isLightClientSideMCPToolConfiguration,
+  isServerSideMCPToolConfiguration,
+} from "@app/lib/actions/types/guards";
+
+const MCP_TOOL_RETRY_POLICY_TYPES = ["retry", "no_retry"] as const;
+export type MCPToolRetryPolicyType =
+  (typeof MCP_TOOL_RETRY_POLICY_TYPES)[number];
+
+// Default to never_retryable if the retry policy is not defined.
+export const DEFAULT_MCP_TOOL_RETRY_POLICY =
+  "no_retry" satisfies MCPToolRetryPolicyType;
+
+export function getRetryPolicyFromToolConfiguration(
+  toolConfiguration: MCPToolConfigurationType | LightMCPToolConfigurationType
+): MCPToolRetryPolicyType {
+  return isLightServerSideMCPToolConfiguration(toolConfiguration) ||
+    (!isLightClientSideMCPToolConfiguration(toolConfiguration) &&
+      isServerSideMCPToolConfiguration(toolConfiguration))
+    ? toolConfiguration.retryPolicy
+    : // Client-side MCP tool retry policy is not supported yet.
+      DEFAULT_MCP_TOOL_RETRY_POLICY;
+}
 
 export type MCPToolType = {
   name: string;

--- a/front/lib/api/mcp.ts
+++ b/front/lib/api/mcp.ts
@@ -2,6 +2,10 @@ import type { JSONSchema7 as JSONSchema } from "json-schema";
 
 import type { MCPToolStakeLevelType } from "@app/lib/actions/constants";
 import type {
+  LightMCPToolConfigurationType,
+  MCPToolConfigurationType,
+} from "@app/lib/actions/mcp";
+import type {
   CustomServerIconType,
   InternalAllowedIconType,
 } from "@app/lib/actions/mcp_icons";
@@ -10,16 +14,12 @@ import type {
   MCPServerAvailability,
 } from "@app/lib/actions/mcp_internal_actions/constants";
 import type { AuthorizationInfo } from "@app/lib/actions/mcp_metadata";
-import type { EditedByUser, MCPOAuthUseCase, ModelId } from "@app/types";
 import {
-  MCPToolConfigurationType,
-  LightMCPToolConfigurationType,
-} from "@app/lib/actions/mcp";
-import {
-  isLightServerSideMCPToolConfiguration,
   isLightClientSideMCPToolConfiguration,
+  isLightServerSideMCPToolConfiguration,
   isServerSideMCPToolConfiguration,
 } from "@app/lib/actions/types/guards";
+import type { EditedByUser, MCPOAuthUseCase, ModelId } from "@app/types";
 
 const MCP_TOOL_RETRY_POLICY_TYPES = ["retry", "no_retry"] as const;
 export type MCPToolRetryPolicyType =

--- a/front/lib/api/mcp/run_tool.ts
+++ b/front/lib/api/mcp/run_tool.ts
@@ -1,13 +1,8 @@
 import { McpError } from "@modelcontextprotocol/sdk/types.js";
 
+import type {ActionBaseParams, MCPApproveExecutionEvent, MCPErrorEvent, MCPParamsEvent, MCPSuccessEvent, ToolNotificationEvent} from "@app/lib/actions/mcp";
 import {
-  getRetryPolicyFromToolConfiguration,
-  type ActionBaseParams,
-  type MCPApproveExecutionEvent,
-  type MCPErrorEvent,
-  type MCPParamsEvent,
-  type MCPSuccessEvent,
-  type ToolNotificationEvent,
+  getRetryPolicyFromToolConfiguration
 } from "@app/lib/actions/mcp";
 import { MCPServerPersonalAuthenticationRequiredError } from "@app/lib/actions/mcp_authentication";
 import {

--- a/front/lib/api/mcp/run_tool.ts
+++ b/front/lib/api/mcp/run_tool.ts
@@ -1,8 +1,12 @@
 import { McpError } from "@modelcontextprotocol/sdk/types.js";
 
-import type {ActionBaseParams, MCPApproveExecutionEvent, MCPErrorEvent, MCPParamsEvent, MCPSuccessEvent, ToolNotificationEvent} from "@app/lib/actions/mcp";
-import {
-  getRetryPolicyFromToolConfiguration
+import type {
+  ActionBaseParams,
+  MCPApproveExecutionEvent,
+  MCPErrorEvent,
+  MCPParamsEvent,
+  MCPSuccessEvent,
+  ToolNotificationEvent,
 } from "@app/lib/actions/mcp";
 import { MCPServerPersonalAuthenticationRequiredError } from "@app/lib/actions/mcp_authentication";
 import {
@@ -24,6 +28,7 @@ import type {
   ConversationType,
 } from "@app/types";
 import { removeNulls } from "@app/types";
+import { getRetryPolicyFromToolConfiguration } from "@app/lib/api/mcp";
 
 /**
  * Runs a tool with streaming for the given MCP action configuration.

--- a/front/lib/api/mcp/run_tool.ts
+++ b/front/lib/api/mcp/run_tool.ts
@@ -17,6 +17,7 @@ import type { ToolPersonalAuthRequiredEvent } from "@app/lib/actions/mcp_interna
 import { ToolBlockedAwaitingInputError } from "@app/lib/actions/mcp_internal_actions/servers/run_agent/types";
 import { hideFileFromActionOutput } from "@app/lib/actions/mcp_utils";
 import type { AgentLoopRunContextType } from "@app/lib/actions/types";
+import { getRetryPolicyFromToolConfiguration } from "@app/lib/api/mcp";
 import { handleMCPActionError } from "@app/lib/api/mcp/error";
 import type { Authenticator } from "@app/lib/auth";
 import type { AgentMCPActionResource } from "@app/lib/resources/agent_mcp_action_resource";
@@ -28,7 +29,6 @@ import type {
   ConversationType,
 } from "@app/types";
 import { removeNulls } from "@app/types";
-import { getRetryPolicyFromToolConfiguration } from "@app/lib/api/mcp";
 
 /**
  * Runs a tool with streaming for the given MCP action configuration.

--- a/front/temporal/agent_loop/activities/run_model_and_create_actions_wrapper.ts
+++ b/front/temporal/agent_loop/activities/run_model_and_create_actions_wrapper.ts
@@ -18,6 +18,11 @@ import type {
   RunAgentExecutionData,
 } from "@app/types/assistant/agent_run";
 import { getRunAgentData } from "@app/types/assistant/agent_run";
+import { isLightServerSideMCPToolConfiguration } from "@app/lib/actions/types/guards";
+import {
+  DEFAULT_MCP_TOOL_RETRY_POLICY,
+  getRetryPolicyFromToolConfiguration,
+} from "@app/lib/actions/mcp";
 
 export type RunModelAndCreateActionsResult = {
   actionBlobs: ActionBlob[];
@@ -174,6 +179,9 @@ async function getExistingActionsAndBlobs(
           actionId: mcpAction.id,
           actionStatus: mcpAction.status,
           needsApproval: mcpAction.status === "blocked_validation_required",
+          retryPolicy: getRetryPolicyFromToolConfiguration(
+            mcpAction.toolConfiguration
+          ),
         });
       }
     }

--- a/front/temporal/agent_loop/activities/run_model_and_create_actions_wrapper.ts
+++ b/front/temporal/agent_loop/activities/run_model_and_create_actions_wrapper.ts
@@ -1,7 +1,7 @@
 import assert from "assert";
 
-import { getRetryPolicyFromToolConfiguration } from "@app/lib/api/mcp";
 import { isToolExecutionStatusFinal } from "@app/lib/actions/statuses";
+import { getRetryPolicyFromToolConfiguration } from "@app/lib/api/mcp";
 import type { AuthenticatorType } from "@app/lib/auth";
 import type { Authenticator } from "@app/lib/auth";
 import { AgentMCPActionModel } from "@app/lib/models/assistant/actions/mcp";

--- a/front/temporal/agent_loop/activities/run_model_and_create_actions_wrapper.ts
+++ b/front/temporal/agent_loop/activities/run_model_and_create_actions_wrapper.ts
@@ -1,6 +1,6 @@
 import assert from "assert";
 
-import { getRetryPolicyFromToolConfiguration } from "@app/lib/actions/mcp";
+import { getRetryPolicyFromToolConfiguration } from "@app/lib/api/mcp";
 import { isToolExecutionStatusFinal } from "@app/lib/actions/statuses";
 import type { AuthenticatorType } from "@app/lib/auth";
 import type { Authenticator } from "@app/lib/auth";

--- a/front/temporal/agent_loop/activities/run_model_and_create_actions_wrapper.ts
+++ b/front/temporal/agent_loop/activities/run_model_and_create_actions_wrapper.ts
@@ -1,5 +1,6 @@
 import assert from "assert";
 
+import { getRetryPolicyFromToolConfiguration } from "@app/lib/actions/mcp";
 import { isToolExecutionStatusFinal } from "@app/lib/actions/statuses";
 import type { AuthenticatorType } from "@app/lib/auth";
 import type { Authenticator } from "@app/lib/auth";
@@ -18,11 +19,6 @@ import type {
   RunAgentExecutionData,
 } from "@app/types/assistant/agent_run";
 import { getRunAgentData } from "@app/types/assistant/agent_run";
-import { isLightServerSideMCPToolConfiguration } from "@app/lib/actions/types/guards";
-import {
-  DEFAULT_MCP_TOOL_RETRY_POLICY,
-  getRetryPolicyFromToolConfiguration,
-} from "@app/lib/actions/mcp";
 
 export type RunModelAndCreateActionsResult = {
   actionBlobs: ActionBlob[];

--- a/front/temporal/agent_loop/lib/activity_interface.ts
+++ b/front/temporal/agent_loop/lib/activity_interface.ts
@@ -14,4 +14,5 @@ export interface AgentLoopActivities {
   publishDeferredEventsActivity: typeof publishDeferredEventsActivity;
   runModelAndCreateActionsActivity: typeof runModelAndCreateActionsActivity;
   runToolActivity: typeof runToolActivity;
+  runRetryableToolActivity: typeof runToolActivity;
 }

--- a/front/temporal/agent_loop/lib/agent_loop_executor.ts
+++ b/front/temporal/agent_loop/lib/agent_loop_executor.ts
@@ -74,12 +74,18 @@ async function executeStepIteration({
 
   // Execute tools and collect any deferred events.
   const toolResults = await Promise.all(
-    actionBlobs.map(({ actionId }) =>
-      activities.runToolActivity(authType, {
-        actionId,
-        runAgentArgs,
-        step: currentStep,
-      })
+    actionBlobs.map(({ actionId, retryPolicy }) =>
+      retryPolicy === "no_retry"
+        ? activities.runToolActivity(authType, {
+            actionId,
+            runAgentArgs,
+            step: currentStep,
+          })
+        : activities.runRetryableToolActivity(authType, {
+            actionId,
+            runAgentArgs,
+            step: currentStep,
+          })
     )
   );
 

--- a/front/temporal/agent_loop/lib/agent_loop_executor.ts
+++ b/front/temporal/agent_loop/lib/agent_loop_executor.ts
@@ -66,7 +66,6 @@ async function executeStepIteration({
   // actions have been approved.
   const needsApproval = actionBlobs.some((a) => a.needsApproval);
   if (needsApproval) {
-    // Break the loop - workflow will be restarted externally once approved.
     return {
       runId,
       shouldContinue: false,

--- a/front/temporal/agent_loop/lib/create_tool_actions.ts
+++ b/front/temporal/agent_loop/lib/create_tool_actions.ts
@@ -1,9 +1,11 @@
+import type {
+  MCPApproveExecutionEvent,
+  MCPToolConfigurationType,
+  MCPToolRetryPolicyType,
+} from "@app/lib/actions/mcp";
 import {
   DEFAULT_MCP_TOOL_RETRY_POLICY,
   getRetryPolicyFromToolConfiguration,
-  type MCPApproveExecutionEvent,
-  type MCPToolConfigurationType,
-  type MCPToolRetryPolicyType,
 } from "@app/lib/actions/mcp";
 import { getAugmentedInputs } from "@app/lib/actions/mcp_execution";
 import { validateToolInputs } from "@app/lib/actions/mcp_utils";

--- a/front/temporal/agent_loop/lib/create_tool_actions.ts
+++ b/front/temporal/agent_loop/lib/create_tool_actions.ts
@@ -1,11 +1,15 @@
-import type {
-  MCPApproveExecutionEvent,
-  MCPToolConfigurationType,
+import {
+  DEFAULT_MCP_TOOL_RETRY_POLICY,
+  getRetryPolicyFromToolConfiguration,
+  type MCPApproveExecutionEvent,
+  type MCPToolConfigurationType,
+  type MCPToolRetryPolicyType,
 } from "@app/lib/actions/mcp";
 import { getAugmentedInputs } from "@app/lib/actions/mcp_execution";
 import { validateToolInputs } from "@app/lib/actions/mcp_utils";
 import type { ToolExecutionStatus } from "@app/lib/actions/statuses";
 import type { StepContext } from "@app/lib/actions/types";
+import { isServerSideMCPToolConfiguration } from "@app/lib/actions/types/guards";
 import { getExecutionStatusFromConfig } from "@app/lib/actions/utils";
 import { createMCPAction } from "@app/lib/api/mcp/create_mcp";
 import type { Authenticator } from "@app/lib/auth";
@@ -25,6 +29,7 @@ export interface ActionBlob {
   actionId: ModelId;
   actionStatus: ToolExecutionStatus;
   needsApproval: boolean;
+  retryPolicy: MCPToolRetryPolicyType;
 }
 
 type CreateToolActionsResult = {
@@ -206,6 +211,7 @@ async function createActionForTool(
       actionId: action.id,
       actionStatus: status,
       needsApproval: status === "blocked_validation_required",
+      retryPolicy: getRetryPolicyFromToolConfiguration(actionConfiguration),
     },
     approvalEventData:
       status === "blocked_validation_required"

--- a/front/temporal/agent_loop/lib/create_tool_actions.ts
+++ b/front/temporal/agent_loop/lib/create_tool_actions.ts
@@ -1,12 +1,11 @@
 import type {
   MCPApproveExecutionEvent,
   MCPToolConfigurationType,
-  MCPToolRetryPolicyType,
 } from "@app/lib/actions/mcp";
 import {
-  DEFAULT_MCP_TOOL_RETRY_POLICY,
   getRetryPolicyFromToolConfiguration,
-} from "@app/lib/actions/mcp";
+  MCPToolRetryPolicyType,
+} from "@app/lib/api/mcp";
 import { getAugmentedInputs } from "@app/lib/actions/mcp_execution";
 import { validateToolInputs } from "@app/lib/actions/mcp_utils";
 import type { ToolExecutionStatus } from "@app/lib/actions/statuses";

--- a/front/temporal/agent_loop/lib/create_tool_actions.ts
+++ b/front/temporal/agent_loop/lib/create_tool_actions.ts
@@ -2,16 +2,13 @@ import type {
   MCPApproveExecutionEvent,
   MCPToolConfigurationType,
 } from "@app/lib/actions/mcp";
-import {
-  getRetryPolicyFromToolConfiguration,
-  MCPToolRetryPolicyType,
-} from "@app/lib/api/mcp";
 import { getAugmentedInputs } from "@app/lib/actions/mcp_execution";
 import { validateToolInputs } from "@app/lib/actions/mcp_utils";
 import type { ToolExecutionStatus } from "@app/lib/actions/statuses";
 import type { StepContext } from "@app/lib/actions/types";
-import { isServerSideMCPToolConfiguration } from "@app/lib/actions/types/guards";
 import { getExecutionStatusFromConfig } from "@app/lib/actions/utils";
+import type { MCPToolRetryPolicyType } from "@app/lib/api/mcp";
+import { getRetryPolicyFromToolConfiguration } from "@app/lib/api/mcp";
 import { createMCPAction } from "@app/lib/api/mcp/create_mcp";
 import type { Authenticator } from "@app/lib/auth";
 import type { AgentMessage } from "@app/lib/models/assistant/conversation";

--- a/front/temporal/agent_loop/lib/run_model.ts
+++ b/front/temporal/agent_loop/lib/run_model.ts
@@ -1,10 +1,7 @@
 import { removeNulls } from "@dust-tt/client";
 import assert from "assert";
 
-import {
-  buildToolSpecification,
-  DEFAULT_MCP_TOOL_RETRY_POLICY,
-} from "@app/lib/actions/mcp";
+import { buildToolSpecification } from "@app/lib/actions/mcp";
 import {
   TOOL_NAME_SEPARATOR,
   tryListMCPTools,
@@ -51,6 +48,7 @@ import type {
   TextContentType,
 } from "@app/types/assistant/agent_message_content";
 import type { RunAgentExecutionData } from "@app/types/assistant/agent_run";
+import { DEFAULT_MCP_TOOL_RETRY_POLICY } from "@app/lib/api/mcp";
 
 const CANCELLATION_CHECK_INTERVAL = 500;
 const MAX_AUTO_RETRY = 3;

--- a/front/temporal/agent_loop/lib/run_model.ts
+++ b/front/temporal/agent_loop/lib/run_model.ts
@@ -1,7 +1,10 @@
 import { removeNulls } from "@dust-tt/client";
 import assert from "assert";
 
-import { buildToolSpecification } from "@app/lib/actions/mcp";
+import {
+  buildToolSpecification,
+  DEFAULT_MCP_TOOL_RETRY_POLICY,
+} from "@app/lib/actions/mcp";
 import {
   TOOL_NAME_SEPARATOR,
   tryListMCPTools,
@@ -831,6 +834,7 @@ export async function runModelActivity(
         permission: "never_ask",
         toolServerId: mcpServerView.internalMCPServerId,
         mcpServerName: "missing_action_catcher" as InternalMCPServerNameType,
+        retryPolicy: DEFAULT_MCP_TOOL_RETRY_POLICY,
       };
     }
 

--- a/front/temporal/agent_loop/lib/run_model.ts
+++ b/front/temporal/agent_loop/lib/run_model.ts
@@ -30,6 +30,7 @@ import { listAttachments } from "@app/lib/api/assistant/jit_utils";
 import { isLegacyAgentConfiguration } from "@app/lib/api/assistant/legacy_agent";
 import { renderConversationForModel } from "@app/lib/api/assistant/preprocessing";
 import config from "@app/lib/api/config";
+import { DEFAULT_MCP_TOOL_RETRY_POLICY } from "@app/lib/api/mcp";
 import { getRedisClient } from "@app/lib/api/redis";
 import { getSupportedModelConfig } from "@app/lib/assistant";
 import type { Authenticator } from "@app/lib/auth";
@@ -48,7 +49,6 @@ import type {
   TextContentType,
 } from "@app/types/assistant/agent_message_content";
 import type { RunAgentExecutionData } from "@app/types/assistant/agent_run";
-import { DEFAULT_MCP_TOOL_RETRY_POLICY } from "@app/lib/api/mcp";
 
 const CANCELLATION_CHECK_INTERVAL = 500;
 const MAX_AUTO_RETRY = 3;

--- a/front/temporal/agent_loop/workflows.ts
+++ b/front/temporal/agent_loop/workflows.ts
@@ -6,6 +6,7 @@ import {
   workflowInfo,
 } from "@temporalio/workflow";
 
+import { MAX_MCP_REQUEST_TIMEOUT_MS } from "@app/lib/actions/constants";
 import type { AuthenticatorType } from "@app/lib/auth";
 import type * as ensureTitleActivities from "@app/temporal/agent_loop/activities/ensure_conversation_title";
 import type * as logAgentLoopMetricsActivities from "@app/temporal/agent_loop/activities/instrumentation";
@@ -19,7 +20,6 @@ import type {
   RunAgentArgs,
   RunAgentAsynchronousArgs,
 } from "@app/types/assistant/agent_run";
-import { MAX_MCP_REQUEST_TIMEOUT_MS } from "@app/lib/actions/constants";
 
 const logMetricsActivities = proxyActivities<
   typeof logAgentLoopMetricsActivities
@@ -31,7 +31,7 @@ const activities: AgentLoopActivities = {
   runModelAndCreateActionsActivity: proxyActivities<
     typeof runModelAndCreateWrapperActivities
   >({
-    startToCloseTimeout: "7 minutes",
+    startToCloseTimeout: "1 minute",
   }).runModelAndCreateActionsActivity,
   runToolActivity: proxyActivities<typeof runToolActivities>({
     // The activity timeout should be slightly longer than the max timeout of

--- a/front/temporal/agent_loop/workflows.ts
+++ b/front/temporal/agent_loop/workflows.ts
@@ -31,7 +31,7 @@ const activities: AgentLoopActivities = {
   runModelAndCreateActionsActivity: proxyActivities<
     typeof runModelAndCreateWrapperActivities
   >({
-    startToCloseTimeout: "1 minute",
+    startToCloseTimeout: "7 minutes",
   }).runModelAndCreateActionsActivity,
   runToolActivity: proxyActivities<typeof runToolActivities>({
     // The activity timeout should be slightly longer than the max timeout of

--- a/front/temporal/agent_loop/workflows.ts
+++ b/front/temporal/agent_loop/workflows.ts
@@ -49,7 +49,7 @@ const activities: AgentLoopActivities = {
       MAX_MCP_REQUEST_TIMEOUT_MS / 1000 / 60 + 1
     } minutes`,
     retry: {
-      maximumAttempts: 10,
+      maximumAttempts: 5,
     },
   }).runToolActivity,
   publishDeferredEventsActivity: proxyActivities<

--- a/front/temporal/agent_loop/workflows.ts
+++ b/front/temporal/agent_loop/workflows.ts
@@ -44,6 +44,14 @@ const activities: AgentLoopActivities = {
       maximumAttempts: 1,
     },
   }).runToolActivity,
+  runRetryableToolActivity: proxyActivities<typeof runToolActivities>({
+    startToCloseTimeout: `${
+      MAX_MCP_REQUEST_TIMEOUT_MS / 1000 / 60 + 1
+    } minutes`,
+    retry: {
+      maximumAttempts: 10,
+    },
+  }).runToolActivity,
   publishDeferredEventsActivity: proxyActivities<
     typeof publishDeferredEventsActivities
   >({


### PR DESCRIPTION
Description
---
Fixes https://github.com/dust-tt/tasks/issues/4067

This PR introduces a retry policy for tools. Existing policies for now:
- no_retry (default);
- retry_on_interrupt (timeout or worker killed), will retry 5 times. 

This is also part 1 of allowing run_agent to run more than the 10mn timeout.

Future policies (e.g. retry_on_whatever) can be added straightforwardly extending this PR, as needed.

Retry policy is implemented at internal tool level, as in the short term future presuming a retry policy for external MCP tools (external server, or client side) is not useful. The server defines a tools_retry_policies (similarly to exiting tools_stakes) with the policy for each tool, and optionally a default policy---useful for variable-name tools like run_agent.

## Risk
blast radius: tool execution loop
risk: low -- only allow triggering retries

## Deploy Plan
front
