### PR TITLE
[Assistant Builder] Fix: Slack channels linking

### DIFF
--- a/front/components/agent_builder/AgentBuilder.tsx
+++ b/front/components/agent_builder/AgentBuilder.tsx
@@ -238,6 +238,9 @@ export default function AgentBuilder({
         agentConfigurationId: duplicateAgentId
           ? null
           : agentConfiguration?.sId || null,
+        areSlackChannelsChanged: form.getFieldState(
+          "agentSettings.slackChannels"
+        ).isDirty,
       });
 
       if (!result.isOk()) {

--- a/front/components/agent_builder/submitAgentBuilderForm.ts
+++ b/front/components/agent_builder/submitAgentBuilderForm.ts
@@ -194,11 +194,13 @@ export async function submitAgentBuilderForm({
   owner,
   agentConfigurationId = null,
   isDraft = false,
+  areSlackChannelsChanged,
 }: {
   formData: AgentBuilderFormData;
   owner: WorkspaceType;
   agentConfigurationId?: string | null;
   isDraft?: boolean;
+  areSlackChannelsChanged?: boolean;
 }): Promise<
   Result<LightAgentConfigurationType | AgentConfigurationType, Error>
 > {
@@ -351,9 +353,13 @@ export async function submitAgentBuilderForm({
     const { slackChannels, slackProvider } = formData.agentSettings;
     // If the user selected channels that were already routed to a different agent, the current behavior is to
     // unlink them from the previous agent and link them to this one.
-    if (slackProvider && slackChannels.length > 0) {
+    // Make the call even if slackChannels is empty, since if the user deselects all channels,
+    // the call need to be made to unlink them.
+    if (slackProvider && areSlackChannelsChanged) {
       const autoRespondWithoutMention =
-        slackChannels[0].autoRespondWithoutMention;
+        slackChannels.length > 0
+          ? slackChannels[0].autoRespondWithoutMention
+          : false;
       const slackRequestBody = JSON.stringify({
         provider: slackProvider,
         slack_channel_internal_ids: slackChannels.map(


### PR DESCRIPTION
Description
---
Previously:
1. call to link_slack_channels was never made on empty slack channels => when user want to unlink their agent from the last slack channel, it would silently fail (because array becomes empty)

2. call to link_slack channels was always made on non-empty array, even if user made no modifications, aka. 99.99% of cases.

The PR fixes that.

Risks
---
low (blast radius: channel linking)

Deploy
---
front

