### PR TITLE
[MCP Validation] Add Pretty/Raw JSON toggle to tool validation details

### DIFF
--- a/front/components/assistant/conversation/blocked_actions/ToolValidationDialogPage.tsx
+++ b/front/components/assistant/conversation/blocked_actions/ToolValidationDialogPage.tsx
@@ -1,8 +1,8 @@
 import {
   Checkbox,
-  CodeBlock,
   CollapsibleComponent,
   Label,
+  CodeBlockWithExtendedSupport,
 } from "@dust-tt/sparkle";
 
 import type { BlockedToolExecution } from "@app/lib/actions/mcp";
@@ -45,15 +45,10 @@ export function ToolValidationDialogPage({
         <CollapsibleComponent
           triggerChildren={<span className="font-medium">Details</span>}
           contentChildren={
-            <div>
-              <div className="max-h-80 overflow-auto rounded-lg bg-muted dark:bg-muted-night">
-                <CodeBlock
-                  wrapLongLines
-                  className="language-json overflow-y-auto"
-                >
-                  {JSON.stringify(blockedAction.inputs, null, 2)}
-                </CodeBlock>
-              </div>
+            <div className="max-h-80 overflow-auto">
+              <CodeBlockWithExtendedSupport className="language-json">
+                {JSON.stringify(blockedAction.inputs, null, 2)}
+              </CodeBlockWithExtendedSupport>
             </div>
           }
         />

--- a/front/components/assistant/conversation/blocked_actions/ToolValidationDialogPage.tsx
+++ b/front/components/assistant/conversation/blocked_actions/ToolValidationDialogPage.tsx
@@ -1,8 +1,8 @@
 import {
   Checkbox,
+  CodeBlockWithExtendedSupport,
   CollapsibleComponent,
   Label,
-  CodeBlockWithExtendedSupport,
 } from "@dust-tt/sparkle";
 
 import type { BlockedToolExecution } from "@app/lib/actions/mcp";

--- a/sparkle/src/components/markdown/CodeBlockWithExtendedSupport.tsx
+++ b/sparkle/src/components/markdown/CodeBlockWithExtendedSupport.tsx
@@ -41,9 +41,14 @@ const getPrettyJsonPreference = () => {
     const prettyJsonPreference = localStorage.getItem(
       PRETTY_JSON_PREFERENCE_KEY
     );
+    // Default to Pretty view when preference is not yet set.
+    if (prettyJsonPreference === null) {
+      return true;
+    }
     return prettyJsonPreference === "true";
   } catch {
-    return false;
+    // If localStorage is unavailable, default to Pretty view.
+    return true;
   }
 };
 


### PR DESCRIPTION
## Description
Fixes https://github.com/dust-tt/tasks/issues/4264

- Replaces raw JSON-only rendering in the tool validation dialog with the shared pretty JSON renderer from Sparkle.
- Uses `CodeBlockWithExtendedSupport` so users can toggle between Pretty JSON and Raw JSON, matching the message breakdown UI (includes download/copy actions via ContentBlockWrapper).
- Switches sparkle to default on pretty view

<img width="861" height="719" alt="image" src="https://github.com/user-attachments/assets/e88374a7-cb55-4abc-a3b9-ca9e28be2b70" />


## Risks
Blast radius: Tool validation dialog JSON details rendering.
Risk: low

## Deploy Plan
- Frontend deploy
- publish sparkle
(minor change so will not do a front bump PR)
