### PR TITLE
assistant to agent in URLs

### DIFF
--- a/front/components/assistant/conversation/ConversationMenu.tsx
+++ b/front/components/assistant/conversation/ConversationMenu.tsx
@@ -74,7 +74,7 @@ export function ConversationMenu({
   const doDelete = useDeleteConversation(owner);
   const leaveOrDelete = useCallback(async () => {
     const res = await doDelete(conversation);
-    res && void router.push(`/w/${owner.sId}/assistant/new`);
+    res && void router.push(`/w/${owner.sId}/agent/new`);
   }, [conversation, doDelete, owner.sId, router]);
 
   const copyConversationLink = useCallback(async () => {

--- a/front/components/assistant/conversation/SidebarMenu.tsx
+++ b/front/components/assistant/conversation/SidebarMenu.tsx
@@ -284,7 +284,8 @@ export function AssistantSidebarMenu({ owner }: AssistantSidebarMenuProps) {
     setSidebarOpen(false);
     const { cId } = router.query;
     const isNewConversation =
-      (router.pathname === "/w/[wId]/assistant/[cId]" || router.pathname === "/w/[wId]/agent/[cId]") &&
+      (router.pathname === "/w/[wId]/assistant/[cId]" ||
+        router.pathname === "/w/[wId]/agent/[cId]") &&
       typeof cId === "string" &&
       cId === "new";
     if (isNewConversation) {

--- a/front/components/assistant/conversation/SidebarMenu.tsx
+++ b/front/components/assistant/conversation/SidebarMenu.tsx
@@ -284,7 +284,7 @@ export function AssistantSidebarMenu({ owner }: AssistantSidebarMenuProps) {
     setSidebarOpen(false);
     const { cId } = router.query;
     const isNewConversation =
-      router.pathname === "/w/[wId]/assistant/[cId]" &&
+      (router.pathname === "/w/[wId]/assistant/[cId]" || router.pathname === "/w/[wId]/agent/[cId]") &&
       typeof cId === "string" &&
       cId === "new";
     if (isNewConversation) {
@@ -333,7 +333,7 @@ export function AssistantSidebarMenu({ owner }: AssistantSidebarMenuProps) {
                 />
                 <Button
                   label="New"
-                  href={`/w/${owner.sId}/assistant/new`}
+                  href={`/w/${owner.sId}/agent/new`}
                   icon={ChatBubbleBottomCenterTextIcon}
                   className="shrink"
                   tooltip="Create a new conversation"
@@ -552,7 +552,7 @@ const RenderConversation = ({
               await new Promise((resolve) => setTimeout(resolve, 600));
             }
             await router.push(
-              `/w/${owner.sId}/assistant/${conversation.sId}`,
+              `/w/${owner.sId}/agent/${conversation.sId}`,
               undefined,
               {
                 shallow: true,

--- a/front/components/assistant/conversation/SidebarMenu.tsx
+++ b/front/components/assistant/conversation/SidebarMenu.tsx
@@ -284,8 +284,7 @@ export function AssistantSidebarMenu({ owner }: AssistantSidebarMenuProps) {
     setSidebarOpen(false);
     const { cId } = router.query;
     const isNewConversation =
-      (router.pathname === "/w/[wId]/assistant/[cId]" ||
-        router.pathname === "/w/[wId]/agent/[cId]") &&
+      router.pathname === "/w/[wId]/agent/[cId]" &&
       typeof cId === "string" &&
       cId === "new";
     if (isNewConversation) {

--- a/front/components/assistant/conversation/input_bar/editor/MentionComponent.tsx
+++ b/front/components/assistant/conversation/input_bar/editor/MentionComponent.tsx
@@ -35,7 +35,7 @@ export const MentionComponent = ({ node, owner }: MentionComponentProps) => {
     if (!owner) {
       return;
     }
-    await router.push(`/w/${owner.sId}/assistant/new?assistant=${agentSId}`);
+    await router.push(`/w/${owner.sId}/agent/new?assistant=${agentSId}`);
   };
 
   const handleSeeDetails = () => {

--- a/front/components/assistant/details/AssistantDetailsButtonBar.tsx
+++ b/front/components/assistant/details/AssistantDetailsButtonBar.tsx
@@ -236,7 +236,7 @@ export function AssistantDetailsButtonBar({
         icon={ChatBubbleBottomCenterTextIcon}
         size="sm"
         variant="outline"
-        href={`/w/${owner.sId}/assistant/new?assistant=${agentConfiguration.sId}`}
+        href={`/w/${owner.sId}/agent/new?assistant=${agentConfiguration.sId}`}
       />
 
       {agentConfiguration.scope !== "global" &&

--- a/front/components/assistant/details/AssistantDetailsButtonBar.tsx
+++ b/front/components/assistant/details/AssistantDetailsButtonBar.tsx
@@ -236,7 +236,7 @@ export function AssistantDetailsButtonBar({
         icon={ChatBubbleBottomCenterTextIcon}
         size="sm"
         variant="outline"
-        href={`/w/${owner.sId}/agent/new?assistant=${agentConfiguration.sId}`}
+        href={`/w/${owner.sId}/agent/new?agent=${agentConfiguration.sId}`}
       />
 
       {agentConfiguration.scope !== "global" &&

--- a/front/components/markdown/MentionBlock.tsx
+++ b/front/components/markdown/MentionBlock.tsx
@@ -28,7 +28,7 @@ function MentionBlock({
     useURLSheet("assistantDetails");
 
   const handleStartConversation = async () => {
-    await router.push(`/w/${owner.sId}/agent/new?assistant=${agentSId}`);
+    await router.push(`/w/${owner.sId}/agent/new?agent=${agentSId}`);
   };
 
   const handleSeeDetails = () => {

--- a/front/components/markdown/MentionBlock.tsx
+++ b/front/components/markdown/MentionBlock.tsx
@@ -28,7 +28,7 @@ function MentionBlock({
     useURLSheet("assistantDetails");
 
   const handleStartConversation = async () => {
-    await router.push(`/w/${owner.sId}/assistant/new?assistant=${agentSId}`);
+    await router.push(`/w/${owner.sId}/agent/new?assistant=${agentSId}`);
   };
 
   const handleSeeDetails = () => {

--- a/front/components/navigation/HelpDropdown.tsx
+++ b/front/components/navigation/HelpDropdown.tsx
@@ -48,7 +48,7 @@ export function HelpDropdown({
     } else {
       // Otherwise we just push the route and prefill the input bar with the @help mention.
       void router.push(
-        `/w/${owner.sId}/agent/new?assistant=${GLOBAL_AGENTS_SID.HELPER}`
+        `/w/${owner.sId}/agent/new?agent=${GLOBAL_AGENTS_SID.HELPER}`
       );
     }
   };

--- a/front/components/navigation/HelpDropdown.tsx
+++ b/front/components/navigation/HelpDropdown.tsx
@@ -41,14 +41,14 @@ export function HelpDropdown({
 
   const handleAskHelp = () => {
     if (router.pathname === "/w/[wId]/assistant/[cId]") {
-      // If we're on /assistant/new page, we just set the selected agent on top of what's already there in the input bar if any.
+      // If we're on /agent/new page, we just set the selected agent on top of what's already there in the input bar if any.
       // This allows to not lose your potential input when you click on the help button.
       setSelectedAssistant({ configurationId: GLOBAL_AGENTS_SID.HELPER });
       setAnimate(true);
     } else {
       // Otherwise we just push the route and prefill the input bar with the @help mention.
       void router.push(
-        `/w/${owner.sId}/assistant/new?assistant=${GLOBAL_AGENTS_SID.HELPER}`
+        `/w/${owner.sId}/agent/new?assistant=${GLOBAL_AGENTS_SID.HELPER}`
       );
     }
   };

--- a/front/components/navigation/config.ts
+++ b/front/components/navigation/config.ts
@@ -115,13 +115,13 @@ export const getTopNavigationTabs = (
   nav.push({
     id: "conversations",
     label: "Chat",
-    href: `/w/${owner.sId}/assistant/new`,
+    href: `/w/${owner.sId}/agent/new`,
     icon: ChatBubbleLeftRightIcon,
     sizing: "hug",
     isCurrent: (currentRoute) =>
       [
-        "/w/[wId]/assistant/new",
-        "/w/[wId]/assistant/[cId]",
+        "/w/[wId]/agent/new",
+        "/w/[wId]/agent/[cId]",
         "/w/[wId]/assistants",
       ].includes(currentRoute),
   });

--- a/front/components/navigation/config.ts
+++ b/front/components/navigation/config.ts
@@ -119,11 +119,7 @@ export const getTopNavigationTabs = (
     icon: ChatBubbleLeftRightIcon,
     sizing: "hug",
     isCurrent: (currentRoute) =>
-      [
-        "/w/[wId]/agent/new",
-        "/w/[wId]/agent/[cId]",
-        "/w/[wId]/assistants",
-      ].includes(currentRoute),
+      ["/w/[wId]/agent/new", "/w/[wId]/agent/[cId]"].includes(currentRoute),
   });
 
   nav.push({

--- a/front/components/sparkle/AppContentLayout.tsx
+++ b/front/components/sparkle/AppContentLayout.tsx
@@ -21,7 +21,7 @@ export const appLayoutBack = async (
   // counts the default page as an entry in the history stack, leading to a history length of 2.
   // Directly opening a link without the "new tab" page results in a history length of 1.
   if (window.history.length < 3) {
-    await router.push(`/w/${owner.sId}/assistant/new`);
+    await router.push(`/w/${owner.sId}/agent/new`);
   } else {
     // Set up beforePopState to intercept the back navigation and clean query params.
     router.beforePopState(({ as }) => {

--- a/front/hooks/useAppKeyboardShortcuts.ts
+++ b/front/hooks/useAppKeyboardShortcuts.ts
@@ -25,7 +25,7 @@ export function useAppKeyboardShortcuts(owner: LightWorkspaceType) {
         switch (event.key) {
           case "/":
             event.preventDefault();
-            void router.push(`/w/${owner.sId}/assistant/new`, undefined, {
+            void router.push(`/w/${owner.sId}/agent/new`, undefined, {
               shallow: true,
             });
             break;

--- a/front/middleware.ts
+++ b/front/middleware.ts
@@ -17,8 +17,8 @@ export function middleware(request: NextRequest) {
   const url = request.nextUrl.pathname;
 
   // Redirect assistant URLs to agent URLs (but not API routes)
-  if (url.includes('/assistant/') && !url.startsWith('/api/')) {
-    const newUrl = url.replace('/assistant/', '/agent/');
+  if (url.includes("/assistant/") && !url.startsWith("/api/")) {
+    const newUrl = url.replace("/assistant/", "/agent/");
     return NextResponse.redirect(new URL(newUrl, request.url));
   }
 

--- a/front/middleware.ts
+++ b/front/middleware.ts
@@ -16,6 +16,12 @@ export function middleware(request: NextRequest) {
 
   const url = request.nextUrl.pathname;
 
+  // Redirect assistant URLs to agent URLs (but not API routes)
+  if (url.includes('/assistant/') && !url.startsWith('/api/')) {
+    const newUrl = url.replace('/assistant/', '/agent/');
+    return NextResponse.redirect(new URL(newUrl, request.url));
+  }
+
   // The CASA test attempts to at least double encode the string to bypass checks hence why we
   // attempt to handle nested encoding up to 8 times.
   let decodedUrl = url;

--- a/front/middleware.ts
+++ b/front/middleware.ts
@@ -16,12 +16,6 @@ export function middleware(request: NextRequest) {
 
   const url = request.nextUrl.pathname;
 
-  // Redirect assistant URLs to agent URLs (but not API routes)
-  if (url.includes("/assistant/") && !url.startsWith("/api/")) {
-    const newUrl = url.replace("/assistant/", "/agent/");
-    return NextResponse.redirect(new URL(newUrl, request.url));
-  }
-
   // The CASA test attempts to at least double encode the string to bypass checks hence why we
   // attempt to handle nested encoding up to 8 times.
   let decodedUrl = url;

--- a/front/next.config.js
+++ b/front/next.config.js
@@ -68,6 +68,11 @@ module.exports = {
         permanent: false,
       },
       {
+        source: "/w/:wId/assistant/:cId",
+        destination: "/w/:wId/agent/:cId",
+        permanent: false,
+      },
+      {
         source: "/contact",
         destination: "/home/contact",
         permanent: true,

--- a/front/pages/w/[wId]/agent/[cId]/index.tsx
+++ b/front/pages/w/[wId]/agent/[cId]/index.tsx
@@ -56,7 +56,7 @@ export const getServerSideProps = withDefaultUserAuthRequirements<
   };
 });
 
-export default function AssistantConversation({
+export default function AgentConversation({
   conversationId: initialConversationId,
   owner,
   subscription,
@@ -68,7 +68,7 @@ export default function AssistantConversation({
 
   const { activeConversationId } = useConversationsNavigation();
 
-  const { assistant } = router.query;
+  const { agent } = router.query;
 
   // This useEffect handles whether to change the key of the ConversationContainer
   // or not. Altering the key forces a re-render of the component. A random number
@@ -85,14 +85,14 @@ export default function AssistantConversation({
       document.getElementById(CONVERSATION_VIEW_SCROLL_LAYOUT)?.scrollTo(0, 0);
     }
 
-    const agentId = assistant ?? null;
+    const agentId = agent ?? null;
     if (agentId && typeof agentId === "string") {
       setAgentIdToMention(agentId);
     } else {
       setAgentIdToMention(null);
     }
   }, [
-    assistant,
+    agent,
     setConversationKey,
     initialConversationId,
     activeConversationId,
@@ -110,7 +110,7 @@ export default function AssistantConversation({
   );
 }
 
-AssistantConversation.getLayout = (
+AgentConversation.getLayout = (
   page: React.ReactElement,
   pageProps: any
 ) => {

--- a/front/pages/w/[wId]/agent/[cId]/index.tsx
+++ b/front/pages/w/[wId]/agent/[cId]/index.tsx
@@ -91,12 +91,7 @@ export default function AgentConversation({
     } else {
       setAgentIdToMention(null);
     }
-  }, [
-    agent,
-    setConversationKey,
-    initialConversationId,
-    activeConversationId,
-  ]);
+  }, [agent, setConversationKey, initialConversationId, activeConversationId]);
 
   return (
     <ConversationContainer
@@ -110,10 +105,7 @@ export default function AgentConversation({
   );
 }
 
-AgentConversation.getLayout = (
-  page: React.ReactElement,
-  pageProps: any
-) => {
+AgentConversation.getLayout = (page: React.ReactElement, pageProps: any) => {
   return (
     <AppRootLayout>
       <ConversationLayout pageProps={pageProps}>{page}</ConversationLayout>

--- a/front/pages/w/[wId]/index.tsx
+++ b/front/pages/w/[wId]/index.tsx
@@ -10,7 +10,7 @@ export const getServerSideProps = withDefaultUserAuthRequirements<object>(
 
     return {
       redirect: {
-        destination: `/w/${context.query.wId}/assistant/new`,
+        destination: `/w/${context.query.wId}/agent/new`,
         permanent: false,
       },
     };

--- a/front/pages/w/[wId]/subscription/payment_processing.tsx
+++ b/front/pages/w/[wId]/subscription/payment_processing.tsx
@@ -54,7 +54,7 @@ export default function PaymentProcessing({
       if (subscription.plan.code === router.query.plan_code) {
         // Then we remove the query params to avoid going through this logic again.
         void router.replace({
-          pathname: `/w/${owner.sId}/assistant/new`,
+          pathname: `/w/${owner.sId}/agent/new`,
           query: { welcome: true },
         });
       } else {

--- a/front/pages/w/[wId]/welcome.tsx
+++ b/front/pages/w/[wId]/welcome.tsx
@@ -99,7 +99,7 @@ export default function Welcome({
     }
 
     await router.push(
-      `/w/${owner.sId}/assistant/new?welcome=true${
+      `/w/${owner.sId}/agent/new?welcome=true${
         conversationId ? `&cId=${conversationId}` : ""
       }`
     );


### PR DESCRIPTION
## Description

Rename URLs from /assistant to /agent on main and chat pages; add legacy redirect from /assistant to /agent (excluding API).
Issue : https://github.com/dust-tt/tasks/issues/4281#issuecomment-3323088434
## Tests

Manual test

## Risk

## Deploy Plan

Run Front
