### PR TITLE
[Run Agent] Ignore Not connected stream errors

### DIFF
--- a/front/lib/actions/mcp_internal_actions/servers/run_agent/index.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/run_agent/index.ts
@@ -707,10 +707,15 @@ ${query}`
             }
           }
 
-          const errorMessage = `Error processing agent stream: ${
-            normalizeError(streamError).message
-          }`;
-          return new Err(new MCPError(errorMessage));
+          const normalizedError = normalizeError(streamError);
+          const isNotConnected = normalizedError.message === "Not connected";
+          const errorMessage = `Error processing agent stream: ${normalizedError.message}`;
+          return new Err(
+            new MCPError(errorMessage, {
+              tracked: !isNotConnected,
+              cause: normalizedError,
+            })
+          );
         }
         finalContent = finalContent.trim();
         chainOfThought = chainOfThought.trim();


### PR DESCRIPTION
## Description
Mark run_agent stream failures caused by Not connected as untracked MCP errors
The not connected failure occurs when the client has closed, aka runTool has decided to move on, but the tool is still emitting notifications. The only direct cause we have of this here is when run_agent times out, in which case it's already abundantly logged and should not trigger a monitor (it will be retried)

## Risks
Blast radius: run_agent progress error reporting
Risk: low

## Deploy Plan
- deploy front