### PR TITLE
refactor(front): move attachment handling in AttachmentCitation

### DIFF
--- a/front/components/assistant/conversation/MessageItem.tsx
+++ b/front/components/assistant/conversation/MessageItem.tsx
@@ -9,6 +9,7 @@ import {
 } from "@app/components/assistant/conversation/AttachmentCitation";
 import type { FeedbackSelectorProps } from "@app/components/assistant/conversation/FeedbackSelector";
 import { UserMessage } from "@app/components/assistant/conversation/UserMessage";
+import { useFileUploaderService } from "@app/hooks/useFileUploaderService";
 import { useSendNotification } from "@app/hooks/useNotification";
 import type { AgentMessageFeedbackType } from "@app/lib/api/assistant/feedback";
 import { useSubmitFunction } from "@app/lib/client/utils";
@@ -42,6 +43,11 @@ const MessageItem = React.forwardRef<HTMLDivElement, MessageItemProps>(
     }: MessageItemProps,
     ref
   ) {
+    const fileUploaderService = useFileUploaderService({
+      owner,
+      useCase: "conversation",
+      useCaseMetadata: { conversationId },
+    });
     const { sId, type } = message;
     const sendNotification = useSendNotification();
 
@@ -117,6 +123,7 @@ const MessageItem = React.forwardRef<HTMLDivElement, MessageItemProps>(
                 <AttachmentCitation
                   key={attachmentCitation.id}
                   attachmentCitation={attachmentCitation}
+                  fileUploaderService={fileUploaderService}
                 />
               );
             })

--- a/front/components/assistant/conversation/MessageItemVirtuoso.tsx
+++ b/front/components/assistant/conversation/MessageItemVirtuoso.tsx
@@ -20,6 +20,7 @@ import {
   isUserMessage,
 } from "@app/components/assistant/conversation/types";
 import { UserMessage } from "@app/components/assistant/conversation/UserMessage";
+import { useFileUploaderService } from "@app/hooks/useFileUploaderService";
 import { useSendNotification } from "@app/hooks/useNotification";
 import { useSubmitFunction } from "@app/lib/client/utils";
 import { classNames } from "@app/lib/utils";
@@ -37,6 +38,12 @@ const MessageItemVirtuoso = React.forwardRef<HTMLDivElement, MessageItemProps>(
     { data, context, prevData, nextData }: MessageItemProps,
     ref
   ) {
+    const fileUploaderService = useFileUploaderService({
+      owner: context.owner,
+      useCase: "conversation",
+      useCaseMetadata: { conversationId: context.conversationId },
+    });
+
     const sId = getMessageSId(data);
 
     const sendNotification = useSendNotification();
@@ -108,6 +115,7 @@ const MessageItemVirtuoso = React.forwardRef<HTMLDivElement, MessageItemProps>(
               <AttachmentCitation
                 key={attachmentCitation.id}
                 attachmentCitation={attachmentCitation}
+                fileUploaderService={fileUploaderService}
               />
             );
           })

--- a/front/components/assistant/conversation/input_bar/InputBarAttachments.tsx
+++ b/front/components/assistant/conversation/input_bar/InputBarAttachments.tsx
@@ -1,28 +1,16 @@
 // Okay to use public API types because it's front/connectors communication.
 // eslint-disable-next-line dust/enforce-client-types-in-public-api
 import { isFolder, isWebsite } from "@dust-tt/client";
-import {
-  CitationGrid,
-  Dialog,
-  DialogContainer,
-  DialogContent,
-  DialogFooter,
-  DialogHeader,
-  DialogTitle,
-  DoubleIcon,
-  Icon,
-} from "@dust-tt/sparkle";
-import { useMemo, useState } from "react";
+import { CitationGrid, DoubleIcon, Icon } from "@dust-tt/sparkle";
+import { useMemo } from "react";
 
 import type {
   Attachment,
   FileAttachment,
   NodeAttachment,
 } from "@app/components/assistant/conversation/AttachmentCitation";
-import {
-  AttachmentCitation,
-  attachmentToAttachmentCitation,
-} from "@app/components/assistant/conversation/AttachmentCitation";
+import { attachmentToAttachmentCitation } from "@app/components/assistant/conversation/AttachmentCitation";
+import { AttachmentCitation } from "@app/components/assistant/conversation/AttachmentCitation";
 import {
   getDisplayDateFromPastedFileId,
   getDisplayNameFromPastedFileId,
@@ -50,7 +38,7 @@ interface NodeAttachmentsProps {
 
 interface InputBarAttachmentsProps {
   owner: LightWorkspaceType;
-  files?: FileAttachmentsProps;
+  files: FileAttachmentsProps;
   nodes?: NodeAttachmentsProps;
 }
 
@@ -92,10 +80,11 @@ export function InputBarAttachments({
           type: "file",
           id: blob.id,
           title,
-          preview: blob.preview,
+          previewImageUrl: blob.previewImageUrl,
           contentType: blob.contentType,
           isUploading: blob.isUploading,
           description: uploadDate,
+          fileId: blob.id,
           onRemove: () => files.service.removeFile(blob.id),
         };
         // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
@@ -142,83 +131,26 @@ export function InputBarAttachments({
     );
   }, [nodes, spacesMap]);
 
-  const [viewerOpen, setViewerOpen] = useState(false);
-  const [viewerTitle, setViewerTitle] = useState("");
-  const [viewerText, setViewerText] = useState("");
-
   const allAttachments: Attachment[] = [...fileAttachments, ...nodeAttachments];
 
   if (allAttachments.length === 0) {
     return null;
   }
 
-  const openPastedViewer = async (attachment: Attachment) => {
-    if (!files) {
-      return;
-    }
-    const blob = files.service.fileBlobs.find((b) => b.id === attachment.id);
-    if (!blob) {
-      return;
-    }
-    const text = await blob.file.text();
-    setViewerTitle(attachment.title);
-    setViewerText(text);
-    setViewerOpen(true);
-  };
-
-  const isTextualContentType = (attachment: Attachment) => {
-    if (attachment.type !== "file") {
-      return false;
-    }
-    const ct = attachment.contentType;
-    if (!ct) {
-      return false;
-    }
-    return (
-      ct.startsWith("text/") ||
-      ct === "application/json" ||
-      ct === "application/xml" ||
-      ct === "application/vnd.dust.section.json"
-    );
-  };
-
   return (
     <>
       <CitationGrid className="border-b border-separator px-3 pb-3 pt-3 dark:border-separator-night">
         {allAttachments.map((attachment) => {
           const attachmentCitation = attachmentToAttachmentCitation(attachment);
-          const canPreviewText = isTextualContentType(attachment);
           return (
             <AttachmentCitation
               key={attachmentCitation.id}
               attachmentCitation={attachmentCitation}
-              onRemove={attachment.onRemove}
-              onClick={
-                canPreviewText ? () => openPastedViewer(attachment) : undefined
-              }
+              fileUploaderService={files.service}
             />
           );
         })}
       </CitationGrid>
-
-      <Dialog open={viewerOpen} onOpenChange={setViewerOpen}>
-        <DialogContent size="xl" height="lg">
-          <DialogHeader>
-            <DialogTitle>{viewerTitle}</DialogTitle>
-          </DialogHeader>
-          <DialogContainer>
-            <pre className="m-0 max-h-[60vh] whitespace-pre-wrap break-words">
-              {viewerText}
-            </pre>
-          </DialogContainer>
-          <DialogFooter
-            rightButtonProps={{
-              label: "Close",
-              variant: "highlight",
-            }}
-          />
-        </DialogContent>
-      </Dialog>
     </>
   );
 }

--- a/front/hooks/useFileUploaderService.ts
+++ b/front/hooks/useFileUploaderService.ts
@@ -32,7 +32,7 @@ export interface FileBlob {
   id: string;
   fileId: string | null;
   isUploading: boolean;
-  preview?: string;
+  previewImageUrl?: string;
   size: number;
   publicUrl?: string;
 }
@@ -266,7 +266,7 @@ export function useFileUploaderService({
           ...fileBlob,
           fileId: file.sId,
           isUploading: false,
-          preview: isSupportedImageContentType(fileBlob.contentType)
+          previewImageUrl: isSupportedImageContentType(fileBlob.contentType)
             ? `${fileUploaded.downloadUrl}?action=view`
             : undefined,
           publicUrl: file.publicUrl,
@@ -358,8 +358,13 @@ export function useFileUploaderService({
     return fileBlobs.filter(fileBlobHasFileId);
   };
 
+  const getFileBlob = (blobId: string) => {
+    return getFileBlobs().find((blob) => blob.id === blobId);
+  };
+
   return {
     fileBlobs,
+    getFileBlob,
     getFileBlobs,
     handleFileChange,
     handleFilesUpload,
@@ -373,8 +378,7 @@ export type FileUploaderService = ReturnType<typeof useFileUploaderService>;
 
 const createFileBlob = (
   file: File,
-  contentType: SupportedFileContentType,
-  preview?: string
+  contentType: SupportedFileContentType
 ): FileBlob => ({
   contentType,
   file,
@@ -383,6 +387,5 @@ const createFileBlob = (
   // Will be set once the file has been uploaded.
   fileId: null,
   isUploading: true,
-  preview,
   size: file.size,
 });


### PR DESCRIPTION
## Description

Refactor the way we handle attachment. But more logic inside `AttachmentCitation` so we get all the nice features in the input bar *and* the messages
## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
