### PR TITLE
feat(front): add gpt5-thinking agent, and nano, and mini

### DIFF
--- a/front/lib/api/assistant/global_agents/configurations/openai.ts
+++ b/front/lib/api/assistant/global_agents/configurations/openai.ts
@@ -15,7 +15,9 @@ import {
   GLOBAL_AGENTS_SID,
   GPT_3_5_TURBO_MODEL_CONFIG,
   GPT_4_1_MODEL_CONFIG,
+  GPT_5_MINI_MODEL_CONFIG,
   GPT_5_MODEL_CONFIG,
+  GPT_5_NANO_MODEL_CONFIG,
   MAX_STEPS_USE_PER_RUN_LIMIT,
   O1_MINI_MODEL_CONFIG,
   O1_MODEL_CONFIG,
@@ -162,6 +164,71 @@ export function _getGPT5GlobalAgent({
     description: metadata.description,
     instructions:
       `${globalAgentGuidelines}\n${globalAgentWebSearchGuidelines}\n` +
+      "Keep the search depth low and aim to provide an answer quickly, with a maximum of 3 steps of tool use.",
+    pictureUrl: metadata.pictureUrl,
+    status,
+    scope: "global",
+    userFavorite: false,
+    model: {
+      providerId: GPT_5_MODEL_CONFIG.providerId,
+      modelId: GPT_5_MODEL_CONFIG.modelId,
+      temperature: 0.7,
+      /**
+       * WARNING: Because the default in ChatGPT is no reasoning, we do the same
+       */
+      reasoningEffort: "none",
+    },
+    actions: [
+      ..._getDefaultWebActionsForGlobalAgent({
+        agentId: sId,
+        webSearchBrowseMCPServerView,
+      }),
+    ],
+    maxStepsPerRun: MAX_STEPS_USE_PER_RUN_LIMIT,
+    visualizationEnabled: true,
+    templateId: null,
+    requestedGroupIds: [],
+    tags: [],
+    canRead: true,
+    canEdit: false,
+  };
+}
+
+/**
+ * GPT5 thinking, is gpt5 with reasoning enabled
+ * In chatGPT the default is no reasoning, so we do the same!
+ */
+export function _getGPT5ThinkingGlobalAgent({
+  auth,
+  settings,
+  webSearchBrowseMCPServerView,
+}: {
+  auth: Authenticator;
+  settings: GlobalAgentSettings | null;
+  webSearchBrowseMCPServerView: MCPServerViewResource | null;
+}): AgentConfigurationType {
+  let status: AgentConfigurationStatus = "active";
+
+  if (settings) {
+    status = settings.status;
+  }
+  if (!auth.isUpgraded()) {
+    status = "disabled_free_workspace";
+  }
+
+  const sId = GLOBAL_AGENTS_SID.GPT5_THINKING;
+  const metadata = getGlobalAgentMetadata(sId);
+
+  return {
+    id: -1,
+    sId,
+    version: 0,
+    versionCreatedAt: null,
+    versionAuthorId: null,
+    name: metadata.name,
+    description: metadata.description,
+    instructions:
+      `${globalAgentGuidelines}\n${globalAgentWebSearchGuidelines}\n` +
       "Unless the user explicitly requests deeper research, keep the search depth low and" +
       " aim to provide an answer quickly, with a maximum of 3 steps of tool use.",
     pictureUrl: metadata.pictureUrl,
@@ -189,6 +256,124 @@ export function _getGPT5GlobalAgent({
     canEdit: false,
   };
 }
+
+export function _getGPT5MiniGlobalAgent({
+  auth,
+  settings,
+  webSearchBrowseMCPServerView,
+}: {
+  auth: Authenticator;
+  settings: GlobalAgentSettings | null;
+  webSearchBrowseMCPServerView: MCPServerViewResource | null;
+}): AgentConfigurationType {
+  let status: AgentConfigurationStatus = "active";
+
+  if (settings) {
+    status = settings.status;
+  }
+  if (!auth.isUpgraded()) {
+    status = "disabled_free_workspace";
+  }
+
+  const sId = GLOBAL_AGENTS_SID.GPT5_MINI;
+  const metadata = getGlobalAgentMetadata(sId);
+
+  return {
+    id: -1,
+    sId,
+    version: 0,
+    versionCreatedAt: null,
+    versionAuthorId: null,
+    name: metadata.name,
+    description: metadata.description,
+    instructions:
+      `${globalAgentGuidelines}\n${globalAgentWebSearchGuidelines}\n` +
+      "Unless the user explicitly requests deeper research, keep the search depth low and" +
+      " aim to provide an answer quickly, with a maximum of 3 steps of tool use.",
+    pictureUrl: metadata.pictureUrl,
+    status,
+    scope: "global",
+    userFavorite: false,
+    model: {
+      providerId: GPT_5_MINI_MODEL_CONFIG.providerId,
+      modelId: GPT_5_MINI_MODEL_CONFIG.modelId,
+      temperature: 0.7,
+      reasoningEffort: GPT_5_MINI_MODEL_CONFIG.defaultReasoningEffort,
+    },
+    actions: [
+      ..._getDefaultWebActionsForGlobalAgent({
+        agentId: sId,
+        webSearchBrowseMCPServerView,
+      }),
+    ],
+    maxStepsPerRun: MAX_STEPS_USE_PER_RUN_LIMIT,
+    visualizationEnabled: true,
+    templateId: null,
+    requestedGroupIds: [],
+    tags: [],
+    canRead: true,
+    canEdit: false,
+  };
+}
+export function _getGPT5NanoGlobalAgent({
+  auth,
+  settings,
+  webSearchBrowseMCPServerView,
+}: {
+  auth: Authenticator;
+  settings: GlobalAgentSettings | null;
+  webSearchBrowseMCPServerView: MCPServerViewResource | null;
+}): AgentConfigurationType {
+  let status: AgentConfigurationStatus = "active";
+
+  if (settings) {
+    status = settings.status;
+  }
+  if (!auth.isUpgraded()) {
+    status = "disabled_free_workspace";
+  }
+
+  const sId = GLOBAL_AGENTS_SID.GPT5_NANO;
+  const metadata = getGlobalAgentMetadata(sId);
+
+  return {
+    id: -1,
+    sId,
+    version: 0,
+    versionCreatedAt: null,
+    versionAuthorId: null,
+    name: metadata.name,
+    description: metadata.description,
+    instructions:
+      `${globalAgentGuidelines}\n${globalAgentWebSearchGuidelines}\n` +
+      "Unless the user explicitly requests deeper research, keep the search depth low and" +
+      " aim to provide an answer quickly, with a maximum of 3 steps of tool use.",
+    pictureUrl: metadata.pictureUrl,
+    status,
+    scope: "global",
+    userFavorite: false,
+    model: {
+      providerId: GPT_5_NANO_MODEL_CONFIG.providerId,
+      modelId: GPT_5_NANO_MODEL_CONFIG.modelId,
+      temperature: 0.7,
+      reasoningEffort: GPT_5_NANO_MODEL_CONFIG.defaultReasoningEffort,
+    },
+    actions: [
+      ..._getDefaultWebActionsForGlobalAgent({
+        agentId: sId,
+        webSearchBrowseMCPServerView,
+      }),
+    ],
+    maxStepsPerRun: MAX_STEPS_USE_PER_RUN_LIMIT,
+    visualizationEnabled: true,
+    templateId: null,
+    requestedGroupIds: [],
+    tags: [],
+    canRead: true,
+    canEdit: false,
+  };
+}
+
 export function _getO3MiniGlobalAgent({
   auth,
   settings,

--- a/front/lib/api/assistant/global_agents/global_agent_metadata.ts
+++ b/front/lib/api/assistant/global_agents/global_agent_metadata.ts
@@ -11,7 +11,9 @@ import {
   GLOBAL_AGENTS_SID,
   GPT_3_5_TURBO_MODEL_CONFIG,
   GPT_4_1_MODEL_CONFIG,
+  GPT_5_MINI_MODEL_CONFIG,
   GPT_5_MODEL_CONFIG,
+  GPT_5_NANO_MODEL_CONFIG,
   MISTRAL_LARGE_MODEL_CONFIG,
   MISTRAL_MEDIUM_MODEL_CONFIG,
   MISTRAL_SMALL_MODEL_CONFIG,
@@ -56,6 +58,27 @@ export function getGlobalAgentMetadata(sId: GLOBAL_AGENTS_SID): AgentMetadata {
         sId: GLOBAL_AGENTS_SID.GPT5,
         name: "gpt5",
         description: GPT_5_MODEL_CONFIG.description,
+        pictureUrl: "https://dust.tt/static/systemavatar/gpt5_avatar_full.png",
+      };
+    case GLOBAL_AGENTS_SID.GPT5_THINKING:
+      return {
+        sId: GLOBAL_AGENTS_SID.GPT5_THINKING,
+        name: "gpt5-thinking",
+        description: GPT_5_MINI_MODEL_CONFIG.description,
+        pictureUrl: "https://dust.tt/static/systemavatar/gpt5_avatar_full.png",
+      };
+    case GLOBAL_AGENTS_SID.GPT5_NANO:
+      return {
+        sId: GLOBAL_AGENTS_SID.GPT5_NANO,
+        name: "gpt5-nano",
+        description: GPT_5_NANO_MODEL_CONFIG.description,
+        pictureUrl: "https://dust.tt/static/systemavatar/gpt5_avatar_full.png",
+      };
+    case GLOBAL_AGENTS_SID.GPT5_MINI:
+      return {
+        sId: GLOBAL_AGENTS_SID.GPT5_MINI,
+        name: "gpt5-mini",
+        description: GPT_5_MINI_MODEL_CONFIG.description,
         pictureUrl: "https://dust.tt/static/systemavatar/gpt5_avatar_full.png",
       };
     case GLOBAL_AGENTS_SID.O1:

--- a/front/lib/api/assistant/global_agents/global_agents.ts
+++ b/front/lib/api/assistant/global_agents/global_agents.ts
@@ -29,6 +29,9 @@ import {
 import {
   _getGPT4GlobalAgent,
   _getGPT5GlobalAgent,
+  _getGPT5MiniGlobalAgent,
+  _getGPT5NanoGlobalAgent,
+  _getGPT5ThinkingGlobalAgent,
   _getGPT35TurboGlobalAgent,
   _getO1GlobalAgent,
   _getO1HighReasoningGlobalAgent,
@@ -138,6 +141,27 @@ function getGlobalAgent({
       break;
     case GLOBAL_AGENTS_SID.GPT5:
       agentConfiguration = _getGPT5GlobalAgent({
+        auth,
+        settings,
+        webSearchBrowseMCPServerView,
+      });
+      break;
+    case GLOBAL_AGENTS_SID.GPT5_NANO:
+      agentConfiguration = _getGPT5NanoGlobalAgent({
+        auth,
+        settings,
+        webSearchBrowseMCPServerView,
+      });
+      break;
+    case GLOBAL_AGENTS_SID.GPT5_MINI:
+      agentConfiguration = _getGPT5MiniGlobalAgent({
+        auth,
+        settings,
+        webSearchBrowseMCPServerView,
+      });
+      break;
+    case GLOBAL_AGENTS_SID.GPT5_THINKING:
+      agentConfiguration = _getGPT5ThinkingGlobalAgent({
         auth,
         settings,
         webSearchBrowseMCPServerView,

--- a/front/types/assistant/assistant.ts
+++ b/front/types/assistant/assistant.ts
@@ -1670,6 +1670,9 @@ export enum GLOBAL_AGENTS_SID {
   GPT35_TURBO = "gpt-3.5-turbo",
   GPT4 = "gpt-4",
   GPT5 = "gpt-5",
+  GPT5_THINKING = "gpt-5-thinking",
+  GPT5_NANO = "gpt-5-nano",
+  GPT5_MINI = "gpt-5-mini",
   O1 = "o1",
   O1_MINI = "o1-mini",
   O1_HIGH_REASONING = "o1_high",
@@ -1700,6 +1703,9 @@ export function getGlobalAgentAuthorName(agentId: string): string {
   switch (agentId) {
     case GLOBAL_AGENTS_SID.GPT4:
     case GLOBAL_AGENTS_SID.GPT5:
+    case GLOBAL_AGENTS_SID.GPT5_THINKING:
+    case GLOBAL_AGENTS_SID.GPT5_NANO:
+    case GLOBAL_AGENTS_SID.GPT5_MINI:
     case GLOBAL_AGENTS_SID.O1:
     case GLOBAL_AGENTS_SID.O1_MINI:
     case GLOBAL_AGENTS_SID.O1_HIGH_REASONING:


### PR DESCRIPTION
## Description

1. Move gpt5 agent to using gtp5 without reasoning
2. Add gpt5-thinking agent using gpt-5 _with_ reasoning
3. Add gpt5-nano agent using gpt-5-nano
4. Add gpt5-mini agent using gpt-5-mini

1) and 2) is done because the default model in chatGPT is mini, as it's fastest

## Tests

Locally


## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
