### PR TITLE
[sparkle] min rows on readonly textarea

### DIFF
--- a/sparkle/src/components/TextArea.tsx
+++ b/sparkle/src/components/TextArea.tsx
@@ -110,11 +110,18 @@ const TextArea = React.forwardRef<HTMLTextAreaElement, TextareaProps>(
 );
 TextArea.displayName = "TextArea";
 
-const ReadOnlyTextArea = ({ content }: { content: string | null }) => {
+const ReadOnlyTextArea = ({
+  content,
+  minRows = 10,
+}: {
+  content: string | null;
+  minRows: number;
+}) => {
   return (
     <TextArea
       disabled
       isDisplay
+      minRows={minRows}
       className={cn(
         "s-copy-sm s-h-full s-min-h-60 s-w-full s-min-w-0 s-rounded-xl",
         "s-resize-none s-border-border s-bg-muted-background",


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

Part of https://github.com/dust-tt/tasks/issues/4292

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

We allow setting a minrows parameter to the text area readonly component.

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

Low

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->

Bump sparkle