### PR TITLE
Center handles of side panel to align them

### DIFF
--- a/front/components/navigation/Navigation.tsx
+++ b/front/components/navigation/Navigation.tsx
@@ -128,8 +128,9 @@ export function Navigation({
           </div>
 
           <div
+            // center handle vertically (top at 50% + translate half the handle height)
             className={classNames(
-              "fixed z-40 hidden lg:top-1/2 lg:flex",
+              "fixed z-40 hidden lg:top-1/2 lg:flex lg:-translate-y-1/2",
               isNavigationBarOpen ? "lg:ml-80" : ""
             )}
           >


### PR DESCRIPTION
## Description

I have put left handle in the middle of the screen so it is aligned with the one of the right panel
The top is put at 50% of the screen then it is translated by half the handle to so the middle is at 50%

<img width="1390" height="1734" alt="image" src="https://github.com/user-attachments/assets/cc0f8ac2-a402-43dd-8bd3-ac2d5a0e6f6c" />


## Tests

manually tested, I have resized the window and it stays aligned

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

deploy front
