### PR TITLE
[front] - chore(InputBar): truncate agent name

### DIFF
--- a/extension/ui/components/input_bar/editor/MentionDropdown.tsx
+++ b/extension/ui/components/input_bar/editor/MentionDropdown.tsx
@@ -1,12 +1,12 @@
 import type { EditorSuggestion } from "@app/ui/components/input_bar/editor/suggestion";
 import {
   Avatar,
+  cn,
   DropdownMenu,
   DropdownMenuContent,
   DropdownMenuTrigger,
+  Spinner,
 } from "@dust-tt/sparkle";
-import { Spinner } from "@dust-tt/sparkle";
-import { cn } from "@dust-tt/sparkle";
 import React, { useCallback, useEffect, useRef, useState } from "react";
 
 interface MentionDropdownProps {
@@ -93,7 +93,9 @@ export const MentionDropdown = ({
                   onMouseEnter={() => onSelectedIndexChange(index)}
                 >
                   <Avatar size="xs" visual={suggestion.pictureUrl} />
-                  {suggestion.label}
+                  <span className="truncate" title={suggestion.label}>
+                    {suggestion.label}
+                  </span>
                 </button>
               </div>
             ))}

--- a/front/components/assistant/conversation/input_bar/editor/MentionDropdown.tsx
+++ b/front/components/assistant/conversation/input_bar/editor/MentionDropdown.tsx
@@ -3,8 +3,8 @@ import {
   DropdownMenu,
   DropdownMenuContent,
   DropdownMenuTrigger,
+  Spinner,
 } from "@dust-tt/sparkle";
-import { Spinner } from "@dust-tt/sparkle";
 import React, { useCallback, useEffect, useRef, useState } from "react";
 
 import type { EditorSuggestion } from "@app/components/assistant/conversation/input_bar/editor/suggestion";
@@ -105,7 +105,9 @@ export const MentionDropdown = ({
                   }}
                 >
                   <Avatar size="xs" visual={suggestion.pictureUrl} />
-                  {suggestion.label}
+                  <span className="truncate" title={suggestion.label}>
+                    {suggestion.label}
+                  </span>
                 </button>
               </div>
             ))}


### PR DESCRIPTION
## Description

This PR improves UI for mention labels in the dropdown to handle overflow with truncation and tooltip for longer labels

**References:**
- https://github.com/dust-tt/tasks/issues/4291

## Tests

Locally

## Risk

Low

## Deploy Plan

Deploy front
