### PR TITLE
[connectors] fix(slack): Add workspace validity check in webhook

### DIFF
--- a/connectors/src/api/webhooks/webhook_slack.ts
+++ b/connectors/src/api/webhooks/webhook_slack.ts
@@ -1,4 +1,4 @@
-import { removeNulls } from "@dust-tt/client";
+import { DustAPI, removeNulls } from "@dust-tt/client";
 import { JSON } from "@jsonjoy.com/util/lib/json-brand";
 import type { Request, Response } from "express";
 
@@ -27,6 +27,7 @@ import {
   launchSlackSyncOneMessageWorkflow,
   launchSlackSyncOneThreadWorkflow,
 } from "@connectors/connectors/slack/temporal/client";
+import { apiConfig } from "@connectors/lib/api/config";
 import { dataSourceConfigFromConnector } from "@connectors/lib/api/data_source_config";
 import { concurrentExecutor } from "@connectors/lib/async_utils";
 import { upsertDataSourceFolder } from "@connectors/lib/data_sources";
@@ -214,6 +215,50 @@ const _webhookSlackAPIHandler = async (
                       permission: slackChannel.permission,
                     },
                     "Ignoring message because channel permission is not read or read_write"
+                  );
+                  return null;
+                }
+
+                // Check if workspace is in maintenance mode
+                const connector = await ConnectorResource.fetchById(
+                  c.connectorId
+                );
+                if (!connector) {
+                  logger.info(
+                    {
+                      connectorId: c.connectorId,
+                      slackChannelId: channel,
+                    },
+                    "Skipping webhook: Connector not found"
+                  );
+                  return null;
+                }
+
+                const dataSourceConfig =
+                  dataSourceConfigFromConnector(connector);
+                const dustAPI = new DustAPI(
+                  {
+                    url: apiConfig.getDustFrontAPIUrl(),
+                  },
+                  {
+                    apiKey: dataSourceConfig.workspaceAPIKey,
+                    workspaceId: dataSourceConfig.workspaceId,
+                  },
+                  logger
+                );
+
+                // Make a simple API call to check if workspace is accessible
+                const spacesRes = await dustAPI.getSpaces();
+                if (spacesRes.isErr()) {
+                  logger.info(
+                    {
+                      connectorId: connector.id,
+                      slackTeamId: teamId,
+                      slackChannelId: channel,
+                      workspaceId: dataSourceConfig.workspaceId,
+                      error: spacesRes.error.message,
+                    },
+                    "Skipping webhook: workspace is unavailable (likely in maintenance)"
                   );
                   return null;
                 }

--- a/connectors/src/connectors/slack/auto_read_channel.ts
+++ b/connectors/src/connectors/slack/auto_read_channel.ts
@@ -71,6 +71,7 @@ export async function autoReadChannel(
       {
         connectorId: connector.id,
         teamId,
+        workspaceId: dataSourceConfig.workspaceId,
         error: spacesRes.error.message,
       },
       "Skipping auto-read channel: workspace API call failed (likely in maintenance)"

--- a/front/lib/api/auth_wrappers.ts
+++ b/front/lib/api/auth_wrappers.ts
@@ -340,7 +340,7 @@ export function withPublicAPIAuthentication<T, U extends boolean>(
             return apiError(req, res, {
               status_code: 503,
               api_error: {
-                type: "not_authenticated",
+                type: "service_unavailable",
                 message: `Service is currently unavailable. [${maintenance}]`,
               },
             });


### PR DESCRIPTION
## Description

When getting slack webhooks we can trigger a temporal workflow, without check if the workspace is valid - it can be in maintenance mode (relocated), or subscription may have ended - in all theses cases, the workflow should not be triggered as they will fail.
Doing a simple call to the api before doing anything else to ensure the workspace is ok.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

minimal

## Deploy Plan

deploy connectors