### PR TITLE
Add checks for circular dependencies

### DIFF
--- a/connectors/src/connectors/notion/temporal/activities.ts
+++ b/connectors/src/connectors/notion/temporal/activities.ts
@@ -2485,8 +2485,14 @@ async function renderPageSection({
       addNode(child.notionBlockId);
     }
   };
+
   addNode("root");
   orderedParentIds.reverse();
+
+  localLogger.info(
+    { pagesCount: visitedNodes.size },
+    "Rendered page sections."
+  );
 
   const adaptedBlocksByParentId: Record<
     string,
@@ -2633,6 +2639,12 @@ async function renderPageSection({
   for (const block of topLevelBlocks) {
     renderedPageSection.sections.push(await renderBlockSection(block, 0));
   }
+
+  localLogger.info(
+    { blocksCount: topLevelBlocks.length },
+    "Rendered block sections."
+  );
+
   return renderedPageSection;
 }
 


### PR DESCRIPTION
## Description

Activity renderAndUpsertPageFromCache is stuck after log "Rendering page" , nothing seems to happen until we hit  a startToCloseTimeout after 10min
We may have cycles which would infinitely block the activity. So :
- Fixed infinite loop in addNode - Added cycle detection with visitedNodes Set
- Fixed infinite loop in renderBlockSection - Added cycle detection with renderingStack Set
- Improved logging - Added log before recursion to identify which block is slow even if it never completes

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

low

## Deploy Plan

deploy connectors
