### PR TITLE
Simpler getFileContent function

### DIFF
--- a/front/lib/actions/mcp_internal_actions/utils/file_utils.ts
+++ b/front/lib/actions/mcp_internal_actions/utils/file_utils.ts
@@ -131,7 +131,7 @@ export async function streamToBuffer(
       if (Buffer.isBuffer(chunk)) {
         chunks.push(chunk);
       } else {
-        chunks.push(Buffer.from(chunk as string));
+        chunks.push(Buffer.from(chunk));
       }
     }
     return new Ok(Buffer.concat(chunks));

--- a/front/lib/api/files/utils.ts
+++ b/front/lib/api/files/utils.ts
@@ -1,9 +1,9 @@
 import type { File } from "formidable";
 import { IncomingForm } from "formidable";
 import type { IncomingMessage } from "http";
-import { Writable } from "stream";
-import { pipeline } from "stream/promises";
+import type { Writable } from "stream";
 
+import { streamToBuffer } from "@app/lib/actions/mcp_internal_actions/utils/file_utils";
 import type { Authenticator } from "@app/lib/auth";
 import type { DustError } from "@app/lib/error";
 import type {
@@ -85,46 +85,19 @@ export const parseUploadRequest = async (
   }
 };
 
-class MemoryWritable extends Writable {
-  private chunks: string[];
-
-  constructor() {
-    super();
-    this.chunks = [];
-  }
-
-  _write(
-    chunk: any,
-    encoding: BufferEncoding,
-    callback: (error?: Error | null) => void
-  ) {
-    this.chunks.push(chunk.toString());
-    callback();
-  }
-
-  getContent() {
-    return this.chunks.join("");
-  }
-}
-
 export async function getFileContent(
   auth: Authenticator,
   file: FileResource,
   version: FileVersion = "processed"
 ): Promise<string | null> {
-  // Create a stream to hold the content of the file
-  const writableStream = new MemoryWritable();
+  const readStream = file.getReadStream({ auth, version });
+  const bufferResult = await streamToBuffer(readStream);
 
-  // Read from the processed file
-  await pipeline(file.getReadStream({ auth, version }), writableStream);
-
-  const content = writableStream.getContent();
-
-  if (!content) {
+  if (bufferResult.isErr()) {
     return null;
   }
 
-  return content;
+  return bufferResult.value.toString("utf-8");
 }
 
 export function getUpdatedContentAndOccurrences({

--- a/front/lib/file_storage/index.ts
+++ b/front/lib/file_storage/index.ts
@@ -53,16 +53,13 @@ export class FileStorage {
     contentType,
     filePath,
   }: {
-    content: string | Buffer;
+    content: string;
     contentType: AllSupportedFileContentType;
     filePath: string;
   }) {
     const gcsFile = this.file(filePath);
 
-    const contentToSave =
-      typeof content === "string"
-        ? Buffer.from(stripNullBytes(content), "utf8")
-        : content;
+    const contentToSave = Buffer.from(stripNullBytes(content), "utf8");
 
     await gcsFile.save(contentToSave, {
       contentType,


### PR DESCRIPTION
## Description

- https://github.com/dust-tt/tasks/issues/4338
- Simplify `getFileContent` by using `streamToBuffer` function instead of custom MemoryWritable
- Remove unused MemoryWritable
- uploadRawContentToBucket is called with string content

### Notes/Questions for reviewer

Why was `MemoryWritable` needed in the first place ?

## Tests

`getFileContent` is called in:

- getClientExecutableFileContent: ✅ 
- generateSnippet: ✅ 
- front/lib/api/files/upsert.ts: ✅ 
- front/pages/api/w/[wId]/files/[fileId]/share.ts: ✅

Checked for non regression everywhere the function is called

## Risk

Risks are have been scoped and verified by the tests above.

## Deploy Plan

Deploy front
