### PR TITLE
Delete modal autofucus

### DIFF
--- a/front/components/assistant/DeleteTagDialog.tsx
+++ b/front/components/assistant/DeleteTagDialog.tsx
@@ -46,6 +46,7 @@ export const DeleteTagDialog = ({
           rightButtonProps={{
             label: "Delete tag",
             variant: "warning",
+            autoFocus: true,
             onClick: onDeleteTag,
           }}
         />

--- a/front/components/assistant/conversation/DeleteConversationsDialog.tsx
+++ b/front/components/assistant/conversation/DeleteConversationsDialog.tsx
@@ -61,6 +61,7 @@ export const DeleteConversationsDialog = ({
               rightButtonProps={{
                 label: "Delete",
                 variant: "warning",
+                autoFocus: true,
                 onClick: async () => {
                   await onDelete();
                   onClose();

--- a/front/components/data_source/DocumentOrTableDeleteDialog.tsx
+++ b/front/components/data_source/DocumentOrTableDeleteDialog.tsx
@@ -134,6 +134,7 @@ export const DocumentOrTableDeleteDialog = ({
               rightButtonProps={{
                 label: "Delete",
                 variant: "warning",
+                autoFocus: true,
                 onClick: async () => {
                   void handleDelete();
                 },

--- a/front/components/triggers/DeleteWebhookSourceDialog.tsx
+++ b/front/components/triggers/DeleteWebhookSourceDialog.tsx
@@ -60,6 +60,7 @@ export function DeleteWebhookSourceDialog({
             label: "Remove",
             variant: "warning",
             disabled: isDeleting,
+            autoFocus: true,
             onClick: async () => {
               const success = await deleteWebhookSource(webhookSource.sId);
               if (success) {


### PR DESCRIPTION
## Description

- Add autofocus on delete button so that once the modal opens we can type "Enter" and it'll delete the item

## Tests

Locally

## Risk

Low

## Deploy Plan
 
Deploy front
