### PR TITLE
[front] Add horizontal padding to Agent Builder preview

### DIFF
--- a/front/components/agent_builder/AgentBuilderRightPanel.tsx
+++ b/front/components/agent_builder/AgentBuilderRightPanel.tsx
@@ -144,7 +144,7 @@ function ExpandedContent({
         />
       )}
       {selectedTab === "testing" && (
-        <div className="min-h-0 flex-1">
+        <div className="min-h-0 flex-1 px-1">
           <AgentBuilderPreview />
         </div>
       )}


### PR DESCRIPTION
## Description

This PR adds a small horizontal padding to the conversation in the preview of the agent builder.
It's much much more noticeable on a big screen with the entire page instead of a zoom in.

Before
<img width="686" height="742" alt="Screenshot 2025-09-25 at 2 59 07 PM" src="https://github.com/user-attachments/assets/aa74e6f9-2715-4c26-b201-fe76af6a3fdb" />

After
<img width="686" height="742" alt="Screenshot 2025-09-25 at 2 58 50 PM" src="https://github.com/user-attachments/assets/9a741708-ab74-4f82-bf01-ee5e1ee2d669" />

## Tests

- Checked locally.

## Risk

- Low.

## Deploy Plan

- Deploy front.
