### PR TITLE
fix(run-agent): attempt to make long run_agent survive across deploys

### DIFF
--- a/front/lib/actions/constants.ts
+++ b/front/lib/actions/constants.ts
@@ -4,7 +4,6 @@ import type {
 } from "@app/lib/actions/mcp_icons";
 
 export const DEFAULT_MCP_REQUEST_TIMEOUT_MS = 3 * 60 * 1000; // 3 minutes.
-export const MAX_MCP_REQUEST_TIMEOUT_MS = 10 * 60 * 1000; // 10 minutes.
 
 // Stored in a separate file to prevent a circular dependency issue.
 

--- a/front/lib/actions/mcp_internal_actions/constants.ts
+++ b/front/lib/actions/mcp_internal_actions/constants.ts
@@ -2,7 +2,7 @@ import type { MCPToolStakeLevelType } from "@app/lib/actions/constants";
 import {
   DEFAULT_AGENT_ROUTER_ACTION_DESCRIPTION,
   DEFAULT_AGENT_ROUTER_ACTION_NAME,
-  MAX_MCP_REQUEST_TIMEOUT_MS,
+  DEFAULT_MCP_REQUEST_TIMEOUT_MS,
 } from "@app/lib/actions/constants";
 import {
   DEFAULT_WEBSEARCH_ACTION_DESCRIPTION,
@@ -1048,7 +1048,7 @@ The directive should be used to display a clickable version of the agent name in
     isPreview: false,
     tools_stakes: undefined,
     tools_retry_policies: { default: "retry_on_interrupt" },
-    timeoutMs: MAX_MCP_REQUEST_TIMEOUT_MS,
+    timeoutMs: DEFAULT_MCP_REQUEST_TIMEOUT_MS,
     serverInfo: {
       name: "run_agent",
       version: "1.0.0",

--- a/front/lib/api/assistant/agent.ts
+++ b/front/lib/api/assistant/agent.ts
@@ -251,6 +251,7 @@ export async function runAgentLoop(
   };
 
   if (runAgentArgsWithTiming.sync && executionMode !== "async") {
+    // TODO(DURABLE_AGENTS): dead code.
     await runAgentSynchronousWithStreaming(authType, runAgentArgsWithTiming, {
       startStep,
       withTimeout: executionMode !== "sync",

--- a/front/temporal/agent_loop/workflows.ts
+++ b/front/temporal/agent_loop/workflows.ts
@@ -7,6 +7,7 @@ import {
   workflowInfo,
 } from "@temporalio/workflow";
 
+import { DEFAULT_MCP_REQUEST_TIMEOUT_MS } from "@app/lib/actions/constants";
 import type { AuthenticatorType } from "@app/lib/auth";
 import type * as commonActivities from "@app/temporal/agent_loop/activities/common";
 import type * as ensureTitleActivities from "@app/temporal/agent_loop/activities/ensure_conversation_title";
@@ -22,6 +23,8 @@ import type {
   RunAgentAsynchronousArgs,
 } from "@app/types/assistant/agent_run";
 
+const toolActivityStartToCloseTimeout = `${DEFAULT_MCP_REQUEST_TIMEOUT_MS / 1000 / 60 + 1} minutes`;
+
 const logMetricsActivities = proxyActivities<
   typeof logAgentLoopMetricsActivities
 >({
@@ -36,14 +39,14 @@ const activities: AgentLoopActivities = {
   }).runModelAndCreateActionsActivity,
   runToolActivity: proxyActivities<typeof runToolActivities>({
     // Activity timeout keeps a short buffer above the tool timeout to detect worker restarts promptly.
-    startToCloseTimeout: "4 minutes",
+    startToCloseTimeout: toolActivityStartToCloseTimeout,
     retry: {
       // Do not retry tool activities. Those are not idempotent.
       maximumAttempts: 1,
     },
   }).runToolActivity,
   runRetryableToolActivity: proxyActivities<typeof runToolActivities>({
-    startToCloseTimeout: "4 minutes",
+    startToCloseTimeout: toolActivityStartToCloseTimeout,
     retry: {
       maximumAttempts: 15,
     },

--- a/front/temporal/agent_loop/workflows.ts
+++ b/front/temporal/agent_loop/workflows.ts
@@ -7,7 +7,6 @@ import {
   workflowInfo,
 } from "@temporalio/workflow";
 
-import { MAX_MCP_REQUEST_TIMEOUT_MS } from "@app/lib/actions/constants";
 import type { AuthenticatorType } from "@app/lib/auth";
 import type * as commonActivities from "@app/temporal/agent_loop/activities/common";
 import type * as ensureTitleActivities from "@app/temporal/agent_loop/activities/ensure_conversation_title";
@@ -36,22 +35,17 @@ const activities: AgentLoopActivities = {
     startToCloseTimeout: "10 minutes",
   }).runModelAndCreateActionsActivity,
   runToolActivity: proxyActivities<typeof runToolActivities>({
-    // The activity timeout should be slightly longer than the max timeout of
-    // the tool, to avoid the activity being killed before the tool timeout.
-    startToCloseTimeout: `${
-      MAX_MCP_REQUEST_TIMEOUT_MS / 1000 / 60 + 2
-    } minutes`,
+    // Activity timeout keeps a short buffer above the tool timeout to detect worker restarts promptly.
+    startToCloseTimeout: "4 minutes",
     retry: {
       // Do not retry tool activities. Those are not idempotent.
       maximumAttempts: 1,
     },
   }).runToolActivity,
   runRetryableToolActivity: proxyActivities<typeof runToolActivities>({
-    startToCloseTimeout: `${
-      MAX_MCP_REQUEST_TIMEOUT_MS / 1000 / 60 + 2
-    } minutes`,
+    startToCloseTimeout: "4 minutes",
     retry: {
-      maximumAttempts: 5,
+      maximumAttempts: 15,
     },
   }).runToolActivity,
   publishDeferredEventsActivity: proxyActivities<


### PR DESCRIPTION
## Description

- Temporal workers restart during deploys while `run_agent` tools are mid-flight; the long 12-minute activity window makes Temporal wait for the full timeout before retrying, so the parent agent appears frozen and eventually fails.
- Reduce the per-attempt tool timeout to 3 minutes, shrink the activity `startToCloseTimeout` to 4 minutes, and raise the retry budget to 15 so retries kick in quickly while preserving the overall execution window.

## Tests

Will have to test in real conditions

## Risk

- If child agents genuinely need more than 3 minutes between progress signals they may now exhaust retries faster; we will monitor Temporal histories and increase limits for exceptional agents if required.
- Changes are configuration-only and can be rolled back by restoring the previous timeout and retry values.

## Deploy Plan

Deploy front