### PR TITLE
[front] - chore(AB): run agent allow multiple

### DIFF
--- a/front/lib/actions/mcp_internal_actions/constants.ts
+++ b/front/lib/actions/mcp_internal_actions/constants.ts
@@ -983,7 +983,7 @@ The directive should be used to display a clickable version of the agent name in
   run_agent: {
     id: 1008,
     availability: "auto",
-    allowMultipleInstances: false,
+    allowMultipleInstances: true,
     isRestricted: undefined,
     isPreview: false,
     tools_stakes: undefined,


### PR DESCRIPTION
## Description

This PR changed the `run_agent` action's `allowMultipleInstances` setting to true to enable multiple usage

## Tests

Locally

## Risk

Low

## Deploy Plan

Deploy front
