### PR TITLE
[Production Checks] Add retries to GDrive GC check to mitigate replica recovery conflicts

### DIFF
--- a/connectors/migrations/db/migration_72.sql
+++ b/connectors/migrations/db/migration_72.sql
@@ -1,7 +1,3 @@
--- Adds an index to speed up batched scans for Google Drive files
--- Pattern optimized: WHERE "connectorId" = ? AND id > ? ORDER BY id ASC LIMIT ?
--- The composite index enables efficient ordered range scans scoped to a connector.
-
-CREATE INDEX CONCURRENTLY "google_drive_files_connectorId_id_idx"
-  ON "public"."google_drive_files" ("connectorId", "id");
+-- Migration created on May 14, 2025
+ALTER TABLE "public"."slack_messages" ADD COLUMN "skipReason" VARCHAR(255);
 

--- a/connectors/migrations/db/migration_72.sql
+++ b/connectors/migrations/db/migration_72.sql
@@ -1,3 +1,2 @@
 -- Migration created on May 14, 2025
 ALTER TABLE "public"."slack_messages" ADD COLUMN "skipReason" VARCHAR(255);
-

--- a/connectors/migrations/db/migration_72.sql
+++ b/connectors/migrations/db/migration_72.sql
@@ -1,2 +1,7 @@
--- Migration created on May 14, 2025
-ALTER TABLE "public"."slack_messages" ADD COLUMN "skipReason" VARCHAR(255);
+-- Adds an index to speed up batched scans for Google Drive files
+-- Pattern optimized: WHERE "connectorId" = ? AND id > ? ORDER BY id ASC LIMIT ?
+-- The composite index enables efficient ordered range scans scoped to a connector.
+
+CREATE INDEX CONCURRENTLY "google_drive_files_connectorId_id_idx"
+  ON "public"."google_drive_files" ("connectorId", "id");
+

--- a/connectors/migrations/db/migration_93.sql
+++ b/connectors/migrations/db/migration_93.sql
@@ -1,0 +1,7 @@
+-- Adds an index to speed up batched scans for Google Drive files
+-- Pattern optimized: WHERE "connectorId" = ? AND id > ? ORDER BY id ASC LIMIT ?
+-- The composite index enables efficient ordered range scans scoped to a connector.
+
+CREATE INDEX CONCURRENTLY "google_drive_files_connectorId_id_idx"
+  ON "public"."google_drive_files" ("connectorId", "id");
+

--- a/front/lib/production_checks/checks/managed_data_source_gdrive_gc.ts
+++ b/front/lib/production_checks/checks/managed_data_source_gdrive_gc.ts
@@ -55,8 +55,8 @@ export const managedDataSourceGCGdriveCheck: CheckFunction = async (
               }
             ),
           {
-            retries: 10,
-            delayBetweenRetriesMs: 5000,
+            retries: 8,
+            delayBetweenRetriesMs: 4000,
           }
         )({})) as { id: number; coreDocumentId: string }[];
 

--- a/front/lib/production_checks/checks/managed_data_source_gdrive_gc.ts
+++ b/front/lib/production_checks/checks/managed_data_source_gdrive_gc.ts
@@ -37,7 +37,7 @@ export const managedDataSourceGCGdriveCheck: CheckFunction = async (
       const connectorDocuments: { id: number; coreDocumentId: string }[] = [];
       let fetched = 0;
       do {
-        // There is a risk of "cancelling statement due to confilct with recovery" errors
+        // There is a risk of "cancelling statement due to conflict with recovery" errors
         // relatively benign in the context of this check, thus the retry policy.
         const batch = (await withRetries(
           logger,


### PR DESCRIPTION
## Description
Wrap the connectors read in `managed_data_source_gdrive_gc` with `withRetries` to mitigate transient Postgres replica errors (`cancelling statement due to conflict with recovery`). Adjusted policy to 8 retries with 4s delay per feedback. Also add a connectors DB migration to optimize the scan pattern used by this check.

- Scope: front production check + connectors SQL migration.
- Implementation:
  - Front: import `withRetries` and execute the SELECT under a retry policy (8 retries, 4s delay).
  - Connectors: new migration `connectors/migrations/db/migration_93.sql` adding composite index `google_drive_files_connectorId_id_idx` on `google_drive_files("connectorId", "id")` (CONCURRENTLY). Restored existing `migration_72.sql` to its original content.
- Rationale: The check performs batched scans with `WHERE "connectorId" = ? AND id > ? ORDER BY id ASC LIMIT ?`. The index enables an efficient ordered range scan per connector. Retries reduce noisy failures without masking persistent issues.

## Risks
Blast radius: Google Drive managed DS GC check and `google_drive_files` read performance only.
Risk: low (additive index; read-only check hardening).

## Deploy Plan
- Apply connectors DB migration `connectors/migrations/db/migration_93.sql` (creates the index concurrently).
- Deploy front (the production check change).
