### PR TITLE
[front] - chore(AB): remove margin-left class from header

### DIFF
--- a/front/components/agent_builder/AgentBuilderRightPanel.tsx
+++ b/front/components/agent_builder/AgentBuilderRightPanel.tsx
@@ -48,7 +48,6 @@ function PanelHeader({
                   variant="ghost-secondary"
                   tooltip="Hide preview"
                   onClick={onTogglePanel}
-                  className="ml-4"
                 />
                 <TabsTrigger
                   value="testing"


### PR DESCRIPTION
## Description

This PR removes the left padding from the right panel header in the agent builder.

## Tests

Locally

## Risk

Low

## Deploy Plan

Deploy front