### PR TITLE
Fix: leverage indexes correctly for mcp server views metadata

### DIFF
--- a/front/lib/resources/mcp_server_view_resource.ts
+++ b/front/lib/resources/mcp_server_view_resource.ts
@@ -233,11 +233,17 @@ export class MCPServerViewResource extends ResourceWithSpace<MCPServerViewModel>
           model: RemoteMCPServerToolMetadataModel,
           as: "internalToolsMetadata",
           required: false,
+          where: {
+            workspaceId: auth.getNonNullableWorkspace().id,
+          },
         },
         {
           model: RemoteMCPServerToolMetadataModel,
           as: "remoteToolsMetadata",
           required: false,
+          where: {
+            workspaceId: auth.getNonNullableWorkspace().id,
+          },
         },
       ],
     });


### PR DESCRIPTION
## Description

Was not leveraging the existing indexes has they requires to have the workspaceId as well.

## Tests

Local (checking the generated SQL) + EXPLAIN ANALYZE in prod.

## Risk

Low

## Deploy Plan

Deploy front