### PR TITLE
[connectors] enh(logging): remove `WithRetriesError` `errors` attribute

### DIFF
--- a/connectors/src/lib/temporal_monitoring.ts
+++ b/connectors/src/lib/temporal_monitoring.ts
@@ -30,8 +30,8 @@ const TRANSIENT_ERROR_PRE_BACKOFF_RETRY_ATTEMPTS = 19;
 
 function redactErrorForLogs(err: unknown) {
   if (err instanceof WithRetriesError) {
-    // Omitting the whole errors array, the meaningful information
-    // should be passed in additionalContext.
+    // Omitting the whole errors array, data meant to be logged  should be
+    // passed in additionalContext.
     return {
       name: err.name,
       message: err.message,

--- a/connectors/src/types/shared/retries.ts
+++ b/connectors/src/types/shared/retries.ts
@@ -10,7 +10,7 @@ import { normalizeError } from "@connectors/types/api";
 
 export class WithRetriesError extends Error {
   constructor(
-    readonly errors: Array<{ attempt: number; error: unknown }>,
+    errors: { attempt: number; error: unknown }[],
     readonly retries: number,
     readonly delayBetweenRetriesMs: number
   ) {

--- a/connectors/src/types/shared/retries.ts
+++ b/connectors/src/types/shared/retries.ts
@@ -9,8 +9,14 @@ import {
 import { normalizeError } from "@connectors/types/api";
 
 export class WithRetriesError extends Error {
+  readonly additionalContext: Record<string, unknown>[];
+
   constructor(
-    errors: { attempt: number; error: unknown }[],
+    errors: {
+      attempt: number;
+      error: unknown;
+      additionalContext: Record<string, unknown>;
+    }[],
     readonly retries: number,
     readonly delayBetweenRetriesMs: number
   ) {
@@ -22,6 +28,7 @@ export class WithRetriesError extends Error {
 
     super(message);
     this.name = "WithRetriesError";
+    this.additionalContext = errors.map((e) => e.additionalContext);
     this.retries = retries;
     this.delayBetweenRetriesMs = delayBetweenRetriesMs;
   }
@@ -44,13 +51,25 @@ export function withRetries<Args extends unknown[], Return>(
   }
 
   return async (...args) => {
-    const errors: Array<{ attempt: number; error: unknown }> = [];
+    const errors: {
+      attempt: number;
+      error: unknown;
+      additionalContext: Record<string, unknown>;
+    }[] = [];
 
     for (let i = 0; i < retries; i++) {
       const attempt = i + 1;
       try {
         return await fn(...args);
       } catch (e) {
+        let additionalContext = {};
+        if (e instanceof AxiosError) {
+          additionalContext = {
+            url: e.config?.url,
+            code: e.code,
+            status: e.status,
+          };
+        }
         if (
           e instanceof AxiosError &&
           e.code === "ERR_BAD_REQUEST" &&
@@ -85,7 +104,7 @@ export function withRetries<Args extends unknown[], Return>(
 
         await setTimeoutAsync(sleepTime);
 
-        errors.push({ attempt: attempt, error: e });
+        errors.push({ attempt: attempt, error: e, additionalContext });
       }
     }
 

--- a/connectors/src/types/shared/retries.ts
+++ b/connectors/src/types/shared/retries.ts
@@ -12,7 +12,7 @@ export class WithRetriesError extends Error {
   readonly additionalContext: Record<string, unknown>[];
 
   constructor(
-    errors: {
+    readonly errors: {
       attempt: number;
       error: unknown;
       additionalContext: Record<string, unknown>;

--- a/connectors/src/types/shared/retries.ts
+++ b/connectors/src/types/shared/retries.ts
@@ -9,6 +9,7 @@ import {
 import { normalizeError } from "@connectors/types/api";
 
 export class WithRetriesError extends Error {
+  // Additional context to each error that will appear in the logs, unlike the whole error.
   readonly additionalContext: Record<string, unknown>[];
 
   constructor(


### PR DESCRIPTION
## Description

- `WithRetriesError` are currently logged like [this](https://app.datadoghq.eu/logs?query=%28%22Activity%20failed%22%20OR%20%22Unhandled%20activity%20error%22%29%20%40attempt%3A%3E19%20%40dd.service%3Aconnectors-worker&agg_m=count&agg_m_source=base&agg_q=%40workflowId&agg_q_source=base&agg_t=count&clustering_pattern_field_path=message&cols=%40workflowId%2C%40error.type&event=AwAAAZmKJugmDk8p8wAAABhBWm1LSnZBc0FBQzJ4VnZzNWRhS3VBQUwAAAAkZjE5OThhMjktNGY3MC00Yjk5LTllMWUtY2ZlNzZmYzZiNTAwAAASAQ&fromUser=true&graphType=flamegraph&messageDisplay=inline&refresh_mode=sliding&sort=time&spanID=6000198897476506285&storage=hot&stream_sort=time%2Cdesc&top_n=25&top_o=top&viz=stream&x_missing=true&from_ts=1758745662562&to_ts=1758749262562&live=true).
- This PR removes the `errors` object from the logs, which is huge and leaky, and only selects a few properties to expose them in the logs.

## Tests

## Risk

- Low.

## Deploy Plan

- Deploy connectors.
