### PR TITLE
Decode sqids when viewing raw objects in poke

### DIFF
--- a/front/components/poke/data_sources/view.tsx
+++ b/front/components/poke/data_sources/view.tsx
@@ -22,7 +22,11 @@ import {
 } from "@app/components/poke/shadcn/ui/table";
 import { useTheme } from "@app/components/sparkle/ThemeContext";
 import { isWebhookBasedProvider } from "@app/lib/connector_providers";
-import { decodeSqids, formatTimestampToFriendlyDate, timeAgoFrom } from "@app/lib/utils";
+import {
+  decodeSqids,
+  formatTimestampToFriendlyDate,
+  timeAgoFrom,
+} from "@app/lib/utils";
 import type {
   ConnectorType,
   CoreAPIDataSource,

--- a/front/components/poke/data_sources/view.tsx
+++ b/front/components/poke/data_sources/view.tsx
@@ -22,7 +22,7 @@ import {
 } from "@app/components/poke/shadcn/ui/table";
 import { useTheme } from "@app/components/sparkle/ThemeContext";
 import { isWebhookBasedProvider } from "@app/lib/connector_providers";
-import { formatTimestampToFriendlyDate, timeAgoFrom } from "@app/lib/utils";
+import { decodeSqids, formatTimestampToFriendlyDate, timeAgoFrom } from "@app/lib/utils";
 import type {
   ConnectorType,
   CoreAPIDataSource,
@@ -275,21 +275,21 @@ function RawObjectsModal({
             <span className="text-sm font-bold">dataSource</span>
             <JsonViewer
               theme={isDark ? "dark" : "light"}
-              value={dataSource}
+              value={decodeSqids(dataSource)}
               rootName={false}
               defaultInspectDepth={1}
             />
             <span className="text-sm font-bold">coreDataSource</span>
             <JsonViewer
               theme={isDark ? "dark" : "light"}
-              value={coreDataSource}
+              value={decodeSqids(coreDataSource)}
               rootName={false}
               defaultInspectDepth={1}
             />
             <span className="text-sm font-bold">connector</span>
             <JsonViewer
               theme={isDark ? "dark" : "light"}
-              value={connector}
+              value={decodeSqids(connector)}
               rootName={false}
               defaultInspectDepth={1}
             />

--- a/front/pages/poke/[wId]/assistants/[aId]/index.tsx
+++ b/front/pages/poke/[wId]/assistants/[aId]/index.tsx
@@ -21,6 +21,7 @@ import { useTheme } from "@app/components/sparkle/ThemeContext";
 import { listsAgentConfigurationVersions } from "@app/lib/api/assistant/configuration/agent";
 import { getAuthors, getEditors } from "@app/lib/api/assistant/editors";
 import { withSuperUserAuthRequirements } from "@app/lib/iam/session";
+import { decodeSqids } from "@app/lib/utils";
 import type {
   AgentConfigurationType,
   UserType,
@@ -164,7 +165,7 @@ const AssistantDetailsPage = ({
                       </div>
                       <JsonViewer
                         theme={isDark ? "dark" : "light"}
-                        value={a.model}
+                        value={decodeSqids(a.model)}
                         rootName={false}
                         defaultInspectDepth={0}
                       />
@@ -182,7 +183,7 @@ const AssistantDetailsPage = ({
                           </div>
                           <JsonViewer
                             theme={isDark ? "dark" : "light"}
-                            value={action}
+                            value={decodeSqids(action)}
                             rootName={false}
                             defaultInspectDepth={0}
                           />

--- a/front/pages/poke/[wId]/data_sources/[dsId]/index.tsx
+++ b/front/pages/poke/[wId]/data_sources/[dsId]/index.tsx
@@ -31,7 +31,7 @@ import { getDisplayNameForDocument } from "@app/lib/data_sources";
 import { withSuperUserAuthRequirements } from "@app/lib/iam/session";
 import { DataSourceResource } from "@app/lib/resources/data_source_resource";
 import { getTemporalClientForConnectorsNamespace } from "@app/lib/temporal";
-import { timeAgoFrom } from "@app/lib/utils";
+import { decodeSqids, timeAgoFrom } from "@app/lib/utils";
 import logger from "@app/logger/logger";
 import { usePokeDocuments, usePokeTables } from "@app/poke/swr";
 import type {
@@ -872,7 +872,7 @@ function NotionUrlCheckOrFind({
                     <>
                       <JsonViewer
                         theme={isDark ? "dark" : "light"}
-                        value={urlDetails.page}
+                        value={decodeSqids(urlDetails.page)}
                         rootName={false}
                       />
                       {command === "find-url" && (
@@ -908,7 +908,7 @@ function NotionUrlCheckOrFind({
                     <>
                       <JsonViewer
                         theme={isDark ? "dark" : "light"}
-                        value={urlDetails.db}
+                        value={decodeSqids(urlDetails.db)}
                         rootName={false}
                       />
                       {command === "find-url" && (
@@ -1106,7 +1106,7 @@ function ZendeskTicketCheck({
                 <div className="mb-1 font-bold">Details</div>
                 <JsonViewer
                   theme={isDark ? "dark" : "light"}
-                  value={ticketDetails.ticket}
+                  value={decodeSqids(ticketDetails.ticket)}
                   rootName={false}
                 />
               </div>

--- a/front/pages/poke/[wId]/spaces/[spaceId]/apps/[appId]/index.tsx
+++ b/front/pages/poke/[wId]/spaces/[spaceId]/apps/[appId]/index.tsx
@@ -18,6 +18,7 @@ import { useTheme } from "@app/components/sparkle/ThemeContext";
 import config from "@app/lib/api/config";
 import { cleanSpecificationFromCore, getSpecification } from "@app/lib/api/run";
 import { withSuperUserAuthRequirements } from "@app/lib/iam/session";
+import { decodeSqids } from "@app/lib/utils";
 import { BaseDustProdActionRegistry } from "@app/lib/registry";
 import { AppResource } from "@app/lib/resources/app_resource";
 import { SpaceResource } from "@app/lib/resources/space_resource";
@@ -224,7 +225,7 @@ function AppSpecification({
       <div className="p-4">
         <JsonViewer
           theme={isDark ? "dark" : "light"}
-          value={specification}
+          value={decodeSqids(specification)}
           rootName={false}
           defaultInspectDepth={2}
         />

--- a/front/pages/poke/[wId]/spaces/[spaceId]/apps/[appId]/index.tsx
+++ b/front/pages/poke/[wId]/spaces/[spaceId]/apps/[appId]/index.tsx
@@ -18,10 +18,10 @@ import { useTheme } from "@app/components/sparkle/ThemeContext";
 import config from "@app/lib/api/config";
 import { cleanSpecificationFromCore, getSpecification } from "@app/lib/api/run";
 import { withSuperUserAuthRequirements } from "@app/lib/iam/session";
-import { decodeSqids } from "@app/lib/utils";
 import { BaseDustProdActionRegistry } from "@app/lib/registry";
 import { AppResource } from "@app/lib/resources/app_resource";
 import { SpaceResource } from "@app/lib/resources/space_resource";
+import { decodeSqids } from "@app/lib/utils";
 import logger from "@app/logger/logger";
 import type {
   AppType,

--- a/front/pages/poke/[wId]/trackers/[tId]/index.tsx
+++ b/front/pages/poke/[wId]/trackers/[tId]/index.tsx
@@ -6,7 +6,7 @@ import type { ReactElement } from "react-markdown/lib/react-markdown";
 import PokeLayout from "@app/components/poke/PokeLayout";
 import { useTheme } from "@app/components/sparkle/ThemeContext";
 import { withSuperUserAuthRequirements } from "@app/lib/iam/session";
-import { formatTimestampToFriendlyDate } from "@app/lib/utils";
+import { decodeSqids, formatTimestampToFriendlyDate } from "@app/lib/utils";
 import { usePokeTracker } from "@app/poke/swr/trackers";
 import type { WorkspaceType } from "@app/types";
 
@@ -66,7 +66,7 @@ export default function TrackerDetailPage({
                   <div className="font-bold">Raw Data</div>
                   <JsonViewer
                     theme={isDark ? "dark" : "light"}
-                    value={data}
+                    value={decodeSqids(data)}
                     defaultInspectDepth={0}
                   />
                 </div>


### PR DESCRIPTION
## Description

Many times, when seeing Sqids (e.g. msv_z2c3wZmBk0), I need to get the underlying resource ID (in this case 40). This change makes it so that when we view raw objects in Poke using JsonViewer, we automatically do that. It gets added in parentheses after the Sqids, e.g. "msv_z2c3wZmBk0 (40)". It looks like this, which shows a bunch of instances of this:

<img width="430" height="471" alt="Screenshot 2025-09-24 at 15 35 54" src="https://github.com/user-attachments/assets/bbba72ee-928f-462f-8514-ea0bed646e22" />


## Tests

Manual.

## Risk

Poke only.

## Deploy Plan

Front