### PR TITLE
[Temporal] Fix heartbeat cancellation handling in agent workflows

### DIFF
--- a/front/temporal/agent_loop/worker.ts
+++ b/front/temporal/agent_loop/worker.ts
@@ -43,6 +43,9 @@ export async function runAgentLoopWorker() {
     connection,
     namespace,
     shutdownGraceTime: SHUTDOWN_GRACE_TIME,
+    // This also bounds the time until an activity may receive a cancellation signal.
+    // See https://docs.temporal.io/encyclopedia/detecting-activity-failures#throttling
+    maxHeartbeatThrottleInterval: "20 seconds",
     interceptors: {
       activityInbound: [
         (ctx: Context) => {

--- a/front/temporal/agent_loop/workflows.ts
+++ b/front/temporal/agent_loop/workflows.ts
@@ -221,8 +221,8 @@ export async function agentLoopWorkflow({
     // Notify error in a non-cancellable scope to ensure it runs even if workflow is cancelled
     await CancellationScope.nonCancellable(async () => {
       if (cancelRequested) {
-        // Run finalization tasks on cancellation (dummy for now).
         await finalizeCancellationActivity(authType, agentLoopArgs);
+        return;
       } else {
         await notifyWorkflowError(authType, {
           conversationId: agentLoopArgs.conversationId,
@@ -231,14 +231,8 @@ export async function agentLoopWorkflow({
           error: workflowError,
         });
       }
+      throw err;
     });
-
-    // If cancellation was explicitly requested via signal, finish gracefully without rethrowing.
-    if (cancelRequested) {
-      return;
-    }
-
-    throw err;
   }
 }
 


### PR DESCRIPTION
## Description

Fixes https://github.com/dust-tt/tasks/issues/4442

Context: https://dust4ai.slack.com/archives/C09GELMTTRT/p1758715482444979?thread_ts=1758715482.444979&cid=C09GELMTTRT

The heartbeat alone doesn't guarantee activities receive cancellation signals. Both `heartbeat()` and a short `sleep()` are needed for proper cancellation detection. The delay is governed by heartbeat throttling, configured via `maxHeartbeatThrottleInterval` (set to 20s).

Added a final check for cancelled agent messages to handle edge cases where cancellation occurs but the signal hasn't been received yet. This is primarily to avoid confusion for users cancelling during a generation but after 5 seconds seeing the message appear completed.

## Risks

Blast radius: Agent execution cancellation flow
Risk: low

## Deploy Plan

- deploy front