### PR TITLE
[HOOTL] Fix: display name rather than sId

### DIFF
--- a/front/components/spaces/SpaceSideBarMenu.tsx
+++ b/front/components/spaces/SpaceSideBarMenu.tsx
@@ -843,7 +843,7 @@ const SpaceTriggersSubMenu = ({
         <Tree isLoading={isWebhookSourceViewsLoading}>
           {webhookSourceViews.map((webhookView) => (
             <SpaceTriggerItem
-              label={webhookView.customName ?? webhookView.sId}
+              label={webhookView.customName ?? webhookView.webhookSource.name}
               key={webhookView.sId}
             />
           ))}


### PR DESCRIPTION
## Description

Webhook source sId is currently displayed in space sidebar if no custom name is set. 
Displaying webhook source name instead

<img width="1650" height="766" alt="Screenshot 2025-09-18 at 16 32 16" src="https://github.com/user-attachments/assets/15412132-7abf-4875-898d-40a005ca6385" />


## Tests

Manually

## Risk

No risk

## Deploy Plan

front
