### PR TITLE
[Tool Timeout] Raise start-to-close for runTool

### DIFF
--- a/front/temporal/agent_loop/workflows.ts
+++ b/front/temporal/agent_loop/workflows.ts
@@ -39,7 +39,7 @@ const activities: AgentLoopActivities = {
     // The activity timeout should be slightly longer than the max timeout of
     // the tool, to avoid the activity being killed before the tool timeout.
     startToCloseTimeout: `${
-      MAX_MCP_REQUEST_TIMEOUT_MS / 1000 / 60 + 1
+      MAX_MCP_REQUEST_TIMEOUT_MS / 1000 / 60 + 2
     } minutes`,
     retry: {
       // Do not retry tool activities. Those are not idempotent.
@@ -48,7 +48,7 @@ const activities: AgentLoopActivities = {
   }).runToolActivity,
   runRetryableToolActivity: proxyActivities<typeof runToolActivities>({
     startToCloseTimeout: `${
-      MAX_MCP_REQUEST_TIMEOUT_MS / 1000 / 60 + 1
+      MAX_MCP_REQUEST_TIMEOUT_MS / 1000 / 60 + 2
     } minutes`,
     retry: {
       maximumAttempts: 5,


### PR DESCRIPTION
Description
---
Fixes an issue of this [thread](https://dust4ai.slack.com/archives/C097P501RB9/p1757579534479469)
It seldom occurs that tools reach start-to-close timeouts. While this is not a big issue, we should rely on catching this beforehand

The mcp tool timeout in front/lib/actions/mcp_actions.ts should prevent this from happening because the MCP timeouts 1mn before the start-to-close, but in some cases we observed a start-to-close timeout (see [this
workflow](https://cloud.temporal.io/namespaces/dust-agent-prod.gmnlm/workflows/agent-loop-workflow-0ec9852c2f-ksugr0gUIz-eNcdfAOOOP/019937e1-3829-7b8b-b3f6-f76ff030185e/history)).

Increasing the STC to 2 minutes more than the timeout should solve those edge cases

Risks
---
~none

Deploy
---
front