### PR TITLE
[chore] - front(Mention): add description on hover

### DIFF
--- a/extension/ui/components/input_bar/editor/extensions/MentionWithPasteExtension.tsx
+++ b/extension/ui/components/input_bar/editor/extensions/MentionWithPasteExtension.tsx
@@ -8,6 +8,25 @@ const escapeRegExp = (string: string): string => {
 };
 
 export const MentionWithPasteExtension = Mention.extend({
+  addAttributes() {
+    return {
+      ...this.parent?.(),
+      // Add description attribute to store agent description for tooltip display
+      description: {
+        default: null,
+        parseHTML: (element) => element.getAttribute("data-description"),
+        renderHTML: (attributes) => {
+          if (!attributes.description) {
+            return {};
+          }
+          return {
+            "data-description": attributes.description,
+          };
+        },
+      },
+    };
+  },
+
   addPasteRules() {
     const pasteRule = nodePasteRule({
       find: (text) => {
@@ -31,7 +50,11 @@ export const MentionWithPasteExtension = Mention.extend({
                 index: match.index,
                 text: match[1],
                 replaceWith: suggestion.label,
-                data: { id: suggestion.id, label: suggestion.label },
+                data: {
+                  id: suggestion.id,
+                  label: suggestion.label,
+                  description: suggestion.description,
+                },
               };
             });
           }
@@ -40,7 +63,11 @@ export const MentionWithPasteExtension = Mention.extend({
       },
       type: this.type,
       getAttributes: (match: Record<string, any>) => {
-        return { label: match.data["label"], id: match.data["id"] };
+        return {
+          label: match.data["label"],
+          id: match.data["id"],
+          description: match.data["description"],
+        };
       },
     });
 

--- a/extension/ui/components/input_bar/editor/suggestion.ts
+++ b/extension/ui/components/input_bar/editor/suggestion.ts
@@ -6,6 +6,7 @@ export interface EditorSuggestion {
   label: string;
   pictureUrl: string;
   userFavorite: boolean;
+  description: string;
 }
 
 export interface EditorSuggestions {

--- a/extension/ui/components/input_bar/editor/useCustomEditor.tsx
+++ b/extension/ui/components/input_bar/editor/useCustomEditor.tsx
@@ -61,6 +61,7 @@ export const ParagraphExtension = Paragraph.extend({
 export interface EditorMention {
   id: string;
   label: string;
+  description?: string;
 }
 
 function getTextAndMentionsFromNode(node?: JSONContent) {
@@ -122,7 +123,15 @@ const useEditorService = (editor: Editor | null) => {
     // Return the service object with utility functions.
     return {
       // Insert mention helper function.
-      insertMention: ({ id, label }: { id: string; label: string }) => {
+      insertMention: ({
+        id,
+        label,
+        description,
+      }: {
+        id: string;
+        label: string;
+        description?: string;
+      }) => {
         const shouldAddSpaceBeforeMention =
           !editor?.isEmpty &&
           editor?.getText()[editor?.getText().length - 1] !== " ";
@@ -132,7 +141,7 @@ const useEditorService = (editor: Editor | null) => {
           .insertContent(shouldAddSpaceBeforeMention ? " " : "") // Add an extra space before the mention.
           .insertContent({
             type: "mention",
-            attrs: { id, label },
+            attrs: { id, label, description },
           })
           .insertContent(" ") // Add an extra space after the mention.
           .run();

--- a/extension/ui/components/input_bar/editor/useHandleMentions.tsx
+++ b/extension/ui/components/input_bar/editor/useHandleMentions.tsx
@@ -44,6 +44,7 @@ const useHandleMentions = (
           mentionsToInsert.push({
             id: agentConfiguration.sId,
             label: agentConfiguration.name,
+            description: agentConfiguration.description,
           });
         }
       }
@@ -69,6 +70,7 @@ const useHandleMentions = (
       const mention = {
         id: agentConfiguration.sId,
         label: agentConfiguration.name,
+        description: agentConfiguration.description,
       };
 
       if (!editorService.hasMention(mention)) {

--- a/extension/ui/components/input_bar/editor/useMentionDropdown.tsx
+++ b/extension/ui/components/input_bar/editor/useMentionDropdown.tsx
@@ -75,7 +75,11 @@ export const useMentionDropdown = (
           .deleteRange(rangeRef.current)
           .insertContent({
             type: "mention",
-            attrs: { id: suggestion.id, label: suggestion.label },
+            attrs: {
+              id: suggestion.id,
+              label: suggestion.label,
+              description: suggestion.description,
+            },
           })
           .insertContent(" ") // Add space after mention
           .run();

--- a/extension/ui/components/input_bar/editor/usePublicAssistantSuggestions.ts
+++ b/extension/ui/components/input_bar/editor/usePublicAssistantSuggestions.ts
@@ -14,6 +14,7 @@ function makeEditorSuggestions(
       label: agent.name,
       pictureUrl: agent.pictureUrl,
       userFavorite: agent.userFavorite,
+      description: agent.description,
     }));
 }
 

--- a/front/components/assistant/conversation/input_bar/InputBarContainer.tsx
+++ b/front/components/assistant/conversation/input_bar/InputBarContainer.tsx
@@ -526,7 +526,11 @@ const InputBarContainer = ({
                   owner={owner}
                   size="xs"
                   onItemClick={(c) => {
-                    editorService.insertMention({ id: c.sId, label: c.name });
+                    editorService.insertMention({
+                      id: c.sId,
+                      label: c.name,
+                      description: c.description,
+                    });
                   }}
                   assistants={allAssistants}
                   showDropdownArrow={false}

--- a/front/components/assistant/conversation/input_bar/editor/MentionComponent.tsx
+++ b/front/components/assistant/conversation/input_bar/editor/MentionComponent.tsx
@@ -5,6 +5,10 @@ import {
   DropdownMenuItem,
   DropdownMenuTrigger,
   EyeIcon,
+  TooltipContent,
+  TooltipProvider,
+  TooltipRoot,
+  TooltipTrigger,
 } from "@dust-tt/sparkle";
 import { NodeViewWrapper } from "@tiptap/react";
 import { useRouter } from "next/router";
@@ -19,6 +23,7 @@ interface MentionComponentProps {
     attrs: {
       id: string;
       label: string;
+      description?: string;
     };
   };
   owner?: WorkspaceType;
@@ -29,7 +34,7 @@ export const MentionComponent = ({ node, owner }: MentionComponentProps) => {
   const { onOpenChange: onOpenChangeAssistantModal } =
     useURLSheet("agentDetails");
 
-  const { id: agentSId, label: agentName } = node.attrs;
+  const { id: agentSId, label: agentName, description } = node.attrs;
 
   const handleStartConversation = async () => {
     if (!owner) {
@@ -45,25 +50,36 @@ export const MentionComponent = ({ node, owner }: MentionComponentProps) => {
 
   return (
     <NodeViewWrapper className="inline-flex">
-      <DropdownMenu>
-        <DropdownMenuTrigger asChild>
-          <span className="inline-block cursor-pointer font-medium text-highlight-500">
-            @{agentName}
-          </span>
-        </DropdownMenuTrigger>
-        <DropdownMenuContent side="top" align="start">
-          <DropdownMenuItem
-            onClick={handleStartConversation}
-            icon={() => <ChatBubbleBottomCenterTextIcon />}
-            label={`New conversation with @${agentName}`}
-          />
-          <DropdownMenuItem
-            onClick={handleSeeDetails}
-            icon={() => <EyeIcon />}
-            label={`About @${agentName}`}
-          />
-        </DropdownMenuContent>
-      </DropdownMenu>
+      <TooltipProvider>
+        <DropdownMenu>
+          <TooltipRoot delayDuration={300}>
+            <TooltipTrigger asChild>
+              <DropdownMenuTrigger asChild>
+                <span className="inline-block cursor-pointer font-medium text-highlight-500">
+                  @{agentName}
+                </span>
+              </DropdownMenuTrigger>
+            </TooltipTrigger>
+            {description && (
+              <TooltipContent side="top" sideOffset={8}>
+                {description}
+              </TooltipContent>
+            )}
+          </TooltipRoot>
+          <DropdownMenuContent side="top" align="start">
+            <DropdownMenuItem
+              onClick={handleStartConversation}
+              icon={() => <ChatBubbleBottomCenterTextIcon />}
+              label={`New conversation with @${agentName}`}
+            />
+            <DropdownMenuItem
+              onClick={handleSeeDetails}
+              icon={() => <EyeIcon />}
+              label={`About @${agentName}`}
+            />
+          </DropdownMenuContent>
+        </DropdownMenu>
+      </TooltipProvider>
     </NodeViewWrapper>
   );
 };

--- a/front/components/assistant/conversation/input_bar/editor/MentionComponent.tsx
+++ b/front/components/assistant/conversation/input_bar/editor/MentionComponent.tsx
@@ -48,33 +48,31 @@ export const MentionComponent = ({ node, owner }: MentionComponentProps) => {
     setQueryParam(router, "agentDetails", agentSId);
   };
 
+  const trigger = (
+    <DropdownMenuTrigger asChild>
+      <span className="inline-block cursor-pointer font-medium text-highlight-500">
+        @{agentName}
+      </span>
+    </DropdownMenuTrigger>
+  );
+
   return (
     <NodeViewWrapper className="inline-flex">
       <TooltipProvider>
         <DropdownMenu>
-          <TooltipRoot delayDuration={300}>
-            <TooltipTrigger asChild>
-              <DropdownMenuTrigger asChild>
-                <span className="inline-block cursor-pointer font-medium text-highlight-500">
-                  @{agentName}
-                </span>
-              </DropdownMenuTrigger>
-            </TooltipTrigger>
-            {description && (
-              <TooltipContent side="top" sideOffset={8}>
-                {description}
-              </TooltipContent>
-            )}
+          <TooltipRoot>
+            <TooltipTrigger asChild>{trigger}</TooltipTrigger>
+            {description && <TooltipContent>{description}</TooltipContent>}
           </TooltipRoot>
           <DropdownMenuContent side="top" align="start">
             <DropdownMenuItem
               onClick={handleStartConversation}
-              icon={() => <ChatBubbleBottomCenterTextIcon />}
+              icon={ChatBubbleBottomCenterTextIcon}
               label={`New conversation with @${agentName}`}
             />
             <DropdownMenuItem
               onClick={handleSeeDetails}
-              icon={() => <EyeIcon />}
+              icon={EyeIcon}
               label={`About @${agentName}`}
             />
           </DropdownMenuContent>

--- a/front/components/assistant/conversation/input_bar/editor/extensions/MentionExtension.tsx
+++ b/front/components/assistant/conversation/input_bar/editor/extensions/MentionExtension.tsx
@@ -23,10 +23,34 @@ export const MentionExtension = Mention.extend<MentionExtensionOptions>({
     };
   },
 
+  addAttributes() {
+    return {
+      ...this.parent?.(),
+      description: {
+        default: null,
+        parseHTML: (element) => element.getAttribute("data-description"),
+        renderHTML: (attributes) => {
+          if (!attributes.description) {
+            return {};
+          }
+          return {
+            "data-description": attributes.description,
+          };
+        },
+      },
+    };
+  },
+
   addNodeView() {
     return ReactNodeViewRenderer((props: NodeViewProps) => (
       <MentionComponent
-        node={{ attrs: props.node.attrs as { id: string; label: string } }}
+        node={{
+          attrs: props.node.attrs as {
+            id: string;
+            label: string;
+            description?: string;
+          },
+        }}
         owner={this.options.owner}
       />
     ));
@@ -55,7 +79,11 @@ export const MentionExtension = Mention.extend<MentionExtensionOptions>({
                 index: match.index,
                 text: match[1],
                 replaceWith: suggestion.label,
-                data: { id: suggestion.id, label: suggestion.label },
+                data: {
+                  id: suggestion.id,
+                  label: suggestion.label,
+                  description: suggestion.description,
+                },
               };
             });
           }
@@ -63,8 +91,14 @@ export const MentionExtension = Mention.extend<MentionExtensionOptions>({
         return results;
       },
       type: this.type,
-      getAttributes: (match: { data: { label: string; id: string } }) => {
-        return { label: match.data.label, id: match.data.id };
+      getAttributes: (match: {
+        data: { label: string; id: string; description: string };
+      }) => {
+        return {
+          label: match.data.label,
+          id: match.data.id,
+          description: match.data.description,
+        };
       },
     });
 

--- a/front/components/assistant/conversation/input_bar/editor/suggestion.ts
+++ b/front/components/assistant/conversation/input_bar/editor/suggestion.ts
@@ -6,6 +6,7 @@ export interface EditorSuggestion {
   label: string;
   pictureUrl: string;
   userFavorite: boolean;
+  description: string;
 }
 
 export interface EditorSuggestions {

--- a/front/components/assistant/conversation/input_bar/editor/useAssistantSuggestions.ts
+++ b/front/components/assistant/conversation/input_bar/editor/useAssistantSuggestions.ts
@@ -15,6 +15,7 @@ function makeEditorSuggestions(
       label: agent.name,
       pictureUrl: agent.pictureUrl,
       userFavorite: agent.userFavorite,
+      description: agent.description,
     }));
 }
 

--- a/front/components/assistant/conversation/input_bar/editor/useCustomEditor.tsx
+++ b/front/components/assistant/conversation/input_bar/editor/useCustomEditor.tsx
@@ -27,6 +27,7 @@ import { URLStorageExtension } from "./extensions/URLStorageExtension";
 export interface EditorMention {
   id: string;
   label: string;
+  description?: string;
 }
 
 const DEFAULT_LONG_TEXT_PASTE_CHARS_THRESHOLD = 16000;
@@ -99,7 +100,15 @@ const useEditorService = (editor: Editor | null) => {
         editor?.chain().focus().insertContent(text).run();
       },
       // Insert mention helper function.
-      insertMention: ({ id, label }: { id: string; label: string }) => {
+      insertMention: ({
+        id,
+        label,
+        description,
+      }: {
+        id: string;
+        label: string;
+        description?: string;
+      }) => {
         const shouldAddSpaceBeforeMention =
           !editor?.isEmpty &&
           editor?.getText()[editor?.getText().length - 1] !== " ";
@@ -109,7 +118,7 @@ const useEditorService = (editor: Editor | null) => {
           .insertContent(shouldAddSpaceBeforeMention ? " " : "") // Add an extra space before the mention.
           .insertContent({
             type: "mention",
-            attrs: { id, label },
+            attrs: { id, label, description },
           })
           .insertContent(" ") // Add an extra space after the mention.
           .run();

--- a/front/components/assistant/conversation/input_bar/editor/useHandleMentions.tsx
+++ b/front/components/assistant/conversation/input_bar/editor/useHandleMentions.tsx
@@ -42,6 +42,7 @@ const useHandleMentions = (
           mentionsToInsert.push({
             id: agentConfiguration.sId,
             label: agentConfiguration.name,
+            description: agentConfiguration.description,
           });
         }
       }
@@ -67,6 +68,7 @@ const useHandleMentions = (
       const mention = {
         id: agentConfiguration.sId,
         label: agentConfiguration.name,
+        description: agentConfiguration.description,
       };
 
       if (!editorService.hasMention(mention)) {

--- a/front/components/assistant/conversation/input_bar/editor/useMentionDropdown.tsx
+++ b/front/components/assistant/conversation/input_bar/editor/useMentionDropdown.tsx
@@ -79,7 +79,11 @@ export const useMentionDropdown = (
           .deleteRange(rangeRef.current)
           .insertContent({
             type: "mention",
-            attrs: { id: suggestion.id, label: suggestion.label },
+            attrs: {
+              id: suggestion.id,
+              label: suggestion.label,
+              description: suggestion.description,
+            },
           })
           .insertContent(" ") // Add space after mention
           .run();


### PR DESCRIPTION
## Description

This PR adds description tooltips to agent mentions in the conversation input bar editor. When hovering over a mention (e.g., @agent-name), users now see a tooltip displaying the agent's description, providing better context about the agent's purpose and capabilities without needing to navigate away from the conversation.

**References:**
- https://github.com/dust-tt/tasks/issues/3353

## Tests

Locally

## Risk

Low

## Deploy Plan

Deploy front