### PR TITLE
[front] Improve Poke data source page subtitle

### DIFF
--- a/front/pages/poke/[wId]/data_sources/[dsId]/index.tsx
+++ b/front/pages/poke/[wId]/data_sources/[dsId]/index.tsx
@@ -564,7 +564,7 @@ const DataSourcePage = ({
       </h3>
       {dataSource.connectorProvider && (
         <p>
-          The data displayed here is fetched from <b>connectors</b>, please{" "}
+          The data displayed here is fetched from <b>connectors</b>, please
           refer to the method {capitalize(dataSource.connectorProvider)}
           ConnectorManager.retrievePermissions
         </p>

--- a/front/pages/poke/[wId]/data_sources/[dsId]/index.tsx
+++ b/front/pages/poke/[wId]/data_sources/[dsId]/index.tsx
@@ -564,7 +564,7 @@ const DataSourcePage = ({
       </h3>
       {dataSource.connectorProvider && (
         <p>
-          The data displayed here is fetched from <b>connectors</b>, please
+          The data displayed here is fetched from <b>connectors</b>, please{" "}
           refer to the method {capitalize(dataSource.connectorProvider)}
           ConnectorManager.retrievePermissions
         </p>

--- a/front/pages/poke/[wId]/data_sources/[dsId]/index.tsx
+++ b/front/pages/poke/[wId]/data_sources/[dsId]/index.tsx
@@ -13,6 +13,7 @@ import {
   Tooltip,
 } from "@dust-tt/sparkle";
 import { JsonViewer } from "@textea/json-viewer";
+import capitalize from "lodash/capitalize";
 import type { InferGetServerSidePropsType } from "next";
 import { useRouter } from "next/router";
 import { useEffect, useState } from "react";
@@ -561,9 +562,13 @@ const DataSourcePage = ({
           {owner.name}
         </a>
       </h3>
-      <p>
-        The data displayed here is fetched from <b>connectors</b>.
-      </p>
+      {dataSource.connectorProvider && (
+        <p>
+          The data displayed here is fetched from <b>connectors</b>, please
+          refer to the method {capitalize(dataSource.connectorProvider)}
+          ConnectorManager.retrievePermissions
+        </p>
+      )}
 
       <div className="flex flex-row gap-x-6">
         <ViewDataSourceTable


### PR DESCRIPTION
## Description

This PR aims at improving the message that appears under the title of the Poke data source page in two ways: hide it for folders (currently it says that the data is fetched from connectors, which doesn't apply to folders), and point to the relevant method.

<img width="829" height="237" alt="Screenshot 2025-09-23 at 7 52 52 PM" src="https://github.com/user-attachments/assets/ad611e38-9b33-40aa-b53e-9e1ae3585f09" />

## Tests

- Checked locally.

## Risk

- None.

## Deploy Plan

- Deploy front.
