### PR TITLE
Add missing dark mode classes

### DIFF
--- a/front/components/assistant/conversation/ConversationMenu.tsx
+++ b/front/components/assistant/conversation/ConversationMenu.tsx
@@ -197,7 +197,7 @@ export function ConversationMenu({
                         />
                       }
                       disabled
-                      className="!text-foreground"
+                      className="!text-foreground dark:!text-foreground-night"
                     />
                   ))}
                 </>
@@ -217,7 +217,7 @@ export function ConversationMenu({
                         />
                       }
                       disabled
-                      className="!text-foreground"
+                      className="!text-foreground dark:!text-foreground-night"
                     />
                   ))}
                 </>


### PR DESCRIPTION
## Description

Fixes 
<img width="278" height="470" alt="Screenshot 2025-09-24 at 19 42 19" src="https://github.com/user-attachments/assets/0457a6b3-a1f3-4807-9ee3-525a4210b0af" />

It's a hack to put disable and then force the text color but I wanted a quick fix so decided not to refacto and just add the missing class 🙏🏻 

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

Deploy front