### PR TITLE
[front] Prevent content flickering in `ConversationFilesPopover`

### DIFF
--- a/front/components/assistant/conversation/ConversationFilesPopover.tsx
+++ b/front/components/assistant/conversation/ConversationFilesPopover.tsx
@@ -171,13 +171,15 @@ export function ConversationFilesPopover({
   owner,
 }: ConversationFilesPopoverProps) {
   const [isOpen, setIsOpen] = React.useState(false);
+  const [shouldDisableConversationFiles, setShouldDisableConversationFiles] =
+    React.useState(true);
 
   const { conversationFiles, isConversationFilesLoading } =
     useConversationFiles({
       conversationId,
       owner,
       options: {
-        disabled: !isOpen,
+        disabled: shouldDisableConversationFiles,
       },
     });
 
@@ -205,7 +207,17 @@ export function ConversationFilesPopover({
   }
 
   return (
-    <PopoverRoot open={isOpen} onOpenChange={setIsOpen}>
+    <PopoverRoot
+      open={isOpen}
+      onOpenChange={(open) => {
+        setIsOpen(open);
+        // If we're opening, we enable the hook right away.
+        if (open) {
+          setShouldDisableConversationFiles(false);
+        }
+        // If we're closing, we don't disable the file hook immediately to prevent flickering.
+      }}
+    >
       <PopoverTrigger asChild>
         <Button
           size="sm"
@@ -218,6 +230,11 @@ export function ConversationFilesPopover({
         className="flex w-96 flex-col gap-3"
         align="end"
         onOpenAutoFocus={(e) => e.preventDefault()}
+        onAnimationEnd={() => {
+          if (!isOpen) {
+            setShouldDisableConversationFiles(true);
+          }
+        }}
       >
         <ScrollArea className="flex flex-col gap-3">
           <div className="heading-lg text-primary dark:text-primary-night">

--- a/front/components/assistant/conversation/ConversationFilesPopover.tsx
+++ b/front/components/assistant/conversation/ConversationFilesPopover.tsx
@@ -211,11 +211,11 @@ export function ConversationFilesPopover({
       open={isOpen}
       onOpenChange={(open) => {
         setIsOpen(open);
-        // If we're opening, we enable the hook right away.
+        // If we're opening, we enable the hook right away, if we're closing,
+        // we disable it after the animation is done to avoid flickering.
         if (open) {
           setShouldDisableConversationFiles(false);
         }
-        // If we're closing, we don't disable the file hook immediately to prevent flickering.
       }}
     >
       <PopoverTrigger asChild>


### PR DESCRIPTION
## Description

- This PR removes flickering on the content of the `ConversationFilesPopover`, which was due to the hook being disabled on the click that closes it rather than at the end of the animation.

Before

https://github.com/user-attachments/assets/a3e9e1ae-7851-4f1e-89de-90bbfb01aaff

After

https://github.com/user-attachments/assets/6da76067-70f4-4be6-82fc-20c0804821fb


## Tests

- Tested locally.

## Risk

- Low.

## Deploy Plan

- Deploy front.
