### PR TITLE
[front] enh(triggeres): Improve error bubbling up

### DIFF
--- a/front/temporal/agent_schedule/activities.ts
+++ b/front/temporal/agent_schedule/activities.ts
@@ -144,6 +144,7 @@ async function createConversationForAgentConfiguration({
         conversationId: newConversation.sId,
         error: messageRes.error,
         triggerId: trigger.sId,
+        workspaceId: auth.workspace()?.sId,
       },
       "scheduledAgentCallActivity: Error sending message."
     );

--- a/front/temporal/agent_schedule/activities.ts
+++ b/front/temporal/agent_schedule/activities.ts
@@ -138,6 +138,15 @@ async function createConversationForAgentConfiguration({
   });
 
   if (messageRes.isErr()) {
+    logger.error(
+      {
+        agentConfigurationId: trigger.agentConfigurationId,
+        conversationId: newConversation.sId,
+        error: messageRes.error,
+        triggerId: trigger.sId,
+      },
+      "scheduledAgentCallActivity: Error sending message."
+    );
     return messageRes;
   }
 


### PR DESCRIPTION
## Description

- This PR aims at improving how errors in `createConversationForAgentConfiguration` are surfaced (current [logs](https://app.datadoghq.eu/logs?query=%28%22Activity%20failed%22%20OR%20%22Unhandled%20activity%20error%22%29%20%40attempt%3A%3E15%20%40dd.service%3Afront-worker%20region%3Aus-central1&agg_m=count&agg_m_source=base&agg_t=count&cols=host%2Cservice&event=AwAAAZmEqlmOuJrcPgAAABhBWm1FcW10a0FBREs4Uk5rd096SzZnQUQAAAAkMDE5OTg0YWEtNzllZi00MDNkLTg1ZTctMGJiMDVmNWU5Y2Y5AAcAug&fromUser=true&link_source=monitor_notif&messageDisplay=inline&refresh_mode=sliding&storage=hot&stream_sort=desc&viz=stream&from_ts=1758863804000&to_ts=1758867404000&live=false)).
- It also prevents a `TriggerType` from being logged as is.

## Tests

## Risk

- Low.

## Deploy Plan

- Deploy front.
