### PR TITLE
[front] Rename `toolName` parameter with `functionCallName` in tests

### DIFF
--- a/front/lib/actions/utils.test.ts
+++ b/front/lib/actions/utils.test.ts
@@ -607,11 +607,11 @@ describe("Tool validation utilities", () => {
       }
 
       // Try to add duplicates and verify no changes
-      for (const tool of functionCallNames) {
+      for (const functionCallName of functionCallNames) {
         await setUserAlwaysApprovedTool({
           user,
           mcpServerId,
-          functionCallName: tool,
+          functionCallName,
         });
       }
 

--- a/front/lib/actions/utils.ts
+++ b/front/lib/actions/utils.ts
@@ -279,7 +279,7 @@ export async function getExecutionStatusFromConfig(
         (await hasUserAlwaysApprovedTool({
           user,
           mcpServerId: actionConfiguration.toolServerId,
-          toolName: actionConfiguration.name,
+          functionCallName: actionConfiguration.name,
         }))
       ) {
         return { status: "ready_allowed_implicitly" };
@@ -308,7 +308,7 @@ export async function setUserAlwaysApprovedTool({
   functionCallName: string;
 }) {
   if (!functionCallName) {
-    throw new Error("toolName is required");
+    throw new Error("functionCallName is required");
   }
   if (!mcpServerId) {
     throw new Error("mcpServerId is required");
@@ -323,24 +323,25 @@ export async function setUserAlwaysApprovedTool({
 export async function hasUserAlwaysApprovedTool({
   user,
   mcpServerId,
-  toolName,
+  functionCallName,
 }: {
   user: UserResource;
   mcpServerId: string;
-  toolName: string;
+  functionCallName: string;
 }) {
   if (!mcpServerId) {
     throw new Error("mcpServerId is required");
   }
 
-  if (!toolName) {
-    throw new Error("toolName is required");
+  if (!functionCallName) {
+    throw new Error("functionCallName is required");
   }
 
   const metadata = await user.getMetadataAsArray(
     getToolsValidationKey(mcpServerId)
   );
   return (
-    metadata.includes(toolName) || metadata.includes(TOOLS_VALIDATION_WILDCARD)
+    metadata.includes(functionCallName) ||
+    metadata.includes(TOOLS_VALIDATION_WILDCARD)
   );
 }

--- a/front/lib/actions/utils.ts
+++ b/front/lib/actions/utils.ts
@@ -298,6 +298,8 @@ const TOOLS_VALIDATION_WILDCARD = "*";
 const getToolsValidationKey = (mcpServerId: string) =>
   `toolsValidations:${mcpServerId}`;
 
+// The function call name is scoped by MCP servers so that the same tool name on different servers
+// does not conflict, which is why we use it here instead of the tool name.
 export async function setUserAlwaysApprovedTool({
   user,
   mcpServerId,


### PR DESCRIPTION
## Description

- This PR renames the `toolName` parameter in `setUserAlwaysApprovedTool` in the tests to `functionCallName` to match the signature (we do store the function call name in prod).

## Tests

- The change is on the tests, they do test the same thing.

## Risk

- Low, only a renaming.

## Deploy Plan

- Deploy front.
