### PR TITLE
Core: log errors from datasource tokenize

### DIFF
--- a/core/src/databases/remote_databases/bigquery.rs
+++ b/core/src/databases/remote_databases/bigquery.rs
@@ -9,9 +9,7 @@ use gcp_bigquery_client::{
     model::{
         field_type::FieldType, get_query_results_parameters::GetQueryResultsParameters, job::Job,
         job_configuration::JobConfiguration, job_configuration_query::JobConfigurationQuery,
-        job_reference::JobReference, query_parameter::QueryParameter,
-        query_parameter_type::QueryParameterType, query_parameter_value::QueryParameterValue,
-        query_request::QueryRequest, table_row::TableRow,
+        job_reference::JobReference, table_row::TableRow,
     },
     yup_oauth2::ServiceAccountKey,
     Client,


### PR DESCRIPTION
## Description

Adding some error logs on core to understand the issue we have with tokenizing text. 
Currently on the error logs from connectors we have only this: [Logs](https://app.datadoghq.eu/logs?query=%22Error%20tokenizing%20text%20for%22&agg_m=count&agg_m_source=base&agg_t=count&clustering_pattern_field_path=message&cols=host%2Cservice%2C%40textPreview&event=AwAAAZkyzuGhglIDVwAAABhBWmt5enZTdEFBRGhVRjFTX1hkaHJ3QUQAAAAkZjE5OTMyZDItY2M1My00NWVlLWE1ZDUtNzJkM2M1OTRiNmY4AAIufw&fromUser=true&messageDisplay=inline&refresh_mode=sliding&storage=hot&stream_sort=time%2Cdesc&viz=stream&from_ts=1757350174651&to_ts=1757436574651&live=true).

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

Can be rolled back. 

## Deploy Plan

Deploy core. 