### PR TITLE
[front] Refactor `runToolWithStreaming`

### DIFF
--- a/front/lib/actions/mcp_actions.ts
+++ b/front/lib/actions/mcp_actions.ts
@@ -408,7 +408,7 @@ export async function* tryCallMCPTool(
           "information on MCP tool result"
         );
 
-        return new Err(new Error(`MCP tool result content size too large.`));
+        return new Err(new Error("MCP tool result content size too large."));
       }
     }
 

--- a/front/lib/actions/mcp_actions.ts
+++ b/front/lib/actions/mcp_actions.ts
@@ -256,10 +256,10 @@ export async function* tryCallMCPTool(
   agentLoopRunContext: AgentLoopRunContextType,
   {
     progressToken,
-    onToolNotification,
+    makeToolNotificationEvent,
   }: {
     progressToken: ModelId;
-    onToolNotification: (
+    makeToolNotificationEvent: (
       notification: MCPProgressNotificationType
     ) => Promise<ToolNotificationEvent>;
   }
@@ -369,7 +369,7 @@ export async function* tryCallMCPTool(
           break;
         }
 
-        yield onToolNotification(iteratorResult.value);
+        yield makeToolNotificationEvent(iteratorResult.value);
       }
     }
 

--- a/front/lib/actions/mcp_actions.ts
+++ b/front/lib/actions/mcp_actions.ts
@@ -250,7 +250,7 @@ function generateContentMetadata(content: CallToolResult["content"]): {
  * May fail when connecting to remote/client-side servers.
  * In case of an error, the error content is bubbled up to expose it to the model.
  */
-export async function tryCallMCPTool(
+export async function* tryCallMCPTool(
   auth: Authenticator,
   inputs: Record<string, unknown> | undefined,
   agentLoopRunContext: AgentLoopRunContextType,
@@ -261,9 +261,12 @@ export async function tryCallMCPTool(
     progressToken: ModelId;
     onToolNotification: (
       notification: MCPProgressNotificationType
-    ) => AsyncGenerator<ToolNotificationEvent>;
+    ) => Promise<ToolNotificationEvent>;
   }
-): Promise<Result<CallToolResult["content"], Error | McpError>> {
+): AsyncGenerator<
+  ToolNotificationEvent,
+  Result<CallToolResult["content"], Error | McpError>
+> {
   const { toolConfiguration } = agentLoopRunContext;
 
   if (!isMCPToolConfiguration(toolConfiguration)) {
@@ -366,7 +369,7 @@ export async function tryCallMCPTool(
           break;
         }
 
-        onToolNotification(iteratorResult.value);
+        yield onToolNotification(iteratorResult.value);
       }
     }
 

--- a/front/lib/actions/mcp_actions.ts
+++ b/front/lib/actions/mcp_actions.ts
@@ -366,9 +366,7 @@ export async function* tryCallMCPTool(
           break;
         }
 
-        if (isMCPProgressNotificationType(iteratorResult.value)) {
-          yield onToolNotification(iteratorResult.value);
-        }
+        yield onToolNotification(iteratorResult.value);
       }
     }
 

--- a/front/lib/actions/mcp_actions.ts
+++ b/front/lib/actions/mcp_actions.ts
@@ -250,7 +250,7 @@ function generateContentMetadata(content: CallToolResult["content"]): {
  * May fail when connecting to remote/client-side servers.
  * In case of an error, the error content is bubbled up to expose it to the model.
  */
-export async function* tryCallMCPTool(
+export async function tryCallMCPTool(
   auth: Authenticator,
   inputs: Record<string, unknown> | undefined,
   agentLoopRunContext: AgentLoopRunContextType,
@@ -261,12 +261,9 @@ export async function* tryCallMCPTool(
     progressToken: ModelId;
     onToolNotification: (
       notification: MCPProgressNotificationType
-    ) => Promise<ToolNotificationEvent>;
+    ) => AsyncGenerator<ToolNotificationEvent>;
   }
-): AsyncGenerator<
-  ToolNotificationEvent,
-  Result<CallToolResult["content"], Error | McpError>
-> {
+): Promise<Result<CallToolResult["content"], Error | McpError>> {
   const { toolConfiguration } = agentLoopRunContext;
 
   if (!isMCPToolConfiguration(toolConfiguration)) {
@@ -369,7 +366,7 @@ export async function* tryCallMCPTool(
           break;
         }
 
-        yield onToolNotification(iteratorResult.value);
+        onToolNotification(iteratorResult.value);
       }
     }
 

--- a/front/lib/actions/mcp_actions.ts
+++ b/front/lib/actions/mcp_actions.ts
@@ -2,7 +2,10 @@
 // eslint-disable-next-line dust/enforce-client-types-in-public-api
 import { INTERNAL_MIME_TYPES } from "@dust-tt/client";
 import type { Client } from "@modelcontextprotocol/sdk/client/index.js";
-import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
+import type {
+  CallToolResult,
+  McpError,
+} from "@modelcontextprotocol/sdk/types.js";
 import {
   CallToolResultSchema,
   ProgressNotificationSchema,
@@ -262,7 +265,7 @@ export async function* tryCallMCPTool(
   }
 ): AsyncGenerator<
   ToolNotificationEvent,
-  Result<CallToolResult["content"], Error>
+  Result<CallToolResult["content"], Error | McpError>
 > {
   const { toolConfiguration } = agentLoopRunContext;
 

--- a/front/lib/actions/mcp_execution.ts
+++ b/front/lib/actions/mcp_execution.ts
@@ -49,7 +49,7 @@ import {
   stripNullBytes,
 } from "@app/types";
 
-export async function processToolNotification(
+export async function* processToolNotification(
   notification: MCPProgressNotificationType,
   {
     action,
@@ -62,7 +62,7 @@ export async function processToolNotification(
     conversation: ConversationType;
     agentMessage: AgentMessageType;
   }
-): Promise<ToolNotificationEvent> {
+): AsyncGenerator<ToolNotificationEvent> {
   const output = notification.params.data.output;
 
   // Handle store_resource notifications by creating output items immediately
@@ -89,7 +89,7 @@ export async function processToolNotification(
   }
 
   // Regular notifications, we yield them as is with the type "tool_notification".
-  return {
+  yield {
     type: "tool_notification",
     created: Date.now(),
     configurationId: agentConfiguration.sId,

--- a/front/lib/actions/mcp_execution.ts
+++ b/front/lib/actions/mcp_execution.ts
@@ -94,51 +94,55 @@ export async function* executeMCPTool({
   for await (const event of tryCallMCPTool(auth, inputs, agentLoopRunContext, {
     progressToken: action.id,
   })) {
-    if (event.type === "result") {
-      toolCallResult = event.result;
-    } else if (event.type === "notification") {
-      const { notification } = event;
-      if (isMCPProgressNotificationType(notification)) {
-        const output = notification.params.data.output;
+    switch (event.type) {
+      case "result": {
+        toolCallResult = event.result;
+        break;
+      }
+      case "notification": {
+        const { notification } = event;
+        if (isMCPProgressNotificationType(notification)) {
+          const output = notification.params.data.output;
 
-        // Handle store_resource notifications by creating output items immediately
-        if (isStoreResourceProgressOutput(output)) {
-          await AgentMCPActionOutputItem.bulkCreate(
-            output.contents.map((content) => ({
-              workspaceId: action.workspaceId,
-              agentMCPActionId: action.id,
-              content,
-            }))
-          );
-        }
+          // Handle store_resource notifications by creating output items immediately
+          if (isStoreResourceProgressOutput(output)) {
+            await AgentMCPActionOutputItem.bulkCreate(
+              output.contents.map((content) => ({
+                workspaceId: action.workspaceId,
+                agentMCPActionId: action.id,
+                content,
+              }))
+            );
+          }
 
-        // Specific handling for run_agent notifications indicating the tool has
-        // started and can be resumed: the action is updated to save the resumeState.
-        if (isRunAgentQueryProgressOutput(output)) {
-          await action.updateStepContext({
-            ...action.stepContext,
-            resumeState: {
-              userMessageId: output.userMessageId,
-              conversationId: output.conversationId,
+          // Specific handling for run_agent notifications indicating the tool has
+          // started and can be resumed: the action is updated to save the resumeState.
+          if (isRunAgentQueryProgressOutput(output)) {
+            await action.updateStepContext({
+              ...action.stepContext,
+              resumeState: {
+                userMessageId: output.userMessageId,
+                conversationId: output.conversationId,
+              },
+            });
+          }
+
+          // Regular notifications, we yield them as is with the type "tool_notification".
+          yield {
+            type: "tool_notification",
+            created: Date.now(),
+            configurationId: agentConfiguration.sId,
+            conversationId: conversation.sId,
+            messageId: agentMessage.sId,
+            action: {
+              ...action.toJSON(),
+              // TODO(2025-08-29 aubin): cleanup as soon as the SDK type is updated.
+              output: null,
+              generatedFiles: [],
             },
-          });
+            notification: notification.params,
+          };
         }
-
-        // Regular notifications, we yield them as is with the type "tool_notification".
-        yield {
-          type: "tool_notification",
-          created: Date.now(),
-          configurationId: agentConfiguration.sId,
-          conversationId: conversation.sId,
-          messageId: agentMessage.sId,
-          action: {
-            ...action.toJSON(),
-            // TODO(2025-08-29 aubin): cleanup as soon as the SDK type is updated.
-            output: null,
-            generatedFiles: [],
-          },
-          notification: notification.params,
-        };
       }
     }
   }

--- a/front/lib/actions/mcp_execution.ts
+++ b/front/lib/actions/mcp_execution.ts
@@ -1,7 +1,4 @@
-import type {
-  CallToolResult,
-  McpError,
-} from "@modelcontextprotocol/sdk/types.js";
+import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
 import type { Logger } from "pino";
 
 import {
@@ -16,26 +13,20 @@ import {
 } from "@app/lib/actions/action_output_limits";
 import type {
   LightMCPToolConfigurationType,
-  MCPApproveExecutionEvent,
   MCPToolConfigurationType,
   ToolNotificationEvent,
 } from "@app/lib/actions/mcp";
-import { tryCallMCPTool } from "@app/lib/actions/mcp_actions";
-import type { MCPServerPersonalAuthenticationRequiredError } from "@app/lib/actions/mcp_authentication";
 import { augmentInputsWithConfiguration } from "@app/lib/actions/mcp_internal_actions/input_configuration";
+import type { MCPProgressNotificationType } from "@app/lib/actions/mcp_internal_actions/output_schemas";
 import {
   isBlobResource,
-  isMCPProgressNotificationType,
   isResourceWithName,
   isRunAgentQueryProgressOutput,
   isStoreResourceProgressOutput,
   isToolGeneratedFile,
 } from "@app/lib/actions/mcp_internal_actions/output_schemas";
 import { handleBase64Upload } from "@app/lib/actions/mcp_utils";
-import type {
-  ActionGeneratedFileType,
-  AgentLoopRunContextType,
-} from "@app/lib/actions/types";
+import type { ActionGeneratedFileType } from "@app/lib/actions/types";
 import { processAndStoreFromUrl } from "@app/lib/api/files/upload";
 import type { Authenticator } from "@app/lib/auth";
 import { AgentMCPActionOutputItem } from "@app/lib/models/assistant/actions/mcp";
@@ -48,7 +39,6 @@ import type {
   ConversationType,
   FileUseCase,
   FileUseCaseMetadata,
-  Result,
   SupportedFileContentType,
 } from "@app/types";
 import {
@@ -59,95 +49,60 @@ import {
   stripNullBytes,
 } from "@app/types";
 
-/**
- * Executes the MCP tool and handles progress notifications.
- * Returns the tool execution result.
- */
-export async function* executeMCPTool({
-  auth,
-  inputs,
-  agentLoopRunContext,
-  action,
-  agentConfiguration,
-  conversation,
-  agentMessage,
-}: {
-  auth: Authenticator;
-  inputs: Record<string, unknown>;
-  agentLoopRunContext: AgentLoopRunContextType;
-  action: AgentMCPActionResource;
-  agentConfiguration: AgentConfigurationType;
-  conversation: ConversationType;
-  agentMessage: AgentMessageType;
-}): AsyncGenerator<
-  ToolNotificationEvent | MCPApproveExecutionEvent,
-  Result<CallToolResult["content"], Error | McpError> | null,
-  unknown
-> {
-  await action.updateStatus("running");
+export async function processToolNotification(
+  notification: MCPProgressNotificationType,
+  {
+    action,
+    agentConfiguration,
+    conversation,
+    agentMessage,
+  }: {
+    action: AgentMCPActionResource;
+    agentConfiguration: AgentConfigurationType;
+    conversation: ConversationType;
+    agentMessage: AgentMessageType;
+  }
+): Promise<ToolNotificationEvent> {
+  const output = notification.params.data.output;
 
-  let toolCallResult: Result<
-    CallToolResult["content"],
-    Error | McpError | MCPServerPersonalAuthenticationRequiredError
-  > | null = null;
-
-  for await (const event of tryCallMCPTool(auth, inputs, agentLoopRunContext, {
-    progressToken: action.id,
-  })) {
-    switch (event.type) {
-      case "result": {
-        toolCallResult = event.result;
-        break;
-      }
-      case "notification": {
-        const { notification } = event;
-        if (isMCPProgressNotificationType(notification)) {
-          const output = notification.params.data.output;
-
-          // Handle store_resource notifications by creating output items immediately
-          if (isStoreResourceProgressOutput(output)) {
-            await AgentMCPActionOutputItem.bulkCreate(
-              output.contents.map((content) => ({
-                workspaceId: action.workspaceId,
-                agentMCPActionId: action.id,
-                content,
-              }))
-            );
-          }
-
-          // Specific handling for run_agent notifications indicating the tool has
-          // started and can be resumed: the action is updated to save the resumeState.
-          if (isRunAgentQueryProgressOutput(output)) {
-            await action.updateStepContext({
-              ...action.stepContext,
-              resumeState: {
-                userMessageId: output.userMessageId,
-                conversationId: output.conversationId,
-              },
-            });
-          }
-
-          // Regular notifications, we yield them as is with the type "tool_notification".
-          yield {
-            type: "tool_notification",
-            created: Date.now(),
-            configurationId: agentConfiguration.sId,
-            conversationId: conversation.sId,
-            messageId: agentMessage.sId,
-            action: {
-              ...action.toJSON(),
-              // TODO(2025-08-29 aubin): cleanup as soon as the SDK type is updated.
-              output: null,
-              generatedFiles: [],
-            },
-            notification: notification.params,
-          };
-        }
-      }
-    }
+  // Handle store_resource notifications by creating output items immediately
+  if (isStoreResourceProgressOutput(output)) {
+    await AgentMCPActionOutputItem.bulkCreate(
+      output.contents.map((content) => ({
+        workspaceId: action.workspaceId,
+        agentMCPActionId: action.id,
+        content,
+      }))
+    );
   }
 
-  return toolCallResult;
+  // Specific handling for run_agent notifications indicating the tool has
+  // started and can be resumed: the action is updated to save the resumeState.
+  if (isRunAgentQueryProgressOutput(output)) {
+    await action.updateStepContext({
+      ...action.stepContext,
+      resumeState: {
+        userMessageId: output.userMessageId,
+        conversationId: output.conversationId,
+      },
+    });
+  }
+
+  // Regular notifications, we yield them as is with the type "tool_notification".
+  return {
+    type: "tool_notification",
+    created: Date.now(),
+    configurationId: agentConfiguration.sId,
+    conversationId: conversation.sId,
+    messageId: agentMessage.sId,
+    action: {
+      ...action.toJSON(),
+      // TODO(2025-08-29 aubin): cleanup as soon as the SDK type is updated.
+      output: null,
+      generatedFiles: [],
+    },
+    notification: notification.params,
+  };
 }
 
 /**

--- a/front/lib/actions/mcp_execution.ts
+++ b/front/lib/actions/mcp_execution.ts
@@ -49,7 +49,7 @@ import {
   stripNullBytes,
 } from "@app/types";
 
-export async function* processToolNotification(
+export async function processToolNotification(
   notification: MCPProgressNotificationType,
   {
     action,
@@ -62,7 +62,7 @@ export async function* processToolNotification(
     conversation: ConversationType;
     agentMessage: AgentMessageType;
   }
-): AsyncGenerator<ToolNotificationEvent> {
+): Promise<ToolNotificationEvent> {
   const output = notification.params.data.output;
 
   // Handle store_resource notifications by creating output items immediately
@@ -89,7 +89,7 @@ export async function* processToolNotification(
   }
 
   // Regular notifications, we yield them as is with the type "tool_notification".
-  yield {
+  return {
     type: "tool_notification",
     created: Date.now(),
     configurationId: agentConfiguration.sId,

--- a/front/lib/api/mcp/run_tool.ts
+++ b/front/lib/api/mcp/run_tool.ts
@@ -105,6 +105,9 @@ export async function* runToolWithStreaming(
     }
   );
 
+  // Err here means an exception ahead of calling the tool, like a connection error, an input
+  // validation error, or any other kind of error from MCP, but not a tool error, which are returned
+  // as content.
   if (toolCallResult.isErr()) {
     statsDClient.increment("mcp_actions_error.count", 1, tags);
     localLogger.error(

--- a/front/lib/api/mcp/run_tool.ts
+++ b/front/lib/api/mcp/run_tool.ts
@@ -89,7 +89,7 @@ export async function* runToolWithStreaming(
     toolConfiguration,
   };
 
-  const toolCallResult = yield* tryCallMCPTool(
+  const toolCallResult = await tryCallMCPTool(
     auth,
     inputs,
     agentLoopRunContext,

--- a/front/lib/api/mcp/run_tool.ts
+++ b/front/lib/api/mcp/run_tool.ts
@@ -95,7 +95,7 @@ export async function* runToolWithStreaming(
     agentLoopRunContext,
     {
       progressToken: action.id,
-      onToolNotification: (notification) =>
+      makeToolNotificationEvent: (notification) =>
         processToolNotification(notification, {
           action,
           agentConfiguration,

--- a/front/lib/api/mcp/run_tool.ts
+++ b/front/lib/api/mcp/run_tool.ts
@@ -89,7 +89,7 @@ export async function* runToolWithStreaming(
     toolConfiguration,
   };
 
-  const toolCallResult = await tryCallMCPTool(
+  const toolCallResult = yield* tryCallMCPTool(
     auth,
     inputs,
     agentLoopRunContext,


### PR DESCRIPTION
## Description

- This PR refactors the code path to call a tool to refine the typing along the way, `runToolWithStreaming` > `executeMCPTool` > `tryCallMCPTool` by removing `executeMCPTool`.
- `tryCallMCPTool` now yields the notifications and returns a non-nullable `Result`.
- This PR fixes two bugs: one with remote MCP servers where the `"MCP tool result content size too large."` error is swallowed (due to only the last result event being processed) and one with the `Too many output items` error being ignored as well (same reason).

## Tests

- Tested locally and on front-edge (tested notifications specifically).

## Risk

- Blast radius quite high given how critical the code path is.

## Deploy Plan

- Deploy front.
