### PR TITLE
[front] chore(cc): prevent button nesting

### DIFF
--- a/front/components/assistant/conversation/content_creation/ClientExecutableRenderer.tsx
+++ b/front/components/assistant/conversation/content_creation/ClientExecutableRenderer.tsx
@@ -360,6 +360,7 @@ function PreviewActionButtons({
       <Tooltip
         label={`${isFullScreen ? "Exit" : "Go to"} full screen mode`}
         side="left"
+        tooltipTriggerAsChild
         trigger={
           <Button
             icon={isFullScreen ? FullscreenExitIcon : FullscreenIcon}
@@ -373,6 +374,7 @@ function PreviewActionButtons({
         <Tooltip
           label="Revert the last change"
           side="left"
+          tooltipTriggerAsChild
           trigger={
             <Button
               variant="ghost"
@@ -386,6 +388,7 @@ function PreviewActionButtons({
       <Tooltip
         label="Reload the file"
         side="left"
+        tooltipTriggerAsChild
         trigger={
           <Button
             icon={ArrowCircleIcon}


### PR DESCRIPTION
## Description

- The `PreviewActionButtons` contains `Tooltip`s that have a `Button` as their trigger, which is rendered as a button within a button (the `TooltipTrigger` contains a button).
- This PR fixes that.
- No change in behavior.

## Tests

- Checked locally.

## Risk

- Low.

## Deploy Plan

- Deploy front.
