### PR TITLE
Display triggers category in spaces (system or not)

### DIFF
--- a/front/components/actions/mcp/AdminActionsList.tsx
+++ b/front/components/actions/mcp/AdminActionsList.tsx
@@ -51,6 +51,7 @@ type RowData = {
 
 const NameCell = ({ row }: { row: RowData }) => {
   const { mcpServer, mcpServerView, isConnected } = row;
+
   return (
     <DataTable.CellContent grow>
       <div
@@ -162,32 +163,28 @@ export const AdminActionsList = ({
     () =>
       mcpServers
         .filter((mcpServer) => mcpServer.availability === "manual")
-        .map((mcpServer) => {
-          const mcpServerWithViews = mcpServers.find(
-            (s) => s.sId === mcpServer.sId
-          );
+        .map((mcpServerWithViews) => {
           const mcpServerView = mcpServerWithViews?.views.find(
             (v) => v.spaceId === systemSpace?.sId
           );
-          const spaceIds = mcpServerWithViews
-            ? mcpServerWithViews.views.map((v) => v.spaceId)
-            : [];
+          const spaceIds =
+            mcpServerWithViews?.views.map((v) => v.spaceId) ?? [];
           const agentsUsage =
             usage && mcpServerView ? usage[mcpServerView.server.sId] : null;
 
           return {
-            mcpServer,
+            mcpServer: mcpServerWithViews,
             mcpServerView,
             spaces: spaces.filter((s) => spaceIds?.includes(s.sId)),
             usage: agentsUsage,
             isConnected: !!connections.find(
               (c) =>
-                c.internalMCPServerId === mcpServer.sId ||
-                c.remoteMCPServerId === mcpServer.sId
+                c.internalMCPServerId === mcpServerWithViews.sId ||
+                c.remoteMCPServerId === mcpServerWithViews.sId
             ),
             onClick: () => {
-              if (mcpServerView && mcpServer) {
-                setMcpServerToShow(mcpServer);
+              if (mcpServerView && mcpServerWithViews) {
+                setMcpServerToShow(mcpServerWithViews);
               }
             },
           };
@@ -242,6 +239,7 @@ export const AdminActionsList = ({
         header: "Access",
         cell: (info: CellContext<RowData, SpaceType[]>) => {
           const globalSpace = info.getValue().find((s) => s.kind === "global");
+
           return (
             <DataTable.CellContent>
               <div className="flex items-center gap-2">
@@ -271,6 +269,7 @@ export const AdminActionsList = ({
         header: "By",
         cell: (info) => {
           const editedByUser = info.row.original.mcpServerView?.editedByUser;
+
           return (
             <DataTable.CellContent
               avatarUrl={editedByUser?.imageUrl ?? ANONYMOUS_USER_IMAGE_URL}

--- a/front/components/spaces/SpaceBreadcrumb.tsx
+++ b/front/components/spaces/SpaceBreadcrumb.tsx
@@ -1,5 +1,6 @@
 import type { BreadcrumbItem } from "@dust-tt/sparkle";
 import {
+  BellIcon,
   BoltIcon,
   Breadcrumbs,
   CloudArrowLeftRightIcon,
@@ -72,20 +73,32 @@ export function SpaceBreadCrumbs({
 
     if (space.kind === "system") {
       // Root managed connection in system space.
-      if (category === "managed" && !dataSourceView) {
-        return [
-          {
-            icon: CloudArrowLeftRightIcon,
-            label: "Connections Admin",
-          },
-        ];
-      } else if (category === "actions") {
-        return [
-          {
-            icon: BoltIcon,
-            label: "Tools",
-          },
-        ];
+      switch (category) {
+        case "managed": {
+          if (dataSourceView === undefined) {
+            return [
+              {
+                icon: CloudArrowLeftRightIcon,
+                label: "Connections Admin",
+              },
+            ];
+          }
+          break;
+        }
+        case "actions":
+          return [
+            {
+              icon: BoltIcon,
+              label: "Tools",
+            },
+          ];
+        case "triggers":
+          return [
+            {
+              icon: BellIcon,
+              label: "Triggers",
+            },
+          ];
       }
 
       // For system space, we don't want the first breadcrumb to show, since

--- a/front/components/spaces/SpaceSideBarMenu.tsx
+++ b/front/components/spaces/SpaceSideBarMenu.tsx
@@ -19,6 +19,7 @@ import { Fragment, useCallback, useEffect, useMemo, useState } from "react";
 
 import { useTheme } from "@app/components/sparkle/ThemeContext";
 import { usePersistedNavigationSelection } from "@app/hooks/usePersistedNavigationSelection";
+import { useSpaceSidebarItemFocus } from "@app/hooks/useSpaceSidebarItemFocus";
 import { getMcpServerDisplayName } from "@app/lib/actions/mcp_helper";
 import { getAvatar } from "@app/lib/actions/mcp_icons";
 import type { MCPServerViewType } from "@app/lib/api/mcp";
@@ -363,18 +364,10 @@ const SpaceMenuItem = ({
 }) => {
   const router = useRouter();
   const { setNavigationSelection } = usePersistedNavigationSelection();
-
   const spacePath = `/w/${owner.sId}/spaces/${space.sId}`;
-  const isAncestorToCurrentPage =
-    router.asPath.startsWith(spacePath + "/") || router.asPath === spacePath;
-
-  // Unfold the space if it's an ancestor of the current page.
-  const [isExpanded, setIsExpanded] = useState(false);
-  useEffect(() => {
-    if (isAncestorToCurrentPage) {
-      setIsExpanded(isAncestorToCurrentPage);
-    }
-  }, [isAncestorToCurrentPage]);
+  const { isExpanded, toggleExpanded, isSelected } = useSpaceSidebarItemFocus({
+    path: spacePath,
+  });
 
   const { spaceInfo, isSpaceInfoLoading } = useSpaceInfo({
     workspaceId: owner.sId,
@@ -394,8 +387,8 @@ const SpaceMenuItem = ({
         });
         void router.push(spacePath);
       }}
-      isSelected={router.asPath === spacePath}
-      onChevronClick={() => setIsExpanded(!isExpanded)}
+      isSelected={isSelected}
+      onChevronClick={toggleExpanded}
       visual={getSpaceIcon(space)}
       tailwindIconTextColor={isMember ? undefined : "text-warning-400"}
       areActionsFading={false}
@@ -576,17 +569,9 @@ const SpaceDataSourceViewSubMenu = ({
   const router = useRouter();
 
   const spaceCategoryPath = `/w/${owner.sId}/spaces/${space.sId}/categories/${category}`;
-  const isAncestorToCurrentPage =
-    router.asPath.startsWith(spaceCategoryPath + "/") ||
-    router.asPath === spaceCategoryPath;
-
-  // Unfold the space's category if it's an ancestor of the current page.
-  const [isExpanded, setIsExpanded] = useState(false);
-  useEffect(() => {
-    if (isAncestorToCurrentPage) {
-      setIsExpanded(isAncestorToCurrentPage);
-    }
-  }, [isAncestorToCurrentPage]);
+  const { isExpanded, toggleExpanded, isSelected } = useSpaceSidebarItemFocus({
+    path: spaceCategoryPath,
+  });
 
   const categoryDetails = CATEGORY_DETAILS[category];
   const { isSpaceDataSourceViewsLoading, spaceDataSourceViews } =
@@ -613,8 +598,8 @@ const SpaceDataSourceViewSubMenu = ({
         });
         void router.push(spaceCategoryPath);
       }}
-      isSelected={router.asPath === spaceCategoryPath}
-      onChevronClick={() => setIsExpanded(!isExpanded)}
+      isSelected={isSelected}
+      onChevronClick={toggleExpanded}
       visual={categoryDetails.icon}
       areActionsFading={false}
       type={
@@ -701,19 +686,10 @@ const SpaceAppSubMenu = ({
 }) => {
   const { setNavigationSelection } = usePersistedNavigationSelection();
   const router = useRouter();
-
   const spaceCategoryPath = `/w/${owner.sId}/spaces/${space.sId}/categories/${category}`;
-  const isAncestorToCurrentPage =
-    router.asPath.startsWith(spaceCategoryPath + "/") ||
-    router.asPath === spaceCategoryPath;
-
-  // Unfold the space's category if it's an ancestor of the current page.
-  const [isExpanded, setIsExpanded] = useState(false);
-  useEffect(() => {
-    if (isAncestorToCurrentPage) {
-      setIsExpanded(isAncestorToCurrentPage);
-    }
-  }, [isAncestorToCurrentPage]);
+  const { isExpanded, toggleExpanded, isSelected } = useSpaceSidebarItemFocus({
+    path: spaceCategoryPath,
+  });
 
   const categoryDetails = CATEGORY_DETAILS[category];
 
@@ -734,8 +710,8 @@ const SpaceAppSubMenu = ({
         });
         void router.push(spaceCategoryPath);
       }}
-      isSelected={router.asPath === spaceCategoryPath}
-      onChevronClick={() => setIsExpanded(!isExpanded)}
+      isSelected={isSelected}
+      onChevronClick={toggleExpanded}
       visual={categoryDetails.icon}
       areActionsFading={false}
       type={isAppsLoading || apps.length > 0 ? "node" : "leaf"}
@@ -762,19 +738,10 @@ const SpaceActionsSubMenu = ({
 }) => {
   const { setNavigationSelection } = usePersistedNavigationSelection();
   const router = useRouter();
-
   const spaceCategoryPath = `/w/${owner.sId}/spaces/${space.sId}/categories/${category}`;
-  const isAncestorToCurrentPage =
-    router.asPath.startsWith(spaceCategoryPath + "/") ||
-    router.asPath === spaceCategoryPath;
-
-  // Unfold the space's category if it's an ancestor of the current page.
-  const [isExpanded, setIsExpanded] = useState(false);
-  useEffect(() => {
-    if (isAncestorToCurrentPage) {
-      setIsExpanded(isAncestorToCurrentPage);
-    }
-  }, [isAncestorToCurrentPage]);
+  const { isExpanded, toggleExpanded, isSelected } = useSpaceSidebarItemFocus({
+    path: spaceCategoryPath,
+  });
 
   const categoryDetails = CATEGORY_DETAILS[category];
 
@@ -795,8 +762,8 @@ const SpaceActionsSubMenu = ({
         });
         void router.push(spaceCategoryPath);
       }}
-      isSelected={router.asPath === spaceCategoryPath}
-      onChevronClick={() => setIsExpanded(!isExpanded)}
+      isSelected={isSelected}
+      onChevronClick={toggleExpanded}
       visual={categoryDetails.icon}
       areActionsFading={false}
       type={isMCPServerViewsLoading || serverViews.length > 0 ? "node" : "leaf"}

--- a/front/components/spaces/SpaceSideBarMenu.tsx
+++ b/front/components/spaces/SpaceSideBarMenu.tsx
@@ -1,4 +1,5 @@
 import {
+  BellIcon,
   BoltIcon,
   Button,
   CloudArrowLeftRightIcon,
@@ -247,6 +248,12 @@ const SYSTEM_SPACE_ITEMS: {
     visual: BoltIcon,
     category: "actions",
     flag: null,
+  },
+  {
+    label: "Triggers",
+    visual: BellIcon,
+    category: "triggers",
+    flag: "hootl_webhooks",
   },
 ];
 

--- a/front/components/spaces/SpaceSideBarMenu.tsx
+++ b/front/components/spaces/SpaceSideBarMenu.tsx
@@ -49,6 +49,7 @@ import type {
   DataSourceViewType,
   LightWorkspaceType,
   SpaceType,
+  WhitelistableFeature,
 } from "@app/types";
 import { assertNever, DATA_SOURCE_VIEW_CATEGORIES } from "@app/types";
 
@@ -229,17 +230,22 @@ const getSpaceSectionDetails = (
 
 // System space.
 
-const SYSTEM_SPACE_ITEMS = [
+const SYSTEM_SPACE_ITEMS: {
+  label: string;
+  visual: IconType;
+  category: DataSourceViewCategory;
+  flag: WhitelistableFeature | null;
+}[] = [
   {
     label: "Connections",
     visual: CloudArrowLeftRightIcon,
-    category: "managed" as DataSourceViewCategory,
+    category: "managed",
     flag: null,
   },
   {
     label: "Tools",
     visual: BoltIcon,
-    category: "actions" as DataSourceViewCategory,
+    category: "actions",
     flag: null,
   },
 ];

--- a/front/components/spaces/SpaceTriggersList.tsx
+++ b/front/components/spaces/SpaceTriggersList.tsx
@@ -1,0 +1,126 @@
+import { DataTable, Spinner } from "@dust-tt/sparkle";
+import type { CellContext, ColumnDef } from "@tanstack/react-table";
+import * as React from "react";
+
+import { usePaginationFromUrl } from "@app/hooks/usePaginationFromUrl";
+import { useWebhookSourceViews } from "@app/lib/swr/webhook_source";
+import { formatTimestampToFriendlyDate } from "@app/lib/utils";
+import type { LightWorkspaceType, SpaceType } from "@app/types";
+
+type RowData = {
+  id: string;
+  name: string;
+  lastUpdated: number;
+  onClick?: () => void;
+};
+
+interface SpaceActionsListProps {
+  owner: LightWorkspaceType;
+  space: SpaceType;
+}
+
+export const SpaceTriggersList = ({ owner, space }: SpaceActionsListProps) => {
+  const { webhookSourceViews, isWebhookSourceViewsLoading } =
+    useWebhookSourceViews({
+      owner,
+      space,
+    });
+
+  const { pagination, setPagination } = usePaginationFromUrl({
+    urlPrefix: "table",
+  });
+
+  const columns: ColumnDef<RowData, string>[] = [
+    {
+      id: "name",
+      cell: (info: CellContext<RowData, string>) => (
+        <DataTable.CellContent>
+          <div className="flex flex-row items-center gap-2 py-3">
+            {info.row.original.name}
+          </div>
+        </DataTable.CellContent>
+      ),
+      accessorFn: (row: RowData) => row.name,
+    },
+    {
+      id: "lastUpdated",
+      header: "Last updated",
+      cell: (info: CellContext<RowData, string>) => (
+        <DataTable.BasicCellContent
+          label={formatTimestampToFriendlyDate(
+            info.row.original.lastUpdated,
+            "compact"
+          )}
+        />
+      ),
+      meta: {
+        className: "w-28",
+      },
+    },
+  ];
+
+  const rows: RowData[] = React.useMemo(() => {
+    // Add some fake rows for UI testing
+    const fakeRows: RowData[] = [
+      {
+        id: "fake-trigger-1",
+        name: "Slack Message Trigger",
+        lastUpdated: Date.now() - 1000 * 60 * 60 * 2, // 2 hours ago
+      },
+      {
+        id: "fake-trigger-2",
+        name: "GitHub PR Webhook",
+        lastUpdated: Date.now() - 1000 * 60 * 60 * 24, // 1 day ago
+      },
+      {
+        id: "fake-trigger-3",
+        name: "Email Notification Trigger",
+        lastUpdated: Date.now() - 1000 * 60 * 30, // 30 minutes ago
+      },
+      {
+        id: "fake-trigger-4",
+        name: "Document Update Trigger",
+        lastUpdated: Date.now() - 1000 * 60 * 60 * 48, // 2 days ago
+      },
+    ];
+
+    const realRows =
+      webhookSourceViews.map((webhookSourceView) => ({
+        id: webhookSourceView.sId,
+        name:
+          webhookSourceView.customName ?? webhookSourceView.webhookSource.name,
+        lastUpdated: webhookSourceView.updatedAt,
+      })) || [];
+
+    return [...realRows, ...fakeRows];
+  }, [webhookSourceViews]);
+
+  if (isWebhookSourceViewsLoading) {
+    return (
+      <div className="mt-8 flex justify-center">
+        <Spinner size="lg" />
+      </div>
+    );
+  }
+
+  const isEmpty = rows.length === 0;
+
+  return (
+    <>
+      {isEmpty ? (
+        <div className="text-center text-sm text-muted-foreground dark:text-muted-foreground-night">
+          You don’t have any triggers yet.
+        </div>
+      ) : (
+        <DataTable
+          data={rows}
+          columns={columns}
+          className="pb-4"
+          filterColumn="name"
+          pagination={pagination}
+          setPagination={setPagination}
+        />
+      )}
+    </>
+  );
+};

--- a/front/components/spaces/SpaceTriggersList.tsx
+++ b/front/components/spaces/SpaceTriggersList.tsx
@@ -59,41 +59,16 @@ export const SpaceTriggersList = ({ owner, space }: SpaceActionsListProps) => {
     },
   ];
 
-  const rows: RowData[] = React.useMemo(() => {
-    // Add some fake rows for UI testing
-    const fakeRows: RowData[] = [
-      {
-        id: "fake-trigger-1",
-        name: "Slack Message Trigger",
-        lastUpdated: Date.now() - 1000 * 60 * 60 * 2, // 2 hours ago
-      },
-      {
-        id: "fake-trigger-2",
-        name: "GitHub PR Webhook",
-        lastUpdated: Date.now() - 1000 * 60 * 60 * 24, // 1 day ago
-      },
-      {
-        id: "fake-trigger-3",
-        name: "Email Notification Trigger",
-        lastUpdated: Date.now() - 1000 * 60 * 30, // 30 minutes ago
-      },
-      {
-        id: "fake-trigger-4",
-        name: "Document Update Trigger",
-        lastUpdated: Date.now() - 1000 * 60 * 60 * 48, // 2 days ago
-      },
-    ];
-
-    const realRows =
+  const rows: RowData[] = React.useMemo(
+    () =>
       webhookSourceViews.map((webhookSourceView) => ({
         id: webhookSourceView.sId,
         name:
           webhookSourceView.customName ?? webhookSourceView.webhookSource.name,
         lastUpdated: webhookSourceView.updatedAt,
-      })) || [];
-
-    return [...realRows, ...fakeRows];
-  }, [webhookSourceViews]);
+      })),
+    [webhookSourceViews]
+  );
 
   if (isWebhookSourceViewsLoading) {
     return (

--- a/front/components/spaces/SystemSpaceTriggersList.tsx
+++ b/front/components/spaces/SystemSpaceTriggersList.tsx
@@ -1,0 +1,22 @@
+import * as React from "react";
+
+import { AdminTriggersList } from "@app/components/triggers/AdminTriggersList";
+import type { LightWorkspaceType, SpaceType } from "@app/types";
+
+interface SpaceActionsListProps {
+  isAdmin: boolean;
+  owner: LightWorkspaceType;
+  space: SpaceType;
+}
+
+export const SystemSpaceTriggersList = ({
+  owner,
+  isAdmin,
+  space,
+}: SpaceActionsListProps) => {
+  if (!isAdmin) {
+    return null;
+  }
+
+  return <AdminTriggersList owner={owner} systemSpace={space} />;
+};

--- a/front/hooks/useSpaceSidebarItemFocus.ts
+++ b/front/hooks/useSpaceSidebarItemFocus.ts
@@ -1,0 +1,29 @@
+import escapeRegExp from "lodash/escapeRegExp";
+import { useRouter } from "next/router";
+import { useEffect, useState } from "react";
+
+export function useSpaceSidebarItemFocus({ path }: { path: string }) {
+  const router = useRouter();
+  const [isExpanded, setIsExpanded] = useState(false);
+
+  const currentRouterPath = router.asPath;
+
+  // Check if input path is a descendant of the given path:
+  const descendantRegex = new RegExp(`^${escapeRegExp(path)}/?$`);
+  const isDescendant = descendantRegex.test(currentRouterPath);
+
+  const isSamePath = currentRouterPath === path;
+
+  // Unfold the space's category if it's an ancestor of the current page.
+  useEffect(() => {
+    if (isDescendant) {
+      setIsExpanded(true);
+    }
+  }, [isDescendant]);
+
+  return {
+    isExpanded,
+    toggleExpanded: () => setIsExpanded((prev) => !prev),
+    isSelected: isSamePath,
+  };
+}

--- a/front/lib/api/agent_data_sources.ts
+++ b/front/lib/api/agent_data_sources.ts
@@ -69,6 +69,9 @@ export async function getDataSourceViewsUsageByCategory({
     case "actions":
       connectorProvider = null;
       break;
+    case "triggers":
+      connectorProvider = null;
+      break;
     default:
       assertNever(category);
   }

--- a/front/lib/resources/webhook_sources_view_resource.ts
+++ b/front/lib/resources/webhook_sources_view_resource.ts
@@ -20,7 +20,7 @@ import type { UserResource } from "@app/lib/resources/user_resource";
 import { WebhookSourceResource } from "@app/lib/resources/webhook_source_resource";
 import type { ModelId, Result } from "@app/types";
 import { Err, formatUserFullName, Ok, removeNulls } from "@app/types";
-import type { WebhookSourcesViewType } from "@app/types/triggers/webhooks";
+import type { WebhookSourceViewType } from "@app/types/triggers/webhooks";
 
 // Attributes are marked as read-only to reflect the stateless nature of our Resource.
 // eslint-disable-next-line @typescript-eslint/no-empty-interface, @typescript-eslint/no-unsafe-declaration-merging
@@ -405,7 +405,7 @@ export class WebhookSourcesViewResource extends ResourceWithSpace<WebhookSources
   }
 
   // Serialization.
-  toJSON(): WebhookSourcesViewType {
+  toJSON(): WebhookSourceViewType {
     return {
       id: this.id,
       sId: this.sId,

--- a/front/lib/spaces.ts
+++ b/front/lib/spaces.ts
@@ -1,4 +1,5 @@
 import {
+  BellIcon,
   CloudArrowLeftRightIcon,
   CommandLineIcon,
   CompanyIcon,
@@ -130,6 +131,11 @@ export const CATEGORY_DETAILS: {
   actions: {
     label: "Tools",
     icon: MCP_SPECIFICATION.cardIcon,
+  },
+  triggers: {
+    label: "Triggers",
+    icon: BellIcon,
+    flag: "hootl_webhooks",
   },
 };
 

--- a/front/lib/swr/webhook_source.ts
+++ b/front/lib/swr/webhook_source.ts
@@ -16,7 +16,10 @@ export function useWebhookSourceViews({
   disabled?: boolean;
 }) {
   const configFetcher: Fetcher<GetWebhookSourceViewsResponseBody> = fetcher;
-  const url = getWebhookSourceViewsKey(owner, space);
+  const url =
+    space !== undefined
+      ? `/api/w/${owner.sId}/spaces/${space.sId}/webhook_source_views`
+      : null;
   const { data, error, mutate } = useSWRWithDefaults(url, configFetcher, {
     disabled,
   });
@@ -33,14 +36,6 @@ export function useWebhookSourceViews({
   };
 }
 
-function getWebhookSourceViewsKey(
-  owner: LightWorkspaceType,
-  space?: SpaceType
-) {
-  return space !== undefined
-    ? `/api/w/${owner.sId}/spaces/${space.sId}/webhook_source_views`
-    : null;
-}
 export function useWebhookSourcesWithViews({
   owner,
   disabled,

--- a/front/lib/swr/webhook_source.ts
+++ b/front/lib/swr/webhook_source.ts
@@ -1,0 +1,34 @@
+import type { Fetcher } from "swr";
+
+import { emptyArray, fetcher, useSWRWithDefaults } from "@app/lib/swr/swr";
+import type { GetWebhookSourcesResponseBody } from "@app/pages/api/w/[wId]/webhook_sources";
+import type { LightWorkspaceType } from "@app/types";
+
+export function useWebhookSourcesWithViews({
+  owner,
+  disabled,
+}: {
+  owner: LightWorkspaceType;
+  disabled?: boolean;
+}) {
+  const configFetcher: Fetcher<GetWebhookSourcesResponseBody> = fetcher;
+
+  const url = `/api/w/${owner.sId}/webhook_sources`;
+
+  const { data, error, mutateRegardlessOfQueryParams } = useSWRWithDefaults(
+    url,
+    configFetcher,
+    {
+      disabled,
+    }
+  );
+
+  const webhookSourcesWithViews = data?.webhookSourcesWithViews ?? emptyArray();
+
+  return {
+    webhookSourcesWithViews,
+    isWebhookSourcesWithViewsLoading: !error && !data && !disabled,
+    isWebhookSourcesWithViewsError: error,
+    mutateWebhookSourcesWithViews: mutateRegardlessOfQueryParams,
+  };
+}

--- a/front/lib/swr/webhook_source.ts
+++ b/front/lib/swr/webhook_source.ts
@@ -1,9 +1,46 @@
+import { useMemo } from "react";
 import type { Fetcher } from "swr";
 
 import { emptyArray, fetcher, useSWRWithDefaults } from "@app/lib/swr/swr";
+import type { GetWebhookSourceViewsResponseBody } from "@app/pages/api/w/[wId]/spaces/[spaceId]/webhook_source_views";
 import type { GetWebhookSourcesResponseBody } from "@app/pages/api/w/[wId]/webhook_sources";
-import type { LightWorkspaceType } from "@app/types";
+import type { LightWorkspaceType, SpaceType } from "@app/types";
 
+export function useWebhookSourceViews({
+  owner,
+  space,
+  disabled,
+}: {
+  owner: LightWorkspaceType;
+  space?: SpaceType;
+  disabled?: boolean;
+}) {
+  const configFetcher: Fetcher<GetWebhookSourceViewsResponseBody> = fetcher;
+  const url = getWebhookSourceViewsKey(owner, space);
+  const { data, error, mutate } = useSWRWithDefaults(url, configFetcher, {
+    disabled,
+  });
+  const webhookSourceViews = useMemo(
+    () => data?.webhookSourceViews ?? [],
+    [data]
+  );
+
+  return {
+    webhookSourceViews,
+    isWebhookSourceViewsLoading: !error && !data && !disabled,
+    isWebhookSourceViewsError: error,
+    mutateWebhookSourceViews: mutate,
+  };
+}
+
+function getWebhookSourceViewsKey(
+  owner: LightWorkspaceType,
+  space?: SpaceType
+) {
+  return space !== undefined
+    ? `/api/w/${owner.sId}/spaces/${space.sId}/webhook_source_views`
+    : null;
+}
 export function useWebhookSourcesWithViews({
   owner,
   disabled,

--- a/front/pages/api/w/[wId]/spaces/[spaceId]/webhook_source_views/index.test.ts
+++ b/front/pages/api/w/[wId]/spaces/[spaceId]/webhook_source_views/index.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from "vitest";
+
+import { createPrivateApiMockRequest } from "@app/tests/utils/generic_private_api_tests";
+import { SpaceFactory } from "@app/tests/utils/SpaceFactory";
+
+import handler from "./index";
+
+describe("GET /api/w/[wId]/spaces/[spaceId]/webhook_source_views", () => {
+  it("returns webhook source views", async () => {
+    const { req, res, workspace } = await createPrivateApiMockRequest({
+      role: "admin",
+    });
+
+    // Create a system space
+    const systemSpace = await SpaceFactory.system(workspace);
+    req.query.spaceId = systemSpace.sId;
+
+    await handler(req, res);
+
+    expect(res._getStatusCode()).toBe(200);
+    expect(res._getJSONData()).toEqual({
+      success: true,
+      webhookSourceViews: expect.any(Array),
+    });
+  });
+});

--- a/front/pages/api/w/[wId]/spaces/[spaceId]/webhook_source_views/index.ts
+++ b/front/pages/api/w/[wId]/spaces/[spaceId]/webhook_source_views/index.ts
@@ -1,0 +1,53 @@
+import type { NextApiRequest, NextApiResponse } from "next";
+
+import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
+import { withResourceFetchingFromRoute } from "@app/lib/api/resource_wrappers";
+import type { Authenticator } from "@app/lib/auth";
+import type { SpaceResource } from "@app/lib/resources/space_resource";
+import { WebhookSourcesViewResource } from "@app/lib/resources/webhook_sources_view_resource";
+import { apiError } from "@app/logger/withlogging";
+import type { WithAPIErrorResponse } from "@app/types";
+import type { WebhookSourceViewType } from "@app/types/triggers/webhooks";
+
+export type GetWebhookSourceViewsResponseBody = {
+  success: boolean;
+  webhookSourceViews: WebhookSourceViewType[];
+};
+
+async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse<WithAPIErrorResponse<GetWebhookSourceViewsResponseBody>>,
+  auth: Authenticator,
+  { space }: { space: SpaceResource }
+): Promise<void> {
+  const { method } = req;
+
+  switch (method) {
+    case "GET": {
+      const webhookSourceViewResources =
+        await WebhookSourcesViewResource.listBySpace(auth, space);
+
+      return res.status(200).json({
+        success: true,
+        webhookSourceViews: webhookSourceViewResources.map(
+          (webhookSourceViewResource) => webhookSourceViewResource.toJSON()
+        ),
+      });
+    }
+    default: {
+      return apiError(req, res, {
+        status_code: 405,
+        api_error: {
+          type: "method_not_supported_error",
+          message: "The method passed is not supported, GET is expected",
+        },
+      });
+    }
+  }
+}
+
+export default withSessionAuthenticationForWorkspace(
+  withResourceFetchingFromRoute(handler, {
+    space: { requireCanReadOrAdministrate: true },
+  })
+);

--- a/front/pages/api/w/[wId]/webhook_sources/index.test.ts
+++ b/front/pages/api/w/[wId]/webhook_sources/index.test.ts
@@ -1,0 +1,65 @@
+import type { RequestMethod } from "node-mocks-http";
+import { describe, expect, it } from "vitest";
+
+import { createPrivateApiMockRequest } from "@app/tests/utils/generic_private_api_tests";
+import { SpaceFactory } from "@app/tests/utils/SpaceFactory";
+import { WebhookSourceFactory } from "@app/tests/utils/WebhookSourceFactory";
+
+import handler from "./index";
+
+async function setupTest(
+  role: "builder" | "user" | "admin" = "admin",
+  method: RequestMethod = "GET"
+) {
+  const { req, res, workspace, authenticator } =
+    await createPrivateApiMockRequest({
+      role,
+      method,
+    });
+
+  // Create a system space to hold the Webhook sources
+  await SpaceFactory.defaults(authenticator);
+
+  // Set up common query parameters
+  req.query.wId = workspace.sId;
+
+  return { req, res, workspace, authenticator };
+}
+
+describe("GET /api/w/[wId]/webhook_sources/", () => {
+  it("should return a list of webhook sources", async () => {
+    const { req, res, workspace } = await setupTest();
+    const webhookSourceFactory = new WebhookSourceFactory(workspace);
+
+    // Create two test servers
+    await webhookSourceFactory.create({
+      name: "Test Webhook Source 1",
+    });
+
+    await webhookSourceFactory.create({
+      name: "Test Webhook Source 2",
+    });
+
+    await handler(req, res);
+
+    expect(res._getStatusCode()).toBe(200);
+
+    const responseData = res._getJSONData();
+
+    expect(responseData).toHaveProperty("webhookSourcesWithViews");
+    expect(responseData.webhookSourcesWithViews).toHaveLength(2);
+  });
+
+  it("should return empty array when no webhook sources exist", async () => {
+    const { req, res } = await setupTest();
+
+    await handler(req, res);
+
+    expect(res._getStatusCode()).toBe(200);
+
+    const responseData = res._getJSONData();
+    expect(responseData).toHaveProperty("webhookSourcesWithViews");
+    expect(responseData.webhookSourcesWithViews).toBeInstanceOf(Array);
+    expect(responseData.webhookSourcesWithViews).toHaveLength(0);
+  });
+});

--- a/front/pages/api/w/[wId]/webhook_sources/index.ts
+++ b/front/pages/api/w/[wId]/webhook_sources/index.ts
@@ -1,0 +1,62 @@
+import type { NextApiRequest, NextApiResponse } from "next";
+
+import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
+import type { Authenticator } from "@app/lib/auth";
+import { WebhookSourceResource } from "@app/lib/resources/webhook_source_resource";
+import { WebhookSourcesViewResource } from "@app/lib/resources/webhook_sources_view_resource";
+import { concurrentExecutor } from "@app/lib/utils/async_utils";
+import { apiError } from "@app/logger/withlogging";
+import type { WithAPIErrorResponse } from "@app/types";
+import type { WebhookSourceWithViews } from "@app/types/triggers/webhooks";
+
+export type GetWebhookSourcesResponseBody = {
+  success: true;
+  webhookSourcesWithViews: WebhookSourceWithViews[];
+};
+
+async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse<WithAPIErrorResponse<GetWebhookSourcesResponseBody>>,
+  auth: Authenticator
+): Promise<void> {
+  const { method } = req;
+
+  switch (method) {
+    case "GET": {
+      const webhookSourceResources =
+        await WebhookSourceResource.listByWorkspace(auth);
+
+      return res.status(200).json({
+        success: true,
+        webhookSourcesWithViews: await concurrentExecutor(
+          webhookSourceResources,
+          async (webhookSourceResource) => {
+            const webhookSource = webhookSourceResource.toJSON();
+            const views = (
+              await WebhookSourcesViewResource.listByWebhookSource(
+                auth,
+                webhookSource.id
+              )
+            ).map((view) => view.toJSON());
+
+            return { ...webhookSource, views };
+          },
+          {
+            concurrency: 10,
+          }
+        ),
+      });
+    }
+    default: {
+      return apiError(req, res, {
+        status_code: 405,
+        api_error: {
+          type: "method_not_supported_error",
+          message: "The method passed is not supported, GET is expected.",
+        },
+      });
+    }
+  }
+}
+
+export default withSessionAuthenticationForWorkspace(handler);

--- a/front/pages/w/[wId]/spaces/[spaceId]/categories/triggers/index.tsx
+++ b/front/pages/w/[wId]/spaces/[spaceId]/categories/triggers/index.tsx
@@ -1,0 +1,81 @@
+import type { InferGetServerSidePropsType } from "next";
+import type { ReactElement } from "react";
+
+import type { SpaceLayoutPageProps } from "@app/components/spaces/SpaceLayout";
+import { SpaceLayout } from "@app/components/spaces/SpaceLayout";
+import { SpaceTriggersList } from "@app/components/spaces/SpaceTriggersList";
+import { SystemSpaceTriggersList } from "@app/components/spaces/SystemSpaceTriggersList";
+import AppRootLayout from "@app/components/sparkle/AppRootLayout";
+import { withDefaultUserAuthRequirements } from "@app/lib/iam/session";
+import { SpaceResource } from "@app/lib/resources/space_resource";
+import type { DataSourceViewCategory, SpaceType, UserType } from "@app/types";
+
+export const getServerSideProps = withDefaultUserAuthRequirements<
+  SpaceLayoutPageProps & {
+    category: DataSourceViewCategory;
+    isAdmin: boolean;
+    user: UserType;
+    space: SpaceType;
+  }
+>(async (context, auth) => {
+  const owner = auth.getNonNullableWorkspace();
+  const user = auth.getNonNullableUser();
+  const subscription = auth.subscription();
+  const plan = auth.getNonNullablePlan();
+  const isAdmin = auth.isAdmin();
+
+  const { spaceId } = context.query;
+
+  if (!subscription || typeof spaceId !== "string") {
+    return {
+      notFound: true,
+    };
+  }
+
+  const space = await SpaceResource.fetchById(auth, spaceId);
+  if (space === null || !space.canReadOrAdministrate(auth)) {
+    return {
+      notFound: true,
+    };
+  }
+
+  const isBuilder = auth.isBuilder();
+  const canWriteInSpace = space.canWrite(auth);
+
+  return {
+    props: {
+      canReadInSpace: space.canRead(auth),
+      canWriteInSpace,
+      category: "triggers",
+      isAdmin,
+      isBuilder,
+      owner,
+      user: user.toJSON(),
+      plan,
+      space: space.toJSON(),
+      subscription,
+    },
+  };
+});
+
+export default function Space({
+  isAdmin,
+  owner,
+  space,
+}: InferGetServerSidePropsType<typeof getServerSideProps>) {
+  if (space.kind === "system") {
+    return (
+      <SystemSpaceTriggersList isAdmin={isAdmin} owner={owner} space={space} />
+    );
+  }
+
+  return <SpaceTriggersList owner={owner} space={space} />;
+}
+
+Space.getLayout = (page: ReactElement, pageProps: any) => {
+  return (
+    <AppRootLayout>
+      <SpaceLayout pageProps={pageProps}>{page}</SpaceLayout>
+    </AppRootLayout>
+  );
+};

--- a/front/tests/utils/WebhookSourceFactory.ts
+++ b/front/tests/utils/WebhookSourceFactory.ts
@@ -1,0 +1,33 @@
+import { faker } from "@faker-js/faker";
+
+import { Authenticator } from "@app/lib/auth";
+import { WebhookSourceResource } from "@app/lib/resources/webhook_source_resource";
+import type { WorkspaceType } from "@app/types";
+
+export class WebhookSourceFactory {
+  private workspace: WorkspaceType;
+
+  constructor(workspace: WorkspaceType) {
+    this.workspace = workspace;
+  }
+
+  async create(
+    options: {
+      name?: string;
+    } = {}
+  ) {
+    const cachedName =
+      options.name || "Test WebhookSource" + faker.number.int(1000);
+
+    const auth = await Authenticator.internalAdminForWorkspace(
+      this.workspace.sId
+    );
+
+    const result = await WebhookSourceResource.makeNew(auth, {
+      workspaceId: this.workspace.id,
+      name: cachedName,
+    });
+
+    return result;
+  }
+}

--- a/front/types/api/public/spaces.ts
+++ b/front/types/api/public/spaces.ts
@@ -37,6 +37,7 @@ export const DATA_SOURCE_VIEW_CATEGORIES = [
   "website",
   "apps",
   "actions",
+  "triggers",
 ] as const;
 
 export type DataSourceViewCategory =

--- a/front/types/shared/feature_flags.ts
+++ b/front/types/shared/feature_flags.ts
@@ -182,6 +182,10 @@ export const WHITELISTABLE_FEATURES_CONFIG = {
       "Enable splitting agent responses into multiple Slack messages for Slack (instead of truncation)",
     stage: "dust_only",
   },
+  hootl_webhooks: {
+    description: "Webhooks for Human Out Of The Loop (aka Triggers) / webhooks",
+    stage: "dust_only",
+  },
 } as const satisfies Record<string, FeatureFlag>;
 
 export type FeatureFlagStage = "dust_only" | "rolling_out" | "on_demand";

--- a/front/types/triggers/webhooks.ts
+++ b/front/types/triggers/webhooks.ts
@@ -26,6 +26,10 @@ export type WebhookSourceViewType = {
   editedByUser: EditedByUser | null;
 };
 
+export type WebhookSourceWithViews = WebhookSourceType & {
+  views: WebhookSourceViewType[];
+};
+
 export const WebhookSourceSchema = t.type({
   name: t.string,
   secret: t.string,

--- a/front/types/triggers/webhooks.ts
+++ b/front/types/triggers/webhooks.ts
@@ -1,7 +1,7 @@
-import { ModelId } from "@app/types/shared/model_id";
-import { EditedByUser } from "@app/types/user";
-
 import * as t from "io-ts";
+
+import type { ModelId } from "@app/types/shared/model_id";
+import type { EditedByUser } from "@app/types/user";
 
 export type WebhookSourceType = {
   id: ModelId;
@@ -15,7 +15,7 @@ export type WebhookSourceType = {
   updatedAt: number;
 };
 
-export type WebhookSourcesViewType = {
+export type WebhookSourceViewType = {
   id: ModelId;
   sId: string;
   customName: string | null;

--- a/sdks/js/package.json
+++ b/sdks/js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dust-tt/client",
-  "version": "1.1.13",
+  "version": "1.1.14",
   "description": "Client for Dust API",
   "repository": {
     "type": "git",

--- a/sdks/js/src/types.ts
+++ b/sdks/js/src/types.ts
@@ -633,6 +633,7 @@ const WhitelistableFeaturesSchema = FlexibleEnumSchema<
   | "google_sheets_tool"
   | "hootl"
   | "hootl_subscriptions"
+  | "hootl_webhooks"
   | "index_private_slack_channel"
   | "interactive_content_server"
   | "jira_tool"

--- a/sdks/js/src/types.ts
+++ b/sdks/js/src/types.ts
@@ -481,7 +481,7 @@ export interface LoggerInterface {
 }
 
 const DataSourceViewCategoriesSchema = FlexibleEnumSchema<
-  "managed" | "folder" | "website" | "apps" | "actions"
+  "managed" | "folder" | "website" | "apps" | "actions" | "triggers"
 >();
 
 const BlockTypeSchema = FlexibleEnumSchema<


### PR DESCRIPTION
## Description

[4026](https://github.com/dust-tt/tasks/issues/4026)
[4035](https://github.com/dust-tt/tasks/issues/4035)

### System space
<img width="1677" height="670" alt="Screenshot 2025-09-10 at 18 39 23" src="https://github.com/user-attachments/assets/61c9d8bf-64b0-46d3-939f-1c512546bc46" />
<img width="1677" height="668" alt="Screenshot 2025-09-10 at 18 41 22" src="https://github.com/user-attachments/assets/fa53eb69-8eed-4776-bfa5-dc84f9b65114" />
<img width="1676" height="670" alt="Screenshot 2025-09-10 at 18 42 04" src="https://github.com/user-attachments/assets/cf86da52-31e2-4f22-9d4a-d1dbb55b364f" />

### Non-system space
<img width="1660" height="689" alt="Screenshot 2025-09-11 at 11 08 55" src="https://github.com/user-attachments/assets/623f6b76-520a-4f14-b43e-057181054665" />

## Tests

Added tests for new api endpoints :
- webhook_sources
- webhook_source_views

## Deploy Plan

Added a feature flag "hootl_webhooks"
