### PR TITLE
[front] Apply `dust/enforce-client-types-in-public-api` eslint rule

### DIFF
--- a/front/lib/actions/mcp_internal_actions/servers/jira/jira_api_helper.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/jira/jira_api_helper.ts
@@ -1,5 +1,3 @@
-import type { Result } from "@dust-tt/client";
-import { Err, Ok } from "@dust-tt/client";
 import type { AuthInfo } from "@modelcontextprotocol/sdk/server/auth/types.js";
 import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
 import { markdownToAdf } from "marklassian";
@@ -45,7 +43,8 @@ import {
 } from "@app/lib/actions/mcp_internal_actions/servers/jira/types";
 import { makeMCPToolTextError } from "@app/lib/actions/mcp_internal_actions/utils";
 import logger from "@app/logger/logger";
-import { normalizeError } from "@app/types";
+import type { Result } from "@app/types";
+import { Err, normalizeError, Ok } from "@app/types";
 
 // Type guard to check if a value is an ADFDocument
 function isADFDocument(value: unknown): value is ADFDocument {

--- a/front/lib/actions/mcp_internal_actions/servers/run_agent/conversation.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/run_agent/conversation.ts
@@ -2,9 +2,7 @@ import type {
   ConversationPublicType,
   DustAPI,
   PublicPostContentFragmentRequestBody,
-  Result,
 } from "@dust-tt/client";
-import { Err, Ok } from "@dust-tt/client";
 
 import type { ChildAgentBlob } from "@app/lib/actions/mcp_internal_actions/servers/run_agent/types";
 import { isRunAgentResumeState } from "@app/lib/actions/mcp_internal_actions/servers/run_agent/types";
@@ -15,7 +13,12 @@ import {
 } from "@app/lib/api/assistant/conversation/attachments";
 import { listAttachments } from "@app/lib/api/assistant/jit_utils";
 import logger from "@app/logger/logger";
-import type { AgentConfigurationType, ConversationType } from "@app/types";
+import type {
+  AgentConfigurationType,
+  ConversationType,
+  Result,
+} from "@app/types";
+import { Err, Ok } from "@app/types";
 
 export async function getOrCreateConversation(
   api: DustAPI,

--- a/front/temporal/agent_loop/activities/run_model_and_create_actions_wrapper.ts
+++ b/front/temporal/agent_loop/activities/run_model_and_create_actions_wrapper.ts
@@ -2,8 +2,7 @@ import assert from "assert";
 
 import { isToolExecutionStatusFinal } from "@app/lib/actions/statuses";
 import { getRetryPolicyFromToolConfiguration } from "@app/lib/api/mcp";
-import type { AuthenticatorType } from "@app/lib/auth";
-import type { Authenticator } from "@app/lib/auth";
+import type { Authenticator, AuthenticatorType } from "@app/lib/auth";
 import { AgentMCPActionModel } from "@app/lib/models/assistant/actions/mcp";
 import { AgentStepContentModel } from "@app/lib/models/assistant/agent_step_content";
 import logger from "@app/logger/logger";

--- a/front/temporal/agent_loop/lib/run_model.ts
+++ b/front/temporal/agent_loop/lib/run_model.ts
@@ -1,4 +1,3 @@
-import { removeNulls } from "@dust-tt/client";
 import assert from "assert";
 
 import { buildToolSpecification } from "@app/lib/actions/mcp";
@@ -43,6 +42,7 @@ import { statsDClient } from "@app/logger/statsDClient";
 import { updateResourceAndPublishEvent } from "@app/temporal/agent_loop/activities/common";
 import { sliceConversationForAgentMessage } from "@app/temporal/agent_loop/lib/loop_utils";
 import type { AgentActionsEvent, ModelId } from "@app/types";
+import { removeNulls } from "@app/types";
 import type {
   FunctionCallContentType,
   ReasoningContentType,

--- a/front/temporal/labs/transcripts/utils/google.ts
+++ b/front/temporal/labs/transcripts/utils/google.ts
@@ -1,4 +1,3 @@
-import { Err, Ok } from "@dust-tt/client";
 import type { drive_v3 } from "googleapis";
 import { google } from "googleapis";
 
@@ -7,7 +6,7 @@ import { getTranscriptsGoogleAuth } from "@app/lib/labs/transcripts/utils/helper
 import type { LabsTranscriptsConfigurationResource } from "@app/lib/resources/labs_transcripts_resource";
 import type { Logger } from "@app/logger/logger";
 import type { ModelId, Result } from "@app/types";
-import { normalizeError } from "@app/types";
+import { Err, normalizeError, Ok } from "@app/types";
 
 export async function retrieveRecentGoogleTranscripts(
   {

--- a/front/types/assistant/agent_run.ts
+++ b/front/types/assistant/agent_run.ts
@@ -1,8 +1,6 @@
 /**
  * Run agent arguments
  */
-import type { Result } from "@dust-tt/client";
-import { Err, Ok } from "@dust-tt/client";
 import { z } from "zod";
 
 import { getAgentConfiguration } from "@app/lib/api/assistant/configuration/agent";
@@ -10,7 +8,8 @@ import { getConversation } from "@app/lib/api/assistant/conversation/fetch";
 import type { AuthenticatorType } from "@app/lib/auth";
 import { Authenticator } from "@app/lib/auth";
 import { AgentMessage, Message } from "@app/lib/models/assistant/conversation";
-import { isGlobalAgentId } from "@app/types";
+import type { Result } from "@app/types";
+import { Err, isGlobalAgentId, Ok } from "@app/types";
 import type { AgentConfigurationType } from "@app/types/assistant/agent";
 import type {
   AgentMessageType,


### PR DESCRIPTION
## Description

- This PR fixes a few occurrences of the `dust/enforce-client-types-in-public-api` eslint rule, notably on `Result`, `Err` and `Ok`, which are sometimes arbitrarily imported either from the SDK or from `types`.

## Tests

## Risk

## Deploy Plan

- Deploy front.
