### PR TITLE
Check header name max length

### DIFF
--- a/core/src/databases/csv.rs
+++ b/core/src/databases/csv.rs
@@ -20,7 +20,7 @@ pub struct GoogleCloudStorageCSVContent {
 }
 
 pub const MAX_TABLE_COLUMNS: usize = 512;
-const MAX_COLUMN_NAME_LENGTH: usize = 1024;
+pub const MAX_COLUMN_NAME_LENGTH: usize = 1024;
 const MAX_TABLE_ROWS: usize = 500_000;
 
 impl GoogleCloudStorageCSVContent {


### PR DESCRIPTION
## Description

We were not checking the max column length here. When using background processing (truncate false), that could lead us to constantly trying to reprocess that row. So now we block it at the entrance.

## Tests

Manual

## Risk

Small

## Deploy Plan

Core