### PR TITLE
Update message breakdown UI + UI for Deep as a tool

### DIFF
--- a/front/components/assistant/conversation/AgentMessageCompletionStatus.tsx
+++ b/front/components/assistant/conversation/AgentMessageCompletionStatus.tsx
@@ -1,0 +1,60 @@
+import { Button, CommandLineIcon } from "@dust-tt/sparkle";
+import React from "react";
+
+import { useConversationSidePanelContext } from "@app/components/assistant/conversation/ConversationSidePanelContext";
+import { formatDurationString } from "@app/lib/utils/timestamps";
+import type {
+  LightAgentMessageType,
+  LightAgentMessageWithActionsType,
+} from "@app/types";
+
+export const AgentMessageCompletionStatus = ({
+  agentMessage,
+}: {
+  agentMessage: LightAgentMessageType | LightAgentMessageWithActionsType;
+}) => {
+  const { openPanel, data } = useConversationSidePanelContext();
+
+  const onClick = () => {
+    openPanel({
+      type: "actions",
+      messageId: agentMessage.sId,
+    });
+  };
+
+  if (agentMessage.completedTs === null) {
+    return (
+      <Button
+        icon={CommandLineIcon}
+        onClick={onClick}
+        size="xs"
+        variant={data === agentMessage.sId ? "ghost-secondary" : "ghost"}
+      />
+    );
+  }
+
+  const completedInMs = agentMessage.completedTs - agentMessage.created;
+
+  let statusText = "Completed in";
+  if (agentMessage.status === "failed") {
+    statusText = "Errored after";
+  } else if (agentMessage.status === "cancelled") {
+    statusText = "Cancelled after";
+  }
+
+  const timeString = formatDurationString(completedInMs);
+
+  return (
+    <div className="flex items-center gap-1">
+      <span className="text-xs text-muted-foreground dark:text-muted-foreground-night">
+        {statusText} {timeString}
+      </span>
+      <Button
+        icon={CommandLineIcon}
+        onClick={onClick}
+        size="xs"
+        variant={data === agentMessage.sId ? "ghost-secondary" : "ghost"}
+      />
+    </div>
+  );
+};

--- a/front/components/assistant/conversation/AgentMessageCompletionStatus.tsx
+++ b/front/components/assistant/conversation/AgentMessageCompletionStatus.tsx
@@ -1,4 +1,4 @@
-import { Button, ChevronLeftIcon, ChevronRightIcon } from "@dust-tt/sparkle";
+import { ChevronRightIcon, cn } from "@dust-tt/sparkle";
 import React from "react";
 
 import { useConversationSidePanelContext } from "@app/components/assistant/conversation/ConversationSidePanelContext";
@@ -22,42 +22,40 @@ export const AgentMessageCompletionStatus = ({
     });
   };
 
-  if (agentMessage.completedTs === null) {
-    return (
-      <Button
-        icon={data === agentMessage.sId ? ChevronLeftIcon : ChevronRightIcon}
-        onClick={onClick}
-        size="xs"
-        variant={data === agentMessage.sId ? "ghost-secondary" : "ghost"}
-      />
-    );
+  if (agentMessage.status === "created") {
+    // This message is not completed yet, so we don't need to show the completion status since we have the activity chip.
+    return null;
   }
 
-  const completedInMs = agentMessage.completedTs - agentMessage.created;
+  let displayText = "Message breakdown";
 
-  let statusText = "Completed in";
-  if (agentMessage.status === "failed") {
-    statusText = "Errored after";
-  } else if (agentMessage.status === "cancelled") {
-    statusText = "Cancelled after";
+  // If we have a completed timestamp, we can show the duration.
+  if (agentMessage.completedTs !== null) {
+    let statusText = "Completed in";
+    if (agentMessage.status === "failed") {
+      statusText = "Errored after";
+    } else if (agentMessage.status === "cancelled") {
+      statusText = "Cancelled after";
+    }
+    const completedInMs = agentMessage.completedTs - agentMessage.created;
+    const timeString = formatDurationString(completedInMs);
+    displayText = `${statusText} ${timeString}`;
   }
 
-  const timeString = formatDurationString(completedInMs);
+  const isOpened = data === agentMessage.sId;
 
   return (
-    <div className="flex items-center gap-1">
-      <span
-        className="cursor-pointer text-xs text-muted-foreground hover:text-foreground dark:text-muted-foreground-night dark:hover:text-foreground-night"
-        onClick={onClick}
-      >
-        {statusText} {timeString}
-      </span>
-      <Button
-        icon={data === agentMessage.sId ? ChevronLeftIcon : ChevronRightIcon}
-        onClick={onClick}
-        size="xs"
-        variant={data === agentMessage.sId ? "ghost-secondary" : "ghost"}
-      />
+    <div
+      className={cn(
+        "flex cursor-pointer items-center gap-1 text-xs",
+        "text-muted-foreground dark:text-muted-foreground-night",
+        "hover:text-foreground dark:hover:text-foreground-night",
+        isOpened && "text-foreground dark:text-foreground-night"
+      )}
+      onClick={onClick}
+    >
+      <span>{displayText}</span>
+      <ChevronRightIcon className="h-3 w-3" />
     </div>
   );
 };

--- a/front/components/assistant/conversation/AgentMessageCompletionStatus.tsx
+++ b/front/components/assistant/conversation/AgentMessageCompletionStatus.tsx
@@ -1,4 +1,4 @@
-import { Button, CommandLineIcon } from "@dust-tt/sparkle";
+import { Button, ChevronLeftIcon, ChevronRightIcon } from "@dust-tt/sparkle";
 import React from "react";
 
 import { useConversationSidePanelContext } from "@app/components/assistant/conversation/ConversationSidePanelContext";
@@ -25,7 +25,7 @@ export const AgentMessageCompletionStatus = ({
   if (agentMessage.completedTs === null) {
     return (
       <Button
-        icon={CommandLineIcon}
+        icon={data === agentMessage.sId ? ChevronLeftIcon : ChevronRightIcon}
         onClick={onClick}
         size="xs"
         variant={data === agentMessage.sId ? "ghost-secondary" : "ghost"}
@@ -46,11 +46,14 @@ export const AgentMessageCompletionStatus = ({
 
   return (
     <div className="flex items-center gap-1">
-      <span className="text-xs text-muted-foreground dark:text-muted-foreground-night">
+      <span
+        className="cursor-pointer text-xs text-muted-foreground hover:text-foreground dark:text-muted-foreground-night dark:hover:text-foreground-night"
+        onClick={onClick}
+      >
         {statusText} {timeString}
       </span>
       <Button
-        icon={CommandLineIcon}
+        icon={data === agentMessage.sId ? ChevronLeftIcon : ChevronRightIcon}
         onClick={onClick}
         size="xs"
         variant={data === agentMessage.sId ? "ghost-secondary" : "ghost"}

--- a/front/components/assistant/conversation/ConversationViewerVirtuoso.tsx
+++ b/front/components/assistant/conversation/ConversationViewerVirtuoso.tsx
@@ -266,7 +266,10 @@ const ConversationViewerVirtuoso = ({
           case "user_message_new":
             if (ref.current) {
               // Skip our own messages, otherwise they get duplicated because the event is fired before we get the message from the backend.
-              if (event.message.user?.id === user.id) {
+              if (
+                event.message.user?.id === user.id &&
+                event.message.context.origin !== "agent_handover"
+              ) {
                 return;
               }
               const predicate = (m: VirtuosoMessage) =>

--- a/front/components/assistant/conversation/MessageGroup.tsx
+++ b/front/components/assistant/conversation/MessageGroup.tsx
@@ -28,6 +28,13 @@ const MAX_OFFSET_PIXEL = 600;
 
 export const LAST_MESSAGE_GROUP_ID = "last-message-group";
 
+const isHandoverUserMessage = (message: MessageWithContentFragmentsType) => {
+  return (
+    message.type === "user_message" &&
+    message.context.origin === "agent_handover"
+  );
+};
+
 export default function MessageGroup({
   messages,
   isLastMessageGroup,
@@ -54,11 +61,9 @@ export default function MessageGroup({
     }
   }, [isLastMessageGroup]);
 
-  const filteredMessages = messages.filter(
-    (message) =>
-      message.type !== "user_message" ||
-      message.context.origin !== "agent_handover"
-  );
+  const isHandoverGroup =
+    messages.length > 0 &&
+    messages.some((message) => isHandoverUserMessage(message));
 
   return (
     <div
@@ -66,7 +71,7 @@ export default function MessageGroup({
       ref={isLastMessageGroup ? lastMessageGroupRef : undefined}
       style={{ minHeight }}
     >
-      {filteredMessages.map((message) => (
+      {messages.map((message) => (
         <MessageItem
           key={`message-${message.sId}`}
           conversationId={conversationId}
@@ -81,6 +86,7 @@ export default function MessageGroup({
           }
           user={user}
           isLastMessage={latestPage?.messages.at(-1)?.sId === message.sId}
+          isHandoverGroup={isHandoverGroup}
         />
       ))}
     </div>

--- a/front/components/assistant/conversation/MessageGroup.tsx
+++ b/front/components/assistant/conversation/MessageGroup.tsx
@@ -28,7 +28,9 @@ const MAX_OFFSET_PIXEL = 600;
 
 export const LAST_MESSAGE_GROUP_ID = "last-message-group";
 
-const isHandoverUserMessage = (message: MessageWithContentFragmentsType) => {
+export const isHandoverUserMessage = (
+  message: MessageWithContentFragmentsType
+) => {
   return (
     message.type === "user_message" &&
     message.context.origin === "agent_handover"

--- a/front/components/assistant/conversation/MessageItem.tsx
+++ b/front/components/assistant/conversation/MessageItem.tsx
@@ -101,6 +101,19 @@ const MessageItem = React.forwardRef<HTMLDivElement, MessageItemProps>(
       isSubmittingThumb,
     };
 
+    const isHandoverUserMessage = (
+      message: MessageWithContentFragmentsType
+    ) => {
+      return (
+        message.type === "user_message" &&
+        message.context.origin === "agent_handover"
+      );
+    };
+
+    if (isHandoverUserMessage(message)) {
+      return null;
+    }
+
     if (isHandoverGroup && type === "user_message") {
       // We do not display the user message in a handover group.
       return null;

--- a/front/components/assistant/conversation/MessageItem.tsx
+++ b/front/components/assistant/conversation/MessageItem.tsx
@@ -101,19 +101,6 @@ const MessageItem = React.forwardRef<HTMLDivElement, MessageItemProps>(
       isSubmittingThumb,
     };
 
-    const isHandoverUserMessage = (
-      message: MessageWithContentFragmentsType
-    ) => {
-      return (
-        message.type === "user_message" &&
-        message.context.origin === "agent_handover"
-      );
-    };
-
-    if (isHandoverUserMessage(message)) {
-      return null;
-    }
-
     if (isHandoverGroup && type === "user_message") {
       // We do not display the user message in a handover group.
       return null;

--- a/front/components/assistant/conversation/MessageItem.tsx
+++ b/front/components/assistant/conversation/MessageItem.tsx
@@ -23,6 +23,7 @@ interface MessageItemProps {
   messageFeedback: AgentMessageFeedbackType | undefined;
   isInModal: boolean;
   isLastMessage: boolean;
+  isHandoverGroup: boolean;
   message: MessageWithContentFragmentsType;
   owner: WorkspaceType;
   user: UserType;
@@ -34,6 +35,7 @@ const MessageItem = React.forwardRef<HTMLDivElement, MessageItemProps>(
       conversationId,
       messageFeedback,
       isLastMessage,
+      isHandoverGroup,
       message,
       owner,
       user,
@@ -99,6 +101,11 @@ const MessageItem = React.forwardRef<HTMLDivElement, MessageItemProps>(
       isSubmittingThumb,
     };
 
+    if (isHandoverGroup && type === "user_message") {
+      // We do not display the user message in a handover group.
+      return null;
+    }
+
     switch (type) {
       case "user_message":
         const citations = message.contentFragments
@@ -141,6 +148,7 @@ const MessageItem = React.forwardRef<HTMLDivElement, MessageItemProps>(
             <AgentMessage
               conversationId={conversationId}
               isLastMessage={isLastMessage}
+              isHandoverGroup={isHandoverGroup}
               message={message}
               messageFeedback={messageFeedbackWithSubmit}
               owner={owner}

--- a/front/components/assistant/conversation/MessageItemVirtuoso.tsx
+++ b/front/components/assistant/conversation/MessageItemVirtuoso.tsx
@@ -23,7 +23,6 @@ import { UserMessage } from "@app/components/assistant/conversation/UserMessage"
 import { useSendNotification } from "@app/hooks/useNotification";
 import { useSubmitFunction } from "@app/lib/client/utils";
 import { classNames } from "@app/lib/utils";
-import type { MessageWithContentFragmentsType } from "@app/types";
 
 interface MessageItemProps {
   data: VirtuosoMessage;
@@ -152,7 +151,7 @@ const MessageItemVirtuoso = React.forwardRef<HTMLDivElement, MessageItemProps>(
               user={context.user}
               conversationId={context.conversationId}
               isLastMessage={!nextData}
-              isAgentMessageHandover={isAgentMessageHandover}
+              isAgentMessageHandover={isAgentMessageHandover ?? false}
               messageStreamState={data}
               messageFeedback={messageFeedbackWithSubmit}
               owner={context.owner}

--- a/front/components/assistant/conversation/MessageItemVirtuoso.tsx
+++ b/front/components/assistant/conversation/MessageItemVirtuoso.tsx
@@ -15,6 +15,7 @@ import type {
 import {
   getMessageDate,
   getMessageSId,
+  isHandoverUserMessage,
   isMessageTemporayState,
   isUserMessage,
 } from "@app/components/assistant/conversation/types";
@@ -22,6 +23,7 @@ import { UserMessage } from "@app/components/assistant/conversation/UserMessage"
 import { useSendNotification } from "@app/hooks/useNotification";
 import { useSubmitFunction } from "@app/lib/client/utils";
 import { classNames } from "@app/lib/utils";
+import type { MessageWithContentFragmentsType } from "@app/types";
 
 interface MessageItemProps {
   data: VirtuosoMessage;
@@ -117,6 +119,13 @@ const MessageItemVirtuoso = React.forwardRef<HTMLDivElement, MessageItemProps>(
       getMessageDate(prevData).toDateString() ===
         getMessageDate(data).toDateString();
 
+    const shouldHideUserMessage = isHandoverUserMessage(data);
+    const isAgentMessageHandover =
+      prevData &&
+      isHandoverUserMessage(prevData) &&
+      isMessageTemporayState(data) &&
+      data.message.parentMessageId === prevData.sId;
+
     return (
       <>
         {!areSameDate && <MessageDateIndicator message={data} />}
@@ -129,7 +138,7 @@ const MessageItemVirtuoso = React.forwardRef<HTMLDivElement, MessageItemProps>(
             context.isInModal ? "max-w-full" : "max-w-3xl"
           )}
         >
-          {isUserMessage(data) && (
+          {isUserMessage(data) && !shouldHideUserMessage && (
             <UserMessage
               citations={citations}
               conversationId={context.conversationId}
@@ -143,6 +152,7 @@ const MessageItemVirtuoso = React.forwardRef<HTMLDivElement, MessageItemProps>(
               user={context.user}
               conversationId={context.conversationId}
               isLastMessage={!nextData}
+              isAgentMessageHandover={isAgentMessageHandover}
               messageStreamState={data}
               messageFeedback={messageFeedbackWithSubmit}
               owner={context.owner}

--- a/front/components/assistant/conversation/actions/AgentActionsPanelSummary.tsx
+++ b/front/components/assistant/conversation/actions/AgentActionsPanelSummary.tsx
@@ -1,6 +1,7 @@
 import { Separator } from "@dust-tt/sparkle";
 import type React from "react";
 
+import { formatDurationString } from "@app/lib/utils/timestamps";
 import type {
   AgentMessageType,
   LightAgentMessageWithActionsType,
@@ -31,7 +32,7 @@ export function AgentActionSummary({
     statusText = "Cancelled after";
   }
 
-  const timeString = formatDuration(completedInMs);
+  const timeString = formatDurationString(completedInMs);
   const toolsText =
     nbActions === 0
       ? "without tools"
@@ -54,18 +55,3 @@ export function AgentActionSummary({
     </div>
   );
 }
-
-// Util to format time duration:
-// takes a number of milliseconds and returns a string like "1 min 30 sec".
-const formatDuration = (ms: number): string => {
-  const seconds = Math.floor(ms / 1000);
-  if (seconds < 60) {
-    return `${seconds} sec`;
-  }
-  const minutes = Math.floor(seconds / 60);
-  const remainingSeconds = seconds % 60;
-  if (remainingSeconds === 0) {
-    return `${minutes} min`;
-  }
-  return `${minutes} min ${remainingSeconds} sec`;
-};

--- a/front/components/assistant/conversation/actions/AgentMessageActions.tsx
+++ b/front/components/assistant/conversation/actions/AgentMessageActions.tsx
@@ -1,9 +1,7 @@
 import {
   AnimatedText,
-  Button,
   Card,
   cn,
-  CommandLineIcon,
   ContentMessage,
   Markdown,
   Spinner,
@@ -122,15 +120,5 @@ export function AgentMessageActions({
         </div>
       )}
     </div>
-  ) : (
-    <div className="flex flex-col items-start gap-y-4">
-      <Button
-        size="xs"
-        label="Message Breakdown"
-        icon={CommandLineIcon}
-        variant={data === agentMessage.sId ? "primary" : "outline"}
-        onClick={onClick}
-      />
-    </div>
-  );
+  ) : null;
 }

--- a/front/components/assistant/conversation/types.ts
+++ b/front/components/assistant/conversation/types.ts
@@ -70,6 +70,13 @@ export const isUserMessage = (
 ): msg is UserMessageType & { contentFragments: ContentFragmentType[] } =>
   "type" in msg && msg.type === "user_message" && "contentFragments" in msg;
 
+export const isHandoverUserMessage = (
+  msg: VirtuosoMessage
+): msg is UserMessageType & { contentFragments: ContentFragmentType[] } =>
+  "type" in msg &&
+  msg.type === "user_message" &&
+  msg.context.origin === "agent_handover";
+
 export const isMessageTemporayState = (
   msg: VirtuosoMessage
 ): msg is MessageTemporaryState => "agentState" in msg;

--- a/front/lib/utils/timestamps.ts
+++ b/front/lib/utils/timestamps.ts
@@ -26,3 +26,22 @@ export const formatTimestring = (timestamp: number): string => {
     minute: "2-digit",
   });
 };
+
+/**
+ * Formats a duration in milliseconds to a human-readable string.
+ * @param durationMs - The duration in milliseconds
+ * @returns A formatted string like "9 min 12 sec" or "45 sec"
+ */
+export const formatDurationString = (durationMs: number): string => {
+  const totalSeconds = Math.floor(durationMs / 1000);
+  const minutes = Math.floor(totalSeconds / 60);
+  const seconds = totalSeconds % 60;
+
+  if (minutes > 0) {
+    if (seconds === 0) {
+      return `${minutes} min`;
+    }
+    return `${minutes} min ${seconds} sec`;
+  }
+  return `${seconds} sec`;
+};

--- a/front/temporal/agent_loop/activities/run_tool.ts
+++ b/front/temporal/agent_loop/activities/run_tool.ts
@@ -134,6 +134,7 @@ export async function runToolActivity(
                 message: {
                   ...agentMessage,
                   content: (agentMessage.content ?? "") + "\n\n" + event.text,
+                  completedTs: event.created,
                 },
                 runIds: runIds ?? [],
               },

--- a/front/temporal/agent_loop/lib/run_model.ts
+++ b/front/temporal/agent_loop/lib/run_model.ts
@@ -710,6 +710,7 @@ export async function runModelActivity(
     }
     agentMessage.content = (agentMessage.content ?? "") + processedContent;
     agentMessage.status = "succeeded";
+    agentMessage.completedTs = Date.now();
 
     await updateResourceAndPublishEvent(auth, {
       event: {


### PR DESCRIPTION
## Description

- Changing the display of the message breakdown button following @Duncid 's designs here: https://github.com/dust-tt/tasks/issues/4348
- Displaying Deep as a tool as explored in Sparkle. 
- We display the timestamp of agent message only if we have a completedTs time (all messages starting from next week) + it's not a deep dive tool. 


<img width="811" height="679" alt="Screenshot 2025-10-07 at 16 29 38" src="https://github.com/user-attachments/assets/e27b6df2-9d77-41a9-961e-b010ab340a78" />


## Tests

Locally. 

## Risk

Can be rolled back. 

## Deploy Plan

Deploy front. 