### PR TITLE
chore: prevent checkin of local env file for agents

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 .idea
 test.ts
 .env.local
+.env.agent.local
 qdrant_storage
 .*.swp
 .rgignore


### PR DESCRIPTION
Avoid checking in .env.agent.local