### PR TITLE
ContinueAsNew for transcripts processing

### DIFF
--- a/front/temporal/labs/transcripts/client.ts
+++ b/front/temporal/labs/transcripts/client.ts
@@ -18,7 +18,7 @@ export async function launchRetrieveTranscriptsWorkflow(
 
   try {
     await client.workflow.start(retrieveNewTranscriptsWorkflow, {
-      args: [transcriptsConfiguration.sId],
+      args: [{ transcriptsConfigurationId: transcriptsConfiguration.sId }],
       taskQueue: TRANSCRIPTS_QUEUE_NAME,
       workflowId: workflowId,
       cronSchedule: "*/5 * * * *",


### PR DESCRIPTION







## Description

Implements `continueAsNew` functionality for the transcripts processing workflow to prevent Temporal workflow history from growing too large. When the workflow history exceeds 1,000 entries, it restarts itself with a `continueAsNew` call, preserving the current processing state by passing the `startIndex` parameter to resume from the correct position in the files array.

## Risk

Low risk change that follows established Temporal patterns. The workflow will continue processing from the exact same point, ensuring no transcripts are skipped or processed twice.

## Deploy Plan

