### PR TITLE
[HOOTL] Add types for webhook source presets

### DIFF
--- a/front/types/triggers/github_webhook_source_presets.ts
+++ b/front/types/triggers/github_webhook_source_presets.ts
@@ -1,8 +1,9 @@
+import { GithubLogo } from "@dust-tt/sparkle";
 import type {
   EventField,
   WebhookEvent,
   PresetWebhook,
-} from "./webhooks_source_preset";
+} from "@app/types/triggers/webhooks_source_preset";
 
 const USER_CHILDREN_FIELDS: EventField[] = [
   {
@@ -342,39 +343,7 @@ const GITHUB_PULL_REQUEST_EVENT: WebhookEvent = {
       description: "The user that triggered the event.",
       type: "object",
       isArray: false,
-      childrenFields: [
-        {
-          name: "login",
-          description: "The username of the user.",
-          type: "string",
-        },
-        {
-          name: "id",
-          description: "The unique identifier of the user.",
-          type: "number",
-        },
-        {
-          name: "url",
-          description: "The API URL of the user.",
-          type: "string",
-        },
-        {
-          name: "html_url",
-          description: "The GitHub profile URL of the user.",
-          type: "string",
-        },
-        {
-          name: "type",
-          description: "The type of the user account.",
-          type: "enum",
-          enumValues: ["User", "Organization"],
-        },
-        {
-          name: "site_admin",
-          description: "Whether the user is a GitHub site administrator.",
-          type: "boolean",
-        },
-      ],
+      childrenFields: USER_CHILDREN_FIELDS,
     },
   ],
 };
@@ -545,4 +514,7 @@ export const GITHUB_WEBHOOK_PRESET: PresetWebhook = {
     field: "X-GitHub-Event",
   },
   events: [GITHUB_PULL_REQUEST_EVENT, GITHUB_ISSUES_EVENT],
+  icon: GithubLogo,
+  description:
+    "Receive events from GitHub such as creation or edition of issues or pull requests.",
 };

--- a/front/types/triggers/github_webhook_source_presets.ts
+++ b/front/types/triggers/github_webhook_source_presets.ts
@@ -1,4 +1,126 @@
-import type { WebhookEvent, PresetWebhook } from "./webhooks_source_preset";
+import type {
+  EventField,
+  WebhookEvent,
+  PresetWebhook,
+} from "./webhooks_source_preset";
+
+const USER_CHILDREN_FIELDS: EventField[] = [
+  {
+    name: "login",
+    description: "The username of the user.",
+    type: "string",
+  },
+  {
+    name: "id",
+    description: "The unique identifier of the user.",
+    type: "number",
+  },
+  {
+    name: "html_url",
+    description: "The GitHub profile URL of the user.",
+    type: "string",
+  },
+  {
+    name: "type",
+    description: "The type of the user account.",
+    type: "enum",
+    enumValues: ["User", "Organization"],
+  },
+  {
+    name: "site_admin",
+    description: "Whether the user is a GitHub site administrator.",
+    type: "boolean",
+  },
+];
+
+const LABEL_CHILDREN_FIELDS: EventField[] = [
+  {
+    name: "id",
+    description: "The unique identifier of the label.",
+    type: "number",
+  },
+  {
+    name: "url",
+    description: "The API URL of the label.",
+    type: "string",
+  },
+  {
+    name: "name",
+    description: "The name of the label.",
+    type: "string",
+  },
+];
+
+const MILESTONE_CHILDREN_FIELDS: EventField[] = [
+  {
+    name: "html_url",
+    description: "The GitHub web URL of the milestone.",
+    type: "string",
+  },
+  {
+    name: "id",
+    description: "The unique identifier of the milestone.",
+    type: "number",
+  },
+  {
+    name: "number",
+    description: "The milestone number.",
+    type: "number",
+  },
+  {
+    name: "title",
+    description: "The title of the milestone.",
+    type: "string",
+  },
+  {
+    name: "description",
+    description: "The description of the milestone.",
+    type: "string",
+  },
+  {
+    name: "creator",
+    description: "The user who created the milestone.",
+    type: "object",
+    isArray: false,
+    childrenFields: USER_CHILDREN_FIELDS,
+  },
+  {
+    name: "open_issues",
+    description: "The number of open issues in the milestone.",
+    type: "number",
+  },
+  {
+    name: "closed_issues",
+    description: "The number of closed issues in the milestone.",
+    type: "number",
+  },
+  {
+    name: "state",
+    description: "The state of the milestone.",
+    type: "enum",
+    enumValues: ["open", "closed"],
+  },
+  {
+    name: "created_at",
+    description: "The timestamp when the milestone was created.",
+    type: "string",
+  },
+  {
+    name: "updated_at",
+    description: "The timestamp when the milestone was last updated.",
+    type: "string",
+  },
+  {
+    name: "due_on",
+    description: "The due date for the milestone.",
+    type: "string",
+  },
+  {
+    name: "closed_at",
+    description: "The timestamp when the milestone was closed.",
+    type: "string",
+  },
+];
 
 const GITHUB_PULL_REQUEST_EVENT: WebhookEvent = {
   name: "pull_request",
@@ -80,34 +202,7 @@ const GITHUB_PULL_REQUEST_EVENT: WebhookEvent = {
           description: "The user who created the pull request.",
           type: "object",
           isArray: false,
-          childrenFields: [
-            {
-              name: "login",
-              description: "The username of the user.",
-              type: "string",
-            },
-            {
-              name: "id",
-              description: "The unique identifier of the user.",
-              type: "number",
-            },
-            {
-              name: "html_url",
-              description: "The GitHub profile URL of the user.",
-              type: "string",
-            },
-            {
-              name: "type",
-              description: "The type of the user account.",
-              type: "enum",
-              enumValues: ["User", "Organization"],
-            },
-            {
-              name: "site_admin",
-              description: "Whether the user is a GitHub site administrator.",
-              type: "boolean",
-            },
-          ],
+          childrenFields: USER_CHILDREN_FIELDS,
         },
         {
           name: "body",
@@ -134,135 +229,35 @@ const GITHUB_PULL_REQUEST_EVENT: WebhookEvent = {
           description: "The user assigned to the pull request.",
           type: "object",
           isArray: false,
-          childrenFields: [
-            {
-              name: "login",
-              description: "The username of the user.",
-              type: "string",
-            },
-            {
-              name: "id",
-              description: "The unique identifier of the user.",
-              type: "number",
-            },
-            {
-              name: "html_url",
-              description: "The GitHub profile URL of the user.",
-              type: "string",
-            },
-            {
-              name: "type",
-              description: "The type of the user account.",
-              type: "enum",
-              enumValues: ["User", "Organization"],
-            },
-            {
-              name: "site_admin",
-              description: "Whether the user is a GitHub site administrator.",
-              type: "boolean",
-            },
-          ],
+          childrenFields: USER_CHILDREN_FIELDS,
         },
         {
           name: "assignees",
           description: "The users assigned to the pull request.",
           type: "object",
           isArray: true,
-          childrenFields: [
-            {
-              name: "login",
-              description: "The username of the user.",
-              type: "string",
-            },
-            {
-              name: "id",
-              description: "The unique identifier of the user.",
-              type: "number",
-            },
-            {
-              name: "html_url",
-              description: "The GitHub profile URL of the user.",
-              type: "string",
-            },
-            {
-              name: "type",
-              description: "The type of the user account.",
-              type: "enum",
-              enumValues: ["User", "Organization"],
-            },
-            {
-              name: "site_admin",
-              description: "Whether the user is a GitHub site administrator.",
-              type: "boolean",
-            },
-          ],
+          childrenFields: USER_CHILDREN_FIELDS,
         },
         {
           name: "requested_reviewers",
           description: "The users requested to review the pull request.",
           type: "object",
           isArray: true,
-          childrenFields: [
-            {
-              name: "login",
-              description: "The username of the user.",
-              type: "string",
-            },
-            {
-              name: "id",
-              description: "The unique identifier of the user.",
-              type: "number",
-            },
-            {
-              name: "html_url",
-              description: "The GitHub profile URL of the user.",
-              type: "string",
-            },
-            {
-              name: "type",
-              description: "The type of the user account.",
-              type: "enum",
-              enumValues: ["User", "Organization"],
-            },
-            {
-              name: "site_admin",
-              description: "Whether the user is a GitHub site administrator.",
-              type: "boolean",
-            },
-          ],
+          childrenFields: USER_CHILDREN_FIELDS,
         },
         {
           name: "labels",
           description: "The labels applied to the pull request.",
           type: "object",
           isArray: true,
-          childrenFields: [
-            {
-              name: "id",
-              description: "The unique identifier of the label.",
-              type: "number",
-            },
-            {
-              name: "url",
-              description: "The API URL of the label.",
-              type: "string",
-            },
-            {
-              name: "name",
-              description: "The name of the label.",
-              type: "string",
-            },
-            {
-              name: "default",
-              description: "Whether this is a default label.",
-              type: "boolean",
-            },
-          ],
+          childrenFields: LABEL_CHILDREN_FIELDS,
         },
         {
           name: "milestone",
           description: "The milestone associated with the pull request.",
-          type: "unknown-object",
+          type: "object",
+          isArray: false,
+          childrenFields: MILESTONE_CHILDREN_FIELDS,
         },
         {
           name: "head",
@@ -444,62 +439,14 @@ const GITHUB_ISSUES_EVENT: WebhookEvent = {
           description: "The user who created the issue.",
           type: "object",
           isArray: false,
-          childrenFields: [
-            {
-              name: "login",
-              description: "The username of the user.",
-              type: "string",
-            },
-            {
-              name: "id",
-              description: "The unique identifier of the user.",
-              type: "number",
-            },
-            {
-              name: "html_url",
-              description: "The GitHub profile URL of the user.",
-              type: "string",
-            },
-            {
-              name: "type",
-              description: "The type of the user account.",
-              type: "enum",
-              enumValues: ["User", "Organization"],
-            },
-            {
-              name: "site_admin",
-              description: "Whether the user is a GitHub site administrator.",
-              type: "boolean",
-            },
-          ],
+          childrenFields: USER_CHILDREN_FIELDS,
         },
         {
           name: "labels",
           description: "The labels applied to the issue.",
           type: "object",
           isArray: true,
-          childrenFields: [
-            {
-              name: "id",
-              description: "The unique identifier of the label.",
-              type: "number",
-            },
-            {
-              name: "url",
-              description: "The API URL of the label.",
-              type: "string",
-            },
-            {
-              name: "name",
-              description: "The name of the label.",
-              type: "string",
-            },
-            {
-              name: "default",
-              description: "Whether this is a default label.",
-              type: "boolean",
-            },
-          ],
+          childrenFields: LABEL_CHILDREN_FIELDS,
         },
         {
           name: "state",
@@ -517,68 +464,21 @@ const GITHUB_ISSUES_EVENT: WebhookEvent = {
           description: "The user assigned to the issue.",
           type: "object",
           isArray: false,
-          childrenFields: [
-            {
-              name: "login",
-              description: "The username of the user.",
-              type: "string",
-            },
-            {
-              name: "id",
-              description: "The unique identifier of the user.",
-              type: "number",
-            },
-            {
-              name: "html_url",
-              description: "The GitHub profile URL of the user.",
-              type: "string",
-            },
-            {
-              name: "type",
-              description: "The type of the user account.",
-              type: "enum",
-              enumValues: ["User", "Organization"],
-            },
-          ],
+          childrenFields: USER_CHILDREN_FIELDS,
         },
         {
           name: "assignees",
           description: "The users assigned to the issue.",
           type: "object",
           isArray: true,
-          childrenFields: [
-            {
-              name: "login",
-              description: "The username of the user.",
-              type: "string",
-            },
-            {
-              name: "id",
-              description: "The unique identifier of the user.",
-              type: "number",
-            },
-            {
-              name: "html_url",
-              description: "The GitHub profile URL of the user.",
-              type: "string",
-            },
-            {
-              name: "type",
-              description: "The type of the user account.",
-              type: "enum",
-              enumValues: ["User", "Organization"],
-            },
-            {
-              name: "site_admin",
-              description: "Whether the user is a GitHub site administrator.",
-              type: "boolean",
-            },
-          ],
+          childrenFields: USER_CHILDREN_FIELDS,
         },
         {
           name: "milestone",
           description: "The milestone associated with the issue.",
-          type: "unknown-object",
+          type: "object",
+          isArray: false,
+          childrenFields: MILESTONE_CHILDREN_FIELDS,
         },
         {
           name: "comments",
@@ -618,34 +518,7 @@ const GITHUB_ISSUES_EVENT: WebhookEvent = {
         "The optional user who was assigned or unassigned from the issue.",
       type: "object",
       isArray: false,
-      childrenFields: [
-        {
-          name: "login",
-          description: "The username of the user.",
-          type: "string",
-        },
-        {
-          name: "id",
-          description: "The unique identifier of the user.",
-          type: "number",
-        },
-        {
-          name: "html_url",
-          description: "The GitHub profile URL of the user.",
-          type: "string",
-        },
-        {
-          name: "type",
-          description: "The type of the user account.",
-          type: "enum",
-          enumValues: ["User", "Organization"],
-        },
-        {
-          name: "site_admin",
-          description: "Whether the user is a GitHub site administrator.",
-          type: "boolean",
-        },
-      ],
+      childrenFields: USER_CHILDREN_FIELDS,
     },
     {
       name: "label",
@@ -653,57 +526,14 @@ const GITHUB_ISSUES_EVENT: WebhookEvent = {
         "The optional label that was added or removed from the issue.",
       type: "object",
       isArray: false,
-      childrenFields: [
-        {
-          name: "id",
-          description: "The unique identifier of the label.",
-          type: "number",
-        },
-        {
-          name: "url",
-          description: "The API URL of the label.",
-          type: "string",
-        },
-        {
-          name: "name",
-          description: "The name of the label.",
-          type: "string",
-        },
-      ],
+      childrenFields: LABEL_CHILDREN_FIELDS,
     },
     {
       name: "sender",
       description: "The user that triggered the event.",
       type: "object",
       isArray: false,
-      childrenFields: [
-        {
-          name: "login",
-          description: "The username of the user.",
-          type: "string",
-        },
-        {
-          name: "id",
-          description: "The unique identifier of the user.",
-          type: "number",
-        },
-        {
-          name: "html_url",
-          description: "The GitHub profile URL of the user.",
-          type: "string",
-        },
-        {
-          name: "type",
-          description: "The type of the user account.",
-          type: "enum",
-          enumValues: ["User", "Organization"],
-        },
-        {
-          name: "site_admin",
-          description: "Whether the user is a GitHub site administrator.",
-          type: "boolean",
-        },
-      ],
+      childrenFields: USER_CHILDREN_FIELDS,
     },
   ],
 };

--- a/front/types/triggers/github_webhook_source_presets.ts
+++ b/front/types/triggers/github_webhook_source_presets.ts
@@ -41,7 +41,8 @@ const GITHUB_PULL_REQUEST_EVENT: WebhookEvent = {
     {
       name: "pull_request",
       description: "The pull request itself.",
-      type: "parent-field",
+      type: "object",
+      isArray: false,
       childrenFields: [
         {
           name: "html_url",
@@ -77,7 +78,8 @@ const GITHUB_PULL_REQUEST_EVENT: WebhookEvent = {
         {
           name: "user",
           description: "The user who created the pull request.",
-          type: "parent-field",
+          type: "object",
+          isArray: false,
           childrenFields: [
             {
               name: "login",
@@ -130,7 +132,8 @@ const GITHUB_PULL_REQUEST_EVENT: WebhookEvent = {
         {
           name: "assignee",
           description: "The user assigned to the pull request.",
-          type: "parent-field",
+          type: "object",
+          isArray: false,
           childrenFields: [
             {
               name: "login",
@@ -163,7 +166,8 @@ const GITHUB_PULL_REQUEST_EVENT: WebhookEvent = {
         {
           name: "assignees",
           description: "The users assigned to the pull request.",
-          type: "parent-of-array",
+          type: "object",
+          isArray: true,
           childrenFields: [
             {
               name: "login",
@@ -196,7 +200,8 @@ const GITHUB_PULL_REQUEST_EVENT: WebhookEvent = {
         {
           name: "requested_reviewers",
           description: "The users requested to review the pull request.",
-          type: "parent-of-array",
+          type: "object",
+          isArray: true,
           childrenFields: [
             {
               name: "login",
@@ -227,14 +232,10 @@ const GITHUB_PULL_REQUEST_EVENT: WebhookEvent = {
           ],
         },
         {
-          name: "requested_teams",
-          description: "The teams requested to review the pull request.",
-          type: "unknown-object",
-        },
-        {
           name: "labels",
           description: "The labels applied to the pull request.",
-          type: "parent-of-array",
+          type: "object",
+          isArray: true,
           childrenFields: [
             {
               name: "id",
@@ -266,7 +267,8 @@ const GITHUB_PULL_REQUEST_EVENT: WebhookEvent = {
         {
           name: "head",
           description: "The head branch of the pull request.",
-          type: "parent-field",
+          type: "object",
+          isArray: false,
           childrenFields: [
             {
               name: "label",
@@ -283,7 +285,8 @@ const GITHUB_PULL_REQUEST_EVENT: WebhookEvent = {
         {
           name: "base",
           description: "The base branch of the pull request.",
-          type: "parent-field",
+          type: "object",
+          isArray: false,
           childrenFields: [
             {
               name: "label",
@@ -340,14 +343,10 @@ const GITHUB_PULL_REQUEST_EVENT: WebhookEvent = {
       ],
     },
     {
-      name: "repository",
-      description: "The repository where the event occurred.",
-      type: "unknown-object",
-    },
-    {
       name: "sender",
       description: "The user that triggered the event.",
-      type: "parent-field",
+      type: "object",
+      isArray: false,
       childrenFields: [
         {
           name: "login",
@@ -417,7 +416,8 @@ const GITHUB_ISSUES_EVENT: WebhookEvent = {
     {
       name: "issue",
       description: "The issue itself.",
-      type: "parent-field",
+      type: "object",
+      isArray: false,
       childrenFields: [
         {
           name: "url",
@@ -442,7 +442,8 @@ const GITHUB_ISSUES_EVENT: WebhookEvent = {
         {
           name: "user",
           description: "The user who created the issue.",
-          type: "parent-field",
+          type: "object",
+          isArray: false,
           childrenFields: [
             {
               name: "login",
@@ -475,7 +476,8 @@ const GITHUB_ISSUES_EVENT: WebhookEvent = {
         {
           name: "labels",
           description: "The labels applied to the issue.",
-          type: "parent-of-array",
+          type: "object",
+          isArray: true,
           childrenFields: [
             {
               name: "id",
@@ -513,7 +515,8 @@ const GITHUB_ISSUES_EVENT: WebhookEvent = {
         {
           name: "assignee",
           description: "The user assigned to the issue.",
-          type: "parent-field",
+          type: "object",
+          isArray: false,
           childrenFields: [
             {
               name: "login",
@@ -541,7 +544,8 @@ const GITHUB_ISSUES_EVENT: WebhookEvent = {
         {
           name: "assignees",
           description: "The users assigned to the issue.",
-          type: "parent-of-array",
+          type: "object",
+          isArray: true,
           childrenFields: [
             {
               name: "login",
@@ -612,7 +616,8 @@ const GITHUB_ISSUES_EVENT: WebhookEvent = {
       name: "assignee",
       description:
         "The optional user who was assigned or unassigned from the issue.",
-      type: "parent-field",
+      type: "object",
+      isArray: false,
       childrenFields: [
         {
           name: "login",
@@ -646,7 +651,8 @@ const GITHUB_ISSUES_EVENT: WebhookEvent = {
       name: "label",
       description:
         "The optional label that was added or removed from the issue.",
-      type: "parent-field",
+      type: "object",
+      isArray: false,
       childrenFields: [
         {
           name: "id",
@@ -668,7 +674,8 @@ const GITHUB_ISSUES_EVENT: WebhookEvent = {
     {
       name: "sender",
       description: "The user that triggered the event.",
-      type: "parent-field",
+      type: "object",
+      isArray: false,
       childrenFields: [
         {
           name: "login",

--- a/front/types/triggers/github_webhook_source_presets.ts
+++ b/front/types/triggers/github_webhook_source_presets.ts
@@ -1,6 +1,6 @@
-import type { EventType, PresetWebhookType } from "./webhooks_source_preset";
+import type { WebhookEvent, PresetWebhook } from "./webhooks_source_preset";
 
-const GITHUB_PULL_REQUEST_EVENT: EventType = {
+const GITHUB_PULL_REQUEST_EVENT: WebhookEvent = {
   name: "pull_request",
   value: "pull_request",
   description:
@@ -42,7 +42,7 @@ const GITHUB_PULL_REQUEST_EVENT: EventType = {
       name: "pull_request",
       description: "The pull request itself.",
       type: "parent-field",
-      childrentFields: [
+      childrenFields: [
         {
           name: "html_url",
           description: "The GitHub web URL of the pull request.",
@@ -78,7 +78,7 @@ const GITHUB_PULL_REQUEST_EVENT: EventType = {
           name: "user",
           description: "The user who created the pull request.",
           type: "parent-field",
-          childrentFields: [
+          childrenFields: [
             {
               name: "login",
               description: "The username of the user.",
@@ -131,7 +131,7 @@ const GITHUB_PULL_REQUEST_EVENT: EventType = {
           name: "assignee",
           description: "The user assigned to the pull request.",
           type: "parent-field",
-          childrentFields: [
+          childrenFields: [
             {
               name: "login",
               description: "The username of the user.",
@@ -164,7 +164,7 @@ const GITHUB_PULL_REQUEST_EVENT: EventType = {
           name: "assignees",
           description: "The users assigned to the pull request.",
           type: "parent-of-array",
-          childrentFields: [
+          childrenFields: [
             {
               name: "login",
               description: "The username of the user.",
@@ -197,7 +197,7 @@ const GITHUB_PULL_REQUEST_EVENT: EventType = {
           name: "requested_reviewers",
           description: "The users requested to review the pull request.",
           type: "parent-of-array",
-          childrentFields: [
+          childrenFields: [
             {
               name: "login",
               description: "The username of the user.",
@@ -235,7 +235,7 @@ const GITHUB_PULL_REQUEST_EVENT: EventType = {
           name: "labels",
           description: "The labels applied to the pull request.",
           type: "parent-of-array",
-          childrentFields: [
+          childrenFields: [
             {
               name: "id",
               description: "The unique identifier of the label.",
@@ -267,7 +267,7 @@ const GITHUB_PULL_REQUEST_EVENT: EventType = {
           name: "head",
           description: "The head branch of the pull request.",
           type: "parent-field",
-          childrentFields: [
+          childrenFields: [
             {
               name: "label",
               description: "The label of the head branch.",
@@ -284,7 +284,7 @@ const GITHUB_PULL_REQUEST_EVENT: EventType = {
           name: "base",
           description: "The base branch of the pull request.",
           type: "parent-field",
-          childrentFields: [
+          childrenFields: [
             {
               name: "label",
               description: "The label of the base branch.",
@@ -348,7 +348,7 @@ const GITHUB_PULL_REQUEST_EVENT: EventType = {
       name: "sender",
       description: "The user that triggered the event.",
       type: "parent-field",
-      childrentFields: [
+      childrenFields: [
         {
           name: "login",
           description: "The username of the user.",
@@ -385,7 +385,7 @@ const GITHUB_PULL_REQUEST_EVENT: EventType = {
   ],
 };
 
-const GITHUB_ISSUES_EVENT: EventType = {
+const GITHUB_ISSUES_EVENT: WebhookEvent = {
   name: "issues",
   value: "issues",
   description:
@@ -418,7 +418,7 @@ const GITHUB_ISSUES_EVENT: EventType = {
       name: "issue",
       description: "The issue itself.",
       type: "parent-field",
-      childrentFields: [
+      childrenFields: [
         {
           name: "url",
           description: "The API URL of the issue.",
@@ -443,7 +443,7 @@ const GITHUB_ISSUES_EVENT: EventType = {
           name: "user",
           description: "The user who created the issue.",
           type: "parent-field",
-          childrentFields: [
+          childrenFields: [
             {
               name: "login",
               description: "The username of the user.",
@@ -476,7 +476,7 @@ const GITHUB_ISSUES_EVENT: EventType = {
           name: "labels",
           description: "The labels applied to the issue.",
           type: "parent-of-array",
-          childrentFields: [
+          childrenFields: [
             {
               name: "id",
               description: "The unique identifier of the label.",
@@ -514,7 +514,7 @@ const GITHUB_ISSUES_EVENT: EventType = {
           name: "assignee",
           description: "The user assigned to the issue.",
           type: "parent-field",
-          childrentFields: [
+          childrenFields: [
             {
               name: "login",
               description: "The username of the user.",
@@ -542,7 +542,7 @@ const GITHUB_ISSUES_EVENT: EventType = {
           name: "assignees",
           description: "The users assigned to the issue.",
           type: "parent-of-array",
-          childrentFields: [
+          childrenFields: [
             {
               name: "login",
               description: "The username of the user.",
@@ -613,7 +613,7 @@ const GITHUB_ISSUES_EVENT: EventType = {
       description:
         "The optional user who was assigned or unassigned from the issue.",
       type: "parent-field",
-      childrentFields: [
+      childrenFields: [
         {
           name: "login",
           description: "The username of the user.",
@@ -647,7 +647,7 @@ const GITHUB_ISSUES_EVENT: EventType = {
       description:
         "The optional label that was added or removed from the issue.",
       type: "parent-field",
-      childrentFields: [
+      childrenFields: [
         {
           name: "id",
           description: "The unique identifier of the label.",
@@ -669,7 +669,7 @@ const GITHUB_ISSUES_EVENT: EventType = {
       name: "sender",
       description: "The user that triggered the event.",
       type: "parent-field",
-      childrentFields: [
+      childrenFields: [
         {
           name: "login",
           description: "The username of the user.",
@@ -701,7 +701,7 @@ const GITHUB_ISSUES_EVENT: EventType = {
   ],
 };
 
-export const GITHUB_WEBHOOK_PRESET: PresetWebhookType = {
+export const GITHUB_WEBHOOK_PRESET: PresetWebhook = {
   name: "GitHub",
   eventCheck: {
     type: "header",

--- a/front/types/triggers/github_webhook_source_presets.ts
+++ b/front/types/triggers/github_webhook_source_presets.ts
@@ -1,0 +1,415 @@
+import type { EventType, PresetWebhookType } from "./webhooks_source_preset";
+
+const GITHUB_PULL_REQUEST_EVENT: EventType = {
+  name: "pull_request",
+  value: "pull_request",
+  description:
+    "Activity related to pull requests. The type of activity is specified in the `action` property of the payload object.",
+  fields: [
+    {
+      name: "action",
+      description: "The action that was performed on the pull request.",
+      type: "enum",
+      enumValues: [
+        "assigned",
+        "auto_merge_disabled",
+        "auto_merge_enabled",
+        "closed",
+        "converted_to_draft",
+        "dequeued",
+        "edited",
+        "enqueued",
+        "labeled",
+        "locked",
+        "merged",
+        "opened",
+        "ready_for_review",
+        "reopened",
+        "review_request_removed",
+        "review_requested",
+        "synchronize",
+        "unassigned",
+        "unlabeled",
+        "unlocked",
+      ],
+    },
+    {
+      name: "number",
+      description: "The pull request number.",
+      type: "number",
+    },
+    {
+      name: "pull_request",
+      description: "The pull request itself.",
+      type: "unknown-object",
+    },
+    {
+      name: "repository",
+      description: "The repository where the event occurred.",
+      type: "unknown-object",
+    },
+    {
+      name: "sender",
+      description: "The user that triggered the event.",
+      type: "parent-field",
+      childrentFields: [
+        {
+          name: "login",
+          description: "The username of the user.",
+          type: "string",
+        },
+        {
+          name: "id",
+          description: "The unique identifier of the user.",
+          type: "number",
+        },
+        {
+          name: "url",
+          description: "The API URL of the user.",
+          type: "string",
+        },
+        {
+          name: "html_url",
+          description: "The GitHub profile URL of the user.",
+          type: "string",
+        },
+        {
+          name: "type",
+          description: "The type of the user account.",
+          type: "enum",
+          enumValues: ["User", "Organization"],
+        },
+        {
+          name: "site_admin",
+          description: "Whether the user is a GitHub site administrator.",
+          type: "boolean",
+        },
+      ],
+    },
+  ],
+};
+
+const GITHUB_ISSUES_EVENT: EventType = {
+  name: "issues",
+  value: "issues",
+  description:
+    "Activity related to an issue. The type of activity is specified in the `action` property of the payload object.",
+  fields: [
+    {
+      name: "action",
+      description: "The action that was performed on the issue.",
+      type: "enum",
+      enumValues: [
+        "assigned",
+        "closed",
+        "deleted",
+        "demilestoned",
+        "edited",
+        "labeled",
+        "locked",
+        "milestoned",
+        "opened",
+        "pinned",
+        "reopened",
+        "transferred",
+        "unassigned",
+        "unlabeled",
+        "unlocked",
+        "unpinned",
+      ],
+    },
+    {
+      name: "issue",
+      description: "The issue itself.",
+      type: "parent-field",
+      childrentFields: [
+        {
+          name: "url",
+          description: "The API URL of the issue.",
+          type: "string",
+        },
+        {
+          name: "id",
+          description: "The unique identifier of the issue.",
+          type: "number",
+        },
+        {
+          name: "number",
+          description: "The issue number.",
+          type: "number",
+        },
+        {
+          name: "title",
+          description: "The title of the issue.",
+          type: "string",
+        },
+        {
+          name: "user",
+          description: "The user who created the issue.",
+          type: "parent-field",
+          childrentFields: [
+            {
+              name: "login",
+              description: "The username of the user.",
+              type: "string",
+            },
+            {
+              name: "id",
+              description: "The unique identifier of the user.",
+              type: "number",
+            },
+            {
+              name: "html_url",
+              description: "The GitHub profile URL of the user.",
+              type: "string",
+            },
+            {
+              name: "type",
+              description: "The type of the user account.",
+              type: "enum",
+              enumValues: ["User", "Organization"],
+            },
+            {
+              name: "site_admin",
+              description: "Whether the user is a GitHub site administrator.",
+              type: "boolean",
+            },
+          ],
+        },
+        {
+          name: "labels",
+          description: "The labels applied to the issue.",
+          type: "parent-of-array",
+          childrentFields: [
+            {
+              name: "id",
+              description: "The unique identifier of the label.",
+              type: "number",
+            },
+            {
+              name: "url",
+              description: "The API URL of the label.",
+              type: "string",
+            },
+            {
+              name: "name",
+              description: "The name of the label.",
+              type: "string",
+            },
+            {
+              name: "default",
+              description: "Whether this is a default label.",
+              type: "boolean",
+            },
+          ],
+        },
+        {
+          name: "state",
+          description: "The state of the issue.",
+          type: "enum",
+          enumValues: ["open", "closed", "all"],
+        },
+        {
+          name: "locked",
+          description: "Whether the issue is locked.",
+          type: "boolean",
+        },
+        {
+          name: "assignee",
+          description: "The user assigned to the issue.",
+          type: "parent-field",
+          childrentFields: [
+            {
+              name: "login",
+              description: "The username of the user.",
+              type: "string",
+            },
+            {
+              name: "id",
+              description: "The unique identifier of the user.",
+              type: "number",
+            },
+            {
+              name: "html_url",
+              description: "The GitHub profile URL of the user.",
+              type: "string",
+            },
+            {
+              name: "type",
+              description: "The type of the user account.",
+              type: "enum",
+              enumValues: ["User", "Organization"],
+            },
+          ],
+        },
+        {
+          name: "assignees",
+          description: "The users assigned to the issue.",
+          type: "parent-of-array",
+          childrentFields: [
+            {
+              name: "login",
+              description: "The username of the user.",
+              type: "string",
+            },
+            {
+              name: "id",
+              description: "The unique identifier of the user.",
+              type: "number",
+            },
+            {
+              name: "html_url",
+              description: "The GitHub profile URL of the user.",
+              type: "string",
+            },
+            {
+              name: "type",
+              description: "The type of the user account.",
+              type: "enum",
+              enumValues: ["User", "Organization"],
+            },
+            {
+              name: "site_admin",
+              description: "Whether the user is a GitHub site administrator.",
+              type: "boolean",
+            },
+          ],
+        },
+        {
+          name: "milestone",
+          description: "The milestone associated with the issue.",
+          type: "unknown-object",
+        },
+        {
+          name: "comments",
+          description: "The number of comments on the issue.",
+          type: "number",
+        },
+        {
+          name: "created_at",
+          description: "The timestamp when the issue was created.",
+          type: "string",
+        },
+        {
+          name: "updated_at",
+          description: "The timestamp when the issue was last updated.",
+          type: "string",
+        },
+        {
+          name: "closed_at",
+          description: "The timestamp when the issue was closed.",
+          type: "string",
+        },
+        {
+          name: "author_association",
+          description: "The association of the author with the repository.",
+          type: "string",
+        },
+        {
+          name: "body",
+          description: "The body content of the issue.",
+          type: "string",
+        },
+      ],
+    },
+    {
+      name: "assignee",
+      description:
+        "The optional user who was assigned or unassigned from the issue.",
+      type: "parent-field",
+      childrentFields: [
+        {
+          name: "login",
+          description: "The username of the user.",
+          type: "string",
+        },
+        {
+          name: "id",
+          description: "The unique identifier of the user.",
+          type: "number",
+        },
+        {
+          name: "html_url",
+          description: "The GitHub profile URL of the user.",
+          type: "string",
+        },
+        {
+          name: "type",
+          description: "The type of the user account.",
+          type: "enum",
+          enumValues: ["User", "Organization"],
+        },
+        {
+          name: "site_admin",
+          description: "Whether the user is a GitHub site administrator.",
+          type: "boolean",
+        },
+      ],
+    },
+    {
+      name: "label",
+      description:
+        "The optional label that was added or removed from the issue.",
+      type: "parent-field",
+      childrentFields: [
+        {
+          name: "id",
+          description: "The unique identifier of the label.",
+          type: "number",
+        },
+        {
+          name: "url",
+          description: "The API URL of the label.",
+          type: "string",
+        },
+        {
+          name: "name",
+          description: "The name of the label.",
+          type: "string",
+        },
+      ],
+    },
+    {
+      name: "sender",
+      description: "The user that triggered the event.",
+      type: "parent-field",
+      childrentFields: [
+        {
+          name: "login",
+          description: "The username of the user.",
+          type: "string",
+        },
+        {
+          name: "id",
+          description: "The unique identifier of the user.",
+          type: "number",
+        },
+        {
+          name: "html_url",
+          description: "The GitHub profile URL of the user.",
+          type: "string",
+        },
+        {
+          name: "type",
+          description: "The type of the user account.",
+          type: "enum",
+          enumValues: ["User", "Organization"],
+        },
+        {
+          name: "site_admin",
+          description: "Whether the user is a GitHub site administrator.",
+          type: "boolean",
+        },
+      ],
+    },
+  ],
+};
+
+export const GITHUB_WEBHOOK_PRESET: PresetWebhookType = {
+  name: "GitHub",
+  eventCheck: {
+    type: "header",
+    field: "X-GitHub-Event",
+  },
+  events: [GITHUB_PULL_REQUEST_EVENT, GITHUB_ISSUES_EVENT],
+};

--- a/front/types/triggers/github_webhook_source_presets.ts
+++ b/front/types/triggers/github_webhook_source_presets.ts
@@ -41,7 +41,303 @@ const GITHUB_PULL_REQUEST_EVENT: EventType = {
     {
       name: "pull_request",
       description: "The pull request itself.",
-      type: "unknown-object",
+      type: "parent-field",
+      childrentFields: [
+        {
+          name: "html_url",
+          description: "The GitHub web URL of the pull request.",
+          type: "string",
+        },
+        {
+          name: "id",
+          description: "The unique identifier of the pull request.",
+          type: "number",
+        },
+        {
+          name: "number",
+          description: "The pull request number.",
+          type: "number",
+        },
+        {
+          name: "state",
+          description: "The state of the pull request.",
+          type: "enum",
+          enumValues: ["open", "closed"],
+        },
+        {
+          name: "locked",
+          description: "Whether the pull request is locked.",
+          type: "boolean",
+        },
+        {
+          name: "title",
+          description: "The title of the pull request.",
+          type: "string",
+        },
+        {
+          name: "user",
+          description: "The user who created the pull request.",
+          type: "parent-field",
+          childrentFields: [
+            {
+              name: "login",
+              description: "The username of the user.",
+              type: "string",
+            },
+            {
+              name: "id",
+              description: "The unique identifier of the user.",
+              type: "number",
+            },
+            {
+              name: "html_url",
+              description: "The GitHub profile URL of the user.",
+              type: "string",
+            },
+            {
+              name: "type",
+              description: "The type of the user account.",
+              type: "enum",
+              enumValues: ["User", "Organization"],
+            },
+            {
+              name: "site_admin",
+              description: "Whether the user is a GitHub site administrator.",
+              type: "boolean",
+            },
+          ],
+        },
+        {
+          name: "body",
+          description: "The body content of the pull request.",
+          type: "string",
+        },
+        {
+          name: "created_at",
+          description: "The timestamp when the pull request was created.",
+          type: "string",
+        },
+        {
+          name: "updated_at",
+          description: "The timestamp when the pull request was last updated.",
+          type: "string",
+        },
+        {
+          name: "merged_at",
+          description: "The timestamp when the pull request was merged.",
+          type: "string",
+        },
+        {
+          name: "assignee",
+          description: "The user assigned to the pull request.",
+          type: "parent-field",
+          childrentFields: [
+            {
+              name: "login",
+              description: "The username of the user.",
+              type: "string",
+            },
+            {
+              name: "id",
+              description: "The unique identifier of the user.",
+              type: "number",
+            },
+            {
+              name: "html_url",
+              description: "The GitHub profile URL of the user.",
+              type: "string",
+            },
+            {
+              name: "type",
+              description: "The type of the user account.",
+              type: "enum",
+              enumValues: ["User", "Organization"],
+            },
+            {
+              name: "site_admin",
+              description: "Whether the user is a GitHub site administrator.",
+              type: "boolean",
+            },
+          ],
+        },
+        {
+          name: "assignees",
+          description: "The users assigned to the pull request.",
+          type: "parent-of-array",
+          childrentFields: [
+            {
+              name: "login",
+              description: "The username of the user.",
+              type: "string",
+            },
+            {
+              name: "id",
+              description: "The unique identifier of the user.",
+              type: "number",
+            },
+            {
+              name: "html_url",
+              description: "The GitHub profile URL of the user.",
+              type: "string",
+            },
+            {
+              name: "type",
+              description: "The type of the user account.",
+              type: "enum",
+              enumValues: ["User", "Organization"],
+            },
+            {
+              name: "site_admin",
+              description: "Whether the user is a GitHub site administrator.",
+              type: "boolean",
+            },
+          ],
+        },
+        {
+          name: "requested_reviewers",
+          description: "The users requested to review the pull request.",
+          type: "parent-of-array",
+          childrentFields: [
+            {
+              name: "login",
+              description: "The username of the user.",
+              type: "string",
+            },
+            {
+              name: "id",
+              description: "The unique identifier of the user.",
+              type: "number",
+            },
+            {
+              name: "html_url",
+              description: "The GitHub profile URL of the user.",
+              type: "string",
+            },
+            {
+              name: "type",
+              description: "The type of the user account.",
+              type: "enum",
+              enumValues: ["User", "Organization"],
+            },
+            {
+              name: "site_admin",
+              description: "Whether the user is a GitHub site administrator.",
+              type: "boolean",
+            },
+          ],
+        },
+        {
+          name: "requested_teams",
+          description: "The teams requested to review the pull request.",
+          type: "unknown-object",
+        },
+        {
+          name: "labels",
+          description: "The labels applied to the pull request.",
+          type: "parent-of-array",
+          childrentFields: [
+            {
+              name: "id",
+              description: "The unique identifier of the label.",
+              type: "number",
+            },
+            {
+              name: "url",
+              description: "The API URL of the label.",
+              type: "string",
+            },
+            {
+              name: "name",
+              description: "The name of the label.",
+              type: "string",
+            },
+            {
+              name: "default",
+              description: "Whether this is a default label.",
+              type: "boolean",
+            },
+          ],
+        },
+        {
+          name: "milestone",
+          description: "The milestone associated with the pull request.",
+          type: "unknown-object",
+        },
+        {
+          name: "head",
+          description: "The head branch of the pull request.",
+          type: "parent-field",
+          childrentFields: [
+            {
+              name: "label",
+              description: "The label of the head branch.",
+              type: "string",
+            },
+            {
+              name: "ref",
+              description: "The ref of the head branch.",
+              type: "string",
+            },
+          ],
+        },
+        {
+          name: "base",
+          description: "The base branch of the pull request.",
+          type: "parent-field",
+          childrentFields: [
+            {
+              name: "label",
+              description: "The label of the base branch.",
+              type: "string",
+            },
+            {
+              name: "ref",
+              description: "The ref of the base branch.",
+              type: "string",
+            },
+          ],
+        },
+        {
+          name: "draft",
+          description: "Whether the pull request is a draft.",
+          type: "boolean",
+        },
+        {
+          name: "merged",
+          description: "Whether the pull request has been merged.",
+          type: "boolean",
+        },
+        {
+          name: "mergeable",
+          description: "Whether the pull request is mergeable.",
+          type: "boolean",
+        },
+        {
+          name: "comments",
+          description: "The number of comments on the pull request.",
+          type: "number",
+        },
+        {
+          name: "commits",
+          description: "The number of commits in the pull request.",
+          type: "number",
+        },
+        {
+          name: "additions",
+          description: "The number of additions in the pull request.",
+          type: "number",
+        },
+        {
+          name: "deletions",
+          description: "The number of deletions in the pull request.",
+          type: "number",
+        },
+        {
+          name: "changed_files",
+          description: "The number of changed files in the pull request.",
+          type: "number",
+        },
+      ],
     },
     {
       name: "repository",

--- a/front/types/triggers/github_webhook_source_presets.ts
+++ b/front/types/triggers/github_webhook_source_presets.ts
@@ -123,6 +123,277 @@ const MILESTONE_CHILDREN_FIELDS: EventField[] = [
   },
 ];
 
+const PULL_REQUEST_OBJECT_CHILDREN_FIELDS: EventField[] = [
+  {
+    name: "html_url",
+    description: "The GitHub web URL of the pull request.",
+    type: "string",
+  },
+  {
+    name: "id",
+    description: "The unique identifier of the pull request.",
+    type: "number",
+  },
+  {
+    name: "number",
+    description: "The pull request number.",
+    type: "number",
+  },
+  {
+    name: "state",
+    description: "The state of the pull request.",
+    type: "enum",
+    enumValues: ["open", "closed"],
+  },
+  {
+    name: "locked",
+    description: "Whether the pull request is locked.",
+    type: "boolean",
+  },
+  {
+    name: "title",
+    description: "The title of the pull request.",
+    type: "string",
+  },
+  {
+    name: "user",
+    description: "The user who created the pull request.",
+    type: "object",
+    isArray: false,
+    childrenFields: USER_CHILDREN_FIELDS,
+  },
+  {
+    name: "body",
+    description: "The body content of the pull request.",
+    type: "string",
+  },
+  {
+    name: "created_at",
+    description: "The timestamp when the pull request was created.",
+    type: "string",
+  },
+  {
+    name: "updated_at",
+    description: "The timestamp when the pull request was last updated.",
+    type: "string",
+  },
+  {
+    name: "merged_at",
+    description: "The timestamp when the pull request was merged.",
+    type: "string",
+  },
+  {
+    name: "assignee",
+    description: "The user assigned to the pull request.",
+    type: "object",
+    isArray: false,
+    childrenFields: USER_CHILDREN_FIELDS,
+  },
+  {
+    name: "assignees",
+    description: "The users assigned to the pull request.",
+    type: "object",
+    isArray: true,
+    childrenFields: USER_CHILDREN_FIELDS,
+  },
+  {
+    name: "requested_reviewers",
+    description: "The users requested to review the pull request.",
+    type: "object",
+    isArray: true,
+    childrenFields: USER_CHILDREN_FIELDS,
+  },
+  {
+    name: "labels",
+    description: "The labels applied to the pull request.",
+    type: "object",
+    isArray: true,
+    childrenFields: LABEL_CHILDREN_FIELDS,
+  },
+  {
+    name: "milestone",
+    description: "The milestone associated with the pull request.",
+    type: "object",
+    isArray: false,
+    childrenFields: MILESTONE_CHILDREN_FIELDS,
+  },
+  {
+    name: "head",
+    description: "The head branch of the pull request.",
+    type: "object",
+    isArray: false,
+    childrenFields: [
+      {
+        name: "label",
+        description: "The label of the head branch.",
+        type: "string",
+      },
+      {
+        name: "ref",
+        description: "The ref of the head branch.",
+        type: "string",
+      },
+    ],
+  },
+  {
+    name: "base",
+    description: "The base branch of the pull request.",
+    type: "object",
+    isArray: false,
+    childrenFields: [
+      {
+        name: "label",
+        description: "The label of the base branch.",
+        type: "string",
+      },
+      {
+        name: "ref",
+        description: "The ref of the base branch.",
+        type: "string",
+      },
+    ],
+  },
+  {
+    name: "draft",
+    description: "Whether the pull request is a draft.",
+    type: "boolean",
+  },
+  {
+    name: "merged",
+    description: "Whether the pull request has been merged.",
+    type: "boolean",
+  },
+  {
+    name: "mergeable",
+    description: "Whether the pull request is mergeable.",
+    type: "boolean",
+  },
+  {
+    name: "comments",
+    description: "The number of comments on the pull request.",
+    type: "number",
+  },
+  {
+    name: "commits",
+    description: "The number of commits in the pull request.",
+    type: "number",
+  },
+  {
+    name: "additions",
+    description: "The number of additions in the pull request.",
+    type: "number",
+  },
+  {
+    name: "deletions",
+    description: "The number of deletions in the pull request.",
+    type: "number",
+  },
+  {
+    name: "changed_files",
+    description: "The number of changed files in the pull request.",
+    type: "number",
+  },
+];
+
+const ISSUE_OBJECT_CHILDREN_FIELDS: EventField[] = [
+  {
+    name: "url",
+    description: "The API URL of the issue.",
+    type: "string",
+  },
+  {
+    name: "id",
+    description: "The unique identifier of the issue.",
+    type: "number",
+  },
+  {
+    name: "number",
+    description: "The issue number.",
+    type: "number",
+  },
+  {
+    name: "title",
+    description: "The title of the issue.",
+    type: "string",
+  },
+  {
+    name: "user",
+    description: "The user who created the issue.",
+    type: "object",
+    isArray: false,
+    childrenFields: USER_CHILDREN_FIELDS,
+  },
+  {
+    name: "labels",
+    description: "The labels applied to the issue.",
+    type: "object",
+    isArray: true,
+    childrenFields: LABEL_CHILDREN_FIELDS,
+  },
+  {
+    name: "state",
+    description: "The state of the issue.",
+    type: "enum",
+    enumValues: ["open", "closed", "all"],
+  },
+  {
+    name: "locked",
+    description: "Whether the issue is locked.",
+    type: "boolean",
+  },
+  {
+    name: "assignee",
+    description: "The user assigned to the issue.",
+    type: "object",
+    isArray: false,
+    childrenFields: USER_CHILDREN_FIELDS,
+  },
+  {
+    name: "assignees",
+    description: "The users assigned to the issue.",
+    type: "object",
+    isArray: true,
+    childrenFields: USER_CHILDREN_FIELDS,
+  },
+  {
+    name: "milestone",
+    description: "The milestone associated with the issue.",
+    type: "object",
+    isArray: false,
+    childrenFields: MILESTONE_CHILDREN_FIELDS,
+  },
+  {
+    name: "comments",
+    description: "The number of comments on the issue.",
+    type: "number",
+  },
+  {
+    name: "created_at",
+    description: "The timestamp when the issue was created.",
+    type: "string",
+  },
+  {
+    name: "updated_at",
+    description: "The timestamp when the issue was last updated.",
+    type: "string",
+  },
+  {
+    name: "closed_at",
+    description: "The timestamp when the issue was closed.",
+    type: "string",
+  },
+  {
+    name: "author_association",
+    description: "The association of the author with the repository.",
+    type: "string",
+  },
+  {
+    name: "body",
+    description: "The body content of the issue.",
+    type: "string",
+  },
+];
+
 const GITHUB_PULL_REQUEST_EVENT: WebhookEvent = {
   name: "pull_request",
   value: "pull_request",
@@ -166,177 +437,7 @@ const GITHUB_PULL_REQUEST_EVENT: WebhookEvent = {
       description: "The pull request itself.",
       type: "object",
       isArray: false,
-      childrenFields: [
-        {
-          name: "html_url",
-          description: "The GitHub web URL of the pull request.",
-          type: "string",
-        },
-        {
-          name: "id",
-          description: "The unique identifier of the pull request.",
-          type: "number",
-        },
-        {
-          name: "number",
-          description: "The pull request number.",
-          type: "number",
-        },
-        {
-          name: "state",
-          description: "The state of the pull request.",
-          type: "enum",
-          enumValues: ["open", "closed"],
-        },
-        {
-          name: "locked",
-          description: "Whether the pull request is locked.",
-          type: "boolean",
-        },
-        {
-          name: "title",
-          description: "The title of the pull request.",
-          type: "string",
-        },
-        {
-          name: "user",
-          description: "The user who created the pull request.",
-          type: "object",
-          isArray: false,
-          childrenFields: USER_CHILDREN_FIELDS,
-        },
-        {
-          name: "body",
-          description: "The body content of the pull request.",
-          type: "string",
-        },
-        {
-          name: "created_at",
-          description: "The timestamp when the pull request was created.",
-          type: "string",
-        },
-        {
-          name: "updated_at",
-          description: "The timestamp when the pull request was last updated.",
-          type: "string",
-        },
-        {
-          name: "merged_at",
-          description: "The timestamp when the pull request was merged.",
-          type: "string",
-        },
-        {
-          name: "assignee",
-          description: "The user assigned to the pull request.",
-          type: "object",
-          isArray: false,
-          childrenFields: USER_CHILDREN_FIELDS,
-        },
-        {
-          name: "assignees",
-          description: "The users assigned to the pull request.",
-          type: "object",
-          isArray: true,
-          childrenFields: USER_CHILDREN_FIELDS,
-        },
-        {
-          name: "requested_reviewers",
-          description: "The users requested to review the pull request.",
-          type: "object",
-          isArray: true,
-          childrenFields: USER_CHILDREN_FIELDS,
-        },
-        {
-          name: "labels",
-          description: "The labels applied to the pull request.",
-          type: "object",
-          isArray: true,
-          childrenFields: LABEL_CHILDREN_FIELDS,
-        },
-        {
-          name: "milestone",
-          description: "The milestone associated with the pull request.",
-          type: "object",
-          isArray: false,
-          childrenFields: MILESTONE_CHILDREN_FIELDS,
-        },
-        {
-          name: "head",
-          description: "The head branch of the pull request.",
-          type: "object",
-          isArray: false,
-          childrenFields: [
-            {
-              name: "label",
-              description: "The label of the head branch.",
-              type: "string",
-            },
-            {
-              name: "ref",
-              description: "The ref of the head branch.",
-              type: "string",
-            },
-          ],
-        },
-        {
-          name: "base",
-          description: "The base branch of the pull request.",
-          type: "object",
-          isArray: false,
-          childrenFields: [
-            {
-              name: "label",
-              description: "The label of the base branch.",
-              type: "string",
-            },
-            {
-              name: "ref",
-              description: "The ref of the base branch.",
-              type: "string",
-            },
-          ],
-        },
-        {
-          name: "draft",
-          description: "Whether the pull request is a draft.",
-          type: "boolean",
-        },
-        {
-          name: "merged",
-          description: "Whether the pull request has been merged.",
-          type: "boolean",
-        },
-        {
-          name: "mergeable",
-          description: "Whether the pull request is mergeable.",
-          type: "boolean",
-        },
-        {
-          name: "comments",
-          description: "The number of comments on the pull request.",
-          type: "number",
-        },
-        {
-          name: "commits",
-          description: "The number of commits in the pull request.",
-          type: "number",
-        },
-        {
-          name: "additions",
-          description: "The number of additions in the pull request.",
-          type: "number",
-        },
-        {
-          name: "deletions",
-          description: "The number of deletions in the pull request.",
-          type: "number",
-        },
-        {
-          name: "changed_files",
-          description: "The number of changed files in the pull request.",
-          type: "number",
-        },
-      ],
+      childrenFields: PULL_REQUEST_OBJECT_CHILDREN_FIELDS,
     },
     {
       name: "sender",
@@ -382,104 +483,7 @@ const GITHUB_ISSUES_EVENT: WebhookEvent = {
       description: "The issue itself.",
       type: "object",
       isArray: false,
-      childrenFields: [
-        {
-          name: "url",
-          description: "The API URL of the issue.",
-          type: "string",
-        },
-        {
-          name: "id",
-          description: "The unique identifier of the issue.",
-          type: "number",
-        },
-        {
-          name: "number",
-          description: "The issue number.",
-          type: "number",
-        },
-        {
-          name: "title",
-          description: "The title of the issue.",
-          type: "string",
-        },
-        {
-          name: "user",
-          description: "The user who created the issue.",
-          type: "object",
-          isArray: false,
-          childrenFields: USER_CHILDREN_FIELDS,
-        },
-        {
-          name: "labels",
-          description: "The labels applied to the issue.",
-          type: "object",
-          isArray: true,
-          childrenFields: LABEL_CHILDREN_FIELDS,
-        },
-        {
-          name: "state",
-          description: "The state of the issue.",
-          type: "enum",
-          enumValues: ["open", "closed", "all"],
-        },
-        {
-          name: "locked",
-          description: "Whether the issue is locked.",
-          type: "boolean",
-        },
-        {
-          name: "assignee",
-          description: "The user assigned to the issue.",
-          type: "object",
-          isArray: false,
-          childrenFields: USER_CHILDREN_FIELDS,
-        },
-        {
-          name: "assignees",
-          description: "The users assigned to the issue.",
-          type: "object",
-          isArray: true,
-          childrenFields: USER_CHILDREN_FIELDS,
-        },
-        {
-          name: "milestone",
-          description: "The milestone associated with the issue.",
-          type: "object",
-          isArray: false,
-          childrenFields: MILESTONE_CHILDREN_FIELDS,
-        },
-        {
-          name: "comments",
-          description: "The number of comments on the issue.",
-          type: "number",
-        },
-        {
-          name: "created_at",
-          description: "The timestamp when the issue was created.",
-          type: "string",
-        },
-        {
-          name: "updated_at",
-          description: "The timestamp when the issue was last updated.",
-          type: "string",
-        },
-        {
-          name: "closed_at",
-          description: "The timestamp when the issue was closed.",
-          type: "string",
-        },
-        {
-          name: "author_association",
-          description: "The association of the author with the repository.",
-          type: "string",
-        },
-        {
-          name: "body",
-          description: "The body content of the issue.",
-          type: "string",
-        },
-      ],
+      childrenFields: ISSUE_OBJECT_CHILDREN_FIELDS,
     },
     {
       name: "assignee",

--- a/front/types/triggers/webhooks.ts
+++ b/front/types/triggers/webhooks.ts
@@ -7,7 +7,7 @@ import type {
 import type { AgentsUsageType } from "@app/types/data_source";
 import type { ModelId } from "@app/types/shared/model_id";
 import type { EditedByUser } from "@app/types/user";
-import type { PresetWebhookType } from "@app/types/triggers/webhooks_source_preset";
+import type { PresetWebhook } from "@app/types/triggers/webhooks_source_preset";
 
 import { GITHUB_WEBHOOK_PRESET } from "./github_webhook_source_presets";
 
@@ -20,7 +20,7 @@ export const WEBHOOK_SOURCE_SIGNATURE_ALGORITHMS = [
 export type WebhookSourceSignatureAlgorithm =
   (typeof WEBHOOK_SOURCE_SIGNATURE_ALGORITHMS)[number];
 
-export const WEBHOOK_SOURCE_PRESETS_MAP: Record<string, PresetWebhookType> = {
+export const WEBHOOK_SOURCE_PRESETS_MAP: Record<string, PresetWebhook> = {
   github: GITHUB_WEBHOOK_PRESET,
 } as const;
 

--- a/front/types/triggers/webhooks.ts
+++ b/front/types/triggers/webhooks.ts
@@ -7,6 +7,9 @@ import type {
 import type { AgentsUsageType } from "@app/types/data_source";
 import type { ModelId } from "@app/types/shared/model_id";
 import type { EditedByUser } from "@app/types/user";
+import type { PresetWebhookType } from "@app/types/triggers/webhooks_source_preset";
+
+import { GITHUB_WEBHOOK_PRESET } from "./github_webhook_source_presets";
 
 export const WEBHOOK_SOURCE_SIGNATURE_ALGORITHMS = [
   "sha1",
@@ -17,7 +20,14 @@ export const WEBHOOK_SOURCE_SIGNATURE_ALGORITHMS = [
 export type WebhookSourceSignatureAlgorithm =
   (typeof WEBHOOK_SOURCE_SIGNATURE_ALGORITHMS)[number];
 
-export const WEBHOOK_SOURCE_KIND = ["custom"] as const;
+export const WEBHOOK_SOURCE_PRESETS_MAP: Record<string, PresetWebhookType> = {
+  github: GITHUB_WEBHOOK_PRESET,
+} as const;
+
+export const WEBHOOK_SOURCE_KIND = [
+  "custom",
+  ...Object.keys(WEBHOOK_SOURCE_PRESETS_MAP),
+] as const;
 
 export type WebhookSourceKind = (typeof WEBHOOK_SOURCE_KIND)[number];
 

--- a/front/types/triggers/webhooks.ts
+++ b/front/types/triggers/webhooks.ts
@@ -20,14 +20,14 @@ export const WEBHOOK_SOURCE_SIGNATURE_ALGORITHMS = [
 export type WebhookSourceSignatureAlgorithm =
   (typeof WEBHOOK_SOURCE_SIGNATURE_ALGORITHMS)[number];
 
-export const WEBHOOK_SOURCE_PRESETS_MAP: Record<string, PresetWebhook> = {
+export const WEBHOOK_SOURCE_KIND_TO_PRESETS_MAP: Record<
+  Exclude<WebhookSourceKind, "custom">,
+  PresetWebhook
+> = {
   github: GITHUB_WEBHOOK_PRESET,
 } as const;
 
-export const WEBHOOK_SOURCE_KIND = [
-  "custom",
-  ...Object.keys(WEBHOOK_SOURCE_PRESETS_MAP),
-] as const;
+export const WEBHOOK_SOURCE_KIND = ["custom", "github"] as const;
 
 export type WebhookSourceKind = (typeof WEBHOOK_SOURCE_KIND)[number];
 

--- a/front/types/triggers/webhooks.ts
+++ b/front/types/triggers/webhooks.ts
@@ -9,7 +9,7 @@ import type { ModelId } from "@app/types/shared/model_id";
 import type { EditedByUser } from "@app/types/user";
 import type { PresetWebhook } from "@app/types/triggers/webhooks_source_preset";
 
-import { GITHUB_WEBHOOK_PRESET } from "./github_webhook_source_presets";
+import { GITHUB_WEBHOOK_PRESET } from "@app/types/triggers/github_webhook_source_presets";
 
 export const WEBHOOK_SOURCE_SIGNATURE_ALGORITHMS = [
   "sha1",

--- a/front/types/triggers/webhooks_source_preset.ts
+++ b/front/types/triggers/webhooks_source_preset.ts
@@ -1,23 +1,26 @@
 import { GithubLogo, JiraLogo } from "@dust-tt/sparkle";
+import { type Icon } from "@dust-tt/sparkle/dist/esm/components/Icon";
 
 type EventFieldBase = {
   name: string;
   description: string;
 };
 
-export type EventField =
-  | (EventFieldBase & {
-      type: "string" | "number" | "boolean" | "array" | "null";
-    })
-  | (EventFieldBase & {
-      type: "enum";
-      enumValues: string[];
-    })
-  | (EventFieldBase & {
-      type: "object";
-      isArray: boolean;
-      childrenFields: EventField[];
-    });
+export type EventField = EventFieldBase &
+  (
+    | {
+        type: "string" | "number" | "boolean" | "array" | "null";
+      }
+    | {
+        type: "enum";
+        enumValues: string[];
+      }
+    | {
+        type: "object";
+        isArray: boolean;
+        childrenFields: EventField[];
+      }
+  );
 
 export type EventCheck = {
   type: "header" | "payload";
@@ -43,6 +46,6 @@ export type PresetWebhook = {
   name: string;
   eventCheck: EventCheck | null;
   events: WebhookEvent[];
-  icon: WebhookPresetIcon;
+  icon: typeof Icon;
   description: string;
 };

--- a/front/types/triggers/webhooks_source_preset.ts
+++ b/front/types/triggers/webhooks_source_preset.ts
@@ -3,7 +3,7 @@ type EventFieldBase = {
   description: string;
 };
 
-export type EventFieldType =
+export type EventField =
   | (EventFieldBase & {
       type:
         | "string"
@@ -19,23 +19,23 @@ export type EventFieldType =
     })
   | (EventFieldBase & {
       type: "parent-field" | "parent-of-array";
-      childrentFields: EventFieldType[];
+      childrenFields: EventField[];
     });
 
-export type EventCheckType = {
+export type EventCheck = {
   type: "header" | "payload";
   field: string;
 };
 
-export type EventType = {
+export type WebhookEvent = {
   name: string;
   value: string;
   description: string;
-  fields: EventFieldType[];
+  fields: EventField[];
 };
 
-export type PresetWebhookType = {
+export type PresetWebhook = {
   name: string;
-  eventCheck: EventCheckType | null;
-  events: EventType[];
+  eventCheck: EventCheck | null;
+  events: WebhookEvent[];
 };

--- a/front/types/triggers/webhooks_source_preset.ts
+++ b/front/types/triggers/webhooks_source_preset.ts
@@ -1,0 +1,41 @@
+type EventFieldBase = {
+  name: string;
+  description: string;
+};
+
+export type EventFieldType =
+  | (EventFieldBase & {
+      type:
+        | "string"
+        | "number"
+        | "boolean"
+        | "array"
+        | "null"
+        | "unknown-object";
+    })
+  | (EventFieldBase & {
+      type: "enum";
+      enumValues: string[];
+    })
+  | (EventFieldBase & {
+      type: "parent-field" | "parent-of-array";
+      childrentFields: EventFieldType[];
+    });
+
+export type EventCheckType = {
+  type: "header" | "payload";
+  field: string;
+};
+
+export type EventType = {
+  name: string;
+  value: string;
+  description: string;
+  fields: EventFieldType[];
+};
+
+export type PresetWebhookType = {
+  name: string;
+  eventCheck: EventCheckType | null;
+  events: EventType[];
+};

--- a/front/types/triggers/webhooks_source_preset.ts
+++ b/front/types/triggers/webhooks_source_preset.ts
@@ -1,3 +1,5 @@
+import { GithubLogo, JiraLogo } from "@dust-tt/sparkle";
+
 type EventFieldBase = {
   name: string;
   description: string;
@@ -29,8 +31,18 @@ export type WebhookEvent = {
   fields: EventField[];
 };
 
+const WebhookPresetIcons = {
+  GithubLogo,
+  JiraLogo,
+} as const;
+
+export type WebhookPresetIcon =
+  (typeof WebhookPresetIcons)[keyof typeof WebhookPresetIcons];
+
 export type PresetWebhook = {
   name: string;
   eventCheck: EventCheck | null;
   events: WebhookEvent[];
+  icon: WebhookPresetIcon;
+  description: string;
 };

--- a/front/types/triggers/webhooks_source_preset.ts
+++ b/front/types/triggers/webhooks_source_preset.ts
@@ -5,20 +5,15 @@ type EventFieldBase = {
 
 export type EventField =
   | (EventFieldBase & {
-      type:
-        | "string"
-        | "number"
-        | "boolean"
-        | "array"
-        | "null"
-        | "unknown-object";
+      type: "string" | "number" | "boolean" | "array" | "null" | "unknown-object";
     })
   | (EventFieldBase & {
       type: "enum";
       enumValues: string[];
     })
   | (EventFieldBase & {
-      type: "parent-field" | "parent-of-array";
+      type: "object";
+      isArray: boolean;
       childrenFields: EventField[];
     });
 

--- a/front/types/triggers/webhooks_source_preset.ts
+++ b/front/types/triggers/webhooks_source_preset.ts
@@ -5,7 +5,7 @@ type EventFieldBase = {
 
 export type EventField =
   | (EventFieldBase & {
-      type: "string" | "number" | "boolean" | "array" | "null" | "unknown-object";
+      type: "string" | "number" | "boolean" | "array" | "null";
     })
   | (EventFieldBase & {
       type: "enum";


### PR DESCRIPTION
## Description

Add some types for the preset webhook source.
I have tried to make it as flexible as possible by taking an example on gihub with quite a lot of fields and sub-fields

I have filter quite a lot of fields which cannot be used for filtering and try to keep it "simple" to begin with.
Complete list of events and fields can be found here: https://octokit.github.io/webhooks/payload-examples/api.github.com/index.json

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

deploy front
