### PR TITLE
[front] fix(cc): add some space above viz loading spinner

### DIFF
--- a/viz/app/components/Components.tsx
+++ b/viz/app/components/Components.tsx
@@ -2,7 +2,7 @@
 
 export const Spinner = () => {
   return (
-    <div className="flex items-center justify-center">
+    <div className="flex items-center justify-center min-h-32">
       <div className="w-8 h-8 border-4 border-blue-500 border-t-transparent border-solid rounded-full animate-spin"></div>
     </div>
   );

--- a/viz/app/components/Components.tsx
+++ b/viz/app/components/Components.tsx
@@ -2,7 +2,7 @@
 
 export const Spinner = () => {
   return (
-    <div className="flex items-center justify-center min-h-32">
+    <div className="flex items-center justify-center min-h-24">
       <div className="w-8 h-8 border-4 border-blue-500 border-t-transparent border-solid rounded-full animate-spin"></div>
     </div>
   );


### PR DESCRIPTION
## Description

Part of https://github.com/dust-tt/tasks/issues/4140
This PR adds some space above viz's loading spinner

Before
<img width="346" height="432" alt="Screenshot 2025-10-03 at 8 05 13 PM" src="https://github.com/user-attachments/assets/44866237-8c1f-450e-9522-70707cb9f228" />

After
<img width="346" height="432" alt="Screenshot 2025-10-03 at 8 05 46 PM" src="https://github.com/user-attachments/assets/bdbc37af-bc9f-47d4-9e02-cd2a4c0171db" />

## Tests

- Checked locally.

## Risk

- Low.

## Deploy Plan

- Deploy viz.
