### PR TITLE
[front] - fix(AB): tools filtering logic

### DIFF
--- a/front/components/agent_builder/capabilities/AgentBuilderCapabilitiesBlock.tsx
+++ b/front/components/agent_builder/capabilities/AgentBuilderCapabilitiesBlock.tsx
@@ -354,7 +354,7 @@ export function AgentBuilderCapabilitiesBlock({
         mode={dialogMode}
         onModeChange={setDialogMode}
         onActionUpdate={handleMcpActionUpdate}
-        actions={fields}
+        selectedActions={fields}
         getAgentInstructions={getAgentInstructions}
       />
     </AgentBuilderSectionContainer>

--- a/front/components/agent_builder/capabilities/mcp/MCPServerViewsSheet.tsx
+++ b/front/components/agent_builder/capabilities/mcp/MCPServerViewsSheet.tsx
@@ -21,8 +21,8 @@ import { useAgentBuilderContext } from "@app/components/agent_builder/AgentBuild
 import type {
   AgentBuilderFormData,
   MCPFormData,
+  MCPServerConfigurationType,
 } from "@app/components/agent_builder/AgentBuilderFormContext";
-import type { MCPServerConfigurationType } from "@app/components/agent_builder/AgentBuilderFormContext";
 import { MCPActionHeader } from "@app/components/agent_builder/capabilities/mcp/MCPActionHeader";
 import { MCPServerInfoPage } from "@app/components/agent_builder/capabilities/mcp/MCPServerInfoPage";
 import { MCPServerSelectionPage } from "@app/components/agent_builder/capabilities/mcp/MCPServerSelectionPage";
@@ -186,16 +186,16 @@ export function MCPServerViewsSheet({
         }
       }
 
-      // Legacy check for backward compatibility - tools can still be filtered by name/configurability
+      // Avoid name-based filtering to prevent collisions with user-defined action names.
+      // For backward compatibility with older actions, only filter if there is an MCP action
+      // explicitly tied to this server view and that action is non-configurable.
       const selectedAction = actions.find(
-        (action) => action.name === view.server.name
+        (action) =>
+          action.type === "MCP" &&
+          action.configuration &&
+          action.configuration.mcpServerViewId === view.sId
       );
-
-      if (selectedAction) {
-        return !selectedAction.configurable; // Should filter out if not configurable
-      }
-
-      return false;
+      return !!selectedAction;
     },
     []
   );

--- a/front/components/agent_builder/capabilities/mcp/MCPServerViewsSheet.tsx
+++ b/front/components/agent_builder/capabilities/mcp/MCPServerViewsSheet.tsx
@@ -167,28 +167,8 @@ export function MCPServerViewsSheet({
 
   const hasReasoningModel = reasoningModels.length > 0;
 
-  // Utility function to check if a server view should be filtered out based on allowMultipleInstances
   const shouldFilterServerView = useCallback(
     (view: MCPServerViewTypeWithLabel, actions: AgentBuilderAction[]) => {
-      // For servers that don't allow multiple instances, check if any action is using this server type
-      if (!view.server.allowMultipleInstances) {
-        const serverAlreadyUsed = actions.some((action) => {
-          // Check if this is an MCP action with the same server ID
-          return (
-            action.type === "MCP" &&
-            action.configuration &&
-            action.configuration.mcpServerViewId === view.sId
-          );
-        });
-
-        if (serverAlreadyUsed) {
-          return true;
-        }
-      }
-
-      // Avoid name-based filtering to prevent collisions with user-defined action names.
-      // For backward compatibility with older actions, only filter if there is an MCP action
-      // explicitly tied to this server view and that action is non-configurable.
       const selectedAction = actions.find(
         (action) =>
           action.type === "MCP" &&

--- a/front/lib/models/assistant/tag_agent.ts
+++ b/front/lib/models/assistant/tag_agent.ts
@@ -1,4 +1,9 @@
-import type { BelongsToGetAssociationMixin, CreationOptional, ForeignKey, NonAttribute, } from "sequelize";
+import type {
+  BelongsToGetAssociationMixin,
+  CreationOptional,
+  ForeignKey,
+  NonAttribute,
+} from "sequelize";
 import { DataTypes } from "sequelize";
 
 import { AgentConfiguration } from "@app/lib/models/assistant/agent";


### PR DESCRIPTION
## Description

This PR eliminates name-based filtering for MCP server views to prevent conflicts with user-defined action names. Instead we introduce a condition to filter out server views tied to specific non-configurable MCP actions

**References:**
- https://github.com/dust-tt/tasks/issues/4358

## Tests

Locally tested: 
- Adding one search tool named "Notion" -> trying to add a "Notion" tool ✅ 
- Adding one search tool named "Notion" -> trying to add a "Notion" tool -> trying to add another "Notion" tool ❌ 

## Risk

Low

## Deploy Plan

Deploy front
