### PR TITLE
[front] Add `ajv-formats` to extend JSON schema validation

### DIFF
--- a/front/lib/actions/mcp_metadata.ts
+++ b/front/lib/actions/mcp_metadata.ts
@@ -488,8 +488,7 @@ export function extractMetadataFromTools(tools: Tool[]): MCPToolType[] {
     }
     return {
       name: tool.name,
-      // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
-      description: tool.description || "",
+      description: tool.description ?? "",
       inputSchema,
     };
   });

--- a/front/lib/utils/json_schemas.ts
+++ b/front/lib/utils/json_schemas.ts
@@ -1,4 +1,5 @@
 import Ajv from "ajv";
+import addFormats from "ajv-formats";
 import type {
   JSONSchema7 as JSONSchema,
   JSONSchema7Definition as JSONSchemaDefinition,
@@ -146,6 +147,7 @@ export function validateJsonSchema(value: object | string | null | undefined): {
   try {
     const parsed = typeof value !== "object" ? JSON.parse(value) : value;
     const ajv = new Ajv();
+    addFormats(ajv); // Adds "date", "date-time", "time", "email" and many other common formats.
     ajv.compile(parsed); // Throws an error if the schema is invalid
     return { isValid: true };
   } catch (e) {

--- a/front/package-lock.json
+++ b/front/package-lock.json
@@ -47,6 +47,7 @@
         "@uiw/react-textarea-code-editor": "^3.0.2",
         "@workos-inc/node": "^7.50.0",
         "ajv": "^8.17.1",
+        "ajv-formats": "^3.0.1",
         "auth0": "^4.3.1",
         "blake3": "^2.1.7",
         "bottleneck": "^2.19.5",
@@ -10551,6 +10552,23 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/ajv-formats": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-3.0.1.tgz",
+      "integrity": "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "ajv": {
+          "optional": true
+        }
       }
     },
     "node_modules/ansi-escapes": {

--- a/front/package.json
+++ b/front/package.json
@@ -67,6 +67,7 @@
     "@uiw/react-textarea-code-editor": "^3.0.2",
     "@workos-inc/node": "^7.50.0",
     "ajv": "^8.17.1",
+    "ajv-formats": "^3.0.1",
     "auth0": "^4.3.1",
     "blake3": "^2.1.7",
     "bottleneck": "^2.19.5",


### PR DESCRIPTION
## Description

- We currently error very often on tool input schema validation (logs [here](https://app.datadoghq.eu/logs?query=env%3Aprod%20service%3A%28%22front-agent-loop-worker%22%20OR%20%22front%22%29%20status%3Aerror%20%28%22%5BMCP%5D%20Invalid%20input%20schema%20for%20tool%3A%22%29&agg_m=count&agg_m_source=base&agg_t=count&messageDisplay=inline&referrer_ide=jetbrains-iu&refresh_mode=sliding&storage=hot&stream_sort=time%2Cdesc&viz=stream&from_ts=1758347640970&to_ts=1758606840970&live=true)).
- A good chunk of these errors seem to come from an overly strict validation, that does not support dates, uuids, emails and some other common formats found in JSONSchemas.
- This PR adds support for this, to accept such JSONSchemas.
- We'll consider whether to keep this validation at all after looking at the remaining errors.

## Tests

- Tested locally.

## Risk

- Low.
- `ajv-formats` is relatively lightweight, it's mostly regexes.

## Deploy Plan

- Deploy front.
