### PR TITLE
[front] update button display logic inside the conversation

### DIFF
--- a/front/components/assistant/conversation/AgentMessage.tsx
+++ b/front/components/assistant/conversation/AgentMessage.tsx
@@ -420,7 +420,8 @@ export function AgentMessage({
   if (
     agentMessageToRender.status !== "created" &&
     agentMessageToRender.status !== "failed" &&
-    (!isGlobalAgent || agentMessageToRender.configuration.status !== "draft")
+    !isGlobalAgent &&
+    agentMessageToRender.configuration.status !== "draft"
   ) {
     buttons.push(
       <Separator key="separator" orientation="vertical" />,

--- a/front/components/assistant/conversation/AgentMessage.tsx
+++ b/front/components/assistant/conversation/AgentMessage.tsx
@@ -420,7 +420,7 @@ export function AgentMessage({
   if (
     agentMessageToRender.status !== "created" &&
     agentMessageToRender.status !== "failed" &&
-    (isGlobalAgent || agentMessageToRender.configuration.status === "draft")
+    (!isGlobalAgent || agentMessageToRender.configuration.status !== "draft")
   ) {
     buttons.push(
       <Separator key="separator" orientation="vertical" />,

--- a/front/components/assistant/conversation/AgentMessage.tsx
+++ b/front/components/assistant/conversation/AgentMessage.tsx
@@ -393,19 +393,6 @@ export function AgentMessage({
         className="text-muted-foreground"
       />
     );
-    // Feedback (not on global agents nor drafts).
-    buttons.push(
-      ...(isGlobalAgent || agentMessageToRender.configuration.status === "draft"
-        ? []
-        : [
-            <Separator key="separator" orientation="vertical" />,
-            <FeedbackSelector
-              key="feedback-selector"
-              {...messageFeedback}
-              getPopoverInfo={PopoverContent}
-            />,
-          ])
-    );
   }
 
   // Show retry button as long as it's not streaming
@@ -425,6 +412,22 @@ export function AgentMessage({
         icon={ArrowPathIcon}
         className="text-muted-foreground"
         disabled={isRetryHandlerProcessing || shouldStream}
+      />
+    );
+  }
+
+  // Add feedback buttons in the end of the array if the agent is not global agents nor drafts (= inside agent builder)
+  if (
+    agentMessageToRender.status !== "created" &&
+    agentMessageToRender.status !== "failed" &&
+    (isGlobalAgent || agentMessageToRender.configuration.status === "draft")
+  ) {
+    buttons.push(
+      <Separator key="separator" orientation="vertical" />,
+      <FeedbackSelector
+        key="feedback-selector"
+        {...messageFeedback}
+        getPopoverInfo={PopoverContent}
       />
     );
   }

--- a/front/components/assistant/conversation/AgentMessage.tsx
+++ b/front/components/assistant/conversation/AgentMessage.tsx
@@ -416,7 +416,7 @@ export function AgentMessage({
     );
   }
 
-  // Add feedback buttons in the end of the array if the agent is not global agents nor drafts (= inside agent builder)
+  // Add feedback buttons in the end of the array if the agent is not global nor in draft (= inside agent builder)
   if (
     agentMessageToRender.status !== "created" &&
     agentMessageToRender.status !== "failed" &&


### PR DESCRIPTION
## Description

tldr: this PR is to not show the message buttons while streaming except when you are running multi agents since there is no other way to stop single agent. 

We did cool improvements in our buttons UI ([stop multiple/single agent button](https://github.com/dust-tt/dust/pull/16200) & [show these buttons all the time](https://github.com/dust-tt/dust/pull/16185)), but I find it slightly annoying to see these buttons while the message is being streamed. Also I suggested to use ⬜ icon for stopping single agent message to be consistent but actually it's hard to understand what it is without label (I'm sorry 🙈), so I think it's better to show "stop agent" label.

When you are running multi agents:
<img width="697" height="403" alt="Screenshot 2025-09-24 at 21 56 22" src="https://github.com/user-attachments/assets/aa673a94-75f2-41d2-9572-051d7e39134d" />

When streaming is done you see the same buttons as before:
<img width="648" height="91" alt="Screenshot 2025-09-24 at 22 09 50" src="https://github.com/user-attachments/assets/5eea0b57-3446-4cf6-b6d4-e1f92fc6bdbb" />


<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
