### PR TITLE
[front] Improve `find_tags` tool output when no match found

### DIFF
--- a/front/lib/actions/mcp_internal_actions/tools/tags/find_tags.ts
+++ b/front/lib/actions/mcp_internal_actions/tools/tags/find_tags.ts
@@ -123,6 +123,15 @@ export function registerFindTagsTool(
           }
         }
 
+        if (result.value.tags.length === 0) {
+          return new Ok([
+            {
+              type: "text",
+              text: "No labels found matching the search criteria.",
+            },
+          ]);
+        }
+
         return new Ok([
           {
             type: "text",


### PR DESCRIPTION
## Description

- This PR aims at making it more obvious for the model when no tags are found.

## Tests

## Risk

- Low.

## Deploy Plan

- Deploy front.
