### PR TITLE
Possibility to add button inside chip

### DIFF
--- a/sparkle/src/components/AttachmentChip.tsx
+++ b/sparkle/src/components/AttachmentChip.tsx
@@ -3,6 +3,7 @@ import React from "react";
 
 import { cn } from "@sparkle/lib/utils";
 
+import { Button } from "./Button";
 import { Icon } from "./Icon";
 import { LinkWrapper, LinkWrapperProps } from "./LinkWrapper";
 
@@ -20,6 +21,11 @@ interface AttachmentChipBaseProps {
   label: string;
   icon?: React.ComponentType;
   className?: string;
+  actionButton?: {
+    label: string;
+    onClick: () => void;
+    tooltip?: string;
+  };
 }
 
 type AttachmentChipButtonProps = AttachmentChipBaseProps & {
@@ -37,12 +43,32 @@ export function AttachmentChip({
   label,
   icon,
   className,
+  actionButton,
   ...props
 }: AttachmentChipProps) {
   const chipContent = (
-    <div className={cn(attachmentChipVariants({}), className)}>
+    <div
+      className={cn(
+        attachmentChipVariants({}),
+        className,
+        actionButton && "s-max-w-fit"
+      )}
+    >
       <Icon visual={icon} size="xs" className="s-shrink-0" />
       <span className="s-pointer s-grow s-truncate">{label}</span>
+      {actionButton && (
+        <Button
+          variant="primary"
+          size="xs"
+          label={actionButton.label}
+          onClick={(e) => {
+            e.stopPropagation();
+            e.preventDefault();
+            actionButton.onClick();
+          }}
+          tooltip={actionButton.tooltip}
+        />
+      )}
     </div>
   );
 

--- a/sparkle/src/stories/AttachmentChip.stories.tsx
+++ b/sparkle/src/stories/AttachmentChip.stories.tsx
@@ -81,3 +81,22 @@ export const LongLabel: Story = {
     ),
   ],
 };
+
+export const ChipWithInnerButton: Story = {
+  args: {
+    label: "Click this ->",
+    icon: DocumentIcon,
+    actionButton: {
+      label: "Action",
+      onClick: () => alert("Action clicked!"),
+      tooltip: "This is an action button",
+    },
+  },
+  decorators: [
+    (Story) => (
+      <ParagraphWrapper>
+        <Story />
+      </ParagraphWrapper>
+    ),
+  ],
+};


### PR DESCRIPTION
## Description

Context: need a way to revert to full inclusion of text if wanted instead of side attached file 

This is needed to add a "Inline" button in pasted chip.

<img width="1016" height="206" alt="image" src="https://github.com/user-attachments/assets/506a494a-87b6-4cb0-b5f0-0fab5db6edca" />

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

deploy sparkle
