### PR TITLE
[sparkle] enh: Support serverside sorting in ScrollableDataTable

### DIFF
--- a/sparkle/src/components/DataTable.tsx
+++ b/sparkle/src/components/DataTable.tsx
@@ -242,7 +242,7 @@ export function DataTable<TData extends TBaseData>({
                         : undefined
                     }
                     className={cn(
-                      header.column.getCanSort() ? "s-cursor-pointer" : ""
+                      header.column.getCanSort() && "s-cursor-pointer"
                     )}
                   >
                     <div className="s-flex s-items-center s-space-x-1 s-whitespace-nowrap">
@@ -255,9 +255,7 @@ export function DataTable<TData extends TBaseData>({
                           visual={
                             header.column.getIsSorted() === "asc"
                               ? ArrowUpIcon
-                              : header.column.getIsSorted() === "desc"
-                                ? ArrowDownIcon
-                                : ArrowDownIcon
+                              : ArrowDownIcon
                           }
                           size="xs"
                           className={cn(
@@ -552,9 +550,9 @@ export function ScrollableDataTable<TData extends TBaseData>({
                       }
                       className={cn(
                         "s-max-w-0",
-                        header.column.getCanSort() && isSorting
-                          ? "s-cursor-pointer"
-                          : ""
+                        header.column.getCanSort() &&
+                          isSorting &&
+                          "s-cursor-pointer"
                       )}
                       style={{
                         width: columnSizing[header.id],
@@ -573,9 +571,7 @@ export function ScrollableDataTable<TData extends TBaseData>({
                             visual={
                               header.column.getIsSorted() === "asc"
                                 ? ArrowUpIcon
-                                : header.column.getIsSorted() === "desc"
-                                  ? ArrowDownIcon
-                                  : ArrowDownIcon
+                                : ArrowDownIcon
                             }
                             size="xs"
                             className={cn(


### PR DESCRIPTION
## Description

This allow support for sorting/setSorting in ScrollableDataTable. Only server side sorting can be supported as data are inherently server-side paginated.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

publish sparkle