### PR TITLE
`configurable: boolean` -> `canBeConfigured: boolean`

### DIFF
--- a/front/components/agent_builder/AgentBuilderFormContext.tsx
+++ b/front/components/agent_builder/AgentBuilderFormContext.tsx
@@ -100,7 +100,7 @@ const baseActionSchema = z.object({
   id: z.string(),
   name: z.string(),
   description: z.string(),
-  configurable: z.boolean().optional(),
+  canBeConfigured: z.boolean().optional(),
 });
 
 const TAG_KINDS = z.union([z.literal("standard"), z.literal("protected")]);

--- a/front/components/agent_builder/capabilities/AgentBuilderCapabilitiesBlock.tsx
+++ b/front/components/agent_builder/capabilities/AgentBuilderCapabilitiesBlock.tsx
@@ -100,10 +100,10 @@ function ActionCard({ action, onRemove, onEdit }: ActionCardProps) {
 
   const mcpServerView =
     action.type === "MCP" && !isMCPServerViewsLoading
-      ? mcpServerViews.find(
+      ? (mcpServerViews.find(
           (mcpServerView) =>
             mcpServerView.sId === action.configuration.mcpServerViewId
-        ) ?? null
+        ) ?? null)
       : null;
 
   const displayName = actionDisplayName(action, mcpServerView);
@@ -204,7 +204,7 @@ export function AgentBuilderCapabilitiesBlock({
       setKnowledgeAction({ action, index });
     } else {
       setDialogMode(
-        action.configurable
+        action.canBeConfigured
           ? { type: "edit", action, index }
           : { type: "info", action, source: "addedTool" }
       );
@@ -227,7 +227,7 @@ export function AgentBuilderCapabilitiesBlock({
     setKnowledgeAction({
       action: {
         ...action,
-        configurable: true, // it's always required for knowledge
+        canBeConfigured: true, // it's always required for knowledge
       },
       index: null,
     });

--- a/front/components/agent_builder/capabilities/mcp/MCPServerViewsSheet.tsx
+++ b/front/components/agent_builder/capabilities/mcp/MCPServerViewsSheet.tsx
@@ -192,7 +192,7 @@ export function MCPServerViewsSheet({
           action.type === "MCP" &&
           action.configuration &&
           action.configuration.mcpServerViewId &&
-          !action.configurable
+          !action.canBeConfigured
         ) {
           const selectedView = allMcpServerViews.find(
             (mcpServerView) =>
@@ -501,7 +501,7 @@ export function MCPServerViewsSheet({
             configuration: null,
             name: DEFAULT_DATA_VISUALIZATION_NAME,
             description: DEFAULT_DATA_VISUALIZATION_DESCRIPTION,
-            configurable: false,
+            canBeConfigured: false,
           };
         } else {
           // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
@@ -634,7 +634,7 @@ export function MCPServerViewsSheet({
           <FormProvider form={form} className="h-full">
             <div className="h-full">
               <div className="h-full space-y-6 pt-3">
-                {configurationTool.configurable && (
+                {configurationTool.canBeConfigured && (
                   <NameSection
                     title="Name"
                     placeholder="My tool name…"

--- a/front/components/agent_builder/capabilities/usePresetActionHandler.ts
+++ b/front/components/agent_builder/capabilities/usePresetActionHandler.ts
@@ -106,7 +106,7 @@ export function usePresetActionHandler({
 
     if (isKnowledgeTemplateAction(presetActionToAdd)) {
       setKnowledgeAction({
-        action: { ...action, configurable: false },
+        action: { ...action, canBeConfigured: false },
         index: null,
         presetData: presetActionToAdd,
       });

--- a/front/components/agent_builder/get_spaceid_to_actions_map.test.ts
+++ b/front/components/agent_builder/get_spaceid_to_actions_map.test.ts
@@ -16,7 +16,7 @@ const createMockAction = (
   configuration: null,
   name,
   description: `Description for ${name}`,
-  configurable: false,
+  canBeConfigured: false,
 });
 
 const createMockMCPAction = (
@@ -44,7 +44,7 @@ const createMockMCPAction = (
     _jsonSchemaString: null,
     secretName: null,
   },
-  configurable: true,
+  canBeConfigured: true,
 });
 
 const createMockMCPServerView = (

--- a/front/components/agent_builder/types.ts
+++ b/front/components/agent_builder/types.ts
@@ -184,15 +184,15 @@ export function getDefaultMCPAction(
     // Ensure default name always matches validation regex (^[a-z0-9_]+$)
     name: sanitizedName,
     description:
-      toolsConfigurations.dataSourceConfiguration ??
+      (toolsConfigurations.dataSourceConfiguration ??
       toolsConfigurations.dataWarehouseConfiguration ??
       toolsConfigurations.tableConfiguration ??
-      false
+      false)
         ? ""
         : mcpServerView
           ? getMcpServerViewDescription(mcpServerView)
           : "",
-    configurable: toolsConfigurations.configurable !== "no",
+    canBeConfigured: toolsConfigurations.configurable !== "no",
   };
 }
 

--- a/front/components/assistant_builder/types.ts
+++ b/front/components/assistant_builder/types.ts
@@ -58,7 +58,7 @@ export interface AssistantBuilderDataVisualizationConfiguration {
   configuration: null;
   name: string;
   description: string;
-  configurable: false;
+  canBeConfigured: false;
 }
 
 // DATA_VISUALIZATION is not an action, but we need to show it in the UI like an action.
@@ -105,7 +105,7 @@ export function getDataVisualizationConfiguration(): AssistantBuilderDataVisuali
     configuration: null,
     name: DEFAULT_DATA_VISUALIZATION_NAME,
     description: DEFAULT_DATA_VISUALIZATION_DESCRIPTION,
-    configurable: false,
+    canBeConfigured: false,
   } satisfies AssistantBuilderDataVisualizationConfiguration;
 }
 
@@ -131,10 +131,10 @@ export function getDefaultMCPServerActionConfiguration(
     },
     name: mcpServerView?.name ?? mcpServerView?.server.name ?? "",
     description:
-      toolsConfigurations.dataSourceConfiguration ??
+      (toolsConfigurations.dataSourceConfiguration ??
       toolsConfigurations.dataWarehouseConfiguration ??
       toolsConfigurations.tableConfiguration ??
-      false
+      false)
         ? ""
         : mcpServerView
           ? getMcpServerViewDescription(mcpServerView)


### PR DESCRIPTION
## Description

Since `getMCPServerToolsConfigurations` is using a `configurable: "no" | "optional" | "required"` design, the many other `configurable: boolean` parameters related to `actionConfiguration` are causing confusion by being the same name but a different type. Since these only wish to capture whether the "is it configurable or not" dichotomy, without care for if the configuration is "optional" or not, it is better to rename them to avoid ambiguity.

## Tests

Ran all tests, but since these are just renamings it shouldn't change any behavior.

## Risk

None.

## Deploy Plan

Deploy front.
