### PR TITLE
[front] chore(FS tools): untrack invalid regex errors

### DIFF
--- a/front/lib/actions/mcp_internal_actions/tools/data_sources_file_system/cat.ts
+++ b/front/lib/actions/mcp_internal_actions/tools/data_sources_file_system/cat.ts
@@ -143,7 +143,10 @@ export function registerCatTool(
         if (readResult.isErr()) {
           return new Err(
             new MCPError(
-              `Could not read node: ${nodeId} (error: ${readResult.error.message})`
+              `Could not read node: ${nodeId} (error: ${readResult.error.message})`,
+              {
+                tracked: readResult.error.code !== "invalid_regex",
+              }
             )
           );
         }


### PR DESCRIPTION
## Description

- When using the `cat` tool the model can pass invalid regexes.
- These errors are not really actionable on our side.
- Code path in core is here https://github.com/dust-tt/dust/blob/main/core/src/api/data_sources.rs#L1080

## Tests

## Risk

- Low.

## Deploy Plan

- Deploy front.
