### PR TITLE
[front] triggers: fix workflow creation

### DIFF
--- a/front/components/agent_builder/AgentBuilder.tsx
+++ b/front/components/agent_builder/AgentBuilder.tsx
@@ -248,6 +248,7 @@ export default function AgentBuilder({
         areSlackChannelsChanged: form.getFieldState(
           "agentSettings.slackChannels"
         ).isDirty,
+        currentUserId: user.id,
       });
 
       if (!result.isOk()) {

--- a/front/lib/api/assistant/configuration/agent.ts
+++ b/front/lib/api/assistant/configuration/agent.ts
@@ -38,6 +38,7 @@ import { generateRandomModelSId } from "@app/lib/resources/string_ids";
 import { TagResource } from "@app/lib/resources/tags_resource";
 import { TemplateResource } from "@app/lib/resources/template_resource";
 import { TriggerResource } from "@app/lib/resources/trigger_resource";
+import { UserResource } from "@app/lib/resources/user_resource";
 import { normalizeArrays } from "@app/lib/utils";
 import { withTransaction } from "@app/lib/utils/sql_utils";
 import logger from "@app/logger/logger";
@@ -62,7 +63,6 @@ import {
 } from "@app/types";
 import { isGlobalAgentId, removeNulls } from "@app/types";
 import type { TagType } from "@app/types/tag";
-import { UserResource } from "@app/lib/resources/user_resource";
 
 /**
  * Get one specific version of a single agent

--- a/front/pages/api/w/[wId]/assistant/agent_configurations/[aId]/triggers/index.ts
+++ b/front/pages/api/w/[wId]/assistant/agent_configurations/[aId]/triggers/index.ts
@@ -84,7 +84,7 @@ async function handler(
   );
 
   const userTriggers = allTriggers.filter(
-    (trigger) => trigger.editor === auth.getNonNullableWorkspace().id
+    (trigger) => trigger.editor === auth.getNonNullableUser().id
   );
 
   switch (req.method) {
@@ -141,10 +141,9 @@ async function handler(
       const workspace = auth.getNonNullableWorkspace();
 
       if (requestTriggers.length > 0) {
-        const triggerNames = [
-          ...requestTriggers.map((t: { name: string }) => t.name),
-          ...allTriggers.map((t) => t.name),
-        ];
+        const triggerNames = requestTriggers.map(
+          (t: { name: string }) => t.name
+        );
         const uniqueTriggerNames = new Set(triggerNames);
         if (uniqueTriggerNames.size !== triggerNames.length) {
           return apiError(req, res, {

--- a/front/temporal/agent_schedule/client.ts
+++ b/front/temporal/agent_schedule/client.ts
@@ -69,6 +69,14 @@ export async function createOrUpdateAgentScheduleWorkflow({
      * If the user is not the editor, we skip the creation/update.
      * This can happen when an admin does operation on a trigger.
      */
+    logger.warn(
+      {
+        userId: auth.getNonNullableUser().sId,
+        triggerId: trigger.sId(),
+        triggerEditorId: trigger.editor,
+      },
+      "User is not the editor of the trigger, skipping schedule creation/update."
+    );
     return new Ok("");
   }
 


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

Some users reported that their schedules were running with another user account.
This is due to a bad use of the auth when saving the agent. We were refreshing the temporal schedule with the auth of the member who saved, which was leading to having discrepancy between what was saved in db (the trigger editor), and who ran the trigger (the auth who saved the agent).

This PR fixes several places that would lead to that issue : 
- When saving in the AB, one only save the triggers that he's the editor of.
- When restoring an agent, we use the trigger auth instead of a the current user auth.
- We prevent updating another user's trigger.
- We do the check in the temporal client itself.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

Tested by hand by creating triggers with several account. AB still works and the triggers run with the correct user.

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

Low

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->

Deploy front.