### PR TITLE
feat(front): enable voice on iphone voice recordings

### DIFF
--- a/front/types/files.ts
+++ b/front/types/files.ts
@@ -319,6 +319,13 @@ export const FILE_FORMATS = {
     exts: [".mp3", ".mp4"],
     isSafeToDisplay: false,
   },
+  // In theory deprecated => https://mimetype.io/audio/x-m4a
+  // But apple voice recordings use it.
+  "audio/x-m4a": {
+    cat: "audio",
+    exts: [".m4a", ".mp4"],
+    isSafeToDisplay: false,
+  },
   "audio/wav": { cat: "audio", exts: [".wav"], isSafeToDisplay: false },
   "audio/ogg": { cat: "audio", exts: [".ogg"], isSafeToDisplay: false },
   "audio/webm": { cat: "audio", exts: [".webm"], isSafeToDisplay: false },

--- a/sdks/js/src/types.ts
+++ b/sdks/js/src/types.ts
@@ -208,6 +208,7 @@ export const supportedImageFileFormats = {
 
 export const supportedAudioFileFormats = {
   "audio/mpeg": [".mp3", ".mp4"],
+  "audio/x-m4a": [".m4a", ".mp4"],
   "audio/ogg": [".ogg"],
   "audio/wav": [".wav"],
   "audio/webm": [".webm"],


### PR DESCRIPTION
## Description

Apple voice recording apps outputs file in `m4a` format with an outdated mime type. 

This PR fixes that. Luckily for us OpenAI model supports this format

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
