### PR TITLE
[front] - chore(ToolCard): add tools info

### DIFF
--- a/extension/package-lock.json
+++ b/extension/package-lock.json
@@ -12,7 +12,7 @@
         "@auth0/auth0-spa-js": "^2.1.3",
         "@datadog/browser-logs": "^6.13.0",
         "@dust-tt/client": "^1.1.12",
-        "@dust-tt/sparkle": "^0.2.611",
+        "@dust-tt/sparkle": "^0.2.612",
         "@frontapp/plugin-sdk": "^1.8.1",
         "@modelcontextprotocol/sdk": "^1.9.0",
         "@tailwindcss/forms": "^0.5.9",
@@ -1294,9 +1294,9 @@
       }
     },
     "node_modules/@dust-tt/sparkle": {
-      "version": "0.2.611",
-      "resolved": "https://registry.npmjs.org/@dust-tt/sparkle/-/sparkle-0.2.611.tgz",
-      "integrity": "sha512-0KD9QCgt7GNFI2vD9D6QJaFimOW1ruaXsY1Oc3k6vIbzXo1EjpT4LZkg8SOQK7an3O2jIJsSRFhkqzUqzoJ6iw==",
+      "version": "0.2.612",
+      "resolved": "https://registry.npmjs.org/@dust-tt/sparkle/-/sparkle-0.2.612.tgz",
+      "integrity": "sha512-8A5g2kU1g7MnAAVqA7281PZrS3ksgtR/TEVZwSnO1eIJajxvLSDKFDNhDSV7EHoPCuwZFk+r5miCAHpAyPomTw==",
       "dependencies": {
         "@emoji-mart/data": "^1.1.2",
         "@emoji-mart/react": "^1.1.1",

--- a/extension/package.json
+++ b/extension/package.json
@@ -59,7 +59,7 @@
     "@auth0/auth0-spa-js": "^2.1.3",
     "@datadog/browser-logs": "^6.13.0",
     "@dust-tt/client": "^1.1.12",
-    "@dust-tt/sparkle": "^0.2.611",
+    "@dust-tt/sparkle": "^0.2.612",
     "@frontapp/plugin-sdk": "^1.8.1",
     "@modelcontextprotocol/sdk": "^1.9.0",
     "@tailwindcss/forms": "^0.5.9",

--- a/front/components/agent_builder/capabilities/AgentBuilderCapabilitiesBlock.tsx
+++ b/front/components/agent_builder/capabilities/AgentBuilderCapabilitiesBlock.tsx
@@ -206,7 +206,7 @@ export function AgentBuilderCapabilitiesBlock({
     } else {
       setDialogMode(
         action.noConfigurationRequired
-          ? { type: "info", action }
+          ? { type: "info", action, source: "addedTool" }
           : { type: "edit", action, index }
       );
     }

--- a/front/components/agent_builder/capabilities/mcp/MCPServerSelectionPage.tsx
+++ b/front/components/agent_builder/capabilities/mcp/MCPServerSelectionPage.tsx
@@ -36,7 +36,7 @@ function DataVisualizationCard({
       isSelected={isSelected}
       canAdd={!isSelected}
       onClick={onClick}
-      cardContainerClassName="h-32"
+      cardContainerClassName="h-36"
     />
   );
 }
@@ -94,7 +94,7 @@ function MCPServerCard({
         isSelected={isSelected}
         canAdd={canAdd}
         onClick={onClick}
-        cardContainerClassName="h-32"
+        cardContainerClassName="h-36"
         mountPortal
         mountPortalContainer={containerRef.current || undefined}
         toolInfo={{

--- a/front/components/agent_builder/capabilities/mcp/MCPServerSelectionPage.tsx
+++ b/front/components/agent_builder/capabilities/mcp/MCPServerSelectionPage.tsx
@@ -98,7 +98,7 @@ function MCPServerCard({
         mountPortal
         mountPortalContainer={containerRef.current || undefined}
         toolInfo={{
-          label: "Tools details",
+          label: "Tool details",
           onClick: onToolInfoClick,
         }}
       />

--- a/front/components/agent_builder/capabilities/mcp/MCPServerSelectionPage.tsx
+++ b/front/components/agent_builder/capabilities/mcp/MCPServerSelectionPage.tsx
@@ -36,6 +36,7 @@ function DataVisualizationCard({
       isSelected={isSelected}
       canAdd={!isSelected}
       onClick={onClick}
+      cardContainerClassName="h-32"
     />
   );
 }
@@ -44,9 +45,15 @@ interface MCPServerCardProps {
   view: MCPServerViewTypeWithLabel;
   isSelected: boolean;
   onClick: () => void;
+  onToolInfoClick: () => void;
 }
 
-function MCPServerCard({ view, isSelected, onClick }: MCPServerCardProps) {
+function MCPServerCard({
+  view,
+  isSelected,
+  onClick,
+  onToolInfoClick,
+}: MCPServerCardProps) {
   const requirement = getMCPServerRequirements(view);
   const canAdd = requirement.noRequirement ? !isSelected : true;
 
@@ -87,8 +94,13 @@ function MCPServerCard({ view, isSelected, onClick }: MCPServerCardProps) {
         isSelected={isSelected}
         canAdd={canAdd}
         onClick={onClick}
+        cardContainerClassName="h-32"
         mountPortal
         mountPortalContainer={containerRef.current || undefined}
+        toolInfo={{
+          label: "Tools details",
+          onClick: onToolInfoClick,
+        }}
       />
     </div>
   );
@@ -101,6 +113,7 @@ interface MCPServerSelectionPageProps {
   dataVisualization?: ActionSpecification | null;
   onDataVisualizationClick?: () => void;
   selectedToolsInSheet?: SelectedTool[];
+  onToolDetailsClick?: (tool: SelectedTool) => void;
 }
 
 export function MCPServerSelectionPage({
@@ -110,6 +123,7 @@ export function MCPServerSelectionPage({
   dataVisualization,
   onDataVisualizationClick,
   selectedToolsInSheet = [],
+  onToolDetailsClick,
 }: MCPServerSelectionPageProps) {
   // Optimize selection lookup with Set-based approach
   const selectedMCPIds = useMemo(() => {
@@ -169,6 +183,11 @@ export function MCPServerSelectionPage({
               view={view}
               isSelected={selectedMCPIds.has(view.sId)}
               onClick={() => onItemClick(view)}
+              onToolInfoClick={() => {
+                if (onToolDetailsClick) {
+                  onToolDetailsClick({ type: "MCP", view });
+                }
+              }}
             />
           ))}
         </div>
@@ -182,6 +201,11 @@ export function MCPServerSelectionPage({
               view={view}
               isSelected={selectedMCPIds.has(view.sId)}
               onClick={() => onItemClick(view)}
+              onToolInfoClick={() => {
+                if (onToolDetailsClick) {
+                  onToolDetailsClick({ type: "MCP", view });
+                }
+              }}
             />
           ))}
         </div>

--- a/front/components/agent_builder/capabilities/mcp/MCPServerViewsSheet.tsx
+++ b/front/components/agent_builder/capabilities/mcp/MCPServerViewsSheet.tsx
@@ -95,7 +95,11 @@ export type SheetMode =
       mcpServerView: MCPServerViewType;
     }
   | { type: "edit"; action: AgentBuilderAction; index: number }
-  | { type: "info"; action: AgentBuilderAction };
+  | {
+      type: "info";
+      action: AgentBuilderAction;
+      source: "toolDetails" | "addedTool";
+    };
 
 type MCPActionWithConfiguration = AgentBuilderAction & {
   type: "MCP";
@@ -401,6 +405,18 @@ export function MCPServerViewsSheet({
     toggleToolSelection(tool);
   }
 
+  const handleToolInfoClick = useCallback(
+    (mcpServerView: MCPServerViewType) => {
+      const action = getDefaultMCPAction(mcpServerView);
+      onModeChange({
+        type: "info",
+        action,
+        source: "toolDetails",
+      });
+    },
+    [onModeChange]
+  );
+
   const handleAddSelectedTools = useCallback(() => {
     // Validate any configured tools before adding
     for (const tool of selectedToolsInSheet) {
@@ -527,6 +543,11 @@ export function MCPServerViewsSheet({
             dataVisualization={showDataVisualization ? dataVisualization : null}
             onDataVisualizationClick={onClickDataVisualization}
             selectedToolsInSheet={selectedToolsInSheet}
+            onToolDetailsClick={(tool) => {
+              if (tool.type === "MCP") {
+                handleToolInfoClick(tool.view);
+              }
+            }}
           />
         </>
       ),
@@ -696,7 +717,7 @@ export function MCPServerViewsSheet({
 
   const footerButtons = getFooterButtons({
     currentPageId,
-    modeType: currentMode,
+    mode,
     selectedToolsInSheet,
     form,
     onCancel: handleCancel,

--- a/front/components/agent_builder/capabilities/mcp/utils/sheetUtils.ts
+++ b/front/components/agent_builder/capabilities/mcp/utils/sheetUtils.ts
@@ -51,7 +51,7 @@ export function getInitialConfigurationTool(
 
 export interface FooterButtonOptions {
   currentPageId: ConfigurationPagePageId;
-  modeType: SheetMode["type"];
+  mode: SheetMode | null;
   selectedToolsInSheet: SelectedTool[];
   form: UseFormReturn<MCPFormData>;
   onCancel: () => void;
@@ -63,7 +63,7 @@ export interface FooterButtonOptions {
 
 export function getFooterButtons({
   currentPageId,
-  modeType,
+  mode,
   selectedToolsInSheet,
   form,
   onCancel,
@@ -98,7 +98,7 @@ export function getFooterButtons({
   }
 
   if (isConfigurationPage) {
-    if (modeType === "edit") {
+    if (mode?.type === "edit") {
       return {
         leftButton: {
           label: "Cancel",
@@ -113,7 +113,7 @@ export function getFooterButtons({
       };
     }
 
-    if (modeType === "configure") {
+    if (mode?.type === "configure") {
       return {
         leftButton: {
           label: "Back",
@@ -143,13 +143,23 @@ export function getFooterButtons({
   }
 
   if (isInfoPage) {
-    return {
-      leftButton: {
-        label: "Close",
-        variant: "primary",
-        onClick: onCancel,
-      },
-    };
+    if (mode?.type === "info" && mode.source === "toolDetails") {
+      return {
+        leftButton: {
+          label: "Back",
+          variant: "outline",
+          onClick: () => onModeChange({ type: "add" }),
+        },
+      };
+    } else {
+      return {
+        leftButton: {
+          label: "Close",
+          variant: "primary",
+          onClick: onCancel,
+        },
+      };
+    }
   }
 
   return {};

--- a/front/package-lock.json
+++ b/front/package-lock.json
@@ -7,7 +7,7 @@
       "dependencies": {
         "@datadog/browser-logs": "^6.13.0",
         "@dust-tt/client": "file:../sdks/js",
-        "@dust-tt/sparkle": "^0.2.611",
+        "@dust-tt/sparkle": "^0.2.612",
         "@google-cloud/bigquery": "^7.9.1",
         "@google-cloud/storage-transfer": "^3.6.0",
         "@heroicons/react": "^2.0.11",
@@ -1123,9 +1123,9 @@
       "link": true
     },
     "node_modules/@dust-tt/sparkle": {
-      "version": "0.2.611",
-      "resolved": "https://registry.npmjs.org/@dust-tt/sparkle/-/sparkle-0.2.611.tgz",
-      "integrity": "sha512-0KD9QCgt7GNFI2vD9D6QJaFimOW1ruaXsY1Oc3k6vIbzXo1EjpT4LZkg8SOQK7an3O2jIJsSRFhkqzUqzoJ6iw==",
+      "version": "0.2.612",
+      "resolved": "https://registry.npmjs.org/@dust-tt/sparkle/-/sparkle-0.2.612.tgz",
+      "integrity": "sha512-8A5g2kU1g7MnAAVqA7281PZrS3ksgtR/TEVZwSnO1eIJajxvLSDKFDNhDSV7EHoPCuwZFk+r5miCAHpAyPomTw==",
       "dependencies": {
         "@emoji-mart/data": "^1.1.2",
         "@emoji-mart/react": "^1.1.1",

--- a/front/package.json
+++ b/front/package.json
@@ -27,7 +27,7 @@
   "dependencies": {
     "@datadog/browser-logs": "^6.13.0",
     "@dust-tt/client": "file:../sdks/js",
-    "@dust-tt/sparkle": "^0.2.611",
+    "@dust-tt/sparkle": "^0.2.612",
     "@google-cloud/bigquery": "^7.9.1",
     "@google-cloud/storage-transfer": "^3.6.0",
     "@heroicons/react": "^2.0.11",


### PR DESCRIPTION
## Description

This PR enhances the MCP server selection experience by adding tool information functionality to `ToolCard` components. It introduces a new `toolInfo` prop to the `ToolCard` component (via sparkle upgrade to 0.2.612), enabling users to view detailed information about available tools before adding them. The implementation adds an "onToolInfoClick" handler to MCPServerCards that opens tool details in an info modal, and extends the dialog mode system to differentiate between tool details views and added tool confirmations through a new `source` parameter.

<img width="754" height="503" alt="Screenshot 2025-09-09 at 10 48 24" src="https://github.com/user-attachments/assets/70c43b8d-883f-4b64-86e3-f4980b3f11d0" />

## Risk

Low risk change focused on UI enhancements. The sparkle library upgrade includes backward-compatible changes to the ToolCard component.

## Deploy Plan

* Deploy front
