### PR TITLE
[front] chore(cc): add back content creation to global agents

### DIFF
--- a/front/lib/api/assistant/global_agents/configurations/anthropic.ts
+++ b/front/lib/api/assistant/global_agents/configurations/anthropic.ts
@@ -3,7 +3,10 @@ import {
   globalAgentGuidelines,
   globalAgentWebSearchGuidelines,
 } from "@app/lib/api/assistant/global_agents/guidelines";
-import { _getDefaultWebActionsForGlobalAgent } from "@app/lib/api/assistant/global_agents/tools";
+import {
+  _getContentCreationToolConfiguration,
+  _getDefaultWebActionsForGlobalAgent,
+} from "@app/lib/api/assistant/global_agents/tools";
 import type { Authenticator } from "@app/lib/auth";
 import type { GlobalAgentSettings } from "@app/lib/models/assistant/agent";
 import type { MCPServerViewResource } from "@app/lib/resources/mcp_server_view_resource";
@@ -112,9 +115,11 @@ export function _getClaude2GlobalAgent({
 export function _getClaude3HaikuGlobalAgent({
   settings,
   webSearchBrowseMCPServerView,
+  contentCreationMCPServerView,
 }: {
   settings: GlobalAgentSettings | null;
   webSearchBrowseMCPServerView: MCPServerViewResource | null;
+  contentCreationMCPServerView: MCPServerViewResource | null;
 }): AgentConfigurationType {
   const status = settings ? settings.status : "disabled_by_admin";
 
@@ -146,9 +151,13 @@ export function _getClaude3HaikuGlobalAgent({
         agentId: sId,
         webSearchBrowseMCPServerView,
       }),
+      ..._getContentCreationToolConfiguration({
+        agentId: sId,
+        contentCreationMCPServerView,
+      }),
     ],
     maxStepsPerRun: MAX_STEPS_USE_PER_RUN_LIMIT,
-    visualizationEnabled: true,
+    visualizationEnabled: false,
     templateId: null,
     requestedGroupIds: [],
     tags: [],
@@ -161,10 +170,12 @@ export function _getClaude3OpusGlobalAgent({
   auth,
   settings,
   webSearchBrowseMCPServerView,
+  contentCreationMCPServerView,
 }: {
   auth: Authenticator;
   settings: GlobalAgentSettings | null;
   webSearchBrowseMCPServerView: MCPServerViewResource | null;
+  contentCreationMCPServerView: MCPServerViewResource | null;
 }): AgentConfigurationType {
   let status = settings?.status ?? "active";
   if (!auth.isUpgraded()) {
@@ -199,9 +210,13 @@ export function _getClaude3OpusGlobalAgent({
         agentId: sId,
         webSearchBrowseMCPServerView,
       }),
+      ..._getContentCreationToolConfiguration({
+        agentId: sId,
+        contentCreationMCPServerView,
+      }),
     ],
     maxStepsPerRun: MAX_STEPS_USE_PER_RUN_LIMIT,
-    visualizationEnabled: true,
+    visualizationEnabled: false,
     templateId: null,
     requestedGroupIds: [],
     tags: [],
@@ -214,10 +229,12 @@ export function _getClaude3GlobalAgent({
   auth,
   settings,
   webSearchBrowseMCPServerView,
+  contentCreationMCPServerView,
 }: {
   auth: Authenticator;
   settings: GlobalAgentSettings | null;
   webSearchBrowseMCPServerView: MCPServerViewResource | null;
+  contentCreationMCPServerView: MCPServerViewResource | null;
 }): AgentConfigurationType {
   let status = settings?.status ?? "active";
   if (!auth.isUpgraded()) {
@@ -252,9 +269,13 @@ export function _getClaude3GlobalAgent({
         agentId: sId,
         webSearchBrowseMCPServerView,
       }),
+      ..._getContentCreationToolConfiguration({
+        agentId: sId,
+        contentCreationMCPServerView,
+      }),
     ],
     maxStepsPerRun: MAX_STEPS_USE_PER_RUN_LIMIT,
-    visualizationEnabled: true,
+    visualizationEnabled: false,
     templateId: null,
     requestedGroupIds: [],
     tags: [],
@@ -267,10 +288,12 @@ export function _getClaude4SonnetGlobalAgent({
   auth,
   settings,
   webSearchBrowseMCPServerView,
+  contentCreationMCPServerView,
 }: {
   auth: Authenticator;
   settings: GlobalAgentSettings | null;
   webSearchBrowseMCPServerView: MCPServerViewResource | null;
+  contentCreationMCPServerView: MCPServerViewResource | null;
 }): AgentConfigurationType {
   let status = settings?.status ?? "active";
   if (!auth.isUpgraded()) {
@@ -305,9 +328,13 @@ export function _getClaude4SonnetGlobalAgent({
         agentId: sId,
         webSearchBrowseMCPServerView,
       }),
+      ..._getContentCreationToolConfiguration({
+        agentId: sId,
+        contentCreationMCPServerView,
+      }),
     ],
     maxStepsPerRun: MAX_STEPS_USE_PER_RUN_LIMIT,
-    visualizationEnabled: true,
+    visualizationEnabled: false,
     templateId: null,
     requestedGroupIds: [],
     tags: [],
@@ -320,10 +347,12 @@ export function _getClaude3_7GlobalAgent({
   auth,
   settings,
   webSearchBrowseMCPServerView,
+  contentCreationMCPServerView,
 }: {
   auth: Authenticator;
   settings: GlobalAgentSettings | null;
   webSearchBrowseMCPServerView: MCPServerViewResource | null;
+  contentCreationMCPServerView: MCPServerViewResource | null;
 }): AgentConfigurationType {
   let status = settings?.status ?? "active";
   if (!auth.isUpgraded()) {
@@ -358,9 +387,13 @@ export function _getClaude3_7GlobalAgent({
         agentId: sId,
         webSearchBrowseMCPServerView,
       }),
+      ..._getContentCreationToolConfiguration({
+        agentId: sId,
+        contentCreationMCPServerView,
+      }),
     ],
     maxStepsPerRun: MAX_STEPS_USE_PER_RUN_LIMIT,
-    visualizationEnabled: true,
+    visualizationEnabled: false,
     templateId: null,
     requestedGroupIds: [],
     tags: [],

--- a/front/lib/api/assistant/global_agents/configurations/dust/dust-deep.ts
+++ b/front/lib/api/assistant/global_agents/configurations/dust/dust-deep.ts
@@ -517,7 +517,7 @@ export function _getDustDeepGlobalAgent(
     scope: "global" as const,
     userFavorite: false,
     model: dummyModelConfiguration,
-    visualizationEnabled: true,
+    visualizationEnabled: false,
     templateId: null,
     requestedGroupIds: [],
     tags: [],

--- a/front/lib/api/assistant/global_agents/configurations/dust/dust.ts
+++ b/front/lib/api/assistant/global_agents/configurations/dust/dust.ts
@@ -8,6 +8,7 @@ import { globalAgentGuidelines } from "@app/lib/api/assistant/global_agents/guid
 import type { PrefetchedDataSourcesType } from "@app/lib/api/assistant/global_agents/tools";
 import {
   _getAgentRouterToolsConfiguration,
+  _getContentCreationToolConfiguration,
   _getDefaultWebActionsForGlobalAgent,
 } from "@app/lib/api/assistant/global_agents/tools";
 import { dummyModelConfiguration } from "@app/lib/api/assistant/global_agents/utils";
@@ -36,6 +37,7 @@ export function _getDustGlobalAgent(
     webSearchBrowseMCPServerView,
     searchMCPServerView,
     deepResearchMCPServerView,
+    contentCreationMCPServerView,
   }: {
     settings: GlobalAgentSettings | null;
     preFetchedDataSources: PrefetchedDataSourcesType | null;
@@ -43,6 +45,7 @@ export function _getDustGlobalAgent(
     webSearchBrowseMCPServerView: MCPServerViewResource | null;
     searchMCPServerView: MCPServerViewResource | null;
     deepResearchMCPServerView: MCPServerViewResource | null;
+    contentCreationMCPServerView: MCPServerViewResource | null;
   }
 ): AgentConfigurationType | null {
   const owner = auth.getNonNullableWorkspace();
@@ -147,7 +150,7 @@ export function _getDustGlobalAgent(
     scope: "global" as const,
     userFavorite: false,
     model,
-    visualizationEnabled: true,
+    visualizationEnabled: false,
     templateId: null,
     requestedGroupIds: [],
     tags: [],
@@ -293,6 +296,13 @@ export function _getDustGlobalAgent(
       secretName: null,
     });
   }
+
+  actions.push(
+    ..._getContentCreationToolConfiguration({
+      agentId: GLOBAL_AGENTS_SID.DUST,
+      contentCreationMCPServerView,
+    })
+  );
 
   // Fix the action ids.
   actions.forEach((action, i) => {

--- a/front/lib/api/assistant/global_agents/configurations/google.ts
+++ b/front/lib/api/assistant/global_agents/configurations/google.ts
@@ -3,7 +3,10 @@ import {
   globalAgentGuidelines,
   globalAgentWebSearchGuidelines,
 } from "@app/lib/api/assistant/global_agents/guidelines";
-import { _getDefaultWebActionsForGlobalAgent } from "@app/lib/api/assistant/global_agents/tools";
+import {
+  _getContentCreationToolConfiguration,
+  _getDefaultWebActionsForGlobalAgent,
+} from "@app/lib/api/assistant/global_agents/tools";
 import type { Authenticator } from "@app/lib/auth";
 import type { GlobalAgentSettings } from "@app/lib/models/assistant/agent";
 import type { MCPServerViewResource } from "@app/lib/resources/mcp_server_view_resource";
@@ -18,10 +21,12 @@ export function _getGeminiProGlobalAgent({
   auth,
   settings,
   webSearchBrowseMCPServerView,
+  contentCreationMCPServerView,
 }: {
   auth: Authenticator;
   settings: GlobalAgentSettings | null;
   webSearchBrowseMCPServerView: MCPServerViewResource | null;
+  contentCreationMCPServerView: MCPServerViewResource | null;
 }): AgentConfigurationType {
   let status = settings?.status ?? "active";
   if (!auth.isUpgraded()) {
@@ -55,9 +60,13 @@ export function _getGeminiProGlobalAgent({
         agentId: sId,
         webSearchBrowseMCPServerView,
       }),
+      ..._getContentCreationToolConfiguration({
+        agentId: sId,
+        contentCreationMCPServerView,
+      }),
     ],
     maxStepsPerRun: MAX_STEPS_USE_PER_RUN_LIMIT,
-    visualizationEnabled: true,
+    visualizationEnabled: false,
     templateId: null,
     requestedGroupIds: [],
     tags: [],

--- a/front/lib/api/assistant/global_agents/configurations/helper.ts
+++ b/front/lib/api/assistant/global_agents/configurations/helper.ts
@@ -8,6 +8,7 @@ import { getGlobalAgentMetadata } from "@app/lib/api/assistant/global_agents/glo
 import { globalAgentGuidelines } from "@app/lib/api/assistant/global_agents/guidelines";
 import {
   _getAgentRouterToolsConfiguration,
+  _getContentCreationToolConfiguration,
   _getDefaultWebActionsForGlobalAgent,
 } from "@app/lib/api/assistant/global_agents/tools";
 import { dummyModelConfiguration } from "@app/lib/api/assistant/global_agents/utils";
@@ -64,12 +65,14 @@ export function _getHelperGlobalAgent({
   agentRouterMCPServerView,
   webSearchBrowseMCPServerView,
   searchMCPServerView,
+  contentCreationMCPServerView,
 }: {
   auth: Authenticator;
   helperPromptInstance: HelperAssistantPrompt;
   agentRouterMCPServerView: MCPServerViewResource | null;
   webSearchBrowseMCPServerView: MCPServerViewResource | null;
   searchMCPServerView: MCPServerViewResource | null;
+  contentCreationMCPServerView: MCPServerViewResource | null;
 }): AgentConfigurationType {
   let prompt = "";
 
@@ -150,6 +153,13 @@ export function _getHelperGlobalAgent({
   const sId = GLOBAL_AGENTS_SID.HELPER;
   const metadata = getGlobalAgentMetadata(sId);
 
+  actions.push(
+    ..._getContentCreationToolConfiguration({
+      agentId: sId,
+      contentCreationMCPServerView,
+    })
+  );
+
   return {
     id: -1,
     sId,
@@ -166,7 +176,7 @@ export function _getHelperGlobalAgent({
     model: model,
     actions,
     maxStepsPerRun: MAX_STEPS_USE_PER_RUN_LIMIT,
-    visualizationEnabled: true,
+    visualizationEnabled: false,
     templateId: null,
     requestedGroupIds: [],
     tags: [],

--- a/front/lib/api/assistant/global_agents/configurations/mistral.ts
+++ b/front/lib/api/assistant/global_agents/configurations/mistral.ts
@@ -3,7 +3,10 @@ import {
   globalAgentGuidelines,
   globalAgentWebSearchGuidelines,
 } from "@app/lib/api/assistant/global_agents/guidelines";
-import { _getDefaultWebActionsForGlobalAgent } from "@app/lib/api/assistant/global_agents/tools";
+import {
+  _getContentCreationToolConfiguration,
+  _getDefaultWebActionsForGlobalAgent,
+} from "@app/lib/api/assistant/global_agents/tools";
 import type { Authenticator } from "@app/lib/auth";
 import type { GlobalAgentSettings } from "@app/lib/models/assistant/agent";
 import type { MCPServerViewResource } from "@app/lib/resources/mcp_server_view_resource";
@@ -28,10 +31,12 @@ export function _getMistralLargeGlobalAgent({
   auth,
   settings,
   webSearchBrowseMCPServerView,
+  contentCreationMCPServerView,
 }: {
   auth: Authenticator;
   settings: GlobalAgentSettings | null;
   webSearchBrowseMCPServerView: MCPServerViewResource | null;
+  contentCreationMCPServerView: MCPServerViewResource | null;
 }): AgentConfigurationType {
   let status = settings?.status ?? "active";
   if (!auth.isUpgraded()) {
@@ -65,9 +70,13 @@ export function _getMistralLargeGlobalAgent({
         agentId: sId,
         webSearchBrowseMCPServerView,
       }),
+      ..._getContentCreationToolConfiguration({
+        agentId: sId,
+        contentCreationMCPServerView,
+      }),
     ],
     maxStepsPerRun: MAX_STEPS_USE_PER_RUN_LIMIT,
-    visualizationEnabled: true,
+    visualizationEnabled: false,
     templateId: null,
     requestedGroupIds: [],
     tags: [],
@@ -80,10 +89,12 @@ export function _getMistralMediumGlobalAgent({
   auth,
   settings,
   webSearchBrowseMCPServerView,
+  contentCreationMCPServerView,
 }: {
   auth: Authenticator;
   settings: GlobalAgentSettings | null;
   webSearchBrowseMCPServerView: MCPServerViewResource | null;
+  contentCreationMCPServerView: MCPServerViewResource | null;
 }): AgentConfigurationType {
   let status = settings?.status ?? "disabled_by_admin";
   if (!auth.isUpgraded()) {
@@ -117,9 +128,13 @@ export function _getMistralMediumGlobalAgent({
         agentId: sId,
         webSearchBrowseMCPServerView,
       }),
+      ..._getContentCreationToolConfiguration({
+        agentId: sId,
+        contentCreationMCPServerView,
+      }),
     ],
     maxStepsPerRun: MAX_STEPS_USE_PER_RUN_LIMIT,
-    visualizationEnabled: true,
+    visualizationEnabled: false,
     templateId: null,
     requestedGroupIds: [],
     tags: [],
@@ -131,9 +146,11 @@ export function _getMistralMediumGlobalAgent({
 export function _getMistralSmallGlobalAgent({
   settings,
   webSearchBrowseMCPServerView,
+  contentCreationMCPServerView,
 }: {
   settings: GlobalAgentSettings | null;
   webSearchBrowseMCPServerView: MCPServerViewResource | null;
+  contentCreationMCPServerView: MCPServerViewResource | null;
 }): AgentConfigurationType {
   const status = settings ? settings.status : "disabled_by_admin";
 
@@ -164,9 +181,13 @@ export function _getMistralSmallGlobalAgent({
         agentId: sId,
         webSearchBrowseMCPServerView,
       }),
+      ..._getContentCreationToolConfiguration({
+        agentId: sId,
+        contentCreationMCPServerView,
+      }),
     ],
     maxStepsPerRun: MAX_STEPS_USE_PER_RUN_LIMIT,
-    visualizationEnabled: true,
+    visualizationEnabled: false,
     templateId: null,
     requestedGroupIds: [],
     tags: [],

--- a/front/lib/api/assistant/global_agents/configurations/openai.ts
+++ b/front/lib/api/assistant/global_agents/configurations/openai.ts
@@ -3,7 +3,10 @@ import {
   globalAgentGuidelines,
   globalAgentWebSearchGuidelines,
 } from "@app/lib/api/assistant/global_agents/guidelines";
-import { _getDefaultWebActionsForGlobalAgent } from "@app/lib/api/assistant/global_agents/tools";
+import {
+  _getContentCreationToolConfiguration,
+  _getDefaultWebActionsForGlobalAgent,
+} from "@app/lib/api/assistant/global_agents/tools";
 import type { Authenticator } from "@app/lib/auth";
 import type { GlobalAgentSettings } from "@app/lib/models/assistant/agent";
 import type { MCPServerViewResource } from "@app/lib/resources/mcp_server_view_resource";
@@ -35,9 +38,11 @@ import {
 export function _getGPT35TurboGlobalAgent({
   settings,
   webSearchBrowseMCPServerView,
+  contentCreationMCPServerView,
 }: {
   settings: GlobalAgentSettings | null;
   webSearchBrowseMCPServerView: MCPServerViewResource | null;
+  contentCreationMCPServerView: MCPServerViewResource | null;
 }): AgentConfigurationType {
   const status = settings ? settings.status : "active";
 
@@ -67,9 +72,13 @@ export function _getGPT35TurboGlobalAgent({
         agentId: sId,
         webSearchBrowseMCPServerView,
       }),
+      ..._getContentCreationToolConfiguration({
+        agentId: sId,
+        contentCreationMCPServerView,
+      }),
     ],
     maxStepsPerRun: MAX_STEPS_USE_PER_RUN_LIMIT,
-    visualizationEnabled: true,
+    visualizationEnabled: false,
     templateId: null,
     requestedGroupIds: [],
     tags: [],
@@ -82,10 +91,12 @@ export function _getGPT4GlobalAgent({
   auth,
   settings,
   webSearchBrowseMCPServerView,
+  contentCreationMCPServerView,
 }: {
   auth: Authenticator;
   settings: GlobalAgentSettings | null;
   webSearchBrowseMCPServerView: MCPServerViewResource | null;
+  contentCreationMCPServerView: MCPServerViewResource | null;
 }): AgentConfigurationType {
   let status: AgentConfigurationStatus = "active";
 
@@ -122,9 +133,13 @@ export function _getGPT4GlobalAgent({
         agentId: sId,
         webSearchBrowseMCPServerView,
       }),
+      ..._getContentCreationToolConfiguration({
+        agentId: sId,
+        contentCreationMCPServerView,
+      }),
     ],
     maxStepsPerRun: MAX_STEPS_USE_PER_RUN_LIMIT,
-    visualizationEnabled: true,
+    visualizationEnabled: false,
     templateId: null,
     requestedGroupIds: [],
     tags: [],
@@ -137,10 +152,12 @@ export function _getGPT5GlobalAgent({
   auth,
   settings,
   webSearchBrowseMCPServerView,
+  contentCreationMCPServerView,
 }: {
   auth: Authenticator;
   settings: GlobalAgentSettings | null;
   webSearchBrowseMCPServerView: MCPServerViewResource | null;
+  contentCreationMCPServerView: MCPServerViewResource | null;
 }): AgentConfigurationType {
   let status: AgentConfigurationStatus = "active";
 
@@ -183,9 +200,13 @@ export function _getGPT5GlobalAgent({
         agentId: sId,
         webSearchBrowseMCPServerView,
       }),
+      ..._getContentCreationToolConfiguration({
+        agentId: sId,
+        contentCreationMCPServerView,
+      }),
     ],
     maxStepsPerRun: MAX_STEPS_USE_PER_RUN_LIMIT,
-    visualizationEnabled: true,
+    visualizationEnabled: false,
     templateId: null,
     requestedGroupIds: [],
     tags: [],
@@ -202,10 +223,12 @@ export function _getGPT5ThinkingGlobalAgent({
   auth,
   settings,
   webSearchBrowseMCPServerView,
+  contentCreationMCPServerView,
 }: {
   auth: Authenticator;
   settings: GlobalAgentSettings | null;
   webSearchBrowseMCPServerView: MCPServerViewResource | null;
+  contentCreationMCPServerView: MCPServerViewResource | null;
 }): AgentConfigurationType {
   let status: AgentConfigurationStatus = "active";
 
@@ -246,9 +269,13 @@ export function _getGPT5ThinkingGlobalAgent({
         agentId: sId,
         webSearchBrowseMCPServerView,
       }),
+      ..._getContentCreationToolConfiguration({
+        agentId: sId,
+        contentCreationMCPServerView,
+      }),
     ],
     maxStepsPerRun: MAX_STEPS_USE_PER_RUN_LIMIT,
-    visualizationEnabled: true,
+    visualizationEnabled: false,
     templateId: null,
     requestedGroupIds: [],
     tags: [],
@@ -261,10 +288,12 @@ export function _getGPT5MiniGlobalAgent({
   auth,
   settings,
   webSearchBrowseMCPServerView,
+  contentCreationMCPServerView,
 }: {
   auth: Authenticator;
   settings: GlobalAgentSettings | null;
   webSearchBrowseMCPServerView: MCPServerViewResource | null;
+  contentCreationMCPServerView: MCPServerViewResource | null;
 }): AgentConfigurationType {
   let status: AgentConfigurationStatus = "active";
 
@@ -305,9 +334,13 @@ export function _getGPT5MiniGlobalAgent({
         agentId: sId,
         webSearchBrowseMCPServerView,
       }),
+      ..._getContentCreationToolConfiguration({
+        agentId: sId,
+        contentCreationMCPServerView,
+      }),
     ],
     maxStepsPerRun: MAX_STEPS_USE_PER_RUN_LIMIT,
-    visualizationEnabled: true,
+    visualizationEnabled: false,
     templateId: null,
     requestedGroupIds: [],
     tags: [],
@@ -319,10 +352,12 @@ export function _getGPT5NanoGlobalAgent({
   auth,
   settings,
   webSearchBrowseMCPServerView,
+  contentCreationMCPServerView,
 }: {
   auth: Authenticator;
   settings: GlobalAgentSettings | null;
   webSearchBrowseMCPServerView: MCPServerViewResource | null;
+  contentCreationMCPServerView: MCPServerViewResource | null;
 }): AgentConfigurationType {
   let status: AgentConfigurationStatus = "active";
 
@@ -363,9 +398,13 @@ export function _getGPT5NanoGlobalAgent({
         agentId: sId,
         webSearchBrowseMCPServerView,
       }),
+      ..._getContentCreationToolConfiguration({
+        agentId: sId,
+        contentCreationMCPServerView,
+      }),
     ],
     maxStepsPerRun: MAX_STEPS_USE_PER_RUN_LIMIT,
-    visualizationEnabled: true,
+    visualizationEnabled: false,
     templateId: null,
     requestedGroupIds: [],
     tags: [],
@@ -378,10 +417,12 @@ export function _getO3MiniGlobalAgent({
   auth,
   settings,
   webSearchBrowseMCPServerView,
+  contentCreationMCPServerView,
 }: {
   auth: Authenticator;
   settings: GlobalAgentSettings | null;
   webSearchBrowseMCPServerView: MCPServerViewResource | null;
+  contentCreationMCPServerView: MCPServerViewResource | null;
 }): AgentConfigurationType {
   let status: AgentConfigurationStatus = "active";
 
@@ -419,9 +460,13 @@ export function _getO3MiniGlobalAgent({
         agentId: sId,
         webSearchBrowseMCPServerView,
       }),
+      ..._getContentCreationToolConfiguration({
+        agentId: sId,
+        contentCreationMCPServerView,
+      }),
     ],
     maxStepsPerRun: MAX_STEPS_USE_PER_RUN_LIMIT,
-    visualizationEnabled: true,
+    visualizationEnabled: false,
     templateId: null,
     requestedGroupIds: [],
     tags: [],
@@ -434,10 +479,12 @@ export function _getO1GlobalAgent({
   auth,
   settings,
   webSearchBrowseMCPServerView,
+  contentCreationMCPServerView,
 }: {
   auth: Authenticator;
   settings: GlobalAgentSettings | null;
   webSearchBrowseMCPServerView: MCPServerViewResource | null;
+  contentCreationMCPServerView: MCPServerViewResource | null;
 }): AgentConfigurationType {
   let status = settings?.status ?? "active";
   if (!auth.isUpgraded()) {
@@ -469,6 +516,10 @@ export function _getO1GlobalAgent({
       ..._getDefaultWebActionsForGlobalAgent({
         agentId: sId,
         webSearchBrowseMCPServerView,
+      }),
+      ..._getContentCreationToolConfiguration({
+        agentId: sId,
+        contentCreationMCPServerView,
       }),
     ],
     maxStepsPerRun: MAX_STEPS_USE_PER_RUN_LIMIT,
@@ -529,10 +580,12 @@ export function _getO1HighReasoningGlobalAgent({
   auth,
   settings,
   webSearchBrowseMCPServerView,
+  contentCreationMCPServerView,
 }: {
   auth: Authenticator;
   settings: GlobalAgentSettings | null;
   webSearchBrowseMCPServerView: MCPServerViewResource | null;
+  contentCreationMCPServerView: MCPServerViewResource | null;
 }): AgentConfigurationType {
   let status = settings?.status ?? "active";
   if (!auth.isUpgraded()) {
@@ -566,6 +619,10 @@ export function _getO1HighReasoningGlobalAgent({
         agentId: sId,
         webSearchBrowseMCPServerView,
       }),
+      ..._getContentCreationToolConfiguration({
+        agentId: sId,
+        contentCreationMCPServerView,
+      }),
     ],
     maxStepsPerRun: MAX_STEPS_USE_PER_RUN_LIMIT,
     visualizationEnabled: false,
@@ -581,10 +638,12 @@ export function _getO3GlobalAgent({
   auth,
   settings,
   webSearchBrowseMCPServerView,
+  contentCreationMCPServerView,
 }: {
   auth: Authenticator;
   settings: GlobalAgentSettings | null;
   webSearchBrowseMCPServerView: MCPServerViewResource | null;
+  contentCreationMCPServerView: MCPServerViewResource | null;
 }): AgentConfigurationType {
   let status = settings?.status ?? "active";
   if (!auth.isUpgraded()) {
@@ -617,9 +676,13 @@ export function _getO3GlobalAgent({
         agentId: sId,
         webSearchBrowseMCPServerView,
       }),
+      ..._getContentCreationToolConfiguration({
+        agentId: sId,
+        contentCreationMCPServerView,
+      }),
     ],
     maxStepsPerRun: MAX_STEPS_USE_PER_RUN_LIMIT,
-    visualizationEnabled: true,
+    visualizationEnabled: false,
     templateId: null,
     requestedGroupIds: [],
     tags: [],

--- a/front/lib/api/assistant/global_agents/global_agents.ts
+++ b/front/lib/api/assistant/global_agents/global_agents.ts
@@ -122,12 +122,14 @@ function getGlobalAgent({
         agentRouterMCPServerView,
         webSearchBrowseMCPServerView,
         searchMCPServerView,
+        contentCreationMCPServerView,
       });
       break;
     case GLOBAL_AGENTS_SID.GPT35_TURBO:
       agentConfiguration = _getGPT35TurboGlobalAgent({
         settings,
         webSearchBrowseMCPServerView,
+        contentCreationMCPServerView,
       });
       break;
     case GLOBAL_AGENTS_SID.GPT4:
@@ -135,6 +137,7 @@ function getGlobalAgent({
         auth,
         settings,
         webSearchBrowseMCPServerView,
+        contentCreationMCPServerView,
       });
       break;
     case GLOBAL_AGENTS_SID.GPT5:
@@ -142,6 +145,7 @@ function getGlobalAgent({
         auth,
         settings,
         webSearchBrowseMCPServerView,
+        contentCreationMCPServerView,
       });
       break;
     case GLOBAL_AGENTS_SID.GPT5_NANO:
@@ -149,6 +153,7 @@ function getGlobalAgent({
         auth,
         settings,
         webSearchBrowseMCPServerView,
+        contentCreationMCPServerView,
       });
       break;
     case GLOBAL_AGENTS_SID.GPT5_MINI:
@@ -156,6 +161,7 @@ function getGlobalAgent({
         auth,
         settings,
         webSearchBrowseMCPServerView,
+        contentCreationMCPServerView,
       });
       break;
     case GLOBAL_AGENTS_SID.GPT5_THINKING:
@@ -163,6 +169,7 @@ function getGlobalAgent({
         auth,
         settings,
         webSearchBrowseMCPServerView,
+        contentCreationMCPServerView,
       });
       break;
     case GLOBAL_AGENTS_SID.O1:
@@ -170,6 +177,7 @@ function getGlobalAgent({
         auth,
         settings,
         webSearchBrowseMCPServerView,
+        contentCreationMCPServerView,
       });
       break;
     case GLOBAL_AGENTS_SID.O1_MINI:
@@ -180,6 +188,7 @@ function getGlobalAgent({
         auth,
         settings,
         webSearchBrowseMCPServerView,
+        contentCreationMCPServerView,
       });
       break;
     case GLOBAL_AGENTS_SID.O3_MINI:
@@ -187,6 +196,7 @@ function getGlobalAgent({
         auth,
         settings,
         webSearchBrowseMCPServerView,
+        contentCreationMCPServerView,
       });
       break;
     case GLOBAL_AGENTS_SID.O3:
@@ -194,16 +204,20 @@ function getGlobalAgent({
         auth,
         settings,
         webSearchBrowseMCPServerView,
+        contentCreationMCPServerView,
       });
       break;
     case GLOBAL_AGENTS_SID.CLAUDE_INSTANT:
-      agentConfiguration = _getClaudeInstantGlobalAgent({ settings });
+      agentConfiguration = _getClaudeInstantGlobalAgent({
+        settings,
+      });
       break;
     case GLOBAL_AGENTS_SID.CLAUDE_4_SONNET:
       agentConfiguration = _getClaude4SonnetGlobalAgent({
         auth,
         settings,
         webSearchBrowseMCPServerView,
+        contentCreationMCPServerView,
       });
       break;
     case GLOBAL_AGENTS_SID.CLAUDE_3_OPUS:
@@ -211,6 +225,7 @@ function getGlobalAgent({
         auth,
         settings,
         webSearchBrowseMCPServerView,
+        contentCreationMCPServerView,
       });
       break;
     case GLOBAL_AGENTS_SID.CLAUDE_3_SONNET:
@@ -218,12 +233,14 @@ function getGlobalAgent({
         auth,
         settings,
         webSearchBrowseMCPServerView,
+        contentCreationMCPServerView,
       });
       break;
     case GLOBAL_AGENTS_SID.CLAUDE_3_HAIKU:
       agentConfiguration = _getClaude3HaikuGlobalAgent({
         settings,
         webSearchBrowseMCPServerView,
+        contentCreationMCPServerView,
       });
       break;
     case GLOBAL_AGENTS_SID.CLAUDE_3_7_SONNET:
@@ -231,16 +248,21 @@ function getGlobalAgent({
         auth,
         settings,
         webSearchBrowseMCPServerView,
+        contentCreationMCPServerView,
       });
       break;
     case GLOBAL_AGENTS_SID.CLAUDE_2:
-      agentConfiguration = _getClaude2GlobalAgent({ auth, settings });
+      agentConfiguration = _getClaude2GlobalAgent({
+        auth,
+        settings,
+      });
       break;
     case GLOBAL_AGENTS_SID.MISTRAL_LARGE:
       agentConfiguration = _getMistralLargeGlobalAgent({
         settings,
         auth,
         webSearchBrowseMCPServerView,
+        contentCreationMCPServerView,
       });
       break;
     case GLOBAL_AGENTS_SID.MISTRAL_MEDIUM:
@@ -248,12 +270,14 @@ function getGlobalAgent({
         settings,
         auth,
         webSearchBrowseMCPServerView,
+        contentCreationMCPServerView,
       });
       break;
     case GLOBAL_AGENTS_SID.MISTRAL_SMALL:
       agentConfiguration = _getMistralSmallGlobalAgent({
         settings,
         webSearchBrowseMCPServerView,
+        contentCreationMCPServerView,
       });
       break;
     case GLOBAL_AGENTS_SID.GEMINI_PRO:
@@ -261,6 +285,7 @@ function getGlobalAgent({
         auth,
         settings,
         webSearchBrowseMCPServerView,
+        contentCreationMCPServerView,
       });
       break;
     case GLOBAL_AGENTS_SID.DEEPSEEK_R1:
@@ -309,6 +334,7 @@ function getGlobalAgent({
         webSearchBrowseMCPServerView,
         searchMCPServerView,
         deepResearchMCPServerView,
+        contentCreationMCPServerView,
       });
       break;
     case GLOBAL_AGENTS_SID.DUST_DEEP:

--- a/front/lib/api/assistant/global_agents/tools.ts
+++ b/front/lib/api/assistant/global_agents/tools.ts
@@ -130,3 +130,36 @@ export function _getAgentRouterToolsConfiguration(
     },
   ];
 }
+
+export function _getContentCreationToolConfiguration({
+  agentId,
+  contentCreationMCPServerView,
+}: {
+  agentId: GLOBAL_AGENTS_SID;
+  contentCreationMCPServerView: MCPServerViewResource | null;
+}): ServerSideMCPServerConfigurationType[] {
+  if (!contentCreationMCPServerView) {
+    return [];
+  }
+
+  return [
+    {
+      id: -1,
+      sId: agentId + "-content-creation",
+      type: "mcp_server_configuration",
+      name: "content_creation",
+      description: "Create & update Content Creation files.",
+      mcpServerViewId: contentCreationMCPServerView.sId,
+      internalMCPServerId: contentCreationMCPServerView.internalMCPServerId,
+      dataSources: null,
+      tables: null,
+      childAgentId: null,
+      reasoningModel: null,
+      additionalConfiguration: {},
+      timeFrame: null,
+      dustAppConfiguration: null,
+      jsonSchema: null,
+      secretName: null,
+    },
+  ];
+}


### PR DESCRIPTION
## Description

- Adds back https://github.com/dust-tt/dust/pull/16535
- Closes https://github.com/dust-tt/tasks/issues/4510.
- This PR removes `viz` from the global agents and adds Content creation instead.

## Tests

- Tested locally.

## Risk

- Low.

## Deploy Plan

- Deploy front.
