### PR TITLE
[front] enh(cc): block PNG export for files with external image URLs client side

### DIFF
--- a/front/components/assistant/conversation/content_creation/ClientExecutableRenderer.tsx
+++ b/front/components/assistant/conversation/content_creation/ClientExecutableRenderer.tsx
@@ -56,7 +56,8 @@ function ExportContentDropdown({
           title: "Export Failed",
           type: "error",
           description:
-            "Content contains images with external URLs, which are blocked for security purposes. Please use images uploaded to the conversation instead.",
+            "Content contains images with external URLs, which are blocked for " +
+            "security purposes. Please use images uploaded to the conversation instead.",
         });
         return;
       }

--- a/front/components/assistant/conversation/content_creation/ClientExecutableRenderer.tsx
+++ b/front/components/assistant/conversation/content_creation/ClientExecutableRenderer.tsx
@@ -56,7 +56,7 @@ function ExportContentDropdown({
           title: "Export Failed",
           type: "error",
           description:
-            "Cannot export to PNG: content contains images with external URLs, which are blocked for security purposes.",
+            "Content contains images with external URLs, which are blocked for security purposes. Please use images uploaded to the conversation instead.",
         });
         return;
       }

--- a/front/components/assistant/conversation/content_creation/ClientExecutableRenderer.tsx
+++ b/front/components/assistant/conversation/content_creation/ClientExecutableRenderer.tsx
@@ -27,8 +27,7 @@ import { useHashParam } from "@app/hooks/useHashParams";
 import { useSendNotification } from "@app/hooks/useNotification";
 import { isUsingConversationFiles } from "@app/lib/files";
 import { useVisualizationRevert } from "@app/lib/swr/conversations";
-import { useFileContent } from "@app/lib/swr/files";
-import { useFileMetadata } from "@app/lib/swr/files";
+import { useFileContent, useFileMetadata } from "@app/lib/swr/files";
 import type {
   ConversationWithoutContentType,
   LightWorkspaceType,
@@ -39,15 +38,30 @@ interface ExportContentDropdownProps {
   iframeRef: React.RefObject<HTMLIFrameElement>;
   owner: LightWorkspaceType;
   fileId: string;
+  fileContent: string | null;
 }
 
 function ExportContentDropdown({
   iframeRef,
   owner,
   fileId,
+  fileContent,
 }: ExportContentDropdownProps) {
   const sendNotification = useSendNotification();
   const exportAsPng = () => {
+    if (fileContent) {
+      const imgRegex = /<img[^>]+src=["'](https?:\/\/[^"']+)["']/gi;
+      if (imgRegex.test(fileContent)) {
+        sendNotification({
+          title: "Export Failed",
+          type: "error",
+          description:
+            "Cannot export to PNG: content contains images with external URLs, which are blocked for security purposes.",
+        });
+        return;
+      }
+    }
+
     if (iframeRef.current?.contentWindow) {
       iframeRef.current.contentWindow.postMessage({ type: `EXPORT_PNG` }, "*");
     } else {
@@ -266,6 +280,7 @@ export function ClientExecutableRenderer({
           iframeRef={iframeRef}
           owner={owner}
           fileId={fileId}
+          fileContent={fileContent ?? null}
         />
         <ShareContentCreationFilePopover
           fileId={fileId}

--- a/front/components/assistant/conversation/content_creation/ClientExecutableRenderer.tsx
+++ b/front/components/assistant/conversation/content_creation/ClientExecutableRenderer.tsx
@@ -53,7 +53,7 @@ function ExportContentDropdown({
       const imgRegex = /<img[^>]+src=["'](https?:\/\/[^"']+)["']/gi;
       if (imgRegex.test(fileContent)) {
         sendNotification({
-          title: "Export Failed",
+          title: "Cannot export as PNG",
           type: "error",
           description:
             "Content contains images with external URLs, which are blocked for " +

--- a/front/components/assistant/conversation/content_creation/ClientExecutableRenderer.tsx
+++ b/front/components/assistant/conversation/content_creation/ClientExecutableRenderer.tsx
@@ -53,8 +53,8 @@ function ExportContentDropdown({
       const imgRegex = /<img[^>]+src=["'](https?:\/\/[^"']+)["']/gi;
       if (imgRegex.test(fileContent)) {
         sendNotification({
-          title: "Cannot export as PNG",
           type: "error",
+          title: "Cannot export as PNG",
           description:
             "Content contains images with external URLs, which are blocked for " +
             "security purposes. Please use images uploaded to the conversation instead.",


### PR DESCRIPTION
## Description

- Part of https://github.com/dust-tt/tasks/issues/4341
- This PR adds a check client side when attempting to export a file as PNG.
- The check is very basic and does not catch URLs that are referenced through a variable.

## Tests

- Tested locally.

## Risk

- Low.

## Deploy Plan

- Deploy front.
