### PR TITLE
connectors/github: allow .exs files in code sync whitelist

### DIFF
--- a/connectors/src/connectors/github/lib/code/supported_files.ts
+++ b/connectors/src/connectors/github/lib/code/supported_files.ts
@@ -8,6 +8,7 @@ const EXTENSION_WHITELIST = [
   ".jsx",
   ".py",
   ".rb",
+  ".exs", // Elixir script
   ".rs",
   ".go",
   ".swift",


### PR DESCRIPTION
## Description 
add extension .exs to github connector extension (connectors/src/connectors/github/lib/code/supported_files.ts) following a client request

## Risk
None

## Deploy plan
deploy connector
