### PR TITLE
[connectors] chore(GoogleDrive): prevent logging file titles

### DIFF
--- a/connectors/src/connectors/google_drive/temporal/file/sync_one_file.ts
+++ b/connectors/src/connectors/google_drive/temporal/file/sync_one_file.ts
@@ -62,7 +62,6 @@ export async function syncOneFile(
         connectorId,
         documentId,
         fileId: file.id,
-        title: file.name,
         mimeType: file.mimeType,
       });
 

--- a/connectors/src/lib/data_sources.ts
+++ b/connectors/src/lib/data_sources.ts
@@ -1060,7 +1060,7 @@ export async function upsertDataSourceTableFromCsv({
   tags?: string[];
   allowEmptySchema?: boolean;
 }) {
-  const localLogger = logger.child({ ...loggerArgs, tableId, tableName });
+  const localLogger = logger.child({ ...loggerArgs, tableId });
   const statsDTags = [
     `data_source_id:${dataSourceConfig.dataSourceId}`,
     `workspace_id:${dataSourceConfig.workspaceId}`,


### PR DESCRIPTION
## Description

- This PR prevents logging document and table titles.

## Tests

## Risk

- Low.

## Deploy Plan

- Deploy connectors.
