### PR TITLE
Exclude run_agent from countActiveUsersForPeriodInWorkspace

### DIFF
--- a/front/lib/plans/usage/mau.ts
+++ b/front/lib/plans/usage/mau.ts
@@ -31,6 +31,8 @@ async function countActiveUsersForPeriodInWorkspace({
     INNER JOIN mentions ON mentions."messageId" = messages.id
     WHERE messages."workspaceId" = :workspaceId
     AND "user_messages"."userId" IS NOT NULL
+    AND "user_messages"."userContextOrigin" != 'run_agent'
+    AND "user_messages"."userContextOrigin" != 'agent_handover'
     AND "mentions"."createdAt" BETWEEN :startDate AND :endDate
     GROUP BY "user_messages"."userId"
     HAVING COUNT(mentions.*) >= :minNumberOfRows

--- a/front/pages/api/v1/w/[wId]/assistant/conversations/[cId]/messages/index.ts
+++ b/front/pages/api/v1/w/[wId]/assistant/conversations/[cId]/messages/index.ts
@@ -170,6 +170,18 @@ async function handler(
         }
       }
 
+      const isRunAgent =
+        context.origin === "run_agent" || context.origin === "agent_handover";
+      if (isRunAgent && !auth.isSystemKey()) {
+        return apiError(req, res, {
+          status_code: 401,
+          api_error: {
+            type: "invalid_request_error",
+            message:
+              "Messages from run_agent or agent_handover must come from a system key.",
+          },
+        });
+      }
       const ctx: UserMessageContext = {
         clientSideMCPServerIds: context.clientSideMCPServerIds ?? [],
         email: context.email?.toLowerCase() ?? null,

--- a/front/pages/api/v1/w/[wId]/assistant/conversations/index.ts
+++ b/front/pages/api/v1/w/[wId]/assistant/conversations/index.ts
@@ -216,6 +216,20 @@ async function handler(
             });
           }
         }
+
+        const isRunAgent =
+          message.context.origin === "run_agent" ||
+          message.context.origin === "agent_handover";
+        if (isRunAgent && !auth.isSystemKey()) {
+          return apiError(req, res, {
+            status_code: 401,
+            api_error: {
+              type: "invalid_request_error",
+              message:
+                "Messages from run_agent or agent_handover must come from a system key.",
+            },
+          });
+        }
       }
 
       if (depth && depth >= MAX_CONVERSATION_DEPTH) {


### PR DESCRIPTION
## Description

Update MAU computation to exclude user messages from `run_agent` & `agent_handoff`

## Tests

Tested locally: Do a handoff and it works as expected. 
Did not test locally the usage workflow computation because not easy to test. 

## Risk

Can be rolled back. 

## Deploy Plan

Deploy front. 