### PR TITLE
[Message Breakdown] Remove extra spacing above code blocks by rendering actions inside

### DIFF
--- a/sparkle/src/components/markdown/CodeBlockWithExtendedSupport.tsx
+++ b/sparkle/src/components/markdown/CodeBlockWithExtendedSupport.tsx
@@ -451,6 +451,8 @@ export function CodeBlockWithExtendedSupport({
     <ContentBlockWrapper
       content={validChildrenContent}
       getContentToDownload={getContentToDownload}
+      buttonDisplay="inside"
+      displayActions="hover"
     >
       <CodeBlock className={className} inline={inline}>
         {children}


### PR DESCRIPTION
Fixes https://github.com/dust-tt/tasks/issues/4370

## Description
- Eliminates the large blank space above single-line code blocks in the Message Breakdown panel and other Markdown-rendered code blocks.
- Change: default Markdown code blocks now use ContentBlockWrapper with `buttonDisplay="inside"` and `displayActions="hover"` in `CodeBlockWithExtendedSupport`.
- Keeps copy/download controls, but shows them inside the block on hover to avoid adding an external spacer.

<img width="1204" height="296" alt="image" src="https://github.com/user-attachments/assets/f621a0f9-5ccf-447a-ac86-29827df4708e" />
<img width="1204" height="296" alt="image" src="https://github.com/user-attachments/assets/cdf626a2-bb3b-4f00-b2a6-5b28301acdbb" />


## Risks
Blast radius: Markdown code block UI across Front/Sparkle surfaces that use `CodeBlockWithExtendedSupport` (rendering only; no logic changes)
Risk: low

## Deploy Plan
- Front deploy only. No migrations.
- Verify code blocks in Message Breakdown and standard assistant messages render without extra top spacing and copy controls appear on hover.