### PR TITLE
[front] - chore(ToolPicker): replace Spinner with loading blocks

### DIFF
--- a/front/components/assistant/ToolsPicker.tsx
+++ b/front/components/assistant/ToolsPicker.tsx
@@ -9,7 +9,7 @@ import {
   DropdownMenuSeparator,
   DropdownMenuTrigger,
   Icon,
-  Spinner,
+  LoadingBlock,
 } from "@dust-tt/sparkle";
 import { useMemo, useState } from "react";
 
@@ -27,6 +27,24 @@ import {
 } from "@app/lib/swr/mcp_servers";
 import { useSpaces } from "@app/lib/swr/spaces";
 import type { WorkspaceType } from "@app/types";
+
+function ToolsPickerLoading({ count = 5 }: { count?: number }) {
+  return (
+    <div className="py-1">
+      {Array.from({ length: count }).map((_, i) => (
+        <div key={`tools-picker-loading-${i}`} className="px-1 py-1">
+          <div className="flex items-center gap-3 rounded-md p-2">
+            <LoadingBlock className="h-5 w-5 rounded-full" />
+            <div className="flex min-w-0 flex-1 flex-col gap-1">
+              <LoadingBlock className="h-4 w-[80%]" />
+              <LoadingBlock className="h-3 w-[60%]" />
+            </div>
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+}
 
 interface ToolsPickerProps {
   owner: WorkspaceType;
@@ -210,13 +228,11 @@ export function ToolsPicker({
                 );
               })}
           </>
+        ) : isAutoServerViewsLoading || isManualServerViewsLoading ? (
+          <ToolsPickerLoading />
         ) : (
           <div className="flex items-center justify-center py-4 text-sm text-muted-foreground">
-            {isAutoServerViewsLoading || isManualServerViewsLoading ? (
-              <Spinner size="sm" />
-            ) : (
-              "No results found"
-            )}
+            No results found
           </div>
         )}
       </DropdownMenuContent>


### PR DESCRIPTION
## Description

This PR replaces the `Toolpicker` spinner with some loading blocks.

<img width="917" height="708" alt="Screenshot 2025-09-24 at 14 53 24" src="https://github.com/user-attachments/assets/8fc18d82-98c4-4fe2-88e0-b52bdf31d17a" />

## Tests

Locally

## Risk

Low

## Deploy Plan

Deploy front
