### PR TITLE
Slack bot: improve rate limit message

### DIFF
--- a/connectors/src/api/webhooks/webhook_slack.ts
+++ b/connectors/src/api/webhooks/webhook_slack.ts
@@ -516,7 +516,7 @@ const _webhookSlackAPIHandler = async (
             });
             await slackClient.chat.postMessage({
               channel: event.channel,
-              text: "You can now talk to Dust in this channel. ⚠️  If private channel synchronization has been allowed on your Dust workspace, admins will now be able to synchronize data from this channel.",
+              text: "You can now talk to Dust in this channel. ⚠️ If private channel synchronization has been allowed on your Dust workspace, admins will now be able to synchronize data from this channel.",
             });
           }
 

--- a/connectors/src/api/webhooks/webhook_slack.ts
+++ b/connectors/src/api/webhooks/webhook_slack.ts
@@ -516,7 +516,7 @@ const _webhookSlackAPIHandler = async (
             });
             await slackClient.chat.postMessage({
               channel: event.channel,
-              text: "You can now talk to Dust in this channel. ⚠️ If private channel synchronization has been allowed on your Dust workspace, admins will now be able to synchronize data from this channel.",
+              text: "You can now talk to Dust in this channel. ⚠️  If private channel synchronization has been allowed on your Dust workspace, admins will now be able to synchronize data from this channel.",
             });
           }
 

--- a/connectors/src/connectors/slack/bot.ts
+++ b/connectors/src/connectors/slack/bot.ts
@@ -69,10 +69,10 @@ import {
   getHeaderFromUserEmail,
 } from "@connectors/types";
 
-const SLACK_RATE_LIMIT_ERROR_MESSAGE =
-  "Slack has blocked the agent from continuing the conversation, due to new restrictive" +
-  " rate limits. You can retry the conversation later. Learn more about the new rate limits" +
-  " and how Dust is responding <https://dust-tt.notion.site/Slack-API-Changes-Impact-and-Response-Plan-21728599d94180f3b2b4e892e6d20af6?pvs=73|here>";
+const SLACK_RATE_LIMIT_ERROR_MARKDOWN =
+  "You have reached a rate limit enforced by Slack. Please try again later (or contact Slack to increase your rate limit on the <https://dust4ai.slack.com/marketplace/A09214D6XQT-dust|Dust App for Slack>).";
+const SLACK_ERROR_TEXT =
+  "An unexpected error occurred while answering your message, please retry.";
 
 const MAX_FILE_SIZE_TO_UPLOAD = 10 * 1024 * 1024; // 10 MB
 
@@ -154,13 +154,13 @@ export async function botAnswerMessage(
       if (e instanceof ProviderRateLimitError || isWebAPIRateLimitedError(e)) {
         await slackClient.chat.postMessage({
           channel: slackChannel,
-          blocks: makeMarkdownBlock(SLACK_RATE_LIMIT_ERROR_MESSAGE),
+          blocks: makeMarkdownBlock(SLACK_RATE_LIMIT_ERROR_MARKDOWN),
           thread_ts: slackMessageTs,
         });
       } else {
         await slackClient.chat.postMessage({
           channel: slackChannel,
-          text: "An unexpected error occurred. Our team has been notified",
+          text: SLACK_ERROR_TEXT,
           thread_ts: slackMessageTs,
         });
       }
@@ -228,13 +228,13 @@ export async function botReplaceMention(
     if (e instanceof ProviderRateLimitError) {
       await slackClient.chat.postMessage({
         channel: slackChannel,
-        blocks: makeMarkdownBlock(SLACK_RATE_LIMIT_ERROR_MESSAGE),
+        blocks: makeMarkdownBlock(SLACK_RATE_LIMIT_ERROR_MARKDOWN),
         thread_ts: slackMessageTs,
       });
     } else {
       await slackClient.chat.postMessage({
         channel: slackChannel,
-        text: "An unexpected error occurred. Our team has been notified.",
+        text: SLACK_ERROR_TEXT,
         thread_ts: slackMessageTs,
       });
     }

--- a/front/package-lock.json
+++ b/front/package-lock.json
@@ -4,6 +4,7 @@
   "requires": true,
   "packages": {
     "": {
+      "name": "front",
       "dependencies": {
         "@datadog/browser-logs": "^6.13.0",
         "@dust-tt/client": "file:../sdks/js",
@@ -1126,10 +1127,9 @@
       "link": true
     },
     "node_modules/@dust-tt/sparkle": {
-      "version": "0.2.616",
-      "resolved": "https://registry.npmjs.org/@dust-tt/sparkle/-/sparkle-0.2.616.tgz",
-      "integrity": "sha512-u2xMhSjBDHlhRvgzhZ3RG2RBGSn04m+lLylIH3pbRQzDMXZ8NYY5OJw3FVRHeGUT+317EEyB1CWe09/nRtnB0w==",
-      "license": "ISC",
+      "version": "0.2.617",
+      "resolved": "https://registry.npmjs.org/@dust-tt/sparkle/-/sparkle-0.2.617.tgz",
+      "integrity": "sha512-cM2BW2fWXl3gf7Ib8OyCMMBmC6bqsiHcAwaaND49rYk5mwOZuUHflSt4HDjrSt4wq/O1yQBlnj32Muu8gMD32Q==",
       "dependencies": {
         "@emoji-mart/data": "^1.1.2",
         "@emoji-mart/react": "^1.1.1",


### PR DESCRIPTION
## Description

Fix: https://github.com/dust-tt/tasks/issues/4189
Improve Slack rate limit error when interacting with Dust bot. Message was not up to date anymore.

## Tests

None, looked at stats of occurence: https://github.com/dust-tt/tasks/issues/4189

## Risk

Low

## Deploy Plan

- deploy `connectors