### PR TITLE
[front] Fix `unsafeHardDeleteAgentConfiguration`

### DIFF
--- a/front/lib/api/assistant/configuration/agent.ts
+++ b/front/lib/api/assistant/configuration/agent.ts
@@ -1029,15 +1029,18 @@ export async function unsafeHardDeleteAgentConfiguration(
   auth: Authenticator,
   agentConfiguration: LightAgentConfigurationType
 ): Promise<void> {
+  const workspaceId = auth.getNonNullableWorkspace().id;
+
   await GroupAgentModel.destroy({
     where: {
       agentConfigurationId: agentConfiguration.id,
-      workspaceId: auth.getNonNullableWorkspace().id,
+      workspaceId,
     },
   });
   await AgentConfiguration.destroy({
     where: {
       id: agentConfiguration.id,
+      workspaceId,
     },
   });
 }

--- a/front/lib/api/assistant/configuration/agent.ts
+++ b/front/lib/api/assistant/configuration/agent.ts
@@ -29,6 +29,7 @@ import {
   AgentConfiguration,
   AgentUserRelation,
 } from "@app/lib/models/assistant/agent";
+import { GroupAgentModel } from "@app/lib/models/assistant/group_agent";
 import { TagAgentModel } from "@app/lib/models/assistant/tag_agent";
 import { DataSourceViewResource } from "@app/lib/resources/data_source_view_resource";
 import { GroupResource } from "@app/lib/resources/group_resource";
@@ -1025,8 +1026,15 @@ export async function restoreAgentConfiguration(
 // Should only be called when we need to clean up the agent configuration
 // right after creating it due to an error.
 export async function unsafeHardDeleteAgentConfiguration(
+  auth: Authenticator,
   agentConfiguration: LightAgentConfigurationType
 ): Promise<void> {
+  await GroupAgentModel.destroy({
+    where: {
+      agentConfigurationId: agentConfiguration.id,
+      workspaceId: auth.getNonNullableWorkspace().id,
+    },
+  });
   await AgentConfiguration.destroy({
     where: {
       id: agentConfiguration.id,

--- a/front/pages/api/w/[wId]/assistant/agent_configurations/index.ts
+++ b/front/pages/api/w/[wId]/assistant/agent_configurations/index.ts
@@ -334,7 +334,10 @@ export async function createOrUpgradeAgentConfiguration({
     if (res.isErr()) {
       // If we fail to create an action, we should delete the agent configuration
       // we just created and re-throw the error.
-      await unsafeHardDeleteAgentConfiguration(agentConfigurationRes.value);
+      await unsafeHardDeleteAgentConfiguration(
+        auth,
+        agentConfigurationRes.value
+      );
       return res;
     }
     actionConfigs.push(res.value);


### PR DESCRIPTION
## Description

- When creating an agent configuration we create the corresponding `group_agent` right after.
- This PR adds a deletion on the newly created `group_agent` in the `unsafeHardDeleteAgentConfiguration` (logs [here](https://app.datadoghq.eu/logs?query=%22Unhandled%20API%20Error%22%20region%3Aeurope-west1&agg_m=count&agg_m_source=base&agg_q=service&agg_q_source=base&agg_t=count&cols=host%2Cservice&event=AwAAAZl3FQ3mapaHXQAAABhBWmwzRlJia0FBQ1RMV29PMnRXLUNRQW4AAAAkZjE5OTc3MTUtMzdkYi00NTg5LTkzMGUtZTJmYTcxODUxMTAxAAJ80g&fromUser=true&link_source=monitor_notif&messageDisplay=inline&refresh_mode=sliding&storage=hot&stream_sort=desc&top_n=10&top_o=top&viz=stream&x_missing=true&from_ts=1758639240000&to_ts=1758639540000&live=false)).
- Investigating in parallel why we end up in this code path in the first place, adding a log in https://github.com/dust-tt/dust/pull/16206.

## Tests

## Risk

- Low.

## Deploy Plan

- Deploy front.
