### PR TITLE
[Sparkle] Align dropdown header background in dark mode

### DIFF
--- a/sparkle/src/components/Dropdown.tsx
+++ b/sparkle/src/components/Dropdown.tsx
@@ -291,7 +291,7 @@ const DropdownMenuContent = React.forwardRef<
         onCloseAutoFocus={handleCloseAutoFocus}
         {...props}
       >
-        <div className="s-sticky s-top-0 s-bg-background dark:s-bg-background-night">
+        <div className="s-sticky s-top-0 s-bg-background dark:s-bg-muted-background-night">
           {dropdownHeaders && dropdownHeaders}
         </div>
         <ScrollArea


### PR DESCRIPTION
## Description
Fixes https://github.com/dust-tt/tasks/issues/4413
- align the dropdown header background with the dark-mode menu container so search fields match surrounding menus in dropdowns that include dropdownHeaders

<img width="850" height="516" alt="image" src="https://github.com/user-attachments/assets/2e058df3-f16d-4779-94aa-53cffc135046" />

## Risks
Blast radius: Sparkle dropdowns that render dropdownHeaders (InputBar pickers, other search menus)
Risk: low

## Deploy Plan
- deploy front