### PR TITLE
[connectors] Fix API validation on Confluence folders

### DIFF
--- a/connectors/src/connectors/confluence/lib/confluence_client.ts
+++ b/connectors/src/connectors/confluence/lib/confluence_client.ts
@@ -47,7 +47,12 @@ const ConfluencePageCodec = t.intersection([
   t.type({
     createdAt: t.string,
     parentId: t.union([t.string, t.null]),
-    parentType: t.union([t.literal("page"), t.literal("folder"), t.null]),
+    parentType: t.union([
+      t.literal("page"),
+      t.literal("folder"),
+      t.null,
+      t.undefined,
+    ]),
     id: t.string,
     title: t.string,
     spaceId: t.string,

--- a/connectors/src/connectors/confluence/lib/confluence_client.ts
+++ b/connectors/src/connectors/confluence/lib/confluence_client.ts
@@ -170,7 +170,12 @@ const ConfluenceFolderCodec = t.intersection([
     createdAt: t.union([t.string, t.number]),
     id: t.string,
     parentId: t.union([t.string, t.null]),
-    parentType: t.union([t.literal("page"), t.literal("folder"), t.null]),
+    parentType: t.union([
+      t.literal("page"),
+      t.literal("folder"),
+      t.null,
+      t.undefined,
+    ]),
     title: t.string,
     version: t.type({
       number: t.number,


### PR DESCRIPTION
## Description

- We have observed in prod a `parentType` being undefined for a Confluence folder, crashing the validation.
- We already handle `null` values, this PR will handle `undefined` values the same way.
- Temporal workflow [here](https://cloud.temporal.io/namespaces/dust-prod.gmnlm/workflows/confluence-sync-27089-space-2138342141-top-level-content-4541972856/01994fec-f2f9-732e-a47e-0702365c0106/history), log [here](https://app.datadoghq.eu/logs?query=%22Response%20validation%20failed%22&agg_m=count&agg_m_source=base&agg_t=count&cols=host%2Cservice&event=AwAAAZlRKMahy0AGAQAAABhBWmxSS05UUkFBQlo4a3hLUWdCTkl3QUQAAAAkZjE5OTUxMjktNzM0MS00ZGU3LWIyM2UtZTc4YjBjMzhhNjA1AABXyw&messageDisplay=inline&refresh_mode=sliding&storage=hot&stream_sort=desc&viz=stream&from_ts=1757928188812&to_ts=1758014588812&live=true).

## Tests

## Risk

- Low.

## Deploy Plan

- Deploy connectors.
