### PR TITLE
[front] Use number for date to fix serialization

### DIFF
--- a/front/lib/api/assistant/conversation.ts
+++ b/front/lib/api/assistant/conversation.ts
@@ -539,7 +539,9 @@ export async function postUserMessage(
                   userContextProfilePictureUrl: context.profilePictureUrl,
                   userContextOrigin: context.origin,
                   userContextOriginMessageId: originMessage?.sId ?? null,
-                  userContextLastTriggerRunAt: context.lastTriggerRunAt,
+                  userContextLastTriggerRunAt: context.lastTriggerRunAt
+                    ? new Date(context.lastTriggerRunAt)
+                    : null,
                   userId: user
                     ? user.id
                     : (

--- a/front/lib/api/assistant/messages.ts
+++ b/front/lib/api/assistant/messages.ts
@@ -213,7 +213,8 @@ async function batchRenderUserMessages(
         origin: userMessage.userContextOrigin,
         originMessageId: userMessage.userContextOriginMessageId,
         clientSideMCPServerIds: userMessage.clientSideMCPServerIds,
-        lastTriggerRunAt: userMessage.userContextLastTriggerRunAt,
+        lastTriggerRunAt:
+          userMessage.userContextLastTriggerRunAt?.getTime() ?? null,
       },
     } satisfies UserMessageType;
     return m;

--- a/front/temporal/agent_schedule/activities.ts
+++ b/front/temporal/agent_schedule/activities.ts
@@ -120,7 +120,7 @@ async function createConversationForAgentConfiguration({
     email: auth.getNonNullableUser().email,
     profilePictureUrl: null,
     origin: "triggered" as const,
-    lastTriggerRunAt: lastRunAt,
+    lastTriggerRunAt: lastRunAt?.getTime() ?? null,
   };
 
   if (contentFragment) {

--- a/front/types/assistant/conversation.ts
+++ b/front/types/assistant/conversation.ts
@@ -89,7 +89,7 @@ export type UserMessageContext = {
   profilePictureUrl: string | null;
   origin?: UserMessageOrigin | null;
   originMessageId?: string | null;
-  lastTriggerRunAt?: Date | null;
+  lastTriggerRunAt?: number | null;
   clientSideMCPServerIds?: string[];
   selectedMCPServerViewIds?: string[];
 };

--- a/sdks/js/src/types.ts
+++ b/sdks/js/src/types.ts
@@ -936,7 +936,7 @@ const UserMessageContextSchema = z.object({
   originMessageId: z.string().optional().nullable(),
   clientSideMCPServerIds: z.array(z.string()).optional().nullable(),
   selectedMCPServerViewIds: z.array(z.string()).optional().nullable(),
-  lastTriggerRunAt: z.date().optional().nullable(),
+  lastTriggerRunAt: z.number().optional().nullable(),
 });
 
 const UserMessageSchema = z.object({


### PR DESCRIPTION
## Description

lastTriggerRunAt is currently defined as Date, serialized as an ISO date string but zod does expect a Date() object - which makes validation crash every time you try to get a conversation which as a triggerDate through the sdk. 
Replacing with number, which is how we usually expose date fields

fixes: https://github.com/dust-tt/tasks/issues/4440

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

deploy front
