### PR TITLE
fix(rate-limiter): swap to Redis LUA script for atomic execution

### DIFF
--- a/front/lib/utils/rate_limiter.ts
+++ b/front/lib/utils/rate_limiter.ts
@@ -58,34 +58,48 @@ export async function rateLimiter({
   const redisKey = makeRateLimiterKey(key);
   const tags: string[] = [];
 
+  // Lua script for atomic rate limiting
+  const luaScript = `
+    local current_time = redis.call('TIME')
+    local key = KEYS[1]
+    local window = tonumber(ARGV[1])
+    local ttl = window + 60
+    local limit = tonumber(ARGV[2])
+
+    local trim_time = tonumber(current_time[1]) - window
+    redis.call('ZREMRANGEBYSCORE', key, 0, trim_time)
+    local request_count = redis.call('ZCARD', key)
+
+    if request_count < limit then
+      redis.call('ZADD', key, current_time[1], current_time[1] .. current_time[2])
+      redis.call('EXPIRE', key, ttl)
+      return limit - request_count;
+    else
+      return 0
+
+    end
+  `;
+
   let redis: undefined | Awaited<ReturnType<typeof redisClient>> = undefined;
   try {
     redis = await getRedisClient({ origin: "rate_limiter", redisUri });
+    const remaining = (await redis.eval(luaScript, {
+      keys: [redisKey],
+      arguments: [timeframeSeconds.toString(), maxPerTimeframe.toString()],
+    })) as number;
 
-    const zcountRes = await redis.zCount(
-      redisKey,
-      new Date().getTime() - timeframeSeconds * 1000,
-      "+inf"
-    );
-    const remaining = maxPerTimeframe - zcountRes;
-    if (remaining > 0) {
-      await redis.zAdd(redisKey, {
-        score: new Date().getTime(),
-        value: uuidv4(),
-      });
-      await redis.expire(redisKey, timeframeSeconds * 2);
-    } else {
-      statsDClient.increment("ratelimiter.exceeded.count", 1, tags);
-    }
     const totalTimeMs = new Date().getTime() - now.getTime();
-
     statsDClient.distribution(
       "ratelimiter.latency.distribution",
       totalTimeMs,
       tags
     );
 
-    return remaining > 0 ? remaining : 0;
+    if (remaining <= 0) {
+      statsDClient.increment("ratelimiter.exceeded.count", 1, tags);
+    }
+
+    return remaining;
   } catch (e) {
     statsDClient.increment("ratelimiter.error.count", 1, tags);
     logger.error(
@@ -97,9 +111,7 @@ export async function rateLimiter({
       },
       `RateLimiter error`
     );
-
-    // In case of error on our side, we allow the request.
-    return 1;
+    return 1; // Allow request if error is on our side
   }
 }
 

--- a/front/lib/utils/rate_limiter.ts
+++ b/front/lib/utils/rate_limiter.ts
@@ -1,5 +1,3 @@
-import { v4 as uuidv4 } from "uuid";
-
 import type { RedisUsageTagsType } from "@app/lib/utils/redis_client";
 import { redisClient } from "@app/lib/utils/redis_client";
 import { getStatsDClient } from "@app/lib/utils/statsd";


### PR DESCRIPTION
## Description

Fixes: #15926

- Redis LUA scripts are atomic.
- Window trimming happens as a first step via ZREMRANGEBYSCORE
- Request count is retrieved via ZCARD
- We queue requests with ZADD with the time in seconds as a score and the time in milliseconds as a unique id
- We expire the key with TTL by window + 60s to cleanup

Note: Requests are still visible with ZRANGE and ZCARD until a request arrives. This is because trimming happens pre-count synchronously.

## Tests

Tested with a limit of 5 API keys and a window of 60s:
- \>5 simultaneous calls 
- 3 then 3, 30s apart

## Risk

Increased Redis load due to moving rate limiting evaluation to Redis
