### PR TITLE
[front] allow bulk remove all jit tools

### DIFF
--- a/front/components/assistant/ToolsPicker.tsx
+++ b/front/components/assistant/ToolsPicker.tsx
@@ -9,6 +9,7 @@ import {
   DropdownMenuTrigger,
   Icon,
   LoadingBlock,
+  TrashIcon,
 } from "@dust-tt/sparkle";
 import { useMemo, useState } from "react";
 
@@ -164,6 +165,21 @@ export function ToolsPicker({
                   setIsOpen(false);
                 }
               }}
+              button={
+                <Button
+                  type="submit"
+                  variant="ghost-secondary"
+                  size="sm"
+                  icon={TrashIcon}
+                  tooltip="Clear all selected tools"
+                  onClick={(e: Event) => {
+                    e.stopPropagation();
+                    e.preventDefault();
+                    selectedMCPServerViews.forEach((v) => onDeselect(v));
+                    setSearchText("");
+                  }}
+                />
+              }
             />
             <DropdownMenuSeparator />
           </>


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

https://github.com/user-attachments/assets/dde9ab26-43cb-4817-ba14-845d267fec45

New button to remove all tools at one time in the jit tools. When you have selected too much of them it's annoying to click on all of them.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

By hand

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

Low

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->

Deploy front