### PR TITLE
[Tokenize Timeout] Abort long tokenize calls and return 504 on timeout

### DIFF
--- a/connectors/src/lib/data_sources.ts
+++ b/connectors/src/lib/data_sources.ts
@@ -520,7 +520,8 @@ export async function renderPrefixSection({
   };
 }
 
-const TOKENIZE_TIMEOUT_MS = 270000; // 4.5 minutes to avoid 5min activity timeouts
+// At 5mn, likeliness of connection close increases significantly. The timeout is set at 4mn30.
+const TOKENIZE_TIMEOUT_MS = 270000;
 
 async function tokenize(text: string, ds: DataSourceConfig) {
   if (!text) {

--- a/front/pages/api/v1/w/[wId]/spaces/[spaceId]/data_sources/[dsId]/tokenize.ts
+++ b/front/pages/api/v1/w/[wId]/spaces/[spaceId]/data_sources/[dsId]/tokenize.ts
@@ -26,7 +26,8 @@ const PostDatasourceTokenizeBodySchema = t.type({
  * @ignoreswagger
  * This endpoint is not to be included in the public API docs.
  */
-const CORE_TOKENIZE_TIMEOUT_MS = 270000; // 4.5 minutes
+// At 5mn, likeliness of connection close increases significantly. The timeout is set at 4mn30.
+const CORE_TOKENIZE_TIMEOUT_MS = 270000;
 
 async function handler(
   req: NextApiRequest,

--- a/front/types/core/core_api.ts
+++ b/front/types/core/core_api.ts
@@ -1533,15 +1533,26 @@ export class CoreAPI {
     return this._resultFromResponse(response);
   }
 
-  async dataSourceTokenize({
-    text,
-    projectId,
-    dataSourceId,
-  }: {
-    text: string;
-    projectId: string;
-    dataSourceId: string;
-  }): Promise<CoreAPIResponse<{ tokens: CoreAPITokenType[] }>> {
+  async dataSourceTokenize(
+    {
+      text,
+      projectId,
+      dataSourceId,
+    }: {
+      text: string;
+      projectId: string;
+      dataSourceId: string;
+    },
+    opts?: { signal?: AbortSignal; timeoutMs?: number }
+  ): Promise<CoreAPIResponse<{ tokens: CoreAPITokenType[] }>> {
+    // Support optional timeout via AbortController to avoid excessively long calls.
+    let signal: AbortSignal | undefined = opts?.signal;
+    let timeoutId: ReturnType<typeof setTimeout> | undefined;
+    if (!signal && opts?.timeoutMs && opts.timeoutMs > 0) {
+      const controller = new AbortController();
+      signal = controller.signal;
+      timeoutId = setTimeout(() => controller.abort(), opts.timeoutMs);
+    }
     const response = await this._fetchWithError(
       `${this._url}/projects/${encodeURIComponent(
         projectId
@@ -1552,8 +1563,12 @@ export class CoreAPI {
           "Content-Type": "application/json",
         },
         body: JSON.stringify({ text }),
+        signal,
       }
     );
+    if (timeoutId) {
+      clearTimeout(timeoutId);
+    }
     return this._resultFromResponse(response);
   }
 
@@ -2277,10 +2292,18 @@ export class CoreAPI {
       return new Ok({ response: res, duration: Date.now() - now });
     } catch (e) {
       const duration = Date.now() - now;
-      const err: CoreAPIError = {
-        code: "unexpected_network_error",
-        message: `Unexpected network error from CoreAPI: ${e}`,
-      };
+      const isAbort = (init && init.signal && (init.signal as AbortSignal).aborted) ||
+        // Some environments throw an AbortError with name property.
+        ((e as any)?.name === "AbortError");
+      const err: CoreAPIError = isAbort
+        ? {
+            code: "request_timeout",
+            message: `CoreAPI request aborted due to timeout`,
+          }
+        : {
+            code: "unexpected_network_error",
+            message: `Unexpected network error from CoreAPI: ${e}`,
+          };
       this._logger.error(
         {
           url,

--- a/front/types/core/core_api.ts
+++ b/front/types/core/core_api.ts
@@ -2292,9 +2292,10 @@ export class CoreAPI {
       return new Ok({ response: res, duration: Date.now() - now });
     } catch (e) {
       const duration = Date.now() - now;
-      const isAbort = (init && init.signal && (init.signal as AbortSignal).aborted) ||
+      const isAbort =
+        (init && init.signal && (init.signal as AbortSignal).aborted) ||
         // Some environments throw an AbortError with name property.
-        ((e as any)?.name === "AbortError");
+        (e as any)?.name === "AbortError";
       const err: CoreAPIError = isAbort
         ? {
             code: "request_timeout",

--- a/sdks/js/src/index.ts
+++ b/sdks/js/src/index.ts
@@ -1073,11 +1073,16 @@ export class DustAPI {
     return this._resultFromResponse(PostMessageFeedbackResponseSchema, res);
   }
 
-  async tokenize(text: string, dataSourceId: string) {
+  async tokenize(
+    text: string,
+    dataSourceId: string,
+    opts?: { signal?: AbortSignal }
+  ) {
     const res = await this.request({
       method: "POST",
       path: `data_sources/${dataSourceId}/tokenize`,
       body: { text },
+      signal: opts?.signal,
     });
 
     const r = await this._resultFromResponse(TokenizeResponseSchema, res);


### PR DESCRIPTION
## Description
Fixes Activity failures on long tokenizing text calls by adding an end-to-end timeout and clean error propagation on the tokenize path.

- SDK (@dust-tt/client): DustAPI.tokenize now accepts an optional AbortSignal. No breaking change to existing callers.
- Connectors: Apply a 4.5-minute timeout to `tokenize` in `connectors/src/lib/data_sources.ts`.
- Front Core client: `CoreAPI.dataSourceTokenize` accepts an optional signal/timeout and maps aborted fetches to `CoreAPIError { code: "request_timeout" }`.
- Front API route: `/data_sources/[dsId]/tokenize` calls Core with a 4.5-minute timeout and returns HTTP 504 on timeout; preserves 500 for other errors.

This prevents >5 min hangs that caused Temporal activity failures, avoid oversolliciting core on dead ends that will likely close anyways, while keeping clear, classifiable errors.

## Risks
Blast radius: Tokenization calls from connectors via front; SDK `tokenize` API (optional param only).
Risk: low

## Deploy Plan
- Deploy Front
- Deploy Connectors
