### PR TITLE
[Durable Agents] Raise start-to-close for runmodel

### DIFF
--- a/front/temporal/agent_loop/workflows.ts
+++ b/front/temporal/agent_loop/workflows.ts
@@ -33,7 +33,7 @@ const activities: AgentLoopActivities = {
   runModelAndCreateActionsActivity: proxyActivities<
     typeof runModelAndCreateWrapperActivities
   >({
-    startToCloseTimeout: "7 minutes",
+    startToCloseTimeout: "10 minutes",
   }).runModelAndCreateActionsActivity,
   runToolActivity: proxyActivities<typeof runToolActivities>({
     // The activity timeout should be slightly longer than the max timeout of


### PR DESCRIPTION
Description
---
Fixes https://dust4ai.slack.com/archives/C05F84CFP0E/p1757572549946409

Since some overloaded model calls can be retried up to 3 times, 10mn stc is a 3mn30 min max time for model call, which should be more than enough.

:warning: We should however avoid going past this limit, and handle differently if issue reproduces

Risks
---
Low

Deploy
---
front

