### PR TITLE
enh: poke to switch bq location + fix exact loc match

### DIFF
--- a/connectors/src/connectors/bigquery/lib/bigquery_api.ts
+++ b/connectors/src/connectors/bigquery/lib/bigquery_api.ts
@@ -111,13 +111,11 @@ export const fetchDatasets = async ({
     return new Ok(
       removeNulls(
         datasets.map((dataset) => {
-          // We want to filter out datasets that are in a different location than the credentials.
-          // But, for example, we want to keep dataset in "us" (multi-region) when selected location is "us-central1" (regional)
-          if (
-            !credentials.location
-              .toLowerCase()
-              .startsWith(dataset.location?.toLowerCase() ?? "")
-          ) {
+          // Strict location matching: only keep datasets whose location exactly matches
+          // the credential's location (case-insensitive). No regional/multi-region expansion.
+          const datasetLocation = dataset.location?.toLowerCase();
+          const credentialLocation = credentials.location.toLowerCase();
+          if (!datasetLocation || datasetLocation !== credentialLocation) {
             return null;
           }
 

--- a/front/lib/api/poke/plugins/data_sources/bigquery_change_location.ts
+++ b/front/lib/api/poke/plugins/data_sources/bigquery_change_location.ts
@@ -1,16 +1,16 @@
-import { BigQuery } from "@google-cloud/bigquery";
 import type { Dataset } from "@google-cloud/bigquery";
+import { BigQuery } from "@google-cloud/bigquery";
 
 import config from "@app/lib/api/config";
 import { createPlugin } from "@app/lib/api/poke/types";
 import logger, { auditLog } from "@app/logger/logger";
+import type {BigQueryCredentialsWithLocation} from "@app/types";
 import {
   ConnectorsAPI,
   Err,
-  Ok,
-  OAuthAPI,
-  type BigQueryCredentialsWithLocation,
   normalizeError,
+  OAuthAPI,
+  Ok
 } from "@app/types";
 
 export const bigqueryChangeLocationPlugin = createPlugin({

--- a/front/lib/api/poke/plugins/data_sources/bigquery_change_location.ts
+++ b/front/lib/api/poke/plugins/data_sources/bigquery_change_location.ts
@@ -4,14 +4,8 @@ import { BigQuery } from "@google-cloud/bigquery";
 import config from "@app/lib/api/config";
 import { createPlugin } from "@app/lib/api/poke/types";
 import logger, { auditLog } from "@app/logger/logger";
-import type {BigQueryCredentialsWithLocation} from "@app/types";
-import {
-  ConnectorsAPI,
-  Err,
-  normalizeError,
-  OAuthAPI,
-  Ok
-} from "@app/types";
+import type { BigQueryCredentialsWithLocation } from "@app/types";
+import { ConnectorsAPI, Err, normalizeError, OAuthAPI, Ok } from "@app/types";
 
 export const bigqueryChangeLocationPlugin = createPlugin({
   manifest: {

--- a/front/lib/api/poke/plugins/data_sources/bigquery_change_location.ts
+++ b/front/lib/api/poke/plugins/data_sources/bigquery_change_location.ts
@@ -1,0 +1,213 @@
+import { BigQuery } from "@google-cloud/bigquery";
+import type { Dataset } from "@google-cloud/bigquery";
+
+import config from "@app/lib/api/config";
+import { createPlugin } from "@app/lib/api/poke/types";
+import logger, { auditLog } from "@app/logger/logger";
+import {
+  ConnectorsAPI,
+  Err,
+  Ok,
+  OAuthAPI,
+  type BigQueryCredentialsWithLocation,
+  normalizeError,
+} from "@app/types";
+
+export const bigqueryChangeLocationPlugin = createPlugin({
+  manifest: {
+    id: "bigquery-change-location",
+    name: "BigQuery: Change Location",
+    description:
+      "Change a BigQuery connector's region by creating a new credential with the selected location and updating the connector.",
+    resourceTypes: ["data_sources"],
+    args: {
+      location: {
+        type: "enum",
+        async: true,
+        multiple: false,
+        label: "New Location",
+        description:
+          "Select the exact location where the datasets reside (e.g., EU, US, europe-west1).",
+        values: [],
+      },
+      confirm: {
+        type: "boolean",
+        label: "Confirm",
+        description:
+          "Confirm you want to update the connector to the selected location.",
+      },
+    },
+  },
+  isApplicableTo: (_, dataSource) => {
+    return !!dataSource && dataSource.connectorProvider === "bigquery";
+  },
+  populateAsyncArgs: async (auth, dataSource) => {
+    if (!dataSource) {
+      return new Err(new Error("Data source not found."));
+    }
+    if (!dataSource.connectorId) {
+      return new Err(new Error("No connector on data source."));
+    }
+
+    // Fetch connector to get current credentials id
+    const connectorsAPI = new ConnectorsAPI(
+      config.getConnectorsAPIConfig(),
+      logger
+    );
+    const connectorRes = await connectorsAPI.getConnector(
+      dataSource.connectorId
+    );
+    if (connectorRes.isErr()) {
+      return new Err(
+        new Error(`Failed to fetch connector: ${connectorRes.error.message}`)
+      );
+    }
+    const connector = connectorRes.value;
+
+    // Fetch existing credentials content
+    const oAuthAPI = new OAuthAPI(config.getOAuthAPIConfig(), logger);
+    const credRes = await oAuthAPI.getCredentials({
+      credentialsId: connector.connectionId,
+    });
+    if (credRes.isErr()) {
+      return new Err(
+        new Error(
+          `Failed to fetch current credentials: ${credRes.error.message}`
+        )
+      );
+    }
+
+    const content = credRes.value.credential
+      .content as BigQueryCredentialsWithLocation;
+
+    // Build a BigQuery client and collect dataset locations
+    const bq = new BigQuery({
+      credentials: content,
+      scopes: ["https://www.googleapis.com/auth/bigquery.readonly"],
+    });
+    let datasets: Dataset[];
+    try {
+      [datasets] = await bq.getDatasets();
+    } catch (e) {
+      return new Err(
+        new Error(`Failed to list datasets: ${normalizeError(e).message}`)
+      );
+    }
+
+    const uniqueLocations = Array.from(
+      new Set(
+        datasets
+          .map((d) => d.location?.toLowerCase())
+          .filter((l): l is string => Boolean(l))
+      )
+    ).sort();
+
+    return new Ok({
+      location: uniqueLocations.map((loc) => ({
+        label: loc,
+        value: loc,
+      })),
+    });
+  },
+  execute: async (auth, dataSource, args) => {
+    if (!dataSource) {
+      return new Err(new Error("Data source not found."));
+    }
+    if (!dataSource.connectorId) {
+      return new Err(new Error("No connector on data source."));
+    }
+    if (!args.confirm) {
+      return new Err(new Error("Please confirm to proceed."));
+    }
+    const selected = args.location?.[0];
+    if (!selected) {
+      return new Err(new Error("You must select a new location."));
+    }
+
+    const connectorsAPI = new ConnectorsAPI(
+      config.getConnectorsAPIConfig(),
+      logger
+    );
+    const oAuthAPI = new OAuthAPI(config.getOAuthAPIConfig(), logger);
+
+    // Fetch connector and its current credentials
+    const connectorRes = await connectorsAPI.getConnector(
+      dataSource.connectorId
+    );
+    if (connectorRes.isErr()) {
+      return new Err(
+        new Error(`Failed to fetch connector: ${connectorRes.error.message}`)
+      );
+    }
+    const connector = connectorRes.value;
+
+    const credRes = await oAuthAPI.getCredentials({
+      credentialsId: connector.connectionId,
+    });
+    if (credRes.isErr()) {
+      return new Err(
+        new Error(
+          `Failed to fetch current credentials: ${credRes.error.message}`
+        )
+      );
+    }
+
+    const content = credRes.value.credential
+      .content as BigQueryCredentialsWithLocation;
+
+    // Prepare new credentials content with updated location
+    const newCredentials: BigQueryCredentialsWithLocation = {
+      ...content,
+      location: selected,
+    };
+
+    // Create new credentials in OAuth service
+    const user = auth.getNonNullableUser();
+    const workspace = auth.getNonNullableWorkspace();
+    const postCredRes = await oAuthAPI.postCredentials({
+      provider: "bigquery",
+      credentials: newCredentials,
+      userId: user.sId,
+      workspaceId: workspace.sId,
+    });
+    if (postCredRes.isErr()) {
+      return new Err(
+        new Error(
+          `Failed to create new credentials: ${postCredRes.error.message}`
+        )
+      );
+    }
+
+    const newCredentialsId = postCredRes.value.credential.credential_id;
+
+    // Update connector to point to the new credentials
+    const updateRes = await connectorsAPI.updateConnector({
+      connectorId: dataSource.connectorId,
+      connectionId: newCredentialsId,
+    });
+    if (updateRes.isErr()) {
+      return new Err(
+        new Error(
+          `Failed to update connector with new credentials: ${updateRes.error.message}`
+        )
+      );
+    }
+
+    auditLog(
+      {
+        connectorId: dataSource.connectorId,
+        previousConnectionId: connector.connectionId,
+        newConnectionId: newCredentialsId,
+        previousLocation: content.location,
+        newLocation: selected,
+        who: auth.user(),
+      },
+      "BigQuery connector location updated"
+    );
+
+    return new Ok({
+      display: "text",
+      value: `Connector ${dataSource.connectorId} updated: location ${content.location} -> ${selected}. A re-sync has been triggered.`,
+    });
+  },
+});

--- a/front/lib/api/poke/plugins/data_sources/index.ts
+++ b/front/lib/api/poke/plugins/data_sources/index.ts
@@ -1,3 +1,4 @@
+export * from "./bigquery_change_location";
 export * from "./compute_statistics";
 export * from "./confluence_page_checker";
 export * from "./delete_data_source";
@@ -12,4 +13,3 @@ export * from "./toggle_restricted_space_agent_slack_access";
 export * from "./toggle_slack_bot";
 export * from "./webcrawler_actions";
 export * from "./webcrawler_frequency";
-export * from "./bigquery_change_location";

--- a/front/lib/api/poke/plugins/data_sources/index.ts
+++ b/front/lib/api/poke/plugins/data_sources/index.ts
@@ -12,3 +12,4 @@ export * from "./toggle_restricted_space_agent_slack_access";
 export * from "./toggle_slack_bot";
 export * from "./webcrawler_actions";
 export * from "./webcrawler_frequency";
+export * from "./bigquery_change_location";

--- a/front/pages/api/w/[wId]/credentials/check_bigquery_locations.test.ts
+++ b/front/pages/api/w/[wId]/credentials/check_bigquery_locations.test.ts
@@ -110,11 +110,7 @@ describe("POST /api/w/[wId]/credentials/check_bigquery_locations", () => {
       locations: {
         us: ["dataset1.table1", "dataset1.table2"],
         eu: ["dataset2.table3"],
-        "eu-central1": [
-          "dataset2.table3",
-          "dataset3.table4",
-          "dataset4.table5",
-        ],
+        "eu-central1": ["dataset3.table4", "dataset4.table5"],
       },
     });
   });

--- a/front/pages/api/w/[wId]/credentials/check_bigquery_locations.ts
+++ b/front/pages/api/w/[wId]/credentials/check_bigquery_locations.ts
@@ -110,7 +110,7 @@ async function handler(
       locations: Object.fromEntries(
         Object.entries(locations).map(([location, tables]) => [
           location,
-          Array.from(tables),
+          Array.from(tables).sort(),
         ])
       ),
     });

--- a/front/pages/api/w/[wId]/credentials/check_bigquery_locations.ts
+++ b/front/pages/api/w/[wId]/credentials/check_bigquery_locations.ts
@@ -8,11 +8,7 @@ import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrapper
 import type { Authenticator } from "@app/lib/auth";
 import { apiError } from "@app/logger/withlogging";
 import type { APIErrorType, WithAPIErrorResponse } from "@app/types";
-import {
-  CheckBigQueryCredentialsSchema,
-  normalizeError,
-  removeNulls,
-} from "@app/types";
+import { CheckBigQueryCredentialsSchema, normalizeError } from "@app/types";
 
 const PostCheckBigQueryRegionsRequestBodySchema = t.type({
   credentials: CheckBigQueryCredentialsSchema,
@@ -94,26 +90,19 @@ async function handler(
     // Get all datasets
     const [datasets] = await bigquery.getDatasets();
 
-    const allDatasetsLocations = removeNulls(
-      datasets.map((dataset) => dataset.location?.toLocaleLowerCase())
-    );
-
-    // Initialize locations map
+    // Strict location listing: only expose actual dataset locations and only associate
+    // tables to their dataset's exact location (no regional/multi-region expansion).
     const locations: Record<string, Set<string>> = {};
 
-    // Process each dataset and its tables
     for (const dataset of datasets) {
+      const dsLocation = dataset.location?.toLowerCase();
+      if (!dsLocation) {
+        continue;
+      }
       const [tables] = await dataset.getTables();
       for (const table of tables) {
-        for (const location of allDatasetsLocations) {
-          if (
-            dataset.location &&
-            location.toLowerCase().startsWith(dataset.location.toLowerCase())
-          ) {
-            locations[location] ??= new Set();
-            locations[location].add(`${dataset.id}.${table.id}`);
-          }
-        }
+        locations[dsLocation] ??= new Set();
+        locations[dsLocation].add(`${dataset.id}.${table.id}`);
       }
     }
 


### PR DESCRIPTION
## Description

This PR does 2 things.

 - Enforce strict BigQuery location matching across connectors and front-end.
  - Remove multi‑region→regional “prefix” expansion that caused EU/US to appear under regional locations.
  - Add Poke plugin to change a BigQuery connector’s location safely.

## Tests

Tested locally

## Risk
Low
## Deploy Plan

Deploy front and connectors