### PR TITLE
[sparkle] Handle context menu on menuItems

### DIFF
--- a/front/components/assistant/TagsManager.tsx
+++ b/front/components/assistant/TagsManager.tsx
@@ -43,7 +43,7 @@ const columns = [
     accessorKey: "action",
     header: "",
     cell: (info: CellContext<any, number>) => (
-      <DataTable.MoreButton menuItems={info.row.original.moreMenuItems} />
+      <DataTable.MoreButton menuItems={info.row.original.menuItems} />
     ),
     meta: { className: "w-14" },
   },
@@ -112,7 +112,7 @@ export function TagsManager({ open, setOpen, owner }: TagsManagerProps) {
 
   const rows = tags.map((tag) => ({
     ...tag,
-    moreMenuItems: [
+    menuItems: [
       {
         icon: PencilSquareIcon,
         label: "Edit tag",

--- a/front/components/assistant/manager/AssistantsTable.tsx
+++ b/front/components/assistant/manager/AssistantsTable.tsx
@@ -1,3 +1,4 @@
+import type { MenuItem } from "@dust-tt/sparkle";
 import {
   Avatar,
   BracesIcon,
@@ -36,14 +37,6 @@ import type {
 import { isAdmin, pluralize } from "@app/types";
 import type { TagType } from "@app/types/tag";
 
-type MoreMenuItem = {
-  label: string;
-  icon: React.ComponentType;
-  onClick: (e: React.MouseEvent) => void;
-  variant?: "warning" | "default";
-  kind: "item";
-};
-
 type RowData = {
   sId: string;
   name: string;
@@ -54,7 +47,7 @@ type RowData = {
   lastUpdate: string | null;
   scope: AgentConfigurationScope;
   onClick?: () => void;
-  moreMenuItems?: MoreMenuItem[];
+  menuItems?: MenuItem[];
   agentTags: TagType[];
   agentTagsAsString: string;
   action?: React.ReactNode;
@@ -232,9 +225,7 @@ const getTableColumns = ({
             </DataTable.CellContent>
           );
         }
-        return (
-          <DataTable.MoreButton menuItems={info.row.original.moreMenuItems} />
-        );
+        return <DataTable.MoreButton menuItems={info.row.original.menuItems} />;
       },
       meta: {
         className: "w-14",
@@ -337,7 +328,7 @@ export function AssistantsTable({
               setShowDetails(agentConfiguration);
             }
           },
-          moreMenuItems:
+          menuItems:
             agentConfiguration.scope !== "global" &&
             agentConfiguration.status !== "archived"
               ? [

--- a/front/components/me/UserToolsTable.tsx
+++ b/front/components/me/UserToolsTable.tsx
@@ -29,7 +29,6 @@ interface UserTableRow {
   connection: MCPServerConnectionType | undefined;
   visual: React.JSX.Element;
   onClick?: () => void;
-  moreMenuItems?: any[];
 }
 
 interface UserToolsTableProps {
@@ -116,7 +115,6 @@ export function UserToolsTable({ owner }: UserToolsTableProps) {
         connection: connectionsByServerId[serverView.server.sId],
         visual: getAvatar(serverView.server),
         onClick: () => {},
-        moreMenuItems: [],
       }));
   }, [serverViews, connections, approvals, searchQuery]);
 

--- a/front/components/spaces/AdvancedNotionManagement.tsx
+++ b/front/components/spaces/AdvancedNotionManagement.tsx
@@ -30,7 +30,6 @@ interface TableData {
   method: "sync" | "delete";
   error_message?: string;
   onClick?: () => void;
-  moreMenuItems?: DropdownMenuItemProps[];
   dropdownMenuProps?: React.ComponentPropsWithoutRef<typeof DropdownMenu>;
 }
 

--- a/front/components/workspace/WorkspaceAccessPanel.tsx
+++ b/front/components/workspace/WorkspaceAccessPanel.tsx
@@ -131,7 +131,6 @@ interface DomainRowData {
   workspaceVerifiedDomain?: WorkspaceDomain;
   status: string;
   onClick?: () => void;
-  moreMenuItems?: any[];
 }
 
 function DomainVerificationTable({

--- a/sparkle/src/components/DataTable.tsx
+++ b/sparkle/src/components/DataTable.tsx
@@ -918,9 +918,7 @@ DataTable.MoreButton = function MoreButton({
       </DropdownMenuTrigger>
 
       <DropdownMenuContent align="end">
-        <DropdownMenuGroup>
-          {menuItems.map((item, index) => renderMenuItem(item, index))}
-        </DropdownMenuGroup>
+        <DropdownMenuGroup>{menuItems.map(renderMenuItem)}</DropdownMenuGroup>
       </DropdownMenuContent>
     </DropdownMenu>
   );

--- a/sparkle/src/components/DataTable.tsx
+++ b/sparkle/src/components/DataTable.tsx
@@ -729,7 +729,6 @@ DataTable.Row = function Row({
   rowData,
   ...props
 }: RowProps) {
-  const [contextMenuOpen, setContextMenuOpen] = useState(false);
   const [contextMenuPosition, setContextMenuPosition] = useState<{
     x: number;
     y: number;
@@ -742,7 +741,6 @@ DataTable.Row = function Row({
 
     event.preventDefault();
     setContextMenuPosition({ x: event.clientX, y: event.clientY });
-    setContextMenuOpen(true);
   };
 
   return (
@@ -764,10 +762,10 @@ DataTable.Row = function Row({
         {children}
       </tr>
 
-      {contextMenuOpen && rowData?.menuItems?.length && (
+      {contextMenuPosition && rowData?.menuItems?.length && (
         <DropdownMenu
-          open={contextMenuOpen}
-          onOpenChange={setContextMenuOpen}
+          open={!!contextMenuPosition}
+          onOpenChange={(open) => !open && setContextMenuPosition(null)}
           modal={false}
         >
           <DropdownMenuPortal>
@@ -782,7 +780,9 @@ DataTable.Row = function Row({
             >
               <DropdownMenuGroup>
                 {rowData?.menuItems?.map((item, index) =>
-                  renderMenuItem(item, index, () => setContextMenuOpen(false))
+                  renderMenuItem(item, index, () =>
+                    setContextMenuPosition(null)
+                  )
                 )}
               </DropdownMenuGroup>
             </DropdownMenuContent>

--- a/sparkle/src/components/DataTable.tsx
+++ b/sparkle/src/components/DataTable.tsx
@@ -68,8 +68,8 @@ declare module "@tanstack/react-table" {
 
 interface TBaseData {
   onClick?: () => void;
-  moreMenuItems?: DropdownMenuItemProps[];
   dropdownMenuProps?: React.ComponentPropsWithoutRef<typeof DropdownMenu>;
+  menuItems?: MenuItem[];
 }
 
 interface ColumnBreakpoint {
@@ -286,6 +286,7 @@ export function DataTable<TData extends TBaseData>({
                 onClick={
                   enableRowSelection ? handleRowClick : row.original.onClick
                 }
+                rowData={row.original}
                 {...(enableRowSelection && {
                   "data-selected": row.getIsSelected(),
                 })}
@@ -562,6 +563,7 @@ export function ScrollableDataTable<TData extends TBaseData>({
                   onClick={
                     enableRowSelection ? handleRowClick : row.original.onClick
                   }
+                  rowData={row.original}
                   className="s-absolute s-w-full"
                   {...(enableRowSelection && {
                     "data-selected": row.getIsSelected(),
@@ -716,6 +718,7 @@ interface RowProps extends React.HTMLAttributes<HTMLTableRowElement> {
   onClick?: () => void;
   widthClassName: string;
   "data-selected"?: boolean;
+  rowData?: TBaseData;
 }
 
 DataTable.Row = function Row({
@@ -723,24 +726,69 @@ DataTable.Row = function Row({
   className,
   onClick,
   widthClassName,
+  rowData,
   ...props
 }: RowProps) {
+  const [contextMenuOpen, setContextMenuOpen] = useState(false);
+  const [contextMenuPosition, setContextMenuPosition] = useState<{
+    x: number;
+    y: number;
+  } | null>(null);
+
+  const handleContextMenu = (event: React.MouseEvent) => {
+    if (!rowData?.menuItems?.length) {
+      return;
+    }
+
+    event.preventDefault();
+    setContextMenuPosition({ x: event.clientX, y: event.clientY });
+    setContextMenuOpen(true);
+  };
+
   return (
-    <tr
-      className={cn(
-        "s-group/dt-row s-justify-center s-border-b s-transition-colors s-duration-300 s-ease-out",
-        "s-border-separator dark:s-border-separator-night",
-        onClick &&
-          "s-cursor-pointer [&:hover:not(:has(input:hover)):not(:has(button:hover))]:s-bg-muted dark:[&:hover:not(:has(input:hover)):not(:has(button:hover))]:s-bg-muted-night",
-        props["data-selected"] && "s-bg-muted/50 dark:s-bg-muted/50",
-        widthClassName,
-        className
+    <>
+      <tr
+        className={cn(
+          "s-group/dt-row s-justify-center s-border-b s-transition-colors s-duration-300 s-ease-out",
+          "s-border-separator dark:s-border-separator-night",
+          onClick &&
+            "s-cursor-pointer [&:hover:not(:has(input:hover)):not(:has(button:hover))]:s-bg-muted dark:[&:hover:not(:has(input:hover)):not(:has(button:hover))]:s-bg-muted-night",
+          props["data-selected"] && "s-bg-muted/50 dark:s-bg-muted/50",
+          widthClassName,
+          className
+        )}
+        onClick={onClick || undefined}
+        onContextMenu={handleContextMenu}
+        {...props}
+      >
+        {children}
+      </tr>
+
+      {contextMenuOpen && rowData?.menuItems?.length && (
+        <DropdownMenu
+          open={contextMenuOpen}
+          onOpenChange={setContextMenuOpen}
+          modal={false}
+        >
+          <DropdownMenuPortal>
+            <DropdownMenuContent
+              align="start"
+              style={{
+                position: "fixed",
+                left: contextMenuPosition?.x || 0,
+                top: contextMenuPosition?.y || 0,
+              }}
+            >
+              <DropdownMenuGroup>
+                {rowData?.menuItems?.map((item, index) =>
+                  renderMenuItem(item, index, () => setContextMenuOpen(false))
+                )}
+              </DropdownMenuGroup>
+            </DropdownMenuContent>
+          </DropdownMenuPortal>
+        </DropdownMenu>
       )}
-      onClick={onClick || undefined}
-      {...props}
-    >
-      {children}
-    </tr>
+    </>
   );
 };
 
@@ -769,6 +817,71 @@ interface SubmenuMenuItem extends BaseMenuItem {
 
 export type MenuItem = RegularMenuItem | SubmenuMenuItem;
 
+// Shared menu rendering functions
+const renderSubmenuItem = (
+  item: SubmenuMenuItem,
+  index: number,
+  onItemClick?: () => void
+) => (
+  <DropdownMenuSub key={`${item.label}-${index}`}>
+    <DropdownMenuSubTrigger label={item.label} disabled={item.disabled} />
+    <DropdownMenuPortal>
+      <DropdownMenuSubContent>
+        <ScrollArea
+          className="s-min-w-24 s-flex s-max-h-72 s-flex-col"
+          hideScrollBar
+        >
+          {item.items.map((subItem) => (
+            <DropdownMenuItem
+              key={subItem.id}
+              label={subItem.name}
+              onClick={(event) => {
+                event.stopPropagation();
+                item.onSelect(subItem.id);
+                onItemClick?.();
+              }}
+            />
+          ))}
+          <ScrollBar className="s-py-0" />
+        </ScrollArea>
+      </DropdownMenuSubContent>
+    </DropdownMenuPortal>
+  </DropdownMenuSub>
+);
+
+const renderRegularItem = (
+  item: RegularMenuItem,
+  index: number,
+  onItemClick?: () => void
+) => {
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  const { kind, ...itemProps } = item;
+  return (
+    <DropdownMenuItem
+      key={`item-${index}`}
+      {...itemProps}
+      onClick={(event) => {
+        event.stopPropagation();
+        itemProps.onClick?.(event);
+        onItemClick?.();
+      }}
+    />
+  );
+};
+
+const renderMenuItem = (
+  item: MenuItem,
+  index: number,
+  onItemClick?: () => void
+) => {
+  switch (item.kind) {
+    case "submenu":
+      return renderSubmenuItem(item, index, onItemClick);
+    case "item":
+      return renderRegularItem(item, index, onItemClick);
+  }
+};
+
 export interface DataTableMoreButtonProps {
   className?: string;
   menuItems?: MenuItem[];
@@ -787,56 +900,6 @@ DataTable.MoreButton = function MoreButton({
     return null;
   }
 
-  const renderSubmenuItem = (item: SubmenuMenuItem, index: number) => (
-    <DropdownMenuSub key={`${item.label}-${index}`}>
-      <DropdownMenuSubTrigger label={item.label} disabled={item.disabled} />
-      <DropdownMenuPortal>
-        <DropdownMenuSubContent>
-          <ScrollArea
-            className="s-min-w-24 s-flex s-max-h-72 s-flex-col"
-            hideScrollBar
-          >
-            {item.items.map((subItem) => (
-              <DropdownMenuItem
-                key={subItem.id}
-                label={subItem.name}
-                onClick={(event) => {
-                  event.stopPropagation();
-                  item.onSelect(subItem.id);
-                }}
-              />
-            ))}
-            <ScrollBar className="s-py-0" />
-          </ScrollArea>
-        </DropdownMenuSubContent>
-      </DropdownMenuPortal>
-    </DropdownMenuSub>
-  );
-
-  const renderRegularItem = (item: RegularMenuItem, index: number) => {
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    const { kind, ...itemProps } = item;
-    return (
-      <DropdownMenuItem
-        key={`item-${index}`}
-        {...itemProps}
-        onClick={(event) => {
-          event.stopPropagation();
-          itemProps.onClick?.(event);
-        }}
-      />
-    );
-  };
-
-  const renderMenuItem = (item: MenuItem, index: number) => {
-    switch (item.kind) {
-      case "submenu":
-        return renderSubmenuItem(item, index);
-      case "item":
-        return renderRegularItem(item, index);
-    }
-  };
-
   return (
     <DropdownMenu modal={false} {...dropdownMenuProps}>
       <DropdownMenuTrigger
@@ -854,7 +917,9 @@ DataTable.MoreButton = function MoreButton({
       </DropdownMenuTrigger>
 
       <DropdownMenuContent align="end">
-        <DropdownMenuGroup>{menuItems.map(renderMenuItem)}</DropdownMenuGroup>
+        <DropdownMenuGroup>
+          {menuItems.map((item, index) => renderMenuItem(item, index))}
+        </DropdownMenuGroup>
       </DropdownMenuContent>
     </DropdownMenu>
   );

--- a/sparkle/src/components/DataTable.tsx
+++ b/sparkle/src/components/DataTable.tsx
@@ -773,6 +773,7 @@ DataTable.Row = function Row({
           <DropdownMenuPortal>
             <DropdownMenuContent
               align="start"
+              className="s-whitespace-nowrap"
               style={{
                 position: "fixed",
                 left: contextMenuPosition?.x || 0,

--- a/sparkle/src/components/DataTable.tsx
+++ b/sparkle/src/components/DataTable.tsx
@@ -918,7 +918,9 @@ DataTable.MoreButton = function MoreButton({
       </DropdownMenuTrigger>
 
       <DropdownMenuContent align="end">
-        <DropdownMenuGroup>{menuItems.map(renderMenuItem)}</DropdownMenuGroup>
+        <DropdownMenuGroup>
+          {menuItems.map((item, index) => renderMenuItem(item, index))}
+        </DropdownMenuGroup>
       </DropdownMenuContent>
     </DropdownMenu>
   );


### PR DESCRIPTION
https://github.com/dust-tt/tasks/issues/4275

## Description

Open context menu with menuItems on right click. 

<img width="515" height="194" alt="Screenshot 2025-09-23 at 13 19 55" src="https://github.com/user-attachments/assets/8a2b3f9f-4437-45c0-8522-a59433ec0173" />

Update front to use menuItems instead of moreMenuItems

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

publish sparkle
