### PR TITLE
[front] Add support for tuples path in preconfigured inputs

### DIFF
--- a/front/lib/actions/mcp_internal_actions/input_configuration.ts
+++ b/front/lib/actions/mcp_internal_actions/input_configuration.ts
@@ -118,8 +118,7 @@ function generateConfiguredInput({
         actionConfiguration.dataSources?.map((config) => ({
           uri: getDataSourceURI(config),
           mimeType,
-          // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
-        })) || []
+        })) ?? []
       );
     }
 
@@ -128,8 +127,7 @@ function generateConfiguredInput({
         actionConfiguration.dataSources?.map((config) => ({
           uri: getDataSourceURI(config),
           mimeType,
-          // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
-        })) || []
+        })) ?? []
       );
     }
 
@@ -138,8 +136,7 @@ function generateConfiguredInput({
         actionConfiguration.tables?.map((config) => ({
           uri: getTableURI(config),
           mimeType,
-          // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
-        })) || []
+        })) ?? []
       );
     }
 


### PR DESCRIPTION
## Description

- This PR adds support for defining paths within a JSONSchema that go through a tuple (`items` with JSONSchemas for each item).
- The goal is to fix [this stuck loop](https://app.datadoghq.eu/logs?query=%28%22Activity%20failed%22%20OR%20%22Unhandled%20activity%20error%22%29%20%40attempt%3A%3E15%20%40dd.service%3Afront-agent-loop-worker%20region%3Aus-central1&agg_m=count&agg_m_source=base&agg_t=count&clustering_pattern_field_path=message&cols=host%2Cservice&event=AwAAAZl9RWm_LLrCiQAAABhBWmw5Uld5a0FBRGtVU0FKVjhONTNBQUUAAAAkZjE5OTdkNDctZDJkNi00MDVjLWFhZmYtYTI5MWEzMjI2NzgzAAV7eg&fromUser=true&link_source=monitor_notif&messageDisplay=inline&refresh_mode=sliding&storage=hot&stream_sort=desc&viz=stream&from_ts=1758739774000&to_ts=1758743374000&live=false).
- The most desirable end state is potentially to revert this PR and remove the whole default configuration as it currently only makes sense for the reasoning tool, which will be sunset, and has already raised other issues+concerns.

## Tests

- Tested the reasoning tool locally.

## Risk

- Medium, high blast radius code path.

## Deploy Plan

- Deploy front.
