### PR TITLE
pubsub / events: centralize publication code

### DIFF
--- a/front/lib/api/assistant/mcp_events.ts
+++ b/front/lib/api/assistant/mcp_events.ts
@@ -3,7 +3,7 @@ import {
   getMCPServerResultsChannelId,
   isMCPEventResult,
 } from "@app/lib/api/actions/mcp_client_side";
-import { publishEvent } from "@app/lib/api/assistant/pubsub";
+import { publishEvent } from "@app/lib/api/assistant/streaming/events";
 import type { EventPayload } from "@app/lib/api/redis-hybrid-manager";
 import { getRedisHybridManager } from "@app/lib/api/redis-hybrid-manager";
 import type { Authenticator } from "@app/lib/auth";

--- a/front/lib/api/assistant/pubsub.ts
+++ b/front/lib/api/assistant/pubsub.ts
@@ -1,6 +1,5 @@
 import type { AgentActionRunningEvents } from "@app/lib/actions/mcp";
 import { getMessageChannelId } from "@app/lib/api/assistant/streaming/helpers";
-import type { RedisUsageTagsType } from "@app/lib/api/redis";
 import type { EventPayload } from "@app/lib/api/redis-hybrid-manager";
 import { getRedisHybridManager } from "@app/lib/api/redis-hybrid-manager";
 import type { Authenticator } from "@app/lib/auth";
@@ -214,16 +213,4 @@ export async function* getMessagesEvents(
 
 function getConversationChannelId(channelId: string) {
   return `conversation-${channelId}`;
-}
-
-export async function publishEvent({
-  origin,
-  channel,
-  event,
-}: {
-  origin: RedisUsageTagsType;
-  channel: string;
-  event: string;
-}) {
-  await getRedisHybridManager().publish(channel, event, origin);
 }

--- a/front/lib/api/assistant/streaming/events.ts
+++ b/front/lib/api/assistant/streaming/events.ts
@@ -7,6 +7,7 @@ import type {
   AgentMessageEvents,
   ConversationEvents,
 } from "@app/lib/api/assistant/streaming/types";
+import type { RedisUsageTagsType } from "@app/lib/api/redis";
 import { getRedisHybridManager } from "@app/lib/api/redis-hybrid-manager";
 import type {
   AgentMessageNewEvent,
@@ -17,6 +18,24 @@ import type {
 } from "@app/types";
 import { assertNever } from "@app/types";
 
+/**
+ * Generic event publication interface.
+ */
+export async function publishEvent({
+  origin,
+  channel,
+  event,
+}: {
+  origin: RedisUsageTagsType;
+  channel: string;
+  event: string;
+}) {
+  await getRedisHybridManager().publish(channel, event, origin);
+}
+
+/**
+ * Conversation event publication interface.
+ */
 export async function publishConversationEvent(
   event: ConversationEvents,
   {
@@ -39,6 +58,9 @@ export async function publishConversationEvent(
   );
 }
 
+/**
+ * Message event publication interface.
+ */
 async function publishMessageEvent(
   event: AgentMessageEvents,
   {

--- a/front/lib/api/assistant/streaming/events.ts
+++ b/front/lib/api/assistant/streaming/events.ts
@@ -36,7 +36,7 @@ export async function publishEvent({
 /**
  * Conversation event publication interface.
  */
-export async function publishConversationEvent(
+async function publishConversationEvent(
   event: ConversationEvents,
   {
     conversationId,

--- a/front/lib/api/assistant/streaming/events.ts
+++ b/front/lib/api/assistant/streaming/events.ts
@@ -36,7 +36,7 @@ export async function publishEvent({
 /**
  * Conversation event publication interface.
  */
-async function publishConversationEvent(
+export async function publishConversationEvent(
   event: ConversationEvents,
   {
     conversationId,


### PR DESCRIPTION
## Description

Ensure that all event publication code lives in one file to better understand all callsites capable of emitting events

## Tests

N/A pure refactor / type system

## Risk

None

## Deploy Plan

- deploy `front`