### PR TITLE
[PQ] Fix: re-introduce assistant details modal

### DIFF
--- a/front/components/assistant/conversation/ConversationLayout.tsx
+++ b/front/components/assistant/conversation/ConversationLayout.tsx
@@ -21,10 +21,12 @@ import { FileDropProvider } from "@app/components/assistant/conversation/FileUpl
 import { GenerationContextProvider } from "@app/components/assistant/conversation/GenerationContextProvider";
 import { InputBarProvider } from "@app/components/assistant/conversation/input_bar/InputBarContext";
 import { AssistantSidebarMenu } from "@app/components/assistant/conversation/SidebarMenu";
+import { AssistantDetails } from "@app/components/assistant/details/AssistantDetails";
 import { WelcomeTourGuide } from "@app/components/assistant/WelcomeTourGuide";
 import { useWelcomeTourGuide } from "@app/components/assistant/WelcomeTourGuideProvider";
 import { ErrorBoundary } from "@app/components/error_boundary/ErrorBoundary";
 import AppContentLayout from "@app/components/sparkle/AppContentLayout";
+import { useURLSheet } from "@app/hooks/useURLSheet";
 import { useConversation } from "@app/lib/swr/conversations";
 import { useFeatureFlags } from "@app/lib/swr/workspaces";
 import type {
@@ -89,7 +91,8 @@ const ConversationLayoutContent = ({
   isAdmin,
 }: ConversationLayoutContentProps) => {
   const router = useRouter();
-
+  const { onOpenChange: onOpenChangeAssistantModal } =
+    useURLSheet("assistantDetails");
   const { activeConversationId } = useConversationsNavigation();
   const { conversation, conversationError } = useConversation({
     conversationId: activeConversationId,
@@ -104,6 +107,14 @@ const ConversationLayoutContent = ({
     () => hasFeature("co_edition"),
     [hasFeature]
   );
+
+  const assistantSId = useMemo(() => {
+    const sid = router.query.assistantDetails ?? [];
+    if (sid && typeof sid === "string") {
+      return sid;
+    }
+    return null;
+  }, [router.query.assistantDetails]);
 
   // Logic for the welcome tour guide. We display it if the welcome query param is set to true.
   const { startConversationRef, spaceMenuButtonRef, createAgentButtonRef } =
@@ -134,6 +145,12 @@ const ConversationLayoutContent = ({
           }
           navChildren={<AssistantSidebarMenu owner={owner} />}
         >
+          <AssistantDetails
+            owner={owner}
+            user={user}
+            assistantId={assistantSId}
+            onClose={() => onOpenChangeAssistantModal(false)}
+          />
           <CoEditionProvider
             owner={owner}
             hasCoEditionFeatureFlag={hasCoEditionFeatureFlag}

--- a/front/components/assistant/conversation/ConversationLayout.tsx
+++ b/front/components/assistant/conversation/ConversationLayout.tsx
@@ -37,6 +37,7 @@ import type {
   UserType,
   WorkspaceType,
 } from "@app/types";
+import { isString } from "@app/types";
 
 export interface ConversationLayoutProps {
   baseUrl: string;
@@ -110,7 +111,7 @@ const ConversationLayoutContent = ({
 
   const assistantSId = useMemo(() => {
     const sid = router.query.assistantDetails ?? [];
-    if (sid && typeof sid === "string") {
+    if (isString(sid)) {
       return sid;
     }
     return null;


### PR DESCRIPTION
## Description

This PR fixes a bug introduced by https://github.com/dust-tt/dust/pull/16190

It keeps the previous behavior for every component opening the assistant details modal through useURLSheet("assistantDetails") while making sure the opening of the AssistantDetails modal still opens through a state in AssistantBrowser

https://github.com/user-attachments/assets/f178c6e1-05be-4c59-a4e4-729e4cd38dec

## Tests

Tested visually cf video ⬆️

## Risk

low

## Deploy Plan

front
