### PR TITLE
[front] schedules: move authenticator to userId/workspaceId

### DIFF
--- a/front/lib/actions/mcp_internal_actions/input_configuration.ts
+++ b/front/lib/actions/mcp_internal_actions/input_configuration.ts
@@ -476,14 +476,18 @@ export function getMCPServerRequirements(
     mcpServerView.toolsMetadata
       ?.filter((tool) => tool.enabled)
       .map((tool) => tool.toolName) ?? [];
-  
-  const enabledTools = server.tools.filter((tool) => enabledToolNames.includes(tool.name));
 
-  const mayRequireTimeFrameConfiguration = enabledTools
-    .some((tool) => tool.inputSchema?.properties?.timeFrame);
+  const enabledTools = server.tools.filter((tool) =>
+    enabledToolNames.includes(tool.name)
+  );
 
-  const mayRequireJsonSchemaConfiguration = enabledTools
-    .some((tool) => tool.inputSchema?.properties?.jsonSchema);
+  const mayRequireTimeFrameConfiguration = enabledTools.some(
+    (tool) => tool.inputSchema?.properties?.timeFrame
+  );
+
+  const mayRequireJsonSchemaConfiguration = enabledTools.some(
+    (tool) => tool.inputSchema?.properties?.jsonSchema
+  );
 
   const requiredStrings = Object.entries(
     findPathsToConfiguration({

--- a/front/scripts/soft_refresh_all_triggers.ts
+++ b/front/scripts/soft_refresh_all_triggers.ts
@@ -1,35 +1,22 @@
 import { Authenticator } from "@app/lib/auth";
 import { TriggerResource } from "@app/lib/resources/trigger_resource";
 import { UserResource } from "@app/lib/resources/user_resource";
-import { WorkspaceResource } from "@app/lib/resources/workspace_resource";
 import { makeScript } from "@app/scripts/helpers";
+import { runOnAllWorkspaces } from "@app/scripts/workspace_helpers";
 
 /**
- * This script pauses/unpauses all triggers of a workspace.
+ * This script pauses/unpauses all triggers across all workspaces.
  * This allows to soft refresh all triggers by doing the pre-delete / post-create logic.
  */
 
-makeScript(
-  {
-    wId: {
-      type: "string",
-      demandOption: true,
-      description: "Workspace ID",
-    },
-  },
-  async ({ wId, execute }, logger) => {
-    // Find the workspace
-    const workspace = await WorkspaceResource.fetchById(wId);
-
-    if (!workspace) {
-      logger.error({ wId }, "Workspace not found");
-      return;
-    }
-
-    const auth = await Authenticator.internalAdminForWorkspace(workspace?.sId);
+makeScript({}, async ({ execute }, logger) => {
+  return runOnAllWorkspaces(async (workspace) => {
+    const auth = await Authenticator.internalAdminForWorkspace(workspace.sId);
 
     const triggers = await TriggerResource.listByWorkspace(auth);
-    for (const trigger of triggers) {
+    const activeTriggers = triggers.filter((t) => t.enabled);
+
+    for (const trigger of activeTriggers) {
       const user = await UserResource.fetchByModelId(trigger.editor);
       if (!user) {
         logger.error(
@@ -62,5 +49,5 @@ makeScript(
         );
       }
     }
-  }
-);
+  });
+});

--- a/front/temporal/agent_schedule/activities.ts
+++ b/front/temporal/agent_schedule/activities.ts
@@ -7,7 +7,6 @@ import {
   createConversation,
   postUserMessage,
 } from "@app/lib/api/assistant/conversation";
-import type { AuthenticatorType } from "@app/lib/auth";
 import { Authenticator } from "@app/lib/auth";
 import { ConversationResource } from "@app/lib/resources/conversation_resource";
 import { MCPServerViewResource } from "@app/lib/resources/mcp_server_view_resource";
@@ -115,10 +114,14 @@ const createConversationForAgentConfiguration = async (
 };
 
 export async function runScheduledAgentsActivity(
-  authType: AuthenticatorType,
+  userId: string,
+  workspaceId: string,
   trigger: TriggerType
 ) {
-  const auth = await Authenticator.fromJSON(authType);
+  const auth = await Authenticator.fromUserIdAndWorkspaceId(
+    userId,
+    workspaceId
+  );
 
   if (!auth.workspace() || !auth.user()) {
     throw new Error("Invalid authentication. Missing workspaceId or userId.");

--- a/front/temporal/agent_schedule/client.ts
+++ b/front/temporal/agent_schedule/client.ts
@@ -22,7 +22,11 @@ function getScheduleOptions(
     action: {
       type: "startWorkflow",
       workflowType: agentScheduleWorkflow,
-      args: [auth.toJSON(), trigger.toJSON()],
+      args: [
+        auth.getNonNullableUser().sId,
+        auth.getNonNullableWorkspace().sId,
+        trigger.toJSON(),
+      ],
       taskQueue: QUEUE_NAME,
     },
     scheduleId,

--- a/front/temporal/agent_schedule/workflows.ts
+++ b/front/temporal/agent_schedule/workflows.ts
@@ -1,6 +1,5 @@
 import { proxyActivities } from "@temporalio/workflow";
 
-import type { AuthenticatorType } from "@app/lib/auth";
 import type * as activities from "@app/temporal/agent_schedule/activities";
 import type { TriggerType } from "@app/types/assistant/triggers";
 
@@ -9,8 +8,9 @@ const { runScheduledAgentsActivity } = proxyActivities<typeof activities>({
 });
 
 export async function agentScheduleWorkflow(
-  authType: AuthenticatorType,
+  userId: string,
+  workspaceId: string,
   trigger: TriggerType
 ) {
-  await runScheduledAgentsActivity(authType, trigger);
+  await runScheduledAgentsActivity(userId, workspaceId, trigger);
 }


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

A schedule is linked to an authenticator. Problem : if this authenticator changes, the changes are not reflected, because we're using the serialized version of the authenticator.
Because of this, if a group disappears for example, then the Authenticator.to/fromJSON is not valid anymore, and it crashes the agent schedule.

This PR moves the authenticator used from the JSON to a userId/workspaceId. We need to migrate the existing schedules too, so it changes the migration script.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

Tested by hand.

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

Low

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->

Run the migration script on both regions, then deploy front.