### PR TITLE
Tweak config.MODEL check

### DIFF
--- a/front/pages/api/v1/w/[wId]/spaces/[spaceId]/apps/[aId]/runs/index.ts
+++ b/front/pages/api/v1/w/[wId]/spaces/[spaceId]/apps/[aId]/runs/index.ts
@@ -277,6 +277,7 @@ async function handler(
       // 1) We use the OpenAI EU endpoint (in Core)
       // 2) We use the DUST_MANAGED_OPENAI_API_KEY_EU env as the key
       let useOpenAIEUKey =
+        config.MODEL && // This could be null, e.g. in the config.CREATE_SUGGESTIONS case
         keyWorkspaceFlags.includes("use_openai_eu_key") &&
         !!apiConfig.getDustManagedOpenAIAPIKeyEU();
 
@@ -326,7 +327,7 @@ async function handler(
         "App run creation"
       );
 
-      if (useOpenAIEUKey && config.MODEL) {
+      if (useOpenAIEUKey) {
         config.MODEL.use_openai_eu_host = true;
       }
 


### PR DESCRIPTION
## Description

If config.MODEL is null (e.g. CREATE_SUGGESTIONS scenario), we'd end up up passing the EU creds but not setting use_openai_eu_host.

## Tests

Manual

## Risk

Minimum

## Deploy Plan

Front