### PR TITLE
[extension] chore(ui): Make extension ui more consistent with front app

### DIFF
--- a/extension/platforms/chrome/components/ChromeCaptureActions.tsx
+++ b/extension/platforms/chrome/components/ChromeCaptureActions.tsx
@@ -43,8 +43,8 @@ export function ChromeCaptureActions({
               ? "Attach text from page"
               : "Attachment disabled on this website"
           }
-          variant="outline"
-          size="sm"
+          variant="ghost-secondary"
+          size="xs"
           className={isBlinking ? "animate-[bgblink_200ms_3]" : ""}
           onClick={handleCapture}
           disabled={isLoading || isBlacklisted}
@@ -58,8 +58,8 @@ export function ChromeCaptureActions({
               ? "Attach page screenshot"
               : "Attachment disabled on this website"
           }
-          variant="outline"
-          size="sm"
+          variant="ghost-secondary"
+          size="xs"
           onClick={handleCapturePageContent}
           disabled={isLoading || isBlacklisted}
         />
@@ -73,8 +73,8 @@ export function ChromeCaptureActions({
               ? "Attach text from page"
               : "Attachment disabled on this website"
           }
-          variant="outline"
-          size="sm"
+          variant="ghost-secondary"
+          size="xs"
           className={isBlinking ? "animate-[bgblink_200ms_3]" : ""}
           onClick={handleCapture}
           disabled={isLoading || isBlacklisted}
@@ -89,8 +89,8 @@ export function ChromeCaptureActions({
               ? "Attach page screenshot"
               : "Attachment disabled on this website"
           }
-          variant="outline"
-          size="sm"
+          variant="ghost-secondary"
+          size="xs"
           onClick={() =>
             fileUploaderService.uploadContentTab({
               includeContent: false,

--- a/extension/ui/components/assistants/AssistantPicker.tsx
+++ b/extension/ui/components/assistants/AssistantPicker.tsx
@@ -56,29 +56,35 @@ export function AssistantPicker({
             icon={RobotIcon}
             className="text-muted-foreground dark:text-muted-foreground-night"
             variant="ghost"
-            isSelect
             size={size}
             tooltip="Pick an agent"
             disabled={isLoading ?? false}
           />
         )}
       </DropdownMenuTrigger>
-      <DropdownMenuContent className="min-w-[300px]" align="end" side="bottom">
-        <DropdownMenuSearchbar
-          ref={searchbarRef}
-          placeholder="Search"
-          name="input"
-          value={searchText}
-          onChange={setSearchText}
-          onKeyDown={(e) => {
-            if (e.key === "Enter" && searchedAssistants.length > 0) {
-              onItemClick(searchedAssistants[0]);
-              setSearchText("");
-              close();
-            }
-          }}
-        />
-        <DropdownMenuSeparator className="mt-2" />
+      <DropdownMenuContent
+        className="h-96 w-64 xs:w-96"
+        align="end"
+        dropdownHeaders={
+          <>
+            <DropdownMenuSearchbar
+              ref={searchbarRef}
+              placeholder="Search Agents"
+              name="input"
+              value={searchText}
+              onChange={setSearchText}
+              onKeyDown={(e) => {
+                if (e.key === "Enter" && searchedAssistants.length > 0) {
+                  onItemClick(searchedAssistants[0]);
+                  setSearchText("");
+                  close();
+                }
+              }}
+            />
+            <DropdownMenuSeparator />
+          </>
+        }
+      >
         <ScrollArea className="flex flex-col mt-1 max-h-[300px] overflow-y-auto">
           {searchedAssistants.map((c) => (
             <DropdownMenuItem

--- a/extension/ui/components/conversation/AttachFragment.tsx
+++ b/extension/ui/components/conversation/AttachFragment.tsx
@@ -37,7 +37,7 @@ export const AttachFragment = ({
   }
 
   return (
-    <div className="flex flex-row gap-2">
+    <div className="flex flex-row">
       <CaptureActionsComponent
         fileUploaderService={fileUploaderService}
         isBlinking={attachPageBlinking}

--- a/extension/ui/components/conversation/ConversationContainer.tsx
+++ b/extension/ui/components/conversation/ConversationContainer.tsx
@@ -259,7 +259,6 @@ export function ConversationContainer({
                 setIncludeContent(includeTab);
               }}
               conversation={conversation ?? undefined}
-              attachmentPickerSide="top"
             />
           </div>
 

--- a/extension/ui/components/input_bar/InputBar.tsx
+++ b/extension/ui/components/input_bar/InputBar.tsx
@@ -50,7 +50,6 @@ export function AssistantInputBar({
   isTabIncluded,
   setIncludeTab,
   isSubmitting,
-  attachmentPickerSide,
 }: {
   owner: ExtensionWorkspaceType;
   onSubmit: (
@@ -65,7 +64,6 @@ export function AssistantInputBar({
   isTabIncluded: boolean;
   setIncludeTab: (includeTab: boolean) => void;
   isSubmitting?: boolean;
-  attachmentPickerSide?: "top" | "right" | "bottom" | "left";
 }) {
   const platform = usePlatform();
   const dustAPI = useDustAPI();
@@ -385,7 +383,6 @@ export function AssistantInputBar({
                 onNodeSelect={handleNodesAttachmentSelect}
                 onNodeUnselect={handleNodesAttachmentRemove}
                 attachedNodes={attachedNodes}
-                attachmentPickerSide={attachmentPickerSide}
               />
             </div>
           </div>

--- a/extension/ui/components/input_bar/InputBarAttachmentPicker.tsx
+++ b/extension/ui/components/input_bar/InputBarAttachmentPicker.tsx
@@ -20,7 +20,6 @@ import {
   DropdownMenu,
   DropdownMenuCheckboxItem,
   DropdownMenuContent,
-  DropdownMenuItem,
   DropdownMenuSearchbar,
   DropdownMenuSeparator,
   DropdownMenuTrigger,
@@ -40,7 +39,6 @@ interface InputBarAttachmentsPickerProps {
   onNodeUnselect: (node: DataSourceViewContentNodeType) => void;
   isLoading?: boolean;
   attachedNodes: DataSourceViewContentNodeType[];
-  side?: "top" | "right" | "bottom" | "left";
 }
 
 export const InputBarAttachmentsPicker = ({
@@ -49,7 +47,6 @@ export const InputBarAttachmentsPicker = ({
   onNodeUnselect,
   attachedNodes,
   isLoading = false,
-  side = "bottom",
 }: InputBarAttachmentsPickerProps) => {
   const fileInputRef = useRef<HTMLInputElement>(null);
   const itemsContainerRef = useRef<HTMLDivElement>(null);
@@ -112,12 +109,6 @@ export const InputBarAttachmentsPicker = ({
 
   const showLoader = isSearchLoading || isDebouncing;
 
-  const searchbarRef = (element: HTMLInputElement) => {
-    if (element) {
-      element.focus();
-    }
-  };
-
   return (
     <DropdownMenu
       open={isOpen}
@@ -137,49 +128,55 @@ export const InputBarAttachmentsPicker = ({
         />
       </DropdownMenuTrigger>
       <DropdownMenuContent
-        className="min-w-64 max-w-96"
-        side={side}
+        className="h-80 w-80 xs:h-96 xs:w-96"
+        collisionPadding={15}
         align="end"
         onInteractOutside={() => setIsOpen(false)}
         onEscapeKeyDown={() => setIsOpen(false)}
+        dropdownHeaders={
+          <>
+            <Input
+              type="file"
+              ref={fileInputRef}
+              style={{ display: "none" }}
+              onChange={async (e) => {
+                setIsOpen(false);
+                await fileUploaderService.handleFileChange(e);
+                if (fileInputRef.current) {
+                  fileInputRef.current.value = "";
+                }
+              }}
+              multiple={true}
+            />
+            <DropdownMenuSearchbar
+              autoFocus
+              name="search-files"
+              placeholder="Search knowledge"
+              value={search}
+              onChange={setSearch}
+              disabled={isLoading}
+              onKeyDown={(e) => {
+                if (e.key === "ArrowDown") {
+                  e.preventDefault();
+                  const firstMenuItem =
+                    itemsContainerRef.current?.querySelector(
+                      '[role="menuitemcheckbox"]'
+                    );
+                  (firstMenuItem as HTMLElement)?.focus();
+                }
+              }}
+              button={
+                <Button
+                  icon={CloudArrowUpIcon}
+                  label="Upload File"
+                  onClick={() => fileInputRef.current?.click()}
+                />
+              }
+            />
+            <DropdownMenuSeparator />
+          </>
+        }
       >
-        <Input
-          type="file"
-          ref={fileInputRef}
-          style={{ display: "none" }}
-          onChange={async (e) => {
-            setIsOpen(false);
-            await fileUploaderService.handleFileChange(e);
-            if (fileInputRef.current) {
-              fileInputRef.current.value = "";
-            }
-          }}
-          multiple={true}
-        />
-        <DropdownMenuItem
-          key="upload-item"
-          label="Upload file"
-          icon={CloudArrowUpIcon}
-          onClick={() => fileInputRef.current?.click()}
-        />
-        <DropdownMenuSeparator />
-        <DropdownMenuSearchbar
-          ref={searchbarRef}
-          name="search-files"
-          placeholder="Search knowledge"
-          value={search}
-          onChange={setSearch}
-          disabled={isLoading}
-          onKeyDown={(e) => {
-            if (e.key === "ArrowDown") {
-              e.preventDefault();
-              const firstMenuItem = itemsContainerRef.current?.querySelector(
-                '[role="menuitemcheckbox"]'
-              );
-              (firstMenuItem as HTMLElement)?.focus();
-            }
-          }}
-        />
         {searchQuery && (
           <>
             <DropdownMenuSeparator />

--- a/extension/ui/components/input_bar/InputBarContainer.tsx
+++ b/extension/ui/components/input_bar/InputBarContainer.tsx
@@ -23,11 +23,27 @@ import type {
   ExtensionWorkspaceType,
   LightAgentConfigurationType,
 } from "@dust-tt/client";
-import { SplitButton, useSendNotification } from "@dust-tt/sparkle";
+import {
+  Button,
+  ChevronDownIcon,
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+  FlexSplitButton,
+  Spinner,
+  useSendNotification,
+} from "@dust-tt/sparkle";
 import type { Editor } from "@tiptap/react";
 import { EditorContent } from "@tiptap/react";
-import { useCallback, useContext, useEffect, useMemo, useState } from "react";
-import { useRef } from "react";
+import {
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
 
 export interface InputBarContainerProps {
   allAssistants: LightAgentConfigurationType[];
@@ -44,7 +60,6 @@ export interface InputBarContainerProps {
   onNodeUnselect: (node: DataSourceViewContentNodeType) => void;
   attachedNodes: DataSourceViewContentNodeType[];
   isSubmitting: boolean;
-  attachmentPickerSide?: "top" | "right" | "bottom" | "left";
 }
 
 export const InputBarContainer = ({
@@ -62,7 +77,6 @@ export const InputBarContainer = ({
   onNodeUnselect,
   attachedNodes,
   isSubmitting,
-  attachmentPickerSide = "bottom",
 }: InputBarContainerProps) => {
   const platform = usePlatform();
   const suggestions = usePublicAssistantSuggestions(agentConfigurations);
@@ -229,6 +243,11 @@ export const InputBarContainer = ({
     onClick,
     isLoading: isSubmitting,
   };
+  const disabled =
+    isSubmitting ||
+    editorService.isEmpty() ||
+    fileUploaderService.isProcessingFiles ||
+    fileUploaderService.isCapturing;
 
   return (
     <div id="InputBarContainer" className="relative flex flex-col w-full">
@@ -239,9 +258,7 @@ export const InputBarContainer = ({
             contentEditableClasses,
             "scrollbar-hide",
             "overflow-y-auto",
-            "min-h-32",
-            "max-h-96",
-            "flex-1"
+            "max-h-96 min-h-24"
           )}
         />
         <div className="flex items-start pt-1">
@@ -252,7 +269,6 @@ export const InputBarContainer = ({
             onNodeSelect={onNodeSelect}
             onNodeUnselect={onNodeUnselect}
             attachedNodes={attachedNodes}
-            side={attachmentPickerSide}
           />
           <AssistantPicker
             owner={owner}
@@ -266,26 +282,42 @@ export const InputBarContainer = ({
         </div>
       </div>
 
-      <div className="flex items-center justify-end space-x-2 mt-2">
+      <div className="flex items-center justify-end space-x-1 mt-2">
         <AttachFragment
           owner={owner}
           fileUploaderService={fileUploaderService}
           isLoading={isSubmitting}
         />
-        <SplitButton
-          size="sm"
-          actions={[SendAction, SendWithContentAction]}
-          action={isTabIncluded ? SendWithContentAction : SendAction}
+        <FlexSplitButton
+          {...(isTabIncluded ? SendWithContentAction : SendAction)}
           variant="highlight"
-          onActionChange={(action) => {
-            setIncludeTab(action === SendWithContentAction);
-          }}
-          disabled={
-            isSubmitting ||
-            editorService.isEmpty() ||
-            fileUploaderService.isProcessingFiles ||
-            fileUploaderService.isCapturing
+          splitAction={
+            isSubmitting ? (
+              <Spinner size="xs" />
+            ) : (
+              <DropdownMenu>
+                <DropdownMenuTrigger asChild>
+                  <Button
+                    size="mini"
+                    variant="highlight"
+                    icon={ChevronDownIcon}
+                    disabled={disabled}
+                  />
+                </DropdownMenuTrigger>
+                <DropdownMenuContent align="end">
+                  <DropdownMenuItem
+                    label={SendAction.label}
+                    onClick={() => setIncludeTab(false)}
+                  />
+                  <DropdownMenuItem
+                    label={SendWithContentAction.label}
+                    onClick={() => setIncludeTab(true)}
+                  />
+                </DropdownMenuContent>
+              </DropdownMenu>
+            )
           }
+          disabled={disabled}
         />
       </div>
 


### PR DESCRIPTION
## Description

https://github.com/dust-tt/tasks/issues/4380

Make extension ui more consistent with front app , use new FlexSplitButton

<img width="337" height="218" alt="Screenshot 2025-09-25 at 18 39 02" src="https://github.com/user-attachments/assets/8e574f81-1374-4544-8b31-642a75133d0b" />
<img width="344" height="237" alt="Screenshot 2025-09-25 at 18 38 49" src="https://github.com/user-attachments/assets/a0687617-6253-400f-95f7-eff635f42093" />
<img width="344" height="276" alt="Screenshot 2025-09-25 at 18 38 41" src="https://github.com/user-attachments/assets/9bd6b666-a334-4296-b9b6-ef3e750afecb" />
<img width="342" height="224" alt="Screenshot 2025-09-25 at 18 37 53" src="https://github.com/user-attachments/assets/7881b9bf-cf49-4ad9-8de5-9ea6c5ab6342" />

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
