### PR TITLE
[front] fix: Fixed message event when we get an early exit

### DIFF
--- a/front/temporal/agent_loop/activities/run_tool.ts
+++ b/front/temporal/agent_loop/activities/run_tool.ts
@@ -131,7 +131,10 @@ export async function runToolActivity(
                 created: event.created,
                 configurationId: agentConfiguration.sId,
                 messageId: agentMessage.sId,
-                message: { ...agentMessage, content: event.text },
+                message: {
+                  ...agentMessage,
+                  content: agentMessage.content + event.text,
+                },
                 runIds: runIds ?? [],
               },
 

--- a/front/temporal/agent_loop/activities/run_tool.ts
+++ b/front/temporal/agent_loop/activities/run_tool.ts
@@ -131,7 +131,7 @@ export async function runToolActivity(
                 created: event.created,
                 configurationId: agentConfiguration.sId,
                 messageId: agentMessage.sId,
-                message: agentMessage,
+                message: { ...agentMessage, content: event.text },
                 runIds: runIds ?? [],
               },
 


### PR DESCRIPTION
## Description

In case of early exit, the success event did not contain the text of the message - this was not visible in the classical conversation viewer as conversation was reloaded after message success, but with virtuoso the message remained empty.
With virtuoso messages are not reloaded, so we need to append the text and send it in the event.

## Tests

locally

## Risk

none

## Deploy Plan

deploy front
