### PR TITLE
Retrieve error from error tokenizing text

### DIFF
--- a/connectors/src/lib/data_sources.ts
+++ b/connectors/src/lib/data_sources.ts
@@ -537,10 +537,7 @@ async function tokenize(text: string, ds: DataSourceConfig) {
   if (tokensRes.isErr()) {
     logger.error(
       {
-        error: tokensRes.error,
-        textLength: sanitizedText.length,
-        sanitizedTextLength: sanitizedText.length,
-        textPreview: sanitizedText.substring(0, 200),
+        error: tokensRes.error.message,
         dataSourceId: ds.dataSourceId,
         workspaceId: ds.workspaceId,
       },


### PR DESCRIPTION
## Description

I'm trying to understand the "Error tokenizing text" that we have. 

First I thought we had an encoding issue so I temporarily added the tokenized content on the error log, but it's not that. 
I tried to search for logs on core and couldn't find any for the /tokenize route, so second attempt is to display the proper error on the log (currently it displays "Object" on DD), ex [here](https://app.datadoghq.eu/logs?query=%22Error%20tokenizing%20text%20for%22%20%40textPreview%3A%2A&agg_m=count&agg_m_source=base&agg_t=count&clustering_pattern_field_path=message&cols=host%2Cservice%2C%40textPreview&event=AwAAAZkuoKai5rzDfgAAABhBWmt1b0xkT0FBQjZ1dFJCek9zT1JBQXMAAAAkZjE5OTJlYTQtNGYyYi00ZDhiLWE5MDAtMDhlZDY3MTc5ZWUyAAA5Yg&messageDisplay=inline&refresh_mode=sliding&storage=hot&stream_sort=time%2Cdesc&viz=stream&from_ts=1757252544303&to_ts=1757425344303&live=true). 

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

Deploy connectors