### PR TITLE
[HOOTL] Verify webhook signature

### DIFF
--- a/front/lib/webhookSource.ts
+++ b/front/lib/webhookSource.ts
@@ -1,4 +1,9 @@
-import type { WebhookSourceWithViews } from "@app/types/triggers/webhooks";
+import { createHmac, timingSafeEqual } from "crypto";
+
+import type {
+  WebhookSourceSignatureAlgorithm,
+  WebhookSourceWithViews,
+} from "@app/types/triggers/webhooks";
 
 export const filterWebhookSource = (
   webhookSource: WebhookSourceWithViews,
@@ -13,5 +18,37 @@ export const filterWebhookSource = (
           view?.customName.toLowerCase().includes(filterValue.toLowerCase())
       )
     );
+  }
+};
+
+export const verifySignature = ({
+  signedContent,
+  secret,
+  signature,
+  algorithm,
+}: {
+  signedContent: string;
+  secret: string;
+  signature: string;
+  algorithm: WebhookSourceSignatureAlgorithm;
+}): boolean => {
+  if (!secret || !signature) {
+    return false;
+  }
+
+  const expectedSignature = `${algorithm}=${createHmac(algorithm, secret)
+    .update(signedContent, "utf8")
+    .digest("hex")}`;
+
+  // timingSafeEqual requires buffers of equal length
+  // Return false immediately if it throws an error
+  try {
+    const isValid = timingSafeEqual(
+      Buffer.from(signature),
+      Buffer.from(expectedSignature)
+    );
+    return isValid;
+  } catch (e) {
+    return false;
   }
 };

--- a/front/pages/api/v1/w/[wId]/triggers/hooks/[webhookSourceId]/index.test.ts
+++ b/front/pages/api/v1/w/[wId]/triggers/hooks/[webhookSourceId]/index.test.ts
@@ -1,3 +1,4 @@
+import { createHmac } from "crypto";
 import { describe, expect, it, vi } from "vitest";
 
 import { Authenticator } from "@app/lib/auth";
@@ -106,5 +107,113 @@ describe("POST /api/v1/w/[wId]/triggers/hooks/[webhookSourceId]", () => {
     await handler(req, res);
 
     expect(res._getStatusCode()).toBe(405);
+  });
+
+  it("returns 200 when webhook source has valid signature", async () => {
+    const { req, res, workspace } = await createPublicApiMockRequest({
+      method: "POST",
+    });
+
+    const auth = await Authenticator.internalAdminForWorkspace(workspace.sId);
+    await SpaceFactory.defaults(auth);
+
+    // Create a webhook source with signature configuration
+    const secret = "my-secret-key";
+    const signatureHeader = "x-signature";
+    const algorithm = "sha256";
+
+    const webhookSourceFactory = new WebhookSourceFactory(workspace);
+    const webhookSourceResult = await webhookSourceFactory.create({
+      name: "Test Webhook Source with Signature",
+      secret,
+      signatureHeader,
+      signatureAlgorithm: algorithm,
+    });
+
+    if (webhookSourceResult.isErr()) {
+      throw new Error(
+        `Failed to create webhook source: ${webhookSourceResult.error.message}`
+      );
+    }
+
+    const webhookSource = webhookSourceResult.value;
+    const payload = { test: "data", timestamp: Date.now() };
+    const payloadString = JSON.stringify(payload);
+
+    // Generate valid signature
+    const validSignature = `${algorithm}=${createHmac(algorithm, secret)
+      .update(payloadString, "utf8")
+      .digest("hex")}`;
+
+    req.query = {
+      wId: workspace.sId,
+      webhookSourceId: webhookSource.sId(),
+    };
+    req.body = payload;
+    req.headers = {
+      [signatureHeader.toLowerCase()]: validSignature,
+    };
+
+    await handler(req, res);
+
+    expect(res._getStatusCode()).toBe(200);
+    expect(res._getJSONData()).toEqual({ success: true });
+  });
+
+  it("returns 401 when webhook source has invalid signature", async () => {
+    const { req, res, workspace } = await createPublicApiMockRequest({
+      method: "POST",
+    });
+
+    const auth = await Authenticator.internalAdminForWorkspace(workspace.sId);
+    await SpaceFactory.defaults(auth);
+
+    // Create a webhook source with signature configuration
+    const secret = "my-secret-key";
+    const signatureHeader = "x-signature";
+    const algorithm = "sha256";
+
+    const webhookSourceFactory = new WebhookSourceFactory(workspace);
+    const webhookSourceResult = await webhookSourceFactory.create({
+      name: "Test Webhook Source with Invalid Signature",
+      secret,
+      signatureHeader,
+      signatureAlgorithm: algorithm,
+    });
+
+    if (webhookSourceResult.isErr()) {
+      throw new Error(
+        `Failed to create webhook source: ${webhookSourceResult.error.message}`
+      );
+    }
+
+    const webhookSource = webhookSourceResult.value;
+    const payload = { test: "data", timestamp: Date.now() };
+
+    // Use an invalid signature
+    const invalidSignature = `${algorithm}=invalid_signature_hash`;
+
+    req.query = {
+      wId: workspace.sId,
+      webhookSourceId: webhookSource.sId(),
+    };
+    req.body = payload;
+    req.headers = {
+      [signatureHeader.toLowerCase()]: invalidSignature,
+    };
+
+    await handler(req, res);
+
+    if (res._getStatusCode() !== 401) {
+      // Help debugging in CI-like environments
+      // eslint-disable-next-line no-console
+      console.error("Handler error response:", res._getJSONData());
+    }
+
+    expect(res._getStatusCode()).toBe(401);
+    const data = res._getJSONData();
+    expect(data).toHaveProperty("error");
+    expect(data.error.type).toBe("not_authenticated");
+    expect(data.error.message).toBe("Invalid webhook signature.");
   });
 });

--- a/front/pages/api/v1/w/[wId]/triggers/hooks/[webhookSourceId]/index.test.ts
+++ b/front/pages/api/v1/w/[wId]/triggers/hooks/[webhookSourceId]/index.test.ts
@@ -62,6 +62,9 @@ describe("POST /api/v1/w/[wId]/triggers/hooks/[webhookSourceId]", () => {
       webhookSourceId: webhookSource.sId(),
     };
     req.body = { any: "payload" };
+    req.headers = {
+      "content-type": "application/json",
+    };
 
     await handler(req, res);
 
@@ -85,6 +88,9 @@ describe("POST /api/v1/w/[wId]/triggers/hooks/[webhookSourceId]", () => {
       webhookSourceId: "webhook_source/nonexistent",
     };
     req.body = { any: "payload" };
+    req.headers = {
+      "content-type": "application/json",
+    };
 
     await handler(req, res);
 
@@ -107,6 +113,29 @@ describe("POST /api/v1/w/[wId]/triggers/hooks/[webhookSourceId]", () => {
     await handler(req, res);
 
     expect(res._getStatusCode()).toBe(405);
+  });
+
+  it("returns 400 when content-type is not application/json", async () => {
+    const { req, res, workspace } = await createPublicApiMockRequest({
+      method: "POST",
+    });
+
+    req.query = {
+      wId: workspace.sId,
+      webhookSourceId: "webhook_source/whatever",
+    };
+    req.body = { any: "payload" };
+    req.headers = {
+      "content-type": "text/plain",
+    };
+
+    await handler(req, res);
+
+    expect(res._getStatusCode()).toBe(400);
+    const data = res._getJSONData();
+    expect(data).toHaveProperty("error");
+    expect(data.error.type).toBe("invalid_request_error");
+    expect(data.error.message).toBe("Content-Type must be application/json.");
   });
 
   it("returns 200 when webhook source has valid signature", async () => {
@@ -151,6 +180,7 @@ describe("POST /api/v1/w/[wId]/triggers/hooks/[webhookSourceId]", () => {
     };
     req.body = payload;
     req.headers = {
+      "content-type": "application/json",
       [signatureHeader.toLowerCase()]: validSignature,
     };
 
@@ -199,6 +229,7 @@ describe("POST /api/v1/w/[wId]/triggers/hooks/[webhookSourceId]", () => {
     };
     req.body = payload;
     req.headers = {
+      "content-type": "application/json",
       [signatureHeader.toLowerCase()]: invalidSignature,
     };
 

--- a/front/pages/api/v1/w/[wId]/triggers/hooks/[webhookSourceId]/index.ts
+++ b/front/pages/api/v1/w/[wId]/triggers/hooks/[webhookSourceId]/index.ts
@@ -89,6 +89,17 @@ async function handler(
     });
   }
 
+  const contentType = req.headers["content-type"];
+  if (!contentType || !contentType.includes("application/json")) {
+    return apiError(req, res, {
+      status_code: 400,
+      api_error: {
+        type: "invalid_request_error",
+        message: "Content-Type must be application/json.",
+      },
+    });
+  }
+
   const { wId, webhookSourceId } = req.query;
 
   if (typeof wId !== "string" || typeof webhookSourceId !== "string") {

--- a/front/tests/utils/WebhookSourceFactory.ts
+++ b/front/tests/utils/WebhookSourceFactory.ts
@@ -14,10 +14,14 @@ export class WebhookSourceFactory {
   async create(
     options: {
       name?: string;
+      secret?: string;
+      signatureHeader?: string;
+      signatureAlgorithm?: "sha1" | "sha256" | "sha512";
+      customHeaders?: Record<string, string>;
     } = {}
   ) {
     const cachedName =
-      options.name || "Test WebhookSource" + faker.number.int(1000);
+      options.name ?? "Test WebhookSource" + faker.number.int(1000);
 
     const auth = await Authenticator.internalAdminForWorkspace(
       this.workspace.sId
@@ -26,6 +30,10 @@ export class WebhookSourceFactory {
     const result = await WebhookSourceResource.makeNew(auth, {
       workspaceId: this.workspace.id,
       name: cachedName,
+      secret: options.secret ?? null,
+      signatureHeader: options.signatureHeader ?? null,
+      signatureAlgorithm: options.signatureAlgorithm ?? null,
+      customHeaders: options.customHeaders ?? null,
     });
 
     return result;

--- a/front/types/error.ts
+++ b/front/types/error.ts
@@ -118,6 +118,7 @@ const API_ERROR_TYPES = [
   "webhook_source_not_found",
   "webhook_source_view_auth_error",
   "webhook_source_view_not_found",
+  "webhook_source_misconfiguration",
   // MCP Server Connections:
   "mcp_server_connection_not_found",
   "mcp_server_view_not_found",


### PR DESCRIPTION
## Description

(https://github.com/dust-tt/tasks/issues/4173)
This adds signature verification logic in the webhook endpoint :
- if the webhook source ha a secret defined in db, then retrieve the header, the payload of the request, hash it with the webhooksource algortihm and check consistency

<img width="1485" height="503" alt="image" src="https://github.com/user-attachments/assets/7284329e-1c5e-4930-9714-af6d7c4610fb" />


## Tests

Tested manually:
- created a webhook on one of my github repo with a webhook.site url (and on jira)
- copied the curl request received on that url
- Sent the same request on my local webhook endpoint

## Risk

Low

## Deploy Plan

Front

Documentation about this api endpoint is planned and will be implemented later (thus documentation-ack)
