### PR TITLE
[front] Migrate `getMCPActionsForAgent` to `AgentMCPActionResource`

### DIFF
--- a/front/lib/resources/agent_mcp_action_resource.ts
+++ b/front/lib/resources/agent_mcp_action_resource.ts
@@ -2,8 +2,10 @@ import assert from "assert";
 import type {
   Attributes,
   CreationAttributes,
+  IncludeOptions,
   NonAttribute,
   Transaction,
+  WhereOptions,
 } from "sequelize";
 import { Op } from "sequelize";
 
@@ -22,7 +24,11 @@ import { getAgentConfigurations } from "@app/lib/api/assistant/configuration/age
 import type { Authenticator } from "@app/lib/auth";
 import { AgentMCPActionModel } from "@app/lib/models/assistant/actions/mcp";
 import { AgentStepContentModel } from "@app/lib/models/assistant/agent_step_content";
-import { AgentMessage, Message } from "@app/lib/models/assistant/conversation";
+import {
+  AgentMessage,
+  ConversationModel,
+  Message,
+} from "@app/lib/models/assistant/conversation";
 import { BaseResource } from "@app/lib/resources/base_resource";
 import { ConversationResource } from "@app/lib/resources/conversation_resource";
 import { MCPServerViewResource } from "@app/lib/resources/mcp_server_view_resource";
@@ -31,6 +37,7 @@ import type { ModelStaticWorkspaceAware } from "@app/lib/resources/storage/wrapp
 import { getResourceIdFromSId, makeSId } from "@app/lib/resources/string_ids";
 import type { ResourceFindOptions } from "@app/lib/resources/types";
 import logger from "@app/logger/logger";
+import type { GetMCPActionsResult } from "@app/pages/api/w/[wId]/labs/mcp_actions/[agentId]";
 import type { ModelId, Result } from "@app/types";
 import { Err, isString, normalizeError, Ok, removeNulls } from "@app/types";
 import type { AgentMCPActionType } from "@app/types/actions";
@@ -402,6 +409,124 @@ export class AgentMCPActionResource extends BaseResource<AgentMCPActionModel> {
   ): Promise<AgentMCPActionResource[]> {
     return this.baseFetch(auth, {
       where: { agentMessageId: { [Op.in]: agentMessageIds } },
+    });
+  }
+
+  static async listByAgent(
+    auth: Authenticator,
+    {
+      agentConfigurationId,
+      limit,
+      cursor,
+    }: {
+      agentConfigurationId: string;
+      limit: number;
+      cursor?: string;
+    }
+  ): Promise<Result<GetMCPActionsResult, Error>> {
+    const owner = auth.getNonNullableWorkspace();
+
+    const whereClause: WhereOptions<AgentStepContentModel> = {
+      workspaceId: owner.id,
+      type: "function_call",
+    };
+
+    if (cursor) {
+      const cursorDate = new Date(cursor);
+      if (isNaN(cursorDate.getTime())) {
+        return new Err(new Error("Invalid cursor format"));
+      }
+      whereClause.createdAt = {
+        [Op.lt]: cursorDate,
+      };
+    }
+
+    const includeClause: IncludeOptions[] = [
+      {
+        model: AgentMessage,
+        as: "agentMessage",
+        required: true,
+        where: {
+          agentConfigurationId,
+        },
+        include: [
+          {
+            model: Message,
+            as: "message",
+            required: true,
+            include: [
+              {
+                model: ConversationModel,
+                as: "conversation",
+                required: true,
+                where: {
+                  visibility: { [Op.ne]: "deleted" },
+                },
+              },
+            ],
+          },
+        ],
+      },
+      {
+        model: AgentMCPActionModel,
+        as: "agentMCPActions",
+        required: true,
+      },
+    ];
+
+    const [totalCount, stepContents] = await Promise.all([
+      AgentStepContentModel.count({
+        include: includeClause,
+        where: whereClause,
+      }),
+      AgentStepContentModel.findAll({
+        include: includeClause,
+        where: whereClause,
+        order: [["createdAt", "DESC"]],
+        limit: limit + 1,
+      }),
+    ]);
+
+    const hasMore = stepContents.length > limit;
+    const actualStepContents = hasMore
+      ? stepContents.slice(0, limit)
+      : stepContents;
+    const nextCursor = hasMore
+      ? actualStepContents[
+          actualStepContents.length - 1
+        ].createdAt.toISOString()
+      : null;
+
+    const actions = actualStepContents.flatMap((stepContent) =>
+      (stepContent.agentMCPActions ?? []).map((action) => {
+        assert(
+          stepContent.agentMessage?.message?.conversation,
+          "Missing required relations"
+        );
+        assert(
+          stepContent.value.type === "function_call",
+          "Step content must be a function call"
+        );
+
+        return {
+          sId: AgentMCPActionResource.modelIdToSId({
+            id: action.id,
+            workspaceId: action.workspaceId,
+          }),
+          createdAt: action.createdAt.toISOString(),
+          functionCallName: stepContent.value.value.name,
+          params: JSON.parse(stepContent.value.value.arguments),
+          status: action.status,
+          conversationId: stepContent.agentMessage.message.conversation.sId,
+          messageId: stepContent.agentMessage.message.sId,
+        };
+      })
+    );
+
+    return new Ok({
+      actions,
+      nextCursor,
+      totalCount,
     });
   }
 

--- a/front/lib/resources/agent_mcp_action_resource.ts
+++ b/front/lib/resources/agent_mcp_action_resource.ts
@@ -38,7 +38,7 @@ import { getResourceIdFromSId, makeSId } from "@app/lib/resources/string_ids";
 import type { ResourceFindOptions } from "@app/lib/resources/types";
 import logger from "@app/logger/logger";
 import type { GetMCPActionsResult } from "@app/pages/api/w/[wId]/labs/mcp_actions/[agentId]";
-import type { ModelId, Result } from "@app/types";
+import type { LightAgentConfigurationType, ModelId, Result } from "@app/types";
 import { Err, isString, normalizeError, Ok, removeNulls } from "@app/types";
 import type { AgentMCPActionType } from "@app/types/actions";
 import type { FunctionCallContentType } from "@app/types/assistant/agent_message_content";
@@ -415,11 +415,11 @@ export class AgentMCPActionResource extends BaseResource<AgentMCPActionModel> {
   static async listByAgent(
     auth: Authenticator,
     {
-      agentConfigurationId,
+      agentConfiguration,
       limit,
       cursor,
     }: {
-      agentConfigurationId: string;
+      agentConfiguration: LightAgentConfigurationType;
       limit: number;
       cursor?: string;
     }
@@ -447,7 +447,7 @@ export class AgentMCPActionResource extends BaseResource<AgentMCPActionModel> {
         as: "agentMessage",
         required: true,
         where: {
-          agentConfigurationId,
+          agentConfigurationId: agentConfiguration.sId,
         },
         include: [
           {

--- a/front/lib/resources/agent_mcp_action_resource.ts
+++ b/front/lib/resources/agent_mcp_action_resource.ts
@@ -423,6 +423,8 @@ export class AgentMCPActionResource extends BaseResource<AgentMCPActionModel> {
       limit: number;
       cursor?: string;
     }
+    // TODO(2025-09-19 aubin): fix this return type, the resource should not need to be aware of
+    //  API-specific types.
   ): Promise<Result<GetMCPActionsResult, Error>> {
     const owner = auth.getNonNullableWorkspace();
 
@@ -474,6 +476,7 @@ export class AgentMCPActionResource extends BaseResource<AgentMCPActionModel> {
       },
     ];
 
+    // TODO(2025-09-19 aubin): extract these in methods of AgentStepContentResource.
     const [totalCount, stepContents] = await Promise.all([
       AgentStepContentModel.count({
         include: includeClause,

--- a/front/lib/resources/agent_step_content_resource.ts
+++ b/front/lib/resources/agent_step_content_resource.ts
@@ -3,10 +3,8 @@ import _ from "lodash";
 import type {
   Attributes,
   CreationAttributes,
-  IncludeOptions,
   ModelStatic,
   Transaction,
-  WhereOptions,
 } from "sequelize";
 import { Op } from "sequelize";
 
@@ -21,12 +19,7 @@ import {
   AgentMCPActionOutputItem,
 } from "@app/lib/models/assistant/actions/mcp";
 import { AgentStepContentModel } from "@app/lib/models/assistant/agent_step_content";
-import {
-  AgentMessage,
-  ConversationModel,
-  Message,
-} from "@app/lib/models/assistant/conversation";
-import { AgentMCPActionResource } from "@app/lib/resources/agent_mcp_action_resource";
+import { AgentMessage } from "@app/lib/models/assistant/conversation";
 import { BaseResource } from "@app/lib/resources/base_resource";
 import { FileResource } from "@app/lib/resources/file_resource";
 import { FileModel } from "@app/lib/resources/storage/models/files";
@@ -34,7 +27,6 @@ import type { ReadonlyAttributesType } from "@app/lib/resources/storage/types";
 import { makeSId } from "@app/lib/resources/string_ids";
 import { withTransaction } from "@app/lib/utils/sql_utils";
 import logger from "@app/logger/logger";
-import type { GetMCPActionsResult } from "@app/pages/api/w/[wId]/labs/mcp_actions/[agentId]";
 import type { ModelId, Result } from "@app/types";
 import { Err, Ok, removeNulls } from "@app/types";
 import type {
@@ -468,125 +460,6 @@ export class AgentStepContentResource extends BaseResource<AgentStepContentModel
         },
         transaction
       );
-    });
-  }
-
-  static async getMCPActionsForAgent(
-    auth: Authenticator,
-    {
-      agentConfigurationId,
-      limit,
-      cursor,
-    }: {
-      agentConfigurationId: string;
-      limit: number;
-      cursor?: string;
-    }
-  ): Promise<Result<GetMCPActionsResult, Error>> {
-    const owner = auth.getNonNullableWorkspace();
-
-    const whereClause: WhereOptions<AgentStepContentModel> = {
-      workspaceId: owner.id,
-      type: "function_call",
-    };
-
-    if (cursor) {
-      const cursorDate = new Date(cursor);
-      if (isNaN(cursorDate.getTime())) {
-        return new Err(new Error("Invalid cursor format"));
-      }
-      whereClause.createdAt = {
-        [Op.lt]: cursorDate,
-      };
-    }
-
-    const includeClause: IncludeOptions[] = [
-      {
-        model: AgentMessage,
-        as: "agentMessage",
-        required: true,
-        where: {
-          agentConfigurationId: agentConfigurationId,
-        },
-        include: [
-          {
-            model: Message,
-            as: "message",
-            required: true,
-            include: [
-              {
-                model: ConversationModel,
-                as: "conversation",
-                required: true,
-                where: {
-                  visibility: { [Op.ne]: "deleted" },
-                },
-              },
-            ],
-          },
-        ],
-      },
-      {
-        model: AgentMCPActionModel,
-        as: "agentMCPActions",
-        required: true,
-      },
-    ];
-
-    const [totalCount, stepContents] = await Promise.all([
-      this.model.count({
-        include: includeClause,
-        where: whereClause,
-      }),
-      this.model.findAll({
-        include: includeClause,
-        where: whereClause,
-        order: [["createdAt", "DESC"]],
-        limit: limit + 1,
-      }),
-    ]);
-
-    const hasMore = stepContents.length > limit;
-    const actualStepContents = hasMore
-      ? stepContents.slice(0, limit)
-      : stepContents;
-    const nextCursor = hasMore
-      ? actualStepContents[
-          actualStepContents.length - 1
-        ].createdAt.toISOString()
-      : null;
-
-    const actions = actualStepContents.flatMap((stepContent) =>
-      // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
-      (stepContent.agentMCPActions || []).map((action) => {
-        assert(
-          stepContent.agentMessage?.message?.conversation,
-          "Missing required relations"
-        );
-        assert(
-          stepContent.value.type === "function_call",
-          "Step content must be a function call"
-        );
-
-        return {
-          sId: AgentMCPActionResource.modelIdToSId({
-            id: action.id,
-            workspaceId: action.workspaceId,
-          }),
-          createdAt: action.createdAt.toISOString(),
-          functionCallName: stepContent.value.value.name,
-          params: JSON.parse(stepContent.value.value.arguments),
-          status: action.status,
-          conversationId: stepContent.agentMessage.message.conversation.sId,
-          messageId: stepContent.agentMessage.message.sId,
-        };
-      })
-    );
-
-    return new Ok({
-      actions,
-      nextCursor,
-      totalCount,
     });
   }
 }

--- a/front/pages/api/w/[wId]/labs/mcp_actions/[agentId]/index.ts
+++ b/front/pages/api/w/[wId]/labs/mcp_actions/[agentId]/index.ts
@@ -9,7 +9,7 @@ import { getAgentConfiguration } from "@app/lib/api/assistant/configuration/agen
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
 import type { Authenticator } from "@app/lib/auth";
 import { getFeatureFlags } from "@app/lib/auth";
-import { AgentStepContentResource } from "@app/lib/resources/agent_step_content_resource";
+import { AgentMCPActionResource } from "@app/lib/resources/agent_mcp_action_resource";
 import { apiError } from "@app/logger/withlogging";
 import type { WithAPIErrorResponse } from "@app/types";
 
@@ -106,14 +106,11 @@ async function handler(
         });
       }
 
-      const result = await AgentStepContentResource.getMCPActionsForAgent(
-        auth,
-        {
-          agentConfigurationId: agentConfiguration.sId,
-          limit,
-          cursor,
-        }
-      );
+      const result = await AgentMCPActionResource.listByAgent(auth, {
+        agentConfigurationId: agentConfiguration.sId,
+        limit,
+        cursor,
+      });
 
       if (result.isErr()) {
         const error = result.error;

--- a/front/pages/api/w/[wId]/labs/mcp_actions/[agentId]/index.ts
+++ b/front/pages/api/w/[wId]/labs/mcp_actions/[agentId]/index.ts
@@ -107,7 +107,7 @@ async function handler(
       }
 
       const result = await AgentMCPActionResource.listByAgent(auth, {
-        agentConfigurationId: agentConfiguration.sId,
+        agentConfiguration,
         limit,
         cursor,
       });


### PR DESCRIPTION
## Description

- This PR moves the `getMCPActionsForAgent` currently used for the labs mcp dashboard from the `AgentStepContentResource` to the `AgentMCPActionResource`.

## Tests

- Tested locally.

## Risk

- Low, only affects the labs dashboard.

## Deploy Plan

- Deploy front.
