### PR TITLE
[front] Initialize intermediate path for nested default values

### DIFF
--- a/front/lib/actions/mcp_internal_actions/input_configuration.ts
+++ b/front/lib/actions/mcp_internal_actions/input_configuration.ts
@@ -17,6 +17,7 @@ import type {
 import type { MCPServerViewType } from "@app/lib/api/mcp";
 import {
   areSchemasEqual,
+  ensurePathExists,
   findSchemaAtPath,
   followInternalRef,
   getValueAtPath,
@@ -458,6 +459,8 @@ export function augmentInputsWithConfiguration({
           keyPath: fullPath.join("."),
         });
 
+        // Ensure intermediate path exists based on schema
+        ensurePathExists(inputs, fullPath, inputSchema);
         // We found a matching mimeType, augment the inputs
         setValueAtPath(inputs, fullPath, value);
         return false;

--- a/front/lib/actions/mcp_internal_actions/input_configuration.ts
+++ b/front/lib/actions/mcp_internal_actions/input_configuration.ts
@@ -459,8 +459,8 @@ export function augmentInputsWithConfiguration({
           keyPath: fullPath.join("."),
         });
 
-        // Ensure intermediate path exists based on schema
-        ensurePathExists(inputs, fullPath, inputSchema);
+        // Ensure intermediate path exists
+        ensurePathExists(inputs, fullPath);
         // We found a matching mimeType, augment the inputs
         setValueAtPath(inputs, fullPath, value);
         return false;

--- a/front/lib/utils/json_schemas.ts
+++ b/front/lib/utils/json_schemas.ts
@@ -112,8 +112,84 @@ export function findSchemaAtPath(
 }
 
 /**
+ * Ensures that intermediate objects/arrays exist in the path based on the schema.
+ * Uses the schema to determine whether to create objects or arrays.
+ */
+export function ensurePathExists(
+  obj: Record<string, unknown>,
+  path: (string | number)[],
+  schema: JSONSchema
+): void {
+  if (path.length === 0) {
+    return;
+  }
+
+  let current: Record<string, unknown> = obj;
+  let currentSchema: JSONSchema | null = schema;
+
+  for (let i = 0; i < path.length - 1; i++) {
+    const key = path[i];
+
+    if (!currentSchema) {
+      return; // Can't determine structure without schema
+    }
+
+    // Navigate schema
+    if (typeof key === "string") {
+      // We're navigating through an object property
+      if (currentSchema.properties && key in currentSchema.properties) {
+        const propSchema: JSONSchemaDefinition = currentSchema.properties[key];
+        if (isJSONSchemaObject(propSchema)) {
+          currentSchema = propSchema;
+        } else {
+          return;
+        }
+      } else {
+        return;
+      }
+
+      // Initialize the key if it doesn't exist
+      if (!current[key] || typeof current[key] !== "object") {
+        // Determine if next level should be array or object
+        if (currentSchema.type === "array") {
+          current[key] = [];
+        } else {
+          current[key] = {};
+        }
+      }
+
+      current = current[key] as Record<string, unknown>;
+    } else {
+      // We're navigating through an array index
+      // The current schema should be an array schema
+      if (currentSchema.type === "array" && currentSchema.items) {
+        if (isJSONSchemaObject(currentSchema.items)) {
+          currentSchema = currentSchema.items;
+        } else {
+          return;
+        }
+      } else {
+        return;
+      }
+
+      // Ensure array has enough elements
+      if (!Array.isArray(current)) {
+        return;
+      }
+
+      while (current.length <= key) {
+        current.push({});
+      }
+
+      current = current[key] as Record<string, unknown>;
+    }
+  }
+}
+
+/**
  * Sets a value at a specific path in a nested object structure.
  * Assumes that intermediate objects already exist.
+ * Use ensurePathExists() first to initialize the path based on schema.
  */
 export function setValueAtPath(
   obj: Record<string, unknown>,


### PR DESCRIPTION
## Description

We have workflow failing when trying to setup values in nested objects. Initialize intermediate path for nested default values

Error from the log is : Invalid path in setValueAtPath.
With obj =
```
{
format: "json",
page_size: 25,
portfolio_id: "6864fe72cfb165a3fff8028a",
sort_by_id: "CI_GHGScope1",
}
```
And path = ```[ "filter","items","items","value"]```

original mcp server schema was : 
```
      inputSchema: {
        type: "object",
        required: ["portfolio_id"],
        properties: {
          portfolio_id: {
            type: "string",
            description: "The ID of the portfolio",
          },
          filter: {
            type: "object",
            properties: {
              items: {
                type: "array",
                items: {
                  type: "object",
                  required: ["field", "operator", "value"],
                  properties: {
                    field:
                      ConfigurableToolInputJSONSchemas[
                        INTERNAL_MIME_TYPES.TOOL_INPUT.STRING
                      ],
                    operator: {
                      type: "string",
                      enum: ["=", "!=", ">", ">=", "<", "<=", "isAnyOf"],
                    },
                    value: {},
                  },
                },
              },
              logicOperator: {
                enum: ["and", "or"],
                type: "string",
              },
            },
            description: "Filter model for filtering portfolio lines",
          },
        },
      },
```

## Tests

tests updated

## Risk

used in all tools, but should only impact tools with nested input schema

## Deploy Plan

deploy front
