### PR TITLE
Fix: disable hover on non compatible devices

### DIFF
--- a/sparkle/tailwind.config.js
+++ b/sparkle/tailwind.config.js
@@ -236,6 +236,9 @@ const safeColorlist = safeColorsArray.flatMap((color) => [
 ]);
 
 module.exports = {
+  future: {
+    hoverOnlyWhenSupported: true,
+  },
   theme: {
     screens: {
       xxs: "384px",


### PR DESCRIPTION
## Description

Disable hover css effect on device that do not support it natively (mobile, pointer device).
It fixes the need to "double-tap" things to select them on mobile.
See [PR](https://github.com/tailwindlabs/tailwindcss/pull/8394)  for more informations.
Note: this is the default behavior on tailwind v4

## Tests

Local

## Risk

Medium, but purely visual if anything on desktop.

## Deploy Plan

Deploy sparkle, then update front & extension to use it.