### PR TITLE
[front] - chore: bump to sparkle 0.2.623

### DIFF
--- a/extension/package-lock.json
+++ b/extension/package-lock.json
@@ -12,7 +12,7 @@
         "@auth0/auth0-spa-js": "^2.1.3",
         "@datadog/browser-logs": "^6.13.0",
         "@dust-tt/client": "^1.1.15",
-        "@dust-tt/sparkle": "^0.2.622",
+        "@dust-tt/sparkle": "^0.2.623",
         "@frontapp/plugin-sdk": "^1.8.1",
         "@modelcontextprotocol/sdk": "^1.9.0",
         "@tailwindcss/forms": "^0.5.9",
@@ -1293,10 +1293,9 @@
       }
     },
     "node_modules/@dust-tt/sparkle": {
-      "version": "0.2.622",
-      "resolved": "https://registry.npmjs.org/@dust-tt/sparkle/-/sparkle-0.2.622.tgz",
-      "integrity": "sha512-R++o1Vf+zZ/A4dn8moaQhD08EFQl+lgrMpqLxOVzym1Pg+IIczTaI146g/X9ksMvNlMnSbC4lc/KMOpco2mocA==",
-      "license": "ISC",
+      "version": "0.2.623",
+      "resolved": "https://registry.npmjs.org/@dust-tt/sparkle/-/sparkle-0.2.623.tgz",
+      "integrity": "sha512-wOiG0SPqZSmNS1Bip4O1e4ozLVKx2vchOcAUsA+5ybnNg9qdSj4YuVnNJXC2TGFHugp9kPJKgYuPc8pF5mXnCQ==",
       "dependencies": {
         "@emoji-mart/data": "^1.1.2",
         "@emoji-mart/react": "^1.1.1",

--- a/extension/package.json
+++ b/extension/package.json
@@ -59,7 +59,7 @@
     "@auth0/auth0-spa-js": "^2.1.3",
     "@datadog/browser-logs": "^6.13.0",
     "@dust-tt/client": "^1.1.15",
-    "@dust-tt/sparkle": "^0.2.622",
+    "@dust-tt/sparkle": "^0.2.623",
     "@frontapp/plugin-sdk": "^1.8.1",
     "@modelcontextprotocol/sdk": "^1.9.0",
     "@tailwindcss/forms": "^0.5.9",

--- a/front/components/agent_builder/capabilities/knowledge/KnowledgeFooter.tsx
+++ b/front/components/agent_builder/capabilities/knowledge/KnowledgeFooter.tsx
@@ -81,6 +81,7 @@ function KnowledgeFooterItem({
     <ContextItem
       key={item.path}
       title={item.name}
+      truncateSubElement
       visual={<Icon size="sm" visual={VisualComponent} />}
       action={
         <Button
@@ -116,7 +117,7 @@ export function KnowledgeFooter() {
       </CollapsibleTrigger>
       <CollapsibleContent>
         <div className="rounded-xl bg-muted dark:bg-muted-night">
-          <ContextItem.List className="max-h-40 overflow-x-scroll">
+          <ContextItem.List className="max-h-40 overflow-y-auto">
             {field.value.in.map((item) => (
               <KnowledgeFooterItem key={item.path} item={item} />
             ))}

--- a/front/package-lock.json
+++ b/front/package-lock.json
@@ -7,7 +7,7 @@
       "dependencies": {
         "@datadog/browser-logs": "^6.13.0",
         "@dust-tt/client": "file:../sdks/js",
-        "@dust-tt/sparkle": "^0.2.622",
+        "@dust-tt/sparkle": "^0.2.623",
         "@google-cloud/bigquery": "^7.9.1",
         "@google-cloud/storage-transfer": "^3.6.0",
         "@heroicons/react": "^2.0.11",
@@ -1126,10 +1126,9 @@
       "link": true
     },
     "node_modules/@dust-tt/sparkle": {
-      "version": "0.2.622",
-      "resolved": "https://registry.npmjs.org/@dust-tt/sparkle/-/sparkle-0.2.622.tgz",
-      "integrity": "sha512-R++o1Vf+zZ/A4dn8moaQhD08EFQl+lgrMpqLxOVzym1Pg+IIczTaI146g/X9ksMvNlMnSbC4lc/KMOpco2mocA==",
-      "license": "ISC",
+      "version": "0.2.623",
+      "resolved": "https://registry.npmjs.org/@dust-tt/sparkle/-/sparkle-0.2.623.tgz",
+      "integrity": "sha512-wOiG0SPqZSmNS1Bip4O1e4ozLVKx2vchOcAUsA+5ybnNg9qdSj4YuVnNJXC2TGFHugp9kPJKgYuPc8pF5mXnCQ==",
       "dependencies": {
         "@emoji-mart/data": "^1.1.2",
         "@emoji-mart/react": "^1.1.1",

--- a/front/package.json
+++ b/front/package.json
@@ -27,7 +27,7 @@
   "dependencies": {
     "@datadog/browser-logs": "^6.13.0",
     "@dust-tt/client": "file:../sdks/js",
-    "@dust-tt/sparkle": "^0.2.622",
+    "@dust-tt/sparkle": "^0.2.623",
     "@google-cloud/bigquery": "^7.9.1",
     "@google-cloud/storage-transfer": "^3.6.0",
     "@heroicons/react": "^2.0.11",


### PR DESCRIPTION
## Description

This PR updates the @dust-tt/sparkle dependency to the latest version which brings https://github.com/dust-tt/dust/pull/16078 changes

## Tests

Locally

## Risk

Low

## Deploy Plan

Deploy front