### PR TITLE
[front] fix: Prevent API access without valid subscription

### DIFF
--- a/front/lib/api/assistant/conversation.ts
+++ b/front/lib/api/assistant/conversation.ts
@@ -1566,15 +1566,25 @@ async function isMessagesLimitReached({
   }
 
   // Checking plan limit
-  if (mentions.length === 0) {
+  const { maxMessages, maxMessagesTimeframe } = plan.limits.assistant;
+
+  if (plan.limits.assistant.maxMessages === -1) {
     return {
       isLimitReached: false,
       limitType: null,
     };
   }
-  const { maxMessages, maxMessagesTimeframe } = plan.limits.assistant;
 
-  if (plan.limits.assistant.maxMessages === -1) {
+  // If no mentions, check general message limit against the plan
+  if (mentions.length === 0) {
+    // Block messages if maxMessages is 0 (no plan or very restrictive plan)
+    if (maxMessages === 0) {
+      return {
+        isLimitReached: true,
+        limitType: "plan_message_limit_exceeded",
+      };
+    }
+    // Otherwise allow non-mention messages for users with a valid plan
     return {
       isLimitReached: false,
       limitType: null,

--- a/front/lib/api/auth_wrappers.ts
+++ b/front/lib/api/auth_wrappers.ts
@@ -310,6 +310,29 @@ export function withPublicAPIAuthentication<T, U extends boolean>(
             });
           }
 
+          const owner = auth.workspace();
+          const plan = auth.plan();
+          if (!owner || !plan) {
+            return apiError(req, res, {
+              status_code: 404,
+              api_error: {
+                type: "workspace_not_found",
+                message: "The workspace was not found.",
+              },
+            });
+          }
+
+          if (!plan.limits.canUseProduct) {
+            return apiError(req, res, {
+              status_code: 403,
+              api_error: {
+                type: "workspace_can_use_product_required_error",
+                message:
+                  "Your current plan does not allow API access. Please upgrade your plan.",
+              },
+            });
+          }
+
           req.addResourceToLog?.(auth.getNonNullableUser());
 
           const maintenance = auth.workspace()?.metadata?.maintenance;
@@ -365,6 +388,17 @@ export function withPublicAPIAuthentication<T, U extends boolean>(
           api_error: {
             type: "workspace_not_found",
             message: "The workspace was not found.",
+          },
+        });
+      }
+
+      if (!plan.limits.canUseProduct) {
+        return apiError(req, res, {
+          status_code: 403,
+          api_error: {
+            type: "workspace_can_use_product_required_error",
+            message:
+              "Your current plan does not allow API access. Please upgrade your plan.",
           },
         });
       }


### PR DESCRIPTION
## Description

Users with FREE_NO_PLAN (canUseProduct: false, maxMessages: 0) can:
- Authenticate successfully via v1 API
- Create conversations
- Post messages without mentions 

This should be blocked - adding two fixes : 
- checking maxMessages when creating a message - even if there's no mention, it should be rejected
- adding a much broader check on all v1 api call to block if there's no scubscription

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

Blocking users who use the api without any subscription 

## Deploy Plan

deploy front
