### PR TITLE
Display the agents using the webhook in the webhooks list view

### DIFF
--- a/front/components/spaces/SystemSpaceTriggersList.tsx
+++ b/front/components/spaces/SystemSpaceTriggersList.tsx
@@ -1,25 +1,29 @@
 import { useMemo, useState } from "react";
 
+import { AssistantDetails } from "@app/components/assistant/details/AssistantDetails";
 import { AdminTriggersList } from "@app/components/triggers/AdminTriggersList";
 import { WebhookSourceDetails } from "@app/components/triggers/WebhookSourceDetails";
 import { useQueryParams } from "@app/hooks/useQueryParams";
 import { useWebhookSourcesWithViews } from "@app/lib/swr/webhook_source";
-import type { LightWorkspaceType, SpaceType } from "@app/types";
+import type { LightWorkspaceType, SpaceType, UserType } from "@app/types";
 
 interface SpaceActionsListProps {
   isAdmin: boolean;
   owner: LightWorkspaceType;
   space: SpaceType;
+  user: UserType;
 }
 
 export const SystemSpaceTriggersList = ({
   owner,
   isAdmin,
   space,
+  user,
 }: SpaceActionsListProps) => {
   const [selectedWebhookSourceId, setSelectedWebhookSourceId] = useState<
     string | null
   >(null);
+  const [agentSId, setAgentSId] = useState<string | null>(null);
 
   const { webhookSourcesWithViews, isWebhookSourcesWithViewsLoading } =
     useWebhookSourcesWithViews({
@@ -62,6 +66,12 @@ export const SystemSpaceTriggersList = ({
 
   return (
     <>
+      <AssistantDetails
+        owner={owner}
+        user={user}
+        assistantId={agentSId}
+        onClose={() => setAgentSId(null)}
+      />
       {selectedWebhookSource?.systemView && (
         <WebhookSourceDetails
           owner={owner}
@@ -76,6 +86,7 @@ export const SystemSpaceTriggersList = ({
         setSelectedWebhookSourceId={setSelectedWebhookSourceId}
         webhookSourcesWithSystemView={webhookSourcesWithSystemView}
         isWebhookSourcesWithViewsLoading={isWebhookSourcesWithViewsLoading}
+        setAgentSId={setAgentSId}
       />
     </>
   );

--- a/front/lib/api/agent_triggers.test.ts
+++ b/front/lib/api/agent_triggers.test.ts
@@ -1,0 +1,149 @@
+import { describe, expect, it } from "vitest";
+
+import { TriggerModel } from "@app/lib/models/assistant/triggers/triggers";
+import { AgentConfigurationFactory } from "@app/tests/utils/AgentConfigurationFactory";
+import { createResourceTest } from "@app/tests/utils/generic_resource_tests";
+import { WebhookSourceViewFactory } from "@app/tests/utils/WebhookSourceViewFactory";
+
+import { getWebhookSourcesUsage } from "./agent_triggers";
+
+describe("getWebhookSourcesUsage", () => {
+  it("returns webhook source usage for accessible agents", async () => {
+    const { workspace, authenticator, systemSpace, user } =
+      await createResourceTest({
+        role: "admin",
+      });
+
+    const agent = await AgentConfigurationFactory.createTestAgent(
+      authenticator,
+      {
+        name: "Agent One",
+      }
+    );
+
+    const webhookSourceViewFactory = new WebhookSourceViewFactory(workspace);
+    const systemView = await webhookSourceViewFactory.create(systemSpace);
+
+    const webhookSourceViewId = Number(systemView.id);
+    const webhookSourceId = Number(systemView.webhookSourceId);
+
+    await TriggerModel.create({
+      workspaceId: workspace.id,
+      name: "Webhook Usage Trigger",
+      kind: "webhook",
+      agentConfigurationId: agent.sId,
+      editor: user.id,
+      customPrompt: null,
+      enabled: true,
+      configuration: { includePayload: true },
+      webhookSourceViewId,
+    });
+
+    const usage = await getWebhookSourcesUsage({ auth: authenticator });
+
+    expect(Object.keys(usage)).toEqual([String(webhookSourceId)]);
+    expect(usage[webhookSourceId]).toEqual({
+      count: 1,
+      agents: [
+        {
+          sId: agent.sId,
+          name: agent.name,
+        },
+      ],
+    });
+  });
+
+  it("returns empty usage when trigger references no accessible agent", async () => {
+    const { workspace, authenticator, systemSpace, user } =
+      await createResourceTest({
+        role: "admin",
+      });
+
+    const webhookSourceViewFactory = new WebhookSourceViewFactory(workspace);
+    const systemView = await webhookSourceViewFactory.create(systemSpace);
+
+    const webhookSourceViewId = Number(systemView.id);
+
+    await TriggerModel.create({
+      workspaceId: workspace.id,
+      name: "Orphan Trigger",
+      kind: "webhook",
+      agentConfigurationId: "non-existent-agent",
+      editor: user.id,
+      customPrompt: null,
+      enabled: true,
+      configuration: { includePayload: true },
+      webhookSourceViewId,
+    });
+
+    const usage = await getWebhookSourcesUsage({ auth: authenticator });
+
+    expect(usage).toEqual({});
+  });
+
+  it("aggregates multiple agents linked to the same webhook source", async () => {
+    const { workspace, authenticator, systemSpace, user } =
+      await createResourceTest({
+        role: "admin",
+      });
+
+    const agentBeta = await AgentConfigurationFactory.createTestAgent(
+      authenticator,
+      {
+        name: "Beta Agent",
+      }
+    );
+    const agentAlpha = await AgentConfigurationFactory.createTestAgent(
+      authenticator,
+      {
+        name: "Alpha Agent",
+      }
+    );
+
+    const webhookSourceViewFactory = new WebhookSourceViewFactory(workspace);
+    const systemView = await webhookSourceViewFactory.create(systemSpace);
+
+    const webhookSourceViewId = Number(systemView.id);
+    const webhookSourceId = Number(systemView.webhookSourceId);
+
+    await TriggerModel.create({
+      workspaceId: workspace.id,
+      name: "Webhook Usage Trigger Beta",
+      kind: "webhook",
+      agentConfigurationId: agentBeta.sId,
+      editor: user.id,
+      customPrompt: null,
+      enabled: true,
+      configuration: { includePayload: true },
+      webhookSourceViewId,
+    });
+
+    await TriggerModel.create({
+      workspaceId: workspace.id,
+      name: "Webhook Usage Trigger Alpha",
+      kind: "webhook",
+      agentConfigurationId: agentAlpha.sId,
+      editor: user.id,
+      customPrompt: null,
+      enabled: true,
+      configuration: { includePayload: true },
+      webhookSourceViewId,
+    });
+
+    const usage = await getWebhookSourcesUsage({ auth: authenticator });
+
+    expect(usage[webhookSourceId]).toEqual({
+      count: 2,
+      agents: [
+        {
+          sId: agentAlpha.sId,
+          name: agentAlpha.name,
+        },
+        {
+          sId: agentBeta.sId,
+          name: agentBeta.name,
+        },
+      ],
+    });
+  });
+});

--- a/front/lib/api/agent_triggers.ts
+++ b/front/lib/api/agent_triggers.ts
@@ -1,0 +1,215 @@
+import { Op } from "sequelize";
+
+import type { Authenticator } from "@app/lib/auth";
+import { AgentConfiguration } from "@app/lib/models/assistant/agent";
+import { TriggerModel } from "@app/lib/models/assistant/triggers/triggers";
+import { WebhookSourcesViewModel } from "@app/lib/models/assistant/triggers/webhook_sources_view";
+import { GroupResource } from "@app/lib/resources/group_resource";
+import type { AgentsUsageType, ModelId } from "@app/types";
+
+// To use in case of heavy db load emergency with these usages queries
+// If it is a problem, let's add caching
+const DISABLE_QUERIES = false;
+
+export type WebhookSourcesUsage = Record<ModelId, AgentsUsageType>;
+
+async function getAccessibleAgentsInfoBySId({
+  auth,
+}: {
+  auth: Authenticator;
+}): Promise<Map<string, { sId: string; name: string }>> {
+  const owner = auth.workspace();
+
+  if (!owner || !auth.isUser()) {
+    return new Map();
+  }
+
+  const getAgentsForUser = async () =>
+    (
+      await GroupResource.findAgentIdsForGroups(
+        auth,
+        auth
+          .groups()
+          .filter((g) => g.kind === "agent_editors")
+          .map((g) => g.id)
+      )
+    ).map((g) => g.agentConfigurationId);
+
+  const agentWhereClause = auth.isAdmin()
+    ? {
+        workspaceId: owner.id,
+        status: "active" as const,
+      }
+    : {
+        workspaceId: owner.id,
+        status: "active" as const,
+        [Op.or]: [
+          {
+            scope: "visible",
+          },
+          {
+            id: {
+              [Op.in]: await getAgentsForUser(),
+            },
+          },
+        ],
+      };
+
+  const accessibleAgents = await AgentConfiguration.findAll({
+    attributes: ["id", "sId", "name"],
+    where: agentWhereClause,
+  });
+
+  return new Map(
+    accessibleAgents.map((agent) => [
+      agent.sId,
+      { sId: agent.sId, name: agent.name },
+    ])
+  );
+}
+
+async function getTriggersWithAgentAccesibleAgent({
+  auth,
+  agentInfoBySId,
+}: {
+  auth: Authenticator;
+  agentInfoBySId: Map<string, { sId: string; name: string }>;
+}): Promise<
+  Array<{
+    webhookSourceViewId: number | string | null;
+    agentConfigurationId: string;
+  }>
+> {
+  const owner = auth.workspace();
+
+  if (!owner) {
+    return [];
+  }
+
+  const triggers = (await TriggerModel.findAll({
+    raw: true,
+    attributes: ["webhookSourceViewId", "agentConfigurationId"],
+    where: {
+      workspaceId: owner.id,
+      kind: "webhook",
+      enabled: true,
+      webhookSourceViewId: {
+        [Op.ne]: null,
+      },
+    },
+  })) as Array<{
+    webhookSourceViewId: number | string | null;
+    agentConfigurationId: string;
+  }>;
+
+  return triggers.filter(
+    (trigger) =>
+      trigger.webhookSourceViewId !== null &&
+      agentInfoBySId.has(trigger.agentConfigurationId)
+  );
+}
+
+export async function getWebhookSourcesUsage({
+  auth,
+}: {
+  auth: Authenticator;
+}): Promise<WebhookSourcesUsage> {
+  const owner = auth.workspace();
+
+  if (!owner || !auth.isUser()) {
+    return {};
+  }
+
+  if (DISABLE_QUERIES) {
+    return {};
+  }
+
+  const agentInfoBySId = await getAccessibleAgentsInfoBySId({ auth });
+
+  if (agentInfoBySId.size === 0) {
+    return {};
+  }
+
+  const filteredTriggers = await getTriggersWithAgentAccesibleAgent({
+    auth,
+    agentInfoBySId,
+  });
+
+  if (filteredTriggers.length === 0) {
+    return {};
+  }
+
+  const viewIds = Array.from(
+    new Set(
+      filteredTriggers
+        .map((trigger) => Number(trigger.webhookSourceViewId))
+        .filter((id) => Number.isFinite(id))
+    )
+  ) as ModelId[];
+
+  if (viewIds.length === 0) {
+    return {};
+  }
+
+  const views = (await WebhookSourcesViewModel.findAll({
+    raw: true,
+    attributes: ["id", "webhookSourceId"],
+    where: {
+      workspaceId: owner.id,
+      id: {
+        [Op.in]: viewIds,
+      },
+    },
+  })) as Array<{ id: ModelId; webhookSourceId: ModelId }>;
+
+  const viewToSource = new Map<ModelId, ModelId>();
+  views.forEach((view) => {
+    viewToSource.set(view.id, view.webhookSourceId);
+  });
+
+  if (viewToSource.size === 0) {
+    return {};
+  }
+
+  const usageMap = new Map<ModelId, Map<string, string>>();
+
+  for (const trigger of filteredTriggers) {
+    const viewId = Number(trigger.webhookSourceViewId);
+    if (!Number.isFinite(viewId)) {
+      continue;
+    }
+
+    const sourceId = viewToSource.get(viewId);
+    if (!sourceId) {
+      continue;
+    }
+
+    const agentInfo = agentInfoBySId.get(trigger.agentConfigurationId);
+    if (!agentInfo) {
+      continue;
+    }
+
+    let agentsForSource = usageMap.get(sourceId);
+    if (!agentsForSource) {
+      agentsForSource = new Map<string, string>();
+      usageMap.set(sourceId, agentsForSource);
+    }
+
+    agentsForSource.set(agentInfo.sId, agentInfo.name);
+  }
+
+  const usage: WebhookSourcesUsage = {};
+
+  usageMap.forEach((agentsMap, sourceId) => {
+    const agents = Array.from(agentsMap.entries())
+      .map(([sId, name]) => ({ sId, name }))
+      .sort((a, b) => a.name.localeCompare(b.name));
+
+    usage[sourceId] = {
+      count: agents.length,
+      agents,
+    };
+  });
+
+  return usage;
+}

--- a/front/lib/swr/webhook_source.ts
+++ b/front/lib/swr/webhook_source.ts
@@ -63,8 +63,7 @@ export function useWebhookSourcesWithViews({
     }
   );
 
-  const webhookSourcesWithViews =
-    data?.webhookSourcesWithDetails ?? emptyArray();
+  const webhookSourcesWithViews = data?.webhookSourcesWithViews ?? emptyArray();
 
   return {
     webhookSourcesWithViews,

--- a/front/lib/swr/webhook_source.ts
+++ b/front/lib/swr/webhook_source.ts
@@ -63,7 +63,8 @@ export function useWebhookSourcesWithViews({
     }
   );
 
-  const webhookSourcesWithViews = data?.webhookSourcesWithViews ?? emptyArray();
+  const webhookSourcesWithViews =
+    data?.webhookSourcesWithDetails ?? emptyArray();
 
   return {
     webhookSourcesWithViews,

--- a/front/pages/api/w/[wId]/webhook_sources/index.ts
+++ b/front/pages/api/w/[wId]/webhook_sources/index.ts
@@ -19,7 +19,7 @@ import { PostWebhookSourcesSchema } from "@app/types/triggers/webhooks";
 
 export type GetWebhookSourcesResponseBody = {
   success: true;
-  webhookSourcesWithDetails: WebhookSourceWithViewsAndUsage[];
+  webhookSourcesWithViews: WebhookSourceWithViewsAndUsage[];
 };
 
 export type PostWebhookSourcesResponseBody = {
@@ -69,7 +69,7 @@ async function handler(
 
         return res.status(200).json({
           success: true,
-          webhookSourcesWithDetails: webhookSourcesWithViews.map((source) => ({
+          webhookSourcesWithViews: webhookSourcesWithViews.map((source) => ({
             ...source,
             usage: usageBySourceId[source.id] ?? { count: 0, agents: [] },
           })),

--- a/front/pages/w/[wId]/spaces/[spaceId]/categories/triggers/index.tsx
+++ b/front/pages/w/[wId]/spaces/[spaceId]/categories/triggers/index.tsx
@@ -62,10 +62,16 @@ export default function Space({
   isAdmin,
   owner,
   space,
+  user,
 }: InferGetServerSidePropsType<typeof getServerSideProps>) {
   if (space.kind === "system") {
     return (
-      <SystemSpaceTriggersList isAdmin={isAdmin} owner={owner} space={space} />
+      <SystemSpaceTriggersList
+        isAdmin={isAdmin}
+        owner={owner}
+        space={space}
+        user={user}
+      />
     );
   }
 

--- a/front/types/triggers/webhooks.ts
+++ b/front/types/triggers/webhooks.ts
@@ -1,5 +1,6 @@
 import { z } from "zod";
 
+import type { AgentsUsageType } from "@app/types/data_source";
 import type { ModelId } from "@app/types/shared/model_id";
 import type { EditedByUser } from "@app/types/user";
 
@@ -42,6 +43,15 @@ export type WebhookSourceWithViews = WebhookSourceType & {
 export type WebhookSourceWithSystemView = WebhookSourceWithViews & {
   systemView: WebhookSourceViewType | null;
 };
+
+export type WebhookSourceWithViewsAndUsage = WebhookSourceWithViews & {
+  usage: AgentsUsageType | null;
+};
+
+export type WebhookSourceWithSystemViewAndUsage =
+  WebhookSourceWithSystemView & {
+    usage: AgentsUsageType | null;
+  };
 
 export type PostWebhookSourcesBody = z.infer<typeof PostWebhookSourcesSchema>;
 


### PR DESCRIPTION
## Description

Add a new API to get the agents per webhook
Add a "Used by" column in the webhooks view
Clicking on a agent name display the agent (similar to other menus)

<img width="861" height="393" alt="Screenshot 2025-09-30 at 18 16 10" src="https://github.com/user-attachments/assets/16a4b0af-4247-47da-9b23-56739e1938df" />


https://github.com/user-attachments/assets/ed053d64-9c58-44e9-9ff2-67b0449a0cf4


## Tests

Manually tested front
Unit tests for API 

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

deploy front
