### PR TITLE
[front] feat(cc): add support for renaming created files

### DIFF
--- a/front/lib/actions/mcp_internal_actions/servers/content_creation/index.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/content_creation/index.ts
@@ -7,6 +7,7 @@ import { MCPError } from "@app/lib/actions/mcp_errors";
 import {
   CREATE_CONTENT_CREATION_FILE_TOOL_NAME,
   EDIT_CONTENT_CREATION_FILE_TOOL_NAME,
+  RENAME_CONTENT_CREATION_FILE_TOOL_NAME,
   RETRIEVE_CONTENT_CREATION_FILE_TOOL_NAME,
   REVERT_CONTENT_CREATION_FILE_TOOL_NAME,
 } from "@app/lib/actions/mcp_internal_actions/servers/content_creation/types";
@@ -17,6 +18,7 @@ import {
   createClientExecutableFile,
   editClientExecutableFile,
   getClientExecutableFileContent,
+  renameClientExecutableFile,
   revertClientExecutableFileChanges,
 } from "@app/lib/api/files/client_executable";
 import type { Authenticator } from "@app/lib/auth";
@@ -335,6 +337,66 @@ const createServer = (
           {
             type: "text",
             text: `File '${fileResource.sId}' reverted successfully.`,
+          },
+        ]);
+      }
+    )
+  );
+
+  server.tool(
+    RENAME_CONTENT_CREATION_FILE_TOOL_NAME,
+    "Rename a Content Creation file. Use this to change the file name while keeping the content unchanged.",
+    {
+      file_id: z
+        .string()
+        .describe(
+          "The ID of the Content Creation file to rename (e.g., 'fil_abc123')"
+        ),
+      new_file_name: z
+        .string()
+        .describe(
+          "The new name for the file, including extension (e.g., 'UpdatedChart.tsx')"
+        ),
+    },
+    withToolLogging(
+      auth,
+      { toolName: RENAME_CONTENT_CREATION_FILE_TOOL_NAME, agentLoopContext },
+      async ({ file_id, new_file_name }, { sendNotification, _meta }) => {
+        const { agentConfiguration } = agentLoopContext?.runContext ?? {};
+
+        const result = await renameClientExecutableFile(auth, {
+          fileId: file_id,
+          newFileName: new_file_name,
+          renamedByAgentConfigurationId: agentConfiguration?.sId,
+        });
+
+        if (result.isErr()) {
+          return new Err(
+            new MCPError(result.error.message, {
+              tracked: result.error.tracked,
+            })
+          );
+        }
+
+        const fileResource = result.value;
+
+        const responseText = `File '${fileResource.sId}' renamed successfully to '${fileResource.fileName}'.`;
+
+        if (_meta?.progressToken) {
+          const notification: MCPProgressNotificationType =
+            buildContentCreationFileNotification(
+              _meta.progressToken,
+              fileResource,
+              "Renaming Content Creation file..."
+            );
+
+          await sendNotification(notification);
+        }
+
+        return new Ok([
+          {
+            type: "text",
+            text: responseText,
           },
         ]);
       }

--- a/front/lib/actions/mcp_internal_actions/servers/content_creation/instructions.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/content_creation/instructions.ts
@@ -11,6 +11,7 @@ import {
 import {
   CREATE_CONTENT_CREATION_FILE_TOOL_NAME,
   EDIT_CONTENT_CREATION_FILE_TOOL_NAME,
+  RENAME_CONTENT_CREATION_FILE_TOOL_NAME,
   RETRIEVE_CONTENT_CREATION_FILE_TOOL_NAME,
   REVERT_CONTENT_CREATION_FILE_TOOL_NAME,
 } from "@app/lib/actions/mcp_internal_actions/servers/content_creation/types";
@@ -34,6 +35,11 @@ You have access to a Content Creation system that allows you to create and updat
 
 ### Reverting Files:
 - Use \`${REVERT_CONTENT_CREATION_FILE_TOOL_NAME}\` to revert the edits made in the last agent message.
+
+### Renaming Files:
+- Use \`${RENAME_CONTENT_CREATION_FILE_TOOL_NAME}\` to rename an existing Content Creation file
+- The new file name must include a valid extension (e.g., .js, .jsx, .ts, .tsx)
+- Renaming only changes the file name; the content remains unchanged
 
 ${VIZ_REACT_COMPONENT_GUIDELINES}
 

--- a/front/lib/actions/mcp_internal_actions/servers/content_creation/types.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/content_creation/types.ts
@@ -6,3 +6,5 @@ export const RETRIEVE_CONTENT_CREATION_FILE_TOOL_NAME =
   "retrieve_content_creation_file";
 export const REVERT_CONTENT_CREATION_FILE_TOOL_NAME =
   "revert_content_creation_file";
+export const RENAME_CONTENT_CREATION_FILE_TOOL_NAME =
+  "rename_content_creation_file";

--- a/front/lib/api/files/client_executable.ts
+++ b/front/lib/api/files/client_executable.ts
@@ -295,35 +295,28 @@ export async function renameClientExecutableFile(
     });
   }
 
-  try {
-    const fileNameValidationResult = validateFileTitle({
-      fileName: newFileName,
-      mimeType: fileResource.contentType,
-    });
-    if (fileNameValidationResult.isErr()) {
-      return fileNameValidationResult;
-    }
+  const fileNameValidationResult = validateFileTitle({
+    fileName: newFileName,
+    mimeType: fileResource.contentType,
+  });
+  if (fileNameValidationResult.isErr()) {
+    return fileNameValidationResult;
+  }
 
-    await fileResource.update({ fileName: newFileName });
+  await fileResource.update({ fileName: newFileName });
 
-    if (
-      renamedByAgentConfigurationId &&
-      fileResource.useCaseMetadata?.lastEditedByAgentConfigurationId !==
-        renamedByAgentConfigurationId
-    ) {
-      await fileResource.setUseCaseMetadata({
-        ...fileResource.useCaseMetadata,
-        lastEditedByAgentConfigurationId: renamedByAgentConfigurationId,
-      });
-    }
-
-    return new Ok(fileResource);
-  } catch (error) {
-    return new Err({
-      message: `Failed to rename file '${fileId}': ${normalizeError(error)}`,
-      tracked: true,
+  if (
+    renamedByAgentConfigurationId &&
+    fileResource.useCaseMetadata?.lastEditedByAgentConfigurationId !==
+      renamedByAgentConfigurationId
+  ) {
+    await fileResource.setUseCaseMetadata({
+      ...fileResource.useCaseMetadata,
+      lastEditedByAgentConfigurationId: renamedByAgentConfigurationId,
     });
   }
+
+  return new Ok(fileResource);
 }
 
 export async function getClientExecutableFileContent(

--- a/front/lib/api/files/client_executable.ts
+++ b/front/lib/api/files/client_executable.ts
@@ -303,7 +303,7 @@ export async function renameClientExecutableFile(
     return fileNameValidationResult;
   }
 
-  await fileResource.update({ fileName: newFileName });
+  await fileResource.rename(newFileName);
 
   if (
     renamedByAgentConfigurationId &&

--- a/front/lib/api/files/client_executable.ts
+++ b/front/lib/api/files/client_executable.ts
@@ -3,7 +3,6 @@ import groupBy from "lodash/groupBy";
 import {
   CREATE_CONTENT_CREATION_FILE_TOOL_NAME,
   EDIT_CONTENT_CREATION_FILE_TOOL_NAME,
-  RENAME_CONTENT_CREATION_FILE_TOOL_NAME,
   REVERT_CONTENT_CREATION_FILE_TOOL_NAME,
 } from "@app/lib/actions/mcp_internal_actions/servers/content_creation/types";
 import {

--- a/front/lib/resources/file_resource.ts
+++ b/front/lib/resources/file_resource.ts
@@ -524,6 +524,10 @@ export class FileResource extends BaseResource<FileModel> {
     return this.update({ snippet });
   }
 
+  rename(newFileName: string) {
+    return this.update({ fileName: newFileName });
+  }
+
   // Sharing logic.
 
   async setShareScope(


### PR DESCRIPTION
## Description

- Closes https://github.com/dust-tt/tasks/issues/4464.
- This PR adds a tool that allows renaming content-created files.

## Tests

- Tested locally.

## Risk

- Low.

## Deploy Plan

- Deploy front.
