### PR TITLE
Prefer nullish coalescing front

### DIFF
--- a/front/.eslintrc.js
+++ b/front/.eslintrc.js
@@ -23,6 +23,7 @@ module.exports = {
         checksVoidReturn: false,
       },
     ],
+    "@typescript-eslint/prefer-nullish-coalescing": "error",
     "jsx-a11y/alt-text": 0,
     "no-restricted-syntax": [
       "error",

--- a/front/components/ContentNodeTree.tsx
+++ b/front/components/ContentNodeTree.tsx
@@ -203,6 +203,7 @@ function ContentNodeTreeChildren({
       {!isResourcesLoading &&
         filteredNodes &&
         filteredNodes.length === 0 &&
+        // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
         (emptyComponent || <Tree.Empty label="No documents" />)}
 
       {filteredNodes.map((n, i) => {
@@ -229,6 +230,7 @@ function ContentNodeTreeChildren({
               (n.preventSelection !== true || checkedState === "partial") &&
               selectedNodes
                 ? {
+                    // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
                     disabled: parentIsSelected || !setSelectedNodes,
                     checked: checkedState,
                     onCheckedChange: (v) => {

--- a/front/components/DataSourceViewPermissionTree.tsx
+++ b/front/components/DataSourceViewPermissionTree.tsx
@@ -65,7 +65,7 @@ export function DataSourceViewPermissionTree({
         owner,
         dataSourceView,
         viewType
-      // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
+        // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
       )(selectedParentId || parentId || null),
     [owner, dataSourceView, viewType, parentId]
   );

--- a/front/components/DataSourceViewPermissionTree.tsx
+++ b/front/components/DataSourceViewPermissionTree.tsx
@@ -65,6 +65,7 @@ export function DataSourceViewPermissionTree({
         owner,
         dataSourceView,
         viewType
+      // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
       )(selectedParentId || parentId || null),
     [owner, dataSourceView, viewType, parentId]
   );

--- a/front/components/WorkspacePicker.tsx
+++ b/front/components/WorkspacePicker.tsx
@@ -31,6 +31,7 @@ export const WorkspacePickerRadioGroup = ({
           return (
             <DropdownMenuRadioItem
               key={org.id}
+              // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
               value={org.externalId || ""}
               onClick={async () => {
                 if (org.externalId && org.externalId !== workspace.sId) {

--- a/front/components/actions/mcp/ConnectMCPServerDialog.tsx
+++ b/front/components/actions/mcp/ConnectMCPServerDialog.tsx
@@ -232,6 +232,7 @@ export function ConnectMCPServerDialog({
                 void handleSave();
               }
             },
+            // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
             disabled: !isFormValid || (authorization && !useCase) || isLoading,
           }}
         />

--- a/front/components/actions/mcp/CreateMCPServerDialog.tsx
+++ b/front/components/actions/mcp/CreateMCPServerDialog.tsx
@@ -503,6 +503,7 @@ export function CreateMCPServerDialog({
             },
             disabled:
               !isOAuthFormValid ||
+              // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
               (authorization && !useCase) ||
               (defaultServerConfig?.authMethod === "bearer" && !sharedSecret) ||
               (!internalMCPServer && !validateUrl(remoteServerUrl).valid) ||

--- a/front/components/actions/mcp/MCPServerDetailsSharing.tsx
+++ b/front/components/actions/mcp/MCPServerDetailsSharing.tsx
@@ -80,7 +80,7 @@ export function MCPServerDetailsSharing({
     mcpServerWithViews?.views.map((v) => ({
       ...v,
       space: spaces.find((space) => space.sId === v.spaceId),
-    // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
+      // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
     })) || [];
 
   const globalView = views.find((view) => view.space?.kind === "global");

--- a/front/components/actions/mcp/MCPServerDetailsSharing.tsx
+++ b/front/components/actions/mcp/MCPServerDetailsSharing.tsx
@@ -80,6 +80,7 @@ export function MCPServerDetailsSharing({
     mcpServerWithViews?.views.map((v) => ({
       ...v,
       space: spaces.find((space) => space.sId === v.spaceId),
+    // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
     })) || [];
 
   const globalView = views.find((view) => view.space?.kind === "global");

--- a/front/components/actions/mcp/MCPServerSettings.tsx
+++ b/front/components/actions/mcp/MCPServerSettings.tsx
@@ -71,6 +71,7 @@ export function MCPServerSettings({
     useState<MCPOAuthUseCase | null>();
 
   const useCase = useMemo(
+    // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
     () => (selectedUseCase || mcpServerView.oAuthUseCase) as MCPOAuthUseCase,
     [selectedUseCase, mcpServerView.oAuthUseCase]
   );

--- a/front/components/actions/mcp/MCPServerViewForm.tsx
+++ b/front/components/actions/mcp/MCPServerViewForm.tsx
@@ -28,6 +28,7 @@ export function MCPServerViewForm({
   const form = useForm<MCPFormType>({
     resolver: zodResolver(MCPFormSchema),
     defaultValues: {
+      // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
       name: mcpServerView.name || mcpServerView.server.name,
       description: getMcpServerViewDescription(mcpServerView),
     },

--- a/front/components/actions/mcp/RemoteMCPForm.tsx
+++ b/front/components/actions/mcp/RemoteMCPForm.tsx
@@ -50,6 +50,7 @@ export function RemoteMCPForm({
     resolver: zodResolver(MCPFormSchema),
     defaultValues: {
       icon: mcpServer.icon,
+      // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
       sharedSecret: mcpServer.sharedSecret || "",
     },
   });

--- a/front/components/actions/mcp/details/MCPAgentManagementActionDetails.tsx
+++ b/front/components/actions/mcp/details/MCPAgentManagementActionDetails.tsx
@@ -65,6 +65,7 @@ export function MCPAgentManagementActionDetails({
               content={
                 toolOutput
                   ?.map((o) => (o.type === "text" ? o.text : ""))
+                  // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
                   .join("\n") || "Agent creation completed."
               }
             />

--- a/front/components/actions/mcp/details/MCPDataSourcesFileSystemActionDetails.tsx
+++ b/front/components/actions/mcp/details/MCPDataSourcesFileSystemActionDetails.tsx
@@ -30,7 +30,9 @@ export function DataSourceNodeContentDetails({
     ?.filter(isDataSourceNodeContentType)
     .map((o) => o.resource)?.[0];
 
+  // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
   const { metadata, text } = dataSourceNodeContent || {};
+  // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
   const { sourceUrl } = metadata || {};
 
   return (
@@ -50,6 +52,7 @@ export function DataSourceNodeContentDetails({
               onClick={
                 sourceUrl ? () => window.open(sourceUrl, "_blank") : undefined
               }
+              // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
               tooltip={`${metadata.parentTitle || metadata.path}${metadata.lastUpdatedAt ? ` • ${metadata.lastUpdatedAt}` : ""}`}
             >
               <CitationIcons>
@@ -81,6 +84,7 @@ export function FilesystemPathDetails({
     ?.filter(isFilesystemPathType)
     .map((o) => o.resource)?.[0];
 
+  // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
   const { path } = filesystemPath || { path: [] };
 
   const breadcrumbItems: BreadcrumbItem[] = path?.map((item) =>

--- a/front/components/actions/mcp/details/MCPRunAgentActionDetails.tsx
+++ b/front/components/actions/mcp/details/MCPRunAgentActionDetails.tsx
@@ -72,9 +72,12 @@ export function MCPRunAgentActionDetails({
     disabled: addedMCPServerViewIds.length === 0,
   });
 
+  // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
   const queryResource = toolOutput?.find(isRunAgentQueryResourceType) || null;
+  // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
   const resultResource = toolOutput?.find(isRunAgentResultResourceType) || null;
   const handoverResource =
+    // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
     toolOutput?.find(isAgentPauseOutputResourceType) || null;
 
   const generatedFiles =
@@ -268,6 +271,7 @@ export function MCPRunAgentActionDetails({
                 </ContentMessage>
               </div>
             )}
+            {/* eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing */}
             {childAgent && (chainOfThought || response) && (
               <CollapsibleComponent
                 rootProps={{ defaultOpen: true }}
@@ -341,6 +345,7 @@ export function MCPRunAgentActionDetails({
                                           : undefined
                                       }
                                       tooltip={
+                                        // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
                                         document.description || document.title
                                       }
                                     >

--- a/front/components/actions/mcp/details/MCPToolOutputDetails.tsx
+++ b/front/components/actions/mcp/details/MCPToolOutputDetails.tsx
@@ -203,7 +203,9 @@ export function SearchResultDetails({
         return null;
       })
       .filter(Boolean)
+      // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
       .join("\n") ||
+    // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
     defaultQuery ||
     "No query provided";
 
@@ -253,6 +255,7 @@ export function SearchResultDetails({
               }`,
               title: node.title,
               icon: <IconComponent />,
+              // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
               href: node.sourceUrl || undefined,
             };
           });
@@ -267,6 +270,7 @@ export function SearchResultDetails({
               }`,
               title: metadata.title,
               icon: <IconComponent />,
+              // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
               href: metadata.sourceUrl || undefined,
             },
           ];

--- a/front/components/agent_builder/AgentBuilder.tsx
+++ b/front/components/agent_builder/AgentBuilder.tsx
@@ -239,8 +239,8 @@ export default function AgentBuilder({
         isDraft: false,
         agentConfigurationId: duplicateAgentId
           ? null
-          // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
-          : agentConfiguration?.sId || null,
+          : // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
+            agentConfiguration?.sId || null,
         areSlackChannelsChanged: form.getFieldState(
           "agentSettings.slackChannels"
         ).isDirty,

--- a/front/components/agent_builder/AgentBuilder.tsx
+++ b/front/components/agent_builder/AgentBuilder.tsx
@@ -188,6 +188,7 @@ export default function AgentBuilder({
       agentSettings: {
         ...baseValues.agentSettings,
         slackProvider,
+        // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
         editors: agentConfiguration || editors.length > 0 ? editors : [user],
         slackChannels: agentSlackChannels,
       },
@@ -238,6 +239,7 @@ export default function AgentBuilder({
         isDraft: false,
         agentConfigurationId: duplicateAgentId
           ? null
+          // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
           : agentConfiguration?.sId || null,
         areSlackChannelsChanged: form.getFieldState(
           "agentSettings.slackChannels"
@@ -257,6 +259,7 @@ export default function AgentBuilder({
       }
 
       const createdAgent = result.value;
+      // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
       const isCreatingNew = duplicateAgentId || !agentConfiguration;
 
       // Check if there's a warning about Slack channel linking
@@ -384,6 +387,7 @@ export default function AgentBuilder({
                 onClick: handleSave,
                 disabled: isSaveDisabled,
               }}
+              // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
               agentConfigurationId={agentConfiguration?.sId || null}
               isActionsLoading={isActionsLoading}
               isTriggersLoading={isTriggersLoading}

--- a/front/components/agent_builder/AgentBuilderPerformance.tsx
+++ b/front/components/agent_builder/AgentBuilderPerformance.tsx
@@ -59,11 +59,13 @@ export function AgentBuilderPerformance({
 
   const { agentConfiguration } = useAgentConfiguration({
     workspaceId: owner.sId,
+    // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
     agentConfigurationId: agentConfigurationSId || null,
   });
 
   const { agentAnalytics, isAgentAnalyticsLoading } = useAgentAnalytics({
     workspaceId: owner.sId,
+    // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
     agentConfigurationId: agentConfiguration?.sId || null,
     period,
   });

--- a/front/components/agent_builder/AgentBuilderPreview.tsx
+++ b/front/components/agent_builder/AgentBuilderPreview.tsx
@@ -208,6 +208,7 @@ export function AgentBuilderPreview() {
       // Update existing draft if agent name changed (with debouncing)
       // Normalize names for comparison (empty string becomes "Preview")
       const normalizedCurrentName = agentName?.trim() || "Preview";
+      // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
       const normalizedDraftName = draftAgent?.name?.trim() || "Preview";
 
       if (draftAgent && normalizedCurrentName !== normalizedDraftName) {

--- a/front/components/agent_builder/capabilities/knowledge/DataSourceBuilderSelector.tsx
+++ b/front/components/agent_builder/capabilities/knowledge/DataSourceBuilderSelector.tsx
@@ -228,10 +228,12 @@ export const DataSourceBuilderSelector = ({
         <div className="flex flex-col gap-2">
           <SearchInput
             name="search"
+            // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
             placeholder={`Search in ${currentSpace?.name || "space"}`}
             value={searchTerm}
             onChange={setSearchTerm}
           />
+          {/* eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing */}
           {(currentNode || currentDataSourceView) && isSearching && (
             <div className="flex items-center gap-1 px-1 py-1">
               <span className="mr-2 text-sm text-muted-foreground">

--- a/front/components/agent_builder/capabilities/knowledge/KnowledgeConfigurationSheet.tsx
+++ b/front/components/agent_builder/capabilities/knowledge/KnowledgeConfigurationSheet.tsx
@@ -362,8 +362,10 @@ function KnowledgeConfigurationSheetContent({
     },
     {
       id: CONFIGURATION_SHEET_PAGE_IDS.CONFIGURATION,
+      // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
       title: config?.configPageTitle || "Configure Knowledge",
       description:
+        // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
         config?.configPageDescription ||
         "Select knowledge type and configure settings",
       icon: config

--- a/front/components/agent_builder/capabilities/knowledge/KnowledgeFooter.tsx
+++ b/front/components/agent_builder/capabilities/knowledge/KnowledgeFooter.tsx
@@ -47,6 +47,7 @@ function KnowledgeFooterItemReadablePath({
       ) : (
         <span className="text-xs">
           {item.type === "data_source" ? (
+            // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
             spaceName || ""
           ) : (
             <>

--- a/front/components/agent_builder/capabilities/mcp/MCPServerSelectionPage.tsx
+++ b/front/components/agent_builder/capabilities/mcp/MCPServerSelectionPage.tsx
@@ -96,6 +96,7 @@ function MCPServerCard({
         onClick={onClick}
         cardContainerClassName="h-36"
         mountPortal
+        // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
         mountPortalContainer={containerRef.current || undefined}
         toolInfo={{
           label: "More info",
@@ -144,6 +145,7 @@ export function MCPServerSelectionPage({
   const hasDefaultViews = defaultMcpServerViews.length > 0;
   const hasNonDefaultViews = nonDefaultMcpServerViews.length > 0;
   const hasAnyResults =
+    // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
     hasDataVisualization || hasDefaultViews || hasNonDefaultViews;
 
   if (!hasAnyResults) {
@@ -164,6 +166,7 @@ export function MCPServerSelectionPage({
   return (
     <>
       <div className="flex flex-col gap-4 py-2">
+        {/* eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing */}
         {((dataVisualization && onDataVisualizationClick) ||
           defaultMcpServerViews) && (
           <span className="text-lg font-semibold">Top tools</span>

--- a/front/components/agent_builder/capabilities/mcp/MCPServerViewsSheet.tsx
+++ b/front/components/agent_builder/capabilities/mcp/MCPServerViewsSheet.tsx
@@ -471,6 +471,7 @@ export function MCPServerViewsSheet({
             configurable: false,
           };
         } else {
+          // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
           return tool.configuredAction || getDefaultMCPAction(tool.view);
         }
       })
@@ -584,6 +585,7 @@ export function MCPServerViewsSheet({
     },
     {
       id: TOOLS_SHEET_PAGE_IDS.CONFIGURATION,
+      // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
       title: mcpServerView?.name || "Configure Tool",
       description: "",
       icon: undefined,
@@ -660,6 +662,7 @@ export function MCPServerViewsSheet({
         mode?.type === "info" ? mode.action : null
       ),
       content:
+        // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
         infoMCPServerView ||
         (mode?.type === "info" &&
           mode.action?.type === "DATA_VISUALIZATION") ? (

--- a/front/components/agent_builder/capabilities/mcp/utils/formDefaults.ts
+++ b/front/components/agent_builder/capabilities/mcp/utils/formDefaults.ts
@@ -50,6 +50,7 @@ export function getDefaultConfiguration(
     set(
       additionalConfig,
       key,
+      // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
       defaultValue !== undefined ? defaultValue : false
     );
   }

--- a/front/components/agent_builder/capabilities/mcp/utils/toolDisplayUtils.ts
+++ b/front/components/agent_builder/capabilities/mcp/utils/toolDisplayUtils.ts
@@ -24,6 +24,7 @@ export function getSelectedToolLabel(
   dataVisualization?: ActionSpecification | null
 ): string {
   if (tool.type === "DATA_VISUALIZATION") {
+    // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
     return dataVisualization?.label || "";
   }
 

--- a/front/components/agent_builder/capabilities/shared/DataSourceViewTagsFilterDropdown.tsx
+++ b/front/components/agent_builder/capabilities/shared/DataSourceViewTagsFilterDropdown.tsx
@@ -67,6 +67,7 @@ export function DataSourceViewTagsFilterDropdown() {
             continue;
           }
 
+          // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
           let newTagsFilter: TagsFilter = source.tagsFilter || {
             in: [],
             not: [],

--- a/front/components/agent_builder/capabilities/shared/DustAppSection.tsx
+++ b/front/components/agent_builder/capabilities/shared/DustAppSection.tsx
@@ -140,6 +140,7 @@ export function DustAppSection() {
           <div className="flex flex-col gap-1">
             <div className="text-sm font-medium">{row.original.name}</div>
             <div className="line-clamp-2 text-xs text-muted-foreground dark:text-muted-foreground-night">
+              {/* eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing */}
               {row.original.description || "No description available"}
             </div>
           </div>

--- a/front/components/agent_builder/capabilities/shared/SelectedDataSources.tsx
+++ b/front/components/agent_builder/capabilities/shared/SelectedDataSources.tsx
@@ -225,6 +225,7 @@ export function SelectedDataSources() {
   );
 
   const isTableOrWarehouseServer = tablesServer.includes(
+    // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
     internalMcpServerView?.server.name || ""
   );
 

--- a/front/components/agent_builder/capabilities/shared/SelectionDisplay.tsx
+++ b/front/components/agent_builder/capabilities/shared/SelectionDisplay.tsx
@@ -24,6 +24,7 @@ export function SelectionDisplay({
         items.push({
           id: resource.internalId,
           title: resource.title,
+          // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
           path: resource.parentTitle || "Root",
           dataSourceViewName: config.dataSourceView.dataSource.name,
         });

--- a/front/components/agent_builder/get_spaceid_to_actions_map.test.ts
+++ b/front/components/agent_builder/get_spaceid_to_actions_map.test.ts
@@ -31,6 +31,7 @@ const createMockMCPAction = (
   name,
   description: `Description for ${name}`,
   configuration: {
+    // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
     mcpServerViewId: mcpServerViewId || "",
     dataSourceConfigurations: dataSourceConfigurations || null,
     tablesConfigurations: tablesConfigurations || null,

--- a/front/components/agent_builder/hooks/useAgentPreview.ts
+++ b/front/components/agent_builder/hooks/useAgentPreview.ts
@@ -125,6 +125,7 @@ export function useDraftConversation({
   const [conversationId, setConversationId] = useState<string | null>(null);
 
   const { conversation } = useConversation({
+    // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
     conversationId: conversationId || "",
     workspaceId: owner.sId,
     options: {
@@ -227,6 +228,7 @@ export function useDraftConversation({
   }, []);
 
   const setConversation = (newConversation: ConversationType | null) => {
+    // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
     setConversationId(newConversation?.sId || null);
   };
 

--- a/front/components/agent_builder/instructions/AgentBuilderInstructionsEditor.tsx
+++ b/front/components/agent_builder/instructions/AgentBuilderInstructionsEditor.tsx
@@ -205,6 +205,7 @@ export function AgentBuilderInstructionsEditor({
       }
 
       const currentText = plainTextFromTipTapContent(editor.getJSON());
+      // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
       const compareText = compareVersion.instructions || "";
 
       editor.commands.applyDiff(compareText, currentText);

--- a/front/components/agent_builder/instructions/extensions/AgentBuilderInstructionsAutoCompleteExtension.ts
+++ b/front/components/agent_builder/instructions/extensions/AgentBuilderInstructionsAutoCompleteExtension.ts
@@ -62,6 +62,7 @@ const fetchAgentBuilderSuggestions = async (
               builderState?.actions?.map((action) => ({
                 name: action.name,
                 description: action.description,
+              // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
               })) || []
             ),
           },

--- a/front/components/agent_builder/instructions/extensions/AgentBuilderInstructionsAutoCompleteExtension.ts
+++ b/front/components/agent_builder/instructions/extensions/AgentBuilderInstructionsAutoCompleteExtension.ts
@@ -62,7 +62,7 @@ const fetchAgentBuilderSuggestions = async (
               builderState?.actions?.map((action) => ({
                 name: action.name,
                 description: action.description,
-              // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
+                // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
               })) || []
             ),
           },

--- a/front/components/agent_builder/instructions/extensions/InstructionBlockExtension.tsx
+++ b/front/components/agent_builder/instructions/extensions/InstructionBlockExtension.tsx
@@ -251,6 +251,7 @@ export const InstructionBlockExtension =
         type: {
           default: "instructions",
           parseHTML: (element) =>
+            // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
             element.getAttribute("data-instruction-type") || "instructions",
           renderHTML: (attributes) => ({
             "data-instruction-type": attributes.type,
@@ -860,6 +861,7 @@ export const InstructionBlockExtension =
                 } else if (child.type.name === "paragraph") {
                   parts.push(child.textContent);
                 } else if (child.isText) {
+                  // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
                   parts.push(child.text || "");
                 } else {
                   parts.push(child.textBetween(0, child.content.size, "\n"));

--- a/front/components/agent_builder/settings/AgentBuilderSettingsBlock.tsx
+++ b/front/components/agent_builder/settings/AgentBuilderSettingsBlock.tsx
@@ -375,9 +375,11 @@ function AgentPictureInput() {
         onPick={field.onChange}
         droidAvatarUrls={DROID_AVATAR_URLS}
         spiritAvatarUrls={SPIRIT_AVATAR_URLS}
+        // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
         avatarUrl={field.value || null}
       />
       <div className="group relative">
+        {/* eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing */}
         <Avatar size="lg" visual={field.value || null} />
         <Button
           variant="outline"

--- a/front/components/agent_builder/settings/EditorsSheet.tsx
+++ b/front/components/agent_builder/settings/EditorsSheet.tsx
@@ -122,6 +122,7 @@ export function EditorsSheet() {
         sId: editor.sId,
         fullName: editor.fullName,
         email: editor.email,
+        // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
         image: editor.image || "",
         isEditor: true,
         onToggleEditor: () => onRemoveEditor(editor),
@@ -134,6 +135,7 @@ export function EditorsSheet() {
           sId: member.sId,
           fullName: member.fullName,
           email: member.email,
+          // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
           image: member.image || "",
           isEditor: localEditorsSet.has(member.sId),
           onToggleEditor: localEditorsSet.has(member.sId)

--- a/front/components/agent_builder/settings/SlackSettingsSheet.tsx
+++ b/front/components/agent_builder/settings/SlackSettingsSheet.tsx
@@ -217,6 +217,7 @@ export function SlackSettingsSheet({
   useEffect(() => {
     setLocalSlackChannels([...(slackChannels || [])]);
     const currentAutoRespondWithoutMention =
+      // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
       (slackChannels || [])[0]?.autoRespondWithoutMention || false;
     setAutoRespondWithoutMentionEnabled(currentAutoRespondWithoutMention);
   }, [slackChannels]);
@@ -225,6 +226,7 @@ export function SlackSettingsSheet({
     if (isOpen) {
       setLocalSlackChannels([...(slackChannels || [])]);
       const currentAutoRespondWithoutMention =
+        // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
         (slackChannels || [])[0]?.autoRespondWithoutMention || false;
       setAutoRespondWithoutMentionEnabled(currentAutoRespondWithoutMention);
     }
@@ -248,6 +250,7 @@ export function SlackSettingsSheet({
   const handleClose = () => {
     setLocalSlackChannels([...(slackChannels || [])]);
     const currentAutoRespondWithoutMention =
+      // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
       (slackChannels || [])[0]?.autoRespondWithoutMention || false;
     setAutoRespondWithoutMentionEnabled(currentAutoRespondWithoutMention);
     onOpenChange();
@@ -270,6 +273,7 @@ export function SlackSettingsSheet({
     );
 
     const currentAutoRespondWithoutMention =
+      // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
       (slackChannels || [])[0]?.autoRespondWithoutMention || false;
     const autoRespondWithoutMentionChanged =
       autoRespondWithoutMentionEnabled !== currentAutoRespondWithoutMention;

--- a/front/components/agent_builder/settings/TagsSelector.tsx
+++ b/front/components/agent_builder/settings/TagsSelector.tsx
@@ -71,6 +71,7 @@ export const TagsSelector = ({
   };
 
   const triggerSuggestions = async () => {
+    // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
     if (!onSuggestTags || isSuggestLoading || !instructions) {
       return;
     }

--- a/front/components/agent_builder/submitAgentBuilderForm.ts
+++ b/front/components/agent_builder/submitAgentBuilderForm.ts
@@ -269,6 +269,7 @@ export async function submitAgentBuilderForm({
       description: formData.agentSettings.description,
       instructions: formData.instructions,
       pictureUrl:
+        // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
         formData.agentSettings.pictureUrl ||
         "https://dust.tt/static/assistants/logo.svg",
       status: isDraft ? "draft" : "active",

--- a/front/components/agent_builder/transformAgentConfiguration.ts
+++ b/front/components/agent_builder/transformAgentConfiguration.ts
@@ -30,6 +30,7 @@ export function transformAgentConfigurationToFormData(
       slackChannels: [], // Will be populated reactively if needed
       tags: agentConfiguration.tags,
     },
+    // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
     instructions: agentConfiguration.instructions || "",
     generationSettings: {
       modelSettings: {
@@ -37,6 +38,7 @@ export function transformAgentConfigurationToFormData(
         providerId: agentConfiguration.model.providerId,
       },
       temperature: agentConfiguration.model.temperature,
+      // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
       reasoningEffort: agentConfiguration.model.reasoningEffort || "none",
       responseFormat: agentConfiguration.model.responseFormat,
     },

--- a/front/components/agent_builder/triggers/AgentBuilderTriggersBlock.tsx
+++ b/front/components/agent_builder/triggers/AgentBuilderTriggersBlock.tsx
@@ -138,6 +138,7 @@ export function AgentBuilderTriggersBlock({
           <CardGrid>
             {triggers.map((trigger, index) => (
               <TriggerCard
+                // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
                 key={trigger.sId || index}
                 trigger={trigger}
                 onRemove={() => handleTriggerRemove(trigger, index)}

--- a/front/components/agent_builder/triggers/ScheduleEditionModal.tsx
+++ b/front/components/agent_builder/triggers/ScheduleEditionModal.tsx
@@ -178,6 +178,7 @@ export function ScheduleEditionModal({
             <ContentMessage variant="info">
               You cannot edit this schedule. It is managed by{" "}
               <span className="font-semibold">
+                {/* eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing */}
                 {trigger.editorEmail || "another user"}
               </span>
               .

--- a/front/components/app/DatasetView.tsx
+++ b/front/components/app/DatasetView.tsx
@@ -207,6 +207,7 @@ export default function DatasetView({
   const [datasetDescription, setDatasetDescription] = useState(
     dataset.description
   );
+  // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
   const [datasetData, setDatasetData] = useState(dataset.data || []);
   const [datasetKeys, setDatasetKeys] = useState(
     checkDatasetData({ data: datasetData })
@@ -214,6 +215,7 @@ export default function DatasetView({
   const [datasetKeyDescriptions, setDatasetKeyDescriptions] = useState<
     string[]
   >(
+    // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
     datasetKeys.map((k) => schema?.find((s) => s.key === k)?.description || "")
   );
 
@@ -488,6 +490,7 @@ export default function DatasetView({
       datasetTypesValidation(),
       {
         name: datasetName.slice(0, MODELS_STRING_MAX_LENGTH),
+        // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
         description: (datasetDescription || "").slice(
           0,
           MODELS_STRING_MAX_LENGTH
@@ -519,6 +522,7 @@ export default function DatasetView({
         valid,
         {
           name: datasetName.slice(0, MODELS_STRING_MAX_LENGTH),
+          // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
           description: (datasetDescription || "").slice(
             0,
             MODELS_STRING_MAX_LENGTH
@@ -567,6 +571,7 @@ export default function DatasetView({
                 name="description"
                 id="datasetDescription"
                 className="w-full"
+                // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
                 value={datasetDescription || ""}
                 onChange={(e) => setDatasetDescription(e.target.value)}
                 message="Optional"

--- a/front/components/app/ModelPicker.tsx
+++ b/front/components/app/ModelPicker.tsx
@@ -68,6 +68,7 @@ export default function ModelPicker({
       if (result.models) {
         setProviderModels((prev) => ({
           ...prev,
+          // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
           [providerId]: result.models || [], // Ensure we never set undefined
         }));
       }

--- a/front/components/app/ReachedLimitPopup.tsx
+++ b/front/components/app/ReachedLimitPopup.tsx
@@ -204,6 +204,7 @@ export function ReachedLimitPopup({
             rightButtonProps={{
               label: validateLabel,
               variant: "highlight",
+              // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
               onClick: onValidate || (() => onClose()),
             }}
           />

--- a/front/components/app/blocks/Output.tsx
+++ b/front/components/app/blocks/Output.tsx
@@ -431,8 +431,8 @@ export default function Output({
             t.meta &&
             (((t.meta as { logs: any[] }).logs &&
               (t.meta as { logs: any[] }).logs.length) ||
+              // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
               (t.meta as { provider_request_id?: string })
-                // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
                 .provider_request_id ||
               (
                 t.meta as {
@@ -482,8 +482,8 @@ export default function Output({
                       .some(
                         (e) =>
                           (e as { logs: any[] }).logs.length ||
+                          // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
                           (e as { provider_request_id?: string })
-                            // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
                             .provider_request_id ||
                           (
                             e as {

--- a/front/components/app/blocks/Output.tsx
+++ b/front/components/app/blocks/Output.tsx
@@ -429,9 +429,9 @@ export default function Output({
         t.filter(
           (t) =>
             t.meta &&
+            /* eslint-disable @typescript-eslint/prefer-nullish-coalescing */
             (((t.meta as { logs: any[] }).logs &&
               (t.meta as { logs: any[] }).logs.length) ||
-              // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
               (t.meta as { provider_request_id?: string })
                 .provider_request_id ||
               (
@@ -444,6 +444,7 @@ export default function Output({
                   };
                 }
               ).token_usage)
+          /* eslint-enable @typescript-eslint/prefer-nullish-coalescing */
         ).length
       );
     }, 0);
@@ -481,8 +482,8 @@ export default function Output({
                       .map((t) => t.meta)
                       .some(
                         (e) =>
+                          /* eslint-disable @typescript-eslint/prefer-nullish-coalescing */
                           (e as { logs: any[] }).logs.length ||
-                          // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
                           (e as { provider_request_id?: string })
                             .provider_request_id ||
                           (
@@ -495,6 +496,7 @@ export default function Output({
                               };
                             }
                           ).token_usage
+                        /* eslint-enable @typescript-eslint/prefer-nullish-coalescing */
                       )
                   ) {
                     return (

--- a/front/components/app/blocks/Output.tsx
+++ b/front/components/app/blocks/Output.tsx
@@ -286,8 +286,10 @@ export function InnerLogs({ trace }: { trace: TraceType }) {
             reasoning_tokens?: number;
           };
         }
+      // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
       | undefined) || null;
 
+  // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
   const logs = [...(meta?.logs || [])];
   if (meta && meta.provider_request_id) {
     logs.push({ provider_request_id: meta.provider_request_id });
@@ -430,6 +432,7 @@ export default function Output({
             (((t.meta as { logs: any[] }).logs &&
               (t.meta as { logs: any[] }).logs.length) ||
               (t.meta as { provider_request_id?: string })
+                // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
                 .provider_request_id ||
               (
                 t.meta as {
@@ -480,6 +483,7 @@ export default function Output({
                         (e) =>
                           (e as { logs: any[] }).logs.length ||
                           (e as { provider_request_id?: string })
+                            // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
                             .provider_request_id ||
                           (
                             e as {

--- a/front/components/assistant/conversation/AgentMessage.tsx
+++ b/front/components/assistant/conversation/AgentMessage.tsx
@@ -249,6 +249,7 @@ export function AgentMessage({
   );
 
   async function handleCopyToClipboard() {
+    // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
     const messageContent = agentMessageToRender.content || "";
     let footnotesMarkdown = "";
     let footnotesHtml = "";
@@ -482,6 +483,7 @@ export function AgentMessage({
       return (
         <ErrorMessage
           error={
+            // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
             agentMessage.error || {
               message: "Unexpected Error",
               code: "unexpected_error",

--- a/front/components/assistant/conversation/AgentSuggestion.tsx
+++ b/front/components/assistant/conversation/AgentSuggestion.tsx
@@ -216,5 +216,6 @@ function sortAgents(
   } else if (b.sId === GLOBAL_AGENTS_SID.DUST_DEEP_2) {
     return 1;
   }
+  // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
   return (b.usage?.messageCount || 0) - (a.usage?.messageCount || 0);
 }

--- a/front/components/assistant/conversation/AttachmentCitation.tsx
+++ b/front/components/assistant/conversation/AttachmentCitation.tsx
@@ -131,6 +131,7 @@ export function AttachmentCitation({
           {attachmentCitation.type === "node" && (
             <CitationDescription className="truncate text-ellipsis">
               <span>
+                {/* eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing */}
                 {attachmentCitation.path || attachmentCitation.spaceName}
               </span>
             </CitationDescription>

--- a/front/components/assistant/conversation/BlockedActionsProvider.tsx
+++ b/front/components/assistant/conversation/BlockedActionsProvider.tsx
@@ -142,6 +142,7 @@ export function BlockedActionsProvider({
   conversation,
   children,
 }: BlockedActionsProviderProps) {
+  // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
   const conversationId = conversation?.sId || null;
 
   const { blockedActions } = useBlockedActions({

--- a/front/components/assistant/conversation/ConversationMenu.tsx
+++ b/front/components/assistant/conversation/ConversationMenu.tsx
@@ -50,6 +50,7 @@ export function ConversationMenu({
   const conversationParticipationOption = useConversationParticipationOption({
     ownerId: owner.sId,
     conversationId: activeConversationId,
+    // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
     userId: user?.sId || null,
     disabled: shouldWaitBeforeFetching,
   });
@@ -141,6 +142,7 @@ export function ConversationMenu({
         onClose={() => setShowRenameDialog(false)}
         ownerId={owner.sId}
         conversationId={activeConversationId}
+        // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
         currentTitle={conversation?.title || ""}
       />
       <DropdownMenu
@@ -187,6 +189,7 @@ export function ConversationMenu({
                         <Avatar
                           size="xs"
                           visual={user.pictureUrl}
+                          // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
                           name={user.fullName || user.username}
                         />
                       }

--- a/front/components/assistant/conversation/ConversationTitle.tsx
+++ b/front/components/assistant/conversation/ConversationTitle.tsx
@@ -28,6 +28,7 @@ export function ConversationTitle({
       <div className="grid h-full min-w-0 max-w-full grid-cols-[1fr,auto] items-center gap-4">
         <div className="flex min-w-0 flex-row items-center gap-4 text-primary dark:text-primary-night">
           <div className="dd-privacy-mask min-w-0 overflow-hidden truncate text-sm font-normal">
+            {/* eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing */}
             {conversation?.title || ""}
           </div>
         </div>

--- a/front/components/assistant/conversation/ErrorMessage.tsx
+++ b/front/components/assistant/conversation/ErrorMessage.tsx
@@ -36,6 +36,7 @@ export function ErrorMessage({ error, retryHandler }: ErrorMessageProps) {
 
   return (
     <ContentMessage
+      // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
       title={`${error.metadata?.errorTitle || "Agent error"}`}
       variant={errorIsRetryable ? "golden" : "warning"}
       className="flex flex-col gap-3"

--- a/front/components/assistant/conversation/SidebarMenu.tsx
+++ b/front/components/assistant/conversation/SidebarMenu.tsx
@@ -300,6 +300,7 @@ export function AssistantSidebarMenu({ owner }: AssistantSidebarMenuProps) {
         isDeleting={isDeleting}
         onClose={() => setShowDeleteDialog(null)}
         onDelete={showDeleteDialog === "all" ? deleteAll : deleteSelection}
+        // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
         type={showDeleteDialog || "all"}
         selectedCount={selectedConversations.length}
       />
@@ -504,6 +505,7 @@ const RenderConversation = ({
 }) => {
   const { sidebarOpen, setSidebarOpen } = useContext(SidebarContext);
   const conversationLabel =
+    // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
     conversation.title ||
     (moment(conversation.created).isSame(moment(), "day")
       ? "New Conversation"

--- a/front/components/assistant/conversation/UserMessage.tsx
+++ b/front/components/assistant/conversation/UserMessage.tsx
@@ -59,6 +59,7 @@ export function UserMessage({
     <div className="flex flex-grow flex-col">
       <div className="min-w-60 max-w-full self-end">
         <ConversationMessage
+          // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
           pictureUrl={message.context.profilePictureUrl || message.user?.image}
           name={message.context.fullName ?? undefined}
           renderName={(name) => <div className="heading-base">{name}</div>}

--- a/front/components/assistant/conversation/actions/AgentActionsPanel.tsx
+++ b/front/components/assistant/conversation/actions/AgentActionsPanel.tsx
@@ -118,6 +118,7 @@ function AgentActionsPanelContent({
   const handleScroll = (e: React.UIEvent<HTMLDivElement>) => {
     const el = e.currentTarget;
     const scrollUp =
+      // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
       Number(el.scrollTop) < Number(el.dataset.lastScrollTop || 0);
 
     el.dataset.lastScrollTop = el.scrollTop.toString();

--- a/front/components/assistant/conversation/actions/AgentMessageActions.tsx
+++ b/front/components/assistant/conversation/actions/AgentMessageActions.tsx
@@ -44,6 +44,7 @@ export function AgentMessageActions({
     ? agentMessage.actions[agentMessage.actions.length - 1]
     : null;
 
+  // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
   const chainOfThought = agentMessage.chainOfThought || "";
 
   const firstRender = useRef<boolean>(true);

--- a/front/components/assistant/conversation/actions/VisualizationActionIframe.tsx
+++ b/front/components/assistant/conversation/actions/VisualizationActionIframe.tsx
@@ -93,6 +93,7 @@ function useVisualizationDataHandler({
       const resBuffer = await response.arrayBuffer();
 
       return new Blob([resBuffer], {
+        // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
         type: response.headers.get("Content-Type") || undefined,
       });
     },

--- a/front/components/assistant/conversation/co_edition/transport.ts
+++ b/front/components/assistant/conversation/co_edition/transport.ts
@@ -142,6 +142,7 @@ export class CoEditionTransport implements Transport {
 
     const params = new URLSearchParams();
     params.set("serverId", this.serverId);
+    // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
     params.set("lastEventId", this.lastEventId || "");
 
     this.eventSource = new EventSource(

--- a/front/components/assistant/conversation/content_creation/ClientExecutableRenderer.tsx
+++ b/front/components/assistant/conversation/content_creation/ClientExecutableRenderer.tsx
@@ -219,6 +219,7 @@ export function ClientExecutableRenderer({
   return (
     <div className="flex h-full flex-col">
       <ContentCreationHeader
+        // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
         title={fileName || "Client Executable"}
         subtitle={fileId}
         onClose={onClosePanel}

--- a/front/components/assistant/conversation/content_creation/UnsupportedContentRenderer.tsx
+++ b/front/components/assistant/conversation/content_creation/UnsupportedContentRenderer.tsx
@@ -23,6 +23,7 @@ export function UnsupportedContentRenderer({
       <ContentCreationHeader
         onClose={closePanel}
         subtitle={fileId}
+        // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
         title={fileName || "Unsupported Content"}
       />
 

--- a/front/components/assistant/conversation/input_bar/InputBar.tsx
+++ b/front/components/assistant/conversation/input_bar/InputBar.tsx
@@ -109,7 +109,7 @@ export function AssistantInputBar({
     if (
       baseAgentConfigurations.find(
         (a) => a.sId === additionalAgentConfiguration?.sId
-      // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
+        // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
       ) ||
       !additionalAgentConfiguration
     ) {

--- a/front/components/assistant/conversation/input_bar/InputBar.tsx
+++ b/front/components/assistant/conversation/input_bar/InputBar.tsx
@@ -109,6 +109,7 @@ export function AssistantInputBar({
     if (
       baseAgentConfigurations.find(
         (a) => a.sId === additionalAgentConfiguration?.sId
+      // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
       ) ||
       !additionalAgentConfiguration
     ) {

--- a/front/components/assistant/conversation/input_bar/InputBarAttachments.tsx
+++ b/front/components/assistant/conversation/input_bar/InputBarAttachments.tsx
@@ -73,6 +73,7 @@ export function InputBarAttachments({
         contentType: blob.contentType,
         isUploading: blob.isUploading,
         onRemove: () => files.service.removeFile(blob.id),
+      // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
       })) || []
     );
   }, [files?.service]);
@@ -111,6 +112,7 @@ export function InputBarAttachments({
           visual,
           onRemove: () => nodes.onRemove(node),
         };
+      // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
       }) || []
     );
   }, [nodes, spacesMap]);

--- a/front/components/assistant/conversation/input_bar/InputBarAttachments.tsx
+++ b/front/components/assistant/conversation/input_bar/InputBarAttachments.tsx
@@ -73,7 +73,7 @@ export function InputBarAttachments({
         contentType: blob.contentType,
         isUploading: blob.isUploading,
         onRemove: () => files.service.removeFile(blob.id),
-      // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
+        // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
       })) || []
     );
   }, [files?.service]);
@@ -112,7 +112,7 @@ export function InputBarAttachments({
           visual,
           onRemove: () => nodes.onRemove(node),
         };
-      // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
+        // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
       }) || []
     );
   }, [nodes, spacesMap]);

--- a/front/components/assistant/conversation/input_bar/InputBarContainer.tsx
+++ b/front/components/assistant/conversation/input_bar/InputBarContainer.tsx
@@ -164,6 +164,7 @@ const InputBarContainer = ({
         }
       : {
           // TextSearchParams
+          // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
           search: nodeOrUrlCandidate?.url || "",
           searchSourceUrls: true,
           includeDataSources: false,

--- a/front/components/assistant/conversation/input_bar/editor/extensions/AgentBuilderInstructionsAutoCompleteExtension.ts
+++ b/front/components/assistant/conversation/input_bar/editor/extensions/AgentBuilderInstructionsAutoCompleteExtension.ts
@@ -50,7 +50,7 @@ const fetchAgentBuilderSuggestions = async (
               builderState?.actions?.map((action) => ({
                 name: action.name,
                 description: action.description,
-              // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
+                // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
               })) || []
             ),
           },

--- a/front/components/assistant/conversation/input_bar/editor/extensions/AgentBuilderInstructionsAutoCompleteExtension.ts
+++ b/front/components/assistant/conversation/input_bar/editor/extensions/AgentBuilderInstructionsAutoCompleteExtension.ts
@@ -50,6 +50,7 @@ const fetchAgentBuilderSuggestions = async (
               builderState?.actions?.map((action) => ({
                 name: action.name,
                 description: action.description,
+              // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
               })) || []
             ),
           },

--- a/front/components/assistant/details/AssistantDetails.tsx
+++ b/front/components/assistant/details/AssistantDetails.tsx
@@ -122,6 +122,7 @@ export function AssistantDetails({
   );
 
   const showPerformanceTabs =
+    // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
     (agentConfiguration?.canEdit || isAdmin(owner)) &&
     assistantId != null &&
     !isGlobalAgent;
@@ -140,6 +141,7 @@ export function AssistantDetails({
             <div>
               <Chip
                 color={SCOPE_INFO[agentConfiguration.scope].color}
+                // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
                 icon={SCOPE_INFO[agentConfiguration.scope].icon || undefined}
               >
                 {SCOPE_INFO[agentConfiguration.scope].label}

--- a/front/components/assistant/manager/AssistantsTable.tsx
+++ b/front/components/assistant/manager/AssistantsTable.tsx
@@ -172,6 +172,7 @@ const getTableColumns = ({
           className="font-semibold"
           tooltip={assistantUsageMessage({
             assistantName: info.row.original.name,
+            // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
             usage: info.row.original.usage || null,
             isLoading: false,
             isError: false,

--- a/front/components/assistant_builder/server_side_props_helpers.ts
+++ b/front/components/assistant_builder/server_side_props_helpers.ts
@@ -184,6 +184,7 @@ async function renderDataSourcesConfigurations(
     resources: ds.filter.parents?.in ?? null,
     excludedResources: ds.filter.parents?.not ?? null,
     isSelectAll: !ds.filter.parents,
+    // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
     tagsFilter: ds.filter.tags || null, // todo(TAF) Remove this when we don't need to support optional tags from builder.
   }));
 

--- a/front/components/assistant_builder/tags/TagSearchSection.tsx
+++ b/front/components/assistant_builder/tags/TagSearchSection.tsx
@@ -69,6 +69,7 @@ export function TagSearchSection({
             tag: tag.tag,
             dustAPIDataSourceId: dataSourceId,
             connectorProvider:
+              // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
               dataSourceView?.dataSource.connectorProvider || null,
           });
         }

--- a/front/components/data_source/CreateOrUpdateConnectionSnowflakeModal.tsx
+++ b/front/components/data_source/CreateOrUpdateConnectionSnowflakeModal.tsx
@@ -411,6 +411,7 @@ export function CreateOrUpdateConnectionSnowflakeModal({
                     type="password"
                     value={
                       "private_key_passphrase" in credentials
+                        // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
                         ? credentials.private_key_passphrase || ""
                         : ""
                     }

--- a/front/components/data_source/CreateOrUpdateConnectionSnowflakeModal.tsx
+++ b/front/components/data_source/CreateOrUpdateConnectionSnowflakeModal.tsx
@@ -411,8 +411,8 @@ export function CreateOrUpdateConnectionSnowflakeModal({
                     type="password"
                     value={
                       "private_key_passphrase" in credentials
-                        // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
-                        ? credentials.private_key_passphrase || ""
+                        ? // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
+                          credentials.private_key_passphrase || ""
                         : ""
                     }
                     placeholder="Leave empty if key is not encrypted"

--- a/front/components/data_source/DataSourceSyncChip.tsx
+++ b/front/components/data_source/DataSourceSyncChip.tsx
@@ -27,6 +27,7 @@ export default function ConnectorSyncingChip({
     dataSource,
   });
 
+  // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
   const connector = refreshedConnector || initialState;
   if (!connector) {
     if (isConnectorError) {

--- a/front/components/data_source/TableUploadOrEditModal.tsx
+++ b/front/components/data_source/TableUploadOrEditModal.tsx
@@ -303,6 +303,7 @@ export const TableUploadOrEditModal = ({
     const isNameValid =
       tableState.name.trim() !== "" && isSlugified(tableState.name);
     const isDescriptionValid = tableState.description.trim() !== "";
+    // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
     const fileOrInitialId = initialId || fileId;
     setIsValidTable(isNameValid && isDescriptionValid && !!fileOrInitialId);
   }, [tableState, initialId, fileId]);

--- a/front/components/data_source/ZendeskConfigView.tsx
+++ b/front/components/data_source/ZendeskConfigView.tsx
@@ -62,6 +62,7 @@ export function ZendeskConfigView({
   const sendNotification = useSendNotification();
   const [loading, setLoading] = useState(false);
   const [retentionInput, setRetentionInput] = useState(
+    // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
     retentionPeriodDays?.toString() || ""
   );
 

--- a/front/components/data_source/ZendeskCustomTagFilters.tsx
+++ b/front/components/data_source/ZendeskCustomTagFilters.tsx
@@ -54,6 +54,7 @@ export function ZendeskCustomFieldFilters({
     if (parsingResult.isErr()) {
       return [];
     }
+    // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
     return (parsingResult.value || []) as CustomField[];
   }, [customFieldsConfigValue]);
 

--- a/front/components/data_source/gong/GongOptionComponent.tsx
+++ b/front/components/data_source/gong/GongOptionComponent.tsx
@@ -53,6 +53,7 @@ export function GongOptionComponent({
   const trackersEnabled = trackersConfigValue === "true";
 
   const [retentionPeriod, setRetentionPeriod] = useState<string>(
+    // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
     retentionPeriodConfigValue || ""
   );
 

--- a/front/components/data_source_view/DataSourceViewSelector.tsx
+++ b/front/components/data_source_view/DataSourceViewSelector.tsx
@@ -163,6 +163,7 @@ const getNodesFromConfig = (
       [r.internalId]: {
         isSelected: true,
         node: r,
+        // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
         parents: r.parentInternalIds || [],
       },
       ...acc,
@@ -212,6 +213,7 @@ const updateSelection = ({
           {
             ...item,
             dataSourceView: dsv,
+            // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
             parentInternalIds: item.parentInternalIds || [],
           },
         ],
@@ -229,6 +231,7 @@ const updateSelection = ({
         {
           ...item,
           dataSourceView: dsv,
+          // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
           parentInternalIds: item.parentInternalIds || [],
         },
       ];

--- a/front/components/data_source_view/context/DataSourceBuilderContext.tsx
+++ b/front/components/data_source_view/context/DataSourceBuilderContext.tsx
@@ -432,6 +432,7 @@ export function DataSourceBuilderProvider({
           in: field.value.in.map((source) => {
             if ("tagsFilter" in source) {
               // Initialize tagsFilter if null
+              // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
               const currentTagsFilter = source.tagsFilter || {
                 in: [],
                 not: [],

--- a/front/components/data_source_view/context/utils.test.ts
+++ b/front/components/data_source_view/context/utils.test.ts
@@ -13,6 +13,7 @@ const createTreeItem = (
   name?: string
 ): DataSourceBuilderTreeItemType => ({
   path,
+  // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
   name: name || path.split("/").pop() || path,
   type: "root",
 });

--- a/front/components/home/ContentBlocks.tsx
+++ b/front/components/home/ContentBlocks.tsx
@@ -597,6 +597,7 @@ export const ImgContent: React.FC<ImgContentProps> = ({ images }) => {
           <img
             key={index}
             src={image.src}
+            // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
             alt={image.alt || `Image ${index + 1}`}
             className={classNames(
               "max-w-40 max-h-32 object-contain",

--- a/front/components/home/FAQ.tsx
+++ b/front/components/home/FAQ.tsx
@@ -67,6 +67,7 @@ export const FAQ: React.FC<FAQProps> = ({
   className,
 }) => {
   return (
+    // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
     <div className={classNames("w-full", className || "")}>
       <div className="w-full">
         <H2 className="mb-12 text-left text-foreground dark:text-foreground-night">

--- a/front/components/home/LandingLayout.tsx
+++ b/front/components/home/LandingLayout.tsx
@@ -215,6 +215,7 @@ const CookieBanner = ({
         "fixed bottom-0 left-0 z-30 flex w-full flex-col items-center justify-between gap-4 border-t border-border bg-blue-100 p-6 shadow-2xl md:flex-row",
         "s-transition-opacity s-duration-300 s-ease-in-out",
         isVisible ? "s-opacity-100" : "s-opacity-0",
+        // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
         className || ""
       )}
     >

--- a/front/components/home/content/Industry/IndustryTemplate.tsx
+++ b/front/components/home/content/Industry/IndustryTemplate.tsx
@@ -70,6 +70,7 @@ const HeroSection = ({
         </div>
       </div>
 
+      {/* eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing */}
       {(config.testimonialCard || config.heroImage) && (
         <div className="relative col-span-12 mt-8 py-2 lg:col-span-6 lg:col-start-7 lg:mt-0">
           {config.decorativeShapes?.topRight && (
@@ -168,6 +169,7 @@ const AIAgentsSection = ({
   <div
     className={classNames(
       "rounded-2xl py-12 md:py-16",
+      // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
       config.bgColor || "bg-gray-50"
     )}
   >
@@ -322,6 +324,7 @@ const ImpactMetricsSection = ({
   config: NonNullable<IndustryPageConfig["impactMetrics"]>;
 }) => (
   <div
+    // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
     className={classNames("rounded-xl py-20", config.bgColor || "bg-blue-50")}
   >
     <div className="container mx-auto max-w-7xl px-4 sm:px-6 md:px-8">
@@ -363,6 +366,7 @@ const TestimonialSection = ({
   <div
     className={classNames(
       "rounded-xl py-8 md:py-16",
+      // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
       config.bgColor || "bg-green-600"
     )}
   >
@@ -371,6 +375,7 @@ const TestimonialSection = ({
         <H1
           className={classNames(
             "mb-10 text-3xl !font-normal sm:text-5xl md:text-6xl lg:text-7xl xl:text-8xl",
+            // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
             config.textColor || "text-white"
           )}
         >
@@ -382,6 +387,7 @@ const TestimonialSection = ({
               size="lg"
               className={classNames(
                 "font-medium",
+                // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
                 config.textColor || "text-white"
               )}
             >
@@ -420,6 +426,7 @@ const JustUseDustSection = ({
   <div
     className={classNames(
       "relative overflow-hidden rounded-xl py-16 md:py-20",
+      // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
       config.bgColor || "bg-blue-50"
     )}
   >
@@ -437,6 +444,7 @@ const JustUseDustSection = ({
         <H2
           className={classNames(
             "mb-8 text-4xl sm:text-5xl md:text-6xl",
+            // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
             config.titleColor || "text-blue-600"
           )}
         >

--- a/front/components/magicui/pointer.tsx
+++ b/front/components/magicui/pointer.tsx
@@ -90,6 +90,7 @@ export function Pointer({
             }}
             {...props}
           >
+            {/* eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing */}
             {children || (
               <svg
                 stroke="currentColor"

--- a/front/components/markdown/VisualizationBlock.tsx
+++ b/front/components/markdown/VisualizationBlock.tsx
@@ -29,6 +29,7 @@ export function VisualizationBlock({
 
   const visualizationRenderer = useMemo(() => {
     return (
+      // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
       customRenderer?.visualization ||
       (() => (
         <div className="pb-2 pt-4 font-medium text-warning">

--- a/front/components/me/AccountSettings.tsx
+++ b/front/components/me/AccountSettings.tsx
@@ -21,7 +21,9 @@ export function AccountSettings({ user, isUserLoading }: AccountSettingsProps) {
   const { register, handleSubmit, reset, formState } =
     useForm<AccountSettingsType>({
       defaultValues: {
+        // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
         firstName: user?.firstName || "",
+        // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
         lastName: user?.lastName || "",
       },
     });
@@ -33,6 +35,7 @@ export function AccountSettings({ user, isUserLoading }: AccountSettingsProps) {
     if (user) {
       reset({
         firstName: user.firstName,
+        // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
         lastName: user.lastName || "",
       });
     }
@@ -112,7 +115,9 @@ export function AccountSettings({ user, isUserLoading }: AccountSettingsProps) {
                 variant="ghost"
                 onClick={() =>
                   reset({
+                    // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
                     firstName: user?.firstName || "",
+                    // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
                     lastName: user?.lastName || "",
                   })
                 }

--- a/front/components/poke/features/table.tsx
+++ b/front/components/poke/features/table.tsx
@@ -28,6 +28,7 @@ function prepareFeatureFlagsForDisplay(
         description: WHITELISTABLE_FEATURES_CONFIG[ff].description,
         stage: WHITELISTABLE_FEATURES_CONFIG[ff].stage,
         enabled: !!enabledFlag,
+        // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
         enabledAt: enabledFlag?.createdAt || null,
       };
     })

--- a/front/components/poke/mcp_server_views/view.tsx
+++ b/front/components/poke/mcp_server_views/view.tsx
@@ -83,6 +83,7 @@ export function ViewMCPServerViewTable({
                     <PokeTableHead>Edited At</PokeTableHead>
                     <PokeTableCell>
                       {formatTimestampToFriendlyDate(
+                        // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
                         mcpServerView.editedByUser.editedAt || 0
                       )}
                     </PokeTableCell>

--- a/front/components/poke/plans/form.tsx
+++ b/front/components/poke/plans/form.tsx
@@ -336,6 +336,7 @@ export const Field: React.FC<FieldProps> = ({
   const disabled = !editingPlan?.isNewPlan && isImmutable;
 
   const renderPlanFieldValue = (x: unknown) => {
+    // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
     let strValue: string = x?.toString() || "";
     let classes = "";
     if (typeof x === "string") {

--- a/front/components/poke/triggers/columns.tsx
+++ b/front/components/poke/triggers/columns.tsx
@@ -91,6 +91,7 @@ export function makeColumnsForTriggers(
       },
       accessorFn: (row) => {
         const agent = agentConfigMap.get(row.agentConfigurationId);
+        // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
         return agent?.name || row.agentConfigurationId;
       },
     },

--- a/front/components/poke/triggers/view.tsx
+++ b/front/components/poke/triggers/view.tsx
@@ -65,6 +65,7 @@ export function ViewTriggerTable({
               </PokeTableRow>
               <PokeTableRow>
                 <PokeTableHead>Custom Prompt</PokeTableHead>
+                {/* eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing */}
                 <PokeTableCell>{trigger.customPrompt || "None"}</PokeTableCell>
               </PokeTableRow>
               <PokeTableRow>

--- a/front/components/poke/workspace/table.tsx
+++ b/front/components/poke/workspace/table.tsx
@@ -161,9 +161,11 @@ export function WorkspaceInfoTable({
               <PokeTableCell>
                 <Chip
                   color={getStatusChipColor(
+                    // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
                     dsyncStatus?.status || "not_configured"
                   )}
                 >
+                  {/* eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing */}
                   {asDisplayName(dsyncStatus?.status || "not_configured")}
                 </Chip>
               </PokeTableCell>

--- a/front/components/providers/ProviderSetup.tsx
+++ b/front/components/providers/ProviderSetup.tsx
@@ -374,6 +374,7 @@ export function ProviderSetup({
           </label>
         )}
         <Input
+          // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
           type={field.type || "text"}
           placeholder={field.placeholder}
           value={values[field.name]}
@@ -418,6 +419,7 @@ export function ProviderSetup({
         <DialogHeader>
           <DialogTitle>{title}</DialogTitle>
           <DialogDescription>
+            {/* eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing */}
             {instructions || (
               <p>Provide the necessary configuration for {title}.</p>
             )}
@@ -434,6 +436,7 @@ export function ProviderSetup({
                 </span>
               ) : testSuccessful ? (
                 <span className="text-green-600">
+                  {/* eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing */}
                   {testSuccessMessage ||
                     `Test succeeded! You can now enable ${title}.`}
                 </span>

--- a/front/components/spaces/ContentActions.tsx
+++ b/front/components/spaces/ContentActions.tsx
@@ -49,6 +49,7 @@ export type ContentAction = {
 const isUploadOrEditAction = (
   action: ContentActionKey | undefined
 ): action is UploadOrEditContentActionKey =>
+  // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
   ["DocumentUploadOrEdit", "TableUploadOrEdit"].includes(action || "");
 
 type ContentActionsProps = {

--- a/front/components/spaces/SearchMembersDropdown.tsx
+++ b/front/components/spaces/SearchMembersDropdown.tsx
@@ -101,6 +101,7 @@ export function SearchMembersDropdown({
           <DropdownMenuItem
             key={member.sId}
             onClick={addMember(member)}
+            // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
             icon={() => <Avatar size="sm" visual={member.image || ""} />}
             label={member.fullName}
             description={member.email}

--- a/front/components/spaces/SpaceActionsList.tsx
+++ b/front/components/spaces/SpaceActionsList.tsx
@@ -44,6 +44,7 @@ export const SpaceActionsList = ({
   space,
 }: SpaceActionsListProps) => {
   const { q: searchParam } = useQueryParams(["q"]);
+  // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
   const searchTerm = searchParam.value || "";
 
   const { serverViews, isMCPServerViewsLoading, mutateMCPServerViews } =

--- a/front/components/spaces/SpaceAppsList.tsx
+++ b/front/components/spaces/SpaceAppsList.tsx
@@ -161,6 +161,7 @@ export const SpaceAppsList = ({
   const [isCreateAppModalOpened, setIsCreateAppModalOpened] = useState(false);
 
   const { q: searchParam } = useQueryParams(["q"]);
+  // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
   const searchTerm = searchParam.value || "";
 
   const { apps, isAppsLoading } = useApps({ owner, space });

--- a/front/components/spaces/SpaceFolderModal.tsx
+++ b/front/components/spaces/SpaceFolderModal.tsx
@@ -43,6 +43,7 @@ export default function SpaceFolderModal({
     useSpaceDataSourceView({
       owner,
       spaceId: space.sId,
+      // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
       dataSourceViewId: dataSourceViewId || undefined,
       disabled: !dataSourceViewId,
     });

--- a/front/components/spaces/SpaceResourcesList.tsx
+++ b/front/components/spaces/SpaceResourcesList.tsx
@@ -172,6 +172,7 @@ function getTableColumns(
     cell: (ctx) => {
       const { dataSourceView, isLoading, isAdmin, buttonOnClick } =
         ctx.row.original;
+      // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
       const disabled = isLoading || !isAdmin;
       const connector = dataSourceView.dataSource.connector;
       if (!connector) {

--- a/front/components/spaces/SpaceSearchLayout.tsx
+++ b/front/components/spaces/SpaceSearchLayout.tsx
@@ -198,7 +198,7 @@ function BackendSearch({
     debouncedValue: debouncedSearch,
     isDebouncing,
     setValue: setSearchValue,
-  // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
+    // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
   } = useDebounce(searchParam.value || "", {
     delay: 300,
     minLength: MIN_SEARCH_QUERY_SIZE,

--- a/front/components/spaces/SpaceSearchLayout.tsx
+++ b/front/components/spaces/SpaceSearchLayout.tsx
@@ -172,6 +172,7 @@ function BackendSearch({
     React.useState<DataSourceViewType | null>(null);
   const [effectiveContentNode, setEffectiveContentNode] =
     React.useState<LightContentNode | null>(null);
+  // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
   const effectiveDataSourceView = dataSourceView || searchResultDataSourceView;
   const [nodeOrUrlCandidate, setNodeOrUrlCandidate] = React.useState<
     UrlCandidate | NodeCandidate | null
@@ -197,6 +198,7 @@ function BackendSearch({
     debouncedValue: debouncedSearch,
     isDebouncing,
     setValue: setSearchValue,
+  // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
   } = useDebounce(searchParam.value || "", {
     delay: 300,
     minLength: MIN_SEARCH_QUERY_SIZE,
@@ -442,6 +444,7 @@ function FrontendSearch({
   parentId,
 }: FullFrontendSearchProps) {
   const { q: searchParam } = useQueryParams(["q"]);
+  // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
   const searchTerm = searchParam.value || "";
 
   return (

--- a/front/components/spaces/SystemSpaceActionsList.tsx
+++ b/front/components/spaces/SystemSpaceActionsList.tsx
@@ -35,6 +35,7 @@ export const SystemSpaceActionsList = ({
   );
 
   const { q: searchParam } = useQueryParams(["q"]);
+  // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
   const searchTerm = searchParam.value || "";
 
   const handleClose = useCallback(() => {

--- a/front/components/spaces/websites/SpaceWebsiteForm.tsx
+++ b/front/components/spaces/websites/SpaceWebsiteForm.tsx
@@ -200,6 +200,7 @@ export function SpaceWebsiteForm({
           />
           <Input
             placeholder={WEBCRAWLER_MAX_PAGES.toString()}
+            // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
             value={state.maxPages?.toString() || ""}
             onChange={(e) => {
               const parsed = parseInt(e.target.value);

--- a/front/components/spaces/websites/SpaceWebsiteModal.tsx
+++ b/front/components/spaces/websites/SpaceWebsiteModal.tsx
@@ -102,6 +102,7 @@ function buildWebCrawlerConfig(
 ): WebCrawlerConfigurationType {
   return {
     url: validatedUrl.standardized,
+    // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
     maxPageToCrawl: state.maxPages || WEBCRAWLER_MAX_PAGES,
     depth: state.depth,
     crawlMode: state.crawlMode,

--- a/front/components/sparkle/AppContentLayout.tsx
+++ b/front/components/sparkle/AppContentLayout.tsx
@@ -80,6 +80,7 @@ export default function AppContentLayout({
   return (
     <div className="flex h-full flex-row">
       <Head>
+        {/* eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing */}
         <title>{pageTitle || `Dust - ${owner.name}`}</title>
       </Head>
       <Navigation

--- a/front/components/sparkle/AppRootLayout.tsx
+++ b/front/components/sparkle/AppRootLayout.tsx
@@ -25,6 +25,7 @@ export default function AppRootLayout({
   useEffect(() => {
     if (typeof window !== "undefined" && user?.sId) {
       // Identify the user with GTM
+      // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
       window.dataLayer = window.dataLayer || [];
       window.dataLayer.push({
         userId: user.sId,

--- a/front/components/trackers/TrackerBuilder.tsx
+++ b/front/components/trackers/TrackerBuilder.tsx
@@ -455,7 +455,7 @@ export const TrackerBuilder = ({
                       label={
                         TRACKER_FREQUENCIES.find(
                           (f) => f.value === tracker.frequency
-                        // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
+                          // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
                         )?.label || "Select Frequency"
                       }
                       variant="outline"

--- a/front/components/trackers/TrackerBuilder.tsx
+++ b/front/components/trackers/TrackerBuilder.tsx
@@ -392,6 +392,7 @@ export const TrackerBuilder = ({
             <div className="md:col-span-1">
               <Input
                 label="Name"
+                // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
                 value={tracker.name || ""}
                 onChange={(e) => {
                   setTracker((t) => ({
@@ -412,6 +413,7 @@ export const TrackerBuilder = ({
             <div className="md:col-span-2">
               <Input
                 label="Description"
+                // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
                 value={tracker.description || ""}
                 onChange={(e) => {
                   setTracker((t) => ({
@@ -453,6 +455,7 @@ export const TrackerBuilder = ({
                       label={
                         TRACKER_FREQUENCIES.find(
                           (f) => f.value === tracker.frequency
+                        // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
                         )?.label || "Select Frequency"
                       }
                       variant="outline"
@@ -543,6 +546,7 @@ export const TrackerBuilder = ({
             <Label className="mb-1">Instructions</Label>
             <TextArea
               placeholder="Describe what changes or updates you want to track (be as specific as possible)."
+              // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
               value={tracker.prompt || ""}
               onChange={(e) => {
                 setTracker((t) => ({

--- a/front/components/workspace/ChangeMemberModal.tsx
+++ b/front/components/workspace/ChangeMemberModal.tsx
@@ -116,6 +116,7 @@ export function ChangeMemberModal({
                       Role:
                     </div>
                     <RoleDropDown
+                      // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
                       selectedRole={selectedRole || role}
                       onChange={setSelectedRole}
                       disabled={hasActiveRoleProvisioningGroups()}

--- a/front/lib/actions/mcp_actions.ts
+++ b/front/lib/actions/mcp_actions.ts
@@ -135,6 +135,7 @@ export function getToolExtraFields(
       return r;
     }
     const serverName = r.value.name;
+    // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
     toolsStakes = INTERNAL_MCP_SERVERS[serverName].tools_stakes || {};
     toolsRetryPolicies = INTERNAL_MCP_SERVERS[serverName].tools_retry_policies;
     serverTimeoutMs = INTERNAL_MCP_SERVERS[serverName]?.timeoutMs;
@@ -179,6 +180,7 @@ function makeServerSideMCPToolConfigurations(
     retryPolicy: tool.retryPolicy,
     mcpServerViewId: config.mcpServerViewId,
     internalMCPServerId: config.internalMCPServerId,
+    // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
     dataSources: config.dataSources || [], // Ensure dataSources is always an array
     tables: config.tables,
     availability: tool.availability,
@@ -822,7 +824,9 @@ export async function listToolsForServerSideMCPServer(
       toolServerId: connectionParams.mcpServerId,
       ...(serverTimeoutMs && { timeoutMs: serverTimeoutMs }),
       retryPolicy:
+        // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
         toolsRetryPolicies?.[tool.name] ||
+        // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
         toolsRetryPolicies?.["default"] ||
         DEFAULT_MCP_TOOL_RETRY_POLICY,
     }));

--- a/front/lib/actions/mcp_internal_actions/input_configuration.ts
+++ b/front/lib/actions/mcp_internal_actions/input_configuration.ts
@@ -130,6 +130,7 @@ function generateConfiguredInput({
         actionConfiguration.dataSources?.map((config) => ({
           uri: getDataSourceURI(config),
           mimeType,
+        // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
         })) || []
       );
     }
@@ -139,6 +140,7 @@ function generateConfiguredInput({
         actionConfiguration.dataSources?.map((config) => ({
           uri: getDataSourceURI(config),
           mimeType,
+        // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
         })) || []
       );
     }
@@ -148,6 +150,7 @@ function generateConfiguredInput({
         actionConfiguration.tables?.map((config) => ({
           uri: getTableURI(config),
           mimeType,
+        // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
         })) || []
       );
     }

--- a/front/lib/actions/mcp_internal_actions/input_configuration.ts
+++ b/front/lib/actions/mcp_internal_actions/input_configuration.ts
@@ -130,7 +130,7 @@ function generateConfiguredInput({
         actionConfiguration.dataSources?.map((config) => ({
           uri: getDataSourceURI(config),
           mimeType,
-        // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
+          // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
         })) || []
       );
     }
@@ -140,7 +140,7 @@ function generateConfiguredInput({
         actionConfiguration.dataSources?.map((config) => ({
           uri: getDataSourceURI(config),
           mimeType,
-        // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
+          // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
         })) || []
       );
     }
@@ -150,7 +150,7 @@ function generateConfiguredInput({
         actionConfiguration.tables?.map((config) => ({
           uri: getTableURI(config),
           mimeType,
-        // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
+          // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
         })) || []
       );
     }

--- a/front/lib/actions/mcp_internal_actions/remote_servers.ts
+++ b/front/lib/actions/mcp_internal_actions/remote_servers.ts
@@ -207,6 +207,7 @@ export const getDefaultRemoteMCPServerByURL = (
   url: string | undefined
 ): DefaultRemoteMCPServerConfig | null => {
   return (
+    // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
     DEFAULT_REMOTE_MCP_SERVERS.find((server) => server.url === url) || null
   );
 };
@@ -214,6 +215,7 @@ export const getDefaultRemoteMCPServerByURL = (
 export const getDefaultRemoteMCPServerById = (
   id: number
 ): DefaultRemoteMCPServerConfig | null => {
+  // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
   return DEFAULT_REMOTE_MCP_SERVERS.find((server) => server.id === id) || null;
 };
 
@@ -221,6 +223,7 @@ export const getDefaultRemoteMCPServerByName = (
   name: string
 ): DefaultRemoteMCPServerConfig | null => {
   return (
+    // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
     DEFAULT_REMOTE_MCP_SERVERS.find((server) => server.name === name) || null
   );
 };

--- a/front/lib/actions/mcp_internal_actions/servers/agent_router.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/agent_router.ts
@@ -132,6 +132,7 @@ const createServer = (auth: Authenticator): McpServer => {
       const formattedSuggestedAgents = suggestedAgents
         .filter((agent) => agent.sId !== "dust")
         .map((agent) => {
+          // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
           const instructions = agent.instructions || "";
           const truncatedInstructions =
             instructions.length > MAX_INSTRUCTIONS_LENGTH

--- a/front/lib/actions/mcp_internal_actions/servers/conversation_files.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/conversation_files.ts
@@ -123,6 +123,7 @@ function createServer(
               type: "resource",
               resource: {
                 uri: content.image_url.url,
+                // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
                 mimeType: attachment?.contentType || "application/octet-stream",
                 text: `Image: ${title}`,
               },
@@ -132,6 +133,7 @@ function createServer(
       }
 
       return makeMCPToolTextError(
+        // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
         `File ${attachment?.title || fileId} of type ${attachment?.contentType || "unknown"} has no text or image content`
       );
     }
@@ -259,6 +261,7 @@ function createServer(
 
       // Apply offset and limit.
       if (offset !== undefined || limit !== undefined) {
+        // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
         const start = offset || 0;
         const end = limit !== undefined ? start + limit : undefined;
 

--- a/front/lib/actions/mcp_internal_actions/servers/data_warehouses/server.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/data_warehouses/server.ts
@@ -80,6 +80,7 @@ const createServer = (
       auth,
       { toolName: TABLES_FILESYSTEM_TOOL_NAME, agentLoopContext },
       async ({ nodeId, limit, nextPageCursor, dataSources }) => {
+        // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
         const effectiveLimit = Math.min(limit || DEFAULT_LIMIT, MAX_LIMIT);
 
         const dataSourceConfigurationsResult =
@@ -182,6 +183,7 @@ const createServer = (
       auth,
       { toolName: TABLES_FILESYSTEM_TOOL_NAME, agentLoopContext },
       async ({ query, rootNodeId, limit, nextPageCursor, dataSources }) => {
+        // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
         const effectiveLimit = Math.min(limit || DEFAULT_LIMIT, MAX_LIMIT);
 
         const dataSourceConfigurationsResult =

--- a/front/lib/actions/mcp_internal_actions/servers/gmail.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/gmail.ts
@@ -418,6 +418,7 @@ const createServer = (): McpServer => {
       }
 
       const originalMessage: GmailMessage = await messageResponse.json();
+      // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
       const headers = originalMessage.payload?.headers || [];
 
       // Extract header values
@@ -431,6 +432,7 @@ const createServer = (): McpServer => {
       const originalDate = getHeaderValue(headers, "Date");
 
       // Determine recipients
+      // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
       const replyTo = to?.length ? to.join(", ") : originalTo || originalFrom;
       const replyCc = cc?.length ? cc.join(", ") : originalCc;
       const replyBcc = bcc?.length ? bcc.join(", ") : originalBcc;
@@ -444,6 +446,7 @@ const createServer = (): McpServer => {
       // Create subject and headers
       const replySubject = originalSubject?.startsWith("Re:")
         ? originalSubject
+        // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
         : `Re: ${originalSubject || "No Subject"}`;
       const encodedSubject = `=?UTF-8?B?${Buffer.from(replySubject, "utf-8").toString("base64")}?=`;
       const threadingHeaders = createThreadingHeaders(
@@ -568,6 +571,7 @@ const createQuoteSection = (
   const separator =
     originalDate && originalFrom
       ? `On ${escapeHtml(originalDate)}, ${escapeHtml(originalFrom)} wrote:`
+      // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
       : `${escapeHtml(originalFrom || "Original sender")} wrote:`;
 
   const quotedOriginal = `<blockquote class="gmail_quote" style="margin:0 0 0 .8ex;border-left:1px #ccc solid;padding-left:1ex">${escapeHtml(originalBody).replace(/\n/g, "<br>")}</blockquote>`;

--- a/front/lib/actions/mcp_internal_actions/servers/gmail.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/gmail.ts
@@ -446,8 +446,8 @@ const createServer = (): McpServer => {
       // Create subject and headers
       const replySubject = originalSubject?.startsWith("Re:")
         ? originalSubject
-        // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
-        : `Re: ${originalSubject || "No Subject"}`;
+        : // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
+          `Re: ${originalSubject || "No Subject"}`;
       const encodedSubject = `=?UTF-8?B?${Buffer.from(replySubject, "utf-8").toString("base64")}?=`;
       const threadingHeaders = createThreadingHeaders(
         originalMessageId,
@@ -571,8 +571,8 @@ const createQuoteSection = (
   const separator =
     originalDate && originalFrom
       ? `On ${escapeHtml(originalDate)}, ${escapeHtml(originalFrom)} wrote:`
-      // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
-      : `${escapeHtml(originalFrom || "Original sender")} wrote:`;
+      : // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
+        `${escapeHtml(originalFrom || "Original sender")} wrote:`;
 
   const quotedOriginal = `<blockquote class="gmail_quote" style="margin:0 0 0 .8ex;border-left:1px #ccc solid;padding-left:1ex">${escapeHtml(originalBody).replace(/\n/g, "<br>")}</blockquote>`;
 

--- a/front/lib/actions/mcp_internal_actions/servers/google_calendar.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/google_calendar.ts
@@ -399,13 +399,16 @@ const createServer = (): McpServer => {
             items: [{ id: email }],
           },
         });
+        // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
         const busySlots = res.data.calendars?.[email]?.busy || [];
         const available = busySlots.length === 0;
         return makeMCPToolJSONSuccess({
           result: {
             available,
             busySlots: busySlots.map((slot) => ({
+              // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
               start: slot.start || "",
+              // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
               end: slot.end || "",
             })),
           },

--- a/front/lib/actions/mcp_internal_actions/servers/google_sheets.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/google_sheets.ts
@@ -357,6 +357,7 @@ const createServer = (): McpServer => {
       try {
         const sheetsToCreate = sheetTitles?.map((sheetTitle) => ({
           properties: { title: sheetTitle },
+        // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
         })) || [{ properties: { title: "Sheet1" } }];
 
         const res = await sheets.spreadsheets.create({

--- a/front/lib/actions/mcp_internal_actions/servers/google_sheets.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/google_sheets.ts
@@ -357,7 +357,7 @@ const createServer = (): McpServer => {
       try {
         const sheetsToCreate = sheetTitles?.map((sheetTitle) => ({
           properties: { title: sheetTitle },
-        // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
+          // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
         })) || [{ properties: { title: "Sheet1" } }];
 
         const res = await sheets.spreadsheets.create({

--- a/front/lib/actions/mcp_internal_actions/servers/hubspot/hubspot_api_helper.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/hubspot/hubspot_api_helper.ts
@@ -211,11 +211,15 @@ export const searchOwners = async (
   const query = searchQuery.toLowerCase();
 
   const filteredOwners = allOwners.filter((owner) => {
+    // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
     const emailMatch = owner.email?.toLowerCase().includes(query) || false;
     const firstNameMatch =
+      // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
       owner.firstName?.toLowerCase().includes(query) || false;
     const lastNameMatch =
+      // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
       owner.lastName?.toLowerCase().includes(query) || false;
+    // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
     const fullNameMatch = `${owner.firstName || ""} ${owner.lastName || ""}`
       .toLowerCase()
       .includes(query);

--- a/front/lib/actions/mcp_internal_actions/servers/hubspot/hubspot_response_helpers.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/hubspot/hubspot_response_helpers.ts
@@ -36,22 +36,30 @@ export function formatHubSpotObject(
       case "contacts":
         return object.properties.firstname && object.properties.lastname
           ? `${object.properties.firstname} ${object.properties.lastname}`
+          // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
           : object.properties.email ||
+              // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
               object.properties.firstname ||
+              // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
               object.properties.lastname ||
               "Unnamed Contact";
       case "companies":
         return (
+          // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
           object.properties.name ||
+          // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
           object.properties.domain ||
           "Unnamed Company"
         );
       case "deals":
+        // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
         return object.properties.dealname || "Unnamed Deal";
 
       default:
         return (
+          // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
           object.properties.name ||
+          // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
           object.properties.title ||
           `${type.slice(0, -1)} #${object.id}`
         );
@@ -90,7 +98,9 @@ export function formatHubSpotObject(
     title: getTitleField(objectType),
     url: hubSpotUrl,
     properties: cleanProperties,
+    // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
     created_at: object.properties.createdate || undefined,
+    // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
     updated_at: object.properties.lastmodifieddate || undefined,
   };
 }

--- a/front/lib/actions/mcp_internal_actions/servers/hubspot/hubspot_response_helpers.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/hubspot/hubspot_response_helpers.ts
@@ -36,8 +36,8 @@ export function formatHubSpotObject(
       case "contacts":
         return object.properties.firstname && object.properties.lastname
           ? `${object.properties.firstname} ${object.properties.lastname}`
-          // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
-          : object.properties.email ||
+          : // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
+            object.properties.email ||
               // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
               object.properties.firstname ||
               // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing

--- a/front/lib/actions/mcp_internal_actions/servers/hubspot/hubspot_utils.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/hubspot/hubspot_utils.ts
@@ -61,6 +61,7 @@ export const convertObjectTypeToId = (objectTypeId: string): string => {
     return objectTypeId;
   }
   const convertedId = getObjectTypeId(objectTypeId);
+  // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
   return convertedId || objectTypeId; // Return original if conversion fails
 };
 

--- a/front/lib/actions/mcp_internal_actions/servers/hubspot/server.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/hubspot/server.ts
@@ -972,6 +972,7 @@ const createServer = (): McpServer => {
       const csvContent = csvRows
         .map((row) =>
           input.propertiesToExport
+            // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
             .map((prop) => `"${String(row[prop] || "").replace(/"/g, '""')}"`)
             .join(",")
         )

--- a/front/lib/actions/mcp_internal_actions/servers/index.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/index.ts
@@ -63,7 +63,7 @@ function isAdvancedSearchMode(agentLoopContext?: AgentLoopContextType) {
       ) &&
       agentLoopContext.runContext.toolConfiguration.additionalConfiguration[
         ADVANCED_SEARCH_SWITCH
-      // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
+        // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
       ] === true) ||
     (agentLoopContext?.listToolsContext &&
       isServerSideMCPServerConfiguration(

--- a/front/lib/actions/mcp_internal_actions/servers/index.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/index.ts
@@ -63,6 +63,7 @@ function isAdvancedSearchMode(agentLoopContext?: AgentLoopContextType) {
       ) &&
       agentLoopContext.runContext.toolConfiguration.additionalConfiguration[
         ADVANCED_SEARCH_SWITCH
+      // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
       ] === true) ||
     (agentLoopContext?.listToolsContext &&
       isServerSideMCPServerConfiguration(

--- a/front/lib/actions/mcp_internal_actions/servers/jira/jira_api_helper.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/jira/jira_api_helper.ts
@@ -80,6 +80,7 @@ async function jiraApiCall<T extends z.ZodTypeAny>(
 ): Promise<Result<z.infer<T>, JiraErrorResult>> {
   try {
     const response = await fetch(`${options.baseUrl}${endpoint}`, {
+      // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
       method: options.method || "GET",
       headers: {
         Authorization: `Bearer ${accessToken}`,
@@ -165,6 +166,7 @@ export async function listUsers(
   let cursor = startAt;
   const results: z.infer<typeof JiraUsersSearchResultSchema> = [];
   const hasName = !!name && name.trim().length > 0;
+  // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
   const normalizedName = (name || "").trim().toLowerCase();
 
   while (results.length < maxResults) {
@@ -377,6 +379,7 @@ export async function getJiraBaseUrl(
   accessToken: string
 ): Promise<string | null> {
   const resourceInfo = await getJiraResourceInfo(accessToken);
+  // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
   const cloudId = resourceInfo?.id || null;
   if (cloudId) {
     return `https://api.atlassian.com/ex/jira/${cloudId}`;
@@ -410,6 +413,7 @@ export async function createComment(
     body: {
       type: adfBody.type,
       version: adfBody.version,
+      // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
       content: adfBody.content || [],
     },
   };
@@ -466,6 +470,7 @@ export async function searchIssues(
     nextPageToken,
     sortBy,
     maxResults = SEARCH_ISSUES_MAX_RESULTS,
+  // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
   } = options || {};
 
   const jql = createJQLFromSearchFilters(filters, sortBy);
@@ -528,6 +533,7 @@ export async function searchJiraIssuesUsingJql(
     nextPageToken,
     maxResults = SEARCH_ISSUES_MAX_RESULTS,
     fields = ["summary"],
+  // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
   } = options || {};
 
   const requestBody: z.infer<typeof JiraSearchRequestSchema> = {
@@ -725,6 +731,7 @@ export async function getAllFields(
   > = {};
 
   for (const field of result.value) {
+    // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
     const fieldKey = field.key || field.id;
     fieldsMetadata[fieldKey] = {
       schema: field.schema
@@ -1001,6 +1008,7 @@ export async function searchUsersByEmailExact(
     for (const u of page) {
       if (
         u.accountType === "atlassian" &&
+        // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
         (u.emailAddress || "").toLowerCase() === normalized
       ) {
         matches.push(u);

--- a/front/lib/actions/mcp_internal_actions/servers/jira/jira_api_helper.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/jira/jira_api_helper.ts
@@ -470,7 +470,7 @@ export async function searchIssues(
     nextPageToken,
     sortBy,
     maxResults = SEARCH_ISSUES_MAX_RESULTS,
-  // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
+    // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
   } = options || {};
 
   const jql = createJQLFromSearchFilters(filters, sortBy);
@@ -533,7 +533,7 @@ export async function searchJiraIssuesUsingJql(
     nextPageToken,
     maxResults = SEARCH_ISSUES_MAX_RESULTS,
     fields = ["summary"],
-  // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
+    // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
   } = options || {};
 
   const requestBody: z.infer<typeof JiraSearchRequestSchema> = {

--- a/front/lib/actions/mcp_internal_actions/servers/monday/monday_api_helper.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/monday/monday_api_helper.ts
@@ -439,6 +439,7 @@ export const searchItems = async (
       );
       return peopleColumns.some((col) => {
         try {
+          // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
           const value = JSON.parse(col.value || "{}");
           const personsIds =
             value.personsAndTeams?.map((p: any) => p.id.toString()) || [];
@@ -482,7 +483,9 @@ export const searchItems = async (
           bVal = new Date(b.created_at).getTime();
           break;
         case "updated_at":
+          // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
           aVal = new Date(a.updated_at || a.created_at).getTime();
+          // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
           bVal = new Date(b.updated_at || b.created_at).getTime();
           break;
         case "name":

--- a/front/lib/actions/mcp_internal_actions/servers/monday/server.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/monday/server.ts
@@ -168,6 +168,7 @@ const createServer = (): McpServer => {
         orderDirection,
       };
 
+      // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
       if (timeframeStart || timeframeEnd) {
         filters.timeframe = {
           start: timeframeStart ? new Date(timeframeStart) : undefined,
@@ -346,6 +347,7 @@ const createServer = (): McpServer => {
       const board = await createBoard(
         accessToken,
         boardName,
+        // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
         boardKind || "public",
         workspaceId,
         description

--- a/front/lib/actions/mcp_internal_actions/servers/outlook/outlook_api_helper.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/outlook/outlook_api_helper.ts
@@ -333,6 +333,7 @@ export async function listEvents(
       urlParams.append("$skip", skip.toString());
     }
 
+    // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
     if (startTime || endTime) {
       const filters = [];
       if (startTime) {
@@ -565,6 +566,7 @@ export async function updateEvent(
   }
   if (body !== undefined) {
     event.body = {
+      // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
       contentType: contentType || "text",
       content: body,
     };
@@ -572,12 +574,14 @@ export async function updateEvent(
   if (startDateTime !== undefined) {
     event.start = {
       dateTime: startDateTime,
+      // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
       timeZone: timeZone || "UTC",
     };
   }
   if (endDateTime !== undefined) {
     event.end = {
       dateTime: endDateTime,
+      // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
       timeZone: timeZone || "UTC",
     };
   }

--- a/front/lib/actions/mcp_internal_actions/servers/process/index.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/process/index.ts
@@ -135,7 +135,9 @@ function makeExtractInformationFromDocumentsTool(
         model,
         dataSources,
         timeFrame,
+        // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
         tagsIn: tagsIn || undefined,
+        // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
         tagsNot: tagsNot || undefined,
       });
 
@@ -225,6 +227,7 @@ function createServer(
         agentLoopContext.listToolsContext.agentActionConfiguration
       ) &&
       agentLoopContext.listToolsContext.agentActionConfiguration.jsonSchema !==
+        // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
         null) ||
     (agentLoopContext?.runContext &&
       isLightServerSideMCPToolConfiguration(
@@ -238,6 +241,7 @@ function createServer(
         agentLoopContext.listToolsContext.agentActionConfiguration
       ) &&
       agentLoopContext.listToolsContext.agentActionConfiguration.timeFrame !==
+        // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
         null) ||
     (agentLoopContext?.runContext &&
       isLightServerSideMCPToolConfiguration(
@@ -377,7 +381,9 @@ async function getConfigForProcessDustApp({
     config,
     dataSourceConfigurations,
     dataSourceViewsMap,
+    // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
     tagsIn || null,
+    // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
     tagsNot || null
   );
 

--- a/front/lib/actions/mcp_internal_actions/servers/process/utils.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/process/utils.ts
@@ -16,6 +16,7 @@ export function getExtractFileTitle({
   schema: JSONSchema | null;
 }): string {
   const schemaNames = Object.keys(schema?.properties ?? {}).join("_");
+  // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
   const title = schema?.title || schemaNames || "extract_results";
   // Make sure title is truncated to 100 characters
   return `${title.substring(0, 100)}.json`;

--- a/front/lib/actions/mcp_internal_actions/servers/run_dust_app.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/run_dust_app.ts
@@ -86,6 +86,7 @@ function convertDatasetSchemaToZodRawShape(
   const shape: ZodRawShape = {};
   if (datasetSchema) {
     for (const entry of datasetSchema) {
+      // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
       const desc = entry.description || "";
       switch (entry.type) {
         case "string":
@@ -122,6 +123,7 @@ async function prepareAppContext(
     logger.error(
       {
         workspaceId: auth.getNonNullableWorkspace().sId,
+        // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
         userId: auth.user()?.sId || "no_user",
         role: auth.role(),
         groupIds: auth.groups().map((g) => g.sId),
@@ -142,6 +144,7 @@ async function prepareAppContext(
     logger.error(
       {
         workspaceId: auth.getNonNullableWorkspace().sId,
+        // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
         userId: auth.user()?.sId || "no_user",
         role: auth.role(),
         groupIds: auth.groups().map((g) => g.sId),

--- a/front/lib/actions/mcp_internal_actions/servers/slack.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/slack.ts
@@ -76,6 +76,7 @@ export const slackSearch = async (
 
   const data: SlackSearchResponse = (await resp.json()) as SlackSearchResponse;
   if (!data.ok) {
+    // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
     throw new Error(data.error || "unknown_error");
   }
 
@@ -585,8 +586,11 @@ const createServer = async (
             );
 
             const getTextFromMatch = (match: SlackSearchMatch) => {
+              // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
               const author = match.author_name || "Unknown";
+              // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
               const channel = match.channel_name || "Unknown";
+              // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
               let content = match.content || "";
 
               // assistant.search.context wraps search words in \uE000 and \uE001,

--- a/front/lib/actions/mcp_internal_actions/servers/webtools_edge.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/webtools_edge.ts
@@ -278,6 +278,7 @@ const createServer = (
             MAXED_OUTPUT_FILE_SNIPPET_LENGTH
           );
 
+          // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
           const baseTitle = title || result.url;
           const fileTitle = `${baseTitle}`;
           const file = await generatePlainTextFile(auth, {

--- a/front/lib/actions/mcp_internal_actions/tools/utils.ts
+++ b/front/lib/actions/mcp_internal_actions/tools/utils.ts
@@ -315,17 +315,24 @@ export async function getAgentDataSourceConfigurations(
             dataSourceViewId: dataSourceViewSId,
             filter: {
               parents:
+                // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
                 agentConfig.parentsIn || agentConfig.parentsNotIn
                   ? {
+                      // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
                       in: agentConfig.parentsIn || [],
+                      // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
                       not: agentConfig.parentsNotIn || [],
                     }
                   : null,
               tags:
+                // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
                 agentConfig.tagsIn || agentConfig.tagsNotIn
                   ? {
+                      // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
                       in: agentConfig.tagsIn || [],
+                      // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
                       not: agentConfig.tagsNotIn || [],
+                      // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
                       mode: agentConfig.tagsMode || "custom",
                     }
                   : undefined,
@@ -478,11 +485,15 @@ export async function getCoreSearchArgs(
         dataSourceId: dataSource.dustAPIDataSourceId,
         filter: {
           tags: {
+            // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
             in: config.filter.tags?.in || null,
+            // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
             not: config.filter.tags?.not || null,
           },
           parents: {
+            // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
             in: config.filter.parents?.in || null,
+            // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
             not: config.filter.parents?.not || null,
           },
         },

--- a/front/lib/actions/mcp_internal_actions/wrappers.ts
+++ b/front/lib/actions/mcp_internal_actions/wrappers.ts
@@ -46,6 +46,7 @@ export function withToolLogging<T>(
     > = {
       workspace: {
         sId: owner.sId,
+        // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
         plan_code: auth.plan()?.code || null,
       },
       toolName,
@@ -74,6 +75,7 @@ export function withToolLogging<T>(
     const tags = [
       `tool:${toolName}`,
       `workspace:${owner.sId}`,
+      // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
       `workspace_plan_code:${auth.plan()?.code || null}`,
     ];
 

--- a/front/lib/actions/mcp_metadata.ts
+++ b/front/lib/actions/mcp_metadata.ts
@@ -479,6 +479,7 @@ export function extractMetadataFromTools(tools: Tool[]): MCPToolType[] {
     }
     return {
       name: tool.name,
+      // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
       description: tool.description || "",
       inputSchema,
     };

--- a/front/lib/actions/mcp_oauth_provider.ts
+++ b/front/lib/actions/mcp_oauth_provider.ts
@@ -82,6 +82,7 @@ export class MCPOAuthProvider implements OAuthClientProvider {
     // We pass the metadata to the client to allow them to handle the oauth flow.
     throw new MCPOAuthRequiredError({
       client_id: clientInformation.client_id,
+      // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
       client_secret: clientInformation.client_secret || "",
       token_endpoint: this.metadata.token_endpoint,
       authorization_endpoint: this.metadata.authorization_endpoint,

--- a/front/lib/actions/server.ts
+++ b/front/lib/actions/server.ts
@@ -113,6 +113,7 @@ export async function runActionStreamed(
     workspace: {
       sId: owner.sId,
       name: owner.name,
+      // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
       plan_code: auth.plan()?.code || null,
     },
     action: actionName,
@@ -126,6 +127,7 @@ export async function runActionStreamed(
     `action:${actionName}`,
     `workspace:${owner.sId}`,
     `workspace_name:${owner.name}`,
+    // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
     `workspace_plan_code:${auth.plan()?.code || null}`,
   ];
 
@@ -234,6 +236,7 @@ export async function runAction(
     workspace: {
       sId: owner.sId,
       name: owner.name,
+      // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
       plan_code: auth.plan()?.code || null,
     },
     action: actionName,
@@ -246,6 +249,7 @@ export async function runAction(
     `action:${actionName}`,
     `workspace:${owner.sId}`,
     `workspace_name:${owner.name}`,
+    // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
     `workspace_plan_code:${auth.plan()?.code || null}`,
   ];
 

--- a/front/lib/actions/types/agent.ts
+++ b/front/lib/actions/types/agent.ts
@@ -64,6 +64,7 @@ export function dustAppRunInputsToInputSchema(
 export function inputSchemaToDustAppRunInputs(
   inputSchema: JSONSchema
 ): DustAppRunInputType[] {
+  // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
   return Object.entries(inputSchema.properties || {}).map(
     ([name, property]) => {
       let type: DustAppRunInputType["type"] = "string";

--- a/front/lib/agent_yaml_converter/converter.ts
+++ b/front/lib/agent_yaml_converter/converter.ts
@@ -159,7 +159,9 @@ export class AgentYAMLConverter {
                       .dataSourceConfigurations as DataSourceViewSelectionConfigurations
                   )
                 : undefined,
+              // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
               time_frame: action.configuration.timeFrame || undefined,
+              // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
               json_schema: action.configuration.jsonSchema || undefined,
               reasoning_model: action.configuration.reasoningModel
                 ? {

--- a/front/lib/api/actions/mcp_client_side.ts
+++ b/front/lib/api/actions/mcp_client_side.ts
@@ -116,9 +116,11 @@ export async function createClientSideMCPServerConfigurations(
     id: -1, // Default ID for client-side MCP servers.
     clientSideMcpServerId: serverId,
     name:
+      // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
       metadata.find((m) => m?.serverId === serverId)?.serverName ||
       `MCP Server ${serverId}`,
     mcpServerName:
+      // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
       metadata.find((m) => m?.serverId === serverId)?.serverName || null,
     sId: serverId,
     type: "mcp_server_configuration",

--- a/front/lib/api/assistant/configuration/actions.ts
+++ b/front/lib/api/assistant/configuration/actions.ts
@@ -189,6 +189,7 @@ async function createAgentDataSourcesConfiguration(
         parentsIn: dsConfig.filter.parents?.in,
         parentsNotIn: dsConfig.filter.parents?.not,
         dataSourceViewId: dataSourceView.id,
+        // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
         mcpServerConfigurationId: mcpServerConfiguration?.id || null,
         tagsMode,
         tagsIn,

--- a/front/lib/api/assistant/configuration/agent.ts
+++ b/front/lib/api/assistant/configuration/agent.ts
@@ -402,6 +402,7 @@ export async function createAgentConfiguration(
         userFavorite = userRelation?.favorite ?? false;
       }
 
+      // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
       const sId = agentConfigurationId || generateRandomModelSId();
 
       // Create Agent config.

--- a/front/lib/api/assistant/email_trigger.ts
+++ b/front/lib/api/assistant/email_trigger.ts
@@ -445,6 +445,7 @@ export async function triggerFromEmail({
       return {
         agentConfiguration,
         agentMessage,
+        // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
         html: sanitizeHtml(await marked.parse(agentMessage.content || ""), {
           // Allow images on top of all defaults from https://www.npmjs.com/package/sanitize-html
           allowedTags: sanitizeHtml.defaults.allowedTags.concat(["img"]),

--- a/front/lib/api/assistant/generation.ts
+++ b/front/lib/api/assistant/generation.ts
@@ -213,6 +213,7 @@ export async function constructPromptMultiActions(
   // Replacement if instructions include "{USER_FULL_NAME}".
   instructions = instructions.replaceAll(
     "{USER_FULL_NAME}",
+    // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
     userMessage.context.fullName || "Unknown user"
   );
 

--- a/front/lib/api/assistant/global_agents/configurations/dust/dust.ts
+++ b/front/lib/api/assistant/global_agents/configurations/dust/dust.ts
@@ -110,6 +110,7 @@ export function _getDustGlobalAgent(
   };
 
   if (
+    // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
     (settings && settings.status === "disabled_by_admin") ||
     !modelConfiguration
   ) {

--- a/front/lib/api/assistant/global_agents/configurations/retired_managed.ts
+++ b/front/lib/api/assistant/global_agents/configurations/retired_managed.ts
@@ -79,6 +79,7 @@ function _getManagedDataSourceAgent(
 
   // Check if deactivated by an admin
   if (
+    // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
     (settings && settings.status === "disabled_by_admin") ||
     !modelConfiguration
   ) {

--- a/front/lib/api/assistant/messages.ts
+++ b/front/lib/api/assistant/messages.ts
@@ -155,6 +155,7 @@ async function batchRenderUserMessages(
     }
     const userMessage = message.userMessage;
     const messageMentions = mentions.filter((m) => m.messageId === message.id);
+    // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
     const user = users.find((u) => u.id === userMessage.userId) || null;
 
     const m = {
@@ -205,6 +206,7 @@ async function batchRenderAgentMessages<V extends RenderMessageVariant>(
 > {
   const agentMessages = messages.filter((m) => !!m.agentMessage);
   const agentMessageIds = removeNulls(
+    // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
     agentMessages.map((m) => m.agentMessageId || null)
   );
   const [agentConfigurations, agentMCPActions] = await Promise.all([

--- a/front/lib/api/assistant/preprocessing.ts
+++ b/front/lib/api/assistant/preprocessing.ts
@@ -196,6 +196,7 @@ export async function renderConversationForModel(
 
       messages.push({
         role: "user" as const,
+        // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
         name: m.context.fullName || m.context.username,
         content: [
           {

--- a/front/lib/api/assistant/reaction.ts
+++ b/front/lib/api/assistant/reaction.ts
@@ -48,6 +48,7 @@ export async function getMessageReactions(
   return new Ok(
     messages.map((m) => ({
       messageId: m.sId,
+      // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
       reactions: _renderMessageReactions(m.reactions || []),
     }))
   );

--- a/front/lib/api/config.ts
+++ b/front/lib/api/config.ts
@@ -112,6 +112,7 @@ const config = {
         EnvironmentConfig.getOptionalEnvVariable("DUST_PROD_API") ??
         PRODUCTION_DUST_API,
       nodeEnv:
+        // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
         EnvironmentConfig.getOptionalEnvVariable("NODE_ENV") || "development",
     };
   },

--- a/front/lib/api/data_source_view.ts
+++ b/front/lib/api/data_source_view.ts
@@ -251,6 +251,7 @@ export async function getContentNodesForDataSourceView(
           index,
           parentInternalId,
         ] of node.parentInternalIds.entries()) {
+          // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
           const parentsInSet = new Set(dataSourceView.parentsIn || []);
           if (parentsInSet.has(parentInternalId)) {
             deepestValidIndex = index;

--- a/front/lib/api/data_sources.ts
+++ b/front/lib/api/data_sources.ts
@@ -448,8 +448,8 @@ export async function upsertDocument({
           content: text,
           sections: [],
         }
-      // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
-      : section || null;
+      : // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
+        section || null;
 
   // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
   const nonNullTags = tags || [];

--- a/front/lib/api/data_sources.ts
+++ b/front/lib/api/data_sources.ts
@@ -389,6 +389,7 @@ export async function upsertDocument({
 > {
   // enforcing validation on the parents and parent_id
   const documentId = document_id;
+  // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
   const documentParents = parents || [documentId];
   const documentParentId = parent_id ?? null;
 
@@ -447,8 +448,10 @@ export async function upsertDocument({
           content: text,
           sections: [],
         }
+      // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
       : section || null;
 
+  // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
   const nonNullTags = tags || [];
 
   const titleInTags = nonNullTags
@@ -895,7 +898,9 @@ export async function createDataSourceFolder(
     dataSourceId: dataSource.dustAPIDataSourceId,
     folderId,
     mimeType,
+    // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
     parentId: parentId || null,
+    // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
     parents: parents || [folderId],
     projectId: dataSource.dustAPIProjectId,
     providerVisibility: "public",

--- a/front/lib/api/files/client_executable.ts
+++ b/front/lib/api/files/client_executable.ts
@@ -38,6 +38,7 @@ function validateTailwindCode(code: string): Result<undefined, Error> {
     const classContent = classMatch[1];
     if (classContent) {
       // Find all matching arbitrary values within the class attribute's value.
+      // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
       const arbitraryMatches = classContent.match(arbitraryRegex) || [];
       matches.push(...arbitraryMatches);
     }

--- a/front/lib/api/files/upload.ts
+++ b/front/lib/api/files/upload.ts
@@ -659,7 +659,9 @@ export async function processAndStoreFromUrl(
 
     const contentLength = response.headers.get("content-length");
     const finalContentType =
+      // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
       contentType ||
+      // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
       response.headers.get("content-type") ||
       "application/octet-stream";
 
@@ -675,6 +677,7 @@ export async function processAndStoreFromUrl(
       workspaceId: auth.getNonNullableWorkspace().id,
       userId: auth.user()?.id ?? null,
       contentType: finalContentType,
+      // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
       fileName: fileName || new URL(url).pathname.split("/").pop() || "file",
       fileSize: contentLength ? parseInt(contentLength) : 1024 * 1024 * 10, // Default 10MB if no content-length
       useCase,

--- a/front/lib/api/files/upsert.test.ts
+++ b/front/lib/api/files/upsert.test.ts
@@ -182,6 +182,7 @@ describe("processAndUpsertToDataSource", () => {
 
       // Should contain both the existing table ID and the new one
       const generatedTables =
+        // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
         updatedFile.useCaseMetadata?.generatedTables || [];
       expect(generatedTables).toContain(existingTableId);
       expect(generatedTables).toContain(file.sId);
@@ -276,6 +277,7 @@ id,category,description
       expect(updatedFile.useCaseMetadata).not.toBeNull();
 
       const generatedTables =
+        // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
         updatedFile.useCaseMetadata?.generatedTables || [];
       expect(generatedTables).toContain(`${file.sId}-${slugify("Sheet1")}`);
       expect(generatedTables).toContain(`${file.sId}-${slugify("Sheet2")}`);
@@ -383,6 +385,7 @@ id,category,description
       expect(updatedFile.useCaseMetadata).not.toBeNull();
 
       const generatedTables =
+        // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
         updatedFile.useCaseMetadata?.generatedTables || [];
       expect(generatedTables).toContain(`${file.sId}-${slugify("Sheet1")}`);
       expect(generatedTables).toContain(`${file.sId}-${slugify("Sheet2")}`);

--- a/front/lib/api/oauth/providers/github.ts
+++ b/front/lib/api/oauth/providers/github.ts
@@ -43,6 +43,7 @@ export class GithubOAuthProvider implements BaseOAuthStrategyProvider {
     // OAuth flow returns "code", GitHub App installation returns "installation_id"
     // Both serve as authorization credentials for their respective flows
     return (
+      // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
       getStringFromQuery(query, "installation_id") ||
       getStringFromQuery(query, "code")
     );

--- a/front/lib/api/oauth/providers/microsoft_tools.ts
+++ b/front/lib/api/oauth/providers/microsoft_tools.ts
@@ -27,6 +27,7 @@ export class MicrosoftToolsOAuthProvider implements BaseOAuthStrategyProvider {
 
     const qs = querystring.stringify({
       response_type: "code",
+      // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
       client_id: clientId || config.getOAuthMicrosoftToolsClientId(),
       state: connection.connection_id,
       redirect_uri: finalizeUriForProvider("microsoft_tools"),

--- a/front/lib/api/oauth/providers/notion.ts
+++ b/front/lib/api/oauth/providers/notion.ts
@@ -138,6 +138,7 @@ export class NotionOAuthProvider implements BaseOAuthStrategyProvider {
           ...restConfig,
           requested_notion_workspace_id: notionWorkspaceId,
           requested_notion_workspace_name:
+            // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
             notionWorkspaceName || "Unknown Workspace",
         };
 
@@ -192,6 +193,7 @@ export class NotionOAuthProvider implements BaseOAuthStrategyProvider {
             "You must connect to the Notion workspace configured by your admin (" +
             requestedNotionWorkspaceName +
             "), instead of the current workspace (" +
+            // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
             (currentNotionWorkspaceName || "Unknown") +
             ").",
         });

--- a/front/lib/api/poke/plugin_manager.ts
+++ b/front/lib/api/poke/plugin_manager.ts
@@ -21,6 +21,7 @@ class PluginManager {
         for (const rt of resourceTypes) {
           // Initialize and push in one statement.
           (this.pluginsByResourceType[rt] =
+            // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
             this.pluginsByResourceType[rt] || []).push(plugin);
         }
 
@@ -40,6 +41,7 @@ class PluginManager {
   }
 
   getPluginsForResourceType(resourceType: SupportedResourceType): AllPlugins[] {
+    // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
     return this.pluginsByResourceType[resourceType] || [];
   }
 

--- a/front/lib/api/poke/plugins/data_sources/notion_url_sync.ts
+++ b/front/lib/api/poke/plugins/data_sources/notion_url_sync.ts
@@ -289,6 +289,7 @@ export async function deleteUrls({
         db: { [key: string]: unknown } | null;
       };
 
+      // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
       if ((page && !page.in_trash) || (db && !db.in_trash)) {
         return {
           url,

--- a/front/lib/api/redis-hybrid-manager.ts
+++ b/front/lib/api/redis-hybrid-manager.ts
@@ -282,6 +282,7 @@ class RedisHybridManager {
     const history: EventPayload[] = await this.getHistory(
       streamClient,
       streamName,
+      // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
       lastEventId || "0-0"
     );
 

--- a/front/lib/api/regions/lookup.ts
+++ b/front/lib/api/regions/lookup.ts
@@ -52,6 +52,7 @@ export async function lookupUserRegionByEmail(
   }
 
   // Return true if there is either a valid pending invite or workspace with verified domain
+  // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
   return Boolean(pendingInvite || workspaceWithVerifiedDomain);
 }
 

--- a/front/lib/api/resource_wrappers.ts
+++ b/front/lib/api/resource_wrappers.ts
@@ -170,6 +170,7 @@ function withSpaceFromRoute<T, A extends SessionOrKeyAuthType>(
   ) => {
     const { spaceId } = req.query;
 
+    // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
     if (spaceId || options.space) {
       // Handling the case where `spaceId` is undefined to keep support for the
       // legacy endpoint for v1 routes (global space assumed in that case).

--- a/front/lib/api/search.ts
+++ b/front/lib/api/search.ts
@@ -182,6 +182,7 @@ export async function handleSearch(
     : allDatasourceViews;
 
   const excludedNodeMimeTypes =
+    // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
     nodeIds || searchSourceUrls ? [] : NON_SEARCHABLE_NODES_MIME_TYPES;
 
   const searchFilterRes = getSearchFilterFromDataSourceViews(

--- a/front/lib/api/tracker.ts
+++ b/front/lib/api/tracker.ts
@@ -46,6 +46,7 @@ export const processTrackerNotification = async ({
   }
 
   // Send the tracker email(s).
+  // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
   const generations = tracker.generations || [];
   if (generations.length > 0 || !tracker.skipEmptyEmails) {
     await sendTrackerEmail({

--- a/front/lib/api/workos/user.ts
+++ b/front/lib/api/workos/user.ts
@@ -157,6 +157,7 @@ export async function getWorkOSSessionFromCookie(
           await getWorkOSSessionFromCookie(refreshedCookie);
         // Send the new cookie
         return {
+          // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
           cookie: cookie || refreshedCookie,
           session,
         };

--- a/front/lib/api/workspace.ts
+++ b/front/lib/api/workspace.ts
@@ -403,6 +403,7 @@ export async function updateWorkspaceMetadata(
   owner: LightWorkspaceType,
   metadata: WorkspaceMetadata
 ): Promise<Result<void, Error>> {
+  // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
   const previousMetadata = owner.metadata || {};
   const newMetadata = { ...previousMetadata, ...metadata };
   return WorkspaceResource.updateMetadata(owner.id, newMetadata);
@@ -433,6 +434,7 @@ export function isWorkspaceRelocationDone(owner: LightWorkspaceType): boolean {
 export function getWorkspacePublicAPILimits(
   owner: LightWorkspaceType
 ): PublicAPILimitsType | null {
+  // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
   return owner.metadata?.publicApiLimits || null;
 }
 

--- a/front/lib/assistant/state/messageReducer.ts
+++ b/front/lib/assistant/state/messageReducer.ts
@@ -171,6 +171,7 @@ export function messageReducer(
           break;
         case "tokens":
           newState.message.content =
+            // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
             (newState.message.content || "") + event.text;
           newState.agentState = "writing";
           break;
@@ -180,6 +181,7 @@ export function messageReducer(
             newState.message.chainOfThought = "";
           } else {
             newState.message.chainOfThought =
+              // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
               (newState.message.chainOfThought || "") + event.text;
           }
           newState.agentState = "thinking";

--- a/front/lib/auth.ts
+++ b/front/lib/auth.ts
@@ -101,10 +101,13 @@ export class Authenticator {
     subscription?: SubscriptionResource | null;
     key?: KeyAuthType;
   }) {
+    // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
     this._workspace = workspace || null;
+    // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
     this._user = user || null;
     this._groups = groups;
     this._role = role;
+    // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
     this._subscription = subscription || null;
     this._key = key;
     if (user) {
@@ -671,6 +674,7 @@ export class Authenticator {
           sId: this._workspace.sId,
           name: this._workspace.name,
           role: this._role,
+          // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
           segmentation: this._workspace.segmentation || null,
           ssoEnforced: this._workspace.ssoEnforced,
           workOSOrganizationId: this._workspace.workOSOrganizationId,
@@ -965,6 +969,7 @@ export async function getSession(
   res: NextApiResponse | GetServerSidePropsContext["res"]
 ): Promise<SessionWithUser | null> {
   const workOsSession = await getWorkOSSession(req, res);
+  // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
   return workOsSession || null;
 }
 

--- a/front/lib/client/agent_builder/instructions.ts
+++ b/front/lib/client/agent_builder/instructions.ts
@@ -12,22 +12,26 @@ function serializeNodeToText(node: JSONContent): string {
     const level = node.attrs?.level || 1;
     const safeLevel = Math.max(1, Math.min(level, 6));
     const prefix = "#".repeat(safeLevel) + " ";
+    // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
     const content = node.content?.map(serializeNodeToText).join("") || "";
     return `${prefix}${content}\n`;
   }
 
   if (node.type === "paragraph") {
+    // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
     const text = node.content?.map(serializeNodeToText).join("") || "";
     return `${text}\n`;
   }
 
   if (node.type === "text") {
+    // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
     return node.text || "";
   }
 
   if (node.type === "codeBlock") {
     // Convert code blocks to markdown format with triple backticks
     const language = node.attrs?.language || "";
+    // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
     const code = node.content?.map(serializeNodeToText).join("") || "";
     // Code blocks should have exactly one newline before the closing backticks
     return `\`\`\`${language}\n${code}\n\`\`\`\n`;

--- a/front/lib/commit-hash.ts
+++ b/front/lib/commit-hash.ts
@@ -1,2 +1,3 @@
 // We must use NEXT_PUBLIC_ prefix to make it available on the client side.
+// eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
 export const COMMIT_HASH = process.env.NEXT_PUBLIC_COMMIT_HASH || "development";

--- a/front/lib/connectors.ts
+++ b/front/lib/connectors.ts
@@ -230,6 +230,7 @@ const providers: Partial<Record<ConnectorProvider, Provider>> = {
     },
     extractor: (url: URL): NodeCandidate => {
       // Try each type of extraction in order
+      // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
       const node = extractThreadNodeId(url) || extractChannelNodeId(url);
       return node
         ? { node, provider: "slack" }

--- a/front/lib/document_upsert_hooks/hooks/data_source_helpers.ts
+++ b/front/lib/document_upsert_hooks/hooks/data_source_helpers.ts
@@ -61,6 +61,7 @@ export async function getDiffBetweenDocumentVersions({
     if (res.isErr()) {
       throw res.error;
     }
+    // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
     return res.value.document.text || "";
   }
 

--- a/front/lib/iam/users.ts
+++ b/front/lib/iam/users.ts
@@ -89,6 +89,7 @@ export async function createOrUpdateUser({
           externalUser.name
         );
         updateArgs.firstName = softHtmlEscape(firstName);
+        // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
         updateArgs.lastName = softHtmlEscape(lastName || "");
       }
     }
@@ -138,7 +139,9 @@ export async function createOrUpdateUser({
       externalUser.name
     );
 
+    // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
     firstName = softHtmlEscape(externalUser.given_name || firstName);
+    // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
     lastName = externalUser.family_name || lastName;
     if (lastName) {
       lastName = softHtmlEscape(lastName);

--- a/front/lib/plans/renderers.ts
+++ b/front/lib/plans/renderers.ts
@@ -65,11 +65,16 @@ export function renderSubscriptionFromModels({
   return {
     status: activeSubscription?.status ?? "active",
     trialing: activeSubscription?.trialing === true,
+    // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
     sId: activeSubscription?.sId || null,
+    // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
     stripeSubscriptionId: activeSubscription?.stripeSubscriptionId || null,
+    // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
     startDate: activeSubscription?.startDate?.getTime() || null,
+    // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
     endDate: activeSubscription?.endDate?.getTime() || null,
     paymentFailingSince:
+      // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
       activeSubscription?.paymentFailingSince?.getTime() || null,
     plan: renderPlanFromModel({ plan }),
     requestCancelAt: activeSubscription?.requestCancelAt?.getTime() ?? null,

--- a/front/lib/resources/agent_step_content_resource.ts
+++ b/front/lib/resources/agent_step_content_resource.ts
@@ -547,6 +547,7 @@ export class AgentStepContentResource extends BaseResource<AgentStepContentModel
       : null;
 
     const actions = actualStepContents.flatMap((stepContent) =>
+      // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
       (stepContent.agentMCPActions || []).map((action) => {
         assert(
           stepContent.agentMessage?.message?.conversation,

--- a/front/lib/resources/app_resource.ts
+++ b/front/lib/resources/app_resource.ts
@@ -313,6 +313,7 @@ export class AppResource extends ResourceWithSpace<AppModel> {
   }
 
   parseSavedSpecification() {
+    // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
     return JSON.parse(this.savedSpecification || "[]") as SpecificationType;
   }
 }

--- a/front/lib/resources/data_source_view_resource.ts
+++ b/front/lib/resources/data_source_view_resource.ts
@@ -550,6 +550,7 @@ export class DataSourceViewResource extends ResourceWithSpace<DataSourceViewMode
     parentsToAdd: string[] = [],
     parentsToRemove: string[] = []
   ): Promise<Result<undefined, Error>> {
+    // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
     const currentParents = this.parentsIn || [];
 
     if (this.kind === "default") {

--- a/front/lib/resources/default_remote_mcp_server_in_memory_resource.ts
+++ b/front/lib/resources/default_remote_mcp_server_in_memory_resource.ts
@@ -63,10 +63,12 @@ export class DefaultRemoteMCPServerInMemoryResource {
         this.config.authMethod === "oauth-dynamic"
           ? {
               provider: "mcp",
+              // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
               supported_use_cases: this.config.supportedOAuthUseCases || [],
             }
           : null,
       tools: [], // There are no predefined tools for default remote servers
+      // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
       documentationUrl: this.config.documentationUrl || null,
       availability: "manual" as const,
       allowMultipleInstances: true,

--- a/front/lib/resources/group_resource.ts
+++ b/front/lib/resources/group_resource.ts
@@ -295,6 +295,7 @@ export class GroupResource extends BaseResource<GroupModel> {
       })
     ).map((group) => new this(GroupModel, group.get()));
     const systemGroup =
+      // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
       existingGroups.find((v) => v.kind === "system") ||
       (await GroupResource.makeNew({
         name: "System",
@@ -302,6 +303,7 @@ export class GroupResource extends BaseResource<GroupModel> {
         workspaceId: workspace.id,
       }));
     const globalGroup =
+      // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
       existingGroups.find((v) => v.kind === "global") ||
       (await GroupResource.makeNew({
         name: "Workspace",
@@ -493,6 +495,7 @@ export class GroupResource extends BaseResource<GroupModel> {
     auth: Authenticator,
     { includes, limit, order, where }: ResourceFindOptions<GroupModel> = {}
   ) {
+    // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
     const includeClauses: Includeable[] = includes || [];
 
     const groupModels = await this.model.findAll({

--- a/front/lib/resources/mcp_server_view_resource.ts
+++ b/front/lib/resources/mcp_server_view_resource.ts
@@ -224,6 +224,7 @@ export class MCPServerViewResource extends ResourceWithSpace<MCPServerViewModel>
         workspaceId: auth.getNonNullableWorkspace().id,
       },
       includes: [
+        // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
         ...(options.includes || []),
         {
           model: UserModel,
@@ -786,6 +787,7 @@ export class MCPServerViewResource extends ResourceWithSpace<MCPServerViewModel>
         this.remoteMCPServer ? this.remoteMCPServer.updatedAt : this.updatedAt
       ),
       toolsMetadata:
+        // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
         this.internalToolsMetadata || this.remoteToolsMetadata || [],
     };
   }

--- a/front/lib/resources/resource_with_space.ts
+++ b/front/lib/resources/resource_with_space.ts
@@ -106,6 +106,7 @@ export abstract class ResourceWithSpace<
             throw new Error("Unreachable: space not found.");
           }
 
+          // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
           const includedResults = (includes || []).reduce<IncludeType>(
             (acc, current) => {
               if (

--- a/front/lib/resources/space_resource.ts
+++ b/front/lib/resources/space_resource.ts
@@ -97,6 +97,7 @@ export class SpaceResource extends BaseResource<SpaceModel> {
       includeConversationsSpace: true,
     });
     const systemSpace =
+      // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
       existingSpaces.find((s) => s.isSystem()) ||
       (await SpaceResource.makeNew(
         {
@@ -109,6 +110,7 @@ export class SpaceResource extends BaseResource<SpaceModel> {
       ));
 
     const globalSpace =
+      // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
       existingSpaces.find((s) => s.isGlobal()) ||
       (await SpaceResource.makeNew(
         {
@@ -121,6 +123,7 @@ export class SpaceResource extends BaseResource<SpaceModel> {
       ));
 
     const conversationsSpace =
+      // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
       existingSpaces.find((s) => s.isConversations()) ||
       (await SpaceResource.makeNew(
         {
@@ -174,6 +177,7 @@ export class SpaceResource extends BaseResource<SpaceModel> {
       {
         model: GroupResource.model,
       },
+      // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
       ...(includes || []),
     ];
 

--- a/front/lib/resources/storage/wrappers/workspace_models.ts
+++ b/front/lib/resources/storage/wrappers/workspace_models.ts
@@ -152,6 +152,7 @@ export class WorkspaceAwareModel<M extends Model = any> extends BaseModel<M> {
           // }
         }
       },
+      // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
       ...(restOptions.hooks || {}),
     };
 
@@ -243,6 +244,7 @@ export class SoftDeletableWorkspaceAwareModel<
     const updateOptions: UpdateOptions<Attributes<M>> = {
       ...options,
       fields: ["deletedAt"],
+      // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
       where: options?.where || {},
     };
 

--- a/front/lib/resources/subscription_resource.ts
+++ b/front/lib/resources/subscription_resource.ts
@@ -656,9 +656,12 @@ export class SubscriptionResource extends BaseResource<Subscription> {
       status: this.status ?? "active",
       trialing: this.trialing === true,
       sId: this.sId || null,
+      // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
       stripeSubscriptionId: this.stripeSubscriptionId || null,
       startDate: this.startDate?.getTime() || null,
+      // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
       endDate: this.endDate?.getTime() || null,
+      // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
       paymentFailingSince: this.paymentFailingSince?.getTime() || null,
       plan: this.getPlan(),
       requestCancelAt: this.requestCancelAt?.getTime() ?? null,

--- a/front/lib/resources/tracker_resource.ts
+++ b/front/lib/resources/tracker_resource.ts
@@ -362,6 +362,7 @@ export class TrackerConfigurationResource extends ResourceWithSpace<TrackerConfi
         workspaceId: this.workspaceId,
       }),
       filter:
+        // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
         m.parentsIn || m.parentsNotIn
           ? {
               parents: {
@@ -382,10 +383,12 @@ export class TrackerConfigurationResource extends ResourceWithSpace<TrackerConfi
     const trackers = await this.baseFetchWithAuthorization(auth, {
       ...options,
       where: {
+        // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
         ...(options?.where || {}),
         workspaceId: auth.getNonNullableWorkspace().id,
       },
       includes: [
+        // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
         ...(options?.includes || []),
         {
           model: TrackerDataSourceConfigurationModel,

--- a/front/lib/resources/webhook_sources_view_resource.ts
+++ b/front/lib/resources/webhook_sources_view_resource.ts
@@ -147,6 +147,7 @@ export class WebhookSourcesViewResource extends ResourceWithSpace<WebhookSources
         workspaceId: auth.getNonNullableWorkspace().id,
       },
       includes: [
+        // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
         ...(options.includes || []),
         {
           model: UserModel,

--- a/front/lib/swr/agent_triggers.ts
+++ b/front/lib/swr/agent_triggers.ts
@@ -193,6 +193,7 @@ export function useRemoveTriggerSubscriber({
   const sendNotification = useSendNotification();
   const { mutateTriggers: mutateAgentTriggers } = useAgentTriggers({
     workspaceId,
+    // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
     agentConfigurationId: agentConfigurationId || null,
     disabled: !agentConfigurationId,
   });
@@ -207,6 +208,7 @@ export function useRemoveTriggerSubscriber({
       triggerAgentConfigurationId?: string
     ): Promise<boolean> => {
       const targetAgentConfigurationId =
+        // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
         triggerAgentConfigurationId || agentConfigurationId;
 
       try {

--- a/front/lib/swr/assistants.ts
+++ b/front/lib/swr/assistants.ts
@@ -168,6 +168,7 @@ export function useSuggestedAgentConfigurations({
       disabled: inCache || disabled,
     });
 
+  // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
   const dataToUse = cachedData || data;
 
   return {

--- a/front/lib/swr/blocked_actions.ts
+++ b/front/lib/swr/blocked_actions.ts
@@ -21,6 +21,7 @@ export function useBlockedActions({
   );
 
   return {
+    // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
     blockedActions: data?.blockedActions || emptyArray(),
     isLoading: !error && !data,
     isError: error,

--- a/front/lib/swr/connectors.ts
+++ b/front/lib/swr/connectors.ts
@@ -100,6 +100,7 @@ export function useConnectorConfig({
   const url = `/api/w/${owner.sId}/data_sources/${dataSource?.sId}/managed/config/${configKey}`;
 
   const { data, error, mutate } = useSWRWithDefaults(url, configFetcher, {
+    // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
     disabled: disabled || !dataSource,
   });
 
@@ -145,6 +146,7 @@ export function useConnector({
 
       return 0;
     },
+    // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
     disabled: disabled || !dataSource.connectorId,
   });
 

--- a/front/lib/swr/data_source_view_tables.ts
+++ b/front/lib/swr/data_source_view_tables.ts
@@ -96,6 +96,7 @@ export function useDataSourceViewTables({
 
   return {
     tables: data?.tables ?? emptyArray(),
+    // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
     nextPageCursor: data?.nextPageCursor || null,
     isTablesLoading: !isDisabled && !error && !data,
     isTablesError: error,

--- a/front/lib/swr/data_source_views.ts
+++ b/front/lib/swr/data_source_views.ts
@@ -317,6 +317,7 @@ export function useInfiniteDataSourceViewContentNodes({
       (_pageIndex, previousPageData) => {
         // If we reached the end, stop fetching
         if (
+          // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
           (previousPageData && !previousPageData.nextPageCursor) ||
           !dataSourceView
         ) {
@@ -362,11 +363,14 @@ export function useInfiniteDataSourceViewContentNodes({
     isNodesValidating: isValidating,
     nodesError: error,
     nodes,
+    // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
     nextPageCursor: lastPage?.nextPageCursor || null,
     hasNextPage,
     loadMore,
     mutate,
+    // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
     totalNodesCount: lastPage?.total || 0,
+    // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
     totalNodesCountIsAccurate: lastPage?.totalIsAccurate || true,
     isLoadingMore:
       isLoading || (size > 0 && data && typeof data[size - 1] === "undefined"),

--- a/front/lib/swr/files.ts
+++ b/front/lib/swr/files.ts
@@ -39,6 +39,7 @@ export function useFileProcessedContent(
     disabled?: boolean;
   }
 ) {
+  // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
   const isDisabled = config?.disabled || fileId === null;
 
   const {

--- a/front/lib/swr/geo.ts
+++ b/front/lib/swr/geo.ts
@@ -79,6 +79,7 @@ export function useGeolocation({ disabled }: { disabled?: boolean } = {}) {
   );
 
   return {
+    // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
     geoData: cachedData || data,
     isGeoDataLoading: !error && !cachedData && !data && !disabled,
     isGeoDataError: error,

--- a/front/lib/swr/mcp_actions.ts
+++ b/front/lib/swr/mcp_actions.ts
@@ -37,6 +37,7 @@ export function useMCPActions({
   const mcpActionsFetcher: Fetcher<GetMCPActionsResult> = fetcher;
 
   // For the current page, we need the cursor from our cache
+  // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
   const cursor = cursors[currentPage] || null;
   const url = cursor
     ? `/api/w/${owner.sId}/labs/mcp_actions/${agentId}?limit=${pageSize}&cursor=${cursor}`
@@ -76,7 +77,9 @@ export function useMCPActions({
   const canGoPrevious = currentPage > 0;
 
   return {
+    // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
     actions: data?.actions || [],
+    // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
     totalCount: data?.totalCount || 0,
     currentPage,
     totalPages,

--- a/front/lib/swr/mcp_servers.ts
+++ b/front/lib/swr/mcp_servers.ts
@@ -126,6 +126,7 @@ export function useMCPServer({
   }
 
   return {
+    // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
     server: data?.server || null,
     isMCPServerLoading: !error && !data && !disabled,
     isMCPServerError: !!error,

--- a/front/lib/swr/spaces.ts
+++ b/front/lib/swr/spaces.ts
@@ -99,6 +99,7 @@ export function useSpaceInfo({
     `/api/w/${workspaceId}/spaces/${spaceId}`,
     spacesCategoriesFetcher,
     {
+      // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
       disabled: disabled || spaceId === null,
     }
   );
@@ -727,6 +728,7 @@ export function useSpacesSearch({
 
   // Only perform a query if we have a valid search
   const url =
+    // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
     (search && search.length >= MIN_SEARCH_QUERY_SIZE) || nodeIds?.length
       ? `/api/w/${owner.sId}/search?${params}`
       : null;
@@ -792,6 +794,7 @@ export function useSpacesSearchWithInfiniteScroll({
 
   // Only perform a query if we have a valid search
   const url =
+    // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
     (search && search.length >= 1) || nodeIds
       ? `/api/w/${owner.sId}/search`
       : null;

--- a/front/lib/utils/apps.ts
+++ b/front/lib/utils/apps.ts
@@ -117,6 +117,7 @@ async function updateDatasets(
       const coreDataset = await coreAPI.createDataset({
         projectId: app.dustAPIProjectId,
         datasetId: datasetToImport.name,
+        // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
         data: datasetToImport.data || [],
       });
       if (coreDataset.isErr()) {

--- a/front/lib/utils/rate_limiter.ts
+++ b/front/lib/utils/rate_limiter.ts
@@ -17,6 +17,7 @@ async function getRedisClient({
   origin: RedisUsageTagsType;
   redisUri?: string;
 }) {
+  // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
   const REDIS_URI = redisUri || process.env.REDIS_URI;
   if (!REDIS_URI) {
     throw new Error("REDIS_URI is not defined");

--- a/front/lib/utils/transcribe_service.ts
+++ b/front/lib/utils/transcribe_service.ts
@@ -39,6 +39,7 @@ async function toFileLike(
   fallbackName = "audio.wav"
 ): Promise<FileLike> {
   const stream = fs.createReadStream(input.filepath);
+  // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
   const name = input.originalFilename || fallbackName;
   return toFile(stream, name);
 }

--- a/front/lib/utils/utm.ts
+++ b/front/lib/utils/utm.ts
@@ -50,6 +50,7 @@ export const appendUTMParams = (
     return url;
   }
 
+  // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
   const params = utmParams || getStoredUTMParams();
 
   if (Object.keys(params).length === 0) {

--- a/front/lib/workspace_usage.ts
+++ b/front/lib/workspace_usage.ts
@@ -683,6 +683,7 @@ export async function getFeedbackUsageData(
       agentConfigurationId: jsonFeedback.agentConfigurationId,
       agentConfigurationVersion: jsonFeedback.agentConfigurationVersion,
       thumb: jsonFeedback.thumbDirection,
+      // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
       content: jsonFeedback.content?.replace(/\r?\n/g, "\\n") || null,
       conversationUrl:
         jsonFeedback.conversationId && jsonFeedback.isConversationShared
@@ -750,5 +751,6 @@ export async function checkWorkspaceActivity(auth: Authenticator) {
     },
   });
 
+  // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
   return hasDataSource || hasCreatedAssistant || hasRecentConversation;
 }

--- a/front/pages/_app.tsx
+++ b/front/pages/_app.tsx
@@ -15,7 +15,9 @@ if (process.env.NEXT_PUBLIC_DATADOG_CLIENT_TOKEN) {
   datadogLogs.init({
     clientToken: process.env.NEXT_PUBLIC_DATADOG_CLIENT_TOKEN,
     env: process.env.NODE_ENV === "production" ? "prod" : "dev",
+    // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
     service: `${process.env.NEXT_PUBLIC_DATADOG_SERVICE || "front"}-browser`,
+    // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
     version: process.env.NEXT_PUBLIC_COMMIT_HASH || "",
     site: "datadoghq.eu",
     forwardErrorsToLogs: true,

--- a/front/pages/_document.tsx
+++ b/front/pages/_document.tsx
@@ -44,17 +44,23 @@ class MyDocument extends Document {
                d=o.createElement(u);d.async=1;d.src=n
                n=o.getElementsByTagName(u)[0];n.parentNode.insertBefore(d,n)
              })(window,document,'script','https://www.datadoghq-browser-agent.com/eu1/v6/datadog-rum.js','DD_RUM')
-             // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
-             '${process.env.NEXT_PUBLIC_DATADOG_CLIENT_TOKEN || ""}' && window.DD_RUM.onReady(function() {
+             '${
+               // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
+               process.env.NEXT_PUBLIC_DATADOG_CLIENT_TOKEN || ""
+             }' && window.DD_RUM.onReady(function() {
                window.DD_RUM.init({
                  clientToken: '${process.env.NEXT_PUBLIC_DATADOG_CLIENT_TOKEN}',
                  applicationId: '5e9735e7-87c8-4093-b09f-49d708816bfd',
                  site: 'datadoghq.eu',
-                 // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
-                 service: '${process.env.NEXT_PUBLIC_DATADOG_SERVICE || "front"}-browser',
+                 service: '${
+                   // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
+                   process.env.NEXT_PUBLIC_DATADOG_SERVICE || "front"
+                 }-browser',
                  env: '${process.env.NODE_ENV === "production" ? "prod" : "dev"}',
-                 // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
-                 version: '${process.env.NEXT_PUBLIC_COMMIT_HASH || ""}',
+                 version: '${
+                   // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
+                   process.env.NEXT_PUBLIC_COMMIT_HASH || ""
+                 }',
                  allowedTracingUrls: [
                    "https://dust.tt",
                    "https://eu.dust.tt",

--- a/front/pages/_document.tsx
+++ b/front/pages/_document.tsx
@@ -44,13 +44,16 @@ class MyDocument extends Document {
                d=o.createElement(u);d.async=1;d.src=n
                n=o.getElementsByTagName(u)[0];n.parentNode.insertBefore(d,n)
              })(window,document,'script','https://www.datadoghq-browser-agent.com/eu1/v6/datadog-rum.js','DD_RUM')
+             // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
              '${process.env.NEXT_PUBLIC_DATADOG_CLIENT_TOKEN || ""}' && window.DD_RUM.onReady(function() {
                window.DD_RUM.init({
                  clientToken: '${process.env.NEXT_PUBLIC_DATADOG_CLIENT_TOKEN}',
                  applicationId: '5e9735e7-87c8-4093-b09f-49d708816bfd',
                  site: 'datadoghq.eu',
+                 // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
                  service: '${process.env.NEXT_PUBLIC_DATADOG_SERVICE || "front"}-browser',
                  env: '${process.env.NODE_ENV === "production" ? "prod" : "dev"}',
+                 // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
                  version: '${process.env.NEXT_PUBLIC_COMMIT_HASH || ""}',
                  allowedTracingUrls: [
                    "https://dust.tt",

--- a/front/pages/api/email/webhook.ts
+++ b/front/pages/api/email/webhook.ts
@@ -59,8 +59,11 @@ const parseSendgridWebhookContent = async (
     }
 
     return new Ok({
+      // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
       subject: subject || "(no subject)",
+      // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
       text: text || "",
+      // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
       auth: { SPF: SPF || "", dkim: dkim || "" },
       envelope: {
         to: envelope.to || [],

--- a/front/pages/api/poke/plugins/[pluginId]/run.ts
+++ b/front/pages/api/poke/plugins/[pluginId]/run.ts
@@ -108,6 +108,7 @@ async function handler(
         : null;
 
       let formData: Record<string, any>;
+      // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
       const contentType = req.headers["content-type"] || "";
 
       if (contentType.includes("application/json")) {

--- a/front/pages/api/poke/templates/[tId].ts
+++ b/front/pages/api/poke/templates/[tId].ts
@@ -130,6 +130,7 @@ async function handler(
         timeFrameDuration: body.timeFrameDuration
           ? parseInt(body.timeFrameDuration)
           : null,
+        // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
         timeFrameUnit: body.timeFrameUnit || null,
         presetDescription: null,
         presetInstructions: body.presetInstructions ?? null,

--- a/front/pages/api/stripe/webhook.ts
+++ b/front/pages/api/stripe/webhook.ts
@@ -111,7 +111,9 @@ async function handler(
           const session = event.data.object as Stripe.Checkout.Session;
           const workspaceId = session.client_reference_id;
           const stripeSubscriptionId = session.subscription;
+          // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
           const planCode = session?.metadata?.planCode || null;
+          // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
           const userId = session?.metadata?.userId || null;
 
           if (session.status === "open" || session.status === "expired") {

--- a/front/pages/api/v1/auth/[action].ts
+++ b/front/pages/api/v1/auth/[action].ts
@@ -105,6 +105,7 @@ async function handleAuthenticate(req: NextApiRequest, res: NextApiResponse) {
       method: "POST",
       headers: {
         "Content-Type": "application/x-www-form-urlencoded",
+        // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
         Origin: req.headers.origin || "",
       },
       credentials: "include",

--- a/front/pages/api/v1/w/[wId]/assistant/conversations/[cId]/events.ts
+++ b/front/pages/api/v1/w/[wId]/assistant/conversations/[cId]/events.ts
@@ -71,6 +71,7 @@ async function handler(
     });
   }
 
+  // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
   const lastEventId = req.query.lastEventId || null;
   if (lastEventId && typeof lastEventId !== "string") {
     return apiError(req, res, {

--- a/front/pages/api/v1/w/[wId]/assistant/conversations/[cId]/messages/[mId]/events.ts
+++ b/front/pages/api/v1/w/[wId]/assistant/conversations/[cId]/messages/[mId]/events.ts
@@ -132,6 +132,7 @@ async function handler(
     });
   }
 
+  // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
   const lastEventId = req.query.lastEventId || null;
   if (lastEventId && typeof lastEventId !== "string") {
     return apiError(req, res, {

--- a/front/pages/api/v1/w/[wId]/assistant/conversations/[cId]/messages/[mId]/feedbacks.ts
+++ b/front/pages/api/v1/w/[wId]/assistant/conversations/[cId]/messages/[mId]/feedbacks.ts
@@ -235,6 +235,7 @@ async function handler(
         user,
         thumbDirection: bodyValidation.right
           .thumbDirection as AgentMessageFeedbackDirection,
+        // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
         content: bodyValidation.right.feedbackContent || "",
         isConversationShared: bodyValidation.right.isConversationShared,
       });

--- a/front/pages/api/v1/w/[wId]/assistant/conversations/index.ts
+++ b/front/pages/api/v1/w/[wId]/assistant/conversations/index.ts
@@ -410,6 +410,7 @@ async function handler(
         newMessage = messageRes.value.userMessage;
       }
 
+      // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
       if (newContentFragment || newMessage) {
         // If we created a user message or a content fragment (or both) we retrieve the
         // conversation. If a user message was posted, we know that the agent messages have been

--- a/front/pages/api/v1/w/[wId]/assistant/generic_agents.ts
+++ b/front/pages/api/v1/w/[wId]/assistant/generic_agents.ts
@@ -35,6 +35,7 @@ function getAgentPictureUrl(
   emoji: string | undefined,
   backgroundColor: `bg-${string}`
 ): string {
+  // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
   const selectedEmoji = emoji || "🤖";
   const emojiData = buildSelectedEmojiType(selectedEmoji);
 

--- a/front/pages/api/v1/w/[wId]/spaces/[spaceId]/data_sources/[dsId]/documents/[documentId]/index.ts
+++ b/front/pages/api/v1/w/[wId]/spaces/[spaceId]/data_sources/[dsId]/documents/[documentId]/index.ts
@@ -441,8 +441,8 @@ async function handler(
               content: r.data.text,
               sections: [],
             }
-          // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
-          : r.data.section || null;
+          : // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
+            r.data.section || null;
 
       if (!section) {
         return apiError(req, res, {

--- a/front/pages/api/v1/w/[wId]/spaces/[spaceId]/data_sources/[dsId]/documents/[documentId]/index.ts
+++ b/front/pages/api/v1/w/[wId]/spaces/[spaceId]/data_sources/[dsId]/documents/[documentId]/index.ts
@@ -441,6 +441,7 @@ async function handler(
               content: r.data.text,
               sections: [],
             }
+          // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
           : r.data.section || null;
 
       if (!section) {
@@ -584,6 +585,7 @@ async function handler(
       const documentId = req.query.documentId as string;
       const mimeType = r.data.mime_type ?? "application/octet-stream";
 
+      // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
       const tags = r.data.tags || [];
       const titleInTags = tags
         .find((t) => t.startsWith("title:"))
@@ -591,6 +593,7 @@ async function handler(
         ?.trim();
 
       // Use titleInTags if no title is provided.
+      // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
       const title = r.data.title?.trim() || titleInTags || UNTITLED_TITLE;
 
       if (!titleInTags) {
@@ -611,11 +614,14 @@ async function handler(
             dataSourceId: dataSource.sId,
             documentId,
             tags,
+            // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
             parentId: r.data.parent_id || null,
+            // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
             parents: r.data.parents || [documentId],
             timestamp: cleanTimestamp(r.data.timestamp),
             sourceUrl,
             section,
+            // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
             upsertContext: r.data.upsert_context || null,
             title,
             mimeType,
@@ -650,8 +656,11 @@ async function handler(
           projectId: dataSource.dustAPIProjectId,
           dataSourceId: dataSource.dustAPIDataSourceId,
           documentId: req.query.documentId as string,
+          // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
           tags: (r.data.tags || []).map((tag) => safeSubstring(tag, 0)),
+          // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
           parentId: r.data.parent_id || null,
+          // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
           parents: r.data.parents || [documentId],
           sourceUrl,
           timestamp: cleanTimestamp(r.data.timestamp),
@@ -683,7 +692,9 @@ async function handler(
           dataSourceId: dataSource.sId,
           documentId: req.query.documentId as string,
           documentHash: upsertRes.value.document.hash,
+          // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
           dataSourceConnectorProvider: dataSource.connectorProvider || null,
+          // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
           upsertContext: r.data.upsert_context || undefined,
         });
         return;

--- a/front/pages/api/v1/w/[wId]/spaces/[spaceId]/data_sources/[dsId]/folders/[fId].ts
+++ b/front/pages/api/v1/w/[wId]/spaces/[spaceId]/data_sources/[dsId]/folders/[fId].ts
@@ -173,7 +173,9 @@ async function handler(
         dataSourceId: dataSource.dustAPIDataSourceId,
         folderId: fId,
         timestamp: timestamp || null,
+        // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
         parentId: parentId || null,
+        // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
         parents: parents || [fId],
         title: title.trim() || "Untitled Folder",
         mimeType: mime_type,

--- a/front/pages/api/v1/w/[wId]/spaces/[spaceId]/data_sources/[dsId]/tables/index.ts
+++ b/front/pages/api/v1/w/[wId]/spaces/[spaceId]/data_sources/[dsId]/tables/index.ts
@@ -323,8 +323,10 @@ async function handler(
         ?.substring(6)
         ?.trim();
       const title =
+        // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
         r.data.title?.trim() || titleInTags || name.trim() || UNTITLED_TITLE;
 
+      // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
       const tableId = maybeTableId || generateRandomModelSId();
 
       // Prohibit passing parents when not coming from connectors.
@@ -392,8 +394,10 @@ async function handler(
         name,
         description,
         timestamp: cleanTimestamp(timestamp),
+        // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
         tags: tags || [],
         // Table is a parent of itself by default.
+        // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
         parents: parents || [tableId],
         parentId: parentId ?? null,
         remoteDatabaseTableId: remoteDatabaseTableId ?? null,

--- a/front/pages/api/w/[wId]/assistant/agent_configurations/index.ts
+++ b/front/pages/api/w/[wId]/assistant/agent_configurations/index.ts
@@ -318,6 +318,7 @@ export async function createOrUpgradeAgentConfiguration({
         name: action.name,
         description: action.description ?? DEFAULT_MCP_ACTION_DESCRIPTION,
         mcpServerViewId: action.mcpServerViewId,
+        // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
         dataSources: action.dataSources || null,
         reasoningModel: action.reasoningModel,
         tables: action.tables,

--- a/front/pages/api/w/[wId]/assistant/agent_configurations/new/yaml.ts
+++ b/front/pages/api/w/[wId]/assistant/agent_configurations/new/yaml.ts
@@ -111,6 +111,7 @@ async function handler(
     name: yamlConfig.agent.handle,
     description: yamlConfig.agent.description,
     instructions: yamlConfig.instructions,
+    // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
     pictureUrl: yamlConfig.agent.avatar_url || "",
     status: "active" as const,
     scope: yamlConfig.agent.scope,
@@ -120,6 +121,7 @@ async function handler(
       temperature: yamlConfig.generation_settings.temperature,
       reasoningEffort: yamlConfig.generation_settings.reasoning_effort,
       responseFormat:
+        // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
         yamlConfig.generation_settings.response_format || undefined,
     },
     maxStepsPerRun: yamlConfig.agent.max_steps_per_run,

--- a/front/pages/api/w/[wId]/assistant/conversations/[cId]/events.ts
+++ b/front/pages/api/w/[wId]/assistant/conversations/[cId]/events.ts
@@ -35,6 +35,7 @@ async function handler(
 
   const conversation = conversationRes.value;
 
+  // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
   const lastEventId = req.query.lastEventId || null;
   if (lastEventId && typeof lastEventId !== "string") {
     return apiError(req, res, {

--- a/front/pages/api/w/[wId]/assistant/conversations/[cId]/messages/[mId]/events.ts
+++ b/front/pages/api/w/[wId]/assistant/conversations/[cId]/messages/[mId]/events.ts
@@ -72,6 +72,7 @@ async function handler(
     });
   }
 
+  // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
   const lastEventId = req.query.lastEventId || null;
   if (lastEventId && typeof lastEventId !== "string") {
     return apiError(req, res, {

--- a/front/pages/api/w/[wId]/assistant/conversations/[cId]/messages/[mId]/feedbacks/index.ts
+++ b/front/pages/api/w/[wId]/assistant/conversations/[cId]/messages/[mId]/feedbacks/index.ts
@@ -87,6 +87,7 @@ async function handler(
         user: user.toJSON(),
         thumbDirection: bodyValidation.right
           .thumbDirection as AgentMessageFeedbackDirection,
+        // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
         content: bodyValidation.right.feedbackContent || "",
         isConversationShared: bodyValidation.right.isConversationShared,
       });

--- a/front/pages/api/w/[wId]/index.ts
+++ b/front/pages/api/w/[wId]/index.ts
@@ -147,6 +147,7 @@ async function handler(
         });
         owner.workOSOrganizationId = body.workOSOrganizationId;
       } else if ("allowContentCreationFileSharing" in body) {
+        // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
         const previousMetadata = owner.metadata || {};
         const newMetadata = {
           ...previousMetadata,

--- a/front/pages/api/w/[wId]/mcp/index.ts
+++ b/front/pages/api/w/[wId]/mcp/index.ts
@@ -132,6 +132,7 @@ async function handler(
         }
 
         // Default to the shared secret if it exists.
+        // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
         let bearerToken = sharedSecret || null;
         let authorization: AuthorizationInfo | null = null;
 
@@ -185,20 +186,24 @@ async function handler(
           (config) => config.url === url
         );
 
+        // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
         const name = defaultConfig?.name || metadata.name;
 
         const newRemoteMCPServer = await RemoteMCPServerResource.makeNew(auth, {
           workspaceId: auth.getNonNullableWorkspace().id,
           url: url,
           cachedName: name,
+          // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
           cachedDescription: defaultConfig?.description || metadata.description,
           cachedTools: metadata.tools,
           icon:
+            // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
             defaultConfig?.icon ||
             (isCustomServerIconType(metadata.icon)
               ? metadata.icon
               : DEFAULT_MCP_SERVER_ICON),
           version: metadata.version,
+          // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
           sharedSecret: sharedSecret || null,
           authorization,
           oAuthUseCase: body.useCase ?? null,

--- a/front/pages/api/w/[wId]/me/approvals.ts
+++ b/front/pages/api/w/[wId]/me/approvals.ts
@@ -56,12 +56,14 @@ async function handler(
             auth,
             validation.mcpServerId
           );
+          // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
           serverName = server?.toJSON().name || "Unknown Internal Server";
         } else if (serverType === "remote") {
           const server = await RemoteMCPServerResource.fetchById(
             auth,
             validation.mcpServerId
           );
+          // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
           serverName = server?.toJSON().name || "Unknown Remote Server";
         }
       } catch (error) {

--- a/front/pages/api/w/[wId]/spaces/[spaceId]/data_source_views/index.ts
+++ b/front/pages/api/w/[wId]/spaces/[spaceId]/data_source_views/index.ts
@@ -117,6 +117,7 @@ async function handler(
                     fetchConnectorError: false,
                     fetchConnectorErrorMessage: null,
                   },
+                  // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
                   usage: usages[dataSourceView.id] || {
                     count: 0,
                     agents: [],
@@ -129,6 +130,7 @@ async function handler(
               return {
                 ...dataSourceView,
                 dataSource: augmentedDataSource,
+                // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
                 usage: usages[dataSourceView.id] || {
                   count: 0,
                   agents: [],

--- a/front/pages/api/w/[wId]/spaces/index.ts
+++ b/front/pages/api/w/[wId]/spaces/index.ts
@@ -30,6 +30,7 @@ async function handler(
       const { role, kind } = req.query;
 
       if (
+        // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
         (role && typeof role !== "string") ||
         (kind && typeof kind !== "string")
       ) {

--- a/front/pages/api/workos/[action].ts
+++ b/front/pages/api/workos/[action].ts
@@ -303,6 +303,7 @@ async function handleCallback(req: NextApiRequest, res: NextApiResponse) {
 }
 
 async function handleLogout(req: NextApiRequest, res: NextApiResponse) {
+  // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
   const returnTo = req.query.returnTo || config.getClientFacingUrl();
 
   const session = await getSession(req, res);

--- a/front/pages/api/workos/actions/[actionSecret].ts
+++ b/front/pages/api/workos/actions/[actionSecret].ts
@@ -62,6 +62,7 @@ async function handler(
 
   // Validate the client IP address.
   const clientIp =
+    // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
     getClientIpFromHeaders(req.headers) || req.socket.remoteAddress;
   if (!isString(clientIp)) {
     return apiError(req, res, {

--- a/front/pages/api/workos/webhooks/[webhookSecret].ts
+++ b/front/pages/api/workos/webhooks/[webhookSecret].ts
@@ -49,6 +49,7 @@ async function handler(
 
   // Validate the client IP address.
   const clientIp =
+    // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
     getClientIpFromHeaders(req.headers) || req.socket.remoteAddress;
   if (typeof clientIp !== "string") {
     return apiError(req, res, {

--- a/front/pages/login-error.tsx
+++ b/front/pages/login-error.tsx
@@ -36,6 +36,7 @@ function getErrorMessage(domain: string | null, reason: string | null) {
     />
   );
 
+  // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
   if (domain || reason === "invalid_domain") {
     return (
       <>

--- a/front/pages/poke/[wId]/data_sources/[dsId]/index.tsx
+++ b/front/pages/poke/[wId]/data_sources/[dsId]/index.tsx
@@ -856,8 +856,10 @@ function NotionUrlCheckOrFind({
                 }
                 return "Not found";
               })()}
+              // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
               color={urlDetails.page || urlDetails.db ? "success" : "warning"}
             />
+            {/* eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing */}
             {(urlDetails.page || urlDetails.db) && (
               <div>
                 <span>

--- a/front/pages/poke/[wId]/data_sources/[dsId]/view.tsx
+++ b/front/pages/poke/[wId]/data_sources/[dsId]/view.tsx
@@ -88,6 +88,7 @@ export default function DataSourceDocumentView({
                 placeholder=""
                 name="document"
                 disabled={true}
+                // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
                 value={document.source_url || ""}
               />
             </div>
@@ -107,6 +108,7 @@ export default function DataSourceDocumentView({
                   "focus:border-gray-300 focus:ring-0"
                 )}
                 disabled={true}
+                // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
                 value={document.text || ""}
               />
             </div>

--- a/front/pages/poke/plans.tsx
+++ b/front/pages/poke/plans.tsx
@@ -77,6 +77,7 @@ const PlansPage = () => {
       (plan) => plan.code.trim() === editingPlan.code.trim()
     );
     if (
+      // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
       (editingPlan.isNewPlan && plansWithSameCode.length > 0) ||
       (!editingPlan.isNewPlan && plansWithSameCode.length > 1)
     ) {
@@ -201,6 +202,7 @@ const PlansPage = () => {
               label="Create a new plan"
               variant="outline"
               onClick={() => createNewPlan()}
+              // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
               disabled={editingPlan?.isNewPlan || !!editingPlan}
             />
           </div>

--- a/front/pages/w/[wId]/builder/agents/index.tsx
+++ b/front/pages/w/[wId]/builder/agents/index.tsx
@@ -304,6 +304,7 @@ export default function WorkspaceAssistants({
         <AssistantDetails
           owner={owner}
           user={user}
+          // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
           assistantId={showDetails?.sId || null}
           onClose={() => setShowDetails(null)}
         />

--- a/front/pages/w/[wId]/labs/mcp_actions/[agentId]/index.tsx
+++ b/front/pages/w/[wId]/labs/mcp_actions/[agentId]/index.tsx
@@ -221,6 +221,7 @@ export default function AgentMCPActions({
                       {actions.map((action) => (
                         <ContextItem
                           key={action.sId}
+                          // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
                           title={action.functionCallName || "Unknown Action"}
                           visual={<Icon visual={ActionCodeBoxIcon} />}
                           action={

--- a/front/pages/w/[wId]/labs/transcripts/index.tsx
+++ b/front/pages/w/[wId]/labs/transcripts/index.tsx
@@ -162,6 +162,7 @@ export default function LabsTranscriptsIndex({
           onClose={() => setIsDeleteProviderDialogOpened(false)}
           onConfirm={async () => {
             await handleDisconnectProvider(
+              // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
               transcriptsConfiguration?.sId || null
             );
           }}

--- a/front/pages/w/[wId]/spaces/[spaceId]/apps/[aId]/datasets/[name]/index.tsx
+++ b/front/pages/w/[wId]/spaces/[spaceId]/apps/[aId]/datasets/[name]/index.tsx
@@ -130,6 +130,7 @@ export default function ViewDatasetView({
       (currentDatasetInEditor.data !== dataset.data ||
         currentDatasetInEditor.name !== dataset.name ||
         (currentDatasetInEditor.description !== dataset.description &&
+          // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
           (currentDatasetInEditor.description || dataset.description)))
     ) {
       setEditorDirty(true);

--- a/front/pages/w/[wId]/spaces/[spaceId]/apps/[aId]/index.tsx
+++ b/front/pages/w/[wId]/spaces/[spaceId]/apps/[aId]/index.tsx
@@ -158,10 +158,12 @@ export default function AppView({
   const { mutate } = useSWRConfig();
 
   const [spec, setSpec] = useState(
+    // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
     JSON.parse(app.savedSpecification || `[]`) as SpecificationType
   );
 
   const [config, setConfig] = useState(
+    // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
     extractConfig(JSON.parse(app.savedSpecification || `{}`))
   );
   const [runnable, setRunnable] = useState(isRunnable(readOnly, spec, config));
@@ -228,6 +230,7 @@ export default function AppView({
     idx: number | null,
     blockType: BlockType | "map_reduce" | "while_end"
   ) => {
+    // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
     const s = addBlock(spec, idx === null ? spec.length - 1 : idx, blockType);
     await update(s);
     if (idx === null) {

--- a/front/pages/w/[wId]/spaces/[spaceId]/apps/[aId]/settings.tsx
+++ b/front/pages/w/[wId]/spaces/[spaceId]/apps/[aId]/settings.tsx
@@ -73,6 +73,7 @@ export default function SettingsView({
   const [appName, setAppName] = useState(app.name);
   const [appNameError, setAppNameError] = useState<boolean>(false);
 
+  // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
   const [appDescription, setAppDescription] = useState(app.description || "");
 
   const [isDeleting, setIsDeleting] = useState(false);

--- a/front/pages/w/[wId]/spaces/[spaceId]/apps/[aId]/specification.tsx
+++ b/front/pages/w/[wId]/spaces/[spaceId]/apps/[aId]/specification.tsx
@@ -78,6 +78,7 @@ export const getServerSideProps = withDefaultUserAuthRequirements<{
   }
 
   const spec = dumpSpecification(
+    // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
     JSON.parse(app.savedSpecification || "[]"),
     latestDatasets
   );

--- a/front/pages/w/[wId]/welcome.tsx
+++ b/front/pages/w/[wId]/welcome.tsx
@@ -65,6 +65,7 @@ export default function Welcome({
 }: InferGetServerSidePropsType<typeof getServerSideProps>) {
   const router = useRouter();
   const [firstName, setFirstName] = useState<string>(user.firstName);
+  // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
   const [lastName, setLastName] = useState<string>(user.lastName || "");
   const [jobType, setJobType] = useState<JobType | undefined>(undefined);
   const [isFormValid, setIsFormValid] = useState<boolean>(false);
@@ -86,11 +87,13 @@ export default function Welcome({
 
     // GTM signup event tracking: only fire after successful submit
     if (typeof window !== "undefined") {
+      // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
       window.dataLayer = window.dataLayer || [];
       window.dataLayer.push({
         event: "signup_completed",
         user_email: user.email,
         company_name: owner.name,
+        // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
         gclid: sessionStorage.getItem("gclid") || null,
       });
     }
@@ -161,6 +164,7 @@ export default function Welcome({
                   variant="outline"
                   className="justify-between text-muted-foreground"
                   label={
+                    // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
                     jobTypes.find((t) => t.value === jobType)?.label ||
                     "Select job type"
                   }
@@ -169,6 +173,7 @@ export default function Welcome({
               </DropdownMenuTrigger>
               <DropdownMenuContent className="w-[var(--radix-dropdown-menu-trigger-width)]">
                 <DropdownMenuRadioGroup
+                  // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
                   value={jobType || ""}
                   onValueChange={(value) => {
                     if (isJobType(value)) {


### PR DESCRIPTION
## Description

This PR follows the [slack discussion](https://dust4ai.slack.com/archives/C050SM8NSPK/p1757589628797709) about tightening eslint config. It adds the rule [prefer-nullish-coallescing](https://typescript-eslint.io/rules/prefer-nullish-coalescing/) and ignore the current errors

The rule has been added in front folder first, and ignored in the following directories checked by next lint in CI:
- components
- lib
- pages

## Tests



## Risk

low

## Deploy Plan

front
