### PR TITLE
[sparkle] move blocked items to orange + remove icon

### DIFF
--- a/sparkle/src/components/NavigationList.tsx
+++ b/sparkle/src/components/NavigationList.tsx
@@ -3,7 +3,6 @@ import { cva, type VariantProps } from "class-variance-authority";
 import * as React from "react";
 
 import {
-  Icon,
   LinkWrapper,
   LinkWrapperProps,
   ScrollArea,

--- a/sparkle/src/components/NavigationList.tsx
+++ b/sparkle/src/components/NavigationList.tsx
@@ -82,7 +82,6 @@ const NavigationListItem = React.forwardRef<
       className,
       selected,
       label,
-      icon,
       href,
       target,
       rel,
@@ -107,13 +106,13 @@ const NavigationListItem = React.forwardRef<
         case "unread":
           return "s-bg-highlight-500 dark:s-bg-highlight-500-night";
         case "blocked":
-          return "s-bg-warning-500 dark:s-bg-warning-500-night";
+          return "s-bg-golden-500 dark:s-bg-golden-500-night";
         default:
           return "";
       }
     };
 
-    const shouldShowStatusDot = status === "unread" || status === "blocked";
+    const shouldShowStatusDot = status !== "idle";
 
     return (
       <div
@@ -155,7 +154,6 @@ const NavigationListItem = React.forwardRef<
                 )}
               />
             )}
-            {icon && <Icon visual={icon} size="sm" />}
             {label && (
               <span className="s-grow s-overflow-hidden s-text-ellipsis s-whitespace-nowrap group-hover/menu-item:s-pr-8 group-data-[selected=true]/menu-item:s-pr-8">
                 {label}


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
<img width="1098" height="674" alt="Capture d’écran 2025-10-09 à 11 21 51" src="https://github.com/user-attachments/assets/92cd4379-db8e-42d2-9641-954fd5165f88" />

This PR uniformizes sparkle NavigationListItem use to remove the icon that was used only for actionRequired in the front code, and move the "blocked" items to golden dots following discussion in #design.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

Tested by hand

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->

Release sparkle