### PR TITLE
Directly open the corresponding modal when clicking add data as space admin

### DIFF
--- a/front/components/spaces/EditSpaceManagedDatasourcesViews.tsx
+++ b/front/components/spaces/EditSpaceManagedDatasourcesViews.tsx
@@ -12,7 +12,13 @@ import {
   Tooltip,
 } from "@dust-tt/sparkle";
 import { useRouter } from "next/router";
-import React, { useContext, useMemo, useState } from "react";
+import React, {
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useState,
+} from "react";
 
 import { ConfirmContext } from "@app/components/Confirm";
 import { confirmPrivateNodesSync } from "@app/components/data_source/ConnectorPermissionsModal";
@@ -42,6 +48,8 @@ interface EditSpaceManagedDataSourcesViewsProps {
   owner: WorkspaceType;
   systemSpace: SpaceType;
   space: SpaceType;
+  shouldOpenModal?: boolean;
+  onOpenModalHandled?: () => void;
 }
 
 /*
@@ -55,6 +63,8 @@ export function EditSpaceManagedDataSourcesViews({
   owner,
   systemSpace,
   space,
+  shouldOpenModal,
+  onOpenModalHandled,
 }: EditSpaceManagedDataSourcesViewsProps) {
   const sendNotification = useSendNotification();
   const confirm = useContext(ConfirmContext);
@@ -279,6 +289,33 @@ export function EditSpaceManagedDataSourcesViews({
     await onSelectedDataUpdated();
   };
 
+  const openAddDataModal = useCallback(() => {
+    if (systemSpaceDataSourceViews.length === 0) {
+      setShowNoConnectionDialog(true);
+    } else {
+      setShowDataSourcesModal(true);
+    }
+  }, [systemSpaceDataSourceViews.length]);
+
+  useEffect(() => {
+    // If the modal should be opened (from query param for instance) we wait for the data to be loaded
+    // before opening it.
+    if (!shouldOpenModal) {
+      return;
+    }
+    if (isSystemSpaceDataSourceViewsLoading || isSpaceDataSourceViewsLoading) {
+      return;
+    }
+    openAddDataModal();
+    onOpenModalHandled?.();
+  }, [
+    shouldOpenModal,
+    isSystemSpaceDataSourceViewsLoading,
+    isSpaceDataSourceViewsLoading,
+    openAddDataModal,
+    onOpenModalHandled,
+  ]);
+
   if (isSystemSpaceDataSourceViewsLoading || isSpaceDataSourceViewsLoading) {
     return false;
   }
@@ -304,11 +341,7 @@ export function EditSpaceManagedDataSourcesViews({
       icon={PlusIcon}
       size="sm"
       onClick={() => {
-        if (systemSpaceDataSourceViews.length === 0) {
-          setShowNoConnectionDialog(true);
-        } else {
-          setShowDataSourcesModal(true);
-        }
+        openAddDataModal();
       }}
       disabled={isSavingDisabled}
     />

--- a/front/components/spaces/SpaceActionsList.tsx
+++ b/front/components/spaces/SpaceActionsList.tsx
@@ -1,6 +1,7 @@
 import { DataTable, Spinner } from "@dust-tt/sparkle";
 import type { CellContext, ColumnDef } from "@tanstack/react-table";
 import { useRouter } from "next/router";
+import type { ParsedUrlQuery } from "querystring";
 import * as React from "react";
 
 import { ACTION_BUTTONS_CONTAINER_ID } from "@app/components/spaces/SpacePageHeaders";
@@ -34,6 +35,11 @@ type RowData = {
   onClick?: () => void;
 };
 
+const hasOpenToolsModalQuery = (
+  query: ParsedUrlQuery
+): query is ParsedUrlQuery & { openToolsModal: string } =>
+  isString(query.openToolsModal);
+
 interface SpaceActionsListProps {
   isAdmin: boolean;
   owner: LightWorkspaceType;
@@ -63,16 +69,12 @@ export const SpaceActionsList = ({
   });
 
   const [shouldOpenToolsMenu, setShouldOpenToolsMenu] = React.useState(false);
-
   React.useEffect(() => {
     if (!router.isReady || !isAdmin) {
       return;
     }
-    const { openToolsModal } = router.query;
-    if (!isString(openToolsModal)) {
-      return;
-    }
-    if (openToolsModal === undefined) {
+    const { query } = router;
+    if (!hasOpenToolsModalQuery(query)) {
       return;
     }
     setShouldOpenToolsMenu(true);

--- a/front/components/spaces/SpaceActionsList.tsx
+++ b/front/components/spaces/SpaceActionsList.tsx
@@ -35,10 +35,10 @@ type RowData = {
   onClick?: () => void;
 };
 
-const hasOpenToolsModalQuery = (
+const hasToolsModalQuery = (
   query: ParsedUrlQuery
-): query is ParsedUrlQuery & { openToolsModal: string } =>
-  isString(query.openToolsModal);
+): query is ParsedUrlQuery & { modal: string } =>
+  isString(query.modal) && query.modal === "tools";
 
 interface SpaceActionsListProps {
   isAdmin: boolean;
@@ -74,12 +74,12 @@ export const SpaceActionsList = ({
       return;
     }
     const { query } = router;
-    if (!hasOpenToolsModalQuery(query)) {
+    if (!hasToolsModalQuery(query)) {
       return;
     }
     setShouldOpenToolsMenu(true);
-    void removeParamFromRouter(router, "openToolsModal");
-  }, [router.isReady, router.query.openToolsModal, isAdmin, router]);
+    void removeParamFromRouter(router, "modal");
+  }, [router.isReady, router.query.modal, isAdmin, router]);
 
   const { pagination, setPagination } = usePaginationFromUrl({
     urlPrefix: "table",

--- a/front/components/spaces/SpaceActionsList.tsx
+++ b/front/components/spaces/SpaceActionsList.tsx
@@ -21,7 +21,7 @@ import {
 import { useAvailableMCPServers } from "@app/lib/swr/mcp_servers";
 import { removeParamFromRouter } from "@app/lib/utils/router_util";
 import type { LightWorkspaceType, SpaceType } from "@app/types";
-import { isDevelopment } from "@app/types";
+import { isDevelopment, isString } from "@app/types";
 
 import { RequestActionsModal } from "./mcp/RequestActionsModal";
 import SpaceManagedActionsViewsModel from "./SpaceManagedActionsViewsModal";

--- a/front/components/spaces/SpaceActionsList.tsx
+++ b/front/components/spaces/SpaceActionsList.tsx
@@ -1,5 +1,6 @@
 import { DataTable, Spinner } from "@dust-tt/sparkle";
 import type { CellContext, ColumnDef } from "@tanstack/react-table";
+import { useRouter } from "next/router";
 import * as React from "react";
 
 import { ACTION_BUTTONS_CONTAINER_ID } from "@app/components/spaces/SpacePageHeaders";
@@ -18,6 +19,7 @@ import {
   useRemoveMCPServerViewFromSpace,
 } from "@app/lib/swr/mcp_servers";
 import { useAvailableMCPServers } from "@app/lib/swr/mcp_servers";
+import { removeParamFromRouter } from "@app/lib/utils/router_util";
 import type { LightWorkspaceType, SpaceType } from "@app/types";
 import { isDevelopment } from "@app/types";
 
@@ -43,6 +45,7 @@ export const SpaceActionsList = ({
   isAdmin,
   space,
 }: SpaceActionsListProps) => {
+  const router = useRouter();
   const { q: searchParam } = useQueryParams(["q"]);
   // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
   const searchTerm = searchParam.value || "";
@@ -58,6 +61,20 @@ export const SpaceActionsList = ({
     owner,
     space,
   });
+
+  const [shouldOpenToolsMenu, setShouldOpenToolsMenu] = React.useState(false);
+
+  React.useEffect(() => {
+    if (!router.isReady || !isAdmin) {
+      return;
+    }
+    const openToolsModal = router.query.openToolsModal;
+    if (openToolsModal === undefined) {
+      return;
+    }
+    setShouldOpenToolsMenu(true);
+    void removeParamFromRouter(router, "openToolsModal");
+  }, [router.isReady, router.query.openToolsModal, isAdmin, router]);
 
   const { pagination, setPagination } = usePaginationFromUrl({
     urlPrefix: "table",
@@ -166,6 +183,8 @@ export const SpaceActionsList = ({
             space={space}
             owner={owner}
             onAddServer={onAddServer}
+            shouldOpenMenu={shouldOpenToolsMenu}
+            onOpenMenuHandled={() => setShouldOpenToolsMenu(false)}
           />
         </>
       ) : (

--- a/front/components/spaces/SpaceActionsList.tsx
+++ b/front/components/spaces/SpaceActionsList.tsx
@@ -68,7 +68,10 @@ export const SpaceActionsList = ({
     if (!router.isReady || !isAdmin) {
       return;
     }
-    const openToolsModal = router.query.openToolsModal;
+    const { openToolsModal } = router.query;
+    if (!isString(openToolsModal)) {
+      return;
+    }
     if (openToolsModal === undefined) {
       return;
     }

--- a/front/components/spaces/SpaceAppsList.tsx
+++ b/front/components/spaces/SpaceAppsList.tsx
@@ -23,6 +23,7 @@ import { useApps, useSavedRunStatus } from "@app/lib/swr/apps";
 import { removeParamFromRouter } from "@app/lib/utils/router_util";
 import type {
   AppType,
+  isString,
   LightWorkspaceType,
   SpaceType,
   WorkspaceType,

--- a/front/components/spaces/SpaceAppsList.tsx
+++ b/front/components/spaces/SpaceAppsList.tsx
@@ -9,6 +9,7 @@ import type { CellContext, ColumnDef } from "@tanstack/react-table";
 import sortBy from "lodash/sortBy";
 import Link from "next/link";
 import { useRouter } from "next/router";
+import type { ParsedUrlQuery } from "querystring";
 import type { ComponentType } from "react";
 import * as React from "react";
 import { useState } from "react";
@@ -21,12 +22,9 @@ import { useQueryParams } from "@app/hooks/useQueryParams";
 import type { ActionApp } from "@app/lib/registry";
 import { useApps, useSavedRunStatus } from "@app/lib/swr/apps";
 import { removeParamFromRouter } from "@app/lib/utils/router_util";
-import type {
-  AppType,
-  isString,
-  LightWorkspaceType,
-  SpaceType,
-  WorkspaceType,
+import type {AppType, LightWorkspaceType, SpaceType, WorkspaceType} from "@app/types";
+import {
+  isString
 } from "@app/types";
 
 type RowData = {
@@ -146,6 +144,11 @@ const AppHashChecker = ({ owner, app, registryApp }: AppHashCheckerProps) => {
   return "";
 };
 
+const hasOpenAppsModalQuery = (
+  query: ParsedUrlQuery
+): query is ParsedUrlQuery & { openAppsModal: string } =>
+  isString(query.openAppsModal);
+
 interface SpaceAppsListProps {
   isBuilder: boolean;
   onSelect: (sId: string) => void;
@@ -194,11 +197,8 @@ export const SpaceAppsList = ({
     if (!router.isReady || !isBuilder) {
       return;
     }
-    const { openAppsModal } = router.query;
-    if (!isString(openAppsModal)) {
-      return;
-    }
-    if (openAppsModal === undefined) {
+    const { query } = router;
+    if (!hasOpenAppsModalQuery(query)) {
       return;
     }
     setIsCreateAppModalOpened(true);

--- a/front/components/spaces/SpaceAppsList.tsx
+++ b/front/components/spaces/SpaceAppsList.tsx
@@ -8,6 +8,7 @@ import {
 import type { CellContext, ColumnDef } from "@tanstack/react-table";
 import sortBy from "lodash/sortBy";
 import Link from "next/link";
+import { useRouter } from "next/router";
 import type { ComponentType } from "react";
 import * as React from "react";
 import { useState } from "react";
@@ -19,6 +20,7 @@ import { usePaginationFromUrl } from "@app/hooks/usePaginationFromUrl";
 import { useQueryParams } from "@app/hooks/useQueryParams";
 import type { ActionApp } from "@app/lib/registry";
 import { useApps, useSavedRunStatus } from "@app/lib/swr/apps";
+import { removeParamFromRouter } from "@app/lib/utils/router_util";
 import type {
   AppType,
   LightWorkspaceType,
@@ -158,6 +160,7 @@ export const SpaceAppsList = ({
   onSelect,
   registryApps,
 }: SpaceAppsListProps) => {
+  const router = useRouter();
   const [isCreateAppModalOpened, setIsCreateAppModalOpened] = useState(false);
 
   const { q: searchParam } = useQueryParams(["q"]);
@@ -184,6 +187,19 @@ export const SpaceAppsList = ({
       })) || [],
     [apps, onSelect, owner]
   );
+
+  React.useEffect(() => {
+    // Extract openAppsModal query param to open modal on first render and remove it from URL
+    if (!router.isReady || !isBuilder) {
+      return;
+    }
+    const openAppsModal = router.query.openAppsModal;
+    if (openAppsModal === undefined) {
+      return;
+    }
+    setIsCreateAppModalOpened(true);
+    void removeParamFromRouter(router, "openAppsModal");
+  }, [router.isReady, router.query.openAppsModal, isBuilder, router]);
 
   const { portalToHeader } = useActionButtonsPortal({
     containerId: ACTION_BUTTONS_CONTAINER_ID,

--- a/front/components/spaces/SpaceAppsList.tsx
+++ b/front/components/spaces/SpaceAppsList.tsx
@@ -22,10 +22,13 @@ import { useQueryParams } from "@app/hooks/useQueryParams";
 import type { ActionApp } from "@app/lib/registry";
 import { useApps, useSavedRunStatus } from "@app/lib/swr/apps";
 import { removeParamFromRouter } from "@app/lib/utils/router_util";
-import type {AppType, LightWorkspaceType, SpaceType, WorkspaceType} from "@app/types";
-import {
-  isString
+import type {
+  AppType,
+  LightWorkspaceType,
+  SpaceType,
+  WorkspaceType,
 } from "@app/types";
+import { isString } from "@app/types";
 
 type RowData = {
   app: AppType;
@@ -144,10 +147,10 @@ const AppHashChecker = ({ owner, app, registryApp }: AppHashCheckerProps) => {
   return "";
 };
 
-const hasOpenAppsModalQuery = (
+const hasAppsModalQuery = (
   query: ParsedUrlQuery
-): query is ParsedUrlQuery & { openAppsModal: string } =>
-  isString(query.openAppsModal);
+): query is ParsedUrlQuery & { modal: string } =>
+  isString(query.modal) && query.modal === "apps";
 
 interface SpaceAppsListProps {
   isBuilder: boolean;
@@ -193,17 +196,17 @@ export const SpaceAppsList = ({
   );
 
   React.useEffect(() => {
-    // Extract openAppsModal query param to open modal on first render and remove it from URL
+    // Extract modal=apps query param to open modal on first render and remove it from URL
     if (!router.isReady || !isBuilder) {
       return;
     }
     const { query } = router;
-    if (!hasOpenAppsModalQuery(query)) {
+    if (!hasAppsModalQuery(query)) {
       return;
     }
     setIsCreateAppModalOpened(true);
-    void removeParamFromRouter(router, "openAppsModal");
-  }, [router.isReady, router.query.openAppsModal, isBuilder, router]);
+    void removeParamFromRouter(router, "modal");
+  }, [router.isReady, router.query.modal, isBuilder, router]);
 
   const { portalToHeader } = useActionButtonsPortal({
     containerId: ACTION_BUTTONS_CONTAINER_ID,

--- a/front/components/spaces/SpaceAppsList.tsx
+++ b/front/components/spaces/SpaceAppsList.tsx
@@ -193,7 +193,10 @@ export const SpaceAppsList = ({
     if (!router.isReady || !isBuilder) {
       return;
     }
-    const openAppsModal = router.query.openAppsModal;
+    const { openAppsModal } = router.query;
+    if (!isString(openAppsModal)) {
+      return;
+    }
     if (openAppsModal === undefined) {
       return;
     }

--- a/front/components/spaces/SpaceCategoriesList.tsx
+++ b/front/components/spaces/SpaceCategoriesList.tsx
@@ -155,7 +155,7 @@ export const SpaceCategoriesList = ({
         <DropdownMenuContent>
           <DropdownMenuItem
             disabled={!isAdmin && !canWriteInSpace}
-            href={`/w/${owner.sId}/spaces/${space.sId}/categories/managed`}
+            href={`/w/${owner.sId}/spaces/${space.sId}/categories/managed?openManagedModal=1`}
             icon={CloudArrowLeftRightIcon}
             label="Connected Data"
           />
@@ -167,19 +167,19 @@ export const SpaceCategoriesList = ({
           />
           <DropdownMenuItem
             disabled={!canWriteInSpace}
-            href={`/w/${owner.sId}/spaces/${space.sId}/categories/website`}
+            href={`/w/${owner.sId}/spaces/${space.sId}/categories/website?openWebsiteModal=1`}
             icon={GlobeAltIcon}
             label="Scrape a website"
           />
           <DropdownMenuItem
             disabled={!isBuilder || !canWriteInSpace}
-            href={`/w/${owner.sId}/spaces/${space.sId}/categories/apps`}
+            href={`/w/${owner.sId}/spaces/${space.sId}/categories/apps?openAppsModal=1`}
             icon={CommandLineIcon}
             label="Create a Dust App"
           />
           <DropdownMenuItem
             disabled={!isAdmin}
-            href={`/w/${owner.sId}/spaces/${space.sId}/categories/actions`}
+            href={`/w/${owner.sId}/spaces/${space.sId}/categories/actions?openToolsModal=1`}
             icon={MCP_SPECIFICATION.cardIcon}
             label="Tools"
           />

--- a/front/components/spaces/SpaceCategoriesList.tsx
+++ b/front/components/spaces/SpaceCategoriesList.tsx
@@ -155,7 +155,7 @@ export const SpaceCategoriesList = ({
         <DropdownMenuContent>
           <DropdownMenuItem
             disabled={!isAdmin && !canWriteInSpace}
-            href={`/w/${owner.sId}/spaces/${space.sId}/categories/managed?openManagedModal=1`}
+            href={`/w/${owner.sId}/spaces/${space.sId}/categories/managed?modal=managed`}
             icon={CloudArrowLeftRightIcon}
             label="Connected Data"
           />
@@ -167,19 +167,19 @@ export const SpaceCategoriesList = ({
           />
           <DropdownMenuItem
             disabled={!canWriteInSpace}
-            href={`/w/${owner.sId}/spaces/${space.sId}/categories/website?openWebsiteModal=1`}
+            href={`/w/${owner.sId}/spaces/${space.sId}/categories/website?modal=website`}
             icon={GlobeAltIcon}
             label="Scrape a website"
           />
           <DropdownMenuItem
             disabled={!isBuilder || !canWriteInSpace}
-            href={`/w/${owner.sId}/spaces/${space.sId}/categories/apps?openAppsModal=1`}
+            href={`/w/${owner.sId}/spaces/${space.sId}/categories/apps?modal=apps`}
             icon={CommandLineIcon}
             label="Create a Dust App"
           />
           <DropdownMenuItem
             disabled={!isAdmin}
-            href={`/w/${owner.sId}/spaces/${space.sId}/categories/actions?openToolsModal=1`}
+            href={`/w/${owner.sId}/spaces/${space.sId}/categories/actions?modal=tools`}
             icon={MCP_SPECIFICATION.cardIcon}
             label="Tools"
           />

--- a/front/components/spaces/SpaceManagedActionsViewsModal.tsx
+++ b/front/components/spaces/SpaceManagedActionsViewsModal.tsx
@@ -8,7 +8,7 @@ import {
   PlusIcon,
   Spinner,
 } from "@dust-tt/sparkle";
-import { useState } from "react";
+import { useEffect, useState } from "react";
 
 import { getMcpServerDisplayName } from "@app/lib/actions/mcp_helper";
 import { getAvatar } from "@app/lib/actions/mcp_icons";
@@ -21,22 +21,44 @@ type SpaceManagedActionsViewsModelProps = {
   owner: LightWorkspaceType;
   space: SpaceType;
   onAddServer: (server: MCPServerType) => void;
+  shouldOpenMenu?: boolean;
+  onOpenMenuHandled?: () => void;
 };
 
 export default function SpaceManagedActionsViewsModel({
   owner,
   space,
   onAddServer,
+  shouldOpenMenu,
+  onOpenMenuHandled,
 }: SpaceManagedActionsViewsModelProps) {
   const [searchText, setSearchText] = useState("");
+  const [menuOpen, setMenuOpen] = useState(false);
   const { availableMCPServers, isAvailableMCPServersLoading } =
     useAvailableMCPServers({
       owner,
       space,
     });
 
+  useEffect(() => {
+    if (!shouldOpenMenu) {
+      return;
+    }
+    setMenuOpen(true);
+    onOpenMenuHandled?.();
+  }, [shouldOpenMenu, onOpenMenuHandled]);
+
   return (
-    <DropdownMenu modal={false}>
+    <DropdownMenu
+      modal={false}
+      open={menuOpen}
+      onOpenChange={(open) => {
+        setMenuOpen(open);
+        if (!open) {
+          setSearchText("");
+        }
+      }}
+    >
       <DropdownMenuTrigger asChild>
         <Button label="Add Tools" variant="primary" icon={PlusIcon} size="sm" />
       </DropdownMenuTrigger>

--- a/front/components/spaces/SpaceResourcesList.tsx
+++ b/front/components/spaces/SpaceResourcesList.tsx
@@ -58,6 +58,7 @@ import type {
 } from "@app/types";
 import {
   ANONYMOUS_USER_IMAGE_URL,
+  isString,
   isWebsiteOrFolderCategory,
 } from "@app/types";
 

--- a/front/components/spaces/SpaceResourcesList.tsx
+++ b/front/components/spaces/SpaceResourcesList.tsx
@@ -45,6 +45,7 @@ import {
   useDeleteFolderOrWebsite,
   useSpaceDataSourceViewsWithDetails,
 } from "@app/lib/swr/spaces";
+import { removeParamFromRouter } from "@app/lib/utils/router_util";
 import type {
   ConnectorProvider,
   DataSourceViewCategoryWithoutApps,
@@ -281,6 +282,7 @@ export const SpaceResourcesList = ({
   const [isLoadingByProvider, setIsLoadingByProvider] = useState<
     Partial<Record<ConnectorProvider, boolean>>
   >({});
+  const [shouldOpenManagedModal, setShouldOpenManagedModal] = useState(false);
 
   const router = useRouter();
   const isSystemSpace = systemSpace.sId === space.sId;
@@ -288,6 +290,38 @@ export const SpaceResourcesList = ({
   const isWebsite = category === "website";
   const isFolder = category === "folder";
   const isWebsiteOrFolder = isWebsiteOrFolderCategory(category);
+
+  useEffect(() => {
+    if (!router.isReady || !isWebsite) {
+      return;
+    }
+    const openWebsiteModal = router.query.openWebsiteModal;
+    if (openWebsiteModal === undefined) {
+      return;
+    }
+    setSelectedDataSourceView(null);
+    setShowFolderOrWebsiteModal(true);
+    void removeParamFromRouter(router, "openWebsiteModal");
+  }, [isWebsite, router.isReady, router.query.openWebsiteModal, router]);
+
+  useEffect(() => {
+    if (!router.isReady || !isManagedCategory || isSystemSpace) {
+      return;
+    }
+    const openManagedModal = router.query.openManagedModal;
+    if (openManagedModal === undefined) {
+      return;
+    }
+    setSelectedDataSourceView(null);
+    setShouldOpenManagedModal(true);
+    void removeParamFromRouter(router, "openManagedModal");
+  }, [
+    isManagedCategory,
+    isSystemSpace,
+    router.isReady,
+    router.query.openManagedModal,
+    router,
+  ]);
 
   const { pagination, setPagination } = usePaginationFromUrl({
     urlPrefix: "table",
@@ -472,6 +506,8 @@ export const SpaceResourcesList = ({
           owner={owner}
           systemSpace={systemSpace}
           space={space}
+          shouldOpenModal={shouldOpenManagedModal}
+          onOpenModalHandled={() => setShouldOpenManagedModal(false)}
         />
       )}
       {isFolder && selectedDataSourceView && (

--- a/front/components/spaces/SpaceResourcesList.tsx
+++ b/front/components/spaces/SpaceResourcesList.tsx
@@ -295,7 +295,10 @@ export const SpaceResourcesList = ({
     if (!router.isReady || !isWebsite) {
       return;
     }
-    const openWebsiteModal = router.query.openWebsiteModal;
+    const { openWebsiteModal } = router.query;
+    if (!isString(openWebsiteModal)) {
+      return;
+    }
     if (openWebsiteModal === undefined) {
       return;
     }
@@ -308,7 +311,10 @@ export const SpaceResourcesList = ({
     if (!router.isReady || !isManagedCategory || isSystemSpace) {
       return;
     }
-    const openManagedModal = router.query.openManagedModal;
+    const { openManagedModal } = router.query;
+    if (!isString(openManagedModal)) {
+      return;
+    }
     if (openManagedModal === undefined) {
       return;
     }

--- a/front/components/spaces/SpaceResourcesList.tsx
+++ b/front/components/spaces/SpaceResourcesList.tsx
@@ -80,15 +80,15 @@ type NumberColumnDef = ColumnDef<RowData, number>;
 
 type TableColumnDef = StringColumnDef | NumberColumnDef;
 
-const hasOpenWebsiteModalQuery = (
+const hasWebsiteModalQuery = (
   query: ParsedUrlQuery
-): query is ParsedUrlQuery & { openWebsiteModal: string } =>
-  isString(query.openWebsiteModal);
+): query is ParsedUrlQuery & { modal: string } =>
+  isString(query.modal) && query.modal === "website";
 
-const hasOpenManagedModalQuery = (
+const hasManagedModalQuery = (
   query: ParsedUrlQuery
-): query is ParsedUrlQuery & { openManagedModal: string } =>
-  isString(query.openManagedModal);
+): query is ParsedUrlQuery & { modal: string } =>
+  isString(query.modal) && query.modal === "managed";
 
 function getTableColumns(
   setAssistantSId: (a: string | null) => void,
@@ -308,30 +308,30 @@ export const SpaceResourcesList = ({
       return;
     }
     const { query } = router;
-    if (!hasOpenWebsiteModalQuery(query)) {
+    if (!hasWebsiteModalQuery(query)) {
       return;
     }
     setSelectedDataSourceView(null);
     setShowFolderOrWebsiteModal(true);
-    void removeParamFromRouter(router, "openWebsiteModal");
-  }, [isWebsite, router.isReady, router.query.openWebsiteModal, router]);
+    void removeParamFromRouter(router, "modal");
+  }, [isWebsite, router.isReady, router.query.modal, router]);
 
   useEffect(() => {
     if (!router.isReady || !isManagedCategory || isSystemSpace) {
       return;
     }
     const { query } = router;
-    if (!hasOpenManagedModalQuery(query)) {
+    if (!hasManagedModalQuery(query)) {
       return;
     }
     setSelectedDataSourceView(null);
     setShouldOpenManagedModal(true);
-    void removeParamFromRouter(router, "openManagedModal");
+    void removeParamFromRouter(router, "modal");
   }, [
     isManagedCategory,
     isSystemSpace,
     router.isReady,
-    router.query.openManagedModal,
+    router.query.modal,
     router,
   ]);
 

--- a/front/components/spaces/SpaceResourcesList.tsx
+++ b/front/components/spaces/SpaceResourcesList.tsx
@@ -13,6 +13,7 @@ import {
 } from "@dust-tt/sparkle";
 import type { ColumnDef, SortingState } from "@tanstack/react-table";
 import { useRouter } from "next/router";
+import type { ParsedUrlQuery } from "querystring";
 import React, {
   useCallback,
   useContext,
@@ -78,6 +79,16 @@ type StringColumnDef = ColumnDef<RowData, string>;
 type NumberColumnDef = ColumnDef<RowData, number>;
 
 type TableColumnDef = StringColumnDef | NumberColumnDef;
+
+const hasOpenWebsiteModalQuery = (
+  query: ParsedUrlQuery
+): query is ParsedUrlQuery & { openWebsiteModal: string } =>
+  isString(query.openWebsiteModal);
+
+const hasOpenManagedModalQuery = (
+  query: ParsedUrlQuery
+): query is ParsedUrlQuery & { openManagedModal: string } =>
+  isString(query.openManagedModal);
 
 function getTableColumns(
   setAssistantSId: (a: string | null) => void,
@@ -296,11 +307,8 @@ export const SpaceResourcesList = ({
     if (!router.isReady || !isWebsite) {
       return;
     }
-    const { openWebsiteModal } = router.query;
-    if (!isString(openWebsiteModal)) {
-      return;
-    }
-    if (openWebsiteModal === undefined) {
+    const { query } = router;
+    if (!hasOpenWebsiteModalQuery(query)) {
       return;
     }
     setSelectedDataSourceView(null);
@@ -312,11 +320,8 @@ export const SpaceResourcesList = ({
     if (!router.isReady || !isManagedCategory || isSystemSpace) {
       return;
     }
-    const { openManagedModal } = router.query;
-    if (!isString(openManagedModal)) {
-      return;
-    }
-    if (openManagedModal === undefined) {
+    const { query } = router;
+    if (!hasOpenManagedModalQuery(query)) {
       return;
     }
     setSelectedDataSourceView(null);

--- a/front/lib/utils/router_util.ts
+++ b/front/lib/utils/router_util.ts
@@ -1,0 +1,30 @@
+import type { NextRouter } from "next/router";
+
+export const removeParamFromRouter = async (
+  router: NextRouter,
+  keys: string | string[]
+) => {
+  const params = Array.isArray(keys) ? keys : [keys];
+  const nextQuery = { ...router.query };
+
+  let didUpdate = false;
+  for (const param of params) {
+    if (param in nextQuery) {
+      delete nextQuery[param];
+      didUpdate = true;
+    }
+  }
+
+  if (!didUpdate) {
+    return;
+  }
+
+  await router.replace(
+    {
+      pathname: router.pathname,
+      query: nextQuery,
+    },
+    undefined,
+    { shallow: true }
+  );
+};

--- a/front/pages/w/[wId]/builder/agents/create.tsx
+++ b/front/pages/w/[wId]/builder/agents/create.tsx
@@ -24,6 +24,7 @@ import { useYAMLUpload } from "@app/hooks/useYAMLUpload";
 import { withDefaultUserAuthRequirements } from "@app/lib/iam/session";
 import { useAssistantTemplates } from "@app/lib/swr/assistants";
 import { useFeatureFlags } from "@app/lib/swr/workspaces";
+import { removeParamFromRouter } from "@app/lib/utils/router_util";
 import type {
   SubscriptionType,
   TemplateTagCodeType,
@@ -115,13 +116,7 @@ export default function CreateAgent({
 
   const closeTemplateModal = async () => {
     setSelectedTemplateId(null);
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    const { templateId, ...queryWithoutTemplate } = router.query;
-    await router.replace(
-      { pathname: router.pathname, query: queryWithoutTemplate },
-      undefined,
-      { shallow: true }
-    );
+    await removeParamFromRouter(router, "templateId");
   };
 
   const handleTagClick = (tagName: TemplateTagCodeType) => {


### PR DESCRIPTION

## Description

Closes https://github.com/dust-tt/tasks/issues/4278

open the corresponding modal when clinking:
 - Add data > Connected App
 - Add data > Scrap website
 - Add data > Add Tool
 - Add data > Create Dust App

I have not changed the Add Data > Upload data as there are several choices a user can do from here: either create a folder or open a folder to then upload data in it.

Implementation is mostly done by passing a "?openWebsiteModal=1" parameter in the URL so it the info can be accessed in the corresponding page.
The flag is immediatly cleared when the value has been retrieve to no longer pollute

## Tests

https://github.com/user-attachments/assets/078f8464-ac04-4c8b-a670-5091d1d4130a

manual tests

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->

deploy front