### PR TITLE
Lower CPU usage, hide sidebar when selecting convo

### DIFF
--- a/connectors/package-lock.json
+++ b/connectors/package-lock.json
@@ -96,7 +96,7 @@
     },
     "../sdks/js": {
       "name": "@dust-tt/client",
-      "version": "1.1.13",
+      "version": "1.1.14",
       "bundleDependencies": [
         "@modelcontextprotocol/sdk"
       ],

--- a/front/components/assistant/conversation/ConversationLayout.tsx
+++ b/front/components/assistant/conversation/ConversationLayout.tsx
@@ -235,7 +235,7 @@ function ConversationInnerLayout({
                     <div
                       id={CONVERSATION_VIEW_SCROLL_LAYOUT}
                       className={cn(
-                        "dd-privacy-mask h-full overflow-y-auto scroll-smooth px-4",
+                        "dd-privacy-mask h-full overflow-y-auto overscroll-y-none scroll-smooth px-4",
                         // Hide conversation on mobile when any panel is opened.
                         currentPanel && "hidden md:block"
                       )}

--- a/front/components/assistant/conversation/SidebarMenu.tsx
+++ b/front/components/assistant/conversation/SidebarMenu.tsx
@@ -444,6 +444,7 @@ const RenderConversation = ({
   router: NextRouter;
   owner: WorkspaceType;
 }) => {
+  const { sidebarOpen, setSidebarOpen } = useContext(SidebarContext);
   const conversationLabel =
     conversation.title ||
     (moment(conversation.created).isSame(moment(), "day")
@@ -483,8 +484,21 @@ const RenderConversation = ({
           }
           label={conversationLabel}
           className={conversation.unread ? "font-medium" : undefined}
-          href={`/w/${owner.sId}/assistant/${conversation.sId}`}
-          shallow
+          onClick={async () => {
+            // Side bar is the floating sidebar that appears when the screen is small.
+            if (sidebarOpen) {
+              setSidebarOpen(false);
+              // Wait a bit before moving to the new conversation to avoid the sidebar from flickering.
+              await new Promise((resolve) => setTimeout(resolve, 600));
+            }
+            await router.push(
+              `/w/${owner.sId}/assistant/${conversation.sId}`,
+              undefined,
+              {
+                shallow: true,
+              }
+            );
+          }}
         />
       )}
     </>

--- a/front/components/assistant/conversation/input_bar/InputBar.tsx
+++ b/front/components/assistant/conversation/input_bar/InputBar.tsx
@@ -1,4 +1,4 @@
-import { Button, cn, RainbowEffect, StopIcon } from "@dust-tt/sparkle";
+import { Button, cn, StopIcon } from "@dust-tt/sparkle";
 import { useContext, useEffect, useMemo, useRef, useState } from "react";
 
 import { useFileDrop } from "@app/components/assistant/conversation/FileUploaderContext";
@@ -68,30 +68,10 @@ export function AssistantInputBar({
   disable = false,
 }: AssistantInputBarProps) {
   const [disableSendButton, setDisableSendButton] = useState(disable);
-  const [isFocused, setIsFocused] = useState(false);
-  const rainbowEffectRef = useRef<HTMLDivElement>(null);
 
   const [attachedNodes, setAttachedNodes] = useState<
     DataSourceViewContentNode[]
   >([]);
-
-  useEffect(() => {
-    const container = rainbowEffectRef.current;
-    if (!container) {
-      return;
-    }
-
-    const onFocusIn = () => setIsFocused(true);
-    const onFocusOut = () => setIsFocused(false);
-
-    container.addEventListener("focusin", onFocusIn);
-    container.addEventListener("focusout", onFocusOut);
-
-    return () => {
-      container.removeEventListener("focusin", onFocusIn);
-      container.removeEventListener("focusout", onFocusOut);
-    };
-  }, []);
 
   const { mutateConversation } = useConversation({
     conversationId,
@@ -344,69 +324,60 @@ export function AssistantInputBar({
         </div>
       )}
 
-      <div ref={rainbowEffectRef} className="flex w-full flex-col">
-        <RainbowEffect
-          className="w-full"
-          containerClassName="w-full"
-          size={isFocused ? "large" : "medium"}
-          disabled={disable || !isFloating}
-        >
-          <div
-            className={classNames(
-              "relative flex w-full flex-1 flex-col items-stretch gap-0 self-stretch sm:flex-row",
-              "rounded-2xl transition-all",
-              "bg-muted-background dark:bg-muted-background-night",
-              "border",
-              "border-border-dark dark:border-border-dark-night",
-              "sm:border-border-dark/50 sm:focus-within:border-border-dark",
-              "dark:focus-within:border-border-dark-night sm:focus-within:border-border-dark",
-              disable && "cursor-not-allowed opacity-75",
-              isFloating
-                ? classNames(
-                    "focus-within:ring-1 dark:focus-within:ring-1",
-                    "dark:focus-within:ring-highlight/30-night focus-within:ring-highlight/30",
-                    "sm:focus-within:ring-2 dark:sm:focus-within:ring-2"
-                  )
-                : classNames(
-                    "focus-within:border-highlight-300",
-                    "dark:focus-within:border-highlight-300-night"
-                  ),
-              isAnimating ? "duration-600 animate-shake" : "duration-300"
-            )}
-          >
-            <div className="relative flex w-full flex-1 flex-col">
-              <InputBarAttachments
-                owner={owner}
-                files={{ service: fileUploaderService }}
-                nodes={{
-                  items: attachedNodes,
-                  onRemove: handleNodesAttachmentRemove,
-                }}
-              />
-              <InputBarContainer
-                actions={actions}
-                disableAutoFocus={disableAutoFocus}
-                allAssistants={activeAgents}
-                agentConfigurations={agentConfigurations}
-                owner={owner}
-                selectedAssistant={selectedAssistant}
-                onEnterKeyDown={handleSubmit}
-                stickyMentions={stickyMentions}
-                fileUploaderService={fileUploaderService}
-                disableSendButton={
-                  disableSendButton || fileUploaderService.isProcessingFiles
-                }
-                disableTextInput={disable}
-                onNodeSelect={handleNodesAttachmentSelect}
-                onNodeUnselect={handleNodesAttachmentRemove}
-                selectedMCPServerViewIds={selectedMCPServerViewIds}
-                onMCPServerViewSelect={handleMCPServerViewSelect}
-                onMCPServerViewDeselect={handleMCPServerViewDeselect}
-                attachedNodes={attachedNodes}
-              />
-            </div>
-          </div>
-        </RainbowEffect>
+      <div
+        className={classNames(
+          "relative flex w-full flex-1 flex-col items-stretch gap-0 self-stretch sm:flex-row",
+          "rounded-2xl transition-all",
+          "bg-muted-background dark:bg-muted-background-night",
+          "border",
+          "border-border-dark dark:border-border-dark-night",
+          "sm:border-border-dark/50 sm:focus-within:border-border-dark",
+          "dark:focus-within:border-border-dark-night sm:focus-within:border-border-dark",
+          disable && "cursor-not-allowed opacity-75",
+          isFloating
+            ? classNames(
+                "focus-within:ring-1 dark:focus-within:ring-1",
+                "dark:focus-within:ring-highlight/30-night focus-within:ring-highlight/30",
+                "sm:focus-within:ring-2 dark:sm:focus-within:ring-2"
+              )
+            : classNames(
+                "focus-within:border-highlight-300",
+                "dark:focus-within:border-highlight-300-night"
+              ),
+          isAnimating ? "duration-600 animate-shake" : "duration-300"
+        )}
+      >
+        <div className="relative flex w-full flex-1 flex-col">
+          <InputBarAttachments
+            owner={owner}
+            files={{ service: fileUploaderService }}
+            nodes={{
+              items: attachedNodes,
+              onRemove: handleNodesAttachmentRemove,
+            }}
+          />
+          <InputBarContainer
+            actions={actions}
+            disableAutoFocus={disableAutoFocus}
+            allAssistants={activeAgents}
+            agentConfigurations={agentConfigurations}
+            owner={owner}
+            selectedAssistant={selectedAssistant}
+            onEnterKeyDown={handleSubmit}
+            stickyMentions={stickyMentions}
+            fileUploaderService={fileUploaderService}
+            disableSendButton={
+              disableSendButton || fileUploaderService.isProcessingFiles
+            }
+            disableTextInput={disable}
+            onNodeSelect={handleNodesAttachmentSelect}
+            onNodeUnselect={handleNodesAttachmentRemove}
+            selectedMCPServerViewIds={selectedMCPServerViewIds}
+            onMCPServerViewSelect={handleMCPServerViewSelect}
+            onMCPServerViewDeselect={handleMCPServerViewDeselect}
+            attachedNodes={attachedNodes}
+          />
+        </div>
       </div>
     </div>
   );

--- a/front/components/assistant/conversation/input_bar/editor/MentionDropdown.tsx
+++ b/front/components/assistant/conversation/input_bar/editor/MentionDropdown.tsx
@@ -96,8 +96,16 @@ export const MentionDropdown = ({
                       ? "text-highlight-500"
                       : "text-foreground dark:text-foreground-night"
                   )}
-                  onClick={() => onSelect(suggestion)}
-                  onMouseEnter={() => onSelectedIndexChange(index)}
+                  onClick={(e) => {
+                    e.preventDefault();
+                    e.stopPropagation();
+                    onSelect(suggestion);
+                  }}
+                  onMouseEnter={(e) => {
+                    e.preventDefault();
+                    e.stopPropagation();
+                    onSelectedIndexChange(index);
+                  }}
                 >
                   {suggestion.label}
                 </button>

--- a/front/package-lock.json
+++ b/front/package-lock.json
@@ -207,7 +207,7 @@
     },
     "../sdks/js": {
       "name": "@dust-tt/client",
-      "version": "1.1.13",
+      "version": "1.1.14",
       "bundleDependencies": [
         "@modelcontextprotocol/sdk"
       ],


### PR DESCRIPTION
## Description

A few first fixes:
- (all) Remove the rainbow effect as it's causing constant repaint of the whole screen => before: 30% cpu usage on my iphone (idle) after: 0.2%.
- (small screen only) Close sidepanel and wait a bit before switching convo.
- (small screen only) Disable bouncy behavior of convos.

## Tests

Desktop + mobile

## Risk

Low, purely visual.

## Deploy Plan

Deploy front