### PR TITLE
Update coding rules: remove MCP serverInfo rule

### DIFF
--- a/front/CODING_RULES.md
+++ b/front/CODING_RULES.md
@@ -356,19 +356,14 @@ class ConversationModel extends Model { }
 
 ## MCP
 
-### [MCP1] Server description at the top of the file
-
-For internal MCP servers, the object `serverInfo` of type `InternalMCPServerDefinitionType` that
-holds the metadata of the server must be defined at the top of the file.
-
-### [MCP2] Single file internal servers
+### [MCP1] Single file internal servers
 
 If possible, internal MCP servers should fit in one file. The name of the file must match the
 name of the server. If having only one file is not possible, they should be placed into a folder
 that contains a file `server.ts` from where the `createServer` function that creates the server
 will be exported.
 
-### [MCP3] Tool output typing
+### [MCP2] Tool output typing
 
 If a tool in an internal MCP server outputs a custom resource, a `zod` schema that describes the
 output must be defined in `lib/actions/mcp_internal_actions/output_schemas.ts`. This way, when


### PR DESCRIPTION
## Description

MCP `serverInfo` are now defined on the constants file, so this rule is outdated. 

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

Merge.