### PR TITLE
[Agent Loop] Remove executionMode parameter

### DIFF
--- a/front/components/assistant/conversation/ConversationContainer.tsx
+++ b/front/components/assistant/conversation/ConversationContainer.tsx
@@ -71,10 +71,6 @@ export function ConversationContainer({
   const { scrollConversationsToTop } = useConversationsNavigation();
 
   const router = useRouter();
-
-  const { execution } = router.query;
-  const executionMode = typeof execution === "string" ? execution : "auto";
-
   const sendNotification = useSendNotification();
 
   const { mutateConversations } = useConversations({
@@ -143,7 +139,6 @@ export function ConversationContainer({
             user,
             conversationId: activeConversationId,
             messageData,
-            executionMode,
           });
 
           // Replace placeholder message with API response.
@@ -235,7 +230,6 @@ export function ConversationContainer({
           clientSideMCPServerIds: removeNulls([serverId]),
           selectedMCPServerViewIds,
         },
-        executionMode,
       });
 
       setIsSubmitting(false);
@@ -272,7 +266,6 @@ export function ConversationContainer({
       }
     },
     [
-      executionMode,
       isSubmitting,
       mutateConversations,
       owner,

--- a/front/components/assistant/conversation/ConversationContainerVirtuoso.tsx
+++ b/front/components/assistant/conversation/ConversationContainerVirtuoso.tsx
@@ -24,7 +24,6 @@ import type { DustError } from "@app/lib/error";
 import {
   useConversationMessages,
   useConversations,
-  useExecutionMode,
 } from "@app/lib/swr/conversations";
 import { getAgentRoute } from "@app/lib/utils/router";
 import type {
@@ -64,8 +63,6 @@ export function ConversationContainerVirtuoso({
   const assistantToMention = useRef<LightAgentConfigurationType | null>(null);
 
   const router = useRouter();
-
-  const executionMode = useExecutionMode();
 
   const sendNotification = useSendNotification();
 
@@ -133,7 +130,6 @@ export function ConversationContainerVirtuoso({
           clientSideMCPServerIds: removeNulls([serverId]),
           selectedMCPServerViewIds,
         },
-        executionMode,
       });
 
       setIsSubmitting(false);
@@ -171,7 +167,6 @@ export function ConversationContainerVirtuoso({
       }
     },
     [
-      executionMode,
       isSubmitting,
       mutateConversations,
       owner,

--- a/front/components/assistant/conversation/ConversationViewerVirtuoso.tsx
+++ b/front/components/assistant/conversation/ConversationViewerVirtuoso.tsx
@@ -50,7 +50,6 @@ import {
   useConversationMessages,
   useConversationParticipants,
   useConversations,
-  useExecutionMode,
 } from "@app/lib/swr/conversations";
 import { classNames } from "@app/lib/utils";
 import type {
@@ -114,7 +113,6 @@ const ConversationViewerVirtuoso = ({
     >(null);
   const sendNotification = useSendNotification();
   const { serverId } = useCoEditionContext();
-  const executionMode = useExecutionMode();
 
   const { currentPanel } = useConversationSidePanelContext();
 
@@ -409,7 +407,6 @@ const ConversationViewerVirtuoso = ({
         user,
         conversationId,
         messageData,
-        executionMode,
       });
 
       if (result.isErr()) {
@@ -456,7 +453,6 @@ const ConversationViewerVirtuoso = ({
       user,
       owner,
       conversationId,
-      executionMode,
       mutateConversations,
       setPlanLimitReached,
       sendNotification,

--- a/front/components/assistant/conversation/lib.ts
+++ b/front/components/assistant/conversation/lib.ts
@@ -144,7 +144,6 @@ export async function submitMessage({
   user,
   conversationId,
   messageData,
-  executionMode,
 }: {
   owner: WorkspaceType;
   user: UserType;
@@ -155,7 +154,6 @@ export async function submitMessage({
     contentFragments: ContentFragmentsType;
     clientSideMCPServerIds?: string[];
   };
-  executionMode?: string;
 }): Promise<Result<PostMessagesResponseBody, SubmitMessageError>> {
   const { input, mentions, contentFragments, clientSideMCPServerIds } =
     messageData;
@@ -223,9 +221,8 @@ export async function submitMessage({
   }
 
   // Create a new user message.
-  const queryParams = executionMode ? `?execution=${executionMode}` : "";
   const mRes = await fetch(
-    `/api/w/${owner.sId}/assistant/conversations/${conversationId}/messages${queryParams}`,
+    `/api/w/${owner.sId}/assistant/conversations/${conversationId}/messages`,
     {
       method: "POST",
       headers: {
@@ -300,7 +297,6 @@ export async function createConversationWithMessage({
   messageData,
   visibility = "unlisted",
   title,
-  executionMode,
 }: {
   owner: WorkspaceType;
   user: UserType;
@@ -313,7 +309,6 @@ export async function createConversationWithMessage({
   };
   visibility?: ConversationVisibility;
   title?: string;
-  executionMode?: string;
 }): Promise<Result<ConversationType, SubmitMessageError>> {
   const {
     input,
@@ -370,17 +365,13 @@ export async function createConversationWithMessage({
   };
 
   // Create new conversation and post the initial message at the same time.
-  const queryParams = executionMode ? `?execution=${executionMode}` : "";
-  const cRes = await fetch(
-    `/api/w/${owner.sId}/assistant/conversations${queryParams}`,
-    {
-      method: "POST",
-      headers: {
-        "Content-Type": "application/json",
-      },
-      body: JSON.stringify(body),
-    }
-  );
+  const cRes = await fetch(`/api/w/${owner.sId}/assistant/conversations`, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify(body),
+  });
 
   if (!cRes.ok) {
     const data = await cRes.json();

--- a/front/lib/actions/mcp_internal_actions/servers/run_agent/conversation.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/run_agent/conversation.ts
@@ -206,10 +206,6 @@ export async function getOrCreateConversation(
     },
     contentFragments,
     skipToolsValidation: agentMessage.skipToolsValidation ?? false,
-    params: {
-      // TODO(DURABLE_AGENT 2025-08-20): Remove this if we decided to always use async mode.
-      execution: "async",
-    },
   });
 
   if (convRes.isErr()) {

--- a/front/lib/actions/mcp_internal_actions/utils/web_summarization.ts
+++ b/front/lib/actions/mcp_internal_actions/utils/web_summarization.ts
@@ -54,7 +54,6 @@ export async function summarizeWithAgent({
         selectedMCPServerViewIds: null,
       },
     },
-    params: { execution: "async" },
   });
 
   if (convRes.isErr() || !convRes.value.message) {

--- a/front/lib/api/assistant/streaming/blocking.ts
+++ b/front/lib/api/assistant/streaming/blocking.ts
@@ -15,7 +15,6 @@ import type {
   UserMessageType,
 } from "@app/types";
 import { Ok } from "@app/types";
-import type { ExecutionMode } from "@app/types/assistant/agent_run";
 
 // We wait for 60 seconds for agent messages to complete.
 const WAIT_FOR_AGENT_COMPLETION_TIMEOUT_MS = 60000 * 3; // 3 minutes.
@@ -145,15 +144,12 @@ export async function postUserMessageAndWaitForCompletion(
     content,
     context,
     conversation,
-    // TODO(pr) remove in follow-up pr.
-    _executionMode,
     mentions,
     skipToolsValidation,
   }: {
     content: string;
     context: UserMessageContext;
     conversation: ConversationType;
-    _executionMode?: ExecutionMode;
     mentions: MentionType[];
     skipToolsValidation: boolean;
   }

--- a/front/lib/swr/conversations.ts
+++ b/front/lib/swr/conversations.ts
@@ -1,4 +1,3 @@
-import { useRouter } from "next/router";
 import { useCallback, useEffect, useMemo, useState } from "react";
 import type { Fetcher } from "swr";
 
@@ -780,11 +779,4 @@ export const useJoinConversation = ({
   ]);
 
   return joinConversation;
-};
-
-export const useExecutionMode = () => {
-  const router = useRouter();
-  const { execution } = router.query;
-  const executionMode = typeof execution === "string" ? execution : "auto";
-  return executionMode;
 };

--- a/front/pages/api/v1/w/[wId]/assistant/conversations/[cId]/messages/index.ts
+++ b/front/pages/api/v1/w/[wId]/assistant/conversations/[cId]/messages/index.ts
@@ -18,7 +18,6 @@ import { concurrentExecutor } from "@app/lib/utils/async_utils";
 import { apiError } from "@app/logger/withlogging";
 import type { UserMessageContext, WithAPIErrorResponse } from "@app/types";
 import { isEmptyString } from "@app/types";
-import { ExecutionModeSchema } from "@app/types/assistant/agent_run";
 
 /**
  * @swagger
@@ -102,13 +101,6 @@ async function handler(
           },
         });
       }
-
-      const executionModeParseResult = ExecutionModeSchema.safeParse(
-        req.query.execution
-      );
-      const executionMode = executionModeParseResult.success
-        ? executionModeParseResult.data
-        : undefined;
 
       const hasReachedLimits = await hasReachedPublicAPILimits(auth);
       if (hasReachedLimits) {
@@ -199,8 +191,6 @@ async function handler(
               content,
               context: ctx,
               conversation,
-              // TODO(pr) Remove in follow-up PR
-              _executionMode: executionMode,
               mentions,
               skipToolsValidation: skipToolsValidation ?? false,
             })

--- a/front/pages/api/v1/w/[wId]/assistant/conversations/index.ts
+++ b/front/pages/api/v1/w/[wId]/assistant/conversations/index.ts
@@ -40,7 +40,6 @@ import {
   isContentFragmentInputWithInlinedContent,
   isEmptyString,
 } from "@app/types";
-import { ExecutionModeSchema } from "@app/types/assistant/agent_run";
 
 const MAX_CONVERSATION_DEPTH = 4;
 
@@ -139,13 +138,6 @@ async function handler(
         skipToolsValidation,
         blocking,
       } = r.data;
-
-      const executionModeParseResult = ExecutionModeSchema.safeParse(
-        req.query.execution
-      );
-      const executionMode = executionModeParseResult.success
-        ? executionModeParseResult.data
-        : undefined;
 
       const hasReachedLimits = await hasReachedPublicAPILimits(auth);
       if (hasReachedLimits) {
@@ -405,8 +397,6 @@ async function handler(
                 content: message.content,
                 context: ctx,
                 conversation,
-                // TODO(pr) remove in follow-up PR.
-                _executionMode: executionMode,
                 mentions: message.mentions,
                 skipToolsValidation: skipToolsValidation ?? false,
               })

--- a/front/pages/api/w/[wId]/assistant/conversations/[cId]/messages/index.ts
+++ b/front/pages/api/w/[wId]/assistant/conversations/[cId]/messages/index.ts
@@ -26,7 +26,6 @@ import {
   isUserMessageType,
   removeNulls,
 } from "@app/types";
-import { ExecutionModeSchema } from "@app/types/assistant/agent_run";
 
 export type PostMessagesResponseBody = {
   message: UserMessageType;
@@ -56,16 +55,6 @@ async function handler(
   }
 
   const conversationId = req.query.cId;
-
-  const executionModeParseResult = ExecutionModeSchema.safeParse(
-    req.query.execution
-  );
-
-  // TODO(pr) remove in follow-up PR
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  const executionMode = executionModeParseResult.success
-    ? executionModeParseResult.data
-    : undefined;
 
   switch (req.method) {
     case "GET":

--- a/front/pages/api/w/[wId]/assistant/conversations/index.ts
+++ b/front/pages/api/w/[wId]/assistant/conversations/index.ts
@@ -27,7 +27,6 @@ import {
   ConversationError,
   InternalPostConversationsRequestBodySchema,
 } from "@app/types";
-import { ExecutionModeSchema } from "@app/types/assistant/agent_run";
 
 export type GetConversationsResponseBody = {
   conversations: ConversationWithoutContentType[];
@@ -75,16 +74,6 @@ async function handler(
 
       const { title, visibility, message, contentFragments } =
         bodyValidation.right;
-
-      const executionModeParseResult = ExecutionModeSchema.safeParse(
-        req.query.execution
-      );
-
-      // TODO(pr) remove in follow-up PR
-      // eslint-disable-next-line @typescript-eslint/no-unused-vars
-      const executionMode = executionModeParseResult.success
-        ? executionModeParseResult.data
-        : undefined;
 
       if (message?.context.clientSideMCPServerIds) {
         const hasServerAccess = await concurrentExecutor(

--- a/front/types/assistant/agent_run.ts
+++ b/front/types/assistant/agent_run.ts
@@ -1,8 +1,6 @@
 /**
  * Run agent arguments
  */
-import { z } from "zod";
-
 import { getAgentConfiguration } from "@app/lib/api/assistant/configuration/agent";
 import { getConversation } from "@app/lib/api/assistant/conversation/fetch";
 import type { AuthenticatorType } from "@app/lib/auth";
@@ -20,9 +18,6 @@ import {
   isAgentMessageType,
   isUserMessageType,
 } from "@app/types/assistant/conversation";
-
-export const ExecutionModeSchema = z.enum(["sync", "async", "auto"]);
-export type ExecutionMode = z.infer<typeof ExecutionModeSchema>;
 
 export type AgentLoopArgs = {
   agentMessageId: string;


### PR DESCRIPTION
## Description
Removes the `executionMode` parameter from all agent execution endpoints and types. This parameter is no longer needed since we removed the sync execution path.

## Changes
- Removed `ExecutionMode` type and schema from `types/assistant/agent_run.ts`
- Removed `executionMode` parameter from:
  - `postUserMessageAndWaitForCompletion` (blocking.ts)
  - `submitMessage` and `createConversationWithMessage` (lib.ts)
  - All API endpoints (v1 and internal)
  - `ConversationContainer` component
- Removed query parameter parsing and passing throughout the stack

## Risks
Blast radius: All agent message creation flows (web UI and API endpoints)
Risk: low
Tested on front edge

## Deploy Plan
:warning: 
- will be merged along with https://github.com/dust-tt/dust/pull/16480 and https://github.com/dust-tt/dust/pull/16484
- deploy front at quiet hours to avoid non-determinism error on workflows