### PR TITLE
Add: request throttler for slack chat.update

### DIFF
--- a/connectors/src/connectors/slack/bot.ts
+++ b/connectors/src/connectors/slack/bot.ts
@@ -51,6 +51,7 @@ import {
   isBotAllowed,
   notifyIfSlackUserIsNotAllowed,
 } from "@connectors/connectors/slack/lib/workspace_limits";
+import { RATE_LIMITS } from "@connectors/connectors/slack/ratelimits";
 import { apiConfig } from "@connectors/lib/api/config";
 import { dataSourceConfigFromConnector } from "@connectors/lib/api/data_source_config";
 import type { CoreAPIDataSourceDocumentSection } from "@connectors/lib/data_sources";
@@ -450,7 +451,7 @@ async function processErrorResult(
       const mainMessageTs = mainMessage.ts;
 
       await throttleWithRedis(
-        50,
+        RATE_LIMITS["chat.update"],
         `${connector.id}-chat-update`,
         false,
         async () =>

--- a/connectors/src/connectors/slack/chat/stream_conversation_handler.ts
+++ b/connectors/src/connectors/slack/chat/stream_conversation_handler.ts
@@ -27,6 +27,7 @@ import {
 import { annotateCitations } from "@connectors/connectors/slack/chat/citations";
 import { makeConversationUrl } from "@connectors/connectors/slack/chat/utils";
 import type { SlackUserInfo } from "@connectors/connectors/slack/lib/slack_client";
+import { RATE_LIMITS } from "@connectors/connectors/slack/ratelimits";
 import { apiConfig } from "@connectors/lib/api/config";
 import { dataSourceConfigFromConnector } from "@connectors/lib/api/data_source_config";
 import type { SlackChatBotMessage } from "@connectors/lib/models/slack";
@@ -433,7 +434,7 @@ async function postSlackMessageUpdate({
   );
 
   const response = await throttleWithRedis(
-    50,
+    RATE_LIMITS["chat.update"],
     `${connector.id}-chat-update`,
     canBeIgnored,
     async () =>

--- a/connectors/src/connectors/slack/feedback_api.ts
+++ b/connectors/src/connectors/slack/feedback_api.ts
@@ -5,6 +5,7 @@ import {
   getSlackClient,
   getSlackUserInfo,
 } from "@connectors/connectors/slack/lib/slack_client";
+import { RATE_LIMITS } from "@connectors/connectors/slack/ratelimits";
 import { apiConfig } from "@connectors/lib/api/config";
 import { throttleWithRedis } from "@connectors/lib/throttle";
 import logger from "@connectors/logger/logger";
@@ -207,7 +208,7 @@ export async function submitFeedbackToAPI({
           }
 
           await throttleWithRedis(
-            50,
+            RATE_LIMITS["chat.update"],
             `${connector.id}-chat-update`,
             false,
             async () =>

--- a/connectors/src/connectors/slack/ratelimits.ts
+++ b/connectors/src/connectors/slack/ratelimits.ts
@@ -1,0 +1,5 @@
+// See slack docs for more details: https://docs.slack.dev/apis/web-api/rate-limits
+
+export const RATE_LIMITS = {
+  "chat.update": 50,
+};

--- a/connectors/src/connectors/slack/ratelimits.ts
+++ b/connectors/src/connectors/slack/ratelimits.ts
@@ -1,5 +1,10 @@
 // See slack docs for more details: https://docs.slack.dev/apis/web-api/rate-limits
 
+import type { RateLimit } from "@connectors/lib/throttle";
+
 export const RATE_LIMITS = {
-  "chat.update": 50,
-};
+  "chat.update": {
+    limit: 50,
+    windowInMs: 60 * 1000,
+  },
+} satisfies Record<string, RateLimit>;

--- a/connectors/src/lib/lock.ts
+++ b/connectors/src/lib/lock.ts
@@ -1,0 +1,84 @@
+import { redisClient } from "@connectors/lib/redis";
+
+// Distributed lock implementation using Redis
+// Returns the lock value if the lock is acquired, that can be used to unlock, otherwise undefined.
+export async function distributedLock(
+  redisCli: Awaited<ReturnType<typeof redisClient>>,
+  key: string
+): Promise<string | undefined> {
+  const lockKey = `lock:${key}`;
+  const lockValue = `${Date.now()}-${Math.random()}`;
+  const lockTimeout = 5000; // 5 seconds timeout
+
+  // Try to acquire the lock using SET with NX and PX options
+  const result = await redisCli.set(lockKey, lockValue, {
+    NX: true,
+    PX: lockTimeout,
+  });
+
+  if (result !== "OK") {
+    // Lock acquisition failed, return undefined - no lock value.
+    return undefined;
+  }
+
+  // Return the lock value that can be used to unlock.
+  return lockValue;
+}
+
+export async function distributedUnlock(
+  redisCli: Awaited<ReturnType<typeof redisClient>>,
+  key: string,
+  lockValue: string
+): Promise<void> {
+  const lockKey = `lock:${key}`;
+
+  // Use Lua script to ensure atomic unlock (only delete if we own the lock: lock value matches)
+  const luaScript = `
+    if redis.call("get", KEYS[1]) == ARGV[1] then
+      return redis.call("del", KEYS[1])
+    else
+      return 0
+    end
+  `;
+
+  await redisCli.eval(luaScript, {
+    keys: [lockKey],
+    arguments: [lockValue],
+  });
+}
+
+const WAIT_BETWEEN_RETRIES = 100;
+
+export const executeWithLock = async <T>(
+  lockName: string,
+  callback: () => Promise<T>,
+  timeoutMs: number = 30000
+): Promise<T> => {
+  const client = await redisClient({ origin: "lock" });
+
+  const start = Date.now();
+  let lockValue: string | undefined;
+  while (Date.now() - start < timeoutMs) {
+    // Try to acquire the lock
+    lockValue = await distributedLock(client, lockName);
+    if (lockValue) {
+      break;
+    }
+    // Wait a bit before retrying
+    await new Promise((resolve) => setTimeout(resolve, WAIT_BETWEEN_RETRIES));
+  }
+
+  if (!lockValue) {
+    throw new Error(`Lock acquisition timed out for ${lockName}`);
+  }
+
+  try {
+    const result = await callback();
+    return result;
+  } finally {
+    // Release the lock if we have it
+    if (lockValue) {
+      await distributedUnlock(client, lockName, lockValue);
+    }
+  }
+};

--- a/connectors/src/lib/redis.ts
+++ b/connectors/src/lib/redis.ts
@@ -6,7 +6,10 @@ import { statsDClient } from "@connectors/logger/withlogging";
 
 let client: RedisClientType;
 
-type RedisUsageTagsType = "notion_gc" | "google_drive_incremental_sync";
+type RedisUsageTagsType =
+  | "notion_gc"
+  | "google_drive_incremental_sync"
+  | "throttle";
 
 export async function redisClient({
   origin,

--- a/connectors/src/lib/redis.ts
+++ b/connectors/src/lib/redis.ts
@@ -9,7 +9,8 @@ let client: RedisClientType;
 type RedisUsageTagsType =
   | "notion_gc"
   | "google_drive_incremental_sync"
-  | "throttle";
+  | "throttle"
+  | "lock";
 
 export async function redisClient({
   origin,

--- a/connectors/src/lib/throttle.test.ts
+++ b/connectors/src/lib/throttle.test.ts
@@ -1,0 +1,680 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { throttle } from "./throttle";
+
+describe("throttle", () => {
+  // Helper function to create mock functions for testing
+  const createMockFunctions = (initialTimestamps: number[] = []) => {
+    const timestamps = [...initialTimestamps];
+    const removedTimestamps: number[] = [];
+
+    const getTimestamps = vi.fn(async () => [...timestamps]);
+    const addTimestamp = vi.fn(async (timestamp: number) => {
+      timestamps.push(timestamp);
+    });
+    const removeTimestamp = vi.fn(async (timestamp: number) => {
+      const index = timestamps.indexOf(timestamp);
+      if (index > -1) {
+        timestamps.splice(index, 1);
+        removedTimestamps.push(timestamp);
+      }
+    });
+
+    return {
+      getTimestamps,
+      addTimestamp,
+      removeTimestamp,
+      getCurrentTimestamps: () => [...timestamps],
+      getRemovedTimestamps: () => [...removedTimestamps],
+    };
+  };
+
+  describe("basic functionality", () => {
+    it("should allow request when under rate limit", async () => {
+      const mocks = createMockFunctions();
+      const now = Date.now();
+
+      const result = await throttle({
+        rateLimitPerMinute: 100,
+        canBeIgnored: false,
+        now,
+        getTimestamps: mocks.getTimestamps,
+        addTimestamp: mocks.addTimestamp,
+        removeTimestamp: mocks.removeTimestamp,
+      });
+
+      expect(result).toBe(0);
+      expect(mocks.getTimestamps).toHaveBeenCalledOnce();
+      expect(mocks.addTimestamp).toHaveBeenCalledWith(now);
+      expect(mocks.removeTimestamp).not.toHaveBeenCalled();
+    });
+
+    it("should allow request when exactly at allowed limit (90% of rate limit)", async () => {
+      const now = Date.now();
+      // For rate limit of 100, allowed is 90. Create 89 existing timestamps
+      const existingTimestamps = Array.from(
+        { length: 89 },
+        (_, i) => now - i * 1000
+      );
+      const mocks = createMockFunctions(existingTimestamps);
+
+      const result = await throttle({
+        rateLimitPerMinute: 100,
+        canBeIgnored: false,
+        now,
+        getTimestamps: mocks.getTimestamps,
+        addTimestamp: mocks.addTimestamp,
+        removeTimestamp: mocks.removeTimestamp,
+      });
+
+      expect(result).toBe(0);
+      expect(mocks.addTimestamp).toHaveBeenCalledWith(now);
+    });
+
+    it("should throttle request when over rate limit", async () => {
+      const now = Date.now();
+      // For rate limit of 100, allowed is 90. Create 90 existing timestamps within the last minute
+      const existingTimestamps = Array.from(
+        { length: 90 },
+        (_, i) => now - i * 500
+      ); // 500ms apart to stay within 1 minute
+      const mocks = createMockFunctions(existingTimestamps);
+
+      const result = await throttle({
+        rateLimitPerMinute: 100,
+        canBeIgnored: false,
+        now,
+        getTimestamps: mocks.getTimestamps,
+        addTimestamp: mocks.addTimestamp,
+        removeTimestamp: mocks.removeTimestamp,
+      });
+
+      expect(result).toBeGreaterThan(0);
+      // Should add future timestamp
+      expect(mocks.addTimestamp).toHaveBeenCalled();
+      const addedTimestamp = mocks.addTimestamp.mock.calls[0]?.[0];
+      expect(addedTimestamp).toBeDefined();
+      expect(addedTimestamp!).toBeGreaterThan(now);
+    });
+  });
+
+  describe("safety margin (90% rule)", () => {
+    it("should apply 90% safety margin correctly", async () => {
+      const now = Date.now();
+
+      // Test with different rate limits
+      const testCases = [
+        { rateLimitPerMinute: 100, expectedAllowed: 90 },
+        { rateLimitPerMinute: 60, expectedAllowed: 54 },
+        { rateLimitPerMinute: 10, expectedAllowed: 9 },
+        { rateLimitPerMinute: 1, expectedAllowed: 0 }, // Math.floor(1 * 0.9) = 0
+      ];
+
+      for (const { rateLimitPerMinute, expectedAllowed } of testCases) {
+        // Create exactly the allowed number of timestamps to test the edge case
+        const existingTimestamps =
+          expectedAllowed > 0
+            ? Array.from({ length: expectedAllowed }, (_, i) => now - i * 500)
+            : [];
+        const mocks = createMockFunctions(existingTimestamps);
+
+        if (expectedAllowed === 0) {
+          // When expectedAllowed is 0 (e.g., rate limit of 1), the function should throw an error
+          await expect(
+            throttle({
+              rateLimitPerMinute,
+              canBeIgnored: false,
+              now,
+              getTimestamps: mocks.getTimestamps,
+              addTimestamp: mocks.addTimestamp,
+              removeTimestamp: mocks.removeTimestamp,
+            })
+          ).rejects.toThrow("Rate limit too low");
+        } else {
+          const result = await throttle({
+            rateLimitPerMinute,
+            canBeIgnored: false,
+            now,
+            getTimestamps: mocks.getTimestamps,
+            addTimestamp: mocks.addTimestamp,
+            removeTimestamp: mocks.removeTimestamp,
+          });
+
+          // When we have exactly the allowed number, adding one more should trigger throttling
+          if (expectedAllowed === existingTimestamps.length) {
+            // We're at the limit, so adding one more should cause throttling
+            expect(result).toBeGreaterThan(0);
+          } else {
+            expect(result).toBe(0); // Should still allow
+          }
+        }
+      }
+    });
+  });
+
+  describe("timestamp cleanup", () => {
+    it("should remove expired timestamps older than 1 minute", async () => {
+      const now = Date.now();
+
+      const existingTimestamps = [
+        now - 30 * 1000, // 30 seconds ago (valid)
+        now - 45 * 1000, // 45 seconds ago (valid)
+        now - 70 * 1000, // 70 seconds ago (expired)
+        now - 90 * 1000, // 90 seconds ago (expired)
+        now - 120 * 1000, // 2 minutes ago (expired)
+      ];
+
+      const mocks = createMockFunctions(existingTimestamps);
+
+      await throttle({
+        rateLimitPerMinute: 100,
+        canBeIgnored: false,
+        now,
+        getTimestamps: mocks.getTimestamps,
+        addTimestamp: mocks.addTimestamp,
+        removeTimestamp: mocks.removeTimestamp,
+      });
+
+      // Should remove the 3 expired timestamps
+      expect(mocks.removeTimestamp).toHaveBeenCalledTimes(3);
+      expect(mocks.removeTimestamp).toHaveBeenCalledWith(now - 70 * 1000);
+      expect(mocks.removeTimestamp).toHaveBeenCalledWith(now - 90 * 1000);
+      expect(mocks.removeTimestamp).toHaveBeenCalledWith(now - 120 * 1000);
+
+      // Should not remove valid timestamps
+      expect(mocks.removeTimestamp).not.toHaveBeenCalledWith(now - 30 * 1000);
+      expect(mocks.removeTimestamp).not.toHaveBeenCalledWith(now - 45 * 1000);
+    });
+
+    it("should handle empty timestamp list", async () => {
+      const mocks = createMockFunctions([]);
+      const now = Date.now();
+
+      const result = await throttle({
+        rateLimitPerMinute: 100,
+        canBeIgnored: false,
+        now,
+        getTimestamps: mocks.getTimestamps,
+        addTimestamp: mocks.addTimestamp,
+        removeTimestamp: mocks.removeTimestamp,
+      });
+
+      expect(result).toBe(0);
+      expect(mocks.removeTimestamp).not.toHaveBeenCalled();
+      expect(mocks.addTimestamp).toHaveBeenCalledWith(now);
+    });
+  });
+
+  describe("canBeIgnored functionality", () => {
+    it("should return -1 when canBeIgnored is true and over limit", async () => {
+      const now = Date.now();
+      // Create 90 timestamps (at the 90% limit for rate limit of 100) within the last minute
+      const existingTimestamps = Array.from(
+        { length: 90 },
+        (_, i) => now - i * 500
+      );
+      const mocks = createMockFunctions(existingTimestamps);
+
+      const result = await throttle({
+        rateLimitPerMinute: 100,
+        canBeIgnored: true,
+        now,
+        getTimestamps: mocks.getTimestamps,
+        addTimestamp: mocks.addTimestamp,
+        removeTimestamp: mocks.removeTimestamp,
+      });
+
+      expect(result).toBe(-1);
+      // Should not add timestamp when ignoring
+      expect(mocks.addTimestamp).not.toHaveBeenCalled();
+    });
+
+    it("should still allow request when canBeIgnored is true but under limit", async () => {
+      const mocks = createMockFunctions([]);
+      const now = Date.now();
+
+      const result = await throttle({
+        rateLimitPerMinute: 100,
+        canBeIgnored: true,
+        now,
+        getTimestamps: mocks.getTimestamps,
+        addTimestamp: mocks.addTimestamp,
+        removeTimestamp: mocks.removeTimestamp,
+      });
+
+      expect(result).toBe(0);
+      expect(mocks.addTimestamp).toHaveBeenCalledWith(now);
+    });
+
+    it("should calculate delay when canBeIgnored is false and over limit", async () => {
+      const now = Date.now();
+      // Create 90 timestamps (at the 90% limit for rate limit of 100) within the last minute
+      const existingTimestamps = Array.from(
+        { length: 90 },
+        (_, i) => now - i * 500
+      );
+      const mocks = createMockFunctions(existingTimestamps);
+
+      const result = await throttle({
+        rateLimitPerMinute: 100,
+        canBeIgnored: false,
+        now,
+        getTimestamps: mocks.getTimestamps,
+        addTimestamp: mocks.addTimestamp,
+        removeTimestamp: mocks.removeTimestamp,
+      });
+
+      expect(result).toBeGreaterThan(0);
+      expect(result).toBeLessThanOrEqual(60 * 1000); // Should be within 1 minute
+      expect(mocks.addTimestamp).toHaveBeenCalled();
+    });
+  });
+
+  describe("delay calculation", () => {
+    it("should calculate correct delay based on oldest timestamp in window", async () => {
+      const now = Date.now();
+      const oldestInWindow = now - 30 * 1000; // 30 seconds ago
+
+      // Create exactly 90 timestamps (90% of 100), with the oldest being 30 seconds ago
+      // Fill the rest with timestamps between oldestInWindow and now
+      const existingTimestamps = [
+        oldestInWindow,
+        ...Array.from({ length: 89 }, (_, i) => oldestInWindow + (i + 1) * 300), // Spread evenly
+      ];
+      const mocks = createMockFunctions(existingTimestamps);
+
+      const result = await throttle({
+        rateLimitPerMinute: 100,
+        canBeIgnored: false,
+        now,
+        getTimestamps: mocks.getTimestamps,
+        addTimestamp: mocks.addTimestamp,
+        removeTimestamp: mocks.removeTimestamp,
+      });
+
+      // With the fixed algorithm, we wait for the oldest timestamp to expire
+      // Expected delay: (oldestInWindow + 60000) - now = 30 seconds
+      const expectedDelay = oldestInWindow + 60 * 1000 - now;
+      expect(result).toBe(expectedDelay);
+      expect(result).toBe(30 * 1000);
+    });
+
+    it("should return 0 delay when calculated delay is negative", async () => {
+      const now = Date.now();
+      // Create a scenario where the calculated delay would be negative
+      const oldestInWindow = now - 70 * 1000; // 70 seconds ago
+
+      const existingTimestamps = [
+        oldestInWindow,
+        ...Array.from({ length: 89 }, (_, i) => now - i * 1000 - 1000),
+      ];
+      const mocks = createMockFunctions(existingTimestamps);
+
+      const result = await throttle({
+        rateLimitPerMinute: 100,
+        canBeIgnored: false,
+        now,
+        getTimestamps: mocks.getTimestamps,
+        addTimestamp: mocks.addTimestamp,
+        removeTimestamp: mocks.removeTimestamp,
+      });
+
+      // Math.max(0, delay) should ensure non-negative result
+      expect(result).toBe(0);
+    });
+
+    it("should add future timestamp when throttling", async () => {
+      const now = Date.now();
+      const oldestInWindow = now - 30 * 1000;
+
+      const existingTimestamps = [
+        oldestInWindow,
+        ...Array.from({ length: 89 }, (_, i) => oldestInWindow + (i + 1) * 300),
+      ];
+      const mocks = createMockFunctions(existingTimestamps);
+
+      await throttle({
+        rateLimitPerMinute: 100,
+        canBeIgnored: false,
+        now,
+        getTimestamps: mocks.getTimestamps,
+        addTimestamp: mocks.addTimestamp,
+        removeTimestamp: mocks.removeTimestamp,
+      });
+
+      expect(mocks.addTimestamp).toHaveBeenCalledOnce();
+      const addedTimestamp = mocks.addTimestamp.mock.calls[0]?.[0];
+      expect(addedTimestamp).toBeDefined();
+      // With the fixed algorithm, we add a timestamp when the oldest will expire
+      const expectedFutureTimestamp = oldestInWindow + 60 * 1000;
+      expect(addedTimestamp!).toBe(expectedFutureTimestamp);
+    });
+  });
+
+  describe("edge cases", () => {
+    it("should throw error for rate limit of 1", async () => {
+      const mocks = createMockFunctions([]);
+      const now = Date.now();
+
+      await expect(
+        throttle({
+          rateLimitPerMinute: 1,
+          canBeIgnored: false,
+          now,
+          getTimestamps: mocks.getTimestamps,
+          addTimestamp: mocks.addTimestamp,
+          removeTimestamp: mocks.removeTimestamp,
+        })
+      ).rejects.toThrow(
+        "Rate limit too low: 1 requests per minute results in 0 allowed requests after applying 90% safety margin. Consider using a higher rate limit (minimum 2 requests per minute recommended)."
+      );
+
+      // No timestamps should be added when throwing error
+      expect(mocks.addTimestamp).not.toHaveBeenCalled();
+    });
+
+    it("should throw error for rate limit of 1 even when canBeIgnored is true", async () => {
+      const mocks = createMockFunctions([]);
+      const now = Date.now();
+
+      await expect(
+        throttle({
+          rateLimitPerMinute: 1,
+          canBeIgnored: true,
+          now,
+          getTimestamps: mocks.getTimestamps,
+          addTimestamp: mocks.addTimestamp,
+          removeTimestamp: mocks.removeTimestamp,
+        })
+      ).rejects.toThrow(
+        "Rate limit too low: 1 requests per minute results in 0 allowed requests after applying 90% safety margin. Consider using a higher rate limit (minimum 2 requests per minute recommended)."
+      );
+    });
+
+    it("should handle very high rate limits", async () => {
+      const mocks = createMockFunctions([]);
+      const now = Date.now();
+
+      const result = await throttle({
+        rateLimitPerMinute: 10000,
+        canBeIgnored: false,
+        now,
+        getTimestamps: mocks.getTimestamps,
+        addTimestamp: mocks.addTimestamp,
+        removeTimestamp: mocks.removeTimestamp,
+      });
+
+      expect(result).toBe(0);
+      expect(mocks.addTimestamp).toHaveBeenCalledWith(now);
+    });
+
+    it("should handle timestamps exactly at the 1-minute boundary", async () => {
+      const now = Date.now();
+      const exactlyOneMinuteAgo = now - 60 * 1000;
+      const justOverOneMinuteAgo = now - 60 * 1000 - 1;
+      const wayOverOneMinuteAgo = now - 120 * 1000;
+
+      const existingTimestamps = [
+        exactlyOneMinuteAgo, // Should be removed (exactly at boundary - condition is timestamp > oneMinuteAgo)
+        justOverOneMinuteAgo, // Should be removed (just over boundary)
+        wayOverOneMinuteAgo, // Should be removed (way over boundary)
+      ];
+
+      const mocks = createMockFunctions(existingTimestamps);
+
+      await throttle({
+        rateLimitPerMinute: 100,
+        canBeIgnored: false,
+        now,
+        getTimestamps: mocks.getTimestamps,
+        addTimestamp: mocks.addTimestamp,
+        removeTimestamp: mocks.removeTimestamp,
+      });
+
+      // All 3 timestamps should be removed because the condition is timestamp > oneMinuteAgo
+      // This means timestamps exactly at the boundary (==) are also removed
+      expect(mocks.removeTimestamp).toHaveBeenCalledTimes(3);
+      expect(mocks.removeTimestamp).toHaveBeenCalledWith(exactlyOneMinuteAgo);
+      expect(mocks.removeTimestamp).toHaveBeenCalledWith(justOverOneMinuteAgo);
+      expect(mocks.removeTimestamp).toHaveBeenCalledWith(wayOverOneMinuteAgo);
+    });
+
+    it("should handle duplicate timestamps", async () => {
+      const now = Date.now();
+      const duplicateTimestamp = now - 30 * 1000;
+
+      const existingTimestamps = [
+        duplicateTimestamp,
+        duplicateTimestamp,
+        duplicateTimestamp,
+      ];
+
+      const mocks = createMockFunctions(existingTimestamps);
+
+      const result = await throttle({
+        rateLimitPerMinute: 100,
+        canBeIgnored: false,
+        now,
+        getTimestamps: mocks.getTimestamps,
+        addTimestamp: mocks.addTimestamp,
+        removeTimestamp: mocks.removeTimestamp,
+      });
+
+      expect(result).toBe(0);
+      expect(mocks.addTimestamp).toHaveBeenCalledWith(now);
+      // No timestamps should be removed (all are within the window)
+      expect(mocks.removeTimestamp).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("sliding window algorithm correctness", () => {
+    it("should use correct timestamp when over capacity", async () => {
+      const now = 60000;
+
+      // Scenario: We have 11 timestamps but only allow 9 (90% of 10)
+      // This can happen due to race conditions or cleanup delays
+      const unsortedTimestamps = [
+        50000,
+        5000, // This is the oldest
+        45000,
+        10000,
+        40000,
+        15000,
+        35000,
+        20000,
+        30000,
+        25000,
+        55000,
+      ];
+
+      const mocks = createMockFunctions(unsortedTimestamps);
+
+      const result = await throttle({
+        rateLimitPerMinute: 10, // 90% = 9 allowed
+        canBeIgnored: false,
+        now,
+        getTimestamps: mocks.getTimestamps,
+        addTimestamp: mocks.addTimestamp,
+        removeTimestamp: mocks.removeTimestamp,
+      });
+
+      // The algorithm should:
+      // 1. Sort timestamps: [5000, 10000, 15000, 20000, 25000, 30000, 35000, 40000, 45000, 50000, 55000]
+      // 2. Pick index [11 - 9] = [2] = 15000
+      // 3. Calculate delay: (15000 + 60000) - 60000 = 15000ms
+
+      const sortedTimestamps = [...unsortedTimestamps].sort((a, b) => a - b);
+      const targetIndex = unsortedTimestamps.length - 9; // 11 - 9 = 2
+      const targetTimestamp = sortedTimestamps[targetIndex]; // 15000
+      const expectedDelay = targetTimestamp! + 60000 - now; // 15000
+
+      expect(result).toBe(expectedDelay);
+      expect(result).toBe(15000);
+
+      // Verify the timestamp was used for scheduling
+      expect(mocks.addTimestamp).toHaveBeenCalledWith(targetTimestamp! + 60000);
+      expect(mocks.addTimestamp).toHaveBeenCalledWith(75000);
+    });
+
+    it("should handle exactly at capacity correctly", async () => {
+      const now = 60000;
+
+      // Scenario: We have exactly 9 timestamps (the allowed amount)
+      const unsortedTimestamps = [
+        45000, 10000, 50000, 15000, 40000, 20000, 35000, 25000, 30000,
+      ];
+
+      // When exactly at capacity, the algorithm picks sortedTimestamps[9-9] = sortedTimestamps[0] (the oldest)
+
+      const mocks = createMockFunctions(unsortedTimestamps);
+
+      const result = await throttle({
+        rateLimitPerMinute: 10, // 90% = 9 allowed
+        canBeIgnored: false,
+        now,
+        getTimestamps: mocks.getTimestamps,
+        addTimestamp: mocks.addTimestamp,
+        removeTimestamp: mocks.removeTimestamp,
+      });
+
+      const sortedTimestamps = [...unsortedTimestamps].sort((a, b) => a - b);
+      const oldestTimestamp = sortedTimestamps[0]; // 10000
+      const expectedDelay = oldestTimestamp! + 60000 - now; // 10000
+
+      expect(result).toBe(expectedDelay);
+      expect(result).toBe(10000);
+
+      console.log(
+        "At capacity - algorithm picks the oldest timestamp:",
+        oldestTimestamp
+      );
+    });
+
+    it("should handle unsorted timestamps correctly", async () => {
+      const now = 60000;
+
+      // Create timestamps in random order (as they might come from Redis)
+      const unsortedTimestamps = [
+        55000,
+        45000,
+        50000,
+        10000,
+        40000,
+        15000, // This should be picked (sortedTimestamps[2])
+        35000,
+        20000,
+        30000,
+        25000,
+        5000,
+      ];
+
+      const mocks = createMockFunctions(unsortedTimestamps);
+
+      const result = await throttle({
+        rateLimitPerMinute: 10,
+        canBeIgnored: false,
+        now,
+        getTimestamps: mocks.getTimestamps,
+        addTimestamp: mocks.addTimestamp,
+        removeTimestamp: mocks.removeTimestamp,
+      });
+
+      // Algorithm: sortedTimestamps[11-9] = sortedTimestamps[2] = 15000
+      const sortedTimestamps = [...unsortedTimestamps].sort((a, b) => a - b);
+      const targetTimestamp = sortedTimestamps[2]; // 15000
+      const expectedDelay = targetTimestamp! + 60000 - now;
+
+      expect(result).toBe(expectedDelay);
+      expect(result).toBe(15000);
+
+      console.log(
+        "Algorithm picks timestamp:",
+        targetTimestamp,
+        "→ delay:",
+        expectedDelay
+      );
+      console.log("Sorted timestamps:", sortedTimestamps.slice(0, 5), "...");
+    });
+  });
+
+  describe("integration scenarios", () => {
+    it("should handle mixed scenario with expired and valid timestamps", async () => {
+      const now = Date.now();
+
+      const existingTimestamps = [
+        // Valid timestamps (within 1 minute)
+        now - 10 * 1000, // 10 seconds ago
+        now - 30 * 1000, // 30 seconds ago
+        now - 50 * 1000, // 50 seconds ago
+        // Expired timestamps (older than 1 minute)
+        now - 70 * 1000, // 70 seconds ago
+        now - 90 * 1000, // 90 seconds ago
+        now - 120 * 1000, // 2 minutes ago
+      ];
+
+      const mocks = createMockFunctions(existingTimestamps);
+
+      const result = await throttle({
+        rateLimitPerMinute: 100,
+        canBeIgnored: false,
+        now,
+        getTimestamps: mocks.getTimestamps,
+        addTimestamp: mocks.addTimestamp,
+        removeTimestamp: mocks.removeTimestamp,
+      });
+
+      // Should allow the request (3 valid + 1 new = 4, well under 90)
+      expect(result).toBe(0);
+
+      // Should remove 3 expired timestamps
+      expect(mocks.removeTimestamp).toHaveBeenCalledTimes(3);
+      expect(mocks.removeTimestamp).toHaveBeenCalledWith(now - 70 * 1000);
+      expect(mocks.removeTimestamp).toHaveBeenCalledWith(now - 90 * 1000);
+      expect(mocks.removeTimestamp).toHaveBeenCalledWith(now - 120 * 1000);
+
+      // Should add current timestamp
+      expect(mocks.addTimestamp).toHaveBeenCalledWith(now);
+    });
+
+    it("should handle rapid successive calls simulation", async () => {
+      const baseTime = Date.now();
+      const timestamps: number[] = [];
+
+      const mocks = {
+        getTimestamps: vi.fn(async () => [...timestamps]),
+        addTimestamp: vi.fn(async (timestamp: number) => {
+          timestamps.push(timestamp);
+        }),
+        removeTimestamp: vi.fn(async (timestamp: number) => {
+          const index = timestamps.indexOf(timestamp);
+          if (index > -1) {
+            timestamps.splice(index, 1);
+          }
+        }),
+      };
+
+      // Simulate 100 requests in quick succession
+      const results: number[] = [];
+      for (let i = 0; i < 100; i++) {
+        const now = baseTime + i * 100; // 100ms apart
+
+        const result = await throttle({
+          rateLimitPerMinute: 100, // 90 allowed due to safety margin
+          canBeIgnored: false,
+          now,
+          getTimestamps: mocks.getTimestamps,
+          addTimestamp: mocks.addTimestamp,
+          removeTimestamp: mocks.removeTimestamp,
+        });
+
+        results.push(result);
+      }
+
+      // First 90 should be allowed (return 0)
+      expect(results.slice(0, 90).every((r) => r === 0)).toBe(true);
+
+      // Remaining 10 should be throttled (return > 0)
+      expect(results.slice(90).every((r) => r > 0)).toBe(true);
+    });
+  });
+});

--- a/connectors/src/lib/throttle.ts
+++ b/connectors/src/lib/throttle.ts
@@ -22,22 +22,48 @@ export async function throttleWithRedis<T>(
     await client.lRem(redisKey, 1, timestamp.toString());
   };
 
-  const delay = await throttle({
-    rateLimitPerMinute,
-    canBeIgnored,
-    now: new Date().getTime(),
-    getTimestamps,
-    addTimestamp,
-    removeTimestamp,
-  });
+  // Try to acquire a lock
+  const lockKey = `lock:${redisKey}`;
+  const acquiredLockTimeout = 3000;
+  const start = Date.now();
 
-  if (delay === -1) {
+  let acquiredLock = false;
+  while (Date.now() - start < acquiredLockTimeout) {
+    const lock = await client.set(lockKey, "1", { NX: true, PX: 3000 });
+    if (lock === "OK") {
+      acquiredLock = true;
+      break;
+    }
+    // Sleep for 100ms before retrying
+    await new Promise((resolve) => setTimeout(resolve, 100));
+  }
+
+  if (!acquiredLock) {
+    throw new Error("Failed to acquire lock for throttling");
+  }
+
+  let throttleRes: { delay: number | undefined; skip: boolean } | undefined;
+  try {
+    throttleRes = await throttle({
+      rateLimitPerMinute,
+      canBeIgnored,
+      now: new Date().getTime(),
+      getTimestamps,
+      addTimestamp,
+      removeTimestamp,
+    });
+  } finally {
+    // Release the lock
+    await client.del(lockKey);
+  }
+
+  if (throttleRes.skip) {
     // Ignore the request
     return;
-  } else if (delay > 0) {
-    logger.info({ delay }, "Delaying api request");
-    await new Promise((resolve) => setTimeout(resolve, delay));
-  } else if (delay === 0) {
+  } else if (throttleRes.delay && throttleRes.delay > 0) {
+    logger.info({ delay: throttleRes }, "Delaying api request");
+    await new Promise((resolve) => setTimeout(resolve, throttleRes.delay));
+  } else if (throttleRes.delay === 0) {
     // Do nothing and just call the function
   } else {
     throw new Error("Invalid delay");
@@ -60,17 +86,7 @@ export async function throttle({
   getTimestamps: () => Promise<number[]>;
   addTimestamp: (timestamp: number) => Promise<void>;
   removeTimestamp: (timestamp: number) => Promise<void>;
-}): Promise<number> {
-  // Reduce to 90% of the rate limit per minute as a safety margin.
-  const allowedRequestsPerMinute = Math.floor(rateLimitPerMinute * 0.9);
-
-  // Handle edge case where rate limit is so low that 90% margin results in 0 allowed requests
-  if (allowedRequestsPerMinute === 0) {
-    throw new Error(
-      `Rate limit too low: ${rateLimitPerMinute} requests per minute results in 0 allowed requests after applying 90% safety margin. Consider using a higher rate limit (minimum 2 requests per minute recommended).`
-    );
-  }
-
+}): Promise<{ delay: number | undefined; skip: boolean }> {
   // Get timestamps data.
   const rawTimestamps = await getTimestamps();
 
@@ -87,21 +103,21 @@ export async function throttle({
   }
 
   // Check if the list of timestamps is less than the rate limit per minute.
-  if (timestamps.length < allowedRequestsPerMinute) {
+  if (timestamps.length < rateLimitPerMinute) {
     // Add the current timestamp to the timestamps
     await addTimestamp(now);
-    return 0; // OK
+    return { delay: 0, skip: false }; // OK
   } else {
     if (canBeIgnored) {
-      return -1; // The caller said the request can be ignored, we don't add it and we return -1 to indicate that the request can be ignored.
+      return { delay: undefined, skip: true }; // The caller said the request can be ignored, we don't add it and we return -1 to indicate that the request can be ignored.
     }
 
     // Sort timestamps first just in case (they should be sorted already)
     const sortedTimestamps = [...timestamps].sort((a, b) => a - b);
     const lastEntryInWindow =
-      sortedTimestamps[timestamps.length - allowedRequestsPerMinute];
+      sortedTimestamps[timestamps.length - rateLimitPerMinute];
 
-    // This should never happen since we checked timestamps.length >= allowedRequestsPerMinute above
+    // This should never happen since we checked timestamps.length >= rateLimitPerMinute above
     if (lastEntryInWindow === undefined) {
       throw new Error(
         "Unexpected: no timestamp found at calculated index when timestamps array should not be empty"
@@ -115,6 +131,6 @@ export async function throttle({
     // Add the future timestamp when the request will be allowed
     await addTimestamp(nextEntryTimestamp);
 
-    return Math.max(0, delay);
+    return { delay: Math.max(0, delay), skip: false };
   }
 }

--- a/connectors/src/lib/throttle.ts
+++ b/connectors/src/lib/throttle.ts
@@ -1,0 +1,120 @@
+import _ from "lodash";
+
+import { redisClient } from "@connectors/lib/redis";
+import logger from "@connectors/logger/logger";
+
+export async function throttleWithRedis<T>(
+  rateLimitPerMinute: number,
+  key: string,
+  canBeIgnored: boolean,
+  func: () => Promise<T>
+): Promise<T | undefined> {
+  const client = await redisClient({ origin: "throttle" });
+  const redisKey = `throttle:${key}`;
+  const getTimestamps = async () => {
+    const timestamps = await client.lRange(redisKey, 0, -1);
+    return timestamps.map(Number);
+  };
+  const addTimestamp = async (timestamp: number) => {
+    await client.rPush(redisKey, timestamp.toString());
+  };
+  const removeTimestamp = async (timestamp: number) => {
+    await client.lRem(redisKey, 1, timestamp.toString());
+  };
+
+  const delay = await throttle({
+    rateLimitPerMinute,
+    canBeIgnored,
+    now: new Date().getTime(),
+    getTimestamps,
+    addTimestamp,
+    removeTimestamp,
+  });
+
+  if (delay === -1) {
+    // Ignore the request
+    return;
+  } else if (delay > 0) {
+    logger.info({ delay }, "Delaying api request");
+    await new Promise((resolve) => setTimeout(resolve, delay));
+  } else if (delay === 0) {
+    // Do nothing and just call the function
+  } else {
+    throw new Error("Invalid delay");
+  }
+
+  return func();
+}
+
+export async function throttle({
+  rateLimitPerMinute,
+  canBeIgnored,
+  now,
+  getTimestamps,
+  addTimestamp,
+  removeTimestamp,
+}: {
+  rateLimitPerMinute: number;
+  canBeIgnored: boolean;
+  now: number;
+  getTimestamps: () => Promise<number[]>;
+  addTimestamp: (timestamp: number) => Promise<void>;
+  removeTimestamp: (timestamp: number) => Promise<void>;
+}): Promise<number> {
+  // Reduce to 90% of the rate limit per minute as a safety margin.
+  const allowedRequestsPerMinute = Math.floor(rateLimitPerMinute * 0.9);
+
+  // Handle edge case where rate limit is so low that 90% margin results in 0 allowed requests
+  if (allowedRequestsPerMinute === 0) {
+    throw new Error(
+      `Rate limit too low: ${rateLimitPerMinute} requests per minute results in 0 allowed requests after applying 90% safety margin. Consider using a higher rate limit (minimum 2 requests per minute recommended).`
+    );
+  }
+
+  // Get timestamps data.
+  const rawTimestamps = await getTimestamps();
+
+  // Trim anything older than 1 minute in data.
+  const oneMinuteAgo = now - 60 * 1000;
+  const timestamps = rawTimestamps.filter((timestamp) => {
+    return timestamp > oneMinuteAgo;
+  });
+
+  // Remove the expired timestamps entries.
+  const diff = _.difference(rawTimestamps, timestamps);
+  for (const timestamp of diff) {
+    await removeTimestamp(timestamp);
+  }
+
+  // Check if the list of timestamps is less than the rate limit per minute.
+  if (timestamps.length < allowedRequestsPerMinute) {
+    // Add the current timestamp to the timestamps
+    await addTimestamp(now);
+    return 0; // OK
+  } else {
+    if (canBeIgnored) {
+      return -1; // The caller said the request can be ignored, we don't add it and we return -1 to indicate that the request can be ignored.
+    }
+
+    // Sort timestamps first just in case (they should be sorted already)
+    const sortedTimestamps = [...timestamps].sort((a, b) => a - b);
+    const lastEntryInWindow =
+      sortedTimestamps[timestamps.length - allowedRequestsPerMinute];
+
+    // This should never happen since we checked timestamps.length >= allowedRequestsPerMinute above
+    if (lastEntryInWindow === undefined) {
+      throw new Error(
+        "Unexpected: no timestamp found at calculated index when timestamps array should not be empty"
+      );
+    }
+
+    const nextEntryTimestamp = lastEntryInWindow + 60 * 1000;
+
+    const delay = nextEntryTimestamp - now;
+
+    // Add the future timestamp when the request will be allowed
+    await addTimestamp(nextEntryTimestamp);
+
+    return Math.max(0, delay);
+  }
+}


### PR DESCRIPTION
## Description

Removed the custom "best effort" delay code to replace with a proper throttler implementation so..
Added a `throttleWithRedis()` method (and a more generic `throttle()` method so I could test it nicely).
Also, added a "canBeIgnored" when the api call can be safely skipped (eg: when we update the intermediary state of the agent message).

## Tests

Added and tested locally with Gliterry Helmet.

## Risk

Medium, I'm wrapping around only a single api call for now, will monitor.

## Deploy Plan

Deploy connectors.