### PR TITLE
Assistant browser - Can select tag from search bar

### DIFF
--- a/front/components/assistant/AssistantBrowser.tsx
+++ b/front/components/assistant/AssistantBrowser.tsx
@@ -81,6 +81,7 @@ type AgentGridProps = {
   handleAssistantClick: (agent: LightAgentConfigurationType) => void;
   handleMoreClick: (agentId: string) => void;
 };
+
 export const AgentGrid = ({
   agentConfigurations,
   handleAssistantClick,
@@ -119,6 +120,7 @@ export const AgentGrid = ({
       nextPage();
     }
   }, [inView, nextPage, entry, agentConfigurations.length, itemsPage]);
+
   const slicedAgentConfigurations = agentConfigurations.slice(
     0,
     (itemsPage + 1) * ITEMS_PER_PAGE

--- a/front/components/assistant/AssistantBrowser.tsx
+++ b/front/components/assistant/AssistantBrowser.tsx
@@ -398,7 +398,6 @@ export function AssistantBrowser({
                   onClick={() => {
                     setSelectedTab("all");
                     setAssistantSearch("");
-                    setSelectedTag(tag.sId);
                     setTimeout(() => {
                       const element = document.getElementById(
                         `anchor-${tag.sId}`

--- a/front/components/assistant/AssistantBrowser.tsx
+++ b/front/components/assistant/AssistantBrowser.tsx
@@ -398,6 +398,7 @@ export function AssistantBrowser({
                   onClick={() => {
                     setSelectedTab("all");
                     setAssistantSearch("");
+                    setSelectedTag(tag.sId);
                     setTimeout(() => {
                       const element = document.getElementById(
                         `anchor-${tag.sId}`

--- a/front/components/assistant/AssistantBrowser.tsx
+++ b/front/components/assistant/AssistantBrowser.tsx
@@ -400,6 +400,7 @@ export function AssistantBrowser({
                   onClick={() => {
                     setSelectedTab("all");
                     setAssistantSearch("");
+                    setSelectedTags([tag.sId]);
                     setTimeout(() => {
                       const element = document.getElementById(
                         `anchor-${tag.sId}`


### PR DESCRIPTION
## Description

- https://github.com/dust-tt/tasks/issues/4398
- Can select a tag from the assistant browser search bar

### Note

Would be nice if "vanilla" models like GPT-x, Claude-x had all a default tag. Out of scope from this PR though.

## Tests

Locally

## Risk

Low

## Deploy Plan

Deploy front
