### PR TITLE
[front] Refine `queryType` typing in `CoreAPI.searchTags`

### DIFF
--- a/front/pages/api/w/[wId]/data_source_views/tags/search.ts
+++ b/front/pages/api/w/[wId]/data_source_views/tags/search.ts
@@ -17,7 +17,11 @@ import { CoreAPI } from "@app/types";
 
 export const PostTagSearchBodySchema = t.type({
   query: t.string,
-  queryType: t.string,
+  queryType: t.union([
+    t.literal("exact"),
+    t.literal("prefix"),
+    t.literal("match"),
+  ]),
   dataSourceViewIds: t.array(t.string),
 });
 

--- a/front/types/core/core_api.ts
+++ b/front/types/core/core_api.ts
@@ -2140,7 +2140,7 @@ export class CoreAPI {
     limit,
   }: {
     query?: string;
-    queryType?: string;
+    queryType?: "exact" | "prefix" | "match";
     dataSourceViews: DataSourceViewType[];
     limit?: number;
   }): Promise<CoreAPIResponse<CoreAPISearchTagsResponse>> {


### PR DESCRIPTION
## Description

- Improve the type to match the one in core.

## Tests

- `tsc`.

## Risk

- None.

## Deploy Plan

- Deploy front.
