### PR TITLE
[sparkle] enh: Add ref prop to access scroll container

### DIFF
--- a/sparkle/src/components/DataTable.tsx
+++ b/sparkle/src/components/DataTable.tsx
@@ -338,6 +338,7 @@ export interface ScrollableDataTableProps<TData extends TBaseData>
   maxHeight?: string | boolean;
   onLoadMore?: () => void;
   isLoading?: boolean;
+  containerRef?: React.Ref<HTMLDivElement>;
 }
 
 // cellHeight in pixels
@@ -361,13 +362,28 @@ export function ScrollableDataTable<TData extends TBaseData>({
   enableRowSelection,
   enableMultiRowSelection = true,
   getRowId,
+  containerRef,
 }: ScrollableDataTableProps<TData>) {
   const windowSize = useWindowSize();
-  const tableContainerRef = useRef<HTMLDivElement>(null);
   const loadMoreRef = useRef<HTMLDivElement>(null);
   const [tableWidth, setTableWidth] = useState(0);
+  const tableContainerRef = useRef<HTMLDivElement | null>(null);
 
   const isSorting = !!setSorting;
+
+  // Handle container ref
+  const setRef = (element: HTMLDivElement | null) => {
+    tableContainerRef.current = element;
+    if (containerRef) {
+      if (typeof containerRef === "function") {
+        containerRef(element);
+      } else if ("current" in containerRef) {
+        (
+          containerRef as React.MutableRefObject<HTMLDivElement | null>
+        ).current = element;
+      }
+    }
+  };
 
   // Monitor table width changes
   useEffect(() => {
@@ -520,7 +536,7 @@ export function ScrollableDataTable<TData extends TBaseData>({
             ? maxHeight
             : "s-max-h-100"
       )}
-      ref={tableContainerRef}
+      ref={setRef}
     >
       <div className="s-relative">
         <DataTable.Root className="s-w-full s-table-fixed">


### PR DESCRIPTION
## Description

Add a containerRef that can be used to control scroll externally (like scroll to top when needed)

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

publish sparkle
