### PR TITLE
enh(webtools-edge): cleanup mcp view + increase concurrency to 8

### DIFF
--- a/front/lib/actions/mcp_internal_actions/servers/webtools_edge.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/webtools_edge.ts
@@ -319,7 +319,7 @@ const createServer = (
 
           return contentBlocks;
         },
-        { concurrency: 3 }
+        { concurrency: 8 }
       );
 
       return { isError: false, content: perUrlContents.flat() };

--- a/front/lib/api/assistant/global_agents/configurations/dust/dust-deep.ts
+++ b/front/lib/api/assistant/global_agents/configurations/dust/dust-deep.ts
@@ -699,13 +699,9 @@ export function _getDustTaskGlobalAgent(
   if (companyDataAction) {
     actions.push(companyDataAction);
   }
-  console.log(
-    "\n\nwebSearchBrowseWithSummaryMCPServerView",
-    webSearchBrowseWithSummaryMCPServerView,
-    "\n\n"
-  );
+
   const summaryAgent = _getBrowserSummaryAgent(auth, { settings });
-  console.log("\n\nsummaryAgent", summaryAgent, "\n\n");
+
   if (webSearchBrowseWithSummaryMCPServerView && summaryAgent) {
     actions.push({
       id: -1,

--- a/front/lib/api/assistant/global_agents/global_agents.ts
+++ b/front/lib/api/assistant/global_agents/global_agents.ts
@@ -68,6 +68,7 @@ function getGlobalAgent({
   globalAgentSettings,
   agentRouterMCPServerView,
   webSearchBrowseMCPServerView,
+  webSearchBrowseWithSummaryMCPServerView,
   searchMCPServerView,
   dataSourcesFileSystemMCPServerView,
   contentCreationMCPServerView,
@@ -84,6 +85,7 @@ function getGlobalAgent({
   globalAgentSettings: GlobalAgentSettings[];
   agentRouterMCPServerView: MCPServerViewResource | null;
   webSearchBrowseMCPServerView: MCPServerViewResource | null;
+  webSearchBrowseWithSummaryMCPServerView: MCPServerViewResource | null;
   searchMCPServerView: MCPServerViewResource | null;
   dataSourcesFileSystemMCPServerView: MCPServerViewResource | null;
   contentCreationMCPServerView: MCPServerViewResource | null;
@@ -306,7 +308,7 @@ function getGlobalAgent({
       agentConfiguration = _getDustTaskGlobalAgent(auth, {
         settings,
         preFetchedDataSources,
-        webSearchBrowseMCPServerView,
+        webSearchBrowseWithSummaryMCPServerView,
         dataSourcesFileSystemMCPServerView,
         dataWarehousesMCPServerView,
       });
@@ -378,7 +380,7 @@ export async function getGlobalAgents(
     helperPromptInstance,
     agentRouterMCPServerView,
     webSearchBrowseMCPServerView,
-    webtoolsEdgeMCPServerView,
+    webSearchBrowseWithSummaryMCPServerView,
     searchMCPServerView,
     dataSourcesFileSystemMCPServerView,
     contentCreationMCPServerView,
@@ -473,11 +475,6 @@ export async function getGlobalAgents(
     );
 
   const flags = await getFeatureFlags(owner);
-  const getWebSearchBrowseViewFor = (sId: string | number) => {
-    const useEdge =
-      sId === GLOBAL_AGENTS_SID.DUST_TASK && webtoolsEdgeMCPServerView;
-    return useEdge ? webtoolsEdgeMCPServerView : webSearchBrowseMCPServerView;
-  };
 
   if (!flags.includes("openai_o1_feature")) {
     agentsIdsToFetch = agentsIdsToFetch.filter(
@@ -521,7 +518,8 @@ export async function getGlobalAgents(
       helperPromptInstance,
       globalAgentSettings,
       agentRouterMCPServerView,
-      webSearchBrowseMCPServerView: getWebSearchBrowseViewFor(sId),
+      webSearchBrowseMCPServerView,
+      webSearchBrowseWithSummaryMCPServerView,
       searchMCPServerView,
       dataSourcesFileSystemMCPServerView,
       contentCreationMCPServerView,

--- a/front/lib/api/assistant/global_agents/tools.ts
+++ b/front/lib/api/assistant/global_agents/tools.ts
@@ -51,8 +51,6 @@ export function _getDefaultWebActionsForGlobalAgent({
       sId: agentId + "-websearch-browse-action",
       type: "mcp_server_configuration",
       name: DEFAULT_WEBSEARCH_ACTION_NAME satisfies InternalMCPServerNameType,
-      // Putting a description here is important as it prevents the global agent being detected as
-      // a legacy agent (see isLegacyAgent) and being capped to 1 action.
       description: DEFAULT_WEBSEARCH_ACTION_DESCRIPTION,
       mcpServerViewId: webSearchBrowseMCPServerView.sId,
       internalMCPServerId: webSearchBrowseMCPServerView.internalMCPServerId,


### PR DESCRIPTION
## Description

- cleanup how the view is passed down to the dust-deep agents
- increase concurrency of webtools edge browse to 8


## Tests

Local

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
