### PR TITLE
[CC] Admin can disable public sharing of content creation files

### DIFF
--- a/front/components/assistant/conversation/content_creation/ShareContentCreationFilePopover.tsx
+++ b/front/components/assistant/conversation/content_creation/ShareContentCreationFilePopover.tsx
@@ -207,7 +207,7 @@ export function ShareContentCreationFilePopover({
                   icon={InformationCircleIcon}
                 >
                   {isSharingForbidden
-                    ? "Your workspace administrator has turned off sharing of Content Creation files with the public."
+                    ? "Your workspace administrator has turned off public sharing of Content Creation files."
                     : "This Content Creation relies on conversation files. The sharing to public option is " +
                       "disabled to protect company information."}
                 </ContentMessage>

--- a/front/components/assistant/conversation/content_creation/ShareContentCreationFilePopover.tsx
+++ b/front/components/assistant/conversation/content_creation/ShareContentCreationFilePopover.tsx
@@ -35,6 +35,7 @@ interface FileSharingDropdownProps {
   disabled?: boolean;
   isLoading?: boolean;
   isUsingConversationFiles: boolean;
+  isSharingForbidden: boolean;
 }
 
 function FileSharingDropdown({
@@ -43,6 +44,7 @@ function FileSharingDropdown({
   owner,
   disabled = false,
   isUsingConversationFiles,
+  isSharingForbidden,
 }: FileSharingDropdownProps) {
   const scopeOptions: {
     icon: React.ComponentType;
@@ -100,7 +102,10 @@ function FileSharingDropdown({
               onClick={() => onScopeChange(option.value)}
               truncateText
               icon={option.icon}
-              disabled={option.value === "public" && isUsingConversationFiles}
+              disabled={
+                option.value === "public" &&
+                (isSharingForbidden || isUsingConversationFiles)
+              }
             />
           ))}
         </DropdownMenuContent>
@@ -202,7 +207,7 @@ export function ShareContentCreationFilePopover({
                   icon={InformationCircleIcon}
                 >
                   {isSharingForbidden
-                    ? "Your workspace administrator has turned off sharing of Content Creation files."
+                    ? "Your workspace administrator has turned off sharing of Content Creation files with the public."
                     : "This Content Creation relies on conversation files. The sharing to public option is " +
                       "disabled to protect company information."}
                 </ContentMessage>
@@ -214,8 +219,9 @@ export function ShareContentCreationFilePopover({
                   selectedScope={selectedScope}
                   onScopeChange={handleScopeChange}
                   owner={owner}
+                  disabled={isUpdatingShare}
                   isUsingConversationFiles={isUsingConversationFiles}
-                  disabled={isSharingForbidden || isUpdatingShare}
+                  isSharingForbidden={isSharingForbidden}
                   isLoading={isUpdatingShare}
                 />
 

--- a/front/components/assistant/conversation/content_creation/ShareContentCreationFilePopover.tsx
+++ b/front/components/assistant/conversation/content_creation/ShareContentCreationFilePopover.tsx
@@ -35,7 +35,7 @@ interface FileSharingDropdownProps {
   disabled?: boolean;
   isLoading?: boolean;
   isUsingConversationFiles: boolean;
-  isSharingForbidden: boolean;
+  isPublicSharingForbidden: boolean;
 }
 
 function FileSharingDropdown({
@@ -44,7 +44,7 @@ function FileSharingDropdown({
   owner,
   disabled = false,
   isUsingConversationFiles,
-  isSharingForbidden,
+  isPublicSharingForbidden,
 }: FileSharingDropdownProps) {
   const scopeOptions: {
     icon: React.ComponentType;
@@ -104,7 +104,7 @@ function FileSharingDropdown({
               icon={option.icon}
               disabled={
                 option.value === "public" &&
-                (isSharingForbidden || isUsingConversationFiles)
+                (isPublicSharingForbidden || isUsingConversationFiles)
               }
             />
           ))}
@@ -132,7 +132,7 @@ export function ShareContentCreationFilePopover({
     "conversation_participants"
   );
 
-  const isSharingForbidden =
+  const isPublicSharingForbidden =
     owner.metadata?.allowContentCreationFileSharing === false;
 
   const { doShare, fileShare, isFileShareLoading, isFileShareError } =
@@ -195,18 +195,18 @@ export function ShareContentCreationFilePopover({
             )}
             {/* Warning if sharing is disabled. */}
             {!isFileShareLoading &&
-              (isSharingForbidden || isUsingConversationFiles) && (
+              (isPublicSharingForbidden || isUsingConversationFiles) && (
                 <ContentMessage
                   className="mb-4"
                   title={
-                    isSharingForbidden
+                    isPublicSharingForbidden
                       ? "Sharing disabled by admin"
                       : "This file contains company data"
                   }
                   variant="golden"
                   icon={InformationCircleIcon}
                 >
-                  {isSharingForbidden
+                  {isPublicSharingForbidden
                     ? "Your workspace administrator has turned off public sharing of Content Creation files."
                     : "This Content Creation relies on conversation files. The sharing to public option is " +
                       "disabled to protect company information."}
@@ -221,7 +221,7 @@ export function ShareContentCreationFilePopover({
                   owner={owner}
                   disabled={isUpdatingShare}
                   isUsingConversationFiles={isUsingConversationFiles}
-                  isSharingForbidden={isSharingForbidden}
+                  isPublicSharingForbidden={isPublicSharingForbidden}
                   isLoading={isUpdatingShare}
                 />
 

--- a/front/pages/api/w/[wId]/index.ts
+++ b/front/pages/api/w/[wId]/index.ts
@@ -147,8 +147,7 @@ async function handler(
         });
         owner.workOSOrganizationId = body.workOSOrganizationId;
       } else if ("allowContentCreationFileSharing" in body) {
-        // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
-        const previousMetadata = owner.metadata || {};
+        const previousMetadata = owner.metadata ?? {};
         const newMetadata = {
           ...previousMetadata,
           allowContentCreationFileSharing: body.allowContentCreationFileSharing,

--- a/front/pages/w/[wId]/workspace/index.tsx
+++ b/front/pages/w/[wId]/workspace/index.tsx
@@ -415,7 +415,7 @@ function ContentCreationSharingToggle({ owner }: { owner: WorkspaceType }) {
       <div className="h-full border-b border-border dark:border-border-night" />
       <ContextItem
         title="Content Creation file sharing"
-        subElement="Enable sharing Content Creation files with the public"
+        subElement="Allow public sharing of Content Creation files"
         visual={<DocumentTextIcon className="h-6 w-6" />}
         hasSeparatorIfLast={true}
         action={

--- a/front/pages/w/[wId]/workspace/index.tsx
+++ b/front/pages/w/[wId]/workspace/index.tsx
@@ -415,7 +415,7 @@ function ContentCreationSharingToggle({ owner }: { owner: WorkspaceType }) {
       <div className="h-full border-b border-border dark:border-border-night" />
       <ContextItem
         title="Content Creation file sharing"
-        subElement="Enable Content Creation files sharing"
+        subElement="Enable sharing Content Creation files with the public"
         visual={<DocumentTextIcon className="h-6 w-6" />}
         hasSeparatorIfLast={true}
         action={


### PR DESCRIPTION
## Description

- https://github.com/dust-tt/tasks/issues/4141
- Disables the options to share a file publicly is sharing has been disabled by the admin.

<img width="351" height="323" alt="Screenshot 2025-09-19 at 17 05 25" src="https://github.com/user-attachments/assets/6b0ccb60-8cb3-4074-aa74-6d3e13b475da" />

### Notes and questions for the reviewer

- Decided to not hide the button to show it's an option that has been explicitly disabled and not a feature missing on our end. Do you think we should hide the buton
- Disabling the sharing won't change the permissions for already publicly shared files. Can be fixed in an other PR as it was already the case and want to keep the PR small.

## Tests

- Locally

## Risk

Low

## Deploy Plan

Deploy front
