### PR TITLE
allow to search top-level pages where parentId is null

### DIFF
--- a/front/lib/actions/mcp_internal_actions/servers/confluence/confluence_api_helper.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/confluence/confluence_api_helper.ts
@@ -315,7 +315,8 @@ export async function updatePage(
       payload.spaceId = updateData.spaceId ?? currentPage.spaceId;
     }
     if (updateData.parentId ?? currentPage.parentId) {
-      payload.parentId = updateData.parentId ?? currentPage.parentId;
+      payload.parentId =
+        updateData.parentId ?? currentPage.parentId ?? undefined;
     }
 
     if (updateData.body) {

--- a/front/lib/actions/mcp_internal_actions/servers/confluence/types.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/confluence/types.ts
@@ -71,7 +71,7 @@ export const ConfluencePageSchema = z
     id: z.string(),
     status: z.string(),
     title: z.string(),
-    parentId: z.string().optional(),
+    parentId: z.string().nullable().optional(),
     spaceId: z.string().optional(),
     body: ConfluencePageBodySchema.optional(),
   })


### PR DESCRIPTION
## Description

allow to search top-level pages where parentId is null

## Tests

locally


## Deploy Plan

Front only
