### PR TITLE
[front] allow to share a preview link with useFile to your workspace

### DIFF
--- a/front/components/assistant/conversation/actions/VisualizationActionIframe.tsx
+++ b/front/components/assistant/conversation/actions/VisualizationActionIframe.tsx
@@ -25,7 +25,6 @@ import React, {
 import { useVisualizationRetry } from "@app/lib/swr/conversations";
 import type {
   CommandResultMap,
-  LightWorkspaceType,
   VisualizationRPCCommand,
   VisualizationRPCRequest,
 } from "@app/types";
@@ -211,39 +210,13 @@ export function CodeDrawer({
     </Sheet>
   );
 }
-
-// This interface represents the props for the VisualizationActionIframe component when it is used
-// in a public context.
-interface PublicVisualizationActionIframeProps {
-  agentConfigurationId: null;
-  conversationId: null;
+interface VisualizationActionIframeProps {
+  agentConfigurationId: string | null;
+  conversationId: string | null;
   isInDrawer?: boolean;
   visualization: Visualization;
-  workspace: null;
-}
-
-// This interface represents the props for the VisualizationActionIframe component when it is used
-// in a conversation context.
-interface ConversationVisualizationActionIframeProps {
-  agentConfigurationId: string;
-  conversationId: string;
-  isInDrawer?: boolean;
-  visualization: Visualization;
-  workspace: LightWorkspaceType;
-}
-
-type VisualizationActionIframeProps =
-  | ConversationVisualizationActionIframeProps
-  | PublicVisualizationActionIframeProps;
-
-function isPublicVisualization(
-  props: VisualizationActionIframeProps
-): props is PublicVisualizationActionIframeProps {
-  return (
-    props.agentConfigurationId === null &&
-    props.conversationId === null &&
-    props.workspace === null
-  );
+  workspaceId: string;
+  isPublic?: boolean;
 }
 
 export const VisualizationActionIframe = forwardRef<
@@ -274,18 +247,18 @@ export const VisualizationActionIframe = forwardRef<
 
   const isErrored = !!errorMessage || retryClicked;
 
-  const isPublic = isPublicVisualization(props);
-
   const {
     agentConfigurationId,
     conversationId,
     isInDrawer = false,
     visualization,
+    workspaceId,
+    isPublic = false,
   } = props;
 
   useVisualizationDataHandler({
     visualization,
-    workspaceId: isPublic ? null : props.workspace.sId,
+    workspaceId,
     setContentHeight,
     setErrorMessage,
     setCodeDrawerOpened,
@@ -301,7 +274,7 @@ export const VisualizationActionIframe = forwardRef<
   );
 
   const { handleVisualizationRetry, canRetry } = useVisualizationRetry({
-    workspaceId: isPublic ? null : props.workspace.sId,
+    workspaceId,
     conversationId,
     agentConfigurationId,
     isPublic,

--- a/front/components/assistant/conversation/content_creation/ClientExecutableRenderer.tsx
+++ b/front/components/assistant/conversation/content_creation/ClientExecutableRenderer.tsx
@@ -18,7 +18,7 @@ import { ShareContentCreationFilePopover } from "@app/components/assistant/conve
 import { useConversationSidePanelContext } from "@app/components/assistant/conversation/ConversationSidePanelContext";
 import { useDesktopNavigation } from "@app/components/navigation/DesktopNavigationContext";
 import { useHashParam } from "@app/hooks/useHashParams";
-import { isFileUsingConversationFiles } from "@app/lib/files";
+import { isUsingConversationFiles } from "@app/lib/files";
 import { useFileContent } from "@app/lib/swr/files";
 import { useFileMetadata } from "@app/lib/swr/files";
 import type {
@@ -92,7 +92,7 @@ export function ClientExecutableRenderer({
   const { fileMetadata } = useFileMetadata({ fileId, owner });
 
   const isUsingConversationFiles = React.useMemo(
-    () => (fileContent ? isFileUsingConversationFiles(fileContent) : false),
+    () => (fileContent ? isUsingConversationFiles(fileContent) : false),
     [fileContent]
   );
 

--- a/front/components/assistant/conversation/content_creation/ClientExecutableRenderer.tsx
+++ b/front/components/assistant/conversation/content_creation/ClientExecutableRenderer.tsx
@@ -226,7 +226,7 @@ export function ClientExecutableRenderer({
                 fileMetadata?.useCaseMetadata
                   .lastEditedByAgentConfigurationId ?? ""
               }
-              workspace={owner}
+              workspaceId={owner.sId}
               visualization={{
                 code: fileContent ?? "",
                 complete: true,

--- a/front/components/assistant/conversation/content_creation/ClientExecutableRenderer.tsx
+++ b/front/components/assistant/conversation/content_creation/ClientExecutableRenderer.tsx
@@ -91,7 +91,7 @@ export function ClientExecutableRenderer({
   });
   const { fileMetadata } = useFileMetadata({ fileId, owner });
 
-  const isUsingConversationFiles = React.useMemo(
+  const isFileUsingConversationFiles = React.useMemo(
     () => (fileContent ? isUsingConversationFiles(fileContent) : false),
     [fileContent]
   );
@@ -207,7 +207,7 @@ export function ClientExecutableRenderer({
         <ShareContentCreationFilePopover
           fileId={fileId}
           owner={owner}
-          isUsingConversationFiles={isUsingConversationFiles}
+          isUsingConversationFiles={isFileUsingConversationFiles}
         />
       </ContentCreationHeader>
 

--- a/front/components/assistant/conversation/content_creation/PublicClientExecutableRenderer.tsx
+++ b/front/components/assistant/conversation/content_creation/PublicClientExecutableRenderer.tsx
@@ -10,12 +10,14 @@ interface PublicClientExecutableRendererProps {
   fileId: string;
   fileName?: string;
   shareToken: string;
+  workspaceId: string;
 }
 
 export function PublicClientExecutableRenderer({
   fileId,
   fileName,
   shareToken,
+  workspaceId,
 }: PublicClientExecutableRendererProps) {
   const { fileContent, isFileLoading, isFileError } = usePublicFile({
     shareToken,
@@ -51,14 +53,15 @@ export function PublicClientExecutableRenderer({
           <VisualizationActionIframe
             agentConfigurationId={null}
             conversationId={null}
-            workspace={null}
+            workspaceId={workspaceId}
             visualization={{
               code: fileContent ?? "",
               complete: true,
               identifier: `viz-${fileId}`,
             }}
             key={`viz-${fileId}`}
-            isInDrawer={true}
+            isInDrawer
+            isPublic
           />
         </div>
       </div>

--- a/front/components/assistant/conversation/content_creation/PublicContentCreationContainer.tsx
+++ b/front/components/assistant/conversation/content_creation/PublicContentCreationContainer.tsx
@@ -9,6 +9,7 @@ import { clientExecutableContentType } from "@app/types";
 
 interface PublicContentCreationContainerProps {
   shareToken: string;
+  workspaceId: string;
 }
 
 /**
@@ -17,6 +18,7 @@ interface PublicContentCreationContainerProps {
  */
 export function PublicContentCreationContainer({
   shareToken,
+  workspaceId,
 }: PublicContentCreationContainerProps) {
   const { fileMetadata, isFileLoading, isFileError } = usePublicFile({
     shareToken,
@@ -43,6 +45,7 @@ export function PublicContentCreationContainer({
             fileId={fileMetadata.sId}
             fileName={fileMetadata.fileName}
             shareToken={shareToken}
+            workspaceId={workspaceId}
           />
         );
 

--- a/front/components/assistant/conversation/content_creation/ShareContentCreationFilePopover.tsx
+++ b/front/components/assistant/conversation/content_creation/ShareContentCreationFilePopover.tsx
@@ -2,6 +2,7 @@ import {
   Button,
   ClipboardCheckIcon,
   ClipboardIcon,
+  cn,
   ContentMessage,
   DropdownMenu,
   DropdownMenuContent,
@@ -33,6 +34,7 @@ interface FileSharingDropdownProps {
   owner: LightWorkspaceType;
   disabled?: boolean;
   isLoading?: boolean;
+  isUsingConversationFiles: boolean;
 }
 
 function FileSharingDropdown({
@@ -40,26 +42,23 @@ function FileSharingDropdown({
   onScopeChange,
   owner,
   disabled = false,
+  isUsingConversationFiles,
 }: FileSharingDropdownProps) {
-  const scopeOptions: {
-    icon: React.ComponentType;
-    label: string;
-    value: FileShareScope;
-  }[] = [
+  const scopeOptions = [
     {
       icon: LockIcon,
       label: "Only conversation participants",
-      value: "conversation_participants",
+      value: "conversation_participants" as const,
     },
     {
       icon: UserGroupIcon,
       label: `Anyone in ${owner.name} workspace`,
-      value: "workspace",
+      value: "workspace" as const,
     },
     {
       icon: GlobeAltIcon,
       label: "Anyone with the link",
-      value: "public",
+      value: "public" as const,
     },
   ];
 
@@ -81,7 +80,12 @@ function FileSharingDropdown({
             label={selectedOption?.label}
             icon={selectedOption?.icon}
             disabled={disabled}
-            className="grid w-full grid-cols-[auto_1fr_auto] truncate"
+            className={cn(
+              "grid w-full grid-cols-[auto_1fr_auto] truncate",
+              selectedOption?.value === "public" &&
+                isUsingConversationFiles &&
+                "text-primary-400 dark:text-primary-400-night"
+            )}
           />
         </DropdownMenuTrigger>
         <DropdownMenuContent className="w-[var(--radix-dropdown-menu-trigger-width)]">
@@ -92,6 +96,7 @@ function FileSharingDropdown({
               onClick={() => onScopeChange(option.value)}
               truncateText
               icon={option.icon}
+              disabled={option.value === "public" && isUsingConversationFiles}
             />
           ))}
         </DropdownMenuContent>
@@ -187,14 +192,14 @@ export function ShareContentCreationFilePopover({
                   title={
                     isSharingForbidden
                       ? "Sharing disabled by admin"
-                      : "This Content Creation contains company data"
+                      : "This file contains company data"
                   }
                   variant="golden"
                   icon={InformationCircleIcon}
                 >
                   {isSharingForbidden
                     ? "Your workspace administrator has turned off sharing of Content Creation files."
-                    : "The Content Creation relies on conversation files, sharing is therefore" +
+                    : "This Content Creation relies on conversation files. The sharing to public option is " +
                       "disabled to protect company information."}
                 </ContentMessage>
               )}
@@ -205,11 +210,8 @@ export function ShareContentCreationFilePopover({
                   selectedScope={selectedScope}
                   onScopeChange={handleScopeChange}
                   owner={owner}
-                  disabled={
-                    isSharingForbidden ||
-                    isUsingConversationFiles ||
-                    isUpdatingShare
-                  }
+                  isUsingConversationFiles={isUsingConversationFiles}
+                  disabled={isSharingForbidden || isUpdatingShare}
                   isLoading={isUpdatingShare}
                 />
 

--- a/front/components/assistant/conversation/content_creation/ShareContentCreationFilePopover.tsx
+++ b/front/components/assistant/conversation/content_creation/ShareContentCreationFilePopover.tsx
@@ -44,21 +44,25 @@ function FileSharingDropdown({
   disabled = false,
   isUsingConversationFiles,
 }: FileSharingDropdownProps) {
-  const scopeOptions = [
+  const scopeOptions: {
+    icon: React.ComponentType;
+    label: string;
+    value: FileShareScope;
+  }[] = [
     {
       icon: LockIcon,
       label: "Only conversation participants",
-      value: "conversation_participants" as const,
+      value: "conversation_participants",
     },
     {
       icon: UserGroupIcon,
       label: `Anyone in ${owner.name} workspace`,
-      value: "workspace" as const,
+      value: "workspace",
     },
     {
       icon: GlobeAltIcon,
       label: "Anyone with the link",
-      value: "public" as const,
+      value: "public",
     },
   ];
 

--- a/front/components/markdown/VisualizationBlock.tsx
+++ b/front/components/markdown/VisualizationBlock.tsx
@@ -60,7 +60,7 @@ export function getVisualizationPlugin(
     visualization: (code: string, complete: boolean, lineStart: number) => {
       return (
         <VisualizationActionIframe
-          workspace={owner}
+          workspaceId={owner.sId}
           visualization={{
             code,
             complete,

--- a/front/lib/files.ts
+++ b/front/lib/files.ts
@@ -3,7 +3,7 @@ import _ from "lodash";
 // We use this to detect if a Content Creation file uses conversation files.
 // In which case, we don't want to display it publicly. Our proxy here is to look for usage of the
 // `useFile` hook.
-export function isFileUsingConversationFiles(content: string): boolean {
+export function isUsingConversationFiles(content: string): boolean {
   // Simple regex to detect useFile hook usage.
   const useFileRegex = /useFile\s*\(/;
   return useFileRegex.test(content);

--- a/front/lib/resources/file_resource.ts
+++ b/front/lib/resources/file_resource.ts
@@ -166,8 +166,8 @@ export class FileResource extends BaseResource<FileModel> {
       return null;
     }
 
-    if (isFileUsingConversationFiles(content)) {
-      // If the file is using conversation files, we don't want to make it accessible.
+    if (isFileUsingConversationFiles(content) && shareableFile.shareScope === 'public') {
+      // If the file is using conversation files, we don't want to make it accessible to public.
       return null;
     }
 

--- a/front/lib/resources/file_resource.ts
+++ b/front/lib/resources/file_resource.ts
@@ -173,7 +173,7 @@ export class FileResource extends BaseResource<FileModel> {
       // We don't make it accessible to public if it's using a conversation file.
       // We have several other check points:
       // - You cannot set it to public if isUsingConversationFiles is true
-      // - When you fetch a file in files/[token] page, we check authentication if it's for workspace sharing. 
+      // - When you fetch a file in files/[token] page, we check authentication if it's for workspace sharing.
       return null;
     }
 

--- a/front/lib/resources/file_resource.ts
+++ b/front/lib/resources/file_resource.ts
@@ -12,7 +12,7 @@ import {
   getPublicUploadBucket,
   getUpsertQueueBucket,
 } from "@app/lib/file_storage";
-import { isFileUsingConversationFiles } from "@app/lib/files";
+import { isUsingConversationFiles } from "@app/lib/files";
 import { BaseResource } from "@app/lib/resources/base_resource";
 import {
   FileModel,
@@ -167,10 +167,13 @@ export class FileResource extends BaseResource<FileModel> {
     }
 
     if (
-      isFileUsingConversationFiles(content) &&
+      isUsingConversationFiles(content) &&
       shareableFile.shareScope === "public"
     ) {
-      // If the file is using conversation files, we don't want to make it accessible to public.
+      // We don't make it accessible to public if it's using a conversation file.
+      // We have several other check points:
+      // - You cannot set it to public if isUsingConversationFiles is true
+      // - When you fetch a file in files/[token] page, we check authentication if it's for workspace sharing. 
       return null;
     }
 

--- a/front/lib/resources/file_resource.ts
+++ b/front/lib/resources/file_resource.ts
@@ -166,7 +166,10 @@ export class FileResource extends BaseResource<FileModel> {
       return null;
     }
 
-    if (isFileUsingConversationFiles(content) && shareableFile.shareScope === 'public') {
+    if (
+      isFileUsingConversationFiles(content) &&
+      shareableFile.shareScope === "public"
+    ) {
       // If the file is using conversation files, we don't want to make it accessible to public.
       return null;
     }

--- a/front/pages/api/w/[wId]/files/[fileId]/share.ts
+++ b/front/pages/api/w/[wId]/files/[fileId]/share.ts
@@ -94,8 +94,8 @@ async function handler(
 
       const { shareScope } = parseResult.data;
 
-      // For workspace/public sharing, check if file uses conversation files.
-      if (shareScope !== "conversation_participants") {
+      // For public sharing, check if file uses conversation files.
+      if (shareScope === "public") {
         const fileContent = await getFileContent(auth, file, "original");
         if (!fileContent) {
           return apiError(req, res, {

--- a/front/pages/api/w/[wId]/files/[fileId]/share.ts
+++ b/front/pages/api/w/[wId]/files/[fileId]/share.ts
@@ -4,7 +4,7 @@ import { z } from "zod";
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
 import { getFileContent } from "@app/lib/api/files/utils";
 import type { Authenticator } from "@app/lib/auth";
-import { isFileUsingConversationFiles } from "@app/lib/files";
+import { isUsingConversationFiles } from "@app/lib/files";
 import { ConversationResource } from "@app/lib/resources/conversation_resource";
 import { FileResource } from "@app/lib/resources/file_resource";
 import { apiError } from "@app/logger/withlogging";
@@ -107,7 +107,7 @@ async function handler(
           });
         }
 
-        if (isFileUsingConversationFiles(fileContent)) {
+        if (isUsingConversationFiles(fileContent)) {
           return apiError(req, res, {
             status_code: 400,
             api_error: {

--- a/front/pages/share/file/[token].tsx
+++ b/front/pages/share/file/[token].tsx
@@ -19,6 +19,7 @@ interface SharedFilePageProps {
   title: string;
   token: string;
   workspaceName: string;
+  workspaceId: string;
 }
 
 export const getServerSideProps = makeGetServerSidePropsRequirementsWrapper({
@@ -78,6 +79,7 @@ export const getServerSideProps = makeGetServerSidePropsRequirementsWrapper({
       title: file.fileName,
       token,
       workspaceName: workspace.name,
+      workspaceId: workspace.sId,
     },
   };
 });
@@ -87,6 +89,7 @@ export default function SharedFilePage({
   title,
   token,
   workspaceName,
+  workspaceId,
 }: SharedFilePageProps) {
   const humanFriendlyTitle = formatFilenameForDisplay(title);
   const faviconPath = getFaviconPath();
@@ -134,7 +137,10 @@ export default function SharedFilePage({
         <link rel="icon" type="image/png" href={faviconPath} />
       </Head>
       <div className="flex h-screen w-full">
-        <PublicContentCreationContainer shareToken={token} />
+        <PublicContentCreationContainer
+          shareToken={token}
+          workspaceId={workspaceId}
+        />
       </div>
     </>
   );


### PR DESCRIPTION
## Description
This PR is to lift the current restriction of sharing a preview link to workspace if a file is accessing a file from conversation (= use `useFile` hook). If useFile hook is used, you cannot share it to public (same as now), but we would like to allow to change it to be able to share with your workspace. 

You will see this in UI:
<img width="389" height="375" alt="Screenshot 2025-09-12 at 16 33 37" src="https://github.com/user-attachments/assets/a793aeb6-6306-4e74-bdbd-f8131d0eaaa3" />



<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->
Will test on front edge if sharing behavior works as expected


## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
