### PR TITLE
New opt-in/user identification behavior

### DIFF
--- a/front/components/app/PostHogTracker.tsx
+++ b/front/components/app/PostHogTracker.tsx
@@ -146,7 +146,6 @@ export function PostHogTracker({ children }: PostHogTrackerProps) {
         : !initializedUserId;
 
       if (needsInitialization) {
-        // First time for this user, or user switched accounts
         posthog.opt_in_capturing();
 
         if (user) {
@@ -156,7 +155,7 @@ export function PostHogTracker({ children }: PostHogTrackerProps) {
         if (typeof window !== "undefined") {
           localStorage.setItem(
             POSTHOG_INITIALIZED_KEY,
-            user?.sId || "anonymous"
+            user?.sId ?? "anonymous"
           );
         }
       }

--- a/front/components/app/PostHogTracker.tsx
+++ b/front/components/app/PostHogTracker.tsx
@@ -10,6 +10,7 @@ import { useWorkspaceActiveSubscription } from "@app/lib/swr/workspaces";
 import { isString } from "@app/types";
 
 const POSTHOG_KEY = process.env.NEXT_PUBLIC_POSTHOG_KEY;
+const POSTHOG_INITIALIZED_KEY = "dust-ph-init";
 
 const EXCLUDED_PATHS = [
   "/subscribe",
@@ -80,12 +81,11 @@ export function PostHogTracker({ children }: PostHogTrackerProps) {
 
   const shouldTrack = isTrackablePage && hasAcceptedCookies;
 
-  const lastIdentifiedUserId = useRef<string | null>(null);
   const lastIdentifiedWorkspaceId = useRef<string | null>(null);
   const lastPlanPropertiesString = useRef<string | null>(null);
   const hasInitialized = useRef(false);
 
-  // Initialize PostHog once with correct default state
+  // Initialize PostHog once
   useEffect(() => {
     if (!POSTHOG_KEY || posthog.__loaded || hasInitialized.current) {
       return;
@@ -104,6 +104,7 @@ export function PostHogTracker({ children }: PostHogTrackerProps) {
         if (!event) {
           return null;
         }
+        // Strip query parameters from URLs for privacy.
         if (event.properties.$current_url) {
           event.properties.$current_url =
             event.properties.$current_url.split("?")[0];
@@ -123,41 +124,50 @@ export function PostHogTracker({ children }: PostHogTrackerProps) {
     hasInitialized.current = true;
   }, [shouldTrack]);
 
-  // Handle tracking state changes only when user logs in or cookie acceptance changes
+  // Handle opt-in and user identification (once per user via localStorage)
   const prevShouldTrack = useRef(shouldTrack);
   useEffect(() => {
     if (!posthog.__loaded || !hasInitialized.current) {
       return;
     }
 
-    if (prevShouldTrack.current !== shouldTrack) {
-      if (shouldTrack) {
-        posthog.opt_in_capturing();
-      } else {
-        posthog.opt_out_capturing();
-      }
-      prevShouldTrack.current = shouldTrack;
-    }
-  }, [shouldTrack]);
-
-  // Identify user when they log in or workspace changes
-  useEffect(() => {
-    if (!posthog.__loaded || !user || !shouldTrack) {
+    const trackingStateChanged = prevShouldTrack.current !== shouldTrack;
+    if (!trackingStateChanged) {
       return;
     }
 
-    const userChanged = lastIdentifiedUserId.current !== user.sId;
+    if (shouldTrack) {
+      const initializedUserId =
+        typeof window !== "undefined"
+          ? localStorage.getItem(POSTHOG_INITIALIZED_KEY)
+          : null;
+      const needsInitialization = user
+        ? initializedUserId !== user.sId
+        : !initializedUserId;
 
-    if (userChanged) {
-      const userProperties: Record<string, string> = {
-        ...(workspaceId && { workspace_id: workspaceId }),
-      };
-      posthog.identify(user.sId, userProperties);
-      lastIdentifiedUserId.current = user.sId;
+      if (needsInitialization) {
+        // First time for this user, or user switched accounts
+        posthog.opt_in_capturing();
+
+        if (user) {
+          posthog.identify(user.sId);
+        }
+
+        if (typeof window !== "undefined") {
+          localStorage.setItem(
+            POSTHOG_INITIALIZED_KEY,
+            user?.sId || "anonymous"
+          );
+        }
+      }
+    } else {
+      posthog.opt_out_capturing();
     }
-  }, [user, workspaceId, shouldTrack]);
 
-  // Group users by workspace (all users) and set workspace properties (admin only).
+    prevShouldTrack.current = shouldTrack;
+  }, [shouldTrack, user]);
+
+  // Group users by workspace and set workspace properties (admin only)
   useEffect(() => {
     if (!posthog.__loaded || !workspaceId || !shouldTrack) {
       return;
@@ -180,7 +190,7 @@ export function PostHogTracker({ children }: PostHogTrackerProps) {
     }
   }, [workspaceId, planProperties, shouldTrack, isAdmin]);
 
-  // Track pageviews on route changes (Next.js client-side navigation)
+  // Track pageviews on route changes.
   useEffect(() => {
     if (!posthog.__loaded || !shouldTrack) {
       return;

--- a/front/lib/tracking.ts
+++ b/front/lib/tracking.ts
@@ -90,6 +90,8 @@ export function trackEvent({
     ...extra,
   };
 
+  // Note: workspace context is automatically included via posthog.group()
+  // which is set in PostHogTracker.tsx when the workspace changes
   posthog.capture(eventName, properties);
 }
 

--- a/front/lib/tracking.ts
+++ b/front/lib/tracking.ts
@@ -90,8 +90,6 @@ export function trackEvent({
     ...extra,
   };
 
-  // Note: workspace context is automatically included via posthog.group()
-  // which is set in PostHogTracker.tsx when the workspace changes
   posthog.capture(eventName, properties);
 }
 


### PR DESCRIPTION









## Description

Optimizes PostHog user identification to prevent duplicate opt-in/identify calls by storing user identification state in localStorage. Previously, the tracker would call `posthog.opt_in_capturing()` and `posthog.identify()` on every session when tracking conditions changed, leading to redundant API calls. The new behavior stores the identified user ID in localStorage (`dust-ph-init` key) and only performs opt-in/identify operations when encountering a new user or when no previous identification exists.

## Risk

Changes PostHog initialization and user identification flow. If localStorage is corrupted or the stored user ID becomes stale, users might need to clear browser data to properly re-identify with PostHog.

## Deploy Plan

No special deployment steps required - the localStorage-based identification will automatically handle existing and new users appropriately.
