### PR TITLE
fix(front): store transcripts as text files, not audio

### DIFF
--- a/front/lib/api/files/upload.ts
+++ b/front/lib/api/files/upload.ts
@@ -273,7 +273,11 @@ export const extractTextFromAudioAndUpload: ProcessingFunction = async (
 
     // 4) Store transcript in processed version as plain text.
     const transcript = tr.value;
-    const writeStream = file.getWriteStream({ auth, version: "processed" });
+    const writeStream = file.getWriteStream({
+      auth,
+      version: "processed",
+      overrideContentType: "text/plain", // Explicitly set content type to plain text as it's a transcription
+    });
     await pipeline(Readable.from(transcript), writeStream);
 
     return new Ok(undefined);


### PR DESCRIPTION
## Description

We used to store audio transcript as "audio" and not "plain/text"
## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
