### PR TITLE
chore(core): add bacon to allow auto reload of core

### DIFF
--- a/core/bacon.toml
+++ b/core/bacon.toml
@@ -1,0 +1,28 @@
+# This is a configuration file for the bacon tool
+#
+# Complete help on configuration: https://dystroy.org/bacon/config/
+#
+# You may check the current default at
+#   https://github.com/Canop/bacon/blob/main/defaults/default-bacon.toml
+
+default_job = "core-api"
+env.CARGO_TERM_COLOR = "always"
+
+[jobs.test]
+command = ["cargo", "test", "--all"]
+need_stdout = true
+
+[jobs.core-api]
+command = ["cargo", "run", "--bin", "core-api"]
+need_stdout = true
+allow_warnings = true
+
+[jobs.oauth]
+command = ["cargo", "run", "--bin", "oauth"]
+need_stdout = true
+allow_warnings = true
+
+[jobs.sqlite-worker]
+command = ["cargo", "run", "--bin", "sqlite-worker"]
+need_stdout = true
+allow_warnings = true

--- a/tools/mprocs.yaml
+++ b/tools/mprocs.yaml
@@ -1,10 +1,16 @@
 # Configuration for mprocs to run the dev environment locally.
-# Requirements: mprocs (`brew install mprocs`)
-# ⚠️ you need to restart front-workers after sdks-js is loaded: select front-workers in the mprocs window and press r
+# Requirements:
+# * mprocs (`brew install mprocs`)
+# * bacon (`cargo install bacon`)
+
+# ⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️
+# you need to restart front-workers after sdks-js is loaded: select front-workers in the mprocs window and press r
+# ⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️
+
 procs:
   core:
     cwd: "<CONFIG_DIR>/../core"
-    shell: "./admin/dev.sh"
+    shell: "bacon core-api"
   sqlite-workers:
     cwd: "<CONFIG_DIR>/../core"
     env:
@@ -12,10 +18,10 @@ procs:
       IS_LOCAL_DEV: "1"
       DATABASES_STORE_DATABASE_URI: "postgresql://dev:dev@localhost:5432/dust_databases_store"
       CORE_API_KEY: "soupinou"
-    shell: "cargo run --bin sqlite-worker"
+    shell: "bacon sqlite-worker"
   oauth:
     cwd: "<CONFIG_DIR>/../core"
-    shell: "./admin/dev_oauth.sh"
+    shell: "bacon oauth"
   front:
     cwd: "<CONFIG_DIR>/../front"
     shell: "./admin/dev.sh"


### PR DESCRIPTION
## Description

Add [bacon](https://dystroy.org/bacon/config/#project-settings) for `core`. 

It's a tool that watches for rust file changes and run command. It allows auto reload of our rust code. No need to relaunch
I've integrated it with `mprocs` for more awesomeness

## Tests

Locally

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
