### PR TITLE
[front] Replace loading button with spinner in `ConversationFilesPopover`

### DIFF
--- a/front/components/assistant/conversation/ConversationFilesPopover.tsx
+++ b/front/components/assistant/conversation/ConversationFilesPopover.tsx
@@ -231,7 +231,7 @@ export function ConversationFilesPopover({
           </div>
 
           {isConversationFilesLoading ? (
-            <div className="flex h-16 w-full items-center justify-center">
+            <div className="flex w-full items-center justify-center p-8">
               <Spinner />
             </div>
           ) : !hasFiles ? (

--- a/front/components/assistant/conversation/ConversationFilesPopover.tsx
+++ b/front/components/assistant/conversation/ConversationFilesPopover.tsx
@@ -8,6 +8,7 @@ import {
   PopoverRoot,
   PopoverTrigger,
   ScrollArea,
+  Spinner,
 } from "@dust-tt/sparkle";
 import React from "react";
 
@@ -194,18 +195,6 @@ export function ConversationFilesPopover({
     setIsOpen(false);
   };
 
-  if (isConversationFilesLoading && isOpen) {
-    return (
-      <Button
-        size="sm"
-        variant="ghost"
-        icon={FolderIcon}
-        tooltip="Loading files..."
-        disabled
-      />
-    );
-  }
-
   return (
     <PopoverRoot
       open={isOpen}
@@ -241,7 +230,11 @@ export function ConversationFilesPopover({
             Generated Content
           </div>
 
-          {!hasFiles ? (
+          {isConversationFilesLoading ? (
+            <div className="flex h-16 w-full items-center justify-center">
+              <Spinner />
+            </div>
+          ) : !hasFiles ? (
             <EmptyFilesState />
           ) : (
             <div className="space-y-4">

--- a/front/pages/api/w/[wId]/assistant/conversations/[cId]/files.ts
+++ b/front/pages/api/w/[wId]/assistant/conversations/[cId]/files.ts
@@ -10,7 +10,7 @@ import { apiError } from "@app/logger/withlogging";
 import type { WithAPIErrorResponse } from "@app/types";
 
 export type GetConversationFilesResponseBody = {
-  files: Array<ActionGeneratedFileType>;
+  files: ActionGeneratedFileType[];
 };
 
 async function handler(


### PR DESCRIPTION
## Description

- This PR changes the behavior when files are loading in the `ConversationFilesPopover`.
- Before: we render a button instead of the popover with a tooltip.

https://github.com/user-attachments/assets/deb705d8-37ab-4f50-abee-bd441083ddcd

- After: we open the popover and show a spinner in place of where the files would be.

https://github.com/user-attachments/assets/eef278fc-955a-499e-ba8c-05cc2d357682

## Tests

- Tested locally.

## Risk

- Low, only UI.

## Deploy Plan

- Deploy front.
