### PR TITLE
fix: fix the Gmail guide URL

### DIFF
--- a/front/lib/actions/mcp_internal_actions/constants.ts
+++ b/front/lib/actions/mcp_internal_actions/constants.ts
@@ -489,7 +489,7 @@ The directive should be used to display a clickable version of the agent name in
           "https://www.googleapis.com/auth/gmail.readonly https://www.googleapis.com/auth/gmail.compose" as const,
       },
       icon: "GmailLogo",
-      documentationUrl: "https://docs.dust.tt/docs/gmail-tool-setup",
+      documentationUrl: "https://docs.dust.tt/docs/gmail",
       instructions: null,
     },
   },


### PR DESCRIPTION
## Description

- When the user wants to add a Gmail tool, the link to the Gmail guide is not valid.
<img width="630" height="298" alt="image" src="https://github.com/user-attachments/assets/472e3bf1-76dd-4764-b773-5b6b2b2696f6" />


## Tests

## Risk

None

## Deploy Plan

Deploy front
