### PR TITLE
[front] change sharing permission for share link 

### DIFF
--- a/front/components/assistant/conversation/content_creation/ShareContentCreationFilePopover.tsx
+++ b/front/components/assistant/conversation/content_creation/ShareContentCreationFilePopover.tsx
@@ -33,15 +33,14 @@ interface FileSharingDropdownProps {
   owner: LightWorkspaceType;
   disabled?: boolean;
   isLoading?: boolean;
+  isUsingConversationFiles: boolean;
 }
 
-function FileSharingDropdown({
-  selectedScope,
-  onScopeChange,
-  owner,
-  disabled = false,
-}: FileSharingDropdownProps) {
-  const scopeOptions: {
+const getScopeOptions = (
+  owner: LightWorkspaceType,
+  isUsingConversationFiles: boolean
+) => {
+  const options: {
     icon: React.ComponentType;
     label: string;
     value: FileShareScope;
@@ -49,19 +48,35 @@ function FileSharingDropdown({
     {
       icon: LockIcon,
       label: "Only conversation participants",
-      value: "conversation_participants",
+      value: "conversation_participants" as const,
     },
     {
       icon: UserGroupIcon,
       label: `Anyone in ${owner.name} workspace`,
-      value: "workspace",
-    },
-    {
-      icon: GlobeAltIcon,
-      label: "Anyone with the link",
-      value: "public",
+      value: "workspace" as const,
     },
   ];
+
+  if (!isUsingConversationFiles) {
+    options.push({
+      icon: GlobeAltIcon,
+      label: "Anyone with the link",
+      value: "public" as const,
+    });
+  }
+
+  return options;
+};
+
+function FileSharingDropdown({
+  selectedScope,
+  onScopeChange,
+  owner,
+  disabled = false,
+  isUsingConversationFiles,
+}: FileSharingDropdownProps) {
+  console.log("FileSharingDropdown");
+  const scopeOptions = getScopeOptions(owner, isUsingConversationFiles);
 
   const selectedOption = scopeOptions.find(
     (opt) => opt.value === selectedScope
@@ -187,14 +202,14 @@ export function ShareContentCreationFilePopover({
                   title={
                     isSharingForbidden
                       ? "Sharing disabled by admin"
-                      : "This Content Creation contains company data"
+                      : "This file contains company data"
                   }
                   variant="golden"
                   icon={InformationCircleIcon}
                 >
                   {isSharingForbidden
                     ? "Your workspace administrator has turned off sharing of Content Creation files."
-                    : "The Content Creation relies on conversation files, sharing is therefore" +
+                    : "This Content Creation relies on conversation files. The sharing to public option is " +
                       "disabled to protect company information."}
                 </ContentMessage>
               )}
@@ -205,11 +220,8 @@ export function ShareContentCreationFilePopover({
                   selectedScope={selectedScope}
                   onScopeChange={handleScopeChange}
                   owner={owner}
-                  disabled={
-                    isSharingForbidden ||
-                    isUsingConversationFiles ||
-                    isUpdatingShare
-                  }
+                  isUsingConversationFiles={isUsingConversationFiles}
+                  disabled={isSharingForbidden || isUpdatingShare}
                   isLoading={isUpdatingShare}
                 />
 

--- a/front/components/assistant/conversation/content_creation/ShareContentCreationFilePopover.tsx
+++ b/front/components/assistant/conversation/content_creation/ShareContentCreationFilePopover.tsx
@@ -2,6 +2,7 @@ import {
   Button,
   ClipboardCheckIcon,
   ClipboardIcon,
+  cn,
   ContentMessage,
   DropdownMenu,
   DropdownMenuContent,
@@ -36,15 +37,14 @@ interface FileSharingDropdownProps {
   isUsingConversationFiles: boolean;
 }
 
-const getScopeOptions = (
-  owner: LightWorkspaceType,
-  isUsingConversationFiles: boolean
-) => {
-  const options: {
-    icon: React.ComponentType;
-    label: string;
-    value: FileShareScope;
-  }[] = [
+function FileSharingDropdown({
+  selectedScope,
+  onScopeChange,
+  owner,
+  disabled = false,
+  isUsingConversationFiles,
+}: FileSharingDropdownProps) {
+  const scopeOptions = [
     {
       icon: LockIcon,
       label: "Only conversation participants",
@@ -55,28 +55,12 @@ const getScopeOptions = (
       label: `Anyone in ${owner.name} workspace`,
       value: "workspace" as const,
     },
-  ];
-
-  if (!isUsingConversationFiles) {
-    options.push({
+    {
       icon: GlobeAltIcon,
       label: "Anyone with the link",
       value: "public" as const,
-    });
-  }
-
-  return options;
-};
-
-function FileSharingDropdown({
-  selectedScope,
-  onScopeChange,
-  owner,
-  disabled = false,
-  isUsingConversationFiles,
-}: FileSharingDropdownProps) {
-  console.log("FileSharingDropdown");
-  const scopeOptions = getScopeOptions(owner, isUsingConversationFiles);
+    },
+  ];
 
   const selectedOption = scopeOptions.find(
     (opt) => opt.value === selectedScope
@@ -96,7 +80,12 @@ function FileSharingDropdown({
             label={selectedOption?.label}
             icon={selectedOption?.icon}
             disabled={disabled}
-            className="grid w-full grid-cols-[auto_1fr_auto] truncate"
+            className={cn(
+              "grid w-full grid-cols-[auto_1fr_auto] truncate",
+              selectedOption?.value === "public" &&
+                isUsingConversationFiles &&
+                "text-primary-400 dark:text-primary-400-night"
+            )}
           />
         </DropdownMenuTrigger>
         <DropdownMenuContent className="w-[var(--radix-dropdown-menu-trigger-width)]">
@@ -107,6 +96,7 @@ function FileSharingDropdown({
               onClick={() => onScopeChange(option.value)}
               truncateText
               icon={option.icon}
+              disabled={option.value === "public" && isUsingConversationFiles}
             />
           ))}
         </DropdownMenuContent>

--- a/front/pages/api/w/[wId]/files/[fileId]/share.ts
+++ b/front/pages/api/w/[wId]/files/[fileId]/share.ts
@@ -94,8 +94,8 @@ async function handler(
 
       const { shareScope } = parseResult.data;
 
-      // For workspace/public sharing, check if file uses conversation files.
-      if (shareScope !== "conversation_participants") {
+      // For public sharing, check if file uses conversation files.
+      if (shareScope === "public") {
         const fileContent = await getFileContent(auth, file, "original");
         if (!fileContent) {
           return apiError(req, res, {


### PR DESCRIPTION
## Description
This PR is to allow users to share a preview link with their workspace even if `useFile` is used, per Théo's request [here](https://dust4ai.slack.com/archives/C050A0S2Z7F/p1757438626967329?thread_ts=1757438623.873799&cid=C050A0S2Z7F)

I also took this opportunity to change the text in the info section: 
<img width="390" height="389" alt="Screenshot 2025-09-10 at 18 40 05" src="https://github.com/user-attachments/assets/03e58695-9409-46bf-b755-ae181aa61a5a" />



<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
