### PR TITLE
Use credential block to pass whether to use EU host

### DIFF
--- a/core/src/blocks/chat.rs
+++ b/core/src/blocks/chat.rs
@@ -313,9 +313,6 @@ impl Block for Chat {
                 if let Some(Value::String(s)) = v.get("openai_organization_id") {
                     extras["openai_organization_id"] = json!(s.clone());
                 }
-                if let Some(Value::Bool(s)) = v.get("use_openai_eu_host") {
-                    extras["use_openai_eu_host"] = json!(s.clone());
-                }
                 if let Some(Value::Object(s)) = v.get("response_format") {
                     extras["response_format"] = json!(s.clone());
                 }

--- a/core/src/providers/openai.rs
+++ b/core/src/providers/openai.rs
@@ -807,9 +807,11 @@ impl LLM for OpenAILLM {
                 Err(_) => false,
             },
         };
-        self.host = match self.use_eu_endpoint {
-            false => Some("api.openai.com".to_string()),
-            true => Some("eu.api.openai.com".to_string()),
+
+        self.host = if self.use_eu_endpoint {
+            Some("eu.api.openai.com".to_string())
+        } else {
+            Some("api.openai.com".to_string())
         };
         info!(model = self.id, host = self.host, "OpenAILLM.initialize");
 

--- a/core/src/providers/openai.rs
+++ b/core/src/providers/openai.rs
@@ -31,6 +31,7 @@ use std::sync::Arc;
 use std::time::Duration;
 use tokio::sync::mpsc::UnboundedSender;
 use tokio::time::timeout;
+use tracing::info;
 
 use super::azure_openai::AzureOpenAIEmbedder;
 use super::openai_compatible_helpers::{
@@ -688,37 +689,35 @@ pub async fn embed(
 
 pub struct OpenAILLM {
     id: String,
+    host: Option<String>,
+    use_eu_endpoint: bool,
     api_key: Option<String>,
 }
 
 impl OpenAILLM {
     pub fn new(id: String) -> Self {
-        OpenAILLM { id, api_key: None }
-    }
-
-    #[inline]
-    fn host(use_openai_eu_host: bool) -> &'static str {
-        if use_openai_eu_host {
-            "eu.api.openai.com"
-        } else {
-            "api.openai.com"
+        OpenAILLM {
+            id,
+            host: None,
+            use_eu_endpoint: false,
+            api_key: None,
         }
     }
 
-    fn uri(&self, use_openai_eu_host: bool) -> Result<Uri> {
-        Ok(format!("https://{}/v1/completions", Self::host(use_openai_eu_host)).parse::<Uri>()?)
+    fn uri(&self) -> Result<Uri> {
+        Ok(format!("https://{}/v1/completions", self.host.as_ref().unwrap()).parse::<Uri>()?)
     }
 
-    fn chat_uri(&self, use_openai_eu_host: bool) -> Result<Uri> {
+    fn chat_uri(&self) -> Result<Uri> {
         Ok(format!(
             "https://{}/v1/chat/completions",
-            Self::host(use_openai_eu_host)
+            self.host.as_ref().unwrap()
         )
         .parse::<Uri>()?)
     }
 
-    fn responses_uri(&self, use_openai_eu_host: bool) -> Result<Uri> {
-        Ok(format!("https://{}/v1/responses", Self::host(use_openai_eu_host)).parse::<Uri>()?)
+    fn responses_uri(&self) -> Result<Uri> {
+        Ok(format!("https://{}/v1/responses", self.host.as_ref().unwrap()).parse::<Uri>()?)
     }
 
     fn tokenizer(&self) -> Arc<RwLock<CoreBPE>> {
@@ -799,6 +798,21 @@ impl LLM for OpenAILLM {
                 ))?,
             },
         }
+        self.use_eu_endpoint = match credentials.get("OPENAI_USE_EU_ENDPOINT") {
+            Some(use_eu_endpoint_str) => use_eu_endpoint_str == "true",
+            None => match tokio::task::spawn_blocking(|| std::env::var("OPENAI_USE_EU_ENDPOINT"))
+                .await?
+            {
+                Ok(use_eu_endpoint_str) => use_eu_endpoint_str == "true",
+                Err(_) => false,
+            },
+        };
+        self.host = match self.use_eu_endpoint {
+            false => Some("api.openai.com".to_string()),
+            true => Some("eu.api.openai.com".to_string()),
+        };
+        info!(model = self.id, host = self.host, "OpenAILLM.initialize");
+
         Ok(())
     }
 
@@ -851,14 +865,6 @@ impl LLM for OpenAILLM {
             None => Err(anyhow!("OPENAI_API_KEY is not set."))?,
         };
 
-        let use_openai_eu_host = match &extras {
-            None => false,
-            Some(v) => match v.get("use_openai_eu_host") {
-                Some(Value::Bool(b)) => *b,
-                _ => false,
-            },
-        };
-
         let (c, request_id) = if event_sender.is_some() {
             if n > 1 {
                 return Err(anyhow!(
@@ -866,7 +872,7 @@ impl LLM for OpenAILLM {
                 ))?;
             }
             streamed_completion(
-                self.uri(use_openai_eu_host)?,
+                self.uri()?,
                 api_key.clone(),
                 match &extras {
                     Some(ex) => match ex.get("openai_organization_id") {
@@ -911,7 +917,7 @@ impl LLM for OpenAILLM {
             .await?
         } else {
             completion(
-                self.uri(use_openai_eu_host)?,
+                self.uri()?,
                 api_key.clone(),
                 match &extras {
                     Some(e) => match e.get("openai_organization_id") {
@@ -1083,18 +1089,10 @@ impl LLM for OpenAILLM {
             None => true,
         };
 
-        let use_openai_eu_host = match &extras {
-            None => false,
-            Some(v) => match v.get("use_openai_eu_host") {
-                Some(Value::Bool(b)) => *b,
-                _ => false,
-            },
-        };
-
         // Use response API only when function_call is not forced and when n == 1.
         if RESPONSES_API_ENABLED && is_auto_function_call && n == 1 && is_reasoning_model {
             openai_responses_api_completion(
-                self.responses_uri(use_openai_eu_host)?,
+                self.responses_uri()?,
                 self.id.clone(),
                 api_key,
                 &messages,
@@ -1105,12 +1103,12 @@ impl LLM for OpenAILLM {
                 event_sender,
                 transform_system_messages,
                 provider_name,
-                use_openai_eu_host,
+                self.use_eu_endpoint,
             )
             .await
         } else {
             openai_compatible_chat_completion(
-                self.chat_uri(use_openai_eu_host)?,
+                self.chat_uri()?,
                 self.id.clone(),
                 api_key,
                 &messages,
@@ -1154,16 +1152,21 @@ pub struct Embeddings {
 
 pub struct OpenAIEmbedder {
     id: String,
+    host: Option<String>,
     api_key: Option<String>,
 }
 
 impl OpenAIEmbedder {
     pub fn new(id: String) -> Self {
-        OpenAIEmbedder { id, api_key: None }
+        OpenAIEmbedder {
+            id,
+            host: None,
+            api_key: None,
+        }
     }
 
     fn uri(&self) -> Result<Uri> {
-        Ok(format!("https://api.openai.com/v1/embeddings",).parse::<Uri>()?)
+        Ok(format!("https://{}/v1/embeddings", self.host.as_ref().unwrap()).parse::<Uri>()?)
     }
 
     fn tokenizer(&self) -> Arc<RwLock<CoreBPE>> {
@@ -1210,6 +1213,24 @@ impl Embedder for OpenAIEmbedder {
                 },
             },
         }
+        let use_eu_endpoint: bool = match credentials.get("OPENAI_USE_EU_ENDPOINT") {
+            Some(use_eu_endpoint_str) => use_eu_endpoint_str == "true",
+            None => match tokio::task::spawn_blocking(|| std::env::var("OPENAI_USE_EU_ENDPOINT"))
+                .await?
+            {
+                Ok(use_eu_endpoint_str) => use_eu_endpoint_str == "true",
+                Err(_) => false,
+            },
+        };
+        self.host = match use_eu_endpoint {
+            false => Some("api.openai.com".to_string()),
+            true => Some("eu.api.openai.com".to_string()),
+        };
+        info!(
+            model = self.id,
+            host = self.host,
+            "OpenAIEmbedder.initialize"
+        );
         Ok(())
     }
 

--- a/front/lib/api/config.ts
+++ b/front/lib/api/config.ts
@@ -272,11 +272,6 @@ const config = {
       "UNTRUSTED_EGRESS_PROXY_PORT"
     );
   },
-  getDustManagedOpenAIAPIKeyEU: (): string | undefined => {
-    return EnvironmentConfig.getOptionalEnvVariable(
-      "DUST_MANAGED_OPENAI_API_KEY_EU"
-    );
-  },
 };
 
 export default config;

--- a/front/pages/api/v1/w/[wId]/spaces/[spaceId]/apps/[aId]/runs/index.ts
+++ b/front/pages/api/v1/w/[wId]/spaces/[spaceId]/apps/[aId]/runs/index.ts
@@ -273,23 +273,16 @@ async function handler(
         keyAuth.getNonNullableWorkspace()
       );
 
-      // When this is on, two things happen:
-      // 1) We use the OpenAI EU endpoint (in Core)
-      // 2) We use the DUST_MANAGED_OPENAI_API_KEY_EU env as the key
-      let useOpenAIEUKey =
-        config.MODEL && // This could be null, e.g. in the config.CREATE_SUGGESTIONS case
-        keyWorkspaceFlags.includes("use_openai_eu_key") &&
-        !!apiConfig.getDustManagedOpenAIAPIKeyEU();
+      // Temporary flag to help test EU OpenAI in specific workspaces.
+      const useOpenAIEUKeyFlag =
+        keyWorkspaceFlags.includes("use_openai_eu_key");
 
       let credentials: CredentialsType | null = null;
       if (auth.isSystemKey() && !useWorkspaceCredentials) {
         // Dust managed credentials: system API key (packaged apps).
-        credentials = dustManagedCredentials({ useOpenAIEU: useOpenAIEUKey });
+        credentials = dustManagedCredentials({ useOpenAIEUKeyFlag });
       } else {
         credentials = credentialsFromProviders(providers);
-
-        // We never want to use the EU hostname with provider credentials.
-        useOpenAIEUKey = false;
       }
 
       if (!auth.isSystemKey()) {
@@ -321,15 +314,11 @@ async function handler(
             name: owner.name,
           },
           app: app.sId,
-          useOpenAIEUKey,
+          useOpenAIEUKeyFlag,
           userWorkspace: keyAuth.getNonNullableWorkspace().sId,
         },
         "App run creation"
       );
-
-      if (useOpenAIEUKey) {
-        config.MODEL.use_openai_eu_host = true;
-      }
 
       const runRes = await coreAPI.createRunStream(
         keyAuth.getNonNullableWorkspace(),

--- a/front/types/api/credentials.ts
+++ b/front/types/api/credentials.ts
@@ -16,6 +16,7 @@ const {
   DUST_MANAGED_FIREWORKS_API_KEY = "",
   DUST_MANAGED_XAI_API_KEY = "",
   DUST_MANAGED_FIRECRAWL_API_KEY = "",
+  DUST_REGION = "",
 } = process.env;
 
 export const credentialsFromProviders = (
@@ -85,16 +86,19 @@ export const credentialsFromProviders = (
 };
 
 export const dustManagedCredentials = (options?: {
-  useOpenAIEU?: boolean;
+  useOpenAIEUKeyFlag?: boolean;
 }): CredentialsType => {
+  const useOpenAIEU =
+    options?.useOpenAIEUKeyFlag && DUST_REGION === "europe-west1";
   return {
     ANTHROPIC_API_KEY: DUST_MANAGED_ANTHROPIC_API_KEY,
     AZURE_OPENAI_API_KEY: DUST_MANAGED_AZURE_OPENAI_API_KEY,
     AZURE_OPENAI_ENDPOINT: DUST_MANAGED_AZURE_OPENAI_ENDPOINT,
     MISTRAL_API_KEY: DUST_MANAGED_MISTRAL_API_KEY,
-    OPENAI_API_KEY: options?.useOpenAIEU
+    OPENAI_API_KEY: useOpenAIEU
       ? DUST_MANAGED_OPENAI_API_KEY_EU
       : DUST_MANAGED_OPENAI_API_KEY,
+    OPENAI_USE_EU_ENDPOINT: useOpenAIEU ? "true" : "false",
     TEXTSYNTH_API_KEY: DUST_MANAGED_TEXTSYNTH_API_KEY,
     GOOGLE_AI_STUDIO_API_KEY: DUST_MANAGED_GOOGLE_AI_STUDIO_API_KEY,
     SERP_API_KEY: DUST_MANAGED_SERP_API_KEY,

--- a/front/types/provider.ts
+++ b/front/types/provider.ts
@@ -5,6 +5,7 @@ export type ProviderType = {
 
 export type CredentialsType = {
   OPENAI_API_KEY?: string;
+  OPENAI_USE_EU_ENDPOINT?: string;
   COHERE_API_KEY?: string;
   AI21_API_KEY?: string;
   AZURE_OPENAI_API_KEY?: string;


### PR DESCRIPTION
## Description

Instead of passing it separately as 'extra', keep the openai cred and the flag that tells us whether it's 'EU' close together, which makes the logic more sane.

I created a gist to show the diff from before my first change for a couple files, which is much easier to look at:
- [openai.rs diff](https://gist.github.com/davidebbo/b21a4171d8ee864757eca82298788278/revisions?diff=unified&w)
- [index.ts diff](https://gist.github.com/davidebbo/abf6085907d65518150adbc9362fe222/revisions?diff=unified&w)

## Tests

Manual

## Risk

Still under flag

## Deploy Plan

Core & Front