### PR TITLE
Cleanup tracking init + add a few events

### DIFF
--- a/front/components/app/PostHogTracker.tsx
+++ b/front/components/app/PostHogTracker.tsx
@@ -1,7 +1,7 @@
 import { useRouter } from "next/router";
 import posthog from "posthog-js";
 import { PostHogProvider } from "posthog-js/react";
-import { useEffect, useMemo, useRef, useState } from "react";
+import { useEffect, useMemo, useRef } from "react";
 import { useCookies } from "react-cookie";
 
 import { DUST_COOKIES_ACCEPTED, hasCookiesAccepted } from "@app/lib/cookies";

--- a/front/components/home/LandingLayout.tsx
+++ b/front/components/home/LandingLayout.tsx
@@ -134,9 +134,13 @@ export default function LandingLayout({
               size="sm"
               label="Sign in"
               icon={LoginIcon}
-              onClick={withTracking(TRACKING_AREAS.NAVIGATION, "sign_in", () => {
-                window.location.href = `/api/workos/login?returnTo=${encodeURIComponent(postLoginReturnToUrl)}`;
-              })}
+              onClick={withTracking(
+                TRACKING_AREAS.NAVIGATION,
+                "sign_in",
+                () => {
+                  window.location.href = `/api/workos/login?returnTo=${encodeURIComponent(postLoginReturnToUrl)}`;
+                }
+              )}
             />
           </div>
         </div>

--- a/front/components/home/LandingLayout.tsx
+++ b/front/components/home/LandingLayout.tsx
@@ -27,6 +27,7 @@ import {
   shouldCheckGeolocation,
 } from "@app/lib/cookies";
 import { useGeolocation } from "@app/lib/swr/geo";
+import { TRACKING_AREAS, withTracking } from "@app/lib/tracking";
 import { classNames, getFaviconPath } from "@app/lib/utils";
 
 export interface LandingLayoutProps {
@@ -126,15 +127,16 @@ export default function LandingLayout({
               variant="outline"
               size="sm"
               label="Request a demo"
+              onClick={withTracking(TRACKING_AREAS.NAVIGATION, "request_demo")}
             />
             <Button
               variant="highlight"
               size="sm"
               label="Sign in"
               icon={LoginIcon}
-              onClick={() => {
+              onClick={withTracking(TRACKING_AREAS.NAVIGATION, "sign_in", () => {
                 window.location.href = `/api/workos/login?returnTo=${encodeURIComponent(postLoginReturnToUrl)}`;
-              }}
+              })}
             />
           </div>
         </div>

--- a/front/lib/tracking.ts
+++ b/front/lib/tracking.ts
@@ -29,6 +29,7 @@ export const TRACKING_AREAS = {
   HOME: "home",
   PRICING: "pricing",
   AUTH: "auth",
+  NAVIGATION: "navigation",
 
   // Product
   ASSISTANT: "assistant",

--- a/front/pages/home/pricing.tsx
+++ b/front/pages/home/pricing.tsx
@@ -54,9 +54,13 @@ export default function Pricing() {
         <div className="dark col-span-12 flex flex-row justify-center md:col-span-10 md:col-start-2 lg:px-2 2xl:px-24">
           <PricePlans
             display="landing"
-            onClickProPlan={() => {
-              window.location.href = "/api/workos/login?screenHint=sign-up";
-            }}
+            onClickProPlan={withTracking(
+              TRACKING_AREAS.PRICING,
+              "plan_card_start_trial",
+              () => {
+                window.location.href = "/api/workos/login?screenHint=sign-up";
+              }
+            )}
           />
         </div>
       </Grid>

--- a/front/pages/home/pricing.tsx
+++ b/front/pages/home/pricing.tsx
@@ -11,7 +11,12 @@ import {
   shapeNames,
 } from "@app/components/home/Particles";
 import { PricePlans } from "@app/components/plans/PlansTables";
-import { TRACKING_AREAS, withTracking } from "@app/lib/tracking";
+import {
+  trackEvent,
+  TRACKING_ACTIONS,
+  TRACKING_AREAS,
+  withTracking,
+} from "@app/lib/tracking";
 
 export async function getStaticProps() {
   return {
@@ -54,13 +59,14 @@ export default function Pricing() {
         <div className="dark col-span-12 flex flex-row justify-center md:col-span-10 md:col-start-2 lg:px-2 2xl:px-24">
           <PricePlans
             display="landing"
-            onClickProPlan={withTracking(
-              TRACKING_AREAS.PRICING,
-              "plan_card_start_trial",
-              () => {
-                window.location.href = "/api/workos/login?screenHint=sign-up";
-              }
-            )}
+            onClickProPlan={() => {
+              trackEvent({
+                area: TRACKING_AREAS.PRICING,
+                object: "plan_card_start_trial",
+                action: TRACKING_ACTIONS.CLICK,
+              });
+              window.location.href = "/api/workos/login?screenHint=sign-up";
+            }}
           />
         </div>
       </Grid>

--- a/front/pages/w/[wId]/welcome.tsx
+++ b/front/pages/w/[wId]/welcome.tsx
@@ -18,7 +18,12 @@ import config from "@app/lib/api/config";
 import { useSubmitFunction } from "@app/lib/client/utils";
 import { withDefaultUserAuthPaywallWhitelisted } from "@app/lib/iam/session";
 import { usePatchUser } from "@app/lib/swr/user";
-import { TRACKING_AREAS, withTracking } from "@app/lib/tracking";
+import {
+  trackEvent,
+  TRACKING_ACTIONS,
+  TRACKING_AREAS,
+  withTracking,
+} from "@app/lib/tracking";
 import { getAgentRoute } from "@app/lib/utils/router";
 import type { UserType, WorkspaceType } from "@app/types";
 import type { JobType } from "@app/types/job_type";
@@ -73,6 +78,15 @@ export default function Welcome({
   const [isFormValid, setIsFormValid] = useState<boolean>(false);
 
   const jobTypes = JOB_TYPE_OPTIONS;
+
+  // Track onboarding page view
+  useEffect(() => {
+    trackEvent({
+      area: TRACKING_AREAS.AUTH,
+      object: "onboarding_start",
+      action: "view",
+    });
+  }, []);
 
   const { patchUser } = usePatchUser();
 

--- a/front/pages/w/[wId]/welcome.tsx
+++ b/front/pages/w/[wId]/welcome.tsx
@@ -18,12 +18,7 @@ import config from "@app/lib/api/config";
 import { useSubmitFunction } from "@app/lib/client/utils";
 import { withDefaultUserAuthPaywallWhitelisted } from "@app/lib/iam/session";
 import { usePatchUser } from "@app/lib/swr/user";
-import {
-  trackEvent,
-  TRACKING_ACTIONS,
-  TRACKING_AREAS,
-  withTracking,
-} from "@app/lib/tracking";
+import { TRACKING_AREAS, withTracking } from "@app/lib/tracking";
 import { getAgentRoute } from "@app/lib/utils/router";
 import type { UserType, WorkspaceType } from "@app/types";
 import type { JobType } from "@app/types/job_type";
@@ -78,15 +73,6 @@ export default function Welcome({
   const [isFormValid, setIsFormValid] = useState<boolean>(false);
 
   const jobTypes = JOB_TYPE_OPTIONS;
-
-  // Track onboarding page view
-  useEffect(() => {
-    trackEvent({
-      area: TRACKING_AREAS.AUTH,
-      object: "onboarding_start",
-      action: "view",
-    });
-  }, []);
 
   const { patchUser } = usePatchUser();
 


### PR DESCRIPTION



## Description
Fixes PostHog tracking initialization and state management issues. The changes consolidate tracking state logic by computing `shouldTrack` upfront and using it consistently throughout the component. Improves the initialization flow by setting the correct default opt-out state and prevents unnecessary re-initialization. Also adds tracking for agent creation events and onboarding page views, and restricts workspace group properties to admin users only to prevent API errors.

## Risk
Changes PostHog initialization behavior and state management logic. The admin-only restriction for workspace group properties may affect tracking granularity for non-admin users.
