### PR TITLE
[front] profile: only show tools for which you have possible action

### DIFF
--- a/front/lib/resources/user_resource.ts
+++ b/front/lib/resources/user_resource.ts
@@ -342,6 +342,29 @@ export class UserResource extends BaseResource<UserModel> {
     });
   }
 
+  async getToolValidations(): Promise<
+    { mcpServerId: string; toolNames: string[] }[]
+  > {
+    const metadata = await UserMetadataModel.findAll({
+      where: {
+        userId: this.id,
+        key: {
+          [Op.like]: "toolsValidations:%",
+        },
+      },
+    });
+
+    return metadata.map((m) => {
+      const mcpServerId = m.key.replace("toolsValidations:", "");
+      const toolNames = m.value
+        .split(USER_METADATA_COMMA_SEPARATOR)
+        .map((v) => v.replaceAll(USER_METADATA_COMMA_REPLACEMENT, ","))
+        .filter((name) => name.length > 0);
+
+      return { mcpServerId, toolNames };
+    });
+  }
+
   fullName(): string {
     return [this.firstName, this.lastName].filter(Boolean).join(" ");
   }

--- a/front/lib/swr/user.ts
+++ b/front/lib/swr/user.ts
@@ -8,6 +8,8 @@ import {
 } from "@app/lib/swr/swr";
 import type { GetUserResponseBody } from "@app/pages/api/user";
 import type { GetUserMetadataResponseBody } from "@app/pages/api/user/metadata/[key]";
+import type { GetUserApprovalsResponseBody } from "@app/pages/api/w/[wId]/me/approvals";
+import type { LightWorkspaceType } from "@app/types";
 import type { JobType } from "@app/types/job_type";
 
 export function useUser() {
@@ -38,9 +40,25 @@ export function useUserMetadata(key: string) {
   };
 }
 
+export function useUserApprovals(owner: LightWorkspaceType) {
+  const userApprovalsFetcher: Fetcher<GetUserApprovalsResponseBody> = fetcher;
+
+  const { data, error, mutate } = useSWRWithDefaults(
+    `/api/w/${owner.sId}/me/approvals`,
+    userApprovalsFetcher
+  );
+
+  return {
+    approvals: data ? data.approvals : [],
+    isApprovalsLoading: !error && !data,
+    isApprovalsError: error,
+    mutateApprovals: mutate,
+  };
+}
+
 export function useDeleteMetadata() {
   const deleteMetadata = async (prefix: string) => {
-    await fetch(`/api/user/metadata/${encodeURIComponent(prefix)}`, {
+    return fetch(`/api/user/metadata/${encodeURIComponent(prefix)}`, {
       method: "DELETE",
     });
   };

--- a/front/pages/api/w/[wId]/me/approvals.ts
+++ b/front/pages/api/w/[wId]/me/approvals.ts
@@ -1,0 +1,84 @@
+import type { NextApiRequest, NextApiResponse } from "next";
+
+import { getServerTypeAndIdFromSId } from "@app/lib/actions/mcp_helper";
+import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
+import type { Authenticator } from "@app/lib/auth";
+import { InternalMCPServerInMemoryResource } from "@app/lib/resources/internal_mcp_server_in_memory_resource";
+import { RemoteMCPServerResource } from "@app/lib/resources/remote_mcp_servers_resource";
+import { UserResource } from "@app/lib/resources/user_resource";
+import { apiError, withLogging } from "@app/logger/withlogging";
+import type { WithAPIErrorResponse } from "@app/types";
+
+export interface GetUserApprovalsResponseBody {
+  approvals: {
+    mcpServerId: string;
+    toolNames: string[];
+    serverName: string;
+  }[];
+}
+
+async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse<WithAPIErrorResponse<GetUserApprovalsResponseBody>>,
+  auth: Authenticator
+): Promise<void> {
+  if (req.method !== "GET") {
+    return apiError(req, res, {
+      status_code: 405,
+      api_error: {
+        type: "method_not_supported_error",
+        message: "The method passed is not supported, GET is expected.",
+      },
+    });
+  }
+
+  const user = auth.getNonNullableUser();
+  const userResource = new UserResource(UserResource.model, user);
+  const toolValidations = await userResource.getToolValidations();
+
+  const approvals: {
+    mcpServerId: string;
+    toolNames: string[];
+    serverName: string;
+  }[] = [];
+
+  for (const validation of toolValidations) {
+    if (validation.toolNames.length > 0) {
+      let serverName = "Unknown Server";
+
+      try {
+        const { serverType } = getServerTypeAndIdFromSId(
+          validation.mcpServerId
+        );
+
+        if (serverType === "internal") {
+          const server = await InternalMCPServerInMemoryResource.fetchById(
+            auth,
+            validation.mcpServerId
+          );
+          serverName = server?.toJSON().name || "Unknown Internal Server";
+        } else if (serverType === "remote") {
+          const server = await RemoteMCPServerResource.fetchById(
+            auth,
+            validation.mcpServerId
+          );
+          serverName = server?.toJSON().name || "Unknown Remote Server";
+        }
+      } catch (error) {
+        // If we can't parse the server ID or fetch the server, use default name
+      }
+
+      approvals.push({
+        mcpServerId: validation.mcpServerId,
+        toolNames: validation.toolNames,
+        serverName,
+      });
+    }
+  }
+
+  return res.status(200).json({
+    approvals,
+  });
+}
+
+export default withLogging(withSessionAuthenticationForWorkspace(handler));


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

For now, tools list in the profile were showing the whole list of tools we had access via different spaces.

This was showing tools multiple times if they were in multiple spaces, this was showing tools for which you did not have any personal tool setting. This was a mess

This PR adds a way to list the tools for which we have a confirmation setting, and list those and only those in the profile.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

Tested by hand

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

Low, only profile page.

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->

Deploy front.