### PR TITLE
[Deep Research] Run_agent can overcome the 10mn timeout

### DIFF
--- a/front/lib/actions/mcp_execution.ts
+++ b/front/lib/actions/mcp_execution.ts
@@ -25,6 +25,7 @@ import {
   isBlobResource,
   isMCPProgressNotificationType,
   isResourceWithName,
+  isRunAgentQueryProgressOutput,
   isToolGeneratedFile,
 } from "@app/lib/actions/mcp_internal_actions/output_schemas";
 import type { ToolBlockedAwaitingInputError } from "@app/lib/actions/mcp_internal_actions/servers/run_agent/types";
@@ -102,6 +103,17 @@ export async function* executeMCPTool({
     } else if (event.type === "notification") {
       const { notification } = event;
       if (isMCPProgressNotificationType(notification)) {
+        // Specific handling for run_agent notifications indicating the tool has
+        // started and can be resumed: the action is updated to save the resumeState.
+        if (isRunAgentQueryProgressOutput(notification.params.data.output)) {
+          action.updateStepContext({
+            ...action.stepContext,
+            resumeState: {
+              userMessageId: notification.params.data.output.userMessageId,
+              conversationId: notification.params.data.output.conversationId,
+            },
+          });
+        }
         // Regular notifications, we yield them as is with the type "tool_notification".
         yield {
           type: "tool_notification",

--- a/front/lib/actions/mcp_execution.ts
+++ b/front/lib/actions/mcp_execution.ts
@@ -106,7 +106,7 @@ export async function* executeMCPTool({
         // Specific handling for run_agent notifications indicating the tool has
         // started and can be resumed: the action is updated to save the resumeState.
         if (isRunAgentQueryProgressOutput(notification.params.data.output)) {
-          action.updateStepContext({
+          await action.updateStepContext({
             ...action.stepContext,
             resumeState: {
               userMessageId: notification.params.data.output.userMessageId,

--- a/front/lib/actions/mcp_internal_actions/constants.ts
+++ b/front/lib/actions/mcp_internal_actions/constants.ts
@@ -938,7 +938,7 @@ The directive should be used to display a clickable version of the agent name in
     isRestricted: undefined,
     isPreview: false,
     tools_stakes: undefined,
-    tools_retry_policies: undefined,
+    tools_retry_policies: { default: "retry_on_interrupt" },
     timeoutMs: MAX_MCP_REQUEST_TIMEOUT_MS,
     serverInfo: {
       name: "run_agent",

--- a/front/lib/actions/mcp_internal_actions/output_schemas.ts
+++ b/front/lib/actions/mcp_internal_actions/output_schemas.ts
@@ -853,6 +853,7 @@ const NotificationRunAgentContentSchema = z.object({
   childAgentId: z.string(),
   conversationId: z.string(),
   query: z.string(),
+  userMessageId: z.string(),
 });
 
 type RunAgentQueryProgressOutput = z.infer<

--- a/front/lib/actions/mcp_internal_actions/servers/run_agent/index.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/run_agent/index.ts
@@ -310,6 +310,7 @@ export default async function createServer(
                 query,
                 childAgentId: childAgentId,
                 conversationId: conversation.sId,
+                userMessageId,
               },
             },
           },


### PR DESCRIPTION
## Description

Fixes https://github.com/dust-tt/tasks/issues/3945

Previously, subagents would be interrupted after reaching the 10mn timeout. Indefinitely extending the timeout was brittle. We now allow subagents to retry on such timeouts, and allow them not restarting from scratch and instead resume from where they left off, leveraging what was already done for subagent tool validation with the resumeState. The solution involves:

- Enabling the `retry_on_interrupt` policy for the `run_agent` tool
- Capturing and saving the conversation's `resumeState` (conversationId and userMessageId) when the agent starts (new conversation)
- Including the `userMessageId` in progress notifications (part of the resume state)

When an agent is interrupted and retried, it will now resume the existing conversation using the saved state.

## Risks

Blast radius: Agent interruption and retry behavior in MCP execution
Risk: low

## Deploy Plan

- Deploy front service