### PR TITLE
Opt: cacheWithRedis re-use the same client

### DIFF
--- a/front/lib/api/redis.ts
+++ b/front/lib/api/redis.ts
@@ -22,6 +22,7 @@ export type RedisUsageTagsType =
   | "reasoning_generation"
   | "retry_agent_message"
   | "update_authors"
+  | "cache_with_redis"
   | "user_message_events";
 
 export async function getRedisClient({

--- a/front/lib/swr/mcp_servers.ts
+++ b/front/lib/swr/mcp_servers.ts
@@ -1178,8 +1178,8 @@ function useMCPServerViewsFromSpacesBase(
 
   const url = `/api/w/${owner.sId}/mcp/views?spaceIds=${spaceIds}&availabilities=${availabilitiesParam}`;
   const { data, error, mutate } = useSWRWithDefaults(url, configFetcher, {
-    disabled: !spaces.length,
     ...swrOptions,
+    ...(!spaces.length ? { disabled: true } : {}),
   });
 
   return {

--- a/front/lib/utils/cache.ts
+++ b/front/lib/utils/cache.ts
@@ -1,5 +1,5 @@
+import { getRedisClient } from "@app/lib/api/redis";
 import { distributedLock, distributedUnlock } from "@app/lib/lock";
-import { redisClient } from "@app/lib/utils/redis_client";
 
 // JSON-serializable primitive types.
 type JsonPrimitive = string | number | boolean | null;
@@ -69,66 +69,56 @@ export function cacheWithRedis<T, Args extends unknown[]>(
       }
       redisUri = REDIS_CACHE_URI;
     }
-    let redisCli: Awaited<ReturnType<typeof redisClient>> | undefined =
-      undefined;
 
     const key = getCacheKey(fn, resolver, args);
 
+    const redisCli = await getRedisClient({ origin: "cache_with_redis" });
+
+    let cacheVal = await redisCli.get(key);
+    if (cacheVal) {
+      return JSON.parse(cacheVal) as JsonSerializable<T>;
+    }
+
+    // specific try-finally to ensure unlock is called only after lock
+    let lockValue: string | undefined;
     try {
-      redisCli = await redisClient({
-        origin: "cache_with_redis",
-        redisUri,
-      });
-      let cacheVal = await redisCli.get(key);
+      // if value not found, lock, recheck and set
+      // we avoid locking for the first read to allow parallel calls to redis if the value is set
+      if (useDistributedLock) {
+        while (!lockValue) {
+          lockValue = await distributedLock(redisCli, key);
+
+          if (!lockValue) {
+            // If lock is not acquired, wait and retry.
+            await new Promise((resolve) => setTimeout(resolve, 100));
+            // Check first if value was set while we were waiting.
+            // Most likely, the value will be set by the lock owner when it's done.
+            cacheVal = await redisCli.get(key);
+            if (cacheVal) {
+              return JSON.parse(cacheVal) as JsonSerializable<T>;
+            }
+          }
+        }
+      } else {
+        await lock(key);
+      }
+      cacheVal = await redisCli.get(key);
       if (cacheVal) {
         return JSON.parse(cacheVal) as JsonSerializable<T>;
       }
 
-      // specific try-finally to ensure unlock is called only after lock
-      let lockValue: string | undefined;
-      try {
-        // if value not found, lock, recheck and set
-        // we avoid locking for the first read to allow parallel calls to redis if the value is set
-        if (useDistributedLock) {
-          while (!lockValue) {
-            lockValue = await distributedLock(redisCli, key);
-
-            if (!lockValue) {
-              // If lock is not acquired, wait and retry.
-              await new Promise((resolve) => setTimeout(resolve, 100));
-              // Check first if value was set while we were waiting.
-              // Most likely, the value will be set by the lock owner when it's done.
-              cacheVal = await redisCli.get(key);
-              if (cacheVal) {
-                return JSON.parse(cacheVal) as JsonSerializable<T>;
-              }
-            }
-          }
-        } else {
-          await lock(key);
-        }
-        cacheVal = await redisCli.get(key);
-        if (cacheVal) {
-          return JSON.parse(cacheVal) as JsonSerializable<T>;
-        }
-
-        const result = await fn(...args);
-        await redisCli.set(key, JSON.stringify(result), {
-          PX: ttlMs,
-        });
-        return result;
-      } finally {
-        if (useDistributedLock) {
-          if (lockValue) {
-            await distributedUnlock(redisCli, key, lockValue);
-          }
-        } else {
-          unlock(key);
-        }
-      }
+      const result = await fn(...args);
+      await redisCli.set(key, JSON.stringify(result), {
+        PX: ttlMs,
+      });
+      return result;
     } finally {
-      if (redisCli) {
-        await redisCli.quit();
+      if (useDistributedLock) {
+        if (lockValue) {
+          await distributedUnlock(redisCli, key, lockValue);
+        }
+      } else {
+        unlock(key);
       }
     }
   };
@@ -150,15 +140,9 @@ export function invalidateCacheWithRedis<T, Args extends unknown[]>(
       }
       redisUri = REDIS_CACHE_URI;
     }
-    let redisCli: Awaited<ReturnType<typeof redisClient>> | undefined =
-      undefined;
+    const redisCli = await getRedisClient({ origin: "cache_with_redis" });
 
     const key = getCacheKey(fn, resolver, args);
-    redisCli = await redisClient({
-      origin: "cache_with_redis",
-      redisUri,
-    });
-
     await redisCli.del(key);
   };
 }

--- a/front/vite.setup.ts
+++ b/front/vite.setup.ts
@@ -13,6 +13,15 @@ beforeEach(async (c) => {
 
   // Mock Redis
   vi.mock("@app/lib/api/redis", () => ({
+    getRedisClient: vi.fn().mockResolvedValue({
+      get: vi.fn(),
+      set: vi.fn(),
+      ttl: vi.fn(),
+      zAdd: vi.fn(),
+      expire: vi.fn(),
+      zRange: vi.fn(),
+      hGetAll: vi.fn().mockResolvedValue([]),
+    }),
     runOnRedis: vi
       .fn()
       .mockImplementation(


### PR DESCRIPTION
## Description

Noticed by investigating performance of an endpoint (via trace) that we were strangely connecting and disconnecting from redis too much :)
Fix cacheWithRedis to re-use the shared redis client.

## Tests

Local

## Risk

Low

## Deploy Plan

Deploy front