### PR TITLE
Add slack preference ability for slack-bot

### DIFF
--- a/connectors/migrations/20230725_slack_channel_permissions.ts
+++ b/connectors/migrations/20230725_slack_channel_permissions.ts
@@ -1,4 +1,4 @@
-import { getChannels } from "@connectors/connectors/slack/lib/channels";
+import { getJoinedChannels } from "@connectors/connectors/slack/lib/channels";
 import { getSlackClient } from "@connectors/connectors/slack/lib/slack_client";
 import { SlackChannel } from "@connectors/lib/models/slack";
 import { ConnectorModel } from "@connectors/resources/storage/models/connector_model";
@@ -26,7 +26,7 @@ async function main() {
 
     const slackClient = await getSlackClient(c.id);
 
-    const channelsInSlack = await getChannels(slackClient, c.id, true);
+    const channelsInSlack = await getJoinedChannels(slackClient, c.id);
     const channelIdsInSlackSet = new Set(
       channelsInSlack.map((c) => c.id).filter((id) => id)
     );

--- a/connectors/migrations/20250429_autojoin_slack_channels.ts
+++ b/connectors/migrations/20250429_autojoin_slack_channels.ts
@@ -2,7 +2,7 @@ import type { Channel } from "@slack/web-api/dist/types/response/ConversationsIn
 import { makeScript } from "scripts/helpers";
 
 import {
-  getChannels,
+  getAllChannels,
   joinChannel,
 } from "@connectors/connectors/slack/lib/channels";
 import { getSlackClient } from "@connectors/connectors/slack/lib/slack_client";
@@ -85,10 +85,9 @@ makeScript(
 
     // Get all channels from Slack.
     const slackClient = await getSlackClient(connector.id);
-    const remoteChannels = await getChannels(
+    const remoteChannels = await getAllChannels(
       slackClient,
-      parseInt(connectorId, 10),
-      false
+      parseInt(connectorId, 10)
     );
     const matchingChannels = remoteChannels.filter(
       (c) => c.name && new RegExp(pattern).test(c.name)

--- a/connectors/scripts/mark_rate_limited_slack_connectors.ts
+++ b/connectors/scripts/mark_rate_limited_slack_connectors.ts
@@ -1,6 +1,6 @@
 import type { Logger } from "pino";
 
-import { getChannels } from "@connectors/connectors/slack/lib/channels";
+import { getJoinedChannels } from "@connectors/connectors/slack/lib/channels";
 import {
   getSlackClient,
   withSlackErrorHandling,
@@ -85,7 +85,7 @@ makeScript(
         let channels;
         try {
           channels = await withSlackErrorHandling(async () =>
-            getChannels(slackClient, connector.id, true)
+            getJoinedChannels(slackClient, connector.id)
           );
         } catch (error: unknown) {
           if (error instanceof ProviderRateLimitError) {

--- a/connectors/src/api/slack_channels_linked_with_agent.ts
+++ b/connectors/src/api/slack_channels_linked_with_agent.ts
@@ -6,13 +6,14 @@ import * as t from "io-ts";
 import * as reporter from "io-ts-reporters";
 import { Op } from "sequelize";
 
-import { getAllChannels } from "@connectors/connectors/slack/lib/channels";
+import { getChannelById } from "@connectors/connectors/slack/lib/channels";
 import { getSlackClient } from "@connectors/connectors/slack/lib/slack_client";
 import { slackChannelIdFromInternalId } from "@connectors/connectors/slack/lib/utils";
 import { launchJoinChannelWorkflow } from "@connectors/connectors/slack/temporal/client";
 import { SlackChannel } from "@connectors/lib/models/slack";
 import { apiError, withLogging } from "@connectors/logger/withlogging";
 import type { WithConnectorsAPIErrorReponse } from "@connectors/types";
+import { normalizeError } from "@connectors/types";
 import { withTransaction } from "@connectors/types/shared/utils/sql_utils";
 
 const PatchSlackChannelsLinkedWithAgentReqBodySchema = t.type({
@@ -88,42 +89,39 @@ const _patchSlackChannelsLinkedWithAgentHandler = async (
 
   await withTransaction(async (t) => {
     if (missingSlackChannelIds.length) {
-      const remoteChannels = (
-        await getAllChannels(slackClient, parseInt(connectorId))
-      ).flatMap((c) =>
-        c.id && c.name
-          ? [{ id: c.id, name: c.name, private: !!c.is_private }]
-          : []
-      );
-      const remoteChannelsById = remoteChannels.reduce(
-        (acc, ch) => {
-          acc[ch.id] = ch;
-          return acc;
-        },
-        {} as Record<string, { id: string; name: string; private: boolean }>
-      );
       const createdChannels = await Promise.all(
-        missingSlackChannelIds.map((slackChannelId) => {
-          const remoteChannel = remoteChannelsById[slackChannelId];
-          if (!remoteChannel) {
+        missingSlackChannelIds.map(async (slackChannelId) => {
+          try {
+            const remoteChannel = await getChannelById(
+              slackClient,
+              parseInt(connectorId),
+              slackChannelId
+            );
+
+            if (!remoteChannel.name) {
+              throw new Error(
+                `Unexpected error: Unable to find Slack channel ${slackChannelId}.`
+              );
+            }
+            return await SlackChannel.create(
+              {
+                connectorId: parseInt(connectorId),
+                slackChannelId,
+                slackChannelName: remoteChannel.name,
+                agentConfigurationId,
+                permission: "write",
+                private: !!remoteChannel.is_private,
+                autoRespondWithoutMention: autoRespondWithoutMention ?? false,
+              },
+              {
+                transaction: t,
+              }
+            );
+          } catch (error) {
             throw new Error(
-              `Unexpected error: Access to the Slack channel ${slackChannelId} seems lost.`
+              `Unexpected error: Unable to find Slack channel ${slackChannelId}: ${normalizeError(error)}`
             );
           }
-          return SlackChannel.create(
-            {
-              connectorId: parseInt(connectorId),
-              slackChannelId,
-              slackChannelName: remoteChannel.name,
-              agentConfigurationId,
-              permission: "write",
-              private: remoteChannel.private,
-              autoRespondWithoutMention: autoRespondWithoutMention ?? false,
-            },
-            {
-              transaction: t,
-            }
-          );
         })
       );
       slackChannelIds.push(...createdChannels.map((c) => c.slackChannelId));

--- a/connectors/src/api/slack_channels_linked_with_agent.ts
+++ b/connectors/src/api/slack_channels_linked_with_agent.ts
@@ -6,7 +6,7 @@ import * as t from "io-ts";
 import * as reporter from "io-ts-reporters";
 import { Op } from "sequelize";
 
-import { getChannels } from "@connectors/connectors/slack/lib/channels";
+import { getAllChannels } from "@connectors/connectors/slack/lib/channels";
 import { getSlackClient } from "@connectors/connectors/slack/lib/slack_client";
 import { slackChannelIdFromInternalId } from "@connectors/connectors/slack/lib/utils";
 import { launchJoinChannelWorkflow } from "@connectors/connectors/slack/temporal/client";
@@ -89,7 +89,7 @@ const _patchSlackChannelsLinkedWithAgentHandler = async (
   await withTransaction(async (t) => {
     if (missingSlackChannelIds.length) {
       const remoteChannels = (
-        await getChannels(slackClient, parseInt(connectorId), false)
+        await getAllChannels(slackClient, parseInt(connectorId))
       ).flatMap((c) =>
         c.id && c.name
           ? [{ id: c.id, name: c.name, private: !!c.is_private }]

--- a/connectors/src/connectors/slack/index.ts
+++ b/connectors/src/connectors/slack/index.ts
@@ -17,7 +17,7 @@ import {
 } from "@connectors/connectors/slack/auto_read_channel";
 import { getBotEnabled } from "@connectors/connectors/slack/bot";
 import {
-  getChannels,
+  getAllChannels,
   joinChannelWithRetries,
 } from "@connectors/connectors/slack/lib/channels";
 import { slackConfig } from "@connectors/connectors/slack/lib/config";
@@ -550,7 +550,7 @@ export class SlackConnectorManager extends BaseConnectorManager<SlackConfigurati
         const slackClient = await getSlackClient(connector.id);
 
         // Fetch all channels from Slack
-        const allChannels = await getChannels(slackClient, connector.id, false);
+        const allChannels = await getAllChannels(slackClient, connector.id);
 
         const results: Result<boolean, Error>[] = [];
 
@@ -817,7 +817,7 @@ async function getFilteredChannels(
     const slackClient = await getSlackClient(connectorId);
 
     const [remoteChannels, localChannels] = await Promise.all([
-      getChannels(slackClient, connectorId, false),
+      getAllChannels(slackClient, connectorId),
       SlackChannel.findAll({
         where: {
           connectorId,

--- a/connectors/src/connectors/slack/lib/channels.ts
+++ b/connectors/src/connectors/slack/lib/channels.ts
@@ -296,41 +296,109 @@ export async function joinChannelWithRetries(
  */
 
 /**
- *  Call cached to avoid rate limits
+ * Call cache to avoid rate limits.
+ * Fetch all channels from Slack API using conversations.list.
+ * This returns all channels in the workspace that the app has access to.
+ *
  *  ON RATE LIMIT ERRORS PERTAINING TO THIS FUNCTION:
  * - the next step will be to paginate (overkill at time of writing)
  * - see issue https://github.com/dust-tt/tasks/issues/1655
  * - and related PR https://github.com/dust-tt/dust/pull/8709
+ * @param slackClient
  * @param connectorId
- * @param joinedOnly
  */
-export const getChannels = cacheWithRedis(
-  _getChannelsUncached,
-  (slackClient, connectorId, joinedOnly) =>
-    `slack-channels-${connectorId}-${joinedOnly}`,
+export const getAllChannels = cacheWithRedis(
+  _getAllChannelsUncached,
+  (slackClient, connectorId) => `slack-all-channels-${connectorId}`,
   {
     ttlMs: 5 * 60 * 1000,
   }
 );
 
-async function _getChannelsUncached(
+/**
+ * Fetch channels that the bot is a member of using users.conversations API.
+ * This is more efficient than getChannels for bot connectors as it only fetches
+ * channels the bot has joined, avoiding rate limits from fetching all workspace channels.
+ *
+ * @param slackClient
+ * @param connectorId
+ * @returns Promise<Channel[]> Array of channels the bot is a member of
+ */
+export const getJoinedChannels = cacheWithRedis(
+  _getJoinedChannelsUncached,
+  (slackClient, connectorId) => `slack-joined-channels-${connectorId}`,
+  {
+    ttlMs: 5 * 60 * 1000,
+  }
+);
+
+async function _getJoinedChannelsUncached(
   slackClient: WebClient,
-  connectorId: ModelId,
-  joinedOnly: boolean
+  connectorId: ModelId
+): Promise<Channel[]> {
+  const allChannels = [];
+  let nextCursor: string | undefined = undefined;
+  let nbCalls = 0;
+
+  do {
+    reportSlackUsage({
+      connectorId,
+      method: "users.conversations",
+      useCase: "bot",
+    });
+
+    const response = await withSlackErrorHandling(() =>
+      slackClient.users.conversations({
+        types: "public_channel,private_channel",
+        exclude_archived: true,
+        limit: 999, // Maximum allowed by Slack API
+        cursor: nextCursor,
+      })
+    );
+
+    nbCalls++;
+
+    logger.info(
+      {
+        connectorId,
+        returnedChannels: allChannels.length,
+        currentCursor: nextCursor,
+        nbCalls,
+      },
+      `[Slack] users.conversations called for getJoinedChannels (${nbCalls} calls)`
+    );
+
+    nextCursor = response?.response_metadata?.next_cursor;
+
+    if (response.error) {
+      throw new Error(`Failed to fetch joined channels: ${response.error}`);
+    }
+
+    if (response.channels === undefined) {
+      throw new Error(
+        "The channels list was undefined." +
+          response?.response_metadata?.next_cursor +
+          ""
+      );
+    }
+
+    for (const channel of response.channels) {
+      if (channel && channel.id) {
+        allChannels.push(channel);
+      }
+    }
+  } while (nextCursor);
+
+  return allChannels;
+}
+
+async function _getAllChannelsUncached(
+  slackClient: WebClient,
+  connectorId: ModelId
 ): Promise<Channel[]> {
   return Promise.all([
-    _getTypedChannelsUncached(
-      slackClient,
-      connectorId,
-      joinedOnly,
-      "public_channel"
-    ),
-    _getTypedChannelsUncached(
-      slackClient,
-      connectorId,
-      joinedOnly,
-      "private_channel"
-    ),
+    _getTypedChannelsUncached(slackClient, connectorId, "public_channel"),
+    _getTypedChannelsUncached(slackClient, connectorId, "private_channel"),
   ]).then(([publicChannels, privateChannels]) => [
     ...publicChannels,
     ...privateChannels,
@@ -340,7 +408,6 @@ async function _getChannelsUncached(
 async function _getTypedChannelsUncached(
   slackClient: WebClient,
   connectorId: ModelId,
-  joinedOnly: boolean,
   types: "public_channel" | "private_channel"
 ): Promise<Channel[]> {
   const allChannels = [];
@@ -386,9 +453,7 @@ async function _getTypedChannelsUncached(
     }
     for (const channel of c.channels) {
       if (channel && channel.id) {
-        if (!joinedOnly || channel.is_member) {
-          allChannels.push(channel);
-        }
+        allChannels.push(channel);
       }
     }
   } while (nextCursor);
@@ -401,7 +466,7 @@ export async function getChannelsToSync(
   connectorId: number
 ) {
   const [remoteChannels, localChannels] = await Promise.all([
-    getChannels(slackClient, connectorId, true),
+    getJoinedChannels(slackClient, connectorId),
     SlackChannel.findAll({
       where: {
         connectorId,
@@ -471,7 +536,7 @@ export async function migrateChannelsFromLegacyBotToNewBot(
 
   // Fetch all channels that the deprecated bot is a member of.
   const channels = await withSlackErrorHandling(() =>
-    getChannels(slackClient, slackConnector.id, true)
+    getJoinedChannels(slackClient, slackConnector.id)
   );
   const publicChannels = channels.filter((c) => !c.is_private);
 

--- a/connectors/src/connectors/slack/lib/cli.ts
+++ b/connectors/src/connectors/slack/lib/cli.ts
@@ -3,8 +3,8 @@ import {
   findMatchingChannelPatterns,
 } from "@connectors/connectors/slack/auto_read_channel";
 import {
+  getAllChannels,
   getChannelById,
-  getChannels,
   joinChannel,
   updateSlackChannelInConnectorsDb,
 } from "@connectors/connectors/slack/lib/channels";
@@ -368,7 +368,7 @@ export const slack = async ({
       const slackClient = await getSlackClient(connector.id);
 
       // Fetch all channels from Slack
-      const allChannels = await getChannels(slackClient, connector.id, false);
+      const allChannels = await getAllChannels(slackClient, connector.id);
       logger.info(
         { connectorId: connector.id, totalChannels: allChannels.length },
         "Fetched all channels from Slack"

--- a/connectors/src/connectors/slack/temporal/activities.ts
+++ b/connectors/src/connectors/slack/temporal/activities.ts
@@ -21,7 +21,7 @@ import {
 } from "@connectors/connectors/slack/lib/bot_user_helpers";
 import {
   getChannelById,
-  getJoinedChannels,
+  getChannels,
   joinChannel,
   migrateChannelsFromLegacyBotToNewBot,
   updateSlackChannelInConnectorsDb,
@@ -1100,10 +1100,12 @@ export async function getChannelsToGarbageCollect(
 
   const slackClient = await getSlackClient(connectorId);
 
+  // TODO: Consider using getJoinedChannels(slackClient, connectorId) for better performance.
+  // The only reason this was not done is to mitigate risk as this is a function with a large blast radius.
   const remoteChannels = new Set(
     (
       await withSlackErrorHandling(() =>
-        getJoinedChannels(slackClient, connectorId)
+        getChannels(slackClient, connectorId, true)
       )
     )
       .filter((c) => c.id)

--- a/connectors/src/connectors/slack/temporal/activities.ts
+++ b/connectors/src/connectors/slack/temporal/activities.ts
@@ -21,7 +21,7 @@ import {
 } from "@connectors/connectors/slack/lib/bot_user_helpers";
 import {
   getChannelById,
-  getChannels,
+  getJoinedChannels,
   joinChannel,
   migrateChannelsFromLegacyBotToNewBot,
   updateSlackChannelInConnectorsDb,
@@ -1103,7 +1103,7 @@ export async function getChannelsToGarbageCollect(
   const remoteChannels = new Set(
     (
       await withSlackErrorHandling(() =>
-        getChannels(slackClient, connectorId, true)
+        getJoinedChannels(slackClient, connectorId)
       )
     )
       .filter((c) => c.id)

--- a/connectors/src/connectors/slack_bot/index.ts
+++ b/connectors/src/connectors/slack_bot/index.ts
@@ -18,7 +18,7 @@ import {
   uninstallSlack,
 } from "@connectors/connectors/slack";
 import { getBotEnabled } from "@connectors/connectors/slack/bot";
-import { getChannels } from "@connectors/connectors/slack/lib/channels";
+import { getJoinedChannels } from "@connectors/connectors/slack/lib/channels";
 import { retrievePermissions } from "@connectors/connectors/slack/lib/retrieve_permissions";
 import {
   getSlackAccessToken,
@@ -622,7 +622,7 @@ async function getFilteredChannels(
   const slackClient = await getSlackClient(connectorId);
 
   const [remoteChannels, localChannels] = await Promise.all([
-    getChannels(slackClient, connectorId, true),
+    getJoinedChannels(slackClient, connectorId),
     SlackChannel.findAll({
       where: {
         connectorId,

--- a/front/components/agent_builder/settings/SlackSettingsSheet.tsx
+++ b/front/components/agent_builder/settings/SlackSettingsSheet.tsx
@@ -296,6 +296,17 @@ export function SlackSettingsSheet({
               <span className="font-bold">@Dust</span> Slack bot is mentioned in
               these channels.
             </div>
+
+            {slackDataSource?.connectorProvider === "slack_bot" && (
+              <div className="rounded-lg border bg-gray-50 p-3 dark:bg-gray-900">
+                <div className="text-sm">
+                  Only channels where the @Dust bot is a member will appear
+                  below. To add the bot to a channel, type{" "}
+                  <code>/invite @Dust</code> in the desired channel.
+                </div>
+              </div>
+            )}
+
             <SlackChannelsList
               existingSelection={localSlackChannels}
               onSelectionChange={handleSelectionChange}

--- a/front/components/agent_builder/settings/SlackSettingsSheet.tsx
+++ b/front/components/agent_builder/settings/SlackSettingsSheet.tsx
@@ -1,6 +1,7 @@
 import {
   Button,
   Checkbox,
+  ContentMessage,
   ExternalLinkIcon,
   Icon,
   SearchInput,
@@ -15,6 +16,7 @@ import {
   SliderToggle,
   Spinner,
 } from "@dust-tt/sparkle";
+import { InformationCircleIcon } from "@heroicons/react/20/solid";
 import React, { useCallback, useEffect, useMemo, useState } from "react";
 import { useController } from "react-hook-form";
 
@@ -23,6 +25,7 @@ import type { AgentBuilderFormData } from "@app/components/agent_builder/AgentBu
 import { useConnectorPermissions } from "@app/lib/swr/connectors";
 import { useFeatureFlags } from "@app/lib/swr/workspaces";
 import type { DataSourceType, WorkspaceType } from "@app/types";
+import { isAdmin } from "@app/types/user";
 
 const SLACK_CHANNEL_INTERNAL_ID_PREFIX = "slack-channel-";
 
@@ -296,47 +299,27 @@ export function SlackSettingsSheet({
               <span className="font-bold">@Dust</span> Slack bot is mentioned in
               these channels.
             </div>
-
-            {slackDataSource?.connectorProvider === "slack_bot" && (
-              <div className="rounded-lg border bg-gray-50 p-3 dark:bg-gray-900">
-                <div className="text-sm">
-                  Only channels where the @Dust bot is a member will appear
-                  below. To add the bot to a channel, type{" "}
-                  <code>/invite @Dust</code> in the desired channel.
-                </div>
-              </div>
+            {!isAdmin(owner) && (
+              <ContentMessage
+                size="md"
+                variant="warning"
+                title="Admin Access Required"
+                icon={InformationCircleIcon}
+              >
+                <p>
+                  Only administrators can enable default agents for specific
+                  Slack channels.
+                </p>
+              </ContentMessage>
             )}
 
-            <SlackChannelsList
-              existingSelection={localSlackChannels}
-              onSelectionChange={handleSelectionChange}
-              owner={owner}
-              slackDataSource={slackDataSource}
-            />
-            {hasFeature("slack_enhanced_default_agent") && (
-              <div className="flex flex-col gap-2 border-t pt-4">
-                <div className="flex items-start justify-between gap-4">
-                  <div className="flex min-w-0 flex-1 flex-col gap-1">
-                    <span className="text-sm font-medium text-foreground dark:text-foreground-night">
-                      Enhanced Default Agent
-                    </span>
-                    <span className="text-xs text-muted-foreground dark:text-muted-foreground-night">
-                      Agent will automatically respond to all new threads (not
-                      just @mentions).
-                    </span>
-                  </div>
-                  <div className="flex-shrink-0">
-                    <SliderToggle
-                      selected={autoRespondWithoutMentionEnabled}
-                      onClick={() =>
-                        setAutoRespondWithoutMentionEnabled(
-                          !autoRespondWithoutMentionEnabled
-                        )
-                      }
-                    />
-                  </div>
-                </div>
-              </div>
+            {isAdmin(owner) && (
+              <SlackChannelsList
+                existingSelection={localSlackChannels}
+                onSelectionChange={handleSelectionChange}
+                owner={owner}
+                slackDataSource={slackDataSource}
+              />
             )}
           </div>
         </SheetContainer>
@@ -353,7 +336,7 @@ export function SlackSettingsSheet({
             disabled: !hasUnsavedChanges,
           }}
         >
-          {hasFeature("slack_enhanced_default_agent") && (
+          {hasFeature("slack_enhanced_default_agent") && isAdmin(owner) && (
             <div className="flex flex-col border-t p-4">
               <div className="flex items-start justify-between gap-4">
                 <div className="flex min-w-0 flex-1 flex-col gap-1">


### PR DESCRIPTION
## Description

* https://github.com/dust-tt/tasks/issues/4013
* For slack bot, channels will not be stored associated with the connector, so we are now calling the Slack user.conversations API. This API allows 50+ calls per minute (https://docs.slack.dev/reference/methods/users.conversations/), as opposed to the users.list API which is 20+ calls per minute. There will be a difference in the logic. Channels will only show if the Slack bot is added to the channel.
* Minor renaming / removal of joinedOnly parameter for getChannels for clarity
* Left the logic untouched if "slack" is still the provider

## Tests

<img width="357" height="729" alt="Screenshot 2025-09-10 at 3 40 36 PM" src="https://github.com/user-attachments/assets/93f19ff7-0fe1-47b9-88d2-cbf2fd9c32ca" />

## Risk

* Intended to fix an existing issue

## Deploy Plan

* Deploy connector