### PR TITLE
[front] Add tooltip

### DIFF
--- a/front/components/assistant/details/AssistantDetailsButtonBar.tsx
+++ b/front/components/assistant/details/AssistantDetailsButtonBar.tsx
@@ -79,6 +79,11 @@ export function AssistantDetailsButtonBar({
               ? StarIcon
               : StarStrokeIcon
           }
+          tooltip={
+            agentConfiguration.userFavorite || isFavoriteDisabled
+              ? "Remove from favorites"
+              : "Add to favorites"
+          }
           size="sm"
           className="group-hover:hidden"
           variant="outline"
@@ -88,6 +93,11 @@ export function AssistantDetailsButtonBar({
 
         <Button
           icon={StarIcon}
+          tooltip={
+            agentConfiguration.userFavorite || isFavoriteDisabled
+              ? "Remove from favorites"
+              : "Add to favorites"
+          }
           size="sm"
           className="hidden group-hover:block"
           variant="outline"
@@ -100,6 +110,7 @@ export function AssistantDetailsButtonBar({
         icon={ChatBubbleBottomCenterTextIcon}
         size="sm"
         variant="outline"
+        tooltip="New conversation"
         href={getAgentRoute(
           owner.sId,
           "new",
@@ -111,6 +122,7 @@ export function AssistantDetailsButtonBar({
         !isRestrictedFromAgentCreation && (
           <Button
             size="sm"
+            tooltip="Edit agent"
             href={
               canEditAssistant
                 ? getAgentBuilderRoute(owner.sId, agentConfiguration.sId)


### PR DESCRIPTION
## Description

Add a tooltip on buttons (can be used in auto test to identify buttons more precisely)

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

none

## Deploy Plan

deploy front
