### PR TITLE
[sparkle] - feat(Sheet): add keyboard shortcut for saving

### DIFF
--- a/sparkle/src/components/MultiPageSheet.tsx
+++ b/sparkle/src/components/MultiPageSheet.tsx
@@ -84,7 +84,7 @@ const MultiPageSheetFooter = ({
         <div>{leftButton && <Button {...leftButton} />}</div>
         <div className="s-flex s-gap-2">
           {centerButton && <Button {...centerButton} />}
-          {rightButton && <Button {...rightButton} />}
+          {rightButton && <Button data-sheet-save="true" {...rightButton} />}
         </div>
       </div>
     </div>

--- a/sparkle/src/components/Sheet.tsx
+++ b/sparkle/src/components/Sheet.tsx
@@ -130,6 +130,22 @@ const SheetContent = React.forwardRef<
       [preventAutoFocusOnOpen, onOpenAutoFocus]
     );
 
+    const onKeyDownCapture = React.useCallback(
+      (e: React.KeyboardEvent<HTMLDivElement>) => {
+        if ((e.metaKey || e.ctrlKey) && e.key === "Enter") {
+          const root = e.currentTarget as HTMLElement;
+          const target = root.querySelector<HTMLButtonElement>(
+            '[data-sheet-save="true"]:not(:disabled)'
+          );
+          if (target) {
+            e.preventDefault();
+            target.click();
+          }
+        }
+      },
+      []
+    );
+
     return (
       <SheetPortal>
         <SheetOverlay />
@@ -143,6 +159,7 @@ const SheetContent = React.forwardRef<
             )}
             onCloseAutoFocus={handleCloseAutoFocus}
             onOpenAutoFocus={handleOpenAutoFocus}
+            onKeyDownCapture={onKeyDownCapture}
             {...props}
           >
             {children}
@@ -233,45 +250,47 @@ const SheetFooter = ({
   rightEndButtonProps,
   sheetCloseClassName,
   ...props
-}: SheetFooterProps) => (
-  <div
-    className={cn(
-      "s-flex s-flex-none s-flex-col s-gap-2",
-      "s-border-border dark:s-border-border-night",
-      className
-    )}
-    {...props}
-  >
-    {children}
-    <div className="s-flex s-flex-row s-gap-2 s-border-t s-border-border s-px-3 s-py-3 dark:s-border-border-night">
-      {leftButtonProps &&
-        (leftButtonProps.disabled ? (
-          <Button {...leftButtonProps} />
-        ) : (
-          <SheetClose className={sheetCloseClassName} asChild>
+}: SheetFooterProps) => {
+  return (
+    <div
+      className={cn(
+        "s-flex s-flex-none s-flex-col s-gap-2",
+        "s-border-border dark:s-border-border-night",
+        className
+      )}
+      {...props}
+    >
+      {children}
+      <div className="s-flex s-flex-row s-gap-2 s-border-t s-border-border s-px-3 s-py-3 dark:s-border-border-night">
+        {leftButtonProps &&
+          (leftButtonProps.disabled ? (
             <Button {...leftButtonProps} />
-          </SheetClose>
-        ))}
-      <div className="s-flex-grow" />
-      {rightButtonProps &&
-        (rightButtonProps.disabled ? (
-          <Button {...rightButtonProps} />
-        ) : (
-          <SheetClose className={sheetCloseClassName} asChild>
-            <Button {...rightButtonProps} />
-          </SheetClose>
-        ))}
-      {rightEndButtonProps &&
-        (rightEndButtonProps.disabled ? (
-          <Button {...rightEndButtonProps} />
-        ) : (
-          <SheetClose className={sheetCloseClassName} asChild>
+          ) : (
+            <SheetClose className={sheetCloseClassName} asChild>
+              <Button {...leftButtonProps} />
+            </SheetClose>
+          ))}
+        <div className="s-flex-grow" />
+        {rightButtonProps &&
+          (rightButtonProps.disabled ? (
+            <Button data-sheet-save="true" {...rightButtonProps} />
+          ) : (
+            <SheetClose className={sheetCloseClassName} asChild>
+              <Button data-sheet-save="true" {...rightButtonProps} />
+            </SheetClose>
+          ))}
+        {rightEndButtonProps &&
+          (rightEndButtonProps.disabled ? (
             <Button {...rightEndButtonProps} />
-          </SheetClose>
-        ))}
+          ) : (
+            <SheetClose className={sheetCloseClassName} asChild>
+              <Button {...rightEndButtonProps} />
+            </SheetClose>
+          ))}
+      </div>
     </div>
-  </div>
-);
+  );
+};
 SheetFooter.displayName = "SheetFooter";
 
 interface SheetTitleProps

--- a/sparkle/src/stories/Sheet.stories.tsx
+++ b/sparkle/src/stories/Sheet.stories.tsx
@@ -50,8 +50,10 @@ export function Demo() {
 }
 
 export function SheetDemo() {
+  const [saveCount, setSaveCount] = React.useState(0);
+
   return (
-    <div>
+    <div className="s-flex s-items-center s-gap-3">
       <Sheet>
         <SheetTrigger asChild>
           <Button variant="outline" label="Edit demo" />
@@ -64,15 +66,25 @@ export function SheetDemo() {
             <div className="s-flex s-flex-col s-gap-6">
               <Input label="Firstname" placeholder="John" />
               <Input label="Lastname" placeholder="Doe" />
+              <div className="s-text-xs s-text-muted-foreground dark:s-text-muted-foreground-night">
+                Tip: Press Cmd/Ctrl + Enter to Save
+              </div>
             </div>
           </SheetContainer>
           <SheetFooter
             sheetCloseClassName="s-flex s-gap-2"
             leftButtonProps={{ label: "Cancel", variant: "warning" }}
-            rightButtonProps={{ label: "Save", disabled: true }}
+            rightButtonProps={{
+              label: "Save",
+              variant: "primary",
+              onClick: () => setSaveCount((c) => c + 1),
+            }}
           />
         </SheetContent>
       </Sheet>
+      <span className="s-text-xs s-text-muted-foreground dark:s-text-muted-foreground-night">
+        Saved: {saveCount}
+      </span>
     </div>
   );
 }


### PR DESCRIPTION
## Description

This PR adds keyboard shortcut support for saving in `Sheet` components. Users can now press `Cmd/Ctrl + Enter` to trigger the save action. 

The implementation adds a `data-sheet-save` attribute to save buttons and implements a keydown event handler in `SheetContent` that looks for this attribute to trigger the save action.

## Tests

Storybook

## Risk

Low

## Deploy Plan

Publish sparkle
