### PR TITLE
[front] - chore(AssistantDetails):

### DIFF
--- a/front/components/assistant/details/AssistantDetails.tsx
+++ b/front/components/assistant/details/AssistantDetails.tsx
@@ -35,7 +35,11 @@ import { RestoreAssistantDialog } from "@app/components/assistant/RestoreAssista
 import { isMCPConfigurationForAgentMemory } from "@app/lib/actions/types/guards";
 import { useAgentConfiguration } from "@app/lib/swr/assistants";
 import { useFeatureFlags } from "@app/lib/swr/workspaces";
-import type { AgentConfigurationScope, UserType, WorkspaceType } from "@app/types";
+import type {
+  AgentConfigurationScope,
+  UserType,
+  WorkspaceType,
+} from "@app/types";
 import { GLOBAL_AGENTS_SID, isAdmin } from "@app/types";
 
 export const SCOPE_INFO: Record<

--- a/front/components/assistant/details/AssistantDetails.tsx
+++ b/front/components/assistant/details/AssistantDetails.tsx
@@ -16,6 +16,7 @@ import {
   SheetTitle,
   Spinner,
   Tabs,
+  TabsContent,
   TabsList,
   TabsTrigger,
   UserGroupIcon,
@@ -208,8 +209,10 @@ export function AssistantDetails({
           </div>
         ) : (
           <>
-            <SheetHeader className="flex flex-col gap-5 pb-0 text-sm text-foreground dark:text-foreground-night">
+            <SheetHeader className="flex flex-col gap-5 text-sm text-foreground dark:text-foreground-night">
               <DescriptionSection />
+            </SheetHeader>
+            <SheetContainer className="pb-4">
               {showEditorsTabs || showPerformanceTabs ? (
                 <Tabs value={selectedTab}>
                   <TabsList border={false}>
@@ -252,49 +255,46 @@ export function AssistantDetails({
                       />
                     )}
                   </TabsList>
+                  {agentConfiguration && (
+                    <div className="mt-4">
+                      <TabsContent value="info">
+                        <AgentInfoTab
+                          agentConfiguration={agentConfiguration}
+                          owner={owner}
+                        />
+                      </TabsContent>
+                      <TabsContent value="triggers">
+                        <AgentTriggersTab
+                          agentConfiguration={agentConfiguration}
+                          owner={owner}
+                        />
+                      </TabsContent>
+
+                      <TabsContent value="performance">
+                        <AgentPerformanceTab
+                          agentConfiguration={agentConfiguration}
+                          owner={owner}
+                          gridMode={false}
+                        />
+                      </TabsContent>
+                      <TabsContent value="editors">
+                        <AgentEditorsTab
+                          owner={owner}
+                          user={user}
+                          agentConfiguration={agentConfiguration}
+                        />
+                      </TabsContent>
+                      <TabsContent value="agent_memory">
+                        <AgentMemoryTab
+                          owner={owner}
+                          agentConfiguration={agentConfiguration}
+                        />
+                      </TabsContent>
+                    </div>
+                  )}
                 </Tabs>
               ) : (
                 <div />
-              )}
-            </SheetHeader>
-            <SheetContainer className="pb-4">
-              {agentConfiguration && (
-                <>
-                  {selectedTab === "info" && (
-                    <AgentInfoTab
-                      agentConfiguration={agentConfiguration}
-                      owner={owner}
-                    />
-                  )}
-                  {showTriggersTabs && selectedTab === "triggers" && (
-                    <AgentTriggersTab
-                      agentConfiguration={agentConfiguration}
-                      owner={owner}
-                    />
-                  )}
-                  {selectedTab === "performance" && (
-                    <AgentPerformanceTab
-                      agentConfiguration={agentConfiguration}
-                      owner={owner}
-                      gridMode={false}
-                    />
-                  )}
-                  {showEditorsTabs && selectedTab === "editors" && (
-                    <AgentEditorsTab
-                      owner={owner}
-                      user={user}
-                      agentConfiguration={agentConfiguration}
-                    />
-                  )}
-                  {showAgentMemory && selectedTab === "agent_memory" && (
-                    <>
-                      <AgentMemoryTab
-                        owner={owner}
-                        agentConfiguration={agentConfiguration}
-                      />
-                    </>
-                  )}
-                </>
               )}
               {isAgentConfigurationError?.error.type ===
                 "agent_configuration_not_found" && (

--- a/front/components/assistant/details/AssistantDetails.tsx
+++ b/front/components/assistant/details/AssistantDetails.tsx
@@ -35,11 +35,7 @@ import { RestoreAssistantDialog } from "@app/components/assistant/RestoreAssista
 import { isMCPConfigurationForAgentMemory } from "@app/lib/actions/types/guards";
 import { useAgentConfiguration } from "@app/lib/swr/assistants";
 import { useFeatureFlags } from "@app/lib/swr/workspaces";
-import type {
-  AgentConfigurationScope,
-  UserType,
-  WorkspaceType,
-} from "@app/types";
+import type { AgentConfigurationScope, UserType, WorkspaceType } from "@app/types";
 import { GLOBAL_AGENTS_SID, isAdmin } from "@app/types";
 
 export const SCOPE_INFO: Record<
@@ -293,6 +289,11 @@ export function AssistantDetails({
                     </div>
                   )}
                 </Tabs>
+              ) : agentConfiguration ? (
+                <AgentInfoTab
+                  agentConfiguration={agentConfiguration}
+                  owner={owner}
+                />
               ) : (
                 <div />
               )}

--- a/front/components/assistant/details/tabs/AgentEditorsTab.tsx
+++ b/front/components/assistant/details/tabs/AgentEditorsTab.tsx
@@ -46,7 +46,7 @@ export function AgentEditorsTab({
   };
 
   return (
-    <div>
+    <div className="flex flex-col gap-4">
       <MembersList
         currentUser={user}
         membersData={{
@@ -64,7 +64,7 @@ export function AgentEditorsTab({
       />
 
       {isCurrentUserEditor && (
-        <div className="mt-4">
+        <div>
           <AddEditorDropdown
             owner={owner}
             editors={editors}

--- a/front/components/assistant/details/tabs/AgentInfoTab/AssistantToolsSection.tsx
+++ b/front/components/assistant/details/tabs/AgentInfoTab/AssistantToolsSection.tsx
@@ -78,33 +78,9 @@ export function AssistantToolsSection({
 
   const filteredModels = removeNulls(models);
   return (
-    <div className="flex flex-row gap-2">
-      {nonHiddenActions.length > 0 && (
-        <div className="flex flex-[1_0_0] flex-col gap-5">
-          <div className="heading-lg text-foreground dark:text-foreground-night">
-            Tools
-          </div>
-          <div className="flex flex-col gap-2">
-            {isLoading ? (
-              <div className="flex flex-row items-center gap-2">
-                <Spinner size="xs" />
-              </div>
-            ) : (
-              sortedActions.map((action) => (
-                <div
-                  className="flex flex-row items-center gap-2"
-                  key={action.title}
-                >
-                  {action.avatar}
-                  <div>{action.title}</div>
-                </div>
-              ))
-            )}
-          </div>
-        </div>
-      )}
+    <div className="flex flex-col gap-5">
       {filteredModels.length > 0 && (
-        <div className="flex flex-[1_0_0] flex-col gap-5">
+        <div className="flex flex-col gap-5">
           <div className="heading-lg text-foreground dark:text-foreground-night">
             Models
           </div>
@@ -121,6 +97,31 @@ export function AssistantToolsSection({
                 <div>{model.displayName}</div>
               </div>
             ))}
+          </div>
+        </div>
+      )}
+
+      {nonHiddenActions.length > 0 && (
+        <div className="flex flex-col gap-5">
+          <div className="heading-lg text-foreground dark:text-foreground-night">
+            Tools
+          </div>
+          <div className="grid grid-cols-2 gap-2">
+            {isLoading ? (
+              <div className="flex flex-row items-center gap-2">
+                <Spinner size="xs" />
+              </div>
+            ) : (
+              sortedActions.map((action) => (
+                <div
+                  className="flex flex-row items-center gap-2"
+                  key={action.title}
+                >
+                  {action.avatar}
+                  <div>{action.title}</div>
+                </div>
+              ))
+            )}
           </div>
         </div>
       )}

--- a/front/components/assistant/details/tabs/AgentInfoTab/index.tsx
+++ b/front/components/assistant/details/tabs/AgentInfoTab/index.tsx
@@ -22,7 +22,7 @@ export function AgentInfoTab({
 }) {
   const isConfigurable = agentConfiguration.sId === GLOBAL_AGENTS_SID.DUST;
   return (
-    <>
+    <div className="flex flex-col gap-4">
       {agentConfiguration.tags.length > 0 && (
         <div className="flex flex-wrap gap-2">
           {agentConfiguration.tags.map((tag) => (
@@ -81,6 +81,6 @@ export function AgentInfoTab({
         agentConfiguration={agentConfiguration}
         owner={owner}
       />
-    </>
+    </div>
   );
 }

--- a/front/components/assistant/details/tabs/AgentMemoryTab.tsx
+++ b/front/components/assistant/details/tabs/AgentMemoryTab.tsx
@@ -99,7 +99,7 @@ export function AgentMemoryTab({
   );
 
   return (
-    <>
+    <div className="flex flex-col gap-4">
       {memoryToDelete && (
         <DeleteMemoryDialog
           owner={owner}
@@ -161,6 +161,6 @@ export function AgentMemoryTab({
           </>
         )}
       </div>
-    </>
+    </div>
   );
 }

--- a/front/components/assistant/details/tabs/AgentPerformanceTab.tsx
+++ b/front/components/assistant/details/tabs/AgentPerformanceTab.tsx
@@ -1,23 +1,24 @@
-import { Page } from "@dust-tt/sparkle";
-import { DropdownMenu } from "@dust-tt/sparkle";
-import { DropdownMenuTrigger } from "@dust-tt/sparkle";
-import { Button } from "@dust-tt/sparkle";
-import { DropdownMenuContent } from "@dust-tt/sparkle";
-import { DropdownMenuItem } from "@dust-tt/sparkle";
-import { Spinner } from "@dust-tt/sparkle";
-import { CardGrid } from "@dust-tt/sparkle";
-import { ValueCard } from "@dust-tt/sparkle";
-import { Avatar } from "@dust-tt/sparkle";
-import { HandThumbUpIcon } from "@dust-tt/sparkle";
-import { HandThumbDownIcon } from "@dust-tt/sparkle";
-import { ChatBubbleLeftRightIcon } from "@dust-tt/sparkle";
-import { ChatBubbleThoughtIcon } from "@dust-tt/sparkle";
+import {
+  Avatar,
+  Button,
+  CardGrid,
+  ChatBubbleLeftRightIcon,
+  ChatBubbleThoughtIcon,
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+  HandThumbDownIcon,
+  HandThumbUpIcon,
+  Page,
+  Spinner,
+  ValueCard,
+} from "@dust-tt/sparkle";
 import { useState } from "react";
 
 import { FeedbacksSection } from "@app/components/assistant_builder/FeedbacksSection";
 import { useAgentAnalytics } from "@app/lib/swr/assistants";
-import type { LightAgentConfigurationType } from "@app/types";
-import type { WorkspaceType } from "@app/types";
+import type { LightAgentConfigurationType, WorkspaceType } from "@app/types";
 import { removeNulls } from "@app/types";
 
 const PERIODS = [
@@ -45,7 +46,7 @@ export function AgentPerformanceTab({
   });
 
   return (
-    <>
+    <div className="flex flex-col gap-4">
       <div className="flex flex-row items-center justify-between gap-3">
         <Page.H variant="h5">Analytics</Page.H>
         <div className="self-end">
@@ -187,6 +188,6 @@ export function AgentPerformanceTab({
           />
         </div>
       )}
-    </>
+    </div>
   );
 }


### PR DESCRIPTION
## Description

This PR refactors the `AssistantDetails` layout to look like this:
<img width="603" height="313" alt="Screenshot 2025-09-24 at 10 51 57" src="https://github.com/user-attachments/assets/2204ac98-4540-4682-a16f-208175d6b7cf" />


**References:**
- https://github.com/dust-tt/tasks/issues/4294


## Tests

Locally

## Risk

Low

## Deploy Plan

Deploy front
