### PR TITLE
[front] Untrack "no data source" error in MCP actions

### DIFF
--- a/front/lib/actions/mcp_internal_actions/servers/data_sources_file_system.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/data_sources_file_system.ts
@@ -191,7 +191,10 @@ async function searchCallback(
   if (coreSearchArgs.length === 0) {
     return new Err(
       new MCPError(
-        "Search action must have at least one data source configured."
+        "Search action must have at least one data source configured.",
+        {
+          tracked: false,
+        }
       )
     );
   }

--- a/front/lib/actions/mcp_internal_actions/servers/search.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/search.ts
@@ -101,7 +101,10 @@ export async function searchFunction({
   if (coreSearchArgs.length === 0) {
     return new Err(
       new MCPError(
-        "Search action must have at least one data source configured."
+        "Search action must have at least one data source configured.",
+        {
+          tracked: false,
+        }
       )
     );
   }

--- a/front/lib/actions/mcp_internal_actions/tools/tags/find_tags.ts
+++ b/front/lib/actions/mcp_internal_actions/tools/tags/find_tags.ts
@@ -91,7 +91,10 @@ export function registerFindTagsTool(
         if (coreSearchArgs.length === 0) {
           return new Err(
             new MCPError(
-              "Search action must have at least one data source configured."
+              "Search action must have at least one data source configured.",
+              {
+                tracked: false,
+              }
             )
           );
         }


### PR DESCRIPTION
## Description

- This PR prevents `"Search action must have at least one data source configured."` from triggering the monitor, as those are not actionable on our end ([logs](https://app.datadoghq.eu/logs?query=%40toolName%3Asemantic_search%20%22Tool%20execution%20error%22%20%40error%3A%2ASearch%5C%20action%5C%20must%5C%20have%5C%20at%5C%20least%5C%20one%5C%20data%5C%20source%5C%20configured.%2A&agg_m=count&agg_m_source=base&agg_t=count&clustering_pattern_field_path=message&cols=host%2Cservice&fromUser=true&graphType=flamegraph&messageDisplay=inline&refresh_mode=sliding&sort=time&spanID=6000198897476506285&storage=hot&stream_sort=time%2Cdesc&viz=stream&from_ts=1731920961786&to_ts=1732525761786&live=true)).
- The error is still exposed to the model, which can relay it to the user.

## Tests

## Risk

- Low, only affects monitoring.

## Deploy Plan

- Deploy front.
