### PR TITLE
[PQ] User facing MCP servers

### DIFF
--- a/front/components/agent_builder/capabilities/mcp/MCPServerViewsSheet.tsx
+++ b/front/components/agent_builder/capabilities/mcp/MCPServerViewsSheet.tsx
@@ -75,6 +75,7 @@ import {
   DEFAULT_DATA_VISUALIZATION_NAME,
 } from "@app/lib/actions/constants";
 import { getAvatar } from "@app/lib/actions/mcp_icons";
+import { AGENT_MEMORY_SERVER_NAME } from "@app/lib/actions/mcp_internal_actions/constants";
 import { getMCPServerToolsConfigurations } from "@app/lib/actions/mcp_internal_actions/input_configuration";
 import type { MCPServerViewType } from "@app/lib/api/mcp";
 import { useModels } from "@app/lib/swr/models";
@@ -83,7 +84,7 @@ import { DEFAULT_REASONING_MODEL_ID } from "@app/types";
 const TOP_MCP_SERVER_VIEWS = [
   "web_search_&_browse",
   "image_generation",
-  "agent_memory",
+  AGENT_MEMORY_SERVER_NAME,
   "deep_research",
   "content_creation",
   "slack",

--- a/front/components/assistant/ToolsPicker.tsx
+++ b/front/components/assistant/ToolsPicker.tsx
@@ -18,6 +18,10 @@ import {
   mcpServerViewSortingFn,
 } from "@app/lib/actions/mcp_helper";
 import { getAvatar } from "@app/lib/actions/mcp_icons";
+import {
+  AGENT_MEMORY_SERVER_NAME,
+  isInternalMCPServerOfName,
+} from "@app/lib/actions/mcp_internal_actions/constants";
 import { getMCPServerToolsConfigurations } from "@app/lib/actions/mcp_internal_actions/input_configuration";
 import type { MCPServerViewType } from "@app/lib/api/mcp";
 import {
@@ -96,6 +100,7 @@ export function ToolsPicker({
       ...manualServerViews,
     ].filter(
       (v) =>
+        !isInternalMCPServerOfName(v.server.sId, AGENT_MEMORY_SERVER_NAME) &&
         // Only tools that do not require any configuration can be enabled directly in a conversation.
         getMCPServerToolsConfigurations(v).configurable !== "required" &&
         (searchText.length === 0 ||

--- a/front/components/assistant/ToolsPicker.tsx
+++ b/front/components/assistant/ToolsPicker.tsx
@@ -18,11 +18,7 @@ import {
   mcpServerViewSortingFn,
 } from "@app/lib/actions/mcp_helper";
 import { getAvatar } from "@app/lib/actions/mcp_icons";
-import {
-  AGENT_MEMORY_SERVER_NAME,
-  isInternalMCPServerOfName,
-} from "@app/lib/actions/mcp_internal_actions/constants";
-import { getMCPServerToolsConfigurations } from "@app/lib/actions/mcp_internal_actions/input_configuration";
+import { isJITMCPServerView } from "@app/lib/actions/mcp_internal_actions/utils";
 import type { MCPServerViewType } from "@app/lib/api/mcp";
 import {
   useInternalMCPServerViewsFromSpaces,
@@ -100,9 +96,7 @@ export function ToolsPicker({
       ...manualServerViews,
     ].filter(
       (v) =>
-        !isInternalMCPServerOfName(v.server.sId, AGENT_MEMORY_SERVER_NAME) &&
-        // Only tools that do not require any configuration can be enabled directly in a conversation.
-        getMCPServerToolsConfigurations(v).configurable !== "required" &&
+        isJITMCPServerView(v) &&
         (searchText.length === 0 ||
           getMcpServerViewDisplayName(v)
             .toLowerCase()

--- a/front/lib/actions/mcp_internal_actions/constants.ts
+++ b/front/lib/actions/mcp_internal_actions/constants.ts
@@ -143,7 +143,7 @@ export const INTERNAL_MCP_SERVERS = {
     serverInfo: {
       name: "github",
       version: "1.0.0",
-      description: "GitHub tools to manage issues and pull requests.",
+      description: "Manage issues and pull requests.",
       authorization: {
         provider: "github" as const,
         supported_use_cases: ["platform_actions", "personal_actions"] as const,
@@ -165,7 +165,8 @@ export const INTERNAL_MCP_SERVERS = {
     serverInfo: {
       name: "image_generation",
       version: "1.0.0",
-      description: "Agent can generate images (GPT Image 1).",
+      description:
+        "Create visual content from text descriptions.",
       icon: "ActionImageIcon",
       authorization: null,
       documentationUrl: null,
@@ -184,7 +185,7 @@ export const INTERNAL_MCP_SERVERS = {
     serverInfo: {
       name: "file_generation",
       version: "1.0.0",
-      description: "Agent can generate and convert files.",
+      description: "Generate and convert documents.",
       authorization: null,
       icon: "ActionDocumentTextIcon",
       documentationUrl: null,
@@ -282,10 +283,7 @@ export const INTERNAL_MCP_SERVERS = {
     serverInfo: {
       name: "hubspot",
       version: "1.0.0",
-      description:
-        "Comprehensive HubSpot CRM integration supporting all object types (contacts, companies, deals) and ALL engagement types (tasks, notes, meetings, calls, emails). " +
-        "Features advanced user activity tracking, owner search and listing, association management, and enhanced search capabilities with owner filtering. " +
-        "Perfect for CRM data management and user activity analysis.",
+      description: "Access CRM contacts, deals and customer activities.",
       authorization: {
         provider: "hubspot" as const,
         supported_use_cases: ["platform_actions", "personal_actions"] as const,
@@ -348,7 +346,7 @@ The directive should be used to display a clickable version of the agent name in
     serverInfo: {
       name: "run_dust_app",
       version: "1.0.0",
-      description: "Run Dust Apps with specified parameters",
+      description: "Run Dust Apps with specified parameters.",
       icon: "CommandLineIcon",
       authorization: null,
       documentationUrl: null,
@@ -388,7 +386,7 @@ The directive should be used to display a clickable version of the agent name in
     serverInfo: {
       name: "notion",
       version: "1.0.0",
-      description: "Notion tools to manage pages and databases.",
+      description: "Access workspace pages and databases.",
       authorization: {
         provider: "notion" as const,
         supported_use_cases: ["platform_actions", "personal_actions"] as const,
@@ -484,7 +482,7 @@ The directive should be used to display a clickable version of the agent name in
     serverInfo: {
       name: "gmail",
       version: "1.0.0",
-      description: "Gmail tools for reading emails and managing email drafts.",
+      description: "Access messages and email drafts.",
       authorization: {
         provider: "google_drive" as const,
         supported_use_cases: ["personal_actions"] as const,
@@ -516,7 +514,7 @@ The directive should be used to display a clickable version of the agent name in
     serverInfo: {
       name: "google_calendar",
       version: "1.0.0",
-      description: "Tools for managing Google calendars and events.",
+      description: "Access calendar schedules and appointments.",
       authorization: {
         provider: "google_drive",
         supported_use_cases: ["personal_actions"] as const,
@@ -540,7 +538,7 @@ The directive should be used to display a clickable version of the agent name in
     serverInfo: {
       name: "conversation_files",
       version: "1.0.0",
-      description: "Include files from conversation attachments",
+      description: "Include files from conversation attachments.",
       icon: "ActionDocumentTextIcon",
       authorization: null,
       documentationUrl: null,
@@ -608,7 +606,7 @@ The directive should be used to display a clickable version of the agent name in
     serverInfo: {
       name: "google_sheets",
       version: "1.0.0",
-      description: "Tools for managing Google Sheets spreadsheets and data.",
+      description: "Work with spreadsheet data and tables.",
       authorization: {
         provider: "gmail",
         supported_use_cases: ["personal_actions"] as const,
@@ -663,8 +661,7 @@ The directive should be used to display a clickable version of the agent name in
     serverInfo: {
       name: "monday",
       version: "1.0.0",
-      description:
-        "Monday.com integration providing CRM-like operations for boards, items, and updates. Enables reading and managing Monday.com boards and items through the GraphQL API.",
+      description: "Manage project boards, items and updates.",
       authorization: {
         provider: "monday" as const,
         supported_use_cases: ["personal_actions", "platform_actions"] as const,
@@ -731,8 +728,7 @@ The directive should be used to display a clickable version of the agent name in
     serverInfo: {
       name: "jira",
       version: "1.0.0",
-      description:
-        "Comprehensive JIRA integration providing full issue management capabilities including create, read, update, comment, workflow transitions, and issue linking operations using the JIRA REST API.",
+      description: "Create, update and track project issues.",
       authorization: {
         provider: "jira" as const,
         supported_use_cases: ["platform_actions", "personal_actions"] as const,
@@ -785,8 +781,7 @@ The directive should be used to display a clickable version of the agent name in
     serverInfo: {
       name: "outlook",
       version: "1.0.0",
-      description:
-        "Outlook tools for reading emails, managing email drafts, and managing contacts.",
+      description: "Read emails, manage drafts and contacts.",
       authorization: {
         provider: "microsoft_tools" as const,
         supported_use_cases: ["personal_actions"] as const,
@@ -869,10 +864,7 @@ The directive should be used to display a clickable version of the agent name in
       name: "freshservice",
       icon: "FreshserviceLogo",
       version: "1.0.0",
-      description:
-        "Freshservice integration supporting ticket management, service catalog, solutions, departments, " +
-        "on-call schedules, and more. Provides comprehensive access to Freshservice resources with " +
-        "OAuth authentication and secure API access.",
+      description: "Connect to tickets, schedules and service catalog.",
       authorization: {
         provider: "freshservice" as const,
         supported_use_cases: ["platform_actions", "personal_actions"] as const,
@@ -897,8 +889,7 @@ The directive should be used to display a clickable version of the agent name in
     serverInfo: {
       name: "google_drive",
       version: "1.0.0",
-      description:
-        "Tools for searching and reading content from Google Drive files (Docs, Sheets, Presentations, text files).",
+      description: "Search and read files (Docs, Sheets, Presentations).",
       authorization: {
         provider: "google_drive" as const,
         supported_use_cases: ["personal_actions"] as const,
@@ -996,8 +987,7 @@ The directive should be used to display a clickable version of the agent name in
     serverInfo: {
       name: "slack_bot",
       version: "1.0.0",
-      description:
-        "Slack tools using workspace bot credentials. Messages and actions will appear as coming from the Dust Slack bot rather than your personal account.",
+      description: "Post messages and reactions as the workspace Dust bot.",
       authorization: {
         provider: "slack" as const,
         supported_use_cases: ["platform_actions"] as const,
@@ -1027,8 +1017,7 @@ The directive should be used to display a clickable version of the agent name in
     serverInfo: {
       name: "openai_usage",
       version: "1.0.0",
-      description:
-        "Direct access to OpenAI APIs for tracking API consumption and costs. Requires OpenAI Admin API key configured as a secret.",
+      description: "Track API consumption and costs.",
       authorization: null,
       icon: "OpenaiLogo",
       documentationUrl: null,
@@ -1053,8 +1042,7 @@ The directive should be used to display a clickable version of the agent name in
     serverInfo: {
       name: "confluence",
       version: "1.0.0",
-      description:
-        "Basic Confluence integration for retrieving page information using the Confluence REST API.",
+      description: "Retrieve page information.",
       authorization: {
         provider: "confluence_tools" as const,
         supported_use_cases: ["platform_actions", "personal_actions"] as const,
@@ -1222,12 +1210,7 @@ The directive should be used to display a clickable version of the agent name in
     serverInfo: {
       name: "data_sources_file_system",
       version: "1.0.0",
-      description:
-        "Comprehensive content navigation toolkit for browsing user data sources. Provides Unix-like " +
-        "browsing (ls, find) and smart search tools to help agents efficiently explore and discover " +
-        "content from manually uploaded files or data synced from SaaS products (Notion, Slack, Github" +
-        ", etc.) organized in a filesystem-like hierarchy. Each item in this tree-like hierarchy is " +
-        "called a node, nodes are referenced by a nodeId.",
+      description: "Browse and search content with filesystem-like navigation.",
       authorization: null,
       icon: "ActionDocumentTextIcon",
       documentationUrl: null,
@@ -1250,7 +1233,7 @@ The directive should be used to display a clickable version of the agent name in
     serverInfo: {
       name: "agent_management",
       version: "1.0.0",
-      description: "Tools for managing agent configurations",
+      description: "Tools for managing agent configurations.",
       authorization: null,
       icon: "ActionRobotIcon",
       documentationUrl: null,
@@ -1269,10 +1252,7 @@ The directive should be used to display a clickable version of the agent name in
     serverInfo: {
       name: DATA_WAREHOUSE_SERVER_NAME,
       version: "1.0.0",
-      description:
-        "Comprehensive tables navigation toolkit for browsing data warehouses and tables. Provides Unix-like " +
-        "browsing (ls, find) to help agents efficiently explore and discover tables organized in a " +
-        "warehouse-centric hierarchy. Each warehouse contains schemas/databases which contain tables.",
+      description: "Browse tables organized by warehouse and schema.",
       authorization: null,
       icon: "ActionTableIcon",
       documentationUrl: null,
@@ -1291,9 +1271,7 @@ The directive should be used to display a clickable version of the agent name in
     serverInfo: {
       name: "toolsets",
       version: "1.0.0",
-      description:
-        "Comprehensive navigation toolkit for browsing available toolsets. " +
-        "Toolsets provide functions for the agent to use.",
+      description: "Browse available toolsets and functions.",
       authorization: null,
       icon: "ActionLightbulbIcon",
       documentationUrl: null,

--- a/front/lib/actions/mcp_internal_actions/constants.ts
+++ b/front/lib/actions/mcp_internal_actions/constants.ts
@@ -55,6 +55,7 @@ export const SEARCH_SERVER_NAME = "search";
 
 export const TABLE_QUERY_V2_SERVER_NAME = "query_tables_v2"; // Do not change the name until we fixed the extension
 export const DATA_WAREHOUSE_SERVER_NAME = "data_warehouses";
+export const AGENT_MEMORY_SERVER_NAME = "agent_memory";
 
 // IDs of internal MCP servers that are no longer present.
 // We need to keep them to avoid breaking previous output that might reference sId that mapped to these servers.
@@ -66,7 +67,7 @@ export const AVAILABLE_INTERNAL_MCP_SERVER_NAMES = [
   // We'll prefix all tools with the server name to avoid conflicts.
   // It's okay to change the name of the server as we don't refer to it directly.
   "agent_management",
-  "agent_memory",
+  AGENT_MEMORY_SERVER_NAME,
   "agent_router",
   "confluence",
   "conversation_files",
@@ -165,8 +166,7 @@ export const INTERNAL_MCP_SERVERS = {
     serverInfo: {
       name: "image_generation",
       version: "1.0.0",
-      description:
-        "Create visual content from text descriptions.",
+      description: "Create visual content from text descriptions.",
       icon: "ActionImageIcon",
       authorization: null,
       documentationUrl: null,
@@ -672,7 +672,7 @@ The directive should be used to display a clickable version of the agent name in
       instructions: null,
     },
   },
-  agent_memory: {
+  [AGENT_MEMORY_SERVER_NAME]: {
     id: 21,
     availability: "auto",
     allowMultipleInstances: false,
@@ -682,7 +682,7 @@ The directive should be used to display a clickable version of the agent name in
     tools_retry_policies: undefined,
     timeoutMs: undefined,
     serverInfo: {
-      name: "agent_memory",
+      name: AGENT_MEMORY_SERVER_NAME,
       version: "1.0.0",
       description: "User-scoped long-term memory tools for agents.",
       authorization: null,

--- a/front/lib/actions/mcp_internal_actions/servers/agent_memory.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/agent_memory.ts
@@ -2,6 +2,7 @@ import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import assert from "assert";
 import { z } from "zod";
 
+import { AGENT_MEMORY_SERVER_NAME } from "@app/lib/actions/mcp_internal_actions/constants";
 import { makeInternalMCPServer } from "@app/lib/actions/mcp_internal_actions/utils";
 import type { AgentLoopContextType } from "@app/lib/actions/types";
 import type { Authenticator } from "@app/lib/auth";
@@ -11,7 +12,7 @@ const createServer = (
   auth: Authenticator,
   agentLoopContext?: AgentLoopContextType
 ): McpServer => {
-  const server = makeInternalMCPServer("agent_memory");
+  const server = makeInternalMCPServer(AGENT_MEMORY_SERVER_NAME);
 
   const isUserScopedMemory = true;
 

--- a/front/lib/actions/mcp_internal_actions/servers/index.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/index.ts
@@ -1,7 +1,10 @@
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 
 import type { InternalMCPServerNameType } from "@app/lib/actions/mcp_internal_actions/constants";
-import { ADVANCED_SEARCH_SWITCH } from "@app/lib/actions/mcp_internal_actions/constants";
+import {
+  ADVANCED_SEARCH_SWITCH,
+  AGENT_MEMORY_SERVER_NAME,
+} from "@app/lib/actions/mcp_internal_actions/constants";
 import { default as agentManagementServer } from "@app/lib/actions/mcp_internal_actions/servers/agent_management";
 import { default as agentMemoryServer } from "@app/lib/actions/mcp_internal_actions/servers/agent_memory";
 import { default as agentRouterServer } from "@app/lib/actions/mcp_internal_actions/servers/agent_router";
@@ -160,7 +163,7 @@ export async function getInternalMCPServer(
       return slackServer(auth, mcpServerId, agentLoopContext);
     case "slack_bot":
       return slackBotServer(auth, mcpServerId, agentLoopContext);
-    case "agent_memory":
+    case AGENT_MEMORY_SERVER_NAME:
       return agentMemoryServer(auth, agentLoopContext);
     case "confluence":
       return confluenceServer();

--- a/front/lib/actions/mcp_internal_actions/utils.ts
+++ b/front/lib/actions/mcp_internal_actions/utils.ts
@@ -11,11 +11,17 @@ import type {
 } from "@modelcontextprotocol/sdk/types.js";
 
 import type { InternalMCPServerNameType } from "@app/lib/actions/mcp_internal_actions/constants";
-import { INTERNAL_MCP_SERVERS } from "@app/lib/actions/mcp_internal_actions/constants";
+import {
+  AGENT_MEMORY_SERVER_NAME,
+  INTERNAL_MCP_SERVERS,
+  isInternalMCPServerOfName,
+} from "@app/lib/actions/mcp_internal_actions/constants";
 import type {
   ToolEarlyExitEvent,
   ToolPersonalAuthRequiredEvent,
 } from "@app/lib/actions/mcp_internal_actions/events";
+import { getMCPServerToolsConfigurations } from "@app/lib/actions/mcp_internal_actions/input_configuration";
+import type { MCPServerViewType } from "@app/lib/api/mcp";
 import type { AgentMCPActionOutputItem } from "@app/lib/models/assistant/actions/mcp";
 import type { AgentMCPActionResource } from "@app/lib/resources/agent_mcp_action_resource";
 import type {
@@ -226,4 +232,12 @@ export async function getExitOrPauseEvents({
   }
 
   return [];
+}
+
+export function isJITMCPServerView(view: MCPServerViewType): boolean {
+  return (
+    !isInternalMCPServerOfName(view.server.sId, AGENT_MEMORY_SERVER_NAME) &&
+    // Only tools that do not require any configuration can be enabled directly in a conversation.
+    getMCPServerToolsConfigurations(view).configurable !== "required"
+  );
 }

--- a/front/lib/actions/types/guards.ts
+++ b/front/lib/actions/types/guards.ts
@@ -8,7 +8,10 @@ import type {
   ServerSideMCPServerConfigurationType,
   ServerSideMCPToolConfigurationType,
 } from "@app/lib/actions/mcp";
-import { isInternalMCPServerOfName } from "@app/lib/actions/mcp_internal_actions/constants";
+import {
+  AGENT_MEMORY_SERVER_NAME,
+  isInternalMCPServerOfName,
+} from "@app/lib/actions/mcp_internal_actions/constants";
 import type { UnsavedMCPServerConfigurationType } from "@app/lib/actions/types/agent";
 import type {
   AgentConfigurationType,
@@ -111,7 +114,7 @@ export function isMCPConfigurationForAgentMemory(
 ): arg is ServerSideMCPServerConfigurationType {
   return (
     isServerSideMCPServerConfiguration(arg) &&
-    isInternalMCPServerOfName(arg.internalMCPServerId, "agent_memory")
+    isInternalMCPServerOfName(arg.internalMCPServerId, AGENT_MEMORY_SERVER_NAME)
   );
 }
 

--- a/front/lib/actions/utils.ts
+++ b/front/lib/actions/utils.ts
@@ -8,6 +8,7 @@ import {
 
 import type { ActionSpecification } from "@app/components/assistant_builder/types";
 import type { MCPToolStakeLevelType } from "@app/lib/actions/constants";
+import { DEFAULT_DATA_VISUALIZATION_DESCRIPTION } from "@app/lib/actions/constants";
 import type { MCPToolConfigurationType } from "@app/lib/actions/mcp";
 import type { StepContext } from "@app/lib/actions/types";
 import {
@@ -40,7 +41,7 @@ export const MCP_SPECIFICATION: ActionSpecification = {
 
 export const DATA_VISUALIZATION_SPECIFICATION: ActionSpecification = {
   label: "Data Visualization",
-  description: "Generate a data visualization",
+  description: DEFAULT_DATA_VISUALIZATION_DESCRIPTION,
   cardIcon: BarChartIcon,
   dropDownIcon: BarChartIcon,
   flag: null,

--- a/front/lib/resources/agent_memory_resource.ts
+++ b/front/lib/resources/agent_memory_resource.ts
@@ -5,6 +5,7 @@ import type {
   Transaction,
 } from "sequelize";
 
+import { AGENT_MEMORY_SERVER_NAME } from "@app/lib/actions/mcp_internal_actions/constants";
 import type { Authenticator } from "@app/lib/auth";
 import { BaseResource } from "@app/lib/resources/base_resource";
 import { AgentMemoryModel } from "@app/lib/resources/storage/models/agent_memories";
@@ -326,7 +327,7 @@ export class AgentMemoryResource extends BaseResource<AgentMemoryModel> {
     id: ModelId;
     workspaceId: ModelId;
   }): string {
-    return makeSId("agent_memory", {
+    return makeSId(AGENT_MEMORY_SERVER_NAME, {
       id,
       workspaceId,
     });


### PR DESCRIPTION
## Description

https://github.com/dust-tt/tasks/issues/4428

- Remove display of agent_memory mcp server as a JIT tool in conversation
- Update mcp servers' user facing descriptions (those are not sent to LLMs)

<img width="753" height="924" alt="image" src="https://github.com/user-attachments/assets/ecb9a1b4-d421-4286-ac20-a493debfce06" />

## Tests

-

## Risk

low

## Deploy Plan

front
