### PR TITLE
Move ConversationMessage from Sparkle to front

### DIFF
--- a/front/components/assistant/conversation/AgentMessage.tsx
+++ b/front/components/assistant/conversation/AgentMessage.tsx
@@ -1,10 +1,12 @@
 import {
   ArrowPathIcon,
+  AtomIcon,
   Button,
   Chip,
   ClipboardCheckIcon,
   ClipboardIcon,
   DocumentIcon,
+  Icon,
   InteractiveImageGrid,
   Markdown,
   Separator,
@@ -73,6 +75,7 @@ import {
 interface AgentMessageProps {
   conversationId: string;
   isLastMessage: boolean;
+  isHandoverGroup: boolean;
   message: LightAgentMessageType;
   messageFeedback: FeedbackSelectorProps;
   owner: WorkspaceType;
@@ -88,6 +91,7 @@ interface AgentMessageProps {
 export function AgentMessage({
   conversationId,
   isLastMessage,
+  isHandoverGroup,
   message,
   messageFeedback,
   owner,
@@ -115,6 +119,10 @@ export function AgentMessage({
     messageId: message.sId,
     options: { disabled: true },
   });
+
+  const isDustDeepHandoverGroup =
+    isHandoverGroup &&
+    message.configuration.sId === GLOBAL_AGENTS_SID.DUST_DEEP;
 
   const { messageStreamState, dispatch, shouldStream } = useAgentMessageStream({
     message,
@@ -491,18 +499,25 @@ export function AgentMessage({
       buttons={buttons}
       avatarBusy={agentMessageToRender.status === "created"}
       isDisabled={isArchived}
-      renderName={() => (
-        <AgentHandle
-          assistant={{
-            sId: agentConfiguration.sId,
-            name: agentConfiguration.name + (isArchived ? " (archived)" : ""),
-          }}
-          canMention={canMention}
-          isDisabled={isArchived}
-        />
-      )}
+      renderName={() =>
+        isDustDeepHandoverGroup ? (
+          <span className="inline-flex items-center text-faint dark:text-faint-night">
+            <Icon visual={AtomIcon} size="sm" />
+            <span className="ml-1">Deep Dive</span>
+          </span>
+        ) : (
+          <AgentHandle
+            assistant={{
+              sId: agentConfiguration.sId,
+              name: agentConfiguration.name + (isArchived ? " (archived)" : ""),
+            }}
+            canMention={canMention}
+            isDisabled={isArchived}
+          />
+        )
+      }
       timestamp={shouldDisplayTimestamp ? messageTimestamp : undefined}
-      type="agent"
+      type={isDustDeepHandoverGroup ? "agentAsTool" : "agent"}
       citations={citations}
     >
       <div>
@@ -512,6 +527,7 @@ export function AgentMessage({
           streaming: shouldStream,
           lastTokenClassification:
             messageStreamState.agentState === "thinking" ? "tokens" : null,
+          isDustDeepHandoverGroup,
         })}
       </div>
       {/* Invisible div to act as a scroll anchor for detecting when the user has scrolled to the bottom */}
@@ -524,11 +540,13 @@ export function AgentMessage({
     references,
     streaming,
     lastTokenClassification,
+    isDustDeepHandoverGroup,
   }: {
     agentMessage: LightAgentMessageType;
     references: { [key: string]: MarkdownCitation };
     streaming: boolean;
     lastTokenClassification: null | "tokens" | "chain_of_thought";
+    isDustDeepHandoverGroup: boolean;
   }) {
     if (agentMessage.status === "failed") {
       const { error } = agentMessage;
@@ -540,6 +558,7 @@ export function AgentMessage({
               lastAgentStateClassification={messageStreamState.agentState}
               actionProgress={messageStreamState.actionProgress}
               owner={owner}
+              isDustDeepHandoverGroup={isDustDeepHandoverGroup}
             />
             <MCPServerPersonalAuthenticationRequired
               owner={owner}
@@ -575,6 +594,7 @@ export function AgentMessage({
             lastAgentStateClassification={messageStreamState.agentState}
             actionProgress={messageStreamState.actionProgress}
             owner={owner}
+            isDustDeepHandoverGroup={isDustDeepHandoverGroup}
           />
           <ErrorMessage
             error={
@@ -625,6 +645,7 @@ export function AgentMessage({
           lastAgentStateClassification={messageStreamState.agentState}
           actionProgress={messageStreamState.actionProgress}
           owner={owner}
+          isDustDeepHandoverGroup={isDustDeepHandoverGroup}
         />
         <AgentMessageContentCreationGeneratedFiles
           files={contentCreationFiles}

--- a/front/components/assistant/conversation/AgentMessage.tsx
+++ b/front/components/assistant/conversation/AgentMessage.tsx
@@ -4,7 +4,6 @@ import {
   Chip,
   ClipboardCheckIcon,
   ClipboardIcon,
-  ConversationMessage,
   DocumentIcon,
   InteractiveImageGrid,
   Markdown,
@@ -25,6 +24,7 @@ import {
 } from "@app/components/assistant/conversation/AgentMessageGeneratedFiles";
 import { useActionValidationContext } from "@app/components/assistant/conversation/BlockedActionsProvider";
 import { useAutoOpenContentCreation } from "@app/components/assistant/conversation/content_creation/useAutoOpenContentCreation";
+import { ConversationMessage } from "@app/components/assistant/conversation/ConversationMessage";
 import { ErrorMessage } from "@app/components/assistant/conversation/ErrorMessage";
 import type { FeedbackSelectorProps } from "@app/components/assistant/conversation/FeedbackSelector";
 import { FeedbackSelector } from "@app/components/assistant/conversation/FeedbackSelector";

--- a/front/components/assistant/conversation/ConversationMessage.tsx
+++ b/front/components/assistant/conversation/ConversationMessage.tsx
@@ -1,0 +1,245 @@
+import type { Button } from "@dust-tt/sparkle";
+import { Avatar, CitationGrid } from "@dust-tt/sparkle";
+import { cn } from "@dust-tt/sparkle";
+import type { VariantProps } from "class-variance-authority";
+import { cva } from "class-variance-authority";
+import React from "react";
+
+export const ConversationContainer = React.forwardRef<
+  HTMLDivElement,
+  React.HTMLAttributes<HTMLDivElement>
+>(({ children, className, ...props }, ref) => {
+  return (
+    <div
+      ref={ref}
+      className={cn(
+        "flex h-full w-full flex-col items-center @container/conversation",
+        className
+      )}
+      {...props}
+    >
+      <div className="flex w-full max-w-3xl flex-col gap-6 p-2 @sm/conversation:gap-8 @md/conversation:gap-10">
+        {children}
+      </div>
+    </div>
+  );
+});
+
+ConversationContainer.displayName = "ConversationContainer";
+
+interface ConversationMessageProps
+  extends React.HTMLAttributes<HTMLDivElement>,
+    VariantProps<typeof messageVariants> {
+  avatarBusy?: boolean;
+  buttons?: React.ReactElement<typeof Button>[];
+  children?: React.ReactNode;
+  citations?: React.ReactElement[];
+  isDisabled?: boolean;
+  name?: string;
+  timestamp?: string;
+  pictureUrl?: string | React.ReactNode | null;
+  renderName?: (name: string | null) => React.ReactNode;
+  infoChip?: React.ReactNode;
+  type: ConversationMessageType;
+}
+
+export type ConversationMessageType = "user" | "agent" | "agentAsTool";
+
+const messageVariants = cva("flex w-full flex-col rounded-2xl", {
+  variants: {
+    type: {
+      user: "bg-muted-background dark:bg-muted-background-night px-5 py-4 gap-2",
+      agent: "w-full gap-3",
+      agentAsTool:
+        "w-full gap-3 border border-border dark:border-border-night rounded-2xl px-5 py-5",
+    },
+  },
+  defaultVariants: {
+    type: "agent",
+  },
+});
+
+const buttonsVariants = cva("flex justify-start gap-2 pt-2", {
+  variants: {
+    type: {
+      user: "justify-end",
+      agent: "justify-start",
+      agentAsTool: "justify-start",
+    },
+  },
+  defaultVariants: {
+    type: "agent",
+  },
+});
+/**
+ * Parent component for both UserMessage and AgentMessage, to ensure avatar,
+ * side buttons and spacing are consistent between the two
+ */
+export const ConversationMessage = React.forwardRef<
+  HTMLDivElement,
+  ConversationMessageProps
+>(
+  (
+    {
+      avatarBusy = false,
+      buttons,
+      children,
+      citations,
+      isDisabled = false,
+      name,
+      timestamp,
+      pictureUrl,
+      renderName = (name) => <span>{name}</span>,
+      infoChip,
+      type,
+      className,
+      ...props
+    },
+    ref
+  ) => {
+    return (
+      <div ref={ref} className="group/message">
+        <div className={cn(messageVariants({ type, className }))} {...props}>
+          <ConversationMessageHeader
+            avatarUrl={pictureUrl}
+            name={name}
+            timestamp={timestamp}
+            isBusy={avatarBusy}
+            isDisabled={isDisabled}
+            renderName={renderName}
+            infoChip={infoChip}
+            type={type}
+          />
+
+          <ConversationMessageContent citations={citations} type={type}>
+            {children}
+          </ConversationMessageContent>
+        </div>
+        {buttons && (
+          <div className={cn(buttonsVariants({ type, className }))}>
+            {buttons}
+          </div>
+        )}
+      </div>
+    );
+  }
+);
+
+ConversationMessage.displayName = "ConversationMessage";
+
+interface ConversationMessageContentProps
+  extends React.HTMLAttributes<HTMLDivElement> {
+  children: React.ReactNode;
+  citations?: React.ReactElement[];
+  type: ConversationMessageType;
+}
+
+export const ConversationMessageContent = React.forwardRef<
+  HTMLDivElement,
+  ConversationMessageContentProps
+>(({ children, citations, className, type, ...props }, ref) => {
+  return (
+    <div
+      ref={ref}
+      className={cn("flex flex-col gap-3 @sm/conversation:gap-4", className)}
+      {...props}
+    >
+      <div
+        className={cn(
+          "text-sm @sm:text-base",
+          "text-foreground dark:text-foreground-night",
+          type !== "agentAsTool" && "@md:px-4"
+        )}
+      >
+        {children}
+      </div>
+      {citations && citations.length > 0 && (
+        <CitationGrid>{citations}</CitationGrid>
+      )}
+    </div>
+  );
+});
+
+ConversationMessageContent.displayName = "ConversationMessageContent";
+
+interface ConversationMessageHeaderProps
+  extends React.HTMLAttributes<HTMLDivElement> {
+  avatarUrl?: string | React.ReactNode;
+  isBusy?: boolean;
+  isDisabled?: boolean;
+  name?: string;
+  timestamp?: string;
+  infoChip?: React.ReactNode;
+  renderName: (name: string | null) => React.ReactNode;
+  type: ConversationMessageType;
+}
+
+export const ConversationMessageHeader = React.forwardRef<
+  HTMLDivElement,
+  ConversationMessageHeaderProps
+>(
+  (
+    {
+      avatarUrl,
+      isBusy,
+      isDisabled,
+      name = "",
+      timestamp,
+      infoChip,
+      type,
+      renderName,
+      className,
+      ...props
+    },
+    ref
+  ) => {
+    return (
+      <div
+        ref={ref}
+        className={cn(
+          "flex items-center gap-2 p-1 @sm/conversation:p-0",
+          className
+        )}
+        {...props}
+      >
+        {type !== "agentAsTool" && (
+          <>
+            <Avatar
+              className="@sm:hidden"
+              name={name}
+              visual={avatarUrl}
+              busy={isBusy}
+              disabled={isDisabled}
+              size="xs"
+            />
+            <Avatar
+              className="hidden @sm:flex"
+              name={name}
+              visual={avatarUrl}
+              busy={isBusy}
+              disabled={isDisabled}
+              size="sm"
+            />
+          </>
+        )}
+        <div className="flex w-full flex-row justify-between gap-0.5">
+          <div
+            className={cn(
+              "heading-sm @sm:text-base",
+              "text-foreground dark:text-foreground-night",
+              "flex flex-row items-center gap-2"
+            )}
+          >
+            {renderName(name)}
+            {infoChip}
+            <span className="text-xs font-normal text-muted-foreground dark:text-muted-foreground-night">
+              {timestamp}
+            </span>
+          </div>
+        </div>
+      </div>
+    );
+  }
+);
+
+ConversationMessageHeader.displayName = "ConversationMessageHeader";

--- a/front/components/assistant/conversation/MessageGroup.tsx
+++ b/front/components/assistant/conversation/MessageGroup.tsx
@@ -28,6 +28,13 @@ const MAX_OFFSET_PIXEL = 600;
 
 export const LAST_MESSAGE_GROUP_ID = "last-message-group";
 
+const isHandoverUserMessage = (message: MessageWithContentFragmentsType) => {
+  return (
+    message.type === "user_message" &&
+    message.context.origin === "agent_handover"
+  );
+};
+
 export default function MessageGroup({
   messages,
   isLastMessageGroup,
@@ -42,6 +49,9 @@ export default function MessageGroup({
 }: MessageGroupProps) {
   const lastMessageGroupRef = useRef<HTMLDivElement>(null);
 
+  console.log("SOUPINOU");
+  console.log(messages);
+
   const offset = Math.min(
     window.innerHeight * VIEWPORT_OFFSET_RATIO,
     MAX_OFFSET_PIXEL
@@ -54,10 +64,12 @@ export default function MessageGroup({
     }
   }, [isLastMessageGroup]);
 
+  const isHandoverGroup = messages.some((message) =>
+    isHandoverUserMessage(message)
+  );
+
   const filteredMessages = messages.filter(
-    (message) =>
-      message.type !== "user_message" ||
-      message.context.origin !== "agent_handover"
+    (message) => !isHandoverUserMessage(message)
   );
 
   return (
@@ -81,6 +93,7 @@ export default function MessageGroup({
           }
           user={user}
           isLastMessage={latestPage?.messages.at(-1)?.sId === message.sId}
+          isHandoverGroup={isHandoverGroup}
         />
       ))}
     </div>

--- a/front/components/assistant/conversation/MessageItem.tsx
+++ b/front/components/assistant/conversation/MessageItem.tsx
@@ -26,6 +26,7 @@ interface MessageItemProps {
   message: MessageWithContentFragmentsType;
   owner: WorkspaceType;
   user: UserType;
+  isHandoverGroup: boolean;
 }
 
 const MessageItem = React.forwardRef<HTMLDivElement, MessageItemProps>(
@@ -34,6 +35,7 @@ const MessageItem = React.forwardRef<HTMLDivElement, MessageItemProps>(
       conversationId,
       messageFeedback,
       isLastMessage,
+      isHandoverGroup,
       message,
       owner,
       user,
@@ -141,6 +143,7 @@ const MessageItem = React.forwardRef<HTMLDivElement, MessageItemProps>(
             <AgentMessage
               conversationId={conversationId}
               isLastMessage={isLastMessage}
+              isHandoverGroup={isHandoverGroup}
               message={message}
               messageFeedback={messageFeedbackWithSubmit}
               owner={owner}

--- a/front/components/assistant/conversation/UserMessage.tsx
+++ b/front/components/assistant/conversation/UserMessage.tsx
@@ -1,16 +1,11 @@
-import {
-  Avatar,
-  ClockIcon,
-  ConversationMessage,
-  Markdown,
-  Tooltip,
-} from "@dust-tt/sparkle";
+import { Avatar, ClockIcon, Markdown, Tooltip } from "@dust-tt/sparkle";
 import { BellIcon } from "lucide-react";
 import { useMemo } from "react";
 import type { Components } from "react-markdown";
 import type { PluggableList } from "react-markdown/lib/react-markdown";
 
 import { AgentSuggestion } from "@app/components/assistant/conversation/AgentSuggestion";
+import { ConversationMessage } from "@app/components/assistant/conversation/ConversationMessage";
 import {
   CiteBlock,
   getCiteDirective,

--- a/front/components/assistant/conversation/actions/AgentMessageActions.tsx
+++ b/front/components/assistant/conversation/actions/AgentMessageActions.tsx
@@ -28,6 +28,7 @@ interface AgentMessageActionsProps {
   lastAgentStateClassification: AgentStateClassification;
   actionProgress: ActionProgressState;
   owner: LightWorkspaceType;
+  isDustDeepHandoverGroup: boolean;
 }
 
 export function AgentMessageActions({
@@ -35,6 +36,7 @@ export function AgentMessageActions({
   lastAgentStateClassification,
   actionProgress,
   owner,
+  isDustDeepHandoverGroup = false,
 }: AgentMessageActionsProps) {
   const { openPanel, currentPanel, data } = useConversationSidePanelContext();
 
@@ -126,7 +128,9 @@ export function AgentMessageActions({
     <div className="flex flex-col items-start gap-y-4">
       <Button
         size="xs"
-        label="Message Breakdown"
+        label={
+          isDustDeepHandoverGroup ? "Deep Dive Breakdown" : "Message Breakdown"
+        }
         icon={CommandLineIcon}
         variant={data === agentMessage.sId ? "primary" : "outline"}
         onClick={onClick}

--- a/front/pages/poke/[wId]/conversations/[cId]/index.tsx
+++ b/front/pages/poke/[wId]/conversations/[cId]/index.tsx
@@ -2,7 +2,6 @@ import {
   Button,
   CheckIcon,
   CodeBlock,
-  ConversationMessage,
   Markdown,
   Page,
   Popover,
@@ -13,6 +12,7 @@ import type { InferGetServerSidePropsType } from "next";
 import type { ReactElement } from "react";
 import { useState } from "react";
 
+import { ConversationMessage } from "@app/components/assistant/conversation/ConversationMessage";
 import PokeLayout from "@app/components/poke/PokeLayout";
 import { withSuperUserAuthRequirements } from "@app/lib/iam/session";
 import type { Action } from "@app/lib/registry";


### PR DESCRIPTION
## Description

Goal: move ConversationMessage from Sparkle to front.
Rationale: this is not that much a reusable component and it takes too much friction to edit it in Sparkle. 

No change on the component from its current definition on Sparkle, only changes are only updating the import and removing the "s-" prefixed classes. 

I will remove it from Sparkle on a dedicated PR. 

## Tests

Locally. 

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

Deploy front. 