### PR TITLE
Dust deep 2 as second dust-deep to eval

### DIFF
--- a/extension/shared/lib/utils.ts
+++ b/extension/shared/lib/utils.ts
@@ -207,6 +207,13 @@ export function compareAgentsForSort(
     return 1;
   }
 
+  if (a.sId === GLOBAL_AGENTS_SID.DUST_DEEP_2) {
+    return -1;
+  }
+  if (b.sId === GLOBAL_AGENTS_SID.DUST_DEEP_2) {
+    return 1;
+  }
+
   if (a.sId === GLOBAL_AGENTS_SID.CLAUDE_4_SONNET) {
     return -1;
   }

--- a/extension/ui/components/conversation/AgentSuggestion.tsx
+++ b/extension/ui/components/conversation/AgentSuggestion.tsx
@@ -147,5 +147,10 @@ function sortAgents(
   } else if (b.sId === GLOBAL_AGENTS_SID.DUST_DEEP) {
     return 1;
   }
+  if (a.sId === GLOBAL_AGENTS_SID.DUST_DEEP_2) {
+    return -1;
+  } else if (b.sId === GLOBAL_AGENTS_SID.DUST_DEEP_2) {
+    return 1;
+  }
   return (b.usage?.messageCount || 0) - (a.usage?.messageCount || 0);
 }

--- a/extension/ui/components/input_bar/editor/suggestion.ts
+++ b/extension/ui/components/input_bar/editor/suggestion.ts
@@ -19,6 +19,7 @@ const SUGGESTION_DISPLAY_LIMIT = 7;
 const SUGGESTION_PRIORITY: Record<string, number> = {
   [GLOBAL_AGENTS_SID.DUST]: 1,
   [GLOBAL_AGENTS_SID.DUST_DEEP]: 2,
+  [GLOBAL_AGENTS_SID.DUST_DEEP_2]: 3,
 };
 
 function filterAndSortSuggestions(

--- a/front/components/assistant/conversation/AgentSuggestion.tsx
+++ b/front/components/assistant/conversation/AgentSuggestion.tsx
@@ -211,5 +211,10 @@ function sortAgents(
   } else if (b.sId === GLOBAL_AGENTS_SID.DUST_DEEP) {
     return 1;
   }
+  if (a.sId === GLOBAL_AGENTS_SID.DUST_DEEP_2) {
+    return -1;
+  } else if (b.sId === GLOBAL_AGENTS_SID.DUST_DEEP_2) {
+    return 1;
+  }
   return (b.usage?.messageCount || 0) - (a.usage?.messageCount || 0);
 }

--- a/front/lib/api/assistant/global_agents/configurations/dust-deep.ts
+++ b/front/lib/api/assistant/global_agents/configurations/dust-deep.ts
@@ -271,6 +271,7 @@ function getCompanyDataWarehousesAction(
 export function _getDustDeepGlobalAgent(
   auth: Authenticator,
   {
+    sId,
     settings,
     preFetchedDataSources,
     webSearchBrowseMCPServerView,
@@ -281,6 +282,7 @@ export function _getDustDeepGlobalAgent(
     toolsetsMCPServerView,
     slideshowMCPServerView,
   }: {
+    sId: GLOBAL_AGENTS_SID.DUST_DEEP | GLOBAL_AGENTS_SID.DUST_DEEP_2;
     settings: GlobalAgentSettings | null;
     preFetchedDataSources: PrefetchedDataSourcesType | null;
     webSearchBrowseMCPServerView: MCPServerViewResource | null;
@@ -294,20 +296,23 @@ export function _getDustDeepGlobalAgent(
 ): AgentConfigurationType | null {
   const owner = auth.getNonNullableWorkspace();
 
-  const name = "dust-deep";
+  const name =
+    sId === GLOBAL_AGENTS_SID.DUST_DEEP_2 ? "dust-deep-2" : "dust-deep";
   const description =
     "Deep research with company data, web search/browse, Content Creation, slideshow presentations, and data warehouses.";
 
   const pictureUrl = "https://dust.tt/static/systemavatar/dust_avatar_full.png";
 
-  const modelConfig = getModelConfig(owner, "anthropic");
+  const preferredModel =
+    sId === GLOBAL_AGENTS_SID.DUST_DEEP_2 ? "openai" : "anthropic";
+  const modelConfig = getModelConfig(owner, preferredModel);
 
   const deepAgent: Omit<
     AgentConfigurationType,
     "status" | "maxStepsPerRun" | "actions"
   > = {
     id: -1,
-    sId: GLOBAL_AGENTS_SID.DUST_DEEP,
+    sId,
     version: 0,
     versionCreatedAt: null,
     versionAuthorId: null,

--- a/front/lib/api/assistant/global_agents/global_agent_metadata.ts
+++ b/front/lib/api/assistant/global_agents/global_agent_metadata.ts
@@ -245,6 +245,15 @@ export function getGlobalAgentMetadata(sId: GLOBAL_AGENTS_SID): AgentMetadata {
         pictureUrl:
           "https://dust.tt/static/systemavatar/dust-deep_avatar_full.png",
       };
+    case GLOBAL_AGENTS_SID.DUST_DEEP_2:
+      return {
+        sId: GLOBAL_AGENTS_SID.DUST_DEEP_2,
+        name: "dust-deep-2",
+        description:
+          "Deep research agent with company data, web search, browsing, Content Creation, and data warehouses.",
+        pictureUrl:
+          "https://dust.tt/static/systemavatar/dust-deep_avatar_full.png",
+      };
     case GLOBAL_AGENTS_SID.DUST_TASK:
       return {
         sId: GLOBAL_AGENTS_SID.DUST_TASK,

--- a/front/lib/api/assistant/global_agents/global_agents.ts
+++ b/front/lib/api/assistant/global_agents/global_agents.ts
@@ -283,7 +283,9 @@ function getGlobalAgent({
       });
       break;
     case GLOBAL_AGENTS_SID.DUST_DEEP:
+    case GLOBAL_AGENTS_SID.DUST_DEEP_2:
       agentConfiguration = _getDustDeepGlobalAgent(auth, {
+        sId: sId as GLOBAL_AGENTS_SID.DUST_DEEP | GLOBAL_AGENTS_SID.DUST_DEEP_2,
         settings,
         preFetchedDataSources,
         webSearchBrowseMCPServerView,
@@ -462,7 +464,14 @@ export async function getGlobalAgents(
 
   if (!flags.includes("research_agent")) {
     agentsIdsToFetch = agentsIdsToFetch.filter(
-      (sId) => sId !== GLOBAL_AGENTS_SID.DUST_DEEP
+      (sId) =>
+        sId !== GLOBAL_AGENTS_SID.DUST_DEEP &&
+        sId !== GLOBAL_AGENTS_SID.DUST_DEEP_2
+    );
+  }
+  if (!flags.includes("research_agent_2")) {
+    agentsIdsToFetch = agentsIdsToFetch.filter(
+      (sId) => sId !== GLOBAL_AGENTS_SID.DUST_DEEP_2
     );
   }
 

--- a/front/package-lock.json
+++ b/front/package-lock.json
@@ -204,7 +204,7 @@
     },
     "../sdks/js": {
       "name": "@dust-tt/client",
-      "version": "1.1.12",
+      "version": "1.1.13",
       "bundleDependencies": [
         "@modelcontextprotocol/sdk"
       ],

--- a/front/types/assistant/assistant.ts
+++ b/front/types/assistant/assistant.ts
@@ -1606,6 +1606,7 @@ export enum GLOBAL_AGENTS_SID {
   HELPER = "helper",
   DUST = "dust",
   DUST_DEEP = "dust-deep",
+  DUST_DEEP_2 = "dust-deep-2",
   DUST_TASK = "dust-task",
   SLACK = "slack",
   GOOGLE_DRIVE = "google_drive",
@@ -1675,6 +1676,7 @@ export function getGlobalAgentAuthorName(agentId: string): string {
 const CUSTOM_ORDER: string[] = [
   GLOBAL_AGENTS_SID.DUST,
   GLOBAL_AGENTS_SID.DUST_DEEP,
+  GLOBAL_AGENTS_SID.DUST_DEEP_2,
   GLOBAL_AGENTS_SID.CLAUDE_4_SONNET,
   GLOBAL_AGENTS_SID.GPT4,
   GLOBAL_AGENTS_SID.O3_MINI,
@@ -1721,6 +1723,13 @@ export function compareAgentsForSort(
     return -1;
   }
   if (b.sId === GLOBAL_AGENTS_SID.DUST_DEEP) {
+    return 1;
+  }
+
+  if (a.sId === GLOBAL_AGENTS_SID.DUST_DEEP_2) {
+    return -1;
+  }
+  if (b.sId === GLOBAL_AGENTS_SID.DUST_DEEP_2) {
     return 1;
   }
 

--- a/front/types/shared/feature_flags.ts
+++ b/front/types/shared/feature_flags.ts
@@ -151,6 +151,11 @@ export const WHITELISTABLE_FEATURES_CONFIG = {
     description: "Activate @research agent.",
     stage: "dust_only",
   },
+  research_agent_2: {
+    description:
+      "Activate second version of @research agent (dust only for evals).",
+    stage: "dust_only",
+  },
   hootl: {
     description: "Human Out Of The Loop (aka Triggers)",
     stage: "dust_only",

--- a/sdks/js/src/types.ts
+++ b/sdks/js/src/types.ts
@@ -622,6 +622,7 @@ const WhitelistableFeaturesSchema = FlexibleEnumSchema<
   | "openai_o1_high_reasoning_custom_assistants_feature"
   | "openai_o1_high_reasoning_feature"
   | "research_agent"
+  | "research_agent_2"
   | "salesforce_synced_queries"
   | "salesforce_tool"
   | "show_debug_tools"


### PR DESCRIPTION
## Description

Add dust-deep-2 on a new feature flag to activate on dust-only -> test diff between both version but both with the exact same tools and prompt. 

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

Deploy front. 
Activate research_agent_2 on dust. 