### PR TITLE
Redirect legacy /share/file/ URLs to /share/frame/

### DIFF
--- a/front/pages/share/file/[token].tsx
+++ b/front/pages/share/file/[token].tsx
@@ -1,24 +1,10 @@
-import Head from "next/head";
-
-import { PublicInteractiveContentContainer } from "@app/components/assistant/conversation/interactive_content/PublicInteractiveContentContainer";
-import config from "@app/lib/api/config";
-import { formatFilenameForDisplay } from "@app/lib/files";
 import { makeGetServerSidePropsRequirementsWrapper } from "@app/lib/iam/session";
 import { FileResource } from "@app/lib/resources/file_resource";
-import { WorkspaceResource } from "@app/lib/resources/workspace_resource";
-import { getFaviconPath } from "@app/lib/utils";
-
-interface SharedFilePageProps {
-  shareUrl: string;
-  title: string;
-  token: string;
-  workspaceName: string;
-  workspaceId: string;
-}
+import { frameContentType } from "@app/types/files";
 
 export const getServerSideProps = makeGetServerSidePropsRequirementsWrapper({
   requireUserPrivilege: "none",
-})<SharedFilePageProps>(async (context) => {
+})(async (context) => {
   if (!context.params) {
     return {
       notFound: true,
@@ -32,7 +18,7 @@ export const getServerSideProps = makeGetServerSidePropsRequirementsWrapper({
     };
   }
 
-  // Fetch the file by token to determine scope.
+  // Fetch the file by token to check the type.
   const result = await FileResource.fetchByShareTokenWithContent(token);
   if (!result) {
     return {
@@ -41,88 +27,17 @@ export const getServerSideProps = makeGetServerSidePropsRequirementsWrapper({
   }
 
   const { file } = result;
-  const workspace = await WorkspaceResource.fetchByModelId(file.workspaceId);
-  if (!workspace) {
+  if (file.contentType === frameContentType) {
+    // Redirect to the new frame route.
     return {
-      notFound: true,
+      redirect: {
+        destination: `/share/frame/${token}`,
+        permanent: true,
+      },
     };
   }
 
-  // Note: We don't protect workspace sharing here - protection happens at the API level.
-  // This allows the page to load but the content API call will fail if unauthorized.
-
-  const shareUrl = `${config.getClientFacingUrl()}${context.req.url}`;
-
   return {
-    props: {
-      shareUrl,
-      title: file.fileName,
-      token,
-      workspaceName: workspace.name,
-      workspaceId: workspace.sId,
-    },
+    notFound: true,
   };
 });
-
-export default function SharedFilePage({
-  shareUrl,
-  title,
-  token,
-  workspaceName,
-  workspaceId,
-}: SharedFilePageProps) {
-  const humanFriendlyTitle = formatFilenameForDisplay(title);
-  const faviconPath = getFaviconPath();
-  const description = `Discover what ${workspaceName} built with AI. Explore now.`;
-
-  return (
-    <>
-      <Head>
-        {/* Basic meta tags */}
-        <title>{humanFriendlyTitle} - Powered by Dust</title>
-        <meta name="description" content={description} />
-
-        {/* Prevent search engine indexing */}
-        <meta
-          name="robots"
-          content="noindex, nofollow, noarchive, nosnippet, noimageindex"
-        />
-        <meta
-          name="googlebot"
-          content="noindex, nofollow, noarchive, nosnippet, noimageindex"
-        />
-        <meta
-          name="bingbot"
-          content="noindex, nofollow, noarchive, nosnippet, noimageindex"
-        />
-
-        {/* Open Graph meta tags */}
-        <meta property="og:type" content="website" />
-        <meta
-          property="og:title"
-          content={`${humanFriendlyTitle} - ${workspaceName}`}
-        />
-        <meta property="og:description" content={description} />
-        <meta property="og:image:height" content="630" />
-        <meta property="og:image:width" content="1200" />
-        <meta property="og:image" content="https://dust.tt/static/og/ic.png" />
-        <meta property="og:site_name" content="Dust" />
-        <meta property="og:type" content="website" />
-        <meta property="og:url" content={shareUrl} />
-        <meta
-          property="og:image:alt"
-          content={`Preview of ${humanFriendlyTitle} created by ${workspaceName}`}
-        />
-
-        {/* Favicon */}
-        <link rel="icon" type="image/png" href={faviconPath} />
-      </Head>
-      <div className="h-dvh flex w-full">
-        <PublicInteractiveContentContainer
-          shareToken={token}
-          workspaceId={workspaceId}
-        />
-      </div>
-    </>
-  );
-}

--- a/front/pages/share/frame/[token].tsx
+++ b/front/pages/share/frame/[token].tsx
@@ -1,0 +1,128 @@
+import Head from "next/head";
+
+import { PublicInteractiveContentContainer } from "@app/components/assistant/conversation/interactive_content/PublicInteractiveContentContainer";
+import config from "@app/lib/api/config";
+import { formatFilenameForDisplay } from "@app/lib/files";
+import { makeGetServerSidePropsRequirementsWrapper } from "@app/lib/iam/session";
+import { FileResource } from "@app/lib/resources/file_resource";
+import { WorkspaceResource } from "@app/lib/resources/workspace_resource";
+import { getFaviconPath } from "@app/lib/utils";
+
+interface SharedFilePageProps {
+  shareUrl: string;
+  title: string;
+  token: string;
+  workspaceName: string;
+  workspaceId: string;
+}
+
+export const getServerSideProps = makeGetServerSidePropsRequirementsWrapper({
+  requireUserPrivilege: "none",
+})<SharedFilePageProps>(async (context) => {
+  if (!context.params) {
+    return {
+      notFound: true,
+    };
+  }
+
+  const { token } = context.params;
+  if (!token || typeof token !== "string") {
+    return {
+      notFound: true,
+    };
+  }
+
+  // Fetch the file by token to determine scope.
+  const result = await FileResource.fetchByShareTokenWithContent(token);
+  if (!result) {
+    return {
+      notFound: true,
+    };
+  }
+
+  const { file } = result;
+  const workspace = await WorkspaceResource.fetchByModelId(file.workspaceId);
+  if (!workspace) {
+    return {
+      notFound: true,
+    };
+  }
+
+  // Note: We don't protect workspace sharing here - protection happens at the API level.
+  // This allows the page to load but the content API call will fail if unauthorized.
+
+  const shareUrl = `${config.getClientFacingUrl()}${context.req.url}`;
+
+  return {
+    props: {
+      shareUrl,
+      title: file.fileName,
+      token,
+      workspaceName: workspace.name,
+      workspaceId: workspace.sId,
+    },
+  };
+});
+
+export default function SharedFilePage({
+  shareUrl,
+  title,
+  token,
+  workspaceName,
+  workspaceId,
+}: SharedFilePageProps) {
+  const humanFriendlyTitle = formatFilenameForDisplay(title);
+  const faviconPath = getFaviconPath();
+  const description = `Discover what ${workspaceName} built with AI. Explore now.`;
+
+  return (
+    <>
+      <Head>
+        {/* Basic meta tags */}
+        <title>{humanFriendlyTitle} - Powered by Dust</title>
+        <meta name="description" content={description} />
+
+        {/* Prevent search engine indexing */}
+        <meta
+          name="robots"
+          content="noindex, nofollow, noarchive, nosnippet, noimageindex"
+        />
+        <meta
+          name="googlebot"
+          content="noindex, nofollow, noarchive, nosnippet, noimageindex"
+        />
+        <meta
+          name="bingbot"
+          content="noindex, nofollow, noarchive, nosnippet, noimageindex"
+        />
+
+        {/* Open Graph meta tags */}
+        <meta property="og:type" content="website" />
+        <meta
+          property="og:title"
+          content={`${humanFriendlyTitle} - ${workspaceName}`}
+        />
+        <meta property="og:description" content={description} />
+        <meta property="og:image:height" content="630" />
+        <meta property="og:image:width" content="1200" />
+        <meta property="og:image" content="https://dust.tt/static/og/ic.png" />
+        <meta property="og:site_name" content="Dust" />
+        <meta property="og:type" content="website" />
+        <meta property="og:url" content={shareUrl} />
+        <meta
+          property="og:image:alt"
+          content={`Preview of ${humanFriendlyTitle} created by ${workspaceName}`}
+        />
+
+        {/* Favicon */}
+        <link rel="icon" type="image/png" href={faviconPath} />
+      </Head>
+      <div className="h-dvh flex w-full">
+        <PublicInteractiveContentContainer
+          shareToken={token}
+          workspaceId={workspaceId}
+        />
+      </div>
+    </>
+  );
+}


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
  - Updates legacy /share/file/[token] route to redirect to /share/frame/[token] for frame content types
  - Maintains backward compatibility by checking file type before redirecting
  - Returns 404 for non-frame content types on the legacy route

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
