### PR TITLE
Small improvements around tables in folders

### DIFF
--- a/core/admin/dev_sqlite_worker.sh
+++ b/core/admin/dev_sqlite_worker.sh
@@ -1,2 +1,2 @@
 #!/bin/sh
-IS_LOCAL_DEV=1 HOSTNAME=loc cargo run --bin sqlite-worker
+CORE_API_KEY=foo IS_LOCAL_DEV=1 HOSTNAME=loc cargo run --bin sqlite-worker

--- a/front/components/data_source/TableUploadOrEditModal.tsx
+++ b/front/components/data_source/TableUploadOrEditModal.tsx
@@ -34,6 +34,7 @@ import {
   isBigFileSize,
   isSlugified,
   MAX_FILE_SIZES,
+  truncate,
 } from "@app/types";
 
 interface Table {
@@ -411,7 +412,7 @@ export const TableUploadOrEditModal = ({
                         label: fileUploaderService.isProcessingFiles
                           ? "Uploading..."
                           : tableState.file
-                            ? tableState.file.name
+                            ? truncate(tableState.file.name, 24)
                             : initialId
                               ? "Replace file"
                               : "Upload file",


### PR DESCRIPTION
## Description

- Fix dev-setup command to run sqlite_workers.
- Truncate file name in header button when long which would otherwise overflow.

## Tests

Tested locally

## Risk

N/A

## Deploy Plan

- deploy `front`