### PR TITLE
Add: log to investigate schema ordering issue with table query

### DIFF
--- a/core/src/databases/table.rs
+++ b/core/src/databases/table.rs
@@ -199,6 +199,9 @@ impl Table {
     pub fn timestamp(&self) -> u64 {
         self.timestamp
     }
+    pub fn is_schema_stale(&self) -> bool {
+        self.schema_stale_at.is_some()
+    }
     pub fn schema_cached(&self) -> Option<&TableSchema> {
         self.schema.as_ref()
     }

--- a/core/src/sqlite_workers/sqlite_database.rs
+++ b/core/src/sqlite_workers/sqlite_database.rs
@@ -17,7 +17,7 @@ use tempfile::NamedTempFile;
 use thiserror::Error;
 use tokio::{task, time::timeout};
 use tokio_stream::StreamExt;
-use tracing::info;
+use tracing::{error, info};
 
 pub struct SqliteDatabase {
     conn: Option<Arc<Mutex<Connection>>>,
@@ -247,6 +247,10 @@ async fn create_in_memory_sqlite_db_with_csv(
                 .schema_cached()
                 .unwrap()
                 .get_create_table_sql_string(&table_name);
+
+            if table.table.is_schema_stale() {
+                error!("Schema is stale for table {} but it should never happen as get_database_schema() should have been called first and recomputed the schema.", table.table.unique_id());
+            }
 
             async move {
                 let mut stream = Object::download_streamed(


### PR DESCRIPTION
## Description

Schema should be up-to-date before querying the table, this add a logs if it's not the case.
