### PR TITLE
[front] Add partial indexes on membership model

### DIFF
--- a/front/lib/resources/storage/models/membership.ts
+++ b/front/lib/resources/storage/models/membership.ts
@@ -56,6 +56,11 @@ MembershipModel.init(
       { fields: ["startAt"] },
       { fields: ["endAt"] },
       { fields: ["workspaceId", "userId", "startAt", "endAt"] },
+      { fields: ["workspaceId", "endAt"] },
+      {
+        fields: ["workspaceId", "startAt"],
+        where: { endAt: null },
+      },
     ],
   }
 );

--- a/front/migrations/db/migration_366.sql
+++ b/front/migrations/db/migration_366.sql
@@ -1,0 +1,9 @@
+-- Migration created on Sep 23, 2025
+CREATE INDEX CONCURRENTLY "memberships_workspace_id_end_at"
+    ON "memberships" ("workspaceId", "endAt")
+    INCLUDE ("startAt", "userId");
+
+CREATE INDEX CONCURRENTLY "memberships_workspace_id_start_at_end_at_null"
+    ON "memberships" ("workspaceId", "startAt")
+    INCLUDE ("userId")
+    WHERE "endAt" IS NULL;


### PR DESCRIPTION
## Description

- The goal is to optimize [this query](https://console.cloud.google.com/sql/instances/cell-00000-front-db/insights;database=front;duration=PT1H;trace=86629680523ac112a34a968e9e8252ed;span=51c542c95c9d9ec9;query_hash=15698711097219184569;sort_by=TOTAL_EXEC_TIME/executed?project=or1g1n-186209), which has a nasty query plan by adding partial indexes that target specifically the 2 cases in the query (`endAt` `null` or not).
- Still WIP, some changes were made yesterday and we probably need to wait for a bit more sampling, to revisit at EOD.

## Tests

## Risk

- Should be relatively lightweight in storage.

## Deploy Plan

- Run migration.
- Deploy front.
