### PR TITLE
Add way to embed host in CORE_DATA_SOURCES_OPENAI_API_KEY

### DIFF
--- a/core/src/providers/openai.rs
+++ b/core/src/providers/openai.rs
@@ -1202,7 +1202,7 @@ impl Embedder for OpenAIEmbedder {
 
         // CORE_DATA_SOURCES_OPENAI_API_KEY can take two forms:
         // - just the API key (e.g. sk-xxxx)
-        // - the API key followed by a semicolon and a custom host (e.g. sk-xxxx;eu.openai.com)
+        // - the API key followed by a semicolon and a custom host (e.g. sk-xxxx;eu.api.openai.com)
 
         let raw_openai_key_env =
             std::env::var("CORE_DATA_SOURCES_OPENAI_API_KEY").map_err(|_| {

--- a/core/src/providers/openai.rs
+++ b/core/src/providers/openai.rs
@@ -1204,10 +1204,15 @@ impl Embedder for OpenAIEmbedder {
         // - just the API key (e.g. sk-xxxx)
         // - the API key followed by a semicolon and a custom host (e.g. sk-xxxx;eu.api.openai.com)
 
-        let raw_openai_key_env =
-            std::env::var("CORE_DATA_SOURCES_OPENAI_API_KEY").map_err(|_| {
-                anyhow!("Environment variable `CORE_DATA_SOURCES_OPENAI_API_KEY` must be set.")
-            })?;
+        let raw_openai_key_env = match std::env::var("CORE_DATA_SOURCES_OPENAI_API_KEY") {
+            Ok(v) => v,
+            _ => {
+                // The fallback to DUST_MANAGED_OPENAI_API_KEY is for local development only
+                std::env::var("DUST_MANAGED_OPENAI_API_KEY").map_err(|_| {
+                    anyhow!("CORE_DATA_SOURCES_OPENAI_API_KEY or DUST_MANAGED_OPENAI_API_KEY must be set.")
+                })?
+            }
+        };
 
         let (key_part, host_part) = match raw_openai_key_env.split_once(';') {
             Some((k, h)) => (k.trim(), h.trim()),

--- a/core/src/providers/openai.rs
+++ b/core/src/providers/openai.rs
@@ -1204,13 +1204,14 @@ impl Embedder for OpenAIEmbedder {
         // - just the API key (e.g. sk-xxxx)
         // - the API key followed by a semicolon and a custom host (e.g. sk-xxxx;eu.openai.com)
 
-        let raw = std::env::var("CORE_DATA_SOURCES_OPENAI_API_KEY").map_err(|_| {
-            anyhow!("Environment variable `CORE_DATA_SOURCES_OPENAI_API_KEY` must be set.")
-        })?;
+        let raw_openai_key_env =
+            std::env::var("CORE_DATA_SOURCES_OPENAI_API_KEY").map_err(|_| {
+                anyhow!("Environment variable `CORE_DATA_SOURCES_OPENAI_API_KEY` must be set.")
+            })?;
 
-        let (key_part, host_part) = match raw.split_once(';') {
+        let (key_part, host_part) = match raw_openai_key_env.split_once(';') {
             Some((k, h)) => (k.trim(), h.trim()),
-            None => (raw.trim(), "api.openai.com"),
+            None => (raw_openai_key_env.trim(), "api.openai.com"),
         };
 
         self.api_key = Some(key_part.to_string());

--- a/core/src/providers/openai.rs
+++ b/core/src/providers/openai.rs
@@ -1200,9 +1200,8 @@ impl Embedder for OpenAIEmbedder {
             ));
         }
 
-        // CORE_DATA_SOURCES_OPENAI_API_KEY can take two forms:
-        // - just the API key (e.g. sk-xxxx)
-        // - the API key followed by a semicolon and a custom host (e.g. sk-xxxx;eu.api.openai.com)
+        // For the Embedder, we deliberately don't rely on passed credentials, to avoid using
+        // user creds in Dust app scenarios (unlike in LLM scenarios, where we want to use them).
 
         let raw_openai_key_env = match std::env::var("CORE_DATA_SOURCES_OPENAI_API_KEY") {
             Ok(v) => v,
@@ -1214,6 +1213,9 @@ impl Embedder for OpenAIEmbedder {
             }
         };
 
+        // The env variable can take two forms:
+        // - just the API key (e.g. sk-xxxx)
+        // - the API key followed by a semicolon and a custom host (e.g. sk-xxxx;eu.api.openai.com)
         let (key_part, host_part) = match raw_openai_key_env.split_once(';') {
             Some((k, h)) => (k.trim(), h.trim()),
             None => (raw_openai_key_env.trim(), "api.openai.com"),

--- a/core/src/providers/openai.rs
+++ b/core/src/providers/openai.rs
@@ -1217,6 +1217,14 @@ impl Embedder for OpenAIEmbedder {
         self.api_key = Some(key_part.to_string());
         self.host = Some(host_part.to_string());
 
+        // Check host validity to protect against SSRF
+        if !self.host.as_ref().unwrap().ends_with(".openai.com") {
+            return Err(anyhow!(
+                "Invalid OpenAI host `{}`: must end with `.openai.com`",
+                self.host.as_ref().unwrap()
+            ));
+        }
+
         info!(
             model = self.id,
             openai_host = self.host,


### PR DESCRIPTION
## Description

Change CORE_DATA_SOURCES_OPENAI_API_KEY to support two forms:
- just the API key (e.g. sk-xxxx)
- the API key followed by a semicolon and a custom host (e.g. sk-xxxx;eu.api.openai.com)

## Tests

Manual

## Risk

Low until we set it to have the host name, then needs monitoring

## Deploy Plan

Core