### PR TITLE
fix: re-place add tools CTA on the right

### DIFF
--- a/front/components/spaces/SpacePageHeaders.tsx
+++ b/front/components/spaces/SpacePageHeaders.tsx
@@ -65,8 +65,10 @@ export function SpacePageHeader({
           dataSourceView={dataSourceView}
           parentId={parentId}
         />
-        <div id={ACTION_BUTTONS_CONTAINER_ID} className="flex gap-2" />
-        <div id={TRIGGER_BUTTONS_CONTAINER_ID} className="flex gap-2" />
+        <div>
+          <div id={ACTION_BUTTONS_CONTAINER_ID} className="flex gap-2" />
+          <div id={TRIGGER_BUTTONS_CONTAINER_ID} className="flex gap-2" />
+        </div>
       </div>
       {description && (
         <div className="text-sm text-muted-foreground">{description}</div>


### PR DESCRIPTION
## Description

Webhook source PR generated a UI bug, this commit fixes it

<img width="1253" height="389" alt="Screenshot 2025-09-15 at 11 20 41" src="https://github.com/user-attachments/assets/1d154e53-f8eb-4ca6-9a33-b4f2cf14ca26" />


## Risk

no risk

## Deploy Plan

front
