### PR TITLE
AgentLoop: max retry 3 for conversation title generation

### DIFF
--- a/front/temporal/agent_loop/workflows.ts
+++ b/front/temporal/agent_loop/workflows.ts
@@ -73,6 +73,11 @@ const { ensureConversationTitleActivity } = proxyActivities<
   typeof ensureTitleActivities
 >({
   startToCloseTimeout: "5 minutes",
+  retry: {
+    // Retry twice and fail given non criticality. The activity will fail if the conversation gets
+    // deleted before it gets to title generation.
+    maximumAttempts: 3,
+  },
 });
 
 const { notifyWorkflowError, finalizeCancellationActivity } = proxyActivities<


### PR DESCRIPTION
## Description

Max retry 3 for conversation title generation as it can fail if the conversation gets deleted before we get to it.

Example: https://app.datadoghq.eu/logs?query=%28%22Activity%20failed%22%20OR%20%22Unhandled%20activity%20error%22%29%20%40attempt%3A%3E14%20-%40workflowId%3Aslack-syncOneChannel-20-C01CD6LKJUC%20%40workflowId%3Aagent-loop-conversation%2A&agg_m=count&agg_m_source=base&agg_t=count&clustering_pattern_field_path=message&cols=host%2Cservice%2C%40workflowId%2C%40activityName&event=AwAAAZmqZyPLoYiuiAAAABhBWm1xWnkxOEFBQTFDUXJHV3NJS1hnQm4AAAAkZjE5OWFhNjctNDdkZi00ZDc3LWFkZDctOGEzMWRkOGVhMDkwAABLUQ&link_source=monitor_notif&messageDisplay=inline&refresh_mode=sliding&storage=hot&stream_sort=time%2Cdesc&viz=stream&from_ts=1759499734362&to_ts=1759500634362&live=true

## Tests

N/A

## Risk

Low

## Deploy Plan

- deploy `front`