### PR TITLE
Custom MCP Sever: Add possibility to set custom headers in remote MCP connection

### DIFF
--- a/front/components/actions/mcp/ConnectMCPServerDialog.tsx
+++ b/front/components/actions/mcp/ConnectMCPServerDialog.tsx
@@ -82,7 +82,12 @@ export function ConnectMCPServerDialog({
         ) {
           setIsLoading(true);
           const discoverOAuthMetadataRes = await discoverOAuthMetadata(
-            mcpServerView.server.url
+            mcpServerView.server.url,
+            mcpServerView.server.customHeaders
+              ? Object.entries(mcpServerView.server.customHeaders).map(
+                  ([key, value]) => ({ key, value: String(value) })
+                )
+              : undefined
           );
 
           if (

--- a/front/components/actions/mcp/CreateMCPServerDialog.tsx
+++ b/front/components/actions/mcp/CreateMCPServerDialog.tsx
@@ -42,9 +42,9 @@ import {
   setupOAuthConnection,
   validateUrl,
 } from "@app/types";
+import { sanitizeHeadersArray } from "@app/types";
 
 import { McpServerHeaders } from "./MCPServerHeaders";
-import { sanitizeHeadersArray } from "@app/types";
 
 const DEFAULT_AUTH_METHOD = "oauth-dynamic";
 
@@ -90,10 +90,13 @@ export function CreateMCPServerDialog({
     "oauth-dynamic" | "oauth-static" | "bearer"
   >(DEFAULT_AUTH_METHOD);
   const [useCustomHeaders, setUseCustomHeaders] = useState(false);
-  const [customHeaders, setCustomHeaders] = useState<{ key: string; value: string }[]>([]);
+  const [customHeaders, setCustomHeaders] = useState<
+    { key: string; value: string }[]
+  >([]);
 
   const sanitizeHeaders = useCallback(
-    (headers: { key: string; value: string }[]) => sanitizeHeadersArray(headers),
+    (headers: { key: string; value: string }[]) =>
+      sanitizeHeadersArray(headers),
     []
   );
 
@@ -131,7 +134,7 @@ export function CreateMCPServerDialog({
     setIsOAuthFormValid(true);
     setAuthorization(null);
     setUseCustomHeaders(false);
-    setCustomHeaders([])
+    setCustomHeaders([]);
   }, [setExternalIsLoading]);
 
   const handleSave = async (e: React.MouseEvent<HTMLButtonElement>) => {
@@ -254,7 +257,9 @@ export function CreateMCPServerDialog({
         includeGlobal: true,
         sharedSecret: authMethod === "bearer" ? sharedSecret : undefined,
         oauthConnection,
-        customHeaders: useCustomHeaders ? sanitizeHeaders(customHeaders) : undefined,
+        customHeaders: useCustomHeaders
+          ? sanitizeHeaders(customHeaders)
+          : undefined,
       });
 
       if (createRes.isErr()) {
@@ -496,9 +501,7 @@ export function CreateMCPServerDialog({
             <div className="space-y-2">
               <div className="flex items-center justify-between">
                 <div className="flex items-center space-x-2">
-                  <Label htmlFor="customHeaders">
-                    Use custom headers
-                  </Label>
+                  <Label htmlFor="customHeaders">Use custom headers</Label>
                   <Tooltip
                     trigger={
                       <Icon

--- a/front/components/actions/mcp/CreateMCPServerDialog.tsx
+++ b/front/components/actions/mcp/CreateMCPServerDialog.tsx
@@ -44,6 +44,7 @@ import {
 } from "@app/types";
 
 import { McpServerHeaders } from "./MCPServerHeaders";
+import { sanitizeHeadersArray } from "@app/types";
 
 const DEFAULT_AUTH_METHOD = "oauth-dynamic";
 
@@ -92,10 +93,7 @@ export function CreateMCPServerDialog({
   const [customHeaders, setCustomHeaders] = useState<{ key: string; value: string }[]>([]);
 
   const sanitizeHeaders = useCallback(
-    (headers: { key: string; value: string }[]) =>
-      headers
-        .map(({ key, value }) => ({ key: key.trim(), value: value.trim() }))
-        .filter(({ key, value }) => key.length > 0 && value.length > 0),
+    (headers: { key: string; value: string }[]) => sanitizeHeadersArray(headers),
     []
   );
 

--- a/front/components/actions/mcp/MCPServerHeaders.tsx
+++ b/front/components/actions/mcp/MCPServerHeaders.tsx
@@ -1,0 +1,78 @@
+import {
+  Button,
+  Input,
+  XMarkIcon,
+} from "@dust-tt/sparkle";
+
+import { WebCrawlerHeaderRedactedValue } from "@app/types";
+
+type Header = { key: string; value: string };
+
+type McpServerHeadersProps = {
+  headers: Header[];
+  onHeadersChange: (headers: Header[]) => void;
+};
+
+export function McpServerHeaders({
+  headers,
+  onHeadersChange,
+}: McpServerHeadersProps) {
+  const updateHeaderField = (
+    index: number,
+    field: keyof Header,
+    value: string
+  ) => {
+    const newHeaders = [...headers];
+    newHeaders[index] = { ...newHeaders[index], [field]: value };
+    onHeadersChange(newHeaders);
+  };
+
+  const removeHeader = (index: number) => {
+    onHeadersChange(headers.filter((_, i) => i !== index));
+  };
+
+  const addHeader = () => {
+    onHeadersChange([...headers, { key: "", value: "" }]);
+  };
+
+  return (
+        <div className="flex w-full flex-col gap-6">
+          <div className="flex w-full flex-col gap-3">
+            <div className="flex flex-col gap-4">
+              {headers.map((header, index) => (
+                <div key={index} className="flex gap-2">
+                  <div className="flex grow flex-col gap-1 px-1">
+                    <Input
+                      placeholder="Header Name"
+                      value={header.key}
+                      name="headerName"
+                      onChange={(e) =>
+                        updateHeaderField(index, "key", e.target.value)
+                      }
+                      disabled={header.value === WebCrawlerHeaderRedactedValue}
+                      className="grow"
+                    />
+                    <Input
+                      name="headerValue"
+                      placeholder="Header Value"
+                      value={header.value}
+                      onChange={(e) =>
+                        updateHeaderField(index, "value", e.target.value)
+                      }
+                      disabled={header.value === WebCrawlerHeaderRedactedValue}
+                      className="flex-1"
+                    />
+                  </div>
+                  <Button
+                    variant="outline"
+                    icon={XMarkIcon}
+                    onClick={() => removeHeader(index)}
+                  />
+                </div>
+              ))}
+            </div>
+            <Button variant="outline" label="Add Header" onClick={addHeader} />
+          </div>
+        </div>
+  );
+}

--- a/front/components/actions/mcp/MCPServerHeaders.tsx
+++ b/front/components/actions/mcp/MCPServerHeaders.tsx
@@ -1,4 +1,6 @@
 import { Button, Input, XMarkIcon } from "@dust-tt/sparkle";
+import type {ChangeEvent} from "react";
+import { useCallback } from "react";
 
 import { WebCrawlerHeaderRedactedValue } from "@app/types";
 
@@ -13,15 +15,21 @@ export function McpServerHeaders({
   headers,
   onHeadersChange,
 }: McpServerHeadersProps) {
-  const updateHeaderField = (
-    index: number,
-    field: keyof Header,
-    value: string
-  ) => {
-    const newHeaders = [...headers];
-    newHeaders[index] = { ...newHeaders[index], [field]: value };
-    onHeadersChange(newHeaders);
-  };
+  const updateHeaderField = useCallback(
+    (index: number, field: keyof Header, value: string) => {
+      const newHeaders = [...headers];
+      newHeaders[index] = { ...newHeaders[index], [field]: value };
+      onHeadersChange(newHeaders);
+    },
+    [headers, onHeadersChange]
+  );
+
+  const getChangeHandler = useCallback(
+    (index: number, field: keyof Header) =>
+      (e: ChangeEvent<HTMLInputElement>) =>
+        updateHeaderField(index, field, e.target.value),
+    [updateHeaderField]
+  );
 
   const removeHeader = (index: number) => {
     onHeadersChange(headers.filter((_, i) => i !== index));
@@ -43,9 +51,7 @@ export function McpServerHeaders({
                     placeholder="Header Name"
                     value={header.key}
                     name="headerName"
-                    onChange={(e) =>
-                      updateHeaderField(index, "key", e.target.value)
-                    }
+                    onChange={getChangeHandler(index, "key")}
                     disabled={header.value === WebCrawlerHeaderRedactedValue}
                     className="w-full"
                   />
@@ -55,9 +61,7 @@ export function McpServerHeaders({
                     name="headerValue"
                     placeholder="Header Value"
                     value={header.value}
-                    onChange={(e) =>
-                      updateHeaderField(index, "value", e.target.value)
-                    }
+                    onChange={getChangeHandler(index, "value")}
                     disabled={header.value === WebCrawlerHeaderRedactedValue}
                     className="w-full"
                   />

--- a/front/components/actions/mcp/MCPServerHeaders.tsx
+++ b/front/components/actions/mcp/MCPServerHeaders.tsx
@@ -36,28 +36,32 @@ export function McpServerHeaders({
       <div className="flex w-full flex-col gap-3">
         <div className="flex flex-col gap-4">
           {headers.map((header, index) => (
-            <div key={index} className="flex gap-2">
-              <div className="flex grow flex-col gap-1 px-1">
-                <Input
-                  placeholder="Header Name"
-                  value={header.key}
-                  name="headerName"
-                  onChange={(e) =>
-                    updateHeaderField(index, "key", e.target.value)
-                  }
-                  disabled={header.value === WebCrawlerHeaderRedactedValue}
-                  className="grow"
-                />
-                <Input
-                  name="headerValue"
-                  placeholder="Header Value"
-                  value={header.value}
-                  onChange={(e) =>
-                    updateHeaderField(index, "value", e.target.value)
-                  }
-                  disabled={header.value === WebCrawlerHeaderRedactedValue}
-                  className="flex-1"
-                />
+            <div key={index} className="flex items-center gap-2">
+              <div className="grid flex-1 grid-cols-3 gap-2 px-1">
+                <div className="col-span-1">
+                  <Input
+                    placeholder="Header Name"
+                    value={header.key}
+                    name="headerName"
+                    onChange={(e) =>
+                      updateHeaderField(index, "key", e.target.value)
+                    }
+                    disabled={header.value === WebCrawlerHeaderRedactedValue}
+                    className="w-full"
+                  />
+                </div>
+                <div className="col-span-2">
+                  <Input
+                    name="headerValue"
+                    placeholder="Header Value"
+                    value={header.value}
+                    onChange={(e) =>
+                      updateHeaderField(index, "value", e.target.value)
+                    }
+                    disabled={header.value === WebCrawlerHeaderRedactedValue}
+                    className="w-full"
+                  />
+                </div>
               </div>
               <Button
                 variant="outline"

--- a/front/components/actions/mcp/MCPServerHeaders.tsx
+++ b/front/components/actions/mcp/MCPServerHeaders.tsx
@@ -1,8 +1,4 @@
-import {
-  Button,
-  Input,
-  XMarkIcon,
-} from "@dust-tt/sparkle";
+import { Button, Input, XMarkIcon } from "@dust-tt/sparkle";
 
 import { WebCrawlerHeaderRedactedValue } from "@app/types";
 
@@ -36,43 +32,43 @@ export function McpServerHeaders({
   };
 
   return (
-        <div className="flex w-full flex-col gap-6">
-          <div className="flex w-full flex-col gap-3">
-            <div className="flex flex-col gap-4">
-              {headers.map((header, index) => (
-                <div key={index} className="flex gap-2">
-                  <div className="flex grow flex-col gap-1 px-1">
-                    <Input
-                      placeholder="Header Name"
-                      value={header.key}
-                      name="headerName"
-                      onChange={(e) =>
-                        updateHeaderField(index, "key", e.target.value)
-                      }
-                      disabled={header.value === WebCrawlerHeaderRedactedValue}
-                      className="grow"
-                    />
-                    <Input
-                      name="headerValue"
-                      placeholder="Header Value"
-                      value={header.value}
-                      onChange={(e) =>
-                        updateHeaderField(index, "value", e.target.value)
-                      }
-                      disabled={header.value === WebCrawlerHeaderRedactedValue}
-                      className="flex-1"
-                    />
-                  </div>
-                  <Button
-                    variant="outline"
-                    icon={XMarkIcon}
-                    onClick={() => removeHeader(index)}
-                  />
-                </div>
-              ))}
+    <div className="flex w-full flex-col gap-6">
+      <div className="flex w-full flex-col gap-3">
+        <div className="flex flex-col gap-4">
+          {headers.map((header, index) => (
+            <div key={index} className="flex gap-2">
+              <div className="flex grow flex-col gap-1 px-1">
+                <Input
+                  placeholder="Header Name"
+                  value={header.key}
+                  name="headerName"
+                  onChange={(e) =>
+                    updateHeaderField(index, "key", e.target.value)
+                  }
+                  disabled={header.value === WebCrawlerHeaderRedactedValue}
+                  className="grow"
+                />
+                <Input
+                  name="headerValue"
+                  placeholder="Header Value"
+                  value={header.value}
+                  onChange={(e) =>
+                    updateHeaderField(index, "value", e.target.value)
+                  }
+                  disabled={header.value === WebCrawlerHeaderRedactedValue}
+                  className="flex-1"
+                />
+              </div>
+              <Button
+                variant="outline"
+                icon={XMarkIcon}
+                onClick={() => removeHeader(index)}
+              />
             </div>
-            <Button variant="outline" label="Add Header" onClick={addHeader} />
-          </div>
+          ))}
         </div>
+        <Button variant="outline" label="Add Header" onClick={addHeader} />
+      </div>
+    </div>
   );
 }

--- a/front/components/actions/mcp/MCPServerHeaders.tsx
+++ b/front/components/actions/mcp/MCPServerHeaders.tsx
@@ -1,5 +1,5 @@
 import { Button, Input, XMarkIcon } from "@dust-tt/sparkle";
-import type {ChangeEvent} from "react";
+import type { ChangeEvent } from "react";
 import { useCallback } from "react";
 
 import { WebCrawlerHeaderRedactedValue } from "@app/types";

--- a/front/components/actions/mcp/RemoteMCPForm.tsx
+++ b/front/components/actions/mcp/RemoteMCPForm.tsx
@@ -18,11 +18,14 @@ import { useCallback, useEffect, useMemo, useState } from "react";
 import { Controller, useForm } from "react-hook-form";
 import { z } from "zod";
 
-import type { MCPServerViewType, RemoteMCPServerType } from "@app/lib/api/mcp";
-import { useSyncRemoteMCPServer, useUpdateMCPServer } from "@app/lib/swr/mcp_servers";
-import { sanitizeHeadersArray } from "@app/types";
-import type { LightWorkspaceType } from "@app/types";
 import { McpServerHeaders } from "@app/components/actions/mcp/MCPServerHeaders";
+import type { MCPServerViewType, RemoteMCPServerType } from "@app/lib/api/mcp";
+import {
+  useSyncRemoteMCPServer,
+  useUpdateMCPServer,
+} from "@app/lib/swr/mcp_servers";
+import type { LightWorkspaceType } from "@app/types";
+import { sanitizeHeadersArray } from "@app/types";
 
 interface RemoteMCPFormProps {
   owner: LightWorkspaceType;
@@ -64,9 +67,8 @@ export function RemoteMCPForm({
       })),
     [mcpServer.customHeaders]
   );
-  const [headersRows, setHeadersRows] = useState<
-    { key: string; value: string }[]
-  >(initialHeaderRows);
+  const [headersRows, setHeadersRows] =
+    useState<{ key: string; value: string }[]>(initialHeaderRows);
   const [headersDirty, setHeadersDirty] = useState(false);
 
   // Use the serverId from state for the hooks

--- a/front/components/actions/mcp/RemoteMCPForm.tsx
+++ b/front/components/actions/mcp/RemoteMCPForm.tsx
@@ -19,10 +19,8 @@ import { Controller, useForm } from "react-hook-form";
 import { z } from "zod";
 
 import type { MCPServerViewType, RemoteMCPServerType } from "@app/lib/api/mcp";
-import {
-  useSyncRemoteMCPServer,
-  useUpdateMCPServer,
-} from "@app/lib/swr/mcp_servers";
+import { useSyncRemoteMCPServer, useUpdateMCPServer } from "@app/lib/swr/mcp_servers";
+import { sanitizeHeadersArray } from "@app/types";
 import type { LightWorkspaceType } from "@app/types";
 import { McpServerHeaders } from "@app/components/actions/mcp/MCPServerHeaders";
 
@@ -90,10 +88,7 @@ export function RemoteMCPForm({
   );
 
   const sanitizeHeaders = useCallback(
-    (rows: { key: string; value: string }[]) =>
-      rows
-        .map(({ key, value }) => ({ key: key.trim(), value: value.trim() }))
-        .filter(({ key, value }) => key.length > 0 && value.length > 0),
+    (rows: { key: string; value: string }[]) => sanitizeHeadersArray(rows),
     []
   );
 

--- a/front/components/actions/mcp/RemoteMCPForm.tsx
+++ b/front/components/actions/mcp/RemoteMCPForm.tsx
@@ -14,7 +14,7 @@ import {
   PopoverTrigger,
 } from "@dust-tt/sparkle";
 import { zodResolver } from "@hookform/resolvers/zod";
-import { useCallback, useState } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 import { Controller, useForm } from "react-hook-form";
 import { z } from "zod";
 
@@ -24,6 +24,7 @@ import {
   useUpdateMCPServer,
 } from "@app/lib/swr/mcp_servers";
 import type { LightWorkspaceType } from "@app/types";
+import { McpServerHeaders } from "@app/components/actions/mcp/MCPServerHeaders";
 
 interface RemoteMCPFormProps {
   owner: LightWorkspaceType;
@@ -57,6 +58,19 @@ export function RemoteMCPForm({
 
   const { url, lastError, lastSyncAt } = mcpServer;
 
+  const initialHeaderRows = useMemo(
+    () =>
+      Object.entries(mcpServer.customHeaders ?? {}).map(([key, value]) => ({
+        key,
+        value: String(value),
+      })),
+    [mcpServer.customHeaders]
+  );
+  const [headersRows, setHeadersRows] = useState<
+    { key: string; value: string }[]
+  >(initialHeaderRows);
+  const [headersDirty, setHeadersDirty] = useState(false);
+
   // Use the serverId from state for the hooks
   const { updateServer } = useUpdateMCPServer(owner, mcpServerView);
   const { syncServer } = useSyncRemoteMCPServer(owner, mcpServer.sId);
@@ -74,6 +88,36 @@ export function RemoteMCPForm({
     },
     [updateServer, form]
   );
+
+  const sanitizeHeaders = useCallback(
+    (rows: { key: string; value: string }[]) =>
+      rows
+        .map(({ key, value }) => ({ key: key.trim(), value: value.trim() }))
+        .filter(({ key, value }) => key.length > 0 && value.length > 0),
+    []
+  );
+
+  const onSaveHeaders = useCallback(async () => {
+    const sanitized = sanitizeHeaders(headersRows);
+    const ok = await updateServer({ customHeaders: sanitized });
+    if (ok) {
+      // After the SWR mutate from the hook refreshes, the effect below
+      // will sync local rows from mcpServer.customHeaders.
+      setHeadersDirty(false);
+    }
+  }, [headersRows, sanitizeHeaders, updateServer]);
+
+  // Keep local headers state in sync with server when not dirty
+  useEffect(() => {
+    if (!headersDirty) {
+      setHeadersRows(
+        Object.entries(mcpServer.customHeaders ?? {}).map(([key, value]) => ({
+          key,
+          value: String(value),
+        }))
+      );
+    }
+  }, [mcpServer.customHeaders, headersDirty]);
 
   const handleSynchronize = useCallback(async () => {
     setIsSynchronizing(true);
@@ -160,6 +204,40 @@ export function RemoteMCPForm({
           />
         </div>
       </div>
+
+      <CollapsibleComponent
+        triggerChildren={<div className="heading-lg">Networking & Headers</div>}
+        contentChildren={
+          <div className="space-y-2">
+            <McpServerHeaders
+              headers={headersRows}
+              onHeadersChange={(rows) => {
+                setHeadersRows(rows);
+                setHeadersDirty(true);
+              }}
+            />
+            {headersDirty && (
+              <div className="flex flex-row items-end justify-end gap-2">
+                <Button
+                  variant="outline"
+                  label={"Cancel"}
+                  onClick={() => {
+                    setHeadersRows(initialHeaderRows);
+                    setHeadersDirty(false);
+                  }}
+                />
+                <Button
+                  variant="highlight"
+                  label={"Save"}
+                  onClick={() => {
+                    void onSaveHeaders();
+                  }}
+                />
+              </div>
+            )}
+          </div>
+        }
+      />
 
       {!mcpServer.authorization && (
         <CollapsibleComponent

--- a/front/lib/actions/mcp_metadata.ts
+++ b/front/lib/actions/mcp_metadata.ts
@@ -313,7 +313,12 @@ export const connectToMCPServer = async (
           try {
             const req = {
               requestInit: {
-                headers: undefined,
+                // Include stored custom headers (excluding Authorization; handled by authProvider)
+                headers: Object.fromEntries(
+                  Object.entries(remoteMCPServer.customHeaders ?? {}).filter(
+                    ([k]) => k.toLowerCase() !== "authorization"
+                  )
+                ),
                 dispatcher: createMCPDispatcher(auth),
               },
               authProvider: new MCPOAuthProvider(auth, token),

--- a/front/lib/api/mcp.ts
+++ b/front/lib/api/mcp.ts
@@ -87,6 +87,7 @@ export type RemoteMCPServerType = MCPServerType & {
   sharedSecret?: string | null;
   lastSyncAt?: Date | null;
   lastError?: string | null;
+  customHeaders?: Record<string, string> | null;
   icon: CustomServerIconType | InternalAllowedIconType;
   // Always manual and allow multiple instances.
   availability: "manual";

--- a/front/lib/models/assistant/actions/remote_mcp_server.ts
+++ b/front/lib/models/assistant/actions/remote_mcp_server.ts
@@ -28,6 +28,7 @@ export class RemoteMCPServerModel extends WorkspaceAwareModel<RemoteMCPServerMod
 
   declare sharedSecret: string | null;
   declare authorization: AuthorizationInfo | null;
+  declare customHeaders: Record<string, string> | null;
 }
 
 RemoteMCPServerModel.init(
@@ -82,6 +83,11 @@ RemoteMCPServerModel.init(
       allowNull: true,
     },
     authorization: {
+      type: DataTypes.JSONB,
+      allowNull: true,
+      defaultValue: null,
+    },
+    customHeaders: {
       type: DataTypes.JSONB,
       allowNull: true,
       defaultValue: null,

--- a/front/lib/resources/remote_mcp_servers_resource.ts
+++ b/front/lib/resources/remote_mcp_servers_resource.ts
@@ -276,7 +276,7 @@ export class RemoteMCPServerResource extends BaseResource<RemoteMCPServerModel> 
     }: {
       icon?: CustomServerIconType | InternalAllowedIconType;
       sharedSecret?: string;
-      customHeaders?: Record<string, string> | null;
+      customHeaders?: Record<string, string>;
       cachedName?: string;
       cachedDescription?: string;
       cachedTools?: MCPToolType[];

--- a/front/lib/resources/remote_mcp_servers_resource.ts
+++ b/front/lib/resources/remote_mcp_servers_resource.ts
@@ -267,6 +267,7 @@ export class RemoteMCPServerResource extends BaseResource<RemoteMCPServerModel> 
     {
       icon,
       sharedSecret,
+      customHeaders,
       cachedName,
       cachedDescription,
       cachedTools,
@@ -275,6 +276,7 @@ export class RemoteMCPServerResource extends BaseResource<RemoteMCPServerModel> 
     }: {
       icon?: CustomServerIconType | InternalAllowedIconType;
       sharedSecret?: string;
+      customHeaders?: Record<string, string> | null;
       cachedName?: string;
       cachedDescription?: string;
       cachedTools?: MCPToolType[];
@@ -297,6 +299,7 @@ export class RemoteMCPServerResource extends BaseResource<RemoteMCPServerModel> 
     await this.update({
       icon,
       sharedSecret,
+      customHeaders,
       cachedName,
       cachedDescription,
       cachedTools,
@@ -343,6 +346,7 @@ export class RemoteMCPServerResource extends BaseResource<RemoteMCPServerModel> 
     lastSyncAt: number | null;
     lastError: string | null;
     sharedSecret: string | null;
+    customHeaders: Record<string, string> | null;
   } {
     const currentTime = new Date();
     const createdAt = new Date(this.createdAt);
@@ -374,6 +378,7 @@ export class RemoteMCPServerResource extends BaseResource<RemoteMCPServerModel> 
       lastSyncAt: this.lastSyncAt?.getTime() ?? null,
       lastError: this.lastError,
       sharedSecret: secret,
+      customHeaders: this.customHeaders,
       documentationUrl: null,
     };
   }

--- a/front/lib/swr/mcp_servers.ts
+++ b/front/lib/swr/mcp_servers.ts
@@ -303,14 +303,15 @@ export function useCreateInternalMCPServer(owner: LightWorkspaceType) {
 export function useDiscoverOAuthMetadata(owner: LightWorkspaceType) {
   const discoverOAuthMetadata = useCallback(
     async (
-      url: string
+      url: string,
+      customHeaders?: { key: string; value: string }[]
     ): Promise<Result<DiscoverOAuthMetadataResponseBody, Error>> => {
       const response = await fetch(
         `/api/w/${owner.sId}/mcp/discover_oauth_metadata`,
         {
           method: "POST",
           headers: { "Content-Type": "application/json" },
-          body: JSON.stringify({ url }),
+          body: JSON.stringify({ url, customHeaders }),
         }
       );
 
@@ -347,11 +348,13 @@ export function useCreateRemoteMCPServer(owner: LightWorkspaceType) {
       includeGlobal,
       sharedSecret,
       oauthConnection,
+      customHeaders,
     }: {
       url: string;
       includeGlobal: boolean;
       sharedSecret?: string;
       oauthConnection?: MCPConnectionType;
+      customHeaders?: { key: string; value: string }[];
     }): Promise<Result<CreateMCPServerResponseBody, Error>> => {
       const body: any = { url, serverType: "remote", includeGlobal };
       if (sharedSecret) {
@@ -361,6 +364,9 @@ export function useCreateRemoteMCPServer(owner: LightWorkspaceType) {
       if (oauthConnection) {
         body.connectionId = oauthConnection.connectionId;
         body.useCase = oauthConnection.useCase;
+      }
+      if (customHeaders) {
+        body.customHeaders = customHeaders;
       }
       const response = await fetch(`/api/w/${owner.sId}/mcp`, {
         method: "POST",

--- a/front/migrations/db/migration_360.sql
+++ b/front/migrations/db/migration_360.sql
@@ -1,0 +1,3 @@
++-- Migration created on Sep 19, 2025
+ALTER TABLE "public"."remote_mcp_servers"
+ADD COLUMN IF NOT EXISTS "customHeaders" jsonb;

--- a/front/pages/api/w/[wId]/mcp/[serverId]/index.ts
+++ b/front/pages/api/w/[wId]/mcp/[serverId]/index.ts
@@ -27,8 +27,7 @@ const PatchMCPServerBodySchema = z
     z.object({
       customHeaders: z
         .array(z.object({ key: z.string(), value: z.string() }))
-        .nullable()
-        .optional(),
+        .nullable(),
     })
   );
 

--- a/front/pages/api/w/[wId]/mcp/[serverId]/index.ts
+++ b/front/pages/api/w/[wId]/mcp/[serverId]/index.ts
@@ -127,7 +127,8 @@ async function handler(
       break;
     }
     case "PATCH": {
-      const sanitizeHeaderPart = (s: string) => s.replace(/[\r\n]/g, " ").trim();
+      const sanitizeHeaderPart = (s: string) =>
+        s.replace(/[\r\n]/g, " ").trim();
       const r = PatchMCPServerBodySchema.safeParse(req.body);
       if (r.error) {
         return apiError(req, res, {
@@ -214,10 +215,11 @@ async function handler(
         }
       } else if ("customHeaders" in r.data) {
         if (server instanceof RemoteMCPServerResource) {
-          const sanitizedRecord = headersArrayToRecord(r.data.customHeaders, {
-            stripAuthorization: true,
-            emptyAsNull: true,
-          }) ?? null;
+          const sanitizedRecord =
+            headersArrayToRecord(r.data.customHeaders, {
+              stripAuthorization: true,
+              emptyAsNull: true,
+            }) ?? null;
 
           const r2 = await server.updateMetadata(auth, {
             customHeaders: sanitizedRecord,

--- a/front/pages/api/w/[wId]/mcp/[serverId]/index.ts
+++ b/front/pages/api/w/[wId]/mcp/[serverId]/index.ts
@@ -127,8 +127,6 @@ async function handler(
       break;
     }
     case "PATCH": {
-      const sanitizeHeaderPart = (s: string) =>
-        s.replace(/[\r\n]/g, " ").trim();
       const r = PatchMCPServerBodySchema.safeParse(req.body);
       if (r.error) {
         return apiError(req, res, {
@@ -215,11 +213,9 @@ async function handler(
         }
       } else if ("customHeaders" in r.data) {
         if (server instanceof RemoteMCPServerResource) {
-          const sanitizedRecord =
-            headersArrayToRecord(r.data.customHeaders, {
-              stripAuthorization: true,
-              emptyAsNull: true,
-            }) ?? null;
+          const sanitizedRecord = headersArrayToRecord(r.data.customHeaders, {
+            stripAuthorization: true,
+          });
 
           const r2 = await server.updateMetadata(auth, {
             customHeaders: sanitizedRecord,

--- a/front/pages/api/w/[wId]/mcp/discover_oauth_metadata.ts
+++ b/front/pages/api/w/[wId]/mcp/discover_oauth_metadata.ts
@@ -9,6 +9,7 @@ import type { MCPOAuthConnectionMetadataType } from "@app/lib/api/oauth/provider
 import type { Authenticator } from "@app/lib/auth";
 import { apiError } from "@app/logger/withlogging";
 import type { WithAPIErrorResponse } from "@app/types";
+import { headersArrayToRecord } from "@app/types";
 
 export type DiscoverOAuthMetadataResponseBody =
   | {
@@ -55,13 +56,9 @@ async function handler(
 
       const { url, customHeaders } = r.right;
 
-      const headers = customHeaders
-        ? Object.fromEntries(
-            customHeaders
-              .filter((h) => h.key && h.value)
-              .map(({ key, value }) => [key.trim(), value])
-          )
-        : undefined;
+      const headers = headersArrayToRecord(customHeaders, {
+        stripAuthorization: false,
+      });
 
       const r2 = await connectToMCPServer(auth, {
         params: {

--- a/front/pages/api/w/[wId]/mcp/discover_oauth_metadata.ts
+++ b/front/pages/api/w/[wId]/mcp/discover_oauth_metadata.ts
@@ -22,7 +22,10 @@ export type DiscoverOAuthMetadataResponseBody =
 
 const PostQueryParamsSchema = t.type({
   url: t.string,
-  customHeaders: t.union([t.array(t.type({ key: t.string, value: t.string })), t.undefined]),
+  customHeaders: t.union([
+    t.array(t.type({ key: t.string, value: t.string })),
+    t.undefined,
+  ]),
 });
 
 /**

--- a/front/pages/api/w/[wId]/mcp/discover_oauth_metadata.ts
+++ b/front/pages/api/w/[wId]/mcp/discover_oauth_metadata.ts
@@ -21,6 +21,7 @@ export type DiscoverOAuthMetadataResponseBody =
 
 const PostQueryParamsSchema = t.type({
   url: t.string,
+  customHeaders: t.union([t.array(t.type({ key: t.string, value: t.string })), t.undefined]),
 });
 
 /**
@@ -52,12 +53,21 @@ async function handler(
         });
       }
 
-      const { url } = r.right;
+      const { url, customHeaders } = r.right;
+
+      const headers = customHeaders
+        ? Object.fromEntries(
+            customHeaders
+              .filter((h) => h.key && h.value)
+              .map(({ key, value }) => [key.trim(), value])
+          )
+        : undefined;
 
       const r2 = await connectToMCPServer(auth, {
         params: {
           type: "remoteMCPServerUrl",
           remoteMCPServerUrl: url,
+          headers,
         },
       });
       if (r2.isErr()) {

--- a/front/pages/api/w/[wId]/mcp/index.ts
+++ b/front/pages/api/w/[wId]/mcp/index.ts
@@ -28,8 +28,8 @@ import { concurrentExecutor } from "@app/lib/utils/async_utils";
 import logger from "@app/logger/logger";
 import { apiError } from "@app/logger/withlogging";
 import type { WithAPIErrorResponse } from "@app/types";
-import { getOAuthConnectionAccessToken } from "@app/types/oauth/client/access_token";
 import { headersArrayToRecord } from "@app/types";
+import { getOAuthConnectionAccessToken } from "@app/types/oauth/client/access_token";
 
 export type GetMCPServersResponseBody = {
   success: true;
@@ -53,7 +53,10 @@ const PostQueryParamsSchema = t.union([
       t.undefined,
     ]),
     connectionId: t.union([t.string, t.undefined]),
-    customHeaders: t.union([t.array(t.type({ key: t.string, value: t.string })), t.undefined]),
+    customHeaders: t.union([
+      t.array(t.type({ key: t.string, value: t.string })),
+      t.undefined,
+    ]),
   }),
   t.type({
     serverType: t.literal("internal"),
@@ -171,7 +174,10 @@ async function handler(
         );
 
         const headers = bearerToken
-          ? { ...(sanitizedCustomHeaders ?? {}), Authorization: `Bearer ${bearerToken}` }
+          ? {
+              ...(sanitizedCustomHeaders ?? {}),
+              Authorization: `Bearer ${bearerToken}`,
+            }
           : sanitizedCustomHeaders;
 
         const r = await fetchRemoteServerMetaDataByURL(auth, url, headers);

--- a/front/pages/api/w/[wId]/mcp/index.ts
+++ b/front/pages/api/w/[wId]/mcp/index.ts
@@ -219,7 +219,6 @@ async function handler(
           // Persist only user-provided custom headers (exclude Authorization)
           customHeaders: headersArrayToRecord(body.customHeaders, {
             stripAuthorization: true,
-            emptyAsNull: true,
           }),
           authorization,
           oAuthUseCase: body.useCase ?? null,

--- a/front/types/index.ts
+++ b/front/types/index.ts
@@ -70,6 +70,7 @@ export * from "./shared/utils/global_error_handler";
 export * from "./shared/utils/hashing";
 export * from "./shared/utils/iots_utils";
 export * from "./shared/utils/string_utils";
+export * from "./shared/utils/http_headers";
 export * from "./shared/utils/structured_data";
 export * from "./shared/utils/time_frame";
 export * from "./shared/utils/url_utils";

--- a/front/types/shared/utils/http_headers.ts
+++ b/front/types/shared/utils/http_headers.ts
@@ -17,19 +17,17 @@ export function sanitizeHeadersArray(rows: HeaderRow[]): HeaderRow[] {
 
 export function headersArrayToRecord(
   rows: HeaderRow[] | null | undefined,
-  opts?: { stripAuthorization?: boolean; emptyAsNull?: boolean }
-): Record<string, string> | null | undefined {
-  if (!rows) return opts?.emptyAsNull ? null : undefined;
+  opts?: { stripAuthorization?: boolean }
+): Record<string, string> {
+  if (!rows) {
+    return Object.fromEntries([]);
+  }
 
   const sanitized = sanitizeHeadersArray(rows);
   let entries = sanitized.map(({ key, value }) => [key, value] as const);
 
   if (opts?.stripAuthorization) {
     entries = entries.filter(([k]) => k.toLowerCase() !== "authorization");
-  }
-
-  if (entries.length === 0) {
-    return opts?.emptyAsNull ? null : undefined;
   }
   return Object.fromEntries(entries);
 }

--- a/front/types/shared/utils/http_headers.ts
+++ b/front/types/shared/utils/http_headers.ts
@@ -1,0 +1,36 @@
+import { stripCRLF } from "./string_utils";
+
+export type HeaderRow = { key: string; value: string };
+
+export function sanitizeHeaderPart(s: string): string {
+  return stripCRLF(s).trim();
+}
+
+export function sanitizeHeadersArray(rows: HeaderRow[]): HeaderRow[] {
+  return rows
+    .map(({ key, value }) => ({
+      key: sanitizeHeaderPart(key),
+      value: sanitizeHeaderPart(value),
+    }))
+    .filter(({ key, value }) => key.length > 0 && value.length > 0);
+}
+
+export function headersArrayToRecord(
+  rows: HeaderRow[] | null | undefined,
+  opts?: { stripAuthorization?: boolean; emptyAsNull?: boolean }
+): Record<string, string> | null | undefined {
+  if (!rows) return opts?.emptyAsNull ? null : undefined;
+
+  const sanitized = sanitizeHeadersArray(rows);
+  let entries = sanitized.map(({ key, value }) => [key, value] as const);
+
+  if (opts?.stripAuthorization) {
+    entries = entries.filter(([k]) => k.toLowerCase() !== "authorization");
+  }
+
+  if (entries.length === 0) {
+    return opts?.emptyAsNull ? null : undefined;
+  }
+  return Object.fromEntries(entries);
+}
+

--- a/front/types/shared/utils/http_headers.ts
+++ b/front/types/shared/utils/http_headers.ts
@@ -24,7 +24,7 @@ export function headersArrayToRecord(
   }
 
   const sanitized = sanitizeHeadersArray(rows);
-  let entries = sanitized.map(({ key, value }) => [key, value] as const);
+  let entries = sanitized.map(({ key, value }) => [key, value]);
 
   if (opts?.stripAuthorization) {
     entries = entries.filter(([k]) => k.toLowerCase() !== "authorization");

--- a/front/types/shared/utils/http_headers.ts
+++ b/front/types/shared/utils/http_headers.ts
@@ -33,4 +33,3 @@ export function headersArrayToRecord(
   }
   return Object.fromEntries(entries);
 }
-

--- a/front/types/shared/utils/string_utils.ts
+++ b/front/types/shared/utils/string_utils.ts
@@ -113,6 +113,10 @@ export function stripNullBytes(text: string): string {
   return text.replace(/\0/g, "");
 }
 
+export function stripCRLF(text: string): string {
+  return text.replace(/[\r\n]+/g, " ");
+}
+
 // Checks for an escaped null Unicode character.
 export function hasNullUnicodeCharacter(text: string): boolean {
   return text.includes("\u0000");


### PR DESCRIPTION
## Description

Fixes https://github.com/dust-tt/tasks/issues/4039

Add custome headers fields when creating a remote MCP server
These values are stores in the remote_mcp_servers table
They can be seen from the admin / tools page, and edited

<img width="600" height="500" alt="image" src="https://github.com/user-attachments/assets/a7e75a79-9f03-49f3-ba13-9c8dea8826de" />

<img width="600" height="700" alt="image" src="https://github.com/user-attachments/assets/54729df5-80a4-4450-b975-23f8a2a059bf" />

<img width="600" height="450" alt="image" src="https://github.com/user-attachments/assets/c217c99d-355b-4a64-b7df-ba2d1f8e58ec" />


## Tests

 - I have tested adding a MCP server manually with some headers (automatic only, I don't know how to quickly test other setup)
 - I have tested adding and deleting headers from the admin page
 - I have tested deleting my MCP server
 - I have tested invalid headers (empty value, Authorization) and they indeed are not accepted
 - I have tested actually using the MCP server
 - I have made sure the header is indeed transmitted by printing the headers in the MCP server


## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->

Merge the PR, update the DB with migration script on bot EU and US, deploy on both
Migration script wil add the new column
