### PR TITLE
fix(openai): don't forward empty response format

### DIFF
--- a/core/src/providers/openai_compatible_helpers.rs
+++ b/core/src/providers/openai_compatible_helpers.rs
@@ -989,7 +989,10 @@ async fn streamed_chat_completion(
         body["tool_choice"] = json!(tool_choice);
     }
     if let Some(response_format) = response_format {
-        body["response_format"] = json!(response_format);
+        // Guard against empty object response_format (must include a string "type").
+        if let Some(Value::String(_)) = response_format.get("type") {
+            body["response_format"] = json!(response_format);
+        }
     }
     if let Some(reasoning_effort) = reasoning_effort {
         body["reasoning_effort"] = json!(reasoning_effort);
@@ -1425,7 +1428,10 @@ async fn chat_completion(
     }
 
     if let Some(response_format) = response_format {
-        body["response_format"] = json!(response_format)
+        // Guard against empty object response_format (must include a string "type").
+        if let Some(Value::String(_)) = response_format.get("type") {
+            body["response_format"] = json!(response_format);
+        }
     }
     if tools.len() > 0 {
         body["tools"] = json!(tools);


### PR DESCRIPTION
## Description

fixes https://github.com/dust-tt/tasks/issues/4454

When people set response format on gpt 4o / 4.1 to "{}" we get OAI errors. This change just ignores those invalid response formats.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
