### PR TITLE
Handle errors in markdown

### DIFF
--- a/sparkle/src/components/markdown/Markdown.tsx
+++ b/sparkle/src/components/markdown/Markdown.tsx
@@ -10,7 +10,7 @@ import remarkGfm from "remark-gfm";
 import remarkMath from "remark-math";
 import { visit } from "unist-util-visit";
 
-import { Checkbox } from "@sparkle/components";
+import { Checkbox, Chip } from "@sparkle/components";
 import { BlockquoteBlock } from "@sparkle/components/markdown/BlockquoteBlock";
 import { CodeBlockWithExtendedSupport } from "@sparkle/components/markdown/CodeBlockWithExtendedSupport";
 import { LiBlock, OlBlock, UlBlock } from "@sparkle/components/markdown/List";
@@ -219,26 +219,37 @@ export function Markdown({
 
   const rehypePlugins = [[rehypeKatex, { output: "mathml" }]] as PluggableList;
 
-  return (
-    <div className={cn("s-w-full", isStreaming ? "s-blinking-cursor" : "")}>
-      <MarkdownContentContext.Provider
-        value={{
-          content: processedContent,
-          isStreaming,
-          isLastMessage,
-        }}
-      >
-        <ReactMarkdown
-          linkTarget="_blank"
-          components={markdownComponents}
-          remarkPlugins={markdownPlugins}
-          rehypePlugins={rehypePlugins}
+  try {
+    return (
+      <div className={cn("s-w-full", isStreaming ? "s-blinking-cursor" : "")}>
+        <MarkdownContentContext.Provider
+          value={{
+            content: processedContent,
+            isStreaming,
+            isLastMessage,
+          }}
         >
-          {processedContent}
-        </ReactMarkdown>
-      </MarkdownContentContext.Provider>
-    </div>
-  );
+          <ReactMarkdown
+            linkTarget="_blank"
+            components={markdownComponents}
+            remarkPlugins={markdownPlugins}
+            rehypePlugins={rehypePlugins}
+          >
+            {processedContent}
+          </ReactMarkdown>
+        </MarkdownContentContext.Provider>
+      </div>
+    );
+  } catch (error) {
+    return (
+      <div className={cn("s-w-full", isStreaming ? "s-blinking-cursor" : "")}>
+        <Chip color="warning">
+          There was an error parsing this markdown content
+        </Chip>
+        {processedContent}
+      </div>
+    );
+  }
 }
 
 function LinkBlock({


### PR DESCRIPTION
## Description

Update Markdown component to avoid breaking the whole page when there is an error parsing the markdown.
Fixes https://app.datadoghq.eu/logs?query=service%3Afront-browser%20%22TypeError%3A%20Cannot%20read%20properties%20of%20undefined%20%28reading%20%27className%27%29%22&agg_m=count&agg_m_source=base&agg_t=count&cols=host%2Cservice&messageDisplay=inline&refresh_mode=sliding&storage=hot&stream_sort=desc&viz=stream&from_ts=1756890275397&to_ts=1758186275397&live=true

## Tests

Locally

## Risk

Low

## Deploy Plan

Deploy sparkle