### PR TITLE
[front] fix: Don't pass specific roles to call API

### DIFF
--- a/front/lib/actions/helpers.ts
+++ b/front/lib/actions/helpers.ts
@@ -92,7 +92,7 @@ export async function callAction<V extends t.Mixed>(
       ...prodCredentials,
       extraHeaders: {
         ...getHeaderFromGroupIds(requestedGroupIds),
-        ...getHeaderFromRole(auth.role()),
+        ...getHeaderFromRole(auth.role()), // Keep the user's role for api.runApp call only
       },
     },
     logger

--- a/front/lib/actions/mcp_internal_actions/servers/agent_router.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/agent_router.ts
@@ -13,7 +13,7 @@ import type { Authenticator } from "@app/lib/auth";
 import { prodAPICredentialsForOwner } from "@app/lib/auth";
 import logger from "@app/logger/logger";
 import type { LightAgentConfigurationType } from "@app/types";
-import { getHeaderFromGroupIds, getHeaderFromRole } from "@app/types/groups";
+import { getHeaderFromGroupIds } from "@app/types/groups";
 
 const MAX_INSTRUCTIONS_LENGTH = 1000;
 const LIST_ALL_AGENTS_TOOL_NAME = "list_all_published_agents";
@@ -37,7 +37,6 @@ const createServer = (auth: Authenticator): McpServer => {
           ...prodCredentials,
           extraHeaders: {
             ...getHeaderFromGroupIds(requestedGroupIds),
-            ...getHeaderFromRole(auth.role()),
           },
         },
         logger
@@ -99,7 +98,6 @@ const createServer = (auth: Authenticator): McpServer => {
           ...prodCredentials,
           extraHeaders: {
             ...getHeaderFromGroupIds(requestedGroupIds),
-            ...getHeaderFromRole(auth.role()),
           },
         },
         logger

--- a/front/lib/actions/mcp_internal_actions/servers/run_dust_app.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/run_dust_app.ts
@@ -423,7 +423,7 @@ export default async function createServer(
             ...prodCredentials,
             extraHeaders: {
               ...getHeaderFromGroupIds(requestedGroupIds),
-              ...getHeaderFromRole(auth.role()),
+              ...getHeaderFromRole(auth.role()), // Keep the user's role for api.runApp call only
             },
           },
           logger,

--- a/front/lib/actions/mcp_internal_actions/servers/toolsets.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/toolsets.ts
@@ -15,7 +15,7 @@ import type { Authenticator } from "@app/lib/auth";
 import { prodAPICredentialsForOwner } from "@app/lib/auth";
 import { SpaceResource } from "@app/lib/resources/space_resource";
 import logger from "@app/logger/logger";
-import { getHeaderFromGroupIds, getHeaderFromRole, Ok } from "@app/types";
+import { getHeaderFromGroupIds, Ok } from "@app/types";
 
 const createServer = (
   auth: Authenticator,
@@ -43,7 +43,6 @@ const createServer = (
           ...prodCredentials,
           extraHeaders: {
             ...getHeaderFromGroupIds(requestedGroupIds),
-            ...getHeaderFromRole(auth.role()),
           },
         },
         logger,

--- a/front/lib/actions/server.ts
+++ b/front/lib/actions/server.ts
@@ -143,7 +143,7 @@ export async function runActionStreamed(
       ...prodCredentials,
       extraHeaders: {
         ...getHeaderFromGroupIds(requestedGroupIds),
-        ...getHeaderFromRole(auth.role()),
+        ...getHeaderFromRole(auth.role()), // Keep the user's role for api.runApp call only
       },
     },
     logger
@@ -265,7 +265,7 @@ export async function runAction(
       ...prodCredentials,
       extraHeaders: {
         ...getHeaderFromGroupIds(requestedGroupIds),
-        ...getHeaderFromRole(auth.role()),
+        ...getHeaderFromRole(auth.role()), // Keep the user's role for api.runApp call only
       },
     },
     logger

--- a/front/types/groups.ts
+++ b/front/types/groups.ts
@@ -98,6 +98,10 @@ export function getRoleFromHeaders(
   return undefined;
 }
 
+/**
+ * Pass the user's role to the API - only use for route which have allowUserOutsideCurrentWorkspace set to
+ * true (runApp or runAppStreamed). Other API calls will always require builder/admin role.
+ */
 export function getHeaderFromRole(role: RoleType | undefined) {
   if (!role) {
     return undefined;


### PR DESCRIPTION
## Description

No need to pass the role, we should keep the default admin role from system key.
If the user is not a builder, passing auth.role() will result in a 401 in the api call. Only "allowUserOutsideCurrentWorkspace" routes (like runAppStream) can be called with non-builder roles.

Fixing toolset and agent router tools

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

deploy front
