### PR TITLE
`configurable: boolean` -> `canBeConfigured`

### DIFF
--- a/front/components/agent_builder/AgentBuilderFormContext.tsx
+++ b/front/components/agent_builder/AgentBuilderFormContext.tsx
@@ -100,7 +100,7 @@ const baseActionSchema = z.object({
   id: z.string(),
   name: z.string(),
   description: z.string(),
-  configurable: z.boolean().optional(),
+  canBeConfigured: z.boolean().optional(),
 });
 
 const TAG_KINDS = z.union([z.literal("standard"), z.literal("protected")]);

--- a/front/components/agent_builder/capabilities/AgentBuilderCapabilitiesBlock.tsx
+++ b/front/components/agent_builder/capabilities/AgentBuilderCapabilitiesBlock.tsx
@@ -204,7 +204,7 @@ export function AgentBuilderCapabilitiesBlock({
       setKnowledgeAction({ action, index });
     } else {
       setDialogMode(
-        action.configurable
+        action.canBeConfigured
           ? { type: "edit", action, index }
           : { type: "info", action, source: "addedTool" }
       );
@@ -227,7 +227,7 @@ export function AgentBuilderCapabilitiesBlock({
     setKnowledgeAction({
       action: {
         ...action,
-        configurable: true, // it's always required for knowledge
+        canBeConfigured: true, // it's always required for knowledge
       },
       index: null,
     });

--- a/front/components/agent_builder/capabilities/mcp/MCPServerSelectionPage.tsx
+++ b/front/components/agent_builder/capabilities/mcp/MCPServerSelectionPage.tsx
@@ -56,8 +56,11 @@ function MCPServerCard({
   onToolInfoClick,
   featureFlags,
 }: MCPServerCardProps) {
-  const requirement = getMCPServerToolsConfigurations(view, featureFlags);
-  const canAdd = requirement.configurable !== "no" ? true : !isSelected;
+  const toolsConfigurations = getMCPServerToolsConfigurations(
+    view,
+    featureFlags
+  );
+  const canAdd = toolsConfigurations.configurable !== "no" ? true : !isSelected;
 
   const icon = isCustomResourceIconType(view.server.icon)
     ? ActionIcons[view.server.icon]

--- a/front/components/agent_builder/capabilities/mcp/MCPServerViewsSheet.tsx
+++ b/front/components/agent_builder/capabilities/mcp/MCPServerViewsSheet.tsx
@@ -192,7 +192,7 @@ export function MCPServerViewsSheet({
           action.type === "MCP" &&
           action.configuration &&
           action.configuration.mcpServerViewId &&
-          !action.configurable
+          !action.canBeConfigured
         ) {
           const selectedView = allMcpServerViews.find(
             (mcpServerView) =>
@@ -501,7 +501,7 @@ export function MCPServerViewsSheet({
             configuration: null,
             name: DEFAULT_DATA_VISUALIZATION_NAME,
             description: DEFAULT_DATA_VISUALIZATION_DESCRIPTION,
-            configurable: false,
+            canBeConfigured: false,
           };
         } else {
           // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
@@ -634,7 +634,7 @@ export function MCPServerViewsSheet({
           <FormProvider form={form} className="h-full">
             <div className="h-full">
               <div className="h-full space-y-6 pt-3">
-                {configurationTool.configurable && (
+                {configurationTool.canBeConfigured && (
                   <NameSection
                     title="Name"
                     placeholder="My tool name…"

--- a/front/components/agent_builder/capabilities/usePresetActionHandler.ts
+++ b/front/components/agent_builder/capabilities/usePresetActionHandler.ts
@@ -106,7 +106,7 @@ export function usePresetActionHandler({
 
     if (isKnowledgeTemplateAction(presetActionToAdd)) {
       setKnowledgeAction({
-        action: { ...action, configurable: false },
+        action: { ...action, canBeConfigured: false },
         index: null,
         presetData: presetActionToAdd,
       });

--- a/front/components/agent_builder/get_spaceid_to_actions_map.test.ts
+++ b/front/components/agent_builder/get_spaceid_to_actions_map.test.ts
@@ -16,7 +16,7 @@ const createMockAction = (
   configuration: null,
   name,
   description: `Description for ${name}`,
-  configurable: false,
+  canBeConfigured: false,
 });
 
 const createMockMCPAction = (
@@ -44,7 +44,7 @@ const createMockMCPAction = (
     _jsonSchemaString: null,
     secretName: null,
   },
-  configurable: true,
+  canBeConfigured: true,
 });
 
 const createMockMCPServerView = (

--- a/front/components/agent_builder/types.ts
+++ b/front/components/agent_builder/types.ts
@@ -192,7 +192,7 @@ export function getDefaultMCPAction(
         : mcpServerView
           ? getMcpServerViewDescription(mcpServerView)
           : "",
-    configurable: toolsConfigurations.configurable !== "no",
+    canBeConfigured: toolsConfigurations.configurable !== "no",
   };
 }
 

--- a/front/components/assistant_builder/types.ts
+++ b/front/components/assistant_builder/types.ts
@@ -45,7 +45,7 @@ export type AssistantBuilderMCPConfiguration = {
   configuration: AssistantBuilderMCPServerConfiguration;
   name: string;
   description: string;
-  configurable?: boolean;
+  canBeConfigured?: boolean;
 };
 
 export type AssistantBuilderMCPConfigurationWithId =
@@ -58,7 +58,7 @@ export interface AssistantBuilderDataVisualizationConfiguration {
   configuration: null;
   name: string;
   description: string;
-  configurable: false;
+  canBeConfigured: false;
 }
 
 // DATA_VISUALIZATION is not an action, but we need to show it in the UI like an action.
@@ -105,7 +105,7 @@ export function getDataVisualizationConfiguration(): AssistantBuilderDataVisuali
     configuration: null,
     name: DEFAULT_DATA_VISUALIZATION_NAME,
     description: DEFAULT_DATA_VISUALIZATION_DESCRIPTION,
-    configurable: false,
+    canBeConfigured: false,
   } satisfies AssistantBuilderDataVisualizationConfiguration;
 }
 
@@ -139,7 +139,7 @@ export function getDefaultMCPServerActionConfiguration(
         : mcpServerView
           ? getMcpServerViewDescription(mcpServerView)
           : "",
-    configurable: toolsConfigurations.configurable !== "no",
+    canBeConfigured: toolsConfigurations.configurable !== "no",
   };
 }
 


### PR DESCRIPTION
## Description

Mass rename, copy of this https://github.com/dust-tt/dust/pull/16563 but with missing changes fixed.

## Tests

Tested locally against the errors we had with the previous PR (cf. https://dust4ai.slack.com/archives/C050SM8NSPK/p1759939924067759)

## Risk

If problem persists or there are others, could break the Agent Builder

## Deploy Plan

Deploy front-edge, then to front.
