### PR TITLE
[DataTable.ContentCell] optional visual props

### DIFF
--- a/sparkle/src/components/DataTable.tsx
+++ b/sparkle/src/components/DataTable.tsx
@@ -1040,7 +1040,7 @@ interface CellContentProps extends React.TdHTMLAttributes<HTMLDivElement> {
   grow?: boolean;
   disabled?: boolean;
   avatarStack?: {
-    items: { name: string; visual: string }[];
+    items: { name: string; visual?: string | React.ReactNode }[];
     nbVisibleItems?: number;
   };
 }

--- a/sparkle/src/stories/DataTable.stories.tsx
+++ b/sparkle/src/stories/DataTable.stories.tsx
@@ -52,7 +52,7 @@ type Data = {
   >;
   id?: number;
   roundedAvatar?: boolean;
-  avatarStack?: { name: string; visual: string }[];
+  avatarStack?: { name: string; visual?: string | React.ReactNode }[];
 };
 
 type TransformedData = {


### PR DESCRIPTION
## Description

- Make visual props optional to be identical to AvatarProps
- https://github.com/dust-tt/dust/blob/avatar-stack-optional-visual/sparkle/src/components/Avatar.tsx#L147

## Tests

- Storybook

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

- Deploy Sparkle
