### PR TITLE
bigquery: reduce concurrency

### DIFF
--- a/connectors/src/connectors/bigquery/lib/bigquery_api.ts
+++ b/connectors/src/connectors/bigquery/lib/bigquery_api.ts
@@ -293,7 +293,7 @@ export const fetchTree = async ({
                 tables,
               };
             },
-            { concurrency: 4 }
+            { concurrency: 2 }
           ),
         };
       },


### PR DESCRIPTION
## Description

Reduce a bit concurrency as we have a rate limit on getTables (but not ont getTableMetadata)

https://app.datadoghq.eu/logs?query=%40workflowId%3Abigquery-sync-23235%20-%22%5BBigQuery%5D%20table.getMetadata%22&agg_m=count&agg_m_source=base&agg_t=count&cols=host%2Cservice&event=AwAAAZmt-1hNYFf01wAAABhBWm10LTJXTEFBQnRpblgwVlowc2x3QUMAAAAkZjE5OWFkZmItNzZlMC00MjU1LWFmOTktOWI1YmE2NDQxZjc4AAAYcg&messageDisplay=inline&refresh_mode=sliding&storage=hot&stream_sort=desc&viz=stream&from_ts=1759546227138&to_ts=1759560627138&live=true

## Tests

N/A

## Risk

Low easy to revert

## Deploy Plan

- deploy `connectors`