### PR TITLE
[front] enh(Poke): Update Temporal link for Gong connectors

### DIFF
--- a/front/components/poke/data_sources/view.tsx
+++ b/front/components/poke/data_sources/view.tsx
@@ -120,7 +120,13 @@ export function ViewDataSourceTable({
                   <PokeTableCell>Logs</PokeTableCell>
                   <PokeTableCell>
                     <Link
-                      href={`https://cloud.temporal.io/namespaces/${temporalWorkspace}/workflows?query=connectorId%3D%22${dataSource.connectorId}%22`}
+                      href={
+                        dataSource.connectorProvider === "gong"
+                          ? // Gong is schedule-based, linking the schedule page that has the list
+                            // of all workflow runs.
+                            `https://cloud.temporal.io/namespaces/${temporalWorkspace}/schedules/gong-sync-${dataSource.connectorId}`
+                          : `https://cloud.temporal.io/namespaces/${temporalWorkspace}/workflows?query=connectorId%3D%22${dataSource.connectorId}%22`
+                      }
                       target="_blank"
                       className="text-sm text-highlight-400"
                     >


### PR DESCRIPTION
## Description

- Gong is schedule-based causing the current link to not work at all, which is misleading if you don't know Gong specifics.
- This PR updates the link to point to the schedule page, both for quick access and to abstract Gong specificities.

## Tests

## Risk

- Low.

## Deploy Plan

- Deploy front.
