### PR TITLE
[cc] improve the preview panel UI

### DIFF
--- a/front/components/assistant/conversation/content_creation/ClientExecutableRenderer.tsx
+++ b/front/components/assistant/conversation/content_creation/ClientExecutableRenderer.tsx
@@ -357,6 +357,18 @@ function PreviewActionButtons({
 }: PreviewActionButtonsProps) {
   return (
     <div className="fixed bottom-4 right-3 flex flex-col gap-1 rounded-lg bg-white p-1 shadow-md dark:bg-gray-900">
+      <Tooltip
+        label={`${isFullScreen ? "Exit" : "Go to"} full screen mode`}
+        side="left"
+        trigger={
+          <Button
+            icon={isFullScreen ? FullscreenExitIcon : FullscreenIcon}
+            variant="ghost"
+            size="xs"
+            onClick={isFullScreen ? exitFullScreen : enterFullScreen}
+          />
+        }
+      />
       {lastEditedByAgentConfigurationId && (
         <Tooltip
           label="Revert the last change"
@@ -371,18 +383,6 @@ function PreviewActionButtons({
           }
         />
       )}
-      <Tooltip
-        label={`${isFullScreen ? "Exit" : "Go to"} full screen mode`}
-        side="left"
-        trigger={
-          <Button
-            icon={isFullScreen ? FullscreenExitIcon : FullscreenIcon}
-            variant="ghost"
-            size="xs"
-            onClick={isFullScreen ? exitFullScreen : enterFullScreen}
-          />
-        }
-      />
       <Tooltip
         label="Reload the file"
         side="left"

--- a/front/components/assistant/conversation/content_creation/ClientExecutableRenderer.tsx
+++ b/front/components/assistant/conversation/content_creation/ClientExecutableRenderer.tsx
@@ -372,7 +372,7 @@ function PreviewActionButtons({
         />
       )}
       <Tooltip
-        label={`${isFullScreen ? "Exit" : "Go to"} full screen model`}
+        label={`${isFullScreen ? "Exit" : "Go to"} full screen mode`}
         side="left"
         trigger={
           <Button

--- a/front/components/assistant/conversation/content_creation/ContentCreationHeader.tsx
+++ b/front/components/assistant/conversation/content_creation/ContentCreationHeader.tsx
@@ -14,20 +14,17 @@ export function ContentCreationHeader({
 }: ContentCreationHeaderProps) {
   return (
     <AppLayoutTitle className="bg-gray-50 @container dark:bg-gray-900">
-      <div className="flex h-full min-w-0 max-w-full items-center justify-end">
-        {/* Actions - always visible and right-aligned. */}
-        <div className="flex shrink-0 items-center gap-2">
-          {children}
-          {onClose && (
-            <Button
-              variant="ghost"
-              size="xs"
-              onClick={onClose}
-              icon={XMarkIcon}
-              className="text-element-600 hover:text-element-900"
-            />
-          )}
-        </div>
+      <div className="flex h-full items-center">
+        {children}
+        {onClose && (
+          <Button
+            variant="ghost"
+            size="xs"
+            onClick={onClose}
+            icon={XMarkIcon}
+            className="text-element-600 hover:text-element-900 ml-auto"
+          />
+        )}
       </div>
     </AppLayoutTitle>
   );

--- a/front/components/assistant/conversation/content_creation/ShareContentCreationFilePopover.tsx
+++ b/front/components/assistant/conversation/content_creation/ShareContentCreationFilePopover.tsx
@@ -174,12 +174,7 @@ export function ShareContentCreationFilePopover({
   return (
     <PopoverRoot open={isOpen} onOpenChange={setIsOpen} modal={true}>
       <PopoverTrigger asChild>
-        <Button
-          icon={LinkIcon}
-          size="xs"
-          variant="ghost"
-          tooltip="Share public link"
-        />
+        <Button size="xs" variant="ghost" label="Share" />
       </PopoverTrigger>
       <PopoverContent className="flex w-96 flex-col" align="end">
         <div className="flex flex-col gap-4">

--- a/front/components/assistant/conversation/content_creation/ShareContentCreationFilePopover.tsx
+++ b/front/components/assistant/conversation/content_creation/ShareContentCreationFilePopover.tsx
@@ -13,7 +13,6 @@ import {
   InformationCircleIcon,
   Input,
   Label,
-  LinkIcon,
   LockIcon,
   PopoverContent,
   PopoverRoot,


### PR DESCRIPTION
## Description
This PR is to improve the preview panel since we have way too many icons there.

light:
<img width="2376" height="1716" alt="CleanShot 2025-10-06 at 21 29 24@2x" src="https://github.com/user-attachments/assets/9a7925ac-4f05-4021-b9ed-c9748f1acc9c" />

dark:
<img width="2374" height="1710" alt="CleanShot 2025-10-06 at 21 36 59@2x" src="https://github.com/user-attachments/assets/dd829eab-9f1f-4ad9-b032-8bce82013e5b" />


<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
