### PR TITLE
[front] fix(poke): Use dedicated endpoint for poke

### DIFF
--- a/front/components/poke/workspace/table.tsx
+++ b/front/components/poke/workspace/table.tsx
@@ -8,7 +8,7 @@ import {
   PokeTableCellWithCopy,
   PokeTableRow,
 } from "@app/components/poke/shadcn/ui/table";
-import { useWorkOSDSyncStatus } from "@app/lib/swr/workos";
+import { usePokeWorkOSDSyncStatus } from "@app/lib/swr/poke";
 import type { WorkOSConnectionSyncStatus } from "@app/lib/types/workos";
 import type {
   ExtensionConfigurationType,
@@ -32,7 +32,7 @@ export function WorkspaceInfoTable({
   workspaceRetention: number | null;
   workosEnvironmentId: string;
 }) {
-  const { dsyncStatus } = useWorkOSDSyncStatus({ owner });
+  const { dsyncStatus } = usePokeWorkOSDSyncStatus({ owner });
 
   const getStatusChipColor = (status: WorkOSConnectionSyncStatus["status"]) => {
     switch (status) {

--- a/front/lib/swr/poke.ts
+++ b/front/lib/swr/poke.ts
@@ -132,3 +132,24 @@ export function usePokeFeatureFlags({
     mutate,
   };
 }
+
+export function usePokeWorkOSDSyncStatus({
+  disabled,
+  owner,
+}: {
+  disabled?: boolean;
+  owner: LightWorkspaceType;
+}) {
+  const { data, error, mutate } = useSWRWithDefaults(
+    `/api/poke/workspaces/${owner.sId}/dsync`,
+    fetcher,
+    { disabled }
+  );
+
+  return {
+    dsyncStatus: data,
+    error,
+    isLoading: !error && !data,
+    mutate,
+  };
+}

--- a/front/pages/api/poke/workspaces/[wId]/dsync.ts
+++ b/front/pages/api/poke/workspaces/[wId]/dsync.ts
@@ -1,0 +1,94 @@
+import type { NextApiRequest, NextApiResponse } from "next";
+
+import { withSessionAuthenticationForPoke } from "@app/lib/api/auth_wrappers";
+import { getWorkOSOrganizationDSyncDirectories } from "@app/lib/api/workos/organization";
+import { Authenticator } from "@app/lib/auth";
+import type { SessionWithUser } from "@app/lib/iam/provider";
+import type { WorkOSConnectionSyncStatus } from "@app/lib/types/workos";
+import { apiError } from "@app/logger/withlogging";
+import type { WithAPIErrorResponse } from "@app/types";
+import { normalizeError } from "@app/types";
+
+async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse<
+    WithAPIErrorResponse<Omit<WorkOSConnectionSyncStatus, "setupLink">>
+  >,
+  session: SessionWithUser
+) {
+  const auth = await Authenticator.fromSuperUserSession(
+    session,
+    req.query.wId as string
+  );
+  const owner = auth.getNonNullableWorkspace();
+
+  if (!owner || !auth.isDustSuperUser()) {
+    return apiError(req, res, {
+      status_code: 404,
+      api_error: {
+        type: "user_not_found",
+        message: "Could not find the user.",
+      },
+    });
+  }
+
+  const r = await getWorkOSOrganizationDSyncDirectories({
+    workspace: owner,
+  });
+  if (r.isErr()) {
+    return apiError(req, res, {
+      status_code: 500,
+      api_error: {
+        type: "workos_server_error",
+        message: `Failed to list directories: ${normalizeError(r.error).message}`,
+      },
+    });
+  }
+  const directories = r.value;
+
+  if (directories.length > 1) {
+    return apiError(req, res, {
+      status_code: 400,
+      api_error: {
+        type: "workos_multiple_directories_not_supported",
+        message: "Multiple directories are not supported.",
+      },
+    });
+  }
+
+  const [activeDirectory] = directories;
+
+  switch (req.method) {
+    case "GET":
+      let status: WorkOSConnectionSyncStatus["status"] = "not_configured";
+
+      if (activeDirectory) {
+        status =
+          activeDirectory.state === "active" ? "configured" : "configuring";
+      }
+
+      res.status(200).json({
+        status,
+        connection: activeDirectory
+          ? {
+              id: activeDirectory.id,
+              state: activeDirectory.state,
+              type: activeDirectory.type,
+            }
+          : null,
+      });
+
+      return;
+
+    default:
+      return apiError(req, res, {
+        status_code: 405,
+        api_error: {
+          type: "method_not_supported_error",
+          message: "The method passed is not supported.",
+        },
+      });
+  }
+}
+
+export default withSessionAuthenticationForPoke(handler);


### PR DESCRIPTION
## Description

Calling standard endpoint in not allowed in poke ( https://app.datadoghq.eu/logs?query=%22Only%20users%20of%20the%20workspace%20can%20access%20this%20route.%22%20%40url%3A%2A%2Fdsync&agg_m=count&agg_m_source=base&agg_q=%40url&agg_q_source=base&agg_t=count&analyticsOptions=%5B%22bars%22%2C%22dog_classic%22%2Cnull%2Cnull%2C%22value%22%5D&clustering_pattern_field_path=message&cols=host%2Cservice&link_source=monitor_notif&messageDisplay=inline&refresh_mode=sliding&storage=hot&stream_sort=desc&top_n=10&top_o=top&viz=stream&x_missing=true&from_ts=1756818889833&to_ts=1758114889833&live=true )
## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
