### PR TITLE
[front] schedules: generate timezone with llm

### DIFF
--- a/front/lib/api/assistant/configuration/triggers.ts
+++ b/front/lib/api/assistant/configuration/triggers.ts
@@ -8,7 +8,6 @@ import { Err, getSmallWhitelistedModel, Ok } from "@app/types";
 function isValidIANATimezone(timezone: string): boolean {
   // Get the list of all supported IANA timezones
   const supportedTimezones = Intl.supportedValuesOf("timeZone");
-  console.log("Supported IANA timezones:", supportedTimezones);
   return supportedTimezones.includes(timezone);
 }
 
@@ -86,8 +85,6 @@ export async function generateCronRule(
       }
     }
   }
-
-  console.log("Generated cron rule:", { cronRule, timezone });
 
   if (
     !cronRule ||

--- a/front/lib/api/assistant/configuration/triggers.ts
+++ b/front/lib/api/assistant/configuration/triggers.ts
@@ -5,14 +5,23 @@ import { cloneBaseConfig } from "@app/lib/registry";
 import type { Result } from "@app/types";
 import { Err, getSmallWhitelistedModel, Ok } from "@app/types";
 
+function isValidIANATimezone(timezone: string): boolean {
+  // Get the list of all supported IANA timezones
+  const supportedTimezones = Intl.supportedValuesOf("timeZone");
+  console.log("Supported IANA timezones:", supportedTimezones);
+  return supportedTimezones.includes(timezone);
+}
+
 export async function generateCronRule(
   auth: Authenticator,
   {
     naturalDescription,
+    defaultTimezone,
   }: {
     naturalDescription: string;
+    defaultTimezone: string;
   }
-): Promise<Result<string, Error>> {
+): Promise<Result<{ cron: string; timezone: string }, Error>> {
   const owner = auth.getNonNullableWorkspace();
 
   const model = getSmallWhitelistedModel(owner);
@@ -23,18 +32,21 @@ export async function generateCronRule(
   }
 
   const config = cloneBaseConfig(
-    getDustProdAction("assistant-builder-cron-rule-generator").config
+    getDustProdAction("assistant-builder-cron-timezone-generator").config
   );
   config.CREATE_CRON.provider_id = model.providerId;
   config.CREATE_CRON.model_id = model.modelId;
+  config.CREATE_TZ.provider_id = model.providerId;
+  config.CREATE_TZ.model_id = model.modelId;
 
   const res = await runActionStreamed(
     auth,
-    "assistant-builder-cron-rule-generator",
+    "assistant-builder-cron-timezone-generator",
     config,
     [
       {
         naturalDescription,
+        defaultTimezone,
       },
     ],
     {
@@ -48,6 +60,7 @@ export async function generateCronRule(
 
   const { eventStream } = res.value;
   let cronRule: string | null = null;
+  let timezone: string | null = null;
 
   for await (const event of eventStream) {
     if (event.type === "error") {
@@ -67,9 +80,14 @@ export async function generateCronRule(
         if (v.cron) {
           cronRule = v.cron;
         }
+        if (v.timezone) {
+          timezone = v.timezone;
+        }
       }
     }
   }
+
+  console.log("Generated cron rule:", { cronRule, timezone });
 
   if (
     !cronRule ||
@@ -79,8 +97,14 @@ export async function generateCronRule(
       /^((((\d+,)+\d+|(\d+(\/|-|#)\d+)|\d+L?|\*(\/\d+)?|L(-\d+)?|\?|[A-Z]{3}(-[A-Z]{3})?) ?){5,7})|(@(annually|yearly|monthly|weekly|daily|hourly|reboot))|(@every (\d+(ns|us|µs|ms|s|m|h))+)$/
     )
   ) {
-    return new Err(new Error("Error generating cron rule: malformed output"));
+    return new Err(
+      new Error("Error generating cron rule: malformed cron output")
+    );
   }
 
-  return new Ok(cronRule);
+  if (!timezone || !isValidIANATimezone(timezone)) {
+    return new Err(new Error("Error generating cron rule: invalid timezone"));
+  }
+
+  return new Ok({ cron: cronRule, timezone });
 }

--- a/front/lib/registry.ts
+++ b/front/lib/registry.ts
@@ -332,21 +332,6 @@ export const BaseDustProdActionRegistry = {
       },
     },
   },
-
-  "assistant-builder-cron-rule-generator": {
-    app: {
-      appId: "I0f9t05qlZ",
-      appHash:
-        "589b73fa1ce8c6af9782bb9ece92f3cd421b1e8d94711b1cfbcb4c043206379c",
-    },
-    config: {
-      CREATE_CRON: {
-        function_call: "set_schedule",
-        use_cache: false,
-        use_stream: true,
-      },
-    },
-  },
   "assistant-builder-cron-timezone-generator": {
     app: {
       appId: "T454vmSliN",

--- a/front/lib/registry.ts
+++ b/front/lib/registry.ts
@@ -347,6 +347,25 @@ export const BaseDustProdActionRegistry = {
       },
     },
   },
+  "assistant-builder-cron-timezone-generator": {
+    app: {
+      appId: "T454vmSliN",
+      appHash:
+        "a7183268ee1d99e56774a5c93e6d715eb684bbfab9d34da99e0b92d299bfbde7",
+    },
+    config: {
+      CREATE_CRON: {
+        function_call: "set_schedule",
+        use_cache: false,
+        use_stream: true,
+      },
+      CREATE_TZ: {
+        function_call: "set_tz",
+        use_cache: false,
+        use_stream: true,
+      },
+    },
+  },
 };
 
 export type DustRegistryActionName = keyof typeof BaseDustProdActionRegistry;

--- a/front/lib/swr/agent_triggers.ts
+++ b/front/lib/swr/agent_triggers.ts
@@ -82,11 +82,12 @@ export function useTextAsCronRule({
           method: "POST",
           body: JSON.stringify({
             naturalDescription,
+            defaultTimezone: Intl.DateTimeFormat().resolvedOptions().timeZone,
           } as PostTextAsCronRuleRequestBody),
         }
       );
 
-      return r.cronRule;
+      return { cron: r.cronRule, timezone: r.timezone };
     },
     [workspace]
   );

--- a/front/pages/api/w/[wId]/assistant/agent_configurations/text_as_cron_rule.ts
+++ b/front/pages/api/w/[wId]/assistant/agent_configurations/text_as_cron_rule.ts
@@ -9,10 +9,12 @@ import type { WithAPIErrorResponse } from "@app/types";
 
 export type PostTextAsCronRuleResponseBody = {
   cronRule: string;
+  timezone: string;
 };
 
 const PostTextAsCronRuleRequestBodySchema = z.object({
   naturalDescription: z.string(),
+  defaultTimezone: z.string(),
 });
 
 export type PostTextAsCronRuleRequestBody = z.infer<
@@ -40,10 +42,11 @@ async function handler(
         });
       }
 
-      const { naturalDescription } = bodyValidation.data;
+      const { naturalDescription, defaultTimezone } = bodyValidation.data;
 
       const r = await generateCronRule(auth, {
         naturalDescription,
+        defaultTimezone,
       });
 
       if (r.isErr()) {
@@ -57,7 +60,8 @@ async function handler(
       }
 
       return res.status(200).json({
-        cronRule: r.value,
+        cronRule: r.value.cron,
+        timezone: r.value.timezone,
       });
     }
 


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

This PR lets the user edit the timezone the cron runs at by typing it in the cron description.
This was the most used flow within the tests from members of the team, to edit the timezone they were trying to enter text in that box.

This works by sending the naturalDescription to the model, + a defaultTimezone that is basically the user's current timezone.

If the user does not input any location hint (i.e, Paris time, SF time, East-Coast time), in his description, the model is instructed to fall back on the defaultTimezone sent alongside the desc.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

Tested by hand generating a dozen of triggers. Works as expected.

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

Low

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->

New Prod dust app already in prod.
Deploy front.