### PR TITLE
Add ability to split slack response to multiple messages via FF

### DIFF
--- a/connectors/src/api/webhooks/webhook_slack_bot.ts
+++ b/connectors/src/api/webhooks/webhook_slack_bot.ts
@@ -9,8 +9,7 @@ import type {
   SlackWebhookResBody,
 } from "@connectors/api/webhooks/slack/utils";
 import {
-  handleChatBotWithMessageSplitting,
-  handleChatBotWithMessageTruncation,
+  handleChatBot,
   isAppMentionMessage,
   isSlackWebhookEventReqBody,
   withTrace,
@@ -94,7 +93,7 @@ const _webhookSlackBotAPIHandler = async (
           await withTrace({
             "slack.team_id": teamId,
             "slack.app": "slack_bot",
-          })(handleChatBotWithMessageTruncation)(req, res, logger);
+          })(handleChatBot)(req, res, logger);
           break;
         }
         /**
@@ -148,7 +147,7 @@ const _webhookSlackBotAPIHandler = async (
             await withTrace({
               "slack.team_id": teamId,
               "slack.app": "slack_bot",
-            })(handleChatBotWithMessageTruncation)(req, res, logger);
+            })(handleChatBot)(req, res, logger);
           } else if (event.channel_type === "channel") {
             if (
               !event.bot_id &&
@@ -190,7 +189,7 @@ const _webhookSlackBotAPIHandler = async (
                   await withTrace({
                     "slack.team_id": teamId,
                     "slack.app": "slack_bot",
-                  })(handleChatBotWithMessageSplitting)(req, res, logger);
+                  })(handleChatBot)(req, res, logger);
                 }
               }
             }

--- a/connectors/src/connectors/slack/bot.ts
+++ b/connectors/src/connectors/slack/bot.ts
@@ -1347,4 +1347,3 @@ async function isAgentAccessingRestrictedSpace(
     );
   }
 }
-

--- a/connectors/src/connectors/slack/chat/stream_conversation_handler.ts
+++ b/connectors/src/connectors/slack/chat/stream_conversation_handler.ts
@@ -345,9 +345,11 @@ async function streamAgentAnswerToSlack(
           normalizeContentForSlack(formattedContent)
         );
 
-        const shouldSplitMessage = 
+        const shouldSplitMessage =
           slackContent.length > MAX_SLACK_MESSAGE_LENGTH
-            ? await getMessageSplittingFromFeatureFlag(conversationData.connector)
+            ? await getMessageSplittingFromFeatureFlag(
+                conversationData.connector
+              )
             : false;
 
         if (shouldSplitMessage) {

--- a/front/types/shared/feature_flags.ts
+++ b/front/types/shared/feature_flags.ts
@@ -173,6 +173,11 @@ export const WHITELISTABLE_FEATURES_CONFIG = {
     description: "Slideshow MCP tool",
     stage: "dust_only",
   },
+  slack_message_splitting: {
+    description:
+      "Enable splitting agent responses into multiple Slack messages for Slack (instead of truncation)",
+    stage: "dust_only",
+  },
 } as const satisfies Record<string, FeatureFlag>;
 
 export type FeatureFlagStage = "dust_only" | "rolling_out" | "on_demand";

--- a/sdks/js/src/types.ts
+++ b/sdks/js/src/types.ts
@@ -628,6 +628,7 @@ const WhitelistableFeaturesSchema = FlexibleEnumSchema<
   | "show_debug_tools"
   | "slack_semantic_search"
   | "slack_enhanced_default_agent"
+  | "slack_message_splitting"
   | "slideshow"
   | "usage_data_api"
   | "xai_feature"


### PR DESCRIPTION
## Description

* Customers were requested ability to split agent response into multiple messages instead of truncating. It is unclear if we want this for all customers, so moving to enable this via a dedicated FF
* Now keeping logic consistent b/w message and app_mention events

## Tests

* Validated in test Slack workspace

## Risk

* Not expected to change logic for any existing customers (will enable FF for the customer that relies on message split)

## Deploy Plan

1. Deploy front
2. Deploy connector