### PR TITLE
[viz] chore: remove redundant logs in production

### DIFF
--- a/viz/app/components/VisualizationWrapper.tsx
+++ b/viz/app/components/VisualizationWrapper.tsx
@@ -167,6 +167,7 @@ export function useVisualizationAPI(
         const validatedMessage = validateMessage(event.data);
         if (!validatedMessage) {
           if (isDevelopment()) {
+            // Log to help debug the addition of new event types.
             console.log("Invalid message format received:", event.data);
           }
           return;

--- a/viz/app/components/VisualizationWrapper.tsx
+++ b/viz/app/components/VisualizationWrapper.tsx
@@ -1,7 +1,8 @@
 "use client";
 
-import {
-  CommandResultMap, isDevelopment,
+import { isDevelopment } from "@viz/app/types";
+import type {
+  CommandResultMap,
   VisualizationRPCCommand,
   VisualizationRPCRequestMap,
 } from "@viz/app/types";

--- a/viz/app/components/VisualizationWrapper.tsx
+++ b/viz/app/components/VisualizationWrapper.tsx
@@ -1,7 +1,7 @@
 "use client";
 
-import type {
-  CommandResultMap,
+import {
+  CommandResultMap, isDevelopment,
   VisualizationRPCCommand,
   VisualizationRPCRequestMap,
 } from "@viz/app/types";
@@ -166,7 +166,9 @@ export function useVisualizationAPI(
         // Validate message structure using zod.
         const validatedMessage = validateMessage(event.data);
         if (!validatedMessage) {
-          console.log("Invalid message format received:", event.data);
+          if (isDevelopment()) {
+            console.log("Invalid message format received:", event.data);
+          }
           return;
         }
 

--- a/viz/app/types.ts
+++ b/viz/app/types.ts
@@ -44,3 +44,10 @@ export interface CommandResultMap {
   setErrorMessage: void;
   displayCode: void;
 }
+
+export function isDevelopment() {
+  return (
+    process.env.NODE_ENV === "development" ||
+    process.env.IS_DEVELOPMENT === "true"
+  );
+}


### PR DESCRIPTION
## Description

- We currently log every unrecognized event in viz's event listener (the one that listens for export png and svg).
- Kept the log in dev to help the debugging when adding new types of events.

## Tests

- Checked locally.

## Risk

- Low.

## Deploy Plan

- Deploy viz
