### PR TITLE
JIRA MCP - allow searching by JQL

### DIFF
--- a/front/lib/actions/mcp_internal_actions/constants.ts
+++ b/front/lib/actions/mcp_internal_actions/constants.ts
@@ -688,6 +688,7 @@ The directive should be used to display a clickable version of the agent name in
       get_project: "never_ask",
       get_transitions: "never_ask",
       get_issues: "never_ask",
+      get_issues_using_jql: "never_ask",
       get_issue_types: "never_ask",
       get_issue_create_fields: "never_ask",
       get_issue_read_fields: "never_ask",

--- a/front/lib/actions/mcp_internal_actions/servers/jira/server.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/jira/server.ts
@@ -17,6 +17,7 @@ import {
   listFieldSummaries,
   listUsers,
   searchIssues,
+  searchJiraIssuesUsingJql,
   searchUsersByEmailExact,
   transitionIssue,
   updateIssue,
@@ -277,6 +278,62 @@ const createServer = (): McpServer => {
             result.value.issues.length === 0
               ? "No issues found matching the search criteria"
               : "Issues retrieved successfully";
+          return makeMCPToolJSONSuccess({
+            message,
+            result: result.value,
+          });
+        },
+        authInfo,
+      });
+    }
+  );
+
+  server.tool(
+    "get_issues_using_jql",
+    "Search JIRA issues using a custom JQL (Jira Query Language) query. This tool allows for advanced search capabilities beyond the filtered search. Examples: 'project = PROJ AND status = Open', 'assignee = currentUser() AND priority = High', 'created >= -30d AND labels = bug'.",
+    {
+      jql: z.string().describe("The JQL (Jira Query Language) query string"),
+      maxResults: z
+        .number()
+        .min(1)
+        .max(100)
+        .optional()
+        .describe(
+          "Maximum number of results to return (default: 50, max: 100)"
+        ),
+      fields: z
+        .array(z.string())
+        .optional()
+        .describe(
+          "Optional list of fields to include in the response. Defaults to ['summary']"
+        ),
+      nextPageToken: z
+        .string()
+        .optional()
+        .describe("Token for next page of results (for pagination)"),
+    },
+    async ({ jql, maxResults, fields, nextPageToken }, { authInfo }) => {
+      return withAuth({
+        action: async (baseUrl, accessToken) => {
+          const result = await searchJiraIssuesUsingJql(
+            baseUrl,
+            accessToken,
+            jql,
+            {
+              maxResults,
+              fields,
+              nextPageToken,
+            }
+          );
+          if (result.isErr()) {
+            return makeMCPToolTextError(
+              `Error executing JQL search: ${result.error}`
+            );
+          }
+          const message =
+            result.value.issues.length === 0
+              ? "No issues found matching the JQL query"
+              : "Issues retrieved successfully using JQL";
           return makeMCPToolJSONSuccess({
             message,
             result: result.value,


### PR DESCRIPTION
## Description

Allows the MCP tool to run JQL queries to fetch issues

## Tests

Tested locally

## Deploy Plan

Front only
