### PR TITLE
Fix the name of claude sonnet 4 model id

### DIFF
--- a/front/migrations/db/migration_357.sql
+++ b/front/migrations/db/migration_357.sql
@@ -1,0 +1,3 @@
+-- Migration created on Sep 15, 2025
+
+UPDATE templates SET "presetModelId"='claude-4-sonnet-20250514' WHERE "presetModelId"='claude-sonnet-4-20250514';

--- a/front/pages/api/w/[wId]/providers/[pId]/models.ts
+++ b/front/pages/api/w/[wId]/providers/[pId]/models.ts
@@ -206,7 +206,7 @@ async function handler(
               // Active models.
               { id: "claude-3-haiku-20240307" },
               { id: "claude-3-5-haiku-20241022" },
-              { id: "claude-sonnet-4-20250514" },
+              { id: "claude-4-sonnet-20250514" },
               { id: "claude-opus-4-20250514" },
             ];
           }


### PR DESCRIPTION
## Description

Both in EU and US, some templates are set to use `claude-sonnet-4-20250514`, which is invalid. Correct name is `claude-4-sonnet-20250514`. For some reason, the problem exists in a different set of templates in US vs EU.

Fixes https://github.com/dust-tt/tasks/issues/4153.

## Tests

Manual

## Risk

Low

## Deploy Plan

Run migration