### PR TITLE
[front] - refacto(AB): tool configuration

### DIFF
--- a/front/components/agent_builder/capabilities/mcp/MCPAdditionalConfigurationPage.tsx
+++ b/front/components/agent_builder/capabilities/mcp/MCPAdditionalConfigurationPage.tsx
@@ -2,6 +2,7 @@ import { Avatar, Button, Card, CommandLineIcon } from "@dust-tt/sparkle";
 import React from "react";
 
 import { AdditionalConfigurationSection } from "@app/components/agent_builder/capabilities/shared/AdditionalConfigurationSection";
+import { ConfigurationSectionContainer } from "@app/components/agent_builder/capabilities/shared/ConfigurationSectionContainer";
 import { NameSection } from "@app/components/agent_builder/capabilities/shared/NameSection";
 import type { MCPServerToolsConfigurations } from "@app/lib/actions/mcp_internal_actions/input_configuration";
 
@@ -36,13 +37,19 @@ export function MCPAdditionalConfigurationPage({
   showNameSection,
   additionalConfigs,
 }: MCPAdditionalConfigurationPageProps) {
-  console.log(">>>>> additionalConfigs", additionalConfigs);
-  console.log(">>>>> selectionSummaries", selectionSummaries);
   return (
     <div className="h-full">
       <div className="h-full space-y-6 pt-3">
+        {showNameSection && (
+          <NameSection
+            title="Name"
+            placeholder="My tool name…"
+            triggerValidationOnChange
+          />
+        )}
+
         {selectionSummaries.length > 0 && (
-          <div className="flex w-full flex-col gap-3">
+          <ConfigurationSectionContainer title="Selection" description="">
             {selectionSummaries.map((s) => (
               <Card key={s.id} size="sm" className="w-full">
                 <div className="flex w-full">
@@ -76,15 +83,7 @@ export function MCPAdditionalConfigurationPage({
                 </div>
               </Card>
             ))}
-          </div>
-        )}
-
-        {showNameSection && (
-          <NameSection
-            title="Name"
-            placeholder="My tool name…"
-            triggerValidationOnChange
-          />
+          </ConfigurationSectionContainer>
         )}
 
         <AdditionalConfigurationSection

--- a/front/components/agent_builder/capabilities/mcp/MCPAdditionalConfigurationPage.tsx
+++ b/front/components/agent_builder/capabilities/mcp/MCPAdditionalConfigurationPage.tsx
@@ -1,16 +1,20 @@
-import { Avatar, Button, Card, CommandLineIcon } from "@dust-tt/sparkle";
+import { Avatar, Button, Card, CommandLineIcon, Icon } from "@dust-tt/sparkle";
 import React from "react";
 
 import { AdditionalConfigurationSection } from "@app/components/agent_builder/capabilities/shared/AdditionalConfigurationSection";
 import { ConfigurationSectionContainer } from "@app/components/agent_builder/capabilities/shared/ConfigurationSectionContainer";
 import { NameSection } from "@app/components/agent_builder/capabilities/shared/NameSection";
+import { getModelProviderLogo } from "@app/components/providers/types";
+import { useTheme } from "@app/components/sparkle/ThemeContext";
 import type { MCPServerToolsConfigurations } from "@app/lib/actions/mcp_internal_actions/input_configuration";
+import type { ModelProviderIdType } from "@app/types";
 
 export type SelectionSummary = {
   id: string;
   visual:
     | { type: "icon" }
-    | { type: "avatar"; name: string; pictureUrl?: string | null };
+    | { type: "avatar"; name: string; pictureUrl?: string | null }
+    | { type: "provider-logo"; providerId: ModelProviderIdType };
   title: string;
   description?: string;
   editLabel: string;
@@ -37,6 +41,7 @@ export function MCPAdditionalConfigurationPage({
   showNameSection,
   additionalConfigs,
 }: MCPAdditionalConfigurationPageProps) {
+  const { isDark } = useTheme();
   return (
     <div className="h-full">
       <div className="h-full space-y-6 pt-3">
@@ -54,14 +59,27 @@ export function MCPAdditionalConfigurationPage({
               <div className="flex w-full">
                 <div className="flex w-full flex-grow flex-col gap-1 overflow-hidden">
                   <div className="flex items-center gap-2">
-                    {selectionSummary.visual.type === "icon" ? (
-                      <CommandLineIcon className="h-6 w-6 text-muted-foreground" />
-                    ) : (
+                    {selectionSummary.visual.type === "avatar" && (
                       <Avatar
                         size="sm"
                         name={selectionSummary.visual.name}
                         visual={selectionSummary.visual.pictureUrl}
                       />
+                    )}
+                    {selectionSummary.visual.type === "provider-logo" &&
+                      (() => {
+                        const Logo = getModelProviderLogo(
+                          selectionSummary.visual.providerId,
+                          isDark
+                        );
+                        return Logo ? (
+                          <Icon visual={Logo} size="lg" />
+                        ) : (
+                          <CommandLineIcon className="h-6 w-6 text-muted-foreground" />
+                        );
+                      })()}
+                    {selectionSummary.visual.type === "icon" && (
+                      <CommandLineIcon className="h-6 w-6 text-muted-foreground" />
                     )}
                     <div className="text-md font-medium">
                       {selectionSummary.title}

--- a/front/components/agent_builder/capabilities/mcp/MCPAdditionalConfigurationPage.tsx
+++ b/front/components/agent_builder/capabilities/mcp/MCPAdditionalConfigurationPage.tsx
@@ -1,0 +1,100 @@
+import { Avatar, Button, Card, CommandLineIcon } from "@dust-tt/sparkle";
+import React from "react";
+
+import { AdditionalConfigurationSection } from "@app/components/agent_builder/capabilities/shared/AdditionalConfigurationSection";
+import { NameSection } from "@app/components/agent_builder/capabilities/shared/NameSection";
+import type { MCPServerToolsConfigurations } from "@app/lib/actions/mcp_internal_actions/input_configuration";
+
+export type SelectionSummary = {
+  id: string;
+  visual:
+    | { type: "icon" }
+    | { type: "avatar"; name: string; pictureUrl?: string | null };
+  title: string;
+  description?: string;
+  editLabel: string;
+  onEdit: () => void;
+};
+
+export type AdditionalConfigs = Pick<
+  MCPServerToolsConfigurations,
+  | "stringConfigurations"
+  | "numberConfigurations"
+  | "booleanConfigurations"
+  | "enumConfigurations"
+  | "listConfigurations"
+>;
+
+interface MCPAdditionalConfigurationPageProps {
+  selectionSummaries?: SelectionSummary[];
+  showNameSection: boolean;
+  additionalConfigs: AdditionalConfigs;
+}
+
+export function MCPAdditionalConfigurationPage({
+  selectionSummaries = [],
+  showNameSection,
+  additionalConfigs,
+}: MCPAdditionalConfigurationPageProps) {
+  console.log(">>>>> additionalConfigs", additionalConfigs);
+  console.log(">>>>> selectionSummaries", selectionSummaries);
+  return (
+    <div className="h-full">
+      <div className="h-full space-y-6 pt-3">
+        {selectionSummaries.length > 0 && (
+          <div className="flex w-full flex-col gap-3">
+            {selectionSummaries.map((s) => (
+              <Card key={s.id} size="sm" className="w-full">
+                <div className="flex w-full">
+                  <div className="flex w-full flex-grow flex-col gap-1 overflow-hidden">
+                    <div className="flex items-center gap-2">
+                      {s.visual.type === "icon" ? (
+                        <CommandLineIcon className="h-6 w-6 text-muted-foreground" />
+                      ) : (
+                        <Avatar
+                          size="sm"
+                          name={s.visual.name}
+                          visual={s.visual.pictureUrl}
+                        />
+                      )}
+                      <div className="text-md font-medium">{s.title}</div>
+                    </div>
+                    {s.description && (
+                      <div className="max-h-24 overflow-y-auto text-sm text-muted-foreground dark:text-muted-foreground-night">
+                        {s.description}
+                      </div>
+                    )}
+                  </div>
+                  <div className="ml-4 self-start">
+                    <Button
+                      variant="outline"
+                      size="sm"
+                      label={s.editLabel}
+                      onClick={s.onEdit}
+                    />
+                  </div>
+                </div>
+              </Card>
+            ))}
+          </div>
+        )}
+
+        {showNameSection && (
+          <NameSection
+            title="Name"
+            placeholder="My tool name…"
+            triggerValidationOnChange
+          />
+        )}
+
+        <AdditionalConfigurationSection
+          stringConfigurations={additionalConfigs.stringConfigurations}
+          numberConfigurations={additionalConfigs.numberConfigurations}
+          booleanConfigurations={additionalConfigs.booleanConfigurations}
+          enumConfigurations={additionalConfigs.enumConfigurations}
+          listConfigurations={additionalConfigs.listConfigurations}
+        />
+      </div>
+    </div>
+  );
+}

--- a/front/components/agent_builder/capabilities/mcp/MCPAdditionalConfigurationPage.tsx
+++ b/front/components/agent_builder/capabilities/mcp/MCPAdditionalConfigurationPage.tsx
@@ -27,13 +27,13 @@ export type AdditionalConfigs = Pick<
 >;
 
 interface MCPAdditionalConfigurationPageProps {
-  selectionSummaries?: SelectionSummary[];
+  selectionSummary?: SelectionSummary | null;
   showNameSection: boolean;
   additionalConfigs: AdditionalConfigs;
 }
 
 export function MCPAdditionalConfigurationPage({
-  selectionSummaries = [],
+  selectionSummary = null,
   showNameSection,
   additionalConfigs,
 }: MCPAdditionalConfigurationPageProps) {
@@ -48,41 +48,41 @@ export function MCPAdditionalConfigurationPage({
           />
         )}
 
-        {selectionSummaries.length > 0 && (
+        {selectionSummary && (
           <ConfigurationSectionContainer title="Selection" description="">
-            {selectionSummaries.map((s) => (
-              <Card key={s.id} size="sm" className="w-full">
-                <div className="flex w-full">
-                  <div className="flex w-full flex-grow flex-col gap-1 overflow-hidden">
-                    <div className="flex items-center gap-2">
-                      {s.visual.type === "icon" ? (
-                        <CommandLineIcon className="h-6 w-6 text-muted-foreground" />
-                      ) : (
-                        <Avatar
-                          size="sm"
-                          name={s.visual.name}
-                          visual={s.visual.pictureUrl}
-                        />
-                      )}
-                      <div className="text-md font-medium">{s.title}</div>
-                    </div>
-                    {s.description && (
-                      <div className="max-h-24 overflow-y-auto text-sm text-muted-foreground dark:text-muted-foreground-night">
-                        {s.description}
-                      </div>
+            <Card key={selectionSummary.id} size="sm" className="w-full">
+              <div className="flex w-full">
+                <div className="flex w-full flex-grow flex-col gap-1 overflow-hidden">
+                  <div className="flex items-center gap-2">
+                    {selectionSummary.visual.type === "icon" ? (
+                      <CommandLineIcon className="h-6 w-6 text-muted-foreground" />
+                    ) : (
+                      <Avatar
+                        size="sm"
+                        name={selectionSummary.visual.name}
+                        visual={selectionSummary.visual.pictureUrl}
+                      />
                     )}
+                    <div className="text-md font-medium">
+                      {selectionSummary.title}
+                    </div>
                   </div>
-                  <div className="ml-4 self-start">
-                    <Button
-                      variant="outline"
-                      size="sm"
-                      label={s.editLabel}
-                      onClick={s.onEdit}
-                    />
-                  </div>
+                  {selectionSummary.description && (
+                    <div className="max-h-24 overflow-y-auto text-sm text-muted-foreground dark:text-muted-foreground-night">
+                      {selectionSummary.description}
+                    </div>
+                  )}
                 </div>
-              </Card>
-            ))}
+                <div className="ml-4 self-start">
+                  <Button
+                    variant="outline"
+                    size="sm"
+                    label={selectionSummary.editLabel}
+                    onClick={selectionSummary.onEdit}
+                  />
+                </div>
+              </div>
+            </Card>
           </ConfigurationSectionContainer>
         )}
 

--- a/front/components/agent_builder/capabilities/mcp/MCPServerViewsSheet.tsx
+++ b/front/components/agent_builder/capabilities/mcp/MCPServerViewsSheet.tsx
@@ -1,13 +1,13 @@
 import type { MultiPageSheetPage } from "@dust-tt/sparkle";
 import {
+  Avatar,
+  Button,
+  Card,
+  CommandLineIcon,
   MultiPageSheet,
   MultiPageSheetContent,
   SearchInput,
   Spinner,
-  Button,
-  Card,
-  Avatar,
-  CommandLineIcon,
 } from "@dust-tt/sparkle";
 import { PencilIcon } from "@heroicons/react/20/solid";
 import { zodResolver } from "@hookform/resolvers/zod";
@@ -82,8 +82,8 @@ import {
 } from "@app/lib/actions/constants";
 import { getMCPServerToolsConfigurations } from "@app/lib/actions/mcp_internal_actions/input_configuration";
 import type { MCPServerViewType } from "@app/lib/api/mcp";
-import { useModels } from "@app/lib/swr/models";
 import { useAgentConfigurations } from "@app/lib/swr/assistants";
+import { useModels } from "@app/lib/swr/models";
 import { DEFAULT_REASONING_MODEL_ID } from "@app/types";
 
 const TOP_MCP_SERVER_VIEWS = [
@@ -182,9 +182,6 @@ export function MCPServerViewsSheet({
     useState<MCPServerViewType | null>(null);
   const [infoMCPServerView, setInfoMCPServerView] =
     useState<MCPServerViewType | null>(null);
-  const [forceSelectionTarget, setForceSelectionTarget] = useState<
-    "agent" | "dust_app" | null
-  >(null);
 
   const hasReasoningModel = reasoningModels.length > 0;
 
@@ -305,6 +302,14 @@ export function MCPServerViewsSheet({
         );
         if (mcpServerView) {
           setConfigurationMCPServerView(mcpServerView);
+          // If editing a Run Agent or Run Dust App tool, jump to Additional Configuration page
+          const cfgs = getMCPServerToolsConfigurations(mcpServerView);
+          if (
+            cfgs.childAgentConfiguration ??
+            cfgs.mayRequireDustAppConfiguration
+          ) {
+            setCurrentPageId(TOOLS_SHEET_PAGE_IDS.ADDITIONAL_CONFIGURATION);
+          }
         }
       }
     } else if (mode?.type === "configure") {
@@ -584,7 +589,6 @@ export function MCPServerViewsSheet({
     setCurrentPageId(TOOLS_SHEET_PAGE_IDS.TOOL_SELECTION);
     setConfigurationTool(null);
     setConfigurationMCPServerView(null);
-    setForceSelectionTarget(null);
   }, []);
 
   const resetSheet = useCallback(() => {
@@ -664,14 +668,11 @@ export function MCPServerViewsSheet({
 
                 {toolsConfigurations.childAgentConfiguration && (
                   <ChildAgentSection
-                    onSelected={() => {
-                      setForceSelectionTarget(null);
+                    onSelected={() =>
                       setCurrentPageId(
                         TOOLS_SHEET_PAGE_IDS.ADDITIONAL_CONFIGURATION
-                      );
-                    }}
-                    forceSelection={forceSelectionTarget === "agent"}
-                    showInlineEdit={false}
+                      )
+                    }
                   />
                 )}
 
@@ -681,14 +682,11 @@ export function MCPServerViewsSheet({
 
                 {toolsConfigurations.mayRequireDustAppConfiguration && (
                   <DustAppSection
-                    onSelected={() => {
-                      setForceSelectionTarget(null);
+                    onSelected={() =>
                       setCurrentPageId(
                         TOOLS_SHEET_PAGE_IDS.ADDITIONAL_CONFIGURATION
-                      );
-                    }}
-                    forceSelection={forceSelectionTarget === "dust_app"}
-                    showInlineEdit={false}
+                      )
+                    }
                   />
                 )}
 
@@ -747,12 +745,11 @@ export function MCPServerViewsSheet({
                                 size="sm"
                                 icon={PencilIcon}
                                 label="Edit selection"
-                                onClick={() => {
-                                  setForceSelectionTarget("dust_app");
+                                onClick={() =>
                                   setCurrentPageId(
                                     TOOLS_SHEET_PAGE_IDS.CONFIGURATION
-                                  );
-                                }}
+                                  )
+                                }
                               />
                             </div>
                           </div>
@@ -796,12 +793,11 @@ export function MCPServerViewsSheet({
                                   size="sm"
                                   icon={PencilIcon}
                                   label="Edit agent"
-                                  onClick={() => {
-                                    setForceSelectionTarget("agent");
+                                  onClick={() =>
                                     setCurrentPageId(
                                       TOOLS_SHEET_PAGE_IDS.CONFIGURATION
-                                    );
-                                  }}
+                                    )
+                                  }
                                 />
                               </div>
                             </div>

--- a/front/components/agent_builder/capabilities/mcp/MCPServerViewsSheet.tsx
+++ b/front/components/agent_builder/capabilities/mcp/MCPServerViewsSheet.tsx
@@ -533,6 +533,25 @@ export function MCPServerViewsSheet({
     [mcpServerView]
   );
 
+  const hasAdditionalConfiguration = useMemo(() => {
+    if (!toolsConfigurations) {
+      return false;
+    }
+    const hasStrings =
+      (toolsConfigurations.stringConfigurations?.length ?? 0) > 0;
+    const hasNumbers =
+      (toolsConfigurations.numberConfigurations?.length ?? 0) > 0;
+    const hasBooleans =
+      (toolsConfigurations.booleanConfigurations?.length ?? 0) > 0;
+    const hasEnums =
+      toolsConfigurations.enumConfigurations &&
+      Object.keys(toolsConfigurations.enumConfigurations).length > 0;
+    const hasLists =
+      toolsConfigurations.listConfigurations &&
+      Object.keys(toolsConfigurations.listConfigurations).length > 0;
+    return hasStrings || hasNumbers || hasBooleans || hasEnums || hasLists;
+  }, [toolsConfigurations]);
+
   // Stable form reset handler - no form dependency to prevent re-renders
   const resetFormValues = useMemo(
     () => createFormResetHandler(configurationTool, mcpServerView, isOpen),
@@ -653,7 +672,23 @@ export function MCPServerViewsSheet({
                     getAgentInstructions={getAgentInstructions}
                   />
                 )}
-
+              </div>
+            </div>
+          </FormProvider>
+        ) : (
+          <div className="flex h-40 w-full items-center justify-center">
+            <Spinner />
+          </div>
+        ),
+    },
+    {
+      id: TOOLS_SHEET_PAGE_IDS.ADDITIONAL_CONFIGURATION,
+      title: "Additional Configuration",
+      content:
+        toolsConfigurations && form ? (
+          <FormProvider form={form} className="h-full">
+            <div className="h-full">
+              <div className="h-full space-y-6 pt-3">
                 <AdditionalConfigurationSection
                   stringConfigurations={
                     toolsConfigurations.stringConfigurations
@@ -792,6 +827,11 @@ export function MCPServerViewsSheet({
     },
     onConfigurationSave: handleConfigurationSave,
     resetToSelection,
+    hasAdditionalConfiguration,
+    goToAdditionalConfiguration: () =>
+      setCurrentPageId(TOOLS_SHEET_PAGE_IDS.ADDITIONAL_CONFIGURATION),
+    goToConfiguration: () =>
+      setCurrentPageId(TOOLS_SHEET_PAGE_IDS.CONFIGURATION),
   });
 
   return (

--- a/front/components/agent_builder/capabilities/mcp/MCPServerViewsSheet.tsx
+++ b/front/components/agent_builder/capabilities/mcp/MCPServerViewsSheet.tsx
@@ -50,6 +50,7 @@ import {
   getInitialConfigurationTool,
   getInitialPageId,
   handleConfigurationSave as handleConfigurationSaveUtil,
+  hasAnyAdditionalConfigs,
   shouldGenerateUniqueName,
 } from "@app/components/agent_builder/capabilities/mcp/utils/sheetUtils";
 import { ChildAgentSection } from "@app/components/agent_builder/capabilities/shared/ChildAgentSection";
@@ -552,22 +553,8 @@ export function MCPServerViewsSheet({
     if (!toolsConfigurations) {
       return false;
     }
-    const hasStrings =
-      (toolsConfigurations.stringConfigurations?.length ?? 0) > 0;
-    const hasNumbers =
-      (toolsConfigurations.numberConfigurations?.length ?? 0) > 0;
-    const hasBooleans =
-      (toolsConfigurations.booleanConfigurations?.length ?? 0) > 0;
-    const hasEnums =
-      toolsConfigurations.enumConfigurations &&
-      Object.keys(toolsConfigurations.enumConfigurations).length > 0;
-    const hasLists =
-      toolsConfigurations.listConfigurations &&
-      Object.keys(toolsConfigurations.listConfigurations).length > 0;
     const hasName = configurationTool?.configurable ?? false;
-    return (
-      hasName || hasStrings || hasNumbers || hasBooleans || hasEnums || hasLists
-    );
+    return hasAnyAdditionalConfigs(toolsConfigurations) || hasName;
   }, [toolsConfigurations, configurationTool?.configurable]);
 
   // Stable form reset handler - no form dependency to prevent re-renders

--- a/front/components/agent_builder/capabilities/mcp/utils/selectionSummaryUtils.ts
+++ b/front/components/agent_builder/capabilities/mcp/utils/selectionSummaryUtils.ts
@@ -1,0 +1,155 @@
+import type { ServerSideMCPServerConfigurationType } from "@app/lib/actions/mcp";
+import type {
+  DustAppRunConfigurationType,
+  LightAgentConfigurationType,
+  ModelConfigurationType,
+} from "@app/types";
+
+export type BaseSelectionSummary = {
+  title: string;
+  description?: string;
+  onEdit: () => void;
+};
+
+export type DustAppSelectionSummary = BaseSelectionSummary & {
+  id: "dust-app";
+  visual: { type: "icon" };
+  editLabel: "Edit selection";
+};
+
+export type ChildAgentSelectionSummary = BaseSelectionSummary & {
+  id: "child-agent";
+  visual: { type: "avatar"; name: string; pictureUrl?: string | null };
+  editLabel: "Edit agent";
+};
+
+export type ReasoningModelSelectionSummary = BaseSelectionSummary & {
+  id: "reasoning-model";
+  visual: { type: "icon" };
+  editLabel: "Edit model";
+};
+
+export type SingleSelectionSummary =
+  | DustAppSelectionSummary
+  | ChildAgentSelectionSummary
+  | ReasoningModelSelectionSummary;
+
+export function createDustAppSummary({
+  dustAppConfiguration,
+  onEdit,
+}: {
+  dustAppConfiguration: DustAppRunConfigurationType | null;
+  onEdit: () => void;
+}): DustAppSelectionSummary | null {
+  if (!dustAppConfiguration) {
+    return null;
+  }
+  return {
+    id: "dust-app",
+    visual: { type: "icon" },
+    title: dustAppConfiguration.name,
+    description: dustAppConfiguration.description ?? "No description available",
+    editLabel: "Edit selection",
+    onEdit,
+  };
+}
+
+export function createChildAgentSummary({
+  childAgentId,
+  agents,
+  onEdit,
+}: {
+  childAgentId: string | null;
+  agents: LightAgentConfigurationType[];
+  onEdit: () => void;
+}): ChildAgentSelectionSummary | null {
+  const selectedAgent = agents.find((a) => a.sId === childAgentId);
+  if (!childAgentId || !selectedAgent) {
+    return null;
+  }
+
+  return {
+    id: "child-agent",
+    visual: {
+      type: "avatar",
+      name: selectedAgent.name,
+      pictureUrl: selectedAgent.pictureUrl,
+    },
+    title: selectedAgent.name,
+    description: selectedAgent.description || "No description available",
+    editLabel: "Edit agent",
+    onEdit,
+  };
+}
+
+export function createReasoningModelSummary({
+  reasoningModel,
+  models,
+  onEdit,
+}: {
+  reasoningModel: { modelId: string; providerId: string } | null;
+  models: ModelConfigurationType[];
+  onEdit: () => void;
+}): ReasoningModelSelectionSummary | null {
+  const model = models.find(
+    (m) =>
+      m.modelId === reasoningModel?.modelId &&
+      m.providerId === reasoningModel?.providerId
+  );
+  if (!model) {
+    return null;
+  }
+
+  return {
+    id: "reasoning-model",
+    visual: { type: "icon" },
+    title: model.displayName,
+    description: model.description || "No description available",
+    editLabel: "Edit model",
+    onEdit,
+  };
+}
+
+type BuildSelectionSummarySharedArgs = {
+  onEdit: () => void;
+};
+
+type BuildSelectionSummaryArgs =
+  | (BuildSelectionSummarySharedArgs & {
+      kind: "dust-app";
+      dustAppConfiguration: ServerSideMCPServerConfigurationType["dustAppConfiguration"];
+    })
+  | (BuildSelectionSummarySharedArgs & {
+      kind: "child-agent";
+      childAgentId: ServerSideMCPServerConfigurationType["childAgentId"];
+      agents: LightAgentConfigurationType[];
+    })
+  | (BuildSelectionSummarySharedArgs & {
+      kind: "reasoning-model";
+      reasoningModel: ServerSideMCPServerConfigurationType["reasoningModel"];
+      models: ModelConfigurationType[];
+    });
+
+export function buildSelectionSummary(
+  args: BuildSelectionSummaryArgs
+): SingleSelectionSummary | null {
+  switch (args.kind) {
+    case "dust-app":
+      return createDustAppSummary({
+        dustAppConfiguration: args.dustAppConfiguration,
+        onEdit: args.onEdit,
+      });
+    case "child-agent":
+      return createChildAgentSummary({
+        childAgentId: args.childAgentId,
+        agents: args.agents,
+        onEdit: args.onEdit,
+      });
+    case "reasoning-model":
+      return createReasoningModelSummary({
+        reasoningModel: args.reasoningModel,
+        models: args.models,
+        onEdit: args.onEdit,
+      });
+  }
+}

--- a/front/components/agent_builder/capabilities/mcp/utils/selectionSummaryUtils.ts
+++ b/front/components/agent_builder/capabilities/mcp/utils/selectionSummaryUtils.ts
@@ -25,7 +25,7 @@ export type ChildAgentSelectionSummary = BaseSelectionSummary & {
 
 export type ReasoningModelSelectionSummary = BaseSelectionSummary & {
   id: "reasoning-model";
-  visual: { type: "icon" };
+  visual: { type: "provider-logo"; providerId: string } | { type: "icon" };
   editLabel: "Edit model";
 };
 
@@ -102,7 +102,9 @@ export function createReasoningModelSummary({
 
   return {
     id: "reasoning-model",
-    visual: { type: "icon" },
+    visual: model.providerId
+      ? { type: "provider-logo", providerId: model.providerId }
+      : { type: "icon" },
     title: model.displayName,
     description: model.description || "No description available",
     editLabel: "Edit model",

--- a/front/components/agent_builder/capabilities/mcp/utils/selectionSummaryUtils.ts
+++ b/front/components/agent_builder/capabilities/mcp/utils/selectionSummaryUtils.ts
@@ -3,6 +3,7 @@ import type {
   DustAppRunConfigurationType,
   LightAgentConfigurationType,
   ModelConfigurationType,
+  ModelProviderIdType,
 } from "@app/types";
 
 export type BaseSelectionSummary = {
@@ -25,7 +26,9 @@ export type ChildAgentSelectionSummary = BaseSelectionSummary & {
 
 export type ReasoningModelSelectionSummary = BaseSelectionSummary & {
   id: "reasoning-model";
-  visual: { type: "provider-logo"; providerId: string } | { type: "icon" };
+  visual:
+    | { type: "provider-logo"; providerId: ModelProviderIdType }
+    | { type: "icon" };
   editLabel: "Edit model";
 };
 
@@ -87,7 +90,7 @@ export function createReasoningModelSummary({
   models,
   onEdit,
 }: {
-  reasoningModel: { modelId: string; providerId: string } | null;
+  reasoningModel: { modelId: string; providerId: ModelProviderIdType } | null;
   models: ModelConfigurationType[];
   onEdit: () => void;
 }): ReasoningModelSelectionSummary | null {

--- a/front/components/agent_builder/capabilities/mcp/utils/sheetUtils.ts
+++ b/front/components/agent_builder/capabilities/mcp/utils/sheetUtils.ts
@@ -11,8 +11,28 @@ import type {
 } from "@app/components/agent_builder/types";
 import { TOOLS_SHEET_PAGE_IDS } from "@app/components/agent_builder/types";
 import { getMcpServerViewDisplayName } from "@app/lib/actions/mcp_helper";
+import type { MCPServerToolsConfigurations } from "@app/lib/actions/mcp_internal_actions/input_configuration";
 import type { MCPServerViewType } from "@app/lib/api/mcp";
 import { pluralize } from "@app/types";
+
+export function hasAnyAdditionalConfigs(
+  toolsConfigurations: MCPServerToolsConfigurations
+): boolean {
+  const hasStrings =
+    (toolsConfigurations.stringConfigurations?.length ?? 0) > 0;
+  const hasNumbers =
+    (toolsConfigurations.numberConfigurations?.length ?? 0) > 0;
+  const hasBooleans =
+    (toolsConfigurations.booleanConfigurations?.length ?? 0) > 0;
+  const hasEnums =
+    toolsConfigurations.enumConfigurations &&
+    Object.keys(toolsConfigurations.enumConfigurations).length > 0;
+  const hasLists =
+    toolsConfigurations.listConfigurations &&
+    Object.keys(toolsConfigurations.listConfigurations).length > 0;
+
+  return hasStrings || hasNumbers || hasBooleans || hasEnums || hasLists;
+}
 
 export function isValidPage<T extends Record<string, string>>(
   pageId: string,

--- a/front/components/agent_builder/capabilities/mcp/utils/sheetUtils.ts
+++ b/front/components/agent_builder/capabilities/mcp/utils/sheetUtils.ts
@@ -59,6 +59,10 @@ export interface FooterButtonOptions {
   onAddSelectedTools: () => void;
   onConfigurationSave: (data: MCPFormData) => void;
   resetToSelection: () => void;
+  // Navigation helpers for multi-page configuration flows
+  hasAdditionalConfiguration?: boolean;
+  goToAdditionalConfiguration?: () => void;
+  goToConfiguration?: () => void;
 }
 
 export function getFooterButtons({
@@ -71,12 +75,17 @@ export function getFooterButtons({
   onAddSelectedTools,
   onConfigurationSave,
   resetToSelection,
+  hasAdditionalConfiguration,
+  goToAdditionalConfiguration,
+  goToConfiguration,
 }: FooterButtonOptions) {
   const isToolSelectionPage =
     currentPageId === TOOLS_SHEET_PAGE_IDS.TOOL_SELECTION;
   const isConfigurationPage =
     currentPageId === TOOLS_SHEET_PAGE_IDS.CONFIGURATION;
   const isInfoPage = currentPageId === TOOLS_SHEET_PAGE_IDS.INFO;
+  const isAdditionalConfigurationPage =
+    currentPageId === TOOLS_SHEET_PAGE_IDS.ADDITIONAL_CONFIGURATION;
 
   if (isToolSelectionPage) {
     return {
@@ -98,6 +107,8 @@ export function getFooterButtons({
   }
 
   if (isConfigurationPage) {
+    const showNext = !!hasAdditionalConfiguration;
+
     if (mode?.type === "edit") {
       return {
         leftButton: {
@@ -105,11 +116,18 @@ export function getFooterButtons({
           variant: "outline",
           onClick: onCancel,
         },
-        rightButton: {
-          label: "Save Changes",
-          variant: "primary",
-          onClick: form.handleSubmit(onConfigurationSave),
-        },
+        rightButton: showNext
+          ? {
+              label: "Next",
+              variant: "primary",
+              onClick: () =>
+                goToAdditionalConfiguration && goToAdditionalConfiguration(),
+            }
+          : {
+              label: "Save Changes",
+              variant: "primary",
+              onClick: form.handleSubmit(onConfigurationSave),
+            },
       };
     }
 
@@ -120,11 +138,18 @@ export function getFooterButtons({
           variant: "outline",
           onClick: () => onModeChange({ type: "add" }),
         },
-        rightButton: {
-          label: "Save Configuration",
-          variant: "primary",
-          onClick: form.handleSubmit(onConfigurationSave),
-        },
+        rightButton: showNext
+          ? {
+              label: "Next",
+              variant: "primary",
+              onClick: () =>
+                goToAdditionalConfiguration && goToAdditionalConfiguration(),
+            }
+          : {
+              label: "Save Configuration",
+              variant: "primary",
+              onClick: form.handleSubmit(onConfigurationSave),
+            },
       };
     }
 
@@ -134,8 +159,33 @@ export function getFooterButtons({
         variant: "outline",
         onClick: resetToSelection,
       },
+      rightButton: showNext
+        ? {
+            label: "Next",
+            variant: "primary",
+            onClick: () =>
+              goToAdditionalConfiguration && goToAdditionalConfiguration(),
+          }
+        : {
+            label: "Save Configuration",
+            variant: "primary",
+            onClick: form.handleSubmit(onConfigurationSave),
+          },
+    };
+  }
+
+  if (isAdditionalConfigurationPage) {
+    const saveLabel =
+      mode?.type === "edit" ? "Save Changes" : "Save Configuration";
+
+    return {
+      leftButton: {
+        label: "Back",
+        variant: "outline",
+        onClick: () => goToConfiguration && goToConfiguration(),
+      },
       rightButton: {
-        label: "Save Configuration",
+        label: saveLabel,
         variant: "primary",
         onClick: form.handleSubmit(onConfigurationSave),
       },

--- a/front/components/agent_builder/capabilities/shared/ChildAgentSection.tsx
+++ b/front/components/agent_builder/capabilities/shared/ChildAgentSection.tsx
@@ -1,14 +1,10 @@
 import {
-  Button,
   ContentMessage,
   DataTable,
   InformationCircleIcon,
   SearchInput,
   Spinner,
 } from "@dust-tt/sparkle";
-import { Avatar } from "@dust-tt/sparkle";
-import { Card } from "@dust-tt/sparkle";
-import { PencilIcon } from "@heroicons/react/20/solid";
 import type { ColumnDef } from "@tanstack/react-table";
 import React, { useMemo, useState } from "react";
 import { useController } from "react-hook-form";
@@ -74,15 +70,7 @@ function AgentMessage({ title, children }: AgentMessageProps) {
   );
 }
 
-export function ChildAgentSection({
-  onSelected,
-  forceSelection = false,
-  showInlineEdit = true,
-}: {
-  onSelected?: () => void;
-  forceSelection?: boolean;
-  showInlineEdit?: boolean;
-}) {
+export function ChildAgentSection({ onSelected }: { onSelected?: () => void }) {
   const { owner } = useAgentBuilderContext();
   const { field, fieldState } = useController<
     MCPFormData,
@@ -105,10 +93,6 @@ export function ChildAgentSection({
   const handleRowClick = (agent: LightAgentConfigurationType) => {
     field.onChange(agent.sId);
     onSelected?.();
-  };
-
-  const handleEditClick = () => {
-    field.onChange(null);
   };
 
   const tableData: AgentTableData[] = agentConfigurations.map((agent) => ({
@@ -146,12 +130,6 @@ export function ChildAgentSection({
     (agent) => agent.sId === field.value
   );
 
-  const shouldShowTable =
-    forceSelection ||
-    (!isAgentConfigurationsError &&
-      agentConfigurations.length > 0 &&
-      !field.value);
-
   let messageProps: { title: string; children: string };
   if (isAgentConfigurationsError) {
     messageProps = {
@@ -182,7 +160,7 @@ export function ChildAgentSection({
         </div>
       )}
 
-      {!isAgentConfigurationsLoading && shouldShowTable && (
+      {!isAgentConfigurationsLoading && (
         <AgentSelectionTable
           tableData={tableData}
           columns={columns}
@@ -191,38 +169,7 @@ export function ChildAgentSection({
         />
       )}
 
-      {!isAgentConfigurationsLoading && !shouldShowTable && selectedAgent && (
-        <Card size="sm" className="w-full">
-          <div className="flex w-full">
-            <div className="flex w-full flex-grow flex-col gap-1 overflow-hidden">
-              <div className="flex items-center gap-2">
-                <Avatar
-                  size="sm"
-                  name={selectedAgent.name}
-                  visual={selectedAgent.pictureUrl}
-                />
-                <div className="text-md font-medium">{selectedAgent.name}</div>
-              </div>
-              <div className="max-h-24 overflow-y-auto text-sm text-muted-foreground dark:text-muted-foreground-night">
-                {selectedAgent.description || "No description available"}
-              </div>
-            </div>
-            {showInlineEdit && (
-              <div className="ml-4 self-start">
-                <Button
-                  variant="outline"
-                  size="sm"
-                  icon={PencilIcon}
-                  label="Edit agent"
-                  onClick={handleEditClick}
-                />
-              </div>
-            )}
-          </div>
-        </Card>
-      )}
-
-      {!isAgentConfigurationsLoading && !shouldShowTable && !selectedAgent && (
+      {!isAgentConfigurationsLoading && !selectedAgent && (
         <AgentMessage {...messageProps} />
       )}
     </ConfigurationSectionContainer>

--- a/front/components/agent_builder/capabilities/shared/ChildAgentSection.tsx
+++ b/front/components/agent_builder/capabilities/shared/ChildAgentSection.tsx
@@ -154,13 +154,11 @@ export function ChildAgentSection({ onSelected }: { onSelected?: () => void }) {
       title="Select Agent"
       error={fieldState.error?.message}
     >
-      {isAgentConfigurationsLoading && (
+      {isAgentConfigurationsLoading ? (
         <div className="flex h-full w-full items-center justify-center">
           <Spinner />
         </div>
-      )}
-
-      {!isAgentConfigurationsLoading && (
+      ) : (
         <AgentSelectionTable
           tableData={tableData}
           columns={columns}

--- a/front/components/agent_builder/capabilities/shared/ChildAgentSection.tsx
+++ b/front/components/agent_builder/capabilities/shared/ChildAgentSection.tsx
@@ -74,7 +74,15 @@ function AgentMessage({ title, children }: AgentMessageProps) {
   );
 }
 
-export function ChildAgentSection() {
+export function ChildAgentSection({
+  onSelected,
+  forceSelection = false,
+  showInlineEdit = true,
+}: {
+  onSelected?: () => void;
+  forceSelection?: boolean;
+  showInlineEdit?: boolean;
+}) {
   const { owner } = useAgentBuilderContext();
   const { field, fieldState } = useController<
     MCPFormData,
@@ -96,6 +104,7 @@ export function ChildAgentSection() {
 
   const handleRowClick = (agent: LightAgentConfigurationType) => {
     field.onChange(agent.sId);
+    onSelected?.();
   };
 
   const handleEditClick = () => {
@@ -138,9 +147,10 @@ export function ChildAgentSection() {
   );
 
   const shouldShowTable =
-    !isAgentConfigurationsError &&
-    agentConfigurations.length > 0 &&
-    !field.value;
+    forceSelection ||
+    (!isAgentConfigurationsError &&
+      agentConfigurations.length > 0 &&
+      !field.value);
 
   let messageProps: { title: string; children: string };
   if (isAgentConfigurationsError) {
@@ -197,15 +207,17 @@ export function ChildAgentSection() {
                 {selectedAgent.description || "No description available"}
               </div>
             </div>
-            <div className="ml-4 self-start">
-              <Button
-                variant="outline"
-                size="sm"
-                icon={PencilIcon}
-                label="Edit agent"
-                onClick={handleEditClick}
-              />
-            </div>
+            {showInlineEdit && (
+              <div className="ml-4 self-start">
+                <Button
+                  variant="outline"
+                  size="sm"
+                  icon={PencilIcon}
+                  label="Edit agent"
+                  onClick={handleEditClick}
+                />
+              </div>
+            )}
           </div>
         </Card>
       )}

--- a/front/components/agent_builder/capabilities/shared/DustAppSection.tsx
+++ b/front/components/agent_builder/capabilities/shared/DustAppSection.tsx
@@ -1,6 +1,5 @@
 import {
   Button,
-  Card,
   CommandLineIcon,
   DataTable,
   DropdownMenu,
@@ -10,7 +9,6 @@ import {
   SearchInput,
   Spinner,
 } from "@dust-tt/sparkle";
-import { PencilIcon } from "@heroicons/react/20/solid";
 import type { ColumnDef } from "@tanstack/react-table";
 import sortBy from "lodash/sortBy";
 import React, { useEffect, useMemo, useState } from "react";
@@ -57,15 +55,7 @@ function AppSelectionTable({ tableData, columns }: AppSelectionTableProps) {
   );
 }
 
-export function DustAppSection({
-  onSelected,
-  forceSelection = false,
-  showInlineEdit = true,
-}: {
-  onSelected?: () => void;
-  forceSelection?: boolean;
-  showInlineEdit?: boolean;
-}) {
+export function DustAppSection({ onSelected }: { onSelected?: () => void }) {
   const { owner } = useAgentBuilderContext();
   const { field, fieldState } = useController<
     MCPFormData,
@@ -124,10 +114,6 @@ export function DustAppSection({
     };
     field.onChange(config);
     onSelected?.();
-  };
-
-  const handleEditClick = () => {
-    field.onChange(null);
   };
 
   const handleSpaceChange = (space: SpaceType) => {
@@ -210,31 +196,6 @@ export function DustAppSection({
           <div className="flex h-full w-full items-center justify-center">
             <Spinner />
           </div>
-        ) : field.value && !forceSelection ? (
-          <Card size="sm" className="w-full">
-            <div className="flex w-full">
-              <div className="flex w-full flex-grow flex-col gap-1 overflow-hidden">
-                <div className="flex items-center gap-2">
-                  <CommandLineIcon className="h-6 w-6 text-muted-foreground" />
-                  <div className="text-md font-medium">{field.value.name}</div>
-                </div>
-                <div className="max-h-24 overflow-y-auto text-sm text-muted-foreground dark:text-muted-foreground-night">
-                  {field.value.description || "No description available"}
-                </div>
-              </div>
-              {showInlineEdit && (
-                <div className="ml-4 self-start">
-                  <Button
-                    variant="outline"
-                    size="sm"
-                    icon={PencilIcon}
-                    label="Edit selection"
-                    onClick={handleEditClick}
-                  />
-                </div>
-              )}
-            </div>
-          </Card>
         ) : spaces.length > 0 && selectedSpace && availableApps.length > 0 ? (
           <AppSelectionTable tableData={tableData} columns={columns} />
         ) : (

--- a/front/components/agent_builder/capabilities/shared/DustAppSection.tsx
+++ b/front/components/agent_builder/capabilities/shared/DustAppSection.tsx
@@ -57,7 +57,15 @@ function AppSelectionTable({ tableData, columns }: AppSelectionTableProps) {
   );
 }
 
-export function DustAppSection() {
+export function DustAppSection({
+  onSelected,
+  forceSelection = false,
+  showInlineEdit = true,
+}: {
+  onSelected?: () => void;
+  forceSelection?: boolean;
+  showInlineEdit?: boolean;
+}) {
   const { owner } = useAgentBuilderContext();
   const { field, fieldState } = useController<
     MCPFormData,
@@ -115,6 +123,7 @@ export function DustAppSection() {
       type: "dust_app_run_configuration",
     };
     field.onChange(config);
+    onSelected?.();
   };
 
   const handleEditClick = () => {
@@ -201,7 +210,7 @@ export function DustAppSection() {
           <div className="flex h-full w-full items-center justify-center">
             <Spinner />
           </div>
-        ) : field.value ? (
+        ) : field.value && !forceSelection ? (
           <Card size="sm" className="w-full">
             <div className="flex w-full">
               <div className="flex w-full flex-grow flex-col gap-1 overflow-hidden">
@@ -213,15 +222,17 @@ export function DustAppSection() {
                   {field.value.description || "No description available"}
                 </div>
               </div>
-              <div className="ml-4 self-start">
-                <Button
-                  variant="outline"
-                  size="sm"
-                  icon={PencilIcon}
-                  label="Edit selection"
-                  onClick={handleEditClick}
-                />
-              </div>
+              {showInlineEdit && (
+                <div className="ml-4 self-start">
+                  <Button
+                    variant="outline"
+                    size="sm"
+                    icon={PencilIcon}
+                    label="Edit selection"
+                    onClick={handleEditClick}
+                  />
+                </div>
+              )}
             </div>
           </Card>
         ) : spaces.length > 0 && selectedSpace && availableApps.length > 0 ? (

--- a/front/components/agent_builder/capabilities/shared/ReasoningModelSection.tsx
+++ b/front/components/agent_builder/capabilities/shared/ReasoningModelSection.tsx
@@ -1,14 +1,11 @@
 import {
-  Button,
-  Card,
   ContentMessage,
   ContextItem,
+  Icon,
   InformationCircleIcon,
   SearchInput,
   Spinner,
 } from "@dust-tt/sparkle";
-import { Icon } from "@dust-tt/sparkle";
-import { PencilIcon } from "@heroicons/react/20/solid";
 import { useMemo, useState } from "react";
 import { useController } from "react-hook-form";
 
@@ -88,7 +85,11 @@ function ModelMessage({ title, children }: ModelMessageProps) {
   );
 }
 
-export function ReasoningModelSection() {
+export function ReasoningModelSection({
+  onSelected,
+}: {
+  onSelected?: () => void;
+}) {
   const { owner } = useAgentBuilderContext();
   const { field, fieldState } = useController<
     MCPFormData,
@@ -110,10 +111,7 @@ export function ReasoningModelSection() {
       temperature: null,
       reasoningEffort: null,
     });
-  };
-
-  const handleEditClick = () => {
-    field.onChange(null);
+    onSelected?.();
   };
 
   const selectedReasoningModelConfig = useMemo(
@@ -154,13 +152,11 @@ export function ReasoningModelSection() {
       title="Reasoning Model"
       error={fieldState.error?.message}
     >
-      {isModelsLoading && (
+      {isModelsLoading ? (
         <div className="flex h-full w-full items-center justify-center">
           <Spinner />
         </div>
-      )}
-
-      {!isModelsLoading && shouldShowList && (
+      ) : (
         <ModelSelectionList
           models={reasoningModels}
           searchQuery={searchQuery}
@@ -168,46 +164,6 @@ export function ReasoningModelSection() {
           onModelSelect={handleRowClick}
           isDark={isDark}
         />
-      )}
-
-      {!isModelsLoading && !shouldShowList && selectedReasoningModelConfig && (
-        <Card size="sm" className="w-full">
-          <div className="flex w-full">
-            <div className="flex w-full flex-grow flex-col gap-1 overflow-hidden">
-              <div className="flex items-center gap-2">
-                <div className="flex items-center gap-2">
-                  {(() => {
-                    const LogoComponent = getModelProviderLogo(
-                      selectedReasoningModelConfig.providerId,
-                      isDark
-                    );
-                    return LogoComponent ? (
-                      <div className="flex h-8 w-8 items-center justify-center">
-                        <Icon visual={LogoComponent} size="lg" />
-                      </div>
-                    ) : null;
-                  })()}
-                  <div className="text-md font-medium">
-                    {selectedReasoningModelConfig.displayName}
-                  </div>
-                </div>
-              </div>
-              <div className="max-h-24 overflow-y-auto text-sm text-muted-foreground dark:text-muted-foreground-night">
-                {selectedReasoningModelConfig.description ||
-                  "No description available"}
-              </div>
-            </div>
-            <div className="ml-4 self-start">
-              <Button
-                variant="outline"
-                size="sm"
-                icon={PencilIcon}
-                label="Edit selection"
-                onClick={handleEditClick}
-              />
-            </div>
-          </div>
-        </Card>
       )}
 
       {!isModelsLoading && !shouldShowList && !selectedReasoningModelConfig && (

--- a/front/components/agent_builder/types.ts
+++ b/front/components/agent_builder/types.ts
@@ -59,6 +59,7 @@ export const CONFIGURATION_SHEET_PAGE_IDS = {
 export const TOOLS_SHEET_PAGE_IDS = {
   TOOL_SELECTION: "tool-selection",
   CONFIGURATION: "configuration",
+  ADDITIONAL_CONFIGURATION: "additional-configuration",
   INFO: "info",
 };
 


### PR DESCRIPTION
## Description

This PR refactors the MCP agent builder tool configuration UI by introducing a dedicated additional configuration page. The refactor separates the configuration flow into distinct pages: tool selection, basic configuration, and additional configuration with better navigation and user experience. The motivation is to fit the knowledge configuration flow.

Key changes include creating a new MCPAdditionalConfigurationPage component that handles tool naming and advanced configurations (strings, numbers, booleans, enums, lists), along with selection summaries for dust apps, child agents, and reasoning models. The navigation flow is enhanced with proper page transitions and footer buttons that adapt based on configuration requirements.

**References:**
- https://github.com/dust-tt/tasks/issues/4402

## Tests

- [x] Locally
- [ ] Front-edge

## Risk

Breaking tools configuration flow

## Deploy Plan

Deploy front
