### PR TITLE
Automatically add default values into configs

### DIFF
--- a/front/lib/actions/mcp_internal_actions/input_configuration.test.ts
+++ b/front/lib/actions/mcp_internal_actions/input_configuration.test.ts
@@ -1114,4 +1114,657 @@ describe("augmentInputsWithConfiguration", () => {
       });
     });
   });
+
+  describe("default value injection", () => {
+    describe("STRING mime type", () => {
+      it("should inject object-level default for missing string value", () => {
+        const rawInputs = {};
+        const config = createBasicMCPConfiguration({
+          inputSchema: {
+            type: "object",
+            properties: {
+              stringParam: {
+                type: "object",
+                properties: {
+                  value: { type: "string" },
+                  mimeType: {
+                    type: "string",
+                    const: INTERNAL_MIME_TYPES.TOOL_INPUT.STRING,
+                  },
+                },
+                required: ["value", "mimeType"],
+                default: {
+                  value: "default-string-value",
+                  mimeType: INTERNAL_MIME_TYPES.TOOL_INPUT.STRING,
+                },
+              },
+            },
+            required: ["stringParam"],
+          },
+          additionalConfiguration: {},
+        });
+
+        const result = augmentInputsWithConfiguration({
+          owner: mockWorkspace,
+          rawInputs,
+          actionConfiguration: config,
+        });
+
+        expect(result).toEqual({
+          stringParam: {
+            value: "default-string-value",
+            mimeType: INTERNAL_MIME_TYPES.TOOL_INPUT.STRING,
+          },
+        });
+      });
+
+      it("should inject property-level default for missing string value", () => {
+        const rawInputs = {};
+        const config = createBasicMCPConfiguration({
+          inputSchema: {
+            type: "object",
+            properties: {
+              stringParam: ConfigurableToolInputJSONSchemas[
+                INTERNAL_MIME_TYPES.TOOL_INPUT.STRING
+              ],
+            },
+            required: ["stringParam"],
+          },
+          additionalConfiguration: {},
+        });
+
+        // Manually modify the schema to add property-level default
+        if (config.inputSchema.properties?.stringParam && 
+            typeof config.inputSchema.properties.stringParam === 'object' &&
+            config.inputSchema.properties.stringParam.properties?.value &&
+            typeof config.inputSchema.properties.stringParam.properties.value === 'object') {
+          config.inputSchema.properties.stringParam.properties.value.default = "property-level-default";
+        }
+
+        const result = augmentInputsWithConfiguration({
+          owner: mockWorkspace,
+          rawInputs,
+          actionConfiguration: config,
+        });
+
+        expect(result).toEqual({
+          stringParam: {
+            value: "property-level-default",
+            mimeType: INTERNAL_MIME_TYPES.TOOL_INPUT.STRING,
+          },
+        });
+      });
+
+      it("should not inject default when value is already provided", () => {
+        const rawInputs = {};
+        const config = createBasicMCPConfiguration({
+          inputSchema: {
+            type: "object",
+            properties: {
+              stringParam: {
+                ...ConfigurableToolInputJSONSchemas[INTERNAL_MIME_TYPES.TOOL_INPUT.STRING],
+                default: {
+                  value: "should-not-be-used",
+                  mimeType: INTERNAL_MIME_TYPES.TOOL_INPUT.STRING,
+                },
+              },
+            },
+            required: ["stringParam"],
+          },
+          additionalConfiguration: {
+            stringParam: "user-provided-value",
+          },
+        });
+
+        const result = augmentInputsWithConfiguration({
+          owner: mockWorkspace,
+          rawInputs,
+          actionConfiguration: config,
+        });
+
+        expect(result).toEqual({
+          stringParam: {
+            value: "user-provided-value",
+            mimeType: INTERNAL_MIME_TYPES.TOOL_INPUT.STRING,
+          },
+        });
+      });
+    });
+
+    describe("NUMBER mime type", () => {
+      it("should inject object-level default for missing number value", () => {
+        const rawInputs = {};
+        const config = createBasicMCPConfiguration({
+          inputSchema: {
+            type: "object",
+            properties: {
+              numberParam: {
+                type: "object",
+                properties: {
+                  value: { type: "number" },
+                  mimeType: {
+                    type: "string",
+                    const: INTERNAL_MIME_TYPES.TOOL_INPUT.NUMBER,
+                  },
+                },
+                required: ["value", "mimeType"],
+                default: {
+                  value: 42,
+                  mimeType: INTERNAL_MIME_TYPES.TOOL_INPUT.NUMBER,
+                },
+              },
+            },
+            required: ["numberParam"],
+          },
+          additionalConfiguration: {},
+        });
+
+        const result = augmentInputsWithConfiguration({
+          owner: mockWorkspace,
+          rawInputs,
+          actionConfiguration: config,
+        });
+
+        expect(result).toEqual({
+          numberParam: {
+            value: 42,
+            mimeType: INTERNAL_MIME_TYPES.TOOL_INPUT.NUMBER,
+          },
+        });
+      });
+
+      it("should inject property-level default for missing number value", () => {
+        const rawInputs = {};
+        const config = createBasicMCPConfiguration({
+          inputSchema: {
+            type: "object",
+            properties: {
+              numberParam: ConfigurableToolInputJSONSchemas[
+                INTERNAL_MIME_TYPES.TOOL_INPUT.NUMBER
+              ],
+            },
+            required: ["numberParam"],
+          },
+          additionalConfiguration: {},
+        });
+
+        // Manually modify the schema to add property-level default
+        if (config.inputSchema.properties?.numberParam && 
+            typeof config.inputSchema.properties.numberParam === 'object' &&
+            config.inputSchema.properties.numberParam.properties?.value &&
+            typeof config.inputSchema.properties.numberParam.properties.value === 'object') {
+          config.inputSchema.properties.numberParam.properties.value.default = 100;
+        }
+
+        const result = augmentInputsWithConfiguration({
+          owner: mockWorkspace,
+          rawInputs,
+          actionConfiguration: config,
+        });
+
+        expect(result).toEqual({
+          numberParam: {
+            value: 100,
+            mimeType: INTERNAL_MIME_TYPES.TOOL_INPUT.NUMBER,
+          },
+        });
+      });
+    });
+
+    describe("BOOLEAN mime type", () => {
+      it("should inject object-level default for missing boolean value", () => {
+        const rawInputs = {};
+        const config = createBasicMCPConfiguration({
+          inputSchema: {
+            type: "object",
+            properties: {
+              booleanParam: {
+                type: "object",
+                properties: {
+                  value: { type: "boolean" },
+                  mimeType: {
+                    type: "string",
+                    const: INTERNAL_MIME_TYPES.TOOL_INPUT.BOOLEAN,
+                  },
+                },
+                required: ["value", "mimeType"],
+                default: {
+                  value: true,
+                  mimeType: INTERNAL_MIME_TYPES.TOOL_INPUT.BOOLEAN,
+                },
+              },
+            },
+            required: ["booleanParam"],
+          },
+          additionalConfiguration: {},
+        });
+
+        const result = augmentInputsWithConfiguration({
+          owner: mockWorkspace,
+          rawInputs,
+          actionConfiguration: config,
+        });
+
+        expect(result).toEqual({
+          booleanParam: {
+            value: true,
+            mimeType: INTERNAL_MIME_TYPES.TOOL_INPUT.BOOLEAN,
+          },
+        });
+      });
+
+      it("should inject property-level default for missing boolean value", () => {
+        const rawInputs = {};
+        const config = createBasicMCPConfiguration({
+          inputSchema: {
+            type: "object",
+            properties: {
+              booleanParam: ConfigurableToolInputJSONSchemas[
+                INTERNAL_MIME_TYPES.TOOL_INPUT.BOOLEAN
+              ],
+            },
+            required: ["booleanParam"],
+          },
+          additionalConfiguration: {},
+        });
+
+        // Manually modify the schema to add property-level default
+        if (config.inputSchema.properties?.booleanParam && 
+            typeof config.inputSchema.properties.booleanParam === 'object' &&
+            config.inputSchema.properties.booleanParam.properties?.value &&
+            typeof config.inputSchema.properties.booleanParam.properties.value === 'object') {
+          config.inputSchema.properties.booleanParam.properties.value.default = false;
+        }
+
+        const result = augmentInputsWithConfiguration({
+          owner: mockWorkspace,
+          rawInputs,
+          actionConfiguration: config,
+        });
+
+        expect(result).toEqual({
+          booleanParam: {
+            value: false,
+            mimeType: INTERNAL_MIME_TYPES.TOOL_INPUT.BOOLEAN,
+          },
+        });
+      });
+    });
+
+    describe("ENUM mime type", () => {
+      it("should inject object-level default for missing enum value", () => {
+        const rawInputs = {};
+        const config = createBasicMCPConfiguration({
+          inputSchema: {
+            type: "object",
+            properties: {
+              enumParam: {
+                type: "object",
+                properties: {
+                  value: { 
+                    type: "string",
+                    enum: ["option1", "option2", "option3"]
+                  },
+                  mimeType: {
+                    type: "string",
+                    const: INTERNAL_MIME_TYPES.TOOL_INPUT.ENUM,
+                  },
+                },
+                required: ["value", "mimeType"],
+                default: {
+                  value: "option2",
+                  mimeType: INTERNAL_MIME_TYPES.TOOL_INPUT.ENUM,
+                },
+              },
+            },
+            required: ["enumParam"],
+          },
+          additionalConfiguration: {},
+        });
+
+        const result = augmentInputsWithConfiguration({
+          owner: mockWorkspace,
+          rawInputs,
+          actionConfiguration: config,
+        });
+
+        expect(result).toEqual({
+          enumParam: {
+            value: "option2",
+            mimeType: INTERNAL_MIME_TYPES.TOOL_INPUT.ENUM,
+          },
+        });
+      });
+
+      it("should inject property-level default for missing enum value", () => {
+        const rawInputs = {};
+        const config = createBasicMCPConfiguration({
+          inputSchema: {
+            type: "object",
+            properties: {
+              enumParam: {
+                type: "object",
+                properties: {
+                  value: { 
+                    type: "string",
+                    enum: ["red", "green", "blue"],
+                    default: "green"
+                  },
+                  mimeType: {
+                    type: "string",
+                    const: INTERNAL_MIME_TYPES.TOOL_INPUT.ENUM,
+                  },
+                },
+                required: ["value", "mimeType"],
+              },
+            },
+            required: ["enumParam"],
+          },
+          additionalConfiguration: {},
+        });
+
+        const result = augmentInputsWithConfiguration({
+          owner: mockWorkspace,
+          rawInputs,
+          actionConfiguration: config,
+        });
+
+        expect(result).toEqual({
+          enumParam: {
+            value: "green",
+            mimeType: INTERNAL_MIME_TYPES.TOOL_INPUT.ENUM,
+          },
+        });
+      });
+    });
+
+    describe("LIST mime type", () => {
+      it("should inject object-level default for missing list value", () => {
+        const rawInputs = {};
+        const config = createBasicMCPConfiguration({
+          inputSchema: {
+            type: "object",
+            properties: {
+              listParam: {
+                type: "object",
+                properties: {
+                  options: { type: "object" },
+                  values: { 
+                    type: "array",
+                    items: { type: "string" }
+                  },
+                  mimeType: {
+                    type: "string",
+                    const: INTERNAL_MIME_TYPES.TOOL_INPUT.LIST,
+                  },
+                },
+                required: ["options", "values", "mimeType"],
+                default: {
+                  values: ["default1", "default2"],
+                  mimeType: INTERNAL_MIME_TYPES.TOOL_INPUT.LIST,
+                },
+              },
+            },
+            required: ["listParam"],
+          },
+          additionalConfiguration: {},
+        });
+
+        const result = augmentInputsWithConfiguration({
+          owner: mockWorkspace,
+          rawInputs,
+          actionConfiguration: config,
+        });
+
+        expect(result).toEqual({
+          listParam: {
+            values: ["default1", "default2"],
+            mimeType: INTERNAL_MIME_TYPES.TOOL_INPUT.LIST,
+          },
+        });
+      });
+
+      it("should inject property-level default for missing list value", () => {
+        const rawInputs = {};
+        const config = createBasicMCPConfiguration({
+          inputSchema: {
+            type: "object",
+            properties: {
+              listParam: {
+                type: "object",
+                properties: {
+                  options: { type: "object" },
+                  values: { 
+                    type: "array",
+                    items: { type: "string" },
+                    default: ["prop1", "prop2", "prop3"]
+                  },
+                  mimeType: {
+                    type: "string",
+                    const: INTERNAL_MIME_TYPES.TOOL_INPUT.LIST,
+                  },
+                },
+                required: ["options", "values", "mimeType"],
+              },
+            },
+            required: ["listParam"],
+          },
+          additionalConfiguration: {},
+        });
+
+        const result = augmentInputsWithConfiguration({
+          owner: mockWorkspace,
+          rawInputs,
+          actionConfiguration: config,
+        });
+
+        expect(result).toEqual({
+          listParam: {
+            values: ["prop1", "prop2", "prop3"],
+            mimeType: INTERNAL_MIME_TYPES.TOOL_INPUT.LIST,
+          },
+        });
+      });
+
+      it("should inject default when list is empty", () => {
+        const rawInputs = {};
+        const config = createBasicMCPConfiguration({
+          inputSchema: {
+            type: "object",
+            properties: {
+              listParam: {
+                type: "object",
+                properties: {
+                  options: { type: "object" },
+                  values: { 
+                    type: "array",
+                    items: { type: "string" }
+                  },
+                  mimeType: {
+                    type: "string",
+                    const: INTERNAL_MIME_TYPES.TOOL_INPUT.LIST,
+                  },
+                },
+                required: ["options", "values", "mimeType"],
+                default: {
+                  options: {},
+                  values: ["fallback1", "fallback2"],
+                  mimeType: INTERNAL_MIME_TYPES.TOOL_INPUT.LIST,
+                },
+              },
+            },
+            required: ["listParam"],
+          },
+          additionalConfiguration: {
+            listParam: [], // Empty array should trigger default
+          },
+        });
+
+        const result = augmentInputsWithConfiguration({
+          owner: mockWorkspace,
+          rawInputs,
+          actionConfiguration: config,
+        });
+
+        expect(result).toEqual({
+          listParam: {
+            values: ["fallback1", "fallback2"],
+            mimeType: INTERNAL_MIME_TYPES.TOOL_INPUT.LIST,
+          },
+        });
+      });
+    });
+
+    describe("type safety", () => {
+      it("should ignore invalid object-level defaults with wrong types", () => {
+        const rawInputs = {};
+        const config = createBasicMCPConfiguration({
+          inputSchema: {
+            type: "object",
+            properties: {
+              stringParam: {
+                ...ConfigurableToolInputJSONSchemas[INTERNAL_MIME_TYPES.TOOL_INPUT.STRING],
+                default: {
+                  value: 123, // Wrong type - should be ignored
+                  mimeType: INTERNAL_MIME_TYPES.TOOL_INPUT.STRING,
+                },
+              },
+            },
+            required: ["stringParam"],
+          },
+          additionalConfiguration: {},
+        });
+
+        // Should throw because no valid default was found and value is required
+        expect(() => {
+          augmentInputsWithConfiguration({
+            owner: mockWorkspace,
+            rawInputs,
+            actionConfiguration: config,
+          });
+        }).toThrow("Expected string value for key stringParam");
+      });
+
+      it("should ignore invalid property-level defaults with wrong types", () => {
+        const rawInputs = {};
+        const config = createBasicMCPConfiguration({
+          inputSchema: {
+            type: "object",
+            properties: {
+              numberParam: ConfigurableToolInputJSONSchemas[
+                INTERNAL_MIME_TYPES.TOOL_INPUT.NUMBER
+              ],
+            },
+            required: ["numberParam"],
+          },
+          additionalConfiguration: {},
+        });
+
+        // Manually modify the schema to add invalid property-level default
+        if (config.inputSchema.properties?.numberParam && 
+            typeof config.inputSchema.properties.numberParam === 'object' &&
+            config.inputSchema.properties.numberParam.properties?.value &&
+            typeof config.inputSchema.properties.numberParam.properties.value === 'object') {
+          config.inputSchema.properties.numberParam.properties.value.default = "not-a-number";
+        }
+
+        // Should throw because no valid default was found and value is required
+        expect(() => {
+          augmentInputsWithConfiguration({
+            owner: mockWorkspace,
+            rawInputs,
+            actionConfiguration: config,
+          });
+        }).toThrow("Expected number value for key numberParam");
+      });
+
+      it("should ignore invalid list defaults with non-string elements", () => {
+        const rawInputs = {};
+        const config = createBasicMCPConfiguration({
+          inputSchema: {
+            type: "object",
+            properties: {
+              listParam: {
+                type: "object",
+                properties: {
+                  options: { type: "object" },
+                  values: { 
+                    type: "array",
+                    items: { type: "string" }
+                  },
+                  mimeType: {
+                    type: "string",
+                    const: INTERNAL_MIME_TYPES.TOOL_INPUT.LIST,
+                  },
+                },
+                required: ["options", "values", "mimeType"],
+                default: {
+                  options: {},
+                  values: ["valid", 123, "also-valid"], // Mixed types - should be ignored
+                  mimeType: INTERNAL_MIME_TYPES.TOOL_INPUT.LIST,
+                },
+              },
+            },
+            required: ["listParam"],
+          },
+          additionalConfiguration: {},
+        });
+
+        // Should throw because no valid default was found and value is required
+        expect(() => {
+          augmentInputsWithConfiguration({
+            owner: mockWorkspace,
+            rawInputs,
+            actionConfiguration: config,
+          });
+        }).toThrow("Expected array of string values for key listParam");
+      });
+    });
+
+    describe("nested paths", () => {
+      it("should inject defaults for nested object properties", () => {
+        const rawInputs = { nested: {} };
+        const config = createBasicMCPConfiguration({
+          inputSchema: {
+            type: "object",
+            properties: {
+              nested: {
+                type: "object",
+                properties: {
+                  stringParam: {
+                    ...ConfigurableToolInputJSONSchemas[INTERNAL_MIME_TYPES.TOOL_INPUT.STRING],
+                    default: {
+                      value: "nested-default",
+                      mimeType: INTERNAL_MIME_TYPES.TOOL_INPUT.STRING,
+                    },
+                  },
+                },
+                required: ["stringParam"],
+              },
+            },
+            required: ["nested"],
+          },
+          additionalConfiguration: {
+            // Use dot notation for nested properties - this will trigger default injection
+            // when the system can't find a valid value
+          },
+        });
+
+        const result = augmentInputsWithConfiguration({
+          owner: mockWorkspace,
+          rawInputs,
+          actionConfiguration: config,
+        });
+
+        expect(result).toEqual({
+          nested: {
+            stringParam: {
+              value: "nested-default",
+              mimeType: INTERNAL_MIME_TYPES.TOOL_INPUT.STRING,
+            },
+          },
+        });
+      });
+    });
+  });
 });

--- a/front/lib/actions/mcp_internal_actions/input_configuration.test.ts
+++ b/front/lib/actions/mcp_internal_actions/input_configuration.test.ts
@@ -1164,9 +1164,10 @@ describe("augmentInputsWithConfiguration", () => {
           inputSchema: {
             type: "object",
             properties: {
-              stringParam: ConfigurableToolInputJSONSchemas[
-                INTERNAL_MIME_TYPES.TOOL_INPUT.STRING
-              ],
+              stringParam:
+                ConfigurableToolInputJSONSchemas[
+                  INTERNAL_MIME_TYPES.TOOL_INPUT.STRING
+                ],
             },
             required: ["stringParam"],
           },
@@ -1174,11 +1175,15 @@ describe("augmentInputsWithConfiguration", () => {
         });
 
         // Manually modify the schema to add property-level default
-        if (config.inputSchema.properties?.stringParam && 
-            typeof config.inputSchema.properties.stringParam === 'object' &&
-            config.inputSchema.properties.stringParam.properties?.value &&
-            typeof config.inputSchema.properties.stringParam.properties.value === 'object') {
-          config.inputSchema.properties.stringParam.properties.value.default = "property-level-default";
+        if (
+          config.inputSchema.properties?.stringParam &&
+          typeof config.inputSchema.properties.stringParam === "object" &&
+          config.inputSchema.properties.stringParam.properties?.value &&
+          typeof config.inputSchema.properties.stringParam.properties.value ===
+            "object"
+        ) {
+          config.inputSchema.properties.stringParam.properties.value.default =
+            "property-level-default";
         }
 
         const result = augmentInputsWithConfiguration({
@@ -1202,7 +1207,9 @@ describe("augmentInputsWithConfiguration", () => {
             type: "object",
             properties: {
               stringParam: {
-                ...ConfigurableToolInputJSONSchemas[INTERNAL_MIME_TYPES.TOOL_INPUT.STRING],
+                ...ConfigurableToolInputJSONSchemas[
+                  INTERNAL_MIME_TYPES.TOOL_INPUT.STRING
+                ],
                 default: {
                   value: "should-not-be-used",
                   mimeType: INTERNAL_MIME_TYPES.TOOL_INPUT.STRING,
@@ -1279,9 +1286,10 @@ describe("augmentInputsWithConfiguration", () => {
           inputSchema: {
             type: "object",
             properties: {
-              numberParam: ConfigurableToolInputJSONSchemas[
-                INTERNAL_MIME_TYPES.TOOL_INPUT.NUMBER
-              ],
+              numberParam:
+                ConfigurableToolInputJSONSchemas[
+                  INTERNAL_MIME_TYPES.TOOL_INPUT.NUMBER
+                ],
             },
             required: ["numberParam"],
           },
@@ -1289,10 +1297,13 @@ describe("augmentInputsWithConfiguration", () => {
         });
 
         // Manually modify the schema to add property-level default
-        if (config.inputSchema.properties?.numberParam && 
-            typeof config.inputSchema.properties.numberParam === 'object' &&
-            config.inputSchema.properties.numberParam.properties?.value &&
-            typeof config.inputSchema.properties.numberParam.properties.value === 'object') {
+        if (
+          config.inputSchema.properties?.numberParam &&
+          typeof config.inputSchema.properties.numberParam === "object" &&
+          config.inputSchema.properties.numberParam.properties?.value &&
+          typeof config.inputSchema.properties.numberParam.properties.value ===
+            "object"
+        ) {
           config.inputSchema.properties.numberParam.properties.value.default = 100;
         }
 
@@ -1359,9 +1370,10 @@ describe("augmentInputsWithConfiguration", () => {
           inputSchema: {
             type: "object",
             properties: {
-              booleanParam: ConfigurableToolInputJSONSchemas[
-                INTERNAL_MIME_TYPES.TOOL_INPUT.BOOLEAN
-              ],
+              booleanParam:
+                ConfigurableToolInputJSONSchemas[
+                  INTERNAL_MIME_TYPES.TOOL_INPUT.BOOLEAN
+                ],
             },
             required: ["booleanParam"],
           },
@@ -1369,11 +1381,15 @@ describe("augmentInputsWithConfiguration", () => {
         });
 
         // Manually modify the schema to add property-level default
-        if (config.inputSchema.properties?.booleanParam && 
-            typeof config.inputSchema.properties.booleanParam === 'object' &&
-            config.inputSchema.properties.booleanParam.properties?.value &&
-            typeof config.inputSchema.properties.booleanParam.properties.value === 'object') {
-          config.inputSchema.properties.booleanParam.properties.value.default = false;
+        if (
+          config.inputSchema.properties?.booleanParam &&
+          typeof config.inputSchema.properties.booleanParam === "object" &&
+          config.inputSchema.properties.booleanParam.properties?.value &&
+          typeof config.inputSchema.properties.booleanParam.properties.value ===
+            "object"
+        ) {
+          config.inputSchema.properties.booleanParam.properties.value.default =
+            false;
         }
 
         const result = augmentInputsWithConfiguration({
@@ -1401,9 +1417,9 @@ describe("augmentInputsWithConfiguration", () => {
               enumParam: {
                 type: "object",
                 properties: {
-                  value: { 
+                  value: {
                     type: "string",
-                    enum: ["option1", "option2", "option3"]
+                    enum: ["option1", "option2", "option3"],
                   },
                   mimeType: {
                     type: "string",
@@ -1445,10 +1461,10 @@ describe("augmentInputsWithConfiguration", () => {
               enumParam: {
                 type: "object",
                 properties: {
-                  value: { 
+                  value: {
                     type: "string",
                     enum: ["red", "green", "blue"],
-                    default: "green"
+                    default: "green",
                   },
                   mimeType: {
                     type: "string",
@@ -1489,9 +1505,9 @@ describe("augmentInputsWithConfiguration", () => {
                 type: "object",
                 properties: {
                   options: { type: "object" },
-                  values: { 
+                  values: {
                     type: "array",
-                    items: { type: "string" }
+                    items: { type: "string" },
                   },
                   mimeType: {
                     type: "string",
@@ -1534,10 +1550,10 @@ describe("augmentInputsWithConfiguration", () => {
                 type: "object",
                 properties: {
                   options: { type: "object" },
-                  values: { 
+                  values: {
                     type: "array",
                     items: { type: "string" },
-                    default: ["prop1", "prop2", "prop3"]
+                    default: ["prop1", "prop2", "prop3"],
                   },
                   mimeType: {
                     type: "string",
@@ -1576,9 +1592,9 @@ describe("augmentInputsWithConfiguration", () => {
                 type: "object",
                 properties: {
                   options: { type: "object" },
-                  values: { 
+                  values: {
                     type: "array",
-                    items: { type: "string" }
+                    items: { type: "string" },
                   },
                   mimeType: {
                     type: "string",
@@ -1623,7 +1639,9 @@ describe("augmentInputsWithConfiguration", () => {
             type: "object",
             properties: {
               stringParam: {
-                ...ConfigurableToolInputJSONSchemas[INTERNAL_MIME_TYPES.TOOL_INPUT.STRING],
+                ...ConfigurableToolInputJSONSchemas[
+                  INTERNAL_MIME_TYPES.TOOL_INPUT.STRING
+                ],
                 default: {
                   value: 123, // Wrong type - should be ignored
                   mimeType: INTERNAL_MIME_TYPES.TOOL_INPUT.STRING,
@@ -1651,9 +1669,10 @@ describe("augmentInputsWithConfiguration", () => {
           inputSchema: {
             type: "object",
             properties: {
-              numberParam: ConfigurableToolInputJSONSchemas[
-                INTERNAL_MIME_TYPES.TOOL_INPUT.NUMBER
-              ],
+              numberParam:
+                ConfigurableToolInputJSONSchemas[
+                  INTERNAL_MIME_TYPES.TOOL_INPUT.NUMBER
+                ],
             },
             required: ["numberParam"],
           },
@@ -1661,11 +1680,15 @@ describe("augmentInputsWithConfiguration", () => {
         });
 
         // Manually modify the schema to add invalid property-level default
-        if (config.inputSchema.properties?.numberParam && 
-            typeof config.inputSchema.properties.numberParam === 'object' &&
-            config.inputSchema.properties.numberParam.properties?.value &&
-            typeof config.inputSchema.properties.numberParam.properties.value === 'object') {
-          config.inputSchema.properties.numberParam.properties.value.default = "not-a-number";
+        if (
+          config.inputSchema.properties?.numberParam &&
+          typeof config.inputSchema.properties.numberParam === "object" &&
+          config.inputSchema.properties.numberParam.properties?.value &&
+          typeof config.inputSchema.properties.numberParam.properties.value ===
+            "object"
+        ) {
+          config.inputSchema.properties.numberParam.properties.value.default =
+            "not-a-number";
         }
 
         // Should throw because no valid default was found and value is required
@@ -1688,9 +1711,9 @@ describe("augmentInputsWithConfiguration", () => {
                 type: "object",
                 properties: {
                   options: { type: "object" },
-                  values: { 
+                  values: {
                     type: "array",
-                    items: { type: "string" }
+                    items: { type: "string" },
                   },
                   mimeType: {
                     type: "string",
@@ -1732,7 +1755,9 @@ describe("augmentInputsWithConfiguration", () => {
                 type: "object",
                 properties: {
                   stringParam: {
-                    ...ConfigurableToolInputJSONSchemas[INTERNAL_MIME_TYPES.TOOL_INPUT.STRING],
+                    ...ConfigurableToolInputJSONSchemas[
+                      INTERNAL_MIME_TYPES.TOOL_INPUT.STRING
+                    ],
                     default: {
                       value: "nested-default",
                       mimeType: INTERNAL_MIME_TYPES.TOOL_INPUT.STRING,

--- a/front/lib/actions/mcp_internal_actions/input_configuration.ts
+++ b/front/lib/actions/mcp_internal_actions/input_configuration.ts
@@ -154,15 +154,17 @@ function generateConfiguredInput({
           if (
             typeof propSchema.default === "object" &&
             propSchema.default !== null &&
-            "value" in propSchema.default
+            "value" in propSchema.default &&
+            typeof propSchema.default.value === "string"
           ) {
-            value = propSchema.default.value as string;
+            value = propSchema.default.value;
           } else if (
             propSchema.properties?.value &&
             isJSONSchemaObject(propSchema.properties.value) &&
-            propSchema.properties.value.default !== undefined
+            propSchema.properties.value.default !== undefined &&
+            typeof propSchema.properties.value.default === "string"
           ) {
-            value = propSchema.properties.value.default as string;
+            value = propSchema.properties.value.default;
           }
         }
       }
@@ -188,15 +190,17 @@ function generateConfiguredInput({
           if (
             typeof propSchema.default === "object" &&
             propSchema.default !== null &&
-            "value" in propSchema.default
+            "value" in propSchema.default &&
+            typeof propSchema.default.value === "number"
           ) {
-            value = propSchema.default.value as number;
+            value = propSchema.default.value;
           } else if (
             propSchema.properties?.value &&
             isJSONSchemaObject(propSchema.properties.value) &&
-            propSchema.properties.value.default !== undefined
+            propSchema.properties.value.default !== undefined &&
+            typeof propSchema.properties.value.default === "number"
           ) {
-            value = propSchema.properties.value.default as number;
+            value = propSchema.properties.value.default;
           }
         }
       }
@@ -222,15 +226,17 @@ function generateConfiguredInput({
           if (
             typeof propSchema.default === "object" &&
             propSchema.default !== null &&
-            "value" in propSchema.default
+            "value" in propSchema.default &&
+            typeof propSchema.default.value === "boolean"
           ) {
-            value = propSchema.default.value as boolean;
+            value = propSchema.default.value;
           } else if (
             propSchema.properties?.value &&
             isJSONSchemaObject(propSchema.properties.value) &&
-            propSchema.properties.value.default !== undefined
+            propSchema.properties.value.default !== undefined &&
+            typeof propSchema.properties.value.default === "boolean"
           ) {
-            value = propSchema.properties.value.default as boolean;
+            value = propSchema.properties.value.default;
           }
         }
       }
@@ -256,15 +262,17 @@ function generateConfiguredInput({
           if (
             typeof propSchema.default === "object" &&
             propSchema.default !== null &&
-            "value" in propSchema.default
+            "value" in propSchema.default &&
+            typeof propSchema.default.value === "string"
           ) {
-            value = propSchema.default.value as string;
+            value = propSchema.default.value;
           } else if (
             propSchema.properties?.value &&
             isJSONSchemaObject(propSchema.properties.value) &&
-            propSchema.properties.value.default !== undefined
+            propSchema.properties.value.default !== undefined &&
+            typeof propSchema.properties.value.default === "string"
           ) {
-            value = propSchema.properties.value.default as string;
+            value = propSchema.properties.value.default;
           }
         }
       }
@@ -295,15 +303,17 @@ function generateConfiguredInput({
             typeof propSchema.default === "object" &&
             propSchema.default !== null &&
             "values" in propSchema.default &&
-            Array.isArray(propSchema.default.values)
+            Array.isArray(propSchema.default.values) &&
+            propSchema.default.values.every((v) => typeof v === "string")
           ) {
-            value = propSchema.default.values as string[];
+            value = propSchema.default.values;
           } else if (
             propSchema.properties?.values &&
             isJSONSchemaObject(propSchema.properties.values) &&
-            Array.isArray(propSchema.properties.values.default)
+            Array.isArray(propSchema.properties.values.default) &&
+            propSchema.properties.values.default.every((v) => typeof v === "string")
           ) {
-            value = propSchema.properties.values.default as string[];
+            value = propSchema.properties.values.default;
           }
         }
       }

--- a/front/lib/actions/mcp_internal_actions/input_configuration.ts
+++ b/front/lib/actions/mcp_internal_actions/input_configuration.ts
@@ -516,19 +516,16 @@ export interface MCPServerRequirements {
   requiresReasoningConfiguration: boolean;
   mayRequireTimeFrameConfiguration: boolean;
   mayRequireJsonSchemaConfiguration: boolean;
-  requiredStrings: { key: string; description?: string; default?: string }[];
-  requiredNumbers: { key: string; description?: string; default?: number }[];
-  requiredBooleans: { key: string; description?: string; default?: boolean }[];
-  requiredEnums: Record<
-    string,
-    { options: string[]; description?: string; default?: string }
-  >;
+  requiredStrings: { key: string; description?: string }[];
+  requiredNumbers: { key: string; description?: string }[];
+  requiredBooleans: { key: string; description?: string }[];
+  requiredEnums: Record<string, { options: string[]; description?: string }>;
   requiredLists: Record<
     string,
     {
       options: Record<string, string>;
       description?: string;
-      default?: string[];
+      values?: string[];
     }
   >;
   requiresDustAppConfiguration: boolean;

--- a/front/lib/actions/mcp_internal_actions/input_configuration.ts
+++ b/front/lib/actions/mcp_internal_actions/input_configuration.ts
@@ -143,20 +143,31 @@ function generateConfiguredInput({
     case INTERNAL_MIME_TYPES.TOOL_INPUT.STRING: {
       // For primitive types, we have rendered the key from the path and use it to look up the value.
       let value = actionConfiguration.additionalConfiguration[keyPath];
-      
+
       // If value is missing and schema has a default, use it
       if (value === undefined || value === null || value === "") {
-        const propSchema = findSchemaAtPath(actionConfiguration.inputSchema, keyPath.split('.'));
+        const propSchema = findSchemaAtPath(
+          actionConfiguration.inputSchema,
+          keyPath.split(".")
+        );
         if (propSchema?.default) {
           // Handle both object-level default {value, mimeType} and property-level default
-          if (typeof propSchema.default === 'object' && propSchema.default !== null && 'value' in propSchema.default) {
+          if (
+            typeof propSchema.default === "object" &&
+            propSchema.default !== null &&
+            "value" in propSchema.default
+          ) {
             value = propSchema.default.value as string;
-          } else if (propSchema.properties?.value && isJSONSchemaObject(propSchema.properties.value) && propSchema.properties.value.default !== undefined) {
+          } else if (
+            propSchema.properties?.value &&
+            isJSONSchemaObject(propSchema.properties.value) &&
+            propSchema.properties.value.default !== undefined
+          ) {
             value = propSchema.properties.value.default as string;
           }
         }
       }
-      
+
       if (typeof value !== "string") {
         throw new Error(
           `Expected string value for key ${keyPath}, got ${typeof value}`
@@ -167,20 +178,31 @@ function generateConfiguredInput({
 
     case INTERNAL_MIME_TYPES.TOOL_INPUT.NUMBER: {
       let value = actionConfiguration.additionalConfiguration[keyPath];
-      
+
       // If value is missing and schema has a default, use it
       if (value === undefined || value === null) {
-        const propSchema = findSchemaAtPath(actionConfiguration.inputSchema, keyPath.split('.'));
+        const propSchema = findSchemaAtPath(
+          actionConfiguration.inputSchema,
+          keyPath.split(".")
+        );
         if (propSchema?.default) {
           // Handle both object-level default {value, mimeType} and property-level default
-          if (typeof propSchema.default === 'object' && propSchema.default !== null && 'value' in propSchema.default) {
+          if (
+            typeof propSchema.default === "object" &&
+            propSchema.default !== null &&
+            "value" in propSchema.default
+          ) {
             value = propSchema.default.value as number;
-          } else if (propSchema.properties?.value && isJSONSchemaObject(propSchema.properties.value) && propSchema.properties.value.default !== undefined) {
+          } else if (
+            propSchema.properties?.value &&
+            isJSONSchemaObject(propSchema.properties.value) &&
+            propSchema.properties.value.default !== undefined
+          ) {
             value = propSchema.properties.value.default as number;
           }
         }
       }
-      
+
       if (typeof value !== "number") {
         throw new Error(
           `Expected number value for key ${keyPath}, got ${typeof value}`
@@ -191,20 +213,31 @@ function generateConfiguredInput({
 
     case INTERNAL_MIME_TYPES.TOOL_INPUT.BOOLEAN: {
       let value = actionConfiguration.additionalConfiguration[keyPath];
-      
+
       // If value is missing and schema has a default, use it
       if (value === undefined || value === null) {
-        const propSchema = findSchemaAtPath(actionConfiguration.inputSchema, keyPath.split('.'));
+        const propSchema = findSchemaAtPath(
+          actionConfiguration.inputSchema,
+          keyPath.split(".")
+        );
         if (propSchema?.default) {
           // Handle both object-level default {value, mimeType} and property-level default
-          if (typeof propSchema.default === 'object' && propSchema.default !== null && 'value' in propSchema.default) {
+          if (
+            typeof propSchema.default === "object" &&
+            propSchema.default !== null &&
+            "value" in propSchema.default
+          ) {
             value = propSchema.default.value as boolean;
-          } else if (propSchema.properties?.value && isJSONSchemaObject(propSchema.properties.value) && propSchema.properties.value.default !== undefined) {
+          } else if (
+            propSchema.properties?.value &&
+            isJSONSchemaObject(propSchema.properties.value) &&
+            propSchema.properties.value.default !== undefined
+          ) {
             value = propSchema.properties.value.default as boolean;
           }
         }
       }
-      
+
       if (typeof value !== "boolean") {
         throw new Error(
           `Expected boolean value for key ${keyPath}, got ${typeof value}`
@@ -215,20 +248,31 @@ function generateConfiguredInput({
 
     case INTERNAL_MIME_TYPES.TOOL_INPUT.ENUM: {
       let value = actionConfiguration.additionalConfiguration[keyPath];
-      
+
       // If value is missing and schema has a default, use it
       if (value === undefined || value === null || value === "") {
-        const propSchema = findSchemaAtPath(actionConfiguration.inputSchema, keyPath.split('.'));
+        const propSchema = findSchemaAtPath(
+          actionConfiguration.inputSchema,
+          keyPath.split(".")
+        );
         if (propSchema?.default) {
           // Handle both object-level default {value, mimeType} and property-level default
-          if (typeof propSchema.default === 'object' && propSchema.default !== null && 'value' in propSchema.default) {
+          if (
+            typeof propSchema.default === "object" &&
+            propSchema.default !== null &&
+            "value" in propSchema.default
+          ) {
             value = propSchema.default.value as string;
-          } else if (propSchema.properties?.value && isJSONSchemaObject(propSchema.properties.value) && propSchema.properties.value.default !== undefined) {
+          } else if (
+            propSchema.properties?.value &&
+            isJSONSchemaObject(propSchema.properties.value) &&
+            propSchema.properties.value.default !== undefined
+          ) {
             value = propSchema.properties.value.default as string;
           }
         }
       }
-      
+
       if (typeof value !== "string") {
         throw new Error(
           `Expected string value for key ${keyPath}, got ${typeof value}`
@@ -239,20 +283,36 @@ function generateConfiguredInput({
 
     case INTERNAL_MIME_TYPES.TOOL_INPUT.LIST: {
       let value = actionConfiguration.additionalConfiguration[keyPath];
-      
+
       // If value is missing and schema has a default, use it
-      if (value === undefined || value === null || (Array.isArray(value) && value.length === 0)) {
-        const propSchema = findSchemaAtPath(actionConfiguration.inputSchema, keyPath.split('.'));
+      if (
+        value === undefined ||
+        value === null ||
+        (Array.isArray(value) && value.length === 0)
+      ) {
+        const propSchema = findSchemaAtPath(
+          actionConfiguration.inputSchema,
+          keyPath.split(".")
+        );
         if (propSchema?.default) {
           // Handle both object-level default {values, mimeType} and property-level default
-          if (typeof propSchema.default === 'object' && propSchema.default !== null && 'values' in propSchema.default && Array.isArray(propSchema.default.values)) {
+          if (
+            typeof propSchema.default === "object" &&
+            propSchema.default !== null &&
+            "values" in propSchema.default &&
+            Array.isArray(propSchema.default.values)
+          ) {
             value = propSchema.default.values as string[];
-          } else if (propSchema.properties?.values && isJSONSchemaObject(propSchema.properties.values) && Array.isArray(propSchema.properties.values.default)) {
+          } else if (
+            propSchema.properties?.values &&
+            isJSONSchemaObject(propSchema.properties.values) &&
+            Array.isArray(propSchema.properties.values.default)
+          ) {
             value = propSchema.properties.values.default as string[];
           }
         }
       }
-      
+
       if (!Array.isArray(value) || value.some((v) => typeof v !== "string")) {
         throw new Error(
           `Expected array of string values for key ${keyPath}, got ${typeof value} for mime type ${mimeType}`
@@ -302,18 +362,17 @@ function findPathsToConfiguration({
     }
 
     if (tool.inputSchema) {
-      const match = findMatchingSubSchemas(tool.inputSchema, mimeType)
+      const match = findMatchingSubSchemas(tool.inputSchema, mimeType);
       matches = {
         ...matches,
         ...match,
       };
       if (!match) {
-        console.log("no match for tool:", tool)
+        console.log("no match for tool:", tool);
       }
     }
   }
 
-  
   return matches;
 }
 
@@ -476,16 +535,21 @@ export interface MCPServerToolsConfigurations {
   requiredStrings: { key: string; description?: string; default?: string }[];
   requiredNumbers: { key: string; description?: string; default?: number }[];
   requiredBooleans: { key: string; description?: string; default?: boolean }[];
-  requiredEnums: Record<string, { options: string[]; description?: string; default?: string }>;
+  requiredEnums: Record<
+    string,
+    { options: string[]; description?: string; default?: string }
+  >;
   requiredLists: Record<
     string,
-    { options: Record<string, string>; description?: string; default?: string[] }
+    {
+      options: Record<string, string>;
+      description?: string;
+      default?: string[];
+    }
   >;
   requiresDustAppConfiguration: boolean;
   noRequirement: boolean;
 }
-
-
 
 export function getMCPServerToolsConfigurations(
   mcpServerView: MCPServerViewType | null | undefined
@@ -696,7 +760,7 @@ export function getMCPServerToolsConfigurations(
       !requiresReasoningConfiguration &&
       !requiredDustAppConfiguration &&
       !mayRequireTimeFrameConfiguration &&
-      stringConfigurations.length <=  0 &&
+      stringConfigurations.length <= 0 &&
       numberConfigurations.length <= 0 &&
       booleanConfigurations.length <= 0 &&
       Object.keys(enumConfigurations).length <= 0 &&

--- a/front/lib/actions/mcp_internal_actions/input_configuration.ts
+++ b/front/lib/actions/mcp_internal_actions/input_configuration.ts
@@ -261,11 +261,11 @@ function generateConfiguredInput({
             propSchema.default !== null &&
             "values" in propSchema.default
           ) {
-            if (
-              Array.isArray(propSchema.default.values) &&
-              propSchema.default.values.every((v) => typeof v === "string")
-            ) {
-              values = propSchema.default.values;
+             if (
+               Array.isArray(propSchema.default.values) &&
+               propSchema.default.values.every((v): v is string => typeof v === "string")
+             ) {
+               values = propSchema.default.values;
             } else {
               // Invalid object-level default type - throw specific error
               throw new Error(
@@ -280,13 +280,13 @@ function generateConfiguredInput({
             propSchema.properties?.values &&
             isJSONSchemaObject(propSchema.properties.values)
           ) {
-            if (
-              Array.isArray(propSchema.properties.values.default) &&
-              propSchema.properties.values.default.every(
-                (v) => typeof v === "string"
-              )
-            ) {
-              values = propSchema.properties.values.default;
+             if (
+               Array.isArray(propSchema.properties.values.default) &&
+               propSchema.properties.values.default.every(
+                 (v): v is string => typeof v === "string"
+               )
+             ) {
+               values = propSchema.properties.values.default;
             } else {
               // Invalid property-level default type - throw specific error
               throw new Error(

--- a/front/lib/actions/mcp_internal_actions/input_configuration.ts
+++ b/front/lib/actions/mcp_internal_actions/input_configuration.ts
@@ -64,7 +64,13 @@ function generateConfiguredInput({
 
   type PrimitiveType = string | number | boolean | string[];
 
-  const handleDefaultValue = <U extends PrimitiveType>(
+  /*
+   * Get a validated value from the action configuration.
+   * If the value is not provided, we look for a default value in the input schema.
+   * If the value is provided, we validate it against the expected type.
+   * If the value is not provided and there is no default value, we throw an error.
+   */
+  const getValidatedValue = <U extends PrimitiveType>(
     actionConfiguration: MCPToolConfigurationType,
     keyPath: string,
     value: PrimitiveType | undefined,
@@ -196,7 +202,7 @@ function generateConfiguredInput({
 
     case INTERNAL_MIME_TYPES.TOOL_INPUT.STRING: {
       // For primitive types, we have rendered the key from the path and use it to look up the value.
-      const value = handleDefaultValue<string>(
+      const value = getValidatedValue<string>(
         actionConfiguration,
         keyPath,
         actionConfiguration.additionalConfiguration[keyPath],
@@ -208,7 +214,7 @@ function generateConfiguredInput({
     }
 
     case INTERNAL_MIME_TYPES.TOOL_INPUT.NUMBER: {
-      const value = handleDefaultValue<number>(
+      const value = getValidatedValue<number>(
         actionConfiguration,
         keyPath,
         actionConfiguration.additionalConfiguration[keyPath],
@@ -220,7 +226,7 @@ function generateConfiguredInput({
     }
 
     case INTERNAL_MIME_TYPES.TOOL_INPUT.BOOLEAN: {
-      const value = handleDefaultValue<boolean>(
+      const value = getValidatedValue<boolean>(
         actionConfiguration,
         keyPath,
         actionConfiguration.additionalConfiguration[keyPath],
@@ -232,7 +238,7 @@ function generateConfiguredInput({
     }
 
     case INTERNAL_MIME_TYPES.TOOL_INPUT.ENUM: {
-      const value = handleDefaultValue<string>(
+      const value = getValidatedValue<string>(
         actionConfiguration,
         keyPath,
         actionConfiguration.additionalConfiguration[keyPath],
@@ -743,11 +749,11 @@ export function getMCPServerRequirements(
       !requiresReasoningConfiguration &&
       !requiredDustAppConfiguration &&
       !mayRequireTimeFrameConfiguration &&
-      requiredStrings.length <= 0 &&
-      requiredNumbers.length <= 0 &&
-      requiredBooleans.length <= 0 &&
-      Object.keys(requiredEnums).length <= 0 &&
-      Object.keys(requiredLists).length <= 0,
+      requiredStrings.length === 0 &&
+      requiredNumbers.length === 0 &&
+      requiredBooleans.length === 0 &&
+      Object.keys(requiredEnums).length === 0 &&
+      Object.keys(requiredLists).length === 0,
   };
 }
 

--- a/front/lib/actions/mcp_internal_actions/input_configuration.ts
+++ b/front/lib/actions/mcp_internal_actions/input_configuration.ts
@@ -144,7 +144,6 @@ function generateConfiguredInput({
       // For primitive types, we have rendered the key from the path and use it to look up the value.
       let value = actionConfiguration.additionalConfiguration[keyPath];
 
-      // If value is missing and schema has a default, use it
       if (value === undefined || value === null || value === "") {
         const propSchema = findSchemaAtPath(
           actionConfiguration.inputSchema,
@@ -179,7 +178,6 @@ function generateConfiguredInput({
     case INTERNAL_MIME_TYPES.TOOL_INPUT.NUMBER: {
       let value = actionConfiguration.additionalConfiguration[keyPath];
 
-      // If value is missing and schema has a default, use it
       if (value === undefined || value === null) {
         const propSchema = findSchemaAtPath(
           actionConfiguration.inputSchema,
@@ -214,7 +212,6 @@ function generateConfiguredInput({
     case INTERNAL_MIME_TYPES.TOOL_INPUT.BOOLEAN: {
       let value = actionConfiguration.additionalConfiguration[keyPath];
 
-      // If value is missing and schema has a default, use it
       if (value === undefined || value === null) {
         const propSchema = findSchemaAtPath(
           actionConfiguration.inputSchema,
@@ -249,7 +246,6 @@ function generateConfiguredInput({
     case INTERNAL_MIME_TYPES.TOOL_INPUT.ENUM: {
       let value = actionConfiguration.additionalConfiguration[keyPath];
 
-      // If value is missing and schema has a default, use it
       if (value === undefined || value === null || value === "") {
         const propSchema = findSchemaAtPath(
           actionConfiguration.inputSchema,
@@ -284,7 +280,6 @@ function generateConfiguredInput({
     case INTERNAL_MIME_TYPES.TOOL_INPUT.LIST: {
       let value = actionConfiguration.additionalConfiguration[keyPath];
 
-      // If value is missing and schema has a default, use it
       if (
         value === undefined ||
         value === null ||

--- a/front/lib/actions/mcp_internal_actions/input_configuration.ts
+++ b/front/lib/actions/mcp_internal_actions/input_configuration.ts
@@ -149,22 +149,35 @@ function generateConfiguredInput({
           actionConfiguration.inputSchema,
           keyPath.split(".")
         );
-        if (propSchema?.default) {
+        if (propSchema) {
           // Handle both object-level default {value, mimeType} and property-level default
           if (
+            propSchema.default &&
             typeof propSchema.default === "object" &&
             propSchema.default !== null &&
-            "value" in propSchema.default &&
-            typeof propSchema.default.value === "string"
+            "value" in propSchema.default
           ) {
-            value = propSchema.default.value;
+            if (typeof propSchema.default.value === "string") {
+              value = propSchema.default.value;
+            } else {
+              // Invalid object-level default type - throw specific error
+              throw new Error(
+                `Expected string value for key ${keyPath}, got ${typeof propSchema.default.value}`
+              );
+            }
           } else if (
             propSchema.properties?.value &&
             isJSONSchemaObject(propSchema.properties.value) &&
-            propSchema.properties.value.default !== undefined &&
-            typeof propSchema.properties.value.default === "string"
+            propSchema.properties.value.default !== undefined
           ) {
-            value = propSchema.properties.value.default;
+            if (typeof propSchema.properties.value.default === "string") {
+              value = propSchema.properties.value.default;
+            } else {
+              // Invalid property-level default type - throw specific error
+              throw new Error(
+                `Expected string value for key ${keyPath}, got ${typeof propSchema.properties.value.default}`
+              );
+            }
           }
         }
       }
@@ -185,9 +198,10 @@ function generateConfiguredInput({
           actionConfiguration.inputSchema,
           keyPath.split(".")
         );
-        if (propSchema?.default) {
+        if (propSchema) {
           // Handle both object-level default {value, mimeType} and property-level default
           if (
+            propSchema.default &&
             typeof propSchema.default === "object" &&
             propSchema.default !== null &&
             "value" in propSchema.default &&
@@ -221,9 +235,10 @@ function generateConfiguredInput({
           actionConfiguration.inputSchema,
           keyPath.split(".")
         );
-        if (propSchema?.default) {
+        if (propSchema) {
           // Handle both object-level default {value, mimeType} and property-level default
           if (
+            propSchema.default &&
             typeof propSchema.default === "object" &&
             propSchema.default !== null &&
             "value" in propSchema.default &&
@@ -257,9 +272,10 @@ function generateConfiguredInput({
           actionConfiguration.inputSchema,
           keyPath.split(".")
         );
-        if (propSchema?.default) {
+        if (propSchema) {
           // Handle both object-level default {value, mimeType} and property-level default
           if (
+            propSchema.default &&
             typeof propSchema.default === "object" &&
             propSchema.default !== null &&
             "value" in propSchema.default &&
@@ -297,9 +313,10 @@ function generateConfiguredInput({
           actionConfiguration.inputSchema,
           keyPath.split(".")
         );
-        if (propSchema?.default) {
+        if (propSchema) {
           // Handle both object-level default {values, mimeType} and property-level default
           if (
+            propSchema.default &&
             typeof propSchema.default === "object" &&
             propSchema.default !== null &&
             "values" in propSchema.default &&

--- a/front/lib/actions/mcp_internal_actions/input_configuration.ts
+++ b/front/lib/actions/mcp_internal_actions/input_configuration.ts
@@ -261,11 +261,13 @@ function generateConfiguredInput({
             propSchema.default !== null &&
             "values" in propSchema.default
           ) {
-             if (
-               Array.isArray(propSchema.default.values) &&
-               propSchema.default.values.every((v): v is string => typeof v === "string")
-             ) {
-               values = propSchema.default.values;
+            if (
+              Array.isArray(propSchema.default.values) &&
+              propSchema.default.values.every(
+                (v): v is string => typeof v === "string"
+              )
+            ) {
+              values = propSchema.default.values;
             } else {
               // Invalid object-level default type - throw specific error
               throw new Error(
@@ -280,13 +282,13 @@ function generateConfiguredInput({
             propSchema.properties?.values &&
             isJSONSchemaObject(propSchema.properties.values)
           ) {
-             if (
-               Array.isArray(propSchema.properties.values.default) &&
-               propSchema.properties.values.default.every(
-                 (v): v is string => typeof v === "string"
-               )
-             ) {
-               values = propSchema.properties.values.default;
+            if (
+              Array.isArray(propSchema.properties.values.default) &&
+              propSchema.properties.values.default.every(
+                (v): v is string => typeof v === "string"
+              )
+            ) {
+              values = propSchema.properties.values.default;
             } else {
               // Invalid property-level default type - throw specific error
               throw new Error(


### PR DESCRIPTION
## Description

As a runtime check, `augmentInputsWithConfiguration` now checks if a missing required property of configuration has a default value defined in the `actionConfiguration`'s schema and if so populates the value with the default.

## Tests

Simply checked against the current test suite for `augmentInputsWithConfiguration` and it passed all tests.

## Risk

Little, this simply adds an extra check and most schemas have no default values defined for now.

## Deploy Plan

Deploy front
