### PR TITLE
[front] - chore: streamline tag button rendering in AssistantBrowser

### DIFF
--- a/front/components/assistant/AssistantBrowser.tsx
+++ b/front/components/assistant/AssistantBrowser.tsx
@@ -540,7 +540,7 @@ export function AssistantBrowser({
           <div className="mb-2 flex flex-wrap items-center gap-2">
             {noTagsDefined ? null : (
               <>
-                {uniqueTags.map((tag, index) => (
+                {uniqueTags.map((tag) => (
                   <Button
                     size="xs"
                     variant={selectedTag === tag.sId ? "primary" : "outline"}

--- a/front/components/assistant/AssistantBrowser.tsx
+++ b/front/components/assistant/AssistantBrowser.tsx
@@ -541,20 +541,15 @@ export function AssistantBrowser({
             {noTagsDefined ? null : (
               <>
                 {uniqueTags.map((tag, index) => (
-                  <>
-                    <Button
-                      size="xs"
-                      variant={selectedTag === tag.sId ? "primary" : "outline"}
-                      key={tag.sId}
-                      label={tag.name}
-                      onClick={() => {
-                        setSelectedTag(tag.sId);
-                      }}
-                    />
-                    {index == 1 && uniqueTags.length > 2 && (
-                      <span className="heading-base">-</span>
-                    )}
-                  </>
+                  <Button
+                    size="xs"
+                    variant={selectedTag === tag.sId ? "primary" : "outline"}
+                    key={tag.sId}
+                    label={tag.name}
+                    onClick={() => {
+                      setSelectedTag(tag.sId);
+                    }}
+                  />
                 ))}
               </>
             )}


### PR DESCRIPTION
## Description

This PR removes an unnecessary span

## Tests

Locally

## Risk

None

## Deploy Plan

Deploy front