### PR TITLE
[front] - fix(ConversationSidePanelContainer): hide resizable handle on small screens

### DIFF
--- a/front/components/assistant/conversation/ConversationSidePanelContainer.tsx
+++ b/front/components/assistant/conversation/ConversationSidePanelContainer.tsx
@@ -23,7 +23,6 @@ export default function ConversationSidePanelContainer({
   const { currentPanel, setPanelRef, onPanelClosed } =
     useConversationSidePanelContext();
   const panelRef = useRef<ImperativePanelHandle | null>(null);
-
   const isMobile = useIsMobile();
 
   useEffect(() => {


### PR DESCRIPTION

## Description

Make the resizable handle for panels hidden on small screens and only visible on medium and larger devices

## Tests

Locally, opening a breakdown panel

## Risk

Low

## Deploy Plan

Deploy front
