### PR TITLE
[sparkle] remove useless padding

### DIFF
--- a/sparkle/src/components/ConversationMessage.tsx
+++ b/sparkle/src/components/ConversationMessage.tsx
@@ -139,7 +139,7 @@ interface ConversationMessageContentProps
 export const ConversationMessageContent = React.forwardRef<
   HTMLDivElement,
   ConversationMessageContentProps
->(({ children, citations, className, type, ...props }, ref) => {
+>(({ children, citations, className, ...props }, ref) => {
   return (
     <div
       ref={ref}
@@ -152,8 +152,7 @@ export const ConversationMessageContent = React.forwardRef<
       <div
         className={cn(
           "s-text-sm @sm:s-text-base",
-          "s-text-foreground dark:s-text-foreground-night",
-          type !== "agentAsTool" && "@md:s-px-4"
+          "s-text-foreground dark:s-text-foreground-night"
         )}
       >
         {children}


### PR DESCRIPTION
## Description
Tested on with/without virtuso ff, on mobile and everything looks good 

before:
<img width="1826" height="1532" alt="CleanShot 2025-10-08 at 11 08 45@2x" src="https://github.com/user-attachments/assets/171fc8e3-f251-4391-9c7b-50ac20270f7c" />


after:
<img width="1542" height="1548" alt="CleanShot 2025-10-08 at 11 06 47@2x" src="https://github.com/user-attachments/assets/297ede5c-8862-42eb-9945-4224bb564238" />


<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
