### PR TITLE
[front] hootl: fix saving triggers

### DIFF
--- a/front/components/agent_builder/AgentBuilder.tsx
+++ b/front/components/agent_builder/AgentBuilder.tsx
@@ -178,12 +178,14 @@ export default function AgentBuilder({
     return {
       ...baseValues,
       actions: processedActions,
-      triggersToCreate: [],
-      triggersToUpdate: duplicateAgentId
+      triggersToCreate: duplicateAgentId
         ? triggers.map((trigger) => ({
             ...trigger,
             editor: user.id,
           }))
+        : emptyArray(),
+      triggersToUpdate: duplicateAgentId
+        ? emptyArray()
         : triggers ?? emptyArray(),
       triggersToDelete: [],
 


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

This PR fixes a bug introduced by https://github.com/dust-tt/dust/pull/16469.
One would not be able to save an agent when there was a trigger he could not act on set up on this agent.

This PR also fixes a little bug on the duplication (triggers should be created, not updated).

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

Tested by hand.

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

Low

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->

Deploy front.