### PR TITLE
Fix Slack auto-join channel based on patterns

### DIFF
--- a/connectors/src/connectors/slack/temporal/activities.ts
+++ b/connectors/src/connectors/slack/temporal/activities.ts
@@ -14,6 +14,7 @@ import type {
 import assert from "assert";
 import { Op, Sequelize } from "sequelize";
 
+import { findMatchingChannelPatterns } from "@connectors/connectors/slack/auto_read_channel";
 import {
   getBotUserIdMemoized,
   shouldIndexSlackMessage,
@@ -1306,10 +1307,10 @@ export async function autoReadChannelActivity(
   }
 
   const { autoReadChannelPatterns } = slackConfiguration;
-  const matchingPatterns = autoReadChannelPatterns.filter((pattern) => {
-    const regex = new RegExp(`^${pattern.pattern}$`);
-    return regex.test(channelName);
-  });
+  const matchingPatterns = findMatchingChannelPatterns(
+    channelName,
+    autoReadChannelPatterns
+  );
 
   if (matchingPatterns.length === 0) {
     return;

--- a/connectors/src/connectors/slack/temporal/workflows.ts
+++ b/connectors/src/connectors/slack/temporal/workflows.ts
@@ -398,6 +398,15 @@ export async function joinChannelWorkflow(
   }
 
   try {
+    if (useCase === "auto-read") {
+      await getSlackActivities().autoReadChannelActivity(
+        connectorId,
+        channelId
+      );
+
+      return { success: true };
+    }
+
     const joinSuccess = await getSlackActivities().attemptChannelJoinActivity(
       connectorId,
       channelId
@@ -408,13 +417,6 @@ export async function joinChannelWorkflow(
         success: false,
         error: "Channel is archived or could not be joined",
       };
-    }
-
-    if (useCase === "auto-read") {
-      await getSlackActivities().autoReadChannelActivity(
-        connectorId,
-        channelId
-      );
     }
 
     return { success: true };


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
This PR aims at resolving https://github.com/dust-tt/tasks/issues/4555.

In https://github.com/dust-tt/dust/pull/15770 a regression was introduced where we would always join newly created Slack channel if at least one pattern was set on the Slack data source.

The regression stems from the auto-join use case being run too late. The channel was already joined regardless of the patterns. 

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
