### PR TITLE
[front] Add script to drop workspace domain

### DIFF
--- a/front/migrations/20250929_drop_domain.ts
+++ b/front/migrations/20250929_drop_domain.ts
@@ -1,0 +1,56 @@
+import { removeWorkOSOrganizationDomain } from "@app/lib/api/workos/organization";
+import { WorkspaceModel } from "@app/lib/resources/storage/models/workspace";
+import { WorkspaceHasDomainModel } from "@app/lib/resources/storage/models/workspace_has_domain";
+import { renderLightWorkspaceType } from "@app/lib/workspace";
+import { makeScript } from "@app/scripts/helpers";
+
+makeScript(
+  {
+    domain: {
+      type: "string",
+    },
+    workspaceId: {
+      type: "string",
+    },
+  },
+  async ({ domain, execute }, logger) => {
+    const existingDomainInRegion = await WorkspaceHasDomainModel.findOne({
+      where: { domain },
+      include: [
+        {
+          model: WorkspaceModel,
+          as: "workspace",
+          required: true,
+        },
+      ],
+    });
+
+    if (!existingDomainInRegion) {
+      logger.error({ domain }, "Domain not found");
+      return;
+    }
+
+    logger.info(
+      {
+        domain,
+        workspaceId: existingDomainInRegion.workspace.id,
+      },
+      "Dropping existing domain"
+    );
+
+    const { workspace } = existingDomainInRegion;
+
+    if (execute) {
+      // Delete the domain from the DB.
+      await existingDomainInRegion.destroy();
+
+      // Delete the domain from WorkOS.
+      await removeWorkOSOrganizationDomain(
+        renderLightWorkspaceType({ workspace }),
+        {
+          domain,
+        }
+      );
+    }
+  }
+);

--- a/front/migrations/20250929_drop_domain.ts
+++ b/front/migrations/20250929_drop_domain.ts
@@ -4,6 +4,12 @@ import { WorkspaceHasDomainModel } from "@app/lib/resources/storage/models/works
 import { renderLightWorkspaceType } from "@app/lib/workspace";
 import { makeScript } from "@app/scripts/helpers";
 
+// Should only be used in the following situation:
+// - Domain was verified in the current region.
+// - Domain was also verified in the other region.
+// - The webhook on the `organization_domain.verified` event crashes.
+// This script mimics what we would do for a single region (see upsertWorkspaceDomain).
+
 makeScript(
   {
     domain: {

--- a/front/migrations/20250929_drop_domain.ts
+++ b/front/migrations/20250929_drop_domain.ts
@@ -19,7 +19,7 @@ makeScript(
       type: "string",
     },
   },
-  async ({ domain, execute }, logger) => {
+  async ({ domain, workspaceId, execute }, logger) => {
     const existingDomainInRegion = await WorkspaceHasDomainModel.findOne({
       where: { domain },
       include: [
@@ -45,6 +45,18 @@ makeScript(
     );
 
     const { workspace } = existingDomainInRegion;
+
+    if (workspace.sId !== workspaceId) {
+      logger.error(
+        {
+          domain,
+          workspaceId: existingDomainInRegion.workspace.id,
+          expectedWorkspaceId: workspaceId,
+        },
+        "Workspace id does not match"
+      );
+      return;
+    }
 
     if (execute) {
       // Delete the domain from the DB.


### PR DESCRIPTION
## Description

- This PR adds a script to drop a workspace domain.
- It addresses the situation observed [here](https://dust4ai.slack.com/archives/C05F84CFP0E/p1759139742936199): a first workspace verifies a domain, then another workspace verifies it in the other region.
- The behavior is the same than if it were in the same region (code copy pasted from `upsertWorkspaceDomain`).

## Tests

## Risk

## Deploy Plan

- Run script in region with the exising domain.
- Let webhook retry in region trying to add the domain.
