### PR TITLE
[front] schedules: display trigger editor on the trigger card

### DIFF
--- a/front/components/agent_builder/AgentBuilder.tsx
+++ b/front/components/agent_builder/AgentBuilder.tsx
@@ -178,15 +178,11 @@ export default function AgentBuilder({
       ...baseValues,
       actions: processedActions,
       triggers: duplicateAgentId
-        ? (triggers ?? []).map((trigger) => ({
+        ? triggers.map((trigger) => ({
             ...trigger,
             editor: user.id,
-            editorEmail: trigger.editorEmail,
           }))
-        : (triggers ?? []).map((trigger) => ({
-            ...trigger,
-            editorEmail: trigger.editorEmail,
-          })),
+        : triggers ?? emptyArray(),
 
       agentSettings: {
         ...baseValues.agentSettings,

--- a/front/components/agent_builder/AgentBuilder.tsx
+++ b/front/components/agent_builder/AgentBuilder.tsx
@@ -178,11 +178,15 @@ export default function AgentBuilder({
       ...baseValues,
       actions: processedActions,
       triggers: duplicateAgentId
-        ? triggers.map((trigger) => ({
+        ? (triggers ?? []).map((trigger) => ({
             ...trigger,
             editor: user.id,
+            editorEmail: trigger.editorEmail,
           }))
-        : triggers ?? emptyArray(),
+        : (triggers ?? []).map((trigger) => ({
+            ...trigger,
+            editorEmail: trigger.editorEmail,
+          })),
 
       agentSettings: {
         ...baseValues.agentSettings,

--- a/front/components/agent_builder/AgentBuilderFormContext.tsx
+++ b/front/components/agent_builder/AgentBuilderFormContext.tsx
@@ -201,6 +201,7 @@ const webhookTriggerSchema = z.object({
   configuration: z.union([webhookConfigSchema, z.null()]),
   editor: z.number().nullable(),
   webhookSourceViewSId: z.string().nullable().optional(),
+  editorEmail: z.string().optional(),
 });
 
 const scheduleTriggerSchema = z.object({
@@ -210,6 +211,7 @@ const scheduleTriggerSchema = z.object({
   customPrompt: z.string().nullable(),
   configuration: scheduleConfigSchema,
   editor: z.number().nullable(),
+  editorEmail: z.string().optional(),
 });
 
 const triggerSchema = z.discriminatedUnion("kind", [

--- a/front/components/agent_builder/triggers/ScheduleEditionModal.tsx
+++ b/front/components/agent_builder/triggers/ScheduleEditionModal.tsx
@@ -137,6 +137,7 @@ export function ScheduleEditionModal({
       },
       editor: trigger?.editor ?? user?.id ?? null,
       customPrompt: data.customPrompt.trim() ?? null,
+      editorEmail: trigger?.editorEmail ?? user?.email,
     };
 
     onSave(triggerData);
@@ -157,6 +158,16 @@ export function ScheduleEditionModal({
         </SheetHeader>
 
         <SheetContainer>
+          {trigger && !isEditor && (
+            <ContentMessage variant="info">
+              You cannot edit this schedule. It is managed by{" "}
+              <span className="font-semibold">
+                {trigger.editorEmail || "another user"}
+              </span>
+              .
+            </ContentMessage>
+          )}
+
           <FormProvider form={form} onSubmit={onSubmit}>
             <div className="space-y-4">
               <div className="space-y-1">

--- a/front/components/agent_builder/triggers/TriggerCard.tsx
+++ b/front/components/agent_builder/triggers/TriggerCard.tsx
@@ -9,7 +9,6 @@ import cronstrue from "cronstrue";
 import { useMemo } from "react";
 
 import type { AgentBuilderTriggerType } from "@app/components/agent_builder/AgentBuilderFormContext";
-import { isAgentBuilderScheduleTriggerType } from "@app/components/agent_builder/AgentBuilderFormContext";
 import { useUser } from "@app/lib/swr/user";
 import type { TriggerKind } from "@app/types/assistant/triggers";
 
@@ -36,7 +35,7 @@ export const TriggerCard = ({
 }: TriggerCardProps) => {
   const { user } = useUser();
   const isEditor = trigger.editor === user?.id;
-  const cronDescription = useMemo(() => {
+  const description = useMemo(() => {
     try {
       if (
         trigger.kind === "schedule" &&
@@ -56,7 +55,7 @@ export const TriggerCard = ({
   return (
     <Card
       variant="primary"
-      className={"h-28 select-none"}
+      className={"min-h-28 select-none"}
       onClick={onEdit}
       action={
         isEditor && (
@@ -76,9 +75,16 @@ export const TriggerCard = ({
           <Avatar visual={getIcon(trigger.kind)} size="xs" />
           <span className="truncate">{trigger.name}</span>
         </div>
-        {isAgentBuilderScheduleTriggerType(trigger) && (
-          <span className="text-muted-foreground dark:text-muted-foreground-night">
-            <span className="line-clamp-2 break-words">{cronDescription}</span>
+        <span className="text-muted-foreground dark:text-muted-foreground-night">
+          <span className="line-clamp-2 break-words">{description}</span>
+        </span>
+        {trigger.editorEmail && (
+          <span className="mt-auto text-xs text-muted-foreground dark:text-muted-foreground-night">
+            Managed by{" "}
+            <span className="font-semibold">
+              {trigger.editorEmail ?? "another user"}
+            </span>
+            .
           </span>
         )}
       </div>

--- a/front/pages/api/w/[wId]/assistant/agent_configurations/[aId]/triggers/index.ts
+++ b/front/pages/api/w/[wId]/assistant/agent_configurations/[aId]/triggers/index.ts
@@ -7,6 +7,7 @@ import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrapper
 import type { Authenticator } from "@app/lib/auth";
 import { getResourceIdFromSId } from "@app/lib/resources/string_ids";
 import { TriggerResource } from "@app/lib/resources/trigger_resource";
+import { UserResource } from "@app/lib/resources/user_resource";
 import logger from "@app/logger/logger";
 import { apiError, withLogging } from "@app/logger/withlogging";
 import type { WithAPIErrorResponse } from "@app/types";
@@ -20,6 +21,7 @@ export interface GetTriggersResponseBody {
   triggers: (TriggerType & {
     isSubscriber: boolean;
     isEditor: boolean;
+    editorEmail?: string;
   })[];
 }
 
@@ -83,11 +85,19 @@ async function handler(
 
   switch (req.method) {
     case "GET": {
+      // Fetch all editor users in batch to avoid N+1 queries
+      const editorIds = [...new Set(triggers.map((trigger) => trigger.editor))];
+      const editorUsers = await UserResource.fetchByModelIds(editorIds);
+      const editorEmailMap = new Map(
+        editorUsers.map((user) => [user.id, user.email])
+      );
+
       const triggersWithIsSubscriber = await Promise.all(
         triggers.map(async (trigger) => ({
           ...trigger.toJSON(),
           isSubscriber: await trigger.isSubscriber(auth),
           isEditor: trigger.editor === auth.getNonNullableUser().id,
+          editorEmail: editorEmailMap.get(trigger.editor),
         }))
       );
 

--- a/front/pages/api/w/[wId]/assistant/agent_configurations/[aId]/triggers/index.ts
+++ b/front/pages/api/w/[wId]/assistant/agent_configurations/[aId]/triggers/index.ts
@@ -85,7 +85,7 @@ async function handler(
 
   switch (req.method) {
     case "GET": {
-      // Fetch all editor users in batch to avoid N+1 queries
+      // Fetch all editor users in batch
       const editorIds = [...new Set(triggers.map((trigger) => trigger.editor))];
       const editorUsers = await UserResource.fetchByModelIds(editorIds);
       const editorEmailMap = new Map(


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

<img width="1512" height="945" alt="Capture d’écran 2025-09-11 à 22 50 36" src="https://github.com/user-attachments/assets/0dca0e15-3e15-4934-bb79-12e96c7d764b" />

This PR adds a content message on top of the schedule modal if you cannot edit it.
This also adds the trigger editor email in the trigger card.

This is to add visibility and clarity as why you can or not edit some specific triggers.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

Tested by hand.

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

Low

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->

Review design + copy w/ ed/alex tomorrow morning.
Merge + deploy front.