### PR TITLE
fix(rate-limiter): swap to Redis LUA script for atomic execution

### DIFF
--- a/front/lib/utils/rate_limiter.ts
+++ b/front/lib/utils/rate_limiter.ts
@@ -1,4 +1,5 @@
 import { v4 as uuidv4 } from "uuid";
+
 import type { RedisUsageTagsType } from "@app/lib/utils/redis_client";
 import { redisClient } from "@app/lib/utils/redis_client";
 import { getStatsDClient } from "@app/lib/utils/statsd";
@@ -97,7 +98,11 @@ export async function rateLimiter({
     redis = await getRedisClient({ origin: "rate_limiter", redisUri });
     const remaining = (await redis.eval(luaScript, {
       keys: [redisKey],
-      arguments: [timeframeSeconds.toString(), maxPerTimeframe.toString(), uuidv4()],
+      arguments: [
+        timeframeSeconds.toString(),
+        maxPerTimeframe.toString(),
+        uuidv4(),
+      ],
     })) as number;
 
     const totalTimeMs = new Date().getTime() - now.getTime();


### PR DESCRIPTION
Fixes: #15926

- Redis LUA scripts are atomic.
- Window trimming happens as a first step via ZREMRANGEBYSCORE
- Request count is retrieved via ZCARD
- We queue requests with ZADD with the time in milliseconds as a score
- We keep the UUIDv4 as a value
- We expire the key with TTL by window + 60s to cleanup

Note: Requests are still visible with ZRANGE and ZCARD until a request arrives. This is because trimming happens pre-count synchronously.