### PR TITLE
Group by planType

### DIFF
--- a/front/components/app/PostHogTracker.tsx
+++ b/front/components/app/PostHogTracker.tsx
@@ -52,9 +52,23 @@ export function PostHogTracker({ children }: PostHogTrackerProps) {
     if (!activeSubscription) {
       return null;
     }
+
+    const planCode = activeSubscription.plan.code;
+    const planCodeUpper = planCode.toUpperCase();
+    let planType = "OTHER";
+
+    if (planCodeUpper.includes("ENT")) {
+      planType = "ENTERPRISE";
+    } else if (planCodeUpper.includes("PRO")) {
+      planType = "PRO";
+    } else if (planCodeUpper.includes("FREE")) {
+      planType = "FREE";
+    }
+
     return {
-      plan_code: activeSubscription.plan.code,
+      plan_code: planCode,
       plan_name: activeSubscription.plan.name,
+      plan_type: planType,
       is_trial: activeSubscription.trialing ? "true" : "false",
     };
   }, [activeSubscription]);


### PR DESCRIPTION










## Description

Adds a `plan_type` property to PostHog workspace group tracking by categorizing plan codes into standardized types (ENTERPRISE, PRO, FREE, OTHER). This enhances analytics capabilities by enabling plan type-based grouping and filtering in PostHog dashboards, complementing the existing `plan_code` and `plan_name` properties.

## Risk

Low risk. This is an additive change that only adds a new property to existing PostHog tracking without modifying any core functionality.

## Deploy Plan

No specific deploy actions required - the new `plan_type` property will be automatically included in PostHog workspace group events.
