### PR TITLE
Skip sending openai encrypted metadata across region

### DIFF
--- a/core/src/providers/anthropic/types.rs
+++ b/core/src/providers/anthropic/types.rs
@@ -291,6 +291,7 @@ impl TryFrom<ChatResponse> for AssistantChatMessage {
                         value: ReasoningContent {
                             reasoning: Some(thinking.thinking),
                             metadata: metadata.to_string(),
+                            region: None,
                         },
                     });
                 }
@@ -303,6 +304,7 @@ impl TryFrom<ChatResponse> for AssistantChatMessage {
                         value: ReasoningContent {
                             reasoning: None,
                             metadata: metadata.to_string(),
+                            region: None,
                         },
                     });
                 }

--- a/core/src/providers/chat_messages.rs
+++ b/core/src/providers/chat_messages.rs
@@ -73,6 +73,8 @@ pub struct ReasoningContent {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub reasoning: Option<String>,
     pub metadata: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub region: Option<String>,
 }
 
 #[derive(Debug, Serialize, Deserialize, PartialEq, Clone)]

--- a/core/src/providers/embedder.rs
+++ b/core/src/providers/embedder.rs
@@ -131,7 +131,7 @@ impl EmbedderRequest {
                 Ok(c)
             }
             Err(e) => Err(anyhow!(
-                "Embedder: Error querying `{}:{}`: error={}",
+                "Error querying `{}:{}`: error={}",
                 self.provider_id.to_string(),
                 self.model_id,
                 e.to_string(),

--- a/core/src/providers/openai.rs
+++ b/core/src/providers/openai.rs
@@ -1105,6 +1105,7 @@ impl LLM for OpenAILLM {
                 event_sender,
                 transform_system_messages,
                 provider_name,
+                use_openai_eu_host,
             )
             .await
         } else {

--- a/core/src/providers/openai_responses_api_helpers.rs
+++ b/core/src/providers/openai_responses_api_helpers.rs
@@ -291,6 +291,7 @@ fn responses_api_input_from_chat_messages(
                                 warn!(
                                     region,
                                     use_openai_eu_host,
+                                    model = assistant_msg.name.as_deref().unwrap_or("unknown"),
                                     "Skipping reasoning metadata due to region mismatch. This is expected if a conversation was started with OpenAI US and is now being continued with OpenAI EU, or vice versa."
                                 );
                                 continue;

--- a/front/lib/api/config.ts
+++ b/front/lib/api/config.ts
@@ -272,6 +272,9 @@ const config = {
       "UNTRUSTED_EGRESS_PROXY_PORT"
     );
   },
+  getDustManagedOpenAIAPIKeyEU: (): string => {
+    return EnvironmentConfig.getEnvVariable("DUST_MANAGED_OPENAI_API_KEY_EU");
+  },
 };
 
 export default config;

--- a/front/lib/api/config.ts
+++ b/front/lib/api/config.ts
@@ -272,8 +272,10 @@ const config = {
       "UNTRUSTED_EGRESS_PROXY_PORT"
     );
   },
-  getDustManagedOpenAIAPIKeyEU: (): string => {
-    return EnvironmentConfig.getEnvVariable("DUST_MANAGED_OPENAI_API_KEY_EU");
+  getDustManagedOpenAIAPIKeyEU: (): string | undefined => {
+    return EnvironmentConfig.getOptionalEnvVariable(
+      "DUST_MANAGED_OPENAI_API_KEY_EU"
+    );
   },
 };
 

--- a/front/pages/api/v1/w/[wId]/spaces/[spaceId]/apps/[aId]/runs/index.ts
+++ b/front/pages/api/v1/w/[wId]/spaces/[spaceId]/apps/[aId]/runs/index.ts
@@ -278,7 +278,7 @@ async function handler(
       // 2) We use the DUST_MANAGED_OPENAI_API_KEY_EU env as the key
       let useOpenAIEUKey =
         keyWorkspaceFlags.includes("use_openai_eu_key") &&
-        !!process.env.DUST_MANAGED_OPENAI_API_KEY_EU;
+        !!apiConfig.getDustManagedOpenAIAPIKeyEU();
 
       let credentials: CredentialsType | null = null;
       if (auth.isSystemKey() && !useWorkspaceCredentials) {

--- a/front/temporal/agent_loop/lib/run_model.ts
+++ b/front/temporal/agent_loop/lib/run_model.ts
@@ -600,7 +600,7 @@ export async function runModelActivity(
             cached_tokens?: number;
           };
         } | null;
-        const reasoningTokens = meta?.token_usage?.reasoning_tokens ?? 0;
+        const reasoningTokens = meta?.token_usage?.reasoning_tokens || 0;
 
         // Determine the region based on feature flag and current region
         let region = "us";

--- a/front/temporal/agent_loop/lib/run_model.ts
+++ b/front/temporal/agent_loop/lib/run_model.ts
@@ -31,8 +31,10 @@ import { renderConversationForModel } from "@app/lib/api/assistant/preprocessing
 import config from "@app/lib/api/config";
 import { DEFAULT_MCP_TOOL_RETRY_POLICY } from "@app/lib/api/mcp";
 import { getRedisClient } from "@app/lib/api/redis";
+import { config as regionsConfig } from "@app/lib/api/regions/config";
 import { getSupportedModelConfig } from "@app/lib/assistant";
 import type { Authenticator } from "@app/lib/auth";
+import { getFeatureFlags } from "@app/lib/auth";
 import { cloneBaseConfig, getDustProdAction } from "@app/lib/registry";
 import { AgentStepContentResource } from "@app/lib/resources/agent_step_content_resource";
 import { MCPServerViewResource } from "@app/lib/resources/mcp_server_view_resource";
@@ -598,7 +600,21 @@ export async function runModelActivity(
             cached_tokens?: number;
           };
         } | null;
-        const reasoningTokens = meta?.token_usage?.reasoning_tokens || 0;
+        const reasoningTokens = meta?.token_usage?.reasoning_tokens ?? 0;
+
+        // Determine the region based on feature flag and current region
+        let region = "us";
+        const workspace = auth.getNonNullableWorkspace();
+        const featureFlags = await getFeatureFlags(workspace);
+
+        if (featureFlags.includes("use_openai_eu_key")) {
+          const currentRegion = regionsConfig.getCurrentRegion();
+          if (currentRegion === "europe-west1") {
+            region = "eu";
+          } else if (currentRegion === "us-central1") {
+            region = "us";
+          }
+        }
 
         const contents = (block.message.contents ?? []).map((content) => {
           if (content.type === "reasoning") {
@@ -608,6 +624,7 @@ export async function runModelActivity(
                 ...content.value,
                 tokens: 0, // Will be updated for the last reasoning item
                 provider: model.providerId,
+                region,
               },
             } satisfies ReasoningContentType;
           }

--- a/front/types/assistant/agent_message_content.ts
+++ b/front/types/assistant/agent_message_content.ts
@@ -15,6 +15,7 @@ export type ReasoningContentType = {
     metadata: string;
     tokens: number;
     provider: ModelProviderIdType;
+    region?: string | null;
   };
 };
 


### PR DESCRIPTION
## Description

OpenAI gives us Reasoning encrypted metadata that we store and send back to them on follow-up messages. The challenge is that when a conversation is started with the US OpenAI endpoint, and continued with the EU endpoint (or vice versa), the encrypted metadata blows up because OpenAI uses different keys.

When we detect this situation, we simply don't send the Reasoning metadata. It may degrade LLM perf a bit, but is the best we can do. Over time, this should become a very rare case as new convos in Dust EU will hit OpenAI EU to begin with.

## Tests

Manual

## Risk

Small, under flag.

## Deploy Plan

Core and Front.