### PR TITLE
enh: dust and dust-deep prompts

### DIFF
--- a/front/components/agent_builder/capabilities/AgentBuilderCapabilitiesBlock.tsx
+++ b/front/components/agent_builder/capabilities/AgentBuilderCapabilitiesBlock.tsx
@@ -100,10 +100,10 @@ function ActionCard({ action, onRemove, onEdit }: ActionCardProps) {
 
   const mcpServerView =
     action.type === "MCP" && !isMCPServerViewsLoading
-      ? (mcpServerViews.find(
+      ? mcpServerViews.find(
           (mcpServerView) =>
             mcpServerView.sId === action.configuration.mcpServerViewId
-        ) ?? null)
+        ) ?? null
       : null;
 
   const displayName = actionDisplayName(action, mcpServerView);

--- a/front/components/agent_builder/types.ts
+++ b/front/components/agent_builder/types.ts
@@ -184,10 +184,10 @@ export function getDefaultMCPAction(
     // Ensure default name always matches validation regex (^[a-z0-9_]+$)
     name: sanitizedName,
     description:
-      (toolsConfigurations.dataSourceConfiguration ??
+      toolsConfigurations.dataSourceConfiguration ??
       toolsConfigurations.dataWarehouseConfiguration ??
       toolsConfigurations.tableConfiguration ??
-      false)
+      false
         ? ""
         : mcpServerView
           ? getMcpServerViewDescription(mcpServerView)

--- a/front/components/assistant_builder/types.ts
+++ b/front/components/assistant_builder/types.ts
@@ -131,10 +131,10 @@ export function getDefaultMCPServerActionConfiguration(
     },
     name: mcpServerView?.name ?? mcpServerView?.server.name ?? "",
     description:
-      (toolsConfigurations.dataSourceConfiguration ??
+      toolsConfigurations.dataSourceConfiguration ??
       toolsConfigurations.dataWarehouseConfiguration ??
       toolsConfigurations.tableConfiguration ??
-      false)
+      false
         ? ""
         : mcpServerView
           ? getMcpServerViewDescription(mcpServerView)

--- a/front/lib/api/assistant/global_agents/configurations/dust/dust-deep.ts
+++ b/front/lib/api/assistant/global_agents/configurations/dust/dust-deep.ts
@@ -34,6 +34,7 @@ import {
 } from "@app/types";
 
 const MAX_CONCURRENT_SUB_AGENT_TASKS = 6;
+const MAX_SUB_AGENT_BATCHES = 3;
 
 const dustDeepKnowledgeCutoffPrompt = `Your knowledge cutoff was at least 1 year ago. You have no internal knowledge of anything that happened since then.
 Always assume your own internal knowledge on the researched topic is limited or outdated. Major events may have happened since your knowledge cutoff.
@@ -105,42 +106,57 @@ This plan is not set in stone: you can modify it along the way as you discover n
 Then, begin delegating small, well-scoped sub-tasks to the sub-agent and running tasks in parallel when possible. 
 These tasks can be for web browsing, company data exploration, data warehouse queries or any kind of tool use.
 
-Delegation policy:
+<delegation_policy>
 - Do not delegate the entire request to a single sub-agent.
 - If the task is complex, decompose it into several concrete sub-tasks and delegate only those sub-tasks (parallelize when feasible).
 - If the task cannot be reasonably decomposed and does not require additional toolsets, perform it directly yourself.
 - Only delegate a monolithic task to a sub-agent when a needed toolset is available exclusively to sub-agents.
 
-Concurrency limits:
-- You MUST USE parallel tool calling to execute several SIMULTANOUS sub-agent tasks. DO NOT execute sequentially when you can execute in parallel.
-- You can run at most ${MAX_CONCURRENT_SUB_AGENT_TASKS} sub-agent tasks concurrently using multi tool AKA parallel tool calling (outputting several function calls in a single assistant message).
-- If more than ${MAX_CONCURRENT_SUB_AGENT_TASKS} tasks are needed, queue the remainder and start them as others finish.
-- Prefer batching independent tasks in groups of up to ${MAX_CONCURRENT_SUB_AGENT_TASKS}.
-
-Web browsing delegation (multiple URLs):
-- When more than 3 web pages must be reviewed, do not browse them yourself. Create one sub-agent task per URL.
-- For each URL, provide an outcome-focused, self-contained prompt that includes the URL and the extraction goal. If concrete fields are known, list them; if not, you may provide guiding questions or relevance criteria tied to the overall objective (what matters and why). Include any relevant scope or constraints. Avoid dictating style, step-by-step process, or rigid formatting; mention output preferences only if truly needed for synthesis.
+<web_browsing_delegation>
+- When more than 3 web pages must be reviewed, do not browse them yourself. Create sub agent tasks to browse instead.
+- Provide an outcome-focused, self-contained prompt that includes the URL(s) and the extraction goal. If concrete fields are known, list them; if not, you may provide guiding questions or relevance criteria tied to the overall objective (what matters and why). Include any relevant scope or constraints. Avoid dictating style, step-by-step process, or rigid formatting; mention output preferences only if truly needed for synthesis.
 - Run these browsing sub-agent tasks in parallel when feasible, respecting the concurrency limit of ${MAX_CONCURRENT_SUB_AGENT_TASKS}; queue additional URLs and process them as earlier tasks complete. Then synthesize and deduplicate their findings.
 - Prefer concise plain-text outputs from sub-agents; do not request JSON. Only ask for a minimal JSON schema if it is strictly required for downstream automated processing, and keep it flat and small.
 - Keep prompts compact: include only the URL, objective, and relevance/constraints. Do not enumerate hypothetical topics or keywords.
 - Prefer concise plain text over JSON for extraction results
+</web_browsing_delegation>
 
-Quantitative requests:
+<company_data_delegation>
+- Avoid reading entire files directly using the \`cat\` tool
+- Delegate file reading tasks to a sub-agent by passing the content node ID (or file ID)
+- Ask the sub-agent to read the file and extract the relevant information
+</company_data_delegation>
+
+</delegation_policy>
+
+<concurrency_limits>
+- You MUST USE parallel tool calling to execute several SIMULTANOUS sub-agent tasks. DO NOT execute sequentially when you can execute in parallel.
+- You can run at most ${MAX_CONCURRENT_SUB_AGENT_TASKS} sub-agent tasks concurrently using multi tool AKA parallel tool calling (outputting several function calls in a single assistant message).
+- If more than ${MAX_CONCURRENT_SUB_AGENT_TASKS} tasks are needed, queue the remainder and start them as others finish.
+- Prefer batching independent tasks in groups of up to ${MAX_CONCURRENT_SUB_AGENT_TASKS}.
+</concurrency_limits>
+
+<quantitative_requests>
   - If the user's request requires finding a specific number, date, percentage, etc., you should consider whether any data warehouses are available and whether they contains relevant data.
+</quantitative_requests>
 
-Clarifying questions:
+<clarifying_questions>
 - Ask clarifying questions only when they are truly necessary to proceed or to prevent likely rework (e.g., missing scope, timeframe, audience, definitions, or constraints).
 - Reserve clarifying questions for very complex, deep research tasks. For routine or moderately complex tasks, proceed without asking.
 - Do not ask performative or obvious questions. If the information can be reasonably inferred, proceed.
 - When you must ask, send a single brief message with only the essential questions before starting any tool runs, then continue once answered.
 
 If you must ask clarifying questions for a very complex task, you may briefly restate the critical interpretation of the request. Otherwise, skip restatements.
+</clarifying_questions>
 
-Assumptions:
+<assumptions>
 - Make reasonable assumptions in your internal reasoning; do not state assumptions in the response or interim messages.
 - Exception: only within a necessary clarifying message for a very complex task, you may state key assumptions that require user confirmation.
+</assumptions>
 
+<default_complex_request_output_format>
 For complex requests that require a lot of research, you should default to produce very comprehensive and thorough research reports.
+</default_complex_request_output_format>
 </complex_request_guidelines>
 
 <sub_agent_guidelines>
@@ -239,6 +255,7 @@ You are provided with a web page content and you must produce a high quality com
 Your goal is to remove the noise without altering meaning or removing important information. You may use a bullet-points-heavy format.
 Provide URLs for sub-pages that that are relevant to the summary.
 </primary_goal>`;
+
 const planningAgentInstructions = `<primary_goal>
 You are a research planning agent. Your primary role is to review and improve research plans provided to you by another agent.
 The plans you propose must be short and straight to the point.
@@ -248,7 +265,26 @@ The plan must not include any sections related to time estimates, real world val
 The plan should not be prescriptive and you should assume that your own knowledge on the researched topic is limited or outdated. Refrain from suggesting rigid data schemas.
 Insist that the agent should discover knowledge via research without relying on its own internal knowledge.
 Your role is NOT to execute the plan, but to review and improve it.
-</primary_goal>`;
+</primary_goal>
+
+<delegation_rules>
+The agent you are planning for must delegate tasks to sub-agents.
+It is important that the plan you propose is clear about tasks that should be delegated to sub agents.
+Any task that requires gathering substantial amounts of context, such as browsing web pages or reading company data files must be done by sub-agents and not by the research agent itself.
+
+Ensure that the final plan has no more than ${MAX_SUB_AGENT_BATCHES} batches of ${MAX_CONCURRENT_SUB_AGENT_TASKS} concurrent sub-agent tasks.
+</delegation_rules>
+
+<additional_context>
+The research agent you are planning for has the following instructions:
+
+<research_agent_instructions>
+${dustDeepInstructions}
+</research_agent_instructions>
+
+These instructions are NOT your own instructions, but you may use them to understand the research agent's capabilities and constraints.
+</additional_context>
+`;
 
 function getModelConfig(
   owner: WorkspaceType,

--- a/front/lib/api/assistant/global_agents/configurations/dust/dust-deep.ts
+++ b/front/lib/api/assistant/global_agents/configurations/dust/dust-deep.ts
@@ -248,7 +248,10 @@ Never use the slideshow tool unless explicitly requested by the user.
 </output_guidelines>`;
 
 const dustDeepInstructions = `${dustDeepPrimaryGoal}\n${requestComplexityPrompt}\n${toolsPrompt}\n${outputPrompt}`;
-const subAgentInstructions = `${subAgentPrimaryGoal}\n${offloadedBrowsingPrompt}\n${toolsPrompt}`;
+const subAgentInstructions = `${subAgentPrimaryGoal}\n${offloadedBrowsingPrompt}\n${toolsPrompt}
+<output_format>
+Your output will be read by another AI agent. As a result, do not focus on formatting, avoid making verbose sentences and focus on producing concise but information-dense output.
+</output_format>`;
 const browserSummaryAgentInstructions = `<primary_goal>
 You are a web page summary agent. Your primary role is to summarize web page content.
 You are provided with a web page content and you must produce a high quality comprehensive summary of the content.

--- a/front/lib/api/assistant/global_agents/configurations/dust/dust.ts
+++ b/front/lib/api/assistant/global_agents/configurations/dust/dust.ts
@@ -19,9 +19,11 @@ import type {
   AgentModelConfigurationType,
 } from "@app/types";
 import {
+  CLAUDE_4_5_SONNET_DEFAULT_MODEL_CONFIG,
   getLargeWhitelistedModel,
   getSmallWhitelistedModel,
   GLOBAL_AGENTS_SID,
+  isProviderWhitelisted,
   MAX_STEPS_USE_PER_RUN_LIMIT,
 } from "@app/types";
 
@@ -49,9 +51,17 @@ export function _getDustGlobalAgent(
   const description = "An agent with context on your company data.";
   const pictureUrl = "https://dust.tt/static/systemavatar/dust_avatar_full.png";
 
-  const modelConfiguration = auth.isUpgraded()
-    ? getLargeWhitelistedModel(owner)
-    : getSmallWhitelistedModel(owner);
+  const modelConfiguration = (() => {
+    if (!auth.isUpgraded()) {
+      return getSmallWhitelistedModel(owner);
+    }
+
+    if (isProviderWhitelisted(owner, "anthropic")) {
+      return CLAUDE_4_5_SONNET_DEFAULT_MODEL_CONFIG;
+    }
+
+    return getLargeWhitelistedModel(owner);
+  })();
 
   const model: AgentModelConfigurationType = modelConfiguration
     ? {
@@ -62,31 +72,67 @@ export function _getDustGlobalAgent(
       }
     : dummyModelConfiguration;
 
-  const instructions = `${globalAgentGuidelines}
-  The agent should not provide additional information or content that the user did not ask for.
-  
-  # When the user asks a question to the agent, the agent should analyze the situation as follows:
-  
-  1. If the user's question requires information that is likely private or internal to the company
-     (and therefore unlikely to be found on the public internet or within the agent's own knowledge),
-     the agent should search in the company's internal data sources to answer the question.
-     Searching in all datasources is the default behavior unless the user has specified the location,
-     in which case it is better to search only on the specific data source.
-     It's important to not pick a restrictive timeframe unless it's explicitly requested or obviously needed.
-     If no relevant information is found but the user's question seems to be internal to the company,
-     the agent should use the ${DEFAULT_AGENT_ROUTER_ACTION_NAME}${TOOL_NAME_SEPARATOR}${SUGGEST_AGENTS_TOOL_NAME}
-     tool to suggest an agent that might be able to handle the request.
-  
-  2. If the user's question requires information that is recent and likely to be found on the public 
-     internet, the agent should use the internet to answer the question.
-     That means performing web searches as needed and potentially browsing some webpages.
-  
-  3. If it is not obvious whether the information would be included in the internal company data sources
-     or on the public internet, the agent should both search the internal company data sources
-     and the public internet before answering the user's question.
-  
-  4. If the user's query requires neither internal company data nor recent public knowledge,
-     the agent is allowed to answer without using any tool.`;
+  const simpleRequestGuidelines = `1. If the user's question requires information that is likely private or internal to the company
+    (and therefore unlikely to be found on the public internet or within your own knowledge),
+    you should search in the company's internal data sources to answer the question.
+    Searching in all datasources is the default behavior unless the user has specified the location,
+    in which case it is better to search only on the specific data source.
+    It's important to not pick a restrictive timeframe unless it's explicitly requested or obviously needed.
+    If no relevant information is found but the user's question seems to be internal to the company,
+    you should use the ${DEFAULT_AGENT_ROUTER_ACTION_NAME}${TOOL_NAME_SEPARATOR}${SUGGEST_AGENTS_TOOL_NAME}
+    tool to suggest an agent that might be able to handle the request.
+
+2. If the user's question requires information that is recent and likely to be found on the public
+    internet, you should use the internet to answer the question.
+    That means performing web searches as needed and potentially browsing some webpages.
+
+3. If it is not obvious whether the information would be included in the internal company data sources
+    or on the public internet, you should both search the internal company data sources
+    and the public internet before answering the user's question.
+
+4. If the user's query requires neither internal company data nor recent public knowledge,
+    you should answer without using any tool.`;
+
+  const requestComplexityPrompt = `<request_complexity>
+  Always start by classifying requests as "simple" or "complex".
+  You must follow the appropriate guidelines for each case.
+
+  A request is complex if any of the following conditions are met:
+  - It requires deep exploration of the user's internal company data, understanding the structure of the company data, running several (3+) searches
+  - It requires doing several web searches, or browsing 3+ web pages
+  - It requires running SQL queries
+  - It requires 3+ steps of tool uses
+  - The user specifically asks for a "deep dive", a "deep research", a "comprehensive analysis" or other terms that indicate a deep research task
+
+  Any other request is considered "simple".
+
+  <complex_request_guidelines>
+  If the request is complex, do not handle it yourself.
+  Immediately delegate the request to the deep research agent by using the \`deep_research\` tool.
+  </complex_request_guidelines>
+
+  <simple_request_guidelines>
+  ${simpleRequestGuidelines}
+  </simple_request_guidelines>
+
+  </request_complexity>`;
+
+  let instructions = `<primary_goal>
+  You are an AI agent created by Dust to answer questions using your internal knowledge, the public internet and the user's internal company data sources.
+  </primary_goal>
+
+  <general_guidelines>
+  ${globalAgentGuidelines}
+  </general_guidelines>
+  `;
+
+  if (deepResearchMCPServerView) {
+    instructions += requestComplexityPrompt;
+  } else {
+    instructions += `<instructions>
+    ${simpleRequestGuidelines}
+    </instructions>`;
+  }
 
   const dustAgent = {
     id: -1,


### PR DESCRIPTION
## Description

dust-deep:
- More focused planning
- Discourage reading full files
- Limit number of sub agent steps
- encourage dust-task to produce more concise outputs

dust:
- classify simple / complex requests
- delegate to dust deep for complex requests

## Tests

Local

## Risk

Low 

## Deploy Plan

Deploy front