### PR TITLE
[front] Enhance `find_tags` tool description to clarify usage

### DIFF
--- a/front/lib/actions/mcp_internal_actions/tools/tags/find_tags.ts
+++ b/front/lib/actions/mcp_internal_actions/tools/tags/find_tags.ts
@@ -41,9 +41,9 @@ export function registerFindTagsTool(
     `Find exact matching labels (also called tags).` +
     "Restricting or excluding content succeeds only with existing labels. " +
     "Searching without verifying labels first typically returns no results." +
-    "The output of this tool can typically be used in tagsIn (if we want to " +
-    "restrict the search to specific tags) or tagsNot (if we want to exclude " +
-    "specific tags) parameters.";
+    "The output of this tool can typically be used in `tagsIn` (if we want " +
+    "to restrict the search to specific tags) or `tagsNot` (if we want to " +
+    "exclude specific tags) parameters.";
   const toolDescription = extraDescription
     ? baseDescription + "\n" + extraDescription
     : baseDescription;

--- a/front/lib/actions/mcp_internal_actions/tools/tags/find_tags.ts
+++ b/front/lib/actions/mcp_internal_actions/tools/tags/find_tags.ts
@@ -40,7 +40,10 @@ export function registerFindTagsTool(
   const baseDescription =
     `Find exact matching labels (also called tags).` +
     "Restricting or excluding content succeeds only with existing labels. " +
-    "Searching without verifying labels first typically returns no results.";
+    "Searching without verifying labels first typically returns no results." +
+    "The output of this tool can typically be used in tagsIn (if we want to " +
+    "restrict the search to specific tags) or tagsNot (if we want to exclude " +
+    "specific tags) parameters.";
   const toolDescription = extraDescription
     ? baseDescription + "\n" + extraDescription
     : baseDescription;


### PR DESCRIPTION
## Description

- Part of https://github.com/dust-tt/tasks/issues/3557.
- Observed a few occurrences of tags being correctly found but not used correctly as `tagsIn` in the subsequent search.
- Example [here](https://dust.tt/poke/WZ6RmsWE7o/conversations/Oc8QMwsrhW).
- This PR improves the description to hint at this usage.

## Tests

- Tested locally, did not actually observe any change (already worked fine for me).

## Risk

- Low, only a change in description.

## Deploy Plan

- Deploy front.
