### PR TITLE
Add scaffolding for discord webhook

### DIFF
--- a/connectors/package-lock.json
+++ b/connectors/package-lock.json
@@ -65,6 +65,7 @@
         "tar-stream": "^3.1.7",
         "tsconfig-paths-webpack-plugin": "^4.1.0",
         "turndown": "^7.1.2",
+        "tweetnacl": "^1.0.3",
         "undici": "^6.21.1",
         "uuid": "^9.0.0",
         "yargs": "^17.7.2"
@@ -96,7 +97,7 @@
     },
     "../sdks/js": {
       "name": "@dust-tt/client",
-      "version": "1.1.14",
+      "version": "1.1.15",
       "bundleDependencies": [
         "@modelcontextprotocol/sdk"
       ],
@@ -16928,6 +16929,11 @@
       "dependencies": {
         "domino": "^2.1.6"
       }
+    },
+    "node_modules/tweetnacl": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-1.0.3.tgz",
+      "integrity": "sha512-6rt+RN7aOi1nGMyC4Xa5DdYiukl2UWCbcJft7YhxReBGQD7OAM8Pbxw6YMo4r2diNEA8FEmu32YOn9rhaiE5yw=="
     },
     "node_modules/type-check": {
       "version": "0.4.0",

--- a/connectors/package.json
+++ b/connectors/package.json
@@ -73,6 +73,7 @@
     "tar": "^6.2.0",
     "tar-stream": "^3.1.7",
     "tsconfig-paths-webpack-plugin": "^4.1.0",
+    "tweetnacl": "^1.0.3",
     "turndown": "^7.1.2",
     "undici": "^6.21.1",
     "uuid": "^9.0.0",

--- a/connectors/src/api/webhooks/webhook_discord_app.ts
+++ b/connectors/src/api/webhooks/webhook_discord_app.ts
@@ -18,7 +18,8 @@ const DiscordInteraction = {
   MODAL_SUBMIT: 5,
 } as const;
 
-type DiscordInteractionType = (typeof DiscordInteraction)[keyof typeof DiscordInteraction];
+type DiscordInteractionType =
+  (typeof DiscordInteraction)[keyof typeof DiscordInteraction];
 
 /**
  * Discord Interaction Response Types (outgoing responses)
@@ -35,7 +36,8 @@ const DiscordInteractionResponse = {
   PREMIUM_REQUIRED: 10,
 } as const;
 
-type DiscordInteractionResponseType = (typeof DiscordInteractionResponse)[keyof typeof DiscordInteractionResponse];
+type DiscordInteractionResponseType =
+  (typeof DiscordInteractionResponse)[keyof typeof DiscordInteractionResponse];
 
 const logger = mainLogger.child(
   {

--- a/connectors/src/api/webhooks/webhook_discord_app.ts
+++ b/connectors/src/api/webhooks/webhook_discord_app.ts
@@ -1,0 +1,176 @@
+import type { Request, Response } from "express";
+import nacl from "tweetnacl";
+
+import { apiConfig } from "@connectors/lib/api/config";
+import mainLogger from "@connectors/logger/logger";
+import { apiError, withLogging } from "@connectors/logger/withlogging";
+import type { WithConnectorsAPIErrorReponse } from "@connectors/types";
+
+/**
+ * Discord Interaction Types (incoming requests)
+ * @see https://discord.com/developers/docs/interactions/receiving-and-responding#interaction-object-interaction-type
+ */
+enum DiscordInteractionType {
+  PING = 1,
+  APPLICATION_COMMAND = 2,
+  MESSAGE_COMPONENT = 3,
+  APPLICATION_COMMAND_AUTOCOMPLETE = 4,
+  MODAL_SUBMIT = 5,
+}
+
+/**
+ * Discord Interaction Response Types (outgoing responses)
+ * @see https://discord.com/developers/docs/interactions/receiving-and-responding#responding-to-an-interaction
+ */
+enum DiscordInteractionResponseType {
+  PONG = 1,
+  CHANNEL_MESSAGE_WITH_SOURCE = 4,
+  DEFERRED_CHANNEL_MESSAGE_WITH_SOURCE = 5,
+  DEFERRED_UPDATE_MESSAGE = 6,
+  UPDATE_MESSAGE = 7,
+  APPLICATION_COMMAND_AUTOCOMPLETE_RESULT = 8,
+  MODAL = 9,
+  PREMIUM_REQUIRED = 10,
+}
+
+const logger = mainLogger.child(
+  {
+    provider: "discord_app",
+    service: "discord_app",
+  },
+  {
+    msgPrefix: "[Discord App] ",
+  }
+);
+
+type DiscordWebhookReqBody = {
+  type: DiscordInteractionType;
+  data?: {
+    name?: string;
+    options?: Array<{
+      name: string;
+      type: number;
+      value?: string | number | boolean;
+      options?: Array<{
+        name: string;
+        type: number;
+        value?: string | number | boolean;
+      }>;
+    }>;
+    custom_id?: string;
+  };
+  guild_id?: string;
+  channel_id?: string;
+  member?: {
+    user?: {
+      id: string;
+    };
+  };
+  user?: {
+    id: string;
+  };
+};
+
+type DiscordWebhookResBody =
+  | WithConnectorsAPIErrorReponse<null>
+  | {
+      type: DiscordInteractionResponseType;
+      data?: { content: string };
+    };
+
+/**
+ * Validates Discord webhook signature using Ed25519.
+ * Specified in the Discord documentation: https://discord.com/developers/docs/interactions/overview#preparing-for-interactions
+ * @param signature - X-Signature-Ed25519 header value
+ * @param timestamp - X-Signature-Timestamp header value
+ * @param body - Raw request body as string
+ * @param publicKey - Discord application public key (hex string)
+ * @returns true if signature is valid, false otherwise
+ */
+function validateDiscordSignature(
+  signature: string,
+  timestamp: string,
+  body: string,
+  publicKey: string
+): boolean {
+  try {
+    const isVerified = nacl.sign.detached.verify(
+      new Uint8Array(Buffer.from(timestamp + body)),
+      new Uint8Array(Buffer.from(signature, "hex")),
+      new Uint8Array(Buffer.from(publicKey, "hex"))
+    );
+    return isVerified;
+  } catch (error) {
+    logger.error(
+      { error, signature, timestamp, publicKey },
+      "Error validating Discord signature"
+    );
+    return false;
+  }
+}
+
+const _webhookDiscordAppHandler = async (
+  req: Request<
+    Record<string, string>,
+    DiscordWebhookResBody,
+    DiscordWebhookReqBody
+  >,
+  res: Response<DiscordWebhookResBody>
+) => {
+  const signature = req.get("X-Signature-Ed25519");
+  const timestamp = req.get("X-Signature-Timestamp");
+  const publicKey = apiConfig.getDiscordAppPublicKey();
+
+  if (!signature || !timestamp || !publicKey) {
+    return apiError(req, res, {
+      api_error: {
+        type: "invalid_request_error",
+        message: "Missing required Discord security headers or public key",
+      },
+      status_code: 401,
+    });
+  }
+
+  const bodyString = await parseExpressRequestRawBody(req);
+  const isValidSignature = validateDiscordSignature(
+    signature,
+    timestamp,
+    bodyString,
+    publicKey
+  );
+
+  if (!isValidSignature) {
+    return apiError(req, res, {
+      api_error: {
+        type: "invalid_request_error",
+        message: "Invalid request signature",
+      },
+      status_code: 401,
+    });
+  }
+
+  const interactionBody = JSON.parse(bodyString);
+
+  // Discord webhook verification - respond to ping
+  if (interactionBody.type === DiscordInteractionType.PING) {
+    logger.info("Discord ping received, responding with pong");
+    return res.status(200).json({
+      type: DiscordInteractionResponseType.PONG,
+    });
+  }
+
+  // Default response for unsupported interaction types
+  return res.status(200).json({
+    type: DiscordInteractionResponseType.PONG,
+  });
+};
+
+async function parseExpressRequestRawBody(req: Request): Promise<string> {
+  if (req !== null && "rawBody" in req && req.rawBody) {
+    return req.rawBody.toString();
+  }
+
+  throw new Error("Raw body not available for signature verification");
+}
+
+export const webhookDiscordAppHandler = withLogging(_webhookDiscordAppHandler);

--- a/connectors/src/api_server.ts
+++ b/connectors/src/api_server.ts
@@ -24,6 +24,7 @@ import { stopConnectorAPIHandler } from "@connectors/api/stop_connector";
 import { syncConnectorAPIHandler } from "@connectors/api/sync_connector";
 import { unpauseConnectorAPIHandler } from "@connectors/api/unpause_connector";
 import { postConnectorUpdateAPIHandler } from "@connectors/api/update_connector";
+import { webhookDiscordAppHandler } from "@connectors/api/webhooks/webhook_discord_app";
 import { webhookGithubAPIHandler } from "@connectors/api/webhooks/webhook_github";
 import {
   webhookIntercomAPIHandler,
@@ -160,6 +161,11 @@ export function startServer(port: number) {
     "/webhooks/:webhooks_secret/firecrawl",
     bodyParser.raw({ type: "application/json" }),
     webhookFirecrawlAPIHandler
+  );
+  app.post(
+    "/webhooks/:webhooks_secret/discord/app",
+    bodyParser.raw({ type: "application/json" }),
+    webhookDiscordAppHandler
   );
 
   // /configuration/ is the new configration method, replacing the old /config/ method

--- a/connectors/src/lib/api/config.ts
+++ b/connectors/src/lib/api/config.ts
@@ -37,4 +37,7 @@ export const apiConfig = {
   getConnectorsPublicURL: (): string => {
     return EnvironmentConfig.getEnvVariable("CONNECTORS_PUBLIC_URL");
   },
+  getDiscordAppPublicKey: (): string | undefined => {
+    return EnvironmentConfig.getOptionalEnvVariable("DISCORD_APP_PUBLIC_KEY");
+  },
 };


### PR DESCRIPTION
## Description

* Goal is to have a Discord app that responds in the same way as the Slack app.
* This first PR is just adding scaffolding to respond to the oauth ping. Not accessible to anyone yet.

## Tests

* Validated able to successfully respond to discord oauth ping

## Risk

* Not user facing yet

## Deploy Plan

* Deploy connector (env variable not needed yet)