### PR TITLE
Defaults appear in forms

### DIFF
--- a/front/components/agent_builder/capabilities/mcp/utils/formDefaults.test.ts
+++ b/front/components/agent_builder/capabilities/mcp/utils/formDefaults.test.ts
@@ -1,0 +1,788 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { MCPServerViewType } from "@app/lib/api/mcp";
+
+import { getDefaultConfiguration } from "./formDefaults";
+
+// Mock the input configuration module
+vi.mock("@app/lib/actions/mcp_internal_actions/input_configuration", () => ({
+  getMCPServerToolsConfigurations: vi.fn(),
+}));
+
+import { getMCPServerToolsConfigurations } from "@app/lib/actions/mcp_internal_actions/input_configuration";
+
+const mockGetMCPServerToolsConfigurations = vi.mocked(
+  getMCPServerToolsConfigurations
+);
+
+describe("getDefaultConfiguration", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe("when mcpServerView is null or undefined", () => {
+    it("should return base defaults for null mcpServerView", () => {
+      const result = getDefaultConfiguration(null);
+
+      expect(result).toEqual({
+        mcpServerViewId: "not-a-valid-sId",
+        dataSourceConfigurations: null,
+        tablesConfigurations: null,
+        childAgentId: null,
+        reasoningModel: null,
+        timeFrame: null,
+        additionalConfiguration: {},
+        dustAppConfiguration: null,
+        jsonSchema: null,
+        _jsonSchemaString: null,
+      });
+    });
+
+    it("should return base defaults for undefined mcpServerView", () => {
+      const result = getDefaultConfiguration(undefined);
+
+      expect(result).toEqual({
+        mcpServerViewId: "not-a-valid-sId",
+        dataSourceConfigurations: null,
+        tablesConfigurations: null,
+        childAgentId: null,
+        reasoningModel: null,
+        timeFrame: null,
+        additionalConfiguration: {},
+        dustAppConfiguration: null,
+        jsonSchema: null,
+        _jsonSchemaString: null,
+      });
+    });
+  });
+
+  describe("when mcpServerView is provided", () => {
+    const mockMCPServerView: MCPServerViewType = {
+      id: 1,
+      sId: "test-server-123",
+      name: "Test Server",
+      description: "Test server description",
+      createdAt: Date.now(),
+      updatedAt: Date.now(),
+      spaceId: "test-space-123",
+      serverType: "internal",
+      server: {
+        sId: "test_server",
+        name: "test_server",
+        version: "1.0.0",
+        description: "Test server",
+        tools: [],
+        icon: "ActionEmotionLaughIcon",
+        authorization: null,
+        availability: "manual",
+        allowMultipleInstances: false,
+        documentationUrl: null,
+      },
+      oAuthUseCase: null,
+      editedByUser: null,
+      toolsMetadata: [],
+    };
+
+    it("should use mcpServerView sId as mcpServerViewId", () => {
+      mockGetMCPServerToolsConfigurations.mockReturnValue({
+        mayRequireDataSourceConfiguration: false,
+        mayRequireDataWarehouseConfiguration: false,
+        mayRequireTableConfiguration: false,
+        mayRequireChildAgentConfiguration: false,
+        mayRequireReasoningConfiguration: false,
+        mayRequireTimeFrameConfiguration: false,
+        mayRequireJsonSchemaConfiguration: false,
+        stringConfigurations: [],
+        numberConfigurations: [],
+        booleanConfigurations: [],
+        enumConfigurations: {},
+        listConfigurations: {},
+        mayRequireDustAppConfiguration: false,
+        noRequirement: true,
+      });
+
+      const result = getDefaultConfiguration(mockMCPServerView);
+
+      expect(result.mcpServerViewId).toBe("test-server-123");
+    });
+
+    describe("boolean configurations", () => {
+      it("should set boolean configurations to false by default", () => {
+        mockGetMCPServerToolsConfigurations.mockReturnValue({
+          mayRequireDataSourceConfiguration: false,
+          mayRequireDataWarehouseConfiguration: false,
+          mayRequireTableConfiguration: false,
+          mayRequireChildAgentConfiguration: false,
+          mayRequireReasoningConfiguration: false,
+          mayRequireTimeFrameConfiguration: false,
+          mayRequireJsonSchemaConfiguration: false,
+          stringConfigurations: [],
+          numberConfigurations: [],
+          booleanConfigurations: [
+            {
+              key: "is_enabled",
+              description: "Whether the feature is enabled",
+            },
+            { key: "admin_mode", description: "Admin mode setting" },
+            { key: "nested.deep.flag", description: "A deeply nested boolean" },
+          ],
+          enumConfigurations: {},
+          listConfigurations: {},
+          mayRequireDustAppConfiguration: false,
+          noRequirement: false,
+        });
+
+        const result = getDefaultConfiguration(mockMCPServerView);
+
+        expect(result.additionalConfiguration).toEqual({
+          is_enabled: false,
+          admin_mode: false,
+          nested: {
+            deep: {
+              flag: false,
+            },
+          },
+        });
+      });
+
+      it("should use explicit boolean defaults when available", () => {
+        mockGetMCPServerToolsConfigurations.mockReturnValue({
+          mayRequireDataSourceConfiguration: false,
+          mayRequireDataWarehouseConfiguration: false,
+          mayRequireTableConfiguration: false,
+          mayRequireChildAgentConfiguration: false,
+          mayRequireReasoningConfiguration: false,
+          mayRequireTimeFrameConfiguration: false,
+          mayRequireJsonSchemaConfiguration: false,
+          stringConfigurations: [],
+          numberConfigurations: [],
+          booleanConfigurations: [
+            {
+              key: "feature_enabled",
+              description: "Feature enabled",
+              default: true,
+            },
+            { key: "debug_mode", description: "Debug mode", default: false },
+            { key: "auto_save", description: "Auto save" }, // no explicit default
+          ],
+          enumConfigurations: {},
+          listConfigurations: {},
+          mayRequireDustAppConfiguration: false,
+          noRequirement: false,
+        });
+
+        const result = getDefaultConfiguration(mockMCPServerView);
+
+        expect(result.additionalConfiguration).toEqual({
+          feature_enabled: true, // explicit default
+          debug_mode: false, // explicit default
+          auto_save: false, // fallback default
+        });
+      });
+
+      it("should handle empty boolean configurations", () => {
+        mockGetMCPServerToolsConfigurations.mockReturnValue({
+          mayRequireDataSourceConfiguration: false,
+          mayRequireDataWarehouseConfiguration: false,
+          mayRequireTableConfiguration: false,
+          mayRequireChildAgentConfiguration: false,
+          mayRequireReasoningConfiguration: false,
+          mayRequireTimeFrameConfiguration: false,
+          mayRequireJsonSchemaConfiguration: false,
+          stringConfigurations: [],
+          numberConfigurations: [],
+          booleanConfigurations: [],
+          enumConfigurations: {},
+          listConfigurations: {},
+          mayRequireDustAppConfiguration: false,
+          noRequirement: true,
+        });
+
+        const result = getDefaultConfiguration(mockMCPServerView);
+
+        expect(result.additionalConfiguration).toEqual({});
+      });
+    });
+
+    describe("enum configurations", () => {
+      it("should set enum configurations to first option", () => {
+        mockGetMCPServerToolsConfigurations.mockReturnValue({
+          mayRequireDataSourceConfiguration: false,
+          mayRequireDataWarehouseConfiguration: false,
+          mayRequireTableConfiguration: false,
+          mayRequireChildAgentConfiguration: false,
+          mayRequireReasoningConfiguration: false,
+          mayRequireTimeFrameConfiguration: false,
+          mayRequireJsonSchemaConfiguration: false,
+          stringConfigurations: [],
+          numberConfigurations: [],
+          booleanConfigurations: [],
+          enumConfigurations: {
+            priority: {
+              options: ["low", "medium", "high"],
+              description: "Priority level",
+            },
+            category: {
+              options: ["A", "B", "C"],
+              description: "Category selection",
+            },
+            "nested.enum": {
+              options: ["option1", "option2"],
+              description: "Nested enum",
+            },
+          },
+          listConfigurations: {},
+          mayRequireDustAppConfiguration: false,
+          noRequirement: false,
+        });
+
+        const result = getDefaultConfiguration(mockMCPServerView);
+
+        expect(result.additionalConfiguration).toEqual({
+          priority: "low",
+          category: "A",
+          nested: {
+            enum: "option1",
+          },
+        });
+      });
+
+      it("should skip enum configurations with empty options", () => {
+        mockGetMCPServerToolsConfigurations.mockReturnValue({
+          mayRequireDataSourceConfiguration: false,
+          mayRequireDataWarehouseConfiguration: false,
+          mayRequireTableConfiguration: false,
+          mayRequireChildAgentConfiguration: false,
+          mayRequireReasoningConfiguration: false,
+          mayRequireTimeFrameConfiguration: false,
+          mayRequireJsonSchemaConfiguration: false,
+          stringConfigurations: [],
+          numberConfigurations: [],
+          booleanConfigurations: [],
+          enumConfigurations: {
+            valid_enum: {
+              options: ["option1", "option2"],
+              description: "Valid enum",
+            },
+            empty_enum: {
+              options: [],
+              description: "Empty enum",
+            },
+          },
+          listConfigurations: {},
+          mayRequireDustAppConfiguration: false,
+          noRequirement: false,
+        });
+
+        const result = getDefaultConfiguration(mockMCPServerView);
+
+        expect(result.additionalConfiguration).toEqual({
+          valid_enum: "option1",
+          // empty_enum should not be present
+        });
+      });
+
+      it("should use explicit enum defaults when available", () => {
+        mockGetMCPServerToolsConfigurations.mockReturnValue({
+          mayRequireDataSourceConfiguration: false,
+          mayRequireDataWarehouseConfiguration: false,
+          mayRequireTableConfiguration: false,
+          mayRequireChildAgentConfiguration: false,
+          mayRequireReasoningConfiguration: false,
+          mayRequireTimeFrameConfiguration: false,
+          mayRequireJsonSchemaConfiguration: false,
+          stringConfigurations: [],
+          numberConfigurations: [],
+          booleanConfigurations: [],
+          enumConfigurations: {
+            priority: {
+              options: ["low", "medium", "high"],
+              description: "Priority level",
+              default: "medium", // explicit default
+            },
+            status: {
+              options: ["draft", "published", "archived"],
+              description: "Status", // no explicit default, should use first
+            },
+          },
+          listConfigurations: {},
+          mayRequireDustAppConfiguration: false,
+          noRequirement: false,
+        });
+
+        const result = getDefaultConfiguration(mockMCPServerView);
+
+        expect(result.additionalConfiguration).toEqual({
+          priority: "medium", // explicit default
+          status: "draft", // first option fallback
+        });
+      });
+    });
+
+    describe("list configurations", () => {
+      it("should set list configurations to empty arrays", () => {
+        mockGetMCPServerToolsConfigurations.mockReturnValue({
+          mayRequireDataSourceConfiguration: false,
+          mayRequireDataWarehouseConfiguration: false,
+          mayRequireTableConfiguration: false,
+          mayRequireChildAgentConfiguration: false,
+          mayRequireReasoningConfiguration: false,
+          mayRequireTimeFrameConfiguration: false,
+          mayRequireJsonSchemaConfiguration: false,
+          stringConfigurations: [],
+          numberConfigurations: [],
+          booleanConfigurations: [],
+          enumConfigurations: {},
+          listConfigurations: {
+            tags: {
+              options: { tag1: "Tag 1", tag2: "Tag 2" },
+              description: "Available tags",
+            },
+            categories: {
+              options: { cat1: "Category 1", cat2: "Category 2" },
+              description: "Available categories",
+            },
+            "nested.lists": {
+              options: { item1: "Item 1" },
+              description: "Nested list",
+            },
+          },
+          mayRequireDustAppConfiguration: false,
+          noRequirement: false,
+        });
+
+        const result = getDefaultConfiguration(mockMCPServerView);
+
+        expect(result.additionalConfiguration).toEqual({
+          tags: [],
+          categories: [],
+          nested: {
+            lists: [],
+          },
+        });
+      });
+    });
+
+    describe("string configurations", () => {
+      it("should set defaults for string configurations when available", () => {
+        mockGetMCPServerToolsConfigurations.mockReturnValue({
+          mayRequireDataSourceConfiguration: false,
+          mayRequireDataWarehouseConfiguration: false,
+          mayRequireTableConfiguration: false,
+          mayRequireChildAgentConfiguration: false,
+          mayRequireReasoningConfiguration: false,
+          mayRequireTimeFrameConfiguration: false,
+          mayRequireJsonSchemaConfiguration: false,
+          stringConfigurations: [
+            {
+              key: "api_key",
+              description: "API Key",
+              default: "default-key-123",
+            },
+            {
+              key: "endpoint_url",
+              description: "Endpoint URL",
+              default: "https://api.example.com",
+            },
+            { key: "user_name", description: "User Name" }, // no default
+          ],
+          numberConfigurations: [],
+          booleanConfigurations: [],
+          enumConfigurations: {},
+          listConfigurations: {},
+          mayRequireDustAppConfiguration: false,
+          noRequirement: false,
+        });
+
+        const result = getDefaultConfiguration(mockMCPServerView);
+
+        // Fixed behavior: strings with defaults ARE now included
+        expect(result.additionalConfiguration).toEqual({
+          api_key: "default-key-123",
+          endpoint_url: "https://api.example.com",
+          // user_name should not be set since it has no default
+        });
+      });
+    });
+
+    describe("number configurations", () => {
+      it("should set defaults for number configurations when available", () => {
+        mockGetMCPServerToolsConfigurations.mockReturnValue({
+          mayRequireDataSourceConfiguration: false,
+          mayRequireDataWarehouseConfiguration: false,
+          mayRequireTableConfiguration: false,
+          mayRequireChildAgentConfiguration: false,
+          mayRequireReasoningConfiguration: false,
+          mayRequireTimeFrameConfiguration: false,
+          mayRequireJsonSchemaConfiguration: false,
+          stringConfigurations: [],
+          numberConfigurations: [
+            { key: "timeout", description: "Timeout in seconds", default: 30 },
+            { key: "max_retries", description: "Maximum retries", default: 3 },
+            { key: "port", description: "Port number" }, // no default
+          ],
+          booleanConfigurations: [],
+          enumConfigurations: {},
+          listConfigurations: {},
+          mayRequireDustAppConfiguration: false,
+          noRequirement: false,
+        });
+
+        const result = getDefaultConfiguration(mockMCPServerView);
+
+        // Fixed behavior: numbers with defaults ARE now included
+        expect(result.additionalConfiguration).toEqual({
+          timeout: 30,
+          max_retries: 3,
+          // port should not be set since it has no default
+        });
+      });
+    });
+
+    describe("mixed configurations", () => {
+      it("should handle all configuration types together", () => {
+        mockGetMCPServerToolsConfigurations.mockReturnValue({
+          mayRequireDataSourceConfiguration: false,
+          mayRequireDataWarehouseConfiguration: false,
+          mayRequireTableConfiguration: false,
+          mayRequireChildAgentConfiguration: false,
+          mayRequireReasoningConfiguration: false,
+          mayRequireTimeFrameConfiguration: false,
+          mayRequireJsonSchemaConfiguration: false,
+          stringConfigurations: [
+            { key: "api_key", description: "API Key", default: "secret-key" },
+          ],
+          numberConfigurations: [
+            { key: "timeout", description: "Timeout", default: 30 },
+          ],
+          booleanConfigurations: [
+            { key: "is_enabled", description: "Enabled" },
+          ],
+          enumConfigurations: {
+            priority: {
+              options: ["low", "medium", "high"],
+              description: "Priority",
+            },
+          },
+          listConfigurations: {
+            tags: {
+              options: { tag1: "Tag 1" },
+              description: "Tags",
+            },
+          },
+          mayRequireDustAppConfiguration: false,
+          noRequirement: false,
+        });
+
+        const result = getDefaultConfiguration(mockMCPServerView);
+
+        // Fixed behavior: all types with defaults get their values set
+        expect(result.additionalConfiguration).toEqual({
+          is_enabled: false,
+          priority: "low",
+          tags: [],
+          api_key: "secret-key", // String default now included
+          timeout: 30, // Number default now included
+        });
+      });
+    });
+
+    describe("comprehensive default handling", () => {
+      it("should handle mixed types with nested paths and explicit defaults", () => {
+        mockGetMCPServerToolsConfigurations.mockReturnValue({
+          mayRequireDataSourceConfiguration: false,
+          mayRequireDataWarehouseConfiguration: false,
+          mayRequireTableConfiguration: false,
+          mayRequireChildAgentConfiguration: false,
+          mayRequireReasoningConfiguration: false,
+          mayRequireTimeFrameConfiguration: false,
+          mayRequireJsonSchemaConfiguration: false,
+          stringConfigurations: [
+            { key: "api.key", description: "API Key", default: "dev-key-123" },
+            { key: "api.endpoint", description: "API Endpoint" }, // no default
+            {
+              key: "database.connection.string",
+              description: "DB Connection",
+              default: "mongodb://localhost:27017",
+            },
+          ],
+          numberConfigurations: [
+            { key: "api.timeout", description: "API Timeout", default: 5000 },
+            { key: "database.pool.max", description: "Max Pool Size" }, // no default
+            { key: "server.port", description: "Server Port", default: 3000 },
+          ],
+          booleanConfigurations: [
+            {
+              key: "features.auth.enabled",
+              description: "Auth enabled",
+              default: true,
+            },
+            { key: "features.logging.debug", description: "Debug logging" }, // no default (will use false)
+          ],
+          enumConfigurations: {
+            "logging.level": {
+              options: ["debug", "info", "warn", "error"],
+              description: "Logging level",
+              default: "info",
+            },
+            environment: {
+              options: ["development", "staging", "production"],
+              description: "Environment", // no default (will use first)
+            },
+          },
+          listConfigurations: {
+            "features.experimental": {
+              options: { feature1: "Feature 1", feature2: "Feature 2" },
+              description: "Experimental features",
+              default: "feature1",
+            },
+            "allowed.origins": {
+              options: { localhost: "Localhost", "example.com": "Example" },
+              description: "Allowed origins", // no default (will use empty array)
+            },
+          },
+          mayRequireDustAppConfiguration: false,
+          noRequirement: false,
+        });
+
+        const result = getDefaultConfiguration(mockMCPServerView);
+
+        expect(result.additionalConfiguration).toEqual({
+          api: {
+            key: "dev-key-123", // string default
+            timeout: 5000, // number default
+            // endpoint: missing - no default
+          },
+          database: {
+            connection: {
+              string: "mongodb://localhost:27017", // nested string default
+            },
+            // pool.max: missing - no default
+          },
+          server: {
+            port: 3000, // number default
+          },
+          features: {
+            auth: {
+              enabled: true, // explicit boolean default
+            },
+            logging: {
+              debug: false, // fallback boolean default
+            },
+            experimental: ["feature1"], // list with explicit default
+          },
+          logging: {
+            level: "info", // explicit enum default
+          },
+          environment: "development", // enum first option fallback
+          allowed: {
+            origins: [], // list fallback to empty array
+          },
+        });
+      });
+    });
+
+    describe("nested path handling", () => {
+      it("should handle deeply nested configuration paths", () => {
+        mockGetMCPServerToolsConfigurations.mockReturnValue({
+          mayRequireDataSourceConfiguration: false,
+          mayRequireDataWarehouseConfiguration: false,
+          mayRequireTableConfiguration: false,
+          mayRequireChildAgentConfiguration: false,
+          mayRequireReasoningConfiguration: false,
+          mayRequireTimeFrameConfiguration: false,
+          mayRequireJsonSchemaConfiguration: false,
+          stringConfigurations: [],
+          numberConfigurations: [],
+          booleanConfigurations: [
+            { key: "level1.level2.level3.deep_flag", description: "Deep flag" },
+          ],
+          enumConfigurations: {
+            "a.b.c.d.enum": {
+              options: ["x", "y"],
+              description: "Deeply nested enum",
+            },
+          },
+          listConfigurations: {
+            "config.advanced.options": {
+              options: { opt1: "Option 1" },
+              description: "Advanced options",
+            },
+          },
+          mayRequireDustAppConfiguration: false,
+          noRequirement: false,
+        });
+
+        const result = getDefaultConfiguration(mockMCPServerView);
+
+        expect(result.additionalConfiguration).toEqual({
+          level1: {
+            level2: {
+              level3: {
+                deep_flag: false,
+              },
+            },
+          },
+          a: {
+            b: {
+              c: {
+                d: {
+                  enum: "x",
+                },
+              },
+            },
+          },
+          config: {
+            advanced: {
+              options: [],
+            },
+          },
+        });
+      });
+    });
+  });
+
+  describe("when toolsConfigurations is null", () => {
+    it("should return base defaults when getMCPServerToolsConfigurations returns null", () => {
+      const mockMCPServerView: MCPServerViewType = {
+        id: 1,
+        sId: "test-server-123",
+        name: "Test Server",
+        description: "Test server description",
+        createdAt: Date.now(),
+        updatedAt: Date.now(),
+        spaceId: "test-space-123",
+        serverType: "internal",
+        server: {
+          sId: "test",
+          name: "test",
+          version: "1.0.0",
+          description: "Test",
+          tools: [],
+          icon: "ActionEmotionLaughIcon",
+          authorization: null,
+          availability: "manual",
+          allowMultipleInstances: false,
+          documentationUrl: null,
+        },
+        oAuthUseCase: null,
+        editedByUser: null,
+        toolsMetadata: [],
+      };
+
+      // Simulate getMCPServerToolsConfigurations returning null somehow
+      mockGetMCPServerToolsConfigurations.mockReturnValue(null as any);
+
+      const result = getDefaultConfiguration(mockMCPServerView);
+
+      expect(result).toEqual({
+        mcpServerViewId: "test-server-123",
+        dataSourceConfigurations: null,
+        tablesConfigurations: null,
+        childAgentId: null,
+        reasoningModel: null,
+        timeFrame: null,
+        additionalConfiguration: {},
+        dustAppConfiguration: null,
+        jsonSchema: null,
+        _jsonSchemaString: null,
+      });
+    });
+  });
+});
+
+describe("Analysis: Why strings and numbers don't get defaults", () => {
+  describe("Historical reasoning investigation - RESOLVED", () => {
+    it("should demonstrate that the fix provides better UX while maintaining validation", () => {
+      // This test shows how the fix improves UX while keeping validation intact
+
+      const mockMCPServerView: MCPServerViewType = {
+        id: 1,
+        sId: "test-server",
+        name: "Test Server",
+        description: "Test server description",
+        createdAt: Date.now(),
+        updatedAt: Date.now(),
+        spaceId: "test-space-123",
+        serverType: "internal",
+        server: {
+          sId: "test",
+          name: "test",
+          version: "1.0.0",
+          description: "Test",
+          tools: [],
+          icon: "ActionEmotionLaughIcon",
+          authorization: null,
+          availability: "manual",
+          allowMultipleInstances: false,
+          documentationUrl: null,
+        },
+        oAuthUseCase: null,
+        editedByUser: null,
+        toolsMetadata: [],
+      };
+
+      mockGetMCPServerToolsConfigurations.mockReturnValue({
+        mayRequireDataSourceConfiguration: false,
+        mayRequireDataWarehouseConfiguration: false,
+        mayRequireTableConfiguration: false,
+        mayRequireChildAgentConfiguration: false,
+        mayRequireReasoningConfiguration: false,
+        mayRequireTimeFrameConfiguration: false,
+        mayRequireJsonSchemaConfiguration: false,
+        stringConfigurations: [
+          { key: "required_field", description: "Required field" }, // no default
+          {
+            key: "optional_field",
+            description: "Optional field",
+            default: "default_value",
+          },
+        ],
+        numberConfigurations: [
+          { key: "required_number", description: "Required number" }, // no default
+          {
+            key: "optional_number",
+            description: "Optional number",
+            default: 42,
+          },
+        ],
+        booleanConfigurations: [],
+        enumConfigurations: {},
+        listConfigurations: {},
+        mayRequireDustAppConfiguration: false,
+        noRequirement: false,
+      });
+
+      const result = getDefaultConfiguration(mockMCPServerView);
+
+      // Fixed behavior: fields with defaults are pre-filled, fields without defaults remain empty
+      expect(result.additionalConfiguration).toEqual({
+        optional_field: "default_value", // ✅ Default applied - better UX
+        optional_number: 42, // ✅ Default applied - better UX
+        // required_field: missing - will trigger validation if required ✅
+        // required_number: missing - will trigger validation if required ✅
+      });
+
+      // The fix provides:
+      // ✅ Better UX: Users see helpful defaults immediately
+      // ✅ Validation still works: Required fields without defaults trigger validation
+      // ✅ User choice: Defaults can be overridden if needed
+      // ✅ Modern behavior: Forms pre-populate sensible defaults
+    });
+  });
+
+  describe("Current validation behavior", () => {
+    it("should show that validation still works with defaults present", () => {
+      // This test would verify that having defaults doesn't prevent validation
+      // from working properly. Validation should still catch:
+      // - Invalid values (wrong type, out of range, etc.)
+      // - Missing required fields that don't have defaults
+      // - Schema violations
+
+      // The presence of a default value doesn't break validation,
+      // it just provides a starting point for the user
+
+      expect(true).toBe(true); // Placeholder - would need actual validation tests
+    });
+  });
+});

--- a/front/components/agent_builder/capabilities/mcp/utils/formDefaults.ts
+++ b/front/components/agent_builder/capabilities/mcp/utils/formDefaults.ts
@@ -114,6 +114,6 @@ export function getDefaultFormValues(mcpServerView: MCPServerViewType | null) {
     description: "",
     configuration: config,
   };
-  
+
   return result;
 }

--- a/front/components/agent_builder/capabilities/mcp/utils/formDefaults.ts
+++ b/front/components/agent_builder/capabilities/mcp/utils/formDefaults.ts
@@ -38,22 +38,63 @@ export function getDefaultConfiguration(
 
   const additionalConfig: AdditionalConfigurationInBuilderType = {};
 
-  // Set default values only for boolean and enums
-  // Strings and numbers should be left empty to trigger validation
-  for (const { key } of toolsConfigurations.booleanConfigurations) {
-    set(additionalConfig, key, false);
+  // Set default values for all configuration types when available
+  // This provides better UX by pre-filling known defaults while still allowing
+  // validation to catch truly missing required fields
+
+  // Boolean configurations: use explicit default or fallback to false
+  for (const {
+    key,
+    default: defaultValue,
+  } of toolsConfigurations.booleanConfigurations) {
+    set(
+      additionalConfig,
+      key,
+      defaultValue !== undefined ? defaultValue : false
+    );
   }
 
-  for (const [key, { options: enumValues }] of Object.entries(
-    toolsConfigurations.enumConfigurations
-  )) {
-    if (enumValues.length > 0) {
+  // Enum configurations: use explicit default or fallback to first option
+  for (const [
+    key,
+    { options: enumValues, default: defaultValue },
+  ] of Object.entries(toolsConfigurations.enumConfigurations)) {
+    if (defaultValue !== undefined) {
+      set(additionalConfig, key, defaultValue);
+    } else if (enumValues.length > 0) {
       set(additionalConfig, key, enumValues[0]);
     }
   }
 
-  for (const [key] of Object.entries(toolsConfigurations.listConfigurations)) {
-    set(additionalConfig, key, []);
+  // List configurations: use explicit default or fallback to empty array
+  for (const [key, { default: defaultValue }] of Object.entries(
+    toolsConfigurations.listConfigurations
+  )) {
+    set(
+      additionalConfig,
+      key,
+      defaultValue !== undefined ? [defaultValue] : []
+    );
+  }
+
+  // String configurations: set defaults when available
+  for (const {
+    key,
+    default: defaultValue,
+  } of toolsConfigurations.stringConfigurations) {
+    if (defaultValue !== undefined) {
+      set(additionalConfig, key, defaultValue);
+    }
+  }
+
+  // Number configurations: set defaults when available
+  for (const {
+    key,
+    default: defaultValue,
+  } of toolsConfigurations.numberConfigurations) {
+    if (defaultValue !== undefined) {
+      set(additionalConfig, key, defaultValue);
+    }
   }
 
   defaults.additionalConfiguration = additionalConfig;
@@ -67,9 +108,12 @@ export function getDefaultConfiguration(
  * @returns Default form data object
  */
 export function getDefaultFormValues(mcpServerView: MCPServerViewType | null) {
-  return {
+  const config = getDefaultConfiguration(mcpServerView);
+  const result = {
     name: "",
     description: "",
-    configuration: getDefaultConfiguration(mcpServerView),
+    configuration: config,
   };
+  
+  return result;
 }

--- a/front/components/agent_builder/capabilities/mcp/utils/formStateUtils.ts
+++ b/front/components/agent_builder/capabilities/mcp/utils/formStateUtils.ts
@@ -36,8 +36,9 @@ export function createFormResetHandler(
       } else if (mcpServerView) {
         // New configuration mode: check if we need to reset
         const currentValues = form.getValues();
-        const currentMcpServerViewId = currentValues.configuration?.mcpServerViewId;
-        
+        const currentMcpServerViewId =
+          currentValues.configuration?.mcpServerViewId;
+
         // Only reset if we're switching to a different MCP server or don't have the right ID
         if (currentMcpServerViewId !== mcpServerView.sId) {
           const defaultValues = getDefaultFormValues(mcpServerView);

--- a/front/components/agent_builder/capabilities/mcp/utils/formStateUtils.ts
+++ b/front/components/agent_builder/capabilities/mcp/utils/formStateUtils.ts
@@ -34,15 +34,22 @@ export function createFormResetHandler(
           configuration: configurationTool.configuration,
         });
       } else if (mcpServerView) {
-        // New configuration mode: reset with default values
-        const defaultValues = getDefaultFormValues(mcpServerView);
-        form.reset({
-          ...defaultValues,
-          configuration: {
-            ...defaultValues.configuration,
-            mcpServerViewId: mcpServerView.sId,
-          },
-        });
+        // New configuration mode: check if we need to reset
+        const currentValues = form.getValues();
+        const currentMcpServerViewId = currentValues.configuration?.mcpServerViewId;
+        
+        // Only reset if we're switching to a different MCP server or don't have the right ID
+        if (currentMcpServerViewId !== mcpServerView.sId) {
+          const defaultValues = getDefaultFormValues(mcpServerView);
+          const resetData = {
+            ...defaultValues,
+            configuration: {
+              ...defaultValues.configuration,
+              mcpServerViewId: mcpServerView.sId,
+            },
+          };
+          form.reset(resetData);
+        }
       } else {
         // No server view: reset to empty state
         form.reset(getDefaultFormValues(null));

--- a/front/components/agent_builder/capabilities/shared/AdditionalConfigurationSection.tsx
+++ b/front/components/agent_builder/capabilities/shared/AdditionalConfigurationSection.tsx
@@ -79,7 +79,7 @@ function BooleanConfigurationInput({
       </div>
       <Checkbox
         id={`boolean-${configKey}`}
-        checked={field.value === false}
+        checked={field.value === true}
         onCheckedChange={(checked) => field.onChange(checked)}
       />
     </div>

--- a/front/components/agent_builder/capabilities/shared/AdditionalConfigurationSection.tsx
+++ b/front/components/agent_builder/capabilities/shared/AdditionalConfigurationSection.tsx
@@ -79,7 +79,7 @@ function BooleanConfigurationInput({
       </div>
       <Checkbox
         id={`boolean-${configKey}`}
-        checked={field.value === true}
+        checked={field.value === false}
         onCheckedChange={(checked) => field.onChange(checked)}
       />
     </div>
@@ -139,6 +139,7 @@ function NumberConfigurationInput({
           id={`number-${configKey}`}
           type="number"
           {...field}
+          value={field.value || null}
           placeholder={`Enter value for ${formatKeyForDisplay(configKey)}`}
           isError={!!fieldState.error}
           message={fieldState.error?.message}
@@ -201,6 +202,7 @@ function StringConfigurationInput({
           id={`string-${configKey}`}
           type="text"
           {...field}
+          value={field.value || null}
           placeholder={`Enter value for ${formatKeyForDisplay(configKey)}`}
           isError={!!fieldState.error}
           message={fieldState.error?.message}

--- a/front/lib/actions/mcp_internal_actions/input_configuration.ts
+++ b/front/lib/actions/mcp_internal_actions/input_configuration.ts
@@ -678,7 +678,10 @@ export function getMCPServerToolsConfigurations(
   ).map(([key, schema]) => ({
     key,
     description: schema.description,
-    default: extractSchemaDefault(schema, (v: unknown): v is string => typeof v === "string"),
+    default: extractSchemaDefault(
+      schema,
+      (v: unknown): v is string => typeof v === "string"
+    ),
   }));
 
   const numberConfigurations = Object.entries(
@@ -689,7 +692,10 @@ export function getMCPServerToolsConfigurations(
   ).map(([key, schema]) => ({
     key,
     description: schema.description,
-    default: extractSchemaDefault(schema, (v: unknown): v is number => typeof v === "number"),
+    default: extractSchemaDefault(
+      schema,
+      (v: unknown): v is number => typeof v === "number"
+    ),
   }));
 
   const booleanConfigurations = Object.entries(
@@ -700,7 +706,10 @@ export function getMCPServerToolsConfigurations(
   ).map(([key, schema]) => ({
     key,
     description: schema.description,
-    default: extractSchemaDefault(schema, (v: unknown): v is boolean => typeof v === "boolean"),
+    default: extractSchemaDefault(
+      schema,
+      (v: unknown): v is boolean => typeof v === "boolean"
+    ),
   }));
 
   const enumConfigurations = Object.fromEntries(
@@ -714,9 +723,12 @@ export function getMCPServerToolsConfigurations(
       if (!valueProperty || !isJSONSchemaObject(valueProperty)) {
         return [key, { options: [], description: schema.description }];
       }
-      
-      const defaultValue = extractSchemaDefault(schema, (v: unknown): v is string => typeof v === "string");
-      
+
+      const defaultValue = extractSchemaDefault(
+        schema,
+        (v: unknown): v is string => typeof v === "string"
+      );
+
       return [
         key,
         {
@@ -770,13 +782,19 @@ export function getMCPServerToolsConfigurations(
         zip(labels, values).map(([label, value]) => [value, label])
       );
 
-      const defaultValue = extractSchemaDefault(schema, (v: unknown): v is string => typeof v === "string");
+      const defaultValue = extractSchemaDefault(
+        schema,
+        (v: unknown): v is string => typeof v === "string"
+      );
 
-      return [key, { 
-        options: valueToLabel, 
-        description: schema.description,
-        default: defaultValue,
-      }];
+      return [
+        key,
+        {
+          options: valueToLabel,
+          description: schema.description,
+          default: defaultValue,
+        },
+      ];
     })
   );
 

--- a/front/lib/actions/mcp_internal_actions/servers/primitive_types_debugger.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/primitive_types_debugger.ts
@@ -34,22 +34,26 @@ function createServer(): McpServer {
       user: z.object({
         name: ConfigurableToolInputSchemas[
           INTERNAL_MIME_TYPES.TOOL_INPUT.STRING
-        ].describe("The name of the user").default({
-          value: "John Doe",
-          mimeType: INTERNAL_MIME_TYPES.TOOL_INPUT.STRING,
-        }),
-        age: ConfigurableToolInputSchemas[
-          INTERNAL_MIME_TYPES.TOOL_INPUT.NUMBER
-        ].describe("The age of the user").default({
-          value: 30,
-          mimeType: INTERNAL_MIME_TYPES.TOOL_INPUT.NUMBER,
-        }),
+        ]
+          .describe("The name of the user")
+          .default({
+            value: "John Doe",
+            mimeType: INTERNAL_MIME_TYPES.TOOL_INPUT.STRING,
+          }),
+        age: ConfigurableToolInputSchemas[INTERNAL_MIME_TYPES.TOOL_INPUT.NUMBER]
+          .describe("The age of the user")
+          .default({
+            value: 30,
+            mimeType: INTERNAL_MIME_TYPES.TOOL_INPUT.NUMBER,
+          }),
         admin: ConfigurableToolInputSchemas[
           INTERNAL_MIME_TYPES.TOOL_INPUT.BOOLEAN
-        ].describe("Whether the user is an admin").default({
-          value: true,
-          mimeType: INTERNAL_MIME_TYPES.TOOL_INPUT.BOOLEAN,
-        }),
+        ]
+          .describe("Whether the user is an admin")
+          .default({
+            value: true,
+            mimeType: INTERNAL_MIME_TYPES.TOOL_INPUT.BOOLEAN,
+          }),
         location: ConfigurableToolInputSchemas[
           INTERNAL_MIME_TYPES.TOOL_INPUT.STRING
         ].describe("The location of the user"),

--- a/front/lib/actions/mcp_internal_actions/servers/primitive_types_debugger.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/primitive_types_debugger.ts
@@ -34,13 +34,22 @@ function createServer(): McpServer {
       user: z.object({
         name: ConfigurableToolInputSchemas[
           INTERNAL_MIME_TYPES.TOOL_INPUT.STRING
-        ].describe("The name of the user"),
+        ].describe("The name of the user").default({
+          value: "John Doe",
+          mimeType: INTERNAL_MIME_TYPES.TOOL_INPUT.STRING,
+        }),
         age: ConfigurableToolInputSchemas[
           INTERNAL_MIME_TYPES.TOOL_INPUT.NUMBER
-        ].describe("The age of the user"),
+        ].describe("The age of the user").default({
+          value: 30,
+          mimeType: INTERNAL_MIME_TYPES.TOOL_INPUT.NUMBER,
+        }),
         admin: ConfigurableToolInputSchemas[
           INTERNAL_MIME_TYPES.TOOL_INPUT.BOOLEAN
-        ].describe("Whether the user is an admin"),
+        ].describe("Whether the user is an admin").default({
+          value: true,
+          mimeType: INTERNAL_MIME_TYPES.TOOL_INPUT.BOOLEAN,
+        }),
         location: ConfigurableToolInputSchemas[
           INTERNAL_MIME_TYPES.TOOL_INPUT.STRING
         ].describe("The location of the user"),


### PR DESCRIPTION
## Description

Makes default values set for MCP tools populate configuration forms in the Agent Builder.

## Tests

Made a batch of tests for this in `front/components/agent_builder/capabilities/mcp/utils/formDefaults.test.ts` and tested by giving default values to `PrimitiveTypesDebugger` and checking visually:

<img width="748" height="703" alt="image" src="https://github.com/user-attachments/assets/855ec4c5-f9b9-40c9-bdfb-67e5e1e1bf52" />

```ts
server.tool(
    "pass_through",
    "Super useful tool that should be used at all times.",
    {
      query: z.string(),
      user: z.object({
        name: ConfigurableToolInputSchemas[
          INTERNAL_MIME_TYPES.TOOL_INPUT.STRING
        ]
          .describe("The name of the user")
          .default({
            value: "John Doe",
            mimeType: INTERNAL_MIME_TYPES.TOOL_INPUT.STRING,
          }),
        age: ConfigurableToolInputSchemas[INTERNAL_MIME_TYPES.TOOL_INPUT.NUMBER]
          .describe("The age of the user")
          .default({
            value: 30,
            mimeType: INTERNAL_MIME_TYPES.TOOL_INPUT.NUMBER,
          }),
        admin: ConfigurableToolInputSchemas[
          INTERNAL_MIME_TYPES.TOOL_INPUT.BOOLEAN
        ]
          .describe("Whether the user is an admin")
          .default({
            value: true,
            mimeType: INTERNAL_MIME_TYPES.TOOL_INPUT.BOOLEAN,
          }),
```

## Risk

No risk really, this simply adds default values to the forms.

## Deploy Plan

Deploy front
