### PR TITLE
feat(front): clean up pasted html so it matches our styles

### DIFF
--- a/front/components/assistant/conversation/input_bar/editor/cleanupPastedHTML.ts
+++ b/front/components/assistant/conversation/input_bar/editor/cleanupPastedHTML.ts
@@ -1,0 +1,86 @@
+import type { Config } from "dompurify";
+import DOMPurify from "dompurify";
+
+// Minimal, conservative allowlist.
+const SANITIZE_CONFIG: Config = {
+  // Allow common text containers and formatting
+  ALLOWED_TAGS: [
+    "a",
+    "p",
+    "br",
+    "div",
+    "span",
+    "b",
+    "strong",
+    "i",
+    "em",
+    "u",
+    "s",
+    "sub",
+    "sup",
+    "blockquote",
+    "pre",
+    "code",
+    "hr",
+    "ul",
+    "ol",
+    "li",
+    "h1",
+    "h2",
+    "h3",
+    "h4",
+    "h5",
+    "h6",
+  ],
+
+  // IMPORTANT: don't set ALLOWED_ATTR here.
+  // Let DOMPurify use its safe defaults and explicitly allow data-* below.
+  ALLOW_DATA_ATTR: true,
+
+  // Strip dangerous containers entirely
+  FORBID_TAGS: [
+    "script",
+    "style",
+    "template",
+    "iframe",
+    "object",
+    "embed",
+    "link",
+    "meta",
+    "form",
+    "input",
+    "button",
+    "textarea",
+    "select",
+    "option",
+    "video",
+    "audio",
+    "svg",
+    "math",
+    "base",
+  ],
+
+  // Remove styling/identifiers
+  FORBID_ATTR: ["style", "class", "id"],
+
+  // Keep text if unexpected wrappers appear
+  KEEP_CONTENT: true,
+
+  // Don't remove mustache-like text; leave templates alone
+  SAFE_FOR_TEMPLATES: false,
+
+  WHOLE_DOCUMENT: false,
+  RETURN_TRUSTED_TYPE: false,
+};
+
+export function cleanupPastedHTML(html: string): string {
+  try {
+    // DOMPurify sanitizes without executing anything; returns a safe string.
+    return DOMPurify.sanitize(html, SANITIZE_CONFIG);
+  } catch {
+    // Secure fallback: return a text-only version (HTML-escaped), never the original unsanitized HTML.
+    const temp = document.createElement("div");
+    temp.textContent = html ?? "";
+    return temp.innerHTML;
+  }
+}

--- a/front/package-lock.json
+++ b/front/package-lock.json
@@ -62,6 +62,7 @@
         "date-fns": "^3.6.0",
         "dd-trace": "^5.52.0",
         "diff": "^7.0.0",
+        "dompurify": "^3.2.7",
         "embla-carousel-react": "^8.0.1",
         "eventsource-parser": "^1.0.0",
         "fast-diff": "^1.3.0",
@@ -13581,9 +13582,10 @@
       }
     },
     "node_modules/dompurify": {
-      "version": "3.2.6",
-      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.2.6.tgz",
-      "integrity": "sha512-/2GogDQlohXPZe6D6NOgQvXLPSYBqIWMnZ8zzOhn09REE4eyAzb+Hed3jhoM9OkuaJ8P6ZGTTVWQKAi8ieIzfQ==",
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.2.7.tgz",
+      "integrity": "sha512-WhL/YuveyGXJaerVlMYGWhvQswa7myDG17P7Vu65EWC05o8vfeNbvNf4d/BOvH99+ZW+LlQsc1GDKMa1vNK6dw==",
+      "license": "(MPL-2.0 OR Apache-2.0)",
       "optionalDependencies": {
         "@types/trusted-types": "^2.0.7"
       }

--- a/front/package.json
+++ b/front/package.json
@@ -40,6 +40,7 @@
     "@radix-ui/react-dialog": "^1.0.5",
     "@radix-ui/react-label": "^2.0.2",
     "@radix-ui/react-navigation-menu": "^1.1.4",
+    "dompurify": "^3.2.7",
     "@radix-ui/react-scroll-area": "^1.0.5",
     "@radix-ui/react-select": "^2.0.0",
     "@radix-ui/react-slot": "^1.0.2",


### PR DESCRIPTION
## Description

When we paste HTML from other sources it keeps the original style, which can have an impact if it's the same class names. 

This adds a cleaning paste html plugin for tiptap, it's inspired from: https://www.linkedin.com/pulse/struggling-pasting-tiptap-editor-heres-how-fix-khoshbayan-m-sc--lnale

https://github.com/user-attachments/assets/9db30962-dbb6-4ac5-bf67-d710d0804202


## Tests

I've tried copying:
* mention
* multiple mentions
* text
* data source links

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
