### PR TITLE
Clarify that name and description of data source cannot empty

### DIFF
--- a/front/components/agent_builder/capabilities/knowledge/KnowledgeConfigurationSheet.tsx
+++ b/front/components/agent_builder/capabilities/knowledge/KnowledgeConfigurationSheet.tsx
@@ -378,7 +378,11 @@ function KnowledgeConfigurationSheetContent({
         <div className="space-y-6">
           <ProcessingMethodSection />
 
-          <NameSection title="Name" placeholder="Name ..." />
+          <NameSection
+            title="Name"
+            placeholder="Name ..."
+            triggerValidationOnChange={true}
+          />
 
           {toolsConfigurations.mayRequireTimeFrameConfiguration && (
             <TimeFrameSection actionType="extract" />
@@ -388,7 +392,12 @@ function KnowledgeConfigurationSheetContent({
             <JsonSchemaSection getAgentInstructions={getAgentInstructions} />
           )}
 
-          {config && <DescriptionSection {...config?.descriptionConfig} />}
+          {config && (
+            <DescriptionSection
+              {...config?.descriptionConfig}
+              triggerValidationOnChange={true}
+            />
+          )}
 
           {/* Advanced Settings collapsible section */}
           {mcpServerView?.serverType === "internal" &&

--- a/front/components/agent_builder/capabilities/shared/DescriptionSection.tsx
+++ b/front/components/agent_builder/capabilities/shared/DescriptionSection.tsx
@@ -26,8 +26,11 @@ export function DescriptionSection({
   const descriptionValue = useWatch({ name: DESCRIPTION_FIELD_NAME });
   const { trigger } = useFormContext();
 
+  // force the validation on empty field so it is validated initially
   useEffect(() => {
-    void trigger(DESCRIPTION_FIELD_NAME); // empty desc will trigger error message
+    if (!descriptionValue || `${descriptionValue}`.trim().length === 0) {
+      void trigger(DESCRIPTION_FIELD_NAME);
+    }
   }, [descriptionValue, trigger]);
 
   return (

--- a/front/components/agent_builder/capabilities/shared/DescriptionSection.tsx
+++ b/front/components/agent_builder/capabilities/shared/DescriptionSection.tsx
@@ -26,7 +26,7 @@ export function DescriptionSection({
   const descriptionValue = useWatch({ name: DESCRIPTION_FIELD_NAME });
   const { trigger } = useFormContext();
 
-  // force the validation on empty field so it is validated initially
+  // Force the validation on empty field so it is validated initially.
   useEffect(() => {
     if (!descriptionValue || `${descriptionValue}`.trim().length === 0) {
       void trigger(DESCRIPTION_FIELD_NAME);

--- a/front/components/agent_builder/capabilities/shared/DescriptionSection.tsx
+++ b/front/components/agent_builder/capabilities/shared/DescriptionSection.tsx
@@ -1,4 +1,6 @@
 import { TextArea } from "@dust-tt/sparkle";
+import { useEffect } from "react";
+import { useFormContext, useWatch } from "react-hook-form";
 
 import { BaseFormFieldSection } from "@app/components/agent_builder/capabilities/shared/BaseFormFieldSection";
 
@@ -21,6 +23,13 @@ export function DescriptionSection({
   maxLength,
   triggerValidationOnChange = false,
 }: DescriptionSectionProps) {
+  const descriptionValue = useWatch({ name: DESCRIPTION_FIELD_NAME });
+  const { trigger } = useFormContext();
+
+  useEffect(() => {
+    void trigger(DESCRIPTION_FIELD_NAME); // empty desc will trigger error message
+  }, [descriptionValue, trigger]);
+
   return (
     <BaseFormFieldSection
       title={title}

--- a/front/components/agent_builder/capabilities/shared/NameSection.tsx
+++ b/front/components/agent_builder/capabilities/shared/NameSection.tsx
@@ -1,5 +1,6 @@
 import { Input } from "@dust-tt/sparkle";
-import { forwardRef } from "react";
+import { forwardRef, useEffect } from "react";
+import { useFormContext, useWatch } from "react-hook-form";
 
 import { BaseFormFieldSection } from "@app/components/agent_builder/capabilities/shared/BaseFormFieldSection";
 
@@ -26,6 +27,13 @@ export const NameSection = forwardRef<HTMLInputElement, NameSectionProps>(
     },
     ref
   ) => {
+    const nameValue = useWatch({ name: NAME_FIELD_NAME });
+    const { trigger } = useFormContext();
+
+    useEffect(() => {
+      void trigger(NAME_FIELD_NAME); // empty name will trigger error message
+    }, [nameValue, trigger]);
+
     return (
       <BaseFormFieldSection
         title={title}

--- a/front/components/agent_builder/capabilities/shared/NameSection.tsx
+++ b/front/components/agent_builder/capabilities/shared/NameSection.tsx
@@ -1,6 +1,5 @@
 import { Input } from "@dust-tt/sparkle";
-import { forwardRef, useEffect } from "react";
-import { useFormContext, useWatch } from "react-hook-form";
+import { forwardRef } from "react";
 
 import { BaseFormFieldSection } from "@app/components/agent_builder/capabilities/shared/BaseFormFieldSection";
 
@@ -27,13 +26,6 @@ export const NameSection = forwardRef<HTMLInputElement, NameSectionProps>(
     },
     ref
   ) => {
-    const nameValue = useWatch({ name: NAME_FIELD_NAME });
-    const { trigger } = useFormContext();
-
-    useEffect(() => {
-      void trigger(NAME_FIELD_NAME); // empty name will trigger error message
-    }, [nameValue, trigger]);
-
     return (
       <BaseFormFieldSection
         title={title}


### PR DESCRIPTION
## Description

I'm triggering the validation of the field on change to display the error message if it is empty.
Let me know if there is a more elegant way to do it.

closes [#4265](https://github.com/dust-tt/tasks/issues/4265)

<img width="500" height="580" alt="image" src="https://github.com/user-attachments/assets/baa45af2-4d96-4d54-975a-914498aefd0d" />

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->


## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
