### PR TITLE
fix: revert sanitize server name + allow ampersand

### DIFF
--- a/front/components/agent_builder/capabilities/mcp/utils/validationMessages.ts
+++ b/front/components/agent_builder/capabilities/mcp/utils/validationMessages.ts
@@ -18,7 +18,7 @@ export const VALIDATION_MESSAGES = {
   name: {
     empty: "The name cannot be empty.",
     format:
-      "The name can only contain lowercase letters, numbers, and underscores (no spaces).",
+      "The name can only contain lowercase letters, numbers, underscores and & (no spaces).",
   },
   description: {
     required: "Description is required",

--- a/front/components/agent_builder/capabilities/mcp/validation/schemaBuilders.ts
+++ b/front/components/agent_builder/capabilities/mcp/validation/schemaBuilders.ts
@@ -23,7 +23,7 @@ export function createBaseFormSchema() {
     name: z
       .string()
       .min(1, VALIDATION_MESSAGES.name.empty)
-      .regex(/^[a-z0-9_]+$/, VALIDATION_MESSAGES.name.format)
+      .regex(/^[a-z0-9_&]+$/, VALIDATION_MESSAGES.name.format)
       .default(""),
     description: z
       .string()

--- a/front/components/agent_builder/types.ts
+++ b/front/components/agent_builder/types.ts
@@ -4,7 +4,6 @@ import { z } from "zod";
 
 import type { agentBuilderFormSchema } from "@app/components/agent_builder/AgentBuilderFormContext";
 import { mcpServerConfigurationSchema } from "@app/components/agent_builder/AgentBuilderFormContext";
-import { nameToStorageFormat } from "@app/components/agent_builder/capabilities/mcp/utils/actionNameUtils";
 import { getDefaultConfiguration } from "@app/components/agent_builder/capabilities/mcp/utils/formDefaults";
 import { dataSourceBuilderTreeType } from "@app/components/data_source_view/context/types";
 import { DEFAULT_MCP_ACTION_NAME } from "@app/lib/actions/constants";
@@ -174,15 +173,12 @@ export function getDefaultMCPAction(
 ): AgentBuilderAction {
   const toolsConfigurations = getMCPServerToolsConfigurations(mcpServerView);
   const configuration = getDefaultConfiguration(mcpServerView);
-  const rawName = mcpServerView?.name ?? mcpServerView?.server.name ?? "";
-  const sanitizedName = rawName ? nameToStorageFormat(rawName) : "";
 
   return {
     id: uniqueId(),
     type: "MCP",
     configuration,
-    // Ensure default name always matches validation regex (^[a-z0-9_]+$)
-    name: sanitizedName,
+    name: mcpServerView?.name ?? mcpServerView?.server.name ?? "",
     description:
       toolsConfigurations.dataSourceConfiguration ??
       toolsConfigurations.dataWarehouseConfiguration ??

--- a/front/components/assistant_builder/server_side_props_helpers.ts
+++ b/front/components/assistant_builder/server_side_props_helpers.ts
@@ -66,8 +66,9 @@ export async function buildInitialActions({
       action.type === "mcp_server_configuration",
       "Legacy action type, non-MCP, are no longer supported."
     );
+    // Prefer matching by view sId for robustness (action names can be customized)
     const mcpServerView = mcpServerViews.find(
-      (mcpServerView) => mcpServerView.server.name === action.name
+      (view) => view.sId === action.mcpServerViewId
     );
 
     const builderAction = await getMCPServerActionConfiguration(


### PR DESCRIPTION
## Description

Sanitizing the name is causing issues with matching. This change simply reverts that and allows using ampersand in the server name (which makes sense since we're allowing it in our own default server names)

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
