### PR TITLE
[HOOTL] Generate a secret for the webhook in Dust

### DIFF
--- a/front/components/triggers/CreateWebhookSourceDialog.tsx
+++ b/front/components/triggers/CreateWebhookSourceDialog.tsx
@@ -35,6 +35,7 @@ export function CreateWebhookSourceDialog({
     defaultValues: {
       name: "",
       secret: "",
+      autoGenerate: true,
       signatureHeader: "",
       signatureAlgorithm: "sha256",
       customHeaders: null,

--- a/front/components/triggers/CreateWebhookSourceForm.tsx
+++ b/front/components/triggers/CreateWebhookSourceForm.tsx
@@ -17,6 +17,7 @@ import {
   PostWebhookSourcesSchema,
   WEBHOOK_SOURCE_SIGNATURE_ALGORITHMS,
 } from "@app/types/triggers/webhooks";
+import { generateSecureSecret } from "@app/lib/resources/string_ids";
 
 export const validateCustomHeadersFromString = (value: string | null) => {
   if (value === null || value.trim() === "") {
@@ -72,15 +73,32 @@ export function CreateWebhookSourceFormContent({
         control={form.control}
         name="secret"
         render={({ field }) => (
-          <Input
-            {...field}
-            label="Secret"
-            type="password"
-            placeholder="Secret for validation..."
-            isError={form.formState.errors.secret !== undefined}
-            message={form.formState.errors.secret?.message}
-            messageStatus="error"
-          />
+          <>
+            <Label htmlFor="secret">Secret</Label>
+            <div className="flex items-center gap-2">
+              <div className="flex-1">
+                <Input
+                  {...field}
+                  id="secret"
+                  type="password"
+                  placeholder="Secret for validation..."
+                  isError={form.formState.errors.secret !== undefined}
+                  message={form.formState.errors.secret?.message}
+                  messageStatus="error"
+                />
+              </div>
+              <Button
+                label="Generate"
+                variant="outline"
+                type="button"
+                onClick={() => field.onChange(generateSecureSecret(64))}
+              />
+            </div>
+            <p className="mt-1 text-sm text-muted-foreground dark:text-muted-foreground-night">
+              Note: You will be able to see and copy this secret for the first
+              10 minutes after creating the webhook.
+            </p>
+          </>
         )}
       />
 

--- a/front/components/triggers/CreateWebhookSourceForm.tsx
+++ b/front/components/triggers/CreateWebhookSourceForm.tsx
@@ -74,11 +74,11 @@ export function CreateWebhookSourceFormContent({
         name="secret"
         render={({ field }) => (
           <>
-            <Label htmlFor="secret">Secret</Label>
-            <div className="flex items-center gap-2">
+            <div className="flex items-end gap-2">
               <div className="flex-1">
                 <Input
                   {...field}
+                  label="Secret"
                   id="secret"
                   type="password"
                   placeholder="Secret for validation..."

--- a/front/components/triggers/CreateWebhookSourceForm.tsx
+++ b/front/components/triggers/CreateWebhookSourceForm.tsx
@@ -7,13 +7,13 @@ import {
   DropdownMenuTrigger,
   Input,
   Label,
+  SliderToggle,
   TextArea,
 } from "@dust-tt/sparkle";
 import type { useForm } from "react-hook-form";
 import { Controller } from "react-hook-form";
 import { z } from "zod";
 
-import { generateSecureSecret } from "@app/lib/resources/string_ids";
 import {
   PostWebhookSourcesSchema,
   WEBHOOK_SOURCE_SIGNATURE_ALGORITHMS,
@@ -38,7 +38,14 @@ export const CreateWebhookSourceSchema = PostWebhookSourcesSchema.extend({
     .string()
     .nullable()
     .refine(validateCustomHeadersFromString, "Invalid JSON format"),
-});
+  autoGenerate: z.boolean().default(true),
+}).refine(
+  (data) => data.autoGenerate || (data.secret ?? "").trim().length > 0,
+  {
+    message: "Secret is required",
+    path: ["secret"],
+  }
+);
 
 export type CreateWebhookSourceFormData = z.infer<
   typeof CreateWebhookSourceSchema
@@ -69,16 +76,42 @@ export function CreateWebhookSourceFormContent({
         )}
       />
 
-      <Controller
-        control={form.control}
-        name="secret"
-        render={({ field }) => (
-          <>
-            <div className="flex items-end gap-2">
-              <div className="flex-1">
+      <div>
+        <Label>Secret</Label>
+        <p className="mt-1 text-sm text-muted-foreground dark:text-muted-foreground-night">
+          <i>
+            Note: You will be able to see and copy this secret for the first 10
+            minutes after creating the webhook.
+          </i>
+        </p>
+        <div className="mb-3 flex items-center justify-between">
+          <Label>Auto-generate</Label>
+          <Controller
+            control={form.control}
+            name="autoGenerate"
+            render={({ field }) => (
+              <SliderToggle
+                selected={field.value}
+                onClick={() => {
+                  const next = !field.value;
+                  field.onChange(next);
+                  if (next) {
+                    form.setValue("secret", "");
+                  }
+                }}
+              />
+            )}
+          />
+        </div>
+
+        {!form.watch("autoGenerate") && (
+          <Controller
+            control={form.control}
+            name="secret"
+            render={({ field }) => (
+              <div className="mt-2">
                 <Input
                   {...field}
-                  label="Secret"
                   id="secret"
                   type="password"
                   placeholder="Secret for validation..."
@@ -87,20 +120,10 @@ export function CreateWebhookSourceFormContent({
                   messageStatus="error"
                 />
               </div>
-              <Button
-                label="Generate"
-                variant="outline"
-                type="button"
-                onClick={() => field.onChange(generateSecureSecret(64))}
-              />
-            </div>
-            <p className="mt-1 text-sm text-muted-foreground dark:text-muted-foreground-night">
-              Note: You will be able to see and copy this secret for the first
-              10 minutes after creating the webhook.
-            </p>
-          </>
+            )}
+          />
         )}
-      />
+      </div>
 
       <Controller
         control={form.control}

--- a/front/components/triggers/CreateWebhookSourceForm.tsx
+++ b/front/components/triggers/CreateWebhookSourceForm.tsx
@@ -13,11 +13,11 @@ import type { useForm } from "react-hook-form";
 import { Controller } from "react-hook-form";
 import { z } from "zod";
 
+import { generateSecureSecret } from "@app/lib/resources/string_ids";
 import {
   PostWebhookSourcesSchema,
   WEBHOOK_SOURCE_SIGNATURE_ALGORITHMS,
 } from "@app/types/triggers/webhooks";
-import { generateSecureSecret } from "@app/lib/resources/string_ids";
 
 export const validateCustomHeadersFromString = (value: string | null) => {
   if (value === null || value.trim() === "") {

--- a/front/lib/resources/string_ids.test.ts
+++ b/front/lib/resources/string_ids.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, it } from "vitest";
+
+import { generateSecureSecret } from "@app/lib/resources/string_ids";
+
+describe("generateSecureSecret", () => {
+  it("default call generates 64-char alphanumeric string", () => {
+    const secret = generateSecureSecret();
+    expect(secret).toHaveLength(64);
+    expect(/^[A-Za-z0-9]+$/.test(secret)).toBe(true);
+  });
+
+  it("custom length generates 100-char alphanumeric string", () => {
+    const secret = generateSecureSecret(100);
+    expect(secret).toHaveLength(100);
+    expect(/^[A-Za-z0-9]+$/.test(secret)).toBe(true);
+  });
+});

--- a/front/lib/resources/string_ids.ts
+++ b/front/lib/resources/string_ids.ts
@@ -252,10 +252,24 @@ export function generateSecureSecret(length = 64): string {
     .toString();
 }
 
+function hasProp<K extends PropertyKey>(
+  value: unknown,
+  key: K
+): value is Record<K, unknown> {
+  return typeof value === "object" && value !== null && key in value;
+}
+
 function hasWebCrypto(obj: unknown): obj is {
-  crypto: { getRandomValues: (arr: Uint8Array) => Uint8Array };
+  crypto: { getRandomValues: (arr: ArrayBufferView) => ArrayBufferView };
 } {
-  return !!obj && typeof (obj as any).crypto?.getRandomValues === "function";
+  if (!hasProp(obj, "crypto")) {
+    return false;
+  }
+  const crypto = obj.crypto;
+  if (!hasProp(crypto, "getRandomValues")) {
+    return false;
+  }
+  return typeof crypto.getRandomValues === "function";
 }
 
 function getSecureRandomBytes(length: number): Uint8Array {

--- a/front/lib/resources/string_ids.ts
+++ b/front/lib/resources/string_ids.ts
@@ -237,6 +237,43 @@ export function generateRandomModelSId(prefix?: string): string {
 }
 
 /**
+ * Generates a long, secure, non-guessable secret composed of
+ * URL-safe alphanumeric characters. It uses a cryptographically
+ * secure RNG (Web Crypto's getRandomValues when available) to draw
+ * random bytes, then maps them uniformly to base62 characters.
+ *
+ * length: number of characters to return (default 64).
+ */
+export function generateSecureSecret(length = 64): string {
+  const bytes = getSecureRandomBytes(length);
+  return Buffer.from(bytes)
+    .map(uniformByteToCode62)
+    .map(alphanumFromCode62)
+    .toString();
+}
+
+function hasWebCrypto(obj: unknown): obj is {
+  crypto: { getRandomValues: (arr: Uint8Array) => Uint8Array };
+} {
+  return !!obj && typeof (obj as any).crypto?.getRandomValues === "function";
+}
+
+function getSecureRandomBytes(length: number): Uint8Array {
+  // Prefer Web Crypto API (browser and modern runtimes).
+  if (hasWebCrypto(globalThis)) {
+    const arr = new Uint8Array(length);
+    globalThis.crypto.getRandomValues(arr);
+    return arr;
+  }
+  // Best-effort fallback if Web Crypto is unavailable.
+  const arr = new Uint8Array(length);
+  for (let i = 0; i < length; i++) {
+    arr[i] = Math.floor(Math.random() * 256);
+  }
+  return arr;
+}
+
+/**
  * Given a code in between 0 and 61 included, returns the corresponding
  * character from [A-Za-z0-9]
  */

--- a/front/lib/resources/string_ids.ts
+++ b/front/lib/resources/string_ids.ts
@@ -243,7 +243,6 @@ export function generateRandomModelSId(prefix?: string): string {
  * length: number of characters to return (default 64).
  */
 export function generateSecureSecret(length = 64): string {
-  // Use BLAKE3 to derive `length` bytes from a fresh UUIDv4 seed.
   const digest = blake3(uuidv4(), { length });
   return Buffer.from(digest)
     .map(uniformByteToCode62)

--- a/front/pages/api/w/[wId]/webhook_sources/index.ts
+++ b/front/pages/api/w/[wId]/webhook_sources/index.ts
@@ -4,6 +4,7 @@ import { fromError } from "zod-validation-error";
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
 import type { Authenticator } from "@app/lib/auth";
 import { SpaceResource } from "@app/lib/resources/space_resource";
+import { generateSecureSecret } from "@app/lib/resources/string_ids";
 import { WebhookSourceResource } from "@app/lib/resources/webhook_source_resource";
 import { WebhookSourcesViewResource } from "@app/lib/resources/webhook_sources_view_resource";
 import { concurrentExecutor } from "@app/lib/utils/async_utils";
@@ -106,7 +107,8 @@ async function handler(
         const webhookSourceRes = await WebhookSourceResource.makeNew(auth, {
           workspaceId: workspace.id,
           name,
-          secret,
+          secret:
+            secret && secret.length > 0 ? secret : generateSecureSecret(64),
           signatureHeader,
           signatureAlgorithm,
           customHeaders,

--- a/front/types/triggers/webhooks.ts
+++ b/front/types/triggers/webhooks.ts
@@ -47,7 +47,8 @@ export type PostWebhookSourcesBody = z.infer<typeof PostWebhookSourcesSchema>;
 
 export const PostWebhookSourcesSchema = z.object({
   name: z.string().min(1, "Name is required"),
-  secret: z.string().min(1, "Secret is required"),
+  // Secret can be omitted or empty when auto-generated server-side.
+  secret: z.string().nullable(),
   signatureHeader: z.string().min(1, "Signature header is required"),
   signatureAlgorithm: z.enum(WEBHOOK_SOURCE_SIGNATURE_ALGORITHMS),
   customHeaders: z.record(z.string(), z.string()).nullable(),


### PR DESCRIPTION
## Description

closes https://github.com/issues/assigned?issue=dust-tt%7Ctasks%7C4213

Add a Auto generate button to create the secret.
This allow to provide no secret so it is generated server side (it can then be retrieved in the webhook description).
It generates a 64 character long string in base62 so it can be used in a URL

<img width="400" height="400" alt="image" src="https://github.com/user-attachments/assets/36f586e3-ac9c-4aea-861d-c1f19ce49e0b" />

<img width="400" height="400" alt="image" src="https://github.com/user-attachments/assets/5289b69e-3a68-45c7-abc3-92468bcc77dc" />


## Tests

Manually tested, it does generate the string and it can be copied during the first 10 minutes.

Added tests on the API
Added unit test on generateSecureSecret

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
