### PR TITLE
[front] chore(cc): remove `conversation_participants` share scope

### DIFF
--- a/front/components/assistant/conversation/content_creation/ShareContentCreationFilePopover.tsx
+++ b/front/components/assistant/conversation/content_creation/ShareContentCreationFilePopover.tsx
@@ -48,11 +48,6 @@ function FileSharingDropdown({
     value: FileShareScope;
   }[] = [
     {
-      icon: LockIcon,
-      label: "Only conversation participants",
-      value: "conversation_participants",
-    },
-    {
       icon: UserGroupIcon,
       label: `Anyone in ${owner.name} workspace`,
       value: "workspace",
@@ -124,9 +119,8 @@ export function ShareContentCreationFilePopover({
   const [isOpen, setIsOpen] = React.useState(false);
   const [isCopied, copyToClipboard] = useCopyToClipboard();
   const [isUpdatingShare, setIsUpdatingShare] = React.useState(false);
-  const [selectedScope, setSelectedScope] = React.useState<FileShareScope>(
-    "conversation_participants"
-  );
+  const [selectedScope, setSelectedScope] =
+    React.useState<FileShareScope>("workspace");
 
   const isPublicSharingForbidden =
     owner.metadata?.allowContentCreationFileSharing === false;

--- a/front/components/assistant/conversation/content_creation/ShareContentCreationFilePopover.tsx
+++ b/front/components/assistant/conversation/content_creation/ShareContentCreationFilePopover.tsx
@@ -11,6 +11,7 @@ import {
   GlobeAltIcon,
   InformationCircleIcon,
   Label,
+  LinkIcon,
   LockIcon,
   PopoverContent,
   PopoverRoot,

--- a/front/components/assistant/conversation/content_creation/ShareContentCreationFilePopover.tsx
+++ b/front/components/assistant/conversation/content_creation/ShareContentCreationFilePopover.tsx
@@ -11,8 +11,6 @@ import {
   GlobeAltIcon,
   InformationCircleIcon,
   Label,
-  LinkIcon,
-  LockIcon,
   PopoverContent,
   PopoverRoot,
   PopoverTrigger,

--- a/front/components/assistant/conversation/content_creation/ShareContentCreationFilePopover.tsx
+++ b/front/components/assistant/conversation/content_creation/ShareContentCreationFilePopover.tsx
@@ -50,7 +50,7 @@ function FileSharingDropdown({
   }[] = [
     {
       icon: UserGroupIcon,
-      label: `Anyone in ${owner.name} workspace`,
+      label: `${owner.name} workspace members with the link`,
       value: "workspace",
     },
     {

--- a/front/lib/resources/file_resource.ts
+++ b/front/lib/resources/file_resource.ts
@@ -316,11 +316,11 @@ export class FileResource extends BaseResource<FileModel> {
     const updateResult = await this.update({ status: "ready" });
 
     // For Content Creation conversation files, automatically create a ShareableFileModel with
-    // default conversation_participants scope.
+    // default workspace scope.
     if (this.isContentCreation) {
       await ShareableFileModel.upsert({
         fileId: this.id,
-        shareScope: "conversation_participants",
+        shareScope: "workspace",
         sharedBy: this.userId ?? null,
         workspaceId: this.workspaceId,
         sharedAt: new Date(),

--- a/front/migrations/20251003_remove_conversation_participants_scope.ts
+++ b/front/migrations/20251003_remove_conversation_participants_scope.ts
@@ -1,0 +1,20 @@
+import { ShareableFileModel } from "@app/lib/resources/storage/models/files";
+import { makeScript } from "@app/scripts/helpers";
+
+makeScript({}, async ({ execute }, logger) => {
+  if (!execute) {
+    logger.info("No action to perform");
+  }
+  const [updatedCount] = await ShareableFileModel.update(
+    { shareScope: "workspace" },
+    {
+      where: {
+        shareScope: "conversation_participants",
+      },
+    }
+  );
+
+  logger.info(
+    `Updated ${updatedCount} shareable_files from "conversation_participants" to "workspace" scope`
+  );
+});

--- a/front/pages/api/v1/public/frames/[token]/index.ts
+++ b/front/pages/api/v1/public/frames/[token]/index.ts
@@ -86,18 +86,6 @@ async function handler(
     });
   }
 
-  // This endpoint does not support conversation participants sharing. It goes through the private
-  // API endpoint instead.
-  if (shareScope === "conversation_participants") {
-    return apiError(req, res, {
-      status_code: 404,
-      api_error: {
-        type: "file_not_found",
-        message: "File not found.",
-      },
-    });
-  }
-
   // For workspace sharing, check authentication.
   if (shareScope === "workspace") {
     const isWorkspaceUser = await isSessionWithUserFromWorkspace(

--- a/front/pages/share/file/[token].tsx
+++ b/front/pages/share/file/[token].tsx
@@ -7,13 +7,6 @@ import { makeGetServerSidePropsRequirementsWrapper } from "@app/lib/iam/session"
 import { FileResource } from "@app/lib/resources/file_resource";
 import { WorkspaceResource } from "@app/lib/resources/workspace_resource";
 import { getFaviconPath } from "@app/lib/utils";
-import { getAgentRoute } from "@app/lib/utils/router";
-import {
-  CONTENT_CREATION_SIDE_PANEL_TYPE,
-  FULL_SCREEN_HASH_PARAM,
-  SIDE_PANEL_HASH_PARAM,
-  SIDE_PANEL_TYPE_HASH_PARAM,
-} from "@app/types/conversation_side_panel";
 
 interface SharedFilePageProps {
   shareUrl: string;
@@ -47,28 +40,11 @@ export const getServerSideProps = makeGetServerSidePropsRequirementsWrapper({
     };
   }
 
-  const { file, shareScope } = result;
+  const { file } = result;
   const workspace = await WorkspaceResource.fetchByModelId(file.workspaceId);
   if (!workspace) {
     return {
       notFound: true,
-    };
-  }
-
-  // If the file is shared with conversation participants, redirect to the conversation.
-  if (shareScope === "conversation_participants") {
-    const pathname = getAgentRoute(
-      workspace.sId,
-      file.useCaseMetadata?.conversationId
-    );
-    const hash = `#?${FULL_SCREEN_HASH_PARAM}=true&${SIDE_PANEL_TYPE_HASH_PARAM}=${CONTENT_CREATION_SIDE_PANEL_TYPE}&${SIDE_PANEL_HASH_PARAM}=${file.sId}`;
-    const destination = pathname + hash;
-
-    return {
-      redirect: {
-        destination,
-        permanent: false,
-      },
     };
   }
 

--- a/front/types/files.ts
+++ b/front/types/files.ts
@@ -31,11 +31,7 @@ export type FileUseCaseMetadata = {
   lastEditedByAgentConfigurationId?: string;
 };
 
-export const fileShareScopeSchema = z.enum([
-  "conversation_participants",
-  "workspace",
-  "public",
-]);
+export const fileShareScopeSchema = z.enum(["workspace", "public"]);
 
 export type FileShareScope = z.infer<typeof fileShareScopeSchema>;
 


### PR DESCRIPTION
## Description

- Closes https://github.com/dust-tt/tasks/issues/4466.
- This PR removes the `conversation_participants` share scope, which is currently used by content creation files.
- This leaves workspace and public scopes, workspace being the new default (the label has been changed to `"xxx workspace members with the link"` instead of `"anyone in the xxx workspace"`).
- The current design changes the scope when selecting the dropdown item, which is a bit different than what we do elsewhere in the product and could be revisited.

## Tests

- Checked locally.

## Risk

- Low, not widely used yet.

## Deploy Plan

- Run migration script.
- Deploy front.
