### PR TITLE
Track user journey in the product

### DIFF
--- a/front/components/app/PostHogTracker.tsx
+++ b/front/components/app/PostHogTracker.tsx
@@ -45,7 +45,7 @@ export function PostHogTracker({ children }: PostHogTrackerProps) {
 
   const { activeSubscription } = useWorkspaceActiveSubscription({
     owner: currentWorkspace,
-    disabled: !currentWorkspace || !isAdmin,
+    disabled: !isAdmin,
   });
 
   const planProperties = useMemo(() => {

--- a/front/components/app/PostHogTracker.tsx
+++ b/front/components/app/PostHogTracker.tsx
@@ -1,14 +1,25 @@
 import { useRouter } from "next/router";
 import posthog from "posthog-js";
 import { PostHogProvider } from "posthog-js/react";
-import { useEffect } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import { useCookies } from "react-cookie";
 
 import { DUST_COOKIES_ACCEPTED, hasCookiesAccepted } from "@app/lib/cookies";
 import { useUser } from "@app/lib/swr/user";
+import { useWorkspaceActiveSubscription } from "@app/lib/swr/workspaces";
 import { isString } from "@app/types";
 
 const POSTHOG_KEY = process.env.NEXT_PUBLIC_POSTHOG_KEY;
+
+const EXCLUDED_PATHS = [
+  "/subscribe",
+  "/poke",
+  "/poke/",
+  "/sso-enforced",
+  "/maintenance",
+  "/oauth/",
+  "/share/",
+];
 
 interface PostHogTrackerProps {
   children: React.ReactNode;
@@ -25,71 +36,121 @@ export function PostHogTracker({ children }: PostHogTrackerProps) {
   const { wId } = router.query;
   const workspaceId = isString(wId) ? wId : undefined;
 
-  const excludedPaths = [
-    "/w",
-    "/w/",
-    "/subscribe",
-    "/poke",
-    "/poke/",
-    "/sso-enforced",
-    "/maintenance",
-    "/oauth/",
-    "/share/",
-  ];
+  const currentWorkspace =
+    user && workspaceId && "workspaces" in user
+      ? user.workspaces.find((w) => w.sId === workspaceId)
+      : undefined;
 
-  const isExcludedPath = excludedPaths.some((path) => {
+  const { activeSubscription } = useWorkspaceActiveSubscription({
+    owner: currentWorkspace,
+    disabled: !currentWorkspace,
+  });
+
+  const planProperties = useMemo(() => {
+    if (!activeSubscription) {
+      return null;
+    }
+    return {
+      plan_code: activeSubscription.plan.code,
+      plan_name: activeSubscription.plan.name,
+      is_trial: activeSubscription.trialing ? "true" : "false",
+    };
+  }, [activeSubscription]);
+
+  const [hasOptedIn, setHasOptedIn] = useState(false);
+  const lastIdentifiedUserId = useRef<string | null>(null);
+  const lastIdentifiedWorkspaceId = useRef<string | null>(null);
+  const lastPlanPropertiesString = useRef<string | null>(null);
+
+  const isExcludedPath = EXCLUDED_PATHS.some((path) => {
     const pathname = router.pathname;
     return pathname.startsWith(path) || pathname.endsWith(path);
   });
   const isTrackablePage = !isExcludedPath;
 
   useEffect(() => {
-    const shouldTrack = isTrackablePage && hasAcceptedCookies;
-
-    if (!shouldTrack) {
-      if (posthog.__loaded) {
-        posthog.opt_out_capturing();
-      }
+    if (!POSTHOG_KEY || posthog.__loaded) {
       return;
     }
 
-    if (!posthog.__loaded && POSTHOG_KEY) {
-      posthog.init(POSTHOG_KEY, {
-        api_host: "/ingest",
-        person_profiles: "identified_only",
-        defaults: "2025-05-24",
-        opt_out_capturing_by_default: true, // Start opted out
-        property_denylist: ["$ip"],
-        sanitize_properties: (properties) => {
-          if (properties.$current_url) {
-            properties.$current_url = properties.$current_url.split("?")[0];
-          }
-          if (properties.$pathname) {
-            properties.$pathname = properties.$pathname.split("?")[0];
-          }
-          return properties;
-        },
-        session_recording: {
-          maskAllInputs: true,
-          maskTextSelector: "*",
-        },
-        loaded: (posthog) => {
-          posthog.opt_in_capturing();
-        },
-      });
-    } else if (posthog.__loaded) {
+    posthog.init(POSTHOG_KEY, {
+      api_host: "/ingest",
+      person_profiles: "identified_only",
+      defaults: "2025-05-24",
+      opt_out_capturing_by_default: true,
+      capture_pageview: true,
+      capture_pageleave: true,
+      autocapture: false,
+      property_denylist: ["$ip"],
+      before_send: (event) => {
+        if (!event) {
+          return null;
+        }
+        if (event.properties.$current_url) {
+          event.properties.$current_url =
+            event.properties.$current_url.split("?")[0];
+        }
+        if (event.properties.$pathname) {
+          event.properties.$pathname = event.properties.$pathname.split("?")[0];
+        }
+        return event;
+      },
+      session_recording: {
+        maskAllInputs: true,
+        maskTextSelector: "*",
+        recordCrossOriginIframes: false,
+      },
+    });
+  }, []);
+
+  useEffect(() => {
+    const shouldTrack = isTrackablePage && hasAcceptedCookies;
+
+    if (!posthog.__loaded) {
+      return;
+    }
+
+    if (shouldTrack && !hasOptedIn) {
       posthog.opt_in_capturing();
+      setHasOptedIn(true);
+    } else if (!shouldTrack && hasOptedIn) {
+      posthog.opt_out_capturing();
+      setHasOptedIn(false);
+    }
+  }, [isTrackablePage, hasAcceptedCookies, hasOptedIn]);
+
+  useEffect(() => {
+    if (!posthog.__loaded || !user || !hasOptedIn) {
+      return;
     }
 
-    if (posthog.__loaded && user) {
-      posthog.identify(user.sId);
+    const planPropsString = planProperties
+      ? JSON.stringify(planProperties)
+      : null;
+    const userChanged = lastIdentifiedUserId.current !== user.sId;
+    const planChanged = lastPlanPropertiesString.current !== planPropsString;
 
-      // Group by workspace
-      if (workspaceId) {
-        posthog.group("workspace", workspaceId);
-      }
+    if (userChanged || planChanged) {
+      const userProperties: Record<string, string> = {
+        ...(planProperties ?? {}),
+        ...(workspaceId && { workspace_id: workspaceId }),
+      };
+      posthog.identify(user.sId, userProperties);
+      lastIdentifiedUserId.current = user.sId;
+      lastPlanPropertiesString.current = planPropsString;
     }
-  }, [router.pathname, hasAcceptedCookies, isTrackablePage, user, workspaceId]);
+  }, [planProperties, workspaceId, hasOptedIn, user]);
+
+  useEffect(() => {
+    if (!posthog.__loaded || !workspaceId || !planProperties || !hasOptedIn) {
+      return;
+    }
+
+    if (lastIdentifiedWorkspaceId.current !== workspaceId) {
+      posthog.group("workspace", workspaceId, planProperties);
+      lastIdentifiedWorkspaceId.current = workspaceId;
+    }
+  }, [workspaceId, planProperties, hasOptedIn]);
 
   if (isTrackablePage && hasAcceptedCookies) {
     return <PostHogProvider client={posthog}>{children}</PostHogProvider>;

--- a/front/components/assistant/AssistantBrowser.tsx
+++ b/front/components/assistant/AssistantBrowser.tsx
@@ -38,6 +38,7 @@ import { useWelcomeTourGuide } from "@app/components/assistant/WelcomeTourGuideP
 import { useHashParam } from "@app/hooks/useHashParams";
 import { usePersistedAgentBrowserSelection } from "@app/hooks/usePersistedAgentBrowserSelection";
 import { useFeatureFlags } from "@app/lib/swr/workspaces";
+import { TRACKING_AREAS, withTracking } from "@app/lib/tracking";
 import {
   compareForFuzzySort,
   getAgentSearchString,
@@ -478,6 +479,7 @@ export function AssistantBrowser({
               data-gtm-label="assistantManagementButton"
               data-gtm-location="homepage"
               size="sm"
+              onClick={withTracking(TRACKING_AREAS.BUILDER, "manage_agents")}
             />
           </div>
         </div>

--- a/front/components/assistant/CreateAgentButton.tsx
+++ b/front/components/assistant/CreateAgentButton.tsx
@@ -15,6 +15,7 @@ import { useState } from "react";
 
 import { useYAMLUpload } from "@app/hooks/useYAMLUpload";
 import { useFeatureFlags } from "@app/lib/swr/workspaces";
+import { TRACKING_AREAS, withTracking } from "@app/lib/tracking";
 import { getAgentBuilderRoute } from "@app/lib/utils/router";
 import type { LightWorkspaceType } from "@app/types";
 
@@ -44,6 +45,7 @@ export const CreateAgentButton = ({
           label="Create"
           data-gtm-label="assistantCreationButton"
           data-gtm-location={dataGtmLocation}
+          onClick={withTracking(TRACKING_AREAS.BUILDER, "create_menu")}
           size="sm"
           isSelect
           isLoading={isLoading}
@@ -54,18 +56,26 @@ export const CreateAgentButton = ({
         <DropdownMenuItem
           label="agent from scratch"
           icon={DocumentIcon}
-          onClick={() => {
-            setIsLoading(true);
-            void router.push(getAgentBuilderRoute(owner.sId, "new"));
-          }}
+          onClick={withTracking(
+            TRACKING_AREAS.BUILDER,
+            "create_from_scratch",
+            () => {
+              setIsLoading(true);
+              void router.push(getAgentBuilderRoute(owner.sId, "new"));
+            }
+          )}
         />
         <DropdownMenuItem
           label="agent from template"
           icon={MagicIcon}
-          onClick={() => {
-            setIsLoading(true);
-            void router.push(getAgentBuilderRoute(owner.sId, "create"));
-          }}
+          onClick={withTracking(
+            TRACKING_AREAS.BUILDER,
+            "create_from_template",
+            () => {
+              setIsLoading(true);
+              void router.push(getAgentBuilderRoute(owner.sId, "create"));
+            }
+          )}
         />
         {hasFeature("agent_to_yaml") && (
           <DropdownMenuItem

--- a/front/components/assistant/conversation/SidebarMenu.tsx
+++ b/front/components/assistant/conversation/SidebarMenu.tsx
@@ -64,6 +64,7 @@ import {
   useDeleteConversation,
 } from "@app/lib/swr/conversations";
 import { useFeatureFlags } from "@app/lib/swr/workspaces";
+import { TRACKING_AREAS, withTracking } from "@app/lib/tracking";
 import { removeDiacritics, subFilter } from "@app/lib/utils";
 import { getAgentBuilderRoute, getAgentRoute } from "@app/lib/utils/router";
 import type { ConversationWithoutContentType, WorkspaceType } from "@app/types";
@@ -395,6 +396,10 @@ export function AssistantSidebarMenu({ owner }: AssistantSidebarMenuProps) {
                                 label="From scratch"
                                 data-gtm-label="assistantCreationButton"
                                 data-gtm-location="sidebarMenu"
+                                onClick={withTracking(
+                                  TRACKING_AREAS.BUILDER,
+                                  "create_from_scratch"
+                                )}
                               />
                               <DropdownMenuItem
                                 href={getAgentBuilderRoute(owner.sId, "create")}
@@ -402,6 +407,10 @@ export function AssistantSidebarMenu({ owner }: AssistantSidebarMenuProps) {
                                 label="From template"
                                 data-gtm-label="assistantCreationButton"
                                 data-gtm-location="sidebarMenu"
+                                onClick={withTracking(
+                                  TRACKING_AREAS.BUILDER,
+                                  "create_from_template"
+                                )}
                               />
                               {hasFeature("agent_to_yaml") && (
                                 <DropdownMenuItem
@@ -471,6 +480,10 @@ export function AssistantSidebarMenu({ owner }: AssistantSidebarMenuProps) {
                         label="Manage agents"
                         data-gtm-label="assistantManagementButton"
                         data-gtm-location="sidebarMenu"
+                        onClick={withTracking(
+                          TRACKING_AREAS.BUILDER,
+                          "manage_agents"
+                        )}
                       />
                     )}
                     <DropdownMenuLabel>Conversations</DropdownMenuLabel>

--- a/front/components/assistant/conversation/input_bar/InputBar.tsx
+++ b/front/components/assistant/conversation/input_bar/InputBar.tsx
@@ -19,6 +19,7 @@ import {
   useConversation,
   useConversationTools,
 } from "@app/lib/swr/conversations";
+import { trackEvent, TRACKING_AREAS } from "@app/lib/tracking";
 import { classNames } from "@app/lib/utils";
 import type {
   AgentMention,
@@ -205,6 +206,17 @@ export function AssistantInputBar({
     const mentions: MentionType[] = [
       ...new Set(rawMentions.map((mention) => mention.id)),
     ].map((id) => ({ configurationId: id }));
+
+    trackEvent({
+      area: TRACKING_AREAS.CONVERSATION,
+      object: "message_send",
+      action: "submit",
+      extra: {
+        has_attachments: attachedNodes.length > 0 ? "true" : "false",
+        has_tools: selectedMCPServerViews.length > 0 ? "true" : "false",
+        has_assistant: selectedAssistant ? "true" : "false",
+      },
+    });
 
     // When we are creating a new conversation, we will disable the input bar, show a loading
     // spinner and in case of error, re-enable the input bar

--- a/front/components/home/content/Product/CallToActionSection.tsx
+++ b/front/components/home/content/Product/CallToActionSection.tsx
@@ -2,6 +2,7 @@ import { RocketIcon } from "@dust-tt/sparkle";
 
 import { H3 } from "@app/components/home/ContentComponents";
 import UTMButton from "@app/components/UTMButton";
+import { TRACKING_AREAS, withTracking } from "@app/lib/tracking";
 import { classNames } from "@app/lib/utils";
 
 export function CallToActionSection() {
@@ -20,12 +21,14 @@ export function CallToActionSection() {
           label="Try Dust now"
           icon={RocketIcon}
           href="/home/pricing"
+          onClick={withTracking(TRACKING_AREAS.HOME, "cta_try_dust")}
         />
         <UTMButton
           variant="outline"
           size="md"
           label="Request demo now"
           href="/home/contact"
+          onClick={withTracking(TRACKING_AREAS.HOME, "cta_request_demo")}
         />
       </div>
     </div>

--- a/front/components/home/content/Product/IntroSection.tsx
+++ b/front/components/home/content/Product/IntroSection.tsx
@@ -13,6 +13,7 @@ import { FunctionsSection } from "@app/components/home/FunctionsSection";
 import TrustedBy from "@app/components/home/TrustedBy";
 import { BorderBeam } from "@app/components/magicui/border-beam";
 import UTMButton from "@app/components/UTMButton";
+import { TRACKING_AREAS, withTracking } from "@app/lib/tracking";
 
 const HeroContent = () => {
   return (
@@ -37,12 +38,14 @@ const HeroContent = () => {
           label="Get started"
           icon={RocketIcon}
           href="/home/pricing"
+          onClick={withTracking(TRACKING_AREAS.HOME, "hero_get_started")}
         />
         <UTMButton
           variant="outline"
           size="md"
           label="Book a demo"
           href="/home/contact"
+          onClick={withTracking(TRACKING_AREAS.HOME, "hero_book_demo")}
         />
       </div>
     </div>
@@ -113,7 +116,13 @@ export const HeroVisual = ({
             size="md"
             label="Watch Dust in motion"
             icon={PlayIcon}
-            onClick={() => onWatch()}
+            onClick={withTracking(
+              TRACKING_AREAS.HOME,
+              "hero_watch_video",
+              () => {
+                onWatch();
+              }
+            )}
             className="shadow-[0_8px_16px_-2px_rgba(0,0,0,0.3),0_4px_8px_-2px_rgba(255,255,255,0.1)] transition-all duration-300 hover:shadow-[0_16px_40px_-2px_rgba(255,255,255,0.2),0_8px_20px_-4px_rgba(255,255,255,0.15)]"
           />
         </div>

--- a/front/components/plans/PlansTables.tsx
+++ b/front/components/plans/PlansTables.tsx
@@ -23,6 +23,7 @@ import {
   PRO_PLAN_SEAT_29_CODE,
   PRO_PLAN_SEAT_39_CODE,
 } from "@app/lib/plans/plan_codes";
+import { TRACKING_AREAS, withTracking } from "@app/lib/tracking";
 import { classNames } from "@app/lib/utils";
 import type { BillingPeriod, PlanType, WorkspaceType } from "@app/types";
 
@@ -234,7 +235,11 @@ export function ProPriceTable({
               }
               icon={RocketIcon}
               disabled={isProcessing}
-              onClick={onClick}
+              onClick={withTracking(
+                TRACKING_AREAS.PRICING,
+                "plan_pro_select",
+                onClick
+              )}
             />
           </PriceTable.ActionContainer>
         )}
@@ -358,7 +363,11 @@ export function BusinessPriceTable({
               }
               icon={RocketIcon}
               disabled={isProcessing}
-              onClick={onClick}
+              onClick={withTracking(
+                TRACKING_AREAS.PRICING,
+                "plan_pro_select",
+                onClick
+              )}
             />
           </PriceTable.ActionContainer>
         )}
@@ -399,6 +408,10 @@ function EnterprisePriceTable({
           size={biggerButtonSize}
           disabled={isProcessing}
           label="Contact Sales"
+          onClick={withTracking(
+            TRACKING_AREAS.PRICING,
+            "plan_enterprise_contact"
+          )}
         />
       </PriceTable.ActionContainer>
       {ENTERPRISE_PLAN_ITEMS.map((item, index) => (

--- a/front/components/spaces/AddConnectionMenu.tsx
+++ b/front/components/spaces/AddConnectionMenu.tsx
@@ -29,6 +29,7 @@ import {
 } from "@app/lib/connector_providers";
 import { useSystemSpace } from "@app/lib/swr/spaces";
 import { useFeatureFlags } from "@app/lib/swr/workspaces";
+import { TRACKING_AREAS, withTracking } from "@app/lib/tracking";
 import type { PostDataSourceRequestBody } from "@app/pages/api/w/[wId]/spaces/[spaceId]/data_sources";
 import type {
   ConnectorProvider,
@@ -483,6 +484,10 @@ export const AddConnectionMenu = ({
               variant="primary"
               icon={CloudArrowLeftRightIcon}
               size="sm"
+              onClick={withTracking(
+                TRACKING_AREAS.DATA_SOURCES,
+                "add_connection_menu"
+              )}
             />
           </DropdownMenuTrigger>
           <DropdownMenuContent>
@@ -494,9 +499,12 @@ export const AddConnectionMenu = ({
                   provider: i.connectorProvider,
                   isDark,
                 })}
-                onClick={() => {
-                  handleConnectionClick(i);
-                }}
+                onClick={withTracking(
+                  TRACKING_AREAS.DATA_SOURCES,
+                  "provider_select",
+                  () => handleConnectionClick(i),
+                  { provider: i.connectorProvider }
+                )}
               />
             ))}
           </DropdownMenuContent>

--- a/front/lib/swr/workspaces.ts
+++ b/front/lib/swr/workspaces.ts
@@ -80,14 +80,14 @@ export function useWorkspaceActiveSubscription({
   owner,
   disabled,
 }: {
-  owner: LightWorkspaceType;
+  owner: LightWorkspaceType | undefined;
   disabled?: boolean;
 }) {
   const workspaceSubscriptionsFetcher: Fetcher<GetSubscriptionsResponseBody> =
     fetcher;
 
   const { data, error } = useSWRWithDefaults(
-    `/api/w/${owner.sId}/subscriptions`,
+    owner ? `/api/w/${owner.sId}/subscriptions` : null,
     workspaceSubscriptionsFetcher,
     {
       disabled,

--- a/front/lib/tracking.ts
+++ b/front/lib/tracking.ts
@@ -1,0 +1,121 @@
+/**
+ * Tracking conventions:
+ * - Event name: {area}:{object}_{action}
+ * - Always include area from TRACKING_AREAS
+ * - Use snake_case for object names
+ * - Common actions: click, submit, create, delete, connect
+ *
+ * @example
+ * // For simple click tracking:
+ * <Button onClick={withTracking(TRACKING_AREAS.BUILDER, "create_agent")} />
+ *
+ * @example
+ * // For tracking with extra params or non-click actions:
+ * trackEvent({
+ *   area: TRACKING_AREAS.BUILDER,
+ *   object: "create_from_template",
+ *   action: "submit",
+ *   extra: { template_id: "123" }
+ * })
+ */
+
+import posthog from "posthog-js";
+
+/**
+ * Tracking areas - logical sections of the application
+ */
+export const TRACKING_AREAS = {
+  // Public
+  HOME: "home",
+  PRICING: "pricing",
+  AUTH: "auth",
+
+  // Product
+  ASSISTANT: "assistant",
+  CONVERSATION: "conversation",
+  WORKSPACE: "workspace",
+  DATA_SOURCES: "datasources",
+  SETTINGS: "settings",
+
+  // Features
+  BUILDER: "builder",
+  SPACES: "spaces",
+  LABS: "labs",
+} as const;
+
+export type TrackingArea = (typeof TRACKING_AREAS)[keyof typeof TRACKING_AREAS];
+
+/**
+ * Common actions
+ */
+export const TRACKING_ACTIONS = {
+  CLICK: "click",
+  SUBMIT: "submit",
+  CREATE: "create",
+  DELETE: "delete",
+  CONNECT: "connect",
+  SELECT: "select",
+  OPEN: "open",
+  CLOSE: "close",
+} as const;
+
+export type TrackingAction =
+  (typeof TRACKING_ACTIONS)[keyof typeof TRACKING_ACTIONS];
+
+interface TrackEventParams {
+  area: TrackingArea | string;
+  object: string;
+  action?: TrackingAction | string;
+  extra?: Record<string, string>;
+}
+
+export function trackEvent({
+  area,
+  object,
+  action = TRACKING_ACTIONS.CLICK,
+  extra,
+}: TrackEventParams): void {
+  if (typeof window === "undefined" || !posthog.__loaded) {
+    return;
+  }
+
+  const eventName = `${area}:${object}_${action}`;
+  const properties: Record<string, string> = {
+    area,
+    object,
+    action,
+    ...extra,
+  };
+
+  posthog.capture(eventName, properties);
+}
+
+/**
+ * Wrapper for onClick handlers that includes tracking.
+ * For click tracking with optional extra params.
+ *
+ * @example
+ * // Without handler (just tracking)
+ * <Button onClick={withTracking(TRACKING_AREAS.BUILDER, "create_agent")} />
+ *
+ * @example
+ * // With handler
+ * <Button onClick={withTracking(TRACKING_AREAS.BUILDER, "create_agent", handleCreate)} />
+ *
+ * @example
+ * // With handler and extra params
+ * <Button onClick={withTracking(TRACKING_AREAS.DATA, "select", handleClick, { id: "123" })} />
+ */
+export function withTracking<T extends Element = HTMLElement>(
+  area: TrackingArea | string,
+  object: string,
+  handler?: (e: React.MouseEvent<T>) => void | Promise<void>,
+  extra?: Record<string, string>
+) {
+  return (e: React.MouseEvent<T>) => {
+    trackEvent({ area, object, action: TRACKING_ACTIONS.CLICK, extra });
+    if (handler) {
+      void handler(e);
+    }
+  };
+}

--- a/front/pages/home/pricing.tsx
+++ b/front/pages/home/pricing.tsx
@@ -11,6 +11,7 @@ import {
   shapeNames,
 } from "@app/components/home/Particles";
 import { PricePlans } from "@app/components/plans/PlansTables";
+import { TRACKING_AREAS, withTracking } from "@app/lib/tracking";
 
 export async function getStaticProps() {
   return {
@@ -38,9 +39,13 @@ export default function Pricing() {
               size="md"
               label="Start with Pro, 15 Days free"
               icon={RocketIcon}
-              onClick={() => {
-                window.location.href = "/api/workos/login?screenHint=sign-up";
-              }}
+              onClick={withTracking(
+                TRACKING_AREAS.PRICING,
+                "hero_start_trial",
+                () => {
+                  window.location.href = "/api/workos/login?screenHint=sign-up";
+                }
+              )}
             />
           </>
         }

--- a/front/pages/w/[wId]/subscribe.tsx
+++ b/front/pages/w/[wId]/subscribe.tsx
@@ -13,6 +13,7 @@ import { withDefaultUserAuthPaywallWhitelisted } from "@app/lib/iam/session";
 import { isOldFreePlan } from "@app/lib/plans/plan_codes";
 import { useUser } from "@app/lib/swr/user";
 import { useWorkspaceSubscriptions } from "@app/lib/swr/workspaces";
+import { TRACKING_AREAS, withTracking } from "@app/lib/tracking";
 import type { BillingPeriod, WorkspaceType } from "@app/types";
 
 export const getServerSideProps = withDefaultUserAuthPaywallWhitelisted<{
@@ -192,9 +193,17 @@ export default function Subscribe({
                   }
                   icon={CreditCardIcon}
                   size="sm"
-                  onClick={() => {
-                    void handleSubscribePlan(billingPeriod);
-                  }}
+                  onClick={withTracking(
+                    TRACKING_AREAS.AUTH,
+                    "subscription_start",
+                    () => {
+                      void handleSubscribePlan(billingPeriod);
+                    },
+                    {
+                      billing_period: billingPeriod,
+                      is_trial: noPreviousSubscription ? "true" : "false",
+                    }
+                  )}
                 />
               </Page.Vertical>
               <Page.Horizontal sizing="grow">

--- a/front/pages/w/[wId]/subscription/index.tsx
+++ b/front/pages/w/[wId]/subscription/index.tsx
@@ -31,6 +31,7 @@ import { withDefaultUserAuthRequirements } from "@app/lib/iam/session";
 import { isUpgraded } from "@app/lib/plans/plan_codes";
 import { getStripeSubscription } from "@app/lib/plans/stripe";
 import { countActiveSeatsInWorkspace } from "@app/lib/plans/usage/seats";
+import { TRACKING_AREAS, withTracking } from "@app/lib/tracking";
 import type { PatchSubscriptionRequestBody } from "@app/pages/api/w/[wId]/subscriptions";
 import type {
   SubscriptionPerSeatPricing,
@@ -326,7 +327,13 @@ export default function Subscription({
                     subscription.stripeSubscriptionId && (
                       <Button
                         label="Manage my subscription"
-                        onClick={handleGoToStripePortal}
+                        onClick={withTracking(
+                          TRACKING_AREAS.AUTH,
+                          "subscription_manage",
+                          () => {
+                            void handleGoToStripePortal();
+                          }
+                        )}
                         variant="outline"
                       />
                     )}
@@ -338,13 +345,25 @@ export default function Subscription({
             <Page.Vertical>
               <Page.Horizontal gap="sm">
                 <Button
-                  onClick={() => setShowSkipFreeTrialDialog(true)}
+                  onClick={withTracking(
+                    TRACKING_AREAS.AUTH,
+                    "subscription_skip_trial",
+                    () => {
+                      setShowSkipFreeTrialDialog(true);
+                    }
+                  )}
                   label="End trial & get full access"
                 />
                 <Button
                   label="Cancel subscription"
                   variant="ghost"
-                  onClick={() => setShowCancelFreeTrialDialog(true)}
+                  onClick={withTracking(
+                    TRACKING_AREAS.AUTH,
+                    "subscription_cancel_trial",
+                    () => {
+                      setShowCancelFreeTrialDialog(true);
+                    }
+                  )}
                 />
               </Page.Horizontal>
             </Page.Vertical>
@@ -393,7 +412,13 @@ export default function Subscription({
                   icon={CardIcon}
                   label="Your billing dashboard on Stripe"
                   variant="ghost"
-                  onClick={handleGoToStripePortal}
+                  onClick={withTracking(
+                    TRACKING_AREAS.AUTH,
+                    "subscription_stripe_portal",
+                    () => {
+                      void handleGoToStripePortal();
+                    }
+                  )}
                 />
               </div>
             </Page.Vertical>

--- a/front/pages/w/[wId]/welcome.tsx
+++ b/front/pages/w/[wId]/welcome.tsx
@@ -18,6 +18,7 @@ import config from "@app/lib/api/config";
 import { useSubmitFunction } from "@app/lib/client/utils";
 import { withDefaultUserAuthPaywallWhitelisted } from "@app/lib/iam/session";
 import { usePatchUser } from "@app/lib/swr/user";
+import { TRACKING_AREAS, withTracking } from "@app/lib/tracking";
 import { getAgentRoute } from "@app/lib/utils/router";
 import type { UserType, WorkspaceType } from "@app/types";
 import type { JobType } from "@app/types/job_type";
@@ -114,7 +115,13 @@ export default function Welcome({
           label={"Next"}
           disabled={!isFormValid || isSubmitting}
           size="sm"
-          onClick={submit}
+          onClick={withTracking(
+            TRACKING_AREAS.AUTH,
+            "onboarding_complete",
+            () => {
+              void submit();
+            }
+          )}
         />
       }
     >
@@ -198,7 +205,13 @@ export default function Welcome({
             label={"Next"}
             disabled={!isFormValid || isSubmitting}
             size="md"
-            onClick={submit}
+            onClick={withTracking(
+              TRACKING_AREAS.AUTH,
+              "onboarding_complete",
+              () => {
+                void submit();
+              }
+            )}
           />
         </div>
       </div>

--- a/sparkle/src/components/AssistantCard.tsx
+++ b/sparkle/src/components/AssistantCard.tsx
@@ -19,7 +19,6 @@ interface BaseAssistantCardProps {
   onClick?: () => void;
   onContextMenu?: (event: React.MouseEvent) => void;
   variant?: CardVariantType;
-  dataAnalytics?: string;
 }
 
 type AssistantCardMore = Omit<MiniButtonProps, "icon" | "size">;
@@ -51,7 +50,6 @@ export const AssistantCard = React.forwardRef<
       subtitle,
       action,
       variant = "primary",
-      dataAnalytics,
     },
     ref
   ) => {
@@ -64,7 +62,6 @@ export const AssistantCard = React.forwardRef<
         onContextMenu={onContextMenu}
         action={action}
         variant={variant}
-        dataAnalytics={dataAnalytics}
       >
         <div className="s-flex s-gap-3">
           <Avatar visual={pictureUrl} size="md" />
@@ -105,41 +102,35 @@ interface LargeAssistantCardProps extends BaseAssistantCardProps {}
 export const LargeAssistantCard = React.forwardRef<
   HTMLDivElement,
   LargeAssistantCardProps
->(
-  (
-    { className, onClick, title, description, pictureUrl, dataAnalytics },
-    ref
-  ) => {
-    return (
-      <Card
-        ref={ref}
-        size="lg"
-        className={className}
-        onClick={onClick}
-        variant="tertiary"
-        dataAnalytics={dataAnalytics}
-      >
-        <div className="s-flex s-gap-3">
-          <Avatar visual={pictureUrl} size="lg" />
-          <div
+>(({ className, onClick, title, description, pictureUrl }, ref) => {
+  return (
+    <Card
+      ref={ref}
+      size="lg"
+      className={className}
+      onClick={onClick}
+      variant="tertiary"
+    >
+      <div className="s-flex s-gap-3">
+        <Avatar visual={pictureUrl} size="lg" />
+        <div
+          className={cn(
+            "s-flex s-flex-col s-gap-2 s-text-base",
+            "s-text-foreground dark:s-text-foreground-night"
+          )}
+        >
+          <h3 className="s-heading-base">{title}</h3>
+          <p
             className={cn(
-              "s-flex s-flex-col s-gap-2 s-text-base",
-              "s-text-foreground dark:s-text-foreground-night"
+              "s-line-clamp-5 s-overflow-hidden s-text-ellipsis",
+              "s-text-muted-foreground dark:s-text-muted-foreground-night"
             )}
           >
-            <h3 className="s-heading-base">{title}</h3>
-            <p
-              className={cn(
-                "s-line-clamp-5 s-overflow-hidden s-text-ellipsis",
-                "s-text-muted-foreground dark:s-text-muted-foreground-night"
-              )}
-            >
-              {description}
-            </p>
-          </div>
+            {description}
+          </p>
         </div>
-      </Card>
-    );
-  }
-);
+      </div>
+    </Card>
+  );
+});
 LargeAssistantCard.displayName = "LargeAssistantCard";

--- a/sparkle/src/components/Button.tsx
+++ b/sparkle/src/components/Button.tsx
@@ -225,7 +225,6 @@ type CommonButtonProps = Omit<MetaButtonProps, "children"> &
     isCounter?: boolean;
     counterValue?: string;
     isRounded?: boolean;
-    dataAnalytics?: string;
   };
 
 export type MiniButtonProps = CommonButtonProps & {
@@ -264,7 +263,6 @@ const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
       replace,
       shallow,
       "aria-label": ariaLabel,
-      dataAnalytics,
       ...props
     },
     ref
@@ -374,7 +372,6 @@ const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
           className
         )}
         aria-label={ariaLabel || tooltip || label}
-        data-analytics={dataAnalytics}
         style={
           {
             "--pulse-color": "#93C5FD",

--- a/sparkle/src/components/Card.tsx
+++ b/sparkle/src/components/Card.tsx
@@ -78,7 +78,6 @@ interface CommonProps {
   variant?: CardVariantType;
   size?: CardSizeType;
   className?: string;
-  dataAnalytics?: string;
 }
 
 interface CardLinkProps extends CommonProps, LinkWrapperProps {
@@ -110,7 +109,6 @@ const InnerCard = React.forwardRef<HTMLDivElement, InnerCardProps>(
       rel = "",
       replace,
       shallow,
-      dataAnalytics,
       ...props
     },
     ref
@@ -137,7 +135,6 @@ const InnerCard = React.forwardRef<HTMLDivElement, InnerCardProps>(
           shallow={shallow}
           target={target}
           rel={rel}
-          data-analytics={dataAnalytics}
         >
           {children}
         </Link>
@@ -149,7 +146,6 @@ const InnerCard = React.forwardRef<HTMLDivElement, InnerCardProps>(
         ref={ref}
         className={cardButtonClassNames}
         onClick={onClick}
-        data-analytics={dataAnalytics}
         {...props}
       >
         {children}

--- a/sparkle/src/components/Dialog.tsx
+++ b/sparkle/src/components/Dialog.tsx
@@ -80,7 +80,6 @@ interface DialogContentProps
   isAlertDialog?: boolean;
   preventAutoFocusOnClose?: boolean;
   mountPortalContainer?: HTMLElement;
-  dataAnalytics?: string;
 }
 
 const DialogContent = React.forwardRef<
@@ -98,7 +97,6 @@ const DialogContent = React.forwardRef<
       preventAutoFocusOnClose = true,
       onCloseAutoFocus,
       mountPortalContainer,
-      dataAnalytics,
       ...props
     },
     ref
@@ -126,7 +124,6 @@ const DialogContent = React.forwardRef<
                 : props.onInteractOutside
             }
             onCloseAutoFocus={handleCloseAutoFocus}
-            data-analytics={dataAnalytics}
             {...props}
           >
             {children}

--- a/sparkle/src/components/EmptyCTA.tsx
+++ b/sparkle/src/components/EmptyCTA.tsx
@@ -42,24 +42,14 @@ EmptyCTA.displayName = "EmptyCTA";
 interface EmptyCTAButtonProps extends RegularButtonProps {
   icon: React.ComponentType;
   label: string;
-  dataAnalytics?: string;
 }
 
 const EmptyCTAButton: React.FC<EmptyCTAButtonProps> = ({
   icon,
   label,
   variant = "highlight",
-  dataAnalytics,
   ...props
-}) => (
-  <Button
-    icon={icon}
-    label={label}
-    variant={variant}
-    dataAnalytics={dataAnalytics}
-    {...props}
-  />
-);
+}) => <Button icon={icon} label={label} variant={variant} {...props} />;
 
 EmptyCTAButton.displayName = "EmptyCTAButton";
 

--- a/sparkle/src/components/LinkWrapper.tsx
+++ b/sparkle/src/components/LinkWrapper.tsx
@@ -10,36 +10,29 @@ export interface LinkWrapperProps {
   shallow?: boolean;
   target?: string;
   prefetch?: boolean;
-  dataAnalytics?: string;
 }
 
 export const LinkWrapper = React.forwardRef<
   HTMLAnchorElement,
   LinkWrapperProps
->(
-  (
-    { children, href, rel, replace, shallow, target, prefetch, dataAnalytics },
-    ref
-  ) => {
-    const { components } = React.useContext(SparkleContext);
+>(({ children, href, rel, replace, shallow, target, prefetch }, ref) => {
+  const { components } = React.useContext(SparkleContext);
 
-    if (href) {
-      return (
-        <components.link
-          ref={ref}
-          href={href}
-          target={target}
-          rel={rel}
-          replace={replace}
-          shallow={shallow}
-          prefetch={prefetch}
-          data-analytics={dataAnalytics}
-        >
-          {children}
-        </components.link>
-      );
-    }
-
-    return children;
+  if (href) {
+    return (
+      <components.link
+        ref={ref}
+        href={href}
+        target={target}
+        rel={rel}
+        replace={replace}
+        shallow={shallow}
+        prefetch={prefetch}
+      >
+        {children}
+      </components.link>
+    );
   }
-);
+
+  return children;
+});

--- a/sparkle/src/components/MultiPageDialog.tsx
+++ b/sparkle/src/components/MultiPageDialog.tsx
@@ -99,7 +99,6 @@ interface MultiPageDialogProps {
   footerContent?: React.ReactNode;
   addFooterSeparator?: boolean;
   hideCloseButton?: boolean;
-  dataAnalytics?: string;
 }
 
 interface MultiPageDialogContentProps extends MultiPageDialogProps {
@@ -130,7 +129,6 @@ const MultiPageDialogContent = React.forwardRef<
       rightButton,
       footerContent,
       hideCloseButton,
-      dataAnalytics,
       ...props
     },
     ref
@@ -190,7 +188,6 @@ const MultiPageDialogContent = React.forwardRef<
         isAlertDialog={isAlertDialog}
         preventAutoFocusOnClose={preventAutoFocusOnClose}
         className={className}
-        dataAnalytics={dataAnalytics}
         {...props}
       >
         <div className={cn(multiPageDialogLayoutVariants())}>

--- a/sparkle/src/components/NavigationList.tsx
+++ b/sparkle/src/components/NavigationList.tsx
@@ -71,7 +71,6 @@ interface NavigationListItemProps
   icon?: React.ComponentType;
   moreMenu?: React.ReactNode;
   status?: "idle" | "unread" | "blocked";
-  dataAnalytics?: string;
 }
 
 const NavigationListItem = React.forwardRef<
@@ -91,7 +90,6 @@ const NavigationListItem = React.forwardRef<
       shallow,
       moreMenu,
       status = "idle",
-      dataAnalytics,
       ...props
     },
     ref
@@ -131,7 +129,6 @@ const NavigationListItem = React.forwardRef<
           rel={rel}
           replace={replace}
           shallow={shallow}
-          dataAnalytics={dataAnalytics}
         >
           <div
             className={cn(

--- a/sparkle/src/components/PriceTable.tsx
+++ b/sparkle/src/components/PriceTable.tsx
@@ -14,7 +14,6 @@ interface PriceTableProps {
   className?: string;
   children: ReactNode;
   magnified?: boolean;
-  dataAnalytics?: string;
 }
 
 const colorTable = {
@@ -46,7 +45,6 @@ export function PriceTable({
   priceLabel = "",
   className = "",
   magnified = true,
-  dataAnalytics,
   children, // Use children instead of tableItems
 }: PriceTableProps) {
   // Pass size prop to all PriceTable.Item children
@@ -75,7 +73,6 @@ export function PriceTable({
         colorTable[color],
         className
       )}
-      data-analytics={dataAnalytics}
     >
       <div
         className={classNames(

--- a/sparkle/src/components/Sheet.tsx
+++ b/sparkle/src/components/Sheet.tsx
@@ -89,7 +89,6 @@ interface SheetContentProps
   side?: SheetSideType;
   preventAutoFocusOnClose?: boolean;
   preventAutoFocusOnOpen?: boolean;
-  dataAnalytics?: string;
 }
 
 const SheetContent = React.forwardRef<
@@ -107,7 +106,6 @@ const SheetContent = React.forwardRef<
       preventAutoFocusOnOpen = true,
       onCloseAutoFocus,
       onOpenAutoFocus,
-      dataAnalytics,
       ...props
     },
     ref
@@ -162,7 +160,6 @@ const SheetContent = React.forwardRef<
             onCloseAutoFocus={handleCloseAutoFocus}
             onOpenAutoFocus={handleOpenAutoFocus}
             onKeyDownCapture={onKeyDownCapture}
-            data-analytics={dataAnalytics}
             {...props}
           >
             {children}

--- a/sparkle/src/components/Tabs.tsx
+++ b/sparkle/src/components/Tabs.tsx
@@ -52,7 +52,6 @@ const TabsTrigger = React.forwardRef<
       >
     > & {
       isLoading?: boolean;
-      dataAnalytics?: string;
     } & Omit<LinkWrapperProps, "children" | "className">
 >(
   (
@@ -70,7 +69,6 @@ const TabsTrigger = React.forwardRef<
       variant = "ghost",
       isCounter = false,
       counterValue,
-      dataAnalytics,
       ...props
     },
     ref
@@ -97,7 +95,6 @@ const TabsTrigger = React.forwardRef<
           shallow={shallow}
           isCounter={isCounter}
           counterValue={counterValue}
-          dataAnalytics={dataAnalytics}
           className={cn(
             "s-relative",
             "after:s-absolute after:s-bottom-[-9px] after:s-left-1/2 after:s-h-[2px] after:s-w-full after:s--translate-x-1/2",


### PR DESCRIPTION





## Description

This PR  re-introduces the comprehensive user journey tracking functionality from https://github.com/dust-tt/dust/pull/16497. 

It addresses the issue that caused the original revert by adding an `!isAdmin` guard on `useWorkspaceActiveSubscription()` to prevent unnecessary API fetches for non-admin users. Additionally, it removes plan properties from PostHog user identification to simplify the tracking implementation while maintaining workspace-level plan properties through group identification.

## Risk

Low risk. The main change is adding a safety guard to prevent subscription fetches for non-admin users, which should reduce unnecessary API calls and potential errors.

## Deploy Plan

No specific deploy actions required - the changes are backward compatible and the PostHog tracking will resume functioning as intended.
