### PR TITLE
[Agent Loop] Send abort signal to tools; allow run_agent cancellation

### DIFF
--- a/front/lib/actions/mcp_actions.ts
+++ b/front/lib/actions/mcp_actions.ts
@@ -36,7 +36,6 @@ import type {
   ToolNotificationEvent,
 } from "@app/lib/actions/mcp";
 import { MCPServerPersonalAuthenticationRequiredError } from "@app/lib/actions/mcp_authentication";
-import { MCPError } from "@app/lib/actions/mcp_errors";
 import { getServerTypeAndIdFromSId } from "@app/lib/actions/mcp_helper";
 import {
   getAvailabilityOfInternalMCPServerById,
@@ -89,9 +88,9 @@ import { generateRandomModelSId } from "@app/lib/resources/string_ids";
 import { concurrentExecutor } from "@app/lib/utils/async_utils";
 import { fromEvent } from "@app/lib/utils/events";
 import logger from "@app/logger/logger";
+import { TOOL_ACTIVITY_HEARTBEAT_TIMEOUT } from "@app/temporal/agent_loop/workflows";
 import type { ModelId, Result } from "@app/types";
 import { Err, normalizeError, Ok, slugify } from "@app/types";
-import { TOOL_ACTIVITY_HEARTBEAT_TIMEOUT } from "@app/temporal/agent_loop/workflows";
 
 const MAX_OUTPUT_ITEMS = 128;
 

--- a/front/lib/actions/mcp_internal_actions/servers/run_agent/index.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/run_agent/index.ts
@@ -405,12 +405,13 @@ export default async function createServer(
 
         if (isHandoff) {
           return finalizeAndReturn(
-	  	 new Ok(
-            makeMCPToolExit({
-              message: `Handoff from :mention[${mainAgent.name}]{sId=${mainAgent.sId}} to :mention[${childAgentBlob.name}]{sId=${childAgentId}} successfully launched.`,
-              isError: false,
-            }).content
-          ));
+            new Ok(
+              makeMCPToolExit({
+                message: `Handoff from :mention[${mainAgent.name}]{sId=${mainAgent.sId}} to :mention[${childAgentBlob.name}]{sId=${childAgentId}} successfully launched.`,
+                isError: false,
+              }).content
+            )
+          );
         }
 
         const { conversation, isNewConversation, userMessageId } =

--- a/front/lib/api/mcp/run_tool.ts
+++ b/front/lib/api/mcp/run_tool.ts
@@ -49,7 +49,8 @@ export async function* runToolWithStreaming(
     agentConfiguration: AgentConfigurationType;
     agentMessage: AgentMessageType;
     conversation: ConversationType;
-  }
+  },
+  options?: { signal?: AbortSignal }
 ): AsyncGenerator<
   | MCPApproveExecutionEvent
   | MCPErrorEvent
@@ -63,6 +64,8 @@ export async function* runToolWithStreaming(
   const owner = auth.getNonNullableWorkspace();
 
   const { toolConfiguration, status, augmentedInputs: inputs } = action;
+
+  const signal = options?.signal;
 
   const localLogger = logger.child({
     actionConfigurationId: toolConfiguration.sId,
@@ -99,6 +102,7 @@ export async function* runToolWithStreaming(
           conversation,
           agentMessage,
         }),
+      signal,
     }
   );
 

--- a/front/temporal/agent_loop/activities/run_tool.ts
+++ b/front/temporal/agent_loop/activities/run_tool.ts
@@ -1,3 +1,4 @@
+import { Context } from "@temporalio/activity";
 import assert from "assert";
 
 import { runToolWithStreaming } from "@app/lib/api/mcp/run_tool";
@@ -62,12 +63,20 @@ export async function runToolActivity(
   );
   assert(action, "Action not found");
 
-  const eventStream = runToolWithStreaming(auth, {
-    action,
-    agentConfiguration,
-    agentMessage,
-    conversation,
-  });
+  const abortSignal = Context.current().cancellationSignal;
+
+  const eventStream = runToolWithStreaming(
+    auth,
+    {
+      action,
+      agentConfiguration,
+      agentMessage,
+      conversation,
+    },
+    {
+      signal: abortSignal,
+    }
+  );
 
   for await (const event of eventStream) {
     switch (event.type) {

--- a/front/temporal/agent_loop/workflows.ts
+++ b/front/temporal/agent_loop/workflows.ts
@@ -28,6 +28,7 @@ import type {
 } from "@app/types/assistant/agent_run";
 
 const toolActivityStartToCloseTimeout = `${DEFAULT_MCP_REQUEST_TIMEOUT_MS / 1000 / 60 + 1} minutes`;
+export const TOOL_ACTIVITY_HEARTBEAT_TIMEOUT = 10_000; // 10 seconds.
 
 const { runModelAndCreateActionsActivity } = proxyActivities<
   typeof runModelAndCreateWrapperActivities
@@ -38,6 +39,7 @@ const { runModelAndCreateActionsActivity } = proxyActivities<
 const { runToolActivity } = proxyActivities<typeof runToolActivities>({
   // Activity timeout keeps a short buffer above the tool timeout to detect worker restarts promptly.
   startToCloseTimeout: toolActivityStartToCloseTimeout,
+  heartbeatTimeout: TOOL_ACTIVITY_HEARTBEAT_TIMEOUT,
   retry: {
     // Do not retry tool activities. Those are not idempotent.
     maximumAttempts: 1,
@@ -48,6 +50,7 @@ const { runToolActivity: runRetryableToolActivity } = proxyActivities<
   typeof runToolActivities
 >({
   startToCloseTimeout: toolActivityStartToCloseTimeout,
+  heartbeatTimeout: TOOL_ACTIVITY_HEARTBEAT_TIMEOUT,
   retry: {
     maximumAttempts: RETRY_ON_INTERRUPT_MAX_ATTEMPTS,
   },


### PR DESCRIPTION
## Description
Fixes https://github.com/dust-tt/tasks/issues/4433

This PR implements graceful cancellation for MCP tool execution when users stop an agent:

- Propagate the Temporal activity abort signal through run_tool → runToolWithStreaming → tryCallMCPTool
- Pass the abort signal to `mcpClient.callTool` so the MCP server can handle cancellation gracefully
- Use Temporal heartbeats to ensure responsive cancellation detection
- Cancel spawned run_agent conversations via cancelMessageGenerationEvent when the parent message stops
- Pass the abort signal to DustAPI streaming so child agent conversations terminate on cancellation

### Architectural Choice: Graceful Cancellation

The implementation prioritizes graceful cleanup over immediate responsiveness:
- When an abort signal fires, it's passed to the MCP tool which can perform cleanup operations
- We continue processing notifications while the tool handles cancellation (e.g., cleanup progress updates)
- The tool either completes gracefully or rejects with an abort error
- The timeout configuration protects against unresponsive tools
- This approach avoids inconsistent state that could occur from abruptly cutting the connection

### Key Implementation Details

**Heartbeat for Cancellation Detection:**
- Added Temporal heartbeat mechanism that fires every 5 seconds during tool execution
- Ensures the activity promptly detects cancellation even when waiting for notifications
- Prevents long delays in cancellation response when no notifications are being sent

**Fixed Agent Message Cancellation:**
- Corrected cancellation to target `agentMessage.sId` instead of `userMessageId`
- This properly cancels the agent's generation, not the user's message

**Removed Notification Flushing:**
- Removed the post-completion notification drain loop that could block indefinitely
- EventEmitter-based streams don't automatically complete, causing potential hangs
- Instead, rely on notification processing during the main loop
- More robust approach that avoids waiting for a completion signal that may never arrive

**Design Pattern: finalizeAndReturn**

In `run_agent/index.ts`, all return paths use `finalizeAndReturn` to ensure child conversation cancellation completes before returning:

```typescript
const finalizeAndReturn = async <T>(result: Result<T, MCPError>) => {
  await (childCancellationPromise ?? Promise.resolve());
  return result;
};
```

**Rationale:**
- Early returns (before child conversation setup) don't need this - `childCancellationPromise` is null
- But using it consistently on all return paths ensures correctness:
  - Prevents bugs if code is refactored and return semantics change
  - Makes the pattern explicit: "always wait for cleanup before returning"
  - Small overhead when not needed (`await Promise.resolve()` is fast)
  - Clearer and more maintainable than mixing direct returns with finalized returns

This is consistent with the cleanup patterns used elsewhere in the codebase.

## Risks
Blast radius: run_agent MCP executions triggered during agent loop tool runs
Risk: standard

## Deploy Plan
- deploy front