### PR TITLE
[connectors] enh(Confluence): remove deleted spaces from connectors db

### DIFF
--- a/connectors/src/connectors/confluence/temporal/activities.ts
+++ b/connectors/src/connectors/confluence/temporal/activities.ts
@@ -592,6 +592,14 @@ export async function confluenceRemoveSpaceActivity(
     dataSourceConfig,
     folderId: makeSpaceInternalId(spaceId),
   });
+
+  // Deleting the space to omit it from subsequent syncs.
+  await ConfluenceSpace.destroy({
+    where: {
+      connectorId,
+      spaceId,
+    },
+  });
 }
 
 export async function fetchConfluenceSpaceIdsForConnectorActivity({


### PR DESCRIPTION
## Description

- This PR removes delete Confluence spaces from connectors db, removing it from subsequent syncs.
- This deletion happens at the end of the space deletion workflow, which is triggered when we can't find a space.
- Important note: by the time we get 404 on Confluence API the space won't appear in the `ConnectorsPermissionsModel` for the end user and stops existing for them then. So the entry in our db really doesn't do anything apart from being retried on every sync, which will cause it to magically reappear as selected if it's reachable again. With this change the customer has to reselect the space if we regain access to it.

## Tests

- Tested the regular sync locally.

## Risk

- If we do sporadically lose and regain access to spaces it will cause it do be unselected for the user.

## Deploy Plan

- Deploy connectors.
