### PR TITLE
[front] don't remove last participant when leave convo

### DIFF
--- a/front/lib/api/assistant/conversation.ts
+++ b/front/lib/api/assistant/conversation.ts
@@ -242,8 +242,9 @@ export async function deleteOrLeaveConversation(
   if (leaveRes.isErr()) {
     return new Err(leaveRes.error);
   }
-  // If the conversation is empty after the leave, soft-delete it.
-  if (leaveRes.value.affectedCount > 0 && leaveRes.value.isConversationEmpty) {
+
+  // If the user was the last member, soft-delete the conversation.
+  if (leaveRes.value.affectedCount === 0 && leaveRes.value.wasLastMember) {
     await conversation.updateVisibilityToDeleted();
   }
   return new Ok({ success: true });


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

For now, we were removing the last participant when soft deleting a convo. This was leading to restoring the convo without participants.

We now keep the last participant in the convo.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

By hand

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

Low

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->

Deploy front