### PR TITLE
Add fixVersion filter on the jira tool

### DIFF
--- a/front/lib/actions/mcp_internal_actions/constants.ts
+++ b/front/lib/actions/mcp_internal_actions/constants.ts
@@ -713,6 +713,7 @@ The directive should be used to display a clickable version of the agent name in
       get_issue: "never_ask",
       get_projects: "never_ask",
       get_project: "never_ask",
+      get_project_versions: "never_ask",
       get_transitions: "never_ask",
       get_issues: "never_ask",
       get_issue_types: "never_ask",

--- a/front/lib/actions/mcp_internal_actions/servers/jira/jira_api_helper.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/jira/jira_api_helper.ts
@@ -282,6 +282,35 @@ export async function getProjects(
   return handleResults(result, []);
 }
 
+export async function getProjectVersions(
+  baseUrl: string,
+  accessToken: string,
+  projectKey: string
+): Promise<Result<any[], JiraErrorResult>> {
+  const result = await jiraApiCall(
+    {
+      endpoint: `/rest/api/3/project/${projectKey}/versions`,
+      accessToken,
+    },
+    z.array(
+      z.object({
+        id: z.string(),
+        name: z.string(),
+        description: z.string().optional(),
+        released: z.boolean().optional(),
+        releaseDate: z.string().optional(),
+        startDate: z.string().optional(),
+        archived: z.boolean().optional(),
+      })
+    ),
+    {
+      baseUrl,
+    }
+  );
+
+  return handleResults(result, []);
+}
+
 export async function getProject(
   baseUrl: string,
   accessToken: string,

--- a/front/lib/actions/mcp_internal_actions/servers/jira/jira_api_helper.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/jira/jira_api_helper.ts
@@ -32,6 +32,7 @@ import {
   JiraIssueSchema,
   JiraIssueTypeSchema,
   JiraProjectSchema,
+  JiraProjectVersionSchema,
   JiraResourceSchema,
   JiraSearchResultSchema,
   JiraTransitionIssueSchema,
@@ -286,23 +287,15 @@ export async function getProjectVersions(
   baseUrl: string,
   accessToken: string,
   projectKey: string
-): Promise<Result<any[], JiraErrorResult>> {
+): Promise<
+  Result<z.infer<typeof JiraProjectVersionSchema>[], JiraErrorResult>
+> {
   const result = await jiraApiCall(
     {
       endpoint: `/rest/api/3/project/${projectKey}/versions`,
       accessToken,
     },
-    z.array(
-      z.object({
-        id: z.string(),
-        name: z.string(),
-        description: z.string().optional(),
-        released: z.boolean().optional(),
-        releaseDate: z.string().optional(),
-        startDate: z.string().optional(),
-        archived: z.boolean().optional(),
-      })
-    ),
+    z.array(JiraProjectVersionSchema),
     {
       baseUrl,
     }

--- a/front/lib/actions/mcp_internal_actions/servers/jira/types.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/jira/types.ts
@@ -173,6 +173,16 @@ export const JiraProjectSchema = z.object({
   name: z.string(),
 });
 
+export const JiraProjectVersionSchema = z.object({
+  id: z.string(),
+  name: z.string(),
+  description: z.string().optional(),
+  released: z.boolean().optional(),
+  releaseDate: z.string().optional(),
+  startDate: z.string().optional(),
+  archived: z.boolean().optional(),
+});
+
 export const JiraTransitionSchema = z.object({
   id: z.string(),
   name: z.string(),

--- a/front/lib/actions/mcp_internal_actions/servers/jira/types.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/jira/types.ts
@@ -14,6 +14,7 @@ export const FIELD_MAPPINGS = {
   assignee: { jqlField: "assignee" },
   created: { jqlField: "created", supportsOperators: true },
   dueDate: { jqlField: "dueDate", supportsOperators: true },
+  fixVersion: { jqlField: "fixVersion" },
   issueType: { jqlField: "issueType" },
   labels: { jqlField: "labels" },
   priority: { jqlField: "priority" },


### PR DESCRIPTION







## Description
Adds support for filtering JIRA issues by `fixVersion` in the search functionality. This enhancement includes adding a new `get_project_versions` tool to retrieve available versions for a project, adding `fixVersion` to the supported filter fields, and updating the tool configuration to set it to "never_ask" mode.

## Risk
Low risk change as this only adds new functionality without modifying existing behavior. The new filter field follows the same pattern as other existing filters.

## Deploy Plan
