### PR TITLE
fix(bigquery): don't mix and match dataset locations

### DIFF
--- a/connectors/src/connectors/bigquery/lib/bigquery_api.ts
+++ b/connectors/src/connectors/bigquery/lib/bigquery_api.ts
@@ -111,13 +111,11 @@ export const fetchDatasets = async ({
     return new Ok(
       removeNulls(
         datasets.map((dataset) => {
-          // We want to filter out datasets that are in a different location than the credentials.
-          // But, for example, we want to keep dataset in "us" (multi-region) when selected location is "us-central1" (regional)
-          if (
-            !credentials.location
-              .toLowerCase()
-              .startsWith(dataset.location?.toLowerCase() ?? "")
-          ) {
+          // Strict location matching: only keep datasets whose location exactly matches
+          // the credential's location (case-insensitive). No regional/multi-region expansion.
+          const datasetLocation = dataset.location?.toLowerCase();
+          const credentialLocation = credentials.location.toLowerCase();
+          if (!datasetLocation || datasetLocation !== credentialLocation) {
             return null;
           }
 

--- a/front/pages/api/w/[wId]/credentials/check_bigquery_locations.test.ts
+++ b/front/pages/api/w/[wId]/credentials/check_bigquery_locations.test.ts
@@ -110,11 +110,7 @@ describe("POST /api/w/[wId]/credentials/check_bigquery_locations", () => {
       locations: {
         us: ["dataset1.table1", "dataset1.table2"],
         eu: ["dataset2.table3"],
-        "eu-central1": [
-          "dataset2.table3",
-          "dataset3.table4",
-          "dataset4.table5",
-        ],
+        "eu-central1": ["dataset3.table4", "dataset4.table5"],
       },
     });
   });

--- a/front/pages/api/w/[wId]/credentials/check_bigquery_locations.ts
+++ b/front/pages/api/w/[wId]/credentials/check_bigquery_locations.ts
@@ -8,11 +8,7 @@ import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrapper
 import type { Authenticator } from "@app/lib/auth";
 import { apiError } from "@app/logger/withlogging";
 import type { APIErrorType, WithAPIErrorResponse } from "@app/types";
-import {
-  CheckBigQueryCredentialsSchema,
-  normalizeError,
-  removeNulls,
-} from "@app/types";
+import { CheckBigQueryCredentialsSchema, normalizeError } from "@app/types";
 
 const PostCheckBigQueryRegionsRequestBodySchema = t.type({
   credentials: CheckBigQueryCredentialsSchema,

--- a/front/pages/api/w/[wId]/credentials/check_bigquery_locations.ts
+++ b/front/pages/api/w/[wId]/credentials/check_bigquery_locations.ts
@@ -94,26 +94,17 @@ async function handler(
     // Get all datasets
     const [datasets] = await bigquery.getDatasets();
 
-    const allDatasetsLocations = removeNulls(
-      datasets.map((dataset) => dataset.location?.toLocaleLowerCase())
-    );
-
-    // Initialize locations map
     const locations: Record<string, Set<string>> = {};
 
-    // Process each dataset and its tables
     for (const dataset of datasets) {
+      const dsLocation = dataset.location?.toLowerCase();
+      if (!dsLocation) {
+        continue;
+      }
       const [tables] = await dataset.getTables();
       for (const table of tables) {
-        for (const location of allDatasetsLocations) {
-          if (
-            dataset.location &&
-            location.toLowerCase().startsWith(dataset.location.toLowerCase())
-          ) {
-            locations[location] ??= new Set();
-            locations[location].add(`${dataset.id}.${table.id}`);
-          }
-        }
+        locations[dsLocation] ??= new Set();
+        locations[dsLocation].add(`${dataset.id}.${table.id}`);
       }
     }
 


### PR DESCRIPTION
## Description

https://github.com/dust-tt/tasks/issues/4410#issuecomment-3338893886

We currently allow multi-location datasets on connectors configured for single-location datasets as long as the multi-location is a superset of the single-location.

This is actually wrong, as a big query job's location must exactly match the datasets location, meaning you can never query e.g an EU dataset along with a europe-west-1 dataset.

This removes the logic that enabled that.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
