### PR TITLE
[core] Update default fallback region for Vertex AI backend

### DIFF
--- a/core/src/providers/anthropic/backend.rs
+++ b/core/src/providers/anthropic/backend.rs
@@ -170,6 +170,7 @@ impl AnthropicBackend for VertexAnthropicBackend {
             Some(location) => location.clone(),
             None => tokio::task::spawn_blocking(|| std::env::var("GOOGLE_CLOUD_LOCATION"))
                 .await?
+                // Default region our credits are allocated on.
                 .unwrap_or_else(|_| "us-south1".to_string()),
         };
 

--- a/core/src/providers/anthropic/backend.rs
+++ b/core/src/providers/anthropic/backend.rs
@@ -172,7 +172,7 @@ impl AnthropicBackend for VertexAnthropicBackend {
                 .await?
             {
                 Ok(location) => location,
-                Err(_) => "global".to_string(), // Default fallback region.
+                Err(_) => "us-south1".to_string(), // Default fallback region.
             },
         };
 

--- a/core/src/providers/anthropic/backend.rs
+++ b/core/src/providers/anthropic/backend.rs
@@ -168,12 +168,9 @@ impl AnthropicBackend for VertexAnthropicBackend {
 
         let location = match credentials.get("GOOGLE_CLOUD_LOCATION") {
             Some(location) => location.clone(),
-            None => match tokio::task::spawn_blocking(|| std::env::var("GOOGLE_CLOUD_LOCATION"))
+            None => tokio::task::spawn_blocking(|| std::env::var("GOOGLE_CLOUD_LOCATION"))
                 .await?
-            {
-                Ok(location) => location,
-                Err(_) => "us-south1".to_string(), // Default fallback region.
-            },
+                .unwrap_or_else(|_| "us-south1".to_string()),
         };
 
         self.api_key = Some(api_key.clone());


### PR DESCRIPTION
## Description

- This PR updates the default location for Vertex AI, from using the global endpoint to using `us-south1`.

## Tests

## Risk

- Low, the fallback is mostly unused for now, we're still experimenting with it.

## Deploy Plan

- Deploy core.
