### PR TITLE
[front] fix(mcp): Fill in all configurable values

### DIFF
--- a/front/lib/actions/mcp_internal_actions/input_configuration.ts
+++ b/front/lib/actions/mcp_internal_actions/input_configuration.ts
@@ -1,6 +1,5 @@
 import type { InternalToolInputMimeType } from "@dust-tt/client";
 import { INTERNAL_MIME_TYPES } from "@dust-tt/client";
-import { Ajv } from "ajv";
 import assert from "assert";
 import type { JSONSchema7 as JSONSchema } from "json-schema";
 

--- a/front/lib/actions/mcp_internal_actions/input_configuration.ts
+++ b/front/lib/actions/mcp_internal_actions/input_configuration.ts
@@ -21,6 +21,7 @@ import {
   findSchemaAtPath,
   followInternalRef,
   isJSONSchemaObject,
+  iterateOverSchemaPropertiesRecursive,
   setValueAtPath,
 } from "@app/lib/utils/json_schemas";
 import type { WorkspaceType } from "@app/types";
@@ -237,7 +238,6 @@ function generateConfiguredInput({
         "string",
         (val): val is string => typeof val === "string"
       );
-
       return { value, mimeType };
     }
 
@@ -446,53 +446,23 @@ export function augmentInputsWithConfiguration({
   }
 
   const inputs = { ...rawInputs };
+  iterateOverSchemaPropertiesRecursive(inputSchema, (fullPath, propSchema) => {
+    for (const mimeType of Object.values(INTERNAL_MIME_TYPES.TOOL_INPUT)) {
+      if (isSchemaConfigurable(propSchema, mimeType)) {
+        const value = generateConfiguredInput({
+          owner,
+          actionConfiguration,
+          mimeType,
+          keyPath: fullPath.join("."),
+        });
 
-  const ajv = new Ajv({ allErrors: true, strict: false });
-
-  // Note: When using AJV validation, string patterns must use regex syntax (e.g. /^fil_/) instead
-  // of startsWith() to avoid "Invalid escape" errors. This is important because our Zod schemas are
-  // converted to JSON Schema for AJV validation, and AJV requires regex patterns for string
-  // validation.
-
-  const validate = ajv.compile(inputSchema);
-  const isValid = validate(inputs);
-
-  if (!isValid && validate.errors) {
-    for (const error of validate.errors) {
-      if (error.keyword !== "required" || !error.params.missingProperty) {
-        continue;
-      }
-      const missingProp = error.params.missingProperty;
-
-      const parentPath = error.instancePath
-        ? error.instancePath.split("/").filter(Boolean)
-        : [];
-
-      const fullPath = [...parentPath, missingProp];
-      let propSchema = findSchemaAtPath(inputSchema, fullPath);
-      // If the schema we found is a reference, follow it.
-      if (propSchema?.$ref) {
-        propSchema = followInternalRef(inputSchema, propSchema.$ref);
-      }
-
-      // If we found a schema and it has a matching MIME type, inject the value
-      if (propSchema) {
-        for (const mimeType of Object.values(INTERNAL_MIME_TYPES.TOOL_INPUT)) {
-          if (isSchemaConfigurable(propSchema, mimeType)) {
-            const value = generateConfiguredInput({
-              owner,
-              actionConfiguration,
-              mimeType,
-              keyPath: fullPath.join("."),
-            });
-
-            // We found a matching mimeType, augment the inputs
-            setValueAtPath(inputs, fullPath, value);
-          }
-        }
+        // We found a matching mimeType, augment the inputs
+        setValueAtPath(inputs, fullPath, value);
+        return false;
       }
     }
-  }
+    return true;
+  });
 
   return inputs;
 }


### PR DESCRIPTION
## Description

This replaces the logic to fill configurable actions in MCP - instead of validating then filling the fields thatwere in error, we iterate on all fields of the schema and see which one is configurable. Previously if any configurable fields was marked as "optional", the validation pass without error and the value was never filled.

## Tests

Tested on multiple MCP servers

## Risk

Issues with complex schema parsing, configured values not properly set

## Deploy Plan

deploy front
