### PR TITLE
[sparkle] fix: Remove dynamic component recreated on every render

### DIFF
--- a/sparkle/src/components/Sheet.tsx
+++ b/sparkle/src/components/Sheet.tsx
@@ -201,22 +201,29 @@ interface SheetContainerProps extends React.HTMLAttributes<HTMLDivElement> {
   noScroll?: boolean;
 }
 
+const ScrollContainer = ({
+  noScroll,
+  className,
+  children,
+}: {
+  noScroll?: boolean;
+  className?: string;
+  children: React.ReactNode;
+}) => {
+  if (noScroll) {
+    return <div className={className}>{children}</div>;
+  }
+  return <ScrollArea className={className}>{children}</ScrollArea>;
+};
+
 const SheetContainer = ({
   children,
   noScroll,
   className,
 }: SheetContainerProps) => {
-  const ScrollContainer = noScroll
-    ? ({
-        children,
-        className,
-      }: {
-        children: React.ReactNode;
-        className?: string;
-      }) => <div className={className}>{children}</div>
-    : ScrollArea;
   return (
     <ScrollContainer
+      noScroll={noScroll}
       className={cn(
         "s-h-full s-w-full s-flex-grow",
         "s-border-t s-border-border/60 s-transition-all s-duration-300 dark:s-border-border-night/60"


### PR DESCRIPTION
## Description

Inside a MultiPageSheet, we have a component that is weirdly unmounted/remounted ("first time the component is rendered") : 

<img width="555" height="147" alt="Screenshot 2025-09-24 at 21 59 25" src="https://github.com/user-attachments/assets/18d744df-1991-4e99-9845-ec83b5bdfc4c" />

It's parent "Anonymous" is actually also recreated : 

<img width="585" height="134" alt="Screenshot 2025-09-24 at 21 59 37" src="https://github.com/user-attachments/assets/10fe7385-2dab-4d55-a788-207875cbd15e" />

While the SheetContainer is only re-rendered :

<img width="556" height="160" alt="Screenshot 2025-09-24 at 21 59 46" src="https://github.com/user-attachments/assets/6db5f79b-38b7-41f6-94ea-803882c9acdb" />

Looking at the code of SheetContainer, the "Anonymous" component ("ScrollContainer")  is actually defined inside render method without memo, so a new component recreated on every render, being necessarily unmounted/remounted with all its sub tree on every render.

Extracting the component to a real, non dynamic one fully fix the render by only re-rendering an existing component :

<img width="399" height="122" alt="Screenshot 2025-09-24 at 22 12 44" src="https://github.com/user-attachments/assets/f3499439-5934-4c85-9504-a6fe148a0d36" />

<img width="373" height="125" alt="Screenshot 2025-09-24 at 22 12 53" src="https://github.com/user-attachments/assets/5ce9add0-ed85-48a0-8053-d4e41c111775" />

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

Publish sparkle