### PR TITLE
github: remove panic flag when skipping >10GB repos

### DIFF
--- a/connectors/src/connectors/github/lib/github_code.ts
+++ b/connectors/src/connectors/github/lib/github_code.ts
@@ -8,7 +8,6 @@ import {
 } from "@connectors/connectors/github/lib/errors";
 import logger from "@connectors/logger/logger";
 import type { ConnectorResource } from "@connectors/resources/connector_resource";
-import { fileSizeToHumanReadable } from "@connectors/types";
 
 const REPO_SIZE_LIMIT = 10 * 1024 * 1024; // 10GB in KB
 

--- a/connectors/src/connectors/github/lib/github_code.ts
+++ b/connectors/src/connectors/github/lib/github_code.ts
@@ -74,7 +74,7 @@ export function isRepoTooLarge(
         repoName: repoInfo.name,
         size: repoInfo.size,
       },
-      `GitHub repository too large to sync`
+      "GitHub repository too large to sync"
     );
 
     return true;

--- a/connectors/src/connectors/github/lib/github_code.ts
+++ b/connectors/src/connectors/github/lib/github_code.ts
@@ -74,9 +74,8 @@ export function isRepoTooLarge(
         repoLogin: repoInfo.owner.login,
         repoName: repoInfo.name,
         size: repoInfo.size,
-        panic: true,
       },
-      `GitHub repository too large to sync (size: ${fileSizeToHumanReadable(repoInfo.size * 1024)}, max: 10 GB).`
+      `GitHub repository too large to sync`
     );
 
     return true;


### PR DESCRIPTION
## Description

Context: https://dust4ai.slack.com/archives/C050SM8NSPK/p1759737201267049
Runbook updated: https://www.notion.so/dust-tt/Runbook-Github-28428599d941802a9501feebd7507e8d?source=copy_link

## Tests

N/A

## Risk

LoW

## Deploy Plan

- deploy `connectors`