### PR TITLE
[front] Fix agent configuration hard deletion

### DIFF
--- a/front/lib/api/assistant/configuration/agent.ts
+++ b/front/lib/api/assistant/configuration/agent.ts
@@ -1031,6 +1031,12 @@ export async function unsafeHardDeleteAgentConfiguration(
 ): Promise<void> {
   const workspaceId = auth.getNonNullableWorkspace().id;
 
+  await TagAgentModel.destroy({
+    where: {
+      agentConfigurationId: agentConfiguration.id,
+      workspaceId,
+    },
+  });
   await GroupAgentModel.destroy({
     where: {
       agentConfigurationId: agentConfiguration.id,


### PR DESCRIPTION
## Description

- The hard delete does not account for the TagAgent relation created just before calling it ([logs](https://app.datadoghq.eu/logs?query=%22Unhandled%20API%20Error%22%20status%3Aerror%20%40dd.env%3Aprod%20service%3Afront&agg_m=count&agg_m_source=base&agg_t=count&cols=host%2Cservice&event=AwAAAZmBoUopnxyHPwAAABhBWm1Cb1V1QkFBQk1DVXBwWE9fQ0h3QVgAAAAkZjE5OTgxYTQtMjYwMS00MTJiLWFhMzctMzNlZjQxYjFhNDBhAAVRXg&messageDisplay=inline&refresh_mode=sliding&storage=hot&stream_sort=desc&viz=stream&from_ts=1758734516977&to_ts=1758820916977&live=true)).
- This PR fixes that.
- This PR is more of a long-term work to make `unsafeHardDeleteAgentConfiguration` usable, the underlying issue is that we have some `MCP server view not found` errors, causing us to enter the code path where we delete every data related to an agent.

## Tests

## Risk

## Deploy Plan

- Deploy front.
