### PR TITLE
[front] - refacto(Dust): @Dust data sources configuration

### DIFF
--- a/front/pages/w/[wId]/builder/agents/dust.tsx
+++ b/front/pages/w/[wId]/builder/agents/dust.tsx
@@ -1,5 +1,7 @@
 import {
   Avatar,
+  Button,
+  Cog6ToothIcon,
   ContextItem,
   DustLogoSquare,
   Page,
@@ -105,6 +107,7 @@ export default function EditDustAgent({
   } = useSpaceDataSourceViews({
     workspaceId: owner.sId,
     spaceId: globalSpace.sId,
+    category: "managed",
   });
 
   // We do not support remote databases for the Dust agent at the moment.
@@ -290,6 +293,28 @@ export default function EditDustAgent({
                     }
                   />
                 ))}
+                <ContextItem
+                  title="Websites"
+                  visual={
+                    <ContextItem.Visual
+                      visual={getConnectorProviderLogoWithFallback({
+                        provider: "webcrawler",
+                      })}
+                    />
+                  }
+                  action={<Button icon={Cog6ToothIcon} variant="outline" />}
+                />
+                <ContextItem
+                  title="Folders"
+                  visual={
+                    <ContextItem.Visual
+                      visual={getConnectorProviderLogoWithFallback({
+                        provider: null,
+                      })}
+                    />
+                  }
+                  action={<Button icon={Cog6ToothIcon} variant="outline" />}
+                />
               </ContextItem.List>
             </>
           ) : dustAgentConfiguration?.status ===

--- a/front/pages/w/[wId]/builder/agents/dust.tsx
+++ b/front/pages/w/[wId]/builder/agents/dust.tsx
@@ -266,56 +266,48 @@ export default function EditDustAgent({
                 title="Data Sources and Connections"
                 description="Configure which Company Data connections and data sources will be searched by the Dust agent."
               />
-              <>
-                {
-                  <ContextItem.List>
-                    {sortedDatasources.map((dsView) => (
-                      <ContextItem
-                        key={dsView.id}
-                        title={getDisplayNameForDataSource(dsView.dataSource)}
-                        visual={
-                          <DustAgentDataSourceVisual dataSourceView={dsView} />
-                        }
-                        action={
-                          <SliderToggle
-                            selected={
-                              dsView.dataSource.assistantDefaultSelected
-                            }
-                            onClick={async () => {
-                              await updateDatasourceSettings(
-                                {
-                                  assistantDefaultSelected:
-                                    !dsView.dataSource.assistantDefaultSelected,
-                                },
-                                dsView.dataSource
-                              );
-                            }}
-                          />
-                        }
+              <ContextItem.List>
+                {sortedDatasources.map((dsView) => (
+                  <ContextItem
+                    key={dsView.id}
+                    title={getDisplayNameForDataSource(dsView.dataSource)}
+                    visual={
+                      <DustAgentDataSourceVisual dataSourceView={dsView} />
+                    }
+                    action={
+                      <SliderToggle
+                        selected={dsView.dataSource.assistantDefaultSelected}
+                        onClick={async () => {
+                          await updateDatasourceSettings(
+                            {
+                              assistantDefaultSelected:
+                                !dsView.dataSource.assistantDefaultSelected,
+                            },
+                            dsView.dataSource
+                          );
+                        }}
                       />
-                    ))}
-                  </ContextItem.List>
-                }
-              </>
+                    }
+                  />
+                ))}
+              </ContextItem.List>
             </>
           ) : dustAgentConfiguration?.status ===
             "disabled_missing_datasource" ? (
-            <>
-              <Page.SectionHeader
-                title="This workspace doesn't currently have any data sources."
-                description="Add Company Data connections or data sources to enable the Dust agent."
-                action={{
-                  label: "Add data",
-                  variant: "primary",
-                  icon: PlusIcon,
-                  onClick: async () => {
-                    await router.push(
-                      `/w/${owner.sId}/spaces/${globalSpace.sId}`
-                    );
-                  },
-                }}
-              />
-            </>
+            <Page.SectionHeader
+              title="This workspace doesn't currently have any data sources."
+              description="Add Company Data connections or data sources to enable the Dust agent."
+              action={{
+                label: "Add data",
+                variant: "primary",
+                icon: PlusIcon,
+                onClick: async () => {
+                  await router.push(
+                    `/w/${owner.sId}/spaces/${globalSpace.sId}`
+                  );
+                },
+              }}
+            />
           ) : null}
         </div>
       </div>

--- a/front/pages/w/[wId]/builder/agents/dust.tsx
+++ b/front/pages/w/[wId]/builder/agents/dust.tsx
@@ -49,6 +49,7 @@ import type {
   SubscriptionType,
   WorkspaceType,
 } from "@app/types";
+import { pluralize } from "@app/types";
 
 export const getServerSideProps = withDefaultUserAuthRequirements<{
   owner: WorkspaceType;
@@ -438,8 +439,9 @@ function DataSourceCategorySheet({
     return initial;
   }, [spaceDataSourceViews]);
 
-  const columns: ColumnDef<Data>[] = useMemo(
+  const columnsWithSelection: ColumnDef<Data>[] = useMemo(
     () => [
+      createSelectionColumn<Data>(),
       {
         header: "Name",
         accessorKey: "name",
@@ -451,10 +453,6 @@ function DataSourceCategorySheet({
       },
     ],
     []
-  );
-  const columnsWithSelection: ColumnDef<Data>[] = useMemo(
-    () => [createSelectionColumn<Data>(), ...columns],
-    [columns]
   );
 
   const onClose = () => {
@@ -493,9 +491,7 @@ function DataSourceCategorySheet({
 
       sendNotification({
         title: "Saved",
-        description: `Updated ${changes.length} ${
-          changes.length === 1 ? "data source" : "data sources"
-        }`,
+        description: `Updated ${changes.length} data source${pluralize(changes.length)}`,
         type: "success",
       });
       setRowSelection({});
@@ -525,10 +521,7 @@ function DataSourceCategorySheet({
         }
       }}
     >
-      <div
-        className="inline-flex"
-        data-testid={`dsv-${category}-sheet-trigger`}
-      >
+      <div className="inline-flex">
         <SheetTrigger asChild>{trigger}</SheetTrigger>
       </div>
       <SheetContent size="lg">


### PR DESCRIPTION
## Description

Refactors the @Dust agent configuration page to improve data source management for folders and websites. This change addresses the issue where managing individual data sources for these categories was becoming unwieldy by introducing modal-based configuration sheets. The refactor replaces individual toggle controls with dedicated configuration modals for "Websites" and "Folders" categories, allowing users to select multiple items at once with search and bulk operations.

**References:**
- https://github.com/dust-tt/tasks/issues/4425

## Risk

Low 

## Deploy Plan

Deploy front
