### PR TITLE
better error message for public shared content

### DIFF
--- a/front/components/assistant/conversation/actions/VisualizationActionIframe.tsx
+++ b/front/components/assistant/conversation/actions/VisualizationActionIframe.tsx
@@ -413,18 +413,22 @@ export const VisualizationActionIframe = forwardRef<
 
               {isErrored && isPublic && (
                 <div className="flex h-full w-full items-center justify-center p-6">
-                  <ContentMessage
-                    title="An error occurred"
-                    variant="warning"
-                    icon={ExclamationCircleIcon}
-                    className="max-w-md text-center"
-                  >
-                    <div className="my-2 text-sm">
-                      This visualization encountered an error and cannot be
-                      displayed. Please contact the creator of this
-                      visualization for assistance.
+                  <div className="flex flex-col gap-3 text-center">
+                    <div>
+                      <span className="text-2xl leading-10 text-foreground dark:text-foreground-night">
+                        📊
+                      </span>
+                      <p className="heading-xl leading-7 text-foreground dark:text-foreground-night">
+                        Visualization Error
+                      </p>
+                      <p className="copy-sm leading-tight text-muted-foreground dark:text-muted-foreground-night">
+                        This visualization encountered an error and cannot be
+                        displayed.
+                        <br /> Please contact the creator of this visualization
+                        for assistance.
+                      </p>
                     </div>
-                  </ContentMessage>
+                  </div>
                 </div>
               )}
             </div>

--- a/front/components/assistant/conversation/actions/VisualizationActionIframe.tsx
+++ b/front/components/assistant/conversation/actions/VisualizationActionIframe.tsx
@@ -377,7 +377,8 @@ export const VisualizationActionIframe = forwardRef<
                   />
                 </div>
               )}
-              {isErrored && !retryClicked && (
+
+              {isErrored && !retryClicked && !isPublic && (
                 <div className="flex h-full w-full items-center justify-center p-6">
                   <ContentMessage
                     title="Visualization Error"
@@ -406,6 +407,23 @@ export const VisualizationActionIframe = forwardRef<
                         />
                       </div>
                     )}
+                  </ContentMessage>
+                </div>
+              )}
+
+              {isErrored && isPublic && (
+                <div className="flex h-full w-full items-center justify-center p-6">
+                  <ContentMessage
+                    title="An error occurred"
+                    variant="warning"
+                    icon={ExclamationCircleIcon}
+                    className="max-w-md text-center"
+                  >
+                    <div className="my-2 text-sm">
+                      This visualization encountered an error and cannot be
+                      displayed. Please contact the creator of this
+                      visualization for assistance.
+                    </div>
                   </ContentMessage>
                 </div>
               )}

--- a/front/components/assistant/conversation/actions/VisualizationActionIframe.tsx
+++ b/front/components/assistant/conversation/actions/VisualizationActionIframe.tsx
@@ -414,13 +414,13 @@ export const VisualizationActionIframe = forwardRef<
               {isErrored && isPublic && (
                 <div className="flex h-full w-full items-center justify-center p-6">
                   <div className="flex flex-col gap-3 text-center">
-                    <div>
-                      <span className="text-2xl leading-10 text-foreground dark:text-foreground-night">
-                        📊
-                      </span>
-                      <p className="heading-xl leading-7 text-foreground dark:text-foreground-night">
-                        Visualization Error
-                      </p>
+                    <div className="flex flex-col items-center gap-2 text-center">
+                      <div className="flex flex-col items-center gap-2">
+                        <ExclamationCircleIcon className="h-8 w-8" />
+                        <p className="heading-xl leading-7 text-foreground dark:text-foreground-night">
+                          Visualization Error
+                        </p>
+                      </div>
                       <p className="copy-sm leading-tight text-muted-foreground dark:text-muted-foreground-night">
                         This visualization encountered an error and cannot be
                         displayed.


### PR DESCRIPTION
## Description

- https://github.com/dust-tt/tasks/issues/4145
- Display a user friendly message when a shared content creation could not be rendered

<img width="1054" height="675" alt="Screenshot 2025-09-12 at 09 40 57" src="https://github.com/user-attachments/assets/8f9b28f9-737b-4949-9165-5e591a9ca493" />

## Tests

Locally

## Risk

Low.

## Deploy Plan

Deploy front
