### PR TITLE
[Slack Channels] Don't re-link channels already linked to agent

### DIFF
--- a/connectors/src/api/slack_channels_linked_with_agent.ts
+++ b/connectors/src/api/slack_channels_linked_with_agent.ts
@@ -70,6 +70,12 @@ const _patchSlackChannelsLinkedWithAgentHandler = async (
     },
   });
 
+  const channelsAlreadyLinkedToThisAgentIds = new Set(
+    slackChannels
+      .filter((c) => c.agentConfigurationId === agentConfigurationId)
+      .map((c) => c.slackChannelId)
+  );
+
   const foundSlackChannelIds = new Set(
     slackChannels.map((c) => c.slackChannelId)
   );
@@ -145,13 +151,18 @@ const _patchSlackChannelsLinkedWithAgentHandler = async (
     );
   });
   const joinPromises = await Promise.all(
-    slackChannelIds.map((slackChannelId) =>
-      launchJoinChannelWorkflow(
-        parseInt(connectorId),
-        slackChannelId,
-        "join-only"
+    slackChannelIds
+      .filter(
+        (slackChannelId) =>
+          !channelsAlreadyLinkedToThisAgentIds.has(slackChannelId)
       )
-    )
+      .map((slackChannelId) =>
+        launchJoinChannelWorkflow(
+          parseInt(connectorId),
+          slackChannelId,
+          "join-only"
+        )
+      )
   );
 
   // If there's an error that's other than workflow already started, return it.


### PR DESCRIPTION
Description
---
As per title. Related to (already fixed) https://github.com/dust-tt/tasks/issues/4133

This would make unnecessary API calls and send useless errors.

Risks
---
low, small blast radius

Deploy
---
connectors