### PR TITLE
[Prod Check] Batch GDrive GC query via id-cursor

### DIFF
--- a/front/lib/production_checks/checks/managed_data_source_gdrive_gc.ts
+++ b/front/lib/production_checks/checks/managed_data_source_gdrive_gc.ts
@@ -27,7 +27,7 @@ export const managedDataSourceGCGdriveCheck: CheckFunction = async (
     heartbeat();
 
     // Retrieve all documents from the connector (first) in 10k batches using an id cursor
-    const BATCH_SIZE = 10_000;
+    const BATCH_SIZE = 5_000;
     let lastId = 0;
     const connectorDocuments: { id: number; coreDocumentId: string }[] = [];
     let fetched = 0;

--- a/front/lib/production_checks/checks/managed_data_source_gdrive_gc.ts
+++ b/front/lib/production_checks/checks/managed_data_source_gdrive_gc.ts
@@ -26,17 +26,33 @@ export const managedDataSourceGCGdriveCheck: CheckFunction = async (
   for (const ds of GdriveDataSources) {
     heartbeat();
 
-    // Retrieve all documents from the connector (first)
-    const connectorDocuments: { id: number; coreDocumentId: string }[] =
-      await connectorsReplica.query(
-        'SELECT id, "dustFileId" as "coreDocumentId" FROM google_drive_files WHERE "connectorId" = :connectorId',
+    // Retrieve all documents from the connector (first) in 10k batches using an id cursor
+    const BATCH_SIZE = 10_000;
+    let lastId = 0;
+    const connectorDocuments: { id: number; coreDocumentId: string }[] = [];
+    let fetched = 0;
+    do {
+      const batch = (await connectorsReplica.query(
+        // eslint-disable-next-line dust/no-raw-sql -- Legit
+        'SELECT id, "dustFileId" as "coreDocumentId" FROM google_drive_files WHERE "connectorId" = :connectorId AND id > :lastId ORDER BY id ASC LIMIT :batchSize',
         {
           replacements: {
             connectorId: ds.connectorId,
+            lastId,
+            batchSize: BATCH_SIZE,
           },
           type: QueryTypes.SELECT,
         }
-      );
+      )) as { id: number; coreDocumentId: string }[];
+
+      fetched = batch.length;
+      if (fetched > 0) {
+        connectorDocuments.push(...batch);
+        lastId = batch[fetched - 1].id;
+        heartbeat();
+      }
+    } while (fetched === BATCH_SIZE);
+
     const connectorDocumentIds = new Set(
       connectorDocuments.map((d) => d.coreDocumentId)
     );


### PR DESCRIPTION
## Description

We're getting "DatabaseError: canceling statement due to conflict with recovery" in production checks on managed_data_source_gdrive_gc, from L31 of front/lib/production_checks/checks/managed_data_source_gdrive_gc.ts . 
Likely cause: the select is too long. 


- Batches `google_drive_files` fetches in 5k chunks using an id cursor (`id > :lastId ORDER BY id ASC LIMIT :batchSize`).
- Aggregates all batches before building the `Set` of connector document IDs.

## Risks
Blast radius: production check `managed_data_source_gdrive_gc` only.
Risk: low

## Deploy Plan
- No migrations. Deploy front as usual. The production check will run with paginated selects on the connectors replica.
