### PR TITLE
[fix] Batch Edit of Agents Manager makes uneditable ones unclickable

### DIFF
--- a/extension/package-lock.json
+++ b/extension/package-lock.json
@@ -12,7 +12,7 @@
         "@auth0/auth0-spa-js": "^2.1.3",
         "@datadog/browser-logs": "^6.13.0",
         "@dust-tt/client": "^1.1.15",
-        "@dust-tt/sparkle": "^0.2.642",
+        "@dust-tt/sparkle": "^0.2.644",
         "@frontapp/plugin-sdk": "^1.8.1",
         "@modelcontextprotocol/sdk": "^1.9.0",
         "@tailwindcss/forms": "^0.5.9",

--- a/extension/package.json
+++ b/extension/package.json
@@ -59,7 +59,7 @@
     "@auth0/auth0-spa-js": "^2.1.3",
     "@datadog/browser-logs": "^6.13.0",
     "@dust-tt/client": "^1.1.15",
-    "@dust-tt/sparkle": "^0.2.642",
+    "@dust-tt/sparkle": "^0.2.644",
     "@frontapp/plugin-sdk": "^1.8.1",
     "@modelcontextprotocol/sdk": "^1.9.0",
     "@tailwindcss/forms": "^0.5.9",

--- a/front/components/assistant/manager/AssistantsTable.tsx
+++ b/front/components/assistant/manager/AssistantsTable.tsx
@@ -58,13 +58,8 @@ type RowData = {
   canArchive: boolean;
 };
 
-function getDisabledClass(
-  canArchive: boolean,
-  isBatchEdit: boolean
-): string | undefined {
-  return !canArchive && isBatchEdit
-    ? "s-cursor-not-allowed s-opacity-50"
-    : undefined;
+function isDisabled(canArchive: boolean, isBatchEdit: boolean): boolean {
+  return !canArchive && isBatchEdit;
 }
 
 const getTableColumns = ({
@@ -99,11 +94,7 @@ const getTableColumns = ({
             accessorKey: "select",
             cell: (info: CellContext<RowData, boolean>) => (
               <DataTable.CellContent
-                className={
-                  !info.row.original.canArchive && isBatchEdit
-                    ? "s-cursor-not-allowed s-opacity-50"
-                    : undefined
-                }
+                disabled={isDisabled(info.row.original.canArchive, isBatchEdit)}
               >
                 <Checkbox
                   checked={info.row.original.isSelected}
@@ -124,10 +115,7 @@ const getTableColumns = ({
       accessorKey: "name",
       cell: (info: CellContext<RowData, string>) => (
         <DataTable.CellContent
-          className={getDisabledClass(
-            info.row.original.canArchive,
-            isBatchEdit
-          )}
+          disabled={isDisabled(info.row.original.canArchive, isBatchEdit)}
         >
           <div className={classNames("flex flex-row items-center gap-2 py-3")}>
             <div>
@@ -153,10 +141,7 @@ const getTableColumns = ({
       accessorKey: "scope",
       cell: (info: CellContext<RowData, AgentConfigurationScope>) => (
         <DataTable.CellContent
-          className={getDisabledClass(
-            info.row.original.canArchive,
-            isBatchEdit
-          )}
+          disabled={isDisabled(info.row.original.canArchive, isBatchEdit)}
         >
           {info.getValue() !== "hidden" && (
             <Chip
@@ -181,10 +166,7 @@ const getTableColumns = ({
         if (!editors) {
           return (
             <DataTable.BasicCellContent
-              className={getDisabledClass(
-                info.row.original.canArchive,
-                isBatchEdit
-              )}
+              disabled={isDisabled(info.row.original.canArchive, isBatchEdit)}
               label="-"
             />
           );
@@ -192,10 +174,7 @@ const getTableColumns = ({
 
         return (
           <DataTable.CellContent
-            className={getDisabledClass(
-              info.row.original.canArchive,
-              isBatchEdit
-            )}
+            disabled={isDisabled(info.row.original.canArchive, isBatchEdit)}
           >
             <Avatar.Stack
               avatars={editors.map((editor) => ({
@@ -219,10 +198,8 @@ const getTableColumns = ({
       cell: (info: CellContext<RowData, string>) => (
         <DataTable.CellContent
           grow
-          className={classNames(
-            "flex flex-row items-center",
-            getDisabledClass(info.row.original.canArchive, isBatchEdit) ?? null
-          )}
+          className={classNames("flex flex-row items-center")}
+          disabled={isDisabled(info.row.original.canArchive, isBatchEdit)}
         >
           <div className="group flex flex-row items-center gap-1">
             <div className="truncate text-muted-foreground dark:text-muted-foreground-night">
@@ -253,10 +230,8 @@ const getTableColumns = ({
       accessorFn: (row: RowData) => row.usage?.messageCount ?? 0,
       cell: (info: CellContext<RowData, AgentUsageType | undefined>) => (
         <DataTable.BasicCellContent
-          className={classNames(
-            "font-semibold",
-            getDisabledClass(info.row.original.canArchive, isBatchEdit) ?? null
-          )}
+          className={classNames("font-semibold")}
+          disabled={isDisabled(info.row.original.canArchive, isBatchEdit)}
           tooltip={assistantUsageMessage({
             assistantName: info.row.original.name,
             // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
@@ -287,11 +262,8 @@ const getTableColumns = ({
           const feedbacksCount = `${f.up + f.down} feedback${pluralize(f.up + f.down)} over the last 30 days`;
           return (
             <DataTable.BasicCellContent
-              className={classNames(
-                "font-semibold",
-                getDisabledClass(info.row.original.canArchive, isBatchEdit) ??
-                  null
-              )}
+              className={classNames("font-semibold")}
+              disabled={isDisabled(info.row.original.canArchive, isBatchEdit)}
               tooltip={feedbacksCount}
               label={`${f.up + f.down}`}
             />
@@ -308,10 +280,7 @@ const getTableColumns = ({
       accessorKey: "lastUpdate",
       cell: (info: CellContext<RowData, number>) => (
         <DataTable.BasicCellContent
-          className={getDisabledClass(
-            info.row.original.canArchive,
-            isBatchEdit
-          )}
+          disabled={isDisabled(info.row.original.canArchive, isBatchEdit)}
           tooltip={formatTimestampToFriendlyDate(info.getValue(), "long")}
           label={
             info.getValue()
@@ -329,10 +298,7 @@ const getTableColumns = ({
         if (info.row.original.scope === "global") {
           return (
             <DataTable.CellContent
-              className={getDisabledClass(
-                info.row.original.canArchive,
-                isBatchEdit
-              )}
+              disabled={isDisabled(info.row.original.canArchive, isBatchEdit)}
             >
               {info.row.original.action}
             </DataTable.CellContent>
@@ -341,10 +307,7 @@ const getTableColumns = ({
         return (
           <DataTable.MoreButton
             menuItems={info.row.original.menuItems}
-            className={getDisabledClass(
-              info.row.original.canArchive,
-              isBatchEdit
-            )}
+            disabled={isDisabled(info.row.original.canArchive, isBatchEdit)}
           />
         );
       },

--- a/front/components/assistant/manager/AssistantsTable.tsx
+++ b/front/components/assistant/manager/AssistantsTable.tsx
@@ -58,7 +58,7 @@ type RowData = {
   canArchive: boolean;
 };
 
-// We disable the global agents in batch mode edit since they cannot be archived.
+// Global agents (canArchive: false) cannot be edited, so we disable them in batch edit.
 function isDisabled(canArchive: boolean, isBatchEdit: boolean): boolean {
   return !canArchive && isBatchEdit;
 }

--- a/front/components/assistant/manager/AssistantsTable.tsx
+++ b/front/components/assistant/manager/AssistantsTable.tsx
@@ -92,7 +92,7 @@ const getTableColumns = ({
               <DataTable.CellContent
                 className={
                   !info.row.original.canArchive && isBatchEdit
-                    ? "opacity-50 cursor-not-allowed"
+                    ? "cursor-not-allowed opacity-50"
                     : undefined
                 }
               >
@@ -117,7 +117,7 @@ const getTableColumns = ({
         <DataTable.CellContent
           className={
             !info.row.original.canArchive && isBatchEdit
-              ? "opacity-50 cursor-not-allowed"
+              ? "cursor-not-allowed opacity-50"
               : undefined
           }
         >
@@ -147,7 +147,7 @@ const getTableColumns = ({
         <DataTable.CellContent
           className={
             !info.row.original.canArchive && isBatchEdit
-              ? "opacity-50 cursor-not-allowed"
+              ? "cursor-not-allowed opacity-50"
               : undefined
           }
         >
@@ -176,7 +176,7 @@ const getTableColumns = ({
             <DataTable.BasicCellContent
               className={
                 !info.row.original.canArchive && isBatchEdit
-                  ? "opacity-50 cursor-not-allowed"
+                  ? "cursor-not-allowed opacity-50"
                   : undefined
               }
               label="-"
@@ -188,7 +188,7 @@ const getTableColumns = ({
           <DataTable.CellContent
             className={
               !info.row.original.canArchive && isBatchEdit
-                ? "opacity-50 cursor-not-allowed"
+                ? "cursor-not-allowed opacity-50"
                 : undefined
             }
           >
@@ -217,7 +217,7 @@ const getTableColumns = ({
           className={classNames(
             "flex flex-row items-center",
             !info.row.original.canArchive && isBatchEdit
-              ? "opacity-50 cursor-not-allowed"
+              ? "cursor-not-allowed opacity-50"
               : null
           )}
         >
@@ -253,7 +253,7 @@ const getTableColumns = ({
           className={classNames(
             "font-semibold",
             !info.row.original.canArchive && isBatchEdit
-              ? "opacity-50 cursor-not-allowed"
+              ? "cursor-not-allowed opacity-50"
               : null
           )}
           tooltip={assistantUsageMessage({
@@ -289,7 +289,7 @@ const getTableColumns = ({
               className={classNames(
                 "font-semibold",
                 !info.row.original.canArchive && isBatchEdit
-                  ? "opacity-50 cursor-not-allowed"
+                  ? "cursor-not-allowed opacity-50"
                   : null
               )}
               tooltip={feedbacksCount}
@@ -310,7 +310,7 @@ const getTableColumns = ({
         <DataTable.BasicCellContent
           className={
             !info.row.original.canArchive && isBatchEdit
-              ? "opacity-50 cursor-not-allowed"
+              ? "cursor-not-allowed opacity-50"
               : undefined
           }
           tooltip={formatTimestampToFriendlyDate(info.getValue(), "long")}
@@ -332,7 +332,7 @@ const getTableColumns = ({
             <DataTable.CellContent
               className={
                 !info.row.original.canArchive && isBatchEdit
-                  ? "opacity-50 cursor-not-allowed"
+                  ? "cursor-not-allowed opacity-50"
                   : undefined
               }
             >

--- a/front/components/assistant/manager/AssistantsTable.tsx
+++ b/front/components/assistant/manager/AssistantsTable.tsx
@@ -58,6 +58,11 @@ type RowData = {
   canArchive: boolean;
 };
 
+// We disable the global agents in batch mode edit since they cannot be archived.
+function isDisabled(canArchive: boolean, isBatchEdit: boolean): boolean {
+  return !canArchive && isBatchEdit;
+}
+
 const getTableColumns = ({
   owner,
   tags,
@@ -89,7 +94,9 @@ const getTableColumns = ({
             header: "",
             accessorKey: "select",
             cell: (info: CellContext<RowData, boolean>) => (
-              <DataTable.CellContent>
+              <DataTable.CellContent
+                disabled={isDisabled(info.row.original.canArchive, isBatchEdit)}
+              >
                 <Checkbox
                   checked={info.row.original.isSelected}
                   disabled={!info.row.original.canArchive}
@@ -108,7 +115,9 @@ const getTableColumns = ({
       header: "Name",
       accessorKey: "name",
       cell: (info: CellContext<RowData, string>) => (
-        <DataTable.CellContent>
+        <DataTable.CellContent
+          disabled={isDisabled(info.row.original.canArchive, isBatchEdit)}
+        >
           <div className={classNames("flex flex-row items-center gap-2 py-3")}>
             <div>
               <Avatar visual={info.row.original.pictureUrl} size="sm" />
@@ -132,7 +141,9 @@ const getTableColumns = ({
       header: "Access",
       accessorKey: "scope",
       cell: (info: CellContext<RowData, AgentConfigurationScope>) => (
-        <DataTable.CellContent>
+        <DataTable.CellContent
+          disabled={isDisabled(info.row.original.canArchive, isBatchEdit)}
+        >
           {info.getValue() !== "hidden" && (
             <Chip
               size="xs"
@@ -154,11 +165,18 @@ const getTableColumns = ({
         const { editors } = info.row.original;
 
         if (!editors) {
-          return <DataTable.BasicCellContent label="-" />;
+          return (
+            <DataTable.BasicCellContent
+              disabled={isDisabled(info.row.original.canArchive, isBatchEdit)}
+              label="-"
+            />
+          );
         }
 
         return (
-          <DataTable.CellContent>
+          <DataTable.CellContent
+            disabled={isDisabled(info.row.original.canArchive, isBatchEdit)}
+          >
             <Avatar.Stack
               avatars={editors.map((editor) => ({
                 name: editor.fullName,
@@ -179,7 +197,11 @@ const getTableColumns = ({
       header: "Tags",
       accessorKey: "agentTagsAsString",
       cell: (info: CellContext<RowData, string>) => (
-        <DataTable.CellContent grow className="flex flex-row items-center">
+        <DataTable.CellContent
+          grow
+          className={classNames("flex flex-row items-center")}
+          disabled={isDisabled(info.row.original.canArchive, isBatchEdit)}
+        >
           <div className="group flex flex-row items-center gap-1">
             <div className="truncate text-muted-foreground dark:text-muted-foreground-night">
               <Tooltip
@@ -209,7 +231,8 @@ const getTableColumns = ({
       accessorFn: (row: RowData) => row.usage?.messageCount ?? 0,
       cell: (info: CellContext<RowData, AgentUsageType | undefined>) => (
         <DataTable.BasicCellContent
-          className="font-semibold"
+          className={classNames("font-semibold")}
+          disabled={isDisabled(info.row.original.canArchive, isBatchEdit)}
           tooltip={assistantUsageMessage({
             assistantName: info.row.original.name,
             // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
@@ -240,7 +263,8 @@ const getTableColumns = ({
           const feedbacksCount = `${f.up + f.down} feedback${pluralize(f.up + f.down)} over the last 30 days`;
           return (
             <DataTable.BasicCellContent
-              className="font-semibold"
+              className={classNames("font-semibold")}
+              disabled={isDisabled(info.row.original.canArchive, isBatchEdit)}
               tooltip={feedbacksCount}
               label={`${f.up + f.down}`}
             />
@@ -257,6 +281,7 @@ const getTableColumns = ({
       accessorKey: "lastUpdate",
       cell: (info: CellContext<RowData, number>) => (
         <DataTable.BasicCellContent
+          disabled={isDisabled(info.row.original.canArchive, isBatchEdit)}
           tooltip={formatTimestampToFriendlyDate(info.getValue(), "long")}
           label={
             info.getValue()
@@ -273,12 +298,19 @@ const getTableColumns = ({
       cell: (info: CellContext<RowData, number>) => {
         if (info.row.original.scope === "global") {
           return (
-            <DataTable.CellContent>
+            <DataTable.CellContent
+              disabled={isDisabled(info.row.original.canArchive, isBatchEdit)}
+            >
               {info.row.original.action}
             </DataTable.CellContent>
           );
         }
-        return <DataTable.MoreButton menuItems={info.row.original.menuItems} />;
+        return (
+          <DataTable.MoreButton
+            menuItems={info.row.original.menuItems}
+            disabled={isDisabled(info.row.original.canArchive, isBatchEdit)}
+          />
+        );
       },
       meta: {
         className: "w-14",

--- a/front/components/assistant/manager/AssistantsTable.tsx
+++ b/front/components/assistant/manager/AssistantsTable.tsx
@@ -63,7 +63,7 @@ function getDisabledClass(
   isBatchEdit: boolean
 ): string | undefined {
   return !canArchive && isBatchEdit
-    ? "cursor-not-allowed opacity-50"
+    ? "s-cursor-not-allowed s-opacity-50"
     : undefined;
 }
 
@@ -101,7 +101,7 @@ const getTableColumns = ({
               <DataTable.CellContent
                 className={
                   !info.row.original.canArchive && isBatchEdit
-                    ? "cursor-not-allowed opacity-50"
+                    ? "s-cursor-not-allowed s-opacity-50"
                     : undefined
                 }
               >

--- a/front/components/assistant/manager/AssistantsTable.tsx
+++ b/front/components/assistant/manager/AssistantsTable.tsx
@@ -89,7 +89,13 @@ const getTableColumns = ({
             header: "",
             accessorKey: "select",
             cell: (info: CellContext<RowData, boolean>) => (
-              <DataTable.CellContent>
+              <DataTable.CellContent
+                className={
+                  !info.row.original.canArchive && isBatchEdit
+                    ? "opacity-50 cursor-not-allowed"
+                    : undefined
+                }
+              >
                 <Checkbox
                   checked={info.row.original.isSelected}
                   disabled={!info.row.original.canArchive}
@@ -108,7 +114,13 @@ const getTableColumns = ({
       header: "Name",
       accessorKey: "name",
       cell: (info: CellContext<RowData, string>) => (
-        <DataTable.CellContent>
+        <DataTable.CellContent
+          className={
+            !info.row.original.canArchive && isBatchEdit
+              ? "opacity-50 cursor-not-allowed"
+              : undefined
+          }
+        >
           <div className={classNames("flex flex-row items-center gap-2 py-3")}>
             <div>
               <Avatar visual={info.row.original.pictureUrl} size="sm" />
@@ -132,7 +144,13 @@ const getTableColumns = ({
       header: "Access",
       accessorKey: "scope",
       cell: (info: CellContext<RowData, AgentConfigurationScope>) => (
-        <DataTable.CellContent>
+        <DataTable.CellContent
+          className={
+            !info.row.original.canArchive && isBatchEdit
+              ? "opacity-50 cursor-not-allowed"
+              : undefined
+          }
+        >
           {info.getValue() !== "hidden" && (
             <Chip
               size="xs"
@@ -154,11 +172,26 @@ const getTableColumns = ({
         const { editors } = info.row.original;
 
         if (!editors) {
-          return <DataTable.BasicCellContent label="-" />;
+          return (
+            <DataTable.BasicCellContent
+              className={
+                !info.row.original.canArchive && isBatchEdit
+                  ? "opacity-50 cursor-not-allowed"
+                  : undefined
+              }
+              label="-"
+            />
+          );
         }
 
         return (
-          <DataTable.CellContent>
+          <DataTable.CellContent
+            className={
+              !info.row.original.canArchive && isBatchEdit
+                ? "opacity-50 cursor-not-allowed"
+                : undefined
+            }
+          >
             <Avatar.Stack
               avatars={editors.map((editor) => ({
                 name: editor.fullName,
@@ -179,7 +212,15 @@ const getTableColumns = ({
       header: "Tags",
       accessorKey: "agentTagsAsString",
       cell: (info: CellContext<RowData, string>) => (
-        <DataTable.CellContent grow className="flex flex-row items-center">
+        <DataTable.CellContent
+          grow
+          className={classNames(
+            "flex flex-row items-center",
+            !info.row.original.canArchive && isBatchEdit
+              ? "opacity-50 cursor-not-allowed"
+              : null
+          )}
+        >
           <div className="group flex flex-row items-center gap-1">
             <div className="truncate text-muted-foreground dark:text-muted-foreground-night">
               <Tooltip
@@ -209,7 +250,12 @@ const getTableColumns = ({
       accessorFn: (row: RowData) => row.usage?.messageCount ?? 0,
       cell: (info: CellContext<RowData, AgentUsageType | undefined>) => (
         <DataTable.BasicCellContent
-          className="font-semibold"
+          className={classNames(
+            "font-semibold",
+            !info.row.original.canArchive && isBatchEdit
+              ? "opacity-50 cursor-not-allowed"
+              : null
+          )}
           tooltip={assistantUsageMessage({
             assistantName: info.row.original.name,
             // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
@@ -240,7 +286,12 @@ const getTableColumns = ({
           const feedbacksCount = `${f.up + f.down} feedback${pluralize(f.up + f.down)} over the last 30 days`;
           return (
             <DataTable.BasicCellContent
-              className="font-semibold"
+              className={classNames(
+                "font-semibold",
+                !info.row.original.canArchive && isBatchEdit
+                  ? "opacity-50 cursor-not-allowed"
+                  : null
+              )}
               tooltip={feedbacksCount}
               label={`${f.up + f.down}`}
             />
@@ -257,6 +308,11 @@ const getTableColumns = ({
       accessorKey: "lastUpdate",
       cell: (info: CellContext<RowData, number>) => (
         <DataTable.BasicCellContent
+          className={
+            !info.row.original.canArchive && isBatchEdit
+              ? "opacity-50 cursor-not-allowed"
+              : undefined
+          }
           tooltip={formatTimestampToFriendlyDate(info.getValue(), "long")}
           label={
             info.getValue()
@@ -273,7 +329,13 @@ const getTableColumns = ({
       cell: (info: CellContext<RowData, number>) => {
         if (info.row.original.scope === "global") {
           return (
-            <DataTable.CellContent>
+            <DataTable.CellContent
+              className={
+                !info.row.original.canArchive && isBatchEdit
+                  ? "opacity-50 cursor-not-allowed"
+                  : undefined
+              }
+            >
               {info.row.original.action}
             </DataTable.CellContent>
           );

--- a/front/components/assistant/manager/AssistantsTable.tsx
+++ b/front/components/assistant/manager/AssistantsTable.tsx
@@ -58,6 +58,15 @@ type RowData = {
   canArchive: boolean;
 };
 
+function getDisabledClass(
+  canArchive: boolean,
+  isBatchEdit: boolean
+): string | undefined {
+  return !canArchive && isBatchEdit
+    ? "cursor-not-allowed opacity-50"
+    : undefined;
+}
+
 const getTableColumns = ({
   owner,
   tags,
@@ -115,11 +124,10 @@ const getTableColumns = ({
       accessorKey: "name",
       cell: (info: CellContext<RowData, string>) => (
         <DataTable.CellContent
-          className={
-            !info.row.original.canArchive && isBatchEdit
-              ? "cursor-not-allowed opacity-50"
-              : undefined
-          }
+          className={getDisabledClass(
+            info.row.original.canArchive,
+            isBatchEdit
+          )}
         >
           <div className={classNames("flex flex-row items-center gap-2 py-3")}>
             <div>
@@ -145,11 +153,10 @@ const getTableColumns = ({
       accessorKey: "scope",
       cell: (info: CellContext<RowData, AgentConfigurationScope>) => (
         <DataTable.CellContent
-          className={
-            !info.row.original.canArchive && isBatchEdit
-              ? "cursor-not-allowed opacity-50"
-              : undefined
-          }
+          className={getDisabledClass(
+            info.row.original.canArchive,
+            isBatchEdit
+          )}
         >
           {info.getValue() !== "hidden" && (
             <Chip
@@ -174,11 +181,10 @@ const getTableColumns = ({
         if (!editors) {
           return (
             <DataTable.BasicCellContent
-              className={
-                !info.row.original.canArchive && isBatchEdit
-                  ? "cursor-not-allowed opacity-50"
-                  : undefined
-              }
+              className={getDisabledClass(
+                info.row.original.canArchive,
+                isBatchEdit
+              )}
               label="-"
             />
           );
@@ -186,11 +192,10 @@ const getTableColumns = ({
 
         return (
           <DataTable.CellContent
-            className={
-              !info.row.original.canArchive && isBatchEdit
-                ? "cursor-not-allowed opacity-50"
-                : undefined
-            }
+            className={getDisabledClass(
+              info.row.original.canArchive,
+              isBatchEdit
+            )}
           >
             <Avatar.Stack
               avatars={editors.map((editor) => ({
@@ -216,9 +221,7 @@ const getTableColumns = ({
           grow
           className={classNames(
             "flex flex-row items-center",
-            !info.row.original.canArchive && isBatchEdit
-              ? "cursor-not-allowed opacity-50"
-              : null
+            getDisabledClass(info.row.original.canArchive, isBatchEdit) ?? null
           )}
         >
           <div className="group flex flex-row items-center gap-1">
@@ -252,9 +255,7 @@ const getTableColumns = ({
         <DataTable.BasicCellContent
           className={classNames(
             "font-semibold",
-            !info.row.original.canArchive && isBatchEdit
-              ? "cursor-not-allowed opacity-50"
-              : null
+            getDisabledClass(info.row.original.canArchive, isBatchEdit) ?? null
           )}
           tooltip={assistantUsageMessage({
             assistantName: info.row.original.name,
@@ -288,9 +289,8 @@ const getTableColumns = ({
             <DataTable.BasicCellContent
               className={classNames(
                 "font-semibold",
-                !info.row.original.canArchive && isBatchEdit
-                  ? "cursor-not-allowed opacity-50"
-                  : null
+                getDisabledClass(info.row.original.canArchive, isBatchEdit) ??
+                  null
               )}
               tooltip={feedbacksCount}
               label={`${f.up + f.down}`}
@@ -308,11 +308,10 @@ const getTableColumns = ({
       accessorKey: "lastUpdate",
       cell: (info: CellContext<RowData, number>) => (
         <DataTable.BasicCellContent
-          className={
-            !info.row.original.canArchive && isBatchEdit
-              ? "cursor-not-allowed opacity-50"
-              : undefined
-          }
+          className={getDisabledClass(
+            info.row.original.canArchive,
+            isBatchEdit
+          )}
           tooltip={formatTimestampToFriendlyDate(info.getValue(), "long")}
           label={
             info.getValue()
@@ -330,17 +329,24 @@ const getTableColumns = ({
         if (info.row.original.scope === "global") {
           return (
             <DataTable.CellContent
-              className={
-                !info.row.original.canArchive && isBatchEdit
-                  ? "cursor-not-allowed opacity-50"
-                  : undefined
-              }
+              className={getDisabledClass(
+                info.row.original.canArchive,
+                isBatchEdit
+              )}
             >
               {info.row.original.action}
             </DataTable.CellContent>
           );
         }
-        return <DataTable.MoreButton menuItems={info.row.original.menuItems} />;
+        return (
+          <DataTable.MoreButton
+            menuItems={info.row.original.menuItems}
+            className={getDisabledClass(
+              info.row.original.canArchive,
+              isBatchEdit
+            )}
+          />
+        );
       },
       meta: {
         className: "w-14",

--- a/front/components/assistant/manager/AssistantsTable.tsx
+++ b/front/components/assistant/manager/AssistantsTable.tsx
@@ -58,11 +58,6 @@ type RowData = {
   canArchive: boolean;
 };
 
-// We disable the global agents in batch mode edit since they cannot be archived.
-function isDisabled(canArchive: boolean, isBatchEdit: boolean): boolean {
-  return !canArchive && isBatchEdit;
-}
-
 const getTableColumns = ({
   owner,
   tags,
@@ -94,9 +89,7 @@ const getTableColumns = ({
             header: "",
             accessorKey: "select",
             cell: (info: CellContext<RowData, boolean>) => (
-              <DataTable.CellContent
-                disabled={isDisabled(info.row.original.canArchive, isBatchEdit)}
-              >
+              <DataTable.CellContent>
                 <Checkbox
                   checked={info.row.original.isSelected}
                   disabled={!info.row.original.canArchive}
@@ -115,9 +108,7 @@ const getTableColumns = ({
       header: "Name",
       accessorKey: "name",
       cell: (info: CellContext<RowData, string>) => (
-        <DataTable.CellContent
-          disabled={isDisabled(info.row.original.canArchive, isBatchEdit)}
-        >
+        <DataTable.CellContent>
           <div className={classNames("flex flex-row items-center gap-2 py-3")}>
             <div>
               <Avatar visual={info.row.original.pictureUrl} size="sm" />
@@ -141,9 +132,7 @@ const getTableColumns = ({
       header: "Access",
       accessorKey: "scope",
       cell: (info: CellContext<RowData, AgentConfigurationScope>) => (
-        <DataTable.CellContent
-          disabled={isDisabled(info.row.original.canArchive, isBatchEdit)}
-        >
+        <DataTable.CellContent>
           {info.getValue() !== "hidden" && (
             <Chip
               size="xs"
@@ -165,18 +154,11 @@ const getTableColumns = ({
         const { editors } = info.row.original;
 
         if (!editors) {
-          return (
-            <DataTable.BasicCellContent
-              disabled={isDisabled(info.row.original.canArchive, isBatchEdit)}
-              label="-"
-            />
-          );
+          return <DataTable.BasicCellContent label="-" />;
         }
 
         return (
-          <DataTable.CellContent
-            disabled={isDisabled(info.row.original.canArchive, isBatchEdit)}
-          >
+          <DataTable.CellContent>
             <Avatar.Stack
               avatars={editors.map((editor) => ({
                 name: editor.fullName,
@@ -197,11 +179,7 @@ const getTableColumns = ({
       header: "Tags",
       accessorKey: "agentTagsAsString",
       cell: (info: CellContext<RowData, string>) => (
-        <DataTable.CellContent
-          grow
-          className={classNames("flex flex-row items-center")}
-          disabled={isDisabled(info.row.original.canArchive, isBatchEdit)}
-        >
+        <DataTable.CellContent grow className="flex flex-row items-center">
           <div className="group flex flex-row items-center gap-1">
             <div className="truncate text-muted-foreground dark:text-muted-foreground-night">
               <Tooltip
@@ -231,8 +209,7 @@ const getTableColumns = ({
       accessorFn: (row: RowData) => row.usage?.messageCount ?? 0,
       cell: (info: CellContext<RowData, AgentUsageType | undefined>) => (
         <DataTable.BasicCellContent
-          className={classNames("font-semibold")}
-          disabled={isDisabled(info.row.original.canArchive, isBatchEdit)}
+          className="font-semibold"
           tooltip={assistantUsageMessage({
             assistantName: info.row.original.name,
             // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
@@ -263,8 +240,7 @@ const getTableColumns = ({
           const feedbacksCount = `${f.up + f.down} feedback${pluralize(f.up + f.down)} over the last 30 days`;
           return (
             <DataTable.BasicCellContent
-              className={classNames("font-semibold")}
-              disabled={isDisabled(info.row.original.canArchive, isBatchEdit)}
+              className="font-semibold"
               tooltip={feedbacksCount}
               label={`${f.up + f.down}`}
             />
@@ -281,7 +257,6 @@ const getTableColumns = ({
       accessorKey: "lastUpdate",
       cell: (info: CellContext<RowData, number>) => (
         <DataTable.BasicCellContent
-          disabled={isDisabled(info.row.original.canArchive, isBatchEdit)}
           tooltip={formatTimestampToFriendlyDate(info.getValue(), "long")}
           label={
             info.getValue()
@@ -298,19 +273,12 @@ const getTableColumns = ({
       cell: (info: CellContext<RowData, number>) => {
         if (info.row.original.scope === "global") {
           return (
-            <DataTable.CellContent
-              disabled={isDisabled(info.row.original.canArchive, isBatchEdit)}
-            >
+            <DataTable.CellContent>
               {info.row.original.action}
             </DataTable.CellContent>
           );
         }
-        return (
-          <DataTable.MoreButton
-            menuItems={info.row.original.menuItems}
-            disabled={isDisabled(info.row.original.canArchive, isBatchEdit)}
-          />
-        );
+        return <DataTable.MoreButton menuItems={info.row.original.menuItems} />;
       },
       meta: {
         className: "w-14",

--- a/front/components/assistant/manager/AssistantsTable.tsx
+++ b/front/components/assistant/manager/AssistantsTable.tsx
@@ -58,6 +58,7 @@ type RowData = {
   canArchive: boolean;
 };
 
+// We disable the global agents in batch mode edit since they cannot be archived.
 function isDisabled(canArchive: boolean, isBatchEdit: boolean): boolean {
   return !canArchive && isBatchEdit;
 }

--- a/front/package-lock.json
+++ b/front/package-lock.json
@@ -7,7 +7,7 @@
       "dependencies": {
         "@datadog/browser-logs": "^6.13.0",
         "@dust-tt/client": "file:../sdks/js",
-        "@dust-tt/sparkle": "^0.2.642",
+        "@dust-tt/sparkle": "^0.2.644",
         "@google-cloud/bigquery": "^7.9.1",
         "@google-cloud/storage-transfer": "^3.6.0",
         "@heroicons/react": "^2.0.11",
@@ -1150,9 +1150,9 @@
       "link": true
     },
     "node_modules/@dust-tt/sparkle": {
-      "version": "0.2.642",
-      "resolved": "https://registry.npmjs.org/@dust-tt/sparkle/-/sparkle-0.2.642.tgz",
-      "integrity": "sha512-2BVATnEWwUTEemxYbBlKnmiWaYts7rXCODJlB/bpcnq01EPhZCqJfoxRPPev7rKVWViOQyqM85gilwhgx4Veuw==",
+      "version": "0.2.644",
+      "resolved": "https://registry.npmjs.org/@dust-tt/sparkle/-/sparkle-0.2.644.tgz",
+      "integrity": "sha512-4p9/hoFtVMQGmIb1V9ulSKTbtKhUxavTKMp1mSjNunB0W4GAFweKL0XVskKjipL+kqOkUOvMh8OVWSLTF9XNvQ==",
       "license": "ISC",
       "dependencies": {
         "@emoji-mart/data": "^1.1.2",

--- a/front/package.json
+++ b/front/package.json
@@ -28,7 +28,7 @@
   "dependencies": {
     "@datadog/browser-logs": "^6.13.0",
     "@dust-tt/client": "file:../sdks/js",
-    "@dust-tt/sparkle": "^0.2.642",
+    "@dust-tt/sparkle": "^0.2.644",
     "@google-cloud/bigquery": "^7.9.1",
     "@google-cloud/storage-transfer": "^3.6.0",
     "@heroicons/react": "^2.0.11",

--- a/sparkle/src/components/DataTable.tsx
+++ b/sparkle/src/components/DataTable.tsx
@@ -961,12 +961,14 @@ export interface DataTableMoreButtonProps {
     React.ComponentPropsWithoutRef<typeof DropdownMenu>,
     "modal"
   >;
+  disabled?: boolean;
 }
 
 DataTable.MoreButton = function MoreButton({
   className,
   menuItems,
   dropdownMenuProps,
+  disabled,
 }: DataTableMoreButtonProps) {
   if (!menuItems?.length) {
     return null;
@@ -984,11 +986,15 @@ DataTable.MoreButton = function MoreButton({
           icon={MoreIcon}
           size="mini"
           variant="ghost-secondary"
-          className={cn(className)}
+          disabled={disabled}
+          className={cn(
+            disabled && "s-cursor-not-allowed s-opacity-50",
+            className
+          )}
         />
       </DropdownMenuTrigger>
 
-      <DropdownMenuContent align="end">
+      <DropdownMenuContent align="end" hidden={disabled}>
         <DropdownMenuGroup>
           {menuItems.map((item, index) => renderMenuItem(item, index))}
         </DropdownMenuGroup>
@@ -1032,6 +1038,7 @@ interface CellContentProps extends React.TdHTMLAttributes<HTMLDivElement> {
   children?: ReactNode;
   description?: string;
   grow?: boolean;
+  disabled?: boolean;
 }
 
 DataTable.CellContent = function CellContent({
@@ -1044,6 +1051,7 @@ DataTable.CellContent = function CellContent({
   iconClassName,
   description,
   grow = false,
+  disabled,
   ...props
 }: CellContentProps) {
   return (
@@ -1051,8 +1059,10 @@ DataTable.CellContent = function CellContent({
       className={cn(
         "s-flex s-items-center",
         grow ? "s-flex-grow" : "",
+        disabled && "s-cursor-not-allowed s-opacity-50",
         className
       )}
+      aria-disabled={disabled || undefined}
       {...props}
     >
       {avatarUrl && avatarTooltipLabel && (
@@ -1117,6 +1127,7 @@ interface BasicCellContentProps extends React.TdHTMLAttributes<HTMLDivElement> {
   label: string | number;
   tooltip?: string | number;
   textToCopy?: string | number;
+  disabled?: boolean;
 }
 
 DataTable.BasicCellContent = function BasicCellContent({
@@ -1124,6 +1135,7 @@ DataTable.BasicCellContent = function BasicCellContent({
   tooltip,
   className,
   textToCopy,
+  disabled,
   ...props
 }: BasicCellContentProps) {
   const [isCopied, copyToClipboard] = useCopyToClipboard();
@@ -1150,8 +1162,10 @@ DataTable.BasicCellContent = function BasicCellContent({
                 cellHeight,
                 "s-group s-flex s-items-center s-gap-2 s-text-sm",
                 "s-text-muted-foreground dark:s-text-muted-foreground-night",
+                disabled && "s-cursor-not-allowed s-opacity-50",
                 className
               )}
+              aria-disabled={disabled || undefined}
               {...props}
             >
               <span className="s-truncate">{label}</span>
@@ -1177,8 +1191,10 @@ DataTable.BasicCellContent = function BasicCellContent({
             cellHeight,
             "s-group s-flex s-items-center s-gap-2 s-text-sm",
             "s-text-muted-foreground dark:s-text-muted-foreground-night",
+            disabled && "s-cursor-not-allowed s-opacity-50",
             className
           )}
+          aria-disabled={disabled || undefined}
           {...props}
         >
           <span className="s-truncate">{label}</span>


### PR DESCRIPTION
## Description

(See: https://github.com/dust-tt/tasks/issues/4387)

Correcting the implementation here: https://github.com/dust-tt/dust/pull/16405
By using the new sparkle components added here: https://github.com/dust-tt/dust/pull/16419

## Tests

Ran locally in light and dark mode.

## Risk

None.

## Deploy Plan

Deploy front.
