### PR TITLE
[front] Add error logging for failed agent action configuration creation

### DIFF
--- a/front/pages/api/w/[wId]/assistant/agent_configurations/index.ts
+++ b/front/pages/api/w/[wId]/assistant/agent_configurations/index.ts
@@ -338,6 +338,7 @@ export async function createOrUpgradeAgentConfiguration({
           error: res.error,
           agentConfigurationId: agentConfigurationRes.value.sId,
           workspaceId: auth.getNonNullableWorkspace().sId,
+          mcpServerViewId: action.mcpServerViewId,
         },
         "Failed to create agent action configuration."
       );

--- a/front/pages/api/w/[wId]/assistant/agent_configurations/index.ts
+++ b/front/pages/api/w/[wId]/assistant/agent_configurations/index.ts
@@ -22,6 +22,7 @@ import { AgentMessageFeedbackResource } from "@app/lib/resources/agent_message_f
 import { KillSwitchResource } from "@app/lib/resources/kill_switch_resource";
 import { UserResource } from "@app/lib/resources/user_resource";
 import { ServerSideTracking } from "@app/lib/tracking/server";
+import logger from "@app/logger/logger";
 import { apiError } from "@app/logger/withlogging";
 import type {
   AgentConfigurationType,
@@ -332,6 +333,14 @@ export async function createOrUpgradeAgentConfiguration({
       agentConfigurationRes.value
     );
     if (res.isErr()) {
+      logger.error(
+        {
+          error: res.error,
+          agentConfigurationId: agentConfigurationRes.value.sId,
+          workspaceId: auth.getNonNullableWorkspace().sId,
+        },
+        "Failed to create agent action configuration."
+      );
       // If we fail to create an action, we should delete the agent configuration
       // we just created and re-throw the error.
       await unsafeHardDeleteAgentConfiguration(agentConfigurationRes.value);


### PR DESCRIPTION
## Description

- We have some errors in [the logs](https://app.datadoghq.eu/logs?query=%22Unhandled%20API%20Error%22%20region%3Aeurope-west1&agg_m=count&agg_m_source=base&agg_q=service&agg_q_source=base&agg_t=count&cols=host%2Cservice&event=AwAAAZl3FQ3mapaHXQAAABhBWmwzRlJia0FBQ1RMV29PMnRXLUNRQW4AAAAkZjE5OTc3MTUtMzdkYi00NTg5LTkzMGUtZTJmYTcxODUxMTAxAAJ80g&fromUser=true&link_source=monitor_notif&messageDisplay=inline&refresh_mode=sliding&storage=hot&stream_sort=desc&top_n=10&top_o=top&viz=stream&x_missing=true&from_ts=1758639240000&to_ts=1758639540000&live=false) where the `unsafeHardDeleteAgentConfiguration` fails.
- This PR adds a log to understand why we end up in this code path in the first place.

## Tests

## Risk

- Low.

## Deploy Plan

- Deploy front.
