### PR TITLE
Fix find matching sub schemas

### DIFF
--- a/front/lib/actions/mcp_internal_actions/input_configuration.ts
+++ b/front/lib/actions/mcp_internal_actions/input_configuration.ts
@@ -783,7 +783,7 @@ export function getMCPServerToolsConfigurations(
  */
 function isSchemaConfigurable(
   schema: JSONSchema,
-  mimeType: InternalToolInputMimeType
+  mimeType: InternalToolInputMimeType,
 ): boolean {
   if (mimeType === INTERNAL_MIME_TYPES.TOOL_INPUT.ENUM) {
     // We only check that the schema has a `value` property and a `mimeType` property with the correct value.
@@ -826,14 +826,21 @@ function isSchemaConfigurable(
 /**
  * Recursively finds all property keys and subschemas match a specific sub-schema.
  * This function handles nested objects and arrays.
+ * @param inputSchema - The current schema to search within
+ * @param mimeType - The mime type to match against
+ * @param rootSchema - The root schema for resolving references (defaults to inputSchema)
  * @returns A record of property keys that match the schema comparison.
  * Empty record if no matches are found.
  */
 export function findMatchingSubSchemas(
   inputSchema: JSONSchema,
-  mimeType: InternalToolInputMimeType
+  mimeType: InternalToolInputMimeType,
+  rootSchema?: JSONSchema,
 ): Record<string, JSONSchema> {
   const matches: Record<string, JSONSchema> = {};
+  
+  // Use the root schema for reference resolution, defaulting to inputSchema for backward compatibility
+  const resolverSchema = rootSchema ?? inputSchema;
 
   if (!isJSONSchemaObject(inputSchema)) {
     return matches;
@@ -851,19 +858,25 @@ export function findMatchingSubSchemas(
         // Following references within the main schema.
         // zodToJsonSchema generates references if the same subSchema is repeated.
         if (propSchema.$ref) {
-          const refSchema = followInternalRef(inputSchema, propSchema.$ref);
-          if (refSchema && isSchemaConfigurable(refSchema, mimeType)) {
+          const refSchema = followInternalRef(resolverSchema, propSchema.$ref);
+          
+          if (refSchema && (isSchemaConfigurable(refSchema, mimeType) || key === "mimeType" || key === "value")) {
             matches[key] = refSchema;
           }
         }
 
         // Recursively check this property's schema
-        const nestedMatches = findMatchingSubSchemas(propSchema, mimeType);
+        const nestedMatches = findMatchingSubSchemas(propSchema, mimeType, resolverSchema);
         // For nested matches, prefix with the current property key
         for (const match of Object.keys(nestedMatches)) {
-          if (match !== "") {
-            // Skip the empty string from direct matches
+          if (match !== "" && match !== "mimeType" && match !== "value") {
+          // Skip the empty string from direct matches
             matches[`${key}.${match}`] = nestedMatches[match];
+          } else if (match === "mimeType" || match === "value") {
+            if (isSchemaConfigurable({...propSchema, properties: { ...nestedMatches }}, mimeType)) {
+              console.log(`Matched ${key} with ${match}`, { ...propSchema, properties: { ...nestedMatches } });
+              matches[key] = { ...propSchema, properties: { ...nestedMatches } };
+            }
           }
         }
       }
@@ -874,7 +887,7 @@ export function findMatchingSubSchemas(
   if (inputSchema.type === "array" && inputSchema.items) {
     if (isJSONSchemaObject(inputSchema.items)) {
       // Single schema for all items
-      const itemMatches = findMatchingSubSchemas(inputSchema.items, mimeType);
+      const itemMatches = findMatchingSubSchemas(inputSchema.items, mimeType, resolverSchema);
       // For array items, we use the 'items' key as a prefix
       for (const match of Object.keys(itemMatches)) {
         if (match !== "") {
@@ -888,7 +901,7 @@ export function findMatchingSubSchemas(
       for (let i = 0; i < inputSchema.items.length; i++) {
         const item = inputSchema.items[i];
         if (isJSONSchemaObject(item)) {
-          const itemMatches = findMatchingSubSchemas(item, mimeType);
+          const itemMatches = findMatchingSubSchemas(item, mimeType, resolverSchema);
           // For tuple items, we use the index as part of the key
           for (const match of Object.keys(itemMatches)) {
             if (match !== "") {
@@ -919,7 +932,7 @@ export function findMatchingSubSchemas(
     if (isJSONSchemaObject(value) && isSchemaConfigurable(value, mimeType)) {
       matches[key] = value;
     } else if (isJSONSchemaObject(value)) {
-      const nestedMatches = findMatchingSubSchemas(value, mimeType);
+      const nestedMatches = findMatchingSubSchemas(value, mimeType, resolverSchema);
       for (const match of Object.keys(nestedMatches)) {
         if (match !== "") {
           matches[`${key}.${match}`] = nestedMatches[match];

--- a/front/lib/actions/mcp_internal_actions/input_configuration.ts
+++ b/front/lib/actions/mcp_internal_actions/input_configuration.ts
@@ -888,10 +888,6 @@ export function findMatchingSubSchemas(
                 mimeType
               )
             ) {
-              console.log(`Matched ${key} with ${match}`, {
-                ...propSchema,
-                properties: { ...nestedMatches },
-              });
               matches[key] = {
                 ...propSchema,
                 properties: { ...nestedMatches },


### PR DESCRIPTION
## Description

A bug occurred where due to Zod generating references in Json Schemas, any duplicate subschemas would be omitted when traversing tool configuration schemas, resulting in having only one configuration per base type (string, boolean, number...) available. This fix correctly follows the references (which have changed due to a change in Zod parameters (see: https://github.com/dust-tt/dust/pull/15780 [in the BUG FOUND area])).

## Tests

Ran all tests, and checked visually with "PrimitiveTypesDebugger" in the Agent Builder which is how I originally found the bug.

## Risk

None.

## Deploy Plan

Deploy front.


NB: Before:
<img width="986" height="1034" alt="image" src="https://github.com/user-attachments/assets/f8d15ae7-3504-4026-83f2-16355eb0c2ee" />

<img width="1518" height="578" alt="image" src="https://github.com/user-attachments/assets/e70038a8-dfad-4ab7-9eee-c4570fd81fba" />


After:

<img width="757" height="371" alt="image" src="https://github.com/user-attachments/assets/cfc20121-9b53-4b99-8409-78c16c4f02f8" />
