### PR TITLE
[core] enh: Add cache boundary on last message

### DIFF
--- a/core/src/providers/anthropic/helpers.rs
+++ b/core/src/providers/anthropic/helpers.rs
@@ -59,6 +59,7 @@ fn convert_chat_message_to_anthropic_chat_message(
                 thinking: None,
                 signature: None,
                 data: None,
+                cache_control: None,
             }],
             role: AnthropicChatMessageRole::User,
         }),
@@ -73,6 +74,7 @@ fn convert_chat_message_to_anthropic_chat_message(
                     thinking: None,
                     signature: None,
                     data: None,
+                    cache_control: None,
                 }],
                 role: AnthropicChatMessageRole::User,
             }),
@@ -89,6 +91,7 @@ fn convert_chat_message_to_anthropic_chat_message(
                             thinking: None,
                             signature: None,
                             data: None,
+                            cache_control: None,
                         }),
                         MixedContent::ImageContent(ic) => {
                             let base64_data = base64_map
@@ -104,6 +107,7 @@ fn convert_chat_message_to_anthropic_chat_message(
                                 thinking: None,
                                 signature: None,
                                 data: None,
+                                cache_control: None,
                             })
                         }
                     })
@@ -133,6 +137,7 @@ fn convert_chat_message_to_anthropic_chat_message(
                             thinking: None,
                             signature: None,
                             data: None,
+                            cache_control: None,
                         })),
                         AssistantContentItem::FunctionCall { value } => {
                             Some(serde_json::from_str(&value.arguments).map(|input| {
@@ -149,6 +154,7 @@ fn convert_chat_message_to_anthropic_chat_message(
                                     thinking: None,
                                     signature: None,
                                     data: None,
+                                    cache_control: None,
                                 }
                             }))
                         }
@@ -174,6 +180,7 @@ fn convert_chat_message_to_anthropic_chat_message(
                                     thinking: None,
                                     signature: None,
                                     data: Some(encrypted_content.to_string()),
+                                    cache_control: None,
                                 }))
                             } else {
                                 Some(Ok(AnthropicContent {
@@ -185,6 +192,7 @@ fn convert_chat_message_to_anthropic_chat_message(
                                     thinking: value.reasoning.clone(),
                                     signature: Some(encrypted_content.to_string()),
                                     data: None,
+                                    cache_control: None,
                                 }))
                             }
                         }
@@ -210,6 +218,7 @@ fn convert_chat_message_to_anthropic_chat_message(
                     thinking: None,
                     signature: None,
                     data: None,
+                    cache_control: None,
                 }],
                 role: AnthropicChatMessageRole::User,
             }),
@@ -248,6 +257,7 @@ fn convert_chat_message_to_anthropic_chat_message(
                         thinking: None,
                         signature: None,
                         data: None,
+                        cache_control: None,
                     }],
                     role: AnthropicChatMessageRole::User,
                 })

--- a/core/src/providers/anthropic/types.rs
+++ b/core/src/providers/anthropic/types.rs
@@ -127,6 +127,9 @@ pub struct AnthropicContent {
 
     #[serde(skip_serializing_if = "Option::is_none")]
     pub data: Option<String>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub cache_control: Option<AnthropicCacheControl>,
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
@@ -138,6 +141,17 @@ pub enum AnthropicContentType {
     ToolResult,
     Thinking,
     RedactedThinking,
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+pub struct AnthropicCacheControl {
+    pub r#type: AnthropicCacheControlType,
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+#[serde(rename_all = "snake_case")]
+pub enum AnthropicCacheControlType {
+    Ephemeral,
 }
 
 #[derive(Debug, Serialize, Deserialize, PartialEq, Clone)]


### PR DESCRIPTION
## Description

Adds a cache: "ephemeral" boundary on the last message, telling anthropic to cache as much as possible up to the end.

## Tests

Previous : 12993 tokens on 74802 tokens cached (only system prompt)
Same message, with boundary at the end : 74793 on 74802 tokens cached

## Risk

minimal

## Deploy Plan

deploy core