### PR TITLE
[front] enh(data-retention): add heartbeat + batching, increase STC

### DIFF
--- a/front/temporal/data_retention/workflows.ts
+++ b/front/temporal/data_retention/workflows.ts
@@ -16,7 +16,8 @@ const {
   purgeConversationsBatchActivity,
   purgeAgentConversationsBatchActivity,
 } = proxyActivities<typeof activities>({
-  startToCloseTimeout: "15 minutes",
+  startToCloseTimeout: "30 minutes",
+  heartbeatTimeout: "5 minutes",
 });
 
 export async function dataRetentionWorkflow(): Promise<void> {


### PR DESCRIPTION
## Description

- This PR increasers the start to close timeout for the data retention policy activities and adds heartbeating (added batching we heartbeat around).
- We had some error with the activity start-to-close timing out.
- This also fixes a hypothetical bug if there were more than 1000 (default batch size in `listAllBeforeDate`) conversations to delete, which is actually fixed on the next workflow (unless more than 1k conversations were created in a day theoretically).

## Tests

- Ran locally.

## Risk

- No logic change except in processing order.

## Deploy Plan

- Deploy front.
