### PR TITLE
Move parseUri back to server-side code

### DIFF
--- a/front/components/agent_builder/capabilities/mcp/utils/formDefaults.ts
+++ b/front/components/agent_builder/capabilities/mcp/utils/formDefaults.ts
@@ -5,7 +5,6 @@ import type {
   MCPServerConfigurationType,
 } from "@app/components/agent_builder/AgentBuilderFormContext";
 import { getMCPServerToolsConfigurations } from "@app/lib/actions/mcp_internal_actions/input_configuration";
-import { parseAgentConfigurationUri } from "@app/lib/actions/mcp_internal_actions/input_schemas";
 import type { MCPServerViewType } from "@app/lib/api/mcp";
 import type {
   ModelIdType,
@@ -101,13 +100,6 @@ export function getDefaultConfiguration(
 
   const reasoningDefault = toolsConfigurations?.reasoningConfiguration?.default;
   defaults.reasoningModel = getValidatedReasoningModel(reasoningDefault);
-
-  defaults.childAgentId = toolsConfigurations?.childAgentConfiguration?.default
-    ?.uri
-    ? parseAgentConfigurationUri(
-        toolsConfigurations?.childAgentConfiguration?.default?.uri
-      ) ?? null
-    : null;
 
   // Set default values for all configuration types when available
   // This provides better UX by pre-filling known defaults while still allowing

--- a/front/lib/actions/mcp_internal_actions/input_schemas.ts
+++ b/front/lib/actions/mcp_internal_actions/input_schemas.ts
@@ -216,9 +216,3 @@ export const ConfigurableToolInputJSONSchemas = Object.fromEntries(
   Record<InternalToolInputMimeType, JSONSchema>,
   typeof INTERNAL_MIME_TYPES.TOOL_INPUT.ENUM
 >;
-
-// TODO we should not need this here, this should stay in webtools_edge
-export function parseAgentConfigurationUri(uri: string): string | null {
-  const match = uri.match(AGENT_CONFIGURATION_URI_PATTERN);
-  return match ? match[2] : null;
-}

--- a/front/lib/actions/mcp_internal_actions/servers/webtools_edge.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/webtools_edge.ts
@@ -12,10 +12,8 @@ import {
   WEBBROWSER_TOOL_NAME,
   WEBSEARCH_TOOL_NAME,
 } from "@app/lib/actions/mcp_internal_actions/constants";
-import {
-  ConfigurableToolInputSchemas,
-  parseAgentConfigurationUri,
-} from "@app/lib/actions/mcp_internal_actions/input_schemas";
+import { AGENT_CONFIGURATION_URI_PATTERN } from "@app/lib/actions/mcp_internal_actions/input_schemas";
+import { ConfigurableToolInputSchemas } from "@app/lib/actions/mcp_internal_actions/input_schemas";
 import type { WebsearchResultResourceType } from "@app/lib/actions/mcp_internal_actions/output_schemas";
 import {
   makeInternalMCPServer,
@@ -326,3 +324,8 @@ const createServer = (
 };
 
 export default createServer;
+
+function parseAgentConfigurationUri(uri: string): string | null {
+  const match = uri.match(AGENT_CONFIGURATION_URI_PATTERN);
+  return match ? match[2] : null;
+}


### PR DESCRIPTION
## Description

Removed calls to `function parseAgentConfigurationUri` from the frontend code in `formDefaults.ts`

## Tests

Ran all current tests.

## Risk

None, doesn't change behavior. (Removing an unsued feature of displaying defaults in the agent builder for tools with subagent tool configs).

## Deploy Plan

Deploy front.
