### PR TITLE
[connectors] Increase Confluence start to close timeout for parents update

### DIFF
--- a/connectors/src/connectors/confluence/temporal/workflows.ts
+++ b/connectors/src/connectors/confluence/temporal/workflows.ts
@@ -57,7 +57,7 @@ const {
 const { confluenceUpdateContentParentIdsActivity } = proxyActivities<
   typeof activities
 >({
-  startToCloseTimeout: "60 minutes",
+  startToCloseTimeout: "90 minutes",
   heartbeatTimeout: "5 minutes",
 });
 


### PR DESCRIPTION
## Description

- This PR increases the start to close timeout to `confluenceUpdateContentParentIdsActivity`, which can be long if there are too many pages.

## Tests

## Risk

## Deploy Plan

- Deploy connectors.
