### PR TITLE
[connectors] Handle `DataSourceQuotaExceededError` for GitHub code issues reactively

### DIFF
--- a/connectors/src/connectors/github/lib/code/file_operations.ts
+++ b/connectors/src/connectors/github/lib/code/file_operations.ts
@@ -195,6 +195,7 @@ export async function upsertCodeFile({
       if (error instanceof DataSourceQuotaExceededError) {
         logger.warn(
           {
+            connectorId,
             error,
             documentId,
             extension: extname(fileName),

--- a/connectors/src/connectors/github/lib/code/file_operations.ts
+++ b/connectors/src/connectors/github/lib/code/file_operations.ts
@@ -200,7 +200,7 @@ export async function upsertCodeFile({
             documentId,
             extension: extname(fileName),
           },
-          "Skipping GitHub code file exceeding plan limit."
+          "Skipping GitHub code file exceeding plan document size limit."
         );
 
         // Not setting a skipReason in purpose in case the file becomes smaller.

--- a/connectors/src/connectors/github/temporal/activities.ts
+++ b/connectors/src/connectors/github/temporal/activities.ts
@@ -43,7 +43,6 @@ import {
   deleteDataSourceFolder,
   renderDocumentTitleAndContent,
   renderMarkdownSection,
-  sectionLength,
   upsertDataSourceDocument,
   upsertDataSourceFolder,
 } from "@connectors/lib/data_sources";

--- a/connectors/src/connectors/github/temporal/activities.ts
+++ b/connectors/src/connectors/github/temporal/activities.ts
@@ -327,7 +327,7 @@ export async function githubUpsertIssueActivity(
           error,
           documentId,
         },
-        "Skipping GitHub issue exceeding plan limit."
+        "Skipping GitHub issue exceeding plan document size limit."
       );
       return;
     }

--- a/connectors/src/connectors/github/temporal/activities.ts
+++ b/connectors/src/connectors/github/temporal/activities.ts
@@ -62,9 +62,6 @@ import type { DataSourceConfig, ModelId } from "@connectors/types";
 import { INTERNAL_MIME_TYPES } from "@connectors/types";
 import { normalizeError } from "@connectors/types/api";
 
-// Only allow documents up to 5mb to be processed.
-const MAX_DOCUMENT_TXT_LEN = 5000000;
-
 export async function githubGetReposResultPageActivity(
   connectorId: ModelId,
   pageNumber: number, // 1-indexed
@@ -286,11 +283,6 @@ export async function githubUpsertIssueActivity(
     updatedAtTimestamp,
     content: renderedIssue,
   } = renderedIssueResult;
-
-  if (sectionLength(renderedIssue) > MAX_DOCUMENT_TXT_LEN) {
-    logger.info("Issue is too large to upsert.");
-    return;
-  }
 
   const documentId = getIssueInternalId(repoId.toString(), issueNumber);
   const issueAuthor = renderGithubUser(issue.creator);
@@ -520,11 +512,6 @@ export async function githubUpsertDiscussionActivity(
 
   const { discussion, content: renderedDiscussion } =
     renderedDiscussionRes.value;
-
-  if (sectionLength(renderedDiscussion) > MAX_DOCUMENT_TXT_LEN) {
-    logger.info("Discussion is too large to upsert.");
-    return;
-  }
 
   const documentId = getDiscussionInternalId(
     repoId.toString(),


### PR DESCRIPTION
## Description

- Same thing as https://github.com/dust-tt/dust/pull/16305 but for GitHub issues and discussions.
- Plans don't have the same limit on the max size of a document, so instead of setting a value in connectors we react to data source quota errors on upserts.

## Tests

## Risk

## Deploy Plan

- Deploy connectors.
