### PR TITLE
[front] misc(template): remove temperature in creation page, update default model

### DIFF
--- a/front/components/poke/templates/TemplatesDataTable.tsx
+++ b/front/components/poke/templates/TemplatesDataTable.tsx
@@ -101,7 +101,7 @@ export function TemplatesDataTable({
     <div className="border-material-200 my-4 flex w-full flex-col gap-2 rounded-lg border p-4">
       <div className="flex w-full items-center justify-between gap-3">
         <h2 className="text-md flex-grow pb-4 font-bold">Templates:</h2>
-        {dustRegionSyncEnabled && (
+        {(dustRegionSyncEnabled || isDevelopment()) && (
           <Button
             variant="outline"
             size="sm"
@@ -113,16 +113,15 @@ export function TemplatesDataTable({
             label={isPulling ? "Pulling..." : "Pull templates"}
           />
         )}
-        {!dustRegionSyncEnabled ||
-          (isDevelopment() && (
-            <Button
-              aria-label="Create template"
-              variant="outline"
-              size="sm"
-              label="Create template"
-              href="/poke/templates/new"
-            />
-          ))}
+        {(!dustRegionSyncEnabled || isDevelopment()) && (
+          <Button
+            aria-label="Create template"
+            variant="outline"
+            size="sm"
+            label="Create template"
+            href="/poke/templates/new"
+          />
+        )}
       </div>
       <SearchInput
         name="search"

--- a/front/lib/resources/template_resource.ts
+++ b/front/lib/resources/template_resource.ts
@@ -111,6 +111,15 @@ export class TemplateResource extends BaseResource<TemplateModel> {
       await existing.update(blob);
       return new Ok(new TemplateResource(TemplateModel, existing.get()));
     }
+
+    const templateWithSameId = await TemplateModel.findOne({
+      where: { id: blob.id },
+    });
+
+    if (templateWithSameId) {
+      return new Err(new Error("Template id already taken"));
+    }
+
     const template = await TemplateResource.makeNew(blob);
     return new Ok(template);
   }

--- a/front/migrations/20250928_check_templates_id_match.ts
+++ b/front/migrations/20250928_check_templates_id_match.ts
@@ -157,7 +157,10 @@ async function fixTemplateMismatch(
             transaction: t,
           }
         );
-        await localTemplate.model.destroy({ transaction: t });
+        await localTemplate.model.destroy({
+          where: { id: localTemplate.id },
+          transaction: t,
+        });
 
         return affectedCount;
       }

--- a/front/pages/api/poke/templates/[tId].ts
+++ b/front/pages/api/poke/templates/[tId].ts
@@ -151,7 +151,6 @@ async function handler(
         presetInstructions: body.presetInstructions ?? null,
         presetModelId: model.modelId,
         presetProviderId: model.providerId,
-        presetTemperature: body.presetTemperature ?? null,
         tags: body.tags,
         visibility: body.visibility,
       });

--- a/front/pages/api/poke/templates/index.ts
+++ b/front/pages/api/poke/templates/index.ts
@@ -112,7 +112,9 @@ async function handler(
         presetInstructions: body.presetInstructions ?? null,
         presetModelId: model.modelId,
         presetProviderId: model.providerId,
-        presetTemperature: body.presetTemperature ?? null,
+        // Not configurable in the template, keeping the column for now since some templates do
+        // have a custom temperature.
+        presetTemperature: "balanced",
         tags: body.tags,
         visibility: body.visibility,
       });

--- a/front/pages/api/poke/templates/index.ts
+++ b/front/pages/api/poke/templates/index.ts
@@ -114,6 +114,8 @@ async function handler(
         presetProviderId: model.providerId,
         // Not configurable in the template, keeping the column for now since some templates do
         // have a custom temperature.
+        // TODO(2025-09-29 aubin): update old templates to remove temperature setting.
+        //  Dependent on fixing it in Agent Builder.
         presetTemperature: "balanced",
         tags: body.tags,
         visibility: body.visibility,

--- a/front/pages/api/poke/templates/pull.test.ts
+++ b/front/pages/api/poke/templates/pull.test.ts
@@ -155,6 +155,7 @@ describe(
             json: () =>
               Promise.resolve({
                 ...SAMPLE_TEMPLATE,
+                id: 1,
                 sId: "template1",
                 handle: "template1",
               }),
@@ -166,6 +167,7 @@ describe(
             json: () =>
               Promise.resolve({
                 ...SAMPLE_TEMPLATE,
+                id: 2,
                 sId: "template2",
                 handle: "template2",
               }),
@@ -213,6 +215,7 @@ describe(
             json: () =>
               Promise.resolve({
                 ...SAMPLE_TEMPLATE,
+                id: 1,
                 sId: "template1",
                 handle: "template1",
               }),

--- a/front/pages/api/poke/templates/pull.test.ts
+++ b/front/pages/api/poke/templates/pull.test.ts
@@ -21,7 +21,6 @@ const SAMPLE_TEMPLATE = {
   presetInstructions: "my instructions",
   presetModelId: "gpt-4o",
   presetProviderId: "openai",
-  presetTemperature: "balanced",
   sId: "tpl_vomozn1XNz",
   tags: ["PRODUCTIVITY"],
   visibility: "published",

--- a/front/pages/api/poke/templates/pull.test.ts
+++ b/front/pages/api/poke/templates/pull.test.ts
@@ -21,6 +21,7 @@ const SAMPLE_TEMPLATE = {
   presetInstructions: "my instructions",
   presetModelId: "gpt-4o",
   presetProviderId: "openai",
+  presetTemperature: "balanced",
   sId: "tpl_vomozn1XNz",
   tags: ["PRODUCTIVITY"],
   visibility: "published",

--- a/front/pages/poke/templates/[tId].tsx
+++ b/front/pages/poke/templates/[tId].tsx
@@ -49,10 +49,9 @@ import { withSuperUserAuthRequirements } from "@app/lib/iam/session";
 import { usePokeAssistantTemplate } from "@app/poke/swr";
 import type { CreateTemplateFormType, TemplateTagCodeType } from "@app/types";
 import {
-  ASSISTANT_CREATIVITY_LEVELS,
+  CLAUDE_4_SONNET_DEFAULT_MODEL_CONFIG,
   CreateTemplateFormSchema,
   generateTailwindBackgroundColors,
-  GPT_4_TURBO_MODEL_CONFIG,
   MULTI_ACTION_PRESETS,
   removeNulls,
   TEMPLATE_VISIBILITIES,
@@ -554,7 +553,7 @@ function TemplatesPage({
       description: "",
       handle: "",
       presetInstructions: "",
-      presetModelId: GPT_4_TURBO_MODEL_CONFIG.modelId,
+      presetModelId: CLAUDE_4_SONNET_DEFAULT_MODEL_CONFIG.modelId,
       presetTemperature: "balanced",
       helpInstructions: "",
       helpActions: "",
@@ -666,14 +665,6 @@ function TemplatesPage({
               options={USED_MODEL_CONFIGS.map((config) => ({
                 value: config.modelId,
                 display: config.displayName,
-              }))}
-            />
-            <SelectField
-              control={form.control}
-              name="presetTemperature"
-              title="Preset Temperature"
-              options={ASSISTANT_CREATIVITY_LEVELS.map((acl) => ({
-                value: acl,
               }))}
             />
           </div>

--- a/front/pages/poke/templates/[tId].tsx
+++ b/front/pages/poke/templates/[tId].tsx
@@ -555,7 +555,6 @@ function TemplatesPage({
       handle: "",
       presetInstructions: "",
       presetModelId: CLAUDE_4_SONNET_DEFAULT_MODEL_CONFIG.modelId,
-      presetTemperature: "balanced",
       helpInstructions: "",
       helpActions: "",
       emoji: "black_cat/1f408-200d-2b1b", // 🐈‍⬛.

--- a/front/pages/poke/templates/[tId].tsx
+++ b/front/pages/poke/templates/[tId].tsx
@@ -27,6 +27,7 @@ import { MultiSelect } from "react-multi-select-component";
 
 import { makeUrlForEmojiAndBackground } from "@app/components/agent_builder/settings/avatar_picker/utils";
 import PokeLayout from "@app/components/poke/PokeLayout";
+import { cn } from "@app/components/poke/shadcn/lib/utils";
 import {
   PokeForm,
   PokeFormControl,
@@ -623,7 +624,13 @@ function TemplatesPage({
                       }}
                       labelledBy="Select"
                       hasSelectAll={false}
-                      className="dark:bg-primary-50-night dark:text-white [&_.dropdown-content]:dark:bg-primary-50-night [&_.dropdown-content]:dark:text-white [&_.dropdown-heading]:dark:bg-primary-50-night [&_.dropdown-heading]:dark:text-white [&_.select-item]:hover:bg-primary-100 [&_.select-item]:dark:hover:bg-primary-100-night [&_.select-panel]:dark:bg-primary-50-night [&_.select-panel]:dark:text-white"
+                      className={cn(
+                        "dark:bg-primary-50-night dark:text-white",
+                        "[&_.dropdown-content]:dark:bg-primary-50-night [&_.dropdown-content]:dark:text-white",
+                        "[&_.dropdown-heading]:dark:bg-primary-50-night [&_.dropdown-heading]:dark:text-white",
+                        "[&_.select-item]:hover:bg-primary-100 [&_.select-item]:dark:hover:bg-primary-100-night",
+                        "[&_.select-panel]:dark:bg-primary-50-night [&_.select-panel]:dark:text-white"
+                      )}
                       ItemRenderer={({
                         checked,
                         option,
@@ -645,7 +652,7 @@ function TemplatesPage({
                             type="checkbox"
                             onChange={() => {}}
                             checked={checked}
-                            className="mr-2 accent-primary"
+                            className="mr-2 accent-primary dark:accent-primary-night"
                           />
                           <span>{option.label}</span>
                         </div>

--- a/front/types/assistant/templates.ts
+++ b/front/types/assistant/templates.ts
@@ -4,7 +4,6 @@ import { NonEmptyString } from "io-ts-types/lib/NonEmptyString";
 
 import { ioTsEnum } from "../shared/utils/iots_utils";
 import { TimeframeUnitCodec } from "../shared/utils/time_frame";
-import { AssistantCreativityLevelCodec } from "./builder";
 
 // TAGS
 

--- a/front/types/assistant/templates.ts
+++ b/front/types/assistant/templates.ts
@@ -170,7 +170,6 @@ export const CreateTemplateFormSchema = t.type({
   presetActions: TemplateActionsPreset,
   presetInstructions: t.union([t.string, t.undefined]),
   presetModelId: t.string,
-  presetTemperature: AssistantCreativityLevelCodec,
   tags: nonEmptyArray(TemplateTagCodeTypeCodec),
   visibility: TemplateVisibilityCodec,
 });


### PR DESCRIPTION
## Description

Micro janitorial changes in the template creation page:
- Change default model from GPT 4 turbo to Claude Sonnet 4 (last commit was quite old).
- Remove temperature setting (to align with Agent Builder since it now doesn't exist there either).
- Tiny tiny improvement on dark mode.
- The design is not pretty, but is still usable.

## Tests

- Checked locally.

## Risk

- Low.

## Deploy Plan

- Deploy front.
