### PR TITLE
[front] Handle duplicate agent loop workflows on retries

### DIFF
--- a/front/lib/api/assistant/agent.ts
+++ b/front/lib/api/assistant/agent.ts
@@ -11,6 +11,7 @@ import {
   LONG_RUNNING_TOOL_THRESHOLD_MS,
   SYNC_TO_ASYNC_TIMEOUT_MS,
 } from "@app/lib/constants/timeouts";
+import type { DustError } from "@app/lib/error";
 import { ConversationResource } from "@app/lib/resources/conversation_resource";
 import { wakeLock } from "@app/lib/wake_lock";
 import {
@@ -227,7 +228,7 @@ export async function runAgentLoop(
     executionMode?: ExecutionMode;
     startStep: number;
   }
-): Promise<Result<undefined, Error>> {
+): Promise<Result<undefined, Error | DustError<"agent_loop_already_running">>> {
   const authType = auth.toJSON();
 
   // Capture initial start time and log total execution start.

--- a/front/lib/api/assistant/agent.ts
+++ b/front/lib/api/assistant/agent.ts
@@ -221,7 +221,12 @@ export async function runAgentLoop(
   {
     executionMode = "auto",
     startStep,
-  }: { executionMode?: ExecutionMode; startStep: number }
+    ignoreExistingWorkflow = false,
+  }: {
+    executionMode?: ExecutionMode;
+    startStep: number;
+    ignoreExistingWorkflow?: boolean;
+  }
 ): Promise<void> {
   const authType = auth.toJSON();
 
@@ -266,6 +271,7 @@ export async function runAgentLoop(
       runAsynchronousAgentArgs: runAgentArgsWithTiming.idArgs,
       startStep,
       initialStartTime: runAgentArgsWithTiming.initialStartTime,
+      ignoreExistingWorkflow,
     });
   }
 }

--- a/front/lib/api/assistant/agent.ts
+++ b/front/lib/api/assistant/agent.ts
@@ -29,6 +29,8 @@ import {
   SyncTimeoutError,
 } from "@app/temporal/agent_loop/lib/agent_loop_executor";
 import { launchUpdateUsageWorkflow } from "@app/temporal/usage_queue/client";
+import type { Result } from "@app/types";
+import { Ok } from "@app/types";
 import type { AgentConfigurationType } from "@app/types/assistant/agent";
 import type {
   ExecutionMode,
@@ -221,13 +223,11 @@ export async function runAgentLoop(
   {
     executionMode = "auto",
     startStep,
-    ignoreExistingWorkflow = false,
   }: {
     executionMode?: ExecutionMode;
     startStep: number;
-    ignoreExistingWorkflow?: boolean;
   }
-): Promise<void> {
+): Promise<Result<undefined, Error>> {
   const authType = auth.toJSON();
 
   // Capture initial start time and log total execution start.
@@ -266,12 +266,13 @@ export async function runAgentLoop(
       startStep,
     });
   } else {
-    await launchAgentLoopWorkflow({
+    return launchAgentLoopWorkflow({
       authType,
       runAsynchronousAgentArgs: runAgentArgsWithTiming.idArgs,
       startStep,
       initialStartTime: runAgentArgsWithTiming.initialStartTime,
-      ignoreExistingWorkflow,
     });
   }
+
+  return new Ok(undefined);
 }

--- a/front/lib/api/assistant/conversation/retry_blocked_actions.ts
+++ b/front/lib/api/assistant/conversation/retry_blocked_actions.ts
@@ -146,6 +146,7 @@ export async function retryBlockedActions(
     {
       // Resume from the step where the action was created.
       startStep: lastStep,
+      ignoreExistingWorkflow: true,
     }
   );
 

--- a/front/lib/api/assistant/conversation/retry_blocked_actions.ts
+++ b/front/lib/api/assistant/conversation/retry_blocked_actions.ts
@@ -3,6 +3,7 @@ import { runAgentLoop } from "@app/lib/api/assistant/agent";
 import { getMessageChannelId } from "@app/lib/api/assistant/streaming/helpers";
 import { getRedisHybridManager } from "@app/lib/api/redis-hybrid-manager";
 import type { Authenticator } from "@app/lib/auth";
+import type { DustError } from "@app/lib/error";
 import { Message } from "@app/lib/models/assistant/conversation";
 import { AgentMCPActionResource } from "@app/lib/resources/agent_mcp_action_resource";
 import logger from "@app/logger/logger";
@@ -91,7 +92,7 @@ export async function retryBlockedActions(
   }: {
     messageId: string;
   }
-): Promise<Result<void, Error>> {
+): Promise<Result<void, Error | DustError<"agent_loop_already_running">>> {
   const { sId: conversationId, title: conversationTitle } = conversation;
 
   const getUserMessageIdRes = await findUserMessageForRetry(

--- a/front/lib/api/assistant/conversation/retry_blocked_actions.ts
+++ b/front/lib/api/assistant/conversation/retry_blocked_actions.ts
@@ -137,7 +137,7 @@ export async function retryBlockedActions(
     return runAgentDataRes;
   }
 
-  await runAgentLoop(
+  return runAgentLoop(
     auth,
     {
       sync: true,
@@ -146,9 +146,6 @@ export async function retryBlockedActions(
     {
       // Resume from the step where the action was created.
       startStep: lastStep,
-      ignoreExistingWorkflow: true,
     }
   );
-
-  return new Ok(undefined);
 }

--- a/front/lib/error.ts
+++ b/front/lib/error.ts
@@ -6,6 +6,7 @@ export type DustErrorCode =
   | "connection_not_found"
   | "file_not_found"
   | "unauthorized"
+  | "agent_loop_already_running"
   // Data source
   | "data_source_error"
   | "data_source_quota_error"

--- a/front/pages/api/w/[wId]/assistant/conversations/[cId]/messages/[mId]/retry.ts
+++ b/front/pages/api/w/[wId]/assistant/conversations/[cId]/messages/[mId]/retry.ts
@@ -94,6 +94,9 @@ async function handler(
           logger.error(
             {
               error,
+              workspaceId: auth.getNonNullableWorkspace().sId,
+              conversationId,
+              messageId,
             },
             "Error retrying blocked actions"
           );

--- a/front/pages/api/w/[wId]/assistant/conversations/[cId]/messages/[mId]/retry.ts
+++ b/front/pages/api/w/[wId]/assistant/conversations/[cId]/messages/[mId]/retry.ts
@@ -91,15 +91,6 @@ async function handler(
 
         if (retryBlockedActionsRes.isErr()) {
           const { error } = retryBlockedActionsRes;
-          logger.error(
-            {
-              error,
-              workspaceId: auth.getNonNullableWorkspace().sId,
-              conversationId,
-              messageId,
-            },
-            "Error retrying blocked actions"
-          );
 
           if (
             error instanceof DustError &&

--- a/front/pages/api/w/[wId]/assistant/conversations/[cId]/messages/[mId]/retry.ts
+++ b/front/pages/api/w/[wId]/assistant/conversations/[cId]/messages/[mId]/retry.ts
@@ -8,7 +8,6 @@ import { retryBlockedActions } from "@app/lib/api/assistant/conversation/retry_b
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
 import type { Authenticator } from "@app/lib/auth";
 import { DustError } from "@app/lib/error";
-import logger from "@app/logger/logger";
 import { apiError } from "@app/logger/withlogging";
 import type { AgentMessageType, WithAPIErrorResponse } from "@app/types";
 import { isAgentMessageType, isString } from "@app/types";


### PR DESCRIPTION
## Description

- This PR handles workflows already running as a 400 in the retry endpoint.
- These errors are currently not handled.

## Tests

- Tested locally.

## Risk

- Low, only a status code change.
- No deterministic error expected as the workflow code remains unchanged.

## Deploy Plan

- Deploy front.
