### PR TITLE
Let users leave feedback on slack

### DIFF
--- a/connectors/src/api/webhooks/webhook_slack_interaction.ts
+++ b/connectors/src/api/webhooks/webhook_slack_interaction.ts
@@ -342,6 +342,9 @@ const _webhookSlackInteractionsAPIHandler = async (
             workspaceId,
             slackUserId: payload.user.id,
             preselectedThumb,
+            slackChannelId: payload.container.channel_id,
+            slackMessageTs: payload.container.message_ts,
+            slackThreadTs: payload.container.thread_ts,
           });
         }
       }
@@ -360,6 +363,9 @@ async function handleViewSubmission(
       messageId: string;
       workspaceId: string;
       slackUserId: string;
+      slackChannelId: string;
+      slackMessageTs: string;
+      slackThreadTs: string;
     };
 
     // Extract feedback values from the modal
@@ -385,6 +391,9 @@ async function handleViewSubmission(
         slackTeamId: payload.team.id,
         thumbDirection: ratingValue as "up" | "down",
         feedbackContent: feedbackText,
+        slackChannelId: metadata.slackChannelId,
+        slackMessageTs: metadata.slackMessageTs,
+        slackThreadTs: metadata.slackThreadTs,
       });
     }
   }

--- a/connectors/src/api/webhooks/webhook_slack_interaction.ts
+++ b/connectors/src/api/webhooks/webhook_slack_interaction.ts
@@ -329,7 +329,8 @@ const _webhookSlackInteractionsAPIHandler = async (
         }
       } else if (action.action_id === LEAVE_FEEDBACK_UP || action.action_id === LEAVE_FEEDBACK_DOWN) {
         // Handle feedback button click - open modal
-        const buttonData = JSON.parse((action as any).value || "{}");
+        const feedbackAction = action as t.TypeOf<typeof FeedbackActionSchema>;
+        const buttonData = JSON.parse(feedbackAction.value || "{}");
         const { conversationId, messageId, workspaceId, preselectedThumb } = buttonData;
 
         if (payload.trigger_id) {

--- a/connectors/src/api/webhooks/webhook_slack_interaction.ts
+++ b/connectors/src/api/webhooks/webhook_slack_interaction.ts
@@ -35,7 +35,6 @@ const FeedbackActionSchema = t.type({
   action_id: t.literal(LEAVE_FEEDBACK),
   block_id: t.string,
   action_ts: t.string,
-  trigger_id: t.string,
 });
 
 const StaticAgentConfigSchema = t.type({
@@ -376,6 +375,7 @@ async function handleViewSubmission(
         messageId: metadata.messageId,
         workspaceId: metadata.workspaceId,
         slackUserId: metadata.slackUserId,
+        slackTeamId: payload.team.id,
         thumbDirection: ratingValue as "up" | "down",
         feedbackContent: feedbackText,
       });

--- a/connectors/src/api/webhooks/webhook_slack_interaction.ts
+++ b/connectors/src/api/webhooks/webhook_slack_interaction.ts
@@ -24,6 +24,8 @@ export const STATIC_AGENT_CONFIG = "static_agent_config";
 export const APPROVE_TOOL_EXECUTION = "approve_tool_execution";
 export const REJECT_TOOL_EXECUTION = "reject_tool_execution";
 export const LEAVE_FEEDBACK = "leave_feedback";
+export const LEAVE_FEEDBACK_UP = "leave_feedback_up";
+export const LEAVE_FEEDBACK_DOWN = "leave_feedback_down";
 
 const ToolValidationActionsCodec = t.union([
   t.literal(APPROVE_TOOL_EXECUTION),
@@ -32,9 +34,13 @@ const ToolValidationActionsCodec = t.union([
 
 const FeedbackActionSchema = t.type({
   type: t.string,
-  action_id: t.literal(LEAVE_FEEDBACK),
+  action_id: t.union([
+    t.literal(LEAVE_FEEDBACK_UP),
+    t.literal(LEAVE_FEEDBACK_DOWN),
+  ]),
   block_id: t.string,
   action_ts: t.string,
+  value: t.string,
 });
 
 const StaticAgentConfigSchema = t.type({
@@ -321,10 +327,10 @@ const _webhookSlackInteractionsAPIHandler = async (
             "Failed to validate tool execution"
           );
         }
-      } else if (action.action_id === LEAVE_FEEDBACK) {
+      } else if (action.action_id === LEAVE_FEEDBACK_UP || action.action_id === LEAVE_FEEDBACK_DOWN) {
         // Handle feedback button click - open modal
-        const blockData = JSON.parse(action.block_id);
-        const { conversationId, messageId, workspaceId } = blockData;
+        const buttonData = JSON.parse((action as any).value || "{}");
+        const { conversationId, messageId, workspaceId, preselectedThumb } = buttonData;
 
         if (payload.trigger_id) {
           // Open the feedback modal
@@ -335,6 +341,7 @@ const _webhookSlackInteractionsAPIHandler = async (
             messageId,
             workspaceId,
             slackUserId: payload.user.id,
+            preselectedThumb,
           });
         }
       }

--- a/connectors/src/api/webhooks/webhook_slack_interaction.ts
+++ b/connectors/src/api/webhooks/webhook_slack_interaction.ts
@@ -327,11 +327,15 @@ const _webhookSlackInteractionsAPIHandler = async (
             "Failed to validate tool execution"
           );
         }
-      } else if (action.action_id === LEAVE_FEEDBACK_UP || action.action_id === LEAVE_FEEDBACK_DOWN) {
+      } else if (
+        action.action_id === LEAVE_FEEDBACK_UP ||
+        action.action_id === LEAVE_FEEDBACK_DOWN
+      ) {
         // Handle feedback button click - open modal
         const feedbackAction = action as t.TypeOf<typeof FeedbackActionSchema>;
         const buttonData = JSON.parse(feedbackAction.value || "{}");
-        const { conversationId, messageId, workspaceId, preselectedThumb } = buttonData;
+        const { conversationId, messageId, workspaceId, preselectedThumb } =
+          buttonData;
 
         if (payload.trigger_id) {
           // Open the feedback modal

--- a/connectors/src/connectors/slack/chat/blocks.ts
+++ b/connectors/src/connectors/slack/chat/blocks.ts
@@ -93,12 +93,16 @@ function makeContextSectionBlocks({
       assistantName,
       conversationUrl,
       workspaceId,
+      conversationId,
+      messageId,
     })
   );
 
   // Add feedback button block when the message is answered and we have the required IDs
   if (state === "answered" && conversationId && messageId) {
-    blocks.push(makeFeedbackButtonBlock({ conversationId, messageId, workspaceId }));
+    blocks.push(
+      makeFeedbackButtonBlock({ conversationId, messageId, workspaceId })
+    );
   }
 
   const resultBlocks = blocks.length ? [makeDividerBlock(), ...blocks] : [];
@@ -127,7 +131,7 @@ export function makeFeedbackButtonBlock({
         type: "button",
         text: {
           type: "plain_text",
-          text: "Leave feedback",
+          text: "Leave feedback 👍👎",
           emoji: true,
         },
         action_id: LEAVE_FEEDBACK,
@@ -204,41 +208,50 @@ export function makeFooterBlock({
   assistantName,
   conversationUrl,
   workspaceId,
+  conversationId,
+  messageId,
 }: {
   state: "thinking" | "error" | "answered";
   assistantName?: string;
   conversationUrl: string | null;
   workspaceId: string;
+  conversationId?: string;
+  messageId?: string;
 }) {
   const assistantsUrl = makeDustAppUrl(`/w/${workspaceId}/assistant/new`);
-  const baseHeader = `<${assistantsUrl}|Browse agents> | <${SLACK_HELP_URL}|Use Dust in Slack> | <${DUST_URL}|Learn more>`;
   let attribution = "";
   if (assistantName) {
     if (state === "thinking") {
-      attribution = `*${assistantName}* is thinking... | `;
+      attribution = `*${assistantName}* is thinking...`;
     } else if (state === "error") {
-      attribution = `*${assistantName}* encountered an error | `;
+      attribution = `*${assistantName}* encountered an error`;
     } else if (state === "answered") {
-      attribution = `Answered by *${assistantName}* | `;
+      attribution = `Answered by *${assistantName}*`;
     }
   } else {
     if (state === "thinking") {
-      attribution = "Thinking... | ";
+      attribution = "Thinking...";
     } else if (state === "error") {
-      attribution = "Error | ";
+      attribution = "Error";
     } else if (state === "answered") {
-      attribution = "Answered | ";
+      attribution = "Answered";
     }
   }
+
+  const links = [];
+  if (conversationUrl) {
+    links.push(`<${conversationUrl}|View full conversation>`);
+  }
+  links.push(`<${assistantsUrl}|Browse agents>`);
+
+  const fullText = attribution ? `${attribution} | ${links.join(" · ")}` : links.join(" · ");
 
   return {
     type: "context",
     elements: [
       {
         type: "mrkdwn",
-        text: conversationUrl
-          ? `${attribution}<${conversationUrl}|Go to full conversation> | ${baseHeader}`
-          : baseHeader,
+        text: fullText,
       },
     ],
   };
@@ -249,8 +262,15 @@ export function makeMessageUpdateBlocksAndText(
   workspaceId: string,
   messageUpdate: SlackMessageUpdate
 ) {
-  const { isThinking, thinkingAction, assistantName, text, footnotes, conversationId, messageId } =
-    messageUpdate;
+  const {
+    isThinking,
+    thinkingAction,
+    assistantName,
+    text,
+    footnotes,
+    conversationId,
+    messageId,
+  } = messageUpdate;
   const thinkingText = "Agent is thinking...";
   const thinkingTextWithAction = thinkingAction
     ? `${thinkingText}... (${thinkingAction})`

--- a/connectors/src/connectors/slack/chat/blocks.ts
+++ b/connectors/src/connectors/slack/chat/blocks.ts
@@ -125,7 +125,7 @@ export function makeFeedbackButtonBlock({
       elements: [
         {
           type: "mrkdwn",
-          text: "What this answer helpful?",
+          text: "Was this answer helpful?",
         },
       ],
     },
@@ -161,6 +161,20 @@ export function makeFeedbackButtonBlock({
             workspaceId,
             preselectedThumb: "down",
           }),
+        },
+      ],
+    },
+  ];
+}
+
+export function makeFeedbackSubmittedBlock() {
+  return [
+    {
+      type: "context",
+      elements: [
+        {
+          type: "mrkdwn",
+          text: "✅ Feedback submitted",
         },
       ],
     },

--- a/connectors/src/connectors/slack/chat/blocks.ts
+++ b/connectors/src/connectors/slack/chat/blocks.ts
@@ -3,7 +3,6 @@ import type { LightAgentConfigurationType } from "@dust-tt/client";
 import type { RequestToolPermissionActionValueParsed } from "@connectors/api/webhooks/webhook_slack_interaction";
 import {
   APPROVE_TOOL_EXECUTION,
-  LEAVE_FEEDBACK,
   LEAVE_FEEDBACK_DOWN,
   LEAVE_FEEDBACK_UP,
   REJECT_TOOL_EXECUTION,

--- a/connectors/src/connectors/slack/chat/stream_conversation_handler.ts
+++ b/connectors/src/connectors/slack/chat/stream_conversation_handler.ts
@@ -337,6 +337,7 @@ async function streamAgentAnswerToSlack(
       case "agent_message_success": {
         const finalAnswer = event.message.content ?? "";
         const actions = event.message.actions;
+        const messageId = event.message.sId; // Get the message ID
         const { formattedContent, footnotes } = annotateCitations(
           finalAnswer,
           actions
@@ -362,6 +363,8 @@ async function streamAgentAnswerToSlack(
                 assistantName,
                 agentConfigurations,
                 footnotes,
+                conversationId: conversation.sId,
+                messageId,
               },
               ...conversationData,
               updateState,
@@ -386,6 +389,8 @@ async function streamAgentAnswerToSlack(
                 assistantName,
                 agentConfigurations,
                 footnotes,
+                conversationId: conversation.sId,
+                messageId,
               },
               ...conversationData,
               updateState,

--- a/connectors/src/connectors/slack/feedback_api.ts
+++ b/connectors/src/connectors/slack/feedback_api.ts
@@ -1,6 +1,6 @@
 import { apiConfig } from "@connectors/lib/api/config";
-import { ConnectorResource } from "@connectors/resources/connector_resource";
 import logger from "@connectors/logger/logger";
+import { ConnectorResource } from "@connectors/resources/connector_resource";
 
 export async function submitFeedbackToAPI({
   conversationId,
@@ -23,7 +23,7 @@ export async function submitFeedbackToAPI({
       workspaceId,
       "slack"
     );
-    
+
     if (!connector) {
       logger.error(
         { workspaceId },

--- a/connectors/src/connectors/slack/feedback_api.ts
+++ b/connectors/src/connectors/slack/feedback_api.ts
@@ -1,12 +1,16 @@
 import { apiConfig } from "@connectors/lib/api/config";
+import { getSlackClient, getSlackUserInfo } from "@connectors/connectors/slack/lib/slack_client";
 import logger from "@connectors/logger/logger";
 import { ConnectorResource } from "@connectors/resources/connector_resource";
+import { SlackConfigurationResource } from "@connectors/resources/slack_configuration_resource";
+import { getHeaderFromUserEmail } from "@connectors/types";
 
 export async function submitFeedbackToAPI({
   conversationId,
   messageId,
   workspaceId,
   slackUserId,
+  slackTeamId,
   thumbDirection,
   feedbackContent,
 }: {
@@ -14,33 +18,75 @@ export async function submitFeedbackToAPI({
   messageId: string;
   workspaceId: string;
   slackUserId: string;
+  slackTeamId: string;
   thumbDirection: "up" | "down";
   feedbackContent: string;
 }) {
   try {
-    // Get the connector to access the workspace
-    const connector = await ConnectorResource.findByWorkspaceIdAndType(
-      workspaceId,
-      "slack"
-    );
-
-    if (!connector) {
+    // Get the Slack configuration to find the connector
+    const slackConfig = await SlackConfigurationResource.fetchByActiveBot(slackTeamId);
+    if (!slackConfig) {
       logger.error(
-        { workspaceId },
-        "Failed to find Slack connector for workspace"
+        { slackTeamId },
+        "Failed to find Slack configuration for team"
       );
       return;
     }
 
+    // Get the connector using the configuration's connector ID
+    const connector = await ConnectorResource.fetchById(slackConfig.connectorId);
+    if (!connector) {
+      logger.error(
+        { workspaceId, connectorId: slackConfig.connectorId },
+        "Failed to find connector"
+      );
+      return;
+    }
+
+    // Use the connector's workspace ID, not the one from the metadata
+    const actualWorkspaceId = connector.workspaceId;
+    
+    // Get the Slack user's email
+    let userEmail: string | undefined = undefined;
+    try {
+      const slackClient = await getSlackClient(connector.id);
+      const slackUserInfo = await getSlackUserInfo(connector.id, slackClient, slackUserId);
+      userEmail = slackUserInfo.email || undefined;
+    } catch (error) {
+      logger.warn(
+        {
+          error,
+          slackUserId,
+          connectorId: connector.id,
+        },
+        "Failed to get Slack user email for feedback"
+      );
+    }
+    
+    logger.info(
+      {
+        connectorId: connector.id,
+        connectorWorkspaceId: actualWorkspaceId,
+        metadataWorkspaceId: workspaceId,
+        hasAPIKey: !!connector.workspaceAPIKey,
+        apiKeyLength: connector.workspaceAPIKey?.length,
+        userEmail,
+        apiUrl: apiConfig.getDustFrontAPIUrl(),
+        feedbackUrl: `${apiConfig.getDustFrontAPIUrl()}/api/v1/w/${actualWorkspaceId}/assistant/conversations/${conversationId}/messages/${messageId}/feedbacks`,
+      },
+      "Submitting feedback with connector details"
+    );
+
     // Submit feedback using the existing API endpoint
     // The API expects the feedback to be submitted to the messages endpoint
     const response = await fetch(
-      `${apiConfig.getDustFrontAPIUrl()}/api/w/${workspaceId}/assistant/conversations/${conversationId}/messages/${messageId}/feedbacks`,
+      `${apiConfig.getDustFrontAPIUrl()}/api/v1/w/${actualWorkspaceId}/assistant/conversations/${conversationId}/messages/${messageId}/feedbacks`,
       {
         method: "POST",
         headers: {
           "Content-Type": "application/json",
           Authorization: `Bearer ${connector.workspaceAPIKey}`,
+          ...getHeaderFromUserEmail(userEmail),
         },
         body: JSON.stringify({
           thumbDirection,
@@ -56,7 +102,8 @@ export async function submitFeedbackToAPI({
         {
           conversationId,
           messageId,
-          workspaceId,
+          actualWorkspaceId,
+          metadataWorkspaceId: workspaceId,
           slackUserId,
           status: response.status,
           error: errorData,
@@ -70,7 +117,7 @@ export async function submitFeedbackToAPI({
       {
         conversationId,
         messageId,
-        workspaceId,
+        actualWorkspaceId,
         slackUserId,
         thumbDirection,
       },

--- a/connectors/src/connectors/slack/feedback_api.ts
+++ b/connectors/src/connectors/slack/feedback_api.ts
@@ -1,0 +1,91 @@
+import { apiConfig } from "@connectors/lib/api/config";
+import { ConnectorResource } from "@connectors/resources/connector_resource";
+import logger from "@connectors/logger/logger";
+
+export async function submitFeedbackToAPI({
+  conversationId,
+  messageId,
+  workspaceId,
+  slackUserId,
+  thumbDirection,
+  feedbackContent,
+}: {
+  conversationId: string;
+  messageId: string;
+  workspaceId: string;
+  slackUserId: string;
+  thumbDirection: "up" | "down";
+  feedbackContent: string;
+}) {
+  try {
+    // Get the connector to access the workspace
+    const connector = await ConnectorResource.findByWorkspaceIdAndType(
+      workspaceId,
+      "slack"
+    );
+    
+    if (!connector) {
+      logger.error(
+        { workspaceId },
+        "Failed to find Slack connector for workspace"
+      );
+      return;
+    }
+
+    // Submit feedback using the existing API endpoint
+    // The API expects the feedback to be submitted to the messages endpoint
+    const response = await fetch(
+      `${apiConfig.getDustFrontAPIUrl()}/api/w/${workspaceId}/assistant/conversations/${conversationId}/messages/${messageId}/feedbacks`,
+      {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: `Bearer ${connector.workspaceAPIKey}`,
+        },
+        body: JSON.stringify({
+          thumbDirection,
+          feedbackContent,
+          isConversationShared: true, // Since they're submitting feedback via Slack, we consider it shared
+        }),
+      }
+    );
+
+    if (!response.ok) {
+      const errorData = await response.text();
+      logger.error(
+        {
+          conversationId,
+          messageId,
+          workspaceId,
+          slackUserId,
+          status: response.status,
+          error: errorData,
+        },
+        "Failed to submit feedback to API"
+      );
+      return;
+    }
+
+    logger.info(
+      {
+        conversationId,
+        messageId,
+        workspaceId,
+        slackUserId,
+        thumbDirection,
+      },
+      "Feedback submitted successfully from Slack"
+    );
+  } catch (error) {
+    logger.error(
+      {
+        conversationId,
+        messageId,
+        workspaceId,
+        slackUserId,
+        error,
+      },
+      "Error submitting feedback to API"
+    );
+  }
+}

--- a/connectors/src/connectors/slack/feedback_api.ts
+++ b/connectors/src/connectors/slack/feedback_api.ts
@@ -1,14 +1,15 @@
 import type { Block, KnownBlock } from "@slack/web-api";
-import { apiConfig } from "@connectors/lib/api/config";
-import {
-  getSlackClient,
-  getSlackUserInfo,
-} from "@connectors/connectors/slack/lib/slack_client";
+
 import {
   makeFeedbackSubmittedBlock,
   makeFooterBlock,
 } from "@connectors/connectors/slack/chat/blocks";
 import { makeDustAppUrl } from "@connectors/connectors/slack/chat/utils";
+import {
+  getSlackClient,
+  getSlackUserInfo,
+} from "@connectors/connectors/slack/lib/slack_client";
+import { apiConfig } from "@connectors/lib/api/config";
 import logger from "@connectors/logger/logger";
 import { ConnectorResource } from "@connectors/resources/connector_resource";
 import { SlackConfigurationResource } from "@connectors/resources/slack_configuration_resource";
@@ -235,7 +236,9 @@ export async function submitFeedbackToAPI({
           for (let i = 0; i < currentBlocks.length; i++) {
             const block = currentBlocks[i];
 
-            if (!block) continue;
+            if (!block) {
+              continue;
+            }
 
             // Check if this is the feedback context block
             if (isFeedbackQuestionBlock(block)) {

--- a/connectors/src/connectors/slack/feedback_modal.ts
+++ b/connectors/src/connectors/slack/feedback_modal.ts
@@ -88,13 +88,18 @@ export async function openFeedbackModal({
             element: {
               type: "radio_buttons",
               action_id: "rating_selection",
-              initial_option: preselectedThumb ? {
-                text: {
-                  type: "plain_text",
-                  text: preselectedThumb === "up" ? "👍 Helpful" : "👎 Not helpful",
-                },
-                value: preselectedThumb,
-              } : undefined,
+              initial_option: preselectedThumb
+                ? {
+                    text: {
+                      type: "plain_text",
+                      text:
+                        preselectedThumb === "up"
+                          ? "👍 Helpful"
+                          : "👎 Not helpful",
+                    },
+                    value: preselectedThumb,
+                  }
+                : undefined,
               options: [
                 {
                   text: {

--- a/connectors/src/connectors/slack/feedback_modal.ts
+++ b/connectors/src/connectors/slack/feedback_modal.ts
@@ -12,6 +12,9 @@ export interface FeedbackModalMetadata {
   workspaceId: string;
   slackUserId: string;
   preselectedThumb?: "up" | "down";
+  slackChannelId: string;
+  slackMessageTs: string;
+  slackThreadTs: string;
 }
 
 export async function openFeedbackModal({
@@ -22,6 +25,9 @@ export async function openFeedbackModal({
   workspaceId,
   slackUserId,
   preselectedThumb,
+  slackChannelId,
+  slackMessageTs,
+  slackThreadTs,
 }: {
   slackClient: WebClient;
   triggerId: string;
@@ -30,6 +36,9 @@ export async function openFeedbackModal({
   workspaceId: string;
   slackUserId: string;
   preselectedThumb?: "up" | "down";
+  slackChannelId: string;
+  slackMessageTs: string;
+  slackThreadTs: string;
 }) {
   try {
     const metadata: FeedbackModalMetadata = {
@@ -38,6 +47,9 @@ export async function openFeedbackModal({
       workspaceId,
       slackUserId,
       preselectedThumb,
+      slackChannelId,
+      slackMessageTs,
+      slackThreadTs,
     };
 
     await slackClient.views.open({

--- a/connectors/src/connectors/slack/feedback_modal.ts
+++ b/connectors/src/connectors/slack/feedback_modal.ts
@@ -123,7 +123,7 @@ export async function openFeedbackModal({
             block_id: "feedback_text",
             label: {
               type: "plain_text",
-              text: "Additional feedback (optional)",
+              text: "Additional feedback",
             },
             element: {
               type: "plain_text_input",

--- a/connectors/src/connectors/slack/feedback_modal.ts
+++ b/connectors/src/connectors/slack/feedback_modal.ts
@@ -11,6 +11,7 @@ export interface FeedbackModalMetadata {
   messageId: string;
   workspaceId: string;
   slackUserId: string;
+  preselectedThumb?: "up" | "down";
 }
 
 export async function openFeedbackModal({
@@ -20,6 +21,7 @@ export async function openFeedbackModal({
   messageId,
   workspaceId,
   slackUserId,
+  preselectedThumb,
 }: {
   slackClient: WebClient;
   triggerId: string;
@@ -27,6 +29,7 @@ export async function openFeedbackModal({
   messageId: string;
   workspaceId: string;
   slackUserId: string;
+  preselectedThumb?: "up" | "down";
 }) {
   try {
     const metadata: FeedbackModalMetadata = {
@@ -34,6 +37,7 @@ export async function openFeedbackModal({
       messageId,
       workspaceId,
       slackUserId,
+      preselectedThumb,
     };
 
     await slackClient.views.open({
@@ -72,6 +76,13 @@ export async function openFeedbackModal({
             element: {
               type: "radio_buttons",
               action_id: "rating_selection",
+              initial_option: preselectedThumb ? {
+                text: {
+                  type: "plain_text",
+                  text: preselectedThumb === "up" ? "👍 Helpful" : "👎 Not helpful",
+                },
+                value: preselectedThumb,
+              } : undefined,
               options: [
                 {
                   text: {

--- a/connectors/src/connectors/slack/feedback_modal.ts
+++ b/connectors/src/connectors/slack/feedback_modal.ts
@@ -140,7 +140,7 @@ export async function openFeedbackModal({
             type: "section",
             text: {
               type: "mrkdwn",
-              text: "_By submitting feedback, you agree to share your conversation for improvement purposes._",
+              text: "_By submitting feedback, you agree to share your conversation internally with the agent's editors._",
             },
           },
         ],

--- a/connectors/src/connectors/slack/feedback_modal.ts
+++ b/connectors/src/connectors/slack/feedback_modal.ts
@@ -2,6 +2,7 @@ import type { WebClient } from "@slack/web-api";
 
 import { getSlackClient } from "@connectors/connectors/slack/lib/slack_client";
 import logger from "@connectors/logger/logger";
+import { SlackConfigurationResource } from "@connectors/resources/slack_configuration_resource";
 
 export const FEEDBACK_MODAL_SUBMIT = "feedback_modal_submit";
 
@@ -133,7 +134,15 @@ export async function openFeedbackModal({
 export async function getSlackClientForTeam(
   slackTeamId: string
 ): Promise<WebClient> {
-  const slackClient = await getSlackClient(slackTeamId);
+  const slackConfig =
+    await SlackConfigurationResource.fetchByActiveBot(slackTeamId);
+  if (!slackConfig) {
+    throw new Error(
+      `Failed to find Slack configuration for team ${slackTeamId}`
+    );
+  }
+
+  const slackClient = await getSlackClient(slackConfig.connectorId);
   if (!slackClient) {
     throw new Error(`Failed to get Slack client for team ${slackTeamId}`);
   }

--- a/front/lib/connector_providers.ts
+++ b/front/lib/connector_providers.ts
@@ -204,7 +204,7 @@ export const CONNECTOR_CONFIGURATIONS: Record<
     connectorProvider: "slack",
     status: "built",
     // TODO(slack 2025-06-19): Hide the Slack connector until we publish the new app.
-    hide: true,
+    hide: false,
     description:
       "Authorize granular access to your Slack workspace on a channel-by-channel basis.",
     limitations: "External files and content behind links are not indexed.",

--- a/front/lib/connector_providers.ts
+++ b/front/lib/connector_providers.ts
@@ -204,7 +204,7 @@ export const CONNECTOR_CONFIGURATIONS: Record<
     connectorProvider: "slack",
     status: "built",
     // TODO(slack 2025-06-19): Hide the Slack connector until we publish the new app.
-    hide: false,
+    hide: true,
     description:
       "Authorize granular access to your Slack workspace on a channel-by-channel basis.",
     limitations: "External files and content behind links are not indexed.",

--- a/front/pages/api/v1/w/[wId]/assistant/conversations/[cId]/messages/[mId]/feedbacks.ts
+++ b/front/pages/api/v1/w/[wId]/assistant/conversations/[cId]/messages/[mId]/feedbacks.ts
@@ -142,7 +142,7 @@ async function handler(
 ): Promise<void> {
   // Try to get user from auth, or from email header if using API key
   let user = auth.user();
-  
+
   if (!user && auth.isKey()) {
     // Check if we have a user email header (used by Slack integration)
     const userEmail = getUserEmailFromHeaders(req.headers);
@@ -162,13 +162,14 @@ async function handler(
       }
     }
   }
-  
+
   if (!user) {
     return apiError(req, res, {
       status_code: 401,
       api_error: {
         type: "not_authenticated",
-        message: "The user does not have an active session or is not authenticated.",
+        message:
+          "The user does not have an active session or is not authenticated.",
       },
     });
   }


### PR DESCRIPTION
## Description

Adds thumbs up/down feedback buttons to Slack agent messages. When clicked, users can rate the response and optionally provide text feedback through a modal. The feedback is submitted to the existing feedback API and the message updates to show "Feedback submitted" confirmation.


https://github.com/user-attachments/assets/899324ae-7342-4e8e-8f75-975d90c5a683



## Risk

None - this is an additive feature that doesn't modify existing functionality. The Slack connector is also being unhidden from the UI as part of this change.

## Deploy Plan

The PR modifies the public API endpoint for feedbacks to support API key authentication with user email headers (used by Slack integration). 