### PR TITLE
Handle nicely the keyboard focus on mobile

### DIFF
--- a/front/components/assistant/conversation/AssistantInputBarVirtuoso.tsx
+++ b/front/components/assistant/conversation/AssistantInputBarVirtuoso.tsx
@@ -12,6 +12,7 @@ import type {
 } from "@app/components/assistant/conversation/types";
 import { isUserMessage } from "@app/components/assistant/conversation/types";
 import { emptyArray } from "@app/lib/swr/swr";
+import { useIsMobile } from "@app/lib/swr/useIsMobile";
 import type { AgentMention } from "@app/types";
 import { isAgentMention } from "@app/types";
 
@@ -20,6 +21,7 @@ export const AssistantInputBarVirtuoso = ({
 }: {
   context: VirtuosoMessageListContext;
 }) => {
+  const isMobile = useIsMobile();
   const methods = useVirtuosoMethods<VirtuosoMessage>();
   const lastUserMessage = methods.data
     .get()
@@ -83,7 +85,7 @@ export const AssistantInputBarVirtuoso = ({
         onSubmit={context.handleSubmit}
         stickyMentions={agentMentions}
         conversationId={context.conversationId}
-        disableAutoFocus={false}
+        disableAutoFocus={isMobile}
       />
     </div>
   );

--- a/front/components/assistant/conversation/input_bar/InputBarContainer.tsx
+++ b/front/components/assistant/conversation/input_bar/InputBarContainer.tsx
@@ -33,6 +33,7 @@ import type { NodeCandidate, UrlCandidate } from "@app/lib/connectors";
 import { isNodeCandidate } from "@app/lib/connectors";
 import { getSpaceAccessPriority } from "@app/lib/spaces";
 import { useSpaces, useSpacesSearch } from "@app/lib/swr/spaces";
+import { useIsMobile } from "@app/lib/swr/useIsMobile";
 import { useFeatureFlags } from "@app/lib/swr/workspaces";
 import { classNames } from "@app/lib/utils";
 import type {
@@ -94,6 +95,7 @@ const InputBarContainer = ({
   onMCPServerViewDeselect,
   selectedMCPServerViews,
 }: InputBarContainerProps) => {
+  const isMobile = useIsMobile();
   const featureFlags = useFeatureFlags({ workspaceId: owner.sId });
   const suggestions = useAssistantSuggestions(agentConfigurations, owner);
   const [nodeOrUrlCandidate, setNodeOrUrlCandidate] = useState<
@@ -432,7 +434,17 @@ const InputBarContainer = ({
                   voiceTranscriberService.isRecording ||
                   voiceTranscriberService.isTranscribing
                 }
-                onClick={async () => {
+                onClick={async (e: React.MouseEvent<HTMLButtonElement>) => {
+                  e.preventDefault();
+                  e.stopPropagation();
+                  if (disableAutoFocus) {
+                    editorService.blur();
+                    // wait a bit for the keyboard to be closed on mobile
+                    if (isMobile) {
+                      editorService.setLoading(true);
+                      await new Promise((resolve) => setTimeout(resolve, 500));
+                    }
+                  }
                   onEnterKeyDown(
                     editorService.isEmpty(),
                     editorService.getMarkdownAndMentions(),

--- a/front/components/assistant/conversation/input_bar/editor/useCustomEditor.tsx
+++ b/front/components/assistant/conversation/input_bar/editor/useCustomEditor.tsx
@@ -179,6 +179,10 @@ const useEditorService = (editor: Editor | null) => {
         return editor?.getText().trim();
       },
 
+      blur() {
+        return editor?.commands.blur();
+      },
+
       clearEditor() {
         return editor?.commands.clearContent();
       },

--- a/front/lib/swr/useIsMobile.ts
+++ b/front/lib/swr/useIsMobile.ts
@@ -1,0 +1,19 @@
+import { useEffect, useState } from "react";
+
+const MOBILE_BREAKPOINT = 768;
+
+export function useIsMobile() {
+  const [isMobile, setIsMobile] = useState<boolean | undefined>();
+
+  useEffect(() => {
+    const mql = window.matchMedia(`(max-width: ${MOBILE_BREAKPOINT - 1}px)`);
+    const onChange = () => {
+      setIsMobile(window.innerWidth < MOBILE_BREAKPOINT);
+    };
+    mql.addEventListener("change", onChange);
+    setIsMobile(window.innerWidth < MOBILE_BREAKPOINT);
+    return () => mql.removeEventListener("change", onChange);
+  }, []);
+
+  return !!isMobile;
+}


### PR DESCRIPTION
## Description

Fix various keyboard focus issues on mobile.
- Avoid having the focus back in the input when we scroll the conversation.
- Wait until the keyboard is closed on mobile before sending the message (look much cleaner than having the message sent at the same time as the keyboard closes)

## Tests

My phone :)

https://github.com/user-attachments/assets/e2084e75-2ca0-478b-bbb5-76147dc0172b


## Risk

Low

## Deploy Plan

Deploy front