### PR TITLE
Fix: use a cached and throttled call for slack users.info

### DIFF
--- a/connectors/src/connectors/slack/bot.ts
+++ b/connectors/src/connectors/slack/bot.ts
@@ -43,7 +43,7 @@ import type { SlackUserInfo } from "@connectors/connectors/slack/lib/slack_clien
 import {
   getSlackBotInfo,
   getSlackClient,
-  getSlackUserInfo,
+  getSlackUserInfoMemoized,
   reportSlackUsage,
 } from "@connectors/connectors/slack/lib/slack_client";
 import { getRepliesFromThread } from "@connectors/connectors/slack/lib/thread";
@@ -522,7 +522,7 @@ async function answerMessage(
   // When a bot sends a message "as a user", we want to honor the user and not the bot.
   if (slackUserId) {
     try {
-      slackUserInfo = await getSlackUserInfo(
+      slackUserInfo = await getSlackUserInfoMemoized(
         connector.id,
         slackClient,
         slackUserId
@@ -648,6 +648,9 @@ async function answerMessage(
 
   if (slackUserInfo.is_bot) {
     const botName = slackUserInfo.real_name;
+    if (!botName) {
+      throw new Error("Failed to get bot name. Should never happen.");
+    }
     requestedGroups = await slackConfig.getBotGroupIds(botName);
   }
 

--- a/connectors/src/connectors/slack/feedback_api.ts
+++ b/connectors/src/connectors/slack/feedback_api.ts
@@ -3,7 +3,7 @@ import type { Block, KnownBlock } from "@slack/web-api";
 import { makeFeedbackSubmittedBlock } from "@connectors/connectors/slack/chat/blocks";
 import {
   getSlackClient,
-  getSlackUserInfo,
+  getSlackUserInfoMemoized,
 } from "@connectors/connectors/slack/lib/slack_client";
 import { RATE_LIMITS } from "@connectors/connectors/slack/ratelimits";
 import { apiConfig } from "@connectors/lib/api/config";
@@ -97,7 +97,7 @@ export async function submitFeedbackToAPI({
     let userEmail: string | undefined = undefined;
     try {
       const slackClient = await getSlackClient(connector.id);
-      const slackUserInfo = await getSlackUserInfo(
+      const slackUserInfo = await getSlackUserInfoMemoized(
         connector.id,
         slackClient,
         slackUserId

--- a/connectors/src/connectors/slack/lib/bot_user_helpers.ts
+++ b/connectors/src/connectors/slack/lib/bot_user_helpers.ts
@@ -1,15 +1,12 @@
 import type { WebClient } from "@slack/web-api";
 import type { MessageElement } from "@slack/web-api/dist/types/response/ConversationsHistoryResponse";
 
-import {
-  isSlackWebAPIPlatformError,
-  isSlackWebAPIPlatformErrorBotNotFound,
-} from "@connectors/connectors/slack/lib/errors";
+import { isSlackWebAPIPlatformErrorBotNotFound } from "@connectors/connectors/slack/lib/errors";
 import {
   getSlackBotInfo,
+  getSlackUserInfoMemoized,
   reportSlackUsage,
 } from "@connectors/connectors/slack/lib/slack_client";
-import { cacheGet, cacheSet } from "@connectors/lib/cache";
 import logger from "@connectors/logger/logger";
 import type { SlackConfigurationResource } from "@connectors/resources/slack_configuration_resource";
 import type { ModelId } from "@connectors/types";
@@ -49,45 +46,19 @@ export async function getUserName(
   connectorId: ModelId,
   slackClient: WebClient
 ): Promise<string | null> {
-  const fromCache = await cacheGet(getUserCacheKey(slackUserId, connectorId));
-  if (fromCache) {
-    return fromCache;
+  const info = await getSlackUserInfoMemoized(
+    connectorId,
+    slackClient,
+    slackUserId
+  );
+
+  const userName = info.display_name || info.real_name || info.name;
+
+  if (userName) {
+    return userName;
   }
 
-  try {
-    reportSlackUsage({
-      connectorId,
-      method: "users.info",
-    });
-    const info = await slackClient.users.info({ user: slackUserId });
-
-    if (info && info.user) {
-      const displayName = info.user.profile?.display_name;
-      const realName = info.user.profile?.real_name;
-      const userName = displayName || realName || info.user.name;
-
-      if (userName) {
-        await cacheSet(getUserCacheKey(slackUserId, connectorId), userName);
-        return userName;
-      }
-    }
-
-    return null;
-  } catch (err) {
-    if (isSlackWebAPIPlatformError(err)) {
-      if (err.data.error === "user_not_found") {
-        logger.info({ connectorId, slackUserId }, "Slack user not found.");
-
-        return null;
-      }
-    }
-
-    throw err;
-  }
-}
-
-export function getUserCacheKey(userId: string, connectorId: ModelId) {
-  return `slack-userid2name-${connectorId}-${userId}`;
+  return null;
 }
 
 export function shouldIndexSlackMessage(

--- a/connectors/src/connectors/slack/lib/workspace_limits.ts
+++ b/connectors/src/connectors/slack/lib/workspace_limits.ts
@@ -219,6 +219,10 @@ export async function isBotAllowed(
 ): Promise<Result<undefined, Error>> {
   const realName = slackUserInfo.real_name;
 
+  if (!realName) {
+    throw new Error("Failed to get bot name. Should never happen.");
+  }
+
   // Whitelisting a bot will accept any message from this bot.
   // This means that even a non verified user of a given Slack workspace who can trigger a bot
   // that talks to our bot (@dust) will be able to use the Dust bot.

--- a/connectors/src/connectors/slack/ratelimits.ts
+++ b/connectors/src/connectors/slack/ratelimits.ts
@@ -7,4 +7,8 @@ export const RATE_LIMITS = {
     limit: 50,
     windowInMs: 60 * 1000,
   },
+  "users.info": {
+    limit: 100,
+    windowInMs: 60 * 1000,
+  },
 } satisfies Record<string, RateLimit>;

--- a/connectors/src/connectors/slack/temporal/config.ts
+++ b/connectors/src/connectors/slack/temporal/config.ts
@@ -1,2 +1,2 @@
-const WORKFLOW_VERSION = 5;
+const WORKFLOW_VERSION = 6;
 export const QUEUE_NAME = `slack-queue-v${WORKFLOW_VERSION}`;

--- a/connectors/src/connectors/slack/temporal/workflows.ts
+++ b/connectors/src/connectors/slack/temporal/workflows.ts
@@ -26,7 +26,6 @@ export type JoinChannelUseCaseType = (typeof JOIN_CHANNEL_USE_CASES)[number];
 function getSlackActivities() {
   const {
     getChannel,
-    fetchUsers,
     saveSuccessSyncActivity,
     syncChannelMetadata,
     reportInitialSyncProgressActivity,
@@ -68,7 +67,6 @@ function getSlackActivities() {
     autoReadChannelActivity,
     deleteChannel,
     deleteChannelsFromConnectorDb,
-    fetchUsers,
     getChannel,
     getChannelsToGarbageCollect,
     migrateChannelsFromLegacyBotToNewBotActivity,
@@ -112,8 +110,6 @@ export async function workspaceFullSync(
     // Add signal to queue
     signalQueue.push(input);
   });
-
-  await getSlackActivities().fetchUsers(connectorId);
 
   while (signalQueue.length > 0) {
     const signal = signalQueue.shift();


### PR DESCRIPTION
## Description

Should kill all the rate limited calls for slack.

## Tests

Locally

## Risk

I slightly changed the return value of `getSlackUserInfo()` but it should be fine.

## Deploy Plan

Deploy connectors