### PR TITLE
Only allow custom icon for custom preset in triggers

### DIFF
--- a/front/components/triggers/WebhookSourceDetailsInfo.tsx
+++ b/front/components/triggers/WebhookSourceDetailsInfo.tsx
@@ -107,6 +107,8 @@ export function WebhookSourceDetailsInfo({
     webhookSourceView.webhookSource.urlSecret,
   ]);
 
+  const isCustomKind = webhookSourceView.webhookSource.kind === "custom";
+
   return (
     <div className="flex flex-col gap-2">
       {editedLabel !== null && (
@@ -117,7 +119,9 @@ export function WebhookSourceDetailsInfo({
 
       <div className="space-y-5 text-foreground dark:text-foreground-night">
         <div className="space-y-2">
-          <Label htmlFor="trigger-name-icon">Name & Icon</Label>
+          <Label htmlFor="trigger-name-icon">
+            {isCustomKind ? "Name & Icon" : "Name"}
+          </Label>
           <div className="flex items-end space-x-2">
             <div className="flex-grow">
               <Input
@@ -128,31 +132,33 @@ export function WebhookSourceDetailsInfo({
                 placeholder={webhookSourceView.webhookSource.name}
               />
             </div>
-            <PopoverRoot open={isPopoverOpen}>
-              <PopoverTrigger asChild>
-                <Button
-                  variant="outline"
-                  size="sm"
-                  icon={IconComponent}
-                  onClick={() => setIsPopoverOpen(true)}
-                  isSelect
-                />
-              </PopoverTrigger>
-              <PopoverContent
-                className="w-fit py-0"
-                onInteractOutside={() => setIsPopoverOpen(false)}
-                onEscapeKeyDown={() => setIsPopoverOpen(false)}
-              >
-                <IconPicker
-                  icons={ActionIcons}
-                  selectedIcon={selectedIcon ?? DEFAULT_WEBHOOK_ICON}
-                  onIconSelect={(iconName: string) => {
-                    form.setValue("icon", iconName, { shouldDirty: true });
-                    setIsPopoverOpen(false);
-                  }}
-                />
-              </PopoverContent>
-            </PopoverRoot>
+            {isCustomKind && (
+              <PopoverRoot open={isPopoverOpen}>
+                <PopoverTrigger asChild>
+                  <Button
+                    variant="outline"
+                    size="sm"
+                    icon={IconComponent}
+                    onClick={() => setIsPopoverOpen(true)}
+                    isSelect
+                  />
+                </PopoverTrigger>
+                <PopoverContent
+                  className="w-fit py-0"
+                  onInteractOutside={() => setIsPopoverOpen(false)}
+                  onEscapeKeyDown={() => setIsPopoverOpen(false)}
+                >
+                  <IconPicker
+                    icons={ActionIcons}
+                    selectedIcon={selectedIcon ?? DEFAULT_WEBHOOK_ICON}
+                    onIconSelect={(iconName: string) => {
+                      form.setValue("icon", iconName, { shouldDirty: true });
+                      setIsPopoverOpen(false);
+                    }}
+                  />
+                </PopoverContent>
+              </PopoverRoot>
+            )}
           </div>
         </div>
 


### PR DESCRIPTION
## Description

Only custom preset should allow custom Icon, otherwise use the preset icon

<img width="550" height="400" alt="image" src="https://github.com/user-attachments/assets/1f6d978f-f04a-4c54-8f52-9a2973cb99e2" />


<img width="550" height="400" alt="image" src="https://github.com/user-attachments/assets/20d9ce0b-6ecc-4c9c-8374-842742a001d2" />

close https://github.com/dust-tt/tasks/issues/4574


## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

deploy front