### PR TITLE
[front] - fix(AssistantDetails): tool name display

### DIFF
--- a/front/components/assistant/details/tabs/AgentInfoTab/AssistantToolsSection.tsx
+++ b/front/components/assistant/details/tabs/AgentInfoTab/AssistantToolsSection.tsx
@@ -6,6 +6,7 @@ import { useTheme } from "@app/components/sparkle/ThemeContext";
 import type { MCPServerConfigurationType } from "@app/lib/actions/mcp";
 import {
   getMcpServerDisplayName,
+  getMcpServerViewDisplayName,
   getServerTypeAndIdFromSId,
 } from "@app/lib/actions/mcp_helper";
 import { getAvatar } from "@app/lib/actions/mcp_icons";
@@ -17,6 +18,7 @@ import type { MCPServerTypeWithViews } from "@app/lib/api/mcp";
 import { useMCPServers } from "@app/lib/swr/mcp_servers";
 import type { AgentConfigurationType, LightWorkspaceType } from "@app/types";
 import {
+  asDisplayName,
   assertNever,
   GLOBAL_AGENTS_SID,
   removeNulls,
@@ -128,16 +130,20 @@ function renderOtherAction(
     if (!mcpServer) {
       return null;
     }
+    const view = mcpServer.views.find((v) => v.sId === action.mcpServerViewId);
     const { serverType } = getServerTypeAndIdFromSId(mcpServer.sId);
     const avatar = getAvatar(mcpServer, "xs");
+    const title = view
+      ? getMcpServerViewDisplayName(view, action)
+      : getMcpServerDisplayName(mcpServer, action);
     return {
-      title: getMcpServerDisplayName(mcpServer),
+      title,
       avatar,
       order: serverType === "internal" ? 1 : 3,
     };
   } else if (isMCPServerConfiguration(action)) {
     return {
-      title: action.name,
+      title: asDisplayName(action.name),
       avatar: <Avatar icon={CommandIcon} size="xs" />,
       order: 3,
     };

--- a/front/lib/actions/mcp_helper.ts
+++ b/front/lib/actions/mcp_helper.ts
@@ -1,5 +1,6 @@
 import type { AgentBuilderAction } from "@app/components/agent_builder/AgentBuilderFormContext";
 import type { AssistantBuilderMCPConfiguration } from "@app/components/assistant_builder/types";
+import type { MCPServerConfigurationType } from "@app/lib/actions/mcp";
 import type {
   AutoInternalMCPServerNameType,
   InternalMCPServerNameType,
@@ -133,7 +134,7 @@ export function getMcpServerViewDisplayName(
   action?:
     | AssistantBuilderMCPConfiguration
     | AgentBuilderAction
-    | { name: string }
+    | MCPServerConfigurationType
 ) {
   if (view.name) {
     return asDisplayName(view.name);
@@ -146,7 +147,7 @@ export function getMcpServerDisplayName(
   action?:
     | AssistantBuilderMCPConfiguration
     | AgentBuilderAction
-    | { name: string }
+    | MCPServerConfigurationType
 ) {
   // Unreleased internal servers are displayed with a suffix in the UI.
   const res = getInternalMCPServerNameAndWorkspaceId(server.sId);

--- a/front/lib/actions/mcp_helper.ts
+++ b/front/lib/actions/mcp_helper.ts
@@ -130,7 +130,10 @@ export function getMcpServerViewDescription(view: MCPServerViewType): string {
 
 export function getMcpServerViewDisplayName(
   view: MCPServerViewType,
-  action?: AssistantBuilderMCPConfiguration | AgentBuilderAction
+  action?:
+    | AssistantBuilderMCPConfiguration
+    | AgentBuilderAction
+    | { name: string }
 ) {
   if (view.name) {
     return asDisplayName(view.name);
@@ -140,7 +143,10 @@ export function getMcpServerViewDisplayName(
 
 export function getMcpServerDisplayName(
   server: MCPServerType,
-  action?: AssistantBuilderMCPConfiguration | AgentBuilderAction
+  action?:
+    | AssistantBuilderMCPConfiguration
+    | AgentBuilderAction
+    | { name: string }
 ) {
   // Unreleased internal servers are displayed with a suffix in the UI.
   const res = getInternalMCPServerNameAndWorkspaceId(server.sId);


### PR DESCRIPTION
## Description

This PR ensures that the tools name displayed in the `AssistantDetails` sheet are coincide with what's displayed in the agent builder.

**References:**
- https://github.com/dust-tt/tasks/issues/4154

## Tests

Locally

## Risk

Low

## Deploy Plan

Deploy front