### PR TITLE
[frame] add cta in public preview link

### DIFF
--- a/front/components/assistant/conversation/content_creation/PublicClientExecutableRenderer.tsx
+++ b/front/components/assistant/conversation/content_creation/PublicClientExecutableRenderer.tsx
@@ -1,13 +1,12 @@
 import { Spinner } from "@dust-tt/sparkle";
 import React from "react";
-import { useCookies } from "react-cookie";
 
 import { VisualizationActionIframe } from "@app/components/assistant/conversation/actions/VisualizationActionIframe";
 import { CenteredState } from "@app/components/assistant/conversation/content_creation/CenteredState";
 import { PublicContentCreationHeader } from "@app/components/assistant/conversation/content_creation/PublicContentCreationHeader";
-import { WORKOS_SESSION } from "@app/lib/cookies";
 import { formatFilenameForDisplay } from "@app/lib/files";
 import { usePublicFrame } from "@app/lib/swr/frames";
+import { useUser } from "@app/lib/swr/user";
 
 interface PublicClientExecutableRendererProps {
   fileId: string;
@@ -25,11 +24,10 @@ export function PublicClientExecutableRenderer({
   const { frameContent, isFrameLoading, error } = usePublicFrame({
     shareToken,
   });
-  const [workOsCookie] = useCookies([WORKOS_SESSION]);
-  const hasWorkspace =
-    workOsCookie &&
-    typeof workOsCookie === "object" &&
-    "lastWorkspaceId" in workOsCookie;
+  const { user } = useUser({
+    revalidateOnFocus: false,
+    revalidateIfStale: false,
+  });
 
   const getFileBlob = React.useCallback(
     async (fileId: string): Promise<Blob | null> => {
@@ -69,7 +67,7 @@ export function PublicClientExecutableRenderer({
     <div className="flex h-full flex-col">
       <PublicContentCreationHeader
         title={formatFilenameForDisplay(fileName ?? "Frame")}
-        hasWorkspace={hasWorkspace}
+        user={user}
       />
 
       {/* Content */}

--- a/front/components/assistant/conversation/content_creation/PublicClientExecutableRenderer.tsx
+++ b/front/components/assistant/conversation/content_creation/PublicClientExecutableRenderer.tsx
@@ -26,7 +26,10 @@ export function PublicClientExecutableRenderer({
     shareToken,
   });
   const [workOsCookie] = useCookies([WORKOS_SESSION]);
-  const hasWorkspace = "lastWorkspaceId" in workOsCookie;
+  const hasWorkspace =
+    workOsCookie &&
+    typeof workOsCookie === "object" &&
+    "lastWorkspaceId" in workOsCookie;
 
   const getFileBlob = React.useCallback(
     async (fileId: string): Promise<Blob | null> => {

--- a/front/components/assistant/conversation/content_creation/PublicClientExecutableRenderer.tsx
+++ b/front/components/assistant/conversation/content_creation/PublicClientExecutableRenderer.tsx
@@ -1,9 +1,11 @@
 import { Spinner } from "@dust-tt/sparkle";
 import React from "react";
+import { useCookies } from "react-cookie";
 
 import { VisualizationActionIframe } from "@app/components/assistant/conversation/actions/VisualizationActionIframe";
 import { CenteredState } from "@app/components/assistant/conversation/content_creation/CenteredState";
 import { PublicContentCreationHeader } from "@app/components/assistant/conversation/content_creation/PublicContentCreationHeader";
+import { WORKOS_SESSION } from "@app/lib/cookies";
 import { formatFilenameForDisplay } from "@app/lib/files";
 import { usePublicFrame } from "@app/lib/swr/frames";
 
@@ -23,6 +25,8 @@ export function PublicClientExecutableRenderer({
   const { frameContent, isFrameLoading, error } = usePublicFrame({
     shareToken,
   });
+  const [workOsCookie] = useCookies([WORKOS_SESSION]);
+  const hasWorkspace = "lastWorkspaceId" in workOsCookie;
 
   const getFileBlob = React.useCallback(
     async (fileId: string): Promise<Blob | null> => {
@@ -62,6 +66,7 @@ export function PublicClientExecutableRenderer({
     <div className="flex h-full flex-col">
       <PublicContentCreationHeader
         title={formatFilenameForDisplay(fileName ?? "Frame")}
+        hasWorkspace={hasWorkspace}
       />
 
       {/* Content */}

--- a/front/components/assistant/conversation/content_creation/PublicContentCreationHeader.tsx
+++ b/front/components/assistant/conversation/content_creation/PublicContentCreationHeader.tsx
@@ -1,10 +1,12 @@
-import { cn } from "@dust-tt/sparkle";
+import { Button, cn, RocketIcon } from "@dust-tt/sparkle";
 
 import { PublicWebsiteLogo } from "@app/components/home/LandingLayout";
 import { AppLayoutTitle } from "@app/components/sparkle/AppLayoutTitle";
+import { TRACKING_AREAS, withTracking } from "@app/lib/tracking";
 
 interface PublicContentCreationHeaderProps {
   title: string;
+  hasWorkspace: boolean;
 }
 
 // Applying flex & justify-center to the title won't make it centered in the header
@@ -14,6 +16,7 @@ interface PublicContentCreationHeaderProps {
 // TODO(CONTENT_CREATION 2025-08-27): optimize the header for mobile views once we have buttons.
 export function PublicContentCreationHeader({
   title,
+  hasWorkspace,
 }: PublicContentCreationHeaderProps) {
   return (
     <AppLayoutTitle className="h-12 bg-gray-50 @container dark:bg-gray-900">
@@ -33,7 +36,17 @@ export function PublicContentCreationHeader({
           </span>
         </div>
 
-        <div className="md:grow-1 md:basis-60"></div>
+        <div className="md:grow-1 flex justify-end md:basis-60">
+          {!hasWorkspace && (
+            <Button
+              label="Try it yourself"
+              href="/home"
+              variant="outline"
+              icon={RocketIcon}
+              onClick={withTracking(TRACKING_AREAS.FRAME, "sign_up")}
+            />
+          )}
+        </div>
       </div>
     </AppLayoutTitle>
   );

--- a/front/components/assistant/conversation/content_creation/PublicContentCreationHeader.tsx
+++ b/front/components/assistant/conversation/content_creation/PublicContentCreationHeader.tsx
@@ -3,10 +3,11 @@ import { Button, cn, RocketIcon } from "@dust-tt/sparkle";
 import { PublicWebsiteLogo } from "@app/components/home/LandingLayout";
 import { AppLayoutTitle } from "@app/components/sparkle/AppLayoutTitle";
 import { TRACKING_AREAS, withTracking } from "@app/lib/tracking";
+import type { UserTypeWithWorkspaces } from "@app/types";
 
 interface PublicContentCreationHeaderProps {
   title: string;
-  hasWorkspace: boolean;
+  user: UserTypeWithWorkspaces | null;
 }
 
 // Applying flex & justify-center to the title won't make it centered in the header
@@ -16,7 +17,7 @@ interface PublicContentCreationHeaderProps {
 // TODO(CONTENT_CREATION 2025-08-27): optimize the header for mobile views once we have buttons.
 export function PublicContentCreationHeader({
   title,
-  hasWorkspace,
+  user,
 }: PublicContentCreationHeaderProps) {
   return (
     <AppLayoutTitle className="h-12 bg-gray-50 @container dark:bg-gray-900">
@@ -37,7 +38,7 @@ export function PublicContentCreationHeader({
         </div>
 
         <div className="md:grow-1 flex justify-end md:basis-60">
-          {!hasWorkspace && (
+          {!user && (
             <Button
               label="Try it yourself"
               href="/home"

--- a/front/lib/cookies.ts
+++ b/front/lib/cookies.ts
@@ -1,7 +1,6 @@
 import type { UserType } from "@app/types/user";
 
 export const DUST_COOKIES_ACCEPTED = "dust-cookies-accepted";
-export const WORKOS_SESSION = "workos_session";
 
 /**
  * Determines if cookies have been accepted based on cookie value or user authentication

--- a/front/lib/cookies.ts
+++ b/front/lib/cookies.ts
@@ -1,6 +1,7 @@
 import type { UserType } from "@app/types/user";
 
 export const DUST_COOKIES_ACCEPTED = "dust-cookies-accepted";
+export const WORKOS_SESSION = "workos_session";
 
 /**
  * Determines if cookies have been accepted based on cookie value or user authentication

--- a/front/lib/swr/user.ts
+++ b/front/lib/swr/user.ts
@@ -1,4 +1,4 @@
-import type { Fetcher } from "swr";
+import type { Fetcher, SWRConfiguration } from "swr";
 
 import { useSendNotification } from "@app/hooks/useNotification";
 import {
@@ -12,9 +12,17 @@ import type { GetUserApprovalsResponseBody } from "@app/pages/api/w/[wId]/me/app
 import type { LightWorkspaceType } from "@app/types";
 import type { JobType } from "@app/types/job_type";
 
-export function useUser() {
+export function useUser(
+  swrOptions?: SWRConfiguration & {
+    disabled?: boolean;
+  }
+) {
   const userFetcher: Fetcher<GetUserResponseBody> = fetcher;
-  const { data, error, mutate } = useSWRWithDefaults("/api/user", userFetcher);
+  const { data, error, mutate } = useSWRWithDefaults(
+    "/api/user",
+    userFetcher,
+    swrOptions
+  );
 
   return {
     user: data ? data.user : null,

--- a/front/lib/tracking.ts
+++ b/front/lib/tracking.ts
@@ -46,6 +46,7 @@ export const TRACKING_AREAS = {
   SPACES: "spaces",
   LABS: "labs",
   TOOLS: "tools",
+  FRAME: "frame",
 } as const;
 
 export type TrackingArea = (typeof TRACKING_AREAS)[keyof typeof TRACKING_AREAS];


### PR DESCRIPTION
## Description
This PR is to add CTA button in public frame view if you don't have workOS session cookie

<img width="1906" height="108" alt="CleanShot 2025-10-08 at 17 17 45@2x" src="https://github.com/user-attachments/assets/3f5d76b1-3ddb-45be-a74d-9ca0655bead1" />
 

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
