### PR TITLE
[front] Allow > 255 char-long `customPrompt` for triggers

### DIFF
--- a/front/lib/models/assistant/triggers/triggers.ts
+++ b/front/lib/models/assistant/triggers/triggers.ts
@@ -57,7 +57,7 @@ TriggerModel.init(
       allowNull: false,
     },
     customPrompt: {
-      type: DataTypes.STRING,
+      type: DataTypes.TEXT,
       allowNull: true,
       defaultValue: null,
     },

--- a/front/migrations/db/migration_363.sql
+++ b/front/migrations/db/migration_363.sql
@@ -1,0 +1,2 @@
+-- Migration created on Sep 23, 2025
+ALTER TABLE "triggers" ALTER COLUMN "customPrompt" TYPE TEXT;


### PR DESCRIPTION
## Description

- Custom prompts longer than 255 chars are not supported in db, this PR fixes that (log [here](https://app.datadoghq.eu/logs?query=%22Unhandled%20API%20Error%22%20region%3Aus-central1&agg_m=count&agg_m_source=base&agg_q=service&agg_q_source=base&agg_t=count&cols=host%2Cservice&event=AwAAAZl162_laa9V5gAAABhBWmwxNjNkM0FBQzF6YkhDWGhhdkxBQWUAAAAkZjE5OTc1ZjAtNDY5NC00NjM3LTk4OWItNTdiMWQxODk4ZmY2AAEnFg&fromUser=true&link_source=monitor_notif&messageDisplay=inline&refresh_mode=sliding&storage=hot&stream_sort=desc&top_n=10&top_o=top&viz=stream&x_missing=true&from_ts=1758619812000&to_ts=1758620112000&live=false)).

## Tests

- Tested locally.

## Risk

- Low, no performance overhead expected.

## Deploy Plan

- Run migration.
- Deploy front.
