### PR TITLE
Add dataanalytics attribute

### DIFF
--- a/sparkle/src/components/AssistantCard.tsx
+++ b/sparkle/src/components/AssistantCard.tsx
@@ -105,36 +105,41 @@ interface LargeAssistantCardProps extends BaseAssistantCardProps {}
 export const LargeAssistantCard = React.forwardRef<
   HTMLDivElement,
   LargeAssistantCardProps
->(({ className, onClick, title, description, pictureUrl, dataAnalytics }, ref) => {
-  return (
-    <Card
-      ref={ref}
-      size="lg"
-      className={className}
-      onClick={onClick}
-      variant="tertiary"
-      dataAnalytics={dataAnalytics}
-    >
-      <div className="s-flex s-gap-3">
-        <Avatar visual={pictureUrl} size="lg" />
-        <div
-          className={cn(
-            "s-flex s-flex-col s-gap-2 s-text-base",
-            "s-text-foreground dark:s-text-foreground-night"
-          )}
-        >
-          <h3 className="s-heading-base">{title}</h3>
-          <p
+>(
+  (
+    { className, onClick, title, description, pictureUrl, dataAnalytics },
+    ref
+  ) => {
+    return (
+      <Card
+        ref={ref}
+        size="lg"
+        className={className}
+        onClick={onClick}
+        variant="tertiary"
+        dataAnalytics={dataAnalytics}
+      >
+        <div className="s-flex s-gap-3">
+          <Avatar visual={pictureUrl} size="lg" />
+          <div
             className={cn(
-              "s-line-clamp-5 s-overflow-hidden s-text-ellipsis",
-              "s-text-muted-foreground dark:s-text-muted-foreground-night"
+              "s-flex s-flex-col s-gap-2 s-text-base",
+              "s-text-foreground dark:s-text-foreground-night"
             )}
           >
-            {description}
-          </p>
+            <h3 className="s-heading-base">{title}</h3>
+            <p
+              className={cn(
+                "s-line-clamp-5 s-overflow-hidden s-text-ellipsis",
+                "s-text-muted-foreground dark:s-text-muted-foreground-night"
+              )}
+            >
+              {description}
+            </p>
+          </div>
         </div>
-      </div>
-    </Card>
-  );
-});
+      </Card>
+    );
+  }
+);
 LargeAssistantCard.displayName = "LargeAssistantCard";

--- a/sparkle/src/components/AssistantCard.tsx
+++ b/sparkle/src/components/AssistantCard.tsx
@@ -105,41 +105,36 @@ interface LargeAssistantCardProps extends BaseAssistantCardProps {}
 export const LargeAssistantCard = React.forwardRef<
   HTMLDivElement,
   LargeAssistantCardProps
->(
-  (
-    { className, onClick, title, description, pictureUrl, dataAnalytics },
-    ref
-  ) => {
-    return (
-      <Card
-        ref={ref}
-        size="lg"
-        className={className}
-        onClick={onClick}
-        variant="tertiary"
-        dataAnalytics={dataAnalytics}
-      >
-        <div className="s-flex s-gap-3">
-          <Avatar visual={pictureUrl} size="lg" />
-          <div
+>(({ className, onClick, title, description, pictureUrl, dataAnalytics }, ref) => {
+  return (
+    <Card
+      ref={ref}
+      size="lg"
+      className={className}
+      onClick={onClick}
+      variant="tertiary"
+      dataAnalytics={dataAnalytics}
+    >
+      <div className="s-flex s-gap-3">
+        <Avatar visual={pictureUrl} size="lg" />
+        <div
+          className={cn(
+            "s-flex s-flex-col s-gap-2 s-text-base",
+            "s-text-foreground dark:s-text-foreground-night"
+          )}
+        >
+          <h3 className="s-heading-base">{title}</h3>
+          <p
             className={cn(
-              "s-flex s-flex-col s-gap-2 s-text-base",
-              "s-text-foreground dark:s-text-foreground-night"
+              "s-line-clamp-5 s-overflow-hidden s-text-ellipsis",
+              "s-text-muted-foreground dark:s-text-muted-foreground-night"
             )}
           >
-            <h3 className="s-font-semibold">{title}</h3>
-            <p
-              className={cn(
-                "s-line-clamp-5 s-overflow-hidden s-text-ellipsis",
-                "s-text-muted-foreground dark:s-text-muted-foreground-night"
-              )}
-            >
-              {description}
-            </p>
-          </div>
+            {description}
+          </p>
         </div>
-      </Card>
-    );
-  }
-);
+      </div>
+    </Card>
+  );
+});
 LargeAssistantCard.displayName = "LargeAssistantCard";

--- a/sparkle/src/components/AssistantCard.tsx
+++ b/sparkle/src/components/AssistantCard.tsx
@@ -19,6 +19,7 @@ interface BaseAssistantCardProps {
   onClick?: () => void;
   onContextMenu?: (event: React.MouseEvent) => void;
   variant?: CardVariantType;
+  dataAnalytics?: string;
 }
 
 type AssistantCardMore = Omit<MiniButtonProps, "icon" | "size">;
@@ -50,6 +51,7 @@ export const AssistantCard = React.forwardRef<
       subtitle,
       action,
       variant = "primary",
+      dataAnalytics,
     },
     ref
   ) => {
@@ -62,6 +64,7 @@ export const AssistantCard = React.forwardRef<
         onContextMenu={onContextMenu}
         action={action}
         variant={variant}
+        dataAnalytics={dataAnalytics}
       >
         <div className="s-flex s-gap-3">
           <Avatar visual={pictureUrl} size="md" />
@@ -102,35 +105,41 @@ interface LargeAssistantCardProps extends BaseAssistantCardProps {}
 export const LargeAssistantCard = React.forwardRef<
   HTMLDivElement,
   LargeAssistantCardProps
->(({ className, onClick, title, description, pictureUrl }, ref) => {
-  return (
-    <Card
-      ref={ref}
-      size="lg"
-      className={className}
-      onClick={onClick}
-      variant="tertiary"
-    >
-      <div className="s-flex s-gap-3">
-        <Avatar visual={pictureUrl} size="lg" />
-        <div
-          className={cn(
-            "s-flex s-flex-col s-gap-2 s-text-base",
-            "s-text-foreground dark:s-text-foreground-night"
-          )}
-        >
-          <h3 className="s-heading-base">{title}</h3>
-          <p
+>(
+  (
+    { className, onClick, title, description, pictureUrl, dataAnalytics },
+    ref
+  ) => {
+    return (
+      <Card
+        ref={ref}
+        size="lg"
+        className={className}
+        onClick={onClick}
+        variant="tertiary"
+        dataAnalytics={dataAnalytics}
+      >
+        <div className="s-flex s-gap-3">
+          <Avatar visual={pictureUrl} size="lg" />
+          <div
             className={cn(
-              "s-line-clamp-5 s-overflow-hidden s-text-ellipsis",
-              "s-text-muted-foreground dark:s-text-muted-foreground-night"
+              "s-flex s-flex-col s-gap-2 s-text-base",
+              "s-text-foreground dark:s-text-foreground-night"
             )}
           >
-            {description}
-          </p>
+            <h3 className="s-font-semibold">{title}</h3>
+            <p
+              className={cn(
+                "s-line-clamp-5 s-overflow-hidden s-text-ellipsis",
+                "s-text-muted-foreground dark:s-text-muted-foreground-night"
+              )}
+            >
+              {description}
+            </p>
+          </div>
         </div>
-      </div>
-    </Card>
-  );
-});
+      </Card>
+    );
+  }
+);
 LargeAssistantCard.displayName = "LargeAssistantCard";

--- a/sparkle/src/components/Button.tsx
+++ b/sparkle/src/components/Button.tsx
@@ -225,6 +225,7 @@ type CommonButtonProps = Omit<MetaButtonProps, "children"> &
     isCounter?: boolean;
     counterValue?: string;
     isRounded?: boolean;
+    dataAnalytics?: string;
   };
 
 export type MiniButtonProps = CommonButtonProps & {
@@ -263,6 +264,7 @@ const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
       replace,
       shallow,
       "aria-label": ariaLabel,
+      dataAnalytics,
       ...props
     },
     ref
@@ -372,6 +374,7 @@ const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
           className
         )}
         aria-label={ariaLabel || tooltip || label}
+        data-analytics={dataAnalytics}
         style={
           {
             "--pulse-color": "#93C5FD",

--- a/sparkle/src/components/Card.tsx
+++ b/sparkle/src/components/Card.tsx
@@ -78,6 +78,7 @@ interface CommonProps {
   variant?: CardVariantType;
   size?: CardSizeType;
   className?: string;
+  dataAnalytics?: string;
 }
 
 interface CardLinkProps extends CommonProps, LinkWrapperProps {
@@ -109,6 +110,7 @@ const InnerCard = React.forwardRef<HTMLDivElement, InnerCardProps>(
       rel = "",
       replace,
       shallow,
+      dataAnalytics,
       ...props
     },
     ref
@@ -135,6 +137,7 @@ const InnerCard = React.forwardRef<HTMLDivElement, InnerCardProps>(
           shallow={shallow}
           target={target}
           rel={rel}
+          data-analytics={dataAnalytics}
         >
           {children}
         </Link>
@@ -146,6 +149,7 @@ const InnerCard = React.forwardRef<HTMLDivElement, InnerCardProps>(
         ref={ref}
         className={cardButtonClassNames}
         onClick={onClick}
+        data-analytics={dataAnalytics}
         {...props}
       >
         {children}

--- a/sparkle/src/components/Dialog.tsx
+++ b/sparkle/src/components/Dialog.tsx
@@ -80,6 +80,7 @@ interface DialogContentProps
   isAlertDialog?: boolean;
   preventAutoFocusOnClose?: boolean;
   mountPortalContainer?: HTMLElement;
+  dataAnalytics?: string;
 }
 
 const DialogContent = React.forwardRef<
@@ -97,6 +98,7 @@ const DialogContent = React.forwardRef<
       preventAutoFocusOnClose = true,
       onCloseAutoFocus,
       mountPortalContainer,
+      dataAnalytics,
       ...props
     },
     ref
@@ -124,6 +126,7 @@ const DialogContent = React.forwardRef<
                 : props.onInteractOutside
             }
             onCloseAutoFocus={handleCloseAutoFocus}
+            data-analytics={dataAnalytics}
             {...props}
           >
             {children}

--- a/sparkle/src/components/EmptyCTA.tsx
+++ b/sparkle/src/components/EmptyCTA.tsx
@@ -42,14 +42,24 @@ EmptyCTA.displayName = "EmptyCTA";
 interface EmptyCTAButtonProps extends RegularButtonProps {
   icon: React.ComponentType;
   label: string;
+  dataAnalytics?: string;
 }
 
 const EmptyCTAButton: React.FC<EmptyCTAButtonProps> = ({
   icon,
   label,
   variant = "highlight",
+  dataAnalytics,
   ...props
-}) => <Button icon={icon} label={label} variant={variant} {...props} />;
+}) => (
+  <Button
+    icon={icon}
+    label={label}
+    variant={variant}
+    dataAnalytics={dataAnalytics}
+    {...props}
+  />
+);
 
 EmptyCTAButton.displayName = "EmptyCTAButton";
 

--- a/sparkle/src/components/LinkWrapper.tsx
+++ b/sparkle/src/components/LinkWrapper.tsx
@@ -10,29 +10,36 @@ export interface LinkWrapperProps {
   shallow?: boolean;
   target?: string;
   prefetch?: boolean;
+  dataAnalytics?: string;
 }
 
 export const LinkWrapper = React.forwardRef<
   HTMLAnchorElement,
   LinkWrapperProps
->(({ children, href, rel, replace, shallow, target, prefetch }, ref) => {
-  const { components } = React.useContext(SparkleContext);
+>(
+  (
+    { children, href, rel, replace, shallow, target, prefetch, dataAnalytics },
+    ref
+  ) => {
+    const { components } = React.useContext(SparkleContext);
 
-  if (href) {
-    return (
-      <components.link
-        ref={ref}
-        href={href}
-        target={target}
-        rel={rel}
-        replace={replace}
-        shallow={shallow}
-        prefetch={prefetch}
-      >
-        {children}
-      </components.link>
-    );
+    if (href) {
+      return (
+        <components.link
+          ref={ref}
+          href={href}
+          target={target}
+          rel={rel}
+          replace={replace}
+          shallow={shallow}
+          prefetch={prefetch}
+          data-analytics={dataAnalytics}
+        >
+          {children}
+        </components.link>
+      );
+    }
+
+    return children;
   }
-
-  return children;
-});
+);

--- a/sparkle/src/components/MultiPageDialog.tsx
+++ b/sparkle/src/components/MultiPageDialog.tsx
@@ -99,6 +99,7 @@ interface MultiPageDialogProps {
   footerContent?: React.ReactNode;
   addFooterSeparator?: boolean;
   hideCloseButton?: boolean;
+  dataAnalytics?: string;
 }
 
 interface MultiPageDialogContentProps extends MultiPageDialogProps {
@@ -129,6 +130,7 @@ const MultiPageDialogContent = React.forwardRef<
       rightButton,
       footerContent,
       hideCloseButton,
+      dataAnalytics,
       ...props
     },
     ref
@@ -188,6 +190,7 @@ const MultiPageDialogContent = React.forwardRef<
         isAlertDialog={isAlertDialog}
         preventAutoFocusOnClose={preventAutoFocusOnClose}
         className={className}
+        dataAnalytics={dataAnalytics}
         {...props}
       >
         <div className={cn(multiPageDialogLayoutVariants())}>

--- a/sparkle/src/components/NavigationList.tsx
+++ b/sparkle/src/components/NavigationList.tsx
@@ -71,6 +71,7 @@ interface NavigationListItemProps
   icon?: React.ComponentType;
   moreMenu?: React.ReactNode;
   status?: "idle" | "unread" | "blocked";
+  dataAnalytics?: string;
 }
 
 const NavigationListItem = React.forwardRef<
@@ -90,6 +91,7 @@ const NavigationListItem = React.forwardRef<
       shallow,
       moreMenu,
       status = "idle",
+      dataAnalytics,
       ...props
     },
     ref
@@ -129,6 +131,7 @@ const NavigationListItem = React.forwardRef<
           rel={rel}
           replace={replace}
           shallow={shallow}
+          dataAnalytics={dataAnalytics}
         >
           <div
             className={cn(

--- a/sparkle/src/components/PriceTable.tsx
+++ b/sparkle/src/components/PriceTable.tsx
@@ -14,6 +14,7 @@ interface PriceTableProps {
   className?: string;
   children: ReactNode;
   magnified?: boolean;
+  dataAnalytics?: string;
 }
 
 const colorTable = {
@@ -45,6 +46,7 @@ export function PriceTable({
   priceLabel = "",
   className = "",
   magnified = true,
+  dataAnalytics,
   children, // Use children instead of tableItems
 }: PriceTableProps) {
   // Pass size prop to all PriceTable.Item children
@@ -73,6 +75,7 @@ export function PriceTable({
         colorTable[color],
         className
       )}
+      data-analytics={dataAnalytics}
     >
       <div
         className={classNames(

--- a/sparkle/src/components/Sheet.tsx
+++ b/sparkle/src/components/Sheet.tsx
@@ -89,6 +89,7 @@ interface SheetContentProps
   side?: SheetSideType;
   preventAutoFocusOnClose?: boolean;
   preventAutoFocusOnOpen?: boolean;
+  dataAnalytics?: string;
 }
 
 const SheetContent = React.forwardRef<
@@ -106,6 +107,7 @@ const SheetContent = React.forwardRef<
       preventAutoFocusOnOpen = true,
       onCloseAutoFocus,
       onOpenAutoFocus,
+      dataAnalytics,
       ...props
     },
     ref
@@ -160,6 +162,7 @@ const SheetContent = React.forwardRef<
             onCloseAutoFocus={handleCloseAutoFocus}
             onOpenAutoFocus={handleOpenAutoFocus}
             onKeyDownCapture={onKeyDownCapture}
+            data-analytics={dataAnalytics}
             {...props}
           >
             {children}

--- a/sparkle/src/components/Tabs.tsx
+++ b/sparkle/src/components/Tabs.tsx
@@ -52,6 +52,7 @@ const TabsTrigger = React.forwardRef<
       >
     > & {
       isLoading?: boolean;
+      dataAnalytics?: string;
     } & Omit<LinkWrapperProps, "children" | "className">
 >(
   (
@@ -69,6 +70,7 @@ const TabsTrigger = React.forwardRef<
       variant = "ghost",
       isCounter = false,
       counterValue,
+      dataAnalytics,
       ...props
     },
     ref
@@ -95,6 +97,7 @@ const TabsTrigger = React.forwardRef<
           shallow={shallow}
           isCounter={isCounter}
           counterValue={counterValue}
+          dataAnalytics={dataAnalytics}
           className={cn(
             "s-relative",
             "after:s-absolute after:s-bottom-[-9px] after:s-left-1/2 after:s-h-[2px] after:s-w-full after:s--translate-x-1/2",

--- a/sparkle/src/stories/Citation.stories.tsx
+++ b/sparkle/src/stories/Citation.stories.tsx
@@ -74,7 +74,7 @@ export const CitationsExample = () => (
         </CitationIcons>
         <CitationTitle>Linkedin, Edouard Wautier</CitationTitle>
       </Citation>
-      
+
       <Citation onClick={() => alert("Card clicked")} className="s-w-48">
         <CitationIcons>
           <FaviconIcon websiteUrl="https://github.com" size="sm" />


### PR DESCRIPTION







## Description

Adds a `dataAnalytics` prop to key Sparkle components (Button, Card, AssistantCard, EmptyCTA, LinkWrapper, NavigationList, Tabs) to enable analytics tracking. The prop is passed through to the underlying HTML elements as a `data-analytics` attribute, allowing external analytics tools like PostHog to track user interactions with specific components.

## Risk

None - this is an additive change that adds an optional prop without modifying existing behavior.
