### PR TITLE
[front] Automatically insert space after mention after clicking on agent name

### DIFF
--- a/front/components/assistant/conversation/input_bar/editor/MentionDropdown.tsx
+++ b/front/components/assistant/conversation/input_bar/editor/MentionDropdown.tsx
@@ -99,7 +99,8 @@ export const MentionDropdown = ({
                     onSelect(suggestion);
                   }}
                   onMouseDown={(e) => {
-                    // This prevents the browser from taking focus away from the editor when onClick is triggered
+                    // This prevents the browser from taking focus away from the editor when onClick is
+                    // triggered.
                     e.preventDefault();
                   }}
                   onMouseEnter={(e) => {

--- a/front/components/assistant/conversation/input_bar/editor/MentionDropdown.tsx
+++ b/front/components/assistant/conversation/input_bar/editor/MentionDropdown.tsx
@@ -98,6 +98,10 @@ export const MentionDropdown = ({
                     e.stopPropagation();
                     onSelect(suggestion);
                   }}
+                  onMouseDown={(e) => {
+                    // This prevents the browser from taking focus away from the editor when onClick is triggered
+                    e.preventDefault();
+                  }}
                   onMouseEnter={(e) => {
                     e.preventDefault();
                     e.stopPropagation();


### PR DESCRIPTION
## Description
This PR is to fix https://github.com/dust-tt/tasks/issues/4330. I don't fully understand how it works, but this only happens when onClick is triggered and never happens when onMouseEnter is triggered. My guess was focus gets being lost when onClick is triggered and we can prevent this by adding `e.preventDefault()` in onMouseDown (this is apparently where the browser decides to change focus, and being called before `onClick`). Though even without it the cursor position was not so wrong so I'm not sure why it ended up inserting the cursor before the extra space 🤔

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
