### PR TITLE
[front] Improve logged errors for cat tool

### DIFF
--- a/front/lib/actions/mcp_internal_actions/tools/data_sources_file_system/cat.ts
+++ b/front/lib/actions/mcp_internal_actions/tools/data_sources_file_system/cat.ts
@@ -93,7 +93,9 @@ export function registerCatTool(
           return new Err(
             new MCPError(
               `Could not find node: ${nodeId} (error: ${
-                searchResult.isErr() ? searchResult.error : "No nodes found"
+                searchResult.isErr()
+                  ? searchResult.error.message
+                  : "No nodes found"
               })`,
               { tracked: false }
             )
@@ -141,7 +143,7 @@ export function registerCatTool(
         if (readResult.isErr()) {
           return new Err(
             new MCPError(
-              `Could not read node: ${nodeId} (error: ${readResult.error})`
+              `Could not read node: ${nodeId} (error: ${readResult.error.message})`
             )
           );
         }


### PR DESCRIPTION
## Description

- We do have logs like [this](https://app.datadoghq.eu/logs?query=region%3Aeurope-west1%20%40toolName%3Acat%20%22Tool%20execution%20error%22&agg_m=count&agg_m_source=base&agg_t=count&clustering_pattern_field_path=message&cols=host%2Cworkspace.sId%2CtoolName%2Cerror&event=AwAAAZl7PfjRxSbHiAAAABhBWmw3UGdDb0FBQXppS1JfSzMtdWZ3QTEAAAAkZjE5OTdiM2YtNTM0OS00MGZjLWIxZGEtNDQ4M2NiMmRmYmExAAJynw&fromUser=true&messageDisplay=inline&refresh_mode=sliding&storage=hot&stream_sort=desc&viz=stream&from_ts=1758708880000&to_ts=1758712780000&live=false) (`[object Object]`).
- We are indeed trying to pass a `CoreAPIError` in a templated string.
- This PR extracts the message only (`CoreAPIError` does not actually inherit `Error` so not usable as a `cause`, it's only a code and a message).

## Tests

## Risk

- Low, only affects the log.

## Deploy Plan

- Deploy front.
