### PR TITLE
[connectors] fix(notion): Increase startToCloseTimeout

### DIFF
--- a/connectors/src/connectors/notion/temporal/workflows/children.ts
+++ b/connectors/src/connectors/notion/temporal/workflows/children.ts
@@ -20,7 +20,7 @@ const {
   renderAndUpsertPageFromCache,
   upsertDatabaseInConnectorsDb,
 } = proxyActivities<typeof activities>({
-  startToCloseTimeout: "10 minute",
+  startToCloseTimeout: "20 minute",
 });
 
 export async function upsertPageChildWorkflow({


### PR DESCRIPTION
## Description

Increase time for renderAndUpsertPageFromCache . The workflow is not stuck (not in a circular reference loop) but the renderBlockSection seems to require more time

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

deploy connectors
