### PR TITLE
[sparkle] triggerAsChild props is not valid

### DIFF
--- a/front/components/NodePathTooltip.tsx
+++ b/front/components/NodePathTooltip.tsx
@@ -46,7 +46,6 @@ export function NodePathTooltip({
     >
       <Tooltip
         tooltipTriggerAsChild
-        triggerAsChild
         label={
           isLoading ? (
             <div className="flex gap-1 text-xs text-muted-foreground dark:text-muted-foreground-night">

--- a/sparkle/src/components/Avatar.tsx
+++ b/sparkle/src/components/Avatar.tsx
@@ -246,6 +246,7 @@ interface AvatarStackProps {
   size?: AvatarStackSizeType;
   isRounded?: boolean;
   hasMagnifier?: boolean;
+  tooltipTriggerAsChild?: boolean;
 }
 
 const sizeClassesPx: Record<AvatarStackSizeType, number> = {
@@ -260,6 +261,7 @@ Avatar.Stack = function ({
   size = "sm",
   isRounded = false,
   hasMagnifier = true,
+  tooltipTriggerAsChild = false,
 }: AvatarStackProps) {
   const [isHovered, setIsHovered] = useState(false);
 
@@ -299,7 +301,7 @@ Avatar.Stack = function ({
   return (
     <Tooltip
       label={tooltipLabel}
-      tooltipTriggerAsChild
+      tooltipTriggerAsChild={tooltipTriggerAsChild}
       trigger={
         <>
           <div

--- a/sparkle/src/components/Avatar.tsx
+++ b/sparkle/src/components/Avatar.tsx
@@ -299,7 +299,7 @@ Avatar.Stack = function ({
   return (
     <Tooltip
       label={tooltipLabel}
-      triggerAsChild
+      tooltipTriggerAsChild
       trigger={
         <>
           <div

--- a/sparkle/src/components/Tooltip.tsx
+++ b/sparkle/src/components/Tooltip.tsx
@@ -77,7 +77,6 @@ interface TooltipProps extends TooltipContentProps {
   trigger: React.ReactNode;
   tooltipTriggerAsChild?: boolean;
   label: React.ReactNode;
-  triggerAsChild?: boolean;
 }
 
 const Tooltip = React.forwardRef<HTMLDivElement, TooltipProps>(


### PR DESCRIPTION
## Description

- [Tooltip] Remove unused triggerAsChild props
- [Avatar.Stack] Use valid tooltipTriggerAsChild props instead

## Tests

Storybook

## Risk

Low

## Deploy Plan

Deploy Sparkle