### PR TITLE
Make Workflow created by trigger more unique

### DIFF
--- a/front/temporal/agent_schedule/client.ts
+++ b/front/temporal/agent_schedule/client.ts
@@ -3,6 +3,7 @@ import {
   ScheduleNotFoundError,
   ScheduleOverlapPolicy,
 } from "@temporalio/client";
+import { randomUUID } from "crypto";
 
 import { Authenticator } from "@app/lib/auth";
 import type { TriggerResource } from "@app/lib/resources/trigger_resource";
@@ -201,5 +202,5 @@ function makeAgentTriggerWorkflowId(
   workspaceId: string,
   trigger: TriggerType
 ): string {
-  return `agent-trigger-${trigger.kind}-${userId}-${workspaceId}-${trigger.id}`;
+  return `agent-trigger-${trigger.kind}-${userId}-${workspaceId}-${trigger.id}-${randomUUID()}`;
 }

--- a/front/temporal/agent_schedule/client.ts
+++ b/front/temporal/agent_schedule/client.ts
@@ -3,7 +3,6 @@ import {
   ScheduleNotFoundError,
   ScheduleOverlapPolicy,
 } from "@temporalio/client";
-import { randomUUID } from "crypto";
 
 import { Authenticator } from "@app/lib/auth";
 import type { TriggerResource } from "@app/lib/resources/trigger_resource";
@@ -202,5 +201,5 @@ function makeAgentTriggerWorkflowId(
   workspaceId: string,
   trigger: TriggerType
 ): string {
-  return `agent-trigger-${trigger.kind}-${userId}-${workspaceId}-${trigger.id}-${randomUUID()}`;
+  return `agent-trigger-${trigger.kind}-${userId}-${workspaceId}-${trigger.sId}-${Date.now()}`;
 }


### PR DESCRIPTION
## Description

closes https://github.com/issues/assigned?issue=dust-tt%7Ctasks%7C4512

A trigger can have several wrokflow running at the same time, so we need somethig to make the name unique and avoid collision.

The choice was between using date.now or a UUID
Claude code recommend using UUID to be sure it is unique

## Tests

No

## Risk



## Deploy Plan

Deploy front
