### PR TITLE
[front] Refactor action listing for labs MCP dashboard

### DIFF
--- a/front/lib/resources/agent_mcp_action_resource.ts
+++ b/front/lib/resources/agent_mcp_action_resource.ts
@@ -3,10 +3,8 @@ import _ from "lodash";
 import type {
   Attributes,
   CreationAttributes,
-  IncludeOptions,
   NonAttribute,
   Transaction,
-  WhereOptions,
 } from "sequelize";
 import { Op } from "sequelize";
 
@@ -29,12 +27,7 @@ import {
   AgentMCPActionModel,
   AgentMCPActionOutputItem,
 } from "@app/lib/models/assistant/actions/mcp";
-import { AgentStepContentModel } from "@app/lib/models/assistant/agent_step_content";
-import {
-  AgentMessage,
-  ConversationModel,
-  Message,
-} from "@app/lib/models/assistant/conversation";
+import { AgentMessage, Message } from "@app/lib/models/assistant/conversation";
 import { AgentStepContentResource } from "@app/lib/resources/agent_step_content_resource";
 import { BaseResource } from "@app/lib/resources/base_resource";
 import { ConversationResource } from "@app/lib/resources/conversation_resource";
@@ -46,8 +39,7 @@ import type { ModelStaticWorkspaceAware } from "@app/lib/resources/storage/wrapp
 import { getResourceIdFromSId, makeSId } from "@app/lib/resources/string_ids";
 import type { ResourceFindOptions } from "@app/lib/resources/types";
 import logger from "@app/logger/logger";
-import type { GetMCPActionsResult } from "@app/pages/api/w/[wId]/labs/mcp_actions/[agentId]";
-import type { LightAgentConfigurationType, ModelId, Result } from "@app/types";
+import type { ModelId, Result } from "@app/types";
 import { Err, isString, normalizeError, Ok, removeNulls } from "@app/types";
 import type {
   AgentMCPActionType,
@@ -467,127 +459,6 @@ export class AgentMCPActionResource extends BaseResource<AgentMCPActionModel> {
     });
   }
 
-  static async listByAgent(
-    auth: Authenticator,
-    {
-      agentConfiguration,
-      limit,
-      cursor,
-    }: {
-      agentConfiguration: LightAgentConfigurationType;
-      limit: number;
-      cursor?: string;
-    }
-    // TODO(2025-09-19 aubin): fix this return type, the resource should not need to be aware of
-    //  API-specific types.
-  ): Promise<Result<GetMCPActionsResult, Error>> {
-    const owner = auth.getNonNullableWorkspace();
-
-    const whereClause: WhereOptions<AgentStepContentModel> = {
-      workspaceId: owner.id,
-      type: "function_call",
-    };
-
-    if (cursor) {
-      const cursorDate = new Date(cursor);
-      if (isNaN(cursorDate.getTime())) {
-        return new Err(new Error("Invalid cursor format"));
-      }
-      whereClause.createdAt = {
-        [Op.lt]: cursorDate,
-      };
-    }
-
-    const includeClause: IncludeOptions[] = [
-      {
-        model: AgentMessage,
-        as: "agentMessage",
-        required: true,
-        where: {
-          agentConfigurationId: agentConfiguration.sId,
-        },
-        include: [
-          {
-            model: Message,
-            as: "message",
-            required: true,
-            include: [
-              {
-                model: ConversationModel,
-                as: "conversation",
-                required: true,
-                where: {
-                  visibility: { [Op.ne]: "deleted" },
-                },
-              },
-            ],
-          },
-        ],
-      },
-      {
-        model: AgentMCPActionModel,
-        as: "agentMCPActions",
-        required: true,
-      },
-    ];
-
-    // TODO(2025-09-19 aubin): extract these in methods of AgentStepContentResource.
-    const [totalCount, stepContents] = await Promise.all([
-      AgentStepContentModel.count({
-        include: includeClause,
-        where: whereClause,
-      }),
-      AgentStepContentModel.findAll({
-        include: includeClause,
-        where: whereClause,
-        order: [["createdAt", "DESC"]],
-        limit: limit + 1,
-      }),
-    ]);
-
-    const hasMore = stepContents.length > limit;
-    const actualStepContents = hasMore
-      ? stepContents.slice(0, limit)
-      : stepContents;
-    const nextCursor = hasMore
-      ? actualStepContents[
-          actualStepContents.length - 1
-        ].createdAt.toISOString()
-      : null;
-
-    const actions = actualStepContents.flatMap((stepContent) =>
-      (stepContent.agentMCPActions ?? []).map((action) => {
-        assert(
-          stepContent.agentMessage?.message?.conversation,
-          "Missing required relations"
-        );
-        assert(
-          stepContent.value.type === "function_call",
-          "Step content must be a function call"
-        );
-
-        return {
-          sId: AgentMCPActionResource.modelIdToSId({
-            id: action.id,
-            workspaceId: action.workspaceId,
-          }),
-          createdAt: action.createdAt.toISOString(),
-          functionCallName: stepContent.value.value.name,
-          params: JSON.parse(stepContent.value.value.arguments),
-          status: action.status,
-          conversationId: stepContent.agentMessage.message.conversation.sId,
-          messageId: stepContent.agentMessage.message.sId,
-        };
-      })
-    );
-
-    return new Ok({
-      actions,
-      nextCursor,
-      totalCount,
-    });
-  }
-
   static async listBlockedActionsForAgentMessage(
     auth: Authenticator,
     { agentMessageId }: { agentMessageId: ModelId }
@@ -703,11 +574,13 @@ export class AgentMCPActionResource extends BaseResource<AgentMCPActionModel> {
     );
 
     return {
+      id: this.id,
+      sId: this.sId,
+      createdAt: this.createdAt.getTime(),
       agentMessageId: this.agentMessageId,
       citationsAllocated: this.citationsAllocated,
       functionCallName: this.functionCallName,
       functionCallId: this.stepContent.value.value.id,
-      id: this.id,
       internalMCPServerName: this.metadata.internalMCPServerName,
       mcpServerId: this.metadata.mcpServerId,
       params: this.augmentedInputs,

--- a/front/lib/resources/agent_step_content_resource.ts
+++ b/front/lib/resources/agent_step_content_resource.ts
@@ -287,7 +287,7 @@ export class AgentStepContentResource extends BaseResource<AgentStepContentModel
         ].createdAt.toISOString()
       : null;
 
-    const resources = actualStepContents.map((stepContent) => {
+    const data = actualStepContents.map((stepContent) => {
       assert(
         stepContent.agentMessage?.message?.conversation,
         "Missing required relations"
@@ -301,7 +301,7 @@ export class AgentStepContentResource extends BaseResource<AgentStepContentModel
     });
 
     return {
-      data: resources,
+      data,
       totalCount,
       nextCursor,
     };

--- a/front/lib/resources/agent_step_content_resource.ts
+++ b/front/lib/resources/agent_step_content_resource.ts
@@ -213,7 +213,11 @@ export class AgentStepContentResource extends BaseResource<AgentStepContentModel
       cursor?: Date;
     }
   ): Promise<{
-    stepContents: AgentStepContentResource[];
+    data: {
+      stepContent: AgentStepContentResource;
+      conversationId: string;
+      messageId: string;
+    }[];
     totalCount: number;
     nextCursor: string | null;
   }> {
@@ -284,11 +288,20 @@ export class AgentStepContentResource extends BaseResource<AgentStepContentModel
       : null;
 
     const resources = actualStepContents.map((stepContent) => {
-      return new this(this.model, stepContent.get());
+      assert(
+        stepContent.agentMessage?.message?.conversation,
+        "Missing required relations"
+      );
+
+      return {
+        stepContent: new this(this.model, stepContent.get()),
+        conversationId: stepContent.agentMessage.message.conversation.sId,
+        messageId: stepContent.agentMessage.message.sId,
+      };
     });
 
     return {
-      stepContents: resources,
+      data: resources,
       totalCount,
       nextCursor,
     };

--- a/front/pages/api/w/[wId]/labs/mcp_actions/[agentId]/index.ts
+++ b/front/pages/api/w/[wId]/labs/mcp_actions/[agentId]/index.ts
@@ -4,25 +4,21 @@ import * as reporter from "io-ts-reporters";
 import { NumberFromString, withFallback } from "io-ts-types";
 import type { NextApiRequest, NextApiResponse } from "next";
 
-import type { ToolExecutionStatus } from "@app/lib/actions/statuses";
 import { getAgentConfiguration } from "@app/lib/api/assistant/configuration/agent";
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
 import type { Authenticator } from "@app/lib/auth";
 import { getFeatureFlags } from "@app/lib/auth";
 import { AgentMCPActionResource } from "@app/lib/resources/agent_mcp_action_resource";
+import { AgentStepContentResource } from "@app/lib/resources/agent_step_content_resource";
 import { apiError } from "@app/logger/withlogging";
 import type { WithAPIErrorResponse } from "@app/types";
+import type { AgentMCPActionType } from "@app/types/actions";
 
 export type GetMCPActionsResult = {
-  actions: {
-    sId: string;
-    createdAt: string;
-    functionCallName: string | null;
-    params: Record<string, unknown>;
-    status: ToolExecutionStatus;
+  actions: AgentMCPActionType[] & {
     conversationId: string;
     messageId: string;
-  }[];
+  };
   nextCursor: string | null;
   totalCount: number;
 };
@@ -67,6 +63,20 @@ async function handler(
 
       const { agentId, limit, cursor } = queryValidation.right;
 
+      let cursorDate: Date | undefined;
+      if (cursor) {
+        cursorDate = new Date(cursor);
+        if (isNaN(cursorDate.getTime())) {
+          return apiError(req, res, {
+            status_code: 400,
+            api_error: {
+              type: "invalid_request_error",
+              message: "Invalid cursor format.",
+            },
+          });
+        }
+      }
+
       const owner = auth.getNonNullableWorkspace();
       const flags = await getFeatureFlags(owner);
       if (!flags.includes("labs_mcp_actions_dashboard")) {
@@ -106,37 +116,23 @@ async function handler(
         });
       }
 
-      const result = await AgentMCPActionResource.listByAgent(auth, {
-        agentConfiguration,
-        limit,
-        cursor,
+      const { stepContents, totalCount, nextCursor } =
+        await AgentStepContentResource.listFunctionCallsForAgent(auth, {
+          agentConfiguration,
+          limit,
+          cursor: cursorDate,
+        });
+
+      const actions = await AgentMCPActionResource.fetchByStepContents(auth, {
+        stepContents,
       });
 
-      if (result.isErr()) {
-        const error = result.error;
-        if (error.message === "Invalid cursor format") {
-          return apiError(req, res, {
-            status_code: 400,
-            api_error: {
-              type: "invalid_request_error",
-              message: "Invalid cursor format.",
-            },
-          });
-        }
-
-        return apiError(req, res, {
-          status_code: 500,
-          api_error: {
-            type: "internal_server_error",
-            message: "Failed to fetch MCP actions from database.",
-          },
-        });
-      }
-
-      const { actions, nextCursor, totalCount } = result.value;
-
       return res.status(200).json({
-        actions,
+        actions: actions.map((a) => ({
+          ...a.toJSON(),
+          conversationId: a.stepContent.agentMessage.message.conversation.sId,
+          messageId: a.stepContent.agentMessage.message.sId,
+        })),
         nextCursor,
         totalCount,
       });

--- a/front/types/actions.ts
+++ b/front/types/actions.ts
@@ -6,16 +6,20 @@ import type { ActionGeneratedFileType } from "@app/lib/actions/types";
 import type { ModelId } from "@app/types/shared/model_id";
 
 export type AgentMCPActionType = {
+  id: ModelId;
+  sId: string;
+  createdAt: number;
+
   agentMessageId: ModelId;
-  citationsAllocated: number;
+  internalMCPServerName: InternalMCPServerNameType | null;
+  mcpServerId: string | null;
   // TODO(MCPActionDetails): prevent exposing the function call name
   //  currently used in the extension to guess the tool name but quite brittle.
   functionCallName: string;
   functionCallId: string;
-  id: ModelId;
-  internalMCPServerName: InternalMCPServerNameType | null;
-  mcpServerId: string | null;
+
   params: Record<string, unknown>;
+  citationsAllocated: number;
   status: ToolExecutionStatus;
   step: number;
 };

--- a/sdks/js/src/types.ts
+++ b/sdks/js/src/types.ts
@@ -748,6 +748,7 @@ const ActionGeneratedFileSchema = z.object({
 
 const AgentActionTypeSchema = z.object({
   id: ModelIdSchema,
+  sId: z.string(),
   mcpServerId: z.string().nullable(),
   internalMCPServerName: z.string().nullable(),
   agentMessageId: ModelIdSchema,

--- a/sdks/js/src/types.ts
+++ b/sdks/js/src/types.ts
@@ -749,6 +749,7 @@ const ActionGeneratedFileSchema = z.object({
 const AgentActionTypeSchema = z.object({
   id: ModelIdSchema,
   sId: z.string(),
+  createdAt: z.number(),
   mcpServerId: z.string().nullable(),
   internalMCPServerName: z.string().nullable(),
   agentMessageId: ModelIdSchema,


### PR DESCRIPTION
## Description

- This PR refactors the function `AgentMCPActionResource.listByAgent` to write it in the new stabilized-world way. Instead of one function where we do multiple includes we fetch the step contents first and then get the corresponding actions.
- The goal is to not introduce an API-specific type in `AgentMCPActionResource` (`GetMCPActionsResult` was the result type from the endpoint) and to give an example of how to use these resources with proper pagination, typing, etc..

## Tests

- Tested locally.

## Risk

- Only affects the labs MCP actions dashboard.

## Deploy Plan

- Deploy front.
