### PR TITLE
[Poke] GC Google Drive Document: accept comma-separated IDs

### DIFF
--- a/front/lib/api/poke/plugins/data_sources/garbage_collect_google_drive_document.ts
+++ b/front/lib/api/poke/plugins/data_sources/garbage_collect_google_drive_document.ts
@@ -39,14 +39,15 @@ export const garbageCollectGoogleDriveDocumentPlugin = createPlugin({
   manifest: {
     id: "garbage-collect-google-drive-document",
     name: "GC Google Drive Document",
-    description: "Garbage collect Google Drive document.",
+    description:
+      "Garbage collect Google Drive document(s). Accepts a single ID or a comma-separated list.",
     resourceTypes: ["data_sources"],
     args: {
       documentId: {
         type: "string",
-        label: "Document ID",
+        label: "Document ID(s)",
         description:
-          "Document ID to garbage collect. e.g. gdrive-1sz1eozmkoydwK63KkO4MMmXKuzqtYrHF",
+          "Document ID to garbage collect, or a comma-separated list. e.g. gdrive-1sz1eozmkoydwK63KkO4MMmXKuzqtYrHF or gdrive-abc, gdrive-def",
       },
     },
   },
@@ -67,18 +68,44 @@ export const garbageCollectGoogleDriveDocumentPlugin = createPlugin({
       return new Err(new Error("No connector on datasource."));
     }
 
-    const { documentId } = args;
+    const rawDocumentIds = args.documentId.trim();
+    if (!rawDocumentIds) {
+      return new Err(new Error("documentId is required"));
+    }
 
-    const gcRes = await garbageCollectGoogleDriveDocument(dataSource, {
-      documentId,
-    });
-    if (gcRes.isErr()) {
-      return new Err(gcRes.error);
+    const documentIds = rawDocumentIds
+      .split(",")
+      .map((d) => d.trim())
+      .filter((d) => d.length > 0);
+
+    const failures: { id: string; error: string }[] = [];
+    let successCount = 0;
+
+    for (const id of documentIds) {
+      const gcRes = await garbageCollectGoogleDriveDocument(dataSource, {
+        documentId: id,
+      });
+      if (gcRes.isErr()) {
+        failures.push({ id, error: gcRes.error.message });
+      } else {
+        successCount += 1;
+      }
+    }
+
+    if (failures.length > 0) {
+      const failedList = failures
+        .map((f) => `${f.id}: ${f.error}`)
+        .join("; ");
+      return new Err(
+        new Error(
+          `Garbage collection failed for ${failures.length}/${documentIds.length} document(s): ${failedList}`
+        )
+      );
     }
 
     return new Ok({
       display: "text",
-      value: `Document ${documentId} garbage collected successfully.`,
+      value: `Garbage collected ${successCount} document(s).`,
     });
   },
 });

--- a/front/lib/api/poke/plugins/data_sources/garbage_collect_google_drive_document.ts
+++ b/front/lib/api/poke/plugins/data_sources/garbage_collect_google_drive_document.ts
@@ -93,9 +93,7 @@ export const garbageCollectGoogleDriveDocumentPlugin = createPlugin({
     }
 
     if (failures.length > 0) {
-      const failedList = failures
-        .map((f) => `${f.id}: ${f.error}`)
-        .join("; ");
+      const failedList = failures.map((f) => `${f.id}: ${f.error}`).join("; ");
       return new Err(
         new Error(
           `Garbage collection failed for ${failures.length}/${documentIds.length} document(s): ${failedList}`


### PR DESCRIPTION
## Description
- Update GC Google Drive Document poke plugin to accept either a single document ID or a comma-separated list.
- Adjust manifest label/description; keep arg name as 'documentId' for backward compatibility.
- Execute now splits on commas, trims entries, runs GC per ID, aggregates failures.

## Risks
Blast radius: Poke admin plugin for Google Drive Data Sources only
Risk: low

## Deploy Plan
- Deploy front (standard)
- No migrations or config changes