### PR TITLE
Fix folder pagination

### DIFF
--- a/front/components/spaces/SpaceResourcesList.tsx
+++ b/front/components/spaces/SpaceResourcesList.tsx
@@ -375,6 +375,7 @@ export const SpaceResourcesList = ({
           onClick: () => onSelect(dataSourceView.sId),
         };
       });
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- onSelect is not stable, mutating the agents list which prevent pagination to work
   }, [
     spaceDataSourceViews,
     owner.sId,
@@ -383,7 +384,6 @@ export const SpaceResourcesList = ({
     isWebsiteOrFolder,
     canWriteInSpace,
     isFolder,
-    onSelect,
     isDark,
   ]);
 


### PR DESCRIPTION
## Description

This is similar to what was done in https://github.com/dust-tt/dust/pull/15366/files. The `onSelect` useMemo dependency does not compare in a stable way, so messes things up. We just remove it from the dependency list.

Fixes https://github.com/dust-tt/tasks/issues/4076

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
