### PR TITLE
[connectors] Handle null user blobs in Gong connector

### DIFF
--- a/connectors/src/connectors/gong/lib/gong_api.ts
+++ b/connectors/src/connectors/gong/lib/gong_api.ts
@@ -15,14 +15,24 @@ import type { ModelId } from "@connectors/types";
 const CatchAllCodec = t.record(t.string, t.unknown);
 
 const GongUserCodec = t.intersection([
-  t.partial({
-    active: t.boolean,
-    created: t.string,
-    emailAddress: t.string,
-    firstName: t.string,
-    id: t.string,
-    lastName: t.string,
-  }),
+  t.union([
+    t.type({
+      active: t.undefined,
+      created: t.undefined,
+      emailAddress: t.undefined,
+      firstName: t.undefined,
+      id: t.undefined,
+      lastName: t.undefined,
+    }),
+    t.partial({
+      active: t.boolean,
+      created: t.string,
+      emailAddress: t.string,
+      firstName: t.string,
+      id: t.string,
+      lastName: t.string,
+    }),
+  ]),
   CatchAllCodec,
 ]);
 

--- a/connectors/src/connectors/gong/lib/gong_api.ts
+++ b/connectors/src/connectors/gong/lib/gong_api.ts
@@ -15,7 +15,7 @@ import type { ModelId } from "@connectors/types";
 const CatchAllCodec = t.record(t.string, t.unknown);
 
 const GongUserCodec = t.intersection([
-  t.type({
+  t.partial({
     active: t.boolean,
     created: t.string,
     emailAddress: t.string,

--- a/connectors/src/connectors/gong/lib/users.ts
+++ b/connectors/src/connectors/gong/lib/users.ts
@@ -7,7 +7,10 @@ import type { GongUserBlob } from "@connectors/resources/gong_resources";
 import { GongUserResource } from "@connectors/resources/gong_resources";
 import { concurrentExecutor } from "@connectors/types";
 
-export function getUserBlobFromGongAPI(user: GongAPIUser): GongUserBlob {
+export function getUserBlobFromGongAPI(user: GongAPIUser): GongUserBlob | null {
+  if (!user.emailAddress || !user.id) {
+    return null;
+  }
   return {
     email: user.emailAddress,
     gongId: user.id,
@@ -47,11 +50,11 @@ export async function getGongUsers(
         return null;
       }
 
-      const newUser = await GongUserResource.makeNew(
-        connector,
-        getUserBlobFromGongAPI(user)
-      );
-      users.push(newUser);
+      const userBlob = getUserBlobFromGongAPI(user);
+      if (userBlob) {
+        const newUser = await GongUserResource.makeNew(connector, userBlob);
+        users.push(newUser);
+      }
     },
     { concurrency: 10 }
   );

--- a/connectors/src/connectors/gong/temporal/activities.ts
+++ b/connectors/src/connectors/gong/temporal/activities.ts
@@ -30,6 +30,7 @@ import {
   GongUserResource,
 } from "@connectors/resources/gong_resources";
 import type { ModelId } from "@connectors/types";
+import { removeNulls } from "@connectors/types/shared/utils/general";
 
 const GARBAGE_COLLECT_BATCH_SIZE = 100;
 
@@ -275,7 +276,7 @@ export async function gongListAndSaveUsersActivity({
 
     await GongUserResource.batchCreate(
       connector,
-      users.map(getUserBlobFromGongAPI)
+      removeNulls(users.map(getUserBlobFromGongAPI))
     );
 
     pageCursor = nextPageCursor;


### PR DESCRIPTION
## Description

- We do observe some users that do not pass the current validation, logs [here](https://app.datadoghq.eu/logs?query=%28%22Activity%20failed%22%20OR%20%22Unhandled%20activity%20error%22%29%20%40attempt%3A%3E19%20%40dd.service%3Aconnectors-worker&agg_m=count&agg_m_source=base&agg_q=%40workflowId&agg_q_source=base&agg_t=count&cols=host%2Cservice&event=AwAAAZl223EKkMrCLAAAABhBWmwyMjN5WEFBQkpwMnpjbFh3V3pBQUMAAAAkZjE5OTc2ZGQtZjExZS00Y2RjLTgyZGUtOTk5MmViNTc2YTFhAAFs5Q&graphType=flamegraph&messageDisplay=inline&refresh_mode=sliding&sort=time&spanID=6000198897476506285&storage=hot&stream_sort=time%2Cdesc&top_n=10&top_o=top&viz=stream&x_missing=true&from_ts=1758632266927&to_ts=1758635866927&live=true).
- This PR relaxes the validation, and skips those.

## Tests

- Tested locally.

## Risk

- Low.

## Deploy Plan

- Deploy connectors.
- Restart the connector if the cursor expired.
