### PR TITLE
Allow setting viewport ref for navigation list

### DIFF
--- a/sparkle/src/components/NavigationList.tsx
+++ b/sparkle/src/components/NavigationList.tsx
@@ -41,13 +41,18 @@ const NavigationListItemStyles = cva(
   }
 );
 
+interface NavigationListProps {
+  viewportRef?: React.RefObject<HTMLDivElement>;
+}
 const NavigationList = React.forwardRef<
   React.ElementRef<typeof ScrollAreaPrimitive.Root>,
-  React.ComponentPropsWithoutRef<typeof ScrollAreaPrimitive.Root>
->(({ className, children, ...props }, ref) => {
+  React.ComponentPropsWithoutRef<typeof ScrollAreaPrimitive.Root> &
+    NavigationListProps
+>(({ className, children, viewportRef, ...props }, ref) => {
   return (
     <ScrollArea
       ref={ref}
+      viewportRef={viewportRef}
       className={cn(className, "s-transition-all s-duration-300")}
       {...props}
     >

--- a/sparkle/src/components/ScrollArea.tsx
+++ b/sparkle/src/components/ScrollArea.tsx
@@ -14,6 +14,7 @@ interface ScrollAreaProps
     active?: string;
     inactive?: string;
   };
+  viewportRef?: React.RefObject<HTMLDivElement>;
 }
 
 const ScrollArea = React.forwardRef<
@@ -29,11 +30,12 @@ const ScrollArea = React.forwardRef<
       scrollBarClassName,
       viewportClassName,
       scrollStyles,
+      viewportRef,
       ...props
     },
     ref
   ) => {
-    const viewportRef = React.useRef<HTMLDivElement>(null);
+    const localViewportRef = React.useRef<HTMLDivElement>(null);
     const [isScrolled, setIsScrolled] = React.useState(false);
 
     const hasCustomScrollBar = useMemo(
@@ -50,8 +52,12 @@ const ScrollArea = React.forwardRef<
     const shouldHideDefaultScrollBar = hideScrollBar || hasCustomScrollBar;
 
     const handleScroll = React.useCallback(() => {
-      if (viewportRef.current) {
+      if (viewportRef && viewportRef.current) {
         setIsScrolled(viewportRef.current.scrollTop > 0);
+      }
+
+      if (localViewportRef.current) {
+        setIsScrolled(localViewportRef.current.scrollTop > 0);
       }
     }, []);
 
@@ -66,7 +72,7 @@ const ScrollArea = React.forwardRef<
         {...props}
       >
         <ScrollAreaPrimitive.Viewport
-          ref={viewportRef}
+          ref={viewportRef || localViewportRef}
           onScroll={handleScroll}
           className={cn(
             "s-h-full s-w-full s-rounded-[inherit]",


### PR DESCRIPTION
## Description

Needed to implement "infinite" scrolling of navigation list because i need to observe intersection with the scrollable viewport.

## Tests

Local

## Risk

Low, should behave identically if not set.

## Deploy Plan

Deploy sparkle.