### PR TITLE
feat(front): have different sizes for headers in the agent builder

### DIFF
--- a/connectors/package-lock.json
+++ b/connectors/package-lock.json
@@ -97,7 +97,7 @@
     },
     "../sdks/js": {
       "name": "@dust-tt/client",
-      "version": "1.1.16",
+      "version": "1.1.17",
       "bundleDependencies": [
         "@modelcontextprotocol/sdk"
       ],

--- a/extension/package-lock.json
+++ b/extension/package-lock.json
@@ -12,7 +12,7 @@
         "@auth0/auth0-spa-js": "^2.1.3",
         "@datadog/browser-logs": "^6.13.0",
         "@dust-tt/client": "^1.1.15",
-        "@dust-tt/sparkle": "^0.2.637",
+        "@dust-tt/sparkle": "^0.2.642",
         "@frontapp/plugin-sdk": "^1.8.1",
         "@modelcontextprotocol/sdk": "^1.9.0",
         "@tailwindcss/forms": "^0.5.9",
@@ -1293,9 +1293,9 @@
       }
     },
     "node_modules/@dust-tt/sparkle": {
-      "version": "0.2.637",
-      "resolved": "https://registry.npmjs.org/@dust-tt/sparkle/-/sparkle-0.2.637.tgz",
-      "integrity": "sha512-kewIlSBw/JadsJqOnow2P5TglsbY6rjNReu4omOc5Y4NQTKPwd5nP8R3d51xbD9ewmWf53zTgJmGiQjsUSQF9Q==",
+      "version": "0.2.642",
+      "resolved": "https://registry.npmjs.org/@dust-tt/sparkle/-/sparkle-0.2.642.tgz",
+      "integrity": "sha512-2BVATnEWwUTEemxYbBlKnmiWaYts7rXCODJlB/bpcnq01EPhZCqJfoxRPPev7rKVWViOQyqM85gilwhgx4Veuw==",
       "license": "ISC",
       "dependencies": {
         "@emoji-mart/data": "^1.1.2",

--- a/extension/package.json
+++ b/extension/package.json
@@ -59,7 +59,7 @@
     "@auth0/auth0-spa-js": "^2.1.3",
     "@datadog/browser-logs": "^6.13.0",
     "@dust-tt/client": "^1.1.15",
-    "@dust-tt/sparkle": "^0.2.637",
+    "@dust-tt/sparkle": "^0.2.642",
     "@frontapp/plugin-sdk": "^1.8.1",
     "@modelcontextprotocol/sdk": "^1.9.0",
     "@tailwindcss/forms": "^0.5.9",

--- a/front/components/agent_builder/instructions/AgentBuilderInstructionsEditor.tsx
+++ b/front/components/agent_builder/instructions/AgentBuilderInstructionsEditor.tsx
@@ -15,6 +15,7 @@ import type { AgentBuilderFormData } from "@app/components/agent_builder/AgentBu
 import { BlockInsertDropdown } from "@app/components/agent_builder/instructions/BlockInsertDropdown";
 import { AgentInstructionDiffExtension } from "@app/components/agent_builder/instructions/extensions/AgentInstructionDiffExtension";
 import { BlockInsertExtension } from "@app/components/agent_builder/instructions/extensions/BlockInsertExtension";
+import { HeadingExtension } from "@app/components/agent_builder/instructions/extensions/HeadingExtension";
 import { InstructionBlockExtension } from "@app/components/agent_builder/instructions/extensions/InstructionBlockExtension";
 import { InstructionTipsPopover } from "@app/components/agent_builder/instructions/InstructionsTipsPopover";
 import { useBlockInsertDropdown } from "@app/components/agent_builder/instructions/useBlockInsertDropdown";
@@ -78,12 +79,7 @@ export function AgentBuilderInstructionsEditor({
     return [
       StarterKit.configure({
         paragraph: false, // We use custom ParagraphExtension
-        heading: {
-          levels: [1, 2, 3, 4, 5, 6],
-          HTMLAttributes: {
-            class: "text-xl font-semibold mt-4 mb-3",
-          },
-        },
+        heading: false,
         bulletList: false,
         orderedList: false,
         listItem: false,
@@ -115,6 +111,12 @@ export function AgentBuilderInstructionsEditor({
       }),
       CharacterCount.configure({
         limit: INSTRUCTIONS_MAXIMUM_CHARACTER_COUNT,
+      }),
+      HeadingExtension.configure({
+        levels: [1, 2, 3, 4, 5, 6],
+        HTMLAttributes: {
+          class: "mt-4 mb-3",
+        },
       }),
     ];
   }, [suggestionHandler]);

--- a/front/components/agent_builder/instructions/extensions/HeadingExtension.ts
+++ b/front/components/agent_builder/instructions/extensions/HeadingExtension.ts
@@ -1,0 +1,27 @@
+import { markdownHeaderClasses } from "@dust-tt/sparkle";
+import { mergeAttributes } from "@tiptap/core";
+import { Heading } from "@tiptap/extension-heading";
+
+export const HeadingExtension = Heading.extend({
+  levels: [1, 2, 3, 4, 5, 6],
+  renderHTML({ node, HTMLAttributes }) {
+    const level = this.options.levels.includes(node.attrs.level)
+      ? node.attrs.level
+      : this.options.levels[0];
+    const classes: { [index: number]: string } = {
+      1: markdownHeaderClasses.h1,
+      2: markdownHeaderClasses.h2,
+      3: markdownHeaderClasses.h3,
+      4: markdownHeaderClasses.h4,
+      5: markdownHeaderClasses.h5,
+      6: markdownHeaderClasses.h6,
+    };
+    return [
+      `h${level}`,
+      mergeAttributes(this.options.HTMLAttributes, HTMLAttributes, {
+        class: `${classes[level]}`,
+      }),
+      0,
+    ];
+  },
+});

--- a/front/package-lock.json
+++ b/front/package-lock.json
@@ -7,7 +7,7 @@
       "dependencies": {
         "@datadog/browser-logs": "^6.13.0",
         "@dust-tt/client": "file:../sdks/js",
-        "@dust-tt/sparkle": "^0.2.637",
+        "@dust-tt/sparkle": "^0.2.642",
         "@google-cloud/bigquery": "^7.9.1",
         "@google-cloud/storage-transfer": "^3.6.0",
         "@heroicons/react": "^2.0.11",
@@ -1150,9 +1150,9 @@
       "link": true
     },
     "node_modules/@dust-tt/sparkle": {
-      "version": "0.2.637",
-      "resolved": "https://registry.npmjs.org/@dust-tt/sparkle/-/sparkle-0.2.637.tgz",
-      "integrity": "sha512-kewIlSBw/JadsJqOnow2P5TglsbY6rjNReu4omOc5Y4NQTKPwd5nP8R3d51xbD9ewmWf53zTgJmGiQjsUSQF9Q==",
+      "version": "0.2.642",
+      "resolved": "https://registry.npmjs.org/@dust-tt/sparkle/-/sparkle-0.2.642.tgz",
+      "integrity": "sha512-2BVATnEWwUTEemxYbBlKnmiWaYts7rXCODJlB/bpcnq01EPhZCqJfoxRPPev7rKVWViOQyqM85gilwhgx4Veuw==",
       "license": "ISC",
       "dependencies": {
         "@emoji-mart/data": "^1.1.2",

--- a/front/package.json
+++ b/front/package.json
@@ -28,7 +28,7 @@
   "dependencies": {
     "@datadog/browser-logs": "^6.13.0",
     "@dust-tt/client": "file:../sdks/js",
-    "@dust-tt/sparkle": "^0.2.637",
+    "@dust-tt/sparkle": "^0.2.642",
     "@google-cloud/bigquery": "^7.9.1",
     "@google-cloud/storage-transfer": "^3.6.0",
     "@heroicons/react": "^2.0.11",

--- a/tools/npm-install-all-projects.sh
+++ b/tools/npm-install-all-projects.sh
@@ -4,6 +4,7 @@ set -euo pipefail
 
 (cd front && npm install)
 (cd connectors && npm install)
+(cd extension && npm install)
 (cd sdks/js && npm install)
 (cd sparkle && npm install)
 


### PR DESCRIPTION
## Description

Now that we have the right CSS classes for the markdown headers in sparkle, we can pass them to tiptap
## Tests

<img width="760" height="388" alt="image" src="https://github.com/user-attachments/assets/f404c592-6edd-4eb0-8d75-010d3fc00975" />


## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
