### PR TITLE
Add chip instead of long pasted text

### DIFF
--- a/extension/ui/components/input_bar/editor/useCustomEditor.tsx
+++ b/extension/ui/components/input_bar/editor/useCustomEditor.tsx
@@ -91,6 +91,12 @@ function getTextAndMentionsFromNode(node?: JSONContent) {
     textContent += "\n";
   }
 
+  if (node.type === "pastedAttachment") {
+    const title = node.attrs?.title ?? "";
+    const fileId = node.attrs?.fileId ?? "";
+    textContent += `:pasted_attachment[${title}]{fileId=${fileId}}`;
+  }
+
   // If the node has content, recursively get text and mentions from each child node
   if (node.content) {
     node.content.forEach((childNode) => {

--- a/front/components/assistant/conversation/UserMessage.tsx
+++ b/front/components/assistant/conversation/UserMessage.tsx
@@ -23,6 +23,10 @@ import {
   getMentionPlugin,
   mentionDirective,
 } from "@app/components/markdown/MentionBlock";
+import {
+  PastedAttachmentBlock,
+  pastedAttachmentDirective,
+} from "@app/components/markdown/PastedAttachmentBlock";
 import { formatTimestring } from "@app/lib/utils/timestamps";
 import type { UserMessageType, WorkspaceType } from "@app/types";
 
@@ -46,12 +50,18 @@ export function UserMessage({
       sup: CiteBlock,
       mention: getMentionPlugin(owner),
       content_node_mention: ContentNodeMentionBlock,
+      pasted_attachment: PastedAttachmentBlock,
     }),
     [owner]
   );
 
   const additionalMarkdownPlugins: PluggableList = useMemo(
-    () => [getCiteDirective(), mentionDirective, contentNodeMentionDirective],
+    () => [
+      getCiteDirective(),
+      mentionDirective,
+      contentNodeMentionDirective,
+      pastedAttachmentDirective,
+    ],
     []
   );
 

--- a/front/components/assistant/conversation/input_bar/InputBarContainer.tsx
+++ b/front/components/assistant/conversation/input_bar/InputBarContainer.tsx
@@ -20,7 +20,10 @@ import { useMentionDropdown } from "@app/components/assistant/conversation/input
 import useUrlHandler from "@app/components/assistant/conversation/input_bar/editor/useUrlHandler";
 import { InputBarAttachmentsPicker } from "@app/components/assistant/conversation/input_bar/InputBarAttachmentsPicker";
 import { InputBarContext } from "@app/components/assistant/conversation/input_bar/InputBarContext";
-import { getPastedFileName } from "@app/components/assistant/conversation/input_bar/pasted_utils";
+import {
+  getDisplayNameFromPastedFileId,
+  getPastedFileName,
+} from "@app/components/assistant/conversation/input_bar/pasted_utils";
 import { ToolsPicker } from "@app/components/assistant/ToolsPicker";
 import { VoicePicker } from "@app/components/assistant/VoicePicker";
 import type { FileUploaderService } from "@app/hooks/useFileUploaderService";
@@ -106,6 +109,89 @@ const InputBarContainer = ({
 
   // Create a ref to hold the editor instance
   const editorRef = useRef<Editor | null>(null);
+  const pastedAttachmentIdsRef = useRef<Set<string>>(new Set());
+
+  const removePastedAttachmentChip = useCallback(
+    (fileId: string) => {
+      const editorInstance = editorRef.current;
+      if (!editorInstance) {
+        return;
+      }
+
+      editorInstance.commands.command(({ state, tr }) => {
+        let removed = false;
+        state.doc.descendants((node, pos) => {
+          if (
+            node.type.name === "pastedAttachment" &&
+            node.attrs?.fileId === fileId
+          ) {
+            tr.delete(pos, pos + node.nodeSize);
+            removed = true;
+            return false;
+          }
+          return true;
+        });
+
+        if (removed) {
+          pastedAttachmentIdsRef.current.delete(fileId);
+        }
+
+        return removed;
+      });
+    },
+    [editorRef]
+  );
+
+  const insertPastedAttachmentChip = useCallback(
+    ({
+      fileId,
+      title,
+      from,
+      to,
+    }: {
+      fileId: string;
+      title: string;
+      from: number;
+      to: number;
+    }) => {
+      const editorInstance = editorRef.current;
+      if (!editorInstance) {
+        return false;
+      }
+
+      const { doc } = editorInstance.state;
+
+      let needsLeadingSpace = false;
+      if (from > 0) {
+        const $from = doc.resolve(from);
+        const textBefore = doc.textBetween($from.start(), from, " ");
+        needsLeadingSpace = !!textBefore && !/\s$/.test(textBefore);
+      }
+
+      const content = [
+        ...(needsLeadingSpace ? [{ type: "text", text: " " }] : []),
+        {
+          type: "pastedAttachment",
+          attrs: { fileId, title },
+          text: `:pasted_attachment[${title}]{fileId=${fileId}}`,
+        },
+        { type: "text", text: " " },
+      ];
+
+      const success = editorInstance
+        .chain()
+        .focus()
+        .insertContentAt({ from, to }, content)
+        .run();
+
+      if (success) {
+        pastedAttachmentIdsRef.current.add(fileId);
+      }
+
+      return success;
+    },
+    [editorRef]
+  );
 
   const handleUrlDetected = useCallback(
     (candidate: UrlCandidate | NodeCandidate | null) => {
@@ -130,17 +216,32 @@ const InputBarContainer = ({
     onUrlDetected: handleUrlDetected,
     suggestionHandler: mentionDropdown.getSuggestionHandler(),
     owner,
-    onLongTextPaste: async (text: string) => {
+    onLongTextPaste: async ({ text, from, to }) => {
+      let filename = "";
+      let inserted = false;
       try {
         const newCount = pastedCount + 1;
         setPastedCount(newCount);
-        const filename = getPastedFileName(newCount);
+        filename = getPastedFileName(newCount);
+        const displayName = getDisplayNameFromPastedFileId(filename);
+
+        inserted = insertPastedAttachmentChip({
+          fileId: filename,
+          title: displayName,
+          from,
+          to,
+        });
+
         const file = new File([text], filename, {
           type: "text/vnd.dust.attachment.pasted",
         });
 
         const uploaded = await fileUploaderService.handleFilesUpload([file]);
         if (!(uploaded && uploaded.length > 0)) {
+          if (inserted) {
+            removePastedAttachmentChip(filename);
+            inserted = false;
+          }
           sendNotification({
             type: "error",
             title: "Failed to attach pasted text",
@@ -148,6 +249,9 @@ const InputBarContainer = ({
           });
         }
       } catch (e) {
+        if (inserted && filename) {
+          removePastedAttachmentChip(filename);
+        }
         sendNotification({
           type: "error",
           title: "Failed to attach pasted text",
@@ -156,6 +260,25 @@ const InputBarContainer = ({
       }
     },
   });
+
+  useEffect(() => {
+    // If an attachment disappears from the uploader, remove its chip from the editor
+    const currentPastedIds = new Set(
+      fileUploaderService.fileBlobs
+        .filter(
+          (blob) => blob.contentType === "text/vnd.dust.attachment.pasted"
+        )
+        .map((blob) => blob.id)
+    );
+
+    const idsInEditor = Array.from(pastedAttachmentIdsRef.current);
+    idsInEditor.forEach((id) => {
+      if (!currentPastedIds.has(id)) {
+        removePastedAttachmentChip(id);
+        pastedAttachmentIdsRef.current.delete(id);
+      }
+    });
+  }, [fileUploaderService.fileBlobs, removePastedAttachmentChip]);
 
   const voiceTranscriberService = useVoiceTranscriberService({
     owner,

--- a/front/components/assistant/conversation/input_bar/editor/PastedAttachmentComponent.tsx
+++ b/front/components/assistant/conversation/input_bar/editor/PastedAttachmentComponent.tsx
@@ -2,11 +2,13 @@ import { AttachmentChip, DoubleQuotesIcon } from "@dust-tt/sparkle";
 import { NodeViewWrapper } from "@tiptap/react";
 import React from "react";
 
+interface PastedAttachmentComponentProps {
+  node: { attrs: { title?: string; fileId?: string } };
+}
+
 export function PastedAttachmentComponent({
   node,
-}: {
-  node: { attrs: { title?: string } };
-}) {
+}: PastedAttachmentComponentProps) {
   const { title } = node.attrs;
   return (
     <NodeViewWrapper className="inline-flex align-middle">

--- a/front/components/assistant/conversation/input_bar/editor/PastedAttachmentComponent.tsx
+++ b/front/components/assistant/conversation/input_bar/editor/PastedAttachmentComponent.tsx
@@ -1,0 +1,16 @@
+import { AttachmentChip, DoubleQuotesIcon } from "@dust-tt/sparkle";
+import { NodeViewWrapper } from "@tiptap/react";
+import React from "react";
+
+export function PastedAttachmentComponent({
+  node,
+}: {
+  node: { attrs: { title?: string } };
+}) {
+  const { title } = node.attrs;
+  return (
+    <NodeViewWrapper className="inline-flex align-middle">
+      <AttachmentChip label={title ?? "Attachment"} icon={DoubleQuotesIcon} />
+    </NodeViewWrapper>
+  );
+}

--- a/front/components/assistant/conversation/input_bar/editor/extensions/PastedAttachmentExtension.ts
+++ b/front/components/assistant/conversation/input_bar/editor/extensions/PastedAttachmentExtension.ts
@@ -11,8 +11,8 @@ export const PastedAttachmentExtension = Node.create({
 
   addAttributes() {
     return {
-      fileId: { default: null },
-      title: { default: null },
+      fileId: { default: null as string | null },
+      title: { default: null as string | null },
     };
   },
 

--- a/front/components/assistant/conversation/input_bar/editor/extensions/PastedAttachmentExtension.ts
+++ b/front/components/assistant/conversation/input_bar/editor/extensions/PastedAttachmentExtension.ts
@@ -1,0 +1,33 @@
+import { mergeAttributes, Node } from "@tiptap/core";
+import { ReactNodeViewRenderer } from "@tiptap/react";
+
+import { PastedAttachmentComponent } from "../PastedAttachmentComponent";
+
+export const PastedAttachmentExtension = Node.create({
+  name: "pastedAttachment",
+  group: "inline",
+  inline: true,
+  atom: true,
+
+  addAttributes() {
+    return {
+      fileId: { default: null },
+      title: { default: null },
+    };
+  },
+
+  parseHTML() {
+    return [{ tag: 'span[data-type="pasted-attachment"]' }];
+  },
+
+  renderHTML({ HTMLAttributes }) {
+    return [
+      "span",
+      mergeAttributes({ "data-type": "pasted-attachment" }, HTMLAttributes),
+    ];
+  },
+
+  addNodeView() {
+    return ReactNodeViewRenderer(PastedAttachmentComponent);
+  },
+});

--- a/front/components/assistant/conversation/input_bar/editor/extensions/PastedAttachmentExtension.ts
+++ b/front/components/assistant/conversation/input_bar/editor/extensions/PastedAttachmentExtension.ts
@@ -11,8 +11,8 @@ export const PastedAttachmentExtension = Node.create({
 
   addAttributes() {
     return {
-      fileId: { default: null as string | null },
-      title: { default: null as string | null },
+      fileId: { default: null },
+      title: { default: null },
     };
   },
 

--- a/front/components/assistant/conversation/input_bar/editor/markdownSerializer.ts
+++ b/front/components/assistant/conversation/input_bar/editor/markdownSerializer.ts
@@ -46,6 +46,15 @@ function buildNodeSerializers(schema: Schema) {
     state.write(`:content_node_mention[${node.attrs.title}]`);
   };
 
+  map.pastedAttachment = (
+    state: MarkdownSerializerState,
+    node: ProseMirrorNode
+  ) => {
+    state.write(
+      `:pasted_attachment[${node.attrs.title}]{fileId=${node.attrs.fileId}}`
+    );
+  };
+
   // Add fallback for any missing nodes in schema.
   Object.keys(schema.nodes).forEach((nodeName) => {
     if (!map[nodeName]) {

--- a/front/components/assistant/conversation/input_bar/editor/useCustomEditor.tsx
+++ b/front/components/assistant/conversation/input_bar/editor/useCustomEditor.tsx
@@ -11,6 +11,7 @@ import { MarkdownStyleExtension } from "@app/components/assistant/conversation/i
 import { MentionExtension } from "@app/components/assistant/conversation/input_bar/editor/extensions/MentionExtension";
 import { MentionStorageExtension } from "@app/components/assistant/conversation/input_bar/editor/extensions/MentionStorageExtension";
 import { ParagraphExtension } from "@app/components/assistant/conversation/input_bar/editor/extensions/ParagraphExtension";
+import { PastedAttachmentExtension } from "@app/components/assistant/conversation/input_bar/editor/extensions/PastedAttachmentExtension";
 import { URLDetectionExtension } from "@app/components/assistant/conversation/input_bar/editor/extensions/URLDetectionExtension";
 import { createMarkdownSerializer } from "@app/components/assistant/conversation/input_bar/editor/markdownSerializer";
 import type { EditorSuggestions } from "@app/components/assistant/conversation/input_bar/editor/suggestion";
@@ -56,6 +57,12 @@ function getTextAndMentionsFromNode(node?: JSONContent) {
   // If the node is a 'hardBreak' or a 'paragraph', add a newline character.
   if (node.type && ["hardBreak", "paragraph"].includes(node.type)) {
     textContent += "\n";
+  }
+
+  if (node.type === "pastedAttachment") {
+    const title = node.attrs?.title ?? "";
+    const fileId = node.attrs?.fileId ?? "";
+    textContent += `:pasted_attachment[${title}]{fileId=${fileId}}`;
   }
 
   // If the node has content, recursively get text and mentions from each child node
@@ -220,8 +227,12 @@ export interface CustomEditorProps {
     };
   };
   owner: WorkspaceType;
-  // If provided, large pasted text will be routed to this callback
-  onLongTextPaste?: (text: string) => void;
+  // If provided, large pasted text will be routed to this callback along with selection bounds
+  onLongTextPaste?: (payload: {
+    text: string;
+    from: number;
+    to: number;
+  }) => void;
   longTextPasteCharsThreshold?: number;
 }
 
@@ -260,6 +271,7 @@ const useCustomEditor = ({
     }),
     MarkdownStyleExtension,
     ParagraphExtension,
+    PastedAttachmentExtension,
     URLStorageExtension,
   ];
   if (onUrlDetected) {
@@ -287,7 +299,8 @@ const useCustomEditor = ({
           return false;
         }
         if (isLongTextPaste(text, longTextPasteCharsThreshold)) {
-          onLongTextPaste(text);
+          const { from, to } = view.state.selection;
+          onLongTextPaste({ text, from, to });
           return true;
         }
         return false;

--- a/front/components/markdown/PastedAttachmentBlock.tsx
+++ b/front/components/markdown/PastedAttachmentBlock.tsx
@@ -1,0 +1,22 @@
+import { AttachmentChip } from "@dust-tt/sparkle";
+import { PaperclipIcon } from "lucide-react";
+import React from "react";
+import { visit } from "unist-util-visit";
+
+export function PastedAttachmentBlock({ title }: { title: string }) {
+  return <AttachmentChip label={title} icon={PaperclipIcon} />;
+}
+
+export function pastedAttachmentDirective() {
+  return (tree: any) => {
+    visit(tree, ["textDirective"], (node) => {
+      if (node.name === "pasted_attachment" && node.children[0]) {
+        const data = node.data || (node.data = {});
+        data.hName = "pasted_attachment";
+        data.hProperties = {
+          title: node.children[0].value,
+        };
+      }
+    });
+  };
+}


### PR DESCRIPTION
## Description

closes https://github.com/dust-tt/tasks/issues/4435

This allow user to place document inside the text so the llms knows what the user is talking about in the text.
I have done something similar in term of implementation to wht was done for Data source link chips.
I have used the same icon as for the citation.

<img width="1606" height="618" alt="image" src="https://github.com/user-attachments/assets/a9d68989-5480-4eba-9c92-2ac9f262865f" />

<img width="1672" height="868" alt="image" src="https://github.com/user-attachments/assets/eae3dcb8-1190-48b4-9cfd-76c6626461d4" />

Deleting the attachment also remove the chip

https://github.com/user-attachments/assets/30257762-447f-42bf-ae87-ad075f4aab79

## Tests

Manual tests

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

deploy front
