### PR TITLE
[front] schedules: make agent aware of the last scheduled run

### DIFF
--- a/front/temporal/agent_schedule/activities.ts
+++ b/front/temporal/agent_schedule/activities.ts
@@ -16,7 +16,6 @@ import logger from "@app/logger/logger";
 import { makeScheduleId } from "@app/temporal/agent_schedule/client";
 import type { AgentConfigurationType } from "@app/types";
 import type { TriggerType } from "@app/types/assistant/triggers";
-import { ScheduleExecutionResult } from "@temporalio/client";
 
 /**
  * We want to create individual conversations if the agent outcome will vary from user to user.

--- a/front/temporal/agent_schedule/activities.ts
+++ b/front/temporal/agent_schedule/activities.ts
@@ -172,21 +172,14 @@ export async function runScheduledAgentsActivity(
 
   let lastRunAt: Date | null = null;
   try {
-    const schedule = client.schedule.getHandle(scheduleId);
-    console.log("Describing schedule with ID:", scheduleId);
-    const result = await schedule.describe();
-    console.log(
-      "Schedule description:",
-      result,
-      result.info,
-      result.info.recentActions
-    );
-    // Get the last recent action (if any)
-    const lastRecentAction =
-      result.info.recentActions.length > 0
-        ? result.info.recentActions[result.info.recentActions.length - 1]
+    const handle = client.schedule.getHandle(scheduleId);
+    const schedule = await handle.describe();
+
+    const recentActions = schedule.info.recentActions;
+    lastRunAt =
+      recentActions.length > 0
+        ? recentActions[recentActions.length - 2].takenAt // -2 to get the last completed action, -1 is the current running action
         : null;
-    lastRunAt = result.info.recentActions[-1].takenAt;
   } catch (error) {
     // We can ignore this error, schedule might not have run yet.
   }

--- a/front/temporal/agent_schedule/client.ts
+++ b/front/temporal/agent_schedule/client.ts
@@ -40,7 +40,7 @@ function getScheduleOptions(
   };
 }
 
-function makeScheduleId(workspaceId: string, triggerId: string): string {
+export function makeScheduleId(workspaceId: string, triggerId: string): string {
   return `agent-schedule-${workspaceId}-${triggerId}`;
 }
 


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

This PR implements a way for the agent to know the last time they were triggered.
This is implemented by adding a little section on the top of the user message.

We're fetching temporal to get the latest runs and use it in the message. Useful for agents running everyday.

<img width="2560" height="1440" alt="Capture d’écran 2025-09-09 à 14 18 49" src="https://github.com/user-attachments/assets/cd396597-3e85-408a-b538-135057902cf9" />

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

By hand.

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

Low

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->

Deploy front.