### PR TITLE
[front] enh(`run_agent`): improve `conversationId` arg description

### DIFF
--- a/front/lib/actions/mcp_internal_actions/servers/run_agent/index.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/run_agent/index.ts
@@ -241,7 +241,11 @@ export default async function createServer(
         .nullable(),
       conversationId: z
         .string()
-        .describe("The conversation id where the sub-agent will run.")
+        .describe(
+          "The conversation id where the sub-agent will run. " +
+            "Can be used to continue an existing conversation of the sub-agent. " +
+            "Cannot be the same as the main conversation."
+        )
         .optional()
         .nullable(),
       ...configurableProperties,


### PR DESCRIPTION
## Description

This parameter seems to be often misused, the main conversation ID is often passed (which makes sense given the description, sees an argument called `conversationId`, it was given a conversation ID so copy pastes it).
Changing the tool arg description should do the trick, at some point we'll need to inject some instructions instead.

## Tests

## Risk

## Deploy Plan

- Deploy front.
