### PR TITLE
[front] fix: Better error handling in doc-tracker

### DIFF
--- a/front/lib/actions/helpers.ts
+++ b/front/lib/actions/helpers.ts
@@ -104,23 +104,6 @@ export async function callAction<V extends t.Mixed>(
     return r;
   }
 
-  // Check if the response is a valid base response first
-  if (isActionResponseBase(r.value)) {
-    // Check if results field exists and is not null
-    const response = r.value as ActionResponseBase & {
-      results?: unknown;
-    };
-
-    if (!response.results || response.results === null) {
-      // The action returned null or missing results, which indicates a failure
-      return new Err({
-        type: "action_failed",
-        message: `Action failed response: results field is null or missing. Status: ${JSON.stringify(r.value.status)}`,
-        runId: r.value.run_id,
-      });
-    }
-  }
-
   // create a schema validator using the provided schema + the base response schema
   const responseSchema = t.intersection([
     ActionResponseBaseSchema,

--- a/front/lib/actions/helpers.ts
+++ b/front/lib/actions/helpers.ts
@@ -104,6 +104,23 @@ export async function callAction<V extends t.Mixed>(
     return r;
   }
 
+  // Check if the response is a valid base response first
+  if (isActionResponseBase(r.value)) {
+    // Check if results field exists and is not null
+    const response = r.value as ActionResponseBase & {
+      results?: unknown;
+    };
+
+    if (!response.results || response.results === null) {
+      // The action returned null or missing results, which indicates a failure
+      return new Err({
+        type: "action_failed",
+        message: `Action failed response: results field is null or missing. Status: ${JSON.stringify(r.value.status)}`,
+        runId: r.value.run_id,
+      });
+    }
+  }
+
   // create a schema validator using the provided schema + the base response schema
   const responseSchema = t.intersection([
     ActionResponseBaseSchema,

--- a/front/temporal/tracker/activities.ts
+++ b/front/temporal/tracker/activities.ts
@@ -267,9 +267,10 @@ export async function trackersGenerationActivity(
           error: maintainedScopeRetrievalRes.error,
           runId,
         },
-        "Error retrieving content from maintained scope."
+        "Error retrieving content from maintained scope. Skipping this tracker."
       );
-      throw maintainedScopeRetrievalRes.error;
+      // Skip this tracker instead of failing the entire workflow
+      continue;
     }
 
     const maintainedScopeRetrieval = maintainedScopeRetrievalRes.value.result;
@@ -389,9 +390,10 @@ export async function trackersGenerationActivity(
           runId,
           error: scoreDocsRes.error,
         },
-        "Error scoring documents."
+        "Error scoring documents. Skipping this tracker."
       );
-      throw scoreDocsRes.error;
+      // Skip this tracker instead of failing the entire workflow
+      continue;
     }
 
     const scoreDocsOutput = scoreDocsRes.value.result;
@@ -448,9 +450,10 @@ export async function trackersGenerationActivity(
             runId,
             error: suggestChangesRes.error,
           },
-          "Error suggesting changes."
+          "Error suggesting changes. Skipping this document."
         );
-        throw suggestChangesRes.error;
+        // Skip this document instead of failing the entire workflow
+        continue;
       }
 
       const suggestChangesOutput = suggestChangesRes.value.result;
@@ -469,9 +472,13 @@ export async function trackersGenerationActivity(
           maintainedDataSourceId
         );
       if (!maintainedDocumentDataSource) {
-        throw new Error(
-          `Could not find maintained data source ${maintainedDataSourceId}`
+        trackerLogger.error(
+          {
+            maintainedDataSourceId,
+          },
+          `Could not find maintained data source. Skipping this document.`
         );
+        continue;
       }
 
       const suggestedChanges = suggestChangesOutput.suggestion;


### PR DESCRIPTION
## Description

The tracker-generate-workflow was failing completely when the semantic search action returned null results, causing the error:
```Action failed response: Expecting Array<Array<{ value: ... }>> at 1.results but instead got: null```

- Enhanced error detection in action helper : added early validation to detect when action results are null or missing. Provides clearer error messages including the action's status for easier debugging

- Improved error resilience in tracker activities : changed from throwing errors to gracefully skipping failed operations.

## Tests


## Risk

low

## Deploy Plan

deploy front