### PR TITLE
Opt: reduce network calls

### DIFF
--- a/front/components/assistant/ToolsPicker.tsx
+++ b/front/components/assistant/ToolsPicker.tsx
@@ -48,7 +48,7 @@ export function ToolsPicker({
   const [searchText, setSearchText] = useState("");
   const [isOpen, setIsOpen] = useState(false);
 
-  const { spaces } = useSpaces({ workspaceId: owner.sId });
+  const { spaces } = useSpaces({ workspaceId: owner.sId, disabled: !isOpen });
   const globalSpaces = useMemo(
     () => spaces.filter((s) => s.kind === "global"),
     [spaces]

--- a/front/components/assistant/conversation/input_bar/InputBar.tsx
+++ b/front/components/assistant/conversation/input_bar/InputBar.tsx
@@ -12,14 +12,12 @@ import { InputBarContext } from "@app/components/assistant/conversation/input_ba
 import { useFileUploaderService } from "@app/hooks/useFileUploaderService";
 import type { MCPServerViewType } from "@app/lib/api/mcp";
 import type { DustError } from "@app/lib/error";
-import { getSpaceIcon } from "@app/lib/spaces";
 import { useUnifiedAgentConfigurations } from "@app/lib/swr/assistants";
 import {
   useAddDeleteConversationTool,
   useConversation,
   useConversationTools,
 } from "@app/lib/swr/conversations";
-import { useSpaces } from "@app/lib/swr/spaces";
 import { classNames } from "@app/lib/utils";
 import type {
   AgentMention,
@@ -30,11 +28,7 @@ import type {
   Result,
   WorkspaceType,
 } from "@app/types";
-import {
-  compareAgentsForSort,
-  GLOBAL_SPACE_NAME,
-  isEqualNode,
-} from "@app/types";
+import { compareAgentsForSort, isEqualNode } from "@app/types";
 
 const DEFAULT_INPUT_BAR_ACTIONS = [...INPUT_BAR_ACTIONS];
 
@@ -80,21 +74,6 @@ export function AssistantInputBar({
   const [attachedNodes, setAttachedNodes] = useState<
     DataSourceViewContentNode[]
   >([]);
-
-  const { spaces } = useSpaces({ workspaceId: owner.sId });
-  const spacesMap = useMemo(
-    () =>
-      Object.fromEntries(
-        spaces?.map((space) => [
-          space.sId,
-          {
-            name: space.kind === "global" ? GLOBAL_SPACE_NAME : space.name,
-            icon: getSpaceIcon(space),
-          },
-        ]) || []
-      ),
-    [spaces]
-  );
 
   useEffect(() => {
     const container = rainbowEffectRef.current;
@@ -397,10 +376,10 @@ export function AssistantInputBar({
           >
             <div className="relative flex w-full flex-1 flex-col">
               <InputBarAttachments
+                owner={owner}
                 files={{ service: fileUploaderService }}
                 nodes={{
                   items: attachedNodes,
-                  spacesMap,
                   onRemove: handleNodesAttachmentRemove,
                 }}
               />

--- a/front/components/assistant/conversation/input_bar/InputBarAttachmentsPicker.tsx
+++ b/front/components/assistant/conversation/input_bar/InputBarAttachmentsPicker.tsx
@@ -69,7 +69,10 @@ export const InputBarAttachmentsPicker = ({
     minLength: MIN_SEARCH_QUERY_SIZE,
   });
 
-  const { spaces, isSpacesLoading } = useSpaces({ workspaceId: owner.sId });
+  const { spaces, isSpacesLoading } = useSpaces({
+    workspaceId: owner.sId,
+    disabled: !isOpen,
+  });
 
   const {
     searchResultNodes,

--- a/front/components/assistant/conversation/input_bar/InputBarContainer.tsx
+++ b/front/components/assistant/conversation/input_bar/InputBarContainer.tsx
@@ -135,7 +135,11 @@ const InputBarContainer = ({
 
   useUrlHandler(editor, selectedNode, nodeOrUrlCandidate, handleUrlReplaced);
 
-  const { spaces, isSpacesLoading } = useSpaces({ workspaceId: owner.sId });
+  const { spaces, isSpacesLoading } = useSpaces({
+    workspaceId: owner.sId,
+    disabled: !nodeOrUrlCandidate,
+  });
+
   const spacesMap = useMemo(
     () => Object.fromEntries(spaces?.map((space) => [space.sId, space]) || []),
     [spaces]

--- a/front/lib/swr/conversations.ts
+++ b/front/lib/swr/conversations.ts
@@ -99,7 +99,10 @@ export function useConversationFeedbacks({
 
   const { data, error, mutate } = useSWRWithDefaults(
     `/api/w/${workspaceId}/assistant/conversations/${conversationId}/feedbacks`,
-    conversationFeedbacksFetcher
+    conversationFeedbacksFetcher,
+    {
+      focusThrottleInterval: 30 * 60 * 1000, // 30 minutes
+    }
   );
 
   return {
@@ -211,7 +214,7 @@ export function useConversationTools({
       ? `/api/w/${workspaceId}/assistant/conversations/${conversationId}/tools`
       : null,
     conversationToolsFetcher,
-    options
+    { ...options, focusThrottleInterval: 30 * 60 * 1000 } // 30 minutes
   );
 
   return {

--- a/front/lib/swr/useAppStatus.ts
+++ b/front/lib/swr/useAppStatus.ts
@@ -8,7 +8,10 @@ export function useAppStatus() {
 
   const { data, error } = useSWRWithDefaults(
     "/api/app-status",
-    appStatusFetcher
+    appStatusFetcher,
+    {
+      focusThrottleInterval: 10 * 60 * 1000, // 10 minutes
+    }
   );
 
   return {

--- a/front/lib/swr/workspaces.ts
+++ b/front/lib/swr/workspaces.ts
@@ -126,6 +126,7 @@ export function useFeatureFlags({
     featureFlagsFetcher,
     {
       disabled,
+      focusThrottleInterval: 30 * 60 * 1000, // 30 minutes
     }
   );
 


### PR DESCRIPTION
## Description

Significantely reduce network calls of the conversation(s) experience by:
- not fetching spaces until we need them.
- throttling "revalidate on focus" for tools (it was mutated client side anyway), feedbacks, app-status and feature flags (very stables).

**Note that throttling on focus only means that we won't do a network request everytime the browser get focused again, if you reload, it will show up.**

## Tests

Locally

## Risk

Low

## Deploy Plan

Deploy front