### PR TITLE
[front] chore(relocation): Remove template ID mapping

### DIFF
--- a/front/temporal/relocation/activities/source_region/front/sql.ts
+++ b/front/temporal/relocation/activities/source_region/front/sql.ts
@@ -188,24 +188,6 @@ export async function readFrontTableChunk({
     }
   );
 
-  // Apply template ID mapping for agent_configurations
-  // because some templates have a different ID between regions.
-  if (
-    tableName === "agent_configurations" &&
-    sourceRegion === "us-central1" &&
-    destRegion === "europe-west1"
-  ) {
-    const templateIdMapping: Record<number, number> = {
-      68: 74,
-    };
-
-    for (const row of rows as [{ id: ModelId; templateId: number | null }]) {
-      if (row.templateId != null && templateIdMapping[row.templateId]) {
-        row.templateId = templateIdMapping[row.templateId];
-      }
-    }
-  }
-
   const blob: RelocationBlob = {
     statements: {
       [tableName]: generateParameterizedInsertStatements(tableName, rows, {


### PR DESCRIPTION
## Description

- A mapping between template IDs was introduced in https://github.com/dust-tt/dust/pull/16285 to unblock a relocation.
- The relocation is now complete, the mapping can be removed.
- Another PR will prevent this issue from happening in the future.

## Tests

## Risk

- None.

## Deploy Plan

- Deploy front.
