### PR TITLE
[front] chore(FS/data-warehouse tools): untrack "node not found" errors

### DIFF
--- a/front/lib/actions/mcp_internal_actions/servers/data_sources_file_system.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/data_sources_file_system.ts
@@ -581,7 +581,11 @@ const createServer = (
         if (isDataSourceNodeId(nodeId)) {
           const dataSourceId = extractDataSourceIdFromNodeId(nodeId);
           if (!dataSourceId) {
-            return new Err(new MCPError("Invalid data source node ID format"));
+            return new Err(
+              new MCPError("Invalid data source node ID format", {
+                tracked: false,
+              })
+            );
           }
 
           const dataSourceConfig = agentDataSourceConfigurations.find(
@@ -590,7 +594,9 @@ const createServer = (
 
           if (!dataSourceConfig) {
             return new Err(
-              new MCPError(`Data source not found for ID: ${dataSourceId}`)
+              new MCPError(`Data source not found for ID: ${dataSourceId}`, {
+                tracked: false,
+              })
             );
           }
 

--- a/front/lib/actions/mcp_internal_actions/servers/data_warehouses/helpers.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/data_warehouses/helpers.ts
@@ -1,6 +1,7 @@
 import { INTERNAL_MIME_TYPES } from "@dust-tt/client";
 import _ from "lodash";
 
+import { MCPError } from "@app/lib/actions/mcp_errors";
 import type {
   RenderedWarehouseNodeType,
   WarehousesBrowseType,
@@ -22,7 +23,7 @@ export async function getAvailableWarehouses(
 ): Promise<
   Result<
     { nodes: RenderedWarehouseNodeType[]; nextPageCursor: string | null },
-    CoreAPIError
+    MCPError
   >
 > {
   const coreAPI = new CoreAPI(config.getCoreAPIConfig(), logger);
@@ -43,7 +44,7 @@ export async function getAvailableWarehouses(
     },
   });
   if (searchResult.isErr()) {
-    return searchResult;
+    return new Err(new MCPError(searchResult.error.message));
   }
 
   const dataSourceById = _.keyBy(
@@ -81,7 +82,7 @@ export async function getWarehouseNodes(
 ): Promise<
   Result<
     { nodes: RenderedWarehouseNodeType[]; nextPageCursor: string | null },
-    Error | CoreAPIError
+    MCPError
   >
 > {
   const coreAPI = new CoreAPI(config.getCoreAPIConfig(), logger);
@@ -96,7 +97,9 @@ export async function getWarehouseNodes(
     const dataSource = await DataSourceResource.fetchById(auth, dataSourceId);
     if (!dataSource) {
       return new Err(
-        new Error(`Data source not found for ID: ${dataSourceId}`)
+        new MCPError(`Data source not found for ID: ${dataSourceId}`, {
+          tracked: false,
+        })
       );
     }
     const dataSourceConfiguration = dataSourceConfigurations.find(
@@ -105,7 +108,9 @@ export async function getWarehouseNodes(
     );
     if (!dataSourceConfiguration) {
       return new Err(
-        new Error(`Data source configuration not found for ID: ${dataSourceId}`)
+        new MCPError(
+          `Data source configuration not found for ID: ${dataSourceId}`
+        )
       );
     }
     configsToUse = [dataSourceConfiguration];
@@ -141,7 +146,7 @@ export async function getWarehouseNodes(
   });
 
   if (result.isErr()) {
-    return result;
+    return new Err(new MCPError(result.error.message));
   }
 
   const nodes = result.value.nodes.map((node) => {

--- a/front/lib/actions/mcp_internal_actions/servers/data_warehouses/server.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/data_warehouses/server.ts
@@ -118,7 +118,7 @@ const createServer = (
               });
 
         if (result.isErr()) {
-          return new Err(new MCPError(result.error.message));
+          return new Err(result.error);
         }
 
         const { nodes, nextPageCursor: newCursor } = result.value;


### PR DESCRIPTION
## Description

- These errors are due to the model misspelling/misunderstanding what the node ID is and should not be tracked (i.e. trigger a monitor on our side).
- The error is still well exposed to the model.
- If we do want to introduce monitoring here, it should target cases where the model was not able to recover from the error after a few attempts.

## Tests

## Risk

- Low.

## Deploy Plan

- Deploy front.
