### PR TITLE
Implements virtuoso list along side the existing pattern

### DIFF
--- a/front/components/assistant/conversation/AgentMessageVirtuoso.tsx
+++ b/front/components/assistant/conversation/AgentMessageVirtuoso.tsx
@@ -1,0 +1,713 @@
+import {
+  ArrowPathIcon,
+  Button,
+  Chip,
+  ClipboardCheckIcon,
+  ClipboardIcon,
+  ConversationMessage,
+  DocumentIcon,
+  InteractiveImageGrid,
+  Markdown,
+  Separator,
+  StopIcon,
+  useCopyToClipboard,
+} from "@dust-tt/sparkle";
+import { useVirtuosoMethods } from "@virtuoso.dev/message-list";
+import { marked } from "marked";
+import React, { useCallback } from "react";
+import type { Components } from "react-markdown";
+import type { PluggableList } from "react-markdown/lib/react-markdown";
+
+import { AgentMessageActions } from "@app/components/assistant/conversation/actions/AgentMessageActions";
+import { AgentHandle } from "@app/components/assistant/conversation/AgentHandle";
+import {
+  AgentMessageContentCreationGeneratedFiles,
+  DefaultAgentMessageGeneratedFiles,
+} from "@app/components/assistant/conversation/AgentMessageGeneratedFiles";
+import { useActionValidationContext } from "@app/components/assistant/conversation/BlockedActionsProvider";
+import { useAutoOpenContentCreation } from "@app/components/assistant/conversation/content_creation/useAutoOpenContentCreation";
+import { ErrorMessage } from "@app/components/assistant/conversation/ErrorMessage";
+import type { FeedbackSelectorProps } from "@app/components/assistant/conversation/FeedbackSelector";
+import { FeedbackSelector } from "@app/components/assistant/conversation/FeedbackSelector";
+import { FeedbackSelectorPopoverContent } from "@app/components/assistant/conversation/FeedbackSelectorPopoverContent";
+import { GenerationContext } from "@app/components/assistant/conversation/GenerationContextProvider";
+import { MCPServerPersonalAuthenticationRequired } from "@app/components/assistant/conversation/MCPServerPersonalAuthenticationRequired";
+import type {
+  AgentMessageStateWithControlEvent,
+  MessageTemporaryState,
+  VirtuosoMessage,
+  VirtuosoMessageListContext,
+} from "@app/components/assistant/conversation/types";
+import {
+  getMessageSId,
+  isMessageTemporayState,
+} from "@app/components/assistant/conversation/types";
+import {
+  CitationsContext,
+  CiteBlock,
+  getCiteDirective,
+} from "@app/components/markdown/CiteBlock";
+import { getImgPlugin, imgDirective } from "@app/components/markdown/Image";
+import type { MarkdownCitation } from "@app/components/markdown/MarkdownCitation";
+import { getCitationIcon } from "@app/components/markdown/MarkdownCitation";
+import {
+  getMentionPlugin,
+  mentionDirective,
+} from "@app/components/markdown/MentionBlock";
+import {
+  getVisualizationPlugin,
+  sanitizeVisualizationContent,
+  visualizationDirective,
+} from "@app/components/markdown/VisualizationBlock";
+import { useTheme } from "@app/components/sparkle/ThemeContext";
+import { useAgentMessageStreamVirtuoso } from "@app/hooks/useAgentMessageStreamVirtuoso";
+import { isImageProgressOutput } from "@app/lib/actions/mcp_internal_actions/output_schemas";
+import { useCancelMessage } from "@app/lib/swr/conversations";
+import { useConversationMessage } from "@app/lib/swr/conversations";
+import { formatTimestring } from "@app/lib/utils/timestamps";
+import type {
+  LightAgentMessageType,
+  LightAgentMessageWithActionsType,
+  PersonalAuthenticationRequiredErrorContent,
+  UserType,
+  WorkspaceType,
+} from "@app/types";
+import {
+  assertNever,
+  GLOBAL_AGENTS_SID,
+  isContentCreationFileContentType,
+  isPersonalAuthenticationRequiredErrorContent,
+  isSupportedImageContentType,
+} from "@app/types";
+
+interface AgentMessageProps {
+  conversationId: string;
+  isLastMessage: boolean;
+  messageStreamState: MessageTemporaryState;
+  messageFeedback: FeedbackSelectorProps;
+  owner: WorkspaceType;
+  user: UserType;
+}
+
+export function AgentMessageVirtuoso({
+  conversationId,
+  isLastMessage,
+  messageStreamState,
+  messageFeedback,
+  owner,
+}: AgentMessageProps) {
+  const sId = getMessageSId(messageStreamState);
+  const { isDark } = useTheme();
+
+  const [isRetryHandlerProcessing, setIsRetryHandlerProcessing] =
+    React.useState<boolean>(false);
+
+  const [activeReferences, setActiveReferences] = React.useState<
+    { index: number; document: MarkdownCitation }[]
+  >([]);
+  const [isCopied, copy] = useCopyToClipboard();
+
+  const isGlobalAgent = Object.values(GLOBAL_AGENTS_SID).includes(
+    messageStreamState.message.configuration.sId as GLOBAL_AGENTS_SID
+  );
+
+  const { showBlockedActionsDialog, enqueueBlockedAction } =
+    useActionValidationContext();
+
+  const { mutateMessage } = useConversationMessage({
+    conversationId,
+    workspaceId: owner.sId,
+    messageId: sId,
+    options: { disabled: true },
+  });
+
+  const { shouldStream } = useAgentMessageStreamVirtuoso({
+    messageStreamState,
+    conversationId,
+    owner,
+    mutateMessage,
+    onEventCallback: useCallback(
+      (eventPayload: {
+        eventId: string;
+        data: AgentMessageStateWithControlEvent;
+      }) => {
+        const eventType = eventPayload.data.type;
+
+        if (eventType === "tool_approve_execution") {
+          showBlockedActionsDialog();
+          enqueueBlockedAction({
+            messageId: sId,
+            blockedAction: {
+              status: "blocked_validation_required",
+              authorizationInfo: null,
+              messageId: eventPayload.data.messageId,
+              conversationId: eventPayload.data.conversationId,
+              actionId: eventPayload.data.actionId,
+              inputs: eventPayload.data.inputs,
+              stake: eventPayload.data.stake,
+              metadata: eventPayload.data.metadata,
+            },
+          });
+        }
+      },
+      [showBlockedActionsDialog, enqueueBlockedAction, sId]
+    ),
+    streamId: `message-${sId}`,
+    useFullChainOfThought: false,
+  });
+
+  const methods = useVirtuosoMethods<
+    VirtuosoMessage,
+    VirtuosoMessageListContext
+  >();
+
+  const agentMessageToRender = getAgentMessageToRender({
+    message: messageStreamState.message,
+    messageStreamState: messageStreamState,
+  });
+  const cancelMessage = useCancelMessage({ owner, conversationId });
+
+  const references = Object.entries(
+    agentMessageToRender.citations ?? {}
+  ).reduce<Record<string, MarkdownCitation>>((acc, [key, citation]) => {
+    if (citation) {
+      const IconComponent = getCitationIcon(
+        citation.provider,
+        isDark,
+        citation.faviconUrl,
+        citation.href
+      );
+      return {
+        ...acc,
+        [key]: {
+          href: citation.href,
+          title: citation.title,
+          description: citation.description,
+          icon: <IconComponent />,
+        },
+      };
+    }
+    return acc;
+  }, {});
+
+  // GenerationContext: to know if we are generating or not.
+  const generationContext = React.useContext(GenerationContext);
+  if (!generationContext) {
+    throw new Error(
+      "AgentMessage must be used within a GenerationContextProvider"
+    );
+  }
+  React.useEffect(() => {
+    const isInArray = generationContext.generatingMessages.some(
+      (m) => m.messageId === sId
+    );
+    if (agentMessageToRender.status === "created" && !isInArray) {
+      generationContext.setGeneratingMessages((s) => [
+        ...s,
+        { messageId: sId, conversationId },
+      ]);
+    } else if (agentMessageToRender.status !== "created" && isInArray) {
+      generationContext.setGeneratingMessages((s) =>
+        s.filter((m) => m.messageId !== sId)
+      );
+    }
+  }, [agentMessageToRender.status, generationContext, sId, conversationId]);
+
+  // Auto-open content creation drawer when content creation files are available.
+  const { contentCreationFiles } = useAutoOpenContentCreation({
+    messageStreamState,
+    agentMessageToRender,
+    isLastMessage,
+  });
+
+  const PopoverContent = useCallback(
+    () => (
+      <FeedbackSelectorPopoverContent
+        owner={owner}
+        agentMessageToRender={agentMessageToRender}
+      />
+    ),
+    [owner, agentMessageToRender]
+  );
+
+  async function handleCopyToClipboard() {
+    const messageContent = agentMessageToRender.content ?? "";
+    let footnotesMarkdown = "";
+    let footnotesHtml = "";
+
+    // 1. Build Key-to-Index Map
+    const keyToIndexMap = new Map<string, number>();
+    if (references && activeReferences) {
+      Object.entries(references).forEach(([key, mdCitation]) => {
+        const activeRefEntry = activeReferences.find(
+          (ar) =>
+            ar.document.href === mdCitation.href &&
+            ar.document.title === mdCitation.title
+        );
+        if (activeRefEntry) {
+          keyToIndexMap.set(key, activeRefEntry.index);
+        }
+      });
+    }
+
+    // 2. Process Message Content for Plain Text numerical citations
+    let processedMessageContent = messageContent;
+    if (keyToIndexMap.size > 0) {
+      const citeDirectiveRegex = /:cite\[([a-zA-Z0-9_,-]+)\]/g;
+      processedMessageContent = messageContent.replace(
+        citeDirectiveRegex,
+        (_match, keysString: string) => {
+          const keys = keysString.split(",").map((k) => k.trim());
+          const resolvedIndices = keys
+            .map((k) => keyToIndexMap.get(k))
+            .filter((idx) => idx !== undefined) as number[];
+
+          if (resolvedIndices.length > 0) {
+            resolvedIndices.sort((a, b) => a - b);
+            return `[${resolvedIndices.join(",")}]`;
+          }
+          return _match;
+        }
+      );
+    }
+
+    if (activeReferences.length > 0) {
+      footnotesMarkdown = "\n\nReferences:\n";
+      footnotesHtml = "<br/><br/><div>References:</div>";
+      const sortedActiveReferences = [...activeReferences].sort(
+        (a, b) => a.index - b.index
+      );
+      for (const ref of sortedActiveReferences) {
+        footnotesMarkdown += `[${ref.index}] ${ref.document.href}\n`;
+        footnotesHtml += `<div>[${ref.index}] <a href="${ref.document.href}">${ref.document.title}</a></div>`;
+      }
+    }
+
+    const markdownText = processedMessageContent + footnotesMarkdown;
+    const htmlContent = (await marked(processedMessageContent)) + footnotesHtml;
+
+    await copy(
+      new ClipboardItem({
+        "text/plain": new Blob([markdownText], { type: "text/plain" }),
+        "text/html": new Blob([htmlContent], { type: "text/html" }),
+      })
+    );
+  }
+
+  const buttons: React.ReactElement[] = [];
+
+  const hasMultiAgents =
+    generationContext.generatingMessages.filter(
+      (m) => m.conversationId === conversationId
+    ).length > 1;
+
+  // Show stop agent button only when streaming with multiple agents
+  // (it feels distractive to show buttons while streaming so we would like to avoid as much as possible.
+  // However, when there are multiple agents there is no other way to stop only single agent so we need to show it here).
+  if (hasMultiAgents && agentMessageToRender.status === "created") {
+    buttons.push(
+      <Button
+        key="stop-msg-button"
+        label="Stop agent"
+        variant="ghost-secondary"
+        size="xs"
+        onClick={async () => {
+          await cancelMessage([sId]);
+        }}
+        icon={StopIcon}
+        className="text-muted-foreground"
+      />
+    );
+  }
+
+  // Show copy & feedback buttons only when streaming is done and it didn't fail
+  if (
+    agentMessageToRender.status !== "created" &&
+    agentMessageToRender.status !== "failed"
+  ) {
+    buttons.push(
+      <Button
+        key="copy-msg-button"
+        tooltip={isCopied ? "Copied!" : "Copy to clipboard"}
+        variant="ghost-secondary"
+        size="xs"
+        onClick={handleCopyToClipboard}
+        icon={isCopied ? ClipboardCheckIcon : ClipboardIcon}
+        className="text-muted-foreground"
+      />
+    );
+  }
+
+  // Show retry button as long as it's not streaming
+  if (agentMessageToRender.status !== "created") {
+    buttons.push(
+      <Button
+        key="retry-msg-button"
+        tooltip="Retry"
+        variant="ghost-secondary"
+        size="xs"
+        onClick={() => {
+          void retryHandler({
+            conversationId,
+            messageId: agentMessageToRender.sId,
+          });
+        }}
+        icon={ArrowPathIcon}
+        className="text-muted-foreground"
+        disabled={isRetryHandlerProcessing || shouldStream}
+      />
+    );
+  }
+
+  // Add feedback buttons in the end of the array if the agent is not global nor in draft (= inside agent builder)
+  if (
+    agentMessageToRender.status !== "created" &&
+    agentMessageToRender.status !== "failed" &&
+    !isGlobalAgent &&
+    agentMessageToRender.configuration.status !== "draft"
+  ) {
+    buttons.push(
+      <Separator key="separator" orientation="vertical" />,
+      <FeedbackSelector
+        key="feedback-selector"
+        {...messageFeedback}
+        getPopoverInfo={PopoverContent}
+      />
+    );
+  }
+
+  const retryHandler = useCallback(
+    async ({
+      conversationId,
+      messageId,
+      blockedOnly = false,
+    }: {
+      conversationId: string;
+      messageId: string;
+      blockedOnly?: boolean;
+    }) => {
+      setIsRetryHandlerProcessing(true);
+      await fetch(
+        `/api/w/${owner.sId}/assistant/conversations/${conversationId}/messages/${messageId}/retry?blocked_only=${blockedOnly}`,
+        {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+          },
+        }
+      );
+
+      setIsRetryHandlerProcessing(false);
+    },
+    [owner.sId]
+  );
+
+  const retryHandlerWithResetState = useCallback(
+    async (error: PersonalAuthenticationRequiredErrorContent) => {
+      methods.data.map((m) =>
+        isMessageTemporayState(m) && getMessageSId(m) === sId
+          ? {
+              ...m,
+              message: {
+                ...m.message,
+                status: "created",
+                error: null,
+              },
+              // Reset the agent state to "acting" to allow for streaming to continue.
+              agentState: "acting",
+            }
+          : m
+      );
+
+      // Retry on the event's conversationId, which may be coming from a subagent.
+      if (error.metadata.conversationId !== conversationId) {
+        await retryHandler({
+          conversationId: error.metadata.conversationId,
+          messageId: error.metadata.messageId,
+          blockedOnly: true,
+        });
+      }
+      // Retry on the main conversation.
+      await retryHandler({
+        conversationId,
+        messageId: sId,
+        blockedOnly: true,
+      });
+    },
+    [conversationId, methods.data, retryHandler, sId]
+  );
+
+  // References logic.
+  function updateActiveReferences(document: MarkdownCitation, index: number) {
+    const existingIndex = activeReferences.find((r) => r.index === index);
+    if (!existingIndex) {
+      setActiveReferences([...activeReferences, { index, document }]);
+    }
+  }
+
+  const { configuration: agentConfiguration } = agentMessageToRender;
+
+  const additionalMarkdownComponents: Components = React.useMemo(
+    () => ({
+      visualization: getVisualizationPlugin(
+        owner,
+        agentConfiguration.sId,
+        conversationId,
+        sId
+      ),
+      sup: CiteBlock,
+      mention: getMentionPlugin(owner),
+      dustimg: getImgPlugin(owner),
+    }),
+    [owner, conversationId, sId, agentConfiguration.sId]
+  );
+
+  const additionalMarkdownPlugins: PluggableList = React.useMemo(
+    () => [
+      mentionDirective,
+      getCiteDirective(),
+      visualizationDirective,
+      imgDirective,
+    ],
+    []
+  );
+
+  const citations = React.useMemo(
+    () => getCitations({ activeReferences }),
+    [activeReferences]
+  );
+
+  const canMention = agentConfiguration.canRead;
+  const isArchived = agentConfiguration.status === "archived";
+
+  return (
+    <ConversationMessage
+      pictureUrl={agentConfiguration.pictureUrl}
+      name={agentConfiguration.name}
+      buttons={buttons}
+      avatarBusy={agentMessageToRender.status === "created"}
+      isDisabled={isArchived}
+      renderName={() => (
+        <AgentHandle
+          assistant={{
+            sId: agentConfiguration.sId,
+            name: agentConfiguration.name + (isArchived ? " (archived)" : ""),
+          }}
+          canMention={canMention}
+          isDisabled={isArchived}
+        />
+      )}
+      timestamp={formatTimestring(agentMessageToRender.created)}
+      type="agent"
+      citations={citations}
+    >
+      <div>
+        {renderAgentMessage({
+          agentMessage: agentMessageToRender,
+          references: references,
+          streaming: shouldStream,
+          lastTokenClassification:
+            messageStreamState.agentState === "thinking" ? "tokens" : null,
+        })}
+      </div>
+    </ConversationMessage>
+  );
+
+  function renderAgentMessage({
+    agentMessage,
+    references,
+    streaming,
+    lastTokenClassification,
+  }: {
+    agentMessage: LightAgentMessageType;
+    references: { [key: string]: MarkdownCitation };
+    streaming: boolean;
+    lastTokenClassification: null | "tokens" | "chain_of_thought";
+  }) {
+    if (agentMessage.status === "failed") {
+      const { error } = agentMessage;
+      if (isPersonalAuthenticationRequiredErrorContent(error)) {
+        return (
+          <MCPServerPersonalAuthenticationRequired
+            owner={owner}
+            mcpServerId={error.metadata.mcp_server_id}
+            provider={error.metadata.provider}
+            scope={error.metadata.scope}
+            retryHandler={() => retryHandlerWithResetState(error)}
+          />
+        );
+      }
+      return (
+        <ErrorMessage
+          error={
+            agentMessage.error ?? {
+              message: "Unexpected Error",
+              code: "unexpected_error",
+              metadata: {},
+            }
+          }
+          retryHandler={async () =>
+            retryHandler({ conversationId, messageId: agentMessage.sId })
+          }
+        />
+      );
+    }
+
+    // Get in-progress images.
+    const inProgressImages = Array.from(
+      messageStreamState.actionProgress.entries()
+    )
+      .filter(([, progress]) =>
+        isImageProgressOutput(progress.progress?.data.output)
+      )
+      .map(([actionId, progress]) => ({
+        id: actionId,
+        isLoading: true,
+        progress: progress.progress?.progress,
+      }));
+
+    // Get completed images.
+    const completedImages = messageStreamState.message.generatedFiles.filter(
+      (file) => isSupportedImageContentType(file.contentType)
+    );
+
+    const generatedFiles = agentMessage.generatedFiles
+      .filter((file) => !file.hidden)
+      .filter(
+        (file) =>
+          !isSupportedImageContentType(file.contentType) &&
+          !isContentCreationFileContentType(file.contentType)
+      );
+
+    return (
+      <div className="flex flex-col gap-y-4">
+        <AgentMessageActions
+          agentMessage={agentMessage}
+          lastAgentStateClassification={messageStreamState.agentState}
+          actionProgress={messageStreamState.actionProgress}
+          owner={owner}
+        />
+        <AgentMessageContentCreationGeneratedFiles
+          files={contentCreationFiles}
+        />
+        {(inProgressImages.length > 0 || completedImages.length > 0) && (
+          <InteractiveImageGrid
+            images={[
+              ...completedImages.map((image) => ({
+                imageUrl: `/api/w/${owner.sId}/files/${image.fileId}?action=view`,
+                downloadUrl: `/api/w/${owner.sId}/files/${image.fileId}?action=download`,
+                alt: `${image.title}`,
+                title: `${image.title}`,
+                isLoading: false,
+              })),
+              ...inProgressImages.map(() => ({
+                alt: "",
+                title: "",
+                isLoading: true,
+              })),
+            ]}
+          />
+        )}
+
+        {agentMessage.content !== null && (
+          <div>
+            {lastTokenClassification !== "chain_of_thought" &&
+            agentMessage.content === "" ? (
+              <div className="blinking-cursor">
+                <span></span>
+              </div>
+            ) : (
+              <CitationsContext.Provider
+                value={{
+                  references,
+                  updateActiveReferences,
+                }}
+              >
+                <Markdown
+                  content={sanitizeVisualizationContent(agentMessage.content)}
+                  isStreaming={
+                    streaming && lastTokenClassification === "tokens"
+                  }
+                  isLastMessage={isLastMessage}
+                  additionalMarkdownComponents={additionalMarkdownComponents}
+                  additionalMarkdownPlugins={additionalMarkdownPlugins}
+                />
+              </CitationsContext.Provider>
+            )}
+          </div>
+        )}
+        {generatedFiles.length > 0 && (
+          <div className="mt-2 grid grid-cols-5 gap-1">
+            {getCitations({
+              activeReferences: generatedFiles.map((file) => ({
+                index: -1,
+                document: {
+                  href: `/api/w/${owner.sId}/files/${file.fileId}`,
+                  icon: <DocumentIcon />,
+                  title: file.title,
+                },
+              })),
+            })}
+          </div>
+        )}
+        {agentMessage.status === "cancelled" && (
+          <div>
+            <Chip
+              label="The message generation was interrupted"
+              size="xs"
+              className="mt-4"
+            />
+          </div>
+        )}
+      </div>
+    );
+  }
+}
+
+/**
+ * Reconstructs the agent message to render based on the message fetched and the data streamed.
+ * The message does not contain actions, we may only have some if we received through the stream.
+ */
+function getAgentMessageToRender({
+  message,
+  messageStreamState,
+}: {
+  message: LightAgentMessageType;
+  messageStreamState: MessageTemporaryState;
+}): LightAgentMessageType | LightAgentMessageWithActionsType {
+  switch (message.status) {
+    case "succeeded":
+    case "failed":
+      return message;
+    case "cancelled":
+      if (messageStreamState.message.status === "created") {
+        return { ...messageStreamState.message, status: "cancelled" };
+      }
+      return messageStreamState.message;
+    case "created":
+      return messageStreamState.message;
+    default:
+      assertNever(message.status);
+  }
+}
+
+function getCitations({
+  activeReferences,
+}: {
+  activeReferences: {
+    index: number;
+    document: MarkdownCitation;
+  }[];
+}) {
+  activeReferences.sort((a, b) => a.index - b.index);
+
+  return activeReferences.map(({ document, index }) => {
+    return (
+      <DefaultAgentMessageGeneratedFiles
+        key={index}
+        document={document}
+        index={index}
+      />
+    );
+  });
+}

--- a/front/components/assistant/conversation/AssistantInputBarVirtuoso.tsx
+++ b/front/components/assistant/conversation/AssistantInputBarVirtuoso.tsx
@@ -1,0 +1,90 @@
+import { Button } from "@dust-tt/sparkle";
+import {
+  useVirtuosoLocation,
+  useVirtuosoMethods,
+} from "@virtuoso.dev/message-list";
+import { ArrowBigDownDashIcon } from "lucide-react";
+
+import { AssistantInputBar } from "@app/components/assistant/conversation/input_bar/InputBar";
+import type {
+  VirtuosoMessage,
+  VirtuosoMessageListContext,
+} from "@app/components/assistant/conversation/types";
+import { isUserMessage } from "@app/components/assistant/conversation/types";
+import { emptyArray } from "@app/lib/swr/swr";
+import type { AgentMention } from "@app/types";
+import { isAgentMention } from "@app/types";
+
+export const AssistantInputBarVirtuoso = ({
+  context,
+}: {
+  context: VirtuosoMessageListContext;
+}) => {
+  const methods = useVirtuosoMethods<VirtuosoMessage>();
+  const lastUserMessage = methods.data
+    .get()
+    .findLast(
+      (m) =>
+        isUserMessage(m) &&
+        m.user?.id === context.user.id &&
+        m.visibility !== "deleted"
+    );
+
+  const agentMentions =
+    !lastUserMessage || !isUserMessage(lastUserMessage)
+      ? emptyArray<AgentMention>()
+      : lastUserMessage.mentions.filter(isAgentMention);
+
+  const { bottomOffset } = useVirtuosoLocation();
+  const distanceUntilButtonVisibe = 100;
+  const distanceToFullOpacity = 200;
+  const hidden = bottomOffset < distanceUntilButtonVisibe;
+  const opacity = Math.min(
+    1,
+    bottomOffset < distanceUntilButtonVisibe
+      ? 0
+      : (bottomOffset - distanceUntilButtonVisibe) / distanceToFullOpacity
+  );
+  const hiddenRotation = 180;
+  const rotation = hiddenRotation * (1 - opacity);
+
+  return (
+    <div
+      className={
+        "z-20 mx-auto flex max-h-screen w-full py-2 sm:w-full sm:max-w-3xl sm:py-4"
+      }
+    >
+      <div
+        className="align-center"
+        style={{
+          position: "absolute",
+          top: "-30px",
+          right: "50%",
+          opacity,
+          transform: `rotate(${rotation}deg)`,
+          visibility: hidden ? "hidden" : "visible",
+        }}
+      >
+        <Button
+          size="xs"
+          icon={ArrowBigDownDashIcon}
+          variant="outline"
+          onClick={() => {
+            methods.scrollToItem({
+              index: "LAST",
+              align: "end",
+              behavior: "smooth",
+            });
+          }}
+        />
+      </div>
+      <AssistantInputBar
+        owner={context.owner}
+        onSubmit={context.handleSubmit}
+        stickyMentions={agentMentions}
+        conversationId={context.conversationId}
+        disableAutoFocus={false}
+      />
+    </div>
+  );
+};

--- a/front/components/assistant/conversation/ConversationContainerVirtuoso.tsx
+++ b/front/components/assistant/conversation/ConversationContainerVirtuoso.tsx
@@ -1,0 +1,298 @@
+import {
+  ContentMessageAction,
+  ContentMessageInline,
+  InformationCircleIcon,
+  Page,
+} from "@dust-tt/sparkle";
+import { useRouter } from "next/router";
+import { useCallback, useContext, useEffect, useRef, useState } from "react";
+
+import { ReachedLimitPopup } from "@app/components/app/ReachedLimitPopup";
+import { AgentBrowserContainer } from "@app/components/assistant/conversation/AgentBrowserContainer";
+import { useActionValidationContext } from "@app/components/assistant/conversation/BlockedActionsProvider";
+import { useCoEditionContext } from "@app/components/assistant/conversation/co_edition/context";
+import { useConversationsNavigation } from "@app/components/assistant/conversation/ConversationsNavigationProvider";
+import ConversationViewerVirtuoso from "@app/components/assistant/conversation/ConversationViewerVirtuoso";
+import { FixedAssistantInputBar } from "@app/components/assistant/conversation/input_bar/InputBar";
+import { InputBarContext } from "@app/components/assistant/conversation/input_bar/InputBarContext";
+import { createConversationWithMessage } from "@app/components/assistant/conversation/lib";
+import { useWelcomeTourGuide } from "@app/components/assistant/WelcomeTourGuideProvider";
+import { DropzoneContainer } from "@app/components/misc/DropzoneContainer";
+import { useSendNotification } from "@app/hooks/useNotification";
+import { getRandomGreetingForName } from "@app/lib/client/greetings";
+import type { DustError } from "@app/lib/error";
+import {
+  useConversationMessages,
+  useConversations,
+  useExecutionMode,
+} from "@app/lib/swr/conversations";
+import { getAgentRoute } from "@app/lib/utils/router";
+import type {
+  ContentFragmentsType,
+  LightAgentConfigurationType,
+  MentionType,
+  Result,
+  SubscriptionType,
+  UserType,
+  WorkspaceType,
+} from "@app/types";
+import { conjugate, Err, Ok, pluralize, removeNulls } from "@app/types";
+
+interface ConversationContainerProps {
+  owner: WorkspaceType;
+  subscription: SubscriptionType;
+  user: UserType;
+  agentIdToMention: string | null;
+}
+
+export function ConversationContainerVirtuoso({
+  owner,
+  subscription,
+  user,
+  agentIdToMention,
+}: ConversationContainerProps) {
+  const { activeConversationId } = useConversationsNavigation();
+
+  const [planLimitReached, setPlanLimitReached] = useState(false);
+
+  const { animate, setAnimate, setSelectedAssistant } =
+    useContext(InputBarContext);
+
+  const { hasBlockedActions, totalBlockedActions, showBlockedActionsDialog } =
+    useActionValidationContext();
+
+  const assistantToMention = useRef<LightAgentConfigurationType | null>(null);
+
+  const router = useRouter();
+
+  const executionMode = useExecutionMode();
+
+  const sendNotification = useSendNotification();
+
+  const { mutateConversations } = useConversations({
+    workspaceId: owner.sId,
+    options: {
+      disabled: true, // We don't need to fetch conversations here.
+    },
+  });
+
+  const { isMessagesError } = useConversationMessages({
+    conversationId: activeConversationId,
+    workspaceId: owner.sId,
+    limit: 50,
+  });
+
+  const setInputBarMention = useCallback(
+    (agentId: string) => {
+      setSelectedAssistant({ configurationId: agentId });
+      setAnimate(true);
+    },
+    [setAnimate, setSelectedAssistant]
+  );
+
+  useEffect(() => {
+    if (agentIdToMention) {
+      setInputBarMention(agentIdToMention);
+    }
+  }, [agentIdToMention, setInputBarMention]);
+
+  useEffect(() => {
+    if (animate) {
+      setTimeout(() => setAnimate(false), 500);
+    }
+  });
+
+  const { serverId } = useCoEditionContext();
+
+  const [isSubmitting, setIsSubmitting] = useState(false);
+
+  const handleConversationCreation = useCallback(
+    async (
+      input: string,
+      mentions: MentionType[],
+      contentFragments: ContentFragmentsType,
+      selectedMCPServerViewIds?: string[]
+    ): Promise<Result<undefined, DustError>> => {
+      if (isSubmitting) {
+        return new Err({
+          code: "internal_error",
+          name: "AlreadySubmitting",
+          message: "Already submitting",
+        });
+      }
+
+      setIsSubmitting(true);
+
+      const conversationRes = await createConversationWithMessage({
+        owner,
+        user,
+        messageData: {
+          input,
+          mentions,
+          contentFragments,
+          clientSideMCPServerIds: removeNulls([serverId]),
+          selectedMCPServerViewIds,
+        },
+        executionMode,
+      });
+
+      setIsSubmitting(false);
+
+      if (conversationRes.isErr()) {
+        if (conversationRes.error.type === "plan_limit_reached_error") {
+          setPlanLimitReached(true);
+        } else {
+          sendNotification({
+            title: conversationRes.error.title,
+            description: conversationRes.error.message,
+            type: "error",
+          });
+        }
+
+        return new Err({
+          code: "internal_error",
+          name: conversationRes.error.title,
+          message: conversationRes.error.message,
+        });
+      } else {
+        // We start the push before creating the message to optimize for instantaneity as well.
+        await router.push(
+          getAgentRoute(owner.sId, conversationRes.value.sId),
+          undefined,
+          { shallow: true }
+        );
+        await mutateConversations();
+
+        return new Ok(undefined);
+      }
+    },
+    [
+      executionMode,
+      isSubmitting,
+      mutateConversations,
+      owner,
+      router,
+      sendNotification,
+      serverId,
+      user,
+    ]
+  );
+
+  useEffect(() => {
+    const scrollContainerElement = document.getElementById(
+      "assistant-input-header"
+    );
+
+    if (scrollContainerElement) {
+      const observer = new IntersectionObserver(
+        () => {
+          if (assistantToMention.current) {
+            setInputBarMention(assistantToMention.current.sId);
+            assistantToMention.current = null;
+          }
+        },
+        { threshold: 0.8 }
+      );
+      observer.observe(scrollContainerElement);
+    }
+    const handleRouteChange = (url: string) => {
+      if (url.endsWith("/new")) {
+        setSelectedAssistant(null);
+        assistantToMention.current = null;
+      }
+    };
+    router.events.on("routeChangeComplete", handleRouteChange);
+  }, [setAnimate, setInputBarMention, router, setSelectedAssistant]);
+
+  const [greeting, setGreeting] = useState<string>("");
+  useEffect(() => {
+    setGreeting(getRandomGreetingForName(user.firstName));
+  }, [user]);
+
+  const { startConversationRef } = useWelcomeTourGuide();
+
+  if (isMessagesError) {
+    return (
+      <div className="flex h-full w-full items-center justify-center">
+        <div className="flex flex-col gap-3 text-center">
+          <div>
+            <span className="text-4xl leading-10 text-foreground dark:text-foreground-night">
+              🚫
+            </span>
+            <p className="copy-sm leading-tight text-muted-foreground dark:text-muted-foreground-night">
+              You don't have access to this conversation.
+            </p>
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <DropzoneContainer
+      description="Drag and drop your text files (txt, doc, pdf) and image files (jpg, png) here."
+      title="Attach files to the conversation"
+    >
+      {activeConversationId ? (
+        <>
+          <ConversationViewerVirtuoso
+            owner={owner}
+            user={user}
+            conversationId={activeConversationId}
+            setPlanLimitReached={setPlanLimitReached}
+          />
+          {hasBlockedActions && (
+            <ContentMessageInline
+              icon={InformationCircleIcon}
+              variant="primary"
+              className="mb-5 flex max-h-screen w-full sm:w-full sm:max-w-3xl"
+            >
+              <span className="font-bold">
+                {totalBlockedActions} action
+                {pluralize(totalBlockedActions)}
+              </span>{" "}
+              require{conjugate(totalBlockedActions)} manual approval
+              <ContentMessageAction
+                label="Review actions"
+                variant="outline"
+                size="xs"
+                onClick={() => showBlockedActionsDialog()}
+              />
+            </ContentMessageInline>
+          )}
+        </>
+      ) : (
+        <>
+          <div
+            id="assistant-input-header"
+            className="flex h-fit min-h-[20vh] w-full max-w-3xl flex-col justify-end gap-8 py-4"
+            ref={startConversationRef}
+          >
+            <Page.Header title={greeting} />
+          </div>
+          <FixedAssistantInputBar
+            owner={owner}
+            onSubmit={handleConversationCreation}
+            conversationId={null}
+            disable={false}
+          />
+          <AgentBrowserContainer
+            onAgentConfigurationClick={setInputBarMention}
+            setAssistantToMention={(assistant) => {
+              assistantToMention.current = assistant;
+            }}
+            owner={owner}
+            user={user}
+          />
+        </>
+      )}
+      <ReachedLimitPopup
+        isOpened={planLimitReached}
+        onClose={() => setPlanLimitReached(false)}
+        subscription={subscription}
+        owner={owner}
+        code="message_limit"
+      />
+    </DropzoneContainer>
+  );
+}

--- a/front/components/assistant/conversation/ConversationLayoutVirtuoso.tsx
+++ b/front/components/assistant/conversation/ConversationLayoutVirtuoso.tsx
@@ -1,17 +1,15 @@
-import { cn, ResizablePanel, ResizablePanelGroup } from "@dust-tt/sparkle";
+import { ResizablePanel, ResizablePanelGroup } from "@dust-tt/sparkle";
 import { useRouter } from "next/router";
 import React, { useMemo } from "react";
 
 import { BlockedActionsProvider } from "@app/components/assistant/conversation/BlockedActionsProvider";
 import { CoEditionProvider } from "@app/components/assistant/conversation/co_edition/CoEditionProvider";
-import { CONVERSATION_VIEW_SCROLL_LAYOUT } from "@app/components/assistant/conversation/constant";
 import {
   ConversationErrorDisplay,
   ErrorDisplay,
 } from "@app/components/assistant/conversation/ConversationError";
 import ConversationSidePanelContainer from "@app/components/assistant/conversation/ConversationSidePanelContainer";
 import { ConversationSidePanelProvider } from "@app/components/assistant/conversation/ConversationSidePanelContext";
-import { useConversationSidePanelContext } from "@app/components/assistant/conversation/ConversationSidePanelContext";
 import {
   ConversationsNavigationProvider,
   useConversationsNavigation,
@@ -46,10 +44,9 @@ export interface ConversationLayoutProps {
   subscription: SubscriptionType;
   user: UserType;
   isAdmin: boolean;
-  useVirtualizedConversation: boolean;
 }
 
-export default function ConversationLayout({
+export default function ConversationLayoutVirtuoso({
   children,
   pageProps,
 }: {
@@ -91,7 +88,7 @@ const ConversationLayoutContent = ({
 }: ConversationLayoutContentProps) => {
   const router = useRouter();
   const { onOpenChange: onOpenChangeAssistantModal } =
-    useURLSheet("agentDetails");
+    useURLSheet("assistantDetails");
   const { activeConversationId } = useConversationsNavigation();
   const { conversation, conversationError } = useConversation({
     conversationId: activeConversationId,
@@ -108,12 +105,12 @@ const ConversationLayoutContent = ({
   );
 
   const assistantSId = useMemo(() => {
-    const sid = router.query.agentDetails ?? [];
+    const sid = router.query.assistantDetails ?? [];
     if (isString(sid)) {
       return sid;
     }
     return null;
-  }, [router.query.agentDetails]);
+  }, [router.query.assistantDetails]);
 
   // Logic for the welcome tour guide. We display it if the welcome query param is set to true.
   const { startConversationRef, spaceMenuButtonRef, createAgentButtonRef } =
@@ -210,8 +207,6 @@ function ConversationInnerLayout({
   conversationError,
   activeConversationId,
 }: ConversationInnerLayoutProps) {
-  const { currentPanel } = useConversationSidePanelContext();
-
   return (
     <ErrorBoundary fallback={<UncaughtConversationErrorFallback />}>
       <div className="flex h-full w-full flex-col">
@@ -227,16 +222,7 @@ function ConversationInnerLayout({
               ) : (
                 <FileDropProvider>
                   <GenerationContextProvider>
-                    <div
-                      id={CONVERSATION_VIEW_SCROLL_LAYOUT}
-                      className={cn(
-                        "dd-privacy-mask h-full overflow-y-auto overscroll-y-none scroll-smooth px-4",
-                        // Hide conversation on mobile when any panel is opened.
-                        currentPanel && "hidden md:block"
-                      )}
-                    >
-                      {children}
-                    </div>
+                    {children}
                   </GenerationContextProvider>
                 </FileDropProvider>
               )}

--- a/front/components/assistant/conversation/ConversationViewerVirtuoso.tsx
+++ b/front/components/assistant/conversation/ConversationViewerVirtuoso.tsx
@@ -1,0 +1,589 @@
+import { Spinner } from "@dust-tt/sparkle";
+import type {
+  ListScrollLocation,
+  VirtuosoMessageListMethods,
+} from "@virtuoso.dev/message-list";
+import {
+  VirtuosoMessageList,
+  VirtuosoMessageListLicense,
+} from "@virtuoso.dev/message-list";
+import _ from "lodash";
+import debounce from "lodash/debounce";
+import React, {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
+
+import { AssistantInputBarVirtuoso } from "@app/components/assistant/conversation/AssistantInputBarVirtuoso";
+import { useCoEditionContext } from "@app/components/assistant/conversation/co_edition/context";
+import { ConversationErrorDisplay } from "@app/components/assistant/conversation/ConversationError";
+import { useConversationSidePanelContext } from "@app/components/assistant/conversation/ConversationSidePanelContext";
+import {
+  createPlaceholderUserMessage,
+  submitMessage,
+} from "@app/components/assistant/conversation/lib";
+import MessageItemVirtuoso from "@app/components/assistant/conversation/MessageItemVirtuoso";
+import { StickyHeaderVirtuoso } from "@app/components/assistant/conversation/StickyHeaderVirtuoso";
+import type {
+  VirtuosoMessage,
+  VirtuosoMessageListContext,
+} from "@app/components/assistant/conversation/types";
+import {
+  isMessageTemporayState,
+  isUserMessage,
+  makeInitialMessageStreamState,
+} from "@app/components/assistant/conversation/types";
+import { useEventSource } from "@app/hooks/useEventSource";
+import { useSendNotification } from "@app/hooks/useNotification";
+import { getLightAgentMessageFromAgentMessage } from "@app/lib/api/assistant/citations";
+import type { AgentMessageFeedbackType } from "@app/lib/api/assistant/feedback";
+import { getUpdatedParticipantsFromEvent } from "@app/lib/client/conversation/event_handlers";
+import type { DustError } from "@app/lib/error";
+import {
+  useConversation,
+  useConversationFeedbacks,
+  useConversationMarkAsRead,
+  useConversationMessages,
+  useConversationParticipants,
+  useConversations,
+  useExecutionMode,
+} from "@app/lib/swr/conversations";
+import { classNames } from "@app/lib/utils";
+import type {
+  AgentGenerationCancelledEvent,
+  AgentMessageDoneEvent,
+  AgentMessageNewEvent,
+  ContentFragmentsType,
+  ContentFragmentType,
+  ConversationTitleEvent,
+  LightMessageType,
+  MentionType,
+  Result,
+  UserMessageNewEvent,
+  UserType,
+  WorkspaceType,
+} from "@app/types";
+import {
+  Err,
+  isContentFragmentType,
+  isUserMessageType,
+  Ok,
+  removeNulls,
+} from "@app/types";
+
+const DEFAULT_PAGE_LIMIT = 50;
+
+interface ConversationViewerProps {
+  conversationId: string;
+  isInModal?: boolean;
+  setPlanLimitReached?: (planLimitReached: boolean) => void;
+  owner: WorkspaceType;
+  user: UserType;
+}
+
+function easeOutSine(x: number): number {
+  return Math.sin((x * Math.PI) / 2);
+}
+
+// Slighly slower than the default smooth scroll.
+function customSmoothScroll() {
+  return {
+    animationFrameCount: 30,
+    easing: easeOutSine,
+  };
+}
+/**
+ *
+ * @param isInModal is the conversation happening in a side modal, i.e. when testing an assistant?
+ * @returns
+ */
+const ConversationViewerVirtuoso = ({
+  owner,
+  user,
+  conversationId,
+  isInModal = false,
+  setPlanLimitReached,
+}: ConversationViewerProps) => {
+  const ref =
+    useRef<
+      VirtuosoMessageListMethods<VirtuosoMessage, VirtuosoMessageListContext>
+    >(null);
+  const sendNotification = useSendNotification();
+  const { serverId } = useCoEditionContext();
+  const executionMode = useExecutionMode();
+
+  const { currentPanel } = useConversationSidePanelContext();
+
+  const {
+    conversation,
+    conversationError,
+    isConversationLoading,
+    mutateConversation,
+  } = useConversation({
+    conversationId,
+    workspaceId: owner.sId,
+  });
+
+  const { markAsRead } = useConversationMarkAsRead({
+    conversation,
+    workspaceId: owner.sId,
+  });
+
+  const { mutateConversations } = useConversations({
+    workspaceId: owner.sId,
+    options: {
+      disabled: true,
+    },
+  });
+
+  const {
+    isLoadingInitialData,
+    isMessagesLoading,
+    isValidating,
+    messages,
+    setSize,
+    size,
+    mutateMessages,
+  } = useConversationMessages({
+    conversationId,
+    workspaceId: owner.sId,
+    limit: DEFAULT_PAGE_LIMIT,
+  });
+
+  const { mutateConversationParticipants } = useConversationParticipants({
+    conversationId,
+    workspaceId: owner.sId,
+    options: { disabled: true }, // We don't need the participants, only the mutator.
+  });
+
+  const [initialListData, setInitialListData] = useState<VirtuosoMessage[]>([]);
+
+  // Setup the initial list data when the conversation is loaded.
+  useEffect(() => {
+    if (initialListData.length === 0 && messages.length > 0) {
+      const messagesToRender = convertLightMessageTypeToVirtuosoMessages(
+        messages.flatMap((m) => m.messages)
+      );
+
+      setInitialListData(messagesToRender);
+    }
+  }, [initialListData, messages, setInitialListData]);
+
+  // This is to handle we just fetched more messages by scrolling up.
+  useEffect(() => {
+    // don't do anything until we have a first page of messages.
+    if (!ref.current || !ref.current.data.get().length) {
+      return;
+    }
+
+    const minRank = Math.min(
+      ...ref.current.data
+        .get()
+        .map((m) => (isMessageTemporayState(m) ? m.message.rank : m.rank))
+    );
+    const maxRank = Math.max(
+      ...ref.current.data
+        .get()
+        .map((m) => (isMessageTemporayState(m) ? m.message.rank : m.rank))
+    );
+
+    const messagesFromBackend = messages.flatMap((m) => m.messages);
+
+    const olderMessagesFromBackend = messagesFromBackend.filter(
+      (m) => m.rank < minRank
+    );
+
+    if (olderMessagesFromBackend.length > 0) {
+      ref.current.data.prepend(
+        convertLightMessageTypeToVirtuosoMessages(olderMessagesFromBackend)
+      );
+    }
+
+    const recentMessagesFromBackend = messagesFromBackend.filter(
+      (m) => m.rank > maxRank
+    );
+
+    if (recentMessagesFromBackend.length > 0) {
+      ref.current.data.append(
+        convertLightMessageTypeToVirtuosoMessages(recentMessagesFromBackend)
+      );
+    }
+  }, [messages]);
+
+  const { feedbacks } = useConversationFeedbacks({
+    conversationId: conversationId ?? "",
+    workspaceId: owner.sId,
+  });
+
+  // Hooks related to conversation events streaming.
+
+  const buildEventSourceURL = useCallback(
+    (lastEvent: string | null) => {
+      const esURL = `/api/w/${owner.sId}/assistant/conversations/${conversationId}/events`;
+      let lastEventId = "";
+      if (lastEvent) {
+        const eventPayload: {
+          eventId: string;
+        } = JSON.parse(lastEvent);
+        lastEventId = eventPayload.eventId;
+      }
+      const url = esURL + "?lastEventId=" + lastEventId;
+
+      return url;
+    },
+    [conversationId, owner.sId]
+  );
+
+  const debouncedMarkAsRead = useMemo(
+    () => debounce(markAsRead, 2000),
+    [markAsRead]
+  );
+
+  const eventIds = useRef<string[]>([]);
+
+  // Only conversation related events are handled here.
+  const onEventCallback = useCallback(
+    (eventStr: string) => {
+      const eventPayload: {
+        eventId: string;
+        data:
+          | UserMessageNewEvent
+          | AgentMessageNewEvent
+          | AgentMessageDoneEvent
+          | AgentGenerationCancelledEvent
+          | ConversationTitleEvent;
+      } = JSON.parse(eventStr);
+      const event = eventPayload.data;
+
+      if (!eventIds.current.includes(eventPayload.eventId)) {
+        eventIds.current.push(eventPayload.eventId);
+
+        switch (event.type) {
+          case "user_message_new":
+            if (ref.current) {
+              // Skip our own messages, otherwise they get duplicated because the event is fired before we get the message from the backend.
+              if (event.message.user?.id === user.id) {
+                return;
+              }
+              const predicate = (m: VirtuosoMessage) =>
+                isUserMessage(m) && m.sId === event.message.sId;
+              const exists = ref.current.data.find(predicate);
+
+              if (!exists) {
+                ref.current.data.append([
+                  { ...event.message, contentFragments: [] },
+                ]);
+              } else {
+                // We don't update if it already exists as if it already exists, it means we have received the message from the backend.
+              }
+
+              void mutateConversationParticipants(async (participants) =>
+                getUpdatedParticipantsFromEvent(participants, event)
+              );
+            }
+            break;
+          case "agent_message_new":
+            if (ref.current) {
+              const messageStreamState = makeInitialMessageStreamState(
+                getLightAgentMessageFromAgentMessage(event.message)
+              );
+
+              // Replace the message in the exist list data, or append.
+              const predicate = (m: VirtuosoMessage) =>
+                isMessageTemporayState(m) &&
+                m.message.rank === messageStreamState.message.rank;
+              const exists = ref.current.data.find(predicate);
+
+              if (exists) {
+                ref.current.data.map((m) =>
+                  predicate(m) ? messageStreamState : m
+                );
+              } else {
+                ref.current.data.append([messageStreamState]);
+              }
+
+              void mutateConversationParticipants(async (participants) =>
+                getUpdatedParticipantsFromEvent(participants, event)
+              );
+            }
+            break;
+
+          case "agent_generation_cancelled":
+            void mutateMessages();
+            break;
+
+          case "conversation_title":
+            void mutateConversation();
+            void mutateConversations(); // to refresh the list of convos in the sidebar (title)
+            break;
+          case "agent_message_done":
+            // Mark as read and do not mutate the list of convos in the sidebar to avoid useless network request.
+            // Debounce the call as we might receive multiple events for the same conversation (as we replay the events).
+            void debouncedMarkAsRead(event.conversationId, false);
+
+            // Mutate the messages to be sure that the swr cache is updated.
+            // Fixes an issue where the last message of a conversation is "thinking" and not "done" the first time you switch back and forth to a conversation.
+            void mutateMessages();
+            break;
+          default:
+            ((t: never) => {
+              console.error("Unknown event type", t);
+            })(event);
+        }
+      }
+    },
+    [
+      mutateConversationParticipants,
+      mutateConversation,
+      mutateConversations,
+      mutateMessages,
+      debouncedMarkAsRead,
+      user.id,
+    ]
+  );
+
+  useEventSource(
+    buildEventSourceURL,
+    onEventCallback,
+    `conversation-${conversationId}`,
+    {
+      // We only start consuming the stream when the conversation has been loaded and we have a first page of message.
+      isReadyToConsumeStream:
+        !isConversationLoading &&
+        !isLoadingInitialData &&
+        messages.length !== 0,
+    }
+  );
+
+  const handleSubmit = useCallback(
+    async (
+      input: string,
+      mentions: MentionType[],
+      contentFragments: ContentFragmentsType
+    ): Promise<Result<undefined, DustError>> => {
+      if (!ref?.current) {
+        return new Err({
+          code: "internal_error",
+          name: "NoRef",
+          message: "No ref",
+        });
+      }
+      const messageData = {
+        input,
+        mentions,
+        contentFragments,
+        clientSideMCPServerIds: removeNulls([serverId]),
+      };
+
+      const lastMessageRank = Math.max(
+        ...ref.current.data
+          .get()
+          .map((m) => (isMessageTemporayState(m) ? m.message.rank : m.rank))
+      );
+
+      const placeholderMessage: VirtuosoMessage = createPlaceholderUserMessage({
+        input,
+        mentions,
+        user,
+        lastMessageRank,
+        contentFragments,
+      });
+
+      const nbMessages = ref.current.data.get().length;
+      ref.current.data.append([placeholderMessage], () => {
+        return {
+          index: nbMessages, // Avoid jumping around when the agent message is generated.
+          align: "start",
+          behavior: customSmoothScroll,
+        };
+      });
+
+      const result = await submitMessage({
+        owner,
+        user,
+        conversationId,
+        messageData,
+        executionMode,
+      });
+
+      if (result.isErr()) {
+        if (result.error.type === "plan_limit_reached_error") {
+          setPlanLimitReached?.(true);
+        } else {
+          sendNotification({
+            title: result.error.title,
+            description: result.error.message,
+            type: "error",
+          });
+        }
+
+        // If the API errors, the original data will be rolled back by SWR automatically.
+        console.error("Failed to post message:", result.error);
+        return new Err({
+          code: "internal_error",
+          name: "FailedToPostMessage",
+          message: `Failed to post message ${result.error}`,
+        });
+      }
+
+      const {
+        message: messageFromBackend,
+        contentFragments: contentFragmentsFromBackend,
+      } = result.value;
+
+      ref.current.data.map((m) =>
+        isUserMessage(m) &&
+        (m.sId === placeholderMessage.sId || m.sId === messageFromBackend.sId)
+          ? {
+              ...messageFromBackend,
+              contentFragments: contentFragmentsFromBackend,
+            }
+          : m
+      );
+
+      await mutateConversations();
+
+      return new Ok(undefined);
+    },
+    [
+      serverId,
+      user,
+      owner,
+      conversationId,
+      executionMode,
+      mutateConversations,
+      setPlanLimitReached,
+      sendNotification,
+    ]
+  );
+
+  const onScroll = useCallback(
+    (location: ListScrollLocation) => {
+      const isLoadingData =
+        isLoadingInitialData || isMessagesLoading || isValidating;
+
+      if (
+        location.listOffset >= -100 &&
+        messages.at(0)?.hasMore &&
+        !isLoadingData
+      ) {
+        // Increment the page number to load more data.
+        void setSize(size + 1);
+      }
+    },
+    [
+      isLoadingInitialData,
+      isMessagesLoading,
+      isValidating,
+      setSize,
+      size,
+      messages,
+    ]
+  );
+
+  const computeItemKey = useCallback(
+    ({
+      data,
+      context,
+    }: {
+      data: VirtuosoMessage;
+      context: VirtuosoMessageListContext;
+    }) => {
+      return `conversation-${context.conversationId}-message-rank-${isMessageTemporayState(data) ? data.message.rank : data.rank}`;
+    },
+    []
+  );
+
+  const feedbacksByMessageId = useMemo(() => {
+    return feedbacks.reduce(
+      (acc, feedback) => {
+        acc[feedback.messageId] = feedback;
+        return acc;
+      },
+      {} as Record<string, AgentMessageFeedbackType>
+    );
+  }, [feedbacks]);
+
+  return (
+    <>
+      {conversationError && (
+        <ConversationErrorDisplay error={conversationError} />
+      )}
+      {initialListData.length > 0 ? (
+        <VirtuosoMessageListLicense licenseKey="">
+          <VirtuosoMessageList<VirtuosoMessage, VirtuosoMessageListContext>
+            initialData={initialListData}
+            initialLocation={{
+              index: "LAST",
+              align: "end",
+              behavior: "instant",
+            }}
+            ref={ref}
+            ItemContent={MessageItemVirtuoso}
+            // Note: do NOT put any verticalpadding here as it will mess with the auto scroll to bottom.
+            className={classNames(
+              "dd-privacy-mask",
+              "s-@container/conversation",
+              "h-full w-full",
+              isInModal ? "" : "px-4 md:px-8",
+              // Hide conversation on mobile when any panel is opened.
+              currentPanel ? "hidden md:block" : ""
+            )}
+            shortSizeAlign="bottom"
+            StickyHeader={StickyHeaderVirtuoso}
+            StickyFooter={AssistantInputBarVirtuoso}
+            computeItemKey={computeItemKey}
+            onScroll={onScroll}
+            context={{
+              user,
+              owner,
+              handleSubmit,
+              conversationId,
+              isInModal,
+              feedbacksByMessageId,
+            }}
+          />
+        </VirtuosoMessageListLicense>
+      ) : (
+        <div className="flex w-full flex-1 flex-col items-center justify-center gap-8 py-4">
+          <Spinner variant="color" size="xl" />
+        </div>
+      )}
+    </>
+  );
+};
+
+export default ConversationViewerVirtuoso;
+
+const convertLightMessageTypeToVirtuosoMessages = (
+  messages: LightMessageType[]
+) => {
+  const output: VirtuosoMessage[] = [];
+  let tempContentFragments: ContentFragmentType[] = [];
+
+  messages.forEach((message) => {
+    if (isContentFragmentType(message)) {
+      tempContentFragments.push(message); // Collect content fragments.
+    } else {
+      let messageWithContentFragments: VirtuosoMessage;
+      if (isUserMessageType(message)) {
+        // Attach collected content fragments to the user message.
+        messageWithContentFragments = {
+          ...message,
+          contentFragments: tempContentFragments,
+        };
+        tempContentFragments = []; // Reset the collected content fragments.
+
+        // Start a new group for user messages.
+        output.push(messageWithContentFragments);
+      } else {
+        messageWithContentFragments = makeInitialMessageStreamState(message);
+        output.push(messageWithContentFragments);
+      }
+    }
+  });
+  return output;
+};

--- a/front/components/assistant/conversation/MessageDateIndicator.tsx
+++ b/front/components/assistant/conversation/MessageDateIndicator.tsx
@@ -1,0 +1,25 @@
+import moment from "moment-timezone";
+
+import type { VirtuosoMessage } from "@app/components/assistant/conversation/types";
+import { getMessageDate } from "@app/components/assistant/conversation/types";
+
+export const MessageDateIndicator = ({
+  message,
+}: {
+  message: VirtuosoMessage;
+}) => {
+  return (
+    <div className="text-center">
+      <span className="rounded bg-background px-4 text-xs text-muted-foreground dark:bg-background-night dark:text-muted-foreground-night">
+        {moment(getMessageDate(message)).calendar(null, {
+          sameDay: "[Today]",
+          nextDay: "[Tomorrow]",
+          nextWeek: "dddd",
+          lastDay: "[Yesterday]",
+          lastWeek: "[Last] dddd",
+          sameElse: "DD/MM/YYYY",
+        })}
+      </span>
+    </div>
+  );
+};

--- a/front/components/assistant/conversation/MessageItemVirtuoso.tsx
+++ b/front/components/assistant/conversation/MessageItemVirtuoso.tsx
@@ -1,0 +1,157 @@
+import React from "react";
+import { useSWRConfig } from "swr";
+
+import { AgentMessageVirtuoso } from "@app/components/assistant/conversation/AgentMessageVirtuoso";
+import {
+  AttachmentCitation,
+  contentFragmentToAttachmentCitation,
+} from "@app/components/assistant/conversation/AttachmentCitation";
+import type { FeedbackSelectorProps } from "@app/components/assistant/conversation/FeedbackSelector";
+import { MessageDateIndicator } from "@app/components/assistant/conversation/MessageDateIndicator";
+import type {
+  VirtuosoMessage,
+  VirtuosoMessageListContext,
+} from "@app/components/assistant/conversation/types";
+import {
+  getMessageDate,
+  getMessageSId,
+  isMessageTemporayState,
+  isUserMessage,
+} from "@app/components/assistant/conversation/types";
+import { UserMessage } from "@app/components/assistant/conversation/UserMessage";
+import { useSendNotification } from "@app/hooks/useNotification";
+import { useSubmitFunction } from "@app/lib/client/utils";
+import { classNames } from "@app/lib/utils";
+
+interface MessageItemProps {
+  data: VirtuosoMessage;
+  context: VirtuosoMessageListContext;
+  index: number;
+  nextData: VirtuosoMessage | null;
+  prevData: VirtuosoMessage | null;
+}
+
+const MessageItemVirtuoso = React.forwardRef<HTMLDivElement, MessageItemProps>(
+  function MessageItem(
+    { data, context, prevData, nextData }: MessageItemProps,
+    ref
+  ) {
+    const sId = getMessageSId(data);
+
+    const sendNotification = useSendNotification();
+
+    const { mutate } = useSWRConfig();
+    const { submit: onSubmitThumb, isSubmitting: isSubmittingThumb } =
+      useSubmitFunction(
+        async ({
+          thumb,
+          shouldRemoveExistingFeedback,
+          feedbackContent,
+          isConversationShared,
+        }: {
+          thumb: string;
+          shouldRemoveExistingFeedback: boolean;
+          feedbackContent: string | null;
+          isConversationShared: boolean;
+        }) => {
+          const res = await fetch(
+            `/api/w/${context.owner.sId}/assistant/conversations/${context.conversationId}/messages/${sId}/feedbacks`,
+            {
+              method: shouldRemoveExistingFeedback ? "DELETE" : "POST",
+              headers: {
+                "Content-Type": "application/json",
+              },
+              body: JSON.stringify({
+                thumbDirection: thumb,
+                feedbackContent,
+                isConversationShared,
+              }),
+            }
+          );
+          if (res.ok) {
+            if (feedbackContent && !shouldRemoveExistingFeedback) {
+              sendNotification({
+                title: "Feedback submitted",
+                description:
+                  "Your comment has been submitted successfully to the Builder of this agent. Thank you!",
+                type: "success",
+              });
+            }
+            await mutate(
+              `/api/w/${context.owner.sId}/assistant/conversations/${context.conversationId}/feedbacks`
+            );
+          }
+        }
+      );
+
+    const messageFeedback = context.feedbacksByMessageId[sId];
+    const messageFeedbackWithSubmit: FeedbackSelectorProps = {
+      feedback: messageFeedback
+        ? {
+            thumb: messageFeedback.thumbDirection,
+            feedbackContent: messageFeedback.content,
+            isConversationShared: messageFeedback.isConversationShared,
+          }
+        : null,
+      onSubmitThumb,
+      isSubmittingThumb,
+    };
+
+    const citations =
+      isUserMessage(data) && data.contentFragments
+        ? data.contentFragments.map((contentFragment) => {
+            const attachmentCitation =
+              contentFragmentToAttachmentCitation(contentFragment);
+
+            return (
+              <AttachmentCitation
+                key={attachmentCitation.id}
+                attachmentCitation={attachmentCitation}
+              />
+            );
+          })
+        : undefined;
+
+    const areSameDate =
+      prevData &&
+      getMessageDate(prevData).toDateString() ===
+        getMessageDate(data).toDateString();
+
+    return (
+      <>
+        {!areSameDate && <MessageDateIndicator message={data} />}
+        <div
+          key={`message-id-${sId}`}
+          ref={ref}
+          className={classNames(
+            "mx-auto min-w-60",
+            "pt-6 md:pt-10",
+            context.isInModal ? "max-w-full" : "max-w-3xl"
+          )}
+        >
+          {isUserMessage(data) && (
+            <UserMessage
+              citations={citations}
+              conversationId={context.conversationId}
+              isLastMessage={!nextData}
+              message={data}
+              owner={context.owner}
+            />
+          )}
+          {isMessageTemporayState(data) && (
+            <AgentMessageVirtuoso
+              user={context.user}
+              conversationId={context.conversationId}
+              isLastMessage={!nextData}
+              messageStreamState={data}
+              messageFeedback={messageFeedbackWithSubmit}
+              owner={context.owner}
+            />
+          )}
+        </div>
+      </>
+    );
+  }
+);
+
+export default MessageItemVirtuoso;

--- a/front/components/assistant/conversation/StickyHeaderVirtuoso.tsx
+++ b/front/components/assistant/conversation/StickyHeaderVirtuoso.tsx
@@ -1,0 +1,29 @@
+import type { VirtuosoMessageListProps } from "@virtuoso.dev/message-list";
+import {
+  useCurrentlyRenderedData,
+  useVirtuosoLocation,
+} from "@virtuoso.dev/message-list";
+
+import { MessageDateIndicator } from "@app/components/assistant/conversation/MessageDateIndicator";
+import type {
+  VirtuosoMessage,
+  VirtuosoMessageListContext,
+} from "@app/components/assistant/conversation/types";
+
+export const StickyHeaderVirtuoso: VirtuosoMessageListProps<
+  VirtuosoMessage,
+  VirtuosoMessageListContext
+>["StickyHeader"] = () => {
+  const firstItem = useCurrentlyRenderedData<VirtuosoMessage>().at(0);
+  const location = useVirtuosoLocation();
+
+  // No item in view or full list is visible without scroll.
+  if (!firstItem || location.scrollHeight === location.visibleListHeight) {
+    return null;
+  }
+  return (
+    <div style={{ width: "100%", position: "absolute", top: 0 }}>
+      <MessageDateIndicator message={firstItem} />
+    </div>
+  );
+};

--- a/front/components/assistant/conversation/lib.ts
+++ b/front/components/assistant/conversation/lib.ts
@@ -6,12 +6,15 @@ import type { PostConversationsResponseBody } from "@app/pages/api/w/[wId]/assis
 import type { PostMessagesResponseBody } from "@app/pages/api/w/[wId]/assistant/conversations/[cId]/messages";
 import type {
   ContentFragmentsType,
+  ContentFragmentType,
   ConversationType,
   ConversationVisibility,
+  FileContentFragmentType,
   InternalPostConversationsRequestBodySchema,
   MentionType,
   Result,
   SubmitMessageError,
+  SupportedContentFragmentType,
   SupportedContentNodeContentType,
   UserMessageType,
   UserType,
@@ -30,12 +33,14 @@ export function createPlaceholderUserMessage({
   mentions,
   user,
   lastMessageRank,
+  contentFragments,
 }: {
   input: string;
   mentions: MentionType[];
   user: UserType;
   lastMessageRank: number;
-}): UserMessageType {
+  contentFragments?: ContentFragmentsType;
+}): UserMessageType & { contentFragments: ContentFragmentType[] } {
   const createdAt = new Date().getTime();
   const { email, fullName, image, username } = user;
 
@@ -58,6 +63,79 @@ export function createPlaceholderUserMessage({
       username,
       origin: "web",
     },
+    contentFragments: [
+      ...(contentFragments?.uploaded ?? []).map(
+        (cf) =>
+          ({
+            type: "content_fragment" as const,
+            contentFragmentType: "file" as const,
+            fileId: cf.fileId,
+            title: cf.title,
+            snippet: null,
+            generatedTables: [],
+            textUrl: "",
+            textBytes: null,
+            id: Math.random(),
+            sId: cf.fileId,
+            created: Date.now(),
+            visibility: "visible" as const,
+            version: 0,
+            rank: lastMessageRank,
+            sourceUrl: null,
+            contentType: cf.contentType,
+            context: {
+              username: user.username,
+              fullName: user.fullName,
+              email: user.email,
+              profilePictureUrl: user.image,
+            },
+            contentFragmentId: "placeholder-content-fragment",
+            contentFragmentVersion: "latest" as const,
+            expiredReason: null,
+          }) satisfies FileContentFragmentType
+      ),
+      ...(contentFragments?.contentNodes ?? []).map(
+        (cf) =>
+          ({
+            type: "content_fragment" as const,
+            contentFragmentType: "content_node" as const,
+
+            contentType: cf.mimeType as SupportedContentFragmentType,
+
+            title: cf.title,
+            id: Math.random(),
+
+            sId: cf.internalId,
+
+            nodeId: cf.internalId,
+            nodeDataSourceViewId: cf.dataSourceView.sId,
+            nodeType: cf.type,
+            contentNodeData: {
+              nodeId: cf.internalId,
+              nodeDataSourceViewId: cf.dataSourceView.sId,
+              nodeType: cf.type,
+              provider: cf.dataSourceView.dataSource.connectorProvider,
+              spaceName: "myspace",
+            },
+
+            created: Date.now(),
+            visibility: "visible" as const,
+            version: 0,
+            rank: lastMessageRank,
+            sourceUrl: null,
+
+            context: {
+              username: user.username,
+              fullName: user.fullName,
+              email: user.email,
+              profilePictureUrl: user.image,
+            },
+            contentFragmentId: "placeholder-content-fragment",
+            contentFragmentVersion: "latest" as const,
+            expiredReason: null,
+          }) satisfies ContentFragmentType
+      ),
+    ],
   };
 }
 

--- a/front/components/assistant/conversation/types.ts
+++ b/front/components/assistant/conversation/types.ts
@@ -1,0 +1,101 @@
+import type { ToolNotificationEvent } from "@app/lib/actions/mcp";
+import type { ProgressNotificationContentType } from "@app/lib/actions/mcp_internal_actions/output_schemas";
+import type { AgentMessageFeedbackType } from "@app/lib/api/assistant/feedback";
+import type { AgentMessageEvents } from "@app/lib/api/assistant/streaming/types";
+import type { DustError } from "@app/lib/error";
+import type {
+  ContentFragmentsType,
+  ContentFragmentType,
+  LightAgentMessageType,
+  LightAgentMessageWithActionsType,
+  LightWorkspaceType,
+  MentionType,
+  ModelId,
+  Result,
+  UserMessageType,
+  UserType,
+} from "@app/types";
+import { isLightAgentMessageWithActionsType } from "@app/types";
+import type { AgentMCPActionType } from "@app/types/actions";
+
+type AgentStateClassification = "thinking" | "acting" | "writing" | "done";
+
+type ActionProgressState = Map<
+  ModelId,
+  {
+    action: AgentMCPActionType;
+    progress?: ProgressNotificationContentType;
+  }
+>;
+
+export interface MessageTemporaryState {
+  message: LightAgentMessageWithActionsType;
+  agentState: AgentStateClassification;
+  isRetrying: boolean;
+  lastUpdated: Date;
+  actionProgress: ActionProgressState;
+  useFullChainOfThought: boolean;
+}
+
+export type AgentMessageStateEvent = (
+  | AgentMessageEvents
+  | ToolNotificationEvent
+) & { step: number };
+
+export type AgentMessageStateWithControlEvent =
+  | AgentMessageStateEvent
+  | { type: "end-of-stream" };
+
+export type VirtuosoMessage =
+  | MessageTemporaryState
+  | (UserMessageType & {
+      contentFragments: ContentFragmentType[];
+    });
+
+export type VirtuosoMessageListContext = {
+  owner: LightWorkspaceType;
+  user: UserType;
+  handleSubmit: (
+    input: string,
+    mentions: MentionType[],
+    contentFragments: ContentFragmentsType
+  ) => Promise<Result<undefined, DustError>>;
+  conversationId: string;
+  isInModal: boolean;
+  feedbacksByMessageId: Record<string, AgentMessageFeedbackType>;
+};
+
+export const isUserMessage = (
+  msg: VirtuosoMessage
+): msg is UserMessageType & { contentFragments: ContentFragmentType[] } =>
+  "type" in msg && msg.type === "user_message" && "contentFragments" in msg;
+
+export const isMessageTemporayState = (
+  msg: VirtuosoMessage
+): msg is MessageTemporaryState => "agentState" in msg;
+
+export const getMessageSId = (msg: VirtuosoMessage): string =>
+  isMessageTemporayState(msg) ? msg.message.sId : msg.sId;
+
+export const getMessageDate = (msg: VirtuosoMessage): Date =>
+  isMessageTemporayState(msg)
+    ? new Date(msg.message.created)
+    : new Date(msg.created);
+
+export const makeInitialMessageStreamState = (
+  message: LightAgentMessageType | LightAgentMessageWithActionsType
+): MessageTemporaryState => {
+  return {
+    actionProgress: new Map(),
+    agentState: message.status === "created" ? "thinking" : "done",
+    isRetrying: false,
+    lastUpdated: new Date(),
+    message: {
+      ...message,
+      actions: isLightAgentMessageWithActionsType(message)
+        ? message.actions
+        : [],
+    },
+    useFullChainOfThought: false,
+  };
+};

--- a/front/components/misc/DropzoneContainer.tsx
+++ b/front/components/misc/DropzoneContainer.tsx
@@ -54,7 +54,7 @@ export function DropzoneContainer({
   return (
     <div
       {...getRootProps()}
-      className="flex h-full w-full flex-col items-center"
+      className="flex h-full min-h-0 w-full flex-col items-center"
       onPaste={onPaste}
     >
       <DropzoneOverlay

--- a/front/hooks/useAgentMessageStreamVirtuoso.ts
+++ b/front/hooks/useAgentMessageStreamVirtuoso.ts
@@ -1,0 +1,323 @@
+import { useVirtuosoMethods } from "@virtuoso.dev/message-list";
+import { useCallback, useMemo, useRef } from "react";
+
+import type {
+  AgentMessageStateWithControlEvent,
+  MessageTemporaryState,
+  VirtuosoMessage,
+  VirtuosoMessageListContext,
+} from "@app/components/assistant/conversation/types";
+import {
+  getMessageSId,
+  isMessageTemporayState,
+} from "@app/components/assistant/conversation/types";
+import { useEventSource } from "@app/hooks/useEventSource";
+import type { ToolNotificationEvent } from "@app/lib/actions/mcp";
+import { getLightAgentMessageFromAgentMessage } from "@app/lib/api/assistant/citations";
+import type {
+  LightAgentMessageWithActionsType,
+  LightWorkspaceType,
+} from "@app/types";
+import { assertNever } from "@app/types";
+import type { AgentMCPActionWithOutputType } from "@app/types/actions";
+
+export function updateMessageWithAction(
+  m: LightAgentMessageWithActionsType,
+  action: AgentMCPActionWithOutputType
+): LightAgentMessageWithActionsType {
+  return {
+    ...m,
+    chainOfThought: "",
+    actions: [...m.actions.filter((a) => a.id !== action.id), action],
+  };
+}
+
+export function updateProgress(
+  state: MessageTemporaryState,
+  event: ToolNotificationEvent
+): MessageTemporaryState {
+  const actionId = event.action.id;
+  const currentProgress = state.actionProgress.get(actionId);
+
+  return {
+    ...state,
+    actionProgress: new Map(state.actionProgress).set(actionId, {
+      action: event.action,
+      progress: {
+        ...currentProgress?.progress,
+        ...event.notification,
+        data: {
+          ...currentProgress?.progress?.data,
+          ...event.notification.data,
+        },
+      },
+    }),
+  };
+}
+interface UseAgentMessageStreamParams {
+  messageStreamState: MessageTemporaryState;
+  conversationId: string | null;
+  owner: LightWorkspaceType;
+  mutateMessage?: () => void;
+  onEventCallback?: (event: {
+    eventId: string;
+    data: AgentMessageStateWithControlEvent;
+  }) => void;
+  streamId: string;
+  useFullChainOfThought: boolean;
+}
+
+export function useAgentMessageStreamVirtuoso({
+  messageStreamState,
+  conversationId,
+  owner,
+  mutateMessage,
+  onEventCallback: customOnEventCallback,
+  streamId,
+}: UseAgentMessageStreamParams) {
+  const sId = getMessageSId(messageStreamState);
+  const methods = useVirtuosoMethods<
+    VirtuosoMessage,
+    VirtuosoMessageListContext
+  >();
+
+  const isFreshMountWithContent = useRef(
+    messageStreamState.message.status === "created" &&
+      (!!messageStreamState.message.content ||
+        !!messageStreamState.message.chainOfThought)
+  );
+
+  const shouldStream = useMemo(
+    () => messageStreamState.message.status === "created",
+    [messageStreamState.message.status]
+  );
+
+  const buildEventSourceURL = useCallback(
+    (lastEvent: string | null) => {
+      const esURL = `/api/w/${owner.sId}/assistant/conversations/${conversationId}/messages/${sId}/events`;
+      let lastEventId = "";
+      if (lastEvent) {
+        const eventPayload: {
+          eventId: string;
+        } = JSON.parse(lastEvent);
+        lastEventId = eventPayload.eventId;
+        // We have a lastEventId, so this is not a fresh mount
+        isFreshMountWithContent.current = false;
+      }
+      const url = esURL + "?lastEventId=" + lastEventId;
+
+      return url;
+    },
+    [conversationId, sId, owner.sId]
+  );
+
+  const onEventCallback = useCallback(
+    (eventStr: string) => {
+      const eventPayload: {
+        eventId: string;
+        data: AgentMessageStateWithControlEvent;
+      } = JSON.parse(eventStr);
+      const eventType = eventPayload.data.type;
+
+      switch (eventType) {
+        case "end-of-stream":
+          // This event is emitted in front/lib/api/assistant/pubsub.ts. Its purpose is to signal the
+          // end of the stream to the client. So we just return.
+          return;
+        case "tool_approve_execution":
+          return;
+
+        case "generation_tokens":
+          if (
+            isFreshMountWithContent.current &&
+            (eventPayload.data.classification === "tokens" ||
+              eventPayload.data.classification === "chain_of_thought")
+          ) {
+            // If this is a fresh mount with existing content and we're getting generation_tokens,
+            // we need to clear the content first to avoid duplication
+            methods.data.map((m) =>
+              isMessageTemporayState(m) && getMessageSId(m) === sId
+                ? {
+                    ...m,
+                    message: {
+                      ...m.message,
+                      content: null,
+                      chainOfThought: null,
+                    },
+                  }
+                : m
+            );
+            isFreshMountWithContent.current = false;
+          }
+
+          const generationTokens = eventPayload.data;
+          const classification = generationTokens.classification;
+          methods.data.map((m) => {
+            if (isMessageTemporayState(m) && getMessageSId(m) === sId) {
+              switch (classification) {
+                case "opening_delimiter":
+                case "closing_delimiter":
+                  return m;
+
+                case "tokens": {
+                  return {
+                    ...m,
+                    message: {
+                      ...m.message,
+                      content:
+                        (m.message.content ?? "") + generationTokens.text,
+                    },
+                    agentState: "writing",
+                  };
+                }
+                case "chain_of_thought": {
+                  // If we're not using the full chain of thought, reset at paragraph boundaries.
+                  const chainOfThought =
+                    !m.useFullChainOfThought && generationTokens.text === "\n\n"
+                      ? ""
+                      : (m.message.chainOfThought ?? "") +
+                        generationTokens.text;
+                  return {
+                    ...m,
+                    message: {
+                      ...m.message,
+                      chainOfThought,
+                    },
+                    agentState: "thinking",
+                  };
+                }
+                default:
+                  assertNever(classification);
+              }
+            } else {
+              return m;
+            }
+          });
+          break;
+
+        case "agent_action_success":
+          const action = eventPayload.data.action;
+          methods.data.map((m) =>
+            isMessageTemporayState(m) && getMessageSId(m) === sId
+              ? {
+                  ...m,
+                  message: updateMessageWithAction(m.message, action),
+                  // Clean up progress for this specific action.
+                  actionProgress: new Map(
+                    Array.from(m.actionProgress.entries()).filter(
+                      ([id]) => id !== action.id
+                    )
+                  ),
+                }
+              : m
+          );
+
+          break;
+
+        case "tool_params":
+          const toolParams = eventPayload.data;
+          methods.data.map((m) =>
+            isMessageTemporayState(m) && getMessageSId(m) === sId
+              ? {
+                  ...m,
+                  message: updateMessageWithAction(
+                    m.message,
+                    toolParams.action
+                  ),
+                  agentState: "acting",
+                }
+              : m
+          );
+          break;
+
+        case "tool_notification":
+          const toolNotification = eventPayload.data;
+          methods.data.map((m) =>
+            isMessageTemporayState(m) && getMessageSId(m) === sId
+              ? updateProgress(m, toolNotification)
+              : m
+          );
+          break;
+
+        case "tool_error":
+        case "agent_error":
+          const error = eventPayload.data.error;
+          methods.data.map((m) =>
+            isMessageTemporayState(m) && getMessageSId(m) === sId
+              ? {
+                  ...m,
+                  message: {
+                    ...m.message,
+                    status: "failed",
+                    error: error,
+                  },
+                  agentState: "done",
+                }
+              : m
+          );
+          break;
+
+        case "agent_generation_cancelled":
+          methods.data.map((m) =>
+            isMessageTemporayState(m) && getMessageSId(m) === sId
+              ? {
+                  ...m,
+                  message: { ...m.message, status: "cancelled" },
+                  agentState: "done",
+                }
+              : m
+          );
+          break;
+
+        case "agent_message_success":
+          const messageSuccess = eventPayload.data;
+          methods.data.map((m) =>
+            isMessageTemporayState(m) && getMessageSId(m) === sId
+              ? {
+                  ...m,
+                  message: {
+                    ...getLightAgentMessageFromAgentMessage(
+                      messageSuccess.message
+                    ),
+                    status: "succeeded",
+                    actions: m.message.actions,
+                    rank: m.message.rank,
+                    version: m.message.version,
+                  },
+                  agentState: "done",
+                }
+              : m
+          );
+          break;
+
+        default:
+          assertNever(eventType);
+      }
+
+      if (customOnEventCallback) {
+        customOnEventCallback(eventPayload);
+      }
+
+      const shouldRefresh = [
+        "agent_action_success",
+        "agent_error",
+        "agent_message_success",
+        "agent_generation_cancelled",
+      ].includes(eventType);
+
+      if (shouldRefresh && mutateMessage) {
+        void mutateMessage();
+      }
+    },
+    [customOnEventCallback, methods.data, mutateMessage, sId]
+  );
+
+  useEventSource(buildEventSourceURL, onEventCallback, streamId, {
+    isReadyToConsumeStream: shouldStream,
+  });
+
+  return {
+    shouldStream,
+    isFreshMountWithContent,
+  };
+}

--- a/front/lib/swr/conversations.ts
+++ b/front/lib/swr/conversations.ts
@@ -1,3 +1,4 @@
+import { useRouter } from "next/router";
 import { useCallback, useEffect, useMemo, useState } from "react";
 import type { Fetcher } from "swr";
 
@@ -779,4 +780,11 @@ export const useJoinConversation = ({
   ]);
 
   return joinConversation;
+};
+
+export const useExecutionMode = () => {
+  const router = useRouter();
+  const { execution } = router.query;
+  const executionMode = typeof execution === "string" ? execution : "auto";
+  return executionMode;
 };

--- a/front/package-lock.json
+++ b/front/package-lock.json
@@ -45,6 +45,7 @@
         "@types/cls-hooked": "^4.3.9",
         "@types/json-schema": "^7.0.15",
         "@uiw/react-textarea-code-editor": "^3.0.2",
+        "@virtuoso.dev/message-list": "^1.13.3",
         "@workos-inc/node": "^7.50.0",
         "ajv": "^8.17.1",
         "ajv-formats": "^3.0.1",
@@ -10731,6 +10732,29 @@
     "node_modules/@ungap/structured-clone": {
       "version": "1.2.0",
       "license": "ISC"
+    },
+    "node_modules/@virtuoso.dev/gurx": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@virtuoso.dev/gurx/-/gurx-1.1.0.tgz",
+      "integrity": "sha512-Z2mOKEgmMPnkf7hb3JaqJCVuvBD7qaK9KuI95BMBzOioHvPqhI79UcC6dHCprz9aZef/YaZ5ZwcYRRGVtfLU0g==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": ">= 16 || >= 17 || >= 18 || >= 19",
+        "react-dom": ">= 16 || >= 17 || >= 18 || >= 19"
+      }
+    },
+    "node_modules/@virtuoso.dev/message-list": {
+      "version": "1.13.3",
+      "resolved": "https://registry.npmjs.org/@virtuoso.dev/message-list/-/message-list-1.13.3.tgz",
+      "integrity": "sha512-kzKFpPJqrQCFuQ2piPEuy7p3qvzphIYZIKiJeHii8zUs73ggOhk6YBwr9BoPyWNX8DUKpSWdcLFx+cd/bAyRTA==",
+      "license": "Commercial",
+      "dependencies": {
+        "@virtuoso.dev/gurx": "1.1.0"
+      },
+      "peerDependencies": {
+        "react": ">= 16 || >= 17 || >= 18 || >= 19",
+        "react-dom": ">= 16 || >= 17 || >= 18 || >= 19"
+      }
     },
     "node_modules/@vitejs/plugin-react": {
       "version": "4.3.4",

--- a/front/package.json
+++ b/front/package.json
@@ -67,6 +67,7 @@
     "@types/cls-hooked": "^4.3.9",
     "@types/json-schema": "^7.0.15",
     "@uiw/react-textarea-code-editor": "^3.0.2",
+    "@virtuoso.dev/message-list": "^1.13.3",
     "@workos-inc/node": "^7.50.0",
     "ajv": "^8.17.1",
     "ajv-formats": "^3.0.1",

--- a/front/types/shared/feature_flags.ts
+++ b/front/types/shared/feature_flags.ts
@@ -189,6 +189,10 @@ export const WHITELISTABLE_FEATURES_CONFIG = {
     description: "Slack semantic search feature",
     stage: "on_demand",
   },
+  virtualized_conversations: {
+    description: "Use virtualized conversations display",
+    stage: "dust_only",
+  },
 } as const satisfies Record<string, FeatureFlag>;
 
 export type FeatureFlagStage = "dust_only" | "rolling_out" | "on_demand";

--- a/sdks/js/src/types.ts
+++ b/sdks/js/src/types.ts
@@ -683,6 +683,7 @@ const WhitelistableFeaturesSchema = FlexibleEnumSchema<
   | "use_openai_eu_key"
   | "xai_feature"
   | "simple_audio_transcription"
+  | "virtualized_conversations"
 >();
 
 export type WhitelistableFeature = z.infer<typeof WhitelistableFeaturesSchema>;


### PR DESCRIPTION
## Description

Implements a new way to display conversations.
Instead of our custom code, this rely on [Virtuoso Message List](https://virtuoso.dev/virtuoso-message-list/) to handle state, display, scroll.

Benefits:
- State is clearer (fully own by Virtuoso Component, updated directly via utilty methods provided by it)
- Scrolling is declarative when adding / remove new messages (instead of relying on various observers everywhere)
- Display is virtualized (only what is visible in the container is added to the DOM)

Main changes:
The agent messages state is always based on MessageTemporaryState instead of a mix of the backend one & the stream one.
Simplified useAgentMessageStream(Virtuoso) to remove the reducer for the message state the double events listening (stream + reducer).

Implemented as a set of different components to make testing using a FF easier.

## Tests

Locally

https://github.com/user-attachments/assets/93e19853-3296-4d01-b6f7-9e76b7bb5782

## Risk

Behind a FF, the existing code is not touched but overall it's a significant refactoring of the conversation viewer.

## Deploy Plan

Deploy front, enable our workspace to use it.