### PR TITLE
[connectors] enh(Notion): speed up batch block cache deletion

### DIFF
--- a/connectors/migrations/db/migration_94.sql
+++ b/connectors/migrations/db/migration_94.sql
@@ -1,3 +1,2 @@
 -- Migration created on Sep 29, 2025
-CREATE INDEX "notion_connector_block_cache_entries_connector_id_workflow_id" ON "notion_connector_block_cache_entries" ("connectorId", "workflowId");
-[09:11:49.442] [32mINFO[39m (94930): [36mDone[39m;
+CREATE INDEX CONCURRENTLY "notion_connector_block_cache_entries_connector_id_workflow_id" ON "notion_connector_block_cache_entries" ("connectorId", "workflowId");

--- a/connectors/migrations/db/migration_94.sql
+++ b/connectors/migrations/db/migration_94.sql
@@ -1,0 +1,3 @@
+-- Migration created on Sep 29, 2025
+CREATE INDEX "notion_connector_block_cache_entries_connector_id_workflow_id" ON "notion_connector_block_cache_entries" ("connectorId", "workflowId");
+[09:11:49.442] [32mINFO[39m (94930): [36mDone[39m;

--- a/connectors/src/connectors/notion/temporal/activities.ts
+++ b/connectors/src/connectors/notion/temporal/activities.ts
@@ -101,8 +101,6 @@ const SKIP_DELETION_CONNECTOR_ID_HASHES = new Set<string>([
   "pDddXWMzWYw4oN/acYfLiOwxB3tlp51IH6MuMYD3YXQ=",
 ]);
 
-const CACHE_DELETION_BATCH_SIZE = 512;
-
 const wrapWithErrorCheck = async <T>(
   callback: () => Promise<T>,
   loggerArgs: Record<string, string | number>
@@ -2339,18 +2337,12 @@ export async function clearWorkflowCache({
       workflowId: topLevelWorkflowId,
     },
   });
-
-  let deletedCount = 0;
-  do {
-    deletedCount = await NotionConnectorBlockCacheEntry.destroy({
-      where: {
-        connectorId: connector.id,
-        workflowId: topLevelWorkflowId,
-      },
-      limit: CACHE_DELETION_BATCH_SIZE,
-    });
-  } while (deletedCount === CACHE_DELETION_BATCH_SIZE);
-
+  await NotionConnectorBlockCacheEntry.destroy({
+    where: {
+      connectorId: connector.id,
+      workflowId: topLevelWorkflowId,
+    },
+  });
   await NotionConnectorResourcesToCheckCacheEntry.destroy({
     where: {
       connectorId: connector.id,

--- a/connectors/src/lib/models/notion.ts
+++ b/connectors/src/lib/models/notion.ts
@@ -438,6 +438,7 @@ NotionConnectorBlockCacheEntry.init(
       { fields: ["parentBlockId"] },
       { fields: ["notionPageId"] },
       { fields: ["workflowId"] },
+      { fields: ["connectorId", "workflowId"] },
     ],
   }
 );


### PR DESCRIPTION
## Description

- This PR adds a composite index to speed up the cached block entry deletions.
- We currently have two indexes, one of connectorId and one on workflowId, and do two bitmap index scans, the goal is to go single index scan.
- The query has a high load in db and takes ~4s in average for 1.2k rows returned in avg.

## Tests

## Risk

- More storage

## Deploy Plan

- Deploy connectors.
- Run migration.
