### PR TITLE
[front] Improve error message for personal tools without a user

### DIFF
--- a/front/lib/resources/mcp_server_connection_resource.ts
+++ b/front/lib/resources/mcp_server_connection_resource.ts
@@ -157,6 +157,11 @@ export class MCPServerConnectionResource extends BaseResource<MCPServerConnectio
   ): Promise<Result<MCPServerConnectionResource, DustError>> {
     const { serverType, id } = getServerTypeAndIdFromSId(mcpServerId);
 
+    const user = auth.user();
+    if (connectionType === "personal" && !user) {
+      throw new Error("Personal tools require the user to be authenticated.");
+    }
+
     const connections = await this.baseFetch(auth, {
       where: {
         serverType,


### PR DESCRIPTION
## Description

- We observe logs on tools requiring personal authentication being used in a context where no user is authenticated (logs [here](https://app.datadoghq.eu/logs?query=%40dd.env%3Aprod%20status%3Aerror%20%28service%3Acore%20OR%20service%3Afront%2A%29%20%40dd.service%3Afront-agent-loop-worker&agg_m=count&agg_m_source=base&agg_t=count&clustering_pattern_field_path=message&cols=host%2Cservice&event=AwAAAZlzLUffP8MyjQAAABhBWmx6TFVpVkFBQlFLeEJkYUNkcUhnQU0AAAAkZjE5OTczMmQtNTVhZC00NzllLTk5ZTItYjNhNzYxMzE5OGEwAAA5xw&fromUser=true&messageDisplay=inline&refresh_mode=sliding&storage=hot&stream_sort=desc&viz=stream&from_ts=1758573003628&to_ts=1758573903628&live=true)).
- All the occurrences observed come from the Make and Zapier integration (example [here](https://dust.tt/poke/TxUKo1tecT/conversations/IHsiUnzEDt)).
- The error `Unexpected unauthenticated call to getNonNullableUser` is exposed to the model here (ultimately can be seen by the user), this PR improves the error for the model to better recover from it and also to help it explain to the end user.

## Tests

- Tested locally.

## Risk

- Low.

## Deploy Plan

- Deploy front.
