### PR TITLE
Increase the attachement snippet size when it is copy-pasted text

### DIFF
--- a/front/lib/api/files/snippet.ts
+++ b/front/lib/api/files/snippet.ts
@@ -75,7 +75,7 @@ export async function generateSnippet(
     }
 
     if (isPastedFile(file.contentType)) {
-      // Include up to 64K (2^16) characters in pasted text snippet
+      // Include up to 2^16 characters in pasted text snippet
       if (content.length > 65536) {
         return new Ok(content.slice(0, 65536) + "... (truncated)");
       }

--- a/front/lib/api/files/snippet.ts
+++ b/front/lib/api/files/snippet.ts
@@ -1,6 +1,7 @@
 // eslint-disable-next-line dust/enforce-client-types-in-public-api
 import { isSupportedPlainTextContentType } from "@dust-tt/client";
 
+import { isPastedFile } from "@app/components/assistant/conversation/input_bar/pasted_utils";
 import { runAction } from "@app/lib/actions/server";
 import config from "@app/lib/api/config";
 import { getFileContent } from "@app/lib/api/files/utils";
@@ -21,8 +22,6 @@ import {
   Ok,
   removeNulls,
 } from "@app/types";
-
-import { isPastedFile } from "../../../components/assistant/conversation/input_bar/pasted_utils";
 
 const ENABLE_LLM_SNIPPETS = false;
 

--- a/front/lib/api/files/snippet.ts
+++ b/front/lib/api/files/snippet.ts
@@ -22,6 +22,8 @@ import {
   removeNulls,
 } from "@app/types";
 
+import { isPastedFile } from "../../../components/assistant/conversation/input_bar/pasted_utils";
+
 const ENABLE_LLM_SNIPPETS = false;
 
 export async function generateSnippet(
@@ -70,6 +72,14 @@ export async function generateSnippet(
     let content = await getFileContent(auth, file);
     if (!content) {
       return new Err(new Error("Failed to get file content"));
+    }
+
+    if (isPastedFile(file.contentType)) {
+      // Include up to 64K (2^16) characters in pasted text snippet
+      if (content.length > 65536) {
+        return new Ok(content.slice(0, 65536) + "... (truncated)");
+      }
+      return new Ok(content);
     }
 
     if (!ENABLE_LLM_SNIPPETS) {


### PR DESCRIPTION
## Description

Closes https://github.com/dust-tt/tasks/issues/4443

This increase the usability of the feature with LLMs which are not good at reading files with tools.

### Before

<img width="800" height="440" alt="image" src="https://github.com/user-attachments/assets/52b856d9-e6b1-4a48-a596-dae4f6409d23" />

### After

<img width="800" height="680" alt="image" src="https://github.com/user-attachments/assets/93de5aab-d1ce-45bf-ae65-a7446e0c3058" />

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

deploy front
