### PR TITLE
[Hootl] Add webhook trigger support with webhookSourceViewId field

### DIFF
--- a/front/components/agent_builder/AgentBuilderFormContext.tsx
+++ b/front/components/agent_builder/AgentBuilderFormContext.tsx
@@ -191,12 +191,16 @@ const scheduleConfigSchema = z.object({
   timezone: z.string(),
 });
 
+const webhookConfigSchema = z.object({
+  webhookSourceViewId: z.string(),
+});
+
 const triggerSchema = z.object({
   sId: z.string().optional(),
   name: z.string(),
-  kind: z.enum(["schedule"]),
+  kind: z.enum(["schedule", "webhook"]),
   customPrompt: z.string().nullable(),
-  configuration: z.union([scheduleConfigSchema, z.null()]),
+  configuration: z.union([scheduleConfigSchema, webhookConfigSchema, z.null()]),
   editor: z.number().nullable(),
 });
 

--- a/front/components/agent_builder/triggers/ScheduleEditionModal.tsx
+++ b/front/components/agent_builder/triggers/ScheduleEditionModal.tsx
@@ -74,10 +74,16 @@ export function ScheduleEditionModal({
 
   const { reset } = form;
   useEffect(() => {
+    const scheduleConfig =
+      trigger?.kind === "schedule" &&
+      trigger?.configuration &&
+      "cron" in trigger.configuration
+        ? trigger.configuration
+        : null;
     reset({
       name: trigger?.name ?? defaultValues.name,
-      cron: trigger?.configuration?.cron ?? defaultValues.cron,
-      timezone: trigger?.configuration?.timezone ?? defaultValues.timezone,
+      cron: scheduleConfig?.cron ?? defaultValues.cron,
+      timezone: scheduleConfig?.timezone ?? defaultValues.timezone,
       customPrompt: trigger?.customPrompt ?? defaultValues.customPrompt,
     });
   }, [
@@ -169,7 +175,11 @@ export function ScheduleEditionModal({
                   <Label htmlFor="trigger-description">Scheduler</Label>
                   <p className="text-sm text-muted-foreground dark:text-muted-foreground-night">
                     The trigger will run in the{" "}
-                    {trigger?.configuration?.timezone ||
+                    {(trigger?.kind === "schedule" &&
+                    trigger?.configuration &&
+                    "timezone" in trigger.configuration
+                      ? trigger.configuration.timezone
+                      : null) ||
                       Intl.DateTimeFormat().resolvedOptions().timeZone}{" "}
                     timezone.
                   </p>

--- a/front/components/agent_builder/triggers/TriggerCard.tsx
+++ b/front/components/agent_builder/triggers/TriggerCard.tsx
@@ -37,14 +37,20 @@ export const TriggerCard = ({
   const isEditor = trigger.editor === user?.id;
   const cronDescription = useMemo(() => {
     try {
-      if (trigger.configuration?.cron) {
-        return `Runs ${cronstrue.toString(trigger.configuration?.cron)}.`;
+      if (
+        trigger.kind === "schedule" &&
+        trigger.configuration &&
+        "cron" in trigger.configuration
+      ) {
+        return `Runs ${cronstrue.toString(trigger.configuration.cron)}.`;
+      } else if (trigger.kind === "webhook") {
+        return "Triggered by webhook.";
       }
     } catch (error) {
       // Ignore.
     }
     return "";
-  }, [trigger.configuration?.cron]);
+  }, [trigger.kind, trigger.configuration]);
 
   return (
     <Card

--- a/front/components/assistant_builder/types.ts
+++ b/front/components/assistant_builder/types.ts
@@ -27,13 +27,18 @@ import type { TagType } from "@app/types/tag";
 export type AssistantBuilderTriggerType = {
   sId?: string;
   name: string;
-  kind: "schedule";
+  kind: "schedule" | "webhook";
   customPrompt: string | null;
   editor: UserType["id"] | null;
-  configuration: {
-    cron: string;
-    timezone: string;
-  } | null;
+  configuration:
+    | {
+        cron: string;
+        timezone: string;
+      }
+    | {
+        webhookSourceViewId: string;
+      }
+    | null;
 };
 
 // MCP configuration

--- a/front/temporal/agent_schedule/client.ts
+++ b/front/temporal/agent_schedule/client.ts
@@ -18,6 +18,13 @@ function getScheduleOptions(
   trigger: TriggerResource,
   scheduleId: string
 ): ScheduleOptions {
+  if (trigger.kind !== "schedule") {
+    throw new Error("Cannot create schedule for non-schedule trigger");
+  }
+  const configuration = trigger.configuration as {
+    cron: string;
+    timezone: string;
+  };
   return {
     action: {
       type: "startWorkflow",
@@ -34,8 +41,8 @@ function getScheduleOptions(
       overlap: ScheduleOverlapPolicy.SKIP,
     },
     spec: {
-      cronExpressions: [trigger.configuration.cron],
-      timezone: trigger.configuration.timezone,
+      cronExpressions: [configuration.cron],
+      timezone: configuration.timezone,
     },
   };
 }

--- a/front/types/assistant/triggers.ts
+++ b/front/types/assistant/triggers.ts
@@ -9,12 +9,21 @@ export type ScheduleConfig = {
   timezone: string;
 };
 
-export type TriggerConfigurationType = ScheduleConfig;
-
-export type TriggerConfiguration = {
-  kind: "schedule";
-  configuration: ScheduleConfig;
+export type WebhookConfig = {
+  webhookSourceViewId: string;
 };
+
+export type TriggerConfigurationType = ScheduleConfig | WebhookConfig;
+
+export type TriggerConfiguration =
+  | {
+      kind: "schedule";
+      configuration: ScheduleConfig;
+    }
+  | {
+      kind: "webhook";
+      configuration: WebhookConfig;
+    };
 
 export type TriggerType = {
   id: ModelId;
@@ -30,7 +39,7 @@ export type TriggerType = {
 export type TriggerKind = TriggerType["kind"];
 
 export function isValidTriggerKind(kind: string): kind is TriggerKind {
-  return ["schedule"].includes(kind);
+  return ["schedule", "webhook"].includes(kind);
 }
 
 const ScheduleConfigSchema = t.type({
@@ -38,9 +47,21 @@ const ScheduleConfigSchema = t.type({
   timezone: t.string,
 });
 
-export const TriggerSchema = t.type({
-  name: t.string,
-  kind: t.literal("schedule"),
-  customPrompt: t.string,
-  configuration: ScheduleConfigSchema,
+const WebhookConfigSchema = t.type({
+  webhookSourceViewId: t.string,
 });
+
+export const TriggerSchema = t.union([
+  t.type({
+    name: t.string,
+    kind: t.literal("schedule"),
+    customPrompt: t.string,
+    configuration: ScheduleConfigSchema,
+  }),
+  t.type({
+    name: t.string,
+    kind: t.literal("webhook"),
+    customPrompt: t.string,
+    configuration: WebhookConfigSchema,
+  }),
+]);


### PR DESCRIPTION
## Description
Fixes https://github.com/dust-tt/tasks/issues/4038

Adds support for webhook triggers with a mandatory `webhookSourceViewId` field. This enables agents to be triggered via webhooks in addition to the existing schedule-based triggers.

## Risks
Blast radius: Trigger system (agent configurations, trigger UI components)
Risk: low (additive change, maintains backward compatibility)

## Deploy Plan
- Deploy front service (no migrations needed as configuration is stored as JSONB)