### PR TITLE
[sparkle] move message date to the left

### DIFF
--- a/sparkle/src/components/ConversationMessage.tsx
+++ b/sparkle/src/components/ConversationMessage.tsx
@@ -222,8 +222,6 @@ export const ConversationMessageHeader = React.forwardRef<
           >
             {renderName(name)}
             {infoChip}
-          </div>
-          <div>
             <span className="s-text-xs s-font-normal s-text-muted-foreground dark:s-text-muted-foreground-night">
               {timestamp}
             </span>


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

This PR moves the message date from the ConversationMessage component in sparkle to the left of the message, as per the latest figma boards.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

Storybook

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

Low

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->

Release sparkle.