### PR TITLE
[Triggers] Add webhook trigger support with webhookSourceViewId field

### DIFF
--- a/front/components/agent_builder/AgentBuilderFormContext.tsx
+++ b/front/components/agent_builder/AgentBuilderFormContext.tsx
@@ -191,14 +191,50 @@ const scheduleConfigSchema = z.object({
   timezone: z.string(),
 });
 
-const triggerSchema = z.object({
+const webhookConfigSchema = z.record(z.never());
+
+const webhookTriggerSchema = z.object({
+  sId: z.string().optional(),
+  name: z.string(),
+  kind: z.enum(["webhook"]),
+  customPrompt: z.string().nullable(),
+  configuration: z.union([webhookConfigSchema, z.null()]),
+  editor: z.number().nullable(),
+  webhookSourceViewSId: z.string().nullable().optional(),
+});
+
+const scheduleTriggerSchema = z.object({
   sId: z.string().optional(),
   name: z.string(),
   kind: z.enum(["schedule"]),
   customPrompt: z.string().nullable(),
-  configuration: z.union([scheduleConfigSchema, z.null()]),
+  configuration: scheduleConfigSchema,
   editor: z.number().nullable(),
 });
+
+const triggerSchema = z.discriminatedUnion("kind", [
+  webhookTriggerSchema,
+  scheduleTriggerSchema,
+]);
+
+export type AgentBuilderWebhookTriggerType = z.infer<
+  typeof webhookTriggerSchema
+>;
+export type AgentBuilderScheduleTriggerType = z.infer<
+  typeof scheduleTriggerSchema
+>;
+
+export function isAgentBuilderWebhookTriggerType(
+  trigger: AgentBuilderTriggerType
+): trigger is AgentBuilderWebhookTriggerType {
+  return trigger.kind === "webhook";
+}
+
+export function isAgentBuilderScheduleTriggerType(
+  trigger: AgentBuilderTriggerType
+): trigger is AgentBuilderScheduleTriggerType {
+  return trigger.kind === "schedule";
+}
 
 export const agentBuilderFormSchema = z.object({
   agentSettings: agentSettingsSchema,

--- a/front/components/agent_builder/triggers/ScheduleEditionModal.tsx
+++ b/front/components/agent_builder/triggers/ScheduleEditionModal.tsx
@@ -75,10 +75,16 @@ export function ScheduleEditionModal({
 
   const { reset } = form;
   useEffect(() => {
+    const scheduleConfig =
+      trigger?.kind === "schedule" &&
+      trigger?.configuration &&
+      "cron" in trigger.configuration
+        ? trigger.configuration
+        : null;
     reset({
       name: trigger?.name ?? defaultValues.name,
-      cron: trigger?.configuration?.cron ?? defaultValues.cron,
-      timezone: trigger?.configuration?.timezone ?? defaultValues.timezone,
+      cron: scheduleConfig?.cron ?? defaultValues.cron,
+      timezone: scheduleConfig?.timezone ?? defaultValues.timezone,
       customPrompt: trigger?.customPrompt ?? defaultValues.customPrompt,
     });
   }, [
@@ -165,14 +171,20 @@ export function ScheduleEditionModal({
                 />
               </div>
 
-              <div className="space-y-1">
-                <Label htmlFor="trigger-description">Scheduler</Label>
-                <p className="text-sm text-muted-foreground dark:text-muted-foreground-night">
-                  Timezone:{" "}
-                  {trigger?.configuration?.timezone ||
-                    Intl.DateTimeFormat().resolvedOptions().timeZone}
-                  .
-                </p>
+              <div>
+                <div className="pb-2">
+                  <Label htmlFor="trigger-description">Scheduler</Label>
+                  <p className="text-sm text-muted-foreground dark:text-muted-foreground-night">
+                    The trigger will run in the{" "}
+                    {(trigger?.kind === "schedule" &&
+                    trigger?.configuration &&
+                    "timezone" in trigger.configuration
+                      ? trigger.configuration.timezone
+                      : null) ||
+                      Intl.DateTimeFormat().resolvedOptions().timeZone}{" "}
+                    timezone.
+                  </p>
+                </div>
 
                 <TextArea
                   id="schedule-description"

--- a/front/components/agent_builder/triggers/TriggerCard.tsx
+++ b/front/components/agent_builder/triggers/TriggerCard.tsx
@@ -9,6 +9,7 @@ import cronstrue from "cronstrue";
 import { useMemo } from "react";
 
 import type { AgentBuilderTriggerType } from "@app/components/agent_builder/AgentBuilderFormContext";
+import { isAgentBuilderScheduleTriggerType } from "@app/components/agent_builder/AgentBuilderFormContext";
 import { useUser } from "@app/lib/swr/user";
 import type { TriggerKind } from "@app/types/assistant/triggers";
 
@@ -37,14 +38,20 @@ export const TriggerCard = ({
   const isEditor = trigger.editor === user?.id;
   const cronDescription = useMemo(() => {
     try {
-      if (trigger.configuration?.cron) {
-        return `Runs ${cronstrue.toString(trigger.configuration?.cron)}.`;
+      if (
+        trigger.kind === "schedule" &&
+        trigger.configuration &&
+        "cron" in trigger.configuration
+      ) {
+        return `Runs ${cronstrue.toString(trigger.configuration.cron)}.`;
+      } else if (trigger.kind === "webhook") {
+        return "Triggered by webhook.";
       }
     } catch (error) {
       // Ignore.
     }
     return "";
-  }, [trigger.configuration?.cron]);
+  }, [trigger.kind, trigger.configuration]);
 
   return (
     <Card
@@ -69,11 +76,11 @@ export const TriggerCard = ({
           <Avatar visual={getIcon(trigger.kind)} size="xs" />
           <span className="truncate">{trigger.name}</span>
         </div>
-        <span className="text-muted-foreground dark:text-muted-foreground-night">
-          {trigger.kind === "schedule" && (
+        {isAgentBuilderScheduleTriggerType(trigger) && (
+          <span className="text-muted-foreground dark:text-muted-foreground-night">
             <span className="line-clamp-2 break-words">{cronDescription}</span>
-          )}
-        </span>
+          </span>
+        )}
       </div>
     </Card>
   );

--- a/front/components/assistant_builder/types.ts
+++ b/front/components/assistant_builder/types.ts
@@ -3,6 +3,7 @@ import type { JSONSchema7 as JSONSchema } from "json-schema";
 import uniqueId from "lodash/uniqueId";
 import type React from "react";
 
+import type { AgentBuilderTriggerType } from "@app/components/agent_builder/AgentBuilderFormContext";
 import {
   DEFAULT_DATA_VISUALIZATION_DESCRIPTION,
   DEFAULT_DATA_VISUALIZATION_NAME,
@@ -23,18 +24,6 @@ import type {
   WhitelistableFeature,
 } from "@app/types";
 import type { TagType } from "@app/types/tag";
-
-export type AssistantBuilderTriggerType = {
-  sId?: string;
-  name: string;
-  kind: "schedule";
-  customPrompt: string | null;
-  editor: UserType["id"] | null;
-  configuration: {
-    cron: string;
-    timezone: string;
-  } | null;
-};
 
 // MCP configuration
 export type AssistantBuilderMCPServerConfiguration = {
@@ -94,7 +83,7 @@ export type AssistantBuilderState = {
     responseFormat?: string;
   };
   actions: AssistantBuilderMCPOrVizState[];
-  triggers: AssistantBuilderTriggerType[];
+  triggers: AgentBuilderTriggerType[];
   visualizationEnabled: boolean;
   templateId: string | null;
   tags: TagType[];

--- a/front/lib/models/assistant/triggers/triggers.ts
+++ b/front/lib/models/assistant/triggers/triggers.ts
@@ -2,6 +2,7 @@ import type { CreationOptional, ForeignKey } from "sequelize";
 import { DataTypes } from "sequelize";
 
 import type { AgentConfiguration } from "@app/lib/models/assistant/agent";
+import { WebhookSourcesViewModel } from "@app/lib/models/assistant/triggers/webhook_sources_view";
 import { frontSequelize } from "@app/lib/resources/storage";
 import { UserModel } from "@app/lib/resources/storage/models/user";
 import { WorkspaceAwareModel } from "@app/lib/resources/storage/wrappers/workspace_models";
@@ -26,6 +27,7 @@ export class TriggerModel extends WorkspaceAwareModel<TriggerModel> {
    */
   declare agentConfigurationId: ForeignKey<AgentConfiguration["sId"]>;
   declare editor: ForeignKey<UserModel["id"]>;
+  declare webhookSourceViewId: ForeignKey<WebhookSourcesViewModel["id"]> | null;
 
   declare configuration: TriggerConfigurationType;
 }
@@ -68,6 +70,10 @@ TriggerModel.init(
       type: DataTypes.JSONB,
       allowNull: false,
     },
+    webhookSourceViewId: {
+      type: DataTypes.BIGINT,
+      allowNull: true,
+    },
   },
   {
     modelName: "trigger",
@@ -81,10 +87,17 @@ TriggerModel.init(
     },
     indexes: [
       { fields: ["workspaceId", "agentConfigurationId", "name"], unique: true },
+      { fields: ["workspaceId", "webhookSourceViewId"] },
     ],
   }
 );
 
 TriggerModel.belongsTo(UserModel, {
   foreignKey: { name: "editor", allowNull: false },
+});
+
+TriggerModel.belongsTo(WebhookSourcesViewModel, {
+  foreignKey: { name: "webhookSourceViewId", allowNull: true },
+  onDelete: "RESTRICT",
+  onUpdate: "CASCADE",
 });

--- a/front/migrations/db/migration_356.sql
+++ b/front/migrations/db/migration_356.sql
@@ -1,0 +1,15 @@
+-- Migration created on Sep 10, 2025
+-- Add webhookSourceViewId column to triggers table for webhook trigger support
+
+-- Add the webhookSourceViewId column
+ALTER TABLE "triggers" 
+ADD COLUMN "webhookSourceViewId" BIGINT DEFAULT NULL 
+REFERENCES "webhook_sources_views" ("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- Add constraint to ensure webhookSourceViewId is set for webhook triggers
+ALTER TABLE "triggers" 
+ADD CONSTRAINT "triggers_webhook_source_view_id_check" 
+CHECK (
+  (kind = 'webhook' AND "webhookSourceViewId" IS NOT NULL) OR 
+  (kind != 'webhook' AND "webhookSourceViewId" IS NULL)
+);

--- a/front/types/triggers/webhooks.ts
+++ b/front/types/triggers/webhooks.ts
@@ -1,7 +1,7 @@
-import { ModelId } from "@app/types/shared/model_id";
-import { EditedByUser } from "@app/types/user";
-
 import * as t from "io-ts";
+
+import type { ModelId } from "@app/types/shared/model_id";
+import type { EditedByUser } from "@app/types/user";
 
 export type WebhookSourceType = {
   id: ModelId;


### PR DESCRIPTION
## Description

Fixes https://github.com/dust-tt/tasks/issues/4038

Adds support for webhook triggers with proper `webhookSourceViewId` field:
- Adds `webhookSourceViewId` column to triggers table with foreign key to `webhook_sources_views`
- Implements database constraint ensuring webhook triggers have webhookSourceViewId
- Converts between numeric database IDs and string sIds in API layer
- Adds Sequelize associations and database index for efficient queries

## Risks

Blast radius: Webhook trigger functionality
Risk: low

## Deploy Plan

- Run migration 356 to add webhookSourceViewId column with foreign key constraint
- Deploy front service