### PR TITLE
Add convo list to Poke agent page

### DIFF
--- a/front/components/poke/PokeConditionalDataTables.tsx
+++ b/front/components/poke/PokeConditionalDataTables.tsx
@@ -12,6 +12,7 @@ interface PokeDataTableConditionalFetchProps<T, M> {
   header: string;
   loadOnInit?: boolean;
   owner: LightWorkspaceType;
+  showSensitiveDataWarning?: boolean;
   useSWRHook: (props: PokeConditionalFetchProps) => {
     data: T;
     isError: any;
@@ -27,6 +28,7 @@ export function PokeDataTableConditionalFetch<T, M>({
   header,
   loadOnInit = false,
   owner,
+  showSensitiveDataWarning = false,
   useSWRHook,
 }: PokeDataTableConditionalFetchProps<T, M>) {
   const [shouldLoad, setShouldLoad] = useState(loadOnInit);
@@ -36,7 +38,17 @@ export function PokeDataTableConditionalFetch<T, M>({
   });
 
   const handleLoadClick = () => {
-    setShouldLoad(true);
+    if (showSensitiveDataWarning) {
+      if (
+        window.confirm(
+          "Are you sure you want to access this sensitive user data? (Access will be logged)"
+        )
+      ) {
+        setShouldLoad(true);
+      }
+    } else {
+      setShouldLoad(true);
+    }
   };
 
   let content;

--- a/front/components/poke/conversations/agent_table.tsx
+++ b/front/components/poke/conversations/agent_table.tsx
@@ -1,0 +1,116 @@
+import { IconButton, LinkWrapper } from "@dust-tt/sparkle";
+import { ArrowsUpDownIcon } from "@heroicons/react/20/solid";
+import type { ColumnDef } from "@tanstack/react-table";
+
+import { PokeDataTableConditionalFetch } from "@app/components/poke/PokeConditionalDataTables";
+import { PokeDataTable } from "@app/components/poke/shadcn/ui/data_table";
+import { formatTimestampToFriendlyDate } from "@app/lib/utils";
+import type { PokeConversationsFetchProps } from "@app/poke/swr/conversations";
+import { usePokeConversations } from "@app/poke/swr/conversations";
+import type {
+  ConversationWithoutContentType,
+  LightWorkspaceType,
+} from "@app/types";
+
+interface ConversationAgentDataTableProps {
+  owner: LightWorkspaceType;
+  agentId: string;
+}
+
+const makeColumnsForConversations = (
+  owner: LightWorkspaceType
+): ColumnDef<ConversationWithoutContentType>[] => {
+  return [
+    {
+      accessorKey: "sId",
+      header: ({ column }) => {
+        return (
+          <div className="flex space-x-2">
+            <p>Conversation ID</p>
+            <IconButton
+              variant="outline"
+              icon={ArrowsUpDownIcon}
+              onClick={() =>
+                column.toggleSorting(column.getIsSorted() === "asc")
+              }
+            />
+          </div>
+        );
+      },
+      cell: ({ row }) => {
+        const conversation = row.original;
+        return (
+          <LinkWrapper
+            href={`/poke/${owner.sId}/conversations/${conversation.sId}`}
+          >
+            {conversation.sId}
+          </LinkWrapper>
+        );
+      },
+    },
+    {
+      accessorKey: "created",
+      header: ({ column }) => {
+        return (
+          <div className="flex space-x-2">
+            <p>Created at</p>
+            <IconButton
+              variant="outline"
+              icon={ArrowsUpDownIcon}
+              onClick={() =>
+                column.toggleSorting(column.getIsSorted() === "asc")
+              }
+            />
+          </div>
+        );
+      },
+      cell: ({ row }) => {
+        return formatTimestampToFriendlyDate(row.original.created);
+      },
+    },
+    {
+      accessorKey: "title",
+      header: ({ column }) => {
+        return (
+          <div className="flex space-x-2">
+            <p>Title</p>
+            <IconButton
+              variant="outline"
+              icon={ArrowsUpDownIcon}
+              onClick={() =>
+                column.toggleSorting(column.getIsSorted() === "asc")
+              }
+            />
+          </div>
+        );
+      },
+    },
+  ];
+};
+
+export function ConversationAgentDataTable({
+  owner,
+  agentId,
+}: ConversationAgentDataTableProps) {
+  const useConversationsWithAgent = (props: PokeConversationsFetchProps) =>
+    usePokeConversations({ ...props, agentId });
+
+  return (
+    <PokeDataTableConditionalFetch
+      header="Conversations"
+      owner={owner}
+      useSWRHook={useConversationsWithAgent}
+    >
+      {(conversations) => {
+        const columns = makeColumnsForConversations(owner);
+
+        return (
+          <PokeDataTable<ConversationWithoutContentType, unknown>
+            columns={columns}
+            data={conversations}
+          />
+        );
+      }}
+    </PokeDataTableConditionalFetch>
+  );
+}

--- a/front/components/poke/conversations/agent_table.tsx
+++ b/front/components/poke/conversations/agent_table.tsx
@@ -99,6 +99,7 @@ export function ConversationAgentDataTable({
     <PokeDataTableConditionalFetch
       header="Conversations"
       owner={owner}
+      showSensitiveDataWarning={true}
       useSWRHook={useConversationsWithAgent}
     >
       {(conversations) => {

--- a/front/pages/api/poke/workspaces/[wId]/conversations/index.ts
+++ b/front/pages/api/poke/workspaces/[wId]/conversations/index.ts
@@ -1,0 +1,87 @@
+import type { NextApiRequest, NextApiResponse } from "next";
+
+import { withSessionAuthenticationForPoke } from "@app/lib/api/auth_wrappers";
+import { Authenticator } from "@app/lib/auth";
+import type { SessionWithUser } from "@app/lib/iam/provider";
+import { ConversationResource } from "@app/lib/resources/conversation_resource";
+import { apiError } from "@app/logger/withlogging";
+import type {
+  ConversationWithoutContentType,
+  WithAPIErrorResponse,
+} from "@app/types";
+
+export type PokeListConversations = {
+  conversations: ConversationWithoutContentType[];
+};
+
+async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse<WithAPIErrorResponse<PokeListConversations>>,
+  session: SessionWithUser
+): Promise<void> {
+  const auth = await Authenticator.fromSuperUserSession(
+    session,
+    req.query.wId as string
+  );
+
+  if (!auth.isDustSuperUser()) {
+    return apiError(req, res, {
+      status_code: 404,
+      api_error: {
+        type: "conversation_not_found",
+        message: "Could not find conversations.",
+      },
+    });
+  }
+
+  switch (req.method) {
+    case "GET":
+      // Get conversation IDs for this agent
+      const conversationIds =
+        await ConversationResource.listConversationWithAgentCreatedBeforeDate({
+          auth,
+          agentConfigurationId: req.query.agentId as string,
+          cutoffDate: new Date(), // Current time to get all conversations
+        });
+
+      // Fetch full conversation objects
+      const conversationResources = await ConversationResource.fetchByIds(
+        auth,
+        conversationIds
+      );
+
+      const conversations = conversationResources.map((c) => {
+        return {
+          id: c.id,
+          created: c.createdAt.getTime(),
+          sId: c.sId,
+          owner: auth.getNonNullableWorkspace(),
+          title: c.title,
+          visibility: c.visibility,
+          depth: c.depth,
+          triggerId: c.triggerSId(),
+          actionRequired: false, // We don't care about actionRequired/unread, so set to false
+          unread: false,
+          requestedGroupIds: c.getConversationRequestedGroupIdsFromModel(auth),
+        };
+      });
+
+      // Sort by creation date (most recent first)
+      conversations.sort((a, b) => b.created - a.created);
+
+      return res.status(200).json({
+        conversations,
+      });
+
+    default:
+      return apiError(req, res, {
+        status_code: 405,
+        api_error: {
+          type: "method_not_supported_error",
+          message: "The method is not supported.",
+        },
+      });
+  }
+}
+
+export default withSessionAuthenticationForPoke(handler);

--- a/front/pages/poke/[wId]/assistants/[aId]/index.tsx
+++ b/front/pages/poke/[wId]/assistants/[aId]/index.tsx
@@ -13,6 +13,7 @@ import { JsonViewer } from "@textea/json-viewer";
 import type { InferGetServerSidePropsType } from "next";
 import type { ReactElement } from "react";
 
+import { ConversationAgentDataTable } from "@app/components/poke/conversations/agent_table";
 import { PluginList } from "@app/components/poke/plugins/PluginList";
 import PokeLayout from "@app/components/poke/PokeLayout";
 import { TriggerDataTable } from "@app/components/poke/triggers/table";
@@ -107,6 +108,13 @@ const AssistantDetailsPage = ({
             resourceType: "agents",
             workspace: workspace,
           }}
+        />
+      </div>
+
+      <div className="mt-4">
+        <ConversationAgentDataTable
+          owner={workspace}
+          agentId={agentConfigurations[0].sId}
         />
       </div>
 

--- a/front/poke/swr/conversations.ts
+++ b/front/poke/swr/conversations.ts
@@ -1,0 +1,31 @@
+import type { Fetcher } from "swr";
+
+import { fetcher, useSWRWithDefaults } from "@app/lib/swr/swr";
+import type { PokeListConversations } from "@app/pages/api/poke/workspaces/[wId]/conversations";
+import type { PokeConditionalFetchProps } from "@app/poke/swr/types";
+
+export interface PokeConversationsFetchProps extends PokeConditionalFetchProps {
+  agentId?: string;
+}
+
+export function usePokeConversations({
+  disabled,
+  owner,
+  agentId,
+}: PokeConversationsFetchProps) {
+  const conversationsFetcher: Fetcher<PokeListConversations> = fetcher;
+  const { data, error, mutate } = useSWRWithDefaults(
+    agentId
+      ? `/api/poke/workspaces/${owner.sId}/conversations?agentId=${agentId}`
+      : null,
+    conversationsFetcher,
+    { disabled }
+  );
+
+  return {
+    data: data?.conversations ?? [],
+    isLoading: !error && !data,
+    isError: error,
+    mutate,
+  };
+}


### PR DESCRIPTION
## Description

Useful for debugging when we get the agent name but customer forgets the convo id (e.g. as in this [issue](https://github.com/dust-tt/tasks/issues/4169#issuecomment-3285868966)).

https://github.com/user-attachments/assets/2ca9438a-45e7-4199-9797-a2ca8fe16f81


## Tests

Manual

## Risk

None

## Deploy Plan

Front