### PR TITLE
[front] conversation : add dates, times, and chip to differentiate triggered messages

### DIFF
--- a/extension/package-lock.json
+++ b/extension/package-lock.json
@@ -12,7 +12,7 @@
         "@auth0/auth0-spa-js": "^2.1.3",
         "@datadog/browser-logs": "^6.13.0",
         "@dust-tt/client": "^1.1.15",
-        "@dust-tt/sparkle": "^0.2.615",
+        "@dust-tt/sparkle": "^0.2.616",
         "@frontapp/plugin-sdk": "^1.8.1",
         "@modelcontextprotocol/sdk": "^1.9.0",
         "@tailwindcss/forms": "^0.5.9",
@@ -1293,9 +1293,9 @@
       }
     },
     "node_modules/@dust-tt/sparkle": {
-      "version": "0.2.615",
-      "resolved": "https://registry.npmjs.org/@dust-tt/sparkle/-/sparkle-0.2.615.tgz",
-      "integrity": "sha512-x8sJDx0TaAaco8pQ2CVL+N+wEZwpww6A6VEDfahIrX/v8t76fG0tQGVP6bnfRuiJ/XcRSGn1To3feh68AAnqGA==",
+      "version": "0.2.616",
+      "resolved": "https://registry.npmjs.org/@dust-tt/sparkle/-/sparkle-0.2.616.tgz",
+      "integrity": "sha512-u2xMhSjBDHlhRvgzhZ3RG2RBGSn04m+lLylIH3pbRQzDMXZ8NYY5OJw3FVRHeGUT+317EEyB1CWe09/nRtnB0w==",
       "license": "ISC",
       "dependencies": {
         "@emoji-mart/data": "^1.1.2",

--- a/extension/package.json
+++ b/extension/package.json
@@ -59,7 +59,7 @@
     "@auth0/auth0-spa-js": "^2.1.3",
     "@datadog/browser-logs": "^6.13.0",
     "@dust-tt/client": "^1.1.15",
-    "@dust-tt/sparkle": "^0.2.615",
+    "@dust-tt/sparkle": "^0.2.616",
     "@frontapp/plugin-sdk": "^1.8.1",
     "@modelcontextprotocol/sdk": "^1.9.0",
     "@tailwindcss/forms": "^0.5.9",

--- a/extension/shared/lib/utils.ts
+++ b/extension/shared/lib/utils.ts
@@ -247,7 +247,7 @@ export function compareAgentsForSort(
   return a.name.localeCompare(b.name, "en", { sensitivity: "base" });
 }
 
-export const formatMessageTime = (timestamp: number): string => {
+export const formatTimestring = (timestamp: number): string => {
   const date = new Date(timestamp);
   return date.toLocaleTimeString("en-US", {
     hour12: false,

--- a/extension/shared/lib/utils.ts
+++ b/extension/shared/lib/utils.ts
@@ -247,6 +247,15 @@ export function compareAgentsForSort(
   return a.name.localeCompare(b.name, "en", { sensitivity: "base" });
 }
 
+export const formatMessageTime = (timestamp: number): string => {
+  const date = new Date(timestamp);
+  return date.toLocaleTimeString("en-US", {
+    hour12: false,
+    hour: "2-digit",
+    minute: "2-digit",
+  });
+};
+
 export function getWeekBoundaries(date: Date): {
   startDate: Date;
   endDate: Date;

--- a/extension/ui/components/conversation/AgentMessage.tsx
+++ b/extension/ui/components/conversation/AgentMessage.tsx
@@ -1,6 +1,6 @@
 import { usePlatform } from "@app/shared/context/PlatformContext";
 import { retryMessage } from "@app/shared/lib/conversation";
-import { formatMessageTime } from "@app/shared/lib/utils";
+import { formatTimestring } from "@app/shared/lib/utils";
 import type { StoredUser } from "@app/shared/services/auth";
 import type {
   AgentMessageStateEvent,
@@ -555,7 +555,7 @@ export function AgentMessage({
         );
       }}
       type="agent"
-      timestamp={formatMessageTime(agentMessageToRender.created)}
+      timestamp={formatTimestring(agentMessageToRender.created)}
       citations={citations}
     >
       <div>

--- a/extension/ui/components/conversation/AgentMessage.tsx
+++ b/extension/ui/components/conversation/AgentMessage.tsx
@@ -1,5 +1,6 @@
 import { usePlatform } from "@app/shared/context/PlatformContext";
 import { retryMessage } from "@app/shared/lib/conversation";
+import { formatMessageTime } from "@app/shared/lib/utils";
 import type { StoredUser } from "@app/shared/services/auth";
 import type {
   AgentMessageStateEvent,
@@ -554,6 +555,7 @@ export function AgentMessage({
         );
       }}
       type="agent"
+      timestamp={formatMessageTime(agentMessageToRender.created)}
       citations={citations}
     >
       <div>

--- a/extension/ui/components/conversation/ConversationViewer.tsx
+++ b/extension/ui/components/conversation/ConversationViewer.tsx
@@ -21,7 +21,8 @@ import type {
   UserMessageType,
 } from "@dust-tt/client";
 import { isAgentMention } from "@dust-tt/client";
-import { debounce, groupBy } from "lodash";
+import groupBy from "lodash/groupBy";
+import debounce from "lodash/debounce";
 import { useCallback, useEffect, useMemo, useRef } from "react";
 
 const formatDateSeparator = (timestamp: number): string => {

--- a/extension/ui/components/conversation/ConversationViewer.tsx
+++ b/extension/ui/components/conversation/ConversationViewer.tsx
@@ -50,16 +50,6 @@ const formatDateSeparator = (timestamp: number): string => {
   }
 };
 
-const isSameDay = (timestamp1: number, timestamp2: number): boolean => {
-  const date1 = new Date(timestamp1);
-  const date2 = new Date(timestamp2);
-  return (
-    date1.getFullYear() === date2.getFullYear() &&
-    date1.getMonth() === date2.getMonth() &&
-    date1.getDate() === date2.getDate()
-  );
-};
-
 type MessageGroupWithDate = {
   date: string;
   timestamp: number;

--- a/extension/ui/components/conversation/ConversationViewer.tsx
+++ b/extension/ui/components/conversation/ConversationViewer.tsx
@@ -21,7 +21,7 @@ import type {
   UserMessageType,
 } from "@dust-tt/client";
 import { isAgentMention } from "@dust-tt/client";
-import { debounce } from "lodash";
+import { debounce, groupBy } from "lodash";
 import { useCallback, useEffect, useMemo, useRef } from "react";
 
 const formatDateSeparator = (timestamp: number): string => {
@@ -308,32 +308,27 @@ const groupMessagesByType = (
 const groupMessagesByDate = (
   messageGroups: MessageWithContentFragmentsType[][]
 ): MessageGroupWithDate[] => {
-  const dateGroups: MessageGroupWithDate[] = [];
+  // Filter out empty groups
+  const nonEmptyGroups = messageGroups.filter((group) => group.length > 0);
 
-  messageGroups.forEach((group) => {
-    if (group.length === 0) {
-      return;
-    }
-
-    // Get the timestamp from the first message in the group
+  // Group by day using lodash groupBy and isSameDay
+  const grouped = groupBy(nonEmptyGroups, (group) => {
     const firstMessage = group[0];
     const timestamp = firstMessage.created || Date.now();
-
-    // Check if we already have a group for this date
-    const existingDateGroup = dateGroups.find((dg) =>
-      isSameDay(dg.timestamp, timestamp)
-    );
-
-    if (existingDateGroup) {
-      existingDateGroup.messages.push(group);
-    } else {
-      dateGroups.push({
-        date: formatDateSeparator(timestamp),
-        timestamp,
-        messages: [group],
-      });
-    }
+    // Use the timestamp as the grouping key (by day)
+    // We'll use the timestamp of the start of the day for grouping
+    const date = new Date(timestamp);
+    date.setHours(0, 0, 0, 0);
+    return date.getTime();
   });
 
-  return dateGroups;
+  // Convert grouped object to array of MessageGroupWithDate
+  return Object.entries(grouped).map(([dayTimestamp, groups]) => {
+    const timestamp = Number(dayTimestamp);
+    return {
+      date: formatDateSeparator(timestamp),
+      timestamp,
+      messages: groups,
+    };
+  });
 };

--- a/extension/ui/components/conversation/ConversationViewer.tsx
+++ b/extension/ui/components/conversation/ConversationViewer.tsx
@@ -21,8 +21,8 @@ import type {
   UserMessageType,
 } from "@dust-tt/client";
 import { isAgentMention } from "@dust-tt/client";
-import groupBy from "lodash/groupBy";
 import debounce from "lodash/debounce";
+import groupBy from "lodash/groupBy";
 import { useCallback, useEffect, useMemo, useRef } from "react";
 
 const formatDateSeparator = (timestamp: number): string => {

--- a/extension/ui/components/conversation/UserMessage.tsx
+++ b/extension/ui/components/conversation/UserMessage.tsx
@@ -1,4 +1,5 @@
 /* eslint-disable @typescript-eslint/no-unused-vars */
+import { formatMessageTime } from "@app/shared/lib/utils";
 import { AgentSuggestion } from "@app/ui/components/conversation/AgentSuggestion";
 import {
   CiteBlock,
@@ -56,6 +57,7 @@ export function UserMessage({
           renderName={(name) => name}
           type="user"
           citations={citations}
+          timestamp={formatMessageTime(message.created)}
         >
           <div className="flex flex-col gap-4">
             <div>

--- a/extension/ui/components/conversation/UserMessage.tsx
+++ b/extension/ui/components/conversation/UserMessage.tsx
@@ -1,5 +1,5 @@
 /* eslint-disable @typescript-eslint/no-unused-vars */
-import { formatMessageTime } from "@app/shared/lib/utils";
+import { formatTimestring } from "@app/shared/lib/utils";
 import { AgentSuggestion } from "@app/ui/components/conversation/AgentSuggestion";
 import {
   CiteBlock,
@@ -57,7 +57,7 @@ export function UserMessage({
           renderName={(name) => name}
           type="user"
           citations={citations}
-          timestamp={formatMessageTime(message.created)}
+          timestamp={formatTimestring(message.created)}
         >
           <div className="flex flex-col gap-4">
             <div>

--- a/front/components/assistant/conversation/AgentMessage.tsx
+++ b/front/components/assistant/conversation/AgentMessage.tsx
@@ -24,6 +24,7 @@ import {
 import { AssistantHandle } from "@app/components/assistant/conversation/AssistantHandle";
 import { useActionValidationContext } from "@app/components/assistant/conversation/BlockedActionsProvider";
 import { useAutoOpenContentCreation } from "@app/components/assistant/conversation/content_creation/useAutoOpenContentCreation";
+import { formatMessageTime } from "@app/lib/utils/timestamps";
 import { ErrorMessage } from "@app/components/assistant/conversation/ErrorMessage";
 import type { FeedbackSelectorProps } from "@app/components/assistant/conversation/FeedbackSelector";
 import { FeedbackSelector } from "@app/components/assistant/conversation/FeedbackSelector";
@@ -413,6 +414,7 @@ export function AgentMessage({
           isDisabled={isArchived}
         />
       )}
+      timestamp={formatMessageTime(agentMessageToRender.created)}
       type="agent"
       citations={citations}
     >

--- a/front/components/assistant/conversation/AgentMessage.tsx
+++ b/front/components/assistant/conversation/AgentMessage.tsx
@@ -24,7 +24,6 @@ import {
 import { AssistantHandle } from "@app/components/assistant/conversation/AssistantHandle";
 import { useActionValidationContext } from "@app/components/assistant/conversation/BlockedActionsProvider";
 import { useAutoOpenContentCreation } from "@app/components/assistant/conversation/content_creation/useAutoOpenContentCreation";
-import { formatMessageTime } from "@app/lib/utils/timestamps";
 import { ErrorMessage } from "@app/components/assistant/conversation/ErrorMessage";
 import type { FeedbackSelectorProps } from "@app/components/assistant/conversation/FeedbackSelector";
 import { FeedbackSelector } from "@app/components/assistant/conversation/FeedbackSelector";
@@ -54,6 +53,7 @@ import { isImageProgressOutput } from "@app/lib/actions/mcp_internal_actions/out
 import type { MessageTemporaryState } from "@app/lib/assistant/state/messageReducer";
 import { RETRY_BLOCKED_ACTIONS_STARTED_EVENT } from "@app/lib/assistant/state/messageReducer";
 import { useConversationMessage } from "@app/lib/swr/conversations";
+import { formatMessageTime } from "@app/lib/utils/timestamps";
 import type {
   LightAgentMessageType,
   LightAgentMessageWithActionsType,

--- a/front/components/assistant/conversation/AgentMessage.tsx
+++ b/front/components/assistant/conversation/AgentMessage.tsx
@@ -53,7 +53,7 @@ import { isImageProgressOutput } from "@app/lib/actions/mcp_internal_actions/out
 import type { MessageTemporaryState } from "@app/lib/assistant/state/messageReducer";
 import { RETRY_BLOCKED_ACTIONS_STARTED_EVENT } from "@app/lib/assistant/state/messageReducer";
 import { useConversationMessage } from "@app/lib/swr/conversations";
-import { formatMessageTime } from "@app/lib/utils/timestamps";
+import { formatTimestring } from "@app/lib/utils/timestamps";
 import type {
   LightAgentMessageType,
   LightAgentMessageWithActionsType,
@@ -414,7 +414,7 @@ export function AgentMessage({
           isDisabled={isArchived}
         />
       )}
-      timestamp={formatMessageTime(agentMessageToRender.created)}
+      timestamp={formatTimestring(agentMessageToRender.created)}
       type="agent"
       citations={citations}
     >

--- a/front/components/assistant/conversation/ConversationViewer.tsx
+++ b/front/components/assistant/conversation/ConversationViewer.tsx
@@ -412,12 +412,8 @@ const ConversationViewer = React.forwardRef<
       {conversation &&
         dateGroupedMessages.map((dateGroup, dateIndex) => (
           <div key={`date-group-${dateIndex}`}>
-            <div className="flex w-full justify-center py-4">
-              <div className="bg-element-4 rounded-full px-3 py-1">
-                <span className="text-element-800 text-xs font-medium">
-                  {dateGroup.date}
-                </span>
-              </div>
+            <div className="flex w-full justify-center py-4 text-xs font-medium text-muted-foreground dark:text-muted-foreground-night">
+              {dateGroup.date}
             </div>
             {dateGroup.messages.map((typedGroup, index) => {
               const isLastGroup =

--- a/front/components/assistant/conversation/ConversationViewer.tsx
+++ b/front/components/assistant/conversation/ConversationViewer.tsx
@@ -53,20 +53,24 @@ const formatDateSeparator = (timestamp: number): string => {
   const date = new Date(timestamp);
   const now = new Date();
   const today = new Date(now.getFullYear(), now.getMonth(), now.getDate());
-  const messageDate = new Date(date.getFullYear(), date.getMonth(), date.getDate());
-  
+  const messageDate = new Date(
+    date.getFullYear(),
+    date.getMonth(),
+    date.getDate()
+  );
+
   const diffTime = today.getTime() - messageDate.getTime();
   const diffDays = Math.ceil(diffTime / (1000 * 60 * 60 * 24));
-  
+
   if (diffDays === 0) {
     return "Today";
   } else if (diffDays === 1) {
     return "Yesterday";
   } else {
-    return date.toLocaleDateString('en-US', { 
-      month: 'short', 
-      day: 'numeric',
-      year: date.getFullYear() !== now.getFullYear() ? 'numeric' : undefined
+    return date.toLocaleDateString("en-US", {
+      month: "short",
+      day: "numeric",
+      year: date.getFullYear() !== now.getFullYear() ? "numeric" : undefined,
     });
   }
 };
@@ -74,9 +78,11 @@ const formatDateSeparator = (timestamp: number): string => {
 const isSameDay = (timestamp1: number, timestamp2: number): boolean => {
   const date1 = new Date(timestamp1);
   const date2 = new Date(timestamp2);
-  return date1.getFullYear() === date2.getFullYear() &&
-         date1.getMonth() === date2.getMonth() &&
-         date1.getDate() === date2.getDate();
+  return (
+    date1.getFullYear() === date2.getFullYear() &&
+    date1.getMonth() === date2.getMonth() &&
+    date1.getDate() === date2.getDate()
+  );
 };
 
 type MessageGroupWithDate = {
@@ -407,15 +413,16 @@ const ConversationViewer = React.forwardRef<
         dateGroupedMessages.map((dateGroup, dateIndex) => (
           <div key={`date-group-${dateIndex}`}>
             <div className="flex w-full justify-center py-4">
-              <div className="rounded-full bg-element-4 px-3 py-1">
-                <span className="text-xs font-medium text-element-800">
+              <div className="bg-element-4 rounded-full px-3 py-1">
+                <span className="text-element-800 text-xs font-medium">
                   {dateGroup.date}
                 </span>
               </div>
             </div>
             {dateGroup.messages.map((typedGroup, index) => {
-              const isLastGroup = dateIndex === dateGroupedMessages.length - 1 && 
-                                index === dateGroup.messages.length - 1;
+              const isLastGroup =
+                dateIndex === dateGroupedMessages.length - 1 &&
+                index === dateGroup.messages.length - 1;
               return (
                 <MessageGroup
                   key={`typed-group-${dateIndex}-${index}`}
@@ -502,31 +509,31 @@ const groupMessagesByDate = (
   messageGroups: MessageWithContentFragmentsType[][]
 ): MessageGroupWithDate[] => {
   const dateGroups: MessageGroupWithDate[] = [];
-  
+
   messageGroups.forEach((group) => {
     if (group.length === 0) {
       return;
     }
-    
+
     // Get the timestamp from the first message in the group
     const firstMessage = group[0];
-    // Both UserMessageType and AgentMessageType (from API) have created field, 
-    // but TypeScript doesn't know this for LightAgentMessageType
-    const timestamp = (firstMessage as any).created || Date.now();
-    
+    const timestamp = firstMessage.created || Date.now();
+
     // Check if we already have a group for this date
-    const existingDateGroup = dateGroups.find(dg => isSameDay(dg.timestamp, timestamp));
-    
+    const existingDateGroup = dateGroups.find((dg) =>
+      isSameDay(dg.timestamp, timestamp)
+    );
+
     if (existingDateGroup) {
       existingDateGroup.messages.push(group);
     } else {
       dateGroups.push({
         date: formatDateSeparator(timestamp),
         timestamp,
-        messages: [group]
+        messages: [group],
       });
     }
   });
-  
+
   return dateGroups;
 };

--- a/front/components/assistant/conversation/ConversationViewer.tsx
+++ b/front/components/assistant/conversation/ConversationViewer.tsx
@@ -76,16 +76,6 @@ const formatDateSeparator = (timestamp: number): string => {
   }
 };
 
-const isSameDay = (timestamp1: number, timestamp2: number): boolean => {
-  const date1 = new Date(timestamp1);
-  const date2 = new Date(timestamp2);
-  return (
-    date1.getFullYear() === date2.getFullYear() &&
-    date1.getMonth() === date2.getMonth() &&
-    date1.getDate() === date2.getDate()
-  );
-};
-
 type MessageGroupWithDate = {
   date: string;
   timestamp: number;

--- a/front/components/assistant/conversation/ConversationViewer.tsx
+++ b/front/components/assistant/conversation/ConversationViewer.tsx
@@ -1,5 +1,6 @@
 import { Spinner } from "@dust-tt/sparkle";
 import debounce from "lodash/debounce";
+import groupBy from "lodash/groupBy";
 import React, {
   useCallback,
   useEffect,
@@ -45,7 +46,6 @@ import {
   isContentFragmentType,
   isUserMessageType,
 } from "@app/types";
-import { groupBy } from "lodash";
 
 const DEFAULT_PAGE_LIMIT = 50;
 

--- a/front/components/assistant/conversation/UserMessage.tsx
+++ b/front/components/assistant/conversation/UserMessage.tsx
@@ -5,6 +5,7 @@ import {
   Markdown,
   Tooltip,
 } from "@dust-tt/sparkle";
+import { BellIcon } from "lucide-react";
 import { useMemo } from "react";
 import type { Components } from "react-markdown";
 import type { PluggableList } from "react-markdown/lib/react-markdown";
@@ -24,7 +25,6 @@ import {
 } from "@app/components/markdown/MentionBlock";
 import { formatMessageTime } from "@app/lib/utils/timestamps";
 import type { UserMessageType, WorkspaceType } from "@app/types";
-import { BellIcon } from "lucide-react";
 
 interface UserMessageProps {
   citations?: React.ReactElement[];

--- a/front/components/assistant/conversation/UserMessage.tsx
+++ b/front/components/assistant/conversation/UserMessage.tsx
@@ -24,6 +24,7 @@ import {
 } from "@app/components/markdown/MentionBlock";
 import { formatMessageTime } from "@app/lib/utils/timestamps";
 import type { UserMessageType, WorkspaceType } from "@app/types";
+import { BellIcon } from "lucide-react";
 
 interface UserMessageProps {
   citations?: React.ReactElement[];
@@ -102,9 +103,9 @@ function TriggerChip({ message }: { message?: UserMessageType }) {
     });
   };
 
-  return (
-    <Tooltip
-      label={
+  const label = (function () {
+    if (message?.context.lastTriggerRunAt) {
+      return (
         <div className="flex flex-col gap-1 text-sm">
           <span className="font-bold">Scheduled and sent automatically</span>
           {message?.created && (
@@ -120,8 +121,19 @@ function TriggerChip({ message }: { message?: UserMessageType }) {
             </span>
           )}
         </div>
-      }
-      trigger={<Avatar size="xs" visual={<ClockIcon className="h-4 w-4" />} />}
-    />
+      );
+    } else {
+      return (
+        <span className="font-bold">Triggered and sent automatically</span>
+      );
+    }
+  })();
+
+  const icon = message?.context.lastTriggerRunAt ? (
+    <ClockIcon className="h-4 w-4" />
+  ) : (
+    <BellIcon className="h-4 w-4" />
   );
+
+  return <Tooltip label={label} trigger={<Avatar size="xs" visual={icon} />} />;
 }

--- a/front/components/assistant/conversation/UserMessage.tsx
+++ b/front/components/assistant/conversation/UserMessage.tsx
@@ -1,4 +1,10 @@
-import { ConversationMessage, Markdown } from "@dust-tt/sparkle";
+import {
+  Avatar,
+  ClockIcon,
+  ConversationMessage,
+  Markdown,
+  Tooltip,
+} from "@dust-tt/sparkle";
 import { useMemo } from "react";
 import type { Components } from "react-markdown";
 import type { PluggableList } from "react-markdown/lib/react-markdown";
@@ -16,6 +22,7 @@ import {
   getMentionPlugin,
   mentionDirective,
 } from "@app/components/markdown/MentionBlock";
+import { formatMessageTime } from "@app/lib/utils/timestamps";
 import type { UserMessageType, WorkspaceType } from "@app/types";
 
 interface UserMessageProps {
@@ -54,6 +61,12 @@ export function UserMessage({
           pictureUrl={message.context.profilePictureUrl || message.user?.image}
           name={message.context.fullName ?? undefined}
           renderName={(name) => <div className="heading-base">{name}</div>}
+          timestamp={formatMessageTime(message.created)}
+          infoChip={
+            message.context.origin === "triggered" && (
+              <TriggerChip message={message} />
+            )
+          }
           type="user"
           citations={citations}
         >
@@ -74,5 +87,41 @@ export function UserMessage({
         />
       )}
     </div>
+  );
+}
+
+function TriggerChip({ message }: { message?: UserMessageType }) {
+  const getChipDateFormat = (date: Date) => {
+    return date.toLocaleDateString("en-EN", {
+      year: "numeric",
+      month: "short",
+      day: "numeric",
+      hour: "2-digit",
+      minute: "2-digit",
+      second: "2-digit",
+    });
+  };
+
+  return (
+    <Tooltip
+      label={
+        <div className="flex flex-col gap-1 text-sm">
+          <span className="font-bold">Scheduled and sent automatically</span>
+          {message?.created && (
+            <span>
+              <span className="font-semibold">Current execution</span>:{" "}
+              {getChipDateFormat(new Date(message?.created))}
+            </span>
+          )}
+          {message?.context.lastTriggerRunAt && (
+            <span>
+              <span className="font-semibold">Previous run</span>:{" "}
+              {getChipDateFormat(new Date(message?.context.lastTriggerRunAt))}
+            </span>
+          )}
+        </div>
+      }
+      trigger={<Avatar size="xs" visual={<ClockIcon className="h-4 w-4" />} />}
+    />
   );
 }

--- a/front/components/assistant/conversation/UserMessage.tsx
+++ b/front/components/assistant/conversation/UserMessage.tsx
@@ -23,7 +23,7 @@ import {
   getMentionPlugin,
   mentionDirective,
 } from "@app/components/markdown/MentionBlock";
-import { formatMessageTime } from "@app/lib/utils/timestamps";
+import { formatTimestring } from "@app/lib/utils/timestamps";
 import type { UserMessageType, WorkspaceType } from "@app/types";
 
 interface UserMessageProps {
@@ -62,7 +62,7 @@ export function UserMessage({
           pictureUrl={message.context.profilePictureUrl || message.user?.image}
           name={message.context.fullName ?? undefined}
           renderName={(name) => <div className="heading-base">{name}</div>}
-          timestamp={formatMessageTime(message.created)}
+          timestamp={formatTimestring(message.created)}
           infoChip={
             message.context.origin === "triggered" && (
               <TriggerChip message={message} />
@@ -91,49 +91,52 @@ export function UserMessage({
   );
 }
 
+function getChipDateFormat(date: Date) {
+  return date.toLocaleDateString("en-EN", {
+    year: "numeric",
+    month: "short",
+    day: "numeric",
+    hour: "2-digit",
+    minute: "2-digit",
+    second: "2-digit",
+  });
+}
+
+function Label({ message }: { message?: UserMessageType }) {
+  if (message?.context.lastTriggerRunAt) {
+    return (
+      <div className="flex flex-col gap-1 text-sm">
+        <span className="font-bold">Scheduled and sent automatically</span>
+        {message?.created && (
+          <span>
+            <span className="font-semibold">Current execution</span>:{" "}
+            {getChipDateFormat(new Date(message?.created))}
+          </span>
+        )}
+        {message?.context.lastTriggerRunAt && (
+          <span>
+            <span className="font-semibold">Previous run</span>:{" "}
+            {getChipDateFormat(new Date(message?.context.lastTriggerRunAt))}
+          </span>
+        )}
+      </div>
+    );
+  } else {
+    return <span className="font-bold">Triggered and sent automatically</span>;
+  }
+}
+
 function TriggerChip({ message }: { message?: UserMessageType }) {
-  const getChipDateFormat = (date: Date) => {
-    return date.toLocaleDateString("en-EN", {
-      year: "numeric",
-      month: "short",
-      day: "numeric",
-      hour: "2-digit",
-      minute: "2-digit",
-      second: "2-digit",
-    });
-  };
-
-  const label = (function () {
-    if (message?.context.lastTriggerRunAt) {
-      return (
-        <div className="flex flex-col gap-1 text-sm">
-          <span className="font-bold">Scheduled and sent automatically</span>
-          {message?.created && (
-            <span>
-              <span className="font-semibold">Current execution</span>:{" "}
-              {getChipDateFormat(new Date(message?.created))}
-            </span>
-          )}
-          {message?.context.lastTriggerRunAt && (
-            <span>
-              <span className="font-semibold">Previous run</span>:{" "}
-              {getChipDateFormat(new Date(message?.context.lastTriggerRunAt))}
-            </span>
-          )}
-        </div>
-      );
-    } else {
-      return (
-        <span className="font-bold">Triggered and sent automatically</span>
-      );
-    }
-  })();
-
   const icon = message?.context.lastTriggerRunAt ? (
     <ClockIcon className="h-4 w-4" />
   ) : (
     <BellIcon className="h-4 w-4" />
   );
 
-  return <Tooltip label={label} trigger={<Avatar size="xs" visual={icon} />} />;
+  return (
+    <Tooltip
+      label={<Label message={message} />}
+      trigger={<Avatar size="xs" visual={icon} />}
+    />
+  );
 }

--- a/front/lib/api/assistant/citations.ts
+++ b/front/lib/api/assistant/citations.ts
@@ -113,6 +113,7 @@ export const getLightAgentMessageFromAgentMessage = (
   return {
     type: "agent_message",
     sId: agentMessage.sId,
+    created: agentMessage.created,
     version: agentMessage.version,
     parentMessageId: agentMessage.parentMessageId,
     content: agentMessage.content,

--- a/front/lib/utils/timestamps.ts
+++ b/front/lib/utils/timestamps.ts
@@ -18,7 +18,7 @@ export const cleanTimestamp = (
   return null;
 };
 
-export const formatMessageTime = (timestamp: number): string => {
+export const formatTimestring = (timestamp: number): string => {
   const date = new Date(timestamp);
   return date.toLocaleTimeString("en-US", {
     hour12: false,

--- a/front/lib/utils/timestamps.ts
+++ b/front/lib/utils/timestamps.ts
@@ -17,3 +17,12 @@ export const cleanTimestamp = (
 
   return null;
 };
+
+export const formatMessageTime = (timestamp: number): string => {
+  const date = new Date(timestamp);
+  return date.toLocaleTimeString("en-US", {
+    hour12: false,
+    hour: "2-digit",
+    minute: "2-digit",
+  });
+};

--- a/front/package-lock.json
+++ b/front/package-lock.json
@@ -207,7 +207,7 @@
     },
     "../sdks/js": {
       "name": "@dust-tt/client",
-      "version": "1.1.14",
+      "version": "1.1.15",
       "bundleDependencies": [
         "@modelcontextprotocol/sdk"
       ],

--- a/front/package-lock.json
+++ b/front/package-lock.json
@@ -7,7 +7,7 @@
       "dependencies": {
         "@datadog/browser-logs": "^6.13.0",
         "@dust-tt/client": "file:../sdks/js",
-        "@dust-tt/sparkle": "^0.2.615",
+        "@dust-tt/sparkle": "^0.2.616",
         "@google-cloud/bigquery": "^7.9.1",
         "@google-cloud/storage-transfer": "^3.6.0",
         "@heroicons/react": "^2.0.11",
@@ -1126,9 +1126,9 @@
       "link": true
     },
     "node_modules/@dust-tt/sparkle": {
-      "version": "0.2.615",
-      "resolved": "https://registry.npmjs.org/@dust-tt/sparkle/-/sparkle-0.2.615.tgz",
-      "integrity": "sha512-x8sJDx0TaAaco8pQ2CVL+N+wEZwpww6A6VEDfahIrX/v8t76fG0tQGVP6bnfRuiJ/XcRSGn1To3feh68AAnqGA==",
+      "version": "0.2.616",
+      "resolved": "https://registry.npmjs.org/@dust-tt/sparkle/-/sparkle-0.2.616.tgz",
+      "integrity": "sha512-u2xMhSjBDHlhRvgzhZ3RG2RBGSn04m+lLylIH3pbRQzDMXZ8NYY5OJw3FVRHeGUT+317EEyB1CWe09/nRtnB0w==",
       "license": "ISC",
       "dependencies": {
         "@emoji-mart/data": "^1.1.2",

--- a/front/package.json
+++ b/front/package.json
@@ -27,7 +27,7 @@
   "dependencies": {
     "@datadog/browser-logs": "^6.13.0",
     "@dust-tt/client": "file:../sdks/js",
-    "@dust-tt/sparkle": "^0.2.615",
+    "@dust-tt/sparkle": "^0.2.616",
     "@google-cloud/bigquery": "^7.9.1",
     "@google-cloud/storage-transfer": "^3.6.0",
     "@heroicons/react": "^2.0.11",

--- a/front/types/assistant/conversation.ts
+++ b/front/types/assistant/conversation.ts
@@ -150,6 +150,7 @@ export type BaseAgentMessageType = {
   type: "agent_message";
   sId: string;
   version: number;
+  created: number;
   parentMessageId: string | null;
   status: AgentMessageStatus;
   content: string | null;


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

<img width="819" height="419" alt="Capture d’écran 2025-09-15 à 17 23 25" src="https://github.com/user-attachments/assets/6e2ac981-ecc3-45c8-af03-9c5c051b3497" />

This PR adds the date of the message, acting a separate between days above the first message of the day.

It also implements the use of the new "timestamp" prop of the sparkle message component.

It also implements a new Tooltip to display informations on messages that originates from a trigger. 

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

Tested by hand

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

Low

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->

Deploy front.