### PR TITLE
[front] ab: fix duplicate agent editors

### DIFF
--- a/front/components/agent_builder/AgentBuilder.tsx
+++ b/front/components/agent_builder/AgentBuilder.tsx
@@ -188,10 +188,10 @@ export default function AgentBuilder({
       agentSettings: {
         ...baseValues.agentSettings,
         slackProvider,
-        // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
         editors: duplicateAgentId
           ? [user]
-          : agentConfiguration || editors.length > 0
+          : // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
+            agentConfiguration || editors.length > 0
             ? editors
             : [user],
         slackChannels: agentSlackChannels,

--- a/front/components/agent_builder/AgentBuilder.tsx
+++ b/front/components/agent_builder/AgentBuilder.tsx
@@ -189,7 +189,10 @@ export default function AgentBuilder({
         ...baseValues.agentSettings,
         slackProvider,
         // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
-        editors: agentConfiguration || editors.length > 0 ? editors : [user],
+        editors:
+          duplicateAgentId || editors.length === 0 || !agentConfiguration
+            ? [user]
+            : editors,
         slackChannels: agentSlackChannels,
       },
     };

--- a/front/components/agent_builder/AgentBuilder.tsx
+++ b/front/components/agent_builder/AgentBuilder.tsx
@@ -189,10 +189,11 @@ export default function AgentBuilder({
         ...baseValues.agentSettings,
         slackProvider,
         // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
-        editors:
-          duplicateAgentId || editors.length === 0 || !agentConfiguration
-            ? [user]
-            : editors,
+        editors: duplicateAgentId
+          ? [user]
+          : agentConfiguration || editors.length > 0
+            ? editors
+            : [user],
         slackChannels: agentSlackChannels,
       },
     };


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

When duplicating an agent, we don't compute editors right.
We should only add the user duplicating the agent to the list.
Currently, we're duplicating the old list, which means the duplicant can not edit or save the duplicated agent.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

Tested by hand.

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

Low

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->

Deploy front