### PR TITLE
[front] remove slideshow outline tool

### DIFF
--- a/front/lib/actions/mcp_internal_actions/servers/slideshow/index.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/slideshow/index.ts
@@ -7,7 +7,6 @@ import { MCPError } from "@app/lib/actions/mcp_errors";
 import { validateTailwindCode } from "@app/lib/actions/mcp_internal_actions/servers/common/viz/validation";
 import {
   CREATE_SLIDESHOW_FILE_TOOL_NAME,
-  CREATE_SLIDESHOW_OUTLINE_TOOL_NAME,
   EDIT_SLIDESHOW_FILE_TOOL_NAME,
   RETRIEVE_SLIDESHOW_FILE_TOOL_NAME,
 } from "@app/lib/actions/mcp_internal_actions/servers/slideshow/types";
@@ -298,69 +297,6 @@ const createServer = (
             text:
               `Slideshow '${fileResource.sId}' (${fileResource.fileName}) retrieved ` +
               `successfully. Content:\n\n${content}`,
-          },
-        ]);
-      }
-    )
-  );
-
-  server.tool(
-    CREATE_SLIDESHOW_OUTLINE_TOOL_NAME,
-    "Create a structured outline for a slideshow presentation. This tool must be used before " +
-      "creating any slideshow content. Returns a formatted outline showing slide titles and key points that must be presented directly to the user for approval.",
-    {
-      topic: z.string().describe("The main topic or title of the slideshow"),
-      context: z
-        .string()
-        .optional()
-        .describe(
-          "Additional context, requirements, or background information"
-        ),
-      target_audience: z
-        .string()
-        .optional()
-        .describe(
-          "Intended audience (e.g., executives, technical team, clients)"
-        ),
-      slides: z
-        .array(
-          z.object({
-            title: z.string().describe("The title of the slide"),
-            key_points: z
-              .array(z.string())
-              .describe("Main points or content for this slide"),
-            notes: z
-              .string()
-              .optional()
-              .describe("Additional notes or requirements for this slide"),
-          })
-        )
-        .describe("Array of slides in the presentation"),
-    },
-    withToolLogging(
-      auth,
-      { toolName: CREATE_SLIDESHOW_OUTLINE_TOOL_NAME, agentLoopContext },
-      async ({ topic, context, target_audience, slides }) => {
-        const structuredOutline = {
-          topic,
-          context,
-          target_audience,
-          slides: slides.map((slide) => ({
-            title: slide.title,
-            key_points: slide.key_points,
-            notes: slide.notes,
-            detailedContent:
-              slide.key_points.join(". ") +
-              (slide.notes ? ` ${slide.notes}` : ""),
-          })),
-        };
-
-        return new Ok([
-          {
-            type: "text",
-            text:
-              `IMPORTANT: Present this outline to the user for review and confirmation before proceeding with slide creation.\n\n` +
-              `${structuredOutline}`,
           },
         ]);
       }

--- a/front/lib/actions/mcp_internal_actions/servers/slideshow/instructions.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/slideshow/instructions.ts
@@ -10,7 +10,6 @@ import {
 } from "@app/lib/actions/mcp_internal_actions/servers/common/viz/instructions";
 import {
   CREATE_SLIDESHOW_FILE_TOOL_NAME,
-  CREATE_SLIDESHOW_OUTLINE_TOOL_NAME,
   EDIT_SLIDESHOW_FILE_TOOL_NAME,
   RETRIEVE_SLIDESHOW_FILE_TOOL_NAME,
 } from "@app/lib/actions/mcp_internal_actions/servers/slideshow/types";
@@ -48,12 +47,6 @@ ${VIZ_USE_FILE_EXAMPLES}
 
 ### When to Use Slideshow Components:
 Use the Slideshow component in Content Creation files for: presentations, tutorials, step-by-step analysis, comparisons, reports
-
-WORKFLOW ENFORCEMENT:
-- STEP 1: ALWAYS use ${CREATE_SLIDESHOW_OUTLINE_TOOL_NAME} tool first
-- STEP 2: Wait for explicit user confirmation of the outline
-- STEP 3: Only after confirmation, proceed with slide creation
-- FORBIDDEN: Never create slides directly without outline approval
 
 CONTENT PRINCIPLES:
 - Start with your key insight, not background context

--- a/front/lib/actions/mcp_internal_actions/servers/slideshow/types.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/slideshow/types.ts
@@ -1,4 +1,3 @@
 export const CREATE_SLIDESHOW_FILE_TOOL_NAME = "create_slideshow_file";
 export const EDIT_SLIDESHOW_FILE_TOOL_NAME = "edit_slideshow_file";
 export const RETRIEVE_SLIDESHOW_FILE_TOOL_NAME = "retrieve_slideshow_file";
-export const CREATE_SLIDESHOW_OUTLINE_TOOL_NAME = "create_slideshow_outline";


### PR DESCRIPTION
## Description
This doesn't work well with dust-deep 🙃 and I imagine this tool would be a way to present data in slide format, instead of creating slides as users want. Let's remove it for now and we can come back in the future.

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
