### PR TITLE
[front] Filter out hidden files from `ConversationFilesPopover`

### DIFF
--- a/front/lib/api/assistant/conversation/files.ts
+++ b/front/lib/api/assistant/conversation/files.ts
@@ -15,7 +15,9 @@ export function listGeneratedFiles(
         action.getGeneratedFiles()
       );
 
-      files.push(...generatedFiles);
+      files.push(
+        ...generatedFiles.filter((generatedFile) => !generatedFile.hidden)
+      );
     }
   }
 


### PR DESCRIPTION
## Description

- This PR filters out hidden files from the `ConversationFilesPopover` (in the backend).

## Tests

- Tested locally.

## Risk

- Low.

## Deploy Plan

- Deploy front.
