### PR TITLE
[front] schedules: split in 2 feature flags

### DIFF
--- a/front/components/assistant/details/AssistantDetails.tsx
+++ b/front/components/assistant/details/AssistantDetails.tsx
@@ -114,7 +114,9 @@ export function AssistantDetails({
   const [showRestoreModal, setShowRestoreModal] = useState(false);
   const showEditorsTabs = assistantId != null && !isGlobalAgent;
   const showTriggersTabs =
-    assistantId != null && !isGlobalAgent && featureFlags.includes("hootl");
+    assistantId != null &&
+    !isGlobalAgent &&
+    featureFlags.includes("hootl_subscriptions");
   const showAgentMemory = !!agentConfiguration?.actions.find(
     isMCPConfigurationForAgentMemory
   );

--- a/front/pages/w/[wId]/me/index.tsx
+++ b/front/pages/w/[wId]/me/index.tsx
@@ -74,12 +74,14 @@ export default function ProfilePage({
             <Separator />
 
             <Page.SectionHeader
-              title={hasFeature("hootl") ? "Tools & Triggers" : "Tools"}
+              title={
+                hasFeature("hootl_subscriptions") ? "Tools & Triggers" : "Tools"
+              }
             />
             <Tabs defaultValue="tools" className="w-full">
               <TabsList>
                 <TabsTrigger value="tools" label="Tools" icon={BoltIcon} />
-                {hasFeature("hootl") && (
+                {hasFeature("hootl_subscriptions") && (
                   <TabsTrigger
                     value="triggers"
                     label="Triggers"
@@ -90,7 +92,7 @@ export default function ProfilePage({
               <TabsContent value="tools" className="mt-4">
                 <UserToolsTable owner={owner} />
               </TabsContent>
-              {hasFeature("hootl") && (
+              {hasFeature("hootl_subscriptions") && (
                 <TabsContent value="triggers" className="mt-4">
                   <ProfileTriggersTab owner={owner} />
                 </TabsContent>

--- a/front/types/shared/feature_flags.ts
+++ b/front/types/shared/feature_flags.ts
@@ -157,7 +157,11 @@ export const WHITELISTABLE_FEATURES_CONFIG = {
     stage: "dust_only",
   },
   hootl: {
-    description: "Human Out Of The Loop (aka Triggers)",
+    description: "Display Triggers section in the Agent Builder",
+    stage: "rolling_out",
+  },
+  hootl_subscriptions: {
+    description: "Subscription feature for Schedule & Triggers.",
     stage: "dust_only",
   },
   slack_enhanced_default_agent: {

--- a/sdks/js/src/types.ts
+++ b/sdks/js/src/types.ts
@@ -632,6 +632,7 @@ const WhitelistableFeaturesSchema = FlexibleEnumSchema<
   | "google_drive_tool"
   | "google_sheets_tool"
   | "hootl"
+  | "hootl_subscriptions"
   | "index_private_slack_channel"
   | "interactive_content_server"
   | "jira_tool"


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

For now, the whole hootl feature was under a single feature flag.
We want the agent builder part to be it's own feature flag.
We want the subscription features to be it's own feature flag.

We'll start by releasing the hootl ff.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

Tested by hand

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

Low

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->

Deploy front