### PR TITLE
Fix: global mutate also support data and options args

### DIFF
--- a/front/components/assistant/conversation/ConversationContainerVirtuoso.tsx
+++ b/front/components/assistant/conversation/ConversationContainerVirtuoso.tsx
@@ -138,7 +138,20 @@ export function ConversationContainerVirtuoso({
           undefined,
           { shallow: true }
         );
-        await mutateConversations();
+
+        await mutateConversations(
+          (currentData) => {
+            // Immediately update the list of conversations in the sidebar by adding the new conversation.
+            return {
+              ...currentData,
+              conversations: [
+                ...(currentData?.conversations ?? []),
+                conversationRes.value,
+              ],
+            };
+          },
+          { revalidate: false }
+        );
 
         return new Ok(undefined);
       }

--- a/front/components/assistant/conversation/ConversationViewerVirtuoso.tsx
+++ b/front/components/assistant/conversation/ConversationViewerVirtuoso.tsx
@@ -318,8 +318,38 @@ const ConversationViewerVirtuoso = ({
             break;
 
           case "conversation_title":
-            void mutateConversation();
-            void mutateConversations(); // to refresh the list of convos in the sidebar (title)
+            void mutateConversation(
+              (current) => {
+                if (current) {
+                  return {
+                    ...current,
+                    conversation: {
+                      ...current.conversation,
+                      title: event.title,
+                    },
+                  };
+                }
+              },
+              { revalidate: false }
+            );
+
+            // to refresh the list of convos in the sidebar (title)
+            void mutateConversations(
+              (currentData) => {
+                if (currentData?.conversations) {
+                  return {
+                    ...currentData,
+                    conversations: currentData.conversations.map((c) =>
+                      c.sId === conversationId
+                        ? { ...c, title: event.title }
+                        : c
+                    ),
+                  };
+                }
+              },
+              { revalidate: false }
+            );
+
             break;
           case "agent_message_done":
             // Mark as read and do not mutate the list of convos in the sidebar to avoid useless network request.
@@ -338,11 +368,12 @@ const ConversationViewerVirtuoso = ({
       }
     },
     [
-      mutateConversationParticipants,
+      conversationId,
+      debouncedMarkAsRead,
       mutateConversation,
+      mutateConversationParticipants,
       mutateConversations,
       mutateMessages,
-      debouncedMarkAsRead,
       user.id,
     ]
   );

--- a/front/components/assistant/conversation/input_bar/InputBar.tsx
+++ b/front/components/assistant/conversation/input_bar/InputBar.tsx
@@ -310,7 +310,7 @@ export const AssistantInputBar = React.memo(function AssistantInputBar({
         .filter((m) => m.conversationId === conversationId)
         .map((m) => m.messageId)
     );
-    mutateConversation();
+    void mutateConversation();
   };
 
   useEffect(() => {

--- a/front/components/poke/PokeConditionalDataTables.tsx
+++ b/front/components/poke/PokeConditionalDataTables.tsx
@@ -1,13 +1,17 @@
 import { Button, Spinner } from "@dust-tt/sparkle";
 import { useState } from "react";
-import type { KeyedMutator } from "swr";
 
+import type { useSWRWithDefaults } from "@app/lib/swr/swr";
 import type { PokeConditionalFetchProps } from "@app/poke/swr/types";
 import type { LightWorkspaceType } from "@app/types";
 
+type MutatorType<TData> = ReturnType<
+  typeof useSWRWithDefaults<string, TData>
+>["mutate"];
+
 interface PokeDataTableConditionalFetchProps<T, M> {
   buttonText?: string;
-  children: (data: T, mutate: KeyedMutator<M>) => React.ReactNode;
+  children: (data: T, mutate: MutatorType<M>) => React.ReactNode;
   globalActions?: React.ReactNode;
   header: string;
   loadOnInit?: boolean;
@@ -17,7 +21,7 @@ interface PokeDataTableConditionalFetchProps<T, M> {
     data: T;
     isError: any;
     isLoading: boolean;
-    mutate: KeyedMutator<M>;
+    mutate: MutatorType<M>;
   };
 }
 

--- a/front/lib/swr/conversations.ts
+++ b/front/lib/swr/conversations.ts
@@ -13,7 +13,10 @@ import {
 } from "@app/lib/swr/swr";
 import datadogLogger from "@app/logger/datadogLogger";
 import type { GetConversationsResponseBody } from "@app/pages/api/w/[wId]/assistant/conversations";
-import type { PatchConversationsRequestBody } from "@app/pages/api/w/[wId]/assistant/conversations/[cId]";
+import type {
+  GetConversationResponseBody,
+  PatchConversationsRequestBody,
+} from "@app/pages/api/w/[wId]/assistant/conversations/[cId]";
 import type { GetConversationFilesResponseBody } from "@app/pages/api/w/[wId]/assistant/conversations/[cId]/files";
 import type { FetchConversationMessageResponse } from "@app/pages/api/w/[wId]/assistant/conversations/[cId]/messages/[mId]";
 import type { FetchConversationParticipantsResponse } from "@app/pages/api/w/[wId]/assistant/conversations/[cId]/participants";
@@ -42,11 +45,11 @@ export function useConversation({
   conversation: ConversationWithoutContentType | null;
   isConversationLoading: boolean;
   conversationError: ConversationError;
-  mutateConversation: () => void;
+  mutateConversation: ReturnType<
+    typeof useSWRWithDefaults<string, GetConversationResponseBody>
+  >["mutate"];
 } {
-  const conversationFetcher: Fetcher<{
-    conversation: ConversationWithoutContentType;
-  }> = fetcher;
+  const conversationFetcher: Fetcher<GetConversationResponseBody> = fetcher;
 
   const { data, error, mutate } = useSWRWithDefaults(
     conversationId

--- a/front/pages/api/w/[wId]/assistant/conversations/[cId]/index.ts
+++ b/front/pages/api/w/[wId]/assistant/conversations/[cId]/index.ts
@@ -31,7 +31,7 @@ export type PatchConversationsRequestBody = t.TypeOf<
   typeof PatchConversationsRequestBodySchema
 >;
 
-export type GetConversationsResponseBody = {
+export type GetConversationResponseBody = {
   conversation: ConversationWithoutContentType;
 };
 
@@ -43,7 +43,7 @@ async function handler(
   req: NextApiRequest,
   res: NextApiResponse<
     WithAPIErrorResponse<
-      GetConversationsResponseBody | PatchConversationResponseBody | void
+      GetConversationResponseBody | PatchConversationResponseBody | void
     >
   >,
   auth: Authenticator

--- a/front/poke/swr/apps.ts
+++ b/front/poke/swr/apps.ts
@@ -1,6 +1,6 @@
 import type { Fetcher } from "swr";
 
-import { fetcher, emptyArray, useSWRWithDefaults } from "@app/lib/swr/swr";
+import { emptyArray, fetcher, useSWRWithDefaults } from "@app/lib/swr/swr";
 import type { PokeListApps } from "@app/pages/api/poke/workspaces/[wId]/apps";
 import type { PokeConditionalFetchProps } from "@app/poke/swr/types";
 


### PR DESCRIPTION
## Description

Fix an issue where the global mutate (used when the hook "fetch" is disabled), ignored the other args leading to ignore optimistic update or revalidation.

## Tests

Local

## Risk

Medium, as big blast radius and might surface bugs regarding stale data that were "invisible" due to the revalidation always happening.

## Deploy Plan

Deploy front