### PR TITLE
[front] Remove redundant typeguard on MCP personal auth errors

### DIFF
--- a/front/components/assistant/conversation/AgentMessage.tsx
+++ b/front/components/assistant/conversation/AgentMessage.tsx
@@ -457,13 +457,7 @@ export function AgentMessage({
               // Dispatch retry event to reset failed state and re-enable streaming.
               dispatch(RETRY_BLOCKED_ACTIONS_STARTED_EVENT);
               // Retry on the event's conversationId, which may be coming from a subagent.
-              // TODO(durable-agents): typeguard on a proper type here.
-              if (
-                error.metadata &&
-                isString(error.metadata.messageId) &&
-                isString(error.metadata.conversationId) &&
-                error.metadata.conversationId !== conversationId
-              ) {
+              if (error.metadata.conversationId !== conversationId) {
                 await retryHandler({
                   conversationId: error.metadata.conversationId,
                   messageId: error.metadata.messageId,

--- a/front/components/assistant/conversation/AgentMessage.tsx
+++ b/front/components/assistant/conversation/AgentMessage.tsx
@@ -65,7 +65,6 @@ import {
   GLOBAL_AGENTS_SID,
   isContentCreationFileContentType,
   isPersonalAuthenticationRequiredErrorContent,
-  isString,
   isSupportedImageContentType,
 } from "@app/types";
 


### PR DESCRIPTION
## Description

- This PR removes a redundant inline typeguard on MCP personal auth errors to make the underlying logic more apparent.

## Tests

- Tested locally.

## Risk

- Low.

## Deploy Plan

- Deploy front.
