### PR TITLE
Webhook source view

### DIFF
--- a/front/components/spaces/SystemSpaceTriggersList.tsx
+++ b/front/components/spaces/SystemSpaceTriggersList.tsx
@@ -1,6 +1,7 @@
 import * as React from "react";
 
 import { AdminTriggersList } from "@app/components/triggers/AdminTriggersList";
+import { useWebhookSourcesWithViews } from "@app/lib/swr/webhook_source";
 import type { LightWorkspaceType, SpaceType } from "@app/types";
 
 interface SpaceActionsListProps {
@@ -14,9 +15,22 @@ export const SystemSpaceTriggersList = ({
   isAdmin,
   space,
 }: SpaceActionsListProps) => {
+  const { webhookSourcesWithViews, isWebhookSourcesWithViewsLoading } =
+    useWebhookSourcesWithViews({
+      owner,
+      disabled: !isAdmin,
+    });
+
   if (!isAdmin) {
     return null;
   }
 
-  return <AdminTriggersList owner={owner} systemSpace={space} />;
+  return (
+      <AdminTriggersList
+        owner={owner}
+        systemSpace={space}
+        webhookSourcesWithViews={webhookSourcesWithViews}
+        isWebhookSourcesWithViewsLoading={isWebhookSourcesWithViewsLoading}
+      />
+  );
 };

--- a/front/components/spaces/SystemSpaceTriggersList.tsx
+++ b/front/components/spaces/SystemSpaceTriggersList.tsx
@@ -1,8 +1,10 @@
-import * as React from "react";
+import { useState } from "react";
 
 import { AdminTriggersList } from "@app/components/triggers/AdminTriggersList";
+import { WebhookSourceDetails } from "@app/components/triggers/WebhookSourceDetails";
 import { useWebhookSourcesWithViews } from "@app/lib/swr/webhook_source";
 import type { LightWorkspaceType, SpaceType } from "@app/types";
+import type { WebhookSourceViewType } from "@app/types/triggers/webhooks";
 
 interface SpaceActionsListProps {
   isAdmin: boolean;
@@ -15,6 +17,9 @@ export const SystemSpaceTriggersList = ({
   isAdmin,
   space,
 }: SpaceActionsListProps) => {
+  const [selectedWebhookSourceView, setSelectedWebhookSourceView] =
+    useState<WebhookSourceViewType | null>(null);
+
   const { webhookSourcesWithViews, isWebhookSourcesWithViewsLoading } =
     useWebhookSourcesWithViews({
       owner,
@@ -26,11 +31,21 @@ export const SystemSpaceTriggersList = ({
   }
 
   return (
+    <>
+      {selectedWebhookSourceView && (
+        <WebhookSourceDetails
+          webhookSourceView={selectedWebhookSourceView}
+          onClose={() => setSelectedWebhookSourceView(null)}
+          isOpen={selectedWebhookSourceView !== null}
+        />
+      )}
       <AdminTriggersList
         owner={owner}
         systemSpace={space}
+        setSelectedWebhookSourceView={setSelectedWebhookSourceView}
         webhookSourcesWithViews={webhookSourcesWithViews}
         isWebhookSourcesWithViewsLoading={isWebhookSourcesWithViewsLoading}
       />
+    </>
   );
 };

--- a/front/components/spaces/SystemSpaceTriggersList.tsx
+++ b/front/components/spaces/SystemSpaceTriggersList.tsx
@@ -32,7 +32,7 @@ export const SystemSpaceTriggersList = ({
 
   return (
     <>
-      {selectedWebhookSourceView && (
+      {selectedWebhookSourceView !== null && (
         <WebhookSourceDetails
           webhookSourceView={selectedWebhookSourceView}
           onClose={() => setSelectedWebhookSourceView(null)}

--- a/front/components/spaces/SystemSpaceTriggersList.tsx
+++ b/front/components/spaces/SystemSpaceTriggersList.tsx
@@ -34,6 +34,7 @@ export const SystemSpaceTriggersList = ({
     <>
       {selectedWebhookSourceView !== null && (
         <WebhookSourceDetails
+          owner={owner}
           webhookSourceView={selectedWebhookSourceView}
           onClose={() => setSelectedWebhookSourceView(null)}
           isOpen={selectedWebhookSourceView !== null}

--- a/front/components/triggers/AdminTriggersList.tsx
+++ b/front/components/triggers/AdminTriggersList.tsx
@@ -13,7 +13,6 @@ import { TRIGGER_BUTTONS_CONTAINER_ID } from "@app/components/spaces/SpacePageHe
 import { CreateWebhookSourceDialog } from "@app/components/triggers/CreateWebhookSourceDialog";
 import { useActionButtonsPortal } from "@app/hooks/useActionButtonsPortal";
 import { useSpacesAsAdmin } from "@app/lib/swr/spaces";
-import { useWebhookSourcesWithViews } from "@app/lib/swr/webhook_source";
 import { formatTimestampToFriendlyDate } from "@app/lib/utils";
 import type { LightWorkspaceType, SpaceType } from "@app/types";
 import { ANONYMOUS_USER_IMAGE_URL } from "@app/types";
@@ -24,7 +23,7 @@ import type {
 
 type RowData = {
   webhookSourceWithViews: WebhookSourceWithViews;
-  webhookSourceView?: WebhookSourceViewType;
+  webhookSourceView: WebhookSourceViewType | null;
   spaces: SpaceType[];
   onClick?: () => void;
 };
@@ -53,11 +52,15 @@ const NameCell = ({ row }: { row: RowData }) => {
 type AdminTriggersListProps = {
   owner: LightWorkspaceType;
   systemSpace: SpaceType;
+  isWebhookSourcesWithViewsLoading: boolean;
+  webhookSourcesWithViews: WebhookSourceWithViews[];
 };
 
 export const AdminTriggersList = ({
   owner,
   systemSpace,
+  isWebhookSourcesWithViewsLoading,
+  webhookSourcesWithViews,
 }: AdminTriggersListProps) => {
   const [isCreateOpen, setIsCreateOpen] = useState(false);
   const { spaces } = useSpacesAsAdmin({
@@ -66,20 +69,15 @@ export const AdminTriggersList = ({
   });
   const { portalToHeader } = useActionButtonsPortal({
     containerId: TRIGGER_BUTTONS_CONTAINER_ID,
-  });
-
-  const { webhookSourcesWithViews, isWebhookSourcesWithViewsLoading } =
-    useWebhookSourcesWithViews({
-      owner,
-      disabled: false,
     });
 
   const rows: RowData[] = useMemo(
     () =>
       webhookSourcesWithViews.map((webhookSourceWithViews) => {
-        const webhookSourceView = webhookSourceWithViews?.views.find(
+        const webhookSourceView =
+          webhookSourceWithViews.views.find(
           (view) => view.spaceId === systemSpace?.sId
-        );
+          ) ?? null;
         const spaceIds =
           webhookSourceWithViews?.views.map((view) => view.spaceId) ?? [];
 

--- a/front/components/triggers/AdminTriggersList.tsx
+++ b/front/components/triggers/AdminTriggersList.tsx
@@ -102,6 +102,35 @@ export const AdminTriggersList = ({
         ),
       },
       {
+        id: "access",
+        accessorKey: "spaces",
+        header: "Access",
+        cell: (info: CellContext<RowData, SpaceType[]>) => {
+          const globalSpace = info.getValue().find((s) => s.kind === "global");
+          const accessibleTo = globalSpace
+            ? "Everyone"
+            : info
+                .getValue()
+                .filter((s) => s.kind === "regular")
+                .map((s) => s.name)
+                .join(", ");
+
+          return (
+            <DataTable.CellContent>
+              <div className="flex items-center gap-2">{accessibleTo}</div>
+            </DataTable.CellContent>
+          );
+        },
+        sortingFn: (rowA, rowB) => {
+          return rowA.original.webhookSourceWithViews.name.localeCompare(
+            rowB.original.webhookSourceWithViews.name
+          );
+        },
+        meta: {
+          className: "w-28",
+        },
+      },
+      {
         id: "by",
         accessorKey: "webhookSourceView.editedByUser",
         header: "By",

--- a/front/components/triggers/WebhookSourceDetails.tsx
+++ b/front/components/triggers/WebhookSourceDetails.tsx
@@ -14,15 +14,18 @@ import { useEffect, useState } from "react";
 
 import { WebhookSourceDetailsHeader } from "@app/components/triggers/WebhookSourceDetailsHeader";
 import { WebhookSourceDetailsInfo } from "@app/components/triggers/WebhookSourceDetailsInfo";
+import type { LightWorkspaceType } from "@app/types";
 import type { WebhookSourceViewType } from "@app/types/triggers/webhooks";
 
 type WebhookSourceDetailsProps = {
+  owner: LightWorkspaceType;
   onClose: () => void;
   webhookSourceView: WebhookSourceViewType;
   isOpen: boolean;
 };
 
 export function WebhookSourceDetails({
+  owner,
   webhookSourceView,
   isOpen,
   onClose,
@@ -58,7 +61,10 @@ export function WebhookSourceDetails({
 
         <SheetContainer>
           {selectedTab === "info" && (
-            <WebhookSourceDetailsInfo webhookSourceView={webhookSourceView} />
+            <WebhookSourceDetailsInfo
+              webhookSourceView={webhookSourceView}
+              owner={owner}
+            />
           )}
         </SheetContainer>
       </SheetContent>

--- a/front/components/triggers/WebhookSourceDetails.tsx
+++ b/front/components/triggers/WebhookSourceDetails.tsx
@@ -6,7 +6,7 @@ import type { WebhookSourceViewType } from "@app/types/triggers/webhooks";
 
 type WebhookSourceDetailsProps = {
   onClose: () => void;
-  webhookSourceView: WebhookSourceViewType | null;
+  webhookSourceView: WebhookSourceViewType;
   isOpen: boolean;
 };
 
@@ -22,9 +22,7 @@ export function WebhookSourceDetails({
           <VisuallyHidden>
             <SheetTitle />
           </VisuallyHidden>
-          {webhookSourceView !== null && (
-            <WebhookSourceDetailsHeader webhookSourceView={webhookSourceView} />
-          )}
+          <WebhookSourceDetailsHeader webhookSourceView={webhookSourceView} />
         </SheetHeader>
       </SheetContent>
     </Sheet>

--- a/front/components/triggers/WebhookSourceDetails.tsx
+++ b/front/components/triggers/WebhookSourceDetails.tsx
@@ -1,5 +1,15 @@
-import { Sheet, SheetContent, SheetHeader, SheetTitle } from "@dust-tt/sparkle";
+import {
+  InformationCircleIcon,
+  Sheet,
+  SheetContent,
+  SheetHeader,
+  SheetTitle,
+  Tabs,
+  TabsList,
+  TabsTrigger,
+} from "@dust-tt/sparkle";
 import { VisuallyHidden } from "@radix-ui/react-visually-hidden";
+import { useEffect, useState } from "react";
 
 import { WebhookSourceDetailsHeader } from "@app/components/triggers/WebhookSourceDetailsHeader";
 import type { WebhookSourceViewType } from "@app/types/triggers/webhooks";
@@ -15,6 +25,14 @@ export function WebhookSourceDetails({
   isOpen,
   onClose,
 }: WebhookSourceDetailsProps) {
+  const [selectedTab, setSelectedTab] = useState<string>("info");
+
+  useEffect(() => {
+    if (isOpen) {
+      setSelectedTab("info");
+    }
+  }, [isOpen]);
+
   return (
     <Sheet open={isOpen} onOpenChange={onClose}>
       <SheetContent size="lg">
@@ -23,6 +41,17 @@ export function WebhookSourceDetails({
             <SheetTitle />
           </VisuallyHidden>
           <WebhookSourceDetailsHeader webhookSourceView={webhookSourceView} />
+
+          <Tabs value={selectedTab}>
+            <TabsList border={false}>
+              <TabsTrigger
+                value="info"
+                label="Info"
+                icon={InformationCircleIcon}
+                onClick={() => setSelectedTab("info")}
+              />
+            </TabsList>
+          </Tabs>
         </SheetHeader>
       </SheetContent>
     </Sheet>

--- a/front/components/triggers/WebhookSourceDetails.tsx
+++ b/front/components/triggers/WebhookSourceDetails.tsx
@@ -1,6 +1,7 @@
 import {
   InformationCircleIcon,
   Sheet,
+  SheetContainer,
   SheetContent,
   SheetHeader,
   SheetTitle,
@@ -12,6 +13,7 @@ import { VisuallyHidden } from "@radix-ui/react-visually-hidden";
 import { useEffect, useState } from "react";
 
 import { WebhookSourceDetailsHeader } from "@app/components/triggers/WebhookSourceDetailsHeader";
+import { WebhookSourceDetailsInfo } from "@app/components/triggers/WebhookSourceDetailsInfo";
 import type { WebhookSourceViewType } from "@app/types/triggers/webhooks";
 
 type WebhookSourceDetailsProps = {
@@ -53,6 +55,12 @@ export function WebhookSourceDetails({
             </TabsList>
           </Tabs>
         </SheetHeader>
+
+        <SheetContainer>
+          {selectedTab === "info" && (
+            <WebhookSourceDetailsInfo webhookSourceView={webhookSourceView} />
+          )}
+        </SheetContainer>
       </SheetContent>
     </Sheet>
   );

--- a/front/components/triggers/WebhookSourceDetails.tsx
+++ b/front/components/triggers/WebhookSourceDetails.tsx
@@ -1,0 +1,32 @@
+import { Sheet, SheetContent, SheetHeader, SheetTitle } from "@dust-tt/sparkle";
+import { VisuallyHidden } from "@radix-ui/react-visually-hidden";
+
+import { WebhookSourceDetailsHeader } from "@app/components/triggers/WebhookSourceDetailsHeader";
+import type { WebhookSourceViewType } from "@app/types/triggers/webhooks";
+
+type WebhookSourceDetailsProps = {
+  onClose: () => void;
+  webhookSourceView: WebhookSourceViewType | null;
+  isOpen: boolean;
+};
+
+export function WebhookSourceDetails({
+  webhookSourceView,
+  isOpen,
+  onClose,
+}: WebhookSourceDetailsProps) {
+  return (
+    <Sheet open={isOpen} onOpenChange={onClose}>
+      <SheetContent size="lg">
+        <SheetHeader className="flex flex-col gap-5 pb-0 text-sm text-foreground dark:text-foreground-night">
+          <VisuallyHidden>
+            <SheetTitle />
+          </VisuallyHidden>
+          {webhookSourceView !== null && (
+            <WebhookSourceDetailsHeader webhookSourceView={webhookSourceView} />
+          )}
+        </SheetHeader>
+      </SheetContent>
+    </Sheet>
+  );
+}

--- a/front/components/triggers/WebhookSourceDetailsHeader.tsx
+++ b/front/components/triggers/WebhookSourceDetailsHeader.tsx
@@ -1,0 +1,25 @@
+import { ActionGlobeAltIcon, Avatar } from "@dust-tt/sparkle";
+
+import type { WebhookSourceViewType } from "@app/types/triggers/webhooks";
+
+interface WebhookSourceDetailsHeaderProps {
+  webhookSourceView: WebhookSourceViewType;
+}
+
+export function WebhookSourceDetailsHeader({
+  webhookSourceView,
+}: WebhookSourceDetailsHeaderProps) {
+  return (
+    <div className="items-top flex flex-col gap-3 sm:flex-row">
+      <Avatar icon={ActionGlobeAltIcon} size="md" />
+      <div className="flex grow flex-col gap-0 pr-9">
+        <h2 className="heading-lg line-clamp-1 text-foreground dark:text-foreground-night">
+          {webhookSourceView.customName ?? webhookSourceView.webhookSource.name}
+        </h2>
+        <div className="line-clamp-1 overflow-hidden text-sm text-muted-foreground dark:text-muted-foreground-night">
+          Webhook source for triggering assistants.
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/front/components/triggers/WebhookSourceDetailsInfo.tsx
+++ b/front/components/triggers/WebhookSourceDetailsInfo.tsx
@@ -1,8 +1,29 @@
-import { useMemo } from "react";
+import { EyeIcon, EyeSlashIcon, IconButton, Separator } from "@dust-tt/sparkle";
+import { useMemo, useState } from "react";
 
 import { WebhookSourceViewForm } from "@app/components/triggers/WebhookSourceViewForm";
 import type { LightWorkspaceType } from "@app/types";
 import type { WebhookSourceViewType } from "@app/types/triggers/webhooks";
+
+const Label = ({ children }: { children: React.ReactNode }) => (
+  <label className="text-sm font-medium text-muted-foreground dark:text-muted-foreground-night">
+    {children}
+  </label>
+);
+
+const Value = ({
+  children,
+  className = "",
+}: {
+  children: React.ReactNode;
+  className?: string;
+}) => (
+  <p
+    className={`text-sm text-foreground dark:text-foreground-night ${className}`}
+  >
+    {children}
+  </p>
+);
 
 type WebhookSourceDetailsInfoProps = {
   webhookSourceView: WebhookSourceViewType;
@@ -34,6 +55,8 @@ export function WebhookSourceDetailsInfo({
   webhookSourceView,
   owner,
 }: WebhookSourceDetailsInfoProps) {
+  const [isSecretVisible, setIsSecretVisible] = useState(false);
+
   const editedLabel = useMemo(
     () => getEditedLabel(webhookSourceView),
     [webhookSourceView]
@@ -51,6 +74,77 @@ export function WebhookSourceDetailsInfo({
         webhookSourceView={webhookSourceView}
         owner={owner}
       />
+
+      <Separator className="mb-4 mt-4" />
+      <div className="heading-lg">Webhook Source Details</div>
+
+      <div className="space-y-6">
+        <div>
+          <Label>Source Name</Label>
+          <Value>{webhookSourceView.webhookSource.name}</Value>
+        </div>
+
+        {webhookSourceView.webhookSource.secret && (
+          <div>
+            <Label>Secret</Label>
+            <div className="flex items-center space-x-2">
+              <Value
+                className={`font-mono ${
+                  isSecretVisible ? "" : "select-none blur-sm"
+                }`}
+              >
+                {webhookSourceView.webhookSource.secret}
+              </Value>
+              <IconButton
+                icon={isSecretVisible ? EyeSlashIcon : EyeIcon}
+                onClick={() => setIsSecretVisible((prev) => !prev)}
+                size="xs"
+              />
+            </div>
+          </div>
+        )}
+
+        {webhookSourceView.webhookSource.signatureHeader && (
+          <>
+            <div>
+              <Label>Signature Header</Label>
+              <Value>{webhookSourceView.webhookSource.signatureHeader}</Value>
+            </div>
+
+            <div>
+              <Label>Signature Algorithm</Label>
+              <Value>
+                {webhookSourceView.webhookSource.signatureAlgorithm}
+              </Value>
+            </div>
+          </>
+        )}
+
+        {webhookSourceView.webhookSource.customHeaders &&
+          Object.keys(webhookSourceView.webhookSource.customHeaders).length >
+            0 && (
+            <div>
+              <Label>Custom Headers</Label>
+              <div className="mt-2 space-y-1">
+                {Object.entries(
+                  webhookSourceView.webhookSource.customHeaders
+                ).map(([key, value]) => (
+                  <div
+                    key={key}
+                    className="flex items-center space-x-2 text-sm"
+                  >
+                    <span className="font-mono text-muted-foreground dark:text-muted-foreground-night">
+                      {key}:
+                    </span>
+                    <span className="text-foreground dark:text-foreground-night">
+                      {value}
+                    </span>
+                  </div>
+                ))}
+              </div>
+            </div>
+          )}
+      </div>
     </div>
   );
 }

--- a/front/components/triggers/WebhookSourceDetailsInfo.tsx
+++ b/front/components/triggers/WebhookSourceDetailsInfo.tsx
@@ -3,6 +3,7 @@ import {
   EyeIcon,
   EyeSlashIcon,
   IconButton,
+  Page,
   Separator,
   useCopyToClipboard,
 } from "@dust-tt/sparkle";
@@ -13,26 +14,6 @@ import { useSendNotification } from "@app/hooks/useNotification";
 import config from "@app/lib/api/config";
 import type { LightWorkspaceType } from "@app/types";
 import type { WebhookSourceViewType } from "@app/types/triggers/webhooks";
-
-const Label = ({ children }: { children: React.ReactNode }) => (
-  <label className="text-sm font-medium text-muted-foreground dark:text-muted-foreground-night">
-    {children}
-  </label>
-);
-
-const Value = ({
-  children,
-  className = "",
-}: {
-  children: React.ReactNode;
-  className?: string;
-}) => (
-  <p
-    className={`text-sm text-foreground dark:text-foreground-night ${className}`}
-  >
-    {children}
-  </p>
-);
 
 type WebhookSourceDetailsInfoProps = {
   webhookSourceView: WebhookSourceViewType;
@@ -102,13 +83,13 @@ export function WebhookSourceDetailsInfo({
       />
 
       <Separator className="mb-4 mt-4" />
-      <div className="heading-lg">Webhook Source Details</div>
+      <Page.H variant="h4">Webhook Source Details</Page.H>
 
       <div className="space-y-6">
         <div>
-          <Label>Webhook URL</Label>
+          <Page.H variant="h6">Webhook URL</Page.H>
           <div className="flex items-center space-x-2">
-            <Value className="truncate font-mono">{webhookUrl}</Value>
+            <Page.P>{webhookUrl}</Page.P>
             <IconButton
               icon={ClipboardIcon}
               onClick={() => copy(webhookUrl)}
@@ -118,21 +99,21 @@ export function WebhookSourceDetailsInfo({
         </div>
 
         <div>
-          <Label>Source Name</Label>
-          <Value>{webhookSourceView.webhookSource.name}</Value>
+          <Page.H variant="h6">Source Name</Page.H>
+          <Page.P>{webhookSourceView.webhookSource.name}</Page.P>
         </div>
 
         {webhookSourceView.webhookSource.secret && (
           <div>
-            <Label>Secret</Label>
+            <Page.H variant="h6">Secret</Page.H>
             <div className="flex items-center space-x-2">
-              <Value
+              <div
                 className={`font-mono ${
                   isSecretVisible ? "" : "select-none blur-sm"
                 }`}
               >
-                {webhookSourceView.webhookSource.secret}
-              </Value>
+                <Page.P>{webhookSourceView.webhookSource.secret}</Page.P>
+              </div>
               <IconButton
                 icon={isSecretVisible ? EyeSlashIcon : EyeIcon}
                 onClick={() => setIsSecretVisible((prev) => !prev)}
@@ -145,15 +126,15 @@ export function WebhookSourceDetailsInfo({
         {webhookSourceView.webhookSource.signatureHeader && (
           <>
             <div>
-              <Label>Signature Header</Label>
-              <Value>{webhookSourceView.webhookSource.signatureHeader}</Value>
+              <Page.H variant="h6">Signature Header</Page.H>
+              <Page.P>{webhookSourceView.webhookSource.signatureHeader}</Page.P>
             </div>
 
             <div>
-              <Label>Signature Algorithm</Label>
-              <Value>
+              <Page.H variant="h6">Signature Algorithm</Page.H>
+              <Page.P>
                 {webhookSourceView.webhookSource.signatureAlgorithm}
-              </Value>
+              </Page.P>
             </div>
           </>
         )}
@@ -162,7 +143,7 @@ export function WebhookSourceDetailsInfo({
           Object.keys(webhookSourceView.webhookSource.customHeaders).length >
             0 && (
             <div>
-              <Label>Custom Headers</Label>
+              <Page.H variant="h6">Custom Headers</Page.H>
               <div className="mt-2 space-y-1">
                 {Object.entries(
                   webhookSourceView.webhookSource.customHeaders

--- a/front/components/triggers/WebhookSourceDetailsInfo.tsx
+++ b/front/components/triggers/WebhookSourceDetailsInfo.tsx
@@ -1,7 +1,15 @@
-import { EyeIcon, EyeSlashIcon, IconButton, Separator } from "@dust-tt/sparkle";
+import {
+  ClipboardIcon,
+  EyeIcon,
+  EyeSlashIcon,
+  IconButton,
+  Separator,
+} from "@dust-tt/sparkle";
 import { useMemo, useState } from "react";
 
 import { WebhookSourceViewForm } from "@app/components/triggers/WebhookSourceViewForm";
+import { useSendNotification } from "@app/hooks/useNotification";
+import config from "@app/lib/api/config";
 import type { LightWorkspaceType } from "@app/types";
 import type { WebhookSourceViewType } from "@app/types/triggers/webhooks";
 
@@ -56,11 +64,25 @@ export function WebhookSourceDetailsInfo({
   owner,
 }: WebhookSourceDetailsInfoProps) {
   const [isSecretVisible, setIsSecretVisible] = useState(false);
+  const sendNotification = useSendNotification();
 
   const editedLabel = useMemo(
     () => getEditedLabel(webhookSourceView),
     [webhookSourceView]
   );
+
+  const webhookUrl = useMemo(() => {
+    const { url } = config.getDustAPIConfig();
+    return `${url}/api/v1/w/${owner.sId}/triggers/hooks/${webhookSourceView.webhookSource.sId}`;
+  }, [owner.sId, webhookSourceView.webhookSource.sId]);
+
+  const copyWebhookUrl = async () => {
+    await navigator.clipboard.writeText(webhookUrl);
+    sendNotification({
+      type: "success",
+      title: "Webhook URL copied to clipboard",
+    });
+  };
 
   return (
     <div className="flex flex-col gap-2">
@@ -79,6 +101,18 @@ export function WebhookSourceDetailsInfo({
       <div className="heading-lg">Webhook Source Details</div>
 
       <div className="space-y-6">
+        <div>
+          <Label>Webhook URL</Label>
+          <div className="flex items-center space-x-2">
+            <Value className="truncate font-mono">{webhookUrl}</Value>
+            <IconButton
+              icon={ClipboardIcon}
+              onClick={copyWebhookUrl}
+              size="xs"
+            />
+          </div>
+        </div>
+
         <div>
           <Label>Source Name</Label>
           <Value>{webhookSourceView.webhookSource.name}</Value>

--- a/front/components/triggers/WebhookSourceDetailsInfo.tsx
+++ b/front/components/triggers/WebhookSourceDetailsInfo.tsx
@@ -1,9 +1,12 @@
 import { useMemo } from "react";
 
+import { WebhookSourceViewForm } from "@app/components/triggers/WebhookSourceViewForm";
+import type { LightWorkspaceType } from "@app/types";
 import type { WebhookSourceViewType } from "@app/types/triggers/webhooks";
 
 type WebhookSourceDetailsInfoProps = {
   webhookSourceView: WebhookSourceViewType;
+  owner: LightWorkspaceType;
 };
 
 const getEditedLabel = (webhookSourceView: WebhookSourceViewType) => {
@@ -29,6 +32,7 @@ const getEditedLabel = (webhookSourceView: WebhookSourceViewType) => {
 
 export function WebhookSourceDetailsInfo({
   webhookSourceView,
+  owner,
 }: WebhookSourceDetailsInfoProps) {
   const editedLabel = useMemo(
     () => getEditedLabel(webhookSourceView),
@@ -42,6 +46,11 @@ export function WebhookSourceDetailsInfo({
           {editedLabel}
         </div>
       )}
+
+      <WebhookSourceViewForm
+        webhookSourceView={webhookSourceView}
+        owner={owner}
+      />
     </div>
   );
 }

--- a/front/components/triggers/WebhookSourceDetailsInfo.tsx
+++ b/front/components/triggers/WebhookSourceDetailsInfo.tsx
@@ -1,0 +1,47 @@
+import { useMemo } from "react";
+
+import type { WebhookSourceViewType } from "@app/types/triggers/webhooks";
+
+type WebhookSourceDetailsInfoProps = {
+  webhookSourceView: WebhookSourceViewType;
+};
+
+const getEditedLabel = (webhookSourceView: WebhookSourceViewType) => {
+  if (
+    webhookSourceView.editedByUser === null ||
+    (webhookSourceView.editedByUser.editedAt === null &&
+      webhookSourceView.editedByUser.fullName === null)
+  ) {
+    return null;
+  }
+  if (webhookSourceView.editedByUser.editedAt === null) {
+    return `Edited by ${webhookSourceView.editedByUser.fullName}`;
+  }
+  const editedAtDateString = new Date(
+    webhookSourceView.editedByUser.editedAt
+  ).toLocaleDateString();
+  if (webhookSourceView.editedByUser.fullName === null) {
+    return `Edited on ${editedAtDateString}`;
+  }
+
+  return `Edited by ${webhookSourceView.editedByUser.fullName}, ${editedAtDateString}`;
+};
+
+export function WebhookSourceDetailsInfo({
+  webhookSourceView,
+}: WebhookSourceDetailsInfoProps) {
+  const editedLabel = useMemo(
+    () => getEditedLabel(webhookSourceView),
+    [webhookSourceView]
+  );
+
+  return (
+    <div className="flex flex-col gap-2">
+      {editedLabel !== null && (
+        <div className="flex w-full justify-end text-sm text-muted-foreground dark:text-muted-foreground-night">
+          {editedLabel}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/front/components/triggers/WebhookSourceDetailsInfo.tsx
+++ b/front/components/triggers/WebhookSourceDetailsInfo.tsx
@@ -4,8 +4,9 @@ import {
   EyeSlashIcon,
   IconButton,
   Separator,
+  useCopyToClipboard,
 } from "@dust-tt/sparkle";
-import { useMemo, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 
 import { WebhookSourceViewForm } from "@app/components/triggers/WebhookSourceViewForm";
 import { useSendNotification } from "@app/hooks/useNotification";
@@ -71,18 +72,21 @@ export function WebhookSourceDetailsInfo({
     [webhookSourceView]
   );
 
+  const [isCopied, copy] = useCopyToClipboard();
+
+  useEffect(() => {
+    if (isCopied) {
+      sendNotification({
+        type: "success",
+        title: "Webhook URL copied to clipboard",
+      });
+    }
+  }, [isCopied, sendNotification]);
+
   const webhookUrl = useMemo(() => {
     const { url } = config.getDustAPIConfig();
     return `${url}/api/v1/w/${owner.sId}/triggers/hooks/${webhookSourceView.webhookSource.sId}`;
   }, [owner.sId, webhookSourceView.webhookSource.sId]);
-
-  const copyWebhookUrl = async () => {
-    await navigator.clipboard.writeText(webhookUrl);
-    sendNotification({
-      type: "success",
-      title: "Webhook URL copied to clipboard",
-    });
-  };
 
   return (
     <div className="flex flex-col gap-2">
@@ -107,7 +111,7 @@ export function WebhookSourceDetailsInfo({
             <Value className="truncate font-mono">{webhookUrl}</Value>
             <IconButton
               icon={ClipboardIcon}
-              onClick={copyWebhookUrl}
+              onClick={() => copy(webhookUrl)}
               size="xs"
             />
           </div>

--- a/front/components/triggers/WebhookSourceDetailsInfo.tsx
+++ b/front/components/triggers/WebhookSourceDetailsInfo.tsx
@@ -1,5 +1,6 @@
 import {
   ClipboardIcon,
+  cn,
   EyeIcon,
   EyeSlashIcon,
   IconButton,
@@ -108,9 +109,9 @@ export function WebhookSourceDetailsInfo({
             <Page.H variant="h6">Secret</Page.H>
             <div className="flex items-center space-x-2">
               <div
-                className={`font-mono ${
-                  isSecretVisible ? "" : "select-none blur-sm"
-                }`}
+                className={cn("font-mono", {
+                  "select-none blur-sm": !isSecretVisible,
+                })}
               >
                 <Page.P>{webhookSourceView.webhookSource.secret}</Page.P>
               </div>

--- a/front/components/triggers/WebhookSourceViewForm.tsx
+++ b/front/components/triggers/WebhookSourceViewForm.tsx
@@ -1,0 +1,90 @@
+import { Button, Input } from "@dust-tt/sparkle";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { useCallback } from "react";
+import { Controller, useForm } from "react-hook-form";
+
+import { useUpdateWebhookSourceView } from "@app/lib/swr/webhook_source";
+import type { LightWorkspaceType } from "@app/types";
+import type {
+  PatchWebhookSourceViewBody,
+  WebhookSourceViewType,
+} from "@app/types/triggers/webhooks";
+import { patchWebhookSourceViewBodySchema } from "@app/types/triggers/webhooks";
+
+interface WebhookSourceViewFormProps {
+  owner: LightWorkspaceType;
+  webhookSourceView: WebhookSourceViewType;
+}
+
+export function WebhookSourceViewForm({
+  owner,
+  webhookSourceView,
+}: WebhookSourceViewFormProps) {
+  const { updateWebhookSourceView } = useUpdateWebhookSourceView({ owner });
+
+  const form = useForm<PatchWebhookSourceViewBody>({
+    resolver: zodResolver(patchWebhookSourceViewBodySchema),
+    defaultValues: {
+      name:
+        webhookSourceView.customName ?? webhookSourceView.webhookSource.name,
+    },
+  });
+
+  const onSubmit = useCallback(
+    async (values: PatchWebhookSourceViewBody) => {
+      const success = await updateWebhookSourceView(webhookSourceView.sId, {
+        name: values.name,
+      });
+
+      if (success) {
+        form.reset(values);
+      }
+    },
+    [updateWebhookSourceView, webhookSourceView.sId, form]
+  );
+
+  return (
+    <div className="space-y-5 text-foreground dark:text-foreground-night">
+      <div className="flex items-end space-x-2">
+        <div className="flex-grow">
+          <Controller
+            control={form.control}
+            name="name"
+            render={({ field }) => (
+              <Input
+                {...field}
+                label="Custom Name"
+                isError={!!form.formState.errors.name}
+                message={form.formState.errors.name?.message}
+                placeholder={webhookSourceView.webhookSource.name}
+              />
+            )}
+          />
+        </div>
+      </div>
+
+      {form.formState.isDirty && (
+        <div className="flex flex-row items-end justify-end gap-2">
+          <Button
+            variant="outline"
+            label={"Cancel"}
+            disabled={form.formState.isSubmitting}
+            onClick={() => {
+              form.reset();
+            }}
+          />
+
+          <Button
+            variant="highlight"
+            label={form.formState.isSubmitting ? "Saving..." : "Save"}
+            disabled={form.formState.isSubmitting}
+            onClick={async (event: Event) => {
+              event.preventDefault();
+              void form.handleSubmit(onSubmit)();
+            }}
+          />
+        </div>
+      )}
+    </div>
+  );
+}

--- a/front/lib/swr/webhook_source.ts
+++ b/front/lib/swr/webhook_source.ts
@@ -1,4 +1,4 @@
-import { useMemo } from "react";
+import { useCallback, useMemo } from "react";
 import type { Fetcher } from "swr";
 
 import { useSendNotification } from "@app/hooks/useNotification";
@@ -116,4 +116,52 @@ export function useCreateWebhookSource({
   };
 
   return createWebhookSource;
+}
+
+export function useUpdateWebhookSourceView({
+  owner,
+}: {
+  owner: LightWorkspaceType;
+}) {
+  const sendNotification = useSendNotification();
+
+  const updateWebhookSourceView = useCallback(
+    async (
+      webhookSourceViewId: string,
+      updates: { name: string }
+    ): Promise<boolean> => {
+      try {
+        const response = await fetch(
+          `/api/w/${owner.sId}/webhook_sources/views/${webhookSourceViewId}`,
+          {
+            method: "PATCH",
+            headers: {
+              "Content-Type": "application/json",
+            },
+            body: JSON.stringify(updates),
+          }
+        );
+
+        if (!response.ok) {
+          throw new Error("Network response was not ok");
+        }
+
+        sendNotification({
+          type: "success",
+          title: "Successfully updated webhook source view",
+        });
+
+        return true;
+      } catch (error) {
+        sendNotification({
+          type: "error",
+          title: "Failed to update webhook source view",
+        });
+        return false;
+      }
+    },
+    [owner.sId, sendNotification]
+  );
+
+  return { updateWebhookSourceView };
 }

--- a/front/pages/api/w/[wId]/webhook_sources/views/[viewId]/index.test.ts
+++ b/front/pages/api/w/[wId]/webhook_sources/views/[viewId]/index.test.ts
@@ -1,0 +1,257 @@
+import type { RequestMethod } from "node-mocks-http";
+import { describe, expect, it, vi } from "vitest";
+
+import { DustError } from "@app/lib/error";
+import { WebhookSourcesViewResource } from "@app/lib/resources/webhook_sources_view_resource";
+import { createPrivateApiMockRequest } from "@app/tests/utils/generic_private_api_tests";
+import { SpaceFactory } from "@app/tests/utils/SpaceFactory";
+import { WebhookSourceViewFactory } from "@app/tests/utils/WebhookSourceViewFactory";
+import { Err } from "@app/types";
+
+import handler from "./index";
+
+async function setupTest(
+  role: "builder" | "user" | "admin" = "admin",
+  method: RequestMethod = "GET"
+) {
+  const { req, res, workspace, authenticator } =
+    await createPrivateApiMockRequest({
+      role,
+      method,
+    });
+
+  const systemSpace = await SpaceFactory.system(workspace);
+
+  // Set up common query parameters
+  req.query.wId = workspace.sId;
+
+  return { req, res, workspace, auth: authenticator, systemSpace };
+}
+
+describe("GET /api/w/[wId]/webhook_sources/views/[viewId]", () => {
+  it("should return webhook source view when valid viewId is provided", async () => {
+    const { req, res, workspace } = await setupTest("admin", "GET");
+
+    const globalSpace = await SpaceFactory.global(workspace);
+    const webhookSourceViewFactory = new WebhookSourceViewFactory(workspace);
+    const webhookSourceView =
+      await webhookSourceViewFactory.create(globalSpace);
+
+    expect(webhookSourceView).not.toBeNull();
+    req.query.viewId = webhookSourceView.sId;
+
+    await handler(req, res);
+
+    expect(res._getStatusCode()).toBe(200);
+    const responseData = res._getJSONData();
+    expect(responseData.webhookSourceView).toBeDefined();
+    expect(responseData.webhookSourceView.sId).toBe(webhookSourceView.sId);
+    expect(responseData.webhookSourceView.webhookSource).toBeDefined();
+  });
+
+  it("should return 404 when webhook source view does not exist", async () => {
+    const { req, res } = await setupTest("admin", "GET");
+
+    req.query.viewId = "non_existent_view_id";
+
+    await handler(req, res);
+
+    expect(res._getStatusCode()).toBe(404);
+    const responseData = res._getJSONData();
+    expect(responseData.error.type).toBe("webhook_source_view_not_found");
+    expect(responseData.error.message).toBe("Webhook source view not found");
+  });
+
+  it("should return 400 when viewId parameter is invalid", async () => {
+    const { req, res } = await setupTest("admin", "GET");
+
+    req.query.viewId = ["invalid", "array"];
+
+    await handler(req, res);
+
+    expect(res._getStatusCode()).toBe(400);
+    const responseData = res._getJSONData();
+    expect(responseData.error.type).toBe("invalid_request_error");
+    expect(responseData.error.message).toBe("Invalid path parameters.");
+  });
+
+  it("should work for user role when accessing valid webhook source view", async () => {
+    const { req, res, workspace } = await setupTest("user", "GET");
+
+    const globalSpace = await SpaceFactory.global(workspace);
+    const webhookSourceViewFactory = new WebhookSourceViewFactory(workspace);
+    const webhookSourceView =
+      await webhookSourceViewFactory.create(globalSpace);
+
+    expect(webhookSourceView).not.toBeNull();
+    req.query.viewId = webhookSourceView.sId;
+
+    await handler(req, res);
+
+    expect(res._getStatusCode()).toBe(200);
+    const responseData = res._getJSONData();
+    expect(responseData.webhookSourceView).toBeDefined();
+    expect(responseData.webhookSourceView.sId).toBe(webhookSourceView.sId);
+  });
+});
+
+describe("PATCH /api/w/[wId]/webhook_sources/views/[viewId]", () => {
+  it("should update webhook source view name successfully", async () => {
+    const { req, res, workspace } = await setupTest("admin", "PATCH");
+
+    const globalSpace = await SpaceFactory.global(workspace);
+    const webhookSourceViewFactory = new WebhookSourceViewFactory(workspace);
+    const webhookSourceView =
+      await webhookSourceViewFactory.create(globalSpace);
+
+    expect(webhookSourceView).not.toBeNull();
+    req.query.viewId = webhookSourceView.sId;
+    req.body = {
+      name: "Updated Webhook View Name",
+    };
+
+    await handler(req, res);
+
+    expect(res._getStatusCode()).toBe(200);
+    const responseData = res._getJSONData();
+    expect(responseData.webhookSourceView).toBeDefined();
+    expect(responseData.webhookSourceView.customName).toBe(
+      "Updated Webhook View Name"
+    );
+  });
+
+  it("should return 400 when name is not provided in request body", async () => {
+    const { req, res, workspace } = await setupTest("admin", "PATCH");
+
+    const globalSpace = await SpaceFactory.global(workspace);
+    const webhookSourceViewFactory = new WebhookSourceViewFactory(workspace);
+    const webhookSourceView =
+      await webhookSourceViewFactory.create(globalSpace);
+
+    expect(webhookSourceView).not.toBeNull();
+    req.query.viewId = webhookSourceView.sId;
+    req.body = {};
+
+    await handler(req, res);
+
+    expect(res._getStatusCode()).toBe(400);
+    const responseData = res._getJSONData();
+    expect(responseData.error.type).toBe("invalid_request_error");
+    expect(responseData.error.message).toBe("Invalid request body");
+  });
+
+  it("should return 400 when name is empty string", async () => {
+    const { req, res, workspace } = await setupTest("admin", "PATCH");
+
+    const globalSpace = await SpaceFactory.global(workspace);
+    const webhookSourceViewFactory = new WebhookSourceViewFactory(workspace);
+    const webhookSourceView =
+      await webhookSourceViewFactory.create(globalSpace);
+
+    expect(webhookSourceView).not.toBeNull();
+    req.query.viewId = webhookSourceView.sId;
+    req.body = {
+      name: "",
+    };
+
+    await handler(req, res);
+
+    expect(res._getStatusCode()).toBe(400);
+    const responseData = res._getJSONData();
+    expect(responseData.error.type).toBe("invalid_request_error");
+    expect(responseData.error.message).toBe("Invalid request body");
+  });
+
+  it("should return 404 when trying to update non-existent webhook source view", async () => {
+    const { req, res } = await setupTest("admin", "PATCH");
+
+    req.query.viewId = "non_existent_view_id";
+    req.body = {
+      name: "Updated Name",
+    };
+
+    await handler(req, res);
+
+    expect(res._getStatusCode()).toBe(404);
+    const responseData = res._getJSONData();
+    expect(responseData.error.type).toBe("webhook_source_view_not_found");
+    expect(responseData.error.message).toBe("Webhook source view not found");
+  });
+
+  it("should fail to update view when user has insufficient permissions", async () => {
+    const { req, res, workspace } = await setupTest("user", "PATCH");
+
+    const globalSpace = await SpaceFactory.global(workspace);
+    const webhookSourceViewFactory = new WebhookSourceViewFactory(workspace);
+    const webhookSourceView =
+      await webhookSourceViewFactory.create(globalSpace);
+
+    expect(webhookSourceView).not.toBeNull();
+    req.query.viewId = webhookSourceView.sId;
+
+    req.body = { name: "Updated Name" };
+    await handler(req, res);
+
+    expect(res._getStatusCode()).toBe(401);
+    const responseData = res._getJSONData();
+    expect(responseData.error.type).toBe("webhook_source_view_auth_error");
+  });
+
+  it("should return 400 when viewId parameter is invalid", async () => {
+    const { req, res } = await setupTest("admin", "PATCH");
+
+    req.query.viewId = ["invalid", "array"];
+    req.body = {
+      name: "Updated Name",
+    };
+
+    await handler(req, res);
+
+    expect(res._getStatusCode()).toBe(400);
+    const responseData = res._getJSONData();
+    expect(responseData.error.type).toBe("invalid_request_error");
+    expect(responseData.error.message).toBe("Invalid path parameters.");
+  });
+
+  it("should handle update failure gracefully", async () => {
+    const { req, res, workspace } = await setupTest("admin", "PATCH");
+
+    const globalSpace = await SpaceFactory.global(workspace);
+    const webhookSourceViewFactory = new WebhookSourceViewFactory(workspace);
+    const webhookSourceView =
+      await webhookSourceViewFactory.create(globalSpace);
+
+    expect(webhookSourceView).not.toBeNull();
+    req.query.viewId = webhookSourceView.sId;
+    req.body = {
+      name: "Updated Name",
+    };
+
+    // Mock the fetchById method to return a webhook source view with failing updateName
+    const mockWebhookSourceView = {
+      ...webhookSourceView,
+      updateName: vi
+        .fn()
+        .mockResolvedValue(
+          new Err(new DustError("internal_error", "Test error"))
+        ),
+      toJSON: vi.fn().mockReturnValue(webhookSourceView.toJSON()),
+    };
+
+    const fetchByIdSpy = vi
+      .spyOn(WebhookSourcesViewResource, "fetchById")
+      .mockResolvedValue(mockWebhookSourceView as any);
+
+    await handler(req, res);
+
+    expect(res._getStatusCode()).toBe(500);
+    const responseData = res._getJSONData();
+    expect(responseData.error.type).toBe("internal_server_error");
+    expect(responseData.error.message).toBe(
+      "Failed to update webhook source view name."
+    );
+
+    // Restore the spy
+    fetchByIdSpy.mockRestore();
+  });
+});

--- a/front/pages/api/w/[wId]/webhook_sources/views/[viewId]/index.ts
+++ b/front/pages/api/w/[wId]/webhook_sources/views/[viewId]/index.ts
@@ -1,0 +1,118 @@
+import type { NextApiRequest, NextApiResponse } from "next";
+
+import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
+import type { Authenticator } from "@app/lib/auth";
+import { WebhookSourcesViewResource } from "@app/lib/resources/webhook_sources_view_resource";
+import { apiError } from "@app/logger/withlogging";
+import type { WithAPIErrorResponse } from "@app/types";
+import type { WebhookSourceViewType } from "@app/types/triggers/webhooks";
+import { patchWebhookSourceViewBodySchema } from "@app/types/triggers/webhooks";
+
+export type GetWebhookSourceViewResponseBody = {
+  webhookSourceView: WebhookSourceViewType;
+};
+
+export type PatchWebhookSourceViewResponseBody = {
+  webhookSourceView: WebhookSourceViewType;
+};
+
+async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse<
+    WithAPIErrorResponse<
+      GetWebhookSourceViewResponseBody | PatchWebhookSourceViewResponseBody
+    >
+  >,
+  auth: Authenticator
+): Promise<void> {
+  const { viewId } = req.query;
+
+  if (typeof viewId !== "string") {
+    return apiError(req, res, {
+      status_code: 400,
+      api_error: {
+        type: "invalid_request_error",
+        message: "Invalid path parameters.",
+      },
+    });
+  }
+
+  const webhookSourceView = await WebhookSourcesViewResource.fetchById(
+    auth,
+    viewId
+  );
+
+  if (webhookSourceView === null) {
+    return apiError(req, res, {
+      status_code: 404,
+      api_error: {
+        type: "webhook_source_view_not_found",
+        message: "Webhook source view not found",
+      },
+    });
+  }
+
+  switch (req.method) {
+    case "GET": {
+      return res.status(200).json({
+        webhookSourceView: webhookSourceView.toJSON(),
+      });
+    }
+
+    case "PATCH": {
+      const bodyValidation = patchWebhookSourceViewBodySchema.safeParse(
+        req.body
+      );
+      if (!bodyValidation.success) {
+        return apiError(req, res, {
+          status_code: 400,
+          api_error: {
+            type: "invalid_request_error",
+            message: "Invalid request body",
+          },
+        });
+      }
+
+      const { name } = bodyValidation.data;
+
+      const result = await webhookSourceView.updateName(auth, name);
+      if (result.isErr()) {
+        switch (result.error.code) {
+          case "unauthorized":
+            return apiError(req, res, {
+              status_code: 401,
+              api_error: {
+                type: "webhook_source_view_auth_error",
+                message:
+                  "You are not authorized to update this webhook source view.",
+              },
+            });
+          default:
+            return apiError(req, res, {
+              status_code: 500,
+              api_error: {
+                type: "internal_server_error",
+                message: "Failed to update webhook source view name.",
+              },
+            });
+        }
+      }
+
+      return res.status(200).json({
+        webhookSourceView: webhookSourceView.toJSON(),
+      });
+    }
+
+    default:
+      return apiError(req, res, {
+        status_code: 405,
+        api_error: {
+          type: "method_not_supported_error",
+          message:
+            "The method passed is not supported, GET and PATCH are expected.",
+        },
+      });
+  }
+}
+
+export default withSessionAuthenticationForWorkspace(handler);

--- a/front/tests/utils/WebhookSourceViewFactory.ts
+++ b/front/tests/utils/WebhookSourceViewFactory.ts
@@ -1,0 +1,71 @@
+import { Authenticator } from "@app/lib/auth";
+import { SpaceResource } from "@app/lib/resources/space_resource";
+import { WebhookSourcesViewResource } from "@app/lib/resources/webhook_sources_view_resource";
+import type { WorkspaceType } from "@app/types";
+
+import { WebhookSourceFactory } from "./WebhookSourceFactory";
+
+export class WebhookSourceViewFactory {
+  private workspace: WorkspaceType;
+
+  constructor(workspace: WorkspaceType) {
+    this.workspace = workspace;
+  }
+
+  async create(
+    space: SpaceResource,
+    options: {
+      webhookSourceId?: number;
+      customName?: string;
+    } = {}
+  ) {
+    const auth = await Authenticator.internalAdminForWorkspace(
+      this.workspace.sId
+    );
+
+    // If no webhook source ID provided, create one
+    let webhookSourceId = options.webhookSourceId;
+    if (!webhookSourceId) {
+      const webhookSourceFactory = new WebhookSourceFactory(this.workspace);
+      const webhookSourceResult = await webhookSourceFactory.create();
+      if (webhookSourceResult.isErr()) {
+        throw webhookSourceResult.error;
+      }
+      webhookSourceId = webhookSourceResult.value.id;
+    }
+
+    const customName = options.customName || null;
+
+    // First create a system space view (required for creation)
+    const systemSpace = await SpaceResource.fetchWorkspaceSystemSpace(auth);
+    let systemView =
+      await WebhookSourcesViewResource.getWebhookSourceViewForSystemSpace(
+        auth,
+        webhookSourceId
+      );
+
+    // If no system view exists, create one using the private makeNew method
+    if (!systemView) {
+      systemView = await (WebhookSourcesViewResource as any).makeNew(
+        auth,
+        {
+          webhookSourceId,
+          customName,
+        },
+        systemSpace,
+        auth.user() ?? undefined
+      );
+    }
+
+    // If the requested space is system space, return the system view
+    if (space.kind === "system") {
+      return systemView!;
+    }
+
+    // Otherwise create a view for the requested space
+    return WebhookSourcesViewResource.create(auth, {
+      systemView: systemView!,
+      space,
+    });
+  }
+}

--- a/front/tests/utils/WebhookSourceViewFactory.ts
+++ b/front/tests/utils/WebhookSourceViewFactory.ts
@@ -1,5 +1,5 @@
 import { Authenticator } from "@app/lib/auth";
-import { SpaceResource } from "@app/lib/resources/space_resource";
+import type { SpaceResource } from "@app/lib/resources/space_resource";
 import { WebhookSourcesViewResource } from "@app/lib/resources/webhook_sources_view_resource";
 import type { WorkspaceType } from "@app/types";
 
@@ -34,27 +34,15 @@ export class WebhookSourceViewFactory {
       webhookSourceId = webhookSourceResult.value.id;
     }
 
-    const customName = options.customName || null;
-
-    // First create a system space view (required for creation)
-    const systemSpace = await SpaceResource.fetchWorkspaceSystemSpace(auth);
-    let systemView =
+    const systemView =
       await WebhookSourcesViewResource.getWebhookSourceViewForSystemSpace(
         auth,
         webhookSourceId
       );
 
-    // If no system view exists, create one using the private makeNew method
+    // System view should be created on webhookSourceFactory.create();
     if (!systemView) {
-      systemView = await (WebhookSourcesViewResource as any).makeNew(
-        auth,
-        {
-          webhookSourceId,
-          customName,
-        },
-        systemSpace,
-        auth.user() ?? undefined
-      );
+      throw new Error("System view for webhook source not found");
     }
 
     // If the requested space is system space, return the system view

--- a/front/types/error.ts
+++ b/front/types/error.ts
@@ -116,6 +116,8 @@ const API_ERROR_TYPES = [
   // Triggers:
   "trigger_not_found",
   "webhook_source_not_found",
+  "webhook_source_view_auth_error",
+  "webhook_source_view_not_found",
   // MCP Server Connections:
   "mcp_server_connection_not_found",
   "mcp_server_view_not_found",

--- a/front/types/triggers/webhooks.ts
+++ b/front/types/triggers/webhooks.ts
@@ -49,3 +49,11 @@ export const PostWebhookSourcesSchema = z.object({
   customHeaders: z.record(z.string(), z.string()).nullable(),
   includeGlobal: z.boolean().optional(),
 });
+
+export type PatchWebhookSourceViewBody = z.infer<
+  typeof patchWebhookSourceViewBodySchema
+>;
+
+export const patchWebhookSourceViewBodySchema = z.object({
+  name: z.string().min(1, "Name is required."),
+});


### PR DESCRIPTION
## Description

[4184](https://github.com/dust-tt/tasks/issues/4184)
This PR enables seeing webhook source informations when clicking on it on the system triggers table page.
<img width="578" height="989" alt="Screenshot 2025-09-16 at 18 16 06" src="https://github.com/user-attachments/assets/d0b19f7f-9d59-4af6-bd09-0b29a2ec31b5" />



## Tests

Added some tests for the get webhook source view and patch webhhook source view apis

## Risk

low, feature flagged

## Deploy Plan

front