### PR TITLE
[front] Drop unused index on AgentStepContent + cleanup durable agents TODOs

### DIFF
--- a/front/lib/actions/mcp.ts
+++ b/front/lib/actions/mcp.ts
@@ -231,7 +231,6 @@ export type ToolNotificationEvent = {
   configurationId: string;
   conversationId: string;
   messageId: string;
-  // TODO(2025-08-29 aubin): replace with AgentMCPActionType as soon as the SDK type is updated.
   action: AgentMCPActionWithOutputType;
   notification: ProgressNotificationContentType;
 };

--- a/front/lib/actions/mcp_execution.ts
+++ b/front/lib/actions/mcp_execution.ts
@@ -97,7 +97,6 @@ export async function processToolNotification(
     messageId: agentMessage.sId,
     action: {
       ...action.toJSON(),
-      // TODO(2025-08-29 aubin): cleanup as soon as the SDK type is updated.
       output: null,
       generatedFiles: [],
     },

--- a/front/lib/models/assistant/agent_step_content.ts
+++ b/front/lib/models/assistant/agent_step_content.ts
@@ -77,11 +77,6 @@ AgentStepContentModel.init(
         fields: ["agentMessageId", "step", "index", "version"],
         name: "agent_step_contents_agent_message_id_step_index_versioned",
       },
-      // TODO(durable-agents, 2025-07-08): drop this index once we start using the one above.
-      {
-        fields: ["agentMessageId", "step", "index"],
-        name: "agent_step_contents_agent_message_id_step_index_in_step",
-      },
       {
         fields: ["agentMessageId"],
         name: "agent_step_contents_agent_message_id_idx",

--- a/front/lib/resources/agent_mcp_action_resource.ts
+++ b/front/lib/resources/agent_mcp_action_resource.ts
@@ -69,7 +69,6 @@ export class AgentMCPActionResource extends BaseResource<AgentMCPActionModel> {
   constructor(
     model: ModelStaticWorkspaceAware<AgentMCPActionModel>,
     blob: Attributes<AgentMCPActionModel>,
-    // TODO(DURABLE-AGENTS, 2025-08-21): consider using the resource instead of the model.
     readonly stepContent: NonAttribute<
       AgentStepContentResource & { value: FunctionCallContentType }
     >,

--- a/front/migrations/db/migration_362.sql
+++ b/front/migrations/db/migration_362.sql
@@ -1,0 +1,2 @@
+-- Migration created on Sep 22, 2025
+DROP INDEX CONCURRENTLY IF EXISTS "agent_step_contents_agent_message_id_step_index_in_step";


### PR DESCRIPTION
## Description

- This PR removes a few outdated TODOs (see comments for context).
- This PR also drops the index on `agent_step_contents` on `("agentMessageId", "step", "index")`. This index is not used anymore (example query plan [here](https://console.cloud.google.com/sql/instances/cell-00000-front-db/insights;database=front;duration=PT1H;trace=9cb3a82681bf5cbded4c7b086ed97833;span=663bfcf74527bcb5;query_hash=8305862447321285427;sort_by=TOTAL_EXEC_TIME/executed?project=or1g1n-186209)).

## Tests

- Checked query plan for queries on this table.
- Tested locally.

## Risk

- Low.

## Deploy Plan

- Deploy front.
- Run migration.
