### PR TITLE
[Agent Builder] Enable full datasource selection from search

### DIFF
--- a/front/components/agent_builder/capabilities/knowledge/DataSourceSearchResults.tsx
+++ b/front/components/agent_builder/capabilities/knowledge/DataSourceSearchResults.tsx
@@ -58,14 +58,21 @@ export function DataSourceSearchResults({
         return [];
       }
 
-      // Build path using IDs: ["root", spaceId, category, dataSourceViewId, nodeId]
-      return [
+      // Build path using IDs: ["root", spaceId, category, dataSourceViewId, nodeId?]
+      // For full datasources, we stop at dataSourceViewId
+      const path = [
         "root",
         space.sId, // Use space ID, not name
         dataSourceView.category,
         dataSourceView.sId, // Use dataSourceView ID
-        node.internalId,
       ];
+
+      // Only add nodeId if this is not a full datasource
+      if (node.mimeType !== DATA_SOURCE_MIME_TYPE) {
+        path.push(node.internalId);
+      }
+
+      return path;
     },
     [spaces]
   );

--- a/front/lib/api/search.ts
+++ b/front/lib/api/search.ts
@@ -20,7 +20,7 @@ import type {
   Result,
   SearchWarningCode,
 } from "@app/types";
-import { CoreAPI, Err, Ok, removeNulls } from "@app/types";
+import { CoreAPI, DATA_SOURCE_NODE_ID, Err, Ok, removeNulls } from "@app/types";
 
 export type DataSourceContentNode = ContentNodeWithParent & {
   dataSource: DataSourceType;
@@ -255,7 +255,8 @@ export async function handleSearch(
       const matchingViews = allDatasourceViews.filter(
         (dsv) =>
           dsv.dataSource.dustAPIDataSourceId === node.data_source_id &&
-          (!dsv.parentsIn ||
+          (node.node_id === DATA_SOURCE_NODE_ID ||
+            !dsv.parentsIn ||
             node.parents?.some(
               (p) => !dsv.parentsIn || dsv.parentsIn.includes(p)
             ))


### PR DESCRIPTION
## Description
Fixes https://github.com/dust-tt/tasks/issues/4418

This PR enables full datasources to appear as search results:
- in knowledge search;
- in inputbar attachment, and the full datasource can be attached;
- in the agent builder, and allows them to be properly selected when clicked.

Changes:
- Added `DATA_SOURCE_NODE_ID` check in search filter to include full datasource nodes in search results
- Modified search result path building to correctly handle full datasource selection (stopping at dataSourceView level instead of including nodeId)

<img width="1181" height="546" alt="image" src="https://github.com/user-attachments/assets/5dd5c6cf-e414-4cfb-ba89-ccf554bf4036" />

<img width="1525" height="953" alt="image" src="https://github.com/user-attachments/assets/2e1dea0c-be3c-4cdd-b0f0-f557752683cb" />

## Risks
Blast radius: Agent builder data source search and selection functionality
Risk: low

## Deploy Plan
- deploy front