### PR TITLE
[connectors] enh(GoogleDrive): add logs to investigate OOMs on Tika 422 errors

### DIFF
--- a/connectors/src/connectors/google_drive/temporal/activities/common/constants.ts
+++ b/connectors/src/connectors/google_drive/temporal/activities/common/constants.ts
@@ -1,2 +1,2 @@
-export const FILES_SYNC_CONCURRENCY = 10;
+export const FILES_SYNC_CONCURRENCY = 8;
 export const FILES_GC_CONCURRENCY = 5;

--- a/connectors/src/connectors/google_drive/temporal/file/sync_one_file.ts
+++ b/connectors/src/connectors/google_drive/temporal/file/sync_one_file.ts
@@ -63,6 +63,7 @@ export async function syncOneFile(
         documentId,
         fileId: file.id,
         mimeType: file.mimeType,
+        fileSize: file.size,
       });
 
       // Early return if lastSeenTs is greater than workflow start.


### PR DESCRIPTION
## Description

- We currently observe large spikes in CPU and RAM usage that are correlated with bursts of 422 errors on Tika.
- These leads to pod OOMing, see [here](https://app.datadoghq.eu/logs?query=container_id%3A83fe577ea052529b5d2e7d35c53788f8ea27a491bb3d5a9c8d76ed9494731b1d&agg_m=count&agg_m_source=base&agg_t=count&event=AwAAAZmW_TbgH8GGaAAAABhBWm1XX1Q0S0FBQ2EydVBWRGpKS3FnQUsAAAAkZjE5OTk2ZmUtMjY0OC00ZWYxLWFlNjMtNmEyYWIyYjE3OGZjAAAoCQ&fromUser=true&messageDisplay=inline&refresh_mode=paused&storage=hot&stream_sort=time%2Cdesc&viz=stream&from_ts=1759174757338&to_ts=1759174866661&live=false), [here](https://app.datadoghq.eu/logs?query=container_id%3Aa332cc5eacdcf213dab6f5883f23a9e0572a1b65705132f670cd7de1bf582ab9&agg_m=count&agg_m_source=base&agg_t=count&event=AwAAAZmW9skOy9GyxQAAABhBWm1XOXRWckFBQWsxdzktckRneWZRQWgAAAAkZjE5OTk2ZjgtYTMzMS00OGY5LThlNmYtZmZlMzQ4MDc2ZDcyAAAs8Q&fromUser=true&messageDisplay=inline&refresh_mode=paused&storage=hot&stream_sort=time%2Cdesc&viz=stream&from_ts=1759174331846&to_ts=1759174402450&live=false) and the corresponding CPU/RAM usage [here](https://app.datadoghq.eu/containers?query=pod_name%3Aconnectors-worker-google-drive-deployment-d9bddb56c-fcsr9&selectedTopGraph=timeseries&sort=container_name%2CASC&from_ts=1759173159382&to_ts=1759176759382&live=false).
- One possible explanation would be that the `Buffer.from` is expensive CPU-wise for large files and that during the time Tika attempts to process the document it stays in memory.
- This PR adds the file size to validate this theory (by summing the file size we can see if it matches the size of RAM spike) and decreases the concurrency slightly.

## Tests

## Risk

- Low.

## Deploy Plan

- Deploy connectors.
