### PR TITLE
[Prod Check] Parallelize GDrive GC check across data sources

### DIFF
--- a/front/lib/production_checks/checks/managed_data_source_gdrive_gc.ts
+++ b/front/lib/production_checks/checks/managed_data_source_gdrive_gc.ts
@@ -31,7 +31,7 @@ export const managedDataSourceGCGdriveCheck: CheckFunction = async (
       heartbeat();
 
       // Retrieve all documents from the connector (first) in batches using an id cursor
-      const BATCH_SIZE = 5_000;
+      const BATCH_SIZE = 1_000;
       let lastId = 0;
       const connectorDocuments: { id: number; coreDocumentId: string }[] = [];
       let fetched = 0;

--- a/front/lib/production_checks/checks/managed_data_source_gdrive_gc.ts
+++ b/front/lib/production_checks/checks/managed_data_source_gdrive_gc.ts
@@ -6,6 +6,7 @@ import {
   getConnectorsReplicaDbConnection,
   getFrontReplicaDbConnection,
 } from "@app/lib/production_checks/utils";
+import { concurrentExecutor } from "@app/lib/utils/async_utils";
 
 export const managedDataSourceGCGdriveCheck: CheckFunction = async (
   checkName,
@@ -23,67 +24,72 @@ export const managedDataSourceGCGdriveCheck: CheckFunction = async (
       { type: QueryTypes.SELECT }
     );
 
-  for (const ds of GdriveDataSources) {
-    heartbeat();
+  const CONCURRENCY = 8;
+  await concurrentExecutor(
+    GdriveDataSources,
+    async (ds) => {
+      heartbeat();
 
-    // Retrieve all documents from the connector (first) in 10k batches using an id cursor
-    const BATCH_SIZE = 5_000;
-    let lastId = 0;
-    const connectorDocuments: { id: number; coreDocumentId: string }[] = [];
-    let fetched = 0;
-    do {
-      const batch = (await connectorsReplica.query(
-        // eslint-disable-next-line dust/no-raw-sql -- Legit
-        'SELECT id, "dustFileId" as "coreDocumentId" FROM google_drive_files WHERE "connectorId" = :connectorId AND id > :lastId ORDER BY id ASC LIMIT :batchSize',
-        {
-          replacements: {
-            connectorId: ds.connectorId,
-            lastId,
-            batchSize: BATCH_SIZE,
-          },
-          type: QueryTypes.SELECT,
+      // Retrieve all documents from the connector (first) in batches using an id cursor
+      const BATCH_SIZE = 5_000;
+      let lastId = 0;
+      const connectorDocuments: { id: number; coreDocumentId: string }[] = [];
+      let fetched = 0;
+      do {
+        const batch = (await connectorsReplica.query(
+          // eslint-disable-next-line dust/no-raw-sql -- Legit
+          'SELECT id, "dustFileId" as "coreDocumentId" FROM google_drive_files WHERE "connectorId" = :connectorId AND id > :lastId ORDER BY id ASC LIMIT :batchSize',
+          {
+            replacements: {
+              connectorId: ds.connectorId,
+              lastId,
+              batchSize: BATCH_SIZE,
+            },
+            type: QueryTypes.SELECT,
+          }
+        )) as { id: number; coreDocumentId: string }[];
+
+        fetched = batch.length;
+        if (fetched > 0) {
+          connectorDocuments.push(...batch);
+          lastId = batch[fetched - 1].id;
+          heartbeat();
         }
-      )) as { id: number; coreDocumentId: string }[];
+      } while (fetched === BATCH_SIZE);
 
-      fetched = batch.length;
-      if (fetched > 0) {
-        connectorDocuments.push(...batch);
-        lastId = batch[fetched - 1].id;
-        heartbeat();
+      const connectorDocumentIds = new Set(
+        connectorDocuments.map((d) => d.coreDocumentId)
+      );
+
+      // Retrieve all documents from the connector (second). We retrieve in this order to avoid race
+      // conditions where a document would get deleted after we retrieve the core documents but before
+      // we retrieve the connectors documents. This would cause the check to fail. In the order we use
+      // here the check won't fail.
+      const coreDocumentsRes = await getCoreDocuments(ds.id);
+      if (coreDocumentsRes.isErr()) {
+        reportFailure(
+          { frontDataSourceId: ds.id },
+          "Could not get core documents"
+        );
+        return;
       }
-    } while (fetched === BATCH_SIZE);
+      const coreDocuments = coreDocumentsRes.value;
+      const coreDocumentIds = coreDocuments.map((d) => d.document_id);
 
-    const connectorDocumentIds = new Set(
-      connectorDocuments.map((d) => d.coreDocumentId)
-    );
-
-    // Retrieve all documents from the connector (second). We retrieve in this order to avoid race
-    // conditions where a document would get deleted after we retrieve the core documents but before
-    // we retrieve the connectors documents. This would cause the check to fail. In the order we use
-    // here the check won't fail.
-    const coreDocumentsRes = await getCoreDocuments(ds.id);
-    if (coreDocumentsRes.isErr()) {
-      reportFailure(
-        { frontDataSourceId: ds.id },
-        "Could not get core documents"
+      const notDeleted = coreDocumentIds.filter(
+        (coreId) => !connectorDocumentIds.has(coreId)
       );
-      continue;
-    }
-    const coreDocuments = coreDocumentsRes.value;
-    const coreDocumentIds = coreDocuments.map((d) => d.document_id);
-
-    const notDeleted = coreDocumentIds.filter(
-      (coreId) => !connectorDocumentIds.has(coreId)
-    );
-    if (notDeleted.length > 0) {
-      reportFailure(
-        { notDeleted, connectorId: ds.connectorId },
-        "Google Drive documents not properly Garbage collected"
-      );
-    } else {
-      reportSuccess({
-        connectorId: ds.connectorId,
-      });
-    }
-  }
+      if (notDeleted.length > 0) {
+        reportFailure(
+          { notDeleted, connectorId: ds.connectorId },
+          "Google Drive documents not properly Garbage collected"
+        );
+      } else {
+        reportSuccess({
+          connectorId: ds.connectorId,
+        });
+      }
+    },
+    { concurrency: CONCURRENCY }
+  );
 };


### PR DESCRIPTION
## Description

Managed google drive GC check sometimes take very long, causing production check monitor failures such as [here](https://app.datadoghq.eu/monitors/22042305?from_ts=1757511681412&to_ts=1758116481412)

This PR:
- Parallelizes managed_data_source_gdrive_gc across data sources using `concurrentExecutor` with `CONCURRENCY = 8`.
- Keeps per-DS logic the same (connector batch fetch with id-cursor, then core fetch) to preserve race-condition safety.
- Calls `heartbeat()` at start and between batches for responsiveness.
- also reduces batch size to 1K

## Risks
Blast radius: production check `managed_data_source_gdrive_gc` only.
Risk: low

## Deploy Plan
- No migrations. Deploy front; the production check runs with bounded parallelism.
