### PR TITLE
[front] enh(FS tools): remove `sortBy` parameter in `find`

### DIFF
--- a/front/lib/actions/mcp_internal_actions/servers/data_sources_file_system.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/data_sources_file_system.ts
@@ -388,7 +388,6 @@ const createServer = (
         query,
         dataSources,
         limit,
-        sortBy,
         nextPageCursor,
         rootNodeId,
         mimeTypes,
@@ -439,14 +438,6 @@ const createServer = (
           options: {
             cursor: nextPageCursor,
             limit,
-            sort: sortBy
-              ? [
-                  {
-                    field: sortBy,
-                    direction: getSearchNodesSortDirection(sortBy),
-                  },
-                ]
-              : undefined,
           },
         });
 

--- a/front/lib/actions/mcp_internal_actions/servers/data_sources_file_system.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/data_sources_file_system.ts
@@ -26,9 +26,7 @@ import {
 import { registerCatTool } from "@app/lib/actions/mcp_internal_actions/tools/data_sources_file_system/cat";
 import { registerListTool } from "@app/lib/actions/mcp_internal_actions/tools/data_sources_file_system/list";
 import {
-  DATA_SOURCE_FILE_SYSTEM_OPTION_PARAMETERS,
   extractDataSourceIdFromNodeId,
-  getSearchNodesSortDirection,
   isDataSourceNodeId,
   makeQueryResourceForFind,
 } from "@app/lib/actions/mcp_internal_actions/tools/data_sources_file_system/utils";
@@ -379,7 +377,20 @@ const createServer = (
         ConfigurableToolInputSchemas[
           INTERNAL_MIME_TYPES.TOOL_INPUT.DATA_SOURCE
         ],
-      ...DATA_SOURCE_FILE_SYSTEM_OPTION_PARAMETERS,
+      limit: z
+        .number()
+        .optional()
+        .describe(
+          "Maximum number of results to return. Initial searches should use 10-20."
+        ),
+      nextPageCursor: z
+        .string()
+        .optional()
+        .describe(
+          "Cursor for fetching the next page of results. This parameter should only be used to fetch " +
+            "the next page of a previous search. The value should be exactly the 'nextPageCursor' from " +
+            "the previous search result."
+        ),
     },
     withToolLogging(
       auth,

--- a/front/lib/actions/mcp_internal_actions/servers/data_sources_file_system.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/data_sources_file_system.ts
@@ -352,8 +352,7 @@ const createServer = (
         .describe(
           "The title to search for. This supports partial matching and does not require the " +
             "exact title. For example, searching for 'budget' will find 'Budget 2024.xlsx', " +
-            "'Q1 Budget Report', etc. This parameter is mutually exclusive with the `sortBy` " +
-            "parameter."
+            "'Q1 Budget Report', etc..."
         ),
       rootNodeId: z
         .string()

--- a/front/lib/actions/mcp_internal_actions/tools/data_sources_file_system/list.ts
+++ b/front/lib/actions/mcp_internal_actions/tools/data_sources_file_system/list.ts
@@ -49,6 +49,14 @@ const ListToolInputSchema = {
     ),
   dataSources:
     ConfigurableToolInputSchemas[INTERNAL_MIME_TYPES.TOOL_INPUT.DATA_SOURCE],
+  sortBy: z
+    .enum(["title", "timestamp"])
+    .optional()
+    .describe(
+      "Field to sort the results by. 'title' sorts alphabetically A-Z, 'timestamp' sorts by " +
+        "most recent first. If not specified, results are returned in the default order, which is " +
+        "folders first, then both documents and tables and alphabetically by title."
+    ),
   ...DATA_SOURCE_FILE_SYSTEM_OPTION_PARAMETERS,
 };
 

--- a/front/lib/actions/mcp_internal_actions/tools/data_sources_file_system/list.ts
+++ b/front/lib/actions/mcp_internal_actions/tools/data_sources_file_system/list.ts
@@ -7,9 +7,7 @@ import { FILESYSTEM_LIST_TOOL_NAME } from "@app/lib/actions/mcp_internal_actions
 import { ConfigurableToolInputSchemas } from "@app/lib/actions/mcp_internal_actions/input_schemas";
 import { renderSearchResults } from "@app/lib/actions/mcp_internal_actions/rendering";
 import {
-  DATA_SOURCE_FILE_SYSTEM_OPTION_PARAMETERS,
   extractDataSourceIdFromNodeId,
-  getSearchNodesSortDirection,
   isDataSourceNodeId,
   makeQueryResourceForList,
 } from "@app/lib/actions/mcp_internal_actions/tools/data_sources_file_system/utils";
@@ -57,7 +55,20 @@ const ListToolInputSchema = {
         "most recent first. If not specified, results are returned in the default order, which is " +
         "folders first, then both documents and tables and alphabetically by title."
     ),
-  ...DATA_SOURCE_FILE_SYSTEM_OPTION_PARAMETERS,
+  limit: z
+    .number()
+    .optional()
+    .describe(
+      "Maximum number of results to return. Initial searches should use 10-20."
+    ),
+  nextPageCursor: z
+    .string()
+    .optional()
+    .describe(
+      "Cursor for fetching the next page of results. This parameter should only be used to fetch " +
+        "the next page of a previous search. The value should be exactly the 'nextPageCursor' from " +
+        "the previous search result."
+    ),
 };
 
 export function registerListTool(
@@ -201,4 +212,16 @@ export function registerListTool(
       }
     )
   );
+}
+
+function getSearchNodesSortDirection(
+  field: "title" | "timestamp"
+): "asc" | "desc" {
+  switch (field) {
+    case "title":
+      return "asc"; // Alphabetical A-Z.
+
+    case "timestamp":
+      return "desc"; // Most recent first.
+  }
 }

--- a/front/lib/actions/mcp_internal_actions/tools/data_sources_file_system/utils.ts
+++ b/front/lib/actions/mcp_internal_actions/tools/data_sources_file_system/utils.ts
@@ -1,38 +1,8 @@
 import { INTERNAL_MIME_TYPES } from "@dust-tt/client";
-import { z } from "zod";
 
 import type { SearchQueryResourceType } from "@app/lib/actions/mcp_internal_actions/output_schemas";
 import { renderMimeType } from "@app/lib/actions/mcp_internal_actions/rendering";
 import { DATA_SOURCE_NODE_ID } from "@app/types";
-
-export const DATA_SOURCE_FILE_SYSTEM_OPTION_PARAMETERS = {
-  limit: z
-    .number()
-    .optional()
-    .describe(
-      "Maximum number of results to return. Initial searches should use 10-20."
-    ),
-  nextPageCursor: z
-    .string()
-    .optional()
-    .describe(
-      "Cursor for fetching the next page of results. This parameter should only be used to fetch " +
-        "the next page of a previous search. The value should be exactly the 'nextPageCursor' from " +
-        "the previous search result."
-    ),
-};
-
-export function getSearchNodesSortDirection(
-  field: "title" | "timestamp"
-): "asc" | "desc" {
-  switch (field) {
-    case "title":
-      return "asc"; // Alphabetical A-Z.
-
-    case "timestamp":
-      return "desc"; // Most recent first.
-  }
-}
 
 /**
  * Check if a node ID represents a data source node.

--- a/front/lib/actions/mcp_internal_actions/tools/data_sources_file_system/utils.ts
+++ b/front/lib/actions/mcp_internal_actions/tools/data_sources_file_system/utils.ts
@@ -12,16 +12,6 @@ export const DATA_SOURCE_FILE_SYSTEM_OPTION_PARAMETERS = {
     .describe(
       "Maximum number of results to return. Initial searches should use 10-20."
     ),
-  sortBy: z
-    .enum(["title", "timestamp"])
-    .optional()
-    .describe(
-      "Field to sort the results by. 'title' sorts alphabetically A-Z, 'timestamp' sorts by " +
-        "most recent first. If not specified, results are returned in default order, which is " +
-        "folders first, then both documents and tables and alphabetically by title. " +
-        "The default order should be kept unless there is a specific reason to change it. " +
-        "This parameter is mutually exclusive with the `query` parameter."
-    ),
   nextPageCursor: z
     .string()
     .optional()


### PR DESCRIPTION
## Description

- `sortBy` in the `find` is really best achieved with a `list`; `query` and `sortBy` are mutually exclusive anyway.
- We won't be able to list everything on a flattened view but this seems to be a minor use case (in any case should either be a different tool or an option on the `list` rather than on the `find`).

## Tests

## Risk

- Low.

## Deploy Plan

- Deploy front.
