### PR TITLE
Add rename and move functionality to Google Sheets MCP

### DIFF
--- a/front/lib/actions/mcp_internal_actions/constants.ts
+++ b/front/lib/actions/mcp_internal_actions/constants.ts
@@ -615,6 +615,8 @@ The directive should be used to display a clickable version of the agent name in
       delete_worksheet: "low",
       format_cells: "low",
       copy_sheet: "low",
+      rename_worksheet: "low",
+      move_worksheet: "low",
     },
     tools_retry_policies: undefined,
     timeoutMs: undefined,

--- a/front/lib/actions/mcp_internal_actions/servers/google_sheets.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/google_sheets.ts
@@ -612,6 +612,101 @@ const createServer = (): McpServer => {
     }
   );
 
+  server.tool(
+    "rename_worksheet",
+    "Rename a worksheet in a Google Sheets spreadsheet.",
+    {
+      spreadsheetId: z.string().describe("The ID of the spreadsheet."),
+      sheetId: z.number().describe("The ID of the worksheet to rename."),
+      newTitle: z.string().describe("The new title for the worksheet."),
+    },
+    async ({ spreadsheetId, sheetId, newTitle }, { authInfo }) => {
+      const sheets = await getSheetsClient(authInfo);
+      if (!sheets) {
+        return makeMCPToolTextError(
+          "Failed to authenticate with Google Sheets"
+        );
+      }
+
+      try {
+        const res = await sheets.spreadsheets.batchUpdate({
+          spreadsheetId,
+          requestBody: {
+            requests: [
+              {
+                updateSheetProperties: {
+                  properties: {
+                    sheetId,
+                    title: newTitle,
+                  },
+                  fields: "title",
+                },
+              },
+            ],
+          },
+        });
+
+        return makeMCPToolJSONSuccess({
+          result: res.data,
+        });
+      } catch (err) {
+        return makeMCPToolTextError(
+          normalizeError(err).message || "Failed to rename worksheet"
+        );
+      }
+    }
+  );
+
+  server.tool(
+    "move_worksheet",
+    "Move a worksheet to a new position in a Google Sheets spreadsheet.",
+    {
+      spreadsheetId: z.string().describe("The ID of the spreadsheet."),
+      sheetId: z.number().describe("The ID of the worksheet to move."),
+      newIndex: z
+        .number()
+        .min(0)
+        .describe(
+          "The new zero-based index position for the worksheet. 0 = first position, 1 = second position, etc."
+        ),
+    },
+    async ({ spreadsheetId, sheetId, newIndex }, { authInfo }) => {
+      const sheets = await getSheetsClient(authInfo);
+      if (!sheets) {
+        return makeMCPToolTextError(
+          "Failed to authenticate with Google Sheets"
+        );
+      }
+
+      try {
+        const res = await sheets.spreadsheets.batchUpdate({
+          spreadsheetId,
+          requestBody: {
+            requests: [
+              {
+                updateSheetProperties: {
+                  properties: {
+                    sheetId,
+                    index: newIndex,
+                  },
+                  fields: "index",
+                },
+              },
+            ],
+          },
+        });
+
+        return makeMCPToolJSONSuccess({
+          result: res.data,
+        });
+      } catch (err) {
+        return makeMCPToolTextError(
+          normalizeError(err).message || "Failed to move worksheet"
+        );
+      }
+    }
+  );
+
   return server;
 };
 


### PR DESCRIPTION
## Description

Adds two new tools to the GSheets MCP server

1. rename a sheet
2. move it to a defined position

## Tests

Tested manually

## Risk

No changes to or overlap with existing functionality. It's easy to rollback changes within any impacted sheets with version history. Minimal deployment risk.
