### PR TITLE
[front] - chore(AB): tool name refactoring

### DIFF
--- a/front/components/actions/mcp/MCPServerDetails.tsx
+++ b/front/components/actions/mcp/MCPServerDetails.tsx
@@ -70,7 +70,7 @@ export function MCPServerDetails({
 
       <Sheet open={isOpen} onOpenChange={onClose}>
         <SheetContent size="lg">
-          <SheetHeader className="flex flex-col gap-5 pb-0 text-sm text-foreground dark:text-foreground-night">
+          <SheetHeader className="flex flex-col gap-5 pb-0 text-foreground dark:text-foreground-night">
             <VisuallyHidden>
               <SheetTitle />
             </VisuallyHidden>

--- a/front/components/agent_builder/capabilities/knowledge/KnowledgeConfigurationSheet.tsx
+++ b/front/components/agent_builder/capabilities/knowledge/KnowledgeConfigurationSheet.tsx
@@ -9,14 +9,7 @@ import {
 } from "@dust-tt/sparkle";
 import { zodResolver } from "@hookform/resolvers/zod";
 import uniqueId from "lodash/uniqueId";
-import {
-  useCallback,
-  useContext,
-  useEffect,
-  useMemo,
-  useRef,
-  useState,
-} from "react";
+import { useCallback, useContext, useEffect, useMemo, useState } from "react";
 import {
   FormProvider,
   useForm,
@@ -40,7 +33,10 @@ import { isValidPage } from "@app/components/agent_builder/capabilities/mcp/util
 import { CustomCheckboxSection } from "@app/components/agent_builder/capabilities/shared/CustomCheckboxSection";
 import { DescriptionSection } from "@app/components/agent_builder/capabilities/shared/DescriptionSection";
 import { JsonSchemaSection } from "@app/components/agent_builder/capabilities/shared/JsonSchemaSection";
-import { NameSection } from "@app/components/agent_builder/capabilities/shared/NameSection";
+import {
+  NAME_FIELD_NAME,
+  NameSection,
+} from "@app/components/agent_builder/capabilities/shared/NameSection";
 import { ProcessingMethodSection } from "@app/components/agent_builder/capabilities/shared/ProcessingMethodSection";
 import { SelectedDataSources } from "@app/components/agent_builder/capabilities/shared/SelectedDataSources";
 import { TimeFrameSection } from "@app/components/agent_builder/capabilities/shared/TimeFrameSection";
@@ -258,8 +254,8 @@ function KnowledgeConfigurationSheetContent({
   isEditing,
 }: KnowledgeConfigurationSheetContentProps) {
   const { currentPageId, setSheetPageId } = useKnowledgePageContext();
-  const nameSectionRef = useRef<HTMLInputElement>(null);
-  const { setValue, getValues } = useFormContext<CapabilityFormData>();
+  const { setValue, getValues, setFocus } =
+    useFormContext<CapabilityFormData>();
   const [isAdvancedSettingsOpen, setAdvancedSettingsOpen] = useState(false);
 
   const mcpServerView = useWatch<CapabilityFormData, "mcpServerView">({
@@ -286,9 +282,12 @@ function KnowledgeConfigurationSheetContent({
   // Focus NameSection input when navigating to CONFIGURATION page
   useEffect(() => {
     if (currentPageId === CONFIGURATION_SHEET_PAGE_IDS.CONFIGURATION) {
-      nameSectionRef.current?.focus();
+      const t = setTimeout(() => {
+        setFocus(NAME_FIELD_NAME);
+      }, 250);
+      return () => clearTimeout(t);
     }
-  }, [currentPageId]);
+  }, [currentPageId, setFocus]);
 
   // Prefill name field with processing method display name when mcpServerView changes
   useEffect(() => {
@@ -375,11 +374,7 @@ function KnowledgeConfigurationSheetContent({
         <div className="space-y-6">
           <ProcessingMethodSection />
 
-          <NameSection
-            ref={nameSectionRef}
-            title="Name"
-            placeholder="Name ..."
-          />
+          <NameSection title="Name" placeholder="Name ..." />
 
           {toolsConfigurations.mayRequireTimeFrameConfiguration && (
             <TimeFrameSection actionType="extract" />

--- a/front/components/agent_builder/capabilities/mcp/MCPActionHeader.tsx
+++ b/front/components/agent_builder/capabilities/mcp/MCPActionHeader.tsx
@@ -38,7 +38,7 @@ export function MCPActionHeader({
   };
 
   return (
-    <div className="flex w-full flex-row items-center justify-between">
+    <div className="flex w-full flex-col items-start gap-4">
       <div className="flex flex-col items-center gap-3 sm:flex-row">
         {getAvatar(mcpServerView.server, "md")}
         <div className="flex grow flex-col gap-0 pr-9">
@@ -51,31 +51,24 @@ export function MCPActionHeader({
         </div>
       </div>
       {allowNameEdit && (
-        <Popover
-          trigger={<Button icon={MoreIcon} size="sm" variant="ghost" />}
-          popoverTriggerAsChild
-          onAnimationEnd={onClose}
-          content={
-            <div className="flex flex-col gap-4">
-              <div className="flex flex-col items-end gap-2">
-                <div className="w-full grow text-sm font-bold text-muted-foreground dark:text-muted-foreground-night">
-                  Name of the tool
-                </div>
-              </div>
-              <Input
-                {...form.register("name", {
-                  onChange: () => {
-                    void form.trigger("name");
-                  },
-                })}
-                placeholder="My tool name…"
-                message={error?.message}
-                messageStatus="error"
-                className="text-sm"
-              />
+        <div className="flex w-full flex-col gap-4">
+          <div className="flex flex-col items-end gap-2">
+            <div className="w-full grow text-sm font-bold text-muted-foreground dark:text-muted-foreground-night">
+              Name of the tool
             </div>
-          }
-        />
+          </div>
+          <Input
+            {...form.register("name", {
+              onChange: () => {
+                void form.trigger("name");
+              },
+            })}
+            placeholder="My tool name…"
+            message={error?.message}
+            messageStatus="error"
+            className="text-sm"
+          />
+        </div>
       )}
     </div>
   );

--- a/front/components/agent_builder/capabilities/mcp/MCPActionHeader.tsx
+++ b/front/components/agent_builder/capabilities/mcp/MCPActionHeader.tsx
@@ -1,5 +1,4 @@
-import { Button, Input, MoreIcon, Popover } from "@dust-tt/sparkle";
-import { useFormContext, useWatch } from "react-hook-form";
+import { useWatch } from "react-hook-form";
 
 import type {
   AgentBuilderAction,
@@ -12,25 +11,13 @@ import type { MCPServerViewType } from "@app/lib/api/mcp";
 interface MCPActionHeaderProps {
   mcpServerView: MCPServerViewType;
   action: AgentBuilderAction;
-  allowNameEdit?: boolean;
 }
 
 export function MCPActionHeader({
   mcpServerView,
   action,
-  allowNameEdit = false,
 }: MCPActionHeaderProps) {
-  const form = useFormContext<MCPFormData>();
-  const error = form.formState.errors.name;
-  const newName = useWatch({ name: "name" });
-
-  // Reset the form with default value if there is an error when popup is closed
-  const onClose = () => {
-    if (error) {
-      form.setValue("name", form.formState.defaultValues?.name ?? "");
-      form.clearErrors("name");
-    }
-  };
+  const newName = useWatch<MCPFormData, "name">({ name: "name" });
 
   const newAction = {
     ...action,
@@ -50,26 +37,6 @@ export function MCPActionHeader({
           </p>
         </div>
       </div>
-      {allowNameEdit && (
-        <div className="flex w-full flex-col gap-4">
-          <div className="flex flex-col items-end gap-2">
-            <div className="w-full grow text-sm font-bold text-muted-foreground dark:text-muted-foreground-night">
-              Name of the tool
-            </div>
-          </div>
-          <Input
-            {...form.register("name", {
-              onChange: () => {
-                void form.trigger("name");
-              },
-            })}
-            placeholder="My tool name…"
-            message={error?.message}
-            messageStatus="error"
-            className="text-sm"
-          />
-        </div>
-      )}
     </div>
   );
 }

--- a/front/components/agent_builder/capabilities/mcp/MCPServerViewsSheet.tsx
+++ b/front/components/agent_builder/capabilities/mcp/MCPServerViewsSheet.tsx
@@ -53,6 +53,7 @@ import { AdditionalConfigurationSection } from "@app/components/agent_builder/ca
 import { ChildAgentSection } from "@app/components/agent_builder/capabilities/shared/ChildAgentSection";
 import { DustAppSection } from "@app/components/agent_builder/capabilities/shared/DustAppSection";
 import { JsonSchemaSection } from "@app/components/agent_builder/capabilities/shared/JsonSchemaSection";
+import { NameSection } from "@app/components/agent_builder/capabilities/shared/NameSection";
 import { ReasoningModelSection } from "@app/components/agent_builder/capabilities/shared/ReasoningModelSection";
 import { TimeFrameSection } from "@app/components/agent_builder/capabilities/shared/TimeFrameSection";
 import type { MCPServerViewTypeWithLabel } from "@app/components/agent_builder/MCPServerViewsContext";
@@ -598,8 +599,15 @@ export function MCPServerViewsSheet({
                 <MCPActionHeader
                   action={configurationTool}
                   mcpServerView={mcpServerView}
-                  allowNameEdit={configurationTool.configurable}
                 />
+
+                {configurationTool.configurable && (
+                  <NameSection
+                    title="Name"
+                    placeholder="My tool name…"
+                    triggerValidationOnChange
+                  />
+                )}
 
                 {toolsConfigurations.mayRequireReasoningConfiguration && (
                   <ReasoningModelSection />

--- a/front/components/agent_builder/capabilities/shared/BaseFormFieldSection.tsx
+++ b/front/components/agent_builder/capabilities/shared/BaseFormFieldSection.tsx
@@ -39,7 +39,6 @@ export function BaseFormFieldSection<
   } = register(fieldName);
 
   const registerRefCallback = (e: E | null) => {
-    // The ref provided by react-hook-form accepts any instance; providing E | null is safe.
     registerRef(e);
   };
 

--- a/front/components/agent_builder/capabilities/shared/BaseFormFieldSection.tsx
+++ b/front/components/agent_builder/capabilities/shared/BaseFormFieldSection.tsx
@@ -1,0 +1,89 @@
+import type { ChangeEvent } from "react";
+import type { UseFormRegisterReturn } from "react-hook-form";
+import { useController, useFormContext } from "react-hook-form";
+
+interface BaseFormFieldSectionProps<
+  E extends HTMLInputElement | HTMLTextAreaElement,
+> {
+  title?: string;
+  description?: string;
+  helpText?: string;
+  fieldName: string;
+  triggerValidationOnChange?: boolean;
+  children: (args: {
+    registerRef: (e: E | null) => void;
+    registerProps: Omit<UseFormRegisterReturn, "onChange" | "ref">;
+    onChange: (e: ChangeEvent<E>) => void;
+    errorMessage?: string;
+    hasError: boolean;
+  }) => React.ReactNode;
+}
+
+export function BaseFormFieldSection<
+  E extends HTMLInputElement | HTMLTextAreaElement,
+>({
+  title,
+  description,
+  helpText,
+  fieldName,
+  triggerValidationOnChange = false,
+  children,
+}: BaseFormFieldSectionProps<E>) {
+  const { register, trigger } = useFormContext();
+  const { fieldState } = useController({ name: fieldName });
+
+  const {
+    ref: registerRef,
+    onChange: registerOnChange,
+    ...restRegisterProps
+  } = register(fieldName);
+
+  const registerRefCallback = (e: E | null) => {
+    // The ref provided by react-hook-form accepts any instance; providing E | null is safe.
+    registerRef(e);
+  };
+
+  const registerProps: Omit<UseFormRegisterReturn, "onChange" | "ref"> =
+    restRegisterProps;
+
+  const onChange = (e: ChangeEvent<E>) => {
+    void registerOnChange?.(e);
+    if (triggerValidationOnChange) {
+      void trigger(fieldName);
+    }
+  };
+
+  return (
+    <div className="space-y-4">
+      {(!!title || !!description) && (
+        <div>
+          {title && (
+            <h3 className="heading-base font-semibold text-foreground dark:text-foreground-night">
+              {title}
+            </h3>
+          )}
+          {description && (
+            <p className="text-sm text-muted-foreground dark:text-muted-foreground-night">
+              {description}
+            </p>
+          )}
+        </div>
+      )}
+
+      <div className="space-y-2">
+        {children({
+          registerRef: registerRefCallback,
+          registerProps,
+          onChange,
+          errorMessage: fieldState.error?.message,
+          hasError: !!fieldState.error,
+        })}
+        {helpText && (
+          <p className="text-xs text-muted-foreground dark:text-muted-foreground-night">
+            {helpText}
+          </p>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/front/components/agent_builder/capabilities/shared/DescriptionSection.tsx
+++ b/front/components/agent_builder/capabilities/shared/DescriptionSection.tsx
@@ -1,7 +1,5 @@
 import { TextArea } from "@dust-tt/sparkle";
-import { useController, useFormContext } from "react-hook-form";
-
-import type { CapabilityFormData } from "@app/components/agent_builder/types";
+import { BaseFormFieldSection } from "@app/components/agent_builder/capabilities/shared/BaseFormFieldSection";
 
 interface DescriptionSectionProps {
   title: string;
@@ -9,40 +7,43 @@ interface DescriptionSectionProps {
   label?: string;
   placeholder: string;
   maxLength?: number;
+  fieldName?: string; // defaults to "description"
+  triggerValidationOnChange?: boolean;
 }
 
-const FIELD_NAME = "description";
+const DEFAULT_FIELD_NAME = "description" as const;
 
 export function DescriptionSection({
   title,
   description,
   label,
   placeholder,
+  maxLength,
+  fieldName = DEFAULT_FIELD_NAME,
+  triggerValidationOnChange = false,
 }: DescriptionSectionProps) {
-  const { register } = useFormContext();
-  const { fieldState } = useController<CapabilityFormData, typeof FIELD_NAME>({
-    name: FIELD_NAME,
-  });
-
   return (
-    <div className="space-y-4">
-      <div>
-        <h3 className="mb-2 text-lg font-semibold">{title}</h3>
-        <p className="text-sm text-muted-foreground dark:text-muted-foreground-night">
-          {description}
-        </p>
-      </div>
-
-      <div className="space-y-2">
-        {label && <label className="text-sm font-medium">{label}</label>}
-        <TextArea
-          placeholder={placeholder}
-          {...register(FIELD_NAME)}
-          rows={4}
-          showErrorLabel={true}
-          error={fieldState.error?.message}
-        />
-      </div>
-    </div>
+    <BaseFormFieldSection<HTMLTextAreaElement>
+      title={title}
+      description={description}
+      fieldName={fieldName}
+      triggerValidationOnChange={triggerValidationOnChange}
+    >
+      {({ registerRef, registerProps, onChange, errorMessage }) => (
+        <>
+          {label && <label className="text-sm font-medium">{label}</label>}
+          <TextArea
+            ref={registerRef}
+            placeholder={placeholder}
+            rows={4}
+            maxLength={maxLength}
+            showErrorLabel={true}
+            error={errorMessage}
+            onChange={onChange}
+            {...registerProps}
+          />
+        </>
+      )}
+    </BaseFormFieldSection>
   );
 }

--- a/front/components/agent_builder/capabilities/shared/DescriptionSection.tsx
+++ b/front/components/agent_builder/capabilities/shared/DescriptionSection.tsx
@@ -1,4 +1,5 @@
 import { TextArea } from "@dust-tt/sparkle";
+
 import { BaseFormFieldSection } from "@app/components/agent_builder/capabilities/shared/BaseFormFieldSection";
 
 interface DescriptionSectionProps {
@@ -7,11 +8,10 @@ interface DescriptionSectionProps {
   label?: string;
   placeholder: string;
   maxLength?: number;
-  fieldName?: string; // defaults to "description"
   triggerValidationOnChange?: boolean;
 }
 
-const DEFAULT_FIELD_NAME = "description" as const;
+const DESCRIPTION_FIELD_NAME = "description";
 
 export function DescriptionSection({
   title,
@@ -19,14 +19,13 @@ export function DescriptionSection({
   label,
   placeholder,
   maxLength,
-  fieldName = DEFAULT_FIELD_NAME,
   triggerValidationOnChange = false,
 }: DescriptionSectionProps) {
   return (
-    <BaseFormFieldSection<HTMLTextAreaElement>
+    <BaseFormFieldSection
       title={title}
       description={description}
-      fieldName={fieldName}
+      fieldName={DESCRIPTION_FIELD_NAME}
       triggerValidationOnChange={triggerValidationOnChange}
     >
       {({ registerRef, registerProps, onChange, errorMessage }) => (
@@ -37,7 +36,7 @@ export function DescriptionSection({
             placeholder={placeholder}
             rows={4}
             maxLength={maxLength}
-            showErrorLabel={true}
+            showErrorLabel
             error={errorMessage}
             onChange={onChange}
             {...registerProps}

--- a/front/components/agent_builder/capabilities/shared/NameSection.tsx
+++ b/front/components/agent_builder/capabilities/shared/NameSection.tsx
@@ -1,66 +1,62 @@
 import { Input } from "@dust-tt/sparkle";
 import { forwardRef } from "react";
-import { useController, useFormContext } from "react-hook-form";
 
-import type { CapabilityFormData } from "@app/components/agent_builder/types";
+import { BaseFormFieldSection } from "@app/components/agent_builder/capabilities/shared/BaseFormFieldSection";
 
 interface NameSectionProps {
-  title: string;
+  title?: string;
   description?: string;
   label?: string;
   placeholder: string;
   helpText?: string;
+  triggerValidationOnChange?: boolean;
 }
 
-const FIELD_NAME = "name";
+const DEFAULT_FIELD_NAME = "name";
 
 export const NameSection = forwardRef<HTMLInputElement, NameSectionProps>(
-  ({ title, description, label, placeholder, helpText }, ref) => {
-    const { register } = useFormContext();
-    const { fieldState } = useController<CapabilityFormData, typeof FIELD_NAME>(
-      {
-        name: FIELD_NAME,
-      }
-    );
-
-    const { ref: registerRef, ...registerProps } = register(FIELD_NAME);
-
+  (
+    {
+      title,
+      description,
+      label,
+      placeholder,
+      helpText,
+      triggerValidationOnChange = false,
+    },
+    ref
+  ) => {
     return (
-      <div className="space-y-4">
-        <div>
-          <h3 className="mb-2 text-lg font-semibold">{title}</h3>
-          {description && (
-            <p className="text-sm text-muted-foreground dark:text-muted-foreground-night">
-              {description}
-            </p>
-          )}
-        </div>
-
-        <div className="space-y-2">
-          <Input
-            ref={(e) => {
-              registerRef(e);
-              if (ref) {
-                if (typeof ref === "function") {
-                  ref(e);
-                } else {
-                  ref.current = e;
+      <BaseFormFieldSection<HTMLInputElement>
+        title={title}
+        description={description}
+        helpText={helpText}
+        fieldName={DEFAULT_FIELD_NAME}
+        triggerValidationOnChange={triggerValidationOnChange}
+      >
+        {({ registerRef, registerProps, onChange, errorMessage, hasError }) => {
+          return (
+            <Input
+              ref={(e) => {
+                registerRef(e);
+                if (ref) {
+                  if (typeof ref === "function") {
+                    ref(e);
+                  } else {
+                    ref.current = e;
+                  }
                 }
-              }
-            }}
-            placeholder={placeholder}
-            {...registerProps}
-            label={label}
-            message={fieldState.error?.message}
-            messageStatus={fieldState.error ? "error" : "default"}
-          />
-          {helpText && (
-            <p className="text-xs text-muted-foreground dark:text-muted-foreground-night">
-              {helpText}
-            </p>
-          )}
-        </div>
-      </div>
+              }}
+              placeholder={placeholder}
+              label={label}
+              onChange={onChange}
+              message={errorMessage}
+              messageStatus={hasError ? "error" : "default"}
+              {...registerProps}
+            />
+          );
+        }}
+      </BaseFormFieldSection>
     );
   }
 );

--- a/front/components/agent_builder/capabilities/shared/NameSection.tsx
+++ b/front/components/agent_builder/capabilities/shared/NameSection.tsx
@@ -12,7 +12,7 @@ interface NameSectionProps {
   triggerValidationOnChange?: boolean;
 }
 
-const DEFAULT_FIELD_NAME = "name";
+export const NAME_FIELD_NAME = "name";
 
 export const NameSection = forwardRef<HTMLInputElement, NameSectionProps>(
   (
@@ -27,11 +27,11 @@ export const NameSection = forwardRef<HTMLInputElement, NameSectionProps>(
     ref
   ) => {
     return (
-      <BaseFormFieldSection<HTMLInputElement>
+      <BaseFormFieldSection
         title={title}
         description={description}
         helpText={helpText}
-        fieldName={DEFAULT_FIELD_NAME}
+        fieldName={NAME_FIELD_NAME}
         triggerValidationOnChange={triggerValidationOnChange}
       >
         {({ registerRef, registerProps, onChange, errorMessage, hasError }) => {


### PR DESCRIPTION
## Description

This PR refactors the agent builder MCP tool name editing UI by moving from a popover-based approach to a dedicated inline form component. The changes include creating a new BaseFormFieldSection component for consistent form field handling and updating the NameSection and DescriptionSection components to use this shared foundation. The MCP action header layout is also simplified by removing the popover-based tool name editing and moving it to a centralized component in the configuration sheet.

**References:**
- https://github.com/dust-tt/tasks/issues/4197

## Tests

Locally

## Risk

Low

## Deploy Plan

Deploy front
