### PR TITLE
[front] Align padding between tab contents in Poke workspace page

### DIFF
--- a/front/components/poke/subscriptions/table.tsx
+++ b/front/components/poke/subscriptions/table.tsx
@@ -92,81 +92,76 @@ export function ActiveSubscriptionTable({
   subscriptions: SubscriptionType[];
 }) {
   return (
-    <>
-      <div className="flex flex-col">
-        <div className="flex justify-between gap-3">
-          <div className="border-material-200 flex flex-grow flex-col rounded-lg border p-4">
-            <div className="flex items-center justify-between gap-3">
-              <h2 className="text-md flex-grow pb-4 font-bold">
-                Active Subscription
-              </h2>
-              <SubscriptionsHistoryModal
-                owner={owner}
-                subscriptions={subscriptions}
-              />
-              <UpgradeDowngradeModal
-                owner={owner}
-                subscription={subscription}
-              />
-            </div>
-            <PokeTable>
-              <PokeTableBody>
-                <PokeTableRow>
-                  <PokeTableCell>Plan Name</PokeTableCell>
-                  <PokeTableCell>{subscription.plan.name}</PokeTableCell>
-                </PokeTableRow>
-                <PokeTableRow>
-                  <PokeTableCell>Plan Code</PokeTableCell>
-                  <PokeTableCell>{subscription.plan.code}</PokeTableCell>
-                </PokeTableRow>
-                <PokeTableRow>
-                  <PokeTableCell>Is in Trial?</PokeTableCell>
-                  <PokeTableCell>
-                    {subscription.trialing ? "✅" : "❌"}
-                  </PokeTableCell>
-                </PokeTableRow>
-                <PokeTableRow>
-                  <PokeTableCell>Stripe Subscription Id</PokeTableCell>
-                  <PokeTableCell>
-                    {subscription.stripeSubscriptionId ? (
-                      <Link
-                        href={
-                          isDevelopment()
-                            ? `https://dashboard.stripe.com/test/subscriptions/${subscription.stripeSubscriptionId}`
-                            : `https://dashboard.stripe.com/subscriptions/${subscription.stripeSubscriptionId}`
-                        }
-                        target="_blank"
-                        className="text-xs text-highlight-400"
-                      >
-                        {subscription.stripeSubscriptionId}
-                      </Link>
-                    ) : (
-                      "No subscription id"
-                    )}
-                  </PokeTableCell>
-                </PokeTableRow>
-                <PokeTableRow>
-                  <PokeTableCell>Start Date</PokeTableCell>
-                  <PokeTableCell>
-                    {subscription.startDate
-                      ? format(subscription.startDate, "yyyy-MM-dd")
-                      : "/"}
-                  </PokeTableCell>
-                </PokeTableRow>
-                <PokeTableRow>
-                  <PokeTableCell>End Date</PokeTableCell>
-                  <PokeTableCell>
-                    {subscription.endDate
-                      ? format(subscription.endDate, "yyyy-MM-dd")
-                      : "/"}
-                  </PokeTableCell>
-                </PokeTableRow>
-              </PokeTableBody>
-            </PokeTable>
+    <div className="flex flex-col">
+      <div className="flex justify-between gap-3">
+        <div className="border-material-200 flex flex-grow flex-col rounded-lg border p-4 pb-2">
+          <div className="flex items-center justify-between gap-3">
+            <h2 className="text-md flex-grow pb-4 font-bold">
+              Active Subscription
+            </h2>
+            <SubscriptionsHistoryModal
+              owner={owner}
+              subscriptions={subscriptions}
+            />
+            <UpgradeDowngradeModal owner={owner} subscription={subscription} />
           </div>
+          <PokeTable>
+            <PokeTableBody>
+              <PokeTableRow>
+                <PokeTableCell>Plan Name</PokeTableCell>
+                <PokeTableCell>{subscription.plan.name}</PokeTableCell>
+              </PokeTableRow>
+              <PokeTableRow>
+                <PokeTableCell>Plan Code</PokeTableCell>
+                <PokeTableCell>{subscription.plan.code}</PokeTableCell>
+              </PokeTableRow>
+              <PokeTableRow>
+                <PokeTableCell>Is in Trial?</PokeTableCell>
+                <PokeTableCell>
+                  {subscription.trialing ? "✅" : "❌"}
+                </PokeTableCell>
+              </PokeTableRow>
+              <PokeTableRow>
+                <PokeTableCell>Stripe Subscription Id</PokeTableCell>
+                <PokeTableCell>
+                  {subscription.stripeSubscriptionId ? (
+                    <Link
+                      href={
+                        isDevelopment()
+                          ? `https://dashboard.stripe.com/test/subscriptions/${subscription.stripeSubscriptionId}`
+                          : `https://dashboard.stripe.com/subscriptions/${subscription.stripeSubscriptionId}`
+                      }
+                      target="_blank"
+                      className="text-xs text-highlight-400"
+                    >
+                      {subscription.stripeSubscriptionId}
+                    </Link>
+                  ) : (
+                    "No subscription id"
+                  )}
+                </PokeTableCell>
+              </PokeTableRow>
+              <PokeTableRow>
+                <PokeTableCell>Start Date</PokeTableCell>
+                <PokeTableCell>
+                  {subscription.startDate
+                    ? format(subscription.startDate, "yyyy-MM-dd")
+                    : "/"}
+                </PokeTableCell>
+              </PokeTableRow>
+              <PokeTableRow>
+                <PokeTableCell>End Date</PokeTableCell>
+                <PokeTableCell>
+                  {subscription.endDate
+                    ? format(subscription.endDate, "yyyy-MM-dd")
+                    : "/"}
+                </PokeTableCell>
+              </PokeTableRow>
+            </PokeTableBody>
+          </PokeTable>
         </div>
       </div>
-    </>
+    </div>
   );
 }
 
@@ -178,123 +173,119 @@ export function PlanLimitationsTable({
   const activePlan = subscription.plan;
 
   return (
-    <>
-      <div className="flex flex-col">
-        <div className="flex justify-between gap-3">
-          <div className="border-material-200 flex flex-grow flex-col rounded-lg border p-4">
-            <h2 className="text-md pb-4 font-bold">Plan limitations</h2>
-            <PokeTable>
-              <PokeTableBody>
-                <PokeTableRow>
-                  <PokeTableCell>SlackBot allowed</PokeTableCell>
-                  <PokeTableCell>
-                    {activePlan.limits.assistant.isSlackBotAllowed
-                      ? "✅"
-                      : "❌"}
-                  </PokeTableCell>
-                </PokeTableRow>
-                <PokeTableRow>
-                  <PokeTableCell>SSO/SCIM features</PokeTableCell>
-                  <PokeTableCell>
-                    {activePlan.limits.users.isSSOAllowed ? "SSO ✅" : "SSO ❌"}
-                    {activePlan.limits.users.isSCIMAllowed
-                      ? " SCIM ✅"
-                      : " SCIM ❌"}
-                  </PokeTableCell>
-                </PokeTableRow>
-                <PokeTableRow>
-                  <PokeTableCell>Connections allowed</PokeTableCell>
-                  <PokeTableCell>
-                    <div className="flex gap-2">
-                      {activePlan.limits.connections.isSlackAllowed ? (
-                        <SlackLogo />
-                      ) : null}
-                      {activePlan.limits.connections.isGoogleDriveAllowed ? (
-                        <GoogleLogo />
-                      ) : null}
-                      {activePlan.limits.connections.isGithubAllowed ? (
-                        <GithubLogo />
-                      ) : null}
-                      {activePlan.limits.connections.isNotionAllowed ? (
-                        <NotionLogo />
-                      ) : null}
-                      {activePlan.limits.connections.isIntercomAllowed ? (
-                        <IntercomLogo />
-                      ) : null}
-                      {activePlan.limits.connections.isConfluenceAllowed ? (
-                        <ConfluenceLogo />
-                      ) : null}
-                      {activePlan.limits.connections.isWebCrawlerAllowed ? (
-                        <GlobeAltIcon />
-                      ) : null}
-                      {activePlan.limits.connections.isSalesforceAllowed ? (
-                        <SalesforceLogo />
-                      ) : null}
-                    </div>
-                  </PokeTableCell>
-                </PokeTableRow>
+    <div className="flex flex-col">
+      <div className="flex justify-between gap-3">
+        <div className="border-material-200 flex flex-grow flex-col rounded-lg border p-4 pb-2">
+          <h2 className="text-md pb-4 font-bold">Plan limitations</h2>
+          <PokeTable>
+            <PokeTableBody>
+              <PokeTableRow>
+                <PokeTableCell>SlackBot allowed</PokeTableCell>
+                <PokeTableCell>
+                  {activePlan.limits.assistant.isSlackBotAllowed ? "✅" : "❌"}
+                </PokeTableCell>
+              </PokeTableRow>
+              <PokeTableRow>
+                <PokeTableCell>SSO/SCIM features</PokeTableCell>
+                <PokeTableCell>
+                  {activePlan.limits.users.isSSOAllowed ? "SSO ✅" : "SSO ❌"}
+                  {activePlan.limits.users.isSCIMAllowed
+                    ? " SCIM ✅"
+                    : " SCIM ❌"}
+                </PokeTableCell>
+              </PokeTableRow>
+              <PokeTableRow>
+                <PokeTableCell>Connections allowed</PokeTableCell>
+                <PokeTableCell>
+                  <div className="flex gap-2">
+                    {activePlan.limits.connections.isSlackAllowed ? (
+                      <SlackLogo />
+                    ) : null}
+                    {activePlan.limits.connections.isGoogleDriveAllowed ? (
+                      <GoogleLogo />
+                    ) : null}
+                    {activePlan.limits.connections.isGithubAllowed ? (
+                      <GithubLogo />
+                    ) : null}
+                    {activePlan.limits.connections.isNotionAllowed ? (
+                      <NotionLogo />
+                    ) : null}
+                    {activePlan.limits.connections.isIntercomAllowed ? (
+                      <IntercomLogo />
+                    ) : null}
+                    {activePlan.limits.connections.isConfluenceAllowed ? (
+                      <ConfluenceLogo />
+                    ) : null}
+                    {activePlan.limits.connections.isWebCrawlerAllowed ? (
+                      <GlobeAltIcon />
+                    ) : null}
+                    {activePlan.limits.connections.isSalesforceAllowed ? (
+                      <SalesforceLogo />
+                    ) : null}
+                  </div>
+                </PokeTableCell>
+              </PokeTableRow>
 
-                <PokeTableRow>
-                  <PokeTableCell>Max number of users</PokeTableCell>
-                  <PokeTableCell>
-                    {activePlan.limits.users.maxUsers === -1
-                      ? "unlimited"
-                      : activePlan.limits.users.maxUsers}
-                  </PokeTableCell>
-                </PokeTableRow>
+              <PokeTableRow>
+                <PokeTableCell>Max number of users</PokeTableCell>
+                <PokeTableCell>
+                  {activePlan.limits.users.maxUsers === -1
+                    ? "unlimited"
+                    : activePlan.limits.users.maxUsers}
+                </PokeTableCell>
+              </PokeTableRow>
 
-                <PokeTableRow>
-                  <PokeTableCell>Max number of spaces</PokeTableCell>
-                  <PokeTableCell>
-                    {activePlan.limits.vaults.maxVaults === -1
-                      ? "unlimited"
-                      : activePlan.limits.vaults.maxVaults}
-                  </PokeTableCell>
-                </PokeTableRow>
+              <PokeTableRow>
+                <PokeTableCell>Max number of spaces</PokeTableCell>
+                <PokeTableCell>
+                  {activePlan.limits.vaults.maxVaults === -1
+                    ? "unlimited"
+                    : activePlan.limits.vaults.maxVaults}
+                </PokeTableCell>
+              </PokeTableRow>
 
-                <PokeTableRow>
-                  <PokeTableCell>Max number of messages</PokeTableCell>
-                  <PokeTableCell>
-                    {activePlan.limits.assistant.maxMessages === -1
-                      ? "unlimited"
-                      : `${activePlan.limits.assistant.maxMessages} / ${activePlan.limits.assistant.maxMessagesTimeframe}`}
-                  </PokeTableCell>
-                </PokeTableRow>
+              <PokeTableRow>
+                <PokeTableCell>Max number of messages</PokeTableCell>
+                <PokeTableCell>
+                  {activePlan.limits.assistant.maxMessages === -1
+                    ? "unlimited"
+                    : `${activePlan.limits.assistant.maxMessages} / ${activePlan.limits.assistant.maxMessagesTimeframe}`}
+                </PokeTableCell>
+              </PokeTableRow>
 
-                <PokeTableRow>
-                  <PokeTableCell>Max number of data sources</PokeTableCell>
-                  <PokeTableCell>
-                    {activePlan.limits.dataSources.count === -1
-                      ? "unlimited"
-                      : activePlan.limits.dataSources.count}
-                  </PokeTableCell>
-                </PokeTableRow>
+              <PokeTableRow>
+                <PokeTableCell>Max number of data sources</PokeTableCell>
+                <PokeTableCell>
+                  {activePlan.limits.dataSources.count === -1
+                    ? "unlimited"
+                    : activePlan.limits.dataSources.count}
+                </PokeTableCell>
+              </PokeTableRow>
 
-                <PokeTableRow>
-                  <PokeTableCell>
-                    Max number of documents in data sources
-                  </PokeTableCell>
-                  <PokeTableCell>
-                    {activePlan.limits.dataSources.documents.count === -1
-                      ? "unlimited"
-                      : activePlan.limits.dataSources.documents.count}
-                  </PokeTableCell>
-                </PokeTableRow>
+              <PokeTableRow>
+                <PokeTableCell>
+                  Max number of documents in data sources
+                </PokeTableCell>
+                <PokeTableCell>
+                  {activePlan.limits.dataSources.documents.count === -1
+                    ? "unlimited"
+                    : activePlan.limits.dataSources.documents.count}
+                </PokeTableCell>
+              </PokeTableRow>
 
-                <PokeTableRow>
-                  <PokeTableCell>Max documents size</PokeTableCell>
-                  <PokeTableCell>
-                    {activePlan.limits.dataSources.documents.sizeMb === -1
-                      ? "unlimited"
-                      : `${activePlan.limits.dataSources.documents.sizeMb}Mb`}
-                  </PokeTableCell>
-                </PokeTableRow>
-              </PokeTableBody>
-            </PokeTable>
-          </div>
+              <PokeTableRow>
+                <PokeTableCell>Max documents size</PokeTableCell>
+                <PokeTableCell>
+                  {activePlan.limits.dataSources.documents.sizeMb === -1
+                    ? "unlimited"
+                    : `${activePlan.limits.dataSources.documents.sizeMb}Mb`}
+                </PokeTableCell>
+              </PokeTableRow>
+            </PokeTableBody>
+          </PokeTable>
         </div>
       </div>
-    </>
+    </div>
   );
 }
 


### PR DESCRIPTION
## Description

- The bottom padding of the `WorkspaceInfoTable` was changed in https://github.com/dust-tt/dust/pull/16205.
- `WorkspaceInfoTable` is actually in a tab. This PR applies the same change for the other tabs.

## Tests

- Checked locally.

## Risk

- Low.

## Deploy Plan

- Deploy front.
