### PR TITLE
Add reaction tools to slack bot

### DIFF
--- a/front/lib/actions/mcp_internal_actions/constants.ts
+++ b/front/lib/actions/mcp_internal_actions/constants.ts
@@ -993,14 +993,17 @@ The directive should be used to display a clickable version of the agent name in
     isRestricted: ({ featureFlags }) => {
       return !featureFlags.includes("slack_bot_mcp");
     },
-    isPreview: true,
+    isPreview: false,
     tools_stakes: {
       list_public_channels: "never_ask" as const,
       list_users: "never_ask" as const,
       get_user: "never_ask" as const,
-      post_message: "low" as const,
       read_channel_history: "never_ask" as const,
       read_thread_messages: "never_ask" as const,
+
+      post_message: "low" as const,
+      add_reaction: "low" as const,
+      remove_reaction: "low" as const,
     },
     tools_retry_policies: undefined,
     timeoutMs: undefined,

--- a/front/lib/actions/mcp_internal_actions/servers/slack/slack_bot.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/slack/slack_bot.ts
@@ -293,6 +293,100 @@ const createServer = async (
     }
   );
 
+  server.tool(
+    "add_reaction",
+    "Add a reaction emoji to a message",
+    {
+      channel: z.string().describe("The channel where the message is located"),
+      timestamp: z
+        .string()
+        .describe("The timestamp of the message to react to"),
+      name: z
+        .string()
+        .describe(
+          "The name of the emoji reaction (without colons, e.g., 'thumbsup', 'heart')"
+        ),
+    },
+    async ({ channel, timestamp, name }, { authInfo }) => {
+      const accessToken = authInfo?.token;
+      if (!accessToken) {
+        throw new Error("Access token not found");
+      }
+
+      const slackClient = await getSlackClient(accessToken);
+
+      try {
+        const response = await slackClient.reactions.add({
+          channel,
+          timestamp,
+          name,
+        });
+
+        if (!response.ok) {
+          return makeMCPToolTextError(
+            `Error adding reaction: ${response.error}`
+          );
+        }
+
+        return makeMCPToolJSONSuccess({
+          message: `Successfully added ${name} reaction to message`,
+          result: response,
+        });
+      } catch (error) {
+        return makeMCPToolTextError(
+          `Error adding reaction: ${normalizeError(error)}`
+        );
+      }
+    }
+  );
+
+  server.tool(
+    "remove_reaction",
+    "Remove a reaction emoji from a message",
+    {
+      channel: z.string().describe("The channel where the message is located"),
+      timestamp: z
+        .string()
+        .describe("The timestamp of the message to remove reaction from"),
+      name: z
+        .string()
+        .describe(
+          "The name of the emoji reaction to remove (without colons, e.g., 'thumbsup', 'heart')"
+        ),
+    },
+    async ({ channel, timestamp, name }, { authInfo }) => {
+      const accessToken = authInfo?.token;
+      if (!accessToken) {
+        throw new Error("Access token not found");
+      }
+
+      const slackClient = await getSlackClient(accessToken);
+
+      try {
+        const response = await slackClient.reactions.remove({
+          channel,
+          timestamp,
+          name,
+        });
+
+        if (!response.ok) {
+          return makeMCPToolTextError(
+            `Error removing reaction: ${response.error}`
+          );
+        }
+
+        return makeMCPToolJSONSuccess({
+          message: `Successfully removed ${name} reaction from message`,
+          result: response,
+        });
+      } catch (error) {
+        return makeMCPToolTextError(
+          `Error removing reaction: ${normalizeError(error)}`
+        );
+      }
+    }
+  );
+
   return server;
 };
 

--- a/front/lib/api/oauth/providers/slack.ts
+++ b/front/lib/api/oauth/providers/slack.ts
@@ -87,7 +87,7 @@ export class SlackOAuthProvider implements BaseOAuthStrategyProvider {
           ];
 
           // TODO: This is temporary until our Slack app scope is approved.
-          if (extraConfig?.feature_flags?.includes("slack_bot_mcp")) {
+          if (extraConfig?.slack_bot_mcp_feature_flag) {
             scopes.push("reactions:read", "reactions:write");
           }
 
@@ -214,10 +214,11 @@ export class SlackOAuthProvider implements BaseOAuthStrategyProvider {
       const feature_flags = await getFeatureFlags(
         auth.getNonNullableWorkspace()
       );
-      return {
-        ...extraConfig,
-        feature_flags: JSON.stringify(feature_flags),
-      };
+      const config = { ...extraConfig };
+      if (feature_flags.includes("slack_bot_mcp")) {
+        config.slack_bot_mcp_feature_flag = "true";
+      }
+      return config;
     }
 
     return extraConfig;


### PR DESCRIPTION
## Description

* Adding reaction tools to Slack bot server
* Putting slack reaction oauth scopes behind the feature flag. Otherwise, oauth will fail until the scopes are added to the Slack app
* Removing preview indicator

## Tests

<img width="300" height="147" alt="Screenshot 2025-09-17 at 4 40 05 PM" src="https://github.com/user-attachments/assets/b980200c-8d55-47d1-979f-169074c126c3" />

## Risk

* No customer enabled yet

## Deploy Plan

* Deploy front