### PR TITLE
[front] Wrap words in Poke `Extension blacklisted domains/URLs` cell

### DIFF
--- a/front/components/poke/workspace/table.tsx
+++ b/front/components/poke/workspace/table.tsx
@@ -134,7 +134,7 @@ export function WorkspaceInfoTable({
             </PokeTableRow>
             <PokeTableRow>
               <PokeTableCell>Verified Domains</PokeTableCell>
-              <PokeTableCell>
+              <PokeTableCell className="max-w-sm break-words">
                 {workspaceVerifiedDomains.map((d) => d.domain).join(", ")}
               </PokeTableCell>
             </PokeTableRow>
@@ -142,7 +142,7 @@ export function WorkspaceInfoTable({
               <PokeTableCell className="max-w-48">
                 Extension blacklisted domains/URLs
               </PokeTableCell>
-              <PokeTableCell>
+              <PokeTableCell className="max-w-sm break-words">
                 {extensionConfig?.blacklistedDomains.length
                   ? extensionConfig.blacklistedDomains.join(", ")
                   : "None"}

--- a/front/components/poke/workspace/table.tsx
+++ b/front/components/poke/workspace/table.tsx
@@ -65,7 +65,7 @@ export function WorkspaceInfoTable({
   };
   return (
     <div className="flex justify-between gap-3">
-      <div className="border-material-200 flex flex-grow flex-col rounded-lg border p-4">
+      <div className="border-material-200 flex flex-grow flex-col rounded-lg border p-4 pb-2">
         <div className="flex items-center justify-between gap-3">
           <h2 className="text-md flex-grow pb-4 font-bold">Workspace info</h2>
         </div>


### PR DESCRIPTION
## Description

- In the poke workspace page, the `WorkspaceTableInfo` can become arbitrarily wide if there are too many URLs or domains in the `Extension blacklisted domains/URLs` cell.
- This PR adds word wrapping (usually there are many or relatively small ones), which can be ugly but is more easily usable that having a super thin column for the plugin list.
- This PR also improves the padding at the bottom of the `WorkspaceTableInfo`.

Before
<img width="862" height="532" alt="Screenshot 2025-09-24 at 8 20 36 AM" src="https://github.com/user-attachments/assets/698640ff-f144-4f3c-9e8c-b4c243165bf8" />

After
<img width="502" height="532" alt="Screenshot 2025-09-24 at 8 20 00 AM" src="https://github.com/user-attachments/assets/53dd9ff5-b45b-4019-88c8-5157fed5446d" />

## Tests

- Checked locally.

## Risk

- None.

## Deploy Plan

- Deploy front.
