### PR TITLE
Start refresh loop after file uploads/deletes

### DIFF
--- a/front/components/data_source/DocumentOrTableDeleteDialog.tsx
+++ b/front/components/data_source/DocumentOrTableDeleteDialog.tsx
@@ -24,12 +24,14 @@ interface DocumentOrTableDeleteDialogProps {
   dataSourceView: DataSourceViewType | null;
   owner: LightWorkspaceType;
   contentNode: LightContentNode | null;
+  onDeleteSuccess?: () => void;
 }
 
 export const DocumentOrTableDeleteDialog = ({
   dataSourceView,
   owner,
   contentNode,
+  onDeleteSuccess,
 }: DocumentOrTableDeleteDialogProps) => {
   const [isLoading, setIsLoading] = useState(false);
   const params = useQueryParams(["viewType", DocumentDeletionKey]);
@@ -78,6 +80,11 @@ export const DocumentOrTableDeleteDialog = ({
           `Deletion of ${contentNode.type} ${contentNode.title} is ongoing, ` +
           `it will complete shortly.`,
       });
+
+      if (onDeleteSuccess) {
+        onDeleteSuccess();
+      }
+
       closeDialog();
     } catch (error) {
       sendNotification({

--- a/front/components/spaces/ContentActions.tsx
+++ b/front/components/spaces/ContentActions.tsx
@@ -141,6 +141,7 @@ export const ContentActions = React.forwardRef<
           dataSourceView={dataSourceView}
           owner={owner}
           contentNode={currentAction.contentNode ?? null}
+          onDeleteSuccess={() => onSave("DeleteContentNode")}
         />
         <DataSourceViewDocumentModal
           owner={owner}

--- a/front/components/spaces/SpaceDataSourceViewContentList.tsx
+++ b/front/components/spaces/SpaceDataSourceViewContentList.tsx
@@ -48,6 +48,7 @@ import { useActionButtonsPortal } from "@app/hooks/useActionButtonsPortal";
 import { useCursorPaginationForDataTable } from "@app/hooks/useCursorPaginationForDataTable";
 import { useHashParam } from "@app/hooks/useHashParams";
 import { useSendNotification } from "@app/hooks/useNotification";
+import { usePeriodicRefresh } from "@app/hooks/usePeriodicRefresh";
 import { getVisualForDataSourceViewContentNode } from "@app/lib/content_nodes";
 import { isFolder, isManaged, isWebsite } from "@app/lib/data_sources";
 import {
@@ -348,6 +349,8 @@ export const SpaceDataSourceViewContentList = ({
     sorting: apiSorting,
   });
 
+  const { startPeriodicRefresh } = usePeriodicRefresh(mutateContentNodes);
+
   const { hasContent: hasDocuments, isNodesValidating: isDocumentsValidating } =
     useStaticDataSourceViewHasContent({
       owner,
@@ -527,6 +530,11 @@ export const SpaceDataSourceViewContentList = ({
   const onSaveAction = useCallback(
     async (action?: ContentActionKey) => {
       await mutateContentNodes();
+
+      // Since the content nodes have changed, we start a periodic refresh to ensure
+      // that any ongoing processing (e.g., file uploads) is reflected in the UI.
+      startPeriodicRefresh();
+
       if (
         action === "DocumentUploadOrEdit" ||
         action === "MultipleDocumentsUpload"
@@ -536,7 +544,7 @@ export const SpaceDataSourceViewContentList = ({
         handleViewTypeChange("table");
       }
     },
-    [handleViewTypeChange, mutateContentNodes]
+    [handleViewTypeChange, mutateContentNodes, startPeriodicRefresh]
   );
 
   const emptySpaceContent =

--- a/front/hooks/usePeriodicRefresh.ts
+++ b/front/hooks/usePeriodicRefresh.ts
@@ -1,0 +1,41 @@
+import { useCallback, useEffect, useRef } from "react";
+
+/**
+ * Hook for triggering periodic refreshes after operations like file upload or delete.
+ */
+export function usePeriodicRefresh(refreshFn: () => void | Promise<any>) {
+  const intervalRef = useRef<NodeJS.Timeout | null>(null);
+  const refreshCountRef = useRef<number>(0);
+
+  const startPeriodicRefresh = useCallback(() => {
+    // Clear any existing interval
+    if (intervalRef.current) {
+      clearInterval(intervalRef.current);
+    }
+
+    refreshCountRef.current = 0;
+
+    // Start periodic refresh every 5 seconds for 30 seconds (6 attempts total)
+    intervalRef.current = setInterval(() => {
+      refreshCountRef.current += 1;
+      void refreshFn();
+
+      if (refreshCountRef.current >= 6) {
+        if (intervalRef.current) {
+          clearInterval(intervalRef.current);
+          intervalRef.current = null;
+        }
+      }
+    }, 5000);
+  }, [refreshFn]);
+
+  useEffect(() => {
+    return () => {
+      if (intervalRef.current) {
+        clearInterval(intervalRef.current);
+      }
+    };
+  }, []);
+
+  return { startPeriodicRefresh };
+}

--- a/front/hooks/usePeriodicRefresh.ts
+++ b/front/hooks/usePeriodicRefresh.ts
@@ -2,8 +2,15 @@ import { useCallback, useEffect, useRef } from "react";
 
 /**
  * Hook for triggering periodic refreshes after operations like file upload or delete.
+ * @param refreshFn - Function to call for refreshing
+ * @param intervalMs - Time between refreshes in milliseconds (default: 5000ms)
+ * @param totalDurationMs - Total time to keep refreshing in milliseconds (default: 30000ms)
  */
-export function usePeriodicRefresh(refreshFn: () => void | Promise<any>) {
+export function usePeriodicRefresh(
+  refreshFn: () => void | Promise<any>,
+  intervalMs: number = 5000,
+  totalDurationMs: number = 30000
+) {
   const intervalRef = useRef<NodeJS.Timeout | null>(null);
   const refreshCountRef = useRef<number>(0);
 
@@ -14,20 +21,21 @@ export function usePeriodicRefresh(refreshFn: () => void | Promise<any>) {
     }
 
     refreshCountRef.current = 0;
+    const maxAttempts = Math.ceil(totalDurationMs / intervalMs);
 
-    // Start periodic refresh every 5 seconds for 30 seconds (6 attempts total)
+    // Start periodic refresh
     intervalRef.current = setInterval(() => {
       refreshCountRef.current += 1;
       void refreshFn();
 
-      if (refreshCountRef.current >= 6) {
+      if (refreshCountRef.current >= maxAttempts) {
         if (intervalRef.current) {
           clearInterval(intervalRef.current);
           intervalRef.current = null;
         }
       }
-    }, 5000);
-  }, [refreshFn]);
+    }, intervalMs);
+  }, [refreshFn, intervalMs, totalDurationMs]);
 
   useEffect(() => {
     return () => {

--- a/front/lib/swr/files.ts
+++ b/front/lib/swr/files.ts
@@ -4,6 +4,7 @@ import type { PublicFileResponseBodyType } from "@dust-tt/client";
 import type { Fetcher, SWRConfiguration } from "swr";
 
 import { useSendNotification } from "@app/hooks/useNotification";
+import { usePeriodicRefresh } from "@app/hooks/usePeriodicRefresh";
 import { useDataSourceViewContentNodes } from "@app/lib/swr/data_source_views";
 import {
   fetcher,
@@ -89,6 +90,7 @@ export function useUpsertFileAsDatasourceEntry(
     });
 
   const sendNotification = useSendNotification();
+  const { startPeriodicRefresh } = usePeriodicRefresh(mutateContentNodes);
 
   const doCreate = async (body: UpsertFileToDataSourceRequestBody) => {
     const upsertUrl = `/api/w/${owner.sId}/data_sources/${dataSourceView.dataSource.sId}/files`;
@@ -109,6 +111,7 @@ export function useUpsertFileAsDatasourceEntry(
       return null;
     } else {
       void mutateContentNodes();
+      startPeriodicRefresh();
 
       sendNotification({
         type: "success",


### PR DESCRIPTION
## Description

After a file upload or delete, we want the UI to automatically reflect the change. Before this change, this only happened if you refreshed the page, or if you switched to a different window and came back.

To address this, after an upload/delete, we start a loop where we refresh every 5 seconds for 30 seconds. The assumption is that most changes will be reflected before 30s. We don't want to do this more than necessary, since this adds extra requests for the backend to handle.

Fixes https://github.com/dust-tt/tasks/issues/4309

## Tests

Manual.

## Risk

Low.

## Deploy Plan

Front