### PR TITLE
Allow popup in content generation iframe

### DIFF
--- a/front/components/assistant/conversation/actions/VisualizationActionIframe.tsx
+++ b/front/components/assistant/conversation/actions/VisualizationActionIframe.tsx
@@ -373,7 +373,7 @@ export const VisualizationActionIframe = forwardRef<
                     ref={combinedRef}
                     className={cn("h-full w-full", !errorMessage && "min-h-96")}
                     src={`${process.env.NEXT_PUBLIC_VIZ_URL}/content?identifier=${visualization.identifier}${isInDrawer ? "&fullHeight=true" : ""}`}
-                    sandbox="allow-scripts"
+                    sandbox="allow-scripts allow-popups"
                   />
                 </div>
               )}


### PR DESCRIPTION
## Description

-  https://github.com/dust-tt/tasks/issues/4080
- Add `allow-popups` to be able to open links using `target=_blank`

## Tests

Tested locally

## Risk

Security risks are low as we have control over the generation.
We could add extra security for example forbid redirection to `http://` addresses

More info: https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/iframe#allow-popups 

## Deploy Plan

Deploy front

