### PR TITLE
[Growth] Add postHog tracking

### DIFF
--- a/front/components/home/menu/FooterNavigation.tsx
+++ b/front/components/home/menu/FooterNavigation.tsx
@@ -36,8 +36,8 @@ export function FooterNavigation() {
               {item?.items?.length &&
                 item.items
                   .filter((item) => item.title.trim() !== "")
-                  .map((item) => (
-                    <React.Fragment key={item.href}>
+                  .map((item, itemIndex) => (
+                    <React.Fragment key={item.href ?? `item-${itemIndex}`}>
                       {item.href ? (
                         <FooterLink
                           href={item.href}

--- a/front/components/home/menu/MainNavigation.tsx
+++ b/front/components/home/menu/MainNavigation.tsx
@@ -60,9 +60,9 @@ export function MainNavigation() {
                         )}
                       >
                         {item.items &&
-                          item.items.map((item) => (
+                          item.items.map((item, itemIndex) => (
                             <ListItem
-                              key={item.title}
+                              key={item.title || `spacer-${itemIndex}`}
                               title={item.title}
                               href={item.href}
                               isExternal={item.isExternal}

--- a/front/components/home/menu/MobileNavigation.tsx
+++ b/front/components/home/menu/MobileNavigation.tsx
@@ -68,8 +68,8 @@ export function MobileNavigation() {
                     </div>
                   )}
                   {item?.items?.length &&
-                    item.items.map((item) => (
-                      <React.Fragment key={item.href}>
+                    item.items.map((item, itemIndex) => (
+                      <React.Fragment key={item.href ?? `item-${itemIndex}`}>
                         {item.href ? (
                           <MobileLink
                             href={item.href}

--- a/front/next.config.js
+++ b/front/next.config.js
@@ -126,6 +126,7 @@ module.exports = {
     ];
   },
   poweredByHeader: false,
+  skipTrailingSlashRedirect: true,
   async headers() {
     return [
       {
@@ -154,6 +155,15 @@ module.exports = {
       {
         source: "/api/v1/w/:wId/vaults",
         destination: "/api/v1/w/:wId/spaces",
+      },
+      // Posthog tracking
+      {
+        source: "/ingest/static/:path*",
+        destination: "https://eu-assets.i.posthog.com/static/:path*",
+      },
+      {
+        source: "/ingest/:path*",
+        destination: "https://eu.i.posthog.com/:path*",
       },
     ];
   },

--- a/front/package-lock.json
+++ b/front/package-lock.json
@@ -98,6 +98,8 @@
         "pino": "^8.11.0",
         "pino-pretty": "^10.0.0",
         "pkce-challenge": "^4.1.0",
+        "posthog-js": "^1.266.1",
+        "posthog-node": "^5.8.5",
         "prosemirror-markdown": "^1.13.1",
         "react": "^18.3.1",
         "react-beforeunload": "^2.5.3",
@@ -4008,6 +4010,12 @@
         "type": "opencollective",
         "url": "https://opencollective.com/popperjs"
       }
+    },
+    "node_modules/@posthog/core": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@posthog/core/-/core-1.1.0.tgz",
+      "integrity": "sha512-igElrcnRPJh2nWYACschjH4OwGwzSa6xVFzRDVzpnjirUivdJ8nv4hE+H31nvwE56MFhvvglfHuotnWLMcRW7w==",
+      "license": "MIT"
     },
     "node_modules/@protobufjs/aspromise": {
       "version": "1.1.2",
@@ -12123,7 +12131,9 @@
       }
     },
     "node_modules/core-js": {
-      "version": "3.35.0",
+      "version": "3.45.1",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.45.1.tgz",
+      "integrity": "sha512-L4NPsJlCfZsPeXukyzHFlg/i7IIVwHSItR0wg0FLNqYClJ4MQYTYLbC7EkjKYRLZF2iof2MUgN0EGy7MdQFChg==",
       "hasInstallScript": true,
       "license": "MIT",
       "funding": {
@@ -23104,10 +23114,63 @@
       "integrity": "sha512-i/hbxIE9803Alj/6ytL7UHQxRvZkI9O4Sy+J3HGc4F4oo/2eQAjTSNJ0bfxyse3bH0nuVesCk+3IRLaMtG3H6w==",
       "dev": true
     },
+    "node_modules/posthog-js": {
+      "version": "1.266.1",
+      "resolved": "https://registry.npmjs.org/posthog-js/-/posthog-js-1.266.1.tgz",
+      "integrity": "sha512-Ei9Fu/IpvBZ1tVn92XRhfXjG7Uakgf0CZbxBI9EZZZoLIR/NjJjwjnQSGEg8Hndv1cCP4HrXj+8ae3fb+EQjng==",
+      "license": "SEE LICENSE IN LICENSE",
+      "dependencies": {
+        "@posthog/core": "1.1.0",
+        "core-js": "^3.38.1",
+        "fflate": "^0.4.8",
+        "preact": "^10.19.3",
+        "web-vitals": "^4.2.4"
+      },
+      "peerDependencies": {
+        "@rrweb/types": "2.0.0-alpha.17",
+        "rrweb-snapshot": "2.0.0-alpha.17"
+      },
+      "peerDependenciesMeta": {
+        "@rrweb/types": {
+          "optional": true
+        },
+        "rrweb-snapshot": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/posthog-js/node_modules/fflate": {
+      "version": "0.4.8",
+      "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.4.8.tgz",
+      "integrity": "sha512-FJqqoDBR00Mdj9ppamLa/Y7vxm+PRmNWA67N846RvsoYVMKB4q3y/de5PA7gUmRMYK/8CMz2GDZQmCRN1wBcWA==",
+      "license": "MIT"
+    },
+    "node_modules/posthog-node": {
+      "version": "5.8.5",
+      "resolved": "https://registry.npmjs.org/posthog-node/-/posthog-node-5.8.5.tgz",
+      "integrity": "sha512-qX/Oq6vTQZvlkieYxyzuWUaFoOgHATdxxqK6iRqTYiS02PotQ2S7iDUMQoj6yZ7McN4OJbN3/VxUU3pkORqlLg==",
+      "license": "MIT",
+      "dependencies": {
+        "@posthog/core": "1.1.0"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
     "node_modules/pprof-format": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/pprof-format/-/pprof-format-2.1.0.tgz",
       "integrity": "sha512-0+G5bHH0RNr8E5hoZo/zJYsL92MhkZjwrHp3O2IxmY8RJL9ooKeuZ8Tm0ZNBw5sGZ9TiM71sthTjWoR2Vf5/xw=="
+    },
+    "node_modules/preact": {
+      "version": "10.27.2",
+      "resolved": "https://registry.npmjs.org/preact/-/preact-10.27.2.tgz",
+      "integrity": "sha512-5SYSgFKSyhCbk6SrXyMpqjb5+MQBgfvEKE/OC+PujcY34sOpqtr+0AZQtPYx5IA6VxynQ7rUPCtKzyovpj9Bpg==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/preact"
+      }
     },
     "node_modules/prebuild-install": {
       "version": "7.1.2",
@@ -28779,6 +28842,12 @@
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
       }
+    },
+    "node_modules/web-vitals": {
+      "version": "4.2.4",
+      "resolved": "https://registry.npmjs.org/web-vitals/-/web-vitals-4.2.4.tgz",
+      "integrity": "sha512-r4DIlprAGwJ7YM11VZp4R884m0Vmgr6EAKe3P+kO0PPj3Unqyvv59rczf6UiGcb9Z8QxZVcqKNwv/g0WNdWwsw==",
+      "license": "Apache-2.0"
     },
     "node_modules/webcrypto-core": {
       "version": "1.8.1",

--- a/front/package.json
+++ b/front/package.json
@@ -118,6 +118,8 @@
     "pino": "^8.11.0",
     "pino-pretty": "^10.0.0",
     "pkce-challenge": "^4.1.0",
+    "posthog-js": "^1.266.1",
+    "posthog-node": "^5.8.5",
     "prosemirror-markdown": "^1.13.1",
     "react": "^18.3.1",
     "react-beforeunload": "^2.5.3",

--- a/front/pages/_app.tsx
+++ b/front/pages/_app.tsx
@@ -19,12 +19,6 @@ import { useEffect } from "react";
 const NEXT_PUBLIC_POSTHOG_KEY = process.env.NEXT_PUBLIC_POSTHOG_KEY;
 const NODE_ENV = process.env.NODE_ENV;
 
-// Log PostHog configuration for debugging
-console.log("[PostHog] Environment check:", {
-  hasKey: !!NEXT_PUBLIC_POSTHOG_KEY,
-  keyLength: NEXT_PUBLIC_POSTHOG_KEY?.length ?? 0,
-  nodeEnv: NODE_ENV,
-});
 import { useCookies } from "react-cookie";
 
 import RootLayout from "@app/components/app/RootLayout";
@@ -79,26 +73,19 @@ export default function App({ Component, pageProps }: AppPropsWithLayout) {
           person_profiles: "identified_only",
           defaults: "2025-05-24",
           loaded: (posthog) => {
-            console.log("[PostHog] Successfully loaded");
             if (NODE_ENV === "development") {
               posthog.debug();
             }
           },
         });
       } else if (posthog.__loaded) {
-        console.log("[PostHog] Already loaded, re-enabling capturing");
         // Re-enable capturing if previously opted out
         posthog.opt_in_capturing();
       } else {
-        console.log("[PostHog] Not initializing - no key available");
+        console.log("[PH] Not initializing - no key available");
       }
     } else {
       // Opt out of capturing if on webapp pages or cookies not accepted
-      console.log("[PostHog] Not initializing:", {
-        isPublicPage,
-        hasAcceptedCookies,
-        pathname: router.pathname,
-      });
       if (posthog.__loaded) {
         posthog.opt_out_capturing();
       }

--- a/front/pages/_app.tsx
+++ b/front/pages/_app.tsx
@@ -23,7 +23,6 @@ const NODE_ENV = process.env.NODE_ENV;
 console.log("[PostHog] Environment check:", {
   hasKey: !!NEXT_PUBLIC_POSTHOG_KEY,
   keyLength: NEXT_PUBLIC_POSTHOG_KEY?.length ?? 0,
-  keyPrefix: NEXT_PUBLIC_POSTHOG_KEY?.substring(0, 10),
   nodeEnv: NODE_ENV,
 });
 import { useCookies } from "react-cookie";

--- a/front/pages/_app.tsx
+++ b/front/pages/_app.tsx
@@ -64,10 +64,6 @@ export default function App({ Component, pageProps }: AppPropsWithLayout) {
     if (isPublicPage && hasAcceptedCookies) {
       // Only initialize if not already initialized
       if (!posthog.__loaded && NEXT_PUBLIC_POSTHOG_KEY) {
-        console.log("[PostHog] Initializing with key:", {
-          keyPrefix: NEXT_PUBLIC_POSTHOG_KEY.substring(0, 10),
-          apiHost: "/ingest",
-        });
         posthog.init(NEXT_PUBLIC_POSTHOG_KEY, {
           api_host: "/ingest",
           person_profiles: "identified_only",

--- a/front/pages/_app.tsx
+++ b/front/pages/_app.tsx
@@ -16,21 +16,24 @@ import { useEffect } from "react";
 // Important: avoid destructuring process.env on the client.
 // Next.js replaces direct property access (process.env.NEXT_PUBLIC_*) at build time,
 // but destructuring `process.env` does not get inlined.
-const NEXT_PUBLIC_POSTHOG_KEY = process.env.NEXT_PUBLIC_POSTHOG_KEY;
+const POSTHOG_KEY = process.env.NEXT_PUBLIC_POSTHOG_KEY;
 const NODE_ENV = process.env.NODE_ENV;
+const DATADOG_CLIENT_TOKEN = process.env.NEXT_PUBLIC_DATADOG_CLIENT_TOKEN;
+const DATADOG_SERVICE = process.env.NEXT_PUBLIC_DATADOG_SERVICE;
+const COMMIT_HASH = process.env.NEXT_PUBLIC_COMMIT_HASH;
 
 import { useCookies } from "react-cookie";
 
 import RootLayout from "@app/components/app/RootLayout";
 
-if (process.env.NEXT_PUBLIC_DATADOG_CLIENT_TOKEN) {
+if (DATADOG_CLIENT_TOKEN) {
   datadogLogs.init({
-    clientToken: process.env.NEXT_PUBLIC_DATADOG_CLIENT_TOKEN,
-    env: process.env.NODE_ENV === "production" ? "prod" : "dev",
+    clientToken: DATADOG_CLIENT_TOKEN,
+    env: NODE_ENV === "production" ? "prod" : "dev",
     // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
-    service: `${process.env.NEXT_PUBLIC_DATADOG_SERVICE || "front"}-browser`,
+    service: `${DATADOG_SERVICE || "front"}-browser`,
     // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
-    version: process.env.NEXT_PUBLIC_COMMIT_HASH || "",
+    version: COMMIT_HASH || "",
     site: "datadoghq.eu",
     forwardErrorsToLogs: true,
     sessionSampleRate: 100,
@@ -63,8 +66,8 @@ export default function App({ Component, pageProps }: AppPropsWithLayout) {
 
     if (isPublicPage && hasAcceptedCookies) {
       // Only initialize if not already initialized
-      if (!posthog.__loaded && NEXT_PUBLIC_POSTHOG_KEY) {
-        posthog.init(NEXT_PUBLIC_POSTHOG_KEY, {
+      if (!posthog.__loaded && POSTHOG_KEY) {
+        posthog.init(POSTHOG_KEY, {
           api_host: "/ingest",
           person_profiles: "identified_only",
           defaults: "2025-05-24",

--- a/front/pages/_app.tsx
+++ b/front/pages/_app.tsx
@@ -8,6 +8,25 @@ import "@app/styles/components.css";
 import { datadogLogs } from "@datadog/browser-logs";
 import type { NextPage } from "next";
 import type { AppProps } from "next/app";
+import { useRouter } from "next/router";
+import posthog from "posthog-js";
+import { PostHogProvider } from "posthog-js/react";
+import { useEffect } from "react";
+
+// Important: avoid destructuring process.env on the client.
+// Next.js replaces direct property access (process.env.NEXT_PUBLIC_*) at build time,
+// but destructuring `process.env` does not get inlined.
+const NEXT_PUBLIC_POSTHOG_KEY = process.env.NEXT_PUBLIC_POSTHOG_KEY;
+const NODE_ENV = process.env.NODE_ENV;
+
+// Log PostHog configuration for debugging
+console.log("[PostHog] Environment check:", {
+  hasKey: !!NEXT_PUBLIC_POSTHOG_KEY,
+  keyLength: NEXT_PUBLIC_POSTHOG_KEY?.length ?? 0,
+  keyPrefix: NEXT_PUBLIC_POSTHOG_KEY?.substring(0, 10),
+  nodeEnv: NODE_ENV,
+});
+import { useCookies } from "react-cookie";
 
 import RootLayout from "@app/components/app/RootLayout";
 
@@ -37,12 +56,69 @@ type AppPropsWithLayout = AppProps & {
 };
 
 export default function App({ Component, pageProps }: AppPropsWithLayout) {
+  const router = useRouter();
+  const [cookies] = useCookies(["dust-cookies-accepted"]);
+
+  // Check if user has accepted cookies
+  const cookieValue = cookies["dust-cookies-accepted"];
+  const hasAcceptedCookies =
+    cookieValue === "true" || cookieValue === "auto" || cookieValue === true;
+
+  // Initialize PostHog only for public pages (not under /w/) and if cookies are accepted
+  useEffect(() => {
+    const isPublicPage = !router.pathname.startsWith("/w/");
+
+    if (isPublicPage && hasAcceptedCookies) {
+      // Only initialize if not already initialized
+      if (!posthog.__loaded && NEXT_PUBLIC_POSTHOG_KEY) {
+        console.log("[PostHog] Initializing with key:", {
+          keyPrefix: NEXT_PUBLIC_POSTHOG_KEY.substring(0, 10),
+          apiHost: "/ingest",
+        });
+        posthog.init(NEXT_PUBLIC_POSTHOG_KEY, {
+          api_host: "/ingest",
+          person_profiles: "identified_only",
+          defaults: "2025-05-24",
+          loaded: (posthog) => {
+            console.log("[PostHog] Successfully loaded");
+            if (NODE_ENV === "development") {
+              posthog.debug();
+            }
+          },
+        });
+      } else if (posthog.__loaded) {
+        console.log("[PostHog] Already loaded, re-enabling capturing");
+        // Re-enable capturing if previously opted out
+        posthog.opt_in_capturing();
+      } else {
+        console.log("[PostHog] Not initializing - no key available");
+      }
+    } else {
+      // Opt out of capturing if on webapp pages or cookies not accepted
+      console.log("[PostHog] Not initializing:", {
+        isPublicPage,
+        hasAcceptedCookies,
+        pathname: router.pathname,
+      });
+      if (posthog.__loaded) {
+        posthog.opt_out_capturing();
+      }
+    }
+  }, [router.pathname, hasAcceptedCookies]);
+
   // Use the layout defined at the page level, if available.
   const getLayout = Component.getLayout ?? ((page) => page);
 
-  return (
+  const content = (
     <RootLayout>
       {getLayout(<Component {...pageProps} />, pageProps)}
     </RootLayout>
   );
+
+  // Only wrap with PostHogProvider for public pages when cookies are accepted
+  if (!router.pathname.startsWith("/w/") && hasAcceptedCookies) {
+    return <PostHogProvider client={posthog}>{content}</PostHogProvider>;
+  }
+
+  return content;
 }

--- a/front/pages/_app.tsx
+++ b/front/pages/_app.tsx
@@ -78,7 +78,17 @@ export default function App({ Component, pageProps }: AppPropsWithLayout) {
         // Re-enable capturing if previously opted out
         posthog.opt_in_capturing();
       } else {
-        console.log("[PH] Not initializing - no key available");
+        // Only log to Datadog when key is not available
+        datadogLogs.logger.warn(
+          "[PostHog] Not initializing - no key available",
+          {
+            isPublicPage,
+            hasAcceptedCookies,
+            posthogLoaded: posthog.__loaded,
+            pathname: router.pathname,
+            env: NODE_ENV,
+          }
+        );
       }
     } else {
       // Opt out of capturing if on webapp pages or cookies not accepted


### PR DESCRIPTION
## Description
Re-adds PostHog analytics tracking to the frontend after resolving environment variable issues. This reverts the previous revert commit and restores the PostHog integration that tracks self-serve funnel performance on public website pages. The implementation includes client-side and server-side SDKs with proper cookie consent handling, restricting tracking to public pages only (excluding `/w/` workspace paths) and activating only when users have accepted cookies. Also fixes React key warnings in navigation components by adding proper itemIndex fallbacks.

## Risk
Adds PostHog dependencies which could impact bundle size and page load performance. The proxy configuration redirects PostHog requests through `/ingest` endpoints which may affect caching behavior.

## Deploy Plan
Requires the `NEXT_PUBLIC_POSTHOG_KEY` environment variable to be properly configured in production before deployment.
