### PR TITLE
[connectors] Add support for whitelisting large GitHub repositories

### DIFF
--- a/connectors/src/connectors/github/lib/github_code.ts
+++ b/connectors/src/connectors/github/lib/github_code.ts
@@ -7,8 +7,12 @@ import {
   RepositoryNotFoundError,
 } from "@connectors/connectors/github/lib/errors";
 import logger from "@connectors/logger/logger";
+import type { ConnectorResource } from "@connectors/resources/connector_resource";
+import { fileSizeToHumanReadable } from "@connectors/types";
 
 const REPO_SIZE_LIMIT = 10 * 1024 * 1024; // 10GB in KB
+
+const CONNECTORS_WHITELISTED_FOR_LARGE_REPOS = [50];
 
 export type RepositoryInfo = Pick<
   Awaited<ReturnType<Octokit["rest"]["repos"]["get"]>>["data"],
@@ -48,19 +52,22 @@ export async function getRepoInfo(
   }
 }
 
-export function isRepoTooLarge(repoInfo: RepositoryInfo): boolean {
+export function isRepoTooLarge(
+  repoInfo: RepositoryInfo,
+  connector: ConnectorResource
+): boolean {
   // `data.size` is the whole repo size in KB, we use it to filter repos > 10GB download size. There
   // is further filtering by file type + for "extracted size" per file to 3MB.
   if (repoInfo.size > REPO_SIZE_LIMIT) {
-    // For now we throw a panic log, so we are able to report the issue to the
-    // user, and continue with the rest of the sync. See runbook for future
-    // improvements
+    // We throw a panic log and skip to keep track of the very large repositories and report to the user.
+    // The rest of the sync is not affected. Please check out the runbook:
     // https://www.notion.so/dust-tt/Panic-Log-Github-repository-too-large-to-sync-1bf28599d9418061a396d2378bdd77de?pvs=4
 
-    // Later on, we might want to build capabilities to handle this (likely a
-    // typed error to return a syncFailed to the user, when we are able to
-    // display granular failure, or increase this limit if we want some largers
-    // repositories).
+    // Some connectors are whitelisted to sync large repositories.
+    // This is on a connectorId basis to avoid leaking repository names.
+    if (CONNECTORS_WHITELISTED_FOR_LARGE_REPOS.includes(connector.id)) {
+      return false;
+    }
 
     logger.error(
       {
@@ -69,7 +76,7 @@ export function isRepoTooLarge(repoInfo: RepositoryInfo): boolean {
         size: repoInfo.size,
         panic: true,
       },
-      `Github Repository is too large to sync (size: ${repoInfo.size}KB, max: 10GB)`
+      `GitHub repository too large to sync (size: ${fileSizeToHumanReadable(repoInfo.size * 1024)}, max: 10 GB).`
     );
 
     return true;

--- a/connectors/src/connectors/github/temporal/activities/sync_code.ts
+++ b/connectors/src/connectors/github/temporal/activities/sync_code.ts
@@ -114,7 +114,7 @@ export async function githubExtractToGcsActivity({
   const repoInfo = repoInfoRes.value;
 
   // If repo is too large, simply return null, to be handled by the caller.
-  if (isRepoTooLarge(repoInfo)) {
+  if (isRepoTooLarge(repoInfo, connector)) {
     return null;
   }
 

--- a/connectors/src/types/shared/utils/string_utils.ts
+++ b/connectors/src/types/shared/utils/string_utils.ts
@@ -77,3 +77,19 @@ export function safeParseJSON(str: string): Result<object | null, Error> {
 export function stripNullBytes(text: string): string {
   return text.replace(/\0/g, "");
 }
+
+export function fileSizeToHumanReadable(size: number, decimals = 0) {
+  if (size < 1024) {
+    return `${size.toFixed(decimals)} B`;
+  }
+
+  if (size < 1024 * 1024) {
+    return `${(size / 1024).toFixed(decimals)} KB`;
+  }
+
+  if (size < 1024 * 1024 * 1024) {
+    return `${(size / (1024 * 1024)).toFixed(decimals)} MB`;
+  }
+
+  return `${(size / (1024 * 1024 * 1024)).toFixed(decimals)} GB`;
+}

--- a/connectors/src/types/shared/utils/string_utils.ts
+++ b/connectors/src/types/shared/utils/string_utils.ts
@@ -78,7 +78,10 @@ export function stripNullBytes(text: string): string {
   return text.replace(/\0/g, "");
 }
 
-export function fileSizeToHumanReadable(size: number, decimals: number = 0) {
+export function fileSizeToHumanReadable(
+  size: number,
+  decimals: number = 0
+): string {
   if (size < 1024) {
     return `${size.toFixed(decimals)} B`;
   }

--- a/connectors/src/types/shared/utils/string_utils.ts
+++ b/connectors/src/types/shared/utils/string_utils.ts
@@ -78,7 +78,7 @@ export function stripNullBytes(text: string): string {
   return text.replace(/\0/g, "");
 }
 
-export function fileSizeToHumanReadable(size: number, decimals = 0) {
+export function fileSizeToHumanReadable(size: number, decimals: number = 0) {
   if (size < 1024) {
     return `${size.toFixed(decimals)} B`;
   }


### PR DESCRIPTION
## Description

- Following up on this [thread](https://dust4ai.slack.com/archives/C05F84CFP0E/p1758620392141619).
- The limit we had on large repositories was lifted on the technical level by https://github.com/dust-tt/dust/pull/14126.
- This PR adds a way to whitelist certain connectors; we'll still keep track of the large repos we are syncing (requires a dev action + confirmation from the user). The rationale is that we have seen in the past extremely large repositories that we did not need to sync (10 GB is a lot, there can be a specific reason as to why a repo is this big, e.g. there's a certain type of file in it).
- See runbook https://www.notion.so/dust-tt/Panic-Log-Github-repository-too-large-to-sync-1bf28599d9418061a396d2378bdd77de.

## Tests

## Risk

- Low.

## Deploy Plan

- Deploy connectors.
