### PR TITLE
Slack Bot: mismatch error is reachable

### DIFF
--- a/front/lib/connector_providers.ts
+++ b/front/lib/connector_providers.ts
@@ -234,7 +234,7 @@ export const CONNECTOR_CONFIGURATIONS: Record<
     permissionsDisabledPlaceholder: "N/A",
     description: "N/A",
     limitations: "N/A",
-    mismatchError: "N/A",
+    mismatchError: `You cannot select another Slack Team.\nPlease contact us at support@dust.tt if you initially selected the wrong Team.`,
     guideLink: "https://docs.dust.tt/docs/slack-connection",
     selectLabel: "N/A",
     getLogoComponent: () => {


### PR DESCRIPTION
## Description

For https://github.com/dust-tt/tasks/issues/4432

The mismatch error is code reachable in connectors for `slack_bot`. This fixes the error displayed to the user.

## Tests

N/A

## Risk

None

## Deploy Plan

- deploy `front`