### PR TITLE
Support for showing configurable tools in JIT if they have default values set

### DIFF
--- a/front/components/agent_builder/AgentBuilderFormContext.tsx
+++ b/front/components/agent_builder/AgentBuilderFormContext.tsx
@@ -98,7 +98,7 @@ const baseActionSchema = z.object({
   id: z.string(),
   name: z.string(),
   description: z.string(),
-  noConfigurationRequired: z.boolean().optional(),
+  configurable: z.boolean().optional(),
 });
 
 const TAG_KINDS = z.union([z.literal("standard"), z.literal("protected")]);

--- a/front/components/agent_builder/capabilities/AgentBuilderCapabilitiesBlock.tsx
+++ b/front/components/agent_builder/capabilities/AgentBuilderCapabilitiesBlock.tsx
@@ -204,9 +204,9 @@ export function AgentBuilderCapabilitiesBlock({
       setKnowledgeAction({ action, index });
     } else {
       setDialogMode(
-        action.noConfigurationRequired
-          ? { type: "info", action, source: "addedTool" }
-          : { type: "edit", action, index }
+        action.configurable
+          ? { type: "edit", action, index }
+          : { type: "info", action, source: "addedTool" }
       );
     }
   };
@@ -227,7 +227,7 @@ export function AgentBuilderCapabilitiesBlock({
     setKnowledgeAction({
       action: {
         ...action,
-        noConfigurationRequired: false, // it's always required for knowledge
+        configurable: true, // it's always required for knowledge
       },
       index: null,
     });

--- a/front/components/agent_builder/capabilities/mcp/MCPServerSelectionPage.tsx
+++ b/front/components/agent_builder/capabilities/mcp/MCPServerSelectionPage.tsx
@@ -55,7 +55,7 @@ function MCPServerCard({
   onToolInfoClick,
 }: MCPServerCardProps) {
   const requirement = getMCPServerToolsConfigurations(view);
-  const canAdd = requirement.noRequirement ? !isSelected : true;
+  const canAdd = requirement.configurable ? true : !isSelected;
 
   const icon = isCustomServerIconType(view.server.icon)
     ? ActionIcons[view.server.icon]

--- a/front/components/agent_builder/capabilities/mcp/MCPServerSelectionPage.tsx
+++ b/front/components/agent_builder/capabilities/mcp/MCPServerSelectionPage.tsx
@@ -55,7 +55,7 @@ function MCPServerCard({
   onToolInfoClick,
 }: MCPServerCardProps) {
   const requirement = getMCPServerToolsConfigurations(view);
-  const canAdd = requirement.configurable ? true : !isSelected;
+  const canAdd = requirement.configurable !== "no" ? true : !isSelected;
 
   const icon = isCustomServerIconType(view.server.icon)
     ? ActionIcons[view.server.icon]

--- a/front/components/agent_builder/capabilities/mcp/MCPServerViewsSheet.tsx
+++ b/front/components/agent_builder/capabilities/mcp/MCPServerViewsSheet.tsx
@@ -371,7 +371,7 @@ export function MCPServerViewsSheet({
     const tool = { type: "MCP", view: mcpServerView } satisfies SelectedTool;
     const requirement = getMCPServerToolsConfigurations(mcpServerView);
 
-    if (requirement.configurable) {
+    if (requirement.configurable !== "no") {
       const action = getDefaultMCPAction(mcpServerView);
       const isReasoning = requirement.mayRequireReasoningConfiguration;
 

--- a/front/components/agent_builder/capabilities/mcp/MCPServerViewsSheet.tsx
+++ b/front/components/agent_builder/capabilities/mcp/MCPServerViewsSheet.tsx
@@ -371,7 +371,7 @@ export function MCPServerViewsSheet({
     const tool = { type: "MCP", view: mcpServerView } satisfies SelectedTool;
     const requirement = getMCPServerToolsConfigurations(mcpServerView);
 
-    if (!requirement.noRequirement) {
+    if (requirement.configurable) {
       const action = getDefaultMCPAction(mcpServerView);
       const isReasoning = requirement.mayRequireReasoningConfiguration;
 

--- a/front/components/agent_builder/capabilities/mcp/MCPServerViewsSheet.tsx
+++ b/front/components/agent_builder/capabilities/mcp/MCPServerViewsSheet.tsx
@@ -192,7 +192,7 @@ export function MCPServerViewsSheet({
       );
 
       if (selectedAction) {
-        return selectedAction.noConfigurationRequired; // Should filter out if not configurable
+        return !selectedAction.configurable; // Should filter out if not configurable
       }
 
       return false;
@@ -468,7 +468,7 @@ export function MCPServerViewsSheet({
             configuration: null,
             name: DEFAULT_DATA_VISUALIZATION_NAME,
             description: DEFAULT_DATA_VISUALIZATION_DESCRIPTION,
-            noConfigurationRequired: true,
+            configurable: false,
           };
         } else {
           return tool.configuredAction || getDefaultMCPAction(tool.view);
@@ -598,7 +598,7 @@ export function MCPServerViewsSheet({
                 <MCPActionHeader
                   action={configurationTool}
                   mcpServerView={mcpServerView}
-                  allowNameEdit={!configurationTool.noConfigurationRequired}
+                  allowNameEdit={configurationTool.configurable}
                 />
 
                 {toolsConfigurations.mayRequireReasoningConfiguration && (

--- a/front/components/agent_builder/capabilities/mcp/utils/formDefaults.test.ts
+++ b/front/components/agent_builder/capabilities/mcp/utils/formDefaults.test.ts
@@ -98,7 +98,7 @@ describe("getDefaultConfiguration", () => {
         enumConfigurations: {},
         listConfigurations: {},
         mayRequireDustAppConfiguration: false,
-        noRequirement: false,
+        configurationNotObligatory: false,
         configurable: true,
       });
 
@@ -130,7 +130,7 @@ describe("getDefaultConfiguration", () => {
           enumConfigurations: {},
           listConfigurations: {},
           mayRequireDustAppConfiguration: false,
-          noRequirement: false,
+          configurationNotObligatory: false,
         configurable: true,
         });
 
@@ -170,7 +170,7 @@ describe("getDefaultConfiguration", () => {
           enumConfigurations: {},
           listConfigurations: {},
           mayRequireDustAppConfiguration: false,
-          noRequirement: false,
+          configurationNotObligatory: false,
           configurable: true,
         });
 
@@ -198,7 +198,7 @@ describe("getDefaultConfiguration", () => {
           enumConfigurations: {},
           listConfigurations: {},
           mayRequireDustAppConfiguration: false,
-          noRequirement: false,
+          configurationNotObligatory: false,
           configurable: true,
         });
 
@@ -237,7 +237,7 @@ describe("getDefaultConfiguration", () => {
           },
           listConfigurations: {},
           mayRequireDustAppConfiguration: false,
-          noRequirement: false,
+          configurationNotObligatory: false,
           configurable: true,
         });
 
@@ -276,7 +276,7 @@ describe("getDefaultConfiguration", () => {
           },
           listConfigurations: {},
           mayRequireDustAppConfiguration: false,
-          noRequirement: false,
+          configurationNotObligatory: false,
           configurable: true,
         });
 
@@ -313,7 +313,7 @@ describe("getDefaultConfiguration", () => {
           },
           listConfigurations: {},
           mayRequireDustAppConfiguration: false,
-          noRequirement: false,
+          configurationNotObligatory: false,
           configurable: true,
         });
 
@@ -355,7 +355,7 @@ describe("getDefaultConfiguration", () => {
             },
           },
           mayRequireDustAppConfiguration: false,
-          noRequirement: false,
+          configurationNotObligatory: false,
           configurable: true,
         });
 
@@ -399,7 +399,7 @@ describe("getDefaultConfiguration", () => {
           enumConfigurations: {},
           listConfigurations: {},
           mayRequireDustAppConfiguration: false,
-          noRequirement: false,
+          configurationNotObligatory: false,
           configurable: true,
         });
 
@@ -434,7 +434,7 @@ describe("getDefaultConfiguration", () => {
           enumConfigurations: {},
           listConfigurations: {},
           mayRequireDustAppConfiguration: false,
-          noRequirement: false,
+          configurationNotObligatory: false,
           configurable: true,
         });
 
@@ -481,7 +481,7 @@ describe("getDefaultConfiguration", () => {
             },
           },
           mayRequireDustAppConfiguration: false,
-          noRequirement: false,
+          configurationNotObligatory: false,
           configurable: true,
         });
 
@@ -553,7 +553,7 @@ describe("getDefaultConfiguration", () => {
             },
           },
           mayRequireDustAppConfiguration: false,
-          noRequirement: false,
+          configurationNotObligatory: false,
           configurable: true,
         });
 
@@ -622,7 +622,7 @@ describe("getDefaultConfiguration", () => {
             },
           },
           mayRequireDustAppConfiguration: false,
-          noRequirement: false,
+          configurationNotObligatory: false,
           configurable: true,
         });
 
@@ -763,7 +763,7 @@ describe("Analysis: Why strings and numbers don't get defaults", () => {
         enumConfigurations: {},
         listConfigurations: {},
         mayRequireDustAppConfiguration: false,
-        noRequirement: false,
+        configurationNotObligatory: false,
         configurable: true,
       });
 

--- a/front/components/agent_builder/capabilities/mcp/utils/formDefaults.test.ts
+++ b/front/components/agent_builder/capabilities/mcp/utils/formDefaults.test.ts
@@ -131,7 +131,7 @@ describe("getDefaultConfiguration", () => {
           listConfigurations: {},
           mayRequireDustAppConfiguration: false,
           configurationNotObligatory: false,
-        configurable: true,
+          configurable: true,
         });
 
         const result = getDefaultConfiguration(mockMCPServerView);

--- a/front/components/agent_builder/capabilities/mcp/utils/formDefaults.test.ts
+++ b/front/components/agent_builder/capabilities/mcp/utils/formDefaults.test.ts
@@ -98,8 +98,7 @@ describe("getDefaultConfiguration", () => {
         enumConfigurations: {},
         listConfigurations: {},
         mayRequireDustAppConfiguration: false,
-        configurationNotObligatory: false,
-        configurable: true,
+        configurable: "optional",
       });
 
       const result = getDefaultConfiguration(mockMCPServerView);
@@ -130,8 +129,7 @@ describe("getDefaultConfiguration", () => {
           enumConfigurations: {},
           listConfigurations: {},
           mayRequireDustAppConfiguration: false,
-          configurationNotObligatory: false,
-          configurable: true,
+          configurable: "optional",
         });
 
         const result = getDefaultConfiguration(mockMCPServerView);
@@ -170,8 +168,7 @@ describe("getDefaultConfiguration", () => {
           enumConfigurations: {},
           listConfigurations: {},
           mayRequireDustAppConfiguration: false,
-          configurationNotObligatory: false,
-          configurable: true,
+          configurable: "optional",
         });
 
         const result = getDefaultConfiguration(mockMCPServerView);
@@ -198,8 +195,7 @@ describe("getDefaultConfiguration", () => {
           enumConfigurations: {},
           listConfigurations: {},
           mayRequireDustAppConfiguration: false,
-          configurationNotObligatory: false,
-          configurable: true,
+          configurable: "optional",
         });
 
         const result = getDefaultConfiguration(mockMCPServerView);
@@ -237,8 +233,7 @@ describe("getDefaultConfiguration", () => {
           },
           listConfigurations: {},
           mayRequireDustAppConfiguration: false,
-          configurationNotObligatory: false,
-          configurable: true,
+          configurable: "optional",
         });
 
         const result = getDefaultConfiguration(mockMCPServerView);
@@ -276,8 +271,7 @@ describe("getDefaultConfiguration", () => {
           },
           listConfigurations: {},
           mayRequireDustAppConfiguration: false,
-          configurationNotObligatory: false,
-          configurable: true,
+          configurable: "optional",
         });
 
         const result = getDefaultConfiguration(mockMCPServerView);
@@ -313,8 +307,7 @@ describe("getDefaultConfiguration", () => {
           },
           listConfigurations: {},
           mayRequireDustAppConfiguration: false,
-          configurationNotObligatory: false,
-          configurable: true,
+          configurable: "optional",
         });
 
         const result = getDefaultConfiguration(mockMCPServerView);
@@ -355,8 +348,7 @@ describe("getDefaultConfiguration", () => {
             },
           },
           mayRequireDustAppConfiguration: false,
-          configurationNotObligatory: false,
-          configurable: true,
+          configurable: "optional",
         });
 
         const result = getDefaultConfiguration(mockMCPServerView);
@@ -399,8 +391,7 @@ describe("getDefaultConfiguration", () => {
           enumConfigurations: {},
           listConfigurations: {},
           mayRequireDustAppConfiguration: false,
-          configurationNotObligatory: false,
-          configurable: true,
+          configurable: "optional",
         });
 
         const result = getDefaultConfiguration(mockMCPServerView);
@@ -434,8 +425,7 @@ describe("getDefaultConfiguration", () => {
           enumConfigurations: {},
           listConfigurations: {},
           mayRequireDustAppConfiguration: false,
-          configurationNotObligatory: false,
-          configurable: true,
+          configurable: "optional",
         });
 
         const result = getDefaultConfiguration(mockMCPServerView);
@@ -481,8 +471,7 @@ describe("getDefaultConfiguration", () => {
             },
           },
           mayRequireDustAppConfiguration: false,
-          configurationNotObligatory: false,
-          configurable: true,
+          configurable: "optional",
         });
 
         const result = getDefaultConfiguration(mockMCPServerView);
@@ -553,8 +542,7 @@ describe("getDefaultConfiguration", () => {
             },
           },
           mayRequireDustAppConfiguration: false,
-          configurationNotObligatory: false,
-          configurable: true,
+          configurable: "optional",
         });
 
         const result = getDefaultConfiguration(mockMCPServerView);
@@ -622,8 +610,7 @@ describe("getDefaultConfiguration", () => {
             },
           },
           mayRequireDustAppConfiguration: false,
-          configurationNotObligatory: false,
-          configurable: true,
+          configurable: "optional",
         });
 
         const result = getDefaultConfiguration(mockMCPServerView);
@@ -763,8 +750,7 @@ describe("Analysis: Why strings and numbers don't get defaults", () => {
         enumConfigurations: {},
         listConfigurations: {},
         mayRequireDustAppConfiguration: false,
-        configurationNotObligatory: false,
-        configurable: true,
+        configurable: "optional",
       });
 
       const result = getDefaultConfiguration(mockMCPServerView);

--- a/front/components/agent_builder/capabilities/mcp/utils/formDefaults.test.ts
+++ b/front/components/agent_builder/capabilities/mcp/utils/formDefaults.test.ts
@@ -98,7 +98,8 @@ describe("getDefaultConfiguration", () => {
         enumConfigurations: {},
         listConfigurations: {},
         mayRequireDustAppConfiguration: false,
-        noRequirement: true,
+        noRequirement: false,
+        configurable: true,
       });
 
       const result = getDefaultConfiguration(mockMCPServerView);
@@ -130,6 +131,7 @@ describe("getDefaultConfiguration", () => {
           listConfigurations: {},
           mayRequireDustAppConfiguration: false,
           noRequirement: false,
+        configurable: true,
         });
 
         const result = getDefaultConfiguration(mockMCPServerView);
@@ -169,6 +171,7 @@ describe("getDefaultConfiguration", () => {
           listConfigurations: {},
           mayRequireDustAppConfiguration: false,
           noRequirement: false,
+          configurable: true,
         });
 
         const result = getDefaultConfiguration(mockMCPServerView);
@@ -195,7 +198,8 @@ describe("getDefaultConfiguration", () => {
           enumConfigurations: {},
           listConfigurations: {},
           mayRequireDustAppConfiguration: false,
-          noRequirement: true,
+          noRequirement: false,
+          configurable: true,
         });
 
         const result = getDefaultConfiguration(mockMCPServerView);
@@ -234,6 +238,7 @@ describe("getDefaultConfiguration", () => {
           listConfigurations: {},
           mayRequireDustAppConfiguration: false,
           noRequirement: false,
+          configurable: true,
         });
 
         const result = getDefaultConfiguration(mockMCPServerView);
@@ -272,6 +277,7 @@ describe("getDefaultConfiguration", () => {
           listConfigurations: {},
           mayRequireDustAppConfiguration: false,
           noRequirement: false,
+          configurable: true,
         });
 
         const result = getDefaultConfiguration(mockMCPServerView);
@@ -308,6 +314,7 @@ describe("getDefaultConfiguration", () => {
           listConfigurations: {},
           mayRequireDustAppConfiguration: false,
           noRequirement: false,
+          configurable: true,
         });
 
         const result = getDefaultConfiguration(mockMCPServerView);
@@ -349,6 +356,7 @@ describe("getDefaultConfiguration", () => {
           },
           mayRequireDustAppConfiguration: false,
           noRequirement: false,
+          configurable: true,
         });
 
         const result = getDefaultConfiguration(mockMCPServerView);
@@ -392,6 +400,7 @@ describe("getDefaultConfiguration", () => {
           listConfigurations: {},
           mayRequireDustAppConfiguration: false,
           noRequirement: false,
+          configurable: true,
         });
 
         const result = getDefaultConfiguration(mockMCPServerView);
@@ -426,6 +435,7 @@ describe("getDefaultConfiguration", () => {
           listConfigurations: {},
           mayRequireDustAppConfiguration: false,
           noRequirement: false,
+          configurable: true,
         });
 
         const result = getDefaultConfiguration(mockMCPServerView);
@@ -472,6 +482,7 @@ describe("getDefaultConfiguration", () => {
           },
           mayRequireDustAppConfiguration: false,
           noRequirement: false,
+          configurable: true,
         });
 
         const result = getDefaultConfiguration(mockMCPServerView);
@@ -543,6 +554,7 @@ describe("getDefaultConfiguration", () => {
           },
           mayRequireDustAppConfiguration: false,
           noRequirement: false,
+          configurable: true,
         });
 
         const result = getDefaultConfiguration(mockMCPServerView);
@@ -611,6 +623,7 @@ describe("getDefaultConfiguration", () => {
           },
           mayRequireDustAppConfiguration: false,
           noRequirement: false,
+          configurable: true,
         });
 
         const result = getDefaultConfiguration(mockMCPServerView);
@@ -751,6 +764,7 @@ describe("Analysis: Why strings and numbers don't get defaults", () => {
         listConfigurations: {},
         mayRequireDustAppConfiguration: false,
         noRequirement: false,
+        configurable: true,
       });
 
       const result = getDefaultConfiguration(mockMCPServerView);

--- a/front/components/agent_builder/capabilities/mcp/utils/formValidation.ts
+++ b/front/components/agent_builder/capabilities/mcp/utils/formValidation.ts
@@ -33,7 +33,7 @@ export function validateMCPActionConfiguration(
   try {
     const toolsConfigurations = getMCPServerToolsConfigurations(serverView);
 
-    if (toolsConfigurations.noRequirement) {
+    if (!toolsConfigurations.configurable) {
       return { isValid: true };
     }
 

--- a/front/components/agent_builder/capabilities/mcp/utils/formValidation.ts
+++ b/front/components/agent_builder/capabilities/mcp/utils/formValidation.ts
@@ -33,7 +33,7 @@ export function validateMCPActionConfiguration(
   try {
     const toolsConfigurations = getMCPServerToolsConfigurations(serverView);
 
-    if (!toolsConfigurations.configurable) {
+    if (toolsConfigurations.configurable === "no") {
       return { isValid: true };
     }
 

--- a/front/components/agent_builder/capabilities/usePresetActionHandler.ts
+++ b/front/components/agent_builder/capabilities/usePresetActionHandler.ts
@@ -106,7 +106,7 @@ export function usePresetActionHandler({
 
     if (isKnowledgeTemplateAction(presetActionToAdd)) {
       setKnowledgeAction({
-        action: { ...action, noConfigurationRequired: false },
+        action: { ...action, configurable: false },
         index: null,
         presetData: presetActionToAdd,
       });

--- a/front/components/agent_builder/get_spaceid_to_actions_map.test.ts
+++ b/front/components/agent_builder/get_spaceid_to_actions_map.test.ts
@@ -16,7 +16,7 @@ const createMockAction = (
   configuration: null,
   name,
   description: `Description for ${name}`,
-  noConfigurationRequired: true,
+  configurable: false,
 });
 
 const createMockMCPAction = (
@@ -42,7 +42,7 @@ const createMockMCPAction = (
     jsonSchema: null,
     _jsonSchemaString: null,
   },
-  noConfigurationRequired: false,
+  configurable: true,
 });
 
 const createMockMCPServerView = (

--- a/front/components/agent_builder/types.ts
+++ b/front/components/agent_builder/types.ts
@@ -187,7 +187,7 @@ export function getDefaultMCPAction(
         : mcpServerView
           ? getMcpServerViewDescription(mcpServerView)
           : "",
-    configurable: toolsConfigurations.configurable,
+    configurable: toolsConfigurations.configurable !== "no",
   };
 }
 

--- a/front/components/agent_builder/types.ts
+++ b/front/components/agent_builder/types.ts
@@ -187,7 +187,7 @@ export function getDefaultMCPAction(
         : mcpServerView
           ? getMcpServerViewDescription(mcpServerView)
           : "",
-    noConfigurationRequired: !toolsConfigurations.configurable,
+    noConfigurationRequired: toolsConfigurations.noRequirement, // TODO : rename and change downstream
   };
 }
 

--- a/front/components/agent_builder/types.ts
+++ b/front/components/agent_builder/types.ts
@@ -187,7 +187,7 @@ export function getDefaultMCPAction(
         : mcpServerView
           ? getMcpServerViewDescription(mcpServerView)
           : "",
-    noConfigurationRequired: toolsConfigurations.noRequirement,
+    noConfigurationRequired: !toolsConfigurations.configurable,
   };
 }
 

--- a/front/components/agent_builder/types.ts
+++ b/front/components/agent_builder/types.ts
@@ -168,7 +168,7 @@ export const capabilityFormSchema = z
     return true;
   });
 
-export function getDefaultMCPAction(
+export function getDefaultMCPxAction(
   mcpServerView?: MCPServerViewType
 ): AgentBuilderAction {
   const toolsConfigurations = getMCPServerToolsConfigurations(mcpServerView);
@@ -187,7 +187,7 @@ export function getDefaultMCPAction(
         : mcpServerView
           ? getMcpServerViewDescription(mcpServerView)
           : "",
-    noConfigurationRequired: toolsConfigurations.noRequirement, // TODO : rename and change downstream
+    configurable: toolsConfigurations.configurable,
   };
 }
 

--- a/front/components/agent_builder/types.ts
+++ b/front/components/agent_builder/types.ts
@@ -168,7 +168,7 @@ export const capabilityFormSchema = z
     return true;
   });
 
-export function getDefaultMCPxAction(
+export function getDefaultMCPAction(
   mcpServerView?: MCPServerViewType
 ): AgentBuilderAction {
   const toolsConfigurations = getMCPServerToolsConfigurations(mcpServerView);

--- a/front/components/assistant/ToolsPicker.tsx
+++ b/front/components/assistant/ToolsPicker.tsx
@@ -79,7 +79,7 @@ export function ToolsPicker({
     ].filter(
       (v) =>
         // Only tools that do not require any configuration can be enabled directly in a conversation.
-        getMCPServerToolsConfigurations(v).noRequirement &&
+        getMCPServerToolsConfigurations(v).configurationNotObligatory &&
         (searchText.length === 0 ||
           getMcpServerViewDisplayName(v)
             .toLowerCase()

--- a/front/components/assistant/ToolsPicker.tsx
+++ b/front/components/assistant/ToolsPicker.tsx
@@ -79,7 +79,7 @@ export function ToolsPicker({
     ].filter(
       (v) =>
         // Only tools that do not require any configuration can be enabled directly in a conversation.
-        getMCPServerToolsConfigurations(v).configurationNotObligatory &&
+        getMCPServerToolsConfigurations(v).configurable !== "required" &&
         (searchText.length === 0 ||
           getMcpServerViewDisplayName(v)
             .toLowerCase()

--- a/front/components/assistant_builder/types.ts
+++ b/front/components/assistant_builder/types.ts
@@ -136,7 +136,7 @@ export function getDefaultMCPServerActionConfiguration(
         : mcpServerView
           ? getMcpServerViewDescription(mcpServerView)
           : "",
-    noConfigurationRequired: toolsConfigurations.noRequirement,
+    noConfigurationRequired: toolsConfigurations.noRequirement, // TODO : rename and change downstream
   };
 }
 

--- a/front/components/assistant_builder/types.ts
+++ b/front/components/assistant_builder/types.ts
@@ -136,7 +136,7 @@ export function getDefaultMCPServerActionConfiguration(
         : mcpServerView
           ? getMcpServerViewDescription(mcpServerView)
           : "",
-    configurable: toolsConfigurations.configurable,
+    configurable: toolsConfigurations.configurable !== "no",
   };
 }
 

--- a/front/components/assistant_builder/types.ts
+++ b/front/components/assistant_builder/types.ts
@@ -44,7 +44,7 @@ export type AssistantBuilderMCPConfiguration = {
   configuration: AssistantBuilderMCPServerConfiguration;
   name: string;
   description: string;
-  noConfigurationRequired?: boolean;
+  configurable?: boolean;
 };
 
 export type AssistantBuilderMCPConfigurationWithId =
@@ -57,7 +57,7 @@ export interface AssistantBuilderDataVisualizationConfiguration {
   configuration: null;
   name: string;
   description: string;
-  noConfigurationRequired: true;
+  configurable: false;
 }
 
 // DATA_VISUALIZATION is not an action, but we need to show it in the UI like an action.
@@ -104,7 +104,7 @@ export function getDataVisualizationConfiguration(): AssistantBuilderDataVisuali
     configuration: null,
     name: DEFAULT_DATA_VISUALIZATION_NAME,
     description: DEFAULT_DATA_VISUALIZATION_DESCRIPTION,
-    noConfigurationRequired: true,
+    configurable: false,
   } satisfies AssistantBuilderDataVisualizationConfiguration;
 }
 
@@ -136,7 +136,7 @@ export function getDefaultMCPServerActionConfiguration(
         : mcpServerView
           ? getMcpServerViewDescription(mcpServerView)
           : "",
-    noConfigurationRequired: toolsConfigurations.noRequirement, // TODO : rename and change downstream
+    configurable: toolsConfigurations.configurable,
   };
 }
 

--- a/front/lib/actions/mcp_internal_actions/constants.ts
+++ b/front/lib/actions/mcp_internal_actions/constants.ts
@@ -87,7 +87,8 @@ export const AVAILABLE_INTERNAL_MCP_SERVER_NAMES = [
   "outlook_calendar",
   "outlook",
   "primitive_types_debugger",
-  "single_tool_debugger",
+  "jit_tool_string_setting_debugger",
+  "jit_tool_datasource_setting_debugger",
   "reasoning",
   "run_agent",
   "run_dust_app",
@@ -1024,7 +1025,7 @@ The directive should be used to display a clickable version of the agent name in
       instructions: null,
     },
   },
-  single_tool_debugger: {
+  jit_tool_string_setting_debugger: {
     id: 1014,
     availability: "manual",
     allowMultipleInstances: false,
@@ -1036,10 +1037,32 @@ The directive should be used to display a clickable version of the agent name in
     tools_retry_policies: undefined,
     timeoutMs: undefined,
     serverInfo: {
-      name: "single_tool_debugger",
+      name: "jit_tool_string_setting_debugger",
       version: "1.0.0",
       description:
-        "Demo server with a single tool and one configurable setting.",
+        "Demo server to test if can be added to JIT even with configurable settings.",
+      icon: "ActionEmotionLaughIcon",
+      authorization: null,
+      documentationUrl: null,
+      instructions: null,
+    },
+  },
+  jit_tool_datasource_setting_debugger: {
+    id: 1015,
+    availability: "manual",
+    allowMultipleInstances: false,
+    isPreview: false,
+    isRestricted: ({ featureFlags }) => {
+      return !featureFlags.includes("dev_mcp_actions");
+    },
+    tools_stakes: undefined,
+    tools_retry_policies: undefined,
+    timeoutMs: undefined,
+    serverInfo: {
+      name: "jit_tool_datasource_setting_debugger",
+      version: "1.0.0",
+      description:
+        "Demo server to test if can be added to JIT even with configurable settings.",
       icon: "ActionEmotionLaughIcon",
       authorization: null,
       documentationUrl: null,

--- a/front/lib/actions/mcp_internal_actions/constants.ts
+++ b/front/lib/actions/mcp_internal_actions/constants.ts
@@ -87,6 +87,7 @@ export const AVAILABLE_INTERNAL_MCP_SERVER_NAMES = [
   "outlook_calendar",
   "outlook",
   "primitive_types_debugger",
+  "single_tool_debugger",
   "reasoning",
   "run_agent",
   "run_dust_app",
@@ -1017,6 +1018,28 @@ The directive should be used to display a clickable version of the agent name in
       version: "1.0.0",
       description:
         "Demo server showing a basic interaction with various configurable blocks.",
+      icon: "ActionEmotionLaughIcon",
+      authorization: null,
+      documentationUrl: null,
+      instructions: null,
+    },
+  },
+  single_tool_debugger: {
+    id: 1014,
+    availability: "manual",
+    allowMultipleInstances: false,
+    isPreview: false,
+    isRestricted: ({ featureFlags }) => {
+      return !featureFlags.includes("dev_mcp_actions");
+    },
+    tools_stakes: undefined,
+    tools_retry_policies: undefined,
+    timeoutMs: undefined,
+    serverInfo: {
+      name: "single_tool_debugger",
+      version: "1.0.0",
+      description:
+        "Demo server with a single tool and one configurable setting.",
       icon: "ActionEmotionLaughIcon",
       authorization: null,
       documentationUrl: null,

--- a/front/lib/actions/mcp_internal_actions/input_configuration.test.ts
+++ b/front/lib/actions/mcp_internal_actions/input_configuration.test.ts
@@ -369,6 +369,75 @@ describe("augmentInputsWithConfiguration", () => {
         },
       });
     });
+
+    it("should NOT augment when a partial model container exists (container present, missing required subfields)", () => {
+      const rawInputs = {
+        // Container present but invalid/partial: missing providerId, mimeType, etc.
+        model: { modelId: "gpt-4o" },
+      } as Record<string, unknown>;
+
+      const config = createBasicMCPConfiguration({
+        reasoningModel: {
+          modelId: "gpt-4o",
+          providerId: "openai",
+          temperature: 0.2,
+          reasoningEffort: "light",
+        },
+        inputSchema: {
+          type: "object",
+          properties: {
+            model:
+              ConfigurableToolInputJSONSchemas[
+                INTERNAL_MIME_TYPES.TOOL_INPUT.REASONING_MODEL
+              ],
+          },
+          required: ["model"],
+        },
+      });
+
+      const result = augmentInputsWithConfiguration({
+        owner: mockWorkspace,
+        rawInputs,
+        actionConfiguration: config,
+      });
+
+      // Current behavior: augmentation only reacts to top-level missing required properties.
+      // With a present (but invalid) container, no replacement occurs; the partial value is preserved.
+      expect(result).toEqual(rawInputs);
+    });
+
+    it("should NOT augment when an empty model object exists", () => {
+      const rawInputs = {
+        model: {},
+      } as Record<string, unknown>;
+
+      const config = createBasicMCPConfiguration({
+        reasoningModel: {
+          modelId: "gpt-4o",
+          providerId: "openai",
+          temperature: 0.5,
+          reasoningEffort: "medium",
+        },
+        inputSchema: {
+          type: "object",
+          properties: {
+            model:
+              ConfigurableToolInputJSONSchemas[
+                INTERNAL_MIME_TYPES.TOOL_INPUT.REASONING_MODEL
+              ],
+          },
+          required: ["model"],
+        },
+      });
+
+      const result = augmentInputsWithConfiguration({
+        owner: mockWorkspace,
+        rawInputs,
+        actionConfiguration: config,
+      });
+
+      expect(result).toEqual(rawInputs);
+    });
   });
 
   describe("NULLABLE_TIME_FRAME mime type", () => {

--- a/front/lib/actions/mcp_internal_actions/input_configuration.ts
+++ b/front/lib/actions/mcp_internal_actions/input_configuration.ts
@@ -561,6 +561,7 @@ export interface MCPServerToolsConfigurations {
   >;
   mayRequireDustAppConfiguration: boolean;
   noRequirement: boolean;
+  configurable: boolean;
 }
 
 export function getMCPServerToolsConfigurations(
@@ -582,6 +583,7 @@ export function getMCPServerToolsConfigurations(
       listConfigurations: {},
       mayRequireDustAppConfiguration: false,
       noRequirement: false,
+      configurable: true,
     };
   }
   const { server } = mcpServerView;
@@ -714,7 +716,7 @@ export function getMCPServerToolsConfigurations(
     ),
   }));
 
-  const enumConfigurations = Object.fromEntries(
+  const enumConfigurations: Record<string, { options: string[]; description?: string; default?: string }> = Object.fromEntries(
     Object.entries(
       findPathsToConfiguration({
         mcpServerView,
@@ -745,7 +747,7 @@ export function getMCPServerToolsConfigurations(
     })
   );
 
-  const listConfigurations = Object.fromEntries(
+  const listConfigurations: Record<string, { options: Record<string, string>; description?: string; values?: string[]; default?: string }> = Object.fromEntries(
     Object.entries(
       findPathsToConfiguration({
         mcpServerView,
@@ -808,6 +810,33 @@ export function getMCPServerToolsConfigurations(
       })
     ).length > 0;
 
+  // TODO: We'll handle the sources and tables later
+  const hasDefaultsForAllConfigurableValues = stringConfigurations.every(
+    (config) => config.default !== undefined
+  ) && numberConfigurations.every(
+    (config) => config.default !== undefined
+  ) && booleanConfigurations.every(
+    (config) => config.default !== undefined
+  ) && Object.values(enumConfigurations).every(
+    (config) => config.default !== undefined
+  ) && Object.values(listConfigurations).every(
+    (config) => config.default !== undefined
+  );
+
+  const configurable = mayRequireDataSourceConfiguration ||
+  mayRequireDataWarehouseConfiguration ||
+  mayRequireTableConfiguration ||
+  mayRequireChildAgentConfiguration ||
+  mayRequireReasoningConfiguration ||
+  mayRequireDustAppConfiguration ||
+  mayRequireTimeFrameConfiguration ||
+  mayRequireJsonSchemaConfiguration || 
+  stringConfigurations.length > 0 ||
+  numberConfigurations.length > 0 ||
+  booleanConfigurations.length > 0 ||
+  Object.keys(enumConfigurations).length > 0 ||
+  Object.keys(listConfigurations).length > 0;
+
   return {
     mayRequireDataSourceConfiguration,
     mayRequireDataWarehouseConfiguration,
@@ -822,19 +851,8 @@ export function getMCPServerToolsConfigurations(
     enumConfigurations,
     listConfigurations,
     mayRequireDustAppConfiguration,
-    noRequirement:
-      !mayRequireDataSourceConfiguration &&
-      !mayRequireDataWarehouseConfiguration &&
-      !mayRequireTableConfiguration &&
-      !mayRequireChildAgentConfiguration &&
-      !mayRequireReasoningConfiguration &&
-      !mayRequireDustAppConfiguration &&
-      !mayRequireTimeFrameConfiguration &&
-      stringConfigurations.length <= 0 &&
-      numberConfigurations.length <= 0 &&
-      booleanConfigurations.length <= 0 &&
-      Object.keys(enumConfigurations).length <= 0 &&
-      Object.keys(listConfigurations).length <= 0,
+    noRequirement: !configurable && hasDefaultsForAllConfigurableValues,
+    configurable,
   };
 }
 

--- a/front/lib/actions/mcp_internal_actions/input_configuration.ts
+++ b/front/lib/actions/mcp_internal_actions/input_configuration.ts
@@ -716,7 +716,10 @@ export function getMCPServerToolsConfigurations(
     ),
   }));
 
-  const enumConfigurations: Record<string, { options: string[]; description?: string; default?: string }> = Object.fromEntries(
+  const enumConfigurations: Record<
+    string,
+    { options: string[]; description?: string; default?: string }
+  > = Object.fromEntries(
     Object.entries(
       findPathsToConfiguration({
         mcpServerView,
@@ -747,7 +750,15 @@ export function getMCPServerToolsConfigurations(
     })
   );
 
-  const listConfigurations: Record<string, { options: Record<string, string>; description?: string; values?: string[]; default?: string }> = Object.fromEntries(
+  const listConfigurations: Record<
+    string,
+    {
+      options: Record<string, string>;
+      description?: string;
+      values?: string[];
+      default?: string;
+    }
+  > = Object.fromEntries(
     Object.entries(
       findPathsToConfiguration({
         mcpServerView,
@@ -811,31 +822,31 @@ export function getMCPServerToolsConfigurations(
     ).length > 0;
 
   // TODO: We'll handle the sources and tables later
-  const hasDefaultsForAllConfigurableValues = stringConfigurations.every(
-    (config) => config.default !== undefined
-  ) && numberConfigurations.every(
-    (config) => config.default !== undefined
-  ) && booleanConfigurations.every(
-    (config) => config.default !== undefined
-  ) && Object.values(enumConfigurations).every(
-    (config) => config.default !== undefined
-  ) && Object.values(listConfigurations).every(
-    (config) => config.default !== undefined
-  );
+  const hasDefaultsForAllConfigurableValues =
+    stringConfigurations.every((config) => config.default !== undefined) &&
+    numberConfigurations.every((config) => config.default !== undefined) &&
+    booleanConfigurations.every((config) => config.default !== undefined) &&
+    Object.values(enumConfigurations).every(
+      (config) => config.default !== undefined
+    ) &&
+    Object.values(listConfigurations).every(
+      (config) => config.default !== undefined
+    );
 
-  const configurable = mayRequireDataSourceConfiguration ||
-  mayRequireDataWarehouseConfiguration ||
-  mayRequireTableConfiguration ||
-  mayRequireChildAgentConfiguration ||
-  mayRequireReasoningConfiguration ||
-  mayRequireDustAppConfiguration ||
-  mayRequireTimeFrameConfiguration ||
-  mayRequireJsonSchemaConfiguration || 
-  stringConfigurations.length > 0 ||
-  numberConfigurations.length > 0 ||
-  booleanConfigurations.length > 0 ||
-  Object.keys(enumConfigurations).length > 0 ||
-  Object.keys(listConfigurations).length > 0;
+  const configurable =
+    mayRequireDataSourceConfiguration ||
+    mayRequireDataWarehouseConfiguration ||
+    mayRequireTableConfiguration ||
+    mayRequireChildAgentConfiguration ||
+    mayRequireReasoningConfiguration ||
+    mayRequireDustAppConfiguration ||
+    mayRequireTimeFrameConfiguration ||
+    mayRequireJsonSchemaConfiguration ||
+    stringConfigurations.length > 0 ||
+    numberConfigurations.length > 0 ||
+    booleanConfigurations.length > 0 ||
+    Object.keys(enumConfigurations).length > 0 ||
+    Object.keys(listConfigurations).length > 0;
 
   return {
     mayRequireDataSourceConfiguration,
@@ -851,7 +862,8 @@ export function getMCPServerToolsConfigurations(
     enumConfigurations,
     listConfigurations,
     mayRequireDustAppConfiguration,
-    configurationNotObligatory: !configurable || hasDefaultsForAllConfigurableValues,
+    configurationNotObligatory:
+      !configurable || hasDefaultsForAllConfigurableValues,
     configurable,
   };
 }

--- a/front/lib/actions/mcp_internal_actions/input_configuration.ts
+++ b/front/lib/actions/mcp_internal_actions/input_configuration.ts
@@ -560,8 +560,7 @@ export interface MCPServerToolsConfigurations {
     }
   >;
   mayRequireDustAppConfiguration: boolean;
-  configurationNotObligatory: boolean;
-  configurable: boolean;
+  configurable: "no" | "optional" | "required";
 }
 
 export function getMCPServerToolsConfigurations(
@@ -582,8 +581,7 @@ export function getMCPServerToolsConfigurations(
       enumConfigurations: {},
       listConfigurations: {},
       mayRequireDustAppConfiguration: false,
-      configurationNotObligatory: false,
-      configurable: true,
+      configurable: "optional",
     };
   }
   const { server } = mcpServerView;
@@ -833,7 +831,9 @@ export function getMCPServerToolsConfigurations(
       (config) => config.default !== undefined
     );
 
-  const configurable =
+  let configurable: "no" | "optional" | "required" = "no";
+
+  const isConfigurable =
     mayRequireDataSourceConfiguration ||
     mayRequireDataWarehouseConfiguration ||
     mayRequireTableConfiguration ||
@@ -847,6 +847,16 @@ export function getMCPServerToolsConfigurations(
     booleanConfigurations.length > 0 ||
     Object.keys(enumConfigurations).length > 0 ||
     Object.keys(listConfigurations).length > 0;
+
+  if (isConfigurable) {
+    if (hasDefaultsForAllConfigurableValues) {
+      configurable = "optional";
+    } else {
+      configurable = "required";
+    }
+  } else {
+    configurable = "no";
+  }
 
   return {
     mayRequireDataSourceConfiguration,
@@ -862,8 +872,6 @@ export function getMCPServerToolsConfigurations(
     enumConfigurations,
     listConfigurations,
     mayRequireDustAppConfiguration,
-    configurationNotObligatory:
-      !configurable || hasDefaultsForAllConfigurableValues,
     configurable,
   };
 }

--- a/front/lib/actions/mcp_internal_actions/input_configuration.ts
+++ b/front/lib/actions/mcp_internal_actions/input_configuration.ts
@@ -560,7 +560,7 @@ export interface MCPServerToolsConfigurations {
     }
   >;
   mayRequireDustAppConfiguration: boolean;
-  noRequirement: boolean;
+  configurationNotObligatory: boolean;
   configurable: boolean;
 }
 
@@ -582,7 +582,7 @@ export function getMCPServerToolsConfigurations(
       enumConfigurations: {},
       listConfigurations: {},
       mayRequireDustAppConfiguration: false,
-      noRequirement: false,
+      configurationNotObligatory: false,
       configurable: true,
     };
   }
@@ -851,7 +851,7 @@ export function getMCPServerToolsConfigurations(
     enumConfigurations,
     listConfigurations,
     mayRequireDustAppConfiguration,
-    noRequirement: !configurable && hasDefaultsForAllConfigurableValues,
+    configurationNotObligatory: !configurable || hasDefaultsForAllConfigurableValues,
     configurable,
   };
 }

--- a/front/lib/actions/mcp_internal_actions/servers/index.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/index.ts
@@ -21,6 +21,8 @@ import { default as hubspotServer } from "@app/lib/actions/mcp_internal_actions/
 import { default as imageGenerationDallEServer } from "@app/lib/actions/mcp_internal_actions/servers/image_generation";
 import { default as includeDataServer } from "@app/lib/actions/mcp_internal_actions/servers/include";
 import { default as jiraServer } from "@app/lib/actions/mcp_internal_actions/servers/jira/server";
+import { default as jitToolDatasourceSettingDebuggerServer } from "@app/lib/actions/mcp_internal_actions/servers/jit_tool_datasource_setting_debugger";
+import { default as jitToolStringSettingDebuggerServer } from "@app/lib/actions/mcp_internal_actions/servers/jit_tool_string_setting_debugger";
 import { default as missingActionCatcherServer } from "@app/lib/actions/mcp_internal_actions/servers/missing_action_catcher";
 import { default as mondayServer } from "@app/lib/actions/mcp_internal_actions/servers/monday/server";
 import { default as notionServer } from "@app/lib/actions/mcp_internal_actions/servers/notion";
@@ -33,7 +35,6 @@ import { default as runAgentServer } from "@app/lib/actions/mcp_internal_actions
 import { default as dustAppServer } from "@app/lib/actions/mcp_internal_actions/servers/run_dust_app";
 import { default as salesforceServer } from "@app/lib/actions/mcp_internal_actions/servers/salesforce";
 import { default as searchServer } from "@app/lib/actions/mcp_internal_actions/servers/search";
-import { default as singleToolDebuggerServer } from "@app/lib/actions/mcp_internal_actions/servers/single_tool_debugger";
 import { default as slackServer } from "@app/lib/actions/mcp_internal_actions/servers/slack";
 import { default as slideshowServer } from "@app/lib/actions/mcp_internal_actions/servers/slideshow";
 import { default as tablesQueryServer } from "@app/lib/actions/mcp_internal_actions/servers/tables_query/server";
@@ -99,8 +100,10 @@ export async function getInternalMCPServer(
       return tablesQueryServerV2(auth, agentLoopContext);
     case "primitive_types_debugger":
       return primitiveTypesDebuggerServer();
-    case "single_tool_debugger":
-      return singleToolDebuggerServer();
+    case "jit_tool_string_setting_debugger":
+      return jitToolStringSettingDebuggerServer();
+    case "jit_tool_datasource_setting_debugger":
+      return jitToolDatasourceSettingDebuggerServer();
     case "think":
       return thinkServer();
     case "web_search_&_browse":

--- a/front/lib/actions/mcp_internal_actions/servers/index.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/index.ts
@@ -33,6 +33,7 @@ import { default as runAgentServer } from "@app/lib/actions/mcp_internal_actions
 import { default as dustAppServer } from "@app/lib/actions/mcp_internal_actions/servers/run_dust_app";
 import { default as salesforceServer } from "@app/lib/actions/mcp_internal_actions/servers/salesforce";
 import { default as searchServer } from "@app/lib/actions/mcp_internal_actions/servers/search";
+import { default as singleToolDebuggerServer } from "@app/lib/actions/mcp_internal_actions/servers/single_tool_debugger";
 import { default as slackServer } from "@app/lib/actions/mcp_internal_actions/servers/slack";
 import { default as slideshowServer } from "@app/lib/actions/mcp_internal_actions/servers/slideshow";
 import { default as tablesQueryServer } from "@app/lib/actions/mcp_internal_actions/servers/tables_query/server";
@@ -98,6 +99,8 @@ export async function getInternalMCPServer(
       return tablesQueryServerV2(auth, agentLoopContext);
     case "primitive_types_debugger":
       return primitiveTypesDebuggerServer();
+    case "single_tool_debugger":
+      return singleToolDebuggerServer();
     case "think":
       return thinkServer();
     case "web_search_&_browse":

--- a/front/lib/actions/mcp_internal_actions/servers/jit_tool_datasource_setting_debugger.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/jit_tool_datasource_setting_debugger.ts
@@ -6,28 +6,27 @@ import { ConfigurableToolInputSchemas } from "@app/lib/actions/mcp_internal_acti
 import { makeInternalMCPServer } from "@app/lib/actions/mcp_internal_actions/utils";
 
 function createServer(): McpServer {
-  const server = makeInternalMCPServer("single_tool_debugger");
+  const server = makeInternalMCPServer("jit_tool_datasource_setting_debugger");
 
   server.tool(
     "echo_with_config",
-    "Echo back the provided message along with a configurable setting.",
+    "Echo back the provided message along with configurable settings, including datasources.",
     {
       message: z.string().describe("Message to echo back"),
-      setting: ConfigurableToolInputSchemas[INTERNAL_MIME_TYPES.TOOL_INPUT.STRING]
-        .describe("A configurable setting included in the response")
-        .default({
-          value: "default_setting_value",
-          mimeType: INTERNAL_MIME_TYPES.TOOL_INPUT.STRING,
-        }),
+      datasources: ConfigurableToolInputSchemas[
+        INTERNAL_MIME_TYPES.TOOL_INPUT.DATA_SOURCE
+      ]
+        .describe("Optional list of datasources to use.")
+        .default([]),
     },
-    async ({ message, setting }) => {
+    async ({ message, datasources }) => {
       return {
         content: [
           {
             type: "text",
             text: `Echo: ${message} | Setting: ${
-              typeof setting === "string" ? setting : setting.value
-            }`,
+              typeof datasources === "string" ? datasources : datasources.values
+            } | Datasources: ${Array.isArray(datasources) ? datasources.length : 0}`,
           },
         ],
       };

--- a/front/lib/actions/mcp_internal_actions/servers/jit_tool_datasource_setting_debugger.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/jit_tool_datasource_setting_debugger.ts
@@ -37,5 +37,3 @@ function createServer(): McpServer {
 }
 
 export default createServer;
-
-

--- a/front/lib/actions/mcp_internal_actions/servers/jit_tool_string_setting_debugger.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/jit_tool_string_setting_debugger.ts
@@ -1,0 +1,42 @@
+import { INTERNAL_MIME_TYPES } from "@dust-tt/client";
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { z } from "zod";
+
+import { ConfigurableToolInputSchemas } from "@app/lib/actions/mcp_internal_actions/input_schemas";
+import { makeInternalMCPServer } from "@app/lib/actions/mcp_internal_actions/utils";
+
+function createServer(): McpServer {
+  const server = makeInternalMCPServer("jit_tool_string_setting_debugger");
+
+  server.tool(
+    "echo_with_config",
+    "Echo back the provided message along with a configurable setting.",
+    {
+      message: z.string().describe("Message to echo back"),
+      setting: ConfigurableToolInputSchemas[INTERNAL_MIME_TYPES.TOOL_INPUT.STRING]
+        .describe("A configurable setting included in the response")
+        .default({
+          value: "default_setting_value",
+          mimeType: INTERNAL_MIME_TYPES.TOOL_INPUT.STRING,
+        }),
+    },
+    async ({ message, setting }) => {
+      return {
+        content: [
+          {
+            type: "text",
+            text: `Echo: ${message} | Setting: ${
+              typeof setting === "string" ? setting : setting.value
+            }`,
+          },
+        ],
+      };
+    }
+  );
+
+  return server;
+}
+
+export default createServer;
+
+

--- a/front/lib/actions/mcp_internal_actions/servers/jit_tool_string_setting_debugger.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/jit_tool_string_setting_debugger.ts
@@ -13,7 +13,9 @@ function createServer(): McpServer {
     "Echo back the provided message along with a configurable setting.",
     {
       message: z.string().describe("Message to echo back"),
-      setting: ConfigurableToolInputSchemas[INTERNAL_MIME_TYPES.TOOL_INPUT.STRING]
+      setting: ConfigurableToolInputSchemas[
+        INTERNAL_MIME_TYPES.TOOL_INPUT.STRING
+      ]
         .describe("A configurable setting included in the response")
         .default({
           value: "default_setting_value",
@@ -38,5 +40,3 @@ function createServer(): McpServer {
 }
 
 export default createServer;
-
-

--- a/front/lib/actions/mcp_internal_actions/servers/single_tool_debugger.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/single_tool_debugger.ts
@@ -1,0 +1,42 @@
+import { INTERNAL_MIME_TYPES } from "@dust-tt/client";
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { z } from "zod";
+
+import { ConfigurableToolInputSchemas } from "@app/lib/actions/mcp_internal_actions/input_schemas";
+import { makeInternalMCPServer } from "@app/lib/actions/mcp_internal_actions/utils";
+
+function createServer(): McpServer {
+  const server = makeInternalMCPServer("single_tool_debugger");
+
+  server.tool(
+    "echo_with_config",
+    "Echo back the provided message along with a configurable setting.",
+    {
+      message: z.string().describe("Message to echo back"),
+      setting: ConfigurableToolInputSchemas[INTERNAL_MIME_TYPES.TOOL_INPUT.STRING]
+        .describe("A configurable setting included in the response")
+        .default({
+          value: "default_setting_value",
+          mimeType: INTERNAL_MIME_TYPES.TOOL_INPUT.STRING,
+        }),
+    },
+    async ({ message, setting }) => {
+      return {
+        content: [
+          {
+            type: "text",
+            text: `Echo: ${message} | Setting: ${
+              typeof setting === "string" ? setting : setting.value
+            }`,
+          },
+        ],
+      };
+    }
+  );
+
+  return server;
+}
+
+export default createServer;
+
+

--- a/front/lib/actions/mcp_internal_actions/servers/toolsets.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/toolsets.ts
@@ -62,8 +62,8 @@ const createServer = (
         )
         .filter(
           (mcpServerView) =>
-            getMCPServerToolsConfigurations(mcpServerView)
-              .configurationNotObligatory
+            getMCPServerToolsConfigurations(mcpServerView).configurable !==
+            "required"
         )
         .filter(
           (mcpServerView) =>

--- a/front/lib/actions/mcp_internal_actions/servers/toolsets.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/toolsets.ts
@@ -62,7 +62,7 @@ const createServer = (
         )
         .filter(
           (mcpServerView) =>
-            getMCPServerToolsConfigurations(mcpServerView).noRequirement
+            getMCPServerToolsConfigurations(mcpServerView).configurationNotObligatory
         )
         .filter(
           (mcpServerView) =>

--- a/front/lib/actions/mcp_internal_actions/servers/toolsets.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/toolsets.ts
@@ -62,7 +62,8 @@ const createServer = (
         )
         .filter(
           (mcpServerView) =>
-            getMCPServerToolsConfigurations(mcpServerView).configurationNotObligatory
+            getMCPServerToolsConfigurations(mcpServerView)
+              .configurationNotObligatory
         )
         .filter(
           (mcpServerView) =>


### PR DESCRIPTION
## Description

Changed `MCPServerToolsConfigurations` 's `noRequirement` to an enum parameter:

```ts
configurable: "no" | "optional" | "required";
```

Basically originally `noRequirement` was used for 2 different things: to mean that there are no config options for a server's tools, and to mean that it doesn't REQUIRE to be configured. This made sense BEFORE we added support for default values.

Now that this support exists, there are places where we need to know wether its **configurable** (i.e. regardless of if default values existing or not), and places where this configuration is **required** (which means if we HAVE default values then we don't NEED to configure anything).

This means for example that code for the Agent Builder would now use the `configurable !== "no"`, to know wether to display the configuration screen, whilst code for e.g. determining what tools to add to JIT or subagents (i.e. those that don't NEED to be configured) would use the `configurable !== "required"`.

This however impacts many places in the codebase. I have tried to be exhaustive and check all occurrences, read their context and determine which variant to keep in each context, i.e. configurable, or noRequirement.

ALSO since `configurable` is in the affirmative, whilst `noRequirement` was in the negative, a lot of these expressions have had to change from `true` to `false` and vice-versa. But I've attempted to check these many times and especially in ternary expressions or ifs to change things appropriately, and maintain the logic.

### Places where I changed `noRequirement` to `configurable`.

Here are the previous appearances of `noRequirement`:

- `front/components/agent_builder/capabilities/mcp/MCPServerSelectionPage.tsx:58`
changed to `configurable !== "no"` because it determines wether to show the configuration pane in the AgentBuilder down the line.

- `front/components/agent_builder/capabilities/mcp/MCPServerViewsSheet.tsx:374`
changed since this triggers the configuration flow and thus determines wether to show configuration or not.

- `front/lib/actions/mcp_internal_actions/servers/toolsets.ts:65`
changed to `configurable !== "required"` because it it used here for "on the fly" adding of tools.

- `front/components/assistant/ToolsPicker.tsx:82`
Same here, used to add tools to a conversation without config and thus used `configurable !== "required"`

- `front/components/agent_builder/capabilities/mcp/utils/formValidation.ts:36`
Checks wether configuration is needed or not, to know if we should early return and not need validation. This is therefore changed to `configurable !== "no"`

- `front/components/agent_builder/capabilities/mcp/utils/formDefaults.test.ts` (All occurrences)
Just added the missing `configurable !== "no"` option which wasn't really used in these tests.

These two are detailed more here since this cascaded: both occurences were to set a `noConfigurationRequired` parameter to types used elsewhere.
- `front/components/agent_builder/types.ts:171`
- `front/components/assistant_builder/types.ts:129`

I renamed these to `configurable: boolean` everywhere as that is what they were used for (i.e. not for the usecase of `configurable !== "required"` now).

## Tests

Ran all regular tests and they pass (including all the ones on `getMCPServerToolsConfigurations`).

I also created 2 new dev tools called `jit_tool_string_setting_debugger` & `jit_tool_datasource_setting_debugger` with only one configurable tool with one configurable setting it has a default value for and only one configurable tool with one configurable datasource it has a default value for. They now both appear in JIT even if configurable as they have default values.

## Risk

Mainly depends on how good I was at making all these changes, and how much our tests cover things because it may break configurability or JIT tool access if not properly done.

## Deploy Plan

Deploy front
