### PR TITLE
removed useless hook call to get toolsMetadata info we already have

### DIFF
--- a/front/components/actions/mcp/ToolsList.tsx
+++ b/front/components/actions/mcp/ToolsList.tsx
@@ -20,10 +20,7 @@ import { getServerTypeAndIdFromSId } from "@app/lib/actions/mcp_helper";
 import { isRemoteMCPServerType } from "@app/lib/actions/mcp_helper";
 import { getDefaultRemoteMCPServerByURL } from "@app/lib/actions/mcp_internal_actions/remote_servers";
 import type { MCPServerViewType } from "@app/lib/api/mcp";
-import {
-  useMCPServerToolsSettings,
-  useUpdateMCPServerToolsSettings,
-} from "@app/lib/swr/mcp_servers";
+import { useUpdateMCPServerToolsSettings } from "@app/lib/swr/mcp_servers";
 import type { LightWorkspaceType } from "@app/types";
 import { asDisplayName, isAdmin } from "@app/types";
 
@@ -52,10 +49,7 @@ export function ToolsList({
     () => mcpServerView.server.tools,
     [mcpServerView.server.tools]
   );
-  const { toolsSettings } = useMCPServerToolsSettings({
-    owner,
-    serverId: mcpServerView.server.sId,
-  });
+  const toolsMetadata = mcpServerView.toolsMetadata ?? [];
 
   const { updateToolSettings } = useUpdateMCPServerToolsSettings({
     owner,
@@ -88,14 +82,17 @@ export function ToolsList({
   };
 
   const getToolPermission = (toolName: string) => {
-    return toolsSettings[toolName]
-      ? toolsSettings[toolName].permission
-      : FALLBACK_MCP_TOOL_STAKE_LEVEL;
+    return (
+      toolsMetadata.find((tool) => tool.toolName === toolName)?.permission ??
+      FALLBACK_MCP_TOOL_STAKE_LEVEL
+    );
   };
 
   const getToolEnabled = (toolName: string) => {
     // Default tools to be enabled by default
-    return toolsSettings[toolName] ? toolsSettings[toolName].enabled : true;
+    return (
+      toolsMetadata.find((tool) => tool.toolName === toolName)?.enabled ?? true
+    );
   };
 
   const toolPermissionLabel: Record<string, string> = {

--- a/front/components/actions/mcp/ToolsList.tsx
+++ b/front/components/actions/mcp/ToolsList.tsx
@@ -11,7 +11,10 @@ import {
 } from "@dust-tt/sparkle";
 import { useMemo } from "react";
 
-import type { CustomRemoteMCPToolStakeLevelType } from "@app/lib/actions/constants";
+import type {
+  CustomRemoteMCPToolStakeLevelType,
+  MCPToolStakeLevelType,
+} from "@app/lib/actions/constants";
 import {
   CUSTOM_REMOTE_MCP_TOOL_STAKE_LEVELS,
   FALLBACK_MCP_TOOL_STAKE_LEVEL,
@@ -49,7 +52,16 @@ export function ToolsList({
     () => mcpServerView.server.tools,
     [mcpServerView.server.tools]
   );
-  const toolsMetadata = mcpServerView.toolsMetadata ?? [];
+  const toolsMetadata = useMemo(() => {
+    const map: Record<
+      string,
+      { permission: MCPToolStakeLevelType; enabled: boolean }
+    > = {};
+    for (const tool of mcpServerView.toolsMetadata ?? []) {
+      map[tool.toolName] = tool;
+    }
+    return map;
+  }, [mcpServerView.toolsMetadata]);
 
   const { updateToolSettings } = useUpdateMCPServerToolsSettings({
     owner,
@@ -82,17 +94,12 @@ export function ToolsList({
   };
 
   const getToolPermission = (toolName: string) => {
-    return (
-      toolsMetadata.find((tool) => tool.toolName === toolName)?.permission ??
-      FALLBACK_MCP_TOOL_STAKE_LEVEL
-    );
+    return toolsMetadata[toolName]?.permission ?? FALLBACK_MCP_TOOL_STAKE_LEVEL;
   };
 
   const getToolEnabled = (toolName: string) => {
     // Default tools to be enabled by default
-    return (
-      toolsMetadata.find((tool) => tool.toolName === toolName)?.enabled ?? true
-    );
+    return toolsMetadata[toolName]?.enabled ?? true;
   };
 
   const toolPermissionLabel: Record<string, string> = {

--- a/front/lib/swr/mcp_servers.ts
+++ b/front/lib/swr/mcp_servers.ts
@@ -740,7 +740,7 @@ export function useDeleteMCPServerConnection({
   return { deleteMCPServerConnection };
 }
 
-export function useMCPServerToolsSettings({
+function useMCPServerToolsSettings({
   owner,
   serverId,
 }: {


### PR DESCRIPTION
## Description

Since a refactor, `mcpServerView` has a `toolsMetadata` property that has the same information as `toolsSettings` that we retrieved from a hook call. I removed the hook and used toolsMetadata directly.

## Tests

Ran all existing tests.

## Risk

None. 

## Deploy Plan

Deploy front
