### PR TITLE
Remove google drive tool FF

### DIFF
--- a/front/lib/actions/mcp_internal_actions/constants.ts
+++ b/front/lib/actions/mcp_internal_actions/constants.ts
@@ -899,7 +899,7 @@ The directive should be used to display a clickable version of the agent name in
     availability: "manual",
     allowMultipleInstances: true,
     isRestricted: undefined,
-    isPreview: true,
+    isPreview: false,
     tools_stakes: {
       list_drives: "never_ask",
       search_files: "never_ask",

--- a/front/lib/actions/mcp_internal_actions/constants.ts
+++ b/front/lib/actions/mcp_internal_actions/constants.ts
@@ -898,9 +898,7 @@ The directive should be used to display a clickable version of the agent name in
     id: 27,
     availability: "manual",
     allowMultipleInstances: true,
-    isRestricted: ({ featureFlags }) => {
-      return !featureFlags.includes("google_drive_tool");
-    },
+    isRestricted: undefined,
     isPreview: true,
     tools_stakes: {
       list_drives: "never_ask",

--- a/front/types/shared/feature_flags.ts
+++ b/front/types/shared/feature_flags.ts
@@ -72,10 +72,6 @@ export const WHITELISTABLE_FEATURES_CONFIG = {
     description: "Google Sheets MCP tool",
     stage: "rolling_out",
   },
-  google_drive_tool: {
-    description: "Google Drive MCP tool",
-    stage: "rolling_out",
-  },
   index_private_slack_channel: {
     description: "Allow indexing of private Slack channels",
     stage: "on_demand",

--- a/sdks/js/src/types.ts
+++ b/sdks/js/src/types.ts
@@ -642,7 +642,6 @@ const WhitelistableFeaturesSchema = FlexibleEnumSchema<
   | "exploded_tables_query"
   | "freshservice_tool"
   | "google_ai_studio_experimental_models_feature"
-  | "google_drive_tool"
   | "google_sheets_tool"
   | "hootl_subscriptions"
   | "hootl_webhooks"


### PR DESCRIPTION
## Description

* Releasing current version of google drive tool. Will not merge until documentation is published.
 
## Tests

* Tool has been validated by multiple customers with great feedback

## Risk

* Minimal

## Deploy Plan

* Deploy front