### PR TITLE
Sparkle Conversation message: completionStatus is a component not a string

### DIFF
--- a/sparkle/src/components/ConversationMessage.tsx
+++ b/sparkle/src/components/ConversationMessage.tsx
@@ -36,7 +36,7 @@ interface ConversationMessageProps
   isDisabled?: boolean;
   name?: string;
   timestamp?: string;
-  completionStatus?: string;
+  completionStatus?: React.ReactNode;
   pictureUrl?: string | React.ReactNode | null;
   renderName?: (name: string | null) => React.ReactNode;
   infoChip?: React.ReactNode;
@@ -174,7 +174,7 @@ interface ConversationMessageHeaderProps
   isDisabled?: boolean;
   name?: string;
   timestamp?: string;
-  completionStatus?: string;
+  completionStatus?: React.ReactNode;
   infoChip?: React.ReactNode;
   renderName: (name: string | null) => React.ReactNode;
   type: ConversationMessageType;
@@ -243,11 +243,7 @@ export const ConversationMessageHeader = React.forwardRef<
               {timestamp}
             </span>
           </div>
-          {completionStatus && (
-            <div className="s-text-xs s-text-muted-foreground dark:s-text-muted-foreground-night">
-              {completionStatus}
-            </div>
-          )}
+          {completionStatus ?? null}
         </div>
       </div>
     );

--- a/sparkle/src/stories/ConversationMessage.stories.tsx
+++ b/sparkle/src/stories/ConversationMessage.stories.tsx
@@ -11,6 +11,7 @@ import {
   CitationTitle,
   ClipboardIcon,
   ClockIcon,
+  CommandLineIcon,
   ConversationContainer,
   ConversationMessage,
   GithubIcon,
@@ -234,7 +235,17 @@ export const ConversationHandoffExample = () => {
                 <span className="s-ml-1">{name}</span>
               </span>
             )}
-            completionStatus="Completed in 9 min 30 sec"
+            completionStatus={
+              <Button
+                icon={CommandLineIcon}
+                onClick={() => {
+                  console.log("soupinou");
+                }}
+                label="Completed in 9 min 30 sec"
+                size="xs"
+                variant={"outline"}
+              />
+            }
             citations={[
               <Citation href="https://www.google.com">
                 <CitationIcons>


### PR DESCRIPTION
## Description

Just changing the type of `completionStatus` in `ConversationMessage` to be a component so that we can put the breakdown button on the header if we want. This was introduced today so no migration of components. 

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

Publish sparkle. 