### PR TITLE
[PQ] Redundant select all button in slack channels selection

### DIFF
--- a/front/components/ContentNodeTree.tsx
+++ b/front/components/ContentNodeTree.tsx
@@ -203,8 +203,7 @@ function ContentNodeTreeChildren({
       {!isResourcesLoading &&
         filteredNodes &&
         filteredNodes.length === 0 &&
-        // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
-        (emptyComponent || <Tree.Empty label="No documents" />)}
+        (emptyComponent ?? <Tree.Empty label="No documents" />)}
 
       {filteredNodes.map((n, i) => {
         const checkedState = getCheckedState(n);

--- a/front/components/ContentNodeTree.tsx
+++ b/front/components/ContentNodeTree.tsx
@@ -334,30 +334,28 @@ function ContentNodeTreeChildren({
               />
             </div>
 
-            {filter.trim().length > 0 && (
-              <Button
-                icon={ListCheckIcon}
-                label={selectAllClicked ? "Unselect All" : "Select All"}
-                size="sm"
-                className="m-1"
-                variant="ghost"
-                onClick={() => {
-                  const isSelected = !selectAllClicked;
-                  setSelectAllClicked(isSelected);
-                  setSelectedNodes((prev) => {
-                    const newState = { ...prev };
-                    filteredNodes.forEach((n) => {
-                      newState[n.internalId] = {
-                        isSelected,
-                        node: n,
-                        parents: isSelected ? parentIds : [],
-                      };
-                    });
-                    return newState;
+            <Button
+              icon={ListCheckIcon}
+              label={selectAllClicked ? "Unselect All" : "Select All"}
+              size="sm"
+              className="m-1"
+              variant="ghost"
+              onClick={() => {
+                const isSelected = !selectAllClicked;
+                setSelectAllClicked(isSelected);
+                setSelectedNodes((prev) => {
+                  const newState = { ...prev };
+                  filteredNodes.forEach((n) => {
+                    newState[n.internalId] = {
+                      isSelected,
+                      node: n,
+                      parents: isSelected ? parentIds : [],
+                    };
                   });
-                }}
-              />
-            )}
+                  return newState;
+                });
+              }}
+            />
           </div>
         </>
       )}

--- a/front/components/ContentNodeTree.tsx
+++ b/front/components/ContentNodeTree.tsx
@@ -340,6 +340,7 @@ function ContentNodeTreeChildren({
               size="sm"
               className="m-1"
               variant="ghost"
+              disabled={filteredNodes.length === 0}
               onClick={() => {
                 const isSelected = !selectAllClicked;
                 setSelectAllClicked(isSelected);

--- a/front/components/data_source/ConnectorPermissionsModal.tsx
+++ b/front/components/data_source/ConnectorPermissionsModal.tsx
@@ -883,7 +883,8 @@ export function ConnectorPermissionsModal({
                       </div>
                       <ContentNodeTree
                         isTitleFilterEnabled={
-                          connectorConfiguration.isTitleFilterEnabled
+                          connectorConfiguration.isTitleFilterEnabled &&
+                          canUpdatePermissions
                         }
                         isRoundedBackground={true}
                         useResourcesHook={useResourcesHook}

--- a/front/components/data_source/ConnectorPermissionsModal.tsx
+++ b/front/components/data_source/ConnectorPermissionsModal.tsx
@@ -13,7 +13,6 @@ import {
   DialogTrigger,
   Hoverable,
   Icon,
-  ListCheckIcon,
   LockIcon,
   Page,
   Sheet,
@@ -605,7 +604,6 @@ export function ConnectorPermissionsModal({
     [owner, dataSource]
   );
 
-  const { resources: treeResources } = useResourcesHook(null);
   const { resources: allSelectedResources, isResourcesLoading } =
     useConnectorPermissions({
       owner,
@@ -627,27 +625,6 @@ export function ConnectorPermissionsModal({
     }
     return node.parentInternalIds ?? [];
   };
-
-  // Helper function to toggle all resource selections
-  const toggleAllResources = () => {
-    const newSelectedState = !isAllSelected;
-    const updates = Object.fromEntries(
-      treeResources.map((resource) => [
-        resource.internalId,
-        { isSelected: newSelectedState, node: resource, parents: [] },
-      ])
-    );
-    setSelectedNodes((prev) => ({ ...prev, ...updates }));
-  };
-
-  const isAllSelected = useMemo(
-    () =>
-      treeResources.length > 0 &&
-      treeResources.every(
-        (resource) => selectedNodes[resource.internalId]?.isSelected === true
-      ),
-    [treeResources, selectedNodes]
-  );
 
   const initialTreeSelectionModel = useMemo(
     () =>
@@ -903,20 +880,6 @@ export function ConnectorPermissionsModal({
                         <div className="heading-xl">
                           {connectorConfiguration.selectLabel}
                         </div>
-                        {canUpdatePermissions &&
-                          !isResourcesLoading &&
-                          treeResources.length > 0 && (
-                            <Button
-                              variant="ghost"
-                              size="sm"
-                              className="text-xs"
-                              label={
-                                isAllSelected ? "Unselect All" : "Select All"
-                              }
-                              icon={ListCheckIcon}
-                              onClick={toggleAllResources}
-                            />
-                          )}
                       </div>
                       <ContentNodeTree
                         isTitleFilterEnabled={


### PR DESCRIPTION
## Description

This PR addresses the following product-quality task : 
https://github.com/dust-tt/tasks/issues/4385

Fix :
- Remove top "select-all" button whose role was to select all channels (regardless of filter)
- Always display "select-all" button in ContentNodeTree (vs. before: when filter was not empty)

https://github.com/user-attachments/assets/4b13f5f9-85de-4c32-86e0-ca9370b063b5

## Tests

Tested manually

## Risk

ContentNodeTree is used in many places in the codebase. However, the filter / search bar is only displayed when `isTitleFilterEnabled` props is true. Only Slack and Slack (bot) connectors pass this props as true and I could not find such NodeTree for Slack (bot) in the codebase but I might be missing some context here...

## Deploy Plan

front
