### PR TITLE
Move posthog logic to PostHogTracker + track in product behind FF

### DIFF
--- a/front/components/app/PostHogTracker.tsx
+++ b/front/components/app/PostHogTracker.tsx
@@ -1,0 +1,106 @@
+import { useRouter } from "next/router";
+import posthog from "posthog-js";
+import { PostHogProvider } from "posthog-js/react";
+import { useEffect } from "react";
+import { useCookies } from "react-cookie";
+
+import { useUser } from "@app/lib/swr/user";
+import { useFeatureFlags } from "@app/lib/swr/workspaces";
+
+const POSTHOG_KEY = process.env.NEXT_PUBLIC_POSTHOG_KEY;
+const NODE_ENV = process.env.NODE_ENV;
+
+interface PostHogTrackerProps {
+  children: React.ReactNode;
+}
+
+export function PostHogTracker({ children }: PostHogTrackerProps) {
+  const router = useRouter();
+  const [cookies] = useCookies(["dust-cookies-accepted"]);
+  const { user } = useUser();
+
+  const cookieValue = cookies["dust-cookies-accepted"];
+  const hasAcceptedCookies =
+    !!user ||
+    cookieValue === "true" ||
+    cookieValue === "auto" ||
+    cookieValue === true;
+
+  // Extract workspace ID from router query for /w/ routes
+  const workspaceId = router.query.wId as string | undefined;
+  const { hasFeature } = useFeatureFlags({
+    workspaceId: workspaceId ?? "",
+    disabled: !workspaceId,
+  });
+
+  const isProductRoute = router.pathname.startsWith("/w/");
+  const hasPostHogFeatureFlag = hasFeature("enable_posthog");
+
+  // Exclude certain paths from tracking (but not /w/ anymore)
+  const excludedPaths = [
+    "/poke",
+    "/poke/",
+    "/sso-enforced",
+    "/maintenance",
+    "/oauth/",
+    "/share/",
+  ];
+
+  const isTrackablePage =
+    !excludedPaths.some((path) => router.pathname.startsWith(path)) &&
+    (!isProductRoute || hasPostHogFeatureFlag);
+
+  useEffect(() => {
+    const shouldTrack = isTrackablePage && hasAcceptedCookies;
+
+    if (!shouldTrack) {
+      if (posthog.__loaded) {
+        posthog.opt_out_capturing();
+      }
+      return;
+    }
+
+    if (!posthog.__loaded && POSTHOG_KEY) {
+      posthog.init(POSTHOG_KEY, {
+        api_host: "/ingest",
+        person_profiles: "identified_only",
+        defaults: "2025-05-24",
+        loaded: (posthog) => {
+          if (NODE_ENV === "development") {
+            posthog.debug();
+          }
+        },
+      });
+    } else if (posthog.__loaded) {
+      posthog.opt_in_capturing();
+    }
+
+    // Identify user if logged in
+    if (posthog.__loaded && user) {
+      posthog.identify(user.sId, {
+        email: user.email,
+        firstName: user.firstName,
+        lastName: user.lastName,
+      });
+
+      // Group by workspace if we're in a product route
+      if (isProductRoute && workspaceId) {
+        posthog.group("workspace", workspaceId);
+      }
+    }
+  }, [
+    router.pathname,
+    hasAcceptedCookies,
+    isTrackablePage,
+    user,
+    workspaceId,
+    isProductRoute,
+  ]);
+
+  // Only wrap with PostHogProvider for trackable pages when cookies are accepted
+  if (isTrackablePage && hasAcceptedCookies) {
+    return <PostHogProvider client={posthog}>{children}</PostHogProvider>;
+  }
+
+  return <>{children}</>;
+}

--- a/front/components/app/PostHogTracker.tsx
+++ b/front/components/app/PostHogTracker.tsx
@@ -27,7 +27,9 @@ export function PostHogTracker({ children }: PostHogTrackerProps) {
     cookieValue === true;
 
   // Extract workspace ID from router query for /w/ routes
-  const workspaceId = router.query.wId as string | undefined;
+  // Extract workspace ID from router query for /w/ routes
+  const { wId } = router.query;
+  const workspaceId = isString(wId) ? wId : undefined;
   const { hasFeature } = useFeatureFlags({
     workspaceId: workspaceId ?? "",
     disabled: !workspaceId,

--- a/front/components/app/PostHogTracker.tsx
+++ b/front/components/app/PostHogTracker.tsx
@@ -4,6 +4,7 @@ import { PostHogProvider } from "posthog-js/react";
 import { useEffect } from "react";
 import { useCookies } from "react-cookie";
 
+import { DUST_COOKIES_ACCEPTED, hasCookiesAccepted } from "@app/lib/cookies";
 import { useUser } from "@app/lib/swr/user";
 import { useFeatureFlags } from "@app/lib/swr/workspaces";
 
@@ -16,17 +17,12 @@ interface PostHogTrackerProps {
 
 export function PostHogTracker({ children }: PostHogTrackerProps) {
   const router = useRouter();
-  const [cookies] = useCookies(["dust-cookies-accepted"]);
+  const [cookies] = useCookies([DUST_COOKIES_ACCEPTED]);
   const { user } = useUser();
 
-  const cookieValue = cookies["dust-cookies-accepted"];
-  const hasAcceptedCookies =
-    !!user ||
-    cookieValue === "true" ||
-    cookieValue === "auto" ||
-    cookieValue === true;
+  const cookieValue = cookies[DUST_COOKIES_ACCEPTED];
+  const hasAcceptedCookies = hasCookiesAccepted(cookieValue, user);
 
-  // Extract workspace ID from router query for /w/ routes
   const workspaceId = router.query.wId as string | undefined;
   const { hasFeature } = useFeatureFlags({
     workspaceId: workspaceId ?? "",
@@ -36,7 +32,6 @@ export function PostHogTracker({ children }: PostHogTrackerProps) {
   const isProductRoute = router.pathname.startsWith("/w/");
   const hasPostHogFeatureFlag = hasFeature("enable_posthog");
 
-  // Exclude certain paths from tracking (but not /w/ anymore)
   const excludedPaths = [
     "/poke",
     "/poke/",

--- a/front/components/home/LandingLayout.tsx
+++ b/front/components/home/LandingLayout.tsx
@@ -21,6 +21,11 @@ import { MobileNavigation } from "@app/components/home/menu/MobileNavigation";
 import ScrollingHeader from "@app/components/home/ScrollingHeader";
 import UTMButton from "@app/components/UTMButton";
 import UTMHandler from "@app/components/UTMHandler";
+import {
+  DUST_COOKIES_ACCEPTED,
+  hasCookiesAccepted,
+  shouldCheckGeolocation,
+} from "@app/lib/cookies";
 import { useGeolocation } from "@app/lib/swr/geo";
 import { classNames, getFaviconPath } from "@app/lib/utils";
 
@@ -44,16 +49,16 @@ export default function LandingLayout({
     utmParams,
   } = pageProps;
 
-  const [cookies, setCookie] = useCookies(["dust-cookies-accepted"], {
+  const [cookies, setCookie] = useCookies([DUST_COOKIES_ACCEPTED], {
     doNotParse: true,
   });
   const [showCookieBanner, setShowCookieBanner] = useState<boolean>(false);
-  const cookieValue = cookies["dust-cookies-accepted"];
+  const cookieValue = cookies[DUST_COOKIES_ACCEPTED];
   const [hasAcceptedCookies, setHasAcceptedCookies] = useState<boolean>(
-    ["true", "auto"].includes(cookieValue)
+    hasCookiesAccepted(cookieValue, null)
   );
 
-  const shouldCheckGeo = cookieValue === undefined;
+  const shouldCheckGeo = shouldCheckGeolocation(cookieValue);
 
   const { geoData, isGeoDataLoading } = useGeolocation({
     disabled: !shouldCheckGeo,
@@ -67,7 +72,7 @@ export default function LandingLayout({
         setHasAcceptedCookies(true);
       }
       setShowCookieBanner(false);
-      setCookie("dust-cookies-accepted", type, {
+      setCookie(DUST_COOKIES_ACCEPTED, type, {
         path: "/",
         maxAge: 183 * 24 * 60 * 60, // 6 months
         sameSite: "lax",

--- a/front/lib/cookies.ts
+++ b/front/lib/cookies.ts
@@ -1,0 +1,35 @@
+import type { UserType } from "@app/types/user";
+
+export const DUST_COOKIES_ACCEPTED = "dust-cookies-accepted";
+
+/**
+ * Determines if cookies have been accepted based on cookie value or user authentication
+ * @param cookieValue - The value of the dust-cookies-accepted cookie
+ * @param user - Optional user object (logged in users are considered to have accepted cookies)
+ * @returns boolean indicating if cookies are accepted
+ */
+export function hasCookiesAccepted(
+  cookieValue: string | boolean | undefined,
+  user?: UserType | null
+): boolean {
+  // Logged-in users are considered to have accepted cookies
+  if (user) {
+    return true;
+  }
+
+  // Check explicit cookie consent values
+  return (
+    cookieValue === "true" || cookieValue === "auto" || cookieValue === true
+  );
+}
+
+/**
+ * Checks if we should auto-accept cookies based on geolocation
+ * @param cookieValue - The current cookie value
+ * @returns boolean indicating if we should check geolocation
+ */
+export function shouldCheckGeolocation(
+  cookieValue: string | boolean | undefined
+): boolean {
+  return cookieValue === undefined;
+}

--- a/front/pages/_app.tsx
+++ b/front/pages/_app.tsx
@@ -8,22 +8,16 @@ import "@app/styles/components.css";
 import { datadogLogs } from "@datadog/browser-logs";
 import type { NextPage } from "next";
 import type { AppProps } from "next/app";
-import { useRouter } from "next/router";
-import posthog from "posthog-js";
-import { PostHogProvider } from "posthog-js/react";
-import { useEffect } from "react";
 
 // Important: avoid destructuring process.env on the client.
 // Next.js replaces direct property access (process.env.NEXT_PUBLIC_*) at build time,
 // but destructuring `process.env` does not get inlined.
-const POSTHOG_KEY = process.env.NEXT_PUBLIC_POSTHOG_KEY;
 const NODE_ENV = process.env.NODE_ENV;
 const DATADOG_CLIENT_TOKEN = process.env.NEXT_PUBLIC_DATADOG_CLIENT_TOKEN;
 const DATADOG_SERVICE = process.env.NEXT_PUBLIC_DATADOG_SERVICE;
 const COMMIT_HASH = process.env.NEXT_PUBLIC_COMMIT_HASH;
 
-import { useCookies } from "react-cookie";
-
+import { PostHogTracker } from "@app/components/app/PostHogTracker";
 import RootLayout from "@app/components/app/RootLayout";
 
 if (DATADOG_CLIENT_TOKEN) {
@@ -52,65 +46,14 @@ type AppPropsWithLayout = AppProps & {
 };
 
 export default function App({ Component, pageProps }: AppPropsWithLayout) {
-  const router = useRouter();
-  const [cookies] = useCookies(["dust-cookies-accepted"]);
-
-  const cookieValue = cookies["dust-cookies-accepted"];
-  const hasAcceptedCookies =
-    cookieValue === "true" || cookieValue === "auto" || cookieValue === true;
-
-  const excludedPaths = [
-    "/w/",
-    "/poke",
-    "/poke/",
-    "/sso-enforced",
-    "/maintenance",
-    "/oauth/",
-    "/share/",
-  ];
-  const isTrackablePage = !excludedPaths.some((path) =>
-    router.pathname.startsWith(path)
-  );
-
-  useEffect(() => {
-    const shouldTrack = isTrackablePage && hasAcceptedCookies;
-
-    if (!shouldTrack) {
-      if (posthog.__loaded) {
-        posthog.opt_out_capturing();
-      }
-      return;
-    }
-
-    if (!posthog.__loaded && POSTHOG_KEY) {
-      posthog.init(POSTHOG_KEY, {
-        api_host: "/ingest",
-        person_profiles: "identified_only",
-        defaults: "2025-05-24",
-        loaded: (posthog) => {
-          if (NODE_ENV === "development") {
-            posthog.debug();
-          }
-        },
-      });
-    } else if (posthog.__loaded) {
-      posthog.opt_in_capturing();
-    }
-  }, [router.pathname, hasAcceptedCookies, isTrackablePage]);
-
   // Use the layout defined at the page level, if available.
   const getLayout = Component.getLayout ?? ((page) => page);
 
-  const content = (
-    <RootLayout>
-      {getLayout(<Component {...pageProps} />, pageProps)}
-    </RootLayout>
+  return (
+    <PostHogTracker>
+      <RootLayout>
+        {getLayout(<Component {...pageProps} />, pageProps)}
+      </RootLayout>
+    </PostHogTracker>
   );
-
-  // Only wrap with PostHogProvider for trackable pages when cookies are accepted
-  if (isTrackablePage && hasAcceptedCookies) {
-    return <PostHogProvider client={posthog}>{content}</PostHogProvider>;
-  }
-
-  return content;
 }

--- a/front/types/shared/feature_flags.ts
+++ b/front/types/shared/feature_flags.ts
@@ -46,6 +46,10 @@ export const WHITELISTABLE_FEATURES_CONFIG = {
     description: "Access to DeepSeek R1 model as global agent",
     stage: "on_demand",
   },
+  enable_posthog: {
+    description: "Enable PostHog tracking within the product (/w/ routes)",
+    stage: "on_demand",
+  },
   dev_mcp_actions: {
     description: "MCP tools currently in development",
     stage: "dust_only",
@@ -183,6 +187,10 @@ export const WHITELISTABLE_FEATURES_CONFIG = {
   },
   slack_bot_mcp: {
     description: "Slack bot MCP server for workspace-level Slack integration",
+    stage: "on_demand",
+  },
+  slack_semantic_search: {
+    description: "Slack semantic search feature",
     stage: "on_demand",
   },
 } as const satisfies Record<string, FeatureFlag>;

--- a/sdks/js/src/types.ts
+++ b/sdks/js/src/types.ts
@@ -652,6 +652,7 @@ const WhitelistableFeaturesSchema = FlexibleEnumSchema<
   | "dev_mcp_actions"
   | "disable_run_logs"
   | "disallow_agent_creation_to_users"
+  | "enable_posthog"
   | "freshservice_tool"
   | "google_ai_studio_experimental_models_feature"
   | "google_sheets_tool"


### PR DESCRIPTION



## Description

Extracts PostHog tracking logic from `_app.tsx` into a dedicated `PostHogTracker` component and introduces workspace-level feature flag control for product routes. This refactoring enables selective PostHog tracking within the product (`/w/` routes) based on the `enable_posthog` feature flag, while maintaining existing tracking behavior for public pages. The implementation includes proper user identification with workspace grouping and respects cookie consent preferences.

## Risk

Changes the PostHog initialization flow and adds feature flag dependency for product route tracking. If the feature flag logic fails, product routes would lose PostHog tracking entirely.

## Deploy Plan

The `enable_posthog` feature flag needs to be configured for workspaces that should have PostHog tracking enabled within the product.
