### PR TITLE
[connectors] Add back GitHub file skipping on `skipReason`

### DIFF
--- a/connectors/src/connectors/github/lib/code/file_operations.ts
+++ b/connectors/src/connectors/github/lib/code/file_operations.ts
@@ -156,7 +156,7 @@ export async function upsertCodeFile({
     githubCodeFile.lastSeenAt = codeSyncStartedAt;
     await githubCodeFile.save();
 
-    return { updatedDirectoryIds: new Set() };
+    return { updatedDirectoryIds };
   }
 
   if (needsUpdate) {

--- a/connectors/src/lib/error.ts
+++ b/connectors/src/lib/error.ts
@@ -114,7 +114,7 @@ export class WorkspaceQuotaExceededError extends Error {
 export class DataSourceQuotaExceededError extends Error {
   constructor() {
     super(
-      "A file size exceeded the allowed size. Potential action: temporarily increase the plan limit for file size to " +
+      "A file size exceeded the allowed size. Action: temporarily increase the plan limit for file size to " +
         "let the activity succeed."
     );
     this.name = "DataSourceQuotaExceededError";

--- a/connectors/src/lib/error.ts
+++ b/connectors/src/lib/error.ts
@@ -114,7 +114,7 @@ export class WorkspaceQuotaExceededError extends Error {
 export class DataSourceQuotaExceededError extends Error {
   constructor() {
     super(
-      "A file size exceeded the allowed size. Action: temporarily increase the plan limit for file size to " +
+      "A file size exceeded the allowed size. Potential action: temporarily increase the plan limit for file size to " +
         "let the activity succeed."
     );
     this.name = "DataSourceQuotaExceededError";


### PR DESCRIPTION
## Description

- We do have a `skipReason` on `GithubCodeFile` but it's currently not respected, it got lost in the refactoring to GCS.

## Tests

## Risk

- Low.

## Deploy Plan

- Deploy connectors.
