### PR TITLE
[front,relocation] Fix template IDs mapping between regions

### DIFF
--- a/front/temporal/relocation/activities/source_region/front/sql.ts
+++ b/front/temporal/relocation/activities/source_region/front/sql.ts
@@ -196,7 +196,7 @@ export async function readFrontTableChunk({
     destRegion === "europe-west1"
   ) {
     const templateIdMapping: Record<number, number> = {
-      68: 274877906957,
+      68: 74,
     };
 
     for (const row of rows as [{ id: ModelId; templateId: number | null }]) {


### PR DESCRIPTION
## Description

- Had the wrong destination template ID in https://github.com/dust-tt/dust/pull/16285.

## Tests


## Risk

## Deploy Plan

- Deploy front.
