### PR TITLE
[PQ] Loading block dark mode 

### DIFF
--- a/sparkle/src/components/LoadingBlock.tsx
+++ b/sparkle/src/components/LoadingBlock.tsx
@@ -10,7 +10,7 @@ function LoadingBlock({
     <div
       className={cn(
         "s-animate-opacity-pulse s-rounded-md",
-        "s-bg-muted dark:s-bg-muted-night",
+        "s-bg-muted dark:s-bg-muted-background-night",
         className
       )}
       {...props}


### PR DESCRIPTION
## Description

This PR updates the loading block dark mode color to be visible :

<img width="910" height="232" alt="image" src="https://github.com/user-attachments/assets/4655f6eb-3011-4da4-bf9e-b0f9485b4a21" />

## Tests

-

## Risk

low

## Deploy Plan

sparkle
