### PR TITLE
Add ability to read Salesforce attachments

### DIFF
--- a/front/components/agent_builder/capabilities/AgentBuilderCapabilitiesBlock.tsx
+++ b/front/components/agent_builder/capabilities/AgentBuilderCapabilitiesBlock.tsx
@@ -100,10 +100,10 @@ function ActionCard({ action, onRemove, onEdit }: ActionCardProps) {
 
   const mcpServerView =
     action.type === "MCP" && !isMCPServerViewsLoading
-      ? (mcpServerViews.find(
+      ? mcpServerViews.find(
           (mcpServerView) =>
             mcpServerView.sId === action.configuration.mcpServerViewId
-        ) ?? null)
+        ) ?? null
       : null;
 
   const displayName = actionDisplayName(action, mcpServerView);

--- a/front/components/agent_builder/types.ts
+++ b/front/components/agent_builder/types.ts
@@ -184,10 +184,10 @@ export function getDefaultMCPAction(
     // Ensure default name always matches validation regex (^[a-z0-9_]+$)
     name: sanitizedName,
     description:
-      (toolsConfigurations.dataSourceConfiguration ??
+      toolsConfigurations.dataSourceConfiguration ??
       toolsConfigurations.dataWarehouseConfiguration ??
       toolsConfigurations.tableConfiguration ??
-      false)
+      false
         ? ""
         : mcpServerView
           ? getMcpServerViewDescription(mcpServerView)

--- a/front/components/assistant_builder/types.ts
+++ b/front/components/assistant_builder/types.ts
@@ -131,10 +131,10 @@ export function getDefaultMCPServerActionConfiguration(
     },
     name: mcpServerView?.name ?? mcpServerView?.server.name ?? "",
     description:
-      (toolsConfigurations.dataSourceConfiguration ??
+      toolsConfigurations.dataSourceConfiguration ??
       toolsConfigurations.dataWarehouseConfiguration ??
       toolsConfigurations.tableConfiguration ??
-      false)
+      false
         ? ""
         : mcpServerView
           ? getMcpServerViewDescription(mcpServerView)

--- a/front/lib/actions/mcp_execution.ts
+++ b/front/lib/actions/mcp_execution.ts
@@ -227,7 +227,7 @@ export async function processToolResults(
             if (isBlobResource(block)) {
               const fileName = isResourceWithName(block)
                 ? block.name
-                : `generated-file-${Date.now()}${extensionsForContentType(block.resource.mimeType as SupportedFileContentType)[0]}`;
+                : `generated-file-${Date.now()}${extensionsForContentType(block.resource.mimeType as SupportedFileContentType)[0] || ""}`;
 
               return handleBase64Upload(auth, {
                 base64Data: block.resource.blob,

--- a/front/lib/actions/mcp_internal_actions/constants.ts
+++ b/front/lib/actions/mcp_internal_actions/constants.ts
@@ -423,6 +423,8 @@ The directive should be used to display a clickable version of the agent name in
       execute_read_query: "never_ask",
       list_objects: "never_ask",
       describe_object: "never_ask",
+      list_attachments: "never_ask",
+      read_attachment: "never_ask",
     },
     tools_retry_policies: undefined,
     timeoutMs: undefined,

--- a/front/lib/actions/mcp_internal_actions/servers/salesforce/salesforce_api_helper.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/salesforce/salesforce_api_helper.ts
@@ -1,0 +1,241 @@
+import type { Connection } from "jsforce";
+
+import type { Result } from "@app/types";
+import { Err, normalizeError, Ok } from "@app/types";
+
+import { extractTextFromBuffer } from "../../utils/attachment_processing";
+
+const SF_API_VERSION = "57.0";
+
+export interface AttachmentMetadata {
+  id: string;
+  filename: string;
+  mimeType: string;
+  size?: number;
+  created?: string;
+  author?: string;
+}
+
+interface SalesforceAttachment {
+  Id: string;
+  Name: string;
+  ContentType: string;
+  BodyLength: number;
+  CreatedDate: string;
+  CreatedBy?: { Name?: string };
+}
+
+async function getSalesforceAttachments(
+  conn: Connection,
+  parentId: string
+): Promise<Result<AttachmentMetadata[], string>> {
+  try {
+    const result = await conn.query<SalesforceAttachment>(`
+      SELECT Id, Name, ContentType, BodyLength, CreatedDate, CreatedBy.Name
+      FROM Attachment
+      WHERE ParentId = '${parentId}'
+      ORDER BY CreatedDate DESC
+    `);
+
+    const attachments: AttachmentMetadata[] = result.records.map((record) => {
+      const filename = record.Name || `attachment-${record.Id}`;
+      return {
+        id: record.Id,
+        filename,
+        mimeType: record.ContentType || "application/octet-stream",
+        size: record.BodyLength,
+        created: record.CreatedDate,
+        author: record.CreatedBy?.Name,
+      };
+    });
+
+    return new Ok(attachments);
+  } catch (error) {
+    return new Err(
+      `Failed to get attachments: ${normalizeError(error).message}`
+    );
+  }
+}
+
+interface ContentDocumentLink {
+  ContentDocumentId: string;
+}
+
+interface ContentVersion {
+  Id: string;
+  Title: string;
+  FileType: string;
+  ContentSize: number;
+  CreatedDate: string;
+  CreatedBy?: { Name?: string };
+}
+
+async function getSalesforceFiles(
+  conn: Connection,
+  parentId: string
+): Promise<Result<AttachmentMetadata[], string>> {
+  try {
+    const linkResult = await conn.query<ContentDocumentLink>(`
+      SELECT ContentDocumentId
+      FROM ContentDocumentLink
+      WHERE LinkedEntityId = '${parentId}'
+    `);
+
+    if (linkResult.records.length === 0) {
+      return new Ok([]);
+    }
+
+    const contentDocumentIds = linkResult.records.map(
+      (record) => record.ContentDocumentId
+    );
+
+    const fileResult = await conn.query<ContentVersion>(`
+      SELECT Id, Title, FileType, ContentSize, CreatedDate, CreatedBy.Name
+      FROM ContentVersion
+      WHERE ContentDocumentId IN ('${contentDocumentIds.join("','")}')
+      AND IsLatest = true
+      ORDER BY CreatedDate DESC
+    `);
+
+    const files: AttachmentMetadata[] = fileResult.records.map((record) => {
+      const filename = record.Title || `file-${record.Id}`;
+      return {
+        id: record.Id,
+        filename,
+        mimeType: getMimeType(record.FileType),
+        size: record.ContentSize,
+        created: record.CreatedDate,
+        author: record.CreatedBy?.Name,
+      };
+    });
+
+    return new Ok(files);
+  } catch (error) {
+    return new Err(`Failed to get files: ${normalizeError(error).message}`);
+  }
+}
+
+async function downloadSalesforceAttachment(
+  conn: Connection,
+  attachmentId: string
+): Promise<Result<Buffer, string>> {
+  try {
+    const url = `${conn.instanceUrl}/services/data/v${SF_API_VERSION}/sobjects/Attachment/${attachmentId}/Body`;
+
+    const response = await fetch(url, {
+      method: "GET",
+      headers: {
+        Authorization: `Bearer ${conn.accessToken}`,
+        Accept: "*/*",
+      },
+    });
+
+    if (!response.ok) {
+      return new Err(`Salesforce API error: ${response.status}`);
+    }
+
+    return new Ok(Buffer.from(await response.arrayBuffer()));
+  } catch (error) {
+    return new Err(
+      `Failed to download attachment: ${normalizeError(error).message}`
+    );
+  }
+}
+
+async function downloadSalesforceFile(
+  conn: Connection,
+  contentVersionId: string
+): Promise<Result<Buffer, string>> {
+  try {
+    const url = `${conn.instanceUrl}/services/data/v${SF_API_VERSION}/sobjects/ContentVersion/${contentVersionId}/VersionData`;
+
+    const response = await fetch(url, {
+      method: "GET",
+      headers: {
+        Authorization: `Bearer ${conn.accessToken}`,
+        Accept: "*/*",
+      },
+    });
+
+    if (!response.ok) {
+      return new Err(`Salesforce API error: ${response.status}`);
+    }
+
+    return new Ok(Buffer.from(await response.arrayBuffer()));
+  } catch (error) {
+    return new Err(`Failed to download file: ${normalizeError(error).message}`);
+  }
+}
+
+export async function getAllSalesforceAttachments(
+  conn: Connection,
+  recordId: string
+): Promise<Result<AttachmentMetadata[], string>> {
+  const [attachmentsResult, filesResult] = await Promise.all([
+    getSalesforceAttachments(conn, recordId),
+    getSalesforceFiles(conn, recordId),
+  ]);
+
+  if (attachmentsResult.isErr()) {
+    return attachmentsResult;
+  }
+
+  if (filesResult.isErr()) {
+    return filesResult;
+  }
+
+  return new Ok([...attachmentsResult.value, ...filesResult.value]);
+}
+
+export async function downloadSalesforceContent(
+  conn: Connection,
+  attachmentId: string
+): Promise<Result<Buffer, string>> {
+  // Salesforce ID prefixes:
+  // "068" = ContentVersion (modern files)
+  // "00P" = Attachment (legacy attachments)
+  const isFile = attachmentId.startsWith("068");
+
+  if (isFile) {
+    return downloadSalesforceFile(conn, attachmentId);
+  } else {
+    return downloadSalesforceAttachment(conn, attachmentId);
+  }
+}
+
+export async function extractTextFromSalesforceAttachment(
+  conn: Connection,
+  attachmentId: string,
+  mimeType: string
+): Promise<Result<string, string>> {
+  const downloadResult = await downloadSalesforceContent(conn, attachmentId);
+
+  if (downloadResult.isErr()) {
+    return downloadResult;
+  }
+
+  return extractTextFromBuffer(downloadResult.value, mimeType);
+}
+
+function getMimeType(fileType: string): string {
+  const type = fileType?.toUpperCase();
+
+  if (type === "TEXT") {
+    return "text/plain";
+  }
+  if (type === "PDF") {
+    return "application/pdf";
+  }
+  if (type === "PNG") {
+    return "image/png";
+  }
+  if (type === "JPG" || type === "JPEG") {
+    return "image/jpeg";
+  }
+  if (type === "GIF") {
+    return "image/gif";
+  }
+
+  // Everything else - will be handled as binary attachment
+  return "application/octet-stream";
+}

--- a/front/lib/actions/mcp_internal_actions/utils/attachment_processing.ts
+++ b/front/lib/actions/mcp_internal_actions/utils/attachment_processing.ts
@@ -1,0 +1,122 @@
+import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
+import { Readable } from "stream";
+
+import {
+  makeMCPToolJSONSuccess,
+  makeMCPToolTextError,
+} from "@app/lib/actions/mcp_internal_actions/utils";
+import { sanitizeFilename } from "@app/lib/actions/mcp_internal_actions/utils/file_utils";
+import config from "@app/lib/api/config";
+import logger from "@app/logger/logger";
+import type { Result } from "@app/types";
+import {
+  Err,
+  isTextExtractionSupportedContentType,
+  normalizeError,
+  Ok,
+} from "@app/types";
+import { TextExtraction } from "@app/types/shared/text_extraction";
+
+/**
+ * Extract text from a buffer using the text extraction service
+ *
+ * Supports OCR for scanned documents and various document formats (PDF, Word, Excel, etc.)
+ *
+ * @param buffer - The file content as a Buffer
+ * @param mimeType - The MIME type of the file (e.g., "application/pdf")
+ * @returns Result with extracted text or error message
+ */
+export async function extractTextFromBuffer(
+  buffer: Buffer,
+  mimeType: string
+): Promise<Result<string, string>> {
+  try {
+    const textExtraction = new TextExtraction(config.getTextExtractionUrl(), {
+      enableOcr: true,
+      logger,
+    });
+
+    const bufferStream = Readable.from(buffer);
+    const textStream = await textExtraction.fromStream(
+      bufferStream,
+      mimeType as Parameters<typeof textExtraction.fromStream>[1]
+    );
+
+    const chunks: string[] = [];
+    for await (const chunk of textStream) {
+      chunks.push(chunk.toString());
+    }
+
+    return new Ok(chunks.join(""));
+  } catch (error) {
+    return new Err(`Failed to extract text: ${normalizeError(error).message}`);
+  }
+}
+
+/**
+ * This function implements a three-step decision tree for handling file attachments:
+ * 1. Try text extraction for supported document types (PDF, Word, Excel, etc.)
+ * 2. Download the file and check if it's plain text
+ * 3. Return binary files as resource blocks for upload
+ *
+ * @param mimeType - MIME type of the attachment (e.g., "application/pdf", "image/png")
+ * @param filename - Name of the attachment file
+ * @param params.extractText - Callback to extract text from the file *
+ * @param params.downloadContent - Callback to download the file content
+ */
+export async function processAttachment({
+  mimeType,
+  filename,
+  extractText,
+  downloadContent,
+}: {
+  mimeType: string;
+  filename: string;
+  extractText: () => Promise<Result<string, string>>;
+  downloadContent: () => Promise<Result<Buffer, string>>;
+}): Promise<CallToolResult> {
+  // Try text extraction for supported file types
+  if (isTextExtractionSupportedContentType(mimeType)) {
+    const textResult = await extractText();
+
+    if (textResult.isOk()) {
+      return makeMCPToolJSONSuccess({ result: textResult.value });
+    }
+
+    logger.warn(
+      `Text extraction failed for ${filename}, falling back to file attachment`,
+      { error: textResult.error }
+    );
+  }
+
+  const downloadResult = await downloadContent();
+
+  if (downloadResult.isErr()) {
+    return makeMCPToolTextError(
+      `Failed to download attachment: ${downloadResult.error}`
+    );
+  }
+
+  const buffer = downloadResult.value;
+
+  // Return plain text content as text
+  if (mimeType.startsWith("text/")) {
+    return makeMCPToolJSONSuccess({ result: buffer.toString("utf-8") });
+  }
+
+  // Return binary files as resource for upload
+  return {
+    isError: false,
+    content: [
+      {
+        type: "resource" as const,
+        resource: {
+          blob: buffer.toString("base64"),
+          text: `Attachment: ${sanitizeFilename(filename)}`,
+          mimeType,
+          uri: "",
+        },
+      },
+    ],
+  };
+}

--- a/front/lib/actions/mcp_internal_actions/utils/attachment_processing.ts
+++ b/front/lib/actions/mcp_internal_actions/utils/attachment_processing.ts
@@ -30,6 +30,10 @@ export async function extractTextFromBuffer(
   buffer: Buffer,
   mimeType: string
 ): Promise<Result<string, string>> {
+  if (!isTextExtractionSupportedContentType(mimeType)) {
+    return new Err(`Text extraction not supported for file type: ${mimeType}.`);
+  }
+
   try {
     const textExtraction = new TextExtraction(config.getTextExtractionUrl(), {
       enableOcr: true,


### PR DESCRIPTION
## Description

* Ability to read attachments from Salesforce objects. Salesforce has an abnormal data format for attachments (there are the legacy "attachments" objects and the newer "content document objects") - we are querying from both of those object types and abstracting from user.
* Consolidating some logic between jira + salesforce as i imagine this could be used by many tools

## Tests

* Adding attachments to test salesforce objects to validate

## Risk

* Low

## Deploy Plan

* Deploy front