### PR TITLE
[front] chore(dark-mode): fix invisible borders

### DIFF
--- a/front/components/navigation/NavigationSidebar.tsx
+++ b/front/components/navigation/NavigationSidebar.tsx
@@ -136,63 +136,61 @@ export const NavigationSidebar = React.forwardRef<
             {navs.map((tab) => (
               <TabsContent key={tab.id} value={tab.id}>
                 <NavigationList className="px-3">
-                  {subNavigation && tab.isCurrent(activePath) && (
-                    <>
-                      {subNavigation.map((nav) => (
-                        <React.Fragment key={`nav-${nav.label}`}>
-                          {nav.label && (
-                            <NavigationListLabel
-                              label={nav.label}
-                              variant={nav.variant}
-                            />
-                          )}
-                          {nav.menus
-                            .filter(
-                              (menu) =>
-                                !menu.featureFlag ||
-                                featureFlags.includes(menu.featureFlag)
-                            )
-                            .map((menu) => (
-                              <React.Fragment key={menu.id}>
-                                <NavigationListItem
-                                  selected={menu.current}
-                                  label={menu.label}
-                                  icon={menu.icon}
-                                  href={menu.href}
-                                  target={menu.target}
-                                  onClick={() => handleTabClick(menu.href)}
-                                />
-                                {menu.subMenuLabel && (
-                                  <div
-                                    className={classNames(
-                                      "grow pb-3 pl-14 pr-4 pt-2 text-sm uppercase",
-                                      "text-muted-foreground dark:text-muted-foreground-night"
-                                    )}
-                                  >
-                                    {menu.subMenuLabel}
-                                  </div>
-                                )}
-                                {menu.subMenu && (
-                                  <div className="mb-2 flex flex-col">
-                                    {menu.subMenu.map((nav) => (
-                                      <NavigationListItem
-                                        key={nav.id}
-                                        selected={nav.current}
-                                        label={nav.label}
-                                        icon={nav.icon}
-                                        className="grow pl-14 pr-4"
-                                        href={nav.href ? nav.href : undefined}
-                                        onClick={() => handleTabClick(nav.href)}
-                                      />
-                                    ))}
-                                  </div>
-                                )}
-                              </React.Fragment>
-                            ))}
-                        </React.Fragment>
-                      ))}
-                    </>
-                  )}
+                  {subNavigation &&
+                    tab.isCurrent(activePath) &&
+                    subNavigation.map((nav) => (
+                      <React.Fragment key={`nav-${nav.label}`}>
+                        {nav.label && (
+                          <NavigationListLabel
+                            label={nav.label}
+                            variant={nav.variant}
+                          />
+                        )}
+                        {nav.menus
+                          .filter(
+                            (menu) =>
+                              !menu.featureFlag ||
+                              featureFlags.includes(menu.featureFlag)
+                          )
+                          .map((menu) => (
+                            <React.Fragment key={menu.id}>
+                              <NavigationListItem
+                                selected={menu.current}
+                                label={menu.label}
+                                icon={menu.icon}
+                                href={menu.href}
+                                target={menu.target}
+                                onClick={() => handleTabClick(menu.href)}
+                              />
+                              {menu.subMenuLabel && (
+                                <div
+                                  className={classNames(
+                                    "grow pb-3 pl-14 pr-4 pt-2 text-sm uppercase",
+                                    "text-muted-foreground dark:text-muted-foreground-night"
+                                  )}
+                                >
+                                  {menu.subMenuLabel}
+                                </div>
+                              )}
+                              {menu.subMenu && (
+                                <div className="mb-2 flex flex-col">
+                                  {menu.subMenu.map((nav) => (
+                                    <NavigationListItem
+                                      key={nav.id}
+                                      selected={nav.current}
+                                      label={nav.label}
+                                      icon={nav.icon}
+                                      className="grow pl-14 pr-4"
+                                      href={nav.href ? nav.href : undefined}
+                                      onClick={() => handleTabClick(nav.href)}
+                                    />
+                                  ))}
+                                </div>
+                              )}
+                            </React.Fragment>
+                          ))}
+                      </React.Fragment>
+                    ))}
                 </NavigationList>
               </TabsContent>
             ))}
@@ -204,7 +202,7 @@ export const NavigationSidebar = React.forwardRef<
         <div
           className={classNames(
             "flex items-center border-t px-2 py-2",
-            "border-border-dark dark:border-border-dark-night",
+            "border-border-dark dark:border-border-darker-night",
             "text-foreground dark:text-foreground-night"
           )}
         >

--- a/front/components/poke/plugins/EnumSelect.tsx
+++ b/front/components/poke/plugins/EnumSelect.tsx
@@ -53,7 +53,8 @@ export function EnumSelect({
             variant="outline"
             role="combobox"
             className={cn(
-              "w-auto justify-between",
+              "w-auto justify-between border-border-dark bg-background " +
+                "dark:border-border-darker-night dark:bg-background-night",
               !values?.length &&
                 "text-muted-foreground dark:text-muted-foreground-night"
             )}

--- a/front/components/poke/plugins/RunPluginDialog.tsx
+++ b/front/components/poke/plugins/RunPluginDialog.tsx
@@ -124,22 +124,20 @@ export function RunPluginDialog({
                 </PokeAlert>
               )}
               {result && result.display === "textWithLink" && (
-                <>
-                  <PokeAlert variant="success">
-                    <PokeAlertTitle>Success</PokeAlertTitle>
-                    <PokeAlertDescription>
-                      <p>{result.value} - Make sure to reload.</p>
-                      <Button
-                        onClick={() => {
-                          window.open(result.link, "_blank");
-                        }}
-                        label={result.linkText}
-                        variant="highlight"
-                        className="mt-2"
-                      />
-                    </PokeAlertDescription>
-                  </PokeAlert>
-                </>
+                <PokeAlert variant="success">
+                  <PokeAlertTitle>Success</PokeAlertTitle>
+                  <PokeAlertDescription>
+                    <p>{result.value} - Make sure to reload.</p>
+                    <Button
+                      onClick={() => {
+                        window.open(result.link, "_blank");
+                      }}
+                      label={result.linkText}
+                      variant="highlight"
+                      className="mt-2"
+                    />
+                  </PokeAlertDescription>
+                </PokeAlert>
               )}
               {result && result.display === "json" && (
                 <div className="mb-4 mt-4">

--- a/front/components/poke/shadcn/ui/form.tsx
+++ b/front/components/poke/shadcn/ui/form.tsx
@@ -176,7 +176,7 @@ const FormInput = React.forwardRef<
     <Input
       ref={ref}
       className={cn(
-        "border-2 border-border-dark dark:border-border-dark-night",
+        "border-2 border-border-dark dark:border-border-darker-night",
         "bg-white dark:bg-muted-background-night",
         className
       )}
@@ -197,7 +197,7 @@ const FormTextArea = React.forwardRef<
     <div ref={ref as React.RefObject<HTMLDivElement>}>
       <TextArea
         className={cn(
-          "border-2 border-border-dark dark:border-border-dark-night",
+          "border-2 border-border-dark dark:border-border-darker-night",
           "bg-white dark:bg-muted-background-night",
           className
         )}

--- a/front/lib/api/poke/plugins/data_sources/garbage_collect_google_drive_document.ts
+++ b/front/lib/api/poke/plugins/data_sources/garbage_collect_google_drive_document.ts
@@ -47,7 +47,7 @@ export const garbageCollectGoogleDriveDocumentPlugin = createPlugin({
         type: "string",
         label: "Document ID(s)",
         description:
-          "Document ID to garbage collect, or a comma-separated list. e.g. gdrive-1sz1eozmkoydwK63KkO4MMmXKuzqtYrHF or gdrive-abc, gdrive-def",
+          "Comma-separated list of document IDs to garbage collect, e.g. gdrive-abc, gdrive-def",
       },
     },
   },


### PR DESCRIPTION
## Description

- `dark:border-border-dark-night` is the same color as `dark:bg-muted-background-night`, causing some borders to be invisible.
- This PR fixes that for all call sites except the input bar, where it's more debatable (there is a very thin border, it does not necessarily clearly looks better or worse with it so will keep as is).
- It also shortens the the description of the Poke plugin GC Google Drive document to fit in one line.
- Also took the opportunity to align the colors of the borders across poke plugin dialogs.

Before
<img width="521" height="270" alt="Screenshot 2025-09-27 at 7 07 58 PM" src="https://github.com/user-attachments/assets/fef5b256-5a22-4cb6-a2dc-ce994a5ca611" />

After
<img width="521" height="270" alt="Screenshot 2025-09-27 at 7 06 22 PM" src="https://github.com/user-attachments/assets/94bc6bdc-167c-42b8-a775-bc6cae1d3a9c" />

## Tests

- Checked locally.

## Risk

- Low.

## Deploy Plan

- Deploy front.
