### PR TITLE
Add ability to attach conversation files to jira issue

### DIFF
--- a/front/lib/actions/mcp_internal_actions/constants.ts
+++ b/front/lib/actions/mcp_internal_actions/constants.ts
@@ -726,6 +726,7 @@ The directive should be used to display a clickable version of the agent name in
       get_connection_info: "never_ask",
       get_issue_link_types: "never_ask",
       get_users: "never_ask",
+      get_attachments: "never_ask",
 
       // Update operations - low stakes
       create_comment: "low",
@@ -734,6 +735,7 @@ The directive should be used to display a clickable version of the agent name in
       update_issue: "low",
       create_issue_link: "low",
       delete_issue_link: "low",
+      upload_attachment: "low",
     },
     tools_retry_policies: undefined,
     timeoutMs: undefined,

--- a/front/lib/actions/mcp_internal_actions/servers/index.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/index.ts
@@ -150,7 +150,7 @@ export async function getInternalMCPServer(
     case "conversation_files":
       return conversationFilesServer(auth, agentLoopContext);
     case "jira":
-      return jiraServer();
+      return jiraServer(auth, agentLoopContext);
     case "monday":
       return mondayServer();
     case "slack":

--- a/front/lib/actions/mcp_internal_actions/servers/jira/jira_api_helper.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/jira/jira_api_helper.ts
@@ -48,6 +48,8 @@ import logger from "@app/logger/logger";
 import type { Result } from "@app/types";
 import { Err, normalizeError, Ok } from "@app/types";
 
+import { sanitizeFilename } from "../../utils/file_utils";
+
 // Type guard to check if a value is an ADFDocument
 function isADFDocument(value: unknown): value is ADFDocument {
   return ADFDocumentSchema.safeParse(value).success;
@@ -1091,10 +1093,11 @@ export async function uploadAttachmentsToJira(
     const parts: Buffer[] = [];
 
     for (const file of files) {
+      const safeFilename = sanitizeFilename(file.filename);
       parts.push(Buffer.from(`--${boundary}\r\n`));
       parts.push(
         Buffer.from(
-          `Content-Disposition: form-data; name="file"; filename="${file.filename}"\r\n`
+          `Content-Disposition: form-data; name="file"; filename="${safeFilename}"\r\n`
         )
       );
       parts.push(Buffer.from(`Content-Type: ${file.contentType}\r\n\r\n`));

--- a/front/lib/actions/mcp_internal_actions/servers/jira/jira_api_helper.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/jira/jira_api_helper.ts
@@ -23,12 +23,14 @@ import type {
 } from "@app/lib/actions/mcp_internal_actions/servers/jira/types";
 import {
   ADFDocumentSchema,
+  JiraAttachmentsResultSchema,
   JiraCommentSchema,
   JiraCreateMetaSchema,
   JiraFieldsSchema,
   JiraIssueLinkTypeSchema,
   JiraIssueSchema,
   JiraIssueTypeSchema,
+  JiraIssueWithAttachmentsSchema,
   JiraProjectSchema,
   JiraProjectVersionSchema,
   JiraResourceSchema,
@@ -1059,4 +1061,126 @@ function logAndReturnError({
     `[JIRA MCP Server] ${message}`
   );
   return makeMCPToolTextError(normalizeError(error).message);
+}
+
+function logAndReturnApiError<T>({
+  error,
+  message,
+}: {
+  error: unknown;
+  message: string;
+}): Result<T, string> {
+  logger.error(`[JIRA MCP Server] ${message}`);
+  return new Err(normalizeError(error).message);
+}
+
+export async function uploadAttachmentsToJira(
+  baseUrl: string,
+  accessToken: string,
+  issueKey: string,
+  files: Array<{
+    buffer: Buffer;
+    filename: string;
+    contentType: string;
+  }>
+): Promise<
+  Result<z.infer<typeof JiraAttachmentsResultSchema>, JiraErrorResult>
+> {
+  try {
+    const boundary = `----formdata-dust-${Date.now()}-${Math.random().toString(36)}`;
+    const parts: Buffer[] = [];
+
+    for (const file of files) {
+      parts.push(Buffer.from(`--${boundary}\r\n`));
+      parts.push(
+        Buffer.from(
+          `Content-Disposition: form-data; name="file"; filename="${file.filename}"\r\n`
+        )
+      );
+      parts.push(Buffer.from(`Content-Type: ${file.contentType}\r\n\r\n`));
+      parts.push(file.buffer);
+      parts.push(Buffer.from("\r\n"));
+    }
+
+    parts.push(Buffer.from(`--${boundary}--\r\n`));
+
+    const body = Buffer.concat(parts);
+
+    const response = await fetch(
+      `${baseUrl}/rest/api/2/issue/${issueKey}/attachments`,
+      {
+        method: "POST",
+        body,
+        headers: {
+          Authorization: `Bearer ${accessToken}`,
+          Accept: "application/json",
+          "X-Atlassian-Token": "no-check", // Required to prevent CSRF blocking
+          "Content-Type": `multipart/form-data; boundary=${boundary}`,
+        },
+      }
+    );
+
+    if (!response.ok) {
+      const errorBody = await response.text();
+      const msg = `JIRA API error: ${response.status} ${response.statusText} - ${errorBody}`;
+      return logAndReturnApiError({
+        error: new Error(msg),
+        message: "JIRA attachment upload failed",
+      });
+    }
+
+    const responseText = await response.text();
+    if (!responseText) {
+      return logAndReturnApiError({
+        error: new Error("Empty response from JIRA attachment upload"),
+        message: "JIRA attachment upload returned empty response",
+      });
+    }
+
+    const rawData = JSON.parse(responseText);
+    const parseResult = JiraAttachmentsResultSchema.safeParse(rawData);
+
+    if (!parseResult.success) {
+      const msg = `Invalid JIRA response format: ${parseResult.error.message}`;
+      return logAndReturnApiError({
+        error: new Error(msg),
+        message: "JIRA attachment upload response format invalid",
+      });
+    }
+
+    return new Ok(parseResult.data);
+  } catch (error: unknown) {
+    return logAndReturnApiError({
+      error,
+      message: "JIRA API call failed for attachment upload",
+    });
+  }
+}
+
+export async function getIssueAttachments({
+  baseUrl,
+  accessToken,
+  issueKey,
+}: {
+  baseUrl: string;
+  accessToken: string;
+  issueKey: string;
+}): Promise<
+  Result<z.infer<typeof JiraAttachmentsResultSchema>, JiraErrorResult>
+> {
+  const result = await jiraApiCall(
+    {
+      endpoint: `/rest/api/2/issue/${issueKey}?fields=attachment`,
+      accessToken,
+    },
+    JiraIssueWithAttachmentsSchema,
+    { baseUrl }
+  );
+
+  if (result.isErr()) {
+    return result;
+  }
+
+  const attachments = result.value.fields?.attachment || [];
+  return new Ok(attachments);
 }

--- a/front/lib/actions/mcp_internal_actions/servers/jira/server.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/jira/server.ts
@@ -8,6 +8,7 @@ import {
   deleteIssueLink,
   getConnectionInfo,
   getIssue,
+  getIssueAttachments,
   getIssueFields,
   getIssueLinkTypes,
   getIssueTypes,
@@ -22,6 +23,7 @@ import {
   searchUsersByEmailExact,
   transitionIssue,
   updateIssue,
+  uploadAttachmentsToJira,
   withAuth,
 } from "@app/lib/actions/mcp_internal_actions/servers/jira/jira_api_helper";
 import {
@@ -37,8 +39,15 @@ import {
   makeMCPToolJSONSuccess,
   makeMCPToolTextError,
 } from "@app/lib/actions/mcp_internal_actions/utils";
+import { getFileFromConversationAttachment } from "@app/lib/actions/mcp_internal_actions/utils/file_utils";
+import type { AgentLoopContextType } from "@app/lib/actions/types";
+import type { Authenticator } from "@app/lib/auth";
+import { normalizeError } from "@app/types";
 
-const createServer = (): McpServer => {
+const createServer = (
+  auth?: Authenticator,
+  agentLoopContext?: AgentLoopContextType
+): McpServer => {
   const server = makeInternalMCPServer("jira");
 
   server.tool(
@@ -762,6 +771,178 @@ const createServer = (): McpServer => {
             result: {
               users: result.value.users,
               nextStartAt: result.value.nextStartAt,
+            },
+          });
+        },
+        authInfo,
+      });
+    }
+  );
+
+  server.tool(
+    "upload_attachment",
+    "Upload a file attachment to a Jira issue. Supports two types of file sources: conversation files (from current Dust conversation) and external files (base64 encoded). The attachment must specify its type and corresponding fields. IMPORTANT: The 'type' field must be exactly 'conversation_file' or 'external_file', not a MIME type like 'image/png'.",
+    {
+      issueKey: z.string().describe("The Jira issue key (e.g., 'PROJ-123')"),
+      attachment: z.union([
+        z.object({
+          type: z
+            .literal("conversation_file")
+            .describe("Use this for files already in the Dust conversation"),
+          fileId: z
+            .string()
+            .describe(
+              "The fileId from conversation attachments (use conversation_list_files to get available files)"
+            ),
+        }),
+        z.object({
+          type: z
+            .literal("external_file")
+            .describe("Use this for new files provided as base64 data"),
+          filename: z
+            .string()
+            .describe(
+              "The filename for the attachment (e.g., 'document.pdf', 'image.png')"
+            ),
+          contentType: z
+            .string()
+            .describe(
+              "MIME type of the file (e.g., 'image/png', 'application/pdf', 'text/plain')"
+            ),
+          base64Data: z.string().describe("Base64 encoded file data"),
+        }),
+      ]),
+    },
+    async ({ issueKey, attachment }, { authInfo }) => {
+      return withAuth({
+        action: async (baseUrl, accessToken) => {
+          try {
+            let fileToUpload: {
+              buffer: Buffer;
+              filename: string;
+              contentType: string;
+            };
+
+            if (attachment.type === "conversation_file") {
+              if (!auth || !agentLoopContext) {
+                return makeMCPToolTextError(
+                  "Authentication and conversation context required for conversation file attachments"
+                );
+              }
+
+              const fileResult = await getFileFromConversationAttachment(
+                auth,
+                attachment.fileId,
+                agentLoopContext
+              );
+
+              if (fileResult.isErr()) {
+                return makeMCPToolTextError(
+                  `Failed to get conversation file ${attachment.fileId}: ${fileResult.error}`
+                );
+              }
+
+              fileToUpload = fileResult.value;
+            } else if (attachment.type === "external_file") {
+              try {
+                const buffer = Buffer.from(attachment.base64Data, "base64");
+                fileToUpload = {
+                  buffer,
+                  filename: attachment.filename,
+                  contentType: attachment.contentType,
+                };
+              } catch (error) {
+                return makeMCPToolTextError(
+                  `Failed to decode base64 data for ${attachment.filename}: ${normalizeError(error).message}`
+                );
+              }
+            } else {
+              return makeMCPToolTextError("Invalid attachment type");
+            }
+
+            const uploadResult = await uploadAttachmentsToJira(
+              baseUrl,
+              accessToken,
+              issueKey,
+              [fileToUpload]
+            );
+
+            if (uploadResult.isErr()) {
+              return makeMCPToolTextError(
+                `Failed to upload attachment: ${uploadResult.error}`
+              );
+            }
+
+            const uploadedAttachment = uploadResult.value[0];
+
+            return makeMCPToolJSONSuccess({
+              message: `Successfully uploaded attachment to issue ${issueKey}`,
+              result: {
+                issueKey,
+                attachment: {
+                  id: uploadedAttachment.id,
+                  filename: uploadedAttachment.filename,
+                  size: uploadedAttachment.size,
+                  mimeType: uploadedAttachment.mimeType,
+                  created: uploadedAttachment.created,
+                  author:
+                    uploadedAttachment.author.displayName ||
+                    uploadedAttachment.author.accountId,
+                },
+              },
+            });
+          } catch (error: unknown) {
+            return makeMCPToolTextError(
+              `Error uploading attachment: ${normalizeError(error).message}`
+            );
+          }
+        },
+        authInfo,
+      });
+    }
+  );
+
+  server.tool(
+    "get_attachments",
+    "Retrieve all attachments for a Jira issue, including metadata like filename, size, MIME type, and download URLs.",
+    {
+      issueKey: z.string().describe("The Jira issue key (e.g., 'PROJ-123')"),
+    },
+    async ({ issueKey }, { authInfo }) => {
+      return withAuth({
+        action: async (baseUrl, accessToken) => {
+          const attachmentsResult = await getIssueAttachments({
+            baseUrl,
+            accessToken,
+            issueKey,
+          });
+
+          if (attachmentsResult.isErr()) {
+            return makeMCPToolTextError(attachmentsResult.error);
+          }
+
+          const attachments = attachmentsResult.value;
+          const attachmentSummary = attachments.map((att) => ({
+            id: att.id,
+            filename: att.filename,
+            size: att.size,
+            mimeType: att.mimeType,
+            created: att.created,
+            author: att.author?.displayName || att.author?.accountId,
+            content: att.content,
+            thumbnail: att.thumbnail,
+          }));
+
+          return makeMCPToolJSONSuccess({
+            message: `Found ${attachments.length} attachment(s) for issue ${issueKey}`,
+            result: {
+              issueKey,
+              attachments: attachmentSummary,
+              totalAttachments: attachments.length,
+              totalSize: attachments.reduce(
+                (sum, att) => sum + (att.size || 0),
+                0
+              ),
             },
           });
         },

--- a/front/lib/actions/mcp_internal_actions/servers/jira/types.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/jira/types.ts
@@ -493,6 +493,31 @@ export const JiraCommentSchema = z.object({
   body: ADFDocumentSchema,
 });
 
+export const JiraAttachmentSchema = z.object({
+  id: z.string(),
+  filename: z.string(),
+  author: z.object({
+    accountId: z.string(),
+    displayName: z.string().optional(),
+    emailAddress: z.string().optional(),
+  }),
+  created: z.string(),
+  size: z.number(),
+  mimeType: z.string(),
+  content: z.string().optional(),
+  thumbnail: z.string().optional(),
+  self: z.string(),
+});
+export const JiraAttachmentsResultSchema = z.array(JiraAttachmentSchema);
+
+export const JiraIssueWithAttachmentsSchema = z.object({
+  id: z.string(),
+  key: z.string(),
+  fields: z.object({
+    attachment: z.array(JiraAttachmentSchema).optional(),
+  }),
+});
+
 // Inferred types
 export type JiraSearchResult = z.infer<typeof JiraSearchResultSchema>;
 export type JiraErrorResult = string;
@@ -512,4 +537,9 @@ export type JiraIssueLink = z.infer<typeof JiraIssueLinkSchema>;
 export type JiraIssueLinkType = z.infer<typeof JiraIssueLinkTypeSchema>;
 export type JiraCreateIssueLinkRequest = z.infer<
   typeof JiraCreateIssueLinkRequestSchema
+>;
+export type JiraAttachment = z.infer<typeof JiraAttachmentSchema>;
+export type JiraAttachmentsResult = z.infer<typeof JiraAttachmentsResultSchema>;
+export type JiraIssueWithAttachments = z.infer<
+  typeof JiraIssueWithAttachmentsSchema
 >;

--- a/front/lib/actions/mcp_internal_actions/utils/file_utils.ts
+++ b/front/lib/actions/mcp_internal_actions/utils/file_utils.ts
@@ -18,6 +18,15 @@ import {
   normalizeError,
 } from "@app/types";
 
+export function sanitizeFilename(filename: string): string {
+  return filename
+    .replace(/\.\./g, "")
+    .replace(/[/\\]/g, "_")
+    .replace(/[\r\n]/g, "")
+    .replace(/[^\w\-._]/g, "_")
+    .substring(0, 255);
+}
+
 /**
  * Get file data from a conversation attachment, including images
  * This is a more comprehensive version than listAttachments() which excludes images
@@ -36,87 +45,86 @@ export async function getFileFromConversationAttachment(
     string
   >
 > {
-  try {
-    if (!agentLoopContext?.runContext) {
-      return new Err("No conversation context available");
-    }
+  if (!agentLoopContext?.runContext) {
+    return new Err("No conversation context available");
+  }
 
-    const conversation = agentLoopContext.runContext.conversation;
-    let attachment: ConversationAttachmentType | null = null;
+  const conversation = agentLoopContext.runContext.conversation;
+  let attachment: ConversationAttachmentType | null = null;
 
-    for (const versions of conversation.content) {
-      const m = versions[versions.length - 1];
+  for (const versions of conversation.content) {
+    const m = versions[versions.length - 1];
 
-      if (isContentFragmentType(m)) {
-        if (m.contentFragmentVersion === "latest") {
-          const candidateAttachment = getAttachmentFromContentFragment(m);
-          if (
-            candidateAttachment &&
-            conversationAttachmentId(candidateAttachment) === fileId
-          ) {
-            attachment = candidateAttachment;
-            break;
-          }
-        }
-      } else if (isAgentMessageType(m)) {
-        const generatedFiles = m.actions.flatMap((a) => a.getGeneratedFiles());
-
-        for (const f of generatedFiles) {
-          if (isContentCreationFileContentType(f.contentType)) {
-            continue;
-          }
-
-          if (f.fileId === fileId) {
-            attachment = getAttachmentFromToolOutput({
-              fileId: f.fileId,
-              contentType: f.contentType,
-              title: f.title,
-              snippet: f.snippet,
-            });
-            break;
-          }
-        }
-        if (attachment) {
+    if (isContentFragmentType(m)) {
+      if (m.contentFragmentVersion === "latest") {
+        const candidateAttachment = getAttachmentFromContentFragment(m);
+        if (
+          candidateAttachment &&
+          conversationAttachmentId(candidateAttachment) === fileId
+        ) {
+          attachment = candidateAttachment;
           break;
         }
       }
-    }
+    } else if (isAgentMessageType(m)) {
+      const generatedFiles = m.actions.flatMap((a) => a.getGeneratedFiles());
 
-    if (!attachment) {
-      return new Err(
-        `Attachment with fileId ${fileId} not found in conversation`
-      );
-    }
+      for (const f of generatedFiles) {
+        if (isContentCreationFileContentType(f.contentType)) {
+          continue;
+        }
 
-    if (!isFileAttachmentType(attachment)) {
-      return new Err(`Attachment ${fileId} is not a file attachment`);
+        if (f.fileId === fileId) {
+          attachment = getAttachmentFromToolOutput({
+            fileId: f.fileId,
+            contentType: f.contentType,
+            title: f.title,
+            snippet: f.snippet,
+          });
+          break;
+        }
+      }
+      if (attachment) {
+        break;
+      }
     }
+  }
 
-    const fileResource = await FileResource.fetchById(auth, attachment.fileId);
-    if (!fileResource) {
-      return new Err(`File resource not found for fileId ${fileId}`);
-    }
-    const readStream = fileResource.getReadStream({
-      auth,
-      version: "original",
-    });
-    const buffer = await streamToBuffer(readStream);
-
-    return new Ok({
-      buffer,
-      filename: attachment.title || `attachment-${fileId}`,
-      contentType: attachment.contentType || "application/octet-stream",
-    });
-  } catch (error) {
+  if (!attachment) {
     return new Err(
-      `Failed to get file from conversation: ${normalizeError(error).message}`
+      `Attachment with fileId ${fileId} not found in conversation`
     );
   }
+
+  if (!isFileAttachmentType(attachment)) {
+    return new Err(`Attachment ${fileId} is not a file attachment`);
+  }
+
+  const fileResource = await FileResource.fetchById(auth, attachment.fileId);
+  if (!fileResource) {
+    return new Err(`File resource not found for fileId ${fileId}`);
+  }
+
+  const readStream = fileResource.getReadStream({
+    auth,
+    version: "original",
+  });
+
+  const bufferResult = await streamToBuffer(readStream);
+  if (bufferResult.isErr()) {
+    return new Err(bufferResult.error);
+  }
+
+  return new Ok({
+    buffer: bufferResult.value,
+    filename: sanitizeFilename(attachment.title || `attachment-${fileId}`),
+    contentType: attachment.contentType || "application/octet-stream",
+  });
 }
 
 export async function streamToBuffer(
   readStream: NodeJS.ReadableStream
-): Promise<Buffer> {
+): Promise<Result<Buffer, string>> {
   try {
     const chunks: Buffer[] = [];
     for await (const chunk of readStream) {
@@ -126,9 +134,9 @@ export async function streamToBuffer(
         chunks.push(Buffer.from(chunk as string));
       }
     }
-    return Buffer.concat(chunks);
+    return new Ok(Buffer.concat(chunks));
   } catch (error) {
-    throw new Error(
+    return new Err(
       `Failed to read file stream: ${normalizeError(error).message}`
     );
   }

--- a/front/lib/actions/mcp_internal_actions/utils/file_utils.ts
+++ b/front/lib/actions/mcp_internal_actions/utils/file_utils.ts
@@ -1,0 +1,135 @@
+import type { Result } from "@dust-tt/client";
+import { Err, Ok } from "@dust-tt/client";
+
+import type { AgentLoopContextType } from "@app/lib/actions/types";
+import type { ConversationAttachmentType } from "@app/lib/api/assistant/conversation/attachments";
+import {
+  conversationAttachmentId,
+  getAttachmentFromContentFragment,
+  getAttachmentFromToolOutput,
+  isFileAttachmentType,
+} from "@app/lib/api/assistant/conversation/attachments";
+import type { Authenticator } from "@app/lib/auth";
+import { FileResource } from "@app/lib/resources/file_resource";
+import {
+  isAgentMessageType,
+  isContentCreationFileContentType,
+  isContentFragmentType,
+  normalizeError,
+} from "@app/types";
+
+/**
+ * Get file data from a conversation attachment, including images
+ * This is a more comprehensive version than listAttachments() which excludes images
+ */
+export async function getFileFromConversationAttachment(
+  auth: Authenticator,
+  fileId: string,
+  agentLoopContext: AgentLoopContextType
+): Promise<
+  Result<
+    {
+      buffer: Buffer;
+      filename: string;
+      contentType: string;
+    },
+    string
+  >
+> {
+  try {
+    if (!agentLoopContext?.runContext) {
+      return new Err("No conversation context available");
+    }
+
+    const conversation = agentLoopContext.runContext.conversation;
+    let attachment: ConversationAttachmentType | null = null;
+
+    for (const versions of conversation.content) {
+      const m = versions[versions.length - 1];
+
+      if (isContentFragmentType(m)) {
+        if (m.contentFragmentVersion === "latest") {
+          const candidateAttachment = getAttachmentFromContentFragment(m);
+          if (
+            candidateAttachment &&
+            conversationAttachmentId(candidateAttachment) === fileId
+          ) {
+            attachment = candidateAttachment;
+            break;
+          }
+        }
+      } else if (isAgentMessageType(m)) {
+        const generatedFiles = m.actions.flatMap((a) => a.getGeneratedFiles());
+
+        for (const f of generatedFiles) {
+          if (isContentCreationFileContentType(f.contentType)) {
+            continue;
+          }
+
+          if (f.fileId === fileId) {
+            attachment = getAttachmentFromToolOutput({
+              fileId: f.fileId,
+              contentType: f.contentType,
+              title: f.title,
+              snippet: f.snippet,
+            });
+            break;
+          }
+        }
+        if (attachment) {
+          break;
+        }
+      }
+    }
+
+    if (!attachment) {
+      return new Err(
+        `Attachment with fileId ${fileId} not found in conversation`
+      );
+    }
+
+    if (!isFileAttachmentType(attachment)) {
+      return new Err(`Attachment ${fileId} is not a file attachment`);
+    }
+
+    const fileResource = await FileResource.fetchById(auth, attachment.fileId);
+    if (!fileResource) {
+      return new Err(`File resource not found for fileId ${fileId}`);
+    }
+    const readStream = fileResource.getReadStream({
+      auth,
+      version: "original",
+    });
+    const buffer = await streamToBuffer(readStream);
+
+    return new Ok({
+      buffer,
+      filename: attachment.title || `attachment-${fileId}`,
+      contentType: attachment.contentType || "application/octet-stream",
+    });
+  } catch (error) {
+    return new Err(
+      `Failed to get file from conversation: ${normalizeError(error).message}`
+    );
+  }
+}
+
+export async function streamToBuffer(
+  readStream: NodeJS.ReadableStream
+): Promise<Buffer> {
+  try {
+    const chunks: Buffer[] = [];
+    for await (const chunk of readStream) {
+      if (Buffer.isBuffer(chunk)) {
+        chunks.push(chunk);
+      } else {
+        chunks.push(Buffer.from(chunk as string));
+      }
+    }
+    return Buffer.concat(chunks);
+  } catch (error) {
+    throw new Error(
+      `Failed to read file stream: ${normalizeError(error).message}`
+    );
+  }
+}


### PR DESCRIPTION
## Description

* Ability to upload Dust conversation files and attachments to a Jira issue

## Tests

* All of these files were uploaded via Dust: https://dust-team-n75ceiaj.atlassian.net/browse/CCS-99

## Risk

* Minimal

## Deploy Plan

* Deploy front