### PR TITLE
[Front Database] Decrease pool to 16

### DIFF
--- a/front/lib/resources/storage/index.ts
+++ b/front/lib/resources/storage/index.ts
@@ -41,7 +41,7 @@ export const frontSequelize = new Sequelize(
   {
     pool: {
       // Default is 5.
-      max: isDevelopment() ? 5 : 20,
+      max: isDevelopment() ? 5 : 16,
     },
     logging: isDevelopment() && DB_LOGGING_ENABLED ? sequelizeLogger : false,
     hooks: {


### PR DESCRIPTION
Description
---

Fixes https://dust4ai.slack.com/archives/C050SM8NSPK/p1757514185312279

Too many connections on our front database, despite a very high 500 connections allowed.

Risks
---
low

Deploy
---
front

