### PR TITLE
[front] - fix(AB): advanced search mode

### DIFF
--- a/front/components/agent_builder/capabilities/knowledge/KnowledgeConfigurationSheet.tsx
+++ b/front/components/agent_builder/capabilities/knowledge/KnowledgeConfigurationSheet.tsx
@@ -1,6 +1,9 @@
 import type { MultiPageSheetPage } from "@dust-tt/sparkle";
 import {
   Avatar,
+  Collapsible,
+  CollapsibleContent,
+  CollapsibleTrigger,
   MultiPageSheet,
   MultiPageSheetContent,
 } from "@dust-tt/sparkle";
@@ -26,6 +29,7 @@ import {
   nameToStorageFormat,
 } from "@app/components/agent_builder/capabilities/mcp/utils/actionNameUtils";
 import { isValidPage } from "@app/components/agent_builder/capabilities/mcp/utils/sheetUtils";
+import { CustomCheckboxSection } from "@app/components/agent_builder/capabilities/shared/CustomCheckboxSection";
 import { DescriptionSection } from "@app/components/agent_builder/capabilities/shared/DescriptionSection";
 import { JsonSchemaSection } from "@app/components/agent_builder/capabilities/shared/JsonSchemaSection";
 import { NameSection } from "@app/components/agent_builder/capabilities/shared/NameSection";
@@ -47,6 +51,7 @@ import {
   useKnowledgePageContext,
 } from "@app/components/data_source_view/context/PageContext";
 import { getMcpServerViewDisplayName } from "@app/lib/actions/mcp_helper";
+import { ADVANCED_SEARCH_SWITCH } from "@app/lib/actions/mcp_internal_actions/constants";
 import { getMCPServerRequirements } from "@app/lib/actions/mcp_internal_actions/input_configuration";
 import type { MCPServerViewType } from "@app/lib/api/mcp";
 import type { TemplateActionPreset } from "@app/types";
@@ -240,6 +245,7 @@ function KnowledgeConfigurationSheetContent({
   const { currentPageId, setSheetPageId } = useKnowledgePageContext();
   const nameSectionRef = useRef<HTMLInputElement>(null);
   const { setValue, getValues } = useFormContext<CapabilityFormData>();
+  const [isAdvancedSettingsOpen, setAdvancedSettingsOpen] = useState(false);
 
   const mcpServerView = useWatch<CapabilityFormData, "mcpServerView">({
     name: "mcpServerView",
@@ -365,6 +371,27 @@ function KnowledgeConfigurationSheetContent({
           {config && <DescriptionSection {...config?.descriptionConfig} />}
 
           <SelectDataSourcesFilters />
+
+          {/* Advanced Settings collapsible section */}
+          <Collapsible
+            open={isAdvancedSettingsOpen}
+            onOpenChange={setAdvancedSettingsOpen}
+          >
+            <CollapsibleTrigger isOpen={isAdvancedSettingsOpen}>
+              <h3 className="heading-base font-semibold text-foreground dark:text-foreground-night">
+                Advanced Settings
+              </h3>
+            </CollapsibleTrigger>
+            <CollapsibleContent className="m-1">
+              <CustomCheckboxSection
+                title="Advanced Search Mode"
+                description="Enable advanced search capabilities with enhanced discovery and filtering options for more precise results."
+                targetMCPServerName="search"
+                selectedMCPServerView={mcpServerView ?? undefined}
+                configurationKey={ADVANCED_SEARCH_SWITCH}
+              />
+            </CollapsibleContent>
+          </Collapsible>
         </div>
       ),
     },

--- a/front/components/agent_builder/capabilities/mcp/utils/formDefaults.ts
+++ b/front/components/agent_builder/capabilities/mcp/utils/formDefaults.ts
@@ -5,7 +5,6 @@ import type {
   MCPServerConfigurationType,
 } from "@app/components/agent_builder/AgentBuilderFormContext";
 import { getMCPServerRequirements } from "@app/lib/actions/mcp_internal_actions/input_configuration";
-import { ADVANCED_SEARCH_SWITCH } from "@app/lib/actions/mcp_internal_actions/constants";
 import type { MCPServerViewType } from "@app/lib/api/mcp";
 
 /**
@@ -55,14 +54,6 @@ export function getDefaultConfiguration(
 
   for (const [key] of Object.entries(requirements.requiredLists)) {
     set(additionalConfig, key, []);
-  }
-
-  // Set default value for advanced search switch for search servers
-  if (
-    mcpServerView?.serverType === "internal" &&
-    mcpServerView.server.name === "search"
-  ) {
-    additionalConfig[ADVANCED_SEARCH_SWITCH] = false;
   }
 
   defaults.additionalConfiguration = additionalConfig;

--- a/front/components/agent_builder/capabilities/mcp/utils/formDefaults.ts
+++ b/front/components/agent_builder/capabilities/mcp/utils/formDefaults.ts
@@ -5,6 +5,7 @@ import type {
   MCPServerConfigurationType,
 } from "@app/components/agent_builder/AgentBuilderFormContext";
 import { getMCPServerRequirements } from "@app/lib/actions/mcp_internal_actions/input_configuration";
+import { ADVANCED_SEARCH_SWITCH } from "@app/lib/actions/mcp_internal_actions/constants";
 import type { MCPServerViewType } from "@app/lib/api/mcp";
 
 /**
@@ -54,6 +55,14 @@ export function getDefaultConfiguration(
 
   for (const [key] of Object.entries(requirements.requiredLists)) {
     set(additionalConfig, key, []);
+  }
+
+  // Set default value for advanced search switch for search servers
+  if (
+    mcpServerView?.serverType === "internal" &&
+    mcpServerView.server.name === "search"
+  ) {
+    additionalConfig[ADVANCED_SEARCH_SWITCH] = false;
   }
 
   defaults.additionalConfiguration = additionalConfig;

--- a/front/components/agent_builder/capabilities/shared/CustomCheckboxSection.tsx
+++ b/front/components/agent_builder/capabilities/shared/CustomCheckboxSection.tsx
@@ -25,6 +25,7 @@ export function CustomCheckboxSection({
 }: CustomCheckboxSectionProps) {
   const { field } = useController<MCPFormData>({
     name: `configuration.additionalConfiguration.${configurationKey}`,
+    defaultValue: false,
   });
 
   const isTargetServer =
@@ -35,7 +36,7 @@ export function CustomCheckboxSection({
     return null;
   }
 
-  const isEnabled = field.value === true;
+  const isEnabled = Boolean(field.value);
 
   return (
     <div className="flex flex-col gap-3">
@@ -43,7 +44,10 @@ export function CustomCheckboxSection({
       <div className="flex items-center justify-between gap-2">
         <Checkbox
           checked={isEnabled}
-          onCheckedChange={(checked) => field.onChange(checked)}
+          onCheckedChange={(checked) => {
+            const boolValue = checked === true;
+            field.onChange(boolValue);
+          }}
         />
         <div className="flex-1">
           {description && (

--- a/front/components/agent_builder/capabilities/shared/CustomCheckboxSection.tsx
+++ b/front/components/agent_builder/capabilities/shared/CustomCheckboxSection.tsx
@@ -1,0 +1,58 @@
+import { Checkbox } from "@dust-tt/sparkle";
+import { useController } from "react-hook-form";
+
+import type { MCPFormData } from "@app/components/agent_builder/AgentBuilderFormContext";
+import type { InternalMCPServerNameType } from "@app/lib/actions/mcp_internal_actions/constants";
+import type { MCPServerViewType } from "@app/lib/api/mcp";
+
+interface CustomCheckboxSectionProps {
+  title: string;
+  description: string;
+  configurationKey: string;
+  selectedMCPServerView?: MCPServerViewType;
+  targetMCPServerName: InternalMCPServerNameType;
+}
+
+/**
+ * Custom checkbox section that stores a boolean configuration in the additionalConfiguration.
+ */
+export function CustomCheckboxSection({
+  title,
+  description,
+  selectedMCPServerView,
+  targetMCPServerName,
+  configurationKey,
+}: CustomCheckboxSectionProps) {
+  const { field } = useController<MCPFormData>({
+    name: `configuration.additionalConfiguration.${configurationKey}`,
+  });
+
+  const isTargetServer =
+    selectedMCPServerView?.serverType === "internal" &&
+    selectedMCPServerView.server.name === targetMCPServerName;
+
+  if (!isTargetServer) {
+    return null;
+  }
+
+  const isEnabled = field.value === true;
+
+  return (
+    <div className="flex flex-col gap-3">
+      <span className="font-semibold">{title}</span>
+      <div className="flex items-center justify-between gap-2">
+        <Checkbox
+          checked={isEnabled}
+          onCheckedChange={(checked) => field.onChange(checked)}
+        />
+        <div className="flex-1">
+          {description && (
+            <p className="text-sm text-muted-foreground dark:text-muted-foreground-night">
+              {description}
+            </p>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Description

This PR restores the "Advanced Search Mode" toggle in the Knowledge Configuration Sheet that was lost during the Agent Builder v2 transition. The toggle enables filesystem-like tools for data source navigation, allowing agents to explore content nodes, include files, and search files by name. The feature is implemented as a collapsible "Advanced Settings" section with a checkbox to enable/disable the advanced search capabilities for the search MCP server.

<img width="709" height="806" alt="Screenshot 2025-09-11 at 09 23 46" src="https://github.com/user-attachments/assets/6ad92b25-f297-4c3a-bef3-56500d8b5798" />

## Tests

Locally

## Risk

Low

## Deploy Plan

Deploy front