### PR TITLE
Add CTA tracking in solutions/industry pages

### DIFF
--- a/front/components/home/content/Industry/IndustryTemplate.tsx
+++ b/front/components/home/content/Industry/IndustryTemplate.tsx
@@ -8,6 +8,7 @@ import { Grid, H1, H2, H3, P } from "@app/components/home/ContentComponents";
 import type { LandingLayoutProps } from "@app/components/home/LandingLayout";
 import LandingLayout from "@app/components/home/LandingLayout";
 import TrustedBy from "@app/components/home/TrustedBy";
+import { TRACKING_AREAS, withTracking } from "@app/lib/tracking";
 import { classNames } from "@app/lib/utils";
 
 import type { IndustryPageConfig, SectionType } from "./configs/utils";
@@ -23,13 +24,16 @@ const GRID_SECTION_CLASSES = classNames(
 
 interface IndustryTemplateProps {
   config: IndustryPageConfig;
+  trackingPrefix?: string;
 }
 
 // Hero Section Component
 const HeroSection = ({
   config,
+  trackingPrefix,
 }: {
   config: NonNullable<IndustryPageConfig["hero"]>;
+  trackingPrefix?: string;
 }) => (
   <div className="container flex w-full flex-col px-6 pt-8 md:px-4 md:pt-24">
     <Grid className="gap-x-4 lg:gap-x-8">
@@ -58,6 +62,10 @@ const HeroSection = ({
               size="md"
               label={config.ctaButtons.primary.label}
               className="w-full sm:w-auto"
+              onClick={withTracking(
+                TRACKING_AREAS.INDUSTRY,
+                `${trackingPrefix || "default"}_hero_cta_primary`
+              )}
             />
           </Link>
           <Button
@@ -66,6 +74,10 @@ const HeroSection = ({
             label={config.ctaButtons.secondary.label}
             href={config.ctaButtons.secondary.href}
             className="w-full sm:w-auto"
+            onClick={withTracking(
+              TRACKING_AREAS.INDUSTRY,
+              `${trackingPrefix || "default"}_hero_cta_secondary`
+            )}
           />
         </div>
       </div>
@@ -420,8 +432,10 @@ const TestimonialSection = ({
 // Just Use Dust Section Component
 const JustUseDustSection = ({
   config,
+  trackingPrefix,
 }: {
   config: NonNullable<IndustryPageConfig["justUseDust"]>;
+  trackingPrefix?: string;
 }) => (
   <div
     className={classNames(
@@ -457,6 +471,10 @@ const JustUseDustSection = ({
               size="md"
               label={config.ctaButtons.primary.label}
               className="w-full sm:w-auto"
+              onClick={withTracking(
+                TRACKING_AREAS.INDUSTRY,
+                `${trackingPrefix || "default"}_footer_cta_primary`
+              )}
             />
           </Link>
           <Link href={config.ctaButtons.secondary.href} passHref legacyBehavior>
@@ -465,6 +483,10 @@ const JustUseDustSection = ({
               size="md"
               label={config.ctaButtons.secondary.label}
               className="w-full sm:w-auto"
+              onClick={withTracking(
+                TRACKING_AREAS.INDUSTRY,
+                `${trackingPrefix || "default"}_footer_cta_secondary`
+              )}
             />
           </Link>
         </div>
@@ -474,7 +496,10 @@ const JustUseDustSection = ({
 );
 
 // Main Industry Template Component
-export default function IndustryTemplate({ config }: IndustryTemplateProps) {
+export default function IndustryTemplate({
+  config,
+  trackingPrefix,
+}: IndustryTemplateProps) {
   // Get the list of enabled sections in the specified order
   const enabledSections = getEnabledSections(config.layout);
 
@@ -483,7 +508,11 @@ export default function IndustryTemplate({ config }: IndustryTemplateProps) {
     switch (sectionType) {
       case "hero":
         return config.hero ? (
-          <HeroSection key="hero" config={config.hero} />
+          <HeroSection
+            key="hero"
+            config={config.hero}
+            trackingPrefix={trackingPrefix}
+          />
         ) : null;
 
       case "aiAgents":
@@ -563,7 +592,11 @@ export default function IndustryTemplate({ config }: IndustryTemplateProps) {
 
       case "justUseDust":
         return config.justUseDust ? (
-          <JustUseDustSection key="justUseDust" config={config.justUseDust} />
+          <JustUseDustSection
+            key="justUseDust"
+            config={config.justUseDust}
+            trackingPrefix={trackingPrefix}
+          />
         ) : null;
 
       default:

--- a/front/components/home/content/Industry/IndustryTemplate.tsx
+++ b/front/components/home/content/Industry/IndustryTemplate.tsx
@@ -64,7 +64,7 @@ const HeroSection = ({
               className="w-full sm:w-auto"
               onClick={withTracking(
                 TRACKING_AREAS.INDUSTRY,
-                `${trackingPrefix || "default"}_hero_cta_primary`
+                `${trackingPrefix ?? "default"}_hero_cta_primary`
               )}
             />
           </Link>
@@ -76,7 +76,7 @@ const HeroSection = ({
             className="w-full sm:w-auto"
             onClick={withTracking(
               TRACKING_AREAS.INDUSTRY,
-              `${trackingPrefix || "default"}_hero_cta_secondary`
+              `${trackingPrefix ?? "default"}_hero_cta_secondary`
             )}
           />
         </div>
@@ -473,7 +473,7 @@ const JustUseDustSection = ({
               className="w-full sm:w-auto"
               onClick={withTracking(
                 TRACKING_AREAS.INDUSTRY,
-                `${trackingPrefix || "default"}_footer_cta_primary`
+                `${trackingPrefix ?? "default"}_footer_cta_primary`
               )}
             />
           </Link>
@@ -485,7 +485,7 @@ const JustUseDustSection = ({
               className="w-full sm:w-auto"
               onClick={withTracking(
                 TRACKING_AREAS.INDUSTRY,
-                `${trackingPrefix || "default"}_footer_cta_secondary`
+                `${trackingPrefix ?? "default"}_footer_cta_secondary`
               )}
             />
           </Link>

--- a/front/components/home/content/Solutions/HeroSection.tsx
+++ b/front/components/home/content/Solutions/HeroSection.tsx
@@ -3,6 +3,7 @@ import Link from "next/link";
 import type { FC } from "react";
 
 import { Grid, H1, H3, P } from "@app/components/home/ContentComponents";
+import { TRACKING_AREAS, withTracking } from "@app/lib/tracking";
 
 interface Visual {
   src: string;
@@ -26,6 +27,7 @@ interface HeroSectionProps {
       href: string;
     };
   };
+  trackingPrefix?: string;
 }
 
 export const HeroSection: FC<HeroSectionProps> = ({
@@ -35,6 +37,7 @@ export const HeroSection: FC<HeroSectionProps> = ({
   visuals,
   accentColor = "text-brand-hunter-green",
   ctaButtons,
+  trackingPrefix = "hero",
 }) => {
   const MainVisual = () => (
     <Hover3D depth={-40} perspective={1000} className="relative">
@@ -73,6 +76,10 @@ export const HeroSection: FC<HeroSectionProps> = ({
                     size="md"
                     label={ctaButtons.primary.label}
                     icon={RocketIcon}
+                    onClick={withTracking(
+                      TRACKING_AREAS.SOLUTIONS,
+                      `${trackingPrefix}_cta_primary`
+                    )}
                   />
                 </Link>
               )}
@@ -82,6 +89,10 @@ export const HeroSection: FC<HeroSectionProps> = ({
                     variant="outline"
                     size="md"
                     label={ctaButtons.secondary.label}
+                    onClick={withTracking(
+                      TRACKING_AREAS.SOLUTIONS,
+                      `${trackingPrefix}_cta_secondary`
+                    )}
                   />
                 </Link>
               )}

--- a/front/lib/tracking.ts
+++ b/front/lib/tracking.ts
@@ -30,6 +30,8 @@ export const TRACKING_AREAS = {
   PRICING: "pricing",
   AUTH: "auth",
   NAVIGATION: "navigation",
+  SOLUTIONS: "solutions",
+  INDUSTRY: "industry",
 
   // Product
   ASSISTANT: "assistant",

--- a/front/pages/home/industry/b2b-saas.tsx
+++ b/front/pages/home/industry/b2b-saas.tsx
@@ -13,7 +13,7 @@ export async function getStaticProps() {
 }
 
 export default function B2BSaaS() {
-  return <IndustryTemplate config={b2bSaasConfig} />;
+  return <IndustryTemplate config={b2bSaasConfig} trackingPrefix="b2b" />;
 }
 
 B2BSaaS.getLayout = (page: ReactElement, pageProps: LandingLayoutProps) => {

--- a/front/pages/home/industry/consulting.tsx
+++ b/front/pages/home/industry/consulting.tsx
@@ -13,7 +13,9 @@ export async function getStaticProps() {
 }
 
 export default function ConsultingFirms() {
-  return <IndustryTemplate config={consultingConfig} />;
+  return (
+    <IndustryTemplate config={consultingConfig} trackingPrefix="consulting" />
+  );
 }
 
 ConsultingFirms.getLayout = (

--- a/front/pages/home/industry/energy-utilities.tsx
+++ b/front/pages/home/industry/energy-utilities.tsx
@@ -13,7 +13,7 @@ export async function getStaticProps() {
 }
 
 export default function EnergyUtilities() {
-  return <IndustryTemplate config={energyConfig} />;
+  return <IndustryTemplate config={energyConfig} trackingPrefix="energy" />;
 }
 
 EnergyUtilities.getLayout = (

--- a/front/pages/home/industry/financial-services.tsx
+++ b/front/pages/home/industry/financial-services.tsx
@@ -13,7 +13,12 @@ export async function getStaticProps() {
 }
 
 export default function FinancialServices() {
-  return <IndustryTemplate config={financialServicesConfig} />;
+  return (
+    <IndustryTemplate
+      config={financialServicesConfig}
+      trackingPrefix="financial"
+    />
+  );
 }
 
 FinancialServices.getLayout = (

--- a/front/pages/home/industry/industrial-manufacturing.tsx
+++ b/front/pages/home/industry/industrial-manufacturing.tsx
@@ -13,7 +13,12 @@ export async function getStaticProps() {
 }
 
 export default function IndustrialFirms() {
-  return <IndustryTemplate config={industrialFirmsConfig} />;
+  return (
+    <IndustryTemplate
+      config={industrialFirmsConfig}
+      trackingPrefix="manufacturing"
+    />
+  );
 }
 
 IndustrialFirms.getLayout = (

--- a/front/pages/home/industry/insurance.tsx
+++ b/front/pages/home/industry/insurance.tsx
@@ -13,7 +13,9 @@ export async function getStaticProps() {
 }
 
 export default function Insurance() {
-  return <IndustryTemplate config={insuranceConfig} />;
+  return (
+    <IndustryTemplate config={insuranceConfig} trackingPrefix="insurance" />
+  );
 }
 
 Insurance.getLayout = (page: ReactElement, pageProps: LandingLayoutProps) => {

--- a/front/pages/home/industry/investment-firms.tsx
+++ b/front/pages/home/industry/investment-firms.tsx
@@ -13,7 +13,9 @@ export async function getStaticProps() {
 }
 
 export default function InvestmentFirms() {
-  return <IndustryTemplate config={investmentConfig} />;
+  return (
+    <IndustryTemplate config={investmentConfig} trackingPrefix="investment" />
+  );
 }
 
 InvestmentFirms.getLayout = (

--- a/front/pages/home/industry/marketplace.tsx
+++ b/front/pages/home/industry/marketplace.tsx
@@ -13,7 +13,9 @@ export async function getStaticProps() {
 }
 
 export default function Marketplace() {
-  return <IndustryTemplate config={marketplaceConfig} />;
+  return (
+    <IndustryTemplate config={marketplaceConfig} trackingPrefix="marketplace" />
+  );
 }
 
 Marketplace.getLayout = (page: ReactElement, pageProps: LandingLayoutProps) => {

--- a/front/pages/home/industry/media.tsx
+++ b/front/pages/home/industry/media.tsx
@@ -13,7 +13,7 @@ export async function getStaticProps() {
 }
 
 export default function Media() {
-  return <IndustryTemplate config={mediaConfig} />;
+  return <IndustryTemplate config={mediaConfig} trackingPrefix="media" />;
 }
 
 Media.getLayout = (page: ReactElement, pageProps: LandingLayoutProps) => {

--- a/front/pages/home/industry/retail-ecommerce.tsx
+++ b/front/pages/home/industry/retail-ecommerce.tsx
@@ -13,7 +13,9 @@ export async function getStaticProps() {
 }
 
 export default function RetailEcommerce() {
-  return <IndustryTemplate config={retailEcommerceConfig} />;
+  return (
+    <IndustryTemplate config={retailEcommerceConfig} trackingPrefix="retail" />
+  );
 }
 
 RetailEcommerce.getLayout = (

--- a/front/pages/home/solutions/customer-support.tsx
+++ b/front/pages/home/solutions/customer-support.tsx
@@ -29,6 +29,7 @@ import {
   shapeNames,
 } from "@app/components/home/Particles";
 import TrustedBy from "@app/components/home/TrustedBy";
+import { TRACKING_AREAS, withTracking } from "@app/lib/tracking";
 import { classNames } from "@app/lib/utils";
 
 export async function getStaticProps() {
@@ -52,7 +53,11 @@ export default function CustomerSupport() {
   return (
     <>
       <div className="container flex w-full flex-col gap-16 px-2 py-2 pb-12">
-        <HeroSection {...Hero} accentColor={pageSettings.accentColor} />
+        <HeroSection
+          {...Hero}
+          accentColor={pageSettings.accentColor}
+          trackingPrefix="support_hero"
+        />
         <Grid>
           <div className={GRID_SECTION_CLASSES}>
             <BenefitsSection benefits={Benefits} />
@@ -86,6 +91,10 @@ export default function CustomerSupport() {
                       size="md"
                       label={Hero.ctaButtons.primary.label}
                       icon={Hero.ctaButtons.primary.icon}
+                      onClick={withTracking(
+                        TRACKING_AREAS.SOLUTIONS,
+                        "support_footer_cta_primary"
+                      )}
                     />
                   </Link>
                 )}
@@ -95,6 +104,10 @@ export default function CustomerSupport() {
                     size="md"
                     label={Hero.ctaButtons.secondary.label}
                     href={Hero.ctaButtons.secondary.href}
+                    onClick={withTracking(
+                      TRACKING_AREAS.SOLUTIONS,
+                      "support_footer_cta_secondary"
+                    )}
                   />
                 )}
               </div>

--- a/front/pages/home/solutions/data-analytics.tsx
+++ b/front/pages/home/solutions/data-analytics.tsx
@@ -25,6 +25,7 @@ import {
   shapeNames,
 } from "@app/components/home/Particles";
 import TrustedBy from "@app/components/home/TrustedBy";
+import { TRACKING_AREAS, withTracking } from "@app/lib/tracking";
 import { classNames } from "@app/lib/utils";
 
 export async function getStaticProps() {
@@ -48,7 +49,11 @@ export default function Data() {
   return (
     <>
       <div className="container flex w-full flex-col gap-16 px-2 py-2 pb-12">
-        <HeroSection {...Hero} accentColor={pageSettings.accentColor} />
+        <HeroSection
+          {...Hero}
+          accentColor={pageSettings.accentColor}
+          trackingPrefix="data_hero"
+        />
         <Grid>
           <div className={GRID_SECTION_CLASSES}>
             <BenefitsSection benefits={Benefits} />
@@ -77,6 +82,10 @@ export default function Data() {
                       size="md"
                       label={Hero.ctaButtons.primary.label}
                       icon={Hero.ctaButtons.primary.icon}
+                      onClick={withTracking(
+                        TRACKING_AREAS.SOLUTIONS,
+                        "data_footer_cta_primary"
+                      )}
                     />
                   </Link>
                 )}
@@ -86,6 +95,10 @@ export default function Data() {
                     size="md"
                     label={Hero.ctaButtons.secondary.label}
                     href={Hero.ctaButtons.secondary.href}
+                    onClick={withTracking(
+                      TRACKING_AREAS.SOLUTIONS,
+                      "data_footer_cta_secondary"
+                    )}
                   />
                 )}
               </div>

--- a/front/pages/home/solutions/dust-platform.tsx
+++ b/front/pages/home/solutions/dust-platform.tsx
@@ -14,6 +14,7 @@ import {
   getParticleShapeIndexByName,
   shapeNames,
 } from "@app/components/home/Particles";
+import { TRACKING_AREAS, withTracking } from "@app/lib/tracking";
 import { classNames } from "@app/lib/utils";
 
 export async function getStaticProps() {
@@ -146,7 +147,15 @@ export default function DustPlatform() {
       >
         <div className="mt-4 flex justify-center gap-4">
           <Link href="/home/contact" shallow={true}>
-            <Button variant="outline" size="md" label="Request a demo" />
+            <Button
+              variant="outline"
+              size="md"
+              label="Request a demo"
+              onClick={withTracking(
+                TRACKING_AREAS.SOLUTIONS,
+                "platform_footer_cta_secondary"
+              )}
+            />
           </Link>
 
           <Link href="/home/pricing" shallow={true}>
@@ -155,6 +164,10 @@ export default function DustPlatform() {
               size="md"
               label="Try Dust now"
               icon={RocketIcon}
+              onClick={withTracking(
+                TRACKING_AREAS.SOLUTIONS,
+                "platform_footer_cta_primary"
+              )}
             />
           </Link>
         </div>

--- a/front/pages/home/solutions/engineering.tsx
+++ b/front/pages/home/solutions/engineering.tsx
@@ -29,6 +29,7 @@ import {
   shapeNames,
 } from "@app/components/home/Particles";
 import TrustedBy from "@app/components/home/TrustedBy";
+import { TRACKING_AREAS, withTracking } from "@app/lib/tracking";
 import { classNames } from "@app/lib/utils";
 
 export async function getStaticProps() {
@@ -52,7 +53,11 @@ export default function Engineering() {
   return (
     <>
       <div className="container flex w-full flex-col gap-16 px-2 py-2 pb-12">
-        <HeroSection {...Hero} accentColor={pageSettings.accentColor} />
+        <HeroSection
+          {...Hero}
+          accentColor={pageSettings.accentColor}
+          trackingPrefix="engineering_hero"
+        />
         <Grid>
           <div className={GRID_SECTION_CLASSES}>
             <BenefitsSection benefits={Benefits} />
@@ -86,6 +91,10 @@ export default function Engineering() {
                       size="md"
                       label={Hero.ctaButtons.primary.label}
                       icon={Hero.ctaButtons.primary.icon}
+                      onClick={withTracking(
+                        TRACKING_AREAS.SOLUTIONS,
+                        "engineering_footer_cta_primary"
+                      )}
                     />
                   </Link>
                 )}
@@ -95,6 +104,10 @@ export default function Engineering() {
                     size="md"
                     label={Hero.ctaButtons.secondary.label}
                     href={Hero.ctaButtons.secondary.href}
+                    onClick={withTracking(
+                      TRACKING_AREAS.SOLUTIONS,
+                      "engineering_footer_cta_secondary"
+                    )}
                   />
                 )}
               </div>

--- a/front/pages/home/solutions/it.tsx
+++ b/front/pages/home/solutions/it.tsx
@@ -27,6 +27,7 @@ import {
   shapeNames,
 } from "@app/components/home/Particles";
 import TrustedBy from "@app/components/home/TrustedBy";
+import { TRACKING_AREAS, withTracking } from "@app/lib/tracking";
 import { classNames } from "@app/lib/utils";
 
 export async function getStaticProps() {
@@ -50,7 +51,11 @@ export default function IT() {
   return (
     <>
       <div className="container flex w-full flex-col gap-16 px-2 py-2 pb-12">
-        <HeroSection {...Hero} accentColor={pageSettings.accentColor} />
+        <HeroSection
+          {...Hero}
+          accentColor={pageSettings.accentColor}
+          trackingPrefix="it_hero"
+        />
         <Grid>
           <div className={GRID_SECTION_CLASSES}>
             <BenefitsSection benefits={Benefits} />
@@ -82,6 +87,10 @@ export default function IT() {
                       size="md"
                       label={Hero.ctaButtons.primary.label}
                       icon={Hero.ctaButtons.primary.icon}
+                      onClick={withTracking(
+                        TRACKING_AREAS.SOLUTIONS,
+                        "it_footer_cta_primary"
+                      )}
                     />
                   </Link>
                 )}
@@ -91,6 +100,10 @@ export default function IT() {
                     size="md"
                     label={Hero.ctaButtons.secondary.label}
                     href={Hero.ctaButtons.secondary.href}
+                    onClick={withTracking(
+                      TRACKING_AREAS.SOLUTIONS,
+                      "it_footer_cta_secondary"
+                    )}
                   />
                 )}
               </div>

--- a/front/pages/home/solutions/knowledge.tsx
+++ b/front/pages/home/solutions/knowledge.tsx
@@ -29,6 +29,7 @@ import {
   shapeNames,
 } from "@app/components/home/Particles";
 import TrustedBy from "@app/components/home/TrustedBy";
+import { TRACKING_AREAS, withTracking } from "@app/lib/tracking";
 import { classNames } from "@app/lib/utils";
 
 export async function getStaticProps() {
@@ -52,7 +53,11 @@ export default function Knowledge() {
   return (
     <>
       <div className="container flex w-full flex-col gap-16 px-2 py-2 pb-12">
-        <HeroSection {...Hero} accentColor={pageSettings.accentColor} />
+        <HeroSection
+          {...Hero}
+          accentColor={pageSettings.accentColor}
+          trackingPrefix="knowledge_hero"
+        />
         <Grid>
           <div className={GRID_SECTION_CLASSES}>
             <BenefitsSection benefits={Benefits} />
@@ -86,6 +91,10 @@ export default function Knowledge() {
                       size="md"
                       label={Hero.ctaButtons.primary.label}
                       icon={Hero.ctaButtons.primary.icon}
+                      onClick={withTracking(
+                        TRACKING_AREAS.SOLUTIONS,
+                        "knowledge_footer_cta_primary"
+                      )}
                     />
                   </Link>
                 )}
@@ -95,6 +104,10 @@ export default function Knowledge() {
                     size="md"
                     label={Hero.ctaButtons.secondary.label}
                     href={Hero.ctaButtons.secondary.href}
+                    onClick={withTracking(
+                      TRACKING_AREAS.SOLUTIONS,
+                      "knowledge_footer_cta_secondary"
+                    )}
                   />
                 )}
               </div>

--- a/front/pages/home/solutions/legal.tsx
+++ b/front/pages/home/solutions/legal.tsx
@@ -29,6 +29,7 @@ import {
   shapeNames,
 } from "@app/components/home/Particles";
 import TrustedBy from "@app/components/home/TrustedBy";
+import { TRACKING_AREAS, withTracking } from "@app/lib/tracking";
 import { classNames } from "@app/lib/utils";
 
 export async function getStaticProps() {
@@ -52,7 +53,11 @@ export default function Legal() {
   return (
     <>
       <div className="container flex w-full flex-col gap-16 px-2 py-2 pb-12">
-        <HeroSection {...Hero} accentColor={pageSettings.accentColor} />
+        <HeroSection
+          {...Hero}
+          accentColor={pageSettings.accentColor}
+          trackingPrefix="legal_hero"
+        />
         <Grid>
           <div className={GRID_SECTION_CLASSES}>
             <BenefitsSection benefits={Benefits} />
@@ -86,6 +91,10 @@ export default function Legal() {
                       size="md"
                       label={Hero.ctaButtons.primary.label}
                       icon={Hero.ctaButtons.primary.icon}
+                      onClick={withTracking(
+                        TRACKING_AREAS.SOLUTIONS,
+                        "legal_footer_cta_primary"
+                      )}
                     />
                   </Link>
                 )}
@@ -95,6 +104,10 @@ export default function Legal() {
                     size="md"
                     label={Hero.ctaButtons.secondary.label}
                     href={Hero.ctaButtons.secondary.href}
+                    onClick={withTracking(
+                      TRACKING_AREAS.SOLUTIONS,
+                      "legal_footer_cta_secondary"
+                    )}
                   />
                 )}
               </div>

--- a/front/pages/home/solutions/marketing.tsx
+++ b/front/pages/home/solutions/marketing.tsx
@@ -29,6 +29,7 @@ import {
   shapeNames,
 } from "@app/components/home/Particles";
 import TrustedBy from "@app/components/home/TrustedBy";
+import { TRACKING_AREAS, withTracking } from "@app/lib/tracking";
 import { classNames } from "@app/lib/utils";
 
 export async function getStaticProps() {
@@ -52,7 +53,11 @@ export default function Marketing() {
   return (
     <>
       <div className="container flex w-full flex-col gap-16 px-2 py-2 pb-12">
-        <HeroSection {...Hero} accentColor={pageSettings.accentColor} />
+        <HeroSection
+          {...Hero}
+          accentColor={pageSettings.accentColor}
+          trackingPrefix="marketing_hero"
+        />
         <Grid>
           <div className={GRID_SECTION_CLASSES}>
             <BenefitsSection benefits={Benefits} />
@@ -86,6 +91,10 @@ export default function Marketing() {
                       size="md"
                       label={Hero.ctaButtons.primary.label}
                       icon={Hero.ctaButtons.primary.icon}
+                      onClick={withTracking(
+                        TRACKING_AREAS.SOLUTIONS,
+                        "marketing_footer_cta_primary"
+                      )}
                     />
                   </Link>
                 )}
@@ -95,6 +104,10 @@ export default function Marketing() {
                     size="md"
                     label={Hero.ctaButtons.secondary.label}
                     href={Hero.ctaButtons.secondary.href}
+                    onClick={withTracking(
+                      TRACKING_AREAS.SOLUTIONS,
+                      "marketing_footer_cta_secondary"
+                    )}
                   />
                 )}
               </div>

--- a/front/pages/home/solutions/productivity.tsx
+++ b/front/pages/home/solutions/productivity.tsx
@@ -29,6 +29,7 @@ import {
   shapeNames,
 } from "@app/components/home/Particles";
 import TrustedBy from "@app/components/home/TrustedBy";
+import { TRACKING_AREAS, withTracking } from "@app/lib/tracking";
 import { classNames } from "@app/lib/utils";
 
 export async function getStaticProps() {
@@ -52,7 +53,11 @@ export default function Productivity() {
   return (
     <>
       <div className="container flex w-full flex-col gap-16 px-2 py-2 pb-12">
-        <HeroSection {...Hero} accentColor={pageSettings.accentColor} />
+        <HeroSection
+          {...Hero}
+          accentColor={pageSettings.accentColor}
+          trackingPrefix="productivity_hero"
+        />
         <Grid>
           <div className={GRID_SECTION_CLASSES}>
             <BenefitsSection benefits={Benefits} />
@@ -86,6 +91,10 @@ export default function Productivity() {
                       size="md"
                       label={Hero.ctaButtons.primary.label}
                       icon={Hero.ctaButtons.primary.icon}
+                      onClick={withTracking(
+                        TRACKING_AREAS.SOLUTIONS,
+                        "productivity_footer_cta_primary"
+                      )}
                     />
                   </Link>
                 )}
@@ -95,6 +104,10 @@ export default function Productivity() {
                     size="md"
                     label={Hero.ctaButtons.secondary.label}
                     href={Hero.ctaButtons.secondary.href}
+                    onClick={withTracking(
+                      TRACKING_AREAS.SOLUTIONS,
+                      "productivity_footer_cta_secondary"
+                    )}
                   />
                 )}
               </div>

--- a/front/pages/home/solutions/recruiting-people.tsx
+++ b/front/pages/home/solutions/recruiting-people.tsx
@@ -29,6 +29,7 @@ import {
   shapeNames,
 } from "@app/components/home/Particles";
 import TrustedBy from "@app/components/home/TrustedBy";
+import { TRACKING_AREAS, withTracking } from "@app/lib/tracking";
 import { classNames } from "@app/lib/utils";
 
 export async function getStaticProps() {
@@ -52,7 +53,11 @@ export default function People() {
   return (
     <>
       <div className="container flex w-full flex-col gap-16 px-2 py-2 pb-12">
-        <HeroSection {...Hero} accentColor={pageSettings.accentColor} />
+        <HeroSection
+          {...Hero}
+          accentColor={pageSettings.accentColor}
+          trackingPrefix="people_hero"
+        />
         <Grid>
           <div className={GRID_SECTION_CLASSES}>
             <BenefitsSection benefits={Benefits} />
@@ -86,6 +91,10 @@ export default function People() {
                       size="md"
                       label={Hero.ctaButtons.primary.label}
                       icon={Hero.ctaButtons.primary.icon}
+                      onClick={withTracking(
+                        TRACKING_AREAS.SOLUTIONS,
+                        "people_footer_cta_primary"
+                      )}
                     />
                   </Link>
                 )}
@@ -95,6 +104,10 @@ export default function People() {
                     size="md"
                     label={Hero.ctaButtons.secondary.label}
                     href={Hero.ctaButtons.secondary.href}
+                    onClick={withTracking(
+                      TRACKING_AREAS.SOLUTIONS,
+                      "people_footer_cta_secondary"
+                    )}
                   />
                 )}
               </div>

--- a/front/pages/home/solutions/sales.tsx
+++ b/front/pages/home/solutions/sales.tsx
@@ -32,6 +32,7 @@ import {
   shapeNames,
 } from "@app/components/home/Particles";
 import TrustedBy from "@app/components/home/TrustedBy";
+import { TRACKING_AREAS, withTracking } from "@app/lib/tracking";
 import { classNames } from "@app/lib/utils";
 
 export async function getStaticProps() {
@@ -65,7 +66,11 @@ export default function Sales() {
         />
       </Head>
       <div className="container flex w-full flex-col gap-16 px-2 py-2 pb-12">
-        <HeroSection {...Hero} accentColor={pageSettings.accentColor} />
+        <HeroSection
+          {...Hero}
+          accentColor={pageSettings.accentColor}
+          trackingPrefix="sales_hero"
+        />
         <Grid>
           <div className={GRID_SECTION_CLASSES}>
             <BenefitsSection benefits={Benefits} />
@@ -102,6 +107,10 @@ export default function Sales() {
                       size="md"
                       label={Hero.ctaButtons.primary.label}
                       icon={Hero.ctaButtons.primary.icon}
+                      onClick={withTracking(
+                        TRACKING_AREAS.SOLUTIONS,
+                        "sales_footer_cta_primary"
+                      )}
                     />
                   </Link>
                 )}
@@ -111,6 +120,10 @@ export default function Sales() {
                     size="md"
                     label={Hero.ctaButtons.secondary.label}
                     href={Hero.ctaButtons.secondary.href}
+                    onClick={withTracking(
+                      TRACKING_AREAS.SOLUTIONS,
+                      "sales_footer_cta_secondary"
+                    )}
                   />
                 )}
               </div>


### PR DESCRIPTION







## Description
Adds comprehensive CTA tracking across solutions and industry pages to measure conversion funnel performance. Implements `withTracking` click handlers on primary and secondary CTA buttons throughout the marketing website, using the new PostHog analytics infrastructure. Each page receives unique tracking prefixes (e.g., "support_hero", "b2b_footer") to differentiate button clicks across different sections and page types. Also adds new `SOLUTIONS` and `INDUSTRY` tracking areas to the existing tracking taxonomy.

## Risk
Low risk - only adds click event tracking without modifying existing functionality. The tracking calls are non-blocking and will fail gracefully if PostHog is not loaded.

## Deploy Plan
No special deployment steps required. The tracking will begin collecting data once deployed.
