### PR TITLE
Fix 'Add tools' button after removing the last tool

### DIFF
--- a/front/components/actions/mcp/AddActionMenu.tsx
+++ b/front/components/actions/mcp/AddActionMenu.tsx
@@ -8,7 +8,7 @@ import {
   PlusIcon,
   Spinner,
 } from "@dust-tt/sparkle";
-import { useState } from "react";
+import { useEffect, useState } from "react";
 
 import { getMcpServerDisplayName } from "@app/lib/actions/mcp_helper";
 import { getAvatar } from "@app/lib/actions/mcp_icons";
@@ -43,6 +43,15 @@ export const AddActionMenu = ({
       owner,
     });
 
+  const [portalContainer, setPortalContainer] = useState<
+    HTMLElement | undefined
+  >(undefined);
+  useEffect(() => {
+    if (typeof document !== "undefined") {
+      setPortalContainer(document.body);
+    }
+  }, []);
+
   return (
     <DropdownMenu modal={false}>
       <DropdownMenuTrigger asChild>
@@ -53,7 +62,10 @@ export const AddActionMenu = ({
           size="sm"
         />
       </DropdownMenuTrigger>
-      <DropdownMenuContent className="w-[500px]">
+      <DropdownMenuContent
+        className="w-[500px]"
+        mountPortalContainer={portalContainer}
+      >
         <DropdownMenuSearchbar
           className="flex-grow items-center gap-14"
           placeholder="Search tools..."


### PR DESCRIPTION
## Description

Fixes https://github.com/dust-tt/tasks/issues/4332

The issue comes from the Dropdown which searches for a container in the DOM and selects the last dialog container. 

https://github.com/dust-tt/dust/blob/79845fbdb47c78a8f7cffd341fa21e5ce9826995/sparkle/src/components/Dropdown.tsx#L313-L321

When deleting the last tools, the button renders while the "confirm delete" dialog is open and picked by the Dropdown instead of picking the document.body

I don't want to change the Dropdown because I dont want to impact other dropdown display. AddActionMenu is only used once so I chose to hardcode that is must display the menu is the document.body

## Tests

Manually deleted the last tools, the button is now usable

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
