### PR TITLE
[front] Fix Poke data source hint

### DIFF
--- a/front/pages/poke/[wId]/data_sources/[dsId]/index.tsx
+++ b/front/pages/poke/[wId]/data_sources/[dsId]/index.tsx
@@ -13,7 +13,6 @@ import {
   Tooltip,
 } from "@dust-tt/sparkle";
 import { JsonViewer } from "@textea/json-viewer";
-import capitalize from "lodash/capitalize";
 import type { InferGetServerSidePropsType } from "next";
 import { useRouter } from "next/router";
 import { useEffect, useState } from "react";
@@ -50,6 +49,7 @@ import {
   isSlackAutoReadPatterns,
   safeParseJSON,
 } from "@app/types";
+import { asDisplayName } from "@app/types/shared/utils/string_utils";
 
 const { TEMPORAL_CONNECTORS_NAMESPACE = "" } = process.env;
 
@@ -565,7 +565,10 @@ const DataSourcePage = ({
       {dataSource.connectorProvider && (
         <p>
           The data displayed here is fetched from <b>connectors</b>, please
-          refer to the method {capitalize(dataSource.connectorProvider)}
+          refer to the method{" "}
+          {capitalize(dataSource.connectorProvider)
+            .replace(/_\w/g, (char) => char.toUpperCase())
+            .replace("_", "")}
           ConnectorManager.retrievePermissions
         </p>
       )}

--- a/front/pages/poke/[wId]/data_sources/[dsId]/index.tsx
+++ b/front/pages/poke/[wId]/data_sources/[dsId]/index.tsx
@@ -13,6 +13,7 @@ import {
   Tooltip,
 } from "@dust-tt/sparkle";
 import { JsonViewer } from "@textea/json-viewer";
+import capitalize from "lodash/capitalize";
 import type { InferGetServerSidePropsType } from "next";
 import { useRouter } from "next/router";
 import { useEffect, useState } from "react";
@@ -49,7 +50,6 @@ import {
   isSlackAutoReadPatterns,
   safeParseJSON,
 } from "@app/types";
-import { asDisplayName } from "@app/types/shared/utils/string_utils";
 
 const { TEMPORAL_CONNECTORS_NAMESPACE = "" } = process.env;
 


### PR DESCRIPTION
## Description

- This PR fixes the subtitle we show in the Poke data source page, it rendered google drive as Google_drive instead of GoogleDrive.

## Tests

- Checked locally.

## Risk

- None

## Deploy Plan

- Deploy front.
