### PR TITLE
[front] enh(FS tools): expose `searchNodes` error in `list`

### DIFF
--- a/front/lib/actions/mcp_internal_actions/tools/data_sources_file_system/list.ts
+++ b/front/lib/actions/mcp_internal_actions/tools/data_sources_file_system/list.ts
@@ -189,7 +189,11 @@ export function registerListTool(
         }
 
         if (searchResult.isErr()) {
-          return new Err(new MCPError("Failed to list folder contents"));
+          return new Err(
+            new MCPError(
+              `Failed to list folder contents: ${searchResult.error.message}`
+            )
+          );
         }
 
         return new Ok([


### PR DESCRIPTION
## Description

- The error from core is currently swallowed.

## Tests

## Risk

- Low.

## Deploy Plan

- Deploy front.
