### PR TITLE
Add: content type to file uploaded contentfragment

### DIFF
--- a/front/components/assistant/conversation/input_bar/InputBar.tsx
+++ b/front/components/assistant/conversation/input_bar/InputBar.tsx
@@ -218,6 +218,7 @@ export function AssistantInputBar({
             return {
               title: cf.filename,
               fileId: cf.fileId,
+              contentType: cf.contentType,
             };
           }),
           contentNodes: attachedNodes,
@@ -239,6 +240,7 @@ export function AssistantInputBar({
           return {
             title: cf.filename,
             fileId: cf.fileId,
+            contentType: cf.contentType,
           };
         }),
         contentNodes: attachedNodes,

--- a/front/types/content_fragment.ts
+++ b/front/types/content_fragment.ts
@@ -78,6 +78,7 @@ export type ContentFragmentType =
 export type UploadedContentFragment = {
   fileId: string;
   title: string;
+  contentType: SupportedContentFragmentType;
 };
 
 export type ContentFragmentsType = {


### PR DESCRIPTION
## Description

Pass down the content type when uploading a file so we can immediately preview the content in the placeholder message.
Add the contentFragments when posting a message so we can update the message in the conversation without fetching all messages.

## Tests

Local

## Risk

Low

## Deploy Plan

Deploy front