### PR TITLE
Adjust posthog for GDPR

### DIFF
--- a/front/components/actions/mcp/MCPServerDetails.tsx
+++ b/front/components/actions/mcp/MCPServerDetails.tsx
@@ -79,10 +79,10 @@ export function MCPServerDetails({
       : undefined,
   });
 
-  // Reset form when mcpServerView changes (e.g., when switching between servers)
+  // Reset form when defaults change (e.g., when switching between servers)
   useEffect(() => {
     form.reset(defaults);
-  }, [mcpServerView?.sId]); // Only reset when server ID changes
+  }, [defaults, form]);
 
   const applyToolChanges = async (
     toolChanges: Array<{

--- a/front/components/app/PostHogTracker.tsx
+++ b/front/components/app/PostHogTracker.tsx
@@ -9,7 +9,6 @@ import { useUser } from "@app/lib/swr/user";
 import { isString } from "@app/types";
 
 const POSTHOG_KEY = process.env.NEXT_PUBLIC_POSTHOG_KEY;
-const NODE_ENV = process.env.NODE_ENV;
 
 interface PostHogTrackerProps {
   children: React.ReactNode;

--- a/front/types/shared/feature_flags.ts
+++ b/front/types/shared/feature_flags.ts
@@ -46,10 +46,6 @@ export const WHITELISTABLE_FEATURES_CONFIG = {
     description: "Access to DeepSeek R1 model as global agent",
     stage: "on_demand",
   },
-  enable_posthog: {
-    description: "Enable PostHog tracking within the product (/w/ routes)",
-    stage: "on_demand",
-  },
   dev_mcp_actions: {
     description: "MCP tools currently in development",
     stage: "dust_only",

--- a/sdks/js/src/types.ts
+++ b/sdks/js/src/types.ts
@@ -653,7 +653,6 @@ const WhitelistableFeaturesSchema = FlexibleEnumSchema<
   | "dev_mcp_actions"
   | "disable_run_logs"
   | "disallow_agent_creation_to_users"
-  | "enable_posthog"
   | "freshservice_tool"
   | "google_ai_studio_experimental_models_feature"
   | "google_sheets_tool"


### PR DESCRIPTION






## Description
Removes the `enable_posthog` feature flag and makes PostHog GDPR compliant by default. Previously, PostHog tracking in product routes was gated behind a feature flag and collected personal data (email, names) and IP addresses. This change removes the feature flag dependency, enabling tracking across all public routes (not in the product yet) while implementing strict GDPR compliance measures including IP masking, query parameter stripping, session recording masking, and removing personal data collection.

## Risk
Changes PostHog initialization behavior by removing feature flag dependency and modifying data collection practices. The GDPR compliance settings may reduce tracking granularity compared to the previous implementation.
