### PR TITLE
Add discord oauth core logic

### DIFF
--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -141,6 +141,7 @@ pub mod oauth {
     pub mod providers {
         pub mod confluence;
         pub mod confluence_tools;
+        pub mod discord;
         pub mod freshservice;
         pub mod github;
         pub mod gmail;

--- a/core/src/oauth/connection.rs
+++ b/core/src/oauth/connection.rs
@@ -2,7 +2,7 @@ use crate::oauth::{
     encryption::{seal_str, unseal_str},
     providers::{
         confluence::ConfluenceConnectionProvider,
-        confluence_tools::ConfluenceToolsConnectionProvider,
+        confluence_tools::ConfluenceToolsConnectionProvider, discord::DiscordConnectionProvider,
         freshservice::FreshserviceConnectionProvider, github::GithubConnectionProvider,
         gmail::GmailConnectionProvider, gong::GongConnectionProvider,
         google_drive::GoogleDriveConnectionProvider, hubspot::HubspotConnectionProvider,
@@ -94,6 +94,7 @@ impl std::error::Error for ConnectionError {}
 pub enum ConnectionProvider {
     Confluence,
     ConfluenceTools,
+    Discord,
     Freshservice,
     Github,
     Gong,
@@ -236,6 +237,7 @@ pub fn provider(t: ConnectionProvider) -> Box<dyn Provider + Sync + Send> {
     match t {
         ConnectionProvider::Confluence => Box::new(ConfluenceConnectionProvider::new()),
         ConnectionProvider::ConfluenceTools => Box::new(ConfluenceToolsConnectionProvider::new()),
+        ConnectionProvider::Discord => Box::new(DiscordConnectionProvider::new()),
         ConnectionProvider::Freshservice => Box::new(FreshserviceConnectionProvider::new()),
         ConnectionProvider::Github => Box::new(GithubConnectionProvider::new()),
         ConnectionProvider::Gong => Box::new(GongConnectionProvider::new()),

--- a/core/src/oauth/providers/discord.rs
+++ b/core/src/oauth/providers/discord.rs
@@ -13,9 +13,10 @@ use lazy_static::lazy_static;
 use std::env;
 
 lazy_static! {
-    static ref OAUTH_DISCORD_CLIENT_ID: String = env::var("OAUTH_DISCORD_CLIENT_ID").unwrap();
-    static ref OAUTH_DISCORD_CLIENT_SECRET: String =
-        env::var("OAUTH_DISCORD_CLIENT_SECRET").unwrap();
+    static ref OAUTH_DISCORD_CLIENT_ID: String = env::var("OAUTH_DISCORD_CLIENT_ID")
+        .expect("OAUTH_DISCORD_CLIENT_ID environment variable must be set");
+    static ref OAUTH_DISCORD_CLIENT_SECRET: String = env::var("OAUTH_DISCORD_CLIENT_SECRET")
+        .expect("OAUTH_DISCORD_CLIENT_SECRET environment variable must be set");
 }
 
 #[derive(Debug, PartialEq, Clone)]

--- a/core/src/oauth/providers/discord.rs
+++ b/core/src/oauth/providers/discord.rs
@@ -1,0 +1,165 @@
+use crate::oauth::{
+    connection::{
+        Connection, ConnectionProvider, FinalizeResult, Provider, ProviderError, RefreshResult,
+        PROVIDER_TIMEOUT_SECONDS,
+    },
+    credential::Credential,
+    providers::utils::execute_request,
+};
+use crate::utils;
+use anyhow::{anyhow, Result};
+use async_trait::async_trait;
+use lazy_static::lazy_static;
+use std::env;
+
+lazy_static! {
+    static ref OAUTH_DISCORD_CLIENT_ID: String = env::var("OAUTH_DISCORD_CLIENT_ID").unwrap();
+    static ref OAUTH_DISCORD_CLIENT_SECRET: String =
+        env::var("OAUTH_DISCORD_CLIENT_SECRET").unwrap();
+}
+
+#[derive(Debug, PartialEq, Clone)]
+pub enum DiscordUseCase {
+    Bot,
+}
+
+pub struct DiscordConnectionProvider {}
+
+impl DiscordConnectionProvider {
+    pub fn new() -> Self {
+        DiscordConnectionProvider {}
+    }
+
+    async fn exchange_token(
+        &self,
+        form_data: Vec<(&str, &str)>,
+    ) -> Result<serde_json::Value, ProviderError> {
+        let req = self
+            .reqwest_client()
+            .post("https://discord.com/api/oauth2/token")
+            .header("Content-Type", "application/x-www-form-urlencoded")
+            .form(&form_data);
+
+        let raw_json = execute_request(ConnectionProvider::Discord, req)
+            .await
+            .map_err(|e| self.handle_provider_request_error(e))?;
+
+        Ok(raw_json)
+    }
+
+    fn parse_token_response(
+        &self,
+        raw_json: &serde_json::Value,
+    ) -> Result<(String, Option<u64>, Option<String>), ProviderError> {
+        let access_token = raw_json["access_token"]
+            .as_str()
+            .ok_or_else(|| anyhow!("Missing `access_token` in response from Discord"))?
+            .to_string();
+
+        let expires_in = raw_json["expires_in"].as_u64();
+        let refresh_token = raw_json["refresh_token"].as_str().map(|s| s.to_string());
+
+        Ok((access_token, expires_in, refresh_token))
+    }
+
+    fn calculate_expiry(&self, expires_in: Option<u64>) -> Option<u64> {
+        expires_in.map(|expires| utils::now() + (expires - PROVIDER_TIMEOUT_SECONDS) * 1000)
+    }
+}
+
+#[async_trait]
+impl Provider for DiscordConnectionProvider {
+    fn id(&self) -> ConnectionProvider {
+        ConnectionProvider::Discord
+    }
+
+    async fn finalize(
+        &self,
+        connection: &Connection,
+        _related_credentials: Option<Credential>,
+        code: &str,
+        redirect_uri: &str,
+    ) -> Result<FinalizeResult, ProviderError> {
+        let _use_case = match connection.metadata()["use_case"].as_str() {
+            Some(use_case) => match use_case {
+                "bot" => DiscordUseCase::Bot,
+                _ => Err(anyhow!("Discord use_case format invalid"))?,
+            },
+            None => Err(anyhow!("Discord use_case missing"))?,
+        };
+
+        let form_data = vec![
+            ("client_id", OAUTH_DISCORD_CLIENT_ID.as_str()),
+            ("client_secret", OAUTH_DISCORD_CLIENT_SECRET.as_str()),
+            ("grant_type", "authorization_code"),
+            ("code", code),
+            ("redirect_uri", redirect_uri),
+            ("scope", "bot"),
+        ];
+
+        let raw_json = self.exchange_token(form_data).await?;
+        let (access_token, expires_in, refresh_token) = self.parse_token_response(&raw_json)?;
+
+        let extra_metadata = match raw_json.get("guild").and_then(|g| g.get("id")) {
+            Some(guild_id_value) => {
+                if let Some(guild_id) = guild_id_value.as_str() {
+                    Some(serde_json::Map::from_iter([(
+                        "guild_id".to_string(),
+                        serde_json::Value::String(guild_id.to_string()),
+                    )]))
+                } else {
+                    None
+                }
+            }
+            None => None,
+        };
+
+        Ok(FinalizeResult {
+            redirect_uri: redirect_uri.to_string(),
+            code: code.to_string(),
+            access_token,
+            access_token_expiry: self.calculate_expiry(expires_in),
+            refresh_token,
+            extra_metadata,
+            raw_json,
+        })
+    }
+
+    async fn refresh(
+        &self,
+        connection: &Connection,
+        _related_credentials: Option<Credential>,
+    ) -> Result<RefreshResult, ProviderError> {
+        // Discord tokens can be refreshed if we have a refresh token
+        let refresh_token = connection
+            .unseal_refresh_token()?
+            .ok_or_else(|| anyhow!("No refresh token available"))?;
+
+        let form_data = vec![
+            ("client_id", OAUTH_DISCORD_CLIENT_ID.as_str()),
+            ("client_secret", OAUTH_DISCORD_CLIENT_SECRET.as_str()),
+            ("grant_type", "refresh_token"),
+            ("refresh_token", &refresh_token),
+            ("scope", "bot"),
+        ];
+
+        let raw_json = self.exchange_token(form_data).await?;
+        let (access_token, expires_in, refresh_token) = self.parse_token_response(&raw_json)?;
+
+        Ok(RefreshResult {
+            access_token,
+            access_token_expiry: self.calculate_expiry(expires_in),
+            refresh_token,
+            raw_json,
+        })
+    }
+
+    fn scrubbed_raw_json(&self, raw_json: &serde_json::Value) -> Result<serde_json::Value> {
+        let mut scrubbed = raw_json.clone();
+        if let Some(obj) = scrubbed.as_object_mut() {
+            obj.remove("access_token");
+            obj.remove("refresh_token");
+        }
+        Ok(scrubbed)
+    }
+}


### PR DESCRIPTION
## Description

* Adding discord oauth logic.
* This is part of the larger initiative to add a Discord bot responder similar to Slack. I will share a document for the team to review before adding the connector logic. 
* Broke this up into multiple PRs just to avoid PR bloat

## Tests

Used to connect successfully:

<img width="687" height="85" alt="Screenshot 2025-09-29 at 11 25 01 AM" src="https://github.com/user-attachments/assets/d1ab6e38-895c-44b6-b991-143ea3927cdb" />


## Risk

* Should not be touched by any service yet

## Deploy Plan

1. Add core OAUTH_DISCORD_CLIENT_SECRET and OAUTH_DISCORD_CLIENT_ID environment variables
2. Deploy core