### PR TITLE
[front] fix enabledTools logic in getMCPServerRequirements

### DIFF
--- a/front/lib/actions/mcp_internal_actions/input_configuration.ts
+++ b/front/lib/actions/mcp_internal_actions/input_configuration.ts
@@ -472,14 +472,16 @@ export function getMCPServerRequirements(
       })
     ).length > 0;
 
-  const enabledToolNames =
+  // If there is no toolsMetadata (= undefined or empty array), it means everything is enabled
+  const disabledToolNames =
     mcpServerView.toolsMetadata
-      ?.filter((tool) => tool.enabled)
+      ?.filter((tool) => tool.enabled === false)
       .map((tool) => tool.toolName) ?? [];
 
-  const enabledTools = server.tools.filter((tool) =>
-    enabledToolNames.includes(tool.name)
-  );
+  const enabledTools =
+    disabledToolNames.length > 0
+      ? server.tools.filter((tool) => !disabledToolNames.includes(tool.name))
+      : server.tools;
 
   const mayRequireTimeFrameConfiguration = enabledTools.some(
     (tool) => tool.inputSchema?.properties?.timeFrame


### PR DESCRIPTION
## Description

Seems like `mcpServerView.toolsMetadata` will be an empty array when nothing is disabled, but we currently treat it in the opposite way which introduce a bug in Agent Builder (you don't see the correct fields in configuration panel, reported here: https://dust4ai.slack.com/archives/C050SM8NSPK/p1757504593100059)

I tested in AB and it seems to work but I lack the context, if you can test in other places that would be great 🙏

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
