### PR TITLE
tweak instructions for the confluence search tool

### DIFF
--- a/front/lib/actions/mcp_internal_actions/servers/confluence/server.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/confluence/server.ts
@@ -39,7 +39,7 @@ const createServer = (): McpServer => {
 
   server.tool(
     "get_pages",
-    "Search for Confluence pages using CQL (Confluence Query Language). Only returns page objects. Examples: 'type=page AND space=DEV', 'type=page AND title~\"meeting\"', 'type=page AND creator=currentUser()'",
+    "Search for Confluence pages using CQL (Confluence Query Language). Only returns page objects. Supports flexible text matching: use '~' for contains (title~\"meeting\"), '!~' for not contains, or '=' for exact match. Examples: 'type=page AND space=DEV', 'type=page AND title~\"meeting notes\"', 'type=page AND text~\"quarterly\"', 'type=page AND creator=currentUser()'",
     {
       cql: z
         .string()


### PR DESCRIPTION
## Description

update instructions to nudge the model into searching with other operators than `=`

## Tests

locally

## Risk

none

## Deploy Plan

front only
