### PR TITLE
[Agent Loop] Don't fail workflow after retry_on_interrupt exhaustion

### DIFF
--- a/front/lib/actions/constants.ts
+++ b/front/lib/actions/constants.ts
@@ -5,6 +5,8 @@ import type {
 
 export const DEFAULT_MCP_REQUEST_TIMEOUT_MS = 3 * 60 * 1000; // 3 minutes.
 
+export const RETRY_ON_INTERRUPT_MAX_ATTEMPTS = 15;
+
 // Stored in a separate file to prevent a circular dependency issue.
 
 // Use top_k of 768 as 512 worked really smoothly during initial tests. Might update to 1024 in the

--- a/front/lib/api/mcp/run_tool.ts
+++ b/front/lib/api/mcp/run_tool.ts
@@ -2,6 +2,7 @@
 import { McpError } from "@modelcontextprotocol/sdk/types.js";
 import { Context } from "@temporalio/activity";
 
+import { RETRY_ON_INTERRUPT_MAX_ATTEMPTS } from "@app/lib/actions/constants";
 import type {
   MCPApproveExecutionEvent,
   MCPErrorEvent,
@@ -33,7 +34,6 @@ import type {
   ConversationType,
 } from "@app/types";
 import { removeNulls } from "@app/types";
-import { RETRY_ON_INTERRUPT_MAX_ATTEMPTS } from "@app/lib/actions/constants";
 
 /**
  * Runs a tool with streaming for the given MCP action configuration.
@@ -136,7 +136,7 @@ export async function* runToolWithStreaming(
         getRetryPolicyFromToolConfiguration(toolConfiguration);
       if (retryPolicy === "retry_on_interrupt") {
         const info = Context.current().info;
-        const isLastAttempt = info.attempt >== RETRY_ON_INTERRUPT_MAX_ATTEMPTS;
+        const isLastAttempt = info.attempt >= RETRY_ON_INTERRUPT_MAX_ATTEMPTS;
         if (!isLastAttempt) {
           errorMessage += ` Error: ${toolError.message}`;
           throw new Error(errorMessage, { cause: toolError });

--- a/front/lib/api/mcp/run_tool.ts
+++ b/front/lib/api/mcp/run_tool.ts
@@ -136,7 +136,7 @@ export async function* runToolWithStreaming(
         getRetryPolicyFromToolConfiguration(toolConfiguration);
       if (retryPolicy === "retry_on_interrupt") {
         const info = Context.current().info;
-        const isLastAttempt = info.attempt === RETRY_ON_INTERRUPT_MAX_ATTEMPTS;
+        const isLastAttempt = info.attempt >== RETRY_ON_INTERRUPT_MAX_ATTEMPTS;
         if (!isLastAttempt) {
           errorMessage += `Error: ${toolError.message}`;
           throw new Error(errorMessage, { cause: toolError });

--- a/front/lib/api/mcp/run_tool.ts
+++ b/front/lib/api/mcp/run_tool.ts
@@ -138,7 +138,7 @@ export async function* runToolWithStreaming(
         const info = Context.current().info;
         const isLastAttempt = info.attempt >== RETRY_ON_INTERRUPT_MAX_ATTEMPTS;
         if (!isLastAttempt) {
-          errorMessage += `Error: ${toolError.message}`;
+          errorMessage += ` Error: ${toolError.message}`;
           throw new Error(errorMessage, { cause: toolError });
         }
       }

--- a/front/lib/api/mcp/run_tool.ts
+++ b/front/lib/api/mcp/run_tool.ts
@@ -1,5 +1,6 @@
 // eslint-disable-next-line dust/enforce-client-types-in-public-api
 import { McpError } from "@modelcontextprotocol/sdk/types.js";
+import { Context } from "@temporalio/activity";
 
 import type {
   MCPApproveExecutionEvent,
@@ -32,7 +33,6 @@ import type {
   ConversationType,
 } from "@app/types";
 import { removeNulls } from "@app/types";
-import { Context } from "@temporalio/activity";
 import { RETRY_ON_INTERRUPT_MAX_ATTEMPTS } from "@app/lib/actions/constants";
 
 /**

--- a/front/temporal/agent_loop/workflows.ts
+++ b/front/temporal/agent_loop/workflows.ts
@@ -8,7 +8,10 @@ import {
   workflowInfo,
 } from "@temporalio/workflow";
 
-import { DEFAULT_MCP_REQUEST_TIMEOUT_MS } from "@app/lib/actions/constants";
+import {
+  DEFAULT_MCP_REQUEST_TIMEOUT_MS,
+  RETRY_ON_INTERRUPT_MAX_ATTEMPTS,
+} from "@app/lib/actions/constants";
 import type { AuthenticatorType } from "@app/lib/auth";
 import type * as commonActivities from "@app/temporal/agent_loop/activities/common";
 import type * as ensureTitleActivities from "@app/temporal/agent_loop/activities/ensure_conversation_title";
@@ -50,7 +53,7 @@ const activities: AgentLoopActivities = {
   runRetryableToolActivity: proxyActivities<typeof runToolActivities>({
     startToCloseTimeout: toolActivityStartToCloseTimeout,
     retry: {
-      maximumAttempts: 15,
+      maximumAttempts: RETRY_ON_INTERRUPT_MAX_ATTEMPTS,
     },
   }).runToolActivity,
   publishDeferredEventsActivity: proxyActivities<


### PR DESCRIPTION
## Description
Fixes https://github.com/dust-tt/tasks/issues/4336
- stop rethrowing timeout errors on the final retry attempt so the workflow no longer fails when retries are exhausted
- share the retry_on_interrupt max attempt constant between the workflow configuration and the tool runner

## Risks
Blast radius: Retryable MCP tool executions in the agent loop
Risk: low

## Deploy Plan
- deploy front
