### PR TITLE
Revert "configurable: bool -> canBeConfigured (#16563)"

### DIFF
--- a/front/components/agent_builder/AgentBuilderFormContext.tsx
+++ b/front/components/agent_builder/AgentBuilderFormContext.tsx
@@ -100,7 +100,7 @@ const baseActionSchema = z.object({
   id: z.string(),
   name: z.string(),
   description: z.string(),
-  canBeConfigured: z.boolean().optional(),
+  configurable: z.boolean().optional(),
 });
 
 const TAG_KINDS = z.union([z.literal("standard"), z.literal("protected")]);

--- a/front/components/agent_builder/capabilities/AgentBuilderCapabilitiesBlock.tsx
+++ b/front/components/agent_builder/capabilities/AgentBuilderCapabilitiesBlock.tsx
@@ -204,7 +204,7 @@ export function AgentBuilderCapabilitiesBlock({
       setKnowledgeAction({ action, index });
     } else {
       setDialogMode(
-        action.canBeConfigured
+        action.configurable
           ? { type: "edit", action, index }
           : { type: "info", action, source: "addedTool" }
       );
@@ -227,7 +227,7 @@ export function AgentBuilderCapabilitiesBlock({
     setKnowledgeAction({
       action: {
         ...action,
-        canBeConfigured: true, // it's always required for knowledge
+        configurable: true, // it's always required for knowledge
       },
       index: null,
     });

--- a/front/components/agent_builder/capabilities/mcp/MCPServerViewsSheet.tsx
+++ b/front/components/agent_builder/capabilities/mcp/MCPServerViewsSheet.tsx
@@ -192,7 +192,7 @@ export function MCPServerViewsSheet({
           action.type === "MCP" &&
           action.configuration &&
           action.configuration.mcpServerViewId &&
-          !action.canBeConfigured
+          !action.configurable
         ) {
           const selectedView = allMcpServerViews.find(
             (mcpServerView) =>
@@ -501,7 +501,7 @@ export function MCPServerViewsSheet({
             configuration: null,
             name: DEFAULT_DATA_VISUALIZATION_NAME,
             description: DEFAULT_DATA_VISUALIZATION_DESCRIPTION,
-            canBeConfigured: false,
+            configurable: false,
           };
         } else {
           // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
@@ -634,7 +634,7 @@ export function MCPServerViewsSheet({
           <FormProvider form={form} className="h-full">
             <div className="h-full">
               <div className="h-full space-y-6 pt-3">
-                {configurationTool.canBeConfigured && (
+                {configurationTool.configurable && (
                   <NameSection
                     title="Name"
                     placeholder="My tool name…"

--- a/front/components/agent_builder/capabilities/usePresetActionHandler.ts
+++ b/front/components/agent_builder/capabilities/usePresetActionHandler.ts
@@ -106,7 +106,7 @@ export function usePresetActionHandler({
 
     if (isKnowledgeTemplateAction(presetActionToAdd)) {
       setKnowledgeAction({
-        action: { ...action, canBeConfigured: false },
+        action: { ...action, configurable: false },
         index: null,
         presetData: presetActionToAdd,
       });

--- a/front/components/agent_builder/get_spaceid_to_actions_map.test.ts
+++ b/front/components/agent_builder/get_spaceid_to_actions_map.test.ts
@@ -16,7 +16,7 @@ const createMockAction = (
   configuration: null,
   name,
   description: `Description for ${name}`,
-  canBeConfigured: false,
+  configurable: false,
 });
 
 const createMockMCPAction = (
@@ -44,7 +44,7 @@ const createMockMCPAction = (
     _jsonSchemaString: null,
     secretName: null,
   },
-  canBeConfigured: true,
+  configurable: true,
 });
 
 const createMockMCPServerView = (

--- a/front/components/agent_builder/types.ts
+++ b/front/components/agent_builder/types.ts
@@ -192,7 +192,7 @@ export function getDefaultMCPAction(
         : mcpServerView
           ? getMcpServerViewDescription(mcpServerView)
           : "",
-    canBeConfigured: toolsConfigurations.configurable !== "no",
+    configurable: toolsConfigurations.configurable !== "no",
   };
 }
 

--- a/front/components/assistant_builder/types.ts
+++ b/front/components/assistant_builder/types.ts
@@ -58,7 +58,7 @@ export interface AssistantBuilderDataVisualizationConfiguration {
   configuration: null;
   name: string;
   description: string;
-  canBeConfigured: false;
+  configurable: false;
 }
 
 // DATA_VISUALIZATION is not an action, but we need to show it in the UI like an action.
@@ -105,7 +105,7 @@ export function getDataVisualizationConfiguration(): AssistantBuilderDataVisuali
     configuration: null,
     name: DEFAULT_DATA_VISUALIZATION_NAME,
     description: DEFAULT_DATA_VISUALIZATION_DESCRIPTION,
-    canBeConfigured: false,
+    configurable: false,
   } satisfies AssistantBuilderDataVisualizationConfiguration;
 }
 


### PR DESCRIPTION
This is to fix https://dust4ai.slack.com/archives/C050SM8NSPK/p1759939924067759

The problem is we don't transform configurable to canBeConfigured when you edit an existing agent but I'm really not sure about this naming and approach so let's revert it for now. 

This reverts commit d2a862435aa785f387e083d2d6385a6f15b4ff6b.

## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
