### PR TITLE
Add icons and description to webhooks

### DIFF
--- a/front/components/actions/mcp/details/MCPActionDetails.tsx
+++ b/front/components/actions/mcp/details/MCPActionDetails.tsx
@@ -26,7 +26,7 @@ import { MCPRunAgentActionDetails } from "@app/components/actions/mcp/details/MC
 import { MCPTablesQueryActionDetails } from "@app/components/actions/mcp/details/MCPTablesQueryActionDetails";
 import { SearchResultDetails } from "@app/components/actions/mcp/details/MCPToolOutputDetails";
 import type { ToolExecutionDetailsProps } from "@app/components/actions/mcp/details/types";
-import { InternalActionIcons } from "@app/lib/actions/mcp_icons";
+import { InternalActionIcons } from "@app/components/resources/resources_icons";
 import {
   DATA_WAREHOUSES_DESCRIBE_TABLES_TOOL_NAME,
   DATA_WAREHOUSES_FIND_TOOL_NAME,

--- a/front/components/actions/mcp/details/MCPListToolsActionDetails.tsx
+++ b/front/components/actions/mcp/details/MCPListToolsActionDetails.tsx
@@ -2,8 +2,8 @@ import { BoltIcon, Chip } from "@dust-tt/sparkle";
 
 import { ActionDetailsWrapper } from "@app/components/actions/ActionDetailsWrapper";
 import type { ToolExecutionDetailsProps } from "@app/components/actions/mcp/details/types";
+import { getIcon } from "@app/components/resources/resources_icons";
 import { getMcpServerViewDisplayName } from "@app/lib/actions/mcp_helper";
-import { getIcon } from "@app/lib/actions/mcp_icons";
 import { isToolsetsResultResourceType } from "@app/lib/actions/mcp_internal_actions/output_schemas";
 import { useMCPServerViews } from "@app/lib/swr/mcp_servers";
 import { useSpaces } from "@app/lib/swr/spaces";

--- a/front/components/actions/mcp/details/MCPRunAgentActionDetails.tsx
+++ b/front/components/actions/mcp/details/MCPRunAgentActionDetails.tsx
@@ -28,9 +28,9 @@ import {
 } from "@app/components/markdown/CiteBlock";
 import type { MarkdownCitation } from "@app/components/markdown/MarkdownCitation";
 import { getCitationIcon } from "@app/components/markdown/MarkdownCitation";
+import { getIcon } from "@app/components/resources/resources_icons";
 import { useTheme } from "@app/components/sparkle/ThemeContext";
 import { getMcpServerViewDisplayName } from "@app/lib/actions/mcp_helper";
-import { getIcon } from "@app/lib/actions/mcp_icons";
 import {
   isAgentPauseOutputResourceType,
   isRunAgentChainOfThoughtProgressOutput,

--- a/front/components/agent_builder/PersonalConnectionRequiredDialog.tsx
+++ b/front/components/agent_builder/PersonalConnectionRequiredDialog.tsx
@@ -16,8 +16,8 @@ import {
 } from "@dust-tt/sparkle";
 import React, { useMemo, useState } from "react";
 
+import { getIcon } from "@app/components/resources/resources_icons";
 import { getMcpServerViewDisplayName } from "@app/lib/actions/mcp_helper";
-import { getIcon } from "@app/lib/actions/mcp_icons";
 import type { MCPServerViewType } from "@app/lib/api/mcp";
 import {
   useCreatePersonalConnection,

--- a/front/components/agent_builder/capabilities/mcp/MCPServerSelectionPage.tsx
+++ b/front/components/agent_builder/capabilities/mcp/MCPServerSelectionPage.tsx
@@ -9,11 +9,11 @@ import React, { useMemo } from "react";
 import type { SelectedTool } from "@app/components/agent_builder/capabilities/mcp/MCPServerViewsSheet";
 import type { MCPServerViewTypeWithLabel } from "@app/components/agent_builder/MCPServerViewsContext";
 import type { ActionSpecification } from "@app/components/agent_builder/types";
-import { getMcpServerViewDescription } from "@app/lib/actions/mcp_helper";
 import {
   InternalActionIcons,
-  isCustomServerIconType,
-} from "@app/lib/actions/mcp_icons";
+  isCustomResourceIconType,
+} from "@app/components/resources/resources_icons";
+import { getMcpServerViewDescription } from "@app/lib/actions/mcp_helper";
 import { getMCPServerToolsConfigurations } from "@app/lib/actions/mcp_internal_actions/input_configuration";
 import type { WhitelistableFeature } from "@app/types";
 
@@ -59,7 +59,7 @@ function MCPServerCard({
   const requirement = getMCPServerToolsConfigurations(view, featureFlags);
   const canAdd = requirement.configurable !== "no" ? true : !isSelected;
 
-  const icon = isCustomServerIconType(view.server.icon)
+  const icon = isCustomResourceIconType(view.server.icon)
     ? ActionIcons[view.server.icon]
     : InternalActionIcons[view.server.icon] || BookOpenIcon;
 

--- a/front/components/agent_builder/capabilities/mcp/utils/infoPageUtils.ts
+++ b/front/components/agent_builder/capabilities/mcp/utils/infoPageUtils.ts
@@ -1,11 +1,11 @@
 import { ActionIcons } from "@dust-tt/sparkle";
 
 import type { AgentBuilderAction } from "@app/components/agent_builder/types";
-import { getMcpServerViewDisplayName } from "@app/lib/actions/mcp_helper";
 import {
   InternalActionIcons,
-  isCustomServerIconType,
-} from "@app/lib/actions/mcp_icons";
+  isCustomResourceIconType,
+} from "@app/components/resources/resources_icons";
+import { getMcpServerViewDisplayName } from "@app/lib/actions/mcp_helper";
 import { DATA_VISUALIZATION_SPECIFICATION } from "@app/lib/actions/utils";
 import type { MCPServerViewType } from "@app/lib/api/mcp";
 
@@ -44,7 +44,7 @@ export function getInfoPageIcon(
   infoAction: AgentBuilderAction | null
 ) {
   if (infoMCPServerView) {
-    return isCustomServerIconType(infoMCPServerView.server.icon)
+    return isCustomResourceIconType(infoMCPServerView.server.icon)
       ? ActionIcons[infoMCPServerView.server.icon]
       : InternalActionIcons[infoMCPServerView.server.icon];
   }

--- a/front/components/agent_builder/capabilities/mcp/utils/toolDisplayUtils.ts
+++ b/front/components/agent_builder/capabilities/mcp/utils/toolDisplayUtils.ts
@@ -2,11 +2,11 @@ import { ActionIcons, BookOpenIcon } from "@dust-tt/sparkle";
 
 import type { SelectedTool } from "@app/components/agent_builder/capabilities/mcp/MCPServerViewsSheet";
 import type { ActionSpecification } from "@app/components/agent_builder/types";
-import { getMcpServerViewDisplayName } from "@app/lib/actions/mcp_helper";
 import {
   InternalActionIcons,
-  isCustomServerIconType,
-} from "@app/lib/actions/mcp_icons";
+  isCustomResourceIconType,
+} from "@app/components/resources/resources_icons";
+import { getMcpServerViewDisplayName } from "@app/lib/actions/mcp_helper";
 import { DATA_VISUALIZATION_SPECIFICATION } from "@app/lib/actions/utils";
 
 export function getSelectedToolIcon(tool: SelectedTool): React.ComponentType {
@@ -14,7 +14,7 @@ export function getSelectedToolIcon(tool: SelectedTool): React.ComponentType {
     return DATA_VISUALIZATION_SPECIFICATION.dropDownIcon;
   }
 
-  return isCustomServerIconType(tool.view.server.icon)
+  return isCustomResourceIconType(tool.view.server.icon)
     ? ActionIcons[tool.view.server.icon]
     : InternalActionIcons[tool.view.server.icon] || BookOpenIcon;
 }

--- a/front/components/agent_builder/capabilities/shared/ProcessingMethodSection.tsx
+++ b/front/components/agent_builder/capabilities/shared/ProcessingMethodSection.tsx
@@ -17,14 +17,14 @@ import { useMCPServerViewsContext } from "@app/components/agent_builder/MCPServe
 import type { CapabilityFormData } from "@app/components/agent_builder/types";
 import type { DataSourceBuilderTreeItemType } from "@app/components/data_source_view/context/types";
 import {
+  InternalActionIcons,
+  isInternalAllowedIcon,
+} from "@app/components/resources/resources_icons";
+import {
   getMcpServerViewDescription,
   getMcpServerViewDisplayName,
 } from "@app/lib/actions/mcp_helper";
-import {
-  getAvatar,
-  InternalActionIcons,
-  isInternalAllowedIcon,
-} from "@app/lib/actions/mcp_icons";
+import { getAvatar } from "@app/lib/actions/mcp_icons";
 import {
   DATA_WAREHOUSE_SERVER_NAME,
   isInternalMCPServerOfName,

--- a/front/components/assistant/conversation/BlockedActionsProvider.tsx
+++ b/front/components/assistant/conversation/BlockedActionsProvider.tsx
@@ -16,10 +16,10 @@ import {
 
 import { ToolValidationDialogPage } from "@app/components/assistant/conversation/blocked_actions/ToolValidationDialogPage";
 import { useNavigationLock } from "@app/components/assistant_builder/useNavigationLock";
+import { getIcon } from "@app/components/resources/resources_icons";
 import { useValidateAction } from "@app/hooks/useValidateAction";
 import type { MCPValidationOutputType } from "@app/lib/actions/constants";
 import type { BlockedToolExecution } from "@app/lib/actions/mcp";
-import { getIcon } from "@app/lib/actions/mcp_icons";
 import { useBlockedActions } from "@app/lib/swr/blocked_actions";
 import type {
   ConversationWithoutContentType,

--- a/front/components/assistant/conversation/blocked_actions/AuthentificationDialogPage.tsx
+++ b/front/components/assistant/conversation/blocked_actions/AuthentificationDialogPage.tsx
@@ -1,8 +1,8 @@
 import { Button, CloudArrowLeftRightIcon, cn, Icon } from "@dust-tt/sparkle";
 import { useCallback } from "react";
 
+import { getIcon } from "@app/components/resources/resources_icons";
 import type { BlockedToolExecution } from "@app/lib/actions/mcp";
-import { getIcon } from "@app/lib/actions/mcp_icons";
 import logger from "@app/logger/logger";
 import type { OAuthProvider, OAuthUseCase } from "@app/types";
 

--- a/front/components/assistant/conversation/input_bar/InputBarContainer.tsx
+++ b/front/components/assistant/conversation/input_bar/InputBarContainer.tsx
@@ -26,11 +26,11 @@ import {
 } from "@app/components/assistant/conversation/input_bar/pasted_utils";
 import { ToolsPicker } from "@app/components/assistant/ToolsPicker";
 import { VoicePicker } from "@app/components/assistant/VoicePicker";
+import { getIcon } from "@app/components/resources/resources_icons";
 import type { FileUploaderService } from "@app/hooks/useFileUploaderService";
 import { useSendNotification } from "@app/hooks/useNotification";
 import { useVoiceTranscriberService } from "@app/hooks/useVoiceTranscriberService";
 import { getMcpServerViewDisplayName } from "@app/lib/actions/mcp_helper";
-import { getIcon } from "@app/lib/actions/mcp_icons";
 import type { MCPServerViewType } from "@app/lib/api/mcp";
 import type { NodeCandidate, UrlCandidate } from "@app/lib/connectors";
 import { isNodeCandidate } from "@app/lib/connectors";

--- a/front/components/resources/resources_icons.tsx
+++ b/front/components/resources/resources_icons.tsx
@@ -1,0 +1,143 @@
+import type { Avatar, Icon } from "@dust-tt/sparkle";
+import {
+  ActionAtomIcon,
+  ActionBrainIcon,
+  ActionCloudArrowLeftRightIcon,
+  ActionDocumentTextIcon,
+  ActionEmotionLaughIcon,
+  ActionGitBranchIcon,
+  ActionGlobeAltIcon,
+  ActionIcons,
+  ActionImageIcon,
+  ActionLightbulbIcon,
+  ActionLockIcon,
+  ActionMagnifyingGlassIcon,
+  ActionPieChartIcon,
+  ActionRobotIcon,
+  ActionScanIcon,
+  ActionSlideshowIcon,
+  ActionTableIcon,
+  ActionTimeIcon,
+  AsanaLogo,
+  Avatar as SparkleAvatar,
+  CommandLineIcon,
+  ConfluenceLogo,
+  DriveLogo,
+  FreshserviceLogo,
+  GcalLogo,
+  GithubLogo,
+  GmailLogo,
+  GoogleSpreadsheetLogo,
+  HubspotLogo,
+  JiraLogo,
+  LinearLogo,
+  MondayLogo,
+  NotionLogo,
+  OpenaiLogo,
+  OutlookLogo,
+  SalesforceLogo,
+  SlackLogo,
+  StripeLogo,
+} from "@dust-tt/sparkle";
+import type { ComponentProps, ComponentType } from "react";
+
+interface ResourceAvatarProps extends ComponentProps<typeof Avatar> {}
+
+/**
+ * As Avatar are not made to support dark/light mode switch, this renders a `Avatar` component for resources icons with support for dark mode.
+ * If `iconColor` or `backgroundColor` are not provided, sensible defaults are applied for both light and dark themes.
+ */
+export function ResourceAvatar({
+  iconColor,
+  backgroundColor,
+  ...props
+}: ResourceAvatarProps) {
+  return (
+    <SparkleAvatar
+      iconColor={iconColor ?? "s-text-foreground dark:s-text-foreground-night"}
+      backgroundColor={
+        backgroundColor ??
+        "s-bg-muted-background dark:s-bg-muted-background-night"
+      }
+      {...props}
+    />
+  );
+}
+
+export const CUSTOM_RESOURCE_ALLOWED = Object.keys(ActionIcons);
+
+export const InternalActionIcons = {
+  ActionAtomIcon,
+  ActionBrainIcon,
+  ActionCloudArrowLeftRightIcon,
+  ActionDocumentTextIcon,
+  ActionEmotionLaughIcon,
+  ActionGitBranchIcon,
+  ActionGlobeAltIcon,
+  ActionImageIcon,
+  ActionLightbulbIcon,
+  ActionLockIcon,
+  ActionMagnifyingGlassIcon,
+  ActionRobotIcon,
+  ActionScanIcon,
+  ActionTableIcon,
+  ActionPieChartIcon,
+  ActionSlideshowIcon,
+  ActionTimeIcon,
+  AsanaLogo,
+  CommandLineIcon,
+  ConfluenceLogo,
+  GcalLogo,
+  GithubLogo,
+  GmailLogo,
+  GoogleSpreadsheetLogo,
+  FreshserviceLogo,
+  HubspotLogo,
+  OutlookLogo,
+  JiraLogo,
+  LinearLogo,
+  MondayLogo,
+  NotionLogo,
+  OpenaiLogo,
+  SalesforceLogo,
+  SlackLogo,
+  StripeLogo,
+  DriveLogo,
+};
+
+export const INTERNAL_ALLOWED_ICONS = Object.keys(InternalActionIcons);
+
+export type CustomResourceIconType = keyof typeof ActionIcons;
+
+export const isCustomResourceIconType = (
+  icon: string
+): icon is CustomResourceIconType =>
+  CUSTOM_RESOURCE_ALLOWED.includes(icon as CustomResourceIconType);
+
+export type InternalAllowedIconType = keyof typeof InternalActionIcons;
+
+export const isInternalAllowedIcon = (
+  icon: string
+): icon is InternalAllowedIconType =>
+  INTERNAL_ALLOWED_ICONS.includes(icon as InternalAllowedIconType);
+
+export const getAvatarFromIcon = (
+  icon: InternalAllowedIconType | CustomResourceIconType,
+  size: ComponentProps<typeof Avatar>["size"] = "sm"
+) => {
+  if (isCustomResourceIconType(icon)) {
+    return <ResourceAvatar icon={ActionIcons[icon]} size={size} />;
+  }
+
+  return <ResourceAvatar icon={InternalActionIcons[icon]} size={size} />;
+};
+
+export const getIcon = (
+  icon: InternalAllowedIconType | CustomResourceIconType
+): ComponentType<ComponentProps<typeof Icon>> => {
+  if (isCustomResourceIconType(icon)) {
+    return ActionIcons[icon];
+  }
+
+  return InternalActionIcons[icon];
+};

--- a/front/components/spaces/SpaceSideBarMenu.tsx
+++ b/front/components/spaces/SpaceSideBarMenu.tsx
@@ -21,7 +21,11 @@ import { useTheme } from "@app/components/sparkle/ThemeContext";
 import { usePersistedNavigationSelection } from "@app/hooks/usePersistedNavigationSelection";
 import { useSpaceSidebarItemFocus } from "@app/hooks/useSpaceSidebarItemFocus";
 import { getMcpServerDisplayName } from "@app/lib/actions/mcp_helper";
-import { getAvatar } from "@app/lib/actions/mcp_icons";
+import type {
+  CustomServerIconType,
+  InternalAllowedIconType,
+} from "@app/lib/actions/mcp_icons";
+import { getAvatar, getAvatarFromIcon } from "@app/lib/actions/mcp_icons";
 import type { MCPServerViewType } from "@app/lib/api/mcp";
 import { getConnectorProviderLogoWithFallback } from "@app/lib/connector_providers";
 import { getVisualForDataSourceViewContentNode } from "@app/lib/content_nodes";
@@ -44,6 +48,7 @@ import {
 } from "@app/lib/swr/spaces";
 import { useWebhookSourceViews } from "@app/lib/swr/webhook_source";
 import { useFeatureFlags } from "@app/lib/swr/workspaces";
+import { normalizeWebhookIcon } from "@app/lib/webhookSource";
 import type {
   AppType,
   DataSourceViewCategory,
@@ -789,8 +794,20 @@ const SpaceActionsSubMenu = ({
   );
 };
 
-const SpaceTriggerItem = ({ label }: { label: string }): ReactElement => {
-  return <Tree.Item type="leaf" label={label} visual={BoltIcon} />;
+const SpaceTriggerItem = ({
+  label,
+  icon,
+}: {
+  label: string;
+  icon: InternalAllowedIconType | CustomServerIconType | null | undefined;
+}): ReactElement => {
+  return (
+    <Tree.Item
+      type="leaf"
+      label={label}
+      visual={() => getAvatarFromIcon(normalizeWebhookIcon(icon), "xs")}
+    />
+  );
 };
 
 const TRIGGERS_CATEGORY: DataSourceViewCategory = "triggers";
@@ -844,6 +861,7 @@ const SpaceTriggersSubMenu = ({
           {webhookSourceViews.map((webhookView) => (
             <SpaceTriggerItem
               label={webhookView.customName ?? webhookView.webhookSource.name}
+              icon={webhookView.icon}
               key={webhookView.sId}
             />
           ))}

--- a/front/components/spaces/SpaceSideBarMenu.tsx
+++ b/front/components/spaces/SpaceSideBarMenu.tsx
@@ -17,15 +17,16 @@ import { useRouter } from "next/router";
 import type { ComponentType, ReactElement } from "react";
 import { Fragment, useCallback, useEffect, useMemo, useState } from "react";
 
+import type {
+  CustomResourceIconType,
+  InternalAllowedIconType,
+} from "@app/components/resources/resources_icons";
+import { getAvatarFromIcon } from "@app/components/resources/resources_icons";
 import { useTheme } from "@app/components/sparkle/ThemeContext";
 import { usePersistedNavigationSelection } from "@app/hooks/usePersistedNavigationSelection";
 import { useSpaceSidebarItemFocus } from "@app/hooks/useSpaceSidebarItemFocus";
 import { getMcpServerDisplayName } from "@app/lib/actions/mcp_helper";
-import type {
-  CustomServerIconType,
-  InternalAllowedIconType,
-} from "@app/lib/actions/mcp_icons";
-import { getAvatar, getAvatarFromIcon } from "@app/lib/actions/mcp_icons";
+import { getAvatar } from "@app/lib/actions/mcp_icons";
 import type { MCPServerViewType } from "@app/lib/api/mcp";
 import { getConnectorProviderLogoWithFallback } from "@app/lib/connector_providers";
 import { getVisualForDataSourceViewContentNode } from "@app/lib/content_nodes";
@@ -799,7 +800,7 @@ const SpaceTriggerItem = ({
   icon,
 }: {
   label: string;
-  icon: InternalAllowedIconType | CustomServerIconType | null | undefined;
+  icon: InternalAllowedIconType | CustomResourceIconType | null | undefined;
 }): ReactElement => {
   return (
     <Tree.Item

--- a/front/components/spaces/SpaceTriggersList.tsx
+++ b/front/components/spaces/SpaceTriggersList.tsx
@@ -3,6 +3,7 @@ import type { CellContext, ColumnDef } from "@tanstack/react-table";
 import * as React from "react";
 
 import { usePaginationFromUrl } from "@app/hooks/usePaginationFromUrl";
+import { getAvatarFromIcon } from "@app/lib/actions/mcp_icons";
 import { useWebhookSourceViews } from "@app/lib/swr/webhook_source";
 import { formatTimestampToFriendlyDate } from "@app/lib/utils";
 import type { LightWorkspaceType, SpaceType } from "@app/types";
@@ -10,6 +11,8 @@ import type { LightWorkspaceType, SpaceType } from "@app/types";
 type RowData = {
   id: string;
   name: string;
+  description: string;
+  avatar: React.ReactNode;
   lastUpdated: number;
   onClick?: () => void;
 };
@@ -36,11 +39,27 @@ export const SpaceTriggersList = ({ owner, space }: SpaceActionsListProps) => {
       cell: (info: CellContext<RowData, string>) => (
         <DataTable.CellContent>
           <div className="flex flex-row items-center gap-2 py-3">
-            {info.row.original.name}
+            <div>{info.row.original.avatar}</div>
+            <div className="flex flex-col">
+              <div className="flex-grow truncate">{info.getValue()}</div>
+            </div>
           </div>
         </DataTable.CellContent>
       ),
       accessorFn: (row: RowData) => row.name,
+      meta: {
+        className: "w-80",
+      },
+    },
+    {
+      id: "description",
+      header: "Description",
+      cell: (info: CellContext<RowData, string>) => (
+        <DataTable.BasicCellContent label={info.row.original.description} />
+      ),
+      meta: {
+        className: "w-full",
+      },
     },
     {
       id: "lastUpdated",
@@ -61,12 +80,17 @@ export const SpaceTriggersList = ({ owner, space }: SpaceActionsListProps) => {
 
   const rows: RowData[] = React.useMemo(
     () =>
-      webhookSourceViews.map((webhookSourceView) => ({
-        id: webhookSourceView.sId,
-        name:
-          webhookSourceView.customName ?? webhookSourceView.webhookSource.name,
-        lastUpdated: webhookSourceView.updatedAt,
-      })),
+      webhookSourceViews.map((webhookSourceView) => {
+        return {
+          id: webhookSourceView.sId,
+          name:
+            webhookSourceView.customName ??
+            webhookSourceView.webhookSource.name,
+          description: webhookSourceView.description ?? "",
+          avatar: getAvatarFromIcon(webhookSourceView.icon, "sm"),
+          lastUpdated: webhookSourceView.updatedAt,
+        };
+      }),
     [webhookSourceViews]
   );
 

--- a/front/components/spaces/SpaceTriggersList.tsx
+++ b/front/components/spaces/SpaceTriggersList.tsx
@@ -2,8 +2,8 @@ import { DataTable, Spinner } from "@dust-tt/sparkle";
 import type { CellContext, ColumnDef } from "@tanstack/react-table";
 import * as React from "react";
 
+import { getAvatarFromIcon } from "@app/components/resources/resources_icons";
 import { usePaginationFromUrl } from "@app/hooks/usePaginationFromUrl";
-import { getAvatarFromIcon } from "@app/lib/actions/mcp_icons";
 import { useWebhookSourceViews } from "@app/lib/swr/webhook_source";
 import { formatTimestampToFriendlyDate } from "@app/lib/utils";
 import type { LightWorkspaceType, SpaceType } from "@app/types";

--- a/front/components/triggers/AdminTriggersList.tsx
+++ b/front/components/triggers/AdminTriggersList.tsx
@@ -10,11 +10,11 @@ import type { CellContext, ColumnDef } from "@tanstack/react-table";
 import type { Dispatch, SetStateAction } from "react";
 import { useMemo, useState } from "react";
 
+import { getAvatarFromIcon } from "@app/components/resources/resources_icons";
 import { TRIGGER_BUTTONS_CONTAINER_ID } from "@app/components/spaces/SpacePageHeaders";
 import { UsedByButton } from "@app/components/spaces/UsedByButton";
 import { CreateWebhookSourceDialog } from "@app/components/triggers/CreateWebhookSourceDialog";
 import { useActionButtonsPortal } from "@app/hooks/useActionButtonsPortal";
-import { getAvatarFromIcon } from "@app/lib/actions/mcp_icons";
 import { useSpacesAsAdmin } from "@app/lib/swr/spaces";
 import { formatTimestampToFriendlyDate } from "@app/lib/utils";
 import { filterWebhookSource } from "@app/lib/webhookSource";

--- a/front/components/triggers/AdminTriggersList.tsx
+++ b/front/components/triggers/AdminTriggersList.tsx
@@ -14,6 +14,7 @@ import { TRIGGER_BUTTONS_CONTAINER_ID } from "@app/components/spaces/SpacePageHe
 import { UsedByButton } from "@app/components/spaces/UsedByButton";
 import { CreateWebhookSourceDialog } from "@app/components/triggers/CreateWebhookSourceDialog";
 import { useActionButtonsPortal } from "@app/hooks/useActionButtonsPortal";
+import { getAvatarFromIcon } from "@app/lib/actions/mcp_icons";
 import { useSpacesAsAdmin } from "@app/lib/swr/spaces";
 import { formatTimestampToFriendlyDate } from "@app/lib/utils";
 import { filterWebhookSource } from "@app/lib/webhookSource";
@@ -29,7 +30,7 @@ type RowData = {
 
 const NameCell = ({ row }: { row: RowData }) => {
   const { webhookSource } = row;
-
+  const systemView = webhookSource.systemView;
   return (
     <DataTable.CellContent grow>
       <div
@@ -38,10 +39,16 @@ const NameCell = ({ row }: { row: RowData }) => {
           webhookSource.systemView ? "" : "opacity-50"
         )}
       >
+        {systemView && <div>{getAvatarFromIcon(systemView.icon, "sm")}</div>}
         <div className="flex flex-grow flex-col gap-0 overflow-hidden truncate">
           <div className="truncate text-sm font-semibold text-foreground dark:text-foreground-night">
-            {webhookSource.systemView?.customName ?? webhookSource.name}
+            {systemView?.customName ?? webhookSource.name}
           </div>
+          {systemView?.description && (
+            <div className="truncate text-xs text-muted-foreground dark:text-muted-foreground-night">
+              {systemView.description}
+            </div>
+          )}
         </div>
       </div>
     </DataTable.CellContent>

--- a/front/components/triggers/WebhookSourceDetailsHeader.tsx
+++ b/front/components/triggers/WebhookSourceDetailsHeader.tsx
@@ -1,5 +1,4 @@
-import { ActionGlobeAltIcon, Avatar } from "@dust-tt/sparkle";
-
+import { getAvatarFromIcon } from "@app/lib/actions/mcp_icons";
 import type { WebhookSourceViewType } from "@app/types/triggers/webhooks";
 
 interface WebhookSourceDetailsHeaderProps {
@@ -11,13 +10,14 @@ export function WebhookSourceDetailsHeader({
 }: WebhookSourceDetailsHeaderProps) {
   return (
     <div className="items-top flex flex-col gap-3 sm:flex-row">
-      <Avatar icon={ActionGlobeAltIcon} size="md" />
+      {getAvatarFromIcon(webhookSourceView.icon, "md")}
       <div className="flex grow flex-col gap-0 pr-9">
         <h2 className="heading-lg line-clamp-1 text-foreground dark:text-foreground-night">
           {webhookSourceView.customName ?? webhookSourceView.webhookSource.name}
         </h2>
         <div className="line-clamp-1 overflow-hidden text-sm text-muted-foreground dark:text-muted-foreground-night">
-          Webhook source for triggering assistants.
+          {webhookSourceView.description ||
+            "Webhook source for triggering assistants."}
         </div>
       </div>
     </div>

--- a/front/components/triggers/WebhookSourceDetailsHeader.tsx
+++ b/front/components/triggers/WebhookSourceDetailsHeader.tsx
@@ -1,4 +1,4 @@
-import { getAvatarFromIcon } from "@app/lib/actions/mcp_icons";
+import { getAvatarFromIcon } from "@app/components/resources/resources_icons";
 import type { WebhookSourceViewType } from "@app/types/triggers/webhooks";
 
 interface WebhookSourceDetailsHeaderProps {

--- a/front/components/triggers/WebhookSourceViewForm.tsx
+++ b/front/components/triggers/WebhookSourceViewForm.tsx
@@ -1,12 +1,27 @@
-import { Button, Input } from "@dust-tt/sparkle";
+import {
+  ActionIcons,
+  Button,
+  IconPicker,
+  Input,
+  Label,
+  PopoverContent,
+  PopoverRoot,
+  PopoverTrigger,
+  TextArea,
+} from "@dust-tt/sparkle";
 import { zodResolver } from "@hookform/resolvers/zod";
-import { useCallback } from "react";
+import { useCallback, useState } from "react";
 import { Controller, useForm } from "react-hook-form";
 
+import { getIcon } from "@app/lib/actions/mcp_icons";
 import {
   useUpdateWebhookSourceView,
   useWebhookSourcesWithViews,
 } from "@app/lib/swr/webhook_source";
+import {
+  DEFAULT_WEBHOOK_ICON,
+  normalizeWebhookIcon,
+} from "@app/lib/webhookSource";
 import type { LightWorkspaceType } from "@app/types";
 import type {
   PatchWebhookSourceViewBody,
@@ -24,12 +39,15 @@ export function WebhookSourceViewForm({
   webhookSourceView,
 }: WebhookSourceViewFormProps) {
   const { updateWebhookSourceView } = useUpdateWebhookSourceView({ owner });
+  const [isPopoverOpen, setIsPopoverOpen] = useState(false);
 
   const form = useForm<PatchWebhookSourceViewBody>({
     resolver: zodResolver(patchWebhookSourceViewBodySchema),
     defaultValues: {
       name:
         webhookSourceView.customName ?? webhookSourceView.webhookSource.name,
+      description: webhookSourceView.description ?? "",
+      icon: webhookSourceView.icon ?? DEFAULT_WEBHOOK_ICON,
     },
   });
 
@@ -42,6 +60,8 @@ export function WebhookSourceViewForm({
     async (values: PatchWebhookSourceViewBody) => {
       const success = await updateWebhookSourceView(webhookSourceView.sId, {
         name: values.name,
+        description: values.description,
+        icon: values.icon,
       });
 
       if (success) {
@@ -57,24 +77,72 @@ export function WebhookSourceViewForm({
     ]
   );
 
+  const selectedIcon = form.watch("icon");
+
+  const IconComponent = getIcon(normalizeWebhookIcon(selectedIcon));
+
   return (
     <div className="space-y-5 text-foreground dark:text-foreground-night">
-      <div className="flex items-end space-x-2">
-        <div className="flex-grow">
-          <Controller
-            control={form.control}
-            name="name"
-            render={({ field }) => (
-              <Input
-                {...field}
-                label="Custom Name"
-                isError={!!form.formState.errors.name}
-                message={form.formState.errors.name?.message}
-                placeholder={webhookSourceView.webhookSource.name}
+      <div className="space-y-2">
+        <Label htmlFor="trigger-name-icon">Name & Icon</Label>
+        <div className="flex items-end space-x-2">
+          <div className="flex-grow">
+            <Controller
+              control={form.control}
+              name="name"
+              render={({ field }) => (
+                <Input
+                  {...field}
+                  id="trigger-name-icon"
+                  isError={!!form.formState.errors.name}
+                  message={form.formState.errors.name?.message}
+                  placeholder={webhookSourceView.webhookSource.name}
+                />
+              )}
+            />
+          </div>
+          <PopoverRoot open={isPopoverOpen}>
+            <PopoverTrigger asChild>
+              <Button
+                variant="outline"
+                size="sm"
+                icon={IconComponent}
+                onClick={() => setIsPopoverOpen(true)}
+                isSelect
               />
-            )}
-          />
+            </PopoverTrigger>
+            <PopoverContent
+              className="w-fit py-0"
+              onInteractOutside={() => setIsPopoverOpen(false)}
+              onEscapeKeyDown={() => setIsPopoverOpen(false)}
+            >
+              <IconPicker
+                icons={ActionIcons}
+                selectedIcon={selectedIcon ?? DEFAULT_WEBHOOK_ICON}
+                onIconSelect={(iconName: string) => {
+                  form.setValue("icon", iconName, { shouldDirty: true });
+                  setIsPopoverOpen(false);
+                }}
+              />
+            </PopoverContent>
+          </PopoverRoot>
         </div>
+      </div>
+
+      <div className="space-y-2">
+        <Label htmlFor="trigger-description">Description</Label>
+        <Controller
+          control={form.control}
+          name="description"
+          render={({ field }) => (
+            <TextArea
+              {...field}
+              id="trigger-description"
+              rows={3}
+              placeholder="Enter a description for this trigger"
+            />
+          )}
+        />
       </div>
 
       {form.formState.isDirty && (

--- a/front/components/triggers/WebhookSourceViewForm.tsx
+++ b/front/components/triggers/WebhookSourceViewForm.tsx
@@ -13,7 +13,7 @@ import { zodResolver } from "@hookform/resolvers/zod";
 import { useCallback, useState } from "react";
 import { Controller, useForm } from "react-hook-form";
 
-import { getIcon } from "@app/lib/actions/mcp_icons";
+import { getIcon } from "@app/components/resources/resources_icons";
 import {
   useUpdateWebhookSourceView,
   useWebhookSourcesWithViews,

--- a/front/lib/actions/configuration/mcp.ts
+++ b/front/lib/actions/configuration/mcp.ts
@@ -1,15 +1,15 @@
 import type { IncludeOptions, WhereOptions } from "sequelize";
 import { Op } from "sequelize";
 
+import type {
+  CustomResourceIconType,
+  InternalAllowedIconType,
+} from "@app/components/resources/resources_icons";
 import {
   renderDataSourceConfiguration,
   renderTableConfiguration,
 } from "@app/lib/actions/configuration/helpers";
 import type { MCPServerConfigurationType } from "@app/lib/actions/mcp";
-import type {
-  CustomServerIconType,
-  InternalAllowedIconType,
-} from "@app/lib/actions/mcp_icons";
 import type { Authenticator } from "@app/lib/auth";
 import { AgentDataSourceConfiguration } from "@app/lib/models/assistant/actions/data_sources";
 import {
@@ -133,8 +133,10 @@ export async function fetchMCPServerActionConfigurations(
     );
     let serverName: string | null = null;
     let serverDescription: string | null = null;
-    let serverIcon: InternalAllowedIconType | CustomServerIconType | undefined =
-      undefined;
+    let serverIcon:
+      | InternalAllowedIconType
+      | CustomResourceIconType
+      | undefined = undefined;
 
     if (!mcpServerView) {
       logger.warn(

--- a/front/lib/actions/constants.ts
+++ b/front/lib/actions/constants.ts
@@ -1,7 +1,7 @@
 import type {
-  CustomServerIconType,
+  CustomResourceIconType,
   InternalAllowedIconType,
-} from "@app/lib/actions/mcp_icons";
+} from "@app/components/resources/resources_icons";
 
 export const DEFAULT_MCP_REQUEST_TIMEOUT_MS = 3 * 60 * 1000; // 3 minutes.
 
@@ -74,5 +74,5 @@ export type MCPValidationMetadataType = {
   mcpServerName: string;
   agentName: string;
   pubsubMessageId?: string;
-  icon?: InternalAllowedIconType | CustomServerIconType;
+  icon?: InternalAllowedIconType | CustomResourceIconType;
 };

--- a/front/lib/actions/mcp.ts
+++ b/front/lib/actions/mcp.ts
@@ -1,13 +1,13 @@
 import type { JSONSchema7 as JSONSchema } from "json-schema";
 
 import type {
+  CustomResourceIconType,
+  InternalAllowedIconType,
+} from "@app/components/resources/resources_icons";
+import type {
   MCPToolStakeLevelType,
   MCPValidationMetadataType,
 } from "@app/lib/actions/constants";
-import type {
-  CustomServerIconType,
-  InternalAllowedIconType,
-} from "@app/lib/actions/mcp_icons";
 import type { MCPServerAvailability } from "@app/lib/actions/mcp_internal_actions/constants";
 import type { ToolPersonalAuthRequiredEvent } from "@app/lib/actions/mcp_internal_actions/events";
 import { hideInternalConfiguration } from "@app/lib/actions/mcp_internal_actions/input_configuration";
@@ -49,7 +49,7 @@ export type BaseMCPServerConfigurationType = {
   name: string;
 
   description: string | null;
-  icon?: CustomServerIconType | InternalAllowedIconType;
+  icon?: CustomResourceIconType | InternalAllowedIconType;
 };
 
 // Server-side MCP server = Remote MCP Server OR our own MCP server.

--- a/front/lib/actions/mcp_icons.tsx
+++ b/front/lib/actions/mcp_icons.tsx
@@ -1,132 +1,14 @@
-import type { Icon } from "@dust-tt/sparkle";
-import {
-  ActionAtomIcon,
-  ActionBrainIcon,
-  ActionCloudArrowLeftRightIcon,
-  ActionDocumentTextIcon,
-  ActionEmotionLaughIcon,
-  ActionGitBranchIcon,
-  ActionGlobeAltIcon,
-  ActionIcons,
-  ActionImageIcon,
-  ActionLightbulbIcon,
-  ActionLockIcon,
-  ActionMagnifyingGlassIcon,
-  ActionPieChartIcon,
-  ActionRobotIcon,
-  ActionScanIcon,
-  ActionSlideshowIcon,
-  ActionTableIcon,
-  ActionTimeIcon,
-  AsanaLogo,
-  Avatar,
-  CommandLineIcon,
-  ConfluenceLogo,
-  DriveLogo,
-  FreshserviceLogo,
-  GcalLogo,
-  GithubLogo,
-  GmailLogo,
-  GoogleSpreadsheetLogo,
-  HubspotLogo,
-  JiraLogo,
-  LinearLogo,
-  MondayLogo,
-  NotionLogo,
-  OpenaiLogo,
-  OutlookLogo,
-  SalesforceLogo,
-  SlackLogo,
-  StripeLogo,
-} from "@dust-tt/sparkle";
-import type React from "react";
-import type { ComponentProps, ComponentType } from "react";
+import type { Avatar } from "@dust-tt/sparkle";
+import type { ComponentProps } from "react";
 
+import { getAvatarFromIcon } from "@app/components/resources/resources_icons";
 import type { MCPServerType } from "@app/lib/api/mcp";
 
 export const DEFAULT_MCP_SERVER_ICON = "ActionCommand1Icon" as const;
-
-export const CUSTOM_SERVER_ALLOWED = Object.keys(ActionIcons);
-
-export const InternalActionIcons = {
-  ActionAtomIcon,
-  ActionBrainIcon,
-  ActionCloudArrowLeftRightIcon,
-  ActionDocumentTextIcon,
-  ActionEmotionLaughIcon,
-  ActionGitBranchIcon,
-  ActionGlobeAltIcon,
-  ActionImageIcon,
-  ActionLightbulbIcon,
-  ActionLockIcon,
-  ActionMagnifyingGlassIcon,
-  ActionRobotIcon,
-  ActionScanIcon,
-  ActionTableIcon,
-  ActionPieChartIcon,
-  ActionSlideshowIcon,
-  ActionTimeIcon,
-  AsanaLogo,
-  CommandLineIcon,
-  ConfluenceLogo,
-  GcalLogo,
-  GithubLogo,
-  GmailLogo,
-  GoogleSpreadsheetLogo,
-  FreshserviceLogo,
-  HubspotLogo,
-  OutlookLogo,
-  JiraLogo,
-  LinearLogo,
-  MondayLogo,
-  NotionLogo,
-  OpenaiLogo,
-  SalesforceLogo,
-  SlackLogo,
-  StripeLogo,
-  DriveLogo,
-};
-
-export const INTERNAL_ALLOWED_ICONS = Object.keys(InternalActionIcons);
-
-export type CustomServerIconType = keyof typeof ActionIcons;
-
-export const isCustomServerIconType = (
-  icon: string
-): icon is CustomServerIconType =>
-  CUSTOM_SERVER_ALLOWED.includes(icon as CustomServerIconType);
-
-export type InternalAllowedIconType = keyof typeof InternalActionIcons;
-
-export const isInternalAllowedIcon = (
-  icon: string
-): icon is InternalAllowedIconType =>
-  INTERNAL_ALLOWED_ICONS.includes(icon as InternalAllowedIconType);
 
 export const getAvatar = (
   mcpServer: MCPServerType,
   size: ComponentProps<typeof Avatar>["size"] = "sm"
 ) => {
   return getAvatarFromIcon(mcpServer.icon, size);
-};
-
-export const getAvatarFromIcon = (
-  icon: InternalAllowedIconType | CustomServerIconType,
-  size: ComponentProps<typeof Avatar>["size"] = "sm"
-) => {
-  if (isCustomServerIconType(icon)) {
-    return <Avatar icon={ActionIcons[icon]} size={size} />;
-  }
-
-  return <Avatar icon={InternalActionIcons[icon]} size={size} />;
-};
-
-export const getIcon = (
-  icon: InternalAllowedIconType | CustomServerIconType
-): ComponentType<ComponentProps<typeof Icon>> => {
-  if (isCustomServerIconType(icon)) {
-    return ActionIcons[icon];
-  }
-
-  return InternalActionIcons[icon];
 };

--- a/front/lib/actions/mcp_icons.tsx
+++ b/front/lib/actions/mcp_icons.tsx
@@ -6,6 +6,7 @@ import type { MCPServerType } from "@app/lib/api/mcp";
 
 export const DEFAULT_MCP_SERVER_ICON = "ActionCommand1Icon" as const;
 
+// MCP-specific function
 export const getAvatar = (
   mcpServer: MCPServerType,
   size: ComponentProps<typeof Avatar>["size"] = "sm"

--- a/front/lib/actions/mcp_internal_actions/constants.ts
+++ b/front/lib/actions/mcp_internal_actions/constants.ts
@@ -1,3 +1,4 @@
+import type { InternalAllowedIconType } from "@app/components/resources/resources_icons";
 import type { MCPToolStakeLevelType } from "@app/lib/actions/constants";
 import {
   DEFAULT_AGENT_ROUTER_ACTION_DESCRIPTION,
@@ -6,7 +7,6 @@ import {
   DEFAULT_WEBSEARCH_ACTION_DESCRIPTION,
   DEFAULT_WEBSEARCH_ACTION_NAME,
 } from "@app/lib/actions/constants";
-import type { InternalAllowedIconType } from "@app/lib/actions/mcp_icons";
 import {
   FRESHSERVICE_SERVER_INSTRUCTIONS,
   JIRA_SERVER_INSTRUCTIONS,

--- a/front/lib/actions/mcp_internal_actions/output_schemas.ts
+++ b/front/lib/actions/mcp_internal_actions/output_schemas.ts
@@ -6,15 +6,15 @@ import type {
 import { NotificationSchema } from "@modelcontextprotocol/sdk/types.js";
 import { z } from "zod";
 
-import { MCP_TOOL_STAKE_LEVELS } from "@app/lib/actions/constants";
 import type {
-  CustomServerIconType,
+  CustomResourceIconType,
   InternalAllowedIconType,
-} from "@app/lib/actions/mcp_icons";
+} from "@app/components/resources/resources_icons";
 import {
-  CUSTOM_SERVER_ALLOWED,
+  CUSTOM_RESOURCE_ALLOWED,
   INTERNAL_ALLOWED_ICONS,
-} from "@app/lib/actions/mcp_icons";
+} from "@app/components/resources/resources_icons";
+import { MCP_TOOL_STAKE_LEVELS } from "@app/lib/actions/constants";
 import type { AllSupportedFileContentType } from "@app/types";
 import { ALL_FILE_FORMATS, CONNECTOR_PROVIDERS } from "@app/types";
 
@@ -841,8 +841,11 @@ const InternalAllowedIconSchema = z.enum(
   ]
 );
 
-const CustomServerIconSchema = z.enum(
-  CUSTOM_SERVER_ALLOWED as [CustomServerIconType, ...CustomServerIconType[]]
+const CustomResourceIconSchema = z.enum(
+  CUSTOM_RESOURCE_ALLOWED as [
+    CustomResourceIconType,
+    ...CustomResourceIconType[],
+  ]
 );
 
 // Schema for the resource of a notification where the tool is asking for tool approval.
@@ -861,7 +864,7 @@ const NotificationToolApproveBubbleUpContentSchema = z.object({
     toolName: z.string(),
     agentName: z.string(),
     icon: z
-      .union([InternalAllowedIconSchema, CustomServerIconSchema])
+      .union([InternalAllowedIconSchema, CustomResourceIconSchema])
       .optional(),
   }),
 });

--- a/front/lib/actions/mcp_internal_actions/remote_servers.ts
+++ b/front/lib/actions/mcp_internal_actions/remote_servers.ts
@@ -1,6 +1,5 @@
+import type { InternalAllowedIconType } from "@app/components/resources/resources_icons";
 import type { MCPOAuthUseCase } from "@app/types";
-
-import type { InternalAllowedIconType } from "../mcp_icons";
 
 export type DefaultRemoteMCPServerConfig = {
   id: number;

--- a/front/lib/actions/mcp_metadata.ts
+++ b/front/lib/actions/mcp_metadata.ts
@@ -9,6 +9,7 @@ import type { Implementation, Tool } from "@modelcontextprotocol/sdk/types.js";
 import type { JSONSchema7 as JSONSchema } from "json-schema";
 import { ProxyAgent } from "undici";
 
+import { isInternalAllowedIcon } from "@app/components/resources/resources_icons";
 import {
   DEFAULT_MCP_ACTION_DESCRIPTION,
   DEFAULT_MCP_ACTION_NAME,
@@ -20,10 +21,7 @@ import {
 } from "@app/lib/actions/mcp_authentication";
 import { MCPServerNotFoundError } from "@app/lib/actions/mcp_errors";
 import { getServerTypeAndIdFromSId } from "@app/lib/actions/mcp_helper";
-import {
-  DEFAULT_MCP_SERVER_ICON,
-  isInternalAllowedIcon,
-} from "@app/lib/actions/mcp_icons";
+import { DEFAULT_MCP_SERVER_ICON } from "@app/lib/actions/mcp_icons";
 import { connectToInternalMCPServer } from "@app/lib/actions/mcp_internal_actions";
 import { InMemoryWithAuthTransport } from "@app/lib/actions/mcp_internal_actions/in_memory_with_auth_transport";
 import { MCPOAuthRequiredError } from "@app/lib/actions/mcp_oauth_error";

--- a/front/lib/api/mcp.ts
+++ b/front/lib/api/mcp.ts
@@ -1,14 +1,14 @@
 import type { JSONSchema7 as JSONSchema } from "json-schema";
 
+import type {
+  CustomResourceIconType,
+  InternalAllowedIconType,
+} from "@app/components/resources/resources_icons";
 import type { MCPToolStakeLevelType } from "@app/lib/actions/constants";
 import type {
   LightMCPToolConfigurationType,
   MCPToolConfigurationType,
 } from "@app/lib/actions/mcp";
-import type {
-  CustomServerIconType,
-  InternalAllowedIconType,
-} from "@app/lib/actions/mcp_icons";
 import type {
   InternalMCPServerNameType,
   MCPServerAvailability,
@@ -73,7 +73,7 @@ export type MCPServerType = {
   name: string;
   version: string;
   description: string;
-  icon: CustomServerIconType | InternalAllowedIconType;
+  icon: CustomResourceIconType | InternalAllowedIconType;
   authorization: AuthorizationInfo | null;
   tools: MCPToolType[];
   availability: MCPServerAvailability;
@@ -88,7 +88,7 @@ export type RemoteMCPServerType = MCPServerType & {
   lastSyncAt?: Date | null;
   lastError?: string | null;
   customHeaders?: Record<string, string> | null;
-  icon: CustomServerIconType | InternalAllowedIconType;
+  icon: CustomResourceIconType | InternalAllowedIconType;
   // Always manual and allow multiple instances.
   availability: "manual";
   allowMultipleInstances: true;

--- a/front/lib/models/assistant/actions/remote_mcp_server.ts
+++ b/front/lib/models/assistant/actions/remote_mcp_server.ts
@@ -1,11 +1,11 @@
 import type { CreationOptional } from "sequelize";
 import { DataTypes } from "sequelize";
 
-import { DEFAULT_MCP_ACTION_VERSION } from "@app/lib/actions/constants";
 import type {
-  CustomServerIconType,
+  CustomResourceIconType,
   InternalAllowedIconType,
-} from "@app/lib/actions/mcp_icons";
+} from "@app/components/resources/resources_icons";
+import { DEFAULT_MCP_ACTION_VERSION } from "@app/lib/actions/constants";
 import type { AuthorizationInfo } from "@app/lib/actions/mcp_metadata";
 import type { MCPToolType } from "@app/lib/api/mcp";
 import { frontSequelize } from "@app/lib/resources/storage";
@@ -16,7 +16,7 @@ export class RemoteMCPServerModel extends WorkspaceAwareModel<RemoteMCPServerMod
   declare updatedAt: CreationOptional<Date>;
 
   declare url: string;
-  declare icon: CustomServerIconType | InternalAllowedIconType;
+  declare icon: CustomResourceIconType | InternalAllowedIconType;
   declare version: string;
 
   declare cachedName: string;

--- a/front/lib/models/assistant/triggers/webhook_sources_view.ts
+++ b/front/lib/models/assistant/triggers/webhook_sources_view.ts
@@ -18,6 +18,8 @@ export class WebhookSourcesViewModel extends SoftDeletableWorkspaceAwareModel<We
   declare webhookSourceId: ForeignKey<WebhookSourceModel["id"]>;
 
   declare customName: string | null;
+  declare description: string;
+  declare icon: string;
 
   declare vaultId: ForeignKey<SpaceModel["id"]>;
 
@@ -48,6 +50,14 @@ WebhookSourcesViewModel.init(
     customName: {
       type: DataTypes.STRING,
       allowNull: true,
+    },
+    description: {
+      type: DataTypes.STRING,
+      allowNull: false,
+    },
+    icon: {
+      type: DataTypes.STRING,
+      allowNull: false,
     },
     webhookSourceId: {
       type: DataTypes.BIGINT,

--- a/front/lib/models/assistant/triggers/webhook_sources_view.ts
+++ b/front/lib/models/assistant/triggers/webhook_sources_view.ts
@@ -52,7 +52,7 @@ WebhookSourcesViewModel.init(
       allowNull: true,
     },
     description: {
-      type: DataTypes.STRING,
+      type: DataTypes.TEXT,
       allowNull: false,
     },
     icon: {

--- a/front/lib/resources/remote_mcp_servers_resource.ts
+++ b/front/lib/resources/remote_mcp_servers_resource.ts
@@ -7,12 +7,12 @@ import type {
 } from "sequelize";
 import { Op } from "sequelize";
 
+import type {
+  CustomResourceIconType,
+  InternalAllowedIconType,
+} from "@app/components/resources/resources_icons";
 import { DEFAULT_MCP_ACTION_DESCRIPTION } from "@app/lib/actions/constants";
 import { remoteMCPServerNameToSId } from "@app/lib/actions/mcp_helper";
-import type {
-  CustomServerIconType,
-  InternalAllowedIconType,
-} from "@app/lib/actions/mcp_icons";
 import type { MCPToolType, RemoteMCPServerType } from "@app/lib/api/mcp";
 import type { Authenticator } from "@app/lib/auth";
 import { DustError } from "@app/lib/error";
@@ -274,7 +274,7 @@ export class RemoteMCPServerResource extends BaseResource<RemoteMCPServerModel> 
       lastSyncAt,
       clearError,
     }: {
-      icon?: CustomServerIconType | InternalAllowedIconType;
+      icon?: CustomResourceIconType | InternalAllowedIconType;
       sharedSecret?: string;
       customHeaders?: Record<string, string>;
       cachedName?: string;

--- a/front/lib/resources/webhook_source_resource.ts
+++ b/front/lib/resources/webhook_source_resource.ts
@@ -14,6 +14,7 @@ import { SpaceResource } from "@app/lib/resources/space_resource";
 import type { ReadonlyAttributesType } from "@app/lib/resources/storage/types";
 import { getResourceIdFromSId, makeSId } from "@app/lib/resources/string_ids";
 import type { ResourceFindOptions } from "@app/lib/resources/types";
+import { DEFAULT_WEBHOOK_ICON } from "@app/lib/webhookSource";
 import type { ModelId, Result } from "@app/types";
 import { Err, normalizeError, Ok, redactString } from "@app/types";
 import type { WebhookSourceType } from "@app/types/triggers/webhooks";
@@ -61,6 +62,8 @@ export class WebhookSourceResource extends BaseResource<WebhookSourceModel> {
           editedAt: new Date(),
           editedByUserId: auth.user()?.id,
           webhookSourceId: webhookSource.id,
+          description: "",
+          icon: DEFAULT_WEBHOOK_ICON,
         },
         {
           transaction,

--- a/front/lib/swr/webhook_source.ts
+++ b/front/lib/swr/webhook_source.ts
@@ -131,7 +131,7 @@ export function useUpdateWebhookSourceView({
   const updateWebhookSourceView = useCallback(
     async (
       webhookSourceViewId: string,
-      updates: { name: string }
+      updates: { name: string; description?: string; icon?: string }
     ): Promise<boolean> => {
       try {
         const response = await fetch(

--- a/front/lib/webhookSource.ts
+++ b/front/lib/webhookSource.ts
@@ -1,9 +1,34 @@
 import { createHmac, timingSafeEqual } from "crypto";
 
 import type {
+  CustomServerIconType,
+  InternalAllowedIconType,
+} from "@app/lib/actions/mcp_icons";
+import {
+  isCustomServerIconType,
+  isInternalAllowedIcon,
+} from "@app/lib/actions/mcp_icons";
+import type {
   WebhookSourceSignatureAlgorithm,
   WebhookSourceWithViews,
 } from "@app/types/triggers/webhooks";
+
+export const DEFAULT_WEBHOOK_ICON: InternalAllowedIconType =
+  "ActionGlobeAltIcon" as const;
+
+export const normalizeWebhookIcon = (
+  icon: string | null | undefined
+): InternalAllowedIconType | CustomServerIconType => {
+  if (!icon) {
+    return DEFAULT_WEBHOOK_ICON;
+  }
+
+  if (isInternalAllowedIcon(icon) || isCustomServerIconType(icon)) {
+    return icon;
+  }
+
+  return DEFAULT_WEBHOOK_ICON;
+};
 
 export const filterWebhookSource = (
   webhookSource: WebhookSourceWithViews,

--- a/front/lib/webhookSource.ts
+++ b/front/lib/webhookSource.ts
@@ -1,13 +1,13 @@
 import { createHmac, timingSafeEqual } from "crypto";
 
 import type {
-  CustomServerIconType,
+  CustomResourceIconType,
   InternalAllowedIconType,
-} from "@app/lib/actions/mcp_icons";
+} from "@app/components/resources/resources_icons";
 import {
-  isCustomServerIconType,
+  isCustomResourceIconType,
   isInternalAllowedIcon,
-} from "@app/lib/actions/mcp_icons";
+} from "@app/components/resources/resources_icons";
 import type {
   WebhookSourceSignatureAlgorithm,
   WebhookSourceWithViews,
@@ -18,12 +18,12 @@ export const DEFAULT_WEBHOOK_ICON: InternalAllowedIconType =
 
 export const normalizeWebhookIcon = (
   icon: string | null | undefined
-): InternalAllowedIconType | CustomServerIconType => {
+): InternalAllowedIconType | CustomResourceIconType => {
   if (!icon) {
     return DEFAULT_WEBHOOK_ICON;
   }
 
-  if (isInternalAllowedIcon(icon) || isCustomServerIconType(icon)) {
+  if (isInternalAllowedIcon(icon) || isCustomResourceIconType(icon)) {
     return icon;
   }
 

--- a/front/migrations/db/migration_374.sql
+++ b/front/migrations/db/migration_374.sql
@@ -1,0 +1,17 @@
+-- Migration created on Oct 07, 2025
+
+-- First add columns as nullable
+ALTER TABLE "webhook_sources_views"
+ADD COLUMN "description" TEXT,
+ADD COLUMN "icon" VARCHAR(255);
+
+-- Update existing rows with default values
+UPDATE "webhook_sources_views"
+SET "description" = '',
+    "icon" = 'ActionGlobeAltIcon'
+WHERE "description" IS NULL OR "icon" IS NULL;
+
+-- Now make the columns NOT NULL (no default at DB level)
+ALTER TABLE "webhook_sources_views"
+ALTER COLUMN "description" SET NOT NULL,
+ALTER COLUMN "icon" SET NOT NULL;

--- a/front/pages/api/w/[wId]/mcp/[serverId]/index.ts
+++ b/front/pages/api/w/[wId]/mcp/[serverId]/index.ts
@@ -2,8 +2,8 @@ import type { NextApiRequest, NextApiResponse } from "next";
 import { z } from "zod";
 import { fromError } from "zod-validation-error";
 
+import type { CustomResourceIconType } from "@app/components/resources/resources_icons";
 import { getServerTypeAndIdFromSId } from "@app/lib/actions/mcp_helper";
-import type { CustomServerIconType } from "@app/lib/actions/mcp_icons";
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
 import type { MCPServerType } from "@app/lib/api/mcp";
 import type { Authenticator } from "@app/lib/auth";
@@ -164,7 +164,7 @@ async function handler(
       if ("icon" in r.data) {
         if (server instanceof RemoteMCPServerResource) {
           const r2 = await server.updateMetadata(auth, {
-            icon: r.data.icon as CustomServerIconType | undefined,
+            icon: r.data.icon as CustomResourceIconType | undefined,
             lastSyncAt: new Date(),
           });
           if (r2.isErr()) {

--- a/front/pages/api/w/[wId]/mcp/index.ts
+++ b/front/pages/api/w/[wId]/mcp/index.ts
@@ -2,10 +2,8 @@ import { isLeft } from "fp-ts/lib/Either";
 import * as t from "io-ts";
 import type { NextApiRequest, NextApiResponse } from "next";
 
-import {
-  DEFAULT_MCP_SERVER_ICON,
-  isCustomServerIconType,
-} from "@app/lib/actions/mcp_icons";
+import { isCustomResourceIconType } from "@app/components/resources/resources_icons";
+import { DEFAULT_MCP_SERVER_ICON } from "@app/lib/actions/mcp_icons";
 import {
   allowsMultipleInstancesOfInternalMCPServerByName,
   isInternalMCPServerName,
@@ -210,7 +208,7 @@ async function handler(
           icon:
             // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
             defaultConfig?.icon ||
-            (isCustomServerIconType(metadata.icon)
+            (isCustomResourceIconType(metadata.icon)
               ? metadata.icon
               : DEFAULT_MCP_SERVER_ICON),
           version: metadata.version,

--- a/front/pages/api/w/[wId]/webhook_sources/views/[viewId]/index.test.ts
+++ b/front/pages/api/w/[wId]/webhook_sources/views/[viewId]/index.test.ts
@@ -47,6 +47,13 @@ describe("GET /api/w/[wId]/webhook_sources/views/[viewId]", () => {
     expect(responseData.webhookSourceView).toBeDefined();
     expect(responseData.webhookSourceView.sId).toBe(webhookSourceView.sId);
     expect(responseData.webhookSourceView.webhookSource).toBeDefined();
+    expect(responseData.webhookSourceView.customName).toBe(
+      webhookSourceView.customName
+    );
+    expect(responseData.webhookSourceView.description).toBe(
+      webhookSourceView.description
+    );
+    expect(responseData.webhookSourceView.icon).toBe(webhookSourceView.icon);
   });
 
   it("should return 404 when webhook source view does not exist", async () => {
@@ -309,6 +316,95 @@ describe("PATCH /api/w/[wId]/webhook_sources/views/[viewId]", () => {
     expect(updatedViews.length).toBe(initialViews.length);
     for (const view of updatedViews) {
       expect(view.customName).toBe("Updated Webhook Name");
+    }
+  });
+
+  it("should update webhook source view description and icon successfully", async () => {
+    const { req, res, workspace, systemSpace } = await setupTest(
+      "admin",
+      "PATCH"
+    );
+
+    const webhookSourceViewFactory = new WebhookSourceViewFactory(workspace);
+    const webhookSourceView =
+      await webhookSourceViewFactory.create(systemSpace);
+
+    expect(webhookSourceView).not.toBeNull();
+    req.query.viewId = webhookSourceView.sId;
+    req.body = {
+      name: "Updated Webhook View Name",
+      description: "This is a test description",
+      icon: "ActionBrainIcon",
+    };
+
+    await handler(req, res);
+
+    expect(res._getStatusCode()).toBe(200);
+    const responseData = res._getJSONData();
+    expect(responseData.webhookSourceView).toBeDefined();
+    expect(responseData.webhookSourceView.customName).toBe(
+      "Updated Webhook View Name"
+    );
+    expect(responseData.webhookSourceView.description).toBe(
+      "This is a test description"
+    );
+    expect(responseData.webhookSourceView.icon).toBe("ActionBrainIcon");
+  });
+
+  it("should update icon and description for all views of the same webhook source when admin", async () => {
+    const { req, res, workspace, auth, systemSpace } = await setupTest(
+      "admin",
+      "PATCH"
+    );
+
+    const webhookSourceViewFactory = new WebhookSourceViewFactory(workspace);
+    const systemView = await webhookSourceViewFactory.create(systemSpace);
+
+    expect(systemView).not.toBeNull();
+
+    // Create additional views in global space for the same webhook source
+    const globalSpace = await SpaceFactory.global(workspace);
+    await webhookSourceViewFactory.create(globalSpace, {
+      webhookSourceId: systemView.webhookSourceSId,
+    });
+
+    // Verify initial state
+    const initialViews = await WebhookSourcesViewResource.listByWebhookSource(
+      auth,
+      systemView.webhookSourceId
+    );
+    expect(initialViews.length).toBeGreaterThanOrEqual(2);
+
+    // Update via system view
+    req.query.viewId = systemView.sId;
+    req.body = {
+      name: "Updated Webhook Name",
+      description: "Updated description for all views",
+      icon: "ActionBrainIcon",
+    };
+    await handler(req, res);
+
+    expect(res._getStatusCode()).toBe(200);
+    const responseData = res._getJSONData();
+    expect(responseData.webhookSourceView).toBeDefined();
+    expect(responseData.webhookSourceView.customName).toBe(
+      "Updated Webhook Name"
+    );
+    expect(responseData.webhookSourceView.description).toBe(
+      "Updated description for all views"
+    );
+    expect(responseData.webhookSourceView.icon).toBe("ActionBrainIcon");
+
+    // Verify all views were updated with the new description and icon
+    const updatedViews = await WebhookSourcesViewResource.listByWebhookSource(
+      auth,
+      systemView.webhookSourceId
+    );
+    expect(updatedViews.length).toBe(initialViews.length);
+    for (const view of updatedViews) {
+      expect(view.customName).toBe("Updated Webhook Name");
+      expect(view.description).toBe("Updated description for all views");
+      expect(view.icon).toBe("ActionBrainIcon");
     }
   });
 });

--- a/front/pages/api/w/[wId]/webhook_sources/views/[viewId]/index.ts
+++ b/front/pages/api/w/[wId]/webhook_sources/views/[viewId]/index.ts
@@ -1,9 +1,9 @@
 import type { NextApiRequest, NextApiResponse } from "next";
 
 import type {
-  CustomServerIconType,
+  CustomResourceIconType,
   InternalAllowedIconType,
-} from "@app/lib/actions/mcp_icons";
+} from "@app/components/resources/resources_icons";
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
 import type { Authenticator } from "@app/lib/auth";
 import { DustError } from "@app/lib/error";
@@ -265,7 +265,7 @@ async function editWebhookSourceDescriptionAndIcon(
   auth: Authenticator,
   webhookSourceView: WebhookSourcesViewResource,
   description?: string,
-  icon?: InternalAllowedIconType | CustomServerIconType
+  icon?: InternalAllowedIconType | CustomResourceIconType
 ): Promise<Result<undefined, DustError<"unauthorized">>> {
   const systemView =
     await WebhookSourcesViewResource.getWebhookSourceViewForSystemSpace(

--- a/front/pages/api/w/[wId]/webhook_sources/views/[viewId]/index.ts
+++ b/front/pages/api/w/[wId]/webhook_sources/views/[viewId]/index.ts
@@ -1,9 +1,14 @@
 import type { NextApiRequest, NextApiResponse } from "next";
 
+import type {
+  CustomServerIconType,
+  InternalAllowedIconType,
+} from "@app/lib/actions/mcp_icons";
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
 import type { Authenticator } from "@app/lib/auth";
 import { DustError } from "@app/lib/error";
 import { WebhookSourcesViewResource } from "@app/lib/resources/webhook_sources_view_resource";
+import { normalizeWebhookIcon } from "@app/lib/webhookSource";
 import { apiError } from "@app/logger/withlogging";
 import type { Result, WithAPIErrorResponse } from "@app/types";
 import { assertNever, Err, Ok } from "@app/types";
@@ -86,11 +91,11 @@ async function handler(
         });
       }
 
-      const { name } = bodyValidation.data;
+      const { name, description, icon } = bodyValidation.data;
 
-      const result = await webhookSourceView.updateName(auth, name);
-      if (result.isErr()) {
-        switch (result.error.code) {
+      const nameResult = await webhookSourceView.updateName(auth, name);
+      if (nameResult.isErr()) {
+        switch (nameResult.error.code) {
           case "unauthorized":
             return apiError(req, res, {
               status_code: 401,
@@ -129,6 +134,63 @@ async function handler(
             });
           default:
             assertNever(updateResult.error.code);
+        }
+      }
+
+      if (description !== undefined || icon !== undefined) {
+        // Normalize the icon to ensure it's a valid icon type
+        const normalizedIcon =
+          icon !== undefined ? normalizeWebhookIcon(icon) : undefined;
+
+        const updateResult = await webhookSourceView.updateDescriptionAndIcon(
+          auth,
+          description,
+          normalizedIcon
+        );
+        if (updateResult.isErr()) {
+          switch (updateResult.error.code) {
+            case "unauthorized":
+              return apiError(req, res, {
+                status_code: 401,
+                api_error: {
+                  type: "webhook_source_view_auth_error",
+                  message:
+                    "You are not authorized to update this webhook source view.",
+                },
+              });
+            default:
+              return apiError(req, res, {
+                status_code: 500,
+                api_error: {
+                  type: "internal_server_error",
+                  message:
+                    "Failed to update webhook source view description or icon.",
+                },
+              });
+          }
+        }
+
+        // Propagate changes from system view to all space views
+        const propagateResult = await editWebhookSourceDescriptionAndIcon(
+          auth,
+          webhookSourceView,
+          description,
+          normalizedIcon
+        );
+        if (propagateResult.isErr()) {
+          switch (propagateResult.error.code) {
+            case "unauthorized":
+              return apiError(req, res, {
+                status_code: 401,
+                api_error: {
+                  type: "workspace_auth_error",
+                  message:
+                    "You are not authorized to update the webhook source view.",
+                },
+              });
+            default:
+              assertNever(propagateResult.error.code);
+          }
         }
       }
 
@@ -194,6 +256,58 @@ async function editWebhookSourceViewsName(
     auth,
     viewIdsToUpdate,
     newName
+  );
+
+  return new Ok(undefined);
+}
+
+async function editWebhookSourceDescriptionAndIcon(
+  auth: Authenticator,
+  webhookSourceView: WebhookSourcesViewResource,
+  description?: string,
+  icon?: InternalAllowedIconType | CustomServerIconType
+): Promise<Result<undefined, DustError<"unauthorized">>> {
+  const systemView =
+    await WebhookSourcesViewResource.getWebhookSourceViewForSystemSpace(
+      auth,
+      webhookSourceView.webhookSourceSId
+    );
+
+  if (!systemView) {
+    // This should never happen as we already validated that the view is a system view
+    return new Err(new DustError("unauthorized", "Only system views allowed"));
+  }
+
+  // Get all views with the same webhook source (excluding the system view already updated)
+  const allViews = await WebhookSourcesViewResource.listByWebhookSource(
+    auth,
+    webhookSourceView.webhookSourceId
+  );
+
+  // Check that the user can administrate all views
+  for (const view of allViews) {
+    if (view.sId !== webhookSourceView.sId && !view.canAdministrate(auth)) {
+      return new Err(
+        new DustError("unauthorized", "Not allowed to update all views.")
+      );
+    }
+  }
+
+  // Get IDs of views to update (excluding the system view)
+  const viewIdsToUpdate = allViews
+    .filter((view) => view.sId !== webhookSourceView.sId)
+    .map((view) => view.id);
+
+  if (viewIdsToUpdate.length === 0) {
+    return new Ok(undefined);
+  }
+
+  // Bulk update all views at once
+  await WebhookSourcesViewResource.bulkUpdateDescriptionAndIcon(
+    auth,
+    viewIdsToUpdate,
+    description,
+    icon
   );
 
   return new Ok(undefined);

--- a/front/types/triggers/webhooks.ts
+++ b/front/types/triggers/webhooks.ts
@@ -82,6 +82,9 @@ export type PatchWebhookSourceViewBody = z.infer<
 
 export const patchWebhookSourceViewBodySchema = z.object({
   name: z.string().min(1, "Name is required."),
-  description: z.string().optional(),
+  description: z
+    .string()
+    .max(4000, "Description must be at most 4000 characters.")
+    .optional(),
   icon: z.string().optional(),
 });

--- a/front/types/triggers/webhooks.ts
+++ b/front/types/triggers/webhooks.ts
@@ -1,9 +1,9 @@
 import { z } from "zod";
 
 import type {
-  CustomServerIconType,
+  CustomResourceIconType,
   InternalAllowedIconType,
-} from "@app/lib/actions/mcp_icons";
+} from "@app/components/resources/resources_icons";
 import type { AgentsUsageType } from "@app/types/data_source";
 import type { ModelId } from "@app/types/shared/model_id";
 import type { EditedByUser } from "@app/types/user";
@@ -39,7 +39,7 @@ export type WebhookSourceViewType = {
   sId: string;
   customName: string | null;
   description: string;
-  icon: InternalAllowedIconType | CustomServerIconType;
+  icon: InternalAllowedIconType | CustomResourceIconType;
   createdAt: number;
   updatedAt: number;
   spaceId: string;

--- a/front/types/triggers/webhooks.ts
+++ b/front/types/triggers/webhooks.ts
@@ -1,5 +1,9 @@
 import { z } from "zod";
 
+import type {
+  CustomServerIconType,
+  InternalAllowedIconType,
+} from "@app/lib/actions/mcp_icons";
 import type { AgentsUsageType } from "@app/types/data_source";
 import type { ModelId } from "@app/types/shared/model_id";
 import type { EditedByUser } from "@app/types/user";
@@ -34,6 +38,8 @@ export type WebhookSourceViewType = {
   id: ModelId;
   sId: string;
   customName: string | null;
+  description: string;
+  icon: InternalAllowedIconType | CustomServerIconType;
   createdAt: number;
   updatedAt: number;
   spaceId: string;
@@ -76,4 +82,6 @@ export type PatchWebhookSourceViewBody = z.infer<
 
 export const patchWebhookSourceViewBodySchema = z.object({
   name: z.string().min(1, "Name is required."),
+  description: z.string().optional(),
+  icon: z.string().optional(),
 });


### PR DESCRIPTION
## Description

Add icons and description for triggers.
They can be changed from the webhook modal
Default description is empty, default trigger is the planet icon 🌐  (see screenshots) but happy to change it to whatever you prefer

<img width="2234" height="946" alt="image" src="https://github.com/user-attachments/assets/2a2ab1e9-3223-4b79-8d31-e109b3ee35cf" />

<img width="2282" height="1660" alt="image" src="https://github.com/user-attachments/assets/8230dafa-a481-4d3c-a973-d9f8bf60dcc3" />

<img width="572" height="942" alt="image" src="https://github.com/user-attachments/assets/af4701fd-a4bd-416f-829c-d3f65485c84c" />


## Tests

Manual tests + API unit tests

## Risk



## Deploy Plan

Lock front
Merge
Apply migration
Deploy
Unlock front
