### PR TITLE
feat: add a noop model and agent for local development

### DIFF
--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -57,12 +57,11 @@ pub mod search_filter;
 pub mod utils;
 pub mod providers {
     pub mod azure_openai;
+    pub mod chat_messages;
     pub mod embedder;
     pub mod llm;
     pub mod mistral;
     pub mod openai;
-
-    pub mod chat_messages;
     pub mod provider;
     pub mod tiktoken {
         pub mod tiktoken;
@@ -81,6 +80,7 @@ pub mod providers {
     pub mod fireworks;
     pub mod google_ai_studio;
     pub mod helpers;
+    pub mod noop;
     pub mod openai_compatible_helpers;
     pub mod openai_responses_api_helpers;
     pub mod togetherai;

--- a/core/src/providers/noop.rs
+++ b/core/src/providers/noop.rs
@@ -1,0 +1,182 @@
+use crate::providers::chat_messages::AssistantContentItem::TextContent;
+use crate::providers::chat_messages::{AssistantChatMessage, ChatMessage};
+use crate::providers::embedder::Embedder;
+use crate::providers::llm::{ChatFunction, ChatMessageRole, Tokens};
+use crate::providers::llm::{LLMChatGeneration, LLMGeneration, LLM};
+use crate::providers::provider::{Provider, ProviderID};
+use crate::providers::tiktoken::tiktoken::{
+    batch_tokenize_async, decode_async, encode_async, o200k_base_singleton, CoreBPE,
+};
+use crate::run::Credentials;
+use crate::utils;
+use anyhow::Result;
+use async_trait::async_trait;
+use parking_lot::RwLock;
+use serde_json::{json, Value};
+use std::sync::Arc;
+use tokio::sync::mpsc::UnboundedSender;
+
+pub struct NoopLLM {
+    id: String,
+}
+
+impl NoopLLM {
+    pub fn new(id: String) -> Self {
+        NoopLLM { id }
+    }
+
+    fn tokenizer(&self) -> Arc<RwLock<CoreBPE>> {
+        o200k_base_singleton()
+    }
+}
+
+#[async_trait]
+impl LLM for NoopLLM {
+    fn id(&self) -> String {
+        self.id.clone()
+    }
+
+    async fn initialize(&mut self, _credentials: Credentials) -> Result<()> {
+        Ok(())
+    }
+
+    fn context_size(&self) -> usize {
+        1_000_000
+    }
+
+    async fn encode(&self, text: &str) -> Result<Vec<usize>> {
+        encode_async(self.tokenizer(), text).await
+    }
+
+    async fn decode(&self, tokens: Vec<usize>) -> Result<String> {
+        decode_async(self.tokenizer(), tokens).await
+    }
+
+    async fn tokenize(&self, texts: Vec<String>) -> Result<Vec<Vec<(usize, String)>>> {
+        batch_tokenize_async(self.tokenizer(), texts).await
+    }
+
+    async fn generate(
+        &self,
+        _prompt: &str,
+        _max_tokens: Option<i32>,
+        _temperature: f32,
+        _n: usize,
+        _stop: &Vec<String>,
+        _frequency_penalty: Option<f32>,
+        _presence_penalty: Option<f32>,
+        _top_p: Option<f32>,
+        _top_logprobs: Option<i32>,
+        _extras: Option<Value>,
+        event_sender: Option<UnboundedSender<Value>>,
+    ) -> Result<LLMGeneration> {
+        // First, we send the tokens to the event sender, so the UI can display them.
+        match event_sender {
+            None => {}
+            Some(e) => e.send(json!({
+                "type": "tokens",
+                "content": {
+                  "text": "noop",
+                }
+            }))?,
+        }
+        Ok(LLMGeneration {
+            created: utils::now(),
+            provider: ProviderID::Noop.to_string(),
+            model: self.id.clone(),
+            completions: vec![Tokens {
+                text: "noop".to_string(),
+                tokens: Some(vec!["noop".to_string()]),
+                logprobs: None,
+                top_logprobs: None,
+            }],
+            prompt: Tokens {
+                text: "noop".to_string(),
+                tokens: Some(vec!["noop".to_string()]),
+                logprobs: None,
+                top_logprobs: None,
+            },
+            usage: None,
+            provider_request_id: None,
+        })
+    }
+
+    async fn chat(
+        &self,
+        _messages: &Vec<ChatMessage>,
+        _functions: &Vec<ChatFunction>,
+        _function_call: Option<String>,
+        _temperature: f32,
+        _top_p: Option<f32>,
+        _n: usize,
+        _stop: &Vec<String>,
+        _max_tokens: Option<i32>,
+        _presence_penalty: Option<f32>,
+        _frequency_penalty: Option<f32>,
+        _logprobs: Option<bool>,
+        _top_logprobs: Option<i32>,
+        _extras: Option<Value>,
+        event_sender: Option<UnboundedSender<Value>>,
+    ) -> Result<LLMChatGeneration> {
+        // First, we send the tokens to the event sender, so the UI can display them.
+        match event_sender {
+            None => {}
+            Some(e) => e.send(json!({
+                "type": "tokens",
+                "content": {
+                  "text": "noop",
+                }
+            }))?,
+        }
+        // Then we return the full completion.
+        Ok(LLMChatGeneration {
+            created: utils::now(),
+            provider: ProviderID::Noop.to_string(),
+            model: "noop".to_string(),
+            completions: vec![AssistantChatMessage {
+                content: None,
+                function_call: None,
+                function_calls: None,
+                name: None,
+                role: ChatMessageRole::Assistant,
+                contents: Some(vec![TextContent {
+                    value: "noop".to_string(),
+                }]),
+            }],
+            usage: None,
+            provider_request_id: None,
+            logprobs: None,
+        })
+    }
+}
+
+pub struct NoopProvider {}
+
+impl NoopProvider {
+    pub fn new() -> Self {
+        NoopProvider {}
+    }
+}
+
+#[async_trait]
+impl Provider for NoopProvider {
+    fn id(&self) -> ProviderID {
+        ProviderID::Noop
+    }
+
+    fn setup(&self) -> Result<()> {
+        Ok(())
+    }
+
+    async fn test(&self) -> Result<()> {
+        Ok(())
+    }
+
+    fn llm(&self, id: String) -> Box<dyn LLM + Sync + Send> {
+        Box::new(NoopLLM::new(id))
+    }
+
+    fn embedder(&self, _id: String) -> Box<dyn Embedder + Sync + Send> {
+        unimplemented!()
+    }
+}

--- a/core/src/providers/provider.rs
+++ b/core/src/providers/provider.rs
@@ -4,6 +4,7 @@ use crate::providers::embedder::Embedder;
 use crate::providers::google_ai_studio::GoogleAiStudioProvider;
 use crate::providers::llm::LLM;
 use crate::providers::mistral::MistralProvider;
+use crate::providers::noop::NoopProvider;
 use crate::providers::openai::OpenAIProvider;
 use crate::utils::ParseError;
 use anyhow::{anyhow, Result};
@@ -35,6 +36,7 @@ pub enum ProviderID {
     Deepseek,
     Fireworks,
     Xai,
+    Noop,
 }
 
 impl fmt::Display for ProviderID {
@@ -49,6 +51,7 @@ impl fmt::Display for ProviderID {
             ProviderID::Deepseek => write!(f, "deepseek"),
             ProviderID::Fireworks => write!(f, "fireworks"),
             ProviderID::Xai => write!(f, "xai"),
+            ProviderID::Noop => write!(f, "noop"),
         }
     }
 }
@@ -66,9 +69,10 @@ impl FromStr for ProviderID {
             "deepseek" => Ok(ProviderID::Deepseek),
             "fireworks" => Ok(ProviderID::Fireworks),
             "xai" => Ok(ProviderID::Xai),
+            "noop" => Ok(ProviderID::Noop),
             _ => Err(ParseError::with_message(
                 "Unknown provider ID \
-                 (possible values: openai, azure_openai, anthropic, mistral, google_ai_studio, togetherai, deepseek, fireworks, xai)",
+                 (possible values: openai, azure_openai, anthropic, mistral, google_ai_studio, togetherai, deepseek, fireworks, xai, noop)",
             ))?,
         }
     }
@@ -88,8 +92,8 @@ pub struct ModelError {
     pub request_id: Option<String>,
 }
 
-impl std::fmt::Display for ModelError {
-    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+impl fmt::Display for ModelError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(
             f,
             "[model_error(retryable={}{})] {}",
@@ -172,5 +176,6 @@ pub fn provider(t: ProviderID) -> Box<dyn Provider + Sync + Send> {
         ProviderID::Deepseek => Box::new(DeepseekProvider::new()),
         ProviderID::Fireworks => Box::new(FireworksProvider::new()),
         ProviderID::Xai => Box::new(XaiProvider::new()),
+        ProviderID::Noop => Box::new(NoopProvider::new()),
     }
 }

--- a/front/components/agent_builder/capabilities/AgentBuilderCapabilitiesBlock.tsx
+++ b/front/components/agent_builder/capabilities/AgentBuilderCapabilitiesBlock.tsx
@@ -100,10 +100,10 @@ function ActionCard({ action, onRemove, onEdit }: ActionCardProps) {
 
   const mcpServerView =
     action.type === "MCP" && !isMCPServerViewsLoading
-      ? (mcpServerViews.find(
+      ? mcpServerViews.find(
           (mcpServerView) =>
             mcpServerView.sId === action.configuration.mcpServerViewId
-        ) ?? null)
+        ) ?? null
       : null;
 
   const displayName = actionDisplayName(action, mcpServerView);

--- a/front/components/agent_builder/types.ts
+++ b/front/components/agent_builder/types.ts
@@ -184,10 +184,10 @@ export function getDefaultMCPAction(
     // Ensure default name always matches validation regex (^[a-z0-9_]+$)
     name: sanitizedName,
     description:
-      (toolsConfigurations.dataSourceConfiguration ??
+      toolsConfigurations.dataSourceConfiguration ??
       toolsConfigurations.dataWarehouseConfiguration ??
       toolsConfigurations.tableConfiguration ??
-      false)
+      false
         ? ""
         : mcpServerView
           ? getMcpServerViewDescription(mcpServerView)

--- a/front/components/assistant_builder/types.ts
+++ b/front/components/assistant_builder/types.ts
@@ -131,10 +131,10 @@ export function getDefaultMCPServerActionConfiguration(
     },
     name: mcpServerView?.name ?? mcpServerView?.server.name ?? "",
     description:
-      (toolsConfigurations.dataSourceConfiguration ??
+      toolsConfigurations.dataSourceConfiguration ??
       toolsConfigurations.dataWarehouseConfiguration ??
       toolsConfigurations.tableConfiguration ??
-      false)
+      false
         ? ""
         : mcpServerView
           ? getMcpServerViewDescription(mcpServerView)

--- a/front/components/providers/types.ts
+++ b/front/components/providers/types.ts
@@ -1,6 +1,7 @@
 import {
   AnthropicLogo,
   DeepseekLogo,
+  DustLogo,
   FireworksLogo,
   GeminiLogo,
   GrokLogo,
@@ -74,6 +75,9 @@ const MODEL_PROVIDER_LOGOS: ModelProviderLogos = {
   },
   xai: {
     light: GrokLogo,
+  },
+  noop: {
+    light: DustLogo,
   },
 };
 

--- a/front/components/workspace/ProviderManagementModal.tsx
+++ b/front/components/workspace/ProviderManagementModal.tsx
@@ -43,6 +43,7 @@ const prettyfiedProviderNames: { [key in ModelProviderIdType]: string } = {
   deepseek: "Deepseek",
   fireworks: "Fireworks",
   xai: "xAI",
+  noop: "noop",
 };
 
 interface ProviderManagementModalProps {

--- a/front/lib/api/assistant/global_agents/configurations/dust/noop.ts
+++ b/front/lib/api/assistant/global_agents/configurations/dust/noop.ts
@@ -1,0 +1,34 @@
+import { _getDefaultWebActionsForGlobalAgent } from "@app/lib/api/assistant/global_agents/tools";
+import type { AgentConfigurationType } from "@app/types";
+import { MAX_STEPS_USE_PER_RUN_LIMIT } from "@app/types";
+import { GLOBAL_AGENTS_SID, NOOP_MODEL_CONFIG } from "@app/types";
+
+export function _getNoopAgent(): AgentConfigurationType | null {
+  return {
+    id: -1,
+    sId: GLOBAL_AGENTS_SID.NOOP,
+    version: 0,
+    versionCreatedAt: null,
+    versionAuthorId: null,
+    name: "noop",
+    description: NOOP_MODEL_CONFIG.description,
+    instructions: "",
+    pictureUrl: "https://dust.tt/static/systemavatar/dust_avatar_full.png",
+    status: "active",
+    scope: "global",
+    userFavorite: false,
+    model: {
+      providerId: NOOP_MODEL_CONFIG.providerId,
+      modelId: NOOP_MODEL_CONFIG.modelId,
+      temperature: 0.7,
+    },
+    actions: [],
+    maxStepsPerRun: MAX_STEPS_USE_PER_RUN_LIMIT,
+    visualizationEnabled: false,
+    templateId: null,
+    requestedGroupIds: [],
+    tags: [],
+    canRead: true,
+    canEdit: false,
+  };
+}

--- a/front/lib/api/assistant/global_agents/global_agent_metadata.ts
+++ b/front/lib/api/assistant/global_agents/global_agent_metadata.ts
@@ -293,6 +293,14 @@ export function getGlobalAgentMetadata(sId: GLOBAL_AGENTS_SID): AgentMetadata {
         pictureUrl:
           "https://dust.tt/static/systemavatar/dust-task_avatar_full.png",
       };
+    case GLOBAL_AGENTS_SID.NOOP:
+      return {
+        sId: GLOBAL_AGENTS_SID.NOOP,
+        name: "noop",
+        description: "A no-op agent that does nothing.",
+        pictureUrl:
+          "https://dust.tt/static/systemavatar/dust-task_avatar_full.png",
+      };
     default:
       assertNever(sId);
   }

--- a/front/lib/api/assistant/global_agents/global_agents.ts
+++ b/front/lib/api/assistant/global_agents/global_agents.ts
@@ -16,6 +16,7 @@ import {
   _getDustTaskGlobalAgent,
   _getPlanningAgent,
 } from "@app/lib/api/assistant/global_agents/configurations/dust/dust-deep";
+import { _getNoopAgent } from "@app/lib/api/assistant/global_agents/configurations/dust/noop";
 import { _getGeminiProGlobalAgent } from "@app/lib/api/assistant/global_agents/configurations/google";
 import {
   _getHelperGlobalAgent,
@@ -57,6 +58,7 @@ import type {
   AgentFetchVariant,
   GlobalAgentStatus,
 } from "@app/types";
+import { isDevelopment } from "@app/types";
 import {
   GLOBAL_AGENTS_SID,
   isGlobalAgentId,
@@ -343,6 +345,13 @@ function getGlobalAgent({
         settings,
       });
       break;
+    case GLOBAL_AGENTS_SID.NOOP:
+      // we want only to have it in development
+      if (isDevelopment()) {
+        agentConfiguration = _getNoopAgent();
+        break;
+      }
+      return null;
     default:
       return null;
   }

--- a/front/lib/api/assistant/token_pricing.ts
+++ b/front/lib/api/assistant/token_pricing.ts
@@ -240,6 +240,10 @@ const CURRENT_MODEL_PRICING: Record<BaseModelIdType, PricingEntry> = {
     input: 2.0,
     output: 10.0,
   },
+  noop: {
+    input: 0,
+    output: 0,
+  },
 };
 
 // Pricing for legacy/deprecated models that are no longer in BaseModelIdType.

--- a/front/types/assistant/assistant.ts
+++ b/front/types/assistant/assistant.ts
@@ -20,6 +20,7 @@ export const MODEL_PROVIDER_IDS = [
   "deepseek",
   "fireworks",
   "xai",
+  "noop",
 ] as const;
 export type ModelProviderIdType = (typeof MODEL_PROVIDER_IDS)[number];
 
@@ -43,6 +44,8 @@ export function getProviderDisplayName(
       return "Fireworks";
     case "xai":
       return "xAI";
+    case "noop":
+      return "noop";
     default:
       return providerId;
   }
@@ -239,6 +242,8 @@ export const GROK_3_FAST_MODEL_ID = "grok-3-fast-latest" as const;
 export const GROK_3_MINI_FAST_MODEL_ID = "grok-3-mini-fast-latest" as const;
 export const GROK_4_MODEL_ID = "grok-4-latest" as const;
 
+export const NOOP_MODEL_ID = "noop" as const;
+
 export const MODEL_IDS = [
   GPT_3_5_TURBO_MODEL_ID,
   GPT_4_TURBO_MODEL_ID,
@@ -297,6 +302,7 @@ export const MODEL_IDS = [
   GROK_3_FAST_MODEL_ID,
   GROK_3_MINI_FAST_MODEL_ID,
   GROK_4_MODEL_ID,
+  NOOP_MODEL_ID,
 ] as const;
 export type ModelIdType = (typeof MODEL_IDS)[number];
 
@@ -1586,6 +1592,27 @@ export const GROK_4_MODEL_CONFIG: ModelConfigurationType = {
   featureFlag: "xai_feature",
 };
 
+export const NOOP_MODEL_CONFIG: ModelConfigurationType = {
+  providerId: "noop",
+  modelId: NOOP_MODEL_ID,
+  displayName: "Noop",
+  contextSize: 1_000_000,
+  recommendedTopK: 64,
+  recommendedExhaustiveTopK: 64,
+  largeModel: true,
+  description: "Noop model that does nothing.",
+  shortDescription: "Noop model.",
+  isLegacy: false,
+  isLatest: true,
+  generationTokensCount: 64_000,
+  supportsVision: false,
+  minimumReasoningEffort: "none",
+  maximumReasoningEffort: "none",
+  defaultReasoningEffort: "none",
+  supportsResponseFormat: false,
+  featureFlag: "noop_model_feature",
+};
+
 export const SUPPORTED_MODEL_CONFIGS: ModelConfigurationType[] = [
   GPT_3_5_TURBO_MODEL_CONFIG,
   GPT_4_TURBO_MODEL_CONFIG,
@@ -1643,6 +1670,7 @@ export const SUPPORTED_MODEL_CONFIGS: ModelConfigurationType[] = [
   GROK_3_FAST_MODEL_CONFIG,
   GROK_3_MINI_FAST_MODEL_CONFIG,
   GROK_4_MODEL_CONFIG,
+  NOOP_MODEL_CONFIG,
 ];
 
 export type ModelConfig = (typeof SUPPORTED_MODEL_CONFIGS)[number];
@@ -1719,6 +1747,8 @@ export enum GLOBAL_AGENTS_SID {
   MISTRAL_SMALL = "mistral",
   GEMINI_PRO = "gemini-pro",
   DEEPSEEK_R1 = "deepseek-r1",
+
+  NOOP = "noop",
 }
 
 export function isGlobalAgentId(sId: string): sId is GLOBAL_AGENTS_SID {
@@ -1754,6 +1784,8 @@ export function getGlobalAgentAuthorName(agentId: string): string {
       return "Google";
     case GLOBAL_AGENTS_SID.DEEPSEEK_R1:
       return "DeepSeek";
+    case GLOBAL_AGENTS_SID.NOOP:
+      return "Noop";
     default:
       return "Dust";
   }
@@ -1782,6 +1814,7 @@ const CUSTOM_ORDER: string[] = [
   GLOBAL_AGENTS_SID.MISTRAL_SMALL,
   GLOBAL_AGENTS_SID.GEMINI_PRO,
   GLOBAL_AGENTS_SID.HELPER,
+  GLOBAL_AGENTS_SID.NOOP,
 ];
 
 // This function implements our general strategy to sort agents to users (input bar, agent list,

--- a/front/types/shared/feature_flags.ts
+++ b/front/types/shared/feature_flags.ts
@@ -131,6 +131,10 @@ export const WHITELISTABLE_FEATURES_CONFIG = {
     description: "Access to xAI models in the agent builder",
     stage: "on_demand",
   },
+  noop_model_feature: {
+    description: "Access to noop model in the agent builder",
+    stage: "dust_only",
+  },
   monday_tool: {
     description: "Monday MCP tool",
     stage: "rolling_out",

--- a/sdks/js/src/types.ts
+++ b/sdks/js/src/types.ts
@@ -30,6 +30,7 @@ const ModelProviderIdSchema = FlexibleEnumSchema<
   | "deepseek"
   | "fireworks"
   | "xai"
+  | "noop"
 >();
 
 const ModelLLMIdSchema = FlexibleEnumSchema<
@@ -90,6 +91,7 @@ const ModelLLMIdSchema = FlexibleEnumSchema<
   | "grok-3-fast-latest" // xAI
   | "grok-3-mini-fast-latest" // xAI
   | "grok-4-latest" // xAI
+  | "noop" // Noop
 >();
 
 const EmbeddingProviderIdSchema = FlexibleEnumSchema<"openai" | "mistral">();
@@ -685,6 +687,7 @@ const WhitelistableFeaturesSchema = FlexibleEnumSchema<
   | "xai_feature"
   | "simple_audio_transcription"
   | "virtualized_conversations"
+  | "noop_model_feature"
 >();
 
 export type WhitelistableFeature = z.infer<typeof WhitelistableFeaturesSchema>;


### PR DESCRIPTION
## Description

This PR adds 2 things:
* a "noop" LLM model that answers "noop" in `core`. It's behind a feature flag in `front`
* an agent only available in DEV that uses this model

Why? 2 reasons:
* we can have an ultra fast agent when developing locally, and it doesn't require an internet connection
* it was a good way to understand how the LLM layer worked in core

How to have it locally:
* enable the feature flag `noop_model_feature` on your workspace
* use local core and dust apps

## Tests

Locally

https://github.com/user-attachments/assets/4c6a0ae0-499e-4c25-ad48-afe4573886e1


## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
