### PR TITLE
[front] Message breakdown switch

### DIFF
--- a/front/components/assistant/conversation/actions/AgentMessageActions.tsx
+++ b/front/components/assistant/conversation/actions/AgentMessageActions.tsx
@@ -8,6 +8,7 @@ import {
   Markdown,
   Spinner,
 } from "@dust-tt/sparkle";
+import { useEffect, useRef } from "react";
 
 import { MCPActionDetails } from "@app/components/actions/mcp/details/MCPActionDetails";
 import { useConversationSidePanelContext } from "@app/components/assistant/conversation/ConversationSidePanelContext";
@@ -35,7 +36,7 @@ export function AgentMessageActions({
   actionProgress,
   owner,
 }: AgentMessageActionsProps) {
-  const { openPanel } = useConversationSidePanelContext();
+  const { openPanel, currentPanel, data } = useConversationSidePanelContext();
 
   const isAgentMessageWithActions =
     isLightAgentMessageWithActionsType(agentMessage);
@@ -45,12 +46,26 @@ export function AgentMessageActions({
 
   const chainOfThought = agentMessage.chainOfThought || "";
 
+  const ref = useRef<boolean>(true);
   const onClick = () => {
     openPanel({
       type: "actions",
       messageId: agentMessage.sId,
     });
   };
+
+  useEffect(() => {
+    if (currentPanel === "actions" && data !== agentMessage.sId) {
+      const isNewLastMessage = agentMessage.content === null && ref.current;
+      if (isNewLastMessage) {
+        openPanel({
+          type: "actions",
+          messageId: agentMessage.sId,
+        });
+      }
+    }
+    ref.current = false;
+  }, [agentMessage, currentPanel, data, openPanel]);
 
   const lastNotification = lastAction
     ? actionProgress.get(lastAction.id)?.progress ?? null
@@ -106,7 +121,7 @@ export function AgentMessageActions({
         size="sm"
         label="Message Breakdown"
         icon={CommandLineIcon}
-        variant="outline"
+        variant={data === agentMessage.sId ? "primary" : "outline"}
         onClick={onClick}
       />
     </div>

--- a/front/components/assistant/conversation/actions/AgentMessageActions.tsx
+++ b/front/components/assistant/conversation/actions/AgentMessageActions.tsx
@@ -46,7 +46,7 @@ export function AgentMessageActions({
 
   const chainOfThought = agentMessage.chainOfThought || "";
 
-  const ref = useRef<boolean>(true);
+  const firstRender = useRef<boolean>(true);
   const onClick = () => {
     openPanel({
       type: "actions",
@@ -55,18 +55,19 @@ export function AgentMessageActions({
   };
 
   useEffect(() => {
+    // Only if we are in the first rendering, message is empty and panel is open on another message.
     if (
       currentPanel === "actions" &&
       data !== agentMessage.sId &&
       agentMessage.content === null &&
-      ref.current
+      firstRender.current
     ) {
       openPanel({
         type: "actions",
         messageId: agentMessage.sId,
       });
     }
-    ref.current = false;
+    firstRender.current = false;
   }, [agentMessage, currentPanel, data, openPanel]);
 
   const lastNotification = lastAction

--- a/front/components/assistant/conversation/actions/AgentMessageActions.tsx
+++ b/front/components/assistant/conversation/actions/AgentMessageActions.tsx
@@ -55,14 +55,16 @@ export function AgentMessageActions({
   };
 
   useEffect(() => {
-    if (currentPanel === "actions" && data !== agentMessage.sId) {
-      const isNewLastMessage = agentMessage.content === null && ref.current;
-      if (isNewLastMessage) {
-        openPanel({
-          type: "actions",
-          messageId: agentMessage.sId,
-        });
-      }
+    if (
+      currentPanel === "actions" &&
+      data !== agentMessage.sId &&
+      agentMessage.content === null &&
+      ref.current
+    ) {
+      openPanel({
+        type: "actions",
+        messageId: agentMessage.sId,
+      });
     }
     ref.current = false;
   }, [agentMessage, currentPanel, data, openPanel]);


### PR DESCRIPTION
## Description

- Highlight the "Message breakdown" button 
- Auto switch to new agent message, either when retrying or posting a new message (only if message breakdown was already open)

<img width="563" height="856" alt="Screenshot 2025-09-10 at 16 00 09" src="https://github.com/user-attachments/assets/51fda971-ee19-425d-ac3b-dbd98427c90b" />

![Sep-10-2025 16-21-03](https://github.com/user-attachments/assets/954a0905-1b3f-4aa2-ae0e-eb5d69962246)

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
