### PR TITLE
Let users use the 2 step file upload for uploading to folders

### DIFF
--- a/front/types/files.ts
+++ b/front/types/files.ts
@@ -442,7 +442,7 @@ export function isAllSupportedFileContentType(
 export function isPubliclySupportedUseCase(
   useCase: string
 ): useCase is FileUseCase {
-  return ["conversation"].includes(useCase);
+  return ["conversation", "folders_document"].includes(useCase);
 }
 
 export function isSupportedImageContentType(

--- a/sdks/js/src/types.ts
+++ b/sdks/js/src/types.ts
@@ -2182,6 +2182,7 @@ export const PostDataSourceDocumentRequestSchema = z.object({
   async: z.boolean().nullable().optional(),
   mime_type: z.string().nullable().optional(),
   title: z.string().nullable().optional(),
+  file_id: z.string().nullable().optional(),
 });
 
 export type PostDataSourceDocumentRequestType = z.infer<
@@ -2494,12 +2495,12 @@ export const FileUploadUrlRequestSchema = z.object({
   contentType: SupportedFileContentFragmentTypeSchema,
   fileName: z.string().max(4096, "File name must be less than 4096 characters"),
   fileSize: z.number(),
-  useCase: z.union([z.literal("conversation"), z.literal("upsert_table")]),
-  useCaseMetadata: z
-    .object({
-      conversationId: z.string(),
-    })
-    .optional(),
+  useCase: z.union([
+    z.literal("conversation"),
+    z.literal("upsert_table"),
+    z.literal("folders_document"),
+  ]),
+  useCaseMetadata: z.string().optional(),
 });
 export type FileUploadUrlRequestType = z.infer<
   typeof FileUploadUrlRequestSchema


### PR DESCRIPTION
## Description

Enables the 2-step file upload process for the `folders_document` use case, allowing users to upload large files (>8MB) to folders by first uploading the file via the `/files` endpoint and then referencing it when creating documents. This addresses the NextJS API route 8MB limit by separating file upload from document creation.

The changes add validation for the `folders_document` use case in the file upload API, requiring a `spaceId` in the metadata, and extend the document upsert endpoint to accept a `file_id` parameter as an alternative to direct text/section content.

## Tests

- Tested file upload with `folders_document` use case and `spaceId` metadata validation
- Verified document creation with `file_id` parameter works correctly
- Confirmed backward compatibility with existing text/section upload methods
- Validated error handling for invalid file IDs and missing spaceId

## Risk

Low risk. The changes maintain backward compatibility by keeping existing text/section upload methods while adding the new file-based upload option. File validation ensures only appropriate files are used for folder document uploads.

## Deploy Plan

No special deployment steps required - the changes are backward compatible and the new functionality is opt-in.