### PR TITLE
feat(sparkle): export markdown header sizes

### DIFF
--- a/sparkle/src/components/markdown/Markdown.tsx
+++ b/sparkle/src/components/markdown/Markdown.tsx
@@ -27,14 +27,18 @@ import {
 import { sanitizeContent } from "@sparkle/components/markdown/utils";
 import { cn } from "@sparkle/lib/utils";
 
-const sizes = {
-  p: "s-copy-sm @sm:s-text-base @sm:s-leading-7",
+export const markdownHeaderClasses = {
   h1: "s-heading-2xl",
   h2: "s-heading-xl",
   h3: "s-heading-lg",
   h4: "s-text-base s-font-semibold",
   h5: "s-text-sm s-font-semibold",
   h6: "s-text-sm s-font-regular s-italic",
+};
+
+const sizes = {
+  p: "s-copy-sm @sm:s-text-base @sm:s-leading-7",
+  ...markdownHeaderClasses,
 };
 
 function showUnsupportedDirective() {


### PR DESCRIPTION
## Description

I want to reuse the markdown header classes in the code, so I need to export them, see next PR

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
