### PR TITLE
Changed default tools to top tools

### DIFF
--- a/front/components/agent_builder/MCPServerViewsContext.tsx
+++ b/front/components/agent_builder/MCPServerViewsContext.tsx
@@ -13,7 +13,6 @@ import { useMCPServerViewsFromSpaces } from "@app/lib/swr/mcp_servers";
 import type { LightWorkspaceType, SpaceType } from "@app/types";
 
 export type MCPServerViewTypeWithLabel = MCPServerViewType & { label: string };
-
 // Sort MCP server views based on priority order.
 // Order: Search -> Include Data -> Query Tables -> Extract Data -> Others (alphabetically).
 export const sortMCPServerViewsByPriority = (
@@ -43,8 +42,7 @@ export const sortMCPServerViewsByPriority = (
 interface MCPServerViewsContextType {
   mcpServerViews: MCPServerViewType[];
   mcpServerViewsWithKnowledge: MCPServerViewTypeWithLabel[];
-  defaultMCPServerViews: MCPServerViewTypeWithLabel[];
-  nonDefaultMCPServerViews: MCPServerViewTypeWithLabel[];
+  mcpServerViewsWithoutKnowledge: MCPServerViewTypeWithLabel[];
   isMCPServerViewsLoading: boolean;
   isMCPServerViewsError: boolean;
 }
@@ -63,8 +61,7 @@ function getGroupedMCPServerViews({
   if (!mcpServerViews || !Array.isArray(mcpServerViews)) {
     return {
       mcpServerViewsWithKnowledge: [],
-      defaultMCPServerViews: [],
-      nonDefaultMCPServerViews: [],
+      mcpServerViewsWithoutKnowledge: [],
     };
   }
 
@@ -129,8 +126,10 @@ function getGroupedMCPServerViews({
     mcpServerViewsWithKnowledge: sortMCPServerViewsByPriority(
       mcpServerViewsWithKnowledge || []
     ),
-    defaultMCPServerViews: grouped.auto || [],
-    nonDefaultMCPServerViews: grouped.manual || [],
+    mcpServerViewsWithoutKnowledge: [
+      ...(grouped.manual || []),
+      ...(grouped.auto || []),
+    ],
   };
 }
 
@@ -169,31 +168,26 @@ export const MCPServerViewsProvider = ({
     [mcpServerViews]
   );
 
-  const {
-    mcpServerViewsWithKnowledge,
-    defaultMCPServerViews,
-    nonDefaultMCPServerViews,
-  } = useMemo(() => {
-    return getGroupedMCPServerViews({
-      mcpServerViews: sortedMCPServerViews,
-      spaces,
-    });
-  }, [sortedMCPServerViews, spaces]);
+  const { mcpServerViewsWithKnowledge, mcpServerViewsWithoutKnowledge } =
+    useMemo(() => {
+      return getGroupedMCPServerViews({
+        mcpServerViews: sortedMCPServerViews,
+        spaces,
+      });
+    }, [sortedMCPServerViews, spaces]);
 
   const value: MCPServerViewsContextType = useMemo(() => {
     return {
       mcpServerViews: sortedMCPServerViews,
       mcpServerViewsWithKnowledge,
-      defaultMCPServerViews,
-      nonDefaultMCPServerViews,
+      mcpServerViewsWithoutKnowledge,
       isMCPServerViewsLoading: isLoading || isSpacesLoading, // Spaces is required to fetch server views so we check isSpacesLoading too.
       isMCPServerViewsError,
     };
   }, [
     sortedMCPServerViews,
     mcpServerViewsWithKnowledge,
-    defaultMCPServerViews,
-    nonDefaultMCPServerViews,
+    mcpServerViewsWithoutKnowledge,
     isLoading,
     isMCPServerViewsError,
     isSpacesLoading,

--- a/front/components/agent_builder/capabilities/mcp/MCPServerSelectionPage.tsx
+++ b/front/components/agent_builder/capabilities/mcp/MCPServerSelectionPage.tsx
@@ -108,8 +108,8 @@ function MCPServerCard({
 }
 
 interface MCPServerSelectionPageProps {
-  defaultMcpServerViews: MCPServerViewTypeWithLabel[];
-  nonDefaultMcpServerViews: MCPServerViewTypeWithLabel[];
+  topMCPServerViews: MCPServerViewTypeWithLabel[];
+  nonTopMCPServerViews: MCPServerViewTypeWithLabel[];
   onItemClick: (mcpServerView: MCPServerViewType) => void;
   dataVisualization?: ActionSpecification | null;
   onDataVisualizationClick?: () => void;
@@ -118,8 +118,8 @@ interface MCPServerSelectionPageProps {
 }
 
 export function MCPServerSelectionPage({
-  defaultMcpServerViews,
-  nonDefaultMcpServerViews,
+  topMCPServerViews,
+  nonTopMCPServerViews,
   onItemClick,
   dataVisualization,
   onDataVisualizationClick,
@@ -142,11 +142,11 @@ export function MCPServerSelectionPage({
   );
 
   const hasDataVisualization = dataVisualization && onDataVisualizationClick;
-  const hasDefaultViews = defaultMcpServerViews.length > 0;
-  const hasNonDefaultViews = nonDefaultMcpServerViews.length > 0;
+  const hasTopViews = topMCPServerViews.length > 0;
+  const hasNonTopViews = nonTopMCPServerViews.length > 0;
   const hasAnyResults =
     // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
-    hasDataVisualization || hasDefaultViews || hasNonDefaultViews;
+    hasDataVisualization || hasTopViews || hasNonTopViews;
 
   if (!hasAnyResults) {
     return (
@@ -168,7 +168,7 @@ export function MCPServerSelectionPage({
       <div className="flex flex-col gap-4 py-2">
         {/* eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing */}
         {((dataVisualization && onDataVisualizationClick) ||
-          defaultMcpServerViews) && (
+          topMCPServerViews) && (
           <span className="text-lg font-semibold">Top tools</span>
         )}
         <div className="grid grid-cols-2 gap-3">
@@ -180,7 +180,7 @@ export function MCPServerSelectionPage({
               onClick={onDataVisualizationClick}
             />
           )}
-          {defaultMcpServerViews.map((view) => (
+          {topMCPServerViews.map((view) => (
             <MCPServerCard
               key={view.id}
               view={view}
@@ -194,11 +194,11 @@ export function MCPServerSelectionPage({
             />
           ))}
         </div>
-        {nonDefaultMcpServerViews.length ? (
+        {nonTopMCPServerViews.length ? (
           <span className="text-lg font-semibold">Other tools</span>
         ) : null}
         <div className="grid grid-cols-2 gap-3">
-          {nonDefaultMcpServerViews.map((view) => (
+          {nonTopMCPServerViews.map((view) => (
             <MCPServerCard
               key={view.id}
               view={view}

--- a/front/components/agent_builder/capabilities/mcp/MCPServerViewsSheet.tsx
+++ b/front/components/agent_builder/capabilities/mcp/MCPServerViewsSheet.tsx
@@ -212,7 +212,7 @@ export function MCPServerViewsSheet({
     []
   );
 
-  console.log("mcpServerViewsWithoutKnowledge", mcpServerViewsWithoutKnowledge);
+-  console.log("mcpServerViewsWithoutKnowledge", mcpServerViewsWithoutKnowledge);
 
   const topMCPServerViews = useMemo(() => {
     return mcpServerViewsWithoutKnowledge.filter((view) =>

--- a/front/components/agent_builder/capabilities/mcp/MCPServerViewsSheet.tsx
+++ b/front/components/agent_builder/capabilities/mcp/MCPServerViewsSheet.tsx
@@ -80,6 +80,17 @@ import type { MCPServerViewType } from "@app/lib/api/mcp";
 import { useModels } from "@app/lib/swr/models";
 import { DEFAULT_REASONING_MODEL_ID } from "@app/types";
 
+const TOP_MCP_SERVER_VIEWS = [
+  "web_search_&_browse",
+  "image_generation",
+  "agent_memory",
+  "deep_research",
+  "content_creation",
+  "slack",
+  "gmail",
+  "google_calendar",
+];
+
 export type SelectedTool =
   | {
       type: "MCP";
@@ -144,8 +155,7 @@ export function MCPServerViewsSheet({
   const { reasoningModels } = useModels({ owner });
   const {
     mcpServerViews: allMcpServerViews,
-    defaultMCPServerViews,
-    nonDefaultMCPServerViews,
+    mcpServerViewsWithoutKnowledge,
     isMCPServerViewsLoading,
   } = useMCPServerViewsContext();
 
@@ -202,8 +212,22 @@ export function MCPServerViewsSheet({
     []
   );
 
-  const selectableDefaultMCPServerViews = useMemo(() => {
-    const filteredList = defaultMCPServerViews.filter(
+  console.log("mcpServerViewsWithoutKnowledge", mcpServerViewsWithoutKnowledge);
+
+  const topMCPServerViews = useMemo(() => {
+    return mcpServerViewsWithoutKnowledge.filter((view) =>
+      TOP_MCP_SERVER_VIEWS.includes(view.server.name)
+    );
+  }, [mcpServerViewsWithoutKnowledge]);
+
+  const nonTopMCPServerViews = useMemo(() => {
+    return mcpServerViewsWithoutKnowledge.filter(
+      (view) => !TOP_MCP_SERVER_VIEWS.includes(view.server.name)
+    );
+  }, [mcpServerViewsWithoutKnowledge]);
+
+  const selectableTopMCPServerViews = useMemo(() => {
+    const filteredList = topMCPServerViews.filter(
       (view) => !shouldFilterServerView(view, actions)
     );
 
@@ -214,19 +238,14 @@ export function MCPServerViewsSheet({
     return filteredList.filter(
       (view) => !getMCPServerToolsConfigurations(view).reasoningConfiguration
     );
-  }, [
-    defaultMCPServerViews,
-    actions,
-    hasReasoningModel,
-    shouldFilterServerView,
-  ]);
+  }, [topMCPServerViews, actions, hasReasoningModel, shouldFilterServerView]);
 
-  const selectableNonDefaultMCPServerViews = useMemo(
+  const selectableNonTopMCPServerViews = useMemo(
     () =>
-      nonDefaultMCPServerViews.filter(
+      nonTopMCPServerViews.filter(
         (view) => !shouldFilterServerView(view, actions)
       ),
-    [nonDefaultMCPServerViews, actions, shouldFilterServerView]
+    [nonTopMCPServerViews, actions, shouldFilterServerView]
   );
 
   const filteredViews = useMemo(() => {
@@ -241,14 +260,10 @@ export function MCPServerViewsSheet({
           });
 
     return {
-      defaultViews: filterViews(selectableDefaultMCPServerViews),
-      nonDefaultViews: filterViews(selectableNonDefaultMCPServerViews),
+      topViews: filterViews(selectableTopMCPServerViews),
+      nonTopViews: filterViews(selectableNonTopMCPServerViews),
     };
-  }, [
-    searchTerm,
-    selectableDefaultMCPServerViews,
-    selectableNonDefaultMCPServerViews,
-  ]);
+  }, [searchTerm, selectableTopMCPServerViews, selectableNonTopMCPServerViews]);
   const showDataVisualization = useMemo(() => {
     if (!searchTerm.trim()) {
       return true;
@@ -569,8 +584,8 @@ export function MCPServerViewsSheet({
             />
           )}
           <MCPServerSelectionPage
-            defaultMcpServerViews={filteredViews.defaultViews}
-            nonDefaultMcpServerViews={filteredViews.nonDefaultViews}
+            topMCPServerViews={filteredViews.topViews}
+            nonTopMCPServerViews={filteredViews.nonTopViews}
             onItemClick={onClickMCPServer}
             dataVisualization={showDataVisualization ? dataVisualization : null}
             onDataVisualizationClick={onClickDataVisualization}

--- a/front/components/agent_builder/capabilities/mcp/MCPServerViewsSheet.tsx
+++ b/front/components/agent_builder/capabilities/mcp/MCPServerViewsSheet.tsx
@@ -212,8 +212,6 @@ export function MCPServerViewsSheet({
     []
   );
 
-  console.log("mcpServerViewsWithoutKnowledge", mcpServerViewsWithoutKnowledge);
-
   const topMCPServerViews = useMemo(() => {
     return mcpServerViewsWithoutKnowledge.filter((view) =>
       TOP_MCP_SERVER_VIEWS.includes(view.server.name)

--- a/front/hooks/useAgentBuilderTools.ts
+++ b/front/hooks/useAgentBuilderTools.ts
@@ -17,8 +17,7 @@ function getGroupedMCPServerViews({
   if (!mcpServerViews || !Array.isArray(mcpServerViews)) {
     return {
       mcpServerViewsWithKnowledge: [],
-      defaultMCPServerViews: [],
-      nonDefaultMCPServerViews: [],
+      mcpServerViewsWithoutKnowledge: [],
     };
   }
 
@@ -75,8 +74,10 @@ function getGroupedMCPServerViews({
 
   return {
     mcpServerViewsWithKnowledge: mcpServerViewsWithKnowledge || [],
-    defaultMCPServerViews: grouped.auto || [],
-    nonDefaultMCPServerViews: grouped.manual || [],
+    mcpServerViewsWithoutKnowledge: [
+      ...(grouped.auto || []),
+      ...(grouped.manual || []),
+    ],
   };
 }
 
@@ -84,17 +85,13 @@ export const useAgentBuilderTools = () => {
   const { spaces } = useSpacesContext();
   const { mcpServerViews } = useMCPServerViewsContext();
 
-  const {
-    mcpServerViewsWithKnowledge,
-    defaultMCPServerViews,
-    nonDefaultMCPServerViews,
-  } = useMemo(() => {
-    return getGroupedMCPServerViews({ mcpServerViews, spaces });
-  }, [mcpServerViews, spaces]);
+  const { mcpServerViewsWithKnowledge, mcpServerViewsWithoutKnowledge } =
+    useMemo(() => {
+      return getGroupedMCPServerViews({ mcpServerViews, spaces });
+    }, [mcpServerViews, spaces]);
 
   return {
     mcpServerViewsWithKnowledge,
-    defaultMCPServerViews,
-    nonDefaultMCPServerViews,
+    mcpServerViewsWithoutKnowledge,
   };
 };


### PR DESCRIPTION
## Description

(cf. https://github.com/dust-tt/tasks/issues/4318)

The Agent Builder separation between "Top Tools" and "Other Tools" was unclear, it was based on internal or external mcp servers, this isn't a good separation criteria for users. We therefore instead suggest more used & common tools in "Top Tools".

## Tests

Tested in local agent builder.

## Risk

None.

## Deploy Plan

Deploy front.
