### PR TITLE
[Slack] Move auto-read channel logic to Temporal workflow

### DIFF
--- a/connectors/src/connectors/slack/auto_read_channel.ts
+++ b/connectors/src/connectors/slack/auto_read_channel.ts
@@ -1,33 +1,11 @@
-import type {
-  ConnectorProvider,
-  DataSourceViewType,
-  Result,
-} from "@dust-tt/client";
-import { DustAPI, Err, Ok } from "@dust-tt/client";
+import type { ConnectorProvider, Result } from "@dust-tt/client";
+import { Err, Ok } from "@dust-tt/client";
 
-import { joinChannelWithRetries } from "@connectors/connectors/slack/lib/channels";
-import {
-  getSlackClient,
-  reportSlackUsage,
-} from "@connectors/connectors/slack/lib/slack_client";
-import {
-  getSlackChannelSourceUrl,
-  slackChannelInternalIdFromSlackChannelId,
-} from "@connectors/connectors/slack/lib/utils";
-import { apiConfig } from "@connectors/lib/api/config";
-import { dataSourceConfigFromConnector } from "@connectors/lib/api/data_source_config";
-import { concurrentExecutor } from "@connectors/lib/async_utils";
-import { upsertDataSourceFolder } from "@connectors/lib/data_sources";
-import { SlackChannel } from "@connectors/lib/models/slack";
+import { launchJoinChannelWorkflow } from "@connectors/connectors/slack/temporal/client";
 import type { Logger } from "@connectors/logger/logger";
 import { ConnectorResource } from "@connectors/resources/connector_resource";
 import { SlackConfigurationResource } from "@connectors/resources/slack_configuration_resource";
-import type { ModelId, SlackAutoReadPattern } from "@connectors/types";
-import {
-  INTERNAL_MIME_TYPES,
-  normalizeError,
-  withRetries,
-} from "@connectors/types";
+import type { SlackAutoReadPattern } from "@connectors/types";
 
 export function findMatchingChannelPatterns(
   remoteChannelName: string,
@@ -69,189 +47,23 @@ export async function autoReadChannel(
     );
   }
 
-  const { connectorId } = slackConfiguration;
+  const { connectorId, autoReadChannelPatterns } = slackConfiguration;
 
-  const slackClient = await getSlackClient(connectorId);
+  // If no patterns are configured, nothing to do
+  if (!autoReadChannelPatterns || autoReadChannelPatterns.length === 0) {
+    return new Ok(false);
+  }
 
-  reportSlackUsage({
+  // Launch workflow which will check if channel matches patterns and process accordingly
+  const workflowResult = await launchJoinChannelWorkflow(
     connectorId,
-    method: "conversations.info",
-    channelId: slackChannelId,
-  });
-  const remoteChannel = await slackClient.conversations.info({
-    channel: slackChannelId,
-  });
-  const remoteChannelName = remoteChannel.channel?.name;
-
-  if (!remoteChannel.ok || !remoteChannelName) {
-    logger.error({
-      connectorId,
-      channelId: slackChannelId,
-      error: remoteChannel.error,
-    });
-    return new Err(new Error("Could not get the Slack channel information."));
-  }
-
-  const { autoReadChannelPatterns } = slackConfiguration;
-
-  const matchingPatterns = findMatchingChannelPatterns(
-    remoteChannelName,
-    autoReadChannelPatterns
+    slackChannelId,
+    "auto-read"
   );
-  if (matchingPatterns.length > 0) {
-    if (!remoteChannel.channel?.is_member) {
-      const joinChannelRes = await withRetries(
-        logger,
-        async (connectorId: ModelId, slackChannelId: string) => {
-          const result = await joinChannelWithRetries(
-            connectorId,
-            slackChannelId
-          );
-          if (result.isErr()) {
-            // Retry on any error, not just rate limit errors
-            throw result.error; // This will trigger a retry
-          }
-          return result;
-        },
-        {
-          retries: 3,
-          delayBetweenRetriesMs: 10000, // 10 seconds between retries
-        }
-      )(connectorId, slackChannelId);
 
-      if (joinChannelRes.isErr()) {
-        return joinChannelRes;
-      }
-    }
-
-    let channel: SlackChannel | null = null;
-    channel = await SlackChannel.findOne({
-      where: {
-        slackChannelId,
-        connectorId,
-      },
-    });
-    if (!channel) {
-      channel = await SlackChannel.create({
-        connectorId,
-        slackChannelId,
-        slackChannelName: remoteChannelName,
-        permission: "read_write",
-        private: remoteChannel.channel?.is_private ?? false,
-      });
-    } else {
-      await channel.update({
-        permission: "read_write",
-      });
-    }
-
-    // For slack_bot context, only do the basic channel setup without data source operations
-    if (provider === "slack_bot") {
-      return new Ok(true);
-    }
-
-    // Slack context: perform full data source operations
-    await upsertDataSourceFolder({
-      dataSourceConfig: dataSourceConfigFromConnector(connector),
-      folderId: slackChannelInternalIdFromSlackChannelId(slackChannelId),
-      title: `#${remoteChannelName}`,
-      parentId: null,
-      parents: [slackChannelInternalIdFromSlackChannelId(slackChannelId)],
-      mimeType: INTERNAL_MIME_TYPES.SLACK.CHANNEL,
-      sourceUrl: getSlackChannelSourceUrl(slackChannelId, slackConfiguration),
-      providerVisibility: remoteChannel.channel?.is_private
-        ? "private"
-        : "public",
-    });
-
-    const dustAPI = new DustAPI(
-      { url: apiConfig.getDustFrontAPIUrl() },
-      {
-        workspaceId: connector.workspaceId,
-        apiKey: connector.workspaceAPIKey,
-      },
-      logger
-    );
-
-    // Loop through all the matching patterns. Swallow errors and continue.
-    const results = await concurrentExecutor(
-      matchingPatterns,
-      async (p: SlackAutoReadPattern) => {
-        const searchParams = new URLSearchParams({
-          vaultId: p.spaceId,
-          dataSourceId: connector.dataSourceId,
-        });
-
-        const searchRes = await dustAPI.searchDataSourceViews(searchParams);
-        if (searchRes.isErr()) {
-          logger.error({
-            connectorId,
-            channelId: slackChannelId,
-            error: searchRes.error.message,
-          });
-
-          throw new Error("Failed to join Slack channel in Dust.");
-        }
-
-        const [dataSourceView] = searchRes.value;
-
-        if (!dataSourceView) {
-          logger.error({
-            connectorId,
-            channelId: slackChannelId,
-            error:
-              "Failed to join Slack channel, there was an issue retrieving dataSourceViews",
-          });
-
-          return new Err(
-            new Error("There was an issue retrieving dataSourceViews")
-          );
-        }
-
-        // Retry if the patch operation fails - it can happen if the channel is not in ES yet
-        try {
-          await withRetries(
-            logger,
-            async (dataSourceView: DataSourceViewType) => {
-              const updateDataSourceViewRes = await dustAPI.patchDataSourceView(
-                dataSourceView,
-                {
-                  parentsToAdd: [
-                    slackChannelInternalIdFromSlackChannelId(
-                      channel.slackChannelId
-                    ),
-                  ],
-                  parentsToRemove: undefined,
-                }
-              );
-
-              if (updateDataSourceViewRes.isErr()) {
-                throw new Error(
-                  `Failed to update Slack data source view for space ${p.spaceId}.`
-                );
-              }
-            },
-            {
-              retries: 3,
-              delayBetweenRetriesMs: 5000,
-            }
-          )(dataSourceView);
-        } catch (e) {
-          return new Err(normalizeError(e));
-        }
-
-        return new Ok(true);
-      },
-      { concurrency: 5 }
-    );
-
-    // If any error, return the first error.
-    if (results.some((r) => r.isErr())) {
-      return results.find((r) => r.isErr())!;
-    }
-
-    return new Ok(true);
+  if (workflowResult.isErr()) {
+    return new Err(workflowResult.error);
   }
 
-  return new Ok(false);
+  return new Ok(true);
 }

--- a/connectors/src/connectors/slack/temporal/activities.ts
+++ b/connectors/src/connectors/slack/temporal/activities.ts
@@ -1,3 +1,5 @@
+import type { DataSourceViewType } from "@dust-tt/client";
+import { DustAPI, Err, Ok } from "@dust-tt/client";
 import type {
   CodedError,
   WebAPIPlatformError,
@@ -41,6 +43,7 @@ import {
   slackNonThreadedMessagesInternalIdFromSlackNonThreadedMessagesIdentifier,
   slackThreadInternalIdFromSlackThreadIdentifier,
 } from "@connectors/connectors/slack/lib/utils";
+import { apiConfig } from "@connectors/lib/api/config";
 import { dataSourceConfigFromConnector } from "@connectors/lib/api/data_source_config";
 import { cacheSet } from "@connectors/lib/cache";
 import {
@@ -63,8 +66,13 @@ import mainLogger from "@connectors/logger/logger";
 import { ConnectorResource } from "@connectors/resources/connector_resource";
 import { SlackConfigurationResource } from "@connectors/resources/slack_configuration_resource";
 import type { ModelId } from "@connectors/types";
-import type { DataSourceConfig } from "@connectors/types";
-import { concurrentExecutor, INTERNAL_MIME_TYPES } from "@connectors/types";
+import type { DataSourceConfig, SlackAutoReadPattern } from "@connectors/types";
+import {
+  concurrentExecutor,
+  INTERNAL_MIME_TYPES,
+  normalizeError,
+  withRetries,
+} from "@connectors/types";
 
 const logger = mainLogger.child({ provider: "slack" });
 
@@ -1276,5 +1284,178 @@ export async function migrateChannelsFromLegacyBotToNewBotActivity(
     }
 
     throw e;
+  }
+}
+
+export async function autoReadChannelActivity(
+  connectorId: ModelId,
+  channelId: string
+): Promise<void> {
+  const connector = await ConnectorResource.fetchById(connectorId);
+  if (!connector) {
+    throw new Error(`Connector ${connectorId} not found`);
+  }
+
+  const slackConfiguration =
+    await SlackConfigurationResource.fetchByConnectorId(connectorId);
+  if (!slackConfiguration) {
+    throw new Error(
+      `Slack configuration not found for connector ${connectorId}`
+    );
+  }
+
+  const slackClient = await getSlackClient(connectorId);
+
+  reportSlackUsage({
+    connectorId,
+    method: "conversations.info",
+    channelId,
+  });
+
+  const remoteChannel = await slackClient.conversations.info({
+    channel: channelId,
+  });
+
+  const channelName = remoteChannel.channel?.name;
+  const isPrivate = remoteChannel.channel?.is_private ?? false;
+
+  if (!remoteChannel.ok || !channelName) {
+    logger.error({
+      connectorId,
+      channelId,
+      error: remoteChannel.error,
+    });
+    throw new Error("Could not get the Slack channel information.");
+  }
+
+  const { autoReadChannelPatterns } = slackConfiguration;
+  const matchingPatterns = autoReadChannelPatterns.filter((pattern) => {
+    const regex = new RegExp(`^${pattern.pattern}$`);
+    return regex.test(channelName);
+  });
+
+  if (matchingPatterns.length === 0) {
+    return;
+  }
+
+  const provider = connector.type as "slack" | "slack_bot";
+  let channel = await SlackChannel.findOne({
+    where: {
+      slackChannelId: channelId,
+      connectorId,
+    },
+  });
+
+  if (!channel) {
+    channel = await SlackChannel.create({
+      connectorId,
+      slackChannelId: channelId,
+      slackChannelName: channelName,
+      permission: "read_write",
+      private: isPrivate,
+    });
+  } else {
+    await channel.update({
+      permission: "read_write",
+    });
+  }
+
+  // For slack_bot context, only do the basic channel setup without data source operations
+  if (provider === "slack_bot") {
+    return;
+  }
+
+  // Slack context: perform full data source operations
+  const dataSourceConfig = dataSourceConfigFromConnector(connector);
+
+  await upsertDataSourceFolder({
+    dataSourceConfig,
+    folderId: slackChannelInternalIdFromSlackChannelId(channelId),
+    title: `#${channelName}`,
+    parentId: null,
+    parents: [slackChannelInternalIdFromSlackChannelId(channelId)],
+    mimeType: INTERNAL_MIME_TYPES.SLACK.CHANNEL,
+    sourceUrl: getSlackChannelSourceUrl(channelId, slackConfiguration),
+    providerVisibility: isPrivate ? "private" : "public",
+  });
+
+  const dustAPI = new DustAPI(
+    { url: apiConfig.getDustFrontAPIUrl() },
+    {
+      workspaceId: connector.workspaceId,
+      apiKey: connector.workspaceAPIKey,
+    },
+    mainLogger.child({ provider: "slack" })
+  );
+
+  const results = await concurrentExecutor(
+    matchingPatterns,
+    async (p: SlackAutoReadPattern) => {
+      const searchParams = new URLSearchParams({
+        vaultId: p.spaceId,
+        dataSourceId: connector.dataSourceId,
+      });
+
+      const searchRes = await dustAPI.searchDataSourceViews(searchParams);
+      if (searchRes.isErr()) {
+        mainLogger.error({
+          connectorId,
+          channelId,
+          error: searchRes.error.message,
+        });
+        return new Err(new Error("Failed to join Slack channel in Dust."));
+      }
+
+      const [dataSourceView] = searchRes.value;
+      if (!dataSourceView) {
+        mainLogger.error({
+          connectorId,
+          channelId,
+          error:
+            "Failed to join Slack channel, there was an issue retrieving dataSourceViews",
+        });
+        return new Err(
+          new Error("There was an issue retrieving dataSourceViews")
+        );
+      }
+
+      // Retry if the patch operation fails - it can happen if the channel is not in ES yet
+      try {
+        await withRetries(
+          mainLogger.child({ provider: "slack" }),
+          async (dataSourceView: DataSourceViewType) => {
+            const updateDataSourceViewRes = await dustAPI.patchDataSourceView(
+              dataSourceView,
+              {
+                parentsToAdd: [
+                  slackChannelInternalIdFromSlackChannelId(channelId),
+                ],
+                parentsToRemove: undefined,
+              }
+            );
+
+            if (updateDataSourceViewRes.isErr()) {
+              throw new Error(
+                `Failed to update Slack data source view for space ${p.spaceId}.`
+              );
+            }
+          },
+          {
+            retries: 3,
+            delayBetweenRetriesMs: 5000,
+          }
+        )(dataSourceView);
+      } catch (e) {
+        return new Err(normalizeError(e));
+      }
+
+      return new Ok(true);
+    },
+    { concurrency: 5 }
+  );
+
+  const firstError = results.find((r) => r.isErr());
+  if (firstError && firstError.isErr()) {
+    throw firstError.error;
   }
 }


### PR DESCRIPTION
## Description
Context: [Slack thread](https://dust4ai.slack.com/archives/C06GZDC29T3/p1735821875421079)
Fixes https://github.com/dust-tt/tasks/issues/3899

Move the synchronous auto-read channel operations into an async Temporal workflow to prevent blocking and timeouts when processing channels that match auto-read patterns.

The auto-read logic is now self-contained in a new activity that fetches channel info, checks patterns, and processes matching channels. This eliminates duplicate logic and provides better separation of concerns.

## Risks
Blast radius: Slack auto-read channel functionality
Risk: low

## Deploy Plan
- Deploy connectors service to apply the new workflow