### PR TITLE
Record Plugin run when upgrading/downgrading a workspace in poké

### DIFF
--- a/front/lib/api/poke/plugin_manager.ts
+++ b/front/lib/api/poke/plugin_manager.ts
@@ -48,6 +48,14 @@ class PluginManager {
   getPluginById(pluginId: string): AllPlugins | undefined {
     return this.plugins.get(pluginId);
   }
+
+  getNonNullablePlugin(pluginId: string): AllPlugins {
+    const plugin = this.getPluginById(pluginId);
+    if (!plugin) {
+      throw new Error(`Plugin ${pluginId} not found`);
+    }
+    return plugin;
+  }
 }
 
 export const pluginManager = new PluginManager();

--- a/front/lib/api/poke/plugins/workspaces/index.ts
+++ b/front/lib/api/poke/plugins/workspaces/index.ts
@@ -18,5 +18,6 @@ export * from "./restore_conversation";
 export * from "./revoke_users";
 export * from "./set_public_api_limits";
 export * from "./toggle_feature_flag";
+export * from "./upgrade_downgrade";
 export * from "./upgrade_to_business_plan";
 export * from "./user_identity_merge";

--- a/front/lib/api/poke/plugins/workspaces/upgrade_downgrade.ts
+++ b/front/lib/api/poke/plugins/workspaces/upgrade_downgrade.ts
@@ -1,0 +1,77 @@
+import { createPlugin } from "@app/lib/api/poke/types";
+import { Err } from "@app/types";
+
+// The following plugins are no-op plugins for the upgrade and downgrade endpoints.
+// They are used to save a plugin record in the database for the upgrade and downgrade endpoints.
+
+export const upgradeEnterprisePlan = createPlugin({
+  manifest: {
+    id: "upgrade-enterprise-plan",
+    name: "Upgrade Enterprise Plan",
+    description: "Upgrade enterprise plan",
+    resourceTypes: ["workspaces"],
+    isHidden: true,
+    args: {
+      planCode: {
+        type: "text",
+        label: "Plan Code",
+        description: "The plan code to upgrade to",
+        placeholder: "e.g., FREE_UPGRADED_PLAN",
+        required: true,
+      },
+      stripeSubscriptionId: {
+        type: "text",
+        label: "Stripe Subscription ID",
+        description: "The stripe subscription id to upgrade to",
+        placeholder: "e.g., sub_1234567890",
+        required: true,
+      },
+    },
+  },
+  execute: async () => {
+    return new Err(new Error("NO_OP"));
+  },
+});
+
+export const upgradeFreePlan = createPlugin({
+  manifest: {
+    id: "upgrade-free-plan",
+    name: "Upgrade Free Plan",
+    description: "Upgrade free plan",
+    resourceTypes: ["workspaces"],
+    isHidden: true,
+    args: {
+      planCode: {
+        type: "text",
+        label: "Plan Code",
+        description: "The plan code to upgrade to",
+        placeholder: "e.g., FREE_UPGRADED_PLAN",
+        required: true,
+      },
+      endDate: {
+        type: "text",
+        label: "End Date",
+        description: "Optional end date for the upgrade",
+        placeholder: "YYYY-MM-DD",
+        required: false,
+      },
+    },
+  },
+  execute: async () => {
+    return new Err(new Error("NO_OP"));
+  },
+});
+
+export const downgradeNoPlan = createPlugin({
+  manifest: {
+    id: "downgrade-no-plan",
+    name: "Downgrade No Plan",
+    description: "Downgrade no plan",
+    resourceTypes: ["workspaces"],
+    isHidden: true,
+    args: {},
+  },
+  execute: async () => {
+    return new Err(new Error("NO_OP"));
+  },
+});

--- a/front/pages/api/poke/plugins/index.ts
+++ b/front/pages/api/poke/plugins/index.ts
@@ -81,6 +81,7 @@ async function handler(
 
       const pluginList = plugins
         .filter((p) => !resourceId || p.isApplicableTo(auth, resource))
+        .filter((p) => !p.manifest.isHidden)
         .map((p) => ({
           id: p.manifest.id,
           name: p.manifest.name,

--- a/front/pages/api/poke/workspaces/[wId]/upgrade.ts
+++ b/front/pages/api/poke/workspaces/[wId]/upgrade.ts
@@ -3,8 +3,10 @@ import * as reporter from "io-ts-reporters";
 import type { NextApiRequest, NextApiResponse } from "next";
 
 import { withSessionAuthenticationForPoke } from "@app/lib/api/auth_wrappers";
+import { pluginManager } from "@app/lib/api/poke/plugin_manager";
 import { Authenticator } from "@app/lib/auth";
 import type { SessionWithUser } from "@app/lib/iam/provider";
+import { PluginRunResource } from "@app/lib/resources/plugin_run_resource";
 import { SubscriptionResource } from "@app/lib/resources/subscription_resource";
 import { renderLightWorkspaceType } from "@app/lib/workspace";
 import { apiError } from "@app/logger/withlogging";
@@ -38,14 +40,28 @@ async function handler(
 
   switch (req.method) {
     case "POST":
+      const plugin = pluginManager.getNonNullablePlugin("upgrade-free-plan");
+      const pluginRun = await PluginRunResource.makeNew(
+        plugin,
+        req.body,
+        auth.getNonNullableUser(),
+        owner,
+        {
+          resourceId: owner.sId,
+          resourceType: "workspaces",
+        }
+      );
+
       const bodyValidation = FreePlanUpgradeFormSchema.decode(req.body);
       if (isLeft(bodyValidation)) {
         const pathError = reporter.formatValidationErrors(bodyValidation.left);
+        const errorMessage = `The request body is invalid: ${pathError}`;
+        await pluginRun.recordError(errorMessage);
         return apiError(req, res, {
           status_code: 400,
           api_error: {
             type: "invalid_request_error",
-            message: `The request body is invalid: ${pathError}`,
+            message: errorMessage,
           },
         });
       }
@@ -53,10 +69,27 @@ async function handler(
       const planCode = body.planCode;
       const endDate = body.endDate;
 
+      if (endDate && new Date(endDate) < new Date()) {
+        const errorMessage = "The end date is in the past.";
+        await pluginRun.recordError(errorMessage);
+        return apiError(req, res, {
+          status_code: 400,
+          api_error: {
+            type: "invalid_request_error",
+            message: "The end date is in the past.",
+          },
+        });
+      }
+
       await SubscriptionResource.pokeUpgradeWorkspaceToPlan({
         auth,
         planCode,
         endDate: endDate ? new Date(endDate) : null,
+      });
+
+      await pluginRun.recordResult({
+        display: "text",
+        value: `Workspace ${owner.name} upgraded to plan ${planCode}.`,
       });
 
       return res.status(200).json({

--- a/front/types/poke/plugins.ts
+++ b/front/types/poke/plugins.ts
@@ -106,6 +106,7 @@ export interface PluginManifest<
   name: string;
   resourceTypes: R[];
   warning?: string;
+  isHidden?: boolean;
 }
 
 interface PluginResourceScope {


### PR DESCRIPTION
## Description

Goal of this PR is to record as plugin runs the executions of poké actions to upgrade / downgrade a workspace; so that we get context on who did it when we have to debug something. 

I did not want to make those actions real plugins because I think it would degrade the XP, so I had to hack the plugin run system by adding fake hidden plugins. 

## Tests

Locally. 

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

Deploy front. 