### PR TITLE
feat: backspace removes 1 char from mentions + opens @-dropdown

### DIFF
--- a/front/components/actions/mcp/details/MCPRunAgentActionDetails.tsx
+++ b/front/components/actions/mcp/details/MCPRunAgentActionDetails.tsx
@@ -168,9 +168,9 @@ export function MCPRunAgentActionDetails({
     const markdownCitations: { [key: string]: MarkdownCitation } = {};
     Object.entries(resultResource.resource.refs).forEach(([key, citation]) => {
       const IconComponent = getCitationIcon(
-        citation.provider, 
-        isDark, 
-        undefined, 
+        citation.provider,
+        isDark,
+        undefined,
         citation.href
       );
       markdownCitations[key] = {

--- a/front/components/assistant/conversation/AgentMessage.tsx
+++ b/front/components/assistant/conversation/AgentMessage.tsx
@@ -157,9 +157,9 @@ export function AgentMessage({
   ).reduce<Record<string, MarkdownCitation>>((acc, [key, citation]) => {
     if (citation) {
       const IconComponent = getCitationIcon(
-        citation.provider, 
-        isDark, 
-        citation.faviconUrl, 
+        citation.provider,
+        isDark,
+        citation.faviconUrl,
         citation.href
       );
       return {

--- a/front/components/assistant/conversation/input_bar/editor/extensions/MentionExtension.tsx
+++ b/front/components/assistant/conversation/input_bar/editor/extensions/MentionExtension.tsx
@@ -1,6 +1,7 @@
 import type { NodeViewProps } from "@tiptap/core";
 import type { MentionOptions } from "@tiptap/extension-mention";
 import Mention from "@tiptap/extension-mention";
+import { TextSelection } from "@tiptap/pm/state";
 import type { PasteRuleMatch } from "@tiptap/react";
 import { ReactNodeViewRenderer } from "@tiptap/react";
 import { nodePasteRule } from "@tiptap/react";
@@ -68,5 +69,54 @@ export const MentionExtension = Mention.extend<MentionExtensionOptions>({
     });
 
     return [pasteRule];
+  },
+
+  // Override Backspace behavior so it removes a single character from the
+  // mention label and converts the chip back to typed text (which re-triggers
+  // the @-suggestion dropdown).
+  addKeyboardShortcuts() {
+    return {
+      ...(this.parent?.() ?? {}),
+      Backspace: () =>
+        this.editor.commands.command(({ tr, state, dispatch }) => {
+          const { selection } = state;
+          const { empty, anchor } = selection;
+
+          if (!empty) {
+            return false;
+          }
+
+          let handled = false;
+
+          // Look for a mention node immediately before the caret.
+          state.doc.nodesBetween(anchor - 1, anchor, (node, pos) => {
+            if (node.type.name === this.name) {
+              handled = true;
+              const trigger = this.options.suggestion?.char ?? "@";
+              const label: string = node.attrs?.label ?? node.attrs?.id ?? "";
+
+              // Compose the raw text form and remove one character from the end.
+              const raw = `${trigger}${label}`;
+              const next = raw.length > 1 ? raw.slice(0, -1) : trigger;
+
+              tr.insertText(next, pos, pos + node.nodeSize);
+
+              // Place the caret at the end of the inserted text (before any trailing space node).
+              const selPos = pos + next.length;
+              tr.setSelection(TextSelection.create(tr.doc, selPos));
+
+              if (dispatch) {
+                dispatch(tr);
+              }
+
+              // Stop scanning further.
+              return false;
+            }
+            return undefined;
+          });
+
+          return handled;
+        }),
+    };
   },
 });

--- a/front/components/assistant/conversation/input_bar/editor/useCustomEditor.tsx
+++ b/front/components/assistant/conversation/input_bar/editor/useCustomEditor.tsx
@@ -236,7 +236,9 @@ const useCustomEditor = ({
         class:
           "min-w-0 px-0 py-0 border-none outline-none focus:outline-none focus:border-none ring-0 focus:ring-0 text-highlight-500 font-semibold",
       },
-      suggestion: suggestionHandler,
+      // Ensure queries can contain spaces (e.g., @Sales Team → decomposes to
+      // text and keeps the dropdown active over the full label).
+      suggestion: { ...suggestionHandler, allowSpaces: true },
     }),
     Placeholder.configure({
       placeholder: "Ask an @agent a question, or get some @help",


### PR DESCRIPTION
## Description

- Override MentionExtension Backspace to expand chip to text and delete 1 char.
- Set suggestion allowSpaces: true for multi‑word agent names.
- Keep trailing-space behavior (first Backspace deletes space, second peels chip).
   
Implementation for https://github.com/dust-tt/tasks/issues/4304

## Tests

Local

## Risk

Low

## Deploy Plan

deploy front