### PR TITLE
[Agent Loop] Signal-based cancel for agent message workflow

### DIFF
--- a/front/lib/api/assistant/pubsub.ts
+++ b/front/lib/api/assistant/pubsub.ts
@@ -115,22 +115,20 @@ export async function cancelMessageGenerationEvent(
       // We use the message id provided by the caller as the agentMessageId.
       const agentMessageId = messageId;
 
-      if (workspaceId && conversationId && agentMessageId) {
-        const workflowId = makeAgentLoopWorkflowId({
-          workspaceId,
-          conversationId,
-          agentMessageId,
-        });
-        try {
-          const handle = client.workflow.getHandle(workflowId);
-          await handle.signal(cancelAgentLoopSignal);
-        } catch (signalError) {
-          // Swallow errors from signaling (workflow might not exist anymore)
-          logger.warn(
-            { error: signalError, messageId },
-            "Failed to signal agent loop workflow for cancellation"
-          );
-        }
+      const workflowId = makeAgentLoopWorkflowId({
+        workspaceId,
+        conversationId,
+        agentMessageId,
+      });
+      try {
+        const handle = client.workflow.getHandle(workflowId);
+        await handle.signal(cancelAgentLoopSignal);
+      } catch (signalError) {
+        // Swallow errors from signaling (workflow might not exist anymore)
+        logger.warn(
+          { error: signalError, messageId },
+          "Failed to signal agent loop workflow for cancellation"
+        );
       }
     },
     { concurrency: 8 }

--- a/front/lib/api/assistant/pubsub.ts
+++ b/front/lib/api/assistant/pubsub.ts
@@ -8,8 +8,11 @@ import {
   ConversationModel,
   Message,
 } from "@app/lib/models/assistant/conversation";
+import { getTemporalClientForAgentNamespace } from "@app/lib/temporal";
 import { createCallbackReader } from "@app/lib/utils";
 import logger from "@app/logger/logger";
+import { makeAgentLoopWorkflowId } from "@app/temporal/agent_loop/lib/workflow_ids";
+import { cancelAgentLoopSignal } from "@app/temporal/agent_loop/signals";
 import type { GenerationTokensEvent } from "@app/types";
 import type {
   AgentActionSuccessEvent,
@@ -17,9 +20,6 @@ import type {
   AgentGenerationCancelledEvent,
 } from "@app/types";
 import type { AgentMessageNewEvent, UserMessageNewEvent } from "@app/types";
-import { getTemporalClientForAgentNamespace } from "@app/lib/temporal";
-import { cancelAgentLoopSignal } from "@app/temporal/agent_loop/signals";
-import { makeAgentLoopWorkflowId } from "@app/temporal/agent_loop/lib/workflow_ids";
 
 export async function* getConversationEvents({
   conversationId,

--- a/front/lib/api/assistant/pubsub.ts
+++ b/front/lib/api/assistant/pubsub.ts
@@ -4,7 +4,10 @@ import type { RedisUsageTagsType } from "@app/lib/api/redis";
 import type { EventPayload } from "@app/lib/api/redis-hybrid-manager";
 import { getRedisHybridManager } from "@app/lib/api/redis-hybrid-manager";
 import type { Authenticator } from "@app/lib/auth";
-import { ConversationModel, Message } from "@app/lib/models/assistant/conversation";
+import {
+  ConversationModel,
+  Message,
+} from "@app/lib/models/assistant/conversation";
 import { getTemporalClientForAgentNamespace } from "@app/lib/temporal";
 import { createCallbackReader } from "@app/lib/utils";
 import { concurrentExecutor } from "@app/lib/utils/async_utils";

--- a/front/lib/api/assistant/pubsub.ts
+++ b/front/lib/api/assistant/pubsub.ts
@@ -4,10 +4,6 @@ import type { RedisUsageTagsType } from "@app/lib/api/redis";
 import type { EventPayload } from "@app/lib/api/redis-hybrid-manager";
 import { getRedisHybridManager } from "@app/lib/api/redis-hybrid-manager";
 import type { Authenticator } from "@app/lib/auth";
-import {
-  ConversationModel,
-  Message,
-} from "@app/lib/models/assistant/conversation";
 import { getTemporalClientForAgentNamespace } from "@app/lib/temporal";
 import { createCallbackReader } from "@app/lib/utils";
 import { concurrentExecutor } from "@app/lib/utils/async_utils";

--- a/front/lib/api/assistant/pubsub.ts
+++ b/front/lib/api/assistant/pubsub.ts
@@ -105,8 +105,10 @@ export async function* getConversationEvents({
 
 export async function cancelMessageGenerationEvent(
   auth: Authenticator,
-  messageIds: string[],
-  opts?: { conversationId?: string }
+  {
+    messageIds,
+    conversationId,
+  }: { messageIds: string[]; conversationId: string }
 ): Promise<void> {
   const client = await getTemporalClientForAgentNamespace();
   const workspaceId = auth.getNonNullableWorkspace().sId;
@@ -114,26 +116,6 @@ export async function cancelMessageGenerationEvent(
   await concurrentExecutor(
     messageIds,
     async (messageId) => {
-      // Best-effort fetch of conversationId if not provided.
-      let conversationId = opts?.conversationId;
-      if (!conversationId) {
-        const m = await Message.findOne({
-          where: {
-            workspaceId: auth.getNonNullableWorkspace().id,
-            sId: messageId,
-          },
-          include: [
-            {
-              model: ConversationModel,
-              as: "conversation",
-              required: true,
-              attributes: ["sId"],
-            },
-          ],
-        });
-        conversationId = m?.conversation?.sId;
-      }
-
       // We use the message id provided by the caller as the agentMessageId.
       const agentMessageId = messageId;
 

--- a/front/pages/api/v1/w/[wId]/assistant/conversations/[cId]/cancel.ts
+++ b/front/pages/api/v1/w/[wId]/assistant/conversations/[cId]/cancel.ts
@@ -104,7 +104,8 @@ async function handler(
         });
       }
 
-      await cancelMessageGenerationEvent(auth, r.data.messageIds, {
+      await cancelMessageGenerationEvent(auth, {
+        messageIds: r.data.messageIds,
         conversationId,
       });
       return res.status(200).json({ success: true });

--- a/front/pages/api/v1/w/[wId]/assistant/conversations/[cId]/cancel.ts
+++ b/front/pages/api/v1/w/[wId]/assistant/conversations/[cId]/cancel.ts
@@ -104,7 +104,9 @@ async function handler(
         });
       }
 
-      await cancelMessageGenerationEvent(auth, r.data.messageIds);
+      await cancelMessageGenerationEvent(auth, r.data.messageIds, {
+        conversationId,
+      });
       return res.status(200).json({ success: true });
 
     default:

--- a/front/pages/api/w/[wId]/assistant/conversations/[cId]/cancel.ts
+++ b/front/pages/api/w/[wId]/assistant/conversations/[cId]/cancel.ts
@@ -58,7 +58,13 @@ async function handler(
           },
         });
       }
-      await cancelMessageGenerationEvent(auth, bodyValidation.right.messageIds);
+      await cancelMessageGenerationEvent(
+        auth,
+        bodyValidation.right.messageIds,
+        {
+          conversationId,
+        }
+      );
       return res.status(200).json({ success: true });
 
     default:

--- a/front/pages/api/w/[wId]/assistant/conversations/[cId]/cancel.ts
+++ b/front/pages/api/w/[wId]/assistant/conversations/[cId]/cancel.ts
@@ -58,13 +58,10 @@ async function handler(
           },
         });
       }
-      await cancelMessageGenerationEvent(
-        auth,
-        bodyValidation.right.messageIds,
-        {
-          conversationId,
-        }
-      );
+      await cancelMessageGenerationEvent(auth, {
+        messageIds: bodyValidation.right.messageIds,
+        conversationId,
+      });
       return res.status(200).json({ success: true });
 
     default:

--- a/front/temporal/agent_loop/activities/common.ts
+++ b/front/temporal/agent_loop/activities/common.ts
@@ -1,3 +1,5 @@
+import _ from "lodash";
+
 import {
   AgentMessageContentParser,
   getDelimitersConfiguration,
@@ -12,11 +14,11 @@ import { AgentStepContentResource } from "@app/lib/resources/agent_step_content_
 import { ConversationResource } from "@app/lib/resources/conversation_resource";
 import logger from "@app/logger/logger";
 import type { ConversationWithoutContentType } from "@app/types";
+import type {
+  RunAgentAsynchronousArgs} from "@app/types/assistant/agent_run";
 import {
-  getRunAgentData,
-  RunAgentAsynchronousArgs,
+  getRunAgentData
 } from "@app/types/assistant/agent_run";
-import _ from "lodash";
 
 // Process database operations for agent events before publishing to Redis.
 async function processEventForDatabase(

--- a/front/temporal/agent_loop/activities/common.ts
+++ b/front/temporal/agent_loop/activities/common.ts
@@ -233,19 +233,15 @@ export async function finalizeCancellationActivity(
     getDelimitersConfiguration({ agentConfiguration })
   );
 
-  // Helper function to flush all pending tokens from the content parser
-  async function flushParserTokens(): Promise<void> {
-    for await (const tokenEvent of contentParser.flushTokens()) {
-      await updateResourceAndPublishEvent(auth, {
-        event: tokenEvent,
-        agentMessageRow,
-        conversation,
-        step,
-      });
-    }
+  // Flush pending tokens from the content parser, if any.
+  for await (const tokenEvent of contentParser.flushTokens()) {
+    await updateResourceAndPublishEvent(auth, {
+      event: tokenEvent,
+      agentMessageRow,
+      conversation,
+      step,
+    });
   }
-
-  await flushParserTokens();
   await updateResourceAndPublishEvent(auth, {
     event: {
       type: "agent_generation_cancelled",
@@ -257,7 +253,7 @@ export async function finalizeCancellationActivity(
     conversation,
     step,
   });
-  logger.error(
+  logger.info(
     {
       agentMessageId: agentMessage.sId,
       conversationId: conversation.sId,

--- a/front/temporal/agent_loop/activities/common.ts
+++ b/front/temporal/agent_loop/activities/common.ts
@@ -14,11 +14,8 @@ import { AgentStepContentResource } from "@app/lib/resources/agent_step_content_
 import { ConversationResource } from "@app/lib/resources/conversation_resource";
 import logger from "@app/logger/logger";
 import type { ConversationWithoutContentType } from "@app/types";
-import type {
-  RunAgentAsynchronousArgs} from "@app/types/assistant/agent_run";
-import {
-  getRunAgentData
-} from "@app/types/assistant/agent_run";
+import type { RunAgentAsynchronousArgs } from "@app/types/assistant/agent_run";
+import { getRunAgentData } from "@app/types/assistant/agent_run";
 
 // Process database operations for agent events before publishing to Redis.
 async function processEventForDatabase(

--- a/front/temporal/agent_loop/activities/common.ts
+++ b/front/temporal/agent_loop/activities/common.ts
@@ -1,3 +1,7 @@
+import {
+  AgentMessageContentParser,
+  getDelimitersConfiguration,
+} from "@app/lib/api/assistant/agent_message_content_parser";
 import { fetchMessageInConversation } from "@app/lib/api/assistant/messages";
 import { publishConversationRelatedEvent } from "@app/lib/api/assistant/streaming/events";
 import type { AgentMessageEvents } from "@app/lib/api/assistant/streaming/types";
@@ -6,7 +10,13 @@ import { Authenticator as AuthenticatorClass } from "@app/lib/auth";
 import type { AgentMessage } from "@app/lib/models/assistant/conversation";
 import { AgentStepContentResource } from "@app/lib/resources/agent_step_content_resource";
 import { ConversationResource } from "@app/lib/resources/conversation_resource";
+import logger from "@app/logger/logger";
 import type { ConversationWithoutContentType } from "@app/types";
+import {
+  getRunAgentData,
+  RunAgentAsynchronousArgs,
+} from "@app/types/assistant/agent_run";
+import _ from "lodash";
 
 // Process database operations for agent events before publishing to Redis.
 async function processEventForDatabase(
@@ -189,4 +199,70 @@ export async function notifyWorkflowError(
     conversation,
     step: 0, // Workflow-level error, not tied to a specific step
   });
+}
+
+/**
+ * Activity executed after a cancel signal
+ */
+export async function finalizeCancellationActivity(
+  authType: AuthenticatorType,
+  runAgentArgs: RunAgentAsynchronousArgs
+): Promise<void> {
+  const runAgentDataRes = await getRunAgentData(authType, {
+    sync: false,
+    idArgs: runAgentArgs,
+  });
+  if (runAgentDataRes.isErr()) {
+    throw new Error(
+      `Failed to get run agent data: ${runAgentDataRes.error.message}`
+    );
+  }
+  const {
+    auth,
+    agentConfiguration,
+    agentMessage,
+    conversation,
+    agentMessageRow,
+  } = runAgentDataRes.value;
+
+  // get the last step of the agent message
+  const step = _.maxBy(agentMessage.contents, "step")?.step || 0;
+
+  const contentParser = new AgentMessageContentParser(
+    agentConfiguration,
+    agentMessage.sId,
+    getDelimitersConfiguration({ agentConfiguration })
+  );
+
+  // Helper function to flush all pending tokens from the content parser
+  async function flushParserTokens(): Promise<void> {
+    for await (const tokenEvent of contentParser.flushTokens()) {
+      await updateResourceAndPublishEvent(auth, {
+        event: tokenEvent,
+        agentMessageRow,
+        conversation,
+        step,
+      });
+    }
+  }
+
+  await flushParserTokens();
+  await updateResourceAndPublishEvent(auth, {
+    event: {
+      type: "agent_generation_cancelled",
+      created: Date.now(),
+      configurationId: agentConfiguration.sId,
+      messageId: agentMessage.sId,
+    },
+    agentMessageRow,
+    conversation,
+    step,
+  });
+  logger.error(
+    {
+      agentMessageId: agentMessage.sId,
+      conversationId: conversation.sId,
+    },
+    "Agent generation cancelled"
+  );
 }

--- a/front/temporal/agent_loop/client.ts
+++ b/front/temporal/agent_loop/client.ts
@@ -5,6 +5,7 @@ import { DustError } from "@app/lib/error";
 import { getTemporalClientForAgentNamespace } from "@app/lib/temporal";
 import logger from "@app/logger/logger";
 import { makeAgentLoopWorkflowId } from "@app/temporal/agent_loop/lib/workflow_ids";
+import assert from "assert";
 import type { Result } from "@app/types";
 import { Err, Ok } from "@app/types";
 import type { RunAgentAsynchronousArgs } from "@app/types/assistant/agent_run";
@@ -27,11 +28,12 @@ export async function launchAgentLoopWorkflow({
 > {
   const client = await getTemporalClientForAgentNamespace();
 
-  const workflowId = makeAgentLoopWorkflowId(
-    authType.workspaceId,
-    runAsynchronousAgentArgs.conversationId,
-    runAsynchronousAgentArgs.agentMessageId
-  );
+  assert(authType.workspaceId, "Workspace ID is required");
+  const workflowId = makeAgentLoopWorkflowId({
+    workspaceId: authType.workspaceId,
+    conversationId: runAsynchronousAgentArgs.conversationId,
+    agentMessageId: runAsynchronousAgentArgs.agentMessageId,
+  });
 
   try {
     await client.workflow.start(agentLoopWorkflow, {

--- a/front/temporal/agent_loop/client.ts
+++ b/front/temporal/agent_loop/client.ts
@@ -28,8 +28,9 @@ export async function launchAgentLoopWorkflow({
   const client = await getTemporalClientForAgentNamespace();
 
   const workflowId = makeAgentLoopWorkflowId(
-    authType,
-    runAsynchronousAgentArgs
+    authType.workspaceId,
+    runAsynchronousAgentArgs.conversationId,
+    runAsynchronousAgentArgs.agentMessageId
   );
 
   try {

--- a/front/temporal/agent_loop/lib/run_model.ts
+++ b/front/temporal/agent_loop/lib/run_model.ts
@@ -51,8 +51,8 @@ import type {
   TextContentType,
 } from "@app/types/assistant/agent_message_content";
 import type { RunAgentExecutionData } from "@app/types/assistant/agent_run";
+import { heartbeat } from "@temporalio/activity";
 
-const CANCELLATION_CHECK_INTERVAL = 500;
 const MAX_AUTO_RETRY = 3;
 
 // This method is used by the multi-actions execution loop to pick the next
@@ -450,9 +450,6 @@ export async function runModelActivity(
     >;
   } | null = null;
 
-  let shouldYieldCancel = false;
-  let lastCheckCancellation = Date.now();
-  const redis = await getRedisClient({ origin: "assistant_generation" });
   let isGeneration = true;
 
   const contentParser = new AgentMessageContentParser(
@@ -460,27 +457,6 @@ export async function runModelActivity(
     agentMessage.sId,
     getDelimitersConfiguration({ agentConfiguration })
   );
-
-  async function checkCancellation() {
-    try {
-      const cancelled = await redis.get(
-        `assistant:generation:cancelled:${agentMessage.sId}`
-      );
-      if (cancelled === "1") {
-        shouldYieldCancel = true;
-        await redis.set(
-          `assistant:generation:cancelled:${agentMessage.sId}`,
-          0,
-          {
-            EX: 3600, // 1 hour
-          }
-        );
-      }
-    } catch (error) {
-      localLogger.error({ error }, "Error checking cancellation");
-      return false;
-    }
-  }
 
   let nativeChainOfThought = "";
 
@@ -497,32 +473,8 @@ export async function runModelActivity(
       return handlePossiblyRetryableError(event.content.message);
     }
 
-    const currentTimestamp = Date.now();
-    if (
-      currentTimestamp - lastCheckCancellation >=
-      CANCELLATION_CHECK_INTERVAL
-    ) {
-      void checkCancellation(); // Trigger the async function without awaiting
-      lastCheckCancellation = currentTimestamp;
-    }
-
-    if (shouldYieldCancel) {
-      await flushParserTokens();
-      await updateResourceAndPublishEvent(auth, {
-        event: {
-          type: "agent_generation_cancelled",
-          created: Date.now(),
-          configurationId: agentConfiguration.sId,
-          messageId: agentMessage.sId,
-        },
-        agentMessageRow,
-        conversation,
-        step,
-      });
-      localLogger.error("Agent generation cancelled");
-
-      return null;
-    }
+    // Heartbeat allows the activity to be cancelled, e.g. on a "Stop agent" request.
+    heartbeat();
 
     if (event.type === "tokens" && isGeneration) {
       for await (const tokenEvent of contentParser.emitTokens(

--- a/front/temporal/agent_loop/lib/run_model.ts
+++ b/front/temporal/agent_loop/lib/run_model.ts
@@ -1,3 +1,4 @@
+import { heartbeat } from "@temporalio/activity";
 import assert from "assert";
 
 import { buildToolSpecification } from "@app/lib/actions/mcp";
@@ -51,7 +52,6 @@ import type {
   TextContentType,
 } from "@app/types/assistant/agent_message_content";
 import type { RunAgentExecutionData } from "@app/types/assistant/agent_run";
-import { heartbeat } from "@temporalio/activity";
 
 const MAX_AUTO_RETRY = 3;
 

--- a/front/temporal/agent_loop/lib/workflow_ids.ts
+++ b/front/temporal/agent_loop/lib/workflow_ids.ts
@@ -1,12 +1,15 @@
 import type { AuthenticatorType } from "@app/lib/auth";
 import type { RunAgentAsynchronousArgs } from "@app/types/assistant/agent_run";
 
-export function makeAgentLoopWorkflowId(args: {
+export function makeAgentLoopWorkflowId({
+  workspaceId,
+  conversationId,
+  agentMessageId,
+}: {
   workspaceId: string; // must be non-null workspace sId
   conversationId: string;
   agentMessageId: string;
 }) {
-  const { workspaceId, conversationId, agentMessageId } = args;
   return `agent-loop-workflow-${workspaceId}-${conversationId}-${agentMessageId}`;
 }
 

--- a/front/temporal/agent_loop/lib/workflow_ids.ts
+++ b/front/temporal/agent_loop/lib/workflow_ids.ts
@@ -6,7 +6,7 @@ export function makeAgentLoopWorkflowId({
   conversationId,
   agentMessageId,
 }: {
-  workspaceId: string; // must be non-null workspace sId
+  workspaceId: string;
   conversationId: string;
   agentMessageId: string;
 }) {

--- a/front/temporal/agent_loop/lib/workflow_ids.ts
+++ b/front/temporal/agent_loop/lib/workflow_ids.ts
@@ -1,11 +1,12 @@
 import type { AuthenticatorType } from "@app/lib/auth";
 import type { RunAgentAsynchronousArgs } from "@app/types/assistant/agent_run";
 
-export function makeAgentLoopWorkflowId(
-  workspaceId: string | null,
-  conversationId: string,
-  agentMessageId: string
-) {
+export function makeAgentLoopWorkflowId(args: {
+  workspaceId: string; // must be non-null workspace sId
+  conversationId: string;
+  agentMessageId: string;
+}) {
+  const { workspaceId, conversationId, agentMessageId } = args;
   return `agent-loop-workflow-${workspaceId}-${conversationId}-${agentMessageId}`;
 }
 

--- a/front/temporal/agent_loop/lib/workflow_ids.ts
+++ b/front/temporal/agent_loop/lib/workflow_ids.ts
@@ -2,12 +2,10 @@ import type { AuthenticatorType } from "@app/lib/auth";
 import type { RunAgentAsynchronousArgs } from "@app/types/assistant/agent_run";
 
 export function makeAgentLoopWorkflowId(
-  authType: AuthenticatorType,
-  runAgentArgs: RunAgentAsynchronousArgs
+  workspaceId: string | null,
+  conversationId: string,
+  agentMessageId: string
 ) {
-  const { workspaceId } = authType;
-  const { agentMessageId, conversationId } = runAgentArgs;
-
   return `agent-loop-workflow-${workspaceId}-${conversationId}-${agentMessageId}`;
 }
 

--- a/front/temporal/agent_loop/signals.ts
+++ b/front/temporal/agent_loop/signals.ts
@@ -5,4 +5,3 @@ import { defineSignal } from "@temporalio/workflow";
 export const cancelAgentLoopSignal = defineSignal<[void]>(
   "cancel_agent_loop_signal"
 );
-

--- a/front/temporal/agent_loop/signals.ts
+++ b/front/temporal/agent_loop/signals.ts
@@ -1,0 +1,8 @@
+import { defineSignal } from "@temporalio/workflow";
+
+// Signal to request cancellation of the agent loop workflow execution.
+// No payload required; the workflow should cancel in-flight activities and finish.
+export const cancelAgentLoopSignal = defineSignal<[void]>(
+  "cancel_agent_loop_signal"
+);
+

--- a/front/temporal/agent_loop/worker.ts
+++ b/front/temporal/agent_loop/worker.ts
@@ -69,7 +69,7 @@ export async function runAgentLoopWorker() {
   try {
     await worker.run(); // this resolves after shutdown completes
   } catch (error) {
-    console.error("Agent loop worker error:", error);
+    logger.error({ error }, "Agent loop worker error");
   } finally {
     await connection.close();
     process.exit(0);

--- a/front/temporal/agent_loop/worker.ts
+++ b/front/temporal/agent_loop/worker.ts
@@ -5,7 +5,10 @@ import TsconfigPathsPlugin from "tsconfig-paths-webpack-plugin";
 import { getTemporalAgentWorkerConnection } from "@app/lib/temporal";
 import { ActivityInboundLogInterceptor } from "@app/lib/temporal_monitoring";
 import logger from "@app/logger/logger";
-import { notifyWorkflowError } from "@app/temporal/agent_loop/activities/common";
+import {
+  notifyWorkflowError,
+  finalizeCancellationActivity,
+} from "@app/temporal/agent_loop/activities/common";
 import { ensureConversationTitleActivity } from "@app/temporal/agent_loop/activities/ensure_conversation_title";
 import {
   logAgentLoopPhaseCompletionActivity,
@@ -31,6 +34,7 @@ export async function runAgentLoopWorker() {
       logAgentLoopPhaseStartActivity,
       logAgentLoopStepCompletionActivity,
       notifyWorkflowError,
+      finalizeCancellationActivity,
       publishDeferredEventsActivity,
       runModelAndCreateActionsActivity,
       runToolActivity,

--- a/front/temporal/agent_loop/worker.ts
+++ b/front/temporal/agent_loop/worker.ts
@@ -6,8 +6,8 @@ import { getTemporalAgentWorkerConnection } from "@app/lib/temporal";
 import { ActivityInboundLogInterceptor } from "@app/lib/temporal_monitoring";
 import logger from "@app/logger/logger";
 import {
-  notifyWorkflowError,
   finalizeCancellationActivity,
+  notifyWorkflowError,
 } from "@app/temporal/agent_loop/activities/common";
 import { ensureConversationTitleActivity } from "@app/temporal/agent_loop/activities/ensure_conversation_title";
 import {

--- a/front/temporal/agent_loop/workflows.ts
+++ b/front/temporal/agent_loop/workflows.ts
@@ -3,8 +3,8 @@ import type { ChildWorkflowHandle } from "@temporalio/workflow";
 import {
   CancellationScope,
   proxyActivities,
-  startChild,
   setHandler,
+  startChild,
   workflowInfo,
 } from "@temporalio/workflow";
 

--- a/front/temporal/agent_loop/workflows.ts
+++ b/front/temporal/agent_loop/workflows.ts
@@ -4,6 +4,7 @@ import {
   CancellationScope,
   proxyActivities,
   startChild,
+  setHandler,
   workflowInfo,
 } from "@temporalio/workflow";
 
@@ -18,6 +19,7 @@ import type * as runToolActivities from "@app/temporal/agent_loop/activities/run
 import type { AgentLoopActivities } from "@app/temporal/agent_loop/lib/activity_interface";
 import { executeAgentLoop } from "@app/temporal/agent_loop/lib/agent_loop_executor";
 import { makeAgentLoopConversationTitleWorkflowId } from "@app/temporal/agent_loop/lib/workflow_ids";
+import { cancelAgentLoopSignal } from "@app/temporal/agent_loop/signals";
 import type {
   RunAgentArgs,
   RunAgentAsynchronousArgs,
@@ -70,7 +72,9 @@ const { ensureConversationTitleActivity } = proxyActivities<
   startToCloseTimeout: "5 minutes",
 });
 
-const { notifyWorkflowError } = proxyActivities<typeof commonActivities>({
+const { notifyWorkflowError, finalizeCancellationActivity } = proxyActivities<
+  typeof commonActivities
+>({
   startToCloseTimeout: "2 minutes",
   retry: {
     maximumAttempts: 5,
@@ -116,6 +120,15 @@ export async function agentLoopWorkflow({
     typeof agentLoopConversationTitleWorkflow
   > | null = null;
 
+  // Allow cancellation of in-flight activities via signal-triggered scope cancellation.
+  let cancelRequested = false;
+  const executionScope = new CancellationScope();
+
+  setHandler(cancelAgentLoopSignal, () => {
+    cancelRequested = true;
+    executionScope.cancel();
+  });
+
   try {
     // If conversation title is not set, launch a child workflow to generate the conversation title in
     // the background. If a workflow with the same ID is already running, ignore the error and
@@ -143,8 +156,10 @@ export async function agentLoopWorkflow({
     }
 
     // In Temporal workflows, we don't pass syncStartTime since async execution doesn't need timeout.
-    await executeAgentLoop(authType, runAgentArgs, activities, {
-      startStep,
+    await executionScope.run(async () => {
+      await executeAgentLoop(authType, runAgentArgs, activities, {
+        startStep,
+      });
     });
 
     if (childWorkflowHandle) {
@@ -155,13 +170,23 @@ export async function agentLoopWorkflow({
 
     // Notify error in a non-cancellable scope to ensure it runs even if workflow is cancelled
     await CancellationScope.nonCancellable(async () => {
-      await notifyWorkflowError(authType, {
-        conversationId: runAsynchronousAgentArgs.conversationId,
-        agentMessageId: runAsynchronousAgentArgs.agentMessageId,
-        agentMessageVersion: runAsynchronousAgentArgs.agentMessageVersion,
-        error: workflowError,
-      });
+      if (cancelRequested) {
+        // Run finalization tasks on cancellation (dummy for now).
+        await finalizeCancellationActivity(authType, runAsynchronousAgentArgs);
+      } else {
+        await notifyWorkflowError(authType, {
+          conversationId: runAsynchronousAgentArgs.conversationId,
+          agentMessageId: runAsynchronousAgentArgs.agentMessageId,
+          agentMessageVersion: runAsynchronousAgentArgs.agentMessageVersion,
+          error: workflowError,
+        });
+      }
     });
+
+    // If cancellation was explicitly requested via signal, finish gracefully without rethrowing.
+    if (cancelRequested) {
+      return;
+    }
 
     throw err;
   }


### PR DESCRIPTION
## Description
Fixes https://github.com/dust-tt/tasks/issues/4273 and https://github.com/dust-tt/tasks/issues/3814

- Update `cancelMessageGenerationEvent` to signal the associated agent loop workflow by ID, removing existing behavior (Redis cancel key and DB status update to "cancelled").
- Change `makeAgentLoopWorkflowId` to take `workspaceId`, `conversationId`, `agentMessageId` as args.
- Add `cancel_agent_loop_signal` and handle it in `agentLoopWorkflow` by cancelling in-flight activities using a `CancellationScope` and finishing. Run a non-cancellable finalization activity on cancellation that handles what was previously done.

## Risks
Blast radius: Agent conversation cancel path (front + agent Temporal worker), workflow ID callers, cancellation event publishing.
Risk: standard

## Deploy Plan
- Deploy front.
- No database migrations required.
