### PR TITLE
Fix escaping of row_id

### DIFF
--- a/core/src/databases/table.rs
+++ b/core/src/databases/table.rs
@@ -1078,10 +1078,13 @@ impl<'de> Deserialize<'de> for Row {
         let value = serde_json::Map::deserialize(deserializer)?;
 
         match value["value"].as_object() {
-            Some(subvalue) => Ok(Row::new_from_value(
-                value["row_id"].to_string(),
-                subvalue.clone(),
-            )),
+            Some(subvalue) => {
+                let row_id = value
+                    .get("row_id")
+                    .and_then(|v| v.as_str())
+                    .ok_or_else(|| D::Error::custom("Missing or invalid row_id in Row"))?;
+                Ok(Row::new_from_value(row_id.to_string(), subvalue.clone()))
+            }
             None => Err(D::Error::custom("Missing value in Row")),
         }
     }

--- a/core/src/databases/table.rs
+++ b/core/src/databases/table.rs
@@ -1079,11 +1079,19 @@ impl<'de> Deserialize<'de> for Row {
 
         match value["value"].as_object() {
             Some(subvalue) => {
-                let row_id = value
+                let row_id_val = value
                     .get("row_id")
-                    .and_then(|v| v.as_str())
-                    .ok_or_else(|| D::Error::custom("Missing or invalid row_id in Row"))?;
-                Ok(Row::new_from_value(row_id.to_string(), subvalue.clone()))
+                    .ok_or_else(|| D::Error::custom("Missing row_id in Row"))?;
+
+                let row_id = if let Some(s) = row_id_val.as_str() {
+                    s.to_string()
+                } else if let Some(i) = row_id_val.as_i64() {
+                    i.to_string()
+                } else {
+                    return Err(D::Error::custom("Invalid row_id type in Row"));
+                };
+
+                Ok(Row::new_from_value(row_id, subvalue.clone()))
             }
             None => Err(D::Error::custom("Missing value in Row")),
         }


### PR DESCRIPTION
## Description

This relates to https://github.com/dust-tt/tasks/issues/4146. We were escaping the row_id when we should not have. This was causing to treat what should have been just "some_row_id" as "\"some_row_id\"", causing various issues downstream.

## Tests

Manual

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

Core