### PR TITLE
[front] fix(templates): ensure ID stability in pull + backfill

### DIFF
--- a/front/components/poke/templates/TemplatesDataTable.tsx
+++ b/front/components/poke/templates/TemplatesDataTable.tsx
@@ -9,9 +9,10 @@ import type { CellContext } from "@tanstack/react-table";
 import Link from "next/link";
 import React, { useState } from "react";
 
+import type { FetchAssistantTemplatesResponse } from "@app/pages/api/templates";
 import { usePokeAssistantTemplates, usePokePullTemplates } from "@app/poke/swr";
 import type { TemplateTagCodeType, TemplateVisibility } from "@app/types";
-import { TEMPLATES_TAGS_CONFIG } from "@app/types";
+import { isDevelopment, TEMPLATES_TAGS_CONFIG } from "@app/types";
 
 export interface TemplatesDisplayType {
   id: string;
@@ -23,7 +24,9 @@ export interface TemplatesDisplayType {
 
 type Info = CellContext<TemplatesDisplayType, unknown>;
 
-function prepareTemplatesForDisplay(templates: any[]): TemplatesDisplayType[] {
+function prepareTemplatesForDisplay(
+  templates: FetchAssistantTemplatesResponse["templates"]
+): TemplatesDisplayType[] {
   return templates.map((t) => ({
     id: t.sId,
     name: t.handle,
@@ -39,14 +42,12 @@ export function makeColumnsForTemplates() {
       cell: (info: Info) => {
         const id: string = info.row.getValue("id");
         return (
-          <>
-            <Link
-              className="font-bold hover:underline"
-              href={`/poke/templates/${id}`}
-            >
-              {id}
-            </Link>
-          </>
+          <Link
+            className="font-bold hover:underline"
+            href={`/poke/templates/${id}`}
+          >
+            {id}
+          </Link>
         );
       },
     },
@@ -59,11 +60,9 @@ export function makeColumnsForTemplates() {
     {
       accessorKey: "visibility",
       cell: (info: Info) => (
-        <>
-          <DataTable.CellContent>
-            {info.row.original.visibility}
-          </DataTable.CellContent>
-        </>
+        <DataTable.CellContent>
+          {info.row.original.visibility}
+        </DataTable.CellContent>
       ),
     },
     {
@@ -79,11 +78,7 @@ export function makeColumnsForTemplates() {
             size="xs"
           />
         ));
-        return (
-          <>
-            <div className="flex gap-x-2">{tagChips}</div>
-          </>
-        );
+        return <div className="flex gap-x-2">{tagChips}</div>;
       },
     },
   ];
@@ -118,13 +113,16 @@ export function TemplatesDataTable({
             label={isPulling ? "Pulling..." : "Pull templates"}
           />
         )}
-        <Button
-          aria-label="Create template"
-          variant="outline"
-          size="sm"
-          label="Create template"
-          href="/poke/templates/new"
-        />
+        {!dustRegionSyncEnabled ||
+          (isDevelopment() && (
+            <Button
+              aria-label="Create template"
+              variant="outline"
+              size="sm"
+              label="Create template"
+              href="/poke/templates/new"
+            />
+          ))}
       </div>
       <SearchInput
         name="search"

--- a/front/lib/resources/template_resource.ts
+++ b/front/lib/resources/template_resource.ts
@@ -60,10 +60,16 @@ export class TemplateResource extends BaseResource<TemplateModel> {
     });
   }
 
-  static async makeNew(blob: CreationAttributes<TemplateModel>) {
-    const template = await TemplateModel.create({
-      ...blob,
-    });
+  static async makeNew(
+    blob: CreationAttributes<TemplateModel>,
+    { transaction }: { transaction?: Transaction } = {}
+  ) {
+    const template = await TemplateModel.create(
+      {
+        ...blob,
+      },
+      { transaction }
+    );
 
     return new this(TemplateModel, template.get());
   }

--- a/front/lib/resources/template_resource.ts
+++ b/front/lib/resources/template_resource.ts
@@ -5,11 +5,9 @@ import type {
   Transaction,
   WhereOptions,
 } from "sequelize";
-import { Op } from "sequelize";
 
 import { makeUrlForEmojiAndBackground } from "@app/components/agent_builder/settings/avatar_picker/utils";
 import type { Authenticator } from "@app/lib/auth";
-import { AgentConfiguration } from "@app/lib/models/assistant/agent";
 import {
   CROSS_WORKSPACE_RESOURCES_WORKSPACE_ID,
   getResourceIdFromSId,
@@ -17,7 +15,6 @@ import {
   makeSId,
 } from "@app/lib/resources//string_ids";
 import { BaseResource } from "@app/lib/resources/base_resource";
-import { frontSequelize } from "@app/lib/resources/storage";
 import { TemplateModel } from "@app/lib/resources/storage/models/templates";
 import type { ReadonlyAttributesType } from "@app/lib/resources/storage/types";
 import type { ModelId, Result, TemplateVisibility } from "@app/types";

--- a/front/lib/resources/template_resource.ts
+++ b/front/lib/resources/template_resource.ts
@@ -172,6 +172,7 @@ export class TemplateResource extends BaseResource<TemplateModel> {
 
   toJSON() {
     return {
+      id: this.id,
       backgroundColor: this.backgroundColor,
       description: this.description,
       emoji: this.emoji,

--- a/front/migrations/20250928_check_templates_id_match.ts
+++ b/front/migrations/20250928_check_templates_id_match.ts
@@ -1,0 +1,214 @@
+import assert from "assert";
+import { Op } from "sequelize";
+
+import { config } from "@app/lib/api/regions/config";
+import { AgentConfiguration } from "@app/lib/models/assistant/agent";
+import { frontSequelize } from "@app/lib/resources/storage";
+import { TemplateModel } from "@app/lib/resources/storage/models/templates";
+import { TemplateResource } from "@app/lib/resources/template_resource";
+import type { Logger } from "@app/logger/logger";
+import type {
+  AssistantTemplateListType,
+  FetchAssistantTemplatesResponse,
+} from "@app/pages/api/templates";
+import { makeScript } from "@app/scripts/helpers";
+
+async function computeTemplateIdMatches({
+  logger,
+}: {
+  logger: Logger;
+}): Promise<
+  {
+    localTemplate: TemplateResource | null;
+    remoteTemplate: AssistantTemplateListType;
+  }[]
+> {
+  if (!config.getDustRegionSyncEnabled()) {
+    logger.info("Region sync not enabled, skipping template ID check");
+    return [];
+  }
+
+  const localTemplates = await TemplateResource.listAll();
+  logger.info(`Found ${localTemplates.length} local templates`);
+
+  const mainRegionUrl = config.getDustRegionSyncMasterUrl();
+
+  const response = await fetch(`${mainRegionUrl}/api/templates`, {
+    method: "GET",
+  });
+
+  if (!response.ok) {
+    throw new Error(
+      `Failed to fetch templates from main region: ${response.status}`
+    );
+  }
+
+  const { templates: remoteTemplates }: FetchAssistantTemplatesResponse =
+    await response.json();
+  logger.info(`Found ${remoteTemplates.length} remote templates`);
+
+  const localTemplatesByHandle = new Map<string, TemplateResource>();
+  for (const template of localTemplates) {
+    localTemplatesByHandle.set(template.handle, template);
+  }
+
+  const mismatches = [];
+  for (const remoteTemplate of remoteTemplates) {
+    const localTemplate = localTemplatesByHandle.get(remoteTemplate.handle);
+    if (localTemplate) {
+      if (localTemplate.id !== remoteTemplate.id) {
+        logger.info(
+          {
+            handle: localTemplate.handle,
+            localId: localTemplate.id,
+            remoteId: remoteTemplate.id,
+          },
+          "Template ID mismatch"
+        );
+        mismatches.push({
+          localTemplate,
+          remoteTemplate,
+        });
+      }
+    } else {
+      logger.info(
+        {
+          handle: remoteTemplate.handle,
+          remoteId: remoteTemplate.id,
+        },
+        "Template not found locally"
+      );
+      mismatches.push({
+        localTemplate: null,
+        remoteTemplate,
+      });
+    }
+  }
+
+  return mismatches;
+}
+
+async function fixTemplateMismatch(
+  mismatch: {
+    localTemplate: TemplateResource | null;
+    remoteTemplate: AssistantTemplateListType;
+  },
+  { execute, logger }: { execute: boolean; logger: Logger }
+): Promise<void> {
+  const { localTemplate, remoteTemplate } = mismatch;
+
+  if (!localTemplate) {
+    logger.warn(
+      {
+        handle: remoteTemplate.handle,
+        remoteId: remoteTemplate.id,
+      },
+      "Template not found locally, please run a pull before proceeding"
+    );
+    return;
+  }
+
+  logger.info(
+    {
+      handle: localTemplate.handle,
+      localId: localTemplate.id,
+      remoteId: remoteTemplate.id,
+    },
+    "Fixing template ID mismatch"
+  );
+
+  // 1. We abort if there is no template with a higher id than the one we want to create.
+  // Since we don't bump the sequence, this prevents creating a template with an id that
+  // could be taken by a future template (although should not happen because of sharding).
+  const templatesWithHigherId = await TemplateModel.findAll({
+    where: {
+      id: { [Op.gt]: remoteTemplate.id },
+    },
+  });
+  if (templatesWithHigherId.length === 0) {
+    logger.error("No templates with higher id found, aborting.");
+  }
+
+  // 2. We abort if the id we want to create is already taken by another template.
+  const templateWithSameId = await TemplateModel.findOne({
+    where: { id: remoteTemplate.id },
+  });
+  if (templateWithSameId) {
+    logger.error("Template ID already taken, aborting.");
+  }
+
+  // 3. We fetch the template from the main region and create a new template with the correct id.
+  // We move the FK from existing agent configurations to the new template's id.
+  if (execute) {
+    const affectedAgentConfigurations = await frontSequelize.transaction(
+      async (t) => {
+        const templateCopy = await TemplateResource.makeNew(
+          { ...localTemplate, id: remoteTemplate.id },
+          { transaction: t }
+        );
+        assert(templateCopy.id === remoteTemplate.id);
+
+        const [affectedCount] = await AgentConfiguration.update(
+          {
+            templateId: templateCopy.id,
+          },
+          {
+            where: { templateId: localTemplate.id },
+            transaction: t,
+          }
+        );
+        await localTemplate.model.destroy({ transaction: t });
+
+        return affectedCount;
+      }
+    );
+    logger.info(
+      {
+        handle: localTemplate.handle,
+        oldId: localTemplate.id,
+        newId: remoteTemplate.id,
+        affectedAgentConfigurations,
+      },
+      "Successfully fixed template ID mismatch"
+    );
+  } else {
+    const affectedAgentConfigurations = await AgentConfiguration.findAll({
+      where: { templateId: localTemplate.id },
+    });
+    logger.info(
+      {
+        handle: localTemplate.handle,
+        oldId: localTemplate.id,
+        newId: remoteTemplate.id,
+        affectedAgentConfigurations: affectedAgentConfigurations.length,
+      },
+      "Would fix template ID mismatch"
+    );
+  }
+}
+
+makeScript({}, async ({ execute }, logger) => {
+  logger.info("Starting template ID match check");
+
+  const mismatches = await computeTemplateIdMatches({ logger });
+
+  if (mismatches.length === 0) {
+    logger.info("No template ID mismatches found");
+    return;
+  }
+
+  if (mismatches.some(({ localTemplate }) => localTemplate === null)) {
+    logger.warn(
+      "Some templates are not found locally, please run a pull before proceeding"
+    );
+    return;
+  }
+
+  logger.info(`Found ${mismatches.length} template ID mismatches`);
+
+  for (const mismatch of mismatches) {
+    await fixTemplateMismatch(mismatch, { execute, logger });
+  }
+
+  logger.info("Template ID match check completed");
+});

--- a/front/pages/api/poke/templates/[tId].ts
+++ b/front/pages/api/poke/templates/[tId].ts
@@ -10,8 +10,11 @@ import type { SessionWithUser } from "@app/lib/iam/provider";
 import { TemplateResource } from "@app/lib/resources/template_resource";
 import { apiError } from "@app/logger/withlogging";
 import type { WithAPIErrorResponse } from "@app/types";
-import { isDevelopment } from "@app/types";
-import { CreateTemplateFormSchema, isTemplateTagCodeArray } from "@app/types";
+import {
+  CreateTemplateFormSchema,
+  isDevelopment,
+  isTemplateTagCodeArray,
+} from "@app/types";
 
 export type PokeFetchAssistantTemplateResponse = ReturnType<
   TemplateResource["toJSON"]
@@ -140,7 +143,7 @@ async function handler(
         helpInstructions: body.helpInstructions ?? null,
         presetActions: body.presetActions,
         timeFrameDuration: body.timeFrameDuration
-          ? parseInt(body.timeFrameDuration)
+          ? parseInt(body.timeFrameDuration, 10)
           : null,
         // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
         timeFrameUnit: body.timeFrameUnit || null,
@@ -182,7 +185,8 @@ async function handler(
         status_code: 405,
         api_error: {
           type: "method_not_supported_error",
-          message: "The method passed is not supported, POST is expected.",
+          message:
+            "The method passed is not supported, GET, PATCH or DELETE is expected.",
         },
       });
   }

--- a/front/pages/api/poke/templates/[tId].ts
+++ b/front/pages/api/poke/templates/[tId].ts
@@ -4,11 +4,13 @@ import type { NextApiRequest, NextApiResponse } from "next";
 
 import { USED_MODEL_CONFIGS } from "@app/components/providers/types";
 import { withSessionAuthenticationForPoke } from "@app/lib/api/auth_wrappers";
+import { config as regionConfig } from "@app/lib/api/regions/config";
 import { Authenticator } from "@app/lib/auth";
 import type { SessionWithUser } from "@app/lib/iam/provider";
 import { TemplateResource } from "@app/lib/resources/template_resource";
 import { apiError } from "@app/logger/withlogging";
 import type { WithAPIErrorResponse } from "@app/types";
+import { isDevelopment } from "@app/types";
 import { CreateTemplateFormSchema, isTemplateTagCodeArray } from "@app/types";
 
 export type PokeFetchAssistantTemplateResponse = ReturnType<
@@ -89,6 +91,16 @@ async function handler(
             type: "invalid_request_error",
             message:
               "The request body is invalid: tags must be an array of template tag names.",
+          },
+        });
+      }
+
+      if (regionConfig.getDustRegionSyncEnabled() && !isDevelopment()) {
+        return apiError(req, res, {
+          status_code: 400,
+          api_error: {
+            type: "invalid_request_error",
+            message: "Cannot update templates in non-main regions.",
           },
         });
       }

--- a/front/pages/api/poke/templates/pull.ts
+++ b/front/pages/api/poke/templates/pull.ts
@@ -82,9 +82,7 @@ async function handler(
         const template: FetchAssistantTemplateResponse =
           await templateResponse.json();
 
-        await TemplateResource.upsertByHandle(template, {
-          keepIdMapping: true,
-        });
+        await TemplateResource.upsertByHandle(template);
 
         count++;
       }

--- a/front/pages/api/poke/templates/pull.ts
+++ b/front/pages/api/poke/templates/pull.ts
@@ -82,7 +82,9 @@ async function handler(
         const template: FetchAssistantTemplateResponse =
           await templateResponse.json();
 
-        await TemplateResource.upsertByHandle(template);
+        await TemplateResource.upsertByHandle(template, {
+          keepIdMapping: true,
+        });
 
         count++;
       }


### PR DESCRIPTION
## Description

- When pulling templates, we currently do not preserve their IDs.
- This crashes the workspace relocation during the agent configurations copy since there is an FK to the templates.
- This PR updates the templates pull to preserve IDs, and adds a script to backfill them if needed to ensure the matching.
- It also prevents template creation/update from a non main region: you can either pull or create. This is to make sure we have the same templates in both regions since we do not want to create two templates with the same data in both regions as it would lead to a hard to remove duplicate (same data, different ID, could both have agents). This can be revisited if we need to create templates only in EU and not in the US.

## Tests

- Hard to test in a single env setup, will test by deploying in prod and using the template pull locally to confirm.

## Risk

- Low but does an update on `agent_configurations` that could be slow.

## Deploy Plan

- Deploy front.
- Run script in EU only.
