### PR TITLE
[front] enh(cc): improve instructions to trigger more selectively

### DIFF
--- a/front/lib/actions/mcp_internal_actions/servers/content_creation/instructions.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/content_creation/instructions.ts
@@ -54,8 +54,8 @@ ${VIZ_MISCELLANEOUS_GUIDELINES}
 
 - When to Create Files:
   - Create files for data visualizations such as graphs, charts, and plots
+  - Create files for complex visualizations that require user interaction
   - Do not create files for simple text-based content that can be rendered in Markdown
-  - Only create files for truly interactive output that requires React components
 
 ${VIZ_USE_FILE_EXAMPLES}
 

--- a/front/lib/actions/mcp_internal_actions/servers/content_creation/instructions.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/content_creation/instructions.ts
@@ -56,8 +56,8 @@ ${VIZ_MISCELLANEOUS_GUIDELINES}
   - Create files for data visualizations such as graphs, charts, and plots
   - Create files for interactive React components that require user interaction
   - Create files for complex visualizations that benefit from being standalone components
-  - Do not create files for simple text-based content that can be rendered in Markdown,
-  - Only create files for truly interactive output that requires React components.
+  - Do not create files for simple text-based content that can be rendered in Markdown
+  - Only create files for truly interactive output that requires React components
 
 ${VIZ_USE_FILE_EXAMPLES}
 

--- a/front/lib/actions/mcp_internal_actions/servers/content_creation/instructions.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/content_creation/instructions.ts
@@ -56,6 +56,7 @@ ${VIZ_MISCELLANEOUS_GUIDELINES}
   - Create files for data visualizations such as graphs, charts, and plots
   - Create files for complex visualizations that require user interaction
   - Do not create files for simple text-based content that can be rendered in Markdown
+  - Do not create files for content that does not require user interaction
 
 ${VIZ_USE_FILE_EXAMPLES}
 

--- a/front/lib/actions/mcp_internal_actions/servers/content_creation/instructions.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/content_creation/instructions.ts
@@ -54,8 +54,6 @@ ${VIZ_MISCELLANEOUS_GUIDELINES}
 
 - When to Create Files:
   - Create files for data visualizations such as graphs, charts, and plots
-  - Create files for interactive React components that require user interaction
-  - Create files for complex visualizations that benefit from being standalone components
   - Do not create files for simple text-based content that can be rendered in Markdown
   - Only create files for truly interactive output that requires React components
 

--- a/front/lib/actions/mcp_internal_actions/servers/content_creation/instructions.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/content_creation/instructions.ts
@@ -56,6 +56,8 @@ ${VIZ_MISCELLANEOUS_GUIDELINES}
   - Create files for data visualizations such as graphs, charts, and plots
   - Create files for interactive React components that require user interaction
   - Create files for complex visualizations that benefit from being standalone components
+  - Do not create files for simple text-based content that can be rendered in Markdown,
+  - Only create files for truly interactive output that requires React components.
 
 ${VIZ_USE_FILE_EXAMPLES}
 


### PR DESCRIPTION
## Description

- Closes https://github.com/dust-tt/tasks/issues/4488.
- Due to having very generic instructions regarding when it could be used, content creation tools are used too eagerly.
- This was observed in the context of deep research, the guidelines added here are inspired by it https://github.com/dust-tt/dust/blob/main/front/lib/api/assistant/global_agents/configurations/dust/dust-deep.ts#L227

## Tests

- Tested with a few examples.

## Risk

- Low.

## Deploy Plan

- Deploy front.
