### PR TITLE
[RunAgent Tool] Fix: allow reconnection on stream error

### DIFF
--- a/front/lib/actions/mcp_internal_actions/servers/run_agent/index.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/run_agent/index.ts
@@ -376,6 +376,11 @@ export default async function createServer(
       const streamRes = await api.streamAgentAnswerEvents({
         conversation: conversation,
         userMessageId,
+        options: {
+          maxReconnectAttempts: 10,
+          reconnectDelay: 10000,
+          autoReconnect: true,
+        },
       });
 
       if (streamRes.isErr()) {


### PR DESCRIPTION
Description
---
Fixes issue related
[here](https://dust4ai.slack.com/archives/C097P501RB9/p1757579534479469)

If the stream is cut, runAgent did not try to reconnect and blew up.

Risks
---
very low

Deploy
---
front
