### PR TITLE
Refactor Optionals in Tool Configurations

### DIFF
--- a/front/components/agent_builder/MCPServerViewsContext.tsx
+++ b/front/components/agent_builder/MCPServerViewsContext.tsx
@@ -107,10 +107,9 @@ function getGroupedMCPServerViews({
 
       const isWithKnowledge =
         !isContentCreationServer &&
-        (toolsConfigurations.dataSourceConfiguration ??
-          toolsConfigurations.dataWarehouseConfiguration ??
-          toolsConfigurations.tableConfiguration ??
-          false);
+        (toolsConfigurations.dataSourceConfigurable !== "no" ||
+          toolsConfigurations.dataWarehouseConfigurable !== "no" ||
+          toolsConfigurations.tableConfigurable !== "no");
 
       return isWithKnowledge
         ? "mcpServerViewsWithKnowledge"

--- a/front/components/agent_builder/capabilities/knowledge/KnowledgeConfigurationSheet.tsx
+++ b/front/components/agent_builder/capabilities/knowledge/KnowledgeConfigurationSheet.tsx
@@ -389,11 +389,11 @@ function KnowledgeConfigurationSheetContent({
             triggerValidationOnChange={true}
           />
 
-          {toolsConfigurations.mayRequireTimeFrameConfiguration && (
+          {toolsConfigurations.timeFrameConfigurable !== "no" && (
             <TimeFrameSection actionType="extract" />
           )}
 
-          {toolsConfigurations.mayRequireJsonSchemaConfiguration && (
+          {toolsConfigurations.jsonSchemaConfigurable !== "no" && (
             <JsonSchemaSection getAgentInstructions={getAgentInstructions} />
           )}
 

--- a/front/components/agent_builder/capabilities/knowledge/KnowledgeConfigurationSheet.tsx
+++ b/front/components/agent_builder/capabilities/knowledge/KnowledgeConfigurationSheet.tsx
@@ -162,9 +162,8 @@ function KnowledgeConfigurationSheetForm({
     );
 
     const datasource =
-      toolsConfigurations.dataSourceConfiguration ??
-      toolsConfigurations.dataWarehouseConfiguration ??
-      false
+      toolsConfigurations.dataSourceConfigurable !== "no" ||
+      toolsConfigurations.dataWarehouseConfigurable !== "no"
         ? { dataSourceConfigurations: dataSourceConfigurations }
         : { tablesConfigurations: dataSourceConfigurations };
 
@@ -357,10 +356,10 @@ function KnowledgeConfigurationSheetContent({
   const pages: MultiPageSheetPage[] = [
     {
       id: CONFIGURATION_SHEET_PAGE_IDS.DATA_SOURCE_SELECTION,
-      title: toolsConfigurations.tableConfiguration
+      title: toolsConfigurations.tableConfigurable !== "no"
         ? "Select Tables"
         : "Select Data Sources",
-      description: toolsConfigurations.tableConfiguration
+      description: toolsConfigurations.tableConfigurable !== "no"
         ? "Choose the tables to query for your processing method"
         : "Choose the data sources to include in your knowledge base",
       icon: undefined,

--- a/front/components/agent_builder/capabilities/mcp/MCPServerViewsSheet.tsx
+++ b/front/components/agent_builder/capabilities/mcp/MCPServerViewsSheet.tsx
@@ -636,19 +636,19 @@ export function MCPServerViewsSheet({
                   <ChildAgentSection />
                 )}
 
-                {toolsConfigurations.mayRequireTimeFrameConfiguration && (
+                {toolsConfigurations.timeFrameConfigurable !== "no" && (
                   <TimeFrameSection actionType="search" />
                 )}
 
-                {toolsConfigurations.mayRequireDustAppConfiguration && (
+                {toolsConfigurations.dustAppConfigurable !== "no" && (
                   <DustAppSection />
                 )}
 
-                {toolsConfigurations.mayRequireSecretConfiguration && (
+                {toolsConfigurations.secretConfigurable !== "no" && (
                   <SecretSection />
                 )}
 
-                {toolsConfigurations.mayRequireJsonSchemaConfiguration && (
+                {toolsConfigurations.jsonSchemaConfigurable !== "no" && (
                   <JsonSchemaSection
                     getAgentInstructions={getAgentInstructions}
                   />

--- a/front/components/agent_builder/capabilities/mcp/MCPServerViewsSheet.tsx
+++ b/front/components/agent_builder/capabilities/mcp/MCPServerViewsSheet.tsx
@@ -632,7 +632,7 @@ export function MCPServerViewsSheet({
                   <ReasoningModelSection />
                 )}
 
-                {toolsConfigurations.childAgentConfiguration && (
+                {toolsConfigurations.childAgentConfigurable !== "no" && (
                   <ChildAgentSection />
                 )}
 

--- a/front/components/agent_builder/capabilities/mcp/utils/formDefaults.test.ts
+++ b/front/components/agent_builder/capabilities/mcp/utils/formDefaults.test.ts
@@ -87,15 +87,19 @@ describe("getDefaultConfiguration", () => {
 
     it("should use mcpServerView sId as mcpServerViewId", () => {
       mockGetMCPServerToolsConfigurations.mockReturnValue({
-        mayRequireTimeFrameConfiguration: false,
-        mayRequireJsonSchemaConfiguration: false,
+        dataSourceConfigurable: "no",
+        dataWarehouseConfigurable: "no",
+        tableConfigurable: "no",
+        timeFrameConfigurable: "no",
+        jsonSchemaConfigurable: "no",
+        dustAppConfigurable: "no",
+        secretConfigurable: "no",
+        childAgentConfigurable: "no",
         stringConfigurations: [],
         numberConfigurations: [],
         booleanConfigurations: [],
         enumConfigurations: {},
         listConfigurations: {},
-        mayRequireDustAppConfiguration: false,
-        mayRequireSecretConfiguration: false,
         configurable: "optional",
       });
 
@@ -107,8 +111,14 @@ describe("getDefaultConfiguration", () => {
     describe("boolean configurations", () => {
       it("should set boolean configurations to false by default", () => {
         mockGetMCPServerToolsConfigurations.mockReturnValue({
-          mayRequireTimeFrameConfiguration: false,
-          mayRequireJsonSchemaConfiguration: false,
+          dataSourceConfigurable: "no",
+          dataWarehouseConfigurable: "no",
+          tableConfigurable: "no",
+          timeFrameConfigurable: "no",
+          jsonSchemaConfigurable: "no",
+          dustAppConfigurable: "no",
+          secretConfigurable: "no",
+          childAgentConfigurable: "no",
           stringConfigurations: [],
           numberConfigurations: [],
           booleanConfigurations: [
@@ -121,8 +131,6 @@ describe("getDefaultConfiguration", () => {
           ],
           enumConfigurations: {},
           listConfigurations: {},
-          mayRequireDustAppConfiguration: false,
-          mayRequireSecretConfiguration: false,
           configurable: "optional",
         });
 
@@ -141,8 +149,14 @@ describe("getDefaultConfiguration", () => {
 
       it("should use explicit boolean defaults when available", () => {
         mockGetMCPServerToolsConfigurations.mockReturnValue({
-          mayRequireTimeFrameConfiguration: false,
-          mayRequireJsonSchemaConfiguration: false,
+          dataSourceConfigurable: "no",
+          dataWarehouseConfigurable: "no",
+          tableConfigurable: "no",
+          timeFrameConfigurable: "no",
+          jsonSchemaConfigurable: "no",
+          dustAppConfigurable: "no",
+          secretConfigurable: "no",
+          childAgentConfigurable: "no",
           stringConfigurations: [],
           numberConfigurations: [],
           booleanConfigurations: [
@@ -156,8 +170,6 @@ describe("getDefaultConfiguration", () => {
           ],
           enumConfigurations: {},
           listConfigurations: {},
-          mayRequireDustAppConfiguration: false,
-          mayRequireSecretConfiguration: false,
           configurable: "optional",
         });
 
@@ -172,15 +184,19 @@ describe("getDefaultConfiguration", () => {
 
       it("should handle empty boolean configurations", () => {
         mockGetMCPServerToolsConfigurations.mockReturnValue({
-          mayRequireTimeFrameConfiguration: false,
-          mayRequireJsonSchemaConfiguration: false,
+          dataSourceConfigurable: "no",
+          dataWarehouseConfigurable: "no",
+          tableConfigurable: "no",
+          timeFrameConfigurable: "no",
+          jsonSchemaConfigurable: "no",
+          dustAppConfigurable: "no",
+          secretConfigurable: "no",
+          childAgentConfigurable: "no",
           stringConfigurations: [],
           numberConfigurations: [],
           booleanConfigurations: [],
           enumConfigurations: {},
           listConfigurations: {},
-          mayRequireDustAppConfiguration: false,
-          mayRequireSecretConfiguration: false,
           configurable: "optional",
         });
 
@@ -193,8 +209,14 @@ describe("getDefaultConfiguration", () => {
     describe("enum configurations", () => {
       it("should set enum configurations to first option", () => {
         mockGetMCPServerToolsConfigurations.mockReturnValue({
-          mayRequireTimeFrameConfiguration: false,
-          mayRequireJsonSchemaConfiguration: false,
+          dataSourceConfigurable: "no",
+          dataWarehouseConfigurable: "no",
+          tableConfigurable: "no",
+          timeFrameConfigurable: "no",
+          jsonSchemaConfigurable: "no",
+          dustAppConfigurable: "no",
+          secretConfigurable: "no",
+          childAgentConfigurable: "no",
           stringConfigurations: [],
           numberConfigurations: [],
           booleanConfigurations: [],
@@ -224,8 +246,6 @@ describe("getDefaultConfiguration", () => {
             },
           },
           listConfigurations: {},
-          mayRequireDustAppConfiguration: false,
-          mayRequireSecretConfiguration: false,
           configurable: "optional",
         });
 
@@ -242,8 +262,14 @@ describe("getDefaultConfiguration", () => {
 
       it("should skip enum configurations with empty options", () => {
         mockGetMCPServerToolsConfigurations.mockReturnValue({
-          mayRequireTimeFrameConfiguration: false,
-          mayRequireJsonSchemaConfiguration: false,
+          dataSourceConfigurable: "no",
+          dataWarehouseConfigurable: "no",
+          tableConfigurable: "no",
+          timeFrameConfigurable: "no",
+          jsonSchemaConfigurable: "no",
+          dustAppConfigurable: "no",
+          secretConfigurable: "no",
+          childAgentConfigurable: "no",
           stringConfigurations: [],
           numberConfigurations: [],
           booleanConfigurations: [],
@@ -261,8 +287,6 @@ describe("getDefaultConfiguration", () => {
             },
           },
           listConfigurations: {},
-          mayRequireDustAppConfiguration: false,
-          mayRequireSecretConfiguration: false,
           configurable: "optional",
         });
 
@@ -276,8 +300,14 @@ describe("getDefaultConfiguration", () => {
 
       it("should use explicit enum defaults when available", () => {
         mockGetMCPServerToolsConfigurations.mockReturnValue({
-          mayRequireTimeFrameConfiguration: false,
-          mayRequireJsonSchemaConfiguration: false,
+          dataSourceConfigurable: "no",
+          dataWarehouseConfigurable: "no",
+          tableConfigurable: "no",
+          timeFrameConfigurable: "no",
+          jsonSchemaConfigurable: "no",
+          dustAppConfigurable: "no",
+          secretConfigurable: "no",
+          childAgentConfigurable: "no",
           stringConfigurations: [],
           numberConfigurations: [],
           booleanConfigurations: [],
@@ -301,8 +331,6 @@ describe("getDefaultConfiguration", () => {
             },
           },
           listConfigurations: {},
-          mayRequireDustAppConfiguration: false,
-          mayRequireSecretConfiguration: false,
           configurable: "optional",
         });
 
@@ -318,8 +346,14 @@ describe("getDefaultConfiguration", () => {
     describe("list configurations", () => {
       it("should set list configurations to empty arrays", () => {
         mockGetMCPServerToolsConfigurations.mockReturnValue({
-          mayRequireTimeFrameConfiguration: false,
-          mayRequireJsonSchemaConfiguration: false,
+          dataSourceConfigurable: "no",
+          dataWarehouseConfigurable: "no",
+          tableConfigurable: "no",
+          timeFrameConfigurable: "no",
+          jsonSchemaConfigurable: "no",
+          dustAppConfigurable: "no",
+          secretConfigurable: "no",
+          childAgentConfigurable: "no",
           stringConfigurations: [],
           numberConfigurations: [],
           booleanConfigurations: [],
@@ -344,8 +378,6 @@ describe("getDefaultConfiguration", () => {
               description: "Nested list",
             },
           },
-          mayRequireDustAppConfiguration: false,
-          mayRequireSecretConfiguration: false,
           configurable: "optional",
         });
 
@@ -364,8 +396,14 @@ describe("getDefaultConfiguration", () => {
     describe("string configurations", () => {
       it("should set defaults for string configurations when available", () => {
         mockGetMCPServerToolsConfigurations.mockReturnValue({
-          mayRequireTimeFrameConfiguration: false,
-          mayRequireJsonSchemaConfiguration: false,
+          dataSourceConfigurable: "no",
+          dataWarehouseConfigurable: "no",
+          tableConfigurable: "no",
+          timeFrameConfigurable: "no",
+          jsonSchemaConfigurable: "no",
+          dustAppConfigurable: "no",
+          secretConfigurable: "no",
+          childAgentConfigurable: "no",
           stringConfigurations: [
             {
               key: "api_key",
@@ -383,8 +421,6 @@ describe("getDefaultConfiguration", () => {
           booleanConfigurations: [],
           enumConfigurations: {},
           listConfigurations: {},
-          mayRequireDustAppConfiguration: false,
-          mayRequireSecretConfiguration: false,
           configurable: "optional",
         });
 
@@ -402,8 +438,14 @@ describe("getDefaultConfiguration", () => {
     describe("number configurations", () => {
       it("should set defaults for number configurations when available", () => {
         mockGetMCPServerToolsConfigurations.mockReturnValue({
-          mayRequireTimeFrameConfiguration: false,
-          mayRequireJsonSchemaConfiguration: false,
+          dataSourceConfigurable: "no",
+          dataWarehouseConfigurable: "no",
+          tableConfigurable: "no",
+          timeFrameConfigurable: "no",
+          jsonSchemaConfigurable: "no",
+          dustAppConfigurable: "no",
+          secretConfigurable: "no",
+          childAgentConfigurable: "no",
           stringConfigurations: [],
           numberConfigurations: [
             { key: "timeout", description: "Timeout in seconds", default: 30 },
@@ -413,8 +455,6 @@ describe("getDefaultConfiguration", () => {
           booleanConfigurations: [],
           enumConfigurations: {},
           listConfigurations: {},
-          mayRequireDustAppConfiguration: false,
-          mayRequireSecretConfiguration: false,
           configurable: "optional",
         });
 
@@ -432,8 +472,14 @@ describe("getDefaultConfiguration", () => {
     describe("mixed configurations", () => {
       it("should handle all configuration types together", () => {
         mockGetMCPServerToolsConfigurations.mockReturnValue({
-          mayRequireTimeFrameConfiguration: false,
-          mayRequireJsonSchemaConfiguration: false,
+          dataSourceConfigurable: "no",
+          dataWarehouseConfigurable: "no",
+          tableConfigurable: "no",
+          timeFrameConfigurable: "no",
+          jsonSchemaConfigurable: "no",
+          dustAppConfigurable: "no",
+          secretConfigurable: "no",
+          childAgentConfigurable: "no",
           stringConfigurations: [
             { key: "api_key", description: "API Key", default: "secret-key" },
           ],
@@ -459,8 +505,6 @@ describe("getDefaultConfiguration", () => {
               description: "Tags",
             },
           },
-          mayRequireDustAppConfiguration: false,
-          mayRequireSecretConfiguration: false,
           configurable: "optional",
         });
 
@@ -480,8 +524,14 @@ describe("getDefaultConfiguration", () => {
     describe("comprehensive default handling", () => {
       it("should handle mixed types with nested paths and explicit defaults", () => {
         mockGetMCPServerToolsConfigurations.mockReturnValue({
-          mayRequireTimeFrameConfiguration: false,
-          mayRequireJsonSchemaConfiguration: false,
+          dataSourceConfigurable: "no",
+          dataWarehouseConfigurable: "no",
+          tableConfigurable: "no",
+          timeFrameConfigurable: "no",
+          jsonSchemaConfigurable: "no",
+          dustAppConfigurable: "no",
+          secretConfigurable: "no",
+          childAgentConfigurable: "no",
           stringConfigurations: [
             { key: "api.key", description: "API Key", default: "dev-key-123" },
             { key: "api.endpoint", description: "API Endpoint" }, // no default
@@ -541,8 +591,6 @@ describe("getDefaultConfiguration", () => {
               description: "Allowed origins", // no default (will use empty array)
             },
           },
-          mayRequireDustAppConfiguration: false,
-          mayRequireSecretConfiguration: false,
           configurable: "optional",
         });
 
@@ -586,8 +634,14 @@ describe("getDefaultConfiguration", () => {
     describe("nested path handling", () => {
       it("should handle deeply nested configuration paths", () => {
         mockGetMCPServerToolsConfigurations.mockReturnValue({
-          mayRequireTimeFrameConfiguration: false,
-          mayRequireJsonSchemaConfiguration: false,
+          dataSourceConfigurable: "no",
+          dataWarehouseConfigurable: "no",
+          tableConfigurable: "no",
+          timeFrameConfigurable: "no",
+          jsonSchemaConfigurable: "no",
+          dustAppConfigurable: "no",
+          secretConfigurable: "no",
+          childAgentConfigurable: "no",
           stringConfigurations: [],
           numberConfigurations: [],
           booleanConfigurations: [
@@ -608,8 +662,6 @@ describe("getDefaultConfiguration", () => {
               description: "Advanced options",
             },
           },
-          mayRequireDustAppConfiguration: false,
-          mayRequireSecretConfiguration: false,
           configurable: "optional",
         });
 
@@ -724,8 +776,14 @@ describe("Analysis: Why strings and numbers don't get defaults", () => {
       };
 
       mockGetMCPServerToolsConfigurations.mockReturnValue({
-        mayRequireTimeFrameConfiguration: false,
-        mayRequireJsonSchemaConfiguration: false,
+        dataSourceConfigurable: "no",
+        dataWarehouseConfigurable: "no",
+        tableConfigurable: "no",
+        timeFrameConfigurable: "no",
+        jsonSchemaConfigurable: "no",
+        dustAppConfigurable: "no",
+        secretConfigurable: "no",
+        childAgentConfigurable: "no",
         stringConfigurations: [
           { key: "required_field", description: "Required field" }, // no default
           {
@@ -745,8 +803,6 @@ describe("Analysis: Why strings and numbers don't get defaults", () => {
         booleanConfigurations: [],
         enumConfigurations: {},
         listConfigurations: {},
-        mayRequireDustAppConfiguration: false,
-        mayRequireSecretConfiguration: false,
         configurable: "optional",
       });
 

--- a/front/components/agent_builder/capabilities/mcp/validation/schemaBuilders.ts
+++ b/front/components/agent_builder/capabilities/mcp/validation/schemaBuilders.ts
@@ -55,7 +55,7 @@ export function createDynamicConfigurationFields(
   toolsConfigurations: MCPServerToolsConfigurations
 ) {
   return {
-    childAgentId: toolsConfigurations.childAgentConfiguration
+    childAgentId: toolsConfigurations.childAgentConfigurable === "required"
       ? childAgentIdSchema.refine((val) => val !== null, {
           message: VALIDATION_MESSAGES.childAgent.required,
         })
@@ -65,12 +65,12 @@ export function createDynamicConfigurationFields(
           message: VALIDATION_MESSAGES.reasoningModel.required,
         })
       : z.null(),
-    dustAppConfiguration: toolsConfigurations.mayRequireDustAppConfiguration
+    dustAppConfiguration: toolsConfigurations.dustAppConfigurable === "required"
       ? dustAppConfigurationSchema.refine((val) => val !== null, {
           message: VALIDATION_MESSAGES.dustApp.required,
         })
       : z.null(),
-    secretName: toolsConfigurations.mayRequireSecretConfiguration
+    secretName: toolsConfigurations.secretConfigurable === "required"
       ? secretNameSchema.refine((val) => val !== null, {
           message: VALIDATION_MESSAGES.secret.required,
         })

--- a/front/components/agent_builder/types.ts
+++ b/front/components/agent_builder/types.ts
@@ -180,10 +180,9 @@ export function getDefaultMCPAction(
     configuration,
     name: mcpServerView?.name ?? mcpServerView?.server.name ?? "",
     description:
-      toolsConfigurations.dataSourceConfiguration ??
-      toolsConfigurations.dataWarehouseConfiguration ??
-      toolsConfigurations.tableConfiguration ??
-      false
+      toolsConfigurations.dataSourceConfigurable !== "no" ||
+      toolsConfigurations.dataWarehouseConfigurable !== "no" ||
+      toolsConfigurations.tableConfigurable !== "no"
         ? ""
         : mcpServerView
           ? getMcpServerViewDescription(mcpServerView)

--- a/front/components/agent_builder/types.ts
+++ b/front/components/agent_builder/types.ts
@@ -133,7 +133,7 @@ export const capabilityFormSchema = z
       return true;
     }
 
-    if (toolsConfigurations.mayRequireTimeFrameConfiguration) {
+    if (toolsConfigurations.timeFrameConfigurable !== "no") {
       if (
         configuration.timeFrame !== null &&
         (configuration.timeFrame.duration === null ||
@@ -149,7 +149,7 @@ export const capabilityFormSchema = z
     }
 
     if (
-      toolsConfigurations.mayRequireJsonSchemaConfiguration &&
+      toolsConfigurations.jsonSchemaConfigurable !== "no" &&
       configuration._jsonSchemaString !== null
     ) {
       const parsedSchema = validateConfiguredJsonSchema(

--- a/front/components/assistant_builder/types.ts
+++ b/front/components/assistant_builder/types.ts
@@ -131,10 +131,9 @@ export function getDefaultMCPServerActionConfiguration(
     },
     name: mcpServerView?.name ?? mcpServerView?.server.name ?? "",
     description:
-      toolsConfigurations.dataSourceConfiguration ??
-      toolsConfigurations.dataWarehouseConfiguration ??
-      toolsConfigurations.tableConfiguration ??
-      false
+      toolsConfigurations.dataSourceConfigurable !== "no" ||
+      toolsConfigurations.dataWarehouseConfigurable !== "no" ||
+      toolsConfigurations.tableConfigurable !== "no"
         ? ""
         : mcpServerView
           ? getMcpServerViewDescription(mcpServerView)

--- a/front/hooks/useAgentBuilderTools.ts
+++ b/front/hooks/useAgentBuilderTools.ts
@@ -57,10 +57,9 @@ function getGroupedMCPServerViews({
       const toolsConfigurations = getMCPServerToolsConfigurations(view);
 
       const isWithKnowledge =
-        toolsConfigurations.dataSourceConfiguration ??
-        toolsConfigurations.dataWarehouseConfiguration ??
-        toolsConfigurations.tableConfiguration ??
-        false;
+        toolsConfigurations.dataSourceConfigurable !== "no" ||
+        toolsConfigurations.dataWarehouseConfigurable !== "no" ||
+        toolsConfigurations.tableConfigurable !== "no";
 
       return isWithKnowledge
         ? "mcpServerViewsWithKnowledge"

--- a/front/lib/actions/mcp_internal_actions/input_configuration.test.ts
+++ b/front/lib/actions/mcp_internal_actions/input_configuration.test.ts
@@ -10,8 +10,10 @@ import {
   findPathsToConfiguration,
 } from "@app/lib/actions/mcp_internal_actions/input_configuration";
 import {
+  ANY_TIME_FRAME,
   ConfigurableToolInputJSONSchemas,
   ConfigurableToolInputSchemas,
+  EMPTY_JSON_SCHEMA,
 } from "@app/lib/actions/mcp_internal_actions/input_schemas";
 import type { MCPServerViewType } from "@app/lib/api/mcp";
 import { generateRandomModelSId } from "@app/lib/resources/string_ids";
@@ -451,7 +453,7 @@ describe("augmentInputsWithConfiguration", () => {
     });
   });
 
-  describe("NULLABLE_TIME_FRAME mime type", () => {
+  describe("TIME_FRAME mime type", () => {
     it("should augment inputs with time frame configuration", () => {
       const rawInputs = {};
       const config = createBasicMCPConfiguration({
@@ -464,7 +466,7 @@ describe("augmentInputsWithConfiguration", () => {
           properties: {
             timeFrame:
               ConfigurableToolInputJSONSchemas[
-                INTERNAL_MIME_TYPES.TOOL_INPUT.NULLABLE_TIME_FRAME
+                INTERNAL_MIME_TYPES.TOOL_INPUT.TIME_FRAME
               ],
           },
           required: ["timeFrame"],
@@ -481,35 +483,19 @@ describe("augmentInputsWithConfiguration", () => {
         timeFrame: {
           duration: 7,
           unit: "day",
-          mimeType: INTERNAL_MIME_TYPES.TOOL_INPUT.NULLABLE_TIME_FRAME,
+          mimeType: INTERNAL_MIME_TYPES.TOOL_INPUT.TIME_FRAME,
         },
       });
     });
 
-    it("should return null when timeFrame is not configured", () => {
+    it("should return ANY_TIME_FRAME when timeFrame is not configured", () => {
       const rawInputs = {};
       const config = createBasicMCPConfiguration({
         timeFrame: null,
         inputSchema: {
           type: "object",
           properties: {
-            timeFrame: {
-              oneOf: [
-                { type: "null" },
-                {
-                  type: "object",
-                  properties: {
-                    duration: { type: "number" },
-                    unit: { type: "string" },
-                    mimeType: {
-                      type: "string",
-                      const: INTERNAL_MIME_TYPES.TOOL_INPUT.NULLABLE_TIME_FRAME,
-                    },
-                  },
-                  required: ["duration", "unit", "mimeType"],
-                },
-              ],
-            },
+            timeFrame: ConfigurableToolInputJSONSchemas[INTERNAL_MIME_TYPES.TOOL_INPUT.TIME_FRAME],
           },
           required: ["timeFrame"],
         },
@@ -522,7 +508,7 @@ describe("augmentInputsWithConfiguration", () => {
       });
 
       expect(result).toEqual({
-        timeFrame: null,
+        timeFrame: ANY_TIME_FRAME,
       });
     });
   });
@@ -566,29 +552,14 @@ describe("augmentInputsWithConfiguration", () => {
       });
     });
 
-    it("should return null when jsonSchema is not configured", () => {
+    it("should return EMPTY_JSON_SCHEMA when jsonSchema is not configured", () => {
       const rawInputs = {};
       const config = createBasicMCPConfiguration({
         jsonSchema: null,
         inputSchema: {
           type: "object",
           properties: {
-            schema: {
-              oneOf: [
-                { type: "null" },
-                {
-                  type: "object",
-                  properties: {
-                    type: { type: "string" },
-                    mimeType: {
-                      type: "string",
-                      const: INTERNAL_MIME_TYPES.TOOL_INPUT.JSON_SCHEMA,
-                    },
-                  },
-                  required: ["type", "mimeType"],
-                },
-              ],
-            },
+            schema: ConfigurableToolInputJSONSchemas[INTERNAL_MIME_TYPES.TOOL_INPUT.JSON_SCHEMA],
           },
           required: ["schema"],
         },
@@ -601,7 +572,7 @@ describe("augmentInputsWithConfiguration", () => {
       });
 
       expect(result).toEqual({
-        schema: null,
+        schema: EMPTY_JSON_SCHEMA,
       });
     });
   });
@@ -1323,13 +1294,13 @@ describe("augmentInputsWithConfiguration", () => {
                 ...ConfigurableToolInputJSONSchemas[
                   INTERNAL_MIME_TYPES.TOOL_INPUT.STRING
                 ],
-                default: {
-                  value: "should-not-be-used",
-                  mimeType: INTERNAL_MIME_TYPES.TOOL_INPUT.STRING,
-                },
               },
             },
             required: ["stringParam"],
+            default: {
+              value: "should-not-be-used",
+              mimeType: INTERNAL_MIME_TYPES.TOOL_INPUT.STRING,
+            },
           },
           additionalConfiguration: {
             stringParam: "user-provided-value",

--- a/front/lib/actions/mcp_internal_actions/input_schemas.ts
+++ b/front/lib/actions/mcp_internal_actions/input_schemas.ts
@@ -6,6 +6,7 @@ import { zodToJsonSchema } from "zod-to-json-schema";
 
 import type { Result } from "@app/types";
 import { Err, normalizeError, Ok } from "@app/types";
+import { ANY_TIME_FRAME  as ANY_TIME_FRAME_WITHOUT_MIME_TYPE } from "@app/types/shared/utils/time_frame";
 
 /**
  * URI pattern for configuring the data source to use within an action.
@@ -145,7 +146,7 @@ export const ConfigurableToolInputSchemas = {
       duration: z.number(),
       unit: z.enum(["hour", "day", "week", "month", "year"]),
       mimeType: z.literal(INTERNAL_MIME_TYPES.TOOL_INPUT.TIME_FRAME),
-    }).nullable()
+    })
     .describe("An optional time frame to use for the tool."),
   [INTERNAL_MIME_TYPES.TOOL_INPUT.JSON_SCHEMA]: z.intersection(
     JsonSchemaSchema,
@@ -172,11 +173,10 @@ export const EMPTY_JSON_SCHEMA : z.infer<typeof ConfigurableToolInputSchemas[typ
   mimeType: INTERNAL_MIME_TYPES.TOOL_INPUT.JSON_SCHEMA,
 };
 
-export const EMPTY_DUST_APP : z.infer<typeof ConfigurableToolInputSchemas[typeof INTERNAL_MIME_TYPES.TOOL_INPUT.DUST_APP]> = {
-  appId: "",
-  mimeType: INTERNAL_MIME_TYPES.TOOL_INPUT.DUST_APP,
+export const ANY_TIME_FRAME : z.infer<typeof ConfigurableToolInputSchemas[typeof INTERNAL_MIME_TYPES.TOOL_INPUT.TIME_FRAME]> = {
+  ...ANY_TIME_FRAME_WITHOUT_MIME_TYPE,
+  mimeType: INTERNAL_MIME_TYPES.TOOL_INPUT.TIME_FRAME,
 };
-
 
 // Type for the tool inputs that have a flexible schema, which are schemas that can vary between tools.
 type FlexibleConfigurableToolInput = {

--- a/front/lib/actions/mcp_internal_actions/input_schemas.ts
+++ b/front/lib/actions/mcp_internal_actions/input_schemas.ts
@@ -140,14 +140,13 @@ export const ConfigurableToolInputSchemas = {
     appId: z.string(),
     mimeType: z.literal(INTERNAL_MIME_TYPES.TOOL_INPUT.DUST_APP),
   }),
-  [INTERNAL_MIME_TYPES.TOOL_INPUT.NULLABLE_TIME_FRAME]: z
+  [INTERNAL_MIME_TYPES.TOOL_INPUT.TIME_FRAME]: z
     .object({
       duration: z.number(),
       unit: z.enum(["hour", "day", "week", "month", "year"]),
-      mimeType: z.literal(INTERNAL_MIME_TYPES.TOOL_INPUT.NULLABLE_TIME_FRAME),
-    })
-    .describe("An optional time frame to use for the tool.")
-    .nullable(),
+      mimeType: z.literal(INTERNAL_MIME_TYPES.TOOL_INPUT.TIME_FRAME),
+    }).nullable()
+    .describe("An optional time frame to use for the tool."),
   [INTERNAL_MIME_TYPES.TOOL_INPUT.JSON_SCHEMA]: z.intersection(
     JsonSchemaSchema,
     z.object({
@@ -165,6 +164,19 @@ export const ConfigurableToolInputSchemas = {
   | typeof INTERNAL_MIME_TYPES.TOOL_INPUT.ENUM
   | typeof INTERNAL_MIME_TYPES.TOOL_INPUT.LIST
 >;
+
+export const EMPTY_JSON_SCHEMA : z.infer<typeof ConfigurableToolInputSchemas[typeof INTERNAL_MIME_TYPES.TOOL_INPUT.JSON_SCHEMA]> = {
+  type: "object",
+  properties: {},
+  required: [],
+  mimeType: INTERNAL_MIME_TYPES.TOOL_INPUT.JSON_SCHEMA,
+};
+
+export const EMPTY_DUST_APP : z.infer<typeof ConfigurableToolInputSchemas[typeof INTERNAL_MIME_TYPES.TOOL_INPUT.DUST_APP]> = {
+  appId: "",
+  mimeType: INTERNAL_MIME_TYPES.TOOL_INPUT.DUST_APP,
+};
+
 
 // Type for the tool inputs that have a flexible schema, which are schemas that can vary between tools.
 type FlexibleConfigurableToolInput = {

--- a/front/lib/actions/mcp_internal_actions/servers/include.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/include.ts
@@ -88,7 +88,7 @@ function createServer(
     tagsIn,
     tagsNot,
   }: {
-    timeFrame: TimeFrame | null;
+    timeFrame: TimeFrame;
     dataSources: DataSourcesToolConfigurationType;
     tagsIn?: string[];
     tagsNot?: string[];
@@ -294,7 +294,7 @@ function createServer(
 }
 
 function makeQueryResource(
-  timeFrame: TimeFrame | null
+  timeFrame: TimeFrame
 ): IncludeQueryResourceType {
   return {
     mimeType: INTERNAL_MIME_TYPES.TOOL_OUTPUT.DATA_SOURCE_INCLUDE_QUERY,
@@ -306,7 +306,7 @@ function makeQueryResource(
 function makeWarningResource(
   documents: CoreAPIDocument[],
   topK: number,
-  timeFrame: TimeFrame | null
+  timeFrame: TimeFrame
 ): WarningResourceType | null {
   const timeFrameAsString = renderRelativeTimeFrameForToolOutput(timeFrame);
 

--- a/front/lib/actions/mcp_internal_actions/servers/include.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/include.ts
@@ -55,7 +55,7 @@ function createServer(
   const commonInputsSchema = {
     timeFrame:
       ConfigurableToolInputSchemas[
-        INTERNAL_MIME_TYPES.TOOL_INPUT.NULLABLE_TIME_FRAME
+        INTERNAL_MIME_TYPES.TOOL_INPUT.TIME_FRAME
       ],
     dataSources:
       ConfigurableToolInputSchemas[INTERNAL_MIME_TYPES.TOOL_INPUT.DATA_SOURCE],
@@ -180,7 +180,7 @@ function createServer(
               not: finalTagsNot.length > 0 ? finalTagsNot : null,
             },
             timestamp: {
-              gt: timeFrame ? timeFrameFromNow(timeFrame) : null,
+              gt: timeFrameFromNow(timeFrame),
               lt: null,
             },
           },

--- a/front/lib/actions/mcp_internal_actions/servers/notion.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/notion.ts
@@ -327,9 +327,8 @@ const createServer = (
       let results = rawResults.results;
 
       // Notion search does not support time frame filtering, so we need to filter the results after the search.
-      
-      if (timeFrame) {
-        const timestampInMs = timeFrameFromNow(timeFrame);
+      const timestampInMs = timeFrame ? timeFrameFromNow(timeFrame) : null;
+      if (timestampInMs) {
         const date = new Date(timestampInMs);
         results = rawResults.results.filter((result) => {
           if (isFullPage(result) || isFullDatabase(result)) {

--- a/front/lib/actions/mcp_internal_actions/servers/notion.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/notion.ts
@@ -327,6 +327,7 @@ const createServer = (
       let results = rawResults.results;
 
       // Notion search does not support time frame filtering, so we need to filter the results after the search.
+      
       if (timeFrame) {
         const timestampInMs = timeFrameFromNow(timeFrame);
         const date = new Date(timestampInMs);

--- a/front/lib/actions/mcp_internal_actions/servers/process/index.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/process/index.ts
@@ -288,7 +288,7 @@ function createServer(
         ),
     timeFrame: isTimeFrameConfigured
       ? ConfigurableToolInputSchemas[
-          INTERNAL_MIME_TYPES.TOOL_INPUT.NULLABLE_TIME_FRAME
+          INTERNAL_MIME_TYPES.TOOL_INPUT.TIME_FRAME
         ]
       : z
           .object({

--- a/front/lib/actions/mcp_internal_actions/servers/slack.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/slack.ts
@@ -182,8 +182,8 @@ function buildSlackSearchQuery(
   }
 ): string {
   let query = initial;
-  if (timeFrame) {
-    const timestampInMs = timeFrameFromNow(timeFrame);
+  const timestampInMs = timeFrame ? timeFrameFromNow(timeFrame) : null;
+  if (timestampInMs) {
     const date = new Date(timestampInMs);
     query = `${query} after:${date.getFullYear()}-${date.getMonth() + 1}-${date.getDate()}`;
   }
@@ -612,8 +612,8 @@ const createServer = async (
       try {
         let query = `-threads:replies in:${channel.charAt(0) === "#" ? channel : `#${channel}`}`;
 
-        if (timeFrame) {
-          const timestampInMs = timeFrameFromNow(timeFrame);
+        const timestampInMs = timeFrame ? timeFrameFromNow(timeFrame) : null;
+        if (timestampInMs) {
           const date = new Date(timestampInMs);
           query = `${query} after:${date.getFullYear()}-${date.getMonth() + 1}-${date.getDate()}`;
         }

--- a/front/lib/utils/json_schemas.test.ts
+++ b/front/lib/utils/json_schemas.test.ts
@@ -245,7 +245,7 @@ describe("JSON Schema Utilities", () => {
           },
           optionalTimeFrame:
             ConfigurableToolInputJSONSchemas[
-              INTERNAL_MIME_TYPES.TOOL_INPUT.NULLABLE_TIME_FRAME
+              INTERNAL_MIME_TYPES.TOOL_INPUT.TIME_FRAME
             ],
         },
         required: ["optionalString"],
@@ -253,7 +253,7 @@ describe("JSON Schema Utilities", () => {
 
       const r = findMatchingSubSchemas(
         mainSchema,
-        INTERNAL_MIME_TYPES.TOOL_INPUT.NULLABLE_TIME_FRAME
+        INTERNAL_MIME_TYPES.TOOL_INPUT.TIME_FRAME
       );
       expect(Object.keys(r)).toStrictEqual(["optionalTimeFrame"]);
     });

--- a/front/types/shared/utils/time_frame.ts
+++ b/front/types/shared/utils/time_frame.ts
@@ -1,4 +1,3 @@
-
 import { ioTsEnum } from "./iots_utils";
 
 export const TIME_FRAME_UNITS = [
@@ -25,6 +24,11 @@ export function isTimeFrame(arg: any): arg is TimeFrame {
     arg.unit !== undefined
   );
 }
+
+export const ANY_TIME_FRAME: TimeFrame = {
+  duration: -1,
+  unit: "year",
+};
 
 /**
  * TimeFrame parsing
@@ -75,8 +79,12 @@ export function parseTimeFrame(raw: string): TimeFrame | null {
   };
 }
 // Turns a TimeFrame into a number of milliseconds from now.
-export function timeFrameFromNow(timeFrame: TimeFrame): number {
+export function timeFrameFromNow(timeFrame: TimeFrame): number | null {
   const now = Date.now();
+
+  if (timeFrame === ANY_TIME_FRAME) {
+    return null;
+  }
 
   switch (timeFrame.unit) {
     case "hour":

--- a/front/types/shared/utils/time_frame.ts
+++ b/front/types/shared/utils/time_frame.ts
@@ -1,3 +1,4 @@
+
 import { ioTsEnum } from "./iots_utils";
 
 export const TIME_FRAME_UNITS = [
@@ -73,7 +74,6 @@ export function parseTimeFrame(raw: string): TimeFrame | null {
     unit,
   };
 }
-
 // Turns a TimeFrame into a number of milliseconds from now.
 export function timeFrameFromNow(timeFrame: TimeFrame): number {
   const now = Date.now();

--- a/sdks/js/src/internal_mime_types.ts
+++ b/sdks/js/src/internal_mime_types.ts
@@ -235,7 +235,7 @@ const TOOL_MIME_TYPES = {
       "LIST",
       "REASONING_MODEL",
       "DUST_APP",
-      "NULLABLE_TIME_FRAME",
+      "TIME_FRAME",
       "JSON_SCHEMA",
       "SECRET",
     ],


### PR DESCRIPTION
## Description

### General Overview

This commit should stabilise the way we work with optional values or default values in MCP Tools.

The result is this:

```ts
export interface MCPServerToolsConfigurations {
  dataSourceConfigurable: "no" | "optional" | "required";
  dataWarehouseConfigurable: "no" | "optional" | "required";
  tableConfigurable: "no" | "optional" | "required";
  timeFrameConfigurable: "no" | "optional" | "required";
  jsonSchemaConfigurable: "no" | "optional" | "required";
  dustAppConfigurable: "no" | "required";
  secretConfigurable: "no" | "required";
  childAgentConfigurable: "no" | "required";
  reasoningConfiguration?: {
    description?: string;
    default?: {
      modelId: string;
      providerId: string;
      temperature: number;
      reasoningEffort: string;
    };
  };
  stringConfigurations: {
    key: string;
    description?: string;
    default?: string;
  }[];
  numberConfigurations: {
    key: string;
    description?: string;
    default?: number;
  }[];
  booleanConfigurations: {
    key: string;
    description?: string;
    default?: boolean;
  }[];
  enumConfigurations: Record<
    string,
    {
      options: Array<{ value: string; label: string; description?: string }>;
      description?: string;
      default?: string;
    }
  >;
  listConfigurations: Record<
    string,
    {
      options: Array<{ value: string; label: string; description?: string }>;
      description?: string;
      values?: string[];
      default?: string;
    }
  >;
  configurable: "no" | "optional" | "required";
}
```

All the primitive types (string, number, boolean, enum, and list) can take default values, they are picked up and shown already in the Agent Builder forms and if set for everything make the tool available in JIT.

The distinctions between `"no" | "optional" | "required"` are used in quite a few places, but chiefly their purpose is for allowing tools to appear in JIT. If all config options are "optional", the item can be in JIT, if any are required then no. And regardless of if optional or required, if something verifies ` !== "no"` then it will be available in the Agent Builder.

### Upgrades to Behavior

TimeFrame & JSON Schema options now can be placed anywhere in the heirarchy of the Zod Schemas. They no longer need to be at the root.

TimeFrame, JSON, DataSource, DataWareHouse, and Table can have an "optional" value.

### How defaults / optionals are set

For Array-like objects (DataSource, DataWarehouse, Table), to give them a null value you can use:

```ts
ConfigurableToolInputSchemas[INTERNAL_MIME_TYPES.TOOL_INPUT.DATA_SOURCE].default([])
```
For other objects, they have a "nullish value" to be set:

```ts
ConfigurableToolInputSchemas[INTERNAL_MIME_TYPES.TOOL_INPUT.TIME_FRAME].default(ANY_TIME_FRAME)
ConfigurableToolInputSchemas[INTERNAL_MIME_TYPES.TOOL_INPUT.JSON_SCHEMA].default(EMPTY_JSON_SCHEMA)
```

DustApps, Secrets, and ChildAgents can purposely not have a null value and must be set with a value, or the config option must not exist, hence : `"no" | "required"`

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
