### PR TITLE
feat(core): add an endpoint to call a llm

### DIFF
--- a/core/src/api/llm.rs
+++ b/core/src/api/llm.rs
@@ -1,0 +1,83 @@
+use crate::providers::chat_messages::ChatMessage;
+use crate::providers::llm::{ChatFunction, LLMChatRequest};
+use crate::providers::provider::ProviderID;
+use crate::run;
+use crate::utils::{error_response, APIResponse};
+use axum::Json;
+use http::StatusCode;
+use serde_json::{json, Value};
+
+#[derive(serde::Deserialize)]
+pub struct LlmChatPayload {
+    // Run
+    run_id: String,
+
+    // mandatory LLM payload
+    provider_id: ProviderID,
+    model_id: String,
+    messages: Vec<ChatMessage>,
+    temperature: f32,
+
+    // credentials and secrets
+    credentials: run::Credentials,
+
+    // optional LLM payload
+    functions: Option<Vec<ChatFunction>>,
+    function_call: Option<String>,
+    top_p: Option<f32>,
+    n: Option<usize>,
+    stop: Option<Vec<String>>,
+    max_tokens: Option<i32>,
+    presence_penalty: Option<f32>,
+    frequency_penalty: Option<f32>,
+    logprobs: Option<bool>,
+    top_logprobs: Option<i32>,
+    extras: Option<Value>,
+}
+pub async fn chat(Json(payload): Json<LlmChatPayload>) -> (StatusCode, Json<APIResponse>) {
+    let request = LLMChatRequest::new(
+        payload.provider_id,
+        &payload.model_id,
+        &payload.messages,
+        &payload.functions.unwrap_or_default(),
+        payload.function_call,
+        payload.temperature,
+        payload.top_p,
+        payload.n.unwrap_or(1),
+        &payload.stop.unwrap_or_default(),
+        payload.max_tokens,
+        payload.presence_penalty,
+        payload.frequency_penalty,
+        payload.logprobs,
+        payload.top_logprobs,
+        payload.extras,
+    );
+
+    let result = request
+        .execute(payload.credentials, None, payload.run_id)
+        .await;
+
+    match result {
+        Err(e) => error_response(
+            StatusCode::INTERNAL_SERVER_ERROR,
+            "llm_error",
+            "Error calling LLM",
+            Some(e),
+        ),
+        Ok(res) => (
+            StatusCode::OK,
+            Json(APIResponse {
+                error: None,
+                response: Some(json!({
+                    "created": res.created,
+                    // ignoring provider and model, as it's in the request
+                    // pub provider: String,
+                    // pub model: String,
+                    "completions": res.completions,
+                    "usage": res.usage,
+                    "logprobs": res.logprobs,
+                })),
+            }),
+        ),
+    }
+}

--- a/core/src/api/runs.rs
+++ b/core/src/api/runs.rs
@@ -24,7 +24,7 @@ use crate::{
 };
 
 #[derive(Clone, serde::Deserialize)]
-struct Secret {
+pub struct Secret {
     name: String,
     value: String,
 }

--- a/core/src/app.rs
+++ b/core/src/app.rs
@@ -501,7 +501,7 @@ impl App {
 
             let block_status = Arc::new(Mutex::new(block_status));
 
-            // We flatten the envs for concurrent and parrallel execution of the block which
+            // We flatten the envs for concurrent and parallel execution of the block, which
             // requires us to keep track of the potential input and map indices of each Env,
             // depending on the state of ExecutionEnvs.
             let e = stream::iter(

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -180,6 +180,7 @@ pub mod api {
     pub mod databases;
     pub mod datasets;
     pub mod folders;
+    pub mod llm;
     pub mod nodes;
     pub mod projects;
     pub(crate) mod run_manager;


### PR DESCRIPTION
## Description

Add an endpoint in core-api to directly call an LLM. 

That's a first step to remove dust Apps if we ever want to do it.

Also ⬇️ 

<img width="474" height="315" alt="image" src="https://github.com/user-attachments/assets/d6d9665c-ac48-4ec3-9618-c88226ebbcae" />


## Tests
```
POST http://localhost:3001/llm/chat{
  "run_id": "1",
  "provider_id": "openai",
  "model_id": "gpt-4o",
  "temperature": 0,
  "messages": [{
    "role": "assistant",
    "content": "hello"
  }],
  "credentials": {
    "OPENAI_API_KEY": "$REDACTED"
  }
}
```

Response
```
{
  "error": null,
  "response": {
    "created": 1758205661485,
    "completions": [
      {
        "content": "Hello! How can I assist you today?",
        "role": "assistant",
        "contents": [
          {
            "type": "text_content",
            "value": "Hello! How can I assist you today?"
          }
        ]
      }
    ],
    "usage": {
      "prompt_tokens": 8,
      "completion_tokens": 9,
      "cached_tokens": 0
    },
    "logprobs": null
  }
}
```

###



###


## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
