### PR TITLE
[RunAgent] Bubble error causes to model; stop alerting datadog on invalid requests

### DIFF
--- a/front/lib/actions/mcp_errors.ts
+++ b/front/lib/actions/mcp_errors.ts
@@ -1,3 +1,5 @@
+import { APIError } from "@dust-tt/client";
+
 export class MCPServerNotFoundError extends Error {
   constructor(message: string) {
     super(message);
@@ -15,7 +17,7 @@ export class MCPError extends Error {
       tracked = true,
       code,
       cause,
-    }: { tracked?: boolean; code?: number; cause?: unknown } = {}
+    }: { tracked?: boolean; code?: number; cause?: Error | APIError } = {}
   ) {
     super(message, { cause });
     this.tracked = tracked;

--- a/front/lib/actions/mcp_errors.ts
+++ b/front/lib/actions/mcp_errors.ts
@@ -11,9 +11,13 @@ export class MCPError extends Error {
 
   constructor(
     message: string,
-    { tracked = true, code }: { tracked?: boolean; code?: number } = {}
+    {
+      tracked = true,
+      code,
+      cause,
+    }: { tracked?: boolean; code?: number; cause?: unknown } = {}
   ) {
-    super(message);
+    super(message, { cause });
     this.tracked = tracked;
     this.code = code;
   }

--- a/front/lib/actions/mcp_errors.ts
+++ b/front/lib/actions/mcp_errors.ts
@@ -1,4 +1,4 @@
-import { APIError } from "@dust-tt/client";
+import type { APIError } from "@app/types";
 
 export class MCPServerNotFoundError extends Error {
   constructor(message: string) {

--- a/front/lib/actions/mcp_internal_actions/servers/deep_research.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/deep_research.ts
@@ -73,7 +73,7 @@ const createServer = (
         });
 
         if (convRes.isErr()) {
-          return new Err(new MCPError(convRes.error.message));
+          return new Err(convRes.error);
         }
 
         const response = makeMCPToolExit({

--- a/front/lib/actions/mcp_internal_actions/servers/run_agent/conversation.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/run_agent/conversation.ts
@@ -4,6 +4,7 @@ import type {
   PublicPostContentFragmentRequestBody,
 } from "@dust-tt/client";
 
+import { MCPError } from "@app/lib/actions/mcp_errors";
 import type { ChildAgentBlob } from "@app/lib/actions/mcp_internal_actions/servers/run_agent/types";
 import { isRunAgentResumeState } from "@app/lib/actions/mcp_internal_actions/servers/run_agent/types";
 import type { AgentLoopRunContextType } from "@app/lib/actions/types";
@@ -19,7 +20,6 @@ import type {
   Result,
 } from "@app/types";
 import { Err, Ok } from "@app/types";
-import { MCPError } from "@app/lib/actions/mcp_errors";
 
 export async function getOrCreateConversation(
   api: DustAPI,

--- a/front/lib/actions/mcp_internal_actions/servers/run_agent/conversation.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/run_agent/conversation.ts
@@ -63,12 +63,16 @@ export async function getOrCreateConversation(
 
     if (convRes.isErr()) {
       // Do not track invalid request errors, since they are user-side and should
-      // not trigger an alert on our end.
-      const tracked = convRes.error.type !== "invalid_request_error";
+      // not trigger an alert on our end. For user-side errors, surface the
+      // underlying message to the model.
+      const isUserSide = convRes.error.type === "invalid_request_error";
+      const message = isUserSide
+        ? convRes.error.message
+        : "Failed to get conversation";
       return new Err(
-        new MCPError("Failed to get conversation", {
+        new MCPError(message, {
           cause: convRes.error,
-          tracked,
+          tracked: !isUserSide,
         })
       );
     }
@@ -136,12 +140,16 @@ export async function getOrCreateConversation(
 
     if (messageRes.isErr()) {
       // Do not track invalid request errors, since they are user-side and should
-      // not trigger an alert on our end.
-      const tracked = messageRes.error.type !== "invalid_request_error";
+      // not trigger an alert on our end. For user-side errors, surface the
+      // underlying message to the model.
+      const isUserSide = messageRes.error.type === "invalid_request_error";
+      const message = isUserSide
+        ? messageRes.error.message
+        : "Failed to create message";
       return new Err(
-        new MCPError("Failed to create message", {
+        new MCPError(message, {
           cause: messageRes.error,
-          tracked,
+          tracked: !isUserSide,
         })
       );
     }
@@ -152,12 +160,16 @@ export async function getOrCreateConversation(
 
     if (convRes.isErr()) {
       // Do not track invalid request errors, since they are user-side and should
-      // not trigger an alert on our end.
-      const tracked = convRes.error.type !== "invalid_request_error";
+      // not trigger an alert on our end. For user-side errors, surface the
+      // underlying message to the model.
+      const isUserSide = convRes.error.type === "invalid_request_error";
+      const message = isUserSide
+        ? convRes.error.message
+        : "Failed to get conversation";
       return new Err(
-        new MCPError("Failed to get conversation", {
+        new MCPError(message, {
           cause: convRes.error,
-          tracked,
+          tracked: !isUserSide,
         })
       );
     }
@@ -205,13 +217,16 @@ export async function getOrCreateConversation(
     );
 
     // Do not track invalid request errors, since they are user-side and should
-    // not trigger an alert on our end.
-    const tracked = convRes.error.type !== "invalid_request_error";
-
+    // not trigger an alert on our end. For user-side errors, surface the
+    // underlying message to the model.
+    const isUserSide = convRes.error.type === "invalid_request_error";
+    const message = isUserSide
+      ? convRes.error.message
+      : "Failed to create conversation";
     return new Err(
-      new MCPError("Failed to create conversation", {
+      new MCPError(message, {
         cause: convRes.error,
-        tracked,
+        tracked: !isUserSide,
       })
     );
   }

--- a/front/lib/actions/mcp_internal_actions/servers/run_agent/index.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/run_agent/index.ts
@@ -360,7 +360,7 @@ ${query}`
         );
 
         if (convRes.isErr()) {
-          return new Err(new MCPError(convRes.error.message));
+          return new Err(convRes.error);
         }
 
         if (isHandoff) {

--- a/front/lib/actions/mcp_internal_actions/wrappers.ts
+++ b/front/lib/actions/mcp_internal_actions/wrappers.ts
@@ -10,7 +10,8 @@ import type { AgentLoopContextType } from "@app/lib/actions/types";
 import type { Authenticator } from "@app/lib/auth";
 import logger from "@app/logger/logger";
 import { statsDClient } from "@app/logger/statsDClient";
-import { errorToString, type Result } from "@app/types";
+import type { Result } from "@app/types";
+import { errorToString } from "@app/types";
 
 /**
  * Wraps a tool callback with logging and monitoring.

--- a/front/lib/actions/mcp_internal_actions/wrappers.ts
+++ b/front/lib/actions/mcp_internal_actions/wrappers.ts
@@ -10,7 +10,7 @@ import type { AgentLoopContextType } from "@app/lib/actions/types";
 import type { Authenticator } from "@app/lib/auth";
 import logger from "@app/logger/logger";
 import { statsDClient } from "@app/logger/statsDClient";
-import type { Result } from "@app/types";
+import { errorToString, type Result } from "@app/types";
 
 /**
  * Wraps a tool callback with logging and monitoring.
@@ -106,7 +106,7 @@ export function withToolLogging<T>(
         content: [
           {
             type: "text",
-            text: result.error.message,
+            text: errorToString(result.error),
           },
         ],
       };

--- a/sdks/js/src/error_utils.ts
+++ b/sdks/js/src/error_utils.ts
@@ -1,7 +1,7 @@
 export function errorToString(error: unknown): string {
   if (error instanceof Error) {
     const cause = "cause" in error ? errorToString(error.cause) : null;
-    return `${error.message} ${cause ? `\n- Cause: ${cause}` : ""}`;
+    return `${error.message}${cause ? `\n- Cause: ${cause}` : ""}`;
   } else if (typeof error === "string") {
     return error;
   }

--- a/sdks/js/src/error_utils.ts
+++ b/sdks/js/src/error_utils.ts
@@ -1,6 +1,7 @@
 export function errorToString(error: unknown): string {
   if (error instanceof Error) {
-    return error.message;
+    const cause = "cause" in error ? errorToString(error.cause) : null;
+    return `${error.message} ${cause ? `\n- Cause: ${cause}` : ""}`;
   } else if (typeof error === "string") {
     return error;
   }


### PR DESCRIPTION
## Description
Fixes erroneous "Tool execution errors" alerts
- Surface access/permission errors from runagent to the model so the user sees actionable feedback (use MCPError and errorToString).
- Treat invalid_request_error as user-side and untracked, preventing monitors/alerts on our side.
- Pass through MCPError instead of rewrapping (deep_research and run_agent servers) to preserve semantics.
- Add cause support to MCPError to thread context cleanly.

<img width="1281" height="240" alt="image" src="https://github.com/user-attachments/assets/2a06dc2e-6f69-47fd-a733-f70da7631a96" />


## Risks
Blast radius: MCP internal actions (run_agent, deep_research), tool wrapper error messaging, shared error utils (front)
Risk: low

## Deploy Plan
- Deploy front (no migrations)
