### PR TITLE
[front] Prevent rendering `ConversationSidePanelContent` without a `conversation`

### DIFF
--- a/front/components/agent_builder/AgentBuilderPreview.tsx
+++ b/front/components/agent_builder/AgentBuilderPreview.tsx
@@ -137,11 +137,13 @@ function PreviewContent({
         </div>
       </div>
 
-      <ConversationSidePanelContent
-        conversation={conversation}
-        owner={owner}
-        currentPanel={currentPanel}
-      />
+      {conversation && (
+        <ConversationSidePanelContent
+          conversation={conversation}
+          owner={owner}
+          currentPanel={currentPanel}
+        />
+      )}
     </>
   );
 }

--- a/front/components/assistant/conversation/ConversationSidePanelContainer.tsx
+++ b/front/components/assistant/conversation/ConversationSidePanelContainer.tsx
@@ -60,7 +60,7 @@ export default function ConversationSidePanelContainer({
           currentPanel && "absolute inset-0 md:relative md:inset-auto"
         )}
       >
-        {currentPanel && (
+        {currentPanel && conversation && (
           <ConversationSidePanelContent
             conversation={conversation}
             owner={owner}

--- a/front/components/assistant/conversation/ConversationSidePanelContent.tsx
+++ b/front/components/assistant/conversation/ConversationSidePanelContent.tsx
@@ -11,7 +11,7 @@ import {
 } from "@app/types/conversation_side_panel";
 
 interface ConversationSidePanelContentProps {
-  conversation: ConversationWithoutContentType | null;
+  conversation: ConversationWithoutContentType;
   owner: LightWorkspaceType;
   currentPanel: ConversationSidePanelType;
 }

--- a/front/components/assistant/conversation/actions/AgentActionsPanel.tsx
+++ b/front/components/assistant/conversation/actions/AgentActionsPanel.tsx
@@ -16,7 +16,7 @@ import type {
 } from "@app/types";
 
 interface AgentActionsPanelProps {
-  conversation: ConversationWithoutContentType | null;
+  conversation: ConversationWithoutContentType;
   owner: LightWorkspaceType;
 }
 
@@ -251,7 +251,7 @@ export function AgentActionsPanel({
     isMessageLoading,
     mutateMessage,
   } = useConversationMessage({
-    conversationId: conversation?.sId ?? null,
+    conversationId: conversation.sId,
     workspaceId: owner.sId,
     messageId: messageId ?? null,
   });

--- a/front/components/assistant/conversation/content_creation/ContentCreationContainer.tsx
+++ b/front/components/assistant/conversation/content_creation/ContentCreationContainer.tsx
@@ -13,7 +13,7 @@ import type {
 import { clientExecutableContentType } from "@app/types";
 
 interface ContentCreationContainerProps {
-  conversation: ConversationWithoutContentType | null;
+  conversation: ConversationWithoutContentType;
   owner: LightWorkspaceType;
 }
 

--- a/front/lib/swr/conversations.ts
+++ b/front/lib/swr/conversations.ts
@@ -522,7 +522,7 @@ export function useConversationMessage({
   messageId,
   options,
 }: {
-  conversationId: string | null;
+  conversationId: string;
   workspaceId: string;
   messageId: string | null;
   options?: {


### PR DESCRIPTION
## Description

- We do fetch on `/api/w/[wId]/assistant/conversation/null/messages/*` quite a lot (logs [here](https://app.datadoghq.eu/logs?query=%40dd.env%3Aprod%20%40url%3A%2Fapi%2Fw%2F%2A%2Fassistant%2Fconversations%2Fnull%2Fmessages%2F%2A%20%40apiError.api_error.type%3Aconversation_not_found&agg_m=count&agg_m_source=base&agg_t=count&clustering_pattern_field_path=message&cols=host%2Cservice&messageDisplay=inline&refresh_mode=sliding&storage=hot&stream_sort=desc&viz=stream&from_ts=1758727803937&to_ts=1758742203937&live=true)).
- This PR aims at preventing this by not rendering the `ConversationSidePanelContent` at all if we don't have a conversation.
- I suspect that the order of the rendering here is the reason why we have no conversation given that we do have a message ID.

## Tests

- Checked locally.

## Risk

- Small risk of creating an unwanted behavior.

## Deploy Plan

- Deploy front.
