### PR TITLE
[connectors] - chore(slack): log Slack channel deletion

### DIFF
--- a/connectors/src/connectors/slack/temporal/activities.ts
+++ b/connectors/src/connectors/slack/temporal/activities.ts
@@ -1147,6 +1147,13 @@ export async function deleteChannel(channelId: string, connectorId: ModelId) {
       },
       limit: maxMessages,
     });
+    logger.info(
+      {
+        nbMessages: slackMessages.length,
+        ...loggerArgs,
+      },
+      `Deleting ${slackMessages.length} messages from channel ${channelId}.`
+    );
     for (const slackMessage of slackMessages) {
       // We delete from the remote datasource first because we would rather double delete remotely
       // than miss one.


### PR DESCRIPTION
## Description

This PR adds logging of the number of messages about to be deleted on a given Slack channel. 

## Tests

N/A

## Risk

Low

## Deploy Plan

Deploy connectors
