### PR TITLE
Add more logs in case of tokenization error + sanitize string

### DIFF
--- a/connectors/src/lib/data_sources.ts
+++ b/connectors/src/lib/data_sources.ts
@@ -521,11 +521,14 @@ export async function renderPrefixSection({
 }
 
 async function tokenize(text: string, ds: DataSourceConfig) {
-  if (!text || text.length === 0) {
+  if (!text) {
     return [];
   }
 
   const sanitizedText = stripNullBytes(text);
+  if (!sanitizedText || sanitizedText.length === 0) {
+    return [];
+  }
 
   const tokensRes = await getDustAPI(ds).tokenize(
     sanitizedText,
@@ -535,9 +538,9 @@ async function tokenize(text: string, ds: DataSourceConfig) {
     logger.error(
       {
         error: tokensRes.error,
-        textLength: text.length,
+        textLength: sanitizedText.length,
         sanitizedTextLength: sanitizedText.length,
-        textPreview: text.substring(0, 100),
+        textPreview: sanitizedText.substring(0, 200),
         dataSourceId: ds.dataSourceId,
         workspaceId: ds.workspaceId,
       },


### PR DESCRIPTION
## Description

We have some recurring errors from the Intercom webhook when trying to sync a conversation: https://app.datadoghq.eu/logs?query=%22Unhandled%20API%20Error%22%20status%3Aerror%20%40dd.env%3Aprod%20%40url%3A%22%2Fwebhooks%2Fwebhooks_2504ff62a80cb88721fd6e391ae222ee%2Fintercom%22&agg_m=count&agg_m_source=base&agg_t=count&clustering_pattern_field_path=message&cols=host%2Cservice&messageDisplay=inline&refresh_mode=sliding&storage=hot&stream_sort=desc&viz=stream&from_ts=1756760657321&to_ts=1757365457321&live=true

On this PR I'm calling `stripNullBytes` just in case, and adding more log info to debug 🙏🏻 

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

Deploy connectors. 