### PR TITLE
Update wordings for Business plan now called Enteprise seat based

### DIFF
--- a/front/lib/api/poke/plugins/global/create_workspace.ts
+++ b/front/lib/api/poke/plugins/global/create_workspace.ts
@@ -26,8 +26,9 @@ export const createWorkspacePlugin = createPlugin({
       },
       isBusiness: {
         type: "boolean",
-        label: "Is Business",
-        description: "Is the workspace a business workspace (Pro plan 39€)",
+        label: "Whitelist workspace for Enterprise seat based plan",
+        description:
+          "Workspace will subscribe to Enterprise seat based plan (45€/$/£) when doing their Stripe checkout session.",
       },
       planCode: {
         type: "string",

--- a/front/lib/api/poke/plugins/workspaces/upgrade_to_business_plan.ts
+++ b/front/lib/api/poke/plugins/workspaces/upgrade_to_business_plan.ts
@@ -5,20 +5,25 @@ import { Err, Ok } from "@app/types";
 export const upgradeToBusinessPlan = createPlugin({
   manifest: {
     id: "upgrade-to-business-plan",
-    name: "Upgrade to Business Plan",
-    description: "Upgrade workspace to business plan (Pro plan 39€).",
+    name: "Whitelist workspace for Enterprise seat based plan",
+    description:
+      "Workspace will be able to subscribe to Enterprise seat based plan (45€/$/£) when doing their Stripe checkout session.",
     resourceTypes: ["workspaces"],
     args: {
       confirm: {
         type: "boolean",
         label: "Confirm",
-        description: "Confirm updating to business plan.",
+        description: "Confirm whitelisting for Enterprise seat based plan.",
       },
     },
   },
   execute: async (auth, _, args) => {
     if (!args.confirm) {
-      return new Err(new Error("Please confirm the upgrade to business plan."));
+      return new Err(
+        new Error(
+          "Please confirm the whitelisting for Enterprise seat based plan."
+        )
+      );
     }
 
     const workspace = auth.getNonNullableWorkspace();
@@ -29,7 +34,7 @@ export const upgradeToBusinessPlan = createPlugin({
 
     return new Ok({
       display: "text",
-      value: `Workspace ${workspace.name} upgrade to business plan.`,
+      value: `Workspace ${workspace.name} whitelisted for Enterprise seat based plan.`,
     });
   },
 });


### PR DESCRIPTION
## Description

The business plan (not self-serve) is now called "Enterprise seat-based" in GTM team, updating wording in poké to clarify this for them. 

## Tests

Locally. 


## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

Deploy front. 