### PR TITLE
Hide the reasoning tool

### DIFF
--- a/front/lib/actions/mcp_internal_actions/constants.ts
+++ b/front/lib/actions/mcp_internal_actions/constants.ts
@@ -1190,7 +1190,7 @@ The directive should be used to display a clickable version of the agent name in
   },
   reasoning: {
     id: 1007,
-    availability: "auto",
+    availability: "auto_hidden_builder",
     allowMultipleInstances: false,
     isRestricted: undefined,
     isPreview: false,


### PR DESCRIPTION
## Description

Reasoning Tool is being sunsetted as the rationale for having it earlier is no longer useful. See this thread: https://dust4ai.slack.com/archives/C09GAQP6T1R/p1758698575679109

This doesn't do any migrations or remove the tool on agents but hides it in the agent builder.

## Tests

Tested locally with an agent. The tool is still visible for agents with it already but otherwise is no longer in the agent builder.

## Risk

None.

## Deploy Plan

Deploy front.
