### PR TITLE
[fix] for 'Unreachable: missing reasoning model configuration.'

### DIFF
--- a/front/components/agent_builder/capabilities/mcp/MCPServerViewsSheet.tsx
+++ b/front/components/agent_builder/capabilities/mcp/MCPServerViewsSheet.tsx
@@ -73,7 +73,7 @@ import {
   DEFAULT_DATA_VISUALIZATION_NAME,
 } from "@app/lib/actions/constants";
 import { getMCPServerToolsConfigurations } from "@app/lib/actions/mcp_internal_actions/input_configuration";
-import { DEFAULT_REASONING_MODEL_ID } from "@app/lib/actions/mcp_internal_actions/servers/reasoning";
+import { DEFAULT_REASONING_CONFIGURATION } from "@app/lib/actions/mcp_internal_actions/servers/reasoning";
 import type { MCPServerViewType } from "@app/lib/api/mcp";
 import { useModels } from "@app/lib/swr/models";
 
@@ -387,7 +387,7 @@ export function MCPServerViewsSheet({
 
         const defaultReasoningModel =
           reasoningModels.find(
-            (model) => model.modelId === DEFAULT_REASONING_MODEL_ID
+            (model) => model.modelId === DEFAULT_REASONING_CONFIGURATION.modelId
           ) ?? reasoningModels[0];
 
         configuredAction = {

--- a/front/components/agent_builder/capabilities/mcp/MCPServerViewsSheet.tsx
+++ b/front/components/agent_builder/capabilities/mcp/MCPServerViewsSheet.tsx
@@ -85,7 +85,6 @@ export type SelectedTool =
     }
   | { type: "DATA_VISUALIZATION" };
 
-
 export type SheetMode =
   | { type: "add" }
   | {

--- a/front/components/agent_builder/capabilities/mcp/MCPServerViewsSheet.tsx
+++ b/front/components/agent_builder/capabilities/mcp/MCPServerViewsSheet.tsx
@@ -73,9 +73,9 @@ import {
   DEFAULT_DATA_VISUALIZATION_NAME,
 } from "@app/lib/actions/constants";
 import { getMCPServerToolsConfigurations } from "@app/lib/actions/mcp_internal_actions/input_configuration";
+import { DEFAULT_REASONING_MODEL_ID } from "@app/lib/actions/mcp_internal_actions/servers/reasoning";
 import type { MCPServerViewType } from "@app/lib/api/mcp";
 import { useModels } from "@app/lib/swr/models";
-import { O4_MINI_MODEL_ID } from "@app/types";
 
 export type SelectedTool =
   | {
@@ -85,7 +85,6 @@ export type SelectedTool =
     }
   | { type: "DATA_VISUALIZATION" };
 
-const DEFAULT_REASONING_MODEL_ID = O4_MINI_MODEL_ID;
 
 export type SheetMode =
   | { type: "add" }

--- a/front/lib/actions/mcp_internal_actions/servers/reasoning.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/reasoning.ts
@@ -36,9 +36,16 @@ import {
 } from "@app/types";
 
 const CANCELLATION_CHECK_INTERVAL = 500;
-export const DEFAULT_REASONING_MODEL_ID = O4_MINI_MODEL_ID;
+const DEFAULT_REASONING_MODEL_ID = O4_MINI_MODEL_ID;
 const DEFAULT_REASONING_MODEL_PROVIDER_ID = "openai";
 const REASONING_GENERATION_TOKENS = 20480;
+
+export const DEFAULT_REASONING_CONFIGURATION = {
+  modelId: DEFAULT_REASONING_MODEL_ID,
+  providerId: DEFAULT_REASONING_MODEL_PROVIDER_ID,
+  temperature: null,
+  reasoningEffort: null,
+};
 
 function createServer(
   auth: Authenticator,
@@ -54,10 +61,7 @@ function createServer(
         INTERNAL_MIME_TYPES.TOOL_INPUT.REASONING_MODEL
       ].default({
         mimeType: INTERNAL_MIME_TYPES.TOOL_INPUT.REASONING_MODEL,
-        modelId: DEFAULT_REASONING_MODEL_ID,
-        providerId: DEFAULT_REASONING_MODEL_PROVIDER_ID,
-        temperature: null,
-        reasoningEffort: null,
+        ...DEFAULT_REASONING_CONFIGURATION,
       }),
     },
     async (

--- a/front/lib/actions/mcp_internal_actions/servers/reasoning.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/reasoning.ts
@@ -50,18 +50,15 @@ function createServer(
     "advanced_reasoning",
     "Offload a reasoning-heavy task to a powerful reasoning model. The reasoning model does not have access to any tools.",
     {
-      model:
-        ConfigurableToolInputSchemas[
-          INTERNAL_MIME_TYPES.TOOL_INPUT.REASONING_MODEL
-        ].default(
-          {
-            mimeType: INTERNAL_MIME_TYPES.TOOL_INPUT.REASONING_MODEL,
-            modelId: DEFAULT_REASONING_MODEL_ID,
-            providerId: DEFAULT_REASONING_MODEL_PROVIDER_ID,
-            temperature: null,
-            reasoningEffort: null,
-          }
-        ),
+      model: ConfigurableToolInputSchemas[
+        INTERNAL_MIME_TYPES.TOOL_INPUT.REASONING_MODEL
+      ].default({
+        mimeType: INTERNAL_MIME_TYPES.TOOL_INPUT.REASONING_MODEL,
+        modelId: DEFAULT_REASONING_MODEL_ID,
+        providerId: DEFAULT_REASONING_MODEL_PROVIDER_ID,
+        temperature: null,
+        reasoningEffort: null,
+      }),
     },
     async (
       { model: { modelId, providerId, temperature, reasoningEffort } },

--- a/front/lib/actions/mcp_internal_actions/servers/reasoning.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/reasoning.ts
@@ -32,10 +32,12 @@ import {
   isModelProviderId,
   isProviderWhitelisted,
   isReasoningEffortId,
+  O4_MINI_MODEL_ID,
 } from "@app/types";
 
 const CANCELLATION_CHECK_INTERVAL = 500;
-
+export const DEFAULT_REASONING_MODEL_ID = O4_MINI_MODEL_ID;
+const DEFAULT_REASONING_MODEL_PROVIDER_ID = "openai";
 const REASONING_GENERATION_TOKENS = 20480;
 
 function createServer(
@@ -51,7 +53,15 @@ function createServer(
       model:
         ConfigurableToolInputSchemas[
           INTERNAL_MIME_TYPES.TOOL_INPUT.REASONING_MODEL
-        ],
+        ].default(
+          {
+            mimeType: INTERNAL_MIME_TYPES.TOOL_INPUT.REASONING_MODEL,
+            modelId: DEFAULT_REASONING_MODEL_ID,
+            providerId: DEFAULT_REASONING_MODEL_PROVIDER_ID,
+            temperature: null,
+            reasoningEffort: null,
+          }
+        ),
     },
     async (
       { model: { modelId, providerId, temperature, reasoningEffort } },


### PR DESCRIPTION
## Description

Solve for the following assertion error we were getting more and more on datadog:

```
Unreachable: missing reasoning model configuration.
```

The source of the bug was that the `reasoning` tool needs to have a configured default reasoning model set. This was done in the `MCPServerViewsContext` which occurs in the Agent Builder, but therefore never happened when the tool was added in JIT (must be a mistake from moving to Agent Builder V2). 

Since we now have support for default values at the tool level, the fix simply sets this on the tool itself:

```ts
{
      model:
        ConfigurableToolInputSchemas[
          INTERNAL_MIME_TYPES.TOOL_INPUT.REASONING_MODEL
        ].default(
            {
              mimeType: INTERNAL_MIME_TYPES.TOOL_INPUT.REASONING_MODEL,
              modelId: DEFAULT_REASONING_MODEL_ID,
              providerId: DEFAULT_REASONING_MODEL_PROVIDER_ID,
              temperature: null,
              reasoningEffort: null,
            }
        ),
    },
```

## Tests

After being able to reproduce the prod bug locally by invoking the reasoning tool JIT, I applied the fix and suddenly the model was able to use the tool without issue and the error no longer appeared in local logs.

## Risk

None.

## Deploy Plan

Deploy front.