### PR TITLE
Copy large text into attached file + see content of attached files

### DIFF
--- a/front/components/assistant/conversation/AttachmentCitation.tsx
+++ b/front/components/assistant/conversation/AttachmentCitation.tsx
@@ -112,6 +112,17 @@ export function AttachmentCitation({
   onRemove,
   onClick,
 }: AttachmentCitationProps) {
+  const citationInteractionProps = onClick
+    ? {
+        onClick: (e: React.MouseEvent<HTMLDivElement>) => {
+          e.preventDefault();
+          onClick();
+        },
+      }
+    : {
+        href: attachmentCitation.sourceUrl ?? "",
+      };
+
   const tooltipContent =
     attachmentCitation.type === "file" ? (
       attachmentCitation.title
@@ -132,13 +143,7 @@ export function AttachmentCitation({
     <Tooltip
       trigger={
         <Citation
-          href={onClick ? undefined : attachmentCitation.sourceUrl ?? undefined}
-          onClick={(e) => {
-            if (onClick) {
-              e.preventDefault();
-              onClick();
-            }
-          }}
+          {...citationInteractionProps}
           isLoading={
             attachmentCitation.type === "file" && attachmentCitation.isUploading
           }

--- a/front/components/assistant/conversation/AttachmentCitation.tsx
+++ b/front/components/assistant/conversation/AttachmentCitation.tsx
@@ -86,11 +86,11 @@ export type AttachmentCitation =
   | FileAttachmentCitation
   | NodeAttachmentCitation;
 
-type AttachmentCitationProps = {
+interface AttachmentCitationProps {
   attachmentCitation: AttachmentCitation;
   onRemove?: () => void;
   onClick?: () => void;
-};
+}
 
 function iconForContent(contentType: string | undefined): React.ComponentType {
   if (!contentType) {

--- a/front/components/assistant/conversation/AttachmentCitation.tsx
+++ b/front/components/assistant/conversation/AttachmentCitation.tsx
@@ -92,19 +92,24 @@ interface AttachmentCitationProps {
   onClick?: () => void;
 }
 
-function iconForContent(contentType: string | undefined): React.ComponentType {
+function getContentTypeIcon(
+  contentType: string | undefined
+): React.ComponentType {
   if (!contentType) {
     return DocumentIcon;
   }
   const isImageType = contentType.startsWith("image/");
+  if (isImageType) {
+    return ImageIcon;
+  }
   const isAudioType = contentType.startsWith("audio/");
-  return isImageType
-    ? ImageIcon
-    : isAudioType
-      ? ActionVolumeUpIcon
-      : isPastedFile(contentType)
-        ? DoubleQuotesIcon
-        : DocumentIcon;
+  if (isAudioType) {
+    return ActionVolumeUpIcon;
+  }
+  if (isPastedFile(contentType)) {
+    return DoubleQuotesIcon;
+  }
+  return DocumentIcon;
 }
 
 export function AttachmentCitation({
@@ -191,7 +196,7 @@ export function contentFragmentToAttachmentCitation(
 ): AttachmentCitation {
   // Handle expired content fragments
   if (contentFragment.expiredReason) {
-    const visual = iconForContent(contentFragment.contentType);
+    const visual = getContentTypeIcon(contentFragment.contentType);
     return {
       type: "file",
       id: contentFragment.sId,
@@ -235,7 +240,7 @@ export function contentFragmentToAttachmentCitation(
       spaceName: contentFragment.contentNodeData.spaceName,
     };
   } else if (isFileContentFragment(contentFragment)) {
-    const visual = iconForContent(contentFragment.contentType);
+    const visual = getContentTypeIcon(contentFragment.contentType);
 
     // Compute custom title/description for pasted files
     const isPasted = isPastedFile(contentFragment.contentType);
@@ -262,7 +267,7 @@ export function attachmentToAttachmentCitation(
   attachment: Attachment
 ): AttachmentCitation {
   if (attachment.type === "file") {
-    const visual = iconForContent(attachment.contentType);
+    const visual = getContentTypeIcon(attachment.contentType);
     return {
       type: "file",
       id: attachment.id,

--- a/front/components/assistant/conversation/AttachmentCitation.tsx
+++ b/front/components/assistant/conversation/AttachmentCitation.tsx
@@ -117,6 +117,7 @@ export function AttachmentCitation({
   onRemove,
   onClick,
 }: AttachmentCitationProps) {
+  // citation cannot have href and onClick at the same time
   const citationInteractionProps = onClick
     ? {
         onClick: (e: React.MouseEvent<HTMLDivElement>) => {

--- a/front/components/assistant/conversation/input_bar/InputBarAttachments.tsx
+++ b/front/components/assistant/conversation/input_bar/InputBarAttachments.tsx
@@ -146,7 +146,7 @@ export function InputBarAttachments({
 
   const [viewerOpen, setViewerOpen] = useState(false);
   const [viewerTitle, setViewerTitle] = useState("");
-  const [viewerText, setViewerText] = useState("");
+  const [sanitizedViewerText, setSanitizedViewerText] = useState("");
 
   const allAttachments: Attachment[] = [...fileAttachments, ...nodeAttachments];
 
@@ -169,7 +169,7 @@ export function InputBarAttachments({
       disallowedTagsMode: "escape",
     });
     setViewerTitle(attachment.title);
-    setViewerText(sanitizedText);
+    setSanitizedViewerText(sanitizedText);
     setViewerOpen(true);
   };
 
@@ -216,9 +216,10 @@ export function InputBarAttachments({
             <DialogTitle>{viewerTitle}</DialogTitle>
           </DialogHeader>
           <DialogContainer>
-            <pre className="m-0 max-h-[60vh] whitespace-pre-wrap break-words">
-              {viewerText}
-            </pre>
+            <pre
+              className="m-0 max-h-[60vh] whitespace-pre-wrap break-words"
+              dangerouslySetInnerHTML={{ __html: sanitizedViewerText }}
+            />
           </DialogContainer>
           <DialogFooter
             rightButtonProps={{

--- a/front/components/assistant/conversation/input_bar/InputBarAttachments.tsx
+++ b/front/components/assistant/conversation/input_bar/InputBarAttachments.tsx
@@ -13,6 +13,7 @@ import {
   Icon,
 } from "@dust-tt/sparkle";
 import { useMemo, useState } from "react";
+import sanitizeHtml from "sanitize-html";
 
 import type {
   Attachment,
@@ -162,8 +163,13 @@ export function InputBarAttachments({
       return;
     }
     const text = await blob.file.text();
+    const sanitizedText = sanitizeHtml(text, {
+      allowedTags: [],
+      allowedAttributes: {},
+      disallowedTagsMode: "escape",
+    });
     setViewerTitle(attachment.title);
-    setViewerText(text);
+    setViewerText(sanitizedText);
     setViewerOpen(true);
   };
 

--- a/front/components/assistant/conversation/input_bar/InputBarAttachments.tsx
+++ b/front/components/assistant/conversation/input_bar/InputBarAttachments.tsx
@@ -191,7 +191,7 @@ export function InputBarAttachments({
 
   return (
     <>
-      <CitationGrid className="border-b border-separator px-3 pb-3 pt-3 dark:border-separator-night"">
+      <CitationGrid className="border-b border-separator px-3 pb-3 pt-3 dark:border-separator-night">
         {allAttachments.map((attachment) => {
           const attachmentCitation = attachmentToAttachmentCitation(attachment);
           const canPreviewText = isTextualContentType(attachment);

--- a/front/components/assistant/conversation/input_bar/InputBarAttachments.tsx
+++ b/front/components/assistant/conversation/input_bar/InputBarAttachments.tsx
@@ -24,6 +24,11 @@ import {
   AttachmentCitation,
   attachmentToAttachmentCitation,
 } from "@app/components/assistant/conversation/AttachmentCitation";
+import {
+  getDisplayDateFromPastedFileId,
+  getDisplayNameFromPastedFileId,
+  isPastedFile,
+} from "@app/components/assistant/conversation/input_bar/pasted_utils";
 import type { FileUploaderService } from "@app/hooks/useFileUploaderService";
 import { getConnectorProviderLogoWithFallback } from "@app/lib/connector_providers";
 import {
@@ -34,12 +39,6 @@ import { getSpaceIcon } from "@app/lib/spaces";
 import { useSpaces } from "@app/lib/swr/spaces";
 import type { DataSourceViewContentNode, LightWorkspaceType } from "@app/types";
 import { GLOBAL_SPACE_NAME } from "@app/types";
-
-import {
-  getDisplayDateFromPastedFileId,
-  getDisplayNameFromPastedFileId,
-  isPastedFile,
-} from "./pasted_utils";
 
 interface FileAttachmentsProps {
   service: FileUploaderService;

--- a/front/components/assistant/conversation/input_bar/InputBarAttachments.tsx
+++ b/front/components/assistant/conversation/input_bar/InputBarAttachments.tsx
@@ -1,8 +1,18 @@
 // Okay to use public API types because it's front/connectors communication.
 // eslint-disable-next-line dust/enforce-client-types-in-public-api
 import { isFolder, isWebsite } from "@dust-tt/client";
-import { CitationGrid, DoubleIcon, Icon } from "@dust-tt/sparkle";
-import { useMemo } from "react";
+import {
+  CitationGrid,
+  Dialog,
+  DialogContainer,
+  DialogContent,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  DoubleIcon,
+  Icon,
+} from "@dust-tt/sparkle";
+import { useMemo, useState } from "react";
 
 import type {
   Attachment,
@@ -23,6 +33,12 @@ import { getSpaceIcon } from "@app/lib/spaces";
 import { useSpaces } from "@app/lib/swr/spaces";
 import type { DataSourceViewContentNode, LightWorkspaceType } from "@app/types";
 import { GLOBAL_SPACE_NAME } from "@app/types";
+
+import {
+  getDisplayDateFromPastedFileId,
+  getDisplayNameFromPastedFileId,
+  isPastedFile,
+} from "./pasted_utils";
 
 interface FileAttachmentsProps {
   service: FileUploaderService;
@@ -65,16 +81,26 @@ export function InputBarAttachments({
   // Convert file blobs to FileAttachment objects
   const fileAttachments: FileAttachment[] = useMemo(() => {
     return (
-      files?.service.fileBlobs.map((blob) => ({
-        type: "file",
-        id: blob.id,
-        title: blob.id,
-        preview: blob.preview,
-        contentType: blob.contentType,
-        isUploading: blob.isUploading,
-        onRemove: () => files.service.removeFile(blob.id),
+      files?.service.fileBlobs.map((blob) => {
+        const isPasted = isPastedFile(blob.contentType);
+        const title = isPasted
+          ? getDisplayNameFromPastedFileId(blob.id)
+          : blob.id;
+        const uploadDate = isPasted
+          ? getDisplayDateFromPastedFileId(blob.id)
+          : undefined;
+        return {
+          type: "file",
+          id: blob.id,
+          title,
+          preview: blob.preview,
+          contentType: blob.contentType,
+          isUploading: blob.isUploading,
+          description: uploadDate,
+          onRemove: () => files.service.removeFile(blob.id),
+        };
         // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
-      })) || []
+      }) || []
     );
   }, [files?.service]);
 
@@ -117,24 +143,85 @@ export function InputBarAttachments({
     );
   }, [nodes, spacesMap]);
 
+  const [viewerOpen, setViewerOpen] = useState(false);
+  const [viewerTitle, setViewerTitle] = useState("");
+  const [viewerText, setViewerText] = useState("");
+
   const allAttachments: Attachment[] = [...fileAttachments, ...nodeAttachments];
 
   if (allAttachments.length === 0) {
     return null;
   }
 
+  const openPastedViewer = async (attachment: FileAttachment) => {
+    if (!files) {
+      return;
+    }
+    const blob = files.service.fileBlobs.find((b) => b.id === attachment.id);
+    if (!blob) {
+      return;
+    }
+    const text = await blob.file.text();
+    setViewerTitle(attachment.title);
+    setViewerText(text);
+    setViewerOpen(true);
+  };
+
+  const isTextualContentType = (attachment: Attachment) => {
+    if (attachment.type !== "file") {
+      return false;
+    }
+    const ct = attachment.contentType;
+    if (!ct) {
+      return false;
+    }
+    return (
+      ct.startsWith("text/") ||
+      ct === "application/json" ||
+      ct === "application/xml" ||
+      ct === "application/vnd.dust.section.json"
+    );
+  };
+
   return (
-    <CitationGrid className="border-b border-separator px-3 pb-3 pt-3 dark:border-separator-night">
-      {allAttachments.map((attachment) => {
-        const attachmentCitation = attachmentToAttachmentCitation(attachment);
-        return (
-          <AttachmentCitation
-            key={attachmentCitation.id}
-            attachmentCitation={attachmentCitation}
-            onRemove={attachment.onRemove}
+    <>
+      <CitationGrid className="border-b border-separator px-3 pb-3 pt-3 dark:border-separator-night"">
+        {allAttachments.map((attachment) => {
+          const attachmentCitation = attachmentToAttachmentCitation(attachment);
+          const canPreviewText = isTextualContentType(attachment);
+          return (
+            <AttachmentCitation
+              key={attachmentCitation.id}
+              attachmentCitation={attachmentCitation}
+              onRemove={attachment.onRemove}
+              onClick={
+                canPreviewText
+                  ? () => openPastedViewer(attachment as FileAttachment)
+                  : undefined
+              }
+            />
+          );
+        })}
+      </CitationGrid>
+
+      <Dialog open={viewerOpen} onOpenChange={setViewerOpen}>
+        <DialogContent size="2xl" height="lg">
+          <DialogHeader>
+            <DialogTitle>{viewerTitle}</DialogTitle>
+          </DialogHeader>
+          <DialogContainer>
+            <pre className="m-0 max-h-[60vh] whitespace-pre-wrap break-words">
+              {viewerText}
+            </pre>
+          </DialogContainer>
+          <DialogFooter
+            rightButtonProps={{
+              label: "Close",
+              variant: "highlight",
+            }}
           />
-        );
-      })}
-    </CitationGrid>
+        </DialogContent>
+      </Dialog>
+    </>
   );
 }

--- a/front/components/assistant/conversation/input_bar/InputBarAttachments.tsx
+++ b/front/components/assistant/conversation/input_bar/InputBarAttachments.tsx
@@ -13,7 +13,6 @@ import {
   Icon,
 } from "@dust-tt/sparkle";
 import { useMemo, useState } from "react";
-import sanitizeHtml from "sanitize-html";
 
 import type {
   Attachment,
@@ -145,7 +144,7 @@ export function InputBarAttachments({
 
   const [viewerOpen, setViewerOpen] = useState(false);
   const [viewerTitle, setViewerTitle] = useState("");
-  const [sanitizedViewerText, setSanitizedViewerText] = useState("");
+  const [viewerText, setViewerText] = useState("");
 
   const allAttachments: Attachment[] = [...fileAttachments, ...nodeAttachments];
 
@@ -162,13 +161,8 @@ export function InputBarAttachments({
       return;
     }
     const text = await blob.file.text();
-    const sanitizedText = sanitizeHtml(text, {
-      allowedTags: [],
-      allowedAttributes: {},
-      disallowedTagsMode: "escape",
-    });
     setViewerTitle(attachment.title);
-    setSanitizedViewerText(sanitizedText);
+    setViewerText(text);
     setViewerOpen(true);
   };
 
@@ -213,10 +207,9 @@ export function InputBarAttachments({
             <DialogTitle>{viewerTitle}</DialogTitle>
           </DialogHeader>
           <DialogContainer>
-            <pre
-              className="m-0 max-h-[60vh] whitespace-pre-wrap break-words"
-              dangerouslySetInnerHTML={{ __html: sanitizedViewerText }}
-            />
+            <pre className="m-0 max-h-[60vh] whitespace-pre-wrap break-words">
+              {viewerText}
+            </pre>
           </DialogContainer>
           <DialogFooter
             rightButtonProps={{

--- a/front/components/assistant/conversation/input_bar/InputBarAttachments.tsx
+++ b/front/components/assistant/conversation/input_bar/InputBarAttachments.tsx
@@ -154,7 +154,7 @@ export function InputBarAttachments({
     return null;
   }
 
-  const openPastedViewer = async (attachment: FileAttachment) => {
+  const openPastedViewer = async (attachment: Attachment) => {
     if (!files) {
       return;
     }
@@ -201,9 +201,7 @@ export function InputBarAttachments({
               attachmentCitation={attachmentCitation}
               onRemove={attachment.onRemove}
               onClick={
-                canPreviewText
-                  ? () => openPastedViewer(attachment as FileAttachment)
-                  : undefined
+                canPreviewText ? () => openPastedViewer(attachment) : undefined
               }
             />
           );
@@ -211,7 +209,7 @@ export function InputBarAttachments({
       </CitationGrid>
 
       <Dialog open={viewerOpen} onOpenChange={setViewerOpen}>
-        <DialogContent size="2xl" height="lg">
+        <DialogContent size="xl" height="lg">
           <DialogHeader>
             <DialogTitle>{viewerTitle}</DialogTitle>
           </DialogHeader>

--- a/front/components/assistant/conversation/input_bar/InputBarContainer.tsx
+++ b/front/components/assistant/conversation/input_bar/InputBarContainer.tsx
@@ -40,10 +40,11 @@ import type {
   LightAgentConfigurationType,
   WorkspaceType,
 } from "@app/types";
-import { assertNever } from "@app/types";
+import { assertNever, normalizeError } from "@app/types";
 import { getSupportedFileExtensions } from "@app/types";
 
 import { getPastedFileName } from "./pasted_utils";
+import { normalize } from "path";
 
 export const INPUT_BAR_ACTIONS = [
   "tools",
@@ -152,7 +153,7 @@ const InputBarContainer = ({
         sendNotification({
           type: "error",
           title: "Failed to attach pasted text",
-          description: e instanceof Error ? e.message : undefined,
+          description: normalizeError(e).message,
         });
       }
     },

--- a/front/components/assistant/conversation/input_bar/InputBarContainer.tsx
+++ b/front/components/assistant/conversation/input_bar/InputBarContainer.tsx
@@ -20,6 +20,7 @@ import { useMentionDropdown } from "@app/components/assistant/conversation/input
 import useUrlHandler from "@app/components/assistant/conversation/input_bar/editor/useUrlHandler";
 import { InputBarAttachmentsPicker } from "@app/components/assistant/conversation/input_bar/InputBarAttachmentsPicker";
 import { InputBarContext } from "@app/components/assistant/conversation/input_bar/InputBarContext";
+import { getPastedFileName } from "@app/components/assistant/conversation/input_bar/pasted_utils";
 import { ToolsPicker } from "@app/components/assistant/ToolsPicker";
 import { VoicePicker } from "@app/components/assistant/VoicePicker";
 import type { FileUploaderService } from "@app/hooks/useFileUploaderService";
@@ -42,8 +43,6 @@ import type {
 } from "@app/types";
 import { assertNever, normalizeError } from "@app/types";
 import { getSupportedFileExtensions } from "@app/types";
-
-import { getPastedFileName } from "./pasted_utils";
 
 export const INPUT_BAR_ACTIONS = [
   "tools",

--- a/front/components/assistant/conversation/input_bar/InputBarContainer.tsx
+++ b/front/components/assistant/conversation/input_bar/InputBarContainer.tsx
@@ -44,7 +44,6 @@ import { assertNever, normalizeError } from "@app/types";
 import { getSupportedFileExtensions } from "@app/types";
 
 import { getPastedFileName } from "./pasted_utils";
-import { normalize } from "path";
 
 export const INPUT_BAR_ACTIONS = [
   "tools",

--- a/front/components/assistant/conversation/input_bar/editor/useCustomEditor.tsx
+++ b/front/components/assistant/conversation/input_bar/editor/useCustomEditor.tsx
@@ -27,7 +27,7 @@ export interface EditorMention {
   label: string;
 }
 
-const DEFAULT_LONG_TEXT_PASTE_THRESHOLD = { maxChars: 2000, maxLines: 30 };
+const DEFAULT_LONG_TEXT_PASTE_CHARS_THRESHOLD = 2000;
 
 function getTextAndMentionsFromNode(node?: JSONContent) {
   let textContent = "";
@@ -69,16 +69,9 @@ function getTextAndMentionsFromNode(node?: JSONContent) {
   return { text: textContent, mentions: mentions };
 }
 
-function isLongTextPaste(
-  text: string,
-  threshold?: { maxChars?: number; maxLines?: number }
-) {
-  const maxChars =
-    threshold?.maxChars ?? DEFAULT_LONG_TEXT_PASTE_THRESHOLD.maxChars;
-  const maxLines =
-    threshold?.maxLines ?? DEFAULT_LONG_TEXT_PASTE_THRESHOLD.maxLines;
-  const lineCount = (text.match(/\n/g)?.length ?? 0) + 1;
-  return text.length > maxChars || lineCount > maxLines;
+function isLongTextPaste(text: string, maxCharThreshold?: number) {
+  const maxChars = maxCharThreshold ?? DEFAULT_LONG_TEXT_PASTE_CHARS_THRESHOLD;
+  return text.length > maxChars;
 }
 
 const useEditorService = (editor: Editor | null) => {
@@ -228,8 +221,7 @@ export interface CustomEditorProps {
   owner: WorkspaceType;
   // If provided, large pasted text will be routed to this callback
   onLongTextPaste?: (text: string) => void;
-  // Optional override for what counts as a long paste
-  longTextPasteThreshold?: { maxChars?: number; maxLines?: number };
+  longTextPasteCharsThreshold?: number;
 }
 
 const useCustomEditor = ({
@@ -240,7 +232,7 @@ const useCustomEditor = ({
   suggestionHandler,
   owner,
   onLongTextPaste,
-  longTextPasteThreshold,
+  longTextPasteCharsThreshold,
 }: CustomEditorProps) => {
   const extensions = [
     StarterKit.configure({
@@ -299,7 +291,7 @@ const useCustomEditor = ({
         if (!text || !onLongTextPaste) {
           return false;
         }
-        if (isLongTextPaste(text, longTextPasteThreshold)) {
+        if (isLongTextPaste(text, longTextPasteCharsThreshold)) {
           onLongTextPaste(text);
           return true;
         }

--- a/front/components/assistant/conversation/input_bar/editor/useCustomEditor.tsx
+++ b/front/components/assistant/conversation/input_bar/editor/useCustomEditor.tsx
@@ -27,7 +27,7 @@ export interface EditorMention {
   label: string;
 }
 
-const DEFAULT_LONG_TEXT_PASTE_THRESHOLD = { maxChars: 1000, maxLines: 15 };
+const DEFAULT_LONG_TEXT_PASTE_THRESHOLD = { maxChars: 2000, maxLines: 30 };
 
 function getTextAndMentionsFromNode(node?: JSONContent) {
   let textContent = "";

--- a/front/components/assistant/conversation/input_bar/editor/useCustomEditor.tsx
+++ b/front/components/assistant/conversation/input_bar/editor/useCustomEditor.tsx
@@ -300,7 +300,6 @@ const useCustomEditor = ({
           return false;
         }
         if (isLongTextPaste(text, longTextPasteThreshold)) {
-          event.preventDefault();
           onLongTextPaste(text);
           return true;
         }

--- a/front/components/assistant/conversation/input_bar/pasted_utils.test.ts
+++ b/front/components/assistant/conversation/input_bar/pasted_utils.test.ts
@@ -1,0 +1,15 @@
+import { describe, expect, test } from "vitest";
+
+import {
+  getDisplayDateFromPastedFileId,
+  getDisplayNameFromPastedFileId,
+  getPastedFileName,
+} from "./pasted_utils";
+
+describe("pasted_utils", () => {
+  test("getDisplayNameFromPastedFileId and getDisplayDateFromPastedFileId from generated filename", () => {
+    const pastedFileName = getPastedFileName(7);
+    expect(getDisplayNameFromPastedFileId(pastedFileName)).toBe("Pasted (7)");
+    expect(getDisplayDateFromPastedFileId(pastedFileName)).not.toBeUndefined();
+  });
+});

--- a/front/components/assistant/conversation/input_bar/pasted_utils.ts
+++ b/front/components/assistant/conversation/input_bar/pasted_utils.ts
@@ -1,0 +1,33 @@
+import dayjs from "dayjs";
+
+export const getDisplayNameFromPastedFileId = (id: string): string => {
+  const match = id.match(/^pasted-text-(\d+)_/);
+  if (match) {
+    return `Pasted (${match[1]})`;
+  }
+  return "Pasted";
+};
+
+export const getDisplayDateFromPastedFileId = (
+  id: string
+): string | undefined => {
+  const match = id.match(
+    /^pasted-text-(\d+)_(\d{4}-\d{2}-\d{2}_\d{2}-\d{2}-\d{2})\.txt$/
+  );
+  if (match) {
+    const datePart = match[2]
+      .replace("_", " ")
+      // convert the "-" in time part into ":" to make it a valid date
+      .replace(/-(\d{2})-(\d{2})$/, ":$1:$2");
+    return new Date(datePart).toLocaleString();
+  }
+  return undefined;
+};
+
+export const getPastedFileName = (count: number): string => {
+  return `pasted-text-${count}_${dayjs().format("YYYY-MM-DD_HH-mm-ss")}.txt`;
+};
+
+export const isPastedFile = (contentType: string | undefined): boolean => {
+  return contentType === "text/vnd.dust.attachment.pasted";
+};

--- a/front/components/assistant/conversation/input_bar/pasted_utils.ts
+++ b/front/components/assistant/conversation/input_bar/pasted_utils.ts
@@ -19,7 +19,10 @@ export const getDisplayDateFromPastedFileId = (
       .replace("_", " ")
       // convert the "-" in time part into ":" to make it a valid date
       .replace(/-(\d{2})-(\d{2})$/, ":$1:$2");
-    return new Date(datePart).toLocaleString();
+    return new Date(datePart).toLocaleString(undefined, {
+      dateStyle: "short",
+      timeStyle: "short",
+    });
   }
   return undefined;
 };

--- a/front/lib/api/files/upload.ts
+++ b/front/lib/api/files/upload.ts
@@ -464,6 +464,11 @@ const getProcessingFunction = ({
         return storeRawText;
       }
       break;
+    case "text/vnd.dust.attachment.pasted":
+      if (useCase === "conversation") {
+        return storeRawText;
+      }
+      break;
     case "application/vnd.dust.section.json":
       if (useCase === "tool_output") {
         return storeRawText;

--- a/front/types/files.ts
+++ b/front/types/files.ts
@@ -205,6 +205,12 @@ export const FILE_FORMATS = {
     exts: [".md", ".markdown"],
     isSafeToDisplay: true,
   },
+  // Internal content type for pasted text attachments in conversations.
+  "text/vnd.dust.attachment.pasted": {
+    cat: "data",
+    exts: [".txt"],
+    isSafeToDisplay: true,
+  },
   "text/vnd.dust.attachment.slack.thread": {
     cat: "data",
     exts: [".txt"],

--- a/sdks/js/src/types.ts
+++ b/sdks/js/src/types.ts
@@ -167,6 +167,7 @@ export const supportedOtherFileFormats = {
   "text/tab-separated-values": [".tsv"],
   "text/tsv": [".tsv"],
   "text/vnd.dust.attachment.slack.thread": [".txt"],
+  "text/vnd.dust.attachment.pasted": [".txt"],
   "text/html": [".html", ".htm", ".xhtml", ".xhtml+xml"],
   "text/xml": [".xml"],
   "text/calendar": [".ics"],


### PR DESCRIPTION
## Description

 - Copy large text into an attached file
 - Content of attached text files (pasted or uploaded) can be seen when clicked on
    - in pasted message, clicking still download the file

Implementation notes:
 - I am using a new file type, following what has been done for "text/vnd.dust.attachment.slack.thread". I could also use a flag somewhere to know if the data has been pasted but it seems like more changes overall

<img width="600" height="200" alt="image" src="https://github.com/user-attachments/assets/9872d2e3-4cd5-4525-867a-ad0245a5ad77" />


<img width="600" height="500" alt="image" src="https://github.com/user-attachments/assets/281f0de0-99fd-4f83-b6c2-1ee5addaa07e" />

<img width="2266" height="1750" alt="image" src="https://github.com/user-attachments/assets/9e93a903-7f21-4a31-b4f7-ac7c06918ddf" />



## Tests

Manual tests
Unit tests for parsed_utils.ts


## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

deploy front
