### PR TITLE
Only admin from system view can update triggers + propagate changes to other views

### DIFF
--- a/front/lib/resources/base_resource.ts
+++ b/front/lib/resources/base_resource.ts
@@ -86,7 +86,9 @@ export abstract class BaseResource<M extends Model & ResourceWithId> {
     });
 
     // Update the current instance with the new values to avoid stale data.
-    Object.assign(this, affectedRows[0].get());
+    if (affectedRows[0]) {
+      Object.assign(this, affectedRows[0].get());
+    }
 
     return [affectedCount];
   }

--- a/front/lib/resources/webhook_sources_view_resource.ts
+++ b/front/lib/resources/webhook_sources_view_resource.ts
@@ -330,6 +330,32 @@ export class WebhookSourcesViewResource extends ResourceWithSpace<WebhookSources
     return new Ok(affectedCount);
   }
 
+  public static async bulkUpdateName(
+    auth: Authenticator,
+    viewIds: ModelId[],
+    name?: string
+  ): Promise<void> {
+    if (viewIds.length === 0) {
+      return;
+    }
+
+    await this.model.update(
+      {
+        customName: name ?? null,
+        editedAt: new Date(),
+        editedByUserId: auth.getNonNullableUser().id,
+      },
+      {
+        where: {
+          workspaceId: auth.getNonNullableWorkspace().id,
+          id: {
+            [Op.in]: viewIds,
+          },
+        },
+      }
+    );
+  }
+
   // Deletion.
 
   protected async softDelete(

--- a/front/lib/resources/webhook_sources_view_resource.ts
+++ b/front/lib/resources/webhook_sources_view_resource.ts
@@ -310,7 +310,8 @@ export class WebhookSourcesViewResource extends ResourceWithSpace<WebhookSources
 
   public async updateName(
     auth: Authenticator,
-    name?: string
+    name?: string,
+    transaction?: Transaction
   ): Promise<Result<number, DustError<"unauthorized">>> {
     if (!this.canAdministrate(auth)) {
       return new Err(
@@ -318,11 +319,14 @@ export class WebhookSourcesViewResource extends ResourceWithSpace<WebhookSources
       );
     }
 
-    const [affectedCount] = await this.update({
-      customName: name ?? null,
-      editedAt: new Date(),
-      editedByUserId: auth.getNonNullableUser().id,
-    });
+    const [affectedCount] = await this.update(
+      {
+        customName: name ?? null,
+        editedAt: new Date(),
+        editedByUserId: auth.getNonNullableUser().id,
+      },
+      transaction
+    );
     return new Ok(affectedCount);
   }
 

--- a/front/pages/api/w/[wId]/webhook_sources/views/[viewId]/index.ts
+++ b/front/pages/api/w/[wId]/webhook_sources/views/[viewId]/index.ts
@@ -180,7 +180,11 @@ async function editWebhookSourceViewsName(
   try {
     for (const view of allViews) {
       if (view.sId !== webhookSourceView.sId) {
-        const viewUpdateResult = await view.updateName(auth, newName, transaction);
+        const viewUpdateResult = await view.updateName(
+          auth,
+          newName,
+          transaction
+        );
         if (viewUpdateResult.isErr()) {
           await transaction.rollback();
           return viewUpdateResult;

--- a/front/pages/api/w/[wId]/webhook_sources/views/[viewId]/index.ts
+++ b/front/pages/api/w/[wId]/webhook_sources/views/[viewId]/index.ts
@@ -2,9 +2,11 @@ import type { NextApiRequest, NextApiResponse } from "next";
 
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
 import type { Authenticator } from "@app/lib/auth";
+import type { DustError } from "@app/lib/error";
 import { WebhookSourcesViewResource } from "@app/lib/resources/webhook_sources_view_resource";
 import { apiError } from "@app/logger/withlogging";
-import type { WithAPIErrorResponse } from "@app/types";
+import type { Result,WithAPIErrorResponse  } from "@app/types";
+import { assertNever, Ok } from "@app/types";
 import type { WebhookSourceViewType } from "@app/types/triggers/webhooks";
 import { patchWebhookSourceViewBodySchema } from "@app/types/triggers/webhooks";
 
@@ -73,6 +75,17 @@ async function handler(
         });
       }
 
+      // Validate that this is a system view
+      if (webhookSourceView.space.kind !== "system") {
+        return apiError(req, res, {
+          status_code: 400,
+          api_error: {
+            type: "invalid_request_error",
+            message: "Updates can only be performed on system views.",
+          },
+        });
+      }
+
       const { name } = bodyValidation.data;
 
       const result = await webhookSourceView.updateName(auth, name);
@@ -98,6 +111,27 @@ async function handler(
         }
       }
 
+      const updateResult = await propagateSystemViewNameChange(
+        auth,
+        webhookSourceView,
+        name
+      );
+      if (updateResult.isErr()) {
+        switch (updateResult.error.code) {
+          case "unauthorized":
+            return apiError(req, res, {
+              status_code: 401,
+              api_error: {
+                type: "workspace_auth_error",
+                message:
+                  "You are not authorized to update the MCP server view.",
+              },
+            });
+          default:
+            assertNever(updateResult.error.code);
+        }
+      }
+
       return res.status(200).json({
         webhookSourceView: webhookSourceView.toJSON(),
       });
@@ -113,6 +147,39 @@ async function handler(
         },
       });
   }
+}
+
+async function propagateSystemViewNameChange(
+  auth: Authenticator,
+  webhookSourceView: WebhookSourcesViewResource,
+  newName: string
+): Promise<Result<undefined, DustError<"unauthorized">>> {
+  // Propagate changes to system view and all space views
+  const systemView =
+    await WebhookSourcesViewResource.getWebhookSourceViewForSystemSpace(
+      auth,
+      webhookSourceView.webhookSourceSId
+    );
+
+  const isSystemView = systemView?.sId === webhookSourceView.sId;
+
+  if (isSystemView) {
+    // This is the system view, update all space views with the same webhook source
+    const allViews = await WebhookSourcesViewResource.listByWebhookSource(
+      auth,
+      webhookSourceView.webhookSourceId
+    );
+
+    for (const view of allViews) {
+      if (view.sId !== webhookSourceView.sId) {
+        const viewUpdateResult = await view.updateName(auth, newName);
+        if (viewUpdateResult.isErr()) {
+          return viewUpdateResult;
+        }
+      }
+    }
+  }
+  return new Ok(undefined);
 }
 
 export default withSessionAuthenticationForWorkspace(handler);

--- a/front/pages/api/w/[wId]/webhook_sources/views/[viewId]/index.ts
+++ b/front/pages/api/w/[wId]/webhook_sources/views/[viewId]/index.ts
@@ -5,7 +5,7 @@ import type { Authenticator } from "@app/lib/auth";
 import type { DustError } from "@app/lib/error";
 import { WebhookSourcesViewResource } from "@app/lib/resources/webhook_sources_view_resource";
 import { apiError } from "@app/logger/withlogging";
-import type { Result,WithAPIErrorResponse  } from "@app/types";
+import type { Result, WithAPIErrorResponse } from "@app/types";
 import { assertNever, Ok } from "@app/types";
 import type { WebhookSourceViewType } from "@app/types/triggers/webhooks";
 import { patchWebhookSourceViewBodySchema } from "@app/types/triggers/webhooks";


### PR DESCRIPTION
## Description

Preliminary work for https://github.com/issues/assigned?issue=dust-tt%7Ctasks%7C4220

Only the system view must be able to edit the name of the triggers
When such change happen, it should propagate to other views
Inspired from what is done for MCP

## Tests

Unit tests on API + manual tests that it works 

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

Deploy front
