### PR TITLE
[front] - fix(DataSourceList): disable incompatible tables

### DIFF
--- a/extension/package-lock.json
+++ b/extension/package-lock.json
@@ -12,7 +12,7 @@
         "@auth0/auth0-spa-js": "^2.1.3",
         "@datadog/browser-logs": "^6.13.0",
         "@dust-tt/client": "^1.1.15",
-        "@dust-tt/sparkle": "^0.2.648",
+        "@dust-tt/sparkle": "^0.2.649",
         "@frontapp/plugin-sdk": "^1.8.1",
         "@modelcontextprotocol/sdk": "^1.9.0",
         "@tailwindcss/forms": "^0.5.9",
@@ -1293,10 +1293,9 @@
       }
     },
     "node_modules/@dust-tt/sparkle": {
-      "version": "0.2.648",
-      "resolved": "https://registry.npmjs.org/@dust-tt/sparkle/-/sparkle-0.2.648.tgz",
-      "integrity": "sha512-ql3vxL7ozQYBsoic7uzew3U2KgXynv4n9ckAJfEoQ3/jmJWVyb1+5g9oY3UgZK5eYeY9e5M3GAlEcYxy8iKqkQ==",
-      "license": "ISC",
+      "version": "0.2.649",
+      "resolved": "https://registry.npmjs.org/@dust-tt/sparkle/-/sparkle-0.2.649.tgz",
+      "integrity": "sha512-k+YCEkwijUV9wGlaepUkym4lYrShZDfvUETHnuA3Df9bX/aOXwTpWybo+f6cckesvKNcm4tv02qJ28KPQbjesQ==",
       "dependencies": {
         "@emoji-mart/data": "^1.1.2",
         "@emoji-mart/react": "^1.1.1",

--- a/extension/package.json
+++ b/extension/package.json
@@ -59,7 +59,7 @@
     "@auth0/auth0-spa-js": "^2.1.3",
     "@datadog/browser-logs": "^6.13.0",
     "@dust-tt/client": "^1.1.15",
-    "@dust-tt/sparkle": "^0.2.648",
+    "@dust-tt/sparkle": "^0.2.649",
     "@frontapp/plugin-sdk": "^1.8.1",
     "@modelcontextprotocol/sdk": "^1.9.0",
     "@tailwindcss/forms": "^0.5.9",

--- a/front/components/agent_builder/capabilities/knowledge/DataSourceList.tsx
+++ b/front/components/agent_builder/capabilities/knowledge/DataSourceList.tsx
@@ -169,7 +169,6 @@ export function DataSourceList({
       }
 
       const isItemRemote = isRemoteDatabase(itemDataSource);
-      const itemProvider = itemDataSource.connectorProvider;
 
       // Check all selected items in the tree
       for (const selected of field.value.in) {
@@ -189,7 +188,6 @@ export function DataSourceList({
         }
 
         const isSelectedRemote = isRemoteDatabase(selectedDataSource);
-        const selectedProvider = selectedDataSource.connectorProvider;
 
         // If a remote table is selected, disable all local tables and other remote tables
         if (isSelectedRemote && !isItemRemote) {
@@ -201,11 +199,11 @@ export function DataSourceList({
           return true;
         }
 
-        // If both are remote but different providers, disable
+        // If both are remote but from different data sources, disable
         if (
           isItemRemote &&
           isSelectedRemote &&
-          itemProvider !== selectedProvider
+          itemDataSource.sId !== selectedDataSource.sId
         ) {
           return true;
         }

--- a/front/components/agent_builder/capabilities/knowledge/DataSourceList.tsx
+++ b/front/components/agent_builder/capabilities/knowledge/DataSourceList.tsx
@@ -430,7 +430,7 @@ export function DataSourceList({
                       handleSelectionChange(item, state)
                     }
                     tooltip={
-                      !disabled
+                      disabled
                         ? "Tables from different data sources cannot be queried together"
                         : undefined
                     }

--- a/front/package-lock.json
+++ b/front/package-lock.json
@@ -7,7 +7,7 @@
       "dependencies": {
         "@datadog/browser-logs": "^6.13.0",
         "@dust-tt/client": "file:../sdks/js",
-        "@dust-tt/sparkle": "^0.2.648",
+        "@dust-tt/sparkle": "^0.2.649",
         "@google-cloud/bigquery": "^7.9.1",
         "@google-cloud/storage-transfer": "^3.6.0",
         "@heroicons/react": "^2.0.11",
@@ -1151,10 +1151,9 @@
       "link": true
     },
     "node_modules/@dust-tt/sparkle": {
-      "version": "0.2.648",
-      "resolved": "https://registry.npmjs.org/@dust-tt/sparkle/-/sparkle-0.2.648.tgz",
-      "integrity": "sha512-ql3vxL7ozQYBsoic7uzew3U2KgXynv4n9ckAJfEoQ3/jmJWVyb1+5g9oY3UgZK5eYeY9e5M3GAlEcYxy8iKqkQ==",
-      "license": "ISC",
+      "version": "0.2.649",
+      "resolved": "https://registry.npmjs.org/@dust-tt/sparkle/-/sparkle-0.2.649.tgz",
+      "integrity": "sha512-k+YCEkwijUV9wGlaepUkym4lYrShZDfvUETHnuA3Df9bX/aOXwTpWybo+f6cckesvKNcm4tv02qJ28KPQbjesQ==",
       "dependencies": {
         "@emoji-mart/data": "^1.1.2",
         "@emoji-mart/react": "^1.1.1",

--- a/front/package.json
+++ b/front/package.json
@@ -28,7 +28,7 @@
   "dependencies": {
     "@datadog/browser-logs": "^6.13.0",
     "@dust-tt/client": "file:../sdks/js",
-    "@dust-tt/sparkle": "^0.2.648",
+    "@dust-tt/sparkle": "^0.2.649",
     "@google-cloud/bigquery": "^7.9.1",
     "@google-cloud/storage-transfer": "^3.6.0",
     "@heroicons/react": "^2.0.11",


### PR DESCRIPTION
## Description

Prevents users from selecting incompatible data sources when configuring table queries in the Agent Builder. Implements logic to disable data source selections that cannot be queried together, specifically preventing mixing of remote tables with local ones or different remote providers.

**References:**
- https://github.com/dust-tt/tasks/issues/4222

## Risk

Low, mainly UI

## Deploy Plan

Deploy front
