### PR TITLE
[front] - fix(triggers): configuration sheet

### DIFF
--- a/front/components/spaces/SystemSpaceTriggersList.tsx
+++ b/front/components/spaces/SystemSpaceTriggersList.tsx
@@ -23,6 +23,7 @@ export const SystemSpaceTriggersList = ({
   const [selectedWebhookSourceId, setSelectedWebhookSourceId] = useState<
     string | null
   >(null);
+  const [isDetailsOpen, setIsDetailsOpen] = useState(false);
   const [agentSId, setAgentSId] = useState<string | null>(null);
 
   const { webhookSourcesWithViews, isWebhookSourcesWithViewsLoading } =
@@ -55,10 +56,23 @@ export const SystemSpaceTriggersList = ({
     return webhookSource;
   }, [webhookSourcesWithSystemView, selectedWebhookSourceId]);
 
-  const selectedSystemView = selectedWebhookSource?.systemView ?? null;
-
   const { q: searchParam } = useQueryParams(["q"]);
   const searchTerm = searchParam.value ?? "";
+
+  const handleClose = () => {
+    setIsDetailsOpen(false);
+  };
+
+  const handleSetSelectedWebhookSourceId = (
+    action: string | null | ((prev: string | null) => string | null)
+  ) => {
+    const newId =
+      typeof action === "function" ? action(selectedWebhookSourceId) : action;
+    setSelectedWebhookSourceId(newId);
+    if (newId !== null) {
+      setIsDetailsOpen(true);
+    }
+  };
 
   if (!isAdmin) {
     return null;
@@ -76,14 +90,14 @@ export const SystemSpaceTriggersList = ({
         <WebhookSourceDetails
           owner={owner}
           webhookSource={selectedWebhookSource}
-          onClose={() => setSelectedWebhookSourceId(null)}
-          isOpen={selectedSystemView !== null}
+          onClose={handleClose}
+          isOpen={isDetailsOpen}
         />
       )}
       <AdminTriggersList
         owner={owner}
         filter={searchTerm}
-        setSelectedWebhookSourceId={setSelectedWebhookSourceId}
+        setSelectedWebhookSourceId={handleSetSelectedWebhookSourceId}
         webhookSourcesWithSystemView={webhookSourcesWithSystemView}
         isWebhookSourcesWithViewsLoading={isWebhookSourcesWithViewsLoading}
         setAgentSId={setAgentSId}

--- a/front/components/triggers/WebhookSourceDetails.tsx
+++ b/front/components/triggers/WebhookSourceDetails.tsx
@@ -94,7 +94,7 @@ export function WebhookSourceDetails({
 
   useEffect(() => {
     form.reset(defaults);
-  }, [systemView.sId]);
+  }, [defaults, form]);
 
   useEffect(() => {
     if (isOpen && !prevIsOpen) {
@@ -211,11 +211,6 @@ export function WebhookSourceDetails({
       },
       async (errors) => {
         const keys = Object.keys(errors);
-        const firstErrorKey = keys[0] as keyof typeof errors | undefined;
-        if (firstErrorKey) {
-          form.setFocus(firstErrorKey as any);
-        }
-
         const errorDetails = keys
           .map((key) => {
             const error = errors[key as keyof typeof errors];

--- a/front/components/triggers/WebhookSourceDetails.tsx
+++ b/front/components/triggers/WebhookSourceDetails.tsx
@@ -253,22 +253,6 @@ export function WebhookSourceDetails({
     setSelectedTab(next);
   };
 
-  const header = useMemo(() => {
-    return (
-      <div className="flex items-center gap-3">
-        <Avatar icon={ActionGlobeAltIcon} size="md" />
-        <div>
-          <SheetTitle>
-            {systemView.customName ?? systemView.webhookSource.name}
-          </SheetTitle>
-          <SheetDescription>
-            Webhook source for triggering assistants.
-          </SheetDescription>
-        </div>
-      </div>
-    );
-  }, [systemView]);
-
   const handleOpenChange = async (open: boolean) => {
     if (open) {
       return;
@@ -298,7 +282,17 @@ export function WebhookSourceDetails({
       <Sheet open={isOpen} onOpenChange={(open) => void handleOpenChange(open)}>
         <SheetContent size="lg">
           <SheetHeader className="flex flex-col gap-5 text-foreground dark:text-foreground-night">
-            {header}
+            <div className="flex items-center gap-3">
+              <Avatar icon={ActionGlobeAltIcon} size="md" />
+              <div>
+                <SheetTitle>
+                  {systemView.customName ?? systemView.webhookSource.name}
+                </SheetTitle>
+                <SheetDescription>
+                  Webhook source for triggering assistants.
+                </SheetDescription>
+              </div>
+            </div>
           </SheetHeader>
           <SheetContainer>
             <Tabs

--- a/front/components/triggers/WebhookSourceDetails.tsx
+++ b/front/components/triggers/WebhookSourceDetails.tsx
@@ -1,29 +1,43 @@
 import {
+  ActionGlobeAltIcon,
+  Avatar,
   Button,
-  DropdownMenu,
-  DropdownMenuContent,
-  DropdownMenuItem,
-  DropdownMenuTrigger,
   InformationCircleIcon,
   LockIcon,
-  MoreIcon,
   Sheet,
   SheetContainer,
   SheetContent,
+  SheetDescription,
+  SheetFooter,
   SheetHeader,
   SheetTitle,
   Tabs,
+  TabsContent,
   TabsList,
   TabsTrigger,
   TrashIcon,
 } from "@dust-tt/sparkle";
-import { VisuallyHidden } from "@radix-ui/react-visually-hidden";
-import { useEffect, useState } from "react";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { useContext, useEffect, useMemo, useState } from "react";
+import { useForm } from "react-hook-form";
 
-import { DeleteWebhookSourceDialog } from "@app/components/triggers/DeleteWebhookSourceDialog";
-import { WebhookSourceDetailsHeader } from "@app/components/triggers/WebhookSourceDetailsHeader";
+import { ConfirmContext } from "@app/components/Confirm";
+import { FormProvider } from "@app/components/sparkle/FormProvider";
+import type { WebhookSourceFormValues } from "@app/components/triggers/forms/webhookSourceFormSchema";
+import {
+  diffWebhookSourceForm,
+  getWebhookSourceFormDefaults,
+  getWebhookSourceFormSchema,
+} from "@app/components/triggers/forms/webhookSourceFormSchema";
 import { WebhookSourceDetailsInfo } from "@app/components/triggers/WebhookSourceDetailsInfo";
 import { WebhookSourceDetailsSharing } from "@app/components/triggers/WebhookSourceDetailsSharing";
+import { useSendNotification } from "@app/hooks/useNotification";
+import { useSpacesAsAdmin } from "@app/lib/swr/spaces";
+import {
+  useDeleteWebhookSource,
+  useWebhookSourcesWithViews,
+} from "@app/lib/swr/webhook_source";
+import datadogLogger from "@app/logger/datadogLogger";
 import type { LightWorkspaceType, RequireAtLeastOne } from "@app/types";
 import type { WebhookSourceWithSystemView } from "@app/types/triggers/webhooks";
 
@@ -40,88 +54,347 @@ export function WebhookSourceDetails({
   isOpen,
   onClose,
 }: WebhookSourceDetailsProps) {
-  const systemView = webhookSource.systemView!; // guaranteed by RequireAtLeastOne
+  const systemView = webhookSource.systemView!;
   const [selectedTab, setSelectedTab] = useState<string>("info");
-  const [isDeleteDialogOpen, setIsDeleteDialogOpen] = useState<boolean>(false);
+  const [prevIsOpen, setPrevIsOpen] = useState(isOpen);
+  const [isSaving, setIsSaving] = useState(false);
+
+  const confirm = useContext(ConfirmContext);
+  const { deleteWebhookSource, isDeleting } = useDeleteWebhookSource({ owner });
+  const sendNotification = useSendNotification(true);
+
+  const { spaces } = useSpacesAsAdmin({
+    workspaceId: owner.sId,
+    disabled: false,
+  });
+  const { mutateWebhookSourcesWithViews, webhookSourcesWithViews } =
+    useWebhookSourcesWithViews({
+      owner,
+    });
+
+  const webhookSourceWithViews = useMemo(
+    () => webhookSourcesWithViews.find((s) => s.sId === webhookSource.sId),
+    [webhookSourcesWithViews, webhookSource.sId]
+  );
+
+  const defaults = useMemo<WebhookSourceFormValues>(() => {
+    return getWebhookSourceFormDefaults(
+      systemView,
+      webhookSourceWithViews,
+      spaces
+    );
+  }, [systemView, webhookSourceWithViews, spaces]);
+
+  const form = useForm<WebhookSourceFormValues>({
+    defaultValues: defaults,
+    mode: "onChange",
+    shouldUnregister: false,
+    resolver: zodResolver(getWebhookSourceFormSchema()),
+  });
 
   useEffect(() => {
-    if (isOpen) {
+    form.reset(defaults);
+  }, [systemView.sId]);
+
+  useEffect(() => {
+    if (isOpen && !prevIsOpen) {
       setSelectedTab("info");
     }
-  }, [isOpen]);
+    setPrevIsOpen(isOpen);
+  }, [isOpen, prevIsOpen]);
+
+  const applySharingChanges = async (
+    sharingChanges: Array<{
+      spaceId: string;
+      action: "add" | "remove";
+    }>
+  ) => {
+    for (const change of sharingChanges) {
+      const space = spaces.find((s) => s.sId === change.spaceId);
+      if (!space || space.kind === "system") {
+        continue;
+      }
+
+      if (change.action === "add") {
+        const response = await fetch(
+          `/api/w/${owner.sId}/spaces/${space.sId}/webhook_source_views`,
+          {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({
+              webhookSourceId: webhookSource.sId,
+            }),
+          }
+        );
+        if (!response.ok) {
+          const body = await response.json();
+          throw new Error(body.error?.message ?? "Failed to add to space");
+        }
+      } else {
+        const view = webhookSourceWithViews?.views.find(
+          (v) => v.spaceId === space.sId
+        );
+        if (view) {
+          const response = await fetch(
+            `/api/w/${owner.sId}/spaces/${space.sId}/webhook_source_views/${view.sId}`,
+            {
+              method: "DELETE",
+            }
+          );
+          if (!response.ok) {
+            const body = await response.json();
+            throw new Error(
+              body.error?.message ?? "Failed to remove from space"
+            );
+          }
+        }
+      }
+    }
+  };
+
+  const onSave = async (): Promise<boolean> => {
+    let success = false;
+    await form.handleSubmit(
+      async (values) => {
+        try {
+          const diff = diffWebhookSourceForm(defaults, values);
+
+          if (diff.name) {
+            const response = await fetch(
+              `/api/w/${owner.sId}/webhook_sources/views/${systemView.sId}`,
+              {
+                method: "PATCH",
+                headers: { "Content-Type": "application/json" },
+                body: JSON.stringify({ name: diff.name }),
+              }
+            );
+            if (!response.ok) {
+              const body = await response.json();
+              throw new Error(
+                body.error?.message ?? "Failed to update webhook source view"
+              );
+            }
+          }
+
+          if (diff.sharingChanges && diff.sharingChanges.length > 0) {
+            await applySharingChanges(diff.sharingChanges);
+          }
+
+          await mutateWebhookSourcesWithViews();
+
+          sendNotification({
+            type: "success",
+            title: `${webhookSource.name} updated`,
+            description: "Your changes have been saved.",
+          });
+
+          form.reset(values);
+          success = true;
+        } catch (error) {
+          sendNotification({
+            type: "error",
+            title: "Failed to save changes",
+            description:
+              error instanceof Error
+                ? error.message
+                : "An error occurred while saving changes.",
+          });
+          datadogLogger.error(
+            {
+              error: error instanceof Error ? error.message : String(error),
+              webhookSourceViewId: systemView.sId,
+            },
+            "[Webhook Details] - Save error"
+          );
+          success = false;
+        }
+      },
+      async (errors) => {
+        const keys = Object.keys(errors);
+        const firstErrorKey = keys[0] as keyof typeof errors | undefined;
+        if (firstErrorKey) {
+          form.setFocus(firstErrorKey as any);
+        }
+
+        const errorDetails = keys
+          .map((key) => {
+            const error = errors[key as keyof typeof errors];
+            return `${key}: ${error?.message ?? "invalid"}`;
+          })
+          .join(", ");
+
+        const details =
+          keys.length > 0 ? `Invalid: ${errorDetails}` : undefined;
+        datadogLogger.error(
+          {
+            fields: keys,
+            errors: errors,
+            values: form.getValues(),
+            webhookSourceViewId: systemView.sId,
+          },
+          "[Webhook Details] - Form validation error"
+        );
+        sendNotification({
+          type: "error",
+          title: "Invalid form data",
+          description: details,
+        });
+        success = false;
+      }
+    )();
+    return success;
+  };
+
+  const onCancel = () => {
+    form.reset();
+  };
+
+  const changeTab = async (next: string) => {
+    setSelectedTab(next);
+  };
+
+  const header = useMemo(() => {
+    return (
+      <div className="flex items-center gap-3">
+        <Avatar icon={ActionGlobeAltIcon} size="md" />
+        <div>
+          <SheetTitle>
+            {systemView.customName ?? systemView.webhookSource.name}
+          </SheetTitle>
+          <SheetDescription>
+            Webhook source for triggering assistants.
+          </SheetDescription>
+        </div>
+      </div>
+    );
+  }, [systemView]);
+
+  const handleOpenChange = async (open: boolean) => {
+    if (open) {
+      return;
+    }
+
+    const hasUnsavedChanges = form.formState.isDirty;
+
+    if (hasUnsavedChanges) {
+      const confirmed = await confirm({
+        title: "Unsaved changes will be lost",
+        message:
+          "All unsaved changes will be lost. Are you sure you want to close?",
+        validateLabel: "Close without saving",
+        validateVariant: "warning",
+      });
+      if (!confirmed) {
+        return;
+      }
+    }
+
+    onCancel();
+    onClose();
+  };
 
   return (
-    <>
-      <DeleteWebhookSourceDialog
-        owner={owner}
-        webhookSource={webhookSource}
-        isOpen={isDeleteDialogOpen}
-        onClose={() => {
-          setIsDeleteDialogOpen(false);
-          onClose();
-        }}
-      />
-      <Sheet open={isOpen} onOpenChange={onClose}>
+    <FormProvider form={form}>
+      <Sheet open={isOpen} onOpenChange={(open) => void handleOpenChange(open)}>
         <SheetContent size="lg">
-          <SheetHeader className="flex flex-col gap-5 pb-0 text-sm text-foreground dark:text-foreground-night">
-            <VisuallyHidden>
-              <SheetTitle />
-            </VisuallyHidden>
-            <WebhookSourceDetailsHeader webhookSourceView={systemView} />
-
-            <Tabs value={selectedTab}>
-              <TabsList border={false}>
+          <SheetHeader className="flex flex-col gap-5 text-foreground dark:text-foreground-night">
+            {header}
+          </SheetHeader>
+          <SheetContainer>
+            <Tabs
+              value={selectedTab}
+              onValueChange={(v) => void changeTab(v as string)}
+            >
+              <TabsList>
                 <TabsTrigger
                   value="info"
                   label="Info"
                   icon={InformationCircleIcon}
-                  onClick={() => setSelectedTab("info")}
                 />
-                <TabsTrigger
-                  value="sharing"
-                  label="Sharing"
-                  icon={LockIcon}
-                  onClick={() => setSelectedTab("sharing")}
-                />
+                <TabsTrigger value="sharing" label="Sharing" icon={LockIcon} />
                 <>
                   <div className="grow" />
-                  <DropdownMenu>
-                    <DropdownMenuTrigger asChild>
-                      <Button icon={MoreIcon} variant="outline" />
-                    </DropdownMenuTrigger>
-                    <DropdownMenuContent>
-                      <DropdownMenuItem
-                        key="remove-webhook-source"
-                        icon={TrashIcon}
-                        label="Remove"
-                        variant="warning"
-                        onClick={() => {
-                          setIsDeleteDialogOpen(true);
-                        }}
-                      />
-                    </DropdownMenuContent>
-                  </DropdownMenu>
+                  <div className="flex h-full flex-row items-center">
+                    <Button
+                      icon={TrashIcon}
+                      variant="warning"
+                      size="xs"
+                      disabled={isDeleting}
+                      onClick={async () => {
+                        const confirmed = await confirm({
+                          title: "Confirm Removal",
+                          message: (
+                            <div>
+                              Are you sure you want to remove{" "}
+                              <span className="font-semibold">
+                                {webhookSource.name}
+                              </span>
+                              ?
+                              <div className="mt-2 font-semibold">
+                                This action cannot be undone.
+                              </div>
+                            </div>
+                          ),
+                          validateLabel: "Remove",
+                          validateVariant: "warning",
+                        });
+                        if (!confirmed) {
+                          return;
+                        }
+                        const deleted = await deleteWebhookSource(
+                          webhookSource.sId
+                        );
+                        if (deleted) {
+                          onClose();
+                        }
+                      }}
+                    />
+                  </div>
                 </>
               </TabsList>
+              <div className="mt-4">
+                <TabsContent value="info">
+                  <div className="flex flex-col gap-4">
+                    <WebhookSourceDetailsInfo
+                      webhookSourceView={systemView}
+                      owner={owner}
+                    />
+                  </div>
+                </TabsContent>
+                <TabsContent value="sharing">
+                  <WebhookSourceDetailsSharing
+                    webhookSource={webhookSource}
+                    owner={owner}
+                    spaces={spaces}
+                  />
+                </TabsContent>
+              </div>
             </Tabs>
-          </SheetHeader>
-
-          <SheetContainer className="pb-4">
-            {selectedTab === "info" && (
-              <WebhookSourceDetailsInfo
-                webhookSourceView={systemView}
-                owner={owner}
-              />
-            )}
-            {selectedTab === "sharing" && (
-              <WebhookSourceDetailsSharing
-                webhookSource={webhookSource}
-                owner={owner}
-              />
-            )}
           </SheetContainer>
+          <SheetFooter
+            leftButtonProps={{
+              label: "Cancel",
+              variant: "outline",
+              disabled: isSaving || form.formState.isSubmitting,
+              onClick: () => handleOpenChange(false),
+            }}
+            rightButtonProps={{
+              label:
+                isSaving || form.formState.isSubmitting ? "Saving..." : "Save",
+              variant: "primary",
+              disabled: isSaving || form.formState.isSubmitting,
+              onClick: async () => {
+                setIsSaving(true);
+                try {
+                  await onSave();
+                } finally {
+                  setIsSaving(false);
+                }
+              },
+            }}
+          />
         </SheetContent>
       </Sheet>
-    </>
+    </FormProvider>
   );
 }

--- a/front/components/triggers/WebhookSourceDetailsInfo.tsx
+++ b/front/components/triggers/WebhookSourceDetailsInfo.tsx
@@ -4,14 +4,16 @@ import {
   EyeIcon,
   EyeSlashIcon,
   IconButton,
+  Input,
   Page,
   Separator,
   useCopyToClipboard,
 } from "@dust-tt/sparkle";
 import { useEffect, useMemo, useState } from "react";
+import { useFormContext } from "react-hook-form";
 
+import type { WebhookSourceFormValues } from "@app/components/triggers/forms/webhookSourceFormSchema";
 import { WebhookEndpointUsageInfo } from "@app/components/triggers/WebhookEndpointUsageInfo";
-import { WebhookSourceViewForm } from "@app/components/triggers/WebhookSourceViewForm";
 import { useSendNotification } from "@app/hooks/useNotification";
 import config from "@app/lib/api/config";
 import type { LightWorkspaceType } from "@app/types";
@@ -49,6 +51,7 @@ export function WebhookSourceDetailsInfo({
 }: WebhookSourceDetailsInfoProps) {
   const [isSecretVisible, setIsSecretVisible] = useState(false);
   const sendNotification = useSendNotification();
+  const form = useFormContext<WebhookSourceFormValues>();
 
   const editedLabel = useMemo(
     () => getEditedLabel(webhookSourceView),
@@ -83,10 +86,15 @@ export function WebhookSourceDetailsInfo({
         </div>
       )}
 
-      <WebhookSourceViewForm
-        webhookSourceView={webhookSourceView}
-        owner={owner}
-      />
+      <div className="space-y-5 text-foreground dark:text-foreground-night">
+        <Input
+          {...form.register("name")}
+          label="Custom Name"
+          isError={!!form.formState.errors.name}
+          message={form.formState.errors.name?.message}
+          placeholder={webhookSourceView.webhookSource.name}
+        />
+      </div>
 
       <Separator className="mb-4 mt-4" />
       <Page.H variant="h4">Webhook Source Details</Page.H>

--- a/front/components/triggers/WebhookSourceDetailsSharing.tsx
+++ b/front/components/triggers/WebhookSourceDetailsSharing.tsx
@@ -7,69 +7,40 @@ import {
 } from "@dust-tt/sparkle";
 import type { CellContext, ColumnDef } from "@tanstack/react-table";
 import { useState } from "react";
+import { useFormContext } from "react-hook-form";
 
-import { useSpacesAsAdmin } from "@app/lib/swr/spaces";
-import {
-  useAddWebhookSourceViewToSpace,
-  useRemoveWebhookSourceViewFromSpace,
-} from "@app/lib/swr/webhook_source";
+import type { WebhookSourceFormValues } from "@app/components/triggers/forms/webhookSourceFormSchema";
 import type { LightWorkspaceType } from "@app/types";
 import type { SpaceType } from "@app/types/space";
-import type {
-  WebhookSourceType,
-  WebhookSourceViewType,
-  WebhookSourceWithViews,
-} from "@app/types/triggers/webhooks";
+import type { WebhookSourceWithViews } from "@app/types/triggers/webhooks";
 
 type WebhookSourceDetailsSharingProps = {
   webhookSource: WebhookSourceWithViews;
   owner: LightWorkspaceType;
+  spaces: SpaceType[];
 };
 
 type RowData = {
   name: string;
   space: SpaceType;
-  webhookSourceView: WebhookSourceViewType | undefined;
+  isEnabled: boolean;
   onClick: () => void;
 };
 
 const ActionCell = ({
-  webhookSource,
-  webhookSourceView,
-  space,
-  addToSpace,
-  removeFromSpace,
+  isEnabled,
+  onToggle,
 }: {
-  webhookSource: WebhookSourceType;
-  webhookSourceView?: WebhookSourceViewType;
-  space: SpaceType;
-  addToSpace: ({
-    space,
-    webhookSource,
-  }: {
-    space: SpaceType;
-    webhookSource: WebhookSourceType;
-  }) => Promise<void>;
-  removeFromSpace: (params: {
-    webhookSourceView: WebhookSourceViewType;
-    space: SpaceType;
-  }) => Promise<void>;
+  isEnabled: boolean;
+  onToggle: () => void;
 }) => {
-  const [loading, setLoading] = useState(false);
-
   return (
     <DataTable.CellContent>
       <SliderToggle
-        disabled={loading}
-        selected={webhookSourceView !== undefined}
-        onClick={async () => {
-          setLoading(true);
-          if (webhookSourceView) {
-            await removeFromSpace({ webhookSourceView, space });
-          } else {
-            await addToSpace({ space, webhookSource });
-          }
-          setLoading(false);
+        selected={isEnabled}
+        onClick={(e) => {
+          e.stopPropagation();
+          onToggle();
         }}
       />
     </DataTable.CellContent>
@@ -77,45 +48,37 @@ const ActionCell = ({
 };
 
 export function WebhookSourceDetailsSharing({
-  webhookSource,
-  owner,
+  spaces,
 }: WebhookSourceDetailsSharingProps) {
-  const [loading, setLoading] = useState(false);
   const [filter, setFilter] = useState("");
-  const { spaces } = useSpacesAsAdmin({
-    workspaceId: owner.sId,
-    disabled: false,
-  });
+  const form = useFormContext<WebhookSourceFormValues>();
+  const sharingSettings = form.watch("sharingSettings") || {};
 
-  const globalSpace = spaces.find((space) => space.kind === "global") ?? null;
-  const webhookSourceViewsWithSpace = webhookSource.views.map((view) => ({
-    ...view,
-    space: spaces.find((space) => space.sId === view.spaceId) ?? null,
-  }));
-  const globalView =
-    webhookSourceViewsWithSpace.find((view) => view.space?.kind === "global") ??
-    null;
-  const isRestricted = globalView === null;
+  const globalSpace = spaces.find((space) => space.kind === "global");
+  const availableSpaces = spaces.filter((s) => s.kind === "regular");
 
-  const { addToSpace } = useAddWebhookSourceViewToSpace({
-    owner,
-  });
-  const { removeFromSpace } = useRemoveWebhookSourceViewFromSpace({
-    owner,
-  });
+  const isRestricted = globalSpace ? !sharingSettings?.[globalSpace.sId] : true;
 
-  const availableSpaces = (spaces ?? []).filter((s) => s.kind === "regular");
+  const handleToggle = (space: SpaceType) => {
+    const currentState = sharingSettings?.[space.sId] ?? false;
+    const newState = !currentState;
+
+    form.setValue(`sharingSettings.${space.sId}`, newState, {
+      shouldDirty: true,
+      shouldTouch: true,
+      shouldValidate: true,
+    });
+  };
 
   const rows: RowData[] = availableSpaces
     .map((space) => ({
       name: space.name,
       space: space,
-      webhookSourceView: webhookSource.views.find(
-        (view) => view.spaceId === space.sId
-      ),
-      onClick: () => {},
+      isEnabled: sharingSettings?.[space.sId] ?? false,
+      onClick: () => handleToggle(space),
     }))
     .sort((a, b) => a.name.localeCompare(b.name));
+
   const columns: ColumnDef<RowData, any>[] = [
     {
       id: "name",
@@ -125,17 +88,14 @@ export function WebhookSourceDetailsSharing({
     {
       id: "action",
       header: "",
-      accessorKey: "viewId",
+      accessorKey: "isEnabled",
       meta: {
         className: "w-14",
       },
-      cell: (info: CellContext<RowData, string>) => (
+      cell: (info: CellContext<RowData, boolean>) => (
         <ActionCell
-          webhookSource={webhookSource}
-          addToSpace={addToSpace}
-          removeFromSpace={removeFromSpace}
-          webhookSourceView={info.row.original.webhookSourceView}
-          space={info.row.original.space}
+          isEnabled={info.row.original.isEnabled}
+          onToggle={info.row.original.onClick}
         />
       ),
     },
@@ -147,20 +107,11 @@ export function WebhookSourceDetailsSharing({
         <div className="flex w-full items-center justify-between overflow-visible">
           <Page.SectionHeader title="Available to all Spaces" />
           <SliderToggle
-            disabled={loading}
             selected={!isRestricted}
-            onClick={async () => {
-              if (globalSpace !== null) {
-                setLoading(true);
-                if (!isRestricted) {
-                  await removeFromSpace({
-                    webhookSourceView: globalView,
-                    space: globalSpace,
-                  });
-                } else {
-                  await addToSpace({ space: globalSpace, webhookSource });
-                }
-                setLoading(false);
+            onClick={(e) => {
+              e.stopPropagation();
+              if (globalSpace) {
+                handleToggle(globalSpace);
               }
             }}
           />
@@ -178,17 +129,18 @@ export function WebhookSourceDetailsSharing({
 
       {isRestricted && (
         <>
-          <div className="flex flex-row gap-2">
+          <div className="flex w-full flex-row gap-2">
             <SearchInput
               name="filter"
               placeholder="Search a space"
               value={filter}
               onChange={(e) => setFilter(e)}
+              className="w-full"
             />
           </div>
 
           <ScrollArea className="h-full">
-            <DataTable
+            <DataTable<RowData>
               data={rows}
               columns={columns}
               filter={filter}

--- a/front/components/triggers/forms/webhookSourceFormSchema.ts
+++ b/front/components/triggers/forms/webhookSourceFormSchema.ts
@@ -1,0 +1,91 @@
+import { z } from "zod";
+
+import type { WebhookSourceViewType } from "@app/types/triggers/webhooks";
+
+export type WebhookSourceFormValues = {
+  name: string;
+  sharingSettings: Record<string, boolean>;
+};
+
+export function getWebhookSourceFormDefaults(
+  view: WebhookSourceViewType,
+  webhookSourceWithViews?: { views: Array<{ spaceId: string }> },
+  spaces?: Array<{ sId: string; kind: string }>
+): WebhookSourceFormValues {
+  const name = view.customName ?? view.webhookSource.name;
+
+  const sharingSettings: Record<string, boolean> = {};
+
+  if (spaces) {
+    for (const space of spaces) {
+      if (space.kind === "regular" || space.kind === "global") {
+        sharingSettings[space.sId] = false;
+      }
+    }
+  }
+
+  if (webhookSourceWithViews && spaces) {
+    for (const webhookView of webhookSourceWithViews.views) {
+      const space = spaces.find((s) => s.sId === webhookView.spaceId);
+      if (space && (space.kind === "regular" || space.kind === "global")) {
+        sharingSettings[webhookView.spaceId] = true;
+      }
+    }
+  } else if (webhookSourceWithViews) {
+    for (const webhookView of webhookSourceWithViews.views) {
+      sharingSettings[webhookView.spaceId] = true;
+    }
+  }
+
+  return {
+    name,
+    sharingSettings,
+  };
+}
+
+export function getWebhookSourceFormSchema() {
+  return z.object({
+    name: z.string().min(1, "Name is required."),
+    sharingSettings: z.record(z.boolean()),
+  });
+}
+
+type FormDiffType = {
+  name?: string;
+  sharingChanges?: Array<{
+    spaceId: string;
+    action: "add" | "remove";
+  }>;
+};
+
+export function diffWebhookSourceForm(
+  initial: WebhookSourceFormValues,
+  current: WebhookSourceFormValues
+): FormDiffType {
+  const out: FormDiffType = {};
+
+  if (current.name !== initial.name) {
+    out.name = current.name;
+  }
+
+  const sharingChanges: typeof out.sharingChanges = [];
+  const allSpaceIds = new Set([
+    ...Object.keys(initial.sharingSettings),
+    ...Object.keys(current.sharingSettings),
+  ]);
+  for (const spaceId of allSpaceIds) {
+    const wasEnabled = initial.sharingSettings[spaceId] ?? false;
+    const isEnabled = current.sharingSettings[spaceId] ?? false;
+    if (wasEnabled !== isEnabled) {
+      sharingChanges.push({
+        spaceId,
+        action: isEnabled ? "add" : "remove",
+      });
+    }
+  }
+  if (sharingChanges.length > 0) {
+    out.sharingChanges = sharingChanges;
+  }
+
+  return out;
+}


### PR DESCRIPTION
## Description

This PR enhances the `WebhookSourceDetails` component with form handling and save functionality. Implements form management using react-hook-form to allow users to edit webhook source configurations directly within the detail view. Adds proper form validation, error handling, and user feedback via notifications. Introduces state management to handle the opening and closing of webhook source detail views, ensuring the detail view is properly toggled when a webhook source selection changes.

**References:**
- https://github.com/dust-tt/tasks/issues/4543

## Tests

Locally

## Risk

Low

## Deploy Plan

Deploy front
