### PR TITLE
[front] handle subscription end/re-start for schedules

### DIFF
--- a/front/temporal/scrub_workspace/activities.ts
+++ b/front/temporal/scrub_workspace/activities.ts
@@ -28,6 +28,7 @@ import { SpaceResource } from "@app/lib/resources/space_resource";
 import { SubscriptionResource } from "@app/lib/resources/subscription_resource";
 import { TagResource } from "@app/lib/resources/tags_resource";
 import { TrackerConfigurationResource } from "@app/lib/resources/tracker_resource";
+import { TriggerResource } from "@app/lib/resources/trigger_resource";
 import { UserResource } from "@app/lib/resources/user_resource";
 import { CustomerioServerSideTracking } from "@app/lib/tracking/customerio/server";
 import { concurrentExecutor } from "@app/lib/utils/async_utils";
@@ -119,6 +120,22 @@ export async function pauseAllConnectors({
       continue;
     }
     await connectorsAPI.pauseConnector(ds.connectorId);
+  }
+}
+
+export async function pauseAllTriggers({
+  workspaceId,
+}: {
+  workspaceId: string;
+}) {
+  const auth = await Authenticator.internalAdminForWorkspace(workspaceId);
+  const disableResult = await TriggerResource.disableAllForWorkspace(auth);
+  if (disableResult.isErr()) {
+    // Don't fail the whole scrub workflow if we can't disable triggers, just log it.
+    logger.error(
+      { workspaceId, error: disableResult.error },
+      "Failed to disable workspace triggers during scrub"
+    );
   }
 }
 

--- a/front/temporal/scrub_workspace/client.ts
+++ b/front/temporal/scrub_workspace/client.ts
@@ -5,7 +5,7 @@ import { getTemporalClientForFrontNamespace } from "@app/lib/temporal";
 import logger from "@app/logger/logger";
 import {
   immediateWorkspaceScrubWorkflow,
-  scheduleWorkspaceScrubWorkflow,
+  scheduleWorkspaceScrubWorkflowV2,
 } from "@app/temporal/scrub_workspace/workflows";
 import type { Result } from "@app/types";
 import { Err, normalizeError, Ok } from "@app/types";
@@ -21,7 +21,7 @@ export async function launchScheduleWorkspaceScrubWorkflow({
   const workflowId = getWorkflowId(workspaceId);
 
   try {
-    await client.workflow.start(scheduleWorkspaceScrubWorkflow, {
+    await client.workflow.start(scheduleWorkspaceScrubWorkflowV2, {
       args: [{ workspaceId }],
       taskQueue: QUEUE_NAME,
       workflowId: workflowId,
@@ -92,7 +92,7 @@ export async function terminateScheduleWorkspaceScrubWorkflow({
   const client = await getTemporalClientForFrontNamespace();
   const workflowId = getWorkflowId(workspaceId);
   try {
-    const handle: WorkflowHandle<typeof scheduleWorkspaceScrubWorkflow> =
+    const handle: WorkflowHandle<typeof scheduleWorkspaceScrubWorkflowV2> =
       client.workflow.getHandle(workflowId);
     await handle.terminate();
     logger.info(

--- a/front/temporal/scrub_workspace/workflows.ts
+++ b/front/temporal/scrub_workspace/workflows.ts
@@ -13,11 +13,10 @@ const { sendDataDeletionEmail } = proxyActivities<typeof activities>({
   },
 });
 
-const { scrubWorkspaceData, pauseAllConnectors } = proxyActivities<
-  typeof activities
->({
-  startToCloseTimeout: "60 minutes",
-});
+const { scrubWorkspaceData, pauseAllConnectors, pauseAllTriggers } =
+  proxyActivities<typeof activities>({
+    startToCloseTimeout: "60 minutes",
+  });
 
 export async function scheduleWorkspaceScrubWorkflow({
   workspaceId,
@@ -25,6 +24,7 @@ export async function scheduleWorkspaceScrubWorkflow({
   workspaceId: string;
 }): Promise<boolean> {
   await pauseAllConnectors({ workspaceId });
+  await pauseAllTriggers({ workspaceId });
   await sendDataDeletionEmail({
     remainingDays: 15,
     workspaceId,


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

When subscription ends, we are not pausing schedules. This leads to creating some temporal workflows that fails, because the user can't send messages (he's subscription has ended).

This PR de-activates all triggers on subscription end.

This PR also re-activates all triggers on subscription restart. This re-activates only triggers that are launching a currently active agent.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

Unit tests.

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

Low

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->

Deploy front.