### PR TITLE
[front] - chore(InputBar): tweak code blocks style

### DIFF
--- a/front/components/assistant/conversation/input_bar/editor/extensions/MarkdownStyleExtension.ts
+++ b/front/components/assistant/conversation/input_bar/editor/extensions/MarkdownStyleExtension.ts
@@ -7,6 +7,14 @@ export const MarkdownStyleExtension = Extension.create({
   addGlobalAttributes() {
     return [
       {
+        types: ["code"],
+        attributes: {
+          class: {
+            default: markdownStyles.code(),
+          },
+        },
+      },
+      {
         types: ["textContent"],
         attributes: {
           class: {

--- a/sparkle/src/components/markdown/CodeBlock.tsx
+++ b/sparkle/src/components/markdown/CodeBlock.tsx
@@ -17,7 +17,7 @@ export const codeBlockVariants = cva(
     variants: {
       variant: {
         surface: [
-          "s-bg-muted dark:s-bg-muted-night",
+          "s-bg-muted/70 dark:s-bg-muted-night/70",
           "s-text-golden-600 dark:s-text-golden-600-night",
         ],
       },


### PR DESCRIPTION
## Description

This PR:
 - Added default class attribute to apply markdown styles for code elements in the editor
 - Changed the background opacity for code blocks to 70% for both light and dark themes

**References:**
- https://github.com/dust-tt/tasks/issues/4302

## Tests

Locally

## Risk

Low

## Deploy Plan

Deploy front. Sparkle changes will be shipped with the next version
