### PR TITLE
NULLABLE_TIME_FRAME -> TIME_FRAME

### DIFF
--- a/front/lib/actions/mcp_internal_actions/input_configuration.test.ts
+++ b/front/lib/actions/mcp_internal_actions/input_configuration.test.ts
@@ -486,7 +486,7 @@ describe("augmentInputsWithConfiguration", () => {
       });
     });
 
-    it("should return null when timeFrame is not configured", () => {
+    it("should return undefined when timeFrame is not configured", () => {
       const rawInputs = {};
       const config = createBasicMCPConfiguration({
         timeFrame: null,
@@ -522,7 +522,7 @@ describe("augmentInputsWithConfiguration", () => {
       });
 
       expect(result).toEqual({
-        timeFrame: null,
+        timeFrame: undefined,
       });
     });
   });
@@ -569,7 +569,7 @@ describe("augmentInputsWithConfiguration", () => {
     it("should return null when jsonSchema is not configured", () => {
       const rawInputs = {};
       const config = createBasicMCPConfiguration({
-        jsonSchema: null,
+        jsonSchema: undefined,
         inputSchema: {
           type: "object",
           properties: {
@@ -601,7 +601,7 @@ describe("augmentInputsWithConfiguration", () => {
       });
 
       expect(result).toEqual({
-        schema: null,
+        schema: undefined,
       });
     });
   });

--- a/front/lib/actions/mcp_internal_actions/input_configuration.test.ts
+++ b/front/lib/actions/mcp_internal_actions/input_configuration.test.ts
@@ -451,7 +451,7 @@ describe("augmentInputsWithConfiguration", () => {
     });
   });
 
-  describe("NULLABLE_TIME_FRAME mime type", () => {
+  describe("TIME_FRAME mime type", () => {
     it("should augment inputs with time frame configuration", () => {
       const rawInputs = {};
       const config = createBasicMCPConfiguration({
@@ -464,7 +464,7 @@ describe("augmentInputsWithConfiguration", () => {
           properties: {
             timeFrame:
               ConfigurableToolInputJSONSchemas[
-                INTERNAL_MIME_TYPES.TOOL_INPUT.NULLABLE_TIME_FRAME
+                INTERNAL_MIME_TYPES.TOOL_INPUT.TIME_FRAME
               ],
           },
           required: ["timeFrame"],
@@ -481,7 +481,7 @@ describe("augmentInputsWithConfiguration", () => {
         timeFrame: {
           duration: 7,
           unit: "day",
-          mimeType: INTERNAL_MIME_TYPES.TOOL_INPUT.NULLABLE_TIME_FRAME,
+          mimeType: INTERNAL_MIME_TYPES.TOOL_INPUT.TIME_FRAME,
         },
       });
     });
@@ -503,7 +503,7 @@ describe("augmentInputsWithConfiguration", () => {
                     unit: { type: "string" },
                     mimeType: {
                       type: "string",
-                      const: INTERNAL_MIME_TYPES.TOOL_INPUT.NULLABLE_TIME_FRAME,
+                      const: INTERNAL_MIME_TYPES.TOOL_INPUT.TIME_FRAME,
                     },
                   },
                   required: ["duration", "unit", "mimeType"],

--- a/front/lib/actions/mcp_internal_actions/input_configuration.ts
+++ b/front/lib/actions/mcp_internal_actions/input_configuration.ts
@@ -165,7 +165,7 @@ function generateConfiguredInput({
       return { modelId, providerId, temperature, reasoningEffort, mimeType };
     }
 
-    case INTERNAL_MIME_TYPES.TOOL_INPUT.NULLABLE_TIME_FRAME: {
+    case INTERNAL_MIME_TYPES.TOOL_INPUT.TIME_FRAME: {
       const { timeFrame } = actionConfiguration;
       if (!timeFrame) {
         return null;

--- a/front/lib/actions/mcp_internal_actions/input_configuration.ts
+++ b/front/lib/actions/mcp_internal_actions/input_configuration.ts
@@ -168,7 +168,7 @@ function generateConfiguredInput({
     case INTERNAL_MIME_TYPES.TOOL_INPUT.TIME_FRAME: {
       const { timeFrame } = actionConfiguration;
       if (!timeFrame) {
-        return null;
+        return undefined;
       }
 
       const { duration, unit } = timeFrame;
@@ -178,7 +178,7 @@ function generateConfiguredInput({
     case INTERNAL_MIME_TYPES.TOOL_INPUT.JSON_SCHEMA: {
       const { jsonSchema } = actionConfiguration;
       if (!jsonSchema) {
-        return null;
+        return undefined;
       }
       const validationResult = validateConfiguredJsonSchema(jsonSchema);
       if (validationResult.isErr()) {

--- a/front/lib/actions/mcp_internal_actions/input_schemas.ts
+++ b/front/lib/actions/mcp_internal_actions/input_schemas.ts
@@ -140,14 +140,13 @@ export const ConfigurableToolInputSchemas = {
     appId: z.string(),
     mimeType: z.literal(INTERNAL_MIME_TYPES.TOOL_INPUT.DUST_APP),
   }),
-  [INTERNAL_MIME_TYPES.TOOL_INPUT.NULLABLE_TIME_FRAME]: z
+  [INTERNAL_MIME_TYPES.TOOL_INPUT.TIME_FRAME]: z
     .object({
       duration: z.number(),
       unit: z.enum(["hour", "day", "week", "month", "year"]),
-      mimeType: z.literal(INTERNAL_MIME_TYPES.TOOL_INPUT.NULLABLE_TIME_FRAME),
+      mimeType: z.literal(INTERNAL_MIME_TYPES.TOOL_INPUT.TIME_FRAME),
     })
-    .describe("An optional time frame to use for the tool.")
-    .nullable(),
+    .describe("An optional time frame to use for the tool."),
   [INTERNAL_MIME_TYPES.TOOL_INPUT.JSON_SCHEMA]: z.intersection(
     JsonSchemaSchema,
     z.object({
@@ -187,7 +186,8 @@ export type ConfigurableToolInputType =
   | z.infer<
       (typeof ConfigurableToolInputSchemas)[keyof typeof ConfigurableToolInputSchemas]
     >
-  | FlexibleConfigurableToolInput[keyof FlexibleConfigurableToolInput];
+  | FlexibleConfigurableToolInput[keyof FlexibleConfigurableToolInput]
+  | null;
 
 export type DataSourcesToolConfigurationType = z.infer<
   (typeof ConfigurableToolInputSchemas)[typeof INTERNAL_MIME_TYPES.TOOL_INPUT.DATA_SOURCE]

--- a/front/lib/actions/mcp_internal_actions/input_schemas.ts
+++ b/front/lib/actions/mcp_internal_actions/input_schemas.ts
@@ -187,7 +187,7 @@ export type ConfigurableToolInputType =
       (typeof ConfigurableToolInputSchemas)[keyof typeof ConfigurableToolInputSchemas]
     >
   | FlexibleConfigurableToolInput[keyof FlexibleConfigurableToolInput]
-  | null;
+  | undefined;
 
 export type DataSourcesToolConfigurationType = z.infer<
   (typeof ConfigurableToolInputSchemas)[typeof INTERNAL_MIME_TYPES.TOOL_INPUT.DATA_SOURCE]

--- a/front/lib/actions/mcp_internal_actions/servers/include.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/include.ts
@@ -54,7 +54,9 @@ function createServer(
 
   const commonInputsSchema = {
     timeFrame:
-      ConfigurableToolInputSchemas[INTERNAL_MIME_TYPES.TOOL_INPUT.TIME_FRAME],
+      ConfigurableToolInputSchemas[
+        INTERNAL_MIME_TYPES.TOOL_INPUT.TIME_FRAME
+      ].optional(),
     dataSources:
       ConfigurableToolInputSchemas[INTERNAL_MIME_TYPES.TOOL_INPUT.DATA_SOURCE],
   };
@@ -86,7 +88,7 @@ function createServer(
     tagsIn,
     tagsNot,
   }: {
-    timeFrame: TimeFrame | null;
+    timeFrame?: TimeFrame;
     dataSources: DataSourcesToolConfigurationType;
     tagsIn?: string[];
     tagsNot?: string[];

--- a/front/lib/actions/mcp_internal_actions/servers/include.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/include.ts
@@ -54,9 +54,7 @@ function createServer(
 
   const commonInputsSchema = {
     timeFrame:
-      ConfigurableToolInputSchemas[
-        INTERNAL_MIME_TYPES.TOOL_INPUT.NULLABLE_TIME_FRAME
-      ],
+      ConfigurableToolInputSchemas[INTERNAL_MIME_TYPES.TOOL_INPUT.TIME_FRAME],
     dataSources:
       ConfigurableToolInputSchemas[INTERNAL_MIME_TYPES.TOOL_INPUT.DATA_SOURCE],
   };

--- a/front/lib/actions/mcp_internal_actions/servers/process/index.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/process/index.ts
@@ -98,7 +98,7 @@ function makeExtractInformationFromDocumentsTool(
       dataSources: DataSourcesToolConfigurationType[number][];
       objective: string;
       jsonSchema: JSONSchema;
-      timeFrame: TimeFrame | null;
+      timeFrame?: TimeFrame;
       tagsIn?: string[];
       tagsNot?: string[];
     }) => {
@@ -134,7 +134,7 @@ function makeExtractInformationFromDocumentsTool(
         auth,
         model,
         dataSources,
-        timeFrame,
+        timeFrame: timeFrame ?? null,
         // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
         tagsIn: tagsIn || undefined,
         // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
@@ -200,7 +200,7 @@ function makeExtractInformationFromDocumentsTool(
         conversation,
         outputs,
         jsonSchema,
-        timeFrame,
+        timeFrame: timeFrame ?? null,
         objective,
       });
       // Upload the file to the conversation data source.
@@ -287,7 +287,9 @@ function createServer(
           EXTRACT_TOOL_JSON_SCHEMA_ARGUMENT_DESCRIPTION
         ),
     timeFrame: isTimeFrameConfigured
-      ? ConfigurableToolInputSchemas[INTERNAL_MIME_TYPES.TOOL_INPUT.TIME_FRAME]
+      ? ConfigurableToolInputSchemas[
+          INTERNAL_MIME_TYPES.TOOL_INPUT.TIME_FRAME
+        ].optional()
       : z
           .object({
             duration: z.number(),
@@ -296,8 +298,7 @@ function createServer(
           .describe(
             "The time frame to use for documents retrieval (e.g. last 7 days, last 2 months). Leave null to search all documents regardless of time."
           )
-          .nullable()
-          .default(null),
+          .optional(),
   };
 
   const toolDescription =

--- a/front/lib/actions/mcp_internal_actions/servers/process/index.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/process/index.ts
@@ -287,9 +287,7 @@ function createServer(
           EXTRACT_TOOL_JSON_SCHEMA_ARGUMENT_DESCRIPTION
         ),
     timeFrame: isTimeFrameConfigured
-      ? ConfigurableToolInputSchemas[
-          INTERNAL_MIME_TYPES.TOOL_INPUT.NULLABLE_TIME_FRAME
-        ]
+      ? ConfigurableToolInputSchemas[INTERNAL_MIME_TYPES.TOOL_INPUT.TIME_FRAME]
       : z
           .object({
             duration: z.number(),

--- a/front/lib/utils/json_schemas.test.ts
+++ b/front/lib/utils/json_schemas.test.ts
@@ -245,7 +245,7 @@ describe("JSON Schema Utilities", () => {
           },
           optionalTimeFrame:
             ConfigurableToolInputJSONSchemas[
-              INTERNAL_MIME_TYPES.TOOL_INPUT.NULLABLE_TIME_FRAME
+              INTERNAL_MIME_TYPES.TOOL_INPUT.TIME_FRAME
             ],
         },
         required: ["optionalString"],
@@ -253,7 +253,7 @@ describe("JSON Schema Utilities", () => {
 
       const r = findMatchingSubSchemas(
         mainSchema,
-        INTERNAL_MIME_TYPES.TOOL_INPUT.NULLABLE_TIME_FRAME
+        INTERNAL_MIME_TYPES.TOOL_INPUT.TIME_FRAME
       );
       expect(Object.keys(r)).toStrictEqual(["optionalTimeFrame"]);
     });

--- a/sdks/js/src/internal_mime_types.ts
+++ b/sdks/js/src/internal_mime_types.ts
@@ -25,7 +25,7 @@ type UnderscoreToDash<T extends string> = T extends `${infer A}_${infer B}`
  */
 function generateConnectorRelativeMimeTypes<
   P extends ConnectorProvider,
-  T extends Uppercase<string>[]
+  T extends Uppercase<string>[],
 >({
   provider,
   resourceTypes,
@@ -193,7 +193,7 @@ export const INCLUDABLE_INTERNAL_CONTENT_NODE_MIME_TYPES = {
 
 function generateToolMimeTypes<
   P extends Uppercase<string>,
-  T extends Uppercase<string>[]
+  T extends Uppercase<string>[],
 >({
   category,
   resourceTypes,
@@ -235,7 +235,7 @@ const TOOL_MIME_TYPES = {
       "LIST",
       "REASONING_MODEL",
       "DUST_APP",
-      "NULLABLE_TIME_FRAME",
+      "TIME_FRAME",
       "JSON_SCHEMA",
       "SECRET",
     ],


### PR DESCRIPTION
## Description

Changing the time_frame type to no longer be nullable. Instead we'll use optionals.

## Tests

Tested with the `include` tool. Works both without a timeFrame set, or with one set (
- Tried to include a file without setting time frame (worked)
- Tried to include a file with a time frame long enough for the file to be there (worked)
- Tried to make sure the file would be unavailable if timeframe too small (worked)

(Also updated the tests in `input_configuration.test.ts`)

## Risk

None.

## Deploy Plan

Deploy sdk, front.
