### PR TITLE
[PQ] Replace DustIcon by new "default" DIcon

### DIFF
--- a/front/components/assistant/details/AssistantDetails.tsx
+++ b/front/components/assistant/details/AssistantDetails.tsx
@@ -6,7 +6,7 @@ import {
   Button,
   Chip,
   ContentMessage,
-  DustIcon,
+  DIcon,
   InformationCircleIcon,
   LockIcon,
   Sheet,
@@ -56,7 +56,7 @@ export const SCOPE_INFO: Record<
     shortLabel: "Default",
     label: "Default Agent",
     color: "primary",
-    icon: DustIcon,
+    icon: DIcon,
     text: "Default agents provided by Dust.",
   },
   hidden: {

--- a/front/pages/w/[wId]/builder/agents/index.tsx
+++ b/front/pages/w/[wId]/builder/agents/index.tsx
@@ -1,7 +1,7 @@
 import {
   Button,
   Chip,
-  DustIcon,
+  DIcon,
   ListSelectIcon,
   MagnifyingGlassIcon,
   Page,
@@ -65,7 +65,7 @@ export const AGENT_MANAGER_TABS = [
   {
     id: "global",
     label: "Default",
-    icon: DustIcon,
+    icon: DIcon,
     description: "Default agents provided by Dust.",
   },
   {


### PR DESCRIPTION
## Description

https://github.com/dust-tt/tasks/issues/4375

https://www.notion.so/dust-tt/Product-Quality-23728599d94180aa8459f6ac8acd2e4c?source=copy_link#27828599d9418053955aee2bc6271a2a

This PR upgrades sparkle and replace DustIcon with default DIcon

<img width="561" height="213" alt="image" src="https://github.com/user-attachments/assets/552efbdc-dea4-4feb-a854-7cbfa0ebdee8" />

<img width="638" height="217" alt="image" src="https://github.com/user-attachments/assets/a0a3ccd3-aa17-4f71-9a4e-bbdbe97c58ae" />

## Tests

## Risk

Low

## Deploy Plan

front + extension
