### PR TITLE
[front] enh: Reset scroll when changing sort

### DIFF
--- a/extension/package-lock.json
+++ b/extension/package-lock.json
@@ -12,7 +12,7 @@
         "@auth0/auth0-spa-js": "^2.1.3",
         "@datadog/browser-logs": "^6.13.0",
         "@dust-tt/client": "^1.1.15",
-        "@dust-tt/sparkle": "^0.2.634",
+        "@dust-tt/sparkle": "^0.2.635",
         "@frontapp/plugin-sdk": "^1.8.1",
         "@modelcontextprotocol/sdk": "^1.9.0",
         "@tailwindcss/forms": "^0.5.9",
@@ -1293,9 +1293,9 @@
       }
     },
     "node_modules/@dust-tt/sparkle": {
-      "version": "0.2.634",
-      "resolved": "https://registry.npmjs.org/@dust-tt/sparkle/-/sparkle-0.2.634.tgz",
-      "integrity": "sha512-fVNtXQVrYlle2+RxF7l+VdPsgNxv2ZbSnO6OFAEm5Y7zlJ0TepIYVWTmrHo3JhXJULSwoYSWLG6+va+i3pTsdA==",
+      "version": "0.2.635",
+      "resolved": "https://registry.npmjs.org/@dust-tt/sparkle/-/sparkle-0.2.635.tgz",
+      "integrity": "sha512-C2ApplgH8W0yKdp2AALQniDxkM17KPVt3NwwujzRjxZ9isiZz1pn0lMj7Oim/hRGJHi1kKfVC8/qlQH/ABgDfA==",
       "dependencies": {
         "@emoji-mart/data": "^1.1.2",
         "@emoji-mart/react": "^1.1.1",

--- a/extension/package.json
+++ b/extension/package.json
@@ -59,7 +59,7 @@
     "@auth0/auth0-spa-js": "^2.1.3",
     "@datadog/browser-logs": "^6.13.0",
     "@dust-tt/client": "^1.1.15",
-    "@dust-tt/sparkle": "^0.2.634",
+    "@dust-tt/sparkle": "^0.2.635",
     "@frontapp/plugin-sdk": "^1.8.1",
     "@modelcontextprotocol/sdk": "^1.9.0",
     "@tailwindcss/forms": "^0.5.9",

--- a/front/components/spaces/SpaceSearchLayout.tsx
+++ b/front/components/spaces/SpaceSearchLayout.tsx
@@ -242,6 +242,7 @@ function BackendSearch({
   const [showSearch, setShowSearch] = React.useState(shouldShowSearchResults);
   const [searchHitCount, setSearchHitCount] = React.useState(0);
   const [sorting, setSorting] = useState<SortingState>([]);
+  const scrollableDataTableRef = useRef<HTMLDivElement>(null);
 
   const {
     cursorPagination,
@@ -253,7 +254,12 @@ function BackendSearch({
   // Reset pagination when debounced search changes
   React.useEffect(() => {
     resetPagination();
-  }, [debouncedSearch, resetPagination]);
+    if (scrollableDataTableRef.current) {
+      scrollableDataTableRef.current.scrollTo({
+        top: 0,
+      });
+    }
+  }, [debouncedSearch, resetPagination, sorting]);
 
   const handleSortingChange = useCallback(
     (sorting: SortingState) => {
@@ -443,6 +449,7 @@ function BackendSearch({
               onClearSearch={handleClearSearch}
               sorting={sorting}
               setSorting={handleSortingChange}
+              scrollableDataTableRef={scrollableDataTableRef}
             />
           </div>
         ) : (
@@ -534,6 +541,7 @@ interface SearchResultsTableProps {
   onOpenDocument?: (node: DataSourceViewContentNode) => void;
   setEffectiveContentNode: (node: DataSourceViewContentNode) => void;
   onClearSearch: () => void;
+  scrollableDataTableRef: React.Ref<HTMLDivElement>;
 }
 
 function SearchResultsTable({
@@ -551,6 +559,7 @@ function SearchResultsTable({
   onOpenDocument,
   setEffectiveContentNode,
   onClearSearch,
+  scrollableDataTableRef,
 }: SearchResultsTableProps) {
   const router = useRouter();
 
@@ -683,16 +692,6 @@ function SearchResultsTable({
     setEffectiveContentNode,
     spaces,
   ]);
-
-  const scrollableDataTableRef = useRef<HTMLDivElement>(null);
-
-  useEffect(() => {
-    if (scrollableDataTableRef.current) {
-      scrollableDataTableRef.current.scrollTo({
-        top: 0,
-      });
-    }
-  }, [sorting]);
 
   return (
     <ScrollableDataTable

--- a/front/components/spaces/SpaceSearchLayout.tsx
+++ b/front/components/spaces/SpaceSearchLayout.tsx
@@ -5,7 +5,13 @@ import type { MenuItem } from "@dust-tt/sparkle";
 import { cn, ScrollableDataTable, SearchInput } from "@dust-tt/sparkle";
 import type { SortingState } from "@tanstack/table-core";
 import { useRouter } from "next/router";
-import React, { useMemo, useState } from "react";
+import React, {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
 
 import { DocumentOrTableDeleteDialog } from "@app/components/data_source/DocumentOrTableDeleteDialog";
 import DataSourceViewDocumentModal from "@app/components/DataSourceViewDocumentModal";
@@ -249,6 +255,14 @@ function BackendSearch({
     resetPagination();
   }, [debouncedSearch, resetPagination]);
 
+  const handleSortingChange = useCallback(
+    (sorting: SortingState) => {
+      resetPagination();
+      setSorting(sorting);
+    },
+    [resetPagination, setSorting]
+  );
+
   const commonSearchParams = {
     owner,
     spaceIds: [space.sId],
@@ -428,7 +442,7 @@ function BackendSearch({
               setEffectiveContentNode={setEffectiveContentNode}
               onClearSearch={handleClearSearch}
               sorting={sorting}
-              setSorting={setSorting}
+              setSorting={handleSortingChange}
             />
           </div>
         ) : (
@@ -670,8 +684,19 @@ function SearchResultsTable({
     spaces,
   ]);
 
+  const scrollableDataTableRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    if (scrollableDataTableRef.current) {
+      scrollableDataTableRef.current.scrollTo({
+        top: 0,
+      });
+    }
+  }, [sorting]);
+
   return (
     <ScrollableDataTable
+      containerRef={scrollableDataTableRef}
       data={rows}
       sorting={sorting}
       setSorting={setSorting}

--- a/front/components/spaces/SpaceSearchLayout.tsx
+++ b/front/components/spaces/SpaceSearchLayout.tsx
@@ -263,6 +263,7 @@ function BackendSearch({
 
   const handleSortingChange = useCallback(
     (sorting: SortingState) => {
+      // Reset pagination early to avoid 2 queries being sent.
       resetPagination();
       setSorting(sorting);
     },

--- a/front/components/spaces/SpaceSearchLayout.tsx
+++ b/front/components/spaces/SpaceSearchLayout.tsx
@@ -5,13 +5,7 @@ import type { MenuItem } from "@dust-tt/sparkle";
 import { cn, ScrollableDataTable, SearchInput } from "@dust-tt/sparkle";
 import type { SortingState } from "@tanstack/table-core";
 import { useRouter } from "next/router";
-import React, {
-  useCallback,
-  useEffect,
-  useMemo,
-  useRef,
-  useState,
-} from "react";
+import React, { useCallback, useMemo, useRef, useState } from "react";
 
 import { DocumentOrTableDeleteDialog } from "@app/components/data_source/DocumentOrTableDeleteDialog";
 import DataSourceViewDocumentModal from "@app/components/DataSourceViewDocumentModal";

--- a/front/package-lock.json
+++ b/front/package-lock.json
@@ -7,7 +7,7 @@
       "dependencies": {
         "@datadog/browser-logs": "^6.13.0",
         "@dust-tt/client": "file:../sdks/js",
-        "@dust-tt/sparkle": "^0.2.634",
+        "@dust-tt/sparkle": "^0.2.635",
         "@google-cloud/bigquery": "^7.9.1",
         "@google-cloud/storage-transfer": "^3.6.0",
         "@heroicons/react": "^2.0.11",
@@ -1128,9 +1128,9 @@
       "link": true
     },
     "node_modules/@dust-tt/sparkle": {
-      "version": "0.2.634",
-      "resolved": "https://registry.npmjs.org/@dust-tt/sparkle/-/sparkle-0.2.634.tgz",
-      "integrity": "sha512-fVNtXQVrYlle2+RxF7l+VdPsgNxv2ZbSnO6OFAEm5Y7zlJ0TepIYVWTmrHo3JhXJULSwoYSWLG6+va+i3pTsdA==",
+      "version": "0.2.635",
+      "resolved": "https://registry.npmjs.org/@dust-tt/sparkle/-/sparkle-0.2.635.tgz",
+      "integrity": "sha512-C2ApplgH8W0yKdp2AALQniDxkM17KPVt3NwwujzRjxZ9isiZz1pn0lMj7Oim/hRGJHi1kKfVC8/qlQH/ABgDfA==",
       "dependencies": {
         "@emoji-mart/data": "^1.1.2",
         "@emoji-mart/react": "^1.1.1",

--- a/front/package.json
+++ b/front/package.json
@@ -27,7 +27,7 @@
   "dependencies": {
     "@datadog/browser-logs": "^6.13.0",
     "@dust-tt/client": "file:../sdks/js",
-    "@dust-tt/sparkle": "^0.2.634",
+    "@dust-tt/sparkle": "^0.2.635",
     "@google-cloud/bigquery": "^7.9.1",
     "@google-cloud/storage-transfer": "^3.6.0",
     "@heroicons/react": "^2.0.11",


### PR DESCRIPTION
## Description

When we change the query or the sort, reset pagination and scroll to top.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

deploy front
