### PR TITLE
[front] Skip missing conversation in conversation deletion

### DIFF
--- a/front/lib/api/assistant/conversation/destroy.ts
+++ b/front/lib/api/assistant/conversation/destroy.ts
@@ -16,6 +16,7 @@ import { AgentMCPActionResource } from "@app/lib/resources/agent_mcp_action_reso
 import { ContentFragmentResource } from "@app/lib/resources/content_fragment_resource";
 import { ConversationResource } from "@app/lib/resources/conversation_resource";
 import { DataSourceResource } from "@app/lib/resources/data_source_resource";
+import logger from "@app/logger/logger";
 import type { ConversationWithoutContentType, ModelId } from "@app/types";
 import { removeNulls } from "@app/types";
 
@@ -141,6 +142,13 @@ export async function destroyConversation(
       { includeDeleted: true, dangerouslySkipPermissionFiltering: true }
     );
   if (conversationRes.isErr()) {
+    if (conversationRes.error.type === "conversation_not_found") {
+      logger.warn(
+        { conversationId, error: conversationRes.error },
+        "Attempting to delete non-existing conversation."
+      );
+      return;
+    }
     throw conversationRes.error;
   }
   const conversation = conversationRes.value;

--- a/front/lib/api/assistant/conversation/destroy.ts
+++ b/front/lib/api/assistant/conversation/destroy.ts
@@ -16,9 +16,13 @@ import { AgentMCPActionResource } from "@app/lib/resources/agent_mcp_action_reso
 import { ContentFragmentResource } from "@app/lib/resources/content_fragment_resource";
 import { ConversationResource } from "@app/lib/resources/conversation_resource";
 import { DataSourceResource } from "@app/lib/resources/data_source_resource";
-import logger from "@app/logger/logger";
-import type { ConversationWithoutContentType, ModelId } from "@app/types";
-import { removeNulls } from "@app/types";
+import type {
+  ConversationError,
+  ConversationWithoutContentType,
+  ModelId,
+  Result,
+} from "@app/types";
+import { Err, Ok, removeNulls } from "@app/types";
 
 const DESTROY_MESSAGE_BATCH = 50;
 
@@ -132,7 +136,7 @@ export async function destroyConversation(
   }: {
     conversationId: string;
   }
-) {
+): Promise<Result<void, ConversationError>> {
   const conversationRes =
     await ConversationResource.fetchConversationWithoutContent(
       auth,
@@ -142,15 +146,9 @@ export async function destroyConversation(
       { includeDeleted: true, dangerouslySkipPermissionFiltering: true }
     );
   if (conversationRes.isErr()) {
-    if (conversationRes.error.type === "conversation_not_found") {
-      logger.warn(
-        { conversationId, error: conversationRes.error },
-        "Attempting to delete non-existing conversation."
-      );
-      return;
-    }
-    throw conversationRes.error;
+    return new Err(conversationRes.error);
   }
+
   const conversation = conversationRes.value;
 
   const messages = await Message.findAll({
@@ -214,4 +212,6 @@ export async function destroyConversation(
   if (c) {
     await c.delete(auth);
   }
+
+  return new Ok(undefined);
 }

--- a/front/temporal/data_retention/activities.ts
+++ b/front/temporal/data_retention/activities.ts
@@ -87,7 +87,18 @@ export async function purgeConversationsBatchActivity({
         const result = await destroyConversation(auth, {
           conversationId: c.sId,
         });
-        if (result.isErr() && result.error.type !== "conversation_not_found") {
+        if (result.isErr()) {
+          if (result.error.type === "conversation_not_found") {
+            logger.warn(
+              {
+                workspaceId,
+                conversationId: c.sId,
+                error: result.error,
+              },
+              "Attempting to delete a non-existing conversation."
+            );
+            return;
+          }
           throw result.error;
         }
       },
@@ -165,7 +176,18 @@ export async function purgeAgentConversationsBatchActivity({
       const result = await destroyConversation(auth, {
         conversationId,
       });
-      if (result.isErr() && result.error.type !== "conversation_not_found") {
+      if (result.isErr()) {
+        if (result.error.type === "conversation_not_found") {
+          logger.warn(
+            {
+              workspaceId,
+              conversationId,
+              error: result.error,
+            },
+            "Attempting to delete a non-existing conversation."
+          );
+          return;
+        }
         throw result.error;
       }
     },

--- a/front/temporal/data_retention/activities.ts
+++ b/front/temporal/data_retention/activities.ts
@@ -83,7 +83,14 @@ export async function purgeConversationsBatchActivity({
 
     await concurrentExecutor(
       conversations,
-      async (c) => destroyConversation(auth, { conversationId: c.sId }),
+      async (c) => {
+        const result = await destroyConversation(auth, {
+          conversationId: c.sId,
+        });
+        if (result.isErr() && result.error.type !== "conversation_not_found") {
+          throw result.error;
+        }
+      },
       {
         concurrency: 4,
       }
@@ -154,7 +161,14 @@ export async function purgeAgentConversationsBatchActivity({
 
   await concurrentExecutor(
     conversationIds,
-    async (cId) => destroyConversation(auth, { conversationId: cId }),
+    async (conversationId) => {
+      const result = await destroyConversation(auth, {
+        conversationId,
+      });
+      if (result.isErr() && result.error.type !== "conversation_not_found") {
+        throw result.error;
+      }
+    },
     {
       concurrency: 4,
     }

--- a/front/temporal/scrub_workspace/activities.ts
+++ b/front/temporal/scrub_workspace/activities.ts
@@ -154,7 +154,12 @@ export async function deleteAllConversations(auth: Authenticator) {
   await concurrentExecutor(
     uniqueConversations,
     async (conversation) => {
-      await destroyConversation(auth, { conversationId: conversation.sId });
+      const result = await destroyConversation(auth, {
+        conversationId: conversation.sId,
+      });
+      if (result.isErr() && result.error.type !== "conversation_not_found") {
+        throw result.error;
+      }
     },
     {
       concurrency: 16,

--- a/front/temporal/scrub_workspace/activities.ts
+++ b/front/temporal/scrub_workspace/activities.ts
@@ -157,7 +157,18 @@ export async function deleteAllConversations(auth: Authenticator) {
       const result = await destroyConversation(auth, {
         conversationId: conversation.sId,
       });
-      if (result.isErr() && result.error.type !== "conversation_not_found") {
+      if (result.isErr()) {
+        if (result.error.type === "conversation_not_found") {
+          logger.warn(
+            {
+              workspaceId: workspace.sId,
+              conversationId: conversation.sId,
+              error: result.error,
+            },
+            "Attempting to delete a non-existing conversation."
+          );
+          return;
+        }
         throw result.error;
       }
     },


### PR DESCRIPTION
## Description

- This PR skips `conversation_not_found` errors when hard deleting a conversation.
- This is a short term fix to unblock the data retention workflow, which is additionally causing a high CPU load on our db ([logs](https://app.datadoghq.eu/logs?query=%28%22Activity%20failed%22%20OR%20%22Unhandled%20activity%20error%22%29%20%40attempt%3A%3E14%20%40dd.service%3Afront-worker&agg_m=count&agg_m_source=base&agg_t=count&cols=host%2Cservice&event=AwAAAZl9IZvnapIsdwAAABhBWmw5SWFTSkFBQlkySHI0czdLbmxRQXQAAAAkZjE5OTdkMjEtZWFmMC00NTljLWJiYzMtMjYxNmU5ZjA3YmUwAAPePw&link_source=monitor_notif&messageDisplay=inline&refresh_mode=sliding&storage=hot&stream_sort=desc&viz=stream&from_ts=1758738830029&to_ts=1758742430029&live=true)), we need to understand why this happens at all.
- 3 code paths affected: data retention for a workspace, data retention for an agent and workspace deletion.
- In call cases we delete conversations we just listed (technically we fetch them twice, which could be optimized but not IMHO not a huge deal and allows for early returning when the conversation was already deleted).

## Tests

- Tested by adding a workspace data retention, haven't triggered the log.

## Risk

- Medium; does affect the data retention but has no change of skipping conversations.

## Deploy Plan

- Deploy front.
