### PR TITLE
[Connectors][Notion] Delay retries 30m for transient 5xx; preserve error type logging

### DIFF
--- a/connectors/src/connectors/notion/temporal/cast_known_errors.ts
+++ b/connectors/src/connectors/notion/temporal/cast_known_errors.ts
@@ -9,7 +9,11 @@ import type {
   ActivityInboundCallsInterceptor,
   Next,
 } from "@temporalio/worker";
-import { ProviderTransientError, ProviderWorkflowError } from "@connectors/lib/error";
+
+import {
+  ProviderTransientError,
+  ProviderWorkflowError,
+} from "@connectors/lib/error";
 
 export class NotionCastKnownErrorsInterceptor
   implements ActivityInboundCallsInterceptor

--- a/connectors/src/connectors/notion/temporal/cast_known_errors.ts
+++ b/connectors/src/connectors/notion/temporal/cast_known_errors.ts
@@ -1,14 +1,14 @@
 import {
+  APIErrorCode,
+  APIResponseError,
   RequestTimeoutError,
   UnknownHTTPResponseError,
 } from "@notionhq/client";
-import { APIErrorCode, APIResponseError } from "@notionhq/client";
 import type {
   ActivityExecuteInput,
   ActivityInboundCallsInterceptor,
   Next,
 } from "@temporalio/worker";
-
 import { ProviderTransientError, ProviderWorkflowError } from "@connectors/lib/error";
 
 export class NotionCastKnownErrorsInterceptor

--- a/connectors/src/connectors/notion/temporal/cast_known_errors.ts
+++ b/connectors/src/connectors/notion/temporal/cast_known_errors.ts
@@ -8,8 +8,6 @@ import type {
   ActivityInboundCallsInterceptor,
   Next,
 } from "@temporalio/worker";
-// no ApplicationFailure here; we cast to ProviderTransientError and let
-// the monitoring interceptor handle retry delay.
 
 import { ProviderTransientError, ProviderWorkflowError } from "@connectors/lib/error";
 

--- a/connectors/src/lib/error.ts
+++ b/connectors/src/lib/error.ts
@@ -70,7 +70,12 @@ export class ProviderTransientError extends ProviderWorkflowError {
     originalError?: Error | APIError,
     readonly retryAfterMs?: number
   ) {
-    super(provider, message, "transient_upstream_activity_error", originalError);
+    super(
+      provider,
+      message,
+      "transient_upstream_activity_error",
+      originalError
+    );
   }
 }
 

--- a/connectors/src/lib/error.ts
+++ b/connectors/src/lib/error.ts
@@ -67,8 +67,8 @@ export class ProviderTransientError extends ProviderWorkflowError {
   constructor(
     provider: ConnectorProvider,
     message: string,
-    originalError?: Error | APIError,
-    readonly retryAfterMs?: number
+    originalError: Error | APIError | undefined,
+    readonly retryAfterMs: number
   ) {
     super(
       provider,

--- a/connectors/src/lib/error.ts
+++ b/connectors/src/lib/error.ts
@@ -62,6 +62,18 @@ export class ProviderRateLimitError extends ProviderWorkflowError {
   }
 }
 
+// Transient upstream error with optional retryAfterMs hint for backoff.
+export class ProviderTransientError extends ProviderWorkflowError {
+  constructor(
+    provider: ConnectorProvider,
+    message: string,
+    originalError?: Error | APIError,
+    readonly retryAfterMs?: number
+  ) {
+    super(provider, message, "transient_upstream_activity_error", originalError);
+  }
+}
+
 export class HTTPError extends Error {
   readonly statusCode: number;
   constructor(message: string, statusCode: number) {

--- a/connectors/src/lib/temporal_monitoring.ts
+++ b/connectors/src/lib/temporal_monitoring.ts
@@ -129,9 +129,9 @@ export class ActivityInboundLogInterceptor
       error = err;
 
       // Convert provider-marked transient upstream errors into ApplicationFailures
-      // with a fixed retry delay to avoid hot-looping.
+      // with the provided retry delay to avoid hot-looping.
       if (err instanceof ProviderTransientError) {
-        const delayMs = err.retryAfterMs ?? 30 * 60 * 1000;
+        const delayMs = err.retryAfterMs;
         throw ApplicationFailure.create({
           message: `${err.message}. Retry after ${Math.floor(delayMs / 1000)}s`,
           type: err.type, // "transient_upstream_activity_error"
@@ -232,9 +232,8 @@ export class ActivityInboundLogInterceptor
             "Activity failed"
           );
         } else if (error instanceof ApplicationFailure) {
-          // ApplicationFailure can carry a custom type; use it for metrics/logs.
-          // This preserves upstream classification when interceptors override retry delays.
-          // Default to unhandled if type is missing.
+          // Keep a dedicated branch: ApplicationFailure carries a custom type that
+          // we want to reflect in logs/metrics instead of classifying as "unhandled".
           // eslint-disable-next-line @typescript-eslint/no-explicit-any
           const appFailure: any = error;
           errorType = appFailure.type ?? "unhandled_internal_activity_error";

--- a/connectors/src/lib/temporal_monitoring.ts
+++ b/connectors/src/lib/temporal_monitoring.ts
@@ -231,20 +231,6 @@ export class ActivityInboundLogInterceptor
             },
             "Activity failed"
           );
-        } else if (error instanceof ApplicationFailure) {
-          // Keep a dedicated branch: ApplicationFailure carries a custom type that
-          // we want to reflect in logs/metrics instead of classifying as "unhandled".
-          // eslint-disable-next-line @typescript-eslint/no-explicit-any
-          const appFailure: any = error;
-          errorType = appFailure.type ?? "unhandled_internal_activity_error";
-          this.logger.error(
-            {
-              error,
-              durationMs,
-              attempt: this.context.info.attempt,
-            },
-            "Activity failed"
-          );
         } else {
           // Unknown error type.
           this.logger.error(

--- a/connectors/src/lib/temporal_monitoring.ts
+++ b/connectors/src/lib/temporal_monitoring.ts
@@ -219,6 +219,21 @@ export class ActivityInboundLogInterceptor
             },
             "Activity failed"
           );
+        } else if (error instanceof ApplicationFailure) {
+          // ApplicationFailure can carry a custom type; use it for metrics/logs.
+          // This preserves upstream classification when interceptors override retry delays.
+          // Default to unhandled if type is missing.
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          const appFailure: any = error;
+          errorType = appFailure.type ?? "unhandled_internal_activity_error";
+          this.logger.error(
+            {
+              error,
+              durationMs,
+              attempt: this.context.info.attempt,
+            },
+            "Activity failed"
+          );
         } else {
           // Unknown error type.
           this.logger.error(


### PR DESCRIPTION
## Description

Implements a provider-level transient error signal and centralizes retry backoff in the monitoring interceptor.

- Introduce `ProviderTransientError` (extends `ProviderWorkflowError`) to represent transient upstream errors with an optional `retryAfterMs` hint.
- Notion interceptor now casts HTTP 502/504/530 into `ProviderTransientError` with a 30-minute retry hint, instead of throwing `ApplicationFailure` directly.
- Monitoring interceptor converts `ProviderTransientError` into `ApplicationFailure.create({ nextRetryDelay: 30m, type: 'transient_upstream_activity_error' })`, ensuring Temporal waits before retrying while preserving error typing for logs/metrics.
- Keeps existing `ProviderWorkflowError` behavior for non-transient cases (e.g., rate limits, validation, request timeouts).

Context: repeated transient 5xx from Notion (esp. 504) caused tight retry loops; this approach keeps provider semantics while centralizing retry control.

## Risks

Blast radius: Notion connector activity retries and monitoring classification
Risk: low

## Deploy Plan

- Deploy connectors service
- No migrations required
