### PR TITLE
add confluence logo to resources for MCP servers

### DIFF
--- a/sdks/js/src/mcp_icon_types.ts
+++ b/sdks/js/src/mcp_icon_types.ts
@@ -17,6 +17,7 @@ export const MCPInternalActionIconSchema = z.enum([
   "ActionTimeIcon",
   "AsanaLogo",
   "CommandLineIcon",
+  "ConfluenceLogo",
   "DriveLogo",
   "GcalLogo",
   "GmailLogo",

--- a/sdks/js/src/types.ts
+++ b/sdks/js/src/types.ts
@@ -633,6 +633,7 @@ const WhitelistableFeaturesSchema = FlexibleEnumSchema<
   | "anthropic_vertex_fallback"
   | "claude_4_opus_feature"
   | "co_edition"
+  | "confluence_tool"
   | "deep_research_as_a_tool"
   | "deepseek_feature"
   | "deepseek_r1_global_agent_feature"


### PR DESCRIPTION
## Description

Add the Confluence logo and type to the list of resources for MCP servers

## Deploy Plan

sdk only
