### PR TITLE
[connectors] Handle `DataSourceQuotaExceededError` for GitHub code files reactively

### DIFF
--- a/connectors/src/connectors/github/lib/code/file_operations.ts
+++ b/connectors/src/connectors/github/lib/code/file_operations.ts
@@ -193,19 +193,16 @@ export async function upsertCodeFile({
       });
     } catch (error) {
       if (error instanceof DataSourceQuotaExceededError) {
-        const skipReason = "file_too_large";
-
         logger.warn(
           {
             error,
             documentId,
-            skipReason,
             extension: extname(fileName),
           },
           "Skipping GitHub code file exceeding plan limit."
         );
 
-        githubCodeFile.skipReason = skipReason;
+        // Not setting a skipReason in purpose in case the file becomes smaller.
         githubCodeFile.lastSeenAt = codeSyncStartedAt;
         await githubCodeFile.save();
 


### PR DESCRIPTION
## Description

- This PR changes the way `DataSourceQuotaExceededError` are handled for GitHub code files.
- This error is raised for files that are individually too large.
- We currently handles this preemptively by checking the size of the content against a fixed value of 3MB. The actual per-document limits depends on the plan, which is why we're currently hitting issues for connectors that have a limit of 2MB but have files between 2 and 3MB.
- Ideally we would get a nice `Result` out of `upsertDataSourceDocument` and handle this more naturally (no try catch), will consider doing this in a future PR.

## Tests

## Risk

- Low.

## Deploy Plan

- Deploy connectors.
