### PR TITLE
[front] Hide empty component during loading in `ContentNodeTree`

### DIFF
--- a/front/components/ContentNodeTree.tsx
+++ b/front/components/ContentNodeTree.tsx
@@ -202,6 +202,7 @@ function ContentNodeTreeChildren({
     <Tree isLoading={isResourcesLoading} isBoxed={isRoundedBackground}>
       {filteredNodes &&
         filteredNodes.length === 0 &&
+        !isResourcesLoading &&
         (emptyComponent || <Tree.Empty label="No documents" />)}
 
       {filteredNodes.map((n, i) => {

--- a/front/components/ContentNodeTree.tsx
+++ b/front/components/ContentNodeTree.tsx
@@ -200,9 +200,9 @@ function ContentNodeTreeChildren({
 
   const tree = (
     <Tree isLoading={isResourcesLoading} isBoxed={isRoundedBackground}>
-      {filteredNodes &&
+      {!isResourcesLoading &&
+        filteredNodes &&
         filteredNodes.length === 0 &&
-        !isResourcesLoading &&
         (emptyComponent || <Tree.Empty label="No documents" />)}
 
       {filteredNodes.map((n, i) => {


### PR DESCRIPTION
## Description

- In the `ContentNodeTree`, when a node is loading we display both the empty component (e.g. `No documents`) and a spinner.
- This PR removes the empty component then.

Before

https://github.com/user-attachments/assets/ed1a3709-9b88-4cc8-a7ec-bc31186a0afd

After

https://github.com/user-attachments/assets/fc5c3f0c-e78d-4be4-8aab-c1abc04c06d3


## Tests

- Tested locally.

## Risk

- Low, only UI.

## Deploy Plan

- Deploy front.
