### PR TITLE
Confluence: more logs to understand 404s better

### DIFF
--- a/connectors/src/connectors/confluence/temporal/activities.ts
+++ b/connectors/src/connectors/confluence/temporal/activities.ts
@@ -125,6 +125,7 @@ export async function confluenceGetSpaceBlobActivity({
   spaceId: string;
 }): Promise<SpaceBlob | null> {
   const localLogger = logger.child({
+    connectorId,
     spaceId,
   });
 
@@ -143,8 +144,7 @@ export async function confluenceGetSpaceBlobActivity({
     };
   } catch (err) {
     if (isNotFoundError(err) || isConfluenceNotFoundError(err)) {
-      localLogger.info("Deleting stale Confluence space.");
-
+      localLogger.info({ error: err }, "Deleting stale Confluence space.");
       return null;
     }
 


### PR DESCRIPTION
## Description

Investigation here: https://github.com/dust-tt/tasks/issues/4053

We see a lot of spaces 404 and hence getting deleted and re-discovered

https://app.datadoghq.eu/logs?query=%22Deleting%20stale%20Confluence%20space.%22&agg_m=count&agg_m_source=base&agg_t=count&cols=host%2Cservice&messageDisplay=inline&refresh_mode=sliding&storage=hot&stream_sort=desc&viz=stream&from_ts=1756208033860&to_ts=1758800033860&live=true

## Tests

N/A

## Risk

Low

## Deploy Plan

- deploy `connectors`