### PR TITLE
[HOOTL] Filter out events in webhook endpoint

### DIFF
--- a/front/types/triggers/github_webhook_source_presets.ts
+++ b/front/types/triggers/github_webhook_source_presets.ts
@@ -515,7 +515,7 @@ const GITHUB_ISSUES_EVENT: WebhookEvent = {
 export const GITHUB_WEBHOOK_PRESET: PresetWebhook = {
   name: "GitHub",
   eventCheck: {
-    type: "header",
+    type: "headers",
     field: "X-GitHub-Event",
   },
   events: [GITHUB_PULL_REQUEST_EVENT, GITHUB_ISSUES_EVENT],

--- a/front/types/triggers/test_webhook_source_presets.ts
+++ b/front/types/triggers/test_webhook_source_presets.ts
@@ -26,7 +26,7 @@ const TEST_EVENT: WebhookEvent = {
 export const TEST_WEBHOOK_PRESET: PresetWebhook = {
   name: "Test",
   eventCheck: {
-    type: "header",
+    type: "headers",
     field: "event-type",
   },
   events: [TEST_EVENT],

--- a/front/types/triggers/webhooks.ts
+++ b/front/types/triggers/webhooks.ts
@@ -10,9 +10,9 @@ import type { AgentsUsageType } from "@app/types/data_source";
 import type { WhitelistableFeature } from "@app/types/shared/feature_flags";
 import type { ModelId } from "@app/types/shared/model_id";
 import { GITHUB_WEBHOOK_PRESET } from "@app/types/triggers/github_webhook_source_presets";
+import { TEST_WEBHOOK_PRESET } from "@app/types/triggers/test_webhook_source_presets";
 import type { PresetWebhook } from "@app/types/triggers/webhooks_source_preset";
 import type { EditedByUser } from "@app/types/user";
-import { TEST_WEBHOOK_PRESET } from "@app/types/triggers/test_webhook_source_presets";
 
 export const WEBHOOK_SOURCE_SIGNATURE_ALGORITHMS = [
   "sha1",

--- a/front/types/triggers/webhooks_source_preset.ts
+++ b/front/types/triggers/webhooks_source_preset.ts
@@ -25,7 +25,7 @@ export type EventField = EventFieldBase &
   );
 
 export type EventCheck = {
-  type: "header" | "payload";
+  type: "headers" | "body";
   field: string;
 };
 
@@ -46,7 +46,7 @@ export type WebhookPresetIcon =
 
 export type PresetWebhook = {
   name: string;
-  eventCheck: EventCheck | null;
+  eventCheck: EventCheck;
   events: WebhookEvent[];
   icon: typeof Icon;
   description: string;


### PR DESCRIPTION
## Description

Based on eventCheck, verify the input and for non custom webhook source, filter out events that
- do not respect the eventCheck 
- are not handled by the preset
- are not subscribed in the webhook source 

Doc-ack because a ticket is planned for that before opening to public

## Tests

Manual

## Risk

low

## Deploy Plan

front
