### PR TITLE
refactor(core): start split the core_api file

### DIFF
--- a/core/src/api/api_state.rs
+++ b/core/src/api/api_state.rs
@@ -1,0 +1,152 @@
+use crate::api::run_manager::RunManager;
+use crate::data_sources::qdrant::QdrantClients;
+use crate::search_stores::search_store::SearchStore;
+use crate::sqlite_workers::client;
+use crate::stores::store;
+use crate::{app, databases_store, run};
+use anyhow::Result;
+use parking_lot::Mutex;
+use std::sync::Arc;
+use tracing::{error, info};
+
+pub struct APIState {
+    pub store: Box<dyn store::Store + Sync + Send>,
+    pub databases_store: Box<dyn databases_store::store::DatabasesStore + Sync + Send>,
+    pub qdrant_clients: QdrantClients,
+    pub search_store: Box<dyn SearchStore + Sync + Send>,
+    run_manager: Arc<Mutex<RunManager>>,
+}
+
+impl APIState {
+    pub fn new(
+        store: Box<dyn store::Store + Sync + Send>,
+        databases_store: Box<dyn databases_store::store::DatabasesStore + Sync + Send>,
+        qdrant_clients: QdrantClients,
+        search_store: Box<dyn SearchStore + Sync + Send>,
+    ) -> Self {
+        APIState {
+            store,
+            qdrant_clients,
+            databases_store,
+            search_store,
+            run_manager: Arc::new(Mutex::new(RunManager {
+                pending_apps: vec![],
+                pending_runs: vec![],
+            })),
+        }
+    }
+
+    pub fn run_app(
+        &self,
+        app: app::App,
+        credentials: run::Credentials,
+        secrets: run::Secrets,
+        store_blocks_results: bool,
+    ) {
+        let mut run_manager = self.run_manager.lock();
+        run_manager
+            .pending_apps
+            .push((app, credentials, secrets, store_blocks_results));
+    }
+
+    pub async fn stop_loop(&self) {
+        loop {
+            let pending_runs = {
+                let manager = self.run_manager.lock();
+                info!(
+                    pending_runs = manager.pending_runs.len(),
+                    "[GRACEFUL] stop_loop pending runs",
+                );
+                manager.pending_runs.len()
+            };
+            if pending_runs == 0 {
+                break;
+            }
+            tokio::time::sleep(std::time::Duration::from_millis(1024)).await;
+        }
+    }
+
+    pub async fn run_loop(&self) -> Result<()> {
+        let mut loop_count = 0;
+
+        loop {
+            let apps: Vec<(app::App, run::Credentials, run::Secrets, bool)> = {
+                let mut manager = self.run_manager.lock();
+                let apps = manager.pending_apps.drain(..).collect::<Vec<_>>();
+                apps.iter().for_each(|app| {
+                    manager
+                        .pending_runs
+                        .push(app.0.run_ref().unwrap().run_id().to_string());
+                });
+                apps
+            };
+            apps.into_iter().for_each(|mut app| {
+                let store = self.store.clone();
+                let databases_store = self.databases_store.clone();
+                let qdrant_clients = self.qdrant_clients.clone();
+                let manager = self.run_manager.clone();
+
+                // Start a task that will run the app in the background.
+                tokio::task::spawn(async move {
+                    let now = std::time::Instant::now();
+
+                    match app
+                        .0
+                        .run(
+                            app.1,
+                            app.2,
+                            store,
+                            databases_store,
+                            qdrant_clients,
+                            None,
+                            app.3,
+                        )
+                        .await
+                    {
+                        Ok(()) => {
+                            info!(
+                                run = app.0.run_ref().unwrap().run_id(),
+                                app_version = app.0.hash(),
+                                elapsed = now.elapsed().as_millis(),
+                                "Run finished"
+                            );
+                        }
+                        Err(e) => {
+                            error!(error = %e, "Run error");
+                        }
+                    }
+                    {
+                        let mut manager = manager.lock();
+                        manager
+                            .pending_runs
+                            .retain(|run_id| run_id != app.0.run_ref().unwrap().run_id());
+                    }
+                });
+            });
+            loop_count += 1;
+            tokio::time::sleep(std::time::Duration::from_millis(4)).await;
+            if loop_count % 1024 == 0 {
+                let manager = self.run_manager.lock();
+                let runs_count = manager.pending_runs.len();
+                if runs_count > 0 || loop_count % 65536 == 0 {
+                    info!(pending_runs = runs_count, "Pending runs {}", runs_count);
+                }
+            }
+            // Roughly every 4 minutes, cleanup dead SQLite workers if any.
+            if loop_count % 65536 == 0 {
+                let store = self.store.clone();
+                tokio::task::spawn(async move {
+                    match store
+                        .sqlite_workers_cleanup(client::HEARTBEAT_INTERVAL_MS)
+                        .await
+                    {
+                        Err(e) => {
+                            error!(error = %e, "Failed to cleanup SQLite workers");
+                        }
+                        Ok(_) => (),
+                    }
+                });
+            }
+        }
+    }
+}

--- a/core/src/api/projects.rs
+++ b/core/src/api/projects.rs
@@ -1,0 +1,158 @@
+use crate::api::api_state::APIState;
+use crate::project;
+use crate::utils::{error_response, APIResponse};
+use anyhow::anyhow;
+use axum::extract::{Path, State};
+use axum::Json;
+use http::StatusCode;
+use serde_json::json;
+use std::sync::Arc;
+
+/// Create a new project (simply generates an id)
+
+pub async fn projects_create(
+    State(state): State<Arc<APIState>>,
+) -> (StatusCode, Json<APIResponse>) {
+    match state.store.create_project().await {
+        Err(e) => error_response(
+            StatusCode::INTERNAL_SERVER_ERROR,
+            "internal_server_error",
+            "Failed to create a new project",
+            Some(e),
+        ),
+        Ok(project) => (
+            StatusCode::OK,
+            Json(APIResponse {
+                error: None,
+                response: Some(json!({
+                    "project": project,
+                })),
+            }),
+        ),
+    }
+}
+
+pub async fn projects_delete(
+    State(state): State<Arc<APIState>>,
+    Path(project_id): Path<i64>,
+) -> (StatusCode, Json<APIResponse>) {
+    let project = project::Project::new_from_id(project_id);
+
+    // Check if the project has data sources and raise if it does.
+    match state.store.has_data_sources(&project).await {
+        Err(e) => {
+            return error_response(
+                StatusCode::INTERNAL_SERVER_ERROR,
+                "internal_server_error",
+                "Failed to check project has data sources before deletion",
+                Some(e),
+            )
+        }
+        Ok(has_data_sources) => {
+            if has_data_sources {
+                return error_response(
+                    StatusCode::BAD_REQUEST,
+                    "bad_request",
+                    "Cannot delete a project with data sources",
+                    None,
+                );
+            }
+        }
+    }
+
+    // Delete the project
+    match state.store.delete_project(&project).await {
+        Err(e) => error_response(
+            StatusCode::INTERNAL_SERVER_ERROR,
+            "internal_server_error",
+            "Failed to delete project",
+            Some(e),
+        ),
+        Ok(()) => (
+            StatusCode::OK,
+            Json(APIResponse {
+                error: None,
+                response: Some(json!({
+                    "success": true
+                })),
+            }),
+        ),
+    }
+}
+
+/// Clones a project.
+/// Simply consists in cloning the latest dataset versions, as we don't copy runs and hence specs.
+
+pub async fn projects_clone(
+    State(state): State<Arc<APIState>>,
+    Path(project_id): Path<i64>,
+) -> (StatusCode, Json<APIResponse>) {
+    let cloned = project::Project::new_from_id(project_id);
+
+    // Create cloned project
+    let project = match state.store.create_project().await {
+        Err(e) => {
+            return error_response(
+                StatusCode::INTERNAL_SERVER_ERROR,
+                "internal_server_error",
+                "Failed to create cloned project",
+                Some(e),
+            )
+        }
+        Ok(project) => project,
+    };
+
+    // Retrieve datasets
+    let datasets = match state.store.list_datasets(&cloned).await {
+        Err(e) => {
+            return error_response(
+                StatusCode::INTERNAL_SERVER_ERROR,
+                "internal_server_error",
+                "Failed to list cloned project datasets",
+                Some(e),
+            )
+        }
+        Ok(datasets) => datasets,
+    };
+
+    // Load and register datasets
+    let store = state.store.clone();
+    match futures::future::join_all(datasets.iter().map(|(d, v)| async {
+        let dataset = match store
+            .load_dataset(&cloned, &d.clone(), &v[0].clone().0)
+            .await?
+        {
+            Some(dataset) => dataset,
+            None => Err(anyhow!(
+                "Could not find latest version of dataset {}",
+                d.clone()
+            ))?,
+        };
+        store.register_dataset(&project, &dataset).await?;
+        Ok::<(), anyhow::Error>(())
+    }))
+    .await
+    .into_iter()
+    .collect::<anyhow::Result<Vec<_>>>()
+    {
+        Err(e) => {
+            return error_response(
+                StatusCode::INTERNAL_SERVER_ERROR,
+                "internal_server_error",
+                "Failed to clone project datasets",
+                Some(e),
+            )
+        }
+        Ok(_) => (),
+    }
+
+    (
+        StatusCode::OK,
+        Json(APIResponse {
+            error: None,
+            response: Some(json!({
+                "project": project,
+            })),
+        }),
+    )
+}

--- a/core/src/api/run_manager.rs
+++ b/core/src/api/run_manager.rs
@@ -1,0 +1,8 @@
+use crate::{app, run};
+
+/// API State
+
+pub(crate) struct RunManager {
+    pub(crate) pending_apps: Vec<(app::App, run::Credentials, run::Secrets, bool)>,
+    pub(crate) pending_runs: Vec<String>,
+}

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -173,3 +173,9 @@ pub mod open_telemetry;
 pub mod otel_log_format;
 
 pub mod mem_check;
+
+pub mod api {
+    pub mod api_state;
+    pub mod projects;
+    pub(crate) mod run_manager;
+}


### PR DESCRIPTION
## Description

The file `core_api.rs` was too long for my taste, 5000 lines is too long for me to understand.

So this is PR is trying to move a few handlers to `src/api`. 

If we agree on the path, I'll continue to split the code in further PRs

⚠️ this is my first time doing rust in ages, I have no idea if what I did is "rustonesque" or not

## Tests

Compilation 🦾 

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
