### PR TITLE
feat(front): add voice intent in the transcripts

### DIFF
--- a/front/components/assistant/conversation/input_bar/InputBarContainer.tsx
+++ b/front/components/assistant/conversation/input_bar/InputBarContainer.tsx
@@ -38,6 +38,7 @@ import type {
   LightAgentConfigurationType,
   WorkspaceType,
 } from "@app/types";
+import { assertNever } from "@app/types";
 import { getSupportedFileExtensions } from "@app/types";
 
 export const INPUT_BAR_ACTIONS = [
@@ -130,8 +131,22 @@ const InputBarContainer = ({
   const voiceTranscriberService = useVoiceTranscriberService({
     owner,
     fileUploaderService,
-    onTranscribeDelta: (delta) => {
-      editorService.insertText(delta);
+    onTranscribeComplete: (transcript) => {
+      for (const message of transcript) {
+        switch (message.type) {
+          case "text":
+            editorService.insertText(message.text);
+            break;
+          case "mention":
+            editorService.insertMention({
+              id: message.id,
+              label: message.name,
+            });
+            break;
+          default:
+            assertNever(message);
+        }
+      }
     },
   });
 

--- a/front/lib/registry.ts
+++ b/front/lib/registry.ts
@@ -351,6 +351,20 @@ export const BaseDustProdActionRegistry = {
       },
     },
   },
+  "voice-find-agent-and-tools": {
+    app: {
+      appId: "F15zoc9d8a",
+      appHash:
+        "b8e00639db1b38ccb0eca33781858fd2adf00f37ad81940451e257c17ce8dd27",
+    },
+    config: {
+      GET_AUGMENTED_MESSAGE: {
+        function_call: "find_agents_and_tools",
+        use_cache: false,
+        use_stream: true,
+      },
+    },
+  },
 };
 
 export type DustRegistryActionName = keyof typeof BaseDustProdActionRegistry;

--- a/front/lib/utils/find_agents_in_message.ts
+++ b/front/lib/utils/find_agents_in_message.ts
@@ -1,0 +1,109 @@
+import { runAction } from "@app/lib/actions/server";
+import { getAgentConfigurationsForView } from "@app/lib/api/assistant/configuration/views";
+import type { Authenticator } from "@app/lib/auth";
+import { cloneBaseConfig, getDustProdAction } from "@app/lib/registry";
+import logger from "@app/logger/logger";
+import {
+  assertNever,
+  getSmallWhitelistedModel,
+  GPT_4_1_MINI_MODEL_ID,
+  removeNulls,
+} from "@app/types";
+
+const _ACTION_NAME = "voice-find-agent-and-tools";
+
+export interface Mention {
+  type: "mention";
+  id: string;
+  name: string;
+}
+
+export interface Text {
+  type: "text";
+  text: string;
+}
+
+export type AugmentedMessage = Mention | Text;
+
+async function listAgents(auth: Authenticator) {
+  const agents = await getAgentConfigurationsForView({
+    auth,
+    agentsGetView: "list",
+    variant: "extra_light",
+  });
+
+  return agents.map((a) => ({
+    id: a.sId,
+    name: a.name,
+  }));
+}
+
+function getActionConfig(auth: Authenticator) {
+  const config = cloneBaseConfig(getDustProdAction(_ACTION_NAME).config);
+  const model = getSmallWhitelistedModel(auth.getNonNullableWorkspace());
+  config.GET_AUGMENTED_MESSAGE.provider_id = model?.providerId ?? "openai";
+  config.GET_AUGMENTED_MESSAGE.model_id =
+    model?.modelId ?? GPT_4_1_MINI_MODEL_ID;
+  return config;
+}
+
+export const findAgentsInMessage = async (
+  auth: Authenticator,
+  message: string
+) => {
+  const agents = await listAgents(auth);
+  const config = getActionConfig(auth);
+
+  const res = await runAction(auth, _ACTION_NAME, config, [
+    {
+      agents_list: agents,
+      message,
+    },
+  ]);
+
+  if (res.isErr()) {
+    logger.error(
+      `Action ${_ACTION_NAME} failed to process message: ${res.error.type} ${res.error.message}`
+    );
+    return [{ type: "message", text: message }];
+  }
+
+  const {
+    status: { run },
+    traces,
+    results,
+    run_id,
+  } = res.value;
+
+  logger.info("Action runId : " + run_id);
+
+  switch (run) {
+    case "errored":
+      const error = removeNulls(traces.map((t) => t[1][0][0].error)).join(", ");
+      logger.error(
+        `Action ${_ACTION_NAME} failed to process message: ${error}`
+      );
+
+      return [{ type: "message", text: message }];
+    case "succeeded":
+      if (!results || results.length === 0) {
+        logger.error(
+          `Action ${_ACTION_NAME} failed to process message: no results returned while run was successful`
+        );
+        return [{ type: "message", text: message }];
+      }
+
+      logger.debug(
+        `Action ${_ACTION_NAME} output: ${JSON.stringify(results[0][0])}`
+      );
+
+      return results[0][0].value as AugmentedMessage[];
+    case "running":
+      logger.error(
+        `Action ${_ACTION_NAME} is still running, expected to be done`
+      );
+      return [{ type: "message", text: message }];
+    default:
+      assertNever(run);
+  }
+};

--- a/front/pages/api/w/[wId]/services/transcribe/index.ts
+++ b/front/pages/api/w/[wId]/services/transcribe/index.ts
@@ -2,6 +2,8 @@ import formidable from "formidable";
 import type { NextApiRequest, NextApiResponse } from "next";
 
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
+import type { Authenticator } from "@app/lib/auth";
+import { findAgentsInMessage } from "@app/lib/utils/find_agents_in_message";
 import {
   transcribeFile,
   transcribeStream,
@@ -23,7 +25,8 @@ export type PostTranscribeResponseBody = { text: string };
 
 async function handler(
   req: NextApiRequest,
-  res: NextApiResponse<WithAPIErrorResponse<PostTranscribeResponseBody | void>>
+  res: NextApiResponse<WithAPIErrorResponse<PostTranscribeResponseBody | void>>,
+  auth: Authenticator
 ) {
   const { wId } = req.query;
   if (!wId || typeof wId !== "string") {
@@ -112,8 +115,13 @@ async function handler(
           break;
 
         case "fullTranscript":
+          const fullTranscript = await findAgentsInMessage(
+            auth,
+            chunk.fullTranscript
+          );
+
           res.write(
-            `data: ${JSON.stringify({ type: "fullTranscript", fullTranscript: chunk.fullTranscript })}\n\n`
+            `data: ${JSON.stringify({ type: "fullTranscript", fullTranscript })}\n\n`
           );
           stop = true;
           break;

--- a/tools/npm-install-all-projects.sh
+++ b/tools/npm-install-all-projects.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env zsh
+
+set -euo pipefail
+
+(cd front && npm install)
+(cd connectors && npm install)
+(cd sdks/js && npm install)
+(cd sparkle && npm install)
+


### PR DESCRIPTION
## Description

Find intent from the voice recording. 

When the transcription is done, we sent it to a specific dust app that will find "agents" in the text. 
The app takes as input:
* the list of dust apps
* the transcription

The app is [here](https://dust.tt/w/78bda07b39/spaces/vlt_rICtlrSEpWqX/apps/F15zoc9d8a/runs/6be775cc1a3811715c81ffa56215fbe8acda0a4be1d3f38ca6a45180e7971d36).

@Duncid proposed a better UX integration to keep the live transcription and get the intent. But this require a change in the editor that is not ready yet. 

https://github.com/user-attachments/assets/6b9e61f3-c7fa-46b9-bacf-a69739a57555


## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
