### PR TITLE
[front] fix(cc): update sharing toggle to reflect state without reload

### DIFF
--- a/front/hooks/useContentCreationSharingToggle.ts
+++ b/front/hooks/useContentCreationSharingToggle.ts
@@ -11,11 +11,10 @@ export function useContentCreationSharingToggle({
   owner,
 }: UseContentCreationSharingToggleProps) {
   const [isChanging, setIsChanging] = useState(false);
-  const sendNotification = useSendNotification();
-
   const [isEnabled, setIsEnabled] = useState(
     owner.metadata?.allowContentCreationFileSharing !== false
   );
+  const sendNotification = useSendNotification();
 
   const doToggleContentCreationSharing = async () => {
     setIsChanging(true);

--- a/front/hooks/useContentCreationSharingToggle.ts
+++ b/front/hooks/useContentCreationSharingToggle.ts
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useEffect, useState } from "react";
 
 import { useSendNotification } from "@app/hooks/useNotification";
 import type { LightWorkspaceType } from "@app/types";
@@ -15,6 +15,10 @@ export function useContentCreationSharingToggle({
     owner.metadata?.allowContentCreationFileSharing !== false
   );
   const sendNotification = useSendNotification();
+
+  useEffect(() => {
+    setIsEnabled(owner.metadata?.allowContentCreationFileSharing !== false);
+  }, [owner.metadata?.allowContentCreationFileSharing]);
 
   const doToggleContentCreationSharing = async () => {
     setIsChanging(true);

--- a/front/hooks/useContentCreationSharingToggle.ts
+++ b/front/hooks/useContentCreationSharingToggle.ts
@@ -13,7 +13,9 @@ export function useContentCreationSharingToggle({
   const [isChanging, setIsChanging] = useState(false);
   const sendNotification = useSendNotification();
 
-  const isEnabled = owner.metadata?.allowContentCreationFileSharing !== false;
+  const [isEnabled, setIsEnabled] = useState(
+    owner.metadata?.allowContentCreationFileSharing !== false
+  );
 
   const doToggleContentCreationSharing = async () => {
     setIsChanging(true);
@@ -32,7 +34,8 @@ export function useContentCreationSharingToggle({
         throw new Error("Failed to update Frame sharing setting");
       }
 
-      window.location.reload();
+      setIsChanging(false);
+      setIsEnabled((prev) => !prev);
     } catch (error) {
       sendNotification({
         type: "error",


### PR DESCRIPTION
## Description

- This PR removes removes a hard full reload in the Workspace Admin settings on the toggle for Frame file sharing.

## Tests

- Checked locally.

## Risk

- Low.

## Deploy Plan

- Deploy front.
