### PR TITLE
[Confluence] Fix: Heartbeat at page upsertion

### DIFF
--- a/connectors/src/connectors/confluence/lib/content/pages.ts
+++ b/connectors/src/connectors/confluence/lib/content/pages.ts
@@ -34,6 +34,7 @@ import logger from "@connectors/logger/logger";
 import type { ConnectorResource } from "@connectors/resources/connector_resource";
 import type { DataSourceConfig, ModelId } from "@connectors/types";
 import { INTERNAL_MIME_TYPES } from "@connectors/types";
+import { heartbeat } from "@connectors/lib/temporal";
 
 const turndownService = new TurndownService();
 
@@ -188,6 +189,8 @@ export async function confluenceCheckAndUpsertSinglePage({
 }: BaseConfluenceCheckAndUpsertSingleEntityActivityInput & {
   pageRef: ConfluencePageRef;
 }) {
+  await heartbeat();
+
   const { id: spaceId, name: spaceName } = space;
   const { id: pageId } = pageRef;
 

--- a/connectors/src/connectors/confluence/lib/content/pages.ts
+++ b/connectors/src/connectors/confluence/lib/content/pages.ts
@@ -30,11 +30,11 @@ import {
 } from "@connectors/lib/data_sources";
 import type { ConfluenceConfiguration } from "@connectors/lib/models/confluence";
 import { ConfluencePage } from "@connectors/lib/models/confluence";
+import { heartbeat } from "@connectors/lib/temporal";
 import logger from "@connectors/logger/logger";
 import type { ConnectorResource } from "@connectors/resources/connector_resource";
 import type { DataSourceConfig, ModelId } from "@connectors/types";
 import { INTERNAL_MIME_TYPES } from "@connectors/types";
-import { heartbeat } from "@connectors/lib/temporal";
 
 const turndownService = new TurndownService();
 


### PR DESCRIPTION
Description
---
Page upsertion can be long, in particular if there are long tokenizations. When upserting leaf content the activity should heartbeat at every page upserted to avoid continuing on a start-to-close timeout

Example [logs](https://app.datadoghq.eu/logs?query=%28%22Activity%20failed%22%20%40workflowId%3Aconfluence-sync-706-space-40730625-top-level-content-521765310%29%20OR%20%40connectorId%3A706%20-%22Deleting%22%20-%22Successfully%22%20-%22Delete%22&agg_m=count&agg_m_source=base&agg_q=%40workflowId&agg_q_source=base&agg_t=count&analyticsOptions=%5B%22bars%22%2C%22dog_classic%22%2Cnull%2Cnull%2C%22value%22%5D&clustering_pattern_field_path=message&cols=host%2Cservice&fromUser=true&messageDisplay=inline&refresh_mode=paused&storage=hot&stream_sort=desc&top_n=10&top_o=top&viz=stream&x_missing=true&from_ts=1758542109116&to_ts=1758543688779&live=false) with start-to-close, attempt 300+

Risks
---
low to none

Deploy
---
connectors


