### PR TITLE
Tracking improvements

### DIFF
--- a/front/components/actions/mcp/AddActionMenu.tsx
+++ b/front/components/actions/mcp/AddActionMenu.tsx
@@ -17,6 +17,7 @@ import { getDefaultRemoteMCPServerByName } from "@app/lib/actions/mcp_internal_a
 import type { MCPServerType } from "@app/lib/api/mcp";
 import { filterMCPServer } from "@app/lib/mcp";
 import { useAvailableMCPServers } from "@app/lib/swr/mcp_servers";
+import { TRACKING_AREAS, withTracking } from "@app/lib/tracking";
 import type { WorkspaceType } from "@app/types";
 
 type AddActionMenuProps = {
@@ -60,6 +61,7 @@ export const AddActionMenu = ({
           variant={buttonVariant}
           icon={PlusIcon}
           size="sm"
+          onClick={withTracking(TRACKING_AREAS.TOOLS, "add_tools_menu")}
         />
       </DropdownMenuTrigger>
       <DropdownMenuContent
@@ -78,7 +80,11 @@ export const AddActionMenu = ({
               icon={PlusIcon}
               label="Add MCP Server"
               // Empty call is required given onClick passes a MouseEvent
-              onClick={() => createRemoteMCPServer()}
+              onClick={withTracking(
+                TRACKING_AREAS.TOOLS,
+                "add_mcp_server",
+                () => createRemoteMCPServer()
+              )}
               size="sm"
             />
           }
@@ -104,16 +110,21 @@ export const AddActionMenu = ({
               key={mcpServer.sId}
               label={getMcpServerDisplayName(mcpServer)}
               icon={() => getAvatar(mcpServer, "xs")}
-              onClick={async () => {
-                const remoteMcpServer = getDefaultRemoteMCPServerByName(
-                  mcpServer.name
-                );
-                if (remoteMcpServer) {
-                  createRemoteMCPServer(remoteMcpServer);
-                } else {
-                  createInternalMCPServer(mcpServer);
-                }
-              }}
+              onClick={withTracking(
+                TRACKING_AREAS.TOOLS,
+                "tool_select",
+                async () => {
+                  const remoteMcpServer = getDefaultRemoteMCPServerByName(
+                    mcpServer.name
+                  );
+                  if (remoteMcpServer) {
+                    createRemoteMCPServer(remoteMcpServer);
+                  } else {
+                    createInternalMCPServer(mcpServer);
+                  }
+                },
+                { tool_name: mcpServer.name }
+              )}
             />
           ))}
       </DropdownMenuContent>

--- a/front/components/agent_builder/submitAgentBuilderForm.ts
+++ b/front/components/agent_builder/submitAgentBuilderForm.ts
@@ -520,7 +520,7 @@ export async function submitAgentBuilderForm({
         action: TRACKING_ACTIONS.SUBMIT,
         extra: {
           scope: formData.agentSettings.scope,
-          has_actions: processedActions.length > 0 ? "true" : "false",
+          has_actions: processedActions.length > 0,
         },
       });
     }

--- a/front/components/app/PostHogTracker.tsx
+++ b/front/components/app/PostHogTracker.tsx
@@ -83,7 +83,7 @@ export function PostHogTracker({ children }: PostHogTrackerProps) {
       defaults: "2025-05-24",
       opt_out_capturing_by_default: !shouldTrack,
       capture_pageview: true,
-      capture_pageleave: true,
+      capture_pageleave: false,
       autocapture: false,
       property_denylist: ["$ip"],
       before_send: (event) => {

--- a/front/components/assistant/conversation/input_bar/InputBar.tsx
+++ b/front/components/assistant/conversation/input_bar/InputBar.tsx
@@ -207,14 +207,20 @@ export function AssistantInputBar({
       ...new Set(rawMentions.map((mention) => mention.id)),
     ].map((id) => ({ configurationId: id }));
 
+    const uploadedFiles = fileUploaderService.getFileBlobs();
+
     trackEvent({
       area: TRACKING_AREAS.CONVERSATION,
       object: "message_send",
       action: "submit",
       extra: {
-        has_attachments: attachedNodes.length > 0,
+        has_attachments: attachedNodes.length > 0 || uploadedFiles.length > 0,
         has_tools: selectedMCPServerViews.length > 0,
-        has_assistant: !!selectedAssistant,
+        has_agents: mentions.length > 0,
+        is_new_conversation: !conversationId,
+        agent_count: mentions.length,
+        attachment_count: attachedNodes.length + uploadedFiles.length,
+        tool_count: selectedMCPServerViews.length,
       },
     });
 

--- a/front/components/assistant/conversation/input_bar/InputBar.tsx
+++ b/front/components/assistant/conversation/input_bar/InputBar.tsx
@@ -212,9 +212,9 @@ export function AssistantInputBar({
       object: "message_send",
       action: "submit",
       extra: {
-        has_attachments: attachedNodes.length > 0 ? "true" : "false",
-        has_tools: selectedMCPServerViews.length > 0 ? "true" : "false",
-        has_assistant: selectedAssistant ? "true" : "false",
+        has_attachments: attachedNodes.length > 0,
+        has_tools: selectedMCPServerViews.length > 0,
+        has_assistant: !!selectedAssistant,
       },
     });
 

--- a/front/components/assistant/conversation/input_bar/InputBar.tsx
+++ b/front/components/assistant/conversation/input_bar/InputBar.tsx
@@ -30,7 +30,7 @@ import type {
   Result,
   WorkspaceType,
 } from "@app/types";
-import { compareAgentsForSort, isEqualNode } from "@app/types";
+import { compareAgentsForSort, isEqualNode, isGlobalAgentId } from "@app/types";
 
 const DEFAULT_INPUT_BAR_ACTIONS = [...INPUT_BAR_ACTIONS];
 
@@ -208,6 +208,9 @@ export function AssistantInputBar({
     ].map((id) => ({ configurationId: id }));
 
     const uploadedFiles = fileUploaderService.getFileBlobs();
+    const mentionedAgents = agentConfigurations.filter((a) =>
+      mentions.some((m) => m.configurationId === a.sId)
+    );
 
     trackEvent({
       area: TRACKING_AREAS.CONVERSATION,
@@ -216,7 +219,9 @@ export function AssistantInputBar({
       extra: {
         has_attachments: attachedNodes.length > 0 || uploadedFiles.length > 0,
         has_tools: selectedMCPServerViews.length > 0,
-        has_agents: mentions.length > 0,
+        has_agents: mentionedAgents.length > 0,
+        has_default_agent: mentionedAgents.some((a) => isGlobalAgentId(a.sId)),
+        has_custom_agent: mentionedAgents.some((a) => !isGlobalAgentId(a.sId)),
         is_new_conversation: !conversationId,
         agent_count: mentions.length,
         attachment_count: attachedNodes.length + uploadedFiles.length,

--- a/front/lib/tracking.ts
+++ b/front/lib/tracking.ts
@@ -69,7 +69,7 @@ interface TrackEventParams {
   area: TrackingArea | string;
   object: string;
   action?: TrackingAction | string;
-  extra?: Record<string, string>;
+  extra?: Record<string, any>;
 }
 
 export function trackEvent({
@@ -83,11 +83,11 @@ export function trackEvent({
   }
 
   const eventName = `${area}:${object}:${action}`;
-  const properties: Record<string, string> = {
+  const properties: Record<string, any> = {
     area,
     object,
     action,
-    ...extra,
+    ...(extra && { extra }),
   };
 
   posthog.capture(eventName, properties);
@@ -113,7 +113,7 @@ export function withTracking<T extends Element = HTMLElement>(
   area: TrackingArea | string,
   object: string,
   handler?: (e: React.MouseEvent<T>) => void | Promise<void>,
-  extra?: Record<string, string>
+  extra?: Record<string, any>
 ) {
   return (e: React.MouseEvent<T>) => {
     trackEvent({ area, object, action: TRACKING_ACTIONS.CLICK, extra });

--- a/front/lib/tracking.ts
+++ b/front/lib/tracking.ts
@@ -66,11 +66,13 @@ export const TRACKING_ACTIONS = {
 export type TrackingAction =
   (typeof TRACKING_ACTIONS)[keyof typeof TRACKING_ACTIONS];
 
+export type TrackingExtra = Record<string, string | number | boolean>;
+
 interface TrackEventParams {
   area: TrackingArea | string;
   object: string;
   action?: TrackingAction | string;
-  extra?: Record<string, any>;
+  extra?: TrackingExtra;
 }
 
 export function trackEvent({
@@ -84,7 +86,7 @@ export function trackEvent({
   }
 
   const eventName = `${area}:${object}:${action}`;
-  const properties: Record<string, any> = {
+  const properties: Record<string, string | TrackingExtra> = {
     area,
     object,
     action,
@@ -114,7 +116,7 @@ export function withTracking<T extends Element = HTMLElement>(
   area: TrackingArea | string,
   object: string,
   handler?: (e: React.MouseEvent<T>) => void | Promise<void>,
-  extra?: Record<string, any>
+  extra?: TrackingExtra
 ) {
   return (e: React.MouseEvent<T>) => {
     trackEvent({ area, object, action: TRACKING_ACTIONS.CLICK, extra });

--- a/front/lib/tracking.ts
+++ b/front/lib/tracking.ts
@@ -44,6 +44,7 @@ export const TRACKING_AREAS = {
   BUILDER: "builder",
   SPACES: "spaces",
   LABS: "labs",
+  TOOLS: "tools",
 } as const;
 
 export type TrackingArea = (typeof TRACKING_AREAS)[keyof typeof TRACKING_AREAS];

--- a/front/lib/tracking.ts
+++ b/front/lib/tracking.ts
@@ -86,11 +86,11 @@ export function trackEvent({
   }
 
   const eventName = `${area}:${object}:${action}`;
-  const properties: Record<string, string | TrackingExtra> = {
+  const properties = {
     area,
     object,
     action,
-    ...(extra && { extra }),
+    ...extra,
   };
 
   posthog.capture(eventName, properties);

--- a/front/lib/tracking.ts
+++ b/front/lib/tracking.ts
@@ -82,7 +82,7 @@ export function trackEvent({
     return;
   }
 
-  const eventName = `${area}:${object}_${action}`;
+  const eventName = `${area}:${object}:${action}`;
   const properties: Record<string, string> = {
     area,
     object,


### PR DESCRIPTION



## Description

This PR refines the tracking infrastructure by standardizing nomenclature, improving type safety, and adding comprehensive tool tracking. Changes the event naming format from `{area}:{object}_{action}` to `{area}:{object}:{action}`, expands the `extra` properties type from `Record<string, string>` to support booleans and numbers, and adds a new `TOOLS` tracking area. Also enhances message submission tracking with richer metadata including agent types, attachment counts, and conversation context.

## Risk

Changes the tracking event naming convention which may affect existing PostHog event aggregation and dashboards. The type change for `extra` properties from string-only to mixed types could impact downstream analytics processing.

## Deploy Plan

No special deployment steps required - tracking changes are backward compatible and will begin collecting enhanced data once deployed.
