### PR TITLE
Slack: prevent future timestamp on folder associated to channel

### DIFF
--- a/connectors/src/connectors/slack/temporal/workflows.ts
+++ b/connectors/src/connectors/slack/temporal/workflows.ts
@@ -285,7 +285,8 @@ export async function syncOneMessageDebounced(
     await getSlackActivities().syncChannelMetadata(
       connectorId,
       channelId,
-      endTsMs
+      // endTsMs can be in the future so we cap it to now for the channel metadata.
+      Math.min(new Date().getTime(), endTsMs)
     );
 
     await getSlackActivities().syncNonThreaded({


### PR DESCRIPTION
## Description

Fixes: https://github.com/dust-tt/tasks/issues/4335

Avoid future "timestamps" in core for channels with unthread messages.

## Tests

N/A

## Risk

Low

## Deploy Plan

- deploy `connectors`