### PR TITLE
[front] Adjust `run_agent` tracking based on error categorization

### DIFF
--- a/front/lib/actions/mcp_internal_actions/servers/run_agent/index.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/run_agent/index.ts
@@ -623,8 +623,8 @@ ${query}`
               return new Err(
                 new MCPError(errorMessage, {
                   tracked:
-                    isAgentErrorCategory(event.error.metadata?.category) &&
-                    [
+                    !isAgentErrorCategory(event.error.metadata?.category) ||
+                    ![
                       "retryable_model_error",
                       "context_window_exceeded",
                       "provider_internal_error",

--- a/front/lib/actions/mcp_internal_actions/servers/run_agent/index.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/run_agent/index.ts
@@ -46,6 +46,7 @@ import { AgentConfiguration } from "@app/lib/models/assistant/agent";
 import { getResourcePrefix } from "@app/lib/resources/string_ids";
 import logger from "@app/logger/logger";
 import type { CitationType, Result } from "@app/types";
+import { AgentErrorCategory } from "@app/types";
 import {
   Err,
   getHeaderFromUserEmail,
@@ -623,13 +624,11 @@ ${query}`
               // Certain types of agent errors should not be tracked as run_agent tool execution
               // errors (they will be exposed to the model and will be tracked as errors from the
               // agentic loop in the sub agent conversation).
-              const tracked =
-                !isAgentErrorCategory(event.error.metadata?.category) ||
-                ![
-                  "retryable_model_error",
-                  "context_window_exceeded",
-                  "provider_internal_error",
-                ].includes(event.error.metadata.category);
+              const tracked = ![
+                "retryable_model_error",
+                "context_window_exceeded",
+                "provider_internal_error",
+              ].includes(event.error.metadata?.category);
               return new Err(
                 new MCPError(errorMessage, {
                   tracked,

--- a/front/lib/actions/mcp_internal_actions/servers/run_agent/index.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/run_agent/index.ts
@@ -620,15 +620,16 @@ ${query}`
               }
             } else if (event.type === "agent_error") {
               const errorMessage = `Agent error: ${event.error.message}`;
+              const tracked =
+                !isAgentErrorCategory(event.error.metadata?.category) ||
+                ![
+                  "retryable_model_error",
+                  "context_window_exceeded",
+                  "provider_internal_error",
+                ].includes(event.error.metadata.category);
               return new Err(
                 new MCPError(errorMessage, {
-                  tracked:
-                    !isAgentErrorCategory(event.error.metadata?.category) ||
-                    ![
-                      "retryable_model_error",
-                      "context_window_exceeded",
-                      "provider_internal_error",
-                    ].includes(event.error.metadata.category),
+                  tracked,
                 })
               );
             } else if (event.type === "user_message_error") {

--- a/front/lib/actions/mcp_internal_actions/servers/run_agent/index.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/run_agent/index.ts
@@ -49,6 +49,7 @@ import type { CitationType, Result } from "@app/types";
 import {
   Err,
   getHeaderFromUserEmail,
+  isAgentErrorCategory,
   isGlobalAgentId,
   normalizeError,
   Ok,
@@ -619,7 +620,17 @@ ${query}`
               }
             } else if (event.type === "agent_error") {
               const errorMessage = `Agent error: ${event.error.message}`;
-              return new Err(new MCPError(errorMessage));
+              return new Err(
+                new MCPError(errorMessage, {
+                  tracked:
+                    isAgentErrorCategory(event.error.metadata?.category) &&
+                    [
+                      "retryable_model_error",
+                      "context_window_exceeded",
+                      "provider_internal_error",
+                    ].includes(event.error.metadata.category),
+                })
+              );
             } else if (event.type === "user_message_error") {
               const errorMessage = `User message error: ${event.error.message}`;
               return new Err(new MCPError(errorMessage));

--- a/front/lib/actions/mcp_internal_actions/servers/run_agent/index.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/run_agent/index.ts
@@ -46,11 +46,9 @@ import { AgentConfiguration } from "@app/lib/models/assistant/agent";
 import { getResourcePrefix } from "@app/lib/resources/string_ids";
 import logger from "@app/logger/logger";
 import type { CitationType, Result } from "@app/types";
-import { AgentErrorCategory } from "@app/types";
 import {
   Err,
   getHeaderFromUserEmail,
-  isAgentErrorCategory,
   isGlobalAgentId,
   normalizeError,
   Ok,

--- a/front/lib/actions/mcp_internal_actions/servers/run_agent/index.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/run_agent/index.ts
@@ -620,6 +620,9 @@ ${query}`
               }
             } else if (event.type === "agent_error") {
               const errorMessage = `Agent error: ${event.error.message}`;
+              // Certain types of agent errors should not be tracked as run_agent tool execution
+              // errors (they will be exposed to the model and will be tracked as errors from the
+              // agentic loop in the sub agent conversation).
               const tracked =
                 !isAgentErrorCategory(event.error.metadata?.category) ||
                 ![


### PR DESCRIPTION
## Description

- This PR prevents certain errors from being tracked as errors in the execution of the `run_agent` tool.
- For instance, a context window error does not need to be monitored as an error of execution of the `run_agent` tool.
- Some of these will be monitored as regular agent errors, the goal is actually to prevent duplicating the monitoring (e.g. being alerted twice via both run agent tool execution and agentic loop failure at all times) and to have the run agent tool errors really track `run_agent` specific issues.

## Tests

## Risk

- Low.

## Deploy Plan

- Deploy front.
