### PR TITLE
[cc] If public sharing is disabled, downgrade share scope to workspace

### DIFF
--- a/front/lib/resources/shareable_file_resource.ts
+++ b/front/lib/resources/shareable_file_resource.ts
@@ -1,0 +1,78 @@
+import type { Attributes } from "sequelize";
+import { Op } from "sequelize";
+
+import type { Authenticator } from "@app/lib/auth";
+import { BaseResource } from "@app/lib/resources/base_resource";
+import { ShareableFileModel } from "@app/lib/resources/storage/models/files";
+import type { ReadonlyAttributesType } from "@app/lib/resources/storage/types";
+import type { ModelStaticWorkspaceAware } from "@app/lib/resources/storage/wrappers/workspace_models";
+import type { Result } from "@app/types/shared/result";
+import { Ok } from "@app/types/shared/result";
+
+// eslint-disable-next-line @typescript-eslint/no-unsafe-declaration-merging
+export interface ShareableFileResource
+  extends ReadonlyAttributesType<ShareableFileModel> {}
+
+// eslint-disable-next-line @typescript-eslint/no-unsafe-declaration-merging
+export class ShareableFileResource extends BaseResource<ShareableFileModel> {
+  static model: ModelStaticWorkspaceAware<ShareableFileModel> =
+    ShareableFileModel;
+
+  constructor(
+    model: ModelStaticWorkspaceAware<ShareableFileModel>,
+    blob: Attributes<ShareableFileModel>
+  ) {
+    super(ShareableFileModel, blob);
+  }
+
+  static async makeNew(blob: Attributes<ShareableFileModel>) {
+    const shareableFile = await this.model.create(blob);
+    return new this(this.model, shareableFile.get());
+  }
+
+  async delete(auth: Authenticator): Promise<Result<undefined, Error>> {
+    const workspace = auth.getNonNullableWorkspace().id;
+    await this.model.destroy({
+      where: { id: this.id, workspaceId: workspace },
+    });
+
+    return new Ok(undefined);
+  }
+
+  static async fetchAllPublicFilesForWorkspace(auth: Authenticator) {
+    const workspace = auth.getNonNullableWorkspace().id;
+    const shareableFiles = await this.model.findAll({
+      where: { workspaceId: workspace, shareScope: "public" },
+    });
+
+    return shareableFiles.map(
+      (shareableFile) => new this(this.model, shareableFile.get())
+    );
+  }
+
+  static async updateShareScopeToWorkspace(
+    auth: Authenticator,
+    shareableFiles: ShareableFileResource[]
+  ) {
+    const workspace = auth.getNonNullableWorkspace().id;
+    await this.model.update(
+      { shareScope: "workspace" },
+      {
+        where: {
+          workspaceId: workspace,
+          id: {
+            [Op.in]: shareableFiles.map((shareableFile) => shareableFile.id),
+          },
+        },
+      }
+    );
+  }
+
+  static async updatePublicShareScopeToWorkspace(auth: Authenticator) {
+    const workspace = auth.getNonNullableWorkspace().id;
+    await this.model.update(
+      { shareScope: "workspace" },
+      { where: { workspaceId: workspace, shareScope: "public" } }
+    );
+  }
+}

--- a/front/lib/resources/shareable_file_resource.ts
+++ b/front/lib/resources/shareable_file_resource.ts
@@ -1,5 +1,4 @@
 import type { Attributes } from "sequelize";
-import { Op } from "sequelize";
 
 import type { Authenticator } from "@app/lib/auth";
 import { BaseResource } from "@app/lib/resources/base_resource";
@@ -26,7 +25,7 @@ export class ShareableFileResource extends BaseResource<ShareableFileModel> {
   }
 
   static async makeNew(blob: Attributes<ShareableFileModel>) {
-    const shareableFile = await this.model.create(blob);
+    const shareableFile = await ShareableFileModel.create(blob);
     return new this(this.model, shareableFile.get());
   }
 
@@ -39,38 +38,9 @@ export class ShareableFileResource extends BaseResource<ShareableFileModel> {
     return new Ok(undefined);
   }
 
-  static async fetchAllPublicFilesForWorkspace(auth: Authenticator) {
-    const workspace = auth.getNonNullableWorkspace().id;
-    const shareableFiles = await this.model.findAll({
-      where: { workspaceId: workspace, shareScope: "public" },
-    });
-
-    return shareableFiles.map(
-      (shareableFile) => new this(this.model, shareableFile.get())
-    );
-  }
-
-  static async updateShareScopeToWorkspace(
-    auth: Authenticator,
-    shareableFiles: ShareableFileResource[]
-  ) {
-    const workspace = auth.getNonNullableWorkspace().id;
-    await this.model.update(
-      { shareScope: "workspace" },
-      {
-        where: {
-          workspaceId: workspace,
-          id: {
-            [Op.in]: shareableFiles.map((shareableFile) => shareableFile.id),
-          },
-        },
-      }
-    );
-  }
-
   static async updatePublicShareScopeToWorkspace(auth: Authenticator) {
     const workspace = auth.getNonNullableWorkspace().id;
-    await this.model.update(
+    return this.model.update(
       { shareScope: "workspace" },
       { where: { workspaceId: workspace, shareScope: "public" } }
     );

--- a/front/lib/resources/shareable_file_resource.ts
+++ b/front/lib/resources/shareable_file_resource.ts
@@ -39,10 +39,10 @@ export class ShareableFileResource extends BaseResource<ShareableFileModel> {
   }
 
   static async updatePublicShareScopeToWorkspace(auth: Authenticator) {
-    const workspace = auth.getNonNullableWorkspace().id;
+    const workspaceId = auth.getNonNullableWorkspace().id;
     return this.model.update(
       { shareScope: "workspace" },
-      { where: { workspaceId: workspace, shareScope: "public" } }
+      { where: { workspaceId, shareScope: "public" } }
     );
   }
 }

--- a/front/lib/resources/storage/models/files.ts
+++ b/front/lib/resources/storage/models/files.ts
@@ -143,7 +143,7 @@ ShareableFileModel.init(
     sequelize: frontSequelize,
     indexes: [
       { fields: ["workspaceId", "fileId"], unique: true },
-      { fields: ["workspaceId", "shareScope"], unique: true },
+      { fields: ["workspaceId", "shareScope"], unique: false },
       { fields: ["token"], unique: true },
     ],
   }

--- a/front/lib/resources/storage/models/files.ts
+++ b/front/lib/resources/storage/models/files.ts
@@ -143,6 +143,7 @@ ShareableFileModel.init(
     sequelize: frontSequelize,
     indexes: [
       { fields: ["workspaceId", "fileId"], unique: true },
+      { fields: ["workspaceId", "shareScope"], unique: true },
       { fields: ["token"], unique: true },
     ],
   }

--- a/front/migrations/db/migration_361.sql
+++ b/front/migrations/db/migration_361.sql
@@ -1,0 +1,2 @@
+-- Migration created on Sep 22, 2025
+CREATE INDEX "shareable_files_workspace_id_share_scope" ON "shareable_files" ("workspaceId", "shareScope");

--- a/front/migrations/db/migration_361.sql
+++ b/front/migrations/db/migration_361.sql
@@ -1,0 +1,2 @@
+-- Migration created on Sep 22, 2025
+CREATE UNIQUE INDEX IF NOT EXISTS "shareable_files_workspace_id_share_scope" ON "shareable_files" ("workspaceId", "shareScope");

--- a/front/migrations/db/migration_361.sql
+++ b/front/migrations/db/migration_361.sql
@@ -1,2 +1,2 @@
 -- Migration created on Sep 22, 2025
-CREATE UNIQUE INDEX IF NOT EXISTS "shareable_files_workspace_id_share_scope" ON "shareable_files" ("workspaceId", "shareScope");
+CREATE INDEX IF NOT EXISTS "shareable_files_workspace_id_share_scope" ON "shareable_files" ("workspaceId", "shareScope");

--- a/front/migrations/db/migration_361.sql
+++ b/front/migrations/db/migration_361.sql
@@ -1,2 +1,0 @@
--- Migration created on Sep 22, 2025
-CREATE INDEX IF NOT EXISTS "shareable_files_workspace_id_share_scope" ON "shareable_files" ("workspaceId", "shareScope");

--- a/front/pages/api/w/[wId]/index.ts
+++ b/front/pages/api/w/[wId]/index.ts
@@ -156,7 +156,7 @@ async function handler(
         await w.update({ metadata: newMetadata });
         owner.metadata = newMetadata;
 
-        // if public sharing is disabled, update all "public" files to be "workspace" in the workspace
+        // if public sharing is disabled, downgrade share scope of all public files to workspace
         if (!body.allowContentCreationFileSharing) {
           await ShareableFileResource.updatePublicShareScopeToWorkspace(auth);
         }

--- a/front/pages/api/w/[wId]/index.ts
+++ b/front/pages/api/w/[wId]/index.ts
@@ -156,7 +156,7 @@ async function handler(
         await w.update({ metadata: newMetadata });
         owner.metadata = newMetadata;
 
-        // update all "public" files to be "workspace" in the workspace
+        // if public sharing is disabled, update all "public" files to be "workspace" in the workspace
         if (!body.allowContentCreationFileSharing) {
           await ShareableFileResource.updatePublicShareScopeToWorkspace(auth);
         }


### PR DESCRIPTION
## Description

- Fixes https://github.com/dust-tt/tasks/issues/4249
- When `allowContentCreationFileSharing` is set to false we downgrade sharefiles with "public" shareScope to "workspace"
- Creates ShareableFileResource

## Tests

- locally

## Risk

Low

## Deploy Plan

- Run migration
- Deploy front
