### PR TITLE
[HOOTL] Set triggers as non valid data source view category

### DIFF
--- a/front/types/api/public/spaces.ts
+++ b/front/types/api/public/spaces.ts
@@ -61,6 +61,7 @@ export function isDataSourceViewCategoryWithoutApps(
 ): category is DataSourceViewCategoryWithoutApps {
   return (
     isValidDataSourceViewCategory(category) &&
+    category !== "triggers" &&
     category !== "apps" &&
     category !== "actions"
   );


### PR DESCRIPTION
## Description

<img width="1673" height="988" alt="Screenshot 2025-10-03 at 10 11 34" src="https://github.com/user-attachments/assets/e5c26c8d-3a3d-42b1-8811-d40d5b741a13" />

Remove this category in Agent builder data source selector (feature flag or not)

## Tests

Visual

## Risk

Low

## Deploy Plan

front
