### PR TITLE
fix(doc-tracker): wait for ES index before shouldRunTrackersActivity

### DIFF
--- a/front/temporal/tracker/workflows.ts
+++ b/front/temporal/tracker/workflows.ts
@@ -32,6 +32,8 @@ const { processTrackerNotificationWorkflowActivity } = proxyActivities<
   startToCloseTimeout: "30 minutes",
 });
 
+const INITIAL_WAIT_TIME = 60000; // 1 minute.
+
 /**
  * Workflow that is ran when a document is upserted.
  * It fetches the trackers that are watching the document and runs the document tracker generation.
@@ -48,6 +50,9 @@ export async function trackersGenerationWorkflow(
   setHandler(newUpsertSignal, () => {
     lastUpsertAt = Date.now();
   });
+
+  // Start by waiting (to ensure elasticsearch index is ready)
+  await sleep(INITIAL_WAIT_TIME);
 
   const shouldRun = await shouldRunTrackersActivity({
     workspaceId,


### PR DESCRIPTION
## Description

Since we moved to the ES-based tree, we actually have a race condition if the upsert is quick due to the fact that ES is eventually consistent (and we rely on retrieving the CN for doc tracker's "should run" condition)

This is a bit unsatisfying, but since latency isn't a concern on doc tracker the easiest solution is by far to add a small delay. in the temporal workflow before we attempt to retrieve the CN.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
