### PR TITLE
[front] Add tag double search strategy to improve discoverability of uncommon tags

### DIFF
--- a/front/lib/actions/mcp_internal_actions/tools/tags/find_tags.ts
+++ b/front/lib/actions/mcp_internal_actions/tools/tags/find_tags.ts
@@ -16,7 +16,7 @@ import { concurrentExecutor } from "@app/lib/utils/async_utils";
 import logger from "@app/logger/logger";
 import { CoreAPI, Err, Ok, removeNulls } from "@app/types";
 
-const DEFAULT_SEARCH_LABELS_LIMIT = 10;
+const DEFAULT_SEARCH_LABELS_UPPER_LIMIT = 2000;
 
 export const findTagsSchema = {
   query: z
@@ -93,16 +93,31 @@ export function registerFindTagsTool(
           );
         }
 
+        const dataSourceViews = coreSearchArgs.map((arg) => arg.dataSourceView);
+
         const coreAPI = new CoreAPI(config.getCoreAPIConfig(), logger);
-        const result = await coreAPI.searchTags({
-          dataSourceViews: coreSearchArgs.map((arg) => arg.dataSourceView),
-          limit: DEFAULT_SEARCH_LABELS_LIMIT,
+        let result = await coreAPI.searchTags({
+          dataSourceViews,
           query,
           queryType: "match",
         });
 
         if (result.isErr()) {
           return new Err(new MCPError("Error searching for labels"));
+        }
+
+        if (result.value.tags.length === 0) {
+          // Performing an additional search with a higher limit to catch uncommon tags.
+          result = await coreAPI.searchTags({
+            dataSourceViews,
+            limit: DEFAULT_SEARCH_LABELS_UPPER_LIMIT,
+            query,
+            queryType: "match",
+          });
+
+          if (result.isErr()) {
+            return new Err(new MCPError("Error searching for labels"));
+          }
         }
 
         return new Ok([


### PR DESCRIPTION
## Description

- Part of https://github.com/dust-tt/tasks/issues/3557.
- This PR aims at improving the support for searching uncommon tags by performing a quick search with a low aggregation limit first, and then doing another slower search with a higher limit if no results were found.

## Tests

- Only saw a 12% increase in latency when jumping from a limit of 10 to 2000.

## Risk

- Increased latency due to the double search, but only occurs on uncommon tags.

## Deploy Plan

- Deploy front.
