### PR TITLE
[Stop Agent] Fix: don't show "stop all" if there's a single agent

### DIFF
--- a/front/components/assistant/conversation/AgentMessage.tsx
+++ b/front/components/assistant/conversation/AgentMessage.tsx
@@ -253,10 +253,13 @@ export function AgentMessage({
       (m) => m.messageId === message.sId
     );
     if (agentMessageToRender.status === "created" && !isInArray) {
-      generationContext.setGeneratingMessages((s) => [
-        ...s,
-        { messageId: message.sId, conversationId },
-      ]);
+      generationContext.setGeneratingMessages((s) =>
+        // Re-check if the message is already in the array since there may be
+        // a race condition on the update (double call of useEffect).
+        s.some((m) => m.messageId === message.sId)
+          ? s
+          : [...s, { messageId: message.sId, conversationId }]
+      );
     } else if (agentMessageToRender.status !== "created" && isInArray) {
       generationContext.setGeneratingMessages((s) =>
         s.filter((m) => m.messageId !== message.sId)


### PR DESCRIPTION
Description
---
Fixes [this](https://dust4ai.slack.com/archives/C09GAQP6T1R/p1758872777392649)

We observed in rare cases that "Stop all agents" show while there's only one agent mentioned.

This likely comes from a race condition in the update of generated messages in the useEffect, which this PR fixes.

The first array check avoids unnecessary calls to setGeneratingMessages so we keep it.

Risks
---
none

Deploy
---
front
