### PR TITLE
[front] Uniformize icon for `Manage Agents` pages

### DIFF
--- a/front/components/assistant/conversation/SidebarMenu.tsx
+++ b/front/components/assistant/conversation/SidebarMenu.tsx
@@ -2,6 +2,7 @@ import {
   Button,
   ChatBubbleBottomCenterTextIcon,
   Checkbox,
+  ContactsRobotIcon,
   DocumentIcon,
   DotIcon,
   DropdownMenu,
@@ -20,7 +21,6 @@ import {
   NavigationListItem,
   NavigationListItemAction,
   NavigationListLabel,
-  RobotIcon,
   SearchInput,
   Spinner,
   TrashIcon,
@@ -388,7 +388,7 @@ export function AssistantSidebarMenu({ owner }: AssistantSidebarMenuProps) {
                     {isBuilder(owner) && (
                       <DropdownMenuItem
                         href={getAgentBuilderRoute(owner.sId, "manage")}
-                        icon={RobotIcon}
+                        icon={ContactsRobotIcon}
                         label="Manage agents"
                         data-gtm-label="assistantManagementButton"
                         data-gtm-location="sidebarMenu"

--- a/front/pages/w/[wId]/builder/agents/index.tsx
+++ b/front/pages/w/[wId]/builder/agents/index.tsx
@@ -6,7 +6,6 @@ import {
   MagnifyingGlassIcon,
   Page,
   PlusIcon,
-  RobotIcon,
   SearchInput,
   Spinner,
   Tabs,

--- a/front/pages/w/[wId]/builder/agents/index.tsx
+++ b/front/pages/w/[wId]/builder/agents/index.tsx
@@ -1,6 +1,7 @@
 import {
   Button,
   Chip,
+  ContactsRobotIcon,
   ListSelectIcon,
   MagnifyingGlassIcon,
   Page,
@@ -309,7 +310,7 @@ export default function WorkspaceAssistants({
           onClose={() => setShowDetails(null)}
         />
         <div className="flex w-full flex-col gap-8 pt-2 lg:pt-8">
-          <Page.Header title="Manage Agents" icon={RobotIcon} />
+          <Page.Header title="Manage Agents" icon={ContactsRobotIcon} />
           <Page.Vertical gap="md" align="stretch">
             <div className="flex flex-row gap-2">
               <SearchInput


### PR DESCRIPTION
## Description

- Follow up on https://github.com/dust-tt/dust/pull/16294.
- This PR uniformizes the choice of icon for `Manage Agents` pages.

<img width="686" height="465" alt="Screenshot 2025-09-25 at 3 50 23 PM" src="https://github.com/user-attachments/assets/6a9bb539-eaa0-4ddc-a87c-71fc37481016" />

## Tests

- Checked locally.

## Risk

- Low.

## Deploy Plan

- Deploy front.
