### PR TITLE
[Message Event stream] Apply retry policy on terminated / aborted errors

### DIFF
--- a/sdks/js/src/index.ts
+++ b/sdks/js/src/index.ts
@@ -128,7 +128,8 @@ function isStreamTerminationError(e: unknown): boolean {
 }
 
 function isTransientHttpStatus(status: number): boolean {
-  return status === 408 || status === 429 || (status >= 500 && status < 600);
+  // Only retry on explicit transient statuses; do NOT retry on 5xx.
+  return status === 408 || status === 429;
 }
 
 // Copied from front/hooks/useEventSource.ts

--- a/sdks/js/src/index.ts
+++ b/sdks/js/src/index.ts
@@ -906,10 +906,9 @@ export class DustAPI {
             }
             await new Promise((resolve) => setTimeout(resolve, reconnectDelay));
             continue;
-          } else {
-            const error = res.error;
-            throw new Error(`Error requesting event stream: ${error.message}`);
           }
+          const error = res.error;
+          throw new Error(`Error requesting event stream: ${error.message}`);
         }
 
         if (!res.value.response.ok || !res.value.response.body) {


### PR DESCRIPTION
## Description
Initial goal is to avoid "TypeError: terminated" error that may happen for run_agent if idle (not sending events) for > 60s


- Reuse `streamAgentMessageEvents` reconnection policy for stream terminations and transient request/HTTP errors.
- Detect terminated/aborted read errors via `isStreamTerminationError` and resume with `lastEventId`.
- Treat request/network errors as transient when `autoReconnect` is enabled (backoff + retry).
- Treat only 408 and 429 as transient HTTP statuses. Do not retry on 5xx.
- Preserve fast-fail for non-transient errors and caller-initiated aborts.

## Risks
Blast radius: SDK streaming of agent message events.
Risk: low — bounded retries using existing options; unchanged behavior for non-transient failures.

## Deploy Plan
- deploy front (no need to publish for this)
