### PR TITLE
[front] fix(auth): invalid links

### DIFF
--- a/front/pages/api/login.ts
+++ b/front/pages/api/login.ts
@@ -103,7 +103,7 @@ async function handler(
     if (flow === "unauthorized") {
       // Only happen if the workspace associated with workOSOrganizationId is not found.
       res.redirect(
-        `/api/auth/logout?returnTo=/login-error${encodeURIComponent(`?type=sso-login&reason=${flow}`)}`
+        `/api/workos/logout?returnTo=/login-error${encodeURIComponent(`?type=sso-login&reason=${flow}`)}`
       );
       return;
     }
@@ -145,7 +145,7 @@ async function handler(
           "Error during login flow."
         );
         res.redirect(
-          `/api/auth/logout?returnTo=/login-error${encodeURIComponent(`?type=login&reason=${error.code}`)}`
+          `/api/workos/logout?returnTo=/login-error${encodeURIComponent(`?type=login&reason=${error.code}`)}`
         );
         return;
       }
@@ -156,7 +156,7 @@ async function handler(
       }
 
       res.redirect(
-        `/api/auth/logout?returnTo=/sso-enforced?workspaceId=${error.workspaceId}`
+        `/api/workos/logout?returnTo=/sso-enforced?workspaceId=${error.workspaceId}`
       );
       return;
     }

--- a/front/pages/w/[wId]/join.tsx
+++ b/front/pages/w/[wId]/join.tsx
@@ -104,7 +104,7 @@ export const getServerSideProps = makeGetServerSidePropsRequirementsWrapper({
       if (res.isErr()) {
         return {
           redirect: {
-            destination: `/api/auth/logout?returnTo=/login-error${encodeURIComponent(`?type=email-invite&reason=${res.error.code}`)}`,
+            destination: `/api/workos/logout?returnTo=/login-error${encodeURIComponent(`?type=email-invite&reason=${res.error.code}`)}`,
             permanent: false,
           },
         };


### PR DESCRIPTION
## Description

Routes to logout is now /api/workos/logout , /api/auth has been removed

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

deploy front
