### PR TITLE
[core] Fix off-by-one index error in `delete_orphaned_points`

### DIFF
--- a/core/bin/qdrant/delete_orphaned_points.rs
+++ b/core/bin/qdrant/delete_orphaned_points.rs
@@ -106,7 +106,7 @@ async fn main() -> Result<()> {
     if args.len() < 2 {
         return Err(anyhow!("Usage: {} <csv_file>", args[0]));
     }
-    let col_offset = if args.len() >= 3 && args[3] == "--skip-date-column" {
+    let col_offset = if args.len() >= 3 && args[2] == "--skip-date-column" {
         1
     } else {
         0


### PR DESCRIPTION
## Description

- This PR fixes an old mistake on the parsing of the arguments of the `delete_orphaned_points` script.

## Tests

- Tested.

## Risk

## Deploy Plan

- No deploy
