### PR TITLE
Make Agent Generated Description and Avatar retry on exit from instructions

### DIFF
--- a/front/components/agent_builder/AgentBuilderLeftPanel.tsx
+++ b/front/components/agent_builder/AgentBuilderLeftPanel.tsx
@@ -51,7 +51,9 @@ export function AgentBuilderLeftPanel({
             owner={owner}
             isTriggersLoading={isTriggersLoading}
           />
-          <AgentBuilderSettingsBlock />
+          <AgentBuilderSettingsBlock
+            agentConfigurationId={agentConfigurationId}
+          />
         </div>
       </ScrollArea>
       <BarFooter

--- a/front/components/agent_builder/instructions/AgentBuilderInstructionsEditor.tsx
+++ b/front/components/agent_builder/instructions/AgentBuilderInstructionsEditor.tsx
@@ -141,6 +141,11 @@ export function AgentBuilderInstructionsEditor({
           debouncedUpdate(editor);
         }
       },
+      onBlur: () => {
+        console.log("onBlur");
+        window.dispatchEvent(new CustomEvent("agent:instructions:blur"));
+        return false;
+      },
     },
     [extensions]
   );

--- a/front/components/agent_builder/instructions/AgentBuilderInstructionsEditor.tsx
+++ b/front/components/agent_builder/instructions/AgentBuilderInstructionsEditor.tsx
@@ -27,6 +27,8 @@ import type { LightAgentConfigurationType } from "@app/types";
 
 export const INSTRUCTIONS_MAXIMUM_CHARACTER_COUNT = 120_000;
 
+export const BLUR_EVENT_NAME = "agent:instructions:blur";
+
 const editorVariants = cva(
   [
     "overflow-auto border rounded-xl p-2 resize-y min-h-60 max-h-[1024px]",
@@ -142,7 +144,7 @@ export function AgentBuilderInstructionsEditor({
         }
       },
       onBlur: () => {
-        window.dispatchEvent(new CustomEvent("agent:instructions:blur"));
+        window.dispatchEvent(new CustomEvent(BLUR_EVENT_NAME));
         return false;
       },
     },

--- a/front/components/agent_builder/instructions/AgentBuilderInstructionsEditor.tsx
+++ b/front/components/agent_builder/instructions/AgentBuilderInstructionsEditor.tsx
@@ -142,7 +142,6 @@ export function AgentBuilderInstructionsEditor({
         }
       },
       onBlur: () => {
-        console.log("onBlur");
         window.dispatchEvent(new CustomEvent("agent:instructions:blur"));
         return false;
       },

--- a/front/components/agent_builder/settings/AgentBuilderSettingsBlock.tsx
+++ b/front/components/agent_builder/settings/AgentBuilderSettingsBlock.tsx
@@ -104,7 +104,6 @@ function AgentNameInput() {
     });
 
     if (result.isErr()) {
-      console.error("Failed to generate name suggestions:", result.error);
       sendNotification({
         type: "error",
         title: "Failed to generate name suggestions",
@@ -223,7 +222,6 @@ function AgentDescriptionInput() {
     });
 
     if (result.isErr()) {
-      console.error("Failed to generate description:", result.error);
       sendNotification({
         type: "error",
         title: "Failed to generate description",

--- a/front/public/swagger.json
+++ b/front/public/swagger.json
@@ -24,7 +24,9 @@
       "get": {
         "summary": "List agents",
         "description": "Get the agent configurations for the workspace identified by {wId}.",
-        "tags": ["Agents"],
+        "tags": [
+          "Agents"
+        ],
         "parameters": [
           {
             "in": "path",
@@ -59,7 +61,10 @@
             "description": "When set to 'true', includes recent authors information for each agent",
             "schema": {
               "type": "string",
-              "enum": ["true", "false"]
+              "enum": [
+                "true",
+                "false"
+              ]
             }
           }
         ],
@@ -110,7 +115,9 @@
       "get": {
         "summary": "Get agent configuration",
         "description": "Retrieve the agent configuration identified by {sId} in the workspace identified by {wId}.",
-        "tags": ["Agents"],
+        "tags": [
+          "Agents"
+        ],
         "parameters": [
           {
             "in": "path",
@@ -137,7 +144,10 @@
             "description": "Configuration variant to retrieve. 'light' returns basic config without actions, 'full' includes complete actions/tools configuration",
             "schema": {
               "type": "string",
-              "enum": ["light", "full"],
+              "enum": [
+                "light",
+                "full"
+              ],
               "default": "light"
             }
           }
@@ -183,7 +193,9 @@
       "patch": {
         "summary": "Update agent configuration",
         "description": "Update the agent configuration identified by {sId} in the workspace identified by {wId}.",
-        "tags": ["Agents"],
+        "tags": [
+          "Agents"
+        ],
         "parameters": [
           {
             "in": "path",
@@ -262,7 +274,9 @@
       "get": {
         "summary": "Search agents by name",
         "description": "Search for agent configurations by name in the workspace identified by {wId}.",
-        "tags": ["Agents"],
+        "tags": [
+          "Agents"
+        ],
         "parameters": [
           {
             "in": "path",
@@ -327,7 +341,9 @@
     },
     "/api/v1/w/{wId}/assistant/conversations/{cId}/cancel": {
       "post": {
-        "tags": ["Conversations"],
+        "tags": [
+          "Conversations"
+        ],
         "summary": "Cancel message generation in a conversation",
         "parameters": [
           {
@@ -360,7 +376,9 @@
             "application/json": {
               "schema": {
                 "type": "object",
-                "required": ["messageIds"],
+                "required": [
+                  "messageIds"
+                ],
                 "properties": {
                   "messageIds": {
                     "type": "array",
@@ -404,7 +422,9 @@
       "post": {
         "summary": "Create a content fragment",
         "description": "Create a new content fragment in the workspace identified by {wId}.",
-        "tags": ["Conversations"],
+        "tags": [
+          "Conversations"
+        ],
         "parameters": [
           {
             "in": "path",
@@ -467,7 +487,9 @@
       "get": {
         "summary": "Get the events for a conversation",
         "description": "Get the events for a conversation in the workspace identified by {wId}.",
-        "tags": ["Conversations"],
+        "tags": [
+          "Conversations"
+        ],
         "parameters": [
           {
             "in": "path",
@@ -528,7 +550,9 @@
       "get": {
         "summary": "Get feedbacks for a conversation",
         "description": "Retrieves all feedback entries for a specific conversation.\nRequires authentication and read:conversation scope.\n",
-        "tags": ["Feedbacks"],
+        "tags": [
+          "Feedbacks"
+        ],
         "parameters": [
           {
             "name": "wId",
@@ -581,7 +605,10 @@
                           },
                           "thumbDirection": {
                             "type": "string",
-                            "enum": ["up", "down"],
+                            "enum": [
+                              "up",
+                              "down"
+                            ],
                             "description": "Direction of the thumb feedback"
                           },
                           "content": {
@@ -635,7 +662,9 @@
       "get": {
         "summary": "Get a conversation",
         "description": "Get a conversation in the workspace identified by {wId}.",
-        "tags": ["Conversations"],
+        "tags": [
+          "Conversations"
+        ],
         "security": [
           {
             "BearerAuth": []
@@ -692,7 +721,9 @@
       "patch": {
         "summary": "Mark a conversation as read",
         "description": "Mark a conversation as read in the workspace identified by {wId}.",
-        "tags": ["Conversations"],
+        "tags": [
+          "Conversations"
+        ],
         "security": [
           {
             "BearerAuth": []
@@ -769,7 +800,9 @@
     },
     "/api/v1/w/{wId}/assistant/conversations/{cId}/messages/{mId}/edit": {
       "post": {
-        "tags": ["Conversations"],
+        "tags": [
+          "Conversations"
+        ],
         "summary": "Edit an existing message in a conversation",
         "parameters": [
           {
@@ -811,7 +844,10 @@
             "application/json": {
               "schema": {
                 "type": "object",
-                "required": ["content", "mentions"],
+                "required": [
+                  "content",
+                  "mentions"
+                ],
                 "properties": {
                   "content": {
                     "type": "string",
@@ -822,7 +858,9 @@
                     "description": "List of agent mentions in the message",
                     "items": {
                       "type": "object",
-                      "required": ["configurationId"],
+                      "required": [
+                        "configurationId"
+                      ],
                       "properties": {
                         "configurationId": {
                           "type": "string",
@@ -870,7 +908,9 @@
       "get": {
         "summary": "Get events for a message",
         "description": "Get events for a message in the workspace identified by {wId}.",
-        "tags": ["Conversations"],
+        "tags": [
+          "Conversations"
+        ],
         "parameters": [
           {
             "in": "path",
@@ -964,7 +1004,9 @@
       "post": {
         "summary": "Submit feedback for a specific message in a conversation",
         "description": "Submit user feedback (thumbs up/down) for a specific message in a conversation.\nRequires authentication and update:conversation scope.\n",
-        "tags": ["Feedbacks"],
+        "tags": [
+          "Feedbacks"
+        ],
         "parameters": [
           {
             "name": "wId",
@@ -1005,11 +1047,16 @@
             "application/json": {
               "schema": {
                 "type": "object",
-                "required": ["thumbDirection"],
+                "required": [
+                  "thumbDirection"
+                ],
                 "properties": {
                   "thumbDirection": {
                     "type": "string",
-                    "enum": ["up", "down"],
+                    "enum": [
+                      "up",
+                      "down"
+                    ],
                     "description": "Direction of the thumb feedback"
                   },
                   "feedbackContent": {
@@ -1055,7 +1102,9 @@
       "delete": {
         "summary": "Delete feedback for a specific message",
         "description": "Delete user feedback for a specific message in a conversation.\nRequires authentication and update:conversation scope.\n",
-        "tags": ["Feedbacks"],
+        "tags": [
+          "Feedbacks"
+        ],
         "parameters": [
           {
             "name": "wId",
@@ -1122,7 +1171,9 @@
       "post": {
         "summary": "Validate an action in a conversation message",
         "description": "Approves or rejects an action taken in a specific message in a conversation",
-        "tags": ["Conversations"],
+        "tags": [
+          "Conversations"
+        ],
         "parameters": [
           {
             "in": "path",
@@ -1158,7 +1209,10 @@
             "application/json": {
               "schema": {
                 "type": "object",
-                "required": ["actionId", "approved"],
+                "required": [
+                  "actionId",
+                  "approved"
+                ],
                 "properties": {
                   "actionId": {
                     "type": "string",
@@ -1213,7 +1267,9 @@
       "post": {
         "summary": "Create a message",
         "description": "Create a message in the workspace identified by {wId} in the conversation identified by {cId}.",
-        "tags": ["Conversations"],
+        "tags": [
+          "Conversations"
+        ],
         "parameters": [
           {
             "in": "path",
@@ -1279,7 +1335,9 @@
       "post": {
         "summary": "Create a new conversation",
         "description": "Create a new conversation in the workspace identified by {wId}.",
-        "tags": ["Conversations"],
+        "tags": [
+          "Conversations"
+        ],
         "parameters": [
           {
             "in": "path",
@@ -1302,7 +1360,9 @@
             "application/json": {
               "schema": {
                 "type": "object",
-                "required": ["message"],
+                "required": [
+                  "message"
+                ],
                 "properties": {
                   "message": {
                     "$ref": "#/components/schemas/Message"
@@ -1362,7 +1422,9 @@
     },
     "/api/v1/w/{wId}/files": {
       "post": {
-        "tags": ["Conversations"],
+        "tags": [
+          "Conversations"
+        ],
         "summary": "Create a file upload URL",
         "parameters": [
           {
@@ -1461,7 +1523,9 @@
       "post": {
         "summary": "Update heartbeat for a client-side MCP server",
         "description": "[Documentation](https://docs.dust.tt/docs/client-side-mcp-server)\nUpdate the heartbeat for a previously registered client-side MCP server.\nThis extends the TTL for the server registration.\n",
-        "tags": ["MCP"],
+        "tags": [
+          "MCP"
+        ],
         "security": [
           {
             "BearerAuth": []
@@ -1484,7 +1548,9 @@
             "application/json": {
               "schema": {
                 "type": "object",
-                "required": ["serverId"],
+                "required": [
+                  "serverId"
+                ],
                 "properties": {
                   "serverId": {
                     "type": "string",
@@ -1534,7 +1600,9 @@
       "post": {
         "summary": "Register a client-side MCP server",
         "description": "[Documentation](https://docs.dust.tt/docs/client-side-mcp-server)\nRegister a client-side MCP server to Dust.\nThe registration is scoped to the current user and workspace.\nA serverId identifier is generated and returned in the response.\n",
-        "tags": ["MCP"],
+        "tags": [
+          "MCP"
+        ],
         "security": [
           {
             "BearerAuth": []
@@ -1557,7 +1625,9 @@
             "application/json": {
               "schema": {
                 "type": "object",
-                "required": ["serverName"],
+                "required": [
+                  "serverName"
+                ],
                 "properties": {
                   "serverName": {
                     "type": "string",
@@ -1604,7 +1674,9 @@
       "get": {
         "summary": "Stream MCP tool requests for a workspace",
         "description": "[Documentation](https://docs.dust.tt/docs/client-side-mcp-server)\nServer-Sent Events (SSE) endpoint that streams MCP tool requests for a workspace.\nThis endpoint is used by client-side MCP servers to listen for tool requests in real-time.\nThe connection will remain open and events will be sent as new tool requests are made.\n",
-        "tags": ["MCP"],
+        "tags": [
+          "MCP"
+        ],
         "security": [
           {
             "BearerAuth": []
@@ -1679,7 +1751,9 @@
       "post": {
         "summary": "Submit MCP tool execution results",
         "description": "[Documentation](https://docs.dust.tt/docs/client-side-mcp-server)\nEndpoint for client-side MCP servers to submit the results of tool executions.\nThis endpoint accepts the output from tools that were executed locally.\n",
-        "tags": ["MCP"],
+        "tags": [
+          "MCP"
+        ],
         "security": [
           {
             "BearerAuth": []
@@ -1702,7 +1776,10 @@
             "application/json": {
               "schema": {
                 "type": "object",
-                "required": ["result", "serverId"],
+                "required": [
+                  "result",
+                  "serverId"
+                ],
                 "properties": {
                   "result": {
                     "type": "object",
@@ -1743,7 +1820,9 @@
       "post": {
         "summary": "Search for nodes in the workspace",
         "description": "Search for nodes in the workspace",
-        "tags": ["Search"],
+        "tags": [
+          "Search"
+        ],
         "parameters": [
           {
             "in": "path",
@@ -1766,7 +1845,9 @@
             "application/json": {
               "schema": {
                 "type": "object",
-                "required": ["query"],
+                "required": [
+                  "query"
+                ],
                 "properties": {
                   "query": {
                     "type": "string",
@@ -1826,7 +1907,9 @@
       "get": {
         "summary": "Get an app run",
         "description": "Retrieve a run for an app in the space identified by {spaceId}.",
-        "tags": ["Apps"],
+        "tags": [
+          "Apps"
+        ],
         "security": [
           {
             "BearerAuth": []
@@ -1899,7 +1982,9 @@
       "post": {
         "summary": "Create an app run",
         "description": "Create and execute a run for an app in the space specified by {spaceId}.",
-        "tags": ["Apps"],
+        "tags": [
+          "Apps"
+        ],
         "security": [
           {
             "BearerAuth": []
@@ -1940,7 +2025,11 @@
             "application/json": {
               "schema": {
                 "type": "object",
-                "required": ["specification_hash", "config", "inputs"],
+                "required": [
+                  "specification_hash",
+                  "config",
+                  "inputs"
+                ],
                 "properties": {
                   "specification_hash": {
                     "type": "string",
@@ -2040,7 +2129,9 @@
       "get": {
         "summary": "List apps",
         "description": "Get all apps in the space identified by {spaceId}.",
-        "tags": ["Apps"],
+        "tags": [
+          "Apps"
+        ],
         "security": [
           {
             "BearerAuth": []
@@ -2139,7 +2230,9 @@
     },
     "/api/v1/w/{wId}/spaces/{spaceId}/data_source_views/{dsvId}": {
       "get": {
-        "tags": ["DatasourceViews"],
+        "tags": [
+          "DatasourceViews"
+        ],
         "security": [
           {
             "BearerAuth": []
@@ -2192,7 +2285,9 @@
         }
       },
       "patch": {
-        "tags": ["DatasourceViews"],
+        "tags": [
+          "DatasourceViews"
+        ],
         "security": [
           {
             "BearerAuth": []
@@ -2242,7 +2337,9 @@
                         }
                       }
                     },
-                    "required": ["parentsIn"]
+                    "required": [
+                      "parentsIn"
+                    ]
                   },
                   {
                     "type": "object",
@@ -2295,7 +2392,9 @@
         }
       },
       "delete": {
-        "tags": ["DatasourceViews"],
+        "tags": [
+          "DatasourceViews"
+        ],
         "security": [
           {
             "BearerAuth": []
@@ -2351,7 +2450,9 @@
       "get": {
         "summary": "Search the data source view",
         "description": "Search the data source view identified by {dsvId} in the workspace identified by {wId}.",
-        "tags": ["DatasourceViews"],
+        "tags": [
+          "DatasourceViews"
+        ],
         "security": [
           {
             "BearerAuth": []
@@ -2548,7 +2649,9 @@
       "get": {
         "summary": "List Data Source Views",
         "description": "Retrieves a list of data source views for the specified space",
-        "tags": ["DatasourceViews"],
+        "tags": [
+          "DatasourceViews"
+        ],
         "security": [
           {
             "BearerAuth": []
@@ -2615,7 +2718,9 @@
       "get": {
         "summary": "Retrieve a document from a data source",
         "description": "Retrieve a document from a data source identified by {dsId} in the workspace identified by {wId}.",
-        "tags": ["Datasources"],
+        "tags": [
+          "Datasources"
+        ],
         "parameters": [
           {
             "in": "path",
@@ -2695,7 +2800,9 @@
       "post": {
         "summary": "Upsert a document in a data source",
         "description": "Upsert a document in a data source in the workspace identified by {wId}.",
-        "tags": ["Datasources"],
+        "tags": [
+          "Datasources"
+        ],
         "parameters": [
           {
             "in": "path",
@@ -2838,7 +2945,9 @@
       "delete": {
         "summary": "Delete a document from a data source",
         "description": "Delete a document from a data source in the workspace identified by {wId}.",
-        "tags": ["Datasources"],
+        "tags": [
+          "Datasources"
+        ],
         "parameters": [
           {
             "in": "path",
@@ -2925,7 +3034,9 @@
       "post": {
         "summary": "Update the parents of a document",
         "description": "Update the parents of a document in the data source identified by {dsId} in the workspace identified by {wId}.",
-        "tags": ["Datasources"],
+        "tags": [
+          "Datasources"
+        ],
         "parameters": [
           {
             "in": "path",
@@ -3018,7 +3129,9 @@
       "get": {
         "summary": "Get documents",
         "description": "Get documents in the data source identified by {dsId} in the workspace identified by {wId}.",
-        "tags": ["Datasources"],
+        "tags": [
+          "Datasources"
+        ],
         "security": [
           {
             "BearerAuth": []
@@ -3115,7 +3228,9 @@
       "get": {
         "summary": "Search the data source",
         "description": "Search the data source identified by {dsId} in the workspace identified by {wId}.",
-        "tags": ["Datasources"],
+        "tags": [
+          "Datasources"
+        ],
         "security": [
           {
             "BearerAuth": []
@@ -3312,7 +3427,9 @@
       "get": {
         "summary": "Get a table",
         "description": "Get a table in the data source identified by {dsId} in the workspace identified by {wId}.",
-        "tags": ["Datasources"],
+        "tags": [
+          "Datasources"
+        ],
         "security": [
           {
             "BearerAuth": []
@@ -3378,7 +3495,9 @@
       "delete": {
         "summary": "Delete a table",
         "description": "Delete a table in the data source identified by {dsId} in the workspace identified by {wId}.",
-        "tags": ["Datasources"],
+        "tags": [
+          "Datasources"
+        ],
         "security": [
           {
             "BearerAuth": []
@@ -3439,7 +3558,9 @@
       "get": {
         "summary": "Get a row",
         "description": "Get a row in the table identified by {tId} in the data source identified by {dsId} in the workspace identified by {wId}.",
-        "tags": ["Datasources"],
+        "tags": [
+          "Datasources"
+        ],
         "security": [
           {
             "BearerAuth": []
@@ -3514,7 +3635,9 @@
       "delete": {
         "summary": "Delete a row",
         "description": "Delete a row in the table identified by {tId} in the data source identified by {dsId} in the workspace identified by {wId}.",
-        "tags": ["Datasources"],
+        "tags": [
+          "Datasources"
+        ],
         "security": [
           {
             "BearerAuth": []
@@ -3584,7 +3707,9 @@
       "get": {
         "summary": "List rows",
         "description": "List rows in the table identified by {tId} in the data source identified by {dsId} in the workspace identified by {wId}.",
-        "tags": ["Datasources"],
+        "tags": [
+          "Datasources"
+        ],
         "security": [
           {
             "BearerAuth": []
@@ -3666,7 +3791,9 @@
       "post": {
         "summary": "Upsert rows",
         "description": "Upsert rows in the table identified by {tId} in the data source identified by {dsId} in the workspace identified by {wId}.",
-        "tags": ["Datasources"],
+        "tags": [
+          "Datasources"
+        ],
         "security": [
           {
             "BearerAuth": []
@@ -3744,7 +3871,9 @@
                                 "properties": {
                                   "type": {
                                     "type": "string",
-                                    "enum": ["datetime"]
+                                    "enum": [
+                                      "datetime"
+                                    ]
                                   },
                                   "epoch": {
                                     "type": "number"
@@ -3799,7 +3928,9 @@
       "get": {
         "summary": "Get tables",
         "description": "Get tables in the data source identified by {dsId} in the workspace identified by {wId}.",
-        "tags": ["Datasources"],
+        "tags": [
+          "Datasources"
+        ],
         "security": [
           {
             "BearerAuth": []
@@ -3856,7 +3987,9 @@
       "post": {
         "summary": "Upsert a table",
         "description": "Upsert a table in the data source identified by {dsId} in the workspace identified by {wId}.",
-        "tags": ["Datasources"],
+        "tags": [
+          "Datasources"
+        ],
         "security": [
           {
             "BearerAuth": []
@@ -3958,7 +4091,9 @@
       "get": {
         "summary": "Get data sources",
         "description": "Get data sources in the workspace identified by {wId}.",
-        "tags": ["Datasources"],
+        "tags": [
+          "Datasources"
+        ],
         "parameters": [
           {
             "in": "path",
@@ -4016,7 +4151,9 @@
       "get": {
         "summary": "List available MCP server views.",
         "description": "Retrieves a list of enabled MCP server views (aka tools) for a specific space of the authenticated workspace.",
-        "tags": ["Tools"],
+        "tags": [
+          "Tools"
+        ],
         "security": [
           {
             "BearerAuth": []
@@ -4083,7 +4220,9 @@
       "get": {
         "summary": "List available spaces.",
         "description": "Retrieves a list of accessible spaces for the authenticated workspace.",
-        "tags": ["Spaces"],
+        "tags": [
+          "Spaces"
+        ],
         "security": [
           {
             "BearerAuth": []
@@ -4141,7 +4280,9 @@
       "post": {
         "summary": "Receive external webhook to trigger flows",
         "description": "Skeleton endpoint that verifies workspace and webhook source and logs receipt.",
-        "tags": ["Triggers"],
+        "tags": [
+          "Triggers"
+        ],
         "security": [
           {
             "BearerAuth": []
@@ -4197,7 +4338,9 @@
       "get": {
         "summary": "Get workspace usage data",
         "description": "Get usage data for the workspace identified by {wId} in CSV or JSON format.",
-        "tags": ["Workspace"],
+        "tags": [
+          "Workspace"
+        ],
         "security": [
           {
             "BearerAuth": []
@@ -4238,7 +4381,10 @@
             "description": "The mode of date range selection",
             "schema": {
               "type": "string",
-              "enum": ["month", "range"]
+              "enum": [
+                "month",
+                "range"
+              ]
             }
           },
           {
@@ -4248,7 +4394,10 @@
             "description": "The output format of the data (defaults to 'csv')",
             "schema": {
               "type": "string",
-              "enum": ["csv", "json"]
+              "enum": [
+                "csv",
+                "json"
+              ]
             }
           },
           {
@@ -4420,7 +4569,10 @@
               "type": "string",
               "description": "Feature flags enabled for the workspace"
             },
-            "example": ["advanced_analytics", "beta_features"]
+            "example": [
+              "advanced_analytics",
+              "beta_features"
+            ]
           },
           "ssoEnforced": {
             "type": "boolean",
@@ -4432,7 +4584,10 @@
               "type": "string",
               "description": "List of allowed authentication providers"
             },
-            "example": ["google", "github"]
+            "example": [
+              "google",
+              "github"
+            ]
           },
           "defaultEmbeddingProvider": {
             "type": "string",
@@ -4444,7 +4599,10 @@
       },
       "Context": {
         "type": "object",
-        "required": ["username", "timezone"],
+        "required": [
+          "username",
+          "timezone"
+        ],
         "properties": {
           "username": {
             "type": "string",
@@ -4741,7 +4899,10 @@
       },
       "Message": {
         "type": "object",
-        "required": ["content", "mentions"],
+        "required": [
+          "content",
+          "mentions"
+        ],
         "properties": {
           "content": {
             "type": "string",
@@ -4762,7 +4923,9 @@
       },
       "ContentFragment": {
         "type": "object",
-        "required": ["title"],
+        "required": [
+          "title"
+        ],
         "properties": {
           "title": {
             "type": "string",
@@ -4817,7 +4980,12 @@
           },
           "kind": {
             "type": "string",
-            "enum": ["regular", "global", "system", "public"],
+            "enum": [
+              "regular",
+              "global",
+              "system",
+              "public"
+            ],
             "description": "The kind of the space"
           },
           "groupIds": {
@@ -4917,7 +5085,13 @@
                 "value_type": {
                   "type": "string",
                   "description": "Data type of the column",
-                  "enum": ["text", "int", "float", "bool", "date"],
+                  "enum": [
+                    "text",
+                    "int",
+                    "float",
+                    "bool",
+                    "date"
+                  ],
                   "example": "int"
                 },
                 "possible_values": {
@@ -4927,7 +5101,11 @@
                     "type": "string"
                   },
                   "nullable": true,
-                  "example": ["1", "2", "3"]
+                  "example": [
+                    "1",
+                    "2",
+                    "3"
+                  ]
                 }
               }
             }
@@ -4958,7 +5136,9 @@
             "items": {
               "type": "string"
             },
-            "example": ["1234f4567c"]
+            "example": [
+              "1234f4567c"
+            ]
           }
         }
       },
@@ -4967,7 +5147,12 @@
         "properties": {
           "category": {
             "type": "string",
-            "enum": ["managed", "folder", "website", "apps"],
+            "enum": [
+              "managed",
+              "folder",
+              "website",
+              "apps"
+            ],
             "description": "The category of the data source view"
           },
           "createdAt": {
@@ -4997,7 +5182,10 @@
           },
           "kind": {
             "type": "string",
-            "enum": ["default", "custom"],
+            "enum": [
+              "default",
+              "custom"
+            ],
             "description": "The kind of the data source view"
           },
           "parentsIn": {
@@ -5117,7 +5305,10 @@
             "items": {
               "type": "string"
             },
-            "example": ["customer_support", "faq"]
+            "example": [
+              "customer_support",
+              "faq"
+            ]
           },
           "parent_id": {
             "type": "string",
@@ -5132,7 +5323,10 @@
             "items": {
               "type": "string"
             },
-            "example": ["7b9d1f3e5a", "2c4a6e8d0f"]
+            "example": [
+              "7b9d1f3e5a",
+              "2c4a6e8d0f"
+            ]
           },
           "source_url": {
             "type": "string",
@@ -5160,12 +5354,22 @@
               {
                 "chunk_id": "9f1d3b5a7c",
                 "text": "This is the first chunk of the document.",
-                "embedding": [0.1, 0.2, 0.3, 0.4]
+                "embedding": [
+                  0.1,
+                  0.2,
+                  0.3,
+                  0.4
+                ]
               },
               {
                 "chunk_id": "4a2c6e8b0d",
                 "text": "This is the second chunk of the document.",
-                "embedding": [0.5, 0.6, 0.7, 0.8]
+                "embedding": [
+                  0.5,
+                  0.6,
+                  0.7,
+                  0.8
+                ]
               }
             ]
           },
@@ -5222,7 +5426,10 @@
           },
           "serverType": {
             "type": "string",
-            "enum": ["remote", "internal"],
+            "enum": [
+              "remote",
+              "internal"
+            ],
             "description": "Type of the MCP server",
             "example": "remote"
           },
@@ -5267,10 +5474,15 @@
                     "type": "array",
                     "items": {
                       "type": "string",
-                      "enum": ["platform_actions", "personal_actions"]
+                      "enum": [
+                        "platform_actions",
+                        "personal_actions"
+                      ]
                     },
                     "description": "Supported use cases for the authorization",
-                    "example": ["platform_actions"]
+                    "example": [
+                      "platform_actions"
+                    ]
                   },
                   "scope": {
                     "type": "string",
@@ -5330,7 +5542,10 @@
           "oAuthUseCase": {
             "type": "string",
             "nullable": true,
-            "enum": ["platform_actions", "personal_actions"],
+            "enum": [
+              "platform_actions",
+              "personal_actions"
+            ],
             "description": "OAuth use case for the MCP server view",
             "example": "platform_actions"
           },


### PR DESCRIPTION
## Description

(cf. https://github.com/dust-tt/tasks/issues/4383)

The original proposal was to do this when the cursor leaves the "instructions". I did not find a way to do this with simple cursor motions but I was able to do this when focus is lost, e.g. clicking outside of it, which will happen when adding knowledge, tools, or many other instances.

This fixes generation of a description which often has too little to go by in the instructions.

## Tests

Ran locally with 2 alternating prompts to see if the description changed.

## Risk

None.

## Deploy Plan

Deploy front.