### PR TITLE
[connectors] feat(Gong): add support for account name as a tag

### DIFF
--- a/connectors/migrations/db/migration_97.sql
+++ b/connectors/migrations/db/migration_97.sql
@@ -1,0 +1,2 @@
+-- Migration created on Oct 09, 2025
+ALTER TABLE "public"."gong_configurations" ADD COLUMN "accountsEnabled" BOOLEAN NOT NULL DEFAULT false;

--- a/connectors/src/connectors/gong/index.ts
+++ b/connectors/src/connectors/gong/index.ts
@@ -82,6 +82,7 @@ export class GongConnectorManager extends BaseConnectorManager<null> {
       {
         baseUrl: baseUrlRes.value,
         trackersEnabled: false,
+        accountsEnabled: false,
       }
     );
 

--- a/connectors/src/connectors/gong/lib/gong_api.ts
+++ b/connectors/src/connectors/gong/lib/gong_api.ts
@@ -381,10 +381,12 @@ export class GongClient {
     callIds,
     pageCursor = null,
     trackersEnabled = false,
+    accountsEnabled = false,
   }: {
     callIds: string[];
     pageCursor?: string | null;
     trackersEnabled?: boolean;
+    accountsEnabled?: boolean;
   }): Promise<{
     callsMetadata: GongTranscriptMetadata[];
     nextPageCursor: string | null;
@@ -403,7 +405,7 @@ export class GongClient {
         callIds,
       },
       contentSelector: {
-        context: "Extended",
+        ...(accountsEnabled ? { context: "Extended" } : {}),
         exposedFields: {
           parties: true,
           ...(trackersEnabled ? { content: { trackers: true } } : {}),

--- a/connectors/src/connectors/gong/lib/gong_api.ts
+++ b/connectors/src/connectors/gong/lib/gong_api.ts
@@ -67,6 +67,37 @@ export const GongParticipantCodec = t.intersection([
   CatchAllCodec,
 ]);
 
+const GongContextObjectCodec = t.intersection([
+  t.type({
+    objectType: t.string,
+    objectId: t.union([t.string, t.null]),
+    fields: t.array(
+      t.intersection([
+        t.type({
+          name: t.string,
+          value: t.union([
+            t.string,
+            t.number,
+            t.array(t.number),
+            t.array(t.string),
+            t.null,
+          ]),
+        }),
+        CatchAllCodec,
+      ])
+    ),
+  }),
+  CatchAllCodec,
+]);
+
+const GongContextCodec = t.intersection([
+  t.type({
+    system: t.string,
+    objects: t.array(GongContextObjectCodec),
+  }),
+  CatchAllCodec,
+]);
+
 const GongTranscriptMetadataWithoutTrackersCodec = t.intersection([
   t.type({
     metaData: t.intersection([
@@ -95,6 +126,7 @@ const GongTranscriptMetadataWithoutTrackersCodec = t.intersection([
     ]),
     // Parties are not defined on imported calls.
     parties: t.union([t.array(GongParticipantCodec), t.undefined]),
+    context: t.union([t.array(GongContextCodec), t.undefined]),
   }),
   CatchAllCodec,
 ]);
@@ -371,6 +403,7 @@ export class GongClient {
         callIds,
       },
       contentSelector: {
+        context: "Extended",
         exposedFields: {
           parties: true,
           ...(trackersEnabled ? { content: { trackers: true } } : {}),
@@ -397,7 +430,7 @@ export class GongClient {
             GongTranscriptMetadataWithoutTrackersCodec
           )
         );
-        // Adding empty trackers to the calls metadata to present a uniformed type.
+        // Adding empty trackers to present a uniformed type.
         return {
           callsMetadata: callsMetadata.calls.map((callMetadata) => ({
             ...callMetadata,

--- a/connectors/src/connectors/gong/lib/upserts.ts
+++ b/connectors/src/connectors/gong/lib/upserts.ts
@@ -141,7 +141,7 @@ export async function syncGongTranscript({
         .filter((obj) => obj.objectType === "Account")
         .flatMap((obj) =>
           obj.fields
-            .filter((field) => field.name === "name" && field.value)
+            .filter((field) => field.name === "Name" && field.value)
             .map((field) => `account:${field.value}`)
         )
     ) ?? [];

--- a/connectors/src/connectors/gong/lib/upserts.ts
+++ b/connectors/src/connectors/gong/lib/upserts.ts
@@ -134,6 +134,18 @@ export async function syncGongTranscript({
     (tracker) => `tracker:${tracker.name}`
   );
 
+  // Extract account names from context where objectType === "Account".
+  const accountTags =
+    transcriptMetadata.context?.flatMap((ctx) =>
+      ctx.objects
+        .filter((obj) => obj.objectType === "Account")
+        .flatMap((obj) =>
+          obj.fields
+            .filter((field) => field.name === "name" && field.value)
+            .map((field) => `account:${field.value}`)
+        )
+    ) ?? [];
+
   await upsertDataSourceDocument({
     dataSourceConfig,
     documentId,
@@ -149,6 +161,7 @@ export async function syncGongTranscript({
       `direction:${transcriptMetadata.metaData.direction}`,
       ...participantEmails.map((email) => `participant:${email}`),
       ...trackerTags,
+      ...accountTags,
     ],
     parents: [documentId, makeGongTranscriptFolderInternalId(connector)],
     parentId: makeGongTranscriptFolderInternalId(connector),

--- a/connectors/src/connectors/gong/temporal/activities.ts
+++ b/connectors/src/connectors/gong/temporal/activities.ts
@@ -77,7 +77,7 @@ export async function getTranscriptsMetadata({
   configuration: GongConfigurationResource;
 }): Promise<GongTranscriptMetadata[]> {
   const gongClient = await getGongClient(connector);
-  const { trackersEnabled } = configuration;
+  const { trackersEnabled, accountsEnabled } = configuration;
 
   const metadata = [];
   let cursor = null;
@@ -86,6 +86,7 @@ export async function getTranscriptsMetadata({
       {
         callIds,
         trackersEnabled,
+        accountsEnabled,
       }
     );
     metadata.push(...callsMetadata);

--- a/connectors/src/lib/models/gong.ts
+++ b/connectors/src/lib/models/gong.ts
@@ -13,6 +13,7 @@ export class GongConfigurationModel extends ConnectorBaseModel<GongConfiguration
   declare baseUrl: string;
   declare retentionPeriodDays: number | null;
   declare trackersEnabled: boolean;
+  declare accountsEnabled: boolean;
 }
 
 GongConfigurationModel.init(
@@ -44,6 +45,11 @@ GongConfigurationModel.init(
       allowNull: true,
     },
     trackersEnabled: {
+      type: DataTypes.BOOLEAN,
+      allowNull: false,
+      defaultValue: false,
+    },
+    accountsEnabled: {
       type: DataTypes.BOOLEAN,
       allowNull: false,
       defaultValue: false,


### PR DESCRIPTION
## Description

- Closes https://github.com/dust-tt/tasks/issues/2903.
- This PR adds the account name attached to a Gong transcript as a tag.
- It is opt-in as it requires pulling more data from the API on each call.
- Next step is to add a UI to let users toggle it.

## Tests

- Tested locally.

## Risk

- Low.

## Deploy Plan

- Run migration.
- Deploy connectors.
