### PR TITLE
[front] Expose MCP errors/exceptions when calling tools messages to the model

### DIFF
--- a/front/lib/actions/mcp_execution.ts
+++ b/front/lib/actions/mcp_execution.ts
@@ -94,51 +94,55 @@ export async function* executeMCPTool({
   for await (const event of tryCallMCPTool(auth, inputs, agentLoopRunContext, {
     progressToken: action.id,
   })) {
-    if (event.type === "result") {
-      toolCallResult = event.result;
-    } else if (event.type === "notification") {
-      const { notification } = event;
-      if (isMCPProgressNotificationType(notification)) {
-        const output = notification.params.data.output;
+    switch (event.type) {
+      case "result": {
+        toolCallResult = event.result;
+        break;
+      }
+      case "notification": {
+        const { notification } = event;
+        if (isMCPProgressNotificationType(notification)) {
+          const output = notification.params.data.output;
 
-        // Handle store_resource notifications by creating output items immediately
-        if (isStoreResourceProgressOutput(output)) {
-          await AgentMCPActionOutputItem.bulkCreate(
-            output.contents.map((content) => ({
-              workspaceId: action.workspaceId,
-              agentMCPActionId: action.id,
-              content,
-            }))
-          );
-        }
+          // Handle store_resource notifications by creating output items immediately
+          if (isStoreResourceProgressOutput(output)) {
+            await AgentMCPActionOutputItem.bulkCreate(
+              output.contents.map((content) => ({
+                workspaceId: action.workspaceId,
+                agentMCPActionId: action.id,
+                content,
+              }))
+            );
+          }
 
-        // Specific handling for run_agent notifications indicating the tool has
-        // started and can be resumed: the action is updated to save the resumeState.
-        if (isRunAgentQueryProgressOutput(output)) {
-          await action.updateStepContext({
-            ...action.stepContext,
-            resumeState: {
-              userMessageId: output.userMessageId,
-              conversationId: output.conversationId,
+          // Specific handling for run_agent notifications indicating the tool has
+          // started and can be resumed: the action is updated to save the resumeState.
+          if (isRunAgentQueryProgressOutput(output)) {
+            await action.updateStepContext({
+              ...action.stepContext,
+              resumeState: {
+                userMessageId: output.userMessageId,
+                conversationId: output.conversationId,
+              },
+            });
+          }
+
+          // Regular notifications, we yield them as is with the type "tool_notification".
+          yield {
+            type: "tool_notification",
+            created: Date.now(),
+            configurationId: agentConfiguration.sId,
+            conversationId: conversation.sId,
+            messageId: agentMessage.sId,
+            action: {
+              ...action.toJSON(),
+              // TODO(2025-08-29 aubin): cleanup as soon as the SDK type is updated.
+              output: null,
+              generatedFiles: [],
             },
-          });
+            notification: notification.params,
+          };
         }
-
-        // Regular notifications, we yield them as is with the type "tool_notification".
-        yield {
-          type: "tool_notification",
-          created: Date.now(),
-          configurationId: agentConfiguration.sId,
-          conversationId: conversation.sId,
-          messageId: agentMessage.sId,
-          action: {
-            ...action.toJSON(),
-            // TODO(2025-08-29 aubin): cleanup as soon as the SDK type is updated.
-            output: null,
-            generatedFiles: [],
-          },
-          notification: notification.params,
-        };
       }
     }
   }

--- a/front/lib/api/mcp/run_tool.ts
+++ b/front/lib/api/mcp/run_tool.ts
@@ -98,6 +98,8 @@ export async function* runToolWithStreaming(
     agentMessage,
   });
 
+  // TODO(2025-09-17 aubin): the code path where toolCallResult is null is actually unreachable
+  //  but it's well covered in typing.
   if (!toolCallResult || toolCallResult.isErr()) {
     statsDClient.increment("mcp_actions_error.count", 1, tags);
     localLogger.error(
@@ -113,10 +115,10 @@ export async function* runToolWithStreaming(
 
     let errorMessage: string;
 
-    // We don't want to expose the MCP full error message to the user.
-    if (toolErr && toolErr instanceof McpError && toolErr.code === -32001) {
-      // MCP Error -32001: Request timed out.
-      errorMessage = `The tool ${action.functionCallName} timed out. `;
+    const isMCPTimeoutError =
+      toolErr && toolErr instanceof McpError && toolErr.code === -32001;
+    if (isMCPTimeoutError) {
+      errorMessage = `The execution of tool ${action.functionCallName} timed out.`;
 
       // If the tool should be retried on interrupt, we throw an error so the workflow retries the
       // `runTool` activity. If the tool should not be retried on interrupt, the error is returned to
@@ -128,11 +130,10 @@ export async function* runToolWithStreaming(
         throw new Error(errorMessage);
       }
     } else {
-      errorMessage = `The tool ${action.functionCallName} returned an error. `;
+      errorMessage = toolErr
+        ? `The tool ${action.functionCallName} failed with the following error: ${toolErr.message}`
+        : `The tool ${action.functionCallName} failed without returning any error information.`;
     }
-
-    errorMessage +=
-      "An error occurred while executing the tool. You can inform the user of this issue.";
 
     yield await handleMCPActionError({
       action,


### PR DESCRIPTION
## Description

- Errors that are not explicitly returned by tools and that happen earlier, such as input schema validation errors, are not correctly exposed to the model currently.
- This PR fixes that.

## Tests

- Tested locally by throwing instead of `mcpClient.callTool`. Confirmed empirically that the model did not see the error message at all and that we now see them in the rendered conversation.

## Risk

- Quite a critical code path but the actual change is small (actually comes down to one message exposed to the model).

## Deploy Plan

- Deploy front.
