### PR TITLE
Add tracking on hubspot form

### DIFF
--- a/front/components/home/HubSpotForm.tsx
+++ b/front/components/home/HubSpotForm.tsx
@@ -62,23 +62,20 @@ export default function HubSpotForm() {
             (e) => {
               const target = e.target as HTMLElement;
 
-              // Find if this is a button
-              const button =
-                target.tagName === "BUTTON" ||
-                target.tagName === "INPUT" ||
-                target.closest("button") ||
-                target.closest("input[type='submit']") ||
-                target.closest("input[type='button']");
+              const isButtonTag =
+                target.tagName === "BUTTON" || target.tagName === "INPUT";
+              const buttonElement = isButtonTag
+                ? target
+                : target.closest("button") ??
+                  target.closest("input[type='submit']") ??
+                  target.closest("input[type='button']");
 
-              if (button) {
-                const buttonElement =
-                  button === true ? target : (button as HTMLElement);
-
-                const text = buttonElement.textContent?.toLowerCase() || "";
+              if (buttonElement) {
+                const text = buttonElement.textContent?.toLowerCase() ?? "";
                 const value =
-                  (buttonElement as HTMLInputElement).value?.toLowerCase() ||
+                  (buttonElement as HTMLInputElement).value?.toLowerCase() ??
                   "";
-                const className = buttonElement.className?.toLowerCase() || "";
+                const className = buttonElement.className?.toLowerCase() ?? "";
                 const buttonType = (
                   buttonElement as HTMLInputElement | HTMLButtonElement
                 ).type;

--- a/front/lib/tracking.ts
+++ b/front/lib/tracking.ts
@@ -32,6 +32,7 @@ export const TRACKING_AREAS = {
   NAVIGATION: "navigation",
   SOLUTIONS: "solutions",
   INDUSTRY: "industry",
+  CONTACT: "contact",
 
   // Product
   ASSISTANT: "assistant",


### PR DESCRIPTION





## Description

Adds comprehensive tracking to the HubSpot contact form component to monitor user interactions and form engagement. The implementation replaces the simple form creation with a MutationObserver-based approach that detects when the form loads and attaches click event listeners to track user navigation through the form steps. Tracking events include form readiness, next/previous step navigation, form submission, and script loading errors. Also adds a new `CONTACT` tracking area to the existing tracking taxonomy.

## Risk

Changes the HubSpot form initialization logic from a simple script load to a more complex MutationObserver pattern. The form tracking relies on text content and CSS class detection to identify button types, which could be fragile if HubSpot changes their form structure.

## Deploy Plan

No special deployment steps required. The tracking events will begin collecting data once deployed and the form functionality remains unchanged.
