### PR TITLE
[front] Improve MCP timeout error bubbling up

### DIFF
--- a/front/lib/api/mcp/run_tool.ts
+++ b/front/lib/api/mcp/run_tool.ts
@@ -132,8 +132,8 @@ export async function* runToolWithStreaming(
       const retryPolicy =
         getRetryPolicyFromToolConfiguration(toolConfiguration);
       if (retryPolicy === "retry_on_interrupt") {
-        errorMessage += "Error: " + JSON.stringify(toolError);
-        throw new Error(errorMessage);
+        errorMessage += `Error: ${toolError.message}`;
+        throw new Error(errorMessage, { cause: toolError });
       }
     } else {
       errorMessage = `The tool ${action.functionCallName} failed with the following error: ${toolError.message}`;


### PR DESCRIPTION
## Description

- This PR improves the bubbling up of mcp timeouts on `retry_on_interrupt` by passing the original error as the cause instead of stringifying it.

## Tests

## Risk

- Low.

## Deploy Plan

- Deploy front.
