### PR TITLE
fix: enable ui interaction after opening a modal from a dropdown menu…

### DIFF
--- a/front/components/assistant/conversation/ConversationMenu.tsx
+++ b/front/components/assistant/conversation/ConversationMenu.tsx
@@ -126,7 +126,7 @@ export function ConversationMenu({
         conversationId={activeConversationId}
         currentTitle={conversation?.title || ""}
       />
-      <DropdownMenu>
+      <DropdownMenu modal={false}>
         <DropdownMenuTrigger asChild>
           <Button
             size="sm"

--- a/front/components/assistant/conversation/SidebarMenu.tsx
+++ b/front/components/assistant/conversation/SidebarMenu.tsx
@@ -294,7 +294,7 @@ export function AssistantSidebarMenu({ owner }: AssistantSidebarMenuProps) {
                   tooltip="Create a new conversation"
                   onClick={handleNewClick}
                 />
-                <DropdownMenu>
+                <DropdownMenu modal={false}>
                   <DropdownMenuTrigger asChild>
                     <Button size="sm" icon={MoreIcon} variant="outline" />
                   </DropdownMenuTrigger>


### PR DESCRIPTION
## Description

This PR is workaround for unexpected behavior caused by this Shadcn issue :
https://github.com/shadcn-ui/ui/issues/1912

When opening a modal from a dropdownmenu item, after modal closes the focus is lost and user must refresh the page to interact afgain with it.

https://github.com/user-attachments/assets/e4514f97-b19c-4488-83ed-ef042dd688ae

