### PR TITLE
New workflow to end and scrub free ended workspaces

### DIFF
--- a/front/temporal/scrub_workspace/activities.ts
+++ b/front/temporal/scrub_workspace/activities.ts
@@ -1,5 +1,4 @@
 import _ from "lodash";
-import { Op } from "sequelize";
 
 import { archiveAgentConfiguration } from "@app/lib/api/assistant/configuration/agent";
 import { getAgentConfigurationsForView } from "@app/lib/api/assistant/configuration/views";
@@ -17,7 +16,6 @@ import {
   unsafeGetWorkspacesByModelId,
 } from "@app/lib/api/workspace";
 import { Authenticator } from "@app/lib/auth";
-import { Subscription } from "@app/lib/models/plan";
 import {
   FREE_NO_PLAN_CODE,
   FREE_TEST_PLAN_CODE,
@@ -27,7 +25,6 @@ import { ConversationResource } from "@app/lib/resources/conversation_resource";
 import { DataSourceResource } from "@app/lib/resources/data_source_resource";
 import { MembershipResource } from "@app/lib/resources/membership_resource";
 import { SpaceResource } from "@app/lib/resources/space_resource";
-import { WorkspaceModel } from "@app/lib/resources/storage/models/workspace";
 import { SubscriptionResource } from "@app/lib/resources/subscription_resource";
 import { TagResource } from "@app/lib/resources/tags_resource";
 import { TrackerConfigurationResource } from "@app/lib/resources/tracker_resource";
@@ -362,40 +359,22 @@ async function cleanupCustomerio(auth: Authenticator) {
 }
 
 export async function endSubscriptionFreeEndedWorkspacesActivity(): Promise<{
-  subscriptionsModelIds: number[];
-  workspaceModelIds: number[];
   workspaceIds: string[];
-  nbEndedSubscriptions: number;
 }> {
-  const freeEndedSubscriptions = await Subscription.findAll({
-    where: {
-      status: "active",
-      stripeSubscriptionId: null,
-      endDate: {
-        [Op.lt]: new Date(),
-      },
-    },
-    include: [WorkspaceModel],
-  });
+  const { workspaces } =
+    await SubscriptionResource.internalFetchWorkspacesWithFreeEndedSubscriptions();
 
-  const workspaceModelIds = freeEndedSubscriptions.map((s) => s.workspace.id);
-  const workspaceIds = freeEndedSubscriptions.map((s) => s.workspace.sId);
-  const subscriptionsModelIds = freeEndedSubscriptions.map((s) => s.id);
-
-  const endedQuery = await Subscription.update(
-    {
-      status: "ended",
+  await concurrentExecutor(
+    workspaces,
+    async (workspace) => {
+      await SubscriptionResource.endActiveSubscription(workspace);
     },
     {
-      where: {
-        id: subscriptionsModelIds,
-      },
+      concurrency: 4,
     }
   );
+
   return {
-    subscriptionsModelIds,
-    workspaceModelIds,
-    workspaceIds,
-    nbEndedSubscriptions: endedQuery[0],
+    workspaceIds: workspaces.map((w) => w.sId),
   };
 }

--- a/front/temporal/scrub_workspace/client.ts
+++ b/front/temporal/scrub_workspace/client.ts
@@ -3,7 +3,9 @@ import { WorkflowNotFoundError } from "@temporalio/client";
 
 import { getTemporalClientForFrontNamespace } from "@app/lib/temporal";
 import logger from "@app/logger/logger";
+import { runScrubFreeEndedWorkspacesSignal } from "@app/temporal/scrub_workspace/signals";
 import {
+  downgradeFreeEndedWorkspacesWorkflow,
   immediateWorkspaceScrubWorkflow,
   scheduleWorkspaceScrubWorkflowV2,
 } from "@app/temporal/scrub_workspace/workflows";
@@ -119,4 +121,37 @@ export async function terminateScheduleWorkspaceScrubWorkflow({
 
 function getWorkflowId(workspaceId: string) {
   return `schedule-workspace-scrub-${workspaceId}`;
+}
+
+export async function launchDowngradeFreeEndedWorkspacesWorkflow(): Promise<
+  Result<undefined, Error>
+> {
+  const client = await getTemporalClientForFrontNamespace();
+  await client.workflow.signalWithStart(downgradeFreeEndedWorkspacesWorkflow, {
+    args: [],
+    taskQueue: QUEUE_NAME,
+    workflowId: "downgrade-and-scrub-free-ended-workflows",
+    signal: runScrubFreeEndedWorkspacesSignal,
+    signalArgs: undefined,
+    cronSchedule: "0 18 * * 1-5", // Every weekday at 6pm.
+  });
+
+  return new Ok(undefined);
+}
+
+export async function stopDowngradeFreeEndedWorkspacesWorkflow() {
+  const client = await getTemporalClientForFrontNamespace();
+
+  try {
+    const handle: WorkflowHandle<typeof downgradeFreeEndedWorkspacesWorkflow> =
+      client.workflow.getHandle("downgrade-and-scrub-free-ended-workflows");
+    await handle.terminate();
+  } catch (e) {
+    logger.error(
+      {
+        error: e,
+      },
+      "[Downgrade and Scrub Free Ended Workspaces] Failed stopping workflow."
+    );
+  }
 }

--- a/front/temporal/scrub_workspace/client.ts
+++ b/front/temporal/scrub_workspace/client.ts
@@ -12,7 +12,10 @@ import {
 import type { Result } from "@app/types";
 import { Err, normalizeError, Ok } from "@app/types";
 
-import { QUEUE_NAME } from "./config";
+import {
+  DOWNGRADE_FREE_ENDED_WORKSPACES_WORKFLOW_ID,
+  QUEUE_NAME,
+} from "./config";
 
 export async function launchScheduleWorkspaceScrubWorkflow({
   workspaceId,
@@ -130,7 +133,7 @@ export async function launchDowngradeFreeEndedWorkspacesWorkflow(): Promise<
   await client.workflow.signalWithStart(downgradeFreeEndedWorkspacesWorkflow, {
     args: [],
     taskQueue: QUEUE_NAME,
-    workflowId: "downgrade-and-scrub-free-ended-workflows",
+    workflowId: DOWNGRADE_FREE_ENDED_WORKSPACES_WORKFLOW_ID,
     signal: runScrubFreeEndedWorkspacesSignal,
     signalArgs: undefined,
     cronSchedule: "0 18 * * 1-5", // Every weekday at 6pm.
@@ -144,7 +147,7 @@ export async function stopDowngradeFreeEndedWorkspacesWorkflow() {
 
   try {
     const handle: WorkflowHandle<typeof downgradeFreeEndedWorkspacesWorkflow> =
-      client.workflow.getHandle("downgrade-and-scrub-free-ended-workflows");
+      client.workflow.getHandle(DOWNGRADE_FREE_ENDED_WORKSPACES_WORKFLOW_ID);
     await handle.terminate();
   } catch (e) {
     logger.error(

--- a/front/temporal/scrub_workspace/config.ts
+++ b/front/temporal/scrub_workspace/config.ts
@@ -1,2 +1,5 @@
 const QUEUE_VERSION = 1;
 export const QUEUE_NAME = `scrub-workspace-queue-v${QUEUE_VERSION}`;
+
+export const DOWNGRADE_FREE_ENDED_WORKSPACES_WORKFLOW_ID =
+  "downgrade-and-scrub-free-ended-workspaces";

--- a/front/temporal/scrub_workspace/signals.ts
+++ b/front/temporal/scrub_workspace/signals.ts
@@ -1,0 +1,5 @@
+import { defineSignal } from "@temporalio/workflow";
+
+export const runScrubFreeEndedWorkspacesSignal = defineSignal<[void]>(
+  "run_scrub_free_ended_workspaces_signal"
+);

--- a/front/temporal/scrub_workspace/workflows.ts
+++ b/front/temporal/scrub_workspace/workflows.ts
@@ -1,6 +1,13 @@
-import { proxyActivities, sleep } from "@temporalio/workflow";
+import {
+  ParentClosePolicy,
+  proxyActivities,
+  setHandler,
+  sleep,
+  startChild,
+} from "@temporalio/workflow";
 
 import type * as activities from "@app/temporal/scrub_workspace/activities";
+import { runScrubFreeEndedWorkspacesSignal } from "@app/temporal/scrub_workspace/signals";
 
 const { shouldStillScrubData } = proxyActivities<typeof activities>({
   startToCloseTimeout: "1 minutes",
@@ -11,6 +18,12 @@ const { sendDataDeletionEmail } = proxyActivities<typeof activities>({
     // We really want to avoid sending the email infinitely.
     maximumAttempts: 1,
   },
+});
+
+const { endSubscriptionFreeEndedWorkspacesActivity } = proxyActivities<
+  typeof activities
+>({
+  startToCloseTimeout: "5 minutes",
 });
 
 const { scrubWorkspaceData, pauseAllConnectors, pauseAllTriggers } =
@@ -75,4 +88,25 @@ export async function immediateWorkspaceScrubWorkflow({
   workspaceId: string;
 }): Promise<void> {
   await scrubWorkspaceData({ workspaceId });
+}
+
+export async function downgradeFreeEndedWorkspacesWorkflow(): Promise<void> {
+  setHandler(runScrubFreeEndedWorkspacesSignal, () => {
+    // Empty handler - just receiving the signal will trigger a workflow execution.
+  });
+
+  // End the subscription status for workspaces that are free with an end date in the past.
+  const { workspaceIds } = await endSubscriptionFreeEndedWorkspacesActivity();
+
+  // For each workspace, schedule the workspace scrub workflow.
+  // We start child workflows but don't wait for them since they take 15+ days to complete.
+  // The abandon policy ensures they continue running after the parent completes.
+  const today = new Date().toISOString().split("T")[0]; // Format: YYYY-MM-DD.
+  for (const workspaceId of workspaceIds) {
+    await startChild(scheduleWorkspaceScrubWorkflowV2, {
+      workflowId: `scrub-workspace-${workspaceId}-${today}`,
+      args: [{ workspaceId }],
+      parentClosePolicy: ParentClosePolicy.ABANDON,
+    });
+  }
 }


### PR DESCRIPTION
## Description

### Context

We added the ability to upgrade a workspace to a free plan with an end date (here: https://github.com/dust-tt/dust/pull/12213/files?diff=split&w=1), we completely foreseen that there's not automatic downgrade for free plans as we have for paid plans from the Stripe webhook. 

Luckily this feature was not heavily used and I already took care of manually downgrading most of the workspaces that were in this situation. 
This task is about automating it. 

### Task

Add a new cron workflow that runs every day to check all the workspaces that are with a free plan and an end date before now. The activity will set the subscription status as ended for all those workspaces and then, for each of them call the existing scrub workspace workflow. 

## Tests

I have not tested it yet I'm submitting the PR and then making local tests. 
I won't merge without testing it of course. 

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

Merge, deploy and then run the command to start the workflow on all regions. 