### PR TITLE
feat(front): add index on workspaceId on all tables

### DIFF
--- a/front/lib/models/assistant/actions/remote_mcp_server.ts
+++ b/front/lib/models/assistant/actions/remote_mcp_server.ts
@@ -96,5 +96,6 @@ RemoteMCPServerModel.init(
   {
     sequelize: frontSequelize,
     modelName: "remote_mcp_server",
+    indexes: [{ fields: ["workspaceId"], concurrently: true }],
   }
 );

--- a/front/lib/models/assistant/conversation.ts
+++ b/front/lib/models/assistant/conversation.ts
@@ -259,7 +259,10 @@ UserMessage.init(
   {
     modelName: "user_message",
     sequelize: frontSequelize,
-    indexes: [{ fields: ["userContextOrigin"], concurrently: true }],
+    indexes: [
+      { fields: ["userContextOrigin"], concurrently: true },
+      { fields: ["workspaceId"], concurrently: true },
+    ],
   }
 );
 
@@ -364,6 +367,7 @@ AgentMessage.init(
   {
     modelName: "agent_message",
     sequelize: frontSequelize,
+    indexes: [{ fields: ["workspaceId"], concurrently: true }],
   }
 );
 
@@ -436,6 +440,7 @@ AgentMessageFeedback.init(
         unique: true,
         name: "agent_message_feedbacks_agent_configuration_id_agent_message_id",
       },
+      { fields: ["workspaceId"], concurrently: true },
     ],
   }
 );
@@ -659,6 +664,7 @@ MessageReaction.init(
         fields: ["userId"],
         concurrently: true,
       },
+      { fields: ["workspaceId"], concurrently: true },
     ],
   }
 );

--- a/front/lib/models/assistant/group_agent.ts
+++ b/front/lib/models/assistant/group_agent.ts
@@ -60,6 +60,7 @@ GroupAgentModel.init(
         fields: ["groupId", "agentConfigurationId"],
       },
       { fields: ["agentConfigurationId"] },
+      { fields: ["workspaceId"], concurrently: true },
     ],
   }
 );

--- a/front/lib/models/assistant/tag_agent.ts
+++ b/front/lib/models/assistant/tag_agent.ts
@@ -1,9 +1,4 @@
-import type {
-  BelongsToGetAssociationMixin,
-  CreationOptional,
-  ForeignKey,
-  NonAttribute,
-} from "sequelize";
+import type { BelongsToGetAssociationMixin, CreationOptional, ForeignKey, NonAttribute, } from "sequelize";
 import { DataTypes } from "sequelize";
 
 import { AgentConfiguration } from "@app/lib/models/assistant/agent";

--- a/front/lib/models/doc_tracker.ts
+++ b/front/lib/models/doc_tracker.ts
@@ -296,7 +296,10 @@ TrackerGenerationModel.init(
   {
     modelName: "tracker_generation",
     sequelize: frontSequelize,
-    indexes: [{ fields: ["trackerConfigurationId"] }],
+    indexes: [
+      { fields: ["trackerConfigurationId"] },
+      { fields: ["workspaceId"], concurrently: true },
+    ],
   }
 );
 

--- a/front/lib/resources/storage/models/apps.ts
+++ b/front/lib/resources/storage/models/apps.ts
@@ -198,6 +198,7 @@ Clone.init(
   {
     modelName: "clone",
     sequelize: frontSequelize,
+    indexes: [{ fields: ["workspaceId"], concurrently: true }],
   }
 );
 Clone.belongsTo(AppModel, {

--- a/front/lib/resources/storage/models/group_memberships.ts
+++ b/front/lib/resources/storage/models/group_memberships.ts
@@ -40,7 +40,10 @@ GroupMembershipModel.init(
   {
     modelName: "group_memberships",
     sequelize: frontSequelize,
-    indexes: [{ fields: ["userId", "groupId"] }],
+    indexes: [
+      { fields: ["userId", "groupId"] },
+      { fields: ["workspaceId"], concurrently: true },
+    ],
   }
 );
 UserModel.hasMany(GroupMembershipModel, {

--- a/front/lib/resources/storage/models/runs.ts
+++ b/front/lib/resources/storage/models/runs.ts
@@ -95,7 +95,11 @@ RunUsageModel.init(
   {
     modelName: "run_usages",
     sequelize: frontSequelize,
-    indexes: [{ fields: ["runId"] }, { fields: ["providerId", "modelId"] }],
+    indexes: [
+      { fields: ["runId"] },
+      { fields: ["providerId", "modelId"] },
+      { fields: ["workspaceId"], concurrently: true },
+    ],
   }
 );
 

--- a/front/lib/resources/storage/models/workspace_has_domain.ts
+++ b/front/lib/resources/storage/models/workspace_has_domain.ts
@@ -34,6 +34,9 @@ WorkspaceHasDomainModel.init(
   {
     modelName: "workspace_has_domains",
     sequelize: frontSequelize,
-    indexes: [{ unique: true, fields: ["domain"] }],
+    indexes: [
+      { unique: true, fields: ["domain"] },
+      { fields: ["workspaceId"], concurrently: true },
+    ],
   }
 );

--- a/front/migrations/db/migration_364.sql
+++ b/front/migrations/db/migration_364.sql
@@ -1,0 +1,13 @@
+-- Migration created on Sep 23, 2025
+CREATE INDEX CONCURRENTLY "workspace_has_domains_workspace_id" ON "workspace_has_domains" ("workspaceId");
+CREATE INDEX CONCURRENTLY "group_memberships_workspace_id" ON "group_memberships" ("workspaceId");
+CREATE INDEX CONCURRENTLY "clones_workspace_id" ON "clones" ("workspaceId");
+CREATE INDEX CONCURRENTLY "run_usages_workspace_id" ON "run_usages" ("workspaceId");
+CREATE INDEX CONCURRENTLY "tracker_generations_workspace_id" ON "tracker_generations" ("workspaceId");
+CREATE INDEX CONCURRENTLY "group_agents_workspace_id" ON "group_agents" ("workspaceId");
+CREATE INDEX CONCURRENTLY "remote_mcp_servers_workspace_id" ON "remote_mcp_servers" ("workspaceId");
+CREATE INDEX CONCURRENTLY "user_messages_workspace_id" ON "user_messages" ("workspaceId");
+CREATE INDEX CONCURRENTLY "agent_messages_workspace_id" ON "agent_messages" ("workspaceId");
+CREATE INDEX CONCURRENTLY "agent_message_feedbacks_workspace_id" ON "agent_message_feedbacks" ("workspaceId");
+CREATE INDEX CONCURRENTLY "message_reactions_workspace_id" ON "message_reactions" ("workspaceId");
+


### PR DESCRIPTION
## Description

While trying to fix the admin analytics, I stumbled upon this [query](https://github.com/dust-tt/dust/blob/6cb11eecb8c8bb549efc5afb25197606d76672b9/front/pages/api/w/%5BwId%5D/workspace-analytics.ts#L77). 

[Its plan is quite clear](https://explain.dalibo.com/plan/fd11bg5ddffcc853#plan/node/1): we are doing a very expensive "Parallel Seq Scan on user_message" on the `workspaceId`. 

Then I stumbled upon the fact we missed quite some indices on `workspaceId`, including the `user_message` table. 

It's good practice to have indices on foreign keys by default. It's useful most of time. I'm 75% sure just adding this index will help on the query

Next potential steps:
* add indices by default on all foreign keys in the code
* enable datadog DB monitoring to get more insights

## Tests

🤷 


## Risk

Low, it's adding the indices concurrently

## Deploy Plan

* Deploy
* Pass migrations

