### PR TITLE
Add test webhook preset for testing

### DIFF
--- a/front/types/triggers/test_webhook_source_presets.ts
+++ b/front/types/triggers/test_webhook_source_presets.ts
@@ -1,0 +1,37 @@
+import { RocketIcon } from "@dust-tt/sparkle";
+
+import type {
+  PresetWebhook,
+  WebhookEvent,
+} from "@app/types/triggers/webhooks_source_preset";
+
+const TEST_EVENT: WebhookEvent = {
+  name: "Test event",
+  value: "test_event",
+  description: "A simple test event with two string fields.",
+  fields: [
+    {
+      name: "A",
+      description: "Field A - a string field.",
+      type: "string",
+    },
+    {
+      name: "B",
+      description: "Field B - a string field.",
+      type: "string",
+    },
+  ],
+};
+
+export const TEST_WEBHOOK_PRESET: PresetWebhook = {
+  name: "Test",
+  eventCheck: {
+    type: "header",
+    field: "event-type",
+  },
+  events: [TEST_EVENT],
+  icon: RocketIcon,
+  description: "A test webhook preset with a simple event structure.",
+  // Used for dev tests only, it should always be hidden behind the flag
+  featureFlag: "hootl_dev_webhooks",
+};

--- a/front/types/triggers/webhooks.ts
+++ b/front/types/triggers/webhooks.ts
@@ -12,6 +12,7 @@ import type { ModelId } from "@app/types/shared/model_id";
 import { GITHUB_WEBHOOK_PRESET } from "@app/types/triggers/github_webhook_source_presets";
 import type { PresetWebhook } from "@app/types/triggers/webhooks_source_preset";
 import type { EditedByUser } from "@app/types/user";
+import { TEST_WEBHOOK_PRESET } from "@app/types/triggers/test_webhook_source_presets";
 
 export const WEBHOOK_SOURCE_SIGNATURE_ALGORITHMS = [
   "sha1",
@@ -33,10 +34,11 @@ export const WEBHOOK_SOURCE_KIND_TO_PRESETS_MAP: Record<
   };
 } = {
   github: GITHUB_WEBHOOK_PRESET,
+  test: TEST_WEBHOOK_PRESET,
   custom: { name: "Custom", icon: ActionGlobeAltIcon },
 } as const;
 
-export const WEBHOOK_SOURCE_KIND = ["custom", "github"] as const;
+export const WEBHOOK_SOURCE_KIND = ["custom", "github", "test"] as const;
 
 export type WebhookSourceKind = (typeof WEBHOOK_SOURCE_KIND)[number];
 


### PR DESCRIPTION
## Description

close https://github.com/dust-tt/tasks/issues/4519?issue=dust-tt%7Ctasks%7C4535

<img width="480" height="364" alt="image" src="https://github.com/user-attachments/assets/a56722b3-d3f6-4fc7-871a-50d3e31e83ea" />

<img width="1622" height="1056" alt="image" src="https://github.com/user-attachments/assets/14ae72a0-814d-4bf7-8951-b7fee38851e9" />

## Tests

Can be tested with following curl command:
```
curl -X POST 'http://localhost:3000/api/v1/w/HrZ4gGTjKs/triggers/hooks/whs_YBECTJ8RUj/pPtdF0pRjNjFCEOXoXvjl3kBrAEsWrl5BzLbjnQKjIgPp1fNTTuNk3ykOX453MQo' \
  -H 'Content-Type: application/json' \
  -H 'X-Test-Event: test_event' \
  -d '{
    "A": "dog",
    "B": "cat"
  }'
```

## Risk




## Deploy Plan

deploy front
