### PR TITLE
feat(front): add download button for audio files

### DIFF
--- a/front/components/assistant/conversation/attachment/AttachmentViewer.tsx
+++ b/front/components/assistant/conversation/attachment/AttachmentViewer.tsx
@@ -1,4 +1,5 @@
 import {
+  Button,
   Dialog,
   DialogContainer,
   DialogContent,
@@ -7,12 +8,14 @@ import {
   DialogTitle,
   Spinner,
 } from "@dust-tt/sparkle";
+import { DownloadIcon } from "lucide-react";
 import React, { useEffect, useMemo, useState } from "react";
 
 import type { FileAttachmentCitation } from "@app/components/assistant/conversation/attachment/types";
 import { isAudioContentType } from "@app/components/assistant/conversation/attachment/utils";
 import type { FileUploaderService } from "@app/hooks/useFileUploaderService";
 import {
+  getFileDownloadUrl,
   getFileViewUrl,
   useFileContent,
   useFileProcessedContent,
@@ -104,7 +107,7 @@ export const AttachmentViewer = ({
       );
     };
 
-    // ok to not await, we handle loading state with isLoading, and if it fails the text will just not show
+    // ok to not await, we handle loading state with isLoading, and if it fails, the text will just not show
     void handleText();
   }, [
     attachmentCitation,
@@ -127,11 +130,32 @@ export const AttachmentViewer = ({
     </>
   );
 
+  const onClickDownload = () => {
+    const downloadUrl =
+      isAudio && fileId ? getFileDownloadUrl(owner, fileId) : undefined;
+
+    if (downloadUrl) {
+      window.open(downloadUrl, "_blank");
+    }
+  };
+
   return (
     <Dialog open={viewerOpen} onOpenChange={setViewerOpen}>
       <DialogContent size="xl" height="lg">
         <DialogHeader>
-          <DialogTitle>{attachmentCitation.title}</DialogTitle>
+          <DialogTitle>
+            {isAudio && (
+              <Button
+                onClick={onClickDownload}
+                icon={DownloadIcon}
+                size="mini"
+                tooltip="Download audio file"
+                variant="ghost"
+                className={"mr-2 align-middle"}
+              />
+            )}
+            {attachmentCitation.title}
+          </DialogTitle>
         </DialogHeader>
         <DialogContainer>
           {isLoading && (

--- a/front/lib/swr/files.ts
+++ b/front/lib/swr/files.ts
@@ -30,6 +30,9 @@ export const getProcessedFileDownloadUrl = (
   fileId: string
 ) => `/api/w/${owner.sId}/files/${fileId}?action=download&version=processed`;
 
+export const getFileDownloadUrl = (owner: LightWorkspaceType, fileId: string) =>
+  `/api/w/${owner.sId}/files/${fileId}?action=download`;
+
 export const getFileViewUrl = (
   owner: LightWorkspaceType,
   fileId: string | null | undefined


### PR DESCRIPTION
## Description

Add a download button on audio files, so we can also get them

<img width="862" height="364" alt="image" src="https://github.com/user-attachments/assets/9b55bf6d-36a4-410b-bde2-9fbf2c7cd6f7" />
## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
