### PR TITLE
[front] fix: set `AgentMCPAction` status to errored on tool errors

### DIFF
--- a/front/lib/actions/mcp_actions.ts
+++ b/front/lib/actions/mcp_actions.ts
@@ -276,7 +276,7 @@ export async function* tryCallMCPTool(
       content: [
         {
           type: "text",
-          text: "Invalid action configuration: not an MCP action configuration",
+          text: "Could not call tool, invalid action configuration: not an MCP action configuration",
         },
       ],
     };
@@ -299,7 +299,7 @@ export async function* tryCallMCPTool(
       content: [
         {
           type: "text",
-          text: connectionParamsRes.error.message,
+          text: `The tool execution failed with the following error: ${connectionParamsRes.error.message}`,
         },
       ],
     };
@@ -331,7 +331,7 @@ export async function* tryCallMCPTool(
         content: [
           {
             type: "text",
-            text: connectionResult.error.message,
+            text: `The tool execution failed with the following error: ${connectionResult.error.message}`,
           },
         ],
       };
@@ -412,7 +412,9 @@ export async function* tryCallMCPTool(
         content: [
           {
             type: "text",
-            text: `Too many output items: ${content.length} (max is ${MAX_OUTPUT_ITEMS})`,
+            text:
+              "The tool execution failed because of too many output items: " +
+              `${content.length} (max is ${MAX_OUTPUT_ITEMS})`,
           },
         ],
       };
@@ -442,7 +444,9 @@ export async function* tryCallMCPTool(
           content: [
             {
               type: "text",
-              text: "MCP tool result content size too large.",
+              text:
+                "The tool execution failed because of a tool result content size exceeding " +
+                "the maximum limit.",
             },
           ],
         };
@@ -476,14 +480,22 @@ export async function* tryCallMCPTool(
         const info = Context.current().info;
         const isLastAttempt = info.attempt >= RETRY_ON_INTERRUPT_MAX_ATTEMPTS;
         if (!isLastAttempt) {
-          throw new Error(`Error: ${error.message}`, { cause: error });
+          throw new Error(
+            `The tool execution timed out, error: ${error.message}`,
+            { cause: error }
+          );
         }
       }
     }
 
     return {
       isError: true,
-      content: [{ type: "text", text: normalizeError(error).message }],
+      content: [
+        {
+          type: "text",
+          text: `The tool execution failed with the following error: ${normalizeError(error).message}`,
+        },
+      ],
     };
   } finally {
     await mcpClient?.close();

--- a/front/lib/actions/mcp_actions.ts
+++ b/front/lib/actions/mcp_actions.ts
@@ -317,7 +317,8 @@ export async function* tryCallMCPTool(
         MCPServerPersonalAuthenticationRequiredError
       ) {
         return {
-          isError: true,
+          // Complex code path, but errors returned here are processed in getExitOrPauseEvents.
+          isError: false,
           content: makePersonalAuthenticationError(
             connectionResult.error.provider,
             connectionResult.error.scope

--- a/front/lib/actions/mcp_actions.ts
+++ b/front/lib/actions/mcp_actions.ts
@@ -404,7 +404,6 @@ export async function* tryCallMCPTool(
     // Type inference is not working here because of them using passthrough in the zod schema.
     const content: CallToolResult["content"] = (toolCallResult.content ??
       []) as CallToolResult["content"];
-    const isError: boolean = (toolCallResult.isError as boolean) ?? false;
 
     if (content.length >= MAX_OUTPUT_ITEMS) {
       return {
@@ -453,7 +452,10 @@ export async function* tryCallMCPTool(
       }
     }
 
-    return { isError, content };
+    return {
+      isError: (toolCallResult.isError as boolean) ?? false,
+      content,
+    };
   } catch (error) {
     logger.error(
       {

--- a/front/lib/actions/mcp_execution.ts
+++ b/front/lib/actions/mcp_execution.ts
@@ -114,13 +114,13 @@ export async function processToolResults(
     action,
     conversation,
     localLogger,
-    toolCallResult,
+    toolCallResultContent,
     toolConfiguration,
   }: {
     action: AgentMCPActionResource;
     conversation: ConversationType;
     localLogger: Logger;
-    toolCallResult: CallToolResult["content"];
+    toolCallResultContent: CallToolResult["content"];
     toolConfiguration: LightMCPToolConfigurationType;
   }
 ): Promise<{
@@ -136,7 +136,7 @@ export async function processToolResults(
     content: CallToolResult["content"][number];
     file: FileResource | null;
   }[] = await concurrentExecutor(
-    toolCallResult,
+    toolCallResultContent,
     async (block) => {
       switch (block.type) {
         case "text": {

--- a/front/lib/api/mcp/run_tool.ts
+++ b/front/lib/api/mcp/run_tool.ts
@@ -1,8 +1,4 @@
 // eslint-disable-next-line dust/enforce-client-types-in-public-api
-import { McpError } from "@modelcontextprotocol/sdk/types.js";
-import { Context } from "@temporalio/activity";
-
-import { RETRY_ON_INTERRUPT_MAX_ATTEMPTS } from "@app/lib/actions/constants";
 import type {
   MCPApproveExecutionEvent,
   MCPErrorEvent,
@@ -22,7 +18,6 @@ import type {
 import { getExitOrPauseEvents } from "@app/lib/actions/mcp_internal_actions/utils";
 import { hideFileFromActionOutput } from "@app/lib/actions/mcp_utils";
 import type { AgentLoopRunContextType } from "@app/lib/actions/types";
-import { getRetryPolicyFromToolConfiguration } from "@app/lib/api/mcp";
 import { handleMCPActionError } from "@app/lib/api/mcp/error";
 import type { Authenticator } from "@app/lib/auth";
 import type { AgentMCPActionResource } from "@app/lib/resources/agent_mcp_action_resource";
@@ -110,48 +105,15 @@ export async function* runToolWithStreaming(
   // Err here means an exception ahead of calling the tool, like a connection error, an input
   // validation error, or any other kind of error from MCP, but not a tool error, which are returned
   // as content.
-  if (toolCallResult.isErr()) {
+  if (toolCallResult.isError) {
     statsDClient.increment("mcp_actions_error.count", 1, tags);
-    localLogger.error(
-      {
-        error: toolCallResult.error.message,
-      },
-      "Error calling MCP tool on run."
-    );
-
-    const { error: toolError } = toolCallResult;
-
-    const isMCPTimeoutError =
-      toolError instanceof McpError && toolError.code === -32001;
-
-    let errorMessage: string;
-    if (isMCPTimeoutError) {
-      errorMessage = `The execution of tool ${action.functionCallName} timed out.`;
-
-      // If the tool should not be retried on interrupt, the error is returned
-      // to the model, to let it decide what to do. If the tool should be
-      // retried on interrupt, we throw an error so the workflow retries the
-      // `runTool` activity, unless it's the last attempt.
-      const retryPolicy =
-        getRetryPolicyFromToolConfiguration(toolConfiguration);
-      if (retryPolicy === "retry_on_interrupt") {
-        const info = Context.current().info;
-        const isLastAttempt = info.attempt >= RETRY_ON_INTERRUPT_MAX_ATTEMPTS;
-        if (!isLastAttempt) {
-          errorMessage += ` Error: ${toolError.message}`;
-          throw new Error(errorMessage, { cause: toolError });
-        }
-      }
-    } else {
-      errorMessage = `The tool ${action.functionCallName} failed with the following error: ${toolError.message}`;
-    }
 
     yield await handleMCPActionError({
       action,
       agentConfiguration,
       agentMessage,
       status,
-      errorMessage,
+      errorContent: toolCallResult.content,
     });
     return;
   }
@@ -160,7 +122,7 @@ export async function* runToolWithStreaming(
     action,
     conversation,
     localLogger,
-    toolCallResult: toolCallResult.value,
+    toolCallResultContent: toolCallResult.content,
     toolConfiguration,
   });
 


### PR DESCRIPTION
## Description

- We currently only set the action status to `errored` on certain types of handcrafted errors (outputs too big) or exceptions (timeouts for instance) but not when the tool errored (e.g. in the tool callback we returned `isError: true`).
- This PR changes that so that `isError: true` means that the `status` column will be set to `errored`.
- This change was achieved by refactoring `tryCallMCPTool` to return the MCP type of `CallToolResult`. For the handcrafted errors the content is created there instead of in `handleMCPActionError` (we turn error messages into a single content of type text).

## Tests

- Tested locally, specifically sub agents and the personal auth flow.

## Risk

- Medium, some level of refactoring on a code path that is quite critical.
- Checked the logic of how we use this column.

## Deploy Plan

- Deploy front.
