### PR TITLE
Add timezone handling to outlook MCP

### DIFF
--- a/front/lib/actions/mcp_internal_actions/constants.ts
+++ b/front/lib/actions/mcp_internal_actions/constants.ts
@@ -809,6 +809,7 @@ The directive should be used to display a clickable version of the agent name in
     isRestricted: undefined,
     isPreview: false,
     tools_stakes: {
+      get_user_timezone: "never_ask",
       list_calendars: "never_ask",
       list_events: "never_ask",
       get_event: "never_ask",
@@ -827,7 +828,7 @@ The directive should be used to display a clickable version of the agent name in
         provider: "microsoft_tools" as const,
         supported_use_cases: ["personal_actions"] as const,
         scope:
-          "Calendars.ReadWrite Calendars.ReadWrite.Shared User.Read offline_access" as const,
+          "Calendars.ReadWrite Calendars.ReadWrite.Shared User.Read MailboxSettings.Read offline_access" as const,
       },
       icon: "OutlookLogo",
       documentationUrl: "https://docs.dust.tt/docs/outlook-calendar-tool-setup",

--- a/front/lib/actions/mcp_internal_actions/servers/outlook/calendar_server.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/outlook/calendar_server.ts
@@ -28,7 +28,8 @@ const createServer = (): McpServer => {
           message: "User timezone retrieved successfully",
           result: {
             timezone: result,
-            description: "Use this timezone value when creating, updating, or searching for calendar events to ensure times are displayed correctly.",
+            description:
+              "Use this timezone value when creating, updating, or searching for calendar events to ensure times are displayed correctly.",
           },
         });
       } else {
@@ -119,7 +120,15 @@ const createServer = (): McpServer => {
         ),
     },
     async (
-      { calendarId, search, startTime, endTime, top = 50, skip = 0, userTimezone },
+      {
+        calendarId,
+        search,
+        startTime,
+        endTime,
+        top = 50,
+        skip = 0,
+        userTimezone,
+      },
       { authInfo }
     ) => {
       const accessToken = authInfo?.token;

--- a/front/lib/actions/mcp_internal_actions/servers/outlook/calendar_server.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/outlook/calendar_server.ts
@@ -12,6 +12,32 @@ const createServer = (): McpServer => {
   const server = makeInternalMCPServer("outlook_calendar");
 
   server.tool(
+    "get_user_timezone",
+    "Get the user's configured timezone from their Outlook mailbox settings. This should be called before creating, updating, or searching for events to ensure proper timezone handling.",
+    {},
+    async (_, { authInfo }) => {
+      const accessToken = authInfo?.token;
+      if (!accessToken) {
+        return makeMCPToolTextError("Authentication required");
+      }
+
+      const result = await OutlookApi.getUserTimezone(accessToken);
+
+      if (typeof result === "string") {
+        return makeMCPToolJSONSuccess({
+          message: "User timezone retrieved successfully",
+          result: {
+            timezone: result,
+            description: "Use this timezone value when creating, updating, or searching for calendar events to ensure times are displayed correctly.",
+          },
+        });
+      } else {
+        return makeMCPToolTextError(result.error);
+      }
+    }
+  );
+
+  server.tool(
     "list_calendars",
     "List all calendars accessible by the user in Outlook.",
     {
@@ -23,14 +49,24 @@ const createServer = (): McpServer => {
         .number()
         .optional()
         .describe("Number of calendars to skip for pagination."),
+      userTimezone: z
+        .string()
+        .optional()
+        .describe(
+          "User's timezone (e.g., 'America/New_York'). Call get_user_timezone first to get this value."
+        ),
     },
-    async ({ top = 250, skip = 0 }, { authInfo }) => {
+    async ({ top = 250, skip = 0, userTimezone }, { authInfo }) => {
       const accessToken = authInfo?.token;
       if (!accessToken) {
         return makeMCPToolTextError("Authentication required");
       }
 
-      const result = await OutlookApi.listCalendars(accessToken, { top, skip });
+      const result = await OutlookApi.listCalendars(accessToken, {
+        top,
+        skip,
+        userTimezone,
+      });
 
       if ("error" in result) {
         return makeMCPToolTextError(result.error);
@@ -45,7 +81,7 @@ const createServer = (): McpServer => {
 
   server.tool(
     "list_events",
-    "List or search events from an Outlook Calendar. Supports filtering and searching.",
+    "List or search events from an Outlook Calendar. Supports filtering and searching. For accurate timezone handling, first call get_user_timezone and pass the timezone parameter.",
     {
       calendarId: z
         .string()
@@ -75,9 +111,15 @@ const createServer = (): McpServer => {
         .number()
         .optional()
         .describe("Number of events to skip for pagination."),
+      userTimezone: z
+        .string()
+        .optional()
+        .describe(
+          "User's timezone (e.g., 'America/New_York'). Call get_user_timezone first to get this value for proper timezone handling."
+        ),
     },
     async (
-      { calendarId, search, startTime, endTime, top = 50, skip = 0 },
+      { calendarId, search, startTime, endTime, top = 50, skip = 0, userTimezone },
       { authInfo }
     ) => {
       const accessToken = authInfo?.token;
@@ -92,6 +134,7 @@ const createServer = (): McpServer => {
         endTime,
         top,
         skip,
+        userTimezone,
       });
 
       if ("error" in result) {
@@ -116,8 +159,14 @@ const createServer = (): McpServer => {
           "The calendar ID. If not provided, uses the user's default calendar."
         ),
       eventId: z.string().describe("The ID of the event to retrieve."),
+      userTimezone: z
+        .string()
+        .optional()
+        .describe(
+          "User's timezone (e.g., 'America/New_York'). Call get_user_timezone first to get this value."
+        ),
     },
-    async ({ calendarId, eventId }, { authInfo }) => {
+    async ({ calendarId, eventId, userTimezone }, { authInfo }) => {
       const accessToken = authInfo?.token;
       if (!accessToken) {
         return makeMCPToolTextError("Authentication required");
@@ -126,6 +175,7 @@ const createServer = (): McpServer => {
       const result = await OutlookApi.getEvent(accessToken, {
         calendarId,
         eventId,
+        userTimezone,
       });
 
       if ("error" in result) {
@@ -141,7 +191,7 @@ const createServer = (): McpServer => {
 
   server.tool(
     "create_event",
-    "Create a new event in an Outlook Calendar.",
+    "Create a new event in an Outlook Calendar. Call get_user_timezone first and pass the userTimezone parameter for proper timezone handling.",
     {
       calendarId: z
         .string()
@@ -184,6 +234,12 @@ const createServer = (): McpServer => {
         .enum(["free", "tentative", "busy", "oof", "workingElsewhere"])
         .optional()
         .describe("Show as status for the event (default: busy)."),
+      userTimezone: z
+        .string()
+        .optional()
+        .describe(
+          "User's timezone (e.g., 'America/New_York'). Call get_user_timezone first to get this value."
+        ),
     },
     async (
       {
@@ -199,6 +255,7 @@ const createServer = (): McpServer => {
         isAllDay = false,
         importance = "normal",
         showAs = "busy",
+        userTimezone,
       },
       { authInfo }
     ) => {
@@ -220,6 +277,7 @@ const createServer = (): McpServer => {
         isAllDay,
         importance,
         showAs,
+        userTimezone,
       });
 
       if ("error" in result) {
@@ -235,7 +293,7 @@ const createServer = (): McpServer => {
 
   server.tool(
     "update_event",
-    "Update an existing event in an Outlook Calendar.",
+    "Update an existing event in an Outlook Calendar. Call get_user_timezone first and pass the userTimezone parameter for proper timezone handling.",
     {
       calendarId: z
         .string()
@@ -270,6 +328,12 @@ const createServer = (): McpServer => {
         .enum(["free", "tentative", "busy", "oof", "workingElsewhere"])
         .optional()
         .describe("Show as status for the event."),
+      userTimezone: z
+        .string()
+        .optional()
+        .describe(
+          "User's timezone (e.g., 'America/New_York'). Call get_user_timezone first to get this value."
+        ),
     },
     async (
       {
@@ -286,6 +350,7 @@ const createServer = (): McpServer => {
         isAllDay,
         importance,
         showAs,
+        userTimezone,
       },
       { authInfo }
     ) => {
@@ -308,6 +373,7 @@ const createServer = (): McpServer => {
         isAllDay,
         importance,
         showAs,
+        userTimezone,
       });
 
       if ("error" in result) {
@@ -332,8 +398,14 @@ const createServer = (): McpServer => {
           "The calendar ID. If not provided, uses the user's default calendar."
         ),
       eventId: z.string().describe("The ID of the event to delete."),
+      userTimezone: z
+        .string()
+        .optional()
+        .describe(
+          "User's timezone (e.g., 'America/New_York'). Call get_user_timezone first to get this value."
+        ),
     },
-    async ({ calendarId, eventId }, { authInfo }) => {
+    async ({ calendarId, eventId, userTimezone }, { authInfo }) => {
       const accessToken = authInfo?.token;
       if (!accessToken) {
         return makeMCPToolTextError("Authentication required");
@@ -342,6 +414,7 @@ const createServer = (): McpServer => {
       const result = await OutlookApi.deleteEvent(accessToken, {
         calendarId,
         eventId,
+        userTimezone,
       });
 
       if ("error" in result) {
@@ -376,9 +449,15 @@ const createServer = (): McpServer => {
         .describe(
           "Interval in minutes for availability slots (default: 60, max: 1440)"
         ),
+      userTimezone: z
+        .string()
+        .optional()
+        .describe(
+          "User's timezone (e.g., 'America/New_York'). Call get_user_timezone first to get this value."
+        ),
     },
     async (
-      { emails, startTime, endTime, intervalInMinutes = 60 },
+      { emails, startTime, endTime, intervalInMinutes = 60, userTimezone },
       { authInfo }
     ) => {
       const accessToken = authInfo?.token;
@@ -391,6 +470,7 @@ const createServer = (): McpServer => {
         startTime,
         endTime,
         intervalInMinutes,
+        userTimezone,
       });
 
       if ("error" in result) {

--- a/front/lib/actions/mcp_internal_actions/servers/outlook/outlook_api_helper.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/outlook/outlook_api_helper.ts
@@ -77,6 +77,7 @@ export type OutlookEvent = z.infer<typeof OutlookEventSchema>;
 export interface ListCalendarsParams {
   top?: number;
   skip?: number;
+  userTimezone?: string;
 }
 
 export interface ListEventsParams {
@@ -86,11 +87,13 @@ export interface ListEventsParams {
   endTime?: string;
   top?: number;
   skip?: number;
+  userTimezone?: string;
 }
 
 export interface GetEventParams {
   calendarId?: string;
   eventId: string;
+  userTimezone?: string;
 }
 
 export interface CreateEventParams {
@@ -106,6 +109,7 @@ export interface CreateEventParams {
   isAllDay?: boolean;
   importance?: "low" | "normal" | "high";
   showAs?: "free" | "tentative" | "busy" | "oof" | "workingElsewhere";
+  userTimezone?: string;
 }
 
 export interface UpdateEventParams {
@@ -122,11 +126,13 @@ export interface UpdateEventParams {
   isAllDay?: boolean;
   importance?: "low" | "normal" | "high";
   showAs?: "free" | "tentative" | "busy" | "oof" | "workingElsewhere";
+  userTimezone?: string;
 }
 
 export interface DeleteEventParams {
   calendarId?: string;
   eventId: string;
+  userTimezone?: string;
 }
 
 export interface CheckAvailabilityParams {
@@ -134,19 +140,33 @@ export interface CheckAvailabilityParams {
   startTime: string;
   endTime: string;
   intervalInMinutes?: number;
+  userTimezone?: string;
 }
 
 const fetchFromOutlook = async (
   endpoint: string,
   accessToken: string,
-  options?: RequestInit
+  options?: RequestInit,
+  userTimezone?: string
 ): Promise<Response> => {
+  const headers: Record<string, string> = {
+    Authorization: `Bearer ${accessToken}`,
+  };
+
+  // Add existing headers from options
+  if (options?.headers) {
+    const existingHeaders = options.headers as Record<string, string>;
+    Object.assign(headers, existingHeaders);
+  }
+
+  // Add Prefer header with timezone if provided
+  if (userTimezone) {
+    headers["Prefer"] = `outlook.timezone="${userTimezone}"`;
+  }
+
   return fetch(`https://graph.microsoft.com/v1.0${endpoint}`, {
     ...options,
-    headers: {
-      Authorization: `Bearer ${accessToken}`,
-      ...options?.headers,
-    },
+    headers,
   });
 };
 
@@ -159,13 +179,38 @@ const getErrorText = async (response: Response): Promise<string> => {
   }
 };
 
+export async function getUserTimezone(
+  accessToken: string
+): Promise<string | { error: string }> {
+  try {
+    const response = await fetchFromOutlook(
+      "/me/mailboxSettings",
+      accessToken,
+      { method: "GET" }
+    );
+
+    if (!response.ok) {
+      const errorText = await getErrorText(response);
+      return {
+        error: `Failed to get user timezone: ${response.status} ${response.statusText} - ${errorText}`,
+      };
+    }
+
+    const result = await response.json();
+    return result.timeZone || "UTC";
+  } catch (error) {
+    localLogger.error({ error }, "Error getting user timezone");
+    return { error: `Error getting user timezone: ${error}` };
+  }
+}
+
 export async function listCalendars(
   accessToken: string,
   params: ListCalendarsParams
 ): Promise<
   { calendars: OutlookCalendar[]; nextLink?: string } | { error: string }
 > {
-  const { top = 250, skip = 0 } = params;
+  const { top = 250, skip = 0, userTimezone } = params;
 
   const urlParams = new URLSearchParams();
   urlParams.append("$top", Math.min(top, 999).toString());
@@ -175,7 +220,8 @@ export async function listCalendars(
     const response = await fetchFromOutlook(
       `/me/calendars?${urlParams.toString()}`,
       accessToken,
-      { method: "GET" }
+      { method: "GET" },
+      userTimezone
     );
 
     if (!response.ok) {
@@ -214,71 +260,126 @@ export async function listEvents(
   accessToken: string,
   params: ListEventsParams
 ): Promise<{ events: OutlookEvent[]; nextLink?: string } | { error: string }> {
-  const { calendarId, search, startTime, endTime, top = 50, skip = 0 } = params;
+  const { calendarId, search, startTime, endTime, top = 50, skip = 0, userTimezone } = params;
 
-  const urlParams = new URLSearchParams();
-  urlParams.append("$top", Math.min(top, 999).toString());
-  urlParams.append("$orderby", "start/dateTime");
-
-  if (search) {
-    urlParams.append("$search", `"${search}"`);
-  } else {
+  // Use calendarView endpoint when date range is specified to get recurring events
+  if (startTime && endTime && !search) {
+    const urlParams = new URLSearchParams();
+    urlParams.append("startDateTime", startTime);
+    urlParams.append("endDateTime", endTime);
+    urlParams.append("$top", Math.min(top, 999).toString());
     urlParams.append("$skip", skip.toString());
-  }
+    urlParams.append("$orderby", "start/dateTime");
 
-  if (startTime || endTime) {
-    const filters = [];
-    if (startTime) {
-      filters.push(`start/dateTime ge '${startTime}'`);
-    }
-    if (endTime) {
-      filters.push(`end/dateTime le '${endTime}'`);
-    }
-    if (filters.length > 0) {
-      urlParams.append("$filter", filters.join(" and "));
-    }
-  }
+    const endpoint = calendarId
+      ? `/me/calendars/${calendarId}/calendarView`
+      : `/me/calendar/calendarView`;
 
-  const endpoint = calendarId
-    ? `/me/calendars/${calendarId}/events`
-    : `/me/events`;
-
-  try {
-    const response = await fetchFromOutlook(
-      `${endpoint}?${urlParams.toString()}`,
-      accessToken,
-      { method: "GET" }
-    );
-
-    if (!response.ok) {
-      const errorText = await getErrorText(response);
-      return {
-        error: `Failed to list events: ${response.status} ${response.statusText} - ${errorText}`,
-      };
-    }
-
-    const result = await response.json();
-    const eventsResult = z
-      .array(OutlookEventSchema)
-      .safeParse(result.value || []);
-
-    if (!eventsResult.success) {
-      localLogger.error(
-        { error: eventsResult.error },
-        "Invalid events data format"
+    try {
+      const response = await fetchFromOutlook(
+        `${endpoint}?${urlParams.toString()}`,
+        accessToken,
+        { method: "GET" },
+        userTimezone
       );
+
+      if (!response.ok) {
+        const errorText = await getErrorText(response);
+        return {
+          error: `Failed to list events: ${response.status} ${response.statusText} - ${errorText}`,
+        };
+      }
+
+      const result = await response.json();
+      const eventsResult = z
+        .array(OutlookEventSchema)
+        .safeParse(result.value || []);
+
+      if (!eventsResult.success) {
+        localLogger.error(
+          { error: eventsResult.error },
+          "Invalid events data format"
+        );
+        return {
+          error: `Invalid events data format: ${eventsResult.error.message}`,
+        };
+      }
+
       return {
-        error: `Invalid events data format: ${eventsResult.error.message}`,
+        events: eventsResult.data,
+        nextLink: result["@odata.nextLink"],
       };
+    } catch (error) {
+      localLogger.error({ error }, "Error listing events");
+      return { error: `Error listing events: ${error}` };
+    }
+  } else {
+    // Fall back to regular events endpoint for search queries or when no date range
+    const urlParams = new URLSearchParams();
+    urlParams.append("$top", Math.min(top, 999).toString());
+    urlParams.append("$orderby", "start/dateTime");
+
+    if (search) {
+      urlParams.append("$search", `"${search}"`);
+    } else {
+      urlParams.append("$skip", skip.toString());
     }
 
-    return {
-      events: eventsResult.data,
-      nextLink: result["@odata.nextLink"],
-    };
-  } catch (error) {
-    localLogger.error({ error }, "Error listing events");
-    return { error: `Error listing events: ${error}` };
+    if (startTime || endTime) {
+      const filters = [];
+      if (startTime) {
+        filters.push(`start/dateTime ge '${startTime}'`);
+      }
+      if (endTime) {
+        filters.push(`end/dateTime le '${endTime}'`);
+      }
+      if (filters.length > 0) {
+        urlParams.append("$filter", filters.join(" and "));
+      }
+    }
+
+    const endpoint = calendarId
+      ? `/me/calendars/${calendarId}/events`
+      : `/me/events`;
+
+    try {
+      const response = await fetchFromOutlook(
+        `${endpoint}?${urlParams.toString()}`,
+        accessToken,
+        { method: "GET" },
+        userTimezone
+      );
+
+      if (!response.ok) {
+        const errorText = await getErrorText(response);
+        return {
+          error: `Failed to list events: ${response.status} ${response.statusText} - ${errorText}`,
+        };
+      }
+
+      const result = await response.json();
+      const eventsResult = z
+        .array(OutlookEventSchema)
+        .safeParse(result.value || []);
+
+      if (!eventsResult.success) {
+        localLogger.error(
+          { error: eventsResult.error },
+          "Invalid events data format"
+        );
+        return {
+          error: `Invalid events data format: ${eventsResult.error.message}`,
+        };
+      }
+
+      return {
+        events: eventsResult.data,
+        nextLink: result["@odata.nextLink"],
+      };
+    } catch (error) {
+      localLogger.error({ error }, "Error listing events");
+      return { error: `Error listing events: ${error}` };
+    }
   }
 }
 
@@ -286,16 +387,19 @@ export async function getEvent(
   accessToken: string,
   params: GetEventParams
 ): Promise<OutlookEvent | { error: string }> {
-  const { calendarId, eventId } = params;
+  const { calendarId, eventId, userTimezone } = params;
 
   const endpoint = calendarId
     ? `/me/calendars/${calendarId}/events/${eventId}`
     : `/me/events/${eventId}`;
 
   try {
-    const response = await fetchFromOutlook(endpoint, accessToken, {
-      method: "GET",
-    });
+    const response = await fetchFromOutlook(
+      endpoint,
+      accessToken,
+      { method: "GET" },
+      userTimezone
+    );
 
     if (!response.ok) {
       const errorText = await getErrorText(response);
@@ -344,6 +448,7 @@ export async function createEvent(
     isAllDay = false,
     importance = "normal",
     showAs = "busy",
+    userTimezone,
   } = params;
 
   const event: any = {
@@ -384,13 +489,18 @@ export async function createEvent(
     : `/me/events`;
 
   try {
-    const response = await fetchFromOutlook(endpoint, accessToken, {
-      method: "POST",
-      headers: {
-        "Content-Type": "application/json",
+    const response = await fetchFromOutlook(
+      endpoint,
+      accessToken,
+      {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify(event),
       },
-      body: JSON.stringify(event),
-    });
+      userTimezone
+    );
 
     if (!response.ok) {
       const errorText = await getErrorText(response);
@@ -437,6 +547,7 @@ export async function updateEvent(
     isAllDay,
     importance,
     showAs,
+    userTimezone,
   } = params;
 
   const event: any = {};
@@ -486,13 +597,18 @@ export async function updateEvent(
     : `/me/events/${eventId}`;
 
   try {
-    const response = await fetchFromOutlook(endpoint, accessToken, {
-      method: "PATCH",
-      headers: {
-        "Content-Type": "application/json",
+    const response = await fetchFromOutlook(
+      endpoint,
+      accessToken,
+      {
+        method: "PATCH",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify(event),
       },
-      body: JSON.stringify(event),
-    });
+      userTimezone
+    );
 
     if (!response.ok) {
       const errorText = await getErrorText(response);
@@ -528,16 +644,19 @@ export async function deleteEvent(
   accessToken: string,
   params: DeleteEventParams
 ): Promise<{ success: true } | { error: string }> {
-  const { calendarId, eventId } = params;
+  const { calendarId, eventId, userTimezone } = params;
 
   const endpoint = calendarId
     ? `/me/calendars/${calendarId}/events/${eventId}`
     : `/me/events/${eventId}`;
 
   try {
-    const response = await fetchFromOutlook(endpoint, accessToken, {
-      method: "DELETE",
-    });
+    const response = await fetchFromOutlook(
+      endpoint,
+      accessToken,
+      { method: "DELETE" },
+      userTimezone
+    );
 
     if (!response.ok) {
       const errorText = await getErrorText(response);
@@ -563,7 +682,7 @@ export async function checkAvailability(
   | { availability: any[]; timeSlot: { start: string; end: string } }
   | { error: string }
 > {
-  const { emails, startTime, endTime, intervalInMinutes = 60 } = params;
+  const { emails, startTime, endTime, intervalInMinutes = 60, userTimezone } = params;
 
   const requestBody = {
     schedules: emails,
@@ -588,7 +707,8 @@ export async function checkAvailability(
           "Content-Type": "application/json",
         },
         body: JSON.stringify(requestBody),
-      }
+      },
+      userTimezone
     );
 
     if (!response.ok) {

--- a/front/lib/actions/mcp_internal_actions/servers/outlook/outlook_api_helper.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/outlook/outlook_api_helper.ts
@@ -260,7 +260,15 @@ export async function listEvents(
   accessToken: string,
   params: ListEventsParams
 ): Promise<{ events: OutlookEvent[]; nextLink?: string } | { error: string }> {
-  const { calendarId, search, startTime, endTime, top = 50, skip = 0, userTimezone } = params;
+  const {
+    calendarId,
+    search,
+    startTime,
+    endTime,
+    top = 50,
+    skip = 0,
+    userTimezone,
+  } = params;
 
   // Use calendarView endpoint when date range is specified to get recurring events
   if (startTime && endTime && !search) {
@@ -682,7 +690,13 @@ export async function checkAvailability(
   | { availability: any[]; timeSlot: { start: string; end: string } }
   | { error: string }
 > {
-  const { emails, startTime, endTime, intervalInMinutes = 60, userTimezone } = params;
+  const {
+    emails,
+    startTime,
+    endTime,
+    intervalInMinutes = 60,
+    userTimezone,
+  } = params;
 
   const requestBody = {
     schedules: emails,


### PR DESCRIPTION
## Description

Adds timezone management to the Outlook MCP server to fix the 2-hour offset issue affecting European users. This implements a new `get_user_timezone` tool that retrieves the user's configured timezone from their Outlook mailbox settings and adds optional `userTimezone` parameters to all calendar operations. The implementation uses Microsoft Graph API's mailbox settings endpoint and the `Prefer` header for proper timezone handling.

## Risk

Adds a new OAuth scope (`MailboxSettings.Read`) to the Outlook MCP configuration which requires users to re-authenticate their Outlook connection.

## Deploy Plan

- Users will need to re-connect their Outlook MCP integration due to the new `MailboxSettings.Read` scope requirement