### PR TITLE
Schema: read all rows at once instead of in batches

### DIFF
--- a/core/src/databases/table.rs
+++ b/core/src/databases/table.rs
@@ -760,27 +760,22 @@ impl LocalTable {
         &self,
         databases_store: Box<dyn DatabasesStore + Sync + Send>,
     ) -> Result<TableSchema> {
-        let mut schema: TableSchema = TableSchema::empty();
-        let limit = 500;
-        let mut offset = 0;
-        loop {
-            let (rows, total) = self
-                .list_rows(databases_store.clone(), Some((limit, offset)))
-                .await?;
-
-            let rows = Arc::new(rows);
-            if offset == 0 {
-                schema = TableSchema::from_rows_async(rows.clone()).await?;
-            } else {
-                schema = schema.merge(&TableSchema::from_rows_async(rows.clone()).await?)?;
-            }
-
-            offset += limit;
-            if offset >= total {
-                break;
-            }
-        }
-
+        let mut now = utils::now();
+        let (rows, _) = self.list_rows(databases_store, None).await?;
+        let rows = Arc::new(rows);
+        info!(
+            duration = utils::now() - now,
+            table_id = self.table.table_id(),
+            row_count = rows.len(),
+            "DSSTRUCTSTAT [compute_schema] list rows"
+        );
+        now = utils::now();
+        let schema = TableSchema::from_rows_async(rows).await?;
+        info!(
+            duration = utils::now() - now,
+            table_id = self.table.table_id(),
+            "DSSTRUCTSTAT [compute_schema] compute schema"
+        );
         Ok(schema)
     }
 


### PR DESCRIPTION
## Description

We had an extremely inefficient way of computing the schema now that files are in GCS.

This is an implementation that made sense when rows were in a table, but completely falls over with the GCS impl. At every iteration of the loop, we end up reading the entire file.

The fix is to read them all at once.

Fixes https://github.com/dust-tt/tasks/issues/4426#event-19945801009

## Tests

Manual.

## Risk

Low.

## Deploy Plan

Core