### PR TITLE
[front] client error boundary

### DIFF
--- a/front/components/assistant/conversation/ConversationError.tsx
+++ b/front/components/assistant/conversation/ConversationError.tsx
@@ -70,7 +70,7 @@ interface ErrorDisplayProps {
   title: string;
 }
 
-function ErrorDisplay({ icon, message, title }: ErrorDisplayProps) {
+export function ErrorDisplay({ icon, message, title }: ErrorDisplayProps) {
   return (
     <div className="flex h-screen flex-col items-center justify-center gap-1">
       {icon && (

--- a/front/components/assistant/conversation/ConversationLayout.tsx
+++ b/front/components/assistant/conversation/ConversationLayout.tsx
@@ -5,7 +5,10 @@ import React, { useMemo } from "react";
 import { BlockedActionsProvider } from "@app/components/assistant/conversation/BlockedActionsProvider";
 import { CoEditionProvider } from "@app/components/assistant/conversation/co_edition/CoEditionProvider";
 import { CONVERSATION_VIEW_SCROLL_LAYOUT } from "@app/components/assistant/conversation/constant";
-import { ConversationErrorDisplay } from "@app/components/assistant/conversation/ConversationError";
+import {
+  ConversationErrorDisplay,
+  ErrorDisplay,
+} from "@app/components/assistant/conversation/ConversationError";
 import ConversationSidePanelContainer from "@app/components/assistant/conversation/ConversationSidePanelContainer";
 import { ConversationSidePanelProvider } from "@app/components/assistant/conversation/ConversationSidePanelContext";
 import { useConversationSidePanelContext } from "@app/components/assistant/conversation/ConversationSidePanelContext";
@@ -21,6 +24,7 @@ import { AssistantSidebarMenu } from "@app/components/assistant/conversation/Sid
 import { AssistantDetails } from "@app/components/assistant/details/AssistantDetails";
 import { WelcomeTourGuide } from "@app/components/assistant/WelcomeTourGuide";
 import { useWelcomeTourGuide } from "@app/components/assistant/WelcomeTourGuideProvider";
+import { ErrorBoundary } from "@app/components/error_boundary/ErrorBoundary";
 import AppContentLayout from "@app/components/sparkle/AppContentLayout";
 import { useURLSheet } from "@app/hooks/useURLSheet";
 import { useConversation } from "@app/lib/swr/conversations";
@@ -189,6 +193,18 @@ interface ConversationInnerLayoutProps {
   activeConversationId: string | null;
 }
 
+function UncaughtConversationErrorFallback() {
+  return (
+    <ErrorDisplay
+      title="Something unexpected happened"
+      message={[
+        "Try refreshing the page to continue your conversation.",
+        "Still having trouble? Reach out at support@dust.tt",
+      ]}
+    />
+  );
+}
+
 function ConversationInnerLayout({
   children,
   conversation,
@@ -200,42 +216,44 @@ function ConversationInnerLayout({
   const { currentPanel } = useConversationSidePanelContext();
 
   return (
-    <div className="flex h-full w-full flex-col">
-      <ResizablePanelGroup
-        direction="horizontal"
-        className="flex h-full w-full flex-1"
-      >
-        <ResizablePanel defaultSize={100}>
-          <div className="flex h-full flex-col">
-            {activeConversationId && (
-              <ConversationTitle owner={owner} baseUrl={baseUrl} />
-            )}
-            {conversationError ? (
-              <ConversationErrorDisplay error={conversationError} />
-            ) : (
-              <FileDropProvider>
-                <GenerationContextProvider>
-                  <div
-                    id={CONVERSATION_VIEW_SCROLL_LAYOUT}
-                    className={cn(
-                      "dd-privacy-mask h-full overflow-y-auto scroll-smooth px-4",
-                      // Hide conversation on mobile when any panel is opened.
-                      currentPanel && "hidden md:block"
-                    )}
-                  >
-                    {children}
-                  </div>
-                </GenerationContextProvider>
-              </FileDropProvider>
-            )}
-          </div>
-        </ResizablePanel>
+    <ErrorBoundary fallback={<UncaughtConversationErrorFallback />}>
+      <div className="flex h-full w-full flex-col">
+        <ResizablePanelGroup
+          direction="horizontal"
+          className="flex h-full w-full flex-1"
+        >
+          <ResizablePanel defaultSize={100}>
+            <div className="flex h-full flex-col">
+              {activeConversationId && (
+                <ConversationTitle owner={owner} baseUrl={baseUrl} />
+              )}
+              {conversationError ? (
+                <ConversationErrorDisplay error={conversationError} />
+              ) : (
+                <FileDropProvider>
+                  <GenerationContextProvider>
+                    <div
+                      id={CONVERSATION_VIEW_SCROLL_LAYOUT}
+                      className={cn(
+                        "dd-privacy-mask h-full overflow-y-auto scroll-smooth px-4",
+                        // Hide conversation on mobile when any panel is opened.
+                        currentPanel && "hidden md:block"
+                      )}
+                    >
+                      {children}
+                    </div>
+                  </GenerationContextProvider>
+                </FileDropProvider>
+              )}
+            </div>
+          </ResizablePanel>
 
-        <ConversationSidePanelContainer
-          owner={owner}
-          conversation={conversation}
-        />
-      </ResizablePanelGroup>
-    </div>
+          <ConversationSidePanelContainer
+            owner={owner}
+            conversation={conversation}
+          />
+        </ResizablePanelGroup>
+      </div>
+    </ErrorBoundary>
   );
 }

--- a/front/components/error_boundary/ErrorBoundary.tsx
+++ b/front/components/error_boundary/ErrorBoundary.tsx
@@ -1,4 +1,3 @@
-import { datadogLogs } from "@datadog/browser-logs";
 import * as React from "react";
 
 interface ErrorBoundaryProps {
@@ -24,8 +23,8 @@ export class ErrorBoundary extends React.Component<
   }
 
   componentDidCatch(error: Error) {
-    // This will send a log to Datadog RUM + log so no need to manually log it
-    console.error(error);
+    // This will send an error to Datadog RUM + logs so no need to manually log it
+    console.error("Uncaught client side error: ", error);
   }
 
   render() {

--- a/front/components/error_boundary/ErrorBoundary.tsx
+++ b/front/components/error_boundary/ErrorBoundary.tsx
@@ -1,0 +1,44 @@
+import { datadogLogs } from "@datadog/browser-logs";
+import * as React from "react";
+
+interface ErrorBoundaryProps {
+  children: React.ReactNode;
+  fallback: React.ReactNode;
+}
+
+interface ErrorBoundaryState {
+  hasError: boolean;
+}
+
+export class ErrorBoundary extends React.Component<
+  ErrorBoundaryProps,
+  ErrorBoundaryState
+> {
+  constructor(props: ErrorBoundaryProps) {
+    super(props);
+    this.state = { hasError: false };
+  }
+
+  static getDerivedStateFromError(): ErrorBoundaryState {
+    return { hasError: true };
+  }
+
+  componentDidCatch(error: Error, info: React.ErrorInfo) {
+    // TODO (yuka): check with Ben what is the best way to log this error
+    console.error(error);
+    datadogLogs.logger.error(error.name || "Uncaught client side error", {
+      error,
+      errorInfo: {
+        componentStack: info.componentStack,
+      },
+    });
+  }
+
+  render() {
+    if (this.state.hasError) {
+      return this.props.fallback;
+    }
+
+    return this.props.children;
+  }
+}

--- a/front/components/error_boundary/ErrorBoundary.tsx
+++ b/front/components/error_boundary/ErrorBoundary.tsx
@@ -23,15 +23,9 @@ export class ErrorBoundary extends React.Component<
     return { hasError: true };
   }
 
-  componentDidCatch(error: Error, info: React.ErrorInfo) {
-    // TODO (yuka): check with Ben what is the best way to log this error
+  componentDidCatch(error: Error) {
+    // This will send a log to Datadog RUM + log so no need to manually log it
     console.error(error);
-    datadogLogs.logger.error(error.name || "Uncaught client side error", {
-      error,
-      errorInfo: {
-        componentStack: info.componentStack,
-      },
-    });
   }
 
   render() {


### PR DESCRIPTION
Reverting revert of error boundary 🙃

I chatted with Ben, and he suggested me to try https://docs.datadoghq.com/integrations/rum-react/ but since I didn't have a chance to take a look at I will simply revert the revert. He told me that if I don't need to manually log since console.error will also send a log too I'm skipping it. 

## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
