### PR TITLE
[cc] update sharing scope

### DIFF
--- a/front/components/assistant/conversation/content_creation/ShareContentCreationFilePopover.tsx
+++ b/front/components/assistant/conversation/content_creation/ShareContentCreationFilePopover.tsx
@@ -57,9 +57,7 @@ interface FileSharingDropdownProps {
   selectedOption: SharingOption;
   options: SharingOption[];
   onScopeChange: (option: SharingOption) => void;
-  owner: LightWorkspaceType;
   disabled?: boolean;
-  isLoading?: boolean;
   isUsingConversationFiles: boolean;
   isPublicSharingForbidden: boolean;
 }
@@ -67,82 +65,49 @@ interface FileSharingDropdownProps {
 function FileSharingDropdown({
   selectedOption,
   onScopeChange,
-  owner,
   disabled = false,
   options,
   isUsingConversationFiles,
   isPublicSharingForbidden,
 }: FileSharingDropdownProps) {
-  const onPublish = () => {
-    const workspaceOption = options.find((opt) => opt.value === "workspace");
-
-    if (workspaceOption) {
-      onScopeChange(workspaceOption);
-    }
-  };
-
-  const placeholderUrl = `${window.location.origin}/w/${owner.sId}/assistant/conversation/share`;
-
   return (
-    <div className="flex flex-col">
-      <div className="flex flex-col gap-3">
-        {selectedOption.value === "none" ? (
-          <div className="flex items-center gap-2">
-            <div className="grow">
-              <Input
-                disabled
-                placeholder={placeholderUrl}
-                className="text-element-600 dark:text-element-600-dark"
-              />
-            </div>
-            <Button
-              label="Create link"
-              icon={LinkIcon}
-              onClick={onPublish}
-              size="sm"
+    <div className="flex flex-col gap-3">
+      <h3 className="text-sm font-semibold text-primary dark:text-primary-night">
+        Who can access
+      </h3>
+      <DropdownMenu>
+        <DropdownMenuTrigger asChild>
+          <Button
+            variant="outline"
+            size="sm"
+            isSelect
+            label={selectedOption.label}
+            icon={selectedOption.icon}
+            className={cn(
+              "grid w-full grid-cols-[auto_1fr_auto] truncate",
+              selectedOption.value === "public" &&
+                isUsingConversationFiles &&
+                "text-primary-400 dark:text-primary-400-night"
+            )}
+            disabled={disabled}
+          />
+        </DropdownMenuTrigger>
+        <DropdownMenuContent className="w-[var(--radix-dropdown-menu-trigger-width)]">
+          {options.map((option) => (
+            <DropdownMenuItem
+              key={option.value}
+              label={option.label}
+              onClick={() => onScopeChange(option)}
+              truncateText
+              icon={option.icon}
+              disabled={
+                option.value === "public" &&
+                (isPublicSharingForbidden || isUsingConversationFiles)
+              }
             />
-          </div>
-        ) : (
-          <div className="flex flex-col gap-3">
-            <h3 className="text-sm font-semibold text-primary dark:text-primary-night">
-              Who can access
-            </h3>
-            <DropdownMenu>
-              <DropdownMenuTrigger asChild>
-                <Button
-                  variant="outline"
-                  size="sm"
-                  isSelect
-                  label={selectedOption.label}
-                  icon={selectedOption.icon}
-                  className={cn(
-                    "grid w-full grid-cols-[auto_1fr_auto] truncate",
-                    selectedOption.value === "public" &&
-                      isUsingConversationFiles &&
-                      "text-primary-400 dark:text-primary-400-night"
-                  )}
-                  disabled={disabled}
-                />
-              </DropdownMenuTrigger>
-              <DropdownMenuContent className="w-[var(--radix-dropdown-menu-trigger-width)]">
-                {options.map((option) => (
-                  <DropdownMenuItem
-                    key={option.value}
-                    label={option.label}
-                    onClick={() => onScopeChange(option)}
-                    truncateText
-                    icon={option.icon}
-                    disabled={
-                      option.value === "public" &&
-                      (isPublicSharingForbidden || isUsingConversationFiles)
-                    }
-                  />
-                ))}
-              </DropdownMenuContent>
-            </DropdownMenu>
-          </div>
-        )}
-      </div>
+          ))}
+        </DropdownMenuContent>
+      </DropdownMenu>
     </div>
   );
 }
@@ -191,6 +156,12 @@ export function ShareContentCreationFilePopover({
       }
     }
   }, [fileShare, isFileShareLoading, isFileShareError, options]);
+
+  const onPublish = async () => {
+    await handleChangeFileShare("workspace");
+  };
+
+  const placeholderUrl = `${window.location.origin}/w/${owner.sId}/assistant/conversation/share`;
 
   const handleChangeFileShare = async (shareScope: FileShareScope) => {
     setIsUpdatingShare(true);
@@ -259,16 +230,33 @@ export function ShareContentCreationFilePopover({
                 )}
 
                 <div className="flex flex-col gap-3">
-                  <FileSharingDropdown
-                    selectedOption={selectedOption}
-                    options={options}
-                    onScopeChange={handleScopeChange}
-                    owner={owner}
-                    disabled={isUpdatingShare}
-                    isUsingConversationFiles={isUsingConversationFiles}
-                    isPublicSharingForbidden={isPublicSharingForbidden}
-                    isLoading={isUpdatingShare}
-                  />
+                  {selectedOption.value === "public" ||
+                  selectedOption.value === "workspace" ? (
+                    <FileSharingDropdown
+                      selectedOption={selectedOption}
+                      options={options}
+                      onScopeChange={handleScopeChange}
+                      disabled={isUpdatingShare}
+                      isUsingConversationFiles={isUsingConversationFiles}
+                      isPublicSharingForbidden={isPublicSharingForbidden}
+                    />
+                  ) : (
+                    <div className="flex items-center gap-2">
+                      <div className="grow">
+                        <Input
+                          disabled
+                          placeholder={placeholderUrl}
+                          className="text-element-600 dark:text-element-600-dark"
+                        />
+                      </div>
+                      <Button
+                        label="Create link"
+                        icon={LinkIcon}
+                        onClick={onPublish}
+                        size="sm"
+                      />
+                    </div>
+                  )}
                   {selectedOption.value !== "none" && (
                     <>
                       <Separator />

--- a/front/lib/resources/file_resource.ts
+++ b/front/lib/resources/file_resource.ts
@@ -303,11 +303,11 @@ export class FileResource extends BaseResource<FileModel> {
     const updateResult = await this.update({ status: "ready" });
 
     // For Content Creation conversation files, automatically create a ShareableFileModel with
-    // default conversation_participants scope.
+    // default none scope.
     if (this.isContentCreation) {
       await ShareableFileModel.upsert({
         fileId: this.id,
-        shareScope: "conversation_participants",
+        shareScope: "none",
         sharedBy: this.userId ?? null,
         workspaceId: this.workspaceId,
         sharedAt: new Date(),

--- a/front/pages/api/v1/public/files/[token].ts
+++ b/front/pages/api/v1/public/files/[token].ts
@@ -85,9 +85,10 @@ async function handler(
     });
   }
 
+  // TODO(2025-09-22 yuka): remove conversation_participants once migration is done.
   // This endpoint does not support conversation participants sharing. It goes through the private
   // API endpoint instead.
-  if (shareScope === "conversation_participants") {
+  if (shareScope === "conversation_participants" || shareScope === "none") {
     return apiError(req, res, {
       status_code: 404,
       api_error: {

--- a/front/types/files.ts
+++ b/front/types/files.ts
@@ -31,8 +31,10 @@ export type FileUseCaseMetadata = {
   lastEditedByAgentConfigurationId?: string;
 };
 
+// TODO(2025-09-22 yuka): remove conversation_participants once migration is done
 export const fileShareScopeSchema = z.enum([
   "conversation_participants",
+  "none",
   "workspace",
   "public",
 ]);


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
The current sharing system is hard for users to understand becase:
- most of people don't know that conversation_participants = anyone in your workspace, and people would expect that conversation_participants = people who send a message in a conversation
- Also when you share with `conversation_participants`, it redirects you to a conversation page (which is also weird). You don't always want to share your prompt history so this might be surprising 
- What is worse, if you set it to `workspace` and share with your team, but after there is no way to disable it, and if you change it to conversation_participants, you will actually end up showing your prompts to everyone in your workspace 🤷‍♀️

so we would like to add an option to disable sharing, but I'm actually not sure if this is the right path 

When it''s not shared:
<img width="433" height="197" alt="Screenshot 2025-09-22 at 22 21 32" src="https://github.com/user-attachments/assets/d6160b60-1db8-4da5-a06b-5717b584bfe0" />


When it's shared:
<img width="448" height="283" alt="Screenshot 2025-09-22 at 22 21 21" src="https://github.com/user-attachments/assets/e9b92ec7-bfb8-422d-a437-69942d262fda" />



## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
