### PR TITLE
[HOOTL] Picker for webhook event in AgentBuilder

### DIFF
--- a/front/components/agent_builder/AgentBuilderFormContext.tsx
+++ b/front/components/agent_builder/AgentBuilderFormContext.tsx
@@ -196,8 +196,8 @@ const scheduleConfigSchema = z.object({
 
 const webhookConfigSchema = z.object({
   includePayload: z.boolean(),
-  event: z.string().nullable(),
-  filter: z.string().nullable().optional(),
+  event: z.string().optional(),
+  filter: z.string().optional(),
 });
 
 const webhookTriggerSchema = z.object({

--- a/front/components/agent_builder/AgentBuilderFormContext.tsx
+++ b/front/components/agent_builder/AgentBuilderFormContext.tsx
@@ -196,6 +196,8 @@ const scheduleConfigSchema = z.object({
 
 const webhookConfigSchema = z.object({
   includePayload: z.boolean(),
+  event: z.string().nullable(),
+  filter: z.string().nullable().optional(),
 });
 
 const webhookTriggerSchema = z.object({

--- a/front/components/agent_builder/triggers/AgentBuilderTriggersBlock.tsx
+++ b/front/components/agent_builder/triggers/AgentBuilderTriggersBlock.tsx
@@ -1,5 +1,5 @@
 import {
-  BellIcon,
+  BoltIcon,
   Button,
   CardGrid,
   ClockIcon,
@@ -175,7 +175,7 @@ export function AgentBuilderTriggersBlock({
               <Button
                 label="Add Webhook"
                 variant="outline"
-                icon={BellIcon}
+                icon={BoltIcon}
                 onClick={() => handleCreateTrigger("webhook")}
                 type="button"
               />
@@ -205,7 +205,7 @@ export function AgentBuilderTriggersBlock({
                   <Button
                     label="Add Webhook"
                     variant="outline"
-                    icon={BellIcon}
+                    icon={BoltIcon}
                     onClick={() => handleCreateTrigger("webhook")}
                     type="button"
                   />

--- a/front/components/agent_builder/triggers/WebhookEditionModal.tsx
+++ b/front/components/agent_builder/triggers/WebhookEditionModal.tsx
@@ -1,3 +1,4 @@
+import type { Icon } from "@dust-tt/sparkle";
 import {
   Button,
   Checkbox,
@@ -31,11 +32,14 @@ import { useWebhookSourcesWithViews } from "@app/lib/swr/webhook_source";
 import type { LightWorkspaceType } from "@app/types";
 import type { WebhookSourceKind } from "@app/types/triggers/webhooks";
 import { WEBHOOK_SOURCE_KIND_TO_PRESETS_MAP } from "@app/types/triggers/webhooks";
+import type { PresetWebhook } from "@app/types/triggers/webhooks_source_preset";
 
 const webhookFormSchema = z.object({
   name: z.string().min(1, "Name is required").max(255, "Name is too long"),
   customPrompt: z.string(),
   webhookSourceViewSId: z.string().min(1, "Select a webhook source"),
+  event: z.string().nullable(),
+  filter: z.string().optional(),
   includePayload: z.boolean().default(false),
 });
 
@@ -53,6 +57,7 @@ type WebhookOption = {
   value: string;
   label: string;
   kind: WebhookSourceKind;
+  icon: typeof Icon;
 };
 
 export function WebhookEditionModal({
@@ -69,6 +74,8 @@ export function WebhookEditionModal({
       name: "Webhook Trigger",
       customPrompt: "",
       webhookSourceViewSId: "",
+      event: null,
+      filter: "",
       includePayload: false,
     }),
     []
@@ -80,6 +87,7 @@ export function WebhookEditionModal({
   });
 
   const selectedViewSId = form.watch("webhookSourceViewSId") ?? "";
+  const selectedEvent = form.watch("event");
   const includePayload = form.watch("includePayload");
 
   const { spaces } = useSpacesContext();
@@ -99,8 +107,8 @@ export function WebhookEditionModal({
 
   const webhookOptions = useMemo((): WebhookOption[] => {
     const options: WebhookOption[] = [];
-
     webhookSourcesWithViews.forEach((wsv) => {
+      const preset = WEBHOOK_SOURCE_KIND_TO_PRESETS_MAP[wsv.kind];
       wsv.views
         .filter((view) => accessibleSpaceIds.has(view.spaceId))
         .forEach((view) => {
@@ -108,12 +116,42 @@ export function WebhookEditionModal({
             value: view.sId,
             label: view.customName ?? wsv.name,
             kind: view.webhookSource.kind,
+            icon: preset.icon,
           });
         });
     });
 
     return options;
   }, [webhookSourcesWithViews, accessibleSpaceIds]);
+
+  const selectedWebhookSource = useMemo(() => {
+    if (!selectedViewSId) {
+      return null;
+    }
+    for (const wsv of webhookSourcesWithViews) {
+      const view = wsv.views.find((v) => v.sId === selectedViewSId);
+      if (view) {
+        return wsv;
+      }
+    }
+    return null;
+  }, [webhookSourcesWithViews, selectedViewSId]);
+
+  const selectedPreset = useMemo((): PresetWebhook | null => {
+    if (!selectedWebhookSource || selectedWebhookSource.kind === "custom") {
+      return null;
+    }
+    return WEBHOOK_SOURCE_KIND_TO_PRESETS_MAP[selectedWebhookSource.kind];
+  }, [selectedWebhookSource]);
+
+  const availableEvents = useMemo(() => {
+    if (!selectedPreset || !selectedWebhookSource) {
+      return [];
+    }
+    return selectedPreset.events.filter((event) =>
+      selectedWebhookSource.subscribedEvents.includes(event.value)
+    );
+  }, [selectedPreset, selectedWebhookSource]);
 
   useEffect(() => {
     if (!isOpen) {
@@ -127,11 +165,15 @@ export function WebhookEditionModal({
     }
 
     const includePayload = trigger.configuration.includePayload;
+    const event = trigger.configuration.event ?? null;
+    const filter = trigger.configuration.filter ?? "";
 
     form.reset({
       name: trigger.name,
       customPrompt: trigger.customPrompt ?? "",
       webhookSourceViewSId: trigger.webhookSourceViewSId ?? "",
+      event,
+      filter,
       includePayload,
     });
   }, [defaultValues, form, isOpen, trigger]);
@@ -146,6 +188,21 @@ export function WebhookEditionModal({
       return;
     }
 
+    // Validate that event is selected for preset webhooks (not custom)
+    if (
+      selectedWebhookSource &&
+      selectedWebhookSource.kind !== "custom" &&
+      selectedPreset &&
+      availableEvents.length > 0 &&
+      !data.event
+    ) {
+      form.setError("event", {
+        type: "manual",
+        message: "Please select an event",
+      });
+      return;
+    }
+
     const editor = trigger?.editor ?? user.id ?? null;
     const editorEmail = trigger?.editorEmail ?? user.email ?? undefined;
 
@@ -156,6 +213,8 @@ export function WebhookEditionModal({
       kind: "webhook",
       configuration: {
         includePayload: data.includePayload,
+        event: data.event ?? null,
+        filter: data.filter?.trim() || null,
       },
       webhookSourceViewSId: data.webhookSourceViewSId ?? undefined,
       editor,
@@ -258,6 +317,70 @@ export function WebhookEditionModal({
                   </DropdownMenu>
                 )}
               </div>
+
+              {/* Event selector for non-custom webhooks */}
+              {selectedPreset && availableEvents.length > 0 && (
+                <div className="flex flex-col space-y-1">
+                  <Label htmlFor="webhook-event">Event</Label>
+                  <p className="text-sm text-muted-foreground dark:text-muted-foreground-night">
+                    Select the event that will trigger this webhook.
+                  </p>
+                  <DropdownMenu>
+                    <DropdownMenuTrigger asChild>
+                      <Button
+                        id="webhook-event"
+                        variant="outline"
+                        isSelect
+                        className="w-fit"
+                        disabled={!isEditor}
+                        label={
+                          selectedEvent
+                            ? availableEvents.find(
+                                (e) => e.value === selectedEvent
+                              )?.name ?? "Select event"
+                            : "Select event"
+                        }
+                      />
+                    </DropdownMenuTrigger>
+                    <DropdownMenuContent>
+                      <DropdownMenuLabel label="Select event" />
+                      {availableEvents.map((event) => (
+                        <DropdownMenuItem
+                          key={event.value}
+                          label={event.name}
+                          disabled={!isEditor}
+                          onClick={() => {
+                            form.setValue("event", event.value, {
+                              shouldValidate: true,
+                            });
+                          }}
+                        />
+                      ))}
+                    </DropdownMenuContent>
+                  </DropdownMenu>
+                  {form.formState.errors.event && (
+                    <p className="text-sm text-warning">
+                      {form.formState.errors.event.message}
+                    </p>
+                  )}
+                </div>
+              )}
+
+              {/* Filters input */}
+              {selectedPreset && availableEvents.length > 0 && (
+                <div className="space-y-1">
+                  <Label htmlFor="trigger-filters">Filters (Optional)</Label>
+                  <p className="text-sm text-muted-foreground dark:text-muted-foreground-night">
+                    Add a filter string for the webhook event
+                  </p>
+                  <Input
+                    id="trigger-filter"
+                    placeholder="Enter filter"
+                    disabled={!isEditor}
+                    {...form.register("filter")}
+                  />
+                </div>
+              )}
 
               <div className="flex items-center justify-between">
                 <div className="flex flex-col space-y-1">

--- a/front/types/assistant/triggers.ts
+++ b/front/types/assistant/triggers.ts
@@ -11,6 +11,8 @@ export type ScheduleConfig = {
 
 export type WebhookConfig = {
   includePayload: boolean;
+  event?: string | null;
+  filter?: string | null;
 };
 
 export type TriggerConfigurationType = ScheduleConfig | WebhookConfig;
@@ -70,9 +72,15 @@ const ScheduleConfigSchema = t.type({
   timezone: t.string,
 });
 
-const WebhookConfigSchema = t.type({
-  includePayload: t.boolean,
-});
+const WebhookConfigSchema = t.intersection([
+  t.type({
+    includePayload: t.boolean,
+    event: t.union([t.string, t.null]),
+  }),
+  t.partial({
+    filter: t.union([t.string, t.null]),
+  }),
+]);
 
 export const TriggerSchema = t.union([
   t.type({

--- a/front/types/assistant/triggers.ts
+++ b/front/types/assistant/triggers.ts
@@ -11,8 +11,8 @@ export type ScheduleConfig = {
 
 export type WebhookConfig = {
   includePayload: boolean;
-  event?: string | null;
-  filter?: string | null;
+  event?: string;
+  filter?: string;
 };
 
 export type TriggerConfigurationType = ScheduleConfig | WebhookConfig;
@@ -75,10 +75,10 @@ const ScheduleConfigSchema = t.type({
 const WebhookConfigSchema = t.intersection([
   t.type({
     includePayload: t.boolean,
-    event: t.union([t.string, t.null]),
   }),
   t.partial({
-    filter: t.union([t.string, t.null]),
+    event: t.string,
+    filter: t.string,
   }),
 ]);
 


### PR DESCRIPTION
## Description

Allow to pick one of the selected event and set a manual filter

CUSTOM = nothing

<img width="1118" height="940" alt="image" src="https://github.com/user-attachments/assets/6e328e55-c3e4-47f3-b34f-66605c47140f" />

GITHUB:

<img width="1128" height="1342" alt="image" src="https://github.com/user-attachments/assets/d6b5ab78-ac87-4910-876d-fd0a63d1bcde" />

TEST:

<img width="1102" height="1376" alt="image" src="https://github.com/user-attachments/assets/8471042c-af50-4be4-99e9-d46795393447" />

Result line in database:
```
2025-10-09 14:26:44.09+00  | 2025-10-09 14:26:44.09+00  | cNBYZ0pzdw           | Webhook Trigger | webhook |              | t       | {"event": "test_event", "filter": "A=5 OR B=6", "includePayload": false}        |                  45 |           1 |  8 |      1
```

## Tests

manual tests

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

deploy front
