### PR TITLE
Fix: debounce calls to chat.update for tool_notifications

### DIFF
--- a/connectors/src/connectors/slack/chat/stream_conversation_handler.ts
+++ b/connectors/src/connectors/slack/chat/stream_conversation_handler.ts
@@ -140,7 +140,7 @@ async function streamAgentAnswerToSlack(
     switch (event.type) {
       case "tool_params":
       case "tool_notification": {
-        await postSlackMessageUpdate({
+        await debouncedPostSlackMessageUpdate({
           messageUpdate: {
             isThinking: true,
             assistantName,
@@ -149,7 +149,7 @@ async function streamAgentAnswerToSlack(
             thinkingAction: TOOL_RUNNING_LABEL,
           },
           ...conversationData,
-          canBeIgnored: false,
+          canBeIgnored: true,
           extraLogs: {
             source: "streamAgentAnswerToSlack",
             eventType: event.type,


### PR DESCRIPTION
## Description

Debounce and allow skipping chat message update on tool_notifications as it has almost 0 usefulness (except showing "....(Using a tool)").

## Tests

Local

## Risk

Low

## Deploy Plan

Deploy connector