### PR TITLE
[connectors] enh(Confluence): track and manage deleted spaces

### DIFF
--- a/connectors/migrations/db/migration_95.sql
+++ b/connectors/migrations/db/migration_95.sql
@@ -1,0 +1,2 @@
+-- Migration created on Sep 29, 2025
+ALTER TABLE "public"."confluence_spaces" ADD COLUMN "deletedAt" TIMESTAMP WITH TIME ZONE;

--- a/connectors/src/lib/models/confluence.ts
+++ b/connectors/src/lib/models/confluence.ts
@@ -55,6 +55,7 @@ export class ConfluenceSpace extends ConnectorBaseModel<ConfluenceSpace> {
   declare name: string;
   declare spaceId: string;
   declare urlSuffix?: string;
+  declare deletedAt: Date | null;
 }
 ConfluenceSpace.init(
   {
@@ -78,6 +79,10 @@ ConfluenceSpace.init(
     },
     urlSuffix: {
       type: DataTypes.STRING,
+      allowNull: true,
+    },
+    deletedAt: {
+      type: DataTypes.DATE,
       allowNull: true,
     },
   },

--- a/connectors/src/lib/models/confluence.ts
+++ b/connectors/src/lib/models/confluence.ts
@@ -52,10 +52,11 @@ ConfluenceConfiguration.init(
 export class ConfluenceSpace extends ConnectorBaseModel<ConfluenceSpace> {
   declare createdAt: CreationOptional<Date>;
   declare updatedAt: CreationOptional<Date>;
+  declare deletedAt: Date | null;
+
   declare name: string;
   declare spaceId: string;
   declare urlSuffix?: string;
-  declare deletedAt: Date | null;
 }
 ConfluenceSpace.init(
   {


### PR DESCRIPTION
## Description

- This PR is part of an investigation on spaces being incorrectly deleted/resynced due to Confluence API sporadically returning a 404 on the endpoint to get a space by ID.
- We currently expect certain 404: we never delete spaces on our end on 404, we keep it in db and recheck it on every sync.  This allows for saving the configuration of the user, and will resync the space if it becomes available again.
- This PR will help single out the initial 404, excluding subsequent ones from the log.
- Part of https://github.com/dust-tt/tasks/issues/4053.

## Tests

## Risk

- Low.

## Deploy Plan

- Run migration.
- Deploy connectors.
