### PR TITLE
[connectors] Cleanup quota exceeded logs

### DIFF
--- a/connectors/src/lib/error.ts
+++ b/connectors/src/lib/error.ts
@@ -101,20 +101,23 @@ export class ExternalOAuthTokenError extends Error {
 }
 
 export class WorkspaceQuotaExceededError extends Error {
-  constructor(readonly innerError?: Error) {
-    super(innerError?.message);
+  constructor() {
+    super(
+      "The workspace quota has been exceeded. This will pause the connector. " +
+        "Action: not anything straightforward, the limit is hardcoded in the workspace quota function. " +
+        "It should realistically never happen for big workspaces."
+    );
     this.name = "WorkspaceQuotaExceededError";
-    this.message =
-      "The workspace quota has been exceeded. This will pause the connector. Action: not anything straightforward, the limit is hardcoded in the workspace quota function. It should realistically never happen for big workspaces.";
   }
 }
 
 export class DataSourceQuotaExceededError extends Error {
-  constructor(readonly innerError?: Error) {
-    super(innerError?.message);
+  constructor() {
+    super(
+      "A file size exceeded the allowed size. Action: temporarily increase the plan limit for file size to " +
+        "let the activity succeed."
+    );
     this.name = "DataSourceQuotaExceededError";
-    this.message =
-      "A file size exceeded the allowed size. Action: temporary increase the plan limit for file size to let the activity succeed.";
   }
 }
 

--- a/connectors/src/types/shared/retries.ts
+++ b/connectors/src/types/shared/retries.ts
@@ -60,12 +60,12 @@ export function withRetries<Args extends unknown[], Return>(
 
           if (errorType === "workspace_quota_error") {
             // This error will pause the connector.
-            throw new WorkspaceQuotaExceededError(e);
+            throw new WorkspaceQuotaExceededError();
           }
 
           if (errorType === "data_source_quota_error") {
             // This error is per file and will NOT pause the connector (important!).
-            throw new DataSourceQuotaExceededError(e);
+            throw new DataSourceQuotaExceededError();
           }
         }
         // If a predicate is provided and returns false, do not retry.


### PR DESCRIPTION
## Description

- These logs show up as [such](https://app.datadoghq.eu/logs?query=%28%22Activity%20failed%22%20OR%20%22Unhandled%20activity%20error%22%29%20%40attempt%3A%3E19%20%40dd.service%3Aconnectors-worker&agg_m=count&agg_m_source=base&agg_q=%40workflowId&agg_q_source=base&agg_t=count&cols=host%2Cservice&event=AwAAAZl8ITZLfR5NbAAAABhBWmw4SVRyVkFBRHFQOHVSZUxXWE1nQVgAAAAkZjE5OTdjMjEtNzQ4NC00ZmFmLTlmOTQtNTY1NzQwNTk0MjkyAAADwQ&fromUser=true&graphType=flamegraph&messageDisplay=inline&refresh_mode=paused&sort=time&spanID=6000198897476506285&storage=hot&stream_sort=time%2Cdesc&top_n=10&top_o=top&viz=stream&x_missing=true&from_ts=1758723994476&to_ts=1758724298987&live=false) (the `innerError` ends up being huge and potentially leaking a bunch of things).
- This PR hides the inner error from the logs (nothing critically useful AFAICT).

## Tests

## Risk

- Low.

## Deploy Plan

- Deploy connectors.
