### PR TITLE
Add agentMessage completedAt nullable column

### DIFF
--- a/front/lib/models/assistant/conversation.ts
+++ b/front/lib/models/assistant/conversation.ts
@@ -304,6 +304,8 @@ export class AgentMessage extends WorkspaceAwareModel<AgentMessage> {
   declare agentStepContents?: NonAttribute<AgentStepContentModel[]>;
   declare message?: NonAttribute<Message>;
   declare feedbacks?: NonAttribute<AgentMessageFeedback[]>;
+
+  declare completedAt: Date | null;
 }
 
 AgentMessage.init(
@@ -373,6 +375,11 @@ AgentMessage.init(
       type: DataTypes.INTEGER,
       allowNull: false,
       defaultValue: 0,
+    },
+    completedAt: {
+      type: DataTypes.DATE,
+      allowNull: true,
+      defaultValue: null,
     },
   },
   {

--- a/front/migrations/db/migration_369.sql
+++ b/front/migrations/db/migration_369.sql
@@ -1,0 +1,2 @@
+-- Migration created on Sep 26, 2025
+ALTER TABLE "public"."agent_messages" ADD COLUMN "completedAt" TIMESTAMP WITH TIME ZONE DEFAULT NULL;


### PR DESCRIPTION
## Description

This PR adds a new column on agentMessage that is nullable. 
This column is not filled nor used yet, this is just the migration PR. 

Why? 

We want to be able to display the time to complete the full execution of an agent message. 
To avoid the new column, I considered these options: 
- Use the agentMessage `updatedAt` -> decided it was too weak - in case we run a migration and update all the updatedAt. 
- Get the `createdAt` of the last `agent_step_contents` when the agent message is with status succeeded or errored. ) -> This seems too complex. 


## Tests

Locally tested to post a new convo and no issue since the new column is nullable. 

## Risk

Migration involved. 

## Deploy Plan

Merge. 
Run migration. 
Deploy. 