### PR TITLE
fix(snowflake): support empty passphrase + support legacy 3des

### DIFF
--- a/core/src/databases/remote_databases/snowflake/api/auth.rs
+++ b/core/src/databases/remote_databases/snowflake/api/auth.rs
@@ -153,9 +153,15 @@ fn generate_jwt_from_key_pair(
 
 fn try_parse_private_key(pem: &str, password: Option<&[u8]>) -> Result<RsaPrivateKey> {
     if let Some(password) = password {
-        if let Ok(private) = RsaPrivateKey::from_pkcs8_encrypted_pem(pem, password) {
-            return Ok(private);
+        if !password.is_empty() {
+            if let Ok(private) = RsaPrivateKey::from_pkcs8_encrypted_pem(pem, password) {
+                return Ok(private);
+            }
         }
+    }
+
+    if let Ok(private) = RsaPrivateKey::from_pkcs8_encrypted_pem(pem, b"") {
+        return Ok(private);
     }
 
     RsaPrivateKey::from_pkcs8_pem(pem).or_else(|pkcs8_err| {


### PR DESCRIPTION
## Description

We've added support for empty passphrase on `connectors` but not `core`.

`core` also didn't support the legacy 3des passphrases


## Tests

Local

## Risk

Low

## Deploy Plan

Deploy `core`