### PR TITLE
Support making queries from Poke

### DIFF
--- a/front/pages/api/poke/workspaces/[wId]/data_sources/[dsId]/query.ts
+++ b/front/pages/api/poke/workspaces/[wId]/data_sources/[dsId]/query.ts
@@ -1,0 +1,126 @@
+import type { NextApiRequest, NextApiResponse } from "next";
+
+import { withSessionAuthenticationForPoke } from "@app/lib/api/auth_wrappers";
+import config from "@app/lib/api/config";
+import { Authenticator } from "@app/lib/auth";
+import type { SessionWithUser } from "@app/lib/iam/provider";
+import { DataSourceResource } from "@app/lib/resources/data_source_resource";
+import logger from "@app/logger/logger";
+import { apiError } from "@app/logger/withlogging";
+import type { WithAPIErrorResponse } from "@app/types";
+import { CoreAPI } from "@app/types";
+
+type QueryResponseType = {
+  schema: Array<{
+    name: string;
+    value_type: string;
+  }>;
+  results: Array<Record<string, string | number | boolean | null | undefined>>;
+};
+
+async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse<WithAPIErrorResponse<QueryResponseType>>,
+  session: SessionWithUser
+): Promise<void> {
+  const auth = await Authenticator.fromSuperUserSession(
+    session,
+    req.query.wId as string
+  );
+
+  if (!auth.isDustSuperUser()) {
+    return apiError(req, res, {
+      status_code: 404,
+      api_error: {
+        type: "data_source_not_found",
+        message: "The data source you requested was not found.",
+      },
+    });
+  }
+
+  const { dsId } = req.query;
+  if (typeof dsId !== "string") {
+    return apiError(req, res, {
+      status_code: 400,
+      api_error: {
+        type: "invalid_request_error",
+        message: "Invalid path parameters.",
+      },
+    });
+  }
+
+  const dataSource = await DataSourceResource.fetchById(auth, dsId);
+  if (!dataSource) {
+    return apiError(req, res, {
+      status_code: 404,
+      api_error: {
+        type: "data_source_not_found",
+        message: "The data source you requested was not found.",
+      },
+    });
+  }
+
+  switch (req.method) {
+    case "POST": {
+      const { query, tableIds } = req.body;
+
+      if (!query || typeof query !== "string") {
+        return apiError(req, res, {
+          status_code: 400,
+          api_error: {
+            type: "invalid_request_error",
+            message: "Query is required and must be a string.",
+          },
+        });
+      }
+
+      if (!Array.isArray(tableIds) || tableIds.length === 0) {
+        return apiError(req, res, {
+          status_code: 400,
+          api_error: {
+            type: "invalid_request_error",
+            message: "At least one table ID is required.",
+          },
+        });
+      }
+
+      const coreAPI = new CoreAPI(config.getCoreAPIConfig(), logger);
+
+      const tables = tableIds.map((tableId: string) => ({
+        project_id: parseInt(dataSource.dustAPIProjectId, 10),
+        data_source_id: dataSource.dustAPIDataSourceId,
+        table_id: tableId,
+      }));
+
+      const queryResult = await coreAPI.queryDatabase({
+        tables,
+        query,
+      });
+
+      if (queryResult.isErr()) {
+        return apiError(req, res, {
+          status_code: 400,
+          api_error: {
+            type: "data_source_error",
+            message: queryResult.error.message,
+          },
+        });
+      }
+
+      return res.json({
+        schema: queryResult.value.schema,
+        results: queryResult.value.results.map((r) => r.value),
+      });
+    }
+    default:
+      return apiError(req, res, {
+        status_code: 405,
+        api_error: {
+          type: "method_not_supported_error",
+          message: "The method passed is not supported, POST is expected.",
+        },
+      });
+  }
+}
+
+export default withSessionAuthenticationForPoke(handler);

--- a/front/pages/poke/[wId]/data_sources/[dsId]/index.tsx
+++ b/front/pages/poke/[wId]/data_sources/[dsId]/index.tsx
@@ -606,6 +606,32 @@ const DataSourcePage = ({
               label="Search Data"
               icon={LockIcon}
             />
+            {[
+              "bigquery",
+              "microsoft",
+              "notion",
+              "salesforce",
+              "snowflake",
+              "google_drive",
+            ].includes(dataSource.connectorProvider ?? "") ||
+            !dataSource.connectorProvider ? (
+              <Button
+                variant="outline"
+                onClick={() => {
+                  if (
+                    window.confirm(
+                      "Are you sure you want to access this sensitive user data? (Access will be logged)"
+                    )
+                  ) {
+                    void router.push(
+                      `/poke/${owner.sId}/data_sources/${dataSource.sId}/query`
+                    );
+                  }
+                }}
+                label="Query Data"
+                icon={LockIcon}
+              />
+            ) : null}
             {dataSource.connectorProvider === "notion" && (
               <NotionUrlCheckOrFind owner={owner} dsId={dataSource.sId} />
             )}

--- a/front/pages/poke/[wId]/data_sources/[dsId]/query.tsx
+++ b/front/pages/poke/[wId]/data_sources/[dsId]/query.tsx
@@ -1,0 +1,286 @@
+import {
+  Button,
+  Checkbox,
+  Chip,
+  Spinner,
+  TextArea,
+} from "@dust-tt/sparkle";
+import type { InferGetServerSidePropsType } from "next";
+import type { ReactElement } from "react";
+import { useState } from "react";
+
+import PokeLayout from "@app/components/poke/PokeLayout";
+import { withSuperUserAuthRequirements } from "@app/lib/iam/session";
+import { DataSourceResource } from "@app/lib/resources/data_source_resource";
+import { usePokeTables } from "@app/poke/swr";
+import type { DataSourceType, WorkspaceType } from "@app/types";
+
+export const getServerSideProps = withSuperUserAuthRequirements<{
+  owner: WorkspaceType;
+  dataSource: DataSourceType;
+}>(async (context, auth) => {
+  const owner = auth.getNonNullableWorkspace();
+
+  const { dsId } = context.params || {};
+  if (typeof dsId !== "string") {
+    return {
+      notFound: true,
+    };
+  }
+
+  const dataSource = await DataSourceResource.fetchById(auth, dsId, {
+    includeEditedBy: true,
+  });
+  if (!dataSource) {
+    return {
+      notFound: true,
+    };
+  }
+
+  return {
+    props: {
+      owner,
+      dataSource: dataSource.toJSON(),
+    },
+  };
+});
+
+type QueryResult = {
+  schema: Array<{
+    name: string;
+    value_type: string;
+  }>;
+  results: Array<Record<string, string | number | boolean | null | undefined>>;
+};
+
+export default function DataSourceQueryPage({
+  owner,
+  dataSource,
+}: InferGetServerSidePropsType<typeof getServerSideProps>) {
+  const [query, setQuery] = useState("");
+  const [selectedTables, setSelectedTables] = useState<Set<string>>(new Set());
+  const [isExecuting, setIsExecuting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [queryResult, setQueryResult] = useState<QueryResult | null>(null);
+
+  const { tables, total: totalTables } = usePokeTables(
+    owner,
+    dataSource,
+    1000,
+    0
+  );
+
+  const handleTableToggle = (tableId: string) => {
+    setSelectedTables((prev) => {
+      const newSet = new Set(prev);
+      if (newSet.has(tableId)) {
+        newSet.delete(tableId);
+      } else {
+        newSet.add(tableId);
+      }
+      return newSet;
+    });
+  };
+
+  const handleExecuteQuery = async () => {
+    if (!query.trim()) {
+      setError("Please enter a query");
+      return;
+    }
+
+    if (selectedTables.size === 0) {
+      setError("Please select at least one table");
+      return;
+    }
+
+    setIsExecuting(true);
+    setError(null);
+    setQueryResult(null);
+
+    try {
+      const response = await fetch(
+        `/api/poke/workspaces/${owner.sId}/data_sources/${dataSource.sId}/query`,
+        {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+          },
+          body: JSON.stringify({
+            query,
+            tableIds: Array.from(selectedTables),
+          }),
+        }
+      );
+
+      if (!response.ok) {
+        const errorData = await response.json();
+        throw new Error(
+          errorData.error?.message || "Failed to execute query"
+        );
+      }
+
+      const result = await response.json();
+      setQueryResult(result);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "An error occurred");
+    } finally {
+      setIsExecuting(false);
+    }
+  };
+
+  return (
+    <div className="max-w-6xl">
+      <h3 className="text-xl font-bold">
+        Query Data Source {dataSource.name} in workspace{" "}
+        <a href={`/poke/${owner.sId}`} className="text-highlight-500">
+          {owner.name}
+        </a>
+      </h3>
+
+      <div className="mt-6 flex flex-col gap-6">
+        {/* Table Selection */}
+        <div className="border-material-200 rounded-lg border p-4">
+          <h4 className="mb-3 text-lg font-semibold">Select Tables</h4>
+          <div className="text-sm text-gray-600">
+            {totalTables} table{totalTables !== 1 ? "s" : ""} available
+          </div>
+          <div className="mt-4 max-h-96 space-y-2 overflow-y-auto">
+            {tables.length > 0 ? (
+              tables.map((table) => (
+                <div key={table.table_id} className="flex items-center gap-2">
+                  <Checkbox
+                    checked={selectedTables.has(table.table_id)}
+                    onCheckedChange={() => handleTableToggle(table.table_id)}
+                  />
+                  <span className="text-sm">{table.name}</span>
+                  {table.description && (
+                    <span className="text-xs text-gray-500">
+                      - {table.description}
+                    </span>
+                  )}
+                </div>
+              ))
+            ) : (
+              <div className="text-sm text-gray-500">
+                No tables available for this data source
+              </div>
+            )}
+          </div>
+          {selectedTables.size > 0 && (
+            <div className="mt-3 flex flex-wrap gap-2">
+              <span className="text-sm text-gray-600">Selected:</span>
+              {Array.from(selectedTables).map((tableId) => {
+                const table = tables.find((t) => t.table_id === tableId);
+                return (
+                  <Chip
+                    key={tableId}
+                    label={table?.name ?? tableId}
+                    color="info"
+                  />
+                );
+              })}
+            </div>
+          )}
+        </div>
+
+        {/* Query Input */}
+        <div className="border-material-200 rounded-lg border p-4">
+          <h4 className="mb-3 text-lg font-semibold">SQL Query</h4>
+          <TextArea
+            value={query}
+            onChange={(e: React.ChangeEvent<HTMLTextAreaElement>) =>
+              setQuery(e.target.value)
+            }
+            placeholder="Enter your SQL query here...&#10;Example: SELECT * FROM table_name LIMIT 10"
+            className="min-h-32 w-full font-mono text-sm"
+          />
+          <div className="mt-3 flex items-center gap-3">
+            <Button
+              variant="primary"
+              onClick={handleExecuteQuery}
+              disabled={isExecuting || selectedTables.size === 0}
+              label={isExecuting ? "Executing..." : "Execute Query"}
+              icon={isExecuting ? Spinner : undefined}
+            />
+            {selectedTables.size === 0 && (
+              <span className="text-sm text-gray-500">
+                Select at least one table to execute queries
+              </span>
+            )}
+          </div>
+        </div>
+
+        {/* Error Display */}
+        {error && (
+          <div className="rounded-lg border border-red-300 bg-red-50 p-4">
+            <p className="text-sm font-semibold text-red-800">Error</p>
+            <p className="mt-1 text-sm text-red-700">{error}</p>
+          </div>
+        )}
+
+        {/* Results Display */}
+        {queryResult && (
+          <div className="border-material-200 rounded-lg border p-4">
+            <h4 className="mb-3 text-lg font-semibold">Results</h4>
+            <div className="mb-2 text-sm text-gray-600">
+              {queryResult.results.length} row
+              {queryResult.results.length !== 1 ? "s" : ""} returned
+            </div>
+            {queryResult.results.length > 0 ? (
+              <div className="overflow-x-auto">
+                <table className="min-w-full divide-y divide-gray-200">
+                  <thead className="bg-gray-50">
+                    <tr>
+                      {queryResult.schema.map((column) => (
+                        <th
+                          key={column.name}
+                          className="px-4 py-3 text-left text-xs font-medium uppercase tracking-wider text-gray-500"
+                        >
+                          <div>{column.name}</div>
+                          <div className="text-xs font-normal normal-case text-gray-400">
+                            {column.value_type}
+                          </div>
+                        </th>
+                      ))}
+                    </tr>
+                  </thead>
+                  <tbody className="divide-y divide-gray-200 bg-white">
+                    {queryResult.results.map((row, rowIndex) => (
+                      <tr key={rowIndex} className="hover:bg-gray-50">
+                        {queryResult.schema.map((column) => (
+                          <td
+                            key={column.name}
+                            className="whitespace-nowrap px-4 py-2 text-sm text-gray-900"
+                          >
+                            {row[column.name] === null
+                              ? "NULL"
+                              : row[column.name] === undefined
+                                ? "-"
+                                : String(row[column.name])}
+                          </td>
+                        ))}
+                      </tr>
+                    ))}
+                  </tbody>
+                </table>
+              </div>
+            ) : (
+              <div className="text-sm text-gray-500">No results returned</div>
+            )}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}
+
+DataSourceQueryPage.getLayout = (
+  page: ReactElement,
+  { owner, dataSource }: { owner: WorkspaceType; dataSource: DataSourceType }
+) => {
+  return (
+    <PokeLayout title={`${owner.name} - Query ${dataSource.name}`}>
+      {page}
+    </PokeLayout>
+  );
+};

--- a/front/pages/poke/[wId]/data_sources/[dsId]/query.tsx
+++ b/front/pages/poke/[wId]/data_sources/[dsId]/query.tsx
@@ -1,10 +1,4 @@
-import {
-  Button,
-  Checkbox,
-  Chip,
-  Spinner,
-  TextArea,
-} from "@dust-tt/sparkle";
+import { Button, Checkbox, Chip, Spinner, TextArea } from "@dust-tt/sparkle";
 import type { InferGetServerSidePropsType } from "next";
 import type { ReactElement } from "react";
 import { useState } from "react";
@@ -114,9 +108,7 @@ export default function DataSourceQueryPage({
 
       if (!response.ok) {
         const errorData = await response.json();
-        throw new Error(
-          errorData.error?.message || "Failed to execute query"
-        );
+        throw new Error(errorData.error?.message || "Failed to execute query");
       }
 
       const result = await response.json();


### PR DESCRIPTION
## Description

Added a Query Data button on Poke's datasource page. It opens a new page that allows making queries. This works both on local and remote datasource tables.

It's super useful for debugging table query issues. The only question is: does that give too much power in case Poke is compromised?

## Tests

Manual.

## Risk

Giving too much power to Poke users. Needs discussion.

## Deploy Plan

Front.