### PR TITLE
MCP server auth: use drowndown instead of 3 mutually exclusive toggles

### DIFF
--- a/front/components/actions/mcp/CreateMCPServerDialog.tsx
+++ b/front/components/actions/mcp/CreateMCPServerDialog.tsx
@@ -266,6 +266,18 @@ export function CreateMCPServerDialog({
     resetState();
   };
 
+  const getAuthMethodLabel = () => {
+    if (authMethod === "oauth-dynamic") {
+      return "Automatic";
+    }
+    if (authMethod === "bearer") {
+      return defaultServerConfig?.authMethod === "bearer"
+        ? `${defaultServerConfig.name} API Key`
+        : "Bearer token";
+    }
+    return "Static OAuth";
+  };
+
   return (
     <Dialog
       open={isOpen}
@@ -354,15 +366,7 @@ export function CreateMCPServerDialog({
                           <Button
                             variant="outline"
                             isSelect
-                            label={
-                              authMethod === "oauth-dynamic"
-                                ? "Automatic"
-                                : authMethod === "bearer"
-                                  ? defaultServerConfig?.authMethod === "bearer"
-                                    ? `${defaultServerConfig.name} API Key`
-                                    : "Bearer token"
-                                  : "Static OAuth"
-                            }
+                            label={getAuthMethodLabel()}
                           />
                         </DropdownMenuTrigger>
                         <DropdownMenuContent>

--- a/front/components/actions/mcp/CreateMCPServerDialog.tsx
+++ b/front/components/actions/mcp/CreateMCPServerDialog.tsx
@@ -417,8 +417,12 @@ export function CreateMCPServerDialog({
                     </div>
                     {(authMethod === "oauth-dynamic" ||
                       defaultServerConfig?.authMethod === "oauth-dynamic") && (
-                    <div className="text-xs text-muted-foreground">
-                        Dust will automatically discover if OAuth authentication is required. If OAuth is not needed, the server will be accessed without authentication. Otherwise, Dust will try to use dynamic client registration to get the OAuth credentials.
+                      <div className="text-xs text-muted-foreground">
+                        Dust will automatically discover if OAuth authentication
+                        is required. If OAuth is not needed, the server will be
+                        accessed without authentication. Otherwise, Dust will
+                        try to use dynamic client registration to get the OAuth
+                        credentials.
                       </div>
                     )}
                     {(authMethod === "bearer" ||
@@ -445,7 +449,8 @@ export function CreateMCPServerDialog({
                     )}
                     {!defaultServerConfig && authMethod === "oauth-static" && (
                       <div className="text-xs text-muted-foreground">
-                        The redirect URI to allow is <strong>
+                        The redirect URI to allow is{" "}
+                        <strong>
                           {window.origin + "/oauth/mcp_static/finalize"}
                         </strong>
                       </div>

--- a/front/components/actions/mcp/CreateMCPServerDialog.tsx
+++ b/front/components/actions/mcp/CreateMCPServerDialog.tsx
@@ -346,7 +346,7 @@ export function CreateMCPServerDialog({
                               className="text-gray-400"
                             />
                           }
-                          label="Choose how to authenticate: Automatic discovery, Bearer token, or Static OAuth credentials. Automatic lets Dust discover if OAuth is required and use dynamic client registration if possible."
+                          label="Choose how to authenticate to the MCP server: Automatic discovery, Bearer token, or Static OAuth credentials."
                         />
                       </div>
                       <DropdownMenu>
@@ -415,6 +415,12 @@ export function CreateMCPServerDialog({
                         </DropdownMenuContent>
                       </DropdownMenu>
                     </div>
+                    {(authMethod === "oauth-dynamic" ||
+                      defaultServerConfig?.authMethod === "oauth-dynamic") && (
+                    <div className="text-xs text-muted-foreground">
+                        Dust will automatically discover if OAuth authentication is required. If OAuth is not needed, the server will be accessed without authentication. Otherwise, Dust will try to use dynamic client registration to get the OAuth credentials.
+                      </div>
+                    )}
                     {(authMethod === "bearer" ||
                       defaultServerConfig?.authMethod === "bearer") && (
                       <div className="flex-grow">

--- a/front/components/actions/mcp/CreateMCPServerDialog.tsx
+++ b/front/components/actions/mcp/CreateMCPServerDialog.tsx
@@ -1,15 +1,20 @@
 import {
+  Button,
   Dialog,
   DialogContainer,
   DialogContent,
   DialogFooter,
   DialogHeader,
   DialogTitle,
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuRadioGroup,
+  DropdownMenuRadioItem,
+  DropdownMenuTrigger,
   Icon,
   InformationCircleIcon,
   Input,
   Label,
-  SliderToggle,
   Tooltip,
 } from "@dust-tt/sparkle";
 import { useCallback, useEffect, useState } from "react";
@@ -327,48 +332,12 @@ export function CreateMCPServerDialog({
                     </div>
                   </div>
                 )}
-                {!defaultServerConfig && (
-                  <div className="space-y-2">
-                    <div className="flex items-center justify-between">
-                      <div className="flex items-center space-x-2">
-                        <Label htmlFor="useDiscovery">
-                          Let Dust discover if OAuth authentication is required
-                        </Label>
-                        <Tooltip
-                          trigger={
-                            <Icon
-                              visual={InformationCircleIcon}
-                              size="xs"
-                              className="text-gray-400"
-                            />
-                          }
-                          label="Dust will automatically discover if OAuth authentication is required. If OAuth is not needed, the server will be accessed without authentication. Otherwise, Dust will try to use dynamic client registration to get the OAuth credentials."
-                        />
-                      </div>
-                      {!defaultServerConfig && (
-                        <SliderToggle
-                          disabled={authMethod === "oauth-dynamic"}
-                          selected={authMethod === "oauth-dynamic"}
-                          onClick={() => {
-                            setAuthMethod("oauth-dynamic");
-                            setAuthorization(null);
-                            setIsOAuthFormValid(true);
-                          }}
-                        />
-                      )}
-                    </div>
-                  </div>
-                )}
                 {(!defaultServerConfig ||
                   defaultServerConfig?.authMethod === "bearer") && (
                   <div className="space-y-2">
                     <div className="flex items-center justify-between">
                       <div className="flex items-center space-x-2">
-                        <Label htmlFor="requiresBearerToken">
-                          {defaultServerConfig?.authMethod === "bearer"
-                            ? `${defaultServerConfig.name} API Key`
-                            : "Use Bearer Token Authentication"}
-                        </Label>
+                        <Label>Authentication</Label>
                         <Tooltip
                           trigger={
                             <Icon
@@ -377,24 +346,74 @@ export function CreateMCPServerDialog({
                               className="text-gray-400"
                             />
                           }
-                          label="Enable bearer token authentication if the server requires an API key."
+                          label="Choose how to authenticate: Automatic discovery, Bearer token, or Static OAuth credentials. Automatic lets Dust discover if OAuth is required and use dynamic client registration if possible."
                         />
                       </div>
-                      {!defaultServerConfig && (
-                        <SliderToggle
-                          disabled={false}
-                          selected={authMethod === "bearer"}
-                          onClick={() => {
-                            setAuthMethod(
-                              authMethod === "bearer"
-                                ? DEFAULT_AUTH_METHOD
-                                : "bearer"
-                            );
-                            setAuthorization(null);
-                            setIsOAuthFormValid(true);
-                          }}
-                        />
-                      )}
+                      <DropdownMenu>
+                        <DropdownMenuTrigger asChild>
+                          <Button
+                            variant="outline"
+                            isSelect
+                            label={
+                              authMethod === "oauth-dynamic"
+                                ? "Automatic"
+                                : authMethod === "bearer"
+                                  ? defaultServerConfig?.authMethod === "bearer"
+                                    ? `${defaultServerConfig.name} API Key`
+                                    : "Bearer token"
+                                  : "Static OAuth"
+                            }
+                          />
+                        </DropdownMenuTrigger>
+                        <DropdownMenuContent>
+                          <DropdownMenuRadioGroup>
+                            {!defaultServerConfig && (
+                              <DropdownMenuRadioItem
+                                value="oauth-dynamic"
+                                label="Automatic"
+                                onClick={() => {
+                                  setAuthMethod("oauth-dynamic");
+                                  setAuthorization(null);
+                                  setIsOAuthFormValid(true);
+                                }}
+                              />
+                            )}
+                            {(!defaultServerConfig ||
+                              defaultServerConfig?.authMethod === "bearer") && (
+                              <DropdownMenuRadioItem
+                                value="bearer"
+                                label={
+                                  defaultServerConfig?.authMethod === "bearer"
+                                    ? `${defaultServerConfig.name} API Key`
+                                    : "Bearer token"
+                                }
+                                onClick={() => {
+                                  setAuthMethod("bearer");
+                                  setAuthorization(null);
+                                  setIsOAuthFormValid(true);
+                                }}
+                              />
+                            )}
+                            {!defaultServerConfig && (
+                              <DropdownMenuRadioItem
+                                value="oauth-static"
+                                label="Static OAuth"
+                                onClick={() => {
+                                  setAuthMethod("oauth-static");
+                                  setAuthorization({
+                                    provider: "mcp_static",
+                                    supported_use_cases: [
+                                      "platform_actions",
+                                      "personal_actions",
+                                    ],
+                                  });
+                                  setIsOAuthFormValid(false);
+                                }}
+                              />
+                            )}
+                          </DropdownMenuRadioGroup>
+                        </DropdownMenuContent>
+                      </DropdownMenu>
                     </div>
                     {(authMethod === "bearer" ||
                       defaultServerConfig?.authMethod === "bearer") && (
@@ -418,56 +437,13 @@ export function CreateMCPServerDialog({
                         />
                       </div>
                     )}
-                  </div>
-                )}
-                {!defaultServerConfig && (
-                  <div className="space-y-2">
-                    <div className="flex items-center justify-between">
-                      <div className="flex items-center space-x-2">
-                        <Label htmlFor="requiresBearerToken">
-                          Use static OAuth credentials
-                        </Label>
-                        <Tooltip
-                          trigger={
-                            <Icon
-                              visual={InformationCircleIcon}
-                              size="xs"
-                              className="text-gray-400"
-                            />
-                          }
-                          label={
-                            <div>
-                              Use static OAuth credentials to authenticate with
-                              the MCP server. The redirect URI to allow is{" "}
-                              <strong>
-                                {window.origin + "/oauth/mcp_static/finalize"}
-                              </strong>
-                            </div>
-                          }
-                        />
+                    {!defaultServerConfig && authMethod === "oauth-static" && (
+                      <div className="text-xs text-muted-foreground">
+                        The redirect URI to allow is <strong>
+                          {window.origin + "/oauth/mcp_static/finalize"}
+                        </strong>
                       </div>
-                      <SliderToggle
-                        disabled={false}
-                        selected={authMethod === "oauth-static"}
-                        onClick={() => {
-                          if (authMethod === "oauth-static") {
-                            setAuthMethod(DEFAULT_AUTH_METHOD);
-                            setAuthorization(null);
-                            setIsOAuthFormValid(true);
-                          } else {
-                            setAuthMethod("oauth-static");
-                            setAuthorization({
-                              provider: "mcp_static",
-                              supported_use_cases: [
-                                "platform_actions",
-                                "personal_actions",
-                              ],
-                            });
-                            setIsOAuthFormValid(false);
-                          }
-                        }}
-                      />
-                    </div>
+                    )}
                   </div>
                 )}
               </>


### PR DESCRIPTION
## Description

Related to https://github.com/issues/assigned?issue=dust-tt%7Ctasks%7C4039

The 3 exclusive toggles have been migrated to a dropdown


<img width="600" height="300" alt="image" src="https://github.com/user-attachments/assets/2fe75d94-e8e7-4bf5-be25-21381d344bc7" />

Note that I have moved the explanation about auto inlined, it used to be in a tooltip

<img width="600" height="300" alt="image" src="https://github.com/user-attachments/assets/3d8c3193-2f10-4228-af69-ebf0c2aae550" />

<img width="600" height="900" alt="image" src="https://github.com/user-attachments/assets/9137e0b0-30e6-4f5f-ba1a-b07a3df7ac87" />


## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

I manually tested in auto and I can still add a MCP server

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
