### PR TITLE
[sparkle] - chore(ContextItem): allow truncating subelement

### DIFF
--- a/sparkle/src/components/ContextItem.tsx
+++ b/sparkle/src/components/ContextItem.tsx
@@ -56,7 +56,14 @@ export function ContextItem({
         {visual}
         <div className="s-mb-0.5 s-flex s-min-w-0 s-grow s-flex-col s-gap-0">
           <div className="s-flex s-min-w-0 s-grow s-flex-col s-text-foreground dark:s-text-foreground-night sm:s-flex-row sm:s-gap-3">
-            <div className="s-heading-base s-min-w-0 s-overflow-hidden s-text-ellipsis s-whitespace-nowrap">
+            <div
+              className={cn(
+                "s-heading-base",
+                truncateSubElement
+                  ? "s-shrink-0"
+                  : "s-min-w-0 s-overflow-hidden s-text-ellipsis s-whitespace-nowrap"
+              )}
+            >
               {title}
             </div>
             {subElement &&
@@ -67,7 +74,7 @@ export function ContextItem({
                   </div>
                 </div>
               ) : (
-                <div className="s-flex s-flex-shrink-0 s-items-center s-gap-3 s-overflow-hidden s-text-sm s-text-muted-foreground dark:s-text-muted-foreground-night">
+                <div className="s-flex s-items-center s-gap-3 s-overflow-hidden s-text-sm s-text-muted-foreground dark:s-text-muted-foreground-night">
                   {subElement}
                 </div>
               ))}

--- a/sparkle/src/components/ContextItem.tsx
+++ b/sparkle/src/components/ContextItem.tsx
@@ -15,6 +15,7 @@ type ContextItemProps = {
   visual: ReactNode;
   hoverAction?: boolean;
   onClick?: () => void;
+  truncateSubElement?: boolean;
 };
 
 export function ContextItem({
@@ -28,6 +29,7 @@ export function ContextItem({
   visual,
   hoverAction,
   onClick,
+  truncateSubElement,
 }: ContextItemProps) {
   return (
     <div
@@ -57,11 +59,18 @@ export function ContextItem({
             <div className="s-heading-base s-min-w-0 s-overflow-hidden s-text-ellipsis s-whitespace-nowrap">
               {title}
             </div>
-            {subElement && (
-              <div className="s-flex s-flex-shrink-0 s-items-center s-gap-3 s-overflow-hidden s-text-sm s-text-muted-foreground dark:s-text-muted-foreground-night">
-                {subElement}
-              </div>
-            )}
+            {subElement &&
+              (truncateSubElement ? (
+                <div className="s-flex s-min-w-0 s-items-center s-gap-3 s-overflow-hidden s-text-sm s-text-muted-foreground dark:s-text-muted-foreground-night">
+                  <div className="s-min-w-0 s-overflow-hidden s-text-ellipsis s-whitespace-nowrap">
+                    {subElement}
+                  </div>
+                </div>
+              ) : (
+                <div className="s-flex s-flex-shrink-0 s-items-center s-gap-3 s-overflow-hidden s-text-sm s-text-muted-foreground dark:s-text-muted-foreground-night">
+                  {subElement}
+                </div>
+              ))}
           </div>
           {children && <div>{children}</div>}
         </div>

--- a/sparkle/src/components/ToolCard.tsx
+++ b/sparkle/src/components/ToolCard.tsx
@@ -100,7 +100,7 @@ export const ToolCard = React.forwardRef<HTMLDivElement, ToolCardProps>(
                   e.stopPropagation();
                   toolInfo.onClick();
                 }}
-                className="hover:s-underline-offset-2 dark:s-text-muted-foreground-night s-cursor-pointer s-text-sm s-font-semibold s-text-muted-foreground hover:s-text-highlight-light hover:s-underline dark:hover:s-text-highlight-light-night"
+                className="s-cursor-pointer s-text-sm s-font-semibold s-text-muted-foreground hover:s-text-highlight-light hover:s-underline hover:s-underline-offset-2 dark:s-text-muted-foreground-night dark:hover:s-text-highlight-light-night"
               >
                 {toolInfo.label}
               </a>

--- a/sparkle/src/components/WindowUtility.tsx
+++ b/sparkle/src/components/WindowUtility.tsx
@@ -13,10 +13,13 @@ export const breakpoints = {
 
 // Helper function to determine active breakpoint
 function getActiveBreakpoint(width: number): keyof typeof breakpoints {
-  const breakpointEntries = Object.entries(breakpoints) as [keyof typeof breakpoints, number][];
+  const breakpointEntries = Object.entries(breakpoints) as [
+    keyof typeof breakpoints,
+    number,
+  ][];
   // Sort breakpoints from largest to smallest
   const sortedBreakpoints = breakpointEntries.sort(([, a], [, b]) => b - a);
-  
+
   for (const [breakpoint, minWidth] of sortedBreakpoints) {
     if (width >= minWidth) {
       return breakpoint;


### PR DESCRIPTION
## Description

This PR adds a new `truncateSubElement` prop to the `ContextItem` component to provide better control over text truncation behavior. When enabled, the prop reverses the default truncation logic - applying ellipsis to the `subElement` instead of the title, while making the title element non-truncated. This addresses layout scenarios where preserving the full title visibility is more important than the sub-element content.

## Tests

Storybook

## Risk

Low

## Deploy Plan

Publish sparkle
