### PR TITLE
Fix: handle missing expires_in in oauth token with a default value of 3600 seconds

### DIFF
--- a/core/src/oauth/providers/mcp.rs
+++ b/core/src/oauth/providers/mcp.rs
@@ -129,7 +129,10 @@ impl Provider for MCPConnectionProvider {
                 Some(n) => n,
                 None => Err(anyhow!("Invalid `expires_in` in response from MCP"))?,
             },
-            _ => Err(anyhow!("Missing `expires_in` in response from MCP"))?,
+            _ => {
+                info!("Missing `expires_in` in response from MCP, using default value of 3600 seconds");
+                3600
+            }
         };
 
         // Some MCP servers do not return a refresh token when finalizing an access token.


### PR DESCRIPTION
## Description

Turns out it's not mandatory to have expires_in in an oauth token ([doc](https://datatracker.ietf.org/doc/html/draft-ietf-oauth-v2-1-13#section-3.2.3)) so we now handle it with a default value.

## Tests

Locally

## Risk

Low

## Deploy Plan

Deploy oauth