### PR TITLE
Fix isExistingDatabase check in fetchDatabaseChildPages

### DIFF
--- a/connectors/src/connectors/notion/temporal/activities.ts
+++ b/connectors/src/connectors/notion/temporal/activities.ts
@@ -1956,8 +1956,6 @@ export async function renderAndUpsertPageFromCache({
     });
 
     if (parentDb) {
-      // parentDb.upsertRequestedRunTs = noz5-
-
       // Only do structured data incremental sync if the DB has already been synced as structured data.
       if (parentDb.structuredDataUpsertedTs) {
         localLogger.info(

--- a/connectors/src/connectors/notion/temporal/activities.ts
+++ b/connectors/src/connectors/notion/temporal/activities.ts
@@ -231,7 +231,7 @@ export async function fetchDatabaseChildPages({
     returnUpToDatePageIdsForExistingDatabase ||
     // If the database is new (either we never seen it before, or the first time we saw it was
     // during this run), we return all the pages.
-    isExistingDatabase
+    !isExistingDatabase
   ) {
     return {
       pageIds: pages.map((p) => p.id),
@@ -1956,6 +1956,8 @@ export async function renderAndUpsertPageFromCache({
     });
 
     if (parentDb) {
+      // parentDb.upsertRequestedRunTs = noz5-
+
       // Only do structured data incremental sync if the DB has already been synced as structured data.
       if (parentDb.structuredDataUpsertedTs) {
         localLogger.info(


### PR DESCRIPTION
## Description

Fix a condition check that was reversed from its intention. This was causing us to process all notion pages for existing DBs, instead of doing it for new DBs.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

Connector