### PR TITLE
Add day of week to gcalendar events

### DIFF
--- a/front/lib/actions/mcp_internal_actions/servers/google_calendar.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/google_calendar.ts
@@ -552,9 +552,23 @@ const createServer = (agentLoopContext?: AgentLoopContextType): McpServer => {
 
     // Find the latest user message to get the timezone
     for (let i = content.length - 1; i >= 0; i--) {
-      const message = content[i]?.find((msg) => msg.type === "user_message");
-      if (message?.context?.timezone) {
-        return message.context.timezone;
+      const contentBlock = content[i];
+      if (Array.isArray(contentBlock)) {
+        const userMessage = contentBlock.find(
+          (msg) =>
+            msg.type === "user_message" &&
+            "context" in msg &&
+            msg.context &&
+            "timezone" in msg.context
+        );
+        if (
+          userMessage &&
+          "context" in userMessage &&
+          userMessage.context &&
+          "timezone" in userMessage.context
+        ) {
+          return userMessage.context.timezone;
+        }
       }
     }
 

--- a/front/lib/actions/mcp_internal_actions/servers/index.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/index.ts
@@ -143,7 +143,7 @@ export async function getInternalMCPServer(
     case "gmail":
       return gmailServer();
     case "google_calendar":
-      return calendarServer();
+      return calendarServer(agentLoopContext);
     case "google_drive":
       return driveServer();
     case "google_sheets":


### PR DESCRIPTION
## Description

* https://github.com/dust-tt/tasks/issues/4354
* Looks like examples of LLM not being able to map day of week to date. Adding info in response to mitigate that risk
* Decreasing amount of information returned from list tool

## Tests

* Validated locally

## Risk

* Minimal

## Deploy Plan

* Deploy front