### PR TITLE
[front] fix: prevent `flushSync` error in input bar editor

### DIFF
--- a/front/components/assistant/conversation/input_bar/editor/useHandleMentions.tsx
+++ b/front/components/assistant/conversation/input_bar/editor/useHandleMentions.tsx
@@ -48,9 +48,11 @@ const useHandleMentions = (
       }
 
       if (mentionsToInsert.length !== 0) {
-        editorService.resetWithMentions(mentionsToInsert, disableAutoFocus);
-        stickyMentionsTextContent.current =
-          editorService.getTrimmedText() ?? null;
+        queueMicrotask(() => {
+          editorService.resetWithMentions(mentionsToInsert, disableAutoFocus);
+          stickyMentionsTextContent.current =
+            editorService.getTrimmedText() ?? null;
+        });
       }
     }
   }, [agentConfigurations, editorService, stickyMentions, disableAutoFocus]);


### PR DESCRIPTION
## Description

- This PR gets rid of a (legit) console error `flushSync was called from inside a lifecycle method`.
- The `flushSync` in question is done by TipTap when resetting sticky mentions.
- This PR addresses the issue by deferring the `flushSync` after the rendering, before the browser paint.

## Tests

- Checked locally.

## Risk

- Medium, still in the input bar, which is quite useful when using Dust.

## Deploy Plan

- Deploy front.
