### PR TITLE
[front] Don't use handover messages for mentioning

### DIFF
--- a/extension/ui/components/conversation/ConversationViewer.tsx
+++ b/extension/ui/components/conversation/ConversationViewer.tsx
@@ -90,6 +90,7 @@ export function ConversationViewer({
     return messages.findLast(
       (message) =>
         message.type === "user_message" &&
+        message.context.origin !== "agent_handover" &&
         message.visibility !== "deleted" &&
         message.user?.sId === user.sId
     );

--- a/front/components/assistant/conversation/ConversationViewer.tsx
+++ b/front/components/assistant/conversation/ConversationViewer.tsx
@@ -204,6 +204,7 @@ const ConversationViewer = React.forwardRef<
     return latestPage?.messages.findLast(
       (message) =>
         isUserMessageType(message) &&
+        message.context.origin !== "agent_handover" &&
         message.visibility !== "deleted" &&
         message.user?.id === user.id
     );


### PR DESCRIPTION
fixes https://github.com/dust-tt/tasks/issues/4234
## Description

Use last real user message to get mentions, skip the user messages coming from handover

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

none

## Deploy Plan

deploy front
