### PR TITLE
[Temporal] Fix: don't return undefined on ApplicationFailure errors

### DIFF
--- a/connectors/src/lib/temporal_monitoring.ts
+++ b/connectors/src/lib/temporal_monitoring.ts
@@ -166,8 +166,7 @@ export class ActivityInboundLogInterceptor
 
       if (
         err instanceof ExternalOAuthTokenError ||
-        err instanceof WorkspaceQuotaExceededError ||
-        err instanceof ApplicationFailure
+        err instanceof WorkspaceQuotaExceededError
       ) {
         // We have a connector working on an expired token, we need to cancel the workflow.
         const { workflowId } = this.context.info.workflowExecution;
@@ -192,10 +191,6 @@ export class ActivityInboundLogInterceptor
             this.logger.info(
               `Stopping connector manager because of quota exceeded for the workspace.`
             );
-          } else if (err instanceof ApplicationFailure) {
-            // This will be handled automatically by the Temporal SDK.
-            // We don't need to do anything here.
-            return;
           } else {
             assertNever(err);
           }


### PR DESCRIPTION
Description
---
Fixes the issue where on some errors, failed activities would return undefined through the interceptor, instead of propagating the failure---which resulted in workflows silently failing such as [this one](https://cloud.temporal.io/namespaces/dust-prod.gmnlm/workflows/confluence-sync-25172-space-12582914/0199629a-f72f-713a-9175-74b801d3f1bb/history)

Additionally, the PR reduces the scope of errors on which the activity failure stops the workflow: it removes ApplicationFailure from those stops.

A first option was to rethrow and just remove the return. However, since ApplicationFailures are a very broad class of temporal errors, they should not indiscriminately stop the workflow. Therefore it seems better to remove ApplicationFailure from the if block entirely, so those failures show as regular activity failures in our monitors.

Edited: I think it would also resolve [those class of workflow failures](https://app.datadoghq.eu/logs?query=%22Workflow%20failed%22&agg_m=count&agg_m_source=base&agg_t=count&cols=host%2Cservice&event=AwAAAZmGcRiSal6gdwAAABhBWm1HY1NRSEFBQkEyT3NoVGpvckF3QlUAAAAkZjE5OTg2NzEtNGQzMi00OWNhLTk0MGMtNzBjNzQ1MjA2NzI3AAAuMg&fromUser=true&messageDisplay=inline&refresh_mode=sliding&storage=hot&stream_sort=desc&viz=stream&from_ts=1758896297665&to_ts=1758897197665) , example [here](https://cloud.temporal.io/namespaces/eu-dust-prod.gmnlm/workflows/slack-syncOneMessageDebounced-20-C0668R0MBL7-1758499200000/5819532d-e700-403c-9ab2-8ccf552b00f2/history)

Risk
---
low

Deploy
---
connectors