### PR TITLE
[front] Remove redundant log on tool execution errors

### DIFF
--- a/front/lib/actions/mcp_actions.ts
+++ b/front/lib/actions/mcp_actions.ts
@@ -375,20 +375,9 @@ export async function* tryCallMCPTool(
     // Tool is done now, wait for the actual result.
     const toolCallResult = await toolPromise;
 
-    // Do not raise an error here as it will break the conversation.
-    // Let the model decide what to do.
-    if (toolCallResult.isError) {
-      logger.error(
-        {
-          conversationId,
-          error: toolCallResult.content,
-          messageId,
-          toolName: toolConfiguration.originalName,
-          workspaceId: auth.getNonNullableWorkspace().sId,
-        },
-        `Error calling MCP tool in tryCallMCPTool().`
-      );
-    }
+    // We do not check toolCallResult.isError here and raise an error if true as this would break
+    // the conversation.
+    // Instead, we let the model decide what to do based on the content exposed.
 
     // Type inference is not working here because of them using passthrough in the zod schema.
     const content: CallToolResult["content"] = (toolCallResult.content ??


### PR DESCRIPTION
## Description

- Following up on [this thread](https://dust4ai.slack.com/archives/C09C8L42C8M/p1756896801937809), item 1 specifically.
- This PR removes one of two redundant logs, the one in `withToolLogging` and the one in `tryCallMCPTool`.
- This means we'll lose the logs on tool executions that are not tracked (i.e. `tracked` set to false or not using `withToolLogging` at all) but the error will always be still in db and this change matches the original intent of the wrapper (should've done this PR when adding the wrapper really).

## Tests

- Tested locally.

## Risk

- Low.

## Deploy Plan

- Deploy front.
