### PR TITLE
fix(front): add responsive on manage agents table

### DIFF
--- a/front/components/assistant/manager/AssistantsTable.tsx
+++ b/front/components/assistant/manager/AssistantsTable.tsx
@@ -13,6 +13,7 @@ import {
 } from "@dust-tt/sparkle";
 import type { CellContext } from "@tanstack/react-table";
 import { useRouter } from "next/router";
+import type { ReactNode } from "react";
 import { useMemo, useState } from "react";
 
 import { DeleteAssistantDialog } from "@app/components/assistant/DeleteAssistantDialog";
@@ -52,7 +53,7 @@ type RowData = {
   menuItems?: MenuItem[];
   agentTags: TagType[];
   agentTagsAsString: string;
-  action?: React.ReactNode;
+  action?: ReactNode;
   isSelected: boolean;
   canArchive: boolean;
 };
@@ -68,6 +69,19 @@ const getTableColumns = ({
   isBatchEdit: boolean;
   mutateAgentConfigurations: () => Promise<any>;
 }) => {
+  /**
+   * Columns order:
+   * - Select (if batch edit)
+   * - Name (always)
+   * - Access (hidden on mobile)
+   * - Editors (hidden on mobile)
+   * - Tags (always)
+   * - Usage (hidden on mobile)
+   * - Feedback (hidden on mobile)
+   * - Last Edited (hidden on mobile)
+   * - Actions (always)
+   */
+
   return [
     ...(isBatchEdit
       ? [
@@ -110,6 +124,9 @@ const getTableColumns = ({
           </div>
         </DataTable.CellContent>
       ),
+      meta: {
+        className: "w-40",
+      },
     },
     {
       header: "Access",
@@ -127,7 +144,7 @@ const getTableColumns = ({
         </DataTable.CellContent>
       ),
       meta: {
-        className: "w-32",
+        className: "hidden @sm:w-32 @sm:table-cell",
       },
     },
     {
@@ -155,7 +172,7 @@ const getTableColumns = ({
         );
       },
       meta: {
-        className: "w-32",
+        className: "hidden @sm:w-32 @sm:table-cell",
       },
     },
     {
@@ -205,7 +222,10 @@ const getTableColumns = ({
           label={info.row.original.usage?.messageCount ?? 0}
         />
       ),
-      meta: { className: "w-16", tooltip: "Messages in the last 30 days" },
+      meta: {
+        className: "hidden @sm:w-16 @sm:table-cell",
+        tooltip: "Messages in the last 30 days",
+      },
     },
     {
       header: "Feedback",
@@ -227,7 +247,10 @@ const getTableColumns = ({
           );
         }
       },
-      meta: { className: "w-20", tooltip: "Active users in the last 30 days" },
+      meta: {
+        className: "hidden @sm:w-20 @sm:table-cell",
+        tooltip: "Active users in the last 30 days",
+      },
     },
     {
       header: "Last Edited",
@@ -242,7 +265,7 @@ const getTableColumns = ({
           }
         />
       ),
-      meta: { className: "w-32" },
+      meta: { className: "hidden @sm:w-32 @sm:table-cell" },
     },
     {
       header: "",


### PR DESCRIPTION
## Description

Hide some columns on smaller displays. I decided to only have name and tag on smaller screens. I don't expect people to manage a lot agents on the go

### Phone
<img width="456" height="470" alt="Screenshot 2025-09-25 at 10 31 39" src="https://github.com/user-attachments/assets/44ee42ba-96b5-47d3-b3bb-ebbbd12c80d6" />


### Tablet
<img width="573" height="396" alt="Screenshot 2025-09-25 at 10 32 03" src="https://github.com/user-attachments/assets/0359ac63-63ae-44c9-a367-e7aa0e278eb7" />


### Computer

<img width="1446" height="510" alt="Screenshot 2025-09-25 at 10 32 16" src="https://github.com/user-attachments/assets/3e470ab5-b885-4ef4-a050-7813abfcc124" />


## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
