### PR TITLE
[front] perf: improve query in `listUsersWithEmailPredicat`

### DIFF
--- a/front/lib/resources/user_resource.ts
+++ b/front/lib/resources/user_resource.ts
@@ -10,7 +10,6 @@ import { Op } from "sequelize";
 import type { Authenticator } from "@app/lib/auth";
 import type { ResourceLogJSON } from "@app/lib/resources/base_resource";
 import { BaseResource } from "@app/lib/resources/base_resource";
-import { MembershipResource } from "@app/lib/resources/membership_resource";
 import { MembershipModel } from "@app/lib/resources/storage/models/membership";
 import {
   UserMetadataModel,

--- a/front/lib/resources/user_resource.ts
+++ b/front/lib/resources/user_resource.ts
@@ -437,6 +437,12 @@ export class UserResource extends BaseResource<UserModel> {
 
     const { count, rows: users } = await UserModel.findAndCountAll({
       where: userWhereClause,
+      include: [
+        {
+          model: MembershipModel,
+          as: "memberships",
+        },
+      ],
       order: [[paginationParams.orderColumn, paginationParams.orderDirection]],
       limit: paginationParams.limit,
       offset: paginationParams.offset,


### PR DESCRIPTION
## Description

- The query is not called often causes a high load on db due to having a sequential scan on users.
- Query plan [here](https://console.cloud.google.com/sql/instances/cell-00000-front-db/insights;database=front;duration=PT1H;trace=3ff86b1bef7485148aaf54d3d826c682;span=ec4ddf36d8937596;query_hash=5063209535320094296;sort_by=TOTAL_EXEC_TIME/executed?project=or1g1n-186209).
- This PR aims at optimizing the query by doing a separate, highly optimized query on the memberships to get the user IDs.

## Tests

## Risk

- Low.

## Deploy Plan

- Deploy front.
