### PR TITLE
Remove table query v1 from auto tools

### DIFF
--- a/front/lib/actions/mcp_internal_actions/constants.ts
+++ b/front/lib/actions/mcp_internal_actions/constants.ts
@@ -186,11 +186,14 @@ export const INTERNAL_MCP_SERVERS = {
       instructions: null,
     },
   },
+  // TODO(seb): remove soonish
   [TABLE_QUERY_SERVER_NAME]: {
     id: 4,
-    availability: "auto",
+    availability: "auto_hidden_builder",
     allowMultipleInstances: false,
-    isRestricted: undefined,
+    isRestricted: () => {
+      return true;
+    },
     isPreview: false,
     tools_stakes: undefined,
     tools_retry_policies: { default: "retry_on_interrupt" },


### PR DESCRIPTION
## Description

Hide table query v1 (until full clean up).

## Tests

Local

## Risk

Low

## Deploy Plan

Deploy front