### PR TITLE
Gdrive: strip null bytes for folder names

### DIFF
--- a/connectors/src/connectors/google_drive/temporal/activities/mark_folder_as_visited.ts
+++ b/connectors/src/connectors/google_drive/temporal/activities/mark_folder_as_visited.ts
@@ -12,7 +12,7 @@ import { GoogleDriveFiles } from "@connectors/lib/models/google_drive";
 import logger from "@connectors/logger/logger";
 import { ConnectorResource } from "@connectors/resources/connector_resource";
 import type { ModelId } from "@connectors/types";
-import { INTERNAL_MIME_TYPES } from "@connectors/types";
+import { INTERNAL_MIME_TYPES, stripNullBytes } from "@connectors/types";
 
 export async function markFolderAsVisited(
   connectorId: ModelId,
@@ -49,13 +49,14 @@ export async function markFolderAsVisited(
   );
 
   const parents = parentGoogleIds.map((parent) => getInternalId(parent));
+  const name = stripNullBytes(file.name) ?? "";
 
   await upsertDataSourceFolder({
     dataSourceConfig,
     folderId: getInternalId(file.id),
     parents,
     parentId: parents[1] || null,
-    title: file.name ?? "",
+    title: name,
     mimeType: INTERNAL_MIME_TYPES.GOOGLE_DRIVE.FOLDER,
     sourceUrl: getSourceUrlForGoogleDriveFiles(file),
   });
@@ -64,7 +65,7 @@ export async function markFolderAsVisited(
     connectorId: connectorId,
     dustFileId: getInternalId(driveFileId),
     driveFileId: file.id,
-    name: file.name,
+    name,
     mimeType: file.mimeType,
     parentId: parents[1] ? getDriveFileId(parents[1]) : null,
     lastSeenTs: new Date(),


### PR DESCRIPTION
## Description

Going after this error: https://app.datadoghq.eu/logs?query=%28%22Activity%20failed%22%20OR%20%22Unhandled%20activity%20error%22%29%20%40attempt%3A%3E14&agg_m=count&agg_m_source=base&agg_t=count&clustering_pattern_field_path=message&cols=host%2Cservice%2C%40workflowId%2C%40activityName&event=AwAAAZmqhd9jISthJAAAABhBWm1xaGV3Y0FBQUxRbi1wMHpHOXBnQUYAAAAkZjE5OWFhODctNWE5MS00MWE3LWFiMmYtY2I3ZDgwZjAxZjA4AAIi4Q&link_source=monitor_notif&messageDisplay=inline&refresh_mode=sliding&storage=hot&stream_sort=time%2Cdesc&viz=stream&from_ts=1759499734362&to_ts=1759500634362&live=true

## Tests

N/A

## Risk

Low

## Deploy Plan

- deploy `connectors`