### PR TITLE
[front] fix(AB): Add feature flag check for advanced search configuration

### DIFF
--- a/front/components/agent_builder/capabilities/knowledge/KnowledgeConfigurationSheet.tsx
+++ b/front/components/agent_builder/capabilities/knowledge/KnowledgeConfigurationSheet.tsx
@@ -17,6 +17,7 @@ import {
   useWatch,
 } from "react-hook-form";
 
+import { useAgentBuilderContext } from "@app/components/agent_builder/AgentBuilderContext";
 import { DataSourceBuilderSelector } from "@app/components/agent_builder/capabilities/knowledge/DataSourceBuilderSelector";
 import { transformTreeToSelectionConfigurations } from "@app/components/agent_builder/capabilities/knowledge/transformations";
 import {
@@ -62,6 +63,7 @@ import {
 } from "@app/lib/actions/mcp_internal_actions/constants";
 import { getMCPServerToolsConfigurations } from "@app/lib/actions/mcp_internal_actions/input_configuration";
 import type { MCPServerViewType } from "@app/lib/api/mcp";
+import { useFeatureFlags } from "@app/lib/swr/workspaces";
 import type { TemplateActionPreset } from "@app/types";
 
 import { KnowledgeFooter } from "./KnowledgeFooter";
@@ -252,10 +254,12 @@ function KnowledgeConfigurationSheetContent({
   getAgentInstructions,
   isEditing,
 }: KnowledgeConfigurationSheetContentProps) {
+  const { owner } = useAgentBuilderContext();
   const { currentPageId, setSheetPageId } = useKnowledgePageContext();
   const { setValue, getValues, setFocus } =
     useFormContext<CapabilityFormData>();
   const [isAdvancedSettingsOpen, setAdvancedSettingsOpen] = useState(false);
+  const { hasFeature } = useFeatureFlags({ workspaceId: owner.sId });
 
   const mcpServerView = useWatch<CapabilityFormData, "mcpServerView">({
     name: "mcpServerView",
@@ -406,7 +410,8 @@ function KnowledgeConfigurationSheetContent({
 
           {/* Advanced Settings collapsible section */}
           {mcpServerView?.serverType === "internal" &&
-            mcpServerView.server.name === SEARCH_SERVER_NAME && (
+            mcpServerView.server.name === SEARCH_SERVER_NAME &&
+            hasFeature("advanced_search") && (
               <Collapsible
                 open={isAdvancedSettingsOpen}
                 onOpenChange={setAdvancedSettingsOpen}
@@ -423,7 +428,6 @@ function KnowledgeConfigurationSheetContent({
                     targetMCPServerName={SEARCH_SERVER_NAME}
                     selectedMCPServerView={mcpServerView ?? undefined}
                     configurationKey={ADVANCED_SEARCH_SWITCH}
-                    featureFlag="advanced_search"
                   />
                 </CollapsibleContent>
               </Collapsible>

--- a/front/components/agent_builder/capabilities/knowledge/KnowledgeConfigurationSheet.tsx
+++ b/front/components/agent_builder/capabilities/knowledge/KnowledgeConfigurationSheet.tsx
@@ -423,6 +423,7 @@ function KnowledgeConfigurationSheetContent({
                     targetMCPServerName={SEARCH_SERVER_NAME}
                     selectedMCPServerView={mcpServerView ?? undefined}
                     configurationKey={ADVANCED_SEARCH_SWITCH}
+                    featureFlag="advanced_search"
                   />
                 </CollapsibleContent>
               </Collapsible>

--- a/front/components/agent_builder/capabilities/shared/CustomCheckboxSection.tsx
+++ b/front/components/agent_builder/capabilities/shared/CustomCheckboxSection.tsx
@@ -1,9 +1,12 @@
 import { Checkbox } from "@dust-tt/sparkle";
 import { useController } from "react-hook-form";
 
+import { useAgentBuilderContext } from "@app/components/agent_builder/AgentBuilderContext";
 import type { MCPFormData } from "@app/components/agent_builder/AgentBuilderFormContext";
 import type { InternalMCPServerNameType } from "@app/lib/actions/mcp_internal_actions/constants";
 import type { MCPServerViewType } from "@app/lib/api/mcp";
+import { useFeatureFlags } from "@app/lib/swr/workspaces";
+import type { WhitelistableFeature } from "@app/types";
 
 interface CustomCheckboxSectionProps {
   title: string;
@@ -11,6 +14,7 @@ interface CustomCheckboxSectionProps {
   configurationKey: string;
   selectedMCPServerView?: MCPServerViewType;
   targetMCPServerName: InternalMCPServerNameType;
+  featureFlag?: WhitelistableFeature;
 }
 
 /**
@@ -22,7 +26,11 @@ export function CustomCheckboxSection({
   selectedMCPServerView,
   targetMCPServerName,
   configurationKey,
+  featureFlag,
 }: CustomCheckboxSectionProps) {
+  const { owner } = useAgentBuilderContext();
+  const { hasFeature } = useFeatureFlags({ workspaceId: owner.sId });
+
   const { field } = useController<MCPFormData>({
     name: `configuration.additionalConfiguration.${configurationKey}`,
     defaultValue: false,
@@ -32,7 +40,7 @@ export function CustomCheckboxSection({
     selectedMCPServerView?.serverType === "internal" &&
     selectedMCPServerView.server.name === targetMCPServerName;
 
-  if (!isTargetServer) {
+  if (!isTargetServer || (featureFlag && !hasFeature(featureFlag))) {
     return null;
   }
 

--- a/front/components/agent_builder/capabilities/shared/CustomCheckboxSection.tsx
+++ b/front/components/agent_builder/capabilities/shared/CustomCheckboxSection.tsx
@@ -1,12 +1,9 @@
 import { Checkbox } from "@dust-tt/sparkle";
 import { useController } from "react-hook-form";
 
-import { useAgentBuilderContext } from "@app/components/agent_builder/AgentBuilderContext";
 import type { MCPFormData } from "@app/components/agent_builder/AgentBuilderFormContext";
 import type { InternalMCPServerNameType } from "@app/lib/actions/mcp_internal_actions/constants";
 import type { MCPServerViewType } from "@app/lib/api/mcp";
-import { useFeatureFlags } from "@app/lib/swr/workspaces";
-import type { WhitelistableFeature } from "@app/types";
 
 interface CustomCheckboxSectionProps {
   title: string;
@@ -14,7 +11,6 @@ interface CustomCheckboxSectionProps {
   configurationKey: string;
   selectedMCPServerView?: MCPServerViewType;
   targetMCPServerName: InternalMCPServerNameType;
-  featureFlag?: WhitelistableFeature;
 }
 
 /**
@@ -26,11 +22,7 @@ export function CustomCheckboxSection({
   selectedMCPServerView,
   targetMCPServerName,
   configurationKey,
-  featureFlag,
 }: CustomCheckboxSectionProps) {
-  const { owner } = useAgentBuilderContext();
-  const { hasFeature } = useFeatureFlags({ workspaceId: owner.sId });
-
   const { field } = useController<MCPFormData>({
     name: `configuration.additionalConfiguration.${configurationKey}`,
     defaultValue: false,
@@ -40,7 +32,7 @@ export function CustomCheckboxSection({
     selectedMCPServerView?.serverType === "internal" &&
     selectedMCPServerView.server.name === targetMCPServerName;
 
-  if (!isTargetServer || (featureFlag && !hasFeature(featureFlag))) {
+  if (!isTargetServer) {
     return null;
   }
 


### PR DESCRIPTION
## Description

- The `CustomCheckboxSection` is currently used for the advanced search mode, which is behind a feature flag.
- This PR adds the feature flag check to hide the Advanced Settings section when the feature flag is not enabled.
- PR for the Assistant Builder: https://github.com/dust-tt/dust/pull/13632.

## Tests

- Checked locally.

## Risk

- Low.

## Deploy Plan

- Deploy front.
