### PR TITLE
Fix Shift+enter in agent builder instructions

### DIFF
--- a/front/components/assistant/conversation/input_bar/editor/extensions/ParagraphExtension.ts
+++ b/front/components/assistant/conversation/input_bar/editor/extensions/ParagraphExtension.ts
@@ -13,7 +13,6 @@ export const ParagraphExtension = Paragraph.extend({
         // - splitBlock: fallback -> normal line break
         return this.editor.commands.first(({ commands }) => [
           () => commands.newlineInCode(),
-          // Only try to split list items if the editor schema includes them
           () =>
             this.editor.schema.nodes.listItem
               ? commands.splitListItem("listItem")

--- a/front/components/assistant/conversation/input_bar/editor/extensions/ParagraphExtension.ts
+++ b/front/components/assistant/conversation/input_bar/editor/extensions/ParagraphExtension.ts
@@ -13,7 +13,11 @@ export const ParagraphExtension = Paragraph.extend({
         // - splitBlock: fallback -> normal line break
         return this.editor.commands.first(({ commands }) => [
           () => commands.newlineInCode(),
-          () => commands.splitListItem("listItem"),
+          // Only try to split list items if the editor schema includes them
+          () =>
+            this.editor.schema.nodes.listItem
+              ? commands.splitListItem("listItem")
+              : false,
           () => commands.liftEmptyBlock(),
           () => commands.createParagraphNear(),
           () => commands.splitBlock(),


### PR DESCRIPTION
## Description

Fixes https://github.com/issues/assigned?issue=dust-tt%7Ctasks%7C4307

shift + enter in the instruction builder text area triggers an error:
```
Uncaught Error: There is no node type named 'listItem'. Maybe you forgot to add the extension?
```
I fixed it by checking if the element exist before trying to split it


## Tests

Manual test: shift + enter now creates a new line

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
