### PR TITLE
Allow searching for datasource tags in poke

### DIFF
--- a/front/pages/poke/[wId]/data_sources/[dsId]/search.tsx
+++ b/front/pages/poke/[wId]/data_sources/[dsId]/search.tsx
@@ -45,6 +45,8 @@ export default function DataSourceView({
   dataSource,
 }: InferGetServerSidePropsType<typeof getServerSideProps>) {
   const [searchQuery, setSearchQuery] = useState("");
+  const [tagsIn, setTagsIn] = useState("");
+  const [tagsNotIn, setTagsNotIn] = useState("");
   const [documents, setDocuments] = useState<DocumentType[]>([]);
   const [expandedChunkId, setExpandedChunkId] = useState<string | null>(null);
   const [isLoading, setIsLoading] = useState<boolean>(false);
@@ -71,14 +73,22 @@ export default function DataSourceView({
     setError(false);
     let isCancelled = false;
     void (async () => {
-      if (searchQuery.trim().length == 0) {
+      if (searchQuery.trim().length == 0 && tagsIn.trim().length == 0 && tagsNotIn.trim().length == 0) {
         setDocuments([]);
 
         return;
       }
       setIsLoading(true);
       const searchParams = new URLSearchParams();
-      searchParams.append("query", searchQuery);
+      if (searchQuery.trim().length > 0) {
+        searchParams.append("query", searchQuery);
+      }
+      if (tagsIn.trim().length > 0) {
+        searchParams.append("tags_in", tagsIn);
+      }
+      if (tagsNotIn.trim().length > 0) {
+        searchParams.append("tags_not", tagsNotIn);
+      }
       searchParams.append("top_k", "10");
       searchParams.append("full_text", "false");
 
@@ -110,7 +120,7 @@ export default function DataSourceView({
     return () => {
       isCancelled = true;
     };
-  }, [dataSource.sId, owner.sId, searchQuery]);
+  }, [dataSource.sId, owner.sId, searchQuery, tagsIn, tagsNotIn]);
 
   const onDisplayDocumentSource = (documentId: string) => {
     if (
@@ -141,6 +151,40 @@ export default function DataSourceView({
                 }
               }}
               placeholder="Search query..."
+            />
+          </div>
+        </div>
+        <div className="sm:col-span-6 mt-4">
+          <div className="mt-1 flex rounded-md">
+            <Input
+              type="text"
+              autoComplete="off"
+              name="tags_in"
+              id="tags_in"
+              className="block w-full min-w-0 flex-1 rounded-md border-gray-300 text-sm focus:border-highlight-500 focus:ring-highlight-500"
+              onKeyDown={(e) => {
+                if (e.key == "Enter") {
+                  setTagsIn(e.currentTarget.value);
+                }
+              }}
+              placeholder="Tags in..."
+            />
+          </div>
+        </div>
+        <div className="sm:col-span-6 mt-4">
+          <div className="mt-1 flex rounded-md">
+            <Input
+              type="text"
+              autoComplete="off"
+              name="tags_not_in"
+              id="tags_not_in"
+              className="block w-full min-w-0 flex-1 rounded-md border-gray-300 text-sm focus:border-highlight-500 focus:ring-highlight-500"
+              onKeyDown={(e) => {
+                if (e.key == "Enter") {
+                  setTagsNotIn(e.currentTarget.value);
+                }
+              }}
+              placeholder="Tags not in..."
             />
           </div>
         </div>
@@ -238,13 +282,15 @@ export default function DataSourceView({
                 if (
                   !isLoading &&
                   searchQuery.length == 0 &&
+                  tagsIn.length == 0 &&
+                  tagsNotIn.length == 0 &&
                   documents.length === 0
                 ) {
                   return null;
                 }
                 if (
                   !isLoading &&
-                  searchQuery.length > 0 &&
+                  (searchQuery.length > 0 || tagsIn.length > 0 || tagsNotIn.length > 0) &&
                   documents.length === 0
                 ) {
                   return <p>No document found.</p>;

--- a/front/pages/poke/[wId]/data_sources/[dsId]/search.tsx
+++ b/front/pages/poke/[wId]/data_sources/[dsId]/search.tsx
@@ -73,7 +73,11 @@ export default function DataSourceView({
     setError(false);
     let isCancelled = false;
     void (async () => {
-      if (searchQuery.trim().length == 0 && tagsIn.trim().length == 0 && tagsNotIn.trim().length == 0) {
+      if (
+        searchQuery.trim().length == 0 &&
+        tagsIn.trim().length == 0 &&
+        tagsNotIn.trim().length == 0
+      ) {
         setDocuments([]);
 
         return;
@@ -154,7 +158,7 @@ export default function DataSourceView({
             />
           </div>
         </div>
-        <div className="sm:col-span-6 mt-4">
+        <div className="mt-4 sm:col-span-6">
           <div className="mt-1 flex rounded-md">
             <Input
               type="text"
@@ -171,7 +175,7 @@ export default function DataSourceView({
             />
           </div>
         </div>
-        <div className="sm:col-span-6 mt-4">
+        <div className="mt-4 sm:col-span-6">
           <div className="mt-1 flex rounded-md">
             <Input
               type="text"
@@ -290,7 +294,9 @@ export default function DataSourceView({
                 }
                 if (
                   !isLoading &&
-                  (searchQuery.length > 0 || tagsIn.length > 0 || tagsNotIn.length > 0) &&
+                  (searchQuery.length > 0 ||
+                    tagsIn.length > 0 ||
+                    tagsNotIn.length > 0) &&
                   documents.length === 0
                 ) {
                   return <p>No document found.</p>;


### PR DESCRIPTION
## Description

UI to use already exposed query params:

<img width="256" height="232" alt="Screenshot 2025-09-12 at 15 56 17" src="https://github.com/user-attachments/assets/060a5907-3795-49b9-a353-27691a79fe13" />


## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

Monimal

## Deploy Plan

Front