### PR TITLE
[sparkle] - feat: add tooltip to Checkbox component

### DIFF
--- a/sparkle/src/components/Checkbox.tsx
+++ b/sparkle/src/components/Checkbox.tsx
@@ -79,7 +79,11 @@ const Checkbox = React.forwardRef<
     </CheckboxPrimitive.Root>
   );
 
-  return tooltip ? <Tooltip label={tooltip} trigger={checkbox} /> : checkbox;
+  return tooltip ? (
+    <Tooltip label={tooltip} trigger={checkbox} tooltipTriggerAsChild />
+  ) : (
+    checkbox
+  );
 });
 
 Checkbox.displayName = CheckboxPrimitive.Root.displayName;

--- a/sparkle/src/components/Checkbox.tsx
+++ b/sparkle/src/components/Checkbox.tsx
@@ -58,7 +58,7 @@ interface CheckboxProps
 const Checkbox = React.forwardRef<
   React.ElementRef<typeof CheckboxPrimitive.Root>,
   CheckboxProps
->(({ className, size, checked, id, ...props }, ref) => {
+>(({ className, size, checked, id, tooltip, ...props }, ref) => {
   const checkbox = (
     <CheckboxPrimitive.Root
       ref={ref}
@@ -79,7 +79,7 @@ const Checkbox = React.forwardRef<
     </CheckboxPrimitive.Root>
   );
 
-  return checkbox;
+  return tooltip ? <Tooltip label={tooltip} trigger={checkbox} /> : checkbox;
 });
 
 Checkbox.displayName = CheckboxPrimitive.Root.displayName;


### PR DESCRIPTION
## Description

This PR adds the following feature: Checkbox now conditionally wraps with a Tooltip component if a tooltip prop is provided

## Tests

Storybook

## Risk

Low

## Deploy Plan

Publish sparkle
