### PR TITLE
[viz & cc] improve prompt

### DIFF
--- a/front/lib/actions/mcp_internal_actions/servers/common/viz/instructions.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/common/viz/instructions.ts
@@ -98,30 +98,37 @@ Example using the \`useFile\` hook:
 
 \`\`\`
 // Reading files from conversation - ASYNC HANDLING REQUIRED
+import React, { useState, useEffect } from "react";
 import { useFile } from "@dust/react-hooks";
-import { useState, useEffect } from "react";
+import Papa from "papaparse";
 
-function Chart() {
-  const file = useFile(fileId);
-  const [fileContent, setFileContent] = useState(null);
+function DataChart() {
+  const file = useFile("fil_abc123"); 
+  const [data, setData] = useState([]);
+  const [loading, setLoading] = useState(true);
 
   useEffect(() => {
     const loadFile = async () => {
       if (file) {
-        // For text files
         const text = await file.text();
-        setFileContent(text);
-
-        // For binary files
-        const arrayBuffer = await file.arrayBuffer();
-        setFileContent(arrayBuffer);
+        const parsed = Papa.parse(text, { header: true, skipEmptyLines: "greedy" });
+        setData(parsed.data);
+        setLoading(false);
       }
     };
     loadFile();
   }, [file]);
-  
-  return ...
+
+  if (loading) return <div>Loading...</div>;
+
+  return (
+    <div>
+      <h2>Data from File</h2>
+      <p>Found {data.length} rows</p>
+    </div>
+  );
 }
+export default DataChart;
 \`\`\`
 
 \`fileId\` can be extracted from the \`<attachment id="\${FILE_ID}" type... name...>\` tags returned by the \`list_conversation_files\` action.

--- a/front/lib/actions/mcp_internal_actions/servers/common/viz/instructions.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/common/viz/instructions.ts
@@ -105,15 +105,21 @@ import Papa from "papaparse";
 function DataChart() {
   const file = useFile("fil_abc123"); 
   const [data, setData] = useState([]);
+  const [fileContent, setFileContent] = useState(null);
   const [loading, setLoading] = useState(true);
 
   useEffect(() => {
     const loadFile = async () => {
       if (file) {
+       // For text files
         const text = await file.text();
         const parsed = Papa.parse(text, { header: true, skipEmptyLines: "greedy" });
         setData(parsed.data);
         setLoading(false);
+
+        // For binary files
+        const arrayBuffer = await file.arrayBuffer();
+        setFileContent(arrayBuffer);
       }
     };
     loadFile();

--- a/front/lib/actions/mcp_internal_actions/servers/common/viz/instructions.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/common/viz/instructions.ts
@@ -101,23 +101,27 @@ Example using the \`useFile\` hook:
 import { useFile } from "@dust/react-hooks";
 import { useState, useEffect } from "react";
 
-const file = useFile(fileId);
-const [fileContent, setFileContent] = useState(null);
+function Chart() {
+  const file = useFile(fileId);
+  const [fileContent, setFileContent] = useState(null);
 
-useEffect(() => {
-  const loadFile = async () => {
-    if (file) {
-      // For text files
-      const text = await file.text();
-      setFileContent(text);
+  useEffect(() => {
+    const loadFile = async () => {
+      if (file) {
+        // For text files
+        const text = await file.text();
+        setFileContent(text);
 
-      // For binary files
-      const arrayBuffer = await file.arrayBuffer();
-      setFileContent(arrayBuffer);
-    }
-  };
-  loadFile();
-}, [file]);
+        // For binary files
+        const arrayBuffer = await file.arrayBuffer();
+        setFileContent(arrayBuffer);
+      }
+    };
+    loadFile();
+  }, [file]);
+  
+  return ...
+}
 \`\`\`
 
 \`fileId\` can be extracted from the \`<attachment id="\${FILE_ID}" type... name...>\` tags returned by the \`list_conversation_files\` action.

--- a/front/lib/api/assistant/visualization.ts
+++ b/front/lib/api/assistant/visualization.ts
@@ -33,6 +33,7 @@ Guidelines using the :::visualization directive:
   - Files from the conversation as returned by \`list_conversation_files\` can be accessed using the \`useFile()\` hook (all files can be accessed by the hook irrespective of their status).
   - \`useFile\` has to be imported from \`"@dust/react-hooks"\`.
   - Once/if the file is available, \`useFile()\` will return a non-null \`File\` object. The \`File\` object is a browser File object. Examples of using \`useFile\` are available below.
+  - \`file.text()\` is ASYNC - Always use await \`file.text()\` inside useEffect with async function. Never call \`file.text()\` directly in render logic as it returns a Promise, not a string.
   - Always use \`papaparse\` to parse CSV files.
 - User data download from the visualization:
   - To let users download data from the visualization, use the \`triggerUserFileDownload()\` function.
@@ -62,16 +63,30 @@ Guidelines using the :::visualization directive:
 Example using the \`useFile\` hook:
 
 \`\`\`
-// Reading files from conversation
+// Reading files from conversation - ASYNC HANDLING REQUIRED
 import { useFile } from "@dust/react-hooks";
+import { useState, useEffect } from "react";
 
-const file = useFile(fileId);
-if (file) {
+function Chart() {
   const file = useFile(fileId);
-  // for text file:
-  const text = await file.text();
-  // for binary file:
-  const arrayBuffer = await file.arrayBuffer();
+  const [fileContent, setFileContent] = useState(null);
+
+  useEffect(() => {
+    const loadFile = async () => {
+      if (file) {
+        // For text files
+        const text = await file.text();
+        setFileContent(text);
+
+        // For binary files
+        const arrayBuffer = await file.arrayBuffer();
+        setFileContent(arrayBuffer);
+      }
+    };
+    loadFile();
+  }, [file]);
+  
+  return ...
 }
 \`\`\`
 

--- a/front/lib/api/assistant/visualization.ts
+++ b/front/lib/api/assistant/visualization.ts
@@ -71,6 +71,7 @@ import Papa from "papaparse";
 function DataChart() {
   const file = useFile("fil_abc123"); 
   const [data, setData] = useState([]);
+  const [fileContent, setFileContent] = useState(null);
   const [loading, setLoading] = useState(true);
 
   useEffect(() => {
@@ -80,6 +81,10 @@ function DataChart() {
         const parsed = Papa.parse(text, { header: true, skipEmptyLines: "greedy" });
         setData(parsed.data);
         setLoading(false);
+
+        // For binary files
+        const arrayBuffer = await file.arrayBuffer();
+        setFileContent(arrayBuffer);
       }
     };
     loadFile();

--- a/front/lib/api/assistant/visualization.ts
+++ b/front/lib/api/assistant/visualization.ts
@@ -64,30 +64,37 @@ Example using the \`useFile\` hook:
 
 \`\`\`
 // Reading files from conversation - ASYNC HANDLING REQUIRED
+import React, { useState, useEffect } from "react";
 import { useFile } from "@dust/react-hooks";
-import { useState, useEffect } from "react";
+import Papa from "papaparse";
 
-function Chart() {
-  const file = useFile(fileId);
-  const [fileContent, setFileContent] = useState(null);
+function DataChart() {
+  const file = useFile("fil_abc123"); 
+  const [data, setData] = useState([]);
+  const [loading, setLoading] = useState(true);
 
   useEffect(() => {
     const loadFile = async () => {
       if (file) {
-        // For text files
         const text = await file.text();
-        setFileContent(text);
-
-        // For binary files
-        const arrayBuffer = await file.arrayBuffer();
-        setFileContent(arrayBuffer);
+        const parsed = Papa.parse(text, { header: true, skipEmptyLines: "greedy" });
+        setData(parsed.data);
+        setLoading(false);
       }
     };
     loadFile();
   }, [file]);
-  
-  return ...
+
+  if (loading) return <div>Loading...</div>;
+
+  return (
+    <div>
+      <h2>Data from File</h2>
+      <p>Found {data.length} rows</p>
+    </div>
+  );
 }
+export default DataChart;
 \`\`\`
 
 \`fileId\` can be extracted from the \`<attachment id="\${FILE_ID}" type... name...>\` tags returned by the \`list_conversation_files\` action.


### PR DESCRIPTION
## Description
This PR is my attempt to improve the prompt for viz & content_creation. I have [an eng-runner ticket](https://github.com/dust-tt/tasks/issues/4258) that saying old viz is not working, and it generated code like this, and I wonder if I can improve by making the useFile example a bit more specific

```
const file = useFile("fil_CvSgrSwGZez83u");

const ProductsByCategoryBar = () => {
  if (!file) return null;
  const [data, setData] = React.useState(null);

  React.useEffect(() => {
    file.text().then((text) => {
      const parsed = Papa.parse(text, { header: true, skipEmptyLines: "greedy" });
      setData(parsed.data.map(d => ({
        CATEGORY: d.CATEGORY,
        PRODUCTS_BOUGHT: Number(d.PRODUCTS_BOUGHT)
      })));
    });
  }, [file]);
```

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
