### PR TITLE
changed conversation hint text to be clearer

### DIFF
--- a/extension/ui/components/input_bar/editor/useCustomEditor.tsx
+++ b/extension/ui/components/input_bar/editor/useCustomEditor.tsx
@@ -268,7 +268,7 @@ const useCustomEditor = ({
       suggestion: suggestionHandler,
     }),
     Placeholder.configure({
-      placeholder: "Ask a question or get some @help",
+      placeholder: "Ask an @agent a question, or get some @help",
       emptyNodeClass:
         "first:before:text-gray-400 first:before:float-left first:before:content-[attr(data-placeholder)] first:before:pointer-events-none first:before:h-0",
     }),

--- a/front/components/assistant/conversation/input_bar/editor/useCustomEditor.tsx
+++ b/front/components/assistant/conversation/input_bar/editor/useCustomEditor.tsx
@@ -239,7 +239,7 @@ const useCustomEditor = ({
       suggestion: suggestionHandler,
     }),
     Placeholder.configure({
-      placeholder: "Ask a question or get some @help",
+      placeholder: "Ask an @agent a question, or get some @help",
       emptyNodeClass:
         "first:before:text-gray-400 first:before:float-left first:before:content-[attr(data-placeholder)] first:before:pointer-events-none first:before:h-0",
     }),


### PR DESCRIPTION
## Description
(see: https://github.com/dust-tt/tasks/issues/4355)
Current text is unclear on how to call agents, making the text be clear you need to use @ to call them:

```
Ask a question or get some @help
```

Becomes:

```
Ask an @agent a question, or get some @help
```

## Tests

Just inspected visually.

## Risk

None.

## Deploy Plan

Deploy front.
