### PR TITLE
[connectors] chore(upserts): Handle 413 as data source quota exceeded

### DIFF
--- a/front/pages/api/poke/plans.ts
+++ b/front/pages/api/poke/plans.ts
@@ -117,7 +117,7 @@ async function handler(
           status_code: 400,
           api_error: {
             type: "invalid_request_error",
-            message: `Data source document size limit must be less than ${maxSizeMb}MB.`,
+            message: `Document size limit must be less than ${maxSizeMb}MB.`,
           },
         });
       }

--- a/front/pages/api/poke/plans.ts
+++ b/front/pages/api/poke/plans.ts
@@ -9,6 +9,7 @@ import type { SessionWithUser } from "@app/lib/iam/provider";
 import { Plan } from "@app/lib/models/plan";
 import { renderPlanFromModel } from "@app/lib/plans/renderers";
 import { apiError } from "@app/logger/withlogging";
+import { config as documentBodyParserConfig } from "@app/pages/api/v1/w/[wId]/spaces/[spaceId]/data_sources/[dsId]/documents/[documentId]";
 import type { PlanType, WithAPIErrorResponse } from "@app/types";
 
 export const PlanTypeSchema = t.type({
@@ -107,6 +108,19 @@ async function handler(
         });
       }
       const body = bodyValidation.right;
+
+      const { sizeLimit } = documentBodyParserConfig.api.bodyParser;
+      const maxSizeMb = parseInt(sizeLimit.replace("mb", ""), 10);
+
+      if (body.limits.dataSources.documents.sizeMb >= maxSizeMb) {
+        return apiError(req, res, {
+          status_code: 400,
+          api_error: {
+            type: "invalid_request_error",
+            message: `Data source document size limit must be less than ${maxSizeMb}MB.`,
+          },
+        });
+      }
 
       await Plan.upsert({
         code: body.code,

--- a/front/pages/poke/plans.tsx
+++ b/front/pages/poke/plans.tsx
@@ -119,96 +119,89 @@ const PlansPage = () => {
     plansToRender.push(editingPlan);
   }
 
-  return (
-    <>
-      {isPlansLoading ? (
-        <Spinner />
-      ) : (
-        <div className="flex h-full flex-col items-center justify-center">
-          <div className="h-full py-8 text-2xl font-bold">Plans</div>
-          <div className="h-full w-full overflow-x-auto pb-52 pt-12">
-            <table className="mx-auto h-full table-auto overflow-visible rounded-lg">
-              <thead className="bg-muted dark:bg-muted-night">
-                <tr>
-                  {Object.keys(PLAN_FIELDS).map((fieldName) => {
-                    const field =
-                      PLAN_FIELDS[fieldName as keyof typeof PLAN_FIELDS];
-                    return (
-                      <th key={fieldName}>
-                        {"IconComponent" in field ? (
-                          <div className="flex flex-row justify-center">
-                            <field.IconComponent />
-                          </div>
-                        ) : (
-                          field.title
-                        )}
-                      </th>
-                    );
-                  })}
-                  <th className="px-4 py-2">Edit</th>
-                </tr>
-              </thead>
-              <tbody className="h-full bg-background pb-48 text-primary-light dark:bg-background-night dark:text-primary-light-night">
-                {plansToRender?.map((plan) => {
-                  const planId = plan.isNewPlan ? "newPlan" : plan.code;
+  return isPlansLoading ? (
+    <Spinner />
+  ) : (
+    <div className="flex h-full flex-col items-center justify-center">
+      <div className="h-full py-8 text-2xl font-bold">Plans</div>
+      <div className="h-full w-full overflow-x-auto pb-52 pt-12">
+        <table className="mx-auto h-full table-auto overflow-visible rounded-lg">
+          <thead className="bg-muted dark:bg-muted-night">
+            <tr>
+              {Object.keys(PLAN_FIELDS).map((fieldName) => {
+                const field =
+                  PLAN_FIELDS[fieldName as keyof typeof PLAN_FIELDS];
+                return (
+                  <th key={fieldName}>
+                    {"IconComponent" in field ? (
+                      <div className="flex flex-row justify-center">
+                        <field.IconComponent />
+                      </div>
+                    ) : (
+                      field.title
+                    )}
+                  </th>
+                );
+              })}
+              <th className="px-4 py-2">Edit</th>
+            </tr>
+          </thead>
+          <tbody className="h-full bg-background pb-48 text-primary-light dark:bg-background-night dark:text-primary-light-night">
+            {plansToRender?.map((plan) => {
+              const planId = plan.isNewPlan ? "newPlan" : plan.code;
 
-                  return (
-                    <tr key={planId}>
-                      {Object.keys(PLAN_FIELDS).map((fieldName) => (
-                        <React.Fragment key={`${planId}:${fieldName}`}>
-                          <Field
-                            plan={plan}
-                            fieldName={fieldName as keyof typeof PLAN_FIELDS}
-                            isEditing={
-                              (!editingPlan?.isNewPlan &&
-                                editingPlan?.code === plan.code) ||
-                              (!!editingPlan?.isNewPlan && !!plan.isNewPlan)
-                            }
-                            setEditingPlan={setEditingPlan}
-                            editingPlan={editingPlan}
-                          />
-                        </React.Fragment>
-                      ))}
-                      <td className="w-12 min-w-16 flex-none border px-4 py-2">
-                        {plan.code === editingPlan?.code || plan.isNewPlan ? (
-                          <div className="flex flex-row justify-center">
-                            <IconButton
-                              icon={CheckIcon}
-                              onClick={handleSavePlan}
-                            />
-                            <IconButton
-                              icon={XMarkIcon}
-                              onClick={resetEditingPlan}
-                            />
-                          </div>
-                        ) : (
-                          <div className="flex flex-row justify-center">
-                            <IconButton
-                              icon={PencilSquareIcon}
-                              onClick={() => setEditingPlan(plan)}
-                            />
-                          </div>
-                        )}
-                      </td>
-                    </tr>
-                  );
-                })}
-              </tbody>
-            </table>
-          </div>
-          <div>
-            <Button
-              icon={PlusIcon}
-              label="Create a new plan"
-              variant="outline"
-              onClick={() => createNewPlan()}
-              // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
-              disabled={editingPlan?.isNewPlan || !!editingPlan}
-            />
-          </div>
-        </div>
-      )}
-    </>
+              return (
+                <tr key={planId}>
+                  {Object.keys(PLAN_FIELDS).map((fieldName) => (
+                    <React.Fragment key={`${planId}:${fieldName}`}>
+                      <Field
+                        plan={plan}
+                        fieldName={fieldName as keyof typeof PLAN_FIELDS}
+                        isEditing={
+                          (!editingPlan?.isNewPlan &&
+                            editingPlan?.code === plan.code) ||
+                          (!!editingPlan?.isNewPlan && !!plan.isNewPlan)
+                        }
+                        setEditingPlan={setEditingPlan}
+                        editingPlan={editingPlan}
+                      />
+                    </React.Fragment>
+                  ))}
+                  <td className="w-12 min-w-16 flex-none border px-4 py-2">
+                    {plan.code === editingPlan?.code || plan.isNewPlan ? (
+                      <div className="flex flex-row justify-center">
+                        <IconButton icon={CheckIcon} onClick={handleSavePlan} />
+                        <IconButton
+                          icon={XMarkIcon}
+                          onClick={resetEditingPlan}
+                        />
+                      </div>
+                    ) : (
+                      <div className="flex flex-row justify-center">
+                        <IconButton
+                          icon={PencilSquareIcon}
+                          onClick={() => setEditingPlan(plan)}
+                        />
+                      </div>
+                    )}
+                  </td>
+                </tr>
+              );
+            })}
+          </tbody>
+        </table>
+      </div>
+      <div>
+        <Button
+          icon={PlusIcon}
+          label="Create a new plan"
+          variant="outline"
+          onClick={() => createNewPlan()}
+          // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
+          disabled={editingPlan?.isNewPlan || !!editingPlan}
+        />
+      </div>
+    </div>
   );
 };
 


### PR DESCRIPTION
## Description

- This PR handles 413 Payload Too Large as per-document quota exceeded on data source document upserts.
- It also prevents setting a plan max document size higher than what is allowed by the `bodyParser` of the uspert endpoint.
- We used to not need this because we checked pre-emptively the size of the document in `connectors`.

## Tests

- Checked locally.

## Risk

- Low

## Deploy Plan

- Deploy front.
- Deploy connectors.
