### PR TITLE
[content creation] Improve sharing process

### DIFF
--- a/front/components/assistant/conversation/content_creation/ShareContentCreationFilePopover.tsx
+++ b/front/components/assistant/conversation/content_creation/ShareContentCreationFilePopover.tsx
@@ -65,7 +65,7 @@ const getScopeDisplayInfo = (
         icon: GlobeAltIcon,
         value: scope,
       };
-    // Treat conversation_participants as workspace scope for backward compatibility
+    // conversation_participants is now treated as workspace scope
     case "conversation_participants":
       return {
         label: `${owner.name} workspace`,

--- a/front/components/assistant/conversation/content_creation/ShareContentCreationFilePopover.tsx
+++ b/front/components/assistant/conversation/content_creation/ShareContentCreationFilePopover.tsx
@@ -65,6 +65,13 @@ const getScopeDisplayInfo = (
         icon: GlobeAltIcon,
         value: scope,
       };
+    // Treat conversation_participants as workspace scope for backward compatibility
+    case "conversation_participants":
+      return {
+        label: `${owner.name} workspace`,
+        icon: UserGroupIcon,
+        value: "workspace" as FileShareScope,
+      };
     default:
       return { label: "Not shared", icon: LockIcon, value: scope };
   }
@@ -77,13 +84,13 @@ function FileSharingDropdown({
   disabled = false,
   isUsingConversationFiles,
 }: FileSharingDropdownProps) {
-  const scopeOptions = fileShareScopeSchema.options.map((scope) =>
-    getScopeDisplayInfo(scope, owner)
-  );
+  const scopeOptions = fileShareScopeSchema.options
+    .filter((scope) => scope !== "conversation_participants")
+    .map((scope) => getScopeDisplayInfo(scope, owner));
 
-  const selectedOption = scopeOptions.find(
-    (opt) => opt.value === selectedScope
-  );
+  const selectedOption =
+    scopeOptions.find((opt) => opt.value === selectedScope) ||
+    getScopeDisplayInfo(selectedScope, owner);
 
   return (
     <div className="flex flex-col gap-2">

--- a/front/components/assistant/conversation/content_creation/ShareContentCreationFilePopover.tsx
+++ b/front/components/assistant/conversation/content_creation/ShareContentCreationFilePopover.tsx
@@ -112,8 +112,9 @@ export function ShareContentCreationFilePopover({
     await doShare(shareScope);
   };
 
-  const handleCreateLink = () => {
+  const handleCreateLink = async () => {
     setShowShareOptions(true);
+    await handleChangeFileShare("workspace");
   };
 
   const handleShareOptionSelect = async (scope: FileShareScope) => {
@@ -243,14 +244,14 @@ export function ShareContentCreationFilePopover({
               <div className="flex flex-col gap-3">
                 {!showShareOptions ? (
                   // Not shared state
-                  <div className="flex space-x-2 justify-between">
+                  <div className="flex justify-between space-x-2">
                     <div className="grow">
-                    <Input
-                      disabled
-                      placeholder={getPlaceholderUrl()}
-                      className="text-element-600 dark:text-element-600-dark"
+                      <Input
+                        disabled
+                        placeholder={getPlaceholderUrl()}
+                        className="text-element-600 dark:text-element-600-dark"
                       />
-                      </div>
+                    </div>
                     <Button
                       label="Create link"
                       icon={LinkIcon}

--- a/front/components/assistant/conversation/content_creation/ShareContentCreationFilePopover.tsx
+++ b/front/components/assistant/conversation/content_creation/ShareContentCreationFilePopover.tsx
@@ -19,6 +19,7 @@ import {
   useCopyToClipboard,
   UserGroupIcon,
 } from "@dust-tt/sparkle";
+import { LockIcon } from "lucide-react";
 import React from "react";
 
 import { useShareContentCreationFile } from "@app/lib/swr/files";
@@ -154,10 +155,33 @@ export function ShareContentCreationFilePopover({
   };
 
   const getPlaceholderUrl = () => {
-    return `${window.location.origin}/w/${owner.sId}/assistant/conversation/share`;
+    return `${window.location.origin}/share/...`;
   };
 
   const isDisabled = isSharingForbidden || isUsingConversationFiles;
+
+  const SHARE_OPTIONS: {
+    scope: FileShareScope;
+    label: string;
+    icon: React.ComponentType<{ className?: string }>;
+  }[] = [
+    {
+      scope: "none",
+      label: "Private",
+      icon: LockIcon,
+    },
+    {
+      scope: "workspace",
+      label: `${owner.name} workspace`,
+      icon: UserGroupIcon,
+    },
+
+    {
+      scope: "public",
+      label: "Anyone with the link",
+      icon: GlobeAltIcon,
+    },
+  ];
 
   const handleOpenChange = (open: boolean) => {
     // Reset to initial state if dialog is closed and file is not shared
@@ -179,8 +203,13 @@ export function ShareContentCreationFilePopover({
       </PopoverTrigger>
       <PopoverContent className="flex w-96 flex-col" align="end">
         <div className="flex flex-col gap-4">
-          <div className="text-base font-semibold text-primary dark:text-primary-night">
-            Share this Content Creation
+          <div className="flex flex-col">
+            <div className="text-base font-semibold text-primary dark:text-primary-night">
+              Share this Content Creation
+            </div>
+            <div className="text-element-600 dark:text-element-600-dark text-sm">
+              Share with your workspace or make it public.
+            </div>
           </div>
 
           <div className="flex flex-col">
@@ -208,28 +237,27 @@ export function ShareContentCreationFilePopover({
                       "disabled to protect company information."}
                 </ContentMessage>
               )}
+
             {/* File sharing options. */}
             {!isFileShareLoading && (
               <div className="flex flex-col gap-3">
                 {!showShareOptions ? (
-                  // Not shared state: disabled input with placeholder and create link button
-                  <div className="flex flex-col gap-3">
-                    <div className="flex items-center gap-2">
-                      <div className="grow">
-                        <Input
-                          disabled
-                          placeholder={getPlaceholderUrl()}
-                          className="text-element-600 dark:text-element-600-dark"
-                        />
+                  // Not shared state
+                  <div className="flex space-x-2 justify-between">
+                    <div className="grow">
+                    <Input
+                      disabled
+                      placeholder={getPlaceholderUrl()}
+                      className="text-element-600 dark:text-element-600-dark"
+                      />
                       </div>
-                    </div>
                     <Button
                       label="Create link"
                       icon={LinkIcon}
                       onClick={handleCreateLink}
                       disabled={isDisabled}
                       size="sm"
-                      className="w-full"
+                      className="w-32"
                     />
                   </div>
                 ) : (
@@ -239,32 +267,18 @@ export function ShareContentCreationFilePopover({
                       Who can access
                     </Label>
                     <div className="flex flex-col gap-2">
-                      <ShareOption
-                        scope="none"
-                        label="Private"
-                        icon={LinkIcon}
-                        isSelected={selectedScope === "none"}
-                        onSelect={() => handleShareOptionSelect("none")}
-                        disabled={isDisabled}
-                      />
-                      <ShareOption
-                        scope="workspace"
-                        label={`${owner.name} workspace`}
-                        icon={UserGroupIcon}
-                        isSelected={selectedScope === "workspace"}
-                        onSelect={() => handleShareOptionSelect("workspace")}
-                        disabled={isDisabled}
-                      />
-                      <ShareOption
-                        scope="public"
-                        label="Anyone with the link"
-                        icon={GlobeAltIcon}
-                        isSelected={selectedScope === "public"}
-                        onSelect={() => handleShareOptionSelect("public")}
-                        disabled={isDisabled}
-                      />
+                      {SHARE_OPTIONS.map((option) => (
+                        <ShareOption
+                          key={option.scope}
+                          scope={option.scope}
+                          label={option.label}
+                          icon={option.icon}
+                          isSelected={selectedScope === option.scope}
+                          onSelect={() => handleShareOptionSelect(option.scope)}
+                          disabled={isDisabled}
+                        />
+                      ))}
                     </div>
-
                     {selectedScope !== "none" && (
                       <>
                         <Separator />

--- a/front/components/assistant/conversation/content_creation/ShareContentCreationFilePopover.tsx
+++ b/front/components/assistant/conversation/content_creation/ShareContentCreationFilePopover.tsx
@@ -14,6 +14,7 @@ import {
   Input,
   Label,
   LinkIcon,
+  LockIcon,
   PopoverContent,
   PopoverRoot,
   PopoverTrigger,
@@ -46,10 +47,10 @@ const getScopeDisplayInfo = (
   value: FileShareScope;
 } => {
   switch (scope) {
-    case "conversation_participants":
+    case "none":
       return {
-        label: "Conversation participants",
-        icon: LinkIcon,
+        label: "Not shared",
+        icon: LockIcon,
         value: scope,
       };
     case "workspace":
@@ -65,7 +66,7 @@ const getScopeDisplayInfo = (
         value: scope,
       };
     default:
-      return { label: "Not shared", icon: LinkIcon, value: scope };
+      return { label: "Not shared", icon: LockIcon, value: scope };
   }
 };
 
@@ -137,9 +138,8 @@ export function ShareContentCreationFilePopover({
   const [isOpen, setIsOpen] = React.useState(false);
   const [isCopied, copyToClipboard] = useCopyToClipboard();
   const [isUpdatingShare, setIsUpdatingShare] = React.useState(false);
-  const [selectedScope, setSelectedScope] = React.useState<FileShareScope>(
-    "conversation_participants"
-  );
+  const [selectedScope, setSelectedScope] =
+    React.useState<FileShareScope>("none");
 
   const isSharingForbidden =
     owner.metadata?.allowContentCreationFileSharing === false;
@@ -187,8 +187,13 @@ export function ShareContentCreationFilePopover({
     : null;
 
   const getShareButtonIcon = () => {
-    if (currentScopeInfo) {
-      return currentScopeInfo.icon;
+    switch (currentShareScope) {
+      case "none":
+        return LinkIcon;
+      case "workspace":
+        return UserGroupIcon;
+      case "public":
+        return GlobeAltIcon;
     }
 
     return LinkIcon;
@@ -254,25 +259,28 @@ export function ShareContentCreationFilePopover({
                   isLoading={isUpdatingShare}
                 />
 
-                <Separator />
-
-                {/* Content area with loading state */}
-                <div className="flex items-center gap-2">
-                  <div className="grow">
-                    <Input
-                      disabled
-                      onClick={(e) => e.currentTarget.select()}
-                      readOnly
-                      value={shareURL}
-                    />
-                  </div>
-                  <IconButton
-                    className="flex-none"
-                    icon={isCopied ? ClipboardCheckIcon : ClipboardIcon}
-                    tooltip={isCopied ? "Copied!" : "Copy link"}
-                    onClick={handleCopyLink}
-                  />
-                </div>
+                {selectedScope !== "none" && (
+                  <>
+                    <Separator />
+                    {/* Content area with loading state */}
+                    <div className="flex items-center gap-2">
+                      <div className="grow">
+                        <Input
+                          disabled
+                          onClick={(e) => e.currentTarget.select()}
+                          readOnly
+                          value={shareURL}
+                        />
+                      </div>
+                      <IconButton
+                        className="flex-none"
+                        icon={isCopied ? ClipboardCheckIcon : ClipboardIcon}
+                        tooltip={isCopied ? "Copied!" : "Copy link"}
+                        onClick={handleCopyLink}
+                      />
+                    </div>
+                  </>
+                )}
               </div>
             )}
           </div>

--- a/front/components/assistant/conversation/content_creation/ShareContentCreationFilePopover.tsx
+++ b/front/components/assistant/conversation/content_creation/ShareContentCreationFilePopover.tsx
@@ -55,9 +55,9 @@ function ShareOption({
       <div className="flex items-center gap-3">
         <Icon className="h-5 w-5" />
         <div className="flex flex-col">
-          <span className="text-sm font-medium text-primary dark:text-primary-night">
+          <Label className="text-sm font-medium text-primary dark:text-primary-night">
             {label}
-          </span>
+          </Label>
           <span className="text-element-600 dark:text-element-600-dark text-xs">
             {scope === "workspace"
               ? "People in your workspace"
@@ -240,6 +240,14 @@ export function ShareContentCreationFilePopover({
                     </Label>
                     <div className="flex flex-col gap-2">
                       <ShareOption
+                        scope="none"
+                        label="Private"
+                        icon={LinkIcon}
+                        isSelected={selectedScope === "none"}
+                        onSelect={() => handleShareOptionSelect("none")}
+                        disabled={isDisabled}
+                      />
+                      <ShareOption
                         scope="workspace"
                         label={`${owner.name} workspace`}
                         icon={UserGroupIcon}
@@ -253,14 +261,6 @@ export function ShareContentCreationFilePopover({
                         icon={GlobeAltIcon}
                         isSelected={selectedScope === "public"}
                         onSelect={() => handleShareOptionSelect("public")}
-                        disabled={isDisabled}
-                      />
-                      <ShareOption
-                        scope="none"
-                        label="Private"
-                        icon={LinkIcon}
-                        isSelected={selectedScope === "none"}
-                        onSelect={() => handleShareOptionSelect("none")}
                         disabled={isDisabled}
                       />
                     </div>

--- a/front/components/assistant/conversation/content_creation/ShareContentCreationFilePopover.tsx
+++ b/front/components/assistant/conversation/content_creation/ShareContentCreationFilePopover.tsx
@@ -44,7 +44,7 @@ function ShareOption({
   return (
     <Card
       className={cn(
-        "cursor-pointer transition-colors",
+        "cursor-pointer",
         isSelected
           ? "border-highlight-500 bg-highlight-100 shadow-md hover:border-highlight-400 hover:bg-highlight-200 dark:border-highlight-400 dark:bg-highlight-800/30 dark:hover:border-highlight-300 dark:hover:bg-highlight-700/30"
           : "hover:border-structure-300 dark:hover:border-structure-300-dark",
@@ -84,7 +84,6 @@ export function ShareContentCreationFilePopover({
 }: ShareContentCreationFilePopoverProps) {
   const [isOpen, setIsOpen] = React.useState(false);
   const [isCopied, copyToClipboard] = useCopyToClipboard();
-  const [isUpdatingShare, setIsUpdatingShare] = React.useState(false);
   const [showShareOptions, setShowShareOptions] = React.useState(false);
   const [selectedScope, setSelectedScope] =
     React.useState<FileShareScope>("none");
@@ -107,14 +106,9 @@ export function ShareContentCreationFilePopover({
   }, [fileShare, isFileShareLoading, isFileShareError]);
 
   const handleChangeFileShare = async (shareScope: FileShareScope) => {
-    setIsUpdatingShare(true);
-    try {
-      await doShare(shareScope);
-      setSelectedScope(shareScope);
-      setShowShareOptions(shareScope !== "none");
-    } finally {
-      setIsUpdatingShare(false);
-    }
+    setSelectedScope(shareScope);
+    setShowShareOptions(shareScope !== "none");
+    await doShare(shareScope);
   };
 
   const handleCreateLink = () => {
@@ -125,10 +119,9 @@ export function ShareContentCreationFilePopover({
     if (scope === "none") {
       setShowShareOptions(false);
       setSelectedScope("none");
-      await handleChangeFileShare("none");
-    } else {
-      await handleChangeFileShare(scope);
     }
+
+    await handleChangeFileShare(scope);
   };
 
   const shareURL = fileShare?.shareUrl ?? "";
@@ -164,8 +157,7 @@ export function ShareContentCreationFilePopover({
     return `${window.location.origin}/w/${owner.sId}/assistant/conversation/share`;
   };
 
-  const isDisabled =
-    isSharingForbidden || isUsingConversationFiles || isUpdatingShare;
+  const isDisabled = isSharingForbidden || isUsingConversationFiles;
 
   const handleOpenChange = (open: boolean) => {
     // Reset to initial state if dialog is closed and file is not shared
@@ -216,11 +208,11 @@ export function ShareContentCreationFilePopover({
                       "disabled to protect company information."}
                 </ContentMessage>
               )}
-            {/* File sharing interface. */}
+            {/* File sharing options. */}
             {!isFileShareLoading && (
               <div className="flex flex-col gap-3">
                 {!showShareOptions ? (
-                  // Initial state: disabled input with placeholder and create link button
+                  // Not shared state: disabled input with placeholder and create link button
                   <div className="flex flex-col gap-3">
                     <div className="flex items-center gap-2">
                       <div className="grow">
@@ -241,7 +233,7 @@ export function ShareContentCreationFilePopover({
                     />
                   </div>
                 ) : (
-                  // Share options state
+                  // Share options
                   <div className="flex flex-col gap-3">
                     <Label className="text-sm font-semibold text-primary dark:text-primary-night">
                       Who can access

--- a/front/components/assistant/conversation/content_creation/ShareContentCreationFilePopover.tsx
+++ b/front/components/assistant/conversation/content_creation/ShareContentCreationFilePopover.tsx
@@ -14,7 +14,6 @@ import {
   Input,
   Label,
   LinkIcon,
-  LockIcon,
   PopoverContent,
   PopoverRoot,
   PopoverTrigger,
@@ -50,7 +49,7 @@ const getScopeDisplayInfo = (
     case "conversation_participants":
       return {
         label: "Conversation participants",
-        icon: LockIcon,
+        icon: LinkIcon,
         value: scope,
       };
     case "workspace":
@@ -66,7 +65,7 @@ const getScopeDisplayInfo = (
         value: scope,
       };
     default:
-      return { label: "Not shared", icon: LockIcon, value: scope };
+      return { label: "Not shared", icon: LinkIcon, value: scope };
   }
 };
 

--- a/front/lib/resources/file_resource.ts
+++ b/front/lib/resources/file_resource.ts
@@ -307,11 +307,11 @@ export class FileResource extends BaseResource<FileModel> {
     const updateResult = await this.update({ status: "ready" });
 
     // For Content Creation conversation files, automatically create a ShareableFileModel with
-    // default conversation_participants scope.
+    // default none scope.
     if (this.isContentCreation) {
       await ShareableFileModel.upsert({
         fileId: this.id,
-        shareScope: "conversation_participants",
+        shareScope: "none",
         sharedBy: this.userId ?? null,
         workspaceId: this.workspaceId,
         sharedAt: new Date(),

--- a/front/lib/resources/file_resource.ts
+++ b/front/lib/resources/file_resource.ts
@@ -170,6 +170,7 @@ export class FileResource extends BaseResource<FileModel> {
       return null;
     }
 
+<<<<<<< HEAD
     if (
       isUsingConversationFiles(content) &&
       shareableFile.shareScope === "public"
@@ -178,6 +179,15 @@ export class FileResource extends BaseResource<FileModel> {
       // We have several other check points:
       // - You cannot set it to public if isUsingConversationFiles is true
       // - When you fetch a file in files/[token] page, we check authentication if it's for workspace sharing.
+=======
+    // Only block conversation files for public sharing.
+    // conversation_participants is now treated as workspace scope.
+    if (
+      shareableFile.shareScope === "public" &&
+      isFileUsingConversationFiles(content)
+    ) {
+      // If the file is using conversation files, we don't want to make it accessible publicly.
+>>>>>>> 9865e1604f (conversation_participants == workspace scope)
       return null;
     }
 

--- a/front/lib/resources/file_resource.ts
+++ b/front/lib/resources/file_resource.ts
@@ -170,7 +170,6 @@ export class FileResource extends BaseResource<FileModel> {
       return null;
     }
 
-<<<<<<< HEAD
     if (
       isUsingConversationFiles(content) &&
       shareableFile.shareScope === "public"
@@ -179,15 +178,6 @@ export class FileResource extends BaseResource<FileModel> {
       // We have several other check points:
       // - You cannot set it to public if isUsingConversationFiles is true
       // - When you fetch a file in files/[token] page, we check authentication if it's for workspace sharing.
-=======
-    // Only block conversation files for public sharing.
-    // conversation_participants is now treated as workspace scope.
-    if (
-      shareableFile.shareScope === "public" &&
-      isFileUsingConversationFiles(content)
-    ) {
-      // If the file is using conversation files, we don't want to make it accessible publicly.
->>>>>>> 9865e1604f (conversation_participants == workspace scope)
       return null;
     }
 

--- a/front/lib/resources/file_resource.ts
+++ b/front/lib/resources/file_resource.ts
@@ -138,6 +138,10 @@ export class FileResource extends BaseResource<FileModel> {
       return null;
     }
 
+    if (shareableFile.shareScope === "none") {
+      return null;
+    }
+
     const [workspace] = await WorkspaceResource.fetchByModelIds([
       shareableFile.workspaceId,
     ]);

--- a/front/pages/api/v1/public/files/[token].ts
+++ b/front/pages/api/v1/public/files/[token].ts
@@ -74,6 +74,17 @@ async function handler(
     });
   }
 
+  // If the share scope is "none", the file should not be accessible to anyone.
+  if (shareScope === "none") {
+    return apiError(req, res, {
+      status_code: 403,
+      api_error: {
+        type: "invalid_request_error",
+        message: "You cannot access this file.",
+      },
+    });
+  }
+
   // Check if file is safe to display.
   if (!file.isSafeToDisplay()) {
     return apiError(req, res, {
@@ -85,18 +96,6 @@ async function handler(
     });
   }
 
-  // This endpoint does not support conversation participants sharing. It goes through the private
-  // API endpoint instead.
-  if (shareScope === "conversation_participants") {
-    return apiError(req, res, {
-      status_code: 404,
-      api_error: {
-        type: "file_not_found",
-        message: "File not found.",
-      },
-    });
-  }
-
   // For workspace sharing, check authentication.
   if (shareScope === "workspace") {
     const isWorkspaceUser = await isSessionWithUserFromWorkspace(
@@ -104,6 +103,7 @@ async function handler(
       res,
       workspace.sId
     );
+
     if (!isWorkspaceUser) {
       return apiError(req, res, {
         status_code: 404,

--- a/front/pages/api/v1/public/files/[token].ts
+++ b/front/pages/api/v1/public/files/[token].ts
@@ -74,17 +74,6 @@ async function handler(
     });
   }
 
-  // If the share scope is "none", the file should not be accessible to anyone.
-  if (shareScope === "none") {
-    return apiError(req, res, {
-      status_code: 403,
-      api_error: {
-        type: "invalid_request_error",
-        message: "You cannot access this file.",
-      },
-    });
-  }
-
   // Check if file is safe to display.
   if (!file.isSafeToDisplay()) {
     return apiError(req, res, {
@@ -92,6 +81,17 @@ async function handler(
       api_error: {
         type: "invalid_request_error",
         message: "File is not safe for public display.",
+      },
+    });
+  }
+
+  // If the share scope is "none", the file should not be accessible to anyone.
+  if (shareScope === "none") {
+    return apiError(req, res, {
+      status_code: 403,
+      api_error: {
+        type: "invalid_request_error",
+        message: "You cannot access this file.",
       },
     });
   }

--- a/front/pages/api/v1/public/files/[token].ts
+++ b/front/pages/api/v1/public/files/[token].ts
@@ -97,7 +97,11 @@ async function handler(
   }
 
   // For workspace sharing, check authentication.
-  if (shareScope === "workspace") {
+  // conversation_participants is treated as workspace scope for backward compatibility
+  if (
+    shareScope === "workspace" ||
+    shareScope === "conversation_participants"
+  ) {
     const isWorkspaceUser = await isSessionWithUserFromWorkspace(
       req,
       res,

--- a/front/pages/api/v1/public/files/[token].ts
+++ b/front/pages/api/v1/public/files/[token].ts
@@ -97,7 +97,7 @@ async function handler(
   }
 
   // For workspace sharing, check authentication.
-  // conversation_participants is treated as workspace scope for backward compatibility
+  // conversation_participants is now treated as workspace scope
   if (
     shareScope === "workspace" ||
     shareScope === "conversation_participants"

--- a/front/pages/api/w/[wId]/files/[fileId]/share.ts
+++ b/front/pages/api/w/[wId]/files/[fileId]/share.ts
@@ -107,6 +107,8 @@ async function handler(
           });
         }
 
+        // We don't want to share Content Creation files that use files from the conversation
+        // to people outside of the workspace.
         if (isUsingConversationFiles(fileContent)) {
           return apiError(req, res, {
             status_code: 400,

--- a/front/pages/share/file/[token].tsx
+++ b/front/pages/share/file/[token].tsx
@@ -46,25 +46,11 @@ export const getServerSideProps = makeGetServerSidePropsRequirementsWrapper({
     };
   }
 
-  const { file, shareScope } = result;
+  const { file } = result;
   const workspace = await WorkspaceResource.fetchByModelId(file.workspaceId);
   if (!workspace) {
     return {
       notFound: true,
-    };
-  }
-
-  // If the file is shared with conversation participants, redirect to the conversation.
-  if (shareScope === "conversation_participants") {
-    const pathname = `/w/${workspace.sId}/assistant/${file.useCaseMetadata?.conversationId}`;
-    const hash = `#?${FULL_SCREEN_HASH_PARAM}=true&${SIDE_PANEL_TYPE_HASH_PARAM}=${CONTENT_CREATION_SIDE_PANEL_TYPE}&${SIDE_PANEL_HASH_PARAM}=${file.sId}`;
-    const destination = pathname + hash;
-
-    return {
-      redirect: {
-        destination,
-        permanent: false,
-      },
     };
   }
 

--- a/front/pages/share/file/[token].tsx
+++ b/front/pages/share/file/[token].tsx
@@ -7,12 +7,6 @@ import { makeGetServerSidePropsRequirementsWrapper } from "@app/lib/iam/session"
 import { FileResource } from "@app/lib/resources/file_resource";
 import { WorkspaceResource } from "@app/lib/resources/workspace_resource";
 import { getFaviconPath } from "@app/lib/utils";
-import {
-  CONTENT_CREATION_SIDE_PANEL_TYPE,
-  FULL_SCREEN_HASH_PARAM,
-  SIDE_PANEL_HASH_PARAM,
-  SIDE_PANEL_TYPE_HASH_PARAM,
-} from "@app/types/conversation_side_panel";
 
 interface SharedFilePageProps {
   shareUrl: string;

--- a/front/public/swagger.json
+++ b/front/public/swagger.json
@@ -24,9 +24,7 @@
       "get": {
         "summary": "List agents",
         "description": "Get the agent configurations for the workspace identified by {wId}.",
-        "tags": [
-          "Agents"
-        ],
+        "tags": ["Agents"],
         "parameters": [
           {
             "in": "path",
@@ -61,10 +59,7 @@
             "description": "When set to 'true', includes recent authors information for each agent",
             "schema": {
               "type": "string",
-              "enum": [
-                "true",
-                "false"
-              ]
+              "enum": ["true", "false"]
             }
           }
         ],
@@ -115,9 +110,7 @@
       "get": {
         "summary": "Get agent configuration",
         "description": "Retrieve the agent configuration identified by {sId} in the workspace identified by {wId}.",
-        "tags": [
-          "Agents"
-        ],
+        "tags": ["Agents"],
         "parameters": [
           {
             "in": "path",
@@ -144,10 +137,7 @@
             "description": "Configuration variant to retrieve. 'light' returns basic config without actions, 'full' includes complete actions/tools configuration",
             "schema": {
               "type": "string",
-              "enum": [
-                "light",
-                "full"
-              ],
+              "enum": ["light", "full"],
               "default": "light"
             }
           }
@@ -193,9 +183,7 @@
       "patch": {
         "summary": "Update agent configuration",
         "description": "Update the agent configuration identified by {sId} in the workspace identified by {wId}.",
-        "tags": [
-          "Agents"
-        ],
+        "tags": ["Agents"],
         "parameters": [
           {
             "in": "path",
@@ -274,9 +262,7 @@
       "get": {
         "summary": "Search agents by name",
         "description": "Search for agent configurations by name in the workspace identified by {wId}.",
-        "tags": [
-          "Agents"
-        ],
+        "tags": ["Agents"],
         "parameters": [
           {
             "in": "path",
@@ -341,9 +327,7 @@
     },
     "/api/v1/w/{wId}/assistant/conversations/{cId}/cancel": {
       "post": {
-        "tags": [
-          "Conversations"
-        ],
+        "tags": ["Conversations"],
         "summary": "Cancel message generation in a conversation",
         "parameters": [
           {
@@ -376,9 +360,7 @@
             "application/json": {
               "schema": {
                 "type": "object",
-                "required": [
-                  "messageIds"
-                ],
+                "required": ["messageIds"],
                 "properties": {
                   "messageIds": {
                     "type": "array",
@@ -422,9 +404,7 @@
       "post": {
         "summary": "Create a content fragment",
         "description": "Create a new content fragment in the workspace identified by {wId}.",
-        "tags": [
-          "Conversations"
-        ],
+        "tags": ["Conversations"],
         "parameters": [
           {
             "in": "path",
@@ -487,9 +467,7 @@
       "get": {
         "summary": "Get the events for a conversation",
         "description": "Get the events for a conversation in the workspace identified by {wId}.",
-        "tags": [
-          "Conversations"
-        ],
+        "tags": ["Conversations"],
         "parameters": [
           {
             "in": "path",
@@ -550,9 +528,7 @@
       "get": {
         "summary": "Get feedbacks for a conversation",
         "description": "Retrieves all feedback entries for a specific conversation.\nRequires authentication and read:conversation scope.\n",
-        "tags": [
-          "Feedbacks"
-        ],
+        "tags": ["Feedbacks"],
         "parameters": [
           {
             "name": "wId",
@@ -605,10 +581,7 @@
                           },
                           "thumbDirection": {
                             "type": "string",
-                            "enum": [
-                              "up",
-                              "down"
-                            ],
+                            "enum": ["up", "down"],
                             "description": "Direction of the thumb feedback"
                           },
                           "content": {
@@ -662,9 +635,7 @@
       "get": {
         "summary": "Get a conversation",
         "description": "Get a conversation in the workspace identified by {wId}.",
-        "tags": [
-          "Conversations"
-        ],
+        "tags": ["Conversations"],
         "security": [
           {
             "BearerAuth": []
@@ -717,92 +688,11 @@
             "description": "Internal Server Error."
           }
         }
-      },
-      "patch": {
-        "summary": "Mark a conversation as read",
-        "description": "Mark a conversation as read in the workspace identified by {wId}.",
-        "tags": [
-          "Conversations"
-        ],
-        "security": [
-          {
-            "OauthToken": []
-          }
-        ],
-        "parameters": [
-          {
-            "in": "path",
-            "name": "wId",
-            "required": true,
-            "description": "ID of the workspace",
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "in": "path",
-            "name": "cId",
-            "required": true,
-            "description": "ID of the conversation",
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "requestBody": {
-          "required": true,
-          "content": {
-            "application/json": {
-              "schema": {
-                "type": "object",
-                "properties": {
-                  "read": {
-                    "type": "boolean"
-                  }
-                }
-              }
-            }
-          }
-        },
-        "responses": {
-          "200": {
-            "description": "Conversation marked as read successfully.",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "success": {
-                      "type": "boolean"
-                    }
-                  }
-                }
-              }
-            }
-          },
-          "400": {
-            "description": "Bad Request. Invalid or missing parameters."
-          },
-          "401": {
-            "description": "Unauthorized. Invalid or missing authentication token."
-          },
-          "404": {
-            "description": "Conversation not found."
-          },
-          "405": {
-            "description": "Method not supported. Only GET or PATCH is expected."
-          },
-          "500": {
-            "description": "Internal Server Error."
-          }
-        }
       }
     },
     "/api/v1/w/{wId}/assistant/conversations/{cId}/messages/{mId}/edit": {
       "post": {
-        "tags": [
-          "Conversations"
-        ],
+        "tags": ["Conversations"],
         "summary": "Edit an existing message in a conversation",
         "parameters": [
           {
@@ -844,10 +734,7 @@
             "application/json": {
               "schema": {
                 "type": "object",
-                "required": [
-                  "content",
-                  "mentions"
-                ],
+                "required": ["content", "mentions"],
                 "properties": {
                   "content": {
                     "type": "string",
@@ -858,9 +745,7 @@
                     "description": "List of agent mentions in the message",
                     "items": {
                       "type": "object",
-                      "required": [
-                        "configurationId"
-                      ],
+                      "required": ["configurationId"],
                       "properties": {
                         "configurationId": {
                           "type": "string",
@@ -908,9 +793,7 @@
       "get": {
         "summary": "Get events for a message",
         "description": "Get events for a message in the workspace identified by {wId}.",
-        "tags": [
-          "Conversations"
-        ],
+        "tags": ["Conversations"],
         "parameters": [
           {
             "in": "path",
@@ -1004,9 +887,7 @@
       "post": {
         "summary": "Submit feedback for a specific message in a conversation",
         "description": "Submit user feedback (thumbs up/down) for a specific message in a conversation.\nRequires authentication and update:conversation scope.\n",
-        "tags": [
-          "Feedbacks"
-        ],
+        "tags": ["Feedbacks"],
         "parameters": [
           {
             "name": "wId",
@@ -1047,16 +928,11 @@
             "application/json": {
               "schema": {
                 "type": "object",
-                "required": [
-                  "thumbDirection"
-                ],
+                "required": ["thumbDirection"],
                 "properties": {
                   "thumbDirection": {
                     "type": "string",
-                    "enum": [
-                      "up",
-                      "down"
-                    ],
+                    "enum": ["up", "down"],
                     "description": "Direction of the thumb feedback"
                   },
                   "feedbackContent": {
@@ -1102,9 +978,7 @@
       "delete": {
         "summary": "Delete feedback for a specific message",
         "description": "Delete user feedback for a specific message in a conversation.\nRequires authentication and update:conversation scope.\n",
-        "tags": [
-          "Feedbacks"
-        ],
+        "tags": ["Feedbacks"],
         "parameters": [
           {
             "name": "wId",
@@ -1171,9 +1045,7 @@
       "post": {
         "summary": "Validate an action in a conversation message",
         "description": "Approves or rejects an action taken in a specific message in a conversation",
-        "tags": [
-          "Conversations"
-        ],
+        "tags": ["Conversations"],
         "parameters": [
           {
             "in": "path",
@@ -1209,10 +1081,7 @@
             "application/json": {
               "schema": {
                 "type": "object",
-                "required": [
-                  "actionId",
-                  "approved"
-                ],
+                "required": ["actionId", "approved"],
                 "properties": {
                   "actionId": {
                     "type": "string",
@@ -1267,9 +1136,7 @@
       "post": {
         "summary": "Create a message",
         "description": "Create a message in the workspace identified by {wId} in the conversation identified by {cId}.",
-        "tags": [
-          "Conversations"
-        ],
+        "tags": ["Conversations"],
         "parameters": [
           {
             "in": "path",
@@ -1335,9 +1202,7 @@
       "post": {
         "summary": "Create a new conversation",
         "description": "Create a new conversation in the workspace identified by {wId}.",
-        "tags": [
-          "Conversations"
-        ],
+        "tags": ["Conversations"],
         "parameters": [
           {
             "in": "path",
@@ -1360,9 +1225,7 @@
             "application/json": {
               "schema": {
                 "type": "object",
-                "required": [
-                  "message"
-                ],
+                "required": ["message"],
                 "properties": {
                   "message": {
                     "$ref": "#/components/schemas/Message"
@@ -1422,9 +1285,7 @@
     },
     "/api/v1/w/{wId}/files": {
       "post": {
-        "tags": [
-          "Conversations"
-        ],
+        "tags": ["Conversations"],
         "summary": "Create a file upload URL",
         "parameters": [
           {
@@ -1523,9 +1384,7 @@
       "post": {
         "summary": "Update heartbeat for a client-side MCP server",
         "description": "[Documentation](https://docs.dust.tt/docs/client-side-mcp-server)\nUpdate the heartbeat for a previously registered client-side MCP server.\nThis extends the TTL for the server registration.\n",
-        "tags": [
-          "MCP"
-        ],
+        "tags": ["MCP"],
         "security": [
           {
             "BearerAuth": []
@@ -1548,9 +1407,7 @@
             "application/json": {
               "schema": {
                 "type": "object",
-                "required": [
-                  "serverId"
-                ],
+                "required": ["serverId"],
                 "properties": {
                   "serverId": {
                     "type": "string",
@@ -1600,9 +1457,7 @@
       "post": {
         "summary": "Register a client-side MCP server",
         "description": "[Documentation](https://docs.dust.tt/docs/client-side-mcp-server)\nRegister a client-side MCP server to Dust.\nThe registration is scoped to the current user and workspace.\nA serverId identifier is generated and returned in the response.\n",
-        "tags": [
-          "MCP"
-        ],
+        "tags": ["MCP"],
         "security": [
           {
             "BearerAuth": []
@@ -1625,9 +1480,7 @@
             "application/json": {
               "schema": {
                 "type": "object",
-                "required": [
-                  "serverName"
-                ],
+                "required": ["serverName"],
                 "properties": {
                   "serverName": {
                     "type": "string",
@@ -1674,9 +1527,7 @@
       "get": {
         "summary": "Stream MCP tool requests for a workspace",
         "description": "[Documentation](https://docs.dust.tt/docs/client-side-mcp-server)\nServer-Sent Events (SSE) endpoint that streams MCP tool requests for a workspace.\nThis endpoint is used by client-side MCP servers to listen for tool requests in real-time.\nThe connection will remain open and events will be sent as new tool requests are made.\n",
-        "tags": [
-          "MCP"
-        ],
+        "tags": ["MCP"],
         "security": [
           {
             "BearerAuth": []
@@ -1751,9 +1602,7 @@
       "post": {
         "summary": "Submit MCP tool execution results",
         "description": "[Documentation](https://docs.dust.tt/docs/client-side-mcp-server)\nEndpoint for client-side MCP servers to submit the results of tool executions.\nThis endpoint accepts the output from tools that were executed locally.\n",
-        "tags": [
-          "MCP"
-        ],
+        "tags": ["MCP"],
         "security": [
           {
             "BearerAuth": []
@@ -1776,10 +1625,7 @@
             "application/json": {
               "schema": {
                 "type": "object",
-                "required": [
-                  "result",
-                  "serverId"
-                ],
+                "required": ["result", "serverId"],
                 "properties": {
                   "result": {
                     "type": "object",
@@ -1820,9 +1666,7 @@
       "post": {
         "summary": "Search for nodes in the workspace",
         "description": "Search for nodes in the workspace",
-        "tags": [
-          "Search"
-        ],
+        "tags": ["Search"],
         "parameters": [
           {
             "in": "path",
@@ -1845,9 +1689,7 @@
             "application/json": {
               "schema": {
                 "type": "object",
-                "required": [
-                  "query"
-                ],
+                "required": ["query"],
                 "properties": {
                   "query": {
                     "type": "string",
@@ -1907,9 +1749,7 @@
       "get": {
         "summary": "Get an app run",
         "description": "Retrieve a run for an app in the space identified by {spaceId}.",
-        "tags": [
-          "Apps"
-        ],
+        "tags": ["Apps"],
         "security": [
           {
             "BearerAuth": []
@@ -1982,9 +1822,7 @@
       "post": {
         "summary": "Create an app run",
         "description": "Create and execute a run for an app in the space specified by {spaceId}.",
-        "tags": [
-          "Apps"
-        ],
+        "tags": ["Apps"],
         "security": [
           {
             "BearerAuth": []
@@ -2025,11 +1863,7 @@
             "application/json": {
               "schema": {
                 "type": "object",
-                "required": [
-                  "specification_hash",
-                  "config",
-                  "inputs"
-                ],
+                "required": ["specification_hash", "config", "inputs"],
                 "properties": {
                   "specification_hash": {
                     "type": "string",
@@ -2129,9 +1963,7 @@
       "get": {
         "summary": "List apps",
         "description": "Get all apps in the space identified by {spaceId}.",
-        "tags": [
-          "Apps"
-        ],
+        "tags": ["Apps"],
         "security": [
           {
             "BearerAuth": []
@@ -2230,9 +2062,7 @@
     },
     "/api/v1/w/{wId}/spaces/{spaceId}/data_source_views/{dsvId}": {
       "get": {
-        "tags": [
-          "DatasourceViews"
-        ],
+        "tags": ["DatasourceViews"],
         "security": [
           {
             "BearerAuth": []
@@ -2285,9 +2115,7 @@
         }
       },
       "patch": {
-        "tags": [
-          "DatasourceViews"
-        ],
+        "tags": ["DatasourceViews"],
         "security": [
           {
             "BearerAuth": []
@@ -2337,9 +2165,7 @@
                         }
                       }
                     },
-                    "required": [
-                      "parentsIn"
-                    ]
+                    "required": ["parentsIn"]
                   },
                   {
                     "type": "object",
@@ -2392,9 +2218,7 @@
         }
       },
       "delete": {
-        "tags": [
-          "DatasourceViews"
-        ],
+        "tags": ["DatasourceViews"],
         "security": [
           {
             "BearerAuth": []
@@ -2450,9 +2274,7 @@
       "get": {
         "summary": "Search the data source view",
         "description": "Search the data source view identified by {dsvId} in the workspace identified by {wId}.",
-        "tags": [
-          "DatasourceViews"
-        ],
+        "tags": ["DatasourceViews"],
         "security": [
           {
             "BearerAuth": []
@@ -2649,9 +2471,7 @@
       "get": {
         "summary": "List Data Source Views",
         "description": "Retrieves a list of data source views for the specified space",
-        "tags": [
-          "DatasourceViews"
-        ],
+        "tags": ["DatasourceViews"],
         "security": [
           {
             "BearerAuth": []
@@ -2718,9 +2538,7 @@
       "get": {
         "summary": "Retrieve a document from a data source",
         "description": "Retrieve a document from a data source identified by {dsId} in the workspace identified by {wId}.",
-        "tags": [
-          "Datasources"
-        ],
+        "tags": ["Datasources"],
         "parameters": [
           {
             "in": "path",
@@ -2800,9 +2618,7 @@
       "post": {
         "summary": "Upsert a document in a data source",
         "description": "Upsert a document in a data source in the workspace identified by {wId}.",
-        "tags": [
-          "Datasources"
-        ],
+        "tags": ["Datasources"],
         "parameters": [
           {
             "in": "path",
@@ -2945,9 +2761,7 @@
       "delete": {
         "summary": "Delete a document from a data source",
         "description": "Delete a document from a data source in the workspace identified by {wId}.",
-        "tags": [
-          "Datasources"
-        ],
+        "tags": ["Datasources"],
         "parameters": [
           {
             "in": "path",
@@ -3034,9 +2848,7 @@
       "post": {
         "summary": "Update the parents of a document",
         "description": "Update the parents of a document in the data source identified by {dsId} in the workspace identified by {wId}.",
-        "tags": [
-          "Datasources"
-        ],
+        "tags": ["Datasources"],
         "parameters": [
           {
             "in": "path",
@@ -3129,9 +2941,7 @@
       "get": {
         "summary": "Get documents",
         "description": "Get documents in the data source identified by {dsId} in the workspace identified by {wId}.",
-        "tags": [
-          "Datasources"
-        ],
+        "tags": ["Datasources"],
         "security": [
           {
             "BearerAuth": []
@@ -3228,9 +3038,7 @@
       "get": {
         "summary": "Search the data source",
         "description": "Search the data source identified by {dsId} in the workspace identified by {wId}.",
-        "tags": [
-          "Datasources"
-        ],
+        "tags": ["Datasources"],
         "security": [
           {
             "BearerAuth": []
@@ -3427,9 +3235,7 @@
       "get": {
         "summary": "Get a table",
         "description": "Get a table in the data source identified by {dsId} in the workspace identified by {wId}.",
-        "tags": [
-          "Datasources"
-        ],
+        "tags": ["Datasources"],
         "security": [
           {
             "BearerAuth": []
@@ -3495,9 +3301,7 @@
       "delete": {
         "summary": "Delete a table",
         "description": "Delete a table in the data source identified by {dsId} in the workspace identified by {wId}.",
-        "tags": [
-          "Datasources"
-        ],
+        "tags": ["Datasources"],
         "security": [
           {
             "BearerAuth": []
@@ -3558,9 +3362,7 @@
       "get": {
         "summary": "Get a row",
         "description": "Get a row in the table identified by {tId} in the data source identified by {dsId} in the workspace identified by {wId}.",
-        "tags": [
-          "Datasources"
-        ],
+        "tags": ["Datasources"],
         "security": [
           {
             "BearerAuth": []
@@ -3635,9 +3437,7 @@
       "delete": {
         "summary": "Delete a row",
         "description": "Delete a row in the table identified by {tId} in the data source identified by {dsId} in the workspace identified by {wId}.",
-        "tags": [
-          "Datasources"
-        ],
+        "tags": ["Datasources"],
         "security": [
           {
             "BearerAuth": []
@@ -3707,9 +3507,7 @@
       "get": {
         "summary": "List rows",
         "description": "List rows in the table identified by {tId} in the data source identified by {dsId} in the workspace identified by {wId}.",
-        "tags": [
-          "Datasources"
-        ],
+        "tags": ["Datasources"],
         "security": [
           {
             "BearerAuth": []
@@ -3791,9 +3589,7 @@
       "post": {
         "summary": "Upsert rows",
         "description": "Upsert rows in the table identified by {tId} in the data source identified by {dsId} in the workspace identified by {wId}.",
-        "tags": [
-          "Datasources"
-        ],
+        "tags": ["Datasources"],
         "security": [
           {
             "BearerAuth": []
@@ -3871,9 +3667,7 @@
                                 "properties": {
                                   "type": {
                                     "type": "string",
-                                    "enum": [
-                                      "datetime"
-                                    ]
+                                    "enum": ["datetime"]
                                   },
                                   "epoch": {
                                     "type": "number"
@@ -3928,9 +3722,7 @@
       "get": {
         "summary": "Get tables",
         "description": "Get tables in the data source identified by {dsId} in the workspace identified by {wId}.",
-        "tags": [
-          "Datasources"
-        ],
+        "tags": ["Datasources"],
         "security": [
           {
             "BearerAuth": []
@@ -3987,9 +3779,7 @@
       "post": {
         "summary": "Upsert a table",
         "description": "Upsert a table in the data source identified by {dsId} in the workspace identified by {wId}.",
-        "tags": [
-          "Datasources"
-        ],
+        "tags": ["Datasources"],
         "security": [
           {
             "BearerAuth": []
@@ -4091,9 +3881,7 @@
       "get": {
         "summary": "Get data sources",
         "description": "Get data sources in the workspace identified by {wId}.",
-        "tags": [
-          "Datasources"
-        ],
+        "tags": ["Datasources"],
         "parameters": [
           {
             "in": "path",
@@ -4151,9 +3939,7 @@
       "get": {
         "summary": "List available MCP server views.",
         "description": "Retrieves a list of enabled MCP server views (aka tools) for a specific space of the authenticated workspace.",
-        "tags": [
-          "Tools"
-        ],
+        "tags": ["Tools"],
         "security": [
           {
             "BearerAuth": []
@@ -4220,9 +4006,7 @@
       "get": {
         "summary": "List available spaces.",
         "description": "Retrieves a list of accessible spaces for the authenticated workspace.",
-        "tags": [
-          "Spaces"
-        ],
+        "tags": ["Spaces"],
         "security": [
           {
             "BearerAuth": []
@@ -4280,9 +4064,7 @@
       "get": {
         "summary": "Get workspace usage data",
         "description": "Get usage data for the workspace identified by {wId} in CSV or JSON format.",
-        "tags": [
-          "Workspace"
-        ],
+        "tags": ["Workspace"],
         "security": [
           {
             "BearerAuth": []
@@ -4323,10 +4105,7 @@
             "description": "The mode of date range selection",
             "schema": {
               "type": "string",
-              "enum": [
-                "month",
-                "range"
-              ]
+              "enum": ["month", "range"]
             }
           },
           {
@@ -4336,10 +4115,7 @@
             "description": "The output format of the data (defaults to 'csv')",
             "schema": {
               "type": "string",
-              "enum": [
-                "csv",
-                "json"
-              ]
+              "enum": ["csv", "json"]
             }
           },
           {
@@ -4511,10 +4287,7 @@
               "type": "string",
               "description": "Feature flags enabled for the workspace"
             },
-            "example": [
-              "advanced_analytics",
-              "beta_features"
-            ]
+            "example": ["advanced_analytics", "beta_features"]
           },
           "ssoEnforced": {
             "type": "boolean",
@@ -4526,10 +4299,7 @@
               "type": "string",
               "description": "List of allowed authentication providers"
             },
-            "example": [
-              "google",
-              "github"
-            ]
+            "example": ["google", "github"]
           },
           "defaultEmbeddingProvider": {
             "type": "string",
@@ -4541,10 +4311,7 @@
       },
       "Context": {
         "type": "object",
-        "required": [
-          "username",
-          "timezone"
-        ],
+        "required": ["username", "timezone"],
         "properties": {
           "username": {
             "type": "string",
@@ -4841,10 +4608,7 @@
       },
       "Message": {
         "type": "object",
-        "required": [
-          "content",
-          "mentions"
-        ],
+        "required": ["content", "mentions"],
         "properties": {
           "content": {
             "type": "string",
@@ -4865,9 +4629,7 @@
       },
       "ContentFragment": {
         "type": "object",
-        "required": [
-          "title"
-        ],
+        "required": ["title"],
         "properties": {
           "title": {
             "type": "string",
@@ -4922,12 +4684,7 @@
           },
           "kind": {
             "type": "string",
-            "enum": [
-              "regular",
-              "global",
-              "system",
-              "public"
-            ],
+            "enum": ["regular", "global", "system", "public"],
             "description": "The kind of the space"
           },
           "groupIds": {
@@ -5027,13 +4784,7 @@
                 "value_type": {
                   "type": "string",
                   "description": "Data type of the column",
-                  "enum": [
-                    "text",
-                    "int",
-                    "float",
-                    "bool",
-                    "date"
-                  ],
+                  "enum": ["text", "int", "float", "bool", "date"],
                   "example": "int"
                 },
                 "possible_values": {
@@ -5043,11 +4794,7 @@
                     "type": "string"
                   },
                   "nullable": true,
-                  "example": [
-                    "1",
-                    "2",
-                    "3"
-                  ]
+                  "example": ["1", "2", "3"]
                 }
               }
             }
@@ -5078,9 +4825,7 @@
             "items": {
               "type": "string"
             },
-            "example": [
-              "1234f4567c"
-            ]
+            "example": ["1234f4567c"]
           }
         }
       },
@@ -5089,12 +4834,7 @@
         "properties": {
           "category": {
             "type": "string",
-            "enum": [
-              "managed",
-              "folder",
-              "website",
-              "apps"
-            ],
+            "enum": ["managed", "folder", "website", "apps"],
             "description": "The category of the data source view"
           },
           "createdAt": {
@@ -5124,10 +4864,7 @@
           },
           "kind": {
             "type": "string",
-            "enum": [
-              "default",
-              "custom"
-            ],
+            "enum": ["default", "custom"],
             "description": "The kind of the data source view"
           },
           "parentsIn": {
@@ -5247,10 +4984,7 @@
             "items": {
               "type": "string"
             },
-            "example": [
-              "customer_support",
-              "faq"
-            ]
+            "example": ["customer_support", "faq"]
           },
           "parent_id": {
             "type": "string",
@@ -5265,10 +4999,7 @@
             "items": {
               "type": "string"
             },
-            "example": [
-              "7b9d1f3e5a",
-              "2c4a6e8d0f"
-            ]
+            "example": ["7b9d1f3e5a", "2c4a6e8d0f"]
           },
           "source_url": {
             "type": "string",
@@ -5296,22 +5027,12 @@
               {
                 "chunk_id": "9f1d3b5a7c",
                 "text": "This is the first chunk of the document.",
-                "embedding": [
-                  0.1,
-                  0.2,
-                  0.3,
-                  0.4
-                ]
+                "embedding": [0.1, 0.2, 0.3, 0.4]
               },
               {
                 "chunk_id": "4a2c6e8b0d",
                 "text": "This is the second chunk of the document.",
-                "embedding": [
-                  0.5,
-                  0.6,
-                  0.7,
-                  0.8
-                ]
+                "embedding": [0.5, 0.6, 0.7, 0.8]
               }
             ]
           },
@@ -5368,10 +5089,7 @@
           },
           "serverType": {
             "type": "string",
-            "enum": [
-              "remote",
-              "internal"
-            ],
+            "enum": ["remote", "internal"],
             "description": "Type of the MCP server",
             "example": "remote"
           },
@@ -5416,15 +5134,10 @@
                     "type": "array",
                     "items": {
                       "type": "string",
-                      "enum": [
-                        "platform_actions",
-                        "personal_actions"
-                      ]
+                      "enum": ["platform_actions", "personal_actions"]
                     },
                     "description": "Supported use cases for the authorization",
-                    "example": [
-                      "platform_actions"
-                    ]
+                    "example": ["platform_actions"]
                   },
                   "scope": {
                     "type": "string",
@@ -5484,10 +5197,7 @@
           "oAuthUseCase": {
             "type": "string",
             "nullable": true,
-            "enum": [
-              "platform_actions",
-              "personal_actions"
-            ],
+            "enum": ["platform_actions", "personal_actions"],
             "description": "OAuth use case for the MCP server view",
             "example": "platform_actions"
           },

--- a/front/public/swagger.json
+++ b/front/public/swagger.json
@@ -24,7 +24,9 @@
       "get": {
         "summary": "List agents",
         "description": "Get the agent configurations for the workspace identified by {wId}.",
-        "tags": ["Agents"],
+        "tags": [
+          "Agents"
+        ],
         "parameters": [
           {
             "in": "path",
@@ -59,7 +61,10 @@
             "description": "When set to 'true', includes recent authors information for each agent",
             "schema": {
               "type": "string",
-              "enum": ["true", "false"]
+              "enum": [
+                "true",
+                "false"
+              ]
             }
           }
         ],
@@ -110,7 +115,9 @@
       "get": {
         "summary": "Get agent configuration",
         "description": "Retrieve the agent configuration identified by {sId} in the workspace identified by {wId}.",
-        "tags": ["Agents"],
+        "tags": [
+          "Agents"
+        ],
         "parameters": [
           {
             "in": "path",
@@ -137,7 +144,10 @@
             "description": "Configuration variant to retrieve. 'light' returns basic config without actions, 'full' includes complete actions/tools configuration",
             "schema": {
               "type": "string",
-              "enum": ["light", "full"],
+              "enum": [
+                "light",
+                "full"
+              ],
               "default": "light"
             }
           }
@@ -183,7 +193,9 @@
       "patch": {
         "summary": "Update agent configuration",
         "description": "Update the agent configuration identified by {sId} in the workspace identified by {wId}.",
-        "tags": ["Agents"],
+        "tags": [
+          "Agents"
+        ],
         "parameters": [
           {
             "in": "path",
@@ -262,7 +274,9 @@
       "get": {
         "summary": "Search agents by name",
         "description": "Search for agent configurations by name in the workspace identified by {wId}.",
-        "tags": ["Agents"],
+        "tags": [
+          "Agents"
+        ],
         "parameters": [
           {
             "in": "path",
@@ -327,7 +341,9 @@
     },
     "/api/v1/w/{wId}/assistant/conversations/{cId}/cancel": {
       "post": {
-        "tags": ["Conversations"],
+        "tags": [
+          "Conversations"
+        ],
         "summary": "Cancel message generation in a conversation",
         "parameters": [
           {
@@ -360,7 +376,9 @@
             "application/json": {
               "schema": {
                 "type": "object",
-                "required": ["messageIds"],
+                "required": [
+                  "messageIds"
+                ],
                 "properties": {
                   "messageIds": {
                     "type": "array",
@@ -404,7 +422,9 @@
       "post": {
         "summary": "Create a content fragment",
         "description": "Create a new content fragment in the workspace identified by {wId}.",
-        "tags": ["Conversations"],
+        "tags": [
+          "Conversations"
+        ],
         "parameters": [
           {
             "in": "path",
@@ -467,7 +487,9 @@
       "get": {
         "summary": "Get the events for a conversation",
         "description": "Get the events for a conversation in the workspace identified by {wId}.",
-        "tags": ["Conversations"],
+        "tags": [
+          "Conversations"
+        ],
         "parameters": [
           {
             "in": "path",
@@ -528,7 +550,9 @@
       "get": {
         "summary": "Get feedbacks for a conversation",
         "description": "Retrieves all feedback entries for a specific conversation.\nRequires authentication and read:conversation scope.\n",
-        "tags": ["Feedbacks"],
+        "tags": [
+          "Feedbacks"
+        ],
         "parameters": [
           {
             "name": "wId",
@@ -581,7 +605,10 @@
                           },
                           "thumbDirection": {
                             "type": "string",
-                            "enum": ["up", "down"],
+                            "enum": [
+                              "up",
+                              "down"
+                            ],
                             "description": "Direction of the thumb feedback"
                           },
                           "content": {
@@ -635,7 +662,9 @@
       "get": {
         "summary": "Get a conversation",
         "description": "Get a conversation in the workspace identified by {wId}.",
-        "tags": ["Conversations"],
+        "tags": [
+          "Conversations"
+        ],
         "security": [
           {
             "BearerAuth": []
@@ -688,11 +717,92 @@
             "description": "Internal Server Error."
           }
         }
+      },
+      "patch": {
+        "summary": "Mark a conversation as read",
+        "description": "Mark a conversation as read in the workspace identified by {wId}.",
+        "tags": [
+          "Conversations"
+        ],
+        "security": [
+          {
+            "OauthToken": []
+          }
+        ],
+        "parameters": [
+          {
+            "in": "path",
+            "name": "wId",
+            "required": true,
+            "description": "ID of the workspace",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "path",
+            "name": "cId",
+            "required": true,
+            "description": "ID of the conversation",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "read": {
+                    "type": "boolean"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Conversation marked as read successfully.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "success": {
+                      "type": "boolean"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request. Invalid or missing parameters."
+          },
+          "401": {
+            "description": "Unauthorized. Invalid or missing authentication token."
+          },
+          "404": {
+            "description": "Conversation not found."
+          },
+          "405": {
+            "description": "Method not supported. Only GET or PATCH is expected."
+          },
+          "500": {
+            "description": "Internal Server Error."
+          }
+        }
       }
     },
     "/api/v1/w/{wId}/assistant/conversations/{cId}/messages/{mId}/edit": {
       "post": {
-        "tags": ["Conversations"],
+        "tags": [
+          "Conversations"
+        ],
         "summary": "Edit an existing message in a conversation",
         "parameters": [
           {
@@ -734,7 +844,10 @@
             "application/json": {
               "schema": {
                 "type": "object",
-                "required": ["content", "mentions"],
+                "required": [
+                  "content",
+                  "mentions"
+                ],
                 "properties": {
                   "content": {
                     "type": "string",
@@ -745,7 +858,9 @@
                     "description": "List of agent mentions in the message",
                     "items": {
                       "type": "object",
-                      "required": ["configurationId"],
+                      "required": [
+                        "configurationId"
+                      ],
                       "properties": {
                         "configurationId": {
                           "type": "string",
@@ -793,7 +908,9 @@
       "get": {
         "summary": "Get events for a message",
         "description": "Get events for a message in the workspace identified by {wId}.",
-        "tags": ["Conversations"],
+        "tags": [
+          "Conversations"
+        ],
         "parameters": [
           {
             "in": "path",
@@ -887,7 +1004,9 @@
       "post": {
         "summary": "Submit feedback for a specific message in a conversation",
         "description": "Submit user feedback (thumbs up/down) for a specific message in a conversation.\nRequires authentication and update:conversation scope.\n",
-        "tags": ["Feedbacks"],
+        "tags": [
+          "Feedbacks"
+        ],
         "parameters": [
           {
             "name": "wId",
@@ -928,11 +1047,16 @@
             "application/json": {
               "schema": {
                 "type": "object",
-                "required": ["thumbDirection"],
+                "required": [
+                  "thumbDirection"
+                ],
                 "properties": {
                   "thumbDirection": {
                     "type": "string",
-                    "enum": ["up", "down"],
+                    "enum": [
+                      "up",
+                      "down"
+                    ],
                     "description": "Direction of the thumb feedback"
                   },
                   "feedbackContent": {
@@ -978,7 +1102,9 @@
       "delete": {
         "summary": "Delete feedback for a specific message",
         "description": "Delete user feedback for a specific message in a conversation.\nRequires authentication and update:conversation scope.\n",
-        "tags": ["Feedbacks"],
+        "tags": [
+          "Feedbacks"
+        ],
         "parameters": [
           {
             "name": "wId",
@@ -1045,7 +1171,9 @@
       "post": {
         "summary": "Validate an action in a conversation message",
         "description": "Approves or rejects an action taken in a specific message in a conversation",
-        "tags": ["Conversations"],
+        "tags": [
+          "Conversations"
+        ],
         "parameters": [
           {
             "in": "path",
@@ -1081,7 +1209,10 @@
             "application/json": {
               "schema": {
                 "type": "object",
-                "required": ["actionId", "approved"],
+                "required": [
+                  "actionId",
+                  "approved"
+                ],
                 "properties": {
                   "actionId": {
                     "type": "string",
@@ -1136,7 +1267,9 @@
       "post": {
         "summary": "Create a message",
         "description": "Create a message in the workspace identified by {wId} in the conversation identified by {cId}.",
-        "tags": ["Conversations"],
+        "tags": [
+          "Conversations"
+        ],
         "parameters": [
           {
             "in": "path",
@@ -1202,7 +1335,9 @@
       "post": {
         "summary": "Create a new conversation",
         "description": "Create a new conversation in the workspace identified by {wId}.",
-        "tags": ["Conversations"],
+        "tags": [
+          "Conversations"
+        ],
         "parameters": [
           {
             "in": "path",
@@ -1225,7 +1360,9 @@
             "application/json": {
               "schema": {
                 "type": "object",
-                "required": ["message"],
+                "required": [
+                  "message"
+                ],
                 "properties": {
                   "message": {
                     "$ref": "#/components/schemas/Message"
@@ -1285,7 +1422,9 @@
     },
     "/api/v1/w/{wId}/files": {
       "post": {
-        "tags": ["Conversations"],
+        "tags": [
+          "Conversations"
+        ],
         "summary": "Create a file upload URL",
         "parameters": [
           {
@@ -1384,7 +1523,9 @@
       "post": {
         "summary": "Update heartbeat for a client-side MCP server",
         "description": "[Documentation](https://docs.dust.tt/docs/client-side-mcp-server)\nUpdate the heartbeat for a previously registered client-side MCP server.\nThis extends the TTL for the server registration.\n",
-        "tags": ["MCP"],
+        "tags": [
+          "MCP"
+        ],
         "security": [
           {
             "BearerAuth": []
@@ -1407,7 +1548,9 @@
             "application/json": {
               "schema": {
                 "type": "object",
-                "required": ["serverId"],
+                "required": [
+                  "serverId"
+                ],
                 "properties": {
                   "serverId": {
                     "type": "string",
@@ -1457,7 +1600,9 @@
       "post": {
         "summary": "Register a client-side MCP server",
         "description": "[Documentation](https://docs.dust.tt/docs/client-side-mcp-server)\nRegister a client-side MCP server to Dust.\nThe registration is scoped to the current user and workspace.\nA serverId identifier is generated and returned in the response.\n",
-        "tags": ["MCP"],
+        "tags": [
+          "MCP"
+        ],
         "security": [
           {
             "BearerAuth": []
@@ -1480,7 +1625,9 @@
             "application/json": {
               "schema": {
                 "type": "object",
-                "required": ["serverName"],
+                "required": [
+                  "serverName"
+                ],
                 "properties": {
                   "serverName": {
                     "type": "string",
@@ -1527,7 +1674,9 @@
       "get": {
         "summary": "Stream MCP tool requests for a workspace",
         "description": "[Documentation](https://docs.dust.tt/docs/client-side-mcp-server)\nServer-Sent Events (SSE) endpoint that streams MCP tool requests for a workspace.\nThis endpoint is used by client-side MCP servers to listen for tool requests in real-time.\nThe connection will remain open and events will be sent as new tool requests are made.\n",
-        "tags": ["MCP"],
+        "tags": [
+          "MCP"
+        ],
         "security": [
           {
             "BearerAuth": []
@@ -1602,7 +1751,9 @@
       "post": {
         "summary": "Submit MCP tool execution results",
         "description": "[Documentation](https://docs.dust.tt/docs/client-side-mcp-server)\nEndpoint for client-side MCP servers to submit the results of tool executions.\nThis endpoint accepts the output from tools that were executed locally.\n",
-        "tags": ["MCP"],
+        "tags": [
+          "MCP"
+        ],
         "security": [
           {
             "BearerAuth": []
@@ -1625,7 +1776,10 @@
             "application/json": {
               "schema": {
                 "type": "object",
-                "required": ["result", "serverId"],
+                "required": [
+                  "result",
+                  "serverId"
+                ],
                 "properties": {
                   "result": {
                     "type": "object",
@@ -1666,7 +1820,9 @@
       "post": {
         "summary": "Search for nodes in the workspace",
         "description": "Search for nodes in the workspace",
-        "tags": ["Search"],
+        "tags": [
+          "Search"
+        ],
         "parameters": [
           {
             "in": "path",
@@ -1689,7 +1845,9 @@
             "application/json": {
               "schema": {
                 "type": "object",
-                "required": ["query"],
+                "required": [
+                  "query"
+                ],
                 "properties": {
                   "query": {
                     "type": "string",
@@ -1749,7 +1907,9 @@
       "get": {
         "summary": "Get an app run",
         "description": "Retrieve a run for an app in the space identified by {spaceId}.",
-        "tags": ["Apps"],
+        "tags": [
+          "Apps"
+        ],
         "security": [
           {
             "BearerAuth": []
@@ -1822,7 +1982,9 @@
       "post": {
         "summary": "Create an app run",
         "description": "Create and execute a run for an app in the space specified by {spaceId}.",
-        "tags": ["Apps"],
+        "tags": [
+          "Apps"
+        ],
         "security": [
           {
             "BearerAuth": []
@@ -1863,7 +2025,11 @@
             "application/json": {
               "schema": {
                 "type": "object",
-                "required": ["specification_hash", "config", "inputs"],
+                "required": [
+                  "specification_hash",
+                  "config",
+                  "inputs"
+                ],
                 "properties": {
                   "specification_hash": {
                     "type": "string",
@@ -1963,7 +2129,9 @@
       "get": {
         "summary": "List apps",
         "description": "Get all apps in the space identified by {spaceId}.",
-        "tags": ["Apps"],
+        "tags": [
+          "Apps"
+        ],
         "security": [
           {
             "BearerAuth": []
@@ -2062,7 +2230,9 @@
     },
     "/api/v1/w/{wId}/spaces/{spaceId}/data_source_views/{dsvId}": {
       "get": {
-        "tags": ["DatasourceViews"],
+        "tags": [
+          "DatasourceViews"
+        ],
         "security": [
           {
             "BearerAuth": []
@@ -2115,7 +2285,9 @@
         }
       },
       "patch": {
-        "tags": ["DatasourceViews"],
+        "tags": [
+          "DatasourceViews"
+        ],
         "security": [
           {
             "BearerAuth": []
@@ -2165,7 +2337,9 @@
                         }
                       }
                     },
-                    "required": ["parentsIn"]
+                    "required": [
+                      "parentsIn"
+                    ]
                   },
                   {
                     "type": "object",
@@ -2218,7 +2392,9 @@
         }
       },
       "delete": {
-        "tags": ["DatasourceViews"],
+        "tags": [
+          "DatasourceViews"
+        ],
         "security": [
           {
             "BearerAuth": []
@@ -2274,7 +2450,9 @@
       "get": {
         "summary": "Search the data source view",
         "description": "Search the data source view identified by {dsvId} in the workspace identified by {wId}.",
-        "tags": ["DatasourceViews"],
+        "tags": [
+          "DatasourceViews"
+        ],
         "security": [
           {
             "BearerAuth": []
@@ -2471,7 +2649,9 @@
       "get": {
         "summary": "List Data Source Views",
         "description": "Retrieves a list of data source views for the specified space",
-        "tags": ["DatasourceViews"],
+        "tags": [
+          "DatasourceViews"
+        ],
         "security": [
           {
             "BearerAuth": []
@@ -2538,7 +2718,9 @@
       "get": {
         "summary": "Retrieve a document from a data source",
         "description": "Retrieve a document from a data source identified by {dsId} in the workspace identified by {wId}.",
-        "tags": ["Datasources"],
+        "tags": [
+          "Datasources"
+        ],
         "parameters": [
           {
             "in": "path",
@@ -2618,7 +2800,9 @@
       "post": {
         "summary": "Upsert a document in a data source",
         "description": "Upsert a document in a data source in the workspace identified by {wId}.",
-        "tags": ["Datasources"],
+        "tags": [
+          "Datasources"
+        ],
         "parameters": [
           {
             "in": "path",
@@ -2761,7 +2945,9 @@
       "delete": {
         "summary": "Delete a document from a data source",
         "description": "Delete a document from a data source in the workspace identified by {wId}.",
-        "tags": ["Datasources"],
+        "tags": [
+          "Datasources"
+        ],
         "parameters": [
           {
             "in": "path",
@@ -2848,7 +3034,9 @@
       "post": {
         "summary": "Update the parents of a document",
         "description": "Update the parents of a document in the data source identified by {dsId} in the workspace identified by {wId}.",
-        "tags": ["Datasources"],
+        "tags": [
+          "Datasources"
+        ],
         "parameters": [
           {
             "in": "path",
@@ -2941,7 +3129,9 @@
       "get": {
         "summary": "Get documents",
         "description": "Get documents in the data source identified by {dsId} in the workspace identified by {wId}.",
-        "tags": ["Datasources"],
+        "tags": [
+          "Datasources"
+        ],
         "security": [
           {
             "BearerAuth": []
@@ -3038,7 +3228,9 @@
       "get": {
         "summary": "Search the data source",
         "description": "Search the data source identified by {dsId} in the workspace identified by {wId}.",
-        "tags": ["Datasources"],
+        "tags": [
+          "Datasources"
+        ],
         "security": [
           {
             "BearerAuth": []
@@ -3235,7 +3427,9 @@
       "get": {
         "summary": "Get a table",
         "description": "Get a table in the data source identified by {dsId} in the workspace identified by {wId}.",
-        "tags": ["Datasources"],
+        "tags": [
+          "Datasources"
+        ],
         "security": [
           {
             "BearerAuth": []
@@ -3301,7 +3495,9 @@
       "delete": {
         "summary": "Delete a table",
         "description": "Delete a table in the data source identified by {dsId} in the workspace identified by {wId}.",
-        "tags": ["Datasources"],
+        "tags": [
+          "Datasources"
+        ],
         "security": [
           {
             "BearerAuth": []
@@ -3362,7 +3558,9 @@
       "get": {
         "summary": "Get a row",
         "description": "Get a row in the table identified by {tId} in the data source identified by {dsId} in the workspace identified by {wId}.",
-        "tags": ["Datasources"],
+        "tags": [
+          "Datasources"
+        ],
         "security": [
           {
             "BearerAuth": []
@@ -3437,7 +3635,9 @@
       "delete": {
         "summary": "Delete a row",
         "description": "Delete a row in the table identified by {tId} in the data source identified by {dsId} in the workspace identified by {wId}.",
-        "tags": ["Datasources"],
+        "tags": [
+          "Datasources"
+        ],
         "security": [
           {
             "BearerAuth": []
@@ -3507,7 +3707,9 @@
       "get": {
         "summary": "List rows",
         "description": "List rows in the table identified by {tId} in the data source identified by {dsId} in the workspace identified by {wId}.",
-        "tags": ["Datasources"],
+        "tags": [
+          "Datasources"
+        ],
         "security": [
           {
             "BearerAuth": []
@@ -3589,7 +3791,9 @@
       "post": {
         "summary": "Upsert rows",
         "description": "Upsert rows in the table identified by {tId} in the data source identified by {dsId} in the workspace identified by {wId}.",
-        "tags": ["Datasources"],
+        "tags": [
+          "Datasources"
+        ],
         "security": [
           {
             "BearerAuth": []
@@ -3667,7 +3871,9 @@
                                 "properties": {
                                   "type": {
                                     "type": "string",
-                                    "enum": ["datetime"]
+                                    "enum": [
+                                      "datetime"
+                                    ]
                                   },
                                   "epoch": {
                                     "type": "number"
@@ -3722,7 +3928,9 @@
       "get": {
         "summary": "Get tables",
         "description": "Get tables in the data source identified by {dsId} in the workspace identified by {wId}.",
-        "tags": ["Datasources"],
+        "tags": [
+          "Datasources"
+        ],
         "security": [
           {
             "BearerAuth": []
@@ -3779,7 +3987,9 @@
       "post": {
         "summary": "Upsert a table",
         "description": "Upsert a table in the data source identified by {dsId} in the workspace identified by {wId}.",
-        "tags": ["Datasources"],
+        "tags": [
+          "Datasources"
+        ],
         "security": [
           {
             "BearerAuth": []
@@ -3881,7 +4091,9 @@
       "get": {
         "summary": "Get data sources",
         "description": "Get data sources in the workspace identified by {wId}.",
-        "tags": ["Datasources"],
+        "tags": [
+          "Datasources"
+        ],
         "parameters": [
           {
             "in": "path",
@@ -4008,7 +4220,9 @@
       "get": {
         "summary": "List available spaces.",
         "description": "Retrieves a list of accessible spaces for the authenticated workspace.",
-        "tags": ["Spaces"],
+        "tags": [
+          "Spaces"
+        ],
         "security": [
           {
             "BearerAuth": []
@@ -4066,7 +4280,9 @@
       "get": {
         "summary": "Get workspace usage data",
         "description": "Get usage data for the workspace identified by {wId} in CSV or JSON format.",
-        "tags": ["Workspace"],
+        "tags": [
+          "Workspace"
+        ],
         "security": [
           {
             "BearerAuth": []
@@ -4107,7 +4323,10 @@
             "description": "The mode of date range selection",
             "schema": {
               "type": "string",
-              "enum": ["month", "range"]
+              "enum": [
+                "month",
+                "range"
+              ]
             }
           },
           {
@@ -4117,7 +4336,10 @@
             "description": "The output format of the data (defaults to 'csv')",
             "schema": {
               "type": "string",
-              "enum": ["csv", "json"]
+              "enum": [
+                "csv",
+                "json"
+              ]
             }
           },
           {
@@ -4289,7 +4511,10 @@
               "type": "string",
               "description": "Feature flags enabled for the workspace"
             },
-            "example": ["advanced_analytics", "beta_features"]
+            "example": [
+              "advanced_analytics",
+              "beta_features"
+            ]
           },
           "ssoEnforced": {
             "type": "boolean",
@@ -4301,7 +4526,10 @@
               "type": "string",
               "description": "List of allowed authentication providers"
             },
-            "example": ["google", "github"]
+            "example": [
+              "google",
+              "github"
+            ]
           },
           "defaultEmbeddingProvider": {
             "type": "string",
@@ -4313,7 +4541,10 @@
       },
       "Context": {
         "type": "object",
-        "required": ["username", "timezone"],
+        "required": [
+          "username",
+          "timezone"
+        ],
         "properties": {
           "username": {
             "type": "string",
@@ -4610,7 +4841,10 @@
       },
       "Message": {
         "type": "object",
-        "required": ["content", "mentions"],
+        "required": [
+          "content",
+          "mentions"
+        ],
         "properties": {
           "content": {
             "type": "string",
@@ -4631,7 +4865,9 @@
       },
       "ContentFragment": {
         "type": "object",
-        "required": ["title"],
+        "required": [
+          "title"
+        ],
         "properties": {
           "title": {
             "type": "string",
@@ -4686,7 +4922,12 @@
           },
           "kind": {
             "type": "string",
-            "enum": ["regular", "global", "system", "public"],
+            "enum": [
+              "regular",
+              "global",
+              "system",
+              "public"
+            ],
             "description": "The kind of the space"
           },
           "groupIds": {
@@ -4786,7 +5027,13 @@
                 "value_type": {
                   "type": "string",
                   "description": "Data type of the column",
-                  "enum": ["text", "int", "float", "bool", "date"],
+                  "enum": [
+                    "text",
+                    "int",
+                    "float",
+                    "bool",
+                    "date"
+                  ],
                   "example": "int"
                 },
                 "possible_values": {
@@ -4796,7 +5043,11 @@
                     "type": "string"
                   },
                   "nullable": true,
-                  "example": ["1", "2", "3"]
+                  "example": [
+                    "1",
+                    "2",
+                    "3"
+                  ]
                 }
               }
             }
@@ -4827,7 +5078,9 @@
             "items": {
               "type": "string"
             },
-            "example": ["1234f4567c"]
+            "example": [
+              "1234f4567c"
+            ]
           }
         }
       },
@@ -4836,7 +5089,12 @@
         "properties": {
           "category": {
             "type": "string",
-            "enum": ["managed", "folder", "website", "apps"],
+            "enum": [
+              "managed",
+              "folder",
+              "website",
+              "apps"
+            ],
             "description": "The category of the data source view"
           },
           "createdAt": {
@@ -4866,7 +5124,10 @@
           },
           "kind": {
             "type": "string",
-            "enum": ["default", "custom"],
+            "enum": [
+              "default",
+              "custom"
+            ],
             "description": "The kind of the data source view"
           },
           "parentsIn": {
@@ -4986,7 +5247,10 @@
             "items": {
               "type": "string"
             },
-            "example": ["customer_support", "faq"]
+            "example": [
+              "customer_support",
+              "faq"
+            ]
           },
           "parent_id": {
             "type": "string",
@@ -5001,7 +5265,10 @@
             "items": {
               "type": "string"
             },
-            "example": ["7b9d1f3e5a", "2c4a6e8d0f"]
+            "example": [
+              "7b9d1f3e5a",
+              "2c4a6e8d0f"
+            ]
           },
           "source_url": {
             "type": "string",
@@ -5029,12 +5296,22 @@
               {
                 "chunk_id": "9f1d3b5a7c",
                 "text": "This is the first chunk of the document.",
-                "embedding": [0.1, 0.2, 0.3, 0.4]
+                "embedding": [
+                  0.1,
+                  0.2,
+                  0.3,
+                  0.4
+                ]
               },
               {
                 "chunk_id": "4a2c6e8b0d",
                 "text": "This is the second chunk of the document.",
-                "embedding": [0.5, 0.6, 0.7, 0.8]
+                "embedding": [
+                  0.5,
+                  0.6,
+                  0.7,
+                  0.8
+                ]
               }
             ]
           },

--- a/front/public/swagger.json
+++ b/front/public/swagger.json
@@ -3939,7 +3939,9 @@
       "get": {
         "summary": "List available MCP server views.",
         "description": "Retrieves a list of enabled MCP server views (aka tools) for a specific space of the authenticated workspace.",
-        "tags": ["Tools"],
+        "tags": [
+          "Tools"
+        ],
         "security": [
           {
             "BearerAuth": []
@@ -5089,7 +5091,10 @@
           },
           "serverType": {
             "type": "string",
-            "enum": ["remote", "internal"],
+            "enum": [
+              "remote",
+              "internal"
+            ],
             "description": "Type of the MCP server",
             "example": "remote"
           },
@@ -5134,10 +5139,15 @@
                     "type": "array",
                     "items": {
                       "type": "string",
-                      "enum": ["platform_actions", "personal_actions"]
+                      "enum": [
+                        "platform_actions",
+                        "personal_actions"
+                      ]
                     },
                     "description": "Supported use cases for the authorization",
-                    "example": ["platform_actions"]
+                    "example": [
+                      "platform_actions"
+                    ]
                   },
                   "scope": {
                     "type": "string",
@@ -5197,7 +5207,10 @@
           "oAuthUseCase": {
             "type": "string",
             "nullable": true,
-            "enum": ["platform_actions", "personal_actions"],
+            "enum": [
+              "platform_actions",
+              "personal_actions"
+            ],
             "description": "OAuth use case for the MCP server view",
             "example": "platform_actions"
           },

--- a/front/types/files.ts
+++ b/front/types/files.ts
@@ -31,11 +31,7 @@ export type FileUseCaseMetadata = {
   lastEditedByAgentConfigurationId?: string;
 };
 
-export const fileShareScopeSchema = z.enum([
-  "conversation_participants",
-  "workspace",
-  "public",
-]);
+export const fileShareScopeSchema = z.enum(["none", "workspace", "public"]);
 
 export type FileShareScope = z.infer<typeof fileShareScopeSchema>;
 

--- a/front/types/files.ts
+++ b/front/types/files.ts
@@ -31,7 +31,12 @@ export type FileUseCaseMetadata = {
   lastEditedByAgentConfigurationId?: string;
 };
 
-export const fileShareScopeSchema = z.enum(["none", "workspace", "public"]);
+export const fileShareScopeSchema = z.enum([
+  "none",
+  "workspace",
+  "public",
+  "conversation_participants",
+]);
 
 export type FileShareScope = z.infer<typeof fileShareScopeSchema>;
 

--- a/front/types/files.ts
+++ b/front/types/files.ts
@@ -35,6 +35,8 @@ export const fileShareScopeSchema = z.enum([
   "none",
   "workspace",
   "public",
+  // TODO(interactive-content/canvas): deprecated. Keep it for backward compatibility.
+  // Can be removed after migration (conversation_participants -> workspace) is done
   "conversation_participants",
 ]);
 


### PR DESCRIPTION
## Description

- Fixes https://github.com/dust-tt/tasks/issues/4081
- Introduce "none" scope to make a presentation private (default)
- conversation_participants is deprecated and has same behavior "workspace" 
-  Changes icon based on sharing scope to make it easier for the users to understand
- Introduce a `none` state where the file is not shared with anyone.

**note: will create a migration script to move all `conversation_participants` shareScope to `workspace` in the table `shareable_files`**

https://github.com/user-attachments/assets/9f17b1bf-6092-418e-8217-c7d105ff03c2

## Tests

- Content currently in scope `conversation_participants` should be visible as if was `workspace` scope
- If a content is given workspace scope it should only be visible if member of workspace (e.g not accessible in incognito)
- If content is given public scope it should be viewable by anyone (e.g visible in incognito)
- If content was in workspace or public and then given none scope it should not be visible by anyone

## Risk

Low/Medium. Need to focus on making sure it's backward compatible. No major risk otherwise.

## Deploy Plan

Deploy front