### PR TITLE
Remove use_openai_eu_key flag (#16448)

### DIFF
--- a/front/pages/api/v1/w/[wId]/spaces/[spaceId]/apps/[aId]/runs/index.ts
+++ b/front/pages/api/v1/w/[wId]/spaces/[spaceId]/apps/[aId]/runs/index.ts
@@ -273,14 +273,10 @@ async function handler(
         keyAuth.getNonNullableWorkspace()
       );
 
-      // Temporary flag to help test EU OpenAI in specific workspaces.
-      const useOpenAIEUKeyFlag =
-        keyWorkspaceFlags.includes("use_openai_eu_key");
-
       let credentials: CredentialsType | null = null;
       if (auth.isSystemKey() && !useWorkspaceCredentials) {
         // Dust managed credentials: system API key (packaged apps).
-        credentials = dustManagedCredentials({ useOpenAIEUKeyFlag });
+        credentials = dustManagedCredentials();
       } else {
         credentials = credentialsFromProviders(providers);
       }

--- a/front/temporal/agent_loop/lib/run_model.ts
+++ b/front/temporal/agent_loop/lib/run_model.ts
@@ -34,7 +34,6 @@ import { DEFAULT_MCP_TOOL_RETRY_POLICY } from "@app/lib/api/mcp";
 import { config as regionsConfig } from "@app/lib/api/regions/config";
 import { getSupportedModelConfig } from "@app/lib/assistant";
 import type { Authenticator } from "@app/lib/auth";
-import { getFeatureFlags } from "@app/lib/auth";
 import { cloneBaseConfig, getDustProdAction } from "@app/lib/registry";
 import { AgentStepContentResource } from "@app/lib/resources/agent_step_content_resource";
 import { MCPServerViewResource } from "@app/lib/resources/mcp_server_view_resource";
@@ -553,18 +552,16 @@ export async function runModelActivity(
         } | null;
         const reasoningTokens = meta?.token_usage?.reasoning_tokens ?? 0;
 
-        // Determine the region based on feature flag and current region
-        let region = "us";
-        const workspace = auth.getNonNullableWorkspace();
-        const featureFlags = await getFeatureFlags(workspace);
-
-        if (featureFlags.includes("use_openai_eu_key")) {
-          const currentRegion = regionsConfig.getCurrentRegion();
-          if (currentRegion === "europe-west1") {
+        // Determine the region, using us as the default
+        const currentRegion = regionsConfig.getCurrentRegion();
+        let region: "us" | "eu";
+        switch (currentRegion) {
+          case "europe-west1":
             region = "eu";
-          } else if (currentRegion === "us-central1") {
+            break;
+          case "us-central1":
             region = "us";
-          }
+            break;
         }
 
         const contents = (block.message.contents ?? []).map((content) => {

--- a/front/temporal/agent_loop/lib/run_model.ts
+++ b/front/temporal/agent_loop/lib/run_model.ts
@@ -562,6 +562,8 @@ export async function runModelActivity(
           case "us-central1":
             region = "us";
             break;
+          default:
+            throw new Error(`Unhandled region: ${currentRegion}`);
         }
 
         const contents = (block.message.contents ?? []).map((content) => {

--- a/front/types/api/credentials.ts
+++ b/front/types/api/credentials.ts
@@ -85,11 +85,8 @@ export const credentialsFromProviders = (
   return credentials;
 };
 
-export const dustManagedCredentials = (options?: {
-  useOpenAIEUKeyFlag?: boolean;
-}): CredentialsType => {
-  const useOpenAIEU =
-    options?.useOpenAIEUKeyFlag && DUST_REGION === "europe-west1";
+export const dustManagedCredentials = (): CredentialsType => {
+  const useOpenAIEU = DUST_REGION === "europe-west1";
   return {
     ANTHROPIC_API_KEY: DUST_MANAGED_ANTHROPIC_API_KEY,
     AZURE_OPENAI_API_KEY: DUST_MANAGED_AZURE_OPENAI_API_KEY,

--- a/front/types/shared/feature_flags.ts
+++ b/front/types/shared/feature_flags.ts
@@ -177,10 +177,6 @@ export const WHITELISTABLE_FEATURES_CONFIG = {
     description: "Webhooks for Human Out Of The Loop (aka Triggers) / webhooks",
     stage: "dust_only",
   },
-  use_openai_eu_key: {
-    description: "Use OpenAI EU API key instead of the default OpenAI API key",
-    stage: "on_demand",
-  },
   slack_bot_mcp: {
     description: "Slack bot MCP server for workspace-level Slack integration",
     stage: "on_demand",

--- a/sdks/js/src/types.ts
+++ b/sdks/js/src/types.ts
@@ -680,7 +680,6 @@ const WhitelistableFeaturesSchema = FlexibleEnumSchema<
   | "slack_message_splitting"
   | "slideshow"
   | "usage_data_api"
-  | "use_openai_eu_key"
   | "web_summarization"
   | "xai_feature"
   | "simple_audio_transcription"


### PR DESCRIPTION
## Description

After this change, we will be using the OpenAI EU endpoint in all our openai scenarios for our EU Dust deployment.

This is the same change as the last one, with the addition of Core logic to deal with `CORE_DATA_SOURCES_OPENAI_API_KEY`.

## Tests

Manual

## Risk

Potential for openai EU issues that we didn't catch on more limited rollout.

## Deploy Plan

Core then Front.