### PR TITLE
[front] - fix(AB): prevent non-configurable actions from selecting MCP views

### DIFF
--- a/front/components/agent_builder/capabilities/mcp/MCPServerViewsSheet.tsx
+++ b/front/components/agent_builder/capabilities/mcp/MCPServerViewsSheet.tsx
@@ -187,7 +187,8 @@ export function MCPServerViewsSheet({
         if (
           action.type === "MCP" &&
           action.configuration &&
-          action.configuration.mcpServerViewId
+          action.configuration.mcpServerViewId &&
+          !action.configurable
         ) {
           const selectedView = allMcpServerViews.find(
             (mcpServerView) =>
@@ -258,6 +259,7 @@ export function MCPServerViewsSheet({
       nonTopViews: filterViews(selectableNonTopMCPServerViews),
     };
   }, [searchTerm, selectableTopMCPServerViews, selectableNonTopMCPServerViews]);
+
   const showDataVisualization = useMemo(() => {
     if (!searchTerm.trim()) {
       return true;


### PR DESCRIPTION
## Description

This PR aims at making sure that configurable actions can be reinstantiated.

**References:**
- https://github.com/dust-tt/tasks/issues/4395

## Tests

Locally

## Risk

Low

## Deploy Plan

Deploy front