### PR TITLE
fix: sanitize action name before saving

### DIFF
--- a/front/components/agent_builder/types.ts
+++ b/front/components/agent_builder/types.ts
@@ -4,6 +4,7 @@ import { z } from "zod";
 
 import type { agentBuilderFormSchema } from "@app/components/agent_builder/AgentBuilderFormContext";
 import { mcpServerConfigurationSchema } from "@app/components/agent_builder/AgentBuilderFormContext";
+import { nameToStorageFormat } from "@app/components/agent_builder/capabilities/mcp/utils/actionNameUtils";
 import { getDefaultConfiguration } from "@app/components/agent_builder/capabilities/mcp/utils/formDefaults";
 import { dataSourceBuilderTreeType } from "@app/components/data_source_view/context/types";
 import { DEFAULT_MCP_ACTION_NAME } from "@app/lib/actions/constants";
@@ -173,12 +174,15 @@ export function getDefaultMCPAction(
 ): AgentBuilderAction {
   const toolsConfigurations = getMCPServerToolsConfigurations(mcpServerView);
   const configuration = getDefaultConfiguration(mcpServerView);
+  const rawName = mcpServerView?.name ?? mcpServerView?.server.name ?? "";
+  const sanitizedName = rawName ? nameToStorageFormat(rawName) : "";
 
   return {
     id: uniqueId(),
     type: "MCP",
     configuration,
-    name: mcpServerView?.name ?? mcpServerView?.server.name ?? "",
+    // Ensure default name always matches validation regex (^[a-z0-9_]+$)
+    name: sanitizedName,
     description:
       toolsConfigurations.dataSourceConfiguration ??
       toolsConfigurations.dataWarehouseConfiguration ??


### PR DESCRIPTION
## Description

The default name for web search & browse (which we don't let people override) does not comply with the agent builder's rules. This is an issue when the "web summarization" flag is enabled, since the tool becomes configurable

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
