### PR TITLE
[front] - fix(AB): enforce no spaces in agent name

### DIFF
--- a/front/components/agent_builder/AgentBuilderFormContext.tsx
+++ b/front/components/agent_builder/AgentBuilderFormContext.tsx
@@ -167,7 +167,10 @@ const userSchema = z.object({
 });
 
 const agentSettingsSchema = z.object({
-  name: z.string().min(1, "Agent name is required"),
+  name: z
+    .string()
+    .min(1, "Agent name is required")
+    .refine((value) => !/\s/.test(value), "Agent name cannot contain space"),
   description: z.string().min(1, "Agent description is required"),
   pictureUrl: z.string().optional(),
   scope: z.enum(["hidden", "visible"]),


### PR DESCRIPTION
## Description

This PR adds a validation rule to ensure the agent name does not contain spaces

## Tests

Locally

## Risk

Low

## Deploy Plan

Deploy front