### PR TITLE
Disable deep research tool if dust-deep was disabled by admin

### DIFF
--- a/front/lib/actions/mcp_internal_actions/constants.ts
+++ b/front/lib/actions/mcp_internal_actions/constants.ts
@@ -943,8 +943,10 @@ The directive should be used to display a clickable version of the agent name in
   deep_research: {
     id: 29,
     availability: "auto",
-    isRestricted: ({ featureFlags }) => {
-      return !featureFlags.includes("deep_research_as_a_tool");
+    isRestricted: ({ featureFlags, isDustDeepDisabled }) => {
+      return (
+        !featureFlags.includes("deep_research_as_a_tool") || isDustDeepDisabled
+      );
     },
     allowMultipleInstances: false,
     isPreview: true,
@@ -1166,6 +1168,7 @@ The directive should be used to display a clickable version of the agent name in
       | ((params: {
           plan: PlanType;
           featureFlags: WhitelistableFeature[];
+          isDustDeepDisabled: boolean;
         }) => boolean)
       | undefined;
     isPreview: boolean;

--- a/front/lib/actions/mcp_internal_actions/index.ts
+++ b/front/lib/actions/mcp_internal_actions/index.ts
@@ -9,6 +9,7 @@ import {
 import type { InMemoryWithAuthTransport } from "@app/lib/actions/mcp_internal_actions/in_memory_with_auth_transport";
 import { getInternalMCPServer } from "@app/lib/actions/mcp_internal_actions/servers";
 import type { AgentLoopContextType } from "@app/lib/actions/types";
+import { isDustDeepDisabledByAdmin } from "@app/lib/api/assistant/global_agents/configurations/dust/utils";
 import type { Authenticator } from "@app/lib/auth";
 import { getFeatureFlags } from "@app/lib/auth";
 
@@ -22,7 +23,13 @@ export const isEnabledForWorkspace = async (
   if (mcpServer.isRestricted) {
     const featureFlags = await getFeatureFlags(auth.getNonNullableWorkspace());
     const plan = auth.getNonNullablePlan();
-    return !mcpServer.isRestricted({ plan, featureFlags });
+    const isDustDeepDisabled = await isDustDeepDisabledByAdmin(auth);
+
+    return !mcpServer.isRestricted({
+      plan,
+      featureFlags,
+      isDustDeepDisabled,
+    });
   }
 
   // If the server has no restriction, it is available by default.

--- a/front/lib/api/assistant/global_agents/configurations/dust/utils.ts
+++ b/front/lib/api/assistant/global_agents/configurations/dust/utils.ts
@@ -6,11 +6,12 @@ export async function isDustDeepDisabledByAdmin(
   auth: Authenticator
 ): Promise<boolean> {
   // We cannot call getGlobalAgents here because it will cause a dependency cycle.
-  const settings = await GlobalAgentSettings.findAll({
+  // Can be cached if too many calls are made.
+  const settings = await GlobalAgentSettings.findOne({
     where: {
       workspaceId: auth.getNonNullableWorkspace().id,
       agentId: GLOBAL_AGENTS_SID.DUST_DEEP,
     },
   });
-  return settings.length > 0 && settings[0].status === "disabled_by_admin";
+  return settings?.status === "disabled_by_admin";
 }

--- a/front/lib/api/assistant/global_agents/configurations/dust/utils.ts
+++ b/front/lib/api/assistant/global_agents/configurations/dust/utils.ts
@@ -1,0 +1,16 @@
+import type { Authenticator } from "@app/lib/auth";
+import { GlobalAgentSettings } from "@app/lib/models/assistant/agent";
+import { GLOBAL_AGENTS_SID } from "@app/types/assistant/assistant";
+
+export async function isDustDeepDisabledByAdmin(
+  auth: Authenticator
+): Promise<boolean> {
+  // We cannot call getGlobalAgents here because it will cause a dependency cycle.
+  const settings = await GlobalAgentSettings.findAll({
+    where: {
+      workspaceId: auth.getNonNullableWorkspace().id,
+      agentId: GLOBAL_AGENTS_SID.DUST_DEEP,
+    },
+  });
+  return settings.length > 0 && settings[0].status === "disabled_by_admin";
+}


### PR DESCRIPTION
## Description

Since the admin can disable the global agent, we need to properly disable the tool if there's no deep agent on the workspace. 

## Tests

Locally. 

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

Deploy front. 