### PR TITLE
[Assistant UX] Toggle Stop vs Retry in message actions

### DIFF
--- a/front/components/assistant/conversation/AgentMessage.tsx
+++ b/front/components/assistant/conversation/AgentMessage.tsx
@@ -421,7 +421,6 @@ export function AgentMessage({
     );
   }
 
-
   // References logic.
   function updateActiveReferences(document: MarkdownCitation, index: number) {
     const existingIndex = activeReferences.find((r) => r.index === index);

--- a/front/components/assistant/conversation/AgentMessage.tsx
+++ b/front/components/assistant/conversation/AgentMessage.tsx
@@ -358,7 +358,6 @@ export function AgentMessage({
     message.status !== "failed" &&
     messageStreamState.agentState !== "thinking"
   ) {
-    // Copy button.
     buttons.push(
       <Button
         key="copy-msg-button"

--- a/front/components/assistant/conversation/AgentMessage.tsx
+++ b/front/components/assistant/conversation/AgentMessage.tsx
@@ -358,6 +358,7 @@ export function AgentMessage({
     message.status !== "failed" &&
     messageStreamState.agentState !== "thinking"
   ) {
+    // Copy button
     buttons.push(
       <Button
         key="copy-msg-button"
@@ -367,23 +368,32 @@ export function AgentMessage({
         onClick={handleCopyToClipboard}
         icon={isCopied ? ClipboardCheckIcon : ClipboardIcon}
         className="text-muted-foreground"
-      />,
-      <Button
-        key="retry-msg-button"
-        tooltip="Retry"
-        variant="ghost-secondary"
-        size="xs"
-        onClick={() => {
-          void retryHandler({
-            conversationId,
-            messageId: agentMessageToRender.sId,
-          });
-        }}
-        icon={ArrowPathIcon}
-        className="text-muted-foreground"
-        disabled={isRetryHandlerProcessing || shouldStream}
-      />,
-      // One cannot leave feedback on global agents.
+      />
+    );
+
+    // Retry only when generation is finished (i.e., not "created").
+    if (agentMessageToRender.status !== "created") {
+      buttons.push(
+        <Button
+          key="retry-msg-button"
+          tooltip="Retry"
+          variant="ghost-secondary"
+          size="xs"
+          onClick={() => {
+            void retryHandler({
+              conversationId,
+              messageId: agentMessageToRender.sId,
+            });
+          }}
+          icon={ArrowPathIcon}
+          className="text-muted-foreground"
+          disabled={isRetryHandlerProcessing || shouldStream}
+        />
+      );
+    }
+
+    // Feedback (not on global agents nor drafts)
+    buttons.push(
       ...(isGlobalAgent || agentMessageToRender.configuration.status === "draft"
         ? []
         : [

--- a/front/components/assistant/conversation/AgentMessage.tsx
+++ b/front/components/assistant/conversation/AgentMessage.tsx
@@ -406,7 +406,7 @@ export function AgentMessage({
       );
     }
 
-    // Feedback (not on global agents nor drafts)
+    // Feedback (not on global agents nor drafts).
     buttons.push(
       ...(isGlobalAgent || agentMessageToRender.configuration.status === "draft"
         ? []

--- a/front/components/assistant/conversation/AgentMessage.tsx
+++ b/front/components/assistant/conversation/AgentMessage.tsx
@@ -358,7 +358,7 @@ export function AgentMessage({
     message.status !== "failed" &&
     messageStreamState.agentState !== "thinking"
   ) {
-    // Copy button
+    // Copy button.
     buttons.push(
       <Button
         key="copy-msg-button"

--- a/front/components/assistant/conversation/AgentMessage.tsx
+++ b/front/components/assistant/conversation/AgentMessage.tsx
@@ -371,8 +371,22 @@ export function AgentMessage({
       />
     );
 
-    // Retry only when generation is finished (i.e., not "created").
-    if (agentMessageToRender.status !== "created") {
+    // Second slot: Stop while generating, else Retry (same position).
+    if (agentMessageToRender.status === "created") {
+      buttons.push(
+        <Button
+          key="stop-msg-button"
+          tooltip="Stop agent"
+          variant="ghost-secondary"
+          size="xs"
+          onClick={async () => {
+            await cancelMessage([message.sId]);
+          }}
+          icon={StopIcon}
+          className="text-muted-foreground"
+        />
+      );
+    } else {
       buttons.push(
         <Button
           key="retry-msg-button"
@@ -407,22 +421,7 @@ export function AgentMessage({
     );
   }
 
-  // Add a per-agent stop control while generating.
-  if (agentMessageToRender.status === "created") {
-    buttons.push(
-      <Button
-        key="stop-msg-button"
-        tooltip="Stop agent"
-        variant="ghost-secondary"
-        size="xs"
-        onClick={async () => {
-          await cancelMessage([message.sId]);
-        }}
-        icon={StopIcon}
-        className="text-muted-foreground"
-      />
-    );
-  }
+  // Stop/Retry toggle handled above to keep a single position.
 
   // References logic.
   function updateActiveReferences(document: MarkdownCitation, index: number) {

--- a/front/components/assistant/conversation/AgentMessage.tsx
+++ b/front/components/assistant/conversation/AgentMessage.tsx
@@ -421,7 +421,6 @@ export function AgentMessage({
     );
   }
 
-  // Stop/Retry toggle handled above to keep a single position.
 
   // References logic.
   function updateActiveReferences(document: MarkdownCitation, index: number) {


### PR DESCRIPTION
## Description

Follow-up to #16200 : when an agent message is still generating, show the Stop button instead of Retry; when generation is finished, show Retry instead of Stop.

## Risks
Blast radius: Agent message action buttons
Risk: low

## Deploy Plan
- Deploy front (no migrations, no backend changes).
