### PR TITLE
Default webhook source global view

### DIFF
--- a/front/components/triggers/CreateWebhookSourceDialog.tsx
+++ b/front/components/triggers/CreateWebhookSourceDialog.tsx
@@ -56,6 +56,7 @@ export function CreateWebhookSourceDialog({
     const apiData = {
       ...data,
       customHeaders: parsedCustomHeaders?.parsed ?? null,
+      includeGlobal: true,
     };
 
     await createWebhookSource(apiData);

--- a/front/lib/resources/webhook_source_resource.ts
+++ b/front/lib/resources/webhook_source_resource.ts
@@ -41,10 +41,8 @@ export class WebhookSourceResource extends BaseResource<WebhookSourceModel> {
     blob: CreationAttributes<WebhookSourceModel>,
     { transaction }: { transaction?: Transaction } = {}
   ): Promise<Result<WebhookSourceResource, Error>> {
-    const canAdministrate =
-      await SpaceResource.canAdministrateSystemSpace(auth);
     assert(
-      canAdministrate,
+      await SpaceResource.canAdministrateSystemSpace(auth),
       "The user is not authorized to create a webhook source"
     );
 

--- a/front/lib/resources/webhook_sources_view_resource.ts
+++ b/front/lib/resources/webhook_sources_view_resource.ts
@@ -286,6 +286,22 @@ export class WebhookSourcesViewResource extends ResourceWithSpace<WebhookSources
     });
   }
 
+  static async getWebhookSourceViewForSystemSpace(
+    auth: Authenticator,
+    webhookSourceId: ModelId
+  ): Promise<WebhookSourcesViewResource | null> {
+    const systemSpace = await SpaceResource.fetchWorkspaceSystemSpace(auth);
+
+    const views = await this.baseFetch(auth, {
+      where: {
+        vaultId: systemSpace.id,
+        webhookSourceId,
+      },
+    });
+
+    return views[0] ?? null;
+  }
+
   public async updateName(
     auth: Authenticator,
     name?: string

--- a/front/types/triggers/webhooks.ts
+++ b/front/types/triggers/webhooks.ts
@@ -47,4 +47,5 @@ export const PostWebhookSourcesSchema = z.object({
   signatureHeader: z.string().min(1, "Signature header is required"),
   signatureAlgorithm: z.enum(WEBHOOK_SOURCE_SIGNATURE_ALGORITHMS),
   customHeaders: z.record(z.string(), z.string()).nullable(),
+  includeGlobal: z.boolean().optional(),
 });


### PR DESCRIPTION
## Description

[4186](https://github.com/dust-tt/tasks/issues/4186)
On webhook source creation in the admin space, create a global webhook source view by default

## Tests


## Risk


## Deploy Plan

front
