### PR TITLE
[front] - fix(AB): empty knowledge tool resources

### DIFF
--- a/front/components/agent_builder/capabilities/AgentBuilderCapabilitiesBlock.tsx
+++ b/front/components/agent_builder/capabilities/AgentBuilderCapabilitiesBlock.tsx
@@ -12,7 +12,6 @@ import {
   Spinner,
   XMarkIcon,
 } from "@dust-tt/sparkle";
-import isEmpty from "lodash/isEmpty";
 import React, { useMemo, useState } from "react";
 import { useFieldArray, useFormContext } from "react-hook-form";
 
@@ -139,6 +138,7 @@ function ActionCard({ action, onRemove, onEdit }: ActionCardProps) {
     </Card>
   );
 }
+
 interface AgentBuilderCapabilitiesBlockProps {
   isActionsLoading: boolean;
 }
@@ -194,12 +194,11 @@ export function AgentBuilderCapabilitiesBlock({
   };
 
   const handleActionEdit = (action: AgentBuilderAction, index: number) => {
+    const mcpServerView = mcpServerViewsWithKnowledge.find(
+      (view) => view.sId === action.configuration?.mcpServerViewId
+    );
     const isDataSourceSelectionRequired =
-      action.type === "MCP" &&
-      Boolean(
-        !isEmpty(action.configuration.dataSourceConfigurations) ||
-          !isEmpty(action.configuration.tablesConfigurations)
-      );
+      action.type === "MCP" && Boolean(mcpServerView);
 
     if (isDataSourceSelectionRequired) {
       setKnowledgeAction({ action, index });

--- a/front/components/agent_builder/capabilities/knowledge/KnowledgeConfigurationSheet.tsx
+++ b/front/components/agent_builder/capabilities/knowledge/KnowledgeConfigurationSheet.tsx
@@ -373,8 +373,6 @@ function KnowledgeConfigurationSheetContent({
 
           {config && <DescriptionSection {...config?.descriptionConfig} />}
 
-          <SelectDataSourcesFilters />
-
           {/* Advanced Settings collapsible section */}
           {mcpServerView?.serverType === "internal" &&
             mcpServerView.server.name === SEARCH_SERVER_NAME && (
@@ -398,6 +396,8 @@ function KnowledgeConfigurationSheetContent({
                 </CollapsibleContent>
               </Collapsible>
             )}
+
+          <SelectDataSourcesFilters />
         </div>
       ),
     },

--- a/front/components/agent_builder/types.ts
+++ b/front/components/agent_builder/types.ts
@@ -62,9 +62,6 @@ export const TOOLS_SHEET_PAGE_IDS = {
   INFO: "info",
 };
 
-export type ConfigurationSheetPageId =
-  (typeof CONFIGURATION_SHEET_PAGE_IDS)[keyof typeof CONFIGURATION_SHEET_PAGE_IDS];
-
 export type ConfigurationPagePageId =
   (typeof TOOLS_SHEET_PAGE_IDS)[keyof typeof TOOLS_SHEET_PAGE_IDS];
 


### PR DESCRIPTION
## Description

This PR aims at fixing the following problem: when saving an agent we post-process the selected resources to filter on the node type supported by the processing method. It can happen that after this post-processing step we end up with no resource.

The checks we were doing before where detecting whether it was a "Knowledge tool" based on the state of `dataSourceConfigurations` and `tablesConfigurations`, which was wrong. We now retrieve the relevant MCP server view.

## Tests

Locally

## Risk

Low

## Deploy Plan

Deploy front