### PR TITLE
[front] - feat(AB): increase page size limit in DataSourceNodeTable

### DIFF
--- a/front/components/agent_builder/capabilities/knowledge/DataSourceNodeTable.tsx
+++ b/front/components/agent_builder/capabilities/knowledge/DataSourceNodeTable.tsx
@@ -13,7 +13,7 @@ import { getVisualForDataSourceViewContentNode } from "@app/lib/content_nodes";
 import { useInfiniteDataSourceViewContentNodes } from "@app/lib/swr/data_source_views";
 import type { ContentNodesViewType } from "@app/types";
 
-const PAGE_SIZE = 25;
+const PAGE_SIZE = 50;
 
 interface DataSourceNodeTableProps {
   viewType: ContentNodesViewType;


### PR DESCRIPTION
## Description

This PR increases the page size for fetching data in DataSourceNodeTable has been increased from 25 to 50 items per page to display more data at once

## Tests

Locally

## Risk

Low

## Deploy Plan

Deploy front