### PR TITLE
Focus on search bar in Manage agents page

### DIFF
--- a/front/pages/w/[wId]/builder/agents/index.tsx
+++ b/front/pages/w/[wId]/builder/agents/index.tsx
@@ -279,6 +279,13 @@ export default function WorkspaceAssistants({
   const searchBarRef = useRef<HTMLInputElement>(null);
 
   useEffect(() => {
+    if (searchBarRef.current) {
+      searchBarRef.current.focus();
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [searchBarRef.current]);
+
+  useEffect(() => {
     const handleKeyPress = (event: KeyboardEvent) => {
       if (event.key === "/") {
         event.preventDefault();


### PR DESCRIPTION
## Description

Fixes https://github.com/dust-tt/tasks/issues/4308

I tried to do the clean thing which would be add an autoFocus option to the SearchInput component but looking in Sparkle I realized that we have some autofocus logic on DropdownMenuSearchbar that calls SearchInput and I did not want to handle a big refacto so I'm going with the easy option. 


I had to had the `searchBarRef.current` as dependency, otherwise on first render `searchBarRef.current` is null and there is no auto focus. 

## Tests

Locally. 

## Risk

Can be rolled back. 

## Deploy Plan

Deploy front. 