### PR TITLE
fix run_dust_app tool not allowing multiple instances

### DIFF
--- a/front/lib/actions/mcp_internal_actions/constants.ts
+++ b/front/lib/actions/mcp_internal_actions/constants.ts
@@ -354,7 +354,7 @@ The directive should be used to display a clickable version of the agent name in
   run_dust_app: {
     id: 10,
     availability: "auto",
-    allowMultipleInstances: false,
+    allowMultipleInstances: true,
     isRestricted: undefined,
     isPreview: false,
     tools_stakes: undefined,


### PR DESCRIPTION
## Description

This is a fix for: https://github.com/dust-tt/tasks/issues/4256

Simply changed the value of `allowMultipleInstances` from `false` to `true`.

## Tests

Checked visually in the agent builder if I could add multiple dust apps.

## Risk

None

## Deploy Plan

Deploy front.
