### PR TITLE
[connectors,front] feat(Gong): add UI for toggling account sync

### DIFF
--- a/connectors/src/connectors/gong/index.ts
+++ b/connectors/src/connectors/gong/index.ts
@@ -43,6 +43,8 @@ const RETENTION_PERIOD_CONFIG_KEY = "gongRetentionPeriodDays";
 
 const TRACKERS_CONFIG_KEY = "gongTrackersEnabled";
 
+const ACCOUNTS_CONFIG_KEY = "gongAccountsEnabled";
+
 // This function generates a connector-wise unique schedule ID for the Gong sync.
 // The IDs of the workflows spawned by this schedule will follow the pattern:
 //   gong-sync-${connectorId}-workflow-${isoFormatDate}
@@ -295,6 +297,8 @@ export class GongConnectorManager extends BaseConnectorManager<null> {
         return new Ok(configuration.retentionPeriodDays?.toString() || null);
       case TRACKERS_CONFIG_KEY:
         return new Ok(configuration.trackersEnabled.toString());
+      case ACCOUNTS_CONFIG_KEY:
+        return new Ok(configuration.accountsEnabled.toString());
       default:
         return new Err(new Error(`Invalid config key ${configKey}`));
     }
@@ -346,6 +350,11 @@ export class GongConnectorManager extends BaseConnectorManager<null> {
       }
       case TRACKERS_CONFIG_KEY: {
         await configuration.setTrackersEnabled(configValue === "true");
+
+        return new Ok(undefined);
+      }
+      case ACCOUNTS_CONFIG_KEY: {
+        await configuration.setAccountsEnabled(configValue === "true");
 
         return new Ok(undefined);
       }

--- a/connectors/src/resources/gong_resources.ts
+++ b/connectors/src/resources/gong_resources.ts
@@ -109,6 +109,12 @@ export class GongConfigurationResource extends BaseResource<GongConfigurationMod
     });
   }
 
+  async setAccountsEnabled(accountsEnabled: boolean): Promise<void> {
+    await this.update({
+      accountsEnabled,
+    });
+  }
+
   async resetLastSyncTimestamp(): Promise<void> {
     await this.update({
       lastSyncTimestamp: null,

--- a/front/components/data_source/gong/GongOptionComponent.tsx
+++ b/front/components/data_source/gong/GongOptionComponent.tsx
@@ -43,6 +43,7 @@ export function GongOptionComponent({
     dataSource,
     configKey: GONG_RETENTION_PERIOD_CONFIG_KEY,
   });
+
   const {
     configValue: trackersConfigValue,
     mutateConfig: mutateTrackersConfig,

--- a/front/pages/api/w/[wId]/data_sources/[dsId]/managed/config/[key]/index.ts
+++ b/front/pages/api/w/[wId]/data_sources/[dsId]/managed/config/[key]/index.ts
@@ -92,6 +92,7 @@ async function handler(
       "zendeskCustomFieldsConfig",
       "gongRetentionPeriodDays",
       "gongTrackersEnabled",
+      "gongAccountsEnabled",
       "privateIntegrationCredentialId",
     ].includes(configKey)
   ) {


### PR DESCRIPTION
## Description

- Follow up on https://github.com/dust-tt/dust/pull/16676.
- This PR adds a toggle to enable/disable Gong account name sync.

## Tests

- Checked locally.

## Risk

- Low.

## Deploy Plan

- Deploy connectors.
- Deploy front.
