### PR TITLE
Validate file share token

### DIFF
--- a/front/lib/resources/file_resource.ts
+++ b/front/lib/resources/file_resource.ts
@@ -4,6 +4,7 @@
 import assert from "assert";
 import type { Attributes, CreationAttributes, Transaction } from "sequelize";
 import type { Readable, Writable } from "stream";
+import { validate } from "uuid";
 
 import config from "@app/lib/api/config";
 import type { Authenticator } from "@app/lib/auth";
@@ -130,15 +131,13 @@ export class FileResource extends BaseResource<FileModel> {
     content: string;
     shareScope: FileShareScope;
   } | null> {
-    let shareableFile = null;
-
-    try {
-      shareableFile = await ShareableFileModel.findOne({
-        where: { token },
-      });
-    } catch (error) {
+    if (!validate(token)) {
       return null;
     }
+
+    const shareableFile = await ShareableFileModel.findOne({
+      where: { token },
+    });
 
     if (!shareableFile) {
       return null;

--- a/front/lib/resources/file_resource.ts
+++ b/front/lib/resources/file_resource.ts
@@ -130,9 +130,15 @@ export class FileResource extends BaseResource<FileModel> {
     content: string;
     shareScope: FileShareScope;
   } | null> {
-    const shareableFile = await ShareableFileModel.findOne({
-      where: { token },
-    });
+    let shareableFile = null;
+
+    try {
+      shareableFile = await ShareableFileModel.findOne({
+        where: { token },
+      });
+    } catch (error) {
+      return null;
+    }
 
     if (!shareableFile) {
       return null;
@@ -141,6 +147,7 @@ export class FileResource extends BaseResource<FileModel> {
     const [workspace] = await WorkspaceResource.fetchByModelIds([
       shareableFile.workspaceId,
     ]);
+
     if (!workspace) {
       return null;
     }

--- a/front/pages/api/v1/public/files/[token].ts
+++ b/front/pages/api/v1/public/files/[token].ts
@@ -51,6 +51,7 @@ async function handler(
   const workspace = await WorkspaceResource.fetchByModelId(
     result.file.workspaceId
   );
+
   if (!workspace) {
     return apiError(req, res, {
       status_code: 404,


### PR DESCRIPTION
## Description

- Fixes https://github.com/dust-tt/tasks/issues/4238
- If a token is not in UUID format, the query will fail SQL side. We have to validate the token is really a UUID before making the request


## Tests

- If not a valid token the page is 404
- If a valid token still works as before

## Risk

Low

## Deploy Plan

Deploy front
